### PR TITLE
fix(voice): keep current batched notices

### DIFF
--- a/apps/desktop/src/main/session-announcement-batch.test.ts
+++ b/apps/desktop/src/main/session-announcement-batch.test.ts
@@ -126,7 +126,7 @@ test("revalidates queued state and restores mixed sources to their meeting holds
         providerSessionId: "waiting",
         title: "waiting",
         status: SESSION_STATUS.WAITING,
-        observedAt: 1_000,
+        observedAt: 1_100,
       },
     ),
     normalizeSession(

--- a/apps/desktop/src/main/session-announcement-batch.ts
+++ b/apps/desktop/src/main/session-announcement-batch.ts
@@ -89,10 +89,7 @@ export function currentSessionAnnouncements(
   return pending.filter((item) => {
     const current = currentSession(item.announcement);
     if (item.source === "notice") {
-      return (
-        current === undefined ||
-        (current.status === item.notice.status && current.observedAt === item.notice.observedAt)
-      );
+      return current === undefined || current.status === item.notice.status;
     }
     return (
       current !== undefined &&


### PR DESCRIPTION
## Summary

- keep a queued deterministic notice when its provider refreshes `observedAt` without changing status
- continue requiring an exact observation for model-reviewed announcements
- cover the refreshed-timestamp case in the existing batch revalidation test

Follow-up to the late Bugbot finding on #623.

## Verification

- `pnpm --filter @luke/desktop exec tsx --test src/main/session-announcement-batch.test.ts`
- `pnpm --filter @luke/desktop typecheck`
- `./scripts/check.sh`

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/33548421480/artifacts/9816520375) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/33548421480)

- Commit: `7b3dc5637b66906b5acf66bcf6991b493d341645`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
