### PR TITLE
feat(ios): draw the Luke face in the voice screen's empty state

### DIFF
--- a/apps/ios/Luke/VoiceView.swift
+++ b/apps/ios/Luke/VoiceView.swift
@@ -330,11 +330,10 @@ struct VoiceView: View {
     private var conversationHistory: some View {
         ZStack {
             if conversation.messages.isEmpty {
-                Text(placeholderText)
-                    .font(.system(size: 17))
+                LukeMark()
                     .foregroundStyle(Color.inkTertiary)
-                    .multilineTextAlignment(.center)
-                    .padding(20)
+                    .frame(width: 96)
+                    .accessibilityHidden(true)
             } else {
                 ScrollViewReader { proxy in
                     ScrollView {
@@ -503,11 +502,5 @@ struct VoiceView: View {
         case .thinking: return "Thinking…"
         case .speaking: return "Speaking…"
         }
-    }
-
-    private var placeholderText: String {
-        model.status == .ready || model.status == .idle
-            ? "Tap once, or hold the button and speak."
-            : ""
     }
 }


### PR DESCRIPTION
## Summary

- An empty voice conversation on iOS used to read "Tap once, or hold the button and speak." That copy repeated the status label directly beneath, which already says "Tap or hold to talk."
- The Luke face now stands in the middle of the empty thread instead, drawn by the existing `LukeMark` in tertiary ink at 96pt, and hidden from accessibility because the status label carries the same instruction.
- The `placeholderText` helper and its status gating are gone with the copy; the face stands whenever the thread is empty, whatever the call's status.

## Verification

- `./scripts/check.sh` passes on the cloud workspace (portable checks; the Swift change is not covered there).
- `xcodebuild -scheme Luke -destination 'platform=iOS Simulator,name=iPhone 17 Pro' build` at this commit on a Mac with Xcode 26.6: `BUILD SUCCEEDED`.
- No physical-notch check was performed; this touches only the iOS app, not the desktop panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/33904889054/artifacts/9949175378) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/33904889054)

- Commit: `da21d04b4030d7799d162adbc49aeab2bfa30747`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
