### PR TITLE
feat(desktop): put the Ask Luke composer at the foot of the History tab

### DIFF
--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -1672,9 +1672,12 @@ export function App(): React.JSX.Element {
       void changeMode(false);
       return;
     }
-    changeTab(PANEL_TAB.SESSIONS);
+    // Sessions and History each hold the composer, so a summons over either
+    // lands in the field already showing; only Settings, which has none,
+    // gives way to the sessions list.
+    if (tabNow() === PANEL_TAB.SETTINGS) changeTab(PANEL_TAB.SESSIONS);
     focusAskField();
-  }, [cancelHover, changeMode, changeTab, presentationOf]);
+  }, [cancelHover, changeMode, changeTab, presentationOf, tabNow]);
 
   /**
    * The session search summons, from its magnifier or Command-F over the

--- a/apps/desktop/src/renderer/ask-luke.tsx
+++ b/apps/desktop/src/renderer/ask-luke.tsx
@@ -86,11 +86,12 @@ export function askRefusal(status: RealtimeStatus, unavailableNote?: string): st
 }
 
 /**
- * The panel's own composer: one pill under the session list, addressed to Luke
- * rather than to any session. Typing is the developer's half of the
- * conversation, so the pill answers in their green — the colour the meter
- * gives their voice — and the reply lands as Luke's spoken words, captioned at
- * the panel's foot directly below the field that asked.
+ * The panel's own composer: one pill at the foot of the sessions list and of
+ * the History thread alike, addressed to Luke rather than to any session.
+ * Typing is the developer's half of the conversation, so the pill answers in
+ * their green — the colour the meter gives their voice — and the reply lands
+ * as Luke's spoken words, captioned at the panel's foot directly below the
+ * field that asked, and as a bubble in the thread the History tab draws.
  *
  * Sending is deliberately quiet. A sent ask clears the field and nothing else:
  * the reply beginning is the confirmation, and a line saying "sent" would sit

--- a/apps/desktop/src/renderer/conversation-history-panel.test.ts
+++ b/apps/desktop/src/renderer/conversation-history-panel.test.ts
@@ -48,6 +48,8 @@ test("an announcement shows its spoken transcript", () => {
         },
       ],
       onClear: () => undefined,
+      ask: async () => undefined,
+      onAskEngaged: () => undefined,
       openable: () => false,
       onOpenSession: () => undefined,
     }),
@@ -69,6 +71,8 @@ test("a recorded entry shows its local time", () => {
         },
       ],
       onClear: () => undefined,
+      ask: async () => undefined,
+      onAskEngaged: () => undefined,
       openable: () => false,
       onOpenSession: () => undefined,
     }),
@@ -85,6 +89,8 @@ test("conversation history is blocked from optional panel recordings", () => {
     createElement(ConversationHistoryPanel, {
       entries: [{ kind: CONVERSATION_ENTRY_KIND.TYPED_ASK, words: "private words" }],
       onClear: () => undefined,
+      ask: async () => undefined,
+      onAskEngaged: () => undefined,
       openable: () => false,
       onOpenSession: () => undefined,
     }),
@@ -104,6 +110,8 @@ test("messages offer a copy control while quiet events offer none", () => {
         { kind: CONVERSATION_ENTRY_KIND.ACT, words: "Sent to Codex." },
       ],
       onClear: () => undefined,
+      ask: async () => undefined,
+      onAskEngaged: () => undefined,
       openable: () => false,
       onOpenSession: () => undefined,
     }),
@@ -126,6 +134,8 @@ test("a line still being said draws as the bubble it will settle into", () => {
       ],
       live: [{ kind: CONVERSATION_ENTRY_KIND.ANNOUNCEMENT, words: "Checkout is" }],
       onClear: () => undefined,
+      ask: async () => undefined,
+      onAskEngaged: () => undefined,
       openable: () => false,
       onOpenSession: () => undefined,
     }),
@@ -145,6 +155,8 @@ test("words still arriving stand the thread up without a settled line", () => {
       entries: [],
       live: [{ kind: CONVERSATION_ENTRY_KIND.REPLY, words: "Looking now." }],
       onClear: () => undefined,
+      ask: async () => undefined,
+      onAskEngaged: () => undefined,
       openable: () => false,
       onOpenSession: () => undefined,
     }),
@@ -161,6 +173,8 @@ test("the empty history reports only its state", () => {
     createElement(ConversationHistoryPanel, {
       entries: [],
       onClear: () => undefined,
+      ask: async () => undefined,
+      onAskEngaged: () => undefined,
       openable: () => false,
       onOpenSession: () => undefined,
     }),
@@ -198,6 +212,8 @@ test("a line's named chats draw pressable chips, worded as recorded", () => {
         { kind: CONVERSATION_ENTRY_KIND.REPLY, words: "No session here." },
       ],
       onClear: () => undefined,
+      ask: async () => undefined,
+      onAskEngaged: () => undefined,
       openable: (identity) => {
         asked.push(identity.providerSessionId);
         return true;
@@ -239,6 +255,8 @@ test("a chat with nowhere to go draws no chip", () => {
         },
       ],
       onClear: () => undefined,
+      ask: async () => undefined,
+      onAskEngaged: () => undefined,
       openable: () => false,
       onOpenSession: () => undefined,
     }),
@@ -267,6 +285,8 @@ test("a quiet act line draws its chat's chip without a copy control", () => {
         },
       ],
       onClear: () => undefined,
+      ask: async () => undefined,
+      onAskEngaged: () => undefined,
       openable: () => true,
       onOpenSession: () => undefined,
     }),
@@ -274,4 +294,36 @@ test("a quiet act line draws its chat's chip without a copy control", () => {
 
   assert.match(markup, /class="history-chip"/);
   assert.doesNotMatch(markup, /history-copy/);
+});
+
+test("the composer stands at the foot of the thread, empty or not", () => {
+  const empty = renderToStaticMarkup(
+    createElement(ConversationHistoryPanel, {
+      entries: [],
+      onClear: () => undefined,
+      openable: () => false,
+      onOpenSession: () => undefined,
+      ask: async () => undefined,
+      onAskEngaged: () => undefined,
+    }),
+  );
+  // "What needs me?" is worth typing before any line has been recorded.
+  assert.match(empty, />No messages yet</);
+  assert.match(empty, /id="ask-luke-input"/);
+
+  const threaded = renderToStaticMarkup(
+    createElement(ConversationHistoryPanel, {
+      entries: [{ kind: CONVERSATION_ENTRY_KIND.TYPED_ASK, words: "ship it" }],
+      onClear: () => undefined,
+      openable: () => false,
+      onOpenSession: () => undefined,
+      ask: async () => undefined,
+      onAskEngaged: () => undefined,
+      askShortcut: "Alt+Space",
+    }),
+  );
+  // One composer, after the list, inside the subtree recordings never see.
+  assert.equal(threaded.match(/id="ask-luke-input"/g)?.length, 1);
+  assert.ok(threaded.indexOf("</ol>") < threaded.indexOf('id="ask-luke-input"'));
+  assert.match(threaded, /aria-keyshortcuts="Alt\+Space"/);
 });

--- a/apps/desktop/src/renderer/conversation-history-panel.tsx
+++ b/apps/desktop/src/renderer/conversation-history-panel.tsx
@@ -7,6 +7,7 @@ import {
 } from "@sidecar/realtime";
 import type { SessionIdentity } from "@sidecar/session";
 import { useEffect, useRef, useState } from "react";
+import { type AskHandler, AskLuke } from "./ask-luke";
 import { PANEL_TAB, panelPanelId, panelTabId } from "./panel-tabs";
 import { CheckIcon, CopyIcon } from "./settings-icons";
 
@@ -169,12 +170,22 @@ function keyedHistoryEntries(entries: readonly ConversationEntry[]) {
  */
 const STREAM_FOLLOW_SLACK_PX = 48;
 
+/**
+ * Where the composer stands in the panel's arrival stack: the tab bar is index
+ * 0, and the thread above it is not a member of the stack, so the pill is the
+ * first thing to fan in under the bar.
+ */
+const HISTORY_COMPOSER_ROW_INDEX = 1;
+
 export function ConversationHistoryPanel({
   entries,
   live = [],
   onClear,
   openable,
   onOpenSession,
+  ask,
+  onAskEngaged,
+  askShortcut,
 }: {
   entries: readonly ConversationEntry[];
   /**
@@ -187,6 +198,10 @@ export function ConversationHistoryPanel({
   openable: (identity: SessionIdentity) => boolean;
   /** Hands a chip's roster-validated identity to the same open a row press takes. */
   onOpenSession: (identity: SessionIdentity) => void;
+  /** The same ask the sessions tab's composer carries: one conversation, reached from either tab. */
+  ask: AskHandler;
+  onAskEngaged: (engaged: boolean) => void;
+  askShortcut?: string;
 }): React.JSX.Element {
   const [confirmingClear, setConfirmingClear] = useState(false);
   const list = useRef<HTMLOListElement | null>(null);
@@ -278,6 +293,17 @@ export function ConversationHistoryPanel({
           ))}
         </ol>
       )}
+      {/* The thread is where a typed ask's reply lands as a bubble, so the field
+          that asks stands at its foot — the same composer the sessions tab
+          holds, addressed to the same conversation. It rides inside the
+          blocked subtree: a draft here is worded beside the words it will
+          join, and a recording sees neither. */}
+      <AskLuke
+        ask={ask}
+        onEngagedChange={onAskEngaged}
+        rowIndex={HISTORY_COMPOSER_ROW_INDEX}
+        {...(askShortcut ? { shortcut: askShortcut } : undefined)}
+      />
     </section>
   );
 }

--- a/apps/desktop/src/renderer/luke-guide.ts
+++ b/apps/desktop/src/renderer/luke-guide.ts
@@ -414,7 +414,9 @@ export function buildLukeGuide(input: LukeGuideInput): AppGuideSnapshot {
         "announcement, and session act, kept across launches in Luke's own file on this Mac — " +
         "up to 200 lines and 14 days, whichever cuts first. Luke carries only the 20 most " +
         "recent entries into a call. The view is blocked from panel recordings, is not " +
-        "exportable, and can be cleared by hand from that tab. A line draws a pressable chip " +
+        "exportable, and can be cleared by hand from that tab. Luke's own composer stands at " +
+        "its foot too, the same typed ask the sessions list offers, so a reply is asked for " +
+        "where it will land. A line draws a pressable chip " +
         "for each chat it named, going to that chat by hand; a chip keeps working for a chat " +
         "archived since — opened at the last address its provider reported this launch — and " +
         "a chat with no address draws none. A spoken open still reaches only sessions " +

--- a/apps/desktop/src/renderer/panel-body.tsx
+++ b/apps/desktop/src/renderer/panel-body.tsx
@@ -942,6 +942,9 @@ export function PanelBody({
           onClear={onClearConversationHistory}
           openable={conversationSessionOpenable}
           onOpenSession={onOpenConversationSession}
+          ask={ask}
+          onAskEngaged={onAskEngaged}
+          {...(askShortcut ? { askShortcut } : undefined)}
         />
       ) : (
         <SessionsPanel

--- a/apps/desktop/src/renderer/styles/history.css
+++ b/apps/desktop/src/renderer/styles/history.css
@@ -8,6 +8,12 @@
   gap: 8px;
 }
 
+/* The thread's own gap already separates the composer from the last bubble;
+   the margin the pill keeps under the sessions list would double it. */
+.history-view .ask-luke-row {
+  margin-top: 0;
+}
+
 .history-header {
   display: flex;
   flex: 0 0 auto;

--- a/apps/desktop/src/renderer/styles/sessions.css
+++ b/apps/desktop/src/renderer/styles/sessions.css
@@ -1297,10 +1297,11 @@ html[data-keyboard="true"] .row-application-button:focus-visible {
 
 /* Ask Luke ----------------------------------------------------------------- */
 
-/* The panel's own composer, pinned under the list. It arrives at the tail of
-   the row fan (the wrapper is in base.css's arrival stack) and holds the
-   panel's foot — which is where Luke's caption rides when he answers, so the
-   question and its answer share an edge. */
+/* The panel's own composer, pinned under the sessions list and under the
+   History thread. It arrives at the tail of the row fan (the wrapper is in
+   base.css's arrival stack) and holds the panel's foot — which is where Luke's
+   caption rides when he answers, so the question and its answer share an
+   edge. */
 .ask-luke-row {
   display: flex;
   flex: 0 0 auto;


### PR DESCRIPTION
## Summary

- The "Ask Luke" composer now stands at the foot of the History tab as well as under the sessions list. It is the same `AskLuke` component wired to the same `ask` handler, so a typed ask from either tab enters the one conversation, and on History the reply lands as a bubble directly above the field that asked.
- The composer rides inside History's `ph-no-capture` subtree, so a draft there is as unrecorded as the thread around it. Nothing new leaves the machine.
- The ask key no longer forces a switch to the Sessions tab: it lands in whichever composer is showing and only gives way to the sessions list from Settings, which has no field.
- The History thread's own gap already separates the pill from the last bubble, so the composer's list margin is zeroed there.
- Luke's guide now says the History tab carries the composer too, and the `ConversationHistoryPanel` test covers the field in the empty and threaded states and its placement after the list.

## Evidence

- Platform-independent checks: `./scripts/check.sh` passed (exit 0) on the Linux cloud workspace, including the new `conversation-history-panel` test.
- macOS Electron verification (`./scripts/verify.sh`): `not run locally` (Linux workspace); CI's macOS job runs it and links the evidence below.

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/33672479524/artifacts/9863140359) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/33672479524)

- Commit: `0d8e9ef67074d0ed78273ceddd02de7a893b0cd4`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

### Physical-device evidence

- Screenshot or screen recording: `not attached`
- Physical-notch check: `not performed`
- Device/display configuration: `not recorded`

## Notes

- Blockers or follow-up verification: inspect CI's History-tab evidence for the composer's spacing under the thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/5176964b-712c-4e0b-bd7c-b143960cab81)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)