### PR TITLE
docs: credit the maintainers in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,11 @@ See [PRIVACY.md](PRIVACY.md).
 Issues and pull requests are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md)
 to get set up, and [SECURITY.md](SECURITY.md) for reporting a vulnerability.
 
+## Built by
+
+[Charles Pan](https://x.com/ceefryingpan) and
+[Dean Stratakos](https://x.com/DeanStratakos).
+
 ## License
 
 Luke is licensed under the [Apache License 2.0](LICENSE).


### PR DESCRIPTION
## Summary

- Add a `Built by` section to the README, crediting Charles Pan and Dean Stratakos with links to their X profiles. It sits between Contributing and License rather than in the header nav, leaving that row free for a product account later.

## Evidence

- Platform-independent checks: `./scripts/check.sh` passed (exit 0)
- macOS Electron verification (`./scripts/verify.sh`): `not run` — docs-only, nothing on the panel changed

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32932886554/artifacts/9593860107) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32932886554)

- Commit: `7a5d0733281a73cdd5332d9fb457cd490a38dd2b`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

### Physical-device evidence

- Screenshot or screen recording: `not attached`
- Physical-notch check: `not performed`
- Device/display configuration: `not recorded`

## Notes

- The first `check.sh` run failed with four native-helper tests (`apple-calendar`, `media-duck`, `output-volume`, `talk-key`); they pass on a clean tree and on this branch when the desktop suite runs alone, and the re-run of the full script passed. They are flaky under the recursive parallel run, not affected by this change.