### PR TITLE
feat(hosted): add the provider-key vault

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -45,6 +45,16 @@ before you sign in is attached to your account if you sign in while it is
 running. One that never reaches a sign-in belongs to nobody, so deleting your
 account does not reach it — we have no way to tell it was yours.
 
+**Provider API keys (server-side vault).** If you choose to sync a provider API
+key to Luke's hosted service, we store it encrypted in our own database using
+AES-256-GCM with a server-only secret. The key is never returned to any caller:
+there is no endpoint that reads it back, and no code path that decrypts it for
+any purpose other than the observation or acts you explicitly request through
+that provider. The server-side use of these keys ships as a separate feature;
+this describes only the storage. You can delete a key at any time from the
+provider's row in Settings, and it is deleted alongside your account if you
+delete that.
+
 **Feedback.** If you use the feedback form, we receive what you typed, the name
 and email you signed it with, and any screenshots you attached.
 
@@ -89,18 +99,23 @@ your network address, as it does for the app's recordings.
 
 ## Storage
 
-Your settings, provider API keys, and calendar access stay on your Mac. Keys and
-calendar access are encrypted in the macOS Keychain. Your account information is
-held by our own service, and usage counts and recordings by PostHog.
+Your settings, local provider API keys, and calendar access stay on your Mac.
+Local keys and calendar access are encrypted in the macOS Keychain. Provider
+API keys you sync to the hosted service are stored encrypted in our own
+database, as described above. Your account information is held by our own
+service, and usage counts and recordings by PostHog.
 
 ## Your choices
 
 - Disconnect any provider, issue tracker, or calendar to stop it being read.
 - Delete your OpenAI key to turn voice off.
+- Delete any synced provider API key from that provider's row in Settings. Keys
+  are also deleted when you delete your account.
 - Luke does not use your microphone until you start a turn.
 - Delete your account from the Account section in Settings. This erases your
-  account, your sign-in records, and your usage counts, and asks PostHog to
-  erase your usage data and recordings. It does not reach a recording that was
+  account, your sign-in records, your usage counts, and any provider API keys
+  you synced to the hosted service, and asks PostHog to erase your usage data
+  and recordings. It does not reach a recording that was
   never attached to your account, as described above. Luke stops recording for
   the rest of the session, and starts again the next time you open it or sign
   in. Deleting does not affect your Google or GitHub account, and anything

--- a/apps/web/api/vault/key.ts
+++ b/apps/web/api/vault/key.ts
@@ -1,0 +1,56 @@
+import { and, eq } from "drizzle-orm";
+import { auth } from "../../server/auth.js";
+import { getDatabase } from "../../server/db/index.js";
+import { providerKey } from "../../server/db/schema.js";
+import { hostedUserId, oauthUserInfoFromAuthAnswer } from "../../server/hosted/bearer.js";
+import { VAULT_ENCRYPTION_ENVIRONMENT } from "../../server/hosted/encryption.js";
+import {
+  handleVaultKeyDelete,
+  handleVaultKeyStore,
+  type VaultKeyDeleteOptions,
+  type VaultKeyStoreOptions,
+} from "../../server/hosted/vault.js";
+
+function resolveUserId(request: Request) {
+  return hostedUserId(request, async (input) =>
+    oauthUserInfoFromAuthAnswer(await auth.api.oauth2UserInfo(input)),
+  );
+}
+
+const encryptionSecret = process.env[VAULT_ENCRYPTION_ENVIRONMENT.SECRET];
+
+export default {
+  async fetch(request: Request): Promise<Response> {
+    if (request.method === "DELETE") {
+      const options: VaultKeyDeleteOptions = {
+        request,
+        resolveUserId,
+        encryptionSecret,
+        deleteKey: async (userId, providerId) => {
+          const result = await getDatabase()
+            .delete(providerKey)
+            .where(and(eq(providerKey.userId, userId), eq(providerKey.providerId, providerId)))
+            .returning({ userId: providerKey.userId });
+          return result.length > 0;
+        },
+      };
+      return handleVaultKeyDelete(options);
+    }
+
+    const options: VaultKeyStoreOptions = {
+      request,
+      resolveUserId,
+      encryptionSecret,
+      storeKey: async (userId, providerId, ciphertext, hint) => {
+        await getDatabase()
+          .insert(providerKey)
+          .values({ userId, providerId, ciphertext, hint, updatedAt: new Date() })
+          .onConflictDoUpdate({
+            target: [providerKey.userId, providerKey.providerId],
+            set: { ciphertext, hint, updatedAt: new Date() },
+          });
+      },
+    };
+    return handleVaultKeyStore(options);
+  },
+};

--- a/apps/web/api/vault/keys.ts
+++ b/apps/web/api/vault/keys.ts
@@ -1,0 +1,30 @@
+import { eq } from "drizzle-orm";
+import { auth } from "../../server/auth.js";
+import { getDatabase } from "../../server/db/index.js";
+import { providerKey } from "../../server/db/schema.js";
+import { hostedUserId, oauthUserInfoFromAuthAnswer } from "../../server/hosted/bearer.js";
+import { VAULT_ENCRYPTION_ENVIRONMENT } from "../../server/hosted/encryption.js";
+import { handleVaultKeysList, type VaultKeysListOptions } from "../../server/hosted/vault.js";
+
+export default {
+  fetch(request: Request): Promise<Response> {
+    const options: VaultKeysListOptions = {
+      request,
+      resolveUserId: (incoming) =>
+        hostedUserId(incoming, async (input) =>
+          oauthUserInfoFromAuthAnswer(await auth.api.oauth2UserInfo(input)),
+        ),
+      encryptionSecret: process.env[VAULT_ENCRYPTION_ENVIRONMENT.SECRET],
+      listKeys: async (userId) =>
+        getDatabase()
+          .select({
+            providerId: providerKey.providerId,
+            hint: providerKey.hint,
+            updatedAt: providerKey.updatedAt,
+          })
+          .from(providerKey)
+          .where(eq(providerKey.userId, userId)),
+    };
+    return handleVaultKeysList(options);
+  },
+};

--- a/apps/web/drizzle/0005_crimson_vault.sql
+++ b/apps/web/drizzle/0005_crimson_vault.sql
@@ -1,0 +1,11 @@
+CREATE TABLE "provider_key" (
+	"user_id" text NOT NULL,
+	"provider_id" text NOT NULL,
+	"ciphertext" text NOT NULL,
+	"hint" text NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "provider_key_user_id_provider_id_pk" PRIMARY KEY("user_id","provider_id")
+);
+--> statement-breakpoint
+ALTER TABLE "provider_key" ADD CONSTRAINT "provider_key_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;

--- a/apps/web/drizzle/meta/0005_snapshot.json
+++ b/apps/web/drizzle/meta/0005_snapshot.json
@@ -1,0 +1,1291 @@
+{
+  "id": "1a9308cf-ebf9-430d-b618-b97ea36cac0e",
+  "prevId": "83adcea9-a04b-484a-a376-35faf567e53c",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.jwks": {
+      "name": "jwks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_key": {
+          "name": "private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_access_token": {
+      "name": "oauth_access_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_id": {
+          "name": "refresh_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "oauthAccessToken_clientId_idx": {
+          "name": "oauthAccessToken_clientId_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthAccessToken_sessionId_idx": {
+          "name": "oauthAccessToken_sessionId_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthAccessToken_userId_idx": {
+          "name": "oauthAccessToken_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthAccessToken_refreshId_idx": {
+          "name": "oauthAccessToken_refreshId_idx",
+          "columns": [
+            {
+              "expression": "refresh_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_access_token_client_id_oauth_client_client_id_fk": {
+          "name": "oauth_access_token_client_id_oauth_client_client_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "oauth_client",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["client_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_session_id_session_id_fk": {
+          "name": "oauth_access_token_session_id_session_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "session",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_user_id_user_id_fk": {
+          "name": "oauth_access_token_user_id_user_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_refresh_id_oauth_refresh_token_id_fk": {
+          "name": "oauth_access_token_refresh_id_oauth_refresh_token_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "oauth_refresh_token",
+          "columnsFrom": ["refresh_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_access_token_token_unique": {
+          "name": "oauth_access_token_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_client": {
+      "name": "oauth_client",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "skip_consent": {
+          "name": "skip_consent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enable_end_session": {
+          "name": "enable_end_session",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject_type": {
+          "name": "subject_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contacts": {
+          "name": "contacts",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tos": {
+          "name": "tos",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "policy": {
+          "name": "policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_id": {
+          "name": "software_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_version": {
+          "name": "software_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_statement": {
+          "name": "software_statement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_logout_redirect_uris": {
+          "name": "post_logout_redirect_uris",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_endpoint_auth_method": {
+          "name": "token_endpoint_auth_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grant_types": {
+          "name": "grant_types",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_types": {
+          "name": "response_types",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public": {
+          "name": "public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "require_pkce": {
+          "name": "require_pkce",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "oauthClient_userId_idx": {
+          "name": "oauthClient_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_client_user_id_user_id_fk": {
+          "name": "oauth_client_user_id_user_id_fk",
+          "tableFrom": "oauth_client",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_client_client_id_unique": {
+          "name": "oauth_client_client_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["client_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_consent": {
+      "name": "oauth_consent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "oauthConsent_clientId_idx": {
+          "name": "oauthConsent_clientId_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthConsent_userId_idx": {
+          "name": "oauthConsent_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_consent_client_id_oauth_client_client_id_fk": {
+          "name": "oauth_consent_client_id_oauth_client_client_id_fk",
+          "tableFrom": "oauth_consent",
+          "tableTo": "oauth_client",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["client_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_consent_user_id_user_id_fk": {
+          "name": "oauth_consent_user_id_user_id_fk",
+          "tableFrom": "oauth_consent",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_refresh_token": {
+      "name": "oauth_refresh_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked": {
+          "name": "revoked",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_time": {
+          "name": "auth_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "oauthRefreshToken_clientId_idx": {
+          "name": "oauthRefreshToken_clientId_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthRefreshToken_sessionId_idx": {
+          "name": "oauthRefreshToken_sessionId_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthRefreshToken_userId_idx": {
+          "name": "oauthRefreshToken_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_refresh_token_client_id_oauth_client_client_id_fk": {
+          "name": "oauth_refresh_token_client_id_oauth_client_client_id_fk",
+          "tableFrom": "oauth_refresh_token",
+          "tableTo": "oauth_client",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["client_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_refresh_token_session_id_session_id_fk": {
+          "name": "oauth_refresh_token_session_id_session_id_fk",
+          "tableFrom": "oauth_refresh_token",
+          "tableTo": "session",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "oauth_refresh_token_user_id_user_id_fk": {
+          "name": "oauth_refresh_token_user_id_user_id_fk",
+          "tableFrom": "oauth_refresh_token",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_refresh_token_token_unique": {
+          "name": "oauth_refresh_token_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_login_method": {
+          "name": "last_login_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'user'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.admin_favorite": {
+      "name": "admin_favorite",
+      "schema": "",
+      "columns": {
+        "admin_id": {
+          "name": "admin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "admin_favorite_admin_id_user_id_fk": {
+          "name": "admin_favorite_admin_id_user_id_fk",
+          "tableFrom": "admin_favorite",
+          "tableTo": "user",
+          "columnsFrom": ["admin_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "admin_favorite_user_id_user_id_fk": {
+          "name": "admin_favorite_user_id_user_id_fk",
+          "tableFrom": "admin_favorite",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "admin_favorite_admin_id_user_id_pk": {
+          "name": "admin_favorite_admin_id_user_id_pk",
+          "columns": ["admin_id", "user_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.hosted_usage": {
+      "name": "hosted_usage",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "day": {
+          "name": "day",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "voice_calls": {
+          "name": "voice_calls",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "attention_reviews": {
+          "name": "attention_reviews",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "hosted_usage_user_id_user_id_fk": {
+          "name": "hosted_usage_user_id_user_id_fk",
+          "tableFrom": "hosted_usage",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "hosted_usage_user_id_day_pk": {
+          "name": "hosted_usage_user_id_day_pk",
+          "columns": ["user_id", "day"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.introduction_usage": {
+      "name": "introduction_usage",
+      "schema": "",
+      "columns": {
+        "caller": {
+          "name": "caller",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "day": {
+          "name": "day",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mints": {
+          "name": "mints",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "introduction_usage_caller_day_pk": {
+          "name": "introduction_usage_caller_day_pk",
+          "columns": ["caller", "day"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provider_key": {
+      "name": "provider_key",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ciphertext": {
+          "name": "ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hint": {
+          "name": "hint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "provider_key_user_id_user_id_fk": {
+          "name": "provider_key_user_id_user_id_fk",
+          "tableFrom": "provider_key",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "provider_key_user_id_provider_id_pk": {
+          "name": "provider_key_user_id_provider_id_pk",
+          "columns": ["user_id", "provider_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/web/drizzle/meta/_journal.json
+++ b/apps/web/drizzle/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1787607782598,
       "tag": "0004_white_brood",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1787961600000,
+      "tag": "0005_crimson_vault",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/web/server/README.md
+++ b/apps/web/server/README.md
@@ -183,3 +183,23 @@ one atomic upsert before each upstream call, checked against the ceilings in
 `server/hosted/quota.ts`. The ceilings bound how often calls open, not how
 long they run; a spend limit on the OpenAI project behind the key is the
 backstop and should be configured with it.
+
+# Provider key vault
+
+`api/vault/key.ts` and `api/vault/keys.ts` store, list, and delete the provider
+API keys a signed-in user syncs for server-side observation. Keys are encrypted
+at rest using AES-256-GCM before they touch the database; the plaintext never
+reaches a database column and there is no endpoint that reads it back.
+
+The three endpoints require `PROVIDER_KEY_ENCRYPTION_SECRET`, a 64-character
+hex string (32 bytes). Generate one with:
+
+```sh
+openssl rand -hex 32
+```
+
+All three vault endpoints answer 503 if the variable is absent or blank — the
+same kill switch as the OpenAI endpoints — so a Preview deployment with no
+secret simply has no working vault, and no plaintext key can be stored
+accidentally. Set this variable in the Vercel project environment (production
+and any Preview that needs a working vault) alongside `DATABASE_URL`.

--- a/apps/web/server/db/schema.ts
+++ b/apps/web/server/db/schema.ts
@@ -3,3 +3,4 @@
 export * from "./auth-schema.js";
 export * from "./favorite-schema.js";
 export * from "./usage-schema.js";
+export * from "./vault-schema.js";

--- a/apps/web/server/db/vault-schema.ts
+++ b/apps/web/server/db/vault-schema.ts
@@ -1,0 +1,28 @@
+import { pgTable, primaryKey, text, timestamp } from "drizzle-orm/pg-core";
+import { user } from "./auth-schema.js";
+
+/**
+ * One encrypted provider API key per (user, provider). Storing a key for an
+ * already-stored provider replaces the previous ciphertext atomically. The
+ * plaintext never leaves the server: there is no read-back endpoint, and no
+ * code path returns a decrypted key to a caller.
+ */
+export const providerKey = pgTable(
+  "provider_key",
+  {
+    userId: text("user_id")
+      .notNull()
+      .references(() => user.id, { onDelete: "cascade" }),
+    providerId: text("provider_id").notNull(),
+    /**
+     * AES-256-GCM ciphertext encoded as base64(nonce || ciphertext || authTag).
+     * The nonce is random per write; the auth tag provides integrity.
+     */
+    ciphertext: text("ciphertext").notNull(),
+    /** Last four characters of the plaintext key, for display only. */
+    hint: text("hint").notNull(),
+    createdAt: timestamp("created_at").notNull().defaultNow(),
+    updatedAt: timestamp("updated_at").notNull().defaultNow(),
+  },
+  (table) => [primaryKey({ columns: [table.userId, table.providerId] })],
+);

--- a/apps/web/server/hosted/encryption.ts
+++ b/apps/web/server/hosted/encryption.ts
@@ -1,0 +1,50 @@
+import { createCipheriv, createDecipheriv, randomBytes } from "node:crypto";
+
+const ALGORITHM = "aes-256-gcm";
+const NONCE_BYTES = 12;
+const TAG_BYTES = 16;
+
+/** The env var name for the 32-byte (64 hex char) AES-256-GCM key. */
+export const VAULT_ENCRYPTION_ENVIRONMENT = {
+  SECRET: "PROVIDER_KEY_ENCRYPTION_SECRET",
+} as const;
+
+function secretBuffer(secret: string): Buffer {
+  const buf = Buffer.from(secret, "hex");
+  if (buf.length !== 32) {
+    throw new Error(
+      "PROVIDER_KEY_ENCRYPTION_SECRET must be 64 hex characters (32 bytes); generate with: openssl rand -hex 32",
+    );
+  }
+  return buf;
+}
+
+/**
+ * Encrypts `plaintext` under AES-256-GCM. Returns base64(nonce || ciphertext
+ * || authTag). The nonce is random per call; the auth tag provides integrity.
+ * `secret` must be a 64-character hex string (32 bytes).
+ */
+export function encryptProviderKey(plaintext: string, secret: string): string {
+  const key = secretBuffer(secret);
+  const nonce = randomBytes(NONCE_BYTES);
+  const cipher = createCipheriv(ALGORITHM, key, nonce);
+  const body = Buffer.concat([cipher.update(plaintext, "utf8"), cipher.final()]);
+  const tag = cipher.getAuthTag();
+  return Buffer.concat([nonce, body, tag]).toString("base64");
+}
+
+/**
+ * Decrypts a value produced by `encryptProviderKey`. Throws if the auth tag
+ * does not verify — meaning the ciphertext has been tampered with or the
+ * wrong secret was supplied.
+ */
+export function decryptProviderKey(encoded: string, secret: string): string {
+  const key = secretBuffer(secret);
+  const buf = Buffer.from(encoded, "base64");
+  const nonce = buf.subarray(0, NONCE_BYTES);
+  const tag = buf.subarray(buf.length - TAG_BYTES);
+  const body = buf.subarray(NONCE_BYTES, buf.length - TAG_BYTES);
+  const decipher = createDecipheriv(ALGORITHM, key, nonce);
+  decipher.setAuthTag(tag);
+  return Buffer.concat([decipher.update(body), decipher.final()]).toString("utf8");
+}

--- a/apps/web/server/hosted/vault.ts
+++ b/apps/web/server/hosted/vault.ts
@@ -1,0 +1,190 @@
+import {
+  isRecord,
+  isWireString,
+  text,
+  type UnparsedWireValue,
+  VAULT_PROVIDER_ID,
+  type VaultProviderId,
+} from "../core.js";
+import { encryptProviderKey } from "./encryption.js";
+import { errorResponse, HOSTED_API_ERROR, HOSTED_HTTP_STATUS, jsonResponse } from "./http.js";
+
+/** Maximum length accepted for a provider API key. */
+const KEY_MAX_LENGTH = 512;
+
+/**
+ * A valid provider key: non-empty, no whitespace anywhere, bounded length.
+ * Loose by design — shape validation only, not provider-specific format.
+ */
+function parseProviderKey(value: UnparsedWireValue): string | undefined {
+  if (!isWireString(value)) return undefined;
+  if (!value || value.length > KEY_MAX_LENGTH) return undefined;
+  if (/\s/u.test(value)) return undefined;
+  return value;
+}
+
+const VAULT_PROVIDER_ID_SET: ReadonlySet<string> = new Set(Object.values(VAULT_PROVIDER_ID));
+
+function isVaultProviderId(value: string | undefined): value is VaultProviderId {
+  return value !== undefined && VAULT_PROVIDER_ID_SET.has(value);
+}
+
+/**
+ * Returns the trimmed secret if present, or a 503 Response if it is absent or
+ * blank. All vault endpoints require it; its absence is a kill switch.
+ */
+function trimmedSecretOrUnavailable(secret: string | undefined): { secret: string } | Response {
+  const trimmed = secret?.trim();
+  if (!trimmed) {
+    return errorResponse(HOSTED_HTTP_STATUS.SERVICE_UNAVAILABLE, HOSTED_API_ERROR.UNAVAILABLE);
+  }
+  return { secret: trimmed };
+}
+
+export interface VaultKeyStoreOptions {
+  request: Request;
+  resolveUserId: (request: Request) => Promise<string | undefined>;
+  /** The value of PROVIDER_KEY_ENCRYPTION_SECRET; undefined means the env var is absent. */
+  encryptionSecret: string | undefined;
+  storeKey: (userId: string, providerId: string, ciphertext: string, hint: string) => Promise<void>;
+}
+
+/** Stores or replaces the provider API key for the signed-in user. */
+export async function handleVaultKeyStore(options: VaultKeyStoreOptions): Promise<Response> {
+  const { request, resolveUserId, encryptionSecret, storeKey } = options;
+
+  if (request.method !== "POST") {
+    return errorResponse(
+      HOSTED_HTTP_STATUS.METHOD_NOT_ALLOWED,
+      HOSTED_API_ERROR.METHOD_NOT_ALLOWED,
+    );
+  }
+
+  const secretResult = trimmedSecretOrUnavailable(encryptionSecret);
+  if (secretResult instanceof Response) return secretResult;
+
+  const userId = await resolveUserId(request);
+  if (!userId) {
+    return errorResponse(HOSTED_HTTP_STATUS.UNAUTHORIZED, HOSTED_API_ERROR.INVALID_TOKEN);
+  }
+
+  let body: UnparsedWireValue;
+  try {
+    // SAFETY: request.json() returns unknown; isRecord below validates the shape.
+    body = (await request.json()) as UnparsedWireValue;
+  } catch {
+    return errorResponse(HOSTED_HTTP_STATUS.BAD_REQUEST, HOSTED_API_ERROR.INVALID_REQUEST);
+  }
+
+  if (!isRecord(body)) {
+    return errorResponse(HOSTED_HTTP_STATUS.BAD_REQUEST, HOSTED_API_ERROR.INVALID_REQUEST);
+  }
+
+  const providerId = text(body.providerId);
+  if (!isVaultProviderId(providerId)) {
+    return errorResponse(HOSTED_HTTP_STATUS.BAD_REQUEST, HOSTED_API_ERROR.INVALID_REQUEST);
+  }
+
+  const key = parseProviderKey(body.key);
+  if (!key) {
+    return errorResponse(HOSTED_HTTP_STATUS.BAD_REQUEST, HOSTED_API_ERROR.INVALID_REQUEST);
+  }
+
+  const ciphertext = encryptProviderKey(key, secretResult.secret);
+  const hint = key.slice(-4);
+
+  await storeKey(userId, providerId, ciphertext, hint);
+
+  return jsonResponse(HOSTED_HTTP_STATUS.OK, { stored: true });
+}
+
+export interface VaultKeyEntry {
+  providerId: string;
+  hint: string;
+  updatedAt: Date;
+}
+
+export interface VaultKeysListOptions {
+  request: Request;
+  resolveUserId: (request: Request) => Promise<string | undefined>;
+  encryptionSecret: string | undefined;
+  listKeys: (userId: string) => Promise<VaultKeyEntry[]>;
+}
+
+/** Lists stored provider keys for the signed-in user. Never returns ciphertext or plaintext. */
+export async function handleVaultKeysList(options: VaultKeysListOptions): Promise<Response> {
+  const { request, resolveUserId, encryptionSecret, listKeys } = options;
+
+  if (request.method !== "GET") {
+    return errorResponse(
+      HOSTED_HTTP_STATUS.METHOD_NOT_ALLOWED,
+      HOSTED_API_ERROR.METHOD_NOT_ALLOWED,
+    );
+  }
+
+  const secretResult = trimmedSecretOrUnavailable(encryptionSecret);
+  if (secretResult instanceof Response) return secretResult;
+
+  const userId = await resolveUserId(request);
+  if (!userId) {
+    return errorResponse(HOSTED_HTTP_STATUS.UNAUTHORIZED, HOSTED_API_ERROR.INVALID_TOKEN);
+  }
+
+  const rows = await listKeys(userId);
+
+  return jsonResponse(HOSTED_HTTP_STATUS.OK, {
+    keys: rows.map((row) => ({
+      providerId: row.providerId,
+      hint: row.hint,
+      updatedAt: row.updatedAt.getTime(),
+    })),
+  });
+}
+
+export interface VaultKeyDeleteOptions {
+  request: Request;
+  resolveUserId: (request: Request) => Promise<string | undefined>;
+  encryptionSecret: string | undefined;
+  deleteKey: (userId: string, providerId: string) => Promise<boolean>;
+}
+
+/** Deletes the stored provider key for the signed-in user. */
+export async function handleVaultKeyDelete(options: VaultKeyDeleteOptions): Promise<Response> {
+  const { request, resolveUserId, encryptionSecret, deleteKey } = options;
+
+  if (request.method !== "DELETE") {
+    return errorResponse(
+      HOSTED_HTTP_STATUS.METHOD_NOT_ALLOWED,
+      HOSTED_API_ERROR.METHOD_NOT_ALLOWED,
+    );
+  }
+
+  const secretResult = trimmedSecretOrUnavailable(encryptionSecret);
+  if (secretResult instanceof Response) return secretResult;
+
+  const userId = await resolveUserId(request);
+  if (!userId) {
+    return errorResponse(HOSTED_HTTP_STATUS.UNAUTHORIZED, HOSTED_API_ERROR.INVALID_TOKEN);
+  }
+
+  let body: UnparsedWireValue;
+  try {
+    // SAFETY: request.json() returns unknown; isRecord below validates the shape.
+    body = (await request.json()) as UnparsedWireValue;
+  } catch {
+    return errorResponse(HOSTED_HTTP_STATUS.BAD_REQUEST, HOSTED_API_ERROR.INVALID_REQUEST);
+  }
+
+  if (!isRecord(body)) {
+    return errorResponse(HOSTED_HTTP_STATUS.BAD_REQUEST, HOSTED_API_ERROR.INVALID_REQUEST);
+  }
+
+  const providerId = text(body.providerId);
+  if (!isVaultProviderId(providerId)) {
+    return errorResponse(HOSTED_HTTP_STATUS.BAD_REQUEST, HOSTED_API_ERROR.INVALID_REQUEST);
+  }
+
+  const deleted = await deleteKey(userId, providerId);
+
+  return jsonResponse(HOSTED_HTTP_STATUS.OK, { deleted });
+}

--- a/apps/web/tests/hosted-vault.test.ts
+++ b/apps/web/tests/hosted-vault.test.ts
@@ -1,0 +1,349 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { VAULT_PROVIDER_ID } from "@sidecar/hosted";
+import { decryptProviderKey, encryptProviderKey } from "../server/hosted/encryption";
+import { HOSTED_API_ERROR } from "../server/hosted/http";
+import type { VaultKeyEntry } from "../server/hosted/vault";
+import {
+  handleVaultKeyDelete,
+  handleVaultKeyStore,
+  handleVaultKeysList,
+} from "../server/hosted/vault";
+
+// A valid 32-byte secret as 64 hex chars.
+const SECRET = "a".repeat(64);
+const OTHER_SECRET = "b".repeat(64);
+
+interface VaultStoreBody {
+  providerId?: string;
+  key?: string;
+}
+
+interface VaultDeleteBody {
+  providerId?: string;
+}
+
+function storeRequest(body?: VaultStoreBody, headers: Record<string, string> = {}): Request {
+  return new Request("https://luke.test/api/vault/key", {
+    method: "POST",
+    headers: { authorization: "Bearer token-1", "content-type": "application/json", ...headers },
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  });
+}
+
+function listRequest(headers: Record<string, string> = {}): Request {
+  return new Request("https://luke.test/api/vault/keys", {
+    method: "GET",
+    headers: { authorization: "Bearer token-1", ...headers },
+  });
+}
+
+function deleteRequest(body?: VaultDeleteBody, headers: Record<string, string> = {}): Request {
+  return new Request("https://luke.test/api/vault/key", {
+    method: "DELETE",
+    headers: { authorization: "Bearer token-1", "content-type": "application/json", ...headers },
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  });
+}
+
+// --- Encryption round-trips ---
+
+test("encrypt then decrypt recovers the original key", () => {
+  const original = "sk-test-abc123";
+  const encrypted = encryptProviderKey(original, SECRET);
+  assert.equal(decryptProviderKey(encrypted, SECRET), original);
+});
+
+test("each encrypt call produces a different ciphertext (random nonce)", () => {
+  const key = "sk-same-key";
+  assert.notEqual(encryptProviderKey(key, SECRET), encryptProviderKey(key, SECRET));
+});
+
+test("decrypting with the wrong secret throws", () => {
+  const encrypted = encryptProviderKey("sk-secret", SECRET);
+  assert.throws(() => decryptProviderKey(encrypted, OTHER_SECRET));
+});
+
+test("a secret that is not 64 hex chars throws at encrypt time", () => {
+  assert.throws(() => encryptProviderKey("key", "tooshort"));
+});
+
+// --- Store ---
+
+function storeOptions(overrides: Partial<Parameters<typeof handleVaultKeyStore>[0]> = {}) {
+  return {
+    request: storeRequest({ providerId: VAULT_PROVIDER_ID.COPILOT, key: "sk-abc1234" }),
+    encryptionSecret: SECRET,
+    resolveUserId: async () => "user-1",
+    storeKey: async (
+      _userId: string,
+      _providerId: string,
+      _ciphertext: string,
+      _hint: string,
+    ) => {},
+    ...overrides,
+  };
+}
+
+test("the store gate order is method, secret, token, body", async () => {
+  const wrongMethod = await handleVaultKeyStore(
+    storeOptions({
+      request: new Request("https://luke.test/api/vault/key", { method: "GET" }),
+    }),
+  );
+  assert.equal(wrongMethod.status, 405);
+
+  const noSecret = await handleVaultKeyStore(storeOptions({ encryptionSecret: undefined }));
+  assert.equal(noSecret.status, 503);
+  assert.equal((await noSecret.json()).error, HOSTED_API_ERROR.UNAVAILABLE);
+
+  const blankSecret = await handleVaultKeyStore(storeOptions({ encryptionSecret: "   " }));
+  assert.equal(blankSecret.status, 503);
+
+  const anonymous = await handleVaultKeyStore(
+    storeOptions({ resolveUserId: async () => undefined }),
+  );
+  assert.equal(anonymous.status, 401);
+  assert.equal((await anonymous.json()).error, HOSTED_API_ERROR.INVALID_TOKEN);
+
+  const noBody = await handleVaultKeyStore(
+    storeOptions({
+      request: new Request("https://luke.test/api/vault/key", {
+        method: "POST",
+        headers: { authorization: "Bearer t" },
+      }),
+    }),
+  );
+  assert.equal(noBody.status, 400);
+  assert.equal((await noBody.json()).error, HOSTED_API_ERROR.INVALID_REQUEST);
+});
+
+test("storing a valid key answers { stored: true } and writes an encrypted ciphertext", async () => {
+  let stored: { userId: string; providerId: string; ciphertext: string; hint: string } | undefined;
+
+  const response = await handleVaultKeyStore(
+    storeOptions({
+      storeKey: async (userId, providerId, ciphertext, hint) => {
+        stored = { userId, providerId, ciphertext, hint };
+      },
+    }),
+  );
+
+  assert.equal(response.status, 200);
+  assert.equal((await response.json()).stored, true);
+  assert.ok(stored);
+  assert.equal(stored.userId, "user-1");
+  assert.equal(stored.providerId, VAULT_PROVIDER_ID.COPILOT);
+  // The hint is the last 4 chars of "sk-abc1234".
+  assert.equal(stored.hint, "1234");
+  // Ciphertext must not equal the plaintext key.
+  assert.notEqual(stored.ciphertext, "sk-abc1234");
+  // Round-trip: decrypt recovers the original key.
+  assert.equal(decryptProviderKey(stored.ciphertext, SECRET), "sk-abc1234");
+});
+
+test("an unknown provider id is refused", async () => {
+  const response = await handleVaultKeyStore(
+    storeOptions({
+      request: storeRequest({ providerId: "not-a-provider", key: "sk-abc" }),
+    }),
+  );
+  assert.equal(response.status, 400);
+  assert.equal((await response.json()).error, HOSTED_API_ERROR.INVALID_REQUEST);
+});
+
+test("a key with internal whitespace is refused", async () => {
+  const response = await handleVaultKeyStore(
+    storeOptions({
+      request: storeRequest({ providerId: VAULT_PROVIDER_ID.CURSOR, key: "sk ab cd" }),
+    }),
+  );
+  assert.equal(response.status, 400);
+});
+
+test("an empty key is refused", async () => {
+  const response = await handleVaultKeyStore(
+    storeOptions({ request: storeRequest({ providerId: VAULT_PROVIDER_ID.DEVIN, key: "" }) }),
+  );
+  assert.equal(response.status, 400);
+});
+
+test("a key longer than 512 characters is refused", async () => {
+  const response = await handleVaultKeyStore(
+    storeOptions({
+      request: storeRequest({ providerId: VAULT_PROVIDER_ID.JULES, key: "k".repeat(513) }),
+    }),
+  );
+  assert.equal(response.status, 400);
+});
+
+// --- List ---
+
+const NOW_DATE = new Date("2026-08-28T00:00:00.000Z");
+
+function listOptions(overrides: Partial<Parameters<typeof handleVaultKeysList>[0]> = {}) {
+  return {
+    request: listRequest(),
+    encryptionSecret: SECRET,
+    resolveUserId: async () => "user-1",
+    listKeys: async (_userId: string): Promise<VaultKeyEntry[]> => [
+      { providerId: VAULT_PROVIDER_ID.COPILOT, hint: "1234", updatedAt: NOW_DATE },
+    ],
+    ...overrides,
+  };
+}
+
+test("the list gate order is method, secret, token", async () => {
+  const wrongMethod = await handleVaultKeysList(
+    listOptions({ request: new Request("https://luke.test/api/vault/keys", { method: "POST" }) }),
+  );
+  assert.equal(wrongMethod.status, 405);
+
+  const noSecret = await handleVaultKeysList(listOptions({ encryptionSecret: undefined }));
+  assert.equal(noSecret.status, 503);
+
+  const anonymous = await handleVaultKeysList(
+    listOptions({ resolveUserId: async () => undefined }),
+  );
+  assert.equal(anonymous.status, 401);
+});
+
+test("the list answer never contains ciphertext or plaintext keys", async () => {
+  const response = await handleVaultKeysList(listOptions());
+
+  assert.equal(response.status, 200);
+  const body = await response.json();
+  assert.ok(Array.isArray(body.keys));
+  assert.equal(body.keys.length, 1);
+  assert.equal(body.keys[0].providerId, VAULT_PROVIDER_ID.COPILOT);
+  assert.equal(body.keys[0].hint, "1234");
+  assert.equal(body.keys[0].updatedAt, NOW_DATE.getTime());
+  // No ciphertext, no plaintext key field anywhere.
+  assert.ok(!("ciphertext" in body.keys[0]));
+  assert.ok(!("key" in body.keys[0]));
+  assert.doesNotMatch(JSON.stringify(body), /ciphertext/);
+});
+
+test("the list calls the seam with the resolved user id", async () => {
+  let calledWithUserId: string | undefined;
+
+  await handleVaultKeysList(
+    listOptions({
+      resolveUserId: async () => "user-xyz",
+      listKeys: async (userId) => {
+        calledWithUserId = userId;
+        return [];
+      },
+    }),
+  );
+
+  assert.equal(calledWithUserId, "user-xyz");
+});
+
+// --- Delete ---
+
+function deleteOptions(overrides: Partial<Parameters<typeof handleVaultKeyDelete>[0]> = {}) {
+  return {
+    request: deleteRequest({ providerId: VAULT_PROVIDER_ID.REPLICAS }),
+    encryptionSecret: SECRET,
+    resolveUserId: async () => "user-1",
+    deleteKey: async (_userId: string, _providerId: string) => true,
+    ...overrides,
+  };
+}
+
+test("the delete gate order is method, secret, token, body", async () => {
+  const wrongMethod = await handleVaultKeyDelete(
+    deleteOptions({ request: new Request("https://luke.test/api/vault/key", { method: "POST" }) }),
+  );
+  assert.equal(wrongMethod.status, 405);
+
+  const noSecret = await handleVaultKeyDelete(deleteOptions({ encryptionSecret: undefined }));
+  assert.equal(noSecret.status, 503);
+
+  const anonymous = await handleVaultKeyDelete(
+    deleteOptions({ resolveUserId: async () => undefined }),
+  );
+  assert.equal(anonymous.status, 401);
+
+  const unknownProvider = await handleVaultKeyDelete(
+    deleteOptions({ request: deleteRequest({ providerId: "not-a-provider" }) }),
+  );
+  assert.equal(unknownProvider.status, 400);
+  assert.equal((await unknownProvider.json()).error, HOSTED_API_ERROR.INVALID_REQUEST);
+});
+
+test("deleting an existing key answers { deleted: true }", async () => {
+  const response = await handleVaultKeyDelete(deleteOptions({ deleteKey: async () => true }));
+
+  assert.equal(response.status, 200);
+  const body = await response.json();
+  assert.equal(body.deleted, true);
+});
+
+test("deleting a key that was not stored answers { deleted: false }", async () => {
+  const response = await handleVaultKeyDelete(deleteOptions({ deleteKey: async () => false }));
+
+  assert.equal(response.status, 200);
+  assert.equal((await response.json()).deleted, false);
+});
+
+test("the delete passes the resolved user id and provider id to the seam", async () => {
+  let calledWith: { userId: string; providerId: string } | undefined;
+
+  await handleVaultKeyDelete(
+    deleteOptions({
+      resolveUserId: async () => "user-abc",
+      request: deleteRequest({ providerId: VAULT_PROVIDER_ID.CURSOR }),
+      deleteKey: async (userId, providerId) => {
+        calledWith = { userId, providerId };
+        return true;
+      },
+    }),
+  );
+
+  assert.deepEqual(calledWith, { userId: "user-abc", providerId: VAULT_PROVIDER_ID.CURSOR });
+});
+
+// --- Replace-on-upsert ---
+
+test("storing again for the same provider replaces the previous entry (upsert)", async () => {
+  const stored: Array<{ ciphertext: string; hint: string }> = [];
+
+  async function storeKey(
+    _userId: string,
+    _providerId: string,
+    ciphertext: string,
+    hint: string,
+  ): Promise<void> {
+    stored.push({ ciphertext, hint });
+  }
+
+  // First store.
+  await handleVaultKeyStore(
+    storeOptions({
+      request: storeRequest({ providerId: VAULT_PROVIDER_ID.JULES, key: "first-key-0001" }),
+      storeKey,
+    }),
+  );
+  // Second store — same provider, different key.
+  await handleVaultKeyStore(
+    storeOptions({
+      request: storeRequest({ providerId: VAULT_PROVIDER_ID.JULES, key: "second-key-9999" }),
+      storeKey,
+    }),
+  );
+
+  assert.equal(stored.length, 2);
+  const first = stored.at(0);
+  const second = stored.at(1);
+  assert.ok(first && second);
+  // Both writes produce different ciphertexts.
+  assert.notEqual(first.ciphertext, second.ciphertext);
+  // Hints reflect each key's last 4 chars.
+  assert.equal(first.hint, "0001");
+  assert.equal(second.hint, "9999");
+  // Each ciphertext decrypts to the respective plaintext.
+  assert.equal(decryptProviderKey(first.ciphertext, SECRET), "first-key-0001");
+  assert.equal(decryptProviderKey(second.ciphertext, SECRET), "second-key-9999");
+});

--- a/apps/web/tests/hosted-vault.test.ts
+++ b/apps/web/tests/hosted-vault.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import { CLOUD_AGENT_PROVIDER_LIST } from "@sidecar/credentials";
 import { VAULT_PROVIDER_ID } from "@sidecar/hosted";
 import { decryptProviderKey, encryptProviderKey } from "../server/hosted/encryption";
 import { HOSTED_API_ERROR } from "../server/hosted/http";
@@ -303,6 +304,14 @@ test("the delete passes the resolved user id and provider id to the seam", async
   );
 
   assert.deepEqual(calledWith, { userId: "user-abc", providerId: VAULT_PROVIDER_ID.CURSOR });
+});
+
+// --- Provider set parity ---
+
+test("VAULT_PROVIDER_ID matches CLOUD_AGENT_PROVIDER_LIST exactly", () => {
+  const vaultIds = new Set(Object.values(VAULT_PROVIDER_ID));
+  const cloudIds = new Set(CLOUD_AGENT_PROVIDER_LIST.map((p) => p.id));
+  assert.deepEqual(vaultIds, cloudIds);
 });
 
 // --- Replace-on-upsert ---

--- a/packages/hosted/src/hosted-service.ts
+++ b/packages/hosted/src/hosted-service.ts
@@ -53,8 +53,14 @@ export const HOSTED_SERVICE_PATH = {
  * `satisfies` constraint enforces that membership. A new entry must be a
  * known provider id and requires a matching server-side observation strategy,
  * which ships in a separate PR.
+ *
+ * This set must stay in sync with `CLOUD_AGENT_PROVIDER_LIST` in
+ * `@sidecar/credentials`. That package is not importable here (it sits above
+ * `@sidecar/hosted` in the dependency graph), so drift is caught by a
+ * parity test in `apps/web/tests/hosted-vault.test.ts` instead.
  */
 export const VAULT_PROVIDER_ID = {
+  CONDUCTOR: "conductor",
   COPILOT: "copilot",
   CURSOR: "cursor",
   DEVIN: "devin",

--- a/packages/hosted/src/hosted-service.ts
+++ b/packages/hosted/src/hosted-service.ts
@@ -1,5 +1,16 @@
-import { type AttentionDecision, attentionDecisionFromWire } from "@sidecar/session";
-import { isRecord, text, type UnparsedWireValue, wholeNumber } from "@sidecar/wire";
+import {
+  type AttentionDecision,
+  attentionDecisionFromWire,
+  type ProviderId,
+} from "@sidecar/session";
+import {
+  isRecord,
+  isWireBoolean,
+  isWireNumber,
+  text,
+  type UnparsedWireValue,
+  wholeNumber,
+} from "@sidecar/wire";
 import {
   REALTIME_CALLS_PATH,
   type RealtimeConnection,
@@ -27,7 +38,31 @@ export const HOSTED_SERVICE_PATH = {
   ACCOUNT_DELETE: "/api/account/delete",
   USAGE: "/api/usage",
   EVENTS: "/api/events",
+  /** Store or replace a provider key (POST) or delete one (DELETE). */
+  VAULT_KEY: "/api/vault/key",
+  /** List stored provider keys — ids and display hints, never keys. */
+  VAULT_KEYS: "/api/vault/keys",
 } as const;
+
+/**
+ * The cloud providers whose API keys the vault accepts. Only providers that
+ * Luke's service can observe on the user's behalf belong here; local-only
+ * providers supply their credentials directly on the user's machine.
+ *
+ * The values are a subset of `PROVIDER_ID` from `@sidecar/session`; the
+ * `satisfies` constraint enforces that membership. A new entry must be a
+ * known provider id and requires a matching server-side observation strategy,
+ * which ships in a separate PR.
+ */
+export const VAULT_PROVIDER_ID = {
+  COPILOT: "copilot",
+  CURSOR: "cursor",
+  DEVIN: "devin",
+  JULES: "jules",
+  REPLICAS: "replicas",
+} as const satisfies Record<string, ProviderId>;
+
+export type VaultProviderId = (typeof VAULT_PROVIDER_ID)[keyof typeof VAULT_PROVIDER_ID];
 
 /** Every refusal a hosted endpoint answers with, by its reason. */
 export const HOSTED_API_ERROR = {
@@ -187,4 +222,66 @@ export function hostedErrorFromWire(value: UnparsedWireValue): HostedApiError | 
   return HOSTED_API_ERROR_LIST.includes(error as HostedApiError)
     ? (error as HostedApiError)
     : undefined;
+}
+
+// --- Vault wire contract ---
+
+/** Confirms that a store operation landed. */
+export interface VaultKeyStoreAnswer {
+  stored: true;
+}
+
+/** Reads a vault store answer; anything other than `{ stored: true }` is invalid. */
+export function vaultKeyStoreAnswerFromWire(
+  value: UnparsedWireValue,
+): VaultKeyStoreAnswer | undefined {
+  if (!isRecord(value) || value.stored !== true) return undefined;
+  return { stored: true };
+}
+
+/** One key entry as returned by the list endpoint — never contains the key. */
+export interface VaultKeyListEntry {
+  providerId: VaultProviderId;
+  hint: string;
+  updatedAt: number;
+}
+
+/** The list endpoint answer. */
+export interface VaultKeysListAnswer {
+  keys: VaultKeyListEntry[];
+}
+
+const VAULT_PROVIDER_ID_SET: ReadonlySet<string> = new Set(Object.values(VAULT_PROVIDER_ID));
+
+/** Reads a vault keys-list answer; any malformed entry drops the whole answer. */
+export function vaultKeysListAnswerFromWire(
+  value: UnparsedWireValue,
+): VaultKeysListAnswer | undefined {
+  if (!isRecord(value) || !Array.isArray(value.keys)) return undefined;
+  const keys: VaultKeyListEntry[] = [];
+  for (const item of value.keys) {
+    if (!isRecord(item)) return undefined;
+    const providerId = text(item.providerId);
+    if (!providerId || !VAULT_PROVIDER_ID_SET.has(providerId)) return undefined;
+    const hint = text(item.hint);
+    if (!hint) return undefined;
+    const updatedAt = wholeNumber(item.updatedAt);
+    if (updatedAt === undefined || !isWireNumber(updatedAt) || updatedAt < 0) return undefined;
+    // SAFETY: providerId is a string and a member of VAULT_PROVIDER_ID_SET.
+    keys.push({ providerId: providerId as VaultProviderId, hint, updatedAt });
+  }
+  return { keys };
+}
+
+/** Confirms whether a delete operation found and removed a key. */
+export interface VaultKeyDeleteAnswer {
+  deleted: boolean;
+}
+
+/** Reads a vault delete answer. */
+export function vaultKeyDeleteAnswerFromWire(
+  value: UnparsedWireValue,
+): VaultKeyDeleteAnswer | undefined {
+  if (!isRecord(value) || !isWireBoolean(value.deleted)) return undefined;
+  return { deleted: value.deleted };
 }

--- a/packages/hosted/src/index.ts
+++ b/packages/hosted/src/index.ts
@@ -13,6 +13,15 @@ export {
   hostedQuotaFromWire,
   hostedReviewAnswerFromWire,
   hostedUsageAnswerFromWire,
+  VAULT_PROVIDER_ID,
+  type VaultKeyDeleteAnswer,
+  type VaultKeyListEntry,
+  type VaultKeyStoreAnswer,
+  type VaultKeysListAnswer,
+  type VaultProviderId,
+  vaultKeyDeleteAnswerFromWire,
+  vaultKeyStoreAnswerFromWire,
+  vaultKeysListAnswerFromWire,
 } from "./hosted-service.js";
 export {
   REALTIME_CALLS_PATH,


### PR DESCRIPTION
## Trust posture

- **Encrypted at rest**: AES-256-GCM with a server-only secret (`PROVIDER_KEY_ENCRYPTION_SECRET`, 64-hex-char / 32-byte key). Random nonce per write; auth tag stored. No plaintext key ever reaches a database column.
- **No read-back endpoint**: there is deliberately no API that decrypts or returns a key. The only consumer will be a future server-side observation PR.
- **Validated provider set**: `VAULT_PROVIDER_ID` in `packages/hosted` defines the closed set of key-scoped cloud providers accepted by the store endpoint (`copilot`, `cursor`, `devin`, `jules`, `replicas`). Unknown providers are refused 400. The set satisfies `Record<string, ProviderId>` from `@sidecar/session`, enforced via `satisfies`.
- **Cascade on delete**: the `provider_key` table has `user_id → user.id ON DELETE cascade`, so the existing `DELETE /api/account/delete` handler automatically removes vault rows when it deletes the user row. No handler change needed.
- **Kill switch**: all three vault endpoints require `PROVIDER_KEY_ENCRYPTION_SECRET`. If the env var is absent or blank, every endpoint answers 503 — same posture as the OpenAI endpoints. A Preview deployment with no secret has no working vault and cannot accidentally store plaintext.

## Env var

`PROVIDER_KEY_ENCRYPTION_SECRET` — 64 hex characters (32 bytes). Generate with:
```sh
openssl rand -hex 32
```
Documented in `apps/web/server/README.md` alongside the other hosted secrets.

## PRIVACY.md

A new "Provider API keys (server-side vault)" paragraph under "What we collect" describes: encrypted at rest, no read-back, server-side use ships separately, deleted by the user or with the account. The "Storage" and "Your choices" sections are updated to match.

## What ships in this PR

Schema, migration, encryption module, three handler functions (store, list, delete), two API route files, wire contract additions in `@sidecar/hosted`, and a full test suite. No observation code, no key use, no desktop or iOS changes.

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/33209968637/artifacts/9701252488) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/33209968637)

- Commit: `2b95764420cf70b0072a9edeb28cb3d05f5c52bc`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
