### PR TITLE
fix(desktop): mirror conversation history across every display's panel

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -302,8 +302,10 @@ Trust constraints:
   posture Luke keeps. The one explicit blocked subtree is History: its root
   carries the recording library's fixed blocking class, so the conversation's
   words do not leave the machine in a recording. That view retains every
-  bounded line from the current renderer lifetime, including session acts, until the developer clears
-  it or quits, while only the 20 most recent lines enter model context. There
+  bounded line from the current app launch, including session acts, until the
+  developer clears it or quits — the same thread on every display's panel,
+  relayed between the windows through the main process and living nowhere but
+  in memory — while only the 20 most recent lines enter model context. There
   is no general masking module to consult and nothing that makes any other new
   component silent by construction, so what a recording may see is decided by
   what the panel draws or explicitly blocks — which makes drawing something

--- a/apps/desktop/src/main/desktop-app.ts
+++ b/apps/desktop/src/main/desktop-app.ts
@@ -457,6 +457,13 @@ let meetingQuietActive = false;
  * one exchange at a time.
  */
 let conversationHistory: readonly ConversationEntry[] = [];
+/**
+ * How many Clears the thread has survived, which is what keeps the relay's
+ * races honest: a report may only extend the generation it was built
+ * against, so a thread still in flight when a Clear lands is dropped rather
+ * than standing the retired lines back up.
+ */
+let conversationHistoryGeneration = 0;
 // Notices come from status edges the registry observed, never from anything a
 // model decided, so they work — and matter most — with no evaluator configured.
 const sessionNoticeTracker = new SessionNoticeTracker();
@@ -1407,6 +1414,7 @@ function registerIpc(): void {
         calendars: accountCapabilitiesActive() ? observedCalendars : [],
         meetingQuiet: accountCapabilitiesActive() && meetingQuietActive,
         conversationHistory,
+        conversationHistoryGeneration,
         sessionReplay: await sessionReplayBootstrap(),
         settings: await settingsStore.snapshot(),
       };
@@ -1419,15 +1427,27 @@ function registerIpc(): void {
   registerBridge(
     BRIDGE,
     {
-      reportConversationHistory(context, entries) {
+      reportConversationHistory(context, entries, generation) {
+        // A report built against a thread a Clear has since retired would
+        // stand the retired lines back up; it is dropped, and the cleared
+        // broadcast already on its way to the reporter says why.
+        if (generation !== conversationHistoryGeneration) return;
         conversationHistory = entries;
-        const payload: ConversationHistoryPayload = { entries, cleared: false };
+        const payload: ConversationHistoryPayload = { entries, cleared: false, generation };
         panels.broadcast(channels.onConversationHistoryChanged, payload, context.sender);
       },
-      reportConversationHistoryCleared(context) {
+      reportConversationHistoryCleared() {
+        conversationHistoryGeneration += 1;
         conversationHistory = [];
-        const payload: ConversationHistoryPayload = { entries: [], cleared: true };
-        panels.broadcast(channels.onConversationHistoryChanged, payload, context.sender);
+        const payload: ConversationHistoryPayload = {
+          entries: [],
+          cleared: true,
+          generation: conversationHistoryGeneration,
+        };
+        // Unlike an ordinary report, the Clear echoes to its own sender too:
+        // the new generation is the sender's licence to report again, and the
+        // echo is the one ordered channel that can carry it.
+        panels.broadcast(channels.onConversationHistoryChanged, payload);
       },
     },
     { ipcMain, trustedSender },

--- a/apps/desktop/src/main/desktop-app.ts
+++ b/apps/desktop/src/main/desktop-app.ts
@@ -50,7 +50,7 @@ import {
   type WorkspaceHostRegistration,
   workspaceHostRegistrations,
 } from "@sidecar/providers";
-import type { SessionAnnouncement } from "@sidecar/realtime";
+import type { ConversationEntry, SessionAnnouncement } from "@sidecar/realtime";
 import {
   CONDUCTOR_LOCAL_WORKSPACE_PROVIDER_ID,
   CreatedWorkspaceOpenTracker,
@@ -114,6 +114,7 @@ import {
   ACCOUNT_STATUS,
   type AccountSnapshot,
   type AppBootstrap,
+  type ConversationHistoryPayload,
   type MicrophoneRoute,
   type MicrophoneStatus,
   type ObservedAccountCalendars,
@@ -158,7 +159,7 @@ import { MediaDuckController } from "./native/media-duck";
 import { MicrophoneRouteWatcher } from "./native/microphone-route";
 import { OutputVolumeWatcher } from "./native/output-volume";
 import { ProviderKeyVaultSync, type VaultSyncAccount } from "./provider-key-vault-sync";
-import { type BridgeContext, registerBridgeEntry } from "./register-bridge";
+import { type BridgeContext, registerBridge, registerBridgeEntry } from "./register-bridge";
 import { runModeFor } from "./run-mode";
 import { createSettingsHandler } from "./settings-handler";
 import { SettingsStore } from "./settings-store";
@@ -446,6 +447,16 @@ const heldEvaluatorSpeech = new SessionNoticeHold<SessionAnnouncement>();
  * so.
  */
 let meetingQuietActive = false;
+/**
+ * The launch's conversation history, one thread shared by every panel window.
+ * Held in memory alone like the renderer copies it mirrors: written to no
+ * disk, dying with the app, never read by anything here — the main process
+ * only relays it between windows and seeds a panel that opens late. Each
+ * window reports the whole thread after a line it appended, and the last
+ * report wins, which is the conversation's own shape: one developer holds
+ * one exchange at a time.
+ */
+let conversationHistory: readonly ConversationEntry[] = [];
 // Notices come from status edges the registry observed, never from anything a
 // model decided, so they work — and matter most — with no evaluator configured.
 const sessionNoticeTracker = new SessionNoticeTracker();
@@ -1395,10 +1406,31 @@ function registerIpc(): void {
         // shown, or held quiet, before the account gate opens.
         calendars: accountCapabilitiesActive() ? observedCalendars : [],
         meetingQuiet: accountCapabilitiesActive() && meetingQuietActive,
+        conversationHistory,
         sessionReplay: await sessionReplayBootstrap(),
         settings: await settingsStore.snapshot(),
       };
     },
+  );
+  // The conversation history's relay between windows. The main process holds
+  // the thread and passes it along; it never reads a line, and the sender is
+  // excluded because it already drew what it reported — an echo could regress
+  // a window that appended again while its report was in flight.
+  registerBridge(
+    BRIDGE,
+    {
+      reportConversationHistory(context, entries) {
+        conversationHistory = entries;
+        const payload: ConversationHistoryPayload = { entries, cleared: false };
+        panels.broadcast(channels.onConversationHistoryChanged, payload, context.sender);
+      },
+      reportConversationHistoryCleared(context) {
+        conversationHistory = [];
+        const payload: ConversationHistoryPayload = { entries: [], cleared: true };
+        panels.broadcast(channels.onConversationHistoryChanged, payload, context.sender);
+      },
+    },
+    { ipcMain, trustedSender },
   );
   registerHandler(BRIDGE.completeArrivalBeat, () => {
     // A report that raced a settle already on file overwrites nothing.

--- a/apps/desktop/src/main/window/panel-manager.ts
+++ b/apps/desktop/src/main/window/panel-manager.ts
@@ -196,7 +196,9 @@ export class PanelManager {
    * one microphone, one reply, one face speaking — so the talk key and the
    * attention readouts go to a single renderer rather than opening one
    * conversation per display: the main display's window when Luke stands there,
-   * else the first window standing anywhere.
+   * else the first window standing anywhere. The thread the exchange leaves
+   * behind is not the host's alone: each appended line comes back through the
+   * conversation history relay, so every display's History reads the same.
    */
   voiceHost(): BrowserWindow | undefined {
     const primary = this.#windows.get(screen.getPrimaryDisplay().id);

--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -2508,7 +2508,7 @@ export function App(): React.JSX.Element {
       // The shared thread's seed guards itself: the conversation hook already
       // holds the live pushes, and a thread this window has touched is always
       // the newer word than the snapshot.
-      seedConversationHistory(value.conversationHistory);
+      seedConversationHistory(value.conversationHistory, value.conversationHistoryGeneration);
       acceptSessionReplayBootstrap(value.sessionReplay);
       acceptSettingsBootstrap(value.settings);
       // The stored filter chips and search words come back with the panel:

--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -2053,7 +2053,7 @@ export function App(): React.JSX.Element {
     conversationHistory,
     clearConversationHistory,
     liveConversationEntries,
-    applySharedConversationHistory,
+    seedConversationHistory,
     voiceTurn,
     lukeCaptions,
     mentionedSessions,
@@ -2422,12 +2422,6 @@ export function App(): React.JSX.Element {
     (onChange) => window.sidecar.onMeetingQuietChanged(onChange),
     setMeetingQuiet,
   );
-  // The other displays' half of the one conversation: an exchange lands on a
-  // single window, and every other panel's History draws the same thread.
-  const acceptConversationHistoryBootstrap = useBootstrapRacedChannel(
-    (onChange) => window.sidecar.onConversationHistoryChanged(onChange),
-    applySharedConversationHistory,
-  );
 
   /**
    * The two writes a row can ask for, handed to the main process by session
@@ -2511,7 +2505,10 @@ export function App(): React.JSX.Element {
       acceptIssuesBootstrap(value.issues);
       acceptCalendarsBootstrap(value.calendars);
       acceptMeetingQuietBootstrap(value.meetingQuiet);
-      acceptConversationHistoryBootstrap({ entries: value.conversationHistory, cleared: false });
+      // The shared thread's seed guards itself: the conversation hook already
+      // holds the live pushes, and a thread this window has touched is always
+      // the newer word than the snapshot.
+      seedConversationHistory(value.conversationHistory);
       acceptSessionReplayBootstrap(value.sessionReplay);
       acceptSettingsBootstrap(value.settings);
       // The stored filter chips and search words come back with the panel:
@@ -2603,7 +2600,6 @@ export function App(): React.JSX.Element {
   }, [
     acceptAccountBootstrap,
     acceptCalendarsBootstrap,
-    acceptConversationHistoryBootstrap,
     acceptIssuesBootstrap,
     acceptMeetingQuietBootstrap,
     acceptOutputAudioBootstrap,
@@ -2618,6 +2614,7 @@ export function App(): React.JSX.Element {
     beginFeedback,
     cancelHover,
     changeTab,
+    seedConversationHistory,
     setMicrophoneStatus,
     setSettingsView,
     startMicrophone,

--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -2053,6 +2053,7 @@ export function App(): React.JSX.Element {
     conversationHistory,
     clearConversationHistory,
     liveConversationEntries,
+    applySharedConversationHistory,
     voiceTurn,
     lukeCaptions,
     mentionedSessions,
@@ -2421,6 +2422,12 @@ export function App(): React.JSX.Element {
     (onChange) => window.sidecar.onMeetingQuietChanged(onChange),
     setMeetingQuiet,
   );
+  // The other displays' half of the one conversation: an exchange lands on a
+  // single window, and every other panel's History draws the same thread.
+  const acceptConversationHistoryBootstrap = useBootstrapRacedChannel(
+    (onChange) => window.sidecar.onConversationHistoryChanged(onChange),
+    applySharedConversationHistory,
+  );
 
   /**
    * The two writes a row can ask for, handed to the main process by session
@@ -2504,6 +2511,7 @@ export function App(): React.JSX.Element {
       acceptIssuesBootstrap(value.issues);
       acceptCalendarsBootstrap(value.calendars);
       acceptMeetingQuietBootstrap(value.meetingQuiet);
+      acceptConversationHistoryBootstrap({ entries: value.conversationHistory, cleared: false });
       acceptSessionReplayBootstrap(value.sessionReplay);
       acceptSettingsBootstrap(value.settings);
       // The stored filter chips and search words come back with the panel:
@@ -2595,6 +2603,7 @@ export function App(): React.JSX.Element {
   }, [
     acceptAccountBootstrap,
     acceptCalendarsBootstrap,
+    acceptConversationHistoryBootstrap,
     acceptIssuesBootstrap,
     acceptMeetingQuietBootstrap,
     acceptOutputAudioBootstrap,

--- a/apps/desktop/src/renderer/use-voice-conversation.ts
+++ b/apps/desktop/src/renderer/use-voice-conversation.ts
@@ -531,8 +531,14 @@ export interface VoiceConversation {
    * exactly as the words it previews do.
    */
   liveConversationEntries: readonly ConversationEntry[];
-  /** Another window's report of the shared thread, applied as this window's own. */
-  applySharedConversationHistory: (payload: ConversationHistoryPayload) => void;
+  /**
+   * Bootstrap's snapshot of the shared thread, for a panel that opens late.
+   * Applied only while this window's own thread is untouched: the snapshot is
+   * older than anything that raced past it — another window's report arrives
+   * on the live channel, and this window's own lines never come back at all —
+   * so a touched thread is always the newer word.
+   */
+  seedConversationHistory: (entries: readonly ConversationEntry[]) => void;
   voiceTurn: WaveformVoice | undefined;
   /**
    * The words being spoken, one entry per response: a turn that speaks twice
@@ -787,6 +793,25 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
       announced: payload.entries.at(-1)?.kind === CONVERSATION_ENTRY_KIND.ANNOUNCEMENT,
     });
   }, []);
+
+  // Every other display's half of the one conversation, mirrored by the main
+  // process. A window's own reports are never echoed back to it, which is why
+  // the bootstrap seed below must yield to a touched thread rather than to a
+  // push having arrived.
+  useEffect(
+    () => window.sidecar.onConversationHistoryChanged(applySharedConversationHistory),
+    [applySharedConversationHistory],
+  );
+
+  const seedConversationHistory = useCallback(
+    (entries: readonly ConversationEntry[]) => {
+      // A snapshot the main process built before this window's first report —
+      // or before a Clear pressed here — must not stand old lines back up.
+      if (conversationRef.current.length > 0 || conversationGenerationRef.current > 0) return;
+      applySharedConversationHistory({ entries, cleared: false });
+    },
+    [applySharedConversationHistory],
+  );
 
   /**
    * Records a spoken ask where its turn happened rather than where its
@@ -1738,7 +1763,7 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
     conversationHistory,
     clearConversationHistory,
     liveConversationEntries: live,
-    applySharedConversationHistory,
+    seedConversationHistory,
     voiceTurn,
     lukeCaptions,
     mentionedSessions: mentioned,

--- a/apps/desktop/src/renderer/use-voice-conversation.ts
+++ b/apps/desktop/src/renderer/use-voice-conversation.ts
@@ -6,6 +6,7 @@ import { mentionedIssues, type TrackedIssue } from "@sidecar/issues";
 import {
   ARRIVAL_SPEECH_KIND,
   type ArrivalSpeech,
+  adoptConversationThread,
   appendConversationThreadEntry,
   CONVERSATION_ENTRY_KIND,
   type ConversationEntry,
@@ -38,7 +39,11 @@ import { TALK_KEY_RELEASE, talkKeyRelease, voiceHotkeyLabel } from "@sidecar/set
 import { ACT_RESULT_STATUS } from "@sidecar/wire";
 import { type RefObject, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { MicrophoneStatus, VoiceHotkeyState } from "#shared/wire/audio";
-import type { SessionOpenResult, WorkspaceProviderId } from "#shared/wire/session";
+import type {
+  ConversationHistoryPayload,
+  SessionOpenResult,
+  WorkspaceProviderId,
+} from "#shared/wire/session";
 import { askRefusal } from "./ask-luke";
 import { voiceQuotaSpentNote } from "./microphone-access";
 import { openPreferredMicrophone } from "./microphone-choice";
@@ -510,8 +515,10 @@ export interface VoiceConversation {
   stopMicrophone: () => Promise<void>;
   askLuke: (text: string) => Promise<string | undefined>;
   /**
-   * Every bounded line from this app launch. It lives only in this renderer;
-   * the model receives a recent slice and the whole view disappears on exit.
+   * Every bounded line from this app launch — the same thread on every
+   * display's panel, relayed through the main process and living nowhere but
+   * in memory; the model receives a recent slice and the whole view
+   * disappears on exit.
    */
   conversationHistory: readonly ConversationEntry[];
   /** Clears the visible history and the context handed to the next call. */
@@ -524,6 +531,8 @@ export interface VoiceConversation {
    * exactly as the words it previews do.
    */
   liveConversationEntries: readonly ConversationEntry[];
+  /** Another window's report of the shared thread, applied as this window's own. */
+  applySharedConversationHistory: (payload: ConversationHistoryPayload) => void;
   voiceTurn: WaveformVoice | undefined;
   /**
    * The words being spoken, one entry per response: a turn that speaks twice
@@ -717,6 +726,10 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
       }
       conversationRef.current = appendConversationThreadEntry(conversationRef.current, entry);
       setConversationHistory(conversationRef.current);
+      // The whole thread goes to the main process, which mirrors it to every
+      // other display's panel: an exchange lands on one window, and the
+      // others' History tabs must read the same.
+      window.sidecar.reportConversationHistory(conversationRef.current);
       voiceSession.current?.updateConversation(recentConversationEntries(conversationRef.current), {
         announced: entry.kind === CONVERSATION_ENTRY_KIND.ANNOUNCEMENT,
       });
@@ -733,11 +746,46 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
     // The previews go with the marks: a transcription still arriving belongs
     // to a turn the press just retired, and could never be recorded anyway.
     setSpokenAskPreviews(NO_SPOKEN_ASK_PREVIEWS);
+    window.sidecar.reportConversationHistoryCleared();
     talkLatched.current = false;
     talkPressedAt.current = undefined;
     voiceSession.current?.clearConversation();
     activeReplyGenerationRef.current = undefined;
     activeAnnouncementGenerationRef.current = undefined;
+  }, []);
+
+  /**
+   * Takes another window's report of the shared thread as this window's own.
+   * An exchange lands on one window — voice on the primary display's panel, a
+   * typed ask on the panel it was typed into — so every other display hears
+   * about it here, through the main process, and draws the same History. A
+   * cleared report is a Clear pressed elsewhere: it retires this window's
+   * in-flight turns the way its own press would, but leaves the talk key's
+   * latch alone, because a key held here is not another display's to let go.
+   */
+  const applySharedConversationHistory = useCallback((payload: ConversationHistoryPayload) => {
+    if (payload.cleared) {
+      conversationGenerationRef.current += 1;
+      conversationRef.current = [];
+      spokenTurnMarksRef.current.clear();
+      pendingSpokenTurnMarksRef.current = [];
+      setConversationHistory([]);
+      // The previews go with the marks here too: the turns they belong to
+      // were just retired, wherever the Clear was pressed.
+      setSpokenAskPreviews(NO_SPOKEN_ASK_PREVIEWS);
+      voiceSession.current?.clearConversation();
+      activeReplyGenerationRef.current = undefined;
+      activeAnnouncementGenerationRef.current = undefined;
+      return;
+    }
+    conversationRef.current = adoptConversationThread(conversationRef.current, payload.entries);
+    setConversationHistory(conversationRef.current);
+    // An announcement tail re-seeds an open call's history item exactly as a
+    // local announcement line would: the line enters that call's own
+    // conversation items nowhere else.
+    voiceSession.current?.updateConversation(recentConversationEntries(conversationRef.current), {
+      announced: payload.entries.at(-1)?.kind === CONVERSATION_ENTRY_KIND.ANNOUNCEMENT,
+    });
   }, []);
 
   /**
@@ -769,10 +817,12 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
       );
       // A transcription that came back empty ended its turn — the preview
       // and the mark are already spent — but placed no line, and a thread
-      // that did not change owes the open call no update.
+      // that did not change owes the open call no update and the other
+      // displays no report.
       if (placed === conversationRef.current) return;
       conversationRef.current = placed;
       setConversationHistory(conversationRef.current);
+      window.sidecar.reportConversationHistory(conversationRef.current);
       voiceSession.current?.updateConversation(recentConversationEntries(conversationRef.current));
     },
     [dropSpokenAskPreview],
@@ -1688,6 +1738,7 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
     conversationHistory,
     clearConversationHistory,
     liveConversationEntries: live,
+    applySharedConversationHistory,
     voiceTurn,
     lukeCaptions,
     mentionedSessions: mentioned,

--- a/apps/desktop/src/renderer/use-voice-conversation.ts
+++ b/apps/desktop/src/renderer/use-voice-conversation.ts
@@ -532,13 +532,13 @@ export interface VoiceConversation {
    */
   liveConversationEntries: readonly ConversationEntry[];
   /**
-   * Bootstrap's snapshot of the shared thread, for a panel that opens late.
-   * Applied only while this window's own thread is untouched: the snapshot is
-   * older than anything that raced past it — another window's report arrives
-   * on the live channel, and this window's own lines never come back at all —
-   * so a touched thread is always the newer word.
+   * Bootstrap's snapshot of the shared thread and its Clear generation, for a
+   * panel that opens late. The snapshot is older than anything that raced
+   * past it, so a push that already landed retires it whole; lines this
+   * window recorded before the seed slide on top of it instead of being
+   * replaced; and the generation is the window's licence to start reporting.
    */
-  seedConversationHistory: (entries: readonly ConversationEntry[]) => void;
+  seedConversationHistory: (entries: readonly ConversationEntry[], generation: number) => void;
   voiceTurn: WaveformVoice | undefined;
   /**
    * The words being spoken, one entry per response: a turn that speaks twice
@@ -659,6 +659,14 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
   const conversationRef = useRef<readonly ConversationEntry[]>([]);
   /** Rises when Clear retires every event that began before that press. */
   const conversationGenerationRef = useRef(0);
+  /**
+   * The main process's Clear generation as this window last heard it — from
+   * the bootstrap seed, or from any relay push — and this window's licence to
+   * report: undefined means the window does not yet know which thread it
+   * would be extending, so it reports nothing, and the seed folds whatever it
+   * held into the launch thread instead.
+   */
+  const sharedConversationGenerationRef = useRef<number | undefined>(undefined);
   // State is the ref's identical drawn copy, so History retains the whole
   // current launch even though a call receives only the recent context slice.
   const [conversationHistory, setConversationHistory] = useState<readonly ConversationEntry[]>([]);
@@ -714,6 +722,20 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
   }, []);
 
   /**
+   * The whole thread to the main process, which mirrors it to every other
+   * display's panel: an exchange lands on one window, and the others' History
+   * tabs must read the same. Reported beside the generation it extends, and
+   * not at all while the generation is unknown — a window that has not been
+   * seeded holds a fragment, and a fragment reported whole would replace the
+   * launch thread everywhere.
+   */
+  const reportConversationThread = useCallback(() => {
+    const generation = sharedConversationGenerationRef.current;
+    if (generation === undefined) return;
+    window.sidecar.reportConversationHistory(conversationRef.current, generation);
+  }, []);
+
+  /**
    * Appends one bounded line to this launch's history and tells the call now
    * open about only the recent context slice. A session leaving the roster
    * costs a line its identity at model render, never its visible words. An
@@ -732,15 +754,12 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
       }
       conversationRef.current = appendConversationThreadEntry(conversationRef.current, entry);
       setConversationHistory(conversationRef.current);
-      // The whole thread goes to the main process, which mirrors it to every
-      // other display's panel: an exchange lands on one window, and the
-      // others' History tabs must read the same.
-      window.sidecar.reportConversationHistory(conversationRef.current);
+      reportConversationThread();
       voiceSession.current?.updateConversation(recentConversationEntries(conversationRef.current), {
         announced: entry.kind === CONVERSATION_ENTRY_KIND.ANNOUNCEMENT,
       });
     },
-    [],
+    [reportConversationThread],
   );
 
   const clearConversationHistory = useCallback(() => {
@@ -752,7 +771,13 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
     // The previews go with the marks: a transcription still arriving belongs
     // to a turn the press just retired, and could never be recorded anyway.
     setSpokenAskPreviews(NO_SPOKEN_ASK_PREVIEWS);
-    window.sidecar.reportConversationHistoryCleared();
+    // The press is relayed only once this window knows the thread it would
+    // clear; before the seed, the developer has only ever seen this window's
+    // own fragment, and the seed delivers the held press instead. The echo
+    // carries back the new generation, which is what re-licenses reporting.
+    if (sharedConversationGenerationRef.current !== undefined) {
+      window.sidecar.reportConversationHistoryCleared();
+    }
     talkLatched.current = false;
     talkPressedAt.current = undefined;
     voiceSession.current?.clearConversation();
@@ -765,11 +790,13 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
    * An exchange lands on one window — voice on the primary display's panel, a
    * typed ask on the panel it was typed into — so every other display hears
    * about it here, through the main process, and draws the same History. A
-   * cleared report is a Clear pressed elsewhere: it retires this window's
-   * in-flight turns the way its own press would, but leaves the talk key's
-   * latch alone, because a key held here is not another display's to let go.
+   * cleared report — pressed elsewhere, or this window's own press echoed
+   * back with the new generation — retires this window's in-flight turns the
+   * way the local press would, but leaves the talk key's latch alone,
+   * because a key held here is not the relay's to let go.
    */
   const applySharedConversationHistory = useCallback((payload: ConversationHistoryPayload) => {
+    sharedConversationGenerationRef.current = payload.generation;
     if (payload.cleared) {
       conversationGenerationRef.current += 1;
       conversationRef.current = [];
@@ -804,13 +831,33 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
   );
 
   const seedConversationHistory = useCallback(
-    (entries: readonly ConversationEntry[]) => {
-      // A snapshot the main process built before this window's first report —
-      // or before a Clear pressed here — must not stand old lines back up.
-      if (conversationRef.current.length > 0 || conversationGenerationRef.current > 0) return;
-      applySharedConversationHistory({ entries, cleared: false });
+    (entries: readonly ConversationEntry[], generation: number) => {
+      // A push that already landed carried the whole thread and a newer
+      // generation; the older snapshot has nothing left to say.
+      if (sharedConversationGenerationRef.current !== undefined) return;
+      sharedConversationGenerationRef.current = generation;
+      // A Clear pressed before the seed arrived went unreported — the window
+      // held no licence yet — and is still a Clear: delivered now, so the
+      // snapshot cannot stand back up what the press retired. The echo
+      // brings back the new generation like any other Clear's.
+      if (conversationGenerationRef.current > 0) {
+        window.sidecar.reportConversationHistoryCleared();
+        return;
+      }
+      if (conversationRef.current.length === 0) {
+        applySharedConversationHistory({ entries, cleared: false, generation });
+        return;
+      }
+      // Lines this window recorded before its seed arrived are strictly newer
+      // than the snapshot and were never reported, so the launch thread slides
+      // in under them — replacing either half would lose the other — and the
+      // whole is reported at last, under the licence just learned.
+      conversationRef.current = [...entries, ...conversationRef.current];
+      setConversationHistory(conversationRef.current);
+      reportConversationThread();
+      voiceSession.current?.updateConversation(recentConversationEntries(conversationRef.current));
     },
-    [applySharedConversationHistory],
+    [applySharedConversationHistory, reportConversationThread],
   );
 
   /**
@@ -847,10 +894,10 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
       if (placed === conversationRef.current) return;
       conversationRef.current = placed;
       setConversationHistory(conversationRef.current);
-      window.sidecar.reportConversationHistory(conversationRef.current);
+      reportConversationThread();
       voiceSession.current?.updateConversation(recentConversationEntries(conversationRef.current));
     },
-    [dropSpokenAskPreview],
+    [dropSpokenAskPreview, reportConversationThread],
   );
 
   const ensureVoiceSession = useCallback((): RealtimeVoiceSession => {

--- a/apps/desktop/src/shared/bridge.test.ts
+++ b/apps/desktop/src/shared/bridge.test.ts
@@ -22,3 +22,30 @@ test("act bridge entries reject legacy and malformed outcomes", () => {
     assert.equal(guard({ ok: false }), false);
   }
 });
+
+test("a conversation history report carries only bounded history lines", () => {
+  const guard = BRIDGE.reportConversationHistory.args;
+  const ask = { kind: "typed-ask", words: "how is it going?", recordedAt: 1 };
+  const announcement = {
+    kind: "announcement",
+    words: "A chat finished.",
+    identity: { providerId: "claude-code", providerSessionId: "session-a" },
+  };
+  assert.equal(guard([[]]), true);
+  assert.equal(guard([[ask, announcement]]), true);
+  // One argument, and it is the thread itself.
+  assert.equal(guard([]), false);
+  assert.equal(guard([[ask], [announcement]]), false);
+  assert.equal(guard([ask]), false);
+  // A line is only a line: a made-up kind, wordless words, a malformed
+  // identity, or a smuggled extra shape all refuse the whole report.
+  assert.equal(guard([[{ kind: "transcript", words: "x" }]]), false);
+  assert.equal(guard([[{ kind: "reply" }]]), false);
+  assert.equal(guard([[{ kind: "reply", words: 3 }]]), false);
+  assert.equal(guard([[{ ...ask, identity: { providerId: "claude-code" } }]]), false);
+  assert.equal(
+    guard([[{ ...ask, identity: { providerId: "nope", providerSessionId: "s" } }]]),
+    false,
+  );
+  assert.equal(guard([[{ ...ask, recordedAt: Number.POSITIVE_INFINITY }]]), false);
+});

--- a/apps/desktop/src/shared/bridge.test.ts
+++ b/apps/desktop/src/shared/bridge.test.ts
@@ -31,21 +31,25 @@ test("a conversation history report carries only bounded history lines", () => {
     words: "A chat finished.",
     identity: { providerId: "claude-code", providerSessionId: "session-a" },
   };
-  assert.equal(guard([[]]), true);
-  assert.equal(guard([[ask, announcement]]), true);
-  // One argument, and it is the thread itself.
+  assert.equal(guard([[], 0]), true);
+  assert.equal(guard([[ask, announcement], 3]), true);
+  // Two arguments: the thread itself, and the Clear generation it extends.
   assert.equal(guard([]), false);
+  assert.equal(guard([[ask, announcement]]), false);
   assert.equal(guard([[ask], [announcement]]), false);
-  assert.equal(guard([ask]), false);
+  assert.equal(guard([ask, 0]), false);
+  assert.equal(guard([[ask], -1]), false);
+  assert.equal(guard([[ask], 1.5]), false);
+  assert.equal(guard([[ask], "1"]), false);
   // A line is only a line: a made-up kind, wordless words, a malformed
   // identity, or a smuggled extra shape all refuse the whole report.
-  assert.equal(guard([[{ kind: "transcript", words: "x" }]]), false);
-  assert.equal(guard([[{ kind: "reply" }]]), false);
-  assert.equal(guard([[{ kind: "reply", words: 3 }]]), false);
-  assert.equal(guard([[{ ...ask, identity: { providerId: "claude-code" } }]]), false);
+  assert.equal(guard([[{ kind: "transcript", words: "x" }], 0]), false);
+  assert.equal(guard([[{ kind: "reply" }], 0]), false);
+  assert.equal(guard([[{ kind: "reply", words: 3 }], 0]), false);
+  assert.equal(guard([[{ ...ask, identity: { providerId: "claude-code" } }], 0]), false);
   assert.equal(
-    guard([[{ ...ask, identity: { providerId: "nope", providerSessionId: "s" } }]]),
+    guard([[{ ...ask, identity: { providerId: "nope", providerSessionId: "s" } }], 0]),
     false,
   );
-  assert.equal(guard([[{ ...ask, recordedAt: Number.POSITIVE_INFINITY }]]), false);
+  assert.equal(guard([[{ ...ask, recordedAt: Number.POSITIVE_INFINITY }], 0]), false);
 });

--- a/apps/desktop/src/shared/bridge.ts
+++ b/apps/desktop/src/shared/bridge.ts
@@ -639,17 +639,26 @@ export const BRIDGE = {
   }),
   /**
    * One window's copy of the conversation history, reported whole after each
-   * line it appends. The main process holds the launch's thread and mirrors
-   * the report to every other panel window, so the History tab reads the same
-   * on every display; a window's own report is not echoed back to it. The
-   * relay never leaves the machine, and every line in it is one the reporting
-   * window already held on the terms the history's own module states.
+   * line it appends, beside the Clear generation it was built against — the
+   * main process drops a report from any other generation, so a thread still
+   * in flight when a Clear lands cannot stand the retired lines back up. The
+   * main process holds the launch's thread and mirrors the report to every
+   * other panel window, so the History tab reads the same on every display; a
+   * window's own report is not echoed back to it. The relay never leaves the
+   * machine, and every line in it is one the reporting window already held on
+   * the terms the history's own module states.
    */
   reportConversationHistory: entry({
     kind: "send",
     channel: "app:report-conversation-history",
-    args: args<[readonly ConversationEntry[]]>(
-      (v) => v.length === 1 && Array.isArray(v[0]) && v[0].every(isConversationEntry),
+    args: args<[readonly ConversationEntry[], number]>(
+      (v) =>
+        v.length === 2 &&
+        Array.isArray(v[0]) &&
+        v[0].every(isConversationEntry) &&
+        isWireNumber(v[1]) &&
+        Number.isInteger(v[1]) &&
+        v[1] >= 0,
     ),
   }),
   /** The History Clear press, relayed so every display lets the same thread go. */

--- a/apps/desktop/src/shared/bridge.ts
+++ b/apps/desktop/src/shared/bridge.ts
@@ -29,11 +29,13 @@ import {
   type TrackedIssue,
   type TrackerActionResult,
 } from "@sidecar/issues";
-import type {
-  IssueToolAction,
-  RealtimeConnection,
-  RealtimeDiagnostics,
-  SessionAnnouncement,
+import {
+  type ConversationEntry,
+  type IssueToolAction,
+  isConversationEntryKind,
+  type RealtimeConnection,
+  type RealtimeDiagnostics,
+  type SessionAnnouncement,
 } from "@sidecar/realtime";
 import {
   isProviderId,
@@ -83,6 +85,7 @@ import type {
 } from "./wire/audio";
 import {
   type AppBootstrap,
+  type ConversationHistoryPayload,
   type DisplayDiagnostic,
   type SessionOpenResult,
   type SessionReplayBootstrap,
@@ -177,6 +180,18 @@ function isSessionIdentity(value: unknown): value is SessionIdentity {
     isProviderId(wire.providerId) &&
     isWireString(wire.providerSessionId) &&
     wire.providerSessionId.length > 0
+  );
+}
+
+// oxlint-disable-next-line anti-slop/no-unknown-parameters -- This function parses an IPC field into a domain history line.
+function isConversationEntry(value: unknown): value is ConversationEntry {
+  const wire = wireValue(value);
+  if (!isRecord(wire)) return false;
+  if (!isConversationEntryKind(wire.kind) || !isWireString(wire.words)) return false;
+  if (wire.identity !== undefined && !isSessionIdentity(wire.identity)) return false;
+  return (
+    wire.recordedAt === undefined ||
+    (isWireNumber(wire.recordedAt) && Number.isFinite(wire.recordedAt))
   );
 }
 
@@ -623,6 +638,27 @@ export const BRIDGE = {
     result: result<void>(),
   }),
   /**
+   * One window's copy of the conversation history, reported whole after each
+   * line it appends. The main process holds the launch's thread and mirrors
+   * the report to every other panel window, so the History tab reads the same
+   * on every display; a window's own report is not echoed back to it. The
+   * relay never leaves the machine, and every line in it is one the reporting
+   * window already held on the terms the history's own module states.
+   */
+  reportConversationHistory: entry({
+    kind: "send",
+    channel: "app:report-conversation-history",
+    args: args<[readonly ConversationEntry[]]>(
+      (v) => v.length === 1 && Array.isArray(v[0]) && v[0].every(isConversationEntry),
+    ),
+  }),
+  /** The History Clear press, relayed so every display lets the same thread go. */
+  reportConversationHistoryCleared: entry({
+    kind: "send",
+    channel: "app:report-conversation-history-cleared",
+    args: noArgs,
+  }),
+  /**
    * Words the renderer already draws, placed on this machine's clipboard and
    * nowhere else. Routed through the main process because the panel's
    * permission handlers deny the sandboxed renderer every Chromium
@@ -853,6 +889,12 @@ export const BRIDGE = {
     channel: "app:session-announcements",
     args: noArgs,
     result: result<readonly SessionAnnouncement[]>(),
+  }),
+  onConversationHistoryChanged: entry({
+    kind: "subscribe",
+    channel: "app:conversation-history-changed",
+    args: noArgs,
+    result: result<ConversationHistoryPayload>(),
   }),
 } as const;
 

--- a/apps/desktop/src/shared/wire/session.ts
+++ b/apps/desktop/src/shared/wire/session.ts
@@ -2,7 +2,7 @@ import type { AccountSnapshot } from "@sidecar/account/snapshot";
 import type { ObservedAccountCalendars } from "@sidecar/calendar/observation";
 import type { FixtureSnapshot } from "@sidecar/fixtures";
 import type { TrackedIssue } from "@sidecar/issues";
-import type { IssueToolAction } from "@sidecar/realtime";
+import type { ConversationEntry, IssueToolAction } from "@sidecar/realtime";
 import type { ObservedWorkspaceProject, Session, SessionAttentionEntry } from "@sidecar/session";
 import type { Rectangle, ResolvedNotchGeometry, WindowMode } from "@sidecar/surface";
 import type { ACT_RESULT_STATUS, ActResult } from "@sidecar/wire";
@@ -104,6 +104,21 @@ export interface SessionReplayBootstrap {
   accountId?: string;
 }
 
+/**
+ * The conversation history as every panel window shares it. A voice exchange
+ * lands on one window — the primary display hosts the talk key and the
+ * announcements, a typed ask lands on the panel it was typed into — so the
+ * thread is relayed through the main process for every other display's
+ * History to draw the same. `cleared` marks the relay of a Clear pressed on
+ * another display, which retires the receiving window's in-flight turns the
+ * way its own press would; an ordinary report replaces the thread and
+ * retires nothing.
+ */
+export interface ConversationHistoryPayload {
+  entries: readonly ConversationEntry[];
+  cleared: boolean;
+}
+
 export interface AppBootstrap {
   mode: WindowMode;
   /** Capture-only: start drawn as the peek, which normally needs a pointer. */
@@ -185,6 +200,12 @@ export interface AppBootstrap {
   calendars: readonly ObservedAccountCalendars[];
   /** Whether the calendar's quiet is holding announcements right now. */
   meetingQuiet: boolean;
+  /**
+   * The launch's conversation history so far, so a panel that opens late — a
+   * display plugged in mid-conversation — draws the History every other
+   * window already holds.
+   */
+  conversationHistory: readonly ConversationEntry[];
   /** Whether, where, and for whom this run may record its own surface. */
   sessionReplay: SessionReplayBootstrap;
   settings: AppSettings;

--- a/apps/desktop/src/shared/wire/session.ts
+++ b/apps/desktop/src/shared/wire/session.ts
@@ -109,14 +109,18 @@ export interface SessionReplayBootstrap {
  * lands on one window — the primary display hosts the talk key and the
  * announcements, a typed ask lands on the panel it was typed into — so the
  * thread is relayed through the main process for every other display's
- * History to draw the same. `cleared` marks the relay of a Clear pressed on
- * another display, which retires the receiving window's in-flight turns the
- * way its own press would; an ordinary report replaces the thread and
- * retires nothing.
+ * History to draw the same. `cleared` marks the relay of a Clear, which
+ * retires the receiving window's in-flight turns the way its own press
+ * would; an ordinary report replaces the thread and retires nothing.
+ * `generation` is the main process's count of Clears, which is what keeps
+ * the relay's races honest: a report may only extend the generation it was
+ * built against, so a thread still in flight when a Clear lands cannot
+ * stand the retired lines back up.
  */
 export interface ConversationHistoryPayload {
   entries: readonly ConversationEntry[];
   cleared: boolean;
+  generation: number;
 }
 
 export interface AppBootstrap {
@@ -203,9 +207,12 @@ export interface AppBootstrap {
   /**
    * The launch's conversation history so far, so a panel that opens late — a
    * display plugged in mid-conversation — draws the History every other
-   * window already holds.
+   * window already holds. The generation rides along because it is the
+   * window's licence to report: a window reports nothing until it knows
+   * which generation of the thread it would be extending.
    */
   conversationHistory: readonly ConversationEntry[];
+  conversationHistoryGeneration: number;
   /** Whether, where, and for whom this run may record its own surface. */
   sessionReplay: SessionReplayBootstrap;
   settings: AppSettings;

--- a/packages/realtime/src/conversation-history.test.ts
+++ b/packages/realtime/src/conversation-history.test.ts
@@ -8,6 +8,7 @@ import {
   type SessionControl,
 } from "@sidecar/session";
 import {
+  adoptConversationThread,
   appendConversationEntry,
   appendConversationThreadEntry,
   CONVERSATION_ENTRY_KIND,
@@ -15,6 +16,7 @@ import {
   conversationHistoryText,
   insertSpokenAskEntry,
   insertSpokenAskThreadEntry,
+  isConversationEntryKind,
   maximumConversationEntries,
   maximumConversationEntryLength,
   recentConversationEntries,
@@ -356,4 +358,58 @@ test("a line whose session left the roster keeps its words and says the session 
 
 test("an empty history says nothing at all", () => {
   assert.equal(conversationHistoryText([], []), undefined);
+});
+
+test("the kind guard admits every history line kind and nothing else", () => {
+  for (const kind of Object.values(CONVERSATION_ENTRY_KIND)) {
+    assert.equal(isConversationEntryKind(kind), true);
+  }
+  assert.equal(isConversationEntryKind("transcript"), false);
+  assert.equal(isConversationEntryKind(""), false);
+  assert.equal(isConversationEntryKind(3), false);
+  assert.equal(isConversationEntryKind(undefined), false);
+});
+
+test("adopting another window's thread reuses the entry objects already held", () => {
+  const identity = { providerId: "claude-code", providerSessionId: "session-a" };
+  const ask: ConversationEntry = {
+    kind: CONVERSATION_ENTRY_KIND.TYPED_ASK,
+    words: "how is it going?",
+    recordedAt: 1,
+  };
+  const reply: ConversationEntry = {
+    kind: CONVERSATION_ENTRY_KIND.REPLY,
+    words: "Two chats are working.",
+    recordedAt: 2,
+  };
+  // The relay recreates every object on the way over; the adoption must hand
+  // back the local ones, because the spoken-turn marks locate a turn by
+  // entry identity.
+  const adopted = adoptConversationThread(
+    [ask, reply],
+    [
+      { ...ask },
+      { ...reply },
+      { kind: CONVERSATION_ENTRY_KIND.ANNOUNCEMENT, words: "A chat finished.", identity },
+    ],
+  );
+  assert.equal(adopted.length, 3);
+  assert.equal(adopted[0], ask);
+  assert.equal(adopted[1], reply);
+  assert.deepEqual(adopted[2]?.identity, identity);
+
+  // Two same-worded lines are told apart by when they were recorded, and a
+  // local object is adopted at most once even when its line repeats.
+  const twin: ConversationEntry = {
+    kind: CONVERSATION_ENTRY_KIND.REPLY,
+    words: "ok",
+    recordedAt: 5,
+  };
+  const doubled = adoptConversationThread([twin], [{ ...twin }, { ...twin }]);
+  assert.equal(doubled[0], twin);
+  assert.notEqual(doubled[1], twin);
+
+  // A cleared or diverged thread is taken as reported: entries the report no
+  // longer carries do not survive the adoption.
+  assert.deepEqual(adoptConversationThread([ask, reply], []), []);
 });

--- a/packages/realtime/src/conversation-history.ts
+++ b/packages/realtime/src/conversation-history.ts
@@ -8,6 +8,11 @@
  * developer opens next; the whole in-memory thread remains available to the
  * developer in the panel until they clear it or quit.
  *
+ * Every panel window draws the same thread. The window that appends a line
+ * reports the whole thread to its own main process, which holds the launch's
+ * copy for a panel that opens late and mirrors each report to every other
+ * display's panel — the relay never leaves the machine.
+ *
  * Every line already traveled to the voice service once, on the call that
  * said it: the developer's own asks — typed, or spoken and handed back as
  * text by the service that heard them — the words Luke spoke or announced,
@@ -17,6 +22,7 @@
  */
 
 import type { Session, SessionIdentity } from "@sidecar/session";
+import { isWireString, type UnparsedWireValue } from "@sidecar/wire";
 import { SESSION_NO_LONGER_OBSERVED_NOTE } from "./realtime-protocol.js";
 import { actNarration, type CarriedSessionAction } from "./realtime-tools.js";
 
@@ -36,6 +42,14 @@ export const CONVERSATION_ENTRY_KIND = {
 
 export type ConversationEntryKind =
   (typeof CONVERSATION_ENTRY_KIND)[keyof typeof CONVERSATION_ENTRY_KIND];
+
+const CONVERSATION_ENTRY_KIND_LIST = Object.values(CONVERSATION_ENTRY_KIND);
+
+export function isConversationEntryKind(value: UnparsedWireValue): value is ConversationEntryKind {
+  if (!isWireString(value)) return false;
+  // SAFETY: value is a string; list membership is the history vocabulary contract check.
+  return CONVERSATION_ENTRY_KIND_LIST.includes(value as ConversationEntryKind);
+}
 
 /**
  * How many recent lines the model receives, and how long every stored line may
@@ -83,6 +97,36 @@ export function appendConversationThreadEntry(
   const appended: ConversationEntry = { kind: entry.kind, words, recordedAt: Date.now() };
   if (entry.identity) appended.identity = entry.identity;
   return [...entries, appended];
+}
+
+/**
+ * Takes another window's copy of the thread as this window's own, reusing the
+ * local entry objects whose lines it repeats. The spoken-turn marks locate a
+ * turn by entry identity — `indexOf` in {@link insertSpokenAskThreadEntry} —
+ * so a relay that recreated every object would strand a transcript still on
+ * its way back; matching by value keeps those marks standing across it.
+ */
+export function adoptConversationThread(
+  current: readonly ConversationEntry[],
+  incoming: readonly ConversationEntry[],
+): readonly ConversationEntry[] {
+  const held = [...current];
+  return incoming.map((entry) => {
+    const at = held.findIndex((candidate) => sameConversationEntry(candidate, entry));
+    if (at === -1) return entry;
+    const [kept] = held.splice(at, 1);
+    return kept ?? entry;
+  });
+}
+
+function sameConversationEntry(a: ConversationEntry, b: ConversationEntry): boolean {
+  return (
+    a.kind === b.kind &&
+    a.words === b.words &&
+    a.recordedAt === b.recordedAt &&
+    a.identity?.providerId === b.identity?.providerId &&
+    a.identity?.providerSessionId === b.identity?.providerSessionId
+  );
 }
 
 /** The recent slice safe to place back into the model's context window. */

--- a/packages/realtime/src/index.ts
+++ b/packages/realtime/src/index.ts
@@ -5,6 +5,7 @@ export {
   realtimeCredentialIsUsable,
 } from "@sidecar/hosted";
 export {
+  adoptConversationThread,
   appendConversationEntry,
   appendConversationThreadEntry,
   CONVERSATION_ENTRY_KIND,
@@ -13,6 +14,7 @@ export {
   conversationHistoryText,
   insertSpokenAskEntry,
   insertSpokenAskThreadEntry,
+  isConversationEntryKind,
   maximumConversationEntries,
   maximumConversationEntryLength,
   recentConversationEntries,


### PR DESCRIPTION
## Problem

Message history wasn't showing up on a secondary display's panel. The conversation history was React state local to whichever renderer ran the exchange, and voice is deliberately routed to the primary display's window (`PanelManager.voiceHost()`), so a secondary display's History tab stayed empty forever. Worse, a typed ask on a secondary panel accumulated a divergent thread of its own, and Clear on one display did nothing to the others. There was no main-process store, no IPC channel, and no bootstrap field for the thread at all.

## Fix

The thread is lifted one level, following the roster/settings pattern:

- **Report**: the window that appends a line (`rememberConversationEntry`, `rememberSpokenAsk`) reports the whole thread over two new bridge sends; Clear reports itself as its own message so receivers can retire in-flight turns the way a local Clear would.
- **Relay**: the main process holds the launch's thread in memory (written to no disk, dying with the app, never read by anything there) and mirrors each report to every other panel window via `panels.broadcast(..., except: sender)` — never echoing the sender, so a window that appended again while its report was in flight can't be regressed by its own echo.
- **Seed**: `AppBootstrap` now carries `conversationHistory`, so a panel that opens late — a display plugged in mid-conversation — catches up, on the usual pushes-beat-bootstrap rule (`useBootstrapRacedChannel`).
- **Adopt**: a received thread is adopted by value (`adoptConversationThread`), reusing local entry objects, because the spoken-turn marks locate a turn by entry identity and a wholesale replacement would strand a transcript still on its way back.

A received thread also refreshes an open call's context item, so a spoken follow-up on one display knows what was typed on another.

## Trust posture (unchanged)

- The relay never leaves the machine: renderer ↔ main IPC only, behind the same `trustedSender` gate and a full wire guard on every reported line.
- The History subtree keeps the recording library's blocking class on every window, so `PRIVACY.md`'s claim holds as written.
- `AGENTS.md`'s replay-stream paragraph is updated: the view now retains the launch's thread mirrored across displays rather than one renderer's lifetime; "in memory alone, dying with the app" stays exactly true.

## Testing

- `./scripts/check.sh` passes (lint, types, all package + desktop tests, builds). One unrelated flaky failure in `output-volume.test.ts` on the first run; passes in isolation and on rerun.
- New tests: bridge args guard for the history report; `adoptConversationThread` identity reuse and divergence; `isConversationEntryKind`.
- `./scripts/verify.sh` not run — this branch was authored in a Linux cloud workspace; relying on CI's macOS validation. No physical-notch check was performed. The fixture evidence should be unchanged: a fixture run draws one display and no exchange.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/5cac3b6b-fa96-4065-a780-e8a59e4a88a5)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/33524624793/artifacts/9807247939) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/33524624793)

- Commit: `4f84da643b707825dc5338bfbd056b197cc7cb78`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
