### PR TITLE
feat(ios): let the voice conversation outlive the voice screen

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -142,8 +142,8 @@ and email you signed it with, and any screenshots you attached.
   memory are kept on your Mac and sent with a call so the conversation carries
   across calls and across launches; on iOS, a call also carries the list of
   projects your synced keys can create a workspace in, while the conversation
-  itself is held in memory and discarded when the session closes, and nothing
-  is remembered between calls.
+  itself is held in memory until the app quits, is never stored on the phone,
+  and each call starts without it.
   The one voice call that happens before you sign in is the spoken
   introduction on first launch of the Mac app: it sends its own fixed script,
   the titles of the coding agent sessions found on your Mac, and anything you

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -142,8 +142,8 @@ and email you signed it with, and any screenshots you attached.
   memory are kept on your Mac and sent with a call so the conversation carries
   across calls and across launches; on iOS, a call also carries the list of
   projects your synced keys can create a workspace in, while the conversation
-  itself is held in memory until the app quits, is never stored on the phone,
-  and each call starts without it.
+  itself is held in memory until the app quits or you sign out, is never
+  stored on the phone, and each call starts without it.
   The one voice call that happens before you sign in is the spoken
   introduction on first launch of the Mac app: it sends its own fixed script,
   the titles of the coding agent sessions found on your Mac, and anything you

--- a/apps/ios/Luke/LukeApp.swift
+++ b/apps/ios/Luke/LukeApp.swift
@@ -90,6 +90,7 @@ struct LukeApp: App {
             }
         case (.signedIn, .signedOut):
             SessionReplay.resetPerson()
+            conversation.clear()
         default:
             break
         }

--- a/apps/ios/Luke/LukeApp.swift
+++ b/apps/ios/Luke/LukeApp.swift
@@ -6,6 +6,7 @@ struct LukeApp: App {
     @State private var session: AccountSession
     @State private var vault: VaultStore
     @State private var events: ProductEventSender
+    @State private var conversation = VoiceConversationThread()
     @Environment(\.scenePhase) private var scenePhase
     // Held for its lifetime — the WCSessionDelegate must not be deallocated.
     private let phoneRelay: PhoneSessionRelay
@@ -54,6 +55,7 @@ struct LukeApp: App {
                 .environment(session)
                 .environment(vault)
                 .environment(events)
+                .environment(conversation)
                 .onChange(of: session.state) { previous, current in
                     accountEdge(from: previous, to: current)
                     switch current {

--- a/apps/ios/Luke/VoiceView.swift
+++ b/apps/ios/Luke/VoiceView.swift
@@ -5,18 +5,6 @@ import SwiftUI
 
 // MARK: - Observable session state
 
-private struct VoiceTranscriptMessage: Identifiable, Equatable {
-    enum Speaker: Equatable {
-        case developer
-        case luke
-    }
-
-    let id = UUID()
-    let turnId: UUID
-    let speaker: Speaker
-    var words: String
-}
-
 /// Where a spoken act asked to take the developer once Luke has finished
 /// saying so: a session's own screen, or the list narrowed as asked. Held
 /// until the reply settles, because moving the screen mid-sentence would
@@ -26,13 +14,15 @@ private enum PendingNavigation {
     case list(VoiceAsks.SessionListAsk)
 }
 
-/// Holds all observable voice session state. Lives on the main actor so the
-/// session's @MainActor callbacks can update it without hopping actors.
+/// Holds the observable state of one visit to the voice screen. Lives on the
+/// main actor so the session's @MainActor callbacks can update it without
+/// hopping actors. The conversation itself is not here: it lives in the
+/// app-scoped VoiceConversationThread this model records into, so the words
+/// survive the screen being popped while the call and its status do not.
 @Observable
 @MainActor
 private final class VoiceSessionModel {
     var status: RealtimeStatus = .idle
-    var messages: [VoiceTranscriptMessage] = []
     var errorMessage: String?
     // Read at each start, so a reconnect mints with the latest choice.
     var voice = RealtimeVoice.default
@@ -50,10 +40,9 @@ private final class VoiceSessionModel {
     /// The New Workspace choices this device remembers, read at the moment a
     /// call opens or an act lands.
     let defaults = WorkspaceCreationDefaults()
+    var thread: VoiceConversationThread?
     private var session: RealtimeSession?
     private var makeActContext: (@MainActor () -> VoiceActContext)?
-    private var activeTurnId: UUID?
-    private var activeResponseMessageId: UUID?
     // Kept while this screen is alive so a direct press can reopen a socket
     // after the three-minute idle close. An idle edge itself never remints.
     private var reconnectCallback: (@MainActor (_ startWithTurn: Bool) async -> Void)?
@@ -98,8 +87,8 @@ private final class VoiceSessionModel {
                     self?.session = nil
                 }
             },
-            onCaption: { [weak self] text in self?.receiveCaption(text) },
-            onSpokenAsk: { [weak self] text in self?.receiveSpokenAsk(text) },
+            onCaption: { [weak self] text in self?.thread?.recordCaption(text) },
+            onSpokenAsk: { [weak self] text in self?.thread?.recordSpokenAsk(text) },
             onError: { [weak self] message in
                 self?.errorMessage = message ?? "Connection error"
             },
@@ -156,8 +145,7 @@ private final class VoiceSessionModel {
         // A new press supersedes what the last reply was about to do: an open
         // the developer talked over is an open they no longer want taken.
         pendingNavigation = nil
-        activeTurnId = UUID()
-        activeResponseMessageId = nil
+        thread?.beginTurn()
         if let session {
             session.beginTurn()
             return
@@ -204,52 +192,6 @@ private final class VoiceSessionModel {
         }
     }
 
-    private func receiveSpokenAsk(_ text: String) {
-        let words = text.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !words.isEmpty else { return }
-        let turnId = currentTurnId()
-        if let index = messages.firstIndex(where: {
-            $0.turnId == turnId && $0.speaker == .developer
-        }) {
-            messages[index].words = words
-            return
-        }
-        let message = VoiceTranscriptMessage(turnId: turnId, speaker: .developer, words: words)
-        if let responseIndex = messages.firstIndex(where: {
-            $0.turnId == turnId && $0.speaker == .luke
-        }) {
-            messages.insert(message, at: responseIndex)
-        } else {
-            messages.append(message)
-        }
-    }
-
-    private func receiveCaption(_ text: String?) {
-        guard let text, !text.isEmpty else {
-            activeResponseMessageId = nil
-            return
-        }
-        if let id = activeResponseMessageId,
-           let index = messages.firstIndex(where: { $0.id == id })
-        {
-            messages[index].words = text
-            return
-        }
-        let message = VoiceTranscriptMessage(
-            turnId: currentTurnId(),
-            speaker: .luke,
-            words: text
-        )
-        messages.append(message)
-        activeResponseMessageId = message.id
-    }
-
-    private func currentTurnId() -> UUID {
-        if let activeTurnId { return activeTurnId }
-        let id = UUID()
-        activeTurnId = id
-        return id
-    }
 }
 
 // MARK: - VoiceView
@@ -258,6 +200,7 @@ private final class VoiceSessionModel {
 /// once to leave the microphone open and tap again to send.
 struct VoiceView: View {
     @Environment(AccountSession.self) private var accountSession
+    @Environment(VoiceConversationThread.self) private var conversation
     @AppStorage(VoiceSettingsKey.voice) private var voice = RealtimeVoice.default
     @AppStorage(VoiceSettingsKey.speed) private var speed = RealtimeVoiceSpeed.default
     @Environment(ProductEventSender.self) private var events
@@ -292,6 +235,7 @@ struct VoiceView: View {
                 .presentationDragIndicator(.visible)
         }
         .task {
+            model.thread = conversation
             model.voice = voice
             model.speed = speed
             // The roster the acts are validated against is the list's own,
@@ -375,7 +319,7 @@ struct VoiceView: View {
 
     private var conversationHistory: some View {
         ZStack {
-            if model.messages.isEmpty {
+            if conversation.messages.isEmpty {
                 Text(placeholderText)
                     .font(.system(size: 17))
                     .foregroundStyle(Color.inkTertiary)
@@ -385,7 +329,7 @@ struct VoiceView: View {
                 ScrollViewReader { proxy in
                     ScrollView {
                         VStack(spacing: 14) {
-                            ForEach(model.messages) { message in
+                            ForEach(conversation.messages) { message in
                                 Group {
                                     switch message.speaker {
                                     case .developer:
@@ -405,12 +349,12 @@ struct VoiceView: View {
                         // bubbles themselves can still scroll behind the glass.
                         .padding(.bottom, 160)
                     }
-                    .onChange(of: model.messages) {
-                        guard let last = model.messages.last else { return }
+                    .onChange(of: conversation.messages) {
+                        guard let last = conversation.messages.last else { return }
                         withAnimation { proxy.scrollTo(last.id, anchor: .bottom) }
                     }
                     .onAppear {
-                        if let last = model.messages.last {
+                        if let last = conversation.messages.last {
                             proxy.scrollTo(last.id, anchor: .bottom)
                         }
                     }
@@ -418,7 +362,7 @@ struct VoiceView: View {
             }
         }
         .frame(maxHeight: .infinity)
-        .animation(.easeInOut(duration: 0.15), value: model.messages.isEmpty)
+        .animation(.easeInOut(duration: 0.15), value: conversation.messages.isEmpty)
     }
 
     private var bottomControls: some View {

--- a/apps/ios/LukeKit/Sources/LukeKit/VoiceConversationThread.swift
+++ b/apps/ios/LukeKit/Sources/LukeKit/VoiceConversationThread.swift
@@ -1,0 +1,121 @@
+import Foundation
+import Observation
+
+// MARK: - One line of the thread
+
+/// One line of the conversation Luke holds with the developer on this phone:
+/// the developer's spoken ask as the voice service transcribed it, or the
+/// words Luke spoke back.
+public struct VoiceConversationMessage: Identifiable, Equatable, Sendable {
+    public enum Speaker: Equatable, Sendable {
+        case developer
+        case luke
+    }
+
+    public let id: UUID
+    public let turnId: UUID
+    public let speaker: Speaker
+    public var words: String
+
+    public init(turnId: UUID, speaker: Speaker, words: String) {
+        id = UUID()
+        self.turnId = turnId
+        self.speaker = speaker
+        self.words = words
+    }
+}
+
+// MARK: - The thread
+
+/// The conversation Luke holds with the developer, kept outside any one voice
+/// call and outside the voice screen. A Realtime call is a transport that
+/// comes and goes — a voice change remints it, the idle timeout retires it —
+/// and the screen is a way of looking at the thread, not its owner: popping
+/// back to the sessions list must not erase what was said. Owned at app scope
+/// and injected into the voice screen, the same continuity the desktop keeps
+/// by holding its thread outside the call. Held in memory only: nothing here
+/// reaches a file, and quitting the app is the end of the record.
+@Observable
+@MainActor
+public final class VoiceConversationThread {
+    /// How much of the thread stays, the desktop's stored bound transcribed.
+    /// It exists so a long day of conversation cannot grow this object and
+    /// the screen's scrollback without limit; every retained line's words
+    /// stay whole, because the thread is the developer's own record.
+    public static let maximumRetainedMessages = 200
+
+    public private(set) var messages: [VoiceConversationMessage] = []
+
+    private var activeTurnId: UUID?
+    private var activeResponseMessageId: UUID?
+
+    public init() {}
+
+    /// Marks a developer press: the ask and reply that follow belong to one
+    /// turn, which is what lets a transcript arriving late find its place.
+    public func beginTurn() {
+        activeTurnId = UUID()
+        activeResponseMessageId = nil
+    }
+
+    /// Records the developer's transcribed words. The transcription arrives
+    /// on the service's own clock — usually while the reply is already
+    /// streaming — so the ask is placed before its own turn's reply rather
+    /// than appended after it, and a fuller transcription of the same turn
+    /// replaces the words rather than repeating the ask.
+    public func recordSpokenAsk(_ text: String) {
+        let words = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !words.isEmpty else { return }
+        let turnId = currentTurnId()
+        if let index = messages.firstIndex(where: {
+            $0.turnId == turnId && $0.speaker == .developer
+        }) {
+            messages[index].words = words
+            return
+        }
+        let message = VoiceConversationMessage(turnId: turnId, speaker: .developer, words: words)
+        if let responseIndex = messages.firstIndex(where: {
+            $0.turnId == turnId && $0.speaker == .luke
+        }) {
+            messages.insert(message, at: responseIndex)
+        } else {
+            messages.append(message)
+        }
+        retainRecentMessages()
+    }
+
+    /// Records the running caption of the reply being spoken; nil ends the
+    /// streaming segment so a tool follow-up gets its own bubble.
+    public func recordCaption(_ text: String?) {
+        guard let text, !text.isEmpty else {
+            activeResponseMessageId = nil
+            return
+        }
+        if let id = activeResponseMessageId,
+           let index = messages.firstIndex(where: { $0.id == id })
+        {
+            messages[index].words = text
+            return
+        }
+        let message = VoiceConversationMessage(
+            turnId: currentTurnId(),
+            speaker: .luke,
+            words: text
+        )
+        messages.append(message)
+        activeResponseMessageId = message.id
+        retainRecentMessages()
+    }
+
+    private func currentTurnId() -> UUID {
+        if let activeTurnId { return activeTurnId }
+        let id = UUID()
+        activeTurnId = id
+        return id
+    }
+
+    private func retainRecentMessages() {
+        let excess = messages.count - Self.maximumRetainedMessages
+        if excess > 0 { messages.removeFirst(excess) }
+    }
+}

--- a/apps/ios/LukeKit/Sources/LukeKit/VoiceConversationThread.swift
+++ b/apps/ios/LukeKit/Sources/LukeKit/VoiceConversationThread.swift
@@ -107,6 +107,15 @@ public final class VoiceConversationThread {
         retainRecentMessages()
     }
 
+    /// Empties the thread at the developer's sign-out. The record is the
+    /// signed-in developer's own: on a shared phone the next account must not
+    /// inherit it, on screen or anywhere a later call could carry it.
+    public func clear() {
+        messages = []
+        activeTurnId = nil
+        activeResponseMessageId = nil
+    }
+
     private func currentTurnId() -> UUID {
         if let activeTurnId { return activeTurnId }
         let id = UUID()

--- a/apps/ios/LukeKit/Tests/LukeKitTests/VoiceConversationThreadTests.swift
+++ b/apps/ios/LukeKit/Tests/LukeKitTests/VoiceConversationThreadTests.swift
@@ -65,6 +65,17 @@ final class VoiceConversationThreadTests: XCTestCase {
         XCTAssertTrue(thread.messages.isEmpty)
     }
 
+    func testClearEmptiesTheThreadAndTheTurnState() {
+        let thread = VoiceConversationThread()
+        thread.beginTurn()
+        thread.recordSpokenAsk("Before sign-out")
+        thread.recordCaption("A reply")
+        thread.clear()
+        XCTAssertTrue(thread.messages.isEmpty)
+        thread.recordCaption("After")
+        XCTAssertEqual(thread.messages.map(\.words), ["After"])
+    }
+
     func testRetentionDropsTheOldestLines() {
         let thread = VoiceConversationThread()
         for index in 0 ..< (VoiceConversationThread.maximumRetainedMessages + 5) {

--- a/apps/ios/LukeKit/Tests/LukeKitTests/VoiceConversationThreadTests.swift
+++ b/apps/ios/LukeKit/Tests/LukeKitTests/VoiceConversationThreadTests.swift
@@ -1,0 +1,77 @@
+import Foundation
+import XCTest
+
+@testable import LukeKit
+
+@MainActor
+final class VoiceConversationThreadTests: XCTestCase {
+    func testCaptionStreamsIntoOneMessage() {
+        let thread = VoiceConversationThread()
+        thread.beginTurn()
+        thread.recordCaption("Working")
+        thread.recordCaption("Working on it")
+        XCTAssertEqual(thread.messages.map(\.words), ["Working on it"])
+        XCTAssertEqual(thread.messages.first?.speaker, .luke)
+    }
+
+    func testCaptionAfterSegmentEndStartsANewBubble() {
+        let thread = VoiceConversationThread()
+        thread.beginTurn()
+        thread.recordCaption("First reply")
+        thread.recordCaption(nil)
+        thread.recordCaption("Tool follow-up")
+        XCTAssertEqual(thread.messages.map(\.words), ["First reply", "Tool follow-up"])
+    }
+
+    func testLateSpokenAskLandsBeforeItsTurnsReply() {
+        let thread = VoiceConversationThread()
+        thread.beginTurn()
+        thread.recordCaption("The tests are green.")
+        thread.recordSpokenAsk("How are the tests?")
+        XCTAssertEqual(
+            thread.messages.map(\.words),
+            ["How are the tests?", "The tests are green."]
+        )
+        XCTAssertEqual(thread.messages.map(\.speaker), [.developer, .luke])
+    }
+
+    func testSpokenAskReplacesItsTurnsEarlierTranscription() {
+        let thread = VoiceConversationThread()
+        thread.beginTurn()
+        thread.recordSpokenAsk("How are")
+        thread.recordSpokenAsk("How are the tests?")
+        XCTAssertEqual(thread.messages.map(\.words), ["How are the tests?"])
+    }
+
+    func testTurnsStaySeparated() {
+        let thread = VoiceConversationThread()
+        thread.beginTurn()
+        thread.recordSpokenAsk("First ask")
+        thread.recordCaption("First reply")
+        thread.recordCaption(nil)
+        thread.beginTurn()
+        thread.recordCaption("Second reply")
+        thread.recordSpokenAsk("Second ask")
+        XCTAssertEqual(
+            thread.messages.map(\.words),
+            ["First ask", "First reply", "Second ask", "Second reply"]
+        )
+    }
+
+    func testEmptySpokenAskRecordsNothing() {
+        let thread = VoiceConversationThread()
+        thread.beginTurn()
+        thread.recordSpokenAsk("   \n")
+        XCTAssertTrue(thread.messages.isEmpty)
+    }
+
+    func testRetentionDropsTheOldestLines() {
+        let thread = VoiceConversationThread()
+        for index in 0 ..< (VoiceConversationThread.maximumRetainedMessages + 5) {
+            thread.beginTurn()
+            thread.recordSpokenAsk("Ask \(index)")
+        }
+        XCTAssertEqual(thread.messages.count, VoiceConversationThread.maximumRetainedMessages)
+        XCTAssertEqual(thread.messages.first?.words, "Ask 5")
+    }
+}


### PR DESCRIPTION
## What

Luke forgot his conversation on iOS whenever the developer went back to the main view: `VoiceView` held the entire thread in its own view-local `@State`, so popping the `NavigationStack` deallocated the messages along with the call.

This PR gives the thread the desktop's shape — the conversation lives outside the call and outside the screen:

- New `VoiceConversationThread` in LukeKit: an `@Observable`, main-actor thread that records the developer's transcribed asks and Luke's streamed captions, with the same late-transcript placement logic the view model had (a spoken ask lands before its own turn's reply).
- `LukeApp` owns one instance and injects it through the environment, the same pattern as `AccountSession` and `VaultStore`; `VoiceView` reads it with `@Environment` and draws from it. The screen visit's own state (status, error, the Realtime call) stays view-local and is still torn down on disappear — only the words survive.
- The thread keeps the desktop's stored bound of 200 lines (`maximumStoredConversationEntries` in `packages/realtime/src/conversation-history.ts`), each line's words kept whole.
- PRIVACY.md's iOS clause moves with it: the conversation is now held in memory until the app quits, is never stored on the phone, and each call still starts without it (re-seeding a new call with the recent slice is the stacked follow-up PR).

## Trust posture

Nothing new leaves the phone in this PR: the thread is memory-only, reaches no file, no provider, and no call. What the session recording can see of the voice screen is unchanged in kind — the same bubbles on the same screen, now surviving a pop-back.

## Validation

- `./scripts/check.sh` passes (portable checks; the diff's only non-Swift file is PRIVACY.md).
- No Swift toolchain is available in this environment, so `xcodebuild … test` and `swift test` for LukeKit (including the new `VoiceConversationThreadTests`) could not be run here and need a Mac. The new thread logic is a verbatim port of the view model's, under tests that pin the late-transcript insertion, caption streaming, turn separation, and retention behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/444a12c4-8bcd-4d96-8af4-6e26d5943d59)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/33820108429/artifacts/9918024159) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/33820108429)

- Commit: `22d639d4f0c0ba09b305a7e0ea4f50057ee419ce`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
