### PR TITLE
fix(web): keep the hero mock's wings inside the phone's screen

### DIFF
--- a/apps/web/src/notch-mock.css
+++ b/apps/web/src/notch-mock.css
@@ -73,6 +73,7 @@
   --surface-fill: #000;
   --surface-shadow: 0 10px 26px rgba(0, 0, 0, 0.46), 0 2px 7px rgba(0, 0, 0, 0.3);
 
+  --display-radius: 18px;
   --panel-radius: 30px;
   --panel-inset: 20px;
   --wing-inset: 9px;
@@ -98,6 +99,14 @@
   /* An illustration, not page copy: dragging across a recreated interface
      should not fill someone's clipboard with invented session titles. */
   user-select: none;
+  /* The display's silhouette is the art's hard boundary. The surface's shadow
+     reaches about 26px past the black, which the desktop frame's slack
+     absorbs but the phone frame's 20px does not, so unclipped it paints two
+     grey wings on the page just outside the gradient. Clipping here — the
+     frame's own rounded rect — bounds everything the mock draws, the shadow's
+     tail and the spring's overshoot alike. */
+  border-radius: var(--display-radius);
+  overflow: clip;
 }
 
 /* A flare belongs to the corner it turns into: beside the housing it
@@ -131,7 +140,7 @@
   position: absolute;
   z-index: 0;
   inset: 0;
-  border-radius: 18px;
+  border-radius: var(--display-radius);
   background: linear-gradient(180deg, var(--frame-top) 0%, var(--frame-bottom) 100%);
 }
 
@@ -144,7 +153,7 @@
   position: absolute;
   z-index: 0;
   inset: 0;
-  border-radius: 18px;
+  border-radius: var(--display-radius);
 }
 
 /* The black surface is the whole animation: one leaf element with no children

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -397,24 +397,34 @@
   }
 }
 
-/* Each step is the largest scale whose 660px art still clears the screen at
-   the step's floor, so the mock fills a phone instead of floating in it and
-   the stage's clip never eats the frame's edges. */
+/* Each step is the largest twentieth whose 660px art still keeps ten or so
+   pixels of page beside it at the step's floor. The gutter is the point: a
+   step chosen to merely clear its floor puts the frame's corners flush
+   against the screen edge — and past it, once the arithmetic slips by half a
+   pixel — where the stage's clip squares them off and the display reads as
+   overflowing the phone. Twentieths, because they land the 660×560 box on
+   whole pixels. */
 @media (width < 520px) {
   :root {
-    --mock-scale: 0.58;
+    --mock-scale: 0.6;
+  }
+}
+
+@media (width < 416px) {
+  :root {
+    --mock-scale: 0.55;
   }
 }
 
 @media (width < 384px) {
   :root {
-    --mock-scale: 0.54;
+    --mock-scale: 0.5;
   }
 }
 
 @media (width < 356px) {
   :root {
-    --mock-scale: 0.5;
+    --mock-scale: 0.45;
   }
 }
 


### PR DESCRIPTION
## Problem

On phones, the hero mock grew grey "wings": the black panel's drop shadow painted past the gradient display onto the page. The surface's shadow reaches ~26px past the black; the desktop frame keeps 40px of gradient beside the panel and absorbs it, but the phone frame keeps only 20px, so the shadow's tail leaked beyond the display's silhouette — a grey fringe hugging both sides of the gradient, running exactly the panel's height.

Separately, the mock's scale steps were sized to *exactly* clear each breakpoint floor, leaving the display flush against the viewport edge at common phone widths — and past it where the arithmetic slipped (660 × 0.54 = 356.4px art at a 356px floor; 330px art on a 320px iPhone SE), where the stage's clip squared off the display's corners.

## Fix

1. **Clip the mock to its display silhouette** (`notch-mock.css`): the frame's rounded rect is now the art's hard boundary, so nothing the mock draws — the shadow's tail or the spring's overshoot — can paint past the display at any size. The 18px radius is hoisted to `--display-radius`, shared by the mock, its frame, and its backdrop.
2. **Retune the phone scale steps** (`styles.css`) so every breakpoint floor keeps ten or so pixels of page beside the art (0.6 / 0.55 / 0.5 / 0.45, with a new 416px step so larger phones don't over-shrink). Twentieths land the 660×560 box on whole pixels, which the old 0.58 step (382.8px art) didn't.

Desktop and tablet are visually unchanged: the desktop frame's slack already contained the shadow, and the ≥520px scale steps are untouched.

## Verification

- Pixel measurement at 449px/2x: page pixels just outside the frame read a uniform (251,251,250) after the clip; before, they darkened to (245,245,244) beside the panel and only recovered below it — the leaking shadow.
- Headless-Chrome sweep across 16 widths (320–899px), dev server and production build both: every width keeps ≥10px of page per side, zero horizontal scroll overflow, frame corners fully visible.
- Desktop (1280px) render compared before/after: unchanged.
- `./scripts/repository-checks.sh`, `pnpm lint`, `pnpm typecheck`, `pnpm build`: pass.
- `pnpm test`: every package passes except a pre-existing, environment-specific failure in `@sidecar/providers` (the OpenCode plugin test's generated `.js` file is parsed as CJS under this sandbox's Node 24 in `/tmp`), which fails identically on a clean checkout of main and is untouched by this CSS-only change.
- No physical-notch check performed; the change is the landing site's hero mock, not the desktop app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/33449812229/artifacts/9779399344) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/33449812229)

- Commit: `50baf47599d0e26a709928217db7466eb1a21cc8`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
