### PR TITLE
fix(voice): stop showing a trim refusal the developer cannot act on

### DIFF
--- a/apps/desktop/src/renderer/realtime-session.test.ts
+++ b/apps/desktop/src/renderer/realtime-session.test.ts
@@ -2670,15 +2670,17 @@ test("a stop does not surface the server refusing a trim past the audio's end", 
   assert.ok(truncate);
 
   // The audible clock runs on the wall, so a stop landing at the reply's very
-  // end can measure past the audio itself. The refusal means every word was
-  // heard and the record is already right — nothing the developer can or
-  // should act on.
+  // end can measure past the audio itself. The refusal names no event — a null
+  // `event_id` is the shape the service actually sends — so the sentence is
+  // all there is to recognize it by, and nothing about it is the developer's
+  // to act on.
   context.emit({
     type: REALTIME_SERVER_EVENT.ERROR,
     error: {
       type: "invalid_request_error",
+      code: "invalid_value",
       message: "Audio content of 1500ms is already shorter than 2000ms",
-      event_id: truncate?.event_id,
+      event_id: null,
     },
   });
 

--- a/apps/desktop/src/renderer/realtime-session.ts
+++ b/apps/desktop/src/renderer/realtime-session.ts
@@ -2244,11 +2244,9 @@ export class RealtimeVoiceSession {
 
   /**
    * Handles an error answering one interruption without letting an old reply's
-   * failure finish the new turn that interrupted it. Two refusals are quiet —
-   * the documented no-active-response race, and a trim refused for asking past
-   * the audio's end, which means the reply was heard whole and the record is
-   * already right; every other refusal still reaches the developer as a real
-   * voice error.
+   * failure finish the new turn that interrupted it. The documented
+   * no-active-response race is quiet; every other refusal still reaches the
+   * developer as a real voice error.
    */
   #interruptionError(event: { message: string; eventId?: string; errorType?: string }): boolean {
     if (event.eventId === undefined) return false;
@@ -2259,11 +2257,7 @@ export class RealtimeVoiceSession {
       kind === INTERRUPTION_EVENT_KIND.CANCELLATION &&
       event.errorType === "invalid_request_error" &&
       NO_ACTIVE_RESPONSE_CANCELLATION.test(event.message);
-    const benignTruncation =
-      kind === INTERRUPTION_EVENT_KIND.TRUNCATION &&
-      event.errorType === "invalid_request_error" &&
-      TRUNCATION_PAST_AUDIO_END.test(event.message);
-    if (!benignCancellation && !benignTruncation) this.#options.onError(event.message);
+    if (!benignCancellation) this.#options.onError(event.message);
     return true;
   }
 
@@ -2477,6 +2471,11 @@ export class RealtimeVoiceSession {
         if (event.itemId) this.#settleSupersede(event.itemId);
         return;
       case REALTIME_SERVER_EVENT.ERROR:
+        // Only Luke's own trim can draw a past-the-end refusal, the service
+        // clamps and truncates anyway, and it names no event this could match
+        // it by — `error.event_id` is null on the wire. Recognized by its
+        // sentence and never shown.
+        if (TRUNCATION_PAST_AUDIO_END.test(event.message)) return;
         // A delete this call issued can be answered with an error rather than a
         // deletion, because the item was already gone — evicted at the window's
         // edge is the way that happens. It is nothing the developer did and

--- a/packages/realtime/src/realtime-protocol.ts
+++ b/packages/realtime/src/realtime-protocol.ts
@@ -301,10 +301,10 @@ export function cancelResponseEvents(input: {
  *
  * `audioEndMs` is how long the reply was audible, measured on a wall clock —
  * which can outrun the audio itself when playback stalls, or when the stop
- * lands at the reply's very end. The server refuses a trim past the end, so
- * the event carries a name for the session to recognize that refusal as its
- * own: a reply refused this way was heard whole, and the record it would have
- * corrected is already right.
+ * lands at the reply's very end. The server answers such a trim with a refusal
+ * and then clamps it to the audio's real end and truncates anyway, so the
+ * record is right either way; the refusal names no event of its own on the
+ * wire, and the session recognizes it by its sentence instead.
  */
 export function truncateResponseEvents(input: {
   itemId: string;


### PR DESCRIPTION
## What

Cutting Luke off mid-reply put a red voice error under the housing:

> Audio content of 9800ms is already shorter than 11579ms

It now stays off the panel.

## Why it happened

A stop sends `conversation.item.truncate` to correct the server's record to what was actually heard. It measures on a wall clock, which can outrun the audio itself. The service refuses a past-the-end trim, **then clamps to the audio's real end and truncates anyway** — so the record is right either way and the refusal is about nothing the developer did or could act on.

#335 already meant to keep this quiet, but recognized the refusal by the client event id echoed back in `error.event_id`. The service sends `null` there, so the guard never matched. From a development trace:

```
03:41:17.092 client  conversation.item.truncate   audio_end_ms: 11579
03:41:17.128 server  error  "Audio content of 9800ms is already shorter than 11579ms"   error.event_id: null
03:41:17.139 server  conversation.item.truncated  audio_end_ms: 9840   ← applied regardless
```

## What changed

The refusal is recognized by its sentence, before anything can draw it. The id-matching `benignTruncation` branch it replaces is removed, as is the doc on `truncateResponseEvents` claiming the event carries a name the session recognizes the refusal by — the false premise behind the bug.

Only this message is silenced. Every other voice error still reaches the developer.

## Testing

The existing test for this passed because its fixture echoed an event id the service does not send. Corrected to the observed shape, it fails on `main` and passes here.

`./scripts/check.sh` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/33140663114/artifacts/9673841166) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/33140663114)

- Commit: `9af038fcd49e2ca1b9af21cfa49a42503230860a`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
