### PR TITLE
feat(session): make the notice tracker's memory portable

### DIFF
--- a/packages/session/src/index.ts
+++ b/packages/session/src/index.ts
@@ -135,10 +135,14 @@ export {
   SessionNoticeHold,
 } from "./session-notice-hold.js";
 export {
+  type NoticedAtMemory,
   SESSION_NOTICE_STATUS,
   type SessionNotice,
+  type SessionNoticeMemory,
   type SessionNoticeStatus,
   SessionNoticeTracker,
+  sessionNoticeMemoryFromWire,
+  type TrackedSessionMemory,
 } from "./session-notices.js";
 export {
   InMemorySessionRegistry,

--- a/packages/session/src/session-notices.test.ts
+++ b/packages/session/src/session-notices.test.ts
@@ -10,6 +10,7 @@ import {
   SessionNoticeTracker,
   type SessionProvider,
   type SessionStatus,
+  sessionNoticeMemoryFromWire,
 } from "@sidecar/session";
 import { MAXIMUM_NOTICES_PER_PASS, SESSION_NOTICE_REPEAT_WINDOW_MS } from "./session-notices.js";
 
@@ -444,4 +445,144 @@ test("a burst is trimmed to the cap with the most urgent notices kept", () => {
     notices.slice(1).map((notice) => notice.providerSessionId),
     ids.slice(0, MAXIMUM_NOTICES_PER_PASS - 1),
   );
+});
+
+test("a fresh tracker's snapshot is empty, and a pass fills it with status alone", () => {
+  const tracker = new SessionNoticeTracker();
+  assert.deepEqual(tracker.snapshot(), []);
+
+  tracker.notices(
+    [session(claude, "a", SESSION_STATUS.WORKING), session(conductor, "b", SESSION_STATUS.WAITING)],
+    1_000,
+  );
+
+  assert.deepEqual(tracker.snapshot(), [
+    { providerId: "claude-code", providerSessionId: "a", status: "working", noticedAt: [] },
+    { providerId: "conductor", providerSessionId: "b", status: "waiting", noticedAt: [] },
+  ]);
+});
+
+test("a snapshot records when each notice was spoken, and nothing a session said", () => {
+  const tracker = new SessionNoticeTracker();
+  tracker.notices([session(claude, "a", SESSION_STATUS.WORKING)], 1_000);
+  tracker.notices(
+    [session(claude, "a", SESSION_STATUS.WAITING, { activity: "Edit file", error: "boom" })],
+    2_000,
+  );
+
+  assert.deepEqual(tracker.snapshot(), [
+    {
+      providerId: "claude-code",
+      providerSessionId: "a",
+      status: "waiting",
+      noticedAt: [{ status: "waiting", at: 2_000 }],
+    },
+  ]);
+});
+
+test("a restored tracker diffs against the memory rather than seeding afresh", () => {
+  const before = new SessionNoticeTracker();
+  before.notices([session(claude, "a", SESSION_STATUS.WORKING)], 1_000);
+
+  const after = SessionNoticeTracker.restore(before.snapshot());
+  const notices = after.notices([session(claude, "a", SESSION_STATUS.COMPLETE)], 2_000);
+
+  assert.equal(notices.length, 1);
+  assert.equal(notices[0]?.status, SESSION_NOTICE_STATUS.COMPLETE);
+  assert.equal(notices[0]?.previousStatus, SESSION_STATUS.WORKING);
+});
+
+test("a restored tracker never replays a status the memory already held", () => {
+  const before = new SessionNoticeTracker();
+  before.notices([session(claude, "a", SESSION_STATUS.WAITING)], 1_000);
+
+  const after = SessionNoticeTracker.restore(before.snapshot());
+  assert.deepEqual(after.notices([session(claude, "a", SESSION_STATUS.WAITING)], 2_000), []);
+});
+
+test("the repeat window survives a restore", () => {
+  const before = new SessionNoticeTracker();
+  before.notices([session(claude, "a", SESSION_STATUS.WORKING)], 1_000);
+  assert.equal(before.notices([session(claude, "a", SESSION_STATUS.ERROR)], 2_000).length, 1);
+
+  const after = SessionNoticeTracker.restore(before.snapshot());
+  const inside = 2_000 + SESSION_NOTICE_REPEAT_WINDOW_MS - 1;
+  after.notices([session(claude, "a", SESSION_STATUS.WORKING)], inside);
+  assert.deepEqual(after.notices([session(claude, "a", SESSION_STATUS.ERROR)], inside), []);
+
+  const outside = 2_000 + SESSION_NOTICE_REPEAT_WINDOW_MS;
+  after.notices([session(claude, "a", SESSION_STATUS.WORKING)], outside);
+  assert.equal(after.notices([session(claude, "a", SESSION_STATUS.ERROR)], outside).length, 1);
+});
+
+test("a memory round-trips through JSON and the wire reader unchanged", () => {
+  const tracker = new SessionNoticeTracker();
+  tracker.notices(
+    [session(claude, "a", SESSION_STATUS.WORKING), session(conductor, "a", SESSION_STATUS.WORKING)],
+    1_000,
+  );
+  tracker.notices(
+    [session(claude, "a", SESSION_STATUS.ERROR), session(conductor, "a", SESSION_STATUS.WAITING)],
+    2_000,
+  );
+
+  const memory = tracker.snapshot();
+  const restored = sessionNoticeMemoryFromWire(JSON.parse(JSON.stringify(memory)));
+  assert.deepEqual(restored, memory);
+  assert.deepEqual(SessionNoticeTracker.restore(restored).snapshot(), memory);
+});
+
+test("the wire reader drops what it cannot place and keeps the rest", () => {
+  const memory = sessionNoticeMemoryFromWire([
+    { providerId: "claude-code", providerSessionId: "a", status: "working", noticedAt: [] },
+    { providerId: "claude-code", providerSessionId: "b", status: "paused", noticedAt: [] },
+    { providerId: "claude-code", providerSessionId: 3, status: "working", noticedAt: [] },
+    { providerId: "", providerSessionId: "d", status: "working", noticedAt: [] },
+    "not a record",
+    {
+      providerId: "conductor",
+      providerSessionId: "e",
+      status: "error",
+      noticedAt: [
+        { status: "error", at: 5_000 },
+        { status: "working", at: 1 },
+        { status: "waiting", at: "soon" },
+        { status: "complete", at: Number.NaN },
+        "later",
+      ],
+    },
+    { providerId: "conductor", providerSessionId: "f", status: "complete", noticedAt: "never" },
+  ]);
+
+  assert.deepEqual(memory, [
+    { providerId: "claude-code", providerSessionId: "a", status: "working", noticedAt: [] },
+    {
+      providerId: "conductor",
+      providerSessionId: "e",
+      status: "error",
+      noticedAt: [{ status: "error", at: 5_000 }],
+    },
+    { providerId: "conductor", providerSessionId: "f", status: "complete", noticedAt: [] },
+  ]);
+  assert.deepEqual(sessionNoticeMemoryFromWire({ providerId: "claude-code" }), []);
+  assert.deepEqual(sessionNoticeMemoryFromWire(undefined), []);
+});
+
+test("a memory naming one session twice keeps the later record", () => {
+  const tracker = SessionNoticeTracker.restore([
+    {
+      providerId: "claude-code",
+      providerSessionId: "a",
+      status: SESSION_STATUS.WORKING,
+      noticedAt: [],
+    },
+    {
+      providerId: "claude-code",
+      providerSessionId: "a",
+      status: SESSION_STATUS.WAITING,
+      noticedAt: [],
+    },
+  ]);
+
+  assert.deepEqual(tracker.notices([session(claude, "a", SESSION_STATUS.WAITING)], 2_000), []);
 });

--- a/packages/session/src/session-notices.ts
+++ b/packages/session/src/session-notices.ts
@@ -1,3 +1,4 @@
+import { isRecord, text, type UnparsedWireValue, wholeNumber } from "@sidecar/wire";
 import type { Session, SessionStatus } from "./session.js";
 import { SESSION_COMPLETION_CAUSE, SESSION_STATUS } from "./session.js";
 
@@ -84,8 +85,69 @@ interface TrackedSessionState {
   noticedAt: Map<SessionNoticeStatus, number>;
 }
 
+/**
+ * One session's place in the tracker's memory, in values that survive a
+ * process: what the tracker needs to tell an edge from a first sight is where
+ * a session stood and when it was last spoken of, never its title, activity,
+ * or error, so a memory that stands in a row carries identifiers and
+ * timestamps alone.
+ */
+export interface TrackedSessionMemory {
+  providerId: string;
+  providerSessionId: string;
+  status: SessionStatus;
+  /** When each notice-worthy status was last noticed, one entry per status. */
+  noticedAt: readonly NoticedAtMemory[];
+}
+
+export interface NoticedAtMemory {
+  status: SessionNoticeStatus;
+  at: number;
+}
+
+export type SessionNoticeMemory = readonly TrackedSessionMemory[];
+
 function noticeStatus(status: SessionStatus): SessionNoticeStatus | undefined {
   return Object.values(SESSION_NOTICE_STATUS).find((candidate) => candidate === status);
+}
+
+function sessionStatus(value: UnparsedWireValue): SessionStatus | undefined {
+  const candidate = text(value);
+  return Object.values(SESSION_STATUS).find((status) => status === candidate);
+}
+
+/**
+ * Reads a memory back from wherever it was kept. A record the reader cannot
+ * place — an unknown status, an identifier that is not text — is dropped
+ * rather than trusted, and a dropped session is merely seen for the first
+ * time again on the next pass, which is the tracker's own answer to a session
+ * it has never met. A timestamp under a status that is not notice-worthy is
+ * dropped the same way; the statuses the repeat window guards are the only
+ * ones it could ever have recorded.
+ */
+export function sessionNoticeMemoryFromWire(value: UnparsedWireValue): SessionNoticeMemory {
+  if (!Array.isArray(value)) return [];
+  const memory: TrackedSessionMemory[] = [];
+  for (const entry of value) {
+    if (!isRecord(entry)) continue;
+    const providerId = text(entry.providerId);
+    const providerSessionId = text(entry.providerSessionId);
+    const status = sessionStatus(entry.status);
+    if (!providerId || !providerSessionId || !status) continue;
+    const noticedAt: NoticedAtMemory[] = [];
+    if (Array.isArray(entry.noticedAt)) {
+      for (const noticed of entry.noticedAt) {
+        if (!isRecord(noticed)) continue;
+        const noticedStatus = sessionStatus(noticed.status);
+        const candidate = noticedStatus === undefined ? undefined : noticeStatus(noticedStatus);
+        const at = wholeNumber(noticed.at);
+        if (candidate === undefined || at === undefined) continue;
+        noticedAt.push({ status: candidate, at });
+      }
+    }
+    memory.push({ providerId, providerSessionId, status, noticedAt });
+  }
+  return memory;
 }
 
 function sessionNotice(session: Session, previousStatus: SessionStatus): SessionNotice {
@@ -133,6 +195,44 @@ function sessionNotice(session: Session, previousStatus: SessionStatus): Session
 export class SessionNoticeTracker {
   /** Keyed by the original identifiers, never a composite string. */
   readonly #sessions = new Map<string, Map<string, TrackedSessionState>>();
+
+  /**
+   * A tracker standing where a previous one left off, so the pass after a
+   * restart diffs against the last reading rather than seeding afresh: a
+   * memory kept between processes is what lets a watcher with no resident
+   * process tell an edge from a first sight. A session named twice keeps the
+   * later record.
+   */
+  static restore(memory: SessionNoticeMemory): SessionNoticeTracker {
+    const tracker = new SessionNoticeTracker();
+    for (const record of memory) {
+      let provider = tracker.#sessions.get(record.providerId);
+      if (!provider) {
+        provider = new Map();
+        tracker.#sessions.set(record.providerId, provider);
+      }
+      const noticedAt = new Map<SessionNoticeStatus, number>();
+      for (const noticed of record.noticedAt) noticedAt.set(noticed.status, noticed.at);
+      provider.set(record.providerSessionId, { status: record.status, noticedAt });
+    }
+    return tracker;
+  }
+
+  /**
+   * The tracker's memory as plain values: everything a later `restore` needs
+   * to continue this tracker's picture, and nothing else.
+   */
+  snapshot(): SessionNoticeMemory {
+    const memory: TrackedSessionMemory[] = [];
+    for (const [providerId, provider] of this.#sessions) {
+      for (const [providerSessionId, state] of provider) {
+        const noticedAt: NoticedAtMemory[] = [];
+        for (const [status, at] of state.noticedAt) noticedAt.push({ status, at });
+        memory.push({ providerId, providerSessionId, status: state.status, noticedAt });
+      }
+    }
+    return memory;
+  }
 
   /**
    * Consumes one full observation pass and returns the notices it produced.


### PR DESCRIPTION
## Summary

- The notice tracker keeps its picture of the roster in a private map, so only a resident process can tell an edge from a first sight. This gives it a snapshot and restore seam so the same edge detection can run on Luke's service, where each tick is a fresh process that has to diff against what the last tick wrote down.
- `SessionNoticeTracker.snapshot()` returns the memory as plain values: provider and session ids, the last status, and when each notice status was last spoken of. Never a title, activity, or error, so a memory that stands in a database row carries identifiers and timestamps alone.
- `SessionNoticeTracker.restore(memory)` stands a new tracker where the old one stopped, so the next pass diffs against the last reading rather than seeding silently. A session named twice keeps the later record.
- `sessionNoticeMemoryFromWire` reads a memory back from storage and drops any record it cannot place (an unknown status, a non-text identifier, a timestamp under a status the repeat window never guards) rather than trusting it. A dropped session is simply first-seen again on the next pass.
- The desktop keeps calling the tracker exactly as before. No behavior change.

This is step 1 of the plan to have the service watch cloud sessions on a schedule and push announcements to a signed-in iPhone. Steps 2 through 4 (device tokens and APNs, the scheduled watcher, and iOS registration) follow as separate PRs.

## Evidence

- Platform-independent checks: `./scripts/check.sh` passes (115 session package tests, 0 failures; full repository check exit 0)
- macOS Electron verification (`./scripts/verify.sh`): `not run` (portable package change only, no UI touched)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/33821573353/artifacts/9918521673) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/33821573353)

- Commit: `6e3226d9aecbdee13b3abac6cfc0653c8628377c`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

### Physical-device evidence

- Screenshot or screen recording: `not attached`
- Physical-notch check: `not performed`
- Device/display configuration: `not recorded`

## Notes

- Blockers or follow-up verification: None

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)