### PR TITLE
feat(desktop): let a keyboard shortcut be deleted outright

### DIFF
--- a/apps/desktop/src/main/settings-store.test.ts
+++ b/apps/desktop/src/main/settings-store.test.ts
@@ -21,6 +21,7 @@ import {
   APP_SETTING_SCHEMA,
   isKeyedAppSettingField,
   settingEntryGuard,
+  VOICE_HOTKEY_NONE,
 } from "@sidecar/settings";
 import { PANEL_FORM_FACTOR } from "@sidecar/surface";
 import { type UnparsedWireValue, unparsedWire, type WireRecord } from "@sidecar/wire";
@@ -1300,6 +1301,25 @@ test("clearing the talk-key chord returns to no choice at all", async (t) => {
   // Absent from the file rather than stored as an empty value: reset is the
   // absence of a choice, and a reopened store must read it the same way.
   assert.equal(await storeIn(directory).get(APP_SETTING_SCHEMA.voiceHotkey.field), undefined);
+});
+
+test("stores a deleted talk key as the none token and reads it back", async (t) => {
+  const directory = await temporaryDirectory(t);
+  const store = storeIn(directory);
+
+  const { settings, reason } = await store.set(
+    APP_SETTING_SCHEMA.voiceHotkey.field,
+    VOICE_HOTKEY_NONE,
+  );
+
+  assert.equal(reason, undefined);
+  // A deletion is a choice, not an absence: unlike a reset it survives the
+  // file being reopened, or the key would come back on the next launch.
+  assert.equal(appSettingsView(settings).voiceHotkey, VOICE_HOTKEY_NONE);
+  assert.equal(
+    await storeIn(directory).get(APP_SETTING_SCHEMA.voiceHotkey.field),
+    VOICE_HOTKEY_NONE,
+  );
 });
 
 test("ignores a stored talk-key chord this build cannot register", async (t) => {

--- a/apps/desktop/src/main/window/hotkey-registrar.test.ts
+++ b/apps/desktop/src/main/window/hotkey-registrar.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import { VOICE_HOTKEY_NONE } from "@sidecar/settings";
 import type { TalkKeyEdges } from "../native/talk-key";
 import {
   HOTKEY_RANK,
@@ -131,6 +132,48 @@ test("reapply from stop lets only itself go", async () => {
   assert.equal(context.unregisterAllCount(), 1);
   assert.deepEqual(context.unregistered().slice(afterTalk), ["Alt+S"]);
   assert.equal(context.registrar.stop, "Control+Alt+X");
+  assert.equal(context.registrar.ask, "Alt+L");
+});
+
+test("a deleted talk key spawns no helper and reserves no chord", async () => {
+  const context = harness();
+  context.registrar.setChosen(HOTKEY_RANK.TALK, VOICE_HOTKEY_NONE);
+  await context.registrar.reapply(HOTKEY_RANK.TALK);
+
+  // Nothing registered and nothing promised: no helper, no toggle fallback,
+  // and the panel is told the honest absence.
+  assert.equal(context.registrar.talk, undefined);
+  assert.deepEqual(context.registered(), ["Alt+L", "Alt+S"]);
+  // A key that will never register defends no candidate list, so the ranks
+  // below may sit even on the talk key's own default.
+  assert.equal(context.registrar.reserve("Alt+Space", HOTKEY_RANK.ASK), undefined);
+});
+
+test("a deleted ask key takes no chord and stop keeps its own", async () => {
+  const context = harness();
+  await context.registrar.reapply(HOTKEY_RANK.TALK);
+  context.announceTalk("Alt+Space");
+
+  context.registrar.setChosen(HOTKEY_RANK.ASK, VOICE_HOTKEY_NONE);
+  await context.registrar.reapply(HOTKEY_RANK.ASK);
+
+  assert.equal(context.registrar.ask, undefined);
+  assert.equal(context.registrar.stop, "Alt+S");
+  // The deleted key's defaults are no longer spoken for either: the stop key
+  // could be moved onto Option-L now without a refusal.
+  assert.equal(context.registrar.reserve("Alt+L", HOTKEY_RANK.STOP), undefined);
+});
+
+test("a deleted stop key lets its chord go and takes nothing back", async () => {
+  const context = harness();
+  await context.registrar.reapply(HOTKEY_RANK.TALK);
+  context.announceTalk("Alt+Space");
+
+  context.registrar.setChosen(HOTKEY_RANK.STOP, VOICE_HOTKEY_NONE);
+  await context.registrar.reapply(HOTKEY_RANK.STOP);
+
+  assert.equal(context.registrar.stop, undefined);
+  assert.ok(context.unregistered().includes("Alt+S"));
   assert.equal(context.registrar.ask, "Alt+L");
 });
 

--- a/apps/desktop/src/main/window/hotkey-registrar.ts
+++ b/apps/desktop/src/main/window/hotkey-registrar.ts
@@ -122,7 +122,12 @@ export class HotkeyRegistrar {
     return this.#stop;
   }
 
-  /** The stored choice for a rank, absent while the defaults stand. */
+  /**
+   * The stored choice for a rank: a chord, the none token for a key deleted
+   * outright, or absent while the defaults stand. The token needs no reading
+   * here — it empties the rank's candidate list at the source, so registration
+   * finds nothing to try and reservation nothing to defend.
+   */
   setChosen(rank: HotkeyRank, chord: string | undefined): void {
     if (rank === HOTKEY_RANK.TALK) this.#chosenTalk = chord;
     else if (rank === HOTKEY_RANK.ASK) this.#chosenAsk = chord;
@@ -199,6 +204,10 @@ export class HotkeyRegistrar {
     // Taking a system-wide key for a feature that cannot run would make every
     // press somewhere else in macOS do nothing, visibly.
     if (!this.#hasCredentials(HOTKEY_RANK.TALK)) return;
+    // A deleted key has no candidates at all, so there is nothing to spawn a
+    // helper for: the honest answer is the absence the panel already shows.
+    const candidates = voiceHotkeyCandidates(this.#chosenTalk);
+    if (candidates.length === 0) return;
     // The helper first, because it is the only one of the two that reports the
     // key being let go of, and a key you hold is the whole point.
     this.#talkKeyWatcher = this.#createTalkKeyWatcher({
@@ -214,7 +223,7 @@ export class HotkeyRegistrar {
         this.#sendTalk();
       },
     });
-    if (this.#talkKeyWatcher.start(voiceHotkeyCandidates(this.#chosenTalk))) return;
+    if (this.#talkKeyWatcher.start(candidates)) return;
     this.#talkKeyWatcher = undefined;
     this.#registerToggle();
   }

--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -29,7 +29,12 @@ import {
   type SessionIdentity,
   workspaceProjectSelectionId,
 } from "@sidecar/session";
-import { APP_SETTING_SCHEMA, voiceHotkeyLabel, voiceHotkeyToShow } from "@sidecar/settings";
+import {
+  APP_SETTING_SCHEMA,
+  VOICE_HOTKEY_NONE,
+  voiceHotkeyLabel,
+  voiceHotkeyToShow,
+} from "@sidecar/settings";
 import {
   MOTION_DURATION_MS,
   SESSION_NOTICE_HEIGHT,
@@ -2674,12 +2679,18 @@ export function App(): React.JSX.Element {
         update: update ?? bootstrap.update,
         voiceAvailable: current.voiceAvailable,
         microphoneStatus,
+        // A removed key reaches the guide as the removal rather than a bare
+        // absence, so Luke says the developer deleted it instead of blaming
+        // another app for a chord nobody is contesting.
         hotkey: {
           ...(talkKey.hotkey ? { hotkey: voiceHotkeyLabel(talkKey.hotkey) } : undefined),
           held: talkKey.held,
+          removed: current.voiceHotkey === VOICE_HOTKEY_NONE,
         },
         ...(askAccelerator ? { askKey: voiceHotkeyLabel(askAccelerator) } : undefined),
+        askKeyRemoved: current.askHotkey === VOICE_HOTKEY_NONE,
         ...(stopAccelerator ? { stopKey: voiceHotkeyLabel(stopAccelerator) } : undefined),
+        stopKeyRemoved: current.stopHotkey === VOICE_HOTKEY_NONE,
       });
       syncGuide(guide);
     },
@@ -3114,14 +3125,17 @@ export function App(): React.JSX.Element {
     ...(shownHotkey.hotkey ? { voiceHotkey: shownHotkey.hotkey } : undefined),
     voiceHotkeyHeld: shownHotkey.held,
     voiceChosen: settings?.voiceHotkey !== undefined,
+    voiceOff: settings?.voiceHotkey === VOICE_HOTKEY_NONE,
     onVoiceHotkeyChange: changeVoiceHotkey,
     // Both rows take the accelerator: they draw the keys apart and
     // label the chord whole for the buttons beside them.
     ...(shownAskHotkey ? { askHotkey: shownAskHotkey } : undefined),
     askChosen: settings?.askHotkey !== undefined,
+    askOff: settings?.askHotkey === VOICE_HOTKEY_NONE,
     onAskHotkeyChange: changeAskHotkey,
     ...(shownStopHotkey ? { stopHotkey: shownStopHotkey } : undefined),
     stopChosen: settings?.stopHotkey !== undefined,
+    stopOff: settings?.stopHotkey === VOICE_HOTKEY_NONE,
     onStopHotkeyChange: changeStopHotkey,
     onCapture: changeShortcutCapture,
   };

--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -2820,17 +2820,20 @@ export function App(): React.JSX.Element {
     voiceStatus,
   ]);
 
+  // A broadcast with no accelerator is still a change — the key was deleted
+  // or lost its chord — so it is kept as one rather than as no news at all,
+  // or bootstrap's old chord would keep winning for the rest of the session.
   useEffect(
     () =>
       window.sidecar.onAskHotkeyChanged((accelerator) =>
-        setAskHotkeyChange(accelerator ? { accelerator } : undefined),
+        setAskHotkeyChange(accelerator ? { accelerator } : {}),
       ),
     [],
   );
   useEffect(
     () =>
       window.sidecar.onStopHotkeyChanged((accelerator) =>
-        setStopHotkeyChange(accelerator ? { accelerator } : undefined),
+        setStopHotkeyChange(accelerator ? { accelerator } : {}),
       ),
     [],
   );

--- a/apps/desktop/src/renderer/luke-guide.test.ts
+++ b/apps/desktop/src/renderer/luke-guide.test.ts
@@ -700,6 +700,14 @@ test("the facts describe stopping a reply, exactly where a reply can exist", () 
   assert.match(keyless, /Escape while Luke is speaking/);
   assert.match(keyless, /No system-wide stop key is registered/);
 
+  // A deleted shortcut is the developer's own choice, and the fact says so
+  // rather than blaming another app for a chord nobody is contesting.
+  const removed = JSON.stringify(
+    buildLukeGuide(guideInput({ stopKey: undefined, stopKeyRemoved: true })).facts,
+  );
+  assert.match(removed, /its shortcut was removed/);
+  assert.doesNotMatch(removed, /another app/);
+
   // Without a voice there is no reply to stop, so the fact would describe a
   // key that does nothing.
   const voiceless = JSON.stringify(buildLukeGuide(guideInput({ voiceAvailable: false })).facts);
@@ -728,6 +736,15 @@ test("the facts follow the talk key, the microphone, and the storage the system 
   );
   assert.match(unregistered, /None is registered/);
 
+  // A removed talk key is the developer's own deletion, said as one rather
+  // than as a chord another app happens to own.
+  const talkRemoved = buildLukeGuide(
+    guideInput({ hotkey: { held: true, removed: true } }),
+  ).facts.find((fact) => fact.label === "Talk key");
+  assert.ok(talkRemoved);
+  assert.match(talkRemoved.detail, /the shortcut was removed/);
+  assert.doesNotMatch(talkRemoved.detail, /another app/);
+
   // The ask key is a fact on the talk key's terms: the registered chord when
   // there is one, and an honest absence when there is not.
   assert.match(held, /⌥L, from any app: summons the panel/);
@@ -736,6 +753,15 @@ test("the facts follow the talk key, the microphone, and the storage the system 
   );
   assert.ok(askless);
   assert.match(askless.detail, /None is registered/);
+
+  // The ask key's removal is said on the talk key's terms, with the typed
+  // composer still offered: deleting the summons does not delete typing.
+  const askRemoved = buildLukeGuide(
+    guideInput({ askKey: undefined, askKeyRemoved: true }),
+  ).facts.find((fact) => fact.label === "Ask key");
+  assert.ok(askRemoved);
+  assert.match(askRemoved.detail, /the shortcut was removed/);
+  assert.match(askRemoved.detail, /typed ask/);
 
   const denied = JSON.stringify(buildLukeGuide(guideInput({ microphoneStatus: "denied" })).facts);
   assert.match(denied, /Privacy & Security/);

--- a/apps/desktop/src/renderer/luke-guide.test.ts
+++ b/apps/desktop/src/renderer/luke-guide.test.ts
@@ -708,6 +708,16 @@ test("the facts describe stopping a reply, exactly where a reply can exist", () 
   assert.match(removed, /its shortcut was removed/);
   assert.doesNotMatch(removed, /another app/);
 
+  // The removal outranks a chord still being reported beside it: a broadcast
+  // can lag the deletion, and teaching the key that was just deleted is worse
+  // than the honest absence.
+  const removedStale = buildLukeGuide(guideInput({ stopKeyRemoved: true })).facts.find(
+    (fact) => fact.label === "Stopping a reply",
+  );
+  assert.ok(removedStale);
+  assert.match(removedStale.detail, /its shortcut was removed/);
+  assert.doesNotMatch(removedStale.detail, /⌥S, from any app/);
+
   // Without a voice there is no reply to stop, so the fact would describe a
   // key that does nothing.
   const voiceless = JSON.stringify(buildLukeGuide(guideInput({ voiceAvailable: false })).facts);
@@ -737,13 +747,16 @@ test("the facts follow the talk key, the microphone, and the storage the system 
   assert.match(unregistered, /None is registered/);
 
   // A removed talk key is the developer's own deletion, said as one rather
-  // than as a chord another app happens to own.
+  // than as a chord another app happens to own — and the removal outranks a
+  // chord still being reported beside it, because a broadcast can lag the
+  // deletion.
   const talkRemoved = buildLukeGuide(
-    guideInput({ hotkey: { held: true, removed: true } }),
+    guideInput({ hotkey: { hotkey: "⌥Space", held: true, removed: true } }),
   ).facts.find((fact) => fact.label === "Talk key");
   assert.ok(talkRemoved);
   assert.match(talkRemoved.detail, /the shortcut was removed/);
   assert.doesNotMatch(talkRemoved.detail, /another app/);
+  assert.doesNotMatch(talkRemoved.detail, /⌥Space, from any app/);
 
   // The ask key is a fact on the talk key's terms: the registered chord when
   // there is one, and an honest absence when there is not.

--- a/apps/desktop/src/renderer/luke-guide.ts
+++ b/apps/desktop/src/renderer/luke-guide.ts
@@ -524,15 +524,18 @@ export function buildLukeGuide(input: LukeGuideInput): AppGuideSnapshot {
           {
             label: "Stopping a reply",
             detail:
-              (input.stopKey
-                ? `${input.stopKey}, from any app, cuts the reply off and asks for nothing in ` +
-                  "its place; Escape does the same while Luke's panel has the keyboard."
-                : "Escape while Luke is speaking cuts the reply off and asks for nothing in " +
-                  "its place. " +
-                  (input.stopKeyRemoved
-                    ? "No system-wide stop key is registered — its shortcut was removed."
-                    : "No system-wide stop key is registered right now — another app " +
-                      "may own the shortcut.")) +
+              // The removal outranks a reported chord: a broadcast can lag the
+              // deletion, and teaching the key that was just deleted is worse
+              // than the honest absence.
+              (input.stopKeyRemoved
+                ? "Escape while Luke is speaking cuts the reply off and asks for nothing in " +
+                  "its place. No system-wide stop key is registered — its shortcut was removed."
+                : input.stopKey
+                  ? `${input.stopKey}, from any app, cuts the reply off and asks for nothing in ` +
+                    "its place; Escape does the same while Luke's panel has the keyboard."
+                  : "Escape while Luke is speaking cuts the reply off and asks for nothing in " +
+                    "its place. No system-wide stop key is registered right now — another app " +
+                    "may own the shortcut.") +
               " The talk key over a reply interrupts too, but takes the turn with the same " +
               `press. A different stop chord can be recorded, the default restored, or the ` +
               `shortcut removed, in ${SHORTCUTS_PAGE}.`,

--- a/apps/desktop/src/renderer/luke-guide.ts
+++ b/apps/desktop/src/renderer/luke-guide.ts
@@ -97,19 +97,31 @@ export interface LukeGuideInput {
   /**
    * The talk key labelled the way macOS writes it, absent when none was
    * registered. Labelled rather than drawn as keys: the guide is spoken and
-   * read, and a chord said aloud is one thing to press.
+   * read, and a chord said aloud is one thing to press. `removed` is the one
+   * absence that is the developer's own choice — the shortcut was deleted —
+   * and the fact must say so rather than blame another app.
    */
-  hotkey: { hotkey?: string; held: boolean };
+  hotkey: { hotkey?: string; held: boolean; removed?: boolean };
   /** The ask key labelled on the same terms, absent when none was registered. */
   askKey?: string;
+  /** Whether the ask key's absence is a deleted shortcut, on the talk key's terms. */
+  askKeyRemoved?: boolean;
   /**
    * The stop key labelled on the same terms, absent when none was registered
    * — another app owns Option-S, or another Luke key was moved onto it.
    */
   stopKey?: string;
+  /** Whether the stop key's absence is a deleted shortcut, on the talk key's terms. */
+  stopKeyRemoved?: boolean;
 }
 
 function talkKeyFact(hotkey: LukeGuideInput["hotkey"]): AppGuideFact {
+  if (hotkey.removed) {
+    return {
+      label: "Talk key",
+      detail: `None — the shortcut was removed, so no key is registered anywhere. A chord can be recorded again, or the default restored, in ${SHORTCUTS_PAGE}.`,
+    };
+  }
   if (!hotkey.hotkey) {
     return {
       label: "Talk key",
@@ -122,11 +134,17 @@ function talkKeyFact(hotkey: LukeGuideInput["hotkey"]): AppGuideFact {
     : "press to talk, again to send, again to interrupt";
   return {
     label: "Talk key",
-    detail: `${hotkey.hotkey}, from any app: ${use}. A different chord can be recorded, or the default restored, in ${SHORTCUTS_PAGE}.`,
+    detail: `${hotkey.hotkey}, from any app: ${use}. A different chord can be recorded, the default restored, or the shortcut removed, in ${SHORTCUTS_PAGE}.`,
   };
 }
 
-function askKeyFact(askKey: string | undefined): AppGuideFact {
+function askKeyFact(askKey: string | undefined, removed: boolean | undefined): AppGuideFact {
+  if (removed) {
+    return {
+      label: "Ask key",
+      detail: `None — the shortcut was removed, so no key summons the composer; the panel's own composer still takes a typed ask. A chord can be recorded again, or the default restored, in ${SHORTCUTS_PAGE}.`,
+    };
+  }
   if (!askKey) {
     return {
       label: "Ask key",
@@ -138,7 +156,7 @@ function askKeyFact(askKey: string | undefined): AppGuideFact {
     label: "Ask key",
     detail:
       `${askKey}, from any app: summons the panel with the caret in the typed composer, and the ` +
-      `same press puts it away. A different chord can be recorded, or the default restored, in ${SHORTCUTS_PAGE}.`,
+      `same press puts it away. A different chord can be recorded, the default restored, or the shortcut removed, in ${SHORTCUTS_PAGE}.`,
   };
 }
 
@@ -499,7 +517,7 @@ export function buildLukeGuide(input: LukeGuideInput): AppGuideSnapshot {
         "itself, and is never sent to a provider.",
     },
     talkKeyFact(input.hotkey),
-    askKeyFact(input.askKey),
+    askKeyFact(input.askKey, input.askKeyRemoved),
     { label: "Microphone access", detail: MICROPHONE_DETAIL[input.microphoneStatus] },
     ...(input.voiceAvailable
       ? [
@@ -510,11 +528,14 @@ export function buildLukeGuide(input: LukeGuideInput): AppGuideSnapshot {
                 ? `${input.stopKey}, from any app, cuts the reply off and asks for nothing in ` +
                   "its place; Escape does the same while Luke's panel has the keyboard."
                 : "Escape while Luke is speaking cuts the reply off and asks for nothing in " +
-                  "its place. No system-wide stop key is registered right now — another app " +
-                  "may own the shortcut.") +
+                  "its place. " +
+                  (input.stopKeyRemoved
+                    ? "No system-wide stop key is registered — its shortcut was removed."
+                    : "No system-wide stop key is registered right now — another app " +
+                      "may own the shortcut.")) +
               " The talk key over a reply interrupts too, but takes the turn with the same " +
-              `press. A different stop chord can be recorded, or the ` +
-              `default restored, in ${SHORTCUTS_PAGE}.`,
+              `press. A different stop chord can be recorded, the default restored, or the ` +
+              `shortcut removed, in ${SHORTCUTS_PAGE}.`,
           },
           {
             // A behavior rather than a setting: stated here so Luke neither

--- a/apps/desktop/src/renderer/settings-panel.tsx
+++ b/apps/desktop/src/renderer/settings-panel.tsx
@@ -41,6 +41,7 @@ import {
   settingsScopeChanged,
   spokenSettingValue,
   VOICE_HOTKEY_CAPTURE,
+  VOICE_HOTKEY_NONE,
   voiceHotkeyLabel,
 } from "@sidecar/settings";
 import {
@@ -237,29 +238,39 @@ export interface ShortcutControl {
   /** Whether a chosen talk chord is stored, which is what Reset has to undo. */
   voiceChosen: boolean;
   /**
-   * Moves the talk key to a recorded chord, or back to the defaults when
-   * omitted. The store answers with why when it refuses, and the row is where
-   * that answer belongs.
+   * Whether the talk key was deleted outright: no chord registered, and no
+   * default standing in. The row says "None" rather than "Unavailable",
+   * because this absence is the user's own choice.
+   */
+  voiceOff: boolean;
+  /**
+   * Moves the talk key to a recorded chord, the none token, or back to the
+   * defaults when omitted. The store answers with why when it refuses, and
+   * the row is where that answer belongs.
    */
   onVoiceHotkeyChange: (accelerator: string | undefined) => Promise<ActResult>;
   /** The ask key as registered, an accelerator on the talk key's terms. */
   askHotkey?: string;
   /** Whether a chosen ask chord is stored, on the talk key's terms. */
   askChosen: boolean;
+  /** Whether the ask key was deleted outright, on the talk key's terms. */
+  askOff: boolean;
   /**
-   * Moves the ask key to a recorded chord, or back to the defaults when
-   * omitted, on the talk key's terms: the store answers with why when it
-   * refuses, and the row is where that answer belongs.
+   * Moves the ask key to a recorded chord, the none token, or back to the
+   * defaults when omitted, on the talk key's terms: the store answers with
+   * why when it refuses, and the row is where that answer belongs.
    */
   onAskHotkeyChange: (accelerator: string | undefined) => Promise<ActResult>;
   /** The stop key as registered, an accelerator on the talk key's terms. */
   stopHotkey?: string;
   /** Whether a chosen stop chord is stored, on the other rows' terms. */
   stopChosen: boolean;
+  /** Whether the stop key was deleted outright, on the other rows' terms. */
+  stopOff: boolean;
   /**
-   * Moves the stop key to a recorded chord, or back to the default when
-   * omitted, on the other rows' terms: the store answers with why when it
-   * refuses, and the row is where that answer belongs.
+   * Moves the stop key to a recorded chord, the none token, or back to the
+   * default when omitted, on the other rows' terms: the store answers with
+   * why when it refuses, and the row is where that answer belongs.
    */
   onStopHotkeyChange: (accelerator: string | undefined) => Promise<ActResult>;
   /**
@@ -2684,6 +2695,12 @@ const SHORTCUT_HINT = "Hold ⌃, ⌥ or ⌘ — ⇧ may join — and press a let
  * key as registered, not as stored — the two differ when another app owns the
  * chosen chord, and a row that showed the stored one would name a key that
  * answers nothing.
+ *
+ * Remove stands beside Reset on Reset's own terms — never while it could only
+ * change nothing, which for a removal is while the key is already deleted —
+ * and is what deletes the shortcut outright: no chord registered, no default
+ * standing in. The row then says "None" rather than "Unavailable", because
+ * this absence is the user's own choice, and Reset is the way back.
  */
 function ShortcutRow({
   title,
@@ -2691,6 +2708,7 @@ function ShortcutRow({
   anchor,
   shown,
   chosen,
+  off,
   defaultKey,
   attention,
   onChange,
@@ -2704,6 +2722,8 @@ function ShortcutRow({
   shown?: string | undefined;
   /** Whether a chosen chord is stored, which is what Reset has to undo. */
   chosen: boolean;
+  /** Whether the shortcut was deleted outright, which is what Remove did. */
+  off: boolean;
   /** The first default, which is what the reset offers to return to. */
   defaultKey: string;
   /** Why the key answers nothing right now, absent while it answers. */
@@ -2753,12 +2773,16 @@ function ShortcutRow({
       <span className="shortcut-controls">
         <span className="settings-actions">
           {/* The chord as its own keys while there is one to press, and a
-              sentence when there is not: "Type a shortcut…" and "Unavailable"
-              are things being said about the key, not keys to draw. */}
+              sentence when there is not: "Type a shortcut…", "None" and
+              "Unavailable" are things being said about the key, not keys to
+              draw — and the two absences differ: "None" was asked for, where
+              "Unavailable" is another app owning the chord. */}
           {recording ? (
             <span className="shortcut-state" data-recording="true">
               Type a shortcut…
             </span>
+          ) : off ? (
+            <span className="shortcut-state">None</span>
           ) : shown ? (
             <Keycaps className="shortcut-chord" accelerator={shown} />
           ) : (
@@ -2774,6 +2798,18 @@ function ShortcutRow({
               onClick={() => void apply(undefined)}
             >
               <ResetIcon />
+            </button>
+          ) : null}
+          {!off && !recording ? (
+            <button
+              type="button"
+              className="icon-button"
+              disabled={busy}
+              aria-label={`Remove the shortcut for ${title}, leaving no key`}
+              title="Remove"
+              onClick={() => void apply(VOICE_HOTKEY_NONE)}
+            >
+              <TrashIcon />
             </button>
           ) : null}
           <button
@@ -2857,14 +2893,22 @@ function ShortcutSection({
   // key will hold once voice is on — the stored choice, or the first default
   // — wearing the same mark the Voice page does instead of an "Unavailable"
   // that reads as broken. A key that is genuinely unregistered while voice is
-  // on — another app owns the chord — keeps the honest "Unavailable".
+  // on — another app owns the chord — keeps the honest "Unavailable". A key
+  // deleted outright shows neither chord nor mark whatever voice does: "None"
+  // is already the whole truth about a key that will never register.
   const attention = voiceAvailable ? undefined : VOICE_KEYLESS_NOTE;
   const promisedTalk = settings?.voiceHotkey ?? DEFAULT_VOICE_HOTKEYS[0];
   const promisedAsk = settings?.askHotkey ?? DEFAULT_ASK_HOTKEYS[0];
   const promisedStop = settings?.stopHotkey ?? DEFAULT_STOP_HOTKEYS[0];
-  const shownTalk = shortcuts.voiceHotkey ?? (voiceAvailable ? undefined : promisedTalk);
-  const shownAsk = shortcuts.askHotkey ?? (voiceAvailable ? undefined : promisedAsk);
-  const shownStop = shortcuts.stopHotkey ?? (voiceAvailable ? undefined : promisedStop);
+  const shownTalk = shortcuts.voiceOff
+    ? undefined
+    : (shortcuts.voiceHotkey ?? (voiceAvailable ? undefined : promisedTalk));
+  const shownAsk = shortcuts.askOff
+    ? undefined
+    : (shortcuts.askHotkey ?? (voiceAvailable ? undefined : promisedAsk));
+  const shownStop = shortcuts.stopOff
+    ? undefined
+    : (shortcuts.stopHotkey ?? (voiceAvailable ? undefined : promisedStop));
   return (
     <section
       className="settings-section settings-plain"
@@ -2883,8 +2927,9 @@ function ShortcutSection({
         }
         {...(shownTalk ? { shown: shownTalk } : undefined)}
         chosen={shortcuts.voiceChosen}
+        off={shortcuts.voiceOff}
         defaultKey={DEFAULT_VOICE_HOTKEYS[0] ?? ""}
-        {...(attention ? { attention } : undefined)}
+        {...(attention && !shortcuts.voiceOff ? { attention } : undefined)}
         onChange={shortcuts.onVoiceHotkeyChange}
         onCapture={shortcuts.onCapture}
       />
@@ -2901,8 +2946,9 @@ function ShortcutSection({
         detail="Press to type to Luke from any app."
         {...(shownAsk ? { shown: shownAsk } : undefined)}
         chosen={shortcuts.askChosen}
+        off={shortcuts.askOff}
         defaultKey={DEFAULT_ASK_HOTKEYS[0] ?? ""}
-        {...(attention ? { attention } : undefined)}
+        {...(attention && !shortcuts.askOff ? { attention } : undefined)}
         onChange={shortcuts.onAskHotkeyChange}
         onCapture={shortcuts.onCapture}
       />
@@ -2912,8 +2958,9 @@ function ShortcutSection({
         detail="Press to cut off a reply, from any app."
         {...(shownStop ? { shown: shownStop } : undefined)}
         chosen={shortcuts.stopChosen}
+        off={shortcuts.stopOff}
         defaultKey={DEFAULT_STOP_HOTKEYS[0] ?? ""}
-        {...(attention ? { attention } : undefined)}
+        {...(attention && !shortcuts.stopOff ? { attention } : undefined)}
         onChange={shortcuts.onStopHotkeyChange}
         onCapture={shortcuts.onCapture}
       />

--- a/apps/desktop/src/renderer/settings-search.tsx
+++ b/apps/desktop/src/renderer/settings-search.tsx
@@ -248,7 +248,7 @@ const ROOT_SETTING_ICON = {
 } satisfies Partial<Record<AppSettingId, React.JSX.Element>>;
 
 /** The words every shortcut row can be found by, beside its own name. */
-const SHORTCUT_WORDS = "keyboard shortcut hotkey key chord record";
+const SHORTCUT_WORDS = "keyboard shortcut hotkey key chord record remove delete none";
 
 /** The words every key row can be found by, beside its provider's name. */
 const KEY_WORDS = "API key credential connect cloud agent";

--- a/apps/desktop/src/renderer/use-voice-conversation.ts
+++ b/apps/desktop/src/renderer/use-voice-conversation.ts
@@ -874,7 +874,11 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
       const working = current.sessions.find(
         (session) => session.status === SESSION_STATUS.WORKING && session.realtimeVoice !== true,
       );
-      const talkKey = voiceHotkeyNow()?.hotkey ?? current.bootstrapVoiceHotkey;
+      // A change wins whole, exactly as `voiceHotkeyToShow` reads the pair: a
+      // changed state with no chord is a key deleted or lost, and falling back
+      // to bootstrap would speak a chord that no longer answers.
+      const changedTalkKey = voiceHotkeyNow();
+      const talkKey = changedTalkKey ? changedTalkKey.hotkey : current.bootstrapVoiceHotkey;
       return {
         ...speech,
         ...(working ? { sessionTitle: working.title } : undefined),

--- a/packages/settings/src/index.ts
+++ b/packages/settings/src/index.ts
@@ -48,6 +48,7 @@ export {
   talkKeyRelease,
   VOICE_HOTKEY_CAPTURE,
   VOICE_HOTKEY_MODIFIER,
+  VOICE_HOTKEY_NONE,
   type VoiceHotkeyCaptureOutcome,
   type VoiceHotkeyCaptureResult,
   type VoiceHotkeyChord,

--- a/packages/settings/src/schema.ts
+++ b/packages/settings/src/schema.ts
@@ -44,7 +44,7 @@ import {
   type PanelFormFactor,
 } from "@sidecar/surface";
 import { isRecord, isWireString, type UnparsedWireValue, type WireRecord } from "@sidecar/wire";
-import { parseVoiceHotkey } from "./voice-hotkey.js";
+import { parseVoiceHotkey, VOICE_HOTKEY_NONE } from "./voice-hotkey.js";
 
 // The ids themselves live in core, because the product-event vocabulary names
 // the same set and may not depend on anything here.
@@ -234,9 +234,18 @@ function boolean(defaultValue: boolean) {
 function hotkey(value: UnparsedWireValue): SettingGuardResult<string | undefined> {
   if (value === undefined) return valid(undefined);
   if (!isWireString(value)) return invalid(undefined);
+  // A deletion is a choice the parser cannot spell: no chord at all, with no
+  // default standing in behind the absence.
+  if (value === VOICE_HOTKEY_NONE) return valid(VOICE_HOTKEY_NONE);
   const parsed = parseVoiceHotkey(value);
   return parsed ? valid(parsed) : invalid(undefined);
 }
+
+// A deleted key counts as off rather than set: a stored value stands either
+// way, and the count is the one reader of the difference. The chord itself
+// never travels, whichever shape is reported.
+const hotkeyAnalytics = (value: StoredSettingValue): ProductSettingValue =>
+  value === VOICE_HOTKEY_NONE ? PRODUCT_SETTING_VALUE.OFF : choiceAnalytics(value);
 
 function workspaceAgentDefaults(
   value: UnparsedWireValue,
@@ -460,7 +469,7 @@ export const APP_SETTING_SCHEMA = {
     // the chord's page is named and a change to it can be counted.
     guideEntry: settingGuideEntry("voiceHotkey", [APP_SETTING_ID.TALK_HOTKEY], () => undefined),
     mainProcessSideEffect: SETTING_SIDE_EFFECT.TALK_HOTKEY,
-    analytics: { id: APP_SETTING_ID.TALK_HOTKEY, value: choiceAnalytics },
+    analytics: { id: APP_SETTING_ID.TALK_HOTKEY, value: hotkeyAnalytics },
   },
   askHotkey: {
     field: "askHotkey",
@@ -473,7 +482,7 @@ export const APP_SETTING_SCHEMA = {
     // the chord's page is named and a change to it can be counted.
     guideEntry: settingGuideEntry("askHotkey", [APP_SETTING_ID.ASK_HOTKEY], () => undefined),
     mainProcessSideEffect: SETTING_SIDE_EFFECT.ASK_HOTKEY,
-    analytics: { id: APP_SETTING_ID.ASK_HOTKEY, value: choiceAnalytics },
+    analytics: { id: APP_SETTING_ID.ASK_HOTKEY, value: hotkeyAnalytics },
   },
   stopHotkey: {
     field: "stopHotkey",
@@ -486,7 +495,7 @@ export const APP_SETTING_SCHEMA = {
     // the chord's page is named and a change to it can be counted.
     guideEntry: settingGuideEntry("stopHotkey", [APP_SETTING_ID.STOP_HOTKEY], () => undefined),
     mainProcessSideEffect: SETTING_SIDE_EFFECT.STOP_HOTKEY,
-    analytics: { id: APP_SETTING_ID.STOP_HOTKEY, value: choiceAnalytics },
+    analytics: { id: APP_SETTING_ID.STOP_HOTKEY, value: hotkeyAnalytics },
   },
   duckOtherMedia: {
     field: "duckOtherMedia",

--- a/packages/settings/src/voice-hotkey.test.ts
+++ b/packages/settings/src/voice-hotkey.test.ts
@@ -12,6 +12,7 @@ import {
   TALK_KEY_TAP_MS,
   talkKeyRelease,
   VOICE_HOTKEY_CAPTURE,
+  VOICE_HOTKEY_NONE,
   voiceHotkeyCandidates,
   voiceHotkeyKeycaps,
   voiceHotkeyLabel,
@@ -158,6 +159,18 @@ test("a chord the helper cannot register is refused rather than guessed at", () 
   assert.equal(parseVoiceHotkey("Alt+F5"), undefined);
   assert.equal(parseVoiceHotkey("Alt+A+B"), undefined);
   assert.equal(parseVoiceHotkey(""), undefined);
+});
+
+test("a deleted key offers no candidate at all", () => {
+  // The defaults stand behind a choice, never behind a removal: a fallback
+  // for a key the user asked to have none would be the key coming back on
+  // its own.
+  assert.deepEqual(voiceHotkeyCandidates(VOICE_HOTKEY_NONE), []);
+  assert.deepEqual(askHotkeyCandidates(VOICE_HOTKEY_NONE, [undefined, undefined]), []);
+  assert.deepEqual(stopHotkeyCandidates(VOICE_HOTKEY_NONE, [undefined, undefined]), []);
+  // The token shares the chord's field, so no recording may ever produce it:
+  // the parser refusing the word is what keeps the two meanings apart.
+  assert.equal(parseVoiceHotkey(VOICE_HOTKEY_NONE), undefined);
 });
 
 test("a chosen chord is tried first and the defaults stay behind it", () => {

--- a/packages/settings/src/voice-hotkey.ts
+++ b/packages/settings/src/voice-hotkey.ts
@@ -18,6 +18,16 @@
 export const DEFAULT_VOICE_HOTKEYS: readonly string[] = ["Alt+Space"];
 
 /**
+ * The stored choice that says a key was deleted outright: no chord registered,
+ * and no default standing in behind the absence. It shares the chord's field
+ * because it answers the chord's question — which key, if any — and it can
+ * never collide with one: `parseVoiceHotkey` refuses the word, holding no
+ * modifier and naming no key in the helper's table, so no recording can ever
+ * produce it.
+ */
+export const VOICE_HOTKEY_NONE = "none";
+
+/**
  * The key that cuts off a reply being spoken, from whatever app is frontmost.
  *
  * Option-S because S is for stop, and Option-letter is the family the other
@@ -33,12 +43,14 @@ export const DEFAULT_STOP_HOTKEYS: readonly string[] = ["Alt+S"];
  * with the default kept behind it, and any chord the other Luke keys could
  * sit on is left out, because the keys must never compete for one chord —
  * whichever registered first would silently cost the other its whole
- * feature, with nothing on screen saying why.
+ * feature, with nothing on screen saying why. A deleted key offers nothing,
+ * on the talk key's terms.
  */
 export function stopHotkeyCandidates(
   chosen: string | undefined,
   taken: readonly (string | undefined)[],
 ): readonly string[] {
+  if (chosen === VOICE_HOTKEY_NONE) return [];
   const candidates = chosen
     ? [chosen, ...DEFAULT_STOP_HOTKEYS.filter((candidate) => candidate !== chosen)]
     : DEFAULT_STOP_HOTKEYS;
@@ -64,12 +76,14 @@ export const DEFAULT_ASK_HOTKEYS: readonly string[] = ["Alt+L", "Alt+Shift+L"];
  * exactly as the talk key's candidates work. Any chord the talk key holds is
  * left out, the chosen one included: the two Luke keys must never compete for
  * one chord — whichever registered first would silently cost the other its
- * whole feature, with nothing on screen saying why.
+ * whole feature, with nothing on screen saying why. A deleted key offers
+ * nothing, on the talk key's terms.
  */
 export function askHotkeyCandidates(
   chosen: string | undefined,
   taken: readonly (string | undefined)[],
 ): readonly string[] {
+  if (chosen === VOICE_HOTKEY_NONE) return [];
   const candidates = chosen
     ? [chosen, ...DEFAULT_ASK_HOTKEYS.filter((candidate) => candidate !== chosen)]
     : DEFAULT_ASK_HOTKEYS;
@@ -174,9 +188,13 @@ export function parseVoiceHotkey(value: string): string | undefined {
  * The chords to try, in order. A chosen key goes first — it is what the user
  * asked for — and the defaults stay behind it, so a chord another app claims
  * while Luke is closed costs the user a different talk key rather than none.
- * The panel shows whichever one actually registered.
+ * The panel shows whichever one actually registered. A deleted key offers
+ * nothing at all: the defaults stand behind a choice, never behind a removal,
+ * because a fallback the user asked to have no key would be the key coming
+ * back on its own.
  */
 export function voiceHotkeyCandidates(chosen: string | undefined): readonly string[] {
+  if (chosen === VOICE_HOTKEY_NONE) return [];
   if (!chosen) return DEFAULT_VOICE_HOTKEYS;
   return [chosen, ...DEFAULT_VOICE_HOTKEYS.filter((candidate) => candidate !== chosen)];
 }


### PR DESCRIPTION
## Summary

- Each shortcut row (talk, ask, stop) gains a Remove control that deletes the shortcut entirely: no chord registered, and no default standing in behind the absence.
- The deletion is stored as a `none` token in the key's own field — a word `parseVoiceHotkey` refuses, so no recording can ever collide with it — and it survives relaunch, unlike a reset.
- A deleted key's candidate list is empty at the source: the registrar spawns no talk-key helper and takes no toggle fallback, and the deleted key reserves no chord, so the ranks below may sit even on its former default.
- The row says "None" rather than "Unavailable" (the absence is the user's own choice), keeps Reset as the way back, and drops the voice-keyless attention mark that would promise a key that will never register.
- The guide says the shortcut was removed instead of blaming another app, and the registered-key facts now name removal beside recording and reset.
- Analytics counts a deletion as `off`, a value `PRODUCT_SETTING_VALUE` already holds — no event, property, or value set widened, and the chord still never travels.

## Evidence

- Platform-independent checks: `./scripts/check.sh` passed in full (desktop 794 tests, settings 28, 0 failures; lint, typecheck, and builds clean).
- macOS Electron verification (`./scripts/verify.sh`): `not run` — this workspace is a Linux cloud sandbox; CI runs the macOS validation.

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/33438715458/artifacts/9775474249) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/33438715458)

- Commit: `8f77ad56e766e45801ab120aeef883b936a79aae`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

### Physical-device evidence

- Screenshot or screen recording: `not attached`
- Physical-notch check: `not performed`
- Device/display configuration: `not recorded`

## Notes

- Blockers or follow-up verification: none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/3c176240-9153-4101-8a66-1ab4d49aeecf)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)