### PR TITLE
feat(desktop): open Luke at login

### DIFF
--- a/apps/desktop/src/main/desktop-app.ts
+++ b/apps/desktop/src/main/desktop-app.ts
@@ -942,6 +942,16 @@ const dock = new DockPresence({
 });
 
 /**
+ * Registers or removes Luke's own login item, the stored setting being the
+ * source of truth every launch re-applies. Only a packaged app may: an
+ * unpackaged run would hand macOS the bare Electron binary, and a fixture or
+ * capture run must not touch the machine it happens to run on.
+ */
+function applyLoginItem(openAtLogin: boolean): void {
+  if (app.isPackaged) app.setLoginItemSettings({ openAtLogin });
+}
+
+/**
  * Starts watching whether the Mac's output would let Luke be heard. Not in a
  * fixture or capture run: evidence must not read the machine it happens to
  * run on, and a fixture run has no voice to go unheard — the muted evidence
@@ -1427,6 +1437,7 @@ function registerIpc(): void {
     applyVoiceCredential,
     hotkeys,
     dock,
+    applyLoginItem,
     panels,
     realtimeCredentials: () => voiceCapabilities.realtimeCredentials,
     mediaDuck,
@@ -2533,6 +2544,10 @@ export function startDesktopApp(): void {
       void settingsStore.get(APP_SETTING_SCHEMA.showInDock.field).then((show) => {
         if (show) dock.apply(true);
       });
+      // The login item reads the same file under the opposite default: it is
+      // opt-out, so the stored setting is re-applied every launch and a login
+      // item removed outside Luke comes back until the toggle says otherwise.
+      void settingsStore.get(APP_SETTING_SCHEMA.openAtLogin.field).then(applyLoginItem);
       // Armed from the settings file alone, like the status item, and for the
       // same reason. A file that cannot be read leaves the duck on, the same
       // answer a file that has never said gives. Never armed in a fixture or

--- a/apps/desktop/src/main/ipc/settings-rows.ts
+++ b/apps/desktop/src/main/ipc/settings-rows.ts
@@ -35,6 +35,7 @@ export interface SettingsRowsIpcDependencies {
   applyVoiceCredential: () => Promise<void>;
   hotkeys: HotkeyRegistrar;
   dock: DockPresence;
+  applyLoginItem: (openAtLogin: boolean) => void;
   panels: PanelManager;
   realtimeCredentials: () => RealtimeCredentialMinter | undefined;
   mediaDuck: MediaDuckController;
@@ -54,6 +55,7 @@ export function registerSettingsRowsIpc(dependencies: SettingsRowsIpcDependencie
     applyVoiceCredential,
     hotkeys,
     dock,
+    applyLoginItem,
     panels,
     realtimeCredentials,
     mediaDuck,
@@ -123,6 +125,9 @@ export function registerSettingsRowsIpc(dependencies: SettingsRowsIpcDependencie
     waitForDeferredEffects = false,
   ): Promise<void> {
     switch (APP_SETTING_SCHEMA[field].mainProcessSideEffect) {
+      case SETTING_SIDE_EFFECT.LOGIN_ITEM:
+        applyLoginItem(settings.stored.openAtLogin);
+        break;
       case SETTING_SIDE_EFFECT.DOCK:
         dock.apply(settings.stored.showInDock, panels.displayIdFor(context.sender));
         break;

--- a/apps/desktop/src/renderer/luke-guide.test.ts
+++ b/apps/desktop/src/renderer/luke-guide.test.ts
@@ -862,6 +862,7 @@ test("every adjustable setting is carried to the bridge call its row uses", asyn
   assert.deepEqual(calls.sort(), [
     "duckOtherMedia:true",
     "formFactor:notch",
+    "openAtLogin:true",
     "preferBuiltInMicrophone:true",
     "quietDuringMeetings:true",
     "showInDock:true",

--- a/packages/guide/src/app-settings.ts
+++ b/packages/guide/src/app-settings.ts
@@ -13,6 +13,7 @@ export const APP_SETTING_ID = {
   PREFER_BUILT_IN_MICROPHONE: "prefer_built_in_microphone",
   QUIET_DURING_MEETINGS: "quiet_during_meetings",
   SHOW_IN_DOCK: "show_in_dock",
+  OPEN_AT_LOGIN: "open_at_login",
   SHOW_ON_ALL_DISPLAYS: "show_on_all_displays",
   FORM_FACTOR: "form_factor",
   DEFAULT_WORKSPACE_PROVIDER: "default_workspace_provider",

--- a/packages/settings/src/schema.ts
+++ b/packages/settings/src/schema.ts
@@ -83,6 +83,7 @@ export type SettingsResetScope = (typeof SETTINGS_RESET_SCOPE)[keyof typeof SETT
 export const SETTING_SIDE_EFFECT = {
   NONE: "none",
   DOCK: "dock",
+  LOGIN_ITEM: "login-item",
   DISPLAYS: "displays",
   FORM_FACTOR: "form-factor",
   VOICE: "voice",
@@ -320,6 +321,30 @@ function workspaceProjectDefaults(
 }
 
 export const APP_SETTING_SCHEMA = {
+  openAtLogin: {
+    field: "openAtLogin",
+    default: true,
+    guard: boolean(true),
+    settingsPage: SETTINGS_PAGE.APPEARANCE,
+    resetScope: SETTINGS_RESET_SCOPE.APPEARANCE,
+    guideEntry: settingGuideEntry(
+      "openAtLogin",
+      [APP_SETTING_ID.OPEN_AT_LOGIN],
+      (settings, defaultValue) => ({
+        id: APP_SETTING_ID.OPEN_AT_LOGIN,
+        label: "Open Luke at login",
+        description: "Whether Luke starts on his own when this Mac signs in.",
+        kind: APP_SETTING_KIND.TOGGLE,
+        value: appToggleText(guideValue<boolean>(settings, "openAtLogin")),
+        defaultValue: appToggleText(defaultValue),
+        adjustable: true,
+        manual: APPEARANCE_PAGE,
+      }),
+    ),
+    mainProcessSideEffect: SETTING_SIDE_EFFECT.LOGIN_ITEM,
+    spokenValue: (value: string) => value === APP_TOGGLE_VALUE.ON,
+    analytics: { id: APP_SETTING_ID.OPEN_AT_LOGIN, value: toggleAnalytics },
+  },
   showInDock: {
     field: "showInDock",
     default: false,


### PR DESCRIPTION
## Summary

- Adds an **Open at login** toggle (default on) to the Appearance settings page, backed by macOS's own login items through `app.setLoginItemSettings`; the stored setting is the source of truth, re-applied at every packaged boot beside the Dock presence, so a login item removed outside Luke returns until the toggle says otherwise.
- The apply is guarded on `app.isPackaged` — an unpackaged run would register the bare Electron binary, and the same guard keeps fixture and capture runs off the machine they happen to run on.
- Everything else derives from the one schema entry (store field, `BRIDGE.updateSetting` path, rendered switch, settings search, analytics `setting_id`, spoken guide), so no renderer JSX changed.

## Evidence

- Platform-independent checks: `./scripts/check.sh` passed
- macOS Electron verification (`./scripts/verify.sh`): passed

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/33420329909/artifacts/9768736675) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/33420329909)

- Commit: `f8fa516ba67d68ae05a642684665ab201d8cb60b`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

### Physical-device evidence

- Screenshot or screen recording: `not attached`
- Physical-notch check: `not performed`
- Device/display configuration: `not recorded`

## Notes

- The new row sits on Settings → Appearance, which the smoke evidence set does not capture; the panel itself is unchanged. The login item is `app.isPackaged`-only, so registration still wants a manual pass on a packaged build (first launch adds Luke to System Settings → General → Login Items; toggling off removes it).

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)