### PR TITLE
feat(desktop): add a copy control to History messages

### DIFF
--- a/apps/desktop/src/main/desktop-app.ts
+++ b/apps/desktop/src/main/desktop-app.ts
@@ -95,6 +95,7 @@ import { ACT_RESULT_STATUS, isRecord, text, type UnparsedWireValue } from "@side
 import {
   app,
   BrowserWindow,
+  clipboard,
   type IpcMainEvent,
   type IpcMainInvokeEvent,
   ipcMain,
@@ -1630,6 +1631,8 @@ function registerIpc(): void {
     if (!introductionWindow.owns(context.sender)) return;
     introductionRendererReady = true;
   });
+
+  registerHandler(BRIDGE.copyText, (words: string) => clipboard.writeText(words));
 
   registerHandler(BRIDGE.quit, app.quit.bind(app));
 

--- a/apps/desktop/src/renderer/conversation-history-panel.test.ts
+++ b/apps/desktop/src/renderer/conversation-history-panel.test.ts
@@ -84,6 +84,7 @@ test("messages offer a copy control while quiet events offer none", () => {
 
   assert.equal(markup.match(/class="history-copy"/g)?.length, 2);
   assert.match(markup, /aria-label="Copy message"/);
+  assert.match(markup, /icon-button-glyph/);
 });
 
 test("the empty history reports only its state", () => {

--- a/apps/desktop/src/renderer/conversation-history-panel.test.ts
+++ b/apps/desktop/src/renderer/conversation-history-panel.test.ts
@@ -70,6 +70,22 @@ test("conversation history is blocked from optional panel recordings", () => {
   assert.doesNotMatch(markup, /stays in memory|typed or spoken exchange/);
 });
 
+test("messages offer a copy control while quiet events offer none", () => {
+  const markup = renderToStaticMarkup(
+    createElement(ConversationHistoryPanel, {
+      entries: [
+        { kind: CONVERSATION_ENTRY_KIND.TYPED_ASK, words: "ship it" },
+        { kind: CONVERSATION_ENTRY_KIND.REPLY, words: "Shipping." },
+        { kind: CONVERSATION_ENTRY_KIND.ACT, words: "Sent to Codex." },
+      ],
+      onClear: () => undefined,
+    }),
+  );
+
+  assert.equal(markup.match(/class="history-copy"/g)?.length, 2);
+  assert.match(markup, /aria-label="Copy message"/);
+});
+
 test("the empty history reports only its state", () => {
   const markup = renderToStaticMarkup(
     createElement(ConversationHistoryPanel, {

--- a/apps/desktop/src/renderer/conversation-history-panel.tsx
+++ b/apps/desktop/src/renderer/conversation-history-panel.tsx
@@ -33,12 +33,39 @@ export function historyEntryPresentation(kind: ConversationEntryKind): HistoryEn
   }
 }
 
+const COPY_CONFIRMATION_MS = 1500;
+
 function HistoryEntryRow({ entry }: { entry: ConversationEntry }): React.JSX.Element {
   const presentation = historyEntryPresentation(entry.kind);
+  const words = entry.displayWords ?? entry.words;
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    if (!copied) return;
+    const timer = setTimeout(() => setCopied(false), COPY_CONFIRMATION_MS);
+    return () => clearTimeout(timer);
+  }, [copied]);
+
   return (
     <li className="history-entry" data-speaker={presentation.speaker}>
       <small className="visually-hidden">{presentation.label}</small>
-      <p>{entry.displayWords ?? entry.words}</p>
+      <p>{words}</p>
+      {presentation.speaker === HISTORY_ENTRY_SPEAKER.EVENT ? null : (
+        <button
+          type="button"
+          className="history-copy"
+          data-copied={copied ? "true" : undefined}
+          aria-label={copied ? "Copied" : "Copy message"}
+          onClick={() => {
+            // The visible words, never the structured model context behind an
+            // announcement: copy takes exactly what the bubble shows.
+            window.sidecar.copyText(words);
+            setCopied(true);
+          }}
+        >
+          {copied ? "Copied" : "Copy"}
+        </button>
+      )}
     </li>
   );
 }

--- a/apps/desktop/src/renderer/conversation-history-panel.tsx
+++ b/apps/desktop/src/renderer/conversation-history-panel.tsx
@@ -5,6 +5,7 @@ import {
 } from "@sidecar/realtime";
 import { useEffect, useRef, useState } from "react";
 import { PANEL_TAB, panelPanelId, panelTabId } from "./panel-tabs";
+import { CheckIcon, CopyIcon } from "./settings-icons";
 
 export const HISTORY_ENTRY_SPEAKER = {
   YOU: "you",
@@ -63,7 +64,7 @@ function HistoryEntryRow({ entry }: { entry: ConversationEntry }): React.JSX.Ele
             setCopied(true);
           }}
         >
-          {copied ? "Copied" : "Copy"}
+          {copied ? <CheckIcon /> : <CopyIcon />}
         </button>
       )}
     </li>

--- a/apps/desktop/src/renderer/settings-icons.tsx
+++ b/apps/desktop/src/renderer/settings-icons.tsx
@@ -54,6 +54,15 @@ export function CheckIcon(): React.JSX.Element {
   );
 }
 
+export function CopyIcon(): React.JSX.Element {
+  return (
+    <Glyph className="icon-button-glyph">
+      <rect x="8.6" y="8.6" width="11" height="11" rx="2.4" />
+      <path d="M5.6 15.4H5A2.4 2.4 0 0 1 2.6 13V5A2.4 2.4 0 0 1 5 2.6h8A2.4 2.4 0 0 1 15.4 5v.6" />
+    </Glyph>
+  );
+}
+
 export function PencilIcon(): React.JSX.Element {
   return (
     <Glyph className="icon-button-glyph">

--- a/apps/desktop/src/renderer/styles/history.css
+++ b/apps/desktop/src/renderer/styles/history.css
@@ -66,10 +66,51 @@
 }
 
 .history-entry {
+  position: relative;
   display: flex;
   max-width: min(82%, 58ch);
   flex: 0 0 auto;
   flex-direction: column;
+}
+
+/* Copy sits in the bubble's free margin, absolutely positioned so a thread
+   with the control lays out exactly like one without it, and hover-revealed
+   because a control on every bubble would out-shout the words. It stays
+   keyboard-reachable while hidden, and :focus-visible reveals it. */
+.history-copy {
+  position: absolute;
+  top: 50%;
+  padding: 3px 8px;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 10px;
+  font-weight: 620;
+  opacity: 0;
+  transform: translateY(-50%);
+  transition:
+    background-color var(--duration-hover) ease,
+    color var(--duration-hover) ease,
+    opacity var(--duration-hover) ease;
+}
+
+.history-entry[data-speaker="luke"] .history-copy {
+  left: calc(100% + 4px);
+}
+
+.history-entry[data-speaker="you"] .history-copy {
+  right: calc(100% + 4px);
+}
+
+.history-entry:hover .history-copy,
+.history-copy:focus-visible,
+.history-copy[data-copied] {
+  opacity: 1;
+}
+
+.history-copy:hover {
+  background: var(--raised);
+  color: var(--text-primary);
 }
 
 .history-entry p {

--- a/apps/desktop/src/renderer/styles/history.css
+++ b/apps/desktop/src/renderer/styles/history.css
@@ -76,16 +76,20 @@
 /* Copy sits in the bubble's free margin, absolutely positioned so a thread
    with the control lays out exactly like one without it, and hover-revealed
    because a control on every bubble would out-shout the words. It stays
-   keyboard-reachable while hidden, and :focus-visible reveals it. */
+   keyboard-reachable while hidden, :focus-visible reveals it, and the glyph
+   alone speaks: the accessible name captions it for a reader, and the copied
+   confirmation is the same green check a finished session wears. */
 .history-copy {
   position: absolute;
   top: 50%;
-  padding: 3px 8px;
+  display: inline-flex;
+  width: 24px;
+  height: 24px;
+  align-items: center;
+  justify-content: center;
   border-radius: 8px;
   background: transparent;
   color: var(--text-secondary);
-  font-size: 10px;
-  font-weight: 620;
   opacity: 0;
   transform: translateY(-50%);
   transition:

--- a/apps/desktop/src/shared/bridge.ts
+++ b/apps/desktop/src/shared/bridge.ts
@@ -625,6 +625,13 @@ export const BRIDGE = {
     args: noArgs,
     result: result<void>(),
   }),
+  /**
+   * Words the renderer already draws, placed on this machine's clipboard and
+   * nowhere else. Routed through the main process because the panel's
+   * permission handlers deny the sandboxed renderer every Chromium
+   * permission but audio capture, the async clipboard included.
+   */
+  copyText: entry({ kind: "send", channel: "app:copy-text", args: oneString }),
   focusPanel: entry({ kind: "send", channel: "app:focus-panel", args: noArgs }),
   requestRealtimeCredential: entry({
     kind: "invoke",


### PR DESCRIPTION
## Summary

- Adds a per-message Copy control to the conversation History tab: hovering a sent or received bubble (or tabbing to it) reveals a small copy glyph in the bubble's free margin — captioned for screen readers, wordless on screen like the panel's other icon buttons — which places that message's visible words on the clipboard and flips briefly to the green completed check as confirmation.
- The copy takes exactly what the bubble shows (`displayWords ?? words`), so an announcement's structured model context never reaches the clipboard. Quiet event lines ("At your request") are not messages and offer no control.
- The write goes through a new `copyText` send entry on the IPC bridge, handled in the main process with Electron's `clipboard.writeText`. The sandboxed renderer cannot use the async clipboard API because the panel's permission handlers deliberately deny everything but audio capture, and this keeps that posture intact rather than widening it.
- The button is absolutely positioned in the bubble's margin, so a thread with the control lays out identically to one without it, and reveal is opacity-only per the motion rules. History remains inside the `ph-no-capture` subtree, so the control and the words it copies stay out of session recordings. The clipboard is this machine's own; nothing leaves it, so `PRIVACY.md` is unchanged.

## Evidence

- Platform-independent checks: `./scripts/check.sh` — exit 0, all suites reporting `fail 0`, including the new `messages offer a copy control while quiet events offer none` test in `apps/desktop`.
- macOS Electron verification (`./scripts/verify.sh`): `not run` — authored in a Linux cloud workspace; relying on CI's macOS evidence job.

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/33211912854/artifacts/9701979139) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/33211912854)

- Commit: `81e0ebaea374f6362bef4385ac320c138d6aa767`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

### Physical-device evidence

- Screenshot or screen recording: `not attached`
- Physical-notch check: `not performed`
- Device/display configuration: `not recorded`

## Notes

- The control is hover-revealed, so the deterministic fixture screenshot will show the History thread unchanged at rest; that is the intended resting appearance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)
