### PR TITLE
refactor(desktop): collapse two observation clocks into one 60s clock

### DIFF
--- a/apps/desktop/src/main/desktop-app.ts
+++ b/apps/desktop/src/main/desktop-app.ts
@@ -252,7 +252,7 @@ const ACCOUNT_BASE_URL =
 // at a local account service mints against it too.
 const HOSTED_SERVICE_BASE_URL = ACCOUNT_BASE_URL.replace(/\/api\/auth\/?$/, "");
 const ACCOUNT_CLIENT_ID = "luke-desktop";
-const SESSION_REFRESH_INTERVAL_MS = 5_000;
+const SESSION_REFRESH_INTERVAL_MS = 60_000;
 const sessionRegistry = new SessionRoster();
 // Declared before the settings store because the store's snapshot asks it
 // what the latest pass learned about the Codex CLI's login. It observes only
@@ -1607,6 +1607,10 @@ const sessionActPerformer = createSessionActPerformer({
 const brainActPerformer = createBrainActPerformer({
   sessionActs: sessionActPerformer,
   sessions: brainActableSessions,
+  // A fresh pass before every session act keeps validation against the
+  // observed roster current. At 60s intervals the registry could otherwise
+  // be almost a minute stale when the act's validation and perform run.
+  refreshSessions: () => sessionObservationLoop.refresh(),
   workspaceProjects: brainWorkspaceProjects,
   workspaceDefaults: readWorkspaceDefaults,
   trackedIssues: () => trackedIssues,
@@ -1678,7 +1682,6 @@ async function rebuildBrain(): Promise<void> {
     ...(agentTrace ? { trace: (record) => agentTrace.recordBrainTurn(record) } : undefined),
     report: (message) => process.stderr.write(`${message}\n`),
   });
-  brain.start();
 }
 
 function adapterFor(providerId: string) {
@@ -2594,9 +2597,13 @@ const sessionObservationLoop = new ObservationLoop({
   intervalMs: SESSION_REFRESH_INTERVAL_MS,
   run: refreshProviderSessions,
   // A pass is also when the Codex CLI login can have changed hands, and no
-  // settings save stands behind that to announce it.
+  // settings save stands behind that to announce it. The brain's roster look
+  // is driven here rather than on its own timer so the two reads stay in sync:
+  // the look always follows a fresh observation, and never runs when the gate
+  // is closed (observesProviders && accountCapabilitiesActive()).
   afterRun: () => {
     void broadcastCodexCloudConnection();
+    brain?.rosterLook();
   },
 });
 const issueObservationLoop = new ObservationLoop({

--- a/apps/desktop/src/main/ipc/brain-acts.test.ts
+++ b/apps/desktop/src/main/ipc/brain-acts.test.ts
@@ -42,6 +42,7 @@ function performer(overrides: Partial<BrainActPerformerDependencies> = {}) {
       openSessionChange: async () => ({ status: ACT_RESULT_STATUS.ACCEPTED }),
     },
     sessions: (): readonly Session[] => [observed],
+    refreshSessions: async () => {},
     workspaceProjects: () => [],
     workspaceDefaults: async () => ({}),
     trackedIssues: () => undefined,

--- a/apps/desktop/src/main/ipc/brain-acts.ts
+++ b/apps/desktop/src/main/ipc/brain-acts.ts
@@ -36,6 +36,11 @@ export interface BrainActPerformerDependencies {
   sessionActs: SessionActPerformer;
   /** The roster as the brain was shown it: every observed session still worth a row. */
   sessions: () => readonly Session[];
+  /**
+   * Triggers a fresh observation pass so the session registry is current before
+   * validation and perform. Called before every session act.
+   */
+  refreshSessions: () => Promise<void>;
   workspaceProjects: () => readonly ObservedWorkspaceProject[];
   workspaceDefaults: () => Promise<WorkspaceCreationDefaults>;
   trackedIssues: () => readonly TrackedIssue[] | undefined;
@@ -75,6 +80,7 @@ export function createBrainActPerformer(
   dependencies: BrainActPerformerDependencies,
 ): BrainActPerformer {
   const performSession = async (call: RealtimeFunctionCall): Promise<WireRecord> => {
+    await dependencies.refreshSessions();
     const sessions = dependencies.sessions();
     const defaults = await dependencies.workspaceDefaults();
     const action = sessionToolAction(

--- a/packages/brain/src/brain-agent.test.ts
+++ b/packages/brain/src/brain-agent.test.ts
@@ -21,7 +21,6 @@ import {
   wireRecord,
 } from "@sidecar/wire";
 import {
-  BRAIN_ROSTER_WAKE_INTERVAL_MS,
   BRAIN_TURN_TRIGGER,
   BrainAgent,
   type BrainAgentOptions,
@@ -553,7 +552,7 @@ test("stop drops pending wakes and takes nothing more", async () => {
   assert.equal(await h.agent.ask("hello?"), undefined);
 });
 
-test("a scheduled roster look carries the roster and only the transcripts that grew", async () => {
+test("a roster look carries the roster and only the transcripts that grew", async () => {
   const working = session("abc", { status: SESSION_STATUS.WORKING });
   const settled = session("def", { status: SESSION_STATUS.COMPLETE, lastActivityAt: NOW - 60_000 });
   const cloud = normalizeSession(
@@ -583,9 +582,8 @@ test("a scheduled roster look carries the roster and only the transcripts that g
       };
     },
   });
-  h.agent.start();
-  assert.equal(h.client.inputs.length, 0);
-  await h.clock.advance(NOW + BRAIN_ROSTER_WAKE_INTERVAL_MS);
+  h.agent.rosterLook();
+  await settle();
 
   assert.equal(h.client.inputs.length, 1);
   const input = h.client.inputs[0] ?? [];
@@ -606,8 +604,9 @@ test("a scheduled roster look carries the roster and only the transcripts that g
   assert.deepEqual(read, ["abc"]);
   assert.equal(h.traces[0]?.trigger, BRAIN_TURN_TRIGGER.ROSTER);
 
-  // The look repeats on its own clock.
-  await h.clock.advance(NOW + 2 * BRAIN_ROSTER_WAKE_INTERVAL_MS);
+  // The look can be triggered again by the host.
+  h.agent.rosterLook();
+  await settle();
   assert.equal(h.client.inputs.length, 2);
   await h.agent.stop();
 });
@@ -620,12 +619,14 @@ test("a roster look is skipped while the client is quiet or a turn is in flight"
       sessions: [session("abc", { status: SESSION_STATUS.WORKING })],
     }),
   });
-  h.agent.start();
-  h.client.quiet = NOW + BRAIN_ROSTER_WAKE_INTERVAL_MS + 30_000;
-  await h.clock.advance(NOW + BRAIN_ROSTER_WAKE_INTERVAL_MS);
+
+  // Quiet: the look is skipped.
+  h.client.quiet = NOW + 30_000;
+  h.agent.rosterLook();
+  await settle();
   assert.equal(h.client.inputs.length, 0);
 
-  // Quiet over, but a turn is under way: the look yields and the next one catches up.
+  // Quiet over, but a turn is under way: the look yields.
   h.client.quiet = undefined;
   let release: (() => void) | undefined;
   const slow = new Promise<void>((resolve) => {
@@ -638,13 +639,17 @@ test("a roster look is skipped while the client is quiet or a turn is in flight"
   };
   const ask = h.agent.ask("what's up?");
   await settle();
-  await h.clock.advance(NOW + 2 * BRAIN_ROSTER_WAKE_INTERVAL_MS);
+  h.agent.rosterLook();
+  await settle();
   assert.equal(h.client.inputs.length, 0);
   release?.();
   await ask;
   await settle();
   assert.equal(h.client.inputs.length, 1);
-  await h.clock.advance(NOW + 3 * BRAIN_ROSTER_WAKE_INTERVAL_MS);
+
+  // After the turn completes, the look proceeds.
+  h.agent.rosterLook();
+  await settle();
   assert.equal(h.client.inputs.length, 2);
   assert.equal(h.traces.at(-1)?.trigger, BRAIN_TURN_TRIGGER.ROSTER);
   await h.agent.stop();

--- a/packages/brain/src/brain-agent.ts
+++ b/packages/brain/src/brain-agent.ts
@@ -68,15 +68,6 @@ export const BRAIN_DEFAULTS = {
   FULL_TRANSCRIPT_CHARS: 60_000,
 } as const;
 
-/**
- * How often the brain looks at the whole roster on its own clock, for the
- * providers no hook covers and for whatever a hook did not report. A look is
- * skipped while a turn is in flight or the client is quiet; the next one
- * catches up, because the look reads what each transcript gained since the
- * brain last saw it rather than what happened in the interval.
- */
-export const BRAIN_ROSTER_WAKE_INTERVAL_MS = 60_000;
-
 /** Stands where the front of a transcript was cut, so the model knows it is reading a tail. */
 export const OMISSION_MARKER = "[… earlier transcript omitted …]";
 
@@ -171,7 +162,6 @@ export interface BrainAgentOptions {
   askDeadlineMs?: number;
   deltaPerSessionChars?: number;
   fullTranscriptChars?: number;
-  rosterWakeIntervalMs?: number;
 }
 
 const TURN_OUTCOME = {
@@ -265,9 +255,7 @@ export class BrainAgent {
   readonly #askDeadlineMs: number;
   readonly #deltaPerSessionChars: number;
   readonly #fullTranscriptChars: number;
-  readonly #rosterWakeIntervalMs: number;
   #memory = new BrainMemory();
-  #rosterTimer: ScheduledTimer | undefined;
   #turnInFlight = false;
   #restored: Promise<void> | undefined;
   #queue: Promise<unknown> = Promise.resolve();
@@ -294,13 +282,6 @@ export class BrainAgent {
     this.#deltaPerSessionChars =
       options.deltaPerSessionChars ?? BRAIN_DEFAULTS.DELTA_PER_SESSION_CHARS;
     this.#fullTranscriptChars = options.fullTranscriptChars ?? BRAIN_DEFAULTS.FULL_TRANSCRIPT_CHARS;
-    this.#rosterWakeIntervalMs = options.rosterWakeIntervalMs ?? BRAIN_ROSTER_WAKE_INTERVAL_MS;
-  }
-
-  /** Starts the scheduled roster looks; nothing is sent until the first interval has passed. */
-  start(): void {
-    if (this.#stopped || this.#rosterTimer !== undefined) return;
-    this.#scheduleRosterLook();
   }
 
   /** How many wakes are waiting for their turn to open. */
@@ -373,31 +354,20 @@ export class BrainAgent {
   async stop(): Promise<void> {
     this.#stopped = true;
     this.#cancelFlush();
-    if (this.#rosterTimer !== undefined) {
-      this.#cancel(this.#rosterTimer);
-      this.#rosterTimer = undefined;
-    }
     this.#pending = [];
     await this.#queue;
   }
 
-  #scheduleRosterLook(): void {
-    this.#rosterTimer = this.#schedule(() => {
-      this.#rosterTimer = undefined;
-      this.#rosterLook();
-      if (!this.#stopped) this.#scheduleRosterLook();
-    }, this.#rosterWakeIntervalMs);
-  }
-
   /**
-   * The scheduled look at the whole roster: one turn carrying the roster as
-   * `list_sessions` renders it and, for every local session the brain has
-   * read before or that is working or waiting now, what its transcript gained
-   * since — sessions with nothing new are left out. Skipped while a turn is in
-   * flight or the client is quiet, because the next look reads the same
-   * deltas; pending hook wakes ride along rather than waiting for their own.
+   * One look at the whole roster, driven by the host's observation pass rather
+   * than an internal timer. Carries the roster as `list_sessions` renders it
+   * and, for every local session the brain has read before or that is working
+   * or waiting now, what its transcript gained since — sessions with nothing
+   * new are left out. Skipped while a turn is in flight or the client is
+   * quiet, because the next look reads the same deltas; pending hook wakes
+   * ride along rather than waiting for their own.
    */
-  #rosterLook(): void {
+  rosterLook(): void {
     if (this.#stopped || this.#turnInFlight) return;
     if (this.#options.client.quietUntil() !== undefined) return;
     const roster = this.#options.roster();

--- a/packages/session/src/workspace-opens.ts
+++ b/packages/session/src/workspace-opens.ts
@@ -9,7 +9,7 @@ import type { Session, SessionIdentity } from "./session.js";
  * read as the answer to the ask that created it, so the entry lapses and the
  * workspace stays where every other session starts: on its row, unopened.
  */
-export const CREATED_WORKSPACE_OPEN_WINDOW_MS = 2 * 60_000;
+export const CREATED_WORKSPACE_OPEN_WINDOW_MS = 5 * 60_000;
 
 /**
  * The created workspaces still waiting to be opened on the developer's screen.


### PR DESCRIPTION
## Summary

- **One clock at 60s**: `SESSION_REFRESH_INTERVAL_MS` 5 000 → 60 000. The `BRAIN_ROSTER_WAKE_INTERVAL_MS` constant and `BrainAgent`'s internal timer are removed entirely; the roster look is now driven by `afterRun` on the observation pass instead.
- **`BrainAgent.rosterLook()` replaces `start()`**: the host calls it after each observation pass completes; `start()`/`stop()` are simplified — `stop()` remains to drain the queue at shutdown, `start()` is gone. The agent remains fully testable without Electron.
- **Act validation freshness**: `performSession` calls `refreshSessions()` (→ `sessionObservationLoop.refresh()`) before reading the session list. A fresh pass before every session act closes the staleness window from ≤60 s to effectively zero for messages, renames, controls (including delete), creates, and opens. If the loop is already running, `refresh()` queues the next pass and returns immediately; validation then uses the most recent completed-pass data, which is close to fresh.
- **`CREATED_WORKSPACE_OPEN_WINDOW_MS`**: 2 min → 5 min. At 60 s per pass, 2 minutes was only 2 chances; 5 minutes gives 5, covering providers that are slow to publish a deep link.

## Behavioral changes

**Observation gate on the roster look (deliberate)**

The roster look now runs inside `afterRun`, which is only called when `isCurrent(generation)` holds — meaning `runMode.observesProviders && accountCapabilitiesActive()`. `BrainAgent`'s own timer was not subject to this gate. That is believed correct — a brain looking at a roster nobody is observing is odd — but it is a deliberate change from the previous behaviour where the timer ran independently.

**Codex CLI login latency**

`broadcastCodexCloudConnection()` still rides `afterRun` with nothing else behind it; Codex CLI login changes now take up to 60 s to propagate. This is acceptable — the user manually ran `codex login` or `codex logout` in their own terminal, and a 60 s delay does not affect anything safety-bearing.

**All session acts refresh, not only writes**

The fresh pass fires before creates and opens too, not only before messages, renames, and deletes. Creates validate against project offers (which the refreshed adapters also update); opens and read-transcript are read-only but cheap to gate. The overhead of one extra observation pass per brain act is acceptable given the correctness benefit at 60 s intervals.

## Test plan

- [x] `./scripts/check.sh` passes: 0 errors (20 pre-existing CSS specificity warnings in unchanged files), all 798 desktop tests pass, 34 brain tests pass, 57 session tests pass, all typechecks clean
- [ ] Physical-notch check not performed (no UI surface change; this is a main-process timing change only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/36938e52-b0a2-46b9-8798-9d49be6df51b)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/33836880393/artifacts/9923631178) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/33836880393)

- Commit: `809900c5f5dca85442e14d8952b84b1ac6b4798e`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
