### PR TITLE
fix(ios): abbreviate session row timestamps the way desktop does

### DIFF
--- a/apps/ios/Luke/SessionsView.swift
+++ b/apps/ios/Luke/SessionsView.swift
@@ -100,10 +100,15 @@ private struct SessionRow: View {
             }
             Spacer(minLength: 0)
             if let date = session.observedAt {
-                Text(date, format: .relative(presentation: .numeric, unitsStyle: .abbreviated))
-                    .font(.system(size: 10))
-                    .foregroundStyle(Color.inkTertiary)
-                    .padding(.top, 2)
+                // The 30-second cadence is the desktop rows' own freshness tick:
+                // without it a minute-granularity label stales until something
+                // else happens to re-render the list.
+                TimelineView(.periodic(from: .distantPast, by: 30)) { context in
+                    Text(observedAgoLabel(observedAt: date, now: context.date))
+                }
+                .font(.system(size: 10))
+                .foregroundStyle(Color.inkTertiary)
+                .padding(.top, 2)
             }
         }
         .padding(.horizontal, 14)

--- a/apps/ios/LukeKit/Sources/LukeKit/ObservedAgoLabel.swift
+++ b/apps/ios/LukeKit/Sources/LukeKit/ObservedAgoLabel.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+/// How long ago a session was observed, worded by the coarsest unit that has
+/// begun — the same rule as the desktop panel's `observedAgoLabel` in
+/// `packages/panel/src/layout.ts`, so a session reads the same age on both
+/// surfaces. Single-letter units with no "ago", the way Mail and Messages
+/// abbreviate, and a timestamp ahead of this device's clock reads "Now",
+/// because clock skew between machines is not news about the session.
+public func observedAgoLabel(observedAt: Date, now: Date) -> String {
+    let elapsedMinutes = Int(floor(now.timeIntervalSince(observedAt) / 60))
+    if elapsedMinutes < 1 { return "Now" }
+    if elapsedMinutes < 60 { return "\(elapsedMinutes)m" }
+    let elapsedHours = elapsedMinutes / 60
+    if elapsedHours < 24 { return "\(elapsedHours)h" }
+    return "\(elapsedHours / 24)d"
+}

--- a/apps/ios/LukeKit/Tests/LukeKitTests/ObservedAgoLabelTests.swift
+++ b/apps/ios/LukeKit/Tests/LukeKitTests/ObservedAgoLabelTests.swift
@@ -1,0 +1,28 @@
+import Foundation
+import XCTest
+
+@testable import LukeKit
+
+/// Mirrors the desktop's boundary test for the same rule
+/// (`apps/desktop/src/renderer/session-model.test.ts`), so the two surfaces
+/// cannot drift apart silently: the label reports the coarsest unit that has
+/// begun, and a timestamp ahead of the clock is skew, not the future.
+final class ObservedAgoLabelTests: XCTestCase {
+    func testWordedByTheUnitThatHasBegun() {
+        let minute: TimeInterval = 60
+        let now = Date(timeIntervalSince1970: 100 * 24 * 60 * minute)
+        func label(_ observedAt: Date) -> String {
+            observedAgoLabel(observedAt: observedAt, now: now)
+        }
+
+        XCTAssertEqual(label(now), "Now")
+        XCTAssertEqual(label(now.addingTimeInterval(-59)), "Now")
+        XCTAssertEqual(label(now.addingTimeInterval(minute)), "Now")
+        XCTAssertEqual(label(now.addingTimeInterval(-minute)), "1m")
+        XCTAssertEqual(label(now.addingTimeInterval(-59 * minute)), "59m")
+        XCTAssertEqual(label(now.addingTimeInterval(-60 * minute)), "1h")
+        XCTAssertEqual(label(now.addingTimeInterval(-23 * 60 * minute)), "23h")
+        XCTAssertEqual(label(now.addingTimeInterval(-24 * 60 * minute)), "1d")
+        XCTAssertEqual(label(now.addingTimeInterval(-3 * 24 * 60 * minute)), "3d")
+    }
+}


### PR DESCRIPTION
## Summary

- The iOS session row formatted its timestamp with SwiftUI's built-in relative formatter (`.relative(presentation: .numeric, unitsStyle: .abbreviated)`), which renders `5 min. ago`, `0 sec. ago`, and — under clock skew — `in 3 min.`, where the desktop rows render `5m` / `Now` / `Now`.
- Ports the desktop's rule (`observedAgoLabel` in `packages/panel/src/layout.ts`) into LukeKit: the coarsest unit that has begun, single-letter units with no "ago", and a timestamp ahead of the device clock clamped to `Now`, because clock skew is not news about the session.
- Drives the label from a 30-second `TimelineView` — the iOS analogue of the desktop renderer's 30s freshness tick — so an idle row's label no longer stales until something else re-renders the list.
- `ObservedAgoLabelTests` mirrors the desktop boundary test (`session-model.test.ts`) point for point: `Now` at 0s / 59s / +1m future, `1m`, `59m`, `1h`, `23h`, `1d`, `3d`.

## How to test

```sh
cd apps/ios/LukeKit && swift test
```

CI runs no iOS job, so the LukeKit suite result is reported in the PR conversation instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/989fc3a8-1ec8-4607-a3a6-b96d976e566d)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/33464372881/artifacts/9784380807) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/33464372881)

- Commit: `57f2de344d23a1e8158cb3b2630927e45e99e124`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
