### PR TITLE
fix(ios): title the main page Sessions instead of the account name

### DIFF
--- a/apps/ios/Luke/ContentView.swift
+++ b/apps/ios/Luke/ContentView.swift
@@ -169,7 +169,7 @@ private struct SignedInView: View {
     var body: some View {
         NavigationStack {
             SessionsView()
-                .navigationTitle(identity.name ?? identity.email)
+                .navigationTitle("Sessions")
                 .navigationBarTitleDisplayMode(.inline)
                 .toolbar {
                     if #available(iOS 26.0, *) {


### PR DESCRIPTION
## Summary
The signed-in view's navigation title was the account's display name (`identity.name ?? identity.email`), which put the user's own name at the top of the main page. The page lists the user's cloud sessions, so it is now titled **Sessions**; the account's name and email stay on the profile sheet the header avatar opens.

## Validation
- `./scripts/check.sh` passes (portable checks; the change is one Swift string in the iOS app).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/0b9cb1f1-7c3f-4b61-b0ea-06a3688ed6d3)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/33464628651/artifacts/9784440437) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/33464628651)

- Commit: `1abf9a94e041c3ab3507bbcc8cb83d814d1b23bf`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
