### PR TITLE
feat(session): retain recaps whole and excerpt them only at the model edges

### DIFF
--- a/packages/attention/src/attention-openai.test.ts
+++ b/packages/attention/src/attention-openai.test.ts
@@ -12,7 +12,7 @@ import {
   attentionUpdateInput,
 } from "@sidecar/attention";
 import {
-  maximumSessionRecapLength,
+  maximumSessionRecapExcerptLength,
   maximumSessionTitleLength,
   SESSION_STATUS,
 } from "@sidecar/session";
@@ -111,15 +111,17 @@ test("a wire update outside the build's value sets is refused, not repaired", ()
   assert.equal(attentionPromptUpdateFromWire("not a record"), undefined);
 });
 
-test("wire fields are cut to the bounds the local roster holds them to", () => {
+test("wire fields are cut to the bounds an update may carry them at", () => {
   const parsed = attentionPromptUpdateFromWire({
     trigger: ATTENTION_TRIGGER.OBSERVED,
     providerName: "p".repeat(maximumSessionTitleLength + 40),
     title: `  ${"t".repeat(maximumSessionTitleLength + 40)}  `,
     status: SESSION_STATUS.WORKING,
-    recap: "r".repeat(maximumSessionRecapLength + 40),
+    // The recap's wire bound is the excerpt's, not the roster's: the roster
+    // retains more than any update is allowed to carry off a machine.
+    recap: "r".repeat(maximumSessionRecapExcerptLength + 40),
   });
   assert.equal(parsed?.providerName.length, maximumSessionTitleLength);
   assert.equal(parsed?.title.length, maximumSessionTitleLength);
-  assert.equal(parsed?.recap?.length, maximumSessionRecapLength);
+  assert.equal(parsed?.recap?.length, maximumSessionRecapExcerptLength);
 });

--- a/packages/attention/src/attention-prompt.ts
+++ b/packages/attention/src/attention-prompt.ts
@@ -1,7 +1,7 @@
 import {
   boundedText,
   maximumSessionDetailLength,
-  maximumSessionRecapLength,
+  maximumSessionRecapExcerptLength,
   maximumSessionTitleLength,
   SESSION_STATUS,
   type SessionStatus,
@@ -104,9 +104,11 @@ function optionalWireText(value: UnparsedWireValue, maximumLength: number): Opti
 
 /**
  * Validates an update arriving as untrusted JSON — a hosted review request —
- * down to the fields the prompt reads, each held to the same bound the local
- * roster holds it to. A value set is checked against the set itself, a
- * malformed field refuses the whole update rather than being repaired.
+ * down to the fields the prompt reads, each held to the bound an update may
+ * carry it at: the roster's own bound for most, the recap's narrower excerpt
+ * bound for the one field the roster retains longer. A value set is checked
+ * against the set itself, a malformed field refuses the whole update rather
+ * than being repaired.
  */
 export function attentionPromptUpdateFromWire(
   value: UnparsedWireValue,
@@ -124,7 +126,10 @@ export function attentionPromptUpdateFromWire(
   if (value.previousStatus !== undefined && !previousStatus) return undefined;
 
   const workspace = optionalWireText(value.workspace, maximumSessionTitleLength);
-  const recap = optionalWireText(value.recap, maximumSessionRecapLength);
+  // The excerpt bound, not the roster's: an update's recap is cut to the
+  // excerpt before it may leave a machine, so a longer one here is not an
+  // update this build produced.
+  const recap = optionalWireText(value.recap, maximumSessionRecapExcerptLength);
   if (!workspace.valid || !recap.valid) return undefined;
 
   if (value.context !== undefined && !isRecord(value.context)) return undefined;

--- a/packages/attention/src/attention.test.ts
+++ b/packages/attention/src/attention.test.ts
@@ -11,6 +11,7 @@ import {
 import {
   ATTENTION_DISPOSITION,
   type AttentionDecision,
+  maximumSessionRecapExcerptLength,
   normalizeSession,
   type ProviderSessionObservation,
   SESSION_COMPLETION_CAUSE,
@@ -121,6 +122,26 @@ test("derives an update only when a session reports something new", () => {
   assert.ok(held);
   assert.equal(held?.holdingForDeveloper, true);
   assert.doesNotMatch(attentionUpdateInput(held), /holdingForDeveloper/);
+});
+
+test("an update carries the recap's excerpt, and a change past it is no development", () => {
+  const opening = `Waiting on the rounding rule. ${"y".repeat(700)}`;
+  const before = session(claude, "review", { recap: opening });
+
+  const update = attentionUpdate(before);
+  assert.equal(update?.recap, opening.slice(0, maximumSessionRecapExcerptLength));
+
+  // A recap that differs only past the excerpt reads identical to the
+  // evaluator, so it opens no review the model would have to judge blind.
+  const changedPastExcerpt = session(claude, "review", { recap: `${opening} and one more word` });
+  assert.equal(attentionUpdate(changedPastExcerpt, before), undefined);
+
+  // A change inside the excerpt is still the development it always was.
+  const changedInsideExcerpt = session(claude, "review", { recap: `Settled. ${opening}` });
+  assert.equal(
+    attentionUpdate(changedInsideExcerpt, before)?.trigger,
+    ATTENTION_TRIGGER.RECAP_CHANGED,
+  );
 });
 
 test("the update names the workspace a chat belongs to, and only by its name", () => {
@@ -822,7 +843,7 @@ test("sends bounded material and withholds what a decision does not turn on", as
     "trigger",
   ]);
   assert.equal(update.title.length, 160, "titles stay bounded by session normalization");
-  assert.equal(update.recap?.length, 500, "recaps stay bounded by session normalization");
+  assert.equal(update.recap?.length, 500, "recaps leave only as the update's bounded excerpt");
 
   // An evaluator is the one place session material leaves the machine, so the
   // session's own address and the change it published stay behind: they are

--- a/packages/attention/src/attention.ts
+++ b/packages/attention/src/attention.ts
@@ -3,6 +3,8 @@ import {
   type AttentionDecision,
   type AttentionDisposition,
   attentionDecisionFromWire,
+  boundedText,
+  maximumSessionRecapExcerptLength,
   normalizeSessionIdentity,
   SESSION_COMPLETION_CAUSE,
   type Session,
@@ -120,6 +122,12 @@ export interface AttentionUpdate extends SessionIdentity {
   /** Local announcement context; intentionally absent from the evaluator prompt. */
   holdingForDeveloper?: boolean;
   previousStatus?: SessionStatus;
+  /**
+   * The bounded excerpt of the session's recap, never the retained recap
+   * whole: the roster may keep a longer one for the surfaces that draw it,
+   * but what leaves the machine in an update stays cut to
+   * {@link maximumSessionRecapExcerptLength}.
+   */
   recap?: string;
   context?: AttentionContext;
   observedAt: number;
@@ -237,10 +245,19 @@ const ATTENTION_DEVELOPMENT = [
   },
   {
     trigger: ATTENTION_TRIGGER.RECAP_CHANGED,
-    ofSession: (session: Session) => session.recap,
+    // The excerpt is what an update carries, so both accessors speak in
+    // excerpts: a recap that changed only past the excerpt is a difference
+    // no evaluator could see, and treating it as a development would open
+    // reviews the model must judge blind — and supersede ones it should not.
+    ofSession: (session: Session) => attentionRecapExcerpt(session.recap),
     ofUpdate: (update: AttentionUpdate) => update.recap,
   },
 ] as const;
+
+/** The one bounded slice of a recap that may leave the machine in an update. */
+function attentionRecapExcerpt(recap: string | undefined): string | undefined {
+  return boundedText(recap, maximumSessionRecapExcerptLength);
+}
 
 /** Fields that change what the voice would say, without opening extra model reviews. */
 function speechValues(update: AttentionUpdate): readonly (string | undefined)[] {
@@ -294,7 +311,8 @@ export function attentionUpdate(session: Session, previous?: Session): Attention
   if (workspace) update.workspace = workspace;
   if (session.holdingForDeveloper === true) update.holdingForDeveloper = true;
   if (previous) update.previousStatus = previous.status;
-  if (session.recap) update.recap = session.recap;
+  const recap = attentionRecapExcerpt(session.recap);
+  if (recap) update.recap = recap;
   if (context) update.context = context;
   return update;
 }

--- a/packages/providers/src/antigravity/adapter.ts
+++ b/packages/providers/src/antigravity/adapter.ts
@@ -1,7 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import {
-  maximumSessionRecapLength,
   maximumSessionTitleLength,
   PROVIDER_ID,
   type ProviderSessionObservation,
@@ -12,7 +11,7 @@ import {
   type SessionProvider,
   type SessionStatus,
 } from "@sidecar/session";
-import { isRecord, oneLine, type WireRecord } from "@sidecar/wire";
+import { isRecord, oneLine, type WireRecord, wholeLine } from "@sidecar/wire";
 import {
   canIgnoreFilesystemError,
   fileStats,
@@ -429,10 +428,7 @@ export class AntigravitySessionAdapter extends LocalSessionAdapter {
     // The agent's latest notification is its own word on where the work
     // stands — the recap field of this store — but only once the turn is not
     // moving past it: mid-run it describes a moment already left behind.
-    const recap =
-      status === SESSION_STATUS.WORKING
-        ? undefined
-        : oneLine(summary.notifyWords, maximumSessionRecapLength);
+    const recap = status === SESSION_STATUS.WORKING ? undefined : wholeLine(summary.notifyWords);
     const link = antigravitySessionLink(profile, summary.conversationId, summary.folderPath);
     return {
       providerSessionId: summary.conversationId,
@@ -512,10 +508,7 @@ export class AntigravitySessionAdapter extends LocalSessionAdapter {
     now: number,
   ): ProviderSessionObservation {
     const status = statusFromDerived(derived.tip, observedAt, now, this.activeSessionFreshnessMs);
-    const recap =
-      status === SESSION_STATUS.WORKING
-        ? undefined
-        : oneLine(derived.notifyWords, maximumSessionRecapLength);
+    const recap = status === SESSION_STATUS.WORKING ? undefined : wholeLine(derived.notifyWords);
     const activity =
       status === SESSION_STATUS.WORKING ||
       (status === SESSION_STATUS.WAITING && derived.tip.holding)

--- a/packages/providers/src/claude-code/adapter.ts
+++ b/packages/providers/src/claude-code/adapter.ts
@@ -1,7 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import {
-  maximumSessionRecapLength,
   maximumSessionTitleLength,
   PROVIDER_ID,
   type ProviderSessionObservation,
@@ -20,6 +19,7 @@ import {
   resolveOptions,
   text,
   type WireRecord,
+  wholeLine,
   wholeNumber,
 } from "@sidecar/wire";
 import {
@@ -334,7 +334,7 @@ function readClaudeRecord(record: WireRecord, parsed: ParsedClaudeSessionTail): 
   }
   if (record.type === CLAUDE_RECORD_TYPE.SYSTEM) {
     if (record.subtype === CLAUDE_SYSTEM_SUBTYPE.AWAY_SUMMARY) {
-      parsed.awaySummary = oneLine(text(record.content), maximumSessionRecapLength);
+      parsed.awaySummary = wholeLine(text(record.content));
     }
     if (record.subtype === CLAUDE_SYSTEM_SUBTYPE.API_ERROR) {
       parsed.apiError = apiErrorFromRecord(record);

--- a/packages/providers/src/codex/adapter.ts
+++ b/packages/providers/src/codex/adapter.ts
@@ -1,7 +1,6 @@
 import os from "node:os";
 import path from "node:path";
 import {
-  maximumSessionRecapLength,
   maximumSessionTitleLength,
   PROVIDER_ID,
   type ProviderSessionObservation,
@@ -24,6 +23,7 @@ import {
   text,
   type UnparsedWireValue,
   type WireRecord,
+  wholeLine,
 } from "@sidecar/wire";
 import {
   type HookStatusRefinement,
@@ -362,10 +362,7 @@ function parseCodexRolloutTail(tail: string): ParsedCodexRollout {
           // A turn that settled cleanly got past any failure it recorded on
           // the way, so a stale error must not outlive it.
           parsed.error = undefined;
-          parsed.lastAgentMessage = oneLine(
-            text(payload.last_agent_message),
-            maximumSessionRecapLength,
-          );
+          parsed.lastAgentMessage = wholeLine(text(payload.last_agent_message));
         }
       }
       continue;

--- a/packages/providers/src/conductor/adapter.test.ts
+++ b/packages/providers/src/conductor/adapter.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { maximumSessionRecapLength, SESSION_STATUS, type SessionControl } from "@sidecar/session";
+import { SESSION_STATUS, type SessionControl } from "@sidecar/session";
 import type { JsonObject, JsonValue } from "@sidecar/wire/testing";
 import { HTTP_STATUS, jsonResponse, recordingFetch } from "@sidecar/wire/testing";
 import { CLOUD_ADAPTER_DEFAULTS, type CloudFetch } from "../shared/cloud-session-adapter.js";
@@ -706,7 +706,8 @@ test("reports no recap for a tail it cannot attribute to the agent", async () =>
   }
 });
 
-test("cuts a recap only at the payload backstop and keeps real parting words whole", async () => {
+test("keeps parting words whole, however long the settled message ran", async () => {
+  const longWords = `the plan landed ${"and a word ".repeat(400)}`.trim();
   const partingWords = `all tests pass ${"and a word ".repeat(80)}`.trim();
   const api = fakeConductorApi({
     userId: TEST_USER_ID,
@@ -720,7 +721,7 @@ test("cuts a recap only at the payload backstop and keeps real parting words who
         id: IDLE_SESSION_UUID,
         workspaceId: "workspace-idle",
         name: TEST_SESSION_NAME,
-        transcriptTail: `## Assistant\n\n${"a word ".repeat(10_000)}`,
+        transcriptTail: `## Assistant\n\n${longWords}`,
         status: TEST_CONDUCTOR_STATUS.IDLE,
         statusUpdatedAt: TEST_TIME - 1_000,
       },
@@ -737,9 +738,9 @@ test("cuts a recap only at the payload backstop and keeps real parting words who
 
   const observations = await adapterFor(api.fetch).observe();
 
-  assert.equal(observations[0]?.recap?.length, maximumSessionRecapLength);
-  // The backstop refuses a runaway payload; real parting words — longer than
-  // the model's excerpt — reach the surfaces whole.
+  // Parting words carry no display bound of their own — the tail read is the
+  // only width — so both messages reach the surfaces whole.
+  assert.equal(observations[0]?.recap, longWords);
   assert.equal(observations[1]?.recap, partingWords);
 });
 

--- a/packages/providers/src/conductor/adapter.test.ts
+++ b/packages/providers/src/conductor/adapter.test.ts
@@ -706,7 +706,7 @@ test("reports no recap for a tail it cannot attribute to the agent", async () =>
   }
 });
 
-test("cuts a recap at the recap bound and keeps a shorter one whole", async () => {
+test("cuts a recap only at the payload backstop and keeps real parting words whole", async () => {
   const partingWords = `all tests pass ${"and a word ".repeat(80)}`.trim();
   const api = fakeConductorApi({
     userId: TEST_USER_ID,
@@ -720,7 +720,7 @@ test("cuts a recap at the recap bound and keeps a shorter one whole", async () =
         id: IDLE_SESSION_UUID,
         workspaceId: "workspace-idle",
         name: TEST_SESSION_NAME,
-        transcriptTail: `## Assistant\n\n${"a word ".repeat(400)}`,
+        transcriptTail: `## Assistant\n\n${"a word ".repeat(10_000)}`,
         status: TEST_CONDUCTOR_STATUS.IDLE,
         statusUpdatedAt: TEST_TIME - 1_000,
       },
@@ -738,7 +738,7 @@ test("cuts a recap at the recap bound and keeps a shorter one whole", async () =
   const observations = await adapterFor(api.fetch).observe();
 
   assert.equal(observations[0]?.recap?.length, maximumSessionRecapLength);
-  // The bound refuses a runaway tail; parting words within it — longer than
+  // The backstop refuses a runaway payload; real parting words — longer than
   // the model's excerpt — reach the surfaces whole.
   assert.equal(observations[1]?.recap, partingWords);
 });

--- a/packages/providers/src/conductor/adapter.test.ts
+++ b/packages/providers/src/conductor/adapter.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { SESSION_STATUS, type SessionControl } from "@sidecar/session";
+import { maximumSessionRecapLength, SESSION_STATUS, type SessionControl } from "@sidecar/session";
 import type { JsonObject, JsonValue } from "@sidecar/wire/testing";
 import { HTTP_STATUS, jsonResponse, recordingFetch } from "@sidecar/wire/testing";
 import { CLOUD_ADAPTER_DEFAULTS, type CloudFetch } from "../shared/cloud-session-adapter.js";
@@ -706,17 +706,29 @@ test("reports no recap for a tail it cannot attribute to the agent", async () =>
   }
 });
 
-test("cuts a recap at the recap bound", async () => {
+test("cuts a recap at the recap bound and keeps a shorter one whole", async () => {
+  const partingWords = `all tests pass ${"and a word ".repeat(80)}`.trim();
   const api = fakeConductorApi({
     userId: TEST_USER_ID,
     projects: [LUKE_PROJECT],
-    workspaces: [ownedWorkspace("workspace-idle", TEST_TIME - 30_000)],
+    workspaces: [
+      ownedWorkspace("workspace-idle", TEST_TIME - 30_000),
+      ownedWorkspace("workspace-talkative", TEST_TIME - 30_000),
+    ],
     sessions: [
       {
         id: IDLE_SESSION_UUID,
         workspaceId: "workspace-idle",
         name: TEST_SESSION_NAME,
-        transcriptTail: `## Assistant\n\n${"a word ".repeat(200)}`,
+        transcriptTail: `## Assistant\n\n${"a word ".repeat(400)}`,
+        status: TEST_CONDUCTOR_STATUS.IDLE,
+        statusUpdatedAt: TEST_TIME - 1_000,
+      },
+      {
+        id: SECOND_IDLE_SESSION_UUID,
+        workspaceId: "workspace-talkative",
+        name: TEST_SESSION_NAME,
+        transcriptTail: `## Assistant\n\n${partingWords}`,
         status: TEST_CONDUCTOR_STATUS.IDLE,
         statusUpdatedAt: TEST_TIME - 1_000,
       },
@@ -725,7 +737,10 @@ test("cuts a recap at the recap bound", async () => {
 
   const observations = await adapterFor(api.fetch).observe();
 
-  assert.equal(observations[0]?.recap?.length, 500);
+  assert.equal(observations[0]?.recap?.length, maximumSessionRecapLength);
+  // The bound refuses a runaway tail; parting words within it — longer than
+  // the model's excerpt — reach the surfaces whole.
+  assert.equal(observations[1]?.recap, partingWords);
 });
 
 test("keeps a session id that is not a UUID out of the read document", async () => {

--- a/packages/providers/src/conductor/adapter.ts
+++ b/packages/providers/src/conductor/adapter.ts
@@ -212,13 +212,14 @@ const CONDUCTOR_SQL_FIELD = {
 } as const;
 
 /**
- * How much of the final message is read: the recap bound itself, because the
- * tail is read only to feed the recap. Tying them keeps the read from ever
- * fetching words the recap could not keep or cutting below what it may show,
- * and makes moving the recap bound the one decision that also moves this
- * read's width.
+ * How much of the final message is read: enough for a recap's worth of its
+ * opening words — where an agent puts the outcome — and no more of it. This
+ * is the read's own width, a decision about how much transcript leaves
+ * Conductor on every pass, so it deliberately does not follow the recap
+ * bound, which is only a payload backstop; a whole conversation is the
+ * documented messages endpoint's job, never this tail's.
  */
-const CONDUCTOR_TRANSCRIPT_TAIL_LENGTH = maximumSessionRecapLength;
+const CONDUCTOR_TRANSCRIPT_TAIL_LENGTH = 2_000;
 
 /**
  * How Conductor's plain-text transcript marks who is speaking. A line inside a

--- a/packages/providers/src/conductor/adapter.ts
+++ b/packages/providers/src/conductor/adapter.ts
@@ -212,10 +212,13 @@ const CONDUCTOR_SQL_FIELD = {
 } as const;
 
 /**
- * How much of the final message is read: enough for a recap's worth of its
- * opening words — where an agent puts the outcome — and no more of it.
+ * How much of the final message is read: the recap bound itself, because the
+ * tail is read only to feed the recap. Tying them keeps the read from ever
+ * fetching words the recap could not keep or cutting below what it may show,
+ * and makes moving the recap bound the one decision that also moves this
+ * read's width.
  */
-const CONDUCTOR_TRANSCRIPT_TAIL_LENGTH = 2_000;
+const CONDUCTOR_TRANSCRIPT_TAIL_LENGTH = maximumSessionRecapLength;
 
 /**
  * How Conductor's plain-text transcript marks who is speaking. A line inside a

--- a/packages/providers/src/conductor/adapter.ts
+++ b/packages/providers/src/conductor/adapter.ts
@@ -3,7 +3,6 @@ import {
   agedStatus,
   agentIdentityFor,
   isListedWorkspaceAgentModel,
-  maximumSessionRecapLength,
   maximumSessionTitleLength,
   OBSERVATION_WINDOW,
   type ProviderSessionObservation,
@@ -1201,7 +1200,7 @@ function recapFromTranscriptTail(tail: string | undefined): string | undefined {
     .join(" ")
     .replace(/\s+/g, " ")
     .trim();
-  return recap ? recap.slice(0, maximumSessionRecapLength) : undefined;
+  return recap || undefined;
 }
 
 /**

--- a/packages/providers/src/cursor/adapter.ts
+++ b/packages/providers/src/cursor/adapter.ts
@@ -2,7 +2,6 @@ import { CREDENTIAL_PROVIDER_ID, CREDENTIAL_PROVIDERS } from "@sidecar/credentia
 import {
   agedStatus,
   maximumObservedWorkspaceProjects,
-  maximumSessionRecapLength,
   maximumSessionTitleLength,
   OBSERVATION_WINDOW,
   type ProviderSessionObservation,
@@ -606,7 +605,7 @@ export class CursorSessionAdapter extends CloudSessionAdapter {
       CURSOR_ADAPTER_DEFAULTS.MAXIMUM_REFERENCE_LABEL_LENGTH,
     );
     const pullRequestUrl = textFromRecord(branch, CURSOR_FIELD.PR_URL);
-    const result = textFromRecord(body, CURSOR_FIELD.RESULT)?.slice(0, maximumSessionRecapLength);
+    const result = textFromRecord(body, CURSOR_FIELD.RESULT);
     return {
       status: knownValue(CURSOR_RUN_STATUS, textFromRecord(body, CURSOR_FIELD.STATUS)),
       updatedAt:

--- a/packages/providers/src/cursor/local-adapter.test.ts
+++ b/packages/providers/src/cursor/local-adapter.test.ts
@@ -5,7 +5,6 @@ import path from "node:path";
 import test, { type TestContext } from "node:test";
 import { pathToFileURL } from "node:url";
 import {
-  maximumSessionRecapLength,
   SESSION_APPLICATION_ID,
   SESSION_APPLICATION_SCOPE,
   SESSION_COMPLETION_CAUSE,
@@ -338,7 +337,9 @@ test("a recap stands only while its turn is the newest word", async (t) => {
     [...settledTurn, messageRecord(TEST_ROLE.USER, TEST_CONTENT_TYPE.TEXT)],
     TEST_TIME - 5_000,
   );
-  // Parting words longer than a recap may carry are cut, not refused.
+  // Parting words carry no display bound: a long settled message is the
+  // recap whole, not an opening with an ellipsis.
+  const longParting = `done: ${"a word ".repeat(300)}`.trim();
   await writeTranscript(
     state,
     "Users-test-luke",
@@ -346,7 +347,7 @@ test("a recap stands only while its turn is the newest word", async (t) => {
     [
       {
         role: TEST_ROLE.ASSISTANT,
-        message: { content: [{ type: "text", text: "y".repeat(maximumSessionRecapLength + 200) }] },
+        message: { content: [{ type: "text", text: longParting }] },
       },
       turnEndedRecord(TEST_TURN_STATUS.SUCCESS),
     ],
@@ -356,8 +357,7 @@ test("a recap stands only while its turn is the newest word", async (t) => {
   const observations = await adapterFor(state).observe();
 
   assert.equal(observations[0]?.recap, undefined);
-  assert.equal(observations[1]?.recap?.length, maximumSessionRecapLength);
-  assert.ok(observations[1]?.recap?.endsWith("…"));
+  assert.equal(observations[1]?.recap, longParting);
   assert.equal(JSON.stringify(observations).includes(SECRET_TRANSCRIPT_TEXT), false);
 });
 

--- a/packages/providers/src/cursor/local-adapter.test.ts
+++ b/packages/providers/src/cursor/local-adapter.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import test, { type TestContext } from "node:test";
 import { pathToFileURL } from "node:url";
 import {
+  maximumSessionRecapLength,
   SESSION_APPLICATION_ID,
   SESSION_APPLICATION_SCOPE,
   SESSION_COMPLETION_CAUSE,
@@ -345,7 +346,7 @@ test("a recap stands only while its turn is the newest word", async (t) => {
     [
       {
         role: TEST_ROLE.ASSISTANT,
-        message: { content: [{ type: "text", text: "y".repeat(700) }] },
+        message: { content: [{ type: "text", text: "y".repeat(maximumSessionRecapLength + 200) }] },
       },
       turnEndedRecord(TEST_TURN_STATUS.SUCCESS),
     ],
@@ -355,7 +356,7 @@ test("a recap stands only while its turn is the newest word", async (t) => {
   const observations = await adapterFor(state).observe();
 
   assert.equal(observations[0]?.recap, undefined);
-  assert.equal(observations[1]?.recap?.length, 500);
+  assert.equal(observations[1]?.recap?.length, maximumSessionRecapLength);
   assert.ok(observations[1]?.recap?.endsWith("…"));
   assert.equal(JSON.stringify(observations).includes(SECRET_TRANSCRIPT_TEXT), false);
 });

--- a/packages/providers/src/cursor/local-adapter.ts
+++ b/packages/providers/src/cursor/local-adapter.ts
@@ -6,7 +6,6 @@ import { fileURLToPath } from "node:url";
 import { boundedInvocation, DEFAULT_CLI_PATH_DIRECTORIES } from "@sidecar/process";
 import {
   ACT_RESULT_STATUS,
-  maximumSessionRecapLength,
   maximumSessionTitleLength,
   type ProviderMessageResult,
   type ProviderSessionObservation,
@@ -29,6 +28,7 @@ import {
   unparsedWire,
   type WireBoundaryInput,
   type WireRecord,
+  wholeLine,
   wholeNumber,
   wireRecord,
 } from "@sidecar/wire";
@@ -436,7 +436,7 @@ function parseCursorTail(tail: string): ParsedCursorTail {
       // A turn that ended is not running its last call, and holding it would
       // keep a stale line on the row until some other tool runs.
       parsed.activity = undefined;
-      parsed.recap = failed ? undefined : oneLine(partingWords, maximumSessionRecapLength);
+      parsed.recap = failed ? undefined : wholeLine(partingWords);
       partingWords = undefined;
       continue;
     }

--- a/packages/providers/src/gemini-cli/adapter.ts
+++ b/packages/providers/src/gemini-cli/adapter.ts
@@ -1,6 +1,5 @@
 import path from "node:path";
 import {
-  maximumSessionRecapLength,
   maximumSessionTitleLength,
   PROVIDER_ID,
   type ProviderSessionObservation,
@@ -12,7 +11,7 @@ import {
   type SessionProvider,
   type SessionStatus,
 } from "@sidecar/session";
-import { isRecord, isWireString, oneLine, text, type WireRecord } from "@sidecar/wire";
+import { isRecord, isWireString, oneLine, text, type WireRecord, wholeLine } from "@sidecar/wire";
 import {
   discoverSessionFiles,
   type HookStatusRefinement,
@@ -212,7 +211,7 @@ export function parseGeminiSessionTail(tail: string): ParsedGeminiSessionTail {
       // A newer prompt or a recorded failure makes a different message the
       // tip, so neither can inherit a stale recap.
       if (parsed.holdingForApproval !== true && parsed.toolCallsOpen !== true) {
-        parsed.recap = oneLine(geminiContentText(message.content), maximumSessionRecapLength);
+        parsed.recap = wholeLine(geminiContentText(message.content));
       }
     }
   }

--- a/packages/providers/src/grok-build/adapter.ts
+++ b/packages/providers/src/grok-build/adapter.ts
@@ -1,6 +1,5 @@
 import path from "node:path";
 import {
-  maximumSessionRecapLength,
   maximumSessionTitleLength,
   PROVIDER_ID,
   type ProviderSessionObservation,
@@ -18,6 +17,7 @@ import {
   text,
   type UnparsedWireValue,
   type WireRecord,
+  wholeLine,
 } from "@sidecar/wire";
 import {
   discoverSessionFiles,
@@ -191,7 +191,7 @@ function recapFromUpdates(updates: readonly WireRecord[]): string | undefined {
     if (words !== undefined) chunks.unshift(words);
   }
   // Chunks are stream deltas of one message, so they join without separators.
-  return oneLine(chunks.join(""), maximumSessionRecapLength);
+  return wholeLine(chunks.join(""));
 }
 
 /** The words of the failure the CLI recorded on the turn's closing update. */
@@ -553,9 +553,7 @@ function observationFromSnapshot(
     // The recap the CLI wrote itself is reported only behind a settled turn:
     // while a newer turn runs, it describes the turn before and would pose
     // as an outcome the session has not reached.
-    ...(settled && snapshot.recap
-      ? { recap: oneLine(snapshot.recap, maximumSessionRecapLength) }
-      : undefined),
+    ...(settled && snapshot.recap ? { recap: wholeLine(snapshot.recap) } : undefined),
     ...(snapshot.directory ? { directory: snapshot.directory } : undefined),
     detail: {
       ...(snapshot.turn?.activity ? { activity: snapshot.turn.activity } : undefined),

--- a/packages/providers/src/omp/adapter.ts
+++ b/packages/providers/src/omp/adapter.ts
@@ -1,6 +1,5 @@
 import path from "node:path";
 import {
-  maximumSessionRecapLength,
   maximumSessionTitleLength,
   PROVIDER_ID,
   type ProviderSessionObservation,
@@ -12,7 +11,7 @@ import {
   type SessionProvider,
   type SessionStatus,
 } from "@sidecar/session";
-import { isRecord, isWireString, oneLine, text, type WireRecord } from "@sidecar/wire";
+import { isRecord, isWireString, oneLine, text, type WireRecord, wholeLine } from "@sidecar/wire";
 import {
   discoverSessionFiles,
   LOCAL_ADAPTER_DEFAULTS,
@@ -215,7 +214,7 @@ function parseTail(tail: string): Omit<ParsedOmpSession, "cwd" | "title"> {
     // sentence mid-turn — or cut by an abort or an error — poses as an outcome.
     parsed.recap =
       open.size === 0 && parsed.turnFailed !== true && parsed.turnAborted !== true
-        ? oneLine(ompMessageText(message), maximumSessionRecapLength)
+        ? wholeLine(ompMessageText(message))
         : undefined;
   }
 

--- a/packages/providers/src/radius/adapter.ts
+++ b/packages/providers/src/radius/adapter.ts
@@ -1,5 +1,4 @@
 import {
-  maximumSessionRecapLength,
   maximumSessionTitleLength,
   PROVIDER_ID,
   type ProviderSessionObservation,
@@ -13,7 +12,14 @@ import {
   type SessionStatus,
   type SessionWorkspace,
 } from "@sidecar/session";
-import { isRecord, oneLine, recordFromJsonLine, text, type WireRecord } from "@sidecar/wire";
+import {
+  isRecord,
+  oneLine,
+  recordFromJsonLine,
+  text,
+  type WireRecord,
+  wholeLine,
+} from "@sidecar/wire";
 import {
   LocalSessionAdapter,
   type LocalSessionAdapterOptions,
@@ -230,7 +236,7 @@ function tipFromEvents(events: readonly WireRecord[]): RadiusTurnTip {
     }
     if (kind === RADIUS_EVENT_KIND.MESSAGE_COMPLETED && recap === undefined && payload) {
       if (text(payload.role) === RADIUS_MESSAGE_ROLE.ASSISTANT) {
-        recap = oneLine(text(payload.text), maximumSessionRecapLength);
+        recap = wholeLine(text(payload.text));
       }
     }
   }

--- a/packages/providers/src/replicas/adapter.ts
+++ b/packages/providers/src/replicas/adapter.ts
@@ -2,7 +2,6 @@ import { CREDENTIAL_PROVIDER_ID, CREDENTIAL_PROVIDERS } from "@sidecar/credentia
 import {
   AGENT_IDENTITY,
   agedStatus,
-  maximumSessionRecapLength,
   OBSERVATION_WINDOW,
   type ProviderSessionObservation,
   type ProviderWorkspaceAgentRequest,
@@ -619,7 +618,7 @@ function modelLabel(
 /** One line of bounded parting words, flattened the way every recap is drawn. */
 function recapText(text: string): string | undefined {
   const flattened = text.replace(/\s+/g, " ").trim();
-  return flattened ? flattened.slice(0, maximumSessionRecapLength) : undefined;
+  return flattened || undefined;
 }
 
 /**

--- a/packages/realtime/src/realtime-context.ts
+++ b/packages/realtime/src/realtime-context.ts
@@ -1,4 +1,6 @@
 import {
+  boundedText,
+  maximumSessionRecapExcerptLength,
   type ObservedWorkspaceProject,
   SESSION_LOCATION,
   type Session,
@@ -227,9 +229,16 @@ export function sessionContextText(sessions: readonly Session[], now: number = D
         sessionAgeText(session.observedAt, now),
         ...sessionAboutText(session),
         // Stating an absence in context invites the voice to speak it, so a
-        // session without a recap simply omits the segment.
+        // session without a recap simply omits the segment. The excerpt, not
+        // the retained recap: the roster keeps a longer one for the panel,
+        // and this render is a place recaps leave the machine.
         ...(session.recap
-          ? [`context for naming this work — do not list its parts: ${session.recap}`]
+          ? [
+              `context for naming this work — do not list its parts: ${boundedText(
+                session.recap,
+                maximumSessionRecapExcerptLength,
+              )}`,
+            ]
           : []),
         `[${sessionCapabilityText(session, {
           mostRecentForProvider: mostRecent.get(session.providerId) === session,

--- a/packages/realtime/src/realtime.test.ts
+++ b/packages/realtime/src/realtime.test.ts
@@ -40,6 +40,7 @@ import {
   workspaceProjectContextText,
 } from "@sidecar/realtime";
 import {
+  maximumSessionRecapExcerptLength,
   maximumWorkspaceNameLength,
   normalizeSession,
   type ObservedWorkspaceProject,
@@ -917,6 +918,23 @@ test("the roster marks a recap as context for naming the work, not prose to reci
     sessionContextText([working]),
     /context for naming this work — do not list its parts: Unifying spawning/,
   );
+
+  // The roster retains a longer recap for the panel; what this render sends
+  // off the machine stays cut to the excerpt.
+  const talkative = normalizeSession(
+    { id: "codex", displayName: "Codex" },
+    {
+      providerSessionId: "session-with-long-recap",
+      title: "Implement the plan",
+      status: SESSION_STATUS.WORKING,
+      observedAt: DECIDED_AT,
+      recap: `The whole plan landed. ${"y".repeat(maximumSessionRecapExcerptLength + 200)}`,
+    },
+  );
+  assert.equal(talkative.recap?.length, maximumSessionRecapExcerptLength + 223);
+  const rendered = sessionContextText([talkative]);
+  assert.ok(rendered.includes(talkative.recap?.slice(0, maximumSessionRecapExcerptLength) ?? ""));
+  assert.ok(!rendered.includes(talkative.recap ?? ""));
 });
 
 test("the roster says which sessions keep a readable transcript and a pull request, never an address", () => {

--- a/packages/session/src/index.ts
+++ b/packages/session/src/index.ts
@@ -67,7 +67,6 @@ export {
   maximumSessionDetailLength,
   maximumSessionMessageLength,
   maximumSessionRecapExcerptLength,
-  maximumSessionRecapLength,
   maximumSessionTitleLength,
   normalizeAttention,
   normalizeSession,

--- a/packages/session/src/index.ts
+++ b/packages/session/src/index.ts
@@ -66,6 +66,7 @@ export {
   maximumSessionApplications,
   maximumSessionDetailLength,
   maximumSessionMessageLength,
+  maximumSessionRecapExcerptLength,
   maximumSessionRecapLength,
   maximumSessionTitleLength,
   normalizeAttention,

--- a/packages/session/src/session-registry.test.ts
+++ b/packages/session/src/session-registry.test.ts
@@ -3,7 +3,6 @@ import test from "node:test";
 import {
   ATTENTION_DISPOSITION,
   InMemorySessionRegistry,
-  maximumSessionRecapLength,
   type ProviderSessionObservation,
   SESSION_APPLICATION_ID,
   SESSION_APPLICATION_SCOPE,
@@ -44,7 +43,7 @@ test("normalizes provider observations without conflating provider-local identit
     observation("run:42", 100, {
       title: "  Implement the shared session core  ",
       parentProviderSessionId: "  run:parent  ",
-      recap: `  ${"a".repeat(maximumSessionRecapLength + 1)}  `,
+      recap: `  ${"a".repeat(2_000)}  `,
       controls: [{ id: TEST_CONTROL_WITH_WHITESPACE, label: " Open workspace " }],
     }),
   );
@@ -56,7 +55,8 @@ test("normalizes provider observations without conflating provider-local identit
   );
   assert.equal(session.title, "Implement the shared session core");
   assert.equal(session.parentProviderSessionId, "run:parent");
-  assert.equal(session.recap?.length, maximumSessionRecapLength);
+  // Trimmed, never cut: the recap carries the whole parting words.
+  assert.equal(session.recap, "a".repeat(2_000));
   assert.deepEqual(session.controls, [{ id: TEST_CONTROL.OPEN, label: "Open workspace" }]);
   assert.deepEqual(registry.snapshot().attention, []);
   assert.equal(supportsSessionControl(session, TEST_CONTROL.OPEN), true);

--- a/packages/session/src/session.ts
+++ b/packages/session/src/session.ts
@@ -543,15 +543,15 @@ export const maximumSpawnableAgentLength = 40;
 /** How many kinds of agent one session may offer to start. */
 export const maximumSpawnableAgents = 8;
 /**
- * How long a reported recap may run: a wire-hygiene bound on an observed
- * field, not a model bound. It matches the widest read any adapter
- * deliberately makes (Conductor's transcript tail), so a recap is never cut
- * below words an adapter was allowed to read, and the surfaces that draw it —
- * a row, a session's own screen — show the settled turn's parting words
- * whole. What may enter a model window or leave the machine unbidden is the
- * narrower {@link maximumSessionRecapExcerptLength}.
+ * How long a reported recap may run: a backstop against a corrupt or hostile
+ * session file, not a display budget. Real parting words never approach it,
+ * so every surface that draws a recap shows the whole message; what the
+ * bound refuses is a runaway payload riding the roster through IPC, the
+ * hosted wire, and a panel recording on every observation pass. What may
+ * enter a model window or leave the machine unbidden is the narrower
+ * {@link maximumSessionRecapExcerptLength}.
  */
-export const maximumSessionRecapLength = 2_000;
+export const maximumSessionRecapLength = 64_000;
 /**
  * The bounded excerpt of a recap that may reach a model: the attention
  * evaluator's update, the announcement worded from it, and the voice roster

--- a/packages/session/src/session.ts
+++ b/packages/session/src/session.ts
@@ -427,8 +427,10 @@ export interface ProviderSessionObservation {
    */
   agent?: SessionProvider;
   /**
-   * A bounded recap of where the work stands — provider-designated, or a
-   * settled turn's parting words. Never the transcript behind it.
+   * A recap of where the work stands — provider-designated, or a settled
+   * turn's parting words, kept whole. Never the transcript behind it, and
+   * never a model's whole to read: what may enter a model window is the
+   * {@link maximumSessionRecapExcerptLength} excerpt its consumers cut.
    */
   recap?: string;
   detail?: SessionDetail;
@@ -543,21 +545,12 @@ export const maximumSpawnableAgentLength = 40;
 /** How many kinds of agent one session may offer to start. */
 export const maximumSpawnableAgents = 8;
 /**
- * How long a reported recap may run: a backstop against a corrupt or hostile
- * session file, not a display budget. Real parting words never approach it,
- * so every surface that draws a recap shows the whole message; what the
- * bound refuses is a runaway payload riding the roster through IPC, the
- * hosted wire, and a panel recording on every observation pass. What may
- * enter a model window or leave the machine unbidden is the narrower
- * {@link maximumSessionRecapExcerptLength}.
- */
-export const maximumSessionRecapLength = 64_000;
-/**
  * The bounded excerpt of a recap that may reach a model: the attention
  * evaluator's update, the announcement worded from it, and the voice roster
- * context all cut to this at their own edge, so a longer retained recap
- * costs a model window — and sends unbidden — exactly what the shorter
- * retained recap used to.
+ * context all cut to this at their own edge. The recap itself carries no
+ * length bound — it is the settled turn's whole parting words, drawn on the
+ * user's own surfaces — so this excerpt is the one place its length is a
+ * budget at all.
  */
 export const maximumSessionRecapExcerptLength = 500;
 /** One line of context beside a title, not a paragraph. */
@@ -890,7 +883,7 @@ export function normalizeSession(
   const observedAt = timestamp(observation.observedAt, "observedAt");
   const status = normalizeStatus(observation.status);
   const completionCause = normalizeCompletionCause(observation.completionCause, status);
-  const recap = boundedText(observation.recap, maximumSessionRecapLength);
+  const recap = observation.recap?.trim() || undefined;
   const parentProviderSessionId = boundedText(
     observation.parentProviderSessionId,
     maximumSessionDetailLength,

--- a/packages/session/src/session.ts
+++ b/packages/session/src/session.ts
@@ -542,7 +542,24 @@ export const maximumSessionApplications = SESSION_APPLICATION_ID_LIST.length;
 export const maximumSpawnableAgentLength = 40;
 /** How many kinds of agent one session may offer to start. */
 export const maximumSpawnableAgents = 8;
-export const maximumSessionRecapLength = 500;
+/**
+ * How long a reported recap may run: a wire-hygiene bound on an observed
+ * field, not a model bound. It matches the widest read any adapter
+ * deliberately makes (Conductor's transcript tail), so a recap is never cut
+ * below words an adapter was allowed to read, and the surfaces that draw it —
+ * a row, a session's own screen — show the settled turn's parting words
+ * whole. What may enter a model window or leave the machine unbidden is the
+ * narrower {@link maximumSessionRecapExcerptLength}.
+ */
+export const maximumSessionRecapLength = 2_000;
+/**
+ * The bounded excerpt of a recap that may reach a model: the attention
+ * evaluator's update, the announcement worded from it, and the voice roster
+ * context all cut to this at their own edge, so a longer retained recap
+ * costs a model window — and sends unbidden — exactly what the shorter
+ * retained recap used to.
+ */
+export const maximumSessionRecapExcerptLength = 500;
 /** One line of context beside a title, not a paragraph. */
 export const maximumSessionDetailLength = 120;
 /** Long enough for any provider's session address without becoming a payload. */

--- a/packages/wire/src/index.ts
+++ b/packages/wire/src/index.ts
@@ -23,6 +23,7 @@ export {
   type WirePrimitive,
   type WireRecord,
   type WireValue,
+  wholeLine,
   wholeNumber,
 } from "./json.js";
 export { parseReleaseVersion } from "./release-version.js";

--- a/packages/wire/src/json.ts
+++ b/packages/wire/src/json.ts
@@ -70,6 +70,15 @@ export function oneLine(value: string | undefined, maximumLength: number): strin
     : normalized;
 }
 
+/**
+ * Collapses whitespace like {@link oneLine} with no length bound, for a field
+ * whose whole words are the point of reporting it.
+ */
+export function wholeLine(value: string | undefined): string | undefined {
+  const normalized = value?.replace(/\s+/gu, " ").trim();
+  return normalized || undefined;
+}
+
 export function recordFromJsonLine(line: string): WireRecord | undefined {
   try {
     // SAFETY: JSON.parse returns a runtime value; isRecord validates the object contract.


### PR DESCRIPTION
Precursor for #612: the session detail view's agent bubble draws the roster recap, which arrived pre-cut to 500 characters, so long parting words read truncated on iOS (and on any surface that draws the recap).

## What changes

The recap was cut to 500 in ~12 places — every provider adapter (`oneLine(..., maximumSessionRecapLength)` / `.slice(...)`), again at `normalizeSession`, and the attention wire guard — even though the cut only exists to bound what an update or a voice render costs a model window and sends off the machine.

- **The recap carries no length bound at all now.** `maximumSessionRecapLength` is deleted. Adapters flatten parting words through the new unbounded `wholeLine` in `@sidecar/wire` (same whitespace collapse as `oneLine`, no cut, no ellipsis), and `normalizeSession` only trims. Every surface — desktop rows (CSS-clamped), the hosted roster, the iOS detail bubble — receives the settled turn's whole message.
- **`packages/session`** — new `maximumSessionRecapExcerptLength = 500`: the one place a recap's length is a budget, applied where it enters a model window or leaves the machine unbidden.
- **`packages/attention`** — `attentionUpdate` carries the recap's 500-character excerpt, never the retained recap; the `RECAP_CHANGED` development comparison and `#isSuperseded` compare the same excerpt on both sides (a recap that changed only past the excerpt is a difference no evaluator could see, so it opens no review the model would judge blind — and supersedes none); the hosted-review wire guard validates at the excerpt bound.
- **`packages/realtime`** — the voice roster context cuts its recap segment to the excerpt at render.
- **`packages/providers/conductor`** — the transcript tail read keeps its own literal width (2,000 characters): how much transcript leaves Conductor on every pass is a read decision, deliberately independent of recap handling, so Conductor recaps top out at what the read itself fetches. A whole conversation is the documented messages endpoint's job (follow-up in flight), never this tail's.

## What deliberately does not change

What reaches a model or leaves the machine unbidden — the evaluator update, edge announcements worded from it, and the voice roster render — stays cut to 500 exactly as today, so the AGENTS.md posture around the evaluator ("a bounded excerpt of the recap") holds unchanged and PRIVACY.md needs no edit (it names no recap length; summaries were already disclosed as shown on the panel and included in recordings).

## Downstream

Once this merges, rebase #612 onto main and the hosted roster serves whole-message recaps with no server or iOS change: `observe.ts` passes `obs.recap` through and `RosterSession` decodes whatever arrives. Conductor's recap still tops out at its 2,000-character tail read; the full-conversation detail view rides the documented `GET /v0/sessions/{id}/messages` endpoint as its own follow-up PR.

## Verification

`./scripts/check.sh` passes (exit 0). Portable-only change — no `apps/` files touched — so per AGENTS.md no macOS evidence run is required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/33584941046/artifacts/9829788784) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/33584941046)

- Commit: `512a59919ca58a89c291531e3a2b2c0cfda86226`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
