### PR TITLE
fix(providers): a stale permission hold stands down on its own

### DIFF
--- a/apps/desktop/src/main/desktop-app.ts
+++ b/apps/desktop/src/main/desktop-app.ts
@@ -209,6 +209,13 @@ const ACCOUNT_BASE_URL =
 const HOSTED_SERVICE_BASE_URL = ACCOUNT_BASE_URL.replace(/\/api\/auth\/?$/, "");
 const ACCOUNT_CLIENT_ID = "luke-desktop";
 const SESSION_REFRESH_INTERVAL_MS = 5_000;
+/**
+ * How often the hook spools shed files old enough to refine nothing. Launch
+ * convergence prunes once; this cadence covers the app left running across
+ * days, where a dead session's spool file would otherwise wait for the next
+ * relaunch. An hour is frequency enough for a bound whose scale is a day.
+ */
+const HOOK_SPOOL_PRUNE_INTERVAL_MS = 60 * 60 * 1000;
 const sessionRegistry = new InMemorySessionRegistry();
 // Declared before the settings store because the store's snapshot asks it
 // what the latest pass learned about the Codex CLI's login. It observes only
@@ -1707,6 +1714,27 @@ async function applyLocalSessionHooks(): Promise<void> {
 }
 
 /**
+ * The recurring half of the spool prune the launch convergence above starts,
+ * absorbing failures per provider for the same reason it does: a spool that
+ * cannot be pruned costs only its own disk, never another provider's pass.
+ */
+async function pruneLocalSessionHookSpools(): Promise<void> {
+  await Promise.all(
+    orderedRegistrations.map(async ({ adapter, pruneObservationHookSpool }) => {
+      if (!pruneObservationHookSpool) return;
+      try {
+        await pruneObservationHookSpool();
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        process.stderr.write(
+          `${adapter.provider.displayName} hook spool prune failed: ${message}\n`,
+        );
+      }
+    }),
+  );
+}
+
+/**
  * The Superset entry of the workspace-host registry carries the whole
  * Superset pass, not only the enrichment: the acts a drawn row still
  * advertises resolve against this module's latest snapshot, and the chatless
@@ -2165,6 +2193,11 @@ const sessionObservationLoop = new ObservationLoop({
   // A pass is also when the Codex CLI login can have changed hands, and no
   // settings save stands behind that to announce it.
   afterRun: () => {
+    // Time alone can expire an attention decision, and the registry has no
+    // clock of its own, so expiry rides the same cadence that ages statuses:
+    // a flagged row returns to status-derived urgency the pass after its
+    // decision ages out, not whenever something else happens to change.
+    sessionRegistry.expireAttention(Date.now());
     broadcastRelevantSessions();
     void broadcastCodexCloudConnection();
   },
@@ -2184,11 +2217,17 @@ const calendarObservationLoop = new ObservationLoop({
   intervalMs: CALENDAR_REFRESH_INTERVAL_MS,
   run: refreshCalendarMeetings,
 });
+const hookSpoolPruneLoop = new ObservationLoop({
+  gate: observationGate,
+  intervalMs: HOOK_SPOOL_PRUNE_INTERVAL_MS,
+  run: () => pruneLocalSessionHookSpools(),
+});
 const observationSupervisor = new ObservationSupervisor([
   sessionObservationLoop,
   attentionObservationLoop,
   issueObservationLoop,
   calendarObservationLoop,
+  hookSpoolPruneLoop,
 ]);
 
 /**

--- a/packages/providers/src/claude-code/adapter.test.ts
+++ b/packages/providers/src/claude-code/adapter.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import test, { type TestContext } from "node:test";
 import { isRosterRelevant, SESSION_COMPLETION_CAUSE, SESSION_STATUS } from "@sidecar/session";
 import type { ParsedJsonObject } from "@sidecar/wire/testing";
+import { HOOK_NOTIFICATION_HOLD_HORIZON_MS } from "../shared/local-session-adapter.js";
 import { CLAUDE_CODE_PROVIDER, ClaudeCodeSessionAdapter } from "./adapter.js";
 
 const TEST_TIME = Date.parse("2026-08-11T23:45:00.000Z");
@@ -1070,6 +1071,38 @@ test("a permission prompt the transcript cannot show turns the row to waiting", 
   // The event also dates the session: the spool is written only by Luke's own
   // script, so its clock cannot suffer the transcripts' bulk-touch problem.
   assert.equal(observation?.observedAt, TEST_TIME - 60_000);
+});
+
+test("a permission hold past the hold horizon stands down on its own", async (t) => {
+  const claudeHome = await temporaryClaudeHome(t);
+  const spool = await temporaryHookSpool(t);
+  // A process killed mid-hold writes neither the answer nor a closing hook.
+  // Past the horizon the standing event refines nothing, and the mid-turn
+  // transcript decays to unknown exactly as it would with no event at all.
+  // SAFETY: Fixture value matches the narrowed runtime shape this test exercises.
+  await writeSessionFile(
+    claudeHome,
+    "-Users-test-luke",
+    "dead-hold",
+    midTurnRecords("/Users/test/luke", "2026-08-11T18:40:00.000Z"),
+    TEST_TIME - 5 * 60 * 60 * 1000,
+  );
+  await writeHookEvent(
+    spool,
+    "dead-hold",
+    "notification",
+    TEST_TIME - HOOK_NOTIFICATION_HOLD_HORIZON_MS - 60_000,
+  );
+
+  const adapter = new ClaudeCodeSessionAdapter({
+    claudeHome,
+    hookEventsDirectory: () => spool,
+    now: () => TEST_TIME,
+  });
+  const [observation] = await adapter.observe();
+
+  assert.equal(observation?.status, SESSION_STATUS.UNKNOWN);
+  assert.equal(observation?.holdingForDeveloper, undefined);
 });
 
 test("a session-end event settles a row the tail would leave waiting", async (t) => {

--- a/packages/providers/src/claude-code/adapter.ts
+++ b/packages/providers/src/claude-code/adapter.ts
@@ -426,8 +426,9 @@ function statusFromTail(
  * definite alongside a closed session because the tail may hold nothing about
  * either. The notification keeps waiting past freshness — a standing event is
  * proof the permission dialog is still up, because any record at or past it
- * would have discarded it, and a crash mid-hold leaves that proof standing
- * only until the spool prune retires it.
+ * would have discarded it — but only within the hold horizon: a crash
+ * mid-hold discards nothing, so past it the shared refinement stands the
+ * event down and the transcript's own decay answers alone.
  */
 const CLAUDE_HOOK_STATUS_REFINEMENT = {
   definitive: [

--- a/packages/providers/src/codex/adapter.test.ts
+++ b/packages/providers/src/codex/adapter.test.ts
@@ -12,6 +12,7 @@ import {
   SESSION_STATUS,
 } from "@sidecar/session";
 import type { ParsedJsonObject } from "@sidecar/wire/testing";
+import { HOOK_NOTIFICATION_HOLD_HORIZON_MS } from "../shared/local-session-adapter.js";
 import { CODEX_PROVIDER, CodexSessionAdapter, isCodexRealtimeDelegationText } from "./adapter.js";
 
 const TEST_TIME = Date.parse("2026-08-11T23:45:00.000Z");
@@ -1554,4 +1555,40 @@ test("a permission hold that outlives the freshness window is still an ask", asy
   const [observation] = await adapter.observe();
 
   assert.equal(observation?.status, SESSION_STATUS.WAITING);
+});
+
+// SAFETY: Fixture value matches the narrowed runtime shape this test exercises.
+test("a permission hold past the hold horizon stands down on its own", async (t) => {
+  const codexHome = await temporaryCodexHome(t);
+  const spool = await temporaryHookSpool(t);
+  const rolloutPath = path.join(codexHome, "rollout-dead-hold.jsonl");
+  // A process killed mid-hold writes neither the approval nor a closing
+  // hook, so the standing event is the only trace of a dialog no longer on
+  // any screen. Past the horizon it refines nothing, and the row says what
+  // the rollout alone says: an open turn.
+  await writeCodexState(codexHome, [
+    {
+      id: "codex-dead-hold",
+      cwd: "/Users/test/luke",
+      observedAt: TEST_TIME - HOOK_NOTIFICATION_HOLD_HORIZON_MS - 60 * 60 * 1000,
+      rolloutPath,
+    },
+  ]);
+  await writeRollout(rolloutPath, [{ type: "event_msg", payload: { type: "task_started" } }]);
+  await writeHookEvent(
+    spool,
+    "codex-dead-hold",
+    "notification",
+    TEST_TIME - HOOK_NOTIFICATION_HOLD_HORIZON_MS - 60_000,
+  );
+
+  const adapter = new CodexSessionAdapter({
+    codexHome,
+    hookEventsDirectory: () => spool,
+    now: () => TEST_TIME,
+  });
+  const [observation] = await adapter.observe();
+
+  assert.equal(observation?.status, SESSION_STATUS.WORKING);
+  assert.equal(observation?.holdingForDeveloper, undefined);
 });

--- a/packages/providers/src/codex/adapter.ts
+++ b/packages/providers/src/codex/adapter.ts
@@ -655,8 +655,9 @@ function statusFromRow(
  * holds, and a turn's true end can sit past the rollout's read. The
  * notification keeps waiting past freshness — a standing event is proof the
  * approval dialog is still up, because any record at or past it would have
- * discarded it, and a process killed mid-hold leaves that proof standing
- * only until the spool prune retires it.
+ * discarded it — but only within the hold horizon: a process killed mid-hold
+ * discards nothing, so past it the shared refinement stands the event down
+ * and the rollout's own verdict answers alone.
  */
 const CODEX_HOOK_STATUS_REFINEMENT = {
   definitive: [{ event: CODEX_HOOK_EVENT.SESSION_END, fresh: SESSION_STATUS.COMPLETE }],

--- a/packages/providers/src/devin/local-adapter.test.ts
+++ b/packages/providers/src/devin/local-adapter.test.ts
@@ -6,6 +6,7 @@ import { DatabaseSync } from "node:sqlite";
 import test, { type TestContext } from "node:test";
 import { SESSION_COMPLETION_CAUSE, SESSION_STATUS } from "@sidecar/session";
 import type { MutableWireRecord, ParsedJsonObject } from "@sidecar/wire/testing";
+import { HOOK_NOTIFICATION_HOLD_HORIZON_MS } from "../shared/local-session-adapter.js";
 import { DEVIN_PROVIDER } from "./adapter.js";
 import { DevinLocalSessionAdapter } from "./local-adapter.js";
 
@@ -859,6 +860,35 @@ test("a permission hold that outlives the freshness window is still an ask", asy
   const [observation] = await adapter.observe();
 
   assert.equal(observation?.status, SESSION_STATUS.WAITING);
+});
+
+test("a permission hold past the hold horizon stands down on its own", async (t) => {
+  const cliDirectory = await temporaryCliDirectory(t);
+  const spool = await temporaryHookSpool(t);
+  // A process killed mid-hold writes neither the approval nor a closing
+  // hook. Past the horizon the standing event refines nothing, and the open
+  // turn decays to unknown exactly as it would with no event at all.
+  await writeOpenTurnState(
+    cliDirectory,
+    "dead-hold",
+    TEST_TIME - HOOK_NOTIFICATION_HOLD_HORIZON_MS - 60 * 60_000,
+  );
+  await writeHookEvent(
+    spool,
+    "dead-hold",
+    "notification",
+    TEST_TIME - HOOK_NOTIFICATION_HOLD_HORIZON_MS - 60_000,
+  );
+
+  const adapter = new DevinLocalSessionAdapter({
+    cliDirectory,
+    hookEventsDirectory: () => spool,
+    now: () => TEST_TIME,
+  });
+  const [observation] = await adapter.observe();
+
+  assert.equal(observation?.status, SESSION_STATUS.UNKNOWN);
+  assert.equal(observation?.holdingForDeveloper, undefined);
 });
 
 test("honors the CLI's own database override", async (t) => {

--- a/packages/providers/src/devin/local-adapter.ts
+++ b/packages/providers/src/devin/local-adapter.ts
@@ -314,8 +314,9 @@ function activityFromToolCallRows(rows: readonly DevinRow[]): string | undefined
  * and the database records no closure at all. The notification keeps waiting
  * past freshness for the same reason Codex's does — a standing event is
  * proof the approval dialog is still up, because any row at or past it would
- * have discarded it, and a process killed mid-hold leaves that proof
- * standing only until the spool prune retires it.
+ * have discarded it — but only within the hold horizon: a process killed
+ * mid-hold discards nothing, so past it the shared refinement stands the
+ * event down and the database's own decay answers alone.
  */
 const DEVIN_HOOK_STATUS_REFINEMENT = {
   definitive: [{ event: DEVIN_HOOK_EVENT.SESSION_END, fresh: SESSION_STATUS.COMPLETE }],

--- a/packages/providers/src/gemini-cli/adapter.test.ts
+++ b/packages/providers/src/gemini-cli/adapter.test.ts
@@ -9,6 +9,7 @@ import {
   UNKNOWN_WORKSPACE_LABEL,
 } from "@sidecar/session";
 import type { ParsedJsonObject } from "@sidecar/wire/testing";
+import { HOOK_NOTIFICATION_HOLD_HORIZON_MS } from "../shared/local-session-adapter.js";
 import { GEMINI_CLI_PROVIDER, GeminiCliSessionAdapter } from "./adapter.js";
 
 const TEST_TIME = Date.parse("2026-08-20T12:00:00.000Z");
@@ -606,6 +607,32 @@ test("a permission hold that outlives the freshness window is still an ask", asy
 
   assert.equal(observation?.status, SESSION_STATUS.WAITING);
   assert.equal(observation?.holdingForDeveloper, true);
+});
+
+test("a permission hold past the hold horizon stands down on its own", async (t) => {
+  const geminiHome = await temporaryGeminiHome(t);
+  const spool = await temporaryHookSpool(t);
+  // A process killed mid-hold writes neither the confirmation nor a closing
+  // hook. Past the horizon the standing event refines nothing, and the
+  // mid-turn recording decays to unknown exactly as it would with no event.
+  await writeSessionFile(
+    geminiHome,
+    "luke",
+    "session-2026-08-20T11-00-abcd1234",
+    midTurnRecords("2026-08-20T11:40:00.000Z"),
+    TEST_TIME - 20 * 60 * 1000,
+  );
+  await writeHookEvent(spool, FULL_SESSION_ID, "notification", TEST_TIME - 60_000);
+
+  const adapter = new GeminiCliSessionAdapter({
+    geminiHome,
+    hookEventsDirectory: () => spool,
+    now: () => TEST_TIME + HOOK_NOTIFICATION_HOLD_HORIZON_MS,
+  });
+  const [observation] = await adapter.observe();
+
+  assert.equal(observation?.status, SESSION_STATUS.UNKNOWN);
+  assert.equal(observation?.holdingForDeveloper, undefined);
 });
 
 test("a stop event keeps a finished turn waiting past the freshness decay", async (t) => {

--- a/packages/providers/src/gemini-cli/adapter.ts
+++ b/packages/providers/src/gemini-cli/adapter.ts
@@ -250,8 +250,10 @@ function statusFromTail(
  * than when the awaiting call reaches the tail, and a stop keeps a settled
  * turn waiting past the freshness decay. The notification keeps waiting past
  * freshness too — a standing event is proof the hold still stands, because
- * any record at or past it would have discarded it, and a crash mid-hold
- * leaves that proof standing only until the spool prune retires it.
+ * any record at or past it would have discarded it — but only within the
+ * hold horizon: a crash mid-hold discards nothing, so past it the shared
+ * refinement stands the event down and the recording's own decay answers
+ * alone.
  */
 const GEMINI_HOOK_STATUS_REFINEMENT = {
   definitive: [{ event: GEMINI_HOOK_EVENT.SESSION_END, fresh: SESSION_STATUS.COMPLETE }],

--- a/packages/providers/src/opencode/adapter.test.ts
+++ b/packages/providers/src/opencode/adapter.test.ts
@@ -6,6 +6,7 @@ import { DatabaseSync } from "node:sqlite";
 import test, { type TestContext } from "node:test";
 import { SESSION_COMPLETION_CAUSE, SESSION_STATUS } from "@sidecar/session";
 import type { ParsedJsonObject } from "@sidecar/wire/testing";
+import { HOOK_NOTIFICATION_HOLD_HORIZON_MS } from "../shared/local-session-adapter.js";
 import { OPENCODE_PROVIDER, OpenCodeSessionAdapter } from "./adapter.js";
 
 const TEST_TIME = Date.parse("2026-08-13T21:30:00.000Z");
@@ -911,6 +912,26 @@ test("a permission hold that outlives the freshness window is still an ask", asy
 
   assert.equal(observation?.status, SESSION_STATUS.WAITING);
   assert.equal(observation?.holdingForDeveloper, true);
+});
+
+test("a permission hold past the hold horizon stands down on its own", async (t) => {
+  const dataDirectory = await temporaryDataDirectory(t);
+  const spoolDirectory = path.join(dataDirectory, "events");
+  await writeWorkingSession(dataDirectory, "ses_dead_hold");
+  await writeHookEvent(spoolDirectory, "ses_dead_hold", "notification", TEST_TIME);
+
+  // A process killed mid-hold writes neither the answer nor a closing hook.
+  // Past the horizon the standing event refines nothing, and the open turn
+  // decays to unknown exactly as it would with no event at all.
+  const adapter = new OpenCodeSessionAdapter({
+    dataDirectory,
+    now: () => TEST_TIME + HOOK_NOTIFICATION_HOLD_HORIZON_MS + 60_000,
+    hookEventsDirectory: () => spoolDirectory,
+  });
+  const [observation] = await adapter.observe();
+
+  assert.equal(observation?.status, SESSION_STATUS.UNKNOWN);
+  assert.equal(observation?.holdingForDeveloper, undefined);
 });
 
 test("a session-end event reads as complete with the closure as its cause", async (t) => {

--- a/packages/providers/src/opencode/adapter.ts
+++ b/packages/providers/src/opencode/adapter.ts
@@ -356,10 +356,11 @@ const OPENCODE_HOOK_STATUS_REFINEMENT = {
   fresh: [
     { event: OPENCODE_HOOK_EVENT.PROMPT, fresh: SESSION_STATUS.WORKING },
     { event: OPENCODE_HOOK_EVENT.STOP, fresh: SESSION_STATUS.WAITING },
-    // The notification keeps waiting past freshness: a standing event is
+    // The notification keeps waiting past freshness — a standing event is
     // proof the hold still stands, because any record at or past it would
-    // have discarded it, and a crash mid-hold leaves that proof standing
-    // only until the spool prune retires it.
+    // have discarded it — but only within the hold horizon: a crash mid-hold
+    // discards nothing, so past it the shared refinement stands the event
+    // down and the database's own decay answers alone.
     {
       event: OPENCODE_HOOK_EVENT.NOTIFICATION,
       fresh: SESSION_STATUS.WAITING,

--- a/packages/providers/src/registrations.test.ts
+++ b/packages/providers/src/registrations.test.ts
@@ -64,6 +64,19 @@ test("declares credentials and observation hooks beside their adapters", () => {
       PROVIDER_ID.OPENCODE,
     ].sort(),
   );
+  // The recurring spool prune travels with the registration: a provider whose
+  // hook writes a spool is exactly the one whose spool must not wait for a
+  // relaunch to shed its dead sessions' files.
+  assert.deepEqual(
+    Object.entries(registrations)
+      .filter(([, registration]) => "pruneObservationHookSpool" in registration)
+      .map(([providerId]) => providerId)
+      .sort(),
+    Object.entries(registrations)
+      .filter(([, registration]) => "registerObservationHook" in registration)
+      .map(([providerId]) => providerId)
+      .sort(),
+  );
 });
 
 test("every registration exposes the one total adapter interface", () => {

--- a/packages/providers/src/registrations.ts
+++ b/packages/providers/src/registrations.ts
@@ -40,6 +40,13 @@ export interface ProviderRegistration {
   adapter: SessionProviderAdapter;
   credential?: CredentialProvider;
   registerObservationHook?: () => Promise<void>;
+  /**
+   * Drops this provider's spool files old enough to refine nothing. The
+   * registration above already prunes once at launch; this one is for the
+   * observation cadence, because an app left running across days would
+   * otherwise carry every dead session's file until its next relaunch.
+   */
+  pruneObservationHookSpool?: () => Promise<void>;
 }
 
 export interface ProviderRegistrationOptions {
@@ -82,19 +89,24 @@ function adapterDiagnostics(
 }
 
 /**
- * One provider's launch convergence: install the arrangement, then prune the
- * spool it writes into, so the spool's size tracks the sessions actually
- * alive rather than every session ever observed.
+ * One provider's hook convergence: install the arrangement at launch, and
+ * prune the spool it writes into — at launch and again whenever the caller's
+ * cadence asks — so the spool's size tracks the sessions actually alive
+ * rather than every session ever observed.
  */
 function observationHookRegistration(
   installHooks: (installation: ObservationHookInstallation) => Promise<void>,
   installation: () => ObservationHookInstallation,
   now: () => number,
-): () => Promise<void> {
-  return async () => {
-    const resolved = installation();
-    await installHooks(resolved);
-    await pruneObservationHookSpool(resolved.spoolDirectory, HOOK_SPOOL_MAXIMUM_AGE_MS, now());
+): Pick<ProviderRegistration, "registerObservationHook" | "pruneObservationHookSpool"> {
+  const prune = () =>
+    pruneObservationHookSpool(installation().spoolDirectory, HOOK_SPOOL_MAXIMUM_AGE_MS, now());
+  return {
+    registerObservationHook: async () => {
+      await installHooks(installation());
+      await prune();
+    },
+    pruneObservationHookSpool: prune,
   };
 }
 
@@ -151,19 +163,11 @@ export function providerRegistrations(options: ProviderRegistrationOptions) {
     },
     [PROVIDER_ID.CLAUDE_CODE]: {
       adapter: locals.claudeCode,
-      registerObservationHook: observationHookRegistration(
-        installClaudeCodeObservationHooks,
-        claudeInstallation,
-        now,
-      ),
+      ...observationHookRegistration(installClaudeCodeObservationHooks, claudeInstallation, now),
     },
     [PROVIDER_ID.CODEX]: {
       adapter: codex,
-      registerObservationHook: observationHookRegistration(
-        installCodexObservationHooks,
-        codexInstallation,
-        now,
-      ),
+      ...observationHookRegistration(installCodexObservationHooks, codexInstallation, now),
     },
     [PROVIDER_ID.CONDUCTOR]: {
       adapter: new ConductorSessionAdapter({
@@ -182,28 +186,16 @@ export function providerRegistrations(options: ProviderRegistrationOptions) {
     [PROVIDER_ID.CURSOR]: {
       adapter: cursor,
       credential: CREDENTIAL_PROVIDERS[CREDENTIAL_PROVIDER_ID.CURSOR],
-      registerObservationHook: observationHookRegistration(
-        installCursorObservationHooks,
-        cursorInstallation,
-        now,
-      ),
+      ...observationHookRegistration(installCursorObservationHooks, cursorInstallation, now),
     },
     [PROVIDER_ID.DEVIN]: {
       adapter: devin,
       credential: CREDENTIAL_PROVIDERS[CREDENTIAL_PROVIDER_ID.DEVIN],
-      registerObservationHook: observationHookRegistration(
-        installDevinObservationHooks,
-        devinInstallation,
-        now,
-      ),
+      ...observationHookRegistration(installDevinObservationHooks, devinInstallation, now),
     },
     [PROVIDER_ID.GEMINI_CLI]: {
       adapter: locals.geminiCli,
-      registerObservationHook: observationHookRegistration(
-        installGeminiObservationHooks,
-        geminiInstallation,
-        now,
-      ),
+      ...observationHookRegistration(installGeminiObservationHooks, geminiInstallation, now),
     },
     // Grok Build's own stores already say whose move it is — the database's
     // newest message, or the 1.0.x lifecycle log with its permission prompts
@@ -220,12 +212,8 @@ export function providerRegistrations(options: ProviderRegistrationOptions) {
       adapter: locals.openCode,
       // The registration is a managed plugin file in OpenCode's own plugin
       // directory rather than a merged entry, but it converges and prunes on
-      // the same launch cadence as every other provider's.
-      registerObservationHook: observationHookRegistration(
-        installOpenCodeObservationPlugin,
-        opencodeInstallation,
-        now,
-      ),
+      // the same cadences as every other provider's.
+      ...observationHookRegistration(installOpenCodeObservationPlugin, opencodeInstallation, now),
     },
     // The browser's own store already says whose move it is — a turn's row
     // records when it ended and what ended it — so its adapter needs no

--- a/packages/providers/src/shared/hook-merge.ts
+++ b/packages/providers/src/shared/hook-merge.ts
@@ -581,7 +581,9 @@ export async function readObservationHookEvent<Event extends string>(
 /**
  * Drops spool files old enough that the adapter would no longer read them:
  * an event beyond the observation window refines nothing, and the sessions
- * behind such files are mostly gone for good. Run where install is run, so
+ * behind such files are mostly gone for good. Run where install is run, and
+ * again on the caller's observation cadence — an app left running across
+ * days must not hold every dead session's file until its next relaunch — so
  * the spool's size tracks the sessions actually alive rather than every
  * session ever observed.
  */

--- a/packages/providers/src/shared/local-session-adapter.test.ts
+++ b/packages/providers/src/shared/local-session-adapter.test.ts
@@ -1,0 +1,179 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { OBSERVATION_WINDOW, SESSION_STATUS, type SessionStatus } from "@sidecar/session";
+import { HOOK_SPOOL_MAXIMUM_AGE_MS } from "./hook-merge.js";
+import {
+  HOOK_EVENT_TOLERANCE_MS,
+  HOOK_NOTIFICATION_HOLD_HORIZON_MS,
+  type HookStatusRefinement,
+  hookRefinedStatus,
+  localSessionStatus,
+} from "./local-session-adapter.js";
+
+const TEST_TIME = Date.parse("2026-08-20T12:00:00.000Z");
+const FRESHNESS_MS = OBSERVATION_WINDOW.ACTIVE_SESSION_FRESHNESS_MS;
+
+const TEST_HOOK_EVENT = {
+  PROMPT: "prompt",
+  STOP: "stop",
+  NOTIFICATION: "notification",
+  SESSION_END: "session-end",
+  STOP_FAILURE: "stop-failure",
+} as const;
+
+type TestHookEvent = (typeof TEST_HOOK_EVENT)[keyof typeof TEST_HOOK_EVENT];
+
+// The same shape every hooked adapter declares, so what these tests pin is
+// the shared merge those adapters stand on rather than any one provider's.
+const TEST_REFINEMENT = {
+  definitive: [
+    { event: TEST_HOOK_EVENT.STOP_FAILURE, fresh: SESSION_STATUS.ERROR },
+    { event: TEST_HOOK_EVENT.SESSION_END, fresh: SESSION_STATUS.COMPLETE },
+  ],
+  fresh: [
+    { event: TEST_HOOK_EVENT.PROMPT, fresh: SESSION_STATUS.WORKING },
+    { event: TEST_HOOK_EVENT.STOP, fresh: SESSION_STATUS.WAITING },
+    {
+      event: TEST_HOOK_EVENT.NOTIFICATION,
+      fresh: SESSION_STATUS.WAITING,
+      stale: SESSION_STATUS.WAITING,
+    },
+  ],
+  notificationEvent: TEST_HOOK_EVENT.NOTIFICATION,
+  sessionEndEvent: TEST_HOOK_EVENT.SESSION_END,
+} as const satisfies HookStatusRefinement<TestHookEvent>;
+
+function refined(options: {
+  hookEvent?: { event: TestHookEvent; atMs: number };
+  providerAtMs: number;
+  providerStatus?: SessionStatus;
+}) {
+  return hookRefinedStatus({
+    refinement: TEST_REFINEMENT,
+    hookEvent: options.hookEvent,
+    providerAtMs: options.providerAtMs,
+    statusAt: (observedAt) =>
+      localSessionStatus(
+        options.providerStatus ?? SESSION_STATUS.WORKING,
+        observedAt,
+        TEST_TIME,
+        FRESHNESS_MS,
+      ),
+    now: TEST_TIME,
+    activeSessionFreshnessMs: FRESHNESS_MS,
+  });
+}
+
+test("an event behind the provider's clock by more than the tolerance refines nothing", () => {
+  const providerAtMs = TEST_TIME - 60_000;
+  const result = refined({
+    hookEvent: {
+      event: TEST_HOOK_EVENT.STOP,
+      atMs: providerAtMs - HOOK_EVENT_TOLERANCE_MS - 1,
+    },
+    providerAtMs,
+  });
+
+  assert.equal(result.status, SESSION_STATUS.WORKING);
+  assert.equal(result.observedAt, providerAtMs);
+});
+
+test("a standing event refines the status and dates the session", () => {
+  const result = refined({
+    hookEvent: { event: TEST_HOOK_EVENT.STOP, atMs: TEST_TIME - 1_000 },
+    providerAtMs: TEST_TIME - 60_000,
+  });
+
+  assert.equal(result.status, SESSION_STATUS.WAITING);
+  assert.equal(result.observedAt, TEST_TIME - 1_000);
+  assert.equal(result.holdingForDeveloper, false);
+});
+
+test("a stop event past freshness decays the way provider state does", () => {
+  const result = refined({
+    hookEvent: { event: TEST_HOOK_EVENT.STOP, atMs: TEST_TIME - 20 * 60_000 },
+    providerAtMs: TEST_TIME - 30 * 60_000,
+  });
+
+  assert.equal(result.status, SESSION_STATUS.UNKNOWN);
+});
+
+test("a notification gets no tolerance against the provider's clock", () => {
+  // The approval was granted and the call ran: provider state past the event
+  // is itself the news that the hold ended.
+  const result = refined({
+    hookEvent: { event: TEST_HOOK_EVENT.NOTIFICATION, atMs: TEST_TIME - 3_000 },
+    providerAtMs: TEST_TIME - 1_000,
+  });
+
+  assert.equal(result.status, SESSION_STATUS.WORKING);
+  assert.equal(result.holdingForDeveloper, false);
+});
+
+test("a notification hold outlives the freshness window", () => {
+  const result = refined({
+    hookEvent: { event: TEST_HOOK_EVENT.NOTIFICATION, atMs: TEST_TIME - 20 * 60_000 },
+    providerAtMs: TEST_TIME - 30 * 60_000,
+  });
+
+  assert.equal(result.status, SESSION_STATUS.WAITING);
+  assert.equal(result.holdingForDeveloper, true);
+});
+
+test("a notification hold at the horizon's edge is still an ask", () => {
+  const result = refined({
+    hookEvent: {
+      event: TEST_HOOK_EVENT.NOTIFICATION,
+      atMs: TEST_TIME - HOOK_NOTIFICATION_HOLD_HORIZON_MS,
+    },
+    providerAtMs: TEST_TIME - HOOK_NOTIFICATION_HOLD_HORIZON_MS - 60 * 60_000,
+  });
+
+  assert.equal(result.status, SESSION_STATUS.WAITING);
+  assert.equal(result.holdingForDeveloper, true);
+});
+
+test("a notification hold past the horizon stands down on its own", () => {
+  const providerAtMs = TEST_TIME - HOOK_NOTIFICATION_HOLD_HORIZON_MS - 60 * 60_000;
+  const result = refined({
+    hookEvent: {
+      event: TEST_HOOK_EVENT.NOTIFICATION,
+      atMs: TEST_TIME - HOOK_NOTIFICATION_HOLD_HORIZON_MS - 60_000,
+    },
+    providerAtMs,
+  });
+
+  assert.equal(result.status, SESSION_STATUS.UNKNOWN);
+  assert.equal(result.holdingForDeveloper, false);
+  // An expired hold refines nothing, dating included: the provider's own
+  // clock answers alone, exactly as it would with no event at all.
+  assert.equal(result.observedAt, providerAtMs);
+});
+
+test("a session-end event reports the closure as the completion's cause", () => {
+  const result = refined({
+    hookEvent: { event: TEST_HOOK_EVENT.SESSION_END, atMs: TEST_TIME - 1_000 },
+    providerAtMs: TEST_TIME - 2_000,
+  });
+
+  assert.equal(result.status, SESSION_STATUS.COMPLETE);
+  assert.equal(result.sessionClosed, true);
+});
+
+test("a provider already settled on complete is never softened", () => {
+  const result = refined({
+    hookEvent: { event: TEST_HOOK_EVENT.STOP, atMs: TEST_TIME - 1_000 },
+    providerAtMs: TEST_TIME - 2_000,
+    providerStatus: SESSION_STATUS.COMPLETE,
+  });
+
+  assert.equal(result.status, SESSION_STATUS.COMPLETE);
+});
+
+test("the hold horizon sits between the freshness decay and the spool's age bound", () => {
+  // Shorter than freshness and the stale mapping would mean nothing; longer
+  // than the spool's maximum age and the prune would drop the file before
+  // this horizon ever decided anything.
+  assert.ok(HOOK_NOTIFICATION_HOLD_HORIZON_MS > OBSERVATION_WINDOW.ACTIVE_SESSION_FRESHNESS_MS);
+  assert.ok(HOOK_NOTIFICATION_HOLD_HORIZON_MS < HOOK_SPOOL_MAXIMUM_AGE_MS);
+});

--- a/packages/providers/src/shared/local-session-adapter.ts
+++ b/packages/providers/src/shared/local-session-adapter.ts
@@ -79,6 +79,20 @@ function refineStatusWithHookEvent<Event extends string>(
  */
 export const HOOK_EVENT_TOLERANCE_MS = 5_000;
 
+/**
+ * How long a standing notification hold is believed. A hold is a live fact
+ * rather than an inference — answering it writes provider state at or past
+ * the event, which discards it — so it rightly outlives the freshness decay.
+ * But the proof assumes a process still holding the dialog, and its one
+ * failure mode is silent: a process killed mid-hold, a closed terminal tab, a
+ * crash, writes neither the answer nor a closing hook, and leaves the event
+ * standing for a dialog no longer on any screen. Four hours believes every
+ * hold a developer plausibly comes back to — a meeting, a long review, a
+ * lunch — and retires a dead one the same working day, instead of pinning
+ * "needs you" on a ghost until the day-scale spool prune drops the file.
+ */
+export const HOOK_NOTIFICATION_HOLD_HORIZON_MS = 4 * 60 * 60 * 1000;
+
 /** What the hook settled for one observation, beyond the status itself. */
 export interface HookRefinedStatus {
   status: SessionStatus;
@@ -106,7 +120,12 @@ export interface HookRefinedStatus {
  * own script writes the spool, so its date cannot suffer the bulk-touch
  * problem a provider's files can — and dates the session for the freshness
  * decay as well. A notification alone gets no tolerance: a granted
- * permission must not read as waiting for even one more pass.
+ * permission must not read as waiting for even one more pass. It is also the
+ * one event with a horizon of its own: its hold rightly outlives the
+ * freshness decay, because holding writes nothing and the standing event is
+ * the proof, but that proof holds only while a process is alive to show the
+ * dialog, so past {@link HOOK_NOTIFICATION_HOLD_HORIZON_MS} the event is
+ * ignored whole too and the provider's own state answers alone.
  */
 export function hookRefinedStatus<Event extends string>(options: {
   refinement: HookStatusRefinement<Event>;
@@ -120,11 +139,13 @@ export function hookRefinedStatus<Event extends string>(options: {
   activeSessionFreshnessMs: number;
 }): HookRefinedStatus {
   const { refinement, hookEvent, providerAtMs } = options;
-  const toleranceMs =
-    refinement.notificationEvent !== undefined && hookEvent?.event === refinement.notificationEvent
-      ? 0
-      : HOOK_EVENT_TOLERANCE_MS;
-  const eventStands = hookEvent !== undefined && hookEvent.atMs + toleranceMs >= providerAtMs;
+  const isNotification =
+    refinement.notificationEvent !== undefined && hookEvent?.event === refinement.notificationEvent;
+  const toleranceMs = isNotification ? 0 : HOOK_EVENT_TOLERANCE_MS;
+  const eventStands =
+    hookEvent !== undefined &&
+    hookEvent.atMs + toleranceMs >= providerAtMs &&
+    !(isNotification && options.now - hookEvent.atMs > HOOK_NOTIFICATION_HOLD_HORIZON_MS);
   const observedAt = eventStands ? Math.max(providerAtMs, hookEvent.atMs) : providerAtMs;
   let status = options.statusAt(observedAt);
   if (eventStands) {

--- a/packages/session/src/index.ts
+++ b/packages/session/src/index.ts
@@ -55,6 +55,7 @@ export {
   workspaceProjectSelectionId,
 } from "./providers.js";
 export {
+  ATTENTION_DECISION_FRESHNESS_MS,
   ATTENTION_DISPOSITION,
   type AttentionDecision,
   type AttentionDisposition,

--- a/packages/session/src/session-registry.test.ts
+++ b/packages/session/src/session-registry.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import {
+  ATTENTION_DECISION_FRESHNESS_MS,
   ATTENTION_DISPOSITION,
   InMemorySessionRegistry,
   maximumSessionRecapLength,
@@ -466,6 +467,29 @@ test("attention changes only for a standing session and one effective decision",
       decision,
     },
   ]);
+});
+
+test("an attention decision past its freshness expires on the clock alone", () => {
+  const registry = new InMemorySessionRegistry();
+  const identity = { providerId: codex.id, providerSessionId: "active" };
+  registry.upsert(codex, observation("active", 10));
+  registry.setAttention(identity, {
+    disposition: ATTENTION_DISPOSITION.SPEAK_AT_TURN_END,
+    decidedAt: 20,
+    summary: "A review decision is ready.",
+  });
+  const revision = registry.revision;
+
+  registry.expireAttention(20 + ATTENTION_DECISION_FRESHNESS_MS);
+  assert.equal(registry.revision, revision);
+  assert.equal(registry.snapshot().attention.length, 1);
+
+  registry.expireAttention(21 + ATTENTION_DECISION_FRESHNESS_MS);
+  assert.equal(registry.revision, revision + 1);
+  assert.deepEqual(registry.snapshot().attention, []);
+  // Only the decision ages out: the session it was about keeps its row and
+  // falls back to the urgency its own status earns.
+  assert.equal(registry.get(identity)?.providerSessionId, "active");
 });
 
 test("each registry listener receives an isolated snapshot", () => {

--- a/packages/session/src/session-registry.ts
+++ b/packages/session/src/session-registry.ts
@@ -1,5 +1,6 @@
 import type { SessionProviderAdapter } from "./providers.js";
 import {
+  ATTENTION_DECISION_FRESHNESS_MS,
   type AttentionDecision,
   normalizeAttention,
   normalizeSession,
@@ -343,6 +344,29 @@ export class InMemorySessionRegistry {
     this.#revision += 1;
     this.#notify();
     return copySession(existing);
+  }
+
+  /**
+   * Drops decisions past their freshness, returning each row to the urgency
+   * its status earns. The evaluator re-decides a session only when it moves
+   * again, so nothing replaces an expired decision here — it simply stops
+   * being reported. Time is the caller's to supply: the registry keeps no
+   * clock, and only the observation cadence can make expiry land on a
+   * session nothing else is changing.
+   */
+  expireAttention(now: number): void {
+    let expired = false;
+    for (const [providerId, decisions] of this.#attention) {
+      for (const [providerSessionId, decision] of decisions) {
+        if (now - decision.decidedAt <= ATTENTION_DECISION_FRESHNESS_MS) continue;
+        decisions.delete(providerSessionId);
+        expired = true;
+      }
+      if (decisions.size === 0) this.#attention.delete(providerId);
+    }
+    if (!expired) return;
+    this.#revision += 1;
+    this.#notify();
   }
 
   remove(identity: SessionIdentity): boolean {

--- a/packages/session/src/session.ts
+++ b/packages/session/src/session.ts
@@ -166,6 +166,17 @@ export interface AttentionDecision {
 /** A spoken sentence stays far shorter than a provider recap. */
 export const maximumAttentionSummaryLength = 180;
 
+/**
+ * How long a decision keeps standing for a session that has not moved since.
+ * The evaluator re-decides only on a session's next development, so without a
+ * bound a non-silent decision pins its row lit — under a summary growing ever
+ * staler — for as long as the session keeps its place on the roster. The
+ * bound is the roster's own freshness window: a decision judges one observed
+ * moment, and once that moment is older than what the roster itself still
+ * believes as live, the row falls back to the urgency its status earns.
+ */
+export const ATTENTION_DECISION_FRESHNESS_MS = OBSERVATION_WINDOW.ACTIVE_SESSION_FRESHNESS_MS;
+
 /** Validates an untrusted attention decision without importing evaluator behavior. */
 export function attentionDecisionFromWire(
   value: UnparsedWireValue,


### PR DESCRIPTION
## The feedback

> "I haven't figured out how to dismiss 'pending' chats (opening doesn't do it) — can't tell if it's a bug in how it detects whether a thread is running or if I'm holding this wrong."

You weren't holding it wrong. It was a detection-staleness bug: a "Needs you" row could stand on state that was no longer true, with no way for it to stop being drawn as true. Opening a row is (correctly) a pure hand-off to the operating system — the roster is a read-only projection of observed provider state — so no press could ever clear it. The fix is not a dismiss control (`CLAUDE.md` forbids inventing fallback controls, and an acknowledge would make the roster something other than a projection); the fix is that stale state now retires itself.

## What was pinned, and what now decays

**1. A permission hold whose process died was pinned forever.** The hooked providers (Claude Code, Codex, Gemini CLI, OpenCode, Devin) map a notification event as waiting even past the freshness decay, on the reasoning that a standing event is proof the dialog is still up — any provider record at or past it would have discarded it. That reasoning holds only while the agent process is alive; a SIGKILL, a closed terminal tab, or a crash writes neither the answer nor a closing hook, and the only exit was the 24-hour spool prune, which ran only at launch. `hookRefinedStatus` now gives the hold a horizon (`HOOK_NOTIFICATION_HOLD_HORIZON_MS`, 4 hours): within it a hold outlives freshness exactly as before — a 20-minute-old ask is still an ask, and the existing adapter tests pinning that stay green — and past it the event refines nothing, so the row decays the same way it would with no event at all. Four hours believes every hold a developer plausibly comes back to (a meeting, a long review, a lunch) and retires a dead one the same working day. One bounded rule in the shared merge, no per-adapter edits beyond the rationale comments.

**2. The spool prune ran only at launch convergence.** If Luke stayed running for a week, a dead entry stayed for a week. Each hooked registration now also exposes the prune, and the desktop runs it on an hourly observation loop beside the others — same 24-hour bound, same per-provider failure absorption, gated off in fixture runs like every observation loop.

**3. A stale attention decision never decayed.** A non-silent evaluator decision kept a row lit indefinitely under a possibly hours-old summary, because decisions were dropped only when their session left the roster and the evaluator re-decides only when a session moves. The registry now expires a decision by its decision time (`ATTENTION_DECISION_FRESHNESS_MS`, the roster's own 15-minute freshness window), driven from the session observation pass, so a flagged row that goes quiet falls back to the urgency its status earns.

Every change tightens what is drawn from observed state. Nothing touches a write path, a provider file, or the spool's content beyond the established prune.

## Tests

- New `packages/providers/src/shared/local-session-adapter.test.ts` covers `hookRefinedStatus` directly for the first time: tolerance, zero-tolerance notifications, freshness decay, the hold outliving freshness, the horizon edge, past-horizon stand-down, definitive events, and the invariant that the horizon sits between the freshness window and the spool's maximum age.
- Each of the five hooked adapters gains "a permission hold past the hold horizon stands down on its own"; the existing "still an ask" tests keep passing unchanged.
- `session-registry.test.ts` covers `expireAttention` (no-op inside the window, expiry with a revision bump past it, the session keeping its row).
- `registrations.test.ts` asserts the recurring prune travels with every hook registration.

## Verification

- `./scripts/bootstrap.sh` then `./scripts/check.sh`: **pass, exit 0** — all package suites green (providers 726/726, session 105/105, desktop 787/787, web 191/191), lint and builds clean.
- `./scripts/verify.sh` was **not run**: this change was made in a Linux cloud workspace and that script is macOS-only. The change draws no new UI — it only changes when existing row states decay — but the macOS validation still needs a run on a Mac before release.

Note: a parallel workspace is changing finished-turn row urgency (`sessionNeedsAttention` / the attention prompt); this PR deliberately stays on the decay/prune/expiry side so the two don't conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/d989d836-097f-42a2-afa5-ab76a1d502f9)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/33028190435/artifacts/9629250265) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/33028190435)

- Commit: `0c7c25d1d8e9c903b0bfcb62d9abdb3cbe539c84`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
