### PR TITLE
feat(ios): watchOS push-to-talk

### DIFF
--- a/apps/ios/Luke.xcodeproj/project.pbxproj
+++ b/apps/ios/Luke.xcodeproj/project.pbxproj
@@ -45,6 +45,10 @@
 		AABBCC0000000000000000D7 /* VoiceActDispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABBCC0000000000000000D3 /* VoiceActDispatcher.swift */; };
 		AABBCC0000000000000000D9 /* VoiceSettingsSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABBCC0000000000000000D8 /* VoiceSettingsSheet.swift */; };
 		AABBCC0000000000000000F9 /* SessionsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABBCC0000000000000000F8 /* SessionsStore.swift */; };
+		AABBCC0000000000000000E6 /* WatchVoiceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABBCC0000000000000000E5 /* WatchVoiceView.swift */; };
+		AABBCC0000000000000000E8 /* WatchVoiceSessionModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABBCC0000000000000000E7 /* WatchVoiceSessionModel.swift */; };
+		AABBCC0000000000000000EA /* WatchAudioCapturer.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABBCC0000000000000000E9 /* WatchAudioCapturer.swift */; };
+		AABBCC0000000000000000EC /* WatchAudioPlayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABBCC0000000000000000EB /* WatchAudioPlayer.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -107,6 +111,10 @@
 		AABBCC0000000000000000D3 /* VoiceActDispatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceActDispatcher.swift; sourceTree = "<group>"; };
 		AABBCC0000000000000000D8 /* VoiceSettingsSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceSettingsSheet.swift; sourceTree = "<group>"; };
 		AABBCC0000000000000000F8 /* SessionsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionsStore.swift; sourceTree = "<group>"; };
+		AABBCC0000000000000000E5 /* WatchVoiceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchVoiceView.swift; sourceTree = "<group>"; };
+		AABBCC0000000000000000E7 /* WatchVoiceSessionModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchVoiceSessionModel.swift; sourceTree = "<group>"; };
+		AABBCC0000000000000000E9 /* WatchAudioCapturer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchAudioCapturer.swift; sourceTree = "<group>"; };
+		AABBCC0000000000000000EB /* WatchAudioPlayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchAudioPlayer.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -208,6 +216,10 @@
 				AABBCC0000000000000000C3 /* WatchConnectivityReceiver.swift */,
 				AABBCC0000000000000000E1 /* WatchRosterStore.swift */,
 				AABBCC0000000000000000E3 /* WatchRosterView.swift */,
+				AABBCC0000000000000000E5 /* WatchVoiceView.swift */,
+				AABBCC0000000000000000E7 /* WatchVoiceSessionModel.swift */,
+				AABBCC0000000000000000E9 /* WatchAudioCapturer.swift */,
+				AABBCC0000000000000000EB /* WatchAudioPlayer.swift */,
 				AABBCC0000000000000000B2 /* Assets.xcassets */,
 			);
 			path = LukeWatch;
@@ -406,6 +418,10 @@
 				AABBCC0000000000000000C9 /* WatchConnectivityReceiver.swift in Sources */,
 				AABBCC0000000000000000E2 /* WatchRosterStore.swift in Sources */,
 				AABBCC0000000000000000E4 /* WatchRosterView.swift in Sources */,
+				AABBCC0000000000000000E6 /* WatchVoiceView.swift in Sources */,
+				AABBCC0000000000000000E8 /* WatchVoiceSessionModel.swift in Sources */,
+				AABBCC0000000000000000EA /* WatchAudioCapturer.swift in Sources */,
+				AABBCC0000000000000000EC /* WatchAudioPlayer.swift in Sources */,
 				AABBCC0000000000000000F4 /* MarkdownMessageView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -651,6 +667,7 @@
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_CFBundleDisplayName = Luke;
+				INFOPLIST_KEY_NSMicrophoneUsageDescription = "Luke uses the microphone to hear your voice when you hold the talk button.";
 				INFOPLIST_KEY_WKCompanionAppBundleIdentifier = dev.tryluke.ios;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -678,6 +695,7 @@
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_CFBundleDisplayName = Luke;
+				INFOPLIST_KEY_NSMicrophoneUsageDescription = "Luke uses the microphone to hear your voice when you hold the talk button.";
 				INFOPLIST_KEY_WKCompanionAppBundleIdentifier = dev.tryluke.ios;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/apps/ios/Luke.xcodeproj/project.pbxproj
+++ b/apps/ios/Luke.xcodeproj/project.pbxproj
@@ -49,6 +49,7 @@
 		AABBCC0000000000000000E8 /* WatchVoiceSessionModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABBCC0000000000000000E7 /* WatchVoiceSessionModel.swift */; };
 		AABBCC0000000000000000EA /* WatchAudioCapturer.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABBCC0000000000000000E9 /* WatchAudioCapturer.swift */; };
 		AABBCC0000000000000000EC /* WatchAudioPlayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABBCC0000000000000000EB /* WatchAudioPlayer.swift */; };
+		AABBCC0000000000000000EE /* WatchLukeMark.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABBCC0000000000000000ED /* WatchLukeMark.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -115,6 +116,7 @@
 		AABBCC0000000000000000E7 /* WatchVoiceSessionModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchVoiceSessionModel.swift; sourceTree = "<group>"; };
 		AABBCC0000000000000000E9 /* WatchAudioCapturer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchAudioCapturer.swift; sourceTree = "<group>"; };
 		AABBCC0000000000000000EB /* WatchAudioPlayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchAudioPlayer.swift; sourceTree = "<group>"; };
+		AABBCC0000000000000000ED /* WatchLukeMark.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchLukeMark.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -220,6 +222,7 @@
 				AABBCC0000000000000000E7 /* WatchVoiceSessionModel.swift */,
 				AABBCC0000000000000000E9 /* WatchAudioCapturer.swift */,
 				AABBCC0000000000000000EB /* WatchAudioPlayer.swift */,
+				AABBCC0000000000000000ED /* WatchLukeMark.swift */,
 				AABBCC0000000000000000B2 /* Assets.xcassets */,
 			);
 			path = LukeWatch;
@@ -422,6 +425,7 @@
 				AABBCC0000000000000000E8 /* WatchVoiceSessionModel.swift in Sources */,
 				AABBCC0000000000000000EA /* WatchAudioCapturer.swift in Sources */,
 				AABBCC0000000000000000EC /* WatchAudioPlayer.swift in Sources */,
+				AABBCC0000000000000000EE /* WatchLukeMark.swift in Sources */,
 				AABBCC0000000000000000F4 /* MarkdownMessageView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/apps/ios/LukeWatch/LukeWatchView.swift
+++ b/apps/ios/LukeWatch/LukeWatchView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct LukeWatchView: View {
     @Environment(WatchAccountSession.self) private var watchSession
     @Environment(WatchRosterStore.self) private var rosterStore
+    @State private var selectedTab = 0
 
     var body: some View {
         Group {
@@ -10,9 +11,15 @@ struct LukeWatchView: View {
             case .signedOut:
                 SignedOutView()
             case .signedIn:
-                NavigationStack {
-                    WatchRosterView()
+                TabView(selection: $selectedTab) {
+                    WatchVoiceView()
+                        .tag(0)
+                    NavigationStack {
+                        WatchRosterView()
+                    }
+                    .tag(1)
                 }
+                .tabViewStyle(.page)
                 .id(watchSession.accountScope)
             }
         }

--- a/apps/ios/LukeWatch/WatchAudioCapturer.swift
+++ b/apps/ios/LukeWatch/WatchAudioCapturer.swift
@@ -19,7 +19,7 @@ final class WatchAudioCapturer: AudioCapturer, @unchecked Sendable {
         }
 
         let audioSession = AVAudioSession.sharedInstance()
-        try audioSession.setCategory(.playAndRecord, mode: .default, options: [.defaultToSpeaker])
+        try audioSession.setCategory(.playAndRecord, mode: .default)
         try audioSession.setActive(true)
 
         let inputNode = engine.inputNode

--- a/apps/ios/LukeWatch/WatchAudioCapturer.swift
+++ b/apps/ios/LukeWatch/WatchAudioCapturer.swift
@@ -1,0 +1,94 @@
+import AVFoundation
+import LukeKit
+
+/// Captures 24 kHz PCM16 mono audio from the microphone using AVAudioEngine.
+/// Mirror of VoiceAudioCapturer without allowBluetoothHFP, which is unnecessary
+/// on watchOS where the watch owns its own Bluetooth audio routing.
+///
+/// Callers should request microphone permission before this is instantiated;
+/// on watchOS 10 the system presents the permission sheet when the engine tap
+/// begins if permission is undetermined, and engine.start() raises an error
+/// if permission was denied.
+final class WatchAudioCapturer: AudioCapturer, @unchecked Sendable {
+    private let engine = AVAudioEngine()
+    private var hasTap = false
+
+    func start() throws -> AsyncStream<[Int16]> {
+        guard AVAudioSession.sharedInstance().recordPermission != .denied else {
+            throw CocoaError(.fileReadUnknown)
+        }
+
+        let audioSession = AVAudioSession.sharedInstance()
+        try audioSession.setCategory(.playAndRecord, mode: .default, options: [.defaultToSpeaker])
+        try audioSession.setActive(true)
+
+        let inputNode = engine.inputNode
+        let hwFormat = inputNode.outputFormat(forBus: 0)
+        // Reject the zero-channel format the simulator can report while its
+        // microphone route changes, the same guard VoiceAudioCapturer keeps.
+        guard hwFormat.sampleRate > 0, hwFormat.channelCount > 0,
+              let targetFormat = AVAudioFormat(
+                commonFormat: .pcmFormatFloat32,
+                sampleRate: Double(PressAudioBuffer.sampleRate),
+                channels: 1,
+                interleaved: false
+              ),
+              let converter = AVAudioConverter(from: hwFormat, to: targetFormat)
+        else {
+            throw CocoaError(.fileReadUnknown)
+        }
+
+        let hwRate = hwFormat.sampleRate
+        let targetRate = targetFormat.sampleRate
+        let (stream, continuation) = AsyncStream<[Int16]>.makeStream()
+
+        inputNode.installTap(onBus: 0, bufferSize: 4096, format: hwFormat) { buffer, _ in
+            let capacity = AVAudioFrameCount(Double(buffer.frameLength) * targetRate / hwRate)
+            guard capacity > 0,
+                  let converted = AVAudioPCMBuffer(
+                    pcmFormat: targetFormat, frameCapacity: max(capacity, 1))
+            else { return }
+            var error: NSError?
+            var consumed = false
+            converter.convert(to: converted, error: &error) { _, status in
+                if consumed {
+                    status.pointee = .noDataNow
+                    return nil
+                }
+                consumed = true
+                status.pointee = .haveData
+                return buffer
+            }
+            guard error == nil, converted.frameLength > 0,
+                  let channelData = converted.floatChannelData else { return }
+            let count = Int(converted.frameLength)
+            let ptr = channelData[0]
+            var samples = [Int16](repeating: 0, count: count)
+            for i in 0 ..< count {
+                let clamped = max(-1.0, min(1.0, ptr[i]))
+                samples[i] = Int16(clamped * 32767.0)
+            }
+            continuation.yield(samples)
+        }
+        hasTap = true
+
+        do {
+            try engine.start()
+        } catch {
+            inputNode.removeTap(onBus: 0)
+            hasTap = false
+            throw error
+        }
+        continuation.onTermination = { [weak self] _ in self?.engine.stop() }
+        return stream
+    }
+
+    func stop() {
+        if hasTap {
+            engine.inputNode.removeTap(onBus: 0)
+            hasTap = false
+        }
+        engine.stop()
+        try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
+    }
+}

--- a/apps/ios/LukeWatch/WatchAudioCapturer.swift
+++ b/apps/ios/LukeWatch/WatchAudioCapturer.swift
@@ -14,7 +14,7 @@ final class WatchAudioCapturer: AudioCapturer, @unchecked Sendable {
     private var hasTap = false
 
     func start() throws -> AsyncStream<[Int16]> {
-        guard AVAudioSession.sharedInstance().recordPermission != .denied else {
+        guard AVAudioApplication.shared.recordPermission != .denied else {
             throw CocoaError(.fileReadUnknown)
         }
 

--- a/apps/ios/LukeWatch/WatchAudioPlayer.swift
+++ b/apps/ios/LukeWatch/WatchAudioPlayer.swift
@@ -1,0 +1,60 @@
+import AVFoundation
+import LukeKit
+
+/// Plays 24 kHz PCM16 mono audio through the speaker using AVAudioPlayerNode.
+/// Mirror of VoiceAudioPlayer without allowBluetoothHFP, which is unnecessary
+/// on watchOS where the watch owns its own Bluetooth audio routing.
+final class WatchAudioPlayer: AudioPlayer, @unchecked Sendable {
+    private let engine = AVAudioEngine()
+    private let playerNode = AVAudioPlayerNode()
+    private let format: AVAudioFormat
+
+    init() {
+        let audioSession = AVAudioSession.sharedInstance()
+        try? audioSession.setCategory(.playAndRecord, mode: .default, options: [.defaultToSpeaker])
+        try? audioSession.setActive(true)
+        format = AVAudioFormat(
+            commonFormat: .pcmFormatFloat32,
+            sampleRate: Double(PressAudioBuffer.sampleRate),
+            channels: 1,
+            interleaved: false
+        )!
+        engine.attach(playerNode)
+        engine.connect(playerNode, to: engine.mainMixerNode, format: format)
+        try? engine.start()
+        playerNode.play()
+    }
+
+    func enqueue(_ samples: [Int16]) {
+        guard !samples.isEmpty else { return }
+        guard let buffer = AVAudioPCMBuffer(
+            pcmFormat: format,
+            frameCapacity: AVAudioFrameCount(samples.count)
+        ) else { return }
+        buffer.frameLength = buffer.frameCapacity
+        if let channelData = buffer.floatChannelData {
+            for (i, sample) in samples.enumerated() {
+                channelData[0][i] = Float(sample) / 32768.0
+            }
+        }
+        playerNode.scheduleBuffer(buffer, completionHandler: nil)
+    }
+
+    func drain(then completion: @MainActor @Sendable @escaping () -> Void) {
+        guard let sentinel = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: 1) else {
+            Task { @MainActor in completion() }
+            return
+        }
+        sentinel.frameLength = 1
+        sentinel.floatChannelData?[0][0] = 0
+        playerNode.scheduleBuffer(sentinel, completionCallbackType: .dataConsumed) { _ in
+            Task { @MainActor in completion() }
+        }
+    }
+
+    func stop() {
+        playerNode.stop()
+        engine.stop()
+        try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
+    }
+}

--- a/apps/ios/LukeWatch/WatchAudioPlayer.swift
+++ b/apps/ios/LukeWatch/WatchAudioPlayer.swift
@@ -11,7 +11,7 @@ final class WatchAudioPlayer: AudioPlayer, @unchecked Sendable {
 
     init() {
         let audioSession = AVAudioSession.sharedInstance()
-        try? audioSession.setCategory(.playAndRecord, mode: .default, options: [.defaultToSpeaker])
+        try? audioSession.setCategory(.playAndRecord, mode: .default)
         try? audioSession.setActive(true)
         format = AVAudioFormat(
             commonFormat: .pcmFormatFloat32,

--- a/apps/ios/LukeWatch/WatchLukeMark.swift
+++ b/apps/ios/LukeWatch/WatchLukeMark.swift
@@ -1,0 +1,58 @@
+import CoreGraphics
+import SwiftUI
+
+// Luke face mark for watchOS. Hand copy of FaceArt + LukeMark from
+// apps/ios/Luke/Marks.swift — change both when the artwork moves.
+// The UIKit import and motion/animation paths are omitted; the watch
+// mark is static and UIKit is unavailable on watchOS.
+
+private enum FaceArt {
+    static let markBox = CGRect(x: 53.85, y: 62.67, width: 134.29, height: 122.37)
+    static let strokeWidth: CGFloat = 16
+    static let eyeY: CGFloat = 92
+    static let eyeRadius: CGFloat = 12
+    static let eyeXs: [CGFloat] = [78, 162]
+    private static let tiltDegrees: CGFloat = -8
+    private static let tiltPivot = CGPoint(x: 120, y: 124)
+
+    static let smile: Path = {
+        var path = Path()
+        path.move(to: CGPoint(x: 104, y: 84))
+        path.addLine(to: CGPoint(x: 104, y: 150))
+        path.addQuadCurve(to: CGPoint(x: 118, y: 164), control: CGPoint(x: 104, y: 164))
+        path.addQuadCurve(to: CGPoint(x: 168, y: 142), control: CGPoint(x: 140, y: 164))
+        return path
+    }()
+
+    static let tilt = CGAffineTransform(translationX: tiltPivot.x, y: tiltPivot.y)
+        .rotated(by: tiltDegrees * .pi / 180)
+        .translatedBy(x: -tiltPivot.x, y: -tiltPivot.y)
+
+    static func draw(_ ctx: GraphicsContext, size: CGSize) {
+        let box = markBox
+        let scale = min(size.width / box.width, size.height / box.height)
+        let placement = CGAffineTransform(scaleX: scale, y: scale)
+            .translatedBy(x: -box.minX, y: -box.minY)
+        let t = tilt.concatenating(placement)
+        ctx.stroke(
+            smile.applying(t), with: .foreground,
+            style: StrokeStyle(lineWidth: strokeWidth * scale, lineCap: .round, lineJoin: .round)
+        )
+        for eyeX in eyeXs {
+            let eye = CGRect(
+                x: eyeX - eyeRadius, y: eyeY - eyeRadius,
+                width: eyeRadius * 2, height: eyeRadius * 2
+            )
+            ctx.fill(Path(ellipseIn: eye).applying(t), with: .foreground)
+        }
+    }
+}
+
+struct WatchLukeMark: View {
+    var body: some View {
+        Canvas { ctx, size in
+            FaceArt.draw(ctx, size: size)
+        }
+        .aspectRatio(FaceArt.markBox.width / FaceArt.markBox.height, contentMode: .fit)
+    }
+}

--- a/apps/ios/LukeWatch/WatchRosterView.swift
+++ b/apps/ios/LukeWatch/WatchRosterView.swift
@@ -48,15 +48,6 @@ struct WatchRosterView: View {
             }
         }
         .navigationTitle("Sessions")
-        .toolbar {
-            ToolbarItem(placement: .topBarTrailing) {
-                NavigationLink {
-                    WatchVoiceView()
-                } label: {
-                    Label("Talk to Luke", systemImage: "mic.fill")
-                }
-            }
-        }
         .navigationDestination(for: RosterSession.self) { session in
             WatchSessionDetailView(session: session)
         }

--- a/apps/ios/LukeWatch/WatchRosterView.swift
+++ b/apps/ios/LukeWatch/WatchRosterView.swift
@@ -48,6 +48,15 @@ struct WatchRosterView: View {
             }
         }
         .navigationTitle("Sessions")
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                NavigationLink {
+                    WatchVoiceView()
+                } label: {
+                    Label("Talk to Luke", systemImage: "mic.fill")
+                }
+            }
+        }
         .navigationDestination(for: RosterSession.self) { session in
             WatchSessionDetailView(session: session)
         }

--- a/apps/ios/LukeWatch/WatchVoiceSessionModel.swift
+++ b/apps/ios/LukeWatch/WatchVoiceSessionModel.swift
@@ -28,6 +28,9 @@ final class WatchVoiceSessionModel {
     private var connectingForTurn = false
     private var endTurnAfterConnect = false
     private var connectTask: Task<Void, Never>?
+    // Tracks whether we are mid-caption-segment for the current luke reply.
+    // nil from onCaption closes the segment so the next text starts a new bubble.
+    private var lukeReplyOpen = false
 
     func prepare(accountSession: WatchAccountSession) {
         self.accountSession = accountSession
@@ -55,16 +58,28 @@ final class WatchVoiceSessionModel {
                 if newStatus == .idle { self?.session = nil }
             },
             onCaption: { [weak self] text in
-                guard let self, let text else { return }
-                if let lastIndex = self.messages.indices.last,
-                   self.messages[lastIndex].speaker == .luke
-                {
-                    self.messages[lastIndex].text = text
+                guard let self else { return }
+                if let text {
+                    // Mid-segment: grow the current luke bubble.
+                    // New segment (lukeReplyOpen == false): always append a fresh bubble
+                    // so a multi-segment reply does not overwrite its own earlier segments.
+                    if self.lukeReplyOpen,
+                       let lastIndex = self.messages.indices.last,
+                       self.messages[lastIndex].speaker == .luke
+                    {
+                        self.messages[lastIndex].text = text
+                    } else {
+                        self.messages.append(WatchVoiceMessage(speaker: .luke, text: text))
+                        self.lukeReplyOpen = true
+                    }
                 } else {
-                    self.messages.append(WatchVoiceMessage(speaker: .luke, text: text))
+                    // nil signals segment end — the next caption begins a new bubble.
+                    self.lukeReplyOpen = false
                 }
             },
             onSpokenAsk: { [weak self] text in
+                // A new developer turn always closes the current luke segment.
+                self?.lukeReplyOpen = false
                 self?.messages.append(WatchVoiceMessage(speaker: .user, text: text))
             },
             onError: { [weak self, weak accountSession] message in
@@ -98,6 +113,7 @@ final class WatchVoiceSessionModel {
         connectTask = nil
         connectingForTurn = false
         endTurnAfterConnect = false
+        lukeReplyOpen = false
         accountSession = nil
         session?.close()
         session = nil
@@ -109,8 +125,14 @@ final class WatchVoiceSessionModel {
             session.beginTurn()
             return
         }
+        if connectingForTurn {
+            // A re-press while the mint is in flight retracts the earlier release
+            // so the turn is not immediately ended when the connection lands.
+            endTurnAfterConnect = false
+            return
+        }
         // No existing session: mint a new one and begin the turn once connected.
-        guard accountSession != nil, !connectingForTurn else { return }
+        guard accountSession != nil else { return }
         connectingForTurn = true
         endTurnAfterConnect = false
         status = .connecting

--- a/apps/ios/LukeWatch/WatchVoiceSessionModel.swift
+++ b/apps/ios/LukeWatch/WatchVoiceSessionModel.swift
@@ -2,17 +2,21 @@ import Foundation
 import LukeKit
 import Observation
 
+struct WatchVoiceMessage: Identifiable {
+    enum Speaker { case user, luke }
+    let id = UUID()
+    let speaker: Speaker
+    var text: String
+}
+
 /// Observable session state for the watch voice screen. Drives one RealtimeSession
 /// with a tool-free configuration — the watch carries no armed-act infrastructure,
 /// so dispatchToolCall always refuses and contextItems is always empty.
 @Observable
 @MainActor
 final class WatchVoiceSessionModel {
+    var messages: [WatchVoiceMessage] = []
     var status: RealtimeStatus = .idle
-    /// The developer's transcribed speech for the current exchange.
-    var spokenAsk: String = ""
-    /// Luke's streaming response caption.
-    var captionText: String = ""
     var errorMessage: String?
 
     private var session: RealtimeSession?
@@ -41,15 +45,17 @@ final class WatchVoiceSessionModel {
                 if newStatus == .idle { self?.session = nil }
             },
             onCaption: { [weak self] text in
-                // nil signals segment end or drain — preserve the last caption
-                // so it stays visible until the next spoken ask clears it.
-                if let text { self?.captionText = text }
+                guard let self, let text else { return }
+                if let lastIndex = self.messages.indices.last,
+                   self.messages[lastIndex].speaker == .luke
+                {
+                    self.messages[lastIndex].text = text
+                } else {
+                    self.messages.append(WatchVoiceMessage(speaker: .luke, text: text))
+                }
             },
             onSpokenAsk: { [weak self] text in
-                // A new developer turn began — clear the previous response caption
-                // so the screen shows the question before Luke replies.
-                self?.spokenAsk = text
-                self?.captionText = ""
+                self?.messages.append(WatchVoiceMessage(speaker: .user, text: text))
             },
             onError: { [weak self, weak accountSession] message in
                 guard let self else { return }
@@ -93,8 +99,6 @@ final class WatchVoiceSessionModel {
 
     func beginTurn() {
         errorMessage = nil
-        spokenAsk = ""
-        captionText = ""
         if let session {
             session.beginTurn()
             return

--- a/apps/ios/LukeWatch/WatchVoiceSessionModel.swift
+++ b/apps/ios/LukeWatch/WatchVoiceSessionModel.swift
@@ -1,0 +1,122 @@
+import Foundation
+import LukeKit
+import Observation
+
+/// Observable session state for the watch voice screen. Drives one RealtimeSession
+/// with a tool-free configuration — the watch carries no armed-act infrastructure,
+/// so dispatchToolCall always refuses and contextItems is always empty.
+@Observable
+@MainActor
+final class WatchVoiceSessionModel {
+    var status: RealtimeStatus = .idle
+    /// The developer's transcribed speech for the current exchange.
+    var spokenAsk: String = ""
+    /// Luke's streaming response caption.
+    var captionText: String = ""
+    var errorMessage: String?
+
+    private var session: RealtimeSession?
+    private var reconnectCallback: (@MainActor (_ startWithTurn: Bool) async -> Void)?
+    private var reconnectTurnTask: Task<Void, Never>?
+    private var reconnectingForTurn = false
+    private var endTurnAfterReconnect = false
+
+    func start(accountSession: WatchAccountSession, startWithTurn: Bool = false) async {
+        guard session == nil else { return }
+        errorMessage = nil
+
+        let opts = RealtimeSessionOptions(
+            requestConnection: { [weak accountSession] in
+                guard let accountSession else { throw AccountSessionError.signedOut }
+                let token = try await accountSession.validAccessToken()
+                return try await VoiceMintClient(baseURL: AccountConstants.serviceURL)
+                    .mint(
+                        accessToken: token,
+                        voice: RealtimeVoice.default.rawValue,
+                        speed: RealtimeVoiceSpeed.default.multiplier
+                    )
+            },
+            onStatus: { [weak self] newStatus in
+                self?.status = newStatus
+                if newStatus == .idle { self?.session = nil }
+            },
+            onCaption: { [weak self] text in self?.captionText = text },
+            onSpokenAsk: { [weak self] text in
+                // A new developer turn began — clear the previous response caption
+                // so the screen shows the question before Luke replies.
+                self?.spokenAsk = text
+                self?.captionText = ""
+            },
+            onError: { [weak self, weak accountSession] message in
+                guard let self else { return }
+                // Surface a credential failure as an actionable prompt rather
+                // than a generic error: the watch can't refresh tokens itself.
+                if accountSession?.state == .signedOut {
+                    self.errorMessage = "Open Luke on your iPhone"
+                } else {
+                    self.errorMessage = message ?? "Connection error"
+                }
+            },
+            onRecoverableError: { [weak self] message in self?.errorMessage = message },
+            onSessionTools: { _ in },
+            dispatchToolCall: { _, _, _ in
+                // The watch carries no armed-act infrastructure. Tool calls are
+                // refused here rather than implementing a partial gate.
+                #"{"error":"not authorized"}"#
+            },
+            contextItems: { [] },
+            makeAudioCapturer: { WatchAudioCapturer() },
+            makeAudioPlayer: { WatchAudioPlayer() }
+        )
+        reconnectCallback = { [weak self, weak accountSession] startWithTurn in
+            guard let accountSession else { return }
+            await self?.start(accountSession: accountSession, startWithTurn: startWithTurn)
+        }
+        let s = RealtimeSession(options: opts)
+        session = s
+        await s.connect(startWithTurn: startWithTurn)
+    }
+
+    func stop() {
+        reconnectTurnTask?.cancel()
+        reconnectTurnTask = nil
+        reconnectingForTurn = false
+        endTurnAfterReconnect = false
+        reconnectCallback = nil
+        session?.close()
+        session = nil
+    }
+
+    func beginTurn() {
+        errorMessage = nil
+        spokenAsk = ""
+        captionText = ""
+        if let session {
+            session.beginTurn()
+            return
+        }
+        guard let reconnect = reconnectCallback, !reconnectingForTurn else { return }
+        reconnectingForTurn = true
+        endTurnAfterReconnect = false
+        status = .connecting
+        reconnectTurnTask = Task { [weak self] in
+            await reconnect(true)
+            guard let self, !Task.isCancelled, self.reconnectingForTurn else { return }
+            self.reconnectingForTurn = false
+            self.reconnectTurnTask = nil
+            if self.endTurnAfterReconnect {
+                self.endTurnAfterReconnect = false
+                self.session?.endTurn()
+            }
+        }
+    }
+
+    func endTurn() {
+        if reconnectingForTurn {
+            endTurnAfterReconnect = true
+            session?.endTurn()
+        } else {
+            session?.endTurn()
+        }
+    }
+}

--- a/apps/ios/LukeWatch/WatchVoiceSessionModel.swift
+++ b/apps/ios/LukeWatch/WatchVoiceSessionModel.swift
@@ -31,6 +31,10 @@ final class WatchVoiceSessionModel {
     // Tracks whether we are mid-caption-segment for the current luke reply.
     // nil from onCaption closes the segment so the next text starts a new bubble.
     private var lukeReplyOpen = false
+    // Index into messages[] where the current turn began. onSpokenAsk inserts the
+    // user bubble here rather than appending, because the realtime service delivers
+    // the transcript after captions have already started arriving.
+    private var turnStartIndex = 0
 
     func prepare(accountSession: WatchAccountSession) {
         self.accountSession = accountSession
@@ -78,9 +82,14 @@ final class WatchVoiceSessionModel {
                 }
             },
             onSpokenAsk: { [weak self] text in
-                // A new developer turn always closes the current luke segment.
-                self?.lukeReplyOpen = false
-                self?.messages.append(WatchVoiceMessage(speaker: .user, text: text))
+                guard let self else { return }
+                // Insert at turnStartIndex, not at the end: captions typically
+                // arrive before the transcript, so the user bubble must be placed
+                // before Luke's reply rather than after it.
+                let insertAt = min(self.turnStartIndex, self.messages.count)
+                self.messages.insert(WatchVoiceMessage(speaker: .user, text: text), at: insertAt)
+                // Leave lukeReplyOpen as-is: the reply segment that started before
+                // the transcript arrived should keep growing from the last bubble.
             },
             onError: { [weak self, weak accountSession] message in
                 guard let self else { return }
@@ -114,6 +123,7 @@ final class WatchVoiceSessionModel {
         connectingForTurn = false
         endTurnAfterConnect = false
         lukeReplyOpen = false
+        turnStartIndex = 0
         accountSession = nil
         session?.close()
         session = nil
@@ -121,6 +131,7 @@ final class WatchVoiceSessionModel {
 
     func beginTurn() {
         errorMessage = nil
+        turnStartIndex = messages.count
         if let session {
             session.beginTurn()
             return

--- a/apps/ios/LukeWatch/WatchVoiceSessionModel.swift
+++ b/apps/ios/LukeWatch/WatchVoiceSessionModel.swift
@@ -12,6 +12,10 @@ struct WatchVoiceMessage: Identifiable {
 /// Observable session state for the watch voice screen. Drives one RealtimeSession
 /// with a tool-free configuration — the watch carries no armed-act infrastructure,
 /// so dispatchToolCall always refuses and contextItems is always empty.
+///
+/// The session is not minted until the developer presses the talk button
+/// (beginTurn). prepare(accountSession:) is called on view appear to store the
+/// credential reference without opening any connection.
 @Observable
 @MainActor
 final class WatchVoiceSessionModel {
@@ -19,14 +23,18 @@ final class WatchVoiceSessionModel {
     var status: RealtimeStatus = .idle
     var errorMessage: String?
 
+    private var accountSession: WatchAccountSession?
     private var session: RealtimeSession?
-    private var reconnectCallback: (@MainActor (_ startWithTurn: Bool) async -> Void)?
-    private var reconnectTurnTask: Task<Void, Never>?
-    private var reconnectingForTurn = false
-    private var endTurnAfterReconnect = false
+    private var connectingForTurn = false
+    private var endTurnAfterConnect = false
+    private var connectTask: Task<Void, Never>?
 
-    func start(accountSession: WatchAccountSession, startWithTurn: Bool = false) async {
-        guard session == nil else { return }
+    func prepare(accountSession: WatchAccountSession) {
+        self.accountSession = accountSession
+    }
+
+    private func connect(startWithTurn: Bool) async {
+        guard session == nil, let accountSession else { return }
         errorMessage = nil
 
         let opts = RealtimeSessionOptions(
@@ -42,6 +50,8 @@ final class WatchVoiceSessionModel {
             },
             onStatus: { [weak self] newStatus in
                 self?.status = newStatus
+                // An idle timeout releases the socket so the next button press
+                // remints rather than sending on a stale connection.
                 if newStatus == .idle { self?.session = nil }
             },
             onCaption: { [weak self] text in
@@ -78,21 +88,17 @@ final class WatchVoiceSessionModel {
             makeAudioCapturer: { WatchAudioCapturer() },
             makeAudioPlayer: { WatchAudioPlayer() }
         )
-        reconnectCallback = { [weak self, weak accountSession] startWithTurn in
-            guard let accountSession else { return }
-            await self?.start(accountSession: accountSession, startWithTurn: startWithTurn)
-        }
         let s = RealtimeSession(options: opts)
         session = s
         await s.connect(startWithTurn: startWithTurn)
     }
 
     func stop() {
-        reconnectTurnTask?.cancel()
-        reconnectTurnTask = nil
-        reconnectingForTurn = false
-        endTurnAfterReconnect = false
-        reconnectCallback = nil
+        connectTask?.cancel()
+        connectTask = nil
+        connectingForTurn = false
+        endTurnAfterConnect = false
+        accountSession = nil
         session?.close()
         session = nil
     }
@@ -103,25 +109,26 @@ final class WatchVoiceSessionModel {
             session.beginTurn()
             return
         }
-        guard let reconnect = reconnectCallback, !reconnectingForTurn else { return }
-        reconnectingForTurn = true
-        endTurnAfterReconnect = false
+        // No existing session: mint a new one and begin the turn once connected.
+        guard accountSession != nil, !connectingForTurn else { return }
+        connectingForTurn = true
+        endTurnAfterConnect = false
         status = .connecting
-        reconnectTurnTask = Task { [weak self] in
-            await reconnect(true)
-            guard let self, !Task.isCancelled, self.reconnectingForTurn else { return }
-            self.reconnectingForTurn = false
-            self.reconnectTurnTask = nil
-            if self.endTurnAfterReconnect {
-                self.endTurnAfterReconnect = false
+        connectTask = Task { [weak self] in
+            await self?.connect(startWithTurn: true)
+            guard let self, !Task.isCancelled, self.connectingForTurn else { return }
+            self.connectingForTurn = false
+            self.connectTask = nil
+            if self.endTurnAfterConnect {
+                self.endTurnAfterConnect = false
                 self.session?.endTurn()
             }
         }
     }
 
     func endTurn() {
-        if reconnectingForTurn {
-            endTurnAfterReconnect = true
+        if connectingForTurn {
+            endTurnAfterConnect = true
             session?.endTurn()
         } else {
             session?.endTurn()

--- a/apps/ios/LukeWatch/WatchVoiceSessionModel.swift
+++ b/apps/ios/LukeWatch/WatchVoiceSessionModel.swift
@@ -40,7 +40,11 @@ final class WatchVoiceSessionModel {
                 self?.status = newStatus
                 if newStatus == .idle { self?.session = nil }
             },
-            onCaption: { [weak self] text in self?.captionText = text },
+            onCaption: { [weak self] text in
+                // nil signals segment end or drain — preserve the last caption
+                // so it stays visible until the next spoken ask clears it.
+                if let text { self?.captionText = text }
+            },
             onSpokenAsk: { [weak self] text in
                 // A new developer turn began — clear the previous response caption
                 // so the screen shows the question before Luke replies.

--- a/apps/ios/LukeWatch/WatchVoiceView.swift
+++ b/apps/ios/LukeWatch/WatchVoiceView.swift
@@ -18,7 +18,7 @@ struct WatchVoiceView: View {
             floatingControls
         }
         .task {
-            await model.start(accountSession: accountSession)
+            model.prepare(accountSession: accountSession)
         }
         .onDisappear {
             model.stop()

--- a/apps/ios/LukeWatch/WatchVoiceView.swift
+++ b/apps/ios/LukeWatch/WatchVoiceView.swift
@@ -32,11 +32,11 @@ struct WatchVoiceView: View {
             ScrollView {
                 VStack(spacing: 6) {
                     if model.messages.isEmpty {
-                        Text(model.status == .connecting ? "" : "Hold the button and speak")
-                            .font(.system(size: 13))
-                            .foregroundStyle(.tertiary)
-                            .multilineTextAlignment(.center)
+                        WatchLukeMark()
+                            .foregroundStyle(.secondary)
+                            .frame(width: 44, height: 40)
                             .frame(maxWidth: .infinity, minHeight: 80, alignment: .center)
+                            .opacity(model.status == .connecting ? 0.4 : 1)
                     } else {
                         ForEach(model.messages) { message in
                             WatchVoiceBubble(message: message)

--- a/apps/ios/LukeWatch/WatchVoiceView.swift
+++ b/apps/ios/LukeWatch/WatchVoiceView.swift
@@ -7,32 +7,16 @@ import SwiftUI
 /// The watch ships tool-free: dispatchToolCall always refuses since the armed-act
 /// infrastructure (roster validation, ActClient, ProjectsAnswer) lives on the
 /// phone. The PR notes this explicitly; a future PR may add a bounded act set.
-///
-/// Captions are drawn as plain text — the watch has no session recording to mask
-/// them from, unlike the iPhone's SessionReplay.
 struct WatchVoiceView: View {
     @Environment(WatchAccountSession.self) private var accountSession
     @State private var model = WatchVoiceSessionModel()
     @State private var isPressing = false
 
     var body: some View {
-        VStack(spacing: 4) {
-            captionArea
-            Spacer(minLength: 0)
-            statusLabel
-            if let error = model.errorMessage {
-                Text(error)
-                    .font(.system(size: 11))
-                    .foregroundStyle(.red)
-                    .multilineTextAlignment(.center)
-                    .lineLimit(2)
-            }
-            talkButton
+        ZStack(alignment: .bottom) {
+            messageThread
+            floatingControls
         }
-        .padding(.horizontal, 8)
-        .padding(.bottom, 4)
-        .navigationTitle("Luke")
-        .navigationBarTitleDisplayMode(.inline)
         .task {
             await model.start(accountSession: accountSession)
         }
@@ -41,51 +25,60 @@ struct WatchVoiceView: View {
         }
     }
 
-    // MARK: - Caption area
+    // MARK: - Message thread
 
-    private var captionArea: some View {
+    private var messageThread: some View {
         ScrollViewReader { proxy in
             ScrollView {
-                VStack(alignment: .leading, spacing: 4) {
-                    if !model.spokenAsk.isEmpty {
-                        Text(model.spokenAsk)
-                            .font(.system(size: 13))
-                            .foregroundStyle(.secondary)
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                            .id("ask")
-                    }
-                    if !model.captionText.isEmpty {
-                        Text(model.captionText)
-                            .font(.system(size: 13))
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                            .id("caption")
-                    }
-                    if model.spokenAsk.isEmpty && model.captionText.isEmpty {
-                        Text(placeholderText)
+                VStack(spacing: 6) {
+                    if model.messages.isEmpty {
+                        Text(model.status == .connecting ? "" : "Hold the button and speak")
                             .font(.system(size: 13))
                             .foregroundStyle(.tertiary)
-                            .frame(maxWidth: .infinity, alignment: .center)
                             .multilineTextAlignment(.center)
+                            .frame(maxWidth: .infinity, minHeight: 80, alignment: .center)
+                    } else {
+                        ForEach(model.messages) { message in
+                            WatchVoiceBubble(message: message)
+                                .id(message.id)
+                        }
                     }
                 }
-                .padding(.top, 4)
+                .padding(.horizontal, 4)
+                .padding(.top, 8)
+                // Bottom padding so the newest bubble clears the floating controls
+                // while still being reachable by scroll.
+                .padding(.bottom, 88)
+                .frame(maxWidth: .infinity)
             }
-            .frame(maxWidth: .infinity)
-            .onChange(of: model.captionText) {
-                withAnimation { proxy.scrollTo("caption", anchor: .bottom) }
+            .onChange(of: model.messages.count) {
+                guard let last = model.messages.last else { return }
+                withAnimation { proxy.scrollTo(last.id, anchor: .bottom) }
             }
-            .onChange(of: model.spokenAsk) {
-                withAnimation { proxy.scrollTo("ask", anchor: .top) }
+            .onChange(of: model.messages.last?.text) {
+                guard let last = model.messages.last else { return }
+                proxy.scrollTo(last.id, anchor: .bottom)
             }
         }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 
-    private var placeholderText: String {
-        switch model.status {
-        case .idle, .ready: "Hold the button and speak"
-        case .connecting: ""
-        case .listening, .thinking, .speaking: ""
+    // MARK: - Floating controls
+
+    private var floatingControls: some View {
+        VStack(spacing: 4) {
+            if let error = model.errorMessage {
+                Text(error)
+                    .font(.system(size: 10))
+                    .foregroundStyle(.red)
+                    .multilineTextAlignment(.center)
+                    .lineLimit(2)
+                    .padding(.horizontal, 8)
+            }
+            statusLabel
+            talkButton
         }
+        .padding(.bottom, 4)
     }
 
     // MARK: - Status label
@@ -183,5 +176,29 @@ struct WatchVoiceView: View {
         case .speaking: return Color(red: 0.2, green: 0.8, blue: 0.5)
         default: return Color.accentColor
         }
+    }
+}
+
+// MARK: - Message bubble
+
+private struct WatchVoiceBubble: View {
+    let message: WatchVoiceMessage
+
+    var body: some View {
+        Text(message.text)
+            .font(.system(size: 13))
+            .foregroundStyle(message.speaker == .user ? Color.white : Color.primary)
+            .multilineTextAlignment(.leading)
+            .padding(.horizontal, 9)
+            .padding(.vertical, 7)
+            .background {
+                RoundedRectangle(cornerRadius: 12)
+                    .fill(
+                        message.speaker == .user
+                            ? Color.accentColor
+                            : Color.secondary.opacity(0.18)
+                    )
+            }
+            .frame(maxWidth: .infinity, alignment: message.speaker == .user ? .trailing : .leading)
     }
 }

--- a/apps/ios/LukeWatch/WatchVoiceView.swift
+++ b/apps/ios/LukeWatch/WatchVoiceView.swift
@@ -1,0 +1,187 @@
+import LukeKit
+import SwiftUI
+
+/// Hold-to-talk voice screen for Apple Watch. Drives WatchVoiceSessionModel,
+/// which in turn drives a RealtimeSession.
+///
+/// The watch ships tool-free: dispatchToolCall always refuses since the armed-act
+/// infrastructure (roster validation, ActClient, ProjectsAnswer) lives on the
+/// phone. The PR notes this explicitly; a future PR may add a bounded act set.
+///
+/// Captions are drawn as plain text — the watch has no session recording to mask
+/// them from, unlike the iPhone's SessionReplay.
+struct WatchVoiceView: View {
+    @Environment(WatchAccountSession.self) private var accountSession
+    @State private var model = WatchVoiceSessionModel()
+    @State private var isPressing = false
+
+    var body: some View {
+        VStack(spacing: 4) {
+            captionArea
+            Spacer(minLength: 0)
+            statusLabel
+            if let error = model.errorMessage {
+                Text(error)
+                    .font(.system(size: 11))
+                    .foregroundStyle(.red)
+                    .multilineTextAlignment(.center)
+                    .lineLimit(2)
+            }
+            talkButton
+        }
+        .padding(.horizontal, 8)
+        .padding(.bottom, 4)
+        .navigationTitle("Luke")
+        .navigationBarTitleDisplayMode(.inline)
+        .task {
+            await model.start(accountSession: accountSession)
+        }
+        .onDisappear {
+            model.stop()
+        }
+    }
+
+    // MARK: - Caption area
+
+    private var captionArea: some View {
+        ScrollViewReader { proxy in
+            ScrollView {
+                VStack(alignment: .leading, spacing: 4) {
+                    if !model.spokenAsk.isEmpty {
+                        Text(model.spokenAsk)
+                            .font(.system(size: 13))
+                            .foregroundStyle(.secondary)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .id("ask")
+                    }
+                    if !model.captionText.isEmpty {
+                        Text(model.captionText)
+                            .font(.system(size: 13))
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .id("caption")
+                    }
+                    if model.spokenAsk.isEmpty && model.captionText.isEmpty {
+                        Text(placeholderText)
+                            .font(.system(size: 13))
+                            .foregroundStyle(.tertiary)
+                            .frame(maxWidth: .infinity, alignment: .center)
+                            .multilineTextAlignment(.center)
+                    }
+                }
+                .padding(.top, 4)
+            }
+            .frame(maxWidth: .infinity)
+            .onChange(of: model.captionText) {
+                withAnimation { proxy.scrollTo("caption", anchor: .bottom) }
+            }
+            .onChange(of: model.spokenAsk) {
+                withAnimation { proxy.scrollTo("ask", anchor: .top) }
+            }
+        }
+    }
+
+    private var placeholderText: String {
+        switch model.status {
+        case .idle, .ready: "Hold the button and speak"
+        case .connecting: ""
+        case .listening, .thinking, .speaking: ""
+        }
+    }
+
+    // MARK: - Status label
+
+    private var statusLabel: some View {
+        HStack(spacing: 4) {
+            statusGlyph
+            Text(statusText)
+                .font(.system(size: 11, weight: .medium))
+                .foregroundStyle(.secondary)
+        }
+        .animation(.easeInOut(duration: 0.15), value: model.status)
+    }
+
+    @ViewBuilder
+    private var statusGlyph: some View {
+        switch model.status {
+        case .connecting:
+            ProgressView()
+                .scaleEffect(0.6)
+                .frame(width: 14, height: 14)
+        case .listening:
+            Image(systemName: "waveform")
+                .font(.system(size: 11, weight: .medium))
+                .foregroundStyle(.blue)
+                .symbolEffect(.variableColor.iterative, isActive: true)
+        case .thinking:
+            Image(systemName: "ellipsis")
+                .font(.system(size: 11, weight: .medium))
+                .foregroundStyle(.yellow)
+                .symbolEffect(.variableColor.iterative, isActive: true)
+        case .speaking:
+            Image(systemName: "speaker.wave.2")
+                .font(.system(size: 11, weight: .medium))
+                .foregroundStyle(.green)
+                .symbolEffect(.variableColor.iterative, isActive: true)
+        default:
+            EmptyView()
+        }
+    }
+
+    private var statusText: String {
+        switch model.status {
+        case .idle: model.errorMessage != nil ? "" : "Hold to talk"
+        case .connecting: "Connecting…"
+        case .ready: "Hold to talk"
+        case .listening: "Listening…"
+        case .thinking: "Thinking…"
+        case .speaking: "Speaking…"
+        }
+    }
+
+    // MARK: - Hold-to-talk button
+
+    private var talkButton: some View {
+        let canTalk = model.status == .ready
+            || model.status == .idle
+            || model.status == .connecting
+            || model.status == .listening
+            || model.status == .speaking
+            || isPressing
+
+        return Circle()
+            .fill(buttonColor)
+            .frame(width: 52, height: 52)
+            .overlay {
+                Image(systemName: isPressing ? "waveform" : "mic.fill")
+                    .font(.system(size: 20, weight: .semibold))
+                    .foregroundStyle(.white)
+                    .contentTransition(.symbolEffect(.replace))
+            }
+            .gesture(
+                DragGesture(minimumDistance: 0)
+                    .onChanged { _ in
+                        guard !isPressing else { return }
+                        isPressing = true
+                        model.beginTurn()
+                    }
+                    .onEnded { _ in
+                        guard isPressing else { return }
+                        isPressing = false
+                        model.endTurn()
+                    }
+            )
+            .disabled(!canTalk)
+            .accessibilityLabel("Talk to Luke")
+            .accessibilityHint("Hold to speak, release to send")
+            .accessibilityAddTraits(.allowsDirectInteraction)
+    }
+
+    private var buttonColor: Color {
+        if isPressing { return Color(red: 0.25, green: 0.55, blue: 1.0) }
+        switch model.status {
+        case .thinking: return Color(red: 0.9, green: 0.7, blue: 0.2)
+        case .speaking: return Color(red: 0.2, green: 0.8, blue: 0.5)
+        default: return Color.accentColor
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds a hold-to-talk voice screen to `apps/ios/LukeWatch` that drives the same `LukeKit.RealtimeSession` the iPhone's `VoiceView` uses, with streaming captions on the wrist.

**Navigation:** Two pages accessible by swiping — voice on the left (default), sessions list on the right. The mic toolbar button on `WatchRosterView` is removed since voice is now a top-level tab.

**Mint timing:** The Realtime session is **not** minted until the developer presses the talk button. `WatchVoiceView.task` stores the credential reference (`prepare`) without opening any connection; `beginTurn()` mints and connects on first press. This keeps parity with iPhone's navigate-then-press gate.

**Watch-specific audio:** `WatchAudioCapturer` and `WatchAudioPlayer` mirror the iPhone classes without `.allowBluetoothHFP` (watchOS owns its own Bluetooth audio routing) and use `AVAudioApplication.shared.recordPermission` (watchOS 10 API).

**Tool-free:** `dispatchToolCall` always returns `{"error":"not authorized"}` and `contextItems` is always empty. The armed-act infrastructure (roster validation, `ActClient`, `ProjectsAnswer`) lives on the phone; a future PR may add a bounded act set.

**Credential handling:** `WatchAccountSession.validAccessToken()` throws `.signedOut` near expiry (the watch cannot refresh tokens). `onError` detects the signed-out state and shows "Open Luke on your iPhone".

**Empty state:** The Luke face mark (`WatchLukeMark` — a watchOS copy of `FaceArt`/`LukeMark` from `apps/ios/Luke/Marks.swift` without UIKit) replaces placeholder text.

**Chat bubbles:** Conversation history accumulates as `[WatchVoiceMessage]`. `onSpokenAsk` appends a user bubble (right-aligned, accent); streaming `onCaption` grows a luke bubble (left-aligned, secondary fill). Bubbles scroll behind the floating mic button.

## Test plan

- [ ] Signed-in watch launch: voice tab is default; no network call is made until the talk button is pressed
- [ ] Press and hold talk button: status transitions connecting → listening → thinking → speaking; captions stream in bubbles
- [ ] Release button: session ends turn; speaking → idle
- [ ] Swipe right: sessions list renders with the roster
- [ ] Swipe back to voice: session reconnects on next button press
- [ ] Signed out: "Open Luke on your iPhone" shown
- [ ] Build passes on both iPhone and watchOS simulator targets

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/33921598717/artifacts/9955313476) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/33921598717)

- Commit: `85f781b9915f8eafde68d37bc05b19becd306f6e`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
