### PR TITLE
feat(desktop): hold announcements while another app uses the microphone

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -485,7 +485,14 @@ Trust constraints:
   nothing about the user's intent. Disconnecting deletes the stored choice, and the
   grant stays the user's own in System Settings, withdrawable there like
   every system permission. The intervals pool with the signed-in accounts'
-  and decide nothing more than theirs do.
+  and decide nothing more than theirs do. A call the calendar never listed is
+  read the same way, through a native helper reporting whether any input
+  device is capturing (CoreAudio's running flag, or a Bluetooth headset's
+  switch to its call codec) as one boolean with no audio, device name, or
+  process name; Luke's own exchange is excluded, so his microphone never
+  counts as a call; the hold stands under the same setting, lifts a fixed
+  grace after capture stops, and decides nothing more than the meetings do.
+  Widening it is a product decision, not an implementation detail.
 - Quieting other media is bounded the way the talk key is: a native helper that
   can do one narrow thing. While a spoken exchange is live, Luke may lower the
   volume of the players the helper names (Music and Spotify, through their own

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -169,6 +169,9 @@ service, usage counts and recordings by PostHog, and crash reports by Sentry.
 - Clear the History tab to delete your stored conversation from your Mac.
 - Ask Luke what he remembers, correct a memory, or tell him to forget one.
 - Luke does not use your microphone until you start a turn.
+- Luke reads whether another app is using your microphone, as one yes-or-no
+  answer from macOS and never as audio, only to hold spoken announcements
+  during calls. Nothing about it leaves your Mac.
 - Delete your account from the Account section in Settings. This erases your
   account, your sign-in records, your usage counts, and any provider API keys
   you synced to the hosted service, and asks PostHog to erase your usage data

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ of supported agents below.
 
 ### Works around your schedule
 
-Connect your calendar and Luke stays quiet until your meeting is over.
+Connect your calendar, or just take a call, and Luke stays quiet until it's over.
 
 ## Supported agents and platforms
 

--- a/apps/desktop/native/macos/InputCapture.swift
+++ b/apps/desktop/native/macos/InputCapture.swift
@@ -1,0 +1,205 @@
+import CoreAudio
+import Foundation
+
+/// Reports whether another app is using this Mac's microphone: one yes-or-no,
+/// and nothing else.
+///
+/// CoreAudio is the reason this is a helper and the bound on what it does. The
+/// HAL says of each input device whether any process has it running — the
+/// same fact the orange dot in the menu bar draws from — and pushes a line
+/// whenever the answer changes. No audio is read, no device or process is
+/// named, and nothing is ever written back: the app holds spoken
+/// announcements while the answer is yes, and that is the whole power.
+///
+/// Two facts are watched, and the answer is their OR:
+///
+/// 1. Any device with input streams is running somewhere. Every input device
+///    is watched, not only the default: a call app may capture from a
+///    non-default microphone.
+/// 2. A Bluetooth headset is on its call codec. Bluetooth microphones do not
+///    set the running flag while in use, but a headset whose mic opens drops
+///    from A2DP to HFP/SCO, which pulls the default output's nominal sample
+///    rate down to 8 or 16 kHz. That drop, on a Bluetooth output, is the
+///    call.
+///
+/// One line per state: `capture running=<0|1>`, emitted once on start and again
+/// on every change. A machine with no input device at all says `unavailable`
+/// instead — the reader treats an answer it cannot see as "not capturing", so
+/// a hold never comes from a guess.
+private let CALL_CODEC_MAXIMUM_SAMPLE_RATE: Float64 = 16_000
+
+private func emit(_ line: String) {
+    guard let payload = "\(line)\n".data(using: .utf8) else { return }
+    FileHandle.standardOutput.write(payload)
+}
+
+private func address(
+    _ selector: AudioObjectPropertySelector,
+    scope: AudioObjectPropertyScope = kAudioObjectPropertyScopeGlobal
+) -> AudioObjectPropertyAddress {
+    AudioObjectPropertyAddress(
+        mSelector: selector,
+        mScope: scope,
+        mElement: kAudioObjectPropertyElementMain
+    )
+}
+
+private func readUInt32(_ device: AudioObjectID, _ selector: AudioObjectPropertySelector) -> UInt32? {
+    var query = address(selector)
+    guard AudioObjectHasProperty(device, &query) else { return nil }
+    var value = UInt32(0)
+    var size = UInt32(MemoryLayout<UInt32>.size)
+    guard AudioObjectGetPropertyData(device, &query, 0, nil, &size, &value) == noErr else {
+        return nil
+    }
+    return value
+}
+
+private func readDefaultOutputDevice() -> AudioObjectID? {
+    var query = address(kAudioHardwarePropertyDefaultOutputDevice)
+    var device = AudioObjectID(kAudioObjectUnknown)
+    var size = UInt32(MemoryLayout<AudioObjectID>.size)
+    let status = AudioObjectGetPropertyData(
+        AudioObjectID(kAudioObjectSystemObject), &query, 0, nil, &size, &device
+    )
+    guard status == noErr, device != kAudioObjectUnknown else { return nil }
+    return device
+}
+
+private func allDevices() -> [AudioObjectID] {
+    var query = address(kAudioHardwarePropertyDevices)
+    var size = UInt32(0)
+    let system = AudioObjectID(kAudioObjectSystemObject)
+    guard AudioObjectGetPropertyDataSize(system, &query, 0, nil, &size) == noErr, size > 0 else {
+        return []
+    }
+    var devices = [AudioObjectID](
+        repeating: AudioObjectID(kAudioObjectUnknown),
+        count: Int(size) / MemoryLayout<AudioObjectID>.size
+    )
+    guard AudioObjectGetPropertyData(system, &query, 0, nil, &size, &devices) == noErr else {
+        return []
+    }
+    return devices
+}
+
+/// Whether the device can capture at all: the device list holds speakers and
+/// displays too, and a microphone is the one with input streams.
+private func hasInputStreams(_ device: AudioObjectID) -> Bool {
+    var query = address(kAudioDevicePropertyStreams, scope: kAudioDevicePropertyScopeInput)
+    var size = UInt32(0)
+    guard AudioObjectGetPropertyDataSize(device, &query, 0, nil, &size) == noErr else {
+        return false
+    }
+    return size > 0
+}
+
+private func isRunningSomewhere(_ device: AudioObjectID) -> Bool {
+    readUInt32(device, kAudioDevicePropertyDeviceIsRunningSomewhere) == 1
+}
+
+private func isBluetooth(_ device: AudioObjectID) -> Bool {
+    switch readUInt32(device, kAudioDevicePropertyTransportType) {
+    case kAudioDeviceTransportTypeBluetooth, kAudioDeviceTransportTypeBluetoothLE:
+        return true
+    default:
+        return false
+    }
+}
+
+private func nominalSampleRate(of device: AudioObjectID) -> Float64? {
+    var query = address(kAudioDevicePropertyNominalSampleRate)
+    guard AudioObjectHasProperty(device, &query) else { return nil }
+    var rate = Float64(0)
+    var size = UInt32(MemoryLayout<Float64>.size)
+    guard AudioObjectGetPropertyData(device, &query, 0, nil, &size, &rate) == noErr else {
+        return nil
+    }
+    return rate
+}
+
+@main
+@MainActor
+private struct InputCaptureCommand {
+    /// The devices already wired, kept because a device is not new twice: a
+    /// headset can come and go all day, and wiring the same one again would
+    /// double every report it ever makes.
+    static var wiredInputs = Set<AudioObjectID>()
+    static var wiredOutputs = Set<AudioObjectID>()
+    static var inputs: [AudioObjectID] = []
+    static var output: AudioObjectID?
+    static var lastLine: String?
+    /// The queue every listener reports on, so a device swap and the swapped
+    /// device's own last change cannot interleave.
+    static let queue = DispatchQueue.main
+
+    static func main() {
+        let system = AudioObjectID(kAudioObjectSystemObject)
+        var devices = address(kAudioHardwarePropertyDevices)
+        AudioObjectAddPropertyListenerBlock(system, &devices, queue) { _, _ in
+            MainActor.assumeIsolated { followInputs() }
+        }
+        var defaultOutput = address(kAudioHardwarePropertyDefaultOutputDevice)
+        AudioObjectAddPropertyListenerBlock(system, &defaultOutput, queue) { _, _ in
+            MainActor.assumeIsolated { followOutput() }
+        }
+        followInputs()
+        followOutput()
+        dispatchMain()
+    }
+
+    static func followInputs() {
+        inputs = allDevices().filter(hasInputStreams)
+        let change: AudioObjectPropertyListenerBlock = { _, _ in
+            MainActor.assumeIsolated { report() }
+        }
+        for device in inputs where !wiredInputs.contains(device) {
+            wiredInputs.insert(device)
+            var running = address(kAudioDevicePropertyDeviceIsRunningSomewhere)
+            AudioObjectAddPropertyListenerBlock(device, &running, queue, change)
+        }
+        report()
+    }
+
+    static func followOutput() {
+        output = readDefaultOutputDevice()
+        if let output, !wiredOutputs.contains(output) {
+            wiredOutputs.insert(output)
+            var rate = address(kAudioDevicePropertyNominalSampleRate)
+            AudioObjectAddPropertyListenerBlock(output, &rate, queue) { _, _ in
+                MainActor.assumeIsolated { report() }
+            }
+        }
+        report()
+    }
+
+    static func headsetOnCallCodec() -> Bool {
+        guard let output, isBluetooth(output), let rate = nominalSampleRate(of: output) else {
+            return false
+        }
+        return rate <= CALL_CODEC_MAXIMUM_SAMPLE_RATE
+    }
+
+    static func report() {
+        // Wired listeners on a device that has since left still fire, so the
+        // answer is read only from the devices the last enumeration listed.
+        let live = inputs.filter { device in
+            var query = address(kAudioDevicePropertyDeviceIsRunningSomewhere)
+            return AudioObjectHasProperty(device, &query)
+        }
+        guard !live.isEmpty else {
+            say("unavailable no-input-device")
+            return
+        }
+        let running = live.contains(where: isRunningSomewhere) || headsetOnCallCodec()
+        say("capture running=\(running ? 1 : 0)")
+    }
+
+    /// Several listeners fire for one change, so only a changed answer is
+    /// written: the reader debounces on edges and a repeat would be noise.
+    static func say(_ line: String) {
+        guard line != lastLine else { return }
+        lastLine = line
+        emit(line)
+    }
+}

--- a/apps/desktop/scripts/package-layout.mjs
+++ b/apps/desktop/scripts/package-layout.mjs
@@ -28,6 +28,7 @@ export const NATIVE_HELPERS = [
     // falls all the way back lands on the folder's own basename.
     bundle: "Luke.app",
   },
+  { source: "InputCapture.swift", binary: "mac-input-capture", frameworks: ["CoreAudio"] },
   { source: "MediaDuck.swift", binary: "mac-media-duck", frameworks: ["AppKit"] },
   {
     source: "MicrophoneRoute.swift",

--- a/apps/desktop/src/main/call-quiet.test.ts
+++ b/apps/desktop/src/main/call-quiet.test.ts
@@ -1,0 +1,144 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { CALL_QUIET_ONSET_MS, CALL_QUIET_RELEASE_MS, CallQuietGate } from "./call-quiet";
+
+type Timer = ReturnType<typeof setTimeout>;
+
+interface Harness {
+  gate: CallQuietGate;
+  changes: boolean[];
+  clock: { advance(ms: number): void };
+}
+
+function harness(): Harness {
+  const changes: boolean[] = [];
+  let now = 0;
+  // Real handles, never fired: they are only keys, and the clock below fires
+  // and clears them itself, so the test decides the order and the moment.
+  const timers = new Map<Timer, { at: number; callback: () => void }>();
+  const gate = new CallQuietGate({
+    onChange: (holding) => changes.push(holding),
+    schedule: (callback, delayMs) => {
+      const handle = setTimeout(() => undefined, 0);
+      clearTimeout(handle);
+      timers.set(handle, { at: now + delayMs, callback });
+      return handle;
+    },
+    cancel: (timer) => {
+      timers.delete(timer);
+    },
+  });
+  return {
+    gate,
+    changes,
+    clock: {
+      advance(ms) {
+        const target = now + ms;
+        for (;;) {
+          const due = [...timers.entries()]
+            .filter(([, timer]) => timer.at <= target)
+            .sort((a, b) => a[1].at - b[1].at)[0];
+          if (!due) break;
+          timers.delete(due[0]);
+          now = due[1].at;
+          due[1].callback();
+        }
+        now = target;
+      },
+    },
+  };
+}
+
+test("a foreign capture holds only once it outlasts the onset", () => {
+  const { gate, changes, clock } = harness();
+  gate.setCapturing(true);
+  clock.advance(CALL_QUIET_ONSET_MS - 1);
+  assert.equal(gate.holding, false);
+  clock.advance(1);
+  assert.equal(gate.holding, true);
+  assert.deepEqual(changes, [true]);
+});
+
+test("a capture that ends before the onset never holds", () => {
+  const { gate, changes, clock } = harness();
+  gate.setCapturing(true);
+  clock.advance(CALL_QUIET_ONSET_MS - 1);
+  gate.setCapturing(false);
+  clock.advance(CALL_QUIET_RELEASE_MS);
+  assert.equal(gate.holding, false);
+  assert.deepEqual(changes, []);
+});
+
+test("a capture during Luke's own exchange is not a call", () => {
+  const { gate, changes, clock } = harness();
+  gate.setExchangeActive(true);
+  gate.setCapturing(true);
+  clock.advance(CALL_QUIET_ONSET_MS * 5);
+  assert.equal(gate.holding, false);
+  // The device outlives the exchange edge by a moment, and that moment is
+  // not a call either.
+  gate.setExchangeActive(false);
+  clock.advance(CALL_QUIET_ONSET_MS - 1);
+  gate.setCapturing(false);
+  clock.advance(CALL_QUIET_RELEASE_MS);
+  assert.deepEqual(changes, []);
+});
+
+test("a capture that lapses inside the grace keeps the hold", () => {
+  const { gate, changes, clock } = harness();
+  gate.setCapturing(true);
+  clock.advance(CALL_QUIET_ONSET_MS);
+  gate.setCapturing(false);
+  clock.advance(CALL_QUIET_RELEASE_MS - 1);
+  gate.setCapturing(true);
+  clock.advance(CALL_QUIET_RELEASE_MS);
+  assert.equal(gate.holding, true);
+  assert.deepEqual(changes, [true]);
+});
+
+test("speaking to Luke mid-call keeps the hold", () => {
+  const { gate, changes, clock } = harness();
+  gate.setCapturing(true);
+  clock.advance(CALL_QUIET_ONSET_MS);
+  gate.setExchangeActive(true);
+  clock.advance(CALL_QUIET_RELEASE_MS - 1);
+  gate.setExchangeActive(false);
+  clock.advance(CALL_QUIET_RELEASE_MS);
+  assert.equal(gate.holding, true);
+  assert.deepEqual(changes, [true]);
+});
+
+test("the hold releases once the capture has been gone for the grace", () => {
+  const { gate, changes, clock } = harness();
+  gate.setCapturing(true);
+  clock.advance(CALL_QUIET_ONSET_MS);
+  gate.setCapturing(false);
+  clock.advance(CALL_QUIET_RELEASE_MS - 1);
+  assert.equal(gate.holding, true);
+  clock.advance(1);
+  assert.equal(gate.holding, false);
+  assert.deepEqual(changes, [true, false]);
+});
+
+test("an unreadable input is not a capture", () => {
+  const { gate, changes, clock } = harness();
+  gate.setCapturing(undefined);
+  clock.advance(CALL_QUIET_ONSET_MS * 2);
+  assert.equal(gate.holding, false);
+  gate.setCapturing(true);
+  clock.advance(CALL_QUIET_ONSET_MS);
+  gate.setCapturing(undefined);
+  clock.advance(CALL_QUIET_RELEASE_MS);
+  assert.deepEqual(changes, [true, false]);
+});
+
+test("stop drops the hold and every timer", () => {
+  const { gate, changes, clock } = harness();
+  gate.setCapturing(true);
+  clock.advance(CALL_QUIET_ONSET_MS);
+  gate.stop();
+  assert.equal(gate.holding, false);
+  assert.deepEqual(changes, [true, false]);
+  clock.advance(CALL_QUIET_RELEASE_MS);
+  assert.deepEqual(changes, [true, false]);
+});

--- a/apps/desktop/src/main/call-quiet.ts
+++ b/apps/desktop/src/main/call-quiet.ts
@@ -1,0 +1,111 @@
+/**
+ * How long another app must hold the microphone before it counts as a call.
+ * The talk key opens Luke's own capture device before the exchange edge goes
+ * active and releases it around the moment the edge goes inactive, with IPC
+ * and CoreAudio ordering not guaranteed, so a brief foreign capture at either
+ * end of every conversation is Luke himself. It also absorbs the probe some
+ * apps make of the microphone on launch. Under the announcement batch window,
+ * so a notice decided in a call's first instant is still pending when delivery
+ * asks the gate.
+ */
+export const CALL_QUIET_ONSET_MS = 3_000;
+/**
+ * How long a capture may lapse before the call is over: a mute that reopens
+ * the device, an app switching microphones, the hang-up moment itself.
+ */
+export const CALL_QUIET_RELEASE_MS = 15_000;
+
+type Timer = ReturnType<typeof setTimeout>;
+type Schedule = (callback: () => void, delayMs: number) => Timer;
+type Cancel = (timer: Timer) => void;
+
+export interface CallQuietGateOptions {
+  /** Fires on each edge of {@link CallQuietGate.holding}. */
+  onChange(holding: boolean): void;
+  schedule?: Schedule;
+  cancel?: Cancel;
+}
+
+/**
+ * Decides whether a call is on from two deterministic facts: whether any app
+ * is capturing from a microphone, and whether the capture is Luke's own
+ * exchange. A foreign capture that lasts the onset becomes a hold; a hold
+ * outlasts the capture by the release grace. Nothing a model wrote can reach
+ * either input — the capture is a helper's reading of CoreAudio and the
+ * exchange is the renderer's own status edge — so holding is the whole power.
+ */
+export class CallQuietGate {
+  readonly #onChange: (holding: boolean) => void;
+  readonly #schedule: Schedule;
+  readonly #cancel: Cancel;
+  #capturing = false;
+  #exchangeActive = false;
+  #holding = false;
+  #onset: Timer | undefined;
+  #release: Timer | undefined;
+
+  constructor(options: CallQuietGateOptions) {
+    this.#onChange = options.onChange;
+    this.#schedule = options.schedule ?? ((callback, delayMs) => setTimeout(callback, delayMs));
+    this.#cancel = options.cancel ?? ((timer) => clearTimeout(timer));
+  }
+
+  get holding(): boolean {
+    return this.#holding;
+  }
+
+  /** `undefined` is an input the helper cannot read, which is not a capture. */
+  setCapturing(running: boolean | undefined): void {
+    this.#capturing = running === true;
+    this.#apply();
+  }
+
+  setExchangeActive(active: boolean): void {
+    this.#exchangeActive = active;
+    this.#apply();
+  }
+
+  /** Drops every timer and the hold. Nothing fires after. */
+  stop(): void {
+    this.#clearOnset();
+    this.#clearRelease();
+    this.#capturing = false;
+    this.#exchangeActive = false;
+    this.#set(false);
+  }
+
+  #apply(): void {
+    const foreign = this.#capturing && !this.#exchangeActive;
+    if (foreign) {
+      this.#clearRelease();
+      if (this.#holding || this.#onset) return;
+      this.#onset = this.#schedule(() => {
+        this.#onset = undefined;
+        this.#set(true);
+      }, CALL_QUIET_ONSET_MS);
+      return;
+    }
+    this.#clearOnset();
+    if (!this.#holding || this.#release) return;
+    this.#release = this.#schedule(() => {
+      this.#release = undefined;
+      this.#set(false);
+    }, CALL_QUIET_RELEASE_MS);
+  }
+
+  #set(holding: boolean): void {
+    if (holding === this.#holding) return;
+    this.#holding = holding;
+    this.#onChange(holding);
+  }
+
+  #clearOnset(): void {
+    if (this.#onset) this.#cancel(this.#onset);
+    this.#onset = undefined;
+  }
+
+  #clearRelease(): void {
+    if (this.#release) this.#cancel(this.#release);
+    this.#release = undefined;
+  }
+}

--- a/apps/desktop/src/main/desktop-app.ts
+++ b/apps/desktop/src/main/desktop-app.ts
@@ -59,6 +59,7 @@ import {
   InMemorySessionRegistry,
   isProviderId,
   isWorkspaceProviderId,
+  MAXIMUM_RELEASED_NOTICES,
   normalizeObservedWorkspaceProjects,
   ObservationLoop,
   ObservationSupervisor,
@@ -140,6 +141,7 @@ import {
   countsFirstAnnouncement,
   shouldBackfillArrivalSettled,
 } from "./arrival-flow";
+import { CallQuietGate } from "./call-quiet";
 import {
   INTRODUCTION_FADE_MS,
   INTRODUCTION_HANDOFF_READY_MS,
@@ -167,6 +169,7 @@ import {
   rememberedFactsFromStored,
   rememberedFactsRecord,
 } from "./memory-flow";
+import { InputCaptureWatcher } from "./native/input-capture";
 import { MediaDuckController } from "./native/media-duck";
 import { MicrophoneRouteWatcher } from "./native/microphone-route";
 import { OutputVolumeWatcher } from "./native/output-volume";
@@ -455,24 +458,36 @@ const APPLE_ACCESS_POLL_INTERVAL_MS = 10_000;
 let appleAccessPollTimer: NodeJS.Timeout | undefined;
 /** Whether the last access probe failed, so only the edges reach the log. */
 let appleAccessProbeFailing = false;
-// Notices decided while a meeting is on wait here, in the main process: the
-// hold has to outlive any renderer, and this is the one place notices are
-// decided. What releases them is the clock against observed intervals —
-// deterministic, like the edges that produced them.
+// Notices decided while a meeting or a call is on wait here, in the main
+// process: the hold has to outlive any renderer, and this is the one place
+// notices are decided. What releases them is the clock against observed
+// intervals, or the capture helper's reading — deterministic, like the edges
+// that produced them.
 const heldNotices = new SessionNoticeHold();
 /**
- * Evaluator approvals deferred by meeting quiet. Their words are not replayed
- * after the meeting because the session may have moved on; release instead
- * reopens a fresh evaluator pass against the current roster.
+ * Evaluator approvals deferred by the quiet. Their words are not replayed
+ * after the meeting or call because the session may have moved on; release
+ * instead reopens a fresh evaluator pass against the current roster.
  */
 const heldEvaluatorSpeech = new SessionNoticeHold<SessionAnnouncement>();
 /**
  * Whether the quiet is holding right now, as last computed — what the
  * renderer draws Luke's sleeping face from. Kept and broadcast on change so
- * every window agrees, and false the moment the meetings or the setting say
- * so.
+ * every window agrees, and false the moment the meetings, the call, or the
+ * setting say so.
  */
 let meetingQuietActive = false;
+/**
+ * The call side of the quiet: another app holding the microphone past a
+ * short onset, read from a helper that reads one boolean and no audio. Its
+ * edges recompute the pooled quiet the same way a meeting boundary does.
+ */
+const callQuiet = new CallQuietGate({
+  onChange: () => {
+    void refreshMeetingQuiet();
+    void releaseHeldNotices();
+  },
+});
 /**
  * The conversation history, one retained thread shared by every panel window
  * and persisted for the next launch. The main process merges whole-window
@@ -735,6 +750,7 @@ function endSessionReplay(): void {
  */
 let outputAudio: OutputAudioState | undefined;
 let outputVolumeWatcher: OutputVolumeWatcher | undefined;
+let inputCaptureWatcher: InputCaptureWatcher | undefined;
 /**
  * Where the developer's voice would be captured from, as last read, and the
  * helper that reads it. The state lives here so the renderer's ask can be
@@ -751,6 +767,7 @@ function rendererUrl(): string {
 const panels = new PanelManager({
   runMode,
   mediaDuck,
+  onExchangeActive: (active) => callQuiet.setExchangeActive(active),
   preloadPath: path.join(__dirname, "preload.js"),
   rendererHtmlPath: path.join(__dirname, "renderer", "index.html"),
   rendererUrl: rendererUrl(),
@@ -1091,6 +1108,20 @@ function startOutputVolumeWatch(): void {
     onUnavailable: () => send(undefined),
   });
   if (!outputVolumeWatcher.start()) outputVolumeWatcher = undefined;
+}
+
+/**
+ * Starts watching whether another app is using the microphone, under the same
+ * rule as the output watch: read-only, one boolean, and not in a fixture or
+ * capture run. What it learns feeds the call quiet alone.
+ */
+function startInputCaptureWatch(): void {
+  if (!runMode.observesProviders) return;
+  inputCaptureWatcher = new InputCaptureWatcher({
+    onCapturing: (running) => callQuiet.setCapturing(running),
+    onUnavailable: () => callQuiet.setCapturing(undefined),
+  });
+  if (!inputCaptureWatcher.start()) inputCaptureWatcher = undefined;
 }
 
 /**
@@ -2167,11 +2198,12 @@ function openCreatedWorkspaces(sessions: readonly Session[]): void {
 }
 
 /**
- * Whether announcements should wait right now: a meeting on the connected
- * calendar covers this instant, and the quiet is switched on. The meetings
- * are consulted before the store so the common case — no calendar — costs no
- * read at all; the store's answer comes from its cached file either way,
- * never the keychain.
+ * Whether announcements should wait right now: an account is signed in, a
+ * meeting on the connected calendar covers this instant or another app has
+ * held the microphone past the call onset, and the quiet is switched on. The
+ * two facts pool under one flag, so the sleeping face and the renderer's gate
+ * need never know which one is holding. The store's answer comes from its
+ * cached file, never the keychain.
  *
  * Consulting it is also what keeps every window honest: the answer is
  * reconciled with the broadcast state on the way out, so speech can never be
@@ -2182,8 +2214,13 @@ function openCreatedWorkspaces(sessions: readonly Session[]): void {
 async function announcementsQuietNow(now: number): Promise<boolean> {
   const inMeeting =
     calendarMeetings !== undefined && activeMeetingEnd(calendarMeetings, now) !== undefined;
+  // The account gate is the call's: meetings are cleared at sign-out and so
+  // imply an account, while a call does not. The setting is read last so the
+  // common case — nothing on — costs no read at all.
   const holding =
-    inMeeting && (await settingsStore.get(APP_SETTING_SCHEMA.quietDuringMeetings.field));
+    accountCapabilitiesActive() &&
+    (inMeeting || callQuiet.holding) &&
+    (await settingsStore.get(APP_SETTING_SCHEMA.quietDuringMeetings.field));
   if (holding !== meetingQuietActive) {
     meetingQuietActive = holding;
     panels.broadcast(channels.onMeetingQuietChanged, holding);
@@ -2260,12 +2297,15 @@ async function releaseHeldNotices(): Promise<void> {
     }
     provider.set(session.providerSessionId, session.status);
   }
-  const released = heldNotices.release().filter((notice) => {
-    const status = current.get(notice.providerId)?.get(notice.providerSessionId);
-    // A session the registry no longer lists settled where the notice said —
-    // its parting words are still the answer to where the work stands.
-    return status === undefined || status === notice.status;
-  });
+  const released = heldNotices
+    .release()
+    .filter((notice) => {
+      const status = current.get(notice.providerId)?.get(notice.providerSessionId);
+      // A session the registry no longer lists settled where the notice said —
+      // its parting words are still the answer to where the work stands.
+      return status === undefined || status === notice.status;
+    })
+    .slice(-MAXIMUM_RELEASED_NOTICES);
   const deferredEvaluatorSpeech = heldEvaluatorSpeech.release();
   if (deferredEvaluatorSpeech.length > 0) {
     voiceCapabilities.attentionReviewer?.reconsider(deferredEvaluatorSpeech);
@@ -2411,6 +2451,9 @@ function startCalendarObservation(): void {
     }, APPLE_ACCESS_POLL_INTERVAL_MS);
     appleAccessPollTimer.unref();
   }
+  // A call already running at sign-in is honored at once, not at the first
+  // tick or pass.
+  void refreshMeetingQuiet();
 }
 
 /**
@@ -2788,6 +2831,7 @@ export function startDesktopApp(): void {
       // what the renderer draws while Luke speaks unheard, and nothing more.
       startOutputVolumeWatch();
       startMicrophoneRouteWatch();
+      startInputCaptureWatch();
       // The introduction owns the screen alone until it completes or is
       // abandoned; both of its endings reconcile the panels themselves.
       if (!introductionWindow.active) panels.reconcile();
@@ -2865,6 +2909,9 @@ export function startDesktopApp(): void {
     outputVolumeWatcher = undefined;
     microphoneRouteWatcher?.stop();
     microphoneRouteWatcher = undefined;
+    inputCaptureWatcher?.stop();
+    inputCaptureWatcher = undefined;
+    callQuiet.stop();
     // The duck helper outlives this by one fade: closing its stdin is what asks
     // it to bring the players back up, so quitting mid-sentence costs the user
     // nothing.

--- a/apps/desktop/src/main/native/input-capture.test.ts
+++ b/apps/desktop/src/main/native/input-capture.test.ts
@@ -1,0 +1,113 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { InputCaptureWatcher, parseInputCaptureLine } from "./input-capture";
+
+interface Harness {
+  watcher: InputCaptureWatcher;
+  events: string[];
+  killed: () => boolean;
+  emit: (chunk: string) => void;
+  die: () => void;
+}
+
+function harness(spawnFails = false): Harness {
+  const events: string[] = [];
+  let killed = false;
+  let onData: ((chunk: string) => void) | undefined;
+  const exits: (() => void)[] = [];
+
+  const watcher = new InputCaptureWatcher({
+    spawnHelper: () =>
+      spawnFails
+        ? undefined
+        : {
+            stdout: {
+              setEncoding: () => undefined,
+              on: (_event, listener) => {
+                onData = listener;
+              },
+            },
+            on: (event, listener) => {
+              if (event === "exit") exits.push(listener);
+            },
+            removeAllListeners: () => {
+              exits.length = 0;
+            },
+            kill: () => {
+              killed = true;
+            },
+          },
+    onCapturing: (running) => events.push(`capturing:${running ? 1 : 0}`),
+    onUnavailable: () => events.push("unavailable"),
+  });
+
+  return {
+    watcher,
+    events,
+    killed: () => killed,
+    emit: (chunk) => onData?.(chunk),
+    die: () => {
+      for (const exit of [...exits]) exit();
+    },
+  };
+}
+
+test("a capture line is parsed and reported", () => {
+  const context = harness();
+  assert.equal(context.watcher.start(), true);
+  context.emit("capture running=1\n");
+  assert.deepEqual(context.events, ["capturing:1"]);
+});
+
+test("a capture survives being split across chunks", () => {
+  const context = harness();
+  context.watcher.start();
+  context.emit("capture runn");
+  assert.deepEqual(context.events, []);
+  context.emit("ing=0\ncapture running=1\n");
+  assert.deepEqual(context.events, ["capturing:0", "capturing:1"]);
+});
+
+test("an unavailable line withdraws the answer without ending the watch", () => {
+  const context = harness();
+  context.watcher.start();
+  context.emit("unavailable no-input-device\n");
+  // A microphone can be plugged in after the helper found none.
+  context.emit("capture running=1\n");
+  assert.deepEqual(context.events, ["unavailable", "capturing:1"]);
+});
+
+test("a helper that dies takes its answer with it", () => {
+  const context = harness();
+  context.watcher.start();
+  context.emit("capture running=1\n");
+  context.die();
+  assert.deepEqual(context.events, ["capturing:1", "unavailable"]);
+  context.emit("capture running=1\n");
+  assert.deepEqual(context.events, ["capturing:1", "unavailable"]);
+});
+
+test("a helper that cannot spawn reports unavailable once", () => {
+  const context = harness(true);
+  assert.equal(context.watcher.start(), false);
+  assert.deepEqual(context.events, ["unavailable"]);
+});
+
+test("stopping kills the helper and silences everything after", () => {
+  const context = harness();
+  context.watcher.start();
+  context.watcher.stop();
+  assert.equal(context.killed(), true);
+  context.emit("capture running=1\n");
+  context.die();
+  assert.deepEqual(context.events, []);
+});
+
+test("a line that does not parse is dropped rather than guessed at", () => {
+  assert.equal(parseInputCaptureLine("capture running=2"), undefined);
+  assert.equal(parseInputCaptureLine("capture running="), undefined);
+  assert.equal(parseInputCaptureLine("capture running=1 extra"), undefined);
+  assert.equal(parseInputCaptureLine("ready"), undefined);
+  assert.equal(parseInputCaptureLine("capture running=0"), false);
+  assert.equal(parseInputCaptureLine("capture running=1"), true);
+});

--- a/apps/desktop/src/main/native/input-capture.ts
+++ b/apps/desktop/src/main/native/input-capture.ts
@@ -1,0 +1,103 @@
+import { NativeHelper, type NativeHelperProcess } from "./native-helper";
+
+/**
+ * The two things the helper says. Parsed rather than assumed, like the output
+ * watcher's lines: a capture the reader guessed at would put Luke to sleep
+ * through news the developer wanted to hear.
+ */
+export const INPUT_CAPTURE_EVENT = {
+  CAPTURE: "capture",
+  UNAVAILABLE: "unavailable",
+} as const;
+
+export interface InputCaptureEdges {
+  /** Whether any app is capturing from an input device, on start and on every change. */
+  onCapturing(running: boolean): void;
+  /**
+   * The input cannot be watched — no input device, or the helper has stopped.
+   * Not final: a device can arrive and be read. Means "not capturing", since a
+   * hold never comes from a guess. Never reported for a stop the app asked for.
+   */
+  onUnavailable(): void;
+}
+
+export type InputCaptureProcess = NativeHelperProcess;
+
+export interface InputCaptureWatcherOptions extends InputCaptureEdges {
+  /** Injectable so the reader can be exercised without a Mac or a binary. */
+  spawnHelper?: () => InputCaptureProcess | undefined;
+}
+
+/**
+ * Watches whether another app is using this Mac's microphone, read by a
+ * helper that reads one boolean from CoreAudio — no audio, no device or
+ * process name — and can write nothing at all. What it learns feeds only the
+ * call quiet, which holds spoken announcements while a call is on.
+ */
+export class InputCaptureWatcher {
+  readonly #options: InputCaptureWatcherOptions;
+  #helper: NativeHelper | undefined;
+  #done = false;
+
+  constructor(options: InputCaptureWatcherOptions) {
+    this.#options = options;
+  }
+
+  /**
+   * Starts the helper, reporting whether it could be launched at all. A `true`
+   * is not yet a readable answer — that arrives on the helper's first line.
+   */
+  start(): boolean {
+    const helper = new NativeHelper({
+      binary: "mac-input-capture",
+      output: "lines",
+      ...(this.#options.spawnHelper ? { spawnProcess: this.#options.spawnHelper } : undefined),
+    });
+    helper.onLine((line) => this.#handle(line));
+    helper.onExit(() => this.#unavailable());
+    if (!helper.start()) {
+      this.#unavailable();
+      return false;
+    }
+    this.#helper = helper;
+    return true;
+  }
+
+  /**
+   * Stops the helper. Detached before killing: this exit is the app's own
+   * doing, and nothing succeeds a watcher during shutdown, so no one waits.
+   */
+  stop(): void {
+    const helper = this.#helper;
+    this.#helper = undefined;
+    this.#done = true;
+    void helper?.stop();
+  }
+
+  #handle(line: string): void {
+    if (line.startsWith(`${INPUT_CAPTURE_EVENT.CAPTURE} `)) {
+      const running = parseInputCaptureLine(line);
+      if (running !== undefined) this.#options.onCapturing(running);
+      return;
+    }
+    if (line.startsWith(INPUT_CAPTURE_EVENT.UNAVAILABLE)) this.#options.onUnavailable();
+  }
+
+  #unavailable(): void {
+    if (this.#done) return;
+    this.#done = true;
+    this.#helper = undefined;
+    this.#options.onUnavailable();
+  }
+}
+
+/**
+ * Reads one `capture running=<0|1>` line. A line that does not parse is
+ * dropped rather than guessed at: missing one report costs a hold arriving a
+ * change later, and misreading one costs a hold that lies.
+ */
+export function parseInputCaptureLine(line: string): boolean | undefined {
+  const match = /^capture running=([01])$/.exec(line);
+  if (!match?.[1]) return undefined;
+  return match[1] === "1";
+}

--- a/apps/desktop/src/main/window/panel-manager.ts
+++ b/apps/desktop/src/main/window/panel-manager.ts
@@ -27,6 +27,11 @@ export interface PanelDuck {
 export interface PanelManagerOptions {
   runMode: RunMode;
   mediaDuck: PanelDuck;
+  /**
+   * Told the same edge the duck is: whether any window holds a live spoken
+   * exchange. The call quiet reads it to tell Luke's own capture from a call.
+   */
+  onExchangeActive?: (active: boolean) => void;
   preloadPath: string;
   rendererHtmlPath: string;
   rendererUrl: string;
@@ -58,6 +63,7 @@ function initialWindowMode(runMode: RunMode, argv: readonly string[]): WindowMod
 export class PanelManager {
   readonly #runMode: RunMode;
   readonly #mediaDuck: PanelDuck;
+  readonly #onExchangeActive: ((active: boolean) => void) | undefined;
   readonly #preloadPath: string;
   readonly #rendererHtmlPath: string;
   readonly #rendererUrl: string;
@@ -92,6 +98,7 @@ export class PanelManager {
   constructor(options: PanelManagerOptions) {
     this.#runMode = options.runMode;
     this.#mediaDuck = options.mediaDuck;
+    this.#onExchangeActive = options.onExchangeActive;
     this.#preloadPath = options.preloadPath;
     this.#rendererHtmlPath = options.rendererHtmlPath;
     this.#rendererUrl = options.rendererUrl;
@@ -416,7 +423,9 @@ export class PanelManager {
   }
 
   #applyVoiceExchanges(): void {
-    this.#mediaDuck.setExchangeActive([...this.#voiceExchanges.values()].some(Boolean));
+    const active = [...this.#voiceExchanges.values()].some(Boolean);
+    this.#mediaDuck.setExchangeActive(active);
+    this.#onExchangeActive?.(active);
   }
 
   #collapseDelay(): number {

--- a/apps/desktop/src/renderer/luke-face-mood.ts
+++ b/apps/desktop/src/renderer/luke-face-mood.ts
@@ -15,9 +15,10 @@ export interface FaceContext {
   speaking: boolean;
   microphoneLive: boolean;
   /**
-   * Whether the calendar's quiet is holding announcements right now. A
-   * deterministic fact from the main process — the clock against observed
-   * meeting intervals — never anything a model decided.
+   * Whether the quiet — a meeting or a call — is holding announcements right
+   * now. A deterministic fact from the main process — the clock against
+   * observed meeting intervals, or a helper's reading of whether another app
+   * holds the microphone — never anything a model decided.
    */
   meetingQuiet: boolean;
   /**
@@ -97,10 +98,10 @@ export function faceYieldsToMeter(input: { turn?: SpeechTurn; hasAudioSignal: bo
 export function restingMotion(context: FaceContext): FaceMotion | undefined {
   if (context.speaking) return FACE_MOTION.TALKING;
   if (context.microphoneLive) return FACE_MOTION.LISTENING;
-  // A meeting the calendar is holding announcements through. Sleeping is the
-  // one visual report the hold makes — Luke is deliberately not speaking —
-  // and it stays true for exactly as long as the meeting covers now, which is
-  // what a rest must do. Speech still outranks it: a developer who opens a
+  // A meeting or a call the quiet is holding announcements through. Sleeping
+  // is the one visual report the hold makes — Luke is deliberately not
+  // speaking — and it stays true for exactly as long as the hold does, which
+  // is what a rest must do. Speech still outranks it: a developer who opens a
   // turn mid-meeting is talking to a face, not to a pillow.
   if (context.meetingQuiet) return FACE_MOTION.SLEEPING;
   // Nothing to watch at all, which is a different thing from nothing

--- a/apps/desktop/src/renderer/settings-panel.tsx
+++ b/apps/desktop/src/renderer/settings-panel.tsx
@@ -1819,8 +1819,9 @@ function AppleCalendarRow({
  * capability: two ways into the same meetings — this Mac's own Calendar
  * behind macOS's consent dialog, and Google accounts behind Google's consent
  * page — sharing one line about what is read and the quiet switch the
- * intervals exist to drive. Each row appears only in a build that can offer
- * it, and the block only when either can.
+ * intervals exist to drive. Each calendar row appears only in a build that
+ * can offer it; the quiet switch stands in every build, because a call holds
+ * announcements with no calendar at all.
  */
 function CalendarIntegrations({
   settings,
@@ -1832,10 +1833,8 @@ function CalendarIntegrations({
   calendar: CalendarControl;
   appleCalendar: AppleCalendarControl;
   writes: SettingsWrites;
-}): React.JSX.Element | null {
-  if (!settings.calendarSignInAvailable && !settings.appleCalendarAvailable) return null;
+}): React.JSX.Element {
   const accounts = settings.calendarAccounts;
-  const connected = accounts.length > 0 || settings.appleCalendar !== undefined;
 
   return (
     <div className="credential">
@@ -1898,20 +1897,16 @@ function CalendarIntegrations({
         </>
       ) : null}
       <p className="settings-note">
-        Luke reads when your meetings start and end — never their titles — and can hold
-        announcements until they finish.
+        Luke reads when your meetings start and end — never their titles — and whether another app
+        is using your microphone — never the audio — and can hold announcements until the meeting or
+        call is over.
       </p>
-      {/* The quiet is a fact about the calendars above it, so it appears with
-          the first connection and leaves with the last — a switch gating what
-          a disconnected calendar cannot do would be a control over nothing. */}
-      {connected ? (
-        <SchemaSettingRows
-          page={SCHEMA_SETTINGS_PAGE.CONNECTIONS}
-          settings={settings}
-          writes={writes}
-          fields={[APP_SETTING_SCHEMA.quietDuringMeetings.field]}
-        />
-      ) : null}
+      <SchemaSettingRows
+        page={SCHEMA_SETTINGS_PAGE.CONNECTIONS}
+        settings={settings}
+        writes={writes}
+        fields={[APP_SETTING_SCHEMA.quietDuringMeetings.field]}
+      />
     </div>
   );
 }

--- a/apps/desktop/src/renderer/settings-search.test.ts
+++ b/apps/desktop/src/renderer/settings-search.test.ts
@@ -119,7 +119,8 @@ test("a row a page is not drawing is not offered", () => {
   // draws it.
   const bare = labels(settingsSearchEntries(searchInput({ voiceControlsDrawn: false })));
   assert.ok(!bare.includes("Captions"), "no voice controls until voice can run");
-  assert.ok(!bare.includes("Quiet during meetings"), "no quiet row without a calendar account");
+  // The quiet holds for a call with no calendar at all, so its row always stands.
+  assert.ok(bare.includes("Quiet during meetings and calls"));
   assert.ok(!bare.includes("Linear"), "no Linear row without its OAuth client");
   assert.ok(!bare.includes("Superset"), "no Superset row while it is not installed");
   assert.ok(!bare.includes("New Conductor agents run"), "no agent row while disconnected");
@@ -131,7 +132,7 @@ test("a row a page is not drawing is not offered", () => {
   const wide = labels(settingsSearchEntries(everythingDrawn()));
   for (const label of [
     "Captions",
-    "Quiet during meetings",
+    "Quiet during meetings and calls",
     "Linear",
     "Superset",
     "New Conductor agents run",
@@ -180,7 +181,7 @@ test("a query narrows by every word, case-blind, and a blank query is no search"
   // Both words must land: "quiet" alone finds several rows, "quiet music" one.
   const quiet = labels(found(searchSettings(entries, "quiet")));
   assert.ok(quiet.includes("Quiet Music and Spotify"));
-  assert.ok(quiet.includes("Quiet during meetings"));
+  assert.ok(quiet.includes("Quiet during meetings and calls"));
   assert.deepEqual(labels(found(searchSettings(entries, "quiet music"))), [
     "Quiet Music and Spotify",
   ]);

--- a/apps/desktop/src/renderer/settings-search.tsx
+++ b/apps/desktop/src/renderer/settings-search.tsx
@@ -199,11 +199,6 @@ const SETTING_ROW_DRAWN = {
   [APP_SETTING_ID.VOICE_CAPTIONS]: voiceControlRowDrawn,
   [APP_SETTING_ID.DUCK_OTHER_MEDIA]: voiceControlRowDrawn,
   [APP_SETTING_ID.PREFER_BUILT_IN_MICROPHONE]: voiceControlRowDrawn,
-  // The quiet rides the calendar block, and appears with its first
-  // connection — a Google account, or this Mac's own Calendar.
-  [APP_SETTING_ID.QUIET_DURING_MEETINGS]: (input) =>
-    (input.settings.calendarSignInAvailable && input.settings.calendarAccounts.length > 0) ||
-    input.settings.appleCalendar !== undefined,
   // The Conductor agent rows belong to a connected provider the build
   // documents a model table for.
   [APP_SETTING_ID.WORKSPACE_AGENT_MODEL]: conductorAgentRowDrawn,

--- a/apps/desktop/src/renderer/spoken-notices.ts
+++ b/apps/desktop/src/renderer/spoken-notices.ts
@@ -87,9 +87,9 @@ export interface SpokenNoticeAnnouncerOptions {
  * A backlog that outlives its attempts is dropped, because every notice is
  * still standing in the panel.
  *
- * The meeting quiet reaches it through {@link setMeetingQuiet}: quiet
- * beginning silences it at once — the announcement mid-sentence on Luke's
- * own call included — and holds it silent until the quiet ends.
+ * The quiet — a meeting or a call — reaches it through {@link setMeetingQuiet}:
+ * quiet beginning silences it at once — the announcement mid-sentence on
+ * Luke's own call included — and holds it silent until the quiet ends.
  *
  * On the developer's own call, a reply Luke just gave them holds the whole
  * backlog for {@link ANNOUNCER_GRACE_MS}: the pause after an answer is where

--- a/apps/desktop/src/shared/wire/session.ts
+++ b/apps/desktop/src/shared/wire/session.ts
@@ -199,7 +199,7 @@ export interface AppBootstrap {
   issues?: readonly TrackedIssue[];
   /** Each connected account's calendars, as last observed. */
   calendars: readonly ObservedAccountCalendars[];
-  /** Whether the calendar's quiet is holding announcements right now. */
+  /** Whether the quiet — a meeting or a call — is holding announcements right now. */
   meetingQuiet: boolean;
   /**
    * The conversation thread as the last launch left it, already retained.

--- a/packages/session/src/index.ts
+++ b/packages/session/src/index.ts
@@ -125,6 +125,7 @@ export {
 } from "./session-mentions.js";
 export {
   MAXIMUM_HELD_NOTICES,
+  MAXIMUM_RELEASED_NOTICES,
   SessionNoticeHold,
 } from "./session-notice-hold.js";
 export {

--- a/packages/session/src/session-notice-hold.test.ts
+++ b/packages/session/src/session-notice-hold.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
   MAXIMUM_HELD_NOTICES,
+  MAXIMUM_RELEASED_NOTICES,
   SESSION_NOTICE_STATUS,
   SESSION_STATUS,
   type SessionNotice,
@@ -97,4 +98,25 @@ test("the backlog is bounded, shedding the oldest first", () => {
   const released = hold.release();
   assert.equal(released[0]?.providerSessionId, "session-3");
   assert.equal(released.at(-1)?.providerSessionId, `session-${MAXIMUM_HELD_NOTICES + 2}`);
+});
+
+test("a limited release hands back the newest, oldest first, and sheds the rest", () => {
+  const hold = new SessionNoticeHold();
+  for (let index = 0; index < MAXIMUM_RELEASED_NOTICES + 2; index += 1) {
+    hold.hold([notice(`session-${index}`, SESSION_NOTICE_STATUS.COMPLETE)]);
+  }
+
+  const released = hold.release(MAXIMUM_RELEASED_NOTICES);
+  assert.deepEqual(
+    released.map((item) => item.providerSessionId),
+    ["session-2", "session-3", "session-4"],
+  );
+  assert.equal(hold.count, 0);
+  assert.deepEqual(hold.release(MAXIMUM_RELEASED_NOTICES), []);
+});
+
+test("a limit wider than the backlog changes nothing", () => {
+  const hold = new SessionNoticeHold();
+  hold.hold([notice("session-1", SESSION_NOTICE_STATUS.COMPLETE)]);
+  assert.equal(hold.release(MAXIMUM_RELEASED_NOTICES).length, 1);
 });

--- a/packages/session/src/session-notice-hold.test.ts
+++ b/packages/session/src/session-notice-hold.test.ts
@@ -2,7 +2,6 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
   MAXIMUM_HELD_NOTICES,
-  MAXIMUM_RELEASED_NOTICES,
   SESSION_NOTICE_STATUS,
   SESSION_STATUS,
   type SessionNotice,
@@ -98,25 +97,4 @@ test("the backlog is bounded, shedding the oldest first", () => {
   const released = hold.release();
   assert.equal(released[0]?.providerSessionId, "session-3");
   assert.equal(released.at(-1)?.providerSessionId, `session-${MAXIMUM_HELD_NOTICES + 2}`);
-});
-
-test("a limited release hands back the newest, oldest first, and sheds the rest", () => {
-  const hold = new SessionNoticeHold();
-  for (let index = 0; index < MAXIMUM_RELEASED_NOTICES + 2; index += 1) {
-    hold.hold([notice(`session-${index}`, SESSION_NOTICE_STATUS.COMPLETE)]);
-  }
-
-  const released = hold.release(MAXIMUM_RELEASED_NOTICES);
-  assert.deepEqual(
-    released.map((item) => item.providerSessionId),
-    ["session-2", "session-3", "session-4"],
-  );
-  assert.equal(hold.count, 0);
-  assert.deepEqual(hold.release(MAXIMUM_RELEASED_NOTICES), []);
-});
-
-test("a limit wider than the backlog changes nothing", () => {
-  const hold = new SessionNoticeHold();
-  hold.hold([notice("session-1", SESSION_NOTICE_STATUS.COMPLETE)]);
-  assert.equal(hold.release(MAXIMUM_RELEASED_NOTICES).length, 1);
 });

--- a/packages/session/src/session-notice-hold.ts
+++ b/packages/session/src/session-notice-hold.ts
@@ -7,6 +7,13 @@ import type { SessionNotice } from "./session-notices.js";
  */
 export const MAXIMUM_HELD_NOTICES = 8;
 
+/**
+ * The most notices a release hands back to be spoken at once. A quiet that
+ * gathered more has made the panel the real record, and reading eight
+ * sentences the moment a call ends is the burst the quiet existed to prevent.
+ */
+export const MAXIMUM_RELEASED_NOTICES = 3;
+
 /** What a hold needs of an item: which session it is about. */
 interface HeldForSession {
   providerId: string;
@@ -51,10 +58,15 @@ export class SessionNoticeHold<Notice extends HeldForSession = SessionNotice> {
     }
   }
 
-  /** Hands back everything held, oldest first, and holds nothing after. */
-  release(): readonly Notice[] {
+  /**
+   * Hands back what is held, oldest first, and holds nothing after. With a
+   * limit, only the newest `limit` are handed back; the rest are shed, still
+   * standing in the panel like every notice the cap shed on arrival.
+   */
+  release(limit?: number): readonly Notice[] {
     const released = this.#held;
     this.#held = [];
-    return released;
+    if (limit === undefined || released.length <= limit) return released;
+    return released.slice(released.length - Math.max(0, limit));
   }
 }

--- a/packages/session/src/session-notice-hold.ts
+++ b/packages/session/src/session-notice-hold.ts
@@ -58,15 +58,10 @@ export class SessionNoticeHold<Notice extends HeldForSession = SessionNotice> {
     }
   }
 
-  /**
-   * Hands back what is held, oldest first, and holds nothing after. With a
-   * limit, only the newest `limit` are handed back; the rest are shed, still
-   * standing in the panel like every notice the cap shed on arrival.
-   */
-  release(limit?: number): readonly Notice[] {
+  /** Hands back what is held, oldest first, and holds nothing after. */
+  release(): readonly Notice[] {
     const released = this.#held;
     this.#held = [];
-    if (limit === undefined || released.length <= limit) return released;
-    return released.slice(released.length - Math.max(0, limit));
+    return released;
   }
 }

--- a/packages/settings/src/schema.ts
+++ b/packages/settings/src/schema.ts
@@ -581,14 +581,14 @@ export const APP_SETTING_SCHEMA = {
       [APP_SETTING_ID.QUIET_DURING_MEETINGS],
       (settings, defaultValue) => ({
         id: APP_SETTING_ID.QUIET_DURING_MEETINGS,
-        label: "Quiet during meetings",
+        label: "Quiet during meetings and calls",
         description:
-          "Whether spoken announcements wait while a connected calendar shows a meeting on, then read out together once it ends. Switched on mid-meeting it takes hold at once. It changes nothing until a calendar — a Google Calendar account, or this Mac's Apple Calendar — is connected.",
+          "Whether spoken announcements wait while a connected calendar shows a meeting on, or while another app is using this Mac's microphone, then read out together once it ends. The microphone is read as one yes-or-no from macOS, never as audio, and the quiet lifts a few seconds after the call ends. Switched on mid-meeting or mid-call it takes hold at once. The call part needs no calendar; the meeting part needs a Google Calendar account or this Mac's Apple Calendar connected.",
         kind: APP_SETTING_KIND.TOGGLE,
         value: appToggleText(guideValue<boolean>(settings, "quietDuringMeetings")),
         defaultValue: appToggleText(defaultValue),
         adjustable: true,
-        manual: `${CONNECTIONS_PAGE} — drawn once a calendar is connected`,
+        manual: CONNECTIONS_PAGE,
       }),
     ),
     mainProcessSideEffect: SETTING_SIDE_EFFECT.MEETING_QUIET,


### PR DESCRIPTION
## Summary

- Adds a native macOS helper (`InputCapture.swift`) that reports one boolean, whether any process is capturing from an input device, read from CoreAudio's running flag or a Bluetooth output's drop to its call codec, with no audio, device name, or process name.
- A pure gate (`call-quiet.ts`) turns a foreign capture, Luke's own exchange excluded, into a hold after a short onset that releases a fixed grace after capture stops.
- The hold pools with calendar meetings under the existing quiet flag, so the sleeping face, the announcer, and the same setting govern both; a released backlog now speaks its newest three rather than eight.
- Updates `AGENTS.md`, `PRIVACY.md`, and the README to disclose the new read.

## Evidence

- Platform-independent checks: `not run`
- macOS Electron verification (`./scripts/verify.sh`): `not run`

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/33683636425/artifacts/9867326112) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/33683636425)

- Commit: `4bd8d349becb7065bb704b4fdff2c07e925c1a86`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

### Physical-device evidence

- Screenshot or screen recording: `not attached`
- Physical-notch check: `not performed`
- Device/display configuration: `not recorded`

## Notes

- Blockers or follow-up verification: None

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/c7503bed-7d47-4784-a2d0-addb50de592c)
