### PR TITLE
feat(ios): read a Conductor session's conversation in the detail view

### DIFF
--- a/apps/ios/Luke/SessionDetailView.swift
+++ b/apps/ios/Luke/SessionDetailView.swift
@@ -283,9 +283,9 @@ struct SessionDetailView: View {
         case .user:
             HStack {
                 Spacer(minLength: 48)
-                Text(message.text)
-                    .font(.system(size: 15))
+                MarkdownMessageView(message.text)
                     .foregroundStyle(.white)
+                    .tint(.white)
                     .padding(.horizontal, 14)
                     .padding(.vertical, 9)
                     .background(Color.accentColor, in: RoundedRectangle(cornerRadius: 18))

--- a/apps/ios/Luke/SessionDetailView.swift
+++ b/apps/ios/Luke/SessionDetailView.swift
@@ -88,6 +88,7 @@ struct SessionDetailView: View {
     /// remain.
     private static let pollSeconds: UInt64 = 10
     private static let maximumPollReads = 5
+    private static let conversationEndId = "conversation-end"
 
     var body: some View {
         // Anchored like Messages: the screen opens at the conversation's end,
@@ -136,10 +137,22 @@ struct SessionDetailView: View {
                     ForEach(thread) { message in
                         userBubble(message)
                     }
+                    // The end of the chat as a scroll target of its own:
+                    // aiming a jump at the last bubble is unreliable in a
+                    // lazy stack whose Markdown is still sizing, where this
+                    // marker is always laid out and always last.
+                    Color.clear
+                        .frame(height: 1)
+                        .id(Self.conversationEndId)
                 }
                 .padding(.horizontal, 16)
                 .padding(.vertical, 12)
             }
+            // A conversation opens at its end and follows new messages while
+            // the reader is already there — the system's own chat anchoring.
+            // A screen that will only ever draw the recap keeps the top
+            // anchor its short content has always had.
+            .defaultScrollAnchor(session.canReadConversation ? .bottom : .top)
             .onChange(of: thread.count) { previousCount, count in
                 // Only growth is a send worth following: a handover shrinks
                 // this thread from a poll, and a reader up in history must
@@ -169,14 +182,9 @@ struct SessionDetailView: View {
                 scrollIntent = nil
                 switch intent {
                 case .end:
-                    // Pending sends draw below the fetched thread, so a chat
-                    // holding one opens on it rather than leaving it under
-                    // the fold.
-                    if let last = thread.last {
-                        proxy.scrollTo(last.id, anchor: .bottom)
-                    } else if let last = conversation.last {
-                        proxy.scrollTo(last.id, anchor: .bottom)
-                    }
+                    // The marker sits below pending sends and fetched thread
+                    // alike, so the open lands on whichever is newest.
+                    proxy.scrollTo(Self.conversationEndId, anchor: .bottom)
                     openSettled = true
                 case .anchor(let id):
                     proxy.scrollTo(id, anchor: .top)

--- a/apps/ios/Luke/SessionDetailView.swift
+++ b/apps/ios/Luke/SessionDetailView.swift
@@ -214,7 +214,18 @@ struct SessionDetailView: View {
         .padding(.bottom, 4)
     }
 
-    private func agentBubble(_ words: String, isError: Bool) -> some View {
+    /// A temporary field diagnostic, to be removed once the conversation
+    /// read is verified on a device: red rings the recap fallback and green
+    /// rings fetched transcript messages, so a screen says at a glance which
+    /// path drew its bubbles.
+    private enum ReadPathDiagnostic {
+        static let recap = Color.red
+        static let transcript = Color.green
+    }
+
+    private func agentBubble(
+        _ words: String, isError: Bool, readPath: Color = ReadPathDiagnostic.recap
+    ) -> some View {
         HStack {
             Group {
                 if isError {
@@ -228,6 +239,7 @@ struct SessionDetailView: View {
                 .padding(.horizontal, 14)
                 .padding(.vertical, 9)
                 .background(Color.cardFill, in: RoundedRectangle(cornerRadius: 18))
+                .overlay(RoundedRectangle(cornerRadius: 18).strokeBorder(readPath, lineWidth: 1.5))
                 .contentShape(.contextMenuPreview, RoundedRectangle(cornerRadius: 18))
                 .contextMenu { copyAction(for: words) }
             Spacer(minLength: 48)
@@ -251,7 +263,7 @@ struct SessionDetailView: View {
     private func conversationBubble(_ message: ConversationMessage) -> some View {
         switch message.author {
         case .agent:
-            agentBubble(message.text, isError: false)
+            agentBubble(message.text, isError: false, readPath: ReadPathDiagnostic.transcript)
         case .user:
             HStack {
                 Spacer(minLength: 48)
@@ -261,6 +273,10 @@ struct SessionDetailView: View {
                     .padding(.horizontal, 14)
                     .padding(.vertical, 9)
                     .background(Color.accentColor, in: RoundedRectangle(cornerRadius: 18))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 18)
+                            .strokeBorder(ReadPathDiagnostic.transcript, lineWidth: 1.5)
+                    )
                     .contentShape(.contextMenuPreview, RoundedRectangle(cornerRadius: 18))
                     .contextMenu { copyAction(for: message.text) }
             }

--- a/apps/ios/Luke/SessionDetailView.swift
+++ b/apps/ios/Luke/SessionDetailView.swift
@@ -140,8 +140,14 @@ struct SessionDetailView: View {
             // The keyboard rising must not cover the newest bubble: focus
             // scrolls back to it once the inset settles, like Messages.
             .onChange(of: composing) {
-                guard composing, let last = thread.last else { return }
-                withAnimation { proxy.scrollTo(last.id, anchor: .bottom) }
+                guard composing else { return }
+                // The newest bubble may be a fetched one once every send has
+                // handed over, so the fallback mirrors the opening jump.
+                if let last = thread.last {
+                    withAnimation { proxy.scrollTo(last.id, anchor: .bottom) }
+                } else if let last = conversation.last {
+                    withAnimation { proxy.scrollTo(last.id, anchor: .bottom) }
+                }
             }
             .onAppear {
                 if let last = thread.last {

--- a/apps/ios/Luke/SessionDetailView.swift
+++ b/apps/ios/Luke/SessionDetailView.swift
@@ -263,18 +263,7 @@ struct SessionDetailView: View {
         .padding(.bottom, 4)
     }
 
-    /// A temporary field diagnostic, to be removed once the conversation
-    /// read is verified on a device: red rings the recap fallback and green
-    /// rings fetched transcript messages, so a screen says at a glance which
-    /// path drew its bubbles.
-    private enum ReadPathDiagnostic {
-        static let recap = Color.red
-        static let transcript = Color.green
-    }
-
-    private func agentBubble(
-        _ words: String, isError: Bool, readPath: Color = ReadPathDiagnostic.recap
-    ) -> some View {
+    private func agentBubble(_ words: String, isError: Bool) -> some View {
         HStack {
             Group {
                 if isError {
@@ -288,7 +277,6 @@ struct SessionDetailView: View {
                 .padding(.horizontal, 14)
                 .padding(.vertical, 9)
                 .background(Color.cardFill, in: RoundedRectangle(cornerRadius: 18))
-                .overlay(RoundedRectangle(cornerRadius: 18).strokeBorder(readPath, lineWidth: 1.5))
                 .contentShape(.contextMenuPreview, RoundedRectangle(cornerRadius: 18))
                 .contextMenu { copyAction(for: words) }
             Spacer(minLength: 48)
@@ -312,7 +300,7 @@ struct SessionDetailView: View {
     private func conversationBubble(_ message: ConversationMessage) -> some View {
         switch message.author {
         case .agent:
-            agentBubble(message.text, isError: false, readPath: ReadPathDiagnostic.transcript)
+            agentBubble(message.text, isError: false)
         case .user:
             HStack {
                 Spacer(minLength: 48)
@@ -322,10 +310,6 @@ struct SessionDetailView: View {
                     .padding(.horizontal, 14)
                     .padding(.vertical, 9)
                     .background(Color.accentColor, in: RoundedRectangle(cornerRadius: 18))
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 18)
-                            .strokeBorder(ReadPathDiagnostic.transcript, lineWidth: 1.5)
-                    )
                     .contentShape(.contextMenuPreview, RoundedRectangle(cornerRadius: 18))
                     .contextMenu { copyAction(for: message.text) }
             }

--- a/apps/ios/Luke/SessionDetailView.swift
+++ b/apps/ios/Luke/SessionDetailView.swift
@@ -15,22 +15,31 @@ struct OutgoingMessage: Identifiable, Equatable {
 
     let id = UUID()
     let text: String
+    /// When the developer pressed send, so a fetched copy of these words can
+    /// prove it is this send and not an identical, older message: a
+    /// conversation is allowed to repeat itself, and matching on the words
+    /// alone would hand this bubble to history.
+    let sentAt = Date()
     var delivery: Delivery
 }
 
-/// The session's own screen: the title at the top, the provider's word on
-/// where the turn stands as the agent's bubble, the developer's sends as
-/// their own bubbles, and a chat input at the bottom where — and only where —
-/// the latest observation advertised taking a message. The thread never
-/// pretends to be the transcript: a cloud session's conversation lives with
-/// its provider, so the agent's side is the bounded recap the roster already
-/// carries, and the sent bubbles live in memory for the app run alone. The
-/// recap and the sent bubbles draw their words as Markdown, since an agent's
-/// parting words and a developer's ask are both written in it; an error is a
+/// The session's own screen: the title at the top, the conversation as the
+/// bubbles a chat draws, and a chat input at the bottom where — and only
+/// where — the latest observation advertised taking a message. Where the
+/// roster advertised the provider's documented conversation read, opening
+/// this screen fetches the thread itself — the developer's sends and the
+/// agent's own words, read on demand and kept only while the screen shows
+/// them — and polls behind the cursor while the screen stays open. Where the
+/// read is not advertised, or a fetch cannot answer, the screen keeps
+/// exactly what it always drew: the provider's word on where the turn
+/// stands as the one agent bubble, and the sent bubbles in memory for the
+/// app run alone. Every bubble draws its words as Markdown, since an agent's
+/// words and a developer's ask are both written in it; an error is a
 /// provider's plain report and draws as the words it is.
 struct SessionDetailView: View {
     let session: RosterSession
     let actClient: ActClient
+    let conversationClient: ConversationClient
     @Binding var thread: [OutgoingMessage]
     /// Runs after a delivered send so the roster refreshes behind this screen.
     let onDelivered: () async -> Void
@@ -39,17 +48,80 @@ struct SessionDetailView: View {
     @Environment(ProductEventSender.self) private var events
     @State private var text = ""
     @FocusState private var composing: Bool
+    /// The fetched conversation, alive only while this screen is: state, not
+    /// storage, so closing the screen is what forgetting means here.
+    @State private var conversation: [ConversationMessage] = []
+    /// The poll's position: the newest provider message id a read consumed,
+    /// so each tick reads only what is newer. Nil until the opening read
+    /// lands, which is also what makes a failed opening retry on the tick.
+    @State private var forwardCursor: String?
+    /// The scroll's position: the stored offset the oldest fetched page began
+    /// at, and whether history stands before it.
+    @State private var oldestOffset: Int?
+    @State private var hasOlder = false
+    /// One older page at a time: the sentinel can reappear while a load runs.
+    @State private var loadingOlder = false
+    /// Where the screen should land once the bubbles a read just handed it
+    /// have been laid out. A `scrollTo` in the same turn as the state change
+    /// would name rows the reader has not built yet, so the intent is state
+    /// and the jump runs from its own `onChange`, after the update.
+    @State private var scrollIntent: ScrollIntent?
+    /// Set once the opening jump to the conversation's end has run, and the
+    /// one thing that lets the history sentinel exist: before it, the first
+    /// layout still sits at the top, where the sentinel would fire at once
+    /// and drag the opened screen into history.
+    @State private var openSettled = false
+
+    private enum ScrollIntent: Equatable {
+        /// The newest bubble, pending sends included: how a chat opens.
+        case end
+        /// The bubble that was topmost before older history was prepended.
+        case anchor(String)
+    }
+
+    /// How long the poll rests between asks while the screen stays open, and
+    /// how many pages one poll may chase while the server says newer messages
+    /// remain.
+    private static let pollSeconds: UInt64 = 10
+    private static let maximumPollReads = 5
 
     var body: some View {
-        // Top-anchored like a short Messages thread; a send scrolls to its
-        // own bubble instead of re-anchoring the whole thread, which would
-        // drop short content to the screen's bottom edge.
+        // Anchored like Messages: the screen opens at the conversation's end,
+        // and scrolling to the top reaches back into history one page at a
+        // time.
         ScrollViewReader { proxy in
             ScrollView {
-                VStack(spacing: 14) {
+                // Lazy so the top sentinel appears — and fetches — only when
+                // the scroll actually reaches it.
+                LazyVStack(spacing: 14) {
                     metaHeader
-                    if let words = session.error ?? session.recap {
-                        agentBubble(words, isError: session.error != nil)
+                    if hasOlder && openSettled {
+                        // The sentinel: reaching it is the ask for the page
+                        // before the one on screen. A failed page leaves it
+                        // standing, and scrolling away and back asks again.
+                        ProgressView()
+                            .frame(maxWidth: .infinity)
+                            .padding(.vertical, 8)
+                            .onAppear { loadOlder() }
+                    }
+                    if conversation.isEmpty {
+                        if let words = session.error ?? session.recap {
+                            agentBubble(words, isError: session.error != nil)
+                        }
+                    } else {
+                        // Masked from the recording the way the desktop
+                        // blocks its History subtree: a session's own words
+                        // do not leave the machine in a replay, where the
+                        // recap always traveled and still does.
+                        ForEach(conversation) { message in
+                            conversationBubble(message)
+                                .postHogMask()
+                        }
+                        // The provider's failure word outranks parting words
+                        // here exactly as it does on the row.
+                        if let error = session.error {
+                            agentBubble(error, isError: true)
+                        }
                     }
                     ForEach(thread) { message in
                         userBubble(message)
@@ -58,8 +130,11 @@ struct SessionDetailView: View {
                 .padding(.horizontal, 16)
                 .padding(.vertical, 12)
             }
-            .onChange(of: thread.count) {
-                guard let last = thread.last else { return }
+            .onChange(of: thread.count) { previousCount, count in
+                // Only growth is a send worth following: a handover shrinks
+                // this thread from a poll, and a reader up in history must
+                // not be dragged to the bottom by it.
+                guard count > previousCount, let last = thread.last else { return }
                 withAnimation { proxy.scrollTo(last.id, anchor: .bottom) }
             }
             // The keyboard rising must not cover the newest bubble: focus
@@ -71,6 +146,35 @@ struct SessionDetailView: View {
             .onAppear {
                 if let last = thread.last {
                     proxy.scrollTo(last.id, anchor: .bottom)
+                }
+            }
+            .onChange(of: scrollIntent) {
+                guard let intent = scrollIntent else { return }
+                scrollIntent = nil
+                switch intent {
+                case .end:
+                    // Pending sends draw below the fetched thread, so a chat
+                    // holding one opens on it rather than leaving it under
+                    // the fold.
+                    if let last = thread.last {
+                        proxy.scrollTo(last.id, anchor: .bottom)
+                    } else if let last = conversation.last {
+                        proxy.scrollTo(last.id, anchor: .bottom)
+                    }
+                    openSettled = true
+                case .anchor(let id):
+                    proxy.scrollTo(id, anchor: .top)
+                }
+            }
+            .task(id: session.id) {
+                guard session.canReadConversation else { return }
+                while !Task.isCancelled {
+                    if forwardCursor == nil {
+                        await openConversation()
+                    } else {
+                        await pollNewer()
+                    }
+                    try? await Task.sleep(nanoseconds: Self.pollSeconds * 1_000_000_000)
                 }
             }
         }
@@ -138,6 +242,156 @@ struct SessionDetailView: View {
             UIPasteboard.general.string = words
         } label: {
             Label("Copy", systemImage: "doc.on.doc")
+        }
+    }
+
+    /// A fetched message wears the anatomy the screen already draws: the
+    /// agent's words in the card bubble, the developer's in the accent one.
+    @ViewBuilder
+    private func conversationBubble(_ message: ConversationMessage) -> some View {
+        switch message.author {
+        case .agent:
+            agentBubble(message.text, isError: false)
+        case .user:
+            HStack {
+                Spacer(minLength: 48)
+                Text(message.text)
+                    .font(.system(size: 15))
+                    .foregroundStyle(.white)
+                    .padding(.horizontal, 14)
+                    .padding(.vertical, 9)
+                    .background(Color.accentColor, in: RoundedRectangle(cornerRadius: 18))
+                    .contentShape(.contextMenuPreview, RoundedRectangle(cornerRadius: 18))
+                    .contextMenu { copyAction(for: message.text) }
+            }
+        }
+    }
+
+    /// The opening read: the latest page of the conversation, drawn from its
+    /// end the way Messages opens a chat. Its answer seeds both positions —
+    /// the poll's forward cursor and the scroll's oldest offset. A failed
+    /// opening changes nothing: the recap fallback stands, and the next tick
+    /// tries again because the cursor is still unset.
+    private func openConversation() async {
+        do {
+            let answer = try await read(.latest)
+            conversation = answer.messages
+            forwardCursor = answer.lastMessageId
+            oldestOffset = answer.firstOffset
+            hasOlder = answer.hasOlder
+            handOverDeliveredSends()
+            scrollIntent = .end
+        } catch {}
+    }
+
+    /// The poll: everything newer than the cursor, chased while the server
+    /// says more remain, to a bounded number of pages. New bubbles append
+    /// without moving the scroll — a reader up in history stays where they
+    /// are, like Messages.
+    private func pollNewer() async {
+        for _ in 0 ..< Self.maximumPollReads {
+            guard !Task.isCancelled, let cursor = forwardCursor else { return }
+            do {
+                let answer = try await read(.after(cursor))
+                let known = Set(conversation.map(\.id))
+                conversation.append(contentsOf: answer.messages.filter { !known.contains($0.id) })
+                if let last = answer.lastMessageId {
+                    forwardCursor = last
+                }
+                handOverDeliveredSends()
+                guard answer.hasMore else { return }
+            } catch {
+                return
+            }
+        }
+    }
+
+    /// A scroll to the top: the page of history just before what the screen
+    /// holds, prepended with the viewport re-anchored to the bubble that was
+    /// topmost, so the reader stays on the words they were looking at.
+    private func loadOlder() {
+        guard !loadingOlder, hasOlder, let offset = oldestOffset, offset > 0 else { return }
+        loadingOlder = true
+        Task {
+            defer { loadingOlder = false }
+            do {
+                let answer = try await read(.before(offset))
+                let anchor = conversation.first?.id
+                let known = Set(conversation.map(\.id))
+                conversation.insert(
+                    contentsOf: answer.messages.filter { !known.contains($0.id) },
+                    at: 0
+                )
+                if let first = answer.firstOffset {
+                    oldestOffset = first
+                }
+                hasOlder = answer.hasOlder
+                if let anchor {
+                    scrollIntent = .anchor(anchor)
+                }
+            } catch {}
+        }
+    }
+
+    private func read(_ position: ConversationPosition) async throws -> ConversationAnswer {
+        try await account.authorized { token in
+            try await conversationClient.read(
+                accessToken: token,
+                providerId: session.providerId,
+                providerSessionId: session.sessionId,
+                position: position
+            )
+        }
+    }
+
+    /// A send whose words now stand in the fetched thread hands its bubble
+    /// over rather than standing beside it twice. The handover demands the
+    /// fetched copy be recorded around this send's own moment — behind a
+    /// tolerance for the two clocks involved — because the same words earlier
+    /// in the history are a different message, and a page carrying them must
+    /// not swallow the bubble of a send still in flight. A copy the provider
+    /// gave no timestamp proves nothing, so the bubble stands beside it
+    /// rather than vanishing on a guess.
+    private static let sendClockTolerance: TimeInterval = 120
+
+    /// A copy hands over one bubble and is spent: without the claim, a second
+    /// identical quick send would match the first send's copy — the sweep
+    /// runs on every poll — and both bubbles would vanish on one message.
+    /// Claims live as long as the screen's own fetched thread does.
+    @State private var claimedCopyIds: Set<String> = []
+
+    /// Claims the oldest unspent fetched copy of this send's words recorded
+    /// at or after its own moment, or answers that none stands yet.
+    private func claimFetchedCopy(for outgoing: OutgoingMessage) -> Bool {
+        let match = conversation.first { fetched in
+            fetched.author == .user
+                && !claimedCopyIds.contains(fetched.id)
+                && fetched.text == outgoing.text
+                && fetched.receivedAt.map {
+                    $0 >= outgoing.sentAt.addingTimeInterval(-Self.sendClockTolerance)
+                } == true
+        }
+        guard let match else { return false }
+        claimedCopyIds.insert(match.id)
+        return true
+    }
+
+    /// Runs against the whole fetched thread rather than one page, because a
+    /// copy can land in a poll while its send is still in flight: the sweep
+    /// here catches bubbles already delivered, and `send` checks once more at
+    /// the moment a bubble turns delivered, so neither order leaves the same
+    /// words standing twice. Oldest send first, so claims pair bubbles and
+    /// copies in arrival order.
+    private func handOverDeliveredSends() {
+        let delivered = thread
+            .filter { $0.delivery == .sent }
+            .sorted { $0.sentAt < $1.sentAt }
+        var handedOver: Set<UUID> = []
+        for bubble in delivered where claimFetchedCopy(for: bubble) {
+            handedOver.insert(bubble.id)
+        }
+        if !handedOver.isEmpty {
+            thread.removeAll { handedOver.contains($0.id) }
         }
     }
 
@@ -272,7 +526,15 @@ struct SessionDetailView: View {
                 delivery = .failed(reason: error.localizedDescription)
             }
             if let index = thread.firstIndex(where: { $0.id == message.id }) {
-                thread[index].delivery = delivery
+                // A poll can fetch the send's copy while the bubble is still
+                // in flight, and that page never comes again: the moment of
+                // delivery re-checks, so the bubble hands over instead of
+                // standing beside its own copy.
+                if delivery == .sent, claimFetchedCopy(for: thread[index]) {
+                    thread.remove(at: index)
+                } else {
+                    thread[index].delivery = delivery
+                }
             }
             if delivery == .sent { await onDelivered() }
         }

--- a/apps/ios/Luke/SessionDetailView.swift
+++ b/apps/ios/Luke/SessionDetailView.swift
@@ -61,6 +61,10 @@ struct SessionDetailView: View {
     @State private var hasOlder = false
     /// One older page at a time: the sentinel can reappear while a load runs.
     @State private var loadingOlder = false
+    /// Whether the opening read has answered at all — success or refusal —
+    /// which is what retires the skeleton: until then the screen holds the
+    /// thread's place, and after a refusal the recap stands as the fallback.
+    @State private var openAttempted = false
     /// Where the screen should land once the bubbles a read just handed it
     /// have been laid out. A `scrollTo` in the same turn as the state change
     /// would name rows the reader has not built yet, so the intent is state
@@ -105,7 +109,13 @@ struct SessionDetailView: View {
                             .onAppear { loadOlder() }
                     }
                     if conversation.isEmpty {
-                        if let words = session.error ?? session.recap {
+                        // While the opening read is in flight the screen says
+                        // "a thread is coming" rather than flashing the recap
+                        // it would only replace; the recap is the answer once
+                        // the read cannot give one, or was never advertised.
+                        if session.canReadConversation && !openAttempted {
+                            ConversationSkeleton()
+                        } else if let words = session.error ?? session.recap {
                             agentBubble(words, isError: session.error != nil)
                         }
                     } else {
@@ -295,6 +305,7 @@ struct SessionDetailView: View {
     /// opening changes nothing: the recap fallback stands, and the next tick
     /// tries again because the cursor is still unset.
     private func openConversation() async {
+        defer { openAttempted = true }
         do {
             let answer = try await read(.latest)
             conversation = answer.messages
@@ -559,6 +570,44 @@ struct SessionDetailView: View {
                 }
             }
             if delivery == .sent { await onDelivered() }
+        }
+    }
+}
+
+/// Pulsing placeholder bubbles while the opening read is in flight, shaped
+/// like the short exchange they stand for — the roster list's SkeletonRow at
+/// this screen's scale. Placeholder blocks carry no words, no copy menu, and
+/// no read-path ring: there is nothing to copy and no path has answered yet.
+private struct ConversationSkeleton: View {
+    @State private var opacity: Double = 0.55
+
+    var body: some View {
+        VStack(spacing: 14) {
+            skeletonBubble(agent: true, characters: 64)
+            skeletonBubble(agent: false, characters: 26)
+            skeletonBubble(agent: true, characters: 96)
+        }
+        .accessibilityHidden(true)
+        .opacity(opacity)
+        .onAppear {
+            withAnimation(.easeInOut(duration: 1.5).repeatForever(autoreverses: true)) {
+                opacity = 1.0
+            }
+        }
+    }
+
+    /// Neutral on both sides: an accent-filled placeholder would read as a
+    /// send nobody made, where a gray block only says a bubble belongs here.
+    private func skeletonBubble(agent: Bool, characters: Int) -> some View {
+        HStack {
+            if !agent { Spacer(minLength: 48) }
+            Text(String(repeating: "x", count: characters))
+                .font(.system(size: 15))
+                .redacted(reason: .placeholder)
+                .padding(.horizontal, 14)
+                .padding(.vertical, 9)
+                .background(Color.cardFill, in: RoundedRectangle(cornerRadius: 18))
+            if agent { Spacer(minLength: 48) }
         }
     }
 }

--- a/apps/ios/Luke/SessionDetailView.swift
+++ b/apps/ios/Luke/SessionDetailView.swift
@@ -89,6 +89,12 @@ struct SessionDetailView: View {
     private static let pollSeconds: UInt64 = 10
     private static let maximumPollReads = 5
     private static let conversationEndId = "conversation-end"
+    /// How long the opening layout gets to settle before the end is pinned a
+    /// second time, and how long the top sentinel must stay visible before
+    /// its ask counts — both measured against the churn of a tall thread
+    /// realizing its rows, which is over well inside half a second.
+    private static let layoutSettleNanoseconds: UInt64 = 300_000_000
+    private static let sentinelDwellNanoseconds: UInt64 = 450_000_000
 
     var body: some View {
         // Anchored like Messages: the screen opens at the conversation's end,
@@ -107,7 +113,18 @@ struct SessionDetailView: View {
                         ProgressView()
                             .frame(maxWidth: .infinity)
                             .padding(.vertical, 8)
-                            .onAppear { loadOlder() }
+                            // A dwell, not a glance: a lazy row can flash
+                            // realized while a tall thread's layout churns,
+                            // and a page loaded off that flash re-anchors the
+                            // opened screen into history. Scrolling away
+                            // cancels the wait, so only a reader actually
+                            // holding the top asks for more.
+                            .task {
+                                try? await Task.sleep(
+                                    nanoseconds: Self.sentinelDwellNanoseconds)
+                                guard !Task.isCancelled else { return }
+                                loadOlder()
+                            }
                     }
                     if conversation.isEmpty {
                         // While the opening read is in flight the screen says
@@ -183,9 +200,17 @@ struct SessionDetailView: View {
                 switch intent {
                 case .end:
                     // The marker sits below pending sends and fetched thread
-                    // alike, so the open lands on whichever is newest.
+                    // alike, so the open lands on whichever is newest. A very
+                    // long newest message can finish sizing after this jump,
+                    // growing the content below the landed offset, so one
+                    // late second jump pins the end once layout has settled —
+                    // and only then may the history sentinel exist.
                     proxy.scrollTo(Self.conversationEndId, anchor: .bottom)
-                    openSettled = true
+                    Task {
+                        try? await Task.sleep(nanoseconds: Self.layoutSettleNanoseconds)
+                        proxy.scrollTo(Self.conversationEndId, anchor: .bottom)
+                        openSettled = true
+                    }
                 case .anchor(let id):
                     proxy.scrollTo(id, anchor: .top)
                 }

--- a/apps/ios/Luke/SessionsView.swift
+++ b/apps/ios/Luke/SessionsView.swift
@@ -47,6 +47,7 @@ struct SessionsView: View {
     private let rosterClient = RosterClient(serviceURL: AccountConstants.serviceURL)
     private let actClient = ActClient(baseURL: AccountConstants.serviceURL)
     private let projectsClient = ProjectsClient(serviceURL: AccountConstants.serviceURL)
+    private let conversationClient = ConversationClient(serviceURL: AccountConstants.serviceURL)
 
     var body: some View {
         Group {
@@ -66,6 +67,7 @@ struct SessionsView: View {
             SessionDetailView(
                 session: sessions.first { $0.id == opened.id } ?? opened,
                 actClient: actClient,
+                conversationClient: conversationClient,
                 thread: Binding(
                     get: { threads[opened.id] ?? [] },
                     set: { threads[opened.id] = $0 }

--- a/apps/ios/LukeKit/Sources/LukeKit/ConversationClient.swift
+++ b/apps/ios/LukeKit/Sources/LukeKit/ConversationClient.swift
@@ -1,0 +1,161 @@
+import Foundation
+
+/// Who wrote one message of a conversation reading. Mirrors
+/// `CONVERSATION_MESSAGE_AUTHOR` in `@sidecar/session`, the same set the
+/// hosted wire types with: only the two voices a chat screen draws exist on
+/// the wire, because a message the provider's store did not attribute never
+/// left the server's adapter at all.
+public enum ConversationAuthor: String, Sendable {
+    case user
+    case agent
+}
+
+/// One attributed message of a session's conversation, as the messages
+/// endpoint relays it. Mirrors the `HostedConversationMessage` wire shape
+/// from `@sidecar/hosted`: the provider's own id, who wrote it, and the
+/// words whole — the read's bounds live on the page, never on the message.
+public struct ConversationMessage: Identifiable, Equatable, Sendable {
+    public let id: String
+    public let author: ConversationAuthor
+    public let text: String
+    /// When the provider recorded the message, when it reported one.
+    public let receivedAt: Date?
+
+    public init(id: String, author: ConversationAuthor, text: String, receivedAt: Date? = nil) {
+        self.id = id
+        self.author = author
+        self.text = text
+        self.receivedAt = receivedAt
+    }
+
+    init?(json: [String: Any]) {
+        guard
+            let id = json["id"] as? String, !id.isEmpty,
+            let rawAuthor = json["author"] as? String,
+            let author = ConversationAuthor(rawValue: rawAuthor),
+            let text = json["text"] as? String, !text.isEmpty
+        else { return nil }
+        self.id = id
+        self.author = author
+        self.text = text
+        if let ms = json["receivedAt"] as? Double {
+            self.receivedAt = Date(timeIntervalSince1970: ms / 1000)
+        } else {
+            self.receivedAt = nil
+        }
+    }
+}
+
+/// Where one conversation read stands, the way a chat screen reads: the
+/// latest page when the screen opens, only what is newer when it polls, and
+/// the history just before what it holds when a scroll reaches the top. One
+/// read names one position, so the two cursors cannot combine.
+public enum ConversationPosition: Equatable, Sendable {
+    case latest
+    case after(String)
+    case before(Int)
+}
+
+/// The messages endpoint answer: one bounded page of attributed messages and
+/// the positions to continue from. `lastMessageId` is where a poll resumes —
+/// absent on an older-history page, which must never move a poll backward —
+/// and `firstOffset`/`hasOlder` are where a scroll to the top continues,
+/// absent on a poll, which never looks backward.
+/// Mirrors the `HostedConversationAnswer` wire shape from `@sidecar/hosted`.
+public struct ConversationAnswer: Equatable, Sendable {
+    public let messages: [ConversationMessage]
+    public let lastMessageId: String?
+    public let hasMore: Bool
+    public let firstOffset: Int?
+    public let hasOlder: Bool
+
+    public init(
+        messages: [ConversationMessage],
+        lastMessageId: String?,
+        hasMore: Bool,
+        firstOffset: Int? = nil,
+        hasOlder: Bool = false
+    ) {
+        self.messages = messages
+        self.lastMessageId = lastMessageId
+        self.hasMore = hasMore
+        self.firstOffset = firstOffset
+        self.hasOlder = hasOlder
+    }
+}
+
+public enum ConversationClientError: Error, Equatable {
+    case invalidResponse
+    case unauthorized
+    case serverError(status: Int)
+}
+
+extension ConversationClientError: HostedUnauthorizedSignaling {
+    public var isUnauthorized: Bool { self == .unauthorized }
+}
+
+/// Reads one session's conversation from the hosted messages endpoint.
+///
+/// The read is on-demand and read-only: the server runs a fresh observation
+/// pass, reads the provider's own documented transcript endpoint under the
+/// caller's synced key, and stores nothing. The screen asks when it opens
+/// and polls with the returned cursor while it stays open; a session whose
+/// roster row did not advertise `canReadConversation` is never asked for.
+public final class ConversationClient: Sendable {
+    private let serviceURL: URL
+    private let http: HTTPClient
+
+    public init(serviceURL: URL, http: HTTPClient = URLSession.shared) {
+        self.serviceURL = serviceURL
+        self.http = http
+    }
+
+    /// Returns one bounded page of the session's conversation at the named
+    /// position: the latest page, only what is newer than a message, or the
+    /// history ending at a stored offset an earlier answer reported.
+    public func read(
+        accessToken: String,
+        providerId: String,
+        providerSessionId: String,
+        position: ConversationPosition = .latest
+    ) async throws -> ConversationAnswer {
+        var components = URLComponents(
+            url: serviceURL.appendingPathComponent("api/sessions/messages"),
+            resolvingAgainstBaseURL: false
+        )
+        var query = [
+            URLQueryItem(name: "providerId", value: providerId),
+            URLQueryItem(name: "providerSessionId", value: providerSessionId),
+        ]
+        switch position {
+        case .latest:
+            break
+        case .after(let messageId):
+            query.append(URLQueryItem(name: "after", value: messageId))
+        case .before(let offset):
+            query.append(URLQueryItem(name: "beforeOffset", value: String(offset)))
+        }
+        components?.queryItems = query
+        guard let url = components?.url else { throw ConversationClientError.invalidResponse }
+        var request = URLRequest(url: url)
+        request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+        let (data, response) = try await http.data(for: request)
+        let status = (response as? HTTPURLResponse)?.statusCode ?? 0
+        if status == 401 { throw ConversationClientError.unauthorized }
+        guard (200 ..< 300).contains(status) else {
+            throw ConversationClientError.serverError(status: status)
+        }
+        guard
+            let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+            let messagesJSON = json["messages"] as? [[String: Any]],
+            let hasMore = json["hasMore"] as? Bool
+        else { throw ConversationClientError.invalidResponse }
+        return ConversationAnswer(
+            messages: messagesJSON.compactMap { ConversationMessage(json: $0) },
+            lastMessageId: json["lastMessageId"] as? String,
+            hasMore: hasMore,
+            firstOffset: json["firstOffset"] as? Int,
+            hasOlder: json["hasOlder"] as? Bool ?? false
+        )
+    }
+}

--- a/apps/ios/LukeKit/Sources/LukeKit/RosterSession.swift
+++ b/apps/ios/LukeKit/Sources/LukeKit/RosterSession.swift
@@ -63,6 +63,10 @@ public struct RosterSession: Identifiable, Hashable, Sendable {
     public let canRename: Bool
     /// Whether the latest observation advertised renaming the session's workspace.
     public let canRenameWorkspace: Bool
+    /// Whether the hosted messages endpoint can read this session's
+    /// conversation — a capability of the provider's documented transcript
+    /// read, so a screen that sees it absent falls back to the recap alone.
+    public let canReadConversation: Bool
 
     public var id: String { "\(providerId):\(sessionId)" }
 
@@ -87,7 +91,8 @@ public struct RosterSession: Identifiable, Hashable, Sendable {
         controls: [RosterSessionControl] = [],
         spawnableAgents: [String] = [],
         canRename: Bool = false,
-        canRenameWorkspace: Bool = false
+        canRenameWorkspace: Bool = false,
+        canReadConversation: Bool = false
     ) {
         self.providerId = providerId
         self.sessionId = sessionId
@@ -103,6 +108,7 @@ public struct RosterSession: Identifiable, Hashable, Sendable {
         self.spawnableAgents = spawnableAgents
         self.canRename = canRename
         self.canRenameWorkspace = canRenameWorkspace
+        self.canReadConversation = canReadConversation
     }
 
     init?(json: [String: Any]) {
@@ -132,5 +138,6 @@ public struct RosterSession: Identifiable, Hashable, Sendable {
         self.spawnableAgents = agents.filter { !$0.isEmpty }
         self.canRename = json["canRename"] as? Bool ?? false
         self.canRenameWorkspace = json["canRenameWorkspace"] as? Bool ?? false
+        self.canReadConversation = json["canReadConversation"] as? Bool ?? false
     }
 }

--- a/apps/ios/LukeKit/Tests/LukeKitTests/ConversationClientTests.swift
+++ b/apps/ios/LukeKit/Tests/LukeKitTests/ConversationClientTests.swift
@@ -1,0 +1,234 @@
+import Foundation
+import XCTest
+
+@testable import LukeKit
+
+private let serviceURL = URL(string: "https://tryluke.dev")!
+
+private func makeConversationResponse(
+    body: [String: Any],
+    status: Int = 200
+) -> (Data, URLResponse) {
+    let data = try! JSONSerialization.data(withJSONObject: body)
+    let response = HTTPURLResponse(
+        url: serviceURL.appendingPathComponent("api/sessions/messages"),
+        statusCode: status,
+        httpVersion: nil,
+        headerFields: nil
+    )!
+    return (data, response)
+}
+
+// MARK: - ConversationMessage parsing
+
+final class ConversationMessageTests: XCTestCase {
+    func testRequiredFieldsMissing() {
+        XCTAssertNil(ConversationMessage(json: [:]))
+        XCTAssertNil(ConversationMessage(json: ["id": "m1", "author": "agent"]))
+        XCTAssertNil(ConversationMessage(json: ["id": "m1", "text": "words"]))
+        XCTAssertNil(ConversationMessage(json: ["id": "", "author": "agent", "text": "words"]))
+        XCTAssertNil(ConversationMessage(json: ["id": "m1", "author": "agent", "text": ""]))
+    }
+
+    func testUnknownAuthorIsDroppedRatherThanGuessed() {
+        XCTAssertNil(ConversationMessage(json: ["id": "m1", "author": "tool", "text": "output"]))
+    }
+
+    func testAttributedMessageParsesWhole() {
+        let message = ConversationMessage(json: [
+            "id": "m1",
+            "author": "user",
+            "text": "  words keep their own shape  ",
+            "receivedAt": 1_756_700_000_000.0,
+        ])
+        XCTAssertNotNil(message)
+        XCTAssertEqual(message?.author, .user)
+        // The words travel exactly as written: rendering never trims them.
+        XCTAssertEqual(message?.text, "  words keep their own shape  ")
+        XCTAssertEqual(message?.receivedAt, Date(timeIntervalSince1970: 1_756_700_000))
+    }
+}
+
+// MARK: - RosterSession advertisement
+
+final class RosterSessionConversationTests: XCTestCase {
+    func testCanReadConversationDefaultsFalse() {
+        let session = RosterSession(json: [
+            "providerId": "devin",
+            "sessionId": "sess-1",
+            "title": "Task",
+            "status": "waiting",
+        ])
+        XCTAssertEqual(session?.canReadConversation, false)
+    }
+
+    func testCanReadConversationParses() {
+        let session = RosterSession(json: [
+            "providerId": "conductor",
+            "sessionId": "sess-1",
+            "title": "Task",
+            "status": "waiting",
+            "canReadConversation": true,
+        ])
+        XCTAssertEqual(session?.canReadConversation, true)
+    }
+}
+
+// MARK: - ConversationClient
+
+final class ConversationClientTests: XCTestCase {
+    func testReadBuildsTheDocumentedQuery() async throws {
+        let stub = StubHTTPClient { request in
+            let components = URLComponents(
+                url: request.url!, resolvingAgainstBaseURL: false
+            )!
+            XCTAssertTrue(components.path.hasSuffix("api/sessions/messages"))
+            XCTAssertEqual(
+                request.value(forHTTPHeaderField: "Authorization"), "Bearer token-1"
+            )
+            let query = Dictionary(
+                uniqueKeysWithValues: (components.queryItems ?? []).map { ($0.name, $0.value) }
+            )
+            XCTAssertEqual(query["providerId"], "conductor")
+            XCTAssertEqual(query["providerSessionId"], "sess-1")
+            XCTAssertEqual(query["after"], "m-cursor")
+            return makeConversationResponse(body: ["messages": [], "hasMore": false])
+        }
+        let client = ConversationClient(serviceURL: serviceURL, http: stub)
+        let answer = try await client.read(
+            accessToken: "token-1",
+            providerId: "conductor",
+            providerSessionId: "sess-1",
+            position: .after("m-cursor")
+        )
+        XCTAssertEqual(answer.messages, [])
+        XCTAssertNil(answer.lastMessageId)
+        XCTAssertFalse(answer.hasMore)
+        XCTAssertNil(answer.firstOffset)
+        XCTAssertFalse(answer.hasOlder)
+    }
+
+    func testTheLatestPositionSendsNoCursorAtAll() async throws {
+        let stub = StubHTTPClient { request in
+            let components = URLComponents(
+                url: request.url!, resolvingAgainstBaseURL: false
+            )!
+            let names = (components.queryItems ?? []).map(\.name)
+            XCTAssertFalse(names.contains("after"))
+            XCTAssertFalse(names.contains("beforeOffset"))
+            return makeConversationResponse(body: ["messages": [], "hasMore": false])
+        }
+        let client = ConversationClient(serviceURL: serviceURL, http: stub)
+        _ = try await client.read(
+            accessToken: "token-1",
+            providerId: "conductor",
+            providerSessionId: "sess-1"
+        )
+    }
+
+    func testAHistoryPositionRidesAsAnOffsetAlone() async throws {
+        let stub = StubHTTPClient { request in
+            let components = URLComponents(
+                url: request.url!, resolvingAgainstBaseURL: false
+            )!
+            let query = Dictionary(
+                uniqueKeysWithValues: (components.queryItems ?? []).map { ($0.name, $0.value) }
+            )
+            XCTAssertEqual(query["beforeOffset"], "240")
+            XCTAssertNil(query["after"])
+            return makeConversationResponse(body: [
+                "messages": [],
+                "hasMore": false,
+                "firstOffset": 140,
+                "hasOlder": true,
+            ])
+        }
+        let client = ConversationClient(serviceURL: serviceURL, http: stub)
+        let answer = try await client.read(
+            accessToken: "token-1",
+            providerId: "conductor",
+            providerSessionId: "sess-1",
+            position: .before(240)
+        )
+        XCTAssertEqual(answer.firstOffset, 140)
+        XCTAssertTrue(answer.hasOlder)
+        XCTAssertNil(answer.lastMessageId)
+    }
+
+    func testReadParsesThePageAndSkipsMalformedEntries() async throws {
+        let stub = StubHTTPClient { _ in
+            makeConversationResponse(body: [
+                "messages": [
+                    ["id": "m1", "author": "user", "text": "Fix the test"],
+                    ["id": "m2", "author": "agent", "text": "Done.", "receivedAt": 1_000.0],
+                    ["id": "m3", "author": "tool", "text": "dropped"],
+                    ["id": "m4"],
+                ],
+                "lastMessageId": "m9",
+                "hasMore": true,
+            ])
+        }
+        let client = ConversationClient(serviceURL: serviceURL, http: stub)
+        let answer = try await client.read(
+            accessToken: "token-1",
+            providerId: "conductor",
+            providerSessionId: "sess-1"
+        )
+        XCTAssertEqual(answer.messages.map(\.id), ["m1", "m2"])
+        XCTAssertEqual(answer.messages.first?.author, .user)
+        XCTAssertEqual(answer.messages.last?.text, "Done.")
+        XCTAssertEqual(answer.lastMessageId, "m9")
+        XCTAssertTrue(answer.hasMore)
+    }
+
+    func testUnauthorizedThrowsItsOwnSignal() async {
+        let stub = StubHTTPClient { _ in
+            makeConversationResponse(body: [:], status: 401)
+        }
+        let client = ConversationClient(serviceURL: serviceURL, http: stub)
+        do {
+            _ = try await client.read(
+                accessToken: "expired",
+                providerId: "conductor",
+                providerSessionId: "sess-1"
+            )
+            XCTFail("expected unauthorized")
+        } catch {
+            XCTAssertEqual(error as? ConversationClientError, .unauthorized)
+        }
+    }
+
+    func testServerErrorCarriesTheStatus() async {
+        let stub = StubHTTPClient { _ in
+            makeConversationResponse(body: [:], status: 502)
+        }
+        let client = ConversationClient(serviceURL: serviceURL, http: stub)
+        do {
+            _ = try await client.read(
+                accessToken: "token-1",
+                providerId: "conductor",
+                providerSessionId: "sess-1"
+            )
+            XCTFail("expected serverError")
+        } catch {
+            XCTAssertEqual(error as? ConversationClientError, .serverError(status: 502))
+        }
+    }
+
+    func testAnAnswerWithoutItsEnvelopeIsInvalid() async {
+        let stub = StubHTTPClient { _ in
+            makeConversationResponse(body: ["messages": []])
+        }
+        let client = ConversationClient(serviceURL: serviceURL, http: stub)
+        do {
+            _ = try await client.read(
+                accessToken: "token-1",
+                providerId: "conductor",
+                providerSessionId: "sess-1"
+            )
+            XCTFail("expected invalidResponse")
+        } catch {
+            XCTAssertEqual(error as? ConversationClientError, .invalidResponse)
+        }
+    }
+}


### PR DESCRIPTION
## What this does

The screen half of Conductor conversation reading, on the endpoint #647 shipped (the endpoints-first split, the shape #616 set for mobile voice). Opening a Conductor session's screen fetches the conversation itself — the developer's sends and the agent's own words — and reads it the way Messages does:

- **Open** → skeleton bubbles hold the thread's place, then the latest page lands pinned to its end (`defaultScrollAnchor(.bottom)` plus an end-marker jump repeated once after a tall thread's Markdown settles).
- **Scroll to top** → older history pages in behind the `firstOffset` the last answer reported, the viewport re-anchored to the bubble that was topmost; the sentinel's ask requires a dwell, so layout churn can't trigger it.
- **Poll** → every 10s while the screen stays open, behind the endpoint's `after` cursor; new bubbles append and the screen follows only while the reader is already at the bottom.
- **Fallback** → where the roster never advertised `canReadConversation`, or a read has refused, the screen keeps exactly what it always drew: the recap bubble and the in-memory sent bubbles.

Fetched words render as Markdown like every other bubble, are masked out of iOS session recordings (`postHogMask()`, the desktop's blocked-History posture), and a delivered send's bubble hands over to its own fetched copy — claimed one-to-one at or after the send's own moment — never to identical words in history.

## Verification

- **Field-verified on a device against the production endpoint**: the read-path diagnostic rings (added for the verification, retired in the final commit) confirmed the fallback and the fetched thread apart; the long-thread opening, skeleton, and bottom anchoring were exercised on real sessions.
- `./scripts/check.sh` passing; `ConversationClientTests` cover the client's three positions and defensive parsing.
- Cursor Bugbot reviewed across eight findings, all fixed: handover matching history, same-turn `scrollTo` no-ops, hidden pending sends, the sentinel firing on open, in-flight send duplicates, one copy swallowing repeated sends, handover dragging readers out of history, and the keyboard covering fetched bubbles.
- **iOS builds/tests are not in CI** (Linux pipeline, no iOS job): a Linux Swift 6.3.3 toolchain typechecks the LukeKit client subset and parses every changed file; the device verification above is the hands-on check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/33700333761/artifacts/9873353428) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/33700333761)

- Commit: `160252b7c38b3668404240ea84b86c34f0c8f7d8`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
