### PR TITLE
feat(ios): register for push and open the session a notification names

### DIFF
--- a/apps/ios/Luke.xcodeproj/project.pbxproj
+++ b/apps/ios/Luke.xcodeproj/project.pbxproj
@@ -38,6 +38,7 @@
 		AABBCC0000000000000000C8 /* WatchAccountSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABBCC0000000000000000C2 /* WatchAccountSession.swift */; };
 		AABBCC0000000000000000C9 /* WatchConnectivityReceiver.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABBCC0000000000000000C3 /* WatchConnectivityReceiver.swift */; };
 		AABBCC0000000000000000CA /* PhoneSessionRelay.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABBCC0000000000000000C4 /* PhoneSessionRelay.swift */; };
+		AABBCC000000000000000111 /* PushNotifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABBCC000000000000000110 /* PushNotifications.swift */; };
 		AABBCC0000000000000000CB /* WatchConnectivity.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AABBCC0000000000000000C5 /* WatchConnectivity.framework */; };
 		AABBCC0000000000000000CC /* WatchConnectivity.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AABBCC0000000000000000C5 /* WatchConnectivity.framework */; };
 		AABBCC0000000000000000E2 /* WatchRosterStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABBCC0000000000000000E1 /* WatchRosterStore.swift */; };
@@ -117,6 +118,8 @@
 		AABBCC0000000000000000E1 /* WatchRosterStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchRosterStore.swift; sourceTree = "<group>"; };
 		AABBCC0000000000000000E3 /* WatchRosterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchRosterView.swift; sourceTree = "<group>"; };
 		AABBCC0000000000000000C4 /* PhoneSessionRelay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhoneSessionRelay.swift; sourceTree = "<group>"; };
+		AABBCC000000000000000110 /* PushNotifications.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushNotifications.swift; sourceTree = "<group>"; };
+		AABBCC000000000000000112 /* Luke.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Luke.entitlements; sourceTree = "<group>"; };
 		AABBCC0000000000000000C5 /* WatchConnectivity.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WatchConnectivity.framework; path = System/Library/Frameworks/WatchConnectivity.framework; sourceTree = SDKROOT; };
 		AABBCC0000000000000000D0 /* VoiceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceView.swift; sourceTree = "<group>"; };
 		AABBCC0000000000000000D1 /* VoiceAudioCapturer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceAudioCapturer.swift; sourceTree = "<group>"; };
@@ -201,6 +204,7 @@
 				AABBCC0000000000000000A1 /* PresenceBinding.swift */,
 				AABBCC0000000000000000A3 /* MarkdownMessageView.swift */,
 				AABBCC0000000000000000C4 /* PhoneSessionRelay.swift */,
+				AABBCC000000000000000110 /* PushNotifications.swift */,
 				AABBCC0000000000000000D0 /* VoiceView.swift */,
 				AABBCC0000000000000000D1 /* VoiceAudioCapturer.swift */,
 				AABBCC0000000000000000D2 /* VoiceAudioPlayer.swift */,
@@ -208,6 +212,7 @@
 				AABBCC000000000000000014 /* Assets.xcassets */,
 				AABBCC00000000000000001C /* Info.plist */,
 				AABBCC000000000000000104 /* PrivacyInfo.xcprivacy */,
+				AABBCC000000000000000112 /* Luke.entitlements */,
 			);
 			path = Luke;
 			sourceTree = "<group>";
@@ -415,6 +420,7 @@
 				AABBCC0000000000000000A2 /* PresenceBinding.swift in Sources */,
 				AABBCC0000000000000000A4 /* MarkdownMessageView.swift in Sources */,
 				AABBCC0000000000000000CA /* PhoneSessionRelay.swift in Sources */,
+				AABBCC000000000000000111 /* PushNotifications.swift in Sources */,
 				AABBCC0000000000000000D4 /* VoiceView.swift in Sources */,
 				AABBCC0000000000000000D5 /* VoiceAudioCapturer.swift in Sources */,
 				AABBCC0000000000000000D6 /* VoiceAudioPlayer.swift in Sources */,
@@ -595,6 +601,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = Luke/Luke.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = 7UHHCDBUK2;
@@ -627,6 +634,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = Luke/Luke.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = 7UHHCDBUK2;

--- a/apps/ios/Luke/ContentView.swift
+++ b/apps/ios/Luke/ContentView.swift
@@ -171,6 +171,7 @@ struct ContentView: View {
 private struct SignedInView: View {
     @Environment(AccountSession.self) private var session
     @Environment(ProductEventSender.self) private var events
+    @Environment(PushCoordinator.self) private var push
     let identity: AccountIdentity
     @State private var profileShown = false
     @State private var creatorShown = false
@@ -229,6 +230,10 @@ private struct SignedInView: View {
                 Task { await store.refresh(account: session, events: events) }
             }
         }
+        .onChange(of: push.pendingOpen, initial: true) { _, open in
+            guard let open else { return }
+            Task { await answer(open) }
+        }
     }
 
     /// The New tab is a button in the bar: its selection opens the creator
@@ -262,6 +267,27 @@ private struct SignedInView: View {
                 profileButton
             }
         }
+    }
+
+    /// A tapped notification opens the session it named, the same press its
+    /// row takes, and only a session the roster reports: the tap carries an
+    /// identity, never an address, so a session the roster no longer lists
+    /// opens nothing. The roster is refreshed once first when the row is not
+    /// yet on screen, since the notification usually arrives before the list
+    /// has caught up. Opening leaves whatever tab was up for the sessions
+    /// tab, the way an open asked of Luke does.
+    private func answer(_ open: PushOpen) async {
+        defer { if push.pendingOpen == open { push.pendingOpen = nil } }
+        if let found = session(matching: open) {
+            store.openLeavingConversation(found)
+            return
+        }
+        await store.refresh(account: session, events: events)
+        if let found = session(matching: open) { store.openLeavingConversation(found) }
+    }
+
+    private func session(matching open: PushOpen) -> RosterSession? {
+        store.sessions.first { $0.providerId == open.providerId && $0.sessionId == open.sessionId }
     }
 
     private var profileButton: some View {
@@ -309,6 +335,7 @@ private struct ProfileSheet: View {
     @Environment(AccountSession.self) private var session
     @Environment(VaultStore.self) private var vault
     @Environment(ProductEventSender.self) private var events
+    @Environment(PushRegistrar.self) private var pushRegistrar
     @Environment(\.dismiss) private var dismiss
     let identity: AccountIdentity
     @State private var editingProvider: VaultProviderID?
@@ -350,6 +377,9 @@ private struct ProfileSheet: View {
                             // or the act would wait for a sign-in to report.
                             events.record(.accountAct(.signOut))
                             await events.flush().value
+                            // Forgotten on the service while this account's
+                            // bearer still stands; the sign-out clears it.
+                            await pushRegistrar.unregister()
                             await session.signOut()
                         }
                     }

--- a/apps/ios/Luke/Luke.entitlements
+++ b/apps/ios/Luke/Luke.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>aps-environment</key>
+	<string>development</string>
+	<key>com.apple.developer.usernotifications.time-sensitive</key>
+	<true/>
+</dict>
+</plist>

--- a/apps/ios/Luke/LukeApp.swift
+++ b/apps/ios/Luke/LukeApp.swift
@@ -7,6 +7,8 @@ struct LukeApp: App {
     @State private var vault: VaultStore
     @State private var events: ProductEventSender
     @State private var conversation = VoiceConversationThread()
+    @State private var pushRegistrar: PushRegistrar
+    @UIApplicationDelegateAdaptor(PushCoordinator.self) private var push
     @Environment(\.scenePhase) private var scenePhase
     // Held for its lifetime — the WCSessionDelegate must not be deallocated.
     private let phoneRelay: PhoneSessionRelay
@@ -22,6 +24,10 @@ struct LukeApp: App {
         phoneRelay = PhoneSessionRelay(accountSession: session)
         _vault = State(initialValue: VaultStore(
             client: VaultClient(baseURL: AccountConstants.serviceURL),
+            session: session
+        ))
+        _pushRegistrar = State(initialValue: PushRegistrar(
+            client: DeviceClient(baseURL: AccountConstants.serviceURL),
             session: session
         ))
         // XCTest launches this app as its suites' host, and a test run's
@@ -57,11 +63,24 @@ struct LukeApp: App {
                 .environment(vault)
                 .environment(events)
                 .environment(conversation)
+                .environment(pushRegistrar)
+                .environment(push)
+                .task {
+                    // Being signed in on this phone is what asks for
+                    // notifications: a launch already signed in asks now, and
+                    // a sign-in below asks at its edge.
+                    push.registrar = pushRegistrar
+                    if case .signedIn = session.state { push.enable() }
+                }
                 .onChange(of: session.state) { previous, current in
                     accountEdge(from: previous, to: current)
                     switch current {
-                    case .signedIn: phoneRelay.push()
-                    case .signedOut: phoneRelay.pushSignOut()
+                    case .signedIn:
+                        phoneRelay.push()
+                        push.enable()
+                        Task { await pushRegistrar.accountSignedIn() }
+                    case .signedOut:
+                        phoneRelay.pushSignOut()
                     }
                 }
         }

--- a/apps/ios/Luke/PushNotifications.swift
+++ b/apps/ios/Luke/PushNotifications.swift
@@ -1,0 +1,118 @@
+import LukeKit
+import Observation
+import UIKit
+import UserNotifications
+
+/// A notification's tap, as the payload named it: the session to open.
+/// Mirrors `WATCH_PAYLOAD_KEY` in `apps/web/server/hosted/watch.ts`.
+struct PushOpen: Equatable {
+    let providerId: String
+    let sessionId: String
+
+    init?(userInfo: [AnyHashable: Any]) {
+        guard let providerId = userInfo["providerId"] as? String, !providerId.isEmpty,
+              let sessionId = userInfo["sessionId"] as? String, !sessionId.isEmpty
+        else { return nil }
+        self.providerId = providerId
+        self.sessionId = sessionId
+    }
+}
+
+/// The app's one door to Apple's push machinery. It asks the system for
+/// notification permission once the account is signed in — being signed in
+/// on this phone is what asks for notifications; there is no switch — hands
+/// the token Apple issues to the registrar, and turns a tapped notification
+/// into a pending open the signed-in hierarchy consumes. It shows nothing and
+/// decides nothing about a notification's words: those are the service's,
+/// composed from what a provider wrote about a session.
+@MainActor
+@Observable
+final class PushCoordinator: NSObject, UIApplicationDelegate, UNUserNotificationCenterDelegate {
+    /// The tap not yet answered by a screen, if any.
+    var pendingOpen: PushOpen?
+    @ObservationIgnored var registrar: PushRegistrar?
+
+    func application(
+        _ application: UIApplication,
+        didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
+    ) -> Bool {
+        UNUserNotificationCenter.current().delegate = self
+        return true
+    }
+
+    /// Asks for permission and a token. Safe to call on every signed-in edge:
+    /// the system's dialog appears once, and re-registering only refreshes
+    /// the token Apple already issued.
+    func enable() {
+        Task {
+            let center = UNUserNotificationCenter.current()
+            let granted = try? await center.requestAuthorization(options: [.alert, .sound, .badge])
+            guard granted == true else { return }
+            UIApplication.shared.registerForRemoteNotifications()
+        }
+    }
+
+    func application(
+        _ application: UIApplication,
+        didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data
+    ) {
+        let token = DeviceToken.hex(from: deviceToken)
+        let environment = Self.pushEnvironment
+        Task { await registrar?.tokenArrived(token, environment: environment) }
+    }
+
+    func application(
+        _ application: UIApplication, didFailToRegisterForRemoteNotificationsWithError error: Error
+    ) {
+        // A simulator without push entitlement, or a device offline: the
+        // roster still shows every session, and the next launch asks again.
+    }
+
+    nonisolated func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        willPresent notification: UNNotification,
+        withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void
+    ) {
+        // Shown in the foreground too: the row already says the state, but
+        // the banner is what says it just changed.
+        completionHandler([.banner, .sound])
+    }
+
+    nonisolated func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        didReceive response: UNNotificationResponse,
+        withCompletionHandler completionHandler: @escaping () -> Void
+    ) {
+        let open = PushOpen(userInfo: response.notification.request.content.userInfo)
+        Task { @MainActor in
+            if let open { self.pendingOpen = open }
+            completionHandler()
+        }
+    }
+
+    /// Which gateway issued this build's tokens. A build signed for
+    /// development carries `aps-environment: development` in its embedded
+    /// provisioning profile; TestFlight and App Store builds carry
+    /// `production`, and the App Store strips the profile altogether, which
+    /// reads as production too. The simulator's tokens are sandbox tokens.
+    static var pushEnvironment: PushEnvironment {
+        #if targetEnvironment(simulator)
+            return .sandbox
+        #else
+            guard let url = Bundle.main.url(forResource: "embedded", withExtension: "mobileprovision"),
+                  let raw = try? Data(contentsOf: url),
+                  let text = String(data: raw, encoding: .isoLatin1),
+                  let start = text.range(of: "<?xml"),
+                  let end = text.range(of: "</plist>")
+            else { return .production }
+            let plist = String(text[start.lowerBound ..< end.upperBound])
+            guard let data = plist.data(using: .isoLatin1),
+                  let object = try? PropertyListSerialization.propertyList(from: data, format: nil),
+                  let profile = object as? [String: Any],
+                  let entitlements = profile["Entitlements"] as? [String: Any],
+                  let environment = entitlements["aps-environment"] as? String
+            else { return .production }
+            return environment == "development" ? .sandbox : .production
+        #endif
+    }
+}

--- a/apps/ios/LukeKit/Sources/LukeKit/DeviceClient.swift
+++ b/apps/ios/LukeKit/Sources/LukeKit/DeviceClient.swift
@@ -1,0 +1,108 @@
+import Foundation
+
+/// The platforms the service registers push tokens for. Mirrors
+/// `DEVICE_PLATFORM` in `@sidecar/hosted`.
+public enum DevicePlatform: String, Sendable {
+    case ios
+}
+
+/// Which of Apple's two push gateways issued this installation's token.
+/// Mirrors `PUSH_ENVIRONMENT` in `@sidecar/hosted`: a build run from Xcode
+/// registers with the sandbox gateway, one from TestFlight or the App Store
+/// with production, and a token sent to the wrong gateway is refused, so the
+/// registration says which.
+public enum PushEnvironment: String, Sendable, Equatable {
+    case sandbox
+    case production
+}
+
+/// The device token as the service stores it: Apple's bytes as lowercase
+/// hex, bounded the way `deviceTokenIsStorable` bounds it.
+public enum DeviceToken {
+    public static let minimumLength = 32
+    public static let maximumLength = 512
+
+    public static func hex(from data: Data) -> String {
+        data.map { String(format: "%02x", $0) }.joined()
+    }
+
+    /// The server's own shape check, applied here so a token it would refuse
+    /// never travels.
+    public static func isStorable(_ token: String) -> Bool {
+        token.count >= minimumLength
+            && token.count <= maximumLength
+            && token.allSatisfy { $0.isHexDigit && ($0.isNumber || $0.isLowercase) }
+    }
+}
+
+public enum DeviceClientError: Error, Equatable, HostedUnauthorizedSignaling {
+    /// The answer was not the shape the wire contract promises.
+    case invalidResponse
+    /// The token failed the same shape check the server applies.
+    case invalidToken
+    case serverError(status: Int, apiError: HostedAPIError?)
+
+    public var isUnauthorized: Bool {
+        if case .serverError(let status, _) = self { return status == 401 }
+        return false
+    }
+}
+
+/// Client for the device-token endpoint. Paths, body shapes, and answer
+/// validation mirror the wire contract in `@sidecar/hosted` and the handler
+/// in `apps/web/server/hosted/devices.ts`.
+public final class DeviceClient: Sendable {
+    private let baseURL: URL
+    private let http: HTTPClient
+
+    /// `baseURL` is the hosted service origin; the endpoint lives under `/api/devices` on it.
+    public init(baseURL: URL, http: HTTPClient = URLSession.shared) {
+        self.baseURL = baseURL
+        self.http = http
+    }
+
+    /// Registers this installation's token under the signed-in account. POST
+    /// /api/devices/token. A token already on file moves to this account.
+    public func register(
+        token: String, environment: PushEnvironment, accessToken: String
+    ) async throws {
+        guard DeviceToken.isStorable(token) else { throw DeviceClientError.invalidToken }
+        let json = try await send(
+            method: "POST",
+            body: [
+                "token": token,
+                "platform": DevicePlatform.ios.rawValue,
+                "environment": environment.rawValue,
+            ],
+            accessToken: accessToken
+        )
+        guard json["stored"] as? Bool == true else { throw DeviceClientError.invalidResponse }
+    }
+
+    /// Forgets this installation's token at sign-out. DELETE /api/devices/token.
+    /// Returns whether the account held it.
+    public func unregister(token: String, accessToken: String) async throws -> Bool {
+        guard DeviceToken.isStorable(token) else { throw DeviceClientError.invalidToken }
+        let json = try await send(method: "DELETE", body: ["token": token], accessToken: accessToken)
+        guard let deleted = json["deleted"] as? Bool else { throw DeviceClientError.invalidResponse }
+        return deleted
+    }
+
+    private func send(
+        method: String, body: [String: String], accessToken: String
+    ) async throws -> [String: Any] {
+        var request = URLRequest(url: baseURL.appendingPathComponent("api/devices/token"))
+        request.httpMethod = method
+        request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try JSONSerialization.data(withJSONObject: body)
+        let (data, response) = try await http.data(for: request)
+        let status = (response as? HTTPURLResponse)?.statusCode ?? 0
+        let json = (try? JSONSerialization.jsonObject(with: data) as? [String: Any]) ?? [:]
+        guard (200 ..< 300).contains(status) else {
+            let reason = (json["error"] as? String).flatMap(HostedAPIError.init(rawValue:))
+            throw DeviceClientError.serverError(status: status, apiError: reason)
+        }
+        return json
+    }
+}

--- a/apps/ios/LukeKit/Sources/LukeKit/PushRegistrar.swift
+++ b/apps/ios/LukeKit/Sources/LukeKit/PushRegistrar.swift
@@ -1,0 +1,87 @@
+import Foundation
+import Observation
+
+/// Keeps the service's record of this phone true to who is signed in on it.
+/// Apple hands the app a token on its own schedule and the account signs in
+/// and out on the developer's, so the registrar holds whichever arrived
+/// first and registers the moment both stand: a token under a signed-in
+/// account. A sign-out unregisters under the account that is leaving, before
+/// its bearer is gone, and the token stays held for the next sign-in, which
+/// moves it to the new account in the same registration.
+@MainActor
+@Observable
+public final class PushRegistrar {
+    public struct HeldToken: Equatable, Sendable {
+        public let token: String
+        public let environment: PushEnvironment
+
+        public init(token: String, environment: PushEnvironment) {
+            self.token = token
+            self.environment = environment
+        }
+    }
+
+    /// The token Apple issued this installation, once it has.
+    public private(set) var held: HeldToken?
+    /// The account the held token is registered under on the service, or nil.
+    public private(set) var registeredAccount: String?
+    public private(set) var lastError: String?
+
+    private let client: DeviceClient
+    private let session: any AccountTokenProviding
+
+    public init(client: DeviceClient, session: any AccountTokenProviding) {
+        self.client = client
+        self.session = session
+    }
+
+    /// Apple issued or re-issued the token. Registered at once under the
+    /// signed-in account, if there is one; held for the sign-in otherwise.
+    public func tokenArrived(_ token: String, environment: PushEnvironment) async {
+        let arrived = HeldToken(token: token, environment: environment)
+        if held != arrived { registeredAccount = nil }
+        held = arrived
+        await registerIfReady()
+    }
+
+    /// The account signed in, or was already signed in at launch: the held
+    /// token, if any, is registered under it.
+    public func accountSignedIn() async {
+        await registerIfReady()
+    }
+
+    /// Forgets the phone on the service under the account about to leave.
+    /// Must run before the sign-out clears the bearer, since the delete is
+    /// scoped to the account that holds the row. The token stays held.
+    public func unregister() async {
+        guard let held, let account = session.accountEmail else { return }
+        do {
+            _ = try await session.authorized { token in
+                try await self.client.unregister(token: held.token, accessToken: token)
+            }
+            lastError = nil
+        } catch {
+            lastError = error.localizedDescription
+        }
+        if registeredAccount == account { registeredAccount = nil }
+    }
+
+    private func registerIfReady() async {
+        guard let held, let account = session.accountEmail else { return }
+        guard registeredAccount != account else { return }
+        do {
+            try await session.authorized { token in
+                try await self.client.register(
+                    token: held.token, environment: held.environment, accessToken: token
+                )
+            }
+            // The account may have changed hands while the call traveled; the
+            // registration is the asking account's alone.
+            guard session.accountEmail == account, self.held == held else { return }
+            registeredAccount = account
+            lastError = nil
+        } catch {
+            lastError = error.localizedDescription
+        }
+    }
+}

--- a/apps/ios/LukeKit/Tests/LukeKitTests/DeviceClientTests.swift
+++ b/apps/ios/LukeKit/Tests/LukeKitTests/DeviceClientTests.swift
@@ -1,0 +1,100 @@
+import Foundation
+import XCTest
+
+@testable import LukeKit
+
+private let serviceURL = URL(string: "https://tryluke.dev")!
+private let token = String(repeating: "0a", count: 32)
+
+private func answer(_ body: [String: Any], status: Int = 200, for request: URLRequest) -> (Data, URLResponse) {
+    let data = try! JSONSerialization.data(withJSONObject: body)
+    let response = HTTPURLResponse(url: request.url!, statusCode: status, httpVersion: nil, headerFields: nil)!
+    return (data, response)
+}
+
+final class DeviceTokenTests: XCTestCase {
+    func testHexIsLowercaseAndZeroPadded() {
+        XCTAssertEqual(DeviceToken.hex(from: Data([0x00, 0x0a, 0xff, 0x10])), "000aff10")
+    }
+
+    func testStorableMirrorsTheServerBounds() {
+        XCTAssertTrue(DeviceToken.isStorable(token))
+        XCTAssertFalse(DeviceToken.isStorable(String(repeating: "0a", count: 15)))
+        XCTAssertFalse(DeviceToken.isStorable(String(repeating: "0a", count: 257)))
+        XCTAssertFalse(DeviceToken.isStorable(String(repeating: "0A", count: 32)))
+        XCTAssertFalse(DeviceToken.isStorable(String(repeating: "0a", count: 31) + "g1"))
+    }
+}
+
+final class DeviceClientTests: XCTestCase {
+    func testRegisterPostsTheContractBody() async throws {
+        let stub = StubHTTPClient { request in
+            XCTAssertEqual(request.httpMethod, "POST")
+            XCTAssertEqual(request.url?.path, "/api/devices/token")
+            XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer at-1")
+            let body = try JSONSerialization.jsonObject(with: request.httpBody ?? Data()) as? [String: String]
+            XCTAssertEqual(body, ["token": token, "platform": "ios", "environment": "sandbox"])
+            return answer(["stored": true], for: request)
+        }
+        let client = DeviceClient(baseURL: serviceURL, http: stub)
+        try await client.register(token: token, environment: .sandbox, accessToken: "at-1")
+    }
+
+    func testRegisterRefusesAnUnstorableTokenBeforeItTravels() async {
+        let stub = StubHTTPClient { _ in
+            XCTFail("nothing should travel")
+            throw URLError(.badURL)
+        }
+        let client = DeviceClient(baseURL: serviceURL, http: stub)
+        do {
+            try await client.register(token: "short", environment: .sandbox, accessToken: "at-1")
+            XCTFail("expected a refusal")
+        } catch let error as DeviceClientError {
+            XCTAssertEqual(error, .invalidToken)
+        } catch {
+            XCTFail("unexpected \(error)")
+        }
+    }
+
+    func testRegisterRejectsAnAnswerOffTheContract() async {
+        let stub = StubHTTPClient { request in answer(["stored": false], for: request) }
+        let client = DeviceClient(baseURL: serviceURL, http: stub)
+        do {
+            try await client.register(token: token, environment: .production, accessToken: "at-1")
+            XCTFail("expected a refusal")
+        } catch let error as DeviceClientError {
+            XCTAssertEqual(error, .invalidResponse)
+        } catch {
+            XCTFail("unexpected \(error)")
+        }
+    }
+
+    func testAServerRefusalCarriesItsReasonAndSignalsUnauthorized() async {
+        let stub = StubHTTPClient { request in
+            answer(["error": "invalid-token"], status: 401, for: request)
+        }
+        let client = DeviceClient(baseURL: serviceURL, http: stub)
+        do {
+            try await client.register(token: token, environment: .production, accessToken: "at-1")
+            XCTFail("expected a refusal")
+        } catch let error as DeviceClientError {
+            XCTAssertEqual(error, .serverError(status: 401, apiError: .invalidToken))
+            XCTAssertTrue(error.isUnauthorized)
+        } catch {
+            XCTFail("unexpected \(error)")
+        }
+    }
+
+    func testUnregisterDeletesAndAnswersWhetherARowWent() async throws {
+        let stub = StubHTTPClient { request in
+            XCTAssertEqual(request.httpMethod, "DELETE")
+            XCTAssertEqual(request.url?.path, "/api/devices/token")
+            let body = try JSONSerialization.jsonObject(with: request.httpBody ?? Data()) as? [String: String]
+            XCTAssertEqual(body, ["token": token])
+            return answer(["deleted": false], for: request)
+        }
+        let client = DeviceClient(baseURL: serviceURL, http: stub)
+        let deleted = try await client.unregister(token: token, accessToken: "at-1")
+        XCTAssertFalse(deleted)
+    }
+}

--- a/apps/ios/LukeKit/Tests/LukeKitTests/PushRegistrarTests.swift
+++ b/apps/ios/LukeKit/Tests/LukeKitTests/PushRegistrarTests.swift
@@ -1,0 +1,173 @@
+import Foundation
+import XCTest
+
+@testable import LukeKit
+
+private let serviceURL = URL(string: "https://tryluke.dev")!
+private let token = String(repeating: "0b", count: 32)
+
+@MainActor
+private final class StubAccount: AccountTokenProviding {
+    var accountEmail: String?
+    var refreshes = 0
+
+    init(accountEmail: String?) {
+        self.accountEmail = accountEmail
+    }
+
+    func validAccessToken() async throws -> String {
+        guard accountEmail != nil else { throw AccountSessionError.signedOut }
+        return "at-\(accountEmail ?? "")"
+    }
+
+    func refreshAccessToken() async throws -> String {
+        refreshes += 1
+        return "fresh-\(accountEmail ?? "")"
+    }
+}
+
+/// Records every call the registrar makes, in order, as method and bearer,
+/// and answers each with the next scripted status (200 once the script runs out).
+private final class Recorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var recorded: [String] = []
+    private var statuses: [Int] = []
+
+    var calls: [String] {
+        lock.withLock { recorded }
+    }
+
+    func script(_ statuses: [Int]) {
+        lock.withLock { self.statuses = statuses }
+    }
+
+    private func record(_ request: URLRequest) -> Int {
+        lock.withLock {
+            let bearer = request.value(forHTTPHeaderField: "Authorization") ?? ""
+            recorded.append("\(request.httpMethod ?? "") \(bearer)")
+            return statuses.isEmpty ? 200 : statuses.removeFirst()
+        }
+    }
+
+    private static func answer(_ request: URLRequest, status: Int) throws -> (Data, URLResponse) {
+        let body: [String: Any]
+        if status != 200 {
+            body = ["error": "invalid-token"]
+        } else if request.httpMethod == "DELETE" {
+            body = ["deleted": true]
+        } else {
+            body = ["stored": true]
+        }
+        let data = try JSONSerialization.data(withJSONObject: body)
+        let response = HTTPURLResponse(
+            url: request.url!, statusCode: status, httpVersion: nil, headerFields: nil
+        )!
+        return (data, response)
+    }
+
+    func client() -> DeviceClient {
+        let recorder = self
+        let stub = StubHTTPClient { request in
+            try Recorder.answer(request, status: recorder.record(request))
+        }
+        return DeviceClient(baseURL: serviceURL, http: stub)
+    }
+}
+
+@MainActor
+final class PushRegistrarTests: XCTestCase {
+    func testATokenArrivingWhileSignedInRegistersAtOnce() async {
+        let recorder = Recorder()
+        let account = StubAccount(accountEmail: "dev@example.com")
+        let registrar = PushRegistrar(client: recorder.client(), session: account)
+
+        await registrar.tokenArrived(token, environment: .sandbox)
+
+        XCTAssertEqual(recorder.calls, ["POST Bearer at-dev@example.com"])
+        XCTAssertEqual(registrar.registeredAccount, "dev@example.com")
+        XCTAssertEqual(registrar.held, .init(token: token, environment: .sandbox))
+    }
+
+    func testATokenArrivingSignedOutWaitsForTheSignIn() async {
+        let recorder = Recorder()
+        let account = StubAccount(accountEmail: nil)
+        let registrar = PushRegistrar(client: recorder.client(), session: account)
+
+        await registrar.tokenArrived(token, environment: .production)
+        XCTAssertEqual(recorder.calls, [])
+        XCTAssertNil(registrar.registeredAccount)
+
+        account.accountEmail = "dev@example.com"
+        await registrar.accountSignedIn()
+        XCTAssertEqual(recorder.calls, ["POST Bearer at-dev@example.com"])
+        XCTAssertEqual(registrar.registeredAccount, "dev@example.com")
+    }
+
+    func testASignInWithNoTokenYetRegistersNothing() async {
+        let recorder = Recorder()
+        let registrar = PushRegistrar(
+            client: recorder.client(), session: StubAccount(accountEmail: "dev@example.com")
+        )
+        await registrar.accountSignedIn()
+        XCTAssertEqual(recorder.calls, [])
+    }
+
+    func testTheSameAccountAndTokenRegisterOnce() async {
+        let recorder = Recorder()
+        let account = StubAccount(accountEmail: "dev@example.com")
+        let registrar = PushRegistrar(client: recorder.client(), session: account)
+
+        await registrar.tokenArrived(token, environment: .sandbox)
+        await registrar.accountSignedIn()
+        await registrar.tokenArrived(token, environment: .sandbox)
+        XCTAssertEqual(recorder.calls.count, 1)
+
+        await registrar.tokenArrived(String(repeating: "0c", count: 32), environment: .sandbox)
+        XCTAssertEqual(recorder.calls.count, 2)
+    }
+
+    func testSignOutUnregistersUnderTheLeavingAccountAndKeepsTheToken() async {
+        let recorder = Recorder()
+        let account = StubAccount(accountEmail: "one@example.com")
+        let registrar = PushRegistrar(client: recorder.client(), session: account)
+        await registrar.tokenArrived(token, environment: .sandbox)
+
+        await registrar.unregister()
+        XCTAssertEqual(recorder.calls, ["POST Bearer at-one@example.com", "DELETE Bearer at-one@example.com"])
+        XCTAssertNil(registrar.registeredAccount)
+        XCTAssertEqual(registrar.held?.token, token)
+
+        account.accountEmail = "two@example.com"
+        await registrar.accountSignedIn()
+        XCTAssertEqual(recorder.calls.last, "POST Bearer at-two@example.com")
+        XCTAssertEqual(registrar.registeredAccount, "two@example.com")
+    }
+
+    func testARefusedBearerIsRefreshedAndRetriedOnce() async {
+        let recorder = Recorder()
+        recorder.script([401])
+        let account = StubAccount(accountEmail: "dev@example.com")
+        let registrar = PushRegistrar(client: recorder.client(), session: account)
+
+        await registrar.tokenArrived(token, environment: .sandbox)
+
+        XCTAssertEqual(recorder.calls, ["POST Bearer at-dev@example.com", "POST Bearer fresh-dev@example.com"])
+        XCTAssertEqual(account.refreshes, 1)
+        XCTAssertEqual(registrar.registeredAccount, "dev@example.com")
+    }
+
+    func testAFailedRegistrationIsRememberedAndRetriedNextEdge() async {
+        let recorder = Recorder()
+        recorder.script([503])
+        let account = StubAccount(accountEmail: "dev@example.com")
+        let registrar = PushRegistrar(client: recorder.client(), session: account)
+
+        await registrar.tokenArrived(token, environment: .sandbox)
+        XCTAssertNil(registrar.registeredAccount)
+        XCTAssertNotNil(registrar.lastError)
+
+        await registrar.accountSignedIn()
+        XCTAssertEqual(registrar.registeredAccount, "dev@example.com")
+        XCTAssertNil(registrar.lastError)
+    }
+}

--- a/apps/ios/README.md
+++ b/apps/ios/README.md
@@ -225,3 +225,22 @@ in `WatchWebSocketChannel`, because URLSession on watchOS does its work in a
 system process that never inherits the grant. The call still opens only at
 the developer's press and closes on the same idle timer as before; the mode
 changes what watchOS lets the socket do, not when Luke listens.
+
+## Notifications
+
+Signing in on this phone is what asks for notifications; there is no switch.
+At a signed-in launch and at the sign-in edge the app requests notification
+permission, registers for a push token, and hands the token Apple issues to
+`LukeKit`'s `PushRegistrar`, which registers it under the signed-in account
+through the service's `/api/devices/token` endpoint. Signing out forgets the
+token on the service first, while the account's bearer still stands, and a
+later sign-in moves the same token to the new account. A tapped notification
+opens the session it named, and only a session the roster reports.
+
+`Luke/Luke.entitlements` carries the push and time-sensitive entitlements. The
+`aps-environment` value there is `development`; a distribution build's
+provisioning profile rewrites it to `production`, and the app reads the
+embedded profile at launch to register the token with the gateway that issued
+it, so a build from Xcode and one from TestFlight each reach the right one.
+The words a notification shows are composed by the service from what a
+provider wrote about the session; nothing here decides or words one.


### PR DESCRIPTION
## Summary

Step 4, the last of the plan to have Luke's service announce to a signed-in iPhone. Stacked on #690 (the scheduled watcher); #687 and #688 have merged. Rebased over the brain cutover on main: the notification tap now lands on main's tab bar by selecting the sessions tab through the store's own open, and the project-file ids for the new Swift file and the entitlements file were renumbered after they collided with ids main's watch work took.

- **Being signed in on this phone is what asks for notifications.** There is no switch. At a signed-in launch and at the sign-in edge the app requests notification permission and a push token.
- **`PushRegistrar`** in LukeKit holds whichever arrives first, the token or the sign-in, and registers the moment both stand, through `DeviceClient` against `/api/devices/token`. A sign-out unregisters under the leaving account before its bearer is cleared, and keeps the token so the next sign-in moves it to the new account. Same 401-refresh-retry discipline as the other hosted clients.
- **`PushCoordinator`** in the app is the one door to Apple's push machinery: the `UIApplicationDelegateAdaptor` that receives the token, the notification-center delegate that shows a banner in the foreground, and the tap handler that turns the payload's provider and session ids into a pending open. `SignedInView` answers it by opening the session the way its row would, refreshing the roster once first, and only for a session the roster reports.
- **Entitlements**: `Luke/Luke.entitlements` carries `aps-environment` and the time-sensitive notifications entitlement; both app configurations point `CODE_SIGN_ENTITLEMENTS` at it. The token's gateway is read from the embedded provisioning profile so a build from Xcode registers with the sandbox and one from TestFlight with production.
- **Docs**: `apps/ios/README.md` gains a Notifications section.

## Evidence

- Platform-independent checks: `./scripts/check.sh` passes on the stack tip (full repository check, 0 error lines)
- macOS Electron verification (`./scripts/verify.sh`): `not run` (no desktop change)
- iOS, run on a Mac with Xcode 26.6 from a throwaway worktree of this commit's content:
  - `swift test` in `apps/ios/LukeKit`: 297 tests, 0 failures (includes the new `DeviceClientTests`, `DeviceTokenTests`, and `PushRegistrarTests`)
  - `xcodebuild test` for the `Luke` scheme on the iPhone 17 Pro simulator with signing disabled: TEST SUCCEEDED

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34259558622/artifacts/10069470128) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34259558622)

- Commit: `228e6e2e5a69612a928f0bd21238b115167bfa42`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

### Physical-device evidence

- Screenshot or screen recording: `not attached`
- Physical-notch check: `not performed` (iOS only)
- Device/display configuration: `not recorded`

## Notes

- Blockers or follow-up verification: a physical-device run is still needed to see a real token register and a real notification arrive, since the simulator's push path differs. The App ID in the developer portal needs the Push Notifications capability, which Xcode's automatic signing adds on the first device build. The service side needs `CRON_SECRET` and the four `APNS_*` variables set in Vercel before anything is delivered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/1df4af80-404c-4293-bedf-18a2c7b51cca)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)
