### PR TITLE
feat(ios): add session filtering and sorting beside search

### DIFF
--- a/apps/ios/Luke/SessionsView.swift
+++ b/apps/ios/Luke/SessionsView.swift
@@ -9,14 +9,17 @@ struct SessionsView: View {
     @State private var isLoading = false
     @State private var fetchError: String?
     @State private var searchQuery = ""
+    @State private var filters: Set<SessionFilter> = []
+    @State private var sort: SessionSort = .urgency
+    @State private var optionsShown = false
 
     private let client = RosterClient(serviceURL: AccountConstants.serviceURL)
 
     var body: some View {
         if #available(iOS 26.0, *) {
-            // Minimized, the search is the magnifier button in the navigation
-            // bar until pressed; earlier systems keep the field the bar draws
-            // for a searchable list.
+            // Minimized, the search is the magnifier button in the bar until
+            // pressed; earlier systems keep the field the bar draws for a
+            // searchable list.
             searchableList.searchToolbarBehavior(.minimize)
         } else {
             searchableList
@@ -25,10 +28,19 @@ struct SessionsView: View {
 
     /// The rows the query leaves: matched with the desktop's own search
     /// semantics, and everything when the query is blank.
-    private var visibleSessions: [RosterSession] {
+    private var searchMatchedSessions: [RosterSession] {
         let tokens = SessionSearch.tokens(from: searchQuery)
         if tokens.isEmpty { return sessions }
         return sessions.filter { SessionSearch.matches($0, tokens: tokens) }
+    }
+
+    /// What the list draws: the query's rows, narrowed by the filter
+    /// selection, in the order the chosen sort names.
+    private var visibleSessions: [RosterSession] {
+        sortedSessions(
+            searchMatchedSessions.filter { matchesFilterSelection(filters, session: $0) },
+            by: sort
+        )
     }
 
     private var searchableList: some View {
@@ -44,8 +56,12 @@ struct SessionsView: View {
                 emptyRow
                     .listRowBackground(Color.clear)
                     .listRowSeparator(.hidden)
-            } else if visibleSessions.isEmpty {
+            } else if searchMatchedSessions.isEmpty {
                 ContentUnavailableView.search(text: searchQuery)
+                    .listRowBackground(Color.clear)
+                    .listRowSeparator(.hidden)
+            } else if visibleSessions.isEmpty {
+                filteredOutRow
                     .listRowBackground(Color.clear)
                     .listRowSeparator(.hidden)
             } else {
@@ -63,8 +79,50 @@ struct SessionsView: View {
         .toolbarBackground(Color.ground, for: .navigationBar)
         .toolbarBackground(.visible, for: .navigationBar)
         .searchable(text: $searchQuery, prompt: "Search sessions")
+        .toolbar {
+            // The filter rides with the search the way Notion docks one in
+            // its search pill: on iOS 26 the system search moves into the
+            // bottom bar and the button stands beside it; earlier systems
+            // keep the bar's own search presentation, so the button keeps
+            // the trailing slot above it.
+            if #available(iOS 26.0, *) {
+                DefaultToolbarItem(kind: .search, placement: .bottomBar)
+                ToolbarSpacer(.flexible, placement: .bottomBar)
+                ToolbarItem(placement: .bottomBar) {
+                    optionsButton
+                }
+            } else {
+                ToolbarItem(placement: .topBarTrailing) {
+                    optionsButton
+                }
+            }
+        }
+        .sheet(isPresented: $optionsShown) {
+            SessionOptionsSheet(sessions: sessions, filters: $filters, sort: $sort)
+                .presentationDetents([.medium, .large])
+        }
         .refreshable { await refreshSessions() }
         .task { await refreshSessions() }
+    }
+
+    private var optionsButton: some View {
+        Button {
+            optionsShown = true
+        } label: {
+            Label("Filter & Sort", systemImage: "line.3.horizontal.decrease")
+                .symbolVariant(filters.isEmpty ? .none : .circle.fill)
+        }
+    }
+
+    private var filteredOutRow: some View {
+        ContentUnavailableView {
+            Label("No matching sessions", systemImage: "line.3.horizontal.decrease")
+        } description: {
+            Text("Filters hide ^[\(searchMatchedSessions.count) sessions](inflect: true).")
+        } actions: {
+            Button("Clear Filters") { filters.removeAll() }
+        }
+        .padding(.top, 40)
     }
 
     private let rowInsets = EdgeInsets(top: 4, leading: 16, bottom: 4, trailing: 16)
@@ -102,6 +160,140 @@ struct SessionsView: View {
         } catch {
             fetchError = error.localizedDescription
         }
+    }
+}
+
+// MARK: - Options sheet
+
+private func axisTitle(_ axis: SessionFilterAxis) -> String {
+    switch axis {
+    case .provider: "Provider"
+    case .status: "Status"
+    }
+}
+
+private func optionTitle(_ filter: SessionFilter) -> String {
+    switch filter {
+    case .provider(let providerId):
+        VaultProviderID(rawValue: providerId)?.displayName ?? providerId.capitalized
+    case .status(let status):
+        status.capitalized
+    }
+}
+
+/// The half sheet the search bar's filter button opens, in the system's own
+/// grouped-sheet vocabulary (the profile sheet's): the sort as a checkmark
+/// list, one drill-in page per filter axis with the selection named on its
+/// row, and a clear action only while something is selected. The list behind
+/// stays visible above the medium detent, so every choice shows its effect
+/// as it is made.
+private struct SessionOptionsSheet: View {
+    let sessions: [RosterSession]
+    @Binding var filters: Set<SessionFilter>
+    @Binding var sort: SessionSort
+    @Environment(\.dismiss) private var dismiss
+
+    private var groups: [SessionFilterAxisOptions] {
+        sessionFilterOptions(sessions: sessions, selection: filters)
+    }
+
+    var body: some View {
+        NavigationStack {
+            List {
+                Section("Sort by") {
+                    sortRow(.urgency, label: "Urgent", detail: "Most urgent first")
+                    sortRow(.recency, label: "Recent", detail: "Most recently observed first")
+                }
+                if !groups.isEmpty {
+                    Section("Filter by") {
+                        ForEach(groups) { group in
+                            NavigationLink {
+                                AxisFilterPage(group: group, filters: $filters)
+                            } label: {
+                                LabeledContent(axisTitle(group.axis), value: selectionSummary(for: group))
+                            }
+                        }
+                    }
+                }
+                if !filters.isEmpty {
+                    Section {
+                        Button("Clear Filters") { filters.removeAll() }
+                            .frame(maxWidth: .infinity)
+                    }
+                }
+            }
+            .navigationTitle("Filter & Sort")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Done") { dismiss() }
+                }
+            }
+        }
+    }
+
+    private func sortRow(_ value: SessionSort, label: String, detail: String) -> some View {
+        Button {
+            sort = value
+        } label: {
+            HStack {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(label)
+                        .foregroundStyle(Color.ink)
+                    Text(detail)
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                }
+                Spacer()
+                Image(systemName: "checkmark")
+                    .fontWeight(.semibold)
+                    .opacity(sort == value ? 1 : 0)
+            }
+        }
+        .accessibilityAddTraits(sort == value ? .isSelected : [])
+    }
+
+    private func selectionSummary(for group: SessionFilterAxisOptions) -> String {
+        let chosen = group.options
+            .filter { filters.contains($0.filter) }
+            .map { optionTitle($0.filter) }
+        return chosen.isEmpty ? "All" : chosen.joined(separator: ", ")
+    }
+}
+
+/// One axis's checklist page: every observed value with its session count,
+/// toggled by row press. The checkmark keeps its slot when unchosen so rows
+/// do not shift underfoot.
+private struct AxisFilterPage: View {
+    let group: SessionFilterAxisOptions
+    @Binding var filters: Set<SessionFilter>
+
+    var body: some View {
+        List {
+            ForEach(group.options) { option in
+                Button {
+                    if filters.contains(option.filter) {
+                        filters.remove(option.filter)
+                    } else {
+                        filters.insert(option.filter)
+                    }
+                } label: {
+                    HStack {
+                        Text(optionTitle(option.filter))
+                            .foregroundStyle(Color.ink)
+                        Spacer()
+                        Text(option.count, format: .number)
+                            .foregroundStyle(.secondary)
+                        Image(systemName: "checkmark")
+                            .fontWeight(.semibold)
+                            .opacity(filters.contains(option.filter) ? 1 : 0)
+                    }
+                }
+                .accessibilityAddTraits(filters.contains(option.filter) ? .isSelected : [])
+            }
+        }
+        .navigationTitle(axisTitle(group.axis))
+        .navigationBarTitleDisplayMode(.inline)
     }
 }
 

--- a/apps/ios/Luke/SessionsView.swift
+++ b/apps/ios/Luke/SessionsView.swift
@@ -278,7 +278,8 @@ private struct AxisFilterPage: View {
                         filters.insert(option.filter)
                     }
                 } label: {
-                    HStack {
+                    HStack(spacing: 12) {
+                        optionMark(option.filter)
                         Text(optionTitle(option.filter))
                             .foregroundStyle(Color.ink)
                         Spacer()
@@ -294,6 +295,56 @@ private struct AxisFilterPage: View {
         }
         .navigationTitle(axisTitle(group.axis))
         .navigationBarTitleDisplayMode(.inline)
+    }
+
+    /// A provider row wears the same brand mark its sessions wear; a status
+    /// row a glyph in the same 30pt slot, so the two pages read as one.
+    @ViewBuilder
+    private func optionMark(_ filter: SessionFilter) -> some View {
+        switch filter {
+        case .provider(let providerId):
+            RosterProviderMark(providerId: providerId)
+        case .status(let status):
+            StatusMark(status: status)
+        }
+    }
+}
+
+/// A status's own glyph in the row-mark's slot, colored the way the session
+/// rows already speak that status: waiting's orange, complete's green, an
+/// error's red, and the neutral inks for working and anything unknown.
+private struct StatusMark: View {
+    let status: String
+
+    var body: some View {
+        ZStack {
+            RoundedRectangle(cornerRadius: 7)
+                .fill(Color.pressedFill)
+                .frame(width: 30, height: 30)
+            Image(systemName: symbol)
+                .font(.system(size: 15, weight: .medium))
+                .foregroundStyle(color)
+        }
+    }
+
+    private var symbol: String {
+        switch status {
+        case "working": "circle.dashed"
+        case "waiting": "exclamationmark.circle"
+        case "complete": "checkmark.circle"
+        case "error": "xmark.circle"
+        default: "questionmark.circle"
+        }
+    }
+
+    private var color: Color {
+        switch status {
+        case "working": Color.inkSecondary
+        case "waiting": Color(red: 1.0, green: 0.627, blue: 0.286)
+        case "complete": Color.stateComplete
+        case "error": Color.errorInk
+        default: Color.inkTertiary
+        }
     }
 }
 

--- a/apps/ios/Luke/SessionsView.swift
+++ b/apps/ios/Luke/SessionsView.swift
@@ -112,6 +112,7 @@ struct SessionsView: View {
             Label("Filter & Sort", systemImage: "line.3.horizontal.decrease")
                 .symbolVariant(filters.isEmpty ? .none : .circle.fill)
         }
+        .tint(Color.ink)
     }
 
     private var filteredOutRow: some View {
@@ -121,6 +122,7 @@ struct SessionsView: View {
             Text("Filters hide ^[\(searchMatchedSessions.count) sessions](inflect: true).")
         } actions: {
             Button("Clear Filters") { filters.removeAll() }
+                .tint(Color.ink)
         }
         .padding(.top, 40)
     }
@@ -186,7 +188,8 @@ private func optionTitle(_ filter: SessionFilter) -> String {
 /// list, one drill-in page per filter axis with the selection named on its
 /// row, and a clear action only while something is selected. The list behind
 /// stays visible above the medium detent, so every choice shows its effect
-/// as it is made.
+/// as it is made. The accent stays the checkmarks' alone — every other
+/// control here wears the panel's own ink.
 private struct SessionOptionsSheet: View {
     let sessions: [RosterSession]
     @Binding var filters: Set<SessionFilter>
@@ -219,6 +222,7 @@ private struct SessionOptionsSheet: View {
                     Section {
                         Button("Clear Filters") { filters.removeAll() }
                             .frame(maxWidth: .infinity)
+                            .tint(Color.ink)
                     }
                 }
             }
@@ -227,6 +231,7 @@ private struct SessionOptionsSheet: View {
             .toolbar {
                 ToolbarItem(placement: .confirmationAction) {
                     Button("Done") { dismiss() }
+                        .tint(Color.ink)
                 }
             }
         }

--- a/apps/ios/LukeKit/Sources/LukeKit/SessionFilter.swift
+++ b/apps/ios/LukeKit/Sources/LukeKit/SessionFilter.swift
@@ -1,0 +1,125 @@
+import Foundation
+
+/// One narrowing the sessions list can hold: a provider whose sessions to
+/// keep, or a status. The values are identities a row already carries, read
+/// straight off the observed roster rather than from a fixed set, because the
+/// wire's provider ids and statuses are open vocabularies this app does not
+/// own. Mirrors `SessionFilter` in `packages/session/src/session-filter.ts`,
+/// narrowed to the two axes the roster's wire shape actually distinguishes.
+public enum SessionFilter: Hashable, Sendable {
+    case provider(String)
+    case status(String)
+
+    public var axis: SessionFilterAxis {
+        switch self {
+        case .provider: .provider
+        case .status: .status
+        }
+    }
+
+    /// The observed value this filter keeps: a session answers it when the
+    /// field its axis reads carries this string.
+    public var value: String {
+        switch self {
+        case .provider(let providerId): providerId
+        case .status(let status): status
+        }
+    }
+}
+
+/// The independent questions the filters answer. Each filter value belongs to
+/// exactly one axis, and the axis is what gives a combined selection its
+/// meaning: values on one axis are alternatives, where values on different
+/// axes are each a further narrowing.
+public enum SessionFilterAxis: CaseIterable, Hashable, Sendable {
+    case provider
+    case status
+
+    fileprivate func filter(_ value: String) -> SessionFilter {
+        switch self {
+        case .provider: .provider(value)
+        case .status: .status(value)
+        }
+    }
+}
+
+extension RosterSession {
+    fileprivate func filterValue(on axis: SessionFilterAxis) -> String {
+        switch axis {
+        case .provider: providerId
+        case .status: status
+        }
+    }
+}
+
+/// Whether a session answers the whole selection. Within one axis the values
+/// are ORed — two providers together is either provider — and across axes
+/// they are ANDed — a provider beside a status is that provider's sessions in
+/// that status. An axis nothing is chosen on asks nothing, so an empty
+/// selection is the unnarrowed list. Mirrors `matchesFilterSelection` in
+/// `packages/session/src/session-filter.ts`.
+public func matchesFilterSelection(
+    _ selection: Set<SessionFilter>,
+    session: RosterSession
+) -> Bool {
+    for axis in SessionFilterAxis.allCases {
+        let alternatives = selection.filter { $0.axis == axis }
+        if alternatives.isEmpty { continue }
+        let observed = session.filterValue(on: axis)
+        if !alternatives.contains(where: { $0.value == observed }) { return false }
+    }
+    return true
+}
+
+/// One offerable filter beside how many observed sessions carry its value.
+public struct SessionFilterOption: Hashable, Sendable, Identifiable {
+    public let filter: SessionFilter
+    public let count: Int
+
+    public var id: SessionFilter { filter }
+
+    public init(filter: SessionFilter, count: Int) {
+        self.filter = filter
+        self.count = count
+    }
+}
+
+/// One axis's options, in the order the menu draws them.
+public struct SessionFilterAxisOptions: Hashable, Sendable, Identifiable {
+    public let axis: SessionFilterAxis
+    public let options: [SessionFilterOption]
+
+    public var id: SessionFilterAxis { axis }
+
+    public init(axis: SessionFilterAxis, options: [SessionFilterOption]) {
+        self.axis = axis
+        self.options = options
+    }
+}
+
+/// The filter menu's contents for an observed roster. An axis is offered only
+/// while it is a real choice — more than one distinct value among the
+/// observed sessions — because a filter every session answers narrows
+/// nothing. On an offered axis, a selected value the roster no longer shows
+/// stays listed at zero, so a checkmark that still narrows the list can
+/// always be lifted where it was set. Options sort by value, not count, so a
+/// refresh cannot reorder the menu under an open press.
+public func sessionFilterOptions(
+    sessions: [RosterSession],
+    selection: Set<SessionFilter>
+) -> [SessionFilterAxisOptions] {
+    SessionFilterAxis.allCases.compactMap { axis in
+        var counts: [String: Int] = [:]
+        for session in sessions {
+            counts[session.filterValue(on: axis), default: 0] += 1
+        }
+        guard counts.count > 1 else { return nil }
+        for filter in selection where filter.axis == axis {
+            if counts[filter.value] == nil { counts[filter.value] = 0 }
+        }
+        let options = counts
+            .sorted { $0.key < $1.key }
+            .map { SessionFilterOption(filter: axis.filter($0.key), count: $0.value) }
+        return SessionFilterAxisOptions(axis: axis, options: options)
+    }
+}

--- a/apps/ios/LukeKit/Sources/LukeKit/SessionSort.swift
+++ b/apps/ios/LukeKit/Sources/LukeKit/SessionSort.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+/// What puts a session at the top. Mirrors `SESSION_LIST_SORT` in
+/// `packages/guide/src/guide.ts` and the desktop's comparators: most urgent
+/// first with recency breaking ties, or last-moved first with urgency
+/// breaking ties.
+public enum SessionSort: CaseIterable, Hashable, Sendable {
+    case urgency
+    case recency
+}
+
+/// The desktop's `URGENCY_PRIORITY` read off the wire statuses: waiting and
+/// error both need the developer, so both rank ahead of a session still
+/// working, and a status this build does not know ranks with unknown.
+private func urgencyRank(of session: RosterSession) -> Int {
+    switch session.status {
+    case "waiting", "error": 0
+    case "working": 1
+    case "complete": 2
+    default: 3
+    }
+}
+
+/// A session the endpoint never dated ranks as the least recently moved.
+private func lastMoved(_ session: RosterSession) -> Date {
+    session.observedAt ?? .distantPast
+}
+
+/// The roster in the order a sort names. `sorted(by:)` is documented stable,
+/// so sessions the comparator cannot tell apart keep the wire's own order.
+public func sortedSessions(_ sessions: [RosterSession], by sort: SessionSort) -> [RosterSession] {
+    switch sort {
+    case .urgency:
+        sessions.sorted {
+            let (left, right) = (urgencyRank(of: $0), urgencyRank(of: $1))
+            return left != right ? left < right : lastMoved($0) > lastMoved($1)
+        }
+    case .recency:
+        sessions.sorted {
+            let (left, right) = (lastMoved($0), lastMoved($1))
+            return left != right ? left > right : urgencyRank(of: $0) < urgencyRank(of: $1)
+        }
+    }
+}

--- a/apps/ios/LukeKit/Tests/LukeKitTests/SessionFilterTests.swift
+++ b/apps/ios/LukeKit/Tests/LukeKitTests/SessionFilterTests.swift
@@ -1,0 +1,92 @@
+import Foundation
+import XCTest
+
+@testable import LukeKit
+
+private func makeSession(provider: String, status: String) -> RosterSession {
+    RosterSession(json: [
+        "providerId": provider,
+        "sessionId": UUID().uuidString,
+        "title": "Task",
+        "status": status,
+    ])!
+}
+
+// MARK: - Matching
+
+final class SessionFilterMatchTests: XCTestCase {
+    func testEmptySelectionIsUnnarrowed() {
+        XCTAssertTrue(matchesFilterSelection([], session: makeSession(provider: "conductor", status: "working")))
+    }
+
+    func testValuesWithinAnAxisAreORed() {
+        let either: Set<SessionFilter> = [.provider("conductor"), .provider("devin")]
+        XCTAssertTrue(matchesFilterSelection(either, session: makeSession(provider: "conductor", status: "working")))
+        XCTAssertTrue(matchesFilterSelection(either, session: makeSession(provider: "devin", status: "waiting")))
+        XCTAssertFalse(matchesFilterSelection(either, session: makeSession(provider: "jules", status: "working")))
+    }
+
+    func testAxesAreANDed() {
+        let both: Set<SessionFilter> = [.provider("conductor"), .status("waiting")]
+        XCTAssertTrue(matchesFilterSelection(both, session: makeSession(provider: "conductor", status: "waiting")))
+        XCTAssertFalse(matchesFilterSelection(both, session: makeSession(provider: "conductor", status: "working")))
+        XCTAssertFalse(matchesFilterSelection(both, session: makeSession(provider: "devin", status: "waiting")))
+    }
+
+    func testAxisWithSelectionStillAsksWhenOtherAxisEmpty() {
+        let statusOnly: Set<SessionFilter> = [.status("complete")]
+        XCTAssertTrue(matchesFilterSelection(statusOnly, session: makeSession(provider: "devin", status: "complete")))
+        XCTAssertFalse(matchesFilterSelection(statusOnly, session: makeSession(provider: "devin", status: "working")))
+    }
+}
+
+// MARK: - Options
+
+final class SessionFilterOptionsTests: XCTestCase {
+    func testAxisOfferedOnlyWhenARealChoice() {
+        let sessions = [
+            makeSession(provider: "conductor", status: "working"),
+            makeSession(provider: "devin", status: "working"),
+        ]
+        let groups = sessionFilterOptions(sessions: sessions, selection: [])
+        XCTAssertEqual(groups.map(\.axis), [.provider])
+    }
+
+    func testNoAxisOfferedForEmptyOrUniformRoster() {
+        XCTAssertTrue(sessionFilterOptions(sessions: [], selection: []).isEmpty)
+        let uniform = [
+            makeSession(provider: "conductor", status: "working"),
+            makeSession(provider: "conductor", status: "working"),
+        ]
+        XCTAssertTrue(sessionFilterOptions(sessions: uniform, selection: []).isEmpty)
+    }
+
+    func testOptionsCarryCountsSortedByValue() {
+        let sessions = [
+            makeSession(provider: "devin", status: "working"),
+            makeSession(provider: "conductor", status: "waiting"),
+            makeSession(provider: "devin", status: "complete"),
+        ]
+        let groups = sessionFilterOptions(sessions: sessions, selection: [])
+        XCTAssertEqual(groups.map(\.axis), [.provider, .status])
+        XCTAssertEqual(groups[0].options, [
+            SessionFilterOption(filter: .provider("conductor"), count: 1),
+            SessionFilterOption(filter: .provider("devin"), count: 2),
+        ])
+        XCTAssertEqual(groups[1].options, [
+            SessionFilterOption(filter: .status("complete"), count: 1),
+            SessionFilterOption(filter: .status("waiting"), count: 1),
+            SessionFilterOption(filter: .status("working"), count: 1),
+        ])
+    }
+
+    func testSelectedValueNoLongerObservedStaysListedAtZero() {
+        let sessions = [
+            makeSession(provider: "conductor", status: "working"),
+            makeSession(provider: "devin", status: "working"),
+        ]
+        let groups = sessionFilterOptions(sessions: sessions, selection: [.provider("jules")])
+        XCTAssertEqual(groups.map(\.axis), [.provider])
+        XCTAssertTrue(groups[0].options.contains(SessionFilterOption(filter: .provider("jules"), count: 0)))
+    }
+}

--- a/apps/ios/LukeKit/Tests/LukeKitTests/SessionSortTests.swift
+++ b/apps/ios/LukeKit/Tests/LukeKitTests/SessionSortTests.swift
@@ -1,0 +1,61 @@
+import Foundation
+import XCTest
+
+@testable import LukeKit
+
+private func makeSession(_ id: String, status: String, observedAt: Double? = nil) -> RosterSession {
+    var json: [String: Any] = [
+        "providerId": "conductor",
+        "sessionId": id,
+        "title": "Task",
+        "status": status,
+    ]
+    if let observedAt { json["observedAt"] = observedAt }
+    return RosterSession(json: json)!
+}
+
+final class SessionSortTests: XCTestCase {
+    func testUrgencyRanksNeedsYouFirstAndUnknownStatusLast() {
+        let sessions = [
+            makeSession("done", status: "complete"),
+            makeSession("novel", status: "someday-status"),
+            makeSession("busy", status: "working"),
+            makeSession("stuck", status: "error"),
+            makeSession("held", status: "waiting"),
+        ]
+        // stuck and held tie on urgency with no dates, so the wire's own
+        // order between them survives the sort.
+        XCTAssertEqual(
+            sortedSessions(sessions, by: .urgency).map(\.sessionId),
+            ["stuck", "held", "busy", "done", "novel"]
+        )
+    }
+
+    func testUrgencyTiesBreakByRecency() {
+        let sessions = [
+            makeSession("old", status: "working", observedAt: 1_000),
+            makeSession("new", status: "working", observedAt: 2_000),
+        ]
+        XCTAssertEqual(sortedSessions(sessions, by: .urgency).map(\.sessionId), ["new", "old"])
+    }
+
+    func testRecencyPutsLastMovedFirst() {
+        let sessions = [
+            makeSession("old", status: "waiting", observedAt: 1_000),
+            makeSession("new", status: "complete", observedAt: 2_000),
+            makeSession("undated", status: "working"),
+        ]
+        XCTAssertEqual(
+            sortedSessions(sessions, by: .recency).map(\.sessionId),
+            ["new", "old", "undated"]
+        )
+    }
+
+    func testRecencyTiesBreakByUrgency() {
+        let sessions = [
+            makeSession("done", status: "complete", observedAt: 1_000),
+            makeSession("stuck", status: "error", observedAt: 1_000),
+        ]
+        XCTAssertEqual(sortedSessions(sessions, by: .recency).map(\.sessionId), ["stuck", "done"])
+    }
+}


### PR DESCRIPTION
## What

The sessions screen gets a filter button that rides with the search, the way Notion docks one in its search pill, opening a half sheet of filter and sort options:

- **iOS 26**: the system search moves into the bottom bar (`DefaultToolbarItem(kind: .search, placement: .bottomBar)`) with the filter button beside it across a flexible `ToolbarSpacer` — the bottom search-pill-plus-action layout from the platform's own vocabulary, closest to the Notion reference. Earlier systems keep `.searchable`'s standard bar presentation with the button at `.topBarTrailing`.
- The button wears `line.3.horizontal.decrease` (Notion's own glyph), switching to the `.circle.fill` variant while any filter is applied.
- Pressing it opens a **half sheet** (`presentationDetents([.medium, .large])`): "Sort by" as a checkmark list (Urgent / Recent, the desktop's two sorts, urgency default), a "Filter by" section with **one drill-in checklist page per axis** (Provider, Status) showing per-option counts and naming the current selection on the row ("All" when unnarrowed); provider rows wear the same brand mark the session rows draw, and status rows a colored SF Symbol in the same slot, and a "Clear Filters" action only while something is selected. The list stays visible above the medium detent, so each choice shows its effect live.
- Search, filters, and sort compose: the query narrows first, the filter selection narrows further, the sort orders what remains. When filters hide every search match, a `ContentUnavailableView` says how many sessions they hide, with a clear button; an empty search keeps the system's own search empty state.

## Why

Mirrors the desktop's session options (`packages/session/src/session-filter.ts`, `SessionOptionsButton`/`SessionOptions` in `apps/desktop/src/renderer/session-parts.tsx`) with iOS-native presentation. Combining semantics are the desktop's exactly: OR within an axis, AND across axes, empty selection unnarrowed; an axis is offered only while it is a real choice (more than one distinct observed value); urgency ranks waiting/error, then working, complete, unknown, with recency breaking ties, and recency sorts last-moved first with urgency breaking ties.

## How

- `apps/ios/LukeKit/Sources/LukeKit/SessionFilter.swift` — the filter vocabulary: `SessionFilter` (provider/status), `matchesFilterSelection`, `sessionFilterOptions` (real-choice axes, whole-roster counts, value-sorted options, vanished-selection kept at zero).
- `apps/ios/LukeKit/Sources/LukeKit/SessionSort.swift` — `SessionSort` and `sortedSessions`, mirroring `SESSION_LIST_SORT` and the desktop comparators.
- `apps/ios/Luke/SessionsView.swift` — the toolbar placement, `SessionOptionsSheet`, `AxisFilterPage`, and the filtered-empty state, rebased onto the merged search (#601) and timestamp fix (#604); search matching (`SessionSearch`) is untouched.
- `apps/ios/LukeKit/Tests/LukeKitTests/SessionFilterTests.swift`, `SessionSortTests.swift` — OR-within-axis, AND-across-axes, empty-selection-unnarrowed, axis-only-when-a-real-choice, counts/ordering, vanished-selection-at-zero, urgency/recency ordering and tiebreaks.

Logic lives in LukeKit so SwiftPM's globbed sources pick it up with no `project.pbxproj` churn and the tests run without a simulator.

## How verified

Authored in a Linux workspace with no macOS/Xcode available, so verification is partial — stated exactly:

- `./scripts/check.sh` — **passed** (exit 0).
- The unit tests — **12/12 passed**, run with Swift 6.3.3 on Linux against a scratch package holding verbatim copies of `RosterSession.swift`, `SessionFilter.swift`, `SessionSort.swift`, and the test files (the full LukeKit package imports Apple-only CryptoKit/Security, so whole-package `swift test` needs a Mac).
- `apps/ios/Luke/SessionsView.swift` — syntax-parsed only (`swiftc -parse`); **not** compiled against the iOS SDK.
- **No simulator or device verification was performed.** The `xcodebuild build`/`test` and `swift test` runs `apps/ios/README.md` calls for still need a Mac before merge, and CI has no iOS job to catch this. Worth eyeballing on a simulator: the iOS 26 bottom-bar arrangement (`DefaultToolbarItem`/`ToolbarSpacer` with `searchToolbarBehavior(.minimize)`), the half sheet at the medium detent, and the drill-in pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/33467853616/artifacts/9785549172) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/33467853616)

- Commit: `b51f5fbda9eb3d698f652e6de665c0bfc7318d0d`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

