### PR TITLE
Persist conversation history and remembered preferences

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -300,12 +300,13 @@ Trust constraints:
   bytes and which input masking does not reach. The one thing withheld is what
   is typed into a field, and that is the library's default rather than a
   posture Luke keeps. The one explicit blocked subtree is History: its root
-  carries the recording library's fixed blocking class, so the conversation's
-  words do not leave the machine in a recording. That view retains every
-  bounded line from the current app launch, including session acts, until the
-  developer clears it or quits — the same thread on every display's panel,
-  relayed between the windows through the main process and living nowhere but
-  in memory — while only the 20 most recent lines enter model context. There
+  carries the recording library's fixed blocking class, so neither the
+  conversation's words nor the entries Luke was asked to remember leave the
+  machine in a recording. That view retains every bounded line the retention
+  policy holds, including session acts and the lines that outlived the last
+  launch, until the developer clears it — the same thread on every display's
+  panel, relayed between windows through the main process — while only the 20
+  most recent lines enter model context. There
   is no general masking module to consult and nothing that makes any other new
   component silent by construction, so what a recording may see is decided by
   what the panel draws or explicitly blocks — which makes drawing something
@@ -334,6 +335,32 @@ Trust constraints:
   the event list, a property's value set, or what the recording client may
   capture is a product decision, not an implementation detail, and each one
   widens what a user was never offered a way to decline.
+- The conversation Luke holds outlives the app, and one narrower thing beside
+  it does too. The thread itself is words that were already said — the
+  developer's asks, what Luke spoke or announced, the acts he carried at their
+  ask — each of which reached the voice service once on the call that said it,
+  so storing it changes only how long it stands, not what it is. It lives in
+  Luke's own application data, never a provider's file, under a real retention
+  policy replacing the old "dies with the app": the 200 most recent lines,
+  nothing older than a fortnight. What reaches a model is unchanged — the same
+  bounded recent slice — and the panel's Clear reaches the file as well as the
+  screen, because a Clear that emptied only the view would leave the words on
+  the machine with nothing left to draw them. The narrower thing is a durable
+  fact about the developer themselves. During a turn the developer opened,
+  Luke may silently keep a concise stable preference, personal fact, goal, or
+  recurring constraint. He skips transient details and uncertain inferences,
+  never stores credentials, and stores a sensitive fact only when explicitly
+  asked. The write runs the same act gauntlet as every other write — validated
+  in the renderer, validated again in the main process, and armed only by a
+  developer-opened turn. A changed fact names the entry it replaces so
+  contradictions do not stand together; duplicates add nothing; and a request
+  to forget names one of the ids the conversation received. At most 32 bounded
+  facts stand in Luke's own application data and the complete list enters each
+  conversation as reply context. It is never drawn, never reaches a provider
+  file, never reaches a write path, and never reaches the attention evaluator,
+  whose input stays what a provider wrote about a session. Widening either —
+  what may be stored, how long it stands, or where it may travel — is a
+  product decision, not an implementation detail.
 - The development trace is the one place Luke's own agent traffic may reach a
   file, and it cannot exist for a user: only an unpackaged, live run whose
   shell set `LUKE_TRACE_DIR` constructs a writer at all, so a packaged build
@@ -579,8 +606,9 @@ What Luke may show:
   call that said it; a transcript reading enters the history only as the fact
   that one was read, never a word of the rendering; each line's identity is
   the roster-validated one the words traveled with, offered only while that
-  session is still observed; and the history lives in memory alone, written
-  to no disk, dying with the app, and never sent on Luke's speak-only call. Its
+  session is still observed; and the history is stored only where the constraint
+  above puts it, on this machine and under its retention policy, and is never
+  sent on Luke's speak-only call. Its
   trigger is a deterministic status edge, the arrival beat's one recorded
   sign-in edge, or the evaluator finding an update worth speaking. The edge
   announcements and approved evaluator sentences speak whenever voice can.

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,6 +1,6 @@
 # Privacy
 
-Last updated: 27 August 2026
+Last updated: 28 August 2026
 
 Luke is a macOS app that watches your coding agent sessions. This policy
 explains what we collect, who we send it to, and how to turn it off.
@@ -14,10 +14,27 @@ contents, or command output, and it writes none of this to disk. If you run
 agents inside the Herdr terminal manager, Luke also asks Herdr's own
 command-line tool which of those sessions it holds, so their rows can say so;
 that read never starts Herdr, reads no terminal output, and sends nothing
-anywhere. It stays on your Mac unless a feature below sends it. Luke also keeps
-your conversation with him in memory for the current app launch so you can
-review it; it is never written to disk, and only the 20 most recent entries are
-carried into a call.
+anywhere. It stays on your Mac unless a feature below sends it.
+
+**Your conversation with Luke.** Luke keeps the conversation you have with him
+— what you typed or said, what he spoke or announced, and the actions he took
+at your request — in a file on your Mac, so it is still there the next time you
+open him. It holds the 200 most recent entries and nothing older than 14 days,
+whichever runs out first; each entry is capped at 400 characters. Only the 20
+most recent are carried into a call, the same as before. Clearing the History
+tab deletes the file as well as the view. Nothing about the conversation is
+written on our servers, and a fixture or evidence run keeps no conversation at
+all.
+
+**Things Luke remembers about you.** During a conversation you start, Luke may
+silently save a concise preference, personal fact, goal, or recurring constraint
+that looks useful later. He skips temporary details and uncertain guesses, never
+saves credentials, and saves sensitive facts only when you explicitly ask. At
+most 32 are stored on your Mac beside your settings and they do not expire. You
+can ask Luke what he remembers, correct something, or tell him to forget it.
+They are sent to OpenAI with the rest of a conversation's context so Luke can
+personalize replies; they are not sent to a coding-agent provider, a tracker, or
+our own service, and they are never used to decide anything on your behalf.
 
 **Your account.** Signing in with Google or GitHub gives us your name, email
 address, and which of the two you used. We also keep the records that keep you
@@ -32,8 +49,8 @@ branches, file paths, summaries, prompts, or error text.
 screen, your editor, your terminal, or any other app. A recording shows whatever
 the panel showed you, including session titles, branches, summaries and error
 text, your name and email address, and any screenshot you attached to the
-feedback form. The History tab is blocked from recordings, so the words in your
-conversation with Luke are not included. Text you type into a field is replaced
+feedback form. The History tab is blocked from recordings, so neither the words in your
+conversation with Luke nor the things he remembers about you are included. Text you type into a field is replaced
 with blocks before the recording leaves your Mac, so an API key or a sign-in
 code you enter is not in it. While recording is on, Luke also reports what you
 clicked, including the text on it, and any error his panel runs into, with its
@@ -71,8 +88,9 @@ and email you signed it with, and any screenshots you attached.
 - OpenAI, for voice and session summaries. A spoken turn sends its audio, a
   typed turn sends your words, and both send the session fields listed above.
   We do not send message history, file contents, or command output, and we ask
-  OpenAI not to store the request. Your conversation is kept in memory so it
-  carries across calls, and is discarded when you quit Luke.
+  OpenAI not to store the request. Your conversation and Luke's durable memory
+  are kept on your Mac and sent with a call so the
+  conversation carries across calls and across launches.
   The one voice call that happens before you sign in is the spoken
   introduction on first launch: it sends its own fixed script, the titles of
   the coding agent sessions found on your Mac, and anything you say during its
@@ -107,7 +125,8 @@ your network address, as it does for the app's recordings.
 
 ## Storage
 
-Your settings, local provider API keys, and calendar access stay on your Mac.
+Your settings, your conversation with Luke, the things he remembers about you,
+local provider API keys, and calendar access stay on your Mac.
 Local keys and calendar access are encrypted in the macOS Keychain. Provider
 API keys you sync to the hosted service are stored encrypted in our own
 database, as described above. Your account information is held by our own
@@ -119,6 +138,8 @@ service, and usage counts and recordings by PostHog.
 - Delete your OpenAI key to turn voice off.
 - Delete any synced provider API key from that provider's row in Settings. Keys
   are also deleted when you delete your account.
+- Clear the History tab to delete your stored conversation from your Mac.
+- Ask Luke what he remembers, correct a memory, or tell him to forget one.
 - Luke does not use your microphone until you start a turn.
 - Delete your account from the Account section in Settings. This erases your
   account, your sign-in records, your usage counts, and any provider API keys

--- a/README.md
+++ b/README.md
@@ -39,9 +39,12 @@ Hold <kbd>⌥</kbd><kbd>Space</kbd> to talk to Luke from any app, or press
 status of your agents, kick fresh ones off for you, or message them on your
 behalf.
 
-The **History** tab keeps the complete conversation from the current app launch
-on your Mac until you clear it or quit. It is not saved or exportable, and only
-the 20 most recent entries are carried into Luke's next call.
+The **History** tab keeps your conversation with Luke on your Mac, across
+launches: the 200 most recent entries and nothing older than a fortnight, until
+you clear it. Clearing deletes the file too. Only the 20 most recent entries are
+carried into Luke's next call. Luke also silently keeps a small local memory of
+useful preferences, personal context, goals, and recurring constraints; ask him
+what he remembers, correct something, or tell him to forget it.
 
 ![Luke's capsule under the notch, speaking a summary of which sessions finished and which are waiting.](docs/media/luke-talking.png)
 

--- a/apps/desktop/src/main/desktop-app.ts
+++ b/apps/desktop/src/main/desktop-app.ts
@@ -8,6 +8,7 @@ import {
   accountGateOpen,
   HostedVaultClient,
 } from "@sidecar/account";
+import type { RememberedFact } from "@sidecar/acts";
 import {
   PRODUCT_CREDENTIAL_SOURCE,
   PRODUCT_DIAGNOSTIC_KIND,
@@ -155,6 +156,14 @@ import { registerSettingsRowsIpc } from "./ipc/settings-rows";
 import { registerTrackerConnectionIpc } from "./ipc/tracker-connection";
 import { registerVoiceRuntimeIpc } from "./ipc/voice-runtime";
 import { registerWindowSurfaceIpc } from "./ipc/window-surface";
+import {
+  CONVERSATION_FILE,
+  conversationFromStored,
+  conversationRecord,
+  REMEMBERED_FACTS_FILE,
+  rememberedFactsFromStored,
+  rememberedFactsRecord,
+} from "./memory-flow";
 import { MediaDuckController } from "./native/media-duck";
 import { MicrophoneRouteWatcher } from "./native/microphone-route";
 import { OutputVolumeWatcher } from "./native/output-volume";
@@ -811,6 +820,59 @@ function writeArrivalState(state: ArrivalState): void {
   }
 }
 
+/**
+ * What Luke keeps across launches: the conversation thread and personal
+ * memory. Both are read once at launch and written
+ * back on every change, and neither is touched by a fixture or capture run —
+ * a deterministic run must draw the same panel every time, and an evidence
+ * PNG carrying a real conversation is the same mistake as a fixture copied
+ * from a real session.
+ */
+const conversationPath = () => path.join(app.getPath("userData"), CONVERSATION_FILE);
+const rememberedFactsPath = () => path.join(app.getPath("userData"), REMEMBERED_FACTS_FILE);
+
+function readStoredState(at: string): string | undefined {
+  try {
+    return fs.readFileSync(at, "utf8");
+  } catch {
+    return undefined;
+  }
+}
+
+function writeStoredState(at: string, contents: string, what: string): boolean {
+  const temporary = `${at}.tmp`;
+  try {
+    fs.writeFileSync(temporary, contents, { mode: 0o600 });
+    fs.chmodSync(temporary, 0o600);
+    fs.renameSync(temporary, at);
+    return true;
+  } catch (error) {
+    try {
+      fs.rmSync(temporary, { force: true });
+    } catch {
+      // The original write failure is the useful one to report.
+    }
+    process.stderr.write(
+      `Could not persist ${what}: ${error instanceof Error ? error.message : String(error)}\n`,
+    );
+    return false;
+  }
+}
+
+function removeStoredState(at: string, what: string): boolean {
+  try {
+    fs.rmSync(at, { force: true });
+    return true;
+  } catch (error) {
+    process.stderr.write(
+      `Could not clear ${what}: ${error instanceof Error ? error.message : String(error)}\n`,
+    );
+    return false;
+  }
+}
+
+let rememberedFacts: readonly RememberedFact[] = [];
+
 /** Whether an attempt to speak the arrival beat is already under way. */
 let arrivalBeatSpeaking = false;
 
@@ -1407,27 +1469,45 @@ function registerIpc(): void {
         calendars: accountCapabilitiesActive() ? observedCalendars : [],
         meetingQuiet: accountCapabilitiesActive() && meetingQuietActive,
         conversationHistory,
+        rememberedFacts,
         sessionReplay: await sessionReplayBootstrap(),
         settings: await settingsStore.snapshot(),
       };
     },
   );
-  // The conversation history's relay between windows. The main process holds
-  // the thread and passes it along; it never reads a line, and the sender is
-  // excluded because it already drew what it reported — an echo could regress
-  // a window that appended again while its report was in flight.
+  // The conversation history's relay between windows and durable store. The
+  // sender already drew what it reported, so only the other panels need the
+  // mirrored snapshot.
   registerBridge(
     BRIDGE,
     {
       reportConversationHistory(context, entries) {
         conversationHistory = entries;
+        if (runMode.observesProviders) {
+          if (entries.length === 0) {
+            removeStoredState(conversationPath(), "the conversation");
+          } else {
+            writeStoredState(
+              conversationPath(),
+              conversationRecord(entries, Date.now()),
+              "the conversation",
+            );
+          }
+        }
         const payload: ConversationHistoryPayload = { entries, cleared: false };
         panels.broadcast(channels.onConversationHistoryChanged, payload, context.sender);
       },
-      reportConversationHistoryCleared(context) {
+      clearConversationHistory(context) {
+        if (
+          runMode.observesProviders &&
+          !removeStoredState(conversationPath(), "the conversation")
+        ) {
+          return false;
+        }
         conversationHistory = [];
         const payload: ConversationHistoryPayload = { entries: [], cleared: true };
         panels.broadcast(channels.onConversationHistoryChanged, payload, context.sender);
+        return true;
       },
     },
     { ipcMain, trustedSender },
@@ -1628,6 +1708,15 @@ function registerIpc(): void {
       ),
     supersetCli,
     recordProductEvent,
+    rememberedFacts: () => rememberedFacts,
+    writeRememberedFacts: (facts) => {
+      if (!runMode.observesProviders) return false;
+      if (!writeStoredState(rememberedFactsPath(), rememberedFactsRecord(facts), "Luke's memory")) {
+        return false;
+      }
+      rememberedFacts = facts;
+      return true;
+    },
   });
 
   // A note to the founders travels one road: typed in the composer, validated
@@ -2549,6 +2638,16 @@ export function startDesktopApp(): void {
       // sign-out lands on the ordinary gate instead of a first meeting.
       if (shouldBackfillIntroductionCompletion(introductionInput)) markIntroductionComplete();
       arrivalState = arrivalStateFromDisk();
+      // Read once, here, so the first bootstrap already carries them: a panel
+      // that opened on an empty History and filled it a beat later would read
+      // as a conversation arriving rather than one resumed.
+      if (runMode.observesProviders) {
+        conversationHistory = conversationFromStored(
+          readStoredState(conversationPath()),
+          Date.now(),
+        );
+        rememberedFacts = rememberedFactsFromStored(readStoredState(rememberedFactsPath()));
+      }
       // A signed-in install with no arrival record predates the beat: its
       // sign-in was never observed, so it is settled now rather than greeted
       // as an arrival on some later sign-in months in.

--- a/apps/desktop/src/main/desktop-app.ts
+++ b/apps/desktop/src/main/desktop-app.ts
@@ -160,6 +160,7 @@ import {
   CONVERSATION_FILE,
   conversationFromStored,
   conversationRecord,
+  mergeConversationHistory,
   REMEMBERED_FACTS_FILE,
   rememberedFactsFromStored,
   rememberedFactsRecord,
@@ -457,15 +458,12 @@ const heldEvaluatorSpeech = new SessionNoticeHold<SessionAnnouncement>();
  */
 let meetingQuietActive = false;
 /**
- * The launch's conversation history, one thread shared by every panel window.
- * Held in memory alone like the renderer copies it mirrors: written to no
- * disk, dying with the app, never read by anything here — the main process
- * only relays it between windows and seeds a panel that opens late. Each
- * window reports the whole thread after a line it appended, and the last
- * report wins, which is the conversation's own shape: one developer holds
- * one exchange at a time.
+ * The conversation history, one retained thread shared by every panel window
+ * and persisted for the next launch. The main process merges whole-window
+ * snapshots before relaying them, so one display cannot erase another's line.
  */
 let conversationHistory: readonly ConversationEntry[] = [];
+let conversationClearedAt: number | undefined;
 // Notices come from status edges the registry observed, never from anything a
 // model decided, so they work — and matter most — with no evaluator configured.
 const sessionNoticeTracker = new SessionNoticeTracker();
@@ -1475,34 +1473,35 @@ function registerIpc(): void {
       };
     },
   );
-  // The conversation history's relay between windows and durable store. The
-  // sender already drew what it reported, so only the other panels need the
-  // mirrored snapshot.
+  // The conversation history's relay between windows and durable store.
   registerBridge(
     BRIDGE,
     {
       reportConversationHistory(context, entries) {
-        conversationHistory = entries;
+        const now = Date.now();
+        const merged = runMode.observesProviders
+          ? mergeConversationHistory(conversationHistory, entries, conversationClearedAt, now)
+          : entries;
         if (runMode.observesProviders) {
-          if (entries.length === 0) {
-            removeStoredState(conversationPath(), "the conversation");
-          } else {
-            writeStoredState(
-              conversationPath(),
-              conversationRecord(entries, Date.now()),
-              "the conversation",
-            );
-          }
+          const persisted =
+            merged.length === 0
+              ? removeStoredState(conversationPath(), "the conversation")
+              : writeStoredState(
+                  conversationPath(),
+                  conversationRecord(merged, now),
+                  "the conversation",
+                );
+          if (!persisted) return;
         }
-        const payload: ConversationHistoryPayload = { entries, cleared: false };
+        conversationHistory = merged;
+        const payload: ConversationHistoryPayload = { entries: merged, cleared: false };
         panels.broadcast(channels.onConversationHistoryChanged, payload, context.sender);
       },
       clearConversationHistory(context) {
-        if (
-          runMode.observesProviders &&
-          !removeStoredState(conversationPath(), "the conversation")
-        ) {
-          return false;
+        if (runMode.observesProviders) {
+          const clearedAt = Date.now();
+          if (!removeStoredState(conversationPath(), "the conversation")) return false;
+          conversationClearedAt = clearedAt;
         }
         conversationHistory = [];
         const payload: ConversationHistoryPayload = { entries: [], cleared: true };
@@ -1715,6 +1714,7 @@ function registerIpc(): void {
         return false;
       }
       rememberedFacts = facts;
+      panels.broadcast(channels.onRememberedFactsChanged, facts);
       return true;
     },
   });

--- a/apps/desktop/src/main/ipc/session-acts.test.ts
+++ b/apps/desktop/src/main/ipc/session-acts.test.ts
@@ -1,9 +1,9 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { type ActEnvelope, SESSION_TOOL_KIND } from "@sidecar/acts";
+import { type ActEnvelope, APP_TOOL_KIND, SESSION_TOOL_KIND } from "@sidecar/acts";
 import { InMemorySessionRegistry, SESSION_STATUS } from "@sidecar/session";
 import { ACT_RESULT_STATUS } from "@sidecar/wire";
-import { authorizeActEnvelope } from "./session-acts";
+import { authorizeActEnvelope, forgetRememberedFact, saveRememberedFact } from "./session-acts";
 
 const identity = { providerId: "claude-code", providerSessionId: "session-a" } as const;
 const openSession = {
@@ -17,6 +17,7 @@ function authorization(registry = new InMemorySessionRegistry()) {
     sessionRegistry: registry,
     adapterFor: () => undefined,
     trackedIssues: () => undefined,
+    rememberedFacts: () => [],
   };
 }
 
@@ -59,4 +60,74 @@ test("main authorization refuses an act id outside the registry", () => {
   const result = authorizeActEnvelope(unknown, authorization());
   assert.equal(result.status, ACT_RESULT_STATUS.REJECTED);
   assert.match(result.status === ACT_RESULT_STATUS.REJECTED ? result.reason : "", /No such act/);
+});
+
+test("main authorization revalidates a remembered entry against the store it will write", () => {
+  const held = [{ id: "fact-one", words: "stop telling me about CI" }];
+  const facts = { ...authorization(), rememberedFacts: () => held };
+
+  const forgetting = {
+    id: "forget_fact",
+    armed: true,
+    act: { kind: APP_TOOL_KIND.FORGET, id: "fact-one" },
+  } satisfies ActEnvelope;
+  assert.deepEqual(authorizeActEnvelope(forgetting, facts), {
+    status: ACT_RESULT_STATUS.ACCEPTED,
+  });
+
+  // The renderer validated against the list it was shown; a list that moved
+  // between the showing and the act is what this second check is for.
+  assert.equal(
+    authorizeActEnvelope(forgetting, authorization()).status,
+    ACT_RESULT_STATUS.REJECTED,
+  );
+
+  // A new fact names nothing, and needs no entry to exist.
+  assert.deepEqual(
+    authorizeActEnvelope(
+      { id: "remember_fact", armed: true, act: { kind: APP_TOOL_KIND.REMEMBER, words: "new" } },
+      authorization(),
+    ),
+    { status: ACT_RESULT_STATUS.ACCEPTED },
+  );
+});
+
+test("memory writes deduplicate and leave state unchanged when persistence fails", () => {
+  const held = [{ id: "fact-one", words: "prefers concise answers" }];
+  let writes = 0;
+  const write = () => {
+    writes += 1;
+    return false;
+  };
+
+  assert.equal(
+    saveRememberedFact(held, "prefers concise answers", undefined, "duplicate", write),
+    held,
+  );
+  assert.equal(writes, 0);
+  assert.equal(saveRememberedFact(held, "works on macOS", undefined, "new", write), held);
+  assert.equal(forgetRememberedFact(held, "fact-one", write), held);
+  assert.equal(writes, 2);
+});
+
+test("replacing a fact with existing wording removes the contradicted entry", () => {
+  const held = [
+    { id: "fact-one", words: "prefers detailed answers" },
+    { id: "fact-two", words: "prefers concise answers" },
+  ];
+  let written: readonly { id: string; words: string }[] | undefined;
+
+  const next = saveRememberedFact(
+    held,
+    "prefers concise answers",
+    "fact-one",
+    "replacement",
+    (facts) => {
+      written = facts;
+      return true;
+    },
+  );
+
+  assert.deepEqual(next, [held[1]]);
+  assert.deepEqual(written, next);
 });

--- a/apps/desktop/src/main/ipc/session-acts.ts
+++ b/apps/desktop/src/main/ipc/session-acts.ts
@@ -4,10 +4,15 @@ import {
   type ActEnvelope,
   APP_TOOL_KIND,
   actValidationTarget,
+  holdsRememberedFact,
   ISSUE_TOOL_KIND,
   isCarriedIssueAction,
   isCarriedSessionAction,
+  maximumRememberedFacts,
+  type RememberedFact,
+  rememberedFactText,
   SESSION_TOOL_KIND,
+  withoutRememberedFact,
 } from "@sidecar/acts";
 import {
   PRODUCT_EVENT,
@@ -75,12 +80,46 @@ export interface SessionActsIpcDependencies {
   supersetContext: (identity: SessionIdentity) => SupersetSessionContext | undefined;
   supersetCli: SupersetCli;
   recordProductEvent: RecordProductEvent;
+  /** The remembered entries as the main process holds them, and the write back. */
+  rememberedFacts: () => readonly RememberedFact[];
+  writeRememberedFacts: (facts: readonly RememberedFact[]) => boolean;
 }
 
 type ActAuthorizationDependencies = Pick<
   SessionActsIpcDependencies,
-  "sessionRegistry" | "adapterFor" | "trackedIssues"
+  "sessionRegistry" | "adapterFor" | "trackedIssues" | "rememberedFacts"
 >;
+
+type MemoryWriter = (facts: readonly RememberedFact[]) => boolean;
+
+export function saveRememberedFact(
+  held: readonly RememberedFact[],
+  words: string,
+  replaces: string | undefined,
+  id: string,
+  write: MemoryWriter,
+): readonly RememberedFact[] {
+  const remembered = rememberedFactText(words);
+  if (!remembered) return held;
+  if (replaces !== undefined && !holdsRememberedFact(held, replaces)) return held;
+  const retained = replaces ? withoutRememberedFact(held, replaces) : held;
+  if (retained.some((fact) => fact.words === remembered)) {
+    return retained.length === held.length || !write(retained) ? held : retained;
+  }
+  if (replaces === undefined && held.length >= maximumRememberedFacts) return held;
+  const next = [...retained, { id, words: remembered }];
+  return write(next) ? next : held;
+}
+
+export function forgetRememberedFact(
+  held: readonly RememberedFact[],
+  id: string,
+  write: MemoryWriter,
+): readonly RememberedFact[] {
+  if (!holdsRememberedFact(held, id)) return held;
+  const next = withoutRememberedFact(held, id);
+  return write(next) ? next : held;
+}
 
 /** Revalidates the renderer's act envelope against the main process's latest observations. */
 export function authorizeActEnvelope(
@@ -157,6 +196,18 @@ export function authorizeActEnvelope(
   if (target === ACT_VALIDATION_TARGET.UPDATE_ROW && act.kind !== APP_TOOL_KIND.UPDATE) {
     return { status: ACT_RESULT_STATUS.REJECTED, reason: "No such update act exists." };
   }
+  // The renderer validated the named entry against the list it was shown; this
+  // is the same check against the list the main process actually holds, which
+  // is the one the write lands on. A new entry names no prior id.
+  if (target === ACT_VALIDATION_TARGET.REMEMBERED_FACT) {
+    if (act.kind !== APP_TOOL_KIND.REMEMBER && act.kind !== APP_TOOL_KIND.FORGET) {
+      return { status: ACT_RESULT_STATUS.REJECTED, reason: "No such memory act exists." };
+    }
+    const named = act.kind === APP_TOOL_KIND.FORGET ? act.id : act.replaces;
+    if (named !== undefined && !holdsRememberedFact(dependencies.rememberedFacts(), named)) {
+      return { status: ACT_RESULT_STATUS.REJECTED, reason: "Nothing remembered goes by that id." };
+    }
+  }
   return { status: ACT_RESULT_STATUS.ACCEPTED };
 }
 
@@ -178,6 +229,8 @@ export function registerSessionActsIpc(dependencies: SessionActsIpcDependencies)
     supersetContext,
     supersetCli,
     recordProductEvent,
+    rememberedFacts,
+    writeRememberedFacts,
   } = dependencies;
   const registerAction = createActionHandler({
     ipcMain,
@@ -194,8 +247,28 @@ export function registerSessionActsIpc(dependencies: SessionActsIpcDependencies)
     });
 
   registerHandler(BRIDGE.authorizeAct, (envelope: ActEnvelope) =>
-    authorizeActEnvelope(envelope, { sessionRegistry, adapterFor, trackedIssues }),
+    authorizeActEnvelope(envelope, {
+      sessionRegistry,
+      adapterFor,
+      trackedIssues,
+      rememberedFacts,
+    }),
   );
+
+  /** The local writes behind automatic memory, returning only what actually persisted. */
+  registerHandler(BRIDGE.rememberFact, (words: string, replaces: string | undefined) => {
+    return saveRememberedFact(
+      rememberedFacts(),
+      words,
+      replaces,
+      randomUUID(),
+      writeRememberedFacts,
+    );
+  });
+
+  registerHandler(BRIDGE.forgetFact, (id: string) => {
+    return forgetRememberedFact(rememberedFacts(), id, writeRememberedFacts);
+  });
   /**
    * Counts an act that actually landed. It takes the result rather than
    * sitting inside `performSessionAct`, because a Superset-managed session

--- a/apps/desktop/src/main/memory-flow.test.ts
+++ b/apps/desktop/src/main/memory-flow.test.ts
@@ -8,6 +8,7 @@ import {
 import {
   conversationFromStored,
   conversationRecord,
+  mergeConversationHistory,
   rememberedFactsFromStored,
   rememberedFactsRecord,
 } from "./memory-flow";
@@ -54,6 +55,23 @@ test("retention cuts by age and by count, whichever bites first", () => {
   const kept = conversationFromStored(conversationRecord(many, NOW), NOW);
   assert.equal(kept.length, maximumStoredConversationEntries);
   assert.equal(kept.at(-1)?.words, `line ${many.length - 1}`);
+});
+
+test("window snapshots merge once and cannot restore a cleared thread", () => {
+  const first = {
+    kind: CONVERSATION_ENTRY_KIND.TYPED_ASK,
+    words: "first window",
+    recordedAt: NOW - 2,
+  };
+  const second = {
+    kind: CONVERSATION_ENTRY_KIND.REPLY,
+    words: "second window",
+    recordedAt: NOW - 1,
+  };
+  const merged = mergeConversationHistory([first], [second], undefined, NOW);
+  assert.deepEqual(merged, [first, second]);
+  assert.deepEqual(mergeConversationHistory(merged, [second], undefined, NOW), merged);
+  assert.deepEqual(mergeConversationHistory([], merged, NOW, NOW), []);
 });
 
 test("remembered entries read back and are never retired by a clock", () => {

--- a/apps/desktop/src/main/memory-flow.test.ts
+++ b/apps/desktop/src/main/memory-flow.test.ts
@@ -1,0 +1,81 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  CONVERSATION_ENTRY_KIND,
+  maximumStoredConversationEntries,
+  storedConversationMaximumAgeMs,
+} from "@sidecar/realtime";
+import {
+  conversationFromStored,
+  conversationRecord,
+  rememberedFactsFromStored,
+  rememberedFactsRecord,
+} from "./memory-flow";
+
+const NOW = 1_800_000_000_000;
+
+test("a stored thread reads back, and an unreadable file is a launch with nothing", () => {
+  const entries = [
+    { kind: CONVERSATION_ENTRY_KIND.TYPED_ASK, words: "what is running", recordedAt: NOW },
+    { kind: CONVERSATION_ENTRY_KIND.REPLY, words: "two agents", recordedAt: NOW },
+  ];
+  assert.deepEqual(conversationFromStored(conversationRecord(entries, NOW), NOW), entries);
+  assert.deepEqual(conversationFromStored("{not json", NOW), []);
+  assert.deepEqual(conversationFromStored(undefined, NOW), []);
+});
+
+test("a line that does not parse drops itself rather than the thread", () => {
+  const stored = JSON.stringify({
+    entries: [
+      { kind: "invented-kind", words: "no", recordedAt: NOW },
+      { kind: CONVERSATION_ENTRY_KIND.REPLY, words: "", recordedAt: NOW },
+      { kind: CONVERSATION_ENTRY_KIND.REPLY, words: "kept", recordedAt: NOW },
+    ],
+  });
+  assert.deepEqual(conversationFromStored(stored, NOW), [
+    { kind: CONVERSATION_ENTRY_KIND.REPLY, words: "kept", recordedAt: NOW },
+  ]);
+});
+
+test("retention cuts by age and by count, whichever bites first", () => {
+  const old = {
+    kind: CONVERSATION_ENTRY_KIND.REPLY,
+    words: "old",
+    recordedAt: NOW - storedConversationMaximumAgeMs - 1,
+  };
+  const fresh = { kind: CONVERSATION_ENTRY_KIND.REPLY, words: "fresh", recordedAt: NOW };
+  assert.deepEqual(conversationFromStored(conversationRecord([old, fresh], NOW), NOW), [fresh]);
+
+  const many = Array.from({ length: maximumStoredConversationEntries + 10 }, (_, index) => ({
+    kind: CONVERSATION_ENTRY_KIND.REPLY,
+    words: `line ${index}`,
+    recordedAt: NOW,
+  }));
+  const kept = conversationFromStored(conversationRecord(many, NOW), NOW);
+  assert.equal(kept.length, maximumStoredConversationEntries);
+  assert.equal(kept.at(-1)?.words, `line ${many.length - 1}`);
+});
+
+test("remembered entries read back and are never retired by a clock", () => {
+  const facts = [
+    {
+      id: "one",
+      words: "stop telling me about CI",
+    },
+  ];
+  assert.deepEqual(rememberedFactsFromStored(rememberedFactsRecord(facts)), facts);
+  assert.deepEqual(rememberedFactsFromStored(JSON.stringify({ facts: [{ id: "" }] })), []);
+  assert.deepEqual(rememberedFactsFromStored(undefined), []);
+});
+
+test("stored memory drops noncanonical and duplicate entries", () => {
+  const stored = JSON.stringify({
+    facts: [
+      { id: "one", words: "kept" },
+      { id: "one", words: "duplicate id" },
+      { id: "two", words: "kept" },
+      { id: "three", words: "x".repeat(241) },
+    ],
+  });
+  assert.deepEqual(rememberedFactsFromStored(stored), [{ id: "one", words: "kept" }]);
+});

--- a/apps/desktop/src/main/memory-flow.ts
+++ b/apps/desktop/src/main/memory-flow.ts
@@ -1,0 +1,81 @@
+import { isRememberedFact, maximumRememberedFacts, type RememberedFact } from "@sidecar/acts";
+import {
+  type ConversationEntry,
+  retainedConversationEntries,
+  storedConversationEntry,
+} from "@sidecar/realtime";
+import { isRecord, type UnparsedWireValue } from "@sidecar/wire";
+
+/**
+ * What Luke keeps across launches, and how it is read back. The decisions are
+ * pure so they can be tested without Electron, on the arrival flow's own
+ * pattern; the wiring that reads and writes the files lives in desktop-app.
+ *
+ * Two files, because the two hold different kinds of thing and deserve
+ * different answers to "how long". The conversation is retired on a clock;
+ * durable facts leave only when Luke replaces or forgets them.
+ *
+ * Both live in Luke's own application data beside `settings.json`, and never
+ * in a provider's file.
+ */
+
+export const CONVERSATION_FILE = "conversation.json";
+export const REMEMBERED_FACTS_FILE = "memory.json";
+
+/**
+ * Reads a stored thread, dropping lines that do not parse rather than the
+ * whole file. A conversation is not load-bearing: half a thread beats none,
+ * and a launch that cannot read the file at all simply begins with nothing,
+ * which is what every launch did before this file existed.
+ */
+export function conversationFromStored(
+  stored: string | undefined,
+  now: number,
+): readonly ConversationEntry[] {
+  const entries: ConversationEntry[] = [];
+  for (const value of parsedList(stored, "entries")) {
+    const entry = storedConversationEntry(value);
+    if (entry) entries.push(entry);
+  }
+  return retainedConversationEntries(entries, now);
+}
+
+/** The record a thread persists as, already retained so the file cannot outgrow the policy. */
+export function conversationRecord(entries: readonly ConversationEntry[], now: number): string {
+  return `${JSON.stringify({ entries: retainedConversationEntries(entries, now) })}\n`;
+}
+
+/**
+ * Reads remembered entries, dropping invalid records and anything beyond the cap.
+ */
+export function rememberedFactsFromStored(stored: string | undefined): readonly RememberedFact[] {
+  const facts: RememberedFact[] = [];
+  const ids = new Set<string>();
+  const words = new Set<string>();
+  for (const value of parsedList(stored, "facts")) {
+    if (isRememberedFact(value) && !ids.has(value.id) && !words.has(value.words)) {
+      facts.push(value);
+      ids.add(value.id);
+      words.add(value.words);
+    }
+    if (facts.length === maximumRememberedFacts) break;
+  }
+  return facts;
+}
+
+export function rememberedFactsRecord(facts: readonly RememberedFact[]): string {
+  return `${JSON.stringify({ facts })}\n`;
+}
+
+function parsedList(stored: string | undefined, field: string): readonly UnparsedWireValue[] {
+  if (stored === undefined) return [];
+  let parsed: UnparsedWireValue;
+  try {
+    parsed = JSON.parse(stored);
+  } catch {
+    return [];
+  }
+  if (!isRecord(parsed)) return [];
+  const list = parsed[field];
+  return Array.isArray(list) ? list : [];
+}

--- a/apps/desktop/src/main/memory-flow.ts
+++ b/apps/desktop/src/main/memory-flow.ts
@@ -45,6 +45,34 @@ export function conversationRecord(entries: readonly ConversationEntry[], now: n
   return `${JSON.stringify({ entries: retainedConversationEntries(entries, now) })}\n`;
 }
 
+/** Merges complete window snapshots without letting either window erase the other's new lines. */
+export function mergeConversationHistory(
+  current: readonly ConversationEntry[],
+  incoming: readonly ConversationEntry[],
+  clearedAt: number | undefined,
+  now: number,
+): readonly ConversationEntry[] {
+  const afterClear = (entry: ConversationEntry) =>
+    clearedAt === undefined || (entry.recordedAt !== undefined && entry.recordedAt > clearedAt);
+  const merged = current.filter(afterClear);
+  const currentCounts = new Map<string, number>();
+  for (const entry of merged) {
+    const key = conversationEntryKey(entry);
+    currentCounts.set(key, (currentCounts.get(key) ?? 0) + 1);
+  }
+  const incomingCounts = new Map<string, number>();
+  for (const entry of incoming.filter(afterClear)) {
+    const key = conversationEntryKey(entry);
+    const count = (incomingCounts.get(key) ?? 0) + 1;
+    incomingCounts.set(key, count);
+    if (count > (currentCounts.get(key) ?? 0)) merged.push(entry);
+  }
+  return retainedConversationEntries(
+    merged.sort((left, right) => (left.recordedAt ?? now) - (right.recordedAt ?? now)),
+    now,
+  );
+}
+
 /**
  * Reads remembered entries, dropping invalid records and anything beyond the cap.
  */
@@ -78,4 +106,14 @@ function parsedList(stored: string | undefined, field: string): readonly Unparse
   if (!isRecord(parsed)) return [];
   const list = parsed[field];
   return Array.isArray(list) ? list : [];
+}
+
+function conversationEntryKey(entry: ConversationEntry): string {
+  return JSON.stringify([
+    entry.kind,
+    entry.words,
+    entry.recordedAt,
+    entry.identity?.providerId,
+    entry.identity?.providerSessionId,
+  ]);
 }

--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -1,3 +1,4 @@
+import type { RememberedFact } from "@sidecar/acts";
 import {
   PRODUCT_PANEL_SOURCE,
   PRODUCT_SEARCH_SURFACE,
@@ -378,6 +379,8 @@ export function App(): React.JSX.Element {
   // so a bootstrap replying "not yet" after a push raced past it clobbers
   // nothing, and the wing stops saying "loading" the moment either arrives.
   const [sessionsSettled, setSessionsSettled] = useState(false);
+  /** The main process's durable memory, mirrored here only to update conversation context. */
+  const [rememberedFacts, setRememberedFacts] = useState<readonly RememberedFact[]>([]);
   const [workspaceProjects, setWorkspaceProjects] = useState<readonly ObservedWorkspaceProject[]>(
     [],
   );
@@ -2011,6 +2014,32 @@ export function App(): React.JSX.Element {
             note: "Luke is quitting to install the downloaded release; this conversation ends with it.",
           };
         },
+        // Automatic memory stays silent; the returned list updates context.
+        [APP_TOOL_KIND.REMEMBER]: async (action): Promise<WireRecord> => {
+          const facts = await window.sidecar.rememberFact(action.words, action.replaces);
+          setRememberedFacts(facts);
+          // The store's answer is the whole report: the words are there or the
+          // write did not land, and a claim to have remembered something the
+          // list does not hold is worse than the refusal.
+          if (!facts.some((fact) => fact.words === action.words)) {
+            return {
+              status: ACT_RESULT_STATUS.REJECTED,
+              reason: "That memory could not be saved.",
+            };
+          }
+          return { status: ACT_RESULT_STATUS.ACCEPTED };
+        },
+        [APP_TOOL_KIND.FORGET]: async (action): Promise<WireRecord> => {
+          const facts = await window.sidecar.forgetFact(action.id);
+          setRememberedFacts(facts);
+          if (facts.some((fact) => fact.id === action.id)) {
+            return {
+              status: ACT_RESULT_STATUS.REJECTED,
+              reason: "That memory could not be removed.",
+            };
+          }
+          return { status: ACT_RESULT_STATUS.ACCEPTED };
+        },
       }),
     [
       accountNow,
@@ -2082,6 +2111,7 @@ export function App(): React.JSX.Element {
     openSession: openSessionAloud,
     openSessionApplication: openSessionApplicationAloud,
     carryAppAction,
+    rememberedFacts,
   });
 
   // A failed call is reported where its reply would have landed: on the
@@ -2498,6 +2528,7 @@ export function App(): React.JSX.Element {
       setBootstrap(value);
       acceptSessionsBootstrap(value.sessionRoster);
       if (value.sessionsSettled) setSessionsSettled(true);
+      setRememberedFacts(value.rememberedFacts);
       // Only fill in what no push has said yet: the bootstrap snapshot is
       // older than any change that raced past it, and the main process will
       // not repeat a list it believes it already announced.

--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -2111,6 +2111,7 @@ export function App(): React.JSX.Element {
     openSession: openSessionAloud,
     openSessionApplication: openSessionApplicationAloud,
     carryAppAction,
+    conversationContextReady: bootstrap !== undefined,
     rememberedFacts,
   });
 

--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -2428,6 +2428,10 @@ export function App(): React.JSX.Element {
       }),
     applySettings,
   );
+  const acceptRememberedFactsBootstrap = useBootstrapRacedChannel(
+    (onChange) => window.sidecar.onRememberedFactsChanged(onChange),
+    setRememberedFacts,
+  );
   const acceptAccountBootstrap = useBootstrapRacedChannel(
     (onChange) => window.sidecar.onAccountChanged(onChange),
     setAccount,
@@ -2528,7 +2532,7 @@ export function App(): React.JSX.Element {
       setBootstrap(value);
       acceptSessionsBootstrap(value.sessionRoster);
       if (value.sessionsSettled) setSessionsSettled(true);
-      setRememberedFacts(value.rememberedFacts);
+      acceptRememberedFactsBootstrap(value.rememberedFacts);
       // Only fill in what no push has said yet: the bootstrap snapshot is
       // older than any change that raced past it, and the main process will
       // not repeat a list it believes it already announced.
@@ -2635,6 +2639,7 @@ export function App(): React.JSX.Element {
     acceptMeetingQuietBootstrap,
     acceptOutputAudioBootstrap,
     acceptProjectsBootstrap,
+    acceptRememberedFactsBootstrap,
     acceptSessionReplayBootstrap,
     acceptSessionsBootstrap,
     acceptSettingsBootstrap,

--- a/apps/desktop/src/renderer/panel-body.tsx
+++ b/apps/desktop/src/renderer/panel-body.tsx
@@ -788,11 +788,11 @@ export interface PanelBodyProps {
   onOpenSessionApplication: (session: SessionView, applicationId: SessionApplicationId) => void;
   /** Carries a typed reply or an advertised action to the session's provider. */
   writes: SessionWriteHandlers;
-  /** The current-launch, renderer-memory conversation between the developer and Luke. */
+  /** The conversation between the developer and Luke, this launch's and what survived the last. */
   conversationHistory: readonly ConversationEntry[];
   /** The lines still being said, drawn under that thread while their words grow. */
   liveConversationEntries: readonly ConversationEntry[];
-  /** Clears that same thread from the view and Luke's next conversational context. */
+  /** Clears that same thread from the view, Luke's next context, and the stored file. */
   onClearConversationHistory: () => void;
   /** Carries a typed ask to Luke's own conversation, answering why it could not go. */
   ask: AskHandler;

--- a/apps/desktop/src/renderer/realtime-session.test.ts
+++ b/apps/desktop/src/renderer/realtime-session.test.ts
@@ -1945,7 +1945,7 @@ test("an empty history says nothing at all", async () => {
   assert.deepEqual(contextItems(context, "[recent conversation"), []);
 });
 
-test("a call accepts only the recent slice of a full current-launch thread", async () => {
+test("a call accepts only the recent slice of the retained thread", async () => {
   const context = harness();
   await context.session.connect();
   const thread = Array.from(

--- a/apps/desktop/src/renderer/realtime-session.ts
+++ b/apps/desktop/src/renderer/realtime-session.ts
@@ -1,3 +1,4 @@
+import { type RememberedFact, rememberedFactsText } from "@sidecar/acts";
 import { TRACE_DIRECTION, type TraceDirection } from "@sidecar/devtrace/vocabulary";
 import { type AppGuideSnapshot, appGuideContextText, EMPTY_APP_GUIDE } from "@sidecar/guide";
 import type { TrackedIssue } from "@sidecar/issues";
@@ -47,6 +48,7 @@ import {
   realtimeSessionSyncEvents,
   realtimeToolFamily,
   recentConversationEntries,
+  rememberedFactsContextEvents,
   type ScheduledTimer,
   SESSION_TOOL_KIND,
   sessionContextEvents,
@@ -111,6 +113,7 @@ export const VOICE_IDLE_TIMEOUT_MS = 3 * 60_000;
 const CONTEXT_FLUSH_ORDER: readonly ContextItemKind[] = [
   CONTEXT_ITEM_KIND.SESSIONS,
   CONTEXT_ITEM_KIND.CONVERSATION,
+  CONTEXT_ITEM_KIND.MEMORY,
   CONTEXT_ITEM_KIND.WORKSPACE_PROJECTS,
 ];
 
@@ -499,6 +502,8 @@ export class RealtimeVoiceSession {
    * call may only name a setting Luke was actually described as having.
    */
   #guide: AppGuideSnapshot = EMPTY_APP_GUIDE;
+  /** The complete bounded memory list that automatic updates are validated against. */
+  #rememberedFacts: readonly RememberedFact[] = [];
   /**
    * The guide's rendered text, waiting to ride the session instructions, and
    * the text the call's instructions last carried. The guide is not a context
@@ -1713,6 +1718,7 @@ export class RealtimeVoiceSession {
     this.#sessions = [];
     this.#conversationEntries = [];
     this.#guide = EMPTY_APP_GUIDE;
+    this.#rememberedFacts = [];
     this.#workspaceProjects = [];
     this.#issues = undefined;
     // What was said on the call goes with the call. The pending answers go too:
@@ -2097,7 +2103,7 @@ export class RealtimeVoiceSession {
     entries: readonly ConversationEntry[],
     { announced = false }: { announced?: boolean } = {},
   ): void {
-    // The caller may retain the whole current-launch thread for its own UI;
+    // The caller may retain the whole bounded thread for its own UI;
     // this transport accepts only the recent slice that may reach the model.
     this.#conversationEntries = recentConversationEntries(entries);
     if (announced) this.#conversationGrewAnnouncement = true;
@@ -2117,6 +2123,19 @@ export class RealtimeVoiceSession {
     }
     this.#rememberContext(CONTEXT_ITEM_KIND.CONVERSATION, text, (itemId) =>
       conversationContextEvents(text, itemId),
+    );
+  }
+
+  /** Supplies durable facts as silent reply context, separate from conversation history. */
+  updateRememberedFacts(facts: readonly RememberedFact[]): void {
+    this.#rememberedFacts = facts;
+    const text = rememberedFactsText(facts);
+    if (text === undefined) {
+      this.#forgetContext(CONTEXT_ITEM_KIND.MEMORY);
+      return;
+    }
+    this.#rememberContext(CONTEXT_ITEM_KIND.MEMORY, text, (itemId) =>
+      rememberedFactsContextEvents(text, itemId),
     );
   }
 
@@ -2619,7 +2638,7 @@ export class RealtimeVoiceSession {
     // An ask about Luke himself is validated against the guide the app
     // actually provided, then carried by the renderer the same way a session
     // act is: perform, and answer with what became of it.
-    const appAction = appToolAction(call, this.#guide, this.#sessions);
+    const appAction = appToolAction(call, this.#guide, this.#sessions, this.#rememberedFacts);
     if (appAction.status === ACT_RESULT_STATUS.REJECTED) {
       return { status: appAction.status, reason: appAction.reason };
     }

--- a/apps/desktop/src/renderer/use-voice-conversation.test.ts
+++ b/apps/desktop/src/renderer/use-voice-conversation.test.ts
@@ -20,9 +20,11 @@ import {
   activeVoiceStream,
   authorizeConversationAct,
   conversationEntryBelongsToConversation,
+  conversationHistoryMayPersist,
   liveConversationEntries,
   liveSpeedApplies,
   lukeCaptionsToShow,
+  rebaseSpokenTurnMarks,
   replyIssueMentions,
   replyMentions,
   spokenAskBelongsToConversation,
@@ -117,6 +119,20 @@ test("a gone call takes its half-transcribed previews with it", () => {
   assert.equal(spokenAskPreviewSurvives(REALTIME_STATUS.READY), true);
   assert.equal(spokenAskPreviewSurvives(REALTIME_STATUS.LISTENING), true);
   assert.equal(spokenAskPreviewSurvives(REALTIME_STATUS.RESPONDING), true);
+});
+
+test("restore anchors pending speech and is the first point history may persist", () => {
+  const restoredTail = { kind: "reply", words: "Earlier reply." } as const;
+  const unanchored = { after: undefined };
+  const anchored = { after: { kind: "reply", words: "Current reply." } as const };
+
+  rebaseSpokenTurnMarks([unanchored, anchored], restoredTail);
+
+  assert.equal(unanchored.after, restoredTail);
+  assert.equal(anchored.after.words, "Current reply.");
+  assert.equal(conversationHistoryMayPersist(false, false), false);
+  assert.equal(conversationHistoryMayPersist(true, true), false);
+  assert.equal(conversationHistoryMayPersist(true, false), true);
 });
 
 test("an authorization that outlives Clear cannot record its act", async () => {

--- a/apps/desktop/src/renderer/use-voice-conversation.test.ts
+++ b/apps/desktop/src/renderer/use-voice-conversation.test.ts
@@ -38,6 +38,7 @@ import {
   voiceExchangeKind,
   voiceNoticeToShow,
   voiceRestartAction,
+  waitForConversationContext,
   waveformVoice,
 } from "./use-voice-conversation";
 import { WAVEFORM_VOICE } from "./waveform";
@@ -133,6 +134,23 @@ test("restore anchors pending speech and is the first point history may persist"
   assert.equal(conversationHistoryMayPersist(false, false), false);
   assert.equal(conversationHistoryMayPersist(true, true), false);
   assert.equal(conversationHistoryMayPersist(true, false), true);
+});
+
+test("the first call waits for durable conversation context", async () => {
+  const waiters = new Set<() => void>();
+  let settled = false;
+  const waiting = waitForConversationContext(false, waiters).then(() => {
+    settled = true;
+  });
+  await Promise.resolve();
+  assert.equal(settled, false);
+  for (const resolve of waiters) resolve();
+  await waiting;
+  assert.equal(settled, true);
+
+  const readyWaiters = new Set<() => void>();
+  await waitForConversationContext(true, readyWaiters);
+  assert.equal(readyWaiters.size, 0);
 });
 
 test("an authorization that outlives Clear cannot record its act", async () => {

--- a/apps/desktop/src/renderer/use-voice-conversation.ts
+++ b/apps/desktop/src/renderer/use-voice-conversation.ts
@@ -25,8 +25,8 @@ import {
   retainedConversationEntries,
   SESSION_TOOL_KIND,
   sessionActConversationEntry,
-  streamingConversationEntry,
   storedConversationMaximumAgeMs,
+  streamingConversationEntry,
 } from "@sidecar/realtime";
 import {
   mentionedSessions,

--- a/apps/desktop/src/renderer/use-voice-conversation.ts
+++ b/apps/desktop/src/renderer/use-voice-conversation.ts
@@ -361,6 +361,19 @@ export function liveConversationEntries(input: {
   return lines;
 }
 
+/** Moves turns opened before restore behind the restored thread. */
+export function rebaseSpokenTurnMarks(
+  marks: readonly { after: ConversationEntry | undefined }[],
+  restoredTail: ConversationEntry,
+): void {
+  for (const mark of marks) mark.after ??= restoredTail;
+}
+
+/** Stored history may change only after restore and outside a pending Clear. */
+export function conversationHistoryMayPersist(seeded: boolean, clearing: boolean): boolean {
+  return seeded && !clearing;
+}
+
 /** Captures the reply that owns an act before main-process authorization can pause it. */
 export async function authorizeConversationAct<T>(
   activeReplyGeneration: { readonly current: number | undefined },
@@ -670,6 +683,8 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
    * stay cleared.
    */
   const conversationSeeded = useRef(false);
+  /** Whether a Clear's deletion is still in flight, so nothing may rewrite it. */
+  const conversationClearing = useRef(false);
   /** Rises when Clear retires every event that began before that press. */
   const conversationGenerationRef = useRef(0);
   // State is the ref's identical drawn copy, so History retains the whole
@@ -736,7 +751,12 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
     voiceSession.current?.updateConversation(recentConversationEntries(conversationRef.current), {
       announced,
     });
-    window.sidecar.reportConversationHistory(conversationRef.current);
+    // Before the restore this thread is only part of itself, and while a Clear
+    // is in flight the file it would write is already being deleted: either
+    // write would stand in for a thread nobody has.
+    if (conversationHistoryMayPersist(conversationSeeded.current, conversationClearing.current)) {
+      window.sidecar.reportConversationHistory(conversationRef.current);
+    }
   }, []);
 
   useEffect(() => {
@@ -776,10 +796,13 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
   );
 
   const clearConversationHistory = useCallback(() => {
+    if (conversationClearing.current) return;
+    conversationClearing.current = true;
     void window.sidecar
       .clearConversationHistory()
       .then((cleared) => {
         if (!cleared) {
+          conversationClearing.current = false;
           setVoiceError("Could not clear history. Try again.");
           return;
         }
@@ -799,8 +822,12 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
         voiceSession.current?.clearConversation();
         activeReplyGenerationRef.current = undefined;
         activeAnnouncementGenerationRef.current = undefined;
+        conversationClearing.current = false;
       })
-      .catch(() => setVoiceError("Could not clear history. Try again."));
+      .catch(() => {
+        conversationClearing.current = false;
+        setVoiceError("Could not clear history. Try again.");
+      });
   }, []);
 
   /**
@@ -852,6 +879,17 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
       // A snapshot the main process built before this window's first report —
       // or before a Clear pressed here — must not stand old lines back up.
       if (conversationSeeded.current || conversationGenerationRef.current > 0) return;
+      const restoredTail = entries.at(-1);
+      if (restoredTail) {
+        rebaseSpokenTurnMarks(
+          [
+            ...spokenTurnMarksRef.current.values(),
+            ...pendingSpokenTurnMarksRef.current,
+            ...(activeSpokenTurnMarkRef.current ? [activeSpokenTurnMarkRef.current] : []),
+          ],
+          restoredTail,
+        );
+      }
       applySharedConversationHistory({
         entries: [...entries, ...conversationRef.current],
         cleared: false,

--- a/apps/desktop/src/renderer/use-voice-conversation.ts
+++ b/apps/desktop/src/renderer/use-voice-conversation.ts
@@ -374,6 +374,15 @@ export function conversationHistoryMayPersist(seeded: boolean, clearing: boolean
   return seeded && !clearing;
 }
 
+/** Holds the first call until bootstrap has supplied its durable reply context. */
+export function waitForConversationContext(
+  ready: boolean,
+  waiters: Set<() => void>,
+): Promise<void> {
+  if (ready) return Promise.resolve();
+  return new Promise((resolve) => waiters.add(resolve));
+}
+
 /** Captures the reply that owns an act before main-process authorization can pause it. */
 export async function authorizeConversationAct<T>(
   activeReplyGeneration: { readonly current: number | undefined },
@@ -499,6 +508,8 @@ export interface VoiceConversationOptions {
    * {@link openSession}.
    */
   carryAppAction: AppActionCarrier;
+  /** Whether restored history and personal memory are ready for the first turn. */
+  conversationContextReady: boolean;
   /** Durable personal memory supplied at bootstrap and kept current by pushes. */
   rememberedFacts: readonly RememberedFact[];
 }
@@ -676,6 +687,7 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
    * goes with its teardown.
    */
   const conversationRef = useRef<readonly ConversationEntry[]>([]);
+  const conversationContextWaitersRef = useRef(new Set<() => void>());
   /**
    * Whether the stored thread has been placed. Once, at the first bootstrap
    * that carries one: a second seeding would re-add lines the developer had
@@ -690,6 +702,11 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
   // State is the ref's identical drawn copy, so History retains the whole
   // current launch even though a call receives only the recent context slice.
   const [conversationHistory, setConversationHistory] = useState<readonly ConversationEntry[]>([]);
+  useEffect(() => {
+    if (!options.conversationContextReady) return;
+    for (const resolve of conversationContextWaitersRef.current) resolve();
+    conversationContextWaitersRef.current.clear();
+  }, [options.conversationContextReady]);
   /** Where each server-identified spoken turn belongs when its transcript returns. */
   const spokenTurnMarksRef = useRef(
     new Map<
@@ -1237,11 +1254,16 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
    * has no part in it — the device stays the press's own act.
    */
   const startConversation = useCallback(async (): Promise<boolean> => {
+    await waitForConversationContext(
+      optionsRef.current.conversationContextReady,
+      conversationContextWaitersRef.current,
+    );
     setVoiceError(undefined);
     setVoiceNotice(undefined);
     const session = ensureVoiceSession();
     if (!(await session.connect())) return false;
-    session.updateSessions(sessionsRef.current);
+    const current = optionsRef.current;
+    session.updateSessions(current.sessions);
     // After the roster, which it is rendered against. The history outlives
     // the calls themselves on purpose: it is the conversation, and this call
     // is only the newest transport to carry it — the announcement a "what did
@@ -1249,13 +1271,13 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
     // this one just replaced.
     session.updateConversation(recentConversationEntries(conversationRef.current));
     session.updateWorkspaceProjects(
-      workspaceProjectsRef.current,
-      defaultWorkspaceProviderRef.current,
-      workspaceProjectDefaultsRef.current,
+      current.workspaceProjects,
+      current.defaultWorkspaceProvider,
+      current.workspaceProjectDefaults,
     );
     session.updateGuide(guideRef.current);
     session.updateIssues(issuesRef.current);
-    session.updateRememberedFacts(rememberedFactsRef.current);
+    session.updateRememberedFacts(current.rememberedFacts);
     return true;
   }, [ensureVoiceSession]);
 

--- a/apps/desktop/src/renderer/use-voice-conversation.ts
+++ b/apps/desktop/src/renderer/use-voice-conversation.ts
@@ -1,3 +1,4 @@
+import type { RememberedFact } from "@sidecar/acts";
 import { PRODUCT_EXCHANGE_KIND, type ProductExchangeKind } from "@sidecar/analytics";
 import { sanitizedTraceEvent } from "@sidecar/devtrace/vocabulary";
 import { FIXTURE_SPEAKING_CAPTION } from "@sidecar/fixtures";
@@ -21,9 +22,11 @@ import {
   type RealtimeVoice,
   type RealtimeVoiceSpeed,
   recentConversationEntries,
+  retainedConversationEntries,
   SESSION_TOOL_KIND,
   sessionActConversationEntry,
   streamingConversationEntry,
+  storedConversationMaximumAgeMs,
 } from "@sidecar/realtime";
 import {
   mentionedSessions,
@@ -483,6 +486,8 @@ export interface VoiceConversationOptions {
    * {@link openSession}.
    */
   carryAppAction: AppActionCarrier;
+  /** Durable personal memory supplied at bootstrap and kept current by pushes. */
+  rememberedFacts: readonly RememberedFact[];
 }
 
 export interface VoiceConversation {
@@ -515,13 +520,12 @@ export interface VoiceConversation {
   stopMicrophone: () => Promise<void>;
   askLuke: (text: string) => Promise<string | undefined>;
   /**
-   * Every bounded line from this app launch — the same thread on every
-   * display's panel, relayed through the main process and living nowhere but
-   * in memory; the model receives a recent slice and the whole view
-   * disappears on exit.
+   * Every bounded line the thread holds — this launch's and, ahead of them,
+   * what the last launch left within the retention policy — shared across
+   * every display's panel. The model still receives only the recent slice.
    */
   conversationHistory: readonly ConversationEntry[];
-  /** Clears the visible history and the context handed to the next call. */
+  /** Clears the visible history, the next call's context, and the stored file. */
   clearConversationHistory: () => void;
   /**
    * The lines still being said, for History to draw under the settled thread:
@@ -642,6 +646,8 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
   const workspaceProjectDefaultsRef = useRef(options.workspaceProjectDefaults);
   const guideRef = useRef<AppGuideSnapshot>(EMPTY_APP_GUIDE);
   const issuesRef = useRef<readonly TrackedIssue[] | undefined>(undefined);
+  /** The remembered entries an automatic replacement or removal is validated against. */
+  const rememberedFactsRef = useRef(options.rememberedFacts);
   // The same roster as state, because the issue chips are derived from it and
   // a derivation only reruns on what React can see change.
   const [trackedIssues, setTrackedIssues] = useState<readonly TrackedIssue[] | undefined>(
@@ -657,6 +663,13 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
    * goes with its teardown.
    */
   const conversationRef = useRef<readonly ConversationEntry[]>([]);
+  /**
+   * Whether the stored thread has been placed. Once, at the first bootstrap
+   * that carries one: a second seeding would re-add lines the developer had
+   * already cleared, and a launch that clears before the bootstrap lands must
+   * stay cleared.
+   */
+  const conversationSeeded = useRef(false);
   /** Rises when Clear retires every event that began before that press. */
   const conversationGenerationRef = useRef(0);
   // State is the ref's identical drawn copy, so History retains the whole
@@ -714,6 +727,32 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
   }, []);
 
   /**
+   * Draws, re-feeds, and persists the same retained thread. Clear uses its own
+   * acknowledged path below so the screen cannot outrun the deletion.
+   */
+  const publishConversation = useCallback((announced = false) => {
+    conversationRef.current = retainedConversationEntries(conversationRef.current, Date.now());
+    setConversationHistory(conversationRef.current);
+    voiceSession.current?.updateConversation(recentConversationEntries(conversationRef.current), {
+      announced,
+    });
+    window.sidecar.reportConversationHistory(conversationRef.current);
+  }, []);
+
+  useEffect(() => {
+    const expiresAt = conversationHistory.reduce(
+      (soonest, entry) =>
+        entry.recordedAt === undefined
+          ? soonest
+          : Math.min(soonest, entry.recordedAt + storedConversationMaximumAgeMs),
+      Number.POSITIVE_INFINITY,
+    );
+    if (!Number.isFinite(expiresAt)) return;
+    const timer = window.setTimeout(publishConversation, Math.max(0, expiresAt - Date.now() + 1));
+    return () => window.clearTimeout(timer);
+  }, [conversationHistory, publishConversation]);
+
+  /**
    * Appends one bounded line to this launch's history and tells the call now
    * open about only the recent context slice. A session leaving the roster
    * costs a line its identity at model render, never its visible words. An
@@ -731,33 +770,37 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
         return;
       }
       conversationRef.current = appendConversationThreadEntry(conversationRef.current, entry);
-      setConversationHistory(conversationRef.current);
-      // The whole thread goes to the main process, which mirrors it to every
-      // other display's panel: an exchange lands on one window, and the
-      // others' History tabs must read the same.
-      window.sidecar.reportConversationHistory(conversationRef.current);
-      voiceSession.current?.updateConversation(recentConversationEntries(conversationRef.current), {
-        announced: entry.kind === CONVERSATION_ENTRY_KIND.ANNOUNCEMENT,
-      });
+      publishConversation(entry.kind === CONVERSATION_ENTRY_KIND.ANNOUNCEMENT);
     },
-    [],
+    [publishConversation],
   );
 
   const clearConversationHistory = useCallback(() => {
-    conversationGenerationRef.current += 1;
-    conversationRef.current = [];
-    spokenTurnMarksRef.current.clear();
-    pendingSpokenTurnMarksRef.current = [];
-    setConversationHistory([]);
-    // The previews go with the marks: a transcription still arriving belongs
-    // to a turn the press just retired, and could never be recorded anyway.
-    setSpokenAskPreviews(NO_SPOKEN_ASK_PREVIEWS);
-    window.sidecar.reportConversationHistoryCleared();
-    talkLatched.current = false;
-    talkPressedAt.current = undefined;
-    voiceSession.current?.clearConversation();
-    activeReplyGenerationRef.current = undefined;
-    activeAnnouncementGenerationRef.current = undefined;
+    void window.sidecar
+      .clearConversationHistory()
+      .then((cleared) => {
+        if (!cleared) {
+          setVoiceError("Could not clear history. Try again.");
+          return;
+        }
+        conversationGenerationRef.current += 1;
+        // Seeded before it is emptied, so a bootstrap still in flight cannot
+        // deliver the very thread this press just cleared.
+        conversationSeeded.current = true;
+        conversationRef.current = [];
+        spokenTurnMarksRef.current.clear();
+        pendingSpokenTurnMarksRef.current = [];
+        setConversationHistory([]);
+        // The previews go with the marks: a transcription still arriving
+        // belongs to a turn the press just retired.
+        setSpokenAskPreviews(NO_SPOKEN_ASK_PREVIEWS);
+        talkLatched.current = false;
+        talkPressedAt.current = undefined;
+        voiceSession.current?.clearConversation();
+        activeReplyGenerationRef.current = undefined;
+        activeAnnouncementGenerationRef.current = undefined;
+      })
+      .catch(() => setVoiceError("Could not clear history. Try again."));
   }, []);
 
   /**
@@ -770,6 +813,7 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
    * latch alone, because a key held here is not another display's to let go.
    */
   const applySharedConversationHistory = useCallback((payload: ConversationHistoryPayload) => {
+    conversationSeeded.current = true;
     if (payload.cleared) {
       conversationGenerationRef.current += 1;
       conversationRef.current = [];
@@ -807,10 +851,14 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
     (entries: readonly ConversationEntry[]) => {
       // A snapshot the main process built before this window's first report —
       // or before a Clear pressed here — must not stand old lines back up.
-      if (conversationRef.current.length > 0 || conversationGenerationRef.current > 0) return;
-      applySharedConversationHistory({ entries, cleared: false });
+      if (conversationSeeded.current || conversationGenerationRef.current > 0) return;
+      applySharedConversationHistory({
+        entries: [...entries, ...conversationRef.current],
+        cleared: false,
+      });
+      publishConversation();
     },
-    [applySharedConversationHistory],
+    [applySharedConversationHistory, publishConversation],
   );
 
   /**
@@ -846,11 +894,9 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
       // displays no report.
       if (placed === conversationRef.current) return;
       conversationRef.current = placed;
-      setConversationHistory(conversationRef.current);
-      window.sidecar.reportConversationHistory(conversationRef.current);
-      voiceSession.current?.updateConversation(recentConversationEntries(conversationRef.current));
+      publishConversation();
     },
-    [dropSpokenAskPreview],
+    [dropSpokenAskPreview, publishConversation],
   );
 
   const ensureVoiceSession = useCallback((): RealtimeVoiceSession => {
@@ -1171,6 +1217,7 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
     );
     session.updateGuide(guideRef.current);
     session.updateIssues(issuesRef.current);
+    session.updateRememberedFacts(rememberedFactsRef.current);
     return true;
   }, [ensureVoiceSession]);
 
@@ -1606,6 +1653,11 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
     sessionsRef.current = options.sessions;
     voiceSession.current?.updateSessions(options.sessions);
   }, [options.sessions]);
+
+  useEffect(() => {
+    rememberedFactsRef.current = options.rememberedFacts;
+    voiceSession.current?.updateRememberedFacts(options.rememberedFacts);
+  }, [options.rememberedFacts]);
 
   useEffect(() => {
     workspaceProjectsRef.current = options.workspaceProjects;

--- a/apps/desktop/src/shared/bridge.test.ts
+++ b/apps/desktop/src/shared/bridge.test.ts
@@ -30,6 +30,7 @@ test("a conversation history report carries only bounded history lines", () => {
     kind: "announcement",
     words: "A chat finished.",
     identity: { providerId: "claude-code", providerSessionId: "session-a" },
+    recordedAt: 2,
   };
   assert.equal(guard([[]]), true);
   assert.equal(guard([[ask, announcement]]), true);
@@ -48,4 +49,24 @@ test("a conversation history report carries only bounded history lines", () => {
     false,
   );
   assert.equal(guard([[{ ...ask, recordedAt: Number.POSITIVE_INFINITY }]]), false);
+});
+
+test("clearing conversation history is acknowledged", () => {
+  assert.equal(BRIDGE.clearConversationHistory.kind, "invoke");
+  assert.equal(BRIDGE.clearConversationHistory.result?.(true), true);
+  assert.equal(BRIDGE.clearConversationHistory.result?.(false), true);
+  assert.equal(BRIDGE.clearConversationHistory.result?.(undefined), false);
+});
+
+test("remembered-fact responses enforce their complete bounded shape", () => {
+  const guard = BRIDGE.rememberFact.result;
+  assert.equal(guard?.([{ id: "one", words: "kept" }]), true);
+  assert.equal(guard?.([{ id: "one", words: "x".repeat(241) }]), false);
+  assert.equal(
+    guard?.([
+      { id: "one", words: "first" },
+      { id: "one", words: "second" },
+    ]),
+    false,
+  );
 });

--- a/apps/desktop/src/shared/bridge.ts
+++ b/apps/desktop/src/shared/bridge.ts
@@ -656,7 +656,13 @@ export const BRIDGE = {
       (v) =>
         v.length === 1 &&
         Array.isArray(v[0]) &&
-        v[0].every((entry) => storedConversationEntry(entry) !== undefined),
+        v[0].every((entry) => {
+          const stored = storedConversationEntry(entry);
+          return (
+            stored !== undefined &&
+            (stored.identity === undefined || isSessionIdentity(stored.identity))
+          );
+        }),
     ),
   }),
   /** The History Clear press, persisted and relayed to every other display. */
@@ -783,6 +789,12 @@ export const BRIDGE = {
     channel: "app:settings-changed",
     args: noArgs,
     result: result<AppSettings>(),
+  }),
+  onRememberedFactsChanged: entry({
+    kind: "subscribe",
+    channel: "app:remembered-facts-changed",
+    args: noArgs,
+    result: result<readonly RememberedFact[]>(isRememberedFacts),
   }),
   onAccountChanged: entry({
     kind: "subscribe",

--- a/apps/desktop/src/shared/bridge.ts
+++ b/apps/desktop/src/shared/bridge.ts
@@ -3,7 +3,8 @@ import {
   type AccountProvider,
   type AccountSnapshot,
 } from "@sidecar/account/snapshot";
-import { type ActEnvelope, isActEnvelope } from "@sidecar/acts";
+import type { RememberedFact } from "@sidecar/acts";
+import { type ActEnvelope, isActEnvelope, isRememberedFacts } from "@sidecar/acts";
 import {
   isProductExchangeKind,
   isProductSurfaceEventName,
@@ -32,10 +33,10 @@ import {
 import {
   type ConversationEntry,
   type IssueToolAction,
-  isConversationEntryKind,
   type RealtimeConnection,
   type RealtimeDiagnostics,
   type SessionAnnouncement,
+  storedConversationEntry,
 } from "@sidecar/realtime";
 import {
   isProviderId,
@@ -180,18 +181,6 @@ function isSessionIdentity(value: unknown): value is SessionIdentity {
     isProviderId(wire.providerId) &&
     isWireString(wire.providerSessionId) &&
     wire.providerSessionId.length > 0
-  );
-}
-
-// oxlint-disable-next-line anti-slop/no-unknown-parameters -- This function parses an IPC field into a domain history line.
-function isConversationEntry(value: unknown): value is ConversationEntry {
-  const wire = wireValue(value);
-  if (!isRecord(wire)) return false;
-  if (!isConversationEntryKind(wire.kind) || !isWireString(wire.words)) return false;
-  if (wire.identity !== undefined && !isSessionIdentity(wire.identity)) return false;
-  return (
-    wire.recordedAt === undefined ||
-    (isWireNumber(wire.recordedAt) && Number.isFinite(wire.recordedAt))
   );
 }
 
@@ -540,6 +529,21 @@ export const BRIDGE = {
     ),
     result: result<ProviderControlResult>(),
   }),
+  /** Memory writes return the complete list that actually persisted. */
+  rememberFact: entry({
+    kind: "invoke",
+    channel: "app:remember-fact",
+    args: args<[string, string?]>(
+      (v) => v.length >= 1 && v.length <= 2 && isWireString(v[0]) && optionalString(v[1]),
+    ),
+    result: result<readonly RememberedFact[]>(isRememberedFacts),
+  }),
+  forgetFact: entry({
+    kind: "invoke",
+    channel: "app:forget-fact",
+    args: oneString,
+    result: result<readonly RememberedFact[]>(isRememberedFacts),
+  }),
   createSessionWorkspace: entry({
     kind: "invoke",
     channel: "app:create-session-workspace",
@@ -649,14 +653,18 @@ export const BRIDGE = {
     kind: "send",
     channel: "app:report-conversation-history",
     args: args<[readonly ConversationEntry[]]>(
-      (v) => v.length === 1 && Array.isArray(v[0]) && v[0].every(isConversationEntry),
+      (v) =>
+        v.length === 1 &&
+        Array.isArray(v[0]) &&
+        v[0].every((entry) => storedConversationEntry(entry) !== undefined),
     ),
   }),
-  /** The History Clear press, relayed so every display lets the same thread go. */
-  reportConversationHistoryCleared: entry({
-    kind: "send",
-    channel: "app:report-conversation-history-cleared",
+  /** The History Clear press, persisted and relayed to every other display. */
+  clearConversationHistory: entry({
+    kind: "invoke",
+    channel: "app:clear-conversation-history",
     args: noArgs,
+    result: result<boolean>(isWireBoolean),
   }),
   /**
    * Words the renderer already draws, placed on this machine's clipboard and

--- a/apps/desktop/src/shared/wire/session.ts
+++ b/apps/desktop/src/shared/wire/session.ts
@@ -1,4 +1,5 @@
 import type { AccountSnapshot } from "@sidecar/account/snapshot";
+import type { RememberedFact } from "@sidecar/acts";
 import type { ObservedAccountCalendars } from "@sidecar/calendar/observation";
 import type { FixtureSnapshot } from "@sidecar/fixtures";
 import type { TrackedIssue } from "@sidecar/issues";
@@ -201,11 +202,14 @@ export interface AppBootstrap {
   /** Whether the calendar's quiet is holding announcements right now. */
   meetingQuiet: boolean;
   /**
-   * The launch's conversation history so far, so a panel that opens late — a
-   * display plugged in mid-conversation — draws the History every other
-   * window already holds.
+   * The conversation thread as the last launch left it, already retained.
+   * Only the recent slice reaches a model; the rest is shared across every
+   * display's panel, so History opens where the developer left it.
+   * Empty in a fixture or capture run, which reads no thread and writes none.
    */
   conversationHistory: readonly ConversationEntry[];
+  /** Luke's bounded durable facts about the developer. Empty in fixture and capture runs. */
+  rememberedFacts: readonly RememberedFact[];
   /** Whether, where, and for whom this run may record its own surface. */
   sessionReplay: SessionReplayBootstrap;
   settings: AppSettings;

--- a/packages/acts/src/acts.test.ts
+++ b/packages/acts/src/acts.test.ts
@@ -1,6 +1,9 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { APP_TOOL_KIND, actNarration } from "./acts.js";
+import { EMPTY_APP_GUIDE } from "@sidecar/guide";
+import { ACT_RESULT_STATUS } from "@sidecar/wire";
+import { APP_TOOL_KIND, actNarration, appToolAction, REALTIME_TOOL } from "./acts.js";
+import { maximumRememberedFacts } from "./memory.js";
 
 test("a setting act narrates the setting label and accepted value", () => {
   assert.equal(
@@ -22,5 +25,91 @@ test("a setting act narrates the setting label and accepted value", () => {
       [],
     ),
     "changed Captions to on",
+  );
+});
+
+const memoryCall = (name: string, args: Record<string, string>) => ({
+  name,
+  argumentsJson: JSON.stringify(args),
+});
+
+const HELD = [{ id: "fact-one", words: "prefers CI updates" }];
+
+test("an automatic memory update may only replace an entry in context", () => {
+  const replacing = appToolAction(
+    memoryCall(REALTIME_TOOL.REMEMBER_FACT, {
+      words: "  stop telling me\n about CI ",
+      replaces: "fact-one",
+    }),
+    EMPTY_APP_GUIDE,
+    [],
+    HELD,
+  );
+  assert.deepEqual(replacing, {
+    kind: APP_TOOL_KIND.REMEMBER,
+    words: "stop telling me about CI",
+    replaces: "fact-one",
+  });
+
+  const invented = appToolAction(
+    memoryCall(REALTIME_TOOL.REMEMBER_FACT, { words: "anything", replaces: "fact-invented" }),
+    EMPTY_APP_GUIDE,
+    [],
+    HELD,
+  );
+  assert.equal(invented.status, ACT_RESULT_STATUS.REJECTED);
+});
+
+test("words that bound away to nothing are remembered as nothing", () => {
+  const empty = appToolAction(
+    memoryCall(REALTIME_TOOL.REMEMBER_FACT, { words: "   " }),
+    EMPTY_APP_GUIDE,
+    [],
+    [],
+  );
+  assert.equal(empty.status, ACT_RESULT_STATUS.REJECTED);
+});
+
+test("the cap refuses a new fact rather than evicting an old one", () => {
+  const full = Array.from({ length: maximumRememberedFacts }, (_, index) => ({
+    id: `fact-${index}`,
+    words: `something ${index}`,
+  }));
+  const refused = appToolAction(
+    memoryCall(REALTIME_TOOL.REMEMBER_FACT, { words: "one more" }),
+    EMPTY_APP_GUIDE,
+    [],
+    full,
+  );
+  assert.equal(refused.status, ACT_RESULT_STATUS.REJECTED);
+
+  // A replacement retires one as it lands, so a full list still takes it.
+  const replacing = appToolAction(
+    memoryCall(REALTIME_TOOL.REMEMBER_FACT, { words: "one more", replaces: "fact-0" }),
+    EMPTY_APP_GUIDE,
+    [],
+    full,
+  );
+  assert.equal(replacing.kind, APP_TOOL_KIND.REMEMBER);
+});
+
+test("forgetting can only name an entry that stands", () => {
+  assert.deepEqual(
+    appToolAction(
+      memoryCall(REALTIME_TOOL.FORGET_FACT, { id: "fact-one" }),
+      EMPTY_APP_GUIDE,
+      [],
+      HELD,
+    ),
+    { kind: APP_TOOL_KIND.FORGET, id: "fact-one" },
+  );
+  assert.equal(
+    appToolAction(
+      memoryCall(REALTIME_TOOL.FORGET_FACT, { id: "fact-two" }),
+      EMPTY_APP_GUIDE,
+      [],
+      HELD,
+    ).status,
+    ACT_RESULT_STATUS.REJECTED,
   );
 });

--- a/packages/acts/src/acts.ts
+++ b/packages/acts/src/acts.ts
@@ -75,6 +75,13 @@ import {
   type WireRecord,
   text as wireText,
 } from "@sidecar/wire";
+import {
+  holdsRememberedFact,
+  maximumRememberedFactLength,
+  maximumRememberedFacts,
+  type RememberedFact,
+  rememberedFactText,
+} from "./memory.js";
 export interface RealtimeFunctionCall {
   name: string;
   argumentsJson: string;
@@ -96,6 +103,7 @@ export const ACT_VALIDATION_TARGET = {
   SETTING_ID: "setting-id",
   UPDATE_ROW: "update-row",
   APP_GUIDE: "app-guide",
+  REMEMBERED_FACT: "remembered-fact",
 } as const;
 
 export type ActValidationTarget =
@@ -125,6 +133,8 @@ export const APP_TOOL_KIND = {
   PANEL: "panel",
   FEEDBACK: "feedback",
   UPDATE: "update",
+  REMEMBER: "remember",
+  FORGET: "forget",
 } as const;
 
 /** The two whole-list scopes of a spoken panel ask beyond the locations. */
@@ -255,7 +265,15 @@ type CarriedAppActionFields =
       query?: string;
     }
   | { kind: typeof APP_TOOL_KIND.FEEDBACK; composer: FeedbackComposerKind; draft?: string }
-  | { kind: typeof APP_TOOL_KIND.UPDATE; act: AppUpdateAct };
+  | { kind: typeof APP_TOOL_KIND.UPDATE; act: AppUpdateAct }
+  | {
+      kind: typeof APP_TOOL_KIND.REMEMBER;
+      /** One concise durable fact selected from the developer-opened turn. */
+      words: string;
+      /** The id of the fact this one stands in for, when it changes one. */
+      replaces?: string;
+    }
+  | { kind: typeof APP_TOOL_KIND.FORGET; id: string };
 
 export type CarriedAppAction = CarriedAppActionFields & {
   status?: never;
@@ -321,6 +339,12 @@ export interface IssueToolContext {
 export interface AppToolContext {
   guide: AppGuideSnapshot;
   sessions: readonly Session[];
+  /**
+   * The facts standing right now, which a replacement or a removal is
+   * validated against — the same discipline a session act keeps against the
+   * roster. An id the conversation was never shown names nothing.
+   */
+  rememberedFacts: readonly RememberedFact[];
 }
 
 type JsonSchemaStringProperty = {
@@ -1198,6 +1222,40 @@ function validateRunUpdateAction(parsed: WireRecord, context: AppToolContext): A
   return { kind: APP_TOOL_KIND.UPDATE, act };
 }
 
+/** Validates one automatic memory update against the bounded list in context. */
+function validateRememberFact(parsed: WireRecord, context: AppToolContext): AppToolAction {
+  const words = rememberedFactText(parsed.words);
+  if (!words) {
+    return {
+      status: ACT_RESULT_STATUS.REJECTED,
+      reason: `A memory has to be under ${maximumRememberedFactLength} characters and longer than nothing.`,
+    };
+  }
+  const replaces = textArgument(parsed, "replaces");
+  if (replaces !== undefined && !holdsRememberedFact(context.rememberedFacts, replaces)) {
+    return {
+      status: ACT_RESULT_STATUS.REJECTED,
+      reason: "Nothing remembered goes by that id.",
+    };
+  }
+  // A replacement retires one as it lands; a new fact never evicts silently.
+  if (replaces === undefined && context.rememberedFacts.length >= maximumRememberedFacts) {
+    return {
+      status: ACT_RESULT_STATUS.REJECTED,
+      reason: `Luke already remembers ${maximumRememberedFacts} things; replace or forget one first.`,
+    };
+  }
+  return { kind: APP_TOOL_KIND.REMEMBER, words, ...(replaces ? { replaces } : undefined) };
+}
+
+function validateForgetFact(parsed: WireRecord, context: AppToolContext): AppToolAction {
+  const id = textArgument(parsed, "id");
+  if (!id || !holdsRememberedFact(context.rememberedFacts, id)) {
+    return { status: ACT_RESULT_STATUS.REJECTED, reason: "Nothing remembered goes by that id." };
+  }
+  return { kind: APP_TOOL_KIND.FORGET, id };
+}
+
 function observedSessionName(identity: SessionIdentity, sessions: readonly Session[]): string {
   const session = sessions.find(
     (candidate) =>
@@ -1693,6 +1751,63 @@ export const ACTS = {
     },
     validate: validateRunUpdateAction,
   },
+  REMEMBER_FACT: {
+    name: "remember_fact",
+    family: REALTIME_TOOL_FAMILY.APP,
+    actionKind: APP_TOOL_KIND.REMEMBER,
+    validatedAgainst: ACT_VALIDATION_TARGET.REMEMBERED_FACT,
+    narration: narrate(APP_TOOL_KIND.REMEMBER, (action) =>
+      action.replaces
+        ? `remembered "${action.words}" in place of something remembered before`
+        : `remembered "${action.words}"`,
+    ),
+    guide: "Silently save useful durable context about the developer.",
+    schema: {
+      description:
+        "Silently save a concise stable preference, personal fact, goal, or recurring constraint " +
+        "from this developer-opened turn. Skip transient details and uncertain inferences. Never " +
+        "save credentials; save sensitive facts only when explicitly asked. Do not mention routine " +
+        "memory changes. Skip duplicates, and pass an existing id as replaces when updating a " +
+        "contradiction.",
+      parameters: {
+        type: "object",
+        properties: {
+          words: {
+            type: "string",
+            description: "A concise durable fact about the developer.",
+          },
+          replaces: {
+            type: "string",
+            description:
+              "The id of the remembered entry this one stands in for, when it changes one.",
+          },
+        },
+        required: ["words"],
+      },
+    },
+    validate: validateRememberFact,
+  },
+  FORGET_FACT: {
+    name: "forget_fact",
+    family: REALTIME_TOOL_FAMILY.APP,
+    actionKind: APP_TOOL_KIND.FORGET,
+    validatedAgainst: ACT_VALIDATION_TARGET.REMEMBERED_FACT,
+    narration: narrate(APP_TOOL_KIND.FORGET, () => "forgot something remembered before"),
+    guide: "Silently forget an outdated entry or one the developer asked to drop.",
+    schema: {
+      description:
+        "Silently forget an outdated or explicitly unwanted memory. Only an id from the remembered " +
+        "list can be named. Do not mention routine memory changes.",
+      parameters: {
+        type: "object",
+        properties: {
+          id: { type: "string", description: "The remembered entry's id." },
+        },
+        required: ["id"],
+      },
+    },
+    validate: validateForgetFact,
+  },
 } as const satisfies Record<string, RealtimeToolSpec>;
 
 /** The history sentence declared by the same row that declared the act. */
@@ -1834,6 +1949,7 @@ export function appToolAction(
   call: RealtimeFunctionCall,
   guide: AppGuideSnapshot,
   sessions: readonly Session[],
+  rememberedFacts: readonly RememberedFact[] = [],
 ): AppToolAction {
   const parsed = parseToolArguments(call);
   if (!parsed.ok) return { status: ACT_RESULT_STATUS.REJECTED, reason: parsed.reason };
@@ -1841,7 +1957,7 @@ export function appToolAction(
   if (!tool || tool.family !== REALTIME_TOOL_FAMILY.APP) {
     return { status: ACT_RESULT_STATUS.REJECTED, reason: "No such tool exists." };
   }
-  return tool.validate(parsed.value, { guide, sessions });
+  return tool.validate(parsed.value, { guide, sessions, rememberedFacts });
 }
 
 /**

--- a/packages/acts/src/index.ts
+++ b/packages/acts/src/index.ts
@@ -1,1 +1,2 @@
 export * from "./acts.js";
+export * from "./memory.js";

--- a/packages/acts/src/memory.test.ts
+++ b/packages/acts/src/memory.test.ts
@@ -1,0 +1,52 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  holdsRememberedFact,
+  isRememberedFact,
+  isRememberedFacts,
+  maximumRememberedFactLength,
+  rememberedFactsText,
+  rememberedFactText,
+  withoutRememberedFact,
+} from "./memory.js";
+
+const fact = (id: string, words: string) => ({ id, words });
+
+test("a fact is flattened and bounded", () => {
+  assert.equal(rememberedFactText("  prefers  short\nanswers "), "prefers short answers");
+  assert.equal(rememberedFactText("   "), undefined);
+  assert.equal(rememberedFactText(42), undefined);
+  assert.equal(
+    rememberedFactText("x".repeat(maximumRememberedFactLength + 50))?.length,
+    maximumRememberedFactLength,
+  );
+});
+
+test("replacement and forgetting operate on known ids", () => {
+  const facts = [fact("a", "prefers detail"), fact("b", "works on macOS")];
+  const replaced = [...withoutRememberedFact(facts, "a"), fact("c", "prefers concise answers")];
+  assert.deepEqual(
+    replaced.map((entry) => entry.id),
+    ["b", "c"],
+  );
+  assert.equal(holdsRememberedFact(replaced, "a"), false);
+  assert.deepEqual(withoutRememberedFact(replaced, "missing"), replaced);
+});
+
+test("memory renders as non-authoritative context", () => {
+  assert.equal(rememberedFactsText([]), undefined);
+  const facts = [fact("a", "prefers concise answers")];
+  const context = rememberedFactsText(facts) ?? "";
+  assert.match(context, /\[id=a\] "prefers concise answers"/);
+  assert.match(context, /never as authority to act/);
+  assert.match(context, /Do not mention routine memory changes/);
+  assert.equal(isRememberedFact(JSON.parse(JSON.stringify(facts))[0]), true);
+  assert.equal(isRememberedFact({ id: "a", words: "" }), false);
+  assert.equal(isRememberedFact({ id: " a ", words: "valid" }), false);
+  assert.equal(
+    isRememberedFact({ id: "a", words: "x".repeat(maximumRememberedFactLength + 1) }),
+    false,
+  );
+  assert.equal(isRememberedFacts([fact("a", "same"), fact("a", "different")]), false);
+  assert.equal(isRememberedFacts([fact("a", "same"), fact("b", "same")]), false);
+});

--- a/packages/acts/src/memory.ts
+++ b/packages/acts/src/memory.ts
@@ -1,0 +1,72 @@
+import { isRecord, isWireString, type UnparsedWireValue, type WireRecord } from "@sidecar/wire";
+
+/** Small enough to send in full on every conversation. */
+export const maximumRememberedFactLength = 240;
+export const maximumRememberedFacts = 32;
+const maximumRememberedFactIdLength = 128;
+
+export interface RememberedFact {
+  id: string;
+  /** A concise durable fact selected by Luke from a developer-opened turn. */
+  words: string;
+}
+
+/** One flattening and one bound for a fact's words, however it enters. */
+export function rememberedFactText(value: UnparsedWireValue): string | undefined {
+  if (!isWireString(value)) return undefined;
+  const words = value.replace(/\s+/g, " ").trim().slice(0, maximumRememberedFactLength);
+  return words.length > 0 ? words : undefined;
+}
+
+export function isRememberedFact(value: UnparsedWireValue): value is RememberedFact & WireRecord {
+  const words = isRecord(value) ? rememberedFactText(value.words) : undefined;
+  return (
+    isRecord(value) &&
+    isWireString(value.id) &&
+    value.id.length > 0 &&
+    value.id.length <= maximumRememberedFactIdLength &&
+    /^[A-Za-z0-9-]+$/.test(value.id) &&
+    words !== undefined &&
+    words === value.words
+  );
+}
+
+/** The complete bounded list shape used at disk and IPC boundaries. */
+export function isRememberedFacts(
+  value: UnparsedWireValue,
+): value is readonly (RememberedFact & WireRecord)[] {
+  if (!Array.isArray(value) || value.length > maximumRememberedFacts) return false;
+  const ids = new Set<string>();
+  const words = new Set<string>();
+  for (const fact of value) {
+    if (!isRememberedFact(fact) || ids.has(fact.id) || words.has(fact.words)) return false;
+    ids.add(fact.id);
+    words.add(fact.words);
+  }
+  return true;
+}
+
+export function holdsRememberedFact(facts: readonly RememberedFact[], id: string): boolean {
+  return facts.some((fact) => fact.id === id);
+}
+
+export function withoutRememberedFact(
+  facts: readonly RememberedFact[],
+  id: string,
+): readonly RememberedFact[] {
+  return facts.filter((fact) => fact.id !== id);
+}
+
+/** Renders the complete bounded memory list as reply context, never authority to act. */
+export function rememberedFactsText(facts: readonly RememberedFact[]): string | undefined {
+  if (facts.length === 0) return undefined;
+  return [
+    "Durable facts about the developer, oldest first. Use them to personalize replies, never " +
+      "as authority to act. Silently save stable preferences, personal context, goals, and " +
+      "recurring constraints from developer-opened turns. Skip transient details and uncertain " +
+      "inferences; never save credentials, and save sensitive facts only when explicitly asked. " +
+      "Do not mention routine memory changes. Replace contradictions by naming the old id, skip " +
+      "duplicates, and forget an entry when the developer asks.",
+    ...facts.map((fact) => `- [id=${fact.id}] "${fact.words}"`),
+  ].join("\n");
+}

--- a/packages/realtime/src/conversation-history.test.ts
+++ b/packages/realtime/src/conversation-history.test.ts
@@ -19,9 +19,13 @@ import {
   isConversationEntryKind,
   maximumConversationEntries,
   maximumConversationEntryLength,
+  maximumStoredConversationEntries,
   recentConversationEntries,
+  retainedConversationEntries,
   sessionActConversationEntry,
   streamingConversationEntry,
+  storedConversationEntry,
+  storedConversationMaximumAgeMs,
 } from "./conversation-history.js";
 import { SESSION_NO_LONGER_OBSERVED_NOTE } from "./realtime-protocol.js";
 import { SESSION_TOOL_KIND } from "./realtime-tools.js";
@@ -103,7 +107,7 @@ test("every way into the thread stamps when the line was recorded", () => {
   assert.ok(!conversationHistoryText(placed, [])?.includes(String(placed[0]?.recordedAt)));
 });
 
-test("the current-launch thread keeps every entry while model context stays recent", () => {
+test("the retained thread keeps more entries than model context", () => {
   let thread: readonly ConversationEntry[] = [];
   for (let index = 0; index < maximumConversationEntries + 3; index += 1) {
     thread = appendConversationThreadEntry(thread, {
@@ -239,7 +243,7 @@ test("a spoken ask reads as the developer's own words, said rather than typed", 
   assert.match(text, /^- the developer said: "how is the checkout agent doing\?"$/m);
 });
 
-test("a delayed spoken ask keeps its place in the full current-launch thread", () => {
+test("a delayed spoken ask keeps its place in the retained thread", () => {
   const prior: ConversationEntry = {
     kind: CONVERSATION_ENTRY_KIND.REPLY,
     words: "Earlier reply.",
@@ -354,6 +358,93 @@ test("a line whose session left the roster keeps its words and says the session 
   );
   assert.ok(aboutNoSession);
   assert.doesNotMatch(aboutNoSession, /no longer observed/);
+});
+
+test("a thread restored from a past launch renders with no identity at all", () => {
+  // Across a launch this is the ordinary case rather than the exception: every
+  // session the last conversation named has a fresh roster to be absent from,
+  // and none of those lines may still offer an identity to a tool call.
+  const restored = [
+    {
+      kind: CONVERSATION_ENTRY_KIND.TYPED_ASK,
+      words: "how is checkout going",
+      recordedAt: 1_800_000_000_000,
+    },
+    {
+      kind: CONVERSATION_ENTRY_KIND.ANNOUNCEMENT,
+      words: "Claude Code finished checkout-service.",
+      identity: { providerId: "claude-code", providerSessionId: "yesterdays-session" },
+      recordedAt: 1_800_000_000_000,
+    },
+  ] satisfies ConversationEntry[];
+
+  const text = conversationHistoryText(restored, []);
+
+  assert.ok(text);
+  assert.match(text, /how is checkout going/);
+  assert.match(text, /finished checkout-service/);
+  assert.doesNotMatch(text, /provider_id=/);
+});
+
+test("a stored line reads back, and retention cuts by age and by count", () => {
+  const now = 1_800_000_000_000;
+  const line = {
+    kind: CONVERSATION_ENTRY_KIND.REPLY,
+    words: "two agents are working",
+    recordedAt: now,
+  };
+  assert.deepEqual(storedConversationEntry(JSON.parse(JSON.stringify(line))), line);
+  assert.equal(
+    storedConversationEntry({ kind: "invented", words: "no", recordedAt: now }),
+    undefined,
+  );
+  assert.equal(
+    storedConversationEntry({ kind: CONVERSATION_ENTRY_KIND.REPLY, words: line.words }),
+    undefined,
+  );
+  assert.equal(storedConversationEntry({ ...line, words: " two agents " }), undefined);
+  assert.equal(
+    storedConversationEntry({ ...line, identity: { providerId: "claude-code" } }),
+    undefined,
+  );
+
+  const stale = { ...line, recordedAt: now - storedConversationMaximumAgeMs - 1 };
+  assert.deepEqual(retainedConversationEntries([stale, line], now), [line]);
+
+  const many = Array.from({ length: maximumStoredConversationEntries + 5 }, (_, index) => ({
+    ...line,
+    words: `line ${index}`,
+  }));
+  assert.equal(retainedConversationEntries(many, now).length, maximumStoredConversationEntries);
+});
+
+test("the live thread obeys the same count and age retention as storage", () => {
+  const now = 1_800_000_000_000;
+  let entries: readonly ConversationEntry[] = [];
+  for (let index = 0; index <= maximumStoredConversationEntries; index += 1) {
+    entries = appendConversationThreadEntry(
+      entries,
+      { kind: CONVERSATION_ENTRY_KIND.REPLY, words: `line ${index}` },
+      now,
+    );
+  }
+  assert.equal(entries.length, maximumStoredConversationEntries);
+  assert.equal(entries[0]?.words, "line 1");
+  assert.deepEqual(
+    retainedConversationEntries(entries, now + storedConversationMaximumAgeMs + 1),
+    [],
+  );
+});
+
+test("an appended line carries retention's clock without it reaching the model", () => {
+  const now = 1_800_000_000_000;
+  const entries = appendConversationEntry(
+    [],
+    { kind: CONVERSATION_ENTRY_KIND.TYPED_ASK, words: "what is running" },
+    now,
+  );
+  assert.equal(entries[0]?.recordedAt, now);
+  assert.doesNotMatch(conversationHistoryText(entries, []) ?? "", /1800000000000/);
 });
 
 test("an empty history says nothing at all", () => {

--- a/packages/realtime/src/conversation-history.test.ts
+++ b/packages/realtime/src/conversation-history.test.ts
@@ -23,9 +23,9 @@ import {
   recentConversationEntries,
   retainedConversationEntries,
   sessionActConversationEntry,
-  streamingConversationEntry,
   storedConversationEntry,
   storedConversationMaximumAgeMs,
+  streamingConversationEntry,
 } from "./conversation-history.js";
 import { SESSION_NO_LONGER_OBSERVED_NOTE } from "./realtime-protocol.js";
 import { SESSION_TOOL_KIND } from "./realtime-tools.js";

--- a/packages/realtime/src/conversation-history.ts
+++ b/packages/realtime/src/conversation-history.ts
@@ -5,8 +5,8 @@
  * asks about it, and the developer's call retires when idle — so the thread
  * itself is kept here, as a record of what was already said and done during
  * this app launch. A bounded recent slice is re-fed to whichever call the
- * developer opens next; the whole in-memory thread remains available to the
- * developer in the panel until they clear it or quit.
+ * developer opens next; the retained thread remains available to the
+ * developer in the panel until they clear it.
  *
  * Every panel window draws the same thread. The window that appends a line
  * reports the whole thread to its own main process, which holds the launch's
@@ -18,11 +18,20 @@
  * text by the service that heard them — the words Luke spoke or announced,
  * and the acts he carried at the developer's ask. Nothing else may enter —
  * not a roster, not a transcript rendering, not an outcome a provider
- * answered with — and the record lives in memory alone, dying with the app.
+ * answered with.
+ *
+ * The thread outlives the app. What is stored is exactly what that rule
+ * already admits — words that were said, each of which reached the voice
+ * service once on the call that said it — and never a claim Luke formed
+ * about the developer, which is a different kind of thing kept somewhere
+ * else. So the justification above holds across a launch unchanged: quitting
+ * and coming back is the same continuity a retired call already has, one
+ * boundary further out. Only the retention changes, because "dies with the
+ * app" was itself a policy and persisting means replacing it with a real one.
  */
 
 import type { Session, SessionIdentity } from "@sidecar/session";
-import { isWireString, type UnparsedWireValue } from "@sidecar/wire";
+import { isRecord, isWireNumber, isWireString, type UnparsedWireValue } from "@sidecar/wire";
 import { SESSION_NO_LONGER_OBSERVED_NOTE } from "./realtime-protocol.js";
 import { actNarration, type CarriedSessionAction } from "./realtime-tools.js";
 
@@ -59,6 +68,25 @@ export function isConversationEntryKind(value: UnparsedWireValue): value is Conv
 export const maximumConversationEntries = 20;
 export const maximumConversationEntryLength = 400;
 
+/**
+ * How much of the thread survives a quit, and for how long. Two bounds
+ * because they answer different failures: the count keeps a busy week from
+ * making the file the panel's slowest read, and the age keeps a conversation
+ * nobody has looked at since from following the developer around forever.
+ * Whichever cuts first wins, and neither widens what reaches the model —
+ * {@link maximumConversationEntries} still bounds that, and persisting is for
+ * continuity and for the panel.
+ *
+ * At this size continuity needs no retrieval: quitting and returning to the
+ * last twenty lines is the whole of it, and the panel simply draws the rest.
+ * Retrieval starts to matter only if the model's slice stops being the recent
+ * slice — if a turn should be able to reach back to something said last month
+ * rather than last night. That is a different feature with a different budget,
+ * and nothing here anticipates it.
+ */
+export const maximumStoredConversationEntries = 200;
+export const storedConversationMaximumAgeMs = 14 * 24 * 60 * 60 * 1000;
+
 export interface ConversationEntry {
   kind: ConversationEntryKind;
   /**
@@ -78,25 +106,27 @@ export interface ConversationEntry {
   identity?: SessionIdentity;
   /**
    * When the line happened in the conversation. Appends stamp themselves;
-   * delayed spoken transcripts carry the time their turn began.
+   * delayed spoken transcripts carry the time their turn began. This is also
+   * retention's clock and never enters model context.
    */
   recordedAt?: number;
 }
 
 /**
- * Appends one length-bounded line to the current-launch thread. An entry with
+ * Appends one length-bounded line to the retained thread. An entry with
  * nothing left after flattening appends nothing: an empty line says nothing
  * worth keeping or spending model-window space on.
  */
 export function appendConversationThreadEntry(
   entries: readonly ConversationEntry[],
   entry: ConversationEntry,
+  now: number = Date.now(),
 ): readonly ConversationEntry[] {
   const words = boundedEntryWords(entry.words);
   if (!words) return entries;
-  const appended: ConversationEntry = { kind: entry.kind, words, recordedAt: Date.now() };
+  const appended: ConversationEntry = { kind: entry.kind, words, recordedAt: now };
   if (entry.identity) appended.identity = entry.identity;
-  return [...entries, appended];
+  return retainedConversationEntries([...entries, appended], now);
 }
 
 /**
@@ -140,8 +170,9 @@ export function recentConversationEntries(
 export function appendConversationEntry(
   entries: readonly ConversationEntry[],
   entry: ConversationEntry,
+  now: number = Date.now(),
 ): readonly ConversationEntry[] {
-  return recentConversationEntries(appendConversationThreadEntry(entries, entry));
+  return recentConversationEntries(appendConversationThreadEntry(entries, entry, now));
 }
 
 /** One flattening and one bound for every line, however it enters. */
@@ -186,7 +217,7 @@ export function insertSpokenAskThreadEntry(
   entries: readonly ConversationEntry[],
   words: string,
   after: ConversationEntry | undefined,
-  recordedAt: number,
+  recordedAt: number = Date.now(),
 ): readonly ConversationEntry[] {
   const bounded = boundedEntryWords(words);
   if (!bounded) return entries;
@@ -207,8 +238,9 @@ export function insertSpokenAskEntry(
   entries: readonly ConversationEntry[],
   words: string,
   after: ConversationEntry | undefined,
+  now: number = Date.now(),
 ): readonly ConversationEntry[] {
-  return recentConversationEntries(insertSpokenAskThreadEntry(entries, words, after, Date.now()));
+  return recentConversationEntries(insertSpokenAskThreadEntry(entries, words, after, now));
 }
 
 /**
@@ -280,4 +312,67 @@ export function conversationHistoryText(
         : `${line} [${SESSION_NO_LONGER_OBSERVED_NOTE}]`;
     }),
   ].join("\n");
+}
+
+const CONVERSATION_ENTRY_KINDS: ReadonlySet<string> = new Set(
+  Object.values(CONVERSATION_ENTRY_KIND),
+);
+
+function isConversationEntryKind(value: UnparsedWireValue): value is ConversationEntryKind {
+  return isWireString(value) && CONVERSATION_ENTRY_KINDS.has(value);
+}
+
+/**
+ * Parses one stored line back, or nothing. A file half-written by a crash, or
+ * a record from a build that spelled an entry differently, drops the line
+ * rather than the thread: history is not load-bearing, and a single unreadable
+ * line is worth less than everything said around it.
+ */
+export function storedConversationEntry(value: UnparsedWireValue): ConversationEntry | undefined {
+  if (!isRecord(value) || !isConversationEntryKind(value.kind)) return undefined;
+  const words = isWireString(value.words) ? boundedEntryWords(value.words) : undefined;
+  if (!words || words !== value.words) return undefined;
+  const recordedAt =
+    isWireNumber(value.recordedAt) && Number.isFinite(value.recordedAt)
+      ? value.recordedAt
+      : undefined;
+  if (recordedAt === undefined || recordedAt < 0) return undefined;
+  const identity = value.identity;
+  const providerId = isRecord(identity) ? identity.providerId : undefined;
+  const providerSessionId = isRecord(identity) ? identity.providerSessionId : undefined;
+  if (
+    identity !== undefined &&
+    (!isWireString(providerId) ||
+      providerId.length === 0 ||
+      !isWireString(providerSessionId) ||
+      providerSessionId.length === 0)
+  ) {
+    return undefined;
+  }
+  return {
+    kind: value.kind,
+    words,
+    recordedAt,
+    ...(isWireString(providerId) && isWireString(providerSessionId)
+      ? { identity: { providerId, providerSessionId } }
+      : undefined),
+  };
+}
+
+/**
+ * Applies both retention bounds, oldest lines going first. Unclocked draft
+ * entries may participate in pure in-memory ordering; the storage parser above
+ * refuses them, and every live append supplies a clock.
+ */
+export function retainedConversationEntries(
+  entries: readonly ConversationEntry[],
+  now: number,
+): readonly ConversationEntry[] {
+  return entries
+    .filter(
+      (entry) =>
+        entry.recordedAt === undefined ||
+        (entry.recordedAt <= now && now - entry.recordedAt <= storedConversationMaximumAgeMs),
+    )
+    .slice(-maximumStoredConversationEntries);
 }

--- a/packages/realtime/src/conversation-history.ts
+++ b/packages/realtime/src/conversation-history.ts
@@ -314,14 +314,6 @@ export function conversationHistoryText(
   ].join("\n");
 }
 
-const CONVERSATION_ENTRY_KINDS: ReadonlySet<string> = new Set(
-  Object.values(CONVERSATION_ENTRY_KIND),
-);
-
-function isConversationEntryKind(value: UnparsedWireValue): value is ConversationEntryKind {
-  return isWireString(value) && CONVERSATION_ENTRY_KINDS.has(value);
-}
-
 /**
  * Parses one stored line back, or nothing. A file half-written by a crash, or
  * a record from a build that spelled an entry differently, drops the line

--- a/packages/realtime/src/index.ts
+++ b/packages/realtime/src/index.ts
@@ -21,9 +21,9 @@ export {
   recentConversationEntries,
   retainedConversationEntries,
   sessionActConversationEntry,
-  streamingConversationEntry,
   storedConversationEntry,
   storedConversationMaximumAgeMs,
+  streamingConversationEntry,
 } from "./conversation-history.js";
 export {
   type IntroductionLine,

--- a/packages/realtime/src/index.ts
+++ b/packages/realtime/src/index.ts
@@ -17,9 +17,13 @@ export {
   isConversationEntryKind,
   maximumConversationEntries,
   maximumConversationEntryLength,
+  maximumStoredConversationEntries,
   recentConversationEntries,
+  retainedConversationEntries,
   sessionActConversationEntry,
   streamingConversationEntry,
+  storedConversationEntry,
+  storedConversationMaximumAgeMs,
 } from "./conversation-history.js";
 export {
   type IntroductionLine,
@@ -39,6 +43,7 @@ export {
   contextSupersedeEventId,
   contextSupersedeEvents,
   conversationContextEvents,
+  rememberedFactsContextEvents,
   sessionContextEvents,
   sessionContextText,
   workspaceProjectContextEvents,

--- a/packages/realtime/src/realtime-context.ts
+++ b/packages/realtime/src/realtime-context.ts
@@ -261,6 +261,7 @@ export function sessionContextText(sessions: readonly Session[], now: number = D
 export const CONTEXT_ITEM_KIND = {
   SESSIONS: "sessions",
   CONVERSATION: "conversation",
+  MEMORY: "memory",
   WORKSPACE_PROJECTS: "workspace-projects",
 } as const;
 
@@ -363,6 +364,11 @@ export function sessionContextEvents(
  */
 export function conversationContextEvents(text: string, itemId: string): readonly WireRecord[] {
   return [labeledContextEvent("recent conversation, sent automatically", text, itemId)];
+}
+
+/** Carries durable personal memory as silent reply context, never authority to act. */
+export function rememberedFactsContextEvents(text: string, itemId: string): readonly WireRecord[] {
+  return [labeledContextEvent("durable personal memory", text, itemId)];
 }
 
 /** How many projects one context update may offer workspace creation in. */

--- a/packages/realtime/src/realtime.test.ts
+++ b/packages/realtime/src/realtime.test.ts
@@ -1017,7 +1017,7 @@ test("the bounded roster keeps every provider's most recent openable chat", () =
   assert.match(text, /1 more observed session is not listed/);
 });
 
-test("the session is minted with the fourteen acts and nothing wider", () => {
+test("the session is minted with the sixteen acts and nothing wider", () => {
   const config = realtimeSessionConfig();
 
   assert.deepEqual(
@@ -1037,6 +1037,8 @@ test("the session is minted with the fourteen acts and nothing wider", () => {
       REALTIME_TOOL.SHOW_PANEL,
       REALTIME_TOOL.OPEN_FEEDBACK_COMPOSER,
       REALTIME_TOOL.RUN_UPDATE_ACTION,
+      REALTIME_TOOL.REMEMBER_FACT,
+      REALTIME_TOOL.FORGET_FACT,
     ],
   );
   assert.equal(config.tool_choice, "auto");


### PR DESCRIPTION
## Summary

- Persist Luke's conversation history locally with 200-entry and 14-day retention bounds, while keeping model context capped at the 20 most recent entries.
- Add explicitly confirmed remembered preferences with validated remember, replace, and forget actions plus individual History controls.
- Update the privacy/product documentation and cover storage, retention, IPC authorization, acts, context, and rendering behavior with tests.

## Evidence

- Platform-independent checks: `./scripts/check.sh` passed
- macOS Electron verification (`./scripts/verify.sh`): `not run`

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/33538057534/artifacts/9812530994) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/33538057534)

- Commit: `b901a16fb02e65212d72c96d700a523b3941630b`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

### Physical-device evidence

- Screenshot or screen recording: `not attached`
- Physical-notch check: `not performed`
- Device/display configuration: `not recorded`

## Notes

- Blockers or follow-up verification: None

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)