### PR TITLE
fix(ios): let the voice screen follow the system appearance

### DIFF
--- a/apps/ios/Luke/VoiceView.swift
+++ b/apps/ios/Luke/VoiceView.swift
@@ -221,7 +221,6 @@ struct VoiceView: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(Color.ground.ignoresSafeArea())
-        .preferredColorScheme(.dark)
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
             ToolbarItem(placement: .principal) { statusLabel }


### PR DESCRIPTION
## Summary

- Remove the `.preferredColorScheme(.dark)` override on the iOS voice screen so it follows the system light/dark setting like every other screen.
- No other change: every colour the screen draws already comes from the appearance-resolved palette in `Palette.swift`, and its message bubbles are the ones `SessionDetailView` already draws in either scheme.

## Test plan

- [ ] Run the iOS app on the Simulator in light mode and open the voice screen: the ground, status label, bubbles, and placeholder should render in the light palette.
- [ ] Switch to dark mode: the screen should look as it did before this change.

No screenshot is attached: the change is Swift-only and this session ran in a Linux cloud sandbox without Xcode, so no build or Simulator capture was possible here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/33790168523/artifacts/9907152741) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/33790168523)

- Commit: `6b6694184c0044241834d5e0387b6bdcd365d1ac`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
