### PR TITLE
feat(desktop): explain the protected-folder consent dialogs

### DIFF
--- a/apps/desktop/scripts/electron-builder-config.mjs
+++ b/apps/desktop/scripts/electron-builder-config.mjs
@@ -15,6 +15,8 @@ import {
   CALENDARS_USAGE_KEYS,
   MACOS_DEPLOYMENT_TARGET,
   MICROPHONE_USAGE_DESCRIPTION,
+  PROTECTED_FOLDER_USAGE_DESCRIPTION,
+  PROTECTED_FOLDER_USAGE_KEYS,
   resolveSigningMode,
   SIGNING_MODE,
 } from "./package-config.mjs";
@@ -111,6 +113,9 @@ export function createElectronBuilderConfig(env = process.env) {
         NSAppleEventsUsageDescription: APPLE_EVENTS_USAGE_DESCRIPTION,
         ...Object.fromEntries(
           CALENDARS_USAGE_KEYS.map((key) => [key, CALENDARS_USAGE_DESCRIPTION]),
+        ),
+        ...Object.fromEntries(
+          PROTECTED_FOLDER_USAGE_KEYS.map((key) => [key, PROTECTED_FOLDER_USAGE_DESCRIPTION]),
         ),
         NSMicrophoneUsageDescription: MICROPHONE_USAGE_DESCRIPTION,
         NSPrefersDisplaySafeAreaCompatibilityMode: false,

--- a/apps/desktop/scripts/package-config.mjs
+++ b/apps/desktop/scripts/package-config.mjs
@@ -35,6 +35,24 @@ export const CALENDARS_USAGE_KEYS = [
   "NSCalendarsUsageDescription",
 ];
 
+// The sentence macOS shows when Luke first touches a repository inside a
+// protected folder, reading a session's git branch from its own `.git` HEAD.
+// Without it the dialog gives no reason at all. It has to say what is read
+// there, and what is not.
+export const PROTECTED_FOLDER_USAGE_DESCRIPTION =
+  "Luke reads each coding session's current git branch from its repository, and nothing else in this folder.";
+
+/**
+ * One key per protected folder macOS guards this way. A repository lives
+ * wherever the developer cloned it, so every folder the dialog can name
+ * carries the same sentence.
+ */
+export const PROTECTED_FOLDER_USAGE_KEYS = [
+  "NSDocumentsFolderUsageDescription",
+  "NSDesktopFolderUsageDescription",
+  "NSDownloadsFolderUsageDescription",
+];
+
 /**
  * The Info.plist of the calendar helper's own minimal bundle. The helper
  * answers to TCC as itself, so this plist is what the consent dialog is

--- a/scripts/packaging.test.mjs
+++ b/scripts/packaging.test.mjs
@@ -24,6 +24,8 @@ import {
   MACOS_DEPLOYMENT_TARGET,
   MICROPHONE_USAGE_DESCRIPTION,
   PACKAGED_ARCHITECTURE,
+  PROTECTED_FOLDER_USAGE_DESCRIPTION,
+  PROTECTED_FOLDER_USAGE_KEYS,
   resolveSigningMode,
   SIGNING_MODE,
   SWIFT_TARGET_TRIPLE,
@@ -258,6 +260,23 @@ test("packaging includes the approved Apple Events description", () => {
     "Luke turns Music and Spotify down while you talk, and back up afterwards",
   );
   assert.equal(config.mac.extendInfo.NSAppleEventsUsageDescription, APPLE_EVENTS_USAGE_DESCRIPTION);
+});
+
+test("packaging includes the approved protected-folder description under every folder's key", () => {
+  const config = builderConfig();
+
+  assert.deepEqual(PROTECTED_FOLDER_USAGE_KEYS, [
+    "NSDocumentsFolderUsageDescription",
+    "NSDesktopFolderUsageDescription",
+    "NSDownloadsFolderUsageDescription",
+  ]);
+  for (const key of PROTECTED_FOLDER_USAGE_KEYS) {
+    assert.equal(
+      config.mac.extendInfo[key],
+      "Luke reads each coding session's current git branch from its repository, and nothing else in this folder.",
+    );
+    assert.equal(config.mac.extendInfo[key], PROTECTED_FOLDER_USAGE_DESCRIPTION);
+  }
 });
 
 test("packaging uses the generated Luke application icon", () => {


### PR DESCRIPTION
## What

A customer updating 0.1.1 → 0.3.12 hit macOS's Documents consent dialog with no explanation. The trigger is observation reading a session's git branch from its repository's own `.git` HEAD (added in 0.3.9 for the Cursor and Antigravity adapters); a repository under Documents, Desktop, or Downloads trips that folder's TCC prompt, and today the dialog shows no app-supplied reason.

## How

`NSDocumentsFolderUsageDescription`, `NSDesktopFolderUsageDescription`, and `NSDownloadsFolderUsageDescription` now all carry one sentence, following the calendar keys' shared-sentence pattern:

> "Luke reads each coding session's current git branch from its repository, and nothing else in this folder."

`packaging.test.mjs` pins the approved sentence and the exact key list, like the other consent sentences.

## Verification

- `node --test scripts/packaging.test.mjs`: 19 pass, 0 fail.
- Info.plist-only change, no UI surface moved; macOS packaging runs on CI (`./scripts/verify.sh`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/c6945d60-851c-4d26-b8bb-9d73cb7476e0)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/33021600630/artifacts/9626780547) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/33021600630)

- Commit: `76423193d7697fbcbcd4d9e79a6ec812f8f55bce`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
