### PR TITLE
fix(web): keep the roster's Last seen from trailing Last active

### DIFF
--- a/apps/web/server/admin/admin-queries.ts
+++ b/apps/web/server/admin/admin-queries.ts
@@ -34,7 +34,12 @@ import {
   windowFetchDays,
 } from "./admin-metrics.js";
 import { type AdminUserSource, calendarDayKeys } from "./admin-user.js";
-import { ADMIN_USERS_LIMIT, type AdminUserListSource, searchLikePattern } from "./admin-users.js";
+import {
+  ADMIN_USERS_LIMIT,
+  type AdminUserListSource,
+  lastSeenInstant,
+  searchLikePattern,
+} from "./admin-users.js";
 import { ADMIN_METRICS_SCOPE, type AdminMetricsScope, type AdminMetricsWindow } from "./http.js";
 
 /** How many of the most active hosted-tier accounts the overview names. */
@@ -561,9 +566,12 @@ export async function readAdminDaySource(
  * first, the never-active tail ordered by youngest account, and the roster
  * cut at the stated bound while `total` still counts everyone. A search
  * narrows the rows and the total alike, so a truncated answer still states
- * how many accounts match. Last-seen
- * instants ride a query of their own: a second one-to-many join would fan
- * the usage aggregates out across each account's session rows.
+ * how many accounts match. Last-seen instants ride two queries of their own,
+ * folded by `lastSeenInstant`: the freshest session write, which cannot join
+ * the main read because a second one-to-many join would fan the usage
+ * aggregates out across each account's session rows, and the all-time last
+ * usage day, which the main read's own usage join cannot say because that
+ * join is cut at the window where last-seen must not be.
  */
 export async function readAdminUsersSource(
   database: Database,
@@ -578,14 +586,23 @@ export async function readAdminUsersSource(
   const windowStartDay = lastNDayKeys(input.now, input.windowDays)[0] ?? utcDayKey(input.now);
   const kept = and(scopeCondition(input.scope), searchCondition(input.search));
 
-  const [[totalRow], lastSeenRows, rows] = await Promise.all([
+  const [[totalRow], sessionSeenRows, usageSeenRows, rows] = await Promise.all([
     database.select({ value: count() }).from(user).where(kept),
     database
-      .select({ userId: session.userId, lastSeenAt: max(session.updatedAt) })
+      .select({ userId: session.userId, seenAt: max(session.updatedAt) })
       .from(session)
       .innerJoin(user, eq(session.userId, user.id))
       .where(kept)
       .groupBy(session.userId),
+    database
+      .select({
+        userId: hostedUsage.userId,
+        lastUsageDay: sql<string | null>`max(${hostedUsage.day})`,
+      })
+      .from(hostedUsage)
+      .innerJoin(user, eq(hostedUsage.userId, user.id))
+      .where(kept)
+      .groupBy(hostedUsage.userId),
     database
       .select({
         id: user.id,
@@ -617,9 +634,13 @@ export async function readAdminUsersSource(
       .limit(ADMIN_USERS_LIMIT),
   ]);
 
-  const lastSeenByUser = new Map<string, Date>();
-  for (const seen of lastSeenRows) {
-    if (seen.lastSeenAt) lastSeenByUser.set(seen.userId, seen.lastSeenAt);
+  const sessionSeenByUser = new Map<string, Date>();
+  for (const seen of sessionSeenRows) {
+    if (seen.seenAt) sessionSeenByUser.set(seen.userId, seen.seenAt);
+  }
+  const lastUsageDayByUser = new Map<string, string>();
+  for (const seen of usageSeenRows) {
+    if (seen.lastUsageDay) lastUsageDayByUser.set(seen.userId, seen.lastUsageDay);
   }
 
   return {
@@ -633,7 +654,10 @@ export async function readAdminUsersSource(
       createdAt: row.createdAt.getTime(),
       activeDays: toNumber(row.activeDays),
       lastActiveDay: row.lastActiveDay,
-      lastSeenAt: lastSeenByUser.get(row.id)?.getTime() ?? null,
+      lastSeenAt: lastSeenInstant(
+        sessionSeenByUser.get(row.id) ?? null,
+        lastUsageDayByUser.get(row.id) ?? null,
+      ),
       voiceCalls: toNumber(row.voiceCalls),
       attentionReviews: toNumber(row.attentionReviews),
       favorite: row.favorite === true,

--- a/apps/web/server/admin/admin-users.ts
+++ b/apps/web/server/admin/admin-users.ts
@@ -53,10 +53,9 @@ export interface AdminUserListRow {
   /** The account's most recent active day inside the window, if any. */
   lastActiveDay: string | null;
   /**
-   * When the account last touched the service at all, in epoch milliseconds:
-   * its freshest auth-session write, which a plain sign-in moves where the
-   * hosted-tier aggregates above stay at zero. Null for an account whose
-   * sessions have all been pruned.
+   * When the account last touched the service at all, in epoch milliseconds,
+   * as `lastSeenInstant` folds it. Null for an account whose sessions have
+   * all been pruned and which never touched the hosted tier.
    */
   lastSeenAt: number | null;
   voiceCalls: number;
@@ -80,6 +79,26 @@ export interface AdminUserList {
 export interface AdminUserListSource {
   total: number;
   rows: readonly AdminUserListRow[];
+}
+
+/**
+ * When one account last touched the service at all: its freshest auth-session
+ * write or, when later, the start of its most recent hosted-usage day. The
+ * session write alone cannot say it — the desktop spends the hosted tier over
+ * OAuth bearer tokens that never touch a session row, so an account can be
+ * active every day while its sessions age — and folding the usage day in is
+ * what keeps the roster's "Last seen" from trailing the account page's own
+ * "Last active". Null only when there is neither: every session pruned and no
+ * hosted use ever.
+ */
+export function lastSeenInstant(
+  sessionSeenAt: Date | null,
+  lastUsageDay: string | null,
+): number | null {
+  const usageDayStart = lastUsageDay === null ? null : Date.parse(`${lastUsageDay}T00:00:00.000Z`);
+  if (sessionSeenAt === null) return usageDayStart;
+  if (usageDayStart === null) return sessionSeenAt.getTime();
+  return Math.max(sessionSeenAt.getTime(), usageDayStart);
 }
 
 /** Stamps the queried roster with the window its aggregates cover and the search that scoped it. */

--- a/apps/web/tests/admin-users.test.ts
+++ b/apps/web/tests/admin-users.test.ts
@@ -7,6 +7,7 @@ import {
   type AdminUserListSource,
   buildAdminUserList,
   handleAdminUsers,
+  lastSeenInstant,
   searchLikePattern,
 } from "../server/admin/admin-users";
 import {
@@ -77,6 +78,22 @@ test("a searched roster echoes the term its rows and total were filtered by", ()
   assert.equal(searched.total, 3);
   assert.equal(searched.limit, ADMIN_USERS_LIMIT);
   assert.deepEqual(searched.rows, [ROW]);
+});
+
+test("last seen is the freshest of the session write and the last usage day", () => {
+  const agingSessionWrite = new Date("2026-08-10T09:30:00.000Z");
+  // Desktop activity rides bearer tokens that never touch a session row, so a
+  // later usage day must win: this is what keeps the roster's "Last seen"
+  // from trailing the account page's "Last active".
+  assert.equal(
+    lastSeenInstant(agingSessionWrite, "2026-08-17"),
+    Date.parse("2026-08-17T00:00:00.000Z"),
+  );
+  const freshSessionWrite = new Date("2026-08-17T09:30:00.000Z");
+  assert.equal(lastSeenInstant(freshSessionWrite, "2026-08-17"), freshSessionWrite.getTime());
+  assert.equal(lastSeenInstant(agingSessionWrite, null), agingSessionWrite.getTime());
+  assert.equal(lastSeenInstant(null, "2026-08-17"), Date.parse("2026-08-17T00:00:00.000Z"));
+  assert.equal(lastSeenInstant(null, null), null);
 });
 
 test("a search pattern matches the term literally, wildcards escaped", () => {


### PR DESCRIPTION
## Why

The admin dashboard's Users tables showed "Last seen" dates that lagged the User Detail page's "Last active" — sometimes by weeks — which reads as nonsense: an account cannot have been active more recently than it was last seen.

The cause: "Last seen" read only `max(session.updatedAt)`, the freshest **web** auth-session write. But the desktop spends the hosted tier over OAuth bearer tokens (`hostedUserId` resolves them through the userinfo endpoint), which never touch a `session` row. A daily-active desktop user's session row only moves when they sign in through a browser, so their "Last seen" froze there while "Last active" (`max(hosted_usage.day)`) kept moving.

## What

- `lastSeenAt` is now folded by a new pure helper, `lastSeenInstant`: the freshest auth-session write or, when later, the start of the account's most recent hosted-usage day. By construction it can never trail the last-active day either surface shows.
- `readAdminUsersSource` gains a third parallel aggregate (all-time `max(hosted_usage.day)` per account) — the roster query's own usage join is window-cut, so it cannot answer this, and the detail page's "Last active" is all-time.
- A plain sign-in with no hosted use still moves "Last seen" exactly as before.

## Testing

- `./scripts/check.sh` passes end to end (portable change only; no macOS or desktop UI surface touched).
- New unit test covers the fold: later usage day wins over an aging session write, a fresher session write wins over the same-day usage, and each side alone or neither behaves as documented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/d1973b30-cffb-4739-b3b3-b1237f02de47)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32998543284/artifacts/9617670555) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32998543284)

- Commit: `74f5f618d6e1023b5579dc2421070cc05c922288`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
