### PR TITLE
chore(release): v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,82 @@
 Notable changes to Luke, newest first. Each heading is a released version and
 the date its release was published.
 
+## 0.5.0 — 2026-09-03
+
+### Spoken sessions on your iPhone
+
+Hold the button and talk to Luke from your phone. The iPhone app opens a
+realtime voice session on the same kind of short-lived credential the desktop
+mints, carrying your session roster with it, with running captions while you
+speak and while he answers. What he can carry from there is the six acts the
+phone's own endpoints serve — sending a session a message, pressing a control,
+adding an agent, creating a workspace, and renaming a workspace or a session —
+each re-validated on the server. A gear on the voice screen offers the same
+voice and speed the desktop does: a speed change reaches the session already
+open, a voice change reopens it in the new voice. Tapping a session opens its
+conversation, paged from Conductor's own messages endpoint and drawn as
+Markdown, and an info button holds that session's details beside the GitHub
+changes and pull requests its provider published.
+([#617](https://github.com/ReviewStage/luke/pull/617),
+[#616](https://github.com/ReviewStage/luke/pull/616),
+[#658](https://github.com/ReviewStage/luke/pull/658),
+[#654](https://github.com/ReviewStage/luke/pull/654),
+[#637](https://github.com/ReviewStage/luke/pull/637),
+[#640](https://github.com/ReviewStage/luke/pull/640),
+[#647](https://github.com/ReviewStage/luke/pull/647))
+
+### Announcements that say what an agent is working on
+
+No field a provider writes says what an agent is generally working on: a title
+is your first message, an activity is the tool running right now, and a recap is
+the last settled turn — so an announcement that named a session by its title
+named work it had stopped doing. Luke now derives one short phrase from a local
+session's own transcript and speaks that instead. The derivation runs only for a
+session about to be announced, at the moment the announcement is delivered, once
+per announcement and under a deadline past which the announcement speaks without
+it; the phrase lives in that one payload, is drawn nowhere, and reaches no act.
+`PRIVACY.md` says the read and the send in as many words.
+([#649](https://github.com/ReviewStage/luke/pull/649))
+
+### Improvements
+
+- Onboarding now ends at a calendar: from your first sign-in Luke stands a gate
+  offering this Mac's own Calendar or Google, because the quiet that keeps
+  announcements out of your meetings only works once he can see one
+  ([#561](https://github.com/ReviewStage/luke/pull/561))
+- A Pause announcements switch on the Voice page holds spoken announcements by
+  hand, over the same speech a meeting's quiet holds, while replies in a
+  conversation you opened still speak
+  ([#651](https://github.com/ReviewStage/luke/pull/651))
+- The Ask Luke composer now stands at the foot of the History tab too, so
+  reading the thread and continuing it no longer costs a tab change
+  ([#643](https://github.com/ReviewStage/luke/pull/643))
+- Luke names every workspace he creates — yours when you chose one out loud,
+  otherwise a short name composed for the work — instead of leaving Conductor to
+  fall back to a random city
+  ([#636](https://github.com/ReviewStage/luke/pull/636))
+
+### Fixes
+
+- Fixed History cutting off any ask or reply longer than 400 characters
+  ([#629](https://github.com/ReviewStage/luke/pull/629))
+- Fixed the Provider keys section reading "The vault answered with something
+  unexpected" for an account holding a key stored for a provider Luke no longer
+  carries ([#656](https://github.com/ReviewStage/luke/pull/656))
+- Fixed the spoken introduction ending on a question you had no chance to answer
+  ([#644](https://github.com/ReviewStage/luke/pull/644))
+
+### Miscellaneous
+
+- Updated the provider set to Conductor, Superset, Claude Code, Codex, and OMP,
+  with Cursor, OpenCode, Copilot, Gemini CLI, and Grok Build staying on as the
+  agents a Conductor or Superset workspace runs
+  ([#645](https://github.com/ReviewStage/luke/pull/645))
+- Added a LukeWatch watchOS companion target, carrying the Luke icon cut for the
+  watch's circular mask
+  ([#652](https://github.com/ReviewStage/luke/pull/652),
+  [#657](https://github.com/ReviewStage/luke/pull/657))
+
 ## 0.4.0 — 2026-09-02
 
 ### Synced provider keys

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@luke/desktop",
   "productName": "Luke",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "private": true,
   "description": "Luke desktop application",
   "main": "dist/main.js",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luke/web",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "private": true,
   "type": "module",
   "description": "Luke landing page",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "luke",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "private": true,
   "description": "A notch-attached desktop sidecar for coding-agent sessions",
   "packageManager": "pnpm@10.34.5",

--- a/packages/account/package.json
+++ b/packages/account/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/account",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/acts/package.json
+++ b/packages/acts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/acts",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/analytics",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/attention/package.json
+++ b/packages/attention/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/attention",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/calendar/package.json
+++ b/packages/calendar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/calendar",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/credentials/package.json
+++ b/packages/credentials/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/credentials",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/devtrace/package.json
+++ b/packages/devtrace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/devtrace",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/feedback/package.json
+++ b/packages/feedback/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/feedback",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/fixtures/package.json
+++ b/packages/fixtures/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/fixtures",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/guide/package.json
+++ b/packages/guide/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/guide",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/hosted/package.json
+++ b/packages/hosted/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/hosted",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/issues/package.json
+++ b/packages/issues/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/issues",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/panel/package.json
+++ b/packages/panel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/panel",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/process/package.json
+++ b/packages/process/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/process",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/providers/package.json
+++ b/packages/providers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/providers",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/realtime/package.json
+++ b/packages/realtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/realtime",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/session/package.json
+++ b/packages/session/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/session",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/settings/package.json
+++ b/packages/settings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/settings",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/superset/package.json
+++ b/packages/superset/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/superset",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/surface/package.json
+++ b/packages/surface/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/surface",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/trackers/package.json
+++ b/packages/trackers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/trackers",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/voice/package.json
+++ b/packages/voice/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/voice",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/wire/package.json
+++ b/packages/wire/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/wire",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "private": true,
   "type": "module",
   "exports": {

--- a/scripts/packaging.test.mjs
+++ b/scripts/packaging.test.mjs
@@ -50,7 +50,7 @@ function builderConfig(env = {}) {
   return createElectronBuilderConfig(env);
 }
 
-test("workspace package versions agree on v0.4.0", () => {
+test("workspace package versions agree on v0.5.0", () => {
   // Enumerated rather than listed, so a package added to the workspace is held
   // to the release version without anyone remembering to name it here.
   const packagePaths = [
@@ -74,7 +74,7 @@ test("workspace package versions agree on v0.4.0", () => {
 
   assert.deepEqual(
     versions.map(({ version }) => version),
-    packagePaths.map(() => "0.4.0"),
+    packagePaths.map(() => "0.5.0"),
   );
 });
 


### PR DESCRIPTION
Version bump and changelog for v0.5.0, covering the 22 commits since v0.4.0.

- Spoken sessions on iPhone (realtime voice, remote mint, voice settings, session details, Conductor conversation reading, Markdown messages)
- Announcements that name what an agent is working on, from a derived session subject
- Calendar onboarding step, Pause announcements switch, History-tab composer, named Conductor workspaces
- Provider set trimmed to Conductor, Superset, Claude Code, Codex, and OMP

`./scripts/check.sh` passes. Portable-only change: no UI or macOS behavior moves, so no visual evidence.

Hosted service on `main` is live: `/api/voice/introduction-mint` 200, `/api/voice/remote-mint` 401 (auth required), `/api/sessions/messages` 405 — all three routes resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/33783797397/artifacts/9904721438) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/33783797397)

- Commit: `7e17d14128789da7deb2367bab70dc9b15b9d64d`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
