### PR TITLE
fix(hosted): list only the providers the vault still accepts

### DIFF
--- a/apps/web/server/hosted/vault.ts
+++ b/apps/web/server/hosted/vault.ts
@@ -119,11 +119,18 @@ export async function handleVaultKeysList(options: VaultKeysListOptions): Promis
 
   const rows = await listKeys(userId);
 
+  // The table outlives the provider set: a key stored for a provider this
+  // build no longer accepts still has a row, and both clients' readers drop
+  // the whole answer on an id they do not know. The list answers only for
+  // the providers the wire contract names, and a stale row is held silently
+  // rather than surfaced as a key that cannot be deleted or used.
   return jsonResponse(HOSTED_HTTP_STATUS.OK, {
-    keys: rows.map((row) => ({
-      providerId: row.providerId,
-      updatedAt: row.updatedAt.getTime(),
-    })),
+    keys: rows
+      .filter((row) => isVaultProviderId(row.providerId))
+      .map((row) => ({
+        providerId: row.providerId,
+        updatedAt: row.updatedAt.getTime(),
+      })),
   });
 }
 

--- a/apps/web/tests/hosted-vault.test.ts
+++ b/apps/web/tests/hosted-vault.test.ts
@@ -217,6 +217,24 @@ test("the list answer never contains ciphertext or plaintext keys", async () => 
   assert.doesNotMatch(JSON.stringify(body), /ciphertext/);
 });
 
+test("the list omits rows stored for a provider the vault no longer accepts", async () => {
+  const response = await handleVaultKeysList(
+    listOptions({
+      listKeys: async () => [
+        { providerId: "cursor", updatedAt: NOW_DATE },
+        { providerId: VAULT_PROVIDER_ID.CONDUCTOR, updatedAt: NOW_DATE },
+        { providerId: "devin", updatedAt: NOW_DATE },
+      ],
+    }),
+  );
+
+  assert.equal(response.status, 200);
+  const body = await response.json();
+  assert.deepEqual(body.keys, [
+    { providerId: VAULT_PROVIDER_ID.CONDUCTOR, updatedAt: NOW_DATE.getTime() },
+  ]);
+});
+
 test("the list calls the seam with the resolved user id", async () => {
   let calledWithUserId: string | undefined;
 


### PR DESCRIPTION
## Summary

The Provider keys section on iOS (simulators and device) showed "The vault answered with something unexpected. Try again later." for any account that had ever stored a key for a provider the vault no longer accepts, while Conductor sessions kept observing fine.

- #645 narrowed `VAULT_PROVIDER_ID` to Conductor, but `provider_key` rows stored earlier for cursor, devin, copilot, jules, or replicas are still there.
- `GET /api/vault/keys` answered every row, and both the iOS `VaultClient.listKeys` and the desktop `vaultKeysListAnswerFromWire` reader deliberately drop the whole answer on an unknown provider id.
- Observe and projects never hit this because they look up ciphertext by adapter id, so stale rows were simply never read there.

The list handler now filters rows to `isVaultProviderId` before answering, so the endpoint's answer matches the wire contract both readers enforce. Stale rows stay in the table untouched; whether to purge them is a separate decision.

## Test plan

- [x] New test: the list omits rows stored for a provider the vault no longer accepts
- [x] `./scripts/check.sh` passes
- [ ] Reopen Profile on iOS against the deployed service and confirm the Conductor row draws without the error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/eb2ffe6a-fc77-4ca2-8b46-cc1650a10ad5)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/33710328043/artifacts/9876735243) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/33710328043)

- Commit: `cfcc555cbf51138062a0827049deb193b7d9bbc2`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
