### PR TITLE
fix(realtime): resolve "that chat" after announcements instead of guessing

### DIFF
--- a/apps/desktop/src/renderer/realtime-session.test.ts
+++ b/apps/desktop/src/renderer/realtime-session.test.ts
@@ -21,6 +21,7 @@ import {
   REALTIME_STATUS,
   type RealtimeConnection,
   type RealtimeStatus,
+  SESSION_NO_LONGER_OBSERVED_NOTE,
 } from "@sidecar/realtime";
 import {
   ATTENTION_DISPOSITION,
@@ -1967,8 +1968,9 @@ test("the history is rendered from the roster as it now stands", async () => {
 
   // The words are history and keep their line; the identity is an offer to a
   // tool call, and a session the roster no longer shows is one no call may
-  // name — so the line lets go of it rather than steering "that chat" toward
-  // a certain refusal.
+  // name — so the line trades it for the note saying the session is gone,
+  // rather than steering "that chat" toward a certain refusal or leaving it
+  // to be guessed among the sessions still observed.
   context.session.updateSessions([]);
   await armDeveloperTurn(context);
 
@@ -1976,6 +1978,7 @@ test("the history is rendered from the roster as it now stands", async () => {
   assert.equal(items.length, 1);
   assert.match(itemText(items[0]), /finished checkout-service/);
   assert.doesNotMatch(itemText(items[0]), /provider_session_id=session-a/);
+  assert.ok(itemText(items[0]).includes(`[${SESSION_NO_LONGER_OBSERVED_NOTE}]`));
 });
 
 test("the history is seeded once per call and later lines are not re-sent", async () => {
@@ -1991,14 +1994,14 @@ test("the history is seeded once per call and later lines are not re-sent", asyn
   const seeded = context.session.liveContextItemIds.get(CONTEXT_ITEM_KIND.CONVERSATION);
   assert.ok(seeded);
 
-  // Every line said from here on rides this call as its own conversation
+  // Every turn taken from here on rides this call as its own conversation
   // items, so re-sending the digest would delete an item out of the cached
   // prefix to restate turns the model already holds. The seed stands, and the
   // new line waits for the next call.
   context.session.stopSpeaking();
   context.session.updateConversation(
     appendConversationEntry(first, {
-      kind: CONVERSATION_ENTRY_KIND.ANNOUNCEMENT,
+      kind: CONVERSATION_ENTRY_KIND.REPLY,
       words: "Codex failed in payments.",
     }),
   );
@@ -2011,6 +2014,61 @@ test("the history is seeded once per call and later lines are not re-sent", asyn
     false,
   );
   assert.equal(context.session.liveContextItemIds.get(CONTEXT_ITEM_KIND.CONVERSATION), seeded);
+});
+
+test("a history that grew an announcement re-seeds at the next developer turn", async () => {
+  const context = harness();
+  await context.session.connect();
+
+  const first = conversationEntries({
+    kind: CONVERSATION_ENTRY_KIND.SPOKEN_ASK,
+    words: "how is checkout going?",
+  });
+  context.session.updateSessions([observedSession("session-b", { title: "payments" })]);
+  context.session.updateConversation(first);
+  await armDeveloperTurn(context);
+  const seeded = context.session.liveContextItemIds.get(CONTEXT_ITEM_KIND.CONVERSATION);
+  assert.ok(seeded);
+
+  // An announcement is voiced out-of-band and enters this call's conversation
+  // nowhere else, so unlike every other line it is one the model has not
+  // seen: the item is re-seeded at the next turn, or "archive that chat"
+  // would be resolved against a history missing the chat it means.
+  context.session.stopSpeaking();
+  context.session.updateConversation(
+    appendConversationEntry(first, {
+      kind: CONVERSATION_ENTRY_KIND.ANNOUNCEMENT,
+      words: "Codex finished payments.",
+      identity: { providerId: "claude-code", providerSessionId: "session-b" },
+    }),
+    { announced: true },
+  );
+  const sentBefore = context.sent.length;
+  await armDeveloperTurn(context);
+
+  const events = context.sent.slice(sentBefore);
+  // SAFETY: Fixture value matches the narrowed runtime shape this test exercises.
+  const deletes = events.filter((event) => event.type === CONVERSATION_ITEM_DELETE) as {
+    item_id?: string;
+  }[];
+  assert.deepEqual(
+    deletes.map((event) => event.item_id),
+    [seeded],
+  );
+  const items = contextItems(context, "[recent conversation", sentBefore);
+  assert.equal(items.length, 1);
+  assert.match(itemText(items[0]), /Luke announced: "Codex finished payments\."/);
+  assert.match(itemText(items[0]), /provider_id=claude-code provider_session_id=session-b/);
+  const reseeded = context.session.liveContextItemIds.get(CONTEXT_ITEM_KIND.CONVERSATION);
+  assert.ok(reseeded);
+  assert.notEqual(reseeded, seeded);
+
+  // The re-seed spends the announcement: the next turn stands pat again.
+  context.session.stopSpeaking();
+  const sentAfter = context.sent.length;
+  await armDeveloperTurn(context);
+  assert.deepEqual(contextItems(context, "[recent conversation", sentAfter), []);
+  assert.equal(context.session.liveContextItemIds.get(CONTEXT_ITEM_KIND.CONVERSATION), reseeded);
 });
 
 test("a new call after teardown re-seeds the accumulated history", async () => {

--- a/apps/desktop/src/renderer/realtime-session.ts
+++ b/apps/desktop/src/renderer/realtime-session.ts
@@ -470,6 +470,16 @@ export class RealtimeVoiceSession {
    */
   #conversationEntries: readonly ConversationEntry[] = [];
   /**
+   * Whether the history has grown an announcement its live context item does
+   * not hold. An announcement is spoken out-of-band and writes nothing into
+   * the conversation, so it is the one history line a call cannot already
+   * hold as its own items — and the reason the seeded item may be superseded
+   * mid-call: without the re-seed, the turn after a mid-call announcement
+   * says "archive that chat" to a model that never saw which chat was
+   * announced. Cleared whenever the history item is brought current.
+   */
+  #conversationGrewAnnouncement = false;
+  /**
    * The app guide as last provided, kept whole for the same reason the roster
    * is: it is what a spoken ask about Luke himself is validated against, and a
    * call may only name a setting Luke was actually described as having.
@@ -2038,10 +2048,11 @@ export class RealtimeVoiceSession {
       sessionContextEvents(sessions, itemId, now),
     );
     // The history is rendered against the roster, so a fresh roster re-renders
-    // it: a line whose session left the roster keeps its words and lets go of
-    // the identity no tool call may name any more. The render reaches the wire
-    // only until this call seeds its one history item; after that it keeps the
-    // staged copy current for nothing but teardown to clear.
+    // it: a line whose session left the roster keeps its words and trades the
+    // identity no tool call may name any more for the note saying so. The
+    // render reaches the wire only until this call seeds its one history item;
+    // after that the staged copy is kept current for an announcement's
+    // re-seed, and otherwise waits for teardown to clear it.
     this.#rememberConversation();
   }
 
@@ -2054,12 +2065,20 @@ export class RealtimeVoiceSession {
    * and an idle call retires with everything said on it. Context on the
    * roster's own terms, flushed with it at the first turn of each call and
    * left standing after that: what is said from then on lives in the call's
-   * own conversation items.
+   * own conversation items — except an announcement, which the caller marks
+   * with `announced` so the item is re-seeded at the next turn. An
+   * announcement is voiced out-of-band and enters the conversation nowhere
+   * else, so the item standing pat would leave "that chat" pointing at a
+   * line this call's model has never seen.
    */
-  updateConversation(entries: readonly ConversationEntry[]): void {
+  updateConversation(
+    entries: readonly ConversationEntry[],
+    { announced = false }: { announced?: boolean } = {},
+  ): void {
     // The caller may retain the whole current-launch thread for its own UI;
     // this transport accepts only the recent slice that may reach the model.
     this.#conversationEntries = recentConversationEntries(entries);
+    if (announced) this.#conversationGrewAnnouncement = true;
     this.#rememberConversation();
   }
 
@@ -2175,14 +2194,20 @@ export class RealtimeVoiceSession {
         this.#contextLive.delete(kind);
         continue;
       }
-      // The history is seeded once per call. It exists to bridge the calls
-      // that came before this one, and every turn taken since it went in is
+      // The history is seeded once per call and re-seeded only for a grown
+      // announcement. Every turn the developer takes since the seed is
       // already held by this call as real conversation items — so superseding
-      // it mid-call would delete an item out of the conversation's cached
-      // prefix to restate turns the model already has. The entries keep
-      // accumulating either way, and teardown clears the live map, so the
-      // next call seeds everything said by then.
-      if (kind === CONTEXT_ITEM_KIND.CONVERSATION && live) continue;
+      // the item for those would delete part of the conversation's cached
+      // prefix to restate turns the model already has. An announcement is the
+      // one line the call's items never hold: it is voiced out-of-band, so a
+      // history that grew one re-seeds at this turn, or a bare "that chat"
+      // would be resolved against a model that never saw the announcement.
+      // Teardown clears the live map either way, so the next call seeds
+      // everything said by then.
+      if (kind === CONTEXT_ITEM_KIND.CONVERSATION) {
+        if (live && !this.#conversationGrewAnnouncement) continue;
+        this.#conversationGrewAnnouncement = false;
+      }
       if (live?.text === pending.text) continue;
       this.#contextSequence += 1;
       const itemId = contextItemId(kind, this.#contextSequence);

--- a/apps/desktop/src/renderer/use-voice-conversation.ts
+++ b/apps/desktop/src/renderer/use-voice-conversation.ts
@@ -647,7 +647,11 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
   /**
    * Appends one bounded line to this launch's history and tells the call now
    * open about only the recent context slice. A session leaving the roster
-   * costs a line its identity at model render, never its visible words.
+   * costs a line its identity at model render, never its visible words. An
+   * announcement line is marked as such: it is the one line an open call's
+   * own conversation items never hold — voiced out-of-band, or only shown —
+   * so the call re-seeds its history item for it, and the next turn's bare
+   * "that chat" can find the announced session.
    */
   const rememberConversationEntry = useCallback(
     (entry: ConversationEntry | undefined, generation = conversationGenerationRef.current) => {
@@ -659,7 +663,9 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
       }
       conversationRef.current = appendConversationThreadEntry(conversationRef.current, entry);
       setConversationHistory(conversationRef.current);
-      voiceSession.current?.updateConversation(recentConversationEntries(conversationRef.current));
+      voiceSession.current?.updateConversation(recentConversationEntries(conversationRef.current), {
+        announced: entry.kind === CONVERSATION_ENTRY_KIND.ANNOUNCEMENT,
+      });
     },
     [],
   );

--- a/packages/realtime/src/conversation-history.test.ts
+++ b/packages/realtime/src/conversation-history.test.ts
@@ -22,7 +22,11 @@ import {
   recentConversationEntries,
   sessionActConversationEntry,
 } from "./conversation-history.js";
-import { ATTENTION_SPEECH_SOURCE, type AttentionSpeech } from "./realtime-protocol.js";
+import {
+  ATTENTION_SPEECH_SOURCE,
+  type AttentionSpeech,
+  SESSION_NO_LONGER_OBSERVED_NOTE,
+} from "./realtime-protocol.js";
 import { SESSION_TOOL_KIND } from "./realtime-tools.js";
 
 const OBSERVED_AT = 1_800_000_000_000;
@@ -316,7 +320,7 @@ test("a spoken ask lands at its turn's own mark, not where its transcription did
   );
 });
 
-test("a line whose session left the roster keeps its words and drops the identity", () => {
+test("a line whose session left the roster keeps its words and says the session is gone", () => {
   const entries = appendConversationEntry([], {
     kind: CONVERSATION_ENTRY_KIND.ANNOUNCEMENT,
     words: "Claude Code finished checkout-service.",
@@ -327,9 +331,21 @@ test("a line whose session left the roster keeps its words and drops the identit
 
   // The words are history and stay; the identity is an offer to a tool call,
   // and an unobserved one would steer "that chat" toward a certain refusal.
+  // The departure is said in the identity's place with the note the standing
+  // instructions teach: a line that merely fell silent would leave "archive
+  // that chat" to be resolved by guessing among the sessions still observed.
   assert.ok(text);
   assert.match(text, /finished checkout-service/);
   assert.doesNotMatch(text, /provider_session_id=session-gone/);
+  assert.match(text, new RegExp(`\\[${SESSION_NO_LONGER_OBSERVED_NOTE}\\]$`, "m"));
+
+  // A line that never named a session carries neither identity nor note.
+  const aboutNoSession = conversationHistoryText(
+    appendConversationEntry([], { kind: CONVERSATION_ENTRY_KIND.REPLY, words: "All quiet." }),
+    [],
+  );
+  assert.ok(aboutNoSession);
+  assert.doesNotMatch(aboutNoSession, /no longer observed/);
 });
 
 test("an empty history says nothing at all", () => {

--- a/packages/realtime/src/conversation-history.ts
+++ b/packages/realtime/src/conversation-history.ts
@@ -17,7 +17,11 @@
  */
 
 import type { Session, SessionIdentity } from "@sidecar/session";
-import { type AttentionSpeech, announcementSummaryText } from "./realtime-protocol.js";
+import {
+  type AttentionSpeech,
+  announcementSummaryText,
+  SESSION_NO_LONGER_OBSERVED_NOTE,
+} from "./realtime-protocol.js";
 import { actNarration, type CarriedSessionAction } from "./realtime-tools.js";
 
 /** What one history line records, which also says who it speaks for. */
@@ -59,8 +63,9 @@ export interface ConversationEntry {
    * The roster-validated session the line was about, when it was about one.
    * Only ever an identity the roster reported at the moment of the entry —
    * never one a model composed — and rendered only while the session is
-   * still observed, so a stale identity cannot steer a tool call toward a
-   * refusal.
+   * still observed; once the roster lets the session go, the render says so
+   * in place of the ids, so a stale identity can neither steer a tool call
+   * toward a refusal nor leave "that chat" open to a lookalike.
    */
   identity?: SessionIdentity;
 }
@@ -193,6 +198,10 @@ const CONVERSATION_ENTRY_LEAD = {
  * still observes that session: the words are history and stay, but an
  * identity the roster no longer reports is one no tool call may name, and a
  * line still offering it would steer "that chat" toward a guaranteed refusal.
+ * The departure is said rather than left blank — a line that merely fell
+ * silent reads like one that never named a session, and an ask pointed at it
+ * would be resolved by guessing among the sessions still observed. The fixed
+ * note is what the standing instructions teach: gone, so say so or ask.
  */
 export function conversationHistoryText(
   entries: readonly ConversationEntry[],
@@ -216,9 +225,10 @@ export function conversationHistoryText(
             candidate.providerId === identity.providerId &&
             candidate.providerSessionId === identity.providerSessionId,
         );
-      return observed && identity
+      if (!identity) return line;
+      return observed
         ? `${line} [provider_id=${identity.providerId} provider_session_id=${identity.providerSessionId}]`
-        : line;
+        : `${line} [${SESSION_NO_LONGER_OBSERVED_NOTE}]`;
     }),
   ].join("\n");
 }

--- a/packages/realtime/src/index.ts
+++ b/packages/realtime/src/index.ts
@@ -86,6 +86,7 @@ export {
   type RealtimeStatus,
   realtimeInstructions,
   type ScheduledTimer,
+  SESSION_NO_LONGER_OBSERVED_NOTE,
   truncateResponseEvents,
   typedAskEvents,
 } from "./realtime-protocol.js";

--- a/packages/realtime/src/realtime-protocol.ts
+++ b/packages/realtime/src/realtime-protocol.ts
@@ -143,6 +143,16 @@ export type AttentionSpeechSource =
   (typeof ATTENTION_SPEECH_SOURCE)[keyof typeof ATTENTION_SPEECH_SOURCE];
 
 /**
+ * The note a history line carries in place of an identity the roster no
+ * longer reports. Defined beside the standing instructions that teach what it
+ * means, and rendered by the history module from this one constant, so the
+ * words the model is taught are always the words it reads: a line wearing it
+ * names work that is gone — perhaps already archived — never an invitation to
+ * act on a lookalike still observed.
+ */
+export const SESSION_NO_LONGER_OBSERVED_NOTE = "this session is no longer observed";
+
+/**
  * A proactive update the attention layer decided is worth voicing. What
  * `summary` is either a finished sentence or observed status fields.
  */
@@ -185,9 +195,13 @@ const REALTIME_INSTRUCTION_HEAD: readonly string[] = [
     "own new turn asks for anything.",
   '- Resolve "that chat" or "that agent" from the conversation: this call\'s own turns first, ' +
     "then the [recent conversation] message.",
-  "- When neither settles which agent is meant, ask instead of guessing. Do not pick an agent " +
-    "just because it is listed first or updated most recently unless the user explicitly asks " +
-    "for the latest or most recent one.",
+  '- Right after an announcement, a bare "that chat", "that agent", or "it" means the newest ' +
+    '"Luke announced" line\'s bracketed identity, unless a turn since named a different agent.',
+  `- A line marked "${SESSION_NO_LONGER_OBSERVED_NOTE}" names work the roster has let go — ` +
+    "perhaps already archived. Say that plainly; never act on a different session in its place.",
+  "- When neither settles which agent is meant, ask which one, naming each candidate in a few " +
+    "words from its work — never guess. Do not pick an agent just because it is listed first " +
+    "or updated most recently unless the user explicitly asks for the latest or most recent one.",
   "- An explicit latest or most-recent ask resolves by the recency labels in the observed roster; " +
     "do not ask for a chat name when recency is the selection the user gave.",
   "- To open the most recent chat from each provider, call open_session once for every distinct " +


### PR DESCRIPTION
## Summary

- After a spoken announcement, "archive that chat" could be resolved by guessing: an announcement is voiced as an out-of-band response (`conversation: "none"`), so it enters the call's conversation nowhere — and the history context item was seeded once per call and never re-sent, so a mid-call announcement was invisible to the very turn that pointed back at it.
- The history item now re-seeds at the next developer turn when the history grew an announcement — the one line kind a call's own conversation items never hold. Ordinary turns keep the seed-once cache economy untouched.
- A history line whose session left the roster now renders `[this session is no longer observed]` in place of its bracketed identity instead of falling silent, so a departed referent (perhaps already archived) reads as gone rather than as a line that never named a session, which invited substituting a lookalike.
- The standing instructions gained the matching resolution rules: a bare "that chat"/"that agent"/"it" right after an announcement means the newest "Luke announced" line's bracketed identity unless a turn since named another; a line wearing the departed note is said plainly, never acted on through a different session; and when nothing settles the referent, Luke asks which one, naming each candidate by its work.

## Evidence

- Platform-independent checks: `./scripts/check.sh` passed (exit 0; realtime package 119 tests, desktop 795 tests, all green)
- macOS Electron verification (`./scripts/verify.sh`): `not run` — no drawn surface changes; conversation-context and prompt logic only

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/33459688951/artifacts/9782768071) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/33459688951)

- Commit: `baed35021e607f17b735bc0d770eea39255986d3`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

### Physical-device evidence

- Screenshot or screen recording: `not attached` — no UI change
- Physical-notch check: `not performed` — no UI change
- Device/display configuration: `not recorded`

## Notes

- Blockers or follow-up verification: None

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/c6d22ca8-7f36-46c4-b16e-a3f6c13a2dcc)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)