### PR TITLE
feat(web): watch cloud sessions on a schedule and notify the phone

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,6 +70,18 @@ Trust constraints:
   credentials, or live sessions. A provider whose sessions exist only in a cloud
   service may read a user-supplied API key, but it must observe nothing until
   the user supplies one and must leave every other provider working without it.
+  The one observation that runs on a timer of Luke's own is the service's
+  scheduled watch, and it is bounded on every side: it runs only for an
+  account that is signed in on a phone and has synced a key, under that same
+  key, once a minute, as the same read-only pass the on-demand endpoint
+  runs; what it keeps between passes is the account's own memory of where
+  each cloud session stood (identifiers, statuses, and when each was last
+  spoken of, never a title, activity, or error); and it keeps nothing at all
+  for an account with no phone or no key, dropping that memory on the next
+  tick. Signing the phone out or deleting the key ends the watch. It exists
+  for exactly one act, the phone notification the announcement rule below
+  names, and widening what it observes, keeps, or does is a product
+  decision, not an implementation detail.
 - A cloud surface that documents no key-scoped API and answers only its own
   CLI (Codex cloud today) is observed through that CLI instead, and the rule
   keeps its shape at one remove. Observation runs the provider's own binary
@@ -842,7 +854,8 @@ What Luke may show:
   message kind, or anything stored is a product decision, not an
   implementation detail.
 - On the brain and speech paths, session material leaves the machine
-  unbidden in exactly two places, each with its own narrower rule; the
+  unbidden in exactly two places, and the service in a third, each with its
+  own narrower rule; the
   analytics, replay, and crash streams above are disclosed on their own terms
   and are not counted here. The brain's own turns are the first, under the
   transcript-read rule above: what a local session's transcript gained since
@@ -852,9 +865,20 @@ What Luke may show:
   bound — which reaches the voice service so it can be said aloud, as the one
   input of a call that carries no tools and no conversation, behind a marker
   that says it is data, so nothing in a briefing can become an act or inherit
-  an earlier question. Nothing decides an announcement deterministically any
-  more: no status edge speaks on its own, and no evaluator sentence stands
-  between the transcript and the voice. The hosted service still answers an
+  an earlier question. On the Mac nothing decides an announcement
+  deterministically any more: no status edge speaks on its own, and no
+  evaluator sentence stands between the transcript and the voice. The third
+  place is the phone notification, and it is the one status edge that still
+  speaks on its own, from the service rather than the machine: on the
+  scheduled watch, a cloud session that started holding for the developer or
+  stopped on an error, judged by the deterministic notice tracker the service
+  keeps for exactly this and by nothing else (no brain and no evaluator runs
+  on that pass, so nothing a model wrote can reach it), is handed to Apple's
+  push service to show on the account's registered phones, carrying the
+  session's title, its workspace, the one line the provider wrote about what
+  it holds on or why it stopped, and its identity for the tap. A finish and a
+  waiting turn the provider did not mark as holding are the phone's roster's
+  to show, never a notification's. The hosted service still answers an
   older installed desktop's attention review and subject derivation under the
   frozen released persona; the current desktop calls neither. Two onboarding
   beats are

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -208,19 +208,34 @@ explicitly request through that provider. The server-side use of these keys
 ships as a separate feature; this describes only the storage. Every synced key
 is deleted alongside your account if you delete that.
 
-**Phone push tokens.** When you sign into the iOS app, it registers the push
+**Phone notifications.** When you sign into the iOS app, it registers the push
 token Apple issued to that installation with our service, so we can address
 notifications to it. The token names the installation and nothing else, and
 it is not a credential. We store it with your account and delete it when you
 sign out on that phone, when Apple reports it gone, and alongside your account
-if you delete that. Sending notifications ships as a separate feature; this
-describes only the registration.
+if you delete that. While a phone is registered and you have synced a
+provider API key, our service checks your cloud sessions about once a minute
+using that key, the same read it makes when you open the app, and sends a
+notification when a session starts waiting on you or stops on an error. To
+tell a change from what it already saw, the service keeps one record per
+account of which sessions it last saw, their status, and when it last
+notified you about each, and nothing else about them; the record is deleted
+when no phone is registered, when no key is synced, and with your account.
+The notification carries the session's title, its workspace, the one line
+its provider wrote about what it is waiting on or why it stopped, and its id
+so a tap opens it. Unlike the Mac app's announcements, no model decides or
+words a notification: it is a fixed rule over the status your provider
+reported.
 
 **Feedback.** If you use the feedback form, we receive what you typed, the name
 and email you signed it with, and any screenshots you attached.
 
 ## Who we send it to
 
+- Apple, for iPhone notifications. Each one carries the session fields named
+  under Phone notifications above and travels through Apple's push service to
+  the phones registered to your account. Apple's handling of it is described
+  in Apple's own privacy policy.
 - OpenAI, for voice and for Luke's own judgment. A spoken turn sends its
   audio, a typed turn sends your words, and both send the session fields
   listed above — on the Mac app, read locally from your machine; on iOS and
@@ -304,8 +319,10 @@ files, the things he remembers about you, local provider API keys, and
 calendar access stay on your Mac.
 Local keys and calendar access are encrypted in the macOS Keychain. Provider
 API keys you sync to the hosted service are stored encrypted in our own
-database, as described above. Your account information is held by our own
-service, usage counts and recordings by PostHog, and crash reports by Sentry.
+database, as described above, and so are your phones' push tokens and the
+record of which cloud sessions our service last saw for them. Your account
+information is held by our own service, usage counts and recordings by
+PostHog, and crash reports by Sentry.
 
 ## Your choices
 
@@ -313,6 +330,9 @@ service, usage counts and recordings by PostHog, and crash reports by Sentry.
 - Delete your OpenAI key to turn voice off.
 - Delete any synced provider API key from that provider's row in Settings. Keys
   are also deleted when you delete your account.
+- Sign out of the iOS app to stop notifications to that phone; its token is
+  deleted at once and the service's record of your sessions on the next
+  check if no phone remains.
 - Clear the History tab to remove the stored conversation and Luke's working
   memory of it behind a recovery archive on your Mac. Nothing discards them
   on a schedule: a conversation stands until you clear it.

--- a/apps/web/api/watch/tick.ts
+++ b/apps/web/api/watch/tick.ts
@@ -1,0 +1,106 @@
+import { and, eq, notInArray, or, sql } from "drizzle-orm";
+import type { UnparsedWireValue } from "../../server/core.js";
+import { getDatabase } from "../../server/db/index.js";
+import { deviceToken, providerKey, watchMemory } from "../../server/db/schema.js";
+import { ApnsSender, apnsCredentialsFromEnvironment } from "../../server/hosted/apns.js";
+import { VAULT_ENCRYPTION_ENVIRONMENT } from "../../server/hosted/encryption.js";
+import {
+  cloudSessionsObserver,
+  handleWatchTick,
+  WATCH_ENVIRONMENT,
+  type WatchTickOptions,
+} from "../../server/hosted/watch.js";
+
+/**
+ * The scheduled watch's one entry, called by Vercel's cron on the cadence
+ * `vercel.json` fixes. The logic lives in `server/hosted/watch.ts`; this file
+ * hands it the deployment's real seams and the database queries behind them.
+ */
+export default {
+  async fetch(request: Request): Promise<Response> {
+    const database = getDatabase();
+    const credentials = apnsCredentialsFromEnvironment(process.env);
+    const sender = credentials ? new ApnsSender({ credentials }) : undefined;
+    const encryptionSecret = process.env[VAULT_ENCRYPTION_ENVIRONMENT.SECRET]?.trim() || undefined;
+
+    const readVaultKeys = (userId: string) =>
+      database
+        .select({ providerId: providerKey.providerId, ciphertext: providerKey.ciphertext })
+        .from(providerKey)
+        .where(eq(providerKey.userId, userId));
+
+    const options: WatchTickOptions = {
+      request,
+      cronSecret: process.env[WATCH_ENVIRONMENT.CRON_SECRET],
+      sender,
+      encryptionSecret,
+      listAccounts: async (limit) => {
+        const rows = await database
+          .select({ userId: deviceToken.userId, passedAt: watchMemory.passedAt })
+          .from(deviceToken)
+          .innerJoin(providerKey, eq(providerKey.userId, deviceToken.userId))
+          .leftJoin(watchMemory, eq(watchMemory.userId, deviceToken.userId))
+          .groupBy(deviceToken.userId, watchMemory.passedAt)
+          .orderBy(sql`${watchMemory.passedAt} asc nulls first`)
+          .limit(limit);
+        return rows.map((row) => ({
+          userId: row.userId,
+          passedAt: row.passedAt?.getTime(),
+        }));
+      },
+      forgetIneligible: async () => {
+        await database
+          .delete(watchMemory)
+          .where(
+            or(
+              notInArray(
+                watchMemory.userId,
+                database.select({ userId: deviceToken.userId }).from(deviceToken),
+              ),
+              notInArray(
+                watchMemory.userId,
+                database.select({ userId: providerKey.userId }).from(providerKey),
+              ),
+            ),
+          );
+      },
+      observeSessions: cloudSessionsObserver({
+        readVaultKeys,
+        encryptionSecret: encryptionSecret ?? "",
+      }),
+      readMemory: async (userId) => {
+        const [row] = await database
+          .select({ memory: watchMemory.memory })
+          .from(watchMemory)
+          .where(eq(watchMemory.userId, userId))
+          .limit(1);
+        // SAFETY: jsonb comes back as a runtime value; sessionNoticeMemoryFromWire validates it.
+        return row?.memory as UnparsedWireValue;
+      },
+      writeMemory: async (userId, memory, passedAt) => {
+        const row = { userId, memory, passedAt: new Date(passedAt) };
+        await database
+          .insert(watchMemory)
+          .values(row)
+          .onConflictDoUpdate({
+            target: watchMemory.userId,
+            set: { memory: row.memory, passedAt: row.passedAt },
+          });
+      },
+      listDevices: (userId) =>
+        database
+          .select({ token: deviceToken.token, environment: deviceToken.environment })
+          .from(deviceToken)
+          .where(eq(deviceToken.userId, userId)),
+      retireDevice: async (token) => {
+        await database.delete(deviceToken).where(and(eq(deviceToken.token, token)));
+      },
+    };
+
+    try {
+      return await handleWatchTick(options);
+    } finally {
+      await sender?.close();
+    }
+  },
+};

--- a/apps/web/drizzle/0008_stale_killraven.sql
+++ b/apps/web/drizzle/0008_stale_killraven.sql
@@ -1,0 +1,7 @@
+CREATE TABLE "watch_memory" (
+	"user_id" text PRIMARY KEY NOT NULL,
+	"memory" jsonb NOT NULL,
+	"passed_at" timestamp NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "watch_memory" ADD CONSTRAINT "watch_memory_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;

--- a/apps/web/drizzle/meta/0008_snapshot.json
+++ b/apps/web/drizzle/meta/0008_snapshot.json
@@ -1,0 +1,1387 @@
+{
+  "id": "c89fdbca-b37e-40fd-994d-1c631b08b3a0",
+  "prevId": "23859655-5c0f-4a42-8251-4f92fe8e41c4",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.jwks": {
+      "name": "jwks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_key": {
+          "name": "private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_access_token": {
+      "name": "oauth_access_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_id": {
+          "name": "refresh_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "oauthAccessToken_clientId_idx": {
+          "name": "oauthAccessToken_clientId_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthAccessToken_sessionId_idx": {
+          "name": "oauthAccessToken_sessionId_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthAccessToken_userId_idx": {
+          "name": "oauthAccessToken_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthAccessToken_refreshId_idx": {
+          "name": "oauthAccessToken_refreshId_idx",
+          "columns": [
+            {
+              "expression": "refresh_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_access_token_client_id_oauth_client_client_id_fk": {
+          "name": "oauth_access_token_client_id_oauth_client_client_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "oauth_client",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["client_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_session_id_session_id_fk": {
+          "name": "oauth_access_token_session_id_session_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "session",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_user_id_user_id_fk": {
+          "name": "oauth_access_token_user_id_user_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_refresh_id_oauth_refresh_token_id_fk": {
+          "name": "oauth_access_token_refresh_id_oauth_refresh_token_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "oauth_refresh_token",
+          "columnsFrom": ["refresh_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_access_token_token_unique": {
+          "name": "oauth_access_token_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_client": {
+      "name": "oauth_client",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "skip_consent": {
+          "name": "skip_consent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enable_end_session": {
+          "name": "enable_end_session",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject_type": {
+          "name": "subject_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contacts": {
+          "name": "contacts",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tos": {
+          "name": "tos",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "policy": {
+          "name": "policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_id": {
+          "name": "software_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_version": {
+          "name": "software_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_statement": {
+          "name": "software_statement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_logout_redirect_uris": {
+          "name": "post_logout_redirect_uris",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_endpoint_auth_method": {
+          "name": "token_endpoint_auth_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grant_types": {
+          "name": "grant_types",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_types": {
+          "name": "response_types",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public": {
+          "name": "public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "require_pkce": {
+          "name": "require_pkce",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "oauthClient_userId_idx": {
+          "name": "oauthClient_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_client_user_id_user_id_fk": {
+          "name": "oauth_client_user_id_user_id_fk",
+          "tableFrom": "oauth_client",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_client_client_id_unique": {
+          "name": "oauth_client_client_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["client_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_consent": {
+      "name": "oauth_consent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "oauthConsent_clientId_idx": {
+          "name": "oauthConsent_clientId_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthConsent_userId_idx": {
+          "name": "oauthConsent_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_consent_client_id_oauth_client_client_id_fk": {
+          "name": "oauth_consent_client_id_oauth_client_client_id_fk",
+          "tableFrom": "oauth_consent",
+          "tableTo": "oauth_client",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["client_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_consent_user_id_user_id_fk": {
+          "name": "oauth_consent_user_id_user_id_fk",
+          "tableFrom": "oauth_consent",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_refresh_token": {
+      "name": "oauth_refresh_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked": {
+          "name": "revoked",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_time": {
+          "name": "auth_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "oauthRefreshToken_clientId_idx": {
+          "name": "oauthRefreshToken_clientId_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthRefreshToken_sessionId_idx": {
+          "name": "oauthRefreshToken_sessionId_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthRefreshToken_userId_idx": {
+          "name": "oauthRefreshToken_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_refresh_token_client_id_oauth_client_client_id_fk": {
+          "name": "oauth_refresh_token_client_id_oauth_client_client_id_fk",
+          "tableFrom": "oauth_refresh_token",
+          "tableTo": "oauth_client",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["client_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_refresh_token_session_id_session_id_fk": {
+          "name": "oauth_refresh_token_session_id_session_id_fk",
+          "tableFrom": "oauth_refresh_token",
+          "tableTo": "session",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "oauth_refresh_token_user_id_user_id_fk": {
+          "name": "oauth_refresh_token_user_id_user_id_fk",
+          "tableFrom": "oauth_refresh_token",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_refresh_token_token_unique": {
+          "name": "oauth_refresh_token_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_login_method": {
+          "name": "last_login_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'user'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.device_token": {
+      "name": "device_token",
+      "schema": "",
+      "columns": {
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "environment": {
+          "name": "environment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "device_token_user_id_user_id_fk": {
+          "name": "device_token_user_id_user_id_fk",
+          "tableFrom": "device_token",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.admin_favorite": {
+      "name": "admin_favorite",
+      "schema": "",
+      "columns": {
+        "admin_id": {
+          "name": "admin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "admin_favorite_admin_id_user_id_fk": {
+          "name": "admin_favorite_admin_id_user_id_fk",
+          "tableFrom": "admin_favorite",
+          "tableTo": "user",
+          "columnsFrom": ["admin_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "admin_favorite_user_id_user_id_fk": {
+          "name": "admin_favorite_user_id_user_id_fk",
+          "tableFrom": "admin_favorite",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "admin_favorite_admin_id_user_id_pk": {
+          "name": "admin_favorite_admin_id_user_id_pk",
+          "columns": ["admin_id", "user_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.hosted_usage": {
+      "name": "hosted_usage",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "day": {
+          "name": "day",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "voice_calls": {
+          "name": "voice_calls",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "attention_reviews": {
+          "name": "attention_reviews",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "hosted_usage_user_id_user_id_fk": {
+          "name": "hosted_usage_user_id_user_id_fk",
+          "tableFrom": "hosted_usage",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "hosted_usage_user_id_day_pk": {
+          "name": "hosted_usage_user_id_day_pk",
+          "columns": ["user_id", "day"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.introduction_usage": {
+      "name": "introduction_usage",
+      "schema": "",
+      "columns": {
+        "caller": {
+          "name": "caller",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "day": {
+          "name": "day",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mints": {
+          "name": "mints",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "introduction_usage_caller_day_pk": {
+          "name": "introduction_usage_caller_day_pk",
+          "columns": ["caller", "day"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provider_key": {
+      "name": "provider_key",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ciphertext": {
+          "name": "ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "provider_key_user_id_user_id_fk": {
+          "name": "provider_key_user_id_user_id_fk",
+          "tableFrom": "provider_key",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "provider_key_user_id_provider_id_pk": {
+          "name": "provider_key_user_id_provider_id_pk",
+          "columns": ["user_id", "provider_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.watch_memory": {
+      "name": "watch_memory",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "memory": {
+          "name": "memory",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "passed_at": {
+          "name": "passed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "watch_memory_user_id_user_id_fk": {
+          "name": "watch_memory_user_id_user_id_fk",
+          "tableFrom": "watch_memory",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/web/drizzle/meta/_journal.json
+++ b/apps/web/drizzle/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1788481578762,
       "tag": "0007_open_wrecking_crew",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1788482062148,
+      "tag": "0008_stale_killraven",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/web/server/README.md
+++ b/apps/web/server/README.md
@@ -263,3 +263,23 @@ the OpenAI and vault endpoints keep: a Preview deployment without the
 credential stores registrations and sends nothing. Each token records which
 of Apple's two gateways issued it, so a build run from Xcode and one from
 TestFlight are addressed at the right host.
+
+# Scheduled watch
+
+`api/watch/tick.ts` is called by Vercel's cron every minute, on the schedule
+`vercel.json` fixes, and is the one observation the service runs on a timer of
+its own. For each account that has a registered phone and a synced key, oldest
+pass first, it observes the account's cloud sessions exactly as `/api/observe`
+does, diffs the pass against the account's row in `watch_memory` with the same
+notice tracker the desktop runs, writes the new memory, and sends a phone
+notification for a session that started holding for the developer or stopped
+on an error. The memory is identifiers, statuses, and timestamps alone; it is
+dropped for an account that no longer has a phone or a key.
+
+The route requires `CRON_SECRET`, which Vercel sends as the bearer on every
+scheduled call once the variable is set, and the four `APNS_*` variables above.
+Either absent means the tick answers 503 and observes nothing, so a Preview
+deployment (where crons do not run anyway) can never start a watch by accident.
+One tick spends at most 45 seconds inside a 60-second function cap and answers
+how many accounts it reached, so a backlog shows as `exhausted: true` in the
+cron logs rather than as a timeout.

--- a/apps/web/server/db/schema.ts
+++ b/apps/web/server/db/schema.ts
@@ -5,3 +5,4 @@ export * from "./device-schema.js";
 export * from "./favorite-schema.js";
 export * from "./usage-schema.js";
 export * from "./vault-schema.js";
+export * from "./watch-schema.js";

--- a/apps/web/server/db/watch-schema.ts
+++ b/apps/web/server/db/watch-schema.ts
@@ -1,0 +1,20 @@
+import { jsonb, pgTable, text, timestamp } from "drizzle-orm/pg-core";
+import { user } from "./auth-schema.js";
+
+/**
+ * The account's memory of where its cloud sessions stood when the scheduled
+ * watch last looked: the notice tracker's snapshot, which is identifiers,
+ * statuses, and timestamps and never a title, activity, or error. One row
+ * per account, because the memory is the account's rather than any one
+ * phone's — a desktop reading it later needs no migration — and rewritten
+ * whole on every pass. The row goes with the account, and with an account
+ * that no longer has a phone or a key to watch for.
+ */
+export const watchMemory = pgTable("watch_memory", {
+  userId: text("user_id")
+    .primaryKey()
+    .references(() => user.id, { onDelete: "cascade" }),
+  memory: jsonb("memory").notNull(),
+  /** When the last pass completed; the gap since it decides whether an edge is news or history. */
+  passedAt: timestamp("passed_at").notNull(),
+});

--- a/apps/web/server/hosted/cloud-adapters.ts
+++ b/apps/web/server/hosted/cloud-adapters.ts
@@ -1,6 +1,9 @@
 import { ConductorSessionAdapter } from "../../../../packages/providers/src/conductor/adapter.js";
-import type { CloudFetch } from "../../../../packages/providers/src/shared/cloud-session-adapter.js";
-import type { SessionProviderAdapter, VaultProviderId } from "../core.js";
+import type {
+  CloudFetch,
+  CloudSessionAdapter,
+} from "../../../../packages/providers/src/shared/cloud-session-adapter.js";
+import type { VaultProviderId } from "../core.js";
 import { VAULT_PROVIDER_ID } from "../core.js";
 
 /**
@@ -16,7 +19,7 @@ export interface CloudAdapterSeams {
   now?: () => number;
 }
 
-type AdapterBuilder = (seams: CloudAdapterSeams) => SessionProviderAdapter;
+type AdapterBuilder = (seams: CloudAdapterSeams) => CloudSessionAdapter;
 
 function baseOptions(seams: CloudAdapterSeams) {
   return {
@@ -35,6 +38,6 @@ const ADAPTER_BUILDERS = {
 export function cloudSessionAdapterFor(
   providerId: VaultProviderId,
   seams: CloudAdapterSeams,
-): SessionProviderAdapter {
+): CloudSessionAdapter {
   return ADAPTER_BUILDERS[providerId](seams);
 }

--- a/apps/web/server/hosted/cloud-observe.ts
+++ b/apps/web/server/hosted/cloud-observe.ts
@@ -1,0 +1,110 @@
+import {
+  CLOUD_FAILURE,
+  type CloudFailure,
+  type CloudFetch,
+} from "../../../../packages/providers/src/shared/cloud-session-adapter.js";
+import type { ProviderSessionObservation } from "../core.js";
+import { VAULT_PROVIDER_ID, type VaultProviderId } from "../core.js";
+import { cloudSessionAdapterFor } from "./cloud-adapters.js";
+import { decryptProviderKey } from "./encryption.js";
+
+/** Stored vault key row as the API routes supply it. */
+export interface VaultKeyRow {
+  providerId: string;
+  ciphertext: string;
+}
+
+export interface CloudObserveSeams {
+  /** Injected in tests; production uses the global fetch. */
+  fetch?: CloudFetch;
+  now?: () => number;
+}
+
+/**
+ * Why one provider's pass could not be trusted as its whole roster. The
+ * adapter answers an unreadable pass with its previous snapshot, which for a
+ * pass built fresh is nothing, so a caller that would write the roster down
+ * has to be told the difference between nothing and unread.
+ */
+export const CLOUD_OBSERVE_FAILURE = {
+  /** The provider refused the key. */
+  UNAUTHORIZED: "unauthorized",
+  /** The provider or the network did not answer. */
+  TRANSIENT: "transient",
+  /** A key row stands but could not be decrypted with this deployment's secret. */
+  KEY_UNREADABLE: "key-unreadable",
+  /** The pass itself threw; a bug in the adapter, not an answer from the provider. */
+  PASS_FAILED: "pass-failed",
+} as const;
+
+export type CloudObserveFailure =
+  (typeof CLOUD_OBSERVE_FAILURE)[keyof typeof CLOUD_OBSERVE_FAILURE];
+
+export interface CloudProviderObservations {
+  providerId: VaultProviderId;
+  observations: readonly ProviderSessionObservation[];
+  /** Set when the observations are not the provider's whole current roster. */
+  failure?: CloudObserveFailure;
+}
+
+/**
+ * One read-only pass over every cloud provider the vault holds a key for:
+ * each adapter is built for this pass alone, reads the caller's decrypted key
+ * behind the same read-at-act-time seam the desktop uses, and is discarded
+ * with the pass. A provider that fails answers nothing rather than failing
+ * the others, and a key that cannot be decrypted is a key that is absent.
+ */
+export async function observeCloudProviders(
+  rows: readonly VaultKeyRow[],
+  secret: string,
+  seams: CloudObserveSeams = {},
+): Promise<CloudProviderObservations[]> {
+  const ciphertextByProviderId = new Map<string, string>(
+    rows.map((row) => [row.providerId, row.ciphertext]),
+  );
+  const unreadableKeys = new Set<string>();
+
+  function readApiKeyFor(providerId: string): () => Promise<string | undefined> {
+    return async () => {
+      const ciphertext = ciphertextByProviderId.get(providerId);
+      if (!ciphertext) return undefined;
+      try {
+        return decryptProviderKey(ciphertext, secret);
+      } catch {
+        unreadableKeys.add(providerId);
+        return undefined;
+      }
+    };
+  }
+
+  const providerIds = Object.values(VAULT_PROVIDER_ID);
+  const adapters = providerIds.map((providerId) =>
+    cloudSessionAdapterFor(providerId, {
+      readApiKey: readApiKeyFor(providerId),
+      ...(seams.fetch ? { fetch: seams.fetch } : undefined),
+      ...(seams.now ? { now: seams.now } : undefined),
+    }),
+  );
+  const results = await Promise.allSettled(adapters.map((adapter) => adapter.observe()));
+
+  const observed: CloudProviderObservations[] = [];
+  for (const [index, providerId] of providerIds.entries()) {
+    const result = results[index];
+    const adapter = adapters[index];
+    if (!result || !adapter) continue;
+    const failure = unreadableKeys.has(providerId)
+      ? CLOUD_OBSERVE_FAILURE.KEY_UNREADABLE
+      : result.status === "rejected"
+        ? CLOUD_OBSERVE_FAILURE.PASS_FAILED
+        : adapterFailure(adapter.lastObserveFailure());
+    const observations = result.status === "fulfilled" ? result.value : [];
+    observed.push({ providerId, observations, ...(failure ? { failure } : undefined) });
+  }
+  return observed;
+}
+
+function adapterFailure(failure: CloudFailure | undefined): CloudObserveFailure | undefined {
+  if (failure === CLOUD_FAILURE.UNAUTHORIZED) return CLOUD_OBSERVE_FAILURE.UNAUTHORIZED;
+  if (failure === CLOUD_FAILURE.TRANSIENT) return CLOUD_OBSERVE_FAILURE.TRANSIENT;
+  return undefined;
+}

--- a/apps/web/server/hosted/notice-tracker.ts
+++ b/apps/web/server/hosted/notice-tracker.ts
@@ -1,0 +1,309 @@
+import {
+  isRecord,
+  SESSION_COMPLETION_CAUSE,
+  SESSION_STATUS,
+  type Session,
+  type SessionStatus,
+  text,
+  type UnparsedWireValue,
+  wholeNumber,
+} from "../core.js";
+
+/**
+ * The deterministic edge detector the service's scheduled watch runs. The
+ * desktop no longer keeps one — its brain notices changes against its own
+ * memory — so this lives with its only consumer, and the phone notification it
+ * feeds is the one place a status edge still speaks on its own.
+ */
+
+/**
+ * The statuses worth telling the user about when a session arrives at one.
+ * `working` is the quiet default and `unknown` is an adapter losing sight of a
+ * session, so neither is news; the three that remain are the three things a
+ * developer steps away from an agent to wait for.
+ */
+export const SESSION_NOTICE_STATUS = {
+  WAITING: SESSION_STATUS.WAITING,
+  ERROR: SESSION_STATUS.ERROR,
+  COMPLETE: SESSION_STATUS.COMPLETE,
+} as const;
+
+export type SessionNoticeStatus =
+  (typeof SESSION_NOTICE_STATUS)[keyof typeof SESSION_NOTICE_STATUS];
+
+/**
+ * When a pass produces more notices than the cap, stopped sessions survive
+ * first, then waiting turns, then final completions that will keep.
+ */
+const NOTICE_PRIORITY: readonly SessionNoticeStatus[] = [
+  SESSION_NOTICE_STATUS.ERROR,
+  SESSION_NOTICE_STATUS.WAITING,
+  SESSION_NOTICE_STATUS.COMPLETE,
+];
+
+/**
+ * How long the same session stays quiet about the same status once it has been
+ * noticed. An adapter that flaps between two readings must not turn each flap
+ * into a banner; a session genuinely stopping twice in an afternoon still gets
+ * its second notice.
+ */
+export const SESSION_NOTICE_REPEAT_WINDOW_MS = 5 * 60_000;
+
+/**
+ * The most notices one pass may produce. A burst larger than this is a
+ * provider reconnecting or re-reading its world, not six agents finishing in
+ * the same five seconds, and the panel still shows every session either way.
+ */
+export const MAXIMUM_NOTICES_PER_PASS = 6;
+
+/**
+ * One session arriving at a status the user may want to know about. Fields,
+ * not sentences: the surface that shows a notice words it, the way it words a
+ * row. Everything here is already bounded by `normalizeSession`.
+ */
+export interface SessionNotice {
+  providerId: string;
+  providerSessionId: string;
+  providerName: string;
+  title: string;
+  /** The workspace the session is one chat of, by name, when its provider groups them. */
+  workspace?: string;
+  status: SessionNoticeStatus;
+  previousStatus: SessionStatus;
+  /** Whether this waiting turn cannot continue without the developer. */
+  holdingForDeveloper?: boolean;
+  /** Why the session stopped, when its provider said. */
+  error?: string;
+  /** The provider's bounded description of the action currently awaiting permission. */
+  activity?: string;
+  repository?: string;
+  branch?: string;
+  /** Whether the provider will take a reply for this session right now. */
+  canReceiveMessage: boolean;
+  lastActivityAt: number;
+}
+
+/**
+ * Distinguishes a turn that needs the developer from one that merely finished.
+ * Only a provider that saw a permission, an approval, or an open question and
+ * said so on the observation counts: a waiting session whose adapter could
+ * not tell is the panel's to show, not a notice's to speak.
+ */
+function waitingHoldsForDeveloper(session: Session): boolean {
+  return session.status === SESSION_STATUS.WAITING && session.holdingForDeveloper === true;
+}
+
+interface TrackedSessionState {
+  status: SessionStatus;
+  /** When each notice-worthy status was last noticed, for the repeat window. */
+  noticedAt: Map<SessionNoticeStatus, number>;
+}
+
+/**
+ * One session's place in the tracker's memory, in values that survive a
+ * process: what the tracker needs to tell an edge from a first sight is where
+ * a session stood and when it was last spoken of, never its title, activity,
+ * or error, so a memory that stands in a row carries identifiers and
+ * timestamps alone.
+ */
+export interface TrackedSessionMemory {
+  providerId: string;
+  providerSessionId: string;
+  status: SessionStatus;
+  /** When each notice-worthy status was last noticed, one entry per status. */
+  noticedAt: readonly NoticedAtMemory[];
+}
+
+export interface NoticedAtMemory {
+  status: SessionNoticeStatus;
+  at: number;
+}
+
+export type SessionNoticeMemory = readonly TrackedSessionMemory[];
+
+function noticeStatus(status: SessionStatus): SessionNoticeStatus | undefined {
+  return Object.values(SESSION_NOTICE_STATUS).find((candidate) => candidate === status);
+}
+
+function sessionStatus(value: UnparsedWireValue): SessionStatus | undefined {
+  const candidate = text(value);
+  return Object.values(SESSION_STATUS).find((status) => status === candidate);
+}
+
+/**
+ * Reads a memory back from wherever it was kept. A record the reader cannot
+ * place — an unknown status, an identifier that is not text — is dropped
+ * rather than trusted, and a dropped session is merely seen for the first
+ * time again on the next pass, which is the tracker's own answer to a session
+ * it has never met. A timestamp under a status that is not notice-worthy is
+ * dropped the same way; the statuses the repeat window guards are the only
+ * ones it could ever have recorded.
+ */
+export function sessionNoticeMemoryFromWire(value: UnparsedWireValue): SessionNoticeMemory {
+  if (!Array.isArray(value)) return [];
+  const memory: TrackedSessionMemory[] = [];
+  for (const entry of value) {
+    if (!isRecord(entry)) continue;
+    const providerId = text(entry.providerId);
+    const providerSessionId = text(entry.providerSessionId);
+    const status = sessionStatus(entry.status);
+    if (!providerId || !providerSessionId || !status) continue;
+    const noticedAt: NoticedAtMemory[] = [];
+    if (Array.isArray(entry.noticedAt)) {
+      for (const noticed of entry.noticedAt) {
+        if (!isRecord(noticed)) continue;
+        const noticedStatus = sessionStatus(noticed.status);
+        const candidate = noticedStatus === undefined ? undefined : noticeStatus(noticedStatus);
+        const at = wholeNumber(noticed.at);
+        if (candidate === undefined || at === undefined) continue;
+        noticedAt.push({ status: candidate, at });
+      }
+    }
+    memory.push({ providerId, providerSessionId, status, noticedAt });
+  }
+  return memory;
+}
+
+function sessionNotice(session: Session, previousStatus: SessionStatus): SessionNotice {
+  const status = noticeStatus(session.status);
+  if (!status) throw new Error(`Not a notice status: ${session.status}`);
+  const notice: SessionNotice = {
+    providerId: session.providerId,
+    providerSessionId: session.providerSessionId,
+    providerName: session.provider.displayName,
+    title: session.title,
+    status,
+    previousStatus,
+    canReceiveMessage: session.canReceiveMessage,
+    lastActivityAt: session.lastActivityAt,
+  };
+  if (session.workspace?.name) notice.workspace = session.workspace.name;
+  if (status === SESSION_NOTICE_STATUS.WAITING) {
+    notice.holdingForDeveloper = waitingHoldsForDeveloper(session);
+  }
+  if (session.detail.error) notice.error = session.detail.error;
+  if (session.detail.activity) notice.activity = session.detail.activity;
+  if (session.detail.repository) notice.repository = session.detail.repository;
+  if (session.detail.branch) notice.branch = session.detail.branch;
+  return notice;
+}
+
+/**
+ * Derives notices from the edges between one observation pass and the next: a
+ * session already waiting when Luke first sees it is the panel's to show, not
+ * a banner's to announce, so only a change of status while watched is news.
+ * The edge is the whole test: no provider records when a status was entered,
+ * only when it last wrote about the session, so the timestamp's age says
+ * nothing about whether the change is news, and an edge first seen after a
+ * long sleep is announced like any other. A waiting edge says whether the
+ * turn merely finished or is holding for the developer, so the voice never
+ * turns an ordinary finish into a false ask.
+ * Deterministic by construction — nothing a model wrote can reach it — and
+ * purely derived from the roster, so it can never act on a session, only
+ * describe one.
+ *
+ * The tracker must be fed every pass whether or not anything will be shown:
+ * feeding is what keeps its picture current, so switching notices on never
+ * replays edges that happened while they were off.
+ */
+export class SessionNoticeTracker {
+  /** Keyed by the original identifiers, never a composite string. */
+  readonly #sessions = new Map<string, Map<string, TrackedSessionState>>();
+
+  /**
+   * A tracker standing where a previous one left off, so the pass after a
+   * restart diffs against the last reading rather than seeding afresh: a
+   * memory kept between processes is what lets a watcher with no resident
+   * process tell an edge from a first sight. A session named twice keeps the
+   * later record.
+   */
+  static restore(memory: SessionNoticeMemory): SessionNoticeTracker {
+    const tracker = new SessionNoticeTracker();
+    for (const record of memory) {
+      let provider = tracker.#sessions.get(record.providerId);
+      if (!provider) {
+        provider = new Map();
+        tracker.#sessions.set(record.providerId, provider);
+      }
+      const noticedAt = new Map<SessionNoticeStatus, number>();
+      for (const noticed of record.noticedAt) noticedAt.set(noticed.status, noticed.at);
+      provider.set(record.providerSessionId, { status: record.status, noticedAt });
+    }
+    return tracker;
+  }
+
+  /**
+   * The tracker's memory as plain values: everything a later `restore` needs
+   * to continue this tracker's picture, and nothing else.
+   */
+  snapshot(): SessionNoticeMemory {
+    const memory: TrackedSessionMemory[] = [];
+    for (const [providerId, provider] of this.#sessions) {
+      for (const [providerSessionId, state] of provider) {
+        const noticedAt: NoticedAtMemory[] = [];
+        for (const [status, at] of state.noticedAt) noticedAt.push({ status, at });
+        memory.push({ providerId, providerSessionId, status: state.status, noticedAt });
+      }
+    }
+    return memory;
+  }
+
+  /**
+   * Consumes one full observation pass and returns the notices it produced.
+   * `now` anchors the repeat window; sessions absent from the pass are
+   * forgotten, so a session that returns later is seeded again rather than
+   * diffed against a stale reading.
+   */
+  notices(sessions: readonly Session[], now: number): readonly SessionNotice[] {
+    const produced: SessionNotice[] = [];
+    const next = new Map<string, Map<string, TrackedSessionState>>();
+
+    for (const session of sessions) {
+      const previous = this.#sessions.get(session.providerId)?.get(session.providerSessionId);
+      const state: TrackedSessionState = {
+        status: session.status,
+        noticedAt: previous?.noticedAt ?? new Map(),
+      };
+      let provider = next.get(session.providerId);
+      if (!provider) {
+        provider = new Map();
+        next.set(session.providerId, provider);
+      }
+      provider.set(session.providerSessionId, state);
+
+      // A session the developer is speaking with announces nothing: its turn
+      // boundaries are the rhythm of a conversation being heard first-hand,
+      // and a voice reading them out would talk over the very exchange it is
+      // reporting. The edge is still tracked, so the conversation ending never
+      // replays what happened inside it — only a fresh edge after it speaks.
+      if (session.realtimeVoiceLive === true) continue;
+      // First sight seeds silently; an unchanged status is not an edge.
+      if (!previous || previous.status === session.status) continue;
+      if (session.completionCause === SESSION_COMPLETION_CAUSE.SESSION_CLOSED) continue;
+      const status = noticeStatus(session.status);
+      if (!status) continue;
+      const lastNoticed = state.noticedAt.get(status);
+      if (lastNoticed !== undefined && now - lastNoticed < SESSION_NOTICE_REPEAT_WINDOW_MS) {
+        continue;
+      }
+      state.noticedAt.set(status, now);
+      produced.push(sessionNotice(session, previous.status));
+    }
+
+    this.#sessions.clear();
+    for (const [providerId, provider] of next) this.#sessions.set(providerId, provider);
+
+    if (produced.length <= MAXIMUM_NOTICES_PER_PASS) return produced;
+    // A stable sort by urgency, then the cap: what is dropped is the tail of
+    // a burst, and every dropped session still shows its state in the panel.
+    return produced
+      .map((notice, index) => ({ notice, index }))
+      .sort((a, b) => {
+        const byPriority =
+          NOTICE_PRIORITY.indexOf(a.notice.status) - NOTICE_PRIORITY.indexOf(b.notice.status);
+        return byPriority !== 0 ? byPriority : a.index - b.index;
+      })
+      .slice(0, MAXIMUM_NOTICES_PER_PASS)
+      .map((entry) => entry.notice);
+  }
+}

--- a/apps/web/server/hosted/observe.ts
+++ b/apps/web/server/hosted/observe.ts
@@ -4,12 +4,10 @@ import {
   normalizeSessionDetail,
   type ObservedSession,
   type ObservedSessionControl,
-  VAULT_PROVIDER_ID,
   type VaultProviderId,
 } from "../core.js";
 import { providerReadsConversation } from "./act-execute.js";
-import { cloudSessionAdapterFor } from "./cloud-adapters.js";
-import { decryptProviderKey } from "./encryption.js";
+import { observeCloudProviders, type VaultKeyRow } from "./cloud-observe.js";
 import { errorResponse, HOSTED_API_ERROR, HOSTED_HTTP_STATUS, jsonResponse } from "./http.js";
 import { createRateBrake } from "./rate-brake.js";
 
@@ -25,11 +23,7 @@ const observeRateLimited = createRateBrake({
   maxTrackedUsers: OBSERVE_RATE_LIMIT.MAX_TRACKED_USERS,
 });
 
-/** Stored vault key row as the API route supplies it. */
-export interface VaultKeyRow {
-  providerId: string;
-  ciphertext: string;
-}
+export type { VaultKeyRow } from "./cloud-observe.js";
 
 export interface ObserveOptions {
   request: Request;
@@ -73,43 +67,14 @@ export async function handleObserve(options: ObserveOptions): Promise<Response> 
     return errorResponse(HOSTED_HTTP_STATUS.TOO_MANY_REQUESTS, HOSTED_API_ERROR.QUOTA_EXHAUSTED);
   }
 
-  const rows = await readVaultKeys(userId);
-  const ciphertextByProviderId = new Map<string, string>(
-    rows.map((row) => [row.providerId, row.ciphertext]),
-  );
-
-  function readApiKeyFor(providerId: string): () => Promise<string | undefined> {
-    return async () => {
-      const ciphertext = ciphertextByProviderId.get(providerId);
-      if (!ciphertext) return undefined;
-      try {
-        return decryptProviderKey(ciphertext, secret);
-      } catch {
-        return undefined;
-      }
-    };
-  }
-
-  const providers: Array<{
-    providerId: VaultProviderId;
-    observe: () => Promise<readonly ProviderSessionObservation[]>;
-  }> = Object.values(VAULT_PROVIDER_ID).map((providerId) => ({
-    providerId,
-    observe: () =>
-      cloudSessionAdapterFor(providerId, {
-        readApiKey: readApiKeyFor(providerId),
-        ...(options.fetch ? { fetch: options.fetch } : undefined),
-        ...(options.now ? { now: options.now } : undefined),
-      }).observe(),
-  }));
-
-  const results = await Promise.allSettled(providers.map(({ observe }) => observe()));
+  const observed = await observeCloudProviders(await readVaultKeys(userId), secret, {
+    ...(options.fetch ? { fetch: options.fetch } : undefined),
+    ...(options.now ? { now: options.now } : undefined),
+  });
 
   const sessions: ObservedSession[] = [];
-  for (const [i, { providerId }] of providers.entries()) {
-    const result = results[i];
-    if (result?.status !== "fulfilled") continue;
-    for (const obs of result.value) {
+  for (const { providerId, observations } of observed) {
+    for (const obs of observations) {
       sessions.push(observedSessionForResponse(providerId, obs));
     }
   }

--- a/apps/web/server/hosted/watch.ts
+++ b/apps/web/server/hosted/watch.ts
@@ -1,0 +1,364 @@
+import { timingSafeEqual } from "node:crypto";
+import {
+  boundedText,
+  isPushEnvironment,
+  normalizeSession,
+  PROVIDER_IDENTITY_BY_ID,
+  type Session,
+  type UnparsedWireValue,
+} from "../core.js";
+import {
+  APNS_DELIVERY,
+  APNS_INTERRUPTION_LEVEL,
+  type ApnsAlert,
+  type ApnsNotification,
+  type ApnsSender,
+} from "./apns.js";
+import {
+  type CloudObserveSeams,
+  observeCloudProviders,
+  type VaultKeyRow,
+} from "./cloud-observe.js";
+import { errorResponse, HOSTED_API_ERROR, HOSTED_HTTP_STATUS, jsonResponse } from "./http.js";
+import {
+  SESSION_NOTICE_STATUS,
+  type SessionNotice,
+  type SessionNoticeMemory,
+  SessionNoticeTracker,
+  sessionNoticeMemoryFromWire,
+} from "./notice-tracker.js";
+
+/**
+ * The scheduled watch: once a minute, for every account signed in on a phone
+ * and holding a synced key, the service observes that account's cloud
+ * sessions exactly as the on-demand endpoint does, diffs the pass against
+ * the account's memory of the last one with the same deterministic tracker
+ * the desktop runs, and tells the phone about a session that started holding
+ * for the developer or stopped on an error. Nothing a model wrote reaches
+ * this pass: there is no evaluator here, and what it keeps between ticks is
+ * the tracker's memory alone.
+ */
+
+/** Where Vercel's scheduler calls, fixed here so the cron entry can be checked against it. */
+export const WATCH_TICK_PATH = "/api/watch/tick";
+
+export const WATCH_ENVIRONMENT = {
+  /** Vercel sends this as the bearer on every scheduled call once it is set. */
+  CRON_SECRET: "CRON_SECRET",
+} as const;
+
+export const WATCH_TICK = {
+  /** How long one tick may spend before leaving the rest for the next; the function's own cap sits above it. */
+  BUDGET_MS: 45_000,
+  /** The most accounts one tick lists; the oldest-passed come first, so nobody starves. */
+  MAX_ACCOUNTS: 200,
+  /** Accounts observed at once; each is a fan of provider requests of its own. */
+  CONCURRENCY: 4,
+  /**
+   * A pass this long after the last is a watch that was down, not a minute
+   * that passed: the edges inside the gap are history arriving late, the
+   * phone's roster's to show and not a notification's to announce, so the
+   * memory reseeds silently instead of diffing across it.
+   */
+  GAP_MS: 5 * 60_000,
+} as const;
+
+/**
+ * The two changes a notification may announce, named for the phone as the
+ * desktop's announcements name them: a turn holding for the developer, or a
+ * session stopped on an error. A finish is deliberately not one of them.
+ */
+export const WATCH_CHANGE = {
+  NEEDS_INPUT: "needs-input",
+  FAILED: "failed",
+} as const;
+
+export type WatchChange = (typeof WATCH_CHANGE)[keyof typeof WATCH_CHANGE];
+
+/** The longest alert line a notification carries; the fields were bounded upstream, this is the belt. */
+const MAXIMUM_ALERT_LINE_LENGTH = 200;
+
+/** Apple caps a collapse id at 64 bytes. */
+const MAXIMUM_COLLAPSE_ID_LENGTH = 64;
+
+export interface WatchedAccount {
+  userId: string;
+  /** When the account's last pass completed, or undefined when it has never been watched. */
+  passedAt: number | undefined;
+}
+
+export interface WatchDevice {
+  token: string;
+  environment: string;
+}
+
+export interface WatchTickOptions {
+  request: Request;
+  /** The value of CRON_SECRET; undefined means the env var is absent and the watch is off. */
+  cronSecret: string | undefined;
+  /** The sender, or undefined when the deployment holds no Apple credential. */
+  sender: Pick<ApnsSender, "send"> | undefined;
+  /**
+   * The value of PROVIDER_KEY_ENCRYPTION_SECRET; undefined means the env var
+   * is absent, and a watch that cannot read a key must not run at all, since a
+   * pass that read nothing would be written down as an account with nothing.
+   */
+  encryptionSecret: string | undefined;
+  /** Accounts with a phone and a key, oldest pass first, never-passed first of all. */
+  listAccounts: (limit: number) => Promise<WatchedAccount[]>;
+  /** Drops the memory of every account that no longer has a phone or a key. */
+  forgetIneligible: () => Promise<void>;
+  /** One read-only observation pass over the account's cloud sessions. */
+  observeSessions: (userId: string) => Promise<WatchObservation>;
+  readMemory: (userId: string) => Promise<UnparsedWireValue>;
+  writeMemory: (userId: string, memory: SessionNoticeMemory, passedAt: number) => Promise<void>;
+  listDevices: (userId: string) => Promise<WatchDevice[]>;
+  /** Deletes a token Apple has said will never take another notification. */
+  retireDevice: (token: string) => Promise<void>;
+  now?: () => number;
+  budgetMs?: number;
+}
+
+/**
+ * One pass over an account's cloud sessions. `complete` says the sessions
+ * are every provider's whole current roster; a pass a provider refused, did
+ * not answer, or whose key could not be read is incomplete, and diffing it
+ * would read every session as gone and then, when the provider answered
+ * again, as new — silently, since first sight is never news.
+ */
+export interface WatchObservation {
+  sessions: readonly Session[];
+  complete: boolean;
+}
+
+export interface WatchTickAnswer {
+  accounts: number;
+  notices: number;
+  delivered: number;
+  retired: number;
+  /** Whether the tick stopped on its budget with accounts still listed. */
+  exhausted: boolean;
+}
+
+function bearerMatches(request: Request, secret: string): boolean {
+  const authorization = request.headers.get("authorization")?.trim() ?? "";
+  const expected = `Bearer ${secret}`;
+  const offered = Buffer.from(authorization);
+  const wanted = Buffer.from(expected);
+  return offered.length === wanted.length && timingSafeEqual(offered, wanted);
+}
+
+/**
+ * The same narrowing the desktop's deterministic path keeps: a finish is not
+ * an interruption, and a waiting session is one only when its provider said
+ * the turn holds for the developer. Everything else the phone's roster shows.
+ */
+export function watchAnnouncementChange(notice: SessionNotice): WatchChange | undefined {
+  if (notice.status === SESSION_NOTICE_STATUS.ERROR) return WATCH_CHANGE.FAILED;
+  if (notice.status === SESSION_NOTICE_STATUS.WAITING && notice.holdingForDeveloper === true) {
+    return WATCH_CHANGE.NEEDS_INPUT;
+  }
+  return undefined;
+}
+
+function flattened(value: string): string {
+  return value.replace(/\s+/g, " ").trim();
+}
+
+function alertLine(value: string): string | undefined {
+  return boundedText(flattened(value), MAXIMUM_ALERT_LINE_LENGTH);
+}
+
+/** The custom keys the phone reads on a tap, beside Apple's `aps`. */
+export const WATCH_PAYLOAD_KEY = {
+  PROVIDER_ID: "providerId",
+  SESSION_ID: "sessionId",
+  CHANGE: "change",
+} as const;
+
+/**
+ * The notification one notice earns, or none. Fields the provider wrote about
+ * the session and nothing else: the title as its alert, the workspace under
+ * it, and one line saying what it holds on or why it stopped.
+ */
+export function watchNotificationFor(
+  notice: SessionNotice,
+  device: WatchDevice,
+): ApnsNotification | undefined {
+  const change = watchAnnouncementChange(notice);
+  if (!change || !isPushEnvironment(device.environment)) return undefined;
+  const title = alertLine(notice.title) ?? notice.providerName;
+  const body =
+    change === WATCH_CHANGE.FAILED
+      ? (notice.error && alertLine(`Stopped: ${notice.error}`)) || "Stopped on an error."
+      : (notice.activity && alertLine(`Waiting on you: ${notice.activity}`)) || "Waiting on you.";
+  const collapseId = boundedText(notice.providerSessionId, MAXIMUM_COLLAPSE_ID_LENGTH);
+  const subtitle = notice.workspace ? alertLine(notice.workspace) : undefined;
+  const alert: ApnsAlert = {
+    title,
+    ...(subtitle && subtitle !== title ? { subtitle } : undefined),
+    body,
+  };
+  return {
+    token: device.token,
+    environment: device.environment,
+    payload: {
+      aps: {
+        alert,
+        sound: "default",
+        "interruption-level": APNS_INTERRUPTION_LEVEL.TIME_SENSITIVE,
+        ...(collapseId ? { "thread-id": collapseId } : undefined),
+      },
+      custom: {
+        [WATCH_PAYLOAD_KEY.PROVIDER_ID]: notice.providerId,
+        [WATCH_PAYLOAD_KEY.SESSION_ID]: notice.providerSessionId,
+        [WATCH_PAYLOAD_KEY.CHANGE]: change,
+      },
+    },
+    ...(collapseId ? { collapseId } : undefined),
+  };
+}
+
+interface AccountOutcome {
+  notices: number;
+  delivered: number;
+  retired: number;
+}
+
+async function watchAccount(
+  account: WatchedAccount,
+  options: WatchTickOptions,
+  sender: Pick<ApnsSender, "send">,
+  now: number,
+): Promise<AccountOutcome> {
+  const outcome: AccountOutcome = { notices: 0, delivered: 0, retired: 0 };
+  const devices = (await options.listDevices(account.userId)).filter((device) =>
+    isPushEnvironment(device.environment),
+  );
+  if (devices.length === 0) return outcome;
+
+  let observation: WatchObservation;
+  try {
+    observation = await options.observeSessions(account.userId);
+  } catch {
+    observation = { sessions: [], complete: false };
+  }
+  // A pass that could not read leaves the memory as it was; the next tick
+  // that can read either continues it or, past the gap, reseeds it.
+  if (!observation.complete) return outcome;
+  const { sessions } = observation;
+
+  const stale = account.passedAt !== undefined && now - account.passedAt > WATCH_TICK.GAP_MS;
+  const tracker = stale
+    ? new SessionNoticeTracker()
+    : SessionNoticeTracker.restore(
+        sessionNoticeMemoryFromWire(await options.readMemory(account.userId)),
+      );
+  const notices = tracker.notices(sessions, now);
+  // Written before anything is sent: a tick that dies mid-send misses a
+  // notification rather than repeating one, and the repeat window it just
+  // recorded is what keeps the next tick from saying it again.
+  await options.writeMemory(account.userId, tracker.snapshot(), now);
+
+  for (const notice of notices) {
+    const change = watchAnnouncementChange(notice);
+    if (!change) continue;
+    outcome.notices += 1;
+    for (const device of devices) {
+      const notification = watchNotificationFor(notice, device);
+      if (!notification) continue;
+      const delivery = await sender.send(notification);
+      if (delivery === APNS_DELIVERY.DELIVERED) outcome.delivered += 1;
+      if (delivery === APNS_DELIVERY.TOKEN_GONE) {
+        await options.retireDevice(device.token);
+        outcome.retired += 1;
+      }
+    }
+  }
+  return outcome;
+}
+
+export async function handleWatchTick(options: WatchTickOptions): Promise<Response> {
+  const { request } = options;
+  if (request.method !== "GET") {
+    return errorResponse(
+      HOSTED_HTTP_STATUS.METHOD_NOT_ALLOWED,
+      HOSTED_API_ERROR.METHOD_NOT_ALLOWED,
+    );
+  }
+
+  const secret = options.cronSecret?.trim();
+  if (!secret || !options.sender || !options.encryptionSecret?.trim()) {
+    return errorResponse(HOSTED_HTTP_STATUS.SERVICE_UNAVAILABLE, HOSTED_API_ERROR.UNAVAILABLE);
+  }
+  if (!bearerMatches(request, secret)) {
+    return errorResponse(HOSTED_HTTP_STATUS.UNAUTHORIZED, HOSTED_API_ERROR.INVALID_TOKEN);
+  }
+
+  const now = options.now ?? Date.now;
+  const startedAt = now();
+  const budgetMs = options.budgetMs ?? WATCH_TICK.BUDGET_MS;
+  const sender = options.sender;
+
+  await options.forgetIneligible();
+  const accounts = await options.listAccounts(WATCH_TICK.MAX_ACCOUNTS);
+
+  const answer: WatchTickAnswer = {
+    accounts: 0,
+    notices: 0,
+    delivered: 0,
+    retired: 0,
+    exhausted: false,
+  };
+  for (let index = 0; index < accounts.length; index += WATCH_TICK.CONCURRENCY) {
+    if (now() - startedAt >= budgetMs) {
+      answer.exhausted = true;
+      break;
+    }
+    const batch = accounts.slice(index, index + WATCH_TICK.CONCURRENCY);
+    const outcomes = await Promise.all(
+      batch.map((account) => watchAccount(account, options, sender, now())),
+    );
+    for (const outcome of outcomes) {
+      answer.accounts += 1;
+      answer.notices += outcome.notices;
+      answer.delivered += outcome.delivered;
+      answer.retired += outcome.retired;
+    }
+  }
+
+  return jsonResponse(HOSTED_HTTP_STATUS.OK, answer);
+}
+
+/**
+ * The production observation seam: the same cloud pass the on-demand endpoint
+ * runs, normalized into the sessions the tracker reads. An observation the
+ * normalizer refuses is dropped alone, never the pass.
+ */
+export function cloudSessionsObserver(input: {
+  readVaultKeys: (userId: string) => Promise<VaultKeyRow[]>;
+  encryptionSecret: string;
+  seams?: CloudObserveSeams;
+}): (userId: string) => Promise<WatchObservation> {
+  return async (userId) => {
+    const observed = await observeCloudProviders(
+      await input.readVaultKeys(userId),
+      input.encryptionSecret,
+      input.seams,
+    );
+    const sessions: Session[] = [];
+    let complete = true;
+    for (const { providerId, observations, failure } of observed) {
+      if (failure) complete = false;
+      const provider = PROVIDER_IDENTITY_BY_ID[providerId];
+      for (const observation of observations) {
+        try {
+          sessions.push(normalizeSession(provider, observation));
+        } catch {
+          // A malformed observation is the adapter's fault and its own row's loss.
+        }
+      }
+    }
+    return { sessions, complete };
+  };
+}

--- a/apps/web/tests/hosted-watch.test.ts
+++ b/apps/web/tests/hosted-watch.test.ts
@@ -1,0 +1,465 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { PUSH_ENVIRONMENT } from "@sidecar/hosted";
+import {
+  normalizeSession,
+  PROVIDER_IDENTITY_BY_ID,
+  type ProviderSessionObservation,
+  SESSION_STATUS,
+  type Session,
+  type SessionStatus,
+} from "@sidecar/session";
+import type { UnparsedWireValue } from "../server/core";
+import {
+  APNS_DELIVERY,
+  APNS_INTERRUPTION_LEVEL,
+  type ApnsDelivery,
+  type ApnsNotification,
+} from "../server/hosted/apns";
+import { HOSTED_API_ERROR } from "../server/hosted/http";
+import { type SessionNoticeMemory, SessionNoticeTracker } from "../server/hosted/notice-tracker";
+import {
+  handleWatchTick,
+  WATCH_CHANGE,
+  WATCH_PAYLOAD_KEY,
+  WATCH_TICK,
+  WATCH_TICK_PATH,
+  type WatchDevice,
+  type WatchedAccount,
+  type WatchObservation,
+  type WatchTickOptions,
+  watchNotificationFor,
+} from "../server/hosted/watch";
+
+function complete(sessions: readonly Session[]): () => Promise<WatchObservation> {
+  return async () => ({ sessions, complete: true });
+}
+
+import vercelConfig from "../vercel.json";
+
+const SECRET = "cron-secret-1";
+const NOW = 1_800_000_000_000;
+const TOKEN_A = "0a".repeat(32);
+const TOKEN_B = "0b".repeat(32);
+const conductor = PROVIDER_IDENTITY_BY_ID.conductor;
+
+function session(
+  providerSessionId: string,
+  status: SessionStatus,
+  overrides: {
+    title?: string;
+    workspace?: string;
+    activity?: string;
+    error?: string;
+    holdingForDeveloper?: boolean;
+  } = {},
+): Session {
+  const observation: ProviderSessionObservation = {
+    providerSessionId,
+    title: overrides.title ?? `Session ${providerSessionId}`,
+    status,
+    lastActivityAt: NOW - 1_000,
+    detail: {},
+  };
+  if (overrides.workspace) {
+    observation.workspace = { providerWorkspaceId: "ws-1", name: overrides.workspace };
+  }
+  if (overrides.holdingForDeveloper !== undefined) {
+    observation.holdingForDeveloper = overrides.holdingForDeveloper;
+  }
+  if (overrides.activity)
+    observation.detail = { ...observation.detail, activity: overrides.activity };
+  if (overrides.error) observation.detail = { ...observation.detail, error: overrides.error };
+  return normalizeSession(conductor, observation);
+}
+
+function tickRequest(headers: Record<string, string> = { authorization: `Bearer ${SECRET}` }) {
+  return new Request(`https://luke.test${WATCH_TICK_PATH}`, { method: "GET", headers });
+}
+
+interface Harness {
+  options: WatchTickOptions;
+  events: string[];
+  sent: ApnsNotification[];
+  memories: Map<string, { memory: SessionNoticeMemory; passedAt: number }>;
+  retired: string[];
+}
+
+function harness(input: {
+  accounts?: WatchedAccount[];
+  sessions?: Record<string, () => Promise<WatchObservation>>;
+  memory?: Record<string, UnparsedWireValue>;
+  devices?: Record<string, WatchDevice[]>;
+  delivery?: (notification: ApnsNotification) => ApnsDelivery;
+  now?: () => number;
+  budgetMs?: number;
+  overrides?: Partial<WatchTickOptions>;
+}): Harness {
+  const events: string[] = [];
+  const sent: ApnsNotification[] = [];
+  const memories = new Map<string, { memory: SessionNoticeMemory; passedAt: number }>();
+  const retired: string[] = [];
+  const options: WatchTickOptions = {
+    request: tickRequest(),
+    cronSecret: SECRET,
+    encryptionSecret: "a".repeat(64),
+    sender: {
+      async send(notification) {
+        events.push(`send:${notification.token}`);
+        sent.push(notification);
+        return input.delivery ? input.delivery(notification) : APNS_DELIVERY.DELIVERED;
+      },
+    },
+    listAccounts: async () => input.accounts ?? [{ userId: "user-1", passedAt: undefined }],
+    forgetIneligible: async () => {
+      events.push("forget");
+    },
+    observeSessions: async (userId) => {
+      events.push(`observe:${userId}`);
+      const found = input.sessions?.[userId];
+      return found ? found() : { sessions: [], complete: true };
+    },
+    readMemory: async (userId) => input.memory?.[userId],
+    writeMemory: async (userId, memory, passedAt) => {
+      events.push(`write:${userId}`);
+      memories.set(userId, { memory, passedAt });
+    },
+    listDevices: async (userId) =>
+      input.devices?.[userId] ?? [{ token: TOKEN_A, environment: PUSH_ENVIRONMENT.PRODUCTION }],
+    retireDevice: async (token) => {
+      retired.push(token);
+    },
+    now: input.now ?? (() => NOW),
+    ...(input.budgetMs !== undefined ? { budgetMs: input.budgetMs } : undefined),
+    ...input.overrides,
+  };
+  return { options, events, sent, memories, retired };
+}
+
+function memoryAfter(...passes: Array<readonly Session[]>): SessionNoticeMemory {
+  const tracker = new SessionNoticeTracker();
+  for (const [index, pass] of passes.entries())
+    tracker.notices(pass, NOW - (passes.length - index) * 60_000);
+  return tracker.snapshot();
+}
+
+test("the cron entry calls the tick path every minute inside a longer function cap", () => {
+  assert.deepEqual(vercelConfig.crons, [{ path: WATCH_TICK_PATH, schedule: "* * * * *" }]);
+  const cap = vercelConfig.functions["api/watch/tick.ts"].maxDuration * 1000;
+  assert.ok(cap > WATCH_TICK.BUDGET_MS);
+});
+
+test("the tick gate order is method, secrets and sender, bearer", async () => {
+  const wrongMethod = await handleWatchTick(
+    harness({
+      overrides: {
+        request: new Request(`https://luke.test${WATCH_TICK_PATH}`, { method: "POST" }),
+      },
+    }).options,
+  );
+  assert.equal(wrongMethod.status, 405);
+
+  const noSecret = await handleWatchTick(harness({ overrides: { cronSecret: undefined } }).options);
+  assert.equal(noSecret.status, 503);
+  assert.equal((await noSecret.json()).error, HOSTED_API_ERROR.UNAVAILABLE);
+
+  const blankSecret = await handleWatchTick(harness({ overrides: { cronSecret: "  " } }).options);
+  assert.equal(blankSecret.status, 503);
+
+  const noSender = await handleWatchTick(harness({ overrides: { sender: undefined } }).options);
+  assert.equal(noSender.status, 503);
+
+  const noVault = await handleWatchTick(
+    harness({ overrides: { encryptionSecret: undefined } }).options,
+  );
+  assert.equal(noVault.status, 503);
+  const blankVault = await handleWatchTick(
+    harness({ overrides: { encryptionSecret: " " } }).options,
+  );
+  assert.equal(blankVault.status, 503);
+
+  const wrongBearer = await handleWatchTick(
+    harness({ overrides: { request: tickRequest({ authorization: "Bearer other" }) } }).options,
+  );
+  assert.equal(wrongBearer.status, 401);
+  assert.equal((await wrongBearer.json()).error, HOSTED_API_ERROR.INVALID_TOKEN);
+
+  const noBearer = await handleWatchTick(
+    harness({ overrides: { request: tickRequest({}) } }).options,
+  );
+  assert.equal(noBearer.status, 401);
+});
+
+test("a tick with nobody to watch forgets the ineligible and answers zeros", async () => {
+  const { options, events } = harness({ accounts: [] });
+  const response = await handleWatchTick(options);
+  assert.equal(response.status, 200);
+  assert.deepEqual(await response.json(), {
+    accounts: 0,
+    notices: 0,
+    delivered: 0,
+    retired: 0,
+    exhausted: false,
+  });
+  assert.deepEqual(events, ["forget"]);
+});
+
+test("an account's first pass seeds its memory silently", async () => {
+  const sessions = [session("a", SESSION_STATUS.WAITING, { holdingForDeveloper: true })];
+  const { options, sent, memories } = harness({ sessions: { "user-1": complete(sessions) } });
+
+  const response = await handleWatchTick(options);
+
+  assert.deepEqual(await response.json(), {
+    accounts: 1,
+    notices: 0,
+    delivered: 0,
+    retired: 0,
+    exhausted: false,
+  });
+  assert.deepEqual(sent, []);
+  assert.deepEqual(memories.get("user-1"), { memory: memoryAfter(sessions), passedAt: NOW });
+});
+
+test("a session that starts holding for the developer reaches every phone, memory written first", async () => {
+  const before = [session("a", SESSION_STATUS.WORKING)];
+  const now = [
+    session("a", SESSION_STATUS.WAITING, {
+      title: "Fix the flaky test",
+      workspace: "luke",
+      holdingForDeveloper: true,
+      activity: "Run pnpm test",
+    }),
+  ];
+  const { options, sent, events, memories } = harness({
+    accounts: [{ userId: "user-1", passedAt: NOW - 60_000 }],
+    memory: { "user-1": JSON.parse(JSON.stringify(memoryAfter(before))) },
+    sessions: { "user-1": complete(now) },
+    devices: {
+      "user-1": [
+        { token: TOKEN_A, environment: PUSH_ENVIRONMENT.PRODUCTION },
+        { token: TOKEN_B, environment: PUSH_ENVIRONMENT.SANDBOX },
+      ],
+    },
+  });
+
+  const response = await handleWatchTick(options);
+
+  assert.deepEqual(await response.json(), {
+    accounts: 1,
+    notices: 1,
+    delivered: 2,
+    retired: 0,
+    exhausted: false,
+  });
+  assert.deepEqual(events, [
+    "forget",
+    "observe:user-1",
+    "write:user-1",
+    `send:${TOKEN_A}`,
+    `send:${TOKEN_B}`,
+  ]);
+  assert.equal(sent.length, 2);
+  assert.deepEqual(sent[0], {
+    token: TOKEN_A,
+    environment: PUSH_ENVIRONMENT.PRODUCTION,
+    collapseId: "a",
+    payload: {
+      aps: {
+        alert: {
+          title: "Fix the flaky test",
+          subtitle: "luke",
+          body: "Waiting on you: Run pnpm test",
+        },
+        sound: "default",
+        "interruption-level": APNS_INTERRUPTION_LEVEL.TIME_SENSITIVE,
+        "thread-id": "a",
+      },
+      custom: {
+        [WATCH_PAYLOAD_KEY.PROVIDER_ID]: "conductor",
+        [WATCH_PAYLOAD_KEY.SESSION_ID]: "a",
+        [WATCH_PAYLOAD_KEY.CHANGE]: WATCH_CHANGE.NEEDS_INPUT,
+      },
+    },
+  });
+  assert.equal(sent[1]?.environment, PUSH_ENVIRONMENT.SANDBOX);
+  const written = memories.get("user-1");
+  assert.ok(written);
+  assert.deepEqual(written.memory, [
+    {
+      providerId: "conductor",
+      providerSessionId: "a",
+      status: "waiting",
+      noticedAt: [{ status: "waiting", at: NOW }],
+    },
+  ]);
+});
+
+test("a session that stops on an error says so, and a finish or an unheld wait says nothing", async () => {
+  const before = [
+    session("stopped", SESSION_STATUS.WORKING),
+    session("finished", SESSION_STATUS.WORKING),
+    session("paused", SESSION_STATUS.WORKING),
+  ];
+  const now = [
+    session("stopped", SESSION_STATUS.ERROR, { error: "Rate   limit\nexceeded" }),
+    session("finished", SESSION_STATUS.COMPLETE),
+    session("paused", SESSION_STATUS.WAITING),
+  ];
+  const { options, sent } = harness({
+    accounts: [{ userId: "user-1", passedAt: NOW - 60_000 }],
+    memory: { "user-1": JSON.parse(JSON.stringify(memoryAfter(before))) },
+    sessions: { "user-1": complete(now) },
+  });
+
+  const response = await handleWatchTick(options);
+
+  assert.equal((await response.json()).notices, 1);
+  assert.equal(sent.length, 1);
+  assert.deepEqual(sent[0]?.payload.aps.alert, {
+    title: "Session stopped",
+    body: "Stopped: Rate limit exceeded",
+  });
+  assert.equal(sent[0]?.payload.custom[WATCH_PAYLOAD_KEY.CHANGE], WATCH_CHANGE.FAILED);
+});
+
+test("a token Apple reports gone is retired and the others still hear", async () => {
+  const before = [session("a", SESSION_STATUS.WORKING)];
+  const now = [session("a", SESSION_STATUS.ERROR)];
+  const { options, retired } = harness({
+    accounts: [{ userId: "user-1", passedAt: NOW - 60_000 }],
+    memory: { "user-1": JSON.parse(JSON.stringify(memoryAfter(before))) },
+    sessions: { "user-1": complete(now) },
+    devices: {
+      "user-1": [
+        { token: TOKEN_A, environment: PUSH_ENVIRONMENT.PRODUCTION },
+        { token: TOKEN_B, environment: PUSH_ENVIRONMENT.PRODUCTION },
+      ],
+    },
+    delivery: (notification) =>
+      notification.token === TOKEN_A ? APNS_DELIVERY.TOKEN_GONE : APNS_DELIVERY.DELIVERED,
+  });
+
+  const response = await handleWatchTick(options);
+
+  assert.deepEqual(await response.json(), {
+    accounts: 1,
+    notices: 1,
+    delivered: 1,
+    retired: 1,
+    exhausted: false,
+  });
+  assert.deepEqual(retired, [TOKEN_A]);
+});
+
+test("a pass long after the last reseeds instead of announcing the gap", async () => {
+  const before = [session("a", SESSION_STATUS.WORKING)];
+  const now = [session("a", SESSION_STATUS.ERROR)];
+  const { options, sent, memories } = harness({
+    accounts: [{ userId: "user-1", passedAt: NOW - WATCH_TICK.GAP_MS - 1 }],
+    memory: { "user-1": JSON.parse(JSON.stringify(memoryAfter(before))) },
+    sessions: { "user-1": complete(now) },
+  });
+
+  await handleWatchTick(options);
+
+  assert.deepEqual(sent, []);
+  assert.deepEqual(memories.get("user-1")?.memory, memoryAfter(now));
+
+  const inside = harness({
+    accounts: [{ userId: "user-1", passedAt: NOW - WATCH_TICK.GAP_MS }],
+    memory: { "user-1": JSON.parse(JSON.stringify(memoryAfter(before))) },
+    sessions: { "user-1": complete(now) },
+  });
+  await handleWatchTick(inside.options);
+  assert.equal(inside.sent.length, 1);
+});
+
+test("an account whose observation fails or is incomplete keeps its memory and its turn", async () => {
+  const before = memoryAfter([session("a", SESSION_STATUS.WORKING)]);
+  const unreadable: Array<() => Promise<WatchObservation>> = [
+    async () => {
+      throw new Error("provider down");
+    },
+    // The adapter's own answer to a refused or unanswered pass: its previous
+    // snapshot, which for a pass built fresh is nothing at all.
+    async () => ({ sessions: [], complete: false }),
+    async () => ({ sessions: [session("a", SESSION_STATUS.ERROR)], complete: false }),
+  ];
+  for (const observe of unreadable) {
+    const { options, sent, memories, events } = harness({
+      accounts: [{ userId: "user-1", passedAt: NOW - 60_000 }],
+      memory: { "user-1": JSON.parse(JSON.stringify(before)) },
+      sessions: { "user-1": observe },
+    });
+
+    const response = await handleWatchTick(options);
+
+    assert.equal(response.status, 200);
+    assert.deepEqual(sent, []);
+    assert.equal(memories.has("user-1"), false);
+    assert.deepEqual(events, ["forget", "observe:user-1"]);
+  }
+});
+
+test("an account with no usable phone is not observed at all", async () => {
+  const { options, events } = harness({
+    sessions: { "user-1": complete([session("a", SESSION_STATUS.WORKING)]) },
+    devices: { "user-1": [{ token: TOKEN_A, environment: "staging" }] },
+  });
+  await handleWatchTick(options);
+  assert.deepEqual(events, ["forget"]);
+});
+
+test("a tick stops on its budget and says so, leaving the rest for the next", async () => {
+  let clock = NOW;
+  const accounts = Array.from({ length: WATCH_TICK.CONCURRENCY * 3 }, (_, index) => ({
+    userId: `user-${index}`,
+    passedAt: undefined,
+  }));
+  const { options, events } = harness({
+    accounts,
+    now: () => clock,
+    budgetMs: 1_000,
+    overrides: {
+      observeSessions: async (userId) => {
+        events.push(`observe:${userId}`);
+        clock += 300;
+        return { sessions: [], complete: true };
+      },
+    },
+  });
+
+  const response = await handleWatchTick(options);
+  const answer = await response.json();
+
+  assert.equal(answer.exhausted, true);
+  assert.equal(answer.accounts, WATCH_TICK.CONCURRENCY);
+  assert.equal(
+    events.filter((event) => event.startsWith("observe:")).length,
+    WATCH_TICK.CONCURRENCY,
+  );
+});
+
+test("a notification is composed only for a notice the phone should hear", () => {
+  const device: WatchDevice = { token: TOKEN_A, environment: PUSH_ENVIRONMENT.PRODUCTION };
+  const tracker = new SessionNoticeTracker();
+  tracker.notices(
+    [session("held", SESSION_STATUS.WORKING), session("done", SESSION_STATUS.WORKING)],
+    NOW - 60_000,
+  );
+  const notices = tracker.notices(
+    [
+      session("held", SESSION_STATUS.WAITING, { holdingForDeveloper: true, title: "  " }),
+      session("done", SESSION_STATUS.COMPLETE),
+    ],
+    NOW,
+  );
+  const [held, done] = notices;
+  assert.ok(held && done);
+  assert.equal(watchNotificationFor(done, device), undefined);
+  assert.equal(watchNotificationFor(held, { ...device, environment: "staging" }), undefined);
+  const composed = watchNotificationFor(held, device);
+  assert.ok(composed);
+  assert.equal(composed.payload.aps.alert.body, "Waiting on you.");
+});

--- a/apps/web/tests/notice-tracker.test.ts
+++ b/apps/web/tests/notice-tracker.test.ts
@@ -1,0 +1,591 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  normalizeSession,
+  type ProviderSessionObservation,
+  SESSION_COMPLETION_CAUSE,
+  SESSION_STATUS,
+  type Session,
+  type SessionProvider,
+  type SessionStatus,
+} from "@sidecar/session";
+import {
+  MAXIMUM_NOTICES_PER_PASS,
+  SESSION_NOTICE_REPEAT_WINDOW_MS,
+  SESSION_NOTICE_STATUS,
+  SessionNoticeTracker,
+  sessionNoticeMemoryFromWire,
+} from "../server/hosted/notice-tracker";
+
+const claude: SessionProvider = { id: "claude-code", displayName: "Claude Code" };
+const conductor: SessionProvider = { id: "conductor", displayName: "Conductor" };
+
+function session(
+  provider: SessionProvider,
+  providerSessionId: string,
+  status: SessionStatus,
+  overrides: {
+    activity?: string;
+    error?: string;
+    repository?: string;
+    branch?: string;
+    lastActivityAt?: number;
+    workspace?: string;
+    canReceiveMessage?: boolean;
+    holdingForDeveloper?: boolean;
+    realtimeVoiceLive?: boolean;
+    completionCause?: (typeof SESSION_COMPLETION_CAUSE)[keyof typeof SESSION_COMPLETION_CAUSE];
+  } = {},
+): Session {
+  const observation: ProviderSessionObservation = {
+    providerSessionId,
+    title: `Session ${providerSessionId}`,
+    status,
+    lastActivityAt: overrides.lastActivityAt ?? 100,
+    detail: {},
+  };
+  if (overrides.completionCause) observation.completionCause = overrides.completionCause;
+  if (overrides.workspace) {
+    observation.workspace = { providerWorkspaceId: "ws-1", name: overrides.workspace };
+  }
+  if (overrides.canReceiveMessage !== undefined) {
+    observation.canReceiveMessage = overrides.canReceiveMessage;
+  }
+  if (overrides.holdingForDeveloper !== undefined) {
+    observation.holdingForDeveloper = overrides.holdingForDeveloper;
+  }
+  if (overrides.realtimeVoiceLive !== undefined) {
+    observation.realtimeVoiceLive = overrides.realtimeVoiceLive;
+  }
+  if (overrides.activity || overrides.error || overrides.repository || overrides.branch) {
+    const detail = observation.detail ?? {};
+    if (overrides.activity) detail.activity = overrides.activity;
+    if (overrides.error) detail.error = overrides.error;
+    if (overrides.repository) detail.repository = overrides.repository;
+    if (overrides.branch) detail.branch = overrides.branch;
+    observation.detail = detail;
+  }
+  return normalizeSession(provider, observation);
+}
+
+test("a session under a live voice conversation announces nothing while it holds", () => {
+  const tracker = new SessionNoticeTracker();
+  tracker.notices(
+    [session(claude, "spoken", SESSION_STATUS.WORKING, { realtimeVoiceLive: true })],
+    1_000,
+  );
+
+  // Each delegated turn settling would otherwise be a waiting banner, and a
+  // failed one an error banner, spoken over the very conversation they belong to.
+  assert.deepEqual(
+    tracker.notices(
+      [session(claude, "spoken", SESSION_STATUS.WAITING, { realtimeVoiceLive: true })],
+      2_000,
+    ),
+    [],
+  );
+  assert.deepEqual(
+    tracker.notices(
+      [
+        session(claude, "spoken", SESSION_STATUS.ERROR, {
+          realtimeVoiceLive: true,
+          error: "sandbox denied",
+        }),
+      ],
+      3_000,
+    ),
+    [],
+  );
+});
+
+test("the voice conversation ending never replays the edges it covered", () => {
+  const tracker = new SessionNoticeTracker();
+  tracker.notices(
+    [session(claude, "spoken", SESSION_STATUS.WORKING, { realtimeVoiceLive: true })],
+    1_000,
+  );
+  tracker.notices(
+    [session(claude, "spoken", SESSION_STATUS.WAITING, { realtimeVoiceLive: true })],
+    2_000,
+  );
+
+  // The conversation closed with the session still waiting: nothing moved, so
+  // there is no news to read out after the fact.
+  assert.deepEqual(tracker.notices([session(claude, "spoken", SESSION_STATUS.WAITING)], 3_000), []);
+
+  // A fresh edge after the conversation speaks like any other session's.
+  tracker.notices([session(claude, "spoken", SESSION_STATUS.WORKING)], 4_000);
+  const notices = tracker.notices([session(claude, "spoken", SESSION_STATUS.COMPLETE)], 5_000);
+  assert.deepEqual(
+    notices.map((notice) => [notice.providerSessionId, notice.status]),
+    [["spoken", SESSION_NOTICE_STATUS.COMPLETE]],
+  );
+});
+
+test("first sight seeds silently, and only a change of status is news", () => {
+  const tracker = new SessionNoticeTracker();
+
+  // A session already waiting at launch is the panel's to show, not a banner's.
+  assert.deepEqual(tracker.notices([session(claude, "a", SESSION_STATUS.WAITING)], 1_000), []);
+  // Nothing moved, nothing said.
+  assert.deepEqual(tracker.notices([session(claude, "a", SESSION_STATUS.WAITING)], 2_000), []);
+
+  const notices = tracker.notices([session(claude, "a", SESSION_STATUS.COMPLETE)], 3_000);
+  assert.equal(notices.length, 1);
+  assert.deepEqual(notices[0], {
+    providerId: claude.id,
+    providerSessionId: "a",
+    providerName: claude.displayName,
+    title: "Session a",
+    status: SESSION_NOTICE_STATUS.COMPLETE,
+    previousStatus: SESSION_STATUS.WAITING,
+    canReceiveMessage: false,
+    lastActivityAt: 100,
+  });
+});
+
+test("every notice-worthy arrival is one, and the quiet statuses are not", () => {
+  const tracker = new SessionNoticeTracker();
+  tracker.notices(
+    [
+      session(claude, "waits", SESSION_STATUS.WORKING),
+      session(claude, "stops", SESSION_STATUS.WORKING),
+      session(claude, "finishes", SESSION_STATUS.WORKING),
+      session(claude, "fades", SESSION_STATUS.WORKING),
+    ],
+    1_000,
+  );
+
+  const notices = tracker.notices(
+    [
+      session(claude, "waits", SESSION_STATUS.WAITING, { holdingForDeveloper: true }),
+      session(claude, "stops", SESSION_STATUS.ERROR, { error: "API rate limit" }),
+      session(claude, "finishes", SESSION_STATUS.COMPLETE),
+      // An adapter losing sight of a session is not the session asking for a hand.
+      session(claude, "fades", SESSION_STATUS.UNKNOWN),
+    ],
+    2_000,
+  );
+
+  assert.deepEqual(
+    notices.map((notice) => [notice.providerSessionId, notice.status]),
+    [
+      ["waits", SESSION_NOTICE_STATUS.WAITING],
+      ["stops", SESSION_NOTICE_STATUS.ERROR],
+      ["finishes", SESSION_NOTICE_STATUS.COMPLETE],
+    ],
+  );
+  assert.equal(notices[1]?.error, "API rate limit");
+});
+
+test("closing a session is tracked as complete without producing a notice", () => {
+  const tracker = new SessionNoticeTracker();
+  tracker.notices([session(claude, "closed", SESSION_STATUS.WAITING)], 1_000);
+
+  assert.deepEqual(
+    tracker.notices(
+      [
+        session(claude, "closed", SESSION_STATUS.COMPLETE, {
+          completionCause: SESSION_COMPLETION_CAUSE.SESSION_CLOSED,
+        }),
+      ],
+      2_000,
+    ),
+    [],
+  );
+  assert.deepEqual(
+    tracker.notices(
+      [
+        session(claude, "closed", SESSION_STATUS.COMPLETE, {
+          completionCause: SESSION_COMPLETION_CAUSE.SESSION_CLOSED,
+        }),
+      ],
+      3_000,
+    ),
+    [],
+  );
+});
+
+test("finishing work still produces a completion notice", () => {
+  const tracker = new SessionNoticeTracker();
+  tracker.notices([session(claude, "finished", SESSION_STATUS.WORKING)], 1_000);
+
+  const notices = tracker.notices(
+    [
+      session(claude, "finished", SESSION_STATUS.COMPLETE, {
+        completionCause: SESSION_COMPLETION_CAUSE.WORK_FINISHED,
+      }),
+    ],
+    2_000,
+  );
+
+  assert.equal(notices.length, 1);
+  assert.equal(notices[0]?.status, SESSION_NOTICE_STATUS.COMPLETE);
+});
+
+test("the provider's own context rides the notice", () => {
+  const tracker = new SessionNoticeTracker();
+  tracker.notices([session(conductor, "ctx", SESSION_STATUS.WORKING)], 1_000);
+
+  const notices = tracker.notices(
+    [session(conductor, "ctx", SESSION_STATUS.COMPLETE, { repository: "luke", branch: "algiers" })],
+    2_000,
+  );
+
+  assert.equal(notices[0]?.repository, "luke");
+  assert.equal(notices[0]?.branch, "algiers");
+});
+
+test("the workspace and reply-ability ride a waiting notice", () => {
+  const tracker = new SessionNoticeTracker();
+  tracker.notices([session(conductor, "asks", SESSION_STATUS.WORKING)], 1_000);
+
+  const notices = tracker.notices(
+    [
+      session(conductor, "asks", SESSION_STATUS.WAITING, {
+        workspace: "Albany",
+        canReceiveMessage: true,
+      }),
+    ],
+    2_000,
+  );
+
+  assert.equal(notices[0]?.workspace, "Albany");
+  assert.equal(notices[0]?.canReceiveMessage, true);
+});
+
+test("a waiting session whose adapter reported no hold claims no developer", () => {
+  const tracker = new SessionNoticeTracker();
+  tracker.notices([session(conductor, "idle", SESSION_STATUS.WORKING)], 1_000);
+
+  // Conductor reports idle and nothing about why, so the notice is the
+  // panel's to show and never a hold: only the adapter's own word makes one.
+  const notices = tracker.notices(
+    [
+      session(conductor, "idle", SESSION_STATUS.WAITING, {
+        canReceiveMessage: true,
+      }),
+    ],
+    2_000,
+  );
+
+  assert.equal(notices.length, 1);
+  assert.equal(notices[0]?.status, SESSION_NOTICE_STATUS.WAITING);
+  assert.equal(notices[0]?.holdingForDeveloper, false);
+});
+
+test("a permission hold is a waiting notice on the adapter's word", () => {
+  const tracker = new SessionNoticeTracker();
+  tracker.notices([session(claude, "held", SESSION_STATUS.WORKING)], 1_000);
+
+  const notices = tracker.notices(
+    [
+      session(claude, "held", SESSION_STATUS.WAITING, {
+        activity: "Bash: pnpm test",
+        holdingForDeveloper: true,
+      }),
+    ],
+    2_000,
+  );
+
+  assert.equal(notices.length, 1);
+  assert.equal(notices[0]?.status, SESSION_NOTICE_STATUS.WAITING);
+  assert.equal(notices[0]?.activity, "Bash: pnpm test");
+});
+
+test("a flapping status is noticed once per repeat window, then again after it", () => {
+  const tracker = new SessionNoticeTracker();
+  tracker.notices([session(claude, "flap", SESSION_STATUS.WORKING)], 0);
+
+  assert.equal(
+    tracker.notices(
+      [session(claude, "flap", SESSION_STATUS.WAITING, { holdingForDeveloper: true })],
+      1_000,
+    ).length,
+    1,
+  );
+  tracker.notices([session(claude, "flap", SESSION_STATUS.WORKING)], 2_000);
+  // The same edge inside the window stays quiet.
+  assert.equal(
+    tracker.notices(
+      [session(claude, "flap", SESSION_STATUS.WAITING, { holdingForDeveloper: true })],
+      3_000,
+    ).length,
+    0,
+  );
+  tracker.notices([session(claude, "flap", SESSION_STATUS.WORKING)], 4_000);
+  // A different status is its own ledger entry.
+  assert.equal(tracker.notices([session(claude, "flap", SESSION_STATUS.ERROR)], 5_000).length, 1);
+  tracker.notices([session(claude, "flap", SESSION_STATUS.WORKING)], 6_000);
+  // And past the window the same status may speak again — the ask is fresh,
+  // not a stale reading resurfacing.
+  assert.equal(
+    tracker.notices(
+      [
+        session(claude, "flap", SESSION_STATUS.WAITING, {
+          holdingForDeveloper: true,
+          lastActivityAt: 1_000 + SESSION_NOTICE_REPEAT_WINDOW_MS,
+        }),
+      ],
+      1_000 + SESSION_NOTICE_REPEAT_WINDOW_MS,
+    ).length,
+    1,
+  );
+});
+
+test("an edge is announced however old its timestamp, and only once", () => {
+  const tracker = new SessionNoticeTracker();
+  const slept = 4 * 60 * 60 * 1_000;
+  tracker.notices([session(claude, "asleep", SESSION_STATUS.WORKING)], 1_000);
+
+  // The Mac slept for hours and the session's file was last written two hours
+  // ago. The timestamp says when the provider last wrote, not when the status
+  // was entered, so it cannot tell late history from a finish that just landed:
+  // the edge seen while watched is the news, and it speaks.
+  const notices = tracker.notices(
+    [
+      session(claude, "asleep", SESSION_STATUS.COMPLETE, {
+        lastActivityAt: 1_000 + slept - 2 * 60 * 60 * 1_000,
+      }),
+    ],
+    1_000 + slept,
+  );
+  assert.deepEqual(
+    notices.map((notice) => [notice.providerSessionId, notice.status]),
+    [["asleep", SESSION_NOTICE_STATUS.COMPLETE]],
+  );
+  // The unchanged status is no edge, so the same finish never speaks again.
+  assert.deepEqual(
+    tracker.notices(
+      [
+        session(claude, "asleep", SESSION_STATUS.COMPLETE, {
+          lastActivityAt: 1_000 + slept - 2 * 60 * 60 * 1_000,
+        }),
+      ],
+      2_000 + slept,
+    ),
+    [],
+  );
+});
+
+test("first sight of an old settled session is still not an edge", () => {
+  const tracker = new SessionNoticeTracker();
+  const now = 30 * 60 * 60 * 1_000;
+
+  // A launch reads yesterday's roster: every session is seen for the first
+  // time, so nothing is news, whatever its timestamp says.
+  assert.deepEqual(
+    tracker.notices(
+      [
+        session(claude, "yesterday", SESSION_STATUS.COMPLETE, {
+          lastActivityAt: now - 20 * 60 * 60 * 1_000,
+        }),
+        session(claude, "earlier", SESSION_STATUS.WAITING, {
+          lastActivityAt: now - 60 * 1_000,
+        }),
+      ],
+      now,
+    ),
+    [],
+  );
+});
+
+test("a session that leaves the roster is forgotten, and its return seeds again", () => {
+  const tracker = new SessionNoticeTracker();
+  tracker.notices([session(claude, "gone", SESSION_STATUS.WORKING)], 1_000);
+  tracker.notices([], 2_000);
+
+  // Returning already complete is a first sight, not an edge.
+  assert.deepEqual(tracker.notices([session(claude, "gone", SESSION_STATUS.COMPLETE)], 3_000), []);
+});
+
+test("two providers' identical session ids never collide", () => {
+  const tracker = new SessionNoticeTracker();
+  tracker.notices(
+    [
+      session(claude, "same", SESSION_STATUS.WORKING),
+      session(conductor, "same", SESSION_STATUS.WAITING),
+    ],
+    1_000,
+  );
+
+  const notices = tracker.notices(
+    [
+      session(claude, "same", SESSION_STATUS.COMPLETE),
+      session(conductor, "same", SESSION_STATUS.WAITING),
+    ],
+    2_000,
+  );
+
+  assert.deepEqual(
+    notices.map((notice) => [notice.providerId, notice.status]),
+    [[claude.id, SESSION_NOTICE_STATUS.COMPLETE]],
+  );
+});
+
+test("a burst is trimmed to the cap with the most urgent notices kept", () => {
+  const tracker = new SessionNoticeTracker();
+  const count = MAXIMUM_NOTICES_PER_PASS + 3;
+  const ids = Array.from({ length: count }, (_, index) => `burst-${index}`);
+  tracker.notices(
+    ids.map((id) => session(claude, id, SESSION_STATUS.WORKING)),
+    1_000,
+  );
+
+  // The completions come first in roster order, so a naive cut would keep
+  // finishes and drop the one session that stopped on an error.
+  const notices = tracker.notices(
+    ids.map((id, index) =>
+      session(claude, id, index === count - 1 ? SESSION_STATUS.ERROR : SESSION_STATUS.COMPLETE),
+    ),
+    2_000,
+  );
+
+  assert.equal(notices.length, MAXIMUM_NOTICES_PER_PASS);
+  assert.equal(notices[0]?.status, SESSION_NOTICE_STATUS.ERROR);
+  // The remaining slots keep the earliest completions in their own order.
+  assert.deepEqual(
+    notices.slice(1).map((notice) => notice.providerSessionId),
+    ids.slice(0, MAXIMUM_NOTICES_PER_PASS - 1),
+  );
+});
+
+test("a fresh tracker's snapshot is empty, and a pass fills it with status alone", () => {
+  const tracker = new SessionNoticeTracker();
+  assert.deepEqual(tracker.snapshot(), []);
+
+  tracker.notices(
+    [session(claude, "a", SESSION_STATUS.WORKING), session(conductor, "b", SESSION_STATUS.WAITING)],
+    1_000,
+  );
+
+  assert.deepEqual(tracker.snapshot(), [
+    { providerId: "claude-code", providerSessionId: "a", status: "working", noticedAt: [] },
+    { providerId: "conductor", providerSessionId: "b", status: "waiting", noticedAt: [] },
+  ]);
+});
+
+test("a snapshot records when each notice was spoken, and nothing a session said", () => {
+  const tracker = new SessionNoticeTracker();
+  tracker.notices([session(claude, "a", SESSION_STATUS.WORKING)], 1_000);
+  tracker.notices(
+    [session(claude, "a", SESSION_STATUS.WAITING, { activity: "Edit file", error: "boom" })],
+    2_000,
+  );
+
+  assert.deepEqual(tracker.snapshot(), [
+    {
+      providerId: "claude-code",
+      providerSessionId: "a",
+      status: "waiting",
+      noticedAt: [{ status: "waiting", at: 2_000 }],
+    },
+  ]);
+});
+
+test("a restored tracker diffs against the memory rather than seeding afresh", () => {
+  const before = new SessionNoticeTracker();
+  before.notices([session(claude, "a", SESSION_STATUS.WORKING)], 1_000);
+
+  const after = SessionNoticeTracker.restore(before.snapshot());
+  const notices = after.notices([session(claude, "a", SESSION_STATUS.COMPLETE)], 2_000);
+
+  assert.equal(notices.length, 1);
+  assert.equal(notices[0]?.status, SESSION_NOTICE_STATUS.COMPLETE);
+  assert.equal(notices[0]?.previousStatus, SESSION_STATUS.WORKING);
+});
+
+test("a restored tracker never replays a status the memory already held", () => {
+  const before = new SessionNoticeTracker();
+  before.notices([session(claude, "a", SESSION_STATUS.WAITING)], 1_000);
+
+  const after = SessionNoticeTracker.restore(before.snapshot());
+  assert.deepEqual(after.notices([session(claude, "a", SESSION_STATUS.WAITING)], 2_000), []);
+});
+
+test("the repeat window survives a restore", () => {
+  const before = new SessionNoticeTracker();
+  before.notices([session(claude, "a", SESSION_STATUS.WORKING)], 1_000);
+  assert.equal(before.notices([session(claude, "a", SESSION_STATUS.ERROR)], 2_000).length, 1);
+
+  const after = SessionNoticeTracker.restore(before.snapshot());
+  const inside = 2_000 + SESSION_NOTICE_REPEAT_WINDOW_MS - 1;
+  after.notices([session(claude, "a", SESSION_STATUS.WORKING)], inside);
+  assert.deepEqual(after.notices([session(claude, "a", SESSION_STATUS.ERROR)], inside), []);
+
+  const outside = 2_000 + SESSION_NOTICE_REPEAT_WINDOW_MS;
+  after.notices([session(claude, "a", SESSION_STATUS.WORKING)], outside);
+  assert.equal(after.notices([session(claude, "a", SESSION_STATUS.ERROR)], outside).length, 1);
+});
+
+test("a memory round-trips through JSON and the wire reader unchanged", () => {
+  const tracker = new SessionNoticeTracker();
+  tracker.notices(
+    [session(claude, "a", SESSION_STATUS.WORKING), session(conductor, "a", SESSION_STATUS.WORKING)],
+    1_000,
+  );
+  tracker.notices(
+    [session(claude, "a", SESSION_STATUS.ERROR), session(conductor, "a", SESSION_STATUS.WAITING)],
+    2_000,
+  );
+
+  const memory = tracker.snapshot();
+  const restored = sessionNoticeMemoryFromWire(JSON.parse(JSON.stringify(memory)));
+  assert.deepEqual(restored, memory);
+  assert.deepEqual(SessionNoticeTracker.restore(restored).snapshot(), memory);
+});
+
+test("the wire reader drops what it cannot place and keeps the rest", () => {
+  const memory = sessionNoticeMemoryFromWire([
+    { providerId: "claude-code", providerSessionId: "a", status: "working", noticedAt: [] },
+    { providerId: "claude-code", providerSessionId: "b", status: "paused", noticedAt: [] },
+    { providerId: "claude-code", providerSessionId: 3, status: "working", noticedAt: [] },
+    { providerId: "", providerSessionId: "d", status: "working", noticedAt: [] },
+    "not a record",
+    {
+      providerId: "conductor",
+      providerSessionId: "e",
+      status: "error",
+      noticedAt: [
+        { status: "error", at: 5_000 },
+        { status: "working", at: 1 },
+        { status: "waiting", at: "soon" },
+        { status: "complete", at: Number.NaN },
+        "later",
+      ],
+    },
+    { providerId: "conductor", providerSessionId: "f", status: "complete", noticedAt: "never" },
+  ]);
+
+  assert.deepEqual(memory, [
+    { providerId: "claude-code", providerSessionId: "a", status: "working", noticedAt: [] },
+    {
+      providerId: "conductor",
+      providerSessionId: "e",
+      status: "error",
+      noticedAt: [{ status: "error", at: 5_000 }],
+    },
+    { providerId: "conductor", providerSessionId: "f", status: "complete", noticedAt: [] },
+  ]);
+  assert.deepEqual(sessionNoticeMemoryFromWire({ providerId: "claude-code" }), []);
+  assert.deepEqual(sessionNoticeMemoryFromWire(undefined), []);
+});
+
+test("a memory naming one session twice keeps the later record", () => {
+  const tracker = SessionNoticeTracker.restore([
+    {
+      providerId: "claude-code",
+      providerSessionId: "a",
+      status: SESSION_STATUS.WORKING,
+      noticedAt: [],
+    },
+    {
+      providerId: "claude-code",
+      providerSessionId: "a",
+      status: SESSION_STATUS.WAITING,
+      noticedAt: [],
+    },
+  ]);
+
+  assert.deepEqual(tracker.notices([session(claude, "a", SESSION_STATUS.WAITING)], 2_000), []);
+});

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -1,7 +1,9 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "buildCommand": "pnpm db:migrate && pnpm auth:seed && pnpm build",
+  "crons": [{ "path": "/api/watch/tick", "schedule": "* * * * *" }],
   "functions": {
+    "api/watch/tick.ts": { "maxDuration": 60 },
     "api/brain/respond.ts": { "maxDuration": 120 },
     "api/brain/v2/respond.ts": { "maxDuration": 120 },
     "api/brain/v2/compact.ts": { "maxDuration": 120 },

--- a/packages/providers/src/shared/cloud-session-adapter.test.ts
+++ b/packages/providers/src/shared/cloud-session-adapter.test.ts
@@ -14,6 +14,7 @@ import { HTTP_STATUS, jsonResponse, recordingFetch } from "@sidecar/wire/testing
 import { ADAPTER_DIAGNOSTIC_KIND, type AdapterDiagnosticCallback } from "./adapter-diagnostics.js";
 import {
   CLOUD_ADAPTER_DEFAULTS,
+  CLOUD_FAILURE,
   type CloudAdapterOptions,
   type CloudFetch,
   type CloudRequest,
@@ -719,4 +720,39 @@ test("runs an advertised control through its documented route, sending no body",
     reason: "That act is not supported by the latest observation.",
   });
   assert.equal(stub.requests.length, observationRequests + 1);
+});
+
+test("names why the latest pass could not read, and clears it once one can", async () => {
+  let status: number = HTTP_STATUS.OK;
+  const stub = stubFetch(() => status);
+  const adapter = adapterFor(stub.fetch);
+  adapter.collected = [observation("session-one")];
+
+  await adapter.observe();
+  assert.equal(adapter.lastObserveFailure(), undefined);
+
+  status = HTTP_STATUS.SERVER_ERROR;
+  assert.equal((await adapter.observe()).length, 1);
+  assert.equal(adapter.lastObserveFailure(), CLOUD_FAILURE.TRANSIENT);
+
+  status = HTTP_STATUS.UNAUTHORIZED;
+  assert.deepEqual(await adapter.observe(), []);
+  assert.equal(adapter.lastObserveFailure(), CLOUD_FAILURE.UNAUTHORIZED);
+
+  status = HTTP_STATUS.OK;
+  assert.equal((await adapter.observe()).length, 1);
+  assert.equal(adapter.lastObserveFailure(), undefined);
+});
+
+test("a pass built fresh answers nothing to a refusal, and says so", async () => {
+  const stub = stubFetch(() => HTTP_STATUS.SERVER_ERROR);
+  const adapter = adapterFor(stub.fetch);
+  adapter.collected = [observation("session-one")];
+
+  assert.deepEqual(await adapter.observe(), []);
+  assert.equal(adapter.lastObserveFailure(), CLOUD_FAILURE.TRANSIENT);
+
+  const keyless = adapterFor(stub.fetch, { apiKey: undefined });
+  assert.deepEqual(await keyless.observe(), []);
+  assert.equal(keyless.lastObserveFailure(), undefined);
 });

--- a/packages/providers/src/shared/cloud-session-adapter.ts
+++ b/packages/providers/src/shared/cloud-session-adapter.ts
@@ -301,6 +301,7 @@ export abstract class CloudSessionAdapter extends SessionProviderAdapterBase {
   #observations: readonly ProviderSessionObservation[] = [];
   #lastAttemptAt = Number.NEGATIVE_INFINITY;
   #collectPass = 0;
+  #lastObserveFailure: CloudFailure | undefined;
 
   constructor(profile: CloudAdapterProfile, options: CloudAdapterOptions) {
     super();
@@ -327,6 +328,7 @@ export abstract class CloudSessionAdapter extends SessionProviderAdapterBase {
     if (!apiKey) {
       this.#credential = undefined;
       this.#forgetObservedState();
+      this.#lastObserveFailure = undefined;
       return this.#observations;
     }
 
@@ -348,7 +350,10 @@ export abstract class CloudSessionAdapter extends SessionProviderAdapterBase {
     const pass = ++this.#collectPass;
     try {
       const collected = await this.collect(this.#requestForPass(pass, apiKey), now);
-      if (pass === this.#collectPass) this.#observations = cloudObservations(collected);
+      if (pass === this.#collectPass) {
+        this.#observations = cloudObservations(collected);
+        this.#lastObserveFailure = undefined;
+      }
     } catch (error) {
       // A rejected credential clears observed state; a transient network or
       // server failure keeps the previous snapshot until the next attempt. A
@@ -359,8 +364,10 @@ export abstract class CloudSessionAdapter extends SessionProviderAdapterBase {
       }
       if (error instanceof CloudRequestError) {
         if (error.failure === CLOUD_FAILURE.UNAUTHORIZED) this.#forgetObservedState();
+        this.#lastObserveFailure = error.failure;
         return this.#observations;
       }
+      this.#lastObserveFailure = CLOUD_FAILURE.TRANSIENT;
       // Anything else is a bug in this pass — a TypeError thrown by a
       // subclass's parsing is not a network blip, and must not keep serving
       // the stale snapshot with no log, counter, or hook.
@@ -377,6 +384,16 @@ export abstract class CloudSessionAdapter extends SessionProviderAdapterBase {
    * A subclass's way onto the same diagnostic channel, for a problem worth
    * surfacing from a pass that otherwise succeeded.
    */
+  /**
+   * Why the latest pass could not read, or undefined when it read (or had no
+   * key to read with, which is an honest nothing rather than a failure). The
+   * pass itself answers with the previous snapshot either way, so a caller
+   * that must tell an empty roster from an unreadable one asks here.
+   */
+  lastObserveFailure(): CloudFailure | undefined {
+    return this.#lastObserveFailure;
+  }
+
   protected reportDiagnostic(kind: AdapterDiagnosticKind, error: Error): void {
     this.#onDiagnostic?.(kind, error);
   }


### PR DESCRIPTION
## Summary

Step 3 of the plan to have Luke's service announce to a signed-in iPhone. #687 (the portable tracker memory) and #688 (device tokens and the APNs sender) have merged; this PR now targets `main` directly and has been rebased over the brain cutover.

- **`/api/watch/tick`**, called by Vercel's cron every minute (`vercel.json` gains the `crons` entry and a 60-second function cap). For each account signed in on a phone and holding a synced key, oldest pass first, it runs the same read-only cloud pass the on-demand observe endpoint runs, restores the account's notice tracker from its `watch_memory` row, diffs, writes the new memory, and sends a notification for a session that started holding for the developer or stopped on an error.
- **The notice tracker now lives in the service** at `server/hosted/notice-tracker.ts`, with its tests. After the brain cutover on main the desktop notices changes against its own memory and keeps no tracker, so the class moves to its only consumer. The phone notification is therefore the one status edge that still speaks on its own, and the guide says so beside the brain's own rule.
- **Same narrowing the desktop's deterministic path kept**: a finish and a waiting turn the provider did not mark as holding are the roster's to show, never a notification's. No brain and no evaluator runs on the pass, so nothing a model wrote can reach a notification.
- **The memory is the account's**, not any phone's: one `watch_memory` row per account holding the tracker snapshot (identifiers, statuses, timestamps; never a title, activity, or error), written before anything is sent so a tick that dies mid-send misses rather than repeats, and dropped on the next tick for an account with no phone or no key.
- **Gap gate**: a pass more than five minutes after the last reseeds silently instead of announcing what changed in the gap, the server analogue of the desktop's stale-edge rule.
- **Kill switches**: the tick answers 503 without `CRON_SECRET` or the four `APNS_*` variables. A wrong bearer is 401. It spends at most 45 seconds and reports `exhausted: true` if accounts remain.
- **Notification payload**: title, workspace as subtitle, one line for what the session holds on or the error it stopped on, time-sensitive interruption level, thread and collapse ids per session, and the provider and session ids as custom keys for the tap.
- **Refactor**: the cloud pass moves from `observe.ts` into `cloud-observe.ts` so observe and the watch read one way. Observe's behavior is unchanged.
- **Docs**: `AGENTS.md` names the watch under the cloud-key rule and adds the phone notification as the service's third place beside the brain's two; `PRIVACY.md` describes the watch, the record it keeps, Apple as a recipient, and sign-out as the way to stop it; `apps/web/server/README.md` documents the tick and `CRON_SECRET`.
- **Migration** `0008` adds `watch_memory`.

## Evidence

- Platform-independent checks: `./scripts/check.sh` passes on the rebased branch (351 web tests, 0 failures, including the relocated tracker suite; lint including oxlint clean; full repository check exit 0)
- macOS Electron verification (`./scripts/verify.sh`): `not run` (service only, no UI touched)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34259019773/artifacts/10069251542) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34259019773)

- Commit: `b211056e5c66514f209f79ad79d163413f962f6e`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

### Physical-device evidence

- Screenshot or screen recording: `not attached`
- Physical-notch check: `not performed`
- Device/display configuration: `not recorded`

## Notes

- Blockers or follow-up verification: `CRON_SECRET` and the four `APNS_*` variables must be set in the Vercel project (production) before the first tick can send. Vercel crons run only on production deployments. Nothing is received until the iOS app registers tokens (step 4).
- Per-minute observation of every eligible account is the agreed starting cadence; a Conductor pass is roughly two requests plus two per workspace plus one per chat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/1df4af80-404c-4293-bedf-18a2c7b51cca)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)
