### PR TITLE
feat(ios): add session search to the main page header

### DIFF
--- a/apps/ios/Luke/SessionsView.swift
+++ b/apps/ios/Luke/SessionsView.swift
@@ -8,10 +8,30 @@ struct SessionsView: View {
     @State private var sessions: [RosterSession] = []
     @State private var isLoading = false
     @State private var fetchError: String?
+    @State private var searchQuery = ""
 
     private let client = RosterClient(serviceURL: AccountConstants.serviceURL)
 
     var body: some View {
+        if #available(iOS 26.0, *) {
+            // Minimized, the search is the magnifier button in the navigation
+            // bar until pressed; earlier systems keep the field the bar draws
+            // for a searchable list.
+            searchableList.searchToolbarBehavior(.minimize)
+        } else {
+            searchableList
+        }
+    }
+
+    /// The rows the query leaves: matched with the desktop's own search
+    /// semantics, and everything when the query is blank.
+    private var visibleSessions: [RosterSession] {
+        let tokens = SessionSearch.tokens(from: searchQuery)
+        if tokens.isEmpty { return sessions }
+        return sessions.filter { SessionSearch.matches($0, tokens: tokens) }
+    }
+
+    private var searchableList: some View {
         List {
             if isLoading && sessions.isEmpty {
                 ForEach(0 ..< 3, id: \.self) { _ in
@@ -24,8 +44,12 @@ struct SessionsView: View {
                 emptyRow
                     .listRowBackground(Color.clear)
                     .listRowSeparator(.hidden)
+            } else if visibleSessions.isEmpty {
+                ContentUnavailableView.search(text: searchQuery)
+                    .listRowBackground(Color.clear)
+                    .listRowSeparator(.hidden)
             } else {
-                ForEach(sessions) { s in
+                ForEach(visibleSessions) { s in
                     SessionRow(session: s)
                         .listRowBackground(Color.clear)
                         .listRowSeparator(.hidden)
@@ -38,6 +62,7 @@ struct SessionsView: View {
         .background(Color.ground.ignoresSafeArea())
         .toolbarBackground(Color.ground, for: .navigationBar)
         .toolbarBackground(.visible, for: .navigationBar)
+        .searchable(text: $searchQuery, prompt: "Search sessions")
         .refreshable { await refreshSessions() }
         .task { await refreshSessions() }
     }

--- a/apps/ios/LukeKit/Sources/LukeKit/SessionSearch.swift
+++ b/apps/ios/LukeKit/Sources/LukeKit/SessionSearch.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+/// Session search with the desktop's semantics (`searchTokens` and
+/// `matchesQuery` in `apps/desktop/src/renderer/session-model.ts`), read over
+/// the fields a `RosterSession` actually carries, so the two surfaces cannot
+/// disagree about what finds a session.
+public enum SessionSearch {
+    /// A query read into the words it asks for: lowercased and split on
+    /// whitespace, because matching is case-blind and every word must be
+    /// found somewhere. A blank query has no words, which is what makes it
+    /// no search at all.
+    public static func tokens(from query: String) -> [String] {
+        query.lowercased().split(whereSeparator: \.isWhitespace).map(String.init)
+    }
+
+    /// Every word somewhere on the row: words narrow, they never widen.
+    public static func matches(_ session: RosterSession, tokens: [String]) -> Bool {
+        if tokens.isEmpty { return true }
+        let lines = searchableLines(of: session).map { $0.lowercased() }
+        return tokens.allSatisfy { token in lines.contains { $0.contains(token) } }
+    }
+
+    /// The lines a query is read against: everything the row itself can say —
+    /// title, recap, workspace, branch — plus the status word, because the
+    /// recap only stands in for it, and the provider under both the wire id
+    /// and the product name, since either is a name the user knows it by.
+    static func searchableLines(of session: RosterSession) -> [String] {
+        var lines = [session.title, session.status, session.providerId]
+        if let provider = VaultProviderID(rawValue: session.providerId) {
+            lines.append(provider.displayName)
+        }
+        if let recap = session.recap { lines.append(recap) }
+        if let workspace = session.workspace { lines.append(workspace) }
+        if let branch = session.branch { lines.append(branch) }
+        return lines
+    }
+}

--- a/apps/ios/LukeKit/Sources/LukeKit/SessionSearch.swift
+++ b/apps/ios/LukeKit/Sources/LukeKit/SessionSearch.swift
@@ -21,14 +21,16 @@ public enum SessionSearch {
     }
 
     /// The lines a query is read against: everything the row itself can say —
-    /// title, recap, workspace, branch — plus the status word, because the
-    /// recap only stands in for it, and the provider under both the wire id
-    /// and the product name, since either is a name the user knows it by.
+    /// title, error, recap, workspace, branch — plus the status word, because
+    /// the sentence under the title only stands in for it, and the provider
+    /// under both the wire id and the product name, since either is a name
+    /// the user knows it by.
     static func searchableLines(of session: RosterSession) -> [String] {
         var lines = [session.title, session.status, session.providerId]
         if let provider = VaultProviderID(rawValue: session.providerId) {
             lines.append(provider.displayName)
         }
+        if let error = session.error { lines.append(error) }
         if let recap = session.recap { lines.append(recap) }
         if let workspace = session.workspace { lines.append(workspace) }
         if let branch = session.branch { lines.append(branch) }

--- a/apps/ios/LukeKit/Tests/LukeKitTests/SessionSearchTests.swift
+++ b/apps/ios/LukeKit/Tests/LukeKitTests/SessionSearchTests.swift
@@ -8,7 +8,8 @@ private func makeSession(
     status: String = "working",
     workspace: String? = nil,
     branch: String? = nil,
-    recap: String? = nil
+    recap: String? = nil,
+    error: String? = nil
 ) -> RosterSession {
     var json: [String: Any] = [
         "providerId": providerId,
@@ -19,6 +20,7 @@ private func makeSession(
     if let workspace { json["workspace"] = workspace }
     if let branch { json["branch"] = branch }
     if let recap { json["recap"] = recap }
+    if let error { json["error"] = error }
     return RosterSession(json: json)!
 }
 
@@ -53,6 +55,7 @@ final class SessionSearchMatchTests: XCTestCase {
     func testMatchesEachField() {
         XCTAssertTrue(SessionSearch.matches(makeSession(title: "Rework onboarding"), tokens: ["onboard"]))
         XCTAssertTrue(SessionSearch.matches(makeSession(recap: "Opened a draft PR"), tokens: ["draft"]))
+        XCTAssertTrue(SessionSearch.matches(makeSession(error: "Rate limit reached"), tokens: ["rate"]))
         XCTAssertTrue(SessionSearch.matches(makeSession(workspace: "luke-ios"), tokens: ["luke-ios"]))
         XCTAssertTrue(SessionSearch.matches(makeSession(branch: "feat/search-header"), tokens: ["search-header"]))
         XCTAssertTrue(SessionSearch.matches(makeSession(status: "waiting"), tokens: ["waiting"]))

--- a/apps/ios/LukeKit/Tests/LukeKitTests/SessionSearchTests.swift
+++ b/apps/ios/LukeKit/Tests/LukeKitTests/SessionSearchTests.swift
@@ -1,0 +1,71 @@
+import XCTest
+
+@testable import LukeKit
+
+private func makeSession(
+    providerId: String = "conductor",
+    title: String = "Ship the roster",
+    status: String = "working",
+    workspace: String? = nil,
+    branch: String? = nil,
+    recap: String? = nil
+) -> RosterSession {
+    var json: [String: Any] = [
+        "providerId": providerId,
+        "sessionId": "s1",
+        "title": title,
+        "status": status,
+    ]
+    if let workspace { json["workspace"] = workspace }
+    if let branch { json["branch"] = branch }
+    if let recap { json["recap"] = recap }
+    return RosterSession(json: json)!
+}
+
+final class SessionSearchTokenTests: XCTestCase {
+    func testLowercasesAndSplitsOnWhitespace() {
+        XCTAssertEqual(SessionSearch.tokens(from: "  Fix\tLogin\nBug "), ["fix", "login", "bug"])
+    }
+
+    func testBlankQueryHasNoTokens() {
+        XCTAssertEqual(SessionSearch.tokens(from: ""), [])
+        XCTAssertEqual(SessionSearch.tokens(from: "   \n\t"), [])
+    }
+}
+
+final class SessionSearchMatchTests: XCTestCase {
+    func testNoTokensMatchesEverything() {
+        XCTAssertTrue(SessionSearch.matches(makeSession(), tokens: []))
+    }
+
+    func testMatchIsCaseBlindSubstring() {
+        let session = makeSession(title: "Ship the Roster")
+        XCTAssertTrue(SessionSearch.matches(session, tokens: SessionSearch.tokens(from: "ROST")))
+        XCTAssertFalse(SessionSearch.matches(session, tokens: SessionSearch.tokens(from: "rooster")))
+    }
+
+    func testEveryTokenMustLandSomewhere() {
+        let session = makeSession(title: "Fix login", branch: "feature/auth")
+        XCTAssertTrue(SessionSearch.matches(session, tokens: SessionSearch.tokens(from: "fix auth")))
+        XCTAssertFalse(SessionSearch.matches(session, tokens: SessionSearch.tokens(from: "fix payments")))
+    }
+
+    func testMatchesEachField() {
+        XCTAssertTrue(SessionSearch.matches(makeSession(title: "Rework onboarding"), tokens: ["onboard"]))
+        XCTAssertTrue(SessionSearch.matches(makeSession(recap: "Opened a draft PR"), tokens: ["draft"]))
+        XCTAssertTrue(SessionSearch.matches(makeSession(workspace: "luke-ios"), tokens: ["luke-ios"]))
+        XCTAssertTrue(SessionSearch.matches(makeSession(branch: "feat/search-header"), tokens: ["search-header"]))
+        XCTAssertTrue(SessionSearch.matches(makeSession(status: "waiting"), tokens: ["waiting"]))
+    }
+
+    func testMatchesProviderByWireId() {
+        XCTAssertTrue(SessionSearch.matches(makeSession(providerId: "cursor", title: "Untitled"), tokens: ["cursor"]))
+        // A provider the vault does not list still matches on its wire id.
+        XCTAssertTrue(SessionSearch.matches(makeSession(providerId: "claude-code", title: "Untitled"), tokens: ["claude"]))
+    }
+
+    func testAbsentOptionalFieldsNeverMatch() {
+        let bare = makeSession(title: "Untitled")
+        XCTAssertFalse(SessionSearch.matches(bare, tokens: ["main"]))
+    }
+}


### PR DESCRIPTION
## What

Adds session search to the signed-in sessions screen's header, mirroring the desktop's session search (`apps/desktop/src/renderer/session-search.tsx` / `session-model.ts`).

- `SessionsView` takes the system's own `.searchable(text:prompt:)` on the sessions list. On iOS 26 it carries `.searchToolbarBehavior(.minimize)`, so search renders as the system's magnifier button in the navigation bar until pressed; on iOS 17–25 (the deployment target is 17.0) the bar keeps its standard search-field presentation for a searchable list. No hand-rolled toolbar field.
- Match semantics are the desktop's, in `SessionSearch` (new, in LukeKit beside `RosterSession`): the query is lowercased and split on whitespace, every token must land somewhere on the row, and a token lands by plain substring. A blank query is no search at all. The searchable lines are the fields a `RosterSession` carries: title, recap, workspace, branch, the status word, and the provider (wire id, plus the vault's display name where it resolves).
- The list filters live as the query changes; when nothing matches, the list shows `ContentUnavailableView.search(text:)`, the system empty state.
- New `SessionSearchTests` in LukeKitTests cover tokenizing (lowercasing, whitespace splitting, blank query), AND-across-tokens, case-blind substring, per-field coverage, provider-id matching, and that absent optional fields never match.

The rest of the row's visual language (Palette semantic colors, light/dark from #596) is untouched; the system search UI and `ContentUnavailableView` adapt to both appearances on their own. The toolbar in `ContentView.swift` is deliberately untouched so the sibling filter-button PR rebases cleanly against this one.

## Why

The desktop panel can already find a session by anything its row says; the iOS roster could not be narrowed at all. This gives the main page the same search with native machinery, and keeps the match semantics shared in spirit with the desktop so the two surfaces cannot disagree about what finds a session.

## How verified

This branch was authored in a Linux cloud workspace, so the honest picture:

- `./scripts/check.sh` — **passed** (exit 0): repository checks, types, tests, and builds for the portable workspace.
- `SessionSearch` unit tests — **passed, 8/8**, via `swift test` on Swift 6.2.1 (Linux x86_64), in a scratch SwiftPM package holding verbatim copies of `SessionSearch.swift`, `SessionSearchTests.swift`, `RosterSession.swift`, `AccountConstants.swift`, and `AccountClient.swift`/`VaultClient.swift` (the last two with only a `#if canImport(FoundationNetworking)` import shim prepended, which Linux Foundation needs for `URLSession`). The full `cd apps/ios/LukeKit && swift test` could **not** run here: `PKCE.swift` and `KeychainStore.swift` import Apple-only `CryptoKit`/`Security`, so the package only builds on a Mac.
- `xcodebuild build` / `xcodebuild test` for the Luke scheme — **not run**: no macOS/Xcode in this environment.
- **No simulator or device verification was performed.** The iOS 26 minimized presentation and the iOS 17 fallback presentation should be eyeballed on a simulator before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/ee7ebb81-a932-445f-9ef0-c6d1d7c049ec)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/33464313712/artifacts/9784356409) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/33464313712)

- Commit: `4bef6ad5a87776e3f13116b9f7ad35853f23508e`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
