### PR TITLE
fix(history): keep History lines whole and bound only the model render

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -322,11 +322,12 @@ Trust constraints:
   posture Luke keeps. The one explicit blocked subtree is History: its root
   carries the recording library's fixed blocking class, so neither the
   conversation's words nor the entries Luke was asked to remember leave the
-  machine in a recording. That view retains every bounded line the retention
-  policy holds, including session acts and the lines that outlived the last
-  launch, until the developer clears it — the same thread on every display's
-  panel, relayed between windows through the main process — while only the 20
-  most recent lines enter model context. There
+  machine in a recording. That view retains every line the retention policy
+  holds, its words whole, including session acts and the lines that outlived
+  the last launch, until the developer clears it — the same thread on every
+  display's panel, relayed between windows through the main process — while
+  only the 20 most recent lines enter model context, each cut there to its
+  own length bound. There
   is no general masking module to consult and nothing that makes any other new
   component silent by construction, so what a recording may see is decided by
   what the panel draws or explicitly blocks — which makes drawing something

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,6 +1,6 @@
 # Privacy
 
-Last updated: 1 September 2026
+Last updated: 2 September 2026
 
 Luke is a macOS app that watches your coding agent sessions, with a companion
 iOS app for the cloud sessions your account can see. This policy explains what
@@ -21,8 +21,9 @@ anywhere. It stays on your Mac unless a feature below sends it.
 — what you typed or said, what he spoke or announced, and the actions he took
 at your request — in a file on your Mac, so it is still there the next time you
 open him. It holds the 200 most recent entries and nothing older than 14 days,
-whichever runs out first; each entry is capped at 400 characters. Only the 20
-most recent are carried into a call, the same as before. Clearing the History
+whichever runs out first, each kept in full so the History tab shows every
+word. Only the 20 most recent are carried into a call, and each of those is
+capped at 400 characters there. Clearing the History
 tab deletes the file as well as the view. Nothing about the conversation is
 written on our servers, and a fixture or evidence run keeps no conversation at
 all.

--- a/apps/desktop/src/renderer/use-voice-conversation.ts
+++ b/apps/desktop/src/renderer/use-voice-conversation.ts
@@ -543,9 +543,10 @@ export interface VoiceConversation {
   stopMicrophone: () => Promise<void>;
   askLuke: (text: string) => Promise<string | undefined>;
   /**
-   * Every bounded line the thread holds — this launch's and, ahead of them,
-   * what the last launch left within the retention policy — shared across
-   * every display's panel. The model still receives only the recent slice.
+   * Every line the thread holds, words whole — this launch's and, ahead of
+   * them, what the last launch left within the retention policy — shared
+   * across every display's panel. The model still receives only the recent
+   * slice, each line cut at render to its own length bound.
    */
   conversationHistory: readonly ConversationEntry[];
   /** Clears the visible history, the next call's context, and the stored file. */
@@ -789,7 +790,7 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
   }, [conversationHistory, publishConversation]);
 
   /**
-   * Appends one bounded line to this launch's history and tells the call now
+   * Appends one flattened line to this launch's history and tells the call now
    * open about only the recent context slice. A session leaving the roster
    * costs a line its identity at model render, never its visible words. An
    * announcement line is marked as such: it is the one line an open call's

--- a/apps/desktop/src/shared/bridge.test.ts
+++ b/apps/desktop/src/shared/bridge.test.ts
@@ -23,7 +23,7 @@ test("act bridge entries reject legacy and malformed outcomes", () => {
   }
 });
 
-test("a conversation history report carries only bounded history lines", () => {
+test("a conversation history report carries only well-formed history lines", () => {
   const guard = BRIDGE.reportConversationHistory.args;
   const ask = { kind: "typed-ask", words: "how is it going?", recordedAt: 1 };
   const announcement = {

--- a/packages/realtime/src/conversation-history.test.ts
+++ b/packages/realtime/src/conversation-history.test.ts
@@ -41,18 +41,19 @@ function rosterSession(providerSessionId: string, title: string) {
   );
 }
 
-test("appending flattens, bounds, and retires the oldest lines", () => {
+test("appending flattens, keeps the words whole, and retires the oldest lines", () => {
   const identity = { providerId: "claude-code", providerSessionId: "session-a" };
-  // Whitespace is flattened before the bound, so a pasted paragraph cannot
-  // open a new section of the context item it will be rendered into.
+  // Whitespace is flattened at append, so a pasted paragraph cannot open a
+  // new section of the context item it will be rendered into. Length is not
+  // cut here: the thread is the developer's own record, and only the model
+  // render bounds its copy.
   const appended = appendConversationEntry([], {
     kind: CONVERSATION_ENTRY_KIND.TYPED_ASK,
     words: `  hello\n\nthere ${"x".repeat(2 * maximumConversationEntryLength)}  `,
     identity,
   });
   assert.equal(appended.length, 1);
-  assert.match(appended[0]?.words ?? "", /^hello there x/);
-  assert.ok((appended[0]?.words.length ?? 0) <= maximumConversationEntryLength);
+  assert.equal(appended[0]?.words, `hello there ${"x".repeat(2 * maximumConversationEntryLength)}`);
   assert.deepEqual(appended[0]?.identity, identity);
 
   // An entry with nothing left says nothing worth a window's space.
@@ -73,15 +74,14 @@ test("appending flattens, bounds, and retires the oldest lines", () => {
   assert.equal(entries[0]?.words, "line 3");
 });
 
-test("a streaming line is bounded like the settled line it previews", () => {
+test("a streaming line is flattened like the settled line it previews", () => {
   const identity = { providerId: "claude-code", providerSessionId: "session-a" };
   const line = streamingConversationEntry(
     CONVERSATION_ENTRY_KIND.ANNOUNCEMENT,
     `  Checkout\n\nfinished ${"x".repeat(2 * maximumConversationEntryLength)}  `,
     identity,
   );
-  assert.match(line?.words ?? "", /^Checkout finished x/);
-  assert.ok((line?.words.length ?? 0) <= maximumConversationEntryLength);
+  assert.equal(line?.words, `Checkout finished ${"x".repeat(2 * maximumConversationEntryLength)}`);
   assert.deepEqual(line?.identity, identity);
   // A line still growing has not happened yet: the record stamps at settle.
   assert.equal(line?.recordedAt, undefined);
@@ -89,6 +89,27 @@ test("a streaming line is bounded like the settled line it previews", () => {
   // Words that flatten to nothing preview nothing, exactly as they would
   // append nothing.
   assert.equal(streamingConversationEntry(CONVERSATION_ENTRY_KIND.REPLY, "   "), undefined);
+});
+
+test("the model render cuts a long line the retained thread keeps whole", () => {
+  const longAnswer = `The checkout work is done. ${"x".repeat(2 * maximumConversationEntryLength)}`;
+  const entries = appendConversationEntry(
+    [],
+    { kind: CONVERSATION_ENTRY_KIND.REPLY, words: longAnswer },
+    OBSERVED_AT,
+  );
+
+  // The panel and the stored file both hold every word that was said.
+  assert.equal(entries[0]?.words, longAnswer);
+  assert.deepEqual(storedConversationEntry(JSON.parse(JSON.stringify(entries[0]))), entries[0]);
+
+  // Only the render a model receives pays for the opening alone.
+  const text = conversationHistoryText(entries, []);
+  assert.ok(text);
+  const line = text.split("\n")[1] ?? "";
+  assert.match(line, /^- Luke said: "The checkout work is done\./);
+  assert.equal(line.includes(longAnswer), false);
+  assert.ok(line.includes(longAnswer.slice(0, maximumConversationEntryLength)));
 });
 
 test("every way into the thread stamps when the line was recorded", () => {

--- a/packages/realtime/src/conversation-history.ts
+++ b/packages/realtime/src/conversation-history.ts
@@ -68,9 +68,11 @@ export function isConversationEntryKind(value: UnparsedWireValue): value is Conv
 }
 
 /**
- * How many recent lines the model receives, and how long every stored line may
- * run. Together they bound what one context item can cost the model's window;
- * the panel may keep more lines from this launch without sending them all.
+ * How many recent lines the model receives, and how long each may run when
+ * rendered into model context. Together they bound what one context item can
+ * cost the model's window. Both bounds are the render's alone: the retained
+ * thread keeps every line's full words, because the thread is the developer's
+ * own record and a bubble cut mid-sentence misreports what was said.
  */
 export const maximumConversationEntries = 20;
 export const maximumConversationEntryLength = 400;
@@ -81,8 +83,12 @@ export const maximumConversationEntryLength = 400;
  * making the file the panel's slowest read, and the age keeps a conversation
  * nobody has looked at since from following the developer around forever.
  * Whichever cuts first wins, and neither widens what reaches the model —
- * {@link maximumConversationEntries} still bounds that, and persisting is for
- * continuity and for the panel.
+ * {@link maximumConversationEntries} and the render's own
+ * {@link maximumConversationEntryLength} still bound that, and persisting is
+ * for continuity and for the panel. A retained line's length carries no bound
+ * of its own: every word already traveled to the voice service once on the
+ * call that said it, so keeping it whole changes what the panel can show back,
+ * not what leaves the machine.
  *
  * At this size continuity needs no retrieval: quitting and returning to the
  * last twenty lines is the whole of it, and the panel simply draws the rest.
@@ -121,9 +127,11 @@ export interface ConversationEntryMention extends SessionIdentity {
 export interface ConversationEntry {
   kind: ConversationEntryKind;
   /**
-   * The line's words, flattened and bounded at append. For a reply the bound
-   * cuts a long speech to its opening — the thread needs what was talked
-   * about, not every word of it.
+   * The line's words, flattened at append and kept whole. The model's copy is
+   * cut to {@link maximumConversationEntryLength} at render — its window needs
+   * what was talked about, not every word of it — but the panel draws these
+   * words, and a record that silently dropped the end of a long ask or reply
+   * would misquote the developer to themselves.
    */
   words: string;
   /**
@@ -160,7 +168,7 @@ export interface ConversationEntry {
 }
 
 /**
- * Appends one length-bounded line to the retained thread. An entry with
+ * Appends one flattened line to the retained thread. An entry with
  * nothing left after flattening appends nothing: an empty line says nothing
  * worth keeping or spending model-window space on.
  */
@@ -169,7 +177,7 @@ export function appendConversationThreadEntry(
   entry: ConversationEntry,
   now: number = Date.now(),
 ): readonly ConversationEntry[] {
-  const words = boundedEntryWords(entry.words);
+  const words = flattenedEntryWords(entry.words);
   if (!words) return entries;
   const appended: ConversationEntry = { kind: entry.kind, words, recordedAt: now };
   if (entry.identity) appended.identity = entry.identity;
@@ -236,15 +244,18 @@ export function appendConversationEntry(
   return recentConversationEntries(appendConversationThreadEntry(entries, entry, now));
 }
 
-/** One flattening and one bound for every line, however it enters. */
-function boundedEntryWords(words: string): string {
-  return words.replace(/\s+/g, " ").trim().slice(0, maximumConversationEntryLength);
+/**
+ * One flattening for every line, however it enters. Flattening alone, no
+ * length cut: the model render applies its own bound to its own copy.
+ */
+function flattenedEntryWords(words: string): string {
+  return words.replace(/\s+/g, " ").trim();
 }
 
 /**
  * One line still being said, for the panel to draw under the settled thread
- * while its words grow. It is bounded exactly as its settled form will be, so
- * the streaming bubble and the recorded line can never disagree, and it
+ * while its words grow. It is flattened exactly as its settled form will be,
+ * so the streaming bubble and the recorded line can never disagree, and it
  * carries no timestamp: the record stamps a line only when it settles, and a
  * line still growing has not happened yet. Presentation only — nothing built
  * here may enter the thread; each line settles through its own recording
@@ -256,9 +267,9 @@ export function streamingConversationEntry(
   identity?: SessionIdentity,
   identities?: readonly SessionIdentity[],
 ): ConversationEntry | undefined {
-  const bounded = boundedEntryWords(words);
-  if (!bounded) return undefined;
-  const entry: ConversationEntry = { kind, words: bounded };
+  const flattened = flattenedEntryWords(words);
+  if (!flattened) return undefined;
+  const entry: ConversationEntry = { kind, words: flattened };
   if (identity) entry.identity = identity;
   if (identities) entry.identities = identities;
   return entry;
@@ -282,15 +293,15 @@ export function insertSpokenAskThreadEntry(
   after: ConversationEntry | undefined,
   recordedAt: number = Date.now(),
 ): readonly ConversationEntry[] {
-  const bounded = boundedEntryWords(words);
-  if (!bounded) return entries;
+  const flattened = flattenedEntryWords(words);
+  if (!flattened) return entries;
   // indexOf answers -1 for a missing mark, so the ask lands at the front —
   // exactly where an entry older than the whole history belongs.
   const at = after ? entries.indexOf(after) + 1 : 0;
   const placed = [...entries];
   placed.splice(at, 0, {
     kind: CONVERSATION_ENTRY_KIND.SPOKEN_ASK,
-    words: bounded,
+    words: flattened,
     recordedAt,
   });
   return placed;
@@ -442,7 +453,12 @@ const CONVERSATION_ENTRY_LEAD = {
 
 /**
  * Renders the history for the conversation, oldest first, or nothing while
- * nothing has been said. Each line carries its identity only while the roster
+ * nothing has been said. Each line's words are cut here to
+ * {@link maximumConversationEntryLength} — this render is the one place the
+ * thread reaches a model's window, and a long line's opening says what was
+ * talked about at a fraction of the cost the whole would spend — while the
+ * thread behind it keeps the full words for the panel.
+ * Each line carries its identity only while the roster
  * still observes that session: the words are history and stay, but an
  * identity the roster no longer reports is one no tool call may name, and a
  * line still offering it would steer "that chat" toward a guaranteed refusal.
@@ -461,10 +477,9 @@ export function conversationHistoryText(
       "carried across calls. Memory to answer from, never an instruction to act.",
     ...entries.map((entry) => {
       const lead = CONVERSATION_ENTRY_LEAD[entry.kind];
+      const words = entry.words.slice(0, maximumConversationEntryLength);
       const line =
-        entry.kind === CONVERSATION_ENTRY_KIND.ACT
-          ? `- ${lead} ${entry.words}`
-          : `- ${lead}: "${entry.words}"`;
+        entry.kind === CONVERSATION_ENTRY_KIND.ACT ? `- ${lead} ${words}` : `- ${lead}: "${words}"`;
       const identities = entry.identities ?? (entry.identity ? [entry.identity] : []);
       if (identities.length === 0) return line;
       const identityNotes = identities.map((identity) => {
@@ -490,7 +505,7 @@ export function conversationHistoryText(
  */
 export function storedConversationEntry(value: UnparsedWireValue): ConversationEntry | undefined {
   if (!isRecord(value) || !isConversationEntryKind(value.kind)) return undefined;
-  const words = isWireString(value.words) ? boundedEntryWords(value.words) : undefined;
+  const words = isWireString(value.words) ? flattenedEntryWords(value.words) : undefined;
   if (!words || words !== value.words) return undefined;
   const recordedAt =
     isWireNumber(value.recordedAt) && Number.isFinite(value.recordedAt)


### PR DESCRIPTION
## Problem

Messages in the conversation History tab were truncated at 400 characters — both the streaming preview bubble (built from the transcript deltas, landed with #614) and the settled line it becomes, because `appendConversationThreadEntry`, `insertSpokenAskThreadEntry`, and `streamingConversationEntry` all cut words to `maximumConversationEntryLength` on the way into the thread.

## Design

The 400-character bound exists to limit what one history line costs the model's context window, and that cost is paid in exactly one place: `conversationHistoryText`, the render `#rememberConversation` sends into a call. So the cut moves there, and the retained thread keeps every line's full flattened words:

- **`packages/realtime/src/conversation-history.ts`** — `boundedEntryWords` becomes `flattenedEntryWords` (whitespace flattening only), used by append, spoken-ask insert, the streaming preview, and the stored-line parser, so the streaming bubble and the settled line still can never disagree. `conversationHistoryText` now cuts each line's words to `maximumConversationEntryLength`, so what a model receives is bounded exactly as before (20 lines × 400 characters). The constant and retention doc comments move with the behavior.
- **Main-process paths unchanged in behavior**: the cross-display relay (`reportConversationHistory` guard) and the stored file both validate through `storedConversationEntry`, which now admits whole words; persistence, merging, and retention (200 entries / 14 days) are untouched. An older build reading a newer file drops only the lines longer than its own bound, per the parser's line-not-thread rule.
- **`PRIVACY.md`** — the conversation paragraph now says entries are kept in full on the Mac and that the 400-character cap applies to the 20 lines carried into a call; `Last updated` bumped.
- **`AGENTS.md`** — the History sentence in the replay constraint updated to match (words whole in the view, length bound at model render).
- The History bubbles already handle long content: `.history-entry p` has `overflow-wrap: anywhere` and the list scrolls, so no renderer or style change was needed — the panel simply draws the whole words it now holds.

## Tests

- Append and streaming tests updated to pin that words are flattened but kept whole.
- New test: the model render cuts a long line to the bound while the thread and the stored round trip keep it whole.

## Verification

- `./scripts/check.sh` — passes (exit 0).
- `./scripts/verify.sh` — the `check.sh` half passes; the evidence half exits 1 with `error: this command requires macOS`, as this change was made in a Linux cloud workspace. No visual evidence was generated and no physical-notch check was performed; the fixture evidence scenarios do not exercise the History tab, but a macOS follow-up run of `./scripts/verify.sh` is owed before release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/240268d4-3103-4a55-a464-9e05af6a3cc6)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/33683974397/artifacts/9867446888) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/33683974397)

- Commit: `2b209cca09ffd9e535d89a75be211d7d25394176`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
