### PR TITLE
feat(settings): replace Pause announcements with Announce when sessions need you

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -433,10 +433,10 @@ Trust constraints:
   as the hold stands, a clock read against observed intervals, never
   anything a model wrote, and holding is the whole power: a calendar entry
   can delay an announcement and put a drawn face to sleep, never create,
-  reword, or act on one. The developer's own Pause announcements switch
-  raises the same hold by hand, over the same set of speech and nothing
-  wider: replies in a conversation they open still speak, and the switch
-  reaches no write path. This Mac's own Calendar is read under the same rule
+  reword, or act on one. The developer's own Announce when sessions need you
+  switch, on by default, raises the same hold by hand when switched off, over
+  the same set of speech and nothing wider: replies in a conversation they
+  open still speak, and the switch reaches no write path. This Mac's own Calendar is read under the same rule
   with no credential at all, through a native helper behind macOS's own
   consent dialog. The dialog is the connection, and nothing is stored but
   the fact of it and the user's calendar choices. EventKit publishes no

--- a/apps/desktop/src/main/desktop-app.ts
+++ b/apps/desktop/src/main/desktop-app.ts
@@ -2337,11 +2337,12 @@ function openCreatedWorkspaces(sessions: readonly Session[]): void {
 }
 
 /**
- * Whether announcements should wait right now: the developer's pause switch
- * is on, or a meeting on the connected calendar covers this instant under the
- * meeting quiet. The pause is read first and the meetings before the quiet
- * setting, so the common case — no pause, no calendar — costs one read; the
- * store's answers come from its cached file either way, never the keychain.
+ * Whether announcements should wait right now: the developer's announce
+ * switch is off, or a meeting on the connected calendar covers this instant
+ * under the meeting quiet. The switch is read first and the meetings before
+ * the quiet setting, so the common case — announcing, no calendar — costs one
+ * read; the store's answers come from its cached file either way, never the
+ * keychain.
  *
  * Consulting it is also what keeps every window honest: the answer is
  * reconciled with the broadcast state on the way out, so speech can never be
@@ -2350,7 +2351,7 @@ function openCreatedWorkspaces(sessions: readonly Session[]): void {
  * end would speak over a face still drawn asleep until the next tick.
  */
 async function announcementsQuietNow(now: number): Promise<boolean> {
-  const paused = await settingsStore.get(APP_SETTING_SCHEMA.pauseAnnouncements.field);
+  const paused = !(await settingsStore.get(APP_SETTING_SCHEMA.announceSessions.field));
   const inMeeting =
     !paused &&
     calendarMeetings !== undefined &&

--- a/apps/desktop/src/main/settings-store.test.ts
+++ b/apps/desktop/src/main/settings-store.test.ts
@@ -802,47 +802,47 @@ test("a corrupt meeting quiet value reads as the default rather than as off", as
   assert.equal(appSettingsView(await storeIn(directory).snapshot()).quietDuringMeetings, true);
 });
 
-test("announcements speak until paused by hand, and the pause survives a reopen", async (t) => {
+test("announcements speak until switched off by hand, and the quiet survives a reopen", async (t) => {
   const directory = await temporaryDirectory(t);
-  // The pause is read on every announcement pass, so like the meeting quiet
+  // The switch is read on every announcement pass, so like the meeting quiet
   // it must answer from the file alone and never reach the Keychain.
   const cipher = countingCipher();
   const store = storeIn(directory, { cipher });
 
-  assert.equal(appSettingsView(await store.snapshot()).pauseAnnouncements, false);
-  assert.equal(await store.get(APP_SETTING_SCHEMA.pauseAnnouncements.field), false);
-  const paused = await store.set(APP_SETTING_SCHEMA.pauseAnnouncements.field, true);
+  assert.equal(appSettingsView(await store.snapshot()).announceSessions, true);
+  assert.equal(await store.get(APP_SETTING_SCHEMA.announceSessions.field), true);
+  const quiet = await store.set(APP_SETTING_SCHEMA.announceSessions.field, false);
 
-  assert.equal(appSettingsView(paused.settings).pauseAnnouncements, true);
-  assert.equal(await storeIn(directory).get(APP_SETTING_SCHEMA.pauseAnnouncements.field), true);
-  assert.equal(appSettingsView(await storeIn(directory).snapshot()).pauseAnnouncements, true);
+  assert.equal(appSettingsView(quiet.settings).announceSessions, false);
+  assert.equal(await storeIn(directory).get(APP_SETTING_SCHEMA.announceSessions.field), false);
+  assert.equal(appSettingsView(await storeIn(directory).snapshot()).announceSessions, false);
   assert.equal(cipher.calls.isAvailable, 0);
   assert.equal(cipher.calls.encrypt, 0);
 });
 
-test("switching the pause never disturbs a stored key", async (t) => {
+test("switching announcements never disturbs a stored key", async (t) => {
   const directory = await temporaryDirectory(t);
   const store = storeIn(directory);
   await store.setApiKey(CONDUCTOR, TEST_API_KEY);
 
-  await store.set(APP_SETTING_SCHEMA.pauseAnnouncements.field, true);
-  const off = await store.set(APP_SETTING_SCHEMA.pauseAnnouncements.field, false);
+  await store.set(APP_SETTING_SCHEMA.announceSessions.field, false);
+  const on = await store.set(APP_SETTING_SCHEMA.announceSessions.field, true);
 
-  assert.equal(appSettingsView(off.settings).pauseAnnouncements, false);
+  assert.equal(appSettingsView(on.settings).announceSessions, true);
   assert.equal(await storeIn(directory).readApiKey(CONDUCTOR), TEST_API_KEY);
 });
 
 // SAFETY: Fixture value matches the narrowed runtime shape this test exercises.
-test("a corrupt pause value reads as the default rather than as paused", async (t) => {
+test("a corrupt announce value reads as the default rather than as silence", async (t) => {
   const directory = await temporaryDirectory(t);
-  // This one's default is off: nonsense must not silence Luke.
+  // This one's default is on: nonsense must not silence Luke.
   await fs.writeFile(
     path.join(directory, SETTINGS_FILE_NAME),
-    JSON.stringify({ version: 2, apiKeys: {}, pauseAnnouncements: "yes" }),
+    JSON.stringify({ version: 2, apiKeys: {}, announceSessions: "yes" }),
     "utf8",
   );
 
-  assert.equal(appSettingsView(await storeIn(directory).snapshot()).pauseAnnouncements, false);
+  assert.equal(appSettingsView(await storeIn(directory).snapshot()).announceSessions, true);
 });
 
 test("keeps each provider's key, environment fallback, and reported source separate", async (t) => {

--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -444,7 +444,7 @@ export function App(): React.JSX.Element {
   const [outputAudio, setOutputAudio] = useState<OutputAudioState>();
   /** Each connected account's calendars, for the settings rows' checkboxes. */
   const [calendars, setCalendars] = useState<readonly ObservedAccountCalendars[]>([]);
-  /** Whether announcements are held — by the pause or a meeting — and the face sleeps on it. */
+  /** Whether announcements are held — the announce switch off or a meeting — and the face sleeps on it. */
   const [announcementsHeld, setAnnouncementsHeld] = useState(false);
   /** Whether the mandatory calendar step of onboarding still stands. */
   const [calendarOnboardingOwed, setCalendarOnboardingOwed] = useState(false);

--- a/apps/desktop/src/renderer/errand-queue.test.ts
+++ b/apps/desktop/src/renderer/errand-queue.test.ts
@@ -46,7 +46,7 @@ function settings(captions: boolean): AppSettingsView {
     voiceCaptions: captions,
     duckOtherMedia: true,
     quietDuringMeetings: true,
-    pauseAnnouncements: false,
+    announceSessions: true,
     calendarSignInAvailable: false,
     linearSignInAvailable: false,
     appleCalendarAvailable: false,

--- a/apps/desktop/src/renderer/luke-errand.test.ts
+++ b/apps/desktop/src/renderer/luke-errand.test.ts
@@ -48,7 +48,7 @@ function settings(): AppSettingsView {
     voiceCaptions: false,
     duckOtherMedia: true,
     quietDuringMeetings: true,
-    pauseAnnouncements: false,
+    announceSessions: true,
     calendarSignInAvailable: false,
     linearSignInAvailable: false,
     appleCalendarAvailable: false,

--- a/apps/desktop/src/renderer/luke-face-mood.ts
+++ b/apps/desktop/src/renderer/luke-face-mood.ts
@@ -16,7 +16,7 @@ export interface FaceContext {
   microphoneLive: boolean;
   /**
    * Whether announcements are held right now. A deterministic fact from the
-   * main process — the developer's own pause switch, or the clock against
+   * main process — the developer's own announce switch off, or the clock against
    * observed meeting intervals — never anything a model decided.
    */
   announcementsHeld: boolean;

--- a/apps/desktop/src/renderer/luke-guide.test.ts
+++ b/apps/desktop/src/renderer/luke-guide.test.ts
@@ -53,7 +53,7 @@ function settings(overrides: Partial<AppSettingsView> = {}): AppSettingsView {
       voiceCaptions: false,
       duckOtherMedia: true,
       quietDuringMeetings: true,
-      pauseAnnouncements: false,
+      announceSessions: true,
       calendarSignInAvailable: false,
       appleCalendarAvailable: false,
       linearSignInAvailable: false,
@@ -894,10 +894,10 @@ test("every adjustable setting is carried to the bridge call its row uses", asyn
   }
 
   assert.deepEqual(calls.sort(), [
+    "announceSessions:true",
     "duckOtherMedia:true",
     "formFactor:notch",
     "openAtLogin:true",
-    "pauseAnnouncements:true",
     "preferBuiltInMicrophone:true",
     "quietDuringMeetings:true",
     "showInDock:true",

--- a/apps/desktop/src/renderer/luke-guide.ts
+++ b/apps/desktop/src/renderer/luke-guide.ts
@@ -528,21 +528,23 @@ export function buildLukeGuide(input: LukeGuideInput): AppGuideSnapshot {
               `shortcut removed, in ${SHORTCUTS_PAGE}.`,
           },
           {
-            // A behavior rather than a setting: stated here so Luke neither
-            // denies announcing nor offers to turn it off.
+            // A behavior rather than a setting: stated here so Luke does not
+            // deny announcing; the switch that turns it off is the schema
+            // entry's to describe.
             label: "Announcements",
             detail:
               "Luke says it out loud when an observed session is holding for you, stops on " +
               "an error, or finishes — a hold is a question, a permission, or an approval, " +
               "not a turn that merely ended — naming the session and what it needs. No " +
-              "conversation needs to be open, the microphone stays off, and it is always on " +
-              "while voice is available. Luke waits five seconds for nearby updates and says " +
+              "conversation needs to be open, the microphone stays off, and it is on by " +
+              "default while voice is available. Luke waits five seconds for nearby updates and says " +
               "them together in one announcement. A session in a live voice conversation " +
               "with its own provider announces nothing until that conversation closes. " +
-              "Announcements can be paused by hand — the Pause announcements switch on the " +
-              "Voice page, or by asking Luke — and held ones are read out once the pause " +
-              "ends, the still-true ones only; conversations the developer opens still " +
-              "answer aloud while paused.",
+              "The Announce when sessions need you switch on the Voice page — on by " +
+              "default, and also flippable by asking Luke — turns them off: Luke sleeps " +
+              "while it is off, and held ones are read out once it is switched back on, " +
+              "the still-true ones only; conversations the developer opens still answer " +
+              "aloud while it is off.",
           },
           {
             // A behavior rather than a setting, for the announcements' own

--- a/apps/desktop/src/renderer/notch-wings.tsx
+++ b/apps/desktop/src/renderer/notch-wings.tsx
@@ -39,7 +39,7 @@ interface NotchWingsProps {
   hasAudioSignal: boolean;
   /** A pressed talk key still waiting for the call it asked to open. */
   voiceOpening: boolean;
-  /** Whether announcements are held, by the pause or a meeting — the face sleeps on it. */
+  /** Whether announcements are held, by the announce switch off or a meeting — the face sleeps on it. */
   announcementsHeld: boolean;
   /**
    * Whether the roster has been read at all yet. Until it has, the wing is

--- a/apps/desktop/src/renderer/settings-search.test.ts
+++ b/apps/desktop/src/renderer/settings-search.test.ts
@@ -36,7 +36,7 @@ function settings(overrides: Partial<AppSettingsView> = {}): AppSettingsView {
       duckOtherMedia: true,
       preferBuiltInMicrophone: true,
       quietDuringMeetings: true,
-      pauseAnnouncements: false,
+      announceSessions: true,
       calendarSignInAvailable: false,
       appleCalendarAvailable: false,
       linearSignInAvailable: false,
@@ -115,7 +115,10 @@ test("a row a page is not drawing is not offered", () => {
   // draws it.
   const bare = labels(settingsSearchEntries(searchInput({ voiceControlsDrawn: false })));
   assert.ok(!bare.includes("Captions"), "no voice controls until voice can run");
-  assert.ok(!bare.includes("Pause announcements"), "the pause rides the voice controls");
+  assert.ok(
+    !bare.includes("Announce when sessions need you"),
+    "the announce switch rides the voice controls",
+  );
   assert.ok(!bare.includes("Quiet during meetings"), "no quiet row without a calendar account");
   assert.ok(!bare.includes("Linear"), "no Linear row without its OAuth client");
   assert.ok(!bare.includes("Superset"), "no Superset row while it is not installed");

--- a/apps/desktop/src/renderer/settings-search.tsx
+++ b/apps/desktop/src/renderer/settings-search.tsx
@@ -197,7 +197,7 @@ const SETTING_ROW_DRAWN = {
   [APP_SETTING_ID.VOICE_CAPTIONS]: voiceControlRowDrawn,
   [APP_SETTING_ID.DUCK_OTHER_MEDIA]: voiceControlRowDrawn,
   [APP_SETTING_ID.PREFER_BUILT_IN_MICROPHONE]: voiceControlRowDrawn,
-  [APP_SETTING_ID.PAUSE_ANNOUNCEMENTS]: voiceControlRowDrawn,
+  [APP_SETTING_ID.ANNOUNCE_SESSIONS]: voiceControlRowDrawn,
   // The quiet rides the calendar block, and appears with its first
   // connection — a Google account, or this Mac's own Calendar.
   [APP_SETTING_ID.QUIET_DURING_MEETINGS]: (input) =>

--- a/apps/desktop/src/renderer/spoken-notices.ts
+++ b/apps/desktop/src/renderer/spoken-notices.ts
@@ -95,7 +95,7 @@ export interface SpokenNoticeAnnouncerOptions {
  * still standing in the panel.
  *
  * The announcement hold reaches it through {@link setHeld}: a hold beginning
- * — the developer's pause or a meeting's quiet — silences it at once, the
+ * — the announce switch turned off or a meeting's quiet — silences it at once, the
  * announcement mid-sentence on Luke's own call included, and holds it silent
  * until the hold ends.
  *
@@ -130,7 +130,7 @@ export class SpokenNoticeAnnouncer {
 
   /**
    * Follows the announcement hold the main process decided. A hold beginning
-   * — the pause switched on, the quiet switched on mid-meeting, or a meeting
+   * — announcements switched off, the quiet switched on mid-meeting, or a meeting
    * starting under it — is asked-for silence right now: the announcement
    * mid-sentence on Luke's own call is cut off and the call closed rather
    * than left lingering into the hold, and the backlog is dropped rather than

--- a/apps/desktop/src/renderer/use-voice-conversation.ts
+++ b/apps/desktop/src/renderer/use-voice-conversation.ts
@@ -483,8 +483,8 @@ export interface VoiceConversationOptions {
   voiceAvailable: boolean | undefined;
   outputSilent: boolean;
   /**
-   * Whether announcements are held — the developer's pause switch is on, or a
-   * meeting on the connected calendar covers now under the meeting quiet.
+   * Whether announcements are held — the developer's announce switch is off,
+   * or a meeting on the connected calendar covers now under the meeting quiet.
    * True silences the announcer at once, the announcement mid-sentence on
    * Luke's own call included.
    */

--- a/packages/guide/src/app-settings.ts
+++ b/packages/guide/src/app-settings.ts
@@ -12,7 +12,7 @@ export const APP_SETTING_ID = {
   DUCK_OTHER_MEDIA: "duck_other_media",
   PREFER_BUILT_IN_MICROPHONE: "prefer_built_in_microphone",
   QUIET_DURING_MEETINGS: "quiet_during_meetings",
-  PAUSE_ANNOUNCEMENTS: "pause_announcements",
+  ANNOUNCE_SESSIONS: "announce_sessions",
   SYNC_PROVIDER_KEYS: "sync_provider_keys",
   SHOW_IN_DOCK: "show_in_dock",
   OPEN_AT_LOGIN: "open_at_login",

--- a/packages/settings/src/schema.ts
+++ b/packages/settings/src/schema.ts
@@ -571,22 +571,22 @@ export const APP_SETTING_SCHEMA = {
     spokenValue: (value: string) => value === APP_TOGGLE_VALUE.ON,
     analytics: { id: APP_SETTING_ID.PREFER_BUILT_IN_MICROPHONE, value: toggleAnalytics },
   },
-  pauseAnnouncements: {
-    field: "pauseAnnouncements",
-    default: false,
-    guard: boolean(false),
+  announceSessions: {
+    field: "announceSessions",
+    default: true,
+    guard: boolean(true),
     settingsPage: SETTINGS_PAGE.VOICE,
     resetScope: SETTINGS_RESET_SCOPE.VOICE,
     guideEntry: settingGuideEntry(
-      "pauseAnnouncements",
-      [APP_SETTING_ID.PAUSE_ANNOUNCEMENTS],
+      "announceSessions",
+      [APP_SETTING_ID.ANNOUNCE_SESSIONS],
       (settings, defaultValue) => ({
-        id: APP_SETTING_ID.PAUSE_ANNOUNCEMENTS,
-        label: "Pause announcements",
+        id: APP_SETTING_ID.ANNOUNCE_SESSIONS,
+        label: "Announce when sessions need you",
         description:
-          "Whether spoken announcements — a session waiting, stopping on an error, or finishing, and Luke's other unprompted remarks — are held while this is on, then read out together, the still-true ones only, once it is switched off. Conversations you open still answer aloud. Luke's face sleeps for as long as the pause holds.",
+          "Whether announcements — a session waiting, stopping on an error, or finishing, and Luke's other unprompted remarks — are spoken as they happen. Switched off, Luke sleeps: announcements are held, then read out together, the still-true ones only, once it is switched back on. Conversations you open still answer aloud either way. Luke's face sleeps for as long as the switch is off.",
         kind: APP_SETTING_KIND.TOGGLE,
-        value: appToggleText(guideValue<boolean>(settings, "pauseAnnouncements")),
+        value: appToggleText(guideValue<boolean>(settings, "announceSessions")),
         defaultValue: appToggleText(defaultValue),
         adjustable: true,
         manual: VOICE_PAGE,
@@ -594,7 +594,7 @@ export const APP_SETTING_SCHEMA = {
     ),
     mainProcessSideEffect: SETTING_SIDE_EFFECT.ANNOUNCEMENT_HOLD,
     spokenValue: (value: string) => value === APP_TOGGLE_VALUE.ON,
-    analytics: { id: APP_SETTING_ID.PAUSE_ANNOUNCEMENTS, value: toggleAnalytics },
+    analytics: { id: APP_SETTING_ID.ANNOUNCE_SESSIONS, value: toggleAnalytics },
   },
   quietDuringMeetings: {
     field: "quietDuringMeetings",


### PR DESCRIPTION
## Summary

The Voice page's **Pause announcements** toggle becomes **Announce when sessions need you**, on by default. The toggle's sense inverts: on means announcements speak as they happen, and switching it off is what raises the hand-held hold — announcements wait, Luke's face sleeps beside the housing, and the still-true held ones are read out together once it is switched back on. Conversations you open still answer aloud either way.

- `APP_SETTING_SCHEMA`: `pauseAnnouncements` (default off) becomes `announceSessions` (default on) with the new label and description; the row, settings search, Luke's guide entry, and the spoken-change wiring all derive from the one entry.
- Setting id `pause_announcements` becomes `announce_sessions`; the analytics `setting_id` vocabulary derives from the same set.
- `announcementsQuietNow` in the main process reads the announce switch and treats off as the hand-raised hold; the `ANNOUNCEMENT_HOLD` side effect is unchanged.
- Guide fact, AGENTS.md calendar-hold passage, and the comments that named the pause switch now describe the announce switch's off state.
- No migration: no released build carried the old field.

## Testing

- `./scripts/check.sh` passes (843 desktop tests, 0 failures).
- `./scripts/verify.sh` not run: this change was made on a Linux cloud workspace, so the macOS visual pass (and physical-notch check) is outstanding. The Voice-page row renders generically from the schema entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/08259419-20e5-40e3-83b2-fa471d69a9d7)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/33819623853/artifacts/9917864403) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/33819623853)

- Commit: `542ccbc3d13ab0d6c73d9aa079c0168c5bc7966c`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
