### PR TITLE
feat(ios): move sign out into the header avatar menu

### DIFF
--- a/apps/ios/Luke/ContentView.swift
+++ b/apps/ios/Luke/ContentView.swift
@@ -42,7 +42,7 @@ struct ContentView: View {
         case .signedOut:
             signedOutCard
         case .signedIn(let identity):
-            signedInCard(identity: identity)
+            SignedInView(identity: identity)
         }
     }
 
@@ -101,53 +101,6 @@ struct ContentView: View {
         }
     }
 
-    // MARK: - Signed-in card
-
-    private func signedInCard(identity: AccountIdentity) -> some View {
-        ZStack {
-            Color.ground.ignoresSafeArea()
-            ScrollView {
-                VStack(spacing: 16) {
-                    VStack(spacing: 12) {
-                        Text(identity.name ?? identity.email)
-                            .font(.system(size: 22, weight: .semibold))
-                            .foregroundStyle(Color.ink)
-                        Text(identity.email)
-                            .font(.subheadline)
-                            .foregroundStyle(Color.inkSecondary)
-                        if !session.credentialsPersisted {
-                            Text("This device is not saving the sign-in, so the next launch will ask again.")
-                                .font(.caption)
-                                .multilineTextAlignment(.center)
-                                .foregroundStyle(Color.warningInk)
-                        }
-                        Button("Sign out") {
-                            Task { await session.signOut() }
-                        }
-                        .buttonStyle(CardButtonStyle())
-                        .padding(.top, 8)
-                    }
-                    .frame(maxWidth: .infinity)
-                    .padding(40)
-                    .background(
-                        RoundedRectangle(cornerRadius: 10)
-                            .fill(Color.cardFill)
-                            .overlay(
-                                RoundedRectangle(cornerRadius: 10)
-                                    .stroke(Color.cardStroke, lineWidth: 1)
-                            )
-                    )
-
-                    // Keyed by account so a different sign-in loads its own
-                    // list rather than standing on the last account's.
-                    VaultSection()
-                        .id(identity.email)
-                }
-                .padding(24)
-            }
-        }
-    }
-
     // MARK: - Sign-in flow
 
     private func startSignIn(provider: SocialProvider) {
@@ -200,6 +153,234 @@ struct ContentView: View {
         webSession.presentationContextProvider = contextProvider
         webSession.prefersEphemeralWebBrowserSession = false
         webSession.start()
+    }
+}
+
+// MARK: - Signed-in view
+
+/// Its own struct so `profileShown` lives and dies with the signed-in
+/// hierarchy: a sign-out tears the flag down with the view, and the next
+/// sign-in starts with the sheet closed rather than inheriting a stale true.
+private struct SignedInView: View {
+    @Environment(AccountSession.self) private var session
+    let identity: AccountIdentity
+    @State private var profileShown = false
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(spacing: 16) {
+                    if !session.credentialsPersisted {
+                        persistenceNotice
+                    }
+                }
+                // Stretched to the proposal, or the scroll view adopts its
+                // content's ideal width and draws as a strip up the middle.
+                .frame(maxWidth: .infinity)
+                .padding(24)
+            }
+            .background(Color.ground.ignoresSafeArea())
+            .toolbar {
+                if #available(iOS 26.0, *) {
+                    ToolbarItem(placement: .topBarLeading) {
+                        profileButton
+                    }
+                    // Separated from the bar's shared glass, which hugs an
+                    // item as a capsule: the avatar's own circle is the
+                    // whole control.
+                    .sharedBackgroundVisibility(.hidden)
+                } else {
+                    ToolbarItem(placement: .topBarLeading) {
+                        profileButton
+                    }
+                }
+            }
+        }
+        .sheet(isPresented: $profileShown) {
+            ProfileSheet(identity: identity)
+        }
+    }
+
+    private var profileButton: some View {
+        Button {
+            profileShown = true
+        } label: {
+            avatarLabel
+        }
+        // Plain, not the toolbar's bordered default: with the shared
+        // background hidden the bordered style still insets its label to
+        // where the capsule's content would sit, holding the circle off the
+        // bar margin the system's own circles start at.
+        .buttonStyle(.plain)
+        .accessibilityLabel("Account profile for \(identity.name ?? identity.email)")
+    }
+
+    /// The avatar in its own circular glass: the shared toolbar background is
+    /// hidden because it hugs an item as a capsule, and this puts back the
+    /// system material in the circle the photo actually is. The label fills
+    /// the bar's own 44pt control size — anything smaller gets centered in
+    /// the item's minimum slot and sits visibly right of where the system's
+    /// circles sit.
+    @ViewBuilder
+    private var avatarLabel: some View {
+        if #available(iOS 26.0, *) {
+            AccountAvatar(identity: identity, diameter: 36)
+                .padding(4)
+                .glassEffect(.regular.interactive(), in: Circle())
+        } else {
+            AccountAvatar(identity: identity, diameter: 36)
+                .padding(4)
+        }
+    }
+
+    private var persistenceNotice: some View {
+        Text("This device is not saving the sign-in, so the next launch will ask again.")
+            .font(.caption)
+            .multilineTextAlignment(.center)
+            .foregroundStyle(Color.warningInk)
+            .frame(maxWidth: .infinity)
+            .padding(16)
+            .background(
+                RoundedRectangle(cornerRadius: 10)
+                    .fill(Color.cardFill)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 10)
+                            .stroke(Color.cardStroke, lineWidth: 1)
+                    )
+            )
+    }
+}
+
+// MARK: - Profile sheet
+
+/// The account surface the header avatar opens, drawn with the system's own
+/// sheet vocabulary — inline title, close button, grouped list: the photo
+/// large at the top center, the account it belongs to, the provider keys,
+/// and at the very bottom the one account act, signing out, over the build's
+/// own version.
+private struct ProfileSheet: View {
+    @Environment(AccountSession.self) private var session
+    @Environment(VaultStore.self) private var vault
+    @Environment(\.dismiss) private var dismiss
+    let identity: AccountIdentity
+    @State private var editingProvider: VaultProviderID?
+
+    var body: some View {
+        NavigationStack {
+            List {
+                Section {
+                    VStack(spacing: 12) {
+                        AccountAvatar(identity: identity, diameter: 88)
+                        VStack(spacing: 2) {
+                            Text(identity.name ?? identity.email)
+                                .font(.title2.weight(.semibold))
+                            if identity.name != nil {
+                                Text(identity.email)
+                                    .font(.subheadline)
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                    }
+                    .frame(maxWidth: .infinity)
+                    .listRowBackground(Color.clear)
+                }
+
+                if !session.credentialsPersisted {
+                    Section {
+                        Text("This device is not saving the sign-in, so the next launch will ask again.")
+                            .font(.footnote)
+                            .foregroundStyle(Color.warningInk)
+                    }
+                }
+
+                VaultSection(editing: $editingProvider)
+
+                Section {
+                    Button("Sign out", role: .destructive) {
+                        Task { await session.signOut() }
+                    }
+                    .frame(maxWidth: .infinity)
+                } footer: {
+                    Text(Self.versionLabel)
+                        .frame(maxWidth: .infinity)
+                        .padding(.top, 8)
+                }
+            }
+            .navigationTitle("Profile")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    closeButton
+                }
+            }
+            // Keyed by account so a different sign-in loads its own list
+            // rather than standing on the last account's.
+            .task(id: identity.email) { await vault.load() }
+            .sheet(item: $editingProvider) { provider in
+                VaultKeyEditor(provider: provider)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var closeButton: some View {
+        if #available(iOS 26.0, *) {
+            Button(role: .close) { dismiss() }
+        } else {
+            Button { dismiss() } label: {
+                Image(systemName: "xmark")
+            }
+            .accessibilityLabel("Close")
+        }
+    }
+
+    private static let versionLabel: String = {
+        let version = Bundle.main
+            .object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String
+        return version.map { "Luke v\($0)" } ?? "Luke"
+    }()
+}
+
+// MARK: - Avatar
+
+/// The account's own avatar, falling back to its initials. A provider's
+/// avatar URL can outlive the image it named, so a failed fetch draws the
+/// letters rather than leaving a broken frame.
+private struct AccountAvatar: View {
+    let identity: AccountIdentity
+    let diameter: CGFloat
+
+    var body: some View {
+        Group {
+            if let url = identity.pictureURL {
+                AsyncImage(url: url) { phase in
+                    if let image = phase.image {
+                        image.resizable().scaledToFill()
+                    } else {
+                        initialsCircle
+                    }
+                }
+            } else {
+                initialsCircle
+            }
+        }
+        .frame(width: diameter, height: diameter)
+        .clipShape(Circle())
+    }
+
+    private var initialsCircle: some View {
+        ZStack {
+            Circle().fill(Color.ink.opacity(0.12))
+            if let initials = identity.initials {
+                Text(initials)
+                    .font(.system(size: diameter * 0.4, weight: .semibold))
+                    .foregroundStyle(Color.ink)
+            } else {
+                Image(systemName: "person.fill")
+                    .font(.system(size: diameter * 0.44))
+                    .foregroundStyle(Color.inkSecondary)
+            }
+        }
     }
 }
 

--- a/apps/ios/Luke/VaultView.swift
+++ b/apps/ios/Luke/VaultView.swift
@@ -3,66 +3,41 @@ import SwiftUI
 
 // MARK: - Provider keys section
 
-/// The vault card on the signed-in screen: one row per provider the vault
-/// accepts, each opening an editor to enter or delete that provider's key.
-/// Only presence and timestamps are drawn — the vault never answers a key,
-/// nor any fragment of one.
+/// The provider-keys section of the profile sheet's grouped list: one row per
+/// provider the vault accepts, each opening an editor to enter or delete that
+/// provider's key. Only presence and timestamps are drawn — the vault never
+/// answers a key, nor any fragment of one. The editor selection is the
+/// sheet's, because a `Section` cannot carry presentation modifiers of its
+/// own inside a `List`.
 struct VaultSection: View {
     @Environment(VaultStore.self) private var vault
-    @State private var editing: VaultProviderID?
+    @Binding var editing: VaultProviderID?
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            Text("Provider keys")
-                .font(.system(size: 17, weight: .semibold))
-                .foregroundStyle(Color.ink)
-            Text("Stored encrypted in your Luke account so Luke can observe these providers' cloud sessions.")
-                .font(.caption)
-                .foregroundStyle(Color.inkSecondary)
-                .padding(.top, 4)
-
+        Section {
             if let error = vault.loadError {
-                Text(error)
-                    .font(.caption)
-                    .foregroundStyle(Color.errorInk)
-                    .padding(.top, 12)
-                Button("Try again") {
-                    Task { await vault.load() }
-                }
-                .font(.caption.weight(.semibold))
-                .foregroundStyle(Color.ink)
-                .padding(.top, 8)
-            }
-
-            VStack(spacing: 0) {
-                ForEach(VaultProviderID.allCases) { provider in
-                    Button {
-                        editing = provider
-                    } label: {
-                        VaultProviderRow(provider: provider, entry: vault.entry(for: provider))
+                VStack(alignment: .leading, spacing: 8) {
+                    Text(error)
+                        .font(.footnote)
+                        .foregroundStyle(Color.errorInk)
+                    Button("Try again") {
+                        Task { await vault.load() }
                     }
-                    .buttonStyle(.plain)
-                    if provider != VaultProviderID.allCases.last {
-                        Divider().overlay(Color.cardStroke)
-                    }
+                    .font(.footnote.weight(.semibold))
                 }
             }
-            .padding(.top, 16)
-            .redacted(reason: vault.isLoading ? .placeholder : [])
-        }
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .padding(20)
-        .background(
-            RoundedRectangle(cornerRadius: 10)
-                .fill(Color.cardFill)
-                .overlay(
-                    RoundedRectangle(cornerRadius: 10)
-                        .stroke(Color.cardStroke, lineWidth: 1)
-                )
-        )
-        .task { await vault.load() }
-        .sheet(item: $editing) { provider in
-            VaultKeyEditor(provider: provider)
+            ForEach(VaultProviderID.allCases) { provider in
+                Button {
+                    editing = provider
+                } label: {
+                    VaultProviderRow(provider: provider, entry: vault.entry(for: provider))
+                }
+                .redacted(reason: vault.isLoading ? .placeholder : [])
+            }
+        } header: {
+            Text("Provider keys")
+        } footer: {
+            Text("Stored encrypted in your Luke account so Luke can observe these providers' cloud sessions.")
         }
     }
 }
@@ -74,23 +49,23 @@ private struct VaultProviderRow: View {
     let entry: VaultKeyEntry?
 
     var body: some View {
-        HStack(spacing: 8) {
+        HStack(spacing: 12) {
             ProviderMark(provider: provider)
                 .frame(width: 18, height: 18)
+            // The concrete label colors, not the hierarchical styles: inside
+            // a list button the inherited foreground style is the tint, and
+            // hierarchical .primary would keep the row's words accent-blue.
             Text(provider.displayName)
-                .font(.system(size: 15, weight: .medium))
-                .foregroundStyle(Color.ink)
+                .foregroundStyle(Color.primary)
             if entry != nil {
                 ConnectedCheck()
                     .frame(width: 12, height: 12)
             }
             Spacer()
             Image(systemName: "chevron.right")
-                .font(.system(size: 11, weight: .semibold))
-                .foregroundStyle(Color.inkTertiary)
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundStyle(Color.secondary)
         }
-        .padding(.vertical, 12)
-        .contentShape(Rectangle())
     }
 }
 
@@ -116,7 +91,7 @@ private struct ConnectedCheck: View {
 /// The sheet a row opens: paste a key to store or replace, or delete the one
 /// standing. The field is the one place a key ever appears, and it is never
 /// echoed back after Save.
-private struct VaultKeyEditor: View {
+struct VaultKeyEditor: View {
     @Environment(VaultStore.self) private var vault
     @Environment(\.dismiss) private var dismiss
     let provider: VaultProviderID

--- a/apps/ios/LukeKit/Sources/LukeKit/AccountClient.swift
+++ b/apps/ios/LukeKit/Sources/LukeKit/AccountClient.swift
@@ -33,11 +33,55 @@ public struct AccountIdentity: Sendable {
     public let id: String?
     public let email: String
     public let name: String?
+    public let pictureURL: URL?
 
-    public init(id: String?, email: String, name: String?) {
+    public init(id: String?, email: String, name: String?, pictureURL: URL? = nil) {
         self.id = id
         self.email = email
         self.name = name
+        self.pictureURL = pictureURL
+    }
+}
+
+extension AccountIdentity {
+    /// The only hosts an avatar may be loaded from, mirroring the desktop
+    /// account client's picture policy exactly: Google serves profile photos
+    /// from `googleusercontent.com` and GitHub from
+    /// `avatars.githubusercontent.com`. A picture anywhere else is dropped
+    /// rather than fetched — and the set is fixed by this build, like every
+    /// address the surface is given.
+    public static func pictureURL(fromWire value: String?) -> URL? {
+        guard let value, !value.isEmpty,
+              let url = URL(string: value),
+              url.scheme == "https",
+              let host = url.host
+        else { return nil }
+        let googleHosted = host == "googleusercontent.com"
+            || host.hasSuffix(".googleusercontent.com")
+        return googleHosted || host == "avatars.githubusercontent.com" ? url : nil
+    }
+
+    /// The account drawn as letters when it has no avatar image, mirroring the
+    /// web dashboard's fallback: the provider's own name for the account is
+    /// the first source, and an account that carries only an address falls
+    /// back to the local part, which is all such an account ever has to be
+    /// named by.
+    public var initials: String? {
+        Self.initials(from: name ?? "")
+            ?? Self.initials(from: email.components(separatedBy: "@").first ?? "")
+    }
+
+    private static let wordSeparators = CharacterSet(charactersIn: "._+-")
+        .union(.whitespacesAndNewlines)
+
+    private static func initials(from source: String) -> String? {
+        let words = source.components(separatedBy: wordSeparators).filter { !$0.isEmpty }
+        guard let first = words.first?.first else { return nil }
+        var letters = String(first).localizedUppercase
+        if words.count > 1, let last = words.last?.first {
+            letters += String(last).localizedUppercase
+        }
+        return letters
     }
 }
 
@@ -126,7 +170,8 @@ public final class AccountClient: Sendable {
         return AccountIdentity(
             id: json["sub"] as? String,
             email: email,
-            name: json["name"] as? String
+            name: json["name"] as? String,
+            pictureURL: AccountIdentity.pictureURL(fromWire: json["picture"] as? String)
         )
     }
 

--- a/apps/ios/LukeKit/Sources/LukeKit/AccountSession.swift
+++ b/apps/ios/LukeKit/Sources/LukeKit/AccountSession.swift
@@ -16,6 +16,7 @@ public enum AuthState: Equatable {
         case (.signedOut, .signedOut): return true
         case let (.signedIn(a), .signedIn(b)):
             return a.email == b.email && a.id == b.id && a.name == b.name
+                && a.pictureURL == b.pictureURL
         default: return false
         }
     }
@@ -157,29 +158,42 @@ public final class AccountSession {
         let identity = AccountIdentity(
             id: KeychainStore.get(.accountID),
             email: email,
-            name: KeychainStore.get(.name)
+            name: KeychainStore.get(.name),
+            // Re-validated on the way out of the keychain so a stored value
+            // is never trusted past the same host policy userinfo applies.
+            pictureURL: AccountIdentity.pictureURL(fromWire: KeychainStore.get(.pictureURL))
         )
         state = .signedIn(identity)
         let gen = generation
         Task { [weak self] in
             guard let self else { return }
-            await self.refreshIfNearExpiry(generation: gen)
+            await self.resolveRestoredIdentity(generation: gen)
         }
     }
 
-    private func refreshIfNearExpiry(generation: Int) async {
-        guard tokenIsNearExpiry else { return }
+    /// Re-resolves the identity from userinfo on every restore — refreshing
+    /// the token first when it is near expiry — so a field the keychain never
+    /// held (a photo added since the sign-in that stored it) arrives without
+    /// waiting for the token to age.
+    private func resolveRestoredIdentity(generation: Int) async {
         do {
-            let tokens = try await refreshStoredTokens()
+            let token: String
+            if tokenIsNearExpiry {
+                token = try await refreshStoredTokens().accessToken
+            } else if let accessToken {
+                token = accessToken
+            } else {
+                return
+            }
             guard self.generation == generation else { return }
-            let identity = try await client.userInfo(accessToken: tokens.accessToken)
+            let identity = try await resolvedIdentity(accessToken: token)
             guard self.generation == generation else { return }
             storeIdentity(identity)
             state = .signedIn(identity)
         } catch {
             // A rejected refresh has already signed out inside performRefresh;
             // anything else is transient (network error, rate limit, etc.) and
-            // the stored tokens may still work.
+            // the stored identity still stands.
         }
     }
 
@@ -206,12 +220,19 @@ public final class AccountSession {
     }
 
     private func storeIdentity(_ identity: AccountIdentity) {
-        // The email gates restore like the tokens do; the id and name are
-        // cosmetic, so their persistence does not decide the flag.
+        // The email gates restore like the tokens do; the id, name, and
+        // picture are cosmetic, so their persistence does not decide the flag.
         let emailPersisted = KeychainStore.set(identity.email, for: .email)
         credentialsPersisted = credentialsPersisted && emailPersisted
         if let id = identity.id { KeychainStore.set(id, for: .accountID) }
         if let name = identity.name { KeychainStore.set(name, for: .name) }
+        // Deleted when absent so a photo removed at the provider does not
+        // outlive the provider's own answer.
+        if let picture = identity.pictureURL {
+            KeychainStore.set(picture.absoluteString, for: .pictureURL)
+        } else {
+            KeychainStore.delete(.pictureURL)
+        }
     }
 }
 

--- a/apps/ios/LukeKit/Sources/LukeKit/KeychainStore.swift
+++ b/apps/ios/LukeKit/Sources/LukeKit/KeychainStore.swift
@@ -12,6 +12,7 @@ enum KeychainStore {
         case email
         case name
         case accountID = "account_id"
+        case pictureURL = "picture_url"
     }
 
     /// Returns whether the write landed. A keychain can refuse writes outright
@@ -42,7 +43,7 @@ enum KeychainStore {
     }
 
     static func clearAll() {
-        for key in [Key.accessToken, .refreshToken, .expiry, .email, .name, .accountID] {
+        for key in [Key.accessToken, .refreshToken, .expiry, .email, .name, .accountID, .pictureURL] {
             delete(key)
         }
     }

--- a/apps/ios/LukeKit/Tests/LukeKitTests/AccountClientTests.swift
+++ b/apps/ios/LukeKit/Tests/LukeKitTests/AccountClientTests.swift
@@ -114,6 +114,87 @@ final class TokenResponseTests: XCTestCase {
     }
 }
 
+// MARK: - Userinfo identity tests
+
+final class UserInfoTests: XCTestCase {
+    private let base = URL(string: "https://example.com")!
+
+    private func identity(fromUserInfo payload: [String: Any]) async throws -> AccountIdentity {
+        let stub = StubHTTPClient { request in
+            XCTAssertTrue(request.url?.path.hasSuffix("oauth2/userinfo") == true)
+            return (jsonData(payload), makeResponse(url: request.url!, status: 200))
+        }
+        let client = AccountClient(baseURL: base, clientID: "c", http: stub)
+        return try await client.userInfo(accessToken: "at")
+    }
+
+    func testCarriesGoogleHostedPicture() async throws {
+        let identity = try await identity(fromUserInfo: [
+            "email": "dev@example.com",
+            "picture": "https://lh3.googleusercontent.com/a/photo",
+        ])
+        XCTAssertEqual(
+            identity.pictureURL?.absoluteString,
+            "https://lh3.googleusercontent.com/a/photo"
+        )
+    }
+
+    func testCarriesGitHubHostedPicture() async throws {
+        let identity = try await identity(fromUserInfo: [
+            "email": "dev@example.com",
+            "picture": "https://avatars.githubusercontent.com/u/1?v=4",
+        ])
+        XCTAssertEqual(
+            identity.pictureURL?.absoluteString,
+            "https://avatars.githubusercontent.com/u/1?v=4"
+        )
+    }
+
+    func testDropsPictureFromOtherHosts() async throws {
+        let identity = try await identity(fromUserInfo: [
+            "email": "dev@example.com",
+            "picture": "https://example.com/photo.png",
+        ])
+        XCTAssertNil(identity.pictureURL)
+    }
+
+    func testDropsInsecurePicture() async throws {
+        let identity = try await identity(fromUserInfo: [
+            "email": "dev@example.com",
+            "picture": "http://lh3.googleusercontent.com/a/photo",
+        ])
+        XCTAssertNil(identity.pictureURL)
+    }
+
+    func testDropsLookalikePictureHost() {
+        XCTAssertNil(AccountIdentity.pictureURL(fromWire: "https://evilgoogleusercontent.com/a"))
+    }
+}
+
+// MARK: - Initials tests
+
+final class AccountInitialsTests: XCTestCase {
+    func testFirstAndLastWordOfName() {
+        let identity = AccountIdentity(id: nil, email: "x@example.com", name: "Ada King Lovelace")
+        XCTAssertEqual(identity.initials, "AL")
+    }
+
+    func testSingleWordName() {
+        let identity = AccountIdentity(id: nil, email: "x@example.com", name: "ada")
+        XCTAssertEqual(identity.initials, "A")
+    }
+
+    func testEmailLocalPartWhenNameMissing() {
+        let identity = AccountIdentity(id: nil, email: "ada.lovelace@example.com", name: nil)
+        XCTAssertEqual(identity.initials, "AL")
+    }
+
+    func testEmptyNameFallsBackToEmail() {
+        let identity = AccountIdentity(id: nil, email: "grace_hopper@example.com", name: "")
+        XCTAssertEqual(identity.initials, "GH")
+    }
+}
+
 // MARK: - Refresh-retry logic tests
 
 final class RefreshRetryTests: XCTestCase {

--- a/apps/ios/LukeTests/LukeTests.swift
+++ b/apps/ios/LukeTests/LukeTests.swift
@@ -133,6 +133,46 @@ final class TokenResponseTests: XCTestCase {
     }
 }
 
+// MARK: - Userinfo identity
+
+final class UserInfoTests: XCTestCase {
+    private let base = URL(string: "https://example.com")!
+
+    private func identity(fromUserInfo payload: [String: Any]) async throws -> AccountIdentity {
+        let stub = StubHTTPClient { request in
+            (jsonData(payload), makeResponse(url: request.url!, status: 200))
+        }
+        let client = AccountClient(baseURL: base, clientID: "c", http: stub)
+        return try await client.userInfo(accessToken: "at")
+    }
+
+    func testCarriesProviderHostedPicture() async throws {
+        let identity = try await identity(fromUserInfo: [
+            "email": "dev@example.com",
+            "picture": "https://avatars.githubusercontent.com/u/1?v=4",
+        ])
+        XCTAssertEqual(
+            identity.pictureURL?.absoluteString,
+            "https://avatars.githubusercontent.com/u/1?v=4"
+        )
+    }
+
+    func testDropsPictureFromOtherHosts() async throws {
+        let identity = try await identity(fromUserInfo: [
+            "email": "dev@example.com",
+            "picture": "https://example.com/photo.png",
+        ])
+        XCTAssertNil(identity.pictureURL)
+    }
+
+    func testInitialsFallBackFromNameToEmail() {
+        let named = AccountIdentity(id: nil, email: "x@example.com", name: "Ada King Lovelace")
+        XCTAssertEqual(named.initials, "AL")
+        let unnamed = AccountIdentity(id: nil, email: "ada.lovelace@example.com", name: nil)
+        XCTAssertEqual(unnamed.initials, "AL")
+    }
+}
+
 // MARK: - Refresh retry decision
 
 final class RefreshRetryTests: XCTestCase {


### PR DESCRIPTION
## What

The signed-in screen's account card gave its whole top to the name, email, and an inline **Sign out** button. The account now lives behind the header:

- The **profile photo sits in the top-left of the system navigation bar** (a `NavigationStack` toolbar item, detached from the bar's shared glass so the avatar's circle is the whole control rather than a capsule around it).
- Its press opens a **profile sheet** drawn with the system's own sheet vocabulary — a navigation bar with an inline "Profile" title and the standard close button top-left, and a grouped `List`: the photo large at the top center, the account's name and email below, the provider keys below that, **Sign out at the very bottom**, and the build's own version ("Luke vX.X.X") as the closing footer.
- The header stands over **every signed-in state** — including the vault load-error state ("The vault refused this account's token. Sign out and back in.", which now has the sign-out it points to one tap away) and the unpersisted-credentials warning, which keeps its own notice card on the main screen.

## How the photo gets there

The identity previously carried no picture. Now:

- `AccountClient.userInfo` parses the `picture` claim under the same host policy the desktop account client enforces (`accountPictureUrl` in `packages/account/src/client.ts`): https only, Google's `googleusercontent.com` (and subdomains) or GitHub's `avatars.githubusercontent.com`, anything else dropped rather than fetched. The set is fixed by the build, matching the desktop renderer's CSP.
- The URL persists in the keychain beside the name (cosmetic, so it doesn't gate `credentialsPersisted`), is re-validated through the same policy on restore, and is deleted when userinfo stops carrying one.
- A restore **re-resolves the identity from userinfo every launch** instead of only near token expiry, so a photo the keychain never held (a sign-in that predates the field) arrives without waiting for the token to age.
- An account without a photo draws its initials, mirroring the web fallback: the provider's own name first, else the email's local part.

## Validation

- `./scripts/check.sh` — passed (exit 0). No desktop/UI change, so `verify.sh` evidence does not apply; no physical-notch check was performed.
- `cd apps/ios/LukeKit && swift test` — 40 tests, 0 failures (includes new `UserInfoTests` covering both avatar hosts, the other-host/insecure/lookalike-host drops, and `AccountInitialsTests`).
- `xcodebuild -project apps/ios/Luke.xcodeproj -scheme Luke -destination 'platform=iOS Simulator,name=iPhone 17 Pro' test` — **TEST SUCCEEDED** (Xcode 26.6), re-run after each revision.
- The earlier header revision was exercised on a physical device by the developer (which surfaced the missing photo and the glass capsule this revision fixes); the profile-sheet revision has not yet had a device check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/33459518061/artifacts/9782723933) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/33459518061)

- Commit: `1f6f72a31d5e61e3837e882331a691c1f86391da`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->


