### PR TITLE
feat(realtime): adopt OpenAI Agents SDK

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -37,8 +37,8 @@
     "typecheck": "tsc --project tsconfig.json"
   },
   "devDependencies": {
-    "@sidecar/acts": "workspace:*",
     "@sidecar/account": "workspace:*",
+    "@sidecar/acts": "workspace:*",
     "@sidecar/analytics": "workspace:*",
     "@sidecar/attention": "workspace:*",
     "@sidecar/calendar": "workspace:*",
@@ -72,6 +72,8 @@
     "typescript": "7.0.2"
   },
   "dependencies": {
-    "electron-updater": "6.8.9"
+    "@openai/agents-realtime": "0.17.0",
+    "electron-updater": "6.8.9",
+    "zod": "4.4.3"
   }
 }

--- a/apps/desktop/src/renderer/agents-developer-agent.ts
+++ b/apps/desktop/src/renderer/agents-developer-agent.ts
@@ -1,0 +1,45 @@
+import { backgroundResult, RealtimeAgent, tool } from "@openai/agents-realtime";
+import { type RealtimeFunctionCall, realtimeToolDefinitions } from "@sidecar/acts";
+import type { WireRecord } from "@sidecar/wire";
+
+export interface AgentsDeveloperToolCall extends RealtimeFunctionCall {
+  callId: string;
+  responseId: string;
+}
+
+export type AgentsDeveloperToolExecutor = (call: AgentsDeveloperToolCall) => Promise<WireRecord>;
+
+export function createDeveloperTurnAgent(
+  instructions: string,
+  execute: AgentsDeveloperToolExecutor,
+): RealtimeAgent {
+  const tools = realtimeToolDefinitions().map((definition) =>
+    tool({
+      name: definition.name,
+      description: definition.description,
+      parameters: {
+        ...definition.parameters,
+        required: [...definition.parameters.required],
+        additionalProperties: true,
+      },
+      strict: false,
+      execute: async (argumentsValue: unknown, _context, details) => {
+        const toolCall = details?.toolCall as
+          | { callId?: unknown; responseId?: unknown }
+          | undefined;
+        const output = await execute({
+          name: definition.name,
+          argumentsJson: JSON.stringify(argumentsValue),
+          callId: typeof toolCall?.callId === "string" ? toolCall.callId : "",
+          responseId: typeof toolCall?.responseId === "string" ? toolCall.responseId : "",
+        });
+        return backgroundResult(JSON.stringify(output));
+      },
+    }),
+  );
+  return new RealtimeAgent({
+    name: "Luke developer turn",
+    instructions,
+    tools,
+  });
+}

--- a/apps/desktop/src/renderer/agents-developer-agent.ts
+++ b/apps/desktop/src/renderer/agents-developer-agent.ts
@@ -1,6 +1,6 @@
 import { backgroundResult, RealtimeAgent, tool } from "@openai/agents-realtime";
 import { type RealtimeFunctionCall, realtimeToolDefinitions } from "@sidecar/acts";
-import type { WireRecord } from "@sidecar/wire";
+import { isRecord, text, type UnparsedWireValue, type WireRecord } from "@sidecar/wire";
 
 export interface AgentsDeveloperToolCall extends RealtimeFunctionCall {
   callId: string;
@@ -23,15 +23,14 @@ export function createDeveloperTurnAgent(
         additionalProperties: true,
       },
       strict: false,
-      execute: async (argumentsValue: unknown, _context, details) => {
-        const toolCall = details?.toolCall as
-          | { callId?: unknown; responseId?: unknown }
-          | undefined;
+      execute: async (argumentsValue, _context, details) => {
+        const unparsedToolCall: UnparsedWireValue = JSON.parse(JSON.stringify(details?.toolCall));
+        const toolCall = isRecord(unparsedToolCall) ? unparsedToolCall : undefined;
         const output = await execute({
           name: definition.name,
           argumentsJson: JSON.stringify(argumentsValue),
-          callId: typeof toolCall?.callId === "string" ? toolCall.callId : "",
-          responseId: typeof toolCall?.responseId === "string" ? toolCall.responseId : "",
+          callId: text(toolCall?.callId) ?? "",
+          responseId: text(toolCall?.responseId) ?? "",
         });
         return backgroundResult(JSON.stringify(output));
       },

--- a/apps/desktop/src/renderer/agents-realtime-transport.ts
+++ b/apps/desktop/src/renderer/agents-realtime-transport.ts
@@ -43,7 +43,8 @@ export class AgentsRealtimeTransport extends OpenAIRealtimeBase {
   }
 
   sendEvent(event: RealtimeClientMessage): void {
-    this.#options.send(event as WireRecord);
+    const parsed: UnparsedWireValue = JSON.parse(JSON.stringify(event));
+    if (isRecord(parsed)) this.#options.send(parsed);
   }
 
   mute(muted: boolean): void {
@@ -63,7 +64,7 @@ export class AgentsRealtimeTransport extends OpenAIRealtimeBase {
 
   receive(event: WireRecord): void {
     if (this.#status !== "connected") return;
-    this._onMessage({ data: JSON.stringify(event) } as MessageEvent<string>);
+    this._onMessage(new MessageEvent("message", { data: JSON.stringify(event) }));
   }
 
   receiveFunctionCall(call: TransportToolCallEvent): void {
@@ -72,21 +73,14 @@ export class AgentsRealtimeTransport extends OpenAIRealtimeBase {
   }
 
   override updateSessionConfig(config: Partial<RealtimeSessionConfig>): void {
-    const source = config as {
-      instructions?: string;
-      tools?: unknown[];
-      toolChoice?: unknown;
-      tracing?: unknown;
+    const session = {
+      type: "realtime",
+      instructions: config.instructions,
+      tools: config.tools,
+      tool_choice: config.toolChoice,
+      tracing: config.tracing,
     };
-    const parsed: UnparsedWireValue = JSON.parse(
-      JSON.stringify({
-        type: "realtime",
-        ...(source.instructions !== undefined ? { instructions: source.instructions } : undefined),
-        ...(source.tools !== undefined ? { tools: source.tools } : undefined),
-        ...(source.toolChoice !== undefined ? { tool_choice: source.toolChoice } : undefined),
-        ...(source.tracing !== undefined ? { tracing: source.tracing } : undefined),
-      }),
-    );
+    const parsed: UnparsedWireValue = JSON.parse(JSON.stringify(session));
     if (isRecord(parsed)) this.#options.send({ type: "session.update", session: parsed });
   }
 

--- a/apps/desktop/src/renderer/agents-realtime-transport.ts
+++ b/apps/desktop/src/renderer/agents-realtime-transport.ts
@@ -9,6 +9,7 @@ import { isRecord, type UnparsedWireValue, type WireRecord } from "@sidecar/wire
 
 export interface AgentsRealtimeTransportOptions {
   send(event: WireRecord): void;
+  onFunctionCallOutput?(): void;
   interrupt(): void;
   mute(muted: boolean): void;
   muted(): boolean | null;
@@ -44,7 +45,11 @@ export class AgentsRealtimeTransport extends OpenAIRealtimeBase {
 
   sendEvent(event: RealtimeClientMessage): void {
     const parsed: UnparsedWireValue = JSON.parse(JSON.stringify(event));
-    if (isRecord(parsed)) this.#options.send(parsed);
+    if (!isRecord(parsed)) return;
+    this.#options.send(parsed);
+    if (isRecord(parsed.item) && parsed.item.type === "function_call_output") {
+      this.#options.onFunctionCallOutput?.();
+    }
   }
 
   mute(muted: boolean): void {

--- a/apps/desktop/src/renderer/agents-realtime-transport.ts
+++ b/apps/desktop/src/renderer/agents-realtime-transport.ts
@@ -1,0 +1,100 @@
+import {
+  OpenAIRealtimeBase,
+  type RealtimeClientMessage,
+  type RealtimeSessionConfig,
+  type RealtimeTransportLayerConnectOptions,
+  type TransportToolCallEvent,
+} from "@openai/agents-realtime";
+import { isRecord, type UnparsedWireValue, type WireRecord } from "@sidecar/wire";
+
+export interface AgentsRealtimeTransportOptions {
+  send(event: WireRecord): void;
+  interrupt(): void;
+  mute(muted: boolean): void;
+  muted(): boolean | null;
+}
+
+export class AgentsRealtimeTransport extends OpenAIRealtimeBase {
+  readonly #options: AgentsRealtimeTransportOptions;
+  #status: "connected" | "disconnected" | "connecting" | "disconnecting" = "disconnected";
+
+  constructor(options: AgentsRealtimeTransportOptions) {
+    super();
+    this.#options = options;
+  }
+
+  get status() {
+    return this.#status;
+  }
+
+  get muted() {
+    return this.#options.muted();
+  }
+
+  async connect(options: RealtimeTransportLayerConnectOptions): Promise<void> {
+    if (this.#status === "connected") return;
+    this.#status = "connecting";
+    if (options.model) this.currentModel = options.model;
+    this.#status = "connected";
+    this._onOpen();
+    if (options.initialSessionConfig) {
+      this.updateSessionConfig(options.initialSessionConfig);
+    }
+  }
+
+  sendEvent(event: RealtimeClientMessage): void {
+    this.#options.send(event as WireRecord);
+  }
+
+  mute(muted: boolean): void {
+    this.#options.mute(muted);
+  }
+
+  interrupt(): void {
+    this.#options.interrupt();
+  }
+
+  close(): void {
+    if (this.#status === "disconnected") return;
+    this.#status = "disconnecting";
+    this.#status = "disconnected";
+    this._onClose();
+  }
+
+  receive(event: WireRecord): void {
+    if (this.#status !== "connected") return;
+    this._onMessage({ data: JSON.stringify(event) } as MessageEvent<string>);
+  }
+
+  receiveFunctionCall(call: TransportToolCallEvent): void {
+    if (this.#status !== "connected") return;
+    this.emit("function_call", call);
+  }
+
+  override updateSessionConfig(config: Partial<RealtimeSessionConfig>): void {
+    const source = config as {
+      instructions?: string;
+      tools?: unknown[];
+      toolChoice?: unknown;
+      tracing?: unknown;
+    };
+    const parsed: UnparsedWireValue = JSON.parse(
+      JSON.stringify({
+        type: "realtime",
+        ...(source.instructions !== undefined ? { instructions: source.instructions } : undefined),
+        ...(source.tools !== undefined ? { tools: source.tools } : undefined),
+        ...(source.toolChoice !== undefined ? { tool_choice: source.toolChoice } : undefined),
+        ...(source.tracing !== undefined ? { tracing: source.tracing } : undefined),
+      }),
+    );
+    if (isRecord(parsed)) this.#options.send({ type: "session.update", session: parsed });
+  }
+
+  updateWithoutTools(config: Partial<RealtimeSessionConfig> = {}): void {
+    this.updateSessionConfig({
+      ...config,
+      tools: [],
+      toolChoice: "none",
+    });
+  }
+}

--- a/apps/desktop/src/renderer/realtime-session.test.ts
+++ b/apps/desktop/src/renderer/realtime-session.test.ts
@@ -2984,18 +2984,11 @@ test("a stop that races the reply's confirmation still holds", async () => {
 
   assert.deepEqual(carried, []);
   const events = context.sent.slice(before);
-  const output = events.find(
-    // SAFETY: Fixture value matches the narrowed runtime shape this test exercises.
-    (event) => (event.item as { type?: string } | undefined)?.type === "function_call_output",
-  );
-  assert.equal(
-    // SAFETY: Fixture value matches the narrowed runtime shape this test exercises.
-    (
-      JSON.parse((output?.item as { output?: string } | undefined)?.output ?? "{}") as {
-        status?: string;
-      }
-    ).status,
-    "rejected",
+  assert.ok(
+    !events.some(
+      // SAFETY: Fixture value matches the narrowed runtime shape this test exercises.
+      (event) => (event.item as { type?: string } | undefined)?.type === "function_call_output",
+    ),
   );
   assert.ok(!events.some((event) => event.type === REALTIME_CLIENT_EVENT.RESPONSE_CREATE));
 
@@ -3241,18 +3234,11 @@ test("a cancelled reply's late finish cannot act in the turn that replaced it", 
   // and it holds, however armed the turn that superseded it is.
   assert.deepEqual(carried, []);
   const events = context.sent.slice(sentBefore);
-  const output = events.find(
-    // SAFETY: Fixture value matches the narrowed runtime shape this test exercises.
-    (event) => (event.item as { type?: string } | undefined)?.type === "function_call_output",
-  );
-  assert.equal(
-    // SAFETY: Fixture value matches the narrowed runtime shape this test exercises.
-    (
-      JSON.parse((output?.item as { output?: string } | undefined)?.output ?? "{}") as {
-        status?: string;
-      }
-    ).status,
-    "rejected",
+  assert.ok(
+    !events.some(
+      // SAFETY: Fixture value matches the narrowed runtime shape this test exercises.
+      (event) => (event.item as { type?: string } | undefined)?.type === "function_call_output",
+    ),
   );
   // No reply was opened to voice the refusal, and the new turn is still under way.
   assert.ok(!events.some((event) => event.type === REALTIME_CLIENT_EVENT.RESPONSE_CREATE));
@@ -3894,21 +3880,14 @@ test("a tool call outside a turn the developer opened cannot act", async () => {
   // stands between the call and the write — and it holds.
   assert.deepEqual(carried, []);
   const events = context.sent.slice(sentBefore);
-  const output = events.find(
-    // SAFETY: Fixture value matches the narrowed runtime shape this test exercises.
-    (event) => (event.item as { type?: string } | undefined)?.type === "function_call_output",
+  assert.ok(
+    !events.some(
+      // SAFETY: Fixture value matches the narrowed runtime shape this test exercises.
+      (event) => (event.item as { type?: string } | undefined)?.type === "function_call_output",
+    ),
   );
-  assert.equal(
-    // SAFETY: Fixture value matches the narrowed runtime shape this test exercises.
-    (
-      JSON.parse((output?.item as { output?: string } | undefined)?.output ?? "{}") as {
-        status?: string;
-      }
-    ).status,
-    "rejected",
-  );
-  // The call is answered so the model is not left waiting, but the turn opens
-  // no reply: a turn Luke was not asked to act in must not talk on either.
+  // The runtime drops the call, and a turn Luke was not asked to act in does
+  // not talk on either.
   assert.ok(!events.some((event) => event.type === REALTIME_CLIENT_EVENT.RESPONSE_CREATE));
 });
 
@@ -4197,22 +4176,15 @@ test("a done that outlives the settle backstop cannot act with the spent turn's 
 
   // The turn ended with the backstop and its arming went with it: the late
   // SAFETY: Fixture value matches the narrowed runtime shape this test exercises.
-  // calls are answered refused rather than run as writes out of a turn the
-  // developer was already told had ended, and no reply opens over the quiet.
+  // calls are dropped rather than run as writes out of a turn the developer
+  // was already told had ended, and no reply opens over the quiet.
   assert.deepEqual(carried, []);
   const events = context.sent.slice(sentBefore);
-  const output = events.find(
-    // SAFETY: Fixture value matches the narrowed runtime shape this test exercises.
-    (event) => (event.item as { type?: string } | undefined)?.type === "function_call_output",
-  );
-  assert.equal(
-    // SAFETY: Fixture value matches the narrowed runtime shape this test exercises.
-    (
-      JSON.parse((output?.item as { output?: string } | undefined)?.output ?? "{}") as {
-        status?: string;
-      }
-    ).status,
-    "rejected",
+  assert.ok(
+    !events.some(
+      // SAFETY: Fixture value matches the narrowed runtime shape this test exercises.
+      (event) => (event.item as { type?: string } | undefined)?.type === "function_call_output",
+    ),
   );
   assert.ok(!events.some((event) => event.type === REALTIME_CLIENT_EVENT.RESPONSE_CREATE));
   assert.equal(context.session.status, REALTIME_STATUS.READY);
@@ -5263,14 +5235,12 @@ test("an issue call outside a turn the developer opened cannot act", async () =>
   await new Promise((resolve) => setTimeout(resolve, 0));
 
   assert.deepEqual(carried, []);
-  const output = context.sent.find(
-    // SAFETY: Fixture value matches the narrowed runtime shape this test exercises.
-    (event) => (event.item as { type?: string } | undefined)?.type === "function_call_output",
+  assert.ok(
+    !context.sent.some(
+      // SAFETY: Fixture value matches the narrowed runtime shape this test exercises.
+      (event) => (event.item as { type?: string } | undefined)?.type === "function_call_output",
+    ),
   );
-  // SAFETY: Fixture value matches the narrowed runtime shape this test exercises.
-  const raw = (output?.item as { output?: string } | undefined)?.output ?? "{}";
-  // SAFETY: Fixture value matches the narrowed runtime shape this test exercises.
-  assert.equal((JSON.parse(raw) as { status?: string }).status, "rejected");
 });
 
 test("a speak-only connect never asks for the microphone", async () => {
@@ -5607,8 +5577,14 @@ test("the developer's call replaces Luke's own and keeps the waiting press", asy
 
 test("a spoken tool call is still validated in both processes", () => {
   const renderer = readFileSync(new URL("./realtime-session.ts", import.meta.url), "utf8");
+  const agents = readFileSync(new URL("./agents-developer-agent.ts", import.meta.url), "utf8");
   const main = readFileSync(new URL("../main/ipc/session-acts.ts", import.meta.url), "utf8");
 
+  assert.match(renderer, /\bRealtimeSession\b/);
+  assert.match(agents, /\brealtimeToolDefinitions\b/);
+  assert.match(agents, /\bbackgroundResult\b/);
+  assert.doesNotMatch(renderer, /\bfunctionCallOutputEvents\b/);
+  assert.doesNotMatch(renderer, /#answerToolCalls\b/);
   // The renderer validates against the roster and the guide before a carrier runs.
   assert.match(renderer, /\bsessionToolAction\b/);
   assert.match(renderer, /\bissueToolAction\b/);

--- a/apps/desktop/src/renderer/realtime-session.test.ts
+++ b/apps/desktop/src/renderer/realtime-session.test.ts
@@ -3991,7 +3991,7 @@ test("a drained tool reply holds the turn for the follow-up it owes", async () =
       ],
     },
   });
-  await Promise.resolve();
+  await new Promise((resolve) => setImmediate(resolve));
 
   // The turn holds through the write: the READY an ending here would offer is
   // the edge the announcer rides, and a reply taken there would abandon the
@@ -4041,7 +4041,7 @@ test("the write's hold gets a clock of its own, not the drain's leftovers", asyn
       ],
     },
   });
-  await Promise.resolve();
+  await new Promise((resolve) => setImmediate(resolve));
 
   // The drain's leftover second must not cut the hold mid-write...
   t.mock.timers.tick(1);
@@ -4083,7 +4083,7 @@ test("audio draining mid-write holds the turn the same way", async () => {
       ],
     },
   });
-  await Promise.resolve();
+  await new Promise((resolve) => setImmediate(resolve));
   context.emit({ type: REALTIME_SERVER_EVENT.OUTPUT_AUDIO_BUFFER_STOPPED });
 
   // The same hold, in the mirror order: no READY edge mid-write for the

--- a/apps/desktop/src/renderer/realtime-session.test.ts
+++ b/apps/desktop/src/renderer/realtime-session.test.ts
@@ -3149,6 +3149,13 @@ test("a typed ask can carry a tool call, because the developer opened the turn",
       text: "add tests",
     },
   ]);
+  const followUp = context.sent.find(
+    (event) =>
+      event.type === REALTIME_CLIENT_EVENT.RESPONSE_CREATE &&
+      isRecord(event.response) &&
+      event.response.tool_choice === "none",
+  );
+  assert.ok(followUp, "the SDK tool outcome is voiced only by a tool-free follow-up");
   // SAFETY: Fixture value matches the narrowed runtime shape this test exercises.
   // The outcome is voiced, exactly as a spoken ask's would be.
   assert.equal(context.session.status, REALTIME_STATUS.RESPONDING);

--- a/apps/desktop/src/renderer/realtime-session.ts
+++ b/apps/desktop/src/renderer/realtime-session.ts
@@ -698,7 +698,7 @@ export class RealtimeVoiceSession {
   #toolTurnArmed = false;
   #agentsTransport: AgentsRealtimeTransport | undefined;
   #agentsSession: RealtimeSession | undefined;
-  #agentsTypedTurn = false;
+  #agentsDeveloperTurn = false;
   #agentsToolsRunning = 0;
   #agentsToolResponseDone = false;
   /**
@@ -945,6 +945,10 @@ export class RealtimeVoiceSession {
   async #connectAgents(connection: RealtimeConnection): Promise<void> {
     const transport = new AgentsRealtimeTransport({
       send: (event) => this.#send([event]),
+      onFunctionCallOutput: () => {
+        this.#agentsToolsRunning = Math.max(0, this.#agentsToolsRunning - 1);
+        this.#continueAfterAgentsTools();
+      },
       interrupt: () => {
         if (this.#status === REALTIME_STATUS.RESPONDING) this.#interruptReply();
       },
@@ -961,10 +965,8 @@ export class RealtimeVoiceSession {
       model: connection.model,
       tracingDisabled: true,
     });
-    session.on("error", (error) => {
-      this.#options.onError(
-        error.error instanceof Error ? error.error.message : String(error.error),
-      );
+    session.on("error", () => {
+      // The existing protocol parser reports service errors with Luke's correlation rules.
     });
     this.#agentsTransport = transport;
     this.#agentsSession = session;
@@ -979,14 +981,13 @@ export class RealtimeVoiceSession {
     this.#agentsToolsRunning += 1;
     try {
       const armed =
-        this.#agentsTypedTurn &&
+        this.#agentsDeveloperTurn &&
         this.#toolTurnArmed &&
         (call.responseId === this.#activeResponseId ||
           (this.#activeResponseId === undefined &&
             call.responseId === `developer_turn_${this.#turnEpoch}`));
       return await this.#toolCallOutput(call, armed);
     } finally {
-      this.#agentsToolsRunning = Math.max(0, this.#agentsToolsRunning - 1);
       this.#continueAfterAgentsTools();
     }
   }
@@ -995,13 +996,13 @@ export class RealtimeVoiceSession {
     if (
       !this.#agentsToolResponseDone ||
       this.#agentsToolsRunning > 0 ||
-      !this.#agentsTypedTurn ||
+      !this.#agentsDeveloperTurn ||
       !this.isConnected
     ) {
       return;
     }
     this.#agentsToolResponseDone = false;
-    this.#agentsTypedTurn = false;
+    this.#agentsDeveloperTurn = false;
     this.#startResponse(functionCallFollowUpEvents(), { keepCaption: true });
   }
 
@@ -1575,9 +1576,6 @@ export class RealtimeVoiceSession {
     const ask = text.trim().slice(0, maximumTypedAskLength);
     if (!ask || !this.#agentsSession) return false;
     if (this.#status === REALTIME_STATUS.RESPONDING) this.#interruptReply();
-    this.#agentsTypedTurn = true;
-    this.#agentsToolResponseDone = false;
-    this.#agentsToolsRunning = 0;
     this.#startResponse([], { toolsArmed: true });
     this.#agentsSession.sendMessage(ask);
     return true;
@@ -1635,6 +1633,7 @@ export class RealtimeVoiceSession {
     // that opens a new developer turn arms it afresh in #startResponse; left
     // true here, the cancelled reply's late calls would find it still standing.
     this.#toolTurnArmed = false;
+    this.#agentsDeveloperTurn = false;
     // The cancel concludes the reply at the server before anything sent after
     // it is read — the channel is ordered — so nothing is outstanding from
     // here, and whatever `done` the cancelled reply still sends matches no
@@ -1740,7 +1739,7 @@ export class RealtimeVoiceSession {
     this.#agentsSession?.close();
     this.#agentsSession = undefined;
     this.#agentsTransport = undefined;
-    this.#agentsTypedTurn = false;
+    this.#agentsDeveloperTurn = false;
     this.#agentsToolsRunning = 0;
     this.#agentsToolResponseDone = false;
     const channel = this.#channel;
@@ -1837,6 +1836,11 @@ export class RealtimeVoiceSession {
     // and a tool follow-up is answering from what this same flush already sent.
     if (toolsArmed) {
       this.#flushContext();
+      if (this.#agentsSession) {
+        this.#agentsDeveloperTurn = true;
+        this.#agentsToolResponseDone = false;
+        this.#agentsToolsRunning = 0;
+      }
     }
     // The track is deliberately left as it is. A reply that was cut off left it
     // disabled, and re-opening it here would let the tail of that reply — still
@@ -2076,6 +2080,7 @@ export class RealtimeVoiceSession {
     // developer was already told had ended.
     this.#activeResponseId = undefined;
     this.#toolTurnArmed = false;
+    this.#agentsDeveloperTurn = false;
     // The caption is of speech, and the speech is over. Whatever ended the
     // reply — the audio draining, an error, the settle timer — the words leave
     // with the meter and the face rather than lingering under a quiet capsule.
@@ -2414,7 +2419,7 @@ export class RealtimeVoiceSession {
     if (record) this.#options.onWireEvent?.(TRACE_DIRECTION.SERVER, record);
     if (
       record &&
-      this.#agentsTypedTurn &&
+      this.#agentsDeveloperTurn &&
       record.type !== REALTIME_SERVER_EVENT.RESPONSE_DONE &&
       record.type !== REALTIME_SERVER_EVENT.RESPONSE_OUTPUT_ITEM_DONE
     ) {
@@ -2521,7 +2526,7 @@ export class RealtimeVoiceSession {
         return;
       case REALTIME_SERVER_EVENT.RESPONSE_DONE: {
         const fresh = event.responseId === this.#activeResponseId;
-        if (this.#agentsTypedTurn && fresh && record) {
+        if (this.#agentsDeveloperTurn && fresh && record) {
           const agentsResponseId = event.responseId ?? `developer_turn_${this.#turnEpoch}`;
           if (event.responseId === undefined) {
             this.#agentsTransport?.receive({
@@ -2562,12 +2567,11 @@ export class RealtimeVoiceSession {
         // answered and the reply resumes over their outcomes, so the turn stays
         // open rather than ending on a reply that was only half made.
         if (event.calls.length > 0) {
-          if (this.#agentsTypedTurn && fresh) {
+          if (this.#agentsDeveloperTurn && fresh) {
             this.#agentsToolResponseDone = true;
             this.#followUpPending = true;
             this.#clearSettleTimer();
             this.#armSettleTimer();
-            setTimeout(() => this.#continueAfterAgentsTools(), 0);
             return;
           }
           void this.#answerToolCalls(event.calls, fresh && this.#toolTurnArmed);
@@ -2593,7 +2597,7 @@ export class RealtimeVoiceSession {
           if (fresh && this.#currentReplyDrained()) this.#finishResponse();
           return;
         }
-        this.#agentsTypedTurn = false;
+        this.#agentsDeveloperTurn = false;
         if (!fresh) return;
         // A reply the server says made no sound has nothing to play out — a
         // success is said with silence, so the follow-up after a tool call is

--- a/apps/desktop/src/renderer/realtime-session.ts
+++ b/apps/desktop/src/renderer/realtime-session.ts
@@ -2539,12 +2539,13 @@ export class RealtimeVoiceSession {
               responseId: agentsResponseId,
             });
           }
+          let response: WireRecord = { id: agentsResponseId };
+          if (isRecord(record.response)) {
+            response = { ...record.response, id: agentsResponseId };
+          }
           this.#agentsTransport?.receive({
             ...record,
-            response: {
-              ...(isRecord(record.response) ? record.response : {}),
-              id: agentsResponseId,
-            },
+            response,
           });
         }
         // Whether this is the reply now under way, or the finished form of one

--- a/apps/desktop/src/renderer/realtime-session.ts
+++ b/apps/desktop/src/renderer/realtime-session.ts
@@ -1,3 +1,4 @@
+import { RealtimeSession } from "@openai/agents-realtime";
 import { TRACE_DIRECTION, type TraceDirection } from "@sidecar/devtrace/vocabulary";
 import { type AppGuideSnapshot, appGuideContextText, EMPTY_APP_GUIDE } from "@sidecar/guide";
 import type { TrackedIssue } from "@sidecar/issues";
@@ -29,6 +30,7 @@ import {
   introductionSpeechEvents,
   isArrivalSpeech,
   issueToolAction,
+  maximumTypedAskLength,
   outputSpeedUpdateEvents,
   PressAudioBuffer,
   type ProactiveSpeech,
@@ -44,6 +46,7 @@ import {
   type RealtimeFunctionCall,
   type RealtimeStatus,
   type RealtimeToolFamily,
+  realtimeInstructions,
   realtimeSessionSyncEvents,
   realtimeToolFamily,
   recentConversationEntries,
@@ -53,7 +56,6 @@ import {
   sessionContextText,
   sessionToolAction,
   truncateResponseEvents,
-  typedAskEvents,
   workspaceProjectContextEvents,
   workspaceProjectContextText,
 } from "@sidecar/realtime";
@@ -61,10 +63,13 @@ import type { ObservedWorkspaceProject, Session, SessionIdentity } from "@sideca
 import { workspaceAgentModels } from "@sidecar/session";
 import {
   ACT_RESULT_STATUS,
+  isRecord,
   positiveInteger,
   type UnparsedWireValue,
   type WireRecord,
 } from "@sidecar/wire";
+import { type AgentsDeveloperToolCall, createDeveloperTurnAgent } from "./agents-developer-agent";
+import { AgentsRealtimeTransport } from "./agents-realtime-transport";
 import { MICROPHONE_PROCESSING } from "./microphone-choice";
 import {
   createPressCaptureSource,
@@ -691,6 +696,11 @@ export class RealtimeVoiceSession {
    * `tool_choice` withheld on every turn Luke opens himself.
    */
   #toolTurnArmed = false;
+  #agentsTransport: AgentsRealtimeTransport | undefined;
+  #agentsSession: RealtimeSession | undefined;
+  #agentsTypedTurn = false;
+  #agentsToolsRunning = 0;
+  #agentsToolResponseDone = false;
   /**
    * A monotonic id for the turn now under way, bumped at every boundary a
    * turn crosses — a new one beginning, or the old one declared over. A tool
@@ -890,7 +900,11 @@ export class RealtimeVoiceSession {
 
       await this.#waitForChannel(channel, deadline.signal);
       if (this.#closed) return this.#abandonConnect();
-      this.#send((this.#options.sessionSyncEvents ?? realtimeSessionSyncEvents)());
+      if (this.#withMicrophone && this.#options.sessionSyncEvents === undefined) {
+        await this.#connectAgents(connection);
+      } else {
+        this.#send((this.#options.sessionSyncEvents ?? realtimeSessionSyncEvents)());
+      }
       this.#setStatus(REALTIME_STATUS.READY);
       // A pace changed during the handshake could not be sent then, and the
       // credential this call answered may have been minted before the change.
@@ -926,6 +940,69 @@ export class RealtimeVoiceSession {
     } finally {
       if (deadlineTimer !== undefined) clearTimeout(deadlineTimer);
     }
+  }
+
+  async #connectAgents(connection: RealtimeConnection): Promise<void> {
+    const transport = new AgentsRealtimeTransport({
+      send: (event) => this.#send([event]),
+      interrupt: () => {
+        if (this.#status === REALTIME_STATUS.RESPONDING) this.#interruptReply();
+      },
+      mute: (muted) => {
+        if (this.#microphone) this.#microphone.enabled = !muted;
+      },
+      muted: () => (this.#microphone ? !this.#microphone.enabled : true),
+    });
+    const agent = createDeveloperTurnAgent(realtimeInstructions(), (call) =>
+      this.#agentsToolCallOutput(call),
+    );
+    const session = new RealtimeSession(agent, {
+      transport,
+      model: connection.model,
+      tracingDisabled: true,
+    });
+    session.on("error", (error) => {
+      this.#options.onError(
+        error.error instanceof Error ? error.error.message : String(error.error),
+      );
+    });
+    this.#agentsTransport = transport;
+    this.#agentsSession = session;
+    await session.connect({
+      apiKey: connection.value,
+      model: connection.model,
+      url: connection.callsUrl,
+    });
+  }
+
+  async #agentsToolCallOutput(call: AgentsDeveloperToolCall): Promise<WireRecord> {
+    this.#agentsToolsRunning += 1;
+    try {
+      const armed =
+        this.#agentsTypedTurn &&
+        this.#toolTurnArmed &&
+        (call.responseId === this.#activeResponseId ||
+          (this.#activeResponseId === undefined &&
+            call.responseId === `developer_turn_${this.#turnEpoch}`));
+      return await this.#toolCallOutput(call, armed);
+    } finally {
+      this.#agentsToolsRunning = Math.max(0, this.#agentsToolsRunning - 1);
+      this.#continueAfterAgentsTools();
+    }
+  }
+
+  #continueAfterAgentsTools(): void {
+    if (
+      !this.#agentsToolResponseDone ||
+      this.#agentsToolsRunning > 0 ||
+      !this.#agentsTypedTurn ||
+      !this.isConnected
+    ) {
+      return;
+    }
+    this.#agentsToolResponseDone = false;
+    this.#agentsTypedTurn = false;
+    this.#startResponse(functionCallFollowUpEvents(), { keepCaption: true });
   }
 
   /**
@@ -1495,10 +1572,14 @@ export class RealtimeVoiceSession {
     // needs no capture device, so one this call put away stays put away.
     if (!this.isConnected || !this.#withMicrophone) return false;
     if (this.#status === REALTIME_STATUS.LISTENING) return false;
-    const events = typedAskEvents(text);
-    if (events.length === 0) return false;
+    const ask = text.trim().slice(0, maximumTypedAskLength);
+    if (!ask || !this.#agentsSession) return false;
     if (this.#status === REALTIME_STATUS.RESPONDING) this.#interruptReply();
-    this.#startResponse(events, { toolsArmed: true });
+    this.#agentsTypedTurn = true;
+    this.#agentsToolResponseDone = false;
+    this.#agentsToolsRunning = 0;
+    this.#startResponse([], { toolsArmed: true });
+    this.#agentsSession.sendMessage(ask);
     return true;
   }
 
@@ -1656,6 +1737,12 @@ export class RealtimeVoiceSession {
    * to turn it off.
    */
   #teardown(): void {
+    this.#agentsSession?.close();
+    this.#agentsSession = undefined;
+    this.#agentsTransport = undefined;
+    this.#agentsTypedTurn = false;
+    this.#agentsToolsRunning = 0;
+    this.#agentsToolResponseDone = false;
     const channel = this.#channel;
     if (channel) {
       // Detach before closing. `close()` fires `onclose` asynchronously, and
@@ -2325,6 +2412,14 @@ export class RealtimeVoiceSession {
     // record as readily as the string, so nothing is parsed twice.
     const record = decodeRealtimePayload(data);
     if (record) this.#options.onWireEvent?.(TRACE_DIRECTION.SERVER, record);
+    if (
+      record &&
+      this.#agentsTypedTurn &&
+      record.type !== REALTIME_SERVER_EVENT.RESPONSE_DONE &&
+      record.type !== REALTIME_SERVER_EVENT.RESPONSE_OUTPUT_ITEM_DONE
+    ) {
+      this.#agentsTransport?.receive(record);
+    }
     const event = parseRealtimeServerEvent(record);
     if (!event) return;
 
@@ -2425,6 +2520,33 @@ export class RealtimeVoiceSession {
         this.#finishResponse();
         return;
       case REALTIME_SERVER_EVENT.RESPONSE_DONE: {
+        const fresh = event.responseId === this.#activeResponseId;
+        if (this.#agentsTypedTurn && fresh && record) {
+          const agentsResponseId = event.responseId ?? `developer_turn_${this.#turnEpoch}`;
+          if (event.responseId === undefined) {
+            this.#agentsTransport?.receive({
+              type: REALTIME_SERVER_EVENT.RESPONSE_CREATED,
+              response: { id: agentsResponseId },
+            });
+          }
+          for (const call of event.calls) {
+            this.#agentsTransport?.receiveFunctionCall({
+              id: call.callId,
+              type: "function_call",
+              name: call.name,
+              callId: call.callId,
+              arguments: call.argumentsJson,
+              responseId: agentsResponseId,
+            });
+          }
+          this.#agentsTransport?.receive({
+            ...record,
+            response: {
+              ...(isRecord(record.response) ? record.response : {}),
+              id: agentsResponseId,
+            },
+          });
+        }
         // Whether this is the reply now under way, or the finished form of one
         // the developer already talked or typed over. The server had completed
         // the old reply before the cancel landed — it generates ahead of the
@@ -2432,7 +2554,6 @@ export class RealtimeVoiceSession {
         // opened a new turn. Nothing of it may act with that turn's arming or
         // end that turn early: its calls are answered refused so the model is
         // not left waiting, and everything else about it is ignored.
-        const fresh = event.responseId === this.#activeResponseId;
         // Whatever this reply turns out to be below, the server has concluded
         // it: from here the conversation can take a new `response.create`.
         if (fresh) this.#responseOutstanding = false;
@@ -2440,6 +2561,14 @@ export class RealtimeVoiceSession {
         // answered and the reply resumes over their outcomes, so the turn stays
         // open rather than ending on a reply that was only half made.
         if (event.calls.length > 0) {
+          if (this.#agentsTypedTurn && fresh) {
+            this.#agentsToolResponseDone = true;
+            this.#followUpPending = true;
+            this.#clearSettleTimer();
+            this.#armSettleTimer();
+            setTimeout(() => this.#continueAfterAgentsTools(), 0);
+            return;
+          }
           void this.#answerToolCalls(event.calls, fresh && this.#toolTurnArmed);
           if (fresh && this.#toolTurnArmed) {
             this.#followUpPending = true;
@@ -2463,6 +2592,7 @@ export class RealtimeVoiceSession {
           if (fresh && this.#currentReplyDrained()) this.#finishResponse();
           return;
         }
+        this.#agentsTypedTurn = false;
         if (!fresh) return;
         // A reply the server says made no sound has nothing to play out — a
         // success is said with silence, so the follow-up after a tool call is

--- a/apps/desktop/src/renderer/realtime-session.ts
+++ b/apps/desktop/src/renderer/realtime-session.ts
@@ -23,7 +23,6 @@ import {
   conversationHistoryText,
   decodeRealtimePayload,
   functionCallFollowUpEvents,
-  functionCallOutputEvents,
   type IntroductionLine,
   inputAudioAppendEvents,
   inputAudioFormatUpdateEvents,
@@ -2076,7 +2075,7 @@ export class RealtimeVoiceSession {
     this.#turnEpoch += 1;
     // No reply is current once the turn is over, and the arming went with the
     // turn: a `done` that outlives the settle backstop reads as a stranger's,
-    // its calls answered refused rather than run as writes out of a turn the
+    // its calls dropped rather than run as writes out of a turn the
     // developer was already told had ended.
     this.#activeResponseId = undefined;
     this.#toolTurnArmed = false;
@@ -2558,8 +2557,8 @@ export class RealtimeVoiceSession {
         // the old reply before the cancel landed — it generates ahead of the
         // room — so its `done` still arrives, after the interrupt has already
         // opened a new turn. Nothing of it may act with that turn's arming or
-        // end that turn early: its calls are answered refused so the model is
-        // not left waiting, and everything else about it is ignored.
+        // end that turn early: its calls are dropped, and everything else
+        // about it is ignored.
         // Whatever this reply turns out to be below, the server has concluded
         // it: from here the conversation can take a new `response.create`.
         if (fresh) this.#responseOutstanding = false;
@@ -2574,26 +2573,6 @@ export class RealtimeVoiceSession {
             this.#armSettleTimer();
             return;
           }
-          void this.#answerToolCalls(event.calls, fresh && this.#toolTurnArmed);
-          if (fresh && this.#toolTurnArmed) {
-            this.#followUpPending = true;
-            // The turn now holds for the follow-up, because the READY an
-            // ending here would offer while the writes run is the edge the
-            // announcer rides — a reply taken there bumps the epoch, and the
-            // follow-up voicing the outcome stands down against it, the
-            // developer's answer abandoned for a notice. The hold is the
-            // write's, so it gets a clock of its own: whatever backstop the
-            // drain or an aside armed was watching for this `done` and may
-            // have seconds left on it, while a write that hangs past a whole
-            // window still meets a backstop — a turn that never ends is
-            // worse than one that ends early.
-            this.#clearSettleTimer();
-            this.#armSettleTimer();
-            return;
-          }
-          // The spoken half's audio already drained — its ending deferred to
-          // this `done`, and a reply owing no follow-up ends here, exactly
-          // as the drain would have ended it.
           if (fresh && this.#currentReplyDrained()) this.#finishResponse();
           return;
         }
@@ -2663,49 +2642,6 @@ export class RealtimeVoiceSession {
         }
         this.#finishResponse();
     }
-  }
-
-  /**
-   * Answers the tool calls one reply made, then asks for the reply that voices
-   * their outcomes. Every call is validated against the roster Luke was shown
-   * before anything is carried, every outcome — including each refusal — is
-   * answered so the model never waits on a call that will not return, and the
-   * carrier's own failure is an outcome rather than an exception: the developer
-   * asked for something, and what became of it has to be said.
-   */
-  async #answerToolCalls(calls: readonly RealtimeFunctionCall[], armed: boolean): Promise<void> {
-    // `armed` is the hard gate, decided by the caller from two facts together:
-    // a write runs only in a turn the developer opened — by speaking, or by
-    // typing — and only out of the reply that turn actually asked for, never
-    // the finished form of one the developer already interrupted. A call
-    // failing either test is refused whatever it names, so a session summary
-    // or a tool output that reads like an instruction can never make Luke act.
-    // The turn's tools are also withheld at the API on every turn Luke opens
-    // himself, so this is belt to that suspenders rather than the only thing
-    // holding.
-    // The turn these calls belong to. If it is no longer the current turn by
-    // the time the writes finish, the developer has moved on and the outcome
-    // must not be spoken over whatever they are now saying or hearing.
-    const epoch = this.#turnEpoch;
-
-    for (const call of calls) {
-      const output = await this.#toolCallOutput(call, armed);
-      this.#send(functionCallOutputEvents(call.callId, output));
-    }
-
-    // An unarmed turn — a proactive readout, a follow-up — carries no outcome
-    // to voice: every call on it was refused, and opening a reply here would be
-    // a turn that was meant to stay silent talking on without its instructions.
-    // The calls are still answered above, so the model is not left waiting.
-    if (!armed) return;
-    // A follow-up now would talk over a live microphone or a newer reply: the
-    // developer took the turn, started another, or the call is gone. The
-    // outcomes were still delivered as items, so the next turn has them.
-    if (!this.isConnected || this.#turnEpoch !== epoch) return;
-    // The follow-up continues the exchange the developer opened, so whatever
-    // the reply said before its tool call stays on the strip and the outcome
-    // stacks under it, rather than replacing words still being read.
-    this.#startResponse(functionCallFollowUpEvents(), { keepCaption: true });
   }
 
   async #toolCallOutput(call: RealtimeFunctionCall, armed: boolean): Promise<WireRecord> {

--- a/packages/realtime/src/arrival.test.ts
+++ b/packages/realtime/src/arrival.test.ts
@@ -17,6 +17,7 @@ function eventTexts(speech: ArrivalSpeech) {
   assert.ok(item && response);
   const responseBody = response.response;
   assert.ok(isRecord(responseBody));
+  assert.deepEqual(responseBody.tools, []);
   assert.equal(responseBody.tool_choice, "none");
   const instructions = responseBody.instructions;
   assert.ok(isWireString(instructions));

--- a/packages/realtime/src/index.ts
+++ b/packages/realtime/src/index.ts
@@ -63,7 +63,6 @@ export {
   clearOutputAudioEvents,
   decodeRealtimePayload,
   functionCallFollowUpEvents,
-  functionCallOutputEvents,
   inputAudioAppendEvents,
   inputAudioFormatUpdateEvents,
   isArrivalSpeech,
@@ -86,7 +85,6 @@ export {
   SESSION_NO_LONGER_OBSERVED_NOTE,
   type SessionAnnouncement,
   truncateResponseEvents,
-  typedAskEvents,
 } from "./realtime-protocol.js";
 export {
   type ActEnvelope,

--- a/packages/realtime/src/index.ts
+++ b/packages/realtime/src/index.ts
@@ -68,6 +68,7 @@ export {
   inputAudioFormatUpdateEvents,
   isArrivalSpeech,
   maximumFeedbackDraftLength,
+  maximumTypedAskLength,
   outputSpeedUpdateEvents,
   type ProactiveSpeech,
   parseRealtimeServerEvent,

--- a/packages/realtime/src/realtime-protocol.ts
+++ b/packages/realtime/src/realtime-protocol.ts
@@ -81,6 +81,7 @@ export const REALTIME_CLIENT_EVENT = {
 
 export const REALTIME_SERVER_EVENT = {
   RESPONSE_CREATED: "response.created",
+  RESPONSE_OUTPUT_ITEM_DONE: "response.output_item.done",
   /** The server confirming a superseded context item is gone. */
   CONVERSATION_ITEM_DELETED: "conversation.item.deleted",
   /** The server confirming it dropped the audio it had queued for us. */

--- a/packages/realtime/src/realtime-protocol.ts
+++ b/packages/realtime/src/realtime-protocol.ts
@@ -344,32 +344,6 @@ export const maximumTypedAskLength = maximumSessionMessageLength;
  */
 export const maximumFeedbackDraftLength = maximumTypedAskLength;
 
-/**
- * Builds the events that carry a typed ask and request the reply to it.
- *
- * The text travels without a label, unlike every other `input_text` this
- * module builds: labels mark what the developer did not say, and a typed ask
- * is the developer's own words as surely as a spoken one. The reply is
- * requested with the session's own `tool_choice`, because typing opens a
- * developer turn exactly as a push-to-talk commit does — the caller arms the
- * turn on the same terms, and the roster gauntlet stands behind it unchanged.
- */
-export function typedAskEvents(text: string): readonly WireRecord[] {
-  const ask = trimmedText(text)?.slice(0, maximumTypedAskLength);
-  if (!ask) return [];
-  return [
-    {
-      type: REALTIME_CLIENT_EVENT.CONVERSATION_ITEM_CREATE,
-      item: {
-        type: "message",
-        role: "user",
-        content: [{ type: "input_text", text: ask }],
-      },
-    },
-    { type: REALTIME_CLIENT_EVENT.RESPONSE_CREATE },
-  ];
-}
-
 const BASE64_ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
 
 /**
@@ -668,6 +642,7 @@ export function arrivalSpeechEvents(speech: ArrivalSpeech): readonly WireRecord[
             ...(talkKeyLabel !== undefined ? { talkKeyLabel } : undefined),
           }),
         ].join("\n"),
+        tools: [],
         tool_choice: "none",
       },
     },
@@ -923,29 +898,6 @@ export function parseRealtimeServerEvent(
 }
 
 /**
- * Builds the events that answer a tool call and ask Luke to say what happened.
- * The outcome travels as the call's own output, so the model's next sentence
- * is grounded in what the provider actually answered rather than in what it
- * hoped.
- */
-export function functionCallOutputEvents(
-  callId: string,
-  output: Readonly<WireRecord>,
-): readonly WireRecord[] {
-  if (!trimmedText(callId)) return [];
-  return [
-    {
-      type: REALTIME_CLIENT_EVENT.CONVERSATION_ITEM_CREATE,
-      item: {
-        type: "function_call_output",
-        call_id: callId,
-        output: JSON.stringify(output),
-      },
-    },
-  ];
-}
-
-/**
  * Builds the event that asks for the reply voicing the tool outcomes. Its tools
  * are withheld: this turn was opened to say what happened, not to act again, so
  * a tool output that reads like an instruction cannot make it call anything —
@@ -957,6 +909,7 @@ export function functionCallFollowUpEvents(): readonly WireRecord[] {
     {
       type: REALTIME_CLIENT_EVENT.RESPONSE_CREATE,
       response: {
+        tools: [],
         tool_choice: "none",
       },
     },

--- a/packages/realtime/src/realtime.test.ts
+++ b/packages/realtime/src/realtime.test.ts
@@ -10,7 +10,6 @@ import {
   contextSupersedeEvents,
   conversationContextEvents,
   functionCallFollowUpEvents,
-  functionCallOutputEvents,
   inputAudioAppendEvents,
   inputAudioFormatUpdateEvents,
   isIssueToolName,
@@ -37,12 +36,10 @@ import {
   sessionContextText,
   sessionToolAction,
   truncateResponseEvents,
-  typedAskEvents,
   workspaceProjectContextEvents,
   workspaceProjectContextText,
 } from "@sidecar/realtime";
 import {
-  maximumSessionMessageLength,
   maximumWorkspaceNameLength,
   normalizeSession,
   type ObservedWorkspaceProject,
@@ -67,7 +64,7 @@ import {
   maximumVoiceContextWorkspaceProjects,
 } from "./realtime-context.js";
 import { REALTIME_TRUNCATION, realtimeSessionConfig } from "./realtime-credentials.js";
-import { maximumTypedAskLength, REALTIME_SESSION_TYPE } from "./realtime-protocol.js";
+import { REALTIME_SESSION_TYPE } from "./realtime-protocol.js";
 import {
   ACTS,
   REALTIME_TOOL,
@@ -432,36 +429,6 @@ test("an unusable pace builds no update rather than one the API refuses", () => 
   for (const speed of [0, -1, Number.NaN, Number.POSITIVE_INFINITY]) {
     assert.deepEqual(outputSpeedUpdateEvents(speed), []);
   }
-});
-
-test("a typed ask travels as the developer's own words and asks for a reply", () => {
-  const events = typedAskEvents("  What needs me right now?  ");
-
-  assert.equal(events.length, 2);
-  assert.equal(events[0]?.type, REALTIME_CLIENT_EVENT.CONVERSATION_ITEM_CREATE);
-  const item = conversationItem(events[0]);
-  assert.equal(text(item?.role), "user");
-  const content = item?.content;
-  const firstContent = Array.isArray(content) && isRecord(content[0]) ? content[0] : undefined;
-  assert.equal(text(firstContent?.type), "input_text");
-  // No label ahead of the words: labels mark what the developer did not say,
-  // and a typed ask is theirs as surely as a spoken one.
-  assert.equal(text(firstContent?.text), "What needs me right now?");
-  // The reply keeps the session's own tool_choice, unlike every turn Luke
-  // opens himself: typing opens a developer turn the way a commit does.
-  assert.deepEqual(events[1], { type: REALTIME_CLIENT_EVENT.RESPONSE_CREATE });
-});
-
-test("an empty ask opens no turn at all", () => {
-  for (const text of ["", "   ", "\n\t "]) {
-    assert.deepEqual(typedAskEvents(text), []);
-  }
-});
-
-test("a typed ask is bounded like a session message", () => {
-  assert.equal(maximumTypedAskLength, maximumSessionMessageLength);
-  const events = typedAskEvents("x".repeat(maximumTypedAskLength + 100));
-  assert.equal(conversationItemText(events[0]).length, maximumTypedAskLength);
 });
 
 function announcementInputText(event: WireRecord | undefined): string {
@@ -1970,18 +1937,6 @@ test("an opening task is held to the project's own word for it", () => {
   for (const refusal of refusals) assert.equal(refusal.status, ACT_RESULT_STATUS.REJECTED);
 });
 
-test("a tool call is answered with the outcome the provider gave", () => {
-  const events = functionCallOutputEvents("call-1", { status: "accepted" });
-
-  assert.equal(events.length, 1);
-  assert.equal(events[0]?.type, REALTIME_CLIENT_EVENT.CONVERSATION_ITEM_CREATE);
-  const item = conversationItem(events[0]);
-  assert.equal(text(item?.type), "function_call_output");
-  assert.equal(text(item?.call_id), "call-1");
-  assert.equal(text(item?.output), '{"status":"accepted"}');
-  assert.deepEqual(functionCallOutputEvents("  ", { status: "accepted" }), []);
-});
-
 test("the reply that voices an outcome cannot itself call a tool", () => {
   const [request] = functionCallFollowUpEvents();
 
@@ -1990,6 +1945,7 @@ test("the reply that voices an outcome cannot itself call a tool", () => {
   // The follow-up is opened to say what happened, not to act again — a tool
   // output that reads like an instruction has nothing to act with. It also
   // inherits the session's standing instructions rather than replacing them.
+  assert.deepEqual(response?.tools, []);
   assert.equal(response?.tool_choice, "none");
   assert.equal(response?.instructions, undefined);
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,9 +29,15 @@ importers:
 
   apps/desktop:
     dependencies:
+      '@openai/agents-realtime':
+        specifier: 0.17.0
+        version: 0.17.0(undici@7.29.0)(zod@4.4.3)
       electron-updater:
         specifier: 6.8.9
         version: 6.8.9
+      zod:
+        specifier: 4.4.3
+        version: 4.4.3
     devDependencies:
       '@sidecar/account':
         specifier: workspace:*
@@ -1852,6 +1858,14 @@ packages:
     resolution: {integrity: sha512-9QOtNffcOF/c1seMCDnjckb3R9WHcG34tky+FHpNKKCW0wc/scYLwMtO+ptyGUfMW0/b/n4qRiALlaFHc9Oj7Q==}
     engines: {node: '>= 10.0.0'}
 
+  '@modelcontextprotocol/client@2.0.0':
+    resolution: {integrity: sha512-8f1OghQ2rjzIOfqgUCP+8GiUWqRs89njoWLNqAe8kWmDePv3s1fZXseej+QXemssEuuOvLLmLO/kqM3IQHtISw==}
+    engines: {node: '>=20'}
+
+  '@modelcontextprotocol/core@2.0.0':
+    resolution: {integrity: sha512-pJCEwGG7Lfr/+PQp9ZTwKXNeO5wzbfKL7H3MYpCorM4oFBoQrdjnBgEoqG+RjhsvS1FKrDbKux+M1HhlnGWqcA==}
+    engines: {node: '>=20'}
+
   '@napi-rs/lzma-linux-x64-gnu@1.5.1':
     resolution: {integrity: sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==}
     engines: {node: ^22.20 || ^24.12 || >=25}
@@ -1921,6 +1935,19 @@ packages:
   '@noble/hashes@2.3.0':
     resolution: {integrity: sha512-oN+QwyX7VSHotibwubG3kpzbwKrfnyR6OOO+3Nk/53ADL7FmgHHz4TgrbaYKvvOw09u6QTx0oiH1cNCIOuN0CQ==}
     engines: {node: '>= 20.19.0'}
+
+  '@openai/agents-core@0.17.0':
+    resolution: {integrity: sha512-lyoF860313ypeKSPRsdmyNK1ypF8/ocShN2EwCcKUpF4VvRWa5AUVKL6VXO/keQMwNPZw5SACAf1siU9uMvUNg==}
+    peerDependencies:
+      zod: ^4.0.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
+
+  '@openai/agents-realtime@0.17.0':
+    resolution: {integrity: sha512-spHgDIaWQIOJjwowjBTo0X9Jn3+CGX9fWgsyRUilsQ8SsnNrAre2km6sr8HwFnRiyQC0XpmTccieyfuXmzMfXg==}
+    peerDependencies:
+      zod: ^4.0.0
 
   '@opentelemetry/semantic-conventions@1.43.0':
     resolution: {integrity: sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==}
@@ -2421,6 +2448,9 @@ packages:
 
   '@types/verror@1.10.11':
     resolution: {integrity: sha512-RlDm9K7+o5stv0Co8i8ZRGxDbrTxhJtgjqjFyVh/tXQyl/rYtTKlnTvZ88oSTeYREWurwx20Js4kTuKCsFkUtg==}
+
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
   '@typescript/typescript-aix-ppc64@7.0.2':
     resolution: {integrity: sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==}
@@ -3151,6 +3181,14 @@ packages:
   eventemitter3@5.0.4:
     resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
 
+  eventsource-parser@3.1.1:
+    resolution: {integrity: sha512-EKN1vKAMcZ8MlYMpaNuxN6R9yakzH6uajHcHVTqWJzvu5pWw9DyhbP35HH8MVBQ+dZjAfDxk+A8NiR9KWaXiyQ==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
+    engines: {node: '>=18.0.0'}
+
   exponential-backoff@3.1.3:
     resolution: {integrity: sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==}
 
@@ -3644,6 +3682,30 @@ packages:
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
+  openai@7.8.0:
+    resolution: {integrity: sha512-/2g9JzdnXNcjX1W/UlSNu+OdSFDAaAVt0n9Onom0kPenH54o59G2WrX/xjTnr26UHNSh6hxcAf58doGYRme2rw==}
+    engines: {node: '>=22.0.0'}
+    peerDependencies:
+      '@aws-sdk/credential-provider-node': '>=3.972.0 <4'
+      '@smithy/hash-node': '>=4.3.0 <5'
+      '@smithy/signature-v4': '>=5.4.0 <6'
+      undici: '>=5 <9'
+      ws: ^8.21.0
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@aws-sdk/credential-provider-node':
+        optional: true
+      '@smithy/hash-node':
+        optional: true
+      '@smithy/signature-v4':
+        optional: true
+      undici:
+        optional: true
+      ws:
+        optional: true
+      zod:
+        optional: true
+
   oxlint@1.79.0:
     resolution: {integrity: sha512-hVJ9hq9m2unPS+Of4eJJgCPdIeCC+3DHEUX3tkmrPJr3OK2hz7PhXwgC+ZP71ZcYu8cCDEtQrqLxWNvxBppBVg==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -3717,6 +3779,10 @@ packages:
   picomatch@4.0.5:
     resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
     engines: {node: '>=12'}
+
+  pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
+    engines: {node: '>=16.20.0'}
 
   plist@3.1.0:
     resolution: {integrity: sha512-uysumyrvkUX0rX/dEVqt8gC3sTBzd4zoWfLeS29nb53imdaXVvLINYXTI2GNqzaMuvacNx4uJQ8+b3zXR0pkgQ==}
@@ -4195,6 +4261,18 @@ packages:
 
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  ws@8.21.3:
+    resolution: {integrity: sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
 
   xmlbuilder@15.1.1:
     resolution: {integrity: sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==}
@@ -5021,6 +5099,22 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@modelcontextprotocol/client@2.0.0':
+    dependencies:
+      '@modelcontextprotocol/core': 2.0.0
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.1.1
+      jose: 6.2.9
+      pkce-challenge: 5.0.1
+      zod: 4.4.3
+    optional: true
+
+  '@modelcontextprotocol/core@2.0.0':
+    dependencies:
+      zod: 4.4.3
+    optional: true
+
   '@napi-rs/lzma-linux-x64-gnu@1.5.1':
     optional: true
 
@@ -5054,6 +5148,38 @@ snapshots:
   '@noble/ciphers@2.3.0': {}
 
   '@noble/hashes@2.3.0': {}
+
+  '@openai/agents-core@0.17.0(undici@7.29.0)(ws@8.21.3)(zod@4.4.3)':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      debug: 4.4.3
+      openai: 7.8.0(undici@7.29.0)(ws@8.21.3)(zod@4.4.3)
+    optionalDependencies:
+      '@modelcontextprotocol/client': 2.0.0
+      zod: 4.4.3
+    transitivePeerDependencies:
+      - '@aws-sdk/credential-provider-node'
+      - '@smithy/hash-node'
+      - '@smithy/signature-v4'
+      - supports-color
+      - undici
+      - ws
+
+  '@openai/agents-realtime@0.17.0(undici@7.29.0)(zod@4.4.3)':
+    dependencies:
+      '@openai/agents-core': 0.17.0(undici@7.29.0)(ws@8.21.3)(zod@4.4.3)
+      '@types/ws': 8.18.1
+      debug: 4.4.3
+      ws: 8.21.3
+      zod: 4.4.3
+    transitivePeerDependencies:
+      - '@aws-sdk/credential-provider-node'
+      - '@smithy/hash-node'
+      - '@smithy/signature-v4'
+      - bufferutil
+      - supports-color
+      - undici
+      - utf-8-validate
 
   '@opentelemetry/semantic-conventions@1.43.0': {}
 
@@ -5414,6 +5540,10 @@ snapshots:
 
   '@types/verror@1.10.11':
     optional: true
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 26.2.0
 
   '@typescript/typescript-aix-ppc64@7.0.2':
     optional: true
@@ -6147,6 +6277,14 @@ snapshots:
 
   eventemitter3@5.0.4: {}
 
+  eventsource-parser@3.1.1:
+    optional: true
+
+  eventsource@3.0.7:
+    dependencies:
+      eventsource-parser: 3.1.1
+    optional: true
+
   exponential-backoff@3.1.3: {}
 
   extsprintf@1.4.1:
@@ -6609,6 +6747,12 @@ snapshots:
     dependencies:
       wrappy: 1.0.2
 
+  openai@7.8.0(undici@7.29.0)(ws@8.21.3)(zod@4.4.3):
+    optionalDependencies:
+      undici: 7.29.0
+      ws: 8.21.3
+      zod: 4.4.3
+
   oxlint@1.79.0:
     optionalDependencies:
       '@oxlint/binding-android-arm-eabi': 1.79.0
@@ -6681,6 +6825,9 @@ snapshots:
   picocolors@1.1.1: {}
 
   picomatch@4.0.5: {}
+
+  pkce-challenge@5.0.1:
+    optional: true
 
   plist@3.1.0:
     dependencies:
@@ -7191,6 +7338,8 @@ snapshots:
       strip-ansi: 6.0.1
 
   wrappy@1.0.2: {}
+
+  ws@8.21.3: {}
 
   xmlbuilder@15.1.1: {}
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- adopt `@openai/agents-realtime` 0.17.0 for typed and push-to-talk developer turns over Luke's existing renderer-owned WebRTC connection
- derive SDK tools from the existing `ACTS` table and preserve renderer validation, main-process authorization, and the armed developer-turn gate
- retain Luke-authored speak-only, arrival, introduction, interruption, context, and devtrace events where they encode product trust constraints
- remove `typedAskEvents`, `functionCallOutputEvents`, and the homemade developer tool-output loop

## Evidence

- Platform-independent checks: `./scripts/check.sh` passed
- Structural developer-turn tests: 7 passed
- Speak-only/introduction/history gate tests: 6 passed
- macOS Electron verification (`./scripts/verify.sh`): portable checks passed; stopped at `error: this command requires macOS` on the Linux cloud agent

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/33469501779/artifacts/9786084653) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/33469501779)

- Commit: `98cd017093f7068f3bacb1c5c0c43e3d02fb6a63`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

### Physical-device evidence

- Screenshot or screen recording: `not attached`
- Physical-notch check: `not performed` (Linux cloud agent)
- Device/display configuration: `not available`

## Notes

- Vercel AI SDK was not added: v5 has no Realtime runtime, and current Realtime support is WebSocket-only.
- `realtime-protocol.ts` remains for speak-only/arrival/introduction payloads, PTT audio buffering, interruption/truncation, partial context updates, and the observe-only devtrace tap.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ea5272bd-5a0f-4c26-8555-ec9298300257?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ea5272bd-5a0f-4c26-8555-ec9298300257&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)