### PR TITLE
feat(ios): stand Luke's loading screen over the app's first load

### DIFF
--- a/apps/ios/Luke.xcodeproj/project.pbxproj
+++ b/apps/ios/Luke.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		AABBCC000000000000000088 /* Palette.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABBCC000000000000000019 /* Palette.swift */; };
 		AABBCC000000000000000089 /* CanvasInkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABBCC00000000000000001A /* CanvasInkTests.swift */; };
 		AABBCC00000000000000008A /* SessionsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABBCC00000000000000001B /* SessionsView.swift */; };
+		AABBCC00000000000000008B /* LukeLoadingFace.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABBCC00000000000000001C /* LukeLoadingFace.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -34,6 +35,7 @@
 		AABBCC000000000000000019 /* Palette.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Palette.swift; sourceTree = "<group>"; };
 		AABBCC00000000000000001A /* CanvasInkTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CanvasInkTests.swift; sourceTree = "<group>"; };
 		AABBCC00000000000000001B /* SessionsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionsView.swift; sourceTree = "<group>"; };
+		AABBCC00000000000000001C /* LukeLoadingFace.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LukeLoadingFace.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -81,6 +83,7 @@
 				AABBCC000000000000000013 /* ContentView.swift */,
 				AABBCC000000000000000016 /* Marks.swift */,
 				AABBCC000000000000000019 /* Palette.swift */,
+				AABBCC00000000000000001C /* LukeLoadingFace.swift */,
 				AABBCC000000000000000017 /* SVGPath.swift */,
 				AABBCC000000000000000018 /* VaultView.swift */,
 				AABBCC00000000000000001B /* SessionsView.swift */,
@@ -209,6 +212,7 @@
 				AABBCC000000000000000021 /* ContentView.swift in Sources */,
 				AABBCC000000000000000085 /* Marks.swift in Sources */,
 				AABBCC000000000000000088 /* Palette.swift in Sources */,
+				AABBCC00000000000000008B /* LukeLoadingFace.swift in Sources */,
 				AABBCC000000000000000086 /* SVGPath.swift in Sources */,
 				AABBCC000000000000000087 /* VaultView.swift in Sources */,
 				AABBCC00000000000000008A /* SessionsView.swift in Sources */,

--- a/apps/ios/Luke/ContentView.swift
+++ b/apps/ios/Luke/ContentView.swift
@@ -165,10 +165,46 @@ private struct SignedInView: View {
     @Environment(AccountSession.self) private var session
     let identity: AccountIdentity
     @State private var profileShown = false
+    /// Flipped by the sessions list once its first fetch has answered,
+    /// success or failure alike, so the loading screen can never outlive the
+    /// load it stands for.
+    @State private var firstLoadDone = false
 
     var body: some View {
+        ZStack {
+            // Hidden from assistive tech and inert while the loading screen
+            // stands: the overlay covers only the visual surface, and
+            // VoiceOver or Full Keyboard Access would otherwise still reach
+            // the controls behind it and could open the profile sheet
+            // under the loader.
+            signedInContent
+                .accessibilityHidden(!firstLoadDone)
+                .disabled(!firstLoadDone)
+            // The app's own loading screen: Luke humming over the ground
+            // until the first roster answer, standing over the whole surface
+            // rather than inside any one component. It marks only time the
+            // fetch is already spending, and stands down the moment the
+            // answer lands. The whole screen leaves the safe area, not just
+            // its ground, so the face centres between the device's physical
+            // edges rather than sitting low in the asymmetric safe-area
+            // window the notch and home indicator leave.
+            if !firstLoadDone {
+                ZStack {
+                    Color.ground
+                    LukeLoadingFace()
+                        .foregroundStyle(Color.ink)
+                        .frame(width: 120)
+                }
+                .ignoresSafeArea()
+                .transition(.opacity)
+            }
+        }
+        .animation(.easeOut(duration: 0.25), value: firstLoadDone)
+    }
+
+    private var signedInContent: some View {
         NavigationStack {
-            SessionsView()
+            SessionsView(firstLoadDone: $firstLoadDone)
                 .navigationTitle("Sessions")
                 .navigationBarTitleDisplayMode(.inline)
                 .toolbar {

--- a/apps/ios/Luke/LukeLoadingFace.swift
+++ b/apps/ios/Luke/LukeLoadingFace.swift
@@ -1,0 +1,118 @@
+// Luke humming along while the wait lasts.
+//
+// The motion is the artwork's monitoring sway — "quiet work, made visible",
+// which is what a wait is — ported from the same table
+// design/generate-brand-assets.mjs cuts the brand SVGs and the desktop's
+// keyframes from. A hand copy, like the geometry in Marks.swift: change both
+// when the artwork moves. The face only ever marks time already being spent;
+// it never holds a load open to finish a cycle.
+import SwiftUI
+
+// MARK: - Loading face
+
+struct LukeLoadingFace: View {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var born = Date()
+
+    var body: some View {
+        TimelineView(.animation(minimumInterval: nil, paused: reduceMotion)) { context in
+            let motion = reduceMotion
+                ? CGAffineTransform.identity
+                : LoadingSway.motion(at: context.date.timeIntervalSince(born))
+            Canvas { ctx, size in
+                FaceArt.draw(ctx, size: size, box: FaceArt.motionBox, motion: motion)
+            }
+        }
+        .aspectRatio(1, contentMode: .fit)
+        .accessibilityLabel("Loading")
+    }
+}
+
+// MARK: - Sway
+
+/// luke-monitoring's cycle, evaluated from the artwork's keyframes rather
+/// than played by a compositor, so a frame is a pure function of elapsed
+/// time and Reduce Motion can hold the rest pose. It begins and ends
+/// upright, so the first drawn frame is the resting face.
+private enum LoadingSway {
+    private static let cycleSeconds = 3.6
+    private static let pivot = CGPoint(x: 120, y: 196)
+    private static let degrees = KeyframeTrack(
+        times: [0, 0.25, 0.5, 0.75, 1],
+        values: [0, 3.5, 0, -3.5, 0],
+        easing: artworkEase.value
+    )
+
+    static func motion(at elapsed: TimeInterval) -> CGAffineTransform {
+        let cycle = max(elapsed, 0).truncatingRemainder(dividingBy: cycleSeconds)
+        return FaceArt.rotation(
+            degrees: CGFloat(degrees.value(at: cycle / cycleSeconds)),
+            about: pivot
+        )
+    }
+}
+
+// MARK: - Timing
+
+/// A generated face-motion.css rule's shape: values at fractions of the
+/// cycle, one easing curve applied to every interval.
+private struct KeyframeTrack {
+    let times: [Double]
+    let values: [Double]
+    let easing: (Double) -> Double
+
+    func value(at progress: Double) -> Double {
+        if progress <= times[0] { return values[0] }
+        guard let last = times.last, progress < last else { return values[values.count - 1] }
+        var index = 1
+        while times[index] <= progress { index += 1 }
+        let span = times[index] - times[index - 1]
+        let local = span > 0 ? (progress - times[index - 1]) / span : 1
+        return values[index - 1] + (values[index] - values[index - 1]) * easing(local)
+    }
+}
+
+/// The artwork's shared curve: every generated layer rule plays
+/// cubic-bezier(0.4, 0, 0.6, 1).
+private let artworkEase = UnitBezier(0.4, 0, 0.6, 1)
+
+/// cubic-bezier(x1, y1, x2, y2), solved the way a compositor solves it:
+/// x(t) inverted by Newton with a bisection fallback, then y at that t.
+private struct UnitBezier {
+    private let ax, bx, cx, ay, by, cy: Double
+
+    init(_ x1: Double, _ y1: Double, _ x2: Double, _ y2: Double) {
+        cx = 3 * x1
+        bx = 3 * (x2 - x1) - cx
+        ax = 1 - cx - bx
+        cy = 3 * y1
+        by = 3 * (y2 - y1) - cy
+        ay = 1 - cy - by
+    }
+
+    func value(_ x: Double) -> Double {
+        sampleY(solveX(min(max(x, 0), 1)))
+    }
+
+    private func sampleX(_ t: Double) -> Double { ((ax * t + bx) * t + cx) * t }
+    private func sampleY(_ t: Double) -> Double { ((ay * t + by) * t + cy) * t }
+    private func sampleDerivativeX(_ t: Double) -> Double { (3 * ax * t + 2 * bx) * t + cx }
+
+    private func solveX(_ x: Double) -> Double {
+        var t = x
+        for _ in 0..<8 {
+            let error = sampleX(t) - x
+            if abs(error) < 1e-6 { return t }
+            let slope = sampleDerivativeX(t)
+            if abs(slope) < 1e-6 { break }
+            t -= error / slope
+        }
+        var low = 0.0, high = 1.0
+        t = x
+        while high - low > 1e-6 {
+            if sampleX(t) < x { low = t } else { high = t }
+            t = (low + high) / 2
+        }
+        return t
+    }
+}

--- a/apps/ios/Luke/Marks.swift
+++ b/apps/ios/Luke/Marks.swift
@@ -6,60 +6,80 @@ import LukeKit
 import SwiftUI
 import UIKit
 
-// MARK: - Luke face mark
+// MARK: - Luke face art
 
-struct LukeMark: View {
-    // FACE_ART constants (packages/surface/src/generated/face-art.ts)
-    private static let vbX: CGFloat = 53.85, vbY: CGFloat = 62.67
-    private static let vbW: CGFloat = 134.29, vbH: CGFloat = 122.37
-    private static let tiltDeg: CGFloat = -8
-    private static let pivotX: CGFloat = 120, pivotY: CGFloat = 124
-    private static let eyeY: CGFloat = 92, eyeR: CGFloat = 12
-    private static let leftEyeX: CGFloat = 78, rightEyeX: CGFloat = 162
-    private static let strokeW: CGFloat = 16
+/// FACE_ART constants (packages/surface/src/generated/face-art.ts), in the
+/// artwork's own 240×240 canvas coordinates. A hand copy, like every mark in
+/// this file: change both when the artwork moves.
+enum FaceArt {
+    /// The face cropped to itself (MARK_VIEW_BOX). Only for a face that never
+    /// moves: it is tight enough that any motion would leave it.
+    static let markBox = CGRect(x: 53.85, y: 62.67, width: 134.29, height: 122.37)
+    /// The square window motions play in (VIEW_BOX), with headroom to move.
+    static let motionBox = CGRect(x: 48, y: 51, width: 146, height: 146)
+    static let strokeWidth: CGFloat = 16
+    static let eyeY: CGFloat = 92
+    static let eyeRadius: CGFloat = 12
+    static let eyeXs: [CGFloat] = [78, 162]
+    private static let tiltDegrees: CGFloat = -8
+    private static let tiltPivot = CGPoint(x: 120, y: 124)
 
-    var body: some View {
-        Canvas { ctx, size in
-            let scale = min(size.width / Self.vbW, size.height / Self.vbH)
-            let t = faceTransform(scale: scale)
+    /// Smile: M 104 84 V 150 Q 104 164 118 164 Q 140 164 168 142
+    static let smile: Path = {
+        var path = Path()
+        path.move(to: CGPoint(x: 104, y: 84))
+        path.addLine(to: CGPoint(x: 104, y: 150))
+        path.addQuadCurve(to: CGPoint(x: 118, y: 164), control: CGPoint(x: 104, y: 164))
+        path.addQuadCurve(to: CGPoint(x: 168, y: 142), control: CGPoint(x: 140, y: 164))
+        return path
+    }()
 
-            // Smile: M 104 84 V 150 Q 104 164 118 164 Q 140 164 168 142
-            let smile = CGMutablePath()
-            smile.move(to: CGPoint(x: 104, y: 84), transform: t)
-            smile.addLine(to: CGPoint(x: 104, y: 150), transform: t)
-            smile.addQuadCurve(
-                to: CGPoint(x: 118, y: 164), control: CGPoint(x: 104, y: 164), transform: t
-            )
-            smile.addQuadCurve(
-                to: CGPoint(x: 168, y: 142), control: CGPoint(x: 140, y: 164), transform: t
-            )
-            ctx.stroke(
-                Path(smile), with: .foreground,
-                style: StrokeStyle(lineWidth: Self.strokeW * scale, lineCap: .round, lineJoin: .round)
-            )
+    /// The head's resting tilt, about the point the motions pivot on.
+    static let tilt = rotation(degrees: tiltDegrees, about: tiltPivot)
 
-            let r = Self.eyeR * scale
-            let lc = CGPoint(x: Self.leftEyeX, y: Self.eyeY).applying(t)
-            let rc = CGPoint(x: Self.rightEyeX, y: Self.eyeY).applying(t)
-            ctx.fill(Path(ellipseIn: CGRect(cx: lc, r: r)), with: .foreground)
-            ctx.fill(Path(ellipseIn: CGRect(cx: rc, r: r)), with: .foreground)
-        }
-        .aspectRatio(Self.vbW / Self.vbH, contentMode: .fit)
+    static func rotation(degrees: CGFloat, about pivot: CGPoint) -> CGAffineTransform {
+        CGAffineTransform(translationX: pivot.x, y: pivot.y)
+            .rotated(by: degrees * .pi / 180)
+            .translatedBy(x: -pivot.x, y: -pivot.y)
     }
 
-    private func faceTransform(scale: CGFloat) -> CGAffineTransform {
-        let angle = Self.tiltDeg * .pi / 180
-        let cx = Self.pivotX, cy = Self.pivotY
-        return CGAffineTransform(translationX: -cx, y: -cy)
-            .concatenating(.init(rotationAngle: angle))
-            .concatenating(.init(translationX: cx - Self.vbX, y: cy - Self.vbY))
-            .concatenating(.init(scaleX: scale, y: scale))
+    /// Draws the face fitted to `box`'s crop of the canvas, with `motion`
+    /// applied to the whole head in canvas coordinates outside the resting
+    /// tilt — the same nesting the desktop's layer groups give the generated
+    /// keyframes.
+    static func draw(
+        _ ctx: GraphicsContext,
+        size: CGSize,
+        box: CGRect,
+        motion: CGAffineTransform = .identity
+    ) {
+        let scale = min(size.width / box.width, size.height / box.height)
+        let placement = CGAffineTransform(scaleX: scale, y: scale)
+            .translatedBy(x: -box.minX, y: -box.minY)
+        let t = tilt.concatenating(motion).concatenating(placement)
+
+        ctx.stroke(
+            smile.applying(t), with: .foreground,
+            style: StrokeStyle(lineWidth: strokeWidth * scale, lineCap: .round, lineJoin: .round)
+        )
+        for eyeX in eyeXs {
+            let eye = CGRect(
+                x: eyeX - eyeRadius, y: eyeY - eyeRadius,
+                width: eyeRadius * 2, height: eyeRadius * 2
+            )
+            ctx.fill(Path(ellipseIn: eye).applying(t), with: .foreground)
+        }
     }
 }
 
-extension CGRect {
-    init(cx: CGPoint, r: CGFloat) {
-        self.init(x: cx.x - r, y: cx.y - r, width: 2 * r, height: 2 * r)
+// MARK: - Luke face mark
+
+struct LukeMark: View {
+    var body: some View {
+        Canvas { ctx, size in
+            FaceArt.draw(ctx, size: size, box: FaceArt.markBox)
+        }
+        .aspectRatio(FaceArt.markBox.width / FaceArt.markBox.height, contentMode: .fit)
     }
 }
 

--- a/apps/ios/Luke/SessionsView.swift
+++ b/apps/ios/Luke/SessionsView.swift
@@ -5,6 +5,11 @@ import SwiftUI
 struct SessionsView: View {
     @Environment(AccountSession.self) private var session
 
+    /// True once the first fetch has answered, success or failure alike. The
+    /// signed-in screen holds its loading screen over everything until then,
+    /// and never again: later refreshes redraw in place.
+    @Binding var firstLoadDone: Bool
+
     @State private var sessions: [RosterSession] = []
     @State private var isLoading = false
     @State private var fetchError: String?
@@ -64,7 +69,10 @@ struct SessionsView: View {
         .toolbarBackground(.visible, for: .navigationBar)
         .searchable(text: $searchQuery, prompt: "Search sessions")
         .refreshable { await refreshSessions() }
-        .task { await refreshSessions() }
+        .task {
+            await refreshSessions()
+            firstLoadDone = true
+        }
     }
 
     private let rowInsets = EdgeInsets(top: 4, leading: 16, bottom: 4, trailing: 16)


### PR DESCRIPTION
## What

While the signed-in screen's first cloud-sessions fetch is in flight, the whole surface is Luke's loading screen: his face humming the artwork's monitoring sway ("quiet work, made visible") centered over the ground colour, covering everything including the navigation bar. It fades out the moment the first answer lands — success or failure alike — and never returns for later refreshes, which redraw in place. The loader marks only time the fetch is already spending; nothing waits on the animation. Earlier revisions drew Luke in with the onboarding wake and lived inside the vault card; both were superseded — loads are too fast for a draw-in, and the loading screen belongs to the app, not a subcomponent.

## How

- `SignedInView` holds the screen over its content until `SessionsView` flips a binding after its first fetch answers; the profile sheet's vault section keeps main's redacted-rows treatment untouched.
- The sway's keyframes, pivot, and easing are ported from the same table `design/generate-brand-assets.mjs` cuts the brand SVGs and the desktop's `face-motion.css` from (monitoring: 3.6s looped on the artwork's shared `cubic-bezier(0.4, 0, 0.6, 1)`). Like the geometry already in `Marks.swift`, it is a hand copy, and says so.
- `Marks.swift`'s face geometry moved into a shared `FaceArt` with a motion-parameterized draw, so `LukeMark` and the loading face trace one implementation; the face inks with the palette's `Color.ink`, following light and dark mode.
- Each frame is a pure function of elapsed time (`TimelineView` + `Canvas`), so Reduce Motion holds the resting face still instead of animating.

## Validation

CI has no iOS job, so the build and both test entries from `apps/ios/README.md` were run on a physical Mac (Xcode 26.6) at every revision, including after each rebase (light/dark mode, the profile sheet, the sessions roster):

- `xcodebuild -project apps/ios/Luke.xcodeproj -scheme Luke -destination 'platform=iOS Simulator,name=iPhone 17 Pro Max' test` — all suites passed (including `CanvasInkTests`)
- `cd apps/ios/LukeKit && swift test` — passed
- `./scripts/check.sh` — passed (exit 0; no generated files touched)

Visual inspection: the full-screen composition was rendered via `ImageRenderer` in both appearances at both sway extremes and inspected, the rest pose matches the existing sign-in mark side by side, and the face never paints outside its frame. No physical-device check was performed; a device recording of the live launch can be attached through the PR editor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/33467971348/artifacts/9785579055) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/33467971348)

- Commit: `92ec5c20637c1f73c19e06101f07520f5c88518c`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
