### PR TITLE
fix(ios): drop sort details and filter counts from the options sheet

### DIFF
--- a/apps/ios/Luke/SessionsView.swift
+++ b/apps/ios/Luke/SessionsView.swift
@@ -246,8 +246,8 @@ private struct SessionOptionsSheet: View {
         NavigationStack {
             List {
                 Section("Sort by") {
-                    sortRow(.urgency, label: "Urgent", detail: "Most urgent first")
-                    sortRow(.recency, label: "Recent", detail: "Most recently observed first")
+                    sortRow(.urgency, label: "Urgent")
+                    sortRow(.recency, label: "Recent")
                 }
                 if !groups.isEmpty {
                     Section("Filter by") {
@@ -279,18 +279,13 @@ private struct SessionOptionsSheet: View {
         }
     }
 
-    private func sortRow(_ value: SessionSort, label: String, detail: String) -> some View {
+    private func sortRow(_ value: SessionSort, label: String) -> some View {
         Button {
             sort = value
         } label: {
             HStack {
-                VStack(alignment: .leading, spacing: 2) {
-                    Text(label)
-                        .foregroundStyle(Color.ink)
-                    Text(detail)
-                        .font(.footnote)
-                        .foregroundStyle(.secondary)
-                }
+                Text(label)
+                    .foregroundStyle(Color.ink)
                 Spacer()
                 Image(systemName: "checkmark")
                     .fontWeight(.semibold)
@@ -308,9 +303,8 @@ private struct SessionOptionsSheet: View {
     }
 }
 
-/// One axis's checklist page: every observed value with its session count,
-/// toggled by row press. The checkmark keeps its slot when unchosen so rows
-/// do not shift underfoot.
+/// One axis's checklist page: every observed value, toggled by row press. The
+/// checkmark keeps its slot when unchosen so rows do not shift underfoot.
 private struct AxisFilterPage: View {
     let group: SessionFilterAxisOptions
     @Binding var filters: Set<SessionFilter>
@@ -330,8 +324,6 @@ private struct AxisFilterPage: View {
                         Text(optionTitle(option.filter))
                             .foregroundStyle(Color.ink)
                         Spacer()
-                        Text(option.count, format: .number)
-                            .foregroundStyle(.secondary)
                         Image(systemName: "checkmark")
                             .fontWeight(.semibold)
                             .opacity(filters.contains(option.filter) ? 1 : 0)

--- a/apps/ios/Luke/SessionsView.swift
+++ b/apps/ios/Luke/SessionsView.swift
@@ -303,8 +303,9 @@ private struct SessionOptionsSheet: View {
     }
 }
 
-/// One axis's checklist page: every observed value, toggled by row press. The
-/// checkmark keeps its slot when unchosen so rows do not shift underfoot.
+/// One axis's checklist page: every observed value with its session count,
+/// toggled by row press. The checkmark keeps its slot when unchosen so rows
+/// do not shift underfoot.
 private struct AxisFilterPage: View {
     let group: SessionFilterAxisOptions
     @Binding var filters: Set<SessionFilter>
@@ -324,6 +325,11 @@ private struct AxisFilterPage: View {
                         Text(optionTitle(option.filter))
                             .foregroundStyle(Color.ink)
                         Spacer()
+                        // .secondary here would resolve against the button's
+                        // tint and read blue; the count wears the panel's own
+                        // secondary ink instead.
+                        Text(option.count, format: .number)
+                            .foregroundStyle(Color.inkSecondary)
                         Image(systemName: "checkmark")
                             .fontWeight(.semibold)
                             .opacity(filters.contains(option.filter) ? 1 : 0)


### PR DESCRIPTION
## Summary

In the iOS Filter & Sort sheet, text inside the sheet's buttons styled with `.secondary` resolved against the button tint and rendered blue instead of the panel's ink:

- The **Urgent**/**Recent** sort rows drop their detail lines ("Most urgent first" / "Most recently observed first") — label and checkmark only now.
- The **Provider** and **Status** pages keep their per-option session counts, now drawn in `Color.inkSecondary` so they read gray, not blue.

The blue checkmarks stay as they were — the accent now really is the checkmarks' alone, as the sheet's own comment promises.

## Testing

- Swift-only change; no portable or desktop macOS surface touched, so `check.sh`/`verify.sh` cover it unchanged. No Swift toolchain in this cloud workspace, so no local iOS build was run; the edit is mechanical and was grepped for leftover references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/33556530321/artifacts/9819655368) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/33556530321)

- Commit: `d8898e57f29265f6c2becc2605cac58dcec383f7`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/2e1fcfe4-193e-4f98-a3b8-23e2e60913bb)
