### PR TITLE
fix(duck): read automation consent about the player's process, on a deadline

### DIFF
--- a/apps/desktop/native/macos/MediaDuck.swift
+++ b/apps/desktop/native/macos/MediaDuck.swift
@@ -26,7 +26,11 @@ import Foundation
 /// every other field dies here unread. A player already playing when this
 /// helper started has said nothing yet, and unknown is a skip, never a
 /// dialog: its next broadcast — a track change at the latest — is when a
-/// later exchange gets to ask.
+/// later exchange gets to ask. The standing answer is read about the
+/// player's running process and against a deadline, because the read
+/// crosses daemons this helper does not own, and a machine that never
+/// answers must cost an exchange one player — never the helper whose exit
+/// is what restores the music.
 ///
 /// The one command language: `duck` fades every playing player down, `restore`
 /// fades back whatever `duck` changed. Stdin closing is the app going away, so
@@ -121,21 +125,72 @@ private final class PlayStateWatch: NSObject {
 /// refused on the user's behalf — is a no this helper honors.
 private let CONSENT_NOT_YET_ASKED: OSStatus = -1744
 
+/// How long macOS may take to answer the standing-consent read. A healthy
+/// machine answers in milliseconds; the observed alternative is Apple Events
+/// daemons that never answer at all, so a generous beat is still the whole
+/// difference between one skipped player and a helper that can no longer
+/// duck, restore, or exit.
+private let CONSENT_ANSWER_SECONDS = 2.0
+
 private enum AutomationConsent {
     case granted
     case notYetAsked
     case withheld(OSStatus)
+    case unanswered
+}
+
+/// The consent reads still waiting on macOS, keyed by the player process each
+/// was about. At most one read may wait per process: on a machine whose
+/// daemons never answer, a wedged player costs one parked thread and every
+/// later exchange skips it outright rather than parking another. A relaunched
+/// player gets a fresh read, because the process it was about is gone.
+@MainActor private var unansweredConsentReads: Set<pid_t> = []
+
+/// Carries the consent read's answer across the queue hop. The semaphore
+/// orders the write before the read, which is what lets this stay a plain
+/// mutable field.
+private final class ConsentAnswer: @unchecked Sendable {
+    var status: OSStatus = noErr
 }
 
 /// macOS's standing answer about this helper speaking to one player, read
 /// without raising the dialog, so the dialog itself can be saved for the
 /// moment it is about.
-private func automationConsent(for player: MediaPlayer) -> AutomationConsent {
-    let target = NSAppleEventDescriptor(bundleIdentifier: player.bundleIdentifier)
-    // A target descriptor that cannot even be read back cannot carry an event
-    // either; -50 is the paramErr such an event would earn.
-    guard let address = target.aeDesc else { return .withheld(-50) }
-    switch AEDeterminePermissionToAutomateTarget(address, typeWildCard, typeWildCard, false) {
+///
+/// The read is addressed to the player's process, never its bundle
+/// identifier: the process is already in hand from the running check, and a
+/// bundle identifier hands macOS a resolution step that a stale
+/// LaunchServices registration — a Spotify updater's leftover staging copy,
+/// in the observed case — can wedge into never answering. And because even
+/// this read is a round trip through daemons outside this process, it waits
+/// on its own thread against a deadline rather than on the main thread the
+/// stdin-closing restore needs: an answer that never comes back is a player
+/// skipped this exchange, not music stranded quiet by a helper that can no
+/// longer hear anything.
+@MainActor
+private func automationConsent(for application: NSRunningApplication) -> AutomationConsent {
+    let pid = application.processIdentifier
+    guard !unansweredConsentReads.contains(pid) else { return .unanswered }
+    unansweredConsentReads.insert(pid)
+    let answered = DispatchSemaphore(value: 0)
+    let answer = ConsentAnswer()
+    DispatchQueue.global().async {
+        let target = NSAppleEventDescriptor(processIdentifier: pid)
+        answer.status = withExtendedLifetime(target) {
+            // A target descriptor that cannot even be read back cannot carry
+            // an event either; -50 is the paramErr such an event would earn.
+            guard let address = target.aeDesc else { return -50 }
+            return AEDeterminePermissionToAutomateTarget(address, typeWildCard, typeWildCard, false)
+        }
+        answered.signal()
+        DispatchQueue.main.async {
+            MainActor.assumeIsolated { _ = unansweredConsentReads.remove(pid) }
+        }
+    }
+    guard answered.wait(timeout: .now() + CONSENT_ANSWER_SECONDS) == .success else {
+        return .unanswered
+    }
+    switch answer.status {
     case noErr: return .granted
     case CONSENT_NOT_YET_ASKED: return .notYetAsked
     case let status: return .withheld(status)
@@ -208,10 +263,14 @@ private func runAppleScript(_ source: String) -> NSAppleEventDescriptor? {
 /// Asked of the system, not of the player: an Apple Event sent to an app that
 /// is not running launches it, and starting the user's music player is the
 /// opposite of quieting it.
-private func isRunning(_ player: MediaPlayer) -> Bool {
-    !NSRunningApplication.runningApplications(
+private func runningApplication(of player: MediaPlayer) -> NSRunningApplication? {
+    NSRunningApplication.runningApplications(
         withBundleIdentifier: player.bundleIdentifier
-    ).isEmpty
+    ).first
+}
+
+private func isRunning(_ player: MediaPlayer) -> Bool {
+    runningApplication(of: player) != nil
 }
 
 private func isPlaying(_ player: MediaPlayer) -> Bool {
@@ -309,8 +368,8 @@ private struct MediaDuckCommand {
     /// ducked volume back as the one to restore to.
     static func duck() {
         for player in PLAYERS where ducked[player.bundleIdentifier] == nil {
-            guard isRunning(player) else { continue }
-            switch automationConsent(for: player) {
+            guard let application = runningApplication(of: player) else { continue }
+            switch automationConsent(for: application) {
             case .granted:
                 break
             case .notYetAsked:
@@ -320,6 +379,11 @@ private struct MediaDuckCommand {
                 // broadcast says is audibly playing. Unknown is a skip, never
                 // a dialog — a later exchange will know.
                 guard playStateWatch.believesPlaying(player) else { continue }
+            case .unanswered:
+                // Said aloud like a refusal, because a machine that answers
+                // nothing and honored consent look identical otherwise.
+                emit("unanswered \(player.bundleIdentifier)")
+                continue
             case .withheld(let status):
                 // Said aloud like a live refusal, because honored consent and
                 // a lost duck look identical otherwise.


### PR DESCRIPTION
## What happened

On a real machine, Luke stopped quieting Spotify entirely. The `mac-media-duck` helper checks macOS's standing Automation consent with `AEDeterminePermissionToAutomateTarget` before every duck, addressed by bundle identifier, synchronously on its main thread. On that machine the call never returned: LaunchServices held stale registrations for `com.spotify.client` (a leftover Spotify auto-updater staging copy whose path no longer existed, plus an iPhone-Mirroring iOS placeholder), and bundle-id resolution wedged inside the Apple Events daemons — persistently, surviving restarts of Spotify, the user `tccd`, and the user `appleeventsd`, while the same consent read addressed **by process id** answered instantly with `granted`.

One wedged read costs everything downstream: the duck never happens, the main thread can never service the stdin-EOF restore, and — because the helper deliberately ignores quit signals so a Ctrl+C can't strand a duck — the process becomes an unkillable orphan pinning a core after the app is gone. Seven such orphans were found on the affected machine, one at 100 % CPU for 45 minutes.

## The fix

- The consent read targets the `NSRunningApplication` the running check already found (`NSAppleEventDescriptor(processIdentifier:)`), so macOS is never handed the bundle-id resolution step that wedged.
- The read waits on a background thread against a two-second deadline. An unanswered read is a new `.unanswered` consent case: the player is skipped for this exchange and the skip is said aloud on stdout (`unanswered <bundle id>`), consistent with `refused`/`skipped`. At most one read may wait per player process, so a permanently wedged machine parks one thread per player rather than one per exchange.

No TypeScript changes; the controller's contract with the helper is unchanged.

## Validation

- Compiled on a physical Mac (M3 Pro, arm64) with the repo's exact flags (`swiftc -parse-as-library -target arm64-apple-macos14.0 -framework AppKit`).
- Live end-to-end on the machine that still reproduces the wedge: `duck` faded Spotify 100 → 24 (requested 25; Spotify's documented off-by-one), stdin-EOF restore brought it back to 100, and the helper exited cleanly — where the unfixed helper, run the same way moments earlier, hung indefinitely in `automationConsent` and had to be SIGKILLed.
- `./scripts/check.sh` passes (exit 0) on Linux; `./scripts/verify.sh` runs in this PR's macOS CI job.
- No UI change; no physical-notch check applicable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/e4d59454-d1f3-494d-b054-d9f54dd2c4e3)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/33226484111/artifacts/9707070767) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/33226484111)

- Commit: `5ea719c411e6738a02c946f92131b50dff199c4c`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
