### PR TITLE
fix(providers): let a slow cloud write outlive the shared request deadline

### DIFF
--- a/packages/providers/src/conductor/adapter.test.ts
+++ b/packages/providers/src/conductor/adapter.test.ts
@@ -1,9 +1,9 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { SESSION_STATUS } from "@sidecar/session";
+import { SESSION_STATUS, type SessionControl } from "@sidecar/session";
 import type { JsonObject, JsonValue } from "@sidecar/wire/testing";
 import { HTTP_STATUS, jsonResponse, recordingFetch } from "@sidecar/wire/testing";
-import type { CloudFetch } from "../shared/cloud-session-adapter.js";
+import { CLOUD_ADAPTER_DEFAULTS, type CloudFetch } from "../shared/cloud-session-adapter.js";
 import { describeCloudAdapterContract } from "../testing/cloud-adapter-contract.js";
 import { CONDUCTOR_PROVIDER, ConductorSessionAdapter } from "./adapter.js";
 
@@ -1888,6 +1888,31 @@ test("archives the workspace the user saw through Conductor's archive endpoint, 
   // Conductor documents no body for an archive.
   assert.equal(write?.contentType, undefined);
   assert.equal(write?.body, undefined);
+});
+
+test("asks the slow deadline for an archive, whose answer waits on the workspace standing down", () => {
+  // The route is protected — nothing outside the adapter builds one — so the
+  // probe is a subclass reading its own seam. Archiving answers only once the
+  // workspace is filed away, past the shared request bound, and a deadline
+  // shorter than the act reports an archive that landed as one that may not
+  // have.
+  class ControlRouteProbe extends ConductorSessionAdapter {
+    deadlineFor(control: SessionControl): number | undefined {
+      return this.controlRoute("session-idle", control)?.timeoutMs;
+    }
+  }
+  const probe = new ControlRouteProbe({
+    readApiKey: async () => TEST_API_KEY,
+    baseUrl: TEST_BASE_URL,
+    fetch: async () => jsonResponse({}),
+  });
+
+  assert.equal(
+    probe.deadlineFor({ id: "archive-workspace", label: "Archive", target: "workspace-active" }),
+    CLOUD_ADAPTER_DEFAULTS.SLOW_REQUEST_TIMEOUT_MS,
+  );
+  // The turn's stop answers at once, so it rides the shared bound.
+  assert.equal(probe.deadlineFor({ id: "cancel-turn", label: "Stop this turn" }), undefined);
 });
 
 test("refuses to archive a workspace no row advertised, before any request exists", async () => {

--- a/packages/providers/src/conductor/adapter.ts
+++ b/packages/providers/src/conductor/adapter.ts
@@ -22,6 +22,7 @@ import {
 } from "@sidecar/session";
 import type { WireRecord } from "@sidecar/wire";
 import {
+  CLOUD_ADAPTER_DEFAULTS,
   type CloudAdapterOptions,
   type CloudRequest,
   CloudSessionAdapter,
@@ -883,6 +884,12 @@ export class ConductorSessionAdapter extends CloudSessionAdapter {
           CONDUCTOR_ROUTE_SEGMENT.ARCHIVE,
         ],
         // Conductor documents no body for an archive, so none is sent.
+        // The answer comes back only once the workspace is actually filed
+        // away — measured near eleven seconds against the live API, past the
+        // shared request bound — so the write rides the slow deadline. On a
+        // shorter one the fetch gives up mid-act and an archive that landed
+        // is reported as one that may not have.
+        timeoutMs: CLOUD_ADAPTER_DEFAULTS.SLOW_REQUEST_TIMEOUT_MS,
       };
     }
     return undefined;

--- a/packages/providers/src/shared/cloud-session-adapter.test.ts
+++ b/packages/providers/src/shared/cloud-session-adapter.test.ts
@@ -13,12 +13,14 @@ import { isWireString } from "@sidecar/wire";
 import { HTTP_STATUS, jsonResponse, recordingFetch } from "@sidecar/wire/testing";
 import { ADAPTER_DIAGNOSTIC_KIND, type AdapterDiagnosticCallback } from "./adapter-diagnostics.js";
 import {
+  CLOUD_ADAPTER_DEFAULTS,
   type CloudAdapterOptions,
   type CloudFetch,
   type CloudRequest,
   CloudSessionAdapter,
   isDefined,
   knownValue,
+  requestDeadlineMs,
 } from "./cloud-session-adapter.js";
 
 const TEST_TIME = Date.parse("2026-08-12T02:45:00.000Z");
@@ -46,6 +48,11 @@ function observation(
 
 const STUB_APPROVE_CONTROL = { id: "approve", label: "Approve" } as const;
 
+/** An act whose provider answers only once it is done, on its route's own deadline. */
+const STUB_SLOW_ACT_CONTROL = { id: "file-away", label: "File away" } as const;
+/** Short enough for a test to overrun; what matters is that it is the route's own. */
+const STUB_SLOW_ACT_DEADLINE_MS = 25;
+
 /** Stands in for a real provider so the shared half can be tested on its own. */
 class StubCloudAdapter extends CloudSessionAdapter {
   passes = 0;
@@ -70,6 +77,12 @@ class StubCloudAdapter extends CloudSessionAdapter {
   }
 
   protected override controlRoute(providerSessionId: string, control: SessionControl) {
+    if (control.id === STUB_SLOW_ACT_CONTROL.id) {
+      return {
+        segments: ["v0", "sessions", providerSessionId, "file-away"],
+        timeoutMs: STUB_SLOW_ACT_DEADLINE_MS,
+      };
+    }
     if (control.id !== STUB_APPROVE_CONTROL.id) return undefined;
     return { segments: ["v0", "sessions", providerSessionId, "approve"] };
   }
@@ -604,6 +617,67 @@ test("reports an unanswered send as indeterminate and makes the next refresh ask
   // instead of serving the cache for the rest of the interval.
   await adapter.observe();
   assert.equal(adapter.passes, 2);
+});
+
+test("a write answered with an unnamed status makes the next refresh ask", async () => {
+  let status: number = HTTP_STATUS.OK;
+  const stub = stubFetch(() => status);
+  const adapter = adapterFor(stub.fetch, { minimumRefreshIntervalMs: 60_000 });
+  adapter.collected = [observation("session-one", { canReceiveMessage: true })];
+  await adapter.observe();
+
+  status = HTTP_STATUS.SERVER_ERROR;
+  const result = await adapter.sendMessage({ providerSessionId: "session-one", text: "go on" });
+
+  assert.equal(result.status, "rejected");
+  assert.match(result.status === "rejected" ? result.reason : "", /may not have landed/);
+  // A gateway that gave up may stand in front of a write that finished, so
+  // the cache must not keep advertising what the provider may have taken.
+  await adapter.observe();
+  assert.equal(adapter.passes, 2);
+});
+
+test("a write runs on the deadline its own route asked for", async () => {
+  const { fetch } = recordingFetch((request) => {
+    if (request.method !== "POST") return jsonResponse({});
+    // An act still in progress at the deadline: the response arrives only as
+    // the refusal the route's own signal raises.
+    return new Promise((_resolve, reject) => {
+      request.init.signal?.addEventListener("abort", () => reject(new Error("deadline")));
+    });
+  });
+  const adapter = adapterFor(fetch, { minimumRefreshIntervalMs: 60_000 });
+  adapter.collected = [observation("session-slow", { controls: [STUB_SLOW_ACT_CONTROL] })];
+  await adapter.observe();
+
+  const startedAt = performance.now();
+  const result = await adapter.executeControl({
+    providerSessionId: "session-slow",
+    control: STUB_SLOW_ACT_CONTROL,
+  });
+
+  assert.equal(result.status, "rejected");
+  assert.match(result.status === "rejected" ? result.reason : "", /may not have landed/);
+  // Refused by the route's own short deadline, not the shared bound: waiting
+  // out the shared bound here would mean the route's ask never reached the
+  // request.
+  assert.ok(performance.now() - startedAt < CLOUD_ADAPTER_DEFAULTS.REQUEST_TIMEOUT_MS / 2);
+  // The act may have finished behind the lost answer, so the next refresh
+  // asks the provider instead of serving the cache.
+  await adapter.observe();
+  assert.equal(adapter.passes, 2);
+});
+
+test("no route can widen a request past the slow bound", () => {
+  assert.equal(requestDeadlineMs(undefined), CLOUD_ADAPTER_DEFAULTS.REQUEST_TIMEOUT_MS);
+  assert.equal(
+    requestDeadlineMs(CLOUD_ADAPTER_DEFAULTS.SLOW_REQUEST_TIMEOUT_MS),
+    CLOUD_ADAPTER_DEFAULTS.SLOW_REQUEST_TIMEOUT_MS,
+  );
+  assert.equal(
+    requestDeadlineMs(Number.MAX_SAFE_INTEGER),
+    CLOUD_ADAPTER_DEFAULTS.SLOW_REQUEST_TIMEOUT_MS,
+  );
 });
 
 test("runs an advertised control through its documented route, sending no body", async () => {

--- a/packages/providers/src/shared/cloud-session-adapter.ts
+++ b/packages/providers/src/shared/cloud-session-adapter.ts
@@ -187,6 +187,27 @@ export interface CloudWriteRoute {
   action?: string;
   /** Left off entirely for an endpoint that documents an empty request. */
   body?: Readonly<WireRecord>;
+  /**
+   * For the rare write the provider answers only once the act itself is done
+   * — Conductor's archive stands the whole workspace down before it says so,
+   * well past the shared request bound. A deadline shorter than the act turns
+   * a write that landed into "may not have landed", so such a route asks for
+   * the slow bound, the same ceiling a slow read gets and the widest this one
+   * can reach.
+   */
+  timeoutMs?: number;
+}
+
+/**
+ * A request's deadline never widens past the slow bound: the option exists for
+ * a read or write the provider is known to answer slowly, not for one that
+ * never ends.
+ */
+export function requestDeadlineMs(requested: number | undefined): number {
+  return Math.min(
+    positiveInteger(requested, CLOUD_ADAPTER_DEFAULTS.REQUEST_TIMEOUT_MS),
+    CLOUD_ADAPTER_DEFAULTS.SLOW_REQUEST_TIMEOUT_MS,
+  );
 }
 
 export function isDefined<Value>(value: Value | undefined): value is Value {
@@ -965,7 +986,7 @@ export abstract class CloudSessionAdapter extends SessionProviderAdapterBase {
           ...(route.body === undefined ? undefined : { "Content-Type": "application/json" }),
         },
         ...(route.body === undefined ? undefined : { body: JSON.stringify(route.body) }),
-        signal: AbortSignal.timeout(CLOUD_ADAPTER_DEFAULTS.REQUEST_TIMEOUT_MS),
+        signal: AbortSignal.timeout(requestDeadlineMs(route.timeoutMs)),
       });
     } catch {
       // A thrown fetch cannot say which side of the wire failed: a connection
@@ -1021,6 +1042,12 @@ export abstract class CloudSessionAdapter extends SessionProviderAdapterBase {
         },
       };
     }
+    // Any other status is an answer that says nothing certain about the act —
+    // a gateway that gave up may stand in front of a write that finished — so
+    // this hedges the way a thrown fetch does, and the refresh that follows
+    // must actually ask rather than keep advertising what the provider may
+    // have already taken.
+    this.#lastAttemptAt = Number.NEGATIVE_INFINITY;
     return {
       outcome: {
         status: ACT_RESULT_STATUS.REJECTED,
@@ -1036,12 +1063,7 @@ export abstract class CloudSessionAdapter extends SessionProviderAdapterBase {
     options: Readonly<{ timeoutMs?: number; document?: string }> = {},
   ): Promise<WireRecord> {
     const name = this.provider.displayName;
-    // A widened deadline never widens past the slow bound: the option exists
-    // for a read the provider documents as slow, not for one that never ends.
-    const timeoutMs = Math.min(
-      positiveInteger(options.timeoutMs, CLOUD_ADAPTER_DEFAULTS.REQUEST_TIMEOUT_MS),
-      CLOUD_ADAPTER_DEFAULTS.SLOW_REQUEST_TIMEOUT_MS,
-    );
+    const timeoutMs = requestDeadlineMs(options.timeoutMs);
     // A read document rides as a POST because that is how its endpoint is
     // documented, not because it writes: the body carries the document and
     // nothing else, so the request can still express nothing but a read.


### PR DESCRIPTION
## What happened

Luke archived a Conductor cloud workspace at the developer's ask, then told them it hadn't gone through — while the workspace was in fact archived.

Reproduced against the live API: `POST /v0/workspaces/{id}/archive` answers only once the workspace is actually filed away, and a probe measured **10.8 s** to its HTTP 200. Every cloud write ran on the shared **8 s** deadline (`CLOUD_ADAPTER_DEFAULTS.REQUEST_TIMEOUT_MS`), so the fetch aborted mid-act, `#postWriteDetailed` answered `rejected: "Conductor did not answer, so the request may not have landed."`, and the voice reply flattened that hedge into "it didn't go through" — while Conductor's server finished the archive anyway.

## The fix

- `CloudWriteRoute` may now name its own deadline for the rare write the provider answers only once the act itself is done. It is clamped to the existing slow bound (45 s) through a shared `requestDeadlineMs`, which the read path's slow option now also rides.
- Conductor's archive route asks for the slow deadline, with the measurement in its rationale. The cancel and the other writes keep the shared bound.
- A write answered with an unnamed status (a 5xx gateway giving up in front of an act that may have finished) now forces the next refresh to actually ask, the way a thrown fetch already did, so a landed archive is reconciled against the provider instead of the cache still advertising the row.

## Verification

- `./scripts/check.sh` passes (portable-only change; no UI or macOS surface touched, so no visual evidence applies).
- New tests: the write deadline is the route's own (signal-observed), no route can widen past the slow bound, an ambiguous write answer forces the next refresh to ask, and Conductor's archive route asks the slow deadline while the stop keeps the shared one. Providers suite: 718 pass, 0 fail.
- Live probe (throwaway workspace, created and archived for this investigation): archive answered HTTP 200 in 10.8 s and is idempotent (a repeat answers 200 in 0.1 s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/d01d50a2-1901-4265-9edb-b1ba2f79f40e)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/33100128097/artifacts/9658168146) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/33100128097)

- Commit: `03bb90190e1b6ec038188ee41e189d30d17b5184`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
