### PR TITLE
docs: offer a contact address on the site and in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,10 @@ See [PRIVACY.md](PRIVACY.md).
 Issues and pull requests are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md)
 to get set up, and [SECURITY.md](SECURITY.md) for reporting a vulnerability.
 
+## Contact
+
+Email [founders@stagereview.app](mailto:founders@stagereview.app).
+
 ## License
 
 Luke is licensed under the [Apache License 2.0](LICENSE).

--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@
 <p align="center">
   <a href="https://tryluke.dev">Website</a> ·
   <a href="PRIVACY.md">Privacy</a> ·
-  <a href="CHANGELOG.md">Changelog</a>
+  <a href="CHANGELOG.md">Changelog</a> ·
+  <a href="mailto:founders@stagereview.app">Contact</a>
 </p>
 
 ![Luke's panel expanded from the notch, listing local and cloud agent sessions with their status, recaps, and workspace grouping.](docs/media/luke-panel.png)
@@ -100,10 +101,6 @@ See [PRIVACY.md](PRIVACY.md).
 
 Issues and pull requests are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md)
 to get set up, and [SECURITY.md](SECURITY.md) for reporting a vulnerability.
-
-## Contact
-
-Email [founders@stagereview.app](mailto:founders@stagereview.app).
 
 ## License
 

--- a/apps/web/src/SiteChrome.tsx
+++ b/apps/web/src/SiteChrome.tsx
@@ -120,6 +120,12 @@ export function SiteFooter(): React.JSX.Element {
         >
           Privacy
         </a>
+        <a
+          className="no-underline transition-colors duration-150 hover:text-foreground motion-reduce:transition-none"
+          href="mailto:founders@stagereview.app"
+        >
+          Contact
+        </a>
       </div>
     </footer>
   );


### PR DESCRIPTION
## Summary

- Adds a `Contact` link to the site footer (shared by the landing page, changelog, and privacy page) and a `## Contact` section to the README, both pointing at `mailto:founders@stagereview.app` — the address `PRIVACY.md` and `SECURITY.md` already answer on, so this adds a way in rather than a new place to write to.

## Evidence

- Platform-independent checks: `./scripts/check.sh` passed (exit 0)
- macOS Electron verification (`./scripts/verify.sh`): `not run`

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32932698310/artifacts/9593807979) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32932698310)

- Commit: `f82a86b72c5d6a6f88739eaa28ceb3b2a3c41702`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

### Physical-device evidence

- Screenshot or screen recording: `not attached`
- Physical-notch check: `not performed`
- Device/display configuration: `not recorded`

## Notes

- `verify.sh` was not run: it packages and validates the macOS desktop app, and this change touches only `README.md` and the web app's footer, neither of which the desktop build draws.