### PR TITLE
feat(ios): remove background tiles from provider logos and status icons

### DIFF
--- a/apps/ios/Luke/SessionsView.swift
+++ b/apps/ios/Luke/SessionsView.swift
@@ -652,14 +652,10 @@ struct StatusMark: View {
     let status: String
 
     var body: some View {
-        ZStack {
-            RoundedRectangle(cornerRadius: 7)
-                .fill(Color.pressedFill)
-                .frame(width: 30, height: 30)
-            Image(systemName: symbol)
-                .font(.system(size: 15, weight: .medium))
-                .foregroundStyle(color)
-        }
+        Image(systemName: symbol)
+            .font(.system(size: 15, weight: .medium))
+            .foregroundStyle(color)
+            .frame(width: 30, height: 30)
     }
 
     private var symbol: String {
@@ -811,10 +807,7 @@ struct RosterProviderMark: View {
     let providerId: String
 
     var body: some View {
-        ZStack {
-            RoundedRectangle(cornerRadius: 7)
-                .fill(Color.pressedFill)
-                .frame(width: 30, height: 30)
+        Group {
             if let provider = VaultProviderID(rawValue: providerId) {
                 ProviderMark(provider: provider)
                     .frame(width: 20, height: 20)
@@ -824,6 +817,7 @@ struct RosterProviderMark: View {
                     .foregroundStyle(Color.inkSecondary)
             }
         }
+        .frame(width: 30, height: 30)
     }
 }
 


### PR DESCRIPTION
## What

Removes the rounded `pressedFill` background tiles behind the provider brand marks and status glyphs in the iOS app. Both marks are shared components (`RosterProviderMark` and `StatusMark` in `SessionsView.swift`), so one change covers every surface that draws them:

- the roster list rows (and the long-press row preview),
- the filter menu's provider and status option rows,
- the session detail screen's title bar mark,
- the session info sheet's Provider and Status rows.

The marks now render flat. The fixed 30pt slot is kept, so row geometry, the filter rows' alignment, and the title bar's 24/30 scale are unchanged; only the tile is gone.

## Verification

- `./scripts/check.sh` passes (exit 0).
- iOS has no CI build; the change is a mechanical SwiftUI edit (drop the `ZStack` tile, keep the 30pt frame) reviewed by inspection. No Simulator screenshot was captured — this environment has no macOS/Xcode toolchain, so a visual check on device/Simulator is left to the reviewer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/33775689080/artifacts/9901588899) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/33775689080)

- Commit: `73c46dc5ade673c475197b9ce7cd0c33b9e8460e`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/776b8fe9-d82a-43b2-abf4-7a4e0ed1b028)
