### PR TITLE
fix(desktop): a finished turn no longer reads "Needs you"

### DIFF
--- a/apps/desktop/src/renderer/session-model.test.ts
+++ b/apps/desktop/src/renderer/session-model.test.ts
@@ -82,7 +82,13 @@ test("the most urgent sessions are listed first in either data source", () => {
   const live = displaySessions(bootstrap(false), [
     liveSession(CODEX_PROVIDER, "codex-1", SESSION_STATUS.COMPLETE),
     liveSession(CLAUDE_PROVIDER, "claude-1", SESSION_STATUS.WORKING),
-    liveSession(CODEX_PROVIDER, "codex-2", SESSION_STATUS.WAITING),
+    normalizeSession(CODEX_PROVIDER, {
+      providerSessionId: "codex-2",
+      title: "Session codex-2",
+      status: SESSION_STATUS.WAITING,
+      observedAt: 1_000,
+      holdingForDeveloper: true,
+    }),
   ]);
   assert.deepEqual(
     live.map((session) => session.id),
@@ -280,6 +286,43 @@ test("a speaking disposition needs a person even while the session works", () =>
     ],
   );
   assert.equal(session?.urgency, SESSION_URGENCY.ATTENTION);
+});
+
+// A local CLI reports every ordinary finished turn as waiting — completion is
+// session teardown, which a terminal left open never reaches — so waiting
+// alone must not read as "Needs you". Only a turn holding for the developer,
+// or a recap that itself asks, is an ask; a finished turn reads as settled.
+test("a finished turn is not an ask; a held or asking one is", () => {
+  const waiting = (
+    providerSessionId: string,
+    extras: { recap?: string; holdingForDeveloper?: boolean },
+  ) =>
+    normalizeSession(CLAUDE_PROVIDER, {
+      providerSessionId,
+      title: `Session ${providerSessionId}`,
+      status: SESSION_STATUS.WAITING,
+      observedAt: 1_000,
+      ...extras,
+    });
+
+  const sessions = displaySessions(bootstrap(false), [
+    waiting("claude-finished", { recap: "Great—the feature is fully working now." }),
+    waiting("claude-held", { holdingForDeveloper: true }),
+    waiting("claude-asking", { recap: "Should I ship it?" }),
+  ]);
+  const byId = new Map(sessions.map((session) => [session.id, session]));
+
+  assert.equal(byId.get("claude-finished")?.urgency, SESSION_URGENCY.COMPLETE);
+  assert.equal(byId.get("claude-finished")?.detail, "Great—the feature is fully working now.");
+  assert.equal(byId.get("claude-held")?.urgency, SESSION_URGENCY.ATTENTION);
+  assert.equal(byId.get("claude-asking")?.urgency, SESSION_URGENCY.ATTENTION);
+
+  // The badge counts the same reading: the finished turn is a Complete, never
+  // a tallied ask for the notch to number.
+  const tally = sessionTally(sessions);
+  assert.equal(tally.attention, 2);
+  assert.equal(tally.complete, 1);
+  assert.equal(tally.attentionIds.includes("claude-finished"), false);
 });
 
 test("attention joins on the whole provider identity and supplies the row detail", () => {
@@ -830,18 +873,20 @@ test("chats of one workspace sit together and read as one tray run", () => {
     id: string,
     status: (typeof SESSION_STATUS)[keyof typeof SESSION_STATUS],
     observedAt: number,
+    recap?: string,
   ) =>
     normalizeSession(CONDUCTOR_PROVIDER, {
       providerSessionId: id,
       title: `Chat ${id}`,
       status,
       observedAt,
+      ...(recap ? { recap } : undefined),
       detail: { repository: "luke" },
       workspace: { providerWorkspaceId: "workspace-lisbon", name: "lisbon-v2" },
     });
 
   const rows = displaySessions(bootstrap(false), [
-    chatOf("chat-asking", SESSION_STATUS.WAITING, 1_000),
+    chatOf("chat-asking", SESSION_STATUS.WAITING, 1_000, "Keep the run seated together?"),
     liveSession(CODEX_PROVIDER, "codex-between", SESSION_STATUS.WORKING, 5_000),
     chatOf("chat-finished", SESSION_STATUS.COMPLETE, 9_000),
   ]);
@@ -1327,6 +1372,7 @@ test("a query finds a session by its status word, even under a busy detail line"
       title: "Fix the login flow",
       status: SESSION_STATUS.WAITING,
       observedAt: 2_000,
+      holdingForDeveloper: true,
       detail: { activity: "Holding for an approval" },
     }),
   ]);

--- a/apps/desktop/src/renderer/session-model.ts
+++ b/apps/desktop/src/renderer/session-model.ts
@@ -35,6 +35,7 @@ import {
   sessionChangeNumber,
   sessionFilterAxis,
   silentAttention,
+  waitingHoldsForDeveloper,
 } from "@sidecar/session";
 import {
   compareSessionsByUrgency,
@@ -497,7 +498,13 @@ type SessionWithAttention = Session & { attention: AttentionDecision };
 
 function sessionNeedsAttention(session: SessionWithAttention): boolean {
   return (
-    session.status === SESSION_STATUS.WAITING ||
+    // Waiting alone is not an ask: a local CLI reports every ordinary finished
+    // turn as waiting, because completion is session teardown, which a
+    // terminal left open never reaches. Only a turn actually holding for the
+    // developer — a permission or question the provider reported, or a recap
+    // that itself asks — reads as "Needs you"; the notices and the voice
+    // already draw this line, and the row draws the same one.
+    waitingHoldsForDeveloper(session) ||
     // A session that stopped on a failure cannot get itself going again, so it
     // wants a person at least as much as one that finished its turn.
     session.status === SESSION_STATUS.ERROR ||
@@ -559,6 +566,9 @@ function noticeAsksByIdentity(
 
 function sessionUrgency(session: SessionWithAttention): SessionUrgency {
   if (sessionNeedsAttention(session)) return SESSION_URGENCY.ATTENTION;
+  // A waiting turn not holding for the developer is a turn that settled: it
+  // reads as Complete, not Working — nothing is running — and not as an ask.
+  if (session.status === SESSION_STATUS.WAITING) return SESSION_URGENCY.COMPLETE;
   if (session.status === SESSION_STATUS.COMPLETE) return SESSION_URGENCY.COMPLETE;
   if (session.status === SESSION_STATUS.UNKNOWN) return SESSION_URGENCY.UNKNOWN;
   return SESSION_URGENCY.WORKING;

--- a/packages/attention/src/attention-prompt.ts
+++ b/packages/attention/src/attention-prompt.ts
@@ -36,7 +36,7 @@ const ATTENTION_INSTRUCTION_LINES: readonly string[] = [
   "As the engineering manager for the user's coding agents, decide whether Luke should speak about an update.",
   `- ${HUMAN_VOICE_INSTRUCTION}`,
   `- ${CTO_RELEVANCE_INSTRUCTION}`,
-  "- Default to silence. Speak only for a concrete question, permission or approval, material error or risk, material outcome that changes what happens next, or an answer to the user's standing ask. A status change, completion, or recap alone is not enough.",
+  "- Default to silence. Speak only for a concrete question, permission or approval, material error or risk, material outcome that changes what happens next, or an answer to the user's standing ask. A status change, completion, or recap alone is not enough: a recap reporting success — the work finished, the feature working, the tests passing — is silent however good the news, unless it contains a concrete question, permission, or approval, or answers the user's standing ask. An outcome changes what happens next only when someone must now act or decide; an outcome the user would merely like to know about does not.",
   "- If speaking, give one short, natural sentence, not a status report. State only what the CTO needs to know; add no advice or next step.",
   `- ${AGENT_WORK_LANGUAGE_INSTRUCTION}`,
   "- Treat waiting as actionable only when the recap or context shows a concrete question, permission, or approval. Before any question, name the agent's work and briefly explain the specific situation or decision topic that makes the interruption relevant; then give the exact question. Never open with a bare question or a generic statement that the agent needs input, needs a decision, is waiting, or cannot continue.",

--- a/packages/session/src/index.ts
+++ b/packages/session/src/index.ts
@@ -132,6 +132,7 @@ export {
   type SessionNotice,
   type SessionNoticeStatus,
   SessionNoticeTracker,
+  waitingHoldsForDeveloper,
 } from "./session-notices.js";
 export {
   InMemorySessionRegistry,

--- a/packages/session/src/session-notices.ts
+++ b/packages/session/src/session-notices.ts
@@ -95,8 +95,12 @@ export interface SessionNotice {
  * a URL is not a question. A `?` that ends a sentence after a link still
  * is: a query string has characters after the mark, and a trailing ask
  * does not.
+ *
+ * Exported because the row's urgency reads the same distinction the notices
+ * do: two heuristics would drift, and a row saying "Needs you" about a turn
+ * the voice rightly stayed quiet about is the drift made visible.
  */
-function waitingHoldsForDeveloper(session: Session): boolean {
+export function waitingHoldsForDeveloper(session: Session): boolean {
   if (session.status !== SESSION_STATUS.WAITING) return false;
   if (session.holdingForDeveloper === true) return true;
   if (!session.recap) return false;


### PR DESCRIPTION
## User feedback

> "If the model response is 'Great—the <feature> is fully working now.' I don't want this to be flagged."

## Diagnosis

"Flagged" happened on two independent layers, and the primary one never read the text at all:

1. **Row urgency (primary, deterministic).** Every local CLI provider reports an ordinary finished turn as `SESSION_STATUS.WAITING` — `COMPLETE` is reserved for session teardown (`result` / `SessionEnd`), which a developer who leaves the terminal open never reaches. The renderer's `sessionNeedsAttention` treated `WAITING` as needing a person unconditionally, so every settled turn earned the "Needs you" band, top-of-list sort, the notch badge tally, and a face gesture — regardless of what its recap said.

2. **Attention evaluator (secondary).** The evaluator prompt said "A status change, completion, or recap alone is not enough" while also authorizing a "material outcome that changes what happens next" — and "the feature is fully working now" reads exactly like a material outcome, so a non-silent disposition could light the row and replace its subtitle.

## Fix

- **Row layer.** `sessionNeedsAttention` now gates WAITING on the same `waitingHoldsForDeveloper` reading the notices (`packages/session/src/session-notices.ts`) and the voice already draw: a provider-reported hold (`holdingForDeveloper`), or a recap that itself asks (with the existing URL-query-string exclusion). The helper is exported from `@sidecar/session` so the row and the notices consult one implementation rather than two heuristics that drift. A WAITING turn not holding for the developer now reads as **Complete** — settled, below Working in the sort, counted in the badge's complete tier, never in the attention tally. A permission hold and `ERROR` still read "Needs you". All three cloud adapters that mean "blocked on you" by WAITING (Jules, Copilot, Devin) already set `holdingForDeveloper: true` explicitly, so none of them is demoted.
- **Evaluator layer.** The prompt now resolves the tension: a recap reporting success is silent however good the news, unless it contains a concrete question, permission, or approval, or answers the user's standing ask; an outcome "changes what happens next" only when someone must now act or decide.
- **Tests.** New renderer test: a WAITING session with a benign completion recap and no hold is Complete (not ATTENTION) and stays out of the badge tally, while a held turn and an asking recap stay "Needs you". Existing tests that relied on bare WAITING → ATTENTION now state the hold they meant. Fixtures are unchanged — the fixture's one attention row carries its urgency explicitly and still describes the intended product.

## Verification

- `./scripts/bootstrap.sh` — completed, exit 0.
- `./scripts/check.sh` — passed, exit 0 (repository checks, types, tests, builds).
- `./scripts/verify.sh` is macOS-only and this change was made in a Linux cloud workspace, so it was **not run**; no physical-notch check was performed. The change is renderer model logic plus a prompt string — no panel geometry or motion moved — but a macOS verify run before release would still be the honest completion invariant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/192929c6-c64c-4645-8d64-92e4d3064560)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/33027461104/artifacts/9628983577) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/33027461104)

- Commit: `552384e48aa2f02d456f8bf3de6637037738d5e9`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
