### PR TITLE
feat(web): register luke-mobile OAuth client

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "auth:generate": "DATABASE_URL=${DATABASE_URL:-postgresql://schema:generate@127.0.0.1:5432/luke} pnpm dlx @better-auth/cli@1.4.21 generate --config server/auth.ts --output server/db/auth-schema.ts --yes && pnpm exec biome check --write server/db/auth-schema.ts",
-    "auth:seed": "tsx server/seed-desktop-client.ts",
+    "auth:seed": "tsx server/seed-clients.ts",
     "build": "vite build",
     "db:check": "drizzle-kit check",
     "db:generate": "drizzle-kit generate",

--- a/apps/web/server/README.md
+++ b/apps/web/server/README.md
@@ -34,18 +34,31 @@ filesystem routing phase, so it cannot reach the Better Auth handler; keep this
 rule in `routes`, ahead of the detected routes.
 
 Each deployment build runs `pnpm auth:seed` after the migration and before Vite,
-so every database the application reaches already carries the client, including
+so every database the application reaches already carries the clients, including
 the branch database Neon creates for a Preview deployment, which would otherwise
-be migrated but empty. The Drizzle seed is idempotent, upserting the one public
+be migrated but empty. The Drizzle seed is idempotent, upserting each public
 OAuth client compiled into Luke, which is what makes running it on every build
 safe. To apply it by hand against production:
 
 ```sh
 vercel env run --environment production --scope stage-review -- \
   pnpm --filter @luke/web auth:seed
-``` Dynamic client registration stays disabled; the client has no secret,
-requires PKCE, accepts loopback callbacks, and skips consent as a trusted
-first-party app.
+```
+
+Dynamic client registration stays disabled. Two public clients are compiled in:
+
+- **`luke-desktop`** (`server/desktop-oauth-client.ts`) — the macOS companion
+  app. It accepts loopback callbacks (`http://127.0.0.1/callback`) via a local
+  HTTP server during sign-in.
+
+- **`luke-mobile`** (`server/mobile-oauth-client.ts`) — the iOS companion app.
+  It uses a custom URL scheme (`dev.tryluke.ios://oauth/callback`) because iOS
+  sign-in runs through `ASWebAuthenticationSession`, which delivers the callback
+  via the registered scheme rather than a local HTTP server. The scheme passes
+  Better Auth's `SafeUrlSchema` validation, which explicitly allows custom
+  schemes for native clients. Both clients share the same trust posture: no
+  client secret, PKCE required, skip consent as a trusted first-party app,
+  public client.
 
 Google's callback is `${BETTER_AUTH_URL}/api/auth/callback/google`; GitHub's is
 `${BETTER_AUTH_URL}/api/auth/callback/github`. The GitHub provider requests

--- a/apps/web/server/auth.ts
+++ b/apps/web/server/auth.ts
@@ -13,8 +13,10 @@ import { authProxy } from "./auth-proxy.js";
 import { getDatabase } from "./db/index.js";
 import * as schema from "./db/schema.js";
 import { DESKTOP_OAUTH_CLIENT } from "./desktop-oauth-client.js";
+import { MOBILE_OAUTH_CLIENT } from "./mobile-oauth-client.js";
 
 export const DESKTOP_OAUTH_CLIENT_ID = DESKTOP_OAUTH_CLIENT.id;
+export const MOBILE_OAUTH_CLIENT_ID = MOBILE_OAUTH_CLIENT.id;
 
 const deployment = authDeployment(process.env);
 
@@ -59,7 +61,7 @@ export const auth = betterAuth({
       consentPage: "/consent.html",
       allowDynamicClientRegistration: false,
       clientPrivileges: denyOAuthClientPrivileges,
-      cachedTrustedClients: new Set([DESKTOP_OAUTH_CLIENT_ID]),
+      cachedTrustedClients: new Set([DESKTOP_OAUTH_CLIENT_ID, MOBILE_OAUTH_CLIENT_ID]),
       accessTokenExpiresIn: 60 * 60,
     }),
   ],

--- a/apps/web/server/mobile-oauth-client.ts
+++ b/apps/web/server/mobile-oauth-client.ts
@@ -1,0 +1,31 @@
+export const MOBILE_OAUTH_CLIENT = {
+  id: "luke-mobile",
+  name: "Luke for iOS",
+  scopes: ["openid", "profile", "email", "offline_access"],
+  redirectUris: ["dev.tryluke.ios://oauth/callback"],
+  tokenEndpointAuthMethod: "none",
+  grantTypes: ["authorization_code", "refresh_token"],
+  responseTypes: ["code"],
+  type: "native",
+} as const;
+
+export function mobileOAuthClientRecord(now: Date) {
+  return {
+    id: MOBILE_OAUTH_CLIENT.id,
+    clientId: MOBILE_OAUTH_CLIENT.id,
+    disabled: false,
+    skipConsent: true,
+    enableEndSession: false,
+    scopes: [...MOBILE_OAUTH_CLIENT.scopes],
+    createdAt: now,
+    updatedAt: now,
+    name: MOBILE_OAUTH_CLIENT.name,
+    redirectUris: [...MOBILE_OAUTH_CLIENT.redirectUris],
+    tokenEndpointAuthMethod: MOBILE_OAUTH_CLIENT.tokenEndpointAuthMethod,
+    grantTypes: [...MOBILE_OAUTH_CLIENT.grantTypes],
+    responseTypes: [...MOBILE_OAUTH_CLIENT.responseTypes],
+    public: true,
+    type: MOBILE_OAUTH_CLIENT.type,
+    requirePKCE: true,
+  };
+}

--- a/apps/web/server/seed-clients.ts
+++ b/apps/web/server/seed-clients.ts
@@ -1,0 +1,17 @@
+import { pathToFileURL } from "node:url";
+import { getDatabase } from "./db/index.js";
+import { seedDesktopOAuthClient } from "./seed-desktop-client.js";
+import { seedMobileOAuthClient } from "./seed-mobile-client.js";
+
+export async function seedOAuthClients(
+  database: Parameters<typeof seedDesktopOAuthClient>[0],
+  now = new Date(),
+): Promise<void> {
+  await seedDesktopOAuthClient(database, now);
+  await seedMobileOAuthClient(database, now);
+}
+
+const executedPath = process.argv[1];
+if (executedPath && import.meta.url === pathToFileURL(executedPath).href) {
+  await seedOAuthClients(getDatabase());
+}

--- a/apps/web/server/seed-mobile-client.ts
+++ b/apps/web/server/seed-mobile-client.ts
@@ -1,0 +1,33 @@
+import { oauthClient } from "./db/auth-schema.js";
+import type { getDatabase } from "./db/index.js";
+import { mobileOAuthClientRecord } from "./mobile-oauth-client.js";
+
+type SeedDatabase = Pick<ReturnType<typeof getDatabase>, "insert">;
+
+export async function seedMobileOAuthClient(
+  database: SeedDatabase,
+  now = new Date(),
+): Promise<void> {
+  const record = mobileOAuthClientRecord(now);
+  await database
+    .insert(oauthClient)
+    .values(record)
+    .onConflictDoUpdate({
+      target: oauthClient.clientId,
+      set: {
+        disabled: record.disabled,
+        skipConsent: record.skipConsent,
+        enableEndSession: record.enableEndSession,
+        scopes: record.scopes,
+        updatedAt: record.updatedAt,
+        name: record.name,
+        redirectUris: record.redirectUris,
+        tokenEndpointAuthMethod: record.tokenEndpointAuthMethod,
+        grantTypes: record.grantTypes,
+        responseTypes: record.responseTypes,
+        public: record.public,
+        type: record.type,
+        requirePKCE: record.requirePKCE,
+      },
+    });
+}

--- a/apps/web/tests/auth-database.test.ts
+++ b/apps/web/tests/auth-database.test.ts
@@ -18,7 +18,9 @@ import {
   verification,
 } from "../server/db/auth-schema";
 import { DESKTOP_OAUTH_CLIENT, desktopOAuthClientRecord } from "../server/desktop-oauth-client";
+import { MOBILE_OAUTH_CLIENT, mobileOAuthClientRecord } from "../server/mobile-oauth-client";
 import { seedDesktopOAuthClient } from "../server/seed-desktop-client";
+import { seedMobileOAuthClient } from "../server/seed-mobile-client";
 
 const AUTH_TABLE_NAME = {
   ACCOUNT: "account",
@@ -108,6 +110,80 @@ test("seeding updates the one client identity instead of creating another", asyn
     updatedAt: now,
     name: "Luke for macOS",
     redirectUris: ["http://127.0.0.1/callback"],
+    tokenEndpointAuthMethod: "none",
+    grantTypes: ["authorization_code", "refresh_token"],
+    responseTypes: ["code"],
+    public: true,
+    type: "native",
+    requirePKCE: true,
+  });
+});
+
+test("the mobile client stays public, secretless, trusted, and bound to PKCE", () => {
+  const now = new Date("2026-08-17T00:00:00.000Z");
+  const record = mobileOAuthClientRecord(now);
+
+  assert.equal(record.id, MOBILE_OAUTH_CLIENT.id);
+  assert.equal(record.clientId, MOBILE_OAUTH_CLIENT.id);
+  assert.equal("clientSecret" in record, false);
+  assert.equal(record.public, true);
+  assert.equal(record.requirePKCE, true);
+  assert.equal(record.skipConsent, true);
+  assert.deepEqual(record.redirectUris, ["dev.tryluke.ios://oauth/callback"]);
+  assert.deepEqual(record.grantTypes, ["authorization_code", "refresh_token"]);
+  assert.deepEqual(record.scopes, ["openid", "profile", "email", "offline_access"]);
+  assert.equal(record.createdAt, now);
+  assert.equal(record.updatedAt, now);
+});
+
+test("mobile client uses a custom URI scheme, not a loopback address", () => {
+  const [redirectUri] = MOBILE_OAUTH_CLIENT.redirectUris;
+  const url = new URL(redirectUri);
+  assert.notEqual(url.protocol, "http:");
+  assert.notEqual(url.protocol, "https:");
+  assert.ok(
+    url.protocol.endsWith(":") &&
+      !["http:", "https:", "javascript:", "data:", "vbscript:"].includes(url.protocol),
+    "redirect URI must use a custom scheme",
+  );
+});
+
+test("mobile client seeding updates the one client identity instead of creating another", async () => {
+  let insertedTable: typeof oauthClient | undefined;
+  let insertedRecord: ReturnType<typeof mobileOAuthClientRecord> | undefined;
+  let conflict: { target?: unknown; set?: unknown } | undefined;
+  type SeedDatabase = Parameters<typeof seedMobileOAuthClient>[0];
+  // SAFETY: Test double implements only the insert chain seedMobileOAuthClient exercises.
+  const database = {
+    insert(table: typeof oauthClient) {
+      insertedTable = table;
+      return {
+        values(record: ReturnType<typeof mobileOAuthClientRecord>) {
+          insertedRecord = record;
+          return {
+            async onConflictDoUpdate(input: { target?: unknown; set?: unknown }) {
+              conflict = input;
+            },
+          };
+        },
+      };
+    },
+  } as unknown as SeedDatabase;
+
+  const now = new Date("2026-08-17T00:00:00.000Z");
+  await seedMobileOAuthClient(database, now);
+
+  assert.equal(insertedTable, oauthClient);
+  assert.deepEqual(insertedRecord, mobileOAuthClientRecord(now));
+  assert.equal(conflict?.target, oauthClient.clientId);
+  assert.deepEqual(conflict?.set, {
+    disabled: false,
+    skipConsent: true,
+    enableEndSession: false,
+    scopes: ["openid", "profile", "email", "offline_access"],
+    updatedAt: now,
+    name: "Luke for iOS",
+    redirectUris: ["dev.tryluke.ios://oauth/callback"],
     tokenEndpointAuthMethod: "none",
     grantTypes: ["authorization_code", "refresh_token"],
     responseTypes: ["code"],


### PR DESCRIPTION
## Summary

- Adds a compiled-in public OAuth client `luke-mobile` mirroring `luke-desktop`, with one required difference: the redirect URI is the custom URL scheme `dev.tryluke.ios://oauth/callback` instead of a loopback address.
- iOS sign-in runs through `ASWebAuthenticationSession`, which delivers the OAuth callback via a registered app scheme rather than a local HTTP server — a loopback address can't work there. Better Auth's `SafeUrlSchema` explicitly allows custom schemes for native mobile clients, so no validation is loosened.
- Same trust posture as desktop: public client, PKCE required, no client secret, skip consent as a trusted first-party app. The integration exists only in builds carrying a registered OAuth client.
- `pnpm auth:seed` now runs `server/seed-clients.ts`, an idempotent entry point that upserts both `luke-desktop` and `luke-mobile`; each seed function remains individually importable by tests.
- `server/auth.ts` adds `luke-mobile` to `cachedTrustedClients` alongside `luke-desktop`.
- `server/README.md` documents both clients side by side.
- Three new tests in `tests/auth-database.test.ts` follow the existing pattern: record shape, scheme assertion, and idempotent-upsert double.

## Test plan

- [x] `./scripts/check.sh` passes — 194 tests pass, typecheck clean, biome clean (pre-existing 1 error in `attention-review.ts` unrelated to this change)
- [ ] After merging, verify `pnpm auth:seed` against production upserts `luke-mobile` alongside `luke-desktop` in the `oauth_client` table

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/f8dbf01d-93d5-46a6-8768-2c738ddfb268)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/33106277466/artifacts/9660664974) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/33106277466)

- Commit: `5dba29f6b44328ceaba59fb503ddd205b57db92b`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
