### PR TITLE
fix(ios): scroll session rows behind the bar instead of clipping them

### DIFF
--- a/apps/ios/Luke/SessionsView.swift
+++ b/apps/ios/Luke/SessionsView.swift
@@ -89,11 +89,6 @@ struct SessionsView: View {
         }
         .listStyle(.plain)
         .scrollContentBackground(.hidden)
-        // No toolbarBackground override: pinning the bar opaque cut rows off
-        // at its edge instead of letting them pass behind it. The system's
-        // own scroll-edge treatment — transparent at rest over the ground,
-        // its own material once rows scroll under — is the native passage
-        // the profile sheet's list already gets by default.
         .background(Color.ground.ignoresSafeArea())
         .searchable(text: $searchQuery, prompt: "Search sessions")
         .toolbar {

--- a/apps/ios/Luke/SessionsView.swift
+++ b/apps/ios/Luke/SessionsView.swift
@@ -89,9 +89,12 @@ struct SessionsView: View {
         }
         .listStyle(.plain)
         .scrollContentBackground(.hidden)
+        // No toolbarBackground override: pinning the bar opaque cut rows off
+        // at its edge instead of letting them pass behind it. The system's
+        // own scroll-edge treatment — transparent at rest over the ground,
+        // its own material once rows scroll under — is the native passage
+        // the profile sheet's list already gets by default.
         .background(Color.ground.ignoresSafeArea())
-        .toolbarBackground(Color.ground, for: .navigationBar)
-        .toolbarBackground(.visible, for: .navigationBar)
         .searchable(text: $searchQuery, prompt: "Search sessions")
         .toolbar {
             // The filter rides with the search the way Notion docks one in


### PR DESCRIPTION
## What

Scrolled session rows on the iOS sessions screen were cut off at the navigation bar's hard edge instead of passing behind it, because the list pinned an opaque `Color.ground` over the bar:

```swift
.toolbarBackground(Color.ground, for: .navigationBar)
.toolbarBackground(.visible, for: .navigationBar)
```

The profile sheet's list never overrides the bar and gets the native behavior for free: the bar transparent at rest over the ground, drawing its own material (Liquid Glass on iOS 26) once content scrolls beneath it, rows visible through the blur. Dropping the override gives the sessions list that same system scroll-edge treatment. A comment now marks the deliberate absence so the override does not quietly return.

## What deliberately does not change

The list's own ground (`Color.ground.ignoresSafeArea()`) still extends under the bar, so the resting appearance keeps the same color in both appearances — the palette is appearance-resolved and needs no scheme override. The iOS 26 bottom-bar search and the pre-26 bar search keep their existing presentations.

## Testing

- `xcodebuild test` (Luke scheme, iPhone 17 Pro Max simulator, Xcode 26.6): **TEST SUCCEEDED**, all app-target suites pass.
- `swift test` in `apps/ios/LukeKit`: passes (package untouched by this change).
- CI has no iOS job; the build and tests above were run on a Mac from a clean worktree of this branch. Scrolled-state behavior is the system's own; a hands-on scroll check on device/simulator is the remaining visual confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/88adc5c6-45a3-4b45-8666-dd7ba6e34194)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/33553189958/artifacts/9818379274) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/33553189958)

- Commit: `5a657ac20cd71fb1d1affc262cc8040f662dd702`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
