### PR TITLE
feat(hosted): carry the websocket realtime endpoint in the voice mint

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -28,6 +28,7 @@
     "@paper-design/shaders": "0.0.80",
     "@sidecar/attention": "workspace:*",
     "@sidecar/credentials": "workspace:*",
+    "@sidecar/hosted": "workspace:*",
     "@sidecar/fixtures": "workspace:*",
     "@sidecar/panel": "workspace:*",
     "@sidecar/realtime": "workspace:*",

--- a/apps/web/server/README.md
+++ b/apps/web/server/README.md
@@ -128,6 +128,17 @@ The logic lives in `server/hosted/` behind injected seams, and each request is
 resolved to a user through the auth service's own `/oauth2/userinfo` endpoint,
 called in process.
 
+The mint answer's `connection` object carries both a WebRTC calls endpoint
+(`callsUrl`) for the desktop renderer and a WebSocket endpoint (`wsUrl`) for
+mobile clients such as the iOS/watchOS companion, which has no WebRTC. Both
+point at the canonical OpenAI host and are pinned by the build rather than
+composed by the client: `callsUrl` is the calls endpoint at
+`https://api.openai.com/v1/realtime/calls`; `wsUrl` is the WebSocket base at
+`wss://api.openai.com/v1/realtime` with the session's model appended as
+`?model=<model>`. The same ephemeral client secret authenticates both
+transports. Clients predating this field ignore `wsUrl`; clients predating
+this server receive a connection without it and must handle its absence.
+
 The endpoints need one secret: `OPENAI_API_KEY`. Without it both answer 503
 and the hosted tier is simply off, the same kill switch as the feedback
 endpoint, which is the intended state for Preview deployments, so a preview

--- a/apps/web/server/hosted/voice-mint.ts
+++ b/apps/web/server/hosted/voice-mint.ts
@@ -1,4 +1,5 @@
 import {
+  HOSTED_WS_BASE_URL,
   isRealtimeVoice,
   isRealtimeVoiceSpeed,
   isRecord,
@@ -145,6 +146,7 @@ export async function mintRealtimeConnection(
     connection: {
       ...credential,
       callsUrl: `${HOSTED_OPENAI_DEFAULTS.BASE_URL}${REALTIME_CALLS_PATH}`,
+      wsUrl: `${HOSTED_WS_BASE_URL}?model=${credential.model}`,
     },
   };
 }

--- a/apps/web/tests/hosted-introduction-mint.test.ts
+++ b/apps/web/tests/hosted-introduction-mint.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import { HOSTED_WS_BASE_URL } from "@sidecar/hosted";
 import { REALTIME_DEFAULTS, REALTIME_VOICE, REALTIME_VOICE_SPEED } from "@sidecar/realtime";
 import { HOSTED_API_ERROR } from "../server/hosted/http";
 import {
@@ -78,6 +79,7 @@ test("a mint hands back a short-capped credential aimed at OpenAI's own calls en
       expiresAt: NOW + 60_000,
       model: REALTIME_DEFAULTS.MODEL,
       callsUrl: "https://api.openai.com/v1/realtime/calls",
+      wsUrl: `${HOSTED_WS_BASE_URL}?model=${REALTIME_DEFAULTS.MODEL}`,
     },
   });
 

--- a/apps/web/tests/hosted-voice-mint.test.ts
+++ b/apps/web/tests/hosted-voice-mint.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import { HOSTED_WS_BASE_URL } from "@sidecar/hosted";
 import type { RealtimeVoice, RealtimeVoiceSpeed } from "@sidecar/realtime";
 import { REALTIME_DEFAULTS, REALTIME_VOICE, REALTIME_VOICE_SPEED } from "@sidecar/realtime";
 import { HOSTED_API_ERROR } from "../server/hosted/http";
@@ -79,6 +80,7 @@ test("a mint hands back an ephemeral credential aimed at OpenAI's own calls endp
     expiresAt: NOW + 60_000,
     model: REALTIME_DEFAULTS.MODEL,
     callsUrl: "https://api.openai.com/v1/realtime/calls",
+    wsUrl: `${HOSTED_WS_BASE_URL}?model=${REALTIME_DEFAULTS.MODEL}`,
   });
   assert.deepEqual(body.quota, OPEN_SPEND.quota);
 
@@ -88,6 +90,16 @@ test("a mint hands back an ephemeral credential aimed at OpenAI's own calls endp
   assert.equal(sent.session.audio.output.voice, REALTIME_VOICE.MARIN);
   assert.equal(sent.session.audio.output.speed, REALTIME_VOICE_SPEED.QUICK);
   assert.equal(sent.session.audio.input.turn_detection, null);
+});
+
+test("the wsUrl is pinned to the build's websocket base and carries the session's model", async () => {
+  const response = await handleVoiceMint(
+    options({ model: "gpt-realtime-next", fetch: upstream({}, mintedPayload) }),
+  );
+  assert.equal(response.status, 200);
+  const body = await response.json();
+  assert.equal(body.connection.wsUrl, `${HOSTED_WS_BASE_URL}?model=gpt-realtime-next`);
+  assert.ok(body.connection.wsUrl.startsWith("wss://api.openai.com/v1/realtime"));
 });
 
 test("an empty body mints the build's own defaults", async () => {

--- a/packages/hosted/src/hosted-service.test.ts
+++ b/packages/hosted/src/hosted-service.test.ts
@@ -3,25 +3,30 @@ import test from "node:test";
 import {
   HOSTED_CALLS_URL,
   HOSTED_SERVICE_PATH,
+  HOSTED_WS_BASE_URL,
   hostedMintAnswerFromWire,
 } from "./hosted-service.js";
 
 const NOW = 1_800_000_000_000;
+const MODEL = "gpt-realtime-2.1";
 
 interface MintedWireOverrides {
   value?: string;
   expiresAt?: number;
   model?: string;
   callsUrl?: string;
+  wsUrl?: string;
 }
 
 function mintedWire(overrides: MintedWireOverrides = {}) {
+  const model = overrides.model ?? MODEL;
   return {
     connection: {
       value: "eph-secret",
       expiresAt: NOW + 60_000,
-      model: "gpt-realtime-2.1",
+      model,
       callsUrl: HOSTED_CALLS_URL,
+      wsUrl: `${HOSTED_WS_BASE_URL}?model=${model}`,
       ...overrides,
     },
   };
@@ -38,8 +43,9 @@ test("a mint answer round-trips through the wire reader, with or without a quota
     connection: {
       value: "eph-secret",
       expiresAt: NOW + 60_000,
-      model: "gpt-realtime-2.1",
+      model: MODEL,
       callsUrl: HOSTED_CALLS_URL,
+      wsUrl: `${HOSTED_WS_BASE_URL}?model=${MODEL}`,
     },
   });
 
@@ -48,12 +54,47 @@ test("a mint answer round-trips through the wire reader, with or without a quota
   assert.deepEqual(metered?.quota, quota);
 });
 
+test("a mint answer without wsUrl (old server) still parses for new readers", () => {
+  const wire = {
+    connection: {
+      value: "eph-secret",
+      expiresAt: NOW + 60_000,
+      model: MODEL,
+      callsUrl: HOSTED_CALLS_URL,
+    },
+  };
+  const answer = hostedMintAnswerFromWire(wire, NOW);
+  assert.ok(answer);
+  assert.equal(answer.connection.wsUrl, undefined);
+});
+
 test("a credential aimed anywhere but the canonical calls endpoint is discarded", () => {
   const foreign = hostedMintAnswerFromWire(
     mintedWire({ callsUrl: "https://evil.example/v1/realtime/calls" }),
     NOW,
   );
   assert.equal(foreign, undefined);
+});
+
+test("a wsUrl aimed at any non-canonical base is discarded", () => {
+  const foreignWs = hostedMintAnswerFromWire(
+    mintedWire({ wsUrl: `wss://evil.example/v1/realtime?model=${MODEL}` }),
+    NOW,
+  );
+  assert.equal(foreignWs, undefined);
+});
+
+test("a wsUrl whose model param does not match the credential's model is discarded", () => {
+  const mismatch = hostedMintAnswerFromWire(
+    mintedWire({ wsUrl: `${HOSTED_WS_BASE_URL}?model=wrong-model` }),
+    NOW,
+  );
+  assert.equal(mismatch, undefined);
+});
+
+test("the wsUrl carries the model the credential was minted for", () => {
+  const answer = hostedMintAnswerFromWire(mintedWire({ model: "gpt-realtime-next" }), NOW);
+  assert.equal(answer?.connection.wsUrl, `${HOSTED_WS_BASE_URL}?model=gpt-realtime-next`);
 });
 
 test("an expired or incomplete credential reads as no answer at all", () => {

--- a/packages/hosted/src/hosted-service.ts
+++ b/packages/hosted/src/hosted-service.ts
@@ -80,13 +80,21 @@ export function hostedQuotaFromWire(value: UnparsedWireValue): HostedQuota | und
 }
 
 /**
- * The one address a hosted credential may point a call at. The renderer's
- * content-security policy only permits the canonical OpenAI host, so a
- * credential aimed anywhere else could not work — validating it here means a
- * mis-answering service reads as a malformed response rather than as a call
- * that dies mid-handshake.
+ * The one address a hosted credential may point a WebRTC call at. The
+ * renderer's content-security policy only permits the canonical OpenAI host,
+ * so a credential aimed anywhere else could not work — validating it here
+ * means a mis-answering service reads as a malformed response rather than as
+ * a call that dies mid-handshake.
  */
 export const HOSTED_CALLS_URL = `https://api.openai.com/v1${REALTIME_CALLS_PATH}`;
+
+/**
+ * The build-pinned WebSocket base URL for OpenAI Realtime. The full endpoint
+ * appends ?model=<model> and is validated field-by-field in the wire reader
+ * the same way callsUrl is, so a mis-answering service cannot redirect a
+ * mobile client's connection.
+ */
+export const HOSTED_WS_BASE_URL = "wss://api.openai.com/v1/realtime";
 
 export interface HostedMintAnswer {
   connection: RealtimeConnection;
@@ -110,12 +118,17 @@ export function hostedMintAnswerFromWire(
   if (!secret || !model) return undefined;
   if (expiresAt === undefined) return undefined;
   if (connection.callsUrl !== HOSTED_CALLS_URL) return undefined;
+  const wsUrlFromWire = text(connection.wsUrl);
+  if (wsUrlFromWire !== undefined && wsUrlFromWire !== `${HOSTED_WS_BASE_URL}?model=${model}`) {
+    return undefined;
+  }
   const credential: RealtimeConnection = {
     value: secret,
     expiresAt,
     model,
     callsUrl: HOSTED_CALLS_URL,
   };
+  if (wsUrlFromWire !== undefined) credential.wsUrl = wsUrlFromWire;
   if (!realtimeCredentialIsUsable(credential, now)) return undefined;
   const quota = hostedQuotaFromWire(value.quota);
   const answer: HostedMintAnswer = { connection: credential };

--- a/packages/hosted/src/index.ts
+++ b/packages/hosted/src/index.ts
@@ -2,6 +2,7 @@ export {
   HOSTED_API_ERROR,
   HOSTED_CALLS_URL,
   HOSTED_SERVICE_PATH,
+  HOSTED_WS_BASE_URL,
   type HostedApiError,
   type HostedMintAnswer,
   type HostedQuota,

--- a/packages/hosted/src/realtime-contract.ts
+++ b/packages/hosted/src/realtime-contract.ts
@@ -11,6 +11,8 @@ export interface RealtimeCredential {
 /** Everything a renderer needs to open a call, and nothing more. */
 export interface RealtimeConnection extends RealtimeCredential {
   callsUrl: string;
+  /** WebSocket realtime endpoint, including ?model=. Absent on servers that predate this field. */
+  wsUrl?: string;
 }
 
 export function realtimeCredentialIsUsable(credential: RealtimeCredential, now: number): boolean {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -162,6 +162,9 @@ importers:
       '@sidecar/fixtures':
         specifier: workspace:*
         version: link:../../packages/fixtures
+      '@sidecar/hosted':
+        specifier: workspace:*
+        version: link:../../packages/hosted
       '@sidecar/panel':
         specifier: workspace:*
         version: link:../../packages/panel


### PR DESCRIPTION
## Summary

Extends the hosted voice mint so a mobile client (iOS/watchOS companion) can open an OpenAI Realtime session over WebSocket using the same ephemeral credential the desktop uses for WebRTC.

**Motivation:** watchOS has no WebRTC. The companion app scaffolded in #554 must use OpenAI's documented `wss://` transport instead. OpenAI's ephemeral client secret (minted via `POST /realtime/client_secrets`) authenticates both transports, so no new auth flow or quota change is needed.

**What changed:**
- `packages/hosted/src/realtime-contract.ts`: adds `wsUrl?: string` to `RealtimeConnection`. Optional for backward compatibility — desktop readers that predate this field ignore it.
- `packages/hosted/src/hosted-service.ts`: adds `HOSTED_WS_BASE_URL = "wss://api.openai.com/v1/realtime"` (build-pinned, same posture as `HOSTED_CALLS_URL`). `hostedMintAnswerFromWire` validates `wsUrl` field-by-field: the base URL must match and the `?model=` param must equal the credential's own model. A missing `wsUrl` (old server) still parses cleanly.
- `apps/web/server/hosted/voice-mint.ts`: `mintRealtimeConnection` now sets `wsUrl: \`${HOSTED_WS_BASE_URL}?model=${credential.model}\`` alongside `callsUrl`. Same quota, same key, no new upstream calls.
- Tests: cover presence and pinning of `wsUrl`, round-trip through the wire reader, mismatch rejection, and backward compat for an old-server answer without the field.
- `apps/web/server/README.md`: documents the new field beside the existing mint documentation.

**Backward compatibility:** The desktop's `callsUrl` field and WebRTC flow are unchanged. `wsUrl` is optional in the TypeScript interface, so existing code that constructs `RealtimeConnection` without it continues to type-check. `hostedMintAnswerFromWire` accepts answers with or without the field.

**Fixed-by-the-build endpoint posture:** The mobile client receives a fully formed `wsUrl` (including `?model=`) in the wire contract and never composes a provider URL itself — the same guarantee the desktop gets with `callsUrl`.

## Test plan

- [x] `./scripts/check.sh` passes (21 pre-existing warnings, no new errors)
- [x] New `hosted-service.test.ts` tests: round-trip with `wsUrl`, old-server answer without `wsUrl`, canonical-base validation, model-mismatch rejection, model-carries-through
- [x] Updated `hosted-voice-mint.test.ts`: asserts `wsUrl` in the mint response; new test verifies model override is carried in `wsUrl`
- [x] Updated `hosted-introduction-mint.test.ts`: same assertion since `mintRealtimeConnection` is shared

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/158b28d0-4d4f-476f-ac25-3a0d9df9f096)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/33135401180/artifacts/9671873040) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/33135401180)

- Commit: `888fbb010ec647bd0da3bc11ea68923292782227`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
