### PR TITLE
docs(readme): reword the tagline around the voice agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@
 </p>
 
 <p align="center">
-  <strong>Your AI engineering manager.</strong><br>
-  A macOS app that watches your coding agents and keeps you updated.
+  <strong>An engineering manager for your coding agents.</strong><br>
+  A macOS voice agent that keeps you in the loop with your agents.
 </p>
 
 <p align="center">


### PR DESCRIPTION
## Summary

- Reword the README's two centered tagline lines: "Your AI engineering manager." becomes "An engineering manager for your coding agents.", and the subline becomes "A macOS voice agent that keeps you in the loop with your agents." Copy only — no code, behavior, or product screenshots change.

## Evidence

- Platform-independent checks: `not run` (README-only copy change; Biome ignores `README.md`)
- macOS Electron verification (`./scripts/verify.sh`): `not run` (no app surface touched)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32932701217/artifacts/9593793278) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32932701217)

- Commit: `0e720aeae9f3d372b16dc16445ed332f60e8f3bd`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

### Physical-device evidence

- Screenshot or screen recording: `not attached`
- Physical-notch check: `not performed`
- Device/display configuration: `not recorded`

## Notes

- Blockers or follow-up verification: None

🤖 Generated with [Claude Code](https://claude.com/claude-code)