### PR TITLE
fix(desktop): unify the API key hints, linked on their destinations

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -46,7 +46,7 @@ running. One that never reaches a sign-in belongs to nobody, so deleting your
 account does not reach it — we have no way to tell it was yours.
 
 **Provider API keys (server-side vault).** While the "Sync provider keys"
-switch in Settings · Connections is on — it starts on — the provider API keys
+switch in Settings > Connections is on — it starts on — the provider API keys
 you entered into Luke on this Mac are kept synced to Luke's hosted service,
 for your other Luke devices: a key saved while signed in syncs in the same
 press, and Luke re-syncs the stored keys when he starts signed in, when you

--- a/apps/desktop/src/main/settings-store.test.ts
+++ b/apps/desktop/src/main/settings-store.test.ts
@@ -57,7 +57,7 @@ const FIRST_CLOUD_PROVIDER: CredentialProvider = {
   id: "first-cloud" as CredentialProviderId,
   displayName: "First Cloud",
   connection: CREDENTIAL_CONNECTION.KEY,
-  hint: "Create a key in First Cloud.",
+  hint: { lead: "Create a key in First Cloud under", destination: "Settings > API keys" },
   environmentVariables: [TEST_ENVIRONMENT_VARIABLE.FIRST_CLOUD_API_KEY],
 };
 
@@ -66,7 +66,7 @@ const SECOND_CLOUD_PROVIDER: CredentialProvider = {
   id: "second-cloud" as CredentialProviderId,
   displayName: "Second Cloud",
   connection: CREDENTIAL_CONNECTION.KEY,
-  hint: "Create a key in Second Cloud.",
+  hint: { lead: "Create a key in Second Cloud under", destination: "Settings > API keys" },
   environmentVariables: [TEST_ENVIRONMENT_VARIABLE.SECOND_CLOUD_API_KEY],
 };
 
@@ -76,7 +76,7 @@ const THIRD_CLOUD_PROVIDER: CredentialProvider = {
   id: "third-cloud" as CredentialProviderId,
   displayName: "Third Cloud",
   connection: CREDENTIAL_CONNECTION.KEY,
-  hint: "Create a key in Third Cloud.",
+  hint: { lead: "Create a key in Third Cloud under", destination: "Settings > API keys" },
   environmentVariables: [TEST_ENVIRONMENT_VARIABLE.THIRD_CLOUD_API_KEY],
   keyFormat: {
     label: "API key",

--- a/apps/desktop/src/renderer/destination-note.tsx
+++ b/apps/desktop/src/renderer/destination-note.tsx
@@ -1,0 +1,37 @@
+import { ExternalIcon } from "./settings-icons";
+
+/**
+ * One sentence whose link is its destination: the lead, then the linked words
+ * that open the page, a full stop, and the caveat if there is one. Every
+ * place the panel says where to fetch a credential — the settings editor, the
+ * key slot, the Superset code slot — draws this one shape, so the wording
+ * cannot drift apart.
+ *
+ * A button, not an anchor: the renderer has no browser to navigate, and the
+ * main process owns every address — a key page is opened by provider id, and
+ * the Superset page is the one its waiting flow built.
+ */
+export function DestinationNote({
+  lead,
+  destination,
+  caveat,
+  disabled,
+  onOpen,
+}: {
+  lead: string;
+  destination: string;
+  caveat?: string;
+  disabled: boolean;
+  onOpen: () => void;
+}): React.JSX.Element {
+  return (
+    <small className="settings-note">
+      {lead}{" "}
+      <button type="button" className="link-button" disabled={disabled} onClick={onOpen}>
+        {destination}
+        <ExternalIcon />
+      </button>
+      .{caveat ? ` ${caveat}` : null}
+    </small>
+  );
+}

--- a/apps/desktop/src/renderer/destination-note.tsx
+++ b/apps/desktop/src/renderer/destination-note.tsx
@@ -2,7 +2,7 @@ import { ExternalIcon } from "./settings-icons";
 
 /**
  * One sentence whose link is its destination: the lead, then the linked words
- * that open the page, a full stop, and the caveat if there is one. Every
+ * that open the page, a full stop, and the trail if there is one. Every
  * place the panel says where to fetch a credential — the settings editor, the
  * key slot, the Superset code slot — draws this one shape, so the wording
  * cannot drift apart.
@@ -14,13 +14,13 @@ import { ExternalIcon } from "./settings-icons";
 export function DestinationNote({
   lead,
   destination,
-  caveat,
+  trail,
   disabled,
   onOpen,
 }: {
   lead: string;
   destination: string;
-  caveat?: string;
+  trail?: string;
   disabled: boolean;
   onOpen: () => void;
 }): React.JSX.Element {
@@ -31,7 +31,7 @@ export function DestinationNote({
         {destination}
         <ExternalIcon />
       </button>
-      .{caveat ? ` ${caveat}` : null}
+      .{trail ? ` ${trail}` : null}
     </small>
   );
 }

--- a/apps/desktop/src/renderer/key-slot.tsx
+++ b/apps/desktop/src/renderer/key-slot.tsx
@@ -12,8 +12,8 @@ import {
   isSubmittable,
   useStagedFocus,
 } from "./credential-entry";
+import { DestinationNote } from "./destination-note";
 import { HIT_REGION } from "./panel-state";
-import { ExternalIcon } from "./settings-icons";
 
 /**
  * The panel stood down to the one thing anyone entering a key needs: somewhere
@@ -143,29 +143,15 @@ export function KeySlot({
             width is not a flourish — the sentence it holds is the same one the
             panel's field holds, and it has to fit. */}
         <div className="settings-row key-slot-foot">
-          <small className="settings-note">
-            {provider.hint ? (
-              <>
-                {provider.hint.lead}{" "}
-                {/* A button, not an anchor: the renderer has no browser to
-                    navigate, and the main process opens the page by provider
-                    rather than by an address the panel supplies. The link sits
-                    on the destination itself, so the sentence names the page
-                    and opens it with the same words. This is what the slot is
-                    standing aside for, so it does not move the shape again. */}
-                <button
-                  type="button"
-                  className="link-button"
-                  disabled={entry.busy}
-                  onClick={() => control.fetchKey()}
-                >
-                  {provider.hint.destination}
-                  <ExternalIcon />
-                </button>
-                .{provider.hint.caveat ? ` ${provider.hint.caveat}` : null}
-              </>
-            ) : null}
-          </small>
+          {/* Opening the key page is what the slot is standing aside for, so
+              the press does not move the shape again. */}
+          {provider.hint ? (
+            <DestinationNote
+              {...provider.hint}
+              disabled={entry.busy}
+              onOpen={() => control.fetchKey()}
+            />
+          ) : null}
           <span className="settings-actions">
             <button
               type="button"

--- a/apps/desktop/src/renderer/key-slot.tsx
+++ b/apps/desktop/src/renderer/key-slot.tsx
@@ -144,20 +144,27 @@ export function KeySlot({
             panel's field holds, and it has to fit. */}
         <div className="settings-row key-slot-foot">
           <small className="settings-note">
-            {provider.hint}{" "}
-            {/* A button, not an anchor: the renderer has no browser to navigate,
-                and the main process opens the page by provider rather than by an
-                address the panel supplies. This is what the slot is standing
-                aside for, so it does not move the shape again. */}
-            <button
-              type="button"
-              className="link-button"
-              disabled={entry.busy}
-              onClick={() => control.fetchKey()}
-            >
-              Where to get one
-              <ExternalIcon />
-            </button>
+            {provider.hint ? (
+              <>
+                {provider.hint.lead}{" "}
+                {/* A button, not an anchor: the renderer has no browser to
+                    navigate, and the main process opens the page by provider
+                    rather than by an address the panel supplies. The link sits
+                    on the destination itself, so the sentence names the page
+                    and opens it with the same words. This is what the slot is
+                    standing aside for, so it does not move the shape again. */}
+                <button
+                  type="button"
+                  className="link-button"
+                  disabled={entry.busy}
+                  onClick={() => control.fetchKey()}
+                >
+                  {provider.hint.destination}
+                  <ExternalIcon />
+                </button>
+                .{provider.hint.caveat ? ` ${provider.hint.caveat}` : null}
+              </>
+            ) : null}
           </small>
           <span className="settings-actions">
             <button

--- a/apps/desktop/src/renderer/settings-panel.tsx
+++ b/apps/desktop/src/renderer/settings-panel.tsx
@@ -101,6 +101,7 @@ import {
   removalStage,
   removalWithdrawable,
 } from "./credential-removal";
+import { DestinationNote } from "./destination-note";
 import type { FeedbackEntryControl } from "./feedback-entry";
 import { FeedbackSection } from "./feedback-panel";
 import { Keycaps } from "./keycaps";
@@ -717,28 +718,13 @@ function ProviderCredential({
             />
           </label>
           <div className="settings-row">
-            <small className="settings-note">
-              {provider.hint ? (
-                <>
-                  {provider.hint.lead}{" "}
-                  {/* A button, not an anchor: the renderer has no browser to
-                      navigate, and the main process opens the page by provider
-                      rather than by an address the panel supplies. The link
-                      sits on the destination itself, so the sentence names
-                      the page and opens it with the same words. */}
-                  <button
-                    type="button"
-                    className="link-button"
-                    disabled={busy}
-                    onClick={() => control.fetchKey()}
-                  >
-                    {provider.hint.destination}
-                    <ExternalIcon />
-                  </button>
-                  .{provider.hint.caveat ? ` ${provider.hint.caveat}` : null}
-                </>
-              ) : null}
-            </small>
+            {provider.hint ? (
+              <DestinationNote
+                {...provider.hint}
+                disabled={busy}
+                onOpen={() => control.fetchKey()}
+              />
+            ) : null}
             <span className="settings-actions">
               <button
                 type="button"

--- a/apps/desktop/src/renderer/settings-panel.tsx
+++ b/apps/desktop/src/renderer/settings-panel.tsx
@@ -718,19 +718,26 @@ function ProviderCredential({
           </label>
           <div className="settings-row">
             <small className="settings-note">
-              {provider.hint}{" "}
-              {/* A button, not an anchor: the renderer has no browser to
-                  navigate, and the main process opens the page by provider
-                  rather than by an address the panel supplies. */}
-              <button
-                type="button"
-                className="link-button"
-                disabled={busy}
-                onClick={() => control.fetchKey()}
-              >
-                Where to get one
-                <ExternalIcon />
-              </button>
+              {provider.hint ? (
+                <>
+                  {provider.hint.lead}{" "}
+                  {/* A button, not an anchor: the renderer has no browser to
+                      navigate, and the main process opens the page by provider
+                      rather than by an address the panel supplies. The link
+                      sits on the destination itself, so the sentence names
+                      the page and opens it with the same words. */}
+                  <button
+                    type="button"
+                    className="link-button"
+                    disabled={busy}
+                    onClick={() => control.fetchKey()}
+                  >
+                    {provider.hint.destination}
+                    <ExternalIcon />
+                  </button>
+                  .{provider.hint.caveat ? ` ${provider.hint.caveat}` : null}
+                </>
+              ) : null}
             </small>
             <span className="settings-actions">
               <button

--- a/apps/desktop/src/renderer/superset-sign-in-slot.test.ts
+++ b/apps/desktop/src/renderer/superset-sign-in-slot.test.ts
@@ -26,7 +26,7 @@ test("the browser stage speaks the key popups' own language", () => {
   assert.match(markup, /key-slot-foot/);
   assert.match(markup, /type="password"/);
   assert.match(markup, /Paste it here/);
-  assert.match(markup, /Where to get one/);
+  assert.match(markup, /its sign-in page/);
   assert.match(markup, /Cancel/);
   assert.match(markup, /Connect</);
   assert.match(markup, /Superset sign-in code/);
@@ -64,7 +64,7 @@ test("the organization switch keeps the one-line dress and asks for no code", ()
   assert.match(markup, /Cancel/);
   assert.doesNotMatch(markup, /Sign-in code/);
   assert.doesNotMatch(markup, /Paste it here/);
-  assert.doesNotMatch(markup, /Where to get one/);
+  assert.doesNotMatch(markup, /its sign-in page/);
 });
 
 test("a bounded failure offers both another sign-in and close", () => {

--- a/apps/desktop/src/renderer/superset-sign-in-slot.tsx
+++ b/apps/desktop/src/renderer/superset-sign-in-slot.tsx
@@ -106,19 +106,21 @@ export function SupersetSignInSlot({
             </div>
             <div className="settings-row key-slot-foot">
               <small className="settings-note">
-                Superset shows a one-time code at the end of its sign-in page.{" "}
+                Superset shows a one-time code at the end of{" "}
                 {/* A button, not an anchor, like the key slot's own: the main
                     process reopens the page the waiting flow built, and no
-                    address crosses from here. */}
+                    address crosses from here. The link sits on the
+                    destination itself, exactly as a key hint's does. */}
                 <button
                   type="button"
                   className="link-button"
                   disabled={exchanging}
                   onClick={onReopen}
                 >
-                  Where to get one
+                  its sign-in page
                   <ExternalIcon />
                 </button>
+                .
               </small>
               <span className="settings-actions">
                 <button type="button" className="quiet-button" onClick={onCancel}>

--- a/apps/desktop/src/renderer/superset-sign-in-slot.tsx
+++ b/apps/desktop/src/renderer/superset-sign-in-slot.tsx
@@ -5,6 +5,7 @@ import { CREDENTIAL_SOURCE } from "#shared/wire/account";
 import type { SupersetSignInSnapshot } from "#shared/wire/session";
 import { SUPERSET_SIGN_IN_STAGE } from "#shared/wire/session";
 import { CREDENTIAL_PLACEHOLDER, useStagedFocus } from "./credential-entry";
+import { DestinationNote } from "./destination-note";
 import { HIT_REGION } from "./panel-state";
 import { ExternalIcon } from "./settings-icons";
 
@@ -105,23 +106,15 @@ export function SupersetSignInSlot({
               />
             </div>
             <div className="settings-row key-slot-foot">
-              <small className="settings-note">
-                Superset shows a one-time code at the end of{" "}
-                {/* A button, not an anchor, like the key slot's own: the main
-                    process reopens the page the waiting flow built, and no
-                    address crosses from here. The link sits on the
-                    destination itself, exactly as a key hint's does. */}
-                <button
-                  type="button"
-                  className="link-button"
-                  disabled={exchanging}
-                  onClick={onReopen}
-                >
-                  its sign-in page
-                  <ExternalIcon />
-                </button>
-                .
-              </small>
+              {/* The key hints' own sentence shape: the main process reopens
+                  the page the waiting flow built, and no address crosses from
+                  here. */}
+              <DestinationNote
+                lead="Superset shows a one-time code at the end of"
+                destination="its sign-in page"
+                disabled={exchanging}
+                onOpen={onReopen}
+              />
               <span className="settings-actions">
                 <button type="button" className="quiet-button" onClick={onCancel}>
                   Cancel

--- a/apps/ios/LukeKit/Sources/LukeKit/VaultClient.swift
+++ b/apps/ios/LukeKit/Sources/LukeKit/VaultClient.swift
@@ -32,19 +32,21 @@ public enum VaultProviderID: String, CaseIterable, Identifiable, Sendable {
     public var keyHint: String {
         switch self {
         case .conductor:
-            "Create a key in Conductor under [Settings · API keys](\(keyPageURL))."
+            "Create a key in Conductor under [Settings > API keys](\(keyPageURL))."
         case .copilot:
-            "Create a GitHub [fine-grained personal access token](\(keyPageURL)) with "
-                + "Agent tasks read access. Classic and installation tokens will not work."
+            "Create a fine-grained personal access token on GitHub under "
+                + "[Settings > Personal access tokens](\(keyPageURL)). Give it Agent tasks "
+                + "read access; classic and installation tokens will not work."
         case .cursor:
-            "Create a key in the Cursor dashboard under [Integrations · API keys](\(keyPageURL))."
+            "Create a key in Cursor under [Dashboard > API Keys](\(keyPageURL))."
         case .devin:
-            "Create one on the [Devin API settings page](\(keyPageURL)), under PATs."
+            "Create a personal access token in Devin under "
+                + "[Settings > Devin API > PATs](\(keyPageURL))."
         case .jules:
-            "Create a key in Jules under [Settings · API key](\(keyPageURL)). "
+            "Create a key in Jules under [Settings > API key](\(keyPageURL)). "
                 + "It is shown only once."
         case .replicas:
-            "Create a key in the Replicas dashboard under [Personal · API keys](\(keyPageURL))."
+            "Create a key in Replicas under [Dashboard > API Keys](\(keyPageURL))."
         }
     }
 
@@ -59,7 +61,7 @@ public enum VaultProviderID: String, CaseIterable, Identifiable, Sendable {
         case .copilot: "https://github.com/settings/personal-access-tokens/new"
         case .cursor: "https://cursor.com/dashboard/api"
         case .devin: "https://app.devin.ai/settings/devin-api?tab=pats"
-        case .jules: "https://jules.google.com/settings"
+        case .jules: "https://jules.google.com/settings/api"
         case .replicas: "https://replicas.dev/dashboard/account/api-keys"
         }
         // swiftlint:disable:next force_unwrapping

--- a/apps/ios/LukeKit/Sources/LukeKit/VaultClient.swift
+++ b/apps/ios/LukeKit/Sources/LukeKit/VaultClient.swift
@@ -43,8 +43,7 @@ public enum VaultProviderID: String, CaseIterable, Identifiable, Sendable {
             "Create a personal access token in Devin under "
                 + "[Settings > Devin API > PATs](\(keyPageURL))."
         case .jules:
-            "Create a key in Jules under [Settings > API key](\(keyPageURL)). "
-                + "It is shown only once."
+            "Create a key in Jules under [Settings > API Key](\(keyPageURL))."
         case .replicas:
             "Create a key in Replicas under [Dashboard > API Keys](\(keyPageURL))."
         }

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -158,7 +158,7 @@ Three categories, and only the first is ever cut:
   after." under a switch reading *Quiet Music and Spotify*. Delete it. If the
   line seems necessary, the label is what to fix.
 - **Instructs.** Tells the developer something they cannot act without.
-  "Create a key in Jules under Settings · API key. It is shown only once."
+  "Create a key in Jules under Settings > API key. It is shown only once."
   Nobody can guess that. Keep it.
 - **Reports state.** This is the row's content. "Version 0.2.0 is available to
   download." Keep it.

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -158,8 +158,8 @@ Three categories, and only the first is ever cut:
   after." under a switch reading *Quiet Music and Spotify*. Delete it. If the
   line seems necessary, the label is what to fix.
 - **Instructs.** Tells the developer something they cannot act without.
-  "Create a key in Jules under Settings > API key. It is shown only once."
-  Nobody can guess that. Keep it.
+  "Talking uses the Realtime API, which needs billing enabled." Nobody can
+  guess that. Keep it.
 - **Reports state.** This is the row's content. "Version 0.2.0 is available to
   download." Keep it.
 

--- a/packages/credentials/src/credential-providers.test.ts
+++ b/packages/credentials/src/credential-providers.test.ts
@@ -111,8 +111,8 @@ test("sends the user to the one GitHub token kind the agent-tasks API answers", 
   // The endpoint takes only user tokens, and GitHub also issues the kinds it
   // refuses, so the copy has to name what to create and what will not work.
   assert.match(copilot.hint.lead, /fine-grained personal access token/i);
-  assert.match(copilot.hint.caveat ?? "", /Agent tasks/);
-  assert.match(copilot.hint.caveat ?? "", /installation/i);
+  assert.match(copilot.hint.trail ?? "", /Agent tasks/);
+  assert.match(copilot.hint.trail ?? "", /installation/i);
   assert.match(copilot.apiKeysUrl, /personal-access-tokens\/new$/);
   // No key format: fine-grained PATs and GitHub App user tokens carry
   // different prefixes, and a single one would refuse a working credential.
@@ -173,8 +173,8 @@ test("holds the key Luke speaks through, apart from the agents he observes", () 
   // Realtime is what a spoken turn runs on, and an account that cannot reach it
   // fails at the first word rather than at the paste.
   assert.ok(openai.hint);
-  assert.match(openai.hint.caveat ?? "", /Realtime/);
-  assert.match(openai.hint.caveat ?? "", /billing/i);
+  assert.match(openai.hint.trail ?? "", /Realtime/);
+  assert.match(openai.hint.trail ?? "", /billing/i);
   // No prefix: every kind OpenAI issues carries `sk-`, so a format would refuse
   // nothing a working key would not also be refused by.
   assert.equal(openai.keyFormat, undefined);

--- a/packages/credentials/src/credential-providers.test.ts
+++ b/packages/credentials/src/credential-providers.test.ts
@@ -36,6 +36,12 @@ test("describes every provider it lists", () => {
     if (provider.connection === CREDENTIAL_CONNECTION.KEY) {
       assert.ok(provider.hint, provider.id);
       assert.ok(provider.apiKeysUrl, provider.id);
+      // One sentence shape for every key: what to create and where, ending on
+      // the destination the link sits on, named as a ">" path with no closing
+      // punctuation of its own — the renderer supplies the full stop.
+      assert.match(provider.hint.lead, /^Create a .+ under$/, provider.id);
+      assert.ok(provider.hint.destination.length > 0, provider.id);
+      assert.doesNotMatch(provider.hint.destination, /[.·]/, provider.id);
     } else {
       assert.equal(provider.hint, undefined, provider.id);
       assert.equal(provider.apiKeysUrl, undefined, provider.id);
@@ -104,9 +110,9 @@ test("sends the user to the one GitHub token kind the agent-tasks API answers", 
   assert.ok(copilot.apiKeysUrl);
   // The endpoint takes only user tokens, and GitHub also issues the kinds it
   // refuses, so the copy has to name what to create and what will not work.
-  assert.match(copilot.hint, /fine-grained personal access token/i);
-  assert.match(copilot.hint, /Agent tasks/);
-  assert.match(copilot.hint, /installation/i);
+  assert.match(copilot.hint.lead, /fine-grained personal access token/i);
+  assert.match(copilot.hint.caveat ?? "", /Agent tasks/);
+  assert.match(copilot.hint.caveat ?? "", /installation/i);
   assert.match(copilot.apiKeysUrl, /personal-access-tokens\/new$/);
   // No key format: fine-grained PATs and GitHub App user tokens carry
   // different prefixes, and a single one would refuse a working credential.
@@ -122,7 +128,7 @@ test("takes only the Devin credentials its API version issues", () => {
   // deprecated v1 and v2 keys carry another and would only ever be refused.
   assert.equal(devin.keyFormat?.prefix, "cog_");
   // Devin calls this a personal access token, and the settings field has to
-  // call it that too: its Settings · API keys page issues the `apk_` keys Luke
+  // call it that too: its Settings > API keys page issues the `apk_` keys Luke
   // refuses, so asking for an "API key" would send the user to the wrong one.
   assert.equal(devin.keyFormat?.label, "Personal access token");
   assert.ok(devin.apiKeysUrl);
@@ -167,8 +173,8 @@ test("holds the key Luke speaks through, apart from the agents he observes", () 
   // Realtime is what a spoken turn runs on, and an account that cannot reach it
   // fails at the first word rather than at the paste.
   assert.ok(openai.hint);
-  assert.match(openai.hint, /Realtime/);
-  assert.match(openai.hint, /billing/i);
+  assert.match(openai.hint.caveat ?? "", /Realtime/);
+  assert.match(openai.hint.caveat ?? "", /billing/i);
   // No prefix: every kind OpenAI issues carries `sk-`, so a format would refuse
   // nothing a working key would not also be refused by.
   assert.equal(openai.keyFormat, undefined);

--- a/packages/credentials/src/credential-providers.ts
+++ b/packages/credentials/src/credential-providers.ts
@@ -99,7 +99,7 @@ export interface CredentialFormat {
 /**
  * Where the user creates a key, said the same way for every provider: the
  * lead, then the destination drawn as the link that opens the provider's key
- * page, then a full stop and the caveat if there is one. Structured rather
+ * page, then a full stop and the trail if there is one. Structured rather
  * than one string so the link can sit on the destination itself instead of
  * beside the sentence.
  */
@@ -113,7 +113,7 @@ export interface CredentialHint {
    */
   destination: string;
   /** A sentence after the link, only where the page alone can still go wrong. */
-  caveat?: string;
+  trail?: string;
 }
 
 export interface CredentialProvider {
@@ -169,7 +169,7 @@ export const CREDENTIAL_PROVIDERS: CredentialProviderRegistry = {
     hint: {
       lead: "Create a fine-grained personal access token on GitHub under",
       destination: "Settings > Personal access tokens",
-      caveat: "Give it Agent tasks read access; classic and installation tokens will not work.",
+      trail: "Give it Agent tasks read access; classic and installation tokens will not work.",
     },
     apiKeysUrl: "https://github.com/settings/personal-access-tokens/new",
     environmentVariables: [COPILOT_ENVIRONMENT.API_KEY],
@@ -216,12 +216,7 @@ export const CREDENTIAL_PROVIDERS: CredentialProviderRegistry = {
     id: CREDENTIAL_PROVIDER_ID.JULES,
     connection: CREDENTIAL_CONNECTION.KEY,
     displayName: PROVIDER_IDENTITY_BY_ID[PROVIDER_ID.JULES].displayName,
-    // Jules shows a key once, on creation, and allows at most three at a time.
-    hint: {
-      lead: "Create a key in Jules under",
-      destination: "Settings > API key",
-      caveat: "It is shown only once.",
-    },
+    hint: { lead: "Create a key in Jules under", destination: "Settings > API Key" },
     apiKeysUrl: "https://jules.google.com/settings/api",
     environmentVariables: [JULES_ENVIRONMENT.API_KEY],
   },
@@ -255,7 +250,7 @@ export const CREDENTIAL_PROVIDERS: CredentialProviderRegistry = {
     hint: {
       lead: "Create a key on the OpenAI platform under",
       destination: "API keys",
-      caveat: "Talking uses the Realtime API, which needs billing enabled.",
+      trail: "Talking uses the Realtime API, which needs billing enabled.",
     },
     apiKeysUrl: "https://platform.openai.com/api-keys",
     // Deliberately no environment fallback, alone among the providers: an

--- a/packages/credentials/src/credential-providers.ts
+++ b/packages/credentials/src/credential-providers.ts
@@ -96,6 +96,26 @@ export interface CredentialFormat {
   rejection: string;
 }
 
+/**
+ * Where the user creates a key, said the same way for every provider: the
+ * lead, then the destination drawn as the link that opens the provider's key
+ * page, then a full stop and the caveat if there is one. Structured rather
+ * than one string so the link can sit on the destination itself instead of
+ * beside the sentence.
+ */
+export interface CredentialHint {
+  /** The sentence up to the linked words: "Create a key in Jules under". */
+  lead: string;
+  /**
+   * The linked words: the path to the key page, named the way the provider's
+   * own site names it, with ">" between the steps. Pressing them opens
+   * {@link CredentialProvider.apiKeysUrl}.
+   */
+  destination: string;
+  /** A sentence after the link, only where the page alone can still go wrong. */
+  caveat?: string;
+}
+
 export interface CredentialProvider {
   id: CredentialProviderId;
   displayName: string;
@@ -106,7 +126,7 @@ export interface CredentialProvider {
    * for a provider connected by consent: there is no editor to say it in, and
    * nothing for the user to go and fetch.
    */
-  hint?: string;
+  hint?: CredentialHint;
   /**
    * The page that issues this provider's keys. It is opened by provider id
    * rather than by a URL the renderer supplies, so the only addresses Luke can
@@ -134,7 +154,7 @@ export const CREDENTIAL_PROVIDERS: CredentialProviderRegistry = {
     id: CREDENTIAL_PROVIDER_ID.CONDUCTOR,
     connection: CREDENTIAL_CONNECTION.KEY,
     displayName: PROVIDER_IDENTITY_BY_ID[PROVIDER_ID.CONDUCTOR].displayName,
-    hint: "Create a key in Conductor under Settings · API keys.",
+    hint: { lead: "Create a key in Conductor under", destination: "Settings > API keys" },
     apiKeysUrl: "https://app.conductor.build/users/api-keys",
     environmentVariables: [CONDUCTOR_ENVIRONMENT.API_KEY, CONDUCTOR_ENVIRONMENT.API_TOKEN],
   },
@@ -146,7 +166,11 @@ export const CREDENTIAL_PROVIDERS: CredentialProviderRegistry = {
     // the kind to create because the wrong kinds also come from GitHub: a
     // classic PAT cannot carry the Agent tasks permission, and an installation
     // token is refused by the endpoint itself.
-    hint: "Create a GitHub fine-grained personal access token with Agent tasks read access. Classic and installation tokens will not work.",
+    hint: {
+      lead: "Create a fine-grained personal access token on GitHub under",
+      destination: "Settings > Personal access tokens",
+      caveat: "Give it Agent tasks read access; classic and installation tokens will not work.",
+    },
     apiKeysUrl: "https://github.com/settings/personal-access-tokens/new",
     environmentVariables: [COPILOT_ENVIRONMENT.API_KEY],
     // No key format: Luke accepts two kinds GitHub issues — fine-grained
@@ -157,7 +181,10 @@ export const CREDENTIAL_PROVIDERS: CredentialProviderRegistry = {
     id: CREDENTIAL_PROVIDER_ID.CURSOR,
     connection: CREDENTIAL_CONNECTION.KEY,
     displayName: PROVIDER_IDENTITY_BY_ID[PROVIDER_ID.CURSOR].displayName,
-    hint: "Create a key in the Cursor dashboard under Integrations · API keys.",
+    hint: {
+      lead: "Create a key in Cursor under",
+      destination: "Dashboard > Integrations > API keys",
+    },
     apiKeysUrl: "https://cursor.com/dashboard/api",
     environmentVariables: [CURSOR_ENVIRONMENT.API_KEY],
   },
@@ -165,8 +192,11 @@ export const CREDENTIAL_PROVIDERS: CredentialProviderRegistry = {
     id: CREDENTIAL_PROVIDER_ID.DEVIN,
     connection: CREDENTIAL_CONNECTION.KEY,
     displayName: PROVIDER_IDENTITY_BY_ID[PROVIDER_ID.DEVIN].displayName,
-    hint: "Create one on the Devin API settings page, under PATs.",
-    // Not the Settings · API keys page, which issues the deprecated `apk_`
+    hint: {
+      lead: "Create a personal access token in Devin under",
+      destination: "Settings > Devin's API > PATs",
+    },
+    // Not the Settings > API keys page, which issues the deprecated `apk_`
     // keys Luke refuses. Personal access tokens live on their own tab.
     apiKeysUrl: "https://app.devin.ai/settings/devin-api?tab=pats",
     environmentVariables: [DEVIN_ENVIRONMENT.API_KEY],
@@ -190,7 +220,11 @@ export const CREDENTIAL_PROVIDERS: CredentialProviderRegistry = {
     connection: CREDENTIAL_CONNECTION.KEY,
     displayName: PROVIDER_IDENTITY_BY_ID[PROVIDER_ID.JULES].displayName,
     // Jules shows a key once, on creation, and allows at most three at a time.
-    hint: "Create a key in Jules under Settings · API key. It is shown only once.",
+    hint: {
+      lead: "Create a key in Jules under",
+      destination: "Settings > API key",
+      caveat: "It is shown only once.",
+    },
     apiKeysUrl: "https://jules.google.com/settings",
     environmentVariables: [JULES_ENVIRONMENT.API_KEY],
   },
@@ -221,7 +255,11 @@ export const CREDENTIAL_PROVIDERS: CredentialProviderRegistry = {
     // Realtime is what a spoken turn runs on, and an account that cannot reach
     // it fails at the first word rather than at the paste — so the line says so
     // before the key is entered rather than after.
-    hint: "Create a key on the OpenAI platform under API keys. Talking uses the Realtime API, which needs billing enabled.",
+    hint: {
+      lead: "Create a key on the OpenAI platform under",
+      destination: "API keys",
+      caveat: "Talking uses the Realtime API, which needs billing enabled.",
+    },
     apiKeysUrl: "https://platform.openai.com/api-keys",
     // Deliberately no environment fallback, alone among the providers: an
     // `OPENAI_API_KEY` exported for some other tool would silently start
@@ -239,7 +277,10 @@ export const CREDENTIAL_PROVIDERS: CredentialProviderRegistry = {
     displayName: PROVIDER_IDENTITY_BY_ID[PROVIDER_ID.REPLICAS].displayName,
     // Replicas issues organization keys and personal keys, and its API takes
     // either; the personal page is the one every member can reach.
-    hint: "Create a key in the Replicas dashboard under Personal · API keys.",
+    hint: {
+      lead: "Create a key in Replicas under",
+      destination: "Dashboard > Personal > API keys",
+    },
     apiKeysUrl: "https://replicas.dev/dashboard/account/api-keys",
     environmentVariables: [REPLICAS_ENVIRONMENT.API_KEY],
     // No key format: Replicas publishes none, so a prefix could only refuse a

--- a/packages/credentials/src/credential-providers.ts
+++ b/packages/credentials/src/credential-providers.ts
@@ -181,10 +181,7 @@ export const CREDENTIAL_PROVIDERS: CredentialProviderRegistry = {
     id: CREDENTIAL_PROVIDER_ID.CURSOR,
     connection: CREDENTIAL_CONNECTION.KEY,
     displayName: PROVIDER_IDENTITY_BY_ID[PROVIDER_ID.CURSOR].displayName,
-    hint: {
-      lead: "Create a key in Cursor under",
-      destination: "Dashboard > Integrations > API keys",
-    },
+    hint: { lead: "Create a key in Cursor under", destination: "Dashboard > API Keys" },
     apiKeysUrl: "https://cursor.com/dashboard/api",
     environmentVariables: [CURSOR_ENVIRONMENT.API_KEY],
   },
@@ -194,7 +191,7 @@ export const CREDENTIAL_PROVIDERS: CredentialProviderRegistry = {
     displayName: PROVIDER_IDENTITY_BY_ID[PROVIDER_ID.DEVIN].displayName,
     hint: {
       lead: "Create a personal access token in Devin under",
-      destination: "Settings > Devin's API > PATs",
+      destination: "Settings > Devin API > PATs",
     },
     // Not the Settings > API keys page, which issues the deprecated `apk_`
     // keys Luke refuses. Personal access tokens live on their own tab.
@@ -225,7 +222,7 @@ export const CREDENTIAL_PROVIDERS: CredentialProviderRegistry = {
       destination: "Settings > API key",
       caveat: "It is shown only once.",
     },
-    apiKeysUrl: "https://jules.google.com/settings",
+    apiKeysUrl: "https://jules.google.com/settings/api",
     environmentVariables: [JULES_ENVIRONMENT.API_KEY],
   },
   [CREDENTIAL_PROVIDER_ID.LINEAR]: {
@@ -277,10 +274,7 @@ export const CREDENTIAL_PROVIDERS: CredentialProviderRegistry = {
     displayName: PROVIDER_IDENTITY_BY_ID[PROVIDER_ID.REPLICAS].displayName,
     // Replicas issues organization keys and personal keys, and its API takes
     // either; the personal page is the one every member can reach.
-    hint: {
-      lead: "Create a key in Replicas under",
-      destination: "Dashboard > Personal > API keys",
-    },
+    hint: { lead: "Create a key in Replicas under", destination: "Dashboard > API Keys" },
     apiKeysUrl: "https://replicas.dev/dashboard/account/api-keys",
     environmentVariables: [REPLICAS_ENVIRONMENT.API_KEY],
     // No key format: Replicas publishes none, so a prefix could only refuse a


### PR DESCRIPTION
## Summary

- Every provider's key hint now says the same sentence — what to create and where, ending on the destination path drawn as the link that opens the provider's key page — replacing the separate "Where to get one" button in the settings editor and the key slot.
- Paths use ">" between steps in the provider's own naming: Conductor "Settings > API keys", Cursor and Replicas "Dashboard > API Keys", Devin "Settings > Devin API > PATs", Jules "Settings > API Key" (its key page corrected to jules.google.com/settings/api). Warnings the page cannot carry (Copilot's token kind, OpenAI's Realtime billing) stay as a trailing sentence after the link; Jules's shown-once note goes, since the page says it itself at creation.
- `hint` becomes a structured `CredentialHint` (`lead`, `destination`, `trail?`) in `packages/credentials`, with a registry test holding every key provider to the one sentence shape.
- The three copies of the sentence-with-linked-destination rendering (settings editor, key slot, Superset code slot) fold into one `DestinationNote` component; the Superset note keeps its own words with the link on "its sign-in page".
- The iOS vault editor's mirrored hints in `LukeKit` say the same words, and `PRIVACY.md`/`docs/DESIGN.md` follow the ">" path style.

## Evidence

- Platform-independent checks: `./scripts/check.sh` passed (exit 0, all tests green)
- macOS Electron verification (`./scripts/verify.sh`): `not run locally (Linux workspace); relying on CI`

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/33449873139/artifacts/9779432450) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/33449873139)

- Commit: `3e0c73a7a4b877ff19e3099f69fb8a1f1b1c152e`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

### Physical-device evidence

- Screenshot or screen recording: `not attached`
- Physical-notch check: `not performed` (copy-only change inside the settings editor and key slot)
- Device/display configuration: `not recorded`

## Notes

- Blockers or follow-up verification: CI does not build `apps/ios`; its hint strings follow the file's existing style and its wording tests are shape-based.

🤖 Generated with [Claude Code](https://claude.com/claude-code)