### PR TITLE
fix(ios): keep API capitalized in the key editor placeholder

### DIFF
--- a/apps/ios/Luke/VaultView.swift
+++ b/apps/ios/Luke/VaultView.swift
@@ -113,7 +113,7 @@ struct VaultKeyEditor: View {
                 }
 
                 Section {
-                    SecureField("Paste \(credentialNoun.lowercased())", text: $key)
+                    SecureField("Paste \(credentialNoun)", text: $key)
                         .textInputAutocapitalization(.never)
                         .autocorrectionDisabled()
                 } footer: {


### PR DESCRIPTION
## Summary

- The provider key sheet's secure field lowercased the credential noun, so the placeholder read "Paste api key". It now reads "Paste API key".
- The label already carries the casing the provider itself uses (the doc comment on `VaultKeyFormat.label` says as much), so the field interpolates it unchanged rather than lowercasing it.

## Test plan

- [ ] CI iOS build passes (no Swift toolchain in the cloud sandbox; the change is a one-line string interpolation).
- [ ] Open Profile → provider row → key sheet on device and confirm the placeholder reads "Paste API key". No physical-device check was performed from this environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/33710220380/artifacts/9876708843) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/33710220380)

- Commit: `74845c32d5f46ff8af6b2dac02decc6f10e168c6`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
