### PR TITLE
Remove mobile sessions title

### DIFF
--- a/apps/ios/Luke/ContentView.swift
+++ b/apps/ios/Luke/ContentView.swift
@@ -205,8 +205,6 @@ private struct SignedInView: View {
     private var signedInContent: some View {
         NavigationStack {
             SessionsView(firstLoadDone: $firstLoadDone)
-                .navigationTitle("Sessions")
-                .navigationBarTitleDisplayMode(.inline)
                 .toolbar {
                     if #available(iOS 26.0, *) {
                         ToolbarItem(placement: .topBarLeading) {


### PR DESCRIPTION
## Summary
- remove the visible Sessions navigation title from the signed-in iOS main page
- keep the existing toolbar/search controls on the sessions view

## Verification
- git diff --check
- rg -n 'navigationTitle\(Sessions\)' apps/ios/Luke (no matches)

Note: xcodebuild is not installed in this Linux VM, so iOS simulator build/test validation was not available here.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/57c50f3c-c41a-4e16-a270-f7b031f6f9dd)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/33526457304/artifacts/9807992437) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/33526457304)

- Commit: `035c2f97ca0fb0b0593e9017e77b495b5a1dd362`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
