### PR TITLE
feat(ios): add voice settings sheet to the voice screen

### DIFF
--- a/apps/ios/Luke.xcodeproj/project.pbxproj
+++ b/apps/ios/Luke.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		AABBCC0000000000000000D5 /* VoiceAudioCapturer.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABBCC0000000000000000D1 /* VoiceAudioCapturer.swift */; };
 		AABBCC0000000000000000D6 /* VoiceAudioPlayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABBCC0000000000000000D2 /* VoiceAudioPlayer.swift */; };
 		AABBCC0000000000000000D7 /* VoiceActDispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABBCC0000000000000000D3 /* VoiceActDispatcher.swift */; };
+		AABBCC0000000000000000D9 /* VoiceSettingsSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABBCC0000000000000000D8 /* VoiceSettingsSheet.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -62,6 +63,7 @@
 		AABBCC0000000000000000D1 /* VoiceAudioCapturer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceAudioCapturer.swift; sourceTree = "<group>"; };
 		AABBCC0000000000000000D2 /* VoiceAudioPlayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceAudioPlayer.swift; sourceTree = "<group>"; };
 		AABBCC0000000000000000D3 /* VoiceActDispatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceActDispatcher.swift; sourceTree = "<group>"; };
+		AABBCC0000000000000000D8 /* VoiceSettingsSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceSettingsSheet.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -132,6 +134,7 @@
 				AABBCC0000000000000000D1 /* VoiceAudioCapturer.swift */,
 				AABBCC0000000000000000D2 /* VoiceAudioPlayer.swift */,
 				AABBCC0000000000000000D3 /* VoiceActDispatcher.swift */,
+				AABBCC0000000000000000D8 /* VoiceSettingsSheet.swift */,
 				AABBCC000000000000000014 /* Assets.xcassets */,
 				AABBCC00000000000000001C /* Info.plist */,
 			);
@@ -314,6 +317,7 @@
 				AABBCC0000000000000000D5 /* VoiceAudioCapturer.swift in Sources */,
 				AABBCC0000000000000000D6 /* VoiceAudioPlayer.swift in Sources */,
 				AABBCC0000000000000000D7 /* VoiceActDispatcher.swift in Sources */,
+				AABBCC0000000000000000D9 /* VoiceSettingsSheet.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/apps/ios/Luke/VoiceSettingsSheet.swift
+++ b/apps/ios/Luke/VoiceSettingsSheet.swift
@@ -1,0 +1,86 @@
+import LukeKit
+import SwiftUI
+
+/// The voice settings the desktop's Voice page offers that reach this
+/// device's own conversation: the voice Luke speaks with and how fast. In the
+/// system's own sheet vocabulary like the Filter & Sort sheet — inline title,
+/// toolbar Done, grouped form — and presented at a half height that expands.
+/// The Mac-only rows (the microphone choice, quieting Music and Spotify,
+/// pausing announcements, captions) are about a machine this app does not
+/// run on, so they are not drawn rather than drawn disabled. The two values
+/// live in UserDefaults under keys the voice screen reads too, so a change
+/// here is heard there: the voice at once, by a fresh connection, and the
+/// speed from the next reply on.
+struct VoiceSettingsSheet: View {
+    @AppStorage(VoiceSettingsKey.voice) private var voice = RealtimeVoice.default
+    @AppStorage(VoiceSettingsKey.speed) private var speed = RealtimeVoiceSpeed.default
+    @Environment(ProductEventSender.self) private var events
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section {
+                    Picker("Voice", selection: $voice) {
+                        ForEach(RealtimeVoice.allCases) { candidate in
+                            Text(candidate.displayName).tag(candidate)
+                        }
+                    }
+                } footer: {
+                    Text("A change is heard right away; a conversation under way starts afresh in the new voice.")
+                }
+
+                Section {
+                    Picker("Speed", selection: $speed) {
+                        ForEach(RealtimeVoiceSpeed.allCases) { candidate in
+                            Text(candidate.displayName).tag(candidate)
+                        }
+                    }
+                    .pickerStyle(.segmented)
+                } header: {
+                    Text("Speed")
+                } footer: {
+                    Text(speedFooter)
+                }
+
+                if isChanged {
+                    Section {
+                        Button("Reset to Defaults") { resetToDefaults() }
+                            .frame(maxWidth: .infinity)
+                            .tint(Color.ink)
+                    }
+                }
+            }
+            .animation(.default, value: isChanged)
+            .navigationTitle("Voice Settings")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Done") { dismiss() }
+                        .tint(Color.ink)
+                }
+            }
+        }
+        .onChange(of: voice) { events.record(.settingUpdate(setting: .voice, value: .set)) }
+        .onChange(of: speed) { events.record(.settingUpdate(setting: .voiceSpeed, value: .set)) }
+    }
+
+    private var isChanged: Bool {
+        voice != RealtimeVoice.default || speed != RealtimeVoiceSpeed.default
+    }
+
+    /// The chosen pace as a multiple of the voice's natural rate, so the
+    /// segment's one word is explained in the footer beneath it.
+    private var speedFooter: String {
+        let rate = speed == .normal
+            ? "The voice's natural rate."
+            : "\(speed.multipleLabel) the voice's natural rate."
+        return "\(rate) A change is heard from the next reply on."
+    }
+
+    private func resetToDefaults() {
+        voice = RealtimeVoice.default
+        speed = RealtimeVoiceSpeed.default
+        events.record(.settingsReset)
+    }
+}

--- a/apps/ios/Luke/VoiceSettingsSheet.swift
+++ b/apps/ios/Luke/VoiceSettingsSheet.swift
@@ -10,7 +10,8 @@ import SwiftUI
 /// run on, so they are not drawn rather than drawn disabled. The two values
 /// live in UserDefaults under keys the voice screen reads too, so a change
 /// here is heard there: the voice at once, by a fresh connection, and the
-/// speed from the next reply on.
+/// speed from the next reply on. The speed is a slider over the vocabulary's
+/// four multiples, labelled in numbers, stepping so it lands on nothing between.
 struct VoiceSettingsSheet: View {
     @AppStorage(VoiceSettingsKey.voice) private var voice = RealtimeVoice.default
     @AppStorage(VoiceSettingsKey.speed) private var speed = RealtimeVoiceSpeed.default
@@ -31,16 +32,23 @@ struct VoiceSettingsSheet: View {
                 }
 
                 Section {
-                    Picker("Speed", selection: $speed) {
-                        ForEach(RealtimeVoiceSpeed.allCases) { candidate in
-                            Text(candidate.displayName).tag(candidate)
-                        }
+                    LabeledContent("Speed", value: speed.multipleLabel)
+                    Slider(
+                        value: speedMultiplier,
+                        in: RealtimeVoiceSpeed.multiplierRange,
+                        step: RealtimeVoiceSpeed.multiplierStep
+                    ) {
+                        Text("Speed")
+                    } minimumValueLabel: {
+                        Text(RealtimeVoiceSpeed.slow.multipleLabel)
+                    } maximumValueLabel: {
+                        Text(RealtimeVoiceSpeed.fast.multipleLabel)
                     }
-                    .pickerStyle(.segmented)
-                } header: {
-                    Text("Speed")
+                    .font(.footnote)
+                    .foregroundStyle(Color.inkSecondary)
+                    .accessibilityValue(speed.multipleLabel)
                 } footer: {
-                    Text(speedFooter)
+                    Text("Times the voice's natural rate. A change is heard from the next reply on.")
                 }
 
                 if isChanged {
@@ -69,13 +77,16 @@ struct VoiceSettingsSheet: View {
         voice != RealtimeVoice.default || speed != RealtimeVoiceSpeed.default
     }
 
-    /// The chosen pace as a multiple of the voice's natural rate, so the
-    /// segment's one word is explained in the footer beneath it.
-    private var speedFooter: String {
-        let rate = speed == .normal
-            ? "The voice's natural rate."
-            : "\(speed.multipleLabel) the voice's natural rate."
-        return "\(rate) A change is heard from the next reply on."
+    /// The slider's steps are the vocabulary's multiples and nothing between,
+    /// so every value it can settle on reads back as a speed; one that does
+    /// not is left unstored rather than sent for the mint to refuse.
+    private var speedMultiplier: Binding<Double> {
+        Binding(
+            get: { speed.multiplier },
+            set: { value in
+                if let step = RealtimeVoiceSpeed(multiplier: value) { speed = step }
+            }
+        )
     }
 
     private func resetToDefaults() {

--- a/apps/ios/Luke/VoiceSettingsSheet.swift
+++ b/apps/ios/Luke/VoiceSettingsSheet.swift
@@ -22,7 +22,7 @@ struct VoiceSettingsSheet: View {
         NavigationStack {
             Form {
                 Section {
-                    Picker("Voice", selection: $voice) {
+                    Picker("Voice", selection: voiceChoice) {
                         ForEach(RealtimeVoice.allCases) { candidate in
                             Text(candidate.displayName).tag(candidate)
                         }
@@ -69,12 +69,24 @@ struct VoiceSettingsSheet: View {
                 }
             }
         }
-        .onChange(of: voice) { events.record(.settingUpdate(setting: .voice, value: .set)) }
-        .onChange(of: speed) { events.record(.settingUpdate(setting: .voiceSpeed, value: .set)) }
     }
 
     private var isChanged: Bool {
         voice != RealtimeVoice.default || speed != RealtimeVoiceSpeed.default
+    }
+
+    // Each control counts its own change, so a reset counts once as a reset
+    // rather than once more per field it moved, the way the desktop counts.
+
+    private var voiceChoice: Binding<RealtimeVoice> {
+        Binding(
+            get: { voice },
+            set: { chosen in
+                guard chosen != voice else { return }
+                voice = chosen
+                events.record(.settingUpdate(setting: .voice, value: .set))
+            }
+        )
     }
 
     /// The slider's steps are the vocabulary's multiples and nothing between,
@@ -84,7 +96,9 @@ struct VoiceSettingsSheet: View {
         Binding(
             get: { speed.multiplier },
             set: { value in
-                if let step = RealtimeVoiceSpeed(multiplier: value) { speed = step }
+                guard let step = RealtimeVoiceSpeed(multiplier: value), step != speed else { return }
+                speed = step
+                events.record(.settingUpdate(setting: .voiceSpeed, value: .set))
             }
         )
     }

--- a/apps/ios/Luke/VoiceSettingsSheet.swift
+++ b/apps/ios/Luke/VoiceSettingsSheet.swift
@@ -1,17 +1,8 @@
 import LukeKit
 import SwiftUI
 
-/// The voice settings the desktop's Voice page offers that reach this
-/// device's own conversation: the voice Luke speaks with and how fast. In the
-/// system's own sheet vocabulary like the Filter & Sort sheet — inline title,
-/// toolbar Done, grouped form — and presented at a half height that expands.
-/// The Mac-only rows (the microphone choice, quieting Music and Spotify,
-/// pausing announcements, captions) are about a machine this app does not
-/// run on, so they are not drawn rather than drawn disabled. The two values
-/// live in UserDefaults under keys the voice screen reads too, so a change
-/// here is heard there: the voice at once, by a fresh connection, and the
-/// speed from the next reply on. The speed is a slider over the vocabulary's
-/// four multiples, labelled in numbers, stepping so it lands on nothing between.
+/// The desktop's voice settings that apply on this device. The Mac-only rows
+/// (microphone choice, media ducking, announcements, captions) are not drawn.
 struct VoiceSettingsSheet: View {
     @AppStorage(VoiceSettingsKey.voice) private var voice = RealtimeVoice.default
     @AppStorage(VoiceSettingsKey.speed) private var speed = RealtimeVoiceSpeed.default
@@ -75,8 +66,7 @@ struct VoiceSettingsSheet: View {
         voice != RealtimeVoice.default || speed != RealtimeVoiceSpeed.default
     }
 
-    // Each control counts its own change, so a reset counts once as a reset
-    // rather than once more per field it moved, the way the desktop counts.
+    // Each control counts its own change so a reset counts once, as a reset.
 
     private var voiceChoice: Binding<RealtimeVoice> {
         Binding(
@@ -89,9 +79,6 @@ struct VoiceSettingsSheet: View {
         )
     }
 
-    /// The slider's steps are the vocabulary's multiples and nothing between,
-    /// so every value it can settle on reads back as a speed; one that does
-    /// not is left unstored rather than sent for the mint to refuse.
     private var speedMultiplier: Binding<Double> {
         Binding(
             get: { speed.multiplier },

--- a/apps/ios/Luke/VoiceView.swift
+++ b/apps/ios/Luke/VoiceView.swift
@@ -25,9 +25,7 @@ private final class VoiceSessionModel {
     var status: RealtimeStatus = .idle
     var messages: [VoiceTranscriptMessage] = []
     var errorMessage: String?
-    // What the next mint asks for. Read at each start rather than captured
-    // once, so a reconnect after the idle close speaks in the voice and at
-    // the pace chosen since.
+    // Read at each start, so a reconnect mints with the latest choice.
     var voice = RealtimeVoice.default
     var speed = RealtimeVoiceSpeed.default
     private var session: RealtimeSession?
@@ -128,10 +126,7 @@ private final class VoiceSessionModel {
         }
     }
 
-    /// A new voice is heard right away: a connection already open was minted
-    /// in the old one, so it is closed and a fresh one opened, the way the
-    /// desktop starts a conversation under way afresh. An idle screen only
-    /// remembers the choice, and the next press mints in it.
+    /// The voice is fixed at mint time, so an open connection is reopened.
     func changeVoice(_ newVoice: RealtimeVoice, accountSession: AccountSession) async {
         guard newVoice != voice else { return }
         voice = newVoice
@@ -140,8 +135,6 @@ private final class VoiceSessionModel {
         await start(accountSession: accountSession)
     }
 
-    /// A new pace reaches the open session at once and is heard from the
-    /// next reply on; the next mint carries it too.
     func changeSpeed(_ newSpeed: RealtimeVoiceSpeed) {
         guard newSpeed != speed else { return }
         speed = newSpeed

--- a/apps/ios/Luke/VoiceView.swift
+++ b/apps/ios/Luke/VoiceView.swift
@@ -25,6 +25,11 @@ private final class VoiceSessionModel {
     var status: RealtimeStatus = .idle
     var messages: [VoiceTranscriptMessage] = []
     var errorMessage: String?
+    // What the next mint asks for. Read at each start rather than captured
+    // once, so a reconnect after the idle close speaks in the voice and at
+    // the pace chosen since.
+    var voice = RealtimeVoice.default
+    var speed = RealtimeVoiceSpeed.default
     private var session: RealtimeSession?
     private var activeTurnId: UUID?
     private var activeResponseMessageId: UUID?
@@ -39,6 +44,8 @@ private final class VoiceSessionModel {
         guard session == nil else { return }
         errorMessage = nil
 
+        let mintVoice = voice.rawValue
+        let mintSpeed = speed.multiplier
         let opts = RealtimeSessionOptions(
             requestConnection: { [weak accountSession] in
                 guard let accountSession else {
@@ -46,7 +53,7 @@ private final class VoiceSessionModel {
                 }
                 let token = try await accountSession.validAccessToken()
                 let connection = try await VoiceMintClient(baseURL: AccountConstants.serviceURL)
-                    .mint(accessToken: token)
+                    .mint(accessToken: token, voice: mintVoice, speed: mintSpeed)
                 return connection
             },
             onStatus: { [weak self] newStatus in
@@ -121,6 +128,26 @@ private final class VoiceSessionModel {
         }
     }
 
+    /// A new voice is heard right away: a connection already open was minted
+    /// in the old one, so it is closed and a fresh one opened, the way the
+    /// desktop starts a conversation under way afresh. An idle screen only
+    /// remembers the choice, and the next press mints in it.
+    func changeVoice(_ newVoice: RealtimeVoice, accountSession: AccountSession) async {
+        guard newVoice != voice else { return }
+        voice = newVoice
+        guard session != nil else { return }
+        stop()
+        await start(accountSession: accountSession)
+    }
+
+    /// A new pace reaches the open session at once and is heard from the
+    /// next reply on; the next mint carries it too.
+    func changeSpeed(_ newSpeed: RealtimeVoiceSpeed) {
+        guard newSpeed != speed else { return }
+        speed = newSpeed
+        session?.applySpeed(newSpeed.multiplier)
+    }
+
     func endTurn() {
         if reconnectingForTurn {
             endTurnAfterReconnect = true
@@ -186,10 +213,13 @@ private final class VoiceSessionModel {
 /// once to leave the microphone open and tap again to send.
 struct VoiceView: View {
     @Environment(AccountSession.self) private var accountSession
+    @AppStorage(VoiceSettingsKey.voice) private var voice = RealtimeVoice.default
+    @AppStorage(VoiceSettingsKey.speed) private var speed = RealtimeVoiceSpeed.default
     @State private var model = VoiceSessionModel()
     @State private var isPressing = false
     @State private var isLatched = false
     @State private var pressBeganAt: TimeInterval?
+    @State private var settingsShown = false
 
     var body: some View {
         ZStack {
@@ -202,8 +232,22 @@ struct VoiceView: View {
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
             ToolbarItem(placement: .principal) { statusLabel }
+            ToolbarItem(placement: .topBarTrailing) { settingsButton }
         }
-        .task { await model.start(accountSession: accountSession) }
+        .sheet(isPresented: $settingsShown) {
+            VoiceSettingsSheet()
+                .presentationDetents([.medium, .large])
+                .presentationDragIndicator(.visible)
+        }
+        .task {
+            model.voice = voice
+            model.speed = speed
+            await model.start(accountSession: accountSession)
+        }
+        .onChange(of: voice) { _, newVoice in
+            Task { await model.changeVoice(newVoice, accountSession: accountSession) }
+        }
+        .onChange(of: speed) { _, newSpeed in model.changeSpeed(newSpeed) }
         .onChange(of: model.status) { _, newStatus in
             // Connecting is part of an idle tap's active turn. Clearing here
             // would make VoiceOver lose the second-tap-to-send affordance.
@@ -213,6 +257,15 @@ struct VoiceView: View {
     }
 
     // MARK: - Sub-views
+
+    private var settingsButton: some View {
+        Button {
+            settingsShown = true
+        } label: {
+            Label("Voice Settings", systemImage: "gearshape")
+        }
+        .tint(Color.ink)
+    }
 
     private var statusLabel: some View {
         Text(statusText)

--- a/apps/ios/LukeKit/Sources/LukeKit/ProductEvents.swift
+++ b/apps/ios/LukeKit/Sources/LukeKit/ProductEvents.swift
@@ -41,6 +41,23 @@ public enum ProductSessionAct: String, Sendable {
     case agentAdd = "agent_add"
 }
 
+/// The settings this app can change, of the shared vocabulary's
+/// `APP_SETTING_ID`: the voice settings its sheet offers and nothing wider.
+public enum ProductSettingID: String, Sendable {
+    case voice
+    case voiceSpeed = "voice_speed"
+}
+
+/// The shape a setting's new value is counted in, never the value itself:
+/// whether a choice was made or returned to nothing is the whole of what
+/// travels, so the voice chosen is not a property a count could carry.
+public enum ProductSettingValue: String, Sendable {
+    case on
+    case off
+    case set
+    case cleared
+}
+
 /// The rungs every count travels on. A raw count is a weak fingerprint —
 /// "137 Codex sessions" identifies a device across days — where a rung says
 /// the same thing about adoption and says it about a crowd rather than a
@@ -71,6 +88,8 @@ public enum ProductEvent: Equatable, Sendable {
     case accountAct(ProductAccountAct)
     case sessionObserve(provider: ProductProviderID, sessions: ProductSessionCountBucket)
     case sessionActSend(provider: ProductProviderID, act: ProductSessionAct)
+    case settingUpdate(setting: ProductSettingID, value: ProductSettingValue)
+    case settingsReset
 
     public var name: String {
         switch self {
@@ -80,6 +99,8 @@ public enum ProductEvent: Equatable, Sendable {
         case .accountAct: "account:act"
         case .sessionObserve: "session:observe"
         case .sessionActSend: "session:act_send"
+        case .settingUpdate: "setting:update"
+        case .settingsReset: "settings:reset"
         }
     }
 
@@ -90,6 +111,8 @@ public enum ProductEvent: Equatable, Sendable {
         static let providerID = "provider_id"
         static let sessionCount = "session_count"
         static let sessionAct = "session_act"
+        static let settingID = "setting_id"
+        static let settingValue = "setting_value"
     }
 
     /// The properties the event's allowlist row names, in the wire's shape.
@@ -105,6 +128,10 @@ public enum ProductEvent: Equatable, Sendable {
             [Property.providerID: provider.rawValue, Property.sessionCount: sessions.rawValue]
         case .sessionActSend(let provider, let act):
             [Property.providerID: provider.rawValue, Property.sessionAct: act.rawValue]
+        case .settingUpdate(let setting, let value):
+            [Property.settingID: setting.rawValue, Property.settingValue: value.rawValue]
+        case .settingsReset:
+            [:]
         }
     }
 }

--- a/apps/ios/LukeKit/Sources/LukeKit/ProductEvents.swift
+++ b/apps/ios/LukeKit/Sources/LukeKit/ProductEvents.swift
@@ -41,16 +41,13 @@ public enum ProductSessionAct: String, Sendable {
     case agentAdd = "agent_add"
 }
 
-/// The settings this app can change, of the shared vocabulary's
-/// `APP_SETTING_ID`: the voice settings its sheet offers and nothing wider.
+/// The subset of the shared vocabulary's `APP_SETTING_ID` this app can change.
 public enum ProductSettingID: String, Sendable {
     case voice
     case voiceSpeed = "voice_speed"
 }
 
-/// The shape a setting's new value is counted in, never the value itself:
-/// whether a choice was made or returned to nothing is the whole of what
-/// travels, so the voice chosen is not a property a count could carry.
+/// The shape of a setting's change, never its value.
 public enum ProductSettingValue: String, Sendable {
     case on
     case off

--- a/apps/ios/LukeKit/Sources/LukeKit/RealtimeSession.swift
+++ b/apps/ios/LukeKit/Sources/LukeKit/RealtimeSession.swift
@@ -186,6 +186,9 @@ public final class RealtimeSession {
     private var interruptedResponseIds: Set<String> = []
     private var pendingInterruptionEventIds: Set<String> = []
     private var interruptionSequence = 0
+    // A speed chosen while the socket is still opening: session.update needs
+    // the channel, so it waits for the open and is sent then, once.
+    private var pendingSpeed: Double?
 
     public init(options: RealtimeSessionOptions) {
         self.options = options
@@ -257,6 +260,26 @@ public final class RealtimeSession {
         }
     }
 
+    /// Asks the open session to speak at `speed` times the voice's natural
+    /// rate from its next reply on. The API applies a speed only between
+    /// model turns, so one landing while Luke is speaking is heard on the
+    /// following reply. An idle session sends nothing: its next connection
+    /// is minted at the speed the caller holds, so there is nothing to update.
+    public func applySpeed(_ speed: Double) {
+        guard speed.isFinite, speed > 0 else { return }
+        switch status {
+        case .idle:
+            pendingSpeed = nil
+        case .connecting:
+            pendingSpeed = speed
+        default:
+            pendingSpeed = nil
+            guard let channel else { return }
+            let event = sessionSpeedUpdateJSON(speed)
+            Task { try? await channel.sendText(event) }
+        }
+    }
+
     /// Closes the connection and resets to idle.
     public func close() {
         idleTask?.cancel(); idleTask = nil
@@ -273,6 +296,7 @@ public final class RealtimeSession {
         responseStarted = false
         pendingDrains = 0
         pendingCommit = false
+        pendingSpeed = nil
         pendingCalls.removeAll()
         captionBuffer = ""
         clearActiveResponse()
@@ -353,6 +377,10 @@ public final class RealtimeSession {
 
     private func onChannelOpen(ws: any WebSocketTask, context: VoiceContextItem) async {
         try? await ws.sendText(contextItemJSON(context))
+        if let speed = pendingSpeed {
+            pendingSpeed = nil
+            try? await ws.sendText(sessionSpeedUpdateJSON(speed))
+        }
         for chunk in pressBuffer.drain() {
             try? await ws.sendText(audioAppendJSON(chunk))
         }
@@ -706,6 +734,10 @@ public final class RealtimeSession {
         return """
             {"type":"conversation.item.create","item":{"type":"function_call_output","call_id":"\(callId)","output":"\(escaped)"}}
             """
+    }
+
+    private func sessionSpeedUpdateJSON(_ speed: Double) -> String {
+        #"{"type":"session.update","session":{"type":"realtime","audio":{"output":{"speed":\#(speed)}}}}"#
     }
 
     private func responseCreateJSON(sequence: Int) -> String {

--- a/apps/ios/LukeKit/Sources/LukeKit/RealtimeSession.swift
+++ b/apps/ios/LukeKit/Sources/LukeKit/RealtimeSession.swift
@@ -186,8 +186,7 @@ public final class RealtimeSession {
     private var interruptedResponseIds: Set<String> = []
     private var pendingInterruptionEventIds: Set<String> = []
     private var interruptionSequence = 0
-    // A speed chosen while the socket is still opening: session.update needs
-    // the channel, so it waits for the open and is sent then, once.
+    // session.update needs the channel; a speed chosen while connecting waits for it.
     private var pendingSpeed: Double?
 
     public init(options: RealtimeSessionOptions) {
@@ -260,11 +259,9 @@ public final class RealtimeSession {
         }
     }
 
-    /// Asks the open session to speak at `speed` times the voice's natural
-    /// rate from its next reply on. The API applies a speed only between
-    /// model turns, so one landing while Luke is speaking is heard on the
-    /// following reply. An idle session sends nothing: its next connection
-    /// is minted at the speed the caller holds, so there is nothing to update.
+    /// The API applies a speed between model turns, so it is heard from the
+    /// next reply. An idle session sends nothing: the caller mints the next
+    /// connection at the speed it holds.
     public func applySpeed(_ speed: Double) {
         guard speed.isFinite, speed > 0 else { return }
         switch status {

--- a/apps/ios/LukeKit/Sources/LukeKit/VoiceSettings.swift
+++ b/apps/ios/LukeKit/Sources/LukeKit/VoiceSettings.swift
@@ -49,6 +49,20 @@ public enum RealtimeVoiceSpeed: String, CaseIterable, Sendable, Identifiable {
         }
     }
 
+    /// The span a slider over the steps covers, and the step between them:
+    /// with these bounds a slider lands on exactly the four multiples above
+    /// and on nothing between, so a drag can never ask for a pace the mint
+    /// would refuse.
+    public static let multiplierRange: ClosedRange<Double> = 0.75 ... 1.5
+    public static let multiplierStep: Double = 0.25
+
+    /// The step a slider's value names, or nil for a value off the steps.
+    public init?(multiplier: Double) {
+        guard let match = Self.allCases.first(where: { abs($0.multiplier - multiplier) < 0.001 })
+        else { return nil }
+        self = match
+    }
+
     public var displayName: String { rawValue.capitalized }
 
     /// The multiple as the settings sheet words it: "1.25×".

--- a/apps/ios/LukeKit/Sources/LukeKit/VoiceSettings.swift
+++ b/apps/ios/LukeKit/Sources/LukeKit/VoiceSettings.swift
@@ -1,0 +1,66 @@
+import Foundation
+
+/// Every voice Luke can speak with, a hand-kept transcription of
+/// `REALTIME_VOICE` in `packages/realtime/src/realtime-voice-settings.ts`,
+/// which stays the source of truth: the set is the Realtime API's, and the
+/// mint refuses a value outside it, so a case here that drifts from the
+/// TypeScript list is a control that cannot work rather than a new voice.
+public enum RealtimeVoice: String, CaseIterable, Sendable, Identifiable {
+    case alloy
+    case ash
+    case ballad
+    case cedar
+    case coral
+    case echo
+    case marin
+    case sage
+    case shimmer
+    case verse
+
+    /// The voice a fresh install speaks with, the desktop's default too.
+    public static let `default`: RealtimeVoice = .echo
+
+    public var id: String { rawValue }
+
+    public var displayName: String { rawValue.capitalized }
+}
+
+/// Every pace Luke can speak at, transcribed from `REALTIME_VOICE_SPEED` in
+/// the same file. Stored by name rather than by multiple so a stored value
+/// reads back through this set: a number the vocabulary has not answered for
+/// falls to the default rather than reaching the mint.
+public enum RealtimeVoiceSpeed: String, CaseIterable, Sendable, Identifiable {
+    case slow
+    case normal
+    case quick
+    case fast
+
+    public static let `default`: RealtimeVoiceSpeed = .normal
+
+    public var id: String { rawValue }
+
+    /// The multiple of the voice's natural rate the API is asked for.
+    public var multiplier: Double {
+        switch self {
+        case .slow: 0.75
+        case .normal: 1
+        case .quick: 1.25
+        case .fast: 1.5
+        }
+    }
+
+    public var displayName: String { rawValue.capitalized }
+
+    /// The multiple as the settings sheet words it: "1.25×".
+    public var multipleLabel: String {
+        "\(multiplier.formatted(.number.precision(.fractionLength(0 ... 2))))×"
+    }
+}
+
+/// The UserDefaults keys the voice settings live under on this device. Both
+/// the voice screen and its settings sheet read the same keys, so a change in
+/// the sheet is a change the screen sees.
+public enum VoiceSettingsKey {
+    public static let voice = "voiceSettings.voice"
+    public static let speed = "voiceSettings.speed"
+}

--- a/apps/ios/LukeKit/Sources/LukeKit/VoiceSettings.swift
+++ b/apps/ios/LukeKit/Sources/LukeKit/VoiceSettings.swift
@@ -1,10 +1,8 @@
 import Foundation
 
-/// Every voice Luke can speak with, a hand-kept transcription of
-/// `REALTIME_VOICE` in `packages/realtime/src/realtime-voice-settings.ts`,
-/// which stays the source of truth: the set is the Realtime API's, and the
-/// mint refuses a value outside it, so a case here that drifts from the
-/// TypeScript list is a control that cannot work rather than a new voice.
+/// Transcribed from `REALTIME_VOICE` in
+/// `packages/realtime/src/realtime-voice-settings.ts`, which stays the source
+/// of truth: the mint refuses a voice outside it.
 public enum RealtimeVoice: String, CaseIterable, Sendable, Identifiable {
     case alloy
     case ash
@@ -17,7 +15,6 @@ public enum RealtimeVoice: String, CaseIterable, Sendable, Identifiable {
     case shimmer
     case verse
 
-    /// The voice a fresh install speaks with, the desktop's default too.
     public static let `default`: RealtimeVoice = .echo
 
     public var id: String { rawValue }
@@ -25,10 +22,8 @@ public enum RealtimeVoice: String, CaseIterable, Sendable, Identifiable {
     public var displayName: String { rawValue.capitalized }
 }
 
-/// Every pace Luke can speak at, transcribed from `REALTIME_VOICE_SPEED` in
-/// the same file. Stored by name rather than by multiple so a stored value
-/// reads back through this set: a number the vocabulary has not answered for
-/// falls to the default rather than reaching the mint.
+/// Transcribed from `REALTIME_VOICE_SPEED` in the same file. Stored by name so
+/// an unknown stored value falls to the default rather than reaching the mint.
 public enum RealtimeVoiceSpeed: String, CaseIterable, Sendable, Identifiable {
     case slow
     case normal
@@ -39,7 +34,6 @@ public enum RealtimeVoiceSpeed: String, CaseIterable, Sendable, Identifiable {
 
     public var id: String { rawValue }
 
-    /// The multiple of the voice's natural rate the API is asked for.
     public var multiplier: Double {
         switch self {
         case .slow: 0.75
@@ -49,14 +43,10 @@ public enum RealtimeVoiceSpeed: String, CaseIterable, Sendable, Identifiable {
         }
     }
 
-    /// The span a slider over the steps covers, and the step between them:
-    /// with these bounds a slider lands on exactly the four multiples above
-    /// and on nothing between, so a drag can never ask for a pace the mint
-    /// would refuse.
+    /// A slider over this range at this step lands only on the cases above.
     public static let multiplierRange: ClosedRange<Double> = 0.75 ... 1.5
     public static let multiplierStep: Double = 0.25
 
-    /// The step a slider's value names, or nil for a value off the steps.
     public init?(multiplier: Double) {
         guard let match = Self.allCases.first(where: { abs($0.multiplier - multiplier) < 0.001 })
         else { return nil }
@@ -65,15 +55,11 @@ public enum RealtimeVoiceSpeed: String, CaseIterable, Sendable, Identifiable {
 
     public var displayName: String { rawValue.capitalized }
 
-    /// The multiple as the settings sheet words it: "1.25×".
     public var multipleLabel: String {
         "\(multiplier.formatted(.number.precision(.fractionLength(0 ... 2))))×"
     }
 }
 
-/// The UserDefaults keys the voice settings live under on this device. Both
-/// the voice screen and its settings sheet read the same keys, so a change in
-/// the sheet is a change the screen sees.
 public enum VoiceSettingsKey {
     public static let voice = "voiceSettings.voice"
     public static let speed = "voiceSettings.speed"

--- a/apps/ios/LukeKit/Tests/LukeKitTests/ProductEventsTests.swift
+++ b/apps/ios/LukeKit/Tests/LukeKitTests/ProductEventsTests.swift
@@ -45,6 +45,15 @@ final class ProductEventsTests: XCTestCase {
             act.wireProperties(appVersion: "0.1.1") as? [String: String],
             ["provider_id": "conductor", "session_act": "message_send"]
         )
+
+        let update = ProductEvent.settingUpdate(setting: .voiceSpeed, value: .set)
+        XCTAssertEqual(update.name, "setting:update")
+        XCTAssertEqual(
+            update.wireProperties(appVersion: "0.1.1") as? [String: String],
+            ["setting_id": "voice_speed", "setting_value": "set"]
+        )
+        XCTAssertEqual(ProductEvent.settingsReset.name, "settings:reset")
+        XCTAssertTrue(ProductEvent.settingsReset.wireProperties(appVersion: "0.1.1").isEmpty)
     }
 
     /// A roster row's provider id reaches a count only through this set, so

--- a/apps/ios/LukeKit/Tests/LukeKitTests/RealtimeSessionTests.swift
+++ b/apps/ios/LukeKit/Tests/LukeKitTests/RealtimeSessionTests.swift
@@ -783,6 +783,80 @@ final class RealtimeSessionStateTests: XCTestCase {
 
     // MARK: - Helpers
 
+    // MARK: - Speed
+
+    func testApplySpeedOnAnOpenSessionSendsOneSessionUpdate() async throws {
+        let ws = MockWebSocketTask()
+        let session = RealtimeSession(options: makeOptions(ws: ws))
+
+        Task { ws.deliver(#"{"type":"session.created"}"#) }
+        await session.connect()
+        try await Task.sleep(nanoseconds: 50_000_000)
+        XCTAssertEqual(session.status, .ready)
+
+        session.applySpeed(1.25)
+        try await Task.sleep(nanoseconds: 50_000_000)
+
+        let updates = ws.outgoing.filter { $0.contains(#""type":"session.update""#) }
+        XCTAssertEqual(updates.count, 1)
+        XCTAssertTrue(updates[0].contains(#""audio":{"output":{"speed":1.25}}"#))
+        XCTAssertTrue(updates[0].contains(#""session":{"type":"realtime""#))
+    }
+
+    func testSpeedChosenWhileConnectingIsSentOnceTheChannelOpens() async throws {
+        let ws = MockWebSocketTask()
+        let mintStarted = AsyncGate()
+        let allowMint = AsyncGate()
+        let session = RealtimeSession(
+            options: makeOptions(
+                ws: ws,
+                requestConnection: {
+                    await mintStarted.open()
+                    await allowMint.wait()
+                    return testConnection
+                }
+            )
+        )
+
+        let connecting = Task { await session.connect() }
+        await mintStarted.wait()
+        XCTAssertEqual(session.status, .connecting)
+        session.applySpeed(0.75)
+        session.applySpeed(1.5)
+        XCTAssertTrue(ws.outgoing.isEmpty)
+
+        await allowMint.open()
+        ws.deliver(#"{"type":"session.created"}"#)
+        await connecting.value
+        try await Task.sleep(nanoseconds: 50_000_000)
+
+        let updates = ws.outgoing.filter { $0.contains(#""type":"session.update""#) }
+        XCTAssertEqual(updates.count, 1)
+        XCTAssertTrue(updates[0].contains(#""speed":1.5"#))
+        // The context item still leads: the model learns the sessions before it hears a pace.
+        let contextIndex = ws.outgoing.firstIndex { $0.contains(#""type":"conversation.item.create""#) }
+        let updateIndex = ws.outgoing.firstIndex { $0.contains(#""type":"session.update""#) }
+        XCTAssertNotNil(contextIndex)
+        XCTAssertLessThan(contextIndex!, updateIndex!)
+    }
+
+    func testApplySpeedWhileIdleSendsNothing() async throws {
+        let ws = MockWebSocketTask()
+        let session = RealtimeSession(options: makeOptions(ws: ws))
+        session.applySpeed(1.25)
+        session.applySpeed(0)
+        session.applySpeed(-1)
+        try await Task.sleep(nanoseconds: 20_000_000)
+        XCTAssertTrue(ws.outgoing.isEmpty)
+
+        // Nothing waits for the next open either: the caller mints that
+        // connection at the speed it holds, so an update would repeat it.
+        Task { ws.deliver(#"{"type":"session.created"}"#) }
+        await session.connect()
+        try await Task.sleep(nanoseconds: 50_000_000)
+        XCTAssertFalse(ws.outgoing.contains { $0.contains(#""type":"session.update""#) })
+    }
+
     private func makeOptions(
         ws: MockWebSocketTask,
         capturer: any AudioCapturer = SilentCapturer(),

--- a/apps/ios/LukeKit/Tests/LukeKitTests/RealtimeSessionTests.swift
+++ b/apps/ios/LukeKit/Tests/LukeKitTests/RealtimeSessionTests.swift
@@ -833,7 +833,6 @@ final class RealtimeSessionStateTests: XCTestCase {
         let updates = ws.outgoing.filter { $0.contains(#""type":"session.update""#) }
         XCTAssertEqual(updates.count, 1)
         XCTAssertTrue(updates[0].contains(#""speed":1.5"#))
-        // The context item still leads: the model learns the sessions before it hears a pace.
         let contextIndex = ws.outgoing.firstIndex { $0.contains(#""type":"conversation.item.create""#) }
         let updateIndex = ws.outgoing.firstIndex { $0.contains(#""type":"session.update""#) }
         XCTAssertNotNil(contextIndex)
@@ -849,8 +848,6 @@ final class RealtimeSessionStateTests: XCTestCase {
         try await Task.sleep(nanoseconds: 20_000_000)
         XCTAssertTrue(ws.outgoing.isEmpty)
 
-        // Nothing waits for the next open either: the caller mints that
-        // connection at the speed it holds, so an update would repeat it.
         Task { ws.deliver(#"{"type":"session.created"}"#) }
         await session.connect()
         try await Task.sleep(nanoseconds: 50_000_000)

--- a/apps/ios/LukeKit/Tests/LukeKitTests/VoiceSettingsTests.swift
+++ b/apps/ios/LukeKit/Tests/LukeKitTests/VoiceSettingsTests.swift
@@ -1,0 +1,30 @@
+import Foundation
+import XCTest
+
+@testable import LukeKit
+
+final class VoiceSettingsTests: XCTestCase {
+    /// The voices must match `REALTIME_VOICE_LIST` name for name and in its
+    /// order: the mint refuses a voice outside the API's set, so a drifted
+    /// case is a picker row that cannot work.
+    func testVoicesMatchTheSharedVocabulary() {
+        XCTAssertEqual(
+            RealtimeVoice.allCases.map(\.rawValue),
+            ["alloy", "ash", "ballad", "cedar", "coral", "echo", "marin", "sage", "shimmer", "verse"]
+        )
+        XCTAssertEqual(RealtimeVoice.default, .echo)
+        XCTAssertEqual(RealtimeVoice.coral.displayName, "Coral")
+        XCTAssertNil(RealtimeVoice(rawValue: "Echo"))
+    }
+
+    /// The speeds must match `REALTIME_VOICE_SPEED` step for step, slowest
+    /// to fastest, because the mint validates the multiple against that set.
+    func testSpeedsMatchTheSharedVocabulary() {
+        XCTAssertEqual(RealtimeVoiceSpeed.allCases, [.slow, .normal, .quick, .fast])
+        XCTAssertEqual(RealtimeVoiceSpeed.allCases.map(\.multiplier), [0.75, 1, 1.25, 1.5])
+        XCTAssertEqual(RealtimeVoiceSpeed.default, .normal)
+        XCTAssertEqual(RealtimeVoiceSpeed.quick.multipleLabel, "1.25×")
+        XCTAssertEqual(RealtimeVoiceSpeed.normal.multipleLabel, "1×")
+        XCTAssertNil(RealtimeVoiceSpeed(rawValue: "1.25"))
+    }
+}

--- a/apps/ios/LukeKit/Tests/LukeKitTests/VoiceSettingsTests.swift
+++ b/apps/ios/LukeKit/Tests/LukeKitTests/VoiceSettingsTests.swift
@@ -27,4 +27,19 @@ final class VoiceSettingsTests: XCTestCase {
         XCTAssertEqual(RealtimeVoiceSpeed.normal.multipleLabel, "1×")
         XCTAssertNil(RealtimeVoiceSpeed(rawValue: "1.25"))
     }
+
+    /// A slider stepping across the range must land on every step and on
+    /// nothing else, because the mint refuses a multiple outside the set.
+    func testSliderStepsCoverExactlyTheSpeeds() {
+        var landed: [RealtimeVoiceSpeed?] = []
+        var value = RealtimeVoiceSpeed.multiplierRange.lowerBound
+        while value <= RealtimeVoiceSpeed.multiplierRange.upperBound + 0.0001 {
+            landed.append(RealtimeVoiceSpeed(multiplier: value))
+            value += RealtimeVoiceSpeed.multiplierStep
+        }
+        XCTAssertEqual(landed, [.slow, .normal, .quick, .fast])
+        XCTAssertEqual(RealtimeVoiceSpeed(multiplier: 1.2500001), .quick)
+        XCTAssertNil(RealtimeVoiceSpeed(multiplier: 1.1))
+        XCTAssertNil(RealtimeVoiceSpeed(multiplier: 2))
+    }
 }

--- a/apps/ios/LukeKit/Tests/LukeKitTests/VoiceSettingsTests.swift
+++ b/apps/ios/LukeKit/Tests/LukeKitTests/VoiceSettingsTests.swift
@@ -4,9 +4,6 @@ import XCTest
 @testable import LukeKit
 
 final class VoiceSettingsTests: XCTestCase {
-    /// The voices must match `REALTIME_VOICE_LIST` name for name and in its
-    /// order: the mint refuses a voice outside the API's set, so a drifted
-    /// case is a picker row that cannot work.
     func testVoicesMatchTheSharedVocabulary() {
         XCTAssertEqual(
             RealtimeVoice.allCases.map(\.rawValue),
@@ -17,8 +14,6 @@ final class VoiceSettingsTests: XCTestCase {
         XCTAssertNil(RealtimeVoice(rawValue: "Echo"))
     }
 
-    /// The speeds must match `REALTIME_VOICE_SPEED` step for step, slowest
-    /// to fastest, because the mint validates the multiple against that set.
     func testSpeedsMatchTheSharedVocabulary() {
         XCTAssertEqual(RealtimeVoiceSpeed.allCases, [.slow, .normal, .quick, .fast])
         XCTAssertEqual(RealtimeVoiceSpeed.allCases.map(\.multiplier), [0.75, 1, 1.25, 1.5])
@@ -28,8 +23,6 @@ final class VoiceSettingsTests: XCTestCase {
         XCTAssertNil(RealtimeVoiceSpeed(rawValue: "1.25"))
     }
 
-    /// A slider stepping across the range must land on every step and on
-    /// nothing else, because the mint refuses a multiple outside the set.
     func testSliderStepsCoverExactlyTheSpeeds() {
         var landed: [RealtimeVoiceSpeed?] = []
         var value = RealtimeVoiceSpeed.multiplierRange.lowerBound


### PR DESCRIPTION
## Summary

- Add a **Voice Settings** gear button to the top-right of the iOS voice screen. It opens a medium/large sheet built from a grouped `Form` with an inline title, a Done button, and a drag indicator, the same sheet vocabulary as Filter & Sort and the session details sheet.
- Offer the two desktop Voice-page settings that apply to this device: the **voice** Luke speaks with, as a menu picker over the Realtime API's ten voices, and the **speed**, as a numeric slider stepping across the four multiples the mint accepts (0.75× to 1.5×) with the chosen value labelled beside it. A **Reset to Defaults** row appears only while something differs from the defaults (echo, 1×).
- Store both in `UserDefaults` through a hand-kept LukeKit transcription of `REALTIME_VOICE` and `REALTIME_VOICE_SPEED`, and send them with every mint. A speed change reaches an open session as a `session.update` (queued while the socket is still opening) and is heard from the next reply on; a voice change reopens the connection in the new voice, as the desktop does. An idle screen only remembers the choice and the next press mints in it.
- Count the changes as the desktop does, through the existing `setting:update` and `settings:reset` events in the shared allowlist, carrying only the setting id and `set`, never the value.
- Not drawn: the Mac-only rows (captions, quieting Music and Spotify, preferring the Mac's microphone, pausing announcements, the credential provider), because they are about a machine this app does not run on.

## Simulator evidence

| Voice screen entry | Default settings | Changed settings |
| --- | --- | --- |
| <img src="https://raw.githubusercontent.com/ReviewStage/luke/9672e5775feb18c5bc1eb6ffc616eba6cc46ca1a/pr-658/voice-settings-entry.png" width="260" alt="Luke voice screen with the Voice Settings gear button in the top-right toolbar"> | <img src="https://raw.githubusercontent.com/ReviewStage/luke/9672e5775feb18c5bc1eb6ffc616eba6cc46ca1a/pr-658/voice-settings-medium.png" width="260" alt="Medium Voice Settings sheet with Echo voice and 1x speed defaults"> | <img src="https://raw.githubusercontent.com/ReviewStage/luke/9672e5775feb18c5bc1eb6ffc616eba6cc46ca1a/pr-658/voice-settings-large-changed.png" width="260" alt="Expanded Voice Settings sheet with Verse voice, 1.5x speed, and Reset to Defaults"> |

Captured from the iOS 26.5 Simulator (iPhone 17 Pro) against code commit `38dacfce33ee87bf1f82585896158e07fea8a369`. The launch used a temporary, uncommitted route into the real SwiftUI screen; analytics and session replay were disabled. Evidence is hosted separately on `pr-assets` at `9672e5775feb18c5bc1eb6ffc616eba6cc46ca1a`; no images are committed to this PR branch.

## Validation

- `./scripts/check.sh` passes.
- `cd apps/ios/LukeKit && swift test`: 201 tests pass, including new coverage for the voice and speed vocabulary, the slider steps, the setting events, and `applySpeed` on an open, connecting, and idle session.
- `xcodebuild -project apps/ios/Luke.xcodeproj -scheme Luke -sdk iphonesimulator -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 17 Pro' CODE_SIGNING_ALLOWED=NO build` succeeds.
- Physical-device check: not performed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/8ce99ef0-6252-44f5-9ec3-3c2797588aac)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/33769299378/artifacts/9899046166) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/33769299378)

- Commit: `b173aca0675c9e6740f9387e0d3207b29209700b`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->