### PR TITLE
feat(desktop): add a dev-only harness for driving app state without live sessions

### DIFF
--- a/apps/desktop/src/main/desktop-app.ts
+++ b/apps/desktop/src/main/desktop-app.ts
@@ -144,6 +144,7 @@ import {
   calendarOnboardingStateFromStored,
   shouldBackfillCalendarOnboardingSettled,
 } from "./calendar-onboarding-flow";
+import { DevHarness } from "./dev-harness";
 import {
   INTRODUCTION_FADE_MS,
   INTRODUCTION_HANDOFF_READY_MS,
@@ -502,6 +503,27 @@ const agentTrace = agentTraceDirectory
   ? new AgentTraceWriter({ directory: agentTraceDirectory })
   : undefined;
 if (agentTrace) process.stderr.write(`Agent trace: ${agentTrace.file}\n`);
+/*
+ * Dev control channel — same gate as the trace writer. Accepts JSON commands
+ * over a Unix socket so a developer can drive session state and the input-
+ * capture override without a live provider session. Nothing is constructed for
+ * a packaged build or a fixture/evidence run; the socket path comes from
+ * LUKE_DEV_HARNESS_SOCK, which run.sh sets by default.
+ */
+const devHarnessSocketPath =
+  app.isPackaged || !runMode.sendsNetwork ? undefined : process.env.LUKE_DEV_HARNESS_SOCK;
+let devHarness: DevHarness | undefined;
+if (devHarnessSocketPath) {
+  const harness = new DevHarness({
+    socketPath: devHarnessSocketPath,
+    onSessionChanged: () => void sessionRegistry.refresh(harness.adapter),
+    // Wire to CallQuietGate.setCapturing when the call-quiet branch lands.
+    onCaptureCommand: (on) =>
+      process.stderr.write(`[dev-harness] capture override: ${on ? "on" : "off"}\n`),
+  });
+  harness.start();
+  devHarness = harness;
+}
 const voiceCapabilities = new VoiceCapabilityAssembler({
   settings: settingsStore,
   credentialsUsable: () => runMode.sendsNetwork && accountCapabilitiesActive(),
@@ -3007,6 +3029,7 @@ export function startDesktopApp(): void {
     // nothing.
     mediaDuck.stop();
     supersetSignIn.shutdown();
+    devHarness?.stop();
   });
 
   app.on("before-quit", () => {

--- a/apps/desktop/src/main/dev-harness.test.ts
+++ b/apps/desktop/src/main/dev-harness.test.ts
@@ -1,0 +1,223 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import net from "node:net";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { SESSION_STATUS } from "@sidecar/session";
+import { isWireBoolean, isWireString } from "@sidecar/wire";
+import { DevHarness } from "./dev-harness";
+
+interface HarnessReply {
+  ok: boolean;
+  error?: string;
+}
+
+type SessionCommand = { cmd: "session"; status: string };
+type CaptureCommand = { cmd: "capture"; on: boolean };
+type BadCommand = { cmd: string };
+type HarnessCommand = SessionCommand | CaptureCommand | BadCommand;
+
+function tmpSocket(): string {
+  return path.join(os.tmpdir(), `dev-harness-test-${process.pid}-${Date.now()}.sock`);
+}
+
+function send(socketPath: string, payload: HarnessCommand): Promise<HarnessReply> {
+  return new Promise((resolve, reject) => {
+    const socket = net.createConnection(socketPath, () => {
+      socket.write(`${JSON.stringify(payload)}\n`);
+    });
+    socket.setEncoding("utf8");
+    let buf = "";
+    socket.on("data", (chunk: string) => {
+      buf += chunk;
+      const nl = buf.indexOf("\n");
+      if (nl === -1) return;
+      try {
+        // SAFETY: JSON.parse returns the runtime shape the harness sent; HarnessReply mirrors it.
+        resolve(JSON.parse(buf.slice(0, nl)) as HarnessReply);
+      } catch (err) {
+        reject(err);
+      }
+    });
+    socket.on("error", reject);
+  });
+}
+
+test("session waiting sets observation and calls onSessionChanged", async () => {
+  const socketPath = tmpSocket();
+  let changed = 0;
+  const harness = new DevHarness({
+    socketPath,
+    onSessionChanged: () => {
+      changed += 1;
+    },
+    onCaptureCommand: () => {},
+  });
+  harness.start();
+
+  const reply = await send(socketPath, { cmd: "session", status: "waiting" });
+  assert.deepEqual(reply, { ok: true });
+  assert.equal(changed, 1);
+
+  const observations = await harness.adapter.observe();
+  const obs = observations.at(0);
+  assert.ok(obs);
+  assert.equal(obs.status, SESSION_STATUS.WAITING);
+  assert.equal(obs.holdingForDeveloper, true);
+
+  harness.stop();
+});
+
+test("session error sets error status", async () => {
+  const socketPath = tmpSocket();
+  const harness = new DevHarness({
+    socketPath,
+    onSessionChanged: () => {},
+    onCaptureCommand: () => {},
+  });
+  harness.start();
+
+  await send(socketPath, { cmd: "session", status: "error" });
+  const observations = await harness.adapter.observe();
+  const obs = observations.at(0);
+  assert.ok(obs);
+  assert.equal(obs.status, SESSION_STATUS.ERROR);
+
+  harness.stop();
+});
+
+test("session finished sets complete status with work-finished cause", async () => {
+  const socketPath = tmpSocket();
+  const harness = new DevHarness({
+    socketPath,
+    onSessionChanged: () => {},
+    onCaptureCommand: () => {},
+  });
+  harness.start();
+
+  await send(socketPath, { cmd: "session", status: "finished" });
+  const observations = await harness.adapter.observe();
+  const obs = observations.at(0);
+  assert.ok(obs);
+  assert.equal(obs.status, SESSION_STATUS.COMPLETE);
+  assert.equal(obs.completionCause, "work-finished");
+
+  harness.stop();
+});
+
+test("capture command calls onCaptureCommand with boolean", async () => {
+  const socketPath = tmpSocket();
+  const captured: boolean[] = [];
+  const harness = new DevHarness({
+    socketPath,
+    onSessionChanged: () => {},
+    onCaptureCommand: (on) => {
+      captured.push(on);
+    },
+  });
+  harness.start();
+
+  const r1 = await send(socketPath, { cmd: "capture", on: true });
+  assert.deepEqual(r1, { ok: true });
+  const r2 = await send(socketPath, { cmd: "capture", on: false });
+  assert.deepEqual(r2, { ok: true });
+  assert.deepEqual(captured, [true, false]);
+
+  harness.stop();
+});
+
+test("unknown cmd returns error", async () => {
+  const socketPath = tmpSocket();
+  const harness = new DevHarness({
+    socketPath,
+    onSessionChanged: () => {},
+    onCaptureCommand: () => {},
+  });
+  harness.start();
+
+  const reply = await send(socketPath, { cmd: "explode" });
+  assert.equal(reply.ok, false);
+  assert.equal(isWireString(reply.error), true);
+
+  harness.stop();
+});
+
+test("unknown session status returns error", async () => {
+  const socketPath = tmpSocket();
+  const harness = new DevHarness({
+    socketPath,
+    onSessionChanged: () => {},
+    onCaptureCommand: () => {},
+  });
+  harness.start();
+
+  const reply = await send(socketPath, { cmd: "session", status: "bogus" });
+  assert.equal(reply.ok, false);
+
+  harness.stop();
+});
+
+test("capture with non-boolean on returns error", async () => {
+  const socketPath = tmpSocket();
+  const harness = new DevHarness({
+    socketPath,
+    onSessionChanged: () => {},
+    onCaptureCommand: () => {},
+  });
+  harness.start();
+
+  // SAFETY: deliberately sending a malformed capture command to exercise error handling.
+  const malformed = { cmd: "capture", on: "yes" } as unknown as CaptureCommand;
+  const reply = await send(socketPath, malformed);
+  assert.equal(reply.ok, false);
+  assert.equal(isWireBoolean(reply.error), false);
+
+  harness.stop();
+});
+
+test("stop removes the socket file", async () => {
+  const socketPath = tmpSocket();
+  const harness = new DevHarness({
+    socketPath,
+    onSessionChanged: () => {},
+    onCaptureCommand: () => {},
+  });
+  harness.start();
+  // Wait for it to bind.
+  await send(socketPath, { cmd: "session", status: "waiting" });
+
+  harness.stop();
+  assert.equal(fs.existsSync(socketPath), false);
+});
+
+test("start removes stale socket from previous run", async () => {
+  const socketPath = tmpSocket();
+  fs.writeFileSync(socketPath, "stale");
+
+  const harness = new DevHarness({
+    socketPath,
+    onSessionChanged: () => {},
+    onCaptureCommand: () => {},
+  });
+  harness.start();
+  // If the stale file blocked bind, this would throw.
+  await send(socketPath, { cmd: "session", status: "waiting" });
+
+  harness.stop();
+});
+
+test("adapter starts empty before any command", async () => {
+  const socketPath = tmpSocket();
+  const harness = new DevHarness({
+    socketPath,
+    onSessionChanged: () => {},
+    onCaptureCommand: () => {},
+  });
+  harness.start();
+
+  const observations = await harness.adapter.observe();
+  assert.equal(observations.length, 0);
+
+  harness.stop();
+});

--- a/apps/desktop/src/main/dev-harness.ts
+++ b/apps/desktop/src/main/dev-harness.ts
@@ -1,0 +1,193 @@
+import fs from "node:fs";
+import net from "node:net";
+import path from "node:path";
+import {
+  type ProviderSessionObservation,
+  SESSION_COMPLETION_CAUSE,
+  SESSION_STATUS,
+  type SessionProvider,
+} from "@sidecar/session";
+import { isRecord, isWireBoolean, isWireString, type WireValue } from "@sidecar/wire";
+
+export const DEV_HARNESS_SESSION_COMMAND = {
+  WAITING: "waiting",
+  ERROR: "error",
+  FINISHED: "finished",
+} as const;
+
+export type DevHarnessSessionCommand =
+  (typeof DEV_HARNESS_SESSION_COMMAND)[keyof typeof DEV_HARNESS_SESSION_COMMAND];
+
+export interface DevHarnessOptions {
+  socketPath: string;
+  /** Called after the synthetic session observation is updated. */
+  onSessionChanged(): void;
+  /**
+   * Called when a capture override command arrives. The caller wires this to
+   * whatever gate reads the capture state — on the main branch a log is
+   * enough; on a branch with the call-quiet gate, wire it to
+   * `CallQuietGate.setCapturing`.
+   */
+  onCaptureCommand(on: boolean): void;
+}
+
+/** Synthetic provider used exclusively by the dev harness. */
+const DEV_PROVIDER: SessionProvider = {
+  id: "dev-harness",
+  displayName: "Dev Harness",
+};
+
+const DEV_SESSION_ID = "dev-session";
+
+type DevHarnessAdapter = Pick<
+  { provider: SessionProvider; observe(): Promise<readonly ProviderSessionObservation[]> },
+  "provider" | "observe"
+>;
+
+interface HarnessReply {
+  ok: boolean;
+  error?: string;
+}
+
+/**
+ * Dev-only control channel, gated the same way as {@link AgentTraceWriter}:
+ * only an unpackaged live run constructs one. A Unix socket at `socketPath`
+ * accepts JSON commands and calls injected callbacks so real announcement
+ * paths can be exercised without a live provider session.
+ *
+ * Commands (newline-terminated JSON, one per connection):
+ *   `{"cmd":"session","status":"waiting"|"error"|"finished"}`
+ *   `{"cmd":"capture","on":true|false}`
+ *
+ * Each command receives a `{"ok":true}` or `{"ok":false,"error":"..."}` reply.
+ */
+export class DevHarness {
+  #observation: ProviderSessionObservation | undefined;
+  #server: net.Server | undefined;
+  readonly #options: DevHarnessOptions;
+
+  constructor(options: DevHarnessOptions) {
+    this.#options = options;
+  }
+
+  /** The synthetic adapter to pass to `sessionRegistry.refresh`. */
+  readonly adapter: DevHarnessAdapter = {
+    provider: DEV_PROVIDER,
+    observe: async () => (this.#observation ? [this.#observation] : []),
+  };
+
+  /**
+   * Binds the socket and prints its path to stderr. Any socket file left from
+   * a previous run is removed first so bind does not fail on a stale path.
+   */
+  start(): void {
+    const { socketPath } = this.#options;
+    fs.mkdirSync(path.dirname(socketPath), { recursive: true });
+    try {
+      fs.unlinkSync(socketPath);
+    } catch {
+      // No leftover socket to remove.
+    }
+    const server = net.createServer((socket) => this.#onConnection(socket));
+    server.listen(socketPath, () => {
+      process.stderr.write(`Dev harness: ${socketPath}\n`);
+    });
+    this.#server = server;
+  }
+
+  stop(): void {
+    this.#server?.close();
+    this.#server = undefined;
+    try {
+      fs.unlinkSync(this.#options.socketPath);
+    } catch {
+      // Already removed.
+    }
+  }
+
+  #onConnection(socket: net.Socket): void {
+    let buffer = "";
+    socket.setEncoding("utf8");
+    socket.on("data", (chunk: string) => {
+      buffer += chunk;
+      const newline = buffer.indexOf("\n");
+      if (newline === -1) return;
+      const line = buffer.slice(0, newline);
+      buffer = buffer.slice(newline + 1);
+      this.#handleCommand(line, socket);
+    });
+  }
+
+  #handleCommand(line: string, socket: net.Socket): void {
+    let raw: WireValue | undefined;
+    try {
+      // SAFETY: JSON.parse returns a runtime value; isRecord validates the contract below.
+      raw = JSON.parse(line) as WireValue;
+    } catch {
+      this.#reply(socket, { ok: false, error: "invalid JSON" });
+      return;
+    }
+    if (!isRecord(raw)) {
+      this.#reply(socket, { ok: false, error: "missing cmd" });
+      return;
+    }
+    const cmd = raw.cmd;
+    if (cmd === "session") {
+      this.#reply(socket, this.#applySession(raw.status));
+      return;
+    }
+    if (cmd === "capture") {
+      if (!isWireBoolean(raw.on)) {
+        this.#reply(socket, { ok: false, error: "capture.on must be a boolean" });
+        return;
+      }
+      this.#options.onCaptureCommand(raw.on);
+      this.#reply(socket, { ok: true });
+      return;
+    }
+    this.#reply(socket, {
+      ok: false,
+      error: `unknown cmd: ${isWireString(cmd) ? cmd : String(cmd)}`,
+    });
+  }
+
+  #reply(socket: net.Socket, payload: HarnessReply): void {
+    socket.write(`${JSON.stringify(payload)}\n`);
+    socket.end();
+  }
+
+  #applySession(status: WireValue | undefined): HarnessReply {
+    const now = Date.now();
+    if (status === DEV_HARNESS_SESSION_COMMAND.WAITING) {
+      this.#observation = {
+        providerSessionId: DEV_SESSION_ID,
+        title: "Dev session",
+        status: SESSION_STATUS.WAITING,
+        observedAt: now,
+        holdingForDeveloper: true,
+      };
+    } else if (status === DEV_HARNESS_SESSION_COMMAND.ERROR) {
+      this.#observation = {
+        providerSessionId: DEV_SESSION_ID,
+        title: "Dev session",
+        status: SESSION_STATUS.ERROR,
+        observedAt: now,
+      };
+    } else if (status === DEV_HARNESS_SESSION_COMMAND.FINISHED) {
+      this.#observation = {
+        providerSessionId: DEV_SESSION_ID,
+        title: "Dev session",
+        status: SESSION_STATUS.COMPLETE,
+        completionCause: SESSION_COMPLETION_CAUSE.WORK_FINISHED,
+        observedAt: now,
+      };
+    } else {
+      return {
+        ok: false,
+        error: `unknown session status: ${isWireString(status) ? status : String(status)}; use waiting, error, or finished`,
+      };
+    }
+    this.#options.onSessionChanged();
+    return { ok: true };
+  }
+}

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "scripts": {
     "build": "pnpm --recursive --if-present run build",
     "check": "pnpm lint && pnpm typecheck && pnpm test && pnpm build",
+    "dev:emit": "node scripts/dev-emit.mjs",
     "evidence:record": "node scripts/record-evidence.mjs",
     "format": "biome format --write .",
     "lint": "biome check . && pnpm oxlint",

--- a/scripts/dev-emit.mjs
+++ b/scripts/dev-emit.mjs
@@ -1,0 +1,92 @@
+#!/usr/bin/env node
+/**
+ * Sends a command to the dev harness socket of a running Luke instance.
+ *
+ * Usage:
+ *   pnpm dev:emit session waiting    # push a waiting session (holds for developer)
+ *   pnpm dev:emit session error      # push an error session
+ *   pnpm dev:emit session finished   # push a finished session
+ *   pnpm dev:emit capture on         # override: another app is using the mic
+ *   pnpm dev:emit capture off        # override: mic is free
+ *
+ * The app must be running via ./scripts/run.sh. The socket path defaults to
+ * .build/dev-harness.sock under the repo root (set by run.sh), or reads
+ * LUKE_DEV_HARNESS_SOCK from the environment.
+ */
+import net from "node:net";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.join(path.dirname(fileURLToPath(import.meta.url)), "..");
+const socketPath =
+  process.env.LUKE_DEV_HARNESS_SOCK ?? path.join(repoRoot, ".build", "dev-harness.sock");
+
+const [cmd, arg] = process.argv.slice(2);
+
+if (!cmd || !arg) {
+  process.stderr.write(
+    `Usage: pnpm dev:emit <cmd> <arg>
+
+Commands:
+  session waiting    Push a waiting session (holds for developer)
+  session error      Push an error session
+  session finished   Push a finished session
+  capture on         Override: another app is using the microphone
+  capture off        Override: microphone is free
+
+The app must be running via ./scripts/run.sh.
+`,
+  );
+  process.exit(1);
+}
+
+/** @type {object} */
+let payload;
+if (cmd === "session") {
+  const valid = ["waiting", "error", "finished"];
+  if (!valid.includes(arg)) {
+    process.stderr.write(`session status must be one of: ${valid.join(", ")}\n`);
+    process.exit(1);
+  }
+  payload = { cmd: "session", status: arg };
+} else if (cmd === "capture") {
+  if (arg !== "on" && arg !== "off") {
+    process.stderr.write(`capture arg must be 'on' or 'off'\n`);
+    process.exit(1);
+  }
+  payload = { cmd: "capture", on: arg === "on" };
+} else {
+  process.stderr.write(`Unknown command: ${cmd}\nRun with no args to see usage.\n`);
+  process.exit(1);
+}
+
+const socket = net.createConnection(socketPath, () => {
+  socket.write(`${JSON.stringify(payload)}\n`);
+});
+socket.setEncoding("utf8");
+let buf = "";
+socket.on("data", (chunk) => {
+  buf += chunk;
+  const nl = buf.indexOf("\n");
+  if (nl === -1) return;
+  let response;
+  try {
+    response = JSON.parse(buf.slice(0, nl));
+  } catch {
+    process.stderr.write(`Bad response from harness\n`);
+    process.exit(1);
+  }
+  if (response.ok) {
+    process.stdout.write(`ok\n`);
+    process.exit(0);
+  } else {
+    process.stderr.write(`error: ${response.error}\n`);
+    process.exit(1);
+  }
+});
+socket.on("error", () => {
+  process.stderr.write(
+    `Could not connect to dev harness at ${socketPath}\nIs the app running? Start it with ./scripts/run.sh\n`,
+  );
+  process.exit(1);
+});

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -40,6 +40,15 @@ if [[ $capture_trace == true && -z ${LUKE_TRACE_DIR:-} ]]; then
     export LUKE_TRACE_DIR="$SIDECAR_REPO_ROOT/.build/traces"
 fi
 
+# Dev control channel: the app listens here for session-state and capture-
+# override commands from `pnpm dev:emit`. A pre-existing value wins so a
+# developer can point the CLI at a custom path. Only an unpackaged live run
+# honours the variable at all, so a fixture run or a packaged build ignores
+# it however this is set.
+if [[ -z ${LUKE_DEV_HARNESS_SOCK:-} ]]; then
+    export LUKE_DEV_HARNESS_SOCK="$SIDECAR_REPO_ROOT/.build/dev-harness.sock"
+fi
+
 if [[ $replace_running_app == true ]]; then
     sidecar_stop_running_app
 fi


### PR DESCRIPTION
## Summary

- Adds `DevHarness`, a Unix-socket control channel constructed only for unpackaged live runs (same gate as `AgentTraceWriter`), so a packaged build carries nothing to switch off
- Adds `pnpm dev:emit` CLI (`scripts/dev-emit.mjs`) that connects to the socket and sends one JSON command, then exits with `ok` or an error message
- Wires the harness into `desktop-app.ts` after the agent-trace section; session commands feed a synthetic `SessionProviderAdapter` directly into `sessionRegistry`, which triggers the full notice/announcement path without any provider; capture commands call an injected callback (logged to stderr on this branch, wirable to `CallQuietGate.setCapturing` in one line when the call-quiet branch lands)
- `run.sh` exports `LUKE_DEV_HARNESS_SOCK` by default (parallel to `LUKE_TRACE_DIR`); the CLI defaults to `.build/dev-harness.sock` relative to repo root so `pnpm dev:emit` works from any terminal in the repo without extra setup

## Testing the call-quiet feature end to end

With the `charleslpan/daegu` branch merged, wire the capture override in `desktop-app.ts`:

```diff
- onCaptureCommand: (on) =>
-   process.stderr.write(`[dev-harness] capture override: ${on ? "on" : "off"}\n`),
+ onCaptureCommand: (on) => callQuietGate.setCapturing(on),
```

Then, in one terminal:

```bash
./scripts/run.sh          # start the app (signs in, enables voice)
```

In a second terminal:

```bash
# Simulate "another app grabbed the mic" — starts the 3 s onset timer
pnpm dev:emit capture on

# 3 s later the gate holds; now push a waiting session — announcement is queued
pnpm dev:emit session waiting

# Confirm it was held (not spoken yet), then release the mic hold
pnpm dev:emit capture off

# 15 s grace expires — announcement speaks; Luke names the waiting dev session
```

To test that a finished session still announces when the mic is clear:

```bash
pnpm dev:emit session finished   # speaks immediately if no hold is active
```

## Test plan

- [x] `./scripts/check.sh` clean (lint, typecheck, 848 tests pass, build succeeds)
- [ ] `./scripts/verify.sh` — requires macOS; cannot run in this Linux cloud environment. The harness is gated to `!app.isPackaged && runMode.sendsNetwork`, so fixture and evidence runs are unaffected and visual evidence is unchanged.
- [ ] Manual smoke: `./scripts/run.sh`, `pnpm dev:emit session waiting` → session row appears, announcement fires (requires macOS + signed-in account)
- [ ] Manual smoke: `pnpm dev:emit capture on/off` → `[dev-harness] capture override: on/off` in stderr (main branch stub)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/b3512196-44a2-4313-bbe4-d25600146d00)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/33694375227/artifacts/9871288292) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/33694375227)

- Commit: `cff16836e36efed3e811b12997e6704bc52715e9`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
