### PR TITLE
feat(desktop): open a history line's chats from pressable chips

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -237,8 +237,9 @@ Trust constraints:
   never from a model's words alone — and a chat archived in its provider
   keeps a working deep link, so its chip still opens it, at the last address an
   observation pass itself reported this run — remembered in the main
-  process, never carried over the bridge — while a session still observed
-  offers exactly what it currently reports, and a chat that never reported
+  process, never carried over the bridge — while a session still reporting
+  an address opens at its current one, the remembered address answering
+  only where the roster has nothing better, and a chat that never reported
   an address draws no chip at all. A workspace Luke just
   created opens itself the same way: the creation ask, already a
   developer-opened turn, is also the ask to be taken there, so the session id

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -223,13 +223,23 @@ Trust constraints:
   endpoint; a session whose provider lists none takes no such ask. A session whose provider documents no way in, or whose current state is
   documented for none, advertises nothing and is offered nothing; local
   sessions have no such endpoint and stay entirely read-only. Opening a
-  session (its row pressed, the same press asked of Luke in conversation, or
-  the notice popup announcing it pressed under the housing) is not a write
+  session (its row pressed, the same press asked of Luke in conversation,
+  the notice popup announcing it pressed under the housing, or a History
+  line's chat chip pressed) is not a write
   and needs no endpoint: the address its provider reported is handed to the
   operating system, and nothing reaches the provider; an open asked of Luke
   still runs only in a developer-opened turn, and a session that reported no
   address is offered nowhere to open; its popup's press opens Luke's own
-  panel instead, which touches no provider at all. A workspace Luke just
+  panel instead, which touches no provider at all. A History line's chips
+  are the one press that outlives a roster row, because the words they were
+  recorded beside do: each line draws a chip per chat it attributably named —
+  identity, title, and marks read from the roster at the moment of the entry,
+  never from a model's words alone — and a chat archived in its provider
+  keeps a working deep link, so its chip still opens it, at the last address an
+  observation pass itself reported this run — remembered in the main
+  process, never carried over the bridge — while a session still observed
+  offers exactly what it currently reports, and a chat that never reported
+  an address draws no chip at all. A workspace Luke just
   created opens itself the same way: the creation ask, already a
   developer-opened turn, is also the ask to be taken there, so the session id
   the provider's creation response named (the one thing read out of that

--- a/apps/desktop/src/main/desktop-app.ts
+++ b/apps/desktop/src/main/desktop-app.ts
@@ -65,6 +65,7 @@ import {
   PROVIDER_ID,
   PROVIDER_ID_LIST,
   type ProviderId,
+  ReportedSessionLinks,
   rosterRelevantSessions,
   type Session,
   type SessionNotice,
@@ -225,6 +226,9 @@ const HOSTED_SERVICE_BASE_URL = ACCOUNT_BASE_URL.replace(/\/api\/auth\/?$/, "");
 const ACCOUNT_CLIENT_ID = "luke-desktop";
 const SESSION_REFRESH_INTERVAL_MS = 5_000;
 const sessionRegistry = new InMemorySessionRegistry();
+// What lets a History line still open a chat whose roster row has departed —
+// archived in its provider — at the last address observation itself reported.
+const reportedSessionLinks = new ReportedSessionLinks();
 // Declared before the settings store because the store's snapshot asks it
 // what the latest pass learned about the Codex CLI's login. It observes only
 // inside the codex composite the provider registrations build; a fixture or
@@ -1689,6 +1693,7 @@ function registerIpc(): void {
     ipcMain,
     trustedSender,
     sessionRegistry,
+    lastReportedSessionLink: (identity) => reportedSessionLinks.lastReported(identity),
     openExternal: (url) => shell.openExternal(url),
     adapterFor,
     sendsNetwork: runMode.sendsNetwork,
@@ -2475,6 +2480,9 @@ function broadcastRelevantSessions(): void {
 function startSessionObservation(): void {
   if (!runMode.observesProviders || !accountCapabilitiesActive() || unsubscribeSessions) return;
   unsubscribeSessions = sessionRegistry.subscribe((snapshot) => {
+    // Remembered from the unfiltered snapshot, before the roster narrows it:
+    // a History press may name any session an observation pass ever addressed.
+    reportedSessionLinks.remember(snapshot.sessions);
     broadcastRelevantSessions();
     // The registry only speaks on an effective change, which is exactly when
     // a status edge can exist to announce. The notices read the unfiltered

--- a/apps/desktop/src/main/ipc/session-acts.ts
+++ b/apps/desktop/src/main/ipc/session-acts.ts
@@ -61,6 +61,8 @@ export interface SessionActsIpcDependencies {
   ipcMain: Pick<IpcMain, "handle" | "on">;
   trustedSender: (event: IpcMainEvent | IpcMainInvokeEvent) => boolean;
   sessionRegistry: InMemorySessionRegistry;
+  /** The last address an observation pass reported for a now-departed session. */
+  lastReportedSessionLink: (identity: SessionIdentity) => string | undefined;
   openExternal: (url: string) => Promise<void>;
   adapterFor: (providerId: string) => SessionProviderAdapter | undefined;
   sendsNetwork: boolean;
@@ -216,6 +218,7 @@ export function registerSessionActsIpc(dependencies: SessionActsIpcDependencies)
     ipcMain,
     trustedSender,
     sessionRegistry,
+    lastReportedSessionLink,
     openExternal,
     adapterFor,
     sendsNetwork,
@@ -327,16 +330,21 @@ export function registerSessionActsIpc(dependencies: SessionActsIpcDependencies)
     // go are different answers, and only the second says what to try instead.
     absentAddressReason: string,
     failureReason: string,
+    // The one open that outlives the roster row: a History chip's press. It
+    // answers only once the session has departed — while a session still
+    // stands, its current word is the whole offer, so an address its
+    // provider withdrew cannot be overruled by an older one.
+    departedAddress?: (identity: SessionIdentity) => string | undefined,
   ) =>
     registerAction<[SessionIdentity], SessionOpenResult>(definition, {
       async act(identity) {
-        if (!sessionRegistry.get(identity))
+        const observed = sessionRegistry.get(identity) !== undefined;
+        const url = observed ? address(identity) : departedAddress?.(identity);
+        if (!url)
           return {
             status: ACT_RESULT_STATUS.UNSUPPORTED,
-            reason: "No observed session matches that identity.",
+            reason: observed ? absentAddressReason : "No observed session matches that identity.",
           };
-        const url = address(identity);
-        if (!url) return { status: ACT_RESULT_STATUS.UNSUPPORTED, reason: absentAddressReason };
         await openExternal(url);
         if (isProviderId(identity.providerId)) {
           recordProductEvent(PRODUCT_EVENT.SESSION_ACT_SEND, {
@@ -359,6 +367,11 @@ export function registerSessionActsIpc(dependencies: SessionActsIpcDependencies)
     (identity) => pressedLink(sessionRegistry.get(identity)?.detail.link),
     "That session has no address to open.",
     "The system could not open that session.",
+    // A History line keeps its press after the roster lets its session go —
+    // Conductor keeps an archived chat's deep link alive — at the last
+    // address an observation pass itself reported, never one the renderer
+    // carried over the bridge.
+    (identity) => pressedLink(lastReportedSessionLink(identity)),
   );
   registerAction<[SessionIdentity, string], SessionOpenResult>(BRIDGE.openSessionApplication, {
     async act(identity, applicationId) {

--- a/apps/desktop/src/main/ipc/session-acts.ts
+++ b/apps/desktop/src/main/ipc/session-acts.ts
@@ -330,16 +330,17 @@ export function registerSessionActsIpc(dependencies: SessionActsIpcDependencies)
     // go are different answers, and only the second says what to try instead.
     absentAddressReason: string,
     failureReason: string,
-    // The one open that outlives the roster row: a History chip's press. It
-    // answers only once the session has departed — while a session still
-    // stands, its current word is the whole offer, so an address its
-    // provider withdrew cannot be overruled by an older one.
-    departedAddress?: (identity: SessionIdentity) => string | undefined,
+    // The one open that outlives the roster row: a History chip's press. A
+    // session still reporting an address opens at its current one; the
+    // remembered address answers only where the roster has nothing better,
+    // so the offer the renderer computes from what it ever saw reported can
+    // never name a chat this refuses on this-run staleness alone.
+    rememberedAddress?: (identity: SessionIdentity) => string | undefined,
   ) =>
     registerAction<[SessionIdentity], SessionOpenResult>(definition, {
       async act(identity) {
         const observed = sessionRegistry.get(identity) !== undefined;
-        const url = observed ? address(identity) : departedAddress?.(identity);
+        const url = (observed ? address(identity) : undefined) ?? rememberedAddress?.(identity);
         if (!url)
           return {
             status: ACT_RESULT_STATUS.UNSUPPORTED,

--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -2392,9 +2392,9 @@ export function App(): React.JSX.Element {
    * line's chips can outlive their roster rows: the words stay on the panel
    * after a chat is archived away, and the main process remembers the
    * departed session's last reported address on the same run lifetime. Grown
-   * from the same broadcast roster the rows draw, and consulted only once
-   * the roster no longer answers, so a session still observed offers exactly
-   * what it currently reports.
+   * from the same broadcast roster the rows draw, which every address the
+   * main process remembers also crossed, so a chip offered from here is one
+   * the press can honor.
    */
   const addressedSessionsRef = useRef<Map<string, Set<string>>>(new Map());
   useEffect(() => {
@@ -2409,6 +2409,11 @@ export function App(): React.JSX.Element {
     }
   }, [sessions]);
 
+  // Openable at the chip is exactly what the main process will open: the
+  // session's current address, or the last one this launch saw reported —
+  // the same order the open itself resolves in, so the offer and the act
+  // cannot disagree about a session the roster filtered or that withdrew
+  // its address while the memory still holds one.
   const conversationSessionOpenable = useCallback(
     (identity: SessionIdentity): boolean => {
       const session = sessions.find(
@@ -2416,10 +2421,10 @@ export function App(): React.JSX.Element {
           candidate.providerId === identity.providerId &&
           candidate.providerSessionId === identity.providerSessionId,
       );
-      if (session) return session.detail.link !== undefined;
       return (
-        addressedSessionsRef.current.get(identity.providerId)?.has(identity.providerSessionId) ??
-        false
+        session?.detail.link !== undefined ||
+        (addressedSessionsRef.current.get(identity.providerId)?.has(identity.providerSessionId) ??
+          false)
       );
     },
     [sessions],

--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -2388,6 +2388,61 @@ export function App(): React.JSX.Element {
   );
 
   /**
+   * Every session this launch reported an address for, kept so a History
+   * line's chips can outlive their roster rows: the words stay on the panel
+   * after a chat is archived away, and the main process remembers the
+   * departed session's last reported address on the same run lifetime. Grown
+   * from the same broadcast roster the rows draw, and consulted only once
+   * the roster no longer answers, so a session still observed offers exactly
+   * what it currently reports.
+   */
+  const addressedSessionsRef = useRef<Map<string, Set<string>>>(new Map());
+  useEffect(() => {
+    for (const session of sessions) {
+      if (session.detail.link === undefined) continue;
+      let provider = addressedSessionsRef.current.get(session.providerId);
+      if (!provider) {
+        provider = new Set();
+        addressedSessionsRef.current.set(session.providerId, provider);
+      }
+      provider.add(session.providerSessionId);
+    }
+  }, [sessions]);
+
+  const conversationSessionOpenable = useCallback(
+    (identity: SessionIdentity): boolean => {
+      const session = sessions.find(
+        (candidate) =>
+          candidate.providerId === identity.providerId &&
+          candidate.providerSessionId === identity.providerSessionId,
+      );
+      if (session) return session.detail.link !== undefined;
+      return (
+        addressedSessionsRef.current.get(identity.providerId)?.has(identity.providerSessionId) ??
+        false
+      );
+    },
+    [sessions],
+  );
+
+  /**
+   * A History chip's press: the row press at one remove, on the identity the
+   * line's words were recorded beside. Only the identity crosses the bridge;
+   * the main process answers with the session's current address, or its last
+   * reported one for a chat whose row has since departed. The panel stands
+   * down for the same reason a row press stands it down: the chat is being
+   * brought forward underneath it.
+   */
+  const openConversationSession = useCallback(
+    (identity: SessionIdentity) => {
+      void window.sidecar.openSession(identity);
+      cancelHover();
+      void changeMode(false);
+    },
+    [cancelHover, changeMode],
+  );
+
+  /**
    * A live push beats a bootstrap snapshot still in flight. The main process
    * will not repeat a list it believes it already announced, so the older
    * snapshot must not clobber one that raced past it.
@@ -3244,6 +3299,8 @@ export function App(): React.JSX.Element {
             conversationHistory={conversationHistory}
             liveConversationEntries={liveConversationEntries}
             onClearConversationHistory={clearConversationHistory}
+            conversationSessionOpenable={conversationSessionOpenable}
+            onOpenConversationSession={openConversationSession}
             ask={askLuke}
             // Reaching for the composer during a spent day is answered before
             // a keystroke: the caret arriving re-announces the spent caption

--- a/apps/desktop/src/renderer/conversation-history-panel.test.ts
+++ b/apps/desktop/src/renderer/conversation-history-panel.test.ts
@@ -48,6 +48,8 @@ test("an announcement shows its spoken transcript", () => {
         },
       ],
       onClear: () => undefined,
+      openable: () => false,
+      onOpenSession: () => undefined,
     }),
   );
 
@@ -67,6 +69,8 @@ test("a recorded entry shows its local time", () => {
         },
       ],
       onClear: () => undefined,
+      openable: () => false,
+      onOpenSession: () => undefined,
     }),
   );
 
@@ -81,6 +85,8 @@ test("conversation history is blocked from optional panel recordings", () => {
     createElement(ConversationHistoryPanel, {
       entries: [{ kind: CONVERSATION_ENTRY_KIND.TYPED_ASK, words: "private words" }],
       onClear: () => undefined,
+      openable: () => false,
+      onOpenSession: () => undefined,
     }),
   );
 
@@ -98,6 +104,8 @@ test("messages offer a copy control while quiet events offer none", () => {
         { kind: CONVERSATION_ENTRY_KIND.ACT, words: "Sent to Codex." },
       ],
       onClear: () => undefined,
+      openable: () => false,
+      onOpenSession: () => undefined,
     }),
   );
 
@@ -118,6 +126,8 @@ test("a line still being said draws as the bubble it will settle into", () => {
       ],
       live: [{ kind: CONVERSATION_ENTRY_KIND.ANNOUNCEMENT, words: "Checkout is" }],
       onClear: () => undefined,
+      openable: () => false,
+      onOpenSession: () => undefined,
     }),
   );
 
@@ -135,6 +145,8 @@ test("words still arriving stand the thread up without a settled line", () => {
       entries: [],
       live: [{ kind: CONVERSATION_ENTRY_KIND.REPLY, words: "Looking now." }],
       onClear: () => undefined,
+      openable: () => false,
+      onOpenSession: () => undefined,
     }),
   );
 
@@ -149,9 +161,117 @@ test("the empty history reports only its state", () => {
     createElement(ConversationHistoryPanel, {
       entries: [],
       onClear: () => undefined,
+      openable: () => false,
+      onOpenSession: () => undefined,
     }),
   );
 
   assert.match(markup, />No messages yet</);
   assert.doesNotMatch(markup, /history-header|next typed|stays in memory/);
+});
+
+test("a line's named chats draw pressable chips, worded as recorded", () => {
+  const asked: string[] = [];
+  const markup = renderToStaticMarkup(
+    createElement(ConversationHistoryPanel, {
+      entries: [
+        {
+          kind: CONVERSATION_ENTRY_KIND.REPLY,
+          words: "checkout-service is done and billing-service is waiting.",
+          mentions: [
+            {
+              providerId: "conductor",
+              providerSessionId: "chat-1",
+              title: "checkout-service",
+              markId: "claude-code",
+              applications: [{ id: "conductor", name: "Conductor" }],
+            },
+            {
+              providerId: "conductor",
+              providerSessionId: "chat-2",
+              title: "billing-service",
+              markId: "conductor",
+              applications: [],
+            },
+          ],
+        },
+        { kind: CONVERSATION_ENTRY_KIND.REPLY, words: "No session here." },
+      ],
+      onClear: () => undefined,
+      openable: (identity) => {
+        asked.push(identity.providerSessionId);
+        return true;
+      },
+      onOpenSession: () => undefined,
+    }),
+  );
+
+  assert.equal(markup.match(/class="history-chip"/g)?.length, 2);
+  assert.match(markup, /aria-label="Open checkout-service"/);
+  assert.match(markup, /aria-label="Open billing-service"/);
+  // The chip leads with the agent's mark and trails the app marks its chat's
+  // row wore when the line was recorded, exactly like the notice band's.
+  assert.match(markup, /data-mark="claude-code"/);
+  assert.match(markup, /aria-label="Also in Conductor"/);
+  // Only the chats the line named ask whether they can still be opened, and
+  // the session ids themselves stay out of the drawn markup.
+  assert.deepEqual(asked, ["chat-1", "chat-2"]);
+  assert.doesNotMatch(markup, /chat-1|chat-2/);
+});
+
+test("a chat with nowhere to go draws no chip", () => {
+  const markup = renderToStaticMarkup(
+    createElement(ConversationHistoryPanel, {
+      entries: [
+        {
+          kind: CONVERSATION_ENTRY_KIND.ANNOUNCEMENT,
+          words: "Local run finished.",
+          identity: { providerId: "claude-code", providerSessionId: "local-1" },
+          mentions: [
+            {
+              providerId: "claude-code",
+              providerSessionId: "local-1",
+              title: "local-run",
+              markId: "claude-code",
+              applications: [],
+            },
+          ],
+        },
+      ],
+      onClear: () => undefined,
+      openable: () => false,
+      onOpenSession: () => undefined,
+    }),
+  );
+
+  assert.doesNotMatch(markup, /history-chip|history-mentions/);
+});
+
+test("a quiet act line draws its chat's chip without a copy control", () => {
+  const markup = renderToStaticMarkup(
+    createElement(ConversationHistoryPanel, {
+      entries: [
+        {
+          kind: CONVERSATION_ENTRY_KIND.ACT,
+          words: "sent Checkout a message.",
+          identity: { providerId: "conductor", providerSessionId: "chat-1" },
+          mentions: [
+            {
+              providerId: "conductor",
+              providerSessionId: "chat-1",
+              title: "Checkout",
+              markId: "conductor",
+              applications: [],
+            },
+          ],
+        },
+      ],
+      onClear: () => undefined,
+      openable: () => true,
+      onOpenSession: () => undefined,
+    }),
+  );
+
+  assert.match(markup, /class="history-chip"/);
+  assert.doesNotMatch(markup, /history-copy/);
 });

--- a/apps/desktop/src/renderer/conversation-history-panel.tsx
+++ b/apps/desktop/src/renderer/conversation-history-panel.tsx
@@ -1,8 +1,10 @@
+import { ProviderMark } from "@sidecar/panel";
 import {
   CONVERSATION_ENTRY_KIND,
   type ConversationEntry,
   type ConversationEntryKind,
 } from "@sidecar/realtime";
+import type { SessionIdentity } from "@sidecar/session";
 import { useEffect, useRef, useState } from "react";
 import { PANEL_TAB, panelPanelId, panelTabId } from "./panel-tabs";
 import { CheckIcon, CopyIcon } from "./settings-icons";
@@ -41,9 +43,13 @@ const ENTRY_TIME = new Intl.DateTimeFormat(undefined, { hour: "numeric", minute:
 function HistoryEntryRow({
   entry,
   streaming,
+  openable,
+  onOpenSession,
 }: {
   entry: ConversationEntry;
   streaming?: boolean;
+  openable: (identity: SessionIdentity) => boolean;
+  onOpenSession: (identity: SessionIdentity) => void;
 }): React.JSX.Element {
   const presentation = historyEntryPresentation(entry.kind);
   const words = entry.words;
@@ -56,6 +62,12 @@ function HistoryEntryRow({
   }, [copied]);
 
   const recordedAt = entry.recordedAt === undefined ? undefined : new Date(entry.recordedAt);
+  // A chip per chat the line named, each the roster-validated identity and
+  // title the words were recorded beside, offered only while a press has
+  // somewhere to land: the session's current address, or — for a chat whose
+  // row has departed — the last one its provider reported, which the main
+  // process keeps and the press only ever names.
+  const mentions = (entry.mentions ?? []).filter((mention) => openable(mention));
 
   return (
     <li
@@ -64,32 +76,75 @@ function HistoryEntryRow({
       data-streaming={streaming ? "true" : undefined}
     >
       <small className="visually-hidden">{presentation.label}</small>
-      <p>
-        {words}
-        {recordedAt ? (
-          <time className="history-time" dateTime={recordedAt.toISOString()}>
-            {ENTRY_TIME.format(recordedAt)}
-          </time>
-        ) : null}
-      </p>
-      {/* Copying words still arriving would copy half a sentence; the control
-          appears with the settled line the same words become. */}
-      {presentation.speaker === HISTORY_ENTRY_SPEAKER.EVENT || streaming ? null : (
-        <button
-          type="button"
-          className="history-copy"
-          data-copied={copied ? "true" : undefined}
-          aria-label={copied ? "Copied" : "Copy message"}
-          onClick={() => {
-            // The visible words, never the structured model context behind an
-            // announcement: copy takes exactly what the bubble shows.
-            window.sidecar.copyText(words);
-            setCopied(true);
-          }}
-        >
-          {copied ? <CheckIcon /> : <CopyIcon />}
-        </button>
-      )}
+      {/* The bubble anchors the copy control, so a chip row wrapping wider
+          below cannot pull the glyph away from the words it copies. */}
+      <span className="history-bubble">
+        <p>
+          {words}
+          {recordedAt ? (
+            <time className="history-time" dateTime={recordedAt.toISOString()}>
+              {ENTRY_TIME.format(recordedAt)}
+            </time>
+          ) : null}
+        </p>
+        {/* Copying words still arriving would copy half a sentence; the control
+            appears with the settled line the same words become. */}
+        {presentation.speaker === HISTORY_ENTRY_SPEAKER.EVENT || streaming ? null : (
+          <button
+            type="button"
+            className="history-copy"
+            data-copied={copied ? "true" : undefined}
+            aria-label={copied ? "Copied" : "Copy message"}
+            onClick={() => {
+              // The visible words, never the structured model context behind an
+              // announcement: copy takes exactly what the bubble shows.
+              window.sidecar.copyText(words);
+              setCopied(true);
+            }}
+          >
+            {copied ? <CheckIcon /> : <CopyIcon />}
+          </button>
+        )}
+      </span>
+      {mentions.length > 0 ? (
+        <span className="history-mentions">
+          {mentions.map((mention) => (
+            <button
+              key={`${mention.providerId}:${mention.providerSessionId}`}
+              type="button"
+              className="history-chip"
+              aria-label={`Open ${mention.title}`}
+              onClick={() =>
+                onOpenSession({
+                  providerId: mention.providerId,
+                  providerSessionId: mention.providerSessionId,
+                })
+              }
+            >
+              <ProviderMark providerId={mention.markId} />
+              <span className="history-chip-name">{mention.title}</span>
+              {/* The app marks the chat's row wore when the line was recorded,
+                  saying where it is also held. Bare marks, never presses of
+                  their own: the chip is one press, like the notice band's. */}
+              {mention.applications.length > 0 ? (
+                <span className="history-chip-applications">
+                  {mention.applications.map((application) => (
+                    <span
+                      key={application.id}
+                      className="history-chip-application"
+                      role="img"
+                      aria-label={`Also in ${application.name}`}
+                      title={application.name}
+                    >
+                      <ProviderMark providerId={application.id} />
+                    </span>
+                  ))}
+                </span>
+              ) : null}
+            </button>
+          ))}
+        </span>
+      ) : null}
     </li>
   );
 }
@@ -118,6 +173,8 @@ export function ConversationHistoryPanel({
   entries,
   live = [],
   onClear,
+  openable,
+  onOpenSession,
 }: {
   entries: readonly ConversationEntry[];
   /**
@@ -126,6 +183,10 @@ export function ConversationHistoryPanel({
    */
   live?: readonly ConversationEntry[];
   onClear: () => void;
+  /** Whether a named chat still has an address a press could reach. */
+  openable: (identity: SessionIdentity) => boolean;
+  /** Hands a chip's roster-validated identity to the same open a row press takes. */
+  onOpenSession: (identity: SessionIdentity) => void;
 }): React.JSX.Element {
   const [confirmingClear, setConfirmingClear] = useState(false);
   const list = useRef<HTMLOListElement | null>(null);
@@ -198,11 +259,22 @@ export function ConversationHistoryPanel({
       ) : (
         <ol className="history-list" ref={list}>
           {keyedHistoryEntries(entries).map(({ entry, key }) => (
-            <HistoryEntryRow key={key} entry={entry} />
+            <HistoryEntryRow
+              key={key}
+              entry={entry}
+              openable={openable}
+              onOpenSession={onOpenSession}
+            />
           ))}
           {live.map((entry, index) => (
-            // biome-ignore lint/suspicious/noArrayIndexKey: A line still being said has no durable id, and its words change on every delta — a key made of either would remount the bubble mid-sentence, while its position holds still for exactly as long as the line does.
-            <HistoryEntryRow key={`live:${entry.kind}:${index}`} entry={entry} streaming />
+            <HistoryEntryRow
+              // biome-ignore lint/suspicious/noArrayIndexKey: A line still being said has no durable id, and its words change on every delta — a key made of either would remount the bubble mid-sentence, while its position holds still for exactly as long as the line does.
+              key={`live:${entry.kind}:${index}`}
+              entry={entry}
+              streaming
+              openable={openable}
+              onOpenSession={onOpenSession}
+            />
           ))}
         </ol>
       )}

--- a/apps/desktop/src/renderer/luke-guide.ts
+++ b/apps/desktop/src/renderer/luke-guide.ts
@@ -413,10 +413,14 @@ export function buildLukeGuide(input: LukeGuideInput): AppGuideSnapshot {
       label: "Conversation history",
       detail:
         "The panel's History tab shows every typed ask, transcribed spoken ask, reply, " +
-        "announcement, and session act from this app launch. Luke carries only the 20 most recent " +
-        "entries into a call. The full view stays only in this app's memory, is blocked from " +
-        "panel recordings, disappears when Luke quits, and can be cleared by hand " +
-        "from that tab. It is not saved or exportable.",
+        "announcement, and session act, kept across launches in Luke's own file on this Mac — " +
+        "up to 200 lines and 14 days, whichever cuts first. Luke carries only the 20 most " +
+        "recent entries into a call. The view is blocked from panel recordings, is not " +
+        "exportable, and can be cleared by hand from that tab. A line draws a pressable chip " +
+        "for each chat it named, going to that chat by hand; a chip keeps working for a chat " +
+        "archived since — opened at the last address its provider reported this launch — and " +
+        "a chat with no address draws none. A spoken open still reaches only sessions " +
+        "currently observed.",
     },
     {
       label: "Account",

--- a/apps/desktop/src/renderer/panel-body.tsx
+++ b/apps/desktop/src/renderer/panel-body.tsx
@@ -8,6 +8,7 @@ import {
   SESSION_CONTROL_KIND,
   SESSION_LOCATION,
   type SessionApplicationId,
+  type SessionIdentity,
 } from "@sidecar/session";
 import { SESSION_URGENCY } from "@sidecar/surface";
 import { cssCustomProperties } from "@sidecar/surface/react-css";
@@ -794,6 +795,10 @@ export interface PanelBodyProps {
   liveConversationEntries: readonly ConversationEntry[];
   /** Clears that same thread from the view, Luke's next context, and the stored file. */
   onClearConversationHistory: () => void;
+  /** Whether a chat a history line named still has an address a press could reach. */
+  conversationSessionOpenable: (identity: SessionIdentity) => boolean;
+  /** Opens one chat a history line named, by identity alone. */
+  onOpenConversationSession: (identity: SessionIdentity) => void;
   /** Carries a typed ask to Luke's own conversation, answering why it could not go. */
   ask: AskHandler;
   /** Reports someone being part-way through an ask, so the panel holds for them. */
@@ -845,6 +850,8 @@ export function PanelBody({
   conversationHistory,
   liveConversationEntries,
   onClearConversationHistory,
+  conversationSessionOpenable,
+  onOpenConversationSession,
   ask,
   onAskEngaged,
   askShortcut,
@@ -933,6 +940,8 @@ export function PanelBody({
           entries={conversationHistory}
           live={liveConversationEntries}
           onClear={onClearConversationHistory}
+          openable={conversationSessionOpenable}
+          onOpenSession={onOpenConversationSession}
         />
       ) : (
         <SessionsPanel

--- a/apps/desktop/src/renderer/styles/history.css
+++ b/apps/desktop/src/renderer/styles/history.css
@@ -231,6 +231,9 @@
 
 .history-entry[data-speaker="luke"] {
   align-self: flex-start;
+  /* Shrink-wrapped, not stretched: the bubble is the copy control's anchor,
+     and a chip row wrapping wider than the words must not widen it. */
+  align-items: flex-start;
 }
 
 .history-entry[data-speaker="luke"] p {

--- a/apps/desktop/src/renderer/styles/history.css
+++ b/apps/desktop/src/renderer/styles/history.css
@@ -73,6 +73,15 @@
   flex-direction: column;
 }
 
+/* The bubble is the copy control's anchor: a chip row wrapping wider below
+   must not pull the glyph off the words it copies. */
+.history-bubble {
+  position: relative;
+  display: flex;
+  min-width: 0;
+  max-width: 100%;
+}
+
 /* Copy sits in the bubble's free margin, absolutely positioned so a thread
    with the control lays out exactly like one without it, and hover-revealed
    because a control on every bubble would out-shout the words. It stays
@@ -115,6 +124,75 @@
 .history-copy:hover {
   background: var(--raised);
   color: var(--text-primary);
+}
+
+/* A chip per chat the line named, in the notice band's own vocabulary: the
+   words above are the record, the chips are the way back to the chats they
+   name. Always visible, unlike the copy glyph, because which chats a line
+   was about is content rather than chrome. */
+.history-mentions {
+  display: flex;
+  max-width: 100%;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-top: 4px;
+}
+
+.history-entry[data-speaker="event"] .history-mentions {
+  justify-content: center;
+}
+
+.history-chip {
+  display: inline-flex;
+  min-width: 0;
+  max-width: 100%;
+  align-items: center;
+  gap: 5px;
+  height: 20px;
+  padding: 0 9px;
+  border-radius: 10px;
+  background: var(--raised);
+  color: var(--text-primary);
+  font-size: 10px;
+  font-weight: 640;
+  transition: background-color var(--duration-hover) ease;
+}
+
+.history-chip:hover {
+  background: var(--raised-strong);
+}
+
+.history-chip .provider-mark {
+  flex: 0 0 auto;
+  width: 11px;
+  height: 11px;
+}
+
+.history-chip .provider-mark[data-mark="superset"] {
+  width: 19px;
+}
+
+.history-chip-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* App associations trail the name as bare marks, the way they trail it on the
+   notice band's chips: the leading mark says which agent this is, these say
+   where the same chat is also held, in secondary ink to stay subordinate to
+   the name inside a chip this small. */
+.history-chip-applications {
+  display: flex;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: 4px;
+  color: var(--text-secondary);
+}
+
+.history-chip-application {
+  display: grid;
+  place-items: center;
 }
 
 .history-entry p {

--- a/apps/desktop/src/renderer/use-voice-conversation.ts
+++ b/apps/desktop/src/renderer/use-voice-conversation.ts
@@ -8,6 +8,7 @@ import {
   ARRIVAL_SPEECH_KIND,
   type ArrivalSpeech,
   adoptConversationThread,
+  announcementConversationEntry,
   appendConversationThreadEntry,
   CONVERSATION_ENTRY_KIND,
   type ConversationEntry,
@@ -22,6 +23,7 @@ import {
   type RealtimeVoice,
   type RealtimeVoiceSpeed,
   recentConversationEntries,
+  replyConversationEntry,
   retainedConversationEntries,
   SESSION_TOOL_KIND,
   sessionActConversationEntry,
@@ -1057,11 +1059,7 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
           const generation = activeAnnouncementGenerationRef.current;
           activeAnnouncementGenerationRef.current = undefined;
           rememberConversationEntry(
-            {
-              kind: CONVERSATION_ENTRY_KIND.ANNOUNCEMENT,
-              words: texts.join(" "),
-              identity: about,
-            },
+            announcementConversationEntry(texts.join(" "), about, sessionsRef.current),
             generation,
           );
           return;
@@ -1072,8 +1070,12 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
         markTranscriptSpoken(false);
         // A transcript reading enters the record only as the act it was.
         if (spokeTranscript) return;
+        // The chats the reply named ride along as chips, read from its words
+        // against the roster at this moment — the same rule the notice
+        // band's chips keep — so the line can offer a way back to the chats
+        // it answered about, even after one is archived away.
         rememberConversationEntry(
-          { kind: CONVERSATION_ENTRY_KIND.REPLY, words: texts.join(" ") },
+          replyConversationEntry(texts.join(" "), sessionsRef.current),
           generation,
         );
       },

--- a/packages/realtime/src/conversation-history.test.ts
+++ b/packages/realtime/src/conversation-history.test.ts
@@ -9,6 +9,7 @@ import {
 } from "@sidecar/session";
 import {
   adoptConversationThread,
+  announcementConversationEntry,
   appendConversationEntry,
   appendConversationThreadEntry,
   CONVERSATION_ENTRY_KIND,
@@ -21,6 +22,7 @@ import {
   maximumConversationEntryLength,
   maximumStoredConversationEntries,
   recentConversationEntries,
+  replyConversationEntry,
   retainedConversationEntries,
   sessionActConversationEntry,
   storedConversationEntry,
@@ -503,4 +505,167 @@ test("adopting another window's thread reuses the entry objects already held", (
   // A cleared or diverged thread is taken as reported: entries the report no
   // longer carries do not survive the adoption.
   assert.deepEqual(adoptConversationThread([ask, reply], []), []);
+});
+
+test("a reply answering about one session records its subject and its chip", () => {
+  const sessions = [
+    rosterSession("session-a", "checkout-service"),
+    rosterSession("session-b", "billing-service"),
+  ];
+
+  const entry = replyConversationEntry("checkout-service just finished its tests.", sessions);
+  assert.equal(entry.kind, CONVERSATION_ENTRY_KIND.REPLY);
+  assert.deepEqual(entry.identity, {
+    providerId: "claude-code",
+    providerSessionId: "session-a",
+  });
+  assert.deepEqual(entry.mentions, [
+    {
+      providerId: "claude-code",
+      providerSessionId: "session-a",
+      title: "checkout-service",
+      markId: "claude-code",
+      applications: [],
+    },
+  ]);
+});
+
+test("a reply naming several sessions draws every chip but records no subject", () => {
+  const sessions = [
+    rosterSession("session-a", "checkout-service"),
+    rosterSession("session-b", "billing-service"),
+  ];
+
+  // Two chats named: a chip each, but the subject a later turn's bare "that
+  // chat" resolves through cannot choose between them.
+  const both = replyConversationEntry(
+    "checkout-service is done and billing-service is waiting.",
+    sessions,
+  );
+  assert.equal(both.identity, undefined);
+  assert.deepEqual(
+    both.mentions?.map((mention) => [mention.providerSessionId, mention.title, mention.markId]),
+    [
+      ["session-a", "checkout-service", "claude-code"],
+      ["session-b", "billing-service", "claude-code"],
+    ],
+  );
+
+  // No observed name appears whole, so nothing a model said earns a chip.
+  const neither = replyConversationEntry("Nothing is running right now.", sessions);
+  assert.equal(neither.identity, undefined);
+  assert.equal(neither.mentions, undefined);
+});
+
+test("a reply's subject is single when the identities are, not when the names were", () => {
+  // The chat's own title and its workspace's name both resolve to session-a:
+  // two mentions, one chat, one chip, still one attributable subject.
+  const chat = normalizeSession(
+    { id: "conductor", displayName: "Conductor" },
+    {
+      providerSessionId: "session-a",
+      title: "checkout-service",
+      status: SESSION_STATUS.WORKING,
+      observedAt: OBSERVED_AT,
+      workspace: { providerWorkspaceId: "ws-1", name: "hong-kong" },
+    },
+  );
+
+  const entry = replyConversationEntry("checkout-service in hong-kong is finished.", [chat]);
+  assert.deepEqual(entry.identity, {
+    providerId: "conductor",
+    providerSessionId: "session-a",
+  });
+  assert.equal(entry.mentions?.length, 1);
+});
+
+test("an announcement's line carries its one subject and that subject's chip", () => {
+  const sessions = [rosterSession("session-a", "checkout-service")];
+  const about = { providerId: "claude-code", providerSessionId: "session-a" };
+
+  const entry = announcementConversationEntry("checkout-service finished.", about, sessions);
+  assert.equal(entry.kind, CONVERSATION_ENTRY_KIND.ANNOUNCEMENT);
+  assert.deepEqual(entry.identity, about);
+  assert.equal(entry.mentions?.length, 1);
+  assert.equal(entry.mentions?.[0]?.title, "checkout-service");
+
+  // A subject the roster cannot word keeps its identity and draws no chip.
+  const unworded = announcementConversationEntry("It finished.", about, []);
+  assert.deepEqual(unworded.identity, about);
+  assert.equal(unworded.mentions, undefined);
+});
+
+test("an act's line wears its session's chip while the roster can word it", () => {
+  const sessions = [rosterSession("session-a", "checkout-service")];
+  const identity = { providerId: "claude-code", providerSessionId: "session-a" };
+
+  const acted = sessionActConversationEntry(
+    { kind: SESSION_TOOL_KIND.MESSAGE, identity, text: "ship it" },
+    sessions,
+  );
+  assert.deepEqual(acted.mentions, [
+    {
+      providerId: "claude-code",
+      providerSessionId: "session-a",
+      title: "checkout-service",
+      markId: "claude-code",
+      applications: [],
+    },
+  ]);
+
+  const departed = sessionActConversationEntry({ kind: SESSION_TOOL_KIND.OPEN, identity }, []);
+  assert.deepEqual(departed.identity, identity);
+  assert.equal(departed.mentions, undefined);
+});
+
+test("a line's chips survive the append, the store, and the read back", () => {
+  const mentions = [
+    {
+      providerId: "conductor",
+      providerSessionId: "chat-1",
+      title: "checkout-service",
+      markId: "claude-code",
+      applications: [{ id: "conductor", name: "Conductor" }],
+    },
+  ];
+  const appended = appendConversationThreadEntry(
+    [],
+    { kind: CONVERSATION_ENTRY_KIND.REPLY, words: "checkout-service is done.", mentions },
+    OBSERVED_AT,
+  );
+  assert.deepEqual(appended[0]?.mentions, mentions);
+
+  // The stored round trip keeps the chips exactly, so a restart or another
+  // display's panel draws the same row of ways back.
+  const stored = storedConversationEntry(JSON.parse(JSON.stringify(appended[0])));
+  assert.deepEqual(stored?.mentions, mentions);
+});
+
+test("a stored line whose mentions this build cannot read drops whole", () => {
+  const line = {
+    kind: CONVERSATION_ENTRY_KIND.REPLY,
+    words: "checkout-service is done.",
+    recordedAt: OBSERVED_AT,
+  };
+  // Absent mentions are an older build's record and read back fine.
+  assert.ok(storedConversationEntry(line));
+  // A mentions list from another spelling refuses the line, like a misspelled
+  // identity: half a chip row would press for chats it cannot name.
+  assert.equal(storedConversationEntry({ ...line, mentions: "checkout" }), undefined);
+  assert.equal(storedConversationEntry({ ...line, mentions: [{ title: "checkout" }] }), undefined);
+  assert.equal(
+    storedConversationEntry({
+      ...line,
+      mentions: [
+        {
+          providerId: "conductor",
+          providerSessionId: "chat-1",
+          title: "checkout-service",
+          markId: "claude-code",
+          applications: [{ id: "conductor" }],
+        },
+      ],
+    }),
+    undefined,
+  );
 });

--- a/packages/realtime/src/conversation-history.ts
+++ b/packages/realtime/src/conversation-history.ts
@@ -30,7 +30,14 @@
  * app" was itself a policy and persisting means replacing it with a real one.
  */
 
-import type { Session, SessionIdentity } from "@sidecar/session";
+import {
+  MAXIMUM_MENTIONED_SESSIONS,
+  mentionedSessions,
+  SESSION_MENTION_KIND,
+  type Session,
+  type SessionIdentity,
+  type SessionMentionKind,
+} from "@sidecar/session";
 import { isRecord, isWireNumber, isWireString, type UnparsedWireValue } from "@sidecar/wire";
 import { SESSION_NO_LONGER_OBSERVED_NOTE } from "./realtime-protocol.js";
 import { actNarration, type CarriedSessionAction } from "./realtime-tools.js";
@@ -87,6 +94,30 @@ export const maximumConversationEntryLength = 400;
 export const maximumStoredConversationEntries = 200;
 export const storedConversationMaximumAgeMs = 14 * 24 * 60 * 60 * 1000;
 
+/** One app mark trailing a chip's name, as the chat's own row wore it at the entry. */
+export interface ConversationEntryMentionApplication {
+  id: string;
+  name: string;
+}
+
+/** One chat a line named, as the roster reported it at the moment of the entry. */
+export interface ConversationEntryMention extends SessionIdentity {
+  /**
+   * The title the roster read when the line was recorded: the label its chip
+   * wears. History is a record, so a later rename does not rewrite it, and a
+   * chat the roster has since let go still has a worded way back.
+   */
+  title: string;
+  /**
+   * The mark the chip leads with — the agent having the conversation, the
+   * same identity the session's own row and the notice band's chips lead
+   * with — falling back to the provider where no agent was reported.
+   */
+  markId: string;
+  /** The app marks trailing the name, less the one the leading mark already draws. */
+  applications: readonly ConversationEntryMentionApplication[];
+}
+
 export interface ConversationEntry {
   kind: ConversationEntryKind;
   /**
@@ -110,6 +141,20 @@ export interface ConversationEntry {
    * retention's clock and never enters model context.
    */
   recordedAt?: number;
+  /**
+   * The chats the line named, for the History panel's chips alone. Each is
+   * an identity the roster reported at the moment of the entry, with the
+   * title it wore then — never anything a model composed — and none of it is
+   * ever rendered into model context: {@link conversationHistoryText}
+   * carries `identity` and nothing of this list, so however many chats a
+   * line names, the model's window pays for one subject at most. A chip's
+   * press hands its identity — never an address — back to the main process,
+   * which answers from what observation itself reported, which is what lets
+   * the press outlast the roster row for a chat archived away. Persisting a
+   * line keeps its chips: labels the roster read on this machine, stored in
+   * Luke's own file beside the words that named them and nowhere else.
+   */
+  mentions?: readonly ConversationEntryMention[];
 }
 
 /**
@@ -126,6 +171,7 @@ export function appendConversationThreadEntry(
   if (!words) return entries;
   const appended: ConversationEntry = { kind: entry.kind, words, recordedAt: now };
   if (entry.identity) appended.identity = entry.identity;
+  if (entry.mentions && entry.mentions.length > 0) appended.mentions = entry.mentions;
   return retainedConversationEntries([...entries, appended], now);
 }
 
@@ -256,8 +302,110 @@ export function sessionActConversationEntry(
 ): ConversationEntry {
   const words = actNarration(action, sessions);
   const entry: ConversationEntry = { kind: CONVERSATION_ENTRY_KIND.ACT, words };
-  if ("identity" in action) entry.identity = action.identity;
+  if ("identity" in action) {
+    entry.identity = action.identity;
+    const mention = rosterMention(action.identity, sessions);
+    if (mention) entry.mentions = [mention];
+  }
   return entry;
+}
+
+/**
+ * The history line an announcement leaves behind: the spoken words, the one
+ * roster-validated subject the update was about, and that subject's chip.
+ * The subject stays the whole answer however many sessions the sentence
+ * brushes past — the same rule the notice band keeps while it speaks.
+ */
+export function announcementConversationEntry(
+  words: string,
+  about: SessionIdentity,
+  sessions: readonly Session[],
+): ConversationEntry {
+  const entry: ConversationEntry = {
+    kind: CONVERSATION_ENTRY_KIND.ANNOUNCEMENT,
+    words,
+    identity: about,
+  };
+  const mention = rosterMention(about, sessions);
+  if (mention) entry.mentions = [mention];
+  return entry;
+}
+
+/**
+ * The history line a conversation reply leaves behind, with the chats it
+ * answered about when the words say so attributably. A reply carries no
+ * subject of its own, so its chats are read the way the notice band reads
+ * its chips: the reply's words matched whole against the observed roster's
+ * own names, under the mention rules' minimum-length and ambiguity bounds,
+ * so nothing a model said can name a session the roster does not observe.
+ * Every chat named earns a chip; only an answer about exactly one also
+ * records it as the line's subject, because the subject is what a later
+ * turn's bare "that chat" resolves through, and several cannot say which.
+ */
+export function replyConversationEntry(
+  words: string,
+  sessions: readonly Session[],
+): ConversationEntry {
+  const entry: ConversationEntry = { kind: CONVERSATION_ENTRY_KIND.REPLY, words };
+  const named = new Map<string, Map<string, ConversationEntryMention>>();
+  for (const mentioned of mentionedSessions(words, sessions)) {
+    const mention = rosterMention(mentioned, sessions, mentioned.kind);
+    if (!mention) continue;
+    let provider = named.get(mention.providerId);
+    if (!provider) {
+      provider = new Map();
+      named.set(mention.providerId, provider);
+    }
+    provider.set(mention.providerSessionId, mention);
+  }
+  // A title mention and its workspace's may resolve to the same chat; the
+  // subject is single when the identities are, not when the names were.
+  const mentions = [...named.values()].flatMap((provider) => [...provider.values()]);
+  if (mentions.length === 0) return entry;
+  entry.mentions = mentions;
+  const [subject] = mentions;
+  if (subject && mentions.length === 1) {
+    entry.identity = {
+      providerId: subject.providerId,
+      providerSessionId: subject.providerSessionId,
+    };
+  }
+  return entry;
+}
+
+/**
+ * The chip one identity earns — its roster row's title, marks, and app
+ * associations, or nothing off-roster. A mention made by a workspace's name
+ * wears that name, since those are the words that named it; every other chip
+ * wears the chat's own title.
+ */
+function rosterMention(
+  identity: SessionIdentity,
+  sessions: readonly Session[],
+  namedAs?: SessionMentionKind,
+): ConversationEntryMention | undefined {
+  const session = sessions.find(
+    (candidate) =>
+      candidate.providerId === identity.providerId &&
+      candidate.providerSessionId === identity.providerSessionId,
+  );
+  if (!session) return undefined;
+  const markId = session.agent?.id ?? session.providerId;
+  return {
+    providerId: identity.providerId,
+    providerSessionId: identity.providerSessionId,
+    title:
+      namedAs === SESSION_MENTION_KIND.WORKSPACE && session.workspace?.name !== undefined
+        ? session.workspace.name
+        : session.title,
+    markId,
+    // An app the leading mark already stands for — a provider that is itself
+    // the app, standing in where no agent was reported — would draw the same
+    // mark twice on one chip.
+    applications: session.applications.flatMap((application) =>
+      application.id === markId ? [] : [{ id: application.id, name: application.displayName }],
+    ),
+  };
 }
 
 /**
@@ -341,6 +489,8 @@ export function storedConversationEntry(value: UnparsedWireValue): ConversationE
   ) {
     return undefined;
   }
+  const mentions = value.mentions === undefined ? [] : storedEntryMentions(value.mentions);
+  if (mentions === undefined) return undefined;
   return {
     kind: value.kind,
     words,
@@ -348,7 +498,50 @@ export function storedConversationEntry(value: UnparsedWireValue): ConversationE
     ...(isWireString(providerId) && isWireString(providerSessionId)
       ? { identity: { providerId, providerSessionId } }
       : undefined),
+    ...(mentions.length > 0 ? { mentions } : undefined),
   };
+}
+
+/**
+ * Parses a stored line's chips back, or refuses the line's mentions whole:
+ * like a misspelled identity, a mentions list this build cannot read means a
+ * record from another spelling, and half a chip row would press for chats it
+ * cannot name. The count bound is the mention rules' own — nothing this build
+ * records can exceed it, so a longer list is not this build's record.
+ */
+function storedEntryMentions(
+  value: UnparsedWireValue,
+): readonly ConversationEntryMention[] | undefined {
+  if (!Array.isArray(value) || value.length > MAXIMUM_MENTIONED_SESSIONS) return undefined;
+  const mentions: ConversationEntryMention[] = [];
+  for (const mention of value) {
+    if (!isRecord(mention)) return undefined;
+    const { providerId, providerSessionId, title, markId, applications } = mention;
+    if (
+      !isWireString(providerId) ||
+      providerId.length === 0 ||
+      !isWireString(providerSessionId) ||
+      providerSessionId.length === 0 ||
+      !isWireString(title) ||
+      title.length === 0 ||
+      !isWireString(markId) ||
+      markId.length === 0 ||
+      !Array.isArray(applications)
+    ) {
+      return undefined;
+    }
+    const marks: ConversationEntryMentionApplication[] = [];
+    for (const application of applications) {
+      if (!isRecord(application)) return undefined;
+      const { id, name } = application;
+      if (!isWireString(id) || id.length === 0 || !isWireString(name) || name.length === 0) {
+        return undefined;
+      }
+      marks.push({ id, name });
+    }
+    mentions.push({ providerId, providerSessionId, title, markId, applications: marks });
+  }
+  return mentions;
 }
 
 /**

--- a/packages/realtime/src/index.ts
+++ b/packages/realtime/src/index.ts
@@ -6,11 +6,14 @@ export {
 } from "@sidecar/hosted";
 export {
   adoptConversationThread,
+  announcementConversationEntry,
   appendConversationEntry,
   appendConversationThreadEntry,
   CONVERSATION_ENTRY_KIND,
   type ConversationEntry,
   type ConversationEntryKind,
+  type ConversationEntryMention,
+  type ConversationEntryMentionApplication,
   conversationHistoryText,
   insertSpokenAskEntry,
   insertSpokenAskThreadEntry,
@@ -19,6 +22,7 @@ export {
   maximumConversationEntryLength,
   maximumStoredConversationEntries,
   recentConversationEntries,
+  replyConversationEntry,
   retainedConversationEntries,
   sessionActConversationEntry,
   storedConversationEntry,

--- a/packages/session/src/index.ts
+++ b/packages/session/src/index.ts
@@ -112,6 +112,7 @@ export {
   type SessionFilterAxis,
   sessionFilterAxis,
 } from "./session-filter.js";
+export { ReportedSessionLinks } from "./session-links.js";
 export {
   firstWholeNameIndex,
   MAXIMUM_MENTIONED_SESSIONS,

--- a/packages/session/src/session-links.test.ts
+++ b/packages/session/src/session-links.test.ts
@@ -1,0 +1,74 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  normalizeSession,
+  ReportedSessionLinks,
+  SESSION_STATUS,
+  type Session,
+  type SessionProvider,
+} from "@sidecar/session";
+
+const conductor: SessionProvider = { id: "conductor", displayName: "Conductor" };
+const cursor: SessionProvider = { id: "cursor", displayName: "Cursor" };
+
+function session(provider: SessionProvider, providerSessionId: string, link?: string): Session {
+  return normalizeSession(provider, {
+    providerSessionId,
+    title: `Session ${providerSessionId}`,
+    status: SESSION_STATUS.WORKING,
+    observedAt: 100,
+    detail: link ? { link } : {},
+  });
+}
+
+test("remembers the last address a session reported, outliving the roster row", () => {
+  const links = new ReportedSessionLinks();
+  links.remember([session(conductor, "chat-1", "conductor://workspace?id=w1&session=chat-1")]);
+
+  // The pass that no longer lists the session — archived away — erases nothing.
+  links.remember([session(conductor, "chat-2")]);
+
+  assert.equal(
+    links.lastReported({ providerId: conductor.id, providerSessionId: "chat-1" }),
+    "conductor://workspace?id=w1&session=chat-1",
+  );
+});
+
+test("the latest reported address wins", () => {
+  const links = new ReportedSessionLinks();
+  links.remember([session(conductor, "chat-1", "conductor://workspace?id=w1&session=chat-1")]);
+  links.remember([session(conductor, "chat-1", "conductor://workspace?id=w2&session=chat-1")]);
+
+  assert.equal(
+    links.lastReported({ providerId: conductor.id, providerSessionId: "chat-1" }),
+    "conductor://workspace?id=w2&session=chat-1",
+  );
+});
+
+test("a pass reporting the session with no address keeps the last one", () => {
+  const links = new ReportedSessionLinks();
+  links.remember([session(conductor, "chat-1", "conductor://workspace?id=w1&session=chat-1")]);
+  links.remember([session(conductor, "chat-1")]);
+
+  assert.equal(
+    links.lastReported({ providerId: conductor.id, providerSessionId: "chat-1" }),
+    "conductor://workspace?id=w1&session=chat-1",
+  );
+});
+
+test("an identity answers only under its own provider, and never unreported", () => {
+  const links = new ReportedSessionLinks();
+  links.remember([
+    session(conductor, "chat-1", "conductor://workspace?id=w1&session=chat-1"),
+    session(cursor, "chat-1"),
+  ]);
+
+  assert.equal(
+    links.lastReported({ providerId: cursor.id, providerSessionId: "chat-1" }),
+    undefined,
+  );
+  assert.equal(
+    links.lastReported({ providerId: conductor.id, providerSessionId: "chat-9" }),
+    undefined,
+  );
+});

--- a/packages/session/src/session-links.ts
+++ b/packages/session/src/session-links.ts
@@ -1,0 +1,44 @@
+import type { Session, SessionIdentity } from "./session.js";
+
+/**
+ * The last address each observed session reported, for the run's lifetime.
+ *
+ * The registry replaces a provider's sessions wholesale on every pass, so a
+ * chat filed away — archived in its provider, or settled off the roster —
+ * takes its address with it, while the History tab keeps the line that named
+ * it. This memory is what lets that line's chip still open the chat: an
+ * entry exists only for an identity an observation pass itself reported with
+ * an address, holds exactly the address normalization already admitted, and
+ * is read back by identity, so nothing composed — by a model or by the
+ * renderer — can reach the operating system through it. It lives in
+ * main-process memory and dies with the run, the same lifetime as the
+ * history whose presses it answers.
+ *
+ * A session that later reports no address keeps its last one here: while the
+ * session still stands on the roster, its current word is the whole offer
+ * and this memory is never consulted, so an address a provider withdrew can
+ * only answer again once the session itself has departed.
+ */
+export class ReportedSessionLinks {
+  /** Last links keyed by the original identifiers, never a composite string. */
+  readonly #links = new Map<string, Map<string, string>>();
+
+  /** Consumes one observation commit, keeping the latest address per session. */
+  remember(sessions: readonly Session[]): void {
+    for (const session of sessions) {
+      const link = session.detail.link;
+      if (link === undefined) continue;
+      let provider = this.#links.get(session.providerId);
+      if (!provider) {
+        provider = new Map();
+        this.#links.set(session.providerId, provider);
+      }
+      provider.set(session.providerSessionId, link);
+    }
+  }
+
+  /** The last address this identity reported, or nothing for one never reported. */
+  lastReported(identity: SessionIdentity): string | undefined {
+    return this.#links.get(identity.providerId)?.get(identity.providerSessionId);
+  }
+}

--- a/packages/session/src/session-links.ts
+++ b/packages/session/src/session-links.ts
@@ -14,10 +14,12 @@ import type { Session, SessionIdentity } from "./session.js";
  * main-process memory and dies with the run, the same lifetime as the
  * history whose presses it answers.
  *
- * A session that later reports no address keeps its last one here: while the
- * session still stands on the roster, its current word is the whole offer
- * and this memory is never consulted, so an address a provider withdrew can
- * only answer again once the session itself has departed.
+ * A session that later reports no address keeps its last one here, and the
+ * open consults this memory only where the roster has nothing better: a
+ * session still reporting an address opens at its current one, and the
+ * remembered address answers for a chat departed, filtered from the drawn
+ * roster, or standing with its address withdrawn — every case where the
+ * words on the History line still name somewhere this run actually saw.
  */
 export class ReportedSessionLinks {
   /** Last links keyed by the original identifiers, never a composite string. */


### PR DESCRIPTION
## What

Each History line now draws a pressable chip per chat it attributably named, and a chip's press opens that chat the way its row press would — including for chats archived since.

- **Chips on history lines** (`conversation-history-panel.tsx`, `history.css`): a line with recorded mentions draws a chip row under its bubble, in the notice band's own vocabulary — leading agent mark (`ProviderMark`), title, trailing app marks as bare `role="img"` spans. The chip is one press; only the roster-validated identity crosses the bridge. The copy control is re-anchored to a new `.history-bubble` wrapper so a chip row wrapping wider than the bubble cannot pull the glyph off the words it copies.
- **Mentions recorded at the moment of the entry** (`packages/realtime/src/conversation-history.ts`): `ConversationEntry` gains `mentions` — identity, title, `markId` (`session.agent?.id ?? providerId`, the row's own rule), and app associations, all read from the roster when the line lands, never from a model's words alone. Replies get one mention per chat their words name whole, under `mentionedSessions`'s existing minimum-length/ambiguity/cap rules (new `replyConversationEntry`; a single-subject reply also records `identity`, so a later "open that chat" resolves). Announcements keep their one validated subject (new `announcementConversationEntry`), and session acts wear their session's chip. Nothing of this enters model context: `conversationHistoryText` still renders `identity` alone.
- **Persistence and relay carry chips**: `storedConversationEntry` parses `mentions` defensively (a malformed list drops the line whole, like a misspelled identity; length is bounded by the mention rules' own cap), so chips survive the multi-window relay and the `conversation.json` round trip that #589 introduced.
- **A chip outlives its roster row** (`packages/session/src/session-links.ts`, `session-acts.ts`, `desktop-app.ts`): new `ReportedSessionLinks` remembers, in main-process memory for the run, the last address each observed session reported. `openSession` falls back to it only once the roster no longer answers — a session still observed offers exactly what it currently reports — so an archived Conductor chat's still-working deep link keeps opening from its line. The renderer offers a chip only where a press can land (current address, or ever-addressed this run, tracked in `app.tsx`).
- Docs kept true in the same change: the AGENTS.md open-press bullet now names the History chip press and its bounds, and Luke's self-knowledge guide describes chips — plus a correction to the same guide fact, which still said history "disappears when Luke quits" after #589 made it persist.

## Why

The History tab kept the words of announcements, answers, and acts, but the chats they named were dead ends — especially archived ones, whose deep links still open fine in Conductor. Chips give every line a worded way back, handle answers that name several chats, and stay inside the existing trust shape: identities only over the bridge, addresses only ever ones an observation pass itself reported, model context unwidened.

## How verified

This branch was authored in a Linux cloud workspace, so the honest picture:

- `./scripts/check.sh` — **passed** (exit 0): repository checks, types, tests, and builds; all 25 workspace test groups report 0 failures.
- New tests: mention construction (reply single/multi/none, workspace-name dedup, announcement subject, act chip, off-roster fallback), stored round-trip and malformed-mentions refusal, `ReportedSessionLinks` retention, and panel markup (chips with marks and `Open <title>` labels, non-openable chats drawing none, act lines chipped without a copy control).
- `./scripts/verify.sh` / evidence capture — **not run**: macOS-only, no Mac in this environment. **No physical-notch check was performed.** The chip row (spacing beside the timestamped bubbles, wrap behavior, event-line centering) should be eyeballed via the CI evidence or a local run before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/af01cd49-d33a-46d9-8b41-125ea13cba25)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/33543632066/artifacts/9814656781) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/33543632066)

- Commit: `66f6f74f07706e4173b5f7254724fd5a54d74f6c`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
