### PR TITLE
fix(ios): move the voice screen's status text below the talk button

### DIFF
--- a/apps/ios/Luke/VoiceView.swift
+++ b/apps/ios/Luke/VoiceView.swift
@@ -223,7 +223,6 @@ struct VoiceView: View {
         .background(Color.ground.ignoresSafeArea())
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
-            ToolbarItem(placement: .principal) { statusLabel }
             ToolbarItem(placement: .topBarTrailing) { settingsButton }
         }
         .sheet(isPresented: $settingsShown) {
@@ -296,7 +295,7 @@ struct VoiceView: View {
                         // The controls float above the thread. Empty space at
                         // its tail lets the newest bubble clear them while the
                         // bubbles themselves can still scroll behind the glass.
-                        .padding(.bottom, 132)
+                        .padding(.bottom, 160)
                     }
                     .onChange(of: model.messages) {
                         guard let last = model.messages.last else { return }
@@ -326,6 +325,7 @@ struct VoiceView: View {
                     .transition(.move(edge: .bottom).combined(with: .opacity))
             }
             talkButton
+            statusLabel
         }
         .padding(.bottom, 10)
         .animation(.easeInOut(duration: 0.2), value: model.errorMessage)


### PR DESCRIPTION
## Summary

On the iOS voice screen, the live status text ("Tap or hold to talk", "Listening…", "Speaking…") was rendered in the navigation bar's `.principal` slot, where it read as a screen title and sat far from the control it describes. This moves it below the microphone button:

- Removed the `.principal` toolbar item; the nav bar now holds only the settings gear.
- Added `statusLabel` to the floating bottom controls directly under `talkButton`, keeping its status-driven animation. The error message still appears above the button.
- Increased the transcript's tail padding from 132 to 160 so the newest bubble scrolls clear of the taller control stack.

## Testing

- `./scripts/check.sh` passes (exit 0).
- Not compiled or screenshotted: this cloud workspace is Linux with no Xcode, so no simulator build or visual evidence was possible. The edit is small and mechanical, but a visual pass on a Mac is worth doing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/4140bdf7-8476-4d35-bec4-98604799b5e6)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/33791290111/artifacts/9907573068) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/33791290111)

- Commit: `52f7c76553a64dd0eb561a78f902505e7a79b848`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
