### PR TITLE
feat(desktop): remove the Usage data settings section

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -323,15 +323,15 @@ Trust constraints:
   sign-in was: nothing erased is re-created either way, but a recorder starting
   up again on the panel that just erased everything reads as though something
   were, and deletion is the one act treated here as unrecoverable.
-  None of the three sends anything in a fixture or evidence run, or while the
-  developer has switched sharing off. The counts have their own switch and the
-  other two share the recording one, both on by default on the settings front
-  page, both belonging to no reset scope, because a reset that turned either
-  back on would be a consent nobody gave; sharing is the outer one, and
-  recording cannot outlive it. Widening the event list, a property's value set,
-  or what the recording client may capture is a product decision, not an
-  implementation detail. `PRIVACY.md` describes all three in kind and moves
-  when any of them changes character.
+  None of the three sends anything in a fixture or evidence run, and nothing
+  else stands in front of any of them: there is no switch, and the run mode is
+  the whole of the gate. That is the deliberate posture of an early product
+  and it puts the entire weight of disclosure on `PRIVACY.md`, which is where
+  a user learns any of this happens — so that file says all three in kind, in
+  as many words, and moves whenever one of them changes character. Widening
+  the event list, a property's value set, or what the recording client may
+  capture is a product decision, not an implementation detail, and each one
+  widens what a user was never offered a way to decline.
 - The development trace is the one place Luke's own agent traffic may reach a
   file, and it cannot exist for a user: only an unpackaged, live run whose
   shell set `LUKE_TRACE_DIR` constructs a writer at all, so a packaged build

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -45,10 +45,6 @@ before you sign in is attached to your account if you sign in while it is
 running. One that never reaches a sign-in belongs to nobody, so deleting your
 account does not reach it — we have no way to tell it was yours.
 
-Usage data and recording are both on by default, with their own switches in
-Settings. Turning off Record my screen in Luke leaves the counts on; turning off
-Share usage data stops everything in these two sections.
-
 **Feedback.** If you use the feedback form, we receive what you typed, the name
 and email you signed it with, and any screenshots you attached.
 

--- a/README.md
+++ b/README.md
@@ -92,8 +92,8 @@ Optional: open **Settings** in Luke to:
 - Connect Apple or Google Calendar.
 - Connect Linear.
 - Add an OpenAI API key for usage billed directly to your OpenAI account.
-- Customize Luke's voice, keyboard shortcuts, appearance, workspace defaults,
-  and data-sharing preferences.
+- Customize Luke's voice, keyboard shortcuts, appearance, and workspace
+  defaults.
 
 Local agents are detected automatically and do not require API keys.
 

--- a/apps/desktop/src/main/desktop-app.ts
+++ b/apps/desktop/src/main/desktop-app.ts
@@ -1432,7 +1432,6 @@ function registerIpc(): void {
     workspaceProjectOffered,
     refreshMeetingQuiet: () => void refreshMeetingQuiet(),
     releaseHeldNotices: () => void releaseHeldNotices(),
-    setUsageSharing: (enabled) => productEvents.setSharing(enabled),
     recordProductEvent,
   });
 
@@ -2542,18 +2541,15 @@ export function startDesktopApp(): void {
           .get(APP_SETTING_SCHEMA.duckOtherMedia.field)
           .then((enabled) => mediaDuck.setEnabled(enabled === true));
       }
-      // Armed from the settings file alone, like the duck above, and on the
-      // same terms: a file that cannot be read leaves counting on, the answer
-      // a file that has never said gives.
-      void settingsStore.get(APP_SETTING_SCHEMA.shareUsageData.field).then((share) => {
-        productEvents.setSharing(share);
-        // Recorded behind the read, because nothing may be counted before
-        // the file has said whether counting is wanted at all.
-        productEvents.record(PRODUCT_EVENT.APP_LAUNCH, { app_version: app.getVersion() });
-        // Luke can run for a week on one launch, so launches alone would
-        // undercount the days he was actually used.
-        productEvents.markDayActive();
-      });
+      // Counting answers to the run and to nothing else. The sender starts
+      // knowing nothing rather than assuming, so this is the arming it waits
+      // for, and it is unconditional: `PRIVACY.md` is where a user learns
+      // this happens at all.
+      productEvents.arm();
+      productEvents.record(PRODUCT_EVENT.APP_LAUNCH, { app_version: app.getVersion() });
+      // Luke can run for a week on one launch, so launches alone would
+      // undercount the days he was actually used.
+      productEvents.markDayActive();
       // Always on, like the announcements: the timed check answers to no
       // setting, only to the run — a fixture or capture run sends no network,
       // so it never asks GitHub anything.

--- a/apps/desktop/src/main/ipc/settings-rows.ts
+++ b/apps/desktop/src/main/ipc/settings-rows.ts
@@ -41,8 +41,6 @@ export interface SettingsRowsIpcDependencies {
   workspaceProjectOffered: (providerId: string, providerProjectId: string) => boolean;
   refreshMeetingQuiet: () => void;
   releaseHeldNotices: () => void;
-  /** Moves the counting switch, which is also what records the move itself. */
-  setUsageSharing: (enabled: boolean) => void;
   recordProductEvent: RecordProductEvent;
 }
 
@@ -62,7 +60,6 @@ export function registerSettingsRowsIpc(dependencies: SettingsRowsIpcDependencie
     workspaceProjectOffered,
     refreshMeetingQuiet,
     releaseHeldNotices,
-    setUsageSharing,
     recordProductEvent,
   } = dependencies;
   // The renderer can replace or clear a provider's credential but never reads
@@ -166,9 +163,6 @@ export function registerSettingsRowsIpc(dependencies: SettingsRowsIpcDependencie
       case SETTING_SIDE_EFFECT.MEETING_QUIET:
         refreshMeetingQuiet();
         releaseHeldNotices();
-        break;
-      case SETTING_SIDE_EFFECT.USAGE_SHARING:
-        setUsageSharing(settings.stored.shareUsageData);
         break;
       case SETTING_SIDE_EFFECT.NONE:
         break;

--- a/apps/desktop/src/main/settings-store.test.ts
+++ b/apps/desktop/src/main/settings-store.test.ts
@@ -788,40 +788,6 @@ test("a corrupt meeting quiet value reads as the default rather than as off", as
   assert.equal(appSettingsView(await storeIn(directory).snapshot()).quietDuringMeetings, true);
 });
 
-test("usage sharing is on in a file that never mentions it, and survives a round trip", async (t) => {
-  const directory = await temporaryDirectory(t);
-  // The one setting on by default that sends something, so a file written
-  // before it existed must read as on rather than as an absence.
-  await fs.writeFile(
-    path.join(directory, SETTINGS_FILE_NAME),
-    JSON.stringify({ version: 2, apiKeys: {} }),
-    "utf8",
-  );
-
-  const store = storeIn(directory);
-  assert.equal(appSettingsView(await store.snapshot()).shareUsageData, true);
-  assert.equal(await store.get(APP_SETTING_SCHEMA.shareUsageData.field), true);
-
-  const stopped = await store.set(APP_SETTING_SCHEMA.shareUsageData.field, false);
-  assert.equal(appSettingsView(stopped.settings).shareUsageData, false);
-  assert.equal(await storeIn(directory).get(APP_SETTING_SCHEMA.shareUsageData.field), false);
-});
-
-test("no reset scope reaches usage sharing", async (t) => {
-  const directory = await temporaryDirectory(t);
-  const store = storeIn(directory);
-  await store.set(APP_SETTING_SCHEMA.shareUsageData.field, false);
-
-  for (const scope of Object.values(SETTINGS_RESET_SCOPE)) {
-    await store.resetSettings(scope);
-    assert.equal(
-      appSettingsView(await store.snapshot()).shareUsageData,
-      false,
-      `${scope} must not restore data sharing`,
-    );
-  }
-});
-
 test("keeps each provider's key, environment fallback, and reported source separate", async (t) => {
   const directory = await temporaryDirectory(t);
   const store = storeIn(directory, {

--- a/apps/desktop/src/renderer/AGENTS.md
+++ b/apps/desktop/src/renderer/AGENTS.md
@@ -145,7 +145,7 @@ and a stale entry is one he will misdescribe.
 The facts deliberately cover only what Luke needs to hold a conversation and
 what a spoken ask may do — capabilities, acts, refusals, and their bounds. A
 detail the developer should know but Luke never acts on (the surface's own
-mechanics, a connector's internals, what a privacy switch governs) stays with
+mechanics, a connector's internals, what an update check sends) stays with
 the surface and the settings entries that already describe it, and the guide's
 closing fact has Luke redirect what it leaves out rather than deny it. The
 rule still binds in full at the act level: a new capability, act, refusal, or

--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -552,9 +552,9 @@ export function App(): React.JSX.Element {
    */
   const replayBootstrap = useRef<SessionReplayBootstrap | undefined>(undefined);
   /**
-   * Recording follows the account as well as the switches: a sign-out ends it
-   * rather than leaving it filed under the person who just left, and a sign-in
-   * can start one without waiting for a relaunch.
+   * Recording follows the account: a sign-out ends it rather than leaving it
+   * filed under the person who just left, and a sign-in can start one without
+   * waiting for a relaunch.
    *
    * It rides the raced-bootstrap rule for a sharper reason than the lists do.
    * Sign-out and deletion halt recording before the account is cleared, so the
@@ -567,10 +567,7 @@ export function App(): React.JSX.Element {
     (onChange) => window.sidecar.onSessionReplayChanged(onChange),
     (replay: SessionReplayBootstrap) => {
       replayBootstrap.current = replay;
-      const current = answeredSettings.current;
-      if (current) {
-        applySessionReplay(replay, current.shareUsageData, current.sessionReplay);
-      }
+      applySessionReplay(replay);
     },
   );
 
@@ -578,12 +575,6 @@ export function App(): React.JSX.Element {
     (next: AppSettingsView) => {
       answeredSettings.current = next;
       setSettings(next);
-      // Every settings change lands here — the panel's own writes, a spoken
-      // change, and a push from another window alike — so this is the one
-      // place recording has to follow the switches from.
-      if (replayBootstrap.current) {
-        applySessionReplay(replayBootstrap.current, next.shareUsageData, next.sessionReplay);
-      }
     },
     [setSettings],
   );

--- a/apps/desktop/src/renderer/errand-queue.test.ts
+++ b/apps/desktop/src/renderer/errand-queue.test.ts
@@ -57,8 +57,6 @@ function settings(captions: boolean): AppSettingsView {
     voiceAvailable: false,
     voiceSource: VOICE_SOURCE.ACCOUNT,
     preferBuiltInMicrophone: false,
-    shareUsageData: false,
-    sessionReplay: false,
     calendarAccounts: [],
     showOnAllDisplays: false,
     formFactor: PANEL_FORM_FACTOR.BUBBLE,

--- a/apps/desktop/src/renderer/feedback-panel.tsx
+++ b/apps/desktop/src/renderer/feedback-panel.tsx
@@ -45,7 +45,7 @@ export function FeedbackSection({ control }: { control: FeedbackEntryControl }):
   return (
     <section
       className="settings-section"
-      style={cssCustomProperties({ "--row-index": 5 })}
+      style={cssCustomProperties({ "--row-index": 4 })}
       {...searchAnchorProps(SETTINGS_SEARCH_ROW.FEEDBACK)}
     >
       <h2>

--- a/apps/desktop/src/renderer/luke-errand.test.ts
+++ b/apps/desktop/src/renderer/luke-errand.test.ts
@@ -59,8 +59,6 @@ function settings(): AppSettingsView {
     voiceAvailable: false,
     voiceSource: VOICE_SOURCE.ACCOUNT,
     preferBuiltInMicrophone: false,
-    shareUsageData: false,
-    sessionReplay: false,
     calendarAccounts: [],
     showOnAllDisplays: false,
     formFactor: PANEL_FORM_FACTOR.BUBBLE,

--- a/apps/desktop/src/renderer/luke-guide.test.ts
+++ b/apps/desktop/src/renderer/luke-guide.test.ts
@@ -3,7 +3,6 @@ import test from "node:test";
 import { CREDENTIAL_PROVIDER_ID } from "@sidecar/credentials/vocabulary";
 import {
   APP_SETTING_KIND,
-  APP_TOGGLE_VALUE,
   APP_UPDATE_ACT,
   APP_UPDATE_WAIT,
   type AppGuideSetting,
@@ -68,8 +67,6 @@ function settings(overrides: Partial<AppSettingsView> = {}): AppSettingsView {
       voiceAvailable: true,
       voiceSource: VOICE_SOURCE.ACCOUNT,
       preferBuiltInMicrophone: true,
-      shareUsageData: true,
-      sessionReplay: true,
     },
     overrides,
   );
@@ -833,17 +830,6 @@ test("the feedback fact says what a spoken open may do, and that sending stays b
   assert.match(fact.detail, /no spoken ask can send one/);
 });
 
-test("the usage-data switch is described where it is turned, and is spoken", () => {
-  const setting = buildLukeGuide(guideInput()).settings.find(
-    (candidate) => candidate.id === APP_SETTING_ID.SHARE_USAGE_DATA,
-  );
-
-  assert.ok(setting);
-  assert.equal(setting.adjustable, true);
-  assert.equal(setting.defaultValue, APP_TOGGLE_VALUE.ON);
-  assert.match(setting.manual, /front page, in the Usage data section/);
-});
-
 test("every adjustable setting is carried to the bridge call its row uses", async () => {
   const calls: string[] = [];
   const answered: SettingsUpdateResult = {
@@ -878,8 +864,6 @@ test("every adjustable setting is carried to the bridge call its row uses", asyn
     "formFactor:notch",
     "preferBuiltInMicrophone:true",
     "quietDuringMeetings:true",
-    "sessionReplay:true",
-    "shareUsageData:true",
     "showInDock:true",
     "showOnAllDisplays:true",
     "voice:alloy",

--- a/apps/desktop/src/renderer/luke-guide.ts
+++ b/apps/desktop/src/renderer/luke-guide.ts
@@ -384,7 +384,7 @@ export function buildLukeGuide(input: LukeGuideInput): AppGuideSnapshot {
         "The panel's History tab shows every typed ask, transcribed spoken ask, reply, " +
         "announcement, and session act from this app launch. Luke carries only the 20 most recent " +
         "entries into a call. The full view stays only in this app's memory, is blocked from " +
-        "optional panel recordings, disappears when Luke quits, and can be cleared by hand " +
+        "panel recordings, disappears when Luke quits, and can be cleared by hand " +
         "from that tab. It is not saved or exportable.",
     },
     {

--- a/apps/desktop/src/renderer/session-replay.test.ts
+++ b/apps/desktop/src/renderer/session-replay.test.ts
@@ -13,8 +13,9 @@ import {
 
 /**
  * The gate, on its own. Recording is the one thing Luke sends that a fixed
- * vocabulary does not bound, so every reason it must not start is asserted
- * here rather than left to be read off three `&&`s.
+ * vocabulary does not bound, and no switch stands in front of it, so the one
+ * reason it must not start is asserted here rather than left to be read off
+ * the run mode it arrives from.
  */
 
 function bootstrap(over: Partial<SessionReplayBootstrap> = {}): SessionReplayBootstrap {
@@ -26,22 +27,16 @@ function bootstrap(over: Partial<SessionReplayBootstrap> = {}): SessionReplayBoo
   };
 }
 
-test("both switches on, in a run that may record, is the only yes", () => {
-  assert.equal(sessionReplayWanted(bootstrap(), true, true), true);
+test("an ordinary run records", () => {
+  assert.equal(sessionReplayWanted(bootstrap()), true);
 });
 
-test("a fixture or capture run records nothing whatever the switches say", () => {
+test("a fixture or capture run records nothing", () => {
   // `permitted` is where `runMode.sendsNetwork` arrives, so this is the same
   // suppression the event sender takes — and the reason an evidence run
-  // reaches no network.
-  assert.equal(sessionReplayWanted(bootstrap({ permitted: false }), true, true), false);
-});
-
-test("sharing is the outer switch: recording cannot outlive it", () => {
-  assert.equal(sessionReplayWanted(bootstrap(), false, true), false);
-  // And the recording switch alone still stops it, without giving up counts.
-  assert.equal(sessionReplayWanted(bootstrap(), true, false), false);
-  assert.equal(sessionReplayWanted(bootstrap(), false, false), false);
+  // reaches no network. A deleted account arrives here too, standing
+  // recording down for the rest of the run.
+  assert.equal(sessionReplayWanted(bootstrap({ permitted: false })), false);
 });
 
 test("no account is no reason not to record: the launch is what it is there for", () => {
@@ -49,7 +44,7 @@ test("no account is no reason not to record: the launch is what it is there for"
   // first run goes wrong, and a recording that waited for a sign-in never saw
   // any of it. What the id decides is whom the recording is filed under, not
   // whether there is one.
-  assert.equal(sessionReplayWanted(bootstrap({ accountId: undefined }), true, true), true);
+  assert.equal(sessionReplayWanted(bootstrap({ accountId: undefined })), true);
 });
 
 /**

--- a/apps/desktop/src/renderer/session-replay.ts
+++ b/apps/desktop/src/renderer/session-replay.ts
@@ -24,15 +24,18 @@ import type { SessionReplayBootstrap } from "#shared/wire/session";
  * file and that one blocked subtree are the whole of what decides it. Nothing
  * else stands between what the panel draws and what leaves the machine.
  *
- * What this file decides on its own is only whether to record at all: the
- * main process says whether this run may, and the developer's two switches
- * say whether it does. No account is among those reasons. Recording begins at
- * the first paint of an ordinary launch, before anyone has signed in and
- * through the spoken introduction, because the launch is where what goes
- * wrong goes wrong and a recording that waited for a sign-in never saw it. A
- * session that reaches one is joined to the person there; a session that
- * never does stays anonymous, which is the part `PRIVACY.md` has to say
- * plainly, because such a recording cannot be erased with an account.
+ * What this file decides on its own is only whether to record at all, and the
+ * main process is the whole of that answer: an ordinary run records, a
+ * fixture or capture run does not, and a run whose account was deleted stops.
+ * There is no switch — `PRIVACY.md` is where a user learns this happens, so
+ * that file carries the whole of the disclosure and has to keep doing it. No
+ * account is among the reasons either. Recording begins at the first paint of
+ * an ordinary launch, before anyone has signed in and through the spoken
+ * introduction, because the launch is where what goes wrong goes wrong and a
+ * recording that waited for a sign-in never saw it. A session that reaches
+ * one is joined to the person there; a session that never does stays
+ * anonymous, which is the part `PRIVACY.md` has to say plainly, because such
+ * a recording cannot be erased with an account.
  */
 
 /**
@@ -241,38 +244,24 @@ let started = false;
 let initialized = false;
 
 /**
- * Brings recording into line with what the developer has just asked for, in
- * either direction. Called at bootstrap and again whenever a settings change
- * lands, so a switch turned off stops the recording where it stands rather
- * than at the next launch — and one turned back on starts a new one.
- *
- * Both switches are read live and both are required: `shareUsageData` is the
- * outer consent and a recording is a thing sent, so recording cannot outlive
- * the sharing it travels under.
+ * Brings recording into line with what the run allows, in either direction.
+ * Called at bootstrap and again on every account transition, so a deletion
+ * stops the recording where it stands rather than at the next launch.
  */
-export function applySessionReplay(
-  bootstrap: SessionReplayBootstrap,
-  sharesUsageData: boolean,
-  recordsSurface: boolean,
-): void {
-  const wanted = sessionReplayWanted(bootstrap, sharesUsageData, recordsSurface);
+export function applySessionReplay(bootstrap: SessionReplayBootstrap): void {
+  const wanted = sessionReplayWanted(bootstrap);
   if (wanted === started) return;
   if (wanted) startSessionReplay(bootstrap);
   else stopSessionReplay();
 }
 
 /**
- * Whether recording should be running, given what the run allows and where
- * the developer's two switches stand. Named and exported so the reasons can
- * be asserted one at a time: this decides whether the one thing Luke sends
+ * Whether recording should be running. Named and exported so the one reason
+ * can be asserted on its own: this decides whether the one thing Luke sends
  * that no vocabulary bounds happens at all.
  */
-export function sessionReplayWanted(
-  bootstrap: SessionReplayBootstrap,
-  sharesUsageData: boolean,
-  recordsSurface: boolean,
-): boolean {
-  return bootstrap.permitted && sharesUsageData && recordsSurface;
+export function sessionReplayWanted(bootstrap: SessionReplayBootstrap): boolean {
+  return bootstrap.permitted;
 }
 
 function startSessionReplay(bootstrap: SessionReplayBootstrap): void {
@@ -281,9 +270,9 @@ function startSessionReplay(bootstrap: SessionReplayBootstrap): void {
   started = true;
   if (initialized) {
     // The client is built once per window. A second `init` would not rebuild
-    // it, so a recording resumed after a switch or an account change is
-    // started rather than re-configured — but it must still be told whose
-    // recording it is, because the person may have changed since the last one.
+    // it, so a recording resumed after an account change is started rather
+    // than re-configured — but it must still be told whose recording it is,
+    // because the person may have changed since the last one.
     optIn();
     registerBuild(bootstrap);
     identifyAccount(bootstrap);
@@ -324,8 +313,7 @@ function startSessionReplay(bootstrap: SessionReplayBootstrap): void {
   });
   // Stopping opts out, and that is written into the same storage this client
   // reads at launch — so without opting back in here, a run that had ever
-  // been stopped would come up recording nothing while every switch said it
-  // was recording.
+  // been stopped would come up recording nothing for the rest of the install.
   optIn();
   registerBuild(bootstrap);
   identifyAccount(bootstrap);
@@ -352,14 +340,12 @@ function identifyAccount(bootstrap: SessionReplayBootstrap): void {
  * Opting in and out rather than only starting and stopping the recorder,
  * because this client sends more than recordings. On the library's own
  * configuration it also autocaptures what was clicked and reports unhandled
- * errors, and neither answers to `stopSessionRecording`. The switch says
- * "record my screen", so everything this client would send has to stop with
- * it — otherwise the developer turns off the one thing they were shown and
- * the rest keeps travelling.
+ * errors, and neither answers to `stopSessionRecording`. A stop has to reach
+ * all three — a deleted account whose clicks kept travelling would be the
+ * erasure failing to erase.
  *
- * The opt-in names no event, because the `$opt_in` the library captures by
- * default is a count of the switch moving, which Luke's own counted events
- * already hold.
+ * The opt-in names no event: `$opt_in` counts a consent moving, and nothing
+ * here moves one.
  */
 function optIn(): void {
   posthog.opt_in_capturing({ captureEventName: false });

--- a/apps/desktop/src/renderer/settings-panel.tsx
+++ b/apps/desktop/src/renderer/settings-panel.tsx
@@ -3243,7 +3243,7 @@ function AccountSection({
   };
 
   return (
-    <section className="settings-section" style={cssCustomProperties({ "--row-index": 6 })}>
+    <section className="settings-section" style={cssCustomProperties({ "--row-index": 5 })}>
       <h2>
         <UserIcon />
         Account
@@ -3533,45 +3533,6 @@ function UpdatesSection({
   );
 }
 
-/**
- * The one thing Luke sends without being asked, and the switch for it. It sits
- * beside Updates because both are always-on background behaviours rather than
- * features with a page: the section is where the developer learns the counting
- * happens at all, so the detail says what travels rather than only naming the
- * switch.
- */
-function UsageDataSection({
-  settings,
-  writes,
-}: {
-  settings: AppSettingsView;
-  writes: SettingsWrites;
-}): React.JSX.Element {
-  return (
-    <section className="settings-section" style={cssCustomProperties({ "--row-index": 4 })}>
-      <h2>
-        <ShieldIcon />
-        Usage data
-      </h2>
-      <SchemaSettingRows
-        page={SCHEMA_SETTINGS_PAGE.ROOT}
-        settings={settings}
-        writes={writes}
-        exclude={[APP_SETTING_SCHEMA.voiceSource.field]}
-        details={{
-          [APP_SETTING_SCHEMA.shareUsageData.field]:
-            "Counts of feature use, tied to your account. Never session contents.",
-          [APP_SETTING_SCHEMA.sessionReplay.field]:
-            "A video of the panel: session titles, summaries, and your name. Not what you type.",
-        }}
-        disabled={{
-          [APP_SETTING_SCHEMA.sessionReplay.field]: !settings.shareUsageData,
-        }}
-      />
-    </section>
-  );
-}
-
 export function SettingsPanel({
   account,
   onSignOut,
@@ -3837,8 +3798,6 @@ export function SettingsPanel({
         <>
           {updateLeads ? null : <UpdatesSection control={updates} rowIndex={3} />}
 
-          {settings ? <UsageDataSection settings={settings} writes={writes} /> : null}
-
           <FeedbackSection control={feedback} />
 
           {/* The account and the two ways out of it, last of the sections:
@@ -3856,7 +3815,7 @@ export function SettingsPanel({
           <button
             type="button"
             className="quit-button"
-            style={cssCustomProperties({ "--row-index": 7 })}
+            style={cssCustomProperties({ "--row-index": 6 })}
             {...searchAnchorProps(SETTINGS_SEARCH_ROW.QUIT)}
             onClick={onQuit}
           >

--- a/apps/desktop/src/renderer/settings-search.test.ts
+++ b/apps/desktop/src/renderer/settings-search.test.ts
@@ -46,8 +46,6 @@ function settings(overrides: Partial<AppSettingsView> = {}): AppSettingsView {
       linearSignInAvailable: false,
       calendarAccounts: [],
       showOnAllDisplays: false,
-      shareUsageData: true,
-      sessionReplay: true,
       formFactor: PANEL_FORM_FACTOR.BUBBLE,
     },
     overrides,

--- a/apps/desktop/src/renderer/settings-search.tsx
+++ b/apps/desktop/src/renderer/settings-search.tsx
@@ -38,7 +38,6 @@ import {
   PlugIcon,
   PowerIcon,
   SearchIcon,
-  ShieldIcon,
   UserIcon,
 } from "./settings-icons";
 import {
@@ -241,12 +240,11 @@ const RESULT_PAGE_WORD = {
 const PAGE_ORDER: readonly SettingsView[] = [SETTINGS_VIEW.ROOT, ...SETTINGS_SUBVIEW_LIST];
 
 /**
- * The two front-page settings wear their sections' own glyphs, because the
- * headless front-page group has no head to carry one for them.
+ * The front-page setting wears its section's own glyph, because the headless
+ * front-page group has no head to carry one for it.
  */
 const ROOT_SETTING_ICON = {
   [APP_SETTING_ID.VOICE_SOURCE]: <LukeIcon />,
-  [APP_SETTING_ID.SHARE_USAGE_DATA]: <ShieldIcon />,
 } satisfies Partial<Record<AppSettingId, React.JSX.Element>>;
 
 /** The words every shortcut row can be found by, beside its own name. */

--- a/packages/analytics/AGENTS.md
+++ b/packages/analytics/AGENTS.md
@@ -54,7 +54,6 @@ governed.
 
 `PRIVACY.md` describes all three in kind: fixed names and values with no free
 text for the counts, and a recording of Luke's own panel that shows what the
-panel showed, with the clicks and errors that ride beside it. The counts have
-their own switch and the other two share the recording one, both on by
-default. It moves when any of them stops being true, not when an event is
-added.
+panel showed, with the clicks and errors that ride beside it. None of the
+three has a switch, so that file is the whole of what a user is told. It moves
+when any of them stops being true, not when an event is added.

--- a/packages/analytics/src/product-events.ts
+++ b/packages/analytics/src/product-events.ts
@@ -63,8 +63,6 @@ export const PRODUCT_EVENT = {
   VOICE_ANNOUNCEMENT_SPEAK: "voice:announcement_speak",
   VOICE_FIRST_ANNOUNCEMENT: "voice:first_announcement",
   SETTING_UPDATE: "setting:update",
-  USAGE_SHARING_STOP: "usage:sharing_stop",
-  USAGE_SHARING_RESUME: "usage:sharing_resume",
 } as const;
 
 export type ProductEventName = (typeof PRODUCT_EVENT)[keyof typeof PRODUCT_EVENT];
@@ -523,8 +521,6 @@ export const PRODUCT_EVENT_PROPERTIES = {
     PRODUCT_EVENT_PROPERTY.SETTING_ID,
     PRODUCT_EVENT_PROPERTY.SETTING_VALUE,
   ],
-  [PRODUCT_EVENT.USAGE_SHARING_STOP]: [],
-  [PRODUCT_EVENT.USAGE_SHARING_RESUME]: [],
 } as const satisfies { [Name in ProductEventName]: readonly ProductEventProperty[] };
 
 /** Exactly the properties one event carries, each with its own value type. */

--- a/packages/analytics/src/sender.test.ts
+++ b/packages/analytics/src/sender.test.ts
@@ -44,7 +44,7 @@ function sharingSender(
   respond?: (request: RecordedRequest) => Response,
 ) {
   const built = senderWith(overrides, respond);
-  built.sender.setSharing(true);
+  built.sender.arm();
   return built;
 }
 
@@ -83,31 +83,12 @@ test("a flush posts one bearer-authenticated batch and empties the queue", async
   assert.equal(requests.length, 1);
 });
 
-test("arming records no transition; turning it off records one stop and then goes quiet", async () => {
+test("a sender that was never armed sends nothing", async () => {
   const { sender, requests } = senderWith();
-  sender.setSharing(true);
-  sender.setSharing(true);
-  await sender.flush();
-  assert.deepEqual(requests, []);
-
-  sender.setSharing(false);
-  await sender.flush();
-  assert.equal(requests.length, 1);
-  assert.deepEqual(sentEvents(recordedRequest(requests)), [
-    { name: PRODUCT_EVENT.USAGE_SHARING_STOP, at: NOON, properties: {} },
-  ]);
-
   sender.record(PRODUCT_EVENT.APP_LAUNCH, { app_version: APP_VERSION });
   sender.markDayActive();
   await sender.flush();
-  assert.equal(requests.length, 1);
-
-  sender.setSharing(true);
-  await sender.flush();
-  assert.equal(requests.length, 2);
-  assert.deepEqual(sentEvents(recordedRequest(requests, 1)), [
-    { name: PRODUCT_EVENT.USAGE_SHARING_RESUME, at: NOON, properties: {} },
-  ]);
+  assert.deepEqual(requests, []);
 });
 
 test("a 401 refreshes and retries once, and the same token twice does not", async () => {
@@ -130,7 +111,7 @@ test("a 401 refreshes and retries once, and the same token twice does not", asyn
     fetch,
     now: () => NOON,
   });
-  sender.setSharing(true);
+  sender.arm();
   sender.record(PRODUCT_EVENT.APP_LAUNCH, { app_version: APP_VERSION });
   await sender.flush();
 
@@ -144,7 +125,7 @@ test("a 401 refreshes and retries once, and the same token twice does not", asyn
     { readAccessToken: async () => "same" },
     () => new Response("{}", { status: HTTP_STATUS.UNAUTHORIZED }),
   );
-  stuck.sender.setSharing(true);
+  stuck.sender.arm();
   stuck.sender.record(PRODUCT_EVENT.APP_LAUNCH, { app_version: APP_VERSION });
   await stuck.sender.flush();
   assert.equal(stuck.requests.length, 1);
@@ -163,7 +144,7 @@ test("a failed send drops its batch rather than retrying it behind the next one"
     fetch,
     now: () => NOON,
   });
-  sender.setSharing(true);
+  sender.arm();
   sender.record(PRODUCT_EVENT.APP_LAUNCH, { app_version: APP_VERSION });
   await sender.flush();
   assert.equal(requests.length, 1);
@@ -188,7 +169,7 @@ test("signed out the queue waits rather than being spent", async () => {
     fetch,
     now: () => NOON,
   });
-  sender.setSharing(true);
+  sender.arm();
   sender.record(PRODUCT_EVENT.APP_LAUNCH, { app_version: APP_VERSION });
   await sender.flush();
   assert.deepEqual(requests, []);

--- a/packages/analytics/src/sender.ts
+++ b/packages/analytics/src/sender.ts
@@ -85,8 +85,7 @@ export class ProductEventSender {
   readonly #queue: ProductEvent[] = [];
   /** Nested rather than an interpolated key: the name and the discriminator stay apart. */
   readonly #recordedDays = new Map<ProductEventName, Map<string, string>>();
-  #sharing = false;
-  #sharingKnown = false;
+  #armed = false;
   #timer: NodeJS.Timeout | undefined;
   #inFlight: Promise<void> | undefined;
 
@@ -166,27 +165,12 @@ export class ProductEventSender {
   }
 
   /**
-   * Arms or moves the switch. The first call is the settings file answering
-   * and records no transition — there is no change yet to count. A later turn
-   * to off records the stop *while sharing still stands* and flushes it: a
-   * stop recorded after the switch moved could never be sent, and the opt-out
-   * rate would be unmeasurable, visible only as people who stayed.
+   * Arms counting. The sender comes up disarmed rather than assuming, so
+   * nothing recorded while the app is still standing itself up can be sent
+   * before the launch has decided whether this run counts at all.
    */
-  setSharing(enabled: boolean): void {
-    if (!this.#sharingKnown) {
-      this.#sharingKnown = true;
-      this.#sharing = enabled;
-      return;
-    }
-    if (this.#sharing === enabled) return;
-    if (enabled) {
-      this.#sharing = true;
-      this.record(PRODUCT_EVENT.USAGE_SHARING_RESUME, {});
-      return;
-    }
-    this.record(PRODUCT_EVENT.USAGE_SHARING_STOP, {});
-    this.#sharing = false;
-    void this.flush();
+  arm(): void {
+    this.#armed = true;
   }
 
   /** Starts the timed flush. The timer never holds the process open. */
@@ -230,7 +214,7 @@ export class ProductEventSender {
   }
 
   #allowed(): boolean {
-    return this.#sends && this.#sharing;
+    return this.#sends && this.#armed;
   }
 
   async #send(): Promise<void> {

--- a/packages/guide/src/app-settings.ts
+++ b/packages/guide/src/app-settings.ts
@@ -20,8 +20,6 @@ export const APP_SETTING_ID = {
   WORKSPACE_AGENT_EFFORT: "workspace_agent_effort",
   SUPERSET_AGENT: "superset_agent",
   VOICE_SOURCE: "voice_source",
-  SHARE_USAGE_DATA: "share_usage_data",
-  SESSION_REPLAY: "session_replay",
   TALK_HOTKEY: "talk_hotkey",
   ASK_HOTKEY: "ask_hotkey",
   STOP_HOTKEY: "stop_hotkey",

--- a/packages/settings/src/schema.ts
+++ b/packages/settings/src/schema.ts
@@ -93,7 +93,6 @@ export const SETTING_SIDE_EFFECT = {
   MEDIA_DUCK: "media-duck",
   VOICE_SOURCE: "voice-source",
   MEETING_QUIET: "meeting-quiet",
-  USAGE_SHARING: "usage-sharing",
 } as const;
 
 export type SettingSideEffect = (typeof SETTING_SIDE_EFFECT)[keyof typeof SETTING_SIDE_EFFECT];
@@ -135,7 +134,6 @@ interface SettingEntryDefinition<Value> {
 const SETTINGS_TAB = "the panel's Settings tab";
 const VOICE_PAGE = `${SETTINGS_TAB}, on its Voice page`;
 const VOICE_SOURCE_SECTION = `${SETTINGS_TAB}, on its front page, in the What Luke runs on section at the top`;
-const USAGE_DATA_SECTION = `${SETTINGS_TAB}, on its front page, in the Usage data section`;
 const APPEARANCE_PAGE = `${SETTINGS_TAB}, on its Appearance page`;
 const CONNECTIONS_PAGE = `${SETTINGS_TAB}, on its Connections page`;
 const CONDUCTOR_ROW_PATH = `the Conductor row under Providers, in ${CONNECTIONS_PAGE} — drawn once Conductor is connected`;
@@ -587,71 +585,6 @@ export const APP_SETTING_SCHEMA = {
     mainProcessSideEffect: SETTING_SIDE_EFFECT.DISPLAYS,
     spokenValue: (value: string) => value === APP_TOGGLE_VALUE.ON,
     analytics: { id: APP_SETTING_ID.SHOW_ON_ALL_DISPLAYS, value: toggleAnalytics },
-  },
-  shareUsageData: {
-    field: "shareUsageData",
-    default: true,
-    guard: boolean(true),
-    settingsPage: SETTINGS_PAGE.ROOT,
-    // No reset scope on purpose: a "reset appearance" that quietly turned
-    // sharing back on would be a consent the developer never gave.
-    guideEntry: settingGuideEntry(
-      "shareUsageData",
-      [APP_SETTING_ID.SHARE_USAGE_DATA],
-      (settings, defaultValue) => ({
-        id: APP_SETTING_ID.SHARE_USAGE_DATA,
-        label: "Share usage data",
-        description:
-          "Whether Luke counts how his own features are used — a launch, a provider connected, " +
-          "a call opened — and sends those counts to Luke's own service, tied to the signed-in " +
-          "account by name and email. Every event and value is fixed by this build, so nothing " +
-          "about a session and nothing typed or spoken can travel in one. On to begin with.",
-        kind: APP_SETTING_KIND.TOGGLE,
-        value: appToggleText(guideValue<boolean>(settings, "shareUsageData")),
-        defaultValue: appToggleText(defaultValue),
-        adjustable: true,
-        manual: USAGE_DATA_SECTION,
-      }),
-    ),
-    mainProcessSideEffect: SETTING_SIDE_EFFECT.USAGE_SHARING,
-    spokenValue: (value: string) => value === APP_TOGGLE_VALUE.ON,
-    analytics: { id: APP_SETTING_ID.SHARE_USAGE_DATA, value: toggleAnalytics },
-  },
-  sessionReplay: {
-    field: "sessionReplay",
-    default: true,
-    guard: boolean(true),
-    settingsPage: SETTINGS_PAGE.ROOT,
-    // No reset scope, for the reason sharing has none: a reset that turned
-    // recording back on would be a consent nobody gave. It is also why this
-    // switch stands on its own rather than riding the sharing one — sharing
-    // off stops recording too, but recording off has to be reachable without
-    // giving up the counts.
-    guideEntry: settingGuideEntry(
-      "sessionReplay",
-      [APP_SETTING_ID.SESSION_REPLAY],
-      (settings, defaultValue) => ({
-        id: APP_SETTING_ID.SESSION_REPLAY,
-        label: "Record my screen in Luke",
-        description:
-          "Whether Luke records what his own panel draws and sends it, as a video of the " +
-          "panel rather than a count. Everything drawn is in it: session titles, branches, " +
-          "summaries, error lines, and your own name and address. Only what you type into a " +
-          "field is hidden. It is the panel alone and never the rest of your screen. Off " +
-          "whenever Share usage data is off. On to begin with.",
-        kind: APP_SETTING_KIND.TOGGLE,
-        value: appToggleText(guideValue<boolean>(settings, "sessionReplay")),
-        defaultValue: appToggleText(defaultValue),
-        adjustable: true,
-        manual: USAGE_DATA_SECTION,
-      }),
-    ),
-    // None in the main process: the recorder lives in the renderer, which
-    // brings itself into line from the settings change it is already handed.
-    // A side effect declared here would be one the switch never runs.
-    mainProcessSideEffect: SETTING_SIDE_EFFECT.NONE,
-    spokenValue: (value: string) => value === APP_TOGGLE_VALUE.ON,
-    analytics: { id: APP_SETTING_ID.SESSION_REPLAY, value: toggleAnalytics },
   },
   formFactor: {
     field: "formFactor",


### PR DESCRIPTION
## Summary

- Removes the Usage data settings section and both switches behind it (`Share usage data`, `Record my screen in Luke`), so counting and screen recording now answer to the run mode alone — an ordinary launch does both, a fixture or capture run still does neither.
- Deletes what only existed to serve the switches: their schema entries and guide ids, the `USAGE_SHARING` side effect, the two events that counted nothing but a switch moving, and the settings-driven re-apply that ran on every settings push; `setSharing(boolean)` becomes `arm()` so disarming is unrepresentable.
- `PRIVACY.md` is now the whole of what a user is told about either stream, so it drops the paragraph about switches and `AGENTS.md`, `packages/analytics/AGENTS.md`, and the renderer's own notes say that instead of pointing at controls that no longer exist.

## Evidence

- Platform-independent checks: `./scripts/check.sh` passed
- macOS Electron verification (`./scripts/verify.sh`): passed

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/33140056780/artifacts/9673623041) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/33140056780)

- Commit: `cc085be9124b589ab42ad434e676fe561ea91881`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

### Physical-device evidence

- Screenshot or screen recording: `not attached`
- Physical-notch check: `not performed`
- Device/display configuration: `not recorded`

## Notes

- The evidence harness captures the panel in six states and has no Settings-front-page profile, so the removed section is covered by tests and typecheck rather than by a screenshot; the six captures were inspected and the panel is unchanged.
- Pre-existing and untouched: `applySessionReplay` returns early when `wanted === started`, so a sign-in landing during an anonymous recording never calls `identifyAccount`, contradicting the attachment claim in `PRIVACY.md`. With the switches gone, account deletion is the only control left, so this deserves its own fix.
- Always-on recording without an opt-out is worth a legal read before this reaches EU/UK users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)