### PR TITLE
feat(devtrace): export the attention review as the model received it

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -305,8 +305,9 @@ Trust constraints:
   whether anything is recorded. What it records is the
   desktop's own view of its own conversation — the realtime events already
   crossing the data channel, with an audio append reduced to its byte count
-  before it leaves the renderer, and the attention evaluator's update and
-  decision — appended as JSONL under the developer's chosen directory and
+  before it leaves the renderer, and the attention evaluator's update,
+  decision, and reviewing model when the desktop knows one — appended as
+  JSONL under the developer's chosen directory and
   sent nowhere; `pnpm trace:export` turns one file into a document a local
   viewer opens. The tap only observes: nothing reads its result, and the
   main process drops the renderer's tapped events whenever no writer stands.

--- a/packages/attention/src/attention.ts
+++ b/packages/attention/src/attention.ts
@@ -170,6 +170,12 @@ export function attentionContext(detail: SessionDetail): AttentionContext | unde
 export interface AttentionEvaluator {
   evaluate(update: AttentionUpdate): Promise<AttentionDecision | undefined>;
   /**
+   * The model reviews are sent to, when this evaluator knows one. The keyed
+   * evaluator names its own; the hosted evaluator's model belongs to the
+   * service's build, so it is honestly absent rather than guessed.
+   */
+  readonly model?: string;
+  /**
    * When the evaluator has stood itself down — a rate limit's quiet — the
    * moment it will take requests again, as epoch milliseconds. A reviewer
    * that asks first skips the pass whole: nothing is sent, no baseline

--- a/packages/devtrace/src/attention-trace.test.ts
+++ b/packages/devtrace/src/attention-trace.test.ts
@@ -61,6 +61,27 @@ test("a recorder that throws costs the trace line, never the pass", async () => 
   assert.equal(await evaluator.evaluate(UPDATE), DECISION);
 });
 
+test("the reviewing model is recorded and forwarded only when the evaluator names one", async () => {
+  const records: AttentionTraceRecord[] = [];
+  const keyed = tracedAttentionEvaluator(
+    { evaluate: async () => DECISION, model: "gpt-5.6-luna" },
+    (record) => records.push(record),
+    () => 0,
+  );
+  assert.equal(keyed.model, "gpt-5.6-luna");
+  await keyed.evaluate(UPDATE);
+  assert.equal(records[0]?.model, "gpt-5.6-luna");
+
+  const hosted = tracedAttentionEvaluator(
+    { evaluate: async () => DECISION },
+    (record) => records.push(record),
+    () => 0,
+  );
+  assert.equal(hosted.model, undefined);
+  await hosted.evaluate(UPDATE);
+  assert.ok(records[1] && !("model" in records[1]));
+});
+
 test("quietUntil is forwarded only when the wrapped evaluator has one", () => {
   const quiet = tracedAttentionEvaluator(
     { evaluate: async () => undefined, quietUntil: () => 42 },

--- a/packages/devtrace/src/attention-trace.ts
+++ b/packages/devtrace/src/attention-trace.ts
@@ -25,9 +25,15 @@ export function tracedAttentionEvaluator(
   return {
     evaluate: async (update: AttentionUpdate) => {
       const started = now();
+      const model = evaluator.model;
       try {
         const decision = await evaluator.evaluate(update);
-        recordQuietly({ update, decision, elapsedMs: now() - started });
+        recordQuietly({
+          update,
+          decision,
+          elapsedMs: now() - started,
+          ...(model ? { model } : undefined),
+        });
         return decision;
       } catch (error) {
         recordQuietly({
@@ -35,10 +41,12 @@ export function tracedAttentionEvaluator(
           decision: undefined,
           elapsedMs: now() - started,
           error: error instanceof Error ? error.message : String(error),
+          ...(model ? { model } : undefined),
         });
         throw error;
       }
     },
+    ...(evaluator.model ? { model: evaluator.model } : undefined),
     // Forwarded only when the wrapped evaluator has one: the reviewer treats
     // the member's absence as "requests are welcome", and a wrapper that
     // always answered would change that reading.

--- a/packages/devtrace/src/trace-writer.ts
+++ b/packages/devtrace/src/trace-writer.ts
@@ -6,14 +6,16 @@ import { type AgentWireTrace, sanitizedTraceEvent } from "./vocabulary.js";
 
 /**
  * One evaluator pass as the trace records it: the bounded update that went to
- * the model, the decision that came back — absent when the pass failed — and
- * how long the round trip took.
+ * the model, the decision that came back — absent when the pass failed — how
+ * long the round trip took, and which model reviewed it, absent when the pass
+ * ran through the hosted service, whose model the desktop never learns.
  */
 export interface AttentionTraceRecord {
   update: AttentionUpdate;
   decision: AttentionDecision | undefined;
   elapsedMs: number;
   error?: string;
+  model?: string;
 }
 
 export const TRACE_ENTRY_KIND = {

--- a/packages/devtrace/src/unbox-export.test.ts
+++ b/packages/devtrace/src/unbox-export.test.ts
@@ -1,5 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import { ATTENTION_TRIGGER, attentionInstructions, attentionUpdateInput } from "@sidecar/attention";
+import { SESSION_STATUS } from "@sidecar/session";
 import { isRecord, type WireRecord, type WireValue } from "@sidecar/wire";
 import { TRACE_ENTRY_KIND } from "./trace-writer.js";
 import { unboxTraceFromLines } from "./unbox-export.js";
@@ -157,11 +159,61 @@ test("an attention pass becomes its own generation, and junk lines cost only the
   const [generation] = generations(trace);
   assert.ok(generation);
   assert.equal(generation.name, "attention-review");
+  // A record carrying no model — a hosted pass, or an older trace — keeps the
+  // placeholder rather than guessing.
+  assert.equal(generation.model, "attention-review");
   const metrics = isRecord(generation.metrics) ? generation.metrics : undefined;
   assert.equal(metrics?.latency, 0.321);
-  const [update, decision] = messagesOf(generation);
+  const definitions = Array.isArray(generation.available_tools)
+    ? generation.available_tools.filter(isRecord)
+    : [];
+  assert.equal(definitions[0]?.type, "response_format");
+  assert.equal(definitions[0]?.name, "attention_decision");
+  assert.ok(isRecord(definitions[0]?.inputSchema));
+  const [instructions, update, decision] = messagesOf(generation);
+  assert.equal(instructions?.role, "system");
+  assert.equal(instructions?.content, attentionInstructions());
+  // The update misses fields the prompt renderer requires, so it stands as
+  // its raw JSON rather than posing as the prompt the model received.
   assert.equal(update?.role, "user");
   assert.match(String(update?.content), /checkout-service/u);
   assert.equal(decision?.role, "assistant");
   assert.match(String(decision?.content), /silent/u);
+});
+
+test("a readable attention update renders as the exact prompt the model received", () => {
+  const update = {
+    trigger: "status-changed",
+    providerName: "Claude Code",
+    title: "checkout-service",
+    status: "complete",
+    previousStatus: "working",
+    recap: "Shipped the retry fix.",
+    noticeRequest: "Tell me when the retry fix lands.",
+  };
+  const attention = JSON.stringify({
+    at: "2026-08-25T10:05:00.000Z",
+    kind: TRACE_ENTRY_KIND.ATTENTION,
+    update,
+    decision: { disposition: "speak" },
+    elapsedMs: 100,
+    model: "gpt-5.6-luna",
+  });
+  const trace = unboxTraceFromLines([attention]);
+  const [generation] = generations(trace);
+  assert.equal(generation?.model, "gpt-5.6-luna");
+  const rendered = messagesOf(generation).find((message) => message.role === "user");
+  assert.equal(
+    rendered?.content,
+    attentionUpdateInput({
+      trigger: ATTENTION_TRIGGER.STATUS_CHANGED,
+      providerName: "Claude Code",
+      title: "checkout-service",
+      status: SESSION_STATUS.COMPLETE,
+      previousStatus: SESSION_STATUS.WORKING,
+      recap: "Shipped the retry fix.",
+      noticeRequest: "Tell me when the retry fix lands.",
+    }),
+  );
+  assert.match(String(rendered?.content), /Developer's ask: Tell me when the retry fix lands\./u);
 });

--- a/packages/devtrace/src/unbox-export.ts
+++ b/packages/devtrace/src/unbox-export.ts
@@ -13,6 +13,13 @@
  * itself, never the export.
  */
 
+import {
+  ATTENTION_DECISION_SCHEMA,
+  ATTENTION_DECISION_SCHEMA_NAME,
+  attentionInstructions,
+  attentionPromptUpdateFromWire,
+  attentionUpdateInput,
+} from "@sidecar/attention";
 import { REALTIME_CLIENT_EVENT, REALTIME_SERVER_EVENT } from "@sidecar/realtime";
 import {
   isRecord,
@@ -34,6 +41,19 @@ export interface UnboxExportOptions {
 const DEFAULT_TRACE_NAME = "luke-agent-trace";
 const UNKNOWN_MODEL = "gpt-realtime";
 const ATTENTION_GENERATION_NAME = "attention-review";
+
+/**
+ * The strict decision schema the review pins as its response format, shown in
+ * the gateway document's definitions slot. The viewer's format has no
+ * response-format field of its own, so the schema travels as a tool-shaped
+ * definition typed by what it actually is, never as a callable function —
+ * the review declares no tools at all.
+ */
+const ATTENTION_RESPONSE_FORMAT = {
+  type: "response_format",
+  name: ATTENTION_DECISION_SCHEMA_NAME,
+  inputSchema: ATTENTION_DECISION_SCHEMA,
+};
 
 function recordItems(value: WireValue | undefined): readonly WireRecord[] {
   return Array.isArray(value) ? value.filter(isRecord) : [];
@@ -209,13 +229,28 @@ function applyWireEntry(state: ExportState, entry: WireRecord, atMs: number | un
   }
 }
 
+/**
+ * The prompt the review actually sent, rebuilt from the recorded update by the
+ * same rendering the evaluator uses. An update the current renderer cannot read
+ * — one an older build recorded — falls back to its raw JSON, so the entry
+ * still shows what was reviewed even when it cannot show it verbatim.
+ */
+function attentionInputText(update: WireValue | undefined): string {
+  const promptUpdate = attentionPromptUpdateFromWire(update);
+  if (promptUpdate) return attentionUpdateInput(promptUpdate);
+  return JSON.stringify(update ?? {}, undefined, 2);
+}
+
 function applyAttentionEntry(state: ExportState, entry: WireRecord): void {
   const decision = wireRecord(entry.decision);
   const error = text(entry.error);
   state.events.push({
     type: "generation",
     name: ATTENTION_GENERATION_NAME,
-    model: ATTENTION_GENERATION_NAME,
+    // A hosted pass records no model, because the service's build owns that
+    // choice and the desktop never learns it; the placeholder says so rather
+    // than guessing.
+    model: text(entry.model) ?? ATTENTION_GENERATION_NAME,
     provider: "openai",
     metrics: {
       // The viewer reads latency in seconds; the trace stamps milliseconds.
@@ -223,8 +258,10 @@ function applyAttentionEntry(state: ExportState, entry: WireRecord): void {
       tokens: { input: 0, output: 0 },
       cost: 0,
     },
+    available_tools: [ATTENTION_RESPONSE_FORMAT],
     messages: [
-      { role: "user", content: JSON.stringify(entry.update ?? {}, undefined, 2) },
+      { role: "system", content: attentionInstructions() },
+      { role: "user", content: attentionInputText(entry.update) },
       decision
         ? { role: "assistant", content: JSON.stringify(decision, undefined, 2) }
         : { role: "assistant", content: error ?? "no decision" },


### PR DESCRIPTION
## What

When a development trace is exported for unbox-ai, an attention review previously rendered as the update's raw JSON and the decision — no instructions, and a user message that both under- and over-represented the request (it carried session identifiers the model never sees, and was not the string the API was given). Each `attention-review` generation now shows the review as the model received it:

- A `system` message carrying `attentionInstructions()` — the same build-fixed function whose output goes in the request's `instructions` field.
- The user message rendered through `attentionUpdateInput()` on the recorded update — byte-for-byte the request's `input` string. An update the current renderer cannot read (an older build's trace) falls back to its raw JSON rather than posing as verbatim.
- The strict `attention_decision` schema in the gateway document's definitions slot, typed `response_format` rather than a callable function, since the review declares no tools.
- The reviewing model, newly recorded into the trace at review time: `AttentionEvaluator` gains an optional `model` the keyed evaluator already satisfies, and the tap records it per pass. A hosted pass records none — the service's build owns that choice and the desktop never learns it — and the export keeps the placeholder for it rather than guessing.

The trace paragraph in `AGENTS.md` moves with the widened record, since what a trace records is a product decision.

## Why

Debugging attention decisions in unbox-ai requires seeing what the model actually saw. The export is a purely local dev tool over a trace that only exists in unpackaged `LUKE_TRACE_DIR` runs, so nothing production-facing changes.

## Testing

- `./scripts/check.sh` passes (exit 0).
- Devtrace tests cover: the system message equals `attentionInstructions()`, a well-formed update renders byte-for-byte as `attentionUpdateInput()` (including the `Developer's ask:` line), an unreadable update falls back to raw JSON, the schema definition rides on the generation, the recorded model shows and its absence keeps the placeholder, and the tap records/forwards `model` only when the evaluator names one.

Portable-only change (dev-only export CLI and trace record); no macOS/UI surface touched, so no visual evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/4b8c9974-4904-44a4-aa0a-8645875aa6c1)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32925939445/artifacts/9591549907) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32925939445)

- Commit: `9463cfeedc3376ce54c4d1ed2dd0803115016f64`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
