### PR TITLE
refactor(attention): group the evaluator instructions into headed sections

### DIFF
--- a/packages/attention/src/attention-prompt.ts
+++ b/packages/attention/src/attention-prompt.ts
@@ -34,14 +34,18 @@ export const AGENT_WORK_LANGUAGE_INSTRUCTION =
 
 const ATTENTION_INSTRUCTION_LINES: readonly string[] = [
   "As the engineering manager for the user's coding agents, decide whether Luke should speak about an update.",
+  "",
+  "When to speak:",
+  "- Default to silence. Speak only for a concrete question, permission or approval, material error or risk, material outcome that changes what happens next, or an answer to the user's standing ask. A status change, completion, or recap alone is not enough.",
+  "- A session waiting on automation it set in motion — CI, a merge queue, a watcher it left running — is not waiting on the developer: nothing they reply can move it, so stay silent and let the automation's outcome be the development.",
+  "- When a user's standing ask is answered, answer it directly without restating the ask, speak, and set answers_ask to true; otherwise set it to false.",
+  "",
+  "How to word it:",
   `- ${HUMAN_VOICE_INSTRUCTION}`,
   `- ${CTO_RELEVANCE_INSTRUCTION}`,
-  "- Default to silence. Speak only for a concrete question, permission or approval, material error or risk, material outcome that changes what happens next, or an answer to the user's standing ask. A status change, completion, or recap alone is not enough.",
   "- If speaking, give one short, natural sentence, not a status report. State only what the CTO needs to know; add no advice or next step.",
   `- ${AGENT_WORK_LANGUAGE_INSTRUCTION}`,
   "- Treat waiting as actionable only when the recap or context shows a concrete question, permission, or approval. Before any question, name the agent's work and briefly explain the specific situation or decision topic that makes the interruption relevant; then give the exact question. Never open with a bare question or a generic statement that the agent needs input, needs a decision, is waiting, or cannot continue.",
-  "- A session waiting on automation it set in motion — CI, a merge queue, a watcher it left running — is not waiting on the developer: nothing they reply can move it, so stay silent and let the automation's outcome be the development.",
-  "- When a user's standing ask is answered, answer it directly without restating the ask, speak, and set answers_ask to true; otherwise set it to false.",
 ];
 
 /**


### PR DESCRIPTION
## What

`ATTENTION_INSTRUCTION_LINES` was a flat list of eight bullets under one opening line, mixing three unrelated kinds of instruction with no boundary between them: voice/tone, relevance, and edge-case logic. This groups them under the same headed-section shape `REALTIME_INSTRUCTION_HEAD` in `packages/realtime/src/realtime-protocol.ts` already uses, so the two prompts share a shape as well as their constants.

**When to speak:** the silence default, the CI/automation rule, the standing-ask rule.

**How to word it:** `HUMAN_VOICE_INSTRUCTION`, `CTO_RELEVANCE_INSTRUCTION`, the one-sentence limit, `AGENT_WORK_LANGUAGE_INSTRUCTION`, the question-framing rule.

Every line's text survives verbatim. Only order and the heading and blank-separator entries are new; nothing is reworded, merged, or dropped, and the three shared constants are untouched because `realtime-protocol.ts` imports them.

## Notes

The "Treat waiting as actionable only when…" line opens with a relevance gate and then spends its length on wording. It landed under **How to word it** rather than being split or duplicated; the trade-off is that its first clause now sits away from the CI rule it pairs with.

`CTO_RELEVANCE_INSTRUCTION` also reads as relevance, but sits under wording to match `REALTIME_INSTRUCTION_HEAD`, which files the identical constant under "How to speak:".

## Verification

Portable-only change, so `./scripts/check.sh` is the completion bar; no UI or macOS surface moves, so `verify.sh` is not required.

`./scripts/check.sh` — exit 0, 25 suites reporting `fail 0`, no failing tests.

`attentionInstructions()` still returns a single newline-joined string. `attentionUpdateInput()`, the wire validators, and `ATTENTION_DECISION_SCHEMA` are untouched. No test pinned the rendered text — `packages/devtrace/src/unbox-export.test.ts:175` compares against `attentionInstructions()` itself — so no test needed updating or loosening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/33140725830/artifacts/9673869800) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/33140725830)

- Commit: `74670c0ff2b3be825c699f9ed6cba9a521d051ac`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
