### PR TITLE
fix(ios): fill the voice screen's talk button with its tint

### DIFF
--- a/apps/ios/Luke/VoiceView.swift
+++ b/apps/ios/Luke/VoiceView.swift
@@ -344,7 +344,7 @@ struct VoiceView: View {
             || isPressing
         if #available(iOS 26.0, *) {
             Button(action: {}) { talkButtonLabel }
-                .buttonStyle(.glass)
+                .buttonStyle(.glassProminent)
                 .buttonBorderShape(.circle)
                 .tint(talkButtonColor)
                 .simultaneousGesture(talkGesture)


### PR DESCRIPTION
## Summary

- The voice screen's talk button used `.glass` on iOS 26, which only washes the tint over the ground beneath it. After #671 let the screen follow the system appearance, light mode showed the always-white microphone glyph on a near-white disc.
- It now uses `.glassProminent`, so the tint is the button's own fill: the same filled accent circle the session screen's send button draws, and what the pre-iOS 26 fallback already drew as an opaque circle. The white glyph is correct on that fill in both appearances.
- Everything else on the screen was audited: ground, status text, placeholder, error line, and gear tint all come from the appearance-resolved palette, and the transcript already reuses the session screen's `AgentMessageBubble` and `DeveloperMessageBubble` with matching spacing.

## Test plan

- [ ] Build `apps/ios/Luke.xcodeproj` (scheme Luke) on an iOS 26 simulator. A local build was attempted but could not finish because the Mac's disk was out of space.
- [ ] Open the voice screen in light mode and confirm the microphone button is a filled accent circle with a legible white glyph, in idle, listening, thinking, and speaking states.
- [ ] Repeat in dark mode.

No visual evidence attached; no physical-notch check applies to iOS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/d4f17bd4-28bd-4d88-8199-1cbdb1239433)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/33796015778/artifacts/9909329947) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/33796015778)

- Commit: `7d6602f98400bdc39b785de9455806ce29a0a81e`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
