### PR TITLE
Rename announcements to notifications

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -420,11 +420,11 @@ Trust constraints:
   cannot even travel, and no event scope is ever held. Only start and end
   instants are kept beyond the pass, and the intervals never leave the
   machine. What the intervals decide is bounded and deterministic: while a
-  meeting covers now and the setting is on, spoken announcements are held and
+  meeting covers now and the setting is on, spoken notifications are held and
   released once it ends, and the face beside the housing sleeps for as long
   as the hold stands, a clock read against observed intervals, never
   anything a model wrote, and holding is the whole power: a calendar entry
-  can delay an announcement and put a drawn face to sleep, never create,
+  can delay a notification and put a drawn face to sleep, never create,
   reword, or act on one. This Mac's own Calendar is read under the same rule
   with no credential at all, through a native helper behind macOS's own
   consent dialog. The dialog is the connection, and nothing is stored but
@@ -537,7 +537,7 @@ Trust constraints:
   routed to the takeover for the introduction's duration, and the spoken
   sign-off is where the introduction ends: the takeover closes, the ordinary
   signed-out panel stands up with its own gate, and observation,
-  announcements, and every other capability still release only through the
+  notifications, and every other capability still release only through the
   ordinary account gate when the sign-in itself lands. An introduction
   that cannot speak stands down to the ordinary signed-out launch and writes
   nothing. Widening what the introduction reads, sends, or can do is a
@@ -573,20 +573,20 @@ What Luke may show:
   even when it is the agent's own parting words, the one bounded line saying
   where the turn ended, the same standing as a recap a provider designated,
   but the transcript it was read from never travels. A
-  spoken announcement (a session that started waiting, stopped on an error,
+  spoken notification (a session that started waiting, stopped on an error,
   or finished, or an evaluator sentence approved for speech) reaches the
   voice service so it can be said aloud. The arrival beat is the
   one member of that set about no session: spoken once per install at the
   deterministic edge of the account's first sign-in, remembered in Luke's own
   state file, worded from a script fixed by the build on the same speak-only,
-  tool-free terms as an edge announcement, and carrying as observed values
+  tool-free terms as an edge notification, and carrying as observed values
   only one working session's title, read from the same roster the rows draw
   and sent as data behind a marker, and the talk key's own name. A moment
   that cannot speak it — no credential, a meeting's quiet, a beat dropped
   before its reply began — leaves it owed for the next signed-in launch
   rather than improvising a substitute; only the voice window reporting the
   reply actually begun settles it, and being about no session it draws no
-  notice band and claims none. An edge announcement
+  notice band and claims none. An edge notification
   sends that update's *about* fields, the same ones the evaluator may see
   with a bounded excerpt of the recap included, and the voice words the
   sentence said aloud, so it can say what the session is waiting on rather
@@ -600,7 +600,7 @@ What Luke may show:
   exchange itself (the developer's own asks, typed or spoken and handed back
   as text by the same service that heard them, the words Luke already spoke
   or announced, and the acts he carried at the developer's ask) so the one
-  conversation survives the calls that transport it: an announcement read out
+  conversation survives the calls that transport it: a notification read out
   on Luke's own call, or a call retired idle, is still remembered by the next
   one. Every history line already traveled to the same service once, on the
   call that said it; a transcript reading enters the history only as the fact
@@ -611,9 +611,9 @@ What Luke may show:
   sent on Luke's speak-only call. Its
   trigger is a deterministic status edge, the arrival beat's one recorded
   sign-in edge, or the evaluator finding an update worth speaking. The edge
-  announcements and approved evaluator sentences speak whenever voice can.
+  notifications and approved evaluator sentences speak whenever voice can.
   Widening either set is a product decision, not an implementation detail;
-  make it deliberately. While an announcement is being spoken, a notice on
+  make it deliberately. While a notification is being spoken, a notice on
   Luke's own surface under the housing names the session it is about,
   drawn on this machine from the roster and the same roster-validated
   identity the voice was handed, leaving it never, and living exactly as
@@ -628,7 +628,7 @@ What Luke may show:
   issue the tracker does not track, and each named issue draws a chip
   beside the session chips, its identifier and title read on this machine
   from that roster, living exactly as long as the words, with an
-  announcement's one session subject still the whole answer. An issue chip's
+  notification's one session subject still the whole answer. An issue chip's
   press hands the issue's tracker-reported address to the operating system
   exactly as a session's would, validated against the observed roster again
   in the main process; it reaches none of the tracker's write paths, and an

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,7 @@
+# Luke domain language
+
+## Notification
+
+A proactive update Luke gives the developer when an observed session needs
+attention or reaches a noteworthy outcome. A notification may be spoken and
+accompanied by on-screen context.

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -155,7 +155,7 @@ service, and usage counts and recordings by PostHog.
 Luke's use of information received from Google APIs adheres to the
 [Google API Services User Data Policy](https://developers.google.com/terms/api-services-user-data-policy),
 including the Limited Use requirements. We use your calendar availability only
-to hold Luke's spoken announcements while you are in a meeting. It is not
+to hold Luke's spoken notifications while you are in a meeting. It is not
 transferred, sold, or used for advertising, and no human reads it.
 
 ## Contact

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ what he remembers, correct something, or tell him to forget it.
 
 ![Luke's capsule under the notch, speaking a summary of which sessions finished and which are waiting.](docs/media/luke-talking.png)
 
-### Announcements
+### Notifications
 
 Luke speaks up when an agent is waiting for you, hits an error, or finishes.
 

--- a/apps/desktop/src/renderer/luke-guide.test.ts
+++ b/apps/desktop/src/renderer/luke-guide.test.ts
@@ -724,12 +724,12 @@ test("the facts describe stopping a reply, exactly where a reply can exist", () 
   assert.doesNotMatch(voiceless, /Stopping a reply/);
 });
 
-test("the announcement fact exists exactly while a voice can speak one", () => {
+test("the notification fact exists exactly while a voice can speak one", () => {
   const rendered = JSON.stringify(buildLukeGuide(guideInput()).facts);
-  assert.match(rendered, /"label":"Announcements"/);
+  assert.match(rendered, /"label":"Notifications"/);
 
   const voiceless = JSON.stringify(buildLukeGuide(guideInput({ voiceAvailable: false })).facts);
-  assert.doesNotMatch(voiceless, /"label":"Announcements"/);
+  assert.doesNotMatch(voiceless, /"label":"Notifications"/);
 });
 
 test("the facts follow the talk key, the microphone, and the storage the system offers", () => {

--- a/apps/desktop/src/renderer/luke-guide.ts
+++ b/apps/desktop/src/renderer/luke-guide.ts
@@ -413,7 +413,7 @@ export function buildLukeGuide(input: LukeGuideInput): AppGuideSnapshot {
       label: "Conversation history",
       detail:
         "The panel's History tab shows every typed ask, transcribed spoken ask, reply, " +
-        "announcement, and session act from this app launch. Luke carries only the 20 most recent " +
+        "notification, and session act from this app launch. Luke carries only the 20 most recent " +
         "entries into a call. The full view stays only in this app's memory, is blocked from " +
         "panel recordings, disappears when Luke quits, and can be cleared by hand " +
         "from that tab. It is not saved or exportable.",
@@ -536,7 +536,7 @@ export function buildLukeGuide(input: LukeGuideInput): AppGuideSnapshot {
           {
             // A behavior rather than a setting: stated here so Luke neither
             // denies announcing nor offers to turn it off.
-            label: "Announcements",
+            label: "Notifications",
             detail:
               "Luke says it out loud when an observed session is holding for you, stops on " +
               "an error, or finishes — a hold is a question, a permission, or an approval, " +
@@ -546,7 +546,7 @@ export function buildLukeGuide(input: LukeGuideInput): AppGuideSnapshot {
               "own provider announces nothing until that conversation closes.",
           },
           {
-            // A behavior rather than a setting, for the announcements' own
+            // A behavior rather than a setting, for the notifications' own
             // reason: Luke must neither deny having just spoken it nor offer
             // to replay it.
             label: "The arrival beat",

--- a/apps/desktop/src/renderer/microphone-access.ts
+++ b/apps/desktop/src/renderer/microphone-access.ts
@@ -158,7 +158,7 @@ export function voiceSourceLabel(source: VoiceSource): string {
  * are the meters' own names; nobody spending them would recognise either.
  */
 export const HOSTED_METER_LABEL = {
-  VOICE: "Talking and announcements",
+  VOICE: "Talking and notifications",
   REVIEWS: "Checks on your sessions",
 } as const;
 

--- a/apps/desktop/src/renderer/settings-panel.tsx
+++ b/apps/desktop/src/renderer/settings-panel.tsx
@@ -1510,7 +1510,7 @@ export interface CalendarControl {
 
 /**
  * Which of a connection's calendars count, one checkbox each — checked
- * meaning its meetings hold announcements — drawn in the calendar's own
+ * meaning its meetings hold notifications — drawn in the calendar's own
  * colour where the list carried one, the panel's working accent where it did
  * not, and sectioned by source where the list reported sources, the way
  * Calendar.app sections its sidebar. A calendar the selection names but the
@@ -1919,7 +1919,7 @@ function CalendarIntegrations({
       ) : null}
       <p className="settings-note">
         Luke reads when your meetings start and end — never their titles — and can hold
-        announcements until they finish.
+        notifications until they finish.
       </p>
       {/* The quiet is a fact about the calendars above it, so it appears with
           the first connection and leaves with the last — a switch gating what

--- a/packages/settings/src/schema.ts
+++ b/packages/settings/src/schema.ts
@@ -584,7 +584,7 @@ export const APP_SETTING_SCHEMA = {
         id: APP_SETTING_ID.QUIET_DURING_MEETINGS,
         label: "Quiet during meetings",
         description:
-          "Whether spoken announcements wait while a connected calendar shows a meeting on, then read out together once it ends. Switched on mid-meeting it takes hold at once. It changes nothing until a calendar — a Google Calendar account, or this Mac's Apple Calendar — is connected.",
+          "Whether spoken notifications wait while a connected calendar shows a meeting on, then read out together once it ends. Switched on mid-meeting it takes hold at once. It changes nothing until a calendar — a Google Calendar account, or this Mac's Apple Calendar — is connected.",
         kind: APP_SETTING_KIND.TOGGLE,
         value: appToggleText(guideValue<boolean>(settings, "quietDuringMeetings")),
         defaultValue: appToggleText(defaultValue),


### PR DESCRIPTION
## Summary

- Rename Luke's user-facing “announcements” language to “notifications” across the app guide, settings, README, privacy copy, and trust documentation.
- Define notification as product domain language and keep the guide regression test aligned.

## Evidence

- Platform-independent checks: `./scripts/check.sh` passed
- macOS Electron verification (`./scripts/verify.sh`): passed

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/33543242752/artifacts/9814538773) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/33543242752)

- Commit: `136dd219a5801c50badab44d869e2720415761b6`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

### Physical-device evidence

- Screenshot or screen recording: `not attached`
- Physical-notch check: `not performed`
- Device/display configuration: `not recorded`

## Notes

- Blockers or follow-up verification: None

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)