### PR TITLE
feat(providers): watch the observation hook spool for events

### DIFF
--- a/packages/providers/src/index.ts
+++ b/packages/providers/src/index.ts
@@ -23,6 +23,14 @@ export {
   textFromRow,
 } from "./shared/local-sqlite.js";
 export {
+  type ObservationSpoolWatcher,
+  type ObservationSpoolWatcherOptions,
+  type ObservedSpoolEvent,
+  type SpoolWatch,
+  type SpoolWatchHandle,
+  watchObservationSpool,
+} from "./shared/spool-watcher.js";
+export {
   type WorkspaceHostEnrichment,
   type WorkspaceHostRegistration,
   type WorkspaceHostRegistrationOptions,

--- a/packages/providers/src/shared/spool-watcher.test.ts
+++ b/packages/providers/src/shared/spool-watcher.test.ts
@@ -1,0 +1,352 @@
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test, { type TestContext } from "node:test";
+import { HOOK_EVENT } from "./hook-events.js";
+import {
+  type ObservedSpoolEvent,
+  type SpoolWatch,
+  type SpoolWatchHandle,
+  watchObservationSpool,
+} from "./spool-watcher.js";
+
+type SpoolEvent = (typeof HOOK_EVENT)[keyof typeof HOOK_EVENT];
+
+const EVENTS: readonly SpoolEvent[] = Object.values(HOOK_EVENT);
+const DEBOUNCE_MS = 500;
+const REARM_INTERVAL_MS = 5000;
+
+type Timer = ReturnType<typeof setTimeout>;
+
+interface FakeClock {
+  schedule: (callback: () => void, delayMs: number) => Timer;
+  cancel: (timer: Timer) => void;
+  advance: (ms: number) => Promise<void>;
+  pending: () => number[];
+}
+
+function fakeClock(): FakeClock {
+  let nowMs = 0;
+  let nextId = 1;
+  const timers = new Map<Timer, { dueMs: number; callback: () => void }>();
+  return {
+    schedule: (callback, delayMs) => {
+      // SAFETY: the watcher only hands the timer back to `cancel`, so any
+      // distinct value serves as its handle.
+      const timer = nextId++ as unknown as Timer;
+      timers.set(timer, { dueMs: nowMs + delayMs, callback });
+      return timer;
+    },
+    cancel: (timer) => {
+      timers.delete(timer);
+    },
+    advance: async (ms) => {
+      const untilMs = nowMs + ms;
+      for (;;) {
+        const due = [...timers.entries()]
+          .filter(([, entry]) => entry.dueMs <= untilMs)
+          .sort(([, a], [, b]) => a.dueMs - b.dueMs)[0];
+        if (!due) break;
+        const [timer, entry] = due;
+        timers.delete(timer);
+        nowMs = entry.dueMs;
+        entry.callback();
+        await settle();
+      }
+      nowMs = untilMs;
+    },
+    pending: () => [...timers.values()].map((entry) => entry.dueMs - nowMs),
+  };
+}
+
+/** Gives the reads a fired timer started a chance to finish before asserting. */
+async function settle(): Promise<void> {
+  for (let i = 0; i < 20; i += 1) await new Promise<void>((resolve) => setImmediate(resolve));
+}
+
+async function waitFor(condition: () => boolean): Promise<void> {
+  const deadline = Date.now() + 5000;
+  while (!condition()) {
+    if (Date.now() > deadline) assert.fail("condition never held");
+    await new Promise<void>((resolve) => setTimeout(resolve, 5));
+  }
+}
+
+interface FakeWatcher {
+  watch: SpoolWatch;
+  directories: string[];
+  emit: (eventType: string, fileName: string | null) => void;
+  fail: (error: Error) => void;
+  closedCount: () => number;
+  /** Errors the next watch calls throw, consumed one per call. */
+  refuse: (...errors: Error[]) => void;
+}
+
+function fakeWatcher(): FakeWatcher {
+  const directories: string[] = [];
+  const refusals: Error[] = [];
+  let closed = 0;
+  let listener: ((eventType: string, fileName: string | null) => void) | undefined;
+  let errorListener: ((error: Error) => void) | undefined;
+  return {
+    directories,
+    watch: (directory, options, onChange) => {
+      assert.equal(options.persistent, false);
+      const refusal = refusals.shift();
+      if (refusal) throw refusal;
+      directories.push(directory);
+      listener = onChange;
+      const handle: SpoolWatchHandle = {
+        on: (_event, onError) => {
+          errorListener = onError;
+        },
+        close: () => {
+          closed += 1;
+          if (listener === onChange) listener = undefined;
+        },
+      };
+      return handle;
+    },
+    emit: (eventType, fileName) => listener?.(eventType, fileName),
+    fail: (error) => errorListener?.(error),
+    closedCount: () => closed,
+    refuse: (...errors) => {
+      refusals.push(...errors);
+    },
+  };
+}
+
+function missingDirectoryError(): Error {
+  const error: NodeJS.ErrnoException = new Error("ENOENT: no such file or directory, watch");
+  error.code = "ENOENT";
+  return error;
+}
+
+async function temporarySpool(t: TestContext): Promise<string> {
+  const directory = await fs.mkdtemp(path.join(os.tmpdir(), "luke-spool-watcher-"));
+  t.after(async () => {
+    await fs.rm(directory, { recursive: true, force: true });
+  });
+  return directory;
+}
+
+async function writeSpoolFile(spoolDirectory: string, fileName: string, content: string) {
+  await fs.writeFile(path.join(spoolDirectory, fileName), content, "utf8");
+}
+
+function standWatcher(
+  t: TestContext,
+  spoolDirectory: string,
+  watcher: FakeWatcher,
+  clock: FakeClock,
+) {
+  const batches: (readonly ObservedSpoolEvent<SpoolEvent>[])[] = [];
+  const handle = watchObservationSpool({
+    spoolDirectory,
+    events: EVENTS,
+    onEvents: (events) => {
+      batches.push(events);
+    },
+    watch: watcher.watch,
+    schedule: clock.schedule,
+    cancel: clock.cancel,
+  });
+  t.after(() => handle.close());
+  return { handle, batches };
+}
+
+test("one debounce window reports every readable spool file it saw as one batch", async (t) => {
+  const spoolDirectory = await temporarySpool(t);
+  const watcher = fakeWatcher();
+  const clock = fakeClock();
+  const { batches } = standWatcher(t, spoolDirectory, watcher, clock);
+  assert.deepEqual(watcher.directories, [spoolDirectory]);
+
+  await writeSpoolFile(spoolDirectory, "session-a.json", '{"event":"stop"}');
+  await writeSpoolFile(spoolDirectory, "session-b.json", '{"event":"prompt"}');
+  await writeSpoolFile(spoolDirectory, "foreign.json", '{"event":"something-else"}');
+  await writeSpoolFile(spoolDirectory, "broken.json", "not json");
+  await writeSpoolFile(spoolDirectory, ".session-c.123.tmp", '{"event":"stop"}');
+
+  watcher.emit("rename", "session-a.json");
+  watcher.emit("change", "session-a.json");
+  watcher.emit("rename", "session-b.json");
+  watcher.emit("rename", "foreign.json");
+  watcher.emit("rename", "broken.json");
+  watcher.emit("rename", "absent.json");
+  watcher.emit("rename", ".session-c.123.tmp");
+  watcher.emit("rename", "../escape.json");
+  watcher.emit("rename", null);
+
+  await clock.advance(DEBOUNCE_MS - 1);
+  assert.equal(batches.length, 0);
+  await clock.advance(1);
+  await waitFor(() => batches.length === 1);
+
+  const batch = batches[0] ?? [];
+  assert.deepEqual(
+    batch.map(({ providerSessionId, event }) => ({ providerSessionId, event })),
+    [
+      { providerSessionId: "session-a", event: HOOK_EVENT.STOP },
+      { providerSessionId: "session-b", event: HOOK_EVENT.PROMPT },
+    ],
+  );
+  const statsA = await fs.stat(path.join(spoolDirectory, "session-a.json"));
+  assert.equal(batch[0]?.atMs, statsA.mtimeMs);
+});
+
+test("the batch window opens at the first event and is not extended by later ones", async (t) => {
+  const spoolDirectory = await temporarySpool(t);
+  const watcher = fakeWatcher();
+  const clock = fakeClock();
+  const { batches } = standWatcher(t, spoolDirectory, watcher, clock);
+
+  await writeSpoolFile(spoolDirectory, "first.json", '{"event":"session-start"}');
+  await writeSpoolFile(spoolDirectory, "second.json", '{"event":"stop"}');
+  watcher.emit("rename", "first.json");
+  await clock.advance(DEBOUNCE_MS - 100);
+  watcher.emit("rename", "second.json");
+  await clock.advance(100);
+  await waitFor(() => batches.length === 1);
+  assert.deepEqual(
+    batches.map((batch) => batch.map((event) => event.providerSessionId)),
+    [["first", "second"]],
+  );
+
+  watcher.emit("rename", "second.json");
+  await clock.advance(DEBOUNCE_MS);
+  await waitFor(() => batches.length === 2);
+  assert.deepEqual(
+    batches.map((batch) => batch.map((event) => event.providerSessionId)),
+    [["first", "second"], ["second"]],
+  );
+});
+
+test("a batch whose files all fail to read reports nothing", async (t) => {
+  const spoolDirectory = await temporarySpool(t);
+  const watcher = fakeWatcher();
+  const clock = fakeClock();
+  const { batches } = standWatcher(t, spoolDirectory, watcher, clock);
+
+  watcher.emit("rename", "gone.json");
+  await clock.advance(DEBOUNCE_MS);
+  assert.equal(batches.length, 0);
+});
+
+test("a spool directory that does not exist yet is watched once it appears", async (t) => {
+  const spoolDirectory = path.join(await temporarySpool(t), "events");
+  const watcher = fakeWatcher();
+  watcher.refuse(missingDirectoryError(), missingDirectoryError());
+  const clock = fakeClock();
+  const { batches } = standWatcher(t, spoolDirectory, watcher, clock);
+  assert.deepEqual(watcher.directories, []);
+  assert.deepEqual(clock.pending(), [REARM_INTERVAL_MS]);
+
+  await clock.advance(REARM_INTERVAL_MS);
+  assert.deepEqual(watcher.directories, []);
+  assert.deepEqual(clock.pending(), [REARM_INTERVAL_MS]);
+
+  await fs.mkdir(spoolDirectory);
+  await clock.advance(REARM_INTERVAL_MS);
+  assert.deepEqual(watcher.directories, [spoolDirectory]);
+  assert.deepEqual(clock.pending(), []);
+
+  await writeSpoolFile(spoolDirectory, "late.json", '{"event":"stop"}');
+  watcher.emit("rename", "late.json");
+  await clock.advance(DEBOUNCE_MS);
+  await waitFor(() => batches.length === 1);
+  assert.deepEqual(
+    batches.map((batch) => batch.map((event) => event.providerSessionId)),
+    [["late"]],
+  );
+});
+
+test("a watch that fails is closed and stood up again after the rearm interval", async (t) => {
+  const spoolDirectory = await temporarySpool(t);
+  const watcher = fakeWatcher();
+  const clock = fakeClock();
+  const { batches } = standWatcher(t, spoolDirectory, watcher, clock);
+
+  watcher.fail(new Error("watch failed"));
+  assert.equal(watcher.closedCount(), 1);
+  assert.deepEqual(clock.pending(), [REARM_INTERVAL_MS]);
+  watcher.fail(new Error("watch failed again"));
+  assert.equal(watcher.closedCount(), 1);
+  assert.deepEqual(clock.pending(), [REARM_INTERVAL_MS]);
+
+  await clock.advance(REARM_INTERVAL_MS);
+  assert.deepEqual(watcher.directories, [spoolDirectory, spoolDirectory]);
+
+  await writeSpoolFile(spoolDirectory, "after.json", '{"event":"notification"}');
+  watcher.emit("rename", "after.json");
+  await clock.advance(DEBOUNCE_MS);
+  await waitFor(() => batches.length === 1);
+  assert.deepEqual(
+    batches.map((batch) => batch.map((event) => event.event)),
+    [[HOOK_EVENT.NOTIFICATION]],
+  );
+});
+
+test("closing stops the watch, drops pending ids, and cancels the rearm", async (t) => {
+  const spoolDirectory = await temporarySpool(t);
+  const watcher = fakeWatcher();
+  const clock = fakeClock();
+  const { handle, batches } = standWatcher(t, spoolDirectory, watcher, clock);
+
+  await writeSpoolFile(spoolDirectory, "pending.json", '{"event":"stop"}');
+  watcher.emit("rename", "pending.json");
+  assert.deepEqual(clock.pending(), [DEBOUNCE_MS]);
+  handle.close();
+  assert.equal(watcher.closedCount(), 1);
+  assert.deepEqual(clock.pending(), []);
+
+  watcher.emit("rename", "pending.json");
+  await clock.advance(DEBOUNCE_MS + REARM_INTERVAL_MS);
+  assert.equal(batches.length, 0);
+  assert.deepEqual(watcher.directories, [spoolDirectory]);
+  handle.close();
+  assert.equal(watcher.closedCount(), 1);
+});
+
+test("closing while a directory is still awaited stops the retries", async (t) => {
+  const spoolDirectory = path.join(await temporarySpool(t), "events");
+  const watcher = fakeWatcher();
+  watcher.refuse(missingDirectoryError());
+  const clock = fakeClock();
+  const { handle } = standWatcher(t, spoolDirectory, watcher, clock);
+  assert.deepEqual(clock.pending(), [REARM_INTERVAL_MS]);
+  handle.close();
+  assert.deepEqual(clock.pending(), []);
+  await fs.mkdir(spoolDirectory);
+  await clock.advance(REARM_INTERVAL_MS);
+  assert.deepEqual(watcher.directories, []);
+});
+
+test("a batch read after close is not reported", async (t) => {
+  const spoolDirectory = await temporarySpool(t);
+  const watcher = fakeWatcher();
+  const clock = fakeClock();
+  let closeDuringRead: () => void = () => undefined;
+  const batches: (readonly ObservedSpoolEvent<SpoolEvent>[])[] = [];
+  const handle = watchObservationSpool({
+    spoolDirectory,
+    events: EVENTS,
+    onEvents: (events) => {
+      batches.push(events);
+    },
+    watch: watcher.watch,
+    schedule: (callback, delayMs) =>
+      clock.schedule(() => {
+        callback();
+        closeDuringRead();
+      }, delayMs),
+    cancel: clock.cancel,
+  });
+  closeDuringRead = () => handle.close();
+
+  await writeSpoolFile(spoolDirectory, "racing.json", '{"event":"stop"}');
+  watcher.emit("rename", "racing.json");
+  await clock.advance(DEBOUNCE_MS);
+  assert.equal(batches.length, 0);
+});

--- a/packages/providers/src/shared/spool-watcher.ts
+++ b/packages/providers/src/shared/spool-watcher.ts
@@ -1,0 +1,208 @@
+import fs from "node:fs";
+import { type ObservedHookEvent, readObservationHookEvent } from "./hook-merge.js";
+
+/**
+ * Watches an observation hook spool so a hook event can wake something the
+ * moment it lands, rather than at the next observation pass. The hook writes
+ * `<session id>.json` by rename, so a directory watch sees every event as a
+ * file name; the file itself is read back through the same bounded reader the
+ * adapters use, and anything it declines to read is dropped here too. The
+ * watcher only sharpens timing: nothing it reports is state the adapters do
+ * not already read from the spool on their own pass, and a machine where it
+ * cannot stand observes exactly as before.
+ */
+
+/**
+ * The spool file names this reader accepts. A session id becomes the spool
+ * file's name, so a name outside this shape was not written by the hook — the
+ * hook's own temporary file, dotted and suffixed, falls outside it too.
+ */
+const SPOOL_FILE_NAME_PATTERN = /^([A-Za-z0-9_-]{1,128})\.json$/;
+
+/**
+ * How long ids collect before one read reports them together. A turn boundary
+ * fires a couple of hooks in quick succession, and several sessions can turn
+ * over at once; one batch reads the spool once for all of them.
+ */
+const DEFAULT_DEBOUNCE_MS = 500;
+
+/**
+ * How often a watcher that could not stand tries again. The spool directory
+ * is created by hook installation and may not exist yet when the watch is
+ * asked for, and a watch can fail on its own later.
+ */
+const DEFAULT_REARM_INTERVAL_MS = 5000;
+
+type Timer = ReturnType<typeof setTimeout>;
+
+/** The narrow slice of `fs.watch` the watcher relies on, so a test can stand in. */
+export interface SpoolWatchHandle {
+  on(event: "error", listener: (error: Error) => void): void;
+  close(): void;
+}
+
+/**
+ * The listener's file name is a string or nothing: `fs.watch` hands back a
+ * `Buffer` only under the buffer encoding, which this watcher never asks for.
+ */
+export type SpoolWatch = (
+  directory: string,
+  options: { persistent: false },
+  listener: (eventType: string, fileName: string | null) => void,
+) => SpoolWatchHandle;
+
+/** One hook event as the spool reported it, named by the session it belongs to. */
+export interface ObservedSpoolEvent<Event extends string> extends ObservedHookEvent<Event> {
+  providerSessionId: string;
+}
+
+export interface ObservationSpoolWatcherOptions<Event extends string> {
+  spoolDirectory: string;
+  /** The tokens the hook may write; a file holding anything else is dropped. */
+  events: readonly Event[];
+  onEvents: (events: readonly ObservedSpoolEvent<Event>[]) => void;
+  debounceMs?: number;
+  rearmIntervalMs?: number;
+  watch?: SpoolWatch;
+  schedule?: (callback: () => void, delayMs: number) => Timer;
+  cancel?: (timer: Timer) => void;
+}
+
+export interface ObservationSpoolWatcher {
+  close(): void;
+}
+
+function spoolSessionId(fileName: string | null): string | undefined {
+  if (fileName === null) return undefined;
+  return SPOOL_FILE_NAME_PATTERN.exec(fileName)?.[1];
+}
+
+class SpoolWatcher<Event extends string> implements ObservationSpoolWatcher {
+  readonly #spoolDirectory: string;
+  readonly #events: readonly Event[];
+  readonly #onEvents: (events: readonly ObservedSpoolEvent<Event>[]) => void;
+  readonly #debounceMs: number;
+  readonly #rearmIntervalMs: number;
+  readonly #watch: SpoolWatch;
+  readonly #schedule: (callback: () => void, delayMs: number) => Timer;
+  readonly #cancel: (timer: Timer) => void;
+
+  readonly #pendingIds = new Set<string>();
+  #debounceTimer: Timer | undefined;
+  #rearmTimer: Timer | undefined;
+  #handle: SpoolWatchHandle | undefined;
+  #reads: Promise<void> = Promise.resolve();
+  #closed = false;
+
+  constructor(options: ObservationSpoolWatcherOptions<Event>) {
+    this.#spoolDirectory = options.spoolDirectory;
+    this.#events = options.events;
+    this.#onEvents = options.onEvents;
+    this.#debounceMs = options.debounceMs ?? DEFAULT_DEBOUNCE_MS;
+    this.#rearmIntervalMs = options.rearmIntervalMs ?? DEFAULT_REARM_INTERVAL_MS;
+    this.#watch = options.watch ?? fs.watch;
+    this.#schedule = options.schedule ?? setTimeout;
+    this.#cancel = options.cancel ?? clearTimeout;
+    this.#arm();
+  }
+
+  close(): void {
+    this.#closed = true;
+    if (this.#debounceTimer !== undefined) this.#cancel(this.#debounceTimer);
+    this.#debounceTimer = undefined;
+    if (this.#rearmTimer !== undefined) this.#cancel(this.#rearmTimer);
+    this.#rearmTimer = undefined;
+    this.#pendingIds.clear();
+    this.#dropHandle();
+  }
+
+  /**
+   * Any failure to stand — a spool directory not created yet, a watch the
+   * platform refused — is answered the same way: try again later. The watch
+   * is a sharpening, so no failure of it is worth surfacing past the spool
+   * read the adapters make anyway.
+   */
+  #arm(): void {
+    if (this.#closed) return;
+    let handle: SpoolWatchHandle;
+    try {
+      handle = this.#watch(this.#spoolDirectory, { persistent: false }, (_eventType, fileName) => {
+        if (handle !== this.#handle) return;
+        this.#collect(fileName);
+      });
+    } catch {
+      this.#scheduleRearm();
+      return;
+    }
+    this.#handle = handle;
+    handle.on("error", () => {
+      if (handle !== this.#handle) return;
+      this.#dropHandle();
+      this.#scheduleRearm();
+    });
+  }
+
+  #dropHandle(): void {
+    const handle = this.#handle;
+    this.#handle = undefined;
+    handle?.close();
+  }
+
+  #scheduleRearm(): void {
+    if (this.#closed || this.#rearmTimer !== undefined) return;
+    this.#rearmTimer = this.#schedule(() => {
+      this.#rearmTimer = undefined;
+      this.#arm();
+    }, this.#rearmIntervalMs);
+  }
+
+  /**
+   * The batch window opens at the first id and is not extended by later ones,
+   * so a spool that never falls quiet still reports on the beat.
+   */
+  #collect(fileName: string | null): void {
+    if (this.#closed) return;
+    const providerSessionId = spoolSessionId(fileName);
+    if (providerSessionId === undefined) return;
+    this.#pendingIds.add(providerSessionId);
+    if (this.#debounceTimer !== undefined) return;
+    this.#debounceTimer = this.#schedule(() => {
+      this.#debounceTimer = undefined;
+      const ids = [...this.#pendingIds];
+      this.#pendingIds.clear();
+      this.#reads = this.#reads.then(() => this.#report(ids));
+    }, this.#debounceMs);
+  }
+
+  /**
+   * Reads run one batch after another so two batches can never reach the
+   * listener out of order. A file that cannot be read — gone again already,
+   * or unreadable for any reason — is dropped: the spool is a refinement of
+   * state the adapters still read for themselves.
+   */
+  async #report(ids: readonly string[]): Promise<void> {
+    const observed: ObservedSpoolEvent<Event>[] = [];
+    for (const providerSessionId of ids) {
+      const event = await readObservationHookEvent(
+        this.#events,
+        this.#spoolDirectory,
+        providerSessionId,
+      ).catch(() => undefined);
+      if (event) observed.push({ providerSessionId, ...event });
+    }
+    if (this.#closed || observed.length === 0) return;
+    this.#onEvents(observed);
+  }
+}
+
+/**
+ * Stands a watch on one provider's spool and reports each batch of hook
+ * events it sees, until closed. A directory that does not exist yet, or a
+ * watch that fails later, is retried on a fixed interval rather than
+ * reported: the watcher is additive to the adapters' own spool reads.
+ */
+export function watchObservationSpool<Event extends string>(
+  options: ObservationSpoolWatcherOptions<Event>,
+): ObservationSpoolWatcher {
+  return new SpoolWatcher(options);
+}


### PR DESCRIPTION
## Summary

Adds `watchObservationSpool` in `packages/providers/src/shared/spool-watcher.ts`, exported from the providers barrel. It stands an `fs.watch` (non-persistent) on one provider's observation hook spool and reports each batch of hook events as it lands, so a hook can wake something the moment a session turns over rather than at the next observation pass.

- Ids are collected from `<id>.json` rename/change events, validated against `/^[A-Za-z0-9_-]{1,128}\.json$/` (the hook's own dotted temporary file falls outside it), and batched in a fixed 500ms window that opens at the first id and is not extended.
- Each id is read back through the existing `readObservationHookEvent`, so unknown tokens, malformed files, and files already gone are dropped here exactly as the adapters drop them. Batches are reported in order.
- A spool directory that does not exist yet (hook installation creates it), or a watch that errors later, closes the watch and retries every 5s. Closing cancels the debounce and rearm timers and closes the watch.
- `watch`, `schedule`, and `cancel` are injectable; tests use a fake watch and fake clock over a real temp directory.

Additive only. Nothing in `apps/desktop` consumes it yet; the brain wiring section owns that. Adapters and hook installation are untouched.

## Verification

`./scripts/check.sh` passes (exit 0). No UI change, so no `verify.sh` run and no physical-notch check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/33806949065/artifacts/9913425156) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/33806949065)

- Commit: `11296fa06c6b7757fdca1884ff34277c737ef085`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
