### PR TITLE
v0.3.12 chore: prepare Luke release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,8 +39,8 @@ the date its release was published.
 - Luke uses Echo as his default voice and gives you a short spoken welcome
   after sign-in ([#520](https://github.com/ReviewStage/luke/pull/520),
   [#541](https://github.com/ReviewStage/luke/pull/541))
-- Luke keeps his conversation context focused on the app guide and the actions
-  you can actually ask him to take
+- Luke keeps his conversation context focused on the app guide and leaves the
+  tracker's issue roster out of the conversation
   ([#528](https://github.com/ReviewStage/luke/pull/528),
   [#538](https://github.com/ReviewStage/luke/pull/538),
   [#539](https://github.com/ReviewStage/luke/pull/539))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,62 @@
 Notable changes to Luke, newest first. Each heading is a released version and
 the date its release was published.
 
+## 0.3.12 — 2026-08-26
+
+### Improvements
+
+- Luke uses Echo as his default voice and gives you a short spoken welcome
+  after sign-in ([#520](https://github.com/ReviewStage/luke/pull/520),
+  [#541](https://github.com/ReviewStage/luke/pull/541))
+- Luke keeps his conversation context focused on the app guide and the actions
+  you can actually ask him to take
+  ([#528](https://github.com/ReviewStage/luke/pull/528),
+  [#538](https://github.com/ReviewStage/luke/pull/538),
+  [#539](https://github.com/ReviewStage/luke/pull/539))
+- Replicas workspaces can sleep when their task finishes, and Luke reports
+  unexpected wakes as observation diagnostics
+  ([#530](https://github.com/ReviewStage/luke/pull/530),
+  [#531](https://github.com/ReviewStage/luke/pull/531),
+  [#536](https://github.com/ReviewStage/luke/pull/536))
+- Development traces capture Luke's local agent traffic and export attention
+  reviews in the form the model received
+  ([#534](https://github.com/ReviewStage/luke/pull/534),
+  [#540](https://github.com/ReviewStage/luke/pull/540))
+- Onboarding stays out of the way while macOS asks for microphone access and
+  signs Luke's wordmark onto his introduction
+  ([#524](https://github.com/ReviewStage/luke/pull/524),
+  [#533](https://github.com/ReviewStage/luke/pull/533))
+
+### Fixes
+
+- Fixed provider marks disappearing while Luke speaks
+  ([#517](https://github.com/ReviewStage/luke/pull/517))
+- Fixed update checks giving up while a newly published release is still
+  uploading ([#523](https://github.com/ReviewStage/luke/pull/523))
+- Fixed voice conversations reseeding history or changing roster context on
+  clock ticks ([#526](https://github.com/ReviewStage/luke/pull/526),
+  [#527](https://github.com/ReviewStage/luke/pull/527))
+- Fixed Conductor reads including archived workspaces or starting from an
+  unfiltered workspace list
+  ([#525](https://github.com/ReviewStage/luke/pull/525),
+  [#537](https://github.com/ReviewStage/luke/pull/537))
+- Fixed GitHub releases becoming visible before all six downloadable assets
+  finished uploading ([#521](https://github.com/ReviewStage/luke/pull/521))
+
+### Miscellaneous
+
+- Updated the hosted macOS release and Replicas lifecycle documentation
+  ([#519](https://github.com/ReviewStage/luke/pull/519),
+  [#529](https://github.com/ReviewStage/luke/pull/529),
+  [#532](https://github.com/ReviewStage/luke/pull/532))
+- Added an About page, contact address, maintainer credits, and refreshed
+  product framing across the website and README
+  ([#542](https://github.com/ReviewStage/luke/pull/542),
+  [#543](https://github.com/ReviewStage/luke/pull/543),
+  [#544](https://github.com/ReviewStage/luke/pull/544),
+  [#545](https://github.com/ReviewStage/luke/pull/545),
+  [#546](https://github.com/ReviewStage/luke/pull/546))
+
 ## 0.3.11 — 2026-08-25
 
 ### Improvements

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@luke/desktop",
   "productName": "Luke",
-  "version": "0.3.11",
+  "version": "0.3.12",
   "private": true,
   "description": "Luke desktop application",
   "main": "dist/main.js",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luke/web",
-  "version": "0.3.11",
+  "version": "0.3.12",
   "private": true,
   "type": "module",
   "description": "Luke landing page",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "luke",
-  "version": "0.3.11",
+  "version": "0.3.12",
   "private": true,
   "description": "A notch-attached desktop sidecar for coding-agent sessions",
   "packageManager": "pnpm@10.34.5",

--- a/packages/account/package.json
+++ b/packages/account/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/account",
-  "version": "0.3.11",
+  "version": "0.3.12",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/acts/package.json
+++ b/packages/acts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/acts",
-  "version": "0.3.11",
+  "version": "0.3.12",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/analytics",
-  "version": "0.3.11",
+  "version": "0.3.12",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/attention/package.json
+++ b/packages/attention/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/attention",
-  "version": "0.3.11",
+  "version": "0.3.12",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/calendar/package.json
+++ b/packages/calendar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/calendar",
-  "version": "0.3.11",
+  "version": "0.3.12",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/credentials/package.json
+++ b/packages/credentials/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/credentials",
-  "version": "0.3.11",
+  "version": "0.3.12",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/devtrace/package.json
+++ b/packages/devtrace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/devtrace",
-  "version": "0.3.11",
+  "version": "0.3.12",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/feedback/package.json
+++ b/packages/feedback/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/feedback",
-  "version": "0.3.11",
+  "version": "0.3.12",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/fixtures/package.json
+++ b/packages/fixtures/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/fixtures",
-  "version": "0.3.11",
+  "version": "0.3.12",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/guide/package.json
+++ b/packages/guide/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/guide",
-  "version": "0.3.11",
+  "version": "0.3.12",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/hosted/package.json
+++ b/packages/hosted/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/hosted",
-  "version": "0.3.11",
+  "version": "0.3.12",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/issues/package.json
+++ b/packages/issues/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/issues",
-  "version": "0.3.11",
+  "version": "0.3.12",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/panel/package.json
+++ b/packages/panel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/panel",
-  "version": "0.3.11",
+  "version": "0.3.12",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/process/package.json
+++ b/packages/process/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/process",
-  "version": "0.3.11",
+  "version": "0.3.12",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/providers/package.json
+++ b/packages/providers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/providers",
-  "version": "0.3.11",
+  "version": "0.3.12",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/realtime/package.json
+++ b/packages/realtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/realtime",
-  "version": "0.3.11",
+  "version": "0.3.12",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/session/package.json
+++ b/packages/session/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/session",
-  "version": "0.3.11",
+  "version": "0.3.12",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/settings/package.json
+++ b/packages/settings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/settings",
-  "version": "0.3.11",
+  "version": "0.3.12",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/superset/package.json
+++ b/packages/superset/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/superset",
-  "version": "0.3.11",
+  "version": "0.3.12",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/surface/package.json
+++ b/packages/surface/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/surface",
-  "version": "0.3.11",
+  "version": "0.3.12",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/trackers/package.json
+++ b/packages/trackers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/trackers",
-  "version": "0.3.11",
+  "version": "0.3.12",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/voice/package.json
+++ b/packages/voice/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/voice",
-  "version": "0.3.11",
+  "version": "0.3.12",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/wire/package.json
+++ b/packages/wire/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/wire",
-  "version": "0.3.11",
+  "version": "0.3.12",
   "private": true,
   "type": "module",
   "exports": {

--- a/scripts/packaging.test.mjs
+++ b/scripts/packaging.test.mjs
@@ -50,7 +50,7 @@ function builderConfig(env = {}) {
   return createElectronBuilderConfig(env);
 }
 
-test("workspace package versions agree on v0.3.11", () => {
+test("workspace package versions agree on v0.3.12", () => {
   // Enumerated rather than listed, so a package added to the workspace is held
   // to the release version without anyone remembering to name it here.
   const packagePaths = [
@@ -74,7 +74,7 @@ test("workspace package versions agree on v0.3.11", () => {
 
   assert.deepEqual(
     versions.map(({ version }) => version),
-    packagePaths.map(() => "0.3.11"),
+    packagePaths.map(() => "0.3.12"),
   );
 });
 


### PR DESCRIPTION
## Summary

- Bump all 26 workspace packages to 0.3.12 and add release notes for every change since 0.3.11
- Prepare the hosted tag-driven macOS release; no local signing credentials are needed

## Verification

- `./scripts/bootstrap.sh`
- `./scripts/check.sh`
- Release and packaging tests: 37 passed
- Coverage audit: 100% of applicable release-metadata paths, 0 gaps
- Public-repository credential scan: no findings
- Pre-landing review: no issues found
- Plan completion: no plan file detected

## Release plan

After merge and hosted-service verification, tag the merge commit as `v0.3.12`. The Release workflow will build, sign, notarize, staple, validate, and publish the six required GitHub Release assets.

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32993277313/artifacts/9615595316) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32993277313)

- Commit: `505216dd5dda02f4b783f1e72d612c28d52f256a`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
