### PR TITLE
feat(ios): remove an archived chat at the press and pop its screen

### DIFF
--- a/apps/ios/Luke/SessionsView.swift
+++ b/apps/ios/Luke/SessionsView.swift
@@ -8,10 +8,13 @@ struct SessionsView: View {
     @Environment(ProductEventSender.self) private var events
 
     @State private var sessions: [RosterSession] = []
-    /// Starts true because the list's first frame can paint before its
-    /// `.task` begins the fetch, and that frame must show the skeletons
-    /// rather than claim "No active sessions" nothing has checked yet.
-    @State private var isLoading = true
+    /// True until the first roster fetch answers, because the list's first
+    /// frame can paint before its `.task` begins the fetch, and that frame
+    /// must show the skeletons rather than claim "No active sessions" nothing
+    /// has checked yet. Only that first wait may show them: a later refresh
+    /// that finds the list already empty (the last chat just archived) must
+    /// not flash skeletons over an emptiness that is real.
+    @State private var awaitingFirstRoster = true
     @State private var fetchError: String?
     @State private var searchQuery = ""
     @State private var filters: Set<SessionFilter> = []
@@ -144,7 +147,7 @@ struct SessionsView: View {
             by: sort
         )
         return List {
-            if isLoading && sessions.isEmpty {
+            if awaitingFirstRoster && sessions.isEmpty {
                 ForEach(0 ..< 3, id: \.self) { _ in
                     SkeletonRow()
                         .listRowBackground(Color.clear)
@@ -413,6 +416,15 @@ struct SessionsView: View {
             if control.kind == .archive {
                 archivingIds.remove(s.id)
                 if !delivered {
+                    // Restored locally before the refresh converges, because
+                    // the outage that refused the act usually fails the
+                    // refresh too, and a chat the server never archived must
+                    // not stay gone on the refusal's word alone.
+                    withAnimation {
+                        if !sessions.contains(where: { $0.id == s.id }) {
+                            sessions.append(s)
+                        }
+                    }
                     await refreshSessions()
                 }
             }
@@ -485,10 +497,9 @@ struct SessionsView: View {
     private func refreshSessions() async {
         refreshPass += 1
         let pass = refreshPass
-        isLoading = true
         fetchError = nil
-        defer { isLoading = false }
         guard case .signedIn = session.state else { return }
+        defer { awaitingFirstRoster = false }
         do {
             let fetched = try await session.authorized { token in
                 try await rosterClient.observe(bearerToken: token)

--- a/apps/ios/Luke/SessionsView.swift
+++ b/apps/ios/Luke/SessionsView.swift
@@ -32,10 +32,16 @@ struct SessionsView: View {
     @State private var renameText = ""
     @State private var creatorShown = false
     @State private var actFailure: String?
-    /// Counts refresh passes so only the newest may write: a pull-to-refresh
-    /// overlapping a post-act refresh must not land its older roster after
-    /// the newer one — an archived row would come back from the dead.
+    /// Counts refresh passes so a stale answer cannot outrank a newer one:
+    /// a pass's roster lands only when no newer pass has landed one (an
+    /// older roster written after a newer would bring an archived row back
+    /// from the dead, but one written where a newer pass only failed still
+    /// beats an error over nothing), and only the newest pass may claim
+    /// failure, since an old outage says nothing about the request still
+    /// running.
     @State private var refreshPass = 0
+    /// The newest pass whose roster actually landed.
+    @State private var landedPass = 0
     /// Sessions whose archive act is still in flight. The row leaves at the
     /// press, so every roster write filters these ids: a refresh whose roster
     /// was read before the archive landed would otherwise bring the row back.
@@ -505,7 +511,8 @@ struct SessionsView: View {
             let fetched = try await session.authorized { token in
                 try await rosterClient.observe(bearerToken: token)
             }
-            guard pass == refreshPass else { return }
+            guard pass > landedPass else { return }
+            landedPass = pass
             // Animated so a row an act just removed slides out the way a
             // deleted Mail row does, instead of blinking.
             withAnimation { sessions = fetched.filter { !archivingIds.contains($0.id) } }
@@ -514,6 +521,7 @@ struct SessionsView: View {
         } catch is AccountSessionError {
             ()  // Signed out — the state change redraws automatically.
         } catch {
+            guard pass == refreshPass else { return }
             fetchError = error.localizedDescription
         }
     }

--- a/apps/ios/Luke/SessionsView.swift
+++ b/apps/ios/Luke/SessionsView.swift
@@ -8,12 +8,14 @@ struct SessionsView: View {
     @Environment(ProductEventSender.self) private var events
 
     @State private var sessions: [RosterSession] = []
-    /// True until the first roster fetch answers, because the list's first
-    /// frame can paint before its `.task` begins the fetch, and that frame
-    /// must show the skeletons rather than claim "No active sessions" nothing
-    /// has checked yet. Only that first wait may show them: a later refresh
-    /// that finds the list already empty (the last chat just archived) must
-    /// not flash skeletons over an emptiness that is real.
+    /// True until a fetched roster has actually landed, so every empty frame
+    /// before one — the first paint racing its `.task`, the first request in
+    /// flight, and a retry running after a failed first load — shows the
+    /// skeletons rather than claim "No active sessions" nothing has
+    /// confirmed. Only that unknown may show them: a refresh that finds the
+    /// list already empty (the last chat just archived) must not flash
+    /// skeletons over an emptiness that is real, and a standing fetch error
+    /// still outranks them.
     @State private var awaitingFirstRoster = true
     @State private var fetchError: String?
     @State private var searchQuery = ""
@@ -147,7 +149,7 @@ struct SessionsView: View {
             by: sort
         )
         return List {
-            if awaitingFirstRoster && sessions.isEmpty {
+            if awaitingFirstRoster && sessions.isEmpty && fetchError == nil {
                 ForEach(0 ..< 3, id: \.self) { _ in
                     SkeletonRow()
                         .listRowBackground(Color.clear)
@@ -499,7 +501,6 @@ struct SessionsView: View {
         let pass = refreshPass
         fetchError = nil
         guard case .signedIn = session.state else { return }
-        defer { awaitingFirstRoster = false }
         do {
             let fetched = try await session.authorized { token in
                 try await rosterClient.observe(bearerToken: token)
@@ -508,6 +509,7 @@ struct SessionsView: View {
             // Animated so a row an act just removed slides out the way a
             // deleted Mail row does, instead of blinking.
             withAnimation { sessions = fetched.filter { !archivingIds.contains($0.id) } }
+            awaitingFirstRoster = false
             recordObservation(fetched)
         } catch is AccountSessionError {
             ()  // Signed out — the state change redraws automatically.

--- a/apps/ios/Luke/SessionsView.swift
+++ b/apps/ios/Luke/SessionsView.swift
@@ -31,6 +31,12 @@ struct SessionsView: View {
     /// overlapping a post-act refresh must not land its older roster after
     /// the newer one — an archived row would come back from the dead.
     @State private var refreshPass = 0
+    /// Sessions whose archive act is still in flight. The row leaves at the
+    /// press, so every roster write filters these ids: a refresh whose roster
+    /// was read before the archive landed would otherwise bring the row back.
+    /// Delivery lifts the hold after the post-act refresh; a refusal lifts it
+    /// and refreshes, restoring the row beside the alert saying why.
+    @State private var archivingIds: Set<String> = []
 
     /// Which advertised rename a menu press opened: the session itself, or
     /// the workspace it runs in. One alert serves both; the flag picks the
@@ -384,6 +390,17 @@ struct SessionsView: View {
     }
 
     private func runControl(_ s: RosterSession, _ control: RosterSessionControl) {
+        // An archive's whole visible outcome is the row leaving, so the leave
+        // happens at the press — the row slides out and the screen it opened
+        // pops — with the act following behind rather than the press waiting
+        // on two round trips.
+        if control.kind == .archive {
+            archivingIds.insert(s.id)
+            if openedSession?.id == s.id {
+                openedSession = nil
+            }
+            withAnimation { sessions.removeAll { $0.id == s.id } }
+        }
         Task {
             let delivered = await performAct(on: s, counting: .controlRun) { token in
                 try await actClient.executeControl(
@@ -393,8 +410,11 @@ struct SessionsView: View {
                     controlId: control.id
                 )
             }
-            if delivered, control.kind == .archive, openedSession?.id == s.id {
-                openedSession = nil
+            if control.kind == .archive {
+                archivingIds.remove(s.id)
+                if !delivered {
+                    await refreshSessions()
+                }
             }
         }
     }
@@ -463,6 +483,8 @@ struct SessionsView: View {
     }
 
     private func refreshSessions() async {
+        refreshPass += 1
+        let pass = refreshPass
         isLoading = true
         fetchError = nil
         defer { isLoading = false }
@@ -471,9 +493,10 @@ struct SessionsView: View {
             let fetched = try await session.authorized { token in
                 try await rosterClient.observe(bearerToken: token)
             }
-            // Animated so a row an act just removed — an archive above all —
-            // slides out the way a deleted Mail row does, instead of blinking.
-            withAnimation { sessions = fetched }
+            guard pass == refreshPass else { return }
+            // Animated so a row an act just removed slides out the way a
+            // deleted Mail row does, instead of blinking.
+            withAnimation { sessions = fetched.filter { !archivingIds.contains($0.id) } }
             recordObservation(fetched)
         } catch is AccountSessionError {
             ()  // Signed out — the state change redraws automatically.


### PR DESCRIPTION
## What

Archiving a chat on iOS — from the roster list's swipe or context menu, or from the session detail screen's menu — now takes effect immediately: the row slides out at the press, the detail screen pops back to the roster at the press, and the archive act runs behind rather than the press waiting on two round trips (the act, then the refresh) before anything moved.

## How

The standard optimistic shape, with the resurrection race closed:

- **Optimistic removal.** `runControl` handles `.archive` specially: it removes the row from `sessions` with the same slide-out animation, pops `openedSession` if the archived chat's screen is open, and only then runs the act.
- **In-flight hold.** A new `archivingIds` set holds each session id while its archive is in flight, and every roster write filters those ids — so a refresh whose roster was read before the archive landed (a pull-to-refresh already in flight, or the post-act refresh against an eventually-consistent provider) cannot bring the row back from the dead. Delivery lifts the hold after the post-act refresh; a refusal lifts it and refreshes, restoring the row beside the existing "Not Delivered" alert with the server's own reason.
- **The refreshPass guard, now real.** `refreshPass` was declared with a comment promising that only the newest refresh pass may write, but nothing read it. `refreshSessions` now snapshots the pass at entry and drops its write if a newer pass has started, which is exactly the stale-roster race the comment described.

Nothing about the act itself changed: it still travels through the same `performAct` runner, is still an advertised control from the session's latest observation, and a refusal still surfaces the server's reason.

## Validation

- `./scripts/check.sh` passes (exit 0).
- CI does not build the iOS app and this Linux workspace has no Xcode, so the change was parse-checked with a Swift 6.0.3 toolchain (`swiftc -parse`, clean) and reviewed by hand; the edits use only symbols already present in the file. No simulator run was possible here, so no screen capture was taken — the flows to spot-check on a device are: swipe-archive from the roster, archive from the row's context menu, archive from the detail screen's menu (should pop immediately), and an archive refused by the server (row returns with the alert).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/e945a477-574e-4a09-ac59-45159ae89717)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/33798660161/artifacts/9910315711) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/33798660161)

- Commit: `47f0aae3fcddc84d1e8b954f0b7d1173c55e4e5a`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
