### PR TITLE
feat(notch): replace the session count with the provider marks

### DIFF
--- a/apps/desktop/src/renderer/AGENTS.md
+++ b/apps/desktop/src/renderer/AGENTS.md
@@ -46,7 +46,7 @@ The window never animates its own frame. An animated `setBounds` re-lays out
 the whole renderer on every frame, because the panel is anchored to the
 viewport's centre. Everything layered on the surface must move with `transform`
 and `opacity` only. Animating width, height, padding, or font-size on the
-wings, the count badge, or the rows re-shapes text on every frame and is what
+wings, the sign-in label, or the rows re-shapes text on every frame and is what
 makes the motion stutter.
 
 The surface is opaque in every state, because it has to pass for part of a

--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -748,25 +748,6 @@ export function App(): React.JSX.Element {
 
   const leavingPanel = useLeavingPanel(presentation);
 
-  // Clicking an icon in the top strip (notch wing) automatically sets the
-  // filter for that app or provider and reveals the sessions in the panel.
-  // Clicking an already-selected single filter toggles it back to all sessions.
-  const handleSelectWingFilter = useCallback(
-    (filter: SessionFilter) => {
-      cancelHover();
-      if (presentationOf() !== PANEL_PRESENTATION.PANEL) {
-        void changeMode(true);
-      }
-      setTab(PANEL_TAB.SESSIONS);
-      setSessionView((current) => ({
-        ...current,
-        filters: sameSessionFilters(current.filters, [filter]) ? [] : [filter],
-      }));
-      setOptionsOpen(false);
-    },
-    [cancelHover, changeMode, presentationOf, setTab],
-  );
-
   /**
    * The panel following its content down is the one move that can take the
    * shape out from under a resting pointer — a settings page opening shorter
@@ -3018,11 +2999,14 @@ export function App(): React.JSX.Element {
   // Luke is watching, not what the panel is currently showing — but it reads
   // in the list's own sort, so the wing's marks sit in the order the rows do.
   const tally = sessionTally(visibleSessions, sessionView.sort);
-  // The capsule button announces the same fact the badge draws: until the
-  // first roster reading lands, an unread zero is "checking", never "none
-  // tracked" — assistive tech must not hear a claim the wing is not making.
-  const tallyAnnouncement =
-    !accountGated && !sessionsSettled && tally.total === 0
+  // The one sentence the wing states about the roster, derived here so the
+  // capsule button's label and the wing's live region can never drift. Until
+  // the first roster reading lands, an unread zero is "checking", never "none
+  // tracked" — assistive tech must not hear a claim the wing is not making —
+  // and a gated Luke is not checking anything.
+  const tallyAnnouncement = accountGated
+    ? "Sign in"
+    : !sessionsSettled && tally.total === 0
       ? "Checking for sessions"
       : tallySummary(tally);
   const list = arrangeSessions(visibleSessions, sessionView);
@@ -3414,8 +3398,7 @@ export function App(): React.JSX.Element {
         presentation={presentation}
         housingWidth={display.notch.housingWidth}
         accountGated={accountGated}
-        onSelectFilter={handleSelectWingFilter}
-        activeFilters={sessionView.filters}
+        statusLabel={tallyAnnouncement}
       />
 
       {/* The one signed-out Luke. Like the caption, he is a single element in

--- a/apps/desktop/src/renderer/introduction/introduction-takeover.tsx
+++ b/apps/desktop/src/renderer/introduction/introduction-takeover.tsx
@@ -25,7 +25,7 @@ import { NotchWings } from "../notch-wings";
 import { SessionRow, type SessionWriteHandlers } from "../panel-body";
 import { PANEL_PRESENTATION } from "../panel-state";
 import { RealtimeVoiceSession } from "../realtime-session";
-import { displaySessions, type SessionView, sessionTally } from "../session-model";
+import { displaySessions, type SessionView, sessionTally, tallySummary } from "../session-model";
 import { parseMilliseconds, useSessionReorderMotion } from "../session-motion";
 import { MicrophoneIcon } from "../settings-icons";
 import { useSignInFaceCycle } from "../sign-in-gate";
@@ -741,6 +741,7 @@ export function IntroductionTakeover({
         ...rows.filter((row) => row.id !== tourFlipId),
       ]
     : rows;
+  const stagedTally = sessionTally(stagedRows);
   const rowsNow = rowsPretend ? FIXTURE_EPOCH_MS : Date.now();
   // Whose turn the strip's meter draws, on the app's own vocabulary. The face
   // yields to the meter while the developer holds the floor — the real wings
@@ -850,12 +851,12 @@ export function IntroductionTakeover({
         </div>
       ) : null}
       {/* The real wings, the moment there is a strip to stand in: the same
-          face, meter, and count the app draws, trading the face for the meter
+          face, meter, and marks the app draws, trading the face for the meter
           while the developer holds the floor. At the gate the strip goes
           deliberately bare, exactly as the app's own signed-out strip does. */}
       {landed ? (
         <NotchWings
-          tally={sessionTally(stagedRows)}
+          tally={stagedTally}
           analyser={meterAnalyser}
           {...(voiceTurn ? { voice: voiceTurn } : undefined)}
           fixtureSpeaking={false}
@@ -867,6 +868,7 @@ export function IntroductionTakeover({
           presentation={presentation}
           housingWidth={bootstrap.display.notch.housingWidth}
           accountGated={standingDown}
+          statusLabel={standingDown ? "Sign in" : tallySummary(stagedTally)}
         />
       ) : null}
       {/* The app's own signed-out Luke, at the wing spot the capsule pose

--- a/apps/desktop/src/renderer/luke-guide.ts
+++ b/apps/desktop/src/renderer/luke-guide.ts
@@ -335,9 +335,19 @@ export function buildLukeGuide(input: LukeGuideInput): AppGuideSnapshot {
     {
       label: "What Luke is",
       detail:
-        "A macOS sidecar living beside the notch. The number beside the housing counts the " +
-        "sessions that most need the developer, wearing that state's colour. Hovering peeks, " +
-        "pressing opens the panel, and Escape closes what is open.",
+        "A macOS sidecar living beside the notch. Luke's own face sits on one side of the " +
+        "housing and the marks of the apps holding tracked work sit on the other. Hovering " +
+        "peeks, pressing opens the panel, and Escape closes what is open.",
+    },
+    {
+      label: "The marks beside the housing",
+      detail:
+        "The apps holding the tracked sessions, most urgent first. At rest there is room " +
+        "for one, so the capsule shows the app whose session needs a person soonest; " +
+        "hovering or opening the panel spreads the whole set out. They report which apps " +
+        "Luke is watching and nothing more — they are not controls, and pressing one does " +
+        "nothing. Narrowing the list by app is done with the filter chips in the Sessions " +
+        "tab.",
     },
     {
       label: "The panel",

--- a/apps/desktop/src/renderer/notch-wings.test.ts
+++ b/apps/desktop/src/renderer/notch-wings.test.ts
@@ -2,19 +2,18 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { CAPSULE_SIDE_WIDTH, PANEL_WIDTH, PEEK_MIN_WIDTH } from "@sidecar/surface";
 import {
-  countBadgeFit,
-  OVERFLOW_SLOT_ID,
   peekSideWidth,
+  signInLabelFit,
   wingMarkCapacity,
+  wingPileOffset,
   wingSlots,
 } from "./notch-wings";
-import { PANEL_PRESENTATION } from "./panel-state";
 import type { ProviderTally } from "./session-model";
 
 const panelSideWidth = (housingWidth: number) => (PANEL_WIDTH - housingWidth) / 2;
 
-test("the peek's side beside the 14-inch housing holds three marks", () => {
-  assert.equal(wingMarkCapacity(peekSideWidth(210)), 3);
+test("the peek's side beside the 14-inch housing holds four marks", () => {
+  assert.equal(wingMarkCapacity(peekSideWidth(210)), 4);
 });
 
 test("the bubble's peek side is half the floored peek, so it holds more marks", () => {
@@ -24,9 +23,9 @@ test("the bubble's peek side is half the floored peek, so it holds more marks", 
 
 test("the panel's side holds what is left after the housing", () => {
   // The fixture display's 210px housing: (620 - 210) / 2 = 205px a side.
-  assert.equal(wingMarkCapacity(panelSideWidth(210)), 7);
+  assert.equal(wingMarkCapacity(panelSideWidth(210)), 8);
   // No housing at all — a display without a notch — leaves the most room.
-  assert.equal(wingMarkCapacity(panelSideWidth(0)), 12);
+  assert.equal(wingMarkCapacity(panelSideWidth(0)), 13);
 });
 
 test("a wider housing costs marks rather than clipping them", () => {
@@ -37,21 +36,27 @@ test("a wing too narrow for the arithmetic still shows one mark", () => {
   assert.equal(wingMarkCapacity(0), 1);
 });
 
-test("while the meter stands beside the face it reserves its own room", () => {
-  // Both reservations spend the same 29 + 26 + 14 the plain arithmetic does,
-  // plus a second 26 for the meter now standing beside the face too.
-  assert.equal(wingMarkCapacity(peekSideWidth(210), true), 2);
-  assert.equal(wingMarkCapacity(panelSideWidth(210), true), 6);
+// The capsule's own side, and the last pixels of it the resting mark keeps
+// clear: the shape is turning its corner there, and the wing clips at the
+// peek's bound rather than the capsule's, so nothing catches a mark drawn past
+// it.
+const RESTING_KEEP = 6;
+const WING_INSET = 9;
+const MARK_WIDTH = 14;
+const MARK_AND_GAP = 21;
+
+test("the one mark drawn at rest stays inside the capsule's side", () => {
+  // The invariant the whole opacity-at-rest change hangs on: a resting mark
+  // drawn past the capsule is drawn on the desktop, and no clip saves it.
+  const right = WING_INSET + wingPileOffset(0) + MARK_WIDTH;
+  assert.ok(right <= CAPSULE_SIDE_WIDTH - RESTING_KEEP);
 });
 
-test("the meter's reservation never grows the capacity, only shrinks it", () => {
-  for (const sideWidth of [0, 40, peekSideWidth(210), panelSideWidth(210), panelSideWidth(0)]) {
-    assert.ok(wingMarkCapacity(sideWidth, true) <= wingMarkCapacity(sideWidth));
-  }
-});
-
-test("a wing too narrow for the meter's own room still shows one mark", () => {
-  assert.equal(wingMarkCapacity(0, true), 1);
+test("every mark past the first rests exactly on it", () => {
+  const seat = (index: number) => wingPileOffset(index) + MARK_AND_GAP * index;
+  assert.equal(seat(0), 0);
+  assert.equal(seat(1), 0);
+  assert.equal(seat(4), 0);
 });
 
 const providers = (...ids: string[]): ProviderTally[] =>
@@ -65,27 +70,15 @@ test("providers that fit are one slot each, named by their own id", () => {
   );
 });
 
-test("more providers than slots ends the strip with the count of the rest", () => {
+test("more providers than slots truncates rather than counting the rest", () => {
   const slots = wingSlots(providers("a", "b", "c", "d", "e"), 4);
   assert.deepEqual(
     slots.map((slot) => slot.id),
-    ["a", "b", "c", OVERFLOW_SLOT_ID],
+    ["a", "b", "c", "d"],
   );
-  const overflow = slots[3];
-  assert.ok(overflow !== undefined && !("provider" in overflow));
-  // The count names its own number: the two that lost the arithmetic, plus the
-  // one whose slot the count itself took.
-  assert.equal(overflow.unshown, 2);
 });
 
-test("the count keeps one id however many it stands for, so it glides rather than re-arriving", () => {
-  const [grown] = wingSlots(providers("a", "b", "c", "d", "e", "f"), 4).slice(-1);
-  const [shrunk] = wingSlots(providers("a", "b", "c", "d", "e"), 4).slice(-1);
-  assert.ok(grown !== undefined && shrunk !== undefined);
-  assert.equal(grown.id, shrunk.id);
-});
-
-test("exactly filling the wing needs no count", () => {
+test("exactly filling the wing drops nothing", () => {
   const slots = wingSlots(providers("a", "b", "c", "d"), 4);
   assert.deepEqual(
     slots.map((slot) => slot.id),
@@ -93,76 +86,17 @@ test("exactly filling the wing needs no count", () => {
   );
 });
 
-// The badge's room in the arithmetic below: the capsule's 36px side minus the
-// wing's 9px inset and the 2px kept off the shape's edge, and the peek's 124px
-// side minus the same.
-const capsuleRoom = CAPSULE_SIDE_WIDTH - 11;
-const peekRoom = peekSideWidth(210) - 11;
+test("the sign-in label keeps its resting scale while the words fit", () => {
+  assert.equal(signInLabelFit(30), 1);
+});
 
-test("the sign-in label starts at the housing and keeps clear of the strip's corner", () => {
-  // Flush to the housing, the label spends no inset and keeps more from the
-  // outer corner, so the same words render larger than a numeral's margins
-  // would allow — and still inside the capsule's side.
+test("a label wider than the capsule's side stands down to fit it", () => {
   const width = 42;
-  const label = countBadgeFit(PANEL_PRESENTATION.CAPSULE, 180, width, 0, true);
-  const count = countBadgeFit(PANEL_PRESENTATION.CAPSULE, 180, width, 0);
-  assert.ok(label > count);
-  assert.ok(label * 0.88 * width <= 36 - 6);
-});
-
-test("a count that fits keeps its resting scale", () => {
-  // Two tabular digits: about 19 layout pixels, 17 once the 0.88 draws them.
-  assert.equal(countBadgeFit(PANEL_PRESENTATION.CAPSULE, 210, 19, 0), 1);
-});
-
-test("a number wider than the capsule's side stands down to fit it", () => {
-  // Five digits: about 47 layout pixels against the capsule's 25 of room.
-  const fit = countBadgeFit(PANEL_PRESENTATION.CAPSULE, 210, 47, 0);
+  const fit = signInLabelFit(width);
   assert.ok(fit < 1);
-  assert.ok(0.88 * fit * 47 <= capsuleRoom + 1e-9);
-});
-
-test("the capsule ignores the caption it never draws", () => {
-  assert.equal(
-    countBadgeFit(PANEL_PRESENTATION.CAPSULE, 210, 19, 400),
-    countBadgeFit(PANEL_PRESENTATION.CAPSULE, 210, 19, 0),
-  );
-});
-
-test("the peek fits the number and its caption together", () => {
-  // A three-digit count beside "121 need you": each fits the peek alone, and
-  // together they outgrow it.
-  const fit = countBadgeFit(PANEL_PRESENTATION.PEEK, 210, 29, 100);
-  assert.ok(fit < 1);
-  assert.ok(0.88 * fit * (29 + 9 + 100) <= peekRoom + 1e-9);
-});
-
-test("the bubble's wider peek side keeps the same text at its resting scale", () => {
-  assert.equal(countBadgeFit(PANEL_PRESENTATION.PEEK, 0, 29, 100), 1);
-});
-
-test("the panel's wider side stands the same text down less than the peek's", () => {
-  const peek = countBadgeFit(PANEL_PRESENTATION.PEEK, 210, 38, 160);
-  const panel = countBadgeFit(PANEL_PRESENTATION.PANEL, 210, 38, 160);
-  assert.ok(peek < panel);
-});
-
-test("the slot keeps the capsule's quiet wing, so it keeps the capsule's fit", () => {
-  assert.equal(
-    countBadgeFit(PANEL_PRESENTATION.SLOT, 210, 47, 0),
-    countBadgeFit(PANEL_PRESENTATION.CAPSULE, 210, 47, 0),
-  );
+  assert.ok(fit * 0.88 * width <= CAPSULE_SIDE_WIDTH - 6 + 1e-9);
 });
 
 test("text not yet measured is not scaled", () => {
-  assert.equal(countBadgeFit(PANEL_PRESENTATION.CAPSULE, 210, 0, 0), 1);
-});
-
-test("wing mark provider slots map to valid session filters", () => {
-  const slots = wingSlots(providers("claude", "codex", "cursor"), 3);
-  for (const slot of slots) {
-    if ("provider" in slot) {
-      assert.ok(["claude", "codex", "cursor"].includes(slot.provider.providerId));
-    }
-  }
+  assert.equal(signInLabelFit(0), 1);
 });

--- a/apps/desktop/src/renderer/notch-wings.tsx
+++ b/apps/desktop/src/renderer/notch-wings.tsx
@@ -1,5 +1,4 @@
-import { ProviderMark, WingFace, wingMarkCapacity } from "@sidecar/panel";
-import { isSessionFilter, type SessionFilter } from "@sidecar/session";
+import { ProviderMark, WingFace, wingMarkCapacity, wingPileOffset } from "@sidecar/panel";
 import { CAPSULE_SIDE_WIDTH, PANEL_WIDTH, peekWidth } from "@sidecar/surface";
 import { cssCustomProperties } from "@sidecar/surface/react-css";
 import { useCallback, useLayoutEffect, useMemo, useRef, useState } from "react";
@@ -11,15 +10,8 @@ import {
   useFaceMotion,
   usePrefersReducedMotion,
 } from "./luke-face-mood";
-import { HIT_REGION, PANEL_PRESENTATION, type PanelPresentation } from "./panel-state";
-import {
-  type ProviderTally,
-  type SessionTally,
-  sameSessionFilters,
-  tallyCaption,
-  tallySummary,
-  tallyValue,
-} from "./session-model";
+import { PANEL_PRESENTATION, type PanelPresentation } from "./panel-state";
+import type { ProviderTally, SessionTally } from "./session-model";
 import {
   LEAVING_ATTRIBUTE,
   useRoster,
@@ -31,10 +23,10 @@ import { WAVEFORM_VOICE, Waveform, type WaveformVoice } from "./waveform";
 /**
  * The strips beside the camera housing. They are rendered once for both window
  * modes and anchored to the notch rather than to a stage, so growing the window
- * re-lays out nothing here: the face and the count badge stay put, the meter
- * and the captions unfold into the space the expanded panel adds, and the
- * marks — resting against the shape's far edge — glide outward with it on the
- * surface's own spring.
+ * re-lays out nothing here: the face keeps its place beside the housing on one
+ * side and the marks keep theirs on the other, the meter unfolds into the
+ * space the expanded panel adds, and the marks spread out of their resting
+ * pile on the surface's own spring.
  */
 interface NotchWingsProps {
   tally: SessionTally;
@@ -53,42 +45,32 @@ interface NotchWingsProps {
   /**
    * Whether the roster has been read at all yet. Until it has, the wing is
    * loading rather than empty: the face waits awake instead of sleeping on a
-   * zero that only means "not looked yet", and the badge says it is checking
-   * rather than counting nothing.
+   * zero that only means "not looked yet".
    */
   sessionsSettled: boolean;
   presentation: PanelPresentation;
   housingWidth: number;
   /**
    * True while sign-in stands between Luke and anything to watch. The strip
-   * stays deliberately bare — no face, no count — so the gate in the panel is
-   * the one thing introducing him, and a zero that means "not looking yet"
-   * never poses as a zero that means "nothing happening".
+   * stays deliberately bare — no face, no marks — so the gate in the panel is
+   * the one thing introducing him.
    */
   accountGated: boolean;
-  /** Carries a filter to narrow the session list by when an icon in the wing is clicked. */
-  onSelectFilter?: (filter: SessionFilter) => void;
-  activeFilters?: readonly SessionFilter[];
+  /**
+   * The one sentence the wing states about the roster, derived where the
+   * capsule button's own label is so the two can never drift. The live region
+   * below is what speaks it as it changes.
+   */
+  statusLabel: string;
 }
 
 /**
- * What one wing costs to fill, in the stylesheet's numbers: `--panel-inset` on
- * the far side, where the marks start level with the tab bar and the rows,
- * `--wing-inset` beside the housing, then the face and its gap, then a first
- * mark and a gap-and-mark for every mark after it.
- */
-/**
  * How many marks fit beside the face in a wing of this width. The peek's side
  * is 124px beside the housing it was measured against, which is where its
- * limit of three comes from: the face and its gap cost 26px of the 95px
- * between the wing's insets, and each mark past the first costs 21px of the
- * 55px that remain. The panel's side is what is left of `--panel-width` after
- * the housing, so it holds roughly twice as many. Whenever the meter stands
- * beside the face rather than in its place, the second argument reserves the
- * same 26px again for it, so the marks give up a slot rather than the meter
- * drawing over one.
+ * limit of four comes from; the panel's side is what is left of
+ * `--panel-width` after the housing, so it holds roughly twice as many.
  */
-export { wingMarkCapacity } from "@sidecar/panel";
+export { wingMarkCapacity, wingPileOffset } from "@sidecar/panel";
 
 /**
  * The peek's side beside this housing: what is left of the floored peek after
@@ -101,95 +83,49 @@ export function peekSideWidth(housingWidth: number): number {
 }
 
 /**
- * What the count badge costs to draw, in the stylesheet's numbers:
- * `--wing-inset` before the number starts, the caption's own margin between
- * the number and its words, and the 0.88 the badge rests at outside the
- * panel. The keep is the last two pixels before the shape's edge, where the
- * black is already turning its corner.
- */
-const COUNT_INSET = 9;
-const COUNT_CAPTION_GAP = 9;
-const COUNT_RESTING_SCALE = 0.88;
-const COUNT_EDGE_KEEP = 2;
-
-/**
  * The sign-in label's own margins, in the stylesheet's numbers. It starts at
  * the housing's edge itself — black on black, the notch is indistinguishable
- * from padding, so the inset a numeral keeps buys nothing here — and keeps
- * more from the strip's outer end, where the shape is already turning its
- * corner and words pressed into the curve read as clipped.
+ * from padding, so an inset there buys nothing — and keeps more from the
+ * strip's outer end, where the shape is already turning its corner and words
+ * pressed into the curve read as clipped.
  */
 const SIGN_IN_INSET = 0;
 const SIGN_IN_EDGE_KEEP = 6;
 
+/** The scale the label rests at, so its text never crosses the shape's edge. */
+const SIGN_IN_RESTING_SCALE = 0.88;
+
 /**
- * How much of its resting scale the count badge keeps so the text never
- * crosses the shape's edge. The number grows with the sessions it counts and
- * the shape beside the housing does not, so past the width the wing can hold
- * the text scales down instead of being drawn onto the desktop. The widths
- * arrive in layout pixels — measured before any transform — so the room is
- * compared against them at the scale the stylesheet is about to apply; the
- * factor multiplies that resting scale rather than replacing it, and is 1
- * whenever the room already suffices. The caption unfolds only in the peek
- * and the panel, so only those states have to fit it; every other state
- * draws the number alone inside the capsule's own side.
+ * How much of its resting scale the sign-in label keeps so the words stay
+ * inside the shape beside the housing. The width arrives in layout pixels —
+ * measured before any transform — so the room is compared against it at the
+ * scale the stylesheet is about to apply; the factor multiplies that resting
+ * scale rather than replacing it, and is 1 whenever the room already
+ * suffices. The label is drawn only in the compact shapes, so the capsule's
+ * own side is the room it has to fit.
  */
-export function countBadgeFit(
-  presentation: PanelPresentation,
-  housingWidth: number,
-  valueWidth: number,
-  captionWidth: number,
-  /** True for the sign-in label, which starts flush at the housing's edge. */
-  flushToHousing = false,
-): number {
-  const captioned =
-    presentation === PANEL_PRESENTATION.PEEK || presentation === PANEL_PRESENTATION.PANEL;
-  const textWidth = captioned ? valueWidth + COUNT_CAPTION_GAP + captionWidth : valueWidth;
-  if (textWidth <= 0) return 1;
-  const sideWidth =
-    presentation === PANEL_PRESENTATION.PANEL
-      ? (PANEL_WIDTH - housingWidth) / 2
-      : presentation === PANEL_PRESENTATION.PEEK
-        ? peekSideWidth(housingWidth)
-        : CAPSULE_SIDE_WIDTH;
-  const restingScale = presentation === PANEL_PRESENTATION.PANEL ? 1 : COUNT_RESTING_SCALE;
-  const inset = flushToHousing ? SIGN_IN_INSET : COUNT_INSET;
-  const keep = flushToHousing ? SIGN_IN_EDGE_KEEP : COUNT_EDGE_KEEP;
-  const room = Math.max(0, sideWidth - inset - keep);
-  return Math.min(1, room / (restingScale * textWidth));
+export function signInLabelFit(labelWidth: number): number {
+  if (labelWidth <= 0) return 1;
+  const room = Math.max(0, CAPSULE_SIDE_WIDTH - SIGN_IN_INSET - SIGN_IN_EDGE_KEEP);
+  return Math.min(1, room / (SIGN_IN_RESTING_SCALE * labelWidth));
 }
 
 /**
- * The wing's strip, as slots: the mark of each app holding tracked work,
- * then — when the apps outnumber the slots — the count standing in for the
- * rest. The
- * marks are a summary, and a summary that hides its own remainder reads as a
- * complete list, so whatever does not fit is counted rather than dropped. The
- * count is a slot like any other, so it takes the last one rather than being
- * added past the edge of the peek — and it carries a slot id like any other,
- * so a reorder glides it along with the marks instead of teleporting it.
+ * The wing's strip, as slots: the mark of each app holding tracked work, in
+ * the order the rows read. Whatever the wing cannot hold is truncated rather
+ * than counted — the marks say which apps are working, and a remainder glyph
+ * would put a number back beside the housing that says nothing about which.
  */
-export type WingSlot =
-  | { id: string; provider: ProviderTally }
-  | { id: typeof OVERFLOW_SLOT_ID; unshown: number };
-
-/**
- * The one slot that is not a provider's, named by the glyph it draws. A mark's
- * slot id is its provider id verbatim, so the count's must be a string no
- * provider id can be — an id is a slug, and a slug never opens with the sign.
- */
-export const OVERFLOW_SLOT_ID = "+";
+export interface WingSlot {
+  id: string;
+  provider: ProviderTally;
+}
 
 export function wingSlots(
   providers: readonly ProviderTally[],
   capacity: number,
 ): readonly WingSlot[] {
-  const overflowing = providers.length > capacity;
-  const shown = providers.slice(0, overflowing ? capacity - 1 : capacity);
-  const unshown = providers.length - shown.length;
-  const slots: WingSlot[] = shown.map((provider) => ({ id: provider.providerId, provider }));
-  if (unshown > 0) slots.push({ id: OVERFLOW_SLOT_ID, unshown });
-  return slots;
+  return providers.slice(0, capacity).map((provider) => ({ id: provider.providerId, provider }));
 }
 
 export function NotchWings({
@@ -206,8 +142,7 @@ export function NotchWings({
   presentation,
   housingWidth,
   accountGated,
-  onSelectFilter,
-  activeFilters,
+  statusLabel,
 }: NotchWingsProps): React.JSX.Element {
   const [voiceActive, setVoiceActive] = useState(false);
   const reportVoiceActivity = useCallback(
@@ -231,12 +166,6 @@ export function NotchWings({
     ...(meterVoice ? { turn: meterVoice } : undefined),
     hasAudioSignal: meterShown,
   });
-  // Whether the meter is standing beside the face rather than in its place —
-  // Luke's own turn, and an audio signal with no turn to read at all. Only
-  // then does the wing draw two things nearest the housing instead of one;
-  // the developer's real turn hands the meter the face's own slot, at the
-  // face's own width, so it costs the marks nothing extra.
-  const meterBesideFace = meterShown && !yieldToMeter;
   // The box the hover is read against, not the face itself: the drawing is
   // remounted for every play, and the hover has to survive the trick it fires.
   const faceElement = useRef<HTMLSpanElement>(null);
@@ -263,13 +192,12 @@ export function NotchWings({
   // The wing is bounded by the shape its state draws, so its capacity is too:
   // the panel's side holds more marks than the peek's, and every other state
   // keeps the peek's capacity because that is the set the next peek unfolds.
-  // Whenever the meter stands beside the face rather than in its place, the
-  // marks give up whatever room it costs rather than letting it draw across
-  // them.
+  // The marks have this wing to themselves — no face, no meter — so nothing
+  // else has to be reserved for.
   const capacity =
     presentation === PANEL_PRESENTATION.PANEL
-      ? wingMarkCapacity((PANEL_WIDTH - housingWidth) / 2, meterBesideFace)
-      : wingMarkCapacity(peekSideWidth(housingWidth), meterBesideFace);
+      ? wingMarkCapacity((PANEL_WIDTH - housingWidth) / 2)
+      : wingMarkCapacity(peekSideWidth(housingWidth));
   // Memoized because the roster below notices a new list by identity: the
   // slots may only change when what they summarize does, not on every render
   // a spoken word or a face gesture asks for.
@@ -281,34 +209,17 @@ export function NotchWings({
   const marksRef = useWingReorderMotion();
   const drawnSlots = useRoster(slots, marksRef);
 
-  // The count's text, measured in layout pixels: `offsetWidth` never sees the
+  // The label's text, measured in layout pixels: `offsetWidth` never sees the
   // transform about to draw it, so the fit below can divide by the scale the
   // stylesheet applies without measuring its own answer. No dependency list,
-  // the way the reorder motion measures — the words change with the tally, and
-  // a re-read per commit costs less than proving which commits reworded them —
-  // and the guard keeps an unchanged measurement from re-rendering anything.
-  const countValueElement = useRef<HTMLSpanElement>(null);
-  const countCaptionElement = useRef<HTMLSpanElement>(null);
-  const [countWidths, setCountWidths] = useState({ value: 0, caption: 0 });
+  // the way the reorder motion measures — and the guard keeps an unchanged
+  // measurement from re-rendering anything.
+  const signInElement = useRef<HTMLSpanElement>(null);
+  const [signInWidth, setSignInWidth] = useState(0);
   useLayoutEffect(() => {
-    const value = countValueElement.current?.offsetWidth ?? 0;
-    const caption = countCaptionElement.current?.offsetWidth ?? 0;
-    setCountWidths((held) =>
-      held.value === value && held.caption === caption ? held : { value, caption },
-    );
+    const width = signInElement.current?.offsetWidth ?? 0;
+    setSignInWidth((held) => (held === width ? held : width));
   });
-  const countFit = countBadgeFit(
-    presentation,
-    housingWidth,
-    countWidths.value,
-    countWidths.caption,
-    accountGated,
-  );
-  // The badge must not count a roster nobody has read: until the first
-  // reading lands it says it is checking, because "0 none tracked" is a
-  // claim about the desk and "still looking" is not. The sign-in label
-  // outranks it — a gated Luke is not checking anything.
-  const rosterLoading = !accountGated && !sessionsSettled && tally.total === 0;
 
   return (
     <>
@@ -316,57 +227,6 @@ export function NotchWings({
         {/* Ordered so the element nearest the notch is the one the capsule
             keeps: the rest unfold outward and never displace it. */}
         <div className="wing-inner">
-          {/* What Luke is watching stays on screen through every turn: whoever
-              is speaking, the marks hold their own place at the shape's far
-              edge rather than giving it up to the meter — the capacity above
-              is what keeps the meter from ever drawing across one. */}
-          <span className="wing-marks" ref={marksRef}>
-            {drawnSlots.map(({ item, leaving }) => {
-              // How the reorder measurement finds this slot again after a
-              // re-sort has moved it, and how a slot whose provider left
-              // says so while it fades where the reader last saw it.
-              const motion = {
-                [WING_SLOT_ID_ATTRIBUTE]: item.id,
-                [LEAVING_ATTRIBUTE]: String(leaving),
-              };
-              if (!("provider" in item)) {
-                return (
-                  <span className="wing-more" key={item.id} {...motion} aria-hidden="true">
-                    +{item.unshown}
-                  </span>
-                );
-              }
-              const filter = isSessionFilter(item.provider.providerId)
-                ? item.provider.providerId
-                : undefined;
-              const active =
-                filter !== undefined && sameSessionFilters(activeFilters ?? [], [filter]);
-              const label = item.provider.provider;
-              return (
-                <button
-                  type="button"
-                  className="wing-mark"
-                  key={item.id}
-                  {...motion}
-                  data-hit-region={HIT_REGION.CAPSULE}
-                  data-active={String(active)}
-                  aria-label={active ? `Clear ${label} filter` : `Filter by ${label}`}
-                  title={active ? `Clear ${label} filter` : `Filter by ${label}`}
-                  disabled={leaving}
-                  tabIndex={leaving ? -1 : 0}
-                  onMouseDown={(event) => event.preventDefault()}
-                  onClick={(event) => {
-                    event.stopPropagation();
-                    if (filter !== undefined) {
-                      onSelectFilter?.(filter);
-                    }
-                  }}
-                >
-                  <ProviderMark providerId={item.provider.providerId} />
-                </button>
-              );
-            })}
-          </span>
           {meterShown && (
             /* Keyed on whose turn it is, so each voice's meter is a fresh
                mount: the arrival choreography lives in a starting style, and
@@ -388,7 +248,7 @@ export function NotchWings({
           )}
           {/* Luke himself. He is drawn in every state but one: he steps out of
               the way of your own voice, which is the only thing that displaces
-              him. Everything else in the wing is what he is watching.
+              him.
 
               Keyed on the play so that each one is a new drawing: a motion plays
               once now, and an element already wearing an animation does not
@@ -411,41 +271,52 @@ export function NotchWings({
 
       <div className="wing wing-right">
         <div className="wing-inner">
+          {/* What Luke is watching: which apps hold the work. The capsule's
+              side has room for one, so at rest it draws the app whose session
+              needs a person soonest and the rest wait behind it; the peek and
+              the panel lay the whole strip out flat. Drawn in every state but
+              the gate, which takes this place for the label below. Decorative —
+              the live region beside them already states everything they show,
+              and the panel's own filter chips are what filtering is done
+              with. */}
+          <span className="wing-marks" ref={marksRef} data-drawn={String(!accountGated)}>
+            {drawnSlots.map(({ item, leaving }, index) => (
+              <span
+                className="wing-mark"
+                key={item.id}
+                // How the reorder measurement finds this slot again after a
+                // re-sort has moved it, and how a slot whose provider left
+                // says so while it fades where the reader last saw it.
+                {...{
+                  [WING_SLOT_ID_ATTRIBUTE]: item.id,
+                  [LEAVING_ATTRIBUTE]: String(leaving),
+                }}
+                data-piled={String(index === 0)}
+                style={cssCustomProperties({ "--mark-rest": `${wingPileOffset(index)}px` })}
+                aria-hidden="true"
+              >
+                <ProviderMark providerId={item.provider.providerId} />
+              </span>
+            ))}
+          </span>
           {/* While sign-in stands between Luke and anything to watch, the
-              badge's place says the one honest thing instead of a zero that
-              would pose as "nothing happening": why Luke is idle, and the one
-              act that wakes him. It shares the count's element and fit, so it
-              scales into the capsule's side exactly as a wide number does. */}
-          <span
-            className="count-badge"
-            style={cssCustomProperties({ "--count-fit": countFit })}
-            data-state={tally.urgency}
-            data-empty={String(accountGated || tally.total === 0)}
-            data-sign-in={String(accountGated)}
-            role="status"
-            aria-live="polite"
-            aria-label={
-              accountGated
-                ? "Sign in"
-                : rosterLoading
-                  ? "Checking for sessions"
-                  : tallySummary(tally)
-            }
-          >
-            <span className="count-value" aria-hidden="true" ref={countValueElement}>
-              {/* Blank while checking: the accessible label already says so,
-                  and a drawn placeholder poses as a count that is not there
-                  yet. */}
-              {accountGated ? "Sign in" : rosterLoading ? null : tallyValue(tally)}
+              strip says the one honest thing instead: why Luke is idle, and
+              the one act that wakes him. */}
+          {accountGated && (
+            <span
+              className="sign-in-label"
+              style={cssCustomProperties({ "--sign-in-fit": signInLabelFit(signInWidth) })}
+              aria-hidden="true"
+              ref={signInElement}
+            >
+              Sign in
             </span>
-            <span className="count-caption" aria-hidden="true" ref={countCaptionElement}>
-              {/* No caption while signed out: the two words are the label
-                  entire, and with nothing beside them the fit keeps their
-                  natural size inside the peek's side. Nor while checking —
-                  the badge stays blank until there is a count to put words
-                  beside. */}
-              {accountGated || rosterLoading ? null : tallyCaption(tally)}
-            </span>
+          )}
+          {/* The roster's own sentence, spoken rather than drawn. It rides its
+              own element rather than the label's, which is rendered only while
+              signed out and would take every later announcement down with it. */}
+          <span className="wing-status" role="status" aria-live="polite">
+            {statusLabel}
           </span>
         </div>
       </div>

--- a/apps/desktop/src/renderer/notch-wings.tsx
+++ b/apps/desktop/src/renderer/notch-wings.tsx
@@ -17,6 +17,7 @@ import {
   useRoster,
   useWingReorderMotion,
   WING_SLOT_ID_ATTRIBUTE,
+  WING_SPREAD_ATTRIBUTE,
 } from "./session-motion";
 import { WAVEFORM_VOICE, Waveform, type WaveformVoice } from "./waveform";
 
@@ -208,6 +209,12 @@ export function NotchWings({
   // unmounting marks mid-fade — and only then does the gap close.
   const marksRef = useWingReorderMotion();
   const drawnSlots = useRoster(slots, marksRef);
+  // Whether the shape has room to lay the strip out flat. The stylesheet
+  // decides the same thing from the presentation; the strip carries it so the
+  // reorder measurement reads the layout actually drawn rather than inferring
+  // it a second way.
+  const spread =
+    presentation === PANEL_PRESENTATION.PEEK || presentation === PANEL_PRESENTATION.PANEL;
 
   // The label's text, measured in layout pixels: `offsetWidth` never sees the
   // transform about to draw it, so the fit below can divide by the scale the
@@ -279,7 +286,12 @@ export function NotchWings({
               the live region beside them already states everything they show,
               and the panel's own filter chips are what filtering is done
               with. */}
-          <span className="wing-marks" ref={marksRef} data-drawn={String(!accountGated)}>
+          <span
+            className="wing-marks"
+            ref={marksRef}
+            data-drawn={String(!accountGated)}
+            {...{ [WING_SPREAD_ATTRIBUTE]: String(spread) }}
+          >
             {drawnSlots.map(({ item, leaving }, index) => (
               <span
                 className="wing-mark"

--- a/apps/desktop/src/renderer/session-model.test.ts
+++ b/apps/desktop/src/renderer/session-model.test.ts
@@ -33,9 +33,7 @@ import {
   sessionRunKeys,
   sessionTally,
   spokenSearchOutcome,
-  tallyCaption,
   tallySummary,
-  tallyValue,
   toggledSessionFilters,
   workspaceTrayActions,
   workspaceTrayChange,
@@ -333,7 +331,6 @@ test("the tally counts per state and per app", () => {
       working: 3,
       complete: 1,
       idle: 1,
-      urgency: SESSION_URGENCY.ATTENTION,
       providers: undefined,
     },
   );
@@ -341,9 +338,7 @@ test("the tally counts per state and per app", () => {
   // under the app holding it: both Conductor chats land under Conductor's
   // mark whatever agent runs them, the Codex chat under ChatGPT, its lead
   // app, and a chat no app holds — the local Claude Code session, the Devin
-  // cloud session — under its provider's own. Five is one more than the
-  // wings hold, so the fixture also proves the remainder is counted rather
-  // than dropped.
+  // cloud session — under its provider's own.
   assert.deepEqual(tally.providers, [
     { providerId: PROVIDER_ID.CLAUDE_CODE, provider: "Claude Code", total: 1, attention: 1 },
     { providerId: SESSION_APPLICATION_ID.CHATGPT, provider: "ChatGPT", total: 1, attention: 0 },
@@ -376,57 +371,16 @@ test("the apps re-seat with the rows when the other sort is chosen", () => {
   );
 });
 
-test("the badge urgency follows the most urgent session", () => {
-  const working = sessionTally(
-    displaySessions(bootstrap(false), [liveSession(CODEX_PROVIDER, "a", SESSION_STATUS.WORKING)]),
-  );
-  const complete = sessionTally(
-    displaySessions(bootstrap(false), [liveSession(CODEX_PROVIDER, "a", SESSION_STATUS.COMPLETE)]),
-  );
-  const empty = sessionTally([]);
-
-  assert.equal(working.urgency, SESSION_URGENCY.WORKING);
-  assert.equal(complete.urgency, SESSION_URGENCY.COMPLETE);
-  assert.equal(empty.urgency, SESSION_URGENCY.UNKNOWN);
-});
-
-test("the badge number counts the state its colour names", () => {
-  // The fixture holds 1 attention, 3 working, 1 complete, and 1 idle session:
-  // SAFETY: Fixture value matches the narrowed runtime shape this test exercises.
-  // the badge says 1 in the attention colour, never a 6 posing as urgent.
-  const attention = sessionTally(displaySessions(bootstrap(true), []));
-  const working = sessionTally(
-    displaySessions(bootstrap(false), [
-      liveSession(CODEX_PROVIDER, "a", SESSION_STATUS.WORKING),
-      liveSession(CODEX_PROVIDER, "b", SESSION_STATUS.WORKING),
-    ]),
-  );
-  const complete = sessionTally(
-    displaySessions(bootstrap(false), [liveSession(CODEX_PROVIDER, "a", SESSION_STATUS.COMPLETE)]),
-  );
-
-  assert.equal(tallyValue(attention), 1);
-  assert.equal(tallyValue(working), 2);
-  assert.equal(tallyValue(complete), 1);
-  assert.equal(tallyValue(sessionTally([])), 0);
-});
-
-test("the caption is the badge state's own words, never a second number", () => {
+test("the spoken summary names the state its own number counts", () => {
   const tally = sessionTally(displaySessions(bootstrap(true), []));
 
-  assert.equal(tallyCaption(tally), "needs you");
   assert.equal(tallySummary(tally), "1 session needs you");
-  assert.equal(tallyCaption({ ...tally, attention: 2 }), "need you");
-  assert.equal(tallyCaption({ ...tally, attention: 0, working: 3 }), "working");
   assert.equal(tallySummary({ ...tally, attention: 0, working: 3 }), "3 sessions working");
-  assert.equal(tallyCaption({ ...tally, attention: 0, working: 0 }), "complete");
   assert.equal(tallySummary({ ...tally, attention: 0, working: 0 }), "1 session complete");
-  assert.equal(tallyCaption({ ...tally, attention: 0, working: 0, complete: 0 }), "tracked");
   assert.equal(
     tallySummary({ ...tally, attention: 0, working: 0, complete: 0 }),
     "6 sessions tracked",
   );
-  assert.equal(tallyCaption(sessionTally([])), "none tracked");
   assert.equal(tallySummary(sessionTally([])), "No sessions tracked");
 });
 

--- a/apps/desktop/src/renderer/session-model.ts
+++ b/apps/desktop/src/renderer/session-model.ts
@@ -480,15 +480,13 @@ export interface SessionTally {
    * The same sessions the count above counts, by id, because one of them
    * starting to ask is a different event from three of them still asking and
    * the count cannot tell those apart: answer one while another starts in the
-   * same poll and it never moves. Luke's face reacts to the event and the badge
-   * reports the count, so the tally has to carry both.
+   * same poll and it never moves. Luke's face reacts to the event and the
+   * spoken summary reports the count, so the tally has to carry both.
    */
   attentionIds: readonly string[];
   working: number;
   complete: number;
   idle: number;
-  /** The urgency the count badge and the notch capsule adopt. */
-  urgency: SessionUrgency;
   /** One app each, seated where its first session reads under the sort. */
   providers: readonly ProviderTally[];
 }
@@ -1208,42 +1206,8 @@ export function sessionTally(
     ...counts,
     attentionIds,
     total: sessions.length,
-    urgency: dominantUrgency(counts),
     providers: [...providers.values()],
   };
-}
-
-function dominantUrgency(counts: {
-  attention: number;
-  working: number;
-  complete: number;
-}): SessionUrgency {
-  if (counts.attention > 0) return SESSION_URGENCY.ATTENTION;
-  if (counts.working > 0) return SESSION_URGENCY.WORKING;
-  if (counts.complete > 0) return SESSION_URGENCY.COMPLETE;
-  return SESSION_URGENCY.UNKNOWN;
-}
-
-/**
- * The number the badge draws: the count of the state its colour names, so the
- * numeral and the tint state one fact. A "12" that meant "12 tracked" while
- * its colour meant "something needs you" made the reader hold two channels
- * apart; here an attention-coloured 2 is 2 sessions needing you. The total
- * only stands in when nothing is live enough to colour, because "how many
- * need me" and "how many are working" are the questions the badge exists to
- * answer, and the total answers neither.
- */
-export function tallyValue(tally: SessionTally): number {
-  switch (tally.urgency) {
-    case SESSION_URGENCY.ATTENTION:
-      return tally.attention;
-    case SESSION_URGENCY.WORKING:
-      return tally.working;
-    case SESSION_URGENCY.COMPLETE:
-      return tally.complete;
-    default:
-      return tally.total;
-  }
 }
 
 /** One sentence that reads correctly for a screen reader in either mode. */
@@ -1273,17 +1237,3 @@ export function tallySummary(tally: SessionTally): string {
  * stays reproducible, and live rows against whatever render tick asked.
  */
 export { observedAgoLabel } from "@sidecar/panel";
-
-/**
- * The caption beside the count once the panel has room for it. The badge's
- * number is the count of the state its colour names, so the caption is only
- * that state's words — never a number of its own, which would stand two
- * numerals with different denominators side by side.
- */
-export function tallyCaption(tally: SessionTally): string {
-  if (tally.total === 0) return "none tracked";
-  if (tally.attention > 0) return tally.attention === 1 ? "needs you" : "need you";
-  if (tally.working > 0) return "working";
-  if (tally.complete > 0) return "complete";
-  return "tracked";
-}

--- a/apps/desktop/src/renderer/session-motion.test.ts
+++ b/apps/desktop/src/renderer/session-motion.test.ts
@@ -7,6 +7,7 @@ import {
   planReorder,
   rosterRows,
   travelApplies,
+  wingSlotOffset,
   withoutDeparture,
 } from "./session-motion";
 
@@ -162,4 +163,15 @@ test("a departure still fading is kept while another begins", () => {
     { item: { id: "b" }, index: 1 },
     { item: { id: "c" }, index: 2 },
   ]);
+});
+
+test("a mark's seat is invariant to the wing's bound moving under it", () => {
+  // A morph grows the wing 88px. The marks are anchored beside the housing,
+  // so the offset must not read that growth as a travel and animate the whole
+  // pile across the wing.
+  // SAFETY: The two fields below are every property the offset reads.
+  const capsule = { offsetLeft: 9, offsetParent: { clientWidth: 36 } } as unknown as HTMLElement;
+  // SAFETY: The same shape at the peek's own bound.
+  const peek = { offsetLeft: 9, offsetParent: { clientWidth: 124 } } as unknown as HTMLElement;
+  assert.equal(wingSlotOffset(capsule), wingSlotOffset(peek));
 });

--- a/apps/desktop/src/renderer/session-motion.test.ts
+++ b/apps/desktop/src/renderer/session-motion.test.ts
@@ -168,10 +168,22 @@ test("a departure still fading is kept while another begins", () => {
 test("a mark's seat is invariant to the wing's bound moving under it", () => {
   // A morph grows the wing 88px. The marks are anchored beside the housing,
   // so the offset must not read that growth as a travel and animate the whole
-  // pile across the wing.
+  // strip across the wing.
   // SAFETY: The two fields below are every property the offset reads.
   const capsule = { offsetLeft: 9, offsetParent: { clientWidth: 36 } } as unknown as HTMLElement;
   // SAFETY: The same shape at the peek's own bound.
   const peek = { offsetLeft: 9, offsetParent: { clientWidth: 124 } } as unknown as HTMLElement;
-  assert.equal(wingSlotOffset(capsule), wingSlotOffset(peek));
+  assert.equal(wingSlotOffset(capsule, true), wingSlotOffset(peek, true));
+});
+
+test("a stacked strip reports one seat, so a reorder at rest is no travel", () => {
+  // Every mark is drawn on the first slot while the strip is stacked. Reading
+  // the laid-out seat instead would spring the new lead mark in from a slot
+  // past the capsule's own side, which the wing does not clip.
+  // SAFETY: `offsetLeft` is every property the offset reads.
+  const lead = { offsetLeft: 9 } as unknown as HTMLElement;
+  // SAFETY: The seat the flex strip lays out for the second mark.
+  const second = { offsetLeft: 30 } as unknown as HTMLElement;
+  assert.equal(wingSlotOffset(lead, false), wingSlotOffset(second, false));
+  assert.notEqual(wingSlotOffset(lead, true), wingSlotOffset(second, true));
 });

--- a/apps/desktop/src/renderer/session-motion.ts
+++ b/apps/desktop/src/renderer/session-motion.ts
@@ -136,20 +136,36 @@ const SESSION_LIST: ReorderList = {
 };
 
 /**
- * Where a mark sits along the wing. The marks are anchored beside the housing,
- * which is the wing's own left edge, so `offsetLeft` is already the distance
- * from the edge that never moves: `--wing-bound` grows the wing 88px on a
- * morph, and a position measured from the far edge would read that growth as
- * a travel and animate the whole pile across the wing.
+ * How the wing's strip says whether it is laid out flat or stacked on its
+ * first slot. The stylesheet decides that from the presentation, and the
+ * measurement below has to agree with it, so the strip states it rather than
+ * either side inferring it.
  */
-export function wingSlotOffset(element: HTMLElement): number {
-  return element.offsetLeft;
+export const WING_SPREAD_ATTRIBUTE = "data-spread";
+
+/**
+ * Where a mark is drawn along the wing. Flat, that is `offsetLeft`: the marks
+ * are anchored beside the housing, which is the wing's own left edge, so it is
+ * already the distance from the edge that never moves — `--wing-bound` grows
+ * the wing 88px on a morph, and a position measured from the far edge would
+ * read that growth as a travel and animate the whole strip across the wing.
+ *
+ * Stacked, every mark is drawn on the first slot whatever seat the flex strip
+ * laid out for it, so they all report the same position and a reorder is no
+ * travel at all. The laid-out seat would be a lie there, and an expensive one:
+ * the new lead mark would spring in from a slot past the capsule's own side,
+ * which the wing does not clip — it is bounded by the peek the capsule can
+ * grow into — and would be drawn on the desktop.
+ */
+export function wingSlotOffset(element: HTMLElement, spread: boolean): number {
+  return spread ? element.offsetLeft : 0;
 }
 
 /** The wing's strip: marks laid along the wing, anchored beside the housing. */
 const WING_STRIP: ReorderList = {
   idAttribute: WING_SLOT_ID_ATTRIBUTE,
-  offset: (element, _container) => wingSlotOffset(element),
+  offset: (element, container) =>
+    wingSlotOffset(element, container.getAttribute(WING_SPREAD_ATTRIBUTE) === "true"),
   translate: (px) => `translateX(${px}px)`,
   arrivesFromFan: false,
 };

--- a/apps/desktop/src/renderer/session-motion.ts
+++ b/apps/desktop/src/renderer/session-motion.ts
@@ -45,11 +45,7 @@ import { useEffect, useLayoutEffect, useRef, useState } from "react";
  */
 export const SESSION_ROW_ID_ATTRIBUTE = "data-session-id";
 
-/**
- * How each slot in the wing's strip names itself: a provider's mark by the
- * provider, and the overflow count by its own sentinel — the count is a slot
- * like any other, so it glides like any other.
- */
+/** How each slot in the wing's strip names itself: by its provider. */
 export const WING_SLOT_ID_ATTRIBUTE = "data-slot-id";
 
 /**
@@ -140,20 +136,20 @@ const SESSION_LIST: ReorderList = {
 };
 
 /**
- * The wing's strip: marks laid along the wing, resting against the shape's far
- * edge. The wing hangs off the housing and grows that edge as the shape
- * morphs — `--wing-bound` moves the left edge of the very element `offsetLeft`
- * is measured from, and the marks move with it — so a slot's position is its
- * distance from the anchored edge instead: measured from the moving one, a
- * morph would read as stillness and the marks would jump to the new edge in
- * one frame. The distance is negated so the numbers still grow the way the
- * axis runs and the travel arithmetic stays the plan's. Measuring the slot's
- * own near edge also keeps the overflow count still while only its digits
- * widen, because the digits grow away from the anchor.
+ * Where a mark sits along the wing. The marks are anchored beside the housing,
+ * which is the wing's own left edge, so `offsetLeft` is already the distance
+ * from the edge that never moves: `--wing-bound` grows the wing 88px on a
+ * morph, and a position measured from the far edge would read that growth as
+ * a travel and animate the whole pile across the wing.
  */
+export function wingSlotOffset(element: HTMLElement): number {
+  return element.offsetLeft;
+}
+
+/** The wing's strip: marks laid along the wing, anchored beside the housing. */
 const WING_STRIP: ReorderList = {
   idAttribute: WING_SLOT_ID_ATTRIBUTE,
-  offset: (element, _container) => element.offsetLeft - (element.offsetParent?.clientWidth ?? 0),
+  offset: (element, _container) => wingSlotOffset(element),
   translate: (px) => `translateX(${px}px)`,
   arrivesFromFan: false,
 };
@@ -233,10 +229,10 @@ function elementVisible(element: HTMLElement): boolean {
  * Whether a planned travel animates for an element in this visibility. A slot
  * hop leaves a hidden element to take its place unseen — nothing a reader
  * watches moved. A travel the bound caused is the shape's own motion and
- * carries every element it displaced, seen or not: a mark can be
- * mid-entrance, transparent on the frame of the morph and visible before the
- * spring settles, and one left untravelled fades in at its new seat ahead of
- * the surface's edge, drawn on the desktop.
+ * carries every element it displaced, seen or not: a mark resting under the
+ * pile is transparent on the frame of the morph and visible before the spring
+ * settles, and one left untravelled would appear at its new seat without ever
+ * having crossed to it.
  */
 export function travelApplies(input: { boundMoved: boolean; visible: boolean }): boolean {
   return input.boundMoved || input.visible;

--- a/apps/desktop/src/renderer/session-parts.tsx
+++ b/apps/desktop/src/renderer/session-parts.tsx
@@ -205,9 +205,10 @@ const NARROWED_ON_BUTTON = 2;
  * that is the row the panel already spends on saying what you are looking at.
  *
  * It also has to say when the list is narrowed. A control that hides its own
- * effect is the one thing this panel cannot afford — the capsule is out there
- * counting sessions the list would not be showing — so the selection in force
- * is named on the button itself rather than only inside the sheet it opens.
+ * effect is the one thing this panel cannot afford — the wing's pile of marks
+ * is out there naming an app the narrowed list is not showing — so the
+ * selection in force is named on the button itself rather than only inside the
+ * sheet it opens.
  * The button has one line to say it on, so it names the first two choices and
  * counts the rest; the full selection stays on the hover and in the sheet.
  * While a selection stands, an X on the right clears every chosen chip at

--- a/apps/desktop/src/renderer/styles/base.css
+++ b/apps/desktop/src/renderer/styles/base.css
@@ -28,8 +28,8 @@
      terminal mark: the frame, and the gray block its favicon keeps inside the
      frame's opening on every surface, and the vertical metallic gradient
      Superset's favicon draws its bracket mark with. Session state is carried
-     by the chips, row tints, and count badge instead, so the two colour
-     systems never compete for the same pixel. */
+     by the chips and the row tints instead, so the two colour systems never
+     compete for the same pixel. */
   --mark-claude-code: #d97757;
   --mark-cmux-left: #12c7f5;
   --mark-cmux-middle: #2d8cff;
@@ -155,8 +155,7 @@
   --slot-radius: 28px;
   --wing-inset: 9px;
   /* The panel's own content edge: where the tab bar, the rows, and the composer
-     all start. The wing's marks take the same start, so the strip up top reads
-     as the first line of the column below it. */
+     all start. */
   --panel-inset: 20px;
   --scroll-fade: 26px;
 }
@@ -193,10 +192,11 @@
   /* The capsule with room for the meter beside the face rather than instead of
      it. Only the left wing needs it — that is where both are drawn — so only
      that side grows: 18px for the meter and the 8px between them, added to the
-     36px the capsule already has there. The right side keeps its 36px, because
-     a count badge with 26px of new space around it is emptier than it was, not
-     better. It is Luke's reply that needs this at all; your own turn puts the
-     meter where the face was and needs no more room than the face did. */
+     36px the capsule already has there. The right side keeps its 36px: the
+     one resting mark sits there against the housing, and a wider side would
+     only carry it toward an edge it must never reach. It is Luke's reply that needs
+     this at all; your own turn puts the meter where the face was and needs no
+     more room than the face did. */
   --capsule-voice-growth: 26px;
   --capsule-voice-width: calc(var(--capsule-width) + var(--capsule-voice-growth));
   /* Growing one side moves the shape's centre half the growth away from it, so
@@ -300,9 +300,9 @@
   --voice-band-widen: calc((var(--voice-band-width) - var(--voice-band-width-compact)) / 2);
 }
 
-/* The wings keep the capsule's quiet form while the slot is drawn — one mark and
-   the count, nothing unfolded — because the slot is asking for a key, and a list
-   of sessions is not an answer to that. Only the bound changes, so nothing
+/* The wings keep the capsule's quiet form while the slot is drawn — the face
+   and the one resting mark, nothing unfolded — because the slot is asking for a
+   key, and a list of sessions is not an answer to that. Only the bound changes, so nothing
    spills past the narrower shape. The composer is asking for words and gets the
    same quiet. */
 .app-stage[data-presentation="slot"] {
@@ -512,10 +512,8 @@ button:disabled {
   transform: translateX(calc(-50% - var(--capsule-voice-shift)));
 }
 
-/* The meter follows the room being made for it, the way the marks follow the
-   peek — but not on the marks' beat, because the two are not the same distance.
-   A mark fades in early and slides 8px, which the peek's edge has long since
-   passed; the capsule grows 26px, and a meter drawn 60ms in is drawn past an
+/* The meter follows the room being made for it, the way the marks spread into
+   the peek. The capsule grows 26px, and a meter drawn 60ms in is drawn past an
    edge that is still 300ms away from it. So it crosses over the last of the
    shape's travel and finishes as the shape settles, which is the same thing the
    marks are doing — arriving inside the black rather than ahead of it.
@@ -545,9 +543,12 @@ button:disabled {
   }
 }
 
+/* A mark arriving into a resting strip lands in its own resting seat rather
+   than at the meter's unfold pose; the meter, which has no seat of its own,
+   reads the fallback. */
 @keyframes wing-mount-travel {
   from {
-    transform: translateX(8px);
+    transform: translateX(var(--mark-rest, 8px));
   }
 }
 
@@ -606,7 +607,7 @@ button:disabled {
   height: calc(var(--capsule-height) - var(--shape-top) * 2 + var(--caption-growth));
 }
 
-/* Under the pointer: wide enough to say what the count means. */
+/* Under the pointer: wide enough to spread the marks out flat. */
 .app-stage[data-presentation="peek"] .panel-surface {
   width: var(--peek-width);
   transition-duration: var(--duration-shape);
@@ -734,69 +735,70 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
   padding: 0 var(--wing-inset);
 }
 
-/* The left wing's inner spans the whole strip rather than shrinking to its
-   contents: the face keeps the notch's edge it always had, and the marks' own
-   auto margin is what holds them against the shape's far edge instead of
-   beside the face. */
-.wing-left .wing-inner {
-  flex: 1;
-  justify-content: flex-end;
-}
-
-/* Anchored to the shape's far edge — the auto margin holds it there — and
-   starting at `--panel-inset` from it, so the first mark lines up with the tab
-   bar and the rows below. The wing already pads `--wing-inset`; the margin
-   makes up the difference. Read the way a list is: the first provider — the
-   one that needs a person soonest — holds the leftmost slot, and the overflow
-   count trails the rest. The far edge is the one a morph moves, so the marks
-   move with it; session-motion glides them there on the surface's own spring,
-   the same way it glides a re-sorted mark to its new slot. */
+/* Anchored beside the housing rather than at the shape's far edge, in every
+   state. The far edge is the one a morph moves; marks that are opaque at rest
+   would travel its whole 88px on every peek, and the strip would collapse
+   toward an edge on its way out. Beside the housing the black under them never
+   moves, so the shrink direction is safe by construction: the strip closes
+   toward the notch and nothing is ever drawn on the desktop. Read the way a
+   list is — the first provider, the one that needs a person soonest, holds the
+   slot nearest the housing, which is also the one the capsule keeps. */
 .wing-marks {
   display: flex;
   height: 22px;
   align-items: center;
   gap: 7px;
-  margin-right: auto;
-  margin-left: calc(var(--panel-inset) - var(--wing-inset));
 }
 
+/* The gate takes this place for its own label, and the two cannot share the
+   capsule's side. */
+.wing-marks[data-drawn="false"] {
+  display: none;
+}
+
+/* Stacked at rest and spread flat once the shape has room. The spread is
+   transform-only: an animated `gap` would re-lay the strip out on every frame,
+   and `--mark-rest` carries each mark's resting seat as an offset from where
+   the flat strip already lays it out.
+
+   The animation is what a mark mounting into an already unfolded wing needs:
+   on a compact mount its computed destination is its own resting seat, so it
+   costs nothing; on an open wing the backwards-filled keyframes provide the
+   missing start state. */
 .wing-mark {
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 0;
-  border: 0;
-  background: none;
   color: var(--text-secondary);
-  cursor: pointer;
-  outline: none;
-  -webkit-app-region: no-drag;
-  -webkit-tap-highlight-color: transparent;
-  pointer-events: none;
+  transform: translateX(var(--mark-rest, 0px));
+  transition:
+    opacity var(--duration-exit) var(--motion-exit),
+    transform var(--duration-shape) var(--spring);
+  animation:
+    wing-mount-fade var(--duration-quick) var(--motion-exit)
+    calc(var(--duration-shape) - var(--duration-quick)) backwards,
+    wing-mount-travel var(--duration-shape) var(--spring)
+    calc(var(--duration-shape) - var(--duration-quick)) backwards;
 }
 
-.wing-mark:hover,
-.wing-mark[data-active="true"] {
-  color: var(--text-primary);
+/* The capsule's side has room for one mark, so every mark past the first rests
+   exactly on it and is drawn nowhere until the shape spreads the strip out.
+   Overlapping them was tried: a facepile reads because avatars share one
+   circular frame, and these are heterogeneous glyphs at 14px, where a crescent
+   carries no identity at all. */
+.wing-mark[data-piled="false"] {
+  opacity: 0;
 }
 
-.wing-mark[data-leaving="true"] {
-  pointer-events: none;
-}
-
-html[data-keyboard="true"] .wing-mark:focus-visible {
-  outline: 2px solid var(--state-working);
-  outline-offset: 2px;
-  border-radius: 2px;
-}
-
-/* The capsule keeps the face and nothing else; what Luke is watching belongs to
-   the states with room for it, and unfolds outward from the notch on the same
-   spring, at the same distance, as the count's caption does on the other side.
-   The two wings are one gesture, so they move as one. */
-.wing-mark,
-.wing-more,
+/* The meter's slot, rather than the meter itself: unfolding is the wing's
+   gesture and belongs to the slot, while the opacity and scale inside it are
+   the meter's own answer to speech. One element cannot carry both. It unfolds
+   outward from the notch on the same spring, at the same distance, as the
+   marks spread on the other side: the two wings are one gesture, so they move
+   as one. */
 .wing-meter {
+  display: flex;
+  align-items: center;
   opacity: 0;
   transform: translateX(8px);
   transition:
@@ -804,11 +806,7 @@ html[data-keyboard="true"] .wing-mark:focus-visible {
     transform var(--duration-shape) var(--spring);
 }
 
-.app-stage[data-presentation="peek"] .wing-mark,
-.app-stage[data-presentation="peek"] .wing-more,
 .app-stage[data-presentation="peek"] .wing-meter,
-.app-stage[data-presentation="panel"] .wing-mark,
-.app-stage[data-presentation="panel"] .wing-more,
 .app-stage[data-presentation="panel"] .wing-meter {
   opacity: 1;
   transform: none;
@@ -817,35 +815,17 @@ html[data-keyboard="true"] .wing-mark:focus-visible {
   transition-delay: var(--peek-delay);
 }
 
-.app-stage[data-presentation="peek"] .wing-mark:not([data-leaving="true"]),
-.app-stage[data-presentation="panel"] .wing-mark:not([data-leaving="true"]) {
-  pointer-events: auto;
-}
-
-/* The marks rest at the shape's far edge, not beside the face, so the peek's
-   early beat would draw them on the desktop ahead of an edge still most of its
-   travel away. They arrive the way the voice meter arrives in the growing
-   capsule: crossing the last of the shape's travel and finishing as it
+/* The marks spread across the last of the shape's travel and finish as it
    settles, inside the black rather than ahead of it. The meter above keeps the
    early beat — it stands beside the face, where the shape's edge passes at
    once. */
 .app-stage[data-presentation="peek"] .wing-mark,
-.app-stage[data-presentation="peek"] .wing-more,
-.app-stage[data-presentation="panel"] .wing-mark,
-.app-stage[data-presentation="panel"] .wing-more {
+.app-stage[data-presentation="panel"] .wing-mark {
+  opacity: 1;
+  transform: none;
+  transition-duration: var(--duration-quick), var(--duration-shape);
+  transition-timing-function: var(--motion-exit), var(--spring);
   transition-delay: calc(var(--duration-shape) - var(--duration-quick));
-}
-
-/* A mark can mount into an already unfolded wing. On a compact mount its
-   computed destination is the same covered pose, so this costs nothing; on an
-   open wing the backwards-filled keyframes provide the missing start state. */
-.wing-mark,
-.wing-more {
-  animation:
-    wing-mount-fade var(--duration-quick) var(--motion-exit)
-    calc(var(--duration-shape) - var(--duration-quick)) backwards,
-    wing-mount-travel var(--duration-shape) var(--spring)
-    calc(var(--duration-shape) - var(--duration-quick)) backwards;
 }
 
 /* A meter drawn for a live turn does not wait for the wing to unfold. It is
@@ -856,24 +836,6 @@ html[data-keyboard="true"] .wing-mark:focus-visible {
 .wing-meter[data-turn] {
   opacity: 1;
   transform: none;
-}
-
-/* More providers than the wing can hold. Counted rather than dropped, at the
-   far end of the row, where it reads as the remainder of a list. */
-.wing-more {
-  flex: 0 0 auto;
-  color: var(--text-tertiary);
-  font-size: 9.5px;
-  font-weight: 660;
-  letter-spacing: -0.2px;
-}
-
-/* The meter's slot, rather than the meter itself: unfolding is the wing's
-   gesture and belongs to the slot, while the opacity and scale inside it are the
-   meter's own answer to speech. One element cannot carry both. */
-.wing-meter {
-  display: flex;
-  align-items: center;
 }
 
 .provider-mark {
@@ -1358,104 +1320,49 @@ html[data-keyboard="true"] .wing-mark:focus-visible {
   pointer-events: auto;
 }
 
-/* Session count ---------------------------------------------------------- */
+/* Sign-in label ---------------------------------------------------------- */
 
-/* A number, not a badge. Seventeen sessions overflowed a pill, and a pill was
-   never carrying meaning the colour and the caption were not already carrying.
-   The rounded system face is the one macOS uses for glanceable numerals.
-   `--count-fit` is the component's answer to a number that outgrows the shape
-   it sits in: notch-wings measures the text and the wing's own room, and the
-   badge stands down from its resting scale just far enough to stay inside the
-   black — on transform, like everything else that moves, so a count crossing
-   a digit boundary re-shapes no text and rides the same spring as the
-   presentation's own scale change. */
-.count-badge {
-  position: relative;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  color: var(--accent);
-  font-family: ui-rounded, -apple-system, "SF Pro Rounded", BlinkMacSystemFont, sans-serif;
-  font-size: 16px;
-  font-variant-numeric: tabular-nums;
-  font-weight: 600;
-  letter-spacing: -0.2px;
-  transform: scale(calc(0.88 * var(--count-fit, 1)));
-  transform-origin: left center;
-  transition: transform var(--duration-shape) var(--spring);
-  will-change: transform;
-}
-
-.count-badge[data-state="attention"] {
-  text-shadow: 0 0 14px color-mix(in srgb, var(--accent) 45%, transparent);
-}
-
-.count-badge[data-empty="true"] {
-  color: var(--text-tertiary);
-}
-
-/* The signed-out label wears words, not a numeral: the count's rounded
-   tabular face at label length reads as a button that is not one, so it
-   steps down to the panel's own text voice at a quieter size. It reads in
-   both compact shapes — inside the capsule's side it stands down to fit,
-   exactly as a wide count does — and hides over the open panel, where the
-   gate itself says it larger. The base rule declares only the transform
-   pair, so this restates it beside the fade rather than adding to it. */
-.count-badge[data-sign-in="true"] {
-  /* Flush to the housing's edge: the notch is black on black, so the inset a
-     numeral keeps reads as nothing here, and every pixel of it is room the
-     words need. The fit arithmetic mirrors this with `SIGN_IN_INSET`. */
+/* The one thing the right wing draws instead of the marks: words, in the
+   panel's own text voice at a quieter size, because a rounded tabular face at
+   label length reads as a button that is not one. It reads in both compact
+   shapes — inside the capsule's side it stands down to fit, which is what
+   `--sign-in-fit` carries: notch-wings measures the text and the wing's own
+   room, and the label stands down from its resting scale just far enough to
+   stay inside the black, on transform like everything else that moves. Over
+   the open panel it hides, where the gate itself says it larger. */
+.sign-in-label {
+  /* Flush to the housing's edge: the notch is black on black, so an inset
+     reads as nothing here, and every pixel of it is room the words need. The
+     fit arithmetic mirrors this with `SIGN_IN_INSET`. */
   margin-left: calc(-1 * var(--wing-inset));
-  font-family: inherit;
+  color: var(--text-tertiary);
   font-size: 12px;
-  font-variant-numeric: normal;
   font-weight: 640;
   letter-spacing: 0.1px;
   opacity: 0;
+  transform: scale(calc(0.88 * var(--sign-in-fit, 1)));
+  transform-origin: left center;
   transition:
     transform var(--duration-shape) var(--spring),
     opacity var(--duration-quick) var(--motion-exit);
-}
-
-.app-stage[data-presentation="capsule"] .count-badge[data-sign-in="true"],
-.app-stage[data-presentation="peek"] .count-badge[data-sign-in="true"] {
-  opacity: 1;
-}
-
-/* The panel has room for it to sit at full size; the capsule and the peek do
-   not, and growing it there read as a second movement competing with the
-   widening. */
-.app-stage[data-presentation="panel"] .count-badge {
-  transform: scale(var(--count-fit, 1));
-}
-
-.count-caption {
-  position: absolute;
-  top: 50%;
-  left: 100%;
-  margin-left: 9px;
-  color: var(--text-secondary);
-  font-size: 9.5px;
-  font-weight: 600;
-  letter-spacing: 0.2px;
-  opacity: 0;
-  text-transform: uppercase;
-  transform: translate(-8px, -50%);
-  /* Two properties, and the state below overrides duration and timing by
-     position: a third entry would have to be added there too. */
-  transition:
-    opacity var(--duration-exit) var(--motion-exit),
-    transform var(--duration-shape) var(--spring);
   white-space: nowrap;
+  will-change: transform;
 }
 
-.app-stage[data-presentation="peek"] .count-caption,
-.app-stage[data-presentation="panel"] .count-caption {
+.app-stage[data-presentation="capsule"] .sign-in-label,
+.app-stage[data-presentation="peek"] .sign-in-label {
   opacity: 1;
-  transform: translate(0, -50%);
-  transition-duration: var(--duration-quick), var(--duration-shape);
-  transition-timing-function: var(--motion-exit), var(--spring);
-  transition-delay: var(--peek-delay);
+}
+
+/* The roster's sentence is spoken, never drawn: assistive tech reads it out of
+   the live region while the wing draws the marks. */
+.wing-status {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip-path: inset(50%);
+  white-space: nowrap;
 }
 
 /* Voice caption ----------------------------------------------------------- */
@@ -2068,16 +1975,16 @@ html[data-keyboard="true"] .wing-mark:focus-visible {
 
 /* Waveform --------------------------------------------------------------- */
 
-/* The meter replaces the marks while the microphone is live and stays drawn for
-   the whole of that — silence is a thing it reports, not a reason to disappear.
-   It unfolds with the peek the way the marks do, because the capsule has no room
-   for it beside the face; there, a live microphone is what the face's colour and
-   tempo say. Speech only raises the meter from idle to full. */
+/* The meter takes the face's own place while the microphone is live and stays
+   drawn for the whole of that — silence is a thing it reports, not a reason to
+   disappear. It unfolds with the peek the way the marks spread, because the
+   capsule has no room for it beside the face; there, a live microphone is what
+   the face's colour and tempo say. Speech only raises the meter from idle to
+   full. */
 /* Exactly the face's 18px, because it stands where the face stands and the
    capsule has room for one of them: five bars at 2px with 2px between them. A
    wider meter is drawn past the black and onto the desktop, since the wings are
-   bounded by the peek the capsule can grow into rather than by the capsule. It
-   is also what keeps `FACE_AND_GAP` in notch-wings.tsx true of either one. */
+   bounded by the peek the capsule can grow into rather than by the capsule. */
 .waveform {
   display: flex;
   width: 18px;
@@ -3078,10 +2985,8 @@ html[data-keyboard="true"] .wing-mark:focus-visible {
   .feedback-stage,
   .key-slot-confirm,
   .wing-mark,
-  .wing-more,
   .wing-meter,
-  .count-badge,
-  .count-caption,
+  .sign-in-label,
   .session-row {
     transition-duration: 1ms;
     transition-delay: 0ms;

--- a/apps/desktop/src/renderer/styles/base.css
+++ b/apps/desktop/src/renderer/styles/base.css
@@ -761,12 +761,14 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
    and `--mark-rest` carries each mark's resting seat as an offset from where
    the flat strip already lays it out.
 
-   The animation is what a mark mounting into an already unfolded wing needs:
-   on a compact mount its computed destination is its own resting seat, so it
-   costs nothing; on an open wing the backwards-filled keyframes provide the
-   missing start state. */
+   A mark never gives up its own width: while a shrinking capacity holds the
+   marks it dropped through their exit beat, the strip briefly carries more
+   than the wing has room for, and a shrinking flex item would squeeze the
+   marks that are staying out of their 14px seat to make room for ones already
+   leaving. */
 .wing-mark {
   display: flex;
+  flex: 0 0 auto;
   align-items: center;
   justify-content: center;
   color: var(--text-secondary);
@@ -774,6 +776,15 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
   transition:
     opacity var(--duration-exit) var(--motion-exit),
     transform var(--duration-shape) var(--spring);
+  animation: wing-mount-fade var(--duration-quick) var(--motion-exit) backwards;
+}
+
+/* A mark mounting into a wing that is already unfolded waits out the shape's
+   own beat, or it is drawn ahead of an edge still most of its travel away. A
+   mark mounting into the resting strip waits for nothing: no shape is moving,
+   and the lead mark is drawn at rest, so a delay here would leave the wing
+   blank for the whole beat on a first roster or a new most urgent app. */
+.wing-marks[data-spread="true"] .wing-mark {
   animation:
     wing-mount-fade var(--duration-quick) var(--motion-exit)
     calc(var(--duration-shape) - var(--duration-quick)) backwards,

--- a/apps/web/src/NotchMock.tsx
+++ b/apps/web/src/NotchMock.tsx
@@ -11,6 +11,7 @@ import {
   SessionRow,
   WingFace,
   wingMarkCapacity,
+  wingPileOffset,
 } from "@sidecar/panel";
 import {
   CAPSULE_SIDE_WIDTH,
@@ -19,7 +20,6 @@ import {
   PANEL_WIDTH,
   PEEK_SIDE_GROWTH,
   SESSION_URGENCY,
-  type SessionUrgency,
   urgencyLabel,
 } from "@sidecar/surface";
 import { cssCustomProperties } from "@sidecar/surface/react-css";
@@ -51,8 +51,8 @@ type MockMode = (typeof MOCK_MODE)[keyof typeof MOCK_MODE];
 /**
  * How long each presentation holds before the loop moves on. The capsule
  * keeps a beat so the product is seen at rest before it answers; the peek
- * holds long enough for its count caption to be read after the surface
- * settles; the panel holds far longest, because the pause on the open state
+ * holds long enough for the marks to be read once the surface settles; the
+ * panel holds far longest, because the pause on the open state
  * is the point and the walk exists to frame it.
  */
 const CYCLE = {
@@ -78,18 +78,6 @@ const MOCK_SESSIONS = fixtureSnapshot("smoke")
   }))
   .toSorted(compareSessionsByUrgency);
 
-const ATTENTION_COUNT = MOCK_SESSIONS.filter(
-  (session) => session.urgency === SESSION_URGENCY.ATTENTION,
-).length;
-
-/** The urgency the count badge and the capsule adopt, as `sessionTally` decides it. */
-const TALLY_URGENCY: SessionUrgency =
-  ATTENTION_COUNT > 0 ? SESSION_URGENCY.ATTENTION : SESSION_URGENCY.WORKING;
-
-/** `tallyCaption` in the renderer: the caption names its own number. */
-const TALLY_CAPTION =
-  ATTENTION_COUNT > 0 ? `${ATTENTION_COUNT} ${ATTENTION_COUNT === 1 ? "needs" : "need"} you` : "";
-
 /**
  * The wing's marks as the renderer's `sessionTally` seats them, first to need
  * a person first: each chat counts under the app holding it — the lead of its
@@ -100,11 +88,9 @@ const WING_PROVIDERS = MOCK_SESSIONS.map(
 ).filter((markId, index, all) => all.indexOf(markId) === index);
 
 /**
- * `wingMarkCapacity` and its constants in the renderer's notch-wings.tsx: what
- * one wing costs to fill, so the peek counts its remainder and the panel does
- * not have to. The insets are `--panel-inset` on the far side, where the marks
- * start level with the tab bar and the rows, plus `--wing-inset` beside the
- * housing.
+ * `wingMarkCapacity` in `@sidecar/panel`: how many marks a wing of each width
+ * lays flat. Whatever a state cannot hold is truncated rather than counted,
+ * and the capsule's own side holds one.
  */
 const PEEK_CAPACITY = wingMarkCapacity(CAPSULE_SIDE_WIDTH + PEEK_SIDE_GROWTH);
 const PANEL_CAPACITY = wingMarkCapacity((PANEL_WIDTH - HOUSING_WIDTH) / 2);
@@ -238,9 +224,7 @@ export function NotchMock(): React.JSX.Element {
     return () => window.clearTimeout(timer);
   }, [capacity, drawnCapacity]);
 
-  const overflowing = WING_PROVIDERS.length > drawnCapacity;
-  const providers = WING_PROVIDERS.slice(0, overflowing ? drawnCapacity - 1 : drawnCapacity);
-  const unshown = WING_PROVIDERS.length - providers.length;
+  const providers = WING_PROVIDERS.slice(0, drawnCapacity);
 
   const mockStyle =
     panelHeight === undefined
@@ -313,28 +297,28 @@ export function NotchMock(): React.JSX.Element {
           </section>
         </div>
 
-        {/* The wings: Luke nearest the housing, what he is watching resting
-              against the shape's far edge, the count and its caption on the
-              other side. */}
+        {/* The wings: Luke beside the housing on one side, the marks of what
+              he is watching beside it on the other — piled at rest, spread
+              flat once the shape has room. */}
         <div className="wing wing-left">
           <div className="wing-inner">
-            <span className="wing-marks">
-              {providers.map((providerId) => (
-                <span className="wing-mark" key={providerId}>
-                  <ProviderMark providerId={providerId} />
-                </span>
-              ))}
-              {unshown > 0 ? <span className="wing-more">+{unshown}</span> : null}
-            </span>
             <WingFace />
           </div>
         </div>
 
         <div className="wing wing-right">
           <div className="wing-inner">
-            <span className="count-badge" data-state={TALLY_URGENCY}>
-              <span className="count-value">{MOCK_SESSIONS.length}</span>
-              <span className="count-caption">{TALLY_CAPTION}</span>
+            <span className="wing-marks">
+              {providers.map((providerId, index) => (
+                <span
+                  className="wing-mark"
+                  key={providerId}
+                  data-piled={String(index === 0)}
+                  style={cssCustomProperties({ "--mark-rest": `${wingPileOffset(index)}px` })}
+                >
+                  <ProviderMark providerId={providerId} />
+                </span>
+              ))}
             </span>
           </div>
         </div>

--- a/apps/web/src/notch-mock.css
+++ b/apps/web/src/notch-mock.css
@@ -266,20 +266,6 @@
   right: calc(50% + var(--notch-housing-width) / 2);
   left: calc(50% - var(--wing-bound) / 2);
   justify-content: flex-end;
-  /* The marks rest against this edge, and this edge is the one a morph moves.
-     In the product session-motion glides them along it on the surface's own
-     spring; here the edge itself takes the surface's exact timing — both
-     travel 50% minus half a springing width — so the marks track the black
-     without a frame of being drawn past it. The handful of fixed-size glyphs
-     inside re-lay out for pennies, and no text is re-shaped. */
-  transition: left var(--duration-shape) var(--spring) var(--duration-exit);
-}
-
-/* Growing, the far edge leads with the surface; shrinking, the base rule's
-   delay holds both back together — the two edges never part. */
-.mock[data-mode="peek"] .wing-left,
-.mock[data-mode="panel"] .wing-left {
-  transition-delay: 0s;
 }
 
 .mock .wing-right {
@@ -295,52 +281,42 @@
   padding: 0 var(--wing-inset);
 }
 
-/* The left wing's inner spans the whole strip rather than shrinking to its
-   contents: the face keeps the notch's edge it always had, and the marks' own
-   auto margin is what holds them against the shape's far edge instead of
-   beside the face. */
-.mock .wing-left .wing-inner {
-  flex: 1;
-  justify-content: flex-end;
-}
-
-/* Anchored to the shape's far edge — the auto margin holds it there — and
-   starting at `--panel-inset` from it, so the first mark lines up with the tab
-   bar and the rows below. The wing already pads `--wing-inset`; the margin
-   makes up the difference. Read the way a list is: the first provider — the
-   one that needs a person soonest — holds the leftmost slot, and the overflow
-   count trails the rest. */
+/* Anchored beside the housing rather than at the shape's far edge, in every
+   state: the far edge is the one a morph moves, and marks that are opaque at
+   rest would travel its whole growth on every peek. Beside the housing the
+   black under them never moves, so the pile closes toward the notch and
+   nothing is drawn outside the shape. Read the way a list is — the first
+   provider, the one that needs a person soonest, holds the slot nearest the
+   housing. */
 .mock .wing-marks {
   display: flex;
   height: 22px;
   align-items: center;
   gap: 7px;
-  margin-right: auto;
-  margin-left: calc(var(--panel-inset) - var(--wing-inset));
 }
 
+/* Stacked at rest and spread flat once the shape has room. The spread is
+   transform-only, as the renderer's own sheet insists: `--mark-rest` carries
+   each mark's resting seat as an offset from where the flat strip already
+   lays it out. */
 .mock .wing-mark {
   display: flex;
   align-items: center;
   color: var(--text-secondary);
-}
-
-/* The capsule keeps the face and nothing else; what Luke is watching unfolds
-   outward from the notch on the same spring, at the same distance, as the
-   count's caption does on the other side. The two wings are one gesture. */
-.mock .wing-mark,
-.mock .wing-more {
-  opacity: 0;
-  transform: translateX(8px);
+  transform: translateX(var(--mark-rest, 0px));
   transition:
     opacity var(--duration-exit) var(--motion-exit),
     transform var(--duration-shape) var(--spring);
 }
 
+/* The capsule's side has room for one mark, so every mark past the first rests
+   exactly on it and is drawn nowhere until the shape spreads the strip out. */
+.mock .wing-mark[data-piled="false"] {
+  opacity: 0;
+}
+
 .mock[data-mode="peek"] .wing-mark,
-.mock[data-mode="peek"] .wing-more,
-.mock[data-mode="panel"] .wing-mark,
-.mock[data-mode="panel"] .wing-more {
+.mock[data-mode="panel"] .wing-mark {
   opacity: 1;
   transform: none;
   transition-duration: var(--duration-quick), var(--duration-shape);
@@ -350,26 +326,14 @@
 
 /* A mark can mount into a wing that is already unfolded — the panel's wing
    holds more marks than the peek's — and a transition only runs from a style
-   the element has held, so a mark that arrives late unfolds on the same
+   the element has held, so a mark that arrives late spreads on the same
    gesture as the rest instead of appearing in place. */
 @starting-style {
   .mock[data-mode="peek"] .wing-mark,
-  .mock[data-mode="peek"] .wing-more,
-  .mock[data-mode="panel"] .wing-mark,
-  .mock[data-mode="panel"] .wing-more {
+  .mock[data-mode="panel"] .wing-mark {
     opacity: 0;
-    transform: translateX(8px);
+    transform: translateX(var(--mark-rest, 0px));
   }
-}
-
-/* More agents than the wing can hold: counted rather than dropped, at the far
-   end of the row, where it reads as the remainder of a list. */
-.mock .wing-more {
-  flex: 0 0 auto;
-  color: var(--text-tertiary);
-  font-size: 9.5px;
-  font-weight: 660;
-  letter-spacing: -0.2px;
 }
 
 .mock .provider-mark {
@@ -413,72 +377,14 @@
   transform: scale(1.22);
 }
 
-/* Luke holds the place nearest the housing in every state: the marks and the
-   captions unfold around a fixed point, and the strip at rest is him rather
-   than whichever agent happens to be first. */
+/* Luke holds the place nearest the housing in every state, as the marks hold
+   theirs on the other side: everything unfolds around two fixed points. */
 .mock .luke-face {
   width: 18px;
   height: 18px;
   flex: 0 0 auto;
   overflow: visible;
   color: var(--text-primary);
-}
-
-/* A number, not a badge: the rounded system face macOS uses for glanceable
-   numerals, in the tally's own state colour. */
-.mock .count-badge {
-  position: relative;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  color: var(--accent);
-  font-family: ui-rounded, -apple-system, "SF Pro Rounded", blinkmacsystemfont, sans-serif;
-  font-size: 16px;
-  font-variant-numeric: tabular-nums;
-  font-weight: 600;
-  letter-spacing: -0.2px;
-  transform: scale(0.88);
-  transform-origin: left center;
-  transition: transform var(--duration-shape) var(--spring);
-  will-change: transform;
-}
-
-.mock .count-badge[data-state="attention"] {
-  text-shadow: 0 0 14px color-mix(in srgb, var(--accent) 45%, transparent);
-}
-
-/* The panel has room for it to sit at full size; the capsule and the peek do
-   not, and growing it there read as a second movement competing with the
-   widening. */
-.mock[data-mode="panel"] .count-badge {
-  transform: scale(1);
-}
-
-.mock .count-caption {
-  position: absolute;
-  top: 50%;
-  left: 100%;
-  margin-left: 9px;
-  color: var(--text-secondary);
-  font-size: 9.5px;
-  font-weight: 600;
-  letter-spacing: 0.2px;
-  opacity: 0;
-  text-transform: uppercase;
-  transform: translate(-8px, -50%);
-  transition:
-    opacity var(--duration-exit) var(--motion-exit),
-    transform var(--duration-shape) var(--spring);
-  white-space: nowrap;
-}
-
-.mock[data-mode="peek"] .count-caption,
-.mock[data-mode="panel"] .count-caption {
-  opacity: 1;
-  transform: translate(0, -50%);
-  transition-duration: var(--duration-quick), var(--duration-shape);
-  transition-timing-function: var(--motion-exit), var(--spring);
-  transition-delay: var(--peek-delay);
 }
 
 /* Expanded panel. Content arrives behind the surface, never in front of it:

--- a/apps/web/src/notch-mock.css
+++ b/apps/web/src/notch-mock.css
@@ -301,6 +301,7 @@
    lays it out. */
 .mock .wing-mark {
   display: flex;
+  flex: 0 0 auto;
   align-items: center;
   color: var(--text-secondary);
   transform: translateX(var(--mark-rest, 0px));

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -440,11 +440,7 @@
 
   .mock .panel-surface,
   .mock .expanded-stage,
-  .mock .wing-left,
   .mock .wing-mark,
-  .mock .wing-more,
-  .mock .count-badge,
-  .mock .count-caption,
   .mock .tab-thumb,
   .mock .session-row,
   .mock .panel-header {

--- a/packages/panel/src/layout.ts
+++ b/packages/panel/src/layout.ts
@@ -1,25 +1,32 @@
+/** `--wing-inset` beside the housing, and the keep before the shape's far corner. */
 const WING_INSETS = 29;
-const FACE_AND_GAP = 26;
 const MARK_WIDTH = 14;
 const MARK_AND_GAP = 21;
-/** The meter is as wide as the face it stands beside, so it costs the same. */
-const METER_AND_GAP = 26;
 
 /**
- * How many marks fit beside the face, in a wing where the meter is also
- * standing beside it rather than taking its place — Luke's own turn, or an
- * audio signal with no turn to read at all. The developer's own live turn
- * hands the meter the face's own slot instead, at the face's own width, so
- * it costs the marks nothing extra. Reserving the meter's width here rather
- * than hiding marks to make room is what keeps the strip from ever drawing
- * the meter across a mark it already committed to.
+ * How many marks fit along a wing of this width, laid flat. The peek's side is
+ * 124px beside the housing it was measured against: each mark past the first
+ * costs 21px of the 95px between the wing's insets. The panel's side is what
+ * is left of `--panel-width` after the housing, so it holds roughly twice as
+ * many.
  */
-export function wingMarkCapacity(sideWidth: number, meterBesideFace = false): number {
-  const beyondFirst = Math.floor(
-    (sideWidth - WING_INSETS - FACE_AND_GAP - (meterBesideFace ? METER_AND_GAP : 0) - MARK_WIDTH) /
-      MARK_AND_GAP,
-  );
-  return Math.max(1, 1 + beyondFirst);
+export function wingMarkCapacity(sideWidth: number): number {
+  return Math.max(1, 1 + Math.floor((sideWidth - WING_INSETS - MARK_WIDTH) / MARK_AND_GAP));
+}
+
+/**
+ * Where slot `index` rests before the shape has room to lay the strip out
+ * flat: exactly on the first slot, which is the only one the capsule's side
+ * draws. Overlapping them instead was tried and abandoned — a facepile reads
+ * because avatars share one circular frame, where these are heterogeneous
+ * glyphs at 14px, and a mark cropped to a crescent carries no identity at all.
+ *
+ * The rest is an offset off the flat layout rather than a layout of its own,
+ * because the spread has to run on transform alone: an animated `gap` would
+ * re-lay the strip out every frame.
+ */
+export function wingPileOffset(index: number): number {
+  return -MARK_AND_GAP * index;
 }
 
 export function observedAgoLabel(observedAt: number, now: number): string {


### PR DESCRIPTION
## Summary

- The number beside the housing changed denominator with the tally's state — attention, working, complete, or the total — so one glyph carried four meanings separated only by a colour at 16px on black, and its disambiguating caption unfolded only in the states where the panel was already open; the provider marks move into its place and are drawn at rest, so the notch reports which apps hold the work instead of an ambiguous quantity.
- The capsule's side holds one mark, so at rest it shows the app whose session needs a person soonest and the peek and panel lay the whole strip out flat; overlapping them in a facepile was tried and abandoned, because avatars pile on a shared circular frame where these are heterogeneous glyphs at 14px, and a mark cropped to a crescent carries no identity.
- The marks become decorative spans rather than filter buttons (the panel's own chips filter better, with per-provider counts and multi-select), the roster's sentence moves to a dedicated live region derived once so the capsule button and the announcement cannot drift, and the `+N` overflow goes with the count rather than putting an uninterpretable number back beside the housing.
- Capacity no longer depends on voice state now that the wing reserves room for no face or meter, taking the peek from three marks to four and the panel from seven to eight; `tallyValue`, `tallyCaption`, `SessionTally.urgency`, and `dominantUrgency` are deleted, and the marketing mirror in `apps/web/` moves in lockstep.
- Anchoring the marks beside the housing rather than at the shape's far edge is what makes drawing them at rest safe: the far edge moves 88px on a morph, so marks resting against it would travel that on every peek and collapse toward an edge on its way out, where beside the housing the black under them never moves.

## Evidence

- Platform-independent checks: `./scripts/check.sh` — pass
- macOS Electron verification (`./scripts/verify.sh`): pass; all six fixture PNGs inspected (capsule, peek, panel, slot, speaking, muted)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/33220492308/artifacts/9705029073) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/33220492308)

- Commit: `482f361918a19aa11f1aaff5a9b57e621b534b32`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

### Physical-device evidence

- Screenshot or screen recording: `not attached`
- Physical-notch check: `not performed`
- Device/display configuration: `not recorded`

## Notes

- Blockers or follow-up verification: `pnpm evidence:record` has not been run, and it is the check this change most needs — the marks are opaque at rest and `.wing` clips at `--wing-bound` rather than at the capsule, so the clip will not save a mispositioned mark mid-morph. Sample that the rightmost drawn mark stays inside the surface's right edge at every frame of the capsule→peek grow, and that the strip is fully collapsed before the shrink starts. `docs/media/luke-desktop.jpg` and `docs/media/luke-talking.png` both show the notch and still need re-shooting.

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)