### PR TITLE
feat(providers): never read a session's folder for its branch

### DIFF
--- a/packages/providers/src/antigravity/adapter.test.ts
+++ b/packages/providers/src/antigravity/adapter.test.ts
@@ -545,7 +545,11 @@ test("an IDE conversation's address opens its own workspace window", async (t) =
   assert.equal(observation.title, "roster");
   assert.equal(observation.directory, workspaceFolder);
   assert.equal(observation.detail?.repository, "roster");
-  assert.equal(observation.detail?.branch, "dev/fix-roster");
+  // The repository stands right there to ask, and observation still reports
+  // no branch: the store's metadata recorded none, and reading the folder's
+  // `.git` costs macOS's folder consent dialog when a repository lives under
+  // Documents, Desktop, or Downloads.
+  assert.equal(observation.detail?.branch, undefined);
   assert.equal(observation.detail?.link, `antigravity-ide://file${workspaceFolder}`);
 });
 

--- a/packages/providers/src/antigravity/adapter.ts
+++ b/packages/providers/src/antigravity/adapter.ts
@@ -12,7 +12,7 @@ import {
   type SessionProvider,
   type SessionStatus,
 } from "@sidecar/session";
-import { isRecord, oneLine, text, type WireRecord } from "@sidecar/wire";
+import { isRecord, oneLine, type WireRecord } from "@sidecar/wire";
 import {
   canIgnoreFilesystemError,
   fileStats,
@@ -149,33 +149,6 @@ const ANTIGRAVITY_METADATA_QUERY = `
   FROM trajectory_metadata_blob
   LIMIT 1
 `;
-
-const GIT_HEAD_BRANCH_PATTERN = /^ref: refs\/heads\/(.+)$/m;
-const GIT_DIRECTORY_POINTER_PATTERN = /^gitdir: (.+)$/m;
-const MAXIMUM_BRANCH_LENGTH = 120;
-
-/**
- * The branch the folder's own HEAD names right now, the same reading the
- * Cursor adapter takes: a worktree's `.git` is a pointer file to its own git
- * directory, followed for the same HEAD; a detached HEAD, an unreadable
- * file, or a folder that is not a repository names no branch at all.
- */
-async function branchFromGitHead(folderPath: string): Promise<string | undefined> {
-  const gitPath = path.join(folderPath, ".git");
-  const stats = await fileStats(gitPath);
-  let headPath: string | undefined;
-  if (stats?.isDirectory()) {
-    headPath = path.join(gitPath, "HEAD");
-  } else if (stats?.isFile()) {
-    const pointer = GIT_DIRECTORY_POINTER_PATTERN.exec((await readTextFile(gitPath)) ?? "")?.[1];
-    const gitDirectory = text(pointer);
-    if (gitDirectory) headPath = path.resolve(folderPath, gitDirectory, "HEAD");
-  }
-  if (!headPath) return undefined;
-  const head = await readTextFile(headPath);
-  if (!head) return undefined;
-  return oneLine(text(GIT_HEAD_BRANCH_PATTERN.exec(head)?.[1]), MAXIMUM_BRANCH_LENGTH);
-}
 
 export interface AntigravityAdapterOptions extends LocalSessionAdapterOptions {
   antigravityHome?: string;
@@ -508,13 +481,12 @@ export class AntigravitySessionAdapter extends LocalSessionAdapter {
       const derived = await this.#derivedConversation(storePath, stats.mtimeMs);
       if (!derived) continue;
       const title = await this.#annotationTitle(profileDirectory, conversationId);
-      // The branch is the folder's own HEAD, read each pass rather than
-      // cached with the store — a checkout moves it without touching the
-      // conversation — with the branch the store's metadata recorded at the
-      // start standing in where the folder cannot say.
-      const branch =
-        (derived.folderPath ? await branchFromGitHead(derived.folderPath) : undefined) ??
-        derived.storedBranch;
+      // The branch the store's metadata recorded at the start, which can be
+      // stale after a checkout. The folder's own HEAD would say where it
+      // stands now, but a repository under Documents, Desktop, or Downloads
+      // pays for that read with macOS's folder consent dialog: a label is
+      // not worth a permission, so observation never touches the folder.
+      const branch = derived.storedBranch;
       observations.set(
         conversationId,
         this.#derivedObservation(

--- a/packages/providers/src/cursor/local-adapter.test.ts
+++ b/packages/providers/src/cursor/local-adapter.test.ts
@@ -848,7 +848,7 @@ test("titles a chat by the name Cursor's own header keeps for it", async (t) => 
   assert.equal(observations[0]?.title, "Fix sticky scrolling");
   // The header's own folder outranks the reduced-name workspace match, for
   // the label and the branch alike; the branch is the header's created-on
-  // record where the folder holds no repository to ask.
+  // record, the one branch observation reports.
   assert.equal(observations[0]?.detail?.repository, "stage");
   assert.equal(observations[0]?.detail?.branch, "dean/fix-sticky-scrolling");
   assert.deepEqual(observations[0]?.detail?.diff, {
@@ -861,7 +861,7 @@ test("titles a chat by the name Cursor's own header keeps for it", async (t) => 
   assert.equal(JSON.stringify(observations).includes(SECRET_TRANSCRIPT_TEXT), false);
 });
 
-test("the folder's own HEAD names the branch over where the chat began", async (t) => {
+test("the folder's own HEAD is never read for the branch, even where one stands", async (t) => {
   const state = await temporaryCursorState(t);
   const folder = path.join(path.dirname(state.cursorHome), "repo");
   await fs.mkdir(path.join(folder, ".git"), { recursive: true });
@@ -900,8 +900,12 @@ test("the folder's own HEAD names the branch over where the chat began", async (
 
   const observations = await adapterFor(state).observe();
 
-  assert.equal(observations[0]?.detail?.branch, "feature/live-branch");
-  assert.equal(observations[1]?.detail?.branch, "wt-branch");
+  // Both repositories stand right there to ask, and observation still
+  // reports only the header's created-on record: reading a folder's `.git`
+  // costs macOS's folder consent dialog when a repository lives under
+  // Documents, Desktop, or Downloads, and a label is not worth a permission.
+  assert.equal(observations[0]?.detail?.branch, "main");
+  assert.equal(observations[1]?.detail?.branch, undefined);
 });
 
 test("a tool call holding for the user reads as waiting, not working", async (t) => {

--- a/packages/providers/src/cursor/local-adapter.ts
+++ b/packages/providers/src/cursor/local-adapter.ts
@@ -676,39 +676,6 @@ function matchingChats(
   }
 }
 
-/** The shape a symbolic HEAD names its branch in; a detached HEAD names none. */
-const GIT_HEAD_BRANCH_PATTERN = /^ref: refs\/heads\/(.+)$/m;
-const GIT_DIRECTORY_POINTER_PATTERN = /^gitdir: (.+)$/m;
-
-/**
- * The branch the chat's folder stands on right now, from the folder's own
- * `.git` HEAD — the one fact read outside Cursor's files, two bounded file
- * reads and never a git invocation, because the header's `createdOnBranch`
- * says where a chat began rather than where its folder stands after a
- * checkout. A worktree's `.git` is a pointer file to its own git directory,
- * followed for the same HEAD; a detached HEAD, an unreadable file, or a
- * folder that is not a repository names no branch at all.
- */
-async function branchFromGitHead(folderPath: string): Promise<string | undefined> {
-  const gitPath = path.join(folderPath, ".git");
-  const stats = await fileStats(gitPath);
-  let headPath: string | undefined;
-  if (stats?.isDirectory()) {
-    headPath = path.join(gitPath, "HEAD");
-  } else if (stats?.isFile()) {
-    const pointer = GIT_DIRECTORY_POINTER_PATTERN.exec((await readTextFile(gitPath)) ?? "")?.[1];
-    const gitDirectory = text(pointer);
-    if (gitDirectory) headPath = path.resolve(folderPath, gitDirectory, "HEAD");
-  }
-  if (!headPath) return undefined;
-  const head = await readTextFile(headPath);
-  if (!head) return undefined;
-  return oneLine(
-    text(GIT_HEAD_BRANCH_PATTERN.exec(head)?.[1]),
-    CURSOR_HEADER_BOUNDS.MAXIMUM_BRANCH_LENGTH,
-  );
-}
-
 /**
  * What Cursor knows about a local session beyond its state: the folder, the
  * tool call an open turn is running, that a turn failed, the branch and
@@ -1151,11 +1118,13 @@ export class CursorLocalSessionAdapter extends LocalFileSessionAdapter<
     }
     const appHeld = this.#appChatIndex.held.has(candidate.providerSessionId);
     const link = appHeld ? cursorChatLink(candidate.providerSessionId) : undefined;
-    // The branch is the folder's own HEAD wherever the folder is known — a
-    // header's created-on branch says where a chat began, not where its
-    // folder stands after a checkout — with that header record standing in
-    // where the folder cannot say.
-    const branch = (directory ? await branchFromGitHead(directory) : undefined) ?? header?.branch;
+    // The branch is the header's created-on record — where the chat began,
+    // which can be stale after a checkout. The folder's own HEAD would say
+    // where it stands now, but reading it is the one observation that leaves
+    // Cursor's files, and a repository under Documents, Desktop, or Downloads
+    // pays for that read with macOS's folder consent dialog: a label is not
+    // worth a permission, so observation never touches the folder.
+    const branch = header?.branch;
     // A message is advertised only where the CLI's documented resume can
     // honestly land one: the turn is settled and nothing newer says work is
     // running — a prompt hook can know about a turn the transcript has not
@@ -1233,9 +1202,9 @@ export class CursorLocalSessionAdapter extends LocalFileSessionAdapter<
     }
     const appHeld = this.#appChatIndex.held.has(candidate.providerSessionId);
     const link = appHeld ? cursorChatLink(candidate.providerSessionId) : undefined;
-    const branch =
-      (candidate.meta.cwd ? await branchFromGitHead(candidate.meta.cwd) : undefined) ??
-      header?.branch;
+    // The header's created-on record, on the transcript rows' own terms: no
+    // folder is ever read for a label.
+    const branch = header?.branch;
     this.#sendTargets.delete(candidate.providerSessionId);
     return {
       providerSessionId: candidate.providerSessionId,


### PR DESCRIPTION
## What

Removes the one observation read that left the providers' own files: the Cursor and Antigravity adapters read each session's current git branch from its workspace folder's `.git` HEAD, and a repository under Documents, Desktop, or Downloads paid for that label with macOS's folder consent dialog (what a customer hit updating 0.1.1 → 0.3.12). Luke now never needs folder permission at all.

Replaces #551, which explained the dialogs instead of removing them.

## How

- `branchFromGitHead` is deleted from both adapters. The branch is now only what each provider recorded itself: Cursor's `createdOnBranch` header record, Antigravity's store metadata.
- Honest tradeoff, stated in the code comments: the recorded branch says where a chat *began*, so a checkout after that isn't reflected — and a session whose provider recorded no branch shows none.
- The tests keep their `.git` fixtures inverted as regression guards: a repository standing right there is still never read.

## Verification

- `@sidecar/providers` test suite: 711 pass, 0 fail.
- `./scripts/check.sh` running on CI (no macOS surface changed; adapters are platform-independent packages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/c6945d60-851c-4d26-b8bb-9d73cb7476e0)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/33024082560/artifacts/9627743840) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/33024082560)

- Commit: `710df0b74a178195a31787b85157ce2f25996b15`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
