### PR TITLE
feat(ios): open a Conductor cloud session in its own app

### DIFF
--- a/apps/ios/Luke/Marks.swift
+++ b/apps/ios/Luke/Marks.swift
@@ -174,10 +174,13 @@ struct ProviderMark: View {
                 y: (side - art.height * scale) / 2
             )
             ctx.scaleBy(x: scale, y: scale)
+            // One fill per path, like the Canvas above: Conductor's paired
+            // halves overlap with opposite windings, and a single non-zero
+            // fill over all of them would cancel the overlaps into holes.
             for path in art.paths {
                 ctx.addPath(cgPath(fromSVG: path))
+                ctx.fillPath()
             }
-            ctx.fillPath()
         }
         return image.withRenderingMode(.alwaysTemplate)
     }

--- a/apps/ios/Luke/Marks.swift
+++ b/apps/ios/Luke/Marks.swift
@@ -157,6 +157,31 @@ struct ProviderMark: View {
         .scaleEffect(art.opticalScale)
     }
 
+    /// The mark rasterized for a menu row. A `Menu` builds a `UIMenu`, which
+    /// draws only an image beside each title and drops a custom label view,
+    /// so the Canvas above can never appear there. The template rendering
+    /// lets the menu ink it like an SF Symbol rather than in brand colour,
+    /// which is how a menu row's icon reads beside the system's own.
+    static func menuIcon(for provider: VaultProviderID) -> UIImage {
+        let art = art(for: provider)
+        let side: CGFloat = 20
+        let size = CGSize(width: side, height: side)
+        let image = UIGraphicsImageRenderer(size: size).image { rendererContext in
+            let ctx = rendererContext.cgContext
+            let scale = min(side / art.width, side / art.height) * art.opticalScale
+            ctx.translateBy(
+                x: (side - art.width * scale) / 2,
+                y: (side - art.height * scale) / 2
+            )
+            ctx.scaleBy(x: scale, y: scale)
+            for path in art.paths {
+                ctx.addPath(cgPath(fromSVG: path))
+            }
+            ctx.fillPath()
+        }
+        return image.withRenderingMode(.alwaysTemplate)
+    }
+
     private struct MarkArt {
         let width: CGFloat
         let height: CGFloat

--- a/apps/ios/Luke/SessionDetailView.swift
+++ b/apps/ios/Luke/SessionDetailView.swift
@@ -121,6 +121,7 @@ struct SessionDetailView: View {
 
     @Environment(AccountSession.self) private var account
     @Environment(ProductEventSender.self) private var events
+    @Environment(\.openURL) private var openURL
     @State private var text = ""
     @FocusState private var composing: Bool
     /// The fetched conversation, alive only while this screen is: state, not
@@ -326,6 +327,11 @@ struct SessionDetailView: View {
             }
             ToolbarItem(placement: .topBarTrailing) {
                 Menu {
+                    if let link = session.link {
+                        Section {
+                            openInProviderButton(link)
+                        }
+                    }
                     sessionActions { infoShown = true }
                 } label: {
                     Label("Session Actions", systemImage: "ellipsis")
@@ -334,11 +340,36 @@ struct SessionDetailView: View {
             }
         }
         .sheet(isPresented: $infoShown) {
-            SessionInfoSheet(session: session)
+            SessionInfoSheet(session: session, openLink: openSessionLink)
                 .presentationDetents([.medium, .large])
                 .presentationDragIndicator(.visible)
         }
         .safeAreaInset(edge: .bottom, spacing: 0) { inputBar }
+    }
+
+    /// Opening is not a write: the address the observation reported is handed
+    /// to the operating system, and nothing reaches the provider.
+    private func openSessionLink(_ link: URL) {
+        openURL(link)
+        if let provider = ProductProviderID(rawValue: session.providerId) {
+            events.record(.sessionActSend(provider: provider, act: .sessionOpen))
+        }
+    }
+
+    private func openInProviderButton(_ link: URL) -> some View {
+        Button {
+            openSessionLink(link)
+        } label: {
+            if let provider = VaultProviderID(rawValue: session.providerId) {
+                Label {
+                    Text("Open")
+                } icon: {
+                    Image(uiImage: ProviderMark.menuIcon(for: provider))
+                }
+            } else {
+                Label("Open", systemImage: "arrow.up.right.square")
+            }
+        }
     }
 
     /// A fetched message wears the anatomy the screen already draws: the
@@ -604,6 +635,9 @@ struct SessionDetailView: View {
 /// controls exist, while this sheet is the provider's descriptive report.
 private struct SessionInfoSheet: View {
     let session: RosterSession
+    /// The detail screen's own open press, so the sheet's row and the menu's
+    /// entry are one act — opened and counted in one place.
+    let openLink: (URL) -> Void
 
     @Environment(\.dismiss) private var dismiss
     @Environment(\.openURL) private var openURL
@@ -649,6 +683,28 @@ private struct SessionInfoSheet: View {
                         } label: {
                             Text("Last activity")
                         }
+                    }
+                }
+
+                if let link = session.link {
+                    Section {
+                        Button {
+                            openLink(link)
+                        } label: {
+                            HStack(spacing: 12) {
+                                if let provider = VaultProviderID(rawValue: session.providerId) {
+                                    ProviderMark(provider: provider)
+                                        .frame(width: 20, height: 20)
+                                } else {
+                                    Image(systemName: "arrow.up.right.square")
+                                        .frame(width: 20, height: 20)
+                                }
+                                Text(
+                                    "Open in \(VaultProviderID.displayLabel(forWireId: session.providerId))"
+                                )
+                            }
+                        }
+                        .tint(Color.ink)
                     }
                 }
 

--- a/apps/ios/LukeKit/Sources/LukeKit/RosterSession.swift
+++ b/apps/ios/LukeKit/Sources/LukeKit/RosterSession.swift
@@ -51,6 +51,9 @@ public struct RosterSession: Identifiable, Hashable, Sendable {
     public let branch: String?
     /// HTTPS address of the work this session published, when it reported one.
     public let change: URL?
+    /// Provider-owned address that opens this session where it lives, when
+    /// the provider reported one — a deep link into the provider's own app.
+    public let link: URL?
     public let recap: String?
     public let error: String?
     /// Unix milliseconds of the last observed activity, when the endpoint reported one.
@@ -87,6 +90,7 @@ public struct RosterSession: Identifiable, Hashable, Sendable {
         workspace: String? = nil,
         branch: String? = nil,
         change: URL? = nil,
+        link: URL? = nil,
         recap: String? = nil,
         error: String? = nil,
         observedAt: Date? = nil,
@@ -104,6 +108,7 @@ public struct RosterSession: Identifiable, Hashable, Sendable {
         self.workspace = workspace
         self.branch = branch
         self.change = change
+        self.link = link
         self.recap = recap
         self.error = error
         self.observedAt = observedAt
@@ -129,6 +134,7 @@ public struct RosterSession: Identifiable, Hashable, Sendable {
         self.workspace = json["workspace"] as? String
         self.branch = json["branch"] as? String
         self.change = Self.httpsURL(json["change"])
+        self.link = Self.openableURL(json["link"])
         self.recap = json["recap"] as? String
         self.error = json["error"] as? String
         if let ms = json["observedAt"] as? Double {
@@ -152,6 +158,25 @@ public struct RosterSession: Identifiable, Hashable, Sendable {
             let url = URL(string: value),
             url.scheme == "https",
             url.host?.isEmpty == false
+        else { return nil }
+        return url
+    }
+
+    /// The schemes a session address may be handed to the operating system
+    /// with. Mirrors `SESSION_LINK_SCHEME` in `@sidecar/session`: the link is
+    /// the one observed field this app acts on rather than draws, so the set
+    /// is fixed by the build and applied here, where the wire is parsed — an
+    /// address outside it never becomes a button at all.
+    private static let openableLinkSchemes: Set<String> = [
+        "https", "codex", "conductor", "superset",
+    ]
+
+    private static func openableURL(_ value: Any?) -> URL? {
+        guard
+            let value = value as? String,
+            let url = URL(string: value),
+            let scheme = url.scheme?.lowercased(),
+            Self.openableLinkSchemes.contains(scheme)
         else { return nil }
         return url
     }

--- a/apps/ios/LukeKit/Tests/LukeKitTests/RosterClientTests.swift
+++ b/apps/ios/LukeKit/Tests/LukeKitTests/RosterClientTests.swift
@@ -57,11 +57,13 @@ final class RosterSessionTests: XCTestCase {
             "workspace": "my-repo",
             "branch": "main",
             "change": "https://github.com/ReviewStage/luke/pull/642",
+            "link": "conductor://workspace?id=ws-1&session=sess-2",
             "recap": "Waiting for approval",
         ])
         XCTAssertEqual(s?.workspace, "my-repo")
         XCTAssertEqual(s?.branch, "main")
         XCTAssertEqual(s?.change, URL(string: "https://github.com/ReviewStage/luke/pull/642"))
+        XCTAssertEqual(s?.link, URL(string: "conductor://workspace?id=ws-1&session=sess-2"))
         XCTAssertEqual(s?.recap, "Waiting for approval")
         XCTAssertNil(s?.error)
     }
@@ -78,6 +80,30 @@ final class RosterSessionTests: XCTestCase {
             var json = base
             json["change"] = invalid
             XCTAssertNil(RosterSession(json: json)?.change)
+        }
+    }
+
+    func testSessionLinkMustWearAnOpenableScheme() {
+        let base: [String: Any] = [
+            "providerId": "conductor",
+            "sessionId": "sess-link",
+            "title": "Deep-linked chat",
+            "status": "working",
+        ]
+
+        for valid in [
+            "conductor://workspace?id=ws-1&session=sess-link",
+            "https://app.conductor.build/sessions/sess-link",
+        ] {
+            var json = base
+            json["link"] = valid
+            XCTAssertEqual(RosterSession(json: json)?.link, URL(string: valid))
+        }
+
+        for invalid in ["/relative", "javascript:alert(1)", "file:///etc/passwd"] {
+            var json = base
+            json["link"] = invalid
+            XCTAssertNil(RosterSession(json: json)?.link)
         }
     }
 }

--- a/apps/web/server/hosted/observe.ts
+++ b/apps/web/server/hosted/observe.ts
@@ -134,6 +134,8 @@ export function observedSessionForResponse(
   if (branch) session.branch = branch;
   const change = detail.change;
   if (change) session.change = change;
+  const link = detail.link;
+  if (link) session.link = link;
   if (obs.recap) session.recap = obs.recap;
   const error = detail.error;
   if (error) session.error = error;

--- a/apps/web/tests/hosted-observe.test.ts
+++ b/apps/web/tests/hosted-observe.test.ts
@@ -111,6 +111,32 @@ test("the observe response carries only a validated published-work address", () 
   assert.equal(invalid.change, undefined);
 });
 
+test("the observe response carries only an openable session address", () => {
+  const observation = {
+    providerSessionId: "sess-link",
+    title: "Deep-linked chat",
+    status: SESSION_STATUS.WORKING,
+    observedAt: Date.parse("2026-09-02T18:00:00.000Z"),
+  };
+
+  assert.equal(
+    observedSessionForResponse("conductor", {
+      ...observation,
+      detail: {
+        link: "conductor://workspace?id=ws-1&session=sess-link",
+      },
+    }).link,
+    "conductor://workspace?id=ws-1&session=sess-link",
+  );
+  const invalid = observedSessionForResponse("conductor", {
+    ...observation,
+    detail: {
+      link: "javascript:alert(1)",
+    },
+  });
+  assert.equal(invalid.link, undefined);
+});
+
 test("observeAnswerFromWire accepts a valid answer", () => {
   const raw = {
     sessions: [
@@ -122,6 +148,7 @@ test("observeAnswerFromWire accepts a valid answer", () => {
         workspace: "my-repo",
         branch: "main",
         change: "https://github.com/ReviewStage/luke/pull/642",
+        link: "conductor://workspace?id=ws-1&session=sess-1",
         recap: "Working on tests",
       },
     ],
@@ -134,6 +161,7 @@ test("observeAnswerFromWire accepts a valid answer", () => {
   assert.equal(answer.sessions[0]?.status, "working");
   assert.equal(answer.sessions[0]?.workspace, "my-repo");
   assert.equal(answer.sessions[0]?.change, "https://github.com/ReviewStage/luke/pull/642");
+  assert.equal(answer.sessions[0]?.link, "conductor://workspace?id=ws-1&session=sess-1");
 });
 
 test("observeAnswerFromWire drops a published-work address that is not HTTPS", () => {
@@ -150,6 +178,22 @@ test("observeAnswerFromWire drops a published-work address that is not HTTPS", (
   });
 
   assert.equal(answer?.sessions[0]?.change, undefined);
+});
+
+test("observeAnswerFromWire drops a session address outside the openable schemes", () => {
+  const answer = observeAnswerFromWire({
+    sessions: [
+      {
+        providerId: "conductor",
+        sessionId: "sess-link",
+        title: "Deep-linked chat",
+        status: "working",
+        link: "javascript:alert(1)",
+      },
+    ],
+  });
+
+  assert.equal(answer?.sessions[0]?.link, undefined);
 });
 
 test("observeAnswerFromWire skips malformed session entries rather than failing", () => {

--- a/packages/hosted/src/hosted-service.ts
+++ b/packages/hosted/src/hosted-service.ts
@@ -471,6 +471,13 @@ export interface ObservedSession {
   branch?: string;
   /** HTTPS address of the work the session published, when it reported one. */
   change?: string;
+  /**
+   * Provider-owned address that opens this session where it lives, when the
+   * provider reported one. Bounded to the openable session-link schemes —
+   * this is the one observed field a surface acts on rather than draws, so
+   * an address outside the set never crosses the wire at all.
+   */
+  link?: string;
   /** Bounded recap of where the work stands, when the provider reported one. */
   recap?: string;
   /** Error description, when the session stopped on something it cannot pass. */
@@ -548,6 +555,8 @@ function observedSessionFromWire(value: UnparsedWireValue): ObservedSession | un
   const branch = text(value.branch);
   const changeValue = text(value.change);
   const change = changeValue ? normalizeSessionDetail({ change: changeValue }).change : undefined;
+  const linkValue = text(value.link);
+  const link = linkValue ? normalizeSessionDetail({ link: linkValue }).link : undefined;
   const recap = text(value.recap);
   const error = text(value.error);
   const observedAt = wholeNumber(value.observedAt);
@@ -555,6 +564,7 @@ function observedSessionFromWire(value: UnparsedWireValue): ObservedSession | un
   if (workspace) session.workspace = workspace;
   if (branch) session.branch = branch;
   if (change) session.change = change;
+  if (link) session.link = link;
   if (recap) session.recap = recap;
   if (error) session.error = error;
   if (observedAt !== undefined) session.observedAt = observedAt;


### PR DESCRIPTION
## What

Adds deep linking from the iOS app to the Conductor app for Conductor cloud sessions, in the two places the session screen offers acts:

- **Ellipsis menu (top-right of the session screen):** a new **Open** entry wearing the Conductor mark, in its own section above the roster row's advertised actions. `UIMenu` draws only images beside its titles, so the Canvas-drawn `ProviderMark` is rasterized once as a template `UIImage` and inked like an SF Symbol.
- **View Details sheet:** an **Open in Conductor** row drawn with the provider's mark, in the same anatomy as the existing View PR / Open Published Change row.

## How the link travels

The Conductor adapter already reports each cloud session's `deepLink` as `detail.link`, but the observe wire dropped it before the phone saw one. This PR carries it through:

- `apps/web/server/hosted/observe.ts` — `observedSessionForResponse` copies `detail.link` onto the wire; `normalizeSessionDetail` has already bounded it to the openable `SESSION_LINK_SCHEME` set and its length bound, dropping (never truncating) anything else.
- `packages/hosted/src/hosted-service.ts` — `ObservedSession.link`, parsed in `observedSessionFromWire` through the same `normalizeSessionDetail` bound the `change` field uses.
- `apps/ios/LukeKit/.../RosterSession.swift` — `link: URL?`, parsed against a fixed mirror of `SESSION_LINK_SCHEME` (`https`, `codex`, `conductor`, `superset`), so an address outside the set never becomes a button at all.

Both buttons are gated on the observed `link` alone — a session that reported no address is offered nowhere to open, and no fallback is invented. Opening hands the observed address to the operating system and reaches no provider (the same posture as the desktop's row press); the press counts the allowlisted `session:act_send` event with `session_act: session_open`, exactly the desktop's shape. Nothing new leaves the machine: the link travels service → phone beside the fields that already do, and no PRIVACY.md posture changes character.

## Tests

- `apps/web/tests/hosted-observe.test.ts`: response carries a validated `conductor://` address and drops a non-openable one, on both the response and wire-parse sides.
- `apps/ios/.../RosterClientTests.swift`: `link` parses for `conductor://` and `https://` and is dropped for relative, `javascript:`, and `file:` addresses.

## Verification

- `./scripts/check.sh` passed (portable repo, type, test, and build checks), including the new wire tests.
- The iOS target cannot be compiled in this Linux environment; iOS CI is the compile check for the Swift changes. No simulator screenshot was captured, and no physical-notch check was performed (iOS-only change; the macOS surface is untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/33792123247/artifacts/9907850925) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/33792123247)

- Commit: `d66d119bab693acbe9eae2f99ce6e3a55da0b804`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/dbe22280-8442-4993-8239-04fb40866b25)
