### PR TITLE
feat(hosted): carry the workspace agent table to mobile and take a selection back

### DIFF
--- a/apps/web/server/hosted/act-execute.ts
+++ b/apps/web/server/hosted/act-execute.ts
@@ -10,6 +10,7 @@ import {
   type SessionProviderAdapter,
   VAULT_PROVIDER_ID,
   type VaultProviderId,
+  type WorkspaceAgentSelection,
 } from "../core.js";
 import {
   CURSOR_PROJECT_REFRESH,
@@ -362,10 +363,12 @@ export async function executeCreateWorkspaceAct(options: {
   providerProjectId: string;
   name: string | undefined;
   task: string | undefined;
+  /** Already validated against the build's table by the handler. */
+  agentSelection?: WorkspaceAgentSelection;
   apiKey: string;
   seams?: ActExecuteSeams;
 }): Promise<ActExecutionAnswer> {
-  const { providerId, providerProjectId, name, task, apiKey } = options;
+  const { providerId, providerProjectId, name, task, agentSelection, apiKey } = options;
   const guarded = capabilityGuard(MOBILE_SESSION_ACT.CREATE_WORKSPACE, providerId);
   if (guarded) return guarded;
 
@@ -388,6 +391,6 @@ export async function executeCreateWorkspaceAct(options: {
     };
   }
   return fromProviderWorkspaceResult(
-    await pass.adapter.createWorkspace({ providerProjectId, name, task }),
+    await pass.adapter.createWorkspace({ providerProjectId, name, task, agentSelection }),
   );
 }

--- a/apps/web/server/hosted/act-workspace.ts
+++ b/apps/web/server/hosted/act-workspace.ts
@@ -3,11 +3,14 @@ import {
   type HostedActResult,
   type HostedActWorkspaceAnswer,
   isRecord,
+  parseWorkspaceAgentSelection,
   sessionMessageText,
   text,
   type UnparsedWireValue,
   VAULT_PROVIDER_ID,
   type VaultProviderId,
+  type WireValue,
+  type WorkspaceAgentSelection,
   workspaceNameText,
 } from "../core.js";
 import { decryptProviderKey } from "./encryption.js";
@@ -64,6 +67,7 @@ export interface ActWorkspaceOptions {
     providerProjectId: string;
     name: string | undefined;
     task: string | undefined;
+    agentSelection: WorkspaceAgentSelection | undefined;
     apiKey: string;
   }) => Promise<ActWorkspaceExecuteResult>;
 }
@@ -129,6 +133,22 @@ export async function handleActWorkspace(options: ActWorkspaceOptions): Promise<
     return errorResponse(HOSTED_HTTP_STATUS.BAD_REQUEST, HOSTED_API_ERROR.INVALID_REQUEST);
   }
 
+  // An agent choice must be one the build's own table lists for this
+  // provider — the same gate the desktop's stores, offers, and adapters all
+  // answer to — so a request carrying any of the three fields either parses
+  // whole against that table or is invalid, never trimmed to something else.
+  let agentSelection: WorkspaceAgentSelection | undefined;
+  const selectionFields: Record<string, WireValue> = {};
+  if (body.agent !== undefined) selectionFields.agent = body.agent;
+  if (body.model !== undefined) selectionFields.model = body.model;
+  if (body.effort !== undefined) selectionFields.effort = body.effort;
+  if (Object.keys(selectionFields).length > 0) {
+    agentSelection = parseWorkspaceAgentSelection(providerId, selectionFields);
+    if (!agentSelection) {
+      return errorResponse(HOSTED_HTTP_STATUS.BAD_REQUEST, HOSTED_API_ERROR.INVALID_REQUEST);
+    }
+  }
+
   const unsupported = unsupportedReason(providerId);
   if (unsupported) {
     const answer: HostedActWorkspaceAnswer = {
@@ -159,6 +179,7 @@ export async function handleActWorkspace(options: ActWorkspaceOptions): Promise<
     providerProjectId,
     name,
     task,
+    agentSelection,
     apiKey,
   });
 

--- a/apps/web/server/hosted/projects.ts
+++ b/apps/web/server/hosted/projects.ts
@@ -1,9 +1,11 @@
 import type { CloudFetch } from "../../../../packages/providers/src/shared/cloud-session-adapter.js";
 import {
+  type HostedWorkspaceAgentModels,
   type HostedWorkspaceProject,
   VAULT_PROVIDER_ID,
   type VaultProviderId,
   type WorkspaceProject,
+  workspaceAgentModels,
 } from "../core.js";
 import { actUnsupportedReason, MOBILE_SESSION_ACT } from "./act-execute.js";
 import { CURSOR_PROJECT_REFRESH, cloudSessionAdapterFor } from "./cloud-adapters.js";
@@ -103,15 +105,29 @@ export async function handleProjects(options: ProjectsOptions): Promise<Response
   );
 
   const projects: HostedWorkspaceProject[] = [];
+  const agentModels: HostedWorkspaceAgentModels[] = [];
   for (const [i, providerId] of providers.entries()) {
     const result = results[i];
     if (result?.status !== "fulfilled") continue;
     for (const project of result.value) {
       projects.push(toWireProject(providerId, project));
     }
+    // The build's own agent table for each provider that actually offered a
+    // project — documented state riding beside the observed state it applies
+    // to, so a provider with nowhere to create advertises no choices either.
+    if (result.value.length > 0) {
+      for (const entry of workspaceAgentModels(providerId)) {
+        agentModels.push({
+          providerId,
+          agent: entry.agent,
+          models: entry.models.map((model) => ({ id: model.id, label: model.label })),
+          efforts: [...entry.efforts],
+        });
+      }
+    }
   }
 
-  return jsonResponse(HOSTED_HTTP_STATUS.OK, { projects });
+  return jsonResponse(HOSTED_HTTP_STATUS.OK, { projects, agentModels });
 }
 
 function toWireProject(

--- a/apps/web/tests/hosted-acts.test.ts
+++ b/apps/web/tests/hosted-acts.test.ts
@@ -441,3 +441,80 @@ test("a workspace creation naming an unreported project is rejected without a wr
   assert.equal(answer.result, "rejected");
   assert.equal(answer.reason, "Project not found.");
 });
+
+// --- The workspace act's agent selection is held to the build's table ---
+
+test("a listed agent selection reaches the executor whole", async () => {
+  let received: unknown;
+  const response = await handleActWorkspace(
+    workspaceOptions({
+      request: workspaceRequest({
+        providerId: "conductor",
+        providerProjectId: "project-1",
+        task: "build the thing",
+        agent: "claude",
+        model: "fable-5",
+        effort: "high",
+      }),
+      executeCreateWorkspace: async (options) => {
+        received = options.agentSelection;
+        return { result: "accepted" };
+      },
+    }),
+  );
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(received, { agent: "claude", model: "fable-5", effort: "high" });
+});
+
+test("an agent selection outside the build's table is an invalid request", async () => {
+  const response = await handleActWorkspace(
+    workspaceOptions({
+      request: workspaceRequest({
+        providerId: "conductor",
+        providerProjectId: "project-1",
+        task: "build the thing",
+        agent: "claude",
+        model: "not-a-listed-model",
+      }),
+      executeCreateWorkspace: async () => {
+        throw new Error("executeCreateWorkspace must not run for an unlisted selection");
+      },
+    }),
+  );
+
+  assert.equal(response.status, 400);
+});
+
+test("a selection for a provider with no table is an invalid request", async () => {
+  const response = await handleActWorkspace(
+    workspaceOptions({
+      request: workspaceRequest({
+        providerId: "cursor",
+        providerProjectId: "https://github.com/owner/repo",
+        task: "build the thing",
+        agent: "claude",
+        model: "fable-5",
+      }),
+      executeCreateWorkspace: async () => {
+        throw new Error("executeCreateWorkspace must not run for an unlisted selection");
+      },
+    }),
+  );
+
+  assert.equal(response.status, 400);
+});
+
+test("no selection fields is no selection, never a guess", async () => {
+  let received: unknown = "unset";
+  await handleActWorkspace(
+    workspaceOptions({
+      executeCreateWorkspace: async (options) => {
+        received = options.agentSelection;
+        return { result: "accepted" };
+      },
+    }),
+  );
+
+  assert.equal(received, undefined);
+});

--- a/apps/web/tests/hosted-acts.test.ts
+++ b/apps/web/tests/hosted-acts.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { text } from "../server/core";
+import { text, type WorkspaceAgentSelection } from "../server/core";
 import {
   actUnsupportedReason,
   executeControlAct,
@@ -445,7 +445,7 @@ test("a workspace creation naming an unreported project is rejected without a wr
 // --- The workspace act's agent selection is held to the build's table ---
 
 test("a listed agent selection reaches the executor whole", async () => {
-  let received: unknown;
+  let received: WorkspaceAgentSelection | undefined;
   const response = await handleActWorkspace(
     workspaceOptions({
       request: workspaceRequest({
@@ -506,15 +506,18 @@ test("a selection for a provider with no table is an invalid request", async () 
 });
 
 test("no selection fields is no selection, never a guess", async () => {
-  let received: unknown = "unset";
+  let received: WorkspaceAgentSelection | undefined;
+  let ran = false;
   await handleActWorkspace(
     workspaceOptions({
       executeCreateWorkspace: async (options) => {
         received = options.agentSelection;
+        ran = true;
         return { result: "accepted" };
       },
     }),
   );
 
+  assert.equal(ran, true);
   assert.equal(received, undefined);
 });

--- a/apps/web/tests/hosted-projects.test.ts
+++ b/apps/web/tests/hosted-projects.test.ts
@@ -151,3 +151,68 @@ test("hostedProjectsAnswerFromWire skips malformed entries rather than failing",
   assert.equal(answer.projects[0]?.providerProjectId, "proj-1");
   assert.equal(answer.projects[0]?.targetName, "Main host");
 });
+
+// --- The build's agent table rides beside the projects it applies to ---
+
+test("a provider that offered a project carries its agent table on the answer", async () => {
+  const ciphertext = encryptProviderKey("conductor-key", SECRET);
+  const response = await handleProjects(
+    projectsOptions({
+      readVaultKeys: async (): Promise<VaultKeyRow[]> => [{ providerId: "conductor", ciphertext }],
+      fetch: async (url) => {
+        if (url.endsWith("/me")) {
+          return new Response(JSON.stringify({ userId: "u1" }), { status: 200 });
+        }
+        if (url.includes("/v0/projects")) {
+          return new Response(
+            JSON.stringify({
+              data: [{ id: "proj-1", gitRemote: "https://github.com/owner/repo", name: "Repo" }],
+            }),
+            { status: 200 },
+          );
+        }
+        return new Response(JSON.stringify({ data: [] }), { status: 200 });
+      },
+    }),
+  );
+
+  assert.equal(response.status, 200);
+  const body = await response.json();
+  assert.equal(body.projects.length, 1);
+  assert.equal(body.projects[0].providerId, "conductor");
+  assert.equal(body.projects[0].taskSupport, "optional");
+  const agents = body.agentModels.map((entry: { agent: string }) => entry.agent);
+  assert.deepEqual(agents, ["claude", "codex", "cursor"]);
+  assert.ok(
+    body.agentModels[0].models.some(
+      (model: { id: string; label: string }) => model.id === "fable-5" && model.label === "Fable 5",
+    ),
+  );
+
+  const answer = hostedProjectsAnswerFromWire(body);
+  assert.ok(answer);
+  assert.equal(answer.agentModels.length, 3);
+});
+
+test("a provider with no table offers projects and no agent choices", async () => {
+  const ciphertext = encryptProviderKey("cursor-key", SECRET);
+  const response = await handleProjects(
+    projectsOptions({
+      readVaultKeys: async (): Promise<VaultKeyRow[]> => [{ providerId: "cursor", ciphertext }],
+      fetch: async (url) => {
+        if (url.includes("/v1/repositories")) {
+          return new Response(
+            JSON.stringify({ items: [{ url: "https://github.com/owner/repo" }] }),
+            { status: 200 },
+          );
+        }
+        return new Response(JSON.stringify({ items: [] }), { status: 200 });
+      },
+    }),
+  );
+
+  assert.equal(response.status, 200);
+  const body = await response.json();
+  assert.equal(body.projects.length, 1);
+  assert.deepEqual(body.agentModels, []);
+});

--- a/packages/hosted/src/hosted-service.ts
+++ b/packages/hosted/src/hosted-service.ts
@@ -496,9 +496,26 @@ export interface HostedWorkspaceProject {
   targetName?: string;
 }
 
+/**
+ * One agent kind a provider's creation endpoint takes, with the models and
+ * effort levels the build's table lists for it — `WORKSPACE_AGENT_MODELS`
+ * from `@sidecar/session`, flattened onto the wire with its provider id. The
+ * table is documented state fixed by the build, so mobile reading it here
+ * offers exactly what the desktop offers, and the workspace act validates a
+ * chosen selection against the same table again server-side.
+ */
+export interface HostedWorkspaceAgentModels {
+  providerId: string;
+  agent: string;
+  models: { id: string; label: string }[];
+  efforts: string[];
+}
+
 /** The projects endpoint answer: where the caller's keys can create a workspace. */
 export interface HostedProjectsAnswer {
   projects: HostedWorkspaceProject[];
+  /** Agent choices for providers in `projects` whose creation takes one. */
+  agentModels: HostedWorkspaceAgentModels[];
 }
 
 const WORKSPACE_TASK_SUPPORT_SET: ReadonlySet<string> = new Set(
@@ -529,6 +546,29 @@ function hostedWorkspaceProjectFromWire(
   return project;
 }
 
+function hostedWorkspaceAgentModelsFromWire(
+  value: UnparsedWireValue,
+): HostedWorkspaceAgentModels | undefined {
+  if (!isRecord(value)) return undefined;
+  const providerId = text(value.providerId);
+  if (!providerId) return undefined;
+  const agent = text(value.agent);
+  if (!agent) return undefined;
+  if (!Array.isArray(value.models) || !Array.isArray(value.efforts)) return undefined;
+  const models: { id: string; label: string }[] = [];
+  for (const model of value.models) {
+    if (!isRecord(model)) return undefined;
+    const id = text(model.id);
+    const label = text(model.label);
+    if (!id || !label) return undefined;
+    models.push({ id, label });
+  }
+  if (models.length === 0) return undefined;
+  const efforts = value.efforts.filter((effort): effort is string => isWireString(effort));
+  if (efforts.length !== value.efforts.length) return undefined;
+  return { providerId, agent, models, efforts };
+}
+
 /** Validates a projects answer; a malformed entry is skipped, not fatal. */
 export function hostedProjectsAnswerFromWire(
   value: UnparsedWireValue,
@@ -539,7 +579,14 @@ export function hostedProjectsAnswerFromWire(
     const project = hostedWorkspaceProjectFromWire(item);
     if (project) projects.push(project);
   }
-  return { projects };
+  const agentModels: HostedWorkspaceAgentModels[] = [];
+  if (Array.isArray(value.agentModels)) {
+    for (const item of value.agentModels) {
+      const entry = hostedWorkspaceAgentModelsFromWire(item);
+      if (entry) agentModels.push(entry);
+    }
+  }
+  return { projects, agentModels };
 }
 
 // --- Act wire contract ---

--- a/packages/hosted/src/index.ts
+++ b/packages/hosted/src/index.ts
@@ -15,6 +15,7 @@ export {
   type HostedQuota,
   type HostedReviewAnswer,
   type HostedUsageAnswer,
+  type HostedWorkspaceAgentModels,
   type HostedWorkspaceProject,
   hostedActAnswerFromWire,
   hostedActWorkspaceAnswerFromWire,


### PR DESCRIPTION
## Summary

Follow-up to #611, feeding the mobile New Workspace redesign (agent/model/effort selection like the desktop's):

- `GET /api/projects` now carries `agentModels` beside `projects`: the build's own `WORKSPACE_AGENT_MODELS` table from `@sidecar/session` (agent kinds, model ids + labels, effort levels a provider's creation endpoint takes), emitted only for providers that actually offered a project on the same pass. Mobile reading it here offers exactly what the desktop offers, from the same source of truth; a provider with no table (everything but Conductor today) advertises no choices.
- `POST /api/acts/workspace` now takes the choice back as optional `agent` / `model` / `effort` fields, parsed whole against the same table via `parseWorkspaceAgentSelection` — an unlisted pairing or a selection for a table-less provider is a 400 `invalid-request`, never trimmed to something else — and handed to the adapter as the same `agentSelection` the desktop's IPC sends (the Conductor adapter re-validates against the table again before anything rides the create body).
- New wire shape `HostedWorkspaceAgentModels` + `hostedProjectsAnswerFromWire` validation in `@sidecar/hosted`.

## Testing

- `apps/web`: 258 tests pass. New cases: a listed Conductor selection reaches the executor whole; an unlisted model, and any selection for a table-less provider (Cursor), are 400s; absent fields mean no selection, never a guess; a Conductor projects pass (faked `/me`, `/v0/projects`, `/v0/workspaces`) answers with its three agent entries while a Cursor-only answer carries none.
- `packages/hosted` typecheck + tests pass.

## Stack

The iOS New Workspace redesign (provider→project two-step, saved defaults, model/effort pickers, native form) follows on `dastratakos/nashville-v4-ios` (#612), which will be restacked onto this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/33582270240/artifacts/9828842935) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/33582270240)

- Commit: `a68df183bcc9a9926e529d1642766cc7faff9ee8`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
