### PR TITLE
feat(desktop): add a setting drawing a talk button in the notch strip

### DIFF
--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -2074,6 +2074,7 @@ export function App(): React.JSX.Element {
     voiceStatus,
     talkOpening,
     voiceHotkey,
+    pressTalk,
     handleVoiceActivity,
     requestMicrophoneAccess,
     startMicrophone,
@@ -3420,6 +3421,9 @@ export function App(): React.JSX.Element {
         accountGated={accountGated}
         onSelectFilter={handleSelectWingFilter}
         activeFilters={sessionView.filters}
+        {...((settings ?? bootstrapSettings)?.showTalkButton === true
+          ? { onTalkPress: pressTalk }
+          : undefined)}
       />
 
       {/* The one signed-out Luke. Like the caption, he is a single element in

--- a/apps/desktop/src/renderer/luke-guide.test.ts
+++ b/apps/desktop/src/renderer/luke-guide.test.ts
@@ -882,6 +882,7 @@ test("every adjustable setting is carried to the bridge call its row uses", asyn
     "shareUsageData:true",
     "showInDock:true",
     "showOnAllDisplays:true",
+    "showTalkButton:true",
     "voice:alloy",
     "voiceCaptions:true",
     // The first choice offered is "slow", which is the 0.75 multiple.

--- a/apps/desktop/src/renderer/notch-wings.test.ts
+++ b/apps/desktop/src/renderer/notch-wings.test.ts
@@ -54,6 +54,22 @@ test("a wing too narrow for the meter's own room still shows one mark", () => {
   assert.equal(wingMarkCapacity(0, true), 1);
 });
 
+test("the talk button reserves the face-sized room it stands in", () => {
+  // The same 26 the meter reserves: the button wraps a face-sized glyph.
+  assert.equal(wingMarkCapacity(peekSideWidth(210), false, true), 2);
+  assert.equal(wingMarkCapacity(panelSideWidth(210), false, true), 6);
+  // Beside a meter also standing, both reservations are spent.
+  assert.equal(wingMarkCapacity(peekSideWidth(210), true, true), 1);
+  assert.equal(wingMarkCapacity(panelSideWidth(210), true, true), 5);
+});
+
+test("the talk button's reservation never grows the capacity, only shrinks it", () => {
+  for (const sideWidth of [0, 40, peekSideWidth(210), panelSideWidth(210), panelSideWidth(0)]) {
+    assert.ok(wingMarkCapacity(sideWidth, false, true) <= wingMarkCapacity(sideWidth));
+    assert.ok(wingMarkCapacity(sideWidth, true, true) <= wingMarkCapacity(sideWidth, true));
+  }
+});
+
 const providers = (...ids: string[]): ProviderTally[] =>
   ids.map((providerId) => ({ providerId, provider: providerId, total: 1, attention: 0 }));
 

--- a/apps/desktop/src/renderer/notch-wings.tsx
+++ b/apps/desktop/src/renderer/notch-wings.tsx
@@ -26,6 +26,7 @@ import {
   useWingReorderMotion,
   WING_SLOT_ID_ATTRIBUTE,
 } from "./session-motion";
+import { MicrophoneIcon } from "./settings-icons";
 import { WAVEFORM_VOICE, Waveform, type WaveformVoice } from "./waveform";
 
 /**
@@ -69,6 +70,12 @@ interface NotchWingsProps {
   /** Carries a filter to narrow the session list by when an icon in the wing is clicked. */
   onSelectFilter?: (filter: SessionFilter) => void;
   activeFilters?: readonly SessionFilter[];
+  /**
+   * The talk key's tap at one remove: present only while its setting is on,
+   * and the presence is what draws the button. One press opens a latched
+   * turn, the next sends it — the same two things a tapped talk key does.
+   */
+  onTalkPress?: () => void;
 }
 
 /**
@@ -208,6 +215,7 @@ export function NotchWings({
   accountGated,
   onSelectFilter,
   activeFilters,
+  onTalkPress,
 }: NotchWingsProps): React.JSX.Element {
   const [voiceActive, setVoiceActive] = useState(false);
   const reportVoiceActivity = useCallback(
@@ -260,16 +268,22 @@ export function NotchWings({
     useFaceHover(faceElement),
   );
 
+  // The talk button stands only where the face does: a gated Luke offers no
+  // turn to open, so the strip stays bare there exactly as it does of him.
+  const talkButton = onTalkPress !== undefined && !accountGated;
+  // Whether the developer holds the turn the button's next press would send —
+  // from the press itself, on the meter's own reasoning above.
+  const developerTurn = meterVoice === WAVEFORM_VOICE.DEVELOPER;
   // The wing is bounded by the shape its state draws, so its capacity is too:
   // the panel's side holds more marks than the peek's, and every other state
   // keeps the peek's capacity because that is the set the next peek unfolds.
   // Whenever the meter stands beside the face rather than in its place, the
   // marks give up whatever room it costs rather than letting it draw across
-  // them.
+  // them — and the talk button, whenever it is drawn, costs them the same way.
   const capacity =
     presentation === PANEL_PRESENTATION.PANEL
-      ? wingMarkCapacity((PANEL_WIDTH - housingWidth) / 2, meterBesideFace)
-      : wingMarkCapacity(peekSideWidth(housingWidth), meterBesideFace);
+      ? wingMarkCapacity((PANEL_WIDTH - housingWidth) / 2, meterBesideFace, talkButton)
+      : wingMarkCapacity(peekSideWidth(housingWidth), meterBesideFace, talkButton);
   // Memoized because the roster below notices a new list by identity: the
   // slots may only change when what they summarize does, not on every render
   // a spoken word or a face gesture asks for.
@@ -367,6 +381,27 @@ export function NotchWings({
               );
             })}
           </span>
+          {talkButton ? (
+            /* The talk key for whoever forgets the chord. It presses the same
+               two edges a tapped key lands, so everything downstream — the
+               latch, the meter, the interrupt — is the key's own behavior
+               rather than a second path to the microphone. */
+            <button
+              type="button"
+              className="wing-talk"
+              data-hit-region={HIT_REGION.CAPSULE}
+              data-active={String(developerTurn)}
+              aria-label={developerTurn ? "Send what you said" : "Talk to Luke"}
+              title={developerTurn ? "Send what you said" : "Talk to Luke"}
+              onMouseDown={(event) => event.preventDefault()}
+              onClick={(event) => {
+                event.stopPropagation();
+                onTalkPress?.();
+              }}
+            >
+              <MicrophoneIcon />
+            </button>
+          ) : null}
           {meterShown && (
             /* Keyed on whose turn it is, so each voice's meter is a fresh
                mount: the arrival choreography lives in a starting style, and

--- a/apps/desktop/src/renderer/settings-search.test.ts
+++ b/apps/desktop/src/renderer/settings-search.test.ts
@@ -211,7 +211,7 @@ test("the kept rows come back grouped under their pages, in the pages' order", (
   ]);
   assert.equal(shortcuts.matched, 3);
 
-  // "key" lands on the front page and two others; the groups keep the front
+  // "key" lands on the front page and three others; the groups keep the front
   // page's own order, front page first.
   const keys = searchSettings(entries, "key");
   assert.ok(keys);
@@ -219,7 +219,12 @@ test("the kept rows come back grouped under their pages, in the pages' order", (
   const pages = keys.groups.map((group) => group.page);
   assert.deepEqual(
     pages,
-    [SETTINGS_VIEW.ROOT, SETTINGS_VIEW.SHORTCUTS, SETTINGS_VIEW.CONNECTIONS],
+    [
+      SETTINGS_VIEW.ROOT,
+      SETTINGS_VIEW.APPEARANCE,
+      SETTINGS_VIEW.SHORTCUTS,
+      SETTINGS_VIEW.CONNECTIONS,
+    ],
     "groups follow the nav's order",
   );
 });

--- a/apps/desktop/src/renderer/styles/base.css
+++ b/apps/desktop/src/renderer/styles/base.css
@@ -786,13 +786,57 @@ html[data-keyboard="true"] .wing-mark:focus-visible {
   border-radius: 2px;
 }
 
+/* The talk key at one remove. It stands beside the face it opens a turn with,
+   at the face's own size, and follows the marks' rules for when it can be
+   pressed: only where the wing is unfolded, because in the capsule the strip
+   is one button and that button opens the peek. */
+.wing-talk {
+  display: flex;
+  width: 18px;
+  height: 18px;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  border: 0;
+  background: none;
+  color: var(--text-secondary);
+  cursor: pointer;
+  outline: none;
+  -webkit-app-region: no-drag;
+  -webkit-tap-highlight-color: transparent;
+  pointer-events: none;
+}
+
+.wing-talk .settings-icon {
+  width: 14px;
+  height: 14px;
+}
+
+.wing-talk:hover {
+  color: var(--text-primary);
+}
+
+/* While the developer holds the turn its next press sends, the button wears
+   the meter's own green, so the two read as one state. */
+.wing-talk[data-active="true"] {
+  color: var(--voice-developer);
+}
+
+html[data-keyboard="true"] .wing-talk:focus-visible {
+  outline: 2px solid var(--state-working);
+  outline-offset: 2px;
+  border-radius: 2px;
+}
+
 /* The capsule keeps the face and nothing else; what Luke is watching belongs to
    the states with room for it, and unfolds outward from the notch on the same
    spring, at the same distance, as the count's caption does on the other side.
    The two wings are one gesture, so they move as one. */
 .wing-mark,
 .wing-more,
-.wing-meter {
+.wing-meter,
+.wing-talk {
   opacity: 0;
   transform: translateX(8px);
   transition:
@@ -803,9 +847,11 @@ html[data-keyboard="true"] .wing-mark:focus-visible {
 .app-stage[data-presentation="peek"] .wing-mark,
 .app-stage[data-presentation="peek"] .wing-more,
 .app-stage[data-presentation="peek"] .wing-meter,
+.app-stage[data-presentation="peek"] .wing-talk,
 .app-stage[data-presentation="panel"] .wing-mark,
 .app-stage[data-presentation="panel"] .wing-more,
-.app-stage[data-presentation="panel"] .wing-meter {
+.app-stage[data-presentation="panel"] .wing-meter,
+.app-stage[data-presentation="panel"] .wing-talk {
   opacity: 1;
   transform: none;
   transition-duration: var(--duration-quick), var(--duration-shape);
@@ -814,7 +860,9 @@ html[data-keyboard="true"] .wing-mark:focus-visible {
 }
 
 .app-stage[data-presentation="peek"] .wing-mark:not([data-leaving="true"]),
-.app-stage[data-presentation="panel"] .wing-mark:not([data-leaving="true"]) {
+.app-stage[data-presentation="peek"] .wing-talk,
+.app-stage[data-presentation="panel"] .wing-mark:not([data-leaving="true"]),
+.app-stage[data-presentation="panel"] .wing-talk {
   pointer-events: auto;
 }
 
@@ -834,9 +882,12 @@ html[data-keyboard="true"] .wing-mark:focus-visible {
 
 /* A mark can mount into an already unfolded wing. On a compact mount its
    computed destination is the same covered pose, so this costs nothing; on an
-   open wing the backwards-filled keyframes provide the missing start state. */
+   open wing the backwards-filled keyframes provide the missing start state.
+   The talk button mounts the same way, at its setting flipping while the wing
+   stands open. */
 .wing-mark,
-.wing-more {
+.wing-more,
+.wing-talk {
   animation:
     wing-mount-fade var(--duration-quick) var(--motion-exit)
     calc(var(--duration-shape) - var(--duration-quick)) backwards,

--- a/apps/desktop/src/renderer/use-voice-conversation.ts
+++ b/apps/desktop/src/renderer/use-voice-conversation.ts
@@ -461,6 +461,11 @@ export interface VoiceConversation {
   setVoiceStatus: (status: RealtimeStatus) => void;
   talkOpening: boolean;
   voiceHotkey: VoiceHotkeyState | undefined;
+  /**
+   * The talk key's tap at one remove, for the strip's talk button: one press
+   * opens a latched turn, the next sends it.
+   */
+  pressTalk: () => void;
   handleVoiceActivity: (active: boolean) => void;
   requestMicrophoneAccess: () => Promise<void>;
   startMicrophone: () => Promise<MicrophoneStatus>;
@@ -1052,6 +1057,20 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
   }, [voiceStatusNow]);
 
   /**
+   * A click on the strip's talk button: the talk key's tap at one remove. The
+   * release lands on the press's own instant rather than waiting out the
+   * handshake behind it — exactly as a tapped key's two edges do — so it reads
+   * as a tap and latches: the session already holds the press as a pending
+   * turn until its call and device arrive, and {@link endTalk} reads that
+   * pending turn (or the listening already open) as the latch. The next click
+   * finds the latch and sends the turn.
+   */
+  const pressTalk = useCallback(() => {
+    void beginTalk();
+    endTalk();
+  }, [beginTalk, endTalk]);
+
+  /**
    * A typed ask to Luke himself. It rides the same call the talk key opens
    * and opens the same kind of turn: typing is the developer asking in their
    * own words, so the turn may carry a tool the way a spoken one may, behind
@@ -1434,6 +1453,7 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
     setVoiceStatus,
     talkOpening,
     voiceHotkey,
+    pressTalk,
     handleVoiceActivity,
     requestMicrophoneAccess,
     startMicrophone,

--- a/apps/desktop/src/renderer/use-voice-conversation.ts
+++ b/apps/desktop/src/renderer/use-voice-conversation.ts
@@ -1064,6 +1064,12 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
    * turn until its call and device arrive, and {@link endTalk} reads that
    * pending turn (or the listening already open) as the latch. The next click
    * finds the latch and sends the turn.
+   *
+   * A click before the microphone is granted keeps the key's own answer, on
+   * purpose: it raises the system's prompt and opens no turn, because the
+   * release already landed while the prompt stood, and a microphone that
+   * went live the instant the dialog closed would be capturing under a
+   * gesture already over. The click after the grant talks.
    */
   const pressTalk = useCallback(() => {
     void beginTalk();

--- a/packages/guide/src/app-settings.ts
+++ b/packages/guide/src/app-settings.ts
@@ -14,6 +14,7 @@ export const APP_SETTING_ID = {
   QUIET_DURING_MEETINGS: "quiet_during_meetings",
   SHOW_IN_DOCK: "show_in_dock",
   SHOW_ON_ALL_DISPLAYS: "show_on_all_displays",
+  SHOW_TALK_BUTTON: "show_talk_button",
   FORM_FACTOR: "form_factor",
   DEFAULT_WORKSPACE_PROVIDER: "default_workspace_provider",
   WORKSPACE_AGENT_MODEL: "workspace_agent_model",

--- a/packages/panel/src/layout.ts
+++ b/packages/panel/src/layout.ts
@@ -4,19 +4,32 @@ const MARK_WIDTH = 14;
 const MARK_AND_GAP = 21;
 /** The meter is as wide as the face it stands beside, so it costs the same. */
 const METER_AND_GAP = 26;
+/** The talk button wraps a face-sized glyph, so it costs what the face does. */
+const TALK_BUTTON_AND_GAP = 26;
 
 /**
  * How many marks fit beside the face, in a wing where the meter is also
  * standing beside it rather than taking its place — Luke's own turn, or an
  * audio signal with no turn to read at all. The developer's own live turn
  * hands the meter the face's own slot instead, at the face's own width, so
- * it costs the marks nothing extra. Reserving the meter's width here rather
- * than hiding marks to make room is what keeps the strip from ever drawing
- * the meter across a mark it already committed to.
+ * it costs the marks nothing extra. The talk button, when its setting draws
+ * one, stands beside the face the same way and reserves the same room.
+ * Reserving these widths here rather than hiding marks to make room is what
+ * keeps the strip from ever drawing either across a mark it already
+ * committed to.
  */
-export function wingMarkCapacity(sideWidth: number, meterBesideFace = false): number {
+export function wingMarkCapacity(
+  sideWidth: number,
+  meterBesideFace = false,
+  talkButton = false,
+): number {
   const beyondFirst = Math.floor(
-    (sideWidth - WING_INSETS - FACE_AND_GAP - (meterBesideFace ? METER_AND_GAP : 0) - MARK_WIDTH) /
+    (sideWidth -
+      WING_INSETS -
+      FACE_AND_GAP -
+      (meterBesideFace ? METER_AND_GAP : 0) -
+      (talkButton ? TALK_BUTTON_AND_GAP : 0) -
+      MARK_WIDTH) /
       MARK_AND_GAP,
   );
   return Math.max(1, 1 + beyondFirst);

--- a/packages/settings/src/schema.ts
+++ b/packages/settings/src/schema.ts
@@ -588,6 +588,35 @@ export const APP_SETTING_SCHEMA = {
     spokenValue: (value: string) => value === APP_TOGGLE_VALUE.ON,
     analytics: { id: APP_SETTING_ID.SHOW_ON_ALL_DISPLAYS, value: toggleAnalytics },
   },
+  showTalkButton: {
+    field: "showTalkButton",
+    default: false,
+    guard: boolean(false),
+    settingsPage: SETTINGS_PAGE.APPEARANCE,
+    resetScope: SETTINGS_RESET_SCOPE.APPEARANCE,
+    guideEntry: settingGuideEntry(
+      "showTalkButton",
+      [APP_SETTING_ID.SHOW_TALK_BUTTON],
+      (settings, defaultValue) => ({
+        id: APP_SETTING_ID.SHOW_TALK_BUTTON,
+        label: "Show a talk button",
+        description:
+          "Whether a microphone button stands beside Luke's face when the strip unfolds: one " +
+          "press starts a spoken turn and the next sends it, the same two things a tap of the " +
+          "talk key does — for whoever would rather click than remember the chord.",
+        kind: APP_SETTING_KIND.TOGGLE,
+        value: appToggleText(guideValue<boolean>(settings, "showTalkButton")),
+        defaultValue: appToggleText(defaultValue),
+        adjustable: true,
+        manual: APPEARANCE_PAGE,
+      }),
+    ),
+    // None in the main process: the button lives in the renderer's own wing,
+    // which redraws from the settings change it is already handed.
+    mainProcessSideEffect: SETTING_SIDE_EFFECT.NONE,
+    spokenValue: (value: string) => value === APP_TOGGLE_VALUE.ON,
+    analytics: { id: APP_SETTING_ID.SHOW_TALK_BUTTON, value: toggleAnalytics },
+  },
   shareUsageData: {
     field: "shareUsageData",
     default: true,


### PR DESCRIPTION
## Motivation

A user said they keep forgetting the talk key's chord. The strip now offers the same act at a click — behind a setting that is **off by default**, so nothing changes for anyone who did not ask for it.

## What changed

- **Setting.** `showTalkButton` in `APP_SETTING_SCHEMA` (`show_talk_button`), default off, on the Appearance page with the Appearance reset scope. The switch row, settings search, the guide entry, and the spoken `change_app_setting` path all follow from the one schema declaration; analytics counts it as the fixed on/off shape every toggle travels in. No main-process side effect — the renderer's wing redraws from the settings change it is already handed.
- **The button.** A microphone button beside Luke's face in the left wing, drawn only while the setting is on and never while sign-in gates the strip. It follows the provider marks' rules: visible and pressable only where the wing unfolds (peek and panel), since in the capsule the strip is one button and that button opens the peek. While the developer holds the turn it wears the meter's green and its label flips to "Send what you said".
- **One path to the microphone.** The press is the talk key's tap at one remove: `pressTalk` on the voice-conversation hook lands the same two edges a tapped key does (`beginTalk` then an immediate `endTalk`, unawaited so the release reads the press's own instant rather than the handshake's). One click opens a latched turn, the next sends it; the latch, the opening meter, the permission ask, and interrupting a reply are all the key's existing behavior, not a second write path.
- **Geometry.** The button reserves a face-sized 26px in `wingMarkCapacity` the way the meter's beside-the-face reservation does, so it can never draw across a mark the strip committed to; new capacity tests cover both reservations together.
- **Guide.** The setting's guide entry teaches Luke what the button does and where its switch lives, in the same change; the adjustable-settings bridge test now carries `showTalkButton:true`.

## Verification

- `./scripts/bootstrap.sh` — completed, exit 0.
- `./scripts/check.sh` — passed, exit 0 (repository checks, types, tests, builds).
- `./scripts/verify.sh` is macOS-only and this change was made in a Linux cloud workspace, so it was **not run** locally; no physical-notch check was performed. CI's macOS job runs it and links the evidence below. The fixture evidence is expected unchanged — the setting defaults off, so the fixture strip draws exactly what it drew before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/8c8b5c9c-0274-48a9-a67a-b7e354b24263)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/33101286762/artifacts/9658649101) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/33101286762)

- Commit: `0cb21ab96c7d3d1709e63084d92b2aca83b5b997`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
