### PR TITLE
feat(voice): adopt the OpenAI Agents realtime SDK for voice transport

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -38,6 +38,7 @@
   },
   "devDependencies": {
     "@sentry/esbuild-plugin": "5.4.0",
+    "@openai/agents-realtime": "0.17.0",
     "@sidecar/account": "workspace:*",
     "@sidecar/acts": "workspace:*",
     "@sidecar/analytics": "workspace:*",
@@ -70,7 +71,8 @@
     "react": "19.2.8",
     "react-dom": "19.2.8",
     "tsx": "4.23.12",
-    "typescript": "7.0.2"
+    "typescript": "7.0.2",
+    "zod": "4.5.4"
   },
   "dependencies": {
     "@sentry/electron": "7.18.0",

--- a/apps/desktop/src/renderer/agents-realtime-transport.test.ts
+++ b/apps/desktop/src/renderer/agents-realtime-transport.test.ts
@@ -1,0 +1,213 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { ScriptedRealtimeTransport } from "@openai/agents-realtime/testing";
+import {
+  introductionSessionConfig,
+  type RealtimeConnection,
+  realtimeSessionConfig,
+} from "@sidecar/realtime";
+import { ACT_RESULT_STATUS } from "@sidecar/wire";
+import {
+  agentsRealtimeErrorMessage,
+  type BuiltRealtimeSessionConfig,
+  createAgentsRealtimeTransport,
+} from "./agents-realtime-transport";
+
+const CONNECTION: RealtimeConnection = {
+  value: "ek_test_secret",
+  expiresAt: 1_800_000_060_000,
+  model: "gpt-realtime-2.1",
+  callsUrl: "https://api.openai.com/v1/realtime/calls",
+};
+
+interface CircularSdkError {
+  error?: { message: string; circular?: CircularSdkError };
+}
+
+function sdkHarness(config: BuiltRealtimeSessionConfig) {
+  const transport = new ScriptedRealtimeTransport();
+  const errors: string[] = [];
+  const executed: string[] = [];
+  const session = createAgentsRealtimeTransport(
+    {
+      sessionConfig: config,
+      audioElement: undefined,
+      onPeerConnection: () => undefined,
+      onTransportEvent: () => undefined,
+      onClientEvent: () => undefined,
+      onToolOutputSent: () => undefined,
+      onConnectionChange: () => undefined,
+      onError: (message) => errors.push(message),
+      executeTool: async (name) => {
+        executed.push(name);
+        return { status: ACT_RESULT_STATUS.ACCEPTED };
+      },
+    },
+    transport,
+  );
+  return { errors, executed, session, transport };
+}
+
+async function connect(context: ReturnType<typeof sdkHarness>) {
+  const call = context.transport.expectCall("connect");
+  await context.session.connect({
+    apiKey: CONNECTION.value,
+    model: CONNECTION.model,
+    url: CONNECTION.callsUrl,
+  });
+  return call;
+}
+
+test("the production SDK adapter preserves full, empty, and subset tool lists", async () => {
+  const full = realtimeSessionConfig({ voice: "ash", speed: 1.25 });
+  const cases: readonly {
+    name: string;
+    config: BuiltRealtimeSessionConfig;
+    expectedTools: readonly string[];
+    expectedToolChoice: "auto" | "none";
+  }[] = [
+    {
+      name: "full",
+      config: full,
+      expectedTools: full.tools.map(({ name }) => name),
+      expectedToolChoice: "auto",
+    },
+    {
+      name: "empty",
+      config: introductionSessionConfig(),
+      expectedTools: [],
+      expectedToolChoice: "none",
+    },
+    {
+      name: "subset",
+      config: { ...full, tools: full.tools.slice(0, 1) },
+      expectedTools: full.tools.slice(0, 1).map(({ name }) => name),
+      expectedToolChoice: "auto",
+    },
+  ];
+
+  for (const fixture of cases) {
+    const context = sdkHarness(fixture.config);
+    const call = await connect(context);
+    const tools = call.options.initialSessionConfig?.tools ?? [];
+    assert.deepEqual(
+      tools.map((tool) => ("name" in tool ? tool.name : undefined)),
+      fixture.expectedTools,
+      fixture.name,
+    );
+    assert.equal(call.options.initialSessionConfig?.toolChoice, fixture.expectedToolChoice);
+    const close = context.transport.expectCall("close");
+    context.session.close();
+    await close;
+  }
+});
+
+test("the production SDK adapter carries the complete session configuration", async () => {
+  const context = sdkHarness(realtimeSessionConfig({ voice: "ash", speed: 1.25 }));
+  const call = await connect(context);
+  const config = call.options.initialSessionConfig;
+
+  assert.ok(config && "audio" in config);
+  assert.equal(config?.toolChoice, "auto");
+  assert.deepEqual(config?.reasoning, { effort: "low" });
+  assert.deepEqual(config?.audio, {
+    input: {
+      format: { type: "audio/pcm", rate: 24_000 },
+      transcription: { model: "gpt-live-transcribe" },
+      turnDetection: null,
+    },
+    output: { voice: "ash", speed: 1.25 },
+  });
+  assert.deepEqual(config?.providerData, {
+    truncation: { type: "retention_ratio", retention_ratio: 0.8 },
+  });
+
+  const close = context.transport.expectCall("close");
+  context.session.close();
+  await close;
+});
+
+test("the production SDK adapter omits reasoning for an unsupported model", async () => {
+  const context = sdkHarness(realtimeSessionConfig({ model: "gpt-realtime-preview" }));
+  const call = await connect(context);
+
+  assert.equal(call.options.initialSessionConfig?.reasoning, undefined);
+
+  const close = context.transport.expectCall("close");
+  context.session.close();
+  await close;
+});
+
+test("the production SDK adapter executes only its configured tool", async () => {
+  const full = realtimeSessionConfig();
+  const [definition] = full.tools;
+  assert.ok(definition);
+  const context = sdkHarness({ ...full, tools: [definition] });
+  await connect(context);
+
+  const output = context.transport.expectCall("sendFunctionCallOutput");
+  context.transport.emit("function_call", {
+    type: "function_call",
+    name: definition.name,
+    callId: "call-1",
+    arguments: "{}",
+    responseId: "response-1",
+  });
+  const call = await output;
+
+  assert.deepEqual(context.executed, [definition.name]);
+  assert.equal(call.toolCall.callId, "call-1");
+  assert.equal(call.startResponse, false);
+  assert.deepEqual(JSON.parse(call.output), { status: ACT_RESULT_STATUS.ACCEPTED });
+
+  const close = context.transport.expectCall("close");
+  context.session.close();
+  await close;
+});
+
+test("SDK errors are rendered without serializing unknown values", () => {
+  const circular: CircularSdkError = {};
+  circular.error = { message: "transport failed", circular };
+
+  assert.equal(agentsRealtimeErrorMessage(circular), "transport failed");
+  assert.doesNotThrow(() => agentsRealtimeErrorMessage({ value: 1n }));
+  assert.equal(
+    agentsRealtimeErrorMessage(
+      new Proxy(
+        {},
+        {
+          get: () => {
+            throw new Error("unreadable");
+          },
+        },
+      ),
+    ),
+    "The voice connection failed.",
+  );
+});
+
+test("a server error is left to the session's own filter, not reported twice", async () => {
+  const context = sdkHarness(realtimeSessionConfig());
+  await connect(context);
+
+  context.transport.emit("error", {
+    type: "error",
+    error: { type: "error", error: { message: "Audio content of 1ms is already shorter" } },
+  });
+  assert.deepEqual(context.errors, []);
+
+  context.transport.emit("error", { type: "error", error: new Error("ice failed") });
+  assert.deepEqual(context.errors, ["ice failed"]);
+  context.transport.disconnect();
+});
+
+test("an SDK close failure is reported without escaping or running twice", async () => {
+  const context = sdkHarness(realtimeSessionConfig());
+  await connect(context);
+  context.transport.failNextCall("close", new Error("close failed"));
+
+  assert.doesNotThrow(() => context.session.close());
+  assert.doesNotThrow(() => context.session.close());
+  assert.deepEqual(context.errors, ["close failed"]);
+  context.transport.disconnect();
+});

--- a/apps/desktop/src/renderer/agents-realtime-transport.ts
+++ b/apps/desktop/src/renderer/agents-realtime-transport.ts
@@ -1,0 +1,267 @@
+import {
+  backgroundResult,
+  OpenAIRealtimeWebRTC,
+  RealtimeAgent,
+  type RealtimeClientMessage,
+  RealtimeSession,
+  type RealtimeSessionConfig,
+  type RealtimeTransportLayer,
+  type TransportError,
+  type TransportEvent,
+  type TransportToolCallEvent,
+  tool,
+} from "@openai/agents-realtime";
+import type { realtimeSessionConfig } from "@sidecar/realtime";
+import { isRecord, text, type UnparsedWireValue, type WireRecord } from "@sidecar/wire";
+
+export type BuiltRealtimeSessionConfig = ReturnType<typeof realtimeSessionConfig>;
+
+export interface SdkToolCallDetails {
+  toolCall?: {
+    type?: string;
+    callId?: string;
+    name?: string;
+    arguments?: string;
+  };
+}
+
+export interface SdkRealtimeTransport {
+  readonly status: "connecting" | "connected" | "disconnected" | "disconnecting";
+  connect(options: { apiKey: string; model: string; url: string }): Promise<void>;
+  sendEvent(event: WireRecord): void;
+  sendMessage(message: string): void;
+  close(): void;
+}
+
+export interface SdkTransportFactoryOptions {
+  sessionConfig: BuiltRealtimeSessionConfig;
+  audioElement: HTMLAudioElement | undefined;
+  onPeerConnection(peer: RTCPeerConnection, silenceTrack: MediaStreamTrack): void;
+  onTransportEvent(event: UnparsedWireValue): void;
+  onClientEvent(event: WireRecord): void;
+  onToolOutputSent(callId: string): void;
+  onConnectionChange(status: SdkRealtimeTransport["status"]): void;
+  onError(message: string): void;
+  executeTool(name: string, details: SdkToolCallDetails | undefined): Promise<WireRecord>;
+}
+
+export type SdkTransportFactory = (options: SdkTransportFactoryOptions) => SdkRealtimeTransport;
+
+interface SdkErrorRecord {
+  readonly type?: TransportError["error"];
+  readonly error?: TransportError["error"];
+  readonly message?: TransportError["error"];
+}
+
+function sdkErrorRecord(value: TransportError["error"]): SdkErrorRecord | undefined {
+  if (value === null || value === undefined) return undefined;
+  if (Object.prototype.toString.call(value) !== "[object Object]") return undefined;
+  const prototype = Object.getPrototypeOf(value);
+  if (prototype !== Object.prototype && prototype !== null) return undefined;
+  // SAFETY: The runtime checks establish a plain object whose fields remain untrusted below.
+  return value as SdkErrorRecord;
+}
+
+function sdkErrorText(value: TransportError["error"]): string | undefined {
+  if (Object.prototype.toString.call(value) !== "[object String]") return undefined;
+  // SAFETY: The runtime tag above establishes a string before its content is normalized.
+  const normalized = (value as string).trim();
+  return normalized || undefined;
+}
+
+export function agentsRealtimeErrorMessage(error: TransportError["error"]): string {
+  try {
+    if (error instanceof Error) return error.message;
+    const record = sdkErrorRecord(error);
+    if (record) {
+      const nested = sdkErrorRecord(record.error);
+      return sdkErrorText(nested?.message) ?? sdkErrorText(record.message) ?? String(error);
+    }
+    return String(error);
+  } catch {
+    return "The voice connection failed.";
+  }
+}
+
+function sdkSessionConfig(config: BuiltRealtimeSessionConfig): Partial<RealtimeSessionConfig> {
+  return {
+    model: config.model,
+    reasoning: config.reasoning,
+    instructions: config.instructions,
+    toolChoice: config.tool_choice,
+    outputModalities: ["audio"],
+    audio: {
+      input: {
+        format: { type: "audio/pcm", rate: config.audio.input.format.rate },
+        transcription: config.audio.input.transcription,
+        turnDetection: config.audio.input.turn_detection,
+      },
+      output: {
+        voice: config.audio.output.voice,
+        speed: config.audio.output.speed,
+      },
+    },
+    providerData: { truncation: config.truncation },
+  };
+}
+
+class LukeRealtimeWebRTC extends OpenAIRealtimeWebRTC {
+  readonly #onClientEvent: (event: WireRecord) => void;
+  readonly #onToolOutputSent: (callId: string) => void;
+
+  constructor(
+    options: ConstructorParameters<typeof OpenAIRealtimeWebRTC>[0],
+    onClientEvent: (event: WireRecord) => void,
+    onToolOutputSent: (callId: string) => void,
+  ) {
+    super(options);
+    this.#onClientEvent = onClientEvent;
+    this.#onToolOutputSent = onToolOutputSent;
+  }
+
+  override sendEvent(event: RealtimeClientMessage): void {
+    super.sendEvent(event);
+    if (isRecord(event)) this.#onClientEvent(event);
+  }
+
+  override sendFunctionCallOutput(
+    toolCall: TransportToolCallEvent,
+    output: string,
+    startResponse = true,
+  ): void {
+    super.sendFunctionCallOutput(toolCall, output, startResponse);
+    this.#onToolOutputSent(toolCall.callId);
+  }
+}
+
+/**
+ * Owns the Agents SDK objects and the browser resources created solely for
+ * their WebRTC transport. Tests may supply the SDK's scripted transport; the
+ * production path creates the real WebRTC transport and its silent sender.
+ */
+export function createAgentsRealtimeTransport(
+  options: SdkTransportFactoryOptions,
+  injectedTransport?: RealtimeTransportLayer,
+): SdkRealtimeTransport {
+  const report = (error: TransportError["error"]): void => {
+    try {
+      options.onError(agentsRealtimeErrorMessage(error));
+    } catch {
+      // Closing a call must not be defeated by an error reporter.
+    }
+  };
+
+  let releaseOwnedResources: (() => void) | undefined;
+  const transport =
+    injectedTransport ??
+    (() => {
+      const silenceContext = new AudioContext();
+      const silenceStream = silenceContext.createMediaStreamDestination().stream;
+      const [silenceTrack] = silenceStream.getAudioTracks();
+      if (!silenceTrack) {
+        try {
+          void silenceContext.close().catch(report);
+        } catch (error) {
+          report(error);
+        }
+        throw new Error("Could not create a silent audio track.");
+      }
+      releaseOwnedResources = () => {
+        let tracks: readonly MediaStreamTrack[] = [];
+        try {
+          tracks = silenceStream.getTracks();
+        } catch (error) {
+          report(error);
+        }
+        for (const track of tracks) {
+          try {
+            track.stop();
+          } catch (error) {
+            report(error);
+          }
+        }
+        try {
+          void silenceContext.close().catch(report);
+        } catch (error) {
+          report(error);
+        }
+      };
+      return new LukeRealtimeWebRTC(
+        {
+          mediaStream: silenceStream,
+          audioElement: options.audioElement,
+          changePeerConnection: (peer) => {
+            options.onPeerConnection(peer, silenceTrack);
+            return peer;
+          },
+        },
+        options.onClientEvent,
+        options.onToolOutputSent,
+      );
+    })();
+
+  const tools = options.sessionConfig.tools.map((definition) =>
+    tool({
+      name: definition.name,
+      description: definition.description,
+      parameters: {
+        ...definition.parameters,
+        required: [...definition.parameters.required],
+        // Omission means true in JSON Schema; spelling it lets the SDK keep
+        // the build's non-strict validation behavior without widening it.
+        additionalProperties: true as const,
+      },
+      strict: false,
+      execute: async (_input, _context, details) =>
+        backgroundResult(await options.executeTool(definition.name, details)),
+    }),
+  );
+  const agent = new RealtimeAgent({
+    name: "Luke",
+    instructions: options.sessionConfig.instructions,
+    voice: options.sessionConfig.audio.output.voice,
+    tools,
+  });
+  const session = new RealtimeSession(agent, {
+    transport,
+    model: options.sessionConfig.model,
+    config: sdkSessionConfig(options.sessionConfig),
+    tracingDisabled: true,
+  });
+  session.on("transport_event", (event: TransportEvent) => {
+    const wireEvent: UnparsedWireValue = JSON.parse(JSON.stringify(event));
+    options.onTransportEvent(wireEvent);
+  });
+  session.on("error", ({ error }) => {
+    // A server `error` event also arrives as a transport event, where the
+    // session decides which ones are its own business and never shown.
+    // Reporting it here as well would draw a fault for every one of those.
+    if (sdkErrorRecord(error)?.type === "error") return;
+    report(error);
+  });
+  transport.on("connection_change", options.onConnectionChange);
+
+  let closed = false;
+  return {
+    get status() {
+      return transport.status;
+    },
+    connect: (connection) => session.connect(connection),
+    sendEvent: (event) => {
+      const type = text(event.type);
+      if (type) transport.sendEvent({ ...event, type });
+    },
+    sendMessage: (message) => session.sendMessage(message),
+    close: () => {
+      if (closed) return;
+      closed = true;
+      try {
+        session.close();
+      } catch (error) {
+        report(error);
+      } finally {
+        releaseOwnedResources?.();
+      }
+    },
+  };
+}

--- a/apps/desktop/src/renderer/introduction/introduction-takeover.tsx
+++ b/apps/desktop/src/renderer/introduction/introduction-takeover.tsx
@@ -1,10 +1,6 @@
 import { FIXTURE_EPOCH_MS } from "@sidecar/fixtures";
 import { WingFace as LukeFace } from "@sidecar/panel";
-import {
-  introductionSessionSyncEvents,
-  REALTIME_STATUS,
-  type RealtimeStatus,
-} from "@sidecar/realtime";
+import { introductionSessionConfig, REALTIME_STATUS, type RealtimeStatus } from "@sidecar/realtime";
 import { DEFAULT_VOICE_HOTKEYS, TALK_KEY_RELEASE, talkKeyRelease } from "@sidecar/settings";
 import {
   FACE_MOTION,
@@ -322,7 +318,8 @@ export function IntroductionTakeover({
   const ensureSession = useCallback((): RealtimeVoiceSession => {
     sessionRef.current ??= new RealtimeVoiceSession({
       requestConnection: () => window.sidecar.requestRealtimeCredential(),
-      sessionSyncEvents: introductionSessionSyncEvents,
+      sessionConfig: (model) => introductionSessionConfig({ model }),
+      audioElement: () => remoteAudioRef.current,
       requestMicrophoneStream: () =>
         openPreferredMicrophone({
           route: () => window.sidecar.getMicrophoneRoute(),

--- a/apps/desktop/src/renderer/realtime-session.test.ts
+++ b/apps/desktop/src/renderer/realtime-session.test.ts
@@ -34,14 +34,15 @@ import { isRecord, text, type WireRecord } from "@sidecar/wire";
 import type { JsonValue, ParsedJsonObject } from "@sidecar/wire/testing";
 import {
   asMediaStream,
+  asMediaTrack,
   asPeerConnection,
-  type MockDataChannel,
   type MockMediaStream,
   type MockMediaTrack,
   type MockPeerConnection,
+  type MockRtpSender,
   type MockTrackEvent,
-  parseClientEvent,
 } from "#testing/realtime-fixtures";
+import type { SdkRealtimeTransport, SdkTransportFactoryOptions } from "./agents-realtime-transport";
 import {
   type ActCarrier,
   type AppActionCarrier,
@@ -60,22 +61,8 @@ function sessionField(event: ParsedJsonObject | undefined): ParsedJsonObject | u
   return isRecord(session) ? session : undefined;
 }
 
-function sessionHasTools(event: ParsedJsonObject): boolean {
-  const session = sessionField(event);
-  return session !== undefined && Array.isArray(session.tools);
-}
-
 function sessionAudioField(event: ParsedJsonObject | undefined): JsonValue | undefined {
   return sessionField(event)?.audio;
-}
-
-function toolParameterPropertyNames(tool: ParsedJsonObject | undefined): readonly string[] {
-  if (!tool) return [];
-  const parameters = tool.parameters;
-  if (!isRecord(parameters)) return [];
-  const properties = parameters.properties;
-  if (!isRecord(properties)) return [];
-  return Object.keys(properties);
 }
 
 const CONNECTION: RealtimeConnection = {
@@ -84,12 +71,6 @@ const CONNECTION: RealtimeConnection = {
   model: "gpt-realtime-2.1",
   callsUrl: "https://api.openai.com/v1/realtime/calls",
 };
-
-/** One transceiver a call declared, as the fixture peer recorded it. */
-interface RecordedTransceiver {
-  kind: string;
-  direction?: string;
-}
 
 interface Harness {
   session: RealtimeVoiceSession;
@@ -115,17 +96,17 @@ interface Harness {
   microphoneStopped: () => boolean;
   emit: (event: JsonValue) => void;
   emitRaw: (data: JsonValue) => void;
+  executeSdkTool: SdkTransportFactoryOptions["executeTool"];
   lukeAudible: () => boolean;
   deliverRemoteTrack: (streams?: readonly object[]) => void;
   provideConnection: () => void;
   setConnectionState: (state: RTCPeerConnectionState) => void;
   closeChannel: () => void;
-  requests: { url: string; init: RequestInit }[];
+  requests: { apiKey: string; model: string; url: string }[];
   /** The order the credential and the device were asked for and answered in. */
   calls: string[];
-  // SAFETY: Fixture value matches the narrowed runtime shape this test exercises.
-  /** The transceivers declared instead of tracks, as a speak-only call does. */
-  transceivers: RecordedTransceiver[];
+  /** The stable synthetic track the SDK sender carries between presses. */
+  silenceTrack: MockMediaTrack;
   /** Every track handed to the sender, `null` standing for the device let go. */
   replacedTracks: () => (object | null)[];
   /**
@@ -173,7 +154,7 @@ function harness(
     carryAction?: SessionActionCarrier;
     carryAppAction?: AppActionCarrier;
     carryIssueAction?: IssueActionCarrier;
-    captureSessionSync?: boolean;
+    sdkCloseError?: Error;
     /** Lets a test ride the status edges, the way the announcer does. */
     onStatus?: (status: RealtimeStatus) => void;
     /** Lets a test stand where the development trace's tap does. */
@@ -199,7 +180,7 @@ function harness(
   const spokenAskFailures: string[] = [];
   const spokenAskItems: string[] = [];
   let spokenAskClosures = 0;
-  const requests: { url: string; init: RequestInit }[] = [];
+  const requests: { apiKey: string; model: string; url: string }[] = [];
   const calls: string[] = [];
   let enabled = false;
   let stopped = false;
@@ -217,51 +198,129 @@ function harness(
   };
   const stream: MockMediaStream = { getAudioTracks: () => [track], getTracks: () => [track] };
 
-  const channel: MockDataChannel = {
-    readyState: options.channelOpensImmediately === false ? "connecting" : "open",
-    send: (payload: string) => {
-      const event = parseClientEvent(payload);
-      const isSessionSync =
-        event.type === REALTIME_CLIENT_EVENT.SESSION_UPDATE && sessionHasTools(event);
-      if (options.captureSessionSync || !isSessionSync) sent.push(event);
-    },
-    close: () => {
-      channel.readyState = "closed";
-      queueMicrotask(() => channel.onclose?.());
+  const remoteTrack = { enabled: true };
+  const replacedTracks: (MockMediaTrack | null)[] = [];
+  const silenceTrack: MockMediaTrack = { kind: "audio" };
+  const connectionStateListeners = new Set<() => void>();
+  const sender: MockRtpSender = {
+    track: silenceTrack,
+    replaceTrack: async (next: MockMediaTrack | null) => {
+      sender.track = next;
+      replacedTracks.push(next);
     },
   };
-
-  const remoteTrack = { enabled: true };
-  const transceivers: RecordedTransceiver[] = [];
-  const replacedTracks: (MockMediaTrack | null)[] = [];
   const peer: MockPeerConnection = {
-    localDescription: { type: "offer", sdp: "v=0 local" },
     connectionState: "connected",
-    addTransceiver: (kind: string, init?: { direction?: string }) => {
-      const entry: RecordedTransceiver = { kind };
-      if (init?.direction) {
-        entry.direction = init.direction;
+    getSenders: () => [sender],
+    addEventListener: (_type, listener) => connectionStateListeners.add(listener),
+  };
+  let sdkOptions: SdkTransportFactoryOptions | undefined;
+  let sdkStatus: SdkRealtimeTransport["status"] = "disconnected";
+  let sdkCloseError = options.sdkCloseError;
+  const dispatchedCalls = new Set<string>();
+  let syntheticResponseSequence = 0;
+
+  const recordClientEvent = (event: WireRecord): void => {
+    const parsed: ParsedJsonObject = JSON.parse(JSON.stringify(event));
+    sent.push(parsed);
+    sdkOptions?.onClientEvent(event);
+  };
+  const dispatchToolCall = (call: ParsedJsonObject): void => {
+    const callId = text(call.call_id);
+    const name = text(call.name);
+    const argumentsJson = text(call.arguments);
+    if (!callId || !name || argumentsJson === undefined || dispatchedCalls.has(callId)) return;
+    dispatchedCalls.add(callId);
+    void sdkOptions
+      ?.executeTool(name, {
+        toolCall: { type: "function_call", callId, name, arguments: argumentsJson },
+      })
+      .then((output) => {
+        recordClientEvent({
+          type: REALTIME_CLIENT_EVENT.CONVERSATION_ITEM_CREATE,
+          item: { type: "function_call_output", call_id: callId, output: JSON.stringify(output) },
+        });
+        sdkOptions?.onToolOutputSent(callId);
+      });
+  };
+  const emitServerEvent = (data: JsonValue): void => {
+    const wireData = JSON.parse(JSON.stringify(data));
+    if (!isRecord(wireData)) {
+      sdkOptions?.onTransportEvent(wireData);
+      return;
+    }
+    let event = wireData;
+    if (event.type === REALTIME_SERVER_EVENT.RESPONSE_DONE && isRecord(event.response)) {
+      const calls = Array.isArray(event.response.output)
+        ? event.response.output.filter(isRecord).filter((item) => item.type === "function_call")
+        : [];
+      if (calls.length > 0 && text(event.response.id) === undefined) {
+        const responseId = `response-${++syntheticResponseSequence}`;
+        sdkOptions?.onTransportEvent({
+          type: REALTIME_SERVER_EVENT.RESPONSE_CREATED,
+          response: { id: responseId },
+        });
+        event = { ...event, response: { ...event.response, id: responseId } };
       }
-      transceivers.push(entry);
-      return {
-        sender: {
-          replaceTrack: async (next: MockMediaTrack | null) => {
-            replacedTracks.push(next);
-          },
-        },
-      };
-    },
-    createDataChannel: () => {
-      channel.readyState = options.channelOpensImmediately === false ? "connecting" : "open";
-      return channel;
-    },
-    createOffer: async () => ({ type: "offer", sdp: "v=0 local" }),
-    setLocalDescription: async () => undefined,
-    setRemoteDescription: async () => undefined,
-    close: () => {
-      peer.connectionState = "closed";
-      queueMicrotask(() => peer.onconnectionstatechange?.());
-    },
+      sdkOptions?.onTransportEvent(JSON.parse(JSON.stringify(event)));
+      for (const call of calls) dispatchToolCall(call);
+      return;
+    }
+    sdkOptions?.onTransportEvent(JSON.parse(JSON.stringify(event)));
+    if (event.type === "response.output_item.done" && isRecord(event.item)) {
+      dispatchToolCall(event.item);
+    }
+  };
+
+  const createSdkTransport = (
+    transportOptions: SdkTransportFactoryOptions,
+  ): SdkRealtimeTransport => {
+    sdkOptions = transportOptions;
+    sender.track = silenceTrack;
+    peer.connectionState = "connected";
+    let closed = false;
+    return {
+      get status() {
+        return sdkStatus;
+      },
+      connect: async (request) => {
+        sdkStatus = "connecting";
+        requests.push(request);
+        connectionStateListeners.clear();
+        transportOptions.onPeerConnection(asPeerConnection(peer), asMediaTrack(silenceTrack));
+        if (options.sdpDelayMs) {
+          await new Promise((resolve) => setTimeout(resolve, options.sdpDelayMs));
+        }
+        const response = options.sdpResponse;
+        if (response && !response.ok)
+          throw new Error(`Realtime call failed with status ${response.status}.`);
+        if (options.channelOpensImmediately === false) {
+          await new Promise<void>(() => undefined);
+        }
+        if (closed) throw new Error("The voice connection closed while opening.");
+        sdkStatus = "connected";
+        transportOptions.onConnectionChange(sdkStatus);
+      },
+      sendEvent: recordClientEvent,
+      sendMessage: (message) => {
+        recordClientEvent({
+          type: REALTIME_CLIENT_EVENT.CONVERSATION_ITEM_CREATE,
+          item: { type: "message", role: "user", content: [{ type: "input_text", text: message }] },
+        });
+        recordClientEvent({ type: REALTIME_CLIENT_EVENT.RESPONSE_CREATE });
+      },
+      close: () => {
+        if (closed) return;
+        closed = true;
+        sdkStatus = "disconnected";
+        transportOptions.onConnectionChange(sdkStatus);
+        if (sdkCloseError) {
+          const error = sdkCloseError;
+          sdkCloseError = undefined;
+          throw error;
+        }
+      },
+    };
   };
 
   let connection = "connection" in options ? options.connection : CONNECTION;
@@ -300,14 +359,7 @@ function harness(
         },
       };
     },
-    createPeerConnection: () => asPeerConnection(peer),
-    exchangeDescription: async (url, init) => {
-      requests.push({ url, init });
-      if (options.sdpDelayMs) {
-        await new Promise((resolve) => setTimeout(resolve, options.sdpDelayMs));
-      }
-      return options.sdpResponse ?? new Response("v=0 remote", { status: 200 });
-    },
+    createSdkTransport,
     onStatus: (status) => options.onStatus?.(status),
     onLocalStream: () => undefined,
     onRemoteStream: (stream) => options.onRemoteStream?.(stream),
@@ -391,18 +443,22 @@ function harness(
       peer.ontrack?.(trackEvent);
     },
     emit: (event) => {
-      channel.onmessage?.({ data: JSON.stringify(event) });
+      emitServerEvent(event);
     },
     emitRaw: (data) => {
-      channel.onmessage?.({ data });
+      sdkOptions?.onTransportEvent(JSON.parse(JSON.stringify(data)));
+    },
+    executeSdkTool: async (name, details) => {
+      if (!sdkOptions) throw new Error("The SDK transport is not connected.");
+      return sdkOptions.executeTool(name, details);
     },
     setConnectionState: (state) => {
       peer.connectionState = state;
-      peer.onconnectionstatechange?.();
+      for (const listener of connectionStateListeners) listener();
     },
     closeChannel: () => {
-      channel.readyState = "closed";
-      channel.onclose?.();
+      sdkStatus = "disconnected";
+      sdkOptions?.onConnectionChange(sdkStatus);
     },
     requests,
     calls,
@@ -418,7 +474,7 @@ function harness(
       microphoneGate = undefined;
       for (const release of held) release();
     },
-    transceivers,
+    silenceTrack,
     pressCaptures,
   };
 }
@@ -492,11 +548,8 @@ test("connecting opens the call and leaves the microphone closed", async () => {
 
   const request = context.requests[0];
   assert.equal(request?.url, CONNECTION.callsUrl);
-  // SAFETY: Fixture headers map matches the string header shape the fake records.
-  const headers = request?.init.headers as Record<string, string>;
-  assert.equal(headers.authorization, `Bearer ${CONNECTION.value}`);
-  assert.equal(headers["content-type"], "application/sdp");
-  assert.equal(request?.init.body, "v=0 local");
+  assert.equal(request?.apiKey, CONNECTION.value);
+  assert.equal(request?.model, CONNECTION.model);
 });
 
 test("the wire tap sees both directions, raw, before the parser narrows or drops", async () => {
@@ -505,9 +558,9 @@ test("the wire tap sees both directions, raw, before the parser narrows or drops
     onWireEvent: (direction, event) => tapped.push({ direction, event }),
   });
   await context.session.connect();
+  context.session.applySpeed(1.25);
 
-  // The session sync the harness's channel filters out of `sent` still
-  // crosses the tap: it is what the call sends, instructions and tools whole.
+  // A live config change crosses the tap as the raw event the call sends.
   const clientTypes = tapped
     .filter((entry) => entry.direction === TRACE_DIRECTION.CLIENT)
     .map((entry) => entry.event.type);
@@ -596,7 +649,7 @@ test("push-to-talk opens the microphone only while held, then asks for a reply",
 
   // The exchange settling is what closes it, in the quiet after the reply.
   assert.equal(context.microphoneStopped(), true);
-  assert.equal(context.replacedTracks().at(-1), null);
+  assert.equal(context.replacedTracks().at(-1), context.silenceTrack);
   assert.deepEqual(
     context.sent.map((event) => event.type),
     [
@@ -1507,19 +1560,6 @@ test("a finished response returns the session to ready", async () => {
   assert.equal(context.session.status, REALTIME_STATUS.READY);
 });
 
-test("an opened call synchronizes the local build's tool schema", async () => {
-  const context = harness({ captureSessionSync: true });
-  await context.session.connect();
-
-  const update = context.sent.find(
-    (event) => event.type === REALTIME_CLIENT_EVENT.SESSION_UPDATE && sessionHasTools(event),
-  );
-  const tools = sessionField(update)?.tools;
-  const toolList = Array.isArray(tools) ? tools.filter(isRecord) : [];
-  const creation = toolList.find((tool) => tool.name === "create_workspace");
-  assert.deepEqual(toolParameterPropertyNames(creation).includes("agent"), true);
-});
-
 test("a changed pace reaches the live call without waiting for the next one", async () => {
   const context = harness();
   await context.session.connect();
@@ -2074,6 +2114,20 @@ test("a new call after teardown re-seeds the accumulated history", async () => {
   assert.equal(items.length, 1);
   assert.match(itemText(items[0]), /finished checkout-service/);
   assert.match(itemText(items[0]), /failed in payments/);
+});
+
+test("a transport close failure cannot strand teardown or the next call", async () => {
+  const context = harness({ sdkCloseError: new Error("close failed") });
+  await context.session.connect();
+  await holdTurn(context);
+
+  context.session.clearConversation();
+
+  assert.equal(context.session.status, REALTIME_STATUS.IDLE);
+  assert.equal(context.microphoneStopped(), true);
+  assert.deepEqual(reportedErrors(context), ["close failed"]);
+  assert.equal(await context.session.connect(), true);
+  assert.doesNotThrow(() => context.session.clearConversation());
 });
 
 test("clearing history deletes its live model-context item", async () => {
@@ -3422,6 +3476,79 @@ test("a spoken ask is carried through the carrier and its outcome is voiced", as
   );
   // The turn never ended: the reply resumes over the outcome.
   assert.equal(context.session.status, REALTIME_STATUS.RESPONDING);
+});
+
+test("a response waits for every SDK tool output before one tool-free follow-up", async () => {
+  const pending = new Map<string, (output: ParsedJsonObject) => void>();
+  const context = harness({
+    carryAction: (action) =>
+      action.kind === "message"
+        ? new Promise<ParsedJsonObject>((resolve) => pending.set(action.text, resolve))
+        : Promise.resolve({ status: "rejected" }),
+  });
+  await context.session.connect();
+  context.session.updateSessions([observedSession("session-a", { canReceiveMessage: true })]);
+  await armDeveloperTurn(context);
+  context.emit({ type: REALTIME_SERVER_EVENT.RESPONSE_CREATED, response: { id: "resp-tools" } });
+  const sentBefore = context.sent.length;
+
+  const calls = [
+    {
+      type: "function_call",
+      name: "send_session_message",
+      call_id: "call-first",
+      arguments: '{"provider_id":"claude-code","provider_session_id":"session-a","text":"first"}',
+    },
+    {
+      type: "function_call",
+      name: "send_session_message",
+      call_id: "call-second",
+      arguments: '{"provider_id":"claude-code","provider_session_id":"session-a","text":"second"}',
+    },
+  ];
+  for (const item of calls) {
+    context.emit({ type: "response.output_item.done", response_id: "resp-tools", item });
+  }
+  await Promise.resolve();
+
+  pending.get("second")?.({ status: "accepted" });
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  context.emit({
+    type: REALTIME_SERVER_EVENT.RESPONSE_DONE,
+    response: { id: "resp-tools", output: calls },
+  });
+  assert.equal(
+    context.sent
+      .slice(sentBefore)
+      .filter((event) => event.type === REALTIME_CLIENT_EVENT.RESPONSE_CREATE).length,
+    0,
+  );
+
+  pending.get("first")?.({ status: "accepted" });
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  const followUps = context.sent
+    .slice(sentBefore)
+    .filter((event) => event.type === REALTIME_CLIENT_EVENT.RESPONSE_CREATE);
+  assert.deepEqual(followUps, [
+    { type: REALTIME_CLIENT_EVENT.RESPONSE_CREATE, response: { tools: [], tool_choice: "none" } },
+  ]);
+});
+
+test("malformed SDK call details are refused before the carrier", async () => {
+  const carried: unknown[] = [];
+  const context = harness({
+    carryAction: async (action) => {
+      carried.push(action);
+      return { status: "accepted" };
+    },
+  });
+  await context.session.connect();
+
+  assert.deepEqual(await context.executeSdkTool("send_session_message", undefined), {
+    status: "rejected",
+    reason: "The tool call was malformed.",
+  });
+  assert.deepEqual(carried, []);
 });
 
 test("a session carrier that throws is refused with the error that caused it", async () => {
@@ -5335,8 +5462,9 @@ test("a speak-only connect never asks for the microphone", async () => {
   // The device was never requested, so there is no permission to ask and no
   // indicator to light.
   assert.ok(!context.calls.includes("microphone-requested"));
-  // The call is speak-only by shape: audio is received and none is offered.
-  assert.deepEqual(context.transceivers, [{ kind: "audio", direction: "recvonly" }]);
+  // The SDK keeps one synthetic track negotiated; no real device rides it.
+  assert.equal(context.replacedTracks().length, 0);
+  assert.equal(context.silenceTrack.kind, "audio");
   assert.equal(context.session.microphoneCall, false);
 });
 
@@ -5446,7 +5574,7 @@ test("the device closes with the exchange and the conversation stays", async () 
   // while the call, and the conversation on it, stay warm and stay the
   // developer's: the next press reopens the device, never replaces the call.
   assert.equal(context.microphoneStopped(), true);
-  assert.equal(context.replacedTracks().at(-1), null);
+  assert.equal(context.replacedTracks().at(-1), context.silenceTrack);
   assert.equal(context.session.isConnected, true);
   assert.equal(context.session.microphoneCall, true);
 });

--- a/apps/desktop/src/renderer/realtime-session.test.ts
+++ b/apps/desktop/src/renderer/realtime-session.test.ts
@@ -101,6 +101,7 @@ interface Harness {
   deliverRemoteTrack: (streams?: readonly object[]) => void;
   provideConnection: () => void;
   setConnectionState: (state: RTCPeerConnectionState) => void;
+  failStalePeer: () => void;
   closeChannel: () => void;
   requests: { apiKey: string; model: string; url: string }[];
   /** The order the credential and the device were asked for and answered in. */
@@ -202,6 +203,7 @@ function harness(
   const replacedTracks: (MockMediaTrack | null)[] = [];
   const silenceTrack: MockMediaTrack = { kind: "audio" };
   const connectionStateListeners = new Set<() => void>();
+  const staleConnectionStateListeners = new Set<() => void>();
   const sender: MockRtpSender = {
     track: silenceTrack,
     replaceTrack: async (next: MockMediaTrack | null) => {
@@ -286,6 +288,8 @@ function harness(
       connect: async (request) => {
         sdkStatus = "connecting";
         requests.push(request);
+        for (const listener of connectionStateListeners)
+          staleConnectionStateListeners.add(listener);
         connectionStateListeners.clear();
         transportOptions.onPeerConnection(asPeerConnection(peer), asMediaTrack(silenceTrack));
         if (options.sdpDelayMs) {
@@ -455,6 +459,10 @@ function harness(
     setConnectionState: (state) => {
       peer.connectionState = state;
       for (const listener of connectionStateListeners) listener();
+    },
+    failStalePeer: () => {
+      peer.connectionState = "failed";
+      for (const listener of staleConnectionStateListeners) listener();
     },
     closeChannel: () => {
       sdkStatus = "disconnected";
@@ -1662,6 +1670,32 @@ test("a failed call releases the microphone instead of stranding it", async () =
   // FAILED offers "Start voice" again, so nothing may still hold the device.
   assert.equal(context.microphoneStopped(), true);
   assert.equal(context.session.isConnected, false);
+});
+
+test("a disconnect reported after a failure keeps the call failed", async () => {
+  const context = harness();
+  await context.session.connect();
+
+  context.setConnectionState("failed");
+  assert.equal(context.session.status, REALTIME_STATUS.FAILED);
+
+  // The SDK's own disconnect can land a tick after the failure tore the call
+  // down; "Voice off" for a call that failed would hide the retry.
+  context.closeChannel();
+  assert.equal(context.session.status, REALTIME_STATUS.FAILED);
+});
+
+test("a replaced peer's late failure does not end the new call", async () => {
+  const context = harness();
+  await context.session.connect();
+  await context.session.close();
+  await context.session.connect();
+  assert.equal(context.session.status, REALTIME_STATUS.READY);
+
+  context.failStalePeer();
+
+  assert.equal(context.session.status, REALTIME_STATUS.READY);
+  assert.equal(context.session.isConnected, true);
 });
 
 test("a stalled handshake times out instead of hanging on connecting", async () => {

--- a/apps/desktop/src/renderer/realtime-session.ts
+++ b/apps/desktop/src/renderer/realtime-session.ts
@@ -23,13 +23,13 @@ import {
   conversationHistoryText,
   decodeRealtimePayload,
   functionCallFollowUpEvents,
-  functionCallOutputEvents,
   type IntroductionLine,
   inputAudioAppendEvents,
   inputAudioFormatUpdateEvents,
   introductionSpeechEvents,
   isArrivalSpeech,
   issueToolAction,
+  maximumTypedAskLength,
   outputSpeedUpdateEvents,
   PressAudioBuffer,
   type ProactiveSpeechTurn,
@@ -37,7 +37,6 @@ import {
   proactiveSpeechEvents,
   pushToTalkCommitEvents,
   REALTIME_CLIENT_EVENT,
-  REALTIME_DATA_CHANNEL,
   REALTIME_SERVER_EVENT,
   REALTIME_STATUS,
   REALTIME_TOOL_FAMILY,
@@ -45,7 +44,7 @@ import {
   type RealtimeFunctionCall,
   type RealtimeStatus,
   type RealtimeToolFamily,
-  realtimeSessionSyncEvents,
+  realtimeSessionConfig,
   realtimeToolFamily,
   recentConversationEntries,
   rememberedFactsContextEvents,
@@ -54,7 +53,6 @@ import {
   sessionContextText,
   sessionToolAction,
   truncateResponseEvents,
-  typedAskEvents,
   workspaceProjectContextEvents,
   workspaceProjectContextText,
 } from "@sidecar/realtime";
@@ -62,10 +60,19 @@ import type { ObservedWorkspaceProject, Session, SessionIdentity } from "@sideca
 import { workspaceAgentModels } from "@sidecar/session";
 import {
   ACT_RESULT_STATUS,
+  isRecord,
   positiveInteger,
+  text,
   type UnparsedWireValue,
   type WireRecord,
 } from "@sidecar/wire";
+import {
+  type BuiltRealtimeSessionConfig,
+  createAgentsRealtimeTransport,
+  type SdkRealtimeTransport,
+  type SdkToolCallDetails,
+  type SdkTransportFactory,
+} from "./agents-realtime-transport";
 import { MICROPHONE_PROCESSING } from "./microphone-choice";
 import {
   createPressCaptureSource,
@@ -73,9 +80,7 @@ import {
   type PressCaptureSource,
 } from "./press-audio-capture";
 
-const SDP_CONTENT_TYPE = "application/sdp";
-
-/** Bounds the SDP exchange and the data channel opening, together. */
+/** Bounds the SDK's WebRTC handshake and initial session acknowledgement. */
 const CONNECT_TIMEOUT_MS = 15_000;
 
 /**
@@ -282,42 +287,16 @@ export interface MicrophoneSender {
   replaceTrack(next: MediaStreamTrack | null): Promise<void>;
 }
 
-export interface DataChannel {
-  readyState: RTCDataChannelState;
-  send(payload: string): void;
-  close(): void;
-  // Each handler names the event the browser really passes, because a
-  // no-argument signature would refuse the real one: a listener may take fewer
-  // arguments than it is given, never more.
-  onopen?: ((event: Event) => void) | null;
-  onclose?: ((event: Event) => void) | null;
-  onerror?: ((event: RTCErrorEvent) => void) | null;
-  onmessage?: ((event: MessageEvent<string>) => void) | null;
-}
-
-export interface PeerConnection {
-  localDescription: RTCSessionDescriptionInit | null;
-  connectionState: RTCPeerConnectionState;
-  addTransceiver(kind: string, init?: { direction?: string }): { sender: MicrophoneSender };
-  createDataChannel(label: string): DataChannel;
-  createOffer(): Promise<RTCSessionDescriptionInit>;
-  setLocalDescription(description?: RTCSessionDescriptionInit): Promise<void>;
-  setRemoteDescription(description: RTCSessionDescriptionInit): Promise<void>;
-  close(): void;
-  ontrack?: ((event: RTCTrackEvent) => void) | null;
-  onconnectionstatechange?: ((event: Event) => void) | null;
-}
-
 export interface RealtimeVoiceSessionOptions extends RealtimeVoiceSessionCallbacks {
   requestConnection(): Promise<RealtimeConnection | undefined>;
   /** Absent means Luke can only speak: every tool call is rejected with a reason. */
   carryAct?: ActCarrier;
-  /**
-   * The browser pieces, injectable so the microphone state machine can be
-   * exercised without a real device or peer connection. Push-to-talk decides
-   * when a microphone is live, which is worth testing directly.
-   */
-  createPeerConnection?: () => PeerConnection;
+  /** The SDK call seam, injectable so the complete transport can be tested without WebRTC. */
+  createSdkTransport?: SdkTransportFactory;
+  /** The full session document used by the SDK; the introduction narrows this to no tools. */
+  sessionConfig?: (model: string) => BuiltRealtimeSessionConfig;
+  /** The existing hidden playback element owned by the renderer. */
+  audioElement?: () => HTMLAudioElement | null;
   requestMicrophoneStream?: () => Promise<MediaStream>;
   /**
    * The local PCM capture a press runs while its call is still connecting.
@@ -325,14 +304,6 @@ export interface RealtimeVoiceSessionOptions extends RealtimeVoiceSessionCallbac
    * state machine worth testing without a real audio graph.
    */
   createPressCapture?: PressCaptureFactory;
-  exchangeDescription?: (url: string, init: RequestInit) => Promise<Response>;
-  /**
-   * The session events reasserted once the call opens, defaulting to the
-   * conversation's own instructions and tools. The introduction is the one
-   * caller that narrows this — to its own instructions and an empty tool
-   * list — so its pre-account call is tool-free at the API itself.
-   */
-  sessionSyncEvents?: (model: string) => readonly WireRecord[];
   connectTimeoutMs?: number;
   /** Injectable so a test can hold the clock a truncate measures against. */
   now?: () => number;
@@ -367,15 +338,25 @@ export function quietIsLukesOwn(input: { status: RealtimeStatus; heardLuke: bool
   return input.status === REALTIME_STATUS.RESPONDING && input.heardLuke;
 }
 
+interface SdkToolBatch {
+  responseId: string;
+  callIds: Set<string>;
+  outputCallIds: Set<string>;
+  epoch: number;
+  armed: boolean;
+  responseDone: boolean;
+  followUpStarted: boolean;
+}
+
 /**
  * Drives one Realtime conversation over WebRTC.
  *
  * The capture device is the developer's, not the call's: it opens when a
  * press takes a turn and closes when the exchange that press started settles,
  * and nothing else — not connecting, not typing, not an announcement — ever
- * touches it. The call negotiates its sending half up front as a bare
- * transceiver, so each turn's fresh track rides the same sender without
- * renegotiating. The press is held as a pending intention while the device
+ * touches it. The SDK negotiates a generated silent track up front, so each
+ * turn's fresh microphone track rides the same sender without renegotiating.
+ * The press is held as a pending intention while the device
  * opens, exactly as a press that beats the call's handshake is. The close
  * waits for the settle rather than the key coming up because closing a
  * capture device is itself audible on shared hardware — a Bluetooth headset
@@ -387,8 +368,8 @@ export function quietIsLukesOwn(input: { status: RealtimeStatus; heardLuke: bool
  */
 export class RealtimeVoiceSession {
   readonly #options: RealtimeVoiceSessionOptions;
-  #peer: PeerConnection | undefined;
-  #channel: DataChannel | undefined;
+  #sdkTransport: SdkRealtimeTransport | undefined;
+  #tearingDown = false;
   #microphone: MediaStreamTrack | undefined;
   #stream: MediaStream | undefined;
   /**
@@ -397,6 +378,7 @@ export class RealtimeVoiceSession {
    * lets the next press attach a fresh track without renegotiating.
    */
   #microphoneSender: MicrophoneSender | undefined;
+  #silenceTrack: MediaStreamTrack | undefined;
   /** The device being reopened, held so two presses cannot open it twice. */
   #acquiring: Promise<void> | undefined;
   /**
@@ -608,7 +590,8 @@ export class RealtimeVoiceSession {
    * reply comes next, the finish that ends the hold, or the interrupt of a
    * developer moving on.
    */
-  #followUpPending = false;
+  #toolBatch: SdkToolBatch | undefined;
+  #toolCallResponseIds = new Map<string, string>();
   /**
    * Whether Luke has actually been heard during this reply. Committing a turn
    * swaps the meter from the microphone to Luke, and the meter reports quiet as
@@ -712,7 +695,7 @@ export class RealtimeVoiceSession {
   }
 
   get isConnected(): boolean {
-    return this.#channel?.readyState === "open";
+    return this.#sdkTransport?.status === "connected";
   }
 
   /**
@@ -782,7 +765,6 @@ export class RealtimeVoiceSession {
     // its capture rides beside the mint — but that is the press's doing,
     // never the connect's.
     let connection: RealtimeConnection | undefined;
-    let deadlineTimer: ReturnType<typeof setTimeout> | undefined;
     try {
       connection = await this.#options.requestConnection();
     } catch (error) {
@@ -801,86 +783,41 @@ export class RealtimeVoiceSession {
     }
 
     try {
-      const peer: PeerConnection =
-        this.#options.createPeerConnection?.() ?? new RTCPeerConnection();
-      this.#peer = peer;
-      if (this.#withMicrophone) {
-        // The developer's call declares its sending half as a bare
-        // transceiver: the line is negotiated now, and each turn's track
-        // joins the kept sender later without renegotiating. No track, no
-        // device, no consent asked — until a press asks for a turn.
-        const transceiver = peer.addTransceiver("audio", { direction: "sendrecv" });
-        this.#microphoneSender = transceiver.sender;
-      } else {
-        // Luke's own call receives audio and offers none: the transceiver says
-        // so up front, so the connection is speak-only by shape rather than by
-        // a track that merely happens to be missing.
-        peer.addTransceiver("audio", { direction: "recvonly" });
-      }
-      peer.ontrack = (event) => {
-        this.#remoteTrack = event.track;
-        // An answer that names no stream for the track (`a=msid` absent, which
-        // a recvonly line permits) still delivers the audio on the track
-        // itself, so one is built for the element rather than handing it
-        // nothing and playing the reply into a healthy-looking silence.
-        this.#options.onRemoteStream(event.streams[0] ?? new MediaStream([event.track]));
-      };
-      peer.onconnectionstatechange = () => {
-        if (this.#closed) return;
-        // `disconnected` is recoverable in WebRTC — ICE routinely passes through
-        // it on a brief network blip — so only a terminal state ends the call.
-        if (peer.connectionState === "failed" || peer.connectionState === "closed") {
-          this.#fail("The voice connection dropped.");
-        }
-      };
-
-      const channel = peer.createDataChannel(REALTIME_DATA_CHANNEL);
-      this.#channel = channel;
-      channel.onmessage = (event) => this.#handleServerEvent(event.data);
-      channel.onclose = () => {
-        if (this.#closed) return;
-        // The service ends every session at an hour whether or not anyone is
-        // finished talking, so this is the ordinary end of a long call, not
-        // an exotic failure — and it costs nothing said: the history holds
-        // the conversation on this side of the wire, and the next press
-        // re-feeds it, so quiet is the honest report rather than a warning
-        // about a thread nobody lost.
-        // A channel that closes on its own still leaves the capture running,
-        // so this has to release the device as thoroughly as an explicit stop.
-        if (this.#captionAbout) this.#discardCaption();
-        this.#teardown();
-        this.#setStatus(REALTIME_STATUS.IDLE);
-      };
-
-      // One deadline covers the SDP exchange and the channel opening together.
-      // Without it a stalled endpoint leaves the panel on "Connecting…" forever,
-      // with the only control that could recover it disabled.
+      const factory = this.#options.createSdkTransport ?? createAgentsRealtimeTransport;
+      const sdkTransport = factory({
+        sessionConfig: (
+          this.#options.sessionConfig ?? ((model) => realtimeSessionConfig({ model }))
+        )(connection.model),
+        audioElement: this.#options.audioElement?.() ?? undefined,
+        onPeerConnection: (peer, silenceTrack) => this.#adoptPeerConnection(peer, silenceTrack),
+        onTransportEvent: (event) => this.#handleServerEvent(event),
+        onClientEvent: (event) => this.#options.onWireEvent?.(TRACE_DIRECTION.CLIENT, event),
+        onToolOutputSent: (callId) => this.#toolOutputSent(callId),
+        onConnectionChange: (status) => this.#connectionChanged(status),
+        onError: (message) => this.#options.onError(message),
+        executeTool: (name, details) => this.#sdkToolOutput(name, details),
+      });
+      this.#sdkTransport = sdkTransport;
       const timeoutMs = positiveInteger(this.#options.connectTimeoutMs, CONNECT_TIMEOUT_MS);
-      const deadline = new AbortController();
-      // AbortSignal.timeout() deliberately does not keep Node's event loop
-      // alive. A referenced timer makes the same product deadline observable
-      // to the test harness, and the finally below clears it once the call has
-      // settled so a successful handshake holds nothing open.
-      deadlineTimer = setTimeout(
-        () =>
-          deadline.abort(
-            new DOMException("The voice connection timed out while opening.", "TimeoutError"),
-          ),
-        timeoutMs,
-      );
-
-      await peer.setLocalDescription(await peer.createOffer());
-      const answer = await this.#exchangeDescription(
-        connection,
-        peer.localDescription?.sdp ?? "",
-        deadline.signal,
-      );
-      if (answer === undefined) return false;
-      await peer.setRemoteDescription({ type: "answer", sdp: answer });
-
-      await this.#waitForChannel(channel, deadline.signal);
+      let deadlineTimer: ReturnType<typeof setTimeout> | undefined;
+      const deadline = new Promise<never>((_resolve, reject) => {
+        deadlineTimer = setTimeout(() => {
+          reject(new Error("The voice connection timed out while opening."));
+        }, timeoutMs);
+      });
+      try {
+        await Promise.race([
+          sdkTransport.connect({
+            apiKey: connection.value,
+            model: connection.model,
+            url: connection.callsUrl,
+          }),
+          deadline,
+        ]);
+      } finally {
+        if (deadlineTimer !== undefined) clearTimeout(deadlineTimer);
+      }
       if (this.#closed) return this.#abandonConnect();
-      this.#send((this.#options.sessionSyncEvents ?? realtimeSessionSyncEvents)(connection.model));
       this.#setStatus(REALTIME_STATUS.READY);
       // A pace changed during the handshake could not be sent then, and the
       // credential this call answered may have been minted before the change.
@@ -913,8 +850,6 @@ export class RealtimeVoiceSession {
       if (this.#closed) return this.#abandonConnect();
       if (!(error instanceof Error)) return this.#fail(String(error));
       return this.#fail(errorMessage(error));
-    } finally {
-      if (deadlineTimer !== undefined) clearTimeout(deadlineTimer);
     }
   }
 
@@ -941,50 +876,34 @@ export class RealtimeVoiceSession {
     );
   }
 
-  async #exchangeDescription(
-    connection: RealtimeConnection,
-    offer: string,
-    deadline: AbortSignal,
-  ): Promise<string | undefined> {
-    const init: RequestInit = {
-      method: "POST",
-      headers: {
-        authorization: `Bearer ${connection.value}`,
-        "content-type": SDP_CONTENT_TYPE,
-      },
-      body: offer,
-      signal: deadline,
+  #adoptPeerConnection(peer: RTCPeerConnection, silenceTrack: MediaStreamTrack): void {
+    const sender = peer.getSenders().find((candidate) => candidate.track === silenceTrack);
+    if (!sender) throw new Error("The voice connection did not provide an audio sender.");
+    this.#silenceTrack = silenceTrack;
+    this.#microphoneSender = sender;
+    const sdkOnTrack = peer.ontrack;
+    peer.ontrack = (event) => {
+      sdkOnTrack?.call(peer, event);
+      this.#remoteTrack = event.track;
+      this.#options.onRemoteStream(event.streams[0] ?? new MediaStream([event.track]));
     };
-    const response = await (this.#options.exchangeDescription?.(connection.callsUrl, init) ??
-      fetch(connection.callsUrl, init));
-    if (!response.ok) {
-      // The status is the diagnosable part; the ephemeral secret never is.
-      this.#fail(`The voice service refused the call (status ${response.status}).`);
-      return undefined;
-    }
-    return response.text();
+    peer.addEventListener("connectionstatechange", () => {
+      if (peer.connectionState === "failed") this.#fail("The voice connection dropped.");
+    });
   }
 
-  #waitForChannel(channel: DataChannel, deadline: AbortSignal): Promise<void> {
-    if (channel.readyState === "open") return Promise.resolve();
-    // The deadline is shared with the SDP exchange and can already have fired
-    // by the time this waiter is armed, in which case no future `abort` event
-    // is coming and listening alone would wait forever.
-    if (deadline.aborted) {
-      return Promise.reject(new Error("The voice connection timed out while opening."));
+  #connectionChanged(status: SdkRealtimeTransport["status"]): void {
+    if (
+      status !== "disconnected" ||
+      this.#closed ||
+      this.#tearingDown ||
+      this.#status === REALTIME_STATUS.CONNECTING
+    ) {
+      return;
     }
-    return new Promise((resolve, reject) => {
-      const settle = (outcome: () => void) => {
-        deadline.removeEventListener("abort", onDeadline);
-        outcome();
-      };
-      const onDeadline = () =>
-        settle(() => reject(new Error("The voice connection timed out while opening.")));
-      deadline.addEventListener("abort", onDeadline, { once: true });
-      channel.onopen = () => settle(resolve);
-      channel.onerror = () =>
-        settle(() => reject(new Error("The voice data channel failed to open.")));
-    });
+    if (this.#captionAbout) this.#discardCaption();
+    this.#teardown();
+    this.#setStatus(REALTIME_STATUS.IDLE);
   }
 
   /**
@@ -1254,7 +1173,7 @@ export class RealtimeVoiceSession {
     stream?.getTracks().forEach((track) => {
       track.stop();
     });
-    void this.#microphoneSender?.replaceTrack(null);
+    void this.#microphoneSender?.replaceTrack(this.#silenceTrack ?? null);
     this.#options.onLocalStream(undefined);
   }
 
@@ -1485,10 +1404,11 @@ export class RealtimeVoiceSession {
     // needs no capture device, so one this call put away stays put away.
     if (!this.isConnected || !this.#withMicrophone) return false;
     if (this.#status === REALTIME_STATUS.LISTENING) return false;
-    const events = typedAskEvents(text);
-    if (events.length === 0) return false;
+    const ask = text.trim().slice(0, maximumTypedAskLength);
+    if (!ask) return false;
     if (this.#status === REALTIME_STATUS.RESPONDING) this.#interruptReply();
-    this.#startResponse(events, { toolsArmed: true });
+    this.#startResponse([], { toolsArmed: true });
+    this.#sdkTransport?.sendMessage(ask);
     return true;
   }
 
@@ -1550,7 +1470,8 @@ export class RealtimeVoiceSession {
     // active response above.
     this.#responseOutstanding = false;
     this.#audioDrained = false;
-    this.#followUpPending = false;
+    this.#toolBatch = undefined;
+    this.#toolCallResponseIds.clear();
     this.#generationDone = false;
     this.#remoteQuiet = false;
     this.#heardLuke = false;
@@ -1646,26 +1567,19 @@ export class RealtimeVoiceSession {
    * to turn it off.
    */
   #teardown(): void {
-    const channel = this.#channel;
-    if (channel) {
-      // Detach before closing. `close()` fires `onclose` asynchronously, and
-      // letting that handler run would tear down a second time and force the
-      // status to idle — overwriting the `failed` the caller is about to set,
-      // so a refused call would surface as "Voice off".
-      channel.onclose = null;
-      channel.onmessage = null;
-      channel.close();
-    }
-    this.#channel = undefined;
-    const peer = this.#peer;
-    if (peer) {
-      // Detach for the same reason the channel does. `close()` drives the
-      // connection to `closed`, and this handler treats that as fatal.
-      peer.onconnectionstatechange = null;
-      peer.ontrack = null;
-      peer.close();
-    }
-    this.#peer = undefined;
+    if (this.#tearingDown) return;
+    this.#tearingDown = true;
+    let teardownError: unknown;
+    const release = (action: () => void): void => {
+      try {
+        action();
+      } catch (error) {
+        teardownError ??= error;
+      }
+    };
+    const transport = this.#sdkTransport;
+    this.#sdkTransport = undefined;
+    release(() => transport?.close());
     this.#remoteTrack = undefined;
     // A fresh token before the capture retires: a device still opening for
     // the attempt this teardown ends finds it stale and releases itself. The
@@ -1674,18 +1588,22 @@ export class RealtimeVoiceSession {
     // sender: there is no call left to carry it, and the words the capture
     // still held die with the attempt.
     this.#attempt = Symbol("connect-attempt");
-    this.#retirePressCapture();
+    release(() => this.#retirePressCapture());
     this.#microphone = undefined;
     this.#microphoneSender = undefined;
-    this.#stream?.getTracks().forEach((track) => {
-      track.stop();
-    });
+    this.#silenceTrack = undefined;
+    const stream = this.#stream;
     this.#stream = undefined;
+    let tracks: readonly MediaStreamTrack[] = [];
+    release(() => {
+      tracks = stream?.getTracks() ?? [];
+    });
+    for (const track of tracks) release(() => track.stop());
     // The reply's last words are handed over before the stores empty: the
     // handover's write-back re-enters this session, and landing it here means
     // the roster it renders against still stands — and everything it wrote is
     // cleared with the rest below, so a retired call keeps nothing pending.
-    this.#clearCaption();
+    release(() => this.#clearCaption());
     this.#sessions = [];
     this.#conversationEntries = [];
     this.#guide = EMPTY_APP_GUIDE;
@@ -1703,7 +1621,8 @@ export class RealtimeVoiceSession {
     this.#pendingInterruptions.clear();
     this.#responseOutstanding = false;
     this.#audioDrained = false;
-    this.#followUpPending = false;
+    this.#toolBatch = undefined;
+    this.#toolCallResponseIds.clear();
     this.#generationDone = false;
     this.#remoteQuiet = false;
     this.#heardLuke = false;
@@ -1717,8 +1636,18 @@ export class RealtimeVoiceSession {
     // Learned about this call, so it does not outlive it.
     this.#audioEndingsReported = false;
     this.#clearSettleTimer();
-    this.#options.onLocalStream(undefined);
-    this.#options.onRemoteStream(undefined);
+    release(() => this.#options.onLocalStream(undefined));
+    release(() => this.#options.onRemoteStream(undefined));
+    this.#tearingDown = false;
+    if (teardownError !== undefined) {
+      try {
+        this.#options.onError(
+          teardownError instanceof Error ? teardownError.message : String(teardownError),
+        );
+      } catch {
+        // Teardown has already completed; an error reporter cannot undo it.
+      }
+    }
   }
 
   #startResponse(
@@ -1756,7 +1685,8 @@ export class RealtimeVoiceSession {
     // waited on, this is the reply that answers or supersedes the wait.
     this.#responseOutstanding = true;
     this.#audioDrained = false;
-    this.#followUpPending = false;
+    this.#toolBatch = undefined;
+    this.#toolCallResponseIds.clear();
     this.#clearQuietTimer();
     this.#responseItemId = undefined;
     // Nothing has been confirmed for this turn yet: whatever `response.done`
@@ -1905,9 +1835,10 @@ export class RealtimeVoiceSession {
     // are handed over before they are let go: the one moment they are both
     // final and still known.
     const texts = this.#captionTexts();
-    if (texts) this.#options.onReplyEnded?.(texts, this.#captionAbout);
+    const about = this.#captionAbout;
     this.#captionSegments = [];
     this.#captionAbout = undefined;
+    if (texts) this.#options.onReplyEnded?.(texts, about);
     this.#options.onCaption(undefined, undefined);
   }
 
@@ -1968,7 +1899,8 @@ export class RealtimeVoiceSession {
     // comes cannot leave every later reply refused against it.
     this.#responseOutstanding = false;
     this.#audioDrained = false;
-    this.#followUpPending = false;
+    this.#toolBatch = undefined;
+    this.#toolCallResponseIds.clear();
     // The turn is over, and everything of it is spent — a write still in
     // flight from it finds this boundary and stands down, rather than opening
     // its follow-up out of a silence already declared.
@@ -2060,7 +1992,7 @@ export class RealtimeVoiceSession {
    * carried. It is what lets a bare "that chat" resolve on a call that never
    * heard the words it points back at: an announcement is often read out on
    * Luke's own speak-only call, which the developer's own press tears down,
-   * and an idle call retires with everything said on it. Context on the
+   * and a dropped call takes everything said on it. Context on the
    * roster's own terms, flushed with it at the first turn of each call and
    * left standing after that: what is said from then on lives in the call's
    * own conversation items — except an announcement, which the caller marks
@@ -2320,6 +2252,25 @@ export class RealtimeVoiceSession {
     return this.isConnected && this.#withMicrophone;
   }
 
+  get #toolFollowUpPending(): boolean {
+    const batch = this.#toolBatch;
+    return Boolean(
+      batch?.armed && batch.responseDone && !batch.followUpStarted && batch.callIds.size > 0,
+    );
+  }
+
+  #observeSdkToolCall(record: WireRecord): void {
+    if (record.type !== "response.output_item.done") return;
+    const item = isRecord(record.item) ? record.item : undefined;
+    if (item?.type !== "function_call") return;
+    const responseId = text(record.response_id);
+    const callId = text(item.call_id);
+    if (!responseId || !callId) return;
+    this.#toolCallResponseIds.set(callId, responseId);
+    const batch = this.#toolBatch;
+    if (batch?.responseId === responseId) batch.callIds.add(callId);
+  }
+
   #handleServerEvent(data: UnparsedWireValue): void {
     // Decoded once, here: the tap reads the record whole — the parser below
     // keeps only the events the conversation acts on, and what it discards
@@ -2327,7 +2278,10 @@ export class RealtimeVoiceSession {
     // of what a trace exists to show — and the parser accepts the decoded
     // record as readily as the string, so nothing is parsed twice.
     const record = decodeRealtimePayload(data);
-    if (record) this.#options.onWireEvent?.(TRACE_DIRECTION.SERVER, record);
+    if (record) {
+      this.#options.onWireEvent?.(TRACE_DIRECTION.SERVER, record);
+      this.#observeSdkToolCall(record);
+    }
     const event = parseRealtimeServerEvent(record);
     if (!event) return;
 
@@ -2347,7 +2301,18 @@ export class RealtimeVoiceSession {
         // `response.done` must present to be read as this reply's: the channel
         // is ordered, so a cancelled reply's `done` lands before this
         // confirmation and finds nothing to match.
-        if (event.responseId) this.#activeResponseId = event.responseId;
+        if (event.responseId) {
+          this.#activeResponseId = event.responseId;
+          this.#toolBatch = {
+            responseId: event.responseId,
+            callIds: new Set(),
+            outputCallIds: new Set(),
+            epoch: this.#turnEpoch,
+            armed: this.#toolTurnArmed,
+            responseDone: false,
+            followUpStarted: false,
+          };
+        }
         this.#unsilenceLuke();
         return;
       case REALTIME_SERVER_EVENT.RESPONSE_OUTPUT_AUDIO_TRANSCRIPT_DELTA:
@@ -2425,7 +2390,7 @@ export class RealtimeVoiceSession {
         // owed holds the same way, in the mirror order: the write is under
         // way, the READY an ending would offer is the same edge, and the
         // `done` already gave the hold a clock of its own.
-        if (this.#responseOutstanding || this.#followUpPending) {
+        if (this.#responseOutstanding || this.#toolFollowUpPending) {
           this.#audioDrained = { responseId: event.responseId };
           this.#armSettleTimer();
           return;
@@ -2452,9 +2417,30 @@ export class RealtimeVoiceSession {
         // answered and the reply resumes over their outcomes, so the turn stays
         // open rather than ending on a reply that was only half made.
         if (event.calls.length > 0) {
-          void this.#answerToolCalls(event.calls, fresh && this.#toolTurnArmed);
-          if (fresh && this.#toolTurnArmed) {
-            this.#followUpPending = true;
+          let batch: SdkToolBatch | undefined;
+          if (fresh && event.responseId) {
+            batch =
+              this.#toolBatch?.responseId === event.responseId
+                ? this.#toolBatch
+                : {
+                    responseId: event.responseId,
+                    callIds: new Set<string>(),
+                    outputCallIds: new Set<string>(),
+                    epoch: this.#turnEpoch,
+                    armed: this.#toolTurnArmed,
+                    responseDone: false,
+                    followUpStarted: false,
+                  };
+          }
+          if (batch && batch.responseId === event.responseId) {
+            this.#toolBatch = batch;
+            batch.responseDone = true;
+            for (const call of event.calls) {
+              batch.callIds.add(call.callId);
+              this.#toolCallResponseIds.set(call.callId, batch.responseId);
+            }
+          }
+          if (batch?.armed) {
             // The turn now holds for the follow-up, because the READY an
             // ending here would offer while the writes run is the edge the
             // announcer rides — a reply taken there bumps the epoch, and the
@@ -2467,6 +2453,7 @@ export class RealtimeVoiceSession {
             // worse than one that ends early.
             this.#clearSettleTimer();
             this.#armSettleTimer();
+            this.#startToolFollowUpIfReady();
             return;
           }
           // The spoken half's audio already drained — its ending deferred to
@@ -2542,46 +2529,49 @@ export class RealtimeVoiceSession {
     }
   }
 
-  /**
-   * Answers the tool calls one reply made, then asks for the reply that voices
-   * their outcomes. Every call is validated against the roster Luke was shown
-   * before anything is carried, every outcome — including each refusal — is
-   * answered so the model never waits on a call that will not return, and the
-   * carrier's own failure is an outcome rather than an exception: the developer
-   * asked for something, and what became of it has to be said.
-   */
-  async #answerToolCalls(calls: readonly RealtimeFunctionCall[], armed: boolean): Promise<void> {
-    // `armed` is the hard gate, decided by the caller from two facts together:
-    // a write runs only in a turn the developer opened — by speaking, or by
-    // typing — and only out of the reply that turn actually asked for, never
-    // the finished form of one the developer already interrupted. A call
-    // failing either test is refused whatever it names, so a session summary
-    // or a tool output that reads like an instruction can never make Luke act.
-    // The turn's tools are also withheld at the API on every turn Luke opens
-    // himself, so this is belt to that suspenders rather than the only thing
-    // holding.
-    // The turn these calls belong to. If it is no longer the current turn by
-    // the time the writes finish, the developer has moved on and the outcome
-    // must not be spoken over whatever they are now saying or hearing.
-    const epoch = this.#turnEpoch;
-
-    for (const call of calls) {
-      const output = await this.#toolCallOutput(call, armed);
-      this.#send(functionCallOutputEvents(call.callId, output));
+  async #sdkToolOutput(
+    expectedName: string,
+    details: SdkToolCallDetails | undefined,
+  ): Promise<WireRecord> {
+    const toolCall = details?.toolCall;
+    const callId = toolCall?.callId;
+    const name = toolCall?.name;
+    if (toolCall?.type !== "function_call" || !callId || name !== expectedName) {
+      return { status: ACT_RESULT_STATUS.REJECTED, reason: "The tool call was malformed." };
     }
+    const argumentsJson = toolCall.arguments;
+    if (argumentsJson === undefined) {
+      return { status: ACT_RESULT_STATUS.REJECTED, reason: "The tool arguments were malformed." };
+    }
+    const responseId = this.#toolCallResponseIds.get(callId);
+    const batch = responseId === this.#toolBatch?.responseId ? this.#toolBatch : undefined;
+    const armed = Boolean(
+      batch?.armed && batch.epoch === this.#turnEpoch && batch.callIds.has(callId),
+    );
+    return this.#toolCallOutput({ name, callId, argumentsJson }, armed);
+  }
 
-    // An unarmed turn — a proactive readout, a follow-up — carries no outcome
-    // to voice: every call on it was refused, and opening a reply here would be
-    // a turn that was meant to stay silent talking on without its instructions.
-    // The calls are still answered above, so the model is not left waiting.
-    if (!armed) return;
-    // A follow-up now would talk over a live microphone or a newer reply: the
-    // developer took the turn, started another, or the call is gone. The
-    // outcomes were still delivered as items, so the next turn has them.
-    if (!this.isConnected || this.#turnEpoch !== epoch) return;
-    // The follow-up continues the exchange the developer opened, so whatever
-    // the reply said before its tool call stays on the strip and the outcome
-    // stacks under it, rather than replacing words still being read.
+  #toolOutputSent(callId: string): void {
+    const responseId = this.#toolCallResponseIds.get(callId);
+    const batch = responseId === this.#toolBatch?.responseId ? this.#toolBatch : undefined;
+    if (!batch?.callIds.has(callId)) return;
+    batch.outputCallIds.add(callId);
+    this.#startToolFollowUpIfReady();
+  }
+
+  #startToolFollowUpIfReady(): void {
+    const batch = this.#toolBatch;
+    if (
+      !batch?.armed ||
+      !batch.responseDone ||
+      batch.followUpStarted ||
+      batch.epoch !== this.#turnEpoch ||
+      !this.isConnected ||
+      [...batch.callIds].some((callId) => !batch.outputCallIds.has(callId))
+    ) {
+      return;
+    }
+    batch.followUpStarted = true;
     this.#startResponse(functionCallFollowUpEvents(), { keepCaption: true });
   }
 
@@ -2683,12 +2673,9 @@ export class RealtimeVoiceSession {
   }
 
   #send(events: readonly WireRecord[]): void {
-    const channel = this.#channel;
-    if (channel?.readyState !== "open") return;
-    for (const event of events) {
-      channel.send(JSON.stringify(event));
-      this.#options.onWireEvent?.(TRACE_DIRECTION.CLIENT, event);
-    }
+    const transport = this.#sdkTransport;
+    if (transport?.status !== "connected") return;
+    for (const event of events) transport.sendEvent(event);
   }
 
   #fail(message: string): boolean {

--- a/apps/desktop/src/renderer/realtime-session.ts
+++ b/apps/desktop/src/renderer/realtime-session.ts
@@ -887,16 +887,24 @@ export class RealtimeVoiceSession {
       this.#remoteTrack = event.track;
       this.#options.onRemoteStream(event.streams[0] ?? new MediaStream([event.track]));
     };
+    // The listener outlives the peer it was added to, so a stale peer's late
+    // `failed` is answered by the attempt token rather than by the live call.
+    const attempt = this.#attempt;
     peer.addEventListener("connectionstatechange", () => {
+      if (attempt !== this.#attempt || this.#closed) return;
       if (peer.connectionState === "failed") this.#fail("The voice connection dropped.");
     });
   }
 
   #connectionChanged(status: SdkRealtimeTransport["status"]): void {
+    // Teardown clears the transport before anything can report on it, so a
+    // `disconnected` with no transport standing is a call already ended — by
+    // a stop or a failure whose status must not be rewritten to idle.
     if (
       status !== "disconnected" ||
       this.#closed ||
       this.#tearingDown ||
+      !this.#sdkTransport ||
       this.#status === REALTIME_STATUS.CONNECTING
     ) {
       return;

--- a/apps/desktop/src/renderer/use-voice-conversation.ts
+++ b/apps/desktop/src/renderer/use-voice-conversation.ts
@@ -22,6 +22,7 @@ import {
   type RealtimeStatus,
   type RealtimeVoice,
   type RealtimeVoiceSpeed,
+  realtimeSessionConfig,
   recentConversationEntries,
   replyConversationEntry,
   retainedConversationEntries,
@@ -962,6 +963,13 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
   const ensureVoiceSession = useCallback((): RealtimeVoiceSession => {
     voiceSession.current ??= new RealtimeVoiceSession({
       requestConnection: () => window.sidecar.requestRealtimeCredential(),
+      sessionConfig: (model) =>
+        realtimeSessionConfig({
+          model,
+          ...(optionsRef.current.voice ? { voice: optionsRef.current.voice } : undefined),
+          ...(optionsRef.current.voiceSpeed ? { speed: optionsRef.current.voiceSpeed } : undefined),
+        }),
+      audioElement: () => remoteAudio.current,
       // The press's device, chosen by facts read natively: the Mac's own
       // microphone where a Bluetooth headset would otherwise pay for the
       // capture with its music codec, the browser's default everywhere else.

--- a/apps/desktop/src/testing/realtime-fixtures.ts
+++ b/apps/desktop/src/testing/realtime-fixtures.ts
@@ -1,6 +1,3 @@
-import type { JsonValue, ParsedJsonObject } from "@sidecar/wire/testing";
-import type { PeerConnection } from "#renderer/realtime-session";
-
 export interface MockAudioTrack {
   enabled: boolean;
   stop: () => void;
@@ -16,15 +13,8 @@ export interface MockTrackEvent {
   streams: readonly object[];
 }
 
-export interface MockDataChannel {
-  readyState: "connecting" | "open" | "closed";
-  send: (payload: string) => void;
-  close: () => void;
-  onmessage?: ((event: { data: string | JsonValue }) => void) | null;
-  onclose?: (() => void) | null;
-}
-
 export interface MockRtpSender {
+  track: MockMediaTrack | null;
   replaceTrack: (next: MockMediaTrack | null) => Promise<void>;
 }
 
@@ -32,21 +22,11 @@ export interface MockMediaTrack {
   readonly kind: string;
 }
 
-export interface MockTransceiverInit {
-  direction?: string;
-}
-
 export interface MockPeerConnection {
-  localDescription: RTCSessionDescriptionInit;
   connectionState: RTCPeerConnectionState | "connected" | "closed";
-  addTransceiver: (kind: string, init?: MockTransceiverInit) => { sender: MockRtpSender };
-  createDataChannel: () => MockDataChannel;
-  createOffer: () => Promise<RTCSessionDescriptionInit>;
-  setLocalDescription: () => Promise<void>;
-  setRemoteDescription: () => Promise<void>;
-  close: () => void;
+  getSenders: () => MockRtpSender[];
+  addEventListener: (type: "connectionstatechange", listener: () => void) => void;
   ontrack?: ((event: MockTrackEvent) => void) | null;
-  onconnectionstatechange?: (() => void) | null;
 }
 
 /** Fixture audio stream implementing only the MediaStream surface the session opens. */
@@ -55,13 +35,14 @@ export function asMediaStream(stream: MockMediaStream): MediaStream {
   return stream as MediaStream;
 }
 
-/** Fixture peer connection, which is the surface the session names, not a cast. */
-export function asPeerConnection(peer: MockPeerConnection): PeerConnection {
-  return peer;
+/** Fixture track implementing only identity and kind, which the session reads. */
+export function asMediaTrack(track: MockMediaTrack): MediaStreamTrack {
+  // SAFETY: The session uses this synthetic track only to find its sender and restore it.
+  return track as MediaStreamTrack;
 }
 
-/** Parsed realtime client event from JSON sent over the data channel. */
-export function parseClientEvent(payload: string): ParsedJsonObject {
-  // SAFETY: Parsed JSON matches the realtime client event shape this harness records.
-  return JSON.parse(payload) as ParsedJsonObject;
+/** Fixture peer connection implementing only the browser surface the session reads. */
+export function asPeerConnection(peer: MockPeerConnection): RTCPeerConnection {
+  // SAFETY: The session reads only getSenders, ontrack, and connection state changes.
+  return peer as RTCPeerConnection;
 }

--- a/packages/realtime/src/index.ts
+++ b/packages/realtime/src/index.ts
@@ -33,7 +33,6 @@ export {
 export {
   type IntroductionLine,
   introductionSessionConfig,
-  introductionSessionSyncEvents,
   introductionSpeechEvents,
 } from "./introduction.js";
 export {
@@ -64,7 +63,7 @@ export {
   realtimeClientSecretRequest,
   realtimeCredentialFromResponse,
   realtimeMintExplanation,
-  realtimeSessionSyncEvents,
+  realtimeSessionConfig,
 } from "./realtime-credentials.js";
 export {
   ARRIVAL_SPEECH_KIND,
@@ -76,11 +75,11 @@ export {
   clearOutputAudioEvents,
   decodeRealtimePayload,
   functionCallFollowUpEvents,
-  functionCallOutputEvents,
   inputAudioAppendEvents,
   inputAudioFormatUpdateEvents,
   isArrivalSpeech,
   maximumFeedbackDraftLength,
+  maximumTypedAskLength,
   outputSpeedUpdateEvents,
   type ProactiveSpeechTurn,
   parseRealtimeServerEvent,
@@ -98,7 +97,6 @@ export {
   SESSION_NO_LONGER_OBSERVED_NOTE,
   type SessionAnnouncement,
   truncateResponseEvents,
-  typedAskEvents,
 } from "./realtime-protocol.js";
 export {
   type ActEnvelope,

--- a/packages/realtime/src/introduction.test.ts
+++ b/packages/realtime/src/introduction.test.ts
@@ -1,13 +1,8 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { isRecord } from "@sidecar/wire";
-import {
-  introductionSessionConfig,
-  introductionSessionSyncEvents,
-  introductionSpeechEvents,
-} from "./introduction.js";
+import { introductionSessionConfig, introductionSpeechEvents } from "./introduction.js";
 import { realtimeSessionConfig } from "./realtime-credentials.js";
-import { REALTIME_DEFAULTS } from "./realtime-voice-settings.js";
 
 test("the minted introduction session declares no tools and no way to choose one", () => {
   const config = introductionSessionConfig({ voice: "marin", speed: 1.2 });
@@ -22,18 +17,6 @@ test("the minted introduction session declares no tools and no way to choose one
   assert.equal(config.audio.input.turn_detection, null);
   assert.match(config.instructions, /audio is noisy, ambiguous, or cut off/i);
   assert.match(config.instructions, /never infer[\s\S]*or call a tool from unclear audio/i);
-});
-
-test("the sync events re-assert the same tool-free session after connect", () => {
-  const events = introductionSessionSyncEvents(REALTIME_DEFAULTS.MODEL);
-  assert.equal(events.length, 1);
-  const event = events[0];
-  assert.ok(event);
-  const session = event.session;
-  assert.ok(isRecord(session));
-  assert.deepEqual(session.tools, []);
-  assert.equal(session.tool_choice, "none");
-  assert.deepEqual(session.reasoning, { effort: "low" });
 });
 
 test("a scripted beat travels as data behind a marker and opens a tool-free turn", () => {

--- a/packages/realtime/src/introduction.ts
+++ b/packages/realtime/src/introduction.ts
@@ -1,12 +1,7 @@
 import { LUKE_PERSONA } from "@sidecar/attention";
 import type { WireRecord } from "@sidecar/wire";
-import {
-  type RealtimeSessionOptions,
-  realtimeReasoning,
-  realtimeSessionConfig,
-} from "./realtime-credentials.js";
-import { REALTIME_CLIENT_EVENT, REALTIME_SESSION_TYPE } from "./realtime-protocol.js";
-import { REALTIME_DEFAULTS } from "./realtime-voice-settings.js";
+import { type RealtimeSessionOptions, realtimeSessionConfig } from "./realtime-credentials.js";
+import { REALTIME_CLIENT_EVENT } from "./realtime-protocol.js";
 
 /**
  * The spoken introduction's wire grammar. The introduction is the one call
@@ -69,30 +64,6 @@ export function introductionSessionConfig(options: RealtimeSessionOptions = {}) 
     tools: [],
     tool_choice: "none",
   };
-}
-
-/**
- * Reasserts the introduction session after the call opens, the same moment the
- * conversation call reasserts its own instructions and tools. The differences
- * are the point: the introduction's instructions replace the conversation's,
- * the tool list is empty, and `tool_choice` is `"none"` — the call is
- * tool-free by declaration, not merely by nobody asking.
- */
-export function introductionSessionSyncEvents(model: string): readonly WireRecord[] {
-  const reasoning = realtimeReasoning(model);
-  return [
-    {
-      type: REALTIME_CLIENT_EVENT.SESSION_UPDATE,
-      session: {
-        type: REALTIME_SESSION_TYPE,
-        ...(reasoning ? { reasoning } : undefined),
-        instructions: introductionInstructions(),
-        tools: [],
-        tool_choice: "none",
-        audio: { input: { transcription: { model: REALTIME_DEFAULTS.TRANSCRIPTION_MODEL } } },
-      },
-    },
-  ];
 }
 
 /**

--- a/packages/realtime/src/realtime-credentials.ts
+++ b/packages/realtime/src/realtime-credentials.ts
@@ -1,17 +1,7 @@
 import type { RealtimeCredential } from "@sidecar/hosted";
-import {
-  isRecord,
-  text,
-  type UnparsedWireValue,
-  type WireRecord,
-  wholeNumber,
-} from "@sidecar/wire";
+import { isRecord, text, type UnparsedWireValue, wholeNumber } from "@sidecar/wire";
 import { PRESS_AUDIO_SAMPLE_RATE } from "./press-audio.js";
-import {
-  REALTIME_CLIENT_EVENT,
-  REALTIME_SESSION_TYPE,
-  realtimeInstructions,
-} from "./realtime-protocol.js";
+import { REALTIME_SESSION_TYPE, realtimeInstructions } from "./realtime-protocol.js";
 import { realtimeToolDefinitions } from "./realtime-tools.js";
 import { REALTIME_DEFAULTS } from "./realtime-voice-settings.js";
 
@@ -107,36 +97,6 @@ export function realtimeSessionConfig(options: RealtimeSessionOptions = {}) {
       },
     },
   };
-}
-
-/**
- * Reasserts the local build's instructions and tools after any credential
- * source opens a call. The transcription rides along for the same reason: the
- * hosted mint composes its session on the service, so the one place every
- * call can be asked to hand the developer's words back is the call itself.
- */
-export function realtimeSessionSyncEvents(model: string): readonly WireRecord[] {
-  const reasoning = realtimeReasoning(model);
-  const built = [
-    {
-      type: REALTIME_CLIENT_EVENT.SESSION_UPDATE,
-      session: {
-        type: REALTIME_SESSION_TYPE,
-        ...(reasoning ? { reasoning } : undefined),
-        instructions: realtimeInstructions(),
-        tools: realtimeToolDefinitions(),
-        tool_choice: "auto",
-        audio: { input: { transcription: { model: REALTIME_DEFAULTS.TRANSCRIPTION_MODEL } } },
-      },
-    },
-  ];
-  const parsed: UnparsedWireValue = JSON.parse(JSON.stringify(built));
-  if (!Array.isArray(parsed)) return [];
-  const records: WireRecord[] = [];
-  for (const item of parsed) {
-    if (isRecord(item)) records.push(item);
-  }
-  return records;
 }
 
 /** Builds the request body that mints an ephemeral client secret. */

--- a/packages/realtime/src/realtime-protocol.ts
+++ b/packages/realtime/src/realtime-protocol.ts
@@ -359,32 +359,6 @@ export const maximumTypedAskLength = maximumSessionMessageLength;
  */
 export const maximumFeedbackDraftLength = maximumTypedAskLength;
 
-/**
- * Builds the events that carry a typed ask and request the reply to it.
- *
- * The text travels without a label, unlike every other `input_text` this
- * module builds: labels mark what the developer did not say, and a typed ask
- * is the developer's own words as surely as a spoken one. The reply is
- * requested with the session's own `tool_choice`, because typing opens a
- * developer turn exactly as a push-to-talk commit does — the caller arms the
- * turn on the same terms, and the roster gauntlet stands behind it unchanged.
- */
-export function typedAskEvents(text: string): readonly WireRecord[] {
-  const ask = trimmedText(text)?.slice(0, maximumTypedAskLength);
-  if (!ask) return [];
-  return [
-    {
-      type: REALTIME_CLIENT_EVENT.CONVERSATION_ITEM_CREATE,
-      item: {
-        type: "message",
-        role: "user",
-        content: [{ type: "input_text", text: ask }],
-      },
-    },
-    { type: REALTIME_CLIENT_EVENT.RESPONSE_CREATE },
-  ];
-}
-
 const BASE64_ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
 
 /**
@@ -972,29 +946,6 @@ export function parseRealtimeServerEvent(
 }
 
 /**
- * Builds the events that answer a tool call and ask Luke to say what happened.
- * The outcome travels as the call's own output, so the model's next sentence
- * is grounded in what the provider actually answered rather than in what it
- * hoped.
- */
-export function functionCallOutputEvents(
-  callId: string,
-  output: Readonly<WireRecord>,
-): readonly WireRecord[] {
-  if (!trimmedText(callId)) return [];
-  return [
-    {
-      type: REALTIME_CLIENT_EVENT.CONVERSATION_ITEM_CREATE,
-      item: {
-        type: "function_call_output",
-        call_id: callId,
-        output: JSON.stringify(output),
-      },
-    },
-  ];
-}
-
-/**
  * Builds the event that asks for the reply voicing the tool outcomes. Its tools
  * are withheld: this turn was opened to say what happened, not to act again, so
  * a tool output that reads like an instruction cannot make it call anything —
@@ -1006,6 +957,7 @@ export function functionCallFollowUpEvents(): readonly WireRecord[] {
     {
       type: REALTIME_CLIENT_EVENT.RESPONSE_CREATE,
       response: {
+        tools: [],
         tool_choice: "none",
       },
     },

--- a/packages/realtime/src/realtime.test.ts
+++ b/packages/realtime/src/realtime.test.ts
@@ -10,7 +10,6 @@ import {
   contextSupersedeEvents,
   conversationContextEvents,
   functionCallFollowUpEvents,
-  functionCallOutputEvents,
   inputAudioAppendEvents,
   inputAudioFormatUpdateEvents,
   isIssueToolName,
@@ -32,18 +31,15 @@ import {
   realtimeCredentialFromResponse,
   realtimeCredentialIsUsable,
   realtimeInstructions,
-  realtimeSessionSyncEvents,
   SESSION_ANNOUNCEMENT_CHANGE,
   sessionContextEvents,
   sessionContextText,
   sessionToolAction,
   truncateResponseEvents,
-  typedAskEvents,
   workspaceProjectContextEvents,
   workspaceProjectContextText,
 } from "@sidecar/realtime";
 import {
-  maximumSessionMessageLength,
   maximumWorkspaceNameLength,
   normalizeSession,
   type ObservedWorkspaceProject,
@@ -68,7 +64,7 @@ import {
   maximumVoiceContextWorkspaceProjects,
 } from "./realtime-context.js";
 import { REALTIME_TRUNCATION, realtimeSessionConfig } from "./realtime-credentials.js";
-import { maximumTypedAskLength, REALTIME_SESSION_TYPE } from "./realtime-protocol.js";
+import { REALTIME_SESSION_TYPE } from "./realtime-protocol.js";
 import {
   ACTS,
   REALTIME_TOOL,
@@ -135,9 +131,6 @@ test("the minted session asks for the developer's spoken words back as text", ()
 
 test("a model override receives no unsupported reasoning configuration", () => {
   assert.equal(realtimeSessionConfig({ model: "gpt-realtime-preview" }).reasoning, undefined);
-  const [sync] = realtimeSessionSyncEvents("gpt-realtime-preview");
-  assert.ok(sync && isRecord(sync.session));
-  assert.equal(sync.session.reasoning, undefined);
 });
 
 test("unclear audio is clarified without guessing or acting", () => {
@@ -384,19 +377,6 @@ test("the keyed mint pins the same input format the appends travel as", () => {
   });
 });
 
-test("the session sync asks every call for the developer's words back", () => {
-  // The hosted mint composes its session on the service, so the sync the
-  // channel opens with is the one place every call — hosted or keyed — can be
-  // asked to transcribe the developer's spoken turns.
-  const [sync] = realtimeSessionSyncEvents(REALTIME_DEFAULTS.MODEL);
-
-  assert.ok(sync && isRecord(sync.session));
-  assert.deepEqual(sync.session.reasoning, { effort: "low" });
-  assert.deepEqual(sync.session.audio, {
-    input: { transcription: { model: REALTIME_DEFAULTS.TRANSCRIPTION_MODEL } },
-  });
-});
-
 test("captured audio travels as one append, little-endian PCM in base64", () => {
   const events = inputAudioAppendEvents(new Int16Array([0, 1, -1, 32_767, -32_768]));
 
@@ -451,36 +431,6 @@ test("an unusable pace builds no update rather than one the API refuses", () => 
   for (const speed of [0, -1, Number.NaN, Number.POSITIVE_INFINITY]) {
     assert.deepEqual(outputSpeedUpdateEvents(speed), []);
   }
-});
-
-test("a typed ask travels as the developer's own words and asks for a reply", () => {
-  const events = typedAskEvents("  What needs me right now?  ");
-
-  assert.equal(events.length, 2);
-  assert.equal(events[0]?.type, REALTIME_CLIENT_EVENT.CONVERSATION_ITEM_CREATE);
-  const item = conversationItem(events[0]);
-  assert.equal(text(item?.role), "user");
-  const content = item?.content;
-  const firstContent = Array.isArray(content) && isRecord(content[0]) ? content[0] : undefined;
-  assert.equal(text(firstContent?.type), "input_text");
-  // No label ahead of the words: labels mark what the developer did not say,
-  // and a typed ask is theirs as surely as a spoken one.
-  assert.equal(text(firstContent?.text), "What needs me right now?");
-  // The reply keeps the session's own tool_choice, unlike every turn Luke
-  // opens himself: typing opens a developer turn the way a commit does.
-  assert.deepEqual(events[1], { type: REALTIME_CLIENT_EVENT.RESPONSE_CREATE });
-});
-
-test("an empty ask opens no turn at all", () => {
-  for (const text of ["", "   ", "\n\t "]) {
-    assert.deepEqual(typedAskEvents(text), []);
-  }
-});
-
-test("a typed ask is bounded like a session message", () => {
-  assert.equal(maximumTypedAskLength, maximumSessionMessageLength);
-  const events = typedAskEvents("x".repeat(maximumTypedAskLength + 100));
-  assert.equal(conversationItemText(events[0]).length, maximumTypedAskLength);
 });
 
 function announcementInputText(event: WireRecord | undefined): string {
@@ -2071,18 +2021,6 @@ test("an opening task is held to the project's own word for it", () => {
   for (const refusal of refusals) assert.equal(refusal.status, ACT_RESULT_STATUS.REJECTED);
 });
 
-test("a tool call is answered with the outcome the provider gave", () => {
-  const events = functionCallOutputEvents("call-1", { status: "accepted" });
-
-  assert.equal(events.length, 1);
-  assert.equal(events[0]?.type, REALTIME_CLIENT_EVENT.CONVERSATION_ITEM_CREATE);
-  const item = conversationItem(events[0]);
-  assert.equal(text(item?.type), "function_call_output");
-  assert.equal(text(item?.call_id), "call-1");
-  assert.equal(text(item?.output), '{"status":"accepted"}');
-  assert.deepEqual(functionCallOutputEvents("  ", { status: "accepted" }), []);
-});
-
 test("the reply that voices an outcome cannot itself call a tool", () => {
   const [request] = functionCallFollowUpEvents();
 
@@ -2092,6 +2030,7 @@ test("the reply that voices an outcome cannot itself call a tool", () => {
   // output that reads like an instruction has nothing to act with. It also
   // inherits the session's standing instructions rather than replacing them.
   assert.equal(response?.tool_choice, "none");
+  assert.deepEqual(response?.tools, []);
   assert.equal(response?.instructions, undefined);
 });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,6 +36,9 @@ importers:
         specifier: 6.8.9
         version: 6.8.9
     devDependencies:
+      '@openai/agents-realtime':
+        specifier: 0.17.0
+        version: 0.17.0(undici@7.29.0)(zod@4.5.4)
       '@sentry/esbuild-plugin':
         specifier: 5.4.0
         version: 5.4.0(rollup@4.62.4)
@@ -138,6 +141,9 @@ importers:
       typescript:
         specifier: 7.0.2
         version: 7.0.2
+      zod:
+        specifier: 4.5.4
+        version: 4.5.4
 
   apps/web:
     dependencies:
@@ -1858,6 +1864,14 @@ packages:
     resolution: {integrity: sha512-9QOtNffcOF/c1seMCDnjckb3R9WHcG34tky+FHpNKKCW0wc/scYLwMtO+ptyGUfMW0/b/n4qRiALlaFHc9Oj7Q==}
     engines: {node: '>= 10.0.0'}
 
+  '@modelcontextprotocol/client@2.0.0':
+    resolution: {integrity: sha512-8f1OghQ2rjzIOfqgUCP+8GiUWqRs89njoWLNqAe8kWmDePv3s1fZXseej+QXemssEuuOvLLmLO/kqM3IQHtISw==}
+    engines: {node: '>=20'}
+
+  '@modelcontextprotocol/core@2.0.0':
+    resolution: {integrity: sha512-pJCEwGG7Lfr/+PQp9ZTwKXNeO5wzbfKL7H3MYpCorM4oFBoQrdjnBgEoqG+RjhsvS1FKrDbKux+M1HhlnGWqcA==}
+    engines: {node: '>=20'}
+
   '@napi-rs/lzma-linux-x64-gnu@1.5.1':
     resolution: {integrity: sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==}
     engines: {node: ^22.20 || ^24.12 || >=25}
@@ -1927,6 +1941,19 @@ packages:
   '@noble/hashes@2.3.0':
     resolution: {integrity: sha512-oN+QwyX7VSHotibwubG3kpzbwKrfnyR6OOO+3Nk/53ADL7FmgHHz4TgrbaYKvvOw09u6QTx0oiH1cNCIOuN0CQ==}
     engines: {node: '>= 20.19.0'}
+
+  '@openai/agents-core@0.17.0':
+    resolution: {integrity: sha512-lyoF860313ypeKSPRsdmyNK1ypF8/ocShN2EwCcKUpF4VvRWa5AUVKL6VXO/keQMwNPZw5SACAf1siU9uMvUNg==}
+    peerDependencies:
+      zod: ^4.0.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
+
+  '@openai/agents-realtime@0.17.0':
+    resolution: {integrity: sha512-spHgDIaWQIOJjwowjBTo0X9Jn3+CGX9fWgsyRUilsQ8SsnNrAre2km6sr8HwFnRiyQC0XpmTccieyfuXmzMfXg==}
+    peerDependencies:
+      zod: ^4.0.0
 
   '@opentelemetry/api-logs@0.220.0':
     resolution: {integrity: sha512-CmVa4ImJ+ynfrPMNaAXHET6Bhb44SwzmfyVJFq9ni2jgXJR/l7C6gfVFddNmHP+ZOkP9cf4f9DBe68qVLTHc9w==}
@@ -2606,6 +2633,9 @@ packages:
 
   '@types/verror@1.10.11':
     resolution: {integrity: sha512-RlDm9K7+o5stv0Co8i8ZRGxDbrTxhJtgjqjFyVh/tXQyl/rYtTKlnTvZ88oSTeYREWurwx20Js4kTuKCsFkUtg==}
+
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
   '@typescript/typescript-aix-ppc64@7.0.2':
     resolution: {integrity: sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==}
@@ -3350,6 +3380,14 @@ packages:
   eventemitter3@5.0.4:
     resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
 
+  eventsource-parser@3.1.1:
+    resolution: {integrity: sha512-EKN1vKAMcZ8MlYMpaNuxN6R9yakzH6uajHcHVTqWJzvu5pWw9DyhbP35HH8MVBQ+dZjAfDxk+A8NiR9KWaXiyQ==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
+    engines: {node: '>=18.0.0'}
+
   exponential-backoff@3.1.3:
     resolution: {integrity: sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==}
 
@@ -3879,6 +3917,30 @@ packages:
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
+  openai@7.8.0:
+    resolution: {integrity: sha512-/2g9JzdnXNcjX1W/UlSNu+OdSFDAaAVt0n9Onom0kPenH54o59G2WrX/xjTnr26UHNSh6hxcAf58doGYRme2rw==}
+    engines: {node: '>=22.0.0'}
+    peerDependencies:
+      '@aws-sdk/credential-provider-node': '>=3.972.0 <4'
+      '@smithy/hash-node': '>=4.3.0 <5'
+      '@smithy/signature-v4': '>=5.4.0 <6'
+      undici: '>=5 <9'
+      ws: ^8.21.0
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@aws-sdk/credential-provider-node':
+        optional: true
+      '@smithy/hash-node':
+        optional: true
+      '@smithy/signature-v4':
+        optional: true
+      undici:
+        optional: true
+      ws:
+        optional: true
+      zod:
+        optional: true
+
   oxlint@1.79.0:
     resolution: {integrity: sha512-hVJ9hq9m2unPS+Of4eJJgCPdIeCC+3DHEUX3tkmrPJr3OK2hz7PhXwgC+ZP71ZcYu8cCDEtQrqLxWNvxBppBVg==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -3964,6 +4026,10 @@ packages:
   picomatch@4.0.5:
     resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
     engines: {node: '>=12'}
+
+  pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
+    engines: {node: '>=16.20.0'}
 
   plist@3.1.0:
     resolution: {integrity: sha512-uysumyrvkUX0rX/dEVqt8gC3sTBzd4zoWfLeS29nb53imdaXVvLINYXTI2GNqzaMuvacNx4uJQ8+b3zXR0pkgQ==}
@@ -4459,6 +4525,18 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
+  ws@8.21.3:
+    resolution: {integrity: sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
   xmlbuilder@15.1.1:
     resolution: {integrity: sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==}
     engines: {node: '>=8.0'}
@@ -4500,6 +4578,9 @@ packages:
 
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
+
+  zod@4.5.4:
+    resolution: {integrity: sha512-sC95tT5iHHH9gtpj6A81kh+NEaRAUFN+qlUPDUbRfOMvNf5QCBqsb3WgvnpVtK5Y+4UfA6KqufotuTvMGiTlsA==}
 
 snapshots:
 
@@ -5286,6 +5367,22 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@modelcontextprotocol/client@2.0.0':
+    dependencies:
+      '@modelcontextprotocol/core': 2.0.0
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.1.1
+      jose: 6.2.9
+      pkce-challenge: 5.0.1
+      zod: 4.5.4
+    optional: true
+
+  '@modelcontextprotocol/core@2.0.0':
+    dependencies:
+      zod: 4.5.4
+    optional: true
+
   '@napi-rs/lzma-linux-x64-gnu@1.5.1':
     optional: true
 
@@ -5319,6 +5416,38 @@ snapshots:
   '@noble/ciphers@2.3.0': {}
 
   '@noble/hashes@2.3.0': {}
+
+  '@openai/agents-core@0.17.0(undici@7.29.0)(ws@8.21.3)(zod@4.5.4)':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      debug: 4.4.3
+      openai: 7.8.0(undici@7.29.0)(ws@8.21.3)(zod@4.5.4)
+    optionalDependencies:
+      '@modelcontextprotocol/client': 2.0.0
+      zod: 4.5.4
+    transitivePeerDependencies:
+      - '@aws-sdk/credential-provider-node'
+      - '@smithy/hash-node'
+      - '@smithy/signature-v4'
+      - supports-color
+      - undici
+      - ws
+
+  '@openai/agents-realtime@0.17.0(undici@7.29.0)(zod@4.5.4)':
+    dependencies:
+      '@openai/agents-core': 0.17.0(undici@7.29.0)(ws@8.21.3)(zod@4.5.4)
+      '@types/ws': 8.18.1
+      debug: 4.4.3
+      ws: 8.21.3
+      zod: 4.5.4
+    transitivePeerDependencies:
+      - '@aws-sdk/credential-provider-node'
+      - '@smithy/hash-node'
+      - '@smithy/signature-v4'
+      - bufferutil
+      - supports-color
+      - undici
+      - utf-8-validate
 
   '@opentelemetry/api-logs@0.220.0':
     dependencies:
@@ -5874,6 +6003,10 @@ snapshots:
 
   '@types/verror@1.10.11':
     optional: true
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 26.2.0
 
   '@typescript/typescript-aix-ppc64@7.0.2':
     optional: true
@@ -6620,6 +6753,14 @@ snapshots:
 
   eventemitter3@5.0.4: {}
 
+  eventsource-parser@3.1.1:
+    optional: true
+
+  eventsource@3.0.7:
+    dependencies:
+      eventsource-parser: 3.1.1
+    optional: true
+
   exponential-backoff@3.1.3: {}
 
   extsprintf@1.4.1:
@@ -7119,6 +7260,12 @@ snapshots:
     dependencies:
       wrappy: 1.0.2
 
+  openai@7.8.0(undici@7.29.0)(ws@8.21.3)(zod@4.5.4):
+    optionalDependencies:
+      undici: 7.29.0
+      ws: 8.21.3
+      zod: 4.5.4
+
   oxlint@1.79.0:
     optionalDependencies:
       '@oxlint/binding-android-arm-eabi': 1.79.0
@@ -7202,6 +7349,9 @@ snapshots:
   picocolors@1.1.1: {}
 
   picomatch@4.0.5: {}
+
+  pkce-challenge@5.0.1:
+    optional: true
 
   plist@3.1.0:
     dependencies:
@@ -7731,6 +7881,8 @@ snapshots:
 
   wrappy@1.0.2: {}
 
+  ws@8.21.3: {}
+
   xmlbuilder@15.1.1: {}
 
   xtend@4.0.2: {}
@@ -7761,3 +7913,5 @@ snapshots:
   yocto-queue@0.1.0: {}
 
   zod@4.4.3: {}
+
+  zod@4.5.4: {}


### PR DESCRIPTION
## Summary

- Replaces the hand-rolled WebRTC realtime session in the desktop renderer with `@openai/agents-realtime`, adding a thin `agents-realtime-transport.ts` adapter so the SDK owns the peer connection, session configuration, typed asks, and tool-call round-trips.
- Removes the now-redundant `realtimeSessionSyncEvents`, `typedAskEvents`, and `functionCallOutputEvents` builders from `packages/realtime`; `realtimeSessionConfig` and `introductionSessionConfig` feed the SDK directly.
- The introduction takeover and voice conversation hook pass the session config and remote audio element through the same adapter, and the trace tap, roster gauntlet, and tool-free proactive turns are unchanged around it.
- Reimplements #610 on top of current main; adds `zod` as a dev dependency the SDK requires.

## Evidence

- Platform-independent checks: `./scripts/check.sh` passed
- macOS Electron verification (`./scripts/verify.sh`): `not run`

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/33583054967/artifacts/9829134507) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/33583054967)

- Commit: `b5930f231b3a7e10ab4824906788a415a6b7e4a3`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

### Physical-device evidence

- Screenshot or screen recording: `not attached`
- Physical-notch check: `not performed`
- Device/display configuration: `not recorded`

## Notes

- Blockers or follow-up verification: live voice call against the real service not exercised in this session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)