### PR TITLE
fix(web): keep the footer hairline off the hero mock on phones

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -11,7 +11,10 @@ export function App(): React.JSX.Element {
         {/* The copy runs left, the way a page of prose does. The mock does not:
             a notch belongs at the horizontal center of a display, so the art
             centers itself inside the column the copy is aligned against. */}
-        <section className="pt-12 pb-16 max-[520px]:pt-8 max-[520px]:pb-0">
+        {/* The footer's hairline draws itself a space-5 above the footer's own
+            box, inside this section's bottom padding, so the padding must keep
+            at least that much clearance or the rule lands across the mock. */}
+        <section className="pt-12 pb-16 max-[520px]:pt-8 max-[520px]:pb-10">
           {/* Fixed rather than fluid, with one step down: at 2.25rem the line
               needs about 490px, so it steps before the column can squeeze it
               rather than at the column's own padding breakpoint. */}


### PR DESCRIPTION
## Problem

On phones (viewports under 520px), the landing page's footer hairline cuts straight through the bottom of the hero mock.

The footer's full-bleed `hairline` rule draws itself a `space-5` (24px) above the footer's own box — inside the previous section's bottom padding. Every other page leaves that rule plenty of clearance, but the hero section zeroes its bottom padding under 520px (`max-[520px]:pb-0`) so the mock can fill a phone, which lands the rule 24px above the mock stage's bottom edge, across the artwork.

## Fix

Give the hero section enough mobile bottom padding (`pb-10`, 40px) to clear the hairline's 24px reach, leaving a 16px gap between the mock and the rule, and record the constraint in a comment so the next padding change doesn't reintroduce it.

## Verification

- `./scripts/check.sh` passes.
- Reproduced before/after with a headless Chrome screenshot of the built site at 412px width: before, the hairline crosses the mock ~24px above its bottom edge (matching the reported phone screenshot); after, the rule sits clear below the mock. Web-only change, so no macOS `verify.sh` run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/f754c5c8-f465-4fed-bc6e-8248a3ea8eb2)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/33280854538/artifacts/9722960979) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/33280854538)

- Commit: `d9326d65444e94e809ef3f4e703208820040ecf8`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
