### PR TITLE
fix(ios): redact the real session row for the skeleton loader

### DIFF
--- a/apps/ios/Luke/SessionsView.swift
+++ b/apps/ios/Luke/SessionsView.swift
@@ -290,6 +290,10 @@ private struct SkeletonRow: View {
     var body: some View {
         SessionRow(session: Self.placeholder)
             .redacted(reason: .placeholder)
+            // Redaction only hides the synthetic words visually; VoiceOver
+            // would still read them as three real sessions, so the row hides
+            // itself the way the desktop skeleton's aria-hidden does.
+            .accessibilityHidden(true)
             .opacity(opacity)
             .onAppear {
                 withAnimation(.easeInOut(duration: 1.5).repeatForever(autoreverses: true)) {

--- a/apps/ios/Luke/SessionsView.swift
+++ b/apps/ios/Luke/SessionsView.swift
@@ -266,40 +266,35 @@ private struct PlaceLine: View {
 
 // MARK: - Skeleton row
 
-/// Three pulsing placeholder cards while the first fetch is in flight.
+/// Pulsing placeholder cards while the first fetch is in flight: the real
+/// SessionRow rendered under `.redacted(reason: .placeholder)`, so the
+/// skeleton's geometry is the row's own rather than a copy kept by hand.
 private struct SkeletonRow: View {
     @State private var opacity: Double = 0.55
 
+    /// Synthetic content sized like a typical row. Redaction replaces every
+    /// text and glyph with a block, so none of these words can draw; the
+    /// status is `complete` because it is the one glyph-bearing status whose
+    /// row neither animates nor tints its border.
+    private static let placeholder = RosterSession(
+        providerId: "placeholder",
+        sessionId: "placeholder",
+        title: "Placeholder session title",
+        status: "complete",
+        workspace: "workspace",
+        branch: "branch-name",
+        recap: "Placeholder recap sized like a settled turn's parting words",
+        observedAt: Date()
+    )
+
     var body: some View {
-        HStack(alignment: .center, spacing: 12) {
-            RoundedRectangle(cornerRadius: 7)
-                .fill(Color.ink.opacity(0.1))
-                .frame(width: 30, height: 30)
-            VStack(alignment: .leading, spacing: 6) {
-                RoundedRectangle(cornerRadius: 4)
-                    .fill(Color.ink.opacity(0.1))
-                    .frame(height: 12)
-                    .frame(maxWidth: 160)
-                RoundedRectangle(cornerRadius: 4)
-                    .fill(Color.ink.opacity(0.07))
-                    .frame(height: 10)
-                    .frame(maxWidth: 220)
+        SessionRow(session: Self.placeholder)
+            .redacted(reason: .placeholder)
+            .opacity(opacity)
+            .onAppear {
+                withAnimation(.easeInOut(duration: 1.5).repeatForever(autoreverses: true)) {
+                    opacity = 1.0
+                }
             }
-            Spacer(minLength: 0)
-        }
-        .padding(.horizontal, 14)
-        .padding(.vertical, 11)
-        .background(Color(white: 1, opacity: 0.028))
-        .overlay(
-            RoundedRectangle(cornerRadius: 15)
-                .strokeBorder(Color(white: 1, opacity: 0.08), lineWidth: 1)
-        )
-        .clipShape(RoundedRectangle(cornerRadius: 15))
-        .opacity(opacity)
-        .onAppear {
-            withAnimation(.easeInOut(duration: 1.5).repeatForever(autoreverses: true)) {
-                opacity = 1.0
-            }
-        }
     }
 }

--- a/apps/ios/LukeKit/Sources/LukeKit/RosterSession.swift
+++ b/apps/ios/LukeKit/Sources/LukeKit/RosterSession.swift
@@ -16,6 +16,28 @@ public struct RosterSession: Identifiable, Sendable {
 
     public var id: String { "\(providerId):\(sessionId)" }
 
+    public init(
+        providerId: String,
+        sessionId: String,
+        title: String,
+        status: String,
+        workspace: String? = nil,
+        branch: String? = nil,
+        recap: String? = nil,
+        error: String? = nil,
+        observedAt: Date? = nil
+    ) {
+        self.providerId = providerId
+        self.sessionId = sessionId
+        self.title = title
+        self.status = status
+        self.workspace = workspace
+        self.branch = branch
+        self.recap = recap
+        self.error = error
+        self.observedAt = observedAt
+    }
+
     init?(json: [String: Any]) {
         guard
             let providerId = json["providerId"] as? String,


### PR DESCRIPTION
## Summary

The session list's skeleton cards were hand-drawn rectangles that had drifted from the rows they stand in for: no doing-line glyph slot, no place line, no trailing timestamp, and different bar metrics, so the list visibly reflowed when real rows landed.

This replaces the hand-drawn skeleton with the system vocabulary for this exact job: the real `SessionRow` rendered with synthetic placeholder content under SwiftUI's own `.redacted(reason: .placeholder)`. The skeleton's geometry is now the row's own by construction — padding, mark slot, doing line, place line, and timestamp all come from the same view the loaded list draws — and it cannot drift again when the row changes. The existing opacity pulse is kept on top.

The placeholder content is synthetic (provider id `placeholder`, generic title/recap/workspace words); redaction replaces every text with a block, so none of the words draw. Status is `complete` because it is the one glyph-bearing status whose row neither animates its glyph nor tints its border. `RosterSession` gains the public memberwise init the placeholder needs.

## Validation

- CI runs no iOS build, so validation is a local `xcodebuild` build + test run and LukeKit `swift test` on a Mac (results reported in PR comments).
- No physical-notch check performed; this is an iOS list view, not the macOS panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/33466821387/artifacts/9785206463) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/33466821387)

- Commit: `2c1fc1dcd9b222521df9707bdb87e37b0f575583`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
