### PR TITLE
feat(history): show local timestamps on conversation entries

### DIFF
--- a/apps/desktop/src/renderer/conversation-history-panel.test.ts
+++ b/apps/desktop/src/renderer/conversation-history-panel.test.ts
@@ -56,6 +56,26 @@ test("an announcement shows its spoken transcript", () => {
   assert.doesNotMatch(markup, /provider:|work recap:/);
 });
 
+test("a recorded entry shows its local time", () => {
+  const markup = renderToStaticMarkup(
+    createElement(ConversationHistoryPanel, {
+      entries: [
+        {
+          kind: CONVERSATION_ENTRY_KIND.REPLY,
+          words: "Checkout is ready.",
+          recordedAt: Date.parse("2026-01-02T03:04:00.000Z"),
+        },
+      ],
+      onClear: () => undefined,
+    }),
+  );
+
+  assert.match(
+    markup,
+    /<time class="history-time" dateTime="2026-01-02T03:04:00.000Z">[^<]+<\/time>/,
+  );
+});
+
 test("conversation history is blocked from optional panel recordings", () => {
   const markup = renderToStaticMarkup(
     createElement(ConversationHistoryPanel, {

--- a/apps/desktop/src/renderer/conversation-history-panel.tsx
+++ b/apps/desktop/src/renderer/conversation-history-panel.tsx
@@ -36,6 +36,8 @@ export function historyEntryPresentation(kind: ConversationEntryKind): HistoryEn
 
 const COPY_CONFIRMATION_MS = 1500;
 
+const ENTRY_TIME = new Intl.DateTimeFormat(undefined, { hour: "numeric", minute: "2-digit" });
+
 function HistoryEntryRow({ entry }: { entry: ConversationEntry }): React.JSX.Element {
   const presentation = historyEntryPresentation(entry.kind);
   const words = entry.words;
@@ -47,10 +49,19 @@ function HistoryEntryRow({ entry }: { entry: ConversationEntry }): React.JSX.Ele
     return () => clearTimeout(timer);
   }, [copied]);
 
+  const recordedAt = entry.recordedAt === undefined ? undefined : new Date(entry.recordedAt);
+
   return (
     <li className="history-entry" data-speaker={presentation.speaker}>
       <small className="visually-hidden">{presentation.label}</small>
-      <p>{words}</p>
+      <p>
+        {words}
+        {recordedAt ? (
+          <time className="history-time" dateTime={recordedAt.toISOString()}>
+            {ENTRY_TIME.format(recordedAt)}
+          </time>
+        ) : null}
+      </p>
       {presentation.speaker === HISTORY_ENTRY_SPEAKER.EVENT ? null : (
         <button
           type="button"

--- a/apps/desktop/src/renderer/styles/history.css
+++ b/apps/desktop/src/renderer/styles/history.css
@@ -127,6 +127,20 @@
   white-space: pre-wrap;
 }
 
+/* The stamp rides inside the bubble, on the last line where a chat app puts
+   it, so a thread with times lays out exactly like one without and the copy
+   control stays centred on the words. It inherits the bubble's own colour
+   because the sent bubble's ground is the accent, where a fixed secondary
+   grey would not be readable. */
+.history-time {
+  margin-left: 6px;
+  color: inherit;
+  font-size: 9.5px;
+  font-variant-numeric: tabular-nums;
+  opacity: 0.62;
+  white-space: nowrap;
+}
+
 .history-entry[data-speaker="you"] {
   align-self: flex-end;
   align-items: flex-end;

--- a/apps/desktop/src/renderer/styles/history.css
+++ b/apps/desktop/src/renderer/styles/history.css
@@ -137,7 +137,6 @@
   color: inherit;
   font-size: 9.5px;
   font-variant-numeric: tabular-nums;
-  opacity: 0.62;
   white-space: nowrap;
 }
 

--- a/apps/desktop/src/renderer/use-voice-conversation.ts
+++ b/apps/desktop/src/renderer/use-voice-conversation.ts
@@ -593,15 +593,18 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
   const [conversationHistory, setConversationHistory] = useState<readonly ConversationEntry[]>([]);
   /** Where each server-identified spoken turn belongs when its transcript returns. */
   const spokenTurnMarksRef = useRef(
-    new Map<string, { after: ConversationEntry | undefined; generation: number }>(),
+    new Map<
+      string,
+      { after: ConversationEntry | undefined; generation: number; recordedAt: number }
+    >(),
   );
   /** Local turn-close marks waiting for the server item ids that name them. */
   const pendingSpokenTurnMarksRef = useRef<
-    { after: ConversationEntry | undefined; generation: number }[]
+    { after: ConversationEntry | undefined; generation: number; recordedAt: number }[]
   >([]);
   /** The turn opened by the current talk-key press, before it closes. */
   const activeSpokenTurnMarkRef = useRef<
-    { after: ConversationEntry | undefined; generation: number } | undefined
+    { after: ConversationEntry | undefined; generation: number; recordedAt: number } | undefined
   >(undefined);
   /** The generation of the developer-opened turn whose reply is still in flight. */
   const activeReplyGenerationRef = useRef<number | undefined>(undefined);
@@ -675,6 +678,7 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
       conversationRef.current,
       transcript,
       mark.after,
+      mark.recordedAt,
     );
     setConversationHistory(conversationRef.current);
     voiceSession.current?.updateConversation(recentConversationEntries(conversationRef.current));
@@ -1080,6 +1084,7 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
     activeSpokenTurnMarkRef.current = {
       after: conversationRef.current.at(-1),
       generation: conversationGenerationRef.current,
+      recordedAt: Date.now(),
     };
     // Only after the interrupted reply's handover does this new turn own the
     // active reply generation.

--- a/packages/realtime/src/conversation-history.test.ts
+++ b/packages/realtime/src/conversation-history.test.ts
@@ -70,12 +70,13 @@ test("every way into the thread stamps when the line was recorded", () => {
     kind: CONVERSATION_ENTRY_KIND.REPLY,
     words: "Checkout is ready.",
   });
-  const placed = insertSpokenAskThreadEntry(appended, "how is checkout going?", undefined);
+  const placed = insertSpokenAskThreadEntry(appended, "how is checkout going?", undefined, before);
 
   for (const entry of placed) {
     assert.ok(entry.recordedAt !== undefined);
     assert.ok(entry.recordedAt >= before && entry.recordedAt <= Date.now());
   }
+  assert.equal(placed[0]?.recordedAt, before);
 
   // The stamp is the panel's alone: the model's context item is unchanged.
   assert.ok(!conversationHistoryText(placed, [])?.includes(String(placed[0]?.recordedAt)));
@@ -227,7 +228,12 @@ test("a delayed spoken ask keeps its place in the full current-launch thread", (
     words: "Later reply.",
   };
 
-  const placed = insertSpokenAskThreadEntry([prior, later], "What happened between those?", prior);
+  const placed = insertSpokenAskThreadEntry(
+    [prior, later],
+    "What happened between those?",
+    prior,
+    OBSERVED_AT,
+  );
 
   assert.deepEqual(
     placed.map((entry) => entry.words),

--- a/packages/realtime/src/conversation-history.test.ts
+++ b/packages/realtime/src/conversation-history.test.ts
@@ -64,6 +64,23 @@ test("appending flattens, bounds, and retires the oldest lines", () => {
   assert.equal(entries[0]?.words, "line 3");
 });
 
+test("every way into the thread stamps when the line was recorded", () => {
+  const before = Date.now();
+  const appended = appendConversationThreadEntry([], {
+    kind: CONVERSATION_ENTRY_KIND.REPLY,
+    words: "Checkout is ready.",
+  });
+  const placed = insertSpokenAskThreadEntry(appended, "how is checkout going?", undefined);
+
+  for (const entry of placed) {
+    assert.ok(entry.recordedAt !== undefined);
+    assert.ok(entry.recordedAt >= before && entry.recordedAt <= Date.now());
+  }
+
+  // The stamp is the panel's alone: the model's context item is unchanged.
+  assert.ok(!conversationHistoryText(placed, [])?.includes(String(placed[0]?.recordedAt)));
+});
+
 test("the current-launch thread keeps every entry while model context stays recent", () => {
   let thread: readonly ConversationEntry[] = [];
   for (let index = 0; index < maximumConversationEntries + 3; index += 1) {

--- a/packages/realtime/src/conversation-history.ts
+++ b/packages/realtime/src/conversation-history.ts
@@ -63,10 +63,8 @@ export interface ConversationEntry {
    */
   identity?: SessionIdentity;
   /**
-   * When the line entered the thread, stamped at append rather than at
-   * construction so every way in carries one. A spoken ask is stamped when
-   * its transcription lands, not when the turn was spoken; the panel shows
-   * minutes, so the difference cannot be seen.
+   * When the line happened in the conversation. Appends stamp themselves;
+   * delayed spoken transcripts carry the time their turn began.
    */
   recordedAt?: number;
 }
@@ -123,6 +121,7 @@ export function insertSpokenAskThreadEntry(
   entries: readonly ConversationEntry[],
   words: string,
   after: ConversationEntry | undefined,
+  recordedAt: number,
 ): readonly ConversationEntry[] {
   const bounded = boundedEntryWords(words);
   if (!bounded) return entries;
@@ -133,7 +132,7 @@ export function insertSpokenAskThreadEntry(
   placed.splice(at, 0, {
     kind: CONVERSATION_ENTRY_KIND.SPOKEN_ASK,
     words: bounded,
-    recordedAt: Date.now(),
+    recordedAt,
   });
   return placed;
 }
@@ -144,7 +143,7 @@ export function insertSpokenAskEntry(
   words: string,
   after: ConversationEntry | undefined,
 ): readonly ConversationEntry[] {
-  return recentConversationEntries(insertSpokenAskThreadEntry(entries, words, after));
+  return recentConversationEntries(insertSpokenAskThreadEntry(entries, words, after, Date.now()));
 }
 
 /**

--- a/packages/realtime/src/conversation-history.ts
+++ b/packages/realtime/src/conversation-history.ts
@@ -62,6 +62,13 @@ export interface ConversationEntry {
    * toward a refusal nor leave "that chat" open to a lookalike.
    */
   identity?: SessionIdentity;
+  /**
+   * When the line entered the thread, stamped at append rather than at
+   * construction so every way in carries one. A spoken ask is stamped when
+   * its transcription lands, not when the turn was spoken; the panel shows
+   * minutes, so the difference cannot be seen.
+   */
+  recordedAt?: number;
 }
 
 /**
@@ -75,7 +82,7 @@ export function appendConversationThreadEntry(
 ): readonly ConversationEntry[] {
   const words = boundedEntryWords(entry.words);
   if (!words) return entries;
-  const appended: ConversationEntry = { kind: entry.kind, words };
+  const appended: ConversationEntry = { kind: entry.kind, words, recordedAt: Date.now() };
   if (entry.identity) appended.identity = entry.identity;
   return [...entries, appended];
 }
@@ -123,7 +130,11 @@ export function insertSpokenAskThreadEntry(
   // exactly where an entry older than the whole history belongs.
   const at = after ? entries.indexOf(after) + 1 : 0;
   const placed = [...entries];
-  placed.splice(at, 0, { kind: CONVERSATION_ENTRY_KIND.SPOKEN_ASK, words: bounded });
+  placed.splice(at, 0, {
+    kind: CONVERSATION_ENTRY_KIND.SPOKEN_ASK,
+    words: bounded,
+    recordedAt: Date.now(),
+  });
   return placed;
 }
 


### PR DESCRIPTION
## Summary

- Show a localized timestamp on every current-launch History entry.
- Preserve a spoken ask's original turn time when its transcript arrives late, without adding timestamps to model context.
- Keep the timestamp readable on both sent and received bubbles, with focused storage and renderer coverage.

## Evidence

- Platform-independent checks: `./scripts/check.sh` passed
- macOS Electron verification (`./scripts/verify.sh`): `not run`

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/33465503424/artifacts/9784755161) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/33465503424)

- Commit: `96627c783d26c3bdafb6a242185d85e1bebcade9`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

### Physical-device evidence

- Screenshot or screen recording: `not attached`
- Physical-notch check: `not performed`
- Device/display configuration: `not recorded`

## Notes

- Blockers or follow-up verification: None

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)