### PR TITLE
fix(desktop): keep Updates in place while downloading

### DIFF
--- a/apps/desktop/src/renderer/settings-panel.test.ts
+++ b/apps/desktop/src/renderer/settings-panel.test.ts
@@ -1,0 +1,16 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const source = readFileSync(new URL("./settings-panel.tsx", import.meta.url), "utf8");
+
+test("the Updates section keeps one place as update state changes", () => {
+  const updates = [...source.matchAll(/<UpdatesSection\b/g)].map(({ index }) => index);
+  const settingsIndex = source.indexOf('className="settings-section settings-index"');
+
+  assert.equal(updates.length, 1, "Updates is not conditionally moved between two render sites");
+  assert.ok((updates[0] ?? -1) > settingsIndex, "Updates stays below the settings page index");
+  assert.match(source, /<WhatLukeRunsOnSection\s+rowIndex=\{1\}/);
+  assert.match(source, /settings-index"\s+style=\{cssCustomProperties\(\{ "--row-index": 2 \}\)\}/);
+  assert.match(source, /<UpdatesSection control=\{updates\} rowIndex=\{3\} \/>/);
+});

--- a/apps/desktop/src/renderer/settings-panel.tsx
+++ b/apps/desktop/src/renderer/settings-panel.tsx
@@ -162,7 +162,7 @@ import {
   type SettingsView,
   settingsNavRowId,
 } from "./settings-views";
-import { UPDATE_ROW_ACTION, type UpdateRowAction, updateAvailable, updateRow } from "./update-row";
+import { UPDATE_ROW_ACTION, type UpdateRowAction, updateRow } from "./update-row";
 
 /** One provider the default-workspace rows can offer, by id and display name. */
 export interface WorkspaceProviderOption {
@@ -3482,11 +3482,9 @@ function updateButton(action: UpdateRowAction, control: UpdateControl): React.JS
 }
 
 /**
- * Where the build stands against the latest release. It sits below the pages
- * until a newer release is positively known, and leads the front page while
- * one is — the place in the stack is itself the answer to "is there news",
- * the same answer the Settings tab's dot gives from outside. The caller says
- * where it stands, because the arrival stagger is counted by the page.
+ * Where the build stands against the latest release. It stays below the pages
+ * while the Settings tab's dot carries the news outside. The caller says where
+ * it stands, because the arrival stagger is counted by the page.
  */
 function UpdatesSection({
   control,
@@ -3653,10 +3651,6 @@ export function SettingsPanel({
   }, [view, panelOpen]);
   // The drawn page's reset, absent while that page stands at its defaults.
   const pageReset = pageResetControl(view, settings, writes);
-  // Whether the Updates section leads the front page instead of sitting below
-  // the pages: a newer release waiting is the one piece of news this page can
-  // hold, and news is not filed under maintenance.
-  const updateLeads = updateAvailable(updates.update);
   return (
     <div
       className="settings"
@@ -3703,15 +3697,13 @@ export function SettingsPanel({
            the founders, whose account this is, and the way out. The allowance leads because it is the one
            thing here worth checking daily; the account itself follows the
            page down to the ways out, which are done once or never. A newer
-           release waiting takes the head of the page for as long as it
-           stands, because it is the one thing here that is news rather than
-           state, and the row indexes below count past it so the arrival
-           stagger keeps one order with the sections. */
+           release waiting is marked on the tab rather than moved here: a
+           section that changed places as its own check found news would
+           rearrange the page under the hand that pressed it. */
         <>
-          {updateLeads ? <UpdatesSection control={updates} rowIndex={1} /> : null}
           {account.status === ACCOUNT_STATUS.SIGNED_IN && settings ? (
             <WhatLukeRunsOnSection
-              rowIndex={updateLeads ? 2 : 1}
+              rowIndex={1}
               panelOpen={panelOpen}
               storageLocked={settings.secretStorage === SECRET_STORAGE.UNAVAILABLE}
               settings={settings}
@@ -3723,7 +3715,7 @@ export function SettingsPanel({
           ) : null}
           <section
             className="settings-section settings-index"
-            style={cssCustomProperties({ "--row-index": updateLeads ? 3 : 2 })}
+            style={cssCustomProperties({ "--row-index": 2 })}
           >
             {SETTINGS_SUBVIEW_LIST.map((subview) => (
               <SettingsNavRow
@@ -3796,7 +3788,7 @@ export function SettingsPanel({
 
       {view !== SETTINGS_VIEW.ROOT || search ? null : (
         <>
-          {updateLeads ? null : <UpdatesSection control={updates} rowIndex={3} />}
+          <UpdatesSection control={updates} rowIndex={3} />
 
           <FeedbackSection control={feedback} />
 

--- a/apps/desktop/src/renderer/update-row.ts
+++ b/apps/desktop/src/renderer/update-row.ts
@@ -26,11 +26,10 @@ export interface UpdateRow {
 
 /**
  * Whether a newer release is positively known to exist. This is what marks
- * the Settings tab and moves the Updates section to the head of the front
- * page — one judgment, so the dot, the section's place, and the row can
- * never disagree about whether there is news. The news stands through the
- * whole install: a release downloading, still publishing, waiting on its
- * restart, or failed mid-fetch is still one this build is not on.
+ * the Settings tab, so the dot and the row can never disagree about whether
+ * there is news. The news stands through the whole install: a release
+ * downloading, still publishing, waiting on its restart, or failed mid-fetch
+ * is still one this build is not on.
  */
 export function updateAvailable(update: UpdateSnapshot): boolean {
   return (


### PR DESCRIPTION
## Summary

- Keep the Updates section in its existing Settings position when a newer release begins downloading
- Preserve the Settings-tab notification dot without using update state to reorder the page
- Add a regression test for the single render site, section order, and fixed animation indices

## Test coverage

- The regression test fails on `origin/main` and passes on this branch
- Update news/non-news states remain covered by `update-row.test.ts`
- Live physical clicking was not performed

## Pre-landing review

No issues found. Scope check: clean.

## Verification

- [x] `./scripts/check.sh`
- [x] Repository contracts, lint, typecheck, full tests, and builds
- [x] Documentation audit: no updates required

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/33225229302/artifacts/9706650202) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/33225229302)

- Commit: `3611dd2d1892f1cb4fdbd269f0625e924177abc4`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
