### PR TITLE
v0.3.13 chore: prepare Luke release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,71 @@
 Notable changes to Luke, newest first. Each heading is a released version and
 the date its release was published.
 
+## 0.3.13 — 2026-08-28
+
+### History
+
+Luke keeps the conversation you have been having with him. A History tab holds
+every line of the current launch — what you asked, what he answered, and the
+acts he carried at your request — and each message offers a copy control that
+takes exactly the words the bubble shows. Clear empties both the thread you can
+see and the context the model still holds, and the whole tab stays out of
+session recordings.
+([#513](https://github.com/ReviewStage/luke/pull/513),
+[#569](https://github.com/ReviewStage/luke/pull/569))
+
+### Improvements
+
+- The notch says which apps hold your work: the provider marks take the place
+  of the session count beside the housing and are drawn at rest
+  ([#577](https://github.com/ReviewStage/luke/pull/577))
+- Luke names each agent by its work and gives you the decision context before
+  he asks a question, in his own casual voice rather than scripted lines
+  ([#553](https://github.com/ReviewStage/luke/pull/553),
+  [#566](https://github.com/ReviewStage/luke/pull/566),
+  [#567](https://github.com/ReviewStage/luke/pull/567),
+  [#578](https://github.com/ReviewStage/luke/pull/578))
+- Luke never asks for folder permission: Cursor and Antigravity sessions no
+  longer read a workspace folder to label their branch
+  ([#552](https://github.com/ReviewStage/luke/pull/552))
+- Rows say when a session is running inside a Herdr pane
+  ([#560](https://github.com/ReviewStage/luke/pull/560))
+- Music and Spotify are asked for automation consent only mid-exchange, and
+  only once that player is audibly playing
+  ([#550](https://github.com/ReviewStage/luke/pull/550))
+- Settings drop the Usage data section: counting and screen recording follow
+  the run mode alone, and `PRIVACY.md` is now the whole of what Luke tells you
+  about either ([#563](https://github.com/ReviewStage/luke/pull/563))
+
+### Fixes
+
+- Fixed desktop session recordings never reaching PostHog at all
+  ([#535](https://github.com/ReviewStage/luke/pull/535))
+- Fixed a red voice error appearing when you cut Luke off mid-reply
+  ([#564](https://github.com/ReviewStage/luke/pull/564))
+- Fixed a slow cloud write being cut short by the observation pass's shared
+  deadline ([#557](https://github.com/ReviewStage/luke/pull/557))
+- Fixed the admin roster's last-seen instant ignoring hosted usage
+  ([#548](https://github.com/ReviewStage/luke/pull/548))
+
+### Miscellaneous
+
+- Added an iPhone app that signs in through LukeKit and the registered
+  `luke-mobile` OAuth client
+  ([#554](https://github.com/ReviewStage/luke/pull/554),
+  [#559](https://github.com/ReviewStage/luke/pull/559),
+  [#565](https://github.com/ReviewStage/luke/pull/565))
+- Added the hosted provider-key vault, which encrypts a stored cloud provider
+  key at rest and offers no way to read one back
+  ([#568](https://github.com/ReviewStage/luke/pull/568))
+- Added the websocket realtime endpoint to the voice mint, so a mobile client
+  can open a spoken session on the same credential
+  ([#562](https://github.com/ReviewStage/luke/pull/562))
+- Updated an act handler's refusals to name their cause
+  ([#572](https://github.com/ReviewStage/luke/pull/572))
+- Added the `entire` CLI's session hooks for Codex, Cursor, and OpenCode
+  ([#549](https://github.com/ReviewStage/luke/pull/549))
+
 ## 0.3.12 — 2026-08-26
 
 ### Improvements

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@luke/desktop",
   "productName": "Luke",
-  "version": "0.3.12",
+  "version": "0.3.13",
   "private": true,
   "description": "Luke desktop application",
   "main": "dist/main.js",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luke/web",
-  "version": "0.3.12",
+  "version": "0.3.13",
   "private": true,
   "type": "module",
   "description": "Luke landing page",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "luke",
-  "version": "0.3.12",
+  "version": "0.3.13",
   "private": true,
   "description": "A notch-attached desktop sidecar for coding-agent sessions",
   "packageManager": "pnpm@10.34.5",

--- a/packages/account/package.json
+++ b/packages/account/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/account",
-  "version": "0.3.12",
+  "version": "0.3.13",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/acts/package.json
+++ b/packages/acts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/acts",
-  "version": "0.3.12",
+  "version": "0.3.13",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/analytics",
-  "version": "0.3.12",
+  "version": "0.3.13",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/attention/package.json
+++ b/packages/attention/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/attention",
-  "version": "0.3.12",
+  "version": "0.3.13",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/calendar/package.json
+++ b/packages/calendar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/calendar",
-  "version": "0.3.12",
+  "version": "0.3.13",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/credentials/package.json
+++ b/packages/credentials/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/credentials",
-  "version": "0.3.12",
+  "version": "0.3.13",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/devtrace/package.json
+++ b/packages/devtrace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/devtrace",
-  "version": "0.3.12",
+  "version": "0.3.13",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/feedback/package.json
+++ b/packages/feedback/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/feedback",
-  "version": "0.3.12",
+  "version": "0.3.13",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/fixtures/package.json
+++ b/packages/fixtures/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/fixtures",
-  "version": "0.3.12",
+  "version": "0.3.13",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/guide/package.json
+++ b/packages/guide/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/guide",
-  "version": "0.3.12",
+  "version": "0.3.13",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/hosted/package.json
+++ b/packages/hosted/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/hosted",
-  "version": "0.3.12",
+  "version": "0.3.13",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/issues/package.json
+++ b/packages/issues/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/issues",
-  "version": "0.3.12",
+  "version": "0.3.13",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/panel/package.json
+++ b/packages/panel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/panel",
-  "version": "0.3.12",
+  "version": "0.3.13",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/process/package.json
+++ b/packages/process/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/process",
-  "version": "0.3.12",
+  "version": "0.3.13",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/providers/package.json
+++ b/packages/providers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/providers",
-  "version": "0.3.12",
+  "version": "0.3.13",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/realtime/package.json
+++ b/packages/realtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/realtime",
-  "version": "0.3.12",
+  "version": "0.3.13",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/session/package.json
+++ b/packages/session/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/session",
-  "version": "0.3.12",
+  "version": "0.3.13",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/settings/package.json
+++ b/packages/settings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/settings",
-  "version": "0.3.12",
+  "version": "0.3.13",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/superset/package.json
+++ b/packages/superset/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/superset",
-  "version": "0.3.12",
+  "version": "0.3.13",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/surface/package.json
+++ b/packages/surface/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/surface",
-  "version": "0.3.12",
+  "version": "0.3.13",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/trackers/package.json
+++ b/packages/trackers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/trackers",
-  "version": "0.3.12",
+  "version": "0.3.13",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/voice/package.json
+++ b/packages/voice/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/voice",
-  "version": "0.3.12",
+  "version": "0.3.13",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/wire/package.json
+++ b/packages/wire/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/wire",
-  "version": "0.3.12",
+  "version": "0.3.13",
   "private": true,
   "type": "module",
   "exports": {

--- a/scripts/packaging.test.mjs
+++ b/scripts/packaging.test.mjs
@@ -50,7 +50,7 @@ function builderConfig(env = {}) {
   return createElectronBuilderConfig(env);
 }
 
-test("workspace package versions agree on v0.3.12", () => {
+test("workspace package versions agree on v0.3.13", () => {
   // Enumerated rather than listed, so a package added to the workspace is held
   // to the release version without anyone remembering to name it here.
   const packagePaths = [
@@ -74,7 +74,7 @@ test("workspace package versions agree on v0.3.12", () => {
 
   assert.deepEqual(
     versions.map(({ version }) => version),
-    packagePaths.map(() => "0.3.12"),
+    packagePaths.map(() => "0.3.13"),
   );
 });
 


### PR DESCRIPTION
Bumps every workspace package to 0.3.13 and adds the release's `CHANGELOG.md`
entry, which `scripts/repository-checks.sh` requires before the tag can be
pushed. Covers the 22 commits landed since v0.3.12.

Headline: the conversation History tab (#513, #569) and the notch's provider
marks replacing the session count (#577).

`./scripts/check.sh` passes. No macOS or UI change here — the version bump and
the notes are the whole diff — so no evidence run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RVSgU8dKmoFi2a8w9Kq6CS

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/33223611878/artifacts/9706111646) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/33223611878)

- Commit: `bbddd44559dba6fb641e02f8159a455e9d019d0e`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
