### PR TITLE
feat(desktop): add local session index projection

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -10,14 +10,18 @@ explains what we collect, who we send it to, and how to turn it off.
 **On your Mac.** Luke reads the session files your coding agents already write,
 using the session title, status, repository, branch, model, current tool,
 errors, and the summary the agent wrote. It does not read message history, file
-contents, or command output, and it writes none of this to disk. If you run
-agents inside the Herdr terminal manager, Luke also asks Herdr's own
-command-line tool which of those sessions it holds, so their rows can say so;
-that read never starts Herdr, reads no terminal output, and sends nothing
-anywhere. It stays on your Mac unless a feature below sends it. Luke also keeps
-your conversation with him in memory for the current app launch so you can
-review it; it is never written to disk, and only the 20 most recent entries are
-carried into a call.
+contents, or command output. Luke keeps a local search index of the bounded
+session details its rows already show: identity, title, status, repository,
+branch, summary, provider, location, workspace, and whether the session is
+standing or waiting for you. The index is rebuilt from provider observation,
+never replaces it, and is deleted row by row when sessions disappear from that
+observation. If you run agents inside the Herdr terminal manager, Luke also
+asks Herdr's own command-line tool which of those sessions it holds, so their
+rows can say so; that read never starts Herdr, reads no terminal output, and
+sends nothing anywhere. It stays on your Mac unless a feature below sends it.
+Luke also keeps your conversation with him in memory for the current app launch
+so you can review it; it is never written to disk, and only the 20 most recent
+entries are carried into a call.
 
 **Your account.** Signing in with Google or GitHub gives us your name, email
 address, and which of the two you used. We also keep the records that keep you
@@ -107,11 +111,13 @@ your network address, as it does for the app's recordings.
 
 ## Storage
 
-Your settings, local provider API keys, and calendar access stay on your Mac.
-Local keys and calendar access are encrypted in the macOS Keychain. Provider
-API keys you sync to the hosted service are stored encrypted in our own
-database, as described above. Your account information is held by our own
-service, and usage counts and recordings by PostHog.
+Your settings, local session search index, local provider API keys, and calendar
+access stay on your Mac. The search index is an owner-only file in Luke's
+application data and contains only the bounded session details described above.
+Local keys and calendar access are encrypted in the macOS Keychain. Provider API
+keys you sync to the hosted service are stored encrypted in our own database,
+as described above. Your account information is held by our own service, and
+usage counts and recordings by PostHog.
 
 ## Your choices
 

--- a/apps/desktop/drizzle.session-index.config.ts
+++ b/apps/desktop/drizzle.session-index.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "drizzle-kit";
+
+export default defineConfig({
+  schema: "./src/main/session-index/schema.ts",
+  out: "./drizzle/session-index",
+  dialect: "sqlite",
+});

--- a/apps/desktop/drizzle/session-index/0000_stormy_sway.sql
+++ b/apps/desktop/drizzle/session-index/0000_stormy_sway.sql
@@ -1,0 +1,109 @@
+CREATE TABLE `observed_sessions` (
+	`provider_id` text NOT NULL,
+	`provider_session_id` text NOT NULL,
+	`title` text NOT NULL,
+	`branch` text,
+	`recap` text,
+	`status` text NOT NULL,
+	`observed_at` integer NOT NULL,
+	`provider_label` text NOT NULL,
+	`location` text NOT NULL,
+	`repository_label` text,
+	`workspace_label` text,
+	`standing` integer NOT NULL,
+	`holding_for_developer` integer NOT NULL,
+	`about_hash` text NOT NULL,
+	PRIMARY KEY(`provider_id`, `provider_session_id`)
+);
+--> statement-breakpoint
+CREATE VIRTUAL TABLE `observed_sessions_fts` USING fts5(
+	`title`,
+	`branch`,
+	`recap`,
+	`provider_label`,
+	`repository_label`,
+	`workspace_label`,
+	content=`observed_sessions`,
+	content_rowid=`rowid`
+);
+--> statement-breakpoint
+CREATE TRIGGER `observed_sessions_fts_insert` AFTER INSERT ON `observed_sessions` BEGIN
+	INSERT INTO `observed_sessions_fts`(
+		rowid,
+		title,
+		branch,
+		recap,
+		provider_label,
+		repository_label,
+		workspace_label
+	) VALUES (
+		new.rowid,
+		new.title,
+		new.branch,
+		new.recap,
+		new.provider_label,
+		new.repository_label,
+		new.workspace_label
+	);
+END;
+--> statement-breakpoint
+CREATE TRIGGER `observed_sessions_fts_delete` AFTER DELETE ON `observed_sessions` BEGIN
+	INSERT INTO `observed_sessions_fts`(
+		`observed_sessions_fts`,
+		rowid,
+		title,
+		branch,
+		recap,
+		provider_label,
+		repository_label,
+		workspace_label
+	) VALUES (
+		'delete',
+		old.rowid,
+		old.title,
+		old.branch,
+		old.recap,
+		old.provider_label,
+		old.repository_label,
+		old.workspace_label
+	);
+END;
+--> statement-breakpoint
+CREATE TRIGGER `observed_sessions_fts_update` AFTER UPDATE ON `observed_sessions` BEGIN
+	INSERT INTO `observed_sessions_fts`(
+		`observed_sessions_fts`,
+		rowid,
+		title,
+		branch,
+		recap,
+		provider_label,
+		repository_label,
+		workspace_label
+	) VALUES (
+		'delete',
+		old.rowid,
+		old.title,
+		old.branch,
+		old.recap,
+		old.provider_label,
+		old.repository_label,
+		old.workspace_label
+	);
+	INSERT INTO `observed_sessions_fts`(
+		rowid,
+		title,
+		branch,
+		recap,
+		provider_label,
+		repository_label,
+		workspace_label
+	) VALUES (
+		new.rowid,
+		new.title,
+		new.branch,
+		new.recap,
+		new.provider_label,
+		new.repository_label,
+		new.workspace_label
+	);
+END;

--- a/apps/desktop/drizzle/session-index/meta/0000_snapshot.json
+++ b/apps/desktop/drizzle/session-index/meta/0000_snapshot.json
@@ -1,0 +1,131 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "a686d86b-2ddb-4623-8f81-b758cacacf33",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "tables": {
+    "observed_sessions": {
+      "name": "observed_sessions",
+      "columns": {
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_session_id": {
+          "name": "provider_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "recap": {
+          "name": "recap",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_label": {
+          "name": "provider_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repository_label": {
+          "name": "repository_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "workspace_label": {
+          "name": "workspace_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "standing": {
+          "name": "standing",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "holding_for_developer": {
+          "name": "holding_for_developer",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "about_hash": {
+          "name": "about_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "observed_sessions_provider_id_provider_session_id_pk": {
+          "columns": ["provider_id", "provider_session_id"],
+          "name": "observed_sessions_provider_id_provider_session_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/apps/desktop/drizzle/session-index/meta/_journal.json
+++ b/apps/desktop/drizzle/session-index/meta/_journal.json
@@ -1,0 +1,13 @@
+{
+  "version": "7",
+  "dialect": "sqlite",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "6",
+      "when": 1788234854477,
+      "tag": "0000_stormy_sway",
+      "breakpoints": true
+    }
+  ]
+}

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -30,6 +30,7 @@
   "scripts": {
     "build": "node scripts/build.mjs",
     "build:native": "node scripts/build-native.mjs",
+    "db:index:generate": "drizzle-kit generate --config drizzle.session-index.config.ts",
     "package": "pnpm build:native && pnpm build && node scripts/prepare-builder-assets.mjs && electron-builder --config electron-builder.ts --mac --arm64 --publish never",
     "release": "LUKE_ELECTRON_BUILDER_NOTARIZE=1 pnpm package",
     "start": "pnpm build:native && pnpm build && electron .",
@@ -37,8 +38,8 @@
     "typecheck": "tsc --project tsconfig.json"
   },
   "devDependencies": {
-    "@sidecar/acts": "workspace:*",
     "@sidecar/account": "workspace:*",
+    "@sidecar/acts": "workspace:*",
     "@sidecar/analytics": "workspace:*",
     "@sidecar/attention": "workspace:*",
     "@sidecar/calendar": "workspace:*",
@@ -59,9 +60,11 @@
     "@sidecar/trackers": "workspace:*",
     "@sidecar/voice": "workspace:*",
     "@sidecar/wire": "workspace:*",
+    "@types/better-sqlite3": "9.6.0",
     "@types/node": "26.2.0",
     "@types/react": "19.2.18",
     "@types/react-dom": "19.2.4",
+    "drizzle-kit": "0.31.10",
     "electron": "43.3.0",
     "electron-builder": "26.8.1",
     "esbuild": "0.28.2",
@@ -72,6 +75,8 @@
     "typescript": "7.0.2"
   },
   "dependencies": {
+    "better-sqlite3": "13.0.3",
+    "drizzle-orm": "0.45.2",
     "electron-updater": "6.8.9"
   }
 }

--- a/apps/desktop/scripts/build.mjs
+++ b/apps/desktop/scripts/build.mjs
@@ -26,7 +26,7 @@ await Promise.all([
     platform: "node",
     format: "cjs",
     target: "node22",
-    external: ["electron"],
+    external: ["better-sqlite3", "electron"],
     define: {
       // The Google Calendar client secret rides into the bundle from the
       // packaging environment rather than sitting in source, where secret
@@ -92,6 +92,9 @@ await fs.copyFile(
   path.join(appRoot, "src/renderer/index.html"),
   path.join(outputRoot, "renderer/index.html"),
 );
+await fs.cp(path.join(appRoot, "drizzle/session-index"), path.join(outputRoot, "session-index"), {
+  recursive: true,
+});
 
 await Promise.all([
   ...Object.entries(DOCK_ICON_IMAGES).map(([name, source]) =>

--- a/apps/desktop/scripts/electron-builder-config.mjs
+++ b/apps/desktop/scripts/electron-builder-config.mjs
@@ -75,7 +75,8 @@ export function createElectronBuilderConfig(env = process.env) {
       output: builderReleaseArtifactDirectory(repoRoot),
     },
     asar: true,
-    npmRebuild: false,
+    asarUnpack: ["node_modules/better-sqlite3/**/*"],
+    npmRebuild: true,
     files: ["dist/**/*", "package.json", "!dist/**/*.map"],
     extraResources: [
       ...packageAssets.helperPaths.map((helperPath) => ({

--- a/apps/desktop/src/main/desktop-app.ts
+++ b/apps/desktop/src/main/desktop-app.ts
@@ -160,6 +160,7 @@ import { OutputVolumeWatcher } from "./native/output-volume";
 import { ProviderKeyVaultSync, type VaultSyncAccount } from "./provider-key-vault-sync";
 import { type BridgeContext, registerBridgeEntry } from "./register-bridge";
 import { runModeFor } from "./run-mode";
+import { SessionIndex } from "./session-index/session-index";
 import { createSettingsHandler } from "./settings-handler";
 import { SettingsStore } from "./settings-store";
 import { createElectronUpdaterEngine } from "./update-installer";
@@ -200,6 +201,12 @@ const captureMode = captureOutput !== undefined;
 // the fixture snapshot and no provider is observed. Capture runs always imply it.
 const fixtureMode = captureMode || fixtureName !== undefined;
 const runMode = runModeFor({ capture: captureMode, fixture: fixtureName !== undefined });
+const sessionIndex = new SessionIndex({
+  directory: () => app.getPath("userData"),
+  migrationsDirectory: path.join(__dirname, "session-index"),
+  enabled: runMode.observesProviders,
+  onDiagnostic: (message) => process.stderr.write(`${message}\n`),
+});
 // A development build may be pointed at a local account service; a packaged one
 // may not. The override redirects the whole sign-in — including the identity
 // request that carries the access token — so it stops at the packaging boundary
@@ -2197,6 +2204,7 @@ const sessionObservationLoop = new ObservationLoop({
   // settings save stands behind that to announce it.
   afterRun: () => {
     broadcastRelevantSessions();
+    void sessionIndex.reconcile(sessionRegistry.snapshot());
     void broadcastCodexCloudConnection();
   },
 });
@@ -2399,6 +2407,7 @@ function stopSessionObservation(): void {
     sessionRegistry.replaceProvider(adapter.provider, []);
   }
   panels.broadcast(channels.onSessionsChanged, { sessions: [], attention: [] });
+  void sessionIndex.clear();
   panels.broadcast(channels.onWorkspaceProjectsChanged, []);
   lastWorkspaceProjects = undefined;
 }

--- a/apps/desktop/src/main/session-index/schema.ts
+++ b/apps/desktop/src/main/session-index/schema.ts
@@ -1,0 +1,28 @@
+import { integer, primaryKey, sqliteTable, text } from "drizzle-orm/sqlite-core";
+
+export const observedSessions = sqliteTable(
+  "observed_sessions",
+  {
+    providerId: text("provider_id").notNull(),
+    providerSessionId: text("provider_session_id").notNull(),
+    title: text("title").notNull(),
+    branch: text("branch"),
+    recap: text("recap"),
+    status: text("status").notNull(),
+    observedAt: integer("observed_at").notNull(),
+    providerLabel: text("provider_label").notNull(),
+    location: text("location").notNull(),
+    repositoryLabel: text("repository_label"),
+    workspaceLabel: text("workspace_label"),
+    standing: integer("standing", { mode: "boolean" }).notNull(),
+    holdingForDeveloper: integer("holding_for_developer", { mode: "boolean" }).notNull(),
+    aboutHash: text("about_hash").notNull(),
+  },
+  (table) => [
+    primaryKey({
+      columns: [table.providerId, table.providerSessionId],
+    }),
+  ],
+);
+
+export type ObservedSessionRow = typeof observedSessions.$inferInsert;

--- a/apps/desktop/src/main/session-index/session-index.test.ts
+++ b/apps/desktop/src/main/session-index/session-index.test.ts
@@ -88,7 +88,7 @@ test("reconciles added, updated, and disappeared sessions into FTS", async (t) =
   assert.equal(initialHits.length, 1);
   assert.equal(initialHits[0]?.providerId, "cursor");
   assert.equal(initialHits[0]?.providerSessionId, "one");
-  assert.equal(typeof initialHits[0]?.rank, "number");
+  assert.equal(Number.isFinite(initialHits[0]?.rank), true);
 
   await index.reconcile(
     snapshot(

--- a/apps/desktop/src/main/session-index/session-index.test.ts
+++ b/apps/desktop/src/main/session-index/session-index.test.ts
@@ -104,6 +104,31 @@ test("reconciles added, updated, and disappeared sessions into FTS", async (t) =
   index.close();
 });
 
+test("an unchanged about hash skips the database update", async (t) => {
+  const directory = await temporaryDirectory(t);
+  const index = indexIn(directory);
+  const current = snapshot([session("one")]);
+  await index.reconcile(current);
+
+  const observer = new BetterSqlite3(path.join(directory, SESSION_INDEX_FILE_NAME));
+  observer.exec(`
+    CREATE TABLE update_audit (count INTEGER NOT NULL);
+    INSERT INTO update_audit (count) VALUES (0);
+    CREATE TRIGGER audit_session_update AFTER UPDATE ON observed_sessions BEGIN
+      UPDATE update_audit SET count = count + 1;
+    END;
+  `);
+
+  await index.reconcile(current);
+
+  assert.equal(
+    observer.prepare<[], { count: number }>("SELECT count FROM update_audit").get()?.count,
+    0,
+  );
+  observer.close();
+  index.close();
+});
+
 test("search applies roster retention while standing sessions remain eligible", async (t) => {
   const directory = await temporaryDirectory(t);
   const index = indexIn(directory);

--- a/apps/desktop/src/main/session-index/session-index.test.ts
+++ b/apps/desktop/src/main/session-index/session-index.test.ts
@@ -1,0 +1,225 @@
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test, { type TestContext } from "node:test";
+import { fileURLToPath } from "node:url";
+import {
+  normalizeSession,
+  SESSION_LOCATION,
+  SESSION_ROSTER_RETENTION_MS,
+  SESSION_STATUS,
+  type Session,
+  type SessionRegistrySnapshot,
+} from "@sidecar/session";
+import BetterSqlite3 from "better-sqlite3";
+import { SESSION_INDEX_FILE_NAME, SessionIndex, type SessionIndexOptions } from "./session-index";
+
+const migrationsDirectory = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../../../drizzle/session-index",
+);
+const NOW = Date.UTC(2026, 8, 1);
+
+async function temporaryDirectory(t: TestContext): Promise<string> {
+  const directory = await fs.mkdtemp(path.join(os.tmpdir(), "luke-session-index-"));
+  t.after(async () => {
+    await fs.rm(directory, { recursive: true, force: true });
+  });
+  return directory;
+}
+
+function session(
+  providerSessionId: string,
+  overrides: {
+    title?: string;
+    status?: Session["status"];
+    observedAt?: number;
+    recap?: string;
+    branch?: string;
+    standing?: boolean;
+  } = {},
+): Session {
+  return normalizeSession(
+    { id: "cursor", displayName: "Cursor" },
+    {
+      providerSessionId,
+      title: overrides.title ?? "Index local sessions",
+      status: overrides.status ?? SESSION_STATUS.WORKING,
+      observedAt: overrides.observedAt ?? NOW,
+      location: SESSION_LOCATION.LOCAL,
+      recap: overrides.recap ?? "Built the roster projection",
+      standing: overrides.standing,
+      holdingForDeveloper: true,
+      detail: {
+        branch: overrides.branch ?? "cursor/LUKE-123-index",
+        repository: "luke",
+      },
+      workspace: {
+        providerWorkspaceId: "workspace-1",
+        name: "Search work",
+      },
+    },
+  );
+}
+
+function snapshot(sessions: readonly Session[], revision = 1): SessionRegistrySnapshot {
+  return { revision, sessions, attention: [] };
+}
+
+function indexIn(
+  directory: string,
+  options: Partial<Pick<SessionIndexOptions, "enabled" | "onDiagnostic">> = {},
+): SessionIndex {
+  return new SessionIndex({
+    directory: () => directory,
+    migrationsDirectory,
+    enabled: options.enabled ?? true,
+    onDiagnostic: options.onDiagnostic,
+  });
+}
+
+test("reconciles added, updated, and disappeared sessions into FTS", async (t) => {
+  const directory = await temporaryDirectory(t);
+  const index = indexIn(directory);
+
+  await index.reconcile(snapshot([session("one")]));
+  const initialHits = await index.search("LUKE-123", NOW);
+  assert.equal(initialHits.length, 1);
+  assert.equal(initialHits[0]?.providerId, "cursor");
+  assert.equal(initialHits[0]?.providerSessionId, "one");
+  assert.equal(typeof initialHits[0]?.rank, "number");
+
+  await index.reconcile(
+    snapshot(
+      [session("one", { branch: "cursor/LUKE-456-search", recap: "Changed the indexed words" })],
+      2,
+    ),
+  );
+  assert.deepEqual(await index.search("LUKE-123", NOW), []);
+  assert.equal((await index.search("LUKE-456", NOW))[0]?.providerSessionId, "one");
+
+  await index.reconcile(snapshot([], 3));
+  assert.deepEqual(await index.search("LUKE-456", NOW), []);
+  index.close();
+});
+
+test("search applies roster retention while standing sessions remain eligible", async (t) => {
+  const directory = await temporaryDirectory(t);
+  const index = indexIn(directory);
+  const expired = NOW - SESSION_ROSTER_RETENTION_MS.SETTLED_MS - 1;
+
+  await index.reconcile(
+    snapshot([
+      session("history", {
+        title: "Archived parser work",
+        status: SESSION_STATUS.COMPLETE,
+        observedAt: expired,
+      }),
+      session("standing", {
+        title: "Standing parser workspace",
+        status: SESSION_STATUS.COMPLETE,
+        observedAt: expired,
+        standing: true,
+      }),
+    ]),
+  );
+
+  assert.deepEqual(
+    (await index.search("parser", NOW)).map((hit) => hit.providerSessionId),
+    ["standing"],
+  );
+  index.close();
+});
+
+test("stores only the approved bounded projection in an owner-only file", async (t) => {
+  const directory = await temporaryDirectory(t);
+  const index = indexIn(directory);
+  await index.reconcile(snapshot([session("one")]));
+  index.close();
+
+  const databasePath = path.join(directory, SESSION_INDEX_FILE_NAME);
+  const stats = await fs.stat(databasePath);
+  assert.equal(stats.mode & 0o777, 0o600);
+
+  const database = new BetterSqlite3(databasePath, { readonly: true });
+  const columns = database
+    .prepare<[], { name: string; type: string }>("PRAGMA table_info(observed_sessions)")
+    .all();
+  assert.deepEqual(
+    columns.map((column) => column.name),
+    [
+      "provider_id",
+      "provider_session_id",
+      "title",
+      "branch",
+      "recap",
+      "status",
+      "observed_at",
+      "provider_label",
+      "location",
+      "repository_label",
+      "workspace_label",
+      "standing",
+      "holding_for_developer",
+      "about_hash",
+    ],
+  );
+  assert.equal(
+    columns.some((column) => column.type.toLowerCase() === "blob"),
+    false,
+  );
+  assert.equal(
+    database
+      .prepare<[], { name: string }>(
+        "SELECT name FROM sqlite_master WHERE type = 'table' AND name LIKE '%transcript%'",
+      )
+      .all().length,
+    0,
+  );
+  database.close();
+});
+
+test("a disabled index creates no fixture or capture state", async (t) => {
+  const directory = await temporaryDirectory(t);
+  const index = indexIn(directory, { enabled: false });
+
+  await index.reconcile(snapshot([session("fixture")]));
+
+  assert.deepEqual(await fs.readdir(directory), []);
+  assert.deepEqual(await index.search("fixture", NOW), []);
+});
+
+test("a corrupt projection is removed and rebuilt from the current snapshot", async (t) => {
+  const directory = await temporaryDirectory(t);
+  await fs.writeFile(path.join(directory, SESSION_INDEX_FILE_NAME), "not a sqlite database", {
+    mode: 0o600,
+  });
+  const index = indexIn(directory);
+
+  await index.reconcile(snapshot([session("rebuilt", { title: "Recovered index" })]));
+
+  assert.equal((await index.search("Recovered", NOW))[0]?.providerSessionId, "rebuilt");
+  index.close();
+});
+
+test("a locked projection leaves the previous index readable and retries later", async (t) => {
+  const directory = await temporaryDirectory(t);
+  const diagnostics: string[] = [];
+  const index = indexIn(directory, { onDiagnostic: (message) => diagnostics.push(message) });
+  await index.reconcile(snapshot([session("one", { title: "Original title" })]));
+
+  const lock = new BetterSqlite3(path.join(directory, SESSION_INDEX_FILE_NAME));
+  lock.exec("BEGIN EXCLUSIVE");
+  await index.reconcile(snapshot([session("one", { title: "Updated title" })], 2));
+  lock.exec("ROLLBACK");
+  lock.close();
+
+  assert.equal(diagnostics.length, 1);
+  assert.match(diagnostics[0] ?? "", /locked/i);
+  assert.equal((await index.search("Original", NOW))[0]?.providerSessionId, "one");
+
+  await index.reconcile(snapshot([session("one", { title: "Updated title" })], 2));
+  assert.equal((await index.search("Updated", NOW))[0]?.providerSessionId, "one");
+  index.close();
+});

--- a/apps/desktop/src/main/session-index/session-index.ts
+++ b/apps/desktop/src/main/session-index/session-index.ts
@@ -81,13 +81,22 @@ function ftsQuery(query: string): string | undefined {
 }
 
 function isCorruptDatabase(error: unknown): boolean {
-  if (!(error instanceof Error)) return false;
-  const code = "code" in error && typeof error.code === "string" ? error.code : "";
-  return (
-    code === "SQLITE_CORRUPT" ||
-    code === "SQLITE_NOTADB" ||
-    /database disk image is malformed|file is not a database/i.test(error.message)
-  );
+  for (
+    let current: unknown = error;
+    current;
+    current = current instanceof Error ? current.cause : undefined
+  ) {
+    if (!(current instanceof Error)) continue;
+    const code = "code" in current && typeof current.code === "string" ? current.code : "";
+    if (
+      code === "SQLITE_CORRUPT" ||
+      code === "SQLITE_NOTADB" ||
+      /database disk image is malformed|file is not a database/i.test(current.message)
+    ) {
+      return true;
+    }
+  }
+  return false;
 }
 
 export class SessionIndex {

--- a/apps/desktop/src/main/session-index/session-index.ts
+++ b/apps/desktop/src/main/session-index/session-index.ts
@@ -1,0 +1,260 @@
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import type { Session, SessionIdentity, SessionRegistrySnapshot } from "@sidecar/session";
+import { isRosterRelevant } from "@sidecar/session";
+import BetterSqlite3 from "better-sqlite3";
+import { drizzle } from "drizzle-orm/better-sqlite3";
+import { migrate } from "drizzle-orm/better-sqlite3/migrator";
+import { type ObservedSessionRow, observedSessions } from "./schema";
+
+export const SESSION_INDEX_FILE_NAME = "observed-sessions.sqlite3";
+const SESSION_INDEX_FILE_MODE = 0o600;
+const SESSION_INDEX_BUSY_TIMEOUT_MS = 50;
+const MAXIMUM_SEARCH_RESULTS = 100;
+const SEARCH_CANDIDATE_MULTIPLIER = 4;
+
+export interface SessionIndexHit extends SessionIdentity {
+  rank: number;
+}
+
+export interface SessionIndexOptions {
+  directory: () => string;
+  migrationsDirectory: string;
+  enabled: boolean;
+  onDiagnostic?: (message: string) => void;
+}
+
+interface IndexedIdentity extends SessionIdentity {
+  aboutHash: string;
+}
+
+interface SearchCandidate extends SessionIndexHit {
+  observedAt: number;
+  standing: number;
+  status: Session["status"];
+}
+
+function aboutHash(row: Omit<ObservedSessionRow, "aboutHash">): string {
+  return createHash("sha256").update(JSON.stringify(row)).digest("hex");
+}
+
+function indexedRow(session: Session): ObservedSessionRow {
+  const row = {
+    providerId: session.providerId,
+    providerSessionId: session.providerSessionId,
+    title: session.title,
+    branch: session.detail.branch,
+    recap: session.recap,
+    status: session.status,
+    observedAt: session.observedAt,
+    providerLabel: session.provider.displayName,
+    location: session.location,
+    repositoryLabel: session.detail.repository,
+    workspaceLabel: session.workspace?.name,
+    standing: session.standing === true,
+    holdingForDeveloper: session.holdingForDeveloper === true,
+  } satisfies Omit<ObservedSessionRow, "aboutHash">;
+  return { ...row, aboutHash: aboutHash(row) };
+}
+
+function nestedIdentityMap<T extends SessionIdentity>(
+  values: readonly T[],
+): Map<string, Map<string, T>> {
+  const identities = new Map<string, Map<string, T>>();
+  for (const value of values) {
+    const provider = identities.get(value.providerId) ?? new Map<string, T>();
+    provider.set(value.providerSessionId, value);
+    identities.set(value.providerId, provider);
+  }
+  return identities;
+}
+
+function ftsQuery(query: string): string | undefined {
+  const tokens = query
+    .trim()
+    .split(/\s+/)
+    .map((token) => token.replaceAll('"', '""'))
+    .filter(Boolean);
+  if (tokens.length === 0) return undefined;
+  return tokens.map((token) => `"${token}"`).join(" AND ");
+}
+
+function isCorruptDatabase(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  const code = "code" in error && typeof error.code === "string" ? error.code : "";
+  return (
+    code === "SQLITE_CORRUPT" ||
+    code === "SQLITE_NOTADB" ||
+    /database disk image is malformed|file is not a database/i.test(error.message)
+  );
+}
+
+export class SessionIndex {
+  readonly #options: SessionIndexOptions;
+  #database: BetterSqlite3.Database | undefined;
+  #queue: Promise<void> = Promise.resolve();
+  #lastDiagnostic: string | undefined;
+
+  constructor(options: SessionIndexOptions) {
+    this.#options = options;
+  }
+
+  reconcile(snapshot: SessionRegistrySnapshot): Promise<void> {
+    if (!this.#options.enabled) return Promise.resolve();
+    const queued = this.#queue.then(() => this.#reconcileWithRecovery(snapshot));
+    this.#queue = queued.catch(() => undefined);
+    return queued;
+  }
+
+  clear(): Promise<void> {
+    return this.reconcile({ revision: 0, sessions: [], attention: [] });
+  }
+
+  async search(query: string, now: number, limit = 20): Promise<readonly SessionIndexHit[]> {
+    if (!this.#options.enabled) return [];
+    await this.#queue;
+    const match = ftsQuery(query);
+    if (!match) return [];
+    try {
+      const database = this.#open();
+      const boundedLimit = Math.max(1, Math.min(limit, MAXIMUM_SEARCH_RESULTS));
+      const candidates = database
+        .prepare<[string, number], SearchCandidate>(
+          `SELECT
+             sessions.provider_id AS providerId,
+             sessions.provider_session_id AS providerSessionId,
+             bm25(observed_sessions_fts) AS rank,
+             sessions.observed_at AS observedAt,
+             sessions.standing AS standing,
+             sessions.status AS status
+           FROM observed_sessions_fts
+           JOIN observed_sessions AS sessions
+             ON sessions.rowid = observed_sessions_fts.rowid
+           WHERE observed_sessions_fts MATCH ?
+           ORDER BY rank
+           LIMIT ?`,
+        )
+        .all(match, boundedLimit * SEARCH_CANDIDATE_MULTIPLIER);
+      this.#lastDiagnostic = undefined;
+      return candidates
+        .filter((candidate) =>
+          isRosterRelevant(
+            {
+              status: candidate.status,
+              observedAt: candidate.observedAt,
+              standing: candidate.standing === 1,
+            },
+            now,
+          ),
+        )
+        .slice(0, boundedLimit)
+        .map(({ providerId, providerSessionId, rank }) => ({
+          providerId,
+          providerSessionId,
+          rank,
+        }));
+    } catch (error) {
+      this.#diagnose(error);
+      return [];
+    }
+  }
+
+  close(): void {
+    this.#database?.close();
+    this.#database = undefined;
+  }
+
+  #reconcileWithRecovery(snapshot: SessionRegistrySnapshot): void {
+    try {
+      this.#reconcile(snapshot);
+      this.#lastDiagnostic = undefined;
+    } catch (error) {
+      if (isCorruptDatabase(error)) {
+        try {
+          this.#rebuild();
+          this.#reconcile(snapshot);
+          this.#lastDiagnostic = undefined;
+          return;
+        } catch (rebuildError) {
+          this.#diagnose(rebuildError);
+          return;
+        }
+      }
+      this.#diagnose(error);
+    }
+  }
+
+  #reconcile(snapshot: SessionRegistrySnapshot): void {
+    const database = this.#open();
+    const orm = drizzle(database);
+    const nextRows = snapshot.sessions.map(indexedRow);
+    const nextIdentities = nestedIdentityMap(nextRows);
+    const currentRows = orm
+      .select({
+        providerId: observedSessions.providerId,
+        providerSessionId: observedSessions.providerSessionId,
+        aboutHash: observedSessions.aboutHash,
+      })
+      .from(observedSessions)
+      .all() satisfies IndexedIdentity[];
+    const currentIdentities = nestedIdentityMap(currentRows);
+    const deleteRow = database.prepare<[string, string]>(
+      "DELETE FROM observed_sessions WHERE provider_id = ? AND provider_session_id = ?",
+    );
+
+    database.transaction(() => {
+      for (const row of nextRows) {
+        const current = currentIdentities.get(row.providerId)?.get(row.providerSessionId);
+        if (current?.aboutHash === row.aboutHash) continue;
+        orm
+          .insert(observedSessions)
+          .values(row)
+          .onConflictDoUpdate({
+            target: [observedSessions.providerId, observedSessions.providerSessionId],
+            set: row,
+          })
+          .run();
+      }
+      for (const current of currentRows) {
+        if (nextIdentities.get(current.providerId)?.has(current.providerSessionId)) continue;
+        deleteRow.run(current.providerId, current.providerSessionId);
+      }
+    })();
+  }
+
+  #open(): BetterSqlite3.Database {
+    if (this.#database) return this.#database;
+    const directory = this.#options.directory();
+    fs.mkdirSync(directory, { recursive: true });
+    const databasePath = path.join(directory, SESSION_INDEX_FILE_NAME);
+    const database = new BetterSqlite3(databasePath);
+    try {
+      database.pragma(`busy_timeout = ${SESSION_INDEX_BUSY_TIMEOUT_MS}`);
+      migrate(drizzle(database), {
+        migrationsFolder: this.#options.migrationsDirectory,
+      });
+      fs.chmodSync(databasePath, SESSION_INDEX_FILE_MODE);
+    } catch (error) {
+      database.close();
+      throw error;
+    }
+    this.#database = database;
+    return database;
+  }
+
+  #rebuild(): void {
+    this.close();
+    const databasePath = path.join(this.#options.directory(), SESSION_INDEX_FILE_NAME);
+    for (const suffix of ["", "-shm", "-wal"]) {
+      fs.rmSync(`${databasePath}${suffix}`, { force: true });
+    }
+  }
+
+  #diagnose(error: unknown): void {
+    const message = error instanceof Error ? error.message : String(error);
+    if (message === this.#lastDiagnostic) return;
+    this.#lastDiagnostic = message;
+    this.#options.onDiagnostic?.(`Session index unavailable: ${message}`);
+  }
+}

--- a/apps/desktop/src/main/session-index/session-index.ts
+++ b/apps/desktop/src/main/session-index/session-index.ts
@@ -80,21 +80,12 @@ function ftsQuery(query: string): string | undefined {
   return tokens.map((token) => `"${token}"`).join(" AND ");
 }
 
-function isCorruptDatabase(error: unknown): boolean {
-  for (
-    let current: unknown = error;
-    current;
-    current = current instanceof Error ? current.cause : undefined
-  ) {
-    if (!(current instanceof Error)) continue;
-    const code = "code" in current && typeof current.code === "string" ? current.code : "";
-    if (
-      code === "SQLITE_CORRUPT" ||
-      code === "SQLITE_NOTADB" ||
-      /database disk image is malformed|file is not a database/i.test(current.message)
-    ) {
+function isCorruptDatabase(error: Error): boolean {
+  for (let current: Error | undefined = error; current; ) {
+    if (/database disk image is malformed|file is not a database/i.test(current.message)) {
       return true;
     }
+    current = current.cause instanceof Error ? current.cause : undefined;
   }
   return false;
 }
@@ -164,7 +155,7 @@ export class SessionIndex {
           rank,
         }));
     } catch (error) {
-      this.#diagnose(error);
+      this.#diagnose(error instanceof Error ? error : new Error(String(error)));
       return [];
     }
   }
@@ -179,18 +170,21 @@ export class SessionIndex {
       this.#reconcile(snapshot);
       this.#lastDiagnostic = undefined;
     } catch (error) {
-      if (isCorruptDatabase(error)) {
+      const failure = error instanceof Error ? error : new Error(String(error));
+      if (isCorruptDatabase(failure)) {
         try {
           this.#rebuild();
           this.#reconcile(snapshot);
           this.#lastDiagnostic = undefined;
           return;
         } catch (rebuildError) {
-          this.#diagnose(rebuildError);
+          this.#diagnose(
+            rebuildError instanceof Error ? rebuildError : new Error(String(rebuildError)),
+          );
           return;
         }
       }
-      this.#diagnose(error);
+      this.#diagnose(failure);
     }
   }
 
@@ -260,8 +254,8 @@ export class SessionIndex {
     }
   }
 
-  #diagnose(error: unknown): void {
-    const message = error instanceof Error ? error.message : String(error);
+  #diagnose(error: Error): void {
+    const message = error.message;
     if (message === this.#lastDiagnostic) return;
     this.#lastDiagnostic = message;
     this.#options.onDiagnostic?.(`Session index unavailable: ${message}`);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,12 @@ importers:
 
   apps/desktop:
     dependencies:
+      better-sqlite3:
+        specifier: 13.0.3
+        version: 13.0.3
+      drizzle-orm:
+        specifier: 0.45.2
+        version: 0.45.2(@types/better-sqlite3@9.6.0)(@types/pg@8.21.0)(better-sqlite3@13.0.3)(kysely@0.29.5)(pg@8.23.0)
       electron-updater:
         specifier: 6.8.9
         version: 6.8.9
@@ -99,6 +105,9 @@ importers:
       '@sidecar/wire':
         specifier: workspace:*
         version: link:../../packages/wire
+      '@types/better-sqlite3':
+        specifier: 9.6.0
+        version: 9.6.0
       '@types/node':
         specifier: 26.2.0
         version: 26.2.0
@@ -108,6 +117,9 @@ importers:
       '@types/react-dom':
         specifier: 19.2.4
         version: 19.2.4(@types/react@19.2.18)
+      drizzle-kit:
+        specifier: 0.31.10
+        version: 0.31.10
       electron:
         specifier: 43.3.0
         version: 43.3.0
@@ -137,10 +149,10 @@ importers:
     dependencies:
       '@better-auth/drizzle-adapter':
         specifier: 1.6.29
-        version: 1.6.29(@better-auth/core@1.6.29(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.5.0))(@better-auth/utils@0.4.2)(drizzle-orm@0.45.2(@types/pg@8.21.0)(kysely@0.29.5)(pg@8.23.0))
+        version: 1.6.29(@better-auth/core@1.6.29(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.5.0))(@better-auth/utils@0.4.2)(drizzle-orm@0.45.2(@types/better-sqlite3@9.6.0)(@types/pg@8.21.0)(kysely@0.29.5)(pg@8.23.0))
       '@better-auth/oauth-provider':
         specifier: 1.6.29
-        version: 1.6.29(@better-auth/core@1.6.29(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.5.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-auth@1.6.29(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@types/pg@8.21.0)(kysely@0.29.5)(pg@8.23.0))(next@16.3.1(@babel/core@7.29.7)(@types/node@22.20.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(pg@8.23.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(better-call@1.4.0(zod@4.4.3))
+        version: 1.6.29(@better-auth/core@1.6.29(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.5.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-auth@1.6.29(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@types/better-sqlite3@9.6.0)(@types/pg@8.21.0)(kysely@0.29.5)(pg@8.23.0))(next@16.3.1(@babel/core@7.29.7)(@types/node@22.20.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(pg@8.23.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(better-call@1.4.0(zod@4.4.3))
       '@fontsource-variable/bricolage-grotesque':
         specifier: 5.3.0
         version: 5.3.0
@@ -182,10 +194,10 @@ importers:
         version: 4.3.3(vite@7.3.1(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.12)(yaml@2.9.0))
       better-auth:
         specifier: 1.6.29
-        version: 1.6.29(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@types/pg@8.21.0)(kysely@0.29.5)(pg@8.23.0))(next@16.3.1(@babel/core@7.29.7)(@types/node@22.20.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(pg@8.23.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        version: 1.6.29(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@types/better-sqlite3@9.6.0)(@types/pg@8.21.0)(kysely@0.29.5)(pg@8.23.0))(next@16.3.1(@babel/core@7.29.7)(@types/node@22.20.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(pg@8.23.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       drizzle-orm:
         specifier: 0.45.2
-        version: 0.45.2(@types/pg@8.21.0)(kysely@0.29.5)(pg@8.23.0)
+        version: 0.45.2(@types/better-sqlite3@9.6.0)(@types/pg@8.21.0)(better-sqlite3@13.0.3)(kysely@0.29.5)(pg@8.23.0)
       marked:
         specifier: 18.0.9
         version: 18.0.9
@@ -2339,6 +2351,9 @@ packages:
   '@types/babel__traverse@7.28.0':
     resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
 
+  '@types/better-sqlite3@9.6.0':
+    resolution: {integrity: sha512-ZEEwBSgMu7GYJOynoagg5X9JbxfL6dTJDsgViJIqh67jV44kyOr9RXfmFjLK5rzC4MWssP06t9hu/JwGDnUbCg==}
+
   '@types/cacheable-request@6.0.3':
     resolution: {integrity: sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==}
 
@@ -2700,6 +2715,10 @@ packages:
     peerDependenciesMeta:
       zod:
         optional: true
+
+  better-sqlite3@13.0.3:
+    resolution: {integrity: sha512-RbOBxmLBG8uvFUc15X9+9SFemKcQ0WBuISBVkpuiaUB2qblC8UWlHEjdWVoZ8AdhSwmoEgsiXKfopX0CQxaACQ==}
+    engines: {node: '>=22'}
 
   boolean@3.2.0:
     resolution: {integrity: sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==}
@@ -3616,6 +3635,10 @@ packages:
   node-addon-api@1.7.2:
     resolution: {integrity: sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg==}
 
+  node-addon-api@8.9.2:
+    resolution: {integrity: sha512-VijLXbi3UACN69I0JVXJsX4tjACjNoQDgv2gTF6sx2wWEi8tkSg2eX8p5gSIFi8z2+DL3oHmY6OyKce38SDolg==}
+    engines: {node: ^18 || ^20 || >= 21}
+
   node-api-version@0.2.1:
     resolution: {integrity: sha512-2xP/IGGMmmSQpI1+O/k72jF/ykvZ89JeuKX3TLJAYPDVLUalrshrLHkeVcCCZqG/eEa635cr8IBYzgnDvM2O8Q==}
 
@@ -4366,12 +4389,12 @@ snapshots:
       nanostores: 1.5.0
       zod: 4.4.3
 
-  '@better-auth/drizzle-adapter@1.6.29(@better-auth/core@1.6.29(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.5.0))(@better-auth/utils@0.4.2)(drizzle-orm@0.45.2(@types/pg@8.21.0)(kysely@0.29.5)(pg@8.23.0))':
+  '@better-auth/drizzle-adapter@1.6.29(@better-auth/core@1.6.29(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.5.0))(@better-auth/utils@0.4.2)(drizzle-orm@0.45.2(@types/better-sqlite3@9.6.0)(@types/pg@8.21.0)(kysely@0.29.5)(pg@8.23.0))':
     dependencies:
       '@better-auth/core': 1.6.29(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.5.0)
       '@better-auth/utils': 0.4.2
     optionalDependencies:
-      drizzle-orm: 0.45.2(@types/pg@8.21.0)(kysely@0.29.5)(pg@8.23.0)
+      drizzle-orm: 0.45.2(@types/better-sqlite3@9.6.0)(@types/pg@8.21.0)(better-sqlite3@13.0.3)(kysely@0.29.5)(pg@8.23.0)
 
   '@better-auth/kysely-adapter@1.6.29(@better-auth/core@1.6.29(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.5.0))(@better-auth/utils@0.4.2)(kysely@0.29.5)':
     dependencies:
@@ -4390,12 +4413,12 @@ snapshots:
       '@better-auth/core': 1.6.29(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.5.0)
       '@better-auth/utils': 0.4.2
 
-  '@better-auth/oauth-provider@1.6.29(@better-auth/core@1.6.29(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.5.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-auth@1.6.29(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@types/pg@8.21.0)(kysely@0.29.5)(pg@8.23.0))(next@16.3.1(@babel/core@7.29.7)(@types/node@22.20.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(pg@8.23.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(better-call@1.4.0(zod@4.4.3))':
+  '@better-auth/oauth-provider@1.6.29(@better-auth/core@1.6.29(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.5.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-auth@1.6.29(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@types/better-sqlite3@9.6.0)(@types/pg@8.21.0)(kysely@0.29.5)(pg@8.23.0))(next@16.3.1(@babel/core@7.29.7)(@types/node@22.20.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(pg@8.23.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(better-call@1.4.0(zod@4.4.3))':
     dependencies:
       '@better-auth/core': 1.6.29(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.5.0)
       '@better-auth/utils': 0.4.2
       '@better-fetch/fetch': 1.3.1
-      better-auth: 1.6.29(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@types/pg@8.21.0)(kysely@0.29.5)(pg@8.23.0))(next@16.3.1(@babel/core@7.29.7)(@types/node@22.20.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(pg@8.23.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      better-auth: 1.6.29(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@types/better-sqlite3@9.6.0)(@types/pg@8.21.0)(kysely@0.29.5)(pg@8.23.0))(next@16.3.1(@babel/core@7.29.7)(@types/node@22.20.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(pg@8.23.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       better-call: 1.4.0(zod@4.4.3)
       jose: 6.2.9
       zod: 4.4.3
@@ -5322,6 +5345,10 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.8
 
+  '@types/better-sqlite3@9.6.0':
+    dependencies:
+      '@types/node': 26.2.0
+
   '@types/cacheable-request@6.0.3':
     dependencies:
       '@types/http-cache-semantics': 4.2.0
@@ -5581,10 +5608,10 @@ snapshots:
 
   baseline-browser-mapping@2.11.13: {}
 
-  better-auth@1.6.29(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@types/pg@8.21.0)(kysely@0.29.5)(pg@8.23.0))(next@16.3.1(@babel/core@7.29.7)(@types/node@22.20.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(pg@8.23.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
+  better-auth@1.6.29(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@types/better-sqlite3@9.6.0)(@types/pg@8.21.0)(kysely@0.29.5)(pg@8.23.0))(next@16.3.1(@babel/core@7.29.7)(@types/node@22.20.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(pg@8.23.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:
       '@better-auth/core': 1.6.29(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.5.0)
-      '@better-auth/drizzle-adapter': 1.6.29(@better-auth/core@1.6.29(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.5.0))(@better-auth/utils@0.4.2)(drizzle-orm@0.45.2(@types/pg@8.21.0)(kysely@0.29.5)(pg@8.23.0))
+      '@better-auth/drizzle-adapter': 1.6.29(@better-auth/core@1.6.29(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.5.0))(@better-auth/utils@0.4.2)(drizzle-orm@0.45.2(@types/better-sqlite3@9.6.0)(@types/pg@8.21.0)(kysely@0.29.5)(pg@8.23.0))
       '@better-auth/kysely-adapter': 1.6.29(@better-auth/core@1.6.29(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.5.0))(@better-auth/utils@0.4.2)(kysely@0.29.5)
       '@better-auth/memory-adapter': 1.6.29(@better-auth/core@1.6.29(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.5.0))(@better-auth/utils@0.4.2)
       '@better-auth/mongo-adapter': 1.6.29(@better-auth/core@1.6.29(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.5.0))(@better-auth/utils@0.4.2)
@@ -5602,7 +5629,7 @@ snapshots:
       zod: 4.4.3
     optionalDependencies:
       drizzle-kit: 0.31.10
-      drizzle-orm: 0.45.2(@types/pg@8.21.0)(kysely@0.29.5)(pg@8.23.0)
+      drizzle-orm: 0.45.2(@types/better-sqlite3@9.6.0)(@types/pg@8.21.0)(better-sqlite3@13.0.3)(kysely@0.29.5)(pg@8.23.0)
       next: 16.3.1(@babel/core@7.29.7)(@types/node@22.20.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       pg: 8.23.0
       react: 19.2.8
@@ -5619,6 +5646,10 @@ snapshots:
       set-cookie-parser: 3.1.2
     optionalDependencies:
       zod: 4.4.3
+
+  better-sqlite3@13.0.3:
+    dependencies:
+      node-addon-api: 8.9.2
 
   boolean@3.2.0:
     optional: true
@@ -5902,9 +5933,11 @@ snapshots:
       esbuild: 0.25.12
       tsx: 4.23.12
 
-  drizzle-orm@0.45.2(@types/pg@8.21.0)(kysely@0.29.5)(pg@8.23.0):
+  drizzle-orm@0.45.2(@types/better-sqlite3@9.6.0)(@types/pg@8.21.0)(better-sqlite3@13.0.3)(kysely@0.29.5)(pg@8.23.0):
     optionalDependencies:
+      '@types/better-sqlite3': 9.6.0
       '@types/pg': 8.21.0
+      better-sqlite3: 13.0.3
       kysely: 0.29.5
       pg: 8.23.0
 
@@ -6576,6 +6609,8 @@ snapshots:
 
   node-addon-api@1.7.2:
     optional: true
+
+  node-addon-api@8.9.2: {}
 
   node-api-version@0.2.1:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,6 @@
 packages:
   - "apps/*"
   - "packages/*"
+
+onlyBuiltDependencies:
+  - better-sqlite3

--- a/scripts/packaging.test.mjs
+++ b/scripts/packaging.test.mjs
@@ -150,6 +150,24 @@ test("packaging is pinned to Apple Silicon and the builder output directory", ()
   );
 });
 
+test("the session index driver is rebuilt for Electron and unpacked from the asar", () => {
+  const config = builderConfig();
+  const manifest = JSON.parse(
+    fs.readFileSync(path.join(repoRoot, "apps", "desktop", "package.json"), "utf8"),
+  );
+  const build = fs.readFileSync(
+    path.join(repoRoot, "apps", "desktop", "scripts", "build.mjs"),
+    "utf8",
+  );
+
+  assert.ok(manifest.dependencies["better-sqlite3"]);
+  assert.ok(manifest.dependencies["drizzle-orm"]);
+  assert.equal(config.npmRebuild, true);
+  assert.deepEqual(config.asarUnpack, ["node_modules/better-sqlite3/**/*"]);
+  assert.match(build, /external: \["better-sqlite3", "electron"\]/);
+  assert.match(build, /drizzle\/session-index/);
+});
+
 test("packaging declares the macOS deployment target", () => {
   const config = builderConfig();
   const compilerArguments = swiftCompilerArguments("source.swift", "helper");

--- a/scripts/repository-checks.sh
+++ b/scripts/repository-checks.sh
@@ -234,6 +234,17 @@ if [[ -n "$renderer_escapes" ]]; then
     exit 1
 fi
 
+native_session_index_escapes=$(grep -rEn \
+    'better-sqlite3|drizzle-orm/better-sqlite3|#main/session-index' \
+    "$SIDECAR_REPO_ROOT/apps/desktop/src/renderer" \
+    "$SIDECAR_REPO_ROOT/apps/desktop/src/preload" \
+    "$SIDECAR_REPO_ROOT"/packages/*/src/index.ts || true)
+if [[ -n "$native_session_index_escapes" ]]; then
+    printf 'error: the native session index belongs to the Electron main process and must not enter renderer, preload, or package barrels:\n%s\n' \
+        "$native_session_index_escapes" >&2
+    exit 1
+fi
+
 # BRIDGE is the one renderer-to-main declaration, and registerBridge is the
 # one place that may attach it to Electron. A handler registered beside its
 # domain logic would bypass the manifest's sender and wire guards.

--- a/scripts/test-macos.sh
+++ b/scripts/test-macos.sh
@@ -26,6 +26,19 @@ if [[ ! -f "$PACKAGED_APP/Contents/Resources/mac-stationary-window.node" ]]; the
     printf 'error: packaged app is missing the mac-stationary-window.node addon\n' >&2
     exit 1
 fi
+PACKAGED_RESOURCES="$PACKAGED_APP/Contents/Resources"
+PACKAGED_SQLITE="$PACKAGED_RESOURCES/app.asar.unpacked/node_modules/better-sqlite3"
+if [[ ! -f "$PACKAGED_SQLITE/build/Release/better_sqlite3.node" ]]; then
+    printf 'error: packaged app is missing the unpacked better-sqlite3 addon\n' >&2
+    exit 1
+fi
+ELECTRON_RUN_AS_NODE=1 "$PACKAGED_APP/Contents/MacOS/Luke" -e '
+const path = require("node:path");
+const Database = require(path.join(process.argv[1], "app.asar", "node_modules", "better-sqlite3"));
+const database = new Database(":memory:");
+database.exec("CREATE VIRTUAL TABLE sessions_fts USING fts5(title)");
+database.close();
+' "$PACKAGED_RESOURCES"
 INFO_PLIST="$PACKAGED_APP/Contents/Info.plist"
 BUNDLE_ICON_FILE=$(plutil -extract CFBundleIconFile raw -o - "$INFO_PLIST")
 PACKAGED_ICON="$PACKAGED_APP/Contents/Resources/$BUNDLE_ICON_FILE"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- add a disposable Drizzle and FTS5 projection of observed sessions under Luke's application data
- reconcile the index after observation passes while keeping the in-memory registry authoritative
- package `better-sqlite3` for Electron and keep fixture/capture runs persistence-free
- disclose the local owner-only index in the privacy policy

## Evidence

- Platform-independent checks: `./scripts/check.sh` passed under Node 24.19.0
- Focused index tests: 7 passed, 0 failed
- macOS Electron verification (`./scripts/verify.sh`): portable checks passed, then verification stopped with `error: this command requires macOS` on the Linux cloud host

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/33468285230/artifacts/9785681004) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/33468285230)

- Commit: `474b6f913af5150e0927eb0d123cf508a877f221`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

### Physical-device evidence

- Screenshot or screen recording: `not attached`
- Physical-notch check: `not performed` (Linux cloud host)
- Device/display configuration: `not available`

## Notes

- The renderer, row source, spoken search, embeddings, vectors, and iOS remain unchanged in this first write-aside PR.
- macOS packaging and visual evidence still require a macOS runner or physical Mac.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-18ad63de-af60-4b06-afb6-0725bab67b25?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-18ad63de-af60-4b06-afb6-0725bab67b25&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)