### PR TITLE
fix(ios): keep Bluetooth voice route active between turns

### DIFF
--- a/apps/ios/Luke/VoiceAudioCapturer.swift
+++ b/apps/ios/Luke/VoiceAudioCapturer.swift
@@ -1,6 +1,29 @@
 import AVFoundation
 import LukeKit
 
+/// Owns the voice screen's audio route. The session is activated before the
+/// realtime connection opens and stays active between microphone and speaker
+/// use, giving a Bluetooth HFP route time to settle before the first press.
+enum VoiceAudioSession {
+    static func activate() throws {
+        let session = AVAudioSession.sharedInstance()
+        try session.setCategory(
+            .playAndRecord,
+            mode: .voiceChat,
+            options: [.defaultToSpeaker, .allowBluetoothHFP]
+        )
+        try session.setActive(true)
+    }
+
+    static func reactivate() throws {
+        try AVAudioSession.sharedInstance().setActive(true)
+    }
+
+    static func deactivate() {
+        try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
+    }
+}
+
 /// Captures 24 kHz PCM16 mono audio from the microphone using AVAudioEngine.
 /// Taps the input node at its hardware format, converts each frame to 24 kHz
 /// Float32 via AVAudioConverter, then yields Int16 samples to the stream.
@@ -9,9 +32,10 @@ final class VoiceAudioCapturer: AudioCapturer, @unchecked Sendable {
     private var hasTap = false
 
     func start() throws -> AsyncStream<[Int16]> {
-        let audioSession = AVAudioSession.sharedInstance()
-        try audioSession.setCategory(.playAndRecord, mode: .default, options: [.defaultToSpeaker, .allowBluetoothHFP])
-        try audioSession.setActive(true)
+        // An interruption may have deactivated the configured session while
+        // the screen remained open. Reassert activation without rebuilding
+        // the Bluetooth route by setting its category again.
+        try VoiceAudioSession.reactivate()
 
         let inputNode = engine.inputNode
         let hwFormat = inputNode.outputFormat(forBus: 0)
@@ -84,6 +108,5 @@ final class VoiceAudioCapturer: AudioCapturer, @unchecked Sendable {
             hasTap = false
         }
         engine.stop()
-        try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
     }
 }

--- a/apps/ios/Luke/VoiceAudioPlayer.swift
+++ b/apps/ios/Luke/VoiceAudioPlayer.swift
@@ -10,13 +10,7 @@ final class VoiceAudioPlayer: AudioPlayer, @unchecked Sendable {
     private let format: AVAudioFormat
 
     init() {
-        let audioSession = AVAudioSession.sharedInstance()
-        try? audioSession.setCategory(
-            .playAndRecord,
-            mode: .default,
-            options: [.defaultToSpeaker, .allowBluetoothHFP]
-        )
-        try? audioSession.setActive(true)
+        try? VoiceAudioSession.reactivate()
         // Float32 mono at 24 kHz — AVAudioPlayerNode's native scheduling format.
         format = AVAudioFormat(
             commonFormat: .pcmFormatFloat32,
@@ -64,6 +58,5 @@ final class VoiceAudioPlayer: AudioPlayer, @unchecked Sendable {
     func stop() {
         playerNode.stop()
         engine.stop()
-        try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
     }
 }

--- a/apps/ios/Luke/VoiceView.swift
+++ b/apps/ios/Luke/VoiceView.swift
@@ -49,6 +49,7 @@ private final class VoiceSessionModel {
     private var reconnectTurnTask: Task<Void, Never>?
     private var reconnectingForTurn = false
     private var endTurnAfterReconnect = false
+    private var audioSessionConfigured = false
 
     func start(
         accountSession: AccountSession,
@@ -58,6 +59,25 @@ private final class VoiceSessionModel {
         guard session == nil else { return }
         errorMessage = nil
         makeActContext = actContext
+        reconnectCallback = { [weak self, weak accountSession] startWithTurn in
+            guard let accountSession else { return }
+            await self?.start(
+                accountSession: accountSession, actContext: actContext, startWithTurn: startWithTurn
+            )
+        }
+
+        do {
+            if audioSessionConfigured {
+                try VoiceAudioSession.reactivate()
+            } else {
+                try VoiceAudioSession.activate()
+                audioSessionConfigured = true
+            }
+        } catch {
+            status = .idle
+            errorMessage = error.localizedDescription
+            return
+        }
 
         let mintVoice = voice.rawValue
         let mintSpeed = speed.multiplier
@@ -129,12 +149,6 @@ private final class VoiceSessionModel {
             makeAudioCapturer: { VoiceAudioCapturer() },
             makeAudioPlayer: { VoiceAudioPlayer() }
         )
-        reconnectCallback = { [weak self, weak accountSession] startWithTurn in
-            guard let accountSession else { return }
-            await self?.start(
-                accountSession: accountSession, actContext: actContext, startWithTurn: startWithTurn
-            )
-        }
         let s = RealtimeSession(options: opts)
         session = s
         await s.connect(startWithTurn: startWithTurn)
@@ -148,6 +162,8 @@ private final class VoiceSessionModel {
         reconnectCallback = nil
         session?.close()
         session = nil
+        VoiceAudioSession.deactivate()
+        audioSessionConfigured = false
     }
 
     func beginTurn() {


### PR DESCRIPTION
## Summary

Tap-to-talk rebuilt the iOS audio session on every microphone and playback transition. With AirPods connected, that repeatedly tore down and renegotiated the Bluetooth HFP route, so capture could start before the input route settled.

This PR now keeps one voice-chat audio session active for the lifetime of the voice screen:

- configure `playAndRecord` + `voiceChat` + Bluetooth HFP before opening the realtime connection
- keep the route active between capture and playback
- reassert activation after interruptions and reconnects without resetting the category
- return activation failures to an idle, retryable state
- deactivate only when the voice screen closes

The previous route watchdogs, diagnostics, short-turn handling, send-chain changes, and tap gesture changes have been removed.

## Verification

- rebased on latest `main` (`a8595319` at verification time)
- `./scripts/check.sh`
- `swift test` in `apps/ios/LukeKit` (242 tests)
- full `Luke` scheme tests on an iPhone 17 Pro simulator running iOS 26.5
- installed and launched the app in the simulator; verified tapping Talk to Luke changes the voice screen from Tap or hold to talk to Listening and the control to Tap to send

The iOS Simulator cannot expose AirPods as an iPhone Bluetooth HFP input route. The route configuration follows the documented `voiceChat` and `allowBluetoothHFP` behavior; the radio path still needs a physical AirPods smoke check.

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/33825791095/artifacts/9919966530) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/33825791095)

- Commit: `debb3b8dca78d399ade592e0c1f6f2579cb60b36`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
