### PR TITLE
feat(brain): have the voice vary a brief acknowledgement before ask_brain

### DIFF
--- a/packages/realtime/src/realtime-protocol.ts
+++ b/packages/realtime/src/realtime-protocol.ts
@@ -202,6 +202,8 @@ const REALTIME_INSTRUCTION_HEAD: readonly string[] = [
   "You are the voice.",
   `- For anything about the developer's agents, settings, issues, or anything to do, call ${ASK_BRAIN_TOOL.name}`,
   "  with their words, and say its answer whole in your own voice.",
+  '- Before calling it, say a brief acknowledgement of about five words, in the spirit of "Let me',
+  '  check", varying the wording so it is not the same phrase every time.',
   "- Small talk you may answer yourself.",
   "- Never invent an agent, a status, or an outcome: what you know about the developer's work is what",
   "  the brain told you this turn, and nothing else.",

--- a/packages/realtime/src/realtime.test.ts
+++ b/packages/realtime/src/realtime.test.ts
@@ -109,8 +109,10 @@ test("the voice knows nothing of the work itself and asks the brain for all of i
   const instructions = realtimeInstructions();
 
   assert.match(instructions, new RegExp(`call ${ASK_BRAIN_TOOL.name}`));
-  // Nothing tells the voice what to say, or not say, before the ask.
-  assert.doesNotMatch(instructions, /acknowledgement/);
+  assert.match(
+    instructions,
+    /a brief acknowledgement of about five words[\s\S]*varying the wording/,
+  );
   assert.match(instructions, /say its answer whole/);
   assert.match(instructions, /Never invent an agent, a status, or an outcome/);
   // The roster, the guide, and the history are the brain's, so the voice is


### PR DESCRIPTION
## Summary

- Adds one sentence to the mouth instructions in `packages/realtime/src/realtime-protocol.ts`: *Before calling it, say a brief acknowledgement of about five words, in the spirit of "Let me check", varying the wording so it is not the same phrase every time.*
- `realtime.test.ts` asserts the sentence is present. This replaces the prior assertion that the instructions carried no acknowledgement wording, which the new sentence necessarily contradicts.

## Verification

`./scripts/check.sh` passes (exit 0). No UI change, so no macOS verify or visual evidence applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/a0378b9f-1424-4ff9-a298-923ecd7e8823)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/33822159630/artifacts/9918734389) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/33822159630)

- Commit: `8a00af34c320c1af8a813271703f129dacd80144`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
