### PR TITLE
feat(conductor): have Luke name the workspaces he creates

### DIFF
--- a/apps/desktop/src/renderer/luke-guide.ts
+++ b/apps/desktop/src/renderer/luke-guide.ts
@@ -462,8 +462,12 @@ export function buildLukeGuide(input: LukeGuideInput): AppGuideSnapshot {
       detail:
         "Where a connected provider documents a creation endpoint — Conductor, Cursor, and " +
         "Superset today — an ask in conversation, spoken or typed, can create a new " +
-        "workspace in a project that provider reports, optionally named, with an opening " +
-        "task in the developer's own words where the project takes one. Only reported " +
+        "workspace in a project that provider reports, with an opening task in the " +
+        "developer's own words where the project takes one, named as the developer chose or, " +
+        "when they chose none, by a short name Luke composes for the work, so a Conductor " +
+        "cloud workspace never falls back to the random city name it would otherwise get; a " +
+        "project listed as naming its own workspaces — Codex cloud, and Conductor's local " +
+        "create link — takes no name at all. Only reported " +
         "projects can be named, a project that needs a task cannot be created without one, " +
         "and a provider that reports none takes no ask; a new Superset workspace needs a " +
         "host, an agent, and an opening task, so a task-less ask for one is refused. A bare " +

--- a/apps/desktop/src/renderer/realtime-session.test.ts
+++ b/apps/desktop/src/renderer/realtime-session.test.ts
@@ -3847,6 +3847,72 @@ test("a Superset workspace requires an observed host and agent", async () => {
   ]);
 });
 
+test("a project that names its own workspaces refuses a name and takes the rest", async () => {
+  const carried: unknown[] = [];
+  const context = harness({
+    carryAction: async (action) => {
+      carried.push(action);
+      return { status: "accepted" };
+    },
+  });
+  await context.session.connect();
+  context.session.updateWorkspaceProjects([
+    {
+      providerId: "codex",
+      providerName: "Codex cloud",
+      providerProjectId: "env-1",
+      repository: "luke",
+      taskSupport: "required",
+      namesItself: true,
+    },
+  ]);
+  await armDeveloperTurn(context);
+  const sentBefore = context.sent.length;
+  context.emit({
+    type: REALTIME_SERVER_EVENT.RESPONSE_DONE,
+    response: {
+      output: [
+        {
+          type: "function_call",
+          name: "create_workspace",
+          call_id: "call-named",
+          arguments:
+            '{"provider_id":"codex","project_id":"env-1","name":"Panel fix","task":"Fix the panel"}',
+        },
+        {
+          type: "function_call",
+          name: "create_workspace",
+          call_id: "call-unnamed",
+          arguments: '{"provider_id":"codex","project_id":"env-1","task":"Fix the panel"}',
+        },
+      ],
+    },
+  });
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  // The named ask is refused before any bridge call exists — the provider
+  // would refuse it anyway, and a refusal here says why — and the same ask
+  // without a name is carried whole.
+  assert.deepEqual(carried, [
+    {
+      kind: "create-workspace",
+      providerId: "codex",
+      providerProjectId: "env-1",
+      task: "Fix the panel",
+    },
+  ]);
+  const outputs = context.sent.slice(sentBefore).filter(
+    // SAFETY: Fixture value matches the narrowed runtime shape this test exercises.
+    (event) => (event.item as { type?: string } | undefined)?.type === "function_call_output",
+  );
+  const [refused] = outputs;
+  assert.match(
+    // SAFETY: Fixture value matches the narrowed runtime shape this test exercises.
+    (refused?.item as { output?: string } | undefined)?.output ?? "",
+    /names its own workspaces/,
+  );
+});
+
 test("a sole Superset project resolves when the model omits its routing ids", async () => {
   const carried: unknown[] = [];
   const context = harness({

--- a/apps/ios/Luke/WorkspaceCreatorSheet.swift
+++ b/apps/ios/Luke/WorkspaceCreatorSheet.swift
@@ -117,10 +117,12 @@ struct WorkspaceCreatorSheet: View {
                 }
             }
 
-            Section {
-                TextField("Name", text: $name)
-            } footer: {
-                Text("Optional — the provider names the workspace otherwise.")
+            if project?.namesItself != true {
+                Section {
+                    TextField("Name", text: $name)
+                } footer: {
+                    Text("Optional — the provider names the workspace otherwise.")
+                }
             }
 
             if project?.taskSupport != ProjectTaskSupport.none {
@@ -261,7 +263,7 @@ struct WorkspaceCreatorSheet: View {
         guard let project else { return }
         creating = true
         failure = nil
-        let chosenName = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        let chosenName = project.namesItself ? "" : name.trimmingCharacters(in: .whitespacesAndNewlines)
         let chosenTask =
             project.taskSupport == ProjectTaskSupport.none
             ? "" : task.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/apps/ios/LukeKit/Sources/LukeKit/ProjectsClient.swift
+++ b/apps/ios/LukeKit/Sources/LukeKit/ProjectsClient.swift
@@ -19,6 +19,8 @@ public struct RosterProject: Identifiable, Equatable, Sendable {
     public let taskSupport: ProjectTaskSupport
     /// The label of the execution target owning this project, when it has one.
     public let targetName: String?
+    /// The provider names a workspace here itself and refuses a name from the ask.
+    public let namesItself: Bool
 
     public var id: String { "\(providerId):\(providerProjectId)" }
 
@@ -27,13 +29,15 @@ public struct RosterProject: Identifiable, Equatable, Sendable {
         providerProjectId: String,
         repository: String,
         taskSupport: ProjectTaskSupport,
-        targetName: String? = nil
+        targetName: String? = nil,
+        namesItself: Bool = false
     ) {
         self.providerId = providerId
         self.providerProjectId = providerProjectId
         self.repository = repository
         self.taskSupport = taskSupport
         self.targetName = targetName
+        self.namesItself = namesItself
     }
 
     init?(json: [String: Any]) {
@@ -49,6 +53,8 @@ public struct RosterProject: Identifiable, Equatable, Sendable {
         self.repository = repository
         self.taskSupport = taskSupport
         self.targetName = json["targetName"] as? String
+        // Only the boolean it is crosses; anything else reads as absent.
+        self.namesItself = json["namesItself"] as? Bool == true
     }
 }
 

--- a/apps/ios/LukeKit/Tests/LukeKitTests/ProjectsClientTests.swift
+++ b/apps/ios/LukeKit/Tests/LukeKitTests/ProjectsClientTests.swift
@@ -55,6 +55,19 @@ final class RosterProjectTests: XCTestCase {
         XCTAssertEqual(project?.id, "replicas:env-1")
         XCTAssertEqual(project?.taskSupport, .required)
         XCTAssertEqual(project?.targetName, "Staging")
+        XCTAssertEqual(project?.namesItself, false)
+    }
+
+    func testNamesItselfCrossesOnlyAsABoolean() {
+        let base: [String: Any] = [
+            "providerId": "codex",
+            "providerProjectId": "env-1",
+            "repository": "owner/repo",
+            "taskSupport": "required",
+        ]
+        XCTAssertEqual(RosterProject(json: base.merging(["namesItself": true]) { $1 })?.namesItself, true)
+        XCTAssertEqual(RosterProject(json: base.merging(["namesItself": "yes"]) { $1 })?.namesItself, false)
+        XCTAssertEqual(RosterProject(json: base)?.namesItself, false)
     }
 }
 

--- a/apps/web/server/hosted/projects.ts
+++ b/apps/web/server/hosted/projects.ts
@@ -136,5 +136,6 @@ function toWireProject(
     taskSupport: project.taskSupport,
   };
   if (project.targetName) wireProject.targetName = project.targetName;
+  if (project.namesItself) wireProject.namesItself = true;
   return wireProject;
 }

--- a/apps/web/tests/hosted-projects.test.ts
+++ b/apps/web/tests/hosted-projects.test.ts
@@ -136,6 +136,20 @@ test("hostedProjectsAnswerFromWire skips malformed entries rather than failing",
         taskSupport: "optional",
         targetName: "Main host",
       },
+      {
+        providerId: "codex",
+        providerProjectId: "env-1",
+        repository: "owner/repo",
+        taskSupport: "required",
+        namesItself: true,
+      },
+      {
+        providerId: "codex",
+        providerProjectId: "env-2",
+        repository: "owner/repo",
+        taskSupport: "required",
+        namesItself: "yes", // not a boolean
+      },
       { providerId: "conductor", providerProjectId: "proj-2" }, // missing fields
       {
         providerId: "conductor",
@@ -147,9 +161,13 @@ test("hostedProjectsAnswerFromWire skips malformed entries rather than failing",
   };
   const answer = hostedProjectsAnswerFromWire(JSON.parse(JSON.stringify(raw)));
   assert.ok(answer);
-  assert.equal(answer.projects.length, 1);
+  assert.equal(answer.projects.length, 3);
   assert.equal(answer.projects[0]?.providerProjectId, "proj-1");
   assert.equal(answer.projects[0]?.targetName, "Main host");
+  assert.equal(answer.projects[0]?.namesItself, undefined);
+  // The flag crosses only as the boolean it is; anything else reads as absent.
+  assert.equal(answer.projects[1]?.namesItself, true);
+  assert.equal(answer.projects[2]?.namesItself, undefined);
 });
 
 // --- The build's agent table rides beside the projects it applies to ---

--- a/packages/acts/src/acts.ts
+++ b/packages/acts/src/acts.ts
@@ -751,6 +751,12 @@ function validateCreateWorkspace(
   }
   let name: string | undefined;
   if (parsed.name !== undefined) {
+    if (project.namesItself) {
+      return {
+        status: ACT_RESULT_STATUS.REJECTED,
+        reason: "That project names its own workspaces.",
+      };
+    }
     name = workspaceNameText(parsed.name);
     if (!name) {
       return {
@@ -1417,7 +1423,8 @@ export const ACTS = {
     validatedAgainst: ACT_VALIDATION_TARGET.WORKSPACE_PROJECT,
     narration: narrate(
       SESSION_TOOL_KIND.CREATE_WORKSPACE,
-      (action) => `asked ${action.providerId} to create a workspace`,
+      (action) =>
+        `asked ${action.providerId} to create a workspace${action.name ? ` named "${action.name}"` : ""}`,
     ),
     guide: "Create only in a project and target from the latest workspace roster.",
     schema: {
@@ -1443,7 +1450,11 @@ export const ACTS = {
           },
           name: {
             type: "string",
-            description: "An optional workspace name.",
+            description:
+              "The workspace's name: the developer's own when they chose one, otherwise a short, " +
+              "specific name composed from what the workspace is for, in a few words with no " +
+              "punctuation. Always supply one, except in a project listed as naming its own " +
+              "workspaces, which takes none.",
           },
           task: {
             type: "string",

--- a/packages/hosted/src/hosted-service.ts
+++ b/packages/hosted/src/hosted-service.ts
@@ -495,6 +495,8 @@ export interface HostedWorkspaceProject {
   taskSupport: WorkspaceTaskSupport;
   /** The bounded label of the execution target owning this project, when it has one. */
   targetName?: string;
+  /** The provider names a workspace here itself and refuses a name from the ask. */
+  namesItself?: boolean;
 }
 
 /**
@@ -541,6 +543,7 @@ function hostedWorkspaceProjectFromWire(
     taskSupport: taskSupport as WorkspaceTaskSupport,
   };
   if (targetName) project.targetName = targetName;
+  if (value.namesItself === true) project.namesItself = true;
   return project;
 }
 

--- a/packages/providers/src/codex/cloud-adapter.test.ts
+++ b/packages/providers/src/codex/cloud-adapter.test.ts
@@ -380,8 +380,13 @@ test("offers one creation target per observed environment, and none signed out",
   // accounts return — and the id is preferred where one exists.
   await adapter.observe();
   assert.deepEqual(adapter.workspaceProjects(), [
-    { providerProjectId: "reviewstage/luke", repository: "luke", taskSupport: "required" },
-    { providerProjectId: "env-2", repository: "site", taskSupport: "required" },
+    {
+      providerProjectId: "reviewstage/luke",
+      repository: "luke",
+      taskSupport: "required",
+      namesItself: true,
+    },
+    { providerProjectId: "env-2", repository: "site", taskSupport: "required", namesItself: true },
   ]);
 
   behavior.loggedIn = false;

--- a/packages/providers/src/codex/cloud-adapter.ts
+++ b/packages/providers/src/codex/cloud-adapter.ts
@@ -370,6 +370,7 @@ function collectEnvironments(
       providerProjectId: target,
       repository: task.repositoryLabel,
       taskSupport: WORKSPACE_TASK_SUPPORT.REQUIRED,
+      namesItself: true,
     });
   }
 }

--- a/packages/providers/src/conductor/local-workspace-adapter.test.ts
+++ b/packages/providers/src/conductor/local-workspace-adapter.test.ts
@@ -187,6 +187,7 @@ test("refresh offers each repository as an optional-task project", async (t) => 
       providerProjectId: "repo-luke",
       repository: "luke",
       taskSupport: WORKSPACE_TASK_SUPPORT.OPTIONAL,
+      namesItself: true,
       providerTargetId: "/Users/dev/repos/luke",
     },
   ]);

--- a/packages/providers/src/conductor/local-workspace-adapter.ts
+++ b/packages/providers/src/conductor/local-workspace-adapter.ts
@@ -215,6 +215,8 @@ export class ConductorLocalWorkspaceAdapter extends SessionProviderAdapterBase {
       // Conductor makes an idle workspace happily and takes the opening task
       // as its first prompt, so a task is welcome but never required.
       taskSupport: WORKSPACE_TASK_SUPPORT.OPTIONAL,
+      // The creation link documents no name, so Conductor names the workspace.
+      namesItself: true,
       // The repository's own main-worktree path, which the creation link
       // matches a project by and which a create reads back rather than trusts
       // from the request.

--- a/packages/realtime/src/conversation-history.test.ts
+++ b/packages/realtime/src/conversation-history.test.ts
@@ -195,6 +195,19 @@ test("an act's line records the ask in words, with the identity it named", () =>
   );
   assert.equal(created.words, "asked conductor to create a workspace");
   assert.equal(created.identity, undefined);
+  const createdNamed = sessionActConversationEntry(
+    {
+      kind: SESSION_TOOL_KIND.CREATE_WORKSPACE,
+      providerId: "conductor",
+      providerProjectId: "p1",
+      name: "Notch panel clipping",
+    },
+    sessions,
+  );
+  assert.equal(
+    createdNamed.words,
+    'asked conductor to create a workspace named "Notch panel clipping"',
+  );
 });
 
 test("the rendering reads oldest first and says who each line speaks for", () => {

--- a/packages/realtime/src/realtime-context.ts
+++ b/packages/realtime/src/realtime-context.ts
@@ -416,7 +416,7 @@ export function workspaceProjectContextText(
     "Projects a new workspace can be created in:",
     ...listed.map(
       (project) =>
-        `- ${project.providerName} — ${project.repository}${project.targetName ? ` on ${project.targetName}` : ""} [provider_id=${project.providerId} project_id=${project.providerProjectId}${project.providerTargetId ? ` target_id=${project.providerTargetId}` : ""}]; ${TASK_SUPPORT_TEXT[project.taskSupport]}${defaultProjectIds?.[project.providerId] === workspaceProjectSelectionId(project) ? "; the provider's default project" : ""}${project.spawnableAgents?.length ? `; agents: ${project.spawnableAgents.join(", ")}${project.defaultAgent ? `; default agent: ${project.defaultAgent}` : ""}` : ""}`,
+        `- ${project.providerName} — ${project.repository}${project.targetName ? ` on ${project.targetName}` : ""} [provider_id=${project.providerId} project_id=${project.providerProjectId}${project.providerTargetId ? ` target_id=${project.providerTargetId}` : ""}]; ${TASK_SUPPORT_TEXT[project.taskSupport]}${project.namesItself ? "; names its own workspaces" : ""}${defaultProjectIds?.[project.providerId] === workspaceProjectSelectionId(project) ? "; the provider's default project" : ""}${project.spawnableAgents?.length ? `; agents: ${project.spawnableAgents.join(", ")}${project.defaultAgent ? `; default agent: ${project.defaultAgent}` : ""}` : ""}`,
     ),
     chosenDefault
       ? `An ask that names no provider creates in ${chosenDefault.providerName} [provider_id=${chosenDefault.providerId}]; do not ask which provider unless the ask names a different one.`

--- a/packages/realtime/src/realtime.test.ts
+++ b/packages/realtime/src/realtime.test.ts
@@ -1535,6 +1535,13 @@ test("the projects context lists each project with the identity a call names", (
   const text = workspaceProjectContextText([OFFERED_PROJECT]);
 
   assert.match(text, /Conductor — luke \[provider_id=conductor project_id=proj-1\]/);
+  // A project that names its own workspaces says so, or the model would be
+  // asked to compose a name the provider refuses.
+  assert.doesNotMatch(text, /names its own workspaces/);
+  assert.match(
+    workspaceProjectContextText([{ ...OFFERED_PROJECT, namesItself: true }]),
+    /takes an opening task; names its own workspaces/,
+  );
   // An empty list is said in words, or the conversation would be free to
   // imagine somewhere a workspace could go.
   assert.match(workspaceProjectContextText([]), /No provider currently offers/);

--- a/packages/session/src/providers.ts
+++ b/packages/session/src/providers.ts
@@ -359,6 +359,11 @@ export interface WorkspaceProject {
   spawnableAgents?: readonly string[];
   /** The saved agent kind used when a creation ask names none. */
   defaultAgent?: string;
+  /**
+   * The provider names a workspace here itself and takes none from the ask,
+   * so an ask carrying one is refused rather than half honoured.
+   */
+  namesItself?: boolean;
 }
 
 /** A workspace project as the app reports it, stamped with who offered it. */
@@ -469,6 +474,7 @@ export function normalizeObservedWorkspaceProjects(
     }
     const defaultAgent = project.defaultAgent?.trim();
     if (defaultAgent) normalizedProject.defaultAgent = defaultAgent;
+    if (project.namesItself === true) normalizedProject.namesItself = true;
     normalized.push(normalizedProject);
   }
   const sorted = normalized.sort(compareWorkspaceProjects);


### PR DESCRIPTION
## Summary

Workspaces Luke created in Conductor cloud landed with random city names. The `create_workspace` tool only sent `name` on `POST /v0/workspaces` when the developer said one, and nothing prompted the model to fill it, so Conductor named almost every one itself ([docs](https://www.conductor.build/docs/api): "Unnamed workspaces get a random city name").

- The tool's `name` argument now asks the model to always supply one: the developer's own when they chose one, otherwise a short, specific name composed from what the workspace is for.
- A project whose provider names workspaces itself carries a `namesItself` flag on its offer: Codex cloud, whose adapter already refused any name, and Conductor's local create link, which documents none and silently dropped one. The project listing tells the model such a project "names its own workspaces", the tool description exempts them, and the validator refuses a name for one before any bridge call.
- The hosted projects wire carries the same flag, read only as the boolean it is. On iOS, `RosterProject` mirrors it and the New Workspace sheet draws no name field for such a project and sends none, so a mobile ask never reaches the server's refusal.
- The "Creating workspaces" guide entry says the same.
- The act's narration in conversation history names the workspace it created, so the developer hears what it was called.

No wire change for Conductor cloud. The name is a bounded tool argument validated in the renderer and again in main, exactly as before, and it still only rides a write in a developer-opened turn. `POST /v0/sessions` (add_workspace_agent) is unchanged.

## Test plan

- [x] `./scripts/check.sh` passes (exit 0) on the tree rebased onto main.
- [x] Renderer test: a named creation in a project that names its own workspaces is refused with that reason, and the same ask without a name is carried whole.
- [x] Listing-text test: a `namesItself` project reads "names its own workspaces"; an ordinary one does not.
- [x] Narration test: a creation carrying a name reads `asked conductor to create a workspace named "…"`.
- [x] Codex cloud and Conductor local project offers carry the flag.
- [x] Hosted wire test: `namesItself: true` crosses; a non-boolean reads as absent.
- [x] LukeKit `swift test` on a Mac: 124 tests pass, including the new `RosterProject` parsing cases.
- [x] `xcodebuild build` of the Luke scheme for the iPhone 17 Pro simulator succeeds.
- No desktop UI surface changed, so no visual evidence or physical-notch check was run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/b55b9101-f5bd-4172-8182-ffdf7d2582b3)
