### PR TITLE
feat(ios): long-press a chat bubble to copy its words

### DIFF
--- a/apps/ios/Luke/SessionDetailView.swift
+++ b/apps/ios/Luke/SessionDetailView.swift
@@ -1,6 +1,7 @@
 import LukeKit
 import PostHog
 import SwiftUI
+import UIKit
 
 /// One message the developer sent from this screen, held in memory alone for
 /// the app run — the user's own words, never written to disk, drawn as the
@@ -114,7 +115,20 @@ struct SessionDetailView: View {
                 .padding(.horizontal, 14)
                 .padding(.vertical, 9)
                 .background(Color.cardFill, in: RoundedRectangle(cornerRadius: 18))
+                .contentShape(.contextMenuPreview, RoundedRectangle(cornerRadius: 18))
+                .contextMenu { copyAction(for: words) }
             Spacer(minLength: 48)
+        }
+    }
+
+    /// A held bubble answers with the system context menu, the way Messages
+    /// does; its one action today puts the bubble's own words on the
+    /// pasteboard, and the lifted preview keeps the bubble's shape.
+    private func copyAction(for words: String) -> some View {
+        Button {
+            UIPasteboard.general.string = words
+        } label: {
+            Label("Copy", systemImage: "doc.on.doc")
         }
     }
 
@@ -135,6 +149,8 @@ struct SessionDetailView: View {
                     .padding(.vertical, 9)
                     .background(Color.accentColor, in: RoundedRectangle(cornerRadius: 18))
                     .opacity(message.delivery == .sending ? 0.55 : 1)
+                    .contentShape(.contextMenuPreview, RoundedRectangle(cornerRadius: 18))
+                    .contextMenu { copyAction(for: message.text) }
                 if case .failed(let reason) = message.delivery {
                     Text("Not Delivered — \(reason)")
                         .font(.caption2)


### PR DESCRIPTION
## Summary
- Long-pressing a bubble on the session chat screen — the agent's recap/error bubble or a sent bubble — opens the system context menu with one action, **Copy**, which puts that bubble's words on the pasteboard.
- Uses built-in SwiftUI `.contextMenu`, so the interaction is the native one: system haptic, background blur, and the bubble lifting into a preview. `.contentShape(.contextMenuPreview, …)` keeps the lifted preview in the bubble's rounded shape.
- Copying is purely local (`UIPasteboard`); nothing reaches a provider.

## Testing
- `./scripts/check.sh` passes. Built in a Linux cloud workspace, so no Xcode compile or device check was run here; the change uses only standard SwiftUI/UIKit APIs available since iOS 15.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/ea93bb13-6843-4859-9117-123dfda2683b)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/33594064023/artifacts/9832843005) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/33594064023)

- Commit: `18a07a3251f97aaa964acd433cd3b44b36cd7bb6`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
