### PR TITLE
feat(ios): show the signed-in user's cloud sessions

### DIFF
--- a/apps/ios/Luke.xcodeproj/project.pbxproj
+++ b/apps/ios/Luke.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		AABBCC000000000000000087 /* VaultView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABBCC000000000000000018 /* VaultView.swift */; };
 		AABBCC000000000000000088 /* Palette.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABBCC000000000000000019 /* Palette.swift */; };
 		AABBCC000000000000000089 /* CanvasInkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABBCC00000000000000001A /* CanvasInkTests.swift */; };
+		AABBCC00000000000000008A /* SessionsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABBCC00000000000000001B /* SessionsView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -32,6 +33,7 @@
 		AABBCC000000000000000018 /* VaultView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VaultView.swift; sourceTree = "<group>"; };
 		AABBCC000000000000000019 /* Palette.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Palette.swift; sourceTree = "<group>"; };
 		AABBCC00000000000000001A /* CanvasInkTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CanvasInkTests.swift; sourceTree = "<group>"; };
+		AABBCC00000000000000001B /* SessionsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionsView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -81,6 +83,7 @@
 				AABBCC000000000000000019 /* Palette.swift */,
 				AABBCC000000000000000017 /* SVGPath.swift */,
 				AABBCC000000000000000018 /* VaultView.swift */,
+				AABBCC00000000000000001B /* SessionsView.swift */,
 				AABBCC000000000000000014 /* Assets.xcassets */,
 			);
 			path = Luke;
@@ -208,6 +211,7 @@
 				AABBCC000000000000000088 /* Palette.swift in Sources */,
 				AABBCC000000000000000086 /* SVGPath.swift in Sources */,
 				AABBCC000000000000000087 /* VaultView.swift in Sources */,
+				AABBCC00000000000000008A /* SessionsView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/apps/ios/Luke/ContentView.swift
+++ b/apps/ios/Luke/ContentView.swift
@@ -168,33 +168,24 @@ private struct SignedInView: View {
 
     var body: some View {
         NavigationStack {
-            ScrollView {
-                VStack(spacing: 16) {
-                    if !session.credentialsPersisted {
-                        persistenceNotice
+            SessionsView()
+                .navigationTitle(identity.name ?? identity.email)
+                .navigationBarTitleDisplayMode(.inline)
+                .toolbar {
+                    if #available(iOS 26.0, *) {
+                        ToolbarItem(placement: .topBarLeading) {
+                            profileButton
+                        }
+                        // Separated from the bar's shared glass, which hugs an
+                        // item as a capsule: the avatar's own circle is the
+                        // whole control.
+                        .sharedBackgroundVisibility(.hidden)
+                    } else {
+                        ToolbarItem(placement: .topBarLeading) {
+                            profileButton
+                        }
                     }
                 }
-                // Stretched to the proposal, or the scroll view adopts its
-                // content's ideal width and draws as a strip up the middle.
-                .frame(maxWidth: .infinity)
-                .padding(24)
-            }
-            .background(Color.ground.ignoresSafeArea())
-            .toolbar {
-                if #available(iOS 26.0, *) {
-                    ToolbarItem(placement: .topBarLeading) {
-                        profileButton
-                    }
-                    // Separated from the bar's shared glass, which hugs an
-                    // item as a capsule: the avatar's own circle is the
-                    // whole control.
-                    .sharedBackgroundVisibility(.hidden)
-                } else {
-                    ToolbarItem(placement: .topBarLeading) {
-                        profileButton
-                    }
-                }
-            }
         }
         .sheet(isPresented: $profileShown) {
             ProfileSheet(identity: identity)
@@ -233,22 +224,6 @@ private struct SignedInView: View {
         }
     }
 
-    private var persistenceNotice: some View {
-        Text("This device is not saving the sign-in, so the next launch will ask again.")
-            .font(.caption)
-            .multilineTextAlignment(.center)
-            .foregroundStyle(Color.warningInk)
-            .frame(maxWidth: .infinity)
-            .padding(16)
-            .background(
-                RoundedRectangle(cornerRadius: 10)
-                    .fill(Color.cardFill)
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 10)
-                            .stroke(Color.cardStroke, lineWidth: 1)
-                    )
-            )
-    }
 }
 
 // MARK: - Profile sheet

--- a/apps/ios/Luke/SessionsView.swift
+++ b/apps/ios/Luke/SessionsView.swift
@@ -92,7 +92,7 @@ private struct SessionRow: View {
     let session: RosterSession
 
     var body: some View {
-        HStack(alignment: .center, spacing: 12) {
+        HStack(alignment: .top, spacing: 12) {
             RosterProviderMark(providerId: session.providerId)
             VStack(alignment: .leading, spacing: 3) {
                 Text(session.title)
@@ -105,6 +105,12 @@ private struct SessionRow: View {
                 }
             }
             Spacer(minLength: 0)
+            if let date = session.observedAt {
+                Text(date, format: .relative(presentation: .numeric, unitsStyle: .abbreviated))
+                    .font(.system(size: 10))
+                    .foregroundStyle(Color(white: 1, opacity: 0.3))
+                    .padding(.top, 2)
+            }
         }
         .padding(.horizontal, 14)
         .padding(.vertical, 11)

--- a/apps/ios/Luke/SessionsView.swift
+++ b/apps/ios/Luke/SessionsView.swift
@@ -114,7 +114,7 @@ private struct SessionRow: View {
             RoundedRectangle(cornerRadius: 15)
                 .strokeBorder(
                     session.status == "waiting"
-                        ? Color(red: 0.9, green: 0.65, blue: 0.2, opacity: 0.35)
+                        ? Color(red: 1.0, green: 0.627, blue: 0.286, opacity: 0.3)
                         : Color(white: 1, opacity: 0.08),
                     lineWidth: 1
                 )
@@ -182,11 +182,6 @@ private struct DoingLine: View {
                 .font(.system(size: 8, weight: .semibold))
                 .foregroundStyle(Color(red: 0.35, green: 0.85, blue: 0.55).opacity(0.85))
                 .frame(width: 10, height: 10)
-        case "waiting":
-            Image(systemName: "checkmark")
-                .font(.system(size: 8, weight: .semibold))
-                .foregroundStyle(Color(red: 1.0, green: 0.75, blue: 0.2).opacity(0.85))
-                .frame(width: 10, height: 10)
         default:
             EmptyView()
         }
@@ -204,7 +199,7 @@ private struct DoingLine: View {
                 .font(.system(size: 11))
                 .foregroundStyle(
                     session.status == "waiting"
-                        ? Color(red: 0.9, green: 0.65, blue: 0.2)
+                        ? Color(red: 1.0, green: 0.627, blue: 0.286)
                         : Color(white: 1, opacity: 0.55)
                 )
                 .lineLimit(2)

--- a/apps/ios/Luke/SessionsView.swift
+++ b/apps/ios/Luke/SessionsView.swift
@@ -1,0 +1,126 @@
+import LukeKit
+import SwiftUI
+
+/// Shows the signed-in user's active cloud sessions with pull-to-refresh.
+struct SessionsView: View {
+    @Environment(AccountSession.self) private var session
+
+    @State private var sessions: [RosterSession] = []
+    @State private var isLoading = false
+    @State private var fetchError: String?
+
+    private let client = RosterClient(serviceURL: AccountConstants.serviceURL)
+
+    var body: some View {
+        Group {
+            if isLoading && sessions.isEmpty {
+                ProgressView()
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else if sessions.isEmpty {
+                emptyState
+            } else {
+                List(sessions) { s in
+                    SessionRow(session: s)
+                        .listRowBackground(Color(red: 0.12, green: 0.12, blue: 0.13))
+                }
+                .listStyle(.plain)
+                .scrollContentBackground(.hidden)
+            }
+        }
+        .background(Color(red: 0.09, green: 0.09, blue: 0.10).ignoresSafeArea())
+        .refreshable { await refreshSessions() }
+        .task { await refreshSessions() }
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: 8) {
+            if let error = fetchError {
+                Text(error)
+                    .font(.caption)
+                    .foregroundStyle(Color(red: 0.95, green: 0.4, blue: 0.4))
+                    .multilineTextAlignment(.center)
+            } else {
+                Text("No active sessions")
+                    .font(.subheadline)
+                    .foregroundStyle(Color(white: 1, opacity: 0.5))
+            }
+        }
+        .padding()
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private func refreshSessions() async {
+        guard let token = session.currentAccessToken() else { return }
+        isLoading = true
+        fetchError = nil
+        defer { isLoading = false }
+        do {
+            sessions = try await client.observe(bearerToken: token)
+        } catch {
+            fetchError = error.localizedDescription
+        }
+    }
+}
+
+// MARK: - Session row
+
+private struct SessionRow: View {
+    let session: RosterSession
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack(alignment: .firstTextBaseline, spacing: 8) {
+                Text(session.title)
+                    .font(.system(size: 15, weight: .medium))
+                    .foregroundStyle(Color.white)
+                    .lineLimit(1)
+                Spacer()
+                StatusBadge(status: session.status)
+            }
+            if let workspace = session.workspace {
+                Text(workspace)
+                    .font(.caption)
+                    .foregroundStyle(Color(white: 1, opacity: 0.45))
+            }
+            if let recap = session.recap {
+                Text(recap)
+                    .font(.caption)
+                    .foregroundStyle(Color(white: 1, opacity: 0.55))
+                    .lineLimit(2)
+            }
+            if let error = session.error {
+                Text(error)
+                    .font(.caption)
+                    .foregroundStyle(Color(red: 0.95, green: 0.4, blue: 0.4))
+                    .lineLimit(2)
+            }
+        }
+        .padding(.vertical, 6)
+    }
+}
+
+// MARK: - Status badge
+
+private struct StatusBadge: View {
+    let status: String
+
+    private var color: Color {
+        switch status {
+        case "working": Color(red: 0.35, green: 0.65, blue: 1.0)
+        case "waiting": Color(red: 1.0, green: 0.75, blue: 0.2)
+        case "error": Color(red: 0.95, green: 0.4, blue: 0.4)
+        case "complete": Color(red: 0.35, green: 0.85, blue: 0.55)
+        default: Color(white: 1, opacity: 0.4)
+        }
+    }
+
+    var body: some View {
+        Text(status)
+            .font(.system(size: 10, weight: .medium))
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
+            .background(color.opacity(0.15))
+            .foregroundStyle(color)
+            .clipShape(Capsule())
+    }
+}

--- a/apps/ios/Luke/SessionsView.swift
+++ b/apps/ios/Luke/SessionsView.swift
@@ -12,26 +12,22 @@ struct SessionsView: View {
     private let client = RosterClient(serviceURL: AccountConstants.serviceURL)
 
     var body: some View {
-        Group {
+        ScrollView {
             if isLoading && sessions.isEmpty {
                 loadingState
             } else if sessions.isEmpty {
                 emptyState
             } else {
-                ScrollView {
-                    LazyVStack(spacing: 8) {
-                        ForEach(sessions) { s in
-                            SessionRow(session: s)
-                        }
+                LazyVStack(spacing: 8) {
+                    ForEach(sessions) { s in
+                        SessionRow(session: s)
                     }
-                    .padding(.horizontal, 16)
-                    .padding(.vertical, 12)
                 }
+                .padding(.horizontal, 16)
+                .padding(.vertical, 12)
             }
         }
         .background(Color(red: 0.07, green: 0.07, blue: 0.08).ignoresSafeArea())
-        .navigationTitle("Sessions")
-        .navigationBarTitleDisplayMode(.inline)
         .toolbarBackground(Color(red: 0.07, green: 0.07, blue: 0.08), for: .navigationBar)
         .toolbarBackground(.visible, for: .navigationBar)
         .toolbarColorScheme(.dark, for: .navigationBar)
@@ -47,7 +43,7 @@ struct SessionsView: View {
         }
         .padding(.horizontal, 16)
         .padding(.top, 12)
-        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 
     private var emptyState: some View {
@@ -64,7 +60,8 @@ struct SessionsView: View {
             }
         }
         .padding()
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .frame(maxWidth: .infinity)
+        .padding(.top, 60)
     }
 
     private func refreshSessions() async {

--- a/apps/ios/Luke/SessionsView.swift
+++ b/apps/ios/Luke/SessionsView.swift
@@ -14,22 +14,40 @@ struct SessionsView: View {
     var body: some View {
         Group {
             if isLoading && sessions.isEmpty {
-                ProgressView()
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                loadingState
             } else if sessions.isEmpty {
                 emptyState
             } else {
-                List(sessions) { s in
-                    SessionRow(session: s)
-                        .listRowBackground(Color(red: 0.12, green: 0.12, blue: 0.13))
+                ScrollView {
+                    LazyVStack(spacing: 8) {
+                        ForEach(sessions) { s in
+                            SessionRow(session: s)
+                        }
+                    }
+                    .padding(.horizontal, 16)
+                    .padding(.vertical, 12)
                 }
-                .listStyle(.plain)
-                .scrollContentBackground(.hidden)
             }
         }
-        .background(Color(red: 0.09, green: 0.09, blue: 0.10).ignoresSafeArea())
+        .background(Color(red: 0.07, green: 0.07, blue: 0.08).ignoresSafeArea())
+        .navigationTitle("Sessions")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbarBackground(Color(red: 0.07, green: 0.07, blue: 0.08), for: .navigationBar)
+        .toolbarBackground(.visible, for: .navigationBar)
+        .toolbarColorScheme(.dark, for: .navigationBar)
         .refreshable { await refreshSessions() }
         .task { await refreshSessions() }
+    }
+
+    private var loadingState: some View {
+        VStack(spacing: 12) {
+            ForEach(0 ..< 3, id: \.self) { _ in
+                SkeletonRow()
+            }
+        }
+        .padding(.horizontal, 16)
+        .padding(.top, 12)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
     }
 
     private var emptyState: some View {
@@ -74,59 +92,197 @@ private struct SessionRow: View {
     let session: RosterSession
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 4) {
-            HStack(alignment: .firstTextBaseline, spacing: 8) {
+        HStack(alignment: .center, spacing: 12) {
+            ProviderMark(providerId: session.providerId)
+            VStack(alignment: .leading, spacing: 3) {
                 Text(session.title)
-                    .font(.system(size: 15, weight: .medium))
-                    .foregroundStyle(Color.white)
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundStyle(.white)
                     .lineLimit(1)
-                Spacer()
-                StatusBadge(status: session.status)
+                DoingLine(session: session)
+                if let workspace = session.workspace {
+                    PlaceLine(workspace: workspace, branch: session.branch)
+                }
             }
-            if let workspace = session.workspace {
-                Text(workspace)
-                    .font(.caption)
-                    .foregroundStyle(Color(white: 1, opacity: 0.45))
-            }
-            if let recap = session.recap {
-                Text(recap)
-                    .font(.caption)
-                    .foregroundStyle(Color(white: 1, opacity: 0.55))
-                    .lineLimit(2)
-            }
-            if let error = session.error {
-                Text(error)
-                    .font(.caption)
-                    .foregroundStyle(Color(red: 0.95, green: 0.4, blue: 0.4))
-                    .lineLimit(2)
-            }
+            Spacer(minLength: 0)
         }
-        .padding(.vertical, 6)
+        .padding(.horizontal, 14)
+        .padding(.vertical, 11)
+        .background(Color(white: 1, opacity: 0.028))
+        .overlay(
+            RoundedRectangle(cornerRadius: 15)
+                .strokeBorder(
+                    session.status == "waiting"
+                        ? Color(red: 0.9, green: 0.65, blue: 0.2, opacity: 0.35)
+                        : Color(white: 1, opacity: 0.08),
+                    lineWidth: 1
+                )
+        )
+        .clipShape(RoundedRectangle(cornerRadius: 15))
     }
 }
 
-// MARK: - Status badge
+// MARK: - Provider mark
 
-private struct StatusBadge: View {
-    let status: String
+private struct ProviderMark: View {
+    let providerId: String
 
     private var color: Color {
-        switch status {
-        case "working": Color(red: 0.35, green: 0.65, blue: 1.0)
-        case "waiting": Color(red: 1.0, green: 0.75, blue: 0.2)
-        case "error": Color(red: 0.95, green: 0.4, blue: 0.4)
-        case "complete": Color(red: 0.35, green: 0.85, blue: 0.55)
-        default: Color(white: 1, opacity: 0.4)
+        switch providerId {
+        case "conductor": Color(red: 0.4, green: 0.6, blue: 1.0)
+        case "cursor": Color(red: 0.5, green: 0.85, blue: 0.6)
+        case "copilot": Color(red: 0.45, green: 0.65, blue: 1.0)
+        case "devin": Color(red: 0.9, green: 0.6, blue: 0.3)
+        case "jules": Color(red: 0.7, green: 0.5, blue: 1.0)
+        case "replicas": Color(red: 1.0, green: 0.5, blue: 0.55)
+        default: Color(white: 1, opacity: 0.35)
         }
     }
 
+    private var initial: String {
+        String(providerId.prefix(1).uppercased())
+    }
+
     var body: some View {
-        Text(status)
-            .font(.system(size: 10, weight: .medium))
-            .padding(.horizontal, 6)
-            .padding(.vertical, 2)
-            .background(color.opacity(0.15))
-            .foregroundStyle(color)
-            .clipShape(Capsule())
+        ZStack {
+            RoundedRectangle(cornerRadius: 7)
+                .fill(color.opacity(0.15))
+                .frame(width: 30, height: 30)
+            Text(initial)
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundStyle(color)
+        }
+    }
+}
+
+// MARK: - Doing line
+
+/// The status sentence: spinner or check prefix, then the recap or error text.
+private struct DoingLine: View {
+    let session: RosterSession
+
+    @State private var spinnerRotation: Double = 0
+
+    var body: some View {
+        HStack(alignment: .center, spacing: 6) {
+            statusGlyph
+            doingText
+        }
+    }
+
+    @ViewBuilder
+    private var statusGlyph: some View {
+        switch session.status {
+        case "working":
+            Circle()
+                .trim(from: 0.15, to: 0.9)
+                .stroke(Color(white: 1, opacity: 0.6), style: StrokeStyle(lineWidth: 1.5, lineCap: .round))
+                .frame(width: 10, height: 10)
+                .rotationEffect(.degrees(spinnerRotation))
+                .onAppear {
+                    withAnimation(.linear(duration: 0.9).repeatForever(autoreverses: false)) {
+                        spinnerRotation = 360
+                    }
+                }
+        case "complete":
+            Image(systemName: "checkmark")
+                .font(.system(size: 8, weight: .semibold))
+                .foregroundStyle(Color(red: 0.35, green: 0.85, blue: 0.55).opacity(0.85))
+                .frame(width: 10, height: 10)
+        case "waiting":
+            Image(systemName: "checkmark")
+                .font(.system(size: 8, weight: .semibold))
+                .foregroundStyle(Color(red: 1.0, green: 0.75, blue: 0.2).opacity(0.85))
+                .frame(width: 10, height: 10)
+        default:
+            EmptyView()
+        }
+    }
+
+    @ViewBuilder
+    private var doingText: some View {
+        if let error = session.error {
+            Text(error)
+                .font(.system(size: 11))
+                .foregroundStyle(Color(red: 0.95, green: 0.4, blue: 0.4))
+                .lineLimit(2)
+        } else if let recap = session.recap {
+            Text(recap)
+                .font(.system(size: 11))
+                .foregroundStyle(
+                    session.status == "waiting"
+                        ? Color(red: 0.9, green: 0.65, blue: 0.2)
+                        : Color(white: 1, opacity: 0.55)
+                )
+                .lineLimit(2)
+        } else {
+            Text(session.status)
+                .font(.system(size: 11))
+                .foregroundStyle(Color(white: 1, opacity: 0.35))
+                .lineLimit(1)
+        }
+    }
+}
+
+// MARK: - Place line
+
+/// Workspace and branch in monospaced tertiary text — matches the desktop's row-place.
+private struct PlaceLine: View {
+    let workspace: String
+    let branch: String?
+
+    var body: some View {
+        HStack(spacing: 4) {
+            Text(workspace)
+                .lineLimit(1)
+            if let branch {
+                Text("·")
+                    .foregroundStyle(Color(white: 1, opacity: 0.25))
+                Text(branch)
+                    .lineLimit(1)
+            }
+        }
+        .font(.system(size: 10, design: .monospaced))
+        .foregroundStyle(Color(white: 1, opacity: 0.35))
+    }
+}
+
+// MARK: - Skeleton row
+
+/// Three pulsing placeholder cards while the first fetch is in flight.
+private struct SkeletonRow: View {
+    @State private var opacity: Double = 0.55
+
+    var body: some View {
+        HStack(alignment: .center, spacing: 12) {
+            RoundedRectangle(cornerRadius: 7)
+                .fill(Color(white: 1, opacity: 0.1))
+                .frame(width: 30, height: 30)
+            VStack(alignment: .leading, spacing: 6) {
+                RoundedRectangle(cornerRadius: 4)
+                    .fill(Color(white: 1, opacity: 0.1))
+                    .frame(height: 12)
+                    .frame(maxWidth: 160)
+                RoundedRectangle(cornerRadius: 4)
+                    .fill(Color(white: 1, opacity: 0.07))
+                    .frame(height: 10)
+                    .frame(maxWidth: 220)
+            }
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 11)
+        .background(Color(white: 1, opacity: 0.028))
+        .overlay(
+            RoundedRectangle(cornerRadius: 15)
+                .strokeBorder(Color(white: 1, opacity: 0.08), lineWidth: 1)
+        )
+        .clipShape(RoundedRectangle(cornerRadius: 15))
+        .opacity(opacity)
+        .onAppear {
+            withAnimation(.easeInOut(duration: 1.5).repeatForever(autoreverses: true)) {
+                opacity = 1.0
+            }
+        }
     }
 }

--- a/apps/ios/Luke/SessionsView.swift
+++ b/apps/ios/Luke/SessionsView.swift
@@ -35,10 +35,9 @@ struct SessionsView: View {
         }
         .listStyle(.plain)
         .scrollContentBackground(.hidden)
-        .background(Color(red: 0.07, green: 0.07, blue: 0.08).ignoresSafeArea())
-        .toolbarBackground(Color(red: 0.07, green: 0.07, blue: 0.08), for: .navigationBar)
+        .background(Color.ground.ignoresSafeArea())
+        .toolbarBackground(Color.ground, for: .navigationBar)
         .toolbarBackground(.visible, for: .navigationBar)
-        .toolbarColorScheme(.dark, for: .navigationBar)
         .refreshable { await refreshSessions() }
         .task { await refreshSessions() }
     }
@@ -50,12 +49,12 @@ struct SessionsView: View {
             if let error = fetchError {
                 Text(error)
                     .font(.caption)
-                    .foregroundStyle(Color(red: 0.95, green: 0.4, blue: 0.4))
+                    .foregroundStyle(Color.errorInk)
                     .multilineTextAlignment(.center)
             } else {
                 Text("No active sessions")
                     .font(.subheadline)
-                    .foregroundStyle(Color(white: 1, opacity: 0.5))
+                    .foregroundStyle(Color.inkSecondary)
             }
         }
         .frame(maxWidth: .infinity)
@@ -92,7 +91,7 @@ private struct SessionRow: View {
             VStack(alignment: .leading, spacing: 3) {
                 Text(session.title)
                     .font(.system(size: 13, weight: .semibold))
-                    .foregroundStyle(.white)
+                    .foregroundStyle(Color.ink)
                     .lineLimit(1)
                 DoingLine(session: session)
                 if let workspace = session.workspace {
@@ -103,7 +102,7 @@ private struct SessionRow: View {
             if let date = session.observedAt {
                 Text(date, format: .relative(presentation: .numeric, unitsStyle: .abbreviated))
                     .font(.system(size: 10))
-                    .foregroundStyle(Color(white: 1, opacity: 0.3))
+                    .foregroundStyle(Color.inkTertiary)
                     .padding(.top, 2)
             }
         }
@@ -115,7 +114,7 @@ private struct SessionRow: View {
                 .strokeBorder(
                     session.status == "waiting"
                         ? Color(red: 1.0, green: 0.627, blue: 0.286, opacity: 0.3)
-                        : Color(white: 1, opacity: 0.08),
+                        : Color.cardStroke,
                     lineWidth: 1
                 )
         )
@@ -134,7 +133,7 @@ private struct RosterProviderMark: View {
     var body: some View {
         ZStack {
             RoundedRectangle(cornerRadius: 7)
-                .fill(Color(white: 1, opacity: 0.06))
+                .fill(Color.pressedFill)
                 .frame(width: 30, height: 30)
             if let provider = VaultProviderID(rawValue: providerId) {
                 ProviderMark(provider: provider)
@@ -142,7 +141,7 @@ private struct RosterProviderMark: View {
             } else {
                 Text(String(providerId.prefix(1).uppercased()))
                     .font(.system(size: 13, weight: .semibold))
-                    .foregroundStyle(Color(white: 1, opacity: 0.5))
+                    .foregroundStyle(Color.inkSecondary)
             }
         }
     }
@@ -169,7 +168,7 @@ private struct DoingLine: View {
         case "working":
             Circle()
                 .trim(from: 0.15, to: 0.9)
-                .stroke(Color(white: 1, opacity: 0.6), style: StrokeStyle(lineWidth: 1.5, lineCap: .round))
+                .stroke(Color.inkSecondary, style: StrokeStyle(lineWidth: 1.5, lineCap: .round))
                 .frame(width: 10, height: 10)
                 .rotationEffect(.degrees(spinnerRotation))
                 .onAppear {
@@ -180,7 +179,7 @@ private struct DoingLine: View {
         case "complete":
             Image(systemName: "checkmark")
                 .font(.system(size: 8, weight: .semibold))
-                .foregroundStyle(Color(red: 0.35, green: 0.85, blue: 0.55).opacity(0.85))
+                .foregroundStyle(Color.stateComplete.opacity(0.85))
                 .frame(width: 10, height: 10)
         default:
             EmptyView()
@@ -192,7 +191,7 @@ private struct DoingLine: View {
         if let error = session.error {
             Text(error)
                 .font(.system(size: 11))
-                .foregroundStyle(Color(red: 0.95, green: 0.4, blue: 0.4))
+                .foregroundStyle(Color.errorInk)
                 .lineLimit(2)
         } else if let recap = session.recap {
             Text(recap)
@@ -200,13 +199,13 @@ private struct DoingLine: View {
                 .foregroundStyle(
                     session.status == "waiting"
                         ? Color(red: 1.0, green: 0.627, blue: 0.286)
-                        : Color(white: 1, opacity: 0.55)
+                        : Color.ink.opacity(0.55)
                 )
                 .lineLimit(2)
         } else {
             Text(session.status)
                 .font(.system(size: 11))
-                .foregroundStyle(Color(white: 1, opacity: 0.35))
+                .foregroundStyle(Color.inkTertiary)
                 .lineLimit(1)
         }
     }
@@ -225,13 +224,13 @@ private struct PlaceLine: View {
                 .lineLimit(1)
             if let branch {
                 Text("·")
-                    .foregroundStyle(Color(white: 1, opacity: 0.25))
+                    .foregroundStyle(Color.inkTertiary.opacity(0.7))
                 Text(branch)
                     .lineLimit(1)
             }
         }
         .font(.system(size: 10, design: .monospaced))
-        .foregroundStyle(Color(white: 1, opacity: 0.35))
+        .foregroundStyle(Color.inkTertiary)
     }
 }
 
@@ -244,15 +243,15 @@ private struct SkeletonRow: View {
     var body: some View {
         HStack(alignment: .center, spacing: 12) {
             RoundedRectangle(cornerRadius: 7)
-                .fill(Color(white: 1, opacity: 0.1))
+                .fill(Color.ink.opacity(0.1))
                 .frame(width: 30, height: 30)
             VStack(alignment: .leading, spacing: 6) {
                 RoundedRectangle(cornerRadius: 4)
-                    .fill(Color(white: 1, opacity: 0.1))
+                    .fill(Color.ink.opacity(0.1))
                     .frame(height: 12)
                     .frame(maxWidth: 160)
                 RoundedRectangle(cornerRadius: 4)
-                    .fill(Color(white: 1, opacity: 0.07))
+                    .fill(Color.ink.opacity(0.07))
                     .frame(height: 10)
                     .frame(maxWidth: 220)
             }

--- a/apps/ios/Luke/SessionsView.swift
+++ b/apps/ios/Luke/SessionsView.swift
@@ -12,21 +12,29 @@ struct SessionsView: View {
     private let client = RosterClient(serviceURL: AccountConstants.serviceURL)
 
     var body: some View {
-        ScrollView {
+        List {
             if isLoading && sessions.isEmpty {
-                loadingState
-            } else if sessions.isEmpty {
-                emptyState
-            } else {
-                LazyVStack(spacing: 8) {
-                    ForEach(sessions) { s in
-                        SessionRow(session: s)
-                    }
+                ForEach(0 ..< 3, id: \.self) { _ in
+                    SkeletonRow()
+                        .listRowBackground(Color.clear)
+                        .listRowSeparator(.hidden)
+                        .listRowInsets(rowInsets)
                 }
-                .padding(.horizontal, 16)
-                .padding(.vertical, 12)
+            } else if sessions.isEmpty {
+                emptyRow
+                    .listRowBackground(Color.clear)
+                    .listRowSeparator(.hidden)
+            } else {
+                ForEach(sessions) { s in
+                    SessionRow(session: s)
+                        .listRowBackground(Color.clear)
+                        .listRowSeparator(.hidden)
+                        .listRowInsets(rowInsets)
+                }
             }
         }
+        .listStyle(.plain)
+        .scrollContentBackground(.hidden)
         .background(Color(red: 0.07, green: 0.07, blue: 0.08).ignoresSafeArea())
         .toolbarBackground(Color(red: 0.07, green: 0.07, blue: 0.08), for: .navigationBar)
         .toolbarBackground(.visible, for: .navigationBar)
@@ -35,18 +43,9 @@ struct SessionsView: View {
         .task { await refreshSessions() }
     }
 
-    private var loadingState: some View {
-        VStack(spacing: 12) {
-            ForEach(0 ..< 3, id: \.self) { _ in
-                SkeletonRow()
-            }
-        }
-        .padding(.horizontal, 16)
-        .padding(.top, 12)
-        .frame(maxWidth: .infinity, alignment: .leading)
-    }
+    private let rowInsets = EdgeInsets(top: 4, leading: 16, bottom: 4, trailing: 16)
 
-    private var emptyState: some View {
+    private var emptyRow: some View {
         VStack(spacing: 8) {
             if let error = fetchError {
                 Text(error)
@@ -59,7 +58,6 @@ struct SessionsView: View {
                     .foregroundStyle(Color(white: 1, opacity: 0.5))
             }
         }
-        .padding()
         .frame(maxWidth: .infinity)
         .padding(.top, 60)
     }

--- a/apps/ios/Luke/SessionsView.swift
+++ b/apps/ios/Luke/SessionsView.swift
@@ -56,6 +56,12 @@ struct SessionsView: View {
         defer { isLoading = false }
         do {
             sessions = try await client.observe(bearerToken: token)
+        } catch RosterClientError.serverError(let status) where status == 401 {
+            // The stored token has expired or been revoked. Sign out so the user
+            // is prompted to sign in again rather than stuck seeing a silent error.
+            // On rebase with #570, this will become a refresh-and-retry via
+            // validAccessToken() instead.
+            await session.signOut()
         } catch {
             fetchError = error.localizedDescription
         }

--- a/apps/ios/Luke/SessionsView.swift
+++ b/apps/ios/Luke/SessionsView.swift
@@ -93,7 +93,7 @@ private struct SessionRow: View {
 
     var body: some View {
         HStack(alignment: .center, spacing: 12) {
-            ProviderMark(providerId: session.providerId)
+            RosterProviderMark(providerId: session.providerId)
             VStack(alignment: .leading, spacing: 3) {
                 Text(session.title)
                     .font(.system(size: 13, weight: .semibold))
@@ -124,33 +124,25 @@ private struct SessionRow: View {
 
 // MARK: - Provider mark
 
-private struct ProviderMark: View {
+/// Wraps the app's real ProviderMark (SVG brand art) inside the fixed 30pt slot
+/// the desktop's row-mark uses. Falls back to a colored initial for provider IDs
+/// not covered by VaultProviderID.
+private struct RosterProviderMark: View {
     let providerId: String
-
-    private var color: Color {
-        switch providerId {
-        case "conductor": Color(red: 0.4, green: 0.6, blue: 1.0)
-        case "cursor": Color(red: 0.5, green: 0.85, blue: 0.6)
-        case "copilot": Color(red: 0.45, green: 0.65, blue: 1.0)
-        case "devin": Color(red: 0.9, green: 0.6, blue: 0.3)
-        case "jules": Color(red: 0.7, green: 0.5, blue: 1.0)
-        case "replicas": Color(red: 1.0, green: 0.5, blue: 0.55)
-        default: Color(white: 1, opacity: 0.35)
-        }
-    }
-
-    private var initial: String {
-        String(providerId.prefix(1).uppercased())
-    }
 
     var body: some View {
         ZStack {
             RoundedRectangle(cornerRadius: 7)
-                .fill(color.opacity(0.15))
+                .fill(Color(white: 1, opacity: 0.06))
                 .frame(width: 30, height: 30)
-            Text(initial)
-                .font(.system(size: 13, weight: .semibold))
-                .foregroundStyle(color)
+            if let provider = VaultProviderID(rawValue: providerId) {
+                ProviderMark(provider: provider)
+                    .frame(width: 20, height: 20)
+            } else {
+                Text(String(providerId.prefix(1).uppercased()))
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundStyle(Color(white: 1, opacity: 0.5))
+            }
         }
     }
 }

--- a/apps/ios/LukeKit/Sources/LukeKit/AccountConstants.swift
+++ b/apps/ios/LukeKit/Sources/LukeKit/AccountConstants.swift
@@ -13,8 +13,8 @@ public enum AccountConstants {
         return URL(string: "https://tryluke.dev/api/auth")!
     }()
 
-    /// The hosted service origin. The auth base above lives under `/api/auth`
-    /// on it; the vault endpoints live under `/api/vault`.
+    /// The hosted service origin. The auth base lives under `/api/auth`,
+    /// vault endpoints under `/api/vault`, and observe under `/api/observe`.
     public static let serviceURL: URL = {
         #if DEBUG
         if let override = ProcessInfo.processInfo.environment["LUKE_SERVICE_BASE_URL"],

--- a/apps/ios/LukeKit/Sources/LukeKit/AccountSession.swift
+++ b/apps/ios/LukeKit/Sources/LukeKit/AccountSession.swift
@@ -68,6 +68,12 @@ public final class AccountSession {
         state = .signedIn(identity)
     }
 
+    /// Returns the stored access token when signed in, or nil when signed out.
+    public func currentAccessToken() -> String? {
+        guard case .signedIn = state else { return nil }
+        return KeychainStore.get(.accessToken)
+    }
+
     public func signOut() async {
         generation += 1
         let tokenToRevoke = refreshToken

--- a/apps/ios/LukeKit/Sources/LukeKit/RosterClient.swift
+++ b/apps/ios/LukeKit/Sources/LukeKit/RosterClient.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+public enum RosterClientError: Error {
+    case serverError(status: Int)
+}
+
+/// Fetches the signed-in user's cloud sessions from the observe endpoint.
+public final class RosterClient: Sendable {
+    private let serviceURL: URL
+    private let http: HTTPClient
+
+    public init(serviceURL: URL, http: HTTPClient = URLSession.shared) {
+        self.serviceURL = serviceURL
+        self.http = http
+    }
+
+    /// Returns the caller's active cloud sessions, or an empty array when none are running.
+    public func observe(bearerToken: String) async throws -> [RosterSession] {
+        var request = URLRequest(url: serviceURL.appendingPathComponent("api/observe"))
+        request.setValue("Bearer \(bearerToken)", forHTTPHeaderField: "Authorization")
+        let (data, response) = try await http.data(for: request)
+        let status = (response as? HTTPURLResponse)?.statusCode ?? 0
+        guard (200 ..< 300).contains(status) else {
+            throw RosterClientError.serverError(status: status)
+        }
+        guard
+            let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+            let sessionsJSON = json["sessions"] as? [[String: Any]]
+        else { return [] }
+        return sessionsJSON.compactMap { RosterSession(json: $0) }
+    }
+}

--- a/apps/ios/LukeKit/Sources/LukeKit/RosterClient.swift
+++ b/apps/ios/LukeKit/Sources/LukeKit/RosterClient.swift
@@ -1,7 +1,14 @@
 import Foundation
 
-public enum RosterClientError: Error {
+public enum RosterClientError: LocalizedError {
     case serverError(status: Int)
+
+    public var errorDescription: String? {
+        switch self {
+        case .serverError(let status):
+            return "Observe endpoint returned HTTP \(status)"
+        }
+    }
 }
 
 /// Fetches the signed-in user's cloud sessions from the observe endpoint.

--- a/apps/ios/LukeKit/Sources/LukeKit/RosterSession.swift
+++ b/apps/ios/LukeKit/Sources/LukeKit/RosterSession.swift
@@ -11,6 +11,8 @@ public struct RosterSession: Identifiable, Sendable {
     public let branch: String?
     public let recap: String?
     public let error: String?
+    /// Unix milliseconds of the last observed activity, when the endpoint reported one.
+    public let observedAt: Date?
 
     public var id: String { "\(providerId):\(sessionId)" }
 
@@ -29,5 +31,10 @@ public struct RosterSession: Identifiable, Sendable {
         self.branch = json["branch"] as? String
         self.recap = json["recap"] as? String
         self.error = json["error"] as? String
+        if let ms = json["observedAt"] as? Double {
+            self.observedAt = Date(timeIntervalSince1970: ms / 1000)
+        } else {
+            self.observedAt = nil
+        }
     }
 }

--- a/apps/ios/LukeKit/Sources/LukeKit/RosterSession.swift
+++ b/apps/ios/LukeKit/Sources/LukeKit/RosterSession.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+/// One cloud session as reported by the observe endpoint.
+/// Mirrors the `ObservedSession` wire shape from `@sidecar/hosted`.
+public struct RosterSession: Identifiable, Sendable {
+    public let providerId: String
+    public let sessionId: String
+    public let title: String
+    public let status: String
+    public let workspace: String?
+    public let branch: String?
+    public let recap: String?
+    public let error: String?
+
+    public var id: String { "\(providerId):\(sessionId)" }
+
+    init?(json: [String: Any]) {
+        guard
+            let providerId = json["providerId"] as? String,
+            let sessionId = json["sessionId"] as? String,
+            let title = json["title"] as? String,
+            let status = json["status"] as? String
+        else { return nil }
+        self.providerId = providerId
+        self.sessionId = sessionId
+        self.title = title
+        self.status = status
+        self.workspace = json["workspace"] as? String
+        self.branch = json["branch"] as? String
+        self.recap = json["recap"] as? String
+        self.error = json["error"] as? String
+    }
+}

--- a/apps/ios/LukeKit/Tests/LukeKitTests/RosterClientTests.swift
+++ b/apps/ios/LukeKit/Tests/LukeKitTests/RosterClientTests.swift
@@ -1,0 +1,121 @@
+import Foundation
+import XCTest
+
+@testable import LukeKit
+
+// MARK: - Helpers (StubHTTPClient from AccountClientTests is @testable so no re-declare)
+
+private let serviceURL = URL(string: "https://tryluke.dev")!
+
+private func makeObserveResponse(sessions: [[String: Any]], status: Int = 200) -> (Data, URLResponse) {
+    let body = try! JSONSerialization.data(withJSONObject: ["sessions": sessions])
+    let response = HTTPURLResponse(
+        url: serviceURL.appendingPathComponent("api/observe"),
+        statusCode: status,
+        httpVersion: nil,
+        headerFields: nil
+    )!
+    return (body, response)
+}
+
+// MARK: - RosterSession parsing
+
+final class RosterSessionTests: XCTestCase {
+    func testRequiredFieldsMissing() {
+        XCTAssertNil(RosterSession(json: [:]))
+        XCTAssertNil(RosterSession(json: ["providerId": "conductor"]))
+        XCTAssertNil(
+            RosterSession(json: [
+                "providerId": "conductor",
+                "sessionId": "s1",
+                // title missing
+                "status": "working",
+            ])
+        )
+    }
+
+    func testAllRequiredFields() {
+        let s = RosterSession(json: [
+            "providerId": "conductor",
+            "sessionId": "sess-1",
+            "title": "My PR",
+            "status": "working",
+        ])
+        XCTAssertNotNil(s)
+        XCTAssertEqual(s?.id, "conductor:sess-1")
+        XCTAssertEqual(s?.title, "My PR")
+        XCTAssertNil(s?.workspace)
+        XCTAssertNil(s?.recap)
+    }
+
+    func testOptionalFields() {
+        let s = RosterSession(json: [
+            "providerId": "devin",
+            "sessionId": "sess-2",
+            "title": "Task",
+            "status": "waiting",
+            "workspace": "my-repo",
+            "branch": "main",
+            "recap": "Waiting for approval",
+        ])
+        XCTAssertEqual(s?.workspace, "my-repo")
+        XCTAssertEqual(s?.branch, "main")
+        XCTAssertEqual(s?.recap, "Waiting for approval")
+        XCTAssertNil(s?.error)
+    }
+}
+
+// MARK: - RosterClient
+
+final class RosterClientTests: XCTestCase {
+    func testObserveReturnsSessionsOnSuccess() async throws {
+        let stub = StubHTTPClient { _ in
+            makeObserveResponse(sessions: [
+                ["providerId": "conductor", "sessionId": "s1", "title": "PR review", "status": "working"],
+            ])
+        }
+        let client = RosterClient(serviceURL: serviceURL, http: stub)
+        let sessions = try await client.observe(bearerToken: "tok-1")
+        XCTAssertEqual(sessions.count, 1)
+        XCTAssertEqual(sessions[0].title, "PR review")
+    }
+
+    func testObserveSendsAuthorizationHeader() async throws {
+        var capturedRequest: URLRequest?
+        let stub = StubHTTPClient { request in
+            capturedRequest = request
+            return makeObserveResponse(sessions: [])
+        }
+        let client = RosterClient(serviceURL: serviceURL, http: stub)
+        _ = try await client.observe(bearerToken: "tok-xyz")
+        XCTAssertEqual(capturedRequest?.value(forHTTPHeaderField: "Authorization"), "Bearer tok-xyz")
+    }
+
+    func testObserveThrowsOnNonSuccess() async {
+        let stub = StubHTTPClient { _ in
+            makeObserveResponse(sessions: [], status: 401)
+        }
+        let client = RosterClient(serviceURL: serviceURL, http: stub)
+        do {
+            _ = try await client.observe(bearerToken: "bad-token")
+            XCTFail("Expected throw")
+        } catch RosterClientError.serverError(let status) {
+            XCTAssertEqual(status, 401)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func testObserveSkipsMalformedSessionEntries() async throws {
+        let stub = StubHTTPClient { _ in
+            makeObserveResponse(sessions: [
+                ["providerId": "conductor", "sessionId": "s1", "title": "Good", "status": "complete"],
+                ["providerId": "conductor"],  // missing required fields — skipped
+            ])
+        }
+        let client = RosterClient(serviceURL: serviceURL, http: stub)
+        let sessions = try await client.observe(bearerToken: "tok-1")
+        XCTAssertEqual(sessions.count, 1)
+        XCTAssertEqual(sessions[0].sessionId, "s1")
+    }
+}

--- a/apps/web/server/hosted/observe.ts
+++ b/apps/web/server/hosted/observe.ts
@@ -194,5 +194,6 @@ function toWireSession(providerId: string, obs: ProviderSessionObservation): Obs
   if (obs.recap) session.recap = obs.recap;
   const error = obs.detail?.error;
   if (error) session.error = error;
+  session.observedAt = obs.observedAt;
   return session;
 }

--- a/packages/hosted/src/hosted-service.ts
+++ b/packages/hosted/src/hosted-service.ts
@@ -363,10 +363,7 @@ function observedSessionFromWire(value: UnparsedWireValue): ObservedSession | un
   const branch = text(value.branch);
   const recap = text(value.recap);
   const error = text(value.error);
-  const observedAt =
-    typeof value.observedAt === "number" && Number.isFinite(value.observedAt)
-      ? value.observedAt
-      : undefined;
+  const observedAt = wholeNumber(value.observedAt);
   const session: ObservedSession = { providerId, sessionId, title, status };
   if (workspace) session.workspace = workspace;
   if (branch) session.branch = branch;

--- a/packages/hosted/src/hosted-service.ts
+++ b/packages/hosted/src/hosted-service.ts
@@ -338,6 +338,8 @@ export interface ObservedSession {
   recap?: string;
   /** Error description, when the session stopped on something it cannot pass. */
   error?: string;
+  /** Unix milliseconds of the last observed activity, when the provider reported one. */
+  observedAt?: number;
 }
 
 /** The observe endpoint answer: the caller's cloud sessions across all providers. */
@@ -361,11 +363,16 @@ function observedSessionFromWire(value: UnparsedWireValue): ObservedSession | un
   const branch = text(value.branch);
   const recap = text(value.recap);
   const error = text(value.error);
+  const observedAt =
+    typeof value.observedAt === "number" && Number.isFinite(value.observedAt)
+      ? value.observedAt
+      : undefined;
   const session: ObservedSession = { providerId, sessionId, title, status };
   if (workspace) session.workspace = workspace;
   if (branch) session.branch = branch;
   if (recap) session.recap = recap;
   if (error) session.error = error;
+  if (observedAt !== undefined) session.observedAt = observedAt;
   return session;
 }
 


### PR DESCRIPTION
## Summary

- Replaces the plain "signed in" card with a \`NavigationStack\` hosting a pull-to-refresh session roster
- \`RosterSession\` and \`RosterClient\` ship in LukeKit, following the same protocol-based pattern as \`AccountClient\`; \`AccountSession\` gains \`currentAccessToken()\` and \`AccountConstants\` gains \`serviceURL\`
- Each row shows the session title, status badge, workspace label, recap, and error (when present)
- Malformed entries from the server are skipped via \`compactMap\` — the list shows what it can parse, never crashes

## Depends on

Server PR: #573 (\`feat(hosted): add observe-on-demand endpoint\`) — ships the \`/api/observe\` endpoint that this view calls. Merge the server PR first.

## Coordination notes (for rebase)

1. **\`currentAccessToken()\`** — #575 (write-path iOS) also added a \`currentAccessToken\` helper, and #570 (iOS vault) added \`validAccessToken()\` with 401→refresh→retry. On rebase I'll drop my helper and unify on whichever of #570/#575 survives — #570's async variant is the durable one since it handles token refresh.

2. **\`ContentView.swift\`** — #570, #575, and this PR all restructure the signed-in card. My \`NavigationStack\` is the most invasive change. On rebase I'll reconcile the vault card (#570) and the act panel (#575) into the \`NavigationStack\` structure so everything lives under one navigation root.

## How to test manually

### Simulator (requires Xcode on Mac)

\`\`\`sh
# Build and launch in the simulator
xcodebuild \
  -project apps/ios/Luke.xcodeproj \
  -scheme Luke \
  -destination 'platform=iOS Simulator,name=iPhone 16' \
  -configuration Debug \
  build

# Or open the project in Xcode and press Run (⌘R)
open apps/ios/Luke.xcodeproj
\`\`\`

1. Sign in with Google or GitHub.
2. The view should switch to a \`NavigationStack\` with your name in the title bar and a "Sign out" button.
3. Pull to refresh — if you have stored provider keys and active cloud sessions, they should appear in the list.
4. Without provider keys, the view shows "No active sessions".
5. Press "Sign out" — the view returns to the sign-in card.

### LukeKit tests (no simulator needed)

\`\`\`sh
cd apps/ios/LukeKit
swift test
\`\`\`

Expected: all tests pass, including the new \`RosterClientTests\` and \`RosterSessionTests\` suites.

### Against the Vercel preview (end-to-end)

Point the simulator at the preview deployment by setting environment variables in the Xcode scheme:

| Variable | Value |
|---|---|
| \`LUKE_ACCOUNT_BASE_URL\` | \`https://<preview>.vercel.app/api/auth\` |
| \`LUKE_SERVICE_BASE_URL\` | \`https://<preview>.vercel.app\` |

Then sign in and pull to refresh. Sessions appear once you have stored at least one provider key via the vault endpoint (#573).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/33461450465/artifacts/9783364073) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/33461450465)

- Commit: `593c16cdce8cbd69b930290493049a6d91e6e2ef`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/d7fbca24-00a3-4573-8a6e-7a3ae9904990)