### PR TITLE
feat(ios): carry the desktop's acts in the phone's conversation

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -41,8 +41,9 @@ all.
 silently save a concise preference, personal fact, goal, or recurring constraint
 that looks useful later. He skips temporary details and uncertain guesses, never
 saves credentials, and saves sensitive facts only when you explicitly ask. At
-most 32 are stored on your Mac beside your settings and they do not expire. You
-can ask Luke what he remembers, correct something, or tell him to forget it.
+most 32 are stored on your Mac beside your settings and they do not expire. The
+iOS app keeps no such memory and does not read the Mac's. You can ask Luke what
+he remembers, correct something, or tell him to forget it.
 They are sent to OpenAI with the rest of a conversation's context so Luke can
 personalize replies; they are not sent to a coding-agent provider, a tracker, or
 our own service, and they are never used to decide anything on your behalf.
@@ -133,11 +134,12 @@ and email you signed it with, and any screenshots you attached.
   your own key if you entered one, otherwise through our service on our key —
   asks OpenAI not to store the request, and our service stores and logs none
   of it either. The phrase that comes back is spoken with that announcement
-  and kept nowhere. On the Mac app,
-  your conversation and Luke's durable memory are kept on your Mac and sent
-  with a call so the conversation carries across calls and across launches; on
-  iOS, the conversation is held in memory and discarded when the session
-  closes.
+  and kept nowhere. On the Mac app, your conversation and Luke's durable
+  memory are kept on your Mac and sent with a call so the conversation carries
+  across calls and across launches; on iOS, a call also carries the list of
+  projects your synced keys can create a workspace in, while the conversation
+  itself is held in memory and discarded when the session closes, and nothing
+  is remembered between calls.
   The one voice call that happens before you sign in is the spoken
   introduction on first launch of the Mac app: it sends its own fixed script,
   the titles of the coding agent sessions found on your Mac, and anything you

--- a/apps/ios/Luke.xcodeproj/project.pbxproj
+++ b/apps/ios/Luke.xcodeproj/project.pbxproj
@@ -40,6 +40,7 @@
 		AABBCC0000000000000000D6 /* VoiceAudioPlayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABBCC0000000000000000D2 /* VoiceAudioPlayer.swift */; };
 		AABBCC0000000000000000D7 /* VoiceActDispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABBCC0000000000000000D3 /* VoiceActDispatcher.swift */; };
 		AABBCC0000000000000000D9 /* VoiceSettingsSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABBCC0000000000000000D8 /* VoiceSettingsSheet.swift */; };
+		AABBCC0000000000000000E1 /* SessionsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABBCC0000000000000000E0 /* SessionsStore.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -75,6 +76,7 @@
 		AABBCC0000000000000000D2 /* VoiceAudioPlayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceAudioPlayer.swift; sourceTree = "<group>"; };
 		AABBCC0000000000000000D3 /* VoiceActDispatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceActDispatcher.swift; sourceTree = "<group>"; };
 		AABBCC0000000000000000D8 /* VoiceSettingsSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceSettingsSheet.swift; sourceTree = "<group>"; };
+		AABBCC0000000000000000E0 /* SessionsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionsStore.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -139,6 +141,7 @@
 				AABBCC000000000000000017 /* SVGPath.swift */,
 				AABBCC000000000000000018 /* VaultView.swift */,
 				AABBCC00000000000000001B /* SessionsView.swift */,
+				AABBCC0000000000000000E0 /* SessionsStore.swift */,
 				AABBCC00000000000000001D /* SessionDetailView.swift */,
 				AABBCC00000000000000001E /* WorkspaceCreatorSheet.swift */,
 				AABBCC00000000000000001F /* SessionReplay.swift */,
@@ -334,6 +337,7 @@
 				AABBCC000000000000000086 /* SVGPath.swift in Sources */,
 				AABBCC000000000000000087 /* VaultView.swift in Sources */,
 				AABBCC00000000000000008A /* SessionsView.swift in Sources */,
+				AABBCC0000000000000000E1 /* SessionsStore.swift in Sources */,
 				AABBCC00000000000000008C /* SessionDetailView.swift in Sources */,
 				AABBCC00000000000000008D /* WorkspaceCreatorSheet.swift in Sources */,
 				AABBCC00000000000000008E /* SessionReplay.swift in Sources */,

--- a/apps/ios/Luke.xcodeproj/project.pbxproj
+++ b/apps/ios/Luke.xcodeproj/project.pbxproj
@@ -40,7 +40,7 @@
 		AABBCC0000000000000000D6 /* VoiceAudioPlayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABBCC0000000000000000D2 /* VoiceAudioPlayer.swift */; };
 		AABBCC0000000000000000D7 /* VoiceActDispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABBCC0000000000000000D3 /* VoiceActDispatcher.swift */; };
 		AABBCC0000000000000000D9 /* VoiceSettingsSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABBCC0000000000000000D8 /* VoiceSettingsSheet.swift */; };
-		AABBCC0000000000000000E1 /* SessionsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABBCC0000000000000000E0 /* SessionsStore.swift */; };
+		AABBCC0000000000000000F9 /* SessionsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABBCC0000000000000000F8 /* SessionsStore.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -76,7 +76,7 @@
 		AABBCC0000000000000000D2 /* VoiceAudioPlayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceAudioPlayer.swift; sourceTree = "<group>"; };
 		AABBCC0000000000000000D3 /* VoiceActDispatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceActDispatcher.swift; sourceTree = "<group>"; };
 		AABBCC0000000000000000D8 /* VoiceSettingsSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceSettingsSheet.swift; sourceTree = "<group>"; };
-		AABBCC0000000000000000E0 /* SessionsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionsStore.swift; sourceTree = "<group>"; };
+		AABBCC0000000000000000F8 /* SessionsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionsStore.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -141,7 +141,7 @@
 				AABBCC000000000000000017 /* SVGPath.swift */,
 				AABBCC000000000000000018 /* VaultView.swift */,
 				AABBCC00000000000000001B /* SessionsView.swift */,
-				AABBCC0000000000000000E0 /* SessionsStore.swift */,
+				AABBCC0000000000000000F8 /* SessionsStore.swift */,
 				AABBCC00000000000000001D /* SessionDetailView.swift */,
 				AABBCC00000000000000001E /* WorkspaceCreatorSheet.swift */,
 				AABBCC00000000000000001F /* SessionReplay.swift */,
@@ -337,7 +337,7 @@
 				AABBCC000000000000000086 /* SVGPath.swift in Sources */,
 				AABBCC000000000000000087 /* VaultView.swift in Sources */,
 				AABBCC00000000000000008A /* SessionsView.swift in Sources */,
-				AABBCC0000000000000000E1 /* SessionsStore.swift in Sources */,
+				AABBCC0000000000000000F9 /* SessionsStore.swift in Sources */,
 				AABBCC00000000000000008C /* SessionDetailView.swift in Sources */,
 				AABBCC00000000000000008D /* WorkspaceCreatorSheet.swift in Sources */,
 				AABBCC00000000000000008E /* SessionReplay.swift in Sources */,

--- a/apps/ios/Luke/ContentView.swift
+++ b/apps/ios/Luke/ContentView.swift
@@ -172,9 +172,16 @@ private struct SignedInView: View {
     @Environment(AccountSession.self) private var session
     let identity: AccountIdentity
     @State private var profileShown = false
+    /// The list's state and the stack above it, owned here so the voice
+    /// screen can drive the same presses the list offers by hand, and torn
+    /// down with the signed-in hierarchy like the profile flag.
+    @State private var store = SessionsStore(
+        rosterClient: RosterClient(serviceURL: AccountConstants.serviceURL)
+    )
 
     var body: some View {
-        NavigationStack {
+        @Bindable var store = store
+        return NavigationStack(path: $store.path) {
             SessionsView()
                 .toolbar {
                     if #available(iOS 26.0, *) {
@@ -191,10 +198,8 @@ private struct SignedInView: View {
                         }
                     }
                 }
-            .navigationDestination(for: String.self) { destination in
-                if destination == "voice" { VoiceView() }
-            }
         }
+        .environment(store)
         .sheet(isPresented: $profileShown) {
             ProfileSheet(identity: identity)
         }

--- a/apps/ios/Luke/SessionsStore.swift
+++ b/apps/ios/Luke/SessionsStore.swift
@@ -1,0 +1,155 @@
+import LukeKit
+import Observation
+import SwiftUI
+
+/// Where the signed-in hierarchy can stand beyond the list: on the voice
+/// screen, or on one session's own screen. A route carries the observed row
+/// it was opened from, so a screen whose session a later refresh no longer
+/// reports keeps its last observed word rather than going blank.
+enum SessionsRoute: Hashable {
+    case voice
+    case session(RosterSession)
+}
+
+/// The list's state and the stack above it, shared between the list, the
+/// session screens, and the voice screen, because Luke can be asked in
+/// conversation for the same presses the list offers by hand: open a
+/// session's screen, narrow or reorder the list, search it. Every act on
+/// this store is a press the list itself draws a control for.
+@MainActor
+@Observable
+final class SessionsStore {
+    var sessions: [RosterSession] = []
+    /// True until a fetched roster has actually landed, so every empty frame
+    /// before one — the first paint racing its fetch, the first request in
+    /// flight, and a retry running after a failed first load — shows the
+    /// skeletons rather than claim "No active sessions" nothing has
+    /// confirmed. Only that unknown may show them: a refresh that finds the
+    /// list already empty (the last chat just archived) must not flash
+    /// skeletons over an emptiness that is real, and a standing fetch error
+    /// still outranks them.
+    var awaitingFirstRoster = true
+    var fetchError: String?
+    var searchQuery = ""
+    /// Whether the search field is up. Set when a spoken search lands, since
+    /// a query nobody can see would narrow the list for no visible reason.
+    var searchPresented = false
+    var filters: Set<SessionFilter> = []
+    var sort: SessionSort = .urgency
+    var path: [SessionsRoute] = []
+
+    /// Counts refresh passes so a stale answer cannot outrank a newer one:
+    /// a pass's roster lands only when no newer pass has landed one (an
+    /// older roster written after a newer would bring an archived row back
+    /// from the dead, but one written where a newer pass only failed still
+    /// beats an error over nothing), and only the newest pass may claim
+    /// failure, since an old outage says nothing about the request still
+    /// running.
+    private var refreshPass = 0
+    /// The newest pass whose roster actually landed.
+    private var landedPass = 0
+    /// Sessions whose archive act is still in flight. The row leaves at the
+    /// press, so every roster write filters these ids: a refresh whose roster
+    /// was read before the archive landed would otherwise bring the row back.
+    private var archivingIds: Set<String> = []
+
+    private let rosterClient: RosterClient
+
+    init(rosterClient: RosterClient) {
+        self.rosterClient = rosterClient
+    }
+
+    /// Opens a session's own screen, the same press a row takes.
+    func open(_ session: RosterSession) {
+        path.append(.session(session))
+    }
+
+    /// Opens a session's screen in the conversation's place: an open asked of
+    /// Luke leaves the conversation the way the desktop's open leaves the
+    /// panel for the provider's app. Covering the voice screen instead would
+    /// close its call and then mint another the moment the developer swiped
+    /// back, spending a voice session nobody asked for.
+    func openLeavingConversation(_ session: RosterSession) {
+        path.removeAll { $0 == .voice }
+        path.append(.session(session))
+    }
+
+    /// A session that just left the roster has no screen to stand on any more.
+    func closeScreen(of session: RosterSession) {
+        path.removeAll { route in
+            if case .session(let opened) = route { return opened.id == session.id }
+            return false
+        }
+    }
+
+    /// An archive's whole visible outcome is the row leaving, so the leave
+    /// happens at the press — the row slides out and the screen it opened
+    /// pops — with the act following behind rather than the press waiting on
+    /// two round trips.
+    func beginArchiving(_ session: RosterSession) {
+        archivingIds.insert(session.id)
+        closeScreen(of: session)
+        withAnimation { sessions.removeAll { $0.id == session.id } }
+    }
+
+    /// Lifts the hold once the act has answered. A refusal restores the row
+    /// locally before any refresh converges, because the outage that refused
+    /// the act usually fails the refresh too, and a chat the server never
+    /// archived must not stay gone on the refusal's word alone.
+    func endArchiving(_ session: RosterSession, delivered: Bool) {
+        archivingIds.remove(session.id)
+        guard !delivered, !sessions.contains(where: { $0.id == session.id }) else { return }
+        withAnimation { sessions.append(session) }
+    }
+
+    /// Shows the list as a spoken ask narrowed, ordered, or searched it, the
+    /// way the filter sheet and the search field would have. The ask arrives
+    /// validated against the roster; this only applies it and pops to the list.
+    func showList(_ ask: VoiceAsks.SessionListAsk) {
+        if let filters = ask.filters { self.filters = filters }
+        if let sort = ask.sort { self.sort = sort }
+        if let query = ask.query {
+            searchQuery = query
+            searchPresented = true
+        }
+        path.removeAll()
+    }
+
+    func refresh(account: AccountSession, events: ProductEventSender) async {
+        refreshPass += 1
+        let pass = refreshPass
+        fetchError = nil
+        guard case .signedIn = account.state else { return }
+        do {
+            let fetched = try await account.authorized { token in
+                try await rosterClient.observe(bearerToken: token)
+            }
+            guard pass > landedPass else { return }
+            landedPass = pass
+            // Animated so a row an act just removed slides out the way a
+            // deleted Mail row does, instead of blinking.
+            withAnimation { sessions = fetched.filter { !archivingIds.contains($0.id) } }
+            awaitingFirstRoster = false
+            recordObservation(fetched, events: events)
+        } catch is AccountSessionError {
+            ()  // Signed out — the state change redraws automatically.
+        } catch {
+            guard pass == refreshPass else { return }
+            fetchError = error.localizedDescription
+        }
+    }
+
+    /// One count per provider per day, in buckets — refreshing is not using.
+    /// A provider id the shared vocabulary has not answered for is left
+    /// uncounted rather than sent to be refused.
+    private func recordObservation(_ sessions: [RosterSession], events: ProductEventSender) {
+        let rowsByProvider = Dictionary(grouping: sessions, by: \.providerId)
+        for (providerId, rows) in rowsByProvider {
+            guard let provider = ProductProviderID(rawValue: providerId) else { continue }
+            events.recordOncePerDay(
+                .sessionObserve(provider: provider, sessions: .bucket(for: rows.count)),
+                discriminator: providerId
+            )
+        }
+    }
+}

--- a/apps/ios/Luke/SessionsView.swift
+++ b/apps/ios/Luke/SessionsView.swift
@@ -3,26 +3,14 @@ import SwiftUI
 import UIKit
 
 /// Shows the signed-in user's active cloud sessions with pull-to-refresh.
+/// The roster, the narrowing, and the stack above the list live in the
+/// shared store, because the voice screen can be asked for the same presses.
 struct SessionsView: View {
     @Environment(AccountSession.self) private var session
     @Environment(ProductEventSender.self) private var events
+    @Environment(SessionsStore.self) private var store
 
-    @State private var sessions: [RosterSession] = []
-    /// True until a fetched roster has actually landed, so every empty frame
-    /// before one — the first paint racing its `.task`, the first request in
-    /// flight, and a retry running after a failed first load — shows the
-    /// skeletons rather than claim "No active sessions" nothing has
-    /// confirmed. Only that unknown may show them: a refresh that finds the
-    /// list already empty (the last chat just archived) must not flash
-    /// skeletons over an emptiness that is real, and a standing fetch error
-    /// still outranks them.
-    @State private var awaitingFirstRoster = true
-    @State private var fetchError: String?
-    @State private var searchQuery = ""
-    @State private var filters: Set<SessionFilter> = []
-    @State private var sort: SessionSort = .urgency
     @State private var optionsShown = false
-    @State private var openedSession: RosterSession?
     /// Sent bubbles per session, in memory alone for the app run — the
     /// developer's own words, never written to disk, surviving push and pop
     /// so a chat reopened mid-run still shows what was just sent.
@@ -32,22 +20,6 @@ struct SessionsView: View {
     @State private var renameText = ""
     @State private var creatorShown = false
     @State private var actFailure: String?
-    /// Counts refresh passes so a stale answer cannot outrank a newer one:
-    /// a pass's roster lands only when no newer pass has landed one (an
-    /// older roster written after a newer would bring an archived row back
-    /// from the dead, but one written where a newer pass only failed still
-    /// beats an error over nothing), and only the newest pass may claim
-    /// failure, since an old outage says nothing about the request still
-    /// running.
-    @State private var refreshPass = 0
-    /// The newest pass whose roster actually landed.
-    @State private var landedPass = 0
-    /// Sessions whose archive act is still in flight. The row leaves at the
-    /// press, so every roster write filters these ids: a refresh whose roster
-    /// was read before the archive landed would otherwise bring the row back.
-    /// Delivery lifts the hold after the post-act refresh; a refusal lifts it
-    /// and refreshes, restoring the row beside the alert saying why.
-    @State private var archivingIds: Set<String> = []
 
     /// Which advertised rename a menu press opened: the session itself, or
     /// the workspace it runs in. One alert serves both; the flag picks the
@@ -61,7 +33,6 @@ struct SessionsView: View {
         var act: ProductSessionAct { isWorkspace ? .workspaceRename : .sessionRename }
     }
 
-    private let rosterClient = RosterClient(serviceURL: AccountConstants.serviceURL)
     private let actClient = ActClient(baseURL: AccountConstants.serviceURL)
     private let projectsClient = ProjectsClient(serviceURL: AccountConstants.serviceURL)
     private let conversationClient = ConversationClient(serviceURL: AccountConstants.serviceURL)
@@ -77,30 +48,36 @@ struct SessionsView: View {
                 searchableList
             }
         }
-        .navigationDestination(item: $openedSession) { opened in
-            // The freshest observation of the opened session wins, so a
-            // refresh behind the screen updates the words it draws; a session
-            // the refresh no longer reports keeps its last observed word.
-            let current = sessions.first { $0.id == opened.id } ?? opened
-            SessionDetailView(
-                session: current,
-                actClient: actClient,
-                conversationClient: conversationClient,
-                thread: Binding(
-                    get: { threads[opened.id] ?? [] },
-                    set: { threads[opened.id] = $0 }
-                ),
-                onDelivered: { await refreshSessions() },
-                sessionActions: { viewDetails in
-                    AnyView(
-                        rowMenu(
-                            current,
-                            viewDetails: viewDetails,
-                            sendMessage: nil
+        .navigationDestination(for: SessionsRoute.self) { route in
+            switch route {
+            case .voice:
+                VoiceView()
+            case .session(let opened):
+                // The freshest observation of the opened session wins, so a
+                // refresh behind the screen updates the words it draws; a
+                // session the refresh no longer reports keeps its last
+                // observed word.
+                let current = store.sessions.first { $0.id == opened.id } ?? opened
+                SessionDetailView(
+                    session: current,
+                    actClient: actClient,
+                    conversationClient: conversationClient,
+                    thread: Binding(
+                        get: { threads[opened.id] ?? [] },
+                        set: { threads[opened.id] = $0 }
+                    ),
+                    onDelivered: { await refreshSessions() },
+                    sessionActions: { viewDetails in
+                        AnyView(
+                            rowMenu(
+                                current,
+                                viewDetails: viewDetails,
+                                sendMessage: nil
+                            )
                         )
-                    )
-                }
-            )
+                    }
+                )
+            }
         }
         .sheet(item: $spawningSession) { s in
             AgentSpawnerSheet(session: s, actClient: actClient) {
@@ -140,34 +117,35 @@ struct SessionsView: View {
     /// The rows the query leaves: matched with the desktop's own search
     /// semantics, and everything when the query is blank.
     private var searchMatchedSessions: [RosterSession] {
-        let tokens = SessionSearch.tokens(from: searchQuery)
-        if tokens.isEmpty { return sessions }
-        return sessions.filter { SessionSearch.matches($0, tokens: tokens) }
+        let tokens = SessionSearch.tokens(from: store.searchQuery)
+        if tokens.isEmpty { return store.sessions }
+        return store.sessions.filter { SessionSearch.matches($0, tokens: tokens) }
     }
 
     private var searchableList: some View {
+        @Bindable var store = store
         // Matched once per build: the empty check, the visible rows, and the
         // filtered-out count all read the same pass instead of re-running the
         // tokenized scan.
         let matched = searchMatchedSessions
         let visible = sortedSessions(
-            matched.filter { matchesFilterSelection(filters, session: $0) },
-            by: sort
+            matched.filter { matchesFilterSelection(store.filters, session: $0) },
+            by: store.sort
         )
         return List {
-            if awaitingFirstRoster && sessions.isEmpty && fetchError == nil {
+            if store.awaitingFirstRoster && store.sessions.isEmpty && store.fetchError == nil {
                 ForEach(0 ..< 3, id: \.self) { _ in
                     SkeletonRow()
                         .listRowBackground(Color.clear)
                         .listRowSeparator(.hidden)
                         .listRowInsets(rowInsets)
                 }
-            } else if sessions.isEmpty {
+            } else if store.sessions.isEmpty {
                 emptyRow
                     .listRowBackground(Color.clear)
                     .listRowSeparator(.hidden)
             } else if matched.isEmpty {
-                ContentUnavailableView.search(text: searchQuery)
+                ContentUnavailableView.search(text: store.searchQuery)
                     .listRowBackground(Color.clear)
                     .listRowSeparator(.hidden)
             } else if visible.isEmpty {
@@ -186,7 +164,7 @@ struct SessionsView: View {
         .listStyle(.plain)
         .scrollContentBackground(.hidden)
         .background(Color.ground.ignoresSafeArea())
-        .searchable(text: $searchQuery, prompt: "Search sessions")
+        .searchable(text: $store.searchQuery, isPresented: $store.searchPresented, prompt: "Search sessions")
         .toolbar {
             // Search and list options flank the primary voice action. Keeping
             // all three in the system bar gives each control native Liquid
@@ -214,7 +192,7 @@ struct SessionsView: View {
             }
         }
         .sheet(isPresented: $optionsShown) {
-            SessionOptionsSheet(sessions: sessions, filters: $filters, sort: $sort)
+            SessionOptionsSheet(sessions: store.sessions, filters: $store.filters, sort: $store.sort)
                 .presentationDetents([.medium, .large])
         }
         .refreshable { await refreshSessions() }
@@ -226,7 +204,7 @@ struct SessionsView: View {
             optionsShown = true
         } label: {
             Label("Filter & Sort", systemImage: "line.3.horizontal.decrease")
-                .symbolVariant(filters.isEmpty ? .none : .circle.fill)
+                .symbolVariant(store.filters.isEmpty ? .none : .circle.fill)
         }
         .tint(Color.ink)
     }
@@ -234,14 +212,14 @@ struct SessionsView: View {
     @ViewBuilder
     private var voiceButton: some View {
         if #available(iOS 26.0, *) {
-            NavigationLink(value: "voice") {
+            NavigationLink(value: SessionsRoute.voice) {
                 LukeMark()
                     .foregroundStyle(Color.ink)
                     .frame(width: 22, height: 20)
             }
             .accessibilityLabel("Talk to Luke")
         } else {
-            NavigationLink(value: "voice") {
+            NavigationLink(value: SessionsRoute.voice) {
                 LukeMark()
                     .foregroundStyle(Color.ink)
                     .frame(width: 22, height: 20)
@@ -265,7 +243,7 @@ struct SessionsView: View {
         } description: {
             Text("Filters hide ^[\(hiddenCount) sessions](inflect: true).")
         } actions: {
-            Button("Clear Filters") { filters.removeAll() }
+            Button("Clear Filters") { store.filters.removeAll() }
                 .tint(Color.ink)
         }
         .padding(.top, 40)
@@ -292,7 +270,7 @@ struct SessionsView: View {
         Group {
             if hasRowActs(s) {
                 core.contextMenu {
-                    rowMenu(s, viewDetails: nil, sendMessage: { openedSession = s })
+                    rowMenu(s, viewDetails: nil, sendMessage: { store.open(s) })
                 } preview: {
                     SessionRowPreview(session: s)
                 }
@@ -317,7 +295,7 @@ struct SessionsView: View {
         // Every row opens the session's own screen; whether that screen takes
         // a message is the observation's word, said there rather than by
         // making some rows dead to the touch.
-        Button { openedSession = s } label: {
+        Button { store.open(s) } label: {
             SessionRow(session: s)
         }
         .buttonStyle(.plain)
@@ -405,13 +383,7 @@ struct SessionsView: View {
         // happens at the press — the row slides out and the screen it opened
         // pops — with the act following behind rather than the press waiting
         // on two round trips.
-        if control.kind == .archive {
-            archivingIds.insert(s.id)
-            if openedSession?.id == s.id {
-                openedSession = nil
-            }
-            withAnimation { sessions.removeAll { $0.id == s.id } }
-        }
+        if control.kind == .archive { store.beginArchiving(s) }
         Task {
             let delivered = await performAct(on: s, counting: .controlRun) { token in
                 try await actClient.executeControl(
@@ -422,19 +394,8 @@ struct SessionsView: View {
                 )
             }
             if control.kind == .archive {
-                archivingIds.remove(s.id)
-                if !delivered {
-                    // Restored locally before the refresh converges, because
-                    // the outage that refused the act usually fails the
-                    // refresh too, and a chat the server never archived must
-                    // not stay gone on the refusal's word alone.
-                    withAnimation {
-                        if !sessions.contains(where: { $0.id == s.id }) {
-                            sessions.append(s)
-                        }
-                    }
-                    await refreshSessions()
-                }
+                store.endArchiving(s, delivered: delivered)
+                if !delivered { await refreshSessions() }
             }
         }
     }
@@ -480,7 +441,7 @@ struct SessionsView: View {
     @ViewBuilder
     private var emptyRow: some View {
         Group {
-            if let error = fetchError {
+            if let error = store.fetchError {
                 ContentUnavailableView {
                     Label("Couldn't Load Sessions", systemImage: "exclamationmark.triangle")
                 } description: {
@@ -503,41 +464,7 @@ struct SessionsView: View {
     }
 
     private func refreshSessions() async {
-        refreshPass += 1
-        let pass = refreshPass
-        fetchError = nil
-        guard case .signedIn = session.state else { return }
-        do {
-            let fetched = try await session.authorized { token in
-                try await rosterClient.observe(bearerToken: token)
-            }
-            guard pass > landedPass else { return }
-            landedPass = pass
-            // Animated so a row an act just removed slides out the way a
-            // deleted Mail row does, instead of blinking.
-            withAnimation { sessions = fetched.filter { !archivingIds.contains($0.id) } }
-            awaitingFirstRoster = false
-            recordObservation(fetched)
-        } catch is AccountSessionError {
-            ()  // Signed out — the state change redraws automatically.
-        } catch {
-            guard pass == refreshPass else { return }
-            fetchError = error.localizedDescription
-        }
-    }
-
-    /// One count per provider per day, in buckets — refreshing is not using.
-    /// A provider id the shared vocabulary has not answered for is left
-    /// uncounted rather than sent to be refused.
-    private func recordObservation(_ sessions: [RosterSession]) {
-        let rowsByProvider = Dictionary(grouping: sessions, by: \.providerId)
-        for (providerId, rows) in rowsByProvider {
-            guard let provider = ProductProviderID(rawValue: providerId) else { continue }
-            events.recordOncePerDay(
-                .sessionObserve(provider: provider, sessions: .bucket(for: rows.count)),
-                discriminator: providerId
-            )
-        }
+        await store.refresh(account: session, events: events)
     }
 }
 

--- a/apps/ios/Luke/VoiceActDispatcher.swift
+++ b/apps/ios/Luke/VoiceActDispatcher.swift
@@ -1,85 +1,202 @@
 import Foundation
 import LukeKit
 
-/// Maps the Realtime tool names the mobile session receives to the hosted act
-/// endpoints that carry them, mirroring `HOSTED_SERVICE_PATH` in `@sidecar/hosted`.
-///
-/// The model's tool call arguments use snake_case (`provider_id`,
-/// `provider_session_id`). The act endpoints accept camelCase body keys
-/// (`providerId`, `providerSessionId`). This function translates between them.
+/// What a tool call is carried against: the roster and projects the
+/// conversation was shown, the account's bearer, and the two presses the
+/// list offers that a spoken ask may take instead. Every value here is read at the moment of the call, so an act is
+/// validated against the roster as it stands then, never as it stood when
+/// the call was minted.
+@MainActor
+struct VoiceActContext {
+    /// The tools the service minted the call with, as the server confirmed
+    /// them at channel open; nil before a call has connected. A call naming
+    /// a tool outside the set is refused before it is looked at.
+    let mintedTools: [String]?
+    let sessions: [RosterSession]
+    let projects: ProjectsAnswer?
+    let defaults: WorkspaceCreationDefaults
+    let actClient: ActClient
+    let accessToken: () async throws -> String
+    /// Counts an act a provider accepted, under its allowlisted name alone.
+    let count: (ProductSessionAct, _ providerId: String) -> Void
+    let refreshRoster: () async -> Void
+    let open: (RosterSession) -> Void
+    let showList: (VoiceAsks.SessionListAsk) -> Void
+}
+
+/// Carries one tool call the model composed in a turn the developer opened.
+/// Each act is validated on the phone against what the conversation was
+/// shown, then either performed here — an open, or the list — or sent
+/// to the hosted act endpoint that serves it, which re-observes and validates
+/// it again before anything is written. The answer is the JSON the model
+/// reads back as the call's output: an outcome and, on a refusal, the reason
+/// Luke can say aloud.
 @MainActor
 func dispatchVoiceToolCall(
     name: String,
     arguments: [String: Any],
-    callId: String,
-    accessToken: String,
-    serviceURL: URL,
-    http: HTTPClient = URLSession.shared
+    context: VoiceActContext
 ) async -> String {
-    guard let path = actPath(for: name) else {
-        return #"{"error":"unsupported tool"}"#
+    guard let tool = VoiceToolName(rawValue: name) else {
+        return refusal("No such tool exists.")
     }
-    let body = actBody(toolName: name, arguments: arguments)
-    guard let bodyData = try? JSONSerialization.data(withJSONObject: body) else {
-        return #"{"error":"invalid arguments"}"#
+    // The minted set is the service's word on what this call may ask for;
+    // the phone honors it even for a tool it knows how to carry.
+    if let minted = context.mintedTools, !minted.contains(name) {
+        return refusal("The service did not mint that tool for this call.")
     }
-    var request = URLRequest(url: serviceURL.appendingPathComponent(path))
-    request.httpMethod = "POST"
-    request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
-    request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-    request.httpBody = bodyData
-    do {
-        let (data, response) = try await http.data(for: request)
-        let status = (response as? HTTPURLResponse)?.statusCode ?? 0
-        // Return the raw JSON response body as the function_call_output. The
-        // server's act result is already a bounded JSON object, so the model
-        // receives {"result":"sent"} or {"result":"rejected","reason":"..."}.
-        if (200 ..< 300).contains(status) || (400 ..< 500).contains(status) {
-            return String(data: data, encoding: .utf8) ?? #"{"error":"empty response"}"#
+    switch tool {
+    case .sendSessionMessage:
+        return await carry(VoiceAsks.message(arguments, in: context.sessions), context, .messageSend) {
+            ask, token in
+            try await context.actClient.sendMessage(
+                accessToken: token,
+                providerId: ask.session.providerId,
+                providerSessionId: ask.session.sessionId,
+                text: ask.text
+            )
         }
-        return #"{"error":"server error \#(status)"}"#
-    } catch {
-        return #"{"error":"network error"}"#
+    case .runSessionControl:
+        return await carry(VoiceAsks.control(arguments, in: context.sessions), context, .controlRun) {
+            ask, token in
+            try await context.actClient.executeControl(
+                accessToken: token,
+                providerId: ask.session.providerId,
+                providerSessionId: ask.session.sessionId,
+                controlId: ask.control.id
+            )
+        }
+    case .addWorkspaceAgent:
+        let agentModels = context.projects?.agentModels ?? []
+        return await carry(
+            VoiceAsks.addAgent(arguments, in: context.sessions, agentModels: agentModels), context,
+            .agentAdd
+        ) { ask, token in
+            try await context.actClient.spawnAgent(
+                accessToken: token,
+                providerId: ask.session.providerId,
+                providerSessionId: ask.session.sessionId,
+                agent: ask.agent,
+                name: ask.name,
+                task: ask.task,
+                model: ask.model,
+                effort: ask.effort
+            )
+        }
+    case .renameWorkspace:
+        return await carry(
+            VoiceAsks.renameWorkspace(arguments, in: context.sessions), context, .workspaceRename
+        ) { ask, token in
+            try await context.actClient.renameWorkspace(
+                accessToken: token,
+                providerId: ask.session.providerId,
+                providerSessionId: ask.session.sessionId,
+                name: ask.name
+            )
+        }
+    case .renameSession:
+        return await carry(
+            VoiceAsks.renameSession(arguments, in: context.sessions), context, .sessionRename
+        ) { ask, token in
+            try await context.actClient.renameSession(
+                accessToken: token,
+                providerId: ask.session.providerId,
+                providerSessionId: ask.session.sessionId,
+                name: ask.name
+            )
+        }
+    case .createWorkspace:
+        guard let projects = context.projects else {
+            return refusal("The projects a workspace can be created in have not loaded yet.")
+        }
+        let ask = VoiceAsks.workspaceCreation(
+            arguments,
+            projects: projects,
+            defaultProviderId: context.defaults.lastProviderId,
+            defaultProjectIds: context.defaults.lastProjectIds
+        )
+        return await carry(ask, context, .workspaceCreate) { ask, token in
+            let answer = try await context.actClient.createWorkspace(
+                accessToken: token,
+                providerId: ask.project.providerId,
+                providerProjectId: ask.project.providerProjectId,
+                name: ask.name,
+                task: ask.task,
+                agent: ask.agent,
+                model: ask.model,
+                effort: ask.effort
+            )
+            if answer.result == .accepted {
+                // The first creation saves its provider as the default, the
+                // same tie-break the New Workspace sheet remembers.
+                context.defaults.lastProviderId = ask.project.providerId
+                context.defaults.setLastProjectId(
+                    ask.project.providerProjectId, for: ask.project.providerId
+                )
+            }
+            return answer
+        }
+    case .openSession:
+        switch VoiceAsks.open(arguments, in: context.sessions) {
+        case .failure(let refused): return refusal(refused.reason)
+        case .success(let session):
+            context.open(session)
+            context.count(.sessionOpen, session.providerId)
+            return voiceToolOutput(["result": "accepted"])
+        }
+    case .showPanel:
+        switch VoiceAsks.sessionList(arguments, in: context.sessions) {
+        case .failure(let refused): return refusal(refused.reason)
+        case .success(let ask):
+            context.showList(ask)
+            return voiceToolOutput(["result": "accepted"])
+        }
     }
 }
 
-// Maps the snake_case tool name from the model to the act endpoint path.
-private func actPath(for toolName: String) -> String? {
-    switch toolName {
-    case "send_session_message": return "api/acts/message"
-    case "run_session_control": return "api/acts/control"
-    case "add_workspace_agent": return "api/acts/agent"
-    case "rename_workspace": return "api/acts/rename-workspace"
-    case "rename_session": return "api/acts/rename-session"
-    default: return nil
+/// Runs one validated session act against its hosted endpoint, counts an
+/// accepted one, and refreshes the roster so the next call is validated
+/// against what the act changed. The endpoint's own answer is what the model
+/// reads: accepted, or rejected with the server's reason.
+@MainActor
+private func carry<Ask: VoiceProviderAsk, Answer: ActAnswer>(
+    _ validated: Result<Ask, VoiceAskRefusal>,
+    _ context: VoiceActContext,
+    _ counted: ProductSessionAct,
+    _ call: (Ask, String) async throws -> Answer
+) async -> String {
+    switch validated {
+    case .failure(let refused):
+        return refusal(refused.reason)
+    case .success(let ask):
+        do {
+            let token = try await context.accessToken()
+            let answer = try await call(ask, token)
+            if answer.result == .accepted {
+                context.count(counted, ask.providerId)
+                await context.refreshRoster()
+            }
+            var output: [String: Any] = ["result": answer.result.rawValue]
+            if let reason = answer.reason { output["reason"] = reason }
+            return voiceToolOutput(output)
+        } catch is AccountSessionError {
+            return voiceToolOutput(["error": "signed out"])
+        } catch {
+            return voiceToolOutput(["error": "network error"])
+        }
     }
 }
 
-// Translates snake_case tool arguments to the camelCase body the act endpoints expect.
-private func actBody(toolName: String, arguments: [String: Any]) -> [String: Any] {
-    func str(_ key: String) -> String? { arguments[key] as? String }
-    var body: [String: Any] = [:]
+private func refusal(_ reason: String) -> String {
+    voiceToolOutput(["result": "rejected", "reason": reason])
+}
 
-    switch toolName {
-    default:
-        if let v = str("provider_id") { body["providerId"] = v }
-        if let v = str("provider_session_id") { body["providerSessionId"] = v }
-        switch toolName {
-        case "send_session_message":
-            if let v = str("text") { body["text"] = v }
-        case "run_session_control":
-            if let v = str("control_id") { body["controlId"] = v }
-        case "add_workspace_agent":
-            if let v = str("agent") { body["agent"] = v }
-            if let v = str("name") { body["name"] = v }
-            if let v = str("task") { body["task"] = v }
-            if let v = str("model") { body["model"] = v }
-            if let v = str("effort") { body["effort"] = v }
-        case "rename_workspace", "rename_session":
-            if let v = str("name") { body["name"] = v }
-        default:
-            break
-        }
-    }
-    return body
+/// The call's output as the model reads it: a bounded JSON object, never
+/// text a value could break out of.
+private func voiceToolOutput(_ fields: [String: Any]) -> String {
+    guard
+        let data = try? JSONSerialization.data(withJSONObject: fields, options: [.sortedKeys]),
+        let text = String(data: data, encoding: .utf8)
+    else { return #"{"error":"unreadable output"}"# }
+    return text
 }

--- a/apps/ios/Luke/VoiceActDispatcher.swift
+++ b/apps/ios/Luke/VoiceActDispatcher.swift
@@ -10,7 +10,8 @@ import LukeKit
 struct VoiceActContext {
     /// The tools the service minted the call with, as the server confirmed
     /// them at channel open; nil before a call has connected. A call naming
-    /// a tool outside the set is refused before it is looked at.
+    /// a tool outside the set, or arriving before the set is known, is
+    /// refused before it is looked at.
     let mintedTools: [String]?
     let sessions: [RosterSession]
     let projects: ProjectsAnswer?
@@ -41,8 +42,12 @@ func dispatchVoiceToolCall(
         return refusal("No such tool exists.")
     }
     // The minted set is the service's word on what this call may ask for;
-    // the phone honors it even for a tool it knows how to carry.
-    if let minted = context.mintedTools, !minted.contains(name) {
+    // the phone honors it even for a tool it knows how to carry, and a call
+    // arriving before the set is known is refused rather than trusted.
+    guard let minted = context.mintedTools else {
+        return refusal("The call's minted tools are not known yet.")
+    }
+    guard minted.contains(name) else {
         return refusal("The service did not mint that tool for this call.")
     }
     switch tool {

--- a/apps/ios/Luke/VoiceSettingsSheet.swift
+++ b/apps/ios/Luke/VoiceSettingsSheet.swift
@@ -3,7 +3,12 @@ import SwiftUI
 
 /// The desktop's voice settings that apply on this device. The Mac-only rows
 /// (microphone choice, media ducking, announcements, captions) are not drawn.
+/// Under them, a debug section lists every tool the desktop's conversation
+/// carries and why Luke cannot be asked for one here right now, read from
+/// the current call and the observed roster.
 struct VoiceSettingsSheet: View {
+    let toolReport: VoiceToolReport
+
     @AppStorage(VoiceSettingsKey.voice) private var voice = RealtimeVoice.default
     @AppStorage(VoiceSettingsKey.speed) private var speed = RealtimeVoiceSpeed.default
     @Environment(ProductEventSender.self) private var events
@@ -49,6 +54,20 @@ struct VoiceSettingsSheet: View {
                             .tint(Color.ink)
                     }
                 }
+
+                Section {
+                    ForEach(toolReport.standings) { standing in
+                        toolRow(standing)
+                    }
+                } header: {
+                    Text("Debug")
+                } footer: {
+                    Text(
+                        toolReport.mintedKnown
+                            ? "Every tool Luke can be asked for on the Mac, and why one is not available here right now. Read from the current call's minted tools and the observed sessions."
+                            : "Every tool Luke can be asked for on the Mac, and why one is not available here right now. Which tools the service minted is known once a call connects."
+                    )
+                }
             }
             .animation(.default, value: isChanged)
             .navigationTitle("Voice Settings")
@@ -64,6 +83,27 @@ struct VoiceSettingsSheet: View {
 
     private var isChanged: Bool {
         voice != RealtimeVoice.default || speed != RealtimeVoiceSpeed.default
+    }
+
+    /// One tool: its name as the model calls it, what it does or why it is
+    /// not available, and a mark for which of the two the second line is.
+    private func toolRow(_ standing: VoiceToolStanding) -> some View {
+        HStack(alignment: .firstTextBaseline, spacing: 12) {
+            VStack(alignment: .leading, spacing: 3) {
+                Text(standing.name)
+                    .font(.subheadline.monospaced())
+                    .foregroundStyle(Color.ink)
+                Text(standing.unavailableReason ?? standing.summary)
+                    .font(.footnote)
+                    .foregroundStyle(Color.inkSecondary)
+            }
+            Spacer(minLength: 0)
+            Image(systemName: standing.isAvailable ? "checkmark.circle.fill" : "minus.circle")
+                .foregroundStyle(standing.isAvailable ? Color.stateComplete : Color.inkTertiary)
+                .accessibilityHidden(true)
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityValue(standing.isAvailable ? "Available" : "Not available")
     }
 
     // Each control counts its own change so a reset counts once, as a reset.

--- a/apps/ios/Luke/VoiceView.swift
+++ b/apps/ios/Luke/VoiceView.swift
@@ -17,6 +17,15 @@ private struct VoiceTranscriptMessage: Identifiable, Equatable {
     var words: String
 }
 
+/// Where a spoken act asked to take the developer once Luke has finished
+/// saying so: a session's own screen, or the list narrowed as asked. Held
+/// until the reply settles, because moving the screen mid-sentence would
+/// close the call that is still speaking.
+private enum PendingNavigation {
+    case open(RosterSession)
+    case list(VoiceAsks.SessionListAsk)
+}
+
 /// Holds all observable voice session state. Lives on the main actor so the
 /// session's @MainActor callbacks can update it without hopping actors.
 @Observable
@@ -28,7 +37,21 @@ private final class VoiceSessionModel {
     // Read at each start, so a reconnect mints with the latest choice.
     var voice = RealtimeVoice.default
     var speed = RealtimeVoiceSpeed.default
+    var pendingNavigation: PendingNavigation?
+    /// The tools the service minted the latest call with, as the server
+    /// confirmed them at channel open; nil until a call has connected.
+    private(set) var mintedTools: [String]?
+    /// Where a workspace can be created, fetched beside the mint so the
+    /// conversation is told it at channel open and a creation ask can be
+    /// validated against it. Nil until an answer lands, and left nil when
+    /// the fetch fails, so the conversation is told nothing rather than
+    /// told there is nowhere.
+    private(set) var projects: ProjectsAnswer?
+    /// The New Workspace choices this device remembers, read at the moment a
+    /// call opens or an act lands.
+    let defaults = WorkspaceCreationDefaults()
     private var session: RealtimeSession?
+    private var makeActContext: (@MainActor () -> VoiceActContext)?
     private var activeTurnId: UUID?
     private var activeResponseMessageId: UUID?
     // Kept while this screen is alive so a direct press can reopen a socket
@@ -38,20 +61,33 @@ private final class VoiceSessionModel {
     private var reconnectingForTurn = false
     private var endTurnAfterReconnect = false
 
-    func start(accountSession: AccountSession, startWithTurn: Bool = false) async {
+    func start(
+        accountSession: AccountSession,
+        actContext: @escaping @MainActor () -> VoiceActContext,
+        startWithTurn: Bool = false
+    ) async {
         guard session == nil else { return }
         errorMessage = nil
+        makeActContext = actContext
 
         let mintVoice = voice.rawValue
         let mintSpeed = speed.multiplier
         let opts = RealtimeSessionOptions(
-            requestConnection: { [weak accountSession] in
+            requestConnection: { [weak accountSession, weak self] in
                 guard let accountSession else {
                     throw AccountSessionError.signedOut
                 }
                 let token = try await accountSession.validAccessToken()
+                // Fetched beside the mint rather than after it: the projects
+                // item is sent at channel open, and the ephemeral key's
+                // minute is not to be spent waiting on a second round trip.
+                async let projects = try? ProjectsClient(serviceURL: AccountConstants.serviceURL)
+                    .projects(bearerToken: token)
                 let connection = try await VoiceMintClient(baseURL: AccountConstants.serviceURL)
                     .mint(accessToken: token, voice: mintVoice, speed: mintSpeed)
+                if let answer = await projects {
+                    await MainActor.run { [weak self] in self?.projects = answer }
+                }
                 return connection
             },
             onStatus: { [weak self] newStatus in
@@ -70,22 +106,35 @@ private final class VoiceSessionModel {
             onRecoverableError: { [weak self] message in
                 self?.errorMessage = message
             },
-            dispatchToolCall: { [weak accountSession] name, arguments, callId in
-                let token = (try? await accountSession?.validAccessToken()) ?? ""
+            onSessionTools: { [weak self] names in self?.mintedTools = names },
+            dispatchToolCall: { [weak self] name, arguments, _ in
+                guard let self, let makeActContext = self.makeActContext else {
+                    return #"{"error":"not authorized"}"#
+                }
                 return await dispatchVoiceToolCall(
                     name: name,
                     arguments: arguments,
-                    callId: callId,
-                    accessToken: token,
-                    serviceURL: AccountConstants.serviceURL
+                    context: makeActContext()
                 )
+            },
+            contextItems: { [weak self] in
+                guard let self, let projects = self.projects else { return [] }
+                return [
+                    WorkspaceProjectsContext.item(
+                        answer: projects,
+                        defaultProviderId: self.defaults.lastProviderId,
+                        defaultProjectIds: self.defaults.lastProjectIds
+                    )
+                ]
             },
             makeAudioCapturer: { VoiceAudioCapturer() },
             makeAudioPlayer: { VoiceAudioPlayer() }
         )
         reconnectCallback = { [weak self, weak accountSession] startWithTurn in
             guard let accountSession else { return }
-            await self?.start(accountSession: accountSession, startWithTurn: startWithTurn)
+            await self?.start(
+                accountSession: accountSession, actContext: actContext, startWithTurn: startWithTurn
+            )
         }
         let s = RealtimeSession(options: opts)
         session = s
@@ -104,6 +153,9 @@ private final class VoiceSessionModel {
 
     func beginTurn() {
         errorMessage = nil
+        // A new press supersedes what the last reply was about to do: an open
+        // the developer talked over is an open they no longer want taken.
+        pendingNavigation = nil
         activeTurnId = UUID()
         activeResponseMessageId = nil
         if let session {
@@ -130,9 +182,9 @@ private final class VoiceSessionModel {
     func changeVoice(_ newVoice: RealtimeVoice, accountSession: AccountSession) async {
         guard newVoice != voice else { return }
         voice = newVoice
-        guard session != nil else { return }
+        guard session != nil, let makeActContext else { return }
         stop()
-        await start(accountSession: accountSession)
+        await start(accountSession: accountSession, actContext: makeActContext)
     }
 
     func changeSpeed(_ newSpeed: RealtimeVoiceSpeed) {
@@ -208,7 +260,10 @@ struct VoiceView: View {
     @Environment(AccountSession.self) private var accountSession
     @AppStorage(VoiceSettingsKey.voice) private var voice = RealtimeVoice.default
     @AppStorage(VoiceSettingsKey.speed) private var speed = RealtimeVoiceSpeed.default
+    @Environment(ProductEventSender.self) private var events
+    @Environment(SessionsStore.self) private var store
     @State private var model = VoiceSessionModel()
+    private let actClient = ActClient(baseURL: AccountConstants.serviceURL)
     @State private var isPressing = false
     @State private var isLatched = false
     @State private var pressBeganAt: TimeInterval?
@@ -226,14 +281,25 @@ struct VoiceView: View {
             ToolbarItem(placement: .topBarTrailing) { settingsButton }
         }
         .sheet(isPresented: $settingsShown) {
-            VoiceSettingsSheet()
+            VoiceSettingsSheet(
+                toolReport: VoiceToolAvailability.report(
+                    mintedTools: model.mintedTools,
+                    sessions: store.sessions,
+                    projects: model.projects
+                )
+            )
                 .presentationDetents([.medium, .large])
                 .presentationDragIndicator(.visible)
         }
         .task {
             model.voice = voice
             model.speed = speed
-            await model.start(accountSession: accountSession)
+            // The roster the acts are validated against is the list's own,
+            // refreshed as the call opens so a session archived since the
+            // list last drew is not offered as somewhere to act.
+            async let roster: Void = store.refresh(account: accountSession, events: events)
+            await model.start(accountSession: accountSession, actContext: makeActContext)
+            await roster
         }
         .onChange(of: voice) { _, newVoice in
             Task { await model.changeVoice(newVoice, accountSession: accountSession) }
@@ -242,9 +308,51 @@ struct VoiceView: View {
         .onChange(of: model.status) { _, newStatus in
             // Connecting is part of an idle tap's active turn. Clearing here
             // would make VoiceOver lose the second-tap-to-send affordance.
-            if newStatus == .ready || newStatus == .idle { isLatched = false }
+            if newStatus == .ready || newStatus == .idle {
+                isLatched = false
+                performPendingNavigation()
+            }
         }
         .onDisappear { model.stop() }
+    }
+
+    /// What a tool call is carried against, read at the moment of the call.
+    /// An open or a list ask is held for the reply to finish rather than
+    /// performed at once: the screen moving mid-sentence would close the call
+    /// still speaking the words that announce it.
+    private func makeActContext() -> VoiceActContext {
+        VoiceActContext(
+            mintedTools: model.mintedTools,
+            sessions: store.sessions,
+            projects: model.projects,
+            defaults: model.defaults,
+            actClient: actClient,
+            accessToken: { [accountSession] in try await accountSession.validAccessToken() },
+            count: { [events] act, providerId in
+                // A provider id the shared vocabulary has not answered for is
+                // left uncounted rather than sent to be refused.
+                guard let provider = ProductProviderID(rawValue: providerId) else { return }
+                events.record(.sessionActSend(provider: provider, act: act))
+            },
+            refreshRoster: { [store, accountSession, events] in
+                await store.refresh(account: accountSession, events: events)
+            },
+            // One screen, so the last open a reply names is the one taken.
+            open: { [model] session in model.pendingNavigation = .open(session) },
+            showList: { [model] ask in model.pendingNavigation = .list(ask) }
+        )
+    }
+
+    /// Takes the developer where the settled reply said they were going. The
+    /// voice screen leaves the stack either way, and this screen's
+    /// `onDisappear` closes the call behind it.
+    private func performPendingNavigation() {
+        guard let pending = model.pendingNavigation else { return }
+        model.pendingNavigation = nil
+        switch pending {
+        case .open(let session): store.openLeavingConversation(session)
+        case .list(let ask): store.showList(ask)
+        }
     }
 
     // MARK: - Sub-views

--- a/apps/ios/LukeKit/Sources/LukeKit/ActClient.swift
+++ b/apps/ios/LukeKit/Sources/LukeKit/ActClient.swift
@@ -112,13 +112,17 @@ public final class ActClient: Sendable {
     ///
     /// `agent` must be one of the kinds the session's latest observation
     /// listed as spawnable; the server re-observes and validates it again.
+    /// `model` and `effort` name a choice from the projects answer's own
+    /// agent table, validated by the server against the same table.
     public func spawnAgent(
         accessToken: String,
         providerId: String,
         providerSessionId: String,
         agent: String,
         name: String? = nil,
-        task: String? = nil
+        task: String? = nil,
+        model: String? = nil,
+        effort: String? = nil
     ) async throws -> ActWorkspaceAnswer {
         let url = baseURL.appendingPathComponent("api/acts/agent")
         var body: [String: String] = [
@@ -132,6 +136,8 @@ public final class ActClient: Sendable {
         if let task = task?.trimmingCharacters(in: .whitespacesAndNewlines), !task.isEmpty {
             body["task"] = task
         }
+        if let model, !model.isEmpty { body["model"] = model }
+        if let effort, !effort.isEmpty { body["effort"] = effort }
         return try await post(url: url, body: body, accessToken: accessToken)
     }
 

--- a/apps/ios/LukeKit/Sources/LukeKit/RealtimeSession.swift
+++ b/apps/ios/LukeKit/Sources/LukeKit/RealtimeSession.swift
@@ -66,6 +66,10 @@ public struct RealtimeSessionOptions: Sendable {
     /// Called when the server rejects one event but keeps the session open.
     /// The current turn may end, but the developer can immediately try again.
     public var onRecoverableError: (@MainActor @Sendable (String) -> Void)?
+    /// Called with the names of the tools the service minted this call with,
+    /// read off the session the server confirms at channel open. The one
+    /// place the phone learns what Luke can actually be asked for.
+    public var onSessionTools: (@MainActor @Sendable ([String]) -> Void)?
 
     /// Dispatches an armed tool call to the appropriate hosted act endpoint.
     /// Receives the tool name, the parsed arguments, and the call id; returns
@@ -76,6 +80,12 @@ public struct RealtimeSessionOptions: Sendable {
         _ arguments: [String: Any],
         _ callId: String
     ) async -> String)?
+
+    /// The context items the phone composes itself — where a workspace can
+    /// be created — read at the moment the channel opens and sent after the
+    /// mint's roster item. Context, never a prompt: sending them requests no
+    /// response.
+    public var contextItems: @MainActor @Sendable () -> [VoiceContextItem]
 
     /// Overrides the WebSocket factory for tests. When nil, the session opens
     /// a URLSessionWebSocketTask to `connection.wsURL` with the ephemeral key.
@@ -103,9 +113,11 @@ public struct RealtimeSessionOptions: Sendable {
         onSpokenAsk: (@MainActor @Sendable (String) -> Void)? = nil,
         onError: @MainActor @Sendable @escaping (String?) -> Void,
         onRecoverableError: (@MainActor @Sendable (String) -> Void)? = nil,
+        onSessionTools: (@MainActor @Sendable ([String]) -> Void)? = nil,
         dispatchToolCall: (
             @Sendable @MainActor (_ name: String, _ arguments: [String: Any], _ callId: String) async -> String
         )? = nil,
+        contextItems: @MainActor @Sendable @escaping () -> [VoiceContextItem] = { [] },
         makeWebSocket: (@Sendable (URL, String) -> any WebSocketTask)? = nil,
         makeAudioCapturer: @Sendable @escaping () -> any AudioCapturer,
         makeAudioPlayer: @Sendable @escaping () -> any AudioPlayer,
@@ -120,7 +132,9 @@ public struct RealtimeSessionOptions: Sendable {
         self.onSpokenAsk = onSpokenAsk
         self.onError = onError
         self.onRecoverableError = onRecoverableError
+        self.onSessionTools = onSessionTools
         self.dispatchToolCall = dispatchToolCall
+        self.contextItems = contextItems
         self.makeWebSocket = makeWebSocket
         self.makeAudioCapturer = makeAudioCapturer
         self.makeAudioPlayer = makeAudioPlayer
@@ -357,6 +371,7 @@ public final class RealtimeSession {
                 if !channelOpen {
                     guard type == "session.created" || type == "session.updated" else { continue }
                     channelOpen = true
+                    options.onSessionTools?(mintedToolNames(json))
                     await onChannelOpen(ws: ws, context: context)
                     continue
                 }
@@ -377,6 +392,9 @@ public final class RealtimeSession {
         if let speed = pendingSpeed {
             pendingSpeed = nil
             try? await ws.sendText(sessionSpeedUpdateJSON(speed))
+        }
+        for item in options.contextItems() {
+            try? await ws.sendText(contextItemJSON(item))
         }
         for chunk in pressBuffer.drain() {
             try? await ws.sendText(audioAppendJSON(chunk))
@@ -503,6 +521,11 @@ public final class RealtimeSession {
             .flatMap { $0["output"] as? [[String: Any]] } ?? []
         let functionCalls = output.filter { $0["type"] as? String == "function_call" }
         responseStarted = false
+        // Marked in flight before the first act is carried, not after: the
+        // primary reply's audio can finish draining while an act's output is
+        // still being sent, and a drain that found no follow-up pending would
+        // return the session to ready with the follow-up's words still to come.
+        if !functionCalls.isEmpty { followUpPending = true }
 
         for item in functionCalls {
             guard
@@ -526,10 +549,8 @@ public final class RealtimeSession {
         }
 
         if !functionCalls.isEmpty {
-            // Follow-up response requested; stay in .thinking until the model speaks.
-            // Mark the follow-up in flight so the current audio ending does not
-            // return the session to .ready prematurely.
-            followUpPending = true
+            // Follow-up response requested; the session stays in .thinking or
+            // .speaking until the model's follow-up speaks and settles.
             responseStarted = false
             try? await ws.sendText(responseCreateJSON(sequence: responseInterruptionSequence))
             // A barge-in can land while the socket send is suspended. Its new
@@ -713,6 +734,14 @@ public final class RealtimeSession {
     }
 
     // MARK: - JSON helpers
+
+    /// The tool names on the session the server confirmed; a session that
+    /// lists none, or lists them in a shape this build does not read, is a
+    /// session with no tools.
+    private func mintedToolNames(_ json: [String: Any]) -> [String] {
+        let tools = (json["session"] as? [String: Any])?["tools"] as? [[String: Any]] ?? []
+        return tools.compactMap { $0["name"] as? String }
+    }
 
     private func contextItemJSON(_ item: VoiceContextItem) -> String {
         let escaped = jsonEscape(item.text)

--- a/apps/ios/LukeKit/Sources/LukeKit/RealtimeSession.swift
+++ b/apps/ios/LukeKit/Sources/LukeKit/RealtimeSession.swift
@@ -744,9 +744,10 @@ public final class RealtimeSession {
     }
 
     private func contextItemJSON(_ item: VoiceContextItem) -> String {
+        let escapedId = jsonEscape(item.itemId)
         let escaped = jsonEscape(item.text)
         return """
-            {"type":"conversation.item.create","item":{"id":"\(item.itemId)","type":"message","role":"user","content":[{"type":"input_text","text":"\(escaped)"}]}}
+            {"type":"conversation.item.create","item":{"id":"\(escapedId)","type":"message","role":"user","content":[{"type":"input_text","text":"\(escaped)"}]}}
             """
     }
 

--- a/apps/ios/LukeKit/Sources/LukeKit/VoiceAsks.swift
+++ b/apps/ios/LukeKit/Sources/LukeKit/VoiceAsks.swift
@@ -1,0 +1,479 @@
+import Foundation
+
+/// The Realtime tools the phone's session may be handed, by the names
+/// `REALTIME_TOOL` in `@sidecar/acts` gives them. A call naming anything
+/// else is refused before it is looked at.
+public enum VoiceToolName: String, Sendable, CaseIterable {
+    case sendSessionMessage = "send_session_message"
+    case runSessionControl = "run_session_control"
+    case openSession = "open_session"
+    case createWorkspace = "create_workspace"
+    case addWorkspaceAgent = "add_workspace_agent"
+    case renameWorkspace = "rename_workspace"
+    case renameSession = "rename_session"
+    case showPanel = "show_panel"
+}
+
+/// Why a tool call was refused, in words Luke can say aloud.
+public struct VoiceAskRefusal: Error, Equatable, Sendable {
+    public let reason: String
+
+    public init(_ reason: String) { self.reason = reason }
+}
+
+/// A validated ask aimed at one provider's endpoint, so the act that lands
+/// can be counted under that provider's name.
+public protocol VoiceProviderAsk: Sendable {
+    var providerId: String { get }
+}
+
+/// The phone's half of the act gauntlet, mirroring the `validate` rows of
+/// `ACTS` in `@sidecar/acts` for the acts the phone carries: a call the model
+/// composed may only name a session the roster showed, doing something that
+/// session advertised, or a project the projects answer listed. Everything
+/// else is refused with a reason. The hosted endpoints validate the same act
+/// again on a fresh observation pass, so this is a first gate, never the last.
+public enum VoiceAsks {
+    /// The same bounds a typed message and a workspace name carry on the desktop.
+    public static let maximumMessageLength = 4_000
+    public static let maximumNameLength = 80
+
+    // MARK: - Session acts
+
+    public struct MessageAsk: Equatable, VoiceProviderAsk {
+        public let session: RosterSession
+        public let text: String
+
+        public var providerId: String { session.providerId }
+    }
+
+    public struct ControlAsk: Equatable, VoiceProviderAsk {
+        public let session: RosterSession
+        public let control: RosterSessionControl
+
+        public var providerId: String { session.providerId }
+    }
+
+    public struct AgentAsk: Equatable, VoiceProviderAsk {
+        public let session: RosterSession
+        public let agent: String
+        public let name: String?
+        public let task: String?
+        /// The model as its wire id, and the effort riding it, when the developer named one.
+        public let model: String?
+        public let effort: String?
+
+        public var providerId: String { session.providerId }
+    }
+
+    public struct RenameAsk: Equatable, VoiceProviderAsk {
+        public let session: RosterSession
+        public let name: String
+
+        public var providerId: String { session.providerId }
+    }
+
+    /// The one session the call names, from the roster as it now stands.
+    public static func session(
+        _ arguments: [String: Any],
+        in sessions: [RosterSession]
+    ) -> Result<RosterSession, VoiceAskRefusal> {
+        let providerId = text(arguments, "provider_id")
+        let sessionId = text(arguments, "provider_session_id")
+        guard
+            let session = sessions.first(where: {
+                $0.providerId == providerId && $0.sessionId == sessionId
+            })
+        else { return .failure(VoiceAskRefusal("No observed session matches that identity.")) }
+        return .success(session)
+    }
+
+    public static func message(
+        _ arguments: [String: Any],
+        in sessions: [RosterSession]
+    ) -> Result<MessageAsk, VoiceAskRefusal> {
+        session(arguments, in: sessions).flatMap { session in
+            guard session.canReceiveMessage else {
+                return .failure(VoiceAskRefusal("That session does not take messages right now."))
+            }
+            guard let words = bounded(arguments["text"], maximumMessageLength) else {
+                return .failure(VoiceAskRefusal("That message is empty or too long."))
+            }
+            return .success(MessageAsk(session: session, text: words))
+        }
+    }
+
+    public static func control(
+        _ arguments: [String: Any],
+        in sessions: [RosterSession]
+    ) -> Result<ControlAsk, VoiceAskRefusal> {
+        session(arguments, in: sessions).flatMap { session in
+            let controlId = text(arguments, "control_id")
+            guard let control = session.controls.first(where: { $0.id == controlId }) else {
+                return .failure(VoiceAskRefusal("That session advertises no such control."))
+            }
+            return .success(ControlAsk(session: session, control: control))
+        }
+    }
+
+    /// An open on the phone lands on the session's own screen, so every
+    /// observed session has somewhere to open.
+    public static func open(
+        _ arguments: [String: Any],
+        in sessions: [RosterSession]
+    ) -> Result<RosterSession, VoiceAskRefusal> {
+        session(arguments, in: sessions)
+    }
+
+    public static func addAgent(
+        _ arguments: [String: Any],
+        in sessions: [RosterSession],
+        agentModels: [WorkspaceAgentOption]
+    ) -> Result<AgentAsk, VoiceAskRefusal> {
+        session(arguments, in: sessions).flatMap { session in
+            guard let agent = text(arguments, "agent"), session.spawnableAgents.contains(agent) else {
+                return .failure(VoiceAskRefusal("That session lists no such agent to add."))
+            }
+            var name: String?
+            if arguments["name"] != nil {
+                guard let bound = bounded(arguments["name"], maximumNameLength) else {
+                    return .failure(VoiceAskRefusal(nameBoundReason("A session name")))
+                }
+                name = bound
+            }
+            var task: String?
+            if arguments["task"] != nil {
+                guard let bound = bounded(arguments["task"], maximumMessageLength) else {
+                    return .failure(VoiceAskRefusal("That task is empty or too long."))
+                }
+                task = bound
+            }
+            let spokenModel = text(arguments, "model")
+            let spokenEffort = text(arguments, "effort")
+            if spokenEffort != nil, spokenModel == nil {
+                return .failure(VoiceAskRefusal("An effort rides a model; name the model too."))
+            }
+            var selection: AgentSelection?
+            if let spokenModel {
+                let entries = agentModels.filter {
+                    $0.providerId == session.providerId && $0.agent == agent
+                }
+                switch resolveModel(entries, model: spokenModel, effort: spokenEffort) {
+                case .success(let resolved): selection = resolved
+                case .failure(let refusal):
+                    return .failure(
+                        refusal.reason == noSuchModelReason
+                            ? VoiceAskRefusal("A \(agent) agent runs no model by that name.") : refusal
+                    )
+                }
+            }
+            return .success(
+                AgentAsk(
+                    session: session, agent: agent, name: name, task: task,
+                    model: selection?.model, effort: selection?.effort
+                )
+            )
+        }
+    }
+
+    public static func renameWorkspace(
+        _ arguments: [String: Any],
+        in sessions: [RosterSession]
+    ) -> Result<RenameAsk, VoiceAskRefusal> {
+        session(arguments, in: sessions).flatMap { session in
+            guard session.canRenameWorkspace else {
+                return .failure(VoiceAskRefusal("That session's workspace cannot be renamed."))
+            }
+            guard let name = bounded(arguments["name"], maximumNameLength) else {
+                return .failure(VoiceAskRefusal(nameBoundReason("A workspace name")))
+            }
+            return .success(RenameAsk(session: session, name: name))
+        }
+    }
+
+    public static func renameSession(
+        _ arguments: [String: Any],
+        in sessions: [RosterSession]
+    ) -> Result<RenameAsk, VoiceAskRefusal> {
+        session(arguments, in: sessions).flatMap { session in
+            guard session.canRename else {
+                return .failure(VoiceAskRefusal("That chat cannot be renamed."))
+            }
+            guard let name = bounded(arguments["name"], maximumNameLength) else {
+                return .failure(VoiceAskRefusal(nameBoundReason("A chat name")))
+            }
+            return .success(RenameAsk(session: session, name: name))
+        }
+    }
+
+    // MARK: - The list
+
+    /// What a spoken list ask changes. A nil field is left as the developer
+    /// had it; an empty filter set is the whole list.
+    public struct SessionListAsk: Equatable, Sendable {
+        public var filters: Set<SessionFilter>?
+        public var sort: SessionSort?
+        public var query: String?
+
+        public init(filters: Set<SessionFilter>? = nil, sort: SessionSort? = nil, query: String? = nil) {
+            self.filters = filters
+            self.sort = sort
+            self.query = query
+        }
+    }
+
+    static let wholeList = "all"
+
+    /// Validates a spoken narrowing against the sessions actually observed. A
+    /// narrowing that would show nothing is refused rather than applied, and
+    /// each value is checked on its own first so the refusal can name the
+    /// value that is wrong rather than only the combination.
+    public static func sessionList(
+        _ arguments: [String: Any],
+        in sessions: [RosterSession]
+    ) -> Result<SessionListAsk, VoiceAskRefusal> {
+        var ask = SessionListAsk()
+        if let sortWord = arguments["sort"] {
+            switch sortWord as? String {
+            case "urgency": ask.sort = .urgency
+            case "recency": ask.sort = .recency
+            default: return .failure(VoiceAskRefusal("The list orders by urgency or by recency."))
+            }
+        }
+        if let query = text(arguments, "query") {
+            guard sessions.count >= 2 else {
+                return .failure(
+                    VoiceAskRefusal("The list offers a search only when more than one session is observed.")
+                )
+            }
+            ask.query = query
+        }
+        guard let spoken = arguments["filters"] else { return .success(ask) }
+        let entries: [String]
+        if let one = spoken as? String {
+            entries = [one]
+        } else if let many = spoken as? [String] {
+            entries = many
+        } else {
+            return .failure(VoiceAskRefusal("filters takes a list of filter values."))
+        }
+        var chosen: [String] = []
+        for entry in entries {
+            let value = entry.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !value.isEmpty, !chosen.contains(value) { chosen.append(value) }
+        }
+        guard !chosen.isEmpty else { return .success(ask) }
+        if chosen.contains(wholeList) {
+            guard chosen.count == 1 else {
+                return .failure(VoiceAskRefusal("\(wholeList) is the whole list, so it combines with nothing."))
+            }
+            ask.filters = []
+            return .success(ask)
+        }
+        var filters = Set<SessionFilter>()
+        for value in chosen {
+            if sessions.contains(where: { $0.providerId == value }) {
+                filters.insert(.provider(value))
+            } else if sessions.contains(where: { $0.status == value }) {
+                filters.insert(.status(value))
+            } else if knownStatuses.contains(value) {
+                return .failure(VoiceAskRefusal("No \(value) sessions are observed right now."))
+            } else {
+                return .failure(
+                    VoiceAskRefusal("No observed session belongs to a provider \"\(value)\".")
+                )
+            }
+        }
+        if filters.count > 1, !sessions.contains(where: { matchesFilterSelection(filters, session: $0) }) {
+            return .failure(VoiceAskRefusal("No observed session matches that combination of filters."))
+        }
+        ask.filters = filters
+        return .success(ask)
+    }
+
+    /// The status words `SESSION_STATUS` fixes, so a status nobody is in right
+    /// now is refused as absent rather than as unknown.
+    static let knownStatuses: Set<String> = ["working", "waiting", "error", "complete", "unknown"]
+
+    // MARK: - Creating a workspace
+
+    public struct WorkspaceCreationAsk: Equatable, VoiceProviderAsk {
+        public let project: RosterProject
+        public let name: String?
+        public let task: String?
+        public let agent: String?
+        public let model: String?
+        public let effort: String?
+
+        public var providerId: String { project.providerId }
+    }
+
+    /// Validates a creation ask against the projects the conversation was
+    /// shown, settling only what the ask left unnamed from this device's own
+    /// defaults: no provider named sends a still-ambiguous ask to the default
+    /// provider while it is offering, and no project named sends it on to
+    /// that provider's chosen project. Neither step can leave the listed set.
+    public static func workspaceCreation(
+        _ arguments: [String: Any],
+        projects answer: ProjectsAnswer,
+        defaultProviderId: String?,
+        defaultProjectIds: [String: String]
+    ) -> Result<WorkspaceCreationAsk, VoiceAskRefusal> {
+        let providerId = text(arguments, "provider_id")
+        let projectId = text(arguments, "project_id")
+        var matching = answer.projects.filter {
+            (providerId == nil || $0.providerId == providerId)
+                && (projectId == nil || $0.providerProjectId == projectId)
+        }
+        if providerId == nil, let defaultProviderId, matching.count > 1 {
+            let offeredByDefault = matching.filter { $0.providerId == defaultProviderId }
+            if !offeredByDefault.isEmpty { matching = offeredByDefault }
+        }
+        if projectId == nil, matching.count > 1, let first = matching.first,
+            matching.allSatisfy({ $0.providerId == first.providerId })
+        {
+            let chosen = matching.filter {
+                defaultProjectIds[$0.providerId] == $0.providerProjectId
+            }
+            if chosen.count == 1 { matching = chosen }
+        }
+        guard matching.count == 1, let project = matching.first else {
+            return .failure(
+                VoiceAskRefusal(
+                    matching.isEmpty
+                        ? "No listed project matches that identity."
+                        : "More than one listed project matches; name the project."
+                )
+            )
+        }
+
+        let options = answer.agentModels.filter { $0.providerId == project.providerId }
+        var agent: String?
+        if let requested = text(arguments, "agent") {
+            let named = options.filter { $0.agent.lowercased() == requested.lowercased() }
+            guard let option = named.first(where: { $0.agent == requested }) ?? (named.count == 1 ? named[0] : nil)
+            else { return .failure(VoiceAskRefusal("That project lists no such agent to start.")) }
+            agent = option.agent
+        }
+
+        var name: String?
+        if arguments["name"] != nil {
+            if project.namesItself {
+                return .failure(VoiceAskRefusal("That project names its own workspaces."))
+            }
+            guard let bound = bounded(arguments["name"], maximumNameLength) else {
+                return .failure(VoiceAskRefusal(nameBoundReason("A workspace name")))
+            }
+            name = bound
+        }
+
+        var task: String?
+        if arguments["task"] != nil {
+            if project.taskSupport == ProjectTaskSupport.none {
+                return .failure(VoiceAskRefusal("That project takes no opening task."))
+            }
+            guard let bound = bounded(arguments["task"], maximumMessageLength) else {
+                return .failure(VoiceAskRefusal("That task is empty or too long."))
+            }
+            task = bound
+        } else if project.taskSupport == .required {
+            return .failure(VoiceAskRefusal("That project needs an opening task to create a workspace."))
+        }
+
+        let spokenModel = text(arguments, "model")
+        let spokenEffort = text(arguments, "effort")
+        if spokenEffort != nil, spokenModel == nil {
+            return .failure(VoiceAskRefusal("An effort rides a model; name the model too."))
+        }
+        var selection: AgentSelection?
+        if let spokenModel {
+            // A model named beside an agent resolves within that agent alone;
+            // named alone, it resolves across the provider's table and the
+            // agent that runs it is the one started.
+            let entries = agent.map { kind in options.filter { $0.agent == kind } } ?? options
+            switch resolveModel(entries, model: spokenModel, effort: spokenEffort) {
+            case .success(let resolved): selection = resolved
+            case .failure(let refusal): return .failure(refusal)
+            }
+        } else if let agent, let option = options.first(where: { $0.agent == agent }),
+            let first = option.models.first
+        {
+            // The creation endpoint takes an agent only beside a model, so an
+            // agent named alone runs the first model its table lists — the
+            // same one the New Workspace sheet preselects for it.
+            selection = AgentSelection(agent: agent, model: first.id, effort: nil)
+        }
+
+        return .success(
+            WorkspaceCreationAsk(
+                project: project,
+                name: name,
+                task: task,
+                agent: selection?.agent ?? agent,
+                model: selection?.model,
+                effort: selection?.effort
+            )
+        )
+    }
+
+    // MARK: - Shared
+
+    struct AgentSelection: Equatable {
+        let agent: String
+        let model: String
+        let effort: String?
+    }
+
+    static let noSuchModelReason = "No documented model goes by that name here."
+
+    /// Resolves a model the developer named — by the label the table lists it
+    /// under, or its id — to the wire pairing the endpoint takes. The effort,
+    /// when named, must be one the resolved model's own agent documents.
+    static func resolveModel(
+        _ entries: [WorkspaceAgentOption],
+        model word: String,
+        effort effortWord: String?
+    ) -> Result<AgentSelection, VoiceAskRefusal> {
+        let normalized = word.lowercased()
+        let named = entries.lazy
+            .flatMap { entry in entry.models.map { (entry: entry, model: $0) } }
+            .first { $0.model.label.lowercased() == normalized || $0.model.id.lowercased() == normalized }
+        guard let named else { return .failure(VoiceAskRefusal(noSuchModelReason)) }
+        var effort: String?
+        if let effortWord {
+            let normalizedEffort = effortWord.lowercased()
+            guard let level = named.entry.efforts.first(where: { $0.lowercased() == normalizedEffort })
+            else {
+                return .failure(
+                    VoiceAskRefusal(
+                        named.entry.efforts.isEmpty
+                            ? "That model takes no effort level."
+                            : "That model's effort is one of \(named.entry.efforts.joined(separator: ", "))."
+                    )
+                )
+            }
+            effort = level
+        }
+        return .success(AgentSelection(agent: named.entry.agent, model: named.model.id, effort: effort))
+    }
+
+    static func nameBoundReason(_ subject: String) -> String {
+        "\(subject) has to be under \(maximumNameLength) characters and longer than nothing."
+    }
+
+    /// A string argument trimmed to its words, or nothing when absent or blank.
+    static func text(_ arguments: [String: Any], _ key: String) -> String? {
+        guard let value = arguments[key] as? String else { return nil }
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    /// Text refused rather than cut when it runs long: a truncated message or
+    /// name says something its author did not.
+    static func bounded(_ value: Any?, _ maximumLength: Int) -> String? {
+        guard let value = value as? String else { return nil }
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, trimmed.count <= maximumLength else { return nil }
+        return trimmed
+    }
+}

--- a/apps/ios/LukeKit/Sources/LukeKit/VoiceMintClient.swift
+++ b/apps/ios/LukeKit/Sources/LukeKit/VoiceMintClient.swift
@@ -13,9 +13,14 @@ public struct VoiceConnection: Sendable {
 
 /// A context item from the mint — an opaque, pre-formatted block of text the
 /// session sends to the model at channel open so it knows the running sessions.
-public struct VoiceContextItem: Sendable {
+public struct VoiceContextItem: Sendable, Equatable {
     public let itemId: String
     public let text: String
+
+    public init(itemId: String, text: String) {
+        self.itemId = itemId
+        self.text = text
+    }
 }
 
 public enum VoiceMintClientError: Error, Equatable {

--- a/apps/ios/LukeKit/Sources/LukeKit/VoiceToolAvailability.swift
+++ b/apps/ios/LukeKit/Sources/LukeKit/VoiceToolAvailability.swift
@@ -1,0 +1,130 @@
+import Foundation
+
+/// One tool as the settings sheet's debug section reports it: what it does,
+/// and why Luke cannot be asked for it right now, or nothing when he can.
+public struct VoiceToolStanding: Equatable, Sendable, Identifiable {
+    public let name: String
+    public let summary: String
+    public let unavailableReason: String?
+
+    public var id: String { name }
+    public var isAvailable: Bool { unavailableReason == nil }
+
+    public init(name: String, summary: String, unavailableReason: String?) {
+        self.name = name
+        self.summary = summary
+        self.unavailableReason = unavailableReason
+    }
+}
+
+/// Every tool the desktop's conversation carries, judged for this phone and
+/// this moment.
+public struct VoiceToolReport: Equatable, Sendable {
+    public let standings: [VoiceToolStanding]
+    /// Whether the service's minted list has been read off a connected call.
+    /// Until it has, a tool is judged on the phone's own terms alone.
+    public let mintedKnown: Bool
+}
+
+/// Judges each tool the way the acts themselves are gated: a tool the
+/// service did not mint for this call is not Luke's to call; a tool the phone
+/// never carries says why the phone has no surface for it; and a tool the
+/// phone carries is available only while the observed roster or projects
+/// answer offers something for it to act on, the same rows the validator
+/// refuses against. The reasons are read from observed state and fixed
+/// prose, never from anything a model said.
+public enum VoiceToolAvailability {
+    /// The desktop's table, in its order, so the list reads row for row.
+    static let desktopTools: [(name: String, summary: String, absence: String?)] = [
+        (VoiceToolName.sendSessionMessage.rawValue, "Send the developer's words to a session.", nil),
+        (VoiceToolName.runSessionControl.rawValue, "Run a control a session advertises.", nil),
+        (VoiceToolName.openSession.rawValue, "Open a session's own screen.", nil),
+        (
+            "read_session_transcript", "Read a local session's transcript aloud.",
+            "The phone observes no local sessions, and a cloud conversation is read only by its own screen."
+        ),
+        (VoiceToolName.createWorkspace.rawValue, "Create a workspace in a reported project.", nil),
+        (VoiceToolName.addWorkspaceAgent.rawValue, "Start another agent in a session's workspace.", nil),
+        (VoiceToolName.renameWorkspace.rawValue, "Rename the workspace a session runs in.", nil),
+        (VoiceToolName.renameSession.rawValue, "Rename a session itself.", nil),
+        (
+            "update_issue_state", "Move a tracked issue to another state.",
+            "No issue tracker is connected on the phone."
+        ),
+        ("comment_on_issue", "Comment on a tracked issue.", "No issue tracker is connected on the phone."),
+        ("change_app_setting", "Change a Luke setting.", "Settings are changed by hand on the phone."),
+        (VoiceToolName.showPanel.rawValue, "Show the session list, narrowed, sorted, or searched.", nil),
+        (
+            "open_feedback_composer", "Open the feedback composer.",
+            "The phone draws no feedback composer."
+        ),
+        (
+            "run_update_action", "Press the Updates row's button.",
+            "The phone updates through the App Store and draws no Updates row."
+        ),
+        ("remember_fact", "Save a durable fact about the developer.", "Luke's memory lives on the Mac alone."),
+        ("forget_fact", "Forget a remembered fact.", "Luke's memory lives on the Mac alone."),
+    ]
+
+    public static func report(
+        mintedTools: [String]?,
+        sessions: [RosterSession],
+        projects: ProjectsAnswer?
+    ) -> VoiceToolReport {
+        let minted = mintedTools.map(Set.init)
+        let standings = desktopTools.map { tool in
+            VoiceToolStanding(
+                name: tool.name,
+                summary: tool.summary,
+                unavailableReason: tool.absence
+                    ?? unmintedReason(tool.name, minted: minted)
+                    ?? rosterReason(tool.name, sessions: sessions, projects: projects)
+            )
+        }
+        return VoiceToolReport(standings: standings, mintedKnown: minted != nil)
+    }
+
+    private static func unmintedReason(_ name: String, minted: Set<String>?) -> String? {
+        guard let minted, !minted.contains(name) else { return nil }
+        return "The service did not mint this tool for the current call; it may predate this build."
+    }
+
+    /// The same gates the validator holds an ask to, read once over the roster.
+    private static func rosterReason(
+        _ name: String,
+        sessions: [RosterSession],
+        projects: ProjectsAnswer?
+    ) -> String? {
+        guard let tool = VoiceToolName(rawValue: name) else { return nil }
+        let noSessions = "No sessions are observed."
+        switch tool {
+        case .sendSessionMessage:
+            if sessions.isEmpty { return noSessions }
+            return sessions.contains { $0.canReceiveMessage }
+                ? nil : "No observed session takes messages right now."
+        case .runSessionControl:
+            if sessions.isEmpty { return noSessions }
+            return sessions.contains { !$0.controls.isEmpty }
+                ? nil : "No observed session advertises a control."
+        case .openSession, .showPanel:
+            return sessions.isEmpty ? noSessions : nil
+        case .createWorkspace:
+            guard let projects else {
+                return "The projects a workspace can be created in have not loaded."
+            }
+            return projects.projects.isEmpty ? "No provider reported a project to create in." : nil
+        case .addWorkspaceAgent:
+            if sessions.isEmpty { return noSessions }
+            return sessions.contains { !$0.spawnableAgents.isEmpty }
+                ? nil : "No observed session lists an agent to add."
+        case .renameWorkspace:
+            if sessions.isEmpty { return noSessions }
+            return sessions.contains { $0.canRenameWorkspace }
+                ? nil : "No observed session advertises renaming its workspace."
+        case .renameSession:
+            if sessions.isEmpty { return noSessions }
+            return sessions.contains { $0.canRename }
+                ? nil : "No observed session advertises renaming."
+        }
+    }
+}

--- a/apps/ios/LukeKit/Sources/LukeKit/WorkspaceCreationDefaults.swift
+++ b/apps/ios/LukeKit/Sources/LukeKit/WorkspaceCreationDefaults.swift
@@ -50,6 +50,12 @@ public final class WorkspaceCreationDefaults {
         projectsByProvider()[providerId]
     }
 
+    /// Every provider's remembered project at once, keyed by provider id —
+    /// the tie-breaks a spoken creation ask is settled against.
+    public var lastProjectIds: [String: String] {
+        projectsByProvider()
+    }
+
     public func setLastProjectId(_ projectId: String, for providerId: String) {
         var held = projectsByProvider()
         held[providerId] = projectId

--- a/apps/ios/LukeKit/Sources/LukeKit/WorkspaceProjectsContext.swift
+++ b/apps/ios/LukeKit/Sources/LukeKit/WorkspaceProjectsContext.swift
@@ -1,0 +1,122 @@
+import Foundation
+
+/// Renders where a spoken creation ask may land, the way the desktop's
+/// `workspaceProjectContextText` in `@sidecar/realtime` does: each project
+/// with the identity a tool call names it by, what it takes, and the agent
+/// choices its provider's creation endpoint documents. The list is what a
+/// creation ask is validated against on the phone, so an empty one is said in
+/// words too — a conversation told nothing would otherwise be free to imagine
+/// somewhere.
+///
+/// The defaults are this device's own last choices, the same ones the New
+/// Workspace sheet preselects: a tie-break that settles an ask naming no
+/// provider or no project, never a widening of where one can land.
+public enum WorkspaceProjectsContext {
+    /// How many projects one context item may offer creation in.
+    public static let maximumProjects = 10
+
+    /// Named like the desktop's item so the model reads both under one label.
+    public static let contextItemId = "luke_ctx_workspace-projects_0"
+    public static let contextLabel = "workspace projects, sent automatically"
+
+    /// The conversation item the list travels as, labelled as data the way
+    /// every observed value the conversation sees is.
+    public static func item(
+        answer: ProjectsAnswer,
+        defaultProviderId: String?,
+        defaultProjectIds: [String: String]
+    ) -> VoiceContextItem {
+        VoiceContextItem(
+            itemId: contextItemId,
+            text: "[\(contextLabel)]\n"
+                + text(
+                    answer: answer, defaultProviderId: defaultProviderId,
+                    defaultProjectIds: defaultProjectIds)
+        )
+    }
+
+    public static func text(
+        answer: ProjectsAnswer,
+        defaultProviderId: String?,
+        defaultProjectIds: [String: String]
+    ) -> String {
+        let projects = answer.projects
+        if projects.isEmpty { return "No provider currently offers workspace creation." }
+        let listed = listedProjects(projects, defaultProjectIds: defaultProjectIds)
+        let chosenDefault = projects.first { $0.providerId == defaultProviderId }
+
+        var lines = ["Projects a new workspace can be created in:"]
+        for project in listed {
+            var line =
+                "- \(VaultProviderID.displayLabel(forWireId: project.providerId)) — \(project.repository)"
+            if let target = project.targetName { line += " on \(target)" }
+            line += " [provider_id=\(project.providerId) project_id=\(project.providerProjectId)]"
+            line += "; \(taskSupportText(project.taskSupport))"
+            if project.namesItself { line += "; names its own workspaces" }
+            if defaultProjectIds[project.providerId] == project.providerProjectId {
+                line += "; the provider's default project"
+            }
+            lines.append(line)
+        }
+        for providerId in answer.providerIds {
+            let options = answer.agentModels.filter { $0.providerId == providerId }
+            guard !options.isEmpty else { continue }
+            let agents = options.map { option in
+                let models = option.models.map { "\($0.label) (\($0.id))" }.joined(separator: ", ")
+                let efforts =
+                    option.efforts.isEmpty
+                    ? "" : "; efforts \(option.efforts.joined(separator: ", "))"
+                return "\(option.agent) — models \(models)\(efforts)"
+            }
+            lines.append(
+                "\(VaultProviderID.displayLabel(forWireId: providerId)) agents a new workspace can start, "
+                    + "each with the models it runs: \(agents.joined(separator: " | ")). Omitted, the "
+                    + "provider's own default agent starts."
+            )
+        }
+        if let chosenDefault {
+            lines.append(
+                "An ask that names no provider creates in "
+                    + "\(VaultProviderID.displayLabel(forWireId: chosenDefault.providerId)) "
+                    + "[provider_id=\(chosenDefault.providerId)]; do not ask which provider unless the ask "
+                    + "names a different one."
+            )
+        } else if defaultProviderId != nil {
+            lines.append(
+                "The chosen default provider is not currently offering; ask which project when more than "
+                    + "one could take the ask."
+            )
+        } else {
+            lines.append(
+                "No default provider is chosen yet; ask which project when more than one could take the "
+                    + "ask, and the first workspace created saves its provider as the default."
+            )
+        }
+        return lines.joined(separator: "\n")
+    }
+
+    /// The bounded slice the conversation is shown, kept default-aware: a
+    /// chosen default project past the cap rides past the cut, or the one
+    /// project a nameless ask should land in would be unlisted.
+    static func listedProjects(
+        _ projects: [RosterProject],
+        defaultProjectIds: [String: String]
+    ) -> [RosterProject] {
+        var listed = Array(projects.prefix(maximumProjects))
+        for project in projects.dropFirst(maximumProjects)
+        where defaultProjectIds[project.providerId] == project.providerProjectId {
+            listed.append(project)
+        }
+        return listed
+    }
+
+    /// How each support level reads, said beside the identity so the ask and
+    /// its validation share one vocabulary.
+    static func taskSupportText(_ support: ProjectTaskSupport) -> String {
+        switch support {
+        case .none: "takes no task"
+        case .optional: "takes an opening task"
+        case .required: "needs an opening task"
+        }
+    }
+}

--- a/apps/ios/LukeKit/Tests/LukeKitTests/RealtimeSessionTests.swift
+++ b/apps/ios/LukeKit/Tests/LukeKitTests/RealtimeSessionTests.swift
@@ -258,6 +258,25 @@ final class RealtimeSessionStateTests: XCTestCase {
         )
     }
 
+    func testContextItemIdIsEscapedLikeItsText() async throws {
+        let ws = MockWebSocketTask()
+        var opts = makeOptions(ws: ws)
+        let hostileId = "ctx\"},\"type\":\"session.update\nx"
+        opts.contextItems = { [VoiceContextItem(itemId: hostileId, text: "Projects here.")] }
+        let session = RealtimeSession(options: opts)
+
+        Task { ws.deliver(#"{"type":"session.created"}"#) }
+        await session.connect()
+        try await Task.sleep(nanoseconds: 50_000_000)
+
+        let created = ws.outgoing.filter { $0.contains("conversation.item.create") }
+        XCTAssertEqual(created.count, 2)
+        let json = try JSONSerialization.jsonObject(with: Data(created[1].utf8)) as? [String: Any]
+        XCTAssertEqual(json?["type"] as? String, "conversation.item.create")
+        let item = json?["item"] as? [String: Any]
+        XCTAssertEqual(item?["id"] as? String, hostileId, "The id travels as one string, never as structure")
+    }
+
     func testTheMintedToolsAreReadOffTheConfirmedSession() async throws {
         let ws = MockWebSocketTask()
         var minted: [[String]] = []

--- a/apps/ios/LukeKit/Tests/LukeKitTests/RealtimeSessionTests.swift
+++ b/apps/ios/LukeKit/Tests/LukeKitTests/RealtimeSessionTests.swift
@@ -236,6 +236,46 @@ final class RealtimeSessionStateTests: XCTestCase {
         XCTAssertTrue(sent.contains(testContext.itemId))
     }
 
+    func testPhoneComposedContextItemsFollowTheRosterItemOnChannelOpen() async throws {
+        let ws = MockWebSocketTask()
+        var opts = makeOptions(ws: ws)
+        opts.contextItems = {
+            [VoiceContextItem(itemId: "luke_ctx_workspace-projects_0", text: "Projects here.")]
+        }
+        let session = RealtimeSession(options: opts)
+
+        Task { ws.deliver(#"{"type":"session.created"}"#) }
+        await session.connect()
+        try await Task.sleep(nanoseconds: 50_000_000)
+
+        let created = ws.outgoing.filter { $0.contains("conversation.item.create") }
+        XCTAssertEqual(created.count, 2)
+        XCTAssertTrue(created[0].contains(testContext.itemId))
+        XCTAssertTrue(created[1].contains("luke_ctx_workspace-projects_0"))
+        XCTAssertFalse(
+            ws.outgoing.contains { $0.contains(#""type":"response.create""#) },
+            "Context is never a prompt"
+        )
+    }
+
+    func testTheMintedToolsAreReadOffTheConfirmedSession() async throws {
+        let ws = MockWebSocketTask()
+        var minted: [[String]] = []
+        var opts = makeOptions(ws: ws)
+        opts.onSessionTools = { minted.append($0) }
+        let session = RealtimeSession(options: opts)
+
+        Task {
+            ws.deliver(
+                #"{"type":"session.created","session":{"tools":[{"type":"function","name":"open_session"},{"type":"function","name":"show_panel"}]}}"#
+            )
+        }
+        await session.connect()
+        try await Task.sleep(nanoseconds: 50_000_000)
+
+        XCTAssertEqual(minted, [["open_session", "show_panel"]])
+    }
+
     func testBeginAndEndTurnSendsCommit() async throws {
         let ws = MockWebSocketTask()
         let opts = makeOptions(ws: ws)
@@ -574,6 +614,53 @@ final class RealtimeSessionStateTests: XCTestCase {
             1,
             "Only the new turn's original response request may exist"
         )
+    }
+
+    func testPrimaryAudioDrainingDuringAnActDoesNotReturnToReadyBeforeTheFollowUp() async throws {
+        let ws = MockWebSocketTask()
+        let player = ControlledDrainPlayer()
+        let dispatchStarted = AsyncGate()
+        let allowDispatchToFinish = AsyncGate()
+        var statuses: [RealtimeStatus] = []
+        let session = RealtimeSession(options: makeOptions(
+            ws: ws,
+            player: player,
+            onStatus: { statuses.append($0) },
+            dispatchToolCall: { _, _, _ in
+                await dispatchStarted.open()
+                await allowDispatchToFinish.wait()
+                return #"{"result":"accepted"}"#
+            }
+        ))
+
+        Task { ws.deliver(#"{"type":"session.created"}"#) }
+        await session.connect()
+        try await Task.sleep(nanoseconds: 50_000_000)
+
+        session.beginTurn()
+        session.endTurn()
+        // Only the turn's own transitions matter; the channel-open ready is not one.
+        statuses.removeAll()
+        ws.deliver(#"{"type":"response.created","response":{"id":"primary"}}"#)
+        ws.deliver(#"{"type":"response.output_audio.delta","response_id":"primary","delta":"AQABAA=="}"#)
+        ws.deliver(#"{"type":"response.output_audio.done","response_id":"primary"}"#)
+        ws.deliver(
+            #"{"type":"response.done","response":{"id":"primary","output":[{"type":"function_call","call_id":"open_call","name":"open_session","arguments":"{}"}]}}"#
+        )
+        await dispatchStarted.wait()
+
+        // The spoken words finish while the act is still being carried.
+        player.completeDrain()
+        try await Task.sleep(nanoseconds: 50_000_000)
+        XCTAssertFalse(statuses.contains(.ready), "The follow-up has not spoken yet")
+        XCTAssertEqual(session.status, .speaking)
+
+        await allowDispatchToFinish.open()
+        try await Task.sleep(nanoseconds: 50_000_000)
+        XCTAssertFalse(statuses.contains(.ready))
+        ws.deliver(#"{"type":"response.done","response":{"id":"follow_up","output":[]}}"#)
+        try await Task.sleep(nanoseconds: 50_000_000)
+        XCTAssertEqual(session.status, .ready)
     }
 
     func testInterruptionDuringFollowUpRequestKeepsNewTurnArmed() async throws {

--- a/apps/ios/LukeKit/Tests/LukeKitTests/VoiceAsksTests.swift
+++ b/apps/ios/LukeKit/Tests/LukeKitTests/VoiceAsksTests.swift
@@ -1,0 +1,318 @@
+import XCTest
+
+@testable import LukeKit
+
+private func session(
+    id: String = "s1",
+    provider: String = "conductor",
+    status: String = "working",
+    canReceiveMessage: Bool = false,
+    controls: [RosterSessionControl] = [],
+    spawnableAgents: [String] = [],
+    canRename: Bool = false,
+    canRenameWorkspace: Bool = false
+) -> RosterSession {
+    RosterSession(
+        providerId: provider,
+        sessionId: id,
+        title: "Session \(id)",
+        status: status,
+        canReceiveMessage: canReceiveMessage,
+        controls: controls,
+        spawnableAgents: spawnableAgents,
+        canRename: canRename,
+        canRenameWorkspace: canRenameWorkspace
+    )
+}
+
+private func identity(_ id: String = "s1", provider: String = "conductor") -> [String: Any] {
+    ["provider_id": provider, "provider_session_id": id]
+}
+
+private func reason<T>(_ result: Result<T, VoiceAskRefusal>) -> String? {
+    if case .failure(let refusal) = result { return refusal.reason }
+    return nil
+}
+
+final class VoiceAsksSessionTests: XCTestCase {
+    func testAnIdentityTheRosterNeverShowedIsRefused() {
+        let roster = [session()]
+        XCTAssertEqual(
+            reason(VoiceAsks.open(identity("other"), in: roster)),
+            "No observed session matches that identity."
+        )
+        XCTAssertEqual(reason(VoiceAsks.open([:], in: roster)), "No observed session matches that identity.")
+        XCTAssertEqual(try VoiceAsks.open(identity(), in: roster).get().sessionId, "s1")
+    }
+
+    func testAMessageNeedsAnAdvertisedInboxAndBoundedWords() throws {
+        let closed = [session()]
+        XCTAssertEqual(
+            reason(VoiceAsks.message(identity().merging(["text": "hi"]) { $1 }, in: closed)),
+            "That session does not take messages right now."
+        )
+        let open = [session(canReceiveMessage: true)]
+        XCTAssertEqual(
+            reason(VoiceAsks.message(identity().merging(["text": "   "]) { $1 }, in: open)),
+            "That message is empty or too long."
+        )
+        let long = String(repeating: "a", count: VoiceAsks.maximumMessageLength + 1)
+        XCTAssertNotNil(reason(VoiceAsks.message(identity().merging(["text": long]) { $1 }, in: open)))
+        let ask = try VoiceAsks.message(identity().merging(["text": "  ship it "]) { $1 }, in: open).get()
+        XCTAssertEqual(ask.text, "ship it")
+        XCTAssertEqual(ask.providerId, "conductor")
+    }
+
+    func testAControlMustBeOneTheRowAdvertised() throws {
+        let stop = RosterSessionControl(id: "stop", label: "Stop", kind: .stop)
+        let roster = [session(controls: [stop])]
+        XCTAssertEqual(
+            reason(VoiceAsks.control(identity().merging(["control_id": "archive"]) { $1 }, in: roster)),
+            "That session advertises no such control."
+        )
+        XCTAssertEqual(
+            try VoiceAsks.control(identity().merging(["control_id": "stop"]) { $1 }, in: roster).get().control,
+            stop
+        )
+    }
+
+    func testRenamesNeedTheAdvertisementAndABoundedName() throws {
+        let roster = [session(canRename: true)]
+        XCTAssertEqual(
+            reason(VoiceAsks.renameWorkspace(identity().merging(["name": "x"]) { $1 }, in: roster)),
+            "That session's workspace cannot be renamed."
+        )
+        XCTAssertEqual(
+            try VoiceAsks.renameSession(identity().merging(["name": " Auth "]) { $1 }, in: roster).get().name,
+            "Auth"
+        )
+        let long = String(repeating: "n", count: VoiceAsks.maximumNameLength + 1)
+        XCTAssertEqual(
+            reason(VoiceAsks.renameSession(identity().merging(["name": long]) { $1 }, in: roster)),
+            "A chat name has to be under 80 characters and longer than nothing."
+        )
+    }
+
+    func testAddingAnAgentResolvesTheModelWithinTheNamedKind() throws {
+        let roster = [session(spawnableAgents: ["claude"])]
+        let table = [
+            WorkspaceAgentOption(
+                providerId: "conductor", agent: "claude",
+                models: [WorkspaceAgentModelChoice(id: "opus-4", label: "Opus 4")],
+                efforts: ["low", "high"]
+            ),
+            WorkspaceAgentOption(
+                providerId: "conductor", agent: "codex",
+                models: [WorkspaceAgentModelChoice(id: "gpt-5", label: "GPT-5")],
+                efforts: []
+            ),
+        ]
+        XCTAssertEqual(
+            reason(VoiceAsks.addAgent(identity().merging(["agent": "codex"]) { $1 }, in: roster, agentModels: table)),
+            "That session lists no such agent to add."
+        )
+        let ask = try VoiceAsks.addAgent(
+            identity().merging(["agent": "claude", "model": "opus 4", "effort": "HIGH", "task": "fix it"]) { $1 },
+            in: roster, agentModels: table
+        ).get()
+        XCTAssertEqual(ask.model, "opus-4")
+        XCTAssertEqual(ask.effort, "high")
+        XCTAssertEqual(ask.task, "fix it")
+        XCTAssertEqual(
+            reason(
+                VoiceAsks.addAgent(
+                    identity().merging(["agent": "claude", "model": "GPT-5"]) { $1 }, in: roster, agentModels: table
+                )),
+            "A claude agent runs no model by that name."
+        )
+        XCTAssertEqual(
+            reason(
+                VoiceAsks.addAgent(identity().merging(["agent": "claude", "effort": "low"]) { $1 }, in: roster, agentModels: table)
+            ),
+            "An effort rides a model; name the model too."
+        )
+        XCTAssertEqual(
+            reason(
+                VoiceAsks.addAgent(
+                    identity().merging(["agent": "claude", "model": "opus-4", "effort": "max"]) { $1 }, in: roster,
+                    agentModels: table
+                )),
+            "That model's effort is one of low, high."
+        )
+    }
+}
+
+final class VoiceAsksSessionListTests: XCTestCase {
+    private let roster = [
+        session(id: "a", status: "waiting"),
+        session(id: "b", status: "working"),
+        session(id: "c", provider: "other", status: "working"),
+    ]
+
+    func testFiltersResolveAgainstTheObservedRoster() throws {
+        let ask = try VoiceAsks.sessionList(["filters": ["conductor", "waiting"]], in: roster).get()
+        XCTAssertEqual(ask.filters, [.provider("conductor"), .status("waiting")])
+        XCTAssertNil(ask.sort)
+        XCTAssertNil(ask.query)
+    }
+
+    func testAStringNarrowsLikeAListOfOne() throws {
+        let ask = try VoiceAsks.sessionList(["filters": "other"], in: roster).get()
+        XCTAssertEqual(ask.filters, [.provider("other")])
+    }
+
+    func testTheWholeListClearsAndCombinesWithNothing() throws {
+        XCTAssertEqual(try VoiceAsks.sessionList(["filters": ["all"]], in: roster).get().filters, [])
+        XCTAssertEqual(
+            reason(VoiceAsks.sessionList(["filters": ["all", "waiting"]], in: roster)),
+            "all is the whole list, so it combines with nothing."
+        )
+    }
+
+    func testANarrowingThatWouldShowNothingIsRefusedByTheValueThatIsWrong() {
+        XCTAssertEqual(
+            reason(VoiceAsks.sessionList(["filters": ["error"]], in: roster)),
+            "No error sessions are observed right now."
+        )
+        XCTAssertEqual(
+            reason(VoiceAsks.sessionList(["filters": ["codex"]], in: roster)),
+            "No observed session belongs to a provider \"codex\"."
+        )
+        XCTAssertEqual(
+            reason(VoiceAsks.sessionList(["filters": ["other", "waiting"]], in: roster)),
+            "No observed session matches that combination of filters."
+        )
+    }
+
+    func testSortAndQueryAreBoundedLikeTheHandsOwnControls() throws {
+        let ask = try VoiceAsks.sessionList(["sort": "recency", "query": " auth "], in: roster).get()
+        XCTAssertEqual(ask.sort, .recency)
+        XCTAssertEqual(ask.query, "auth")
+        XCTAssertNil(ask.filters)
+        XCTAssertEqual(
+            reason(VoiceAsks.sessionList(["sort": "alphabetical"], in: roster)),
+            "The list orders by urgency or by recency."
+        )
+        XCTAssertEqual(
+            reason(VoiceAsks.sessionList(["query": "auth"], in: [session()])),
+            "The list offers a search only when more than one session is observed."
+        )
+    }
+
+    func testBlankEntriesAreDroppedAndAnEmptiedListNarrowsNothing() throws {
+        let ask = try VoiceAsks.sessionList(["filters": ["  ", ""]], in: roster).get()
+        XCTAssertNil(ask.filters)
+        XCTAssertEqual(
+            reason(VoiceAsks.sessionList(["filters": 3], in: roster)),
+            "filters takes a list of filter values."
+        )
+    }
+}
+
+final class VoiceAsksWorkspaceCreationTests: XCTestCase {
+    private let answer = ProjectsAnswer(
+        projects: [
+            RosterProject(
+                providerId: "conductor", providerProjectId: "p1", repository: "acme/web",
+                taskSupport: .optional),
+            RosterProject(
+                providerId: "conductor", providerProjectId: "p2", repository: "acme/api",
+                taskSupport: .required, namesItself: true),
+        ],
+        agentModels: [
+            WorkspaceAgentOption(
+                providerId: "conductor", agent: "claude",
+                models: [
+                    WorkspaceAgentModelChoice(id: "opus-4", label: "Opus 4"),
+                    WorkspaceAgentModelChoice(id: "sonnet-4", label: "Sonnet 4"),
+                ],
+                efforts: ["low", "high"]
+            ),
+            WorkspaceAgentOption(
+                providerId: "conductor", agent: "codex",
+                models: [WorkspaceAgentModelChoice(id: "gpt-5", label: "GPT-5")],
+                efforts: []
+            ),
+        ]
+    )
+
+    private func creation(
+        _ arguments: [String: Any],
+        defaultProviderId: String? = nil,
+        defaultProjectIds: [String: String] = [:]
+    ) -> Result<VoiceAsks.WorkspaceCreationAsk, VoiceAskRefusal> {
+        VoiceAsks.workspaceCreation(
+            arguments, projects: answer, defaultProviderId: defaultProviderId,
+            defaultProjectIds: defaultProjectIds)
+    }
+
+    func testAnAskNamesAListedProjectOrIsSettledByTheDeviceDefaults() throws {
+        XCTAssertEqual(
+            reason(creation([:])), "More than one listed project matches; name the project.")
+        XCTAssertEqual(
+            reason(creation(["project_id": "nope"])), "No listed project matches that identity.")
+        XCTAssertEqual(try creation(["project_id": "p1"]).get().project.providerProjectId, "p1")
+        XCTAssertEqual(
+            try creation([:], defaultProviderId: "conductor", defaultProjectIds: ["conductor": "p1"]).get()
+                .project.providerProjectId,
+            "p1"
+        )
+        // A default settles only what the ask left unnamed.
+        XCTAssertEqual(
+            try creation(["project_id": "p2", "task": "go"], defaultProjectIds: ["conductor": "p1"]).get()
+                .project.providerProjectId,
+            "p2"
+        )
+    }
+
+    func testNameAndTaskFollowTheProjectsOwnWord() throws {
+        XCTAssertEqual(
+            reason(creation(["project_id": "p2", "task": "go", "name": "Mine"])),
+            "That project names its own workspaces."
+        )
+        XCTAssertEqual(
+            reason(creation(["project_id": "p2"])),
+            "That project needs an opening task to create a workspace."
+        )
+        XCTAssertEqual(
+            reason(creation(["project_id": "p1", "task": "  "])), "That task is empty or too long.")
+        let ask = try creation(["project_id": "p1", "name": " Auth fix ", "task": "Fix auth"]).get()
+        XCTAssertEqual(ask.name, "Auth fix")
+        XCTAssertEqual(ask.task, "Fix auth")
+        XCTAssertNil(ask.agent)
+        XCTAssertNil(ask.model)
+    }
+
+    func testAnAgentNamedAloneRunsItsTablesFirstModel() throws {
+        let ask = try creation(["project_id": "p1", "agent": "Claude"]).get()
+        XCTAssertEqual(ask.agent, "claude")
+        XCTAssertEqual(ask.model, "opus-4")
+        XCTAssertNil(ask.effort)
+        XCTAssertEqual(
+            reason(creation(["project_id": "p1", "agent": "gemini"])),
+            "That project lists no such agent to start."
+        )
+    }
+
+    func testAModelNamedAloneDecidesTheAgentThatRunsIt() throws {
+        let ask = try creation(["project_id": "p1", "model": "gpt-5"]).get()
+        XCTAssertEqual(ask.agent, "codex")
+        XCTAssertEqual(ask.model, "gpt-5")
+        let withEffort = try creation(["project_id": "p1", "model": "Sonnet 4", "effort": "Low"]).get()
+        XCTAssertEqual(withEffort.agent, "claude")
+        XCTAssertEqual(withEffort.model, "sonnet-4")
+        XCTAssertEqual(withEffort.effort, "low")
+        XCTAssertEqual(
+            reason(creation(["project_id": "p1", "model": "gpt-5", "effort": "low"])),
+            "That model takes no effort level."
+        )
+        XCTAssertEqual(
+            reason(creation(["project_id": "p1", "agent": "codex", "model": "Opus 4"])),
+            "No documented model goes by that name here."
+        )
+        XCTAssertEqual(
+            reason(creation(["project_id": "p1", "effort": "low"])),
+            "An effort rides a model; name the model too."
+        )
+    }
+}

--- a/apps/ios/LukeKit/Tests/LukeKitTests/VoiceToolAvailabilityTests.swift
+++ b/apps/ios/LukeKit/Tests/LukeKitTests/VoiceToolAvailabilityTests.swift
@@ -1,0 +1,91 @@
+import XCTest
+
+@testable import LukeKit
+
+final class VoiceToolAvailabilityTests: XCTestCase {
+    private let phoneTools = VoiceToolName.allCases.map(\.rawValue)
+
+    private func standing(_ name: String, in report: VoiceToolReport) -> VoiceToolStanding? {
+        report.standings.first { $0.name == name }
+    }
+
+    func testTheListIsTheDesktopsTableRowForRow() {
+        let report = VoiceToolAvailability.report(mintedTools: nil, sessions: [], projects: nil)
+        XCTAssertEqual(report.standings.count, 16)
+        XCTAssertEqual(report.standings.first?.name, "send_session_message")
+        XCTAssertEqual(report.standings.last?.name, "forget_fact")
+        XCTAssertFalse(report.mintedKnown)
+        for tool in phoneTools {
+            XCTAssertNotNil(standing(tool, in: report), tool)
+        }
+    }
+
+    func testToolsThePhoneNeverCarriesSayWhy() {
+        let report = VoiceToolAvailability.report(mintedTools: phoneTools, sessions: [], projects: nil)
+        for name in [
+            "read_session_transcript", "update_issue_state", "comment_on_issue", "change_app_setting",
+            "open_feedback_composer", "run_update_action", "remember_fact", "forget_fact",
+        ] {
+            XCTAssertFalse(standing(name, in: report)?.isAvailable ?? true, name)
+        }
+        XCTAssertEqual(
+            standing("remember_fact", in: report)?.unavailableReason,
+            "Luke's memory lives on the Mac alone."
+        )
+    }
+
+    func testAToolTheServiceDidNotMintIsNotLukes() {
+        let roster = [
+            RosterSession(providerId: "conductor", sessionId: "s", title: "T", status: "working", canReceiveMessage: true)
+        ]
+        let minted = ["send_session_message", "run_session_control"]
+        let report = VoiceToolAvailability.report(mintedTools: minted, sessions: roster, projects: nil)
+        XCTAssertTrue(report.mintedKnown)
+        XCTAssertTrue(standing("send_session_message", in: report)?.isAvailable == true)
+        XCTAssertEqual(
+            standing("open_session", in: report)?.unavailableReason,
+            "The service did not mint this tool for the current call; it may predate this build."
+        )
+    }
+
+    func testPhoneToolsFollowWhatTheRosterAndProjectsOffer() {
+        let empty = VoiceToolAvailability.report(mintedTools: phoneTools, sessions: [], projects: nil)
+        XCTAssertEqual(standing("open_session", in: empty)?.unavailableReason, "No sessions are observed.")
+        XCTAssertEqual(
+            standing("create_workspace", in: empty)?.unavailableReason,
+            "The projects a workspace can be created in have not loaded."
+        )
+
+        let roster = [
+            RosterSession(
+                providerId: "conductor", sessionId: "s", title: "T", status: "working",
+                controls: [RosterSessionControl(id: "stop", label: "Stop", kind: .stop)],
+                canRename: true
+            )
+        ]
+        let report = VoiceToolAvailability.report(
+            mintedTools: phoneTools, sessions: roster,
+            projects: ProjectsAnswer(projects: [], agentModels: [])
+        )
+        XCTAssertTrue(standing("open_session", in: report)?.isAvailable == true)
+        XCTAssertTrue(standing("show_panel", in: report)?.isAvailable == true)
+        XCTAssertTrue(standing("run_session_control", in: report)?.isAvailable == true)
+        XCTAssertTrue(standing("rename_session", in: report)?.isAvailable == true)
+        XCTAssertEqual(
+            standing("send_session_message", in: report)?.unavailableReason,
+            "No observed session takes messages right now."
+        )
+        XCTAssertEqual(
+            standing("add_workspace_agent", in: report)?.unavailableReason,
+            "No observed session lists an agent to add."
+        )
+        XCTAssertEqual(
+            standing("rename_workspace", in: report)?.unavailableReason,
+            "No observed session advertises renaming its workspace."
+        )
+        XCTAssertEqual(
+            standing("create_workspace", in: report)?.unavailableReason,
+            "No provider reported a project to create in."
+        )
+    }
+}

--- a/apps/ios/LukeKit/Tests/LukeKitTests/WorkspaceProjectsContextTests.swift
+++ b/apps/ios/LukeKit/Tests/LukeKitTests/WorkspaceProjectsContextTests.swift
@@ -1,0 +1,87 @@
+import XCTest
+
+@testable import LukeKit
+
+final class WorkspaceProjectsContextTests: XCTestCase {
+    private func project(
+        _ id: String, repository: String, support: ProjectTaskSupport = .optional,
+        target: String? = nil, namesItself: Bool = false
+    ) -> RosterProject {
+        RosterProject(
+            providerId: "conductor", providerProjectId: id, repository: repository,
+            taskSupport: support, targetName: target, namesItself: namesItself)
+    }
+
+    func testAnEmptyListIsSaidInWords() {
+        XCTAssertEqual(
+            WorkspaceProjectsContext.text(
+                answer: ProjectsAnswer(projects: [], agentModels: []), defaultProviderId: nil,
+                defaultProjectIds: [:]),
+            "No provider currently offers workspace creation."
+        )
+    }
+
+    func testEachProjectCarriesTheIdentityACallNamesItByAndWhatItTakes() {
+        let answer = ProjectsAnswer(
+            projects: [
+                project("p1", repository: "acme/web", support: .required, target: "Mac mini"),
+                project("p2", repository: "acme/api", support: .none, namesItself: true),
+            ],
+            agentModels: [
+                WorkspaceAgentOption(
+                    providerId: "conductor", agent: "claude",
+                    models: [WorkspaceAgentModelChoice(id: "opus-4", label: "Opus 4")],
+                    efforts: ["low", "high"]
+                )
+            ]
+        )
+        let text = WorkspaceProjectsContext.text(
+            answer: answer, defaultProviderId: "conductor", defaultProjectIds: ["conductor": "p2"])
+        let lines = text.split(separator: "\n").map(String.init)
+        XCTAssertEqual(lines[0], "Projects a new workspace can be created in:")
+        XCTAssertEqual(
+            lines[1],
+            "- Conductor — acme/web on Mac mini [provider_id=conductor project_id=p1]; needs an opening task"
+        )
+        XCTAssertEqual(
+            lines[2],
+            "- Conductor — acme/api [provider_id=conductor project_id=p2]; takes no task; names its own workspaces; the provider's default project"
+        )
+        XCTAssertTrue(lines[3].contains("claude — models Opus 4 (opus-4); efforts low, high"))
+        XCTAssertEqual(
+            lines[4],
+            "An ask that names no provider creates in Conductor [provider_id=conductor]; do not ask which provider unless the ask names a different one."
+        )
+    }
+
+    func testTheDefaultSentenceFollowsWhetherADefaultStandsAndOffers() {
+        let answer = ProjectsAnswer(projects: [project("p1", repository: "acme/web")], agentModels: [])
+        XCTAssertTrue(
+            WorkspaceProjectsContext.text(answer: answer, defaultProviderId: nil, defaultProjectIds: [:])
+                .hasSuffix("the first workspace created saves its provider as the default.")
+        )
+        XCTAssertTrue(
+            WorkspaceProjectsContext.text(answer: answer, defaultProviderId: "other", defaultProjectIds: [:])
+                .contains("The chosen default provider is not currently offering")
+        )
+    }
+
+    func testTheCapKeepsTheDefaultProjectPastTheCut() {
+        let projects = (0 ..< 12).map { project("p\($0)", repository: "repo-\($0)") }
+        let listed = WorkspaceProjectsContext.listedProjects(projects, defaultProjectIds: ["conductor": "p11"])
+        XCTAssertEqual(listed.count, WorkspaceProjectsContext.maximumProjects + 1)
+        XCTAssertEqual(listed.last?.providerProjectId, "p11")
+        XCTAssertFalse(listed.contains { $0.providerProjectId == "p10" })
+    }
+
+    func testTheItemIsLabelledAsData() {
+        let item = WorkspaceProjectsContext.item(
+            answer: ProjectsAnswer(projects: [], agentModels: []), defaultProviderId: nil,
+            defaultProjectIds: [:])
+        XCTAssertEqual(item.itemId, "luke_ctx_workspace-projects_0")
+        XCTAssertEqual(
+            item.text,
+            "[workspace projects, sent automatically]\nNo provider currently offers workspace creation."
+        )
+    }
+}

--- a/apps/ios/README.md
+++ b/apps/ios/README.md
@@ -36,6 +36,30 @@ pick up an SPM test target from this app scheme — neither as a testable
 reference nor through a test plan — so a scheme entry would claim coverage the
 simulator run does not deliver.
 
+## Voice acts
+
+The voice screen carries the same acts the desktop's conversation does,
+minus the ones that have no surface on a phone. The tool list is minted
+server-side from `remoteRealtimeToolDefinitions()` in `packages/acts`, and
+each call is validated on the phone in `LukeKit`'s `VoiceAsks` against the
+roster and projects the conversation was shown before anything is sent:
+
+| Tool | What happens on the phone |
+| --- | --- |
+| `send_session_message`, `run_session_control`, `add_workspace_agent`, `rename_session`, `rename_workspace`, `create_workspace` | Validated against the observed roster or projects answer, then sent to the hosted act endpoint, which re-observes and validates again |
+| `open_session` | Pushes the session's own screen once Luke's reply has finished |
+| `show_panel` | Pops to the list and applies the filters, sort, or search the ask named, as the filter sheet and search field would |
+
+The voice settings sheet ends in a Debug section listing every tool the
+desktop's conversation carries, marked available or not, with the reason:
+read from the tool list the service minted the current call with and from
+what the observed roster and projects answer offer right now.
+
+Absent on purpose: `read_session_transcript` (no local sessions on a phone),
+the issue acts (no tracker is connected here), `remember_fact` and
+`forget_fact` (the phone keeps no memory; Luke's durable facts live on the
+Mac), `change_app_setting`, the feedback composer, and the Updates row.
+
 ## Analytics
 
 The app runs the desktop's two analytics streams on this platform's terms,

--- a/apps/web/server/hosted/remote-context.ts
+++ b/apps/web/server/hosted/remote-context.ts
@@ -11,8 +11,11 @@ import {
  * sessions, no transcript reads, no desktop-app links. The output format
  * matches `sessionContextText` from `@sidecar/realtime` so the model's
  * instructions and this context share one vocabulary, with fields the server
- * does not have (open link, running tool, pull request, workspace display
- * name) simply omitted.
+ * does not have (running tool, pull request, workspace display name) simply
+ * omitted. Every row opens, because the phone draws a screen of its own for
+ * each session it lists: an open there lands in the app, never at a
+ * provider's address, so the recency labels the instructions read for "open
+ * the latest" name the same row as the plain recency label.
  */
 
 const MAXIMUM_REMOTE_VOICE_CONTEXT_SESSIONS = 25;
@@ -64,11 +67,12 @@ function remoteCapabilityText(
   const capabilities = [
     `provider_id=${session.providerId} provider_session_id=${session.sessionId}`,
     `messages=${Boolean(session.canReceiveMessage)}`,
-    // Cloud sessions have no remote-accessible open link or local transcript.
-    "open=false",
+    // The phone opens a session on its own screen; no cloud session has a
+    // transcript on the device to read.
+    "open=true",
     "transcript=false",
     ...(mostRecent.get(session.providerId) === session.sessionId
-      ? ["most_recent_for_provider=true"]
+      ? ["most_recent_for_provider=true", "most_recent_openable_for_provider=true"]
       : []),
     ...(controls.length > 0
       ? [

--- a/apps/web/tests/hosted-remote-context.test.ts
+++ b/apps/web/tests/hosted-remote-context.test.ts
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { ObservedSession } from "@sidecar/hosted";
+import { remoteSessionContextText } from "../server/hosted/remote-context";
+
+const NOW = 1_700_000_000_000;
+
+function session(overrides: Partial<ObservedSession> = {}): ObservedSession {
+  return {
+    providerId: "conductor",
+    sessionId: "session-1",
+    title: "Refactor auth",
+    status: "working",
+    observedAt: NOW - 60_000,
+    ...overrides,
+  };
+}
+
+test("every phone row opens, and the newest per provider wears both recency labels", () => {
+  const text = remoteSessionContextText(
+    [
+      session(),
+      session({ sessionId: "session-2", title: "Older work", observedAt: NOW - 3_600_000 }),
+    ],
+    NOW,
+  );
+  const [, newest, older] = text.split("\n");
+  assert.ok(newest?.includes("open=true"));
+  assert.ok(newest?.includes("transcript=false"));
+  assert.ok(newest?.includes("most_recent_for_provider=true"));
+  assert.ok(newest?.includes("most_recent_openable_for_provider=true"));
+  assert.ok(older?.includes("open=true"));
+  assert.ok(!older?.includes("most_recent"));
+  assert.ok(!text.includes("open=false"));
+});
+
+test("an empty roster says so in words", () => {
+  assert.equal(
+    remoteSessionContextText([], NOW),
+    "No coding-agent sessions are currently observed.",
+  );
+});

--- a/packages/acts/src/acts.test.ts
+++ b/packages/acts/src/acts.test.ts
@@ -2,7 +2,14 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { EMPTY_APP_GUIDE } from "@sidecar/guide";
 import { ACT_RESULT_STATUS } from "@sidecar/wire";
-import { APP_TOOL_KIND, actNarration, appToolAction, REALTIME_TOOL } from "./acts.js";
+import {
+  APP_TOOL_KIND,
+  actNarration,
+  appToolAction,
+  REALTIME_TOOL,
+  realtimeToolDefinitions,
+  remoteRealtimeToolDefinitions,
+} from "./acts.js";
 import { maximumRememberedFacts } from "./memory.js";
 
 test("a setting act narrates the setting label and accepted value", () => {
@@ -112,4 +119,63 @@ test("forgetting can only name an entry that stands", () => {
     ).status,
     ACT_RESULT_STATUS.REJECTED,
   );
+});
+
+test("the phone is handed the acts it carries, in the shape its own surface gives them", () => {
+  const remote = remoteRealtimeToolDefinitions();
+  const names: readonly string[] = remote.map((tool) => tool.name);
+  // Spread so the equality narrows a copy, leaving `names` a plain string list.
+  assert.deepEqual(
+    [...names],
+    [
+      REALTIME_TOOL.SEND_SESSION_MESSAGE,
+      REALTIME_TOOL.RUN_SESSION_CONTROL,
+      REALTIME_TOOL.OPEN_SESSION,
+      REALTIME_TOOL.CREATE_WORKSPACE,
+      REALTIME_TOOL.ADD_WORKSPACE_AGENT,
+      REALTIME_TOOL.RENAME_WORKSPACE,
+      REALTIME_TOOL.RENAME_SESSION,
+      REALTIME_TOOL.SHOW_PANEL,
+    ],
+  );
+  // No local transcript, tracker, setting, composer, Updates row, or memory stands on the phone.
+  for (const absent of [
+    REALTIME_TOOL.READ_SESSION_TRANSCRIPT,
+    REALTIME_TOOL.REMEMBER_FACT,
+    REALTIME_TOOL.FORGET_FACT,
+    REALTIME_TOOL.UPDATE_ISSUE_STATE,
+    REALTIME_TOOL.COMMENT_ON_ISSUE,
+    REALTIME_TOOL.CHANGE_APP_SETTING,
+    REALTIME_TOOL.OPEN_FEEDBACK_COMPOSER,
+    REALTIME_TOOL.RUN_UPDATE_ACTION,
+  ]) {
+    assert.ok(!names.includes(absent), `${absent} must not reach the phone`);
+  }
+
+  // An open on the phone lands on the app's own screen, so no app to open in is offered.
+  const open = remote.find((tool) => tool.name === REALTIME_TOOL.OPEN_SESSION);
+  assert.ok(open);
+  assert.deepEqual(Object.keys(open.parameters.properties), ["provider_id", "provider_session_id"]);
+  assert.match(open.description, /own screen in this app/);
+
+  // The phone's list narrows on provider and status, and has no tabs to show.
+  const panel = remote.find((tool) => tool.name === REALTIME_TOOL.SHOW_PANEL);
+  assert.ok(panel);
+  assert.deepEqual(Object.keys(panel.parameters.properties), ["filters", "sort", "query"]);
+  const filters = panel.parameters.properties.filters;
+  assert.ok(filters && filters.type === "array");
+  const values = filters.items.enum ?? [];
+  assert.ok(values.includes("all"));
+  assert.ok(values.includes("waiting"));
+  assert.ok(values.includes("conductor"));
+  assert.ok(!values.includes("local"));
+  assert.ok(!values.includes("voice"));
+
+  // Every other act keeps the desktop's own schema.
+  const desktop = new Map(realtimeToolDefinitions().map((tool) => [tool.name, tool]));
+  for (const tool of remote) {
+    if (tool.name === REALTIME_TOOL.OPEN_SESSION || tool.name === REALTIME_TOOL.SHOW_PANEL)
+      continue;
+    assert.deepEqual(tool, desktop.get(tool.name));
+  }
 });

--- a/packages/acts/src/acts.ts
+++ b/packages/acts/src/acts.ts
@@ -55,6 +55,7 @@ import {
   PROVIDER_ID_LIST,
   SESSION_APPLICATION_ID,
   SESSION_LOCATION,
+  SESSION_STATUS,
   type Session,
   type SessionApplicationId,
   type SessionControl,
@@ -167,6 +168,23 @@ const SESSION_LIST_FILTER_DESCRIPTION =
   `${SESSION_LIST_VOICE} for voice chats, an agent's provider_id, or an associated app's id. ` +
   `Values combine — ${SESSION_LOCATION.LOCAL} with an agent keeps that agent's local ` +
   `sessions — and ${SESSION_LIST_ALL} stands alone.`;
+
+/**
+ * The narrowing vocabulary the phone's list holds: its chips read a row's
+ * provider and status and nothing else, so a spoken narrowing there picks
+ * from those two axes and the whole-list scope. Which values narrow to
+ * anything is the observed roster's question, answered on the phone.
+ */
+const REMOTE_SESSION_LIST_FILTER_VALUES: readonly string[] = [
+  ...new Set<string>([SESSION_LIST_ALL, ...PROVIDER_ID_LIST, ...Object.values(SESSION_STATUS)]),
+];
+
+const REMOTE_SESSION_LIST_FILTER_DESCRIPTION =
+  `The values to narrow the session list to: ${SESSION_LIST_ALL} for every session, a ` +
+  `provider_id for one provider's sessions, or a status (${Object.values(SESSION_STATUS).join(
+    ", ",
+  )}). Values combine — a provider with a status keeps that provider's sessions in that ` +
+  `status — and ${SESSION_LIST_ALL} stands alone.`;
 
 /** What one validated tool call asks for, ready for the bridge that carries it. */
 type CarriedSessionActionFields =
@@ -411,6 +429,13 @@ type SessionToolSpec = {
   narration: ActNarration;
   guide: string;
   schema: RealtimeToolSchema;
+  /**
+   * The same act as the phone offers it, where the phone's surface gives the
+   * act a different shape: an open lands on the app's own screen rather than
+   * a provider's address, and the list narrows on the axes its chips hold.
+   * Absent, the phone is handed the desktop's schema unchanged.
+   */
+  remoteSchema?: RealtimeToolSchema;
   validate: SessionToolValidate;
 };
 
@@ -422,6 +447,7 @@ type IssueToolSpec = {
   narration: ActNarration;
   guide: string;
   schema: RealtimeToolSchema;
+  remoteSchema?: RealtimeToolSchema;
   validate: IssueToolValidate;
 };
 
@@ -433,6 +459,7 @@ type AppToolSpec = {
   narration: ActNarration;
   guide: string;
   schema: RealtimeToolSchema;
+  remoteSchema?: RealtimeToolSchema;
   validate: AppToolValidate;
 };
 
@@ -1393,6 +1420,19 @@ export const ACTS = {
         required: ["provider_id", "provider_session_id"],
       },
     },
+    remoteSchema: {
+      description:
+        "Open one observed session's own screen in this app, leaving this conversation — only " +
+        "when the developer asks to open, go to, or jump into that specific session. An ask to " +
+        'show, see, or list sessions or agents — "show me the waiting sessions" — narrows the ' +
+        "list through show_panel instead, never this. The phone shows one screen, so open one " +
+        "session per response; asked for several, ask which.",
+      parameters: {
+        type: "object",
+        properties: { ...SESSION_IDENTITY_PARAMETERS },
+        required: ["provider_id", "provider_session_id"],
+      },
+    },
     validate: validateOpenSession,
   },
   READ_SESSION_TRANSCRIPT: {
@@ -1703,6 +1743,35 @@ export const ACTS = {
         required: [],
       },
     },
+    remoteSchema: {
+      description:
+        "Show the session list — and narrow, search, or reorder it. An ask to show, see, or " +
+        'list sessions of some kind — "show me the waiting sessions", "show me the Conductor ' +
+        'agents" — is this tool with a filter, not open_session.',
+      parameters: {
+        type: "object",
+        properties: {
+          filters: {
+            type: "array",
+            items: { type: "string", enum: REMOTE_SESSION_LIST_FILTER_VALUES },
+            description: REMOTE_SESSION_LIST_FILTER_DESCRIPTION,
+          },
+          sort: {
+            type: "string",
+            enum: Object.values(SESSION_LIST_SORT),
+            description:
+              `Reorders the session list: ${SESSION_LIST_SORT.URGENCY} puts what needs the ` +
+              `developer first, ${SESSION_LIST_SORT.RECENCY} puts what moved last first.`,
+          },
+          query: {
+            type: "string",
+            description:
+              "Optional words to search the session list for; only rows saying every word stay.",
+          },
+        },
+        required: [],
+      },
+    },
     validate: validateShowPanel,
   },
   OPEN_FEEDBACK_COMPOSER: {
@@ -1891,32 +1960,44 @@ export function realtimeToolDefinitions(): readonly RealtimeToolWireDefinition[]
 }
 
 /**
- * The SESSION acts the mobile act endpoints already serve — MESSAGE, CONTROL,
- * ADD_AGENT, RENAME_WORKSPACE, RENAME_SESSION — as tool schemas for a mobile
- * Realtime session. OPEN and READ_TRANSCRIPT are excluded because no mobile
- * endpoint takes them; ISSUE and APP tools are excluded because mobile has no
- * equivalent endpoints for those. CREATE_WORKSPACE is excluded because mobile
- * carries no projects context, so the model cannot name a valid project.
+ * The acts the phone carries, as tool schemas for a mobile Realtime session.
+ * The session writes are the ones the hosted act endpoints serve — MESSAGE,
+ * CONTROL, CREATE_WORKSPACE, ADD_AGENT, RENAME_WORKSPACE, RENAME_SESSION —
+ * and the phone validates each against the roster and projects it was shown
+ * before an endpoint sees it, the renderer's half of the gauntlet. OPEN lands
+ * on the session's own screen in the app and PANEL on the app's own list, so
+ * each is performed on the phone and reaches no endpoint at all.
+ *
+ * READ_TRANSCRIPT is absent because the phone observes no local session, and
+ * a cloud conversation is read only by its own opened screen. The issue
+ * acts are absent because no tracker is connected on the phone; a setting
+ * change, the feedback composer, and the Updates row are surfaces the phone
+ * does not draw. REMEMBER and FORGET are absent because the phone keeps no
+ * memory: Luke's durable facts live on the Mac alone.
  */
-const REMOTE_SESSION_ACTION_KINDS: ReadonlySet<string> = new Set([
+const REMOTE_ACTION_KINDS: ReadonlySet<string> = new Set([
   SESSION_TOOL_KIND.MESSAGE,
   SESSION_TOOL_KIND.CONTROL,
+  SESSION_TOOL_KIND.OPEN,
+  SESSION_TOOL_KIND.CREATE_WORKSPACE,
   SESSION_TOOL_KIND.ADD_AGENT,
   SESSION_TOOL_KIND.RENAME_WORKSPACE,
   SESSION_TOOL_KIND.RENAME_SESSION,
+  APP_TOOL_KIND.PANEL,
 ]);
 
 export function remoteRealtimeToolDefinitions(): readonly RealtimeToolWireDefinition[] {
-  return REALTIME_TOOL_LIST.filter(
-    (tool) =>
-      tool.family === REALTIME_TOOL_FAMILY.SESSION &&
-      REMOTE_SESSION_ACTION_KINDS.has(tool.actionKind),
-  ).map((tool) => ({
-    type: "function",
-    name: tool.name,
-    description: tool.schema.description,
-    parameters: tool.schema.parameters,
-  }));
+  return REALTIME_TOOL_LIST.filter((tool) => REMOTE_ACTION_KINDS.has(tool.actionKind)).map(
+    (tool) => {
+      const schema = tool.remoteSchema ?? tool.schema;
+      return {
+        type: "function",
+        name: tool.name,
+        description: schema.description,
+        parameters: schema.parameters,
+      };
+    },
+  );
 }
 
 /**

--- a/packages/realtime/src/realtime-credentials.ts
+++ b/packages/realtime/src/realtime-credentials.ts
@@ -107,7 +107,8 @@ export function realtimeClientSecretRequest(options: RealtimeSessionOptions = {}
 /**
  * Builds the request body for a mobile Realtime mint. The session config
  * matches the desktop's — same instructions, audio format, and turn detection —
- * but the tool list is narrowed to the acts the mobile act endpoints serve.
+ * but the tool list is narrowed to the acts the phone carries, each in the
+ * shape the phone's own surface gives it.
  */
 export function remoteRealtimeClientSecretRequest(options: RealtimeSessionOptions = {}) {
   return { session: { ...realtimeSessionConfig(options), tools: remoteRealtimeToolDefinitions() } };


### PR DESCRIPTION
## Summary

Luke's conversation on the phone now carries every act the desktop's conversation carries that has a surface on a phone. The mobile mint already narrowed the tool list to five session writes; this widens it to eight and gives each phone-side act the shape the phone's own surface has.

| Tool | On the phone |
| --- | --- |
| `open_session` | Pushes the session's own screen, once Luke's reply has finished speaking |
| `show_panel` | Pops to the list and applies the filters (provider, status), sort, or search the ask named, exactly as the filter sheet and search field would |
| `create_workspace` | Validated against the projects answer and this device's remembered defaults, then sent to `/api/acts/workspace` |
| the five existing session writes | Now validated on the phone against the observed roster before the endpoint sees them, the renderer's half of the gauntlet |

Deliberately absent: `change_app_setting` (per the ask), `remember_fact` and `forget_fact` (the phone keeps no memory; Luke's durable facts stay on the Mac), `read_session_transcript` (no local sessions on a phone; a cloud conversation is read only by its own opened screen), the issue acts (no tracker on the phone), `open_feedback_composer`, and `run_update_action`.

## How it fits together

- `packages/acts`: tool rows gain an optional `remoteSchema`; `open_session` and `show_panel` get phone-shaped schemas (no app to open in, filters on provider and status, no tabs). `remoteRealtimeToolDefinitions()` now covers the eight acts.
- `apps/web`: the remote roster context says `open=true` for every row and labels the newest per provider as openable, since every session has a screen on the phone.
- `LukeKit`: `VoiceAsks` (validation mirroring the desktop's `validate` rows), `WorkspaceProjectsContext` (transcription of the desktop's projects context, with the device's defaults as tie-breaks), and a `contextItems` seam on `RealtimeSession`.
- `Luke` app: a shared `SessionsStore` holds the roster, narrowing, and a path-based `NavigationStack`, so the voice screen can drive the same presses the list offers. Navigation from a spoken act waits for the reply to settle, because moving the screen closes the call still speaking.
- `PRIVACY.md` says a phone call carries the projects list, and that the phone keeps no memory of its own.
- The voice settings sheet gains a Debug section listing all sixteen desktop tools, each marked available or not with the reason: not minted by the service for the current call (read off the `session.created` event), no surface on the phone, or nothing in the observed roster or projects for it to act on.
- The dispatcher refuses a tool call outside the call's minted set, and one that arrives before the set is known; the phone-composed context item's id is JSON-escaped like its text.

## Debug section against production

Checked on the iOS 26.5 Simulator (iPhone 17 Pro Max) signed in against production (`tryluke.dev`) with a live Conductor roster. Five tools read available (`send_session_message`, `run_session_control`, `add_workspace_agent`, `rename_workspace`, `rename_session`) and the three this PR adds (`open_session`, `create_workspace`, `show_panel`) read "The service did not mint this tool for the current call; it may predate this build." That is the expected reading until this PR deploys: production runs main, whose `remoteRealtimeToolDefinitions()` still mints the five-tool list, and the phone reads the minted set off the confirmed session rather than assuming its own build's. The three become available on the next call once the service ships this change; the same sheet is the check to repeat after the deploy.

## Simulator evidence

| show_panel result | open_session result |
| --- | --- |
| <img src="https://raw.githubusercontent.com/ReviewStage/luke/9672e5775feb18c5bc1eb6ffc616eba6cc46ca1a/pr-659/show-panel-filtered.png" width="300" alt="Luke iOS sessions list showing the synthetic waiting-session result after applying a spoken panel search and filter"> | <img src="https://raw.githubusercontent.com/ReviewStage/luke/9672e5775feb18c5bc1eb6ffc616eba6cc46ca1a/pr-659/open-session.png" width="300" alt="Luke iOS synthetic session detail reached through the spoken open-session navigation path"> |

Captured on the iOS 26.5 Simulator (iPhone 17 Pro Max) against code commit 25bc01bebbf378b253a0f861d9db229e770dcca5. A temporary, uncommitted synthetic roster invoked the exact SessionsStore.showList and openLeavingConversation paths; analytics and session replay were disabled. This validates the rendered navigation results, not a live model tool call. Evidence is hosted on pr-assets at 9672e5775feb18c5bc1eb6ffc616eba6cc46ca1a.

## Testing

- `./scripts/check.sh` passes (lint, typecheck, tests, build), including new tests for the remote tool table and the remote roster context.
- On a Mac with Xcode 26.6: `swift test` in `apps/ios/LukeKit` — 229 tests, 0 failures (new suites for `VoiceAsks`, `WorkspaceProjectsContext`, `VoiceToolAvailability`, and the realtime context items, including the context item id escaping). `xcodebuild test` for the Luke scheme on an iPhone 17 Pro Max simulator — TEST SUCCEEDED.
- No desktop UI changed. The iOS changes were built and tested in the simulator only; no physical-device check was performed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/25e55968-8eea-47f6-87fb-67bfab8ae2dc)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/33805716189/artifacts/9912938548) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/33805716189)

- Commit: `dfe36f573539e94c35a44f5cf69e7989d8648c42`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->



