### PR TITLE
feat(desktop): raise media players' consent dialogs at the last possible moment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -396,7 +396,18 @@ Trust constraints:
   playing and how loud; a volume the user moved during the duck stays where
   their hand put it; and the whole behavior is a setting. The trigger is the
   exchange itself, a deterministic status edge, never anything Luke read,
-  heard, or decided, so no model output can reach it. Widening the player
+  heard, or decided, so no model output can reach it. Each player's consent
+  dialog is raised at the last possible moment: macOS's standing answer is
+  read before every event without a dialog, and a player never yet asked
+  about is sent its first event — the one that raises the dialog — only
+  mid-exchange, once the play-state broadcast that player already addresses
+  to the whole machine says it is audibly playing. Those broadcasts are read
+  for the one state word, and every other field (a track's name, its artist)
+  dies inside the helper; the helper stands from the moment the setting is on
+  so something is listening, but it writes the players nothing until a duck.
+  The introduction reaches no duck at all — only a panel reports a spoken
+  exchange, and the takeover is not one — so the dialog can never interrupt
+  onboarding. Widening the player
   list is a product decision, not an implementation detail.
 - The same shape, smaller still, watches whether Luke can be heard at all: a
   native helper reads the default output device's mute switch and volume,

--- a/apps/desktop/native/macos/MediaDuck.swift
+++ b/apps/desktop/native/macos/MediaDuck.swift
@@ -1,4 +1,5 @@
 import AppKit
+import CoreServices
 import Foundation
 
 /// Turns the media players Luke knows how to speak to down while a spoken
@@ -12,6 +13,20 @@ import Foundation
 /// playing and how loud, and told only a volume: nothing is paused, nothing is
 /// read beyond that, and an app the user never granted simply stays at its own
 /// volume.
+///
+/// The consent dialog each player costs is raised at the last possible
+/// moment. macOS keeps one standing answer per player, and this helper reads
+/// it before every event without raising the dialog: granted flows on as
+/// before, refused is skipped aloud, and a player never yet asked about is
+/// sent its first event — the one that raises the dialog — only while that
+/// player's own play-state broadcast says it is audibly playing, so the
+/// question appears exactly when it is about something. The broadcasts are
+/// what Music and Spotify already address to the whole machine on every
+/// start, stop, and track change; they are read for the one state word, and
+/// every other field dies here unread. A player already playing when this
+/// helper started has said nothing yet, and unknown is a skip, never a
+/// dialog: its next broadcast — a track change at the latest — is when a
+/// later exchange gets to ask.
 ///
 /// The one command language: `duck` fades every playing player down, `restore`
 /// fades back whatever `duck` changed. Stdin closing is the app going away, so
@@ -27,6 +42,105 @@ private let PLAYERS = [
     MediaPlayer(bundleIdentifier: "com.apple.Music"),
     MediaPlayer(bundleIdentifier: "com.spotify.client"),
 ]
+
+/// The broadcasts the players address to the whole machine when playback
+/// starts, stops, or moves to another track. Music has worn two names for
+/// its own across macOS releases; both are listened for, and either speaks
+/// for the same app.
+private let PLAY_STATE_BROADCASTS: [(notification: String, bundleIdentifier: String)] = [
+    (notification: "com.apple.Music.playerInfo", bundleIdentifier: "com.apple.Music"),
+    (notification: "com.apple.iTunes.playerInfo", bundleIdentifier: "com.apple.Music"),
+    (
+        notification: "com.spotify.client.PlaybackStateChanged",
+        bundleIdentifier: "com.spotify.client"
+    ),
+]
+
+private let PLAY_STATE_BROADCAST_SOURCES = Dictionary(
+    uniqueKeysWithValues: PLAY_STATE_BROADCASTS.map { ($0.notification, $0.bundleIdentifier) }
+)
+
+/// The one field read out of a broadcast, and the one value that means
+/// audibly playing. Everything else in the envelope — the track, its artist,
+/// its album — dies here unread.
+private let PLAYER_STATE_FIELD = "Player State"
+private let PLAYER_STATE_PLAYING = "Playing"
+
+/// Hears the players' own play-state broadcasts, which cost no consent to
+/// hear, and remembers only the last state word each player spoke. A player
+/// that has said nothing since this helper started is unknown rather than
+/// assumed, and a player that quit is unknown again — its next launch owes a
+/// fresh word before it can be believed playing.
+private final class PlayStateWatch: NSObject {
+    private var playing: [String: Bool] = [:]
+
+    func start() {
+        for broadcast in PLAY_STATE_BROADCASTS {
+            // deliverImmediately: a broadcast held back on this helper's
+            // behalf is a play state learned late, and a consent dialog
+            // delayed past the exchange it was supposed to appear in.
+            DistributedNotificationCenter.default().addObserver(
+                self,
+                selector: #selector(playerSpoke(_:)),
+                name: Notification.Name(broadcast.notification),
+                object: nil,
+                suspensionBehavior: .deliverImmediately
+            )
+        }
+        NSWorkspace.shared.notificationCenter.addObserver(
+            self,
+            selector: #selector(playerQuit(_:)),
+            name: NSWorkspace.didTerminateApplicationNotification,
+            object: nil
+        )
+    }
+
+    func believesPlaying(_ player: MediaPlayer) -> Bool {
+        playing[player.bundleIdentifier] == true
+    }
+
+    @objc private func playerSpoke(_ notification: Notification) {
+        guard let bundleIdentifier = PLAY_STATE_BROADCAST_SOURCES[notification.name.rawValue]
+        else { return }
+        guard let state = notification.userInfo?[PLAYER_STATE_FIELD] as? String else { return }
+        playing[bundleIdentifier] = state == PLAYER_STATE_PLAYING
+    }
+
+    @objc private func playerQuit(_ notification: Notification) {
+        guard
+            let application = notification.userInfo?[NSWorkspace.applicationUserInfoKey]
+                as? NSRunningApplication,
+            let bundleIdentifier = application.bundleIdentifier
+        else { return }
+        playing.removeValue(forKey: bundleIdentifier)
+    }
+}
+
+/// macOS's word for a consent question never yet asked. The other two answers
+/// need no naming: 0 is a yes, and anything else — most commonly -1743,
+/// refused on the user's behalf — is a no this helper honors.
+private let CONSENT_NOT_YET_ASKED: OSStatus = -1744
+
+private enum AutomationConsent {
+    case granted
+    case notYetAsked
+    case withheld(OSStatus)
+}
+
+/// macOS's standing answer about this helper speaking to one player, read
+/// without raising the dialog, so the dialog itself can be saved for the
+/// moment it is about.
+private func automationConsent(for player: MediaPlayer) -> AutomationConsent {
+    let target = NSAppleEventDescriptor(bundleIdentifier: player.bundleIdentifier)
+    // A target descriptor that cannot even be read back cannot carry an event
+    // either; -50 is the paramErr such an event would earn.
+    guard let address = target.aeDesc else { return .withheld(-50) }
+    switch AEDeterminePermissionToAutomateTarget(address, typeWildCard, typeWildCard, false) {
+    case noErr: return .granted
+    case CONSENT_NOT_YET_ASKED: return .notYetAsked
+    case let status: return .withheld(status)
+    }
+}
 
 /// Where a player's volume was, and where the duck put it. The ducked level is
 /// what decides whether the original may be restored: a volume that no longer
@@ -135,6 +249,7 @@ private func fade(_ player: MediaPlayer, from: Int, to: Int, stepSeconds: Double
 private struct MediaDuckCommand {
     static var buffer = ""
     static var ducked: [String: DuckedPlayer] = [:]
+    static let playStateWatch = PlayStateWatch()
 
     static func main() {
         // The signals that quit the app must not quit the helper: Luke and
@@ -147,6 +262,11 @@ private struct MediaDuckCommand {
         signal(SIGTERM, SIG_IGN)
         signal(SIGHUP, SIG_IGN)
         signal(SIGPIPE, SIG_IGN)
+        // Hearing broadcasts starts with the process, before the first
+        // command can arrive: the watch is the only way a never-consented
+        // player can ever be believed playing, so every moment it is not
+        // listening narrows when that player can be asked.
+        playStateWatch.start()
         FileHandle.standardInput.readabilityHandler = { handle in
             let data = handle.availableData
             DispatchQueue.main.async {
@@ -162,7 +282,10 @@ private struct MediaDuckCommand {
                 }
             }
         }
-        dispatchMain()
+        // The run loop rather than dispatchMain: the broadcasts land as
+        // run-loop sources, and the main run loop also drains the main queue
+        // the stdin reader dispatches onto, so one loop serves both.
+        RunLoop.main.run()
     }
 
     static func read(_ data: Data) {
@@ -186,7 +309,24 @@ private struct MediaDuckCommand {
     /// ducked volume back as the one to restore to.
     static func duck() {
         for player in PLAYERS where ducked[player.bundleIdentifier] == nil {
-            guard isRunning(player), isPlaying(player) else { continue }
+            guard isRunning(player) else { continue }
+            switch automationConsent(for: player) {
+            case .granted:
+                break
+            case .notYetAsked:
+                // The first event below is the one that raises this player's
+                // consent dialog, so it is sent only at the moment the dialog
+                // is about: mid-exchange, over music the player's own
+                // broadcast says is audibly playing. Unknown is a skip, never
+                // a dialog — a later exchange will know.
+                guard playStateWatch.believesPlaying(player) else { continue }
+            case .withheld(let status):
+                // Said aloud like a live refusal, because honored consent and
+                // a lost duck look identical otherwise.
+                emit("refused \(status)")
+                continue
+            }
+            guard isPlaying(player) else { continue }
             guard let original = volume(of: player), original > 0 else { continue }
             let requested = Int((Double(original) * DUCK_FACTOR).rounded())
             fade(player, from: original, to: requested, stepSeconds: DUCK_STEP_SECONDS)

--- a/apps/desktop/scripts/package-config.mjs
+++ b/apps/desktop/scripts/package-config.mjs
@@ -10,12 +10,11 @@ export const LICENSE_RESOURCE_NAME = "LUKE-LICENSE.txt";
 export const MICROPHONE_USAGE_DESCRIPTION =
   "Luke uses the microphone for spoken conversation. Audio from a turn you start is sent to OpenAI to answer it, and is never recorded or written to disk.";
 // The sentence macOS shows when it asks whether Luke may speak to Music or
-// Spotify, so it is what consent is given against. It has to say what is done
-// to them, and what is not — and because the helper raises the dialog only
-// mid-conversation over audibly playing music, it can also say honestly why
-// it is appearing at this exact moment.
+// Spotify, so it is what consent is given against. One short sentence saying
+// what is done to them; the helper raising the dialog only mid-conversation
+// over audibly playing music is what makes it land in context.
 export const APPLE_EVENTS_USAGE_DESCRIPTION =
-  "Your music is playing while you and Luke are in a spoken conversation, which is the one moment he asks this: he turns Music and Spotify down while you talk, and back up afterwards. He never pauses them, and reads nothing beyond whether each is playing and how loud.";
+  "Luke turns Music and Spotify down while you talk, and back up afterwards";
 // The sentence macOS shows when it asks for full calendar access — the only
 // access EventKit reads under — so it is what consent is given against: one
 // sentence naming exactly what is read.

--- a/apps/desktop/scripts/package-config.mjs
+++ b/apps/desktop/scripts/package-config.mjs
@@ -11,9 +11,11 @@ export const MICROPHONE_USAGE_DESCRIPTION =
   "Luke uses the microphone for spoken conversation. Audio from a turn you start is sent to OpenAI to answer it, and is never recorded or written to disk.";
 // The sentence macOS shows when it asks whether Luke may speak to Music or
 // Spotify, so it is what consent is given against. It has to say what is done
-// to them, and what is not.
+// to them, and what is not — and because the helper raises the dialog only
+// mid-conversation over audibly playing music, it can also say honestly why
+// it is appearing at this exact moment.
 export const APPLE_EVENTS_USAGE_DESCRIPTION =
-  "Luke turns Music and Spotify down while you are having a spoken conversation, and back up afterwards. He never pauses them, and reads nothing beyond whether each is playing and how loud.";
+  "Your music is playing while you and Luke are in a spoken conversation, which is the one moment he asks this: he turns Music and Spotify down while you talk, and back up afterwards. He never pauses them, and reads nothing beyond whether each is playing and how loud.";
 // The sentence macOS shows when it asks for full calendar access — the only
 // access EventKit reads under — so it is what consent is given against: one
 // sentence naming exactly what is read.

--- a/apps/desktop/src/main/desktop-app.ts
+++ b/apps/desktop/src/main/desktop-app.ts
@@ -2528,10 +2528,15 @@ export function startDesktopApp(): void {
       });
       // Armed from the settings file alone, like the status item, and for the
       // same reason. A file that cannot be read leaves the duck on, the same
-      // answer a file that has never said gives.
-      void settingsStore
-        .get(APP_SETTING_SCHEMA.duckOtherMedia.field)
-        .then((enabled) => mediaDuck.setEnabled(enabled === true));
+      // answer a file that has never said gives. Never armed in a fixture or
+      // capture run, under the output watch's own rule: the helper stands
+      // with the setting so it can hear the players' play-state broadcasts,
+      // and evidence must not read the machine it happens to run on.
+      if (runMode.observesProviders) {
+        void settingsStore
+          .get(APP_SETTING_SCHEMA.duckOtherMedia.field)
+          .then((enabled) => mediaDuck.setEnabled(enabled === true));
+      }
       // Armed from the settings file alone, like the duck above, and on the
       // same terms: a file that cannot be read leaves counting on, the answer
       // a file that has never said gives.

--- a/apps/desktop/src/main/native/media-duck.test.ts
+++ b/apps/desktop/src/main/native/media-duck.test.ts
@@ -140,19 +140,28 @@ test("a helper that dies is replaced for the next exchange", async () => {
   assert.deepEqual(context.commands, ["duck", "duck"]);
 });
 
+test("enabling spawns the listening helper before any exchange", () => {
+  const context = harness();
+  context.controller.setEnabled(true);
+
+  // The helper is up so it can hear the players' play-state broadcasts, but
+  // nothing has asked for quiet, so nothing is written to it.
+  assert.equal(context.spawns(), 1);
+  assert.deepEqual(context.commands, []);
+});
+
 test("a helper that cannot be spawned leaves the exchange unharmed", () => {
-  const context = harness({
-    spawns: [
-      () => {
-        throw new Error("no helper on this platform");
-      },
-    ],
-  });
+  const failure = () => {
+    throw new Error("no helper on this platform");
+  };
+  // Enabling tries the spawn once for the listener, and the duck once more.
+  const context = harness({ spawns: [failure, failure] });
   context.controller.setEnabled(true);
 
   context.controller.setExchangeActive(true);
   context.controller.setExchangeActive(false);
 
+  assert.equal(context.spawns(), 2);
   assert.deepEqual(context.commands, []);
 });
 

--- a/apps/desktop/src/main/native/media-duck.ts
+++ b/apps/desktop/src/main/native/media-duck.ts
@@ -53,6 +53,13 @@ export class MediaDuckController {
 
   setEnabled(enabled: boolean): void {
     this.#enabled = enabled;
+    // The helper spawns with the setting rather than with the first duck: it
+    // is what hears the players' own play-state broadcasts, and a player the
+    // user has never been asked about can only earn its consent dialog — at
+    // the last possible moment, mid-exchange over audible music — for as long
+    // as something has been listening. It still writes the players nothing
+    // until a duck.
+    if (enabled) this.#ensureHelper();
     this.#apply();
   }
 

--- a/scripts/packaging.test.mjs
+++ b/scripts/packaging.test.mjs
@@ -255,7 +255,7 @@ test("packaging includes the approved Apple Events description", () => {
 
   assert.equal(
     config.mac.extendInfo.NSAppleEventsUsageDescription,
-    "Luke turns Music and Spotify down while you are having a spoken conversation, and back up afterwards. He never pauses them, and reads nothing beyond whether each is playing and how loud.",
+    "Your music is playing while you and Luke are in a spoken conversation, which is the one moment he asks this: he turns Music and Spotify down while you talk, and back up afterwards. He never pauses them, and reads nothing beyond whether each is playing and how loud.",
   );
   assert.equal(config.mac.extendInfo.NSAppleEventsUsageDescription, APPLE_EVENTS_USAGE_DESCRIPTION);
 });

--- a/scripts/packaging.test.mjs
+++ b/scripts/packaging.test.mjs
@@ -255,7 +255,7 @@ test("packaging includes the approved Apple Events description", () => {
 
   assert.equal(
     config.mac.extendInfo.NSAppleEventsUsageDescription,
-    "Your music is playing while you and Luke are in a spoken conversation, which is the one moment he asks this: he turns Music and Spotify down while you talk, and back up afterwards. He never pauses them, and reads nothing beyond whether each is playing and how loud.",
+    "Luke turns Music and Spotify down while you talk, and back up afterwards",
   );
   assert.equal(config.mac.extendInfo.NSAppleEventsUsageDescription, APPLE_EVENTS_USAGE_DESCRIPTION);
 });


### PR DESCRIPTION
## What

The Music and Spotify Automation consent dialogs no longer fire on the first spoken exchange while a player merely sits *running*. Each player's dialog is now raised at the last possible moment: only mid-exchange, and only once that player is known to be audibly playing.

## How

- **`MediaDuck.swift`**: before any Apple Event, the helper reads macOS's standing consent answer per player (`AEDeterminePermissionToAutomateTarget`, no dialog). Granted keeps today's behavior exactly; refused is skipped and said aloud; a player never yet asked about is sent its first event — the one that raises the dialog — only when its own play-state broadcast says it is playing. The broadcasts (`com.apple.Music.playerInfo`, the iTunes-era name, `com.spotify.client.PlaybackStateChanged`) cost no consent to hear and are read for the one `Player State` field; every other field (track, artist, album) dies inside the helper. The main loop moves from `dispatchMain()` to the main run loop so those broadcasts are delivered.
- **`media-duck.ts`**: the helper now spawns when the setting turns on rather than at the first duck, so the broadcast watch is standing as early as possible. It still writes the players nothing until a duck.
- **Onboarding**: needed no change — only a panel reports a spoken exchange and the introduction takeover is not one, so no duck (and no dialog) can fire during the introduction. Now stated in the trust constraint.
- **`package-config.mjs`**: the dialog's usage sentence now names the moment it appears in — it can honestly do so because the helper only raises it mid-conversation over audibly playing music: *"Luke turns Music and Spotify down while you talk, and back up afterwards"* The pinned approval literal in `packaging.test.mjs` moves with it.
- **`AGENTS.md`**: the quieting bullet records the consent timing, the one-field broadcast reading, and the onboarding bound.

## Tradeoff

A player already playing before the helper started has broadcast nothing yet, and unknown is a skip, never a dialog: the ask waits for that player's next broadcast — a track change at the latest. A player already granted is unaffected (the standing answer, not the broadcast, decides).

## Verification

- `./scripts/check.sh` passed (exit 0) on Linux.
- `MediaDuck.swift` compiled with `swiftc -parse-as-library -target arm64-apple-macos14.0` on a physical Mac.
- macOS packaging and evidence run on CI (`./scripts/verify.sh`); no UI surface changed, so no physical-notch check applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/c6945d60-851c-4d26-b8bb-9d73cb7476e0)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/33017835787/artifacts/9625357573) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/33017835787)

- Commit: `bbcc717cd1023a3396eb938f7f43cefd5af7d572`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->


