### PR TITLE
feat(history): stream the bubbles while their words arrive

### DIFF
--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -2052,6 +2052,7 @@ export function App(): React.JSX.Element {
     askLuke,
     conversationHistory,
     clearConversationHistory,
+    liveConversationEntries,
     voiceTurn,
     lukeCaptions,
     mentionedSessions,
@@ -3198,6 +3199,7 @@ export function App(): React.JSX.Element {
             onOpenSessionApplication={openSessionApplication}
             writes={sessionWrites}
             conversationHistory={conversationHistory}
+            liveConversationEntries={liveConversationEntries}
             onClearConversationHistory={clearConversationHistory}
             ask={askLuke}
             // Reaching for the composer during a spent day is answered before

--- a/apps/desktop/src/renderer/conversation-history-panel.test.ts
+++ b/apps/desktop/src/renderer/conversation-history-panel.test.ts
@@ -106,6 +106,44 @@ test("messages offer a copy control while quiet events offer none", () => {
   assert.match(markup, /icon-button-glyph/);
 });
 
+test("a line still being said draws as the bubble it will settle into", () => {
+  const markup = renderToStaticMarkup(
+    createElement(ConversationHistoryPanel, {
+      entries: [
+        {
+          kind: CONVERSATION_ENTRY_KIND.TYPED_ASK,
+          words: "ship it",
+          recordedAt: Date.parse("2026-01-02T03:04:00.000Z"),
+        },
+      ],
+      live: [{ kind: CONVERSATION_ENTRY_KIND.ANNOUNCEMENT, words: "Checkout is" }],
+      onClear: () => undefined,
+    }),
+  );
+
+  assert.match(markup, /data-streaming="true"/);
+  assert.match(markup, />Checkout is</);
+  // Copying half a sentence serves nobody: the settled ask keeps the one
+  // copy control, and a line not yet recorded wears no timestamp.
+  assert.equal(markup.match(/class="history-copy"/g)?.length, 1);
+  assert.equal(markup.match(/class="history-time"/g)?.length, 1);
+});
+
+test("words still arriving stand the thread up without a settled line", () => {
+  const markup = renderToStaticMarkup(
+    createElement(ConversationHistoryPanel, {
+      entries: [],
+      live: [{ kind: CONVERSATION_ENTRY_KIND.REPLY, words: "Looking now." }],
+      onClear: () => undefined,
+    }),
+  );
+
+  assert.match(markup, />Looking now\.</);
+  assert.doesNotMatch(markup, />No messages yet</);
+  // Clear retires recorded lines, and nothing here is recorded yet.
+  assert.doesNotMatch(markup, /history-header/);
+});
+
 test("the empty history reports only its state", () => {
   const markup = renderToStaticMarkup(
     createElement(ConversationHistoryPanel, {

--- a/apps/desktop/src/renderer/conversation-history-panel.tsx
+++ b/apps/desktop/src/renderer/conversation-history-panel.tsx
@@ -38,7 +38,13 @@ const COPY_CONFIRMATION_MS = 1500;
 
 const ENTRY_TIME = new Intl.DateTimeFormat(undefined, { hour: "numeric", minute: "2-digit" });
 
-function HistoryEntryRow({ entry }: { entry: ConversationEntry }): React.JSX.Element {
+function HistoryEntryRow({
+  entry,
+  streaming,
+}: {
+  entry: ConversationEntry;
+  streaming?: boolean;
+}): React.JSX.Element {
   const presentation = historyEntryPresentation(entry.kind);
   const words = entry.words;
   const [copied, setCopied] = useState(false);
@@ -52,7 +58,11 @@ function HistoryEntryRow({ entry }: { entry: ConversationEntry }): React.JSX.Ele
   const recordedAt = entry.recordedAt === undefined ? undefined : new Date(entry.recordedAt);
 
   return (
-    <li className="history-entry" data-speaker={presentation.speaker}>
+    <li
+      className="history-entry"
+      data-speaker={presentation.speaker}
+      data-streaming={streaming ? "true" : undefined}
+    >
       <small className="visually-hidden">{presentation.label}</small>
       <p>
         {words}
@@ -62,7 +72,9 @@ function HistoryEntryRow({ entry }: { entry: ConversationEntry }): React.JSX.Ele
           </time>
         ) : null}
       </p>
-      {presentation.speaker === HISTORY_ENTRY_SPEAKER.EVENT ? null : (
+      {/* Copying words still arriving would copy half a sentence; the control
+          appears with the settled line the same words become. */}
+      {presentation.speaker === HISTORY_ENTRY_SPEAKER.EVENT || streaming ? null : (
         <button
           type="button"
           className="history-copy"
@@ -94,16 +106,31 @@ function keyedHistoryEntries(entries: readonly ConversationEntry[]) {
   });
 }
 
+/**
+ * How close to the tail a reader still counts as following it. Words arriving
+ * grow the list under the reader a little at a time, so the tail they were
+ * pinned to is at most a delta away; a reader who scrolled up to reread is
+ * further than that, and the stream must not drag them back down.
+ */
+const STREAM_FOLLOW_SLACK_PX = 48;
+
 export function ConversationHistoryPanel({
   entries,
+  live = [],
   onClear,
 }: {
   entries: readonly ConversationEntry[];
+  /**
+   * The lines still being said, drawn under the settled thread as the same
+   * bubbles they will settle into — words growing, no timestamp, no copy.
+   */
+  live?: readonly ConversationEntry[];
   onClear: () => void;
 }): React.JSX.Element {
   const [confirmingClear, setConfirmingClear] = useState(false);
   const list = useRef<HTMLOListElement | null>(null);
   const entryCount = entries.length;
+  const liveLength = live.reduce((total, entry) => total + entry.words.length, 0);
 
   useEffect(() => {
     // Reading the count binds the scroll to an append or clear, not to an
@@ -112,6 +139,16 @@ export function ConversationHistoryPanel({
     const element = list.current;
     if (element) element.scrollTop = element.scrollHeight;
   }, [entryCount]);
+
+  useEffect(() => {
+    // A streaming line only carries the reader along; unlike an append, it
+    // never pulls one back who has scrolled up while Luke talks.
+    if (liveLength === 0) return;
+    const element = list.current;
+    if (!element) return;
+    const fromTail = element.scrollHeight - element.scrollTop - element.clientHeight;
+    if (fromTail <= STREAM_FOLLOW_SLACK_PX) element.scrollTop = element.scrollHeight;
+  }, [liveLength]);
 
   useEffect(() => {
     if (entries.length === 0) setConfirmingClear(false);
@@ -154,7 +191,7 @@ export function ConversationHistoryPanel({
           </span>
         </header>
       ) : null}
-      {entries.length === 0 ? (
+      {entries.length === 0 && live.length === 0 ? (
         <div className="history-empty">
           <strong>No messages yet</strong>
         </div>
@@ -162,6 +199,10 @@ export function ConversationHistoryPanel({
         <ol className="history-list" ref={list}>
           {keyedHistoryEntries(entries).map(({ entry, key }) => (
             <HistoryEntryRow key={key} entry={entry} />
+          ))}
+          {live.map((entry, index) => (
+            // biome-ignore lint/suspicious/noArrayIndexKey: A line still being said has no durable id, and its words change on every delta — a key made of either would remount the bubble mid-sentence, while its position holds still for exactly as long as the line does.
+            <HistoryEntryRow key={`live:${entry.kind}:${index}`} entry={entry} streaming />
           ))}
         </ol>
       )}

--- a/apps/desktop/src/renderer/panel-body.tsx
+++ b/apps/desktop/src/renderer/panel-body.tsx
@@ -790,6 +790,8 @@ export interface PanelBodyProps {
   writes: SessionWriteHandlers;
   /** The current-launch, renderer-memory conversation between the developer and Luke. */
   conversationHistory: readonly ConversationEntry[];
+  /** The lines still being said, drawn under that thread while their words grow. */
+  liveConversationEntries: readonly ConversationEntry[];
   /** Clears that same thread from the view and Luke's next conversational context. */
   onClearConversationHistory: () => void;
   /** Carries a typed ask to Luke's own conversation, answering why it could not go. */
@@ -841,6 +843,7 @@ export function PanelBody({
   onOpenSessionApplication,
   writes,
   conversationHistory,
+  liveConversationEntries,
   onClearConversationHistory,
   ask,
   onAskEngaged,
@@ -928,6 +931,7 @@ export function PanelBody({
       ) : tab === PANEL_TAB.HISTORY ? (
         <ConversationHistoryPanel
           entries={conversationHistory}
+          live={liveConversationEntries}
           onClear={onClearConversationHistory}
         />
       ) : (

--- a/apps/desktop/src/renderer/realtime-session.test.ts
+++ b/apps/desktop/src/renderer/realtime-session.test.ts
@@ -104,6 +104,10 @@ interface Harness {
   replyEndings: { texts: readonly string[]; about: string | undefined }[];
   /** The developer's spoken turns, as the service handed them back. */
   spokenAsks: string[];
+  /** The growing pieces of those turns' words, in arrival order. */
+  spokenAskDeltas: { itemId: string; delta: string }[];
+  /** The turns whose transcription the service gave up on. */
+  spokenAskFailures: string[];
   /** Conversation items fixed for those turns before their transcripts returned. */
   spokenAskItems: string[];
   /** Number of local audio turns closed before the server acknowledged them. */
@@ -216,6 +220,8 @@ function harness(
   const captionSubjects: (string | undefined)[] = [];
   const replyEndings: { texts: readonly string[]; about: string | undefined }[] = [];
   const spokenAsks: string[] = [];
+  const spokenAskDeltas: { itemId: string; delta: string }[] = [];
+  const spokenAskFailures: string[] = [];
   const spokenAskItems: string[] = [];
   let spokenAskClosures = 0;
   const requests: { url: string; init: RequestInit }[] = [];
@@ -358,6 +364,12 @@ function harness(
     onSpokenAsk: (transcript) => {
       spokenAsks.push(transcript);
     },
+    onSpokenAskDelta: (itemId, delta) => {
+      spokenAskDeltas.push({ itemId, delta });
+    },
+    onSpokenAskFailed: (itemId) => {
+      spokenAskFailures.push(itemId);
+    },
     onSpokenAskClosed: () => {
       spokenAskClosures += 1;
     },
@@ -398,6 +410,8 @@ function harness(
     captionSubjects,
     replyEndings,
     spokenAsks,
+    spokenAskDeltas,
+    spokenAskFailures,
     spokenAskItems,
     spokenAskClosures: () => spokenAskClosures,
     microphoneEnabled: () => enabled,
@@ -2201,6 +2215,56 @@ test("a speak-only call has no spoken turns to hand back", async () => {
   });
 
   assert.deepEqual(context.spokenAsks, []);
+});
+
+test("the developer's spoken words preview as they are transcribed", async () => {
+  const context = harness();
+  await context.session.connect();
+
+  // Each piece is handed over as it arrives, keyed by its own turn, so the
+  // caller can grow the right preview while the completed transcript is
+  // still on the service's clock — and a failure hands the turn back so the
+  // preview can leave instead of streaming forever.
+  context.emit({
+    type: REALTIME_SERVER_EVENT.INPUT_AUDIO_TRANSCRIPTION_DELTA,
+    item_id: "item-1",
+    delta: "how is the",
+  });
+  context.emit({
+    type: REALTIME_SERVER_EVENT.INPUT_AUDIO_TRANSCRIPTION_DELTA,
+    item_id: "item-1",
+    delta: " checkout agent doing?",
+  });
+  context.emit({
+    type: REALTIME_SERVER_EVENT.INPUT_AUDIO_TRANSCRIPTION_FAILED,
+    item_id: "item-2",
+  });
+
+  assert.deepEqual(context.spokenAskDeltas, [
+    { itemId: "item-1", delta: "how is the" },
+    { itemId: "item-1", delta: " checkout agent doing?" },
+  ]);
+  assert.deepEqual(context.spokenAskFailures, ["item-2"]);
+});
+
+test("a speak-only call has no spoken words taking shape either", async () => {
+  const context = harness();
+  await context.session.connect({ microphone: false });
+
+  // The completed transcript's microphone guard, applied to its preview and
+  // its failure alike.
+  context.emit({
+    type: REALTIME_SERVER_EVENT.INPUT_AUDIO_TRANSCRIPTION_DELTA,
+    item_id: "item-1",
+    delta: "how is the",
+  });
+  context.emit({
+    type: REALTIME_SERVER_EVENT.INPUT_AUDIO_TRANSCRIPTION_FAILED,
+    item_id: "item-1",
+  });
+
+  assert.deepEqual(context.spokenAskDeltas, []);
+  assert.deepEqual(context.spokenAskFailures, []);
 });
 
 test("a reply hands its words back as it ends, whole and once", async () => {

--- a/apps/desktop/src/renderer/realtime-session.test.ts
+++ b/apps/desktop/src/renderer/realtime-session.test.ts
@@ -2185,6 +2185,21 @@ test("the developer's spoken words come back only from their own call", async ()
   assert.deepEqual(context.spokenAsks, ["how is the checkout agent doing?"]);
 });
 
+test("a transcription that came back empty still hands its turn back", async () => {
+  const context = harness();
+  await context.session.connect();
+
+  // The empty words record nothing — the caller's own paths refuse them —
+  // but the turn ending is what lets a preview built from deltas leave.
+  context.emit({
+    type: REALTIME_SERVER_EVENT.INPUT_AUDIO_TRANSCRIPTION_COMPLETED,
+    item_id: "item-1",
+    transcript: "  ",
+  });
+
+  assert.deepEqual(context.spokenAsks, [""]);
+});
+
 test("a developer turn is identified before its transcript returns", async () => {
   const context = harness();
   await context.session.connect();

--- a/apps/desktop/src/renderer/realtime-session.ts
+++ b/apps/desktop/src/renderer/realtime-session.ts
@@ -254,6 +254,20 @@ export interface RealtimeVoiceSessionCallbacks {
    * records the words so the thread holds both halves of the exchange.
    */
   onSpokenAsk?(transcript: string, itemId: string): void;
+  /**
+   * The developer's spoken words taking shape, one growing piece at a time,
+   * from the same call and under the same microphone guard as the completed
+   * transcript. Preview only: the caller may draw the ask as it is
+   * transcribed, but records nothing until `onSpokenAsk` hands the settled
+   * words over — a turn whose transcription fails previews and then leaves.
+   */
+  onSpokenAskDelta?(itemId: string, delta: string): void;
+  /**
+   * A spoken turn whose transcription the service gave up on. No completed
+   * transcript is coming, so whatever preview the turn's deltas built must
+   * leave rather than stand forever as words still arriving.
+   */
+  onSpokenAskFailed?(itemId: string): void;
   /** The local audio turn closed, before its commit can be acknowledged. */
   onSpokenAskClosed?(): void;
   /** The server item that fixes which current-launch history a spoken turn belongs to. */
@@ -2388,11 +2402,20 @@ export class RealtimeVoiceSession {
           this.#armSettleTimer();
         }
         return;
+      case REALTIME_SERVER_EVENT.INPUT_AUDIO_TRANSCRIPTION_DELTA:
+        // The completed transcript's own microphone guard, applied to its
+        // preview: a speak-only call has no developer words to be taking
+        // shape either.
+        if (this.#withMicrophone) this.#options.onSpokenAskDelta?.(event.itemId, event.delta);
+        return;
       case REALTIME_SERVER_EVENT.INPUT_AUDIO_TRANSCRIPTION_COMPLETED:
         // Only the developer's own call has spoken turns to hand back; the
         // guard is belt to the speak-only shape's suspenders, so a stray
         // event on Luke's own call can never write a developer line.
         if (this.#withMicrophone) this.#options.onSpokenAsk?.(event.transcript, event.itemId);
+        return;
+      case REALTIME_SERVER_EVENT.INPUT_AUDIO_TRANSCRIPTION_FAILED:
+        if (this.#withMicrophone) this.#options.onSpokenAskFailed?.(event.itemId);
         return;
       case REALTIME_SERVER_EVENT.INPUT_AUDIO_BUFFER_COMMITTED:
         if (this.#withMicrophone) this.#options.onSpokenAskCommitted?.(event.itemId);

--- a/apps/desktop/src/renderer/use-voice-conversation.test.ts
+++ b/apps/desktop/src/renderer/use-voice-conversation.test.ts
@@ -3,7 +3,12 @@ import test from "node:test";
 import { PRODUCT_EXCHANGE_KIND } from "@sidecar/analytics";
 import { FIXTURE_SPEAKING_CAPTION } from "@sidecar/fixtures";
 import { ISSUE_TRACKER_ID, normalizeTrackedIssue, type TrackedIssue } from "@sidecar/issues";
-import { REALTIME_STATUS, REALTIME_VOICE, REALTIME_VOICE_SPEED } from "@sidecar/realtime";
+import {
+  CONVERSATION_ENTRY_KIND,
+  REALTIME_STATUS,
+  REALTIME_VOICE,
+  REALTIME_VOICE_SPEED,
+} from "@sidecar/realtime";
 import {
   normalizeSession,
   type ProviderSessionObservation,
@@ -15,11 +20,13 @@ import {
   activeVoiceStream,
   authorizeConversationAct,
   conversationEntryBelongsToConversation,
+  liveConversationEntries,
   liveSpeedApplies,
   lukeCaptionsToShow,
   replyIssueMentions,
   replyMentions,
   spokenAskBelongsToConversation,
+  spokenAskPreviewSurvives,
   talkKeyPress,
   talkOpeningHolds,
   typedAskHolds,
@@ -43,6 +50,73 @@ test("work that began before Clear cannot repopulate conversation history", () =
   assert.equal(conversationEntryBelongsToConversation(3, 4), false);
   assert.equal(conversationEntryBelongsToConversation(4, 4), true);
   assert.equal(conversationEntryBelongsToConversation(undefined, 4), false);
+});
+
+test("the live lines mirror exactly what their recording paths will keep", () => {
+  const lines = liveConversationEntries({
+    spokenAskPreviews: new Map([
+      ["item-1", "how is the checkout agent"],
+      ["item-2", "and the deploy?"],
+    ]),
+    captions: ["Checkout is", "nearly done."],
+    about: undefined,
+    transcriptSpoken: false,
+  });
+
+  // The asks precede the answer, and the reply's segments join into the one
+  // line onReplyEnded will record.
+  assert.deepEqual(
+    lines.map((line) => ({ kind: line.kind, words: line.words })),
+    [
+      { kind: CONVERSATION_ENTRY_KIND.SPOKEN_ASK, words: "how is the checkout agent" },
+      { kind: CONVERSATION_ENTRY_KIND.SPOKEN_ASK, words: "and the deploy?" },
+      { kind: CONVERSATION_ENTRY_KIND.REPLY, words: "Checkout is nearly done." },
+    ],
+  );
+  // A line still growing has not happened yet, so none is stamped.
+  assert.ok(lines.every((line) => line.recordedAt === undefined));
+});
+
+test("an announcement's live line carries its validated subject", () => {
+  const about = { providerId: "claude-code", providerSessionId: "session-a" };
+  const lines = liveConversationEntries({
+    spokenAskPreviews: new Map(),
+    captions: ["Claude Code finished checkout-service."],
+    about,
+    transcriptSpoken: false,
+  });
+
+  assert.deepEqual(lines, [
+    {
+      kind: CONVERSATION_ENTRY_KIND.ANNOUNCEMENT,
+      words: "Claude Code finished checkout-service.",
+      identity: about,
+    },
+  ]);
+});
+
+test("a transcript reading's reply previews nothing it may never record", () => {
+  // The record keeps the act and not a word of the rendering, so the live
+  // line keeps the same silence the settled thread will.
+  assert.deepEqual(
+    liveConversationEntries({
+      spokenAskPreviews: new Map(),
+      captions: ["The session said the tests pass."],
+      about: undefined,
+      transcriptSpoken: true,
+    }),
+    [],
+  );
+});
+
+test("a gone call takes its half-transcribed previews with it", () => {
+  assert.equal(spokenAskPreviewSurvives(REALTIME_STATUS.IDLE), false);
+  assert.equal(spokenAskPreviewSurvives(REALTIME_STATUS.FAILED), false);
+  assert.equal(spokenAskPreviewSurvives(REALTIME_STATUS.UNAVAILABLE), false);
+  assert.equal(spokenAskPreviewSurvives(REALTIME_STATUS.CONNECTING), true);
+  assert.equal(spokenAskPreviewSurvives(REALTIME_STATUS.READY), true);
+  assert.equal(spokenAskPreviewSurvives(REALTIME_STATUS.LISTENING), true);
+  assert.equal(spokenAskPreviewSurvives(REALTIME_STATUS.RESPONDING), true);
 });
 
 test("an authorization that outlives Clear cannot record its act", async () => {

--- a/apps/desktop/src/renderer/use-voice-conversation.ts
+++ b/apps/desktop/src/renderer/use-voice-conversation.ts
@@ -761,12 +761,17 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
       ) {
         return;
       }
-      conversationRef.current = insertSpokenAskThreadEntry(
+      const placed = insertSpokenAskThreadEntry(
         conversationRef.current,
         transcript,
         mark.after,
         mark.recordedAt,
       );
+      // A transcription that came back empty ended its turn — the preview
+      // and the mark are already spent — but placed no line, and a thread
+      // that did not change owes the open call no update.
+      if (placed === conversationRef.current) return;
+      conversationRef.current = placed;
       setConversationHistory(conversationRef.current);
       voiceSession.current?.updateConversation(recentConversationEntries(conversationRef.current));
     },

--- a/apps/desktop/src/renderer/use-voice-conversation.ts
+++ b/apps/desktop/src/renderer/use-voice-conversation.ts
@@ -22,6 +22,7 @@ import {
   recentConversationEntries,
   SESSION_TOOL_KIND,
   sessionActConversationEntry,
+  streamingConversationEntry,
 } from "@sidecar/realtime";
 import {
   mentionedSessions,
@@ -305,6 +306,53 @@ export function conversationEntryBelongsToConversation(
   return entryGeneration !== undefined && entryGeneration === conversationGeneration;
 }
 
+/**
+ * Whether a status still has a call behind it. A gone call takes its
+ * half-transcribed spoken turns with it: their completed transcripts can no
+ * longer arrive, so a preview left standing would stream forever.
+ */
+export function spokenAskPreviewSurvives(status: RealtimeStatus): boolean {
+  return (
+    status !== REALTIME_STATUS.IDLE &&
+    status !== REALTIME_STATUS.FAILED &&
+    status !== REALTIME_STATUS.UNAVAILABLE
+  );
+}
+
+/** One empty map, so clearing previews repeatedly re-renders nothing. */
+const NO_SPOKEN_ASK_PREVIEWS: ReadonlyMap<string, string> = new Map();
+
+/**
+ * The lines still being said, for History to draw under the settled thread:
+ * the developer's spoken turns as the service transcribes them, then the
+ * reply or announcement as its words are generated — the ask precedes its
+ * answer. Presentation only, so each line mirrors exactly what its own
+ * recording path will keep: an announcement carries its validated subject,
+ * and the reply that is voicing a transcript reading draws nothing, because
+ * the record keeps the act and never a word of the rendering.
+ */
+export function liveConversationEntries(input: {
+  spokenAskPreviews: ReadonlyMap<string, string>;
+  captions: readonly string[] | undefined;
+  about: SessionIdentity | undefined;
+  transcriptSpoken: boolean;
+}): readonly ConversationEntry[] {
+  const lines: ConversationEntry[] = [];
+  for (const words of input.spokenAskPreviews.values()) {
+    const ask = streamingConversationEntry(CONVERSATION_ENTRY_KIND.SPOKEN_ASK, words);
+    if (ask) lines.push(ask);
+  }
+  if (input.captions && (input.about || !input.transcriptSpoken)) {
+    const speech = streamingConversationEntry(
+      input.about ? CONVERSATION_ENTRY_KIND.ANNOUNCEMENT : CONVERSATION_ENTRY_KIND.REPLY,
+      input.captions.join(" "),
+      input.about,
+    );
+    if (speech) lines.push(speech);
+  }
+  return lines;
+}
+
 /** Captures the reply that owns an act before main-process authorization can pause it. */
 export async function authorizeConversationAct<T>(
   activeReplyGeneration: { readonly current: number | undefined },
@@ -468,6 +516,14 @@ export interface VoiceConversation {
   conversationHistory: readonly ConversationEntry[];
   /** Clears the visible history and the context handed to the next call. */
   clearConversationHistory: () => void;
+  /**
+   * The lines still being said, for History to draw under the settled thread:
+   * a spoken ask as the service transcribes it, a reply or announcement as
+   * its words are generated. Never part of {@link conversationHistory} — each
+   * settles into it through its own recording path, or leaves without one
+   * exactly as the words it previews do.
+   */
+  liveConversationEntries: readonly ConversationEntry[];
   voiceTurn: WaveformVoice | undefined;
   /**
    * The words being spoken, one entry per response: a turn that speaks twice
@@ -617,6 +673,30 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
    * and not a word of what it rendered.
    */
   const transcriptSpokenRef = useRef(false);
+  // State beside the ref, because the session's callbacks read the flag
+  // synchronously while History's live line derives from what React can see.
+  const [transcriptSpoken, setTranscriptSpoken] = useState(false);
+  const markTranscriptSpoken = useCallback((value: boolean) => {
+    transcriptSpokenRef.current = value;
+    setTranscriptSpoken(value);
+  }, []);
+  /**
+   * The developer's spoken turns still being transcribed, keyed by the server
+   * item that names each turn: the preview History draws while the completed
+   * transcript is still on the service's own clock. Kept apart from the
+   * thread — a preview settles by leaving when `rememberSpokenAsk` records
+   * the completed words, or by leaving alone when nothing ever will.
+   */
+  const [spokenAskPreviews, setSpokenAskPreviews] =
+    useState<ReadonlyMap<string, string>>(NO_SPOKEN_ASK_PREVIEWS);
+  const dropSpokenAskPreview = useCallback((itemId: string) => {
+    setSpokenAskPreviews((previews) => {
+      if (!previews.has(itemId)) return previews;
+      const next = new Map(previews);
+      next.delete(itemId);
+      return next;
+    });
+  }, []);
 
   /**
    * Appends one bounded line to this launch's history and tells the call now
@@ -650,6 +730,9 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
     spokenTurnMarksRef.current.clear();
     pendingSpokenTurnMarksRef.current = [];
     setConversationHistory([]);
+    // The previews go with the marks: a transcription still arriving belongs
+    // to a turn the press just retired, and could never be recorded anyway.
+    setSpokenAskPreviews(NO_SPOKEN_ASK_PREVIEWS);
     talkLatched.current = false;
     talkPressedAt.current = undefined;
     voiceSession.current?.clearConversation();
@@ -665,24 +748,30 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
    * server item binds it to the mark made for that exact turn, so a transcript
    * delayed past Clear cannot borrow a newer turn's place.
    */
-  const rememberSpokenAsk = useCallback((transcript: string, itemId: string) => {
-    const mark = spokenTurnMarksRef.current.get(itemId);
-    spokenTurnMarksRef.current.delete(itemId);
-    if (
-      !mark ||
-      !spokenAskBelongsToConversation(mark.generation, conversationGenerationRef.current)
-    ) {
-      return;
-    }
-    conversationRef.current = insertSpokenAskThreadEntry(
-      conversationRef.current,
-      transcript,
-      mark.after,
-      mark.recordedAt,
-    );
-    setConversationHistory(conversationRef.current);
-    voiceSession.current?.updateConversation(recentConversationEntries(conversationRef.current));
-  }, []);
+  const rememberSpokenAsk = useCallback(
+    (transcript: string, itemId: string) => {
+      // The completed words supersede the turn's preview whether or not they
+      // may be recorded: either way, nothing about this turn is still arriving.
+      dropSpokenAskPreview(itemId);
+      const mark = spokenTurnMarksRef.current.get(itemId);
+      spokenTurnMarksRef.current.delete(itemId);
+      if (
+        !mark ||
+        !spokenAskBelongsToConversation(mark.generation, conversationGenerationRef.current)
+      ) {
+        return;
+      }
+      conversationRef.current = insertSpokenAskThreadEntry(
+        conversationRef.current,
+        transcript,
+        mark.after,
+        mark.recordedAt,
+      );
+      setConversationHistory(conversationRef.current);
+      voiceSession.current?.updateConversation(recentConversationEntries(conversationRef.current));
+    },
+    [dropSpokenAskPreview],
+  );
 
   const ensureVoiceSession = useCallback((): RealtimeVoiceSession => {
     voiceSession.current ??= new RealtimeVoiceSession({
@@ -739,7 +828,7 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
         // The reply that voices a transcript reading must stay out of the
         // history: the rendering travels only in the turn that asked for it.
         if (action.kind === SESSION_TOOL_KIND.READ_TRANSCRIPT) {
-          transcriptSpokenRef.current = true;
+          markTranscriptSpoken(true);
         }
         return dispatchByKind(action, {
           [SESSION_TOOL_KIND.MESSAGE]: (act) =>
@@ -799,7 +888,7 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
         const generation = activeReplyGenerationRef.current;
         activeReplyGenerationRef.current = undefined;
         const spokeTranscript = transcriptSpokenRef.current;
-        transcriptSpokenRef.current = false;
+        markTranscriptSpoken(false);
         // A transcript reading enters the record only as the act it was.
         if (spokeTranscript) return;
         rememberConversationEntry(
@@ -820,6 +909,27 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
       // placed where their turn happened: the thread holds both halves of
       // the exchange, in the order they were said.
       onSpokenAsk: rememberSpokenAsk,
+      // The same words while they are still arriving, previewed on the
+      // completed transcript's own terms: only a turn whose committed item
+      // holds a mark in the history generation still showing may draw, so a
+      // straggler after Clear previews nothing it could never record.
+      onSpokenAskDelta: (itemId, delta) => {
+        const mark = spokenTurnMarksRef.current.get(itemId);
+        if (
+          !mark ||
+          !spokenAskBelongsToConversation(mark.generation, conversationGenerationRef.current)
+        ) {
+          return;
+        }
+        setSpokenAskPreviews((previews) => {
+          const next = new Map(previews);
+          next.set(itemId, (next.get(itemId) ?? "") + delta);
+          return next;
+        });
+      },
+      // No completed transcript is coming for this turn, so its preview
+      // leaves the way its recorded line never arrives.
+      onSpokenAskFailed: dropSpokenAskPreview,
       // The development trace's tap, checked at each event rather than at
       // construction because the session outlives the bootstrap that says
       // whether a writer stands behind the bridge. The audio is stripped
@@ -830,7 +940,13 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
       },
     });
     return voiceSession.current;
-  }, [rememberConversationEntry, rememberSpokenAsk, setVoiceStatus]);
+  }, [
+    dropSpokenAskPreview,
+    markTranscriptSpoken,
+    rememberConversationEntry,
+    rememberSpokenAsk,
+    setVoiceStatus,
+  ]);
 
   /**
    * Words the arrival beat from what is true at the moment it is spoken, not
@@ -1186,7 +1302,7 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
         // A new typed turn lets a leftover transcript skip go, exactly as a
         // spoken one does — after the send, whose interrupt hands over the
         // cut reply's words and is the flag's last rightful consumer.
-        transcriptSpokenRef.current = false;
+        markTranscriptSpoken(false);
         // The developer's own words enter the history as they were typed, so
         // the thread holds both halves of the exchange the reply answers.
         rememberConversationEntry(
@@ -1210,7 +1326,13 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
       setVoiceNotice(refusal);
       return refusal;
     },
-    [rememberConversationEntry, ensureVoiceSession, spentAllowanceNote, startConversation],
+    [
+      markTranscriptSpoken,
+      rememberConversationEntry,
+      ensureVoiceSession,
+      spentAllowanceNote,
+      startConversation,
+    ],
   );
 
   const discardListening = useCallback(() => {
@@ -1307,7 +1429,12 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
     // a new spoken turn opening lets it go, or the flag would swallow the
     // next reply from the history.
     if (voiceStatus === REALTIME_STATUS.LISTENING) {
-      transcriptSpokenRef.current = false;
+      markTranscriptSpoken(false);
+    }
+    // The call gone takes its half-transcribed turns with it: no completed
+    // transcript can arrive to settle a preview, so none may keep streaming.
+    if (!spokenAskPreviewSurvives(voiceStatus)) {
+      setSpokenAskPreviews(NO_SPOKEN_ASK_PREVIEWS);
     }
     // Any settled status ends the wait the press started, however it ended:
     // listening takes the meter live, ready means the turn was dropped
@@ -1322,7 +1449,7 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
     ) {
       setTalkOpening(false);
     }
-  }, [voiceStatus]);
+  }, [markTranscriptSpoken, voiceStatus]);
 
   // The strip the error is drawn on takes no pointer, so nothing but time can
   // dismiss it: a fault left up would sit on the desktop all afternoon. A new
@@ -1513,6 +1640,20 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
     [options.fixtureSpeaking, trackedIssues, voiceCaption],
   );
 
+  // Derived like the mentions: the live lines arrive with the captions and
+  // the previews, and die with them, so History can never show words still
+  // arriving for a reply or a turn that has already settled or left.
+  const live = useMemo(
+    () =>
+      liveConversationEntries({
+        spokenAskPreviews,
+        captions: voiceCaption.texts,
+        about: voiceCaption.about,
+        transcriptSpoken,
+      }),
+    [spokenAskPreviews, transcriptSpoken, voiceCaption],
+  );
+
   const voiceTurn = waveformVoice(voiceStatus);
   const lukeCaptions = lukeCaptionsToShow({
     fixtureSpeaking: options.fixtureSpeaking,
@@ -1541,6 +1682,7 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
     askLuke,
     conversationHistory,
     clearConversationHistory,
+    liveConversationEntries: live,
     voiceTurn,
     lukeCaptions,
     mentionedSessions: mentioned,

--- a/packages/realtime/src/conversation-history.test.ts
+++ b/packages/realtime/src/conversation-history.test.ts
@@ -308,7 +308,10 @@ test("a spoken ask lands at its turn's own mark, not where its transcription did
   });
   assert.equal(retired[0]?.words, "an ancient ask");
 
-  // The same flattening and bounds as an append: nothing left, nothing placed.
+  // The same flattening and bounds as an append: nothing left, nothing
+  // placed — and the very thread handed in, so a caller can tell an unchanged
+  // history from one that owes the open call an update.
+  assert.equal(insertSpokenAskThreadEntry(exchange, "   ", priorReply, OBSERVED_AT), exchange);
   assert.deepEqual(insertSpokenAskEntry(exchange, "   ", priorReply), exchange);
   let full: readonly ConversationEntry[] = [];
   for (let index = 0; index < maximumConversationEntries; index += 1) {

--- a/packages/realtime/src/conversation-history.test.ts
+++ b/packages/realtime/src/conversation-history.test.ts
@@ -19,6 +19,7 @@ import {
   maximumConversationEntryLength,
   recentConversationEntries,
   sessionActConversationEntry,
+  streamingConversationEntry,
 } from "./conversation-history.js";
 import { SESSION_NO_LONGER_OBSERVED_NOTE } from "./realtime-protocol.js";
 import { SESSION_TOOL_KIND } from "./realtime-tools.js";
@@ -62,6 +63,24 @@ test("appending flattens, bounds, and retires the oldest lines", () => {
   }
   assert.equal(entries.length, maximumConversationEntries);
   assert.equal(entries[0]?.words, "line 3");
+});
+
+test("a streaming line is bounded like the settled line it previews", () => {
+  const identity = { providerId: "claude-code", providerSessionId: "session-a" };
+  const line = streamingConversationEntry(
+    CONVERSATION_ENTRY_KIND.ANNOUNCEMENT,
+    `  Checkout\n\nfinished ${"x".repeat(2 * maximumConversationEntryLength)}  `,
+    identity,
+  );
+  assert.match(line?.words ?? "", /^Checkout finished x/);
+  assert.ok((line?.words.length ?? 0) <= maximumConversationEntryLength);
+  assert.deepEqual(line?.identity, identity);
+  // A line still growing has not happened yet: the record stamps at settle.
+  assert.equal(line?.recordedAt, undefined);
+
+  // Words that flatten to nothing preview nothing, exactly as they would
+  // append nothing.
+  assert.equal(streamingConversationEntry(CONVERSATION_ENTRY_KIND.REPLY, "   "), undefined);
 });
 
 test("every way into the thread stamps when the line was recorded", () => {

--- a/packages/realtime/src/conversation-history.ts
+++ b/packages/realtime/src/conversation-history.ts
@@ -106,6 +106,27 @@ function boundedEntryWords(words: string): string {
 }
 
 /**
+ * One line still being said, for the panel to draw under the settled thread
+ * while its words grow. It is bounded exactly as its settled form will be, so
+ * the streaming bubble and the recorded line can never disagree, and it
+ * carries no timestamp: the record stamps a line only when it settles, and a
+ * line still growing has not happened yet. Presentation only — nothing built
+ * here may enter the thread; each line settles through its own recording
+ * path, or leaves without one exactly as the words it previews do.
+ */
+export function streamingConversationEntry(
+  kind: ConversationEntryKind,
+  words: string,
+  identity?: SessionIdentity,
+): ConversationEntry | undefined {
+  const bounded = boundedEntryWords(words);
+  if (!bounded) return undefined;
+  const entry: ConversationEntry = { kind, words: bounded };
+  if (identity) entry.identity = identity;
+  return entry;
+}
+
+/**
  * Places a spoken ask where its turn actually happened. The transcription
  * arrives on the service's own clock — usually while the reply is still being
  * spoken, sometimes after it has ended — and a plain append would then store

--- a/packages/realtime/src/index.ts
+++ b/packages/realtime/src/index.ts
@@ -17,6 +17,7 @@ export {
   maximumConversationEntryLength,
   recentConversationEntries,
   sessionActConversationEntry,
+  streamingConversationEntry,
 } from "./conversation-history.js";
 export {
   type IntroductionLine,

--- a/packages/realtime/src/realtime-protocol.ts
+++ b/packages/realtime/src/realtime-protocol.ts
@@ -876,16 +876,17 @@ export function parseRealtimeServerEvent(
       };
     }
     case REALTIME_SERVER_EVENT.INPUT_AUDIO_TRANSCRIPTION_COMPLETED: {
-      // A transcription that came back empty said nothing worth a history
-      // line; a failed one arrives as its own event, parsed below, so the
-      // preview its deltas built can be let go.
-      const transcript = text(event.transcript);
+      // A transcription that came back empty still ends its turn — whatever
+      // preview its deltas built must leave with it — it just carries
+      // nothing worth a history line, which the recording path refuses on
+      // its own. A failed transcription arrives as its own event, parsed
+      // below, and ends its turn the same way.
       const itemId = text(event.item_id);
-      if (!transcript || !itemId) return undefined;
+      if (!itemId) return undefined;
       return {
         type: REALTIME_SERVER_EVENT.INPUT_AUDIO_TRANSCRIPTION_COMPLETED,
         itemId,
-        transcript,
+        transcript: text(event.transcript) ?? "",
       };
     }
     case REALTIME_SERVER_EVENT.INPUT_AUDIO_TRANSCRIPTION_FAILED: {

--- a/packages/realtime/src/realtime-protocol.ts
+++ b/packages/realtime/src/realtime-protocol.ts
@@ -113,12 +113,25 @@ export const REALTIME_SERVER_EVENT = {
   /** The server has made one developer audio turn into a conversation item. */
   INPUT_AUDIO_BUFFER_COMMITTED: "input_audio_buffer.committed",
   /**
+   * The developer's own spoken words, arriving as the service transcribes
+   * them. They only preview the completed transcript below — the settled
+   * words supersede whatever the deltas built — so a surface may show the
+   * ask taking shape while the history still records only what completed.
+   */
+  INPUT_AUDIO_TRANSCRIPTION_DELTA: "conversation.item.input_audio_transcription.delta",
+  /**
    * The developer's own spoken turn, as the service transcribed it. It
    * arrives on its own clock — transcription runs beside the reply, not ahead
-   * of it — and it is the one way their spoken words come back as text at
-   * all, so the conversation history can hold both halves of the exchange.
+   * of it — and it is the one way their spoken words settle as text at all,
+   * so the conversation history can hold both halves of the exchange.
    */
   INPUT_AUDIO_TRANSCRIPTION_COMPLETED: "conversation.item.input_audio_transcription.completed",
+  /**
+   * A spoken turn whose transcription the service gave up on. No words ever
+   * arrive for it, so whatever preview its deltas built must leave rather
+   * than stand forever for a completion that is not coming.
+   */
+  INPUT_AUDIO_TRANSCRIPTION_FAILED: "conversation.item.input_audio_transcription.failed",
   RESPONSE_DONE: "response.done",
   ERROR: "error",
 } as const;
@@ -698,10 +711,16 @@ export type ParsedRealtimeServerEvent =
       transcript: string;
     }
   | {
+      type: typeof REALTIME_SERVER_EVENT.INPUT_AUDIO_TRANSCRIPTION_DELTA;
+      itemId: string;
+      delta: string;
+    }
+  | {
       type: typeof REALTIME_SERVER_EVENT.INPUT_AUDIO_TRANSCRIPTION_COMPLETED;
       itemId: string;
       transcript: string;
     }
+  | { type: typeof REALTIME_SERVER_EVENT.INPUT_AUDIO_TRANSCRIPTION_FAILED; itemId: string }
   | { type: typeof REALTIME_SERVER_EVENT.INPUT_AUDIO_BUFFER_COMMITTED; itemId: string }
   | { type: typeof REALTIME_SERVER_EVENT.OUTPUT_AUDIO_BUFFER_STOPPED; responseId?: string }
   | { type: typeof REALTIME_SERVER_EVENT.OUTPUT_AUDIO_BUFFER_STARTED; responseId?: string }
@@ -844,9 +863,22 @@ export function parseRealtimeServerEvent(
       if (itemId) parsed.itemId = itemId;
       return parsed;
     }
+    case REALTIME_SERVER_EVENT.INPUT_AUDIO_TRANSCRIPTION_DELTA: {
+      // A delta needs its item: the preview it grows is keyed by the turn it
+      // belongs to, and words no turn claims could only be drawn wrong.
+      if (!isWireString(event.delta) || event.delta.length === 0) return undefined;
+      const itemId = text(event.item_id);
+      if (!itemId) return undefined;
+      return {
+        type: REALTIME_SERVER_EVENT.INPUT_AUDIO_TRANSCRIPTION_DELTA,
+        itemId,
+        delta: event.delta,
+      };
+    }
     case REALTIME_SERVER_EVENT.INPUT_AUDIO_TRANSCRIPTION_COMPLETED: {
       // A transcription that came back empty said nothing worth a history
-      // line, and a failed one arrives as its own event this parser ignores.
+      // line; a failed one arrives as its own event, parsed below, so the
+      // preview its deltas built can be let go.
       const transcript = text(event.transcript);
       const itemId = text(event.item_id);
       if (!transcript || !itemId) return undefined;
@@ -855,6 +887,11 @@ export function parseRealtimeServerEvent(
         itemId,
         transcript,
       };
+    }
+    case REALTIME_SERVER_EVENT.INPUT_AUDIO_TRANSCRIPTION_FAILED: {
+      const itemId = text(event.item_id);
+      if (!itemId) return undefined;
+      return { type: REALTIME_SERVER_EVENT.INPUT_AUDIO_TRANSCRIPTION_FAILED, itemId };
     }
     case REALTIME_SERVER_EVENT.INPUT_AUDIO_BUFFER_COMMITTED: {
       const itemId = text(event.item_id);

--- a/packages/realtime/src/realtime.test.ts
+++ b/packages/realtime/src/realtime.test.ts
@@ -1219,6 +1219,25 @@ test("inbound events the conversation acts on are parsed, and nothing else is", 
   );
   assert.deepEqual(
     parseRealtimeServerEvent({
+      type: REALTIME_SERVER_EVENT.INPUT_AUDIO_TRANSCRIPTION_DELTA,
+      item_id: "item-2",
+      delta: "how is the",
+    }),
+    {
+      type: REALTIME_SERVER_EVENT.INPUT_AUDIO_TRANSCRIPTION_DELTA,
+      itemId: "item-2",
+      delta: "how is the",
+    },
+  );
+  assert.deepEqual(
+    parseRealtimeServerEvent({
+      type: REALTIME_SERVER_EVENT.INPUT_AUDIO_TRANSCRIPTION_FAILED,
+      item_id: "item-2",
+    }),
+    { type: REALTIME_SERVER_EVENT.INPUT_AUDIO_TRANSCRIPTION_FAILED, itemId: "item-2" },
+  );
+  assert.deepEqual(
+    parseRealtimeServerEvent({
       type: REALTIME_SERVER_EVENT.INPUT_AUDIO_BUFFER_COMMITTED,
       item_id: "item-2",
     }),
@@ -1265,6 +1284,10 @@ test("inbound events the conversation acts on are parsed, and nothing else is", 
     // A transcription that came back empty said nothing worth acting on.
     { type: REALTIME_SERVER_EVENT.INPUT_AUDIO_TRANSCRIPTION_COMPLETED, transcript: "  " },
     { type: REALTIME_SERVER_EVENT.INPUT_AUDIO_TRANSCRIPTION_COMPLETED, transcript: "hello" },
+    // A preview without its turn, or without words, previews nothing.
+    { type: REALTIME_SERVER_EVENT.INPUT_AUDIO_TRANSCRIPTION_DELTA, delta: "hello" },
+    { type: REALTIME_SERVER_EVENT.INPUT_AUDIO_TRANSCRIPTION_DELTA, item_id: "item-2", delta: "" },
+    { type: REALTIME_SERVER_EVENT.INPUT_AUDIO_TRANSCRIPTION_FAILED },
     { type: REALTIME_SERVER_EVENT.INPUT_AUDIO_BUFFER_COMMITTED },
     { type: "session.updated" },
   ];

--- a/packages/realtime/src/realtime.test.ts
+++ b/packages/realtime/src/realtime.test.ts
@@ -1217,6 +1217,20 @@ test("inbound events the conversation acts on are parsed, and nothing else is", 
       transcript: "how is the checkout agent doing?",
     },
   );
+  // A transcription that came back empty still ends its turn, so the preview
+  // its deltas built can leave; the empty words record nothing downstream.
+  assert.deepEqual(
+    parseRealtimeServerEvent({
+      type: REALTIME_SERVER_EVENT.INPUT_AUDIO_TRANSCRIPTION_COMPLETED,
+      item_id: "item-2",
+      transcript: "  ",
+    }),
+    {
+      type: REALTIME_SERVER_EVENT.INPUT_AUDIO_TRANSCRIPTION_COMPLETED,
+      itemId: "item-2",
+      transcript: "",
+    },
+  );
   assert.deepEqual(
     parseRealtimeServerEvent({
       type: REALTIME_SERVER_EVENT.INPUT_AUDIO_TRANSCRIPTION_DELTA,
@@ -1281,7 +1295,7 @@ test("inbound events the conversation acts on are parsed, and nothing else is", 
     {},
     { type: REALTIME_SERVER_EVENT.OUTPUT_AUDIO_BUFFER_CLEARED },
     { type: REALTIME_SERVER_EVENT.RESPONSE_OUTPUT_AUDIO_TRANSCRIPT_DELTA, item_id: "item-1" },
-    // A transcription that came back empty said nothing worth acting on.
+    // A transcription without its turn's item names nothing to act on.
     { type: REALTIME_SERVER_EVENT.INPUT_AUDIO_TRANSCRIPTION_COMPLETED, transcript: "  " },
     { type: REALTIME_SERVER_EVENT.INPUT_AUDIO_TRANSCRIPTION_COMPLETED, transcript: "hello" },
     // A preview without its turn, or without words, previews nothing.


### PR DESCRIPTION
## What

The History tab drew a bubble only once its line settled: a reply or announcement appeared after the speech ended, and a spoken ask only when its transcription completed. The words already stream through the caption pipeline, so History now draws each line as it is being said — an announcement's text shows from its first word — and the settled entry takes over seamlessly through its unchanged recording path.

- **Replies and announcements** stream from the live caption the session already emits (`onCaption`), rendered as a provisional bubble under the settled thread. `onReplyEnded` still records the line; the caption clearing and the append land in one batched render, so the bubble hands over without a flicker.
- **Spoken asks** gain a preview from two new protocol events, `conversation.item.input_audio_transcription.delta` and `.failed`, forwarded under the completed transcript's own microphone guard and accumulated only for a turn whose committed item holds a mark in the history generation still showing.
- The list follows streaming growth only while the reader is at the tail; an append still scrolls as before.

## What deliberately does not change

The live lines are presentation only. Nothing new enters the thread, the model context (`updateConversation` still fires only on the settle paths), or a recording (the whole subtree keeps `ph-no-capture`). A transcript reading previews nothing, mirroring the record that keeps the act and never a word of the rendering; a failed announcement still leaves no line (`#discardCaption` clears the caption and the bubble with it); Clear retires previews with the marks; a gone call takes its half-transcribed previews with it. A streaming bubble shows no timestamp and no copy control until it settles.

## Testing

- `./scripts/check.sh` passes (lint, typecheck, all workspace tests, build).
- New tests: parser cases for the two events, session forwarding and its speak-only guard, the bounded streaming entry, the live-line derivation (kinds, ordering, subject, transcript suppression, gone-call cleanup), and panel rendering (streaming bubble, no copy/time, list stands up without settled lines).
- UI change: CI's macOS job runs `./scripts/verify.sh` and links the visual evidence from this description. No physical-notch check was performed (cloud workspace); the streaming states themselves need a live call, which the fixture run does not open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/69acbffa-ee37-459e-977e-ce60152e0470)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/33474048331/artifacts/9787576483) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/33474048331)

- Commit: `75ac6b5271932b32b10ab6f293e7bef407e27029`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
