### PR TITLE
feat(ios): add a typed way in on the voice screen

### DIFF
--- a/apps/ios/Luke/VoiceView.swift
+++ b/apps/ios/Luke/VoiceView.swift
@@ -477,7 +477,7 @@ struct VoiceView: View {
         withAnimation(.smooth(duration: 0.25)) { composerShown = false }
     }
 
-    /// The typed way in: a quiet glass circle at the controls' bottom right
+    /// The typed way in: a quiet glass circle at the controls' bottom left
     /// that stands the composer up. Hidden while the microphone is open,
     /// because a typed ask is refused there — typing must not cut off what is
     /// being said — and an absent control is honest where a refusing one is not.

--- a/apps/ios/Luke/VoiceView.swift
+++ b/apps/ios/Luke/VoiceView.swift
@@ -176,6 +176,26 @@ private final class VoiceSessionModel {
         }
     }
 
+    /// Sends a typed ask: the same explicit developer turn a press opens,
+    /// minus the microphone. When the idle timeout has released the socket,
+    /// typing reopens the call the way a press does, and the session holds
+    /// the ask until the channel opens. Returns whether the ask was taken;
+    /// a refused ask stays in the composer, because it is still the
+    /// developer's words.
+    func sendTypedAsk(_ text: String) async -> Bool {
+        errorMessage = nil
+        // A typed ask supersedes what the last reply was about to do, the
+        // same way a new press does.
+        pendingNavigation = nil
+        if session == nil, let reconnect = reconnectCallback, !reconnectingForTurn {
+            status = .connecting
+            await reconnect(false)
+        }
+        guard let session, session.sendTypedAsk(text) else { return false }
+        thread?.recordTypedAsk(text)
+        return true
+    }
+
     /// The voice is fixed at mint time, so an open connection is reopened.
     func changeVoice(_ newVoice: RealtimeVoice, accountSession: AccountSession) async {
         guard newVoice != voice else { return }
@@ -221,6 +241,20 @@ struct VoiceView: View {
     @State private var isLatched = false
     @State private var pressBeganAt: TimeInterval?
     @State private var settingsShown = false
+    @State private var draft = ""
+    // Whether the keyboard button has stood the composer up in the talk
+    // controls' place; the focus edge below stands it back down.
+    @State private var composerShown = false
+    // Guards the double-send window while an ask is reopening the call; the
+    // send button alone cannot, because a disabled state lands a render late.
+    @State private var typedAskInFlight = false
+    @FocusState private var composing: Bool
+    // One glass identity per morphing pair: the keyboard button becomes the
+    // composer's capsule, and the talk button becomes the microphone at the
+    // composer's side.
+    @Namespace private var glassNamespace
+    private static let composerGlassID = "composer"
+    private static let talkGlassID = "talk"
 
     var body: some View {
         ZStack {
@@ -328,46 +362,52 @@ struct VoiceView: View {
     }
 
     private var conversationHistory: some View {
-        ZStack {
+        // The scroll view stands even before anything is said: it is what
+        // carries the keyboard's interactive swipe-down, and an empty state
+        // that replaced it would leave the composer with no way to swipe.
+        ScrollViewReader { proxy in
+            ScrollView {
+                VStack(spacing: 14) {
+                    ForEach(conversation.messages) { message in
+                        Group {
+                            switch message.speaker {
+                            case .developer:
+                                DeveloperMessageBubble(words: message.words)
+                            case .luke:
+                                AgentMessageBubble(words: message.words)
+                            }
+                        }
+                        .id(message.id)
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .top)
+                .padding(.horizontal, 16)
+                .padding(.vertical, 12)
+                // The controls float above the thread. Empty space at
+                // its tail lets the newest bubble clear them while the
+                // bubbles themselves can still scroll behind the glass.
+                .padding(.bottom, 200)
+            }
+            .scrollDismissesKeyboard(.interactively)
+            .onChange(of: conversation.messages) {
+                guard let last = conversation.messages.last else { return }
+                withAnimation { proxy.scrollTo(last.id, anchor: .bottom) }
+            }
+            .onAppear {
+                if let last = conversation.messages.last {
+                    proxy.scrollTo(last.id, anchor: .bottom)
+                }
+            }
+        }
+        .overlay {
             if conversation.messages.isEmpty {
                 LukeMark()
                     .foregroundStyle(Color.inkTertiary)
                     .frame(width: 96)
                     .accessibilityHidden(true)
-            } else {
-                ScrollViewReader { proxy in
-                    ScrollView {
-                        VStack(spacing: 14) {
-                            ForEach(conversation.messages) { message in
-                                Group {
-                                    switch message.speaker {
-                                    case .developer:
-                                        DeveloperMessageBubble(words: message.words)
-                                    case .luke:
-                                        AgentMessageBubble(words: message.words)
-                                    }
-                                }
-                                .id(message.id)
-                            }
-                        }
-                        .frame(maxWidth: .infinity, alignment: .top)
-                        .padding(.horizontal, 16)
-                        .padding(.vertical, 12)
-                        // The controls float above the thread. Empty space at
-                        // its tail lets the newest bubble clear them while the
-                        // bubbles themselves can still scroll behind the glass.
-                        .padding(.bottom, 160)
-                    }
-                    .onChange(of: conversation.messages) {
-                        guard let last = conversation.messages.last else { return }
-                        withAnimation { proxy.scrollTo(last.id, anchor: .bottom) }
-                    }
-                    .onAppear {
-                        if let last = conversation.messages.last {
-                            proxy.scrollTo(last.id, anchor: .bottom)
-                        }
-                    }
-                }
+                    // Artwork, not a control: a swipe over the face belongs
+                    // to the scroll view beneath.
+                    .allowsHitTesting(false)
             }
         }
         .frame(maxHeight: .infinity)
@@ -385,29 +425,202 @@ struct VoiceView: View {
                     .padding(.horizontal, 24)
                     .transition(.move(edge: .bottom).combined(with: .opacity))
             }
-            talkButton
-            statusLabel
+            controlsStage
         }
         .padding(.bottom, 10)
         .animation(.easeInOut(duration: 0.2), value: model.errorMessage)
+        .onChange(of: composing) { _, isFocused in
+            // The keyboard going away is the composer's dismissal; the draft
+            // stays for the next press of the keyboard button.
+            if !isFocused { hideComposer() }
+        }
     }
 
+    /// Every glass shape of both states in one container, one identity per
+    /// pair: the keyboard button becomes the composer's capsule, and the talk
+    /// button becomes the microphone at the capsule's side, so each pair
+    /// reads as one piece of glass changing shape. Earlier systems keep the
+    /// plain swap, having no glass to morph.
     @ViewBuilder
-    private var talkButton: some View {
-        // Keep the view enabled while the user is actively pressing — disabling
-        // during .listening would cancel the in-flight DragGesture and fire
-        // onEnded immediately, collapsing every hold into an instant tap.
-        let canTalk = model.status == .ready
+    private var controlsStage: some View {
+        if #available(iOS 26.0, *) {
+            GlassEffectContainer {
+                controlsContent
+            }
+        } else {
+            controlsContent
+                .animation(.easeInOut(duration: 0.2), value: composerShown)
+        }
+    }
+
+    private var controlsContent: some View {
+        VStack(spacing: 10) {
+            if !composerShown {
+                talkButton
+                statusLabel
+            }
+            composerRow
+        }
+    }
+
+    /// The controls' last row: the keyboard button waiting at the bottom
+    /// left, or the composer with the microphone at its side — iMessage's
+    /// own anatomy.
+    private var composerRow: some View {
+        HStack(spacing: 8) {
+            if composerShown {
+                composer
+                micButton
+                    .padding(.trailing, 12)
+            } else {
+                keyboardButton
+                    .padding(.leading, 12)
+                Spacer()
+            }
+        }
+    }
+
+    private func showComposer() {
+        withAnimation { composerShown = true }
+        // Focus set beside the reveal is the framework's own pattern: the
+        // keyboard rise is deferred until the field exists, so the box and
+        // the keyboard arrive together.
+        composing = true
+    }
+
+    private func hideComposer() {
+        withAnimation { composerShown = false }
+    }
+
+    /// The typed way in: a quiet glass circle at the controls' bottom right
+    /// that stands the composer up. Hidden while the microphone is open,
+    /// because a typed ask is refused there — typing must not cut off what is
+    /// being said — and an absent control is honest where a refusing one is not.
+    @ViewBuilder
+    private var keyboardButton: some View {
+        if !isPressing, !isLatched, model.status != .listening {
+            if #available(iOS 26.0, *) {
+                // Explicit glass rather than the glass button style: only a
+                // glassEffect can carry the glassEffectID the morph pairs on.
+                Button(action: showComposer) { keyboardButtonLabel }
+                    .buttonStyle(.plain)
+                    .glassEffect(.regular.interactive(), in: Circle())
+                    .glassEffectID(Self.composerGlassID, in: glassNamespace)
+                    .accessibilityLabel("Type to Luke")
+                    .accessibilityHint("Opens the keyboard to type your ask")
+            } else {
+                Button(action: showComposer) { keyboardButtonLabel }
+                    .buttonStyle(.plain)
+                    .background(Color.cardFill, in: Circle())
+                    .overlay(Circle().strokeBorder(Color.controlStroke, lineWidth: 1))
+                    .accessibilityLabel("Type to Luke")
+                    .accessibilityHint("Opens the keyboard to type your ask")
+            }
+        }
+    }
+
+    private var keyboardButtonLabel: some View {
+        Image(systemName: "keyboard")
+            .font(.system(size: 18, weight: .semibold))
+            .foregroundStyle(Color.ink)
+            .frame(width: 44, height: 44)
+    }
+
+    /// The desktop composer's iOS shape: the same capsule anatomy the session
+    /// screen's input keeps, sending a turn instead of a session message.
+    /// What is typed here stays masked from session replay by the recording
+    /// library's own input masking.
+    @ViewBuilder
+    private var composer: some View {
+        if #available(iOS 26.0, *) {
+            composerField
+                .glassEffect(.regular, in: RoundedRectangle(cornerRadius: 22))
+                .glassEffectID(Self.composerGlassID, in: glassNamespace)
+                .padding(.leading, 12)
+        } else {
+            composerField
+                .background(
+                    RoundedRectangle(cornerRadius: 22)
+                        .fill(Color.cardFill)
+                        .strokeBorder(Color.controlStroke, lineWidth: 1)
+                )
+                .padding(.leading, 12)
+        }
+    }
+
+    private var composerField: some View {
+        TextField("Ask Luke…", text: $draft, axis: .vertical)
+            .focused($composing)
+            .lineLimit(1 ... 5)
+            .font(.body)
+            .foregroundStyle(Color.ink)
+            .padding(.leading, 14)
+            .padding(.trailing, 42)
+            .padding(.vertical, 9)
+            .overlay(alignment: .bottomTrailing) {
+                if canSendTypedAsk {
+                    Button(action: submitTypedAsk) {
+                        Image(systemName: "arrow.up")
+                            .font(.system(size: 15, weight: .semibold))
+                            .foregroundStyle(.white)
+                            .frame(width: 30, height: 30)
+                            .background(Color.accentColor, in: Circle())
+                    }
+                    .padding(5)
+                    .accessibilityLabel("Send to Luke")
+                    .transition(.scale.combined(with: .opacity))
+                }
+            }
+            .animation(.spring(duration: 0.25), value: canSendTypedAsk)
+    }
+
+    /// An open microphone keeps the floor: the send appears again once the
+    /// held or latched turn is released.
+    private var canSendTypedAsk: Bool {
+        !typedAskInFlight
+            && model.status != .listening
+            && draft.contains { !$0.isWhitespace }
+    }
+
+    private func submitTypedAsk() {
+        guard canSendTypedAsk else { return }
+        let text = draft.trimmingCharacters(in: .whitespacesAndNewlines)
+        typedAskInFlight = true
+        Task {
+            let accepted = await model.sendTypedAsk(text)
+            typedAskInFlight = false
+            // A refused ask keeps the draft — it is still the developer's
+            // words. A taken one lowers the keyboard so the reply's captions
+            // have the screen.
+            if accepted {
+                draft = ""
+                composing = false
+            }
+        }
+    }
+
+    // Keep the buttons enabled while the user is actively pressing — disabling
+    // during .listening would cancel the in-flight DragGesture and fire
+    // onEnded immediately, collapsing every hold into an instant tap.
+    private var canTalk: Bool {
+        model.status == .ready
             || model.status == .idle
             || model.status == .connecting
             || model.status == .listening
             || model.status == .speaking
             || isPressing
+    }
+
+    @ViewBuilder
+    private var talkButton: some View {
         if #available(iOS 26.0, *) {
+            // Explicit tinted glass rather than the prominent button style:
+            // only a glassEffect can carry the glassEffectID the morph into
+            // the composer-side microphone pairs on.
             Button(action: {}) { talkButtonLabel }
-                .buttonStyle(.glassProminent)
-                .buttonBorderShape(.circle)
-                .tint(talkButtonColor)
+                .buttonStyle(.plain)
+                .glassEffect(.regular.tint(talkButtonColor).interactive(), in: Circle())
+                .glassEffectID(Self.talkGlassID, in: glassNamespace)
                 .simultaneousGesture(talkGesture)
                 .disabled(!canTalk)
                 .accessibilityLabel(isLatched ? "Tap to send" : "Talk to Luke")
@@ -431,6 +644,50 @@ struct VoiceView: View {
                 )
                 .accessibilityAction { activateTalkButton() }
         }
+    }
+
+    /// The talk button at iMessage scale while the composer is up: the same
+    /// glass identity as the big circle, so the microphone morphs to the
+    /// field's side rather than vanishing, and the same gesture, so a hold
+    /// or a latched tap works mid-compose.
+    @ViewBuilder
+    private var micButton: some View {
+        if #available(iOS 26.0, *) {
+            Button(action: {}) { micButtonLabel }
+                .buttonStyle(.plain)
+                .glassEffect(.regular.tint(talkButtonColor).interactive(), in: Circle())
+                .glassEffectID(Self.talkGlassID, in: glassNamespace)
+                .simultaneousGesture(talkGesture)
+                .disabled(!canTalk)
+                .accessibilityLabel(isLatched ? "Tap to send" : "Talk to Luke")
+                .accessibilityHint(
+                    isLatched
+                        ? "Stops listening and sends your message"
+                        : "Tap to keep listening, or hold to talk"
+                )
+                .accessibilityAction { activateTalkButton() }
+        } else {
+            Button(action: {}) { micButtonLabel }
+                .buttonStyle(.plain)
+                .background(talkButtonColor, in: Circle())
+                .simultaneousGesture(talkGesture)
+                .disabled(!canTalk)
+                .accessibilityLabel(isLatched ? "Tap to send" : "Talk to Luke")
+                .accessibilityHint(
+                    isLatched
+                        ? "Stops listening and sends your message"
+                        : "Tap to keep listening, or hold to talk"
+                )
+                .accessibilityAction { activateTalkButton() }
+        }
+    }
+
+    private var micButtonLabel: some View {
+        Image(systemName: isPressing || isLatched ? "waveform" : "mic.fill")
+            .font(.system(size: 18, weight: .semibold))
+            .foregroundStyle(Color.white)
+            .frame(width: 44, height: 44)
+            .contentTransition(.symbolEffect(.replace))
     }
 
     /// VoiceOver invokes the control's default accessibility action rather

--- a/apps/ios/Luke/VoiceView.swift
+++ b/apps/ios/Luke/VoiceView.swift
@@ -426,11 +426,6 @@ struct VoiceView: View {
         }
         .padding(.bottom, 10)
         .animation(.easeInOut(duration: 0.2), value: model.errorMessage)
-        .onChange(of: composing) { _, isFocused in
-            // The keyboard going away is the composer's dismissal; the draft
-            // stays for the next press of the keyboard button.
-            if !isFocused { hideComposer() }
-        }
     }
 
     /// Every glass shape in one container so SwiftUI can morph the keyboard
@@ -597,6 +592,7 @@ struct VoiceView: View {
             if accepted {
                 draft = ""
                 composing = false
+                hideComposer()
             }
         }
     }

--- a/apps/ios/Luke/VoiceView.swift
+++ b/apps/ios/Luke/VoiceView.swift
@@ -249,12 +249,9 @@ struct VoiceView: View {
     // send button alone cannot, because a disabled state lands a render late.
     @State private var typedAskInFlight = false
     @FocusState private var composing: Bool
-    // One glass identity per morphing pair: the keyboard button becomes the
-    // composer's capsule, and the talk button becomes the microphone at the
-    // composer's side.
+    // The keyboard button and composer are the two shapes of one control.
     @Namespace private var glassNamespace
     private static let composerGlassID = "composer"
-    private static let talkGlassID = "talk"
 
     var body: some View {
         ZStack {
@@ -436,11 +433,9 @@ struct VoiceView: View {
         }
     }
 
-    /// Every glass shape of both states in one container, one identity per
-    /// pair: the keyboard button becomes the composer's capsule, and the talk
-    /// button becomes the microphone at the capsule's side, so each pair
-    /// reads as one piece of glass changing shape. Earlier systems keep the
-    /// plain swap, having no glass to morph.
+    /// Every glass shape in one container so SwiftUI can morph the keyboard
+    /// button into the composer. Earlier systems keep the same standard view
+    /// transition without Liquid Glass.
     @ViewBuilder
     private var controlsStage: some View {
         if #available(iOS 26.0, *) {
@@ -449,47 +444,42 @@ struct VoiceView: View {
             }
         } else {
             controlsContent
-                .animation(.easeInOut(duration: 0.2), value: composerShown)
         }
     }
 
     private var controlsContent: some View {
         VStack(spacing: 10) {
             if !composerShown {
-                talkButton
                 statusLabel
+                    .transition(.move(edge: .bottom).combined(with: .opacity))
             }
-            composerRow
-        }
-    }
-
-    /// The controls' last row: the keyboard button waiting at the bottom
-    /// left, or the composer with the microphone at its side — iMessage's
-    /// own anatomy.
-    private var composerRow: some View {
-        HStack(spacing: 8) {
-            if composerShown {
-                composer
-                micButton
-                    .padding(.trailing, 12)
-            } else {
-                keyboardButton
-                    .padding(.leading, 12)
-                Spacer()
+            ZStack(alignment: .bottom) {
+                if composerShown {
+                    composer
+                        .frame(maxWidth: .infinity)
+                        .padding(.trailing, 52)
+                } else {
+                    keyboardButton
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+                talkButton
+                    .frame(
+                        maxWidth: .infinity,
+                        alignment: composerShown ? .trailing : .center
+                    )
             }
+            .frame(maxWidth: .infinity)
+            .padding(.horizontal, 12)
         }
+        .animation(.smooth(duration: 0.25), value: composerShown)
     }
 
     private func showComposer() {
-        withAnimation { composerShown = true }
-        // Focus set beside the reveal is the framework's own pattern: the
-        // keyboard rise is deferred until the field exists, so the box and
-        // the keyboard arrive together.
-        composing = true
+        withAnimation(.smooth(duration: 0.25)) { composerShown = true }
     }
 
     private func hideComposer() {
-        withAnimation { composerShown = false }
+        withAnimation(.smooth(duration: 0.25)) { composerShown = false }
     }
 
     /// The typed way in: a quiet glass circle at the controls' bottom right
@@ -506,6 +496,7 @@ struct VoiceView: View {
                     .buttonStyle(.plain)
                     .glassEffect(.regular.interactive(), in: Circle())
                     .glassEffectID(Self.composerGlassID, in: glassNamespace)
+                    .glassEffectTransition(.matchedGeometry)
                     .accessibilityLabel("Type to Luke")
                     .accessibilityHint("Opens the keyboard to type your ask")
             } else {
@@ -513,6 +504,7 @@ struct VoiceView: View {
                     .buttonStyle(.plain)
                     .background(Color.cardFill, in: Circle())
                     .overlay(Circle().strokeBorder(Color.controlStroke, lineWidth: 1))
+                    .matchedGeometryEffect(id: Self.composerGlassID, in: glassNamespace)
                     .accessibilityLabel("Type to Luke")
                     .accessibilityHint("Opens the keyboard to type your ask")
             }
@@ -536,7 +528,7 @@ struct VoiceView: View {
             composerField
                 .glassEffect(.regular, in: RoundedRectangle(cornerRadius: 22))
                 .glassEffectID(Self.composerGlassID, in: glassNamespace)
-                .padding(.leading, 12)
+                .glassEffectTransition(.matchedGeometry)
         } else {
             composerField
                 .background(
@@ -544,7 +536,7 @@ struct VoiceView: View {
                         .fill(Color.cardFill)
                         .strokeBorder(Color.controlStroke, lineWidth: 1)
                 )
-                .padding(.leading, 12)
+                .matchedGeometryEffect(id: Self.composerGlassID, in: glassNamespace)
         }
     }
 
@@ -572,6 +564,16 @@ struct VoiceView: View {
                 }
             }
             .animation(.spring(duration: 0.25), value: canSendTypedAsk)
+            // The field must exist before FocusState can make it first
+            // responder. Scheduling the assignment from onAppear keeps the
+            // keyboard presentation on SwiftUI's normal focus path.
+            .onAppear {
+                Task { @MainActor in
+                    await Task.yield()
+                    guard composerShown else { return }
+                    composing = true
+                }
+            }
     }
 
     /// An open microphone keeps the floor: the send appears again once the
@@ -614,13 +616,9 @@ struct VoiceView: View {
     @ViewBuilder
     private var talkButton: some View {
         if #available(iOS 26.0, *) {
-            // Explicit tinted glass rather than the prominent button style:
-            // only a glassEffect can carry the glassEffectID the morph into
-            // the composer-side microphone pairs on.
             Button(action: {}) { talkButtonLabel }
                 .buttonStyle(.plain)
                 .glassEffect(.regular.tint(talkButtonColor).interactive(), in: Circle())
-                .glassEffectID(Self.talkGlassID, in: glassNamespace)
                 .simultaneousGesture(talkGesture)
                 .disabled(!canTalk)
                 .accessibilityLabel(isLatched ? "Tap to send" : "Talk to Luke")
@@ -644,50 +642,6 @@ struct VoiceView: View {
                 )
                 .accessibilityAction { activateTalkButton() }
         }
-    }
-
-    /// The talk button at iMessage scale while the composer is up: the same
-    /// glass identity as the big circle, so the microphone morphs to the
-    /// field's side rather than vanishing, and the same gesture, so a hold
-    /// or a latched tap works mid-compose.
-    @ViewBuilder
-    private var micButton: some View {
-        if #available(iOS 26.0, *) {
-            Button(action: {}) { micButtonLabel }
-                .buttonStyle(.plain)
-                .glassEffect(.regular.tint(talkButtonColor).interactive(), in: Circle())
-                .glassEffectID(Self.talkGlassID, in: glassNamespace)
-                .simultaneousGesture(talkGesture)
-                .disabled(!canTalk)
-                .accessibilityLabel(isLatched ? "Tap to send" : "Talk to Luke")
-                .accessibilityHint(
-                    isLatched
-                        ? "Stops listening and sends your message"
-                        : "Tap to keep listening, or hold to talk"
-                )
-                .accessibilityAction { activateTalkButton() }
-        } else {
-            Button(action: {}) { micButtonLabel }
-                .buttonStyle(.plain)
-                .background(talkButtonColor, in: Circle())
-                .simultaneousGesture(talkGesture)
-                .disabled(!canTalk)
-                .accessibilityLabel(isLatched ? "Tap to send" : "Talk to Luke")
-                .accessibilityHint(
-                    isLatched
-                        ? "Stops listening and sends your message"
-                        : "Tap to keep listening, or hold to talk"
-                )
-                .accessibilityAction { activateTalkButton() }
-        }
-    }
-
-    private var micButtonLabel: some View {
-        Image(systemName: isPressing || isLatched ? "waveform" : "mic.fill")
-            .font(.system(size: 18, weight: .semibold))
-            .foregroundStyle(Color.white)
-            .frame(width: 44, height: 44)
-            .contentTransition(.symbolEffect(.replace))
     }
 
     /// VoiceOver invokes the control's default accessibility action rather
@@ -705,9 +659,12 @@ struct VoiceView: View {
 
     private var talkButtonLabel: some View {
         Image(systemName: isPressing || isLatched ? "waveform" : "mic.fill")
-            .font(.system(size: 27, weight: .semibold))
+            .font(.system(size: composerShown ? 18 : 27, weight: .semibold))
             .foregroundStyle(Color.white)
-            .frame(width: 58, height: 58)
+            .frame(
+                width: composerShown ? 44 : 58,
+                height: composerShown ? 44 : 58
+            )
             .contentTransition(.symbolEffect(.replace))
     }
 

--- a/apps/ios/LukeKit/Sources/LukeKit/ConversationContext.swift
+++ b/apps/ios/LukeKit/Sources/LukeKit/ConversationContext.swift
@@ -35,7 +35,8 @@ public enum ConversationContext {
         let lines = messages.suffix(maximumRecentMessages).map { message in
             let words = String(message.words.prefix(maximumRenderedMessageLength))
             switch message.speaker {
-            case .developer: return "- the developer said: \"\(words)\""
+            case .developer:
+                return "- the developer \(message.typed ? "typed" : "said"): \"\(words)\""
             case .luke: return "- Luke said: \"\(words)\""
             }
         }

--- a/apps/ios/LukeKit/Sources/LukeKit/RealtimeSession.swift
+++ b/apps/ios/LukeKit/Sources/LukeKit/RealtimeSession.swift
@@ -193,6 +193,9 @@ public final class RealtimeSession {
     private var receiveTask: Task<Void, Never>?
     private var captureTask: Task<Void, Never>?
     private var idleTask: Task<Void, Never>?
+    // All user-turn control events share one queue. A cancellation must reach
+    // the server before the item and response.create that supersede it.
+    private var sendTask: Task<Void, Never>?
 
     private var pendingCalls: [String: (name: String, args: String)] = [:]
     private var captionBuffer = ""
@@ -302,17 +305,16 @@ public final class RealtimeSession {
             return true
         case .ready, .thinking, .speaking:
             guard let channel else { return false }
-            if status != .ready { interruptResponse() }
+            let interruptionEvents = status == .ready
+                ? []
+                : interruptResponse(sendEvents: false)
             isArmed = true
             idleTask?.cancel(); idleTask = nil
             responseStarted = false
             status = .thinking
             let item = typedAskItemJSON(ask)
             let request = responseCreateJSON(sequence: interruptionSequence)
-            Task {
-                try? await channel.sendText(item)
-                try? await channel.sendText(request)
-            }
+            enqueueSend(interruptionEvents + [item, request], on: channel)
             return true
         }
     }
@@ -339,6 +341,7 @@ public final class RealtimeSession {
     public func close() {
         idleTask?.cancel(); idleTask = nil
         receiveTask?.cancel(); receiveTask = nil
+        sendTask?.cancel(); sendTask = nil
         stopCapturing()
         player?.stop(); player = nil
         for drainingPlayer in drainingPlayers.values { drainingPlayer.stop() }
@@ -400,8 +403,11 @@ public final class RealtimeSession {
     private func commitAndRequestResponse() async {
         guard let ws = channel else { return }
         responseStarted = false
-        try? await ws.sendText(#"{"type":"input_audio_buffer.commit"}"#)
-        try? await ws.sendText(responseCreateJSON(sequence: interruptionSequence))
+        let task = enqueueSend([
+            #"{"type":"input_audio_buffer.commit"}"#,
+            responseCreateJSON(sequence: interruptionSequence),
+        ], on: ws)
+        await task.value
     }
 
     // MARK: - Receive loop
@@ -464,7 +470,11 @@ public final class RealtimeSession {
             isArmed = true
             responseStarted = false
             status = .thinking
-            try? await ws.sendText(responseCreateJSON(sequence: interruptionSequence))
+            let task = enqueueSend(
+                [responseCreateJSON(sequence: interruptionSequence)],
+                on: ws
+            )
+            await task.value
         } else {
             status = .ready
             resetIdleTimer()
@@ -611,7 +621,11 @@ public final class RealtimeSession {
             // Follow-up response requested; the session stays in .thinking or
             // .speaking until the model's follow-up speaks and settles.
             responseStarted = false
-            try? await ws.sendText(responseCreateJSON(sequence: responseInterruptionSequence))
+            let task = enqueueSend(
+                [responseCreateJSON(sequence: responseInterruptionSequence)],
+                on: ws
+            )
+            await task.value
             // A barge-in can land while the socket send is suspended. Its new
             // turn is already armed and must not be cleared by this old turn.
             guard interruptionSequence == responseInterruptionSequence else { return }
@@ -677,11 +691,15 @@ public final class RealtimeSession {
     /// playing. WebSocket sessions own their playback buffer locally, so the
     /// player is stopped here; the server is separately told to stop making
     /// more audio and to forget the generated tail nobody heard.
-    private func interruptResponse() {
+    @discardableResult
+    private func interruptResponse(sendEvents: Bool = true) -> [String] {
         let responseId = activeResponseId
         let responseItemId = activeResponseItemId
         let audioEndMs = heardAudioMilliseconds()
-        let shouldCancel = responseStarted
+        // In .thinking, response.create may be queued or accepted even before
+        // response.created arrives. Queue its cancel behind that request so a
+        // superseding typed turn never creates two live responses.
+        let shouldCancel = responseStarted || status == .thinking || followUpPending
 
         player?.stop()
         player = nil
@@ -723,16 +741,33 @@ public final class RealtimeSession {
             pendingInterruptionEventIds.remove(pendingInterruptionEventIds.first!)
         }
 
-        if let channel, !events.isEmpty {
-            Task {
-                for event in events { try? await channel.sendText(event) }
-            }
+        if sendEvents, let channel, !events.isEmpty {
+            enqueueSend(events, on: channel)
         }
 
         responseStarted = false
         followUpPending = false
         pendingCalls.removeAll()
         clearActiveResponse()
+        return events
+    }
+
+    @discardableResult
+    private func enqueueSend(
+        _ events: [String],
+        on channel: any WebSocketTask
+    ) -> Task<Void, Never> {
+        let precedingTask = sendTask
+        let task = Task {
+            await precedingTask?.value
+            guard !Task.isCancelled else { return }
+            for event in events {
+                guard !Task.isCancelled else { return }
+                try? await channel.sendText(event)
+            }
+        }
+        sendTask = task
+        return task
     }
 
     private func heardAudioMilliseconds() -> Int {

--- a/apps/ios/LukeKit/Sources/LukeKit/RealtimeSession.swift
+++ b/apps/ios/LukeKit/Sources/LukeKit/RealtimeSession.swift
@@ -186,6 +186,9 @@ public final class RealtimeSession {
     // Set when the developer releases while still connecting, so we commit
     // and request a response the moment the channel opens.
     private var pendingCommit = false
+    // A typed ask taken while still connecting, held for the channel the way
+    // a press's audio is held in PressAudioBuffer.
+    private var pendingTypedAsk: String?
 
     private var receiveTask: Task<Void, Never>?
     private var captureTask: Task<Void, Never>?
@@ -273,6 +276,47 @@ public final class RealtimeSession {
         }
     }
 
+    /// Sends the developer's typed ask: the same explicitly opened turn a
+    /// press is, arming tool calls for the one response it requests, with no
+    /// microphone anywhere in it. Mirrors the desktop's typed path — refused
+    /// while the microphone is open, because typing must not cut off what is
+    /// being said; interrupting a reply still in flight, because a new ask
+    /// supersedes the answer to the last; and held for the channel while it
+    /// is still connecting. Returns whether the ask was taken.
+    public func sendTypedAsk(_ text: String) -> Bool {
+        // The desktop's bound on a typed ask: trimmed, then cut at the same
+        // length a session message carries.
+        let ask = String(
+            text.trimmingCharacters(in: .whitespacesAndNewlines)
+                .prefix(VoiceAsks.maximumMessageLength)
+        )
+        guard !ask.isEmpty else { return false }
+        switch status {
+        case .idle, .listening:
+            return false
+        case .connecting:
+            // A turn already opened by press keeps the floor, and one held
+            // typed ask is enough: the composer waits for its answer.
+            guard !isArmed, !pendingCommit, pendingTypedAsk == nil else { return false }
+            pendingTypedAsk = ask
+            return true
+        case .ready, .thinking, .speaking:
+            guard let channel else { return false }
+            if status != .ready { interruptResponse() }
+            isArmed = true
+            idleTask?.cancel(); idleTask = nil
+            responseStarted = false
+            status = .thinking
+            let item = typedAskItemJSON(ask)
+            let request = responseCreateJSON(sequence: interruptionSequence)
+            Task {
+                try? await channel.sendText(item)
+                try? await channel.sendText(request)
+            }
+            return true
+        }
+    }
+
     /// The API applies a speed between model turns, so it is heard from the
     /// next reply. An idle session sends nothing: the caller mints the next
     /// connection at the speed it holds.
@@ -307,6 +351,7 @@ public final class RealtimeSession {
         responseStarted = false
         pendingDrains = 0
         pendingCommit = false
+        pendingTypedAsk = nil
         pendingSpeed = nil
         pendingCalls.removeAll()
         captionBuffer = ""
@@ -396,6 +441,15 @@ public final class RealtimeSession {
         for item in options.contextItems() {
             try? await ws.sendText(contextItemJSON(item))
         }
+        // A held typed ask travels whichever turn owns the response: its words
+        // go in ahead of any press audio, and it requests a response only when
+        // no pressed turn is standing to request its own.
+        var typedAskSent = false
+        if let ask = pendingTypedAsk {
+            pendingTypedAsk = nil
+            typedAskSent = true
+            try? await ws.sendText(typedAskItemJSON(ask))
+        }
         for chunk in pressBuffer.drain() {
             try? await ws.sendText(audioAppendJSON(chunk))
         }
@@ -406,6 +460,11 @@ public final class RealtimeSession {
         } else if isArmed {
             // Capture already running; status tracks listening once the first chunk arrives.
             status = .listening
+        } else if typedAskSent {
+            isArmed = true
+            responseStarted = false
+            status = .thinking
+            try? await ws.sendText(responseCreateJSON(sequence: interruptionSequence))
         } else {
             status = .ready
             resetIdleTimer()
@@ -748,6 +807,13 @@ public final class RealtimeSession {
         let escaped = jsonEscape(item.text)
         return """
             {"type":"conversation.item.create","item":{"id":"\(escapedId)","type":"message","role":"user","content":[{"type":"input_text","text":"\(escaped)"}]}}
+            """
+    }
+
+    private func typedAskItemJSON(_ text: String) -> String {
+        let escaped = jsonEscape(text)
+        return """
+            {"type":"conversation.item.create","item":{"type":"message","role":"user","content":[{"type":"input_text","text":"\(escaped)"}]}}
             """
     }
 

--- a/apps/ios/LukeKit/Sources/LukeKit/VoiceConversationThread.swift
+++ b/apps/ios/LukeKit/Sources/LukeKit/VoiceConversationThread.swift
@@ -4,8 +4,8 @@ import Observation
 // MARK: - One line of the thread
 
 /// One line of the conversation Luke holds with the developer on this phone:
-/// the developer's spoken ask as the voice service transcribed it, or the
-/// words Luke spoke back.
+/// the developer's ask — spoken and transcribed by the voice service, or
+/// typed into the composer — or the words Luke spoke back.
 public struct VoiceConversationMessage: Identifiable, Equatable, Sendable {
     public enum Speaker: Equatable, Sendable {
         case developer
@@ -16,12 +16,17 @@ public struct VoiceConversationMessage: Identifiable, Equatable, Sendable {
     public let turnId: UUID
     public let speaker: Speaker
     public var words: String
+    /// Whether the developer typed these words rather than speaking them, so
+    /// the context re-feed can lead with the same distinction the desktop's
+    /// history keeps.
+    public let typed: Bool
 
-    public init(turnId: UUID, speaker: Speaker, words: String) {
+    public init(turnId: UUID, speaker: Speaker, words: String, typed: Bool = false) {
         id = UUID()
         self.turnId = turnId
         self.speaker = speaker
         self.words = words
+        self.typed = typed
     }
 }
 
@@ -70,7 +75,10 @@ public final class VoiceConversationThread {
         if let index = messages.firstIndex(where: {
             $0.turnId == turnId && $0.speaker == .developer
         }) {
-            messages[index].words = words
+            // A typed ask is already its author's whole words: a transcript
+            // landing on its turn is a spoken turn's late arrival, not a
+            // fuller version of what was typed.
+            if !messages[index].typed { messages[index].words = words }
             return
         }
         let message = VoiceConversationMessage(turnId: turnId, speaker: .developer, words: words)
@@ -81,6 +89,22 @@ public final class VoiceConversationThread {
         } else {
             messages.append(message)
         }
+        retainRecentMessages()
+    }
+
+    /// Records the developer's typed ask and opens its turn in one move:
+    /// unlike a spoken ask, the words arrive whole at the moment of the send,
+    /// on no service clock, so the turn and its ask land together and no
+    /// fuller version ever follows to replace them.
+    public func recordTypedAsk(_ text: String) {
+        let words = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !words.isEmpty else { return }
+        beginTurn()
+        messages.append(
+            VoiceConversationMessage(
+                turnId: currentTurnId(), speaker: .developer, words: words, typed: true
+            )
+        )
         retainRecentMessages()
     }
 

--- a/apps/ios/LukeKit/Tests/LukeKitTests/ConversationContextTests.swift
+++ b/apps/ios/LukeKit/Tests/LukeKitTests/ConversationContextTests.swift
@@ -23,6 +23,15 @@ final class ConversationContextTests: XCTestCase {
         )
     }
 
+    func testTypedAskLeadsWithTyped() {
+        let typed = VoiceConversationMessage(
+            turnId: UUID(), speaker: .developer, words: "Open the Codex session", typed: true
+        )
+        let rendered = ConversationContext.text(messages: [typed]) ?? ""
+        XCTAssertTrue(rendered.contains("- the developer typed: \"Open the Codex session\""))
+        XCTAssertFalse(rendered.contains("the developer said"))
+    }
+
     func testNothingSaidYetIsNoItemAtAll() {
         XCTAssertNil(ConversationContext.text(messages: []))
         XCTAssertNil(ConversationContext.item(messages: []))

--- a/apps/ios/LukeKit/Tests/LukeKitTests/RealtimeSessionTests.swift
+++ b/apps/ios/LukeKit/Tests/LukeKitTests/RealtimeSessionTests.swift
@@ -124,6 +124,12 @@ private actor AsyncGate {
 private actor ResponseCreateCounter {
     private var count = 0
 
+    func isFirst(_ text: String) -> Bool {
+        guard text.contains(#""type":"response.create""#) else { return false }
+        count += 1
+        return count == 1
+    }
+
     func isSecond(_ text: String) -> Bool {
         guard text.contains(#""type":"response.create""#) else { return false }
         count += 1
@@ -1014,6 +1020,43 @@ final class RealtimeSessionStateTests: XCTestCase {
         try await Task.sleep(nanoseconds: 50_000_000)
         XCTAssertTrue(dispatchedNames.isEmpty)
         XCTAssertEqual(session.status, .thinking)
+    }
+
+    func testTypedAskWhileThinkingCancelsThePendingResponseBeforeStartingAnother() async throws {
+        let firstCreateStarted = AsyncGate()
+        let allowFirstCreate = AsyncGate()
+        let createCounter = ResponseCreateCounter()
+        let ws = MockWebSocketTask(onSend: { text in
+            if await createCounter.isFirst(text) {
+                await firstCreateStarted.open()
+                await allowFirstCreate.wait()
+            }
+        })
+        let session = RealtimeSession(options: makeOptions(ws: ws))
+
+        Task { ws.deliver(#"{"type":"session.created"}"#) }
+        await session.connect()
+        try await Task.sleep(nanoseconds: 50_000_000)
+
+        session.beginTurn()
+        session.endTurn()
+        await firstCreateStarted.wait()
+
+        XCTAssertTrue(session.sendTypedAsk("Use the newer request"))
+        await allowFirstCreate.open()
+        try await Task.sleep(nanoseconds: 50_000_000)
+
+        let oldCreate = ws.outgoing.firstIndex { $0.contains(#""type":"response.create""#) }
+        let cancel = ws.outgoing.firstIndex { $0.contains(#""type":"response.cancel""#) }
+        let item = ws.outgoing.firstIndex { $0.contains("Use the newer request") }
+        let newCreate = ws.outgoing.lastIndex { $0.contains(#""type":"response.create""#) }
+        XCTAssertNotNil(oldCreate)
+        XCTAssertNotNil(cancel)
+        XCTAssertNotNil(item)
+        XCTAssertNotNil(newCreate)
+        XCTAssertLessThan(oldCreate!, cancel!)
+        XCTAssertLessThan(cancel!, item!)
+        XCTAssertLessThan(item!, newCreate!)
     }
 
     func testTypedAskHeldWhileConnectingIsSentAtChannelOpen() async throws {

--- a/apps/ios/LukeKit/Tests/LukeKitTests/RealtimeSessionTests.swift
+++ b/apps/ios/LukeKit/Tests/LukeKitTests/RealtimeSessionTests.swift
@@ -873,6 +873,211 @@ final class RealtimeSessionStateTests: XCTestCase {
         XCTAssertTrue(sent.contains(#""call_id":"c1""#), "Should address the correct call_id")
     }
 
+    // MARK: - Typed asks
+
+    func testTypedAskSendsTheDeveloperWordsAndRequestsAnArmedResponse() async throws {
+        let ws = MockWebSocketTask()
+        var dispatchedNames: [String] = []
+        let opts = makeOptions(ws: ws, dispatchToolCall: { name, _, _ in
+            dispatchedNames.append(name)
+            return #"{"result":"sent"}"#
+        })
+        let session = RealtimeSession(options: opts)
+
+        Task { ws.deliver(#"{"type":"session.created"}"#) }
+        await session.connect()
+        try await Task.sleep(nanoseconds: 50_000_000)
+
+        XCTAssertTrue(session.sendTypedAsk("  Open the Codex session  "))
+        XCTAssertEqual(session.status, .thinking)
+        try await Task.sleep(nanoseconds: 50_000_000)
+
+        let items = ws.outgoing.filter { $0.contains(#""type":"conversation.item.create""#) }
+        XCTAssertEqual(items.count, 2, "The channel-open context item, then the typed ask")
+        let json = try JSONSerialization.jsonObject(with: Data(items[1].utf8)) as? [String: Any]
+        let item = (json?["item"] as? [String: Any])
+        XCTAssertEqual(item?["role"] as? String, "user")
+        let content = (item?["content"] as? [[String: Any]])?.first
+        XCTAssertEqual(content?["type"] as? String, "input_text")
+        XCTAssertEqual(content?["text"] as? String, "Open the Codex session")
+        XCTAssertTrue(ws.outgoing.contains { $0.contains(#""type":"response.create""#) })
+        XCTAssertFalse(
+            ws.outgoing.contains { $0.contains("input_audio_buffer.commit") },
+            "A typed turn commits no audio"
+        )
+
+        ws.deliver(
+            #"{"type":"response.done","response":{"output":[{"type":"function_call","call_id":"c1","name":"open_session","arguments":"{}"}]}}"#
+        )
+        try await Task.sleep(nanoseconds: 50_000_000)
+        XCTAssertEqual(dispatchedNames, ["open_session"])
+    }
+
+    func testTypedAskIsRefusedWhileTheMicrophoneIsOpen() async throws {
+        let ws = MockWebSocketTask()
+        let session = RealtimeSession(options: makeOptions(ws: ws))
+
+        Task { ws.deliver(#"{"type":"session.created"}"#) }
+        await session.connect()
+        try await Task.sleep(nanoseconds: 50_000_000)
+
+        session.beginTurn()
+        XCTAssertEqual(session.status, .listening)
+        XCTAssertFalse(session.sendTypedAsk("Typed over the open microphone"))
+        try await Task.sleep(nanoseconds: 20_000_000)
+        XCTAssertEqual(session.status, .listening)
+        XCTAssertFalse(ws.outgoing.contains { $0.contains("Typed over the open microphone") })
+    }
+
+    func testEmptyAndIdleTypedAsksAreRefused() async throws {
+        let ws = MockWebSocketTask()
+        let session = RealtimeSession(options: makeOptions(ws: ws))
+        XCTAssertFalse(session.sendTypedAsk("Typed before any call"), "Idle takes no ask")
+
+        Task { ws.deliver(#"{"type":"session.created"}"#) }
+        await session.connect()
+        try await Task.sleep(nanoseconds: 50_000_000)
+
+        XCTAssertFalse(session.sendTypedAsk("   \n "))
+        try await Task.sleep(nanoseconds: 20_000_000)
+        XCTAssertEqual(session.status, .ready)
+        XCTAssertFalse(ws.outgoing.contains { $0.contains(#""type":"response.create""#) })
+    }
+
+    func testTypedAskIsCutAtTheSessionMessageBound() async throws {
+        let ws = MockWebSocketTask()
+        let session = RealtimeSession(options: makeOptions(ws: ws))
+
+        Task { ws.deliver(#"{"type":"session.created"}"#) }
+        await session.connect()
+        try await Task.sleep(nanoseconds: 50_000_000)
+
+        let overlong = String(repeating: "a", count: VoiceAsks.maximumMessageLength) + "z"
+        XCTAssertTrue(session.sendTypedAsk(overlong))
+        try await Task.sleep(nanoseconds: 50_000_000)
+
+        let sent = ws.outgoing.joined(separator: "\n")
+        XCTAssertTrue(sent.contains(String(repeating: "a", count: VoiceAsks.maximumMessageLength)))
+        XCTAssertFalse(sent.contains("z"))
+    }
+
+    func testTypedAskWhileSpeakingInterruptsTheReply() async throws {
+        let ws = MockWebSocketTask()
+        let player = RecordingPlayer()
+        let clock = TestClock(10.0)
+        var dispatchedNames: [String] = []
+        let session = RealtimeSession(options: makeOptions(
+            ws: ws,
+            player: player,
+            dispatchToolCall: { name, _, _ in
+                dispatchedNames.append(name)
+                return #"{"result":"sent"}"#
+            },
+            now: { clock.read() }
+        ))
+
+        Task { ws.deliver(#"{"type":"session.created"}"#) }
+        await session.connect()
+        try await Task.sleep(nanoseconds: 50_000_000)
+
+        session.beginTurn()
+        session.endTurn()
+        ws.deliver(#"{"type":"response.created","response":{"id":"response_old"}}"#)
+        ws.deliver(
+            #"{"type":"response.output_item.added","response_id":"response_old","item":{"id":"item_old","type":"message","role":"assistant"}}"#
+        )
+        let audio = [Int16](repeating: 1, count: 2_400)
+            .withUnsafeBytes { Data($0).base64EncodedString() }
+        ws.deliver(
+            #"{"type":"response.output_audio.delta","response_id":"response_old","delta":"\#(audio)"}"#
+        )
+        try await Task.sleep(nanoseconds: 50_000_000)
+        XCTAssertEqual(session.status, .speaking)
+
+        clock.set(11.0)
+        XCTAssertTrue(session.sendTypedAsk("Actually, open the Codex session"))
+        XCTAssertEqual(session.status, .thinking)
+        try await Task.sleep(nanoseconds: 50_000_000)
+
+        XCTAssertEqual(player.stopCount, 1)
+        let sent = ws.outgoing.joined(separator: "\n")
+        XCTAssertTrue(sent.contains(#""type":"response.cancel""#))
+        XCTAssertTrue(sent.contains(#""type":"conversation.item.truncate""#))
+        XCTAssertTrue(sent.contains("Actually, open the Codex session"))
+        XCTAssertTrue(sent.contains(#""ios_interruption_sequence":"1""#))
+
+        // The interrupted response's late arrivals cannot act under the
+        // typed turn's arming.
+        ws.deliver(
+            #"{"type":"response.done","response":{"id":"response_old","output":[{"type":"function_call","call_id":"old_call","name":"send_session_message","arguments":"{}"}]}}"#
+        )
+        try await Task.sleep(nanoseconds: 50_000_000)
+        XCTAssertTrue(dispatchedNames.isEmpty)
+        XCTAssertEqual(session.status, .thinking)
+    }
+
+    func testTypedAskHeldWhileConnectingIsSentAtChannelOpen() async throws {
+        let ws = MockWebSocketTask()
+        let mintStarted = AsyncGate()
+        let allowMint = AsyncGate()
+        let session = RealtimeSession(
+            options: makeOptions(
+                ws: ws,
+                requestConnection: {
+                    await mintStarted.open()
+                    await allowMint.wait()
+                    return testConnection
+                }
+            )
+        )
+
+        let connecting = Task { await session.connect() }
+        await mintStarted.wait()
+        XCTAssertEqual(session.status, .connecting)
+        XCTAssertTrue(session.sendTypedAsk("Open the Codex session"))
+        XCTAssertFalse(session.sendTypedAsk("A second held ask"), "One held ask is enough")
+
+        await allowMint.open()
+        ws.deliver(#"{"type":"session.created"}"#)
+        await connecting.value
+        try await Task.sleep(nanoseconds: 50_000_000)
+
+        XCTAssertEqual(session.status, .thinking)
+        let contextIndex = ws.outgoing.firstIndex { $0.contains(testContext.itemId) }
+        let askIndex = ws.outgoing.firstIndex { $0.contains("Open the Codex session") }
+        let createIndex = ws.outgoing.firstIndex { $0.contains(#""type":"response.create""#) }
+        XCTAssertNotNil(contextIndex)
+        XCTAssertNotNil(askIndex)
+        XCTAssertNotNil(createIndex)
+        XCTAssertLessThan(contextIndex!, askIndex!)
+        XCTAssertLessThan(askIndex!, createIndex!)
+        XCTAssertFalse(ws.outgoing.contains { $0.contains("A second held ask") })
+        XCTAssertFalse(ws.outgoing.contains { $0.contains("input_audio_buffer.commit") })
+    }
+
+    func testPressedTurnWhileConnectingOwnsTheResponseOverAHeldTypedAsk() async throws {
+        let ws = MockWebSocketTask()
+        let session = RealtimeSession(options: makeOptions(ws: ws))
+
+        await session.connect()
+        XCTAssertTrue(session.sendTypedAsk("Open the Codex session"))
+        session.beginTurn()
+        XCTAssertFalse(session.sendTypedAsk("Typed behind the press"))
+
+        ws.deliver(#"{"type":"session.created"}"#)
+        try await Task.sleep(nanoseconds: 50_000_000)
+
+        XCTAssertEqual(session.status, .listening)
+        XCTAssertTrue(
+            ws.outgoing.contains { $0.contains("Open the Codex session") },
+            "The held ask's words still travel, ahead of the pressed turn"
+        )
+        XCTAssertFalse(
+            ws.outgoing.contains { $0.contains(#""type":"response.create""#) },
+            "The open microphone's turn requests its own response"
+        )
+    }
+
     func testCloseResetsToIdle() async throws {
         let ws = MockWebSocketTask()
         let opts = makeOptions(ws: ws)

--- a/apps/ios/LukeKit/Tests/LukeKitTests/VoiceConversationThreadTests.swift
+++ b/apps/ios/LukeKit/Tests/LukeKitTests/VoiceConversationThreadTests.swift
@@ -58,6 +58,39 @@ final class VoiceConversationThreadTests: XCTestCase {
         )
     }
 
+    func testTypedAskOpensItsOwnTurn() {
+        let thread = VoiceConversationThread()
+        thread.beginTurn()
+        thread.recordSpokenAsk("First ask")
+        thread.recordCaption("First reply")
+        thread.recordCaption(nil)
+        thread.recordTypedAsk("  Open the Codex session  ")
+        thread.recordCaption("Opening it.")
+        XCTAssertEqual(
+            thread.messages.map(\.words),
+            ["First ask", "First reply", "Open the Codex session", "Opening it."]
+        )
+        XCTAssertEqual(
+            thread.messages.map(\.typed),
+            [false, false, true, false]
+        )
+        XCTAssertEqual(thread.messages[2].speaker, .developer)
+        XCTAssertEqual(thread.messages[2].turnId, thread.messages[3].turnId)
+    }
+
+    func testLateTranscriptNeverReplacesATypedAsk() {
+        let thread = VoiceConversationThread()
+        thread.recordTypedAsk("Open the Codex session")
+        thread.recordSpokenAsk("A spoken turn's late transcript")
+        XCTAssertEqual(thread.messages.map(\.words), ["Open the Codex session"])
+    }
+
+    func testEmptyTypedAskRecordsNothing() {
+        let thread = VoiceConversationThread()
+        thread.recordTypedAsk("   \n")
+        XCTAssertTrue(thread.messages.isEmpty)
+    }
+
     func testEmptySpokenAskRecordsNothing() {
         let thread = VoiceConversationThread()
         thread.beginTurn()

--- a/apps/ios/README.md
+++ b/apps/ios/README.md
@@ -39,7 +39,11 @@ simulator run does not deliver.
 ## Voice acts
 
 The voice screen carries the same acts the desktop's conversation does,
-minus the ones that have no surface on a phone. The tool list is minted
+minus the ones that have no surface on a phone. A turn is opened by the talk
+button or by the keyboard button beside it, which stands a composer up in the
+controls' place: a typed ask is the same explicitly opened, tool-armed turn a
+press is, with no microphone anywhere in it, mirroring the desktop's Ask Luke
+field. The tool list is minted
 server-side from `remoteRealtimeToolDefinitions()` in `packages/acts`, and
 each call is validated on the phone in `LukeKit`'s `VoiceAsks` against the
 roster and projects the conversation was shown before anything is sent:


### PR DESCRIPTION
## What

The iOS voice screen gains the desktop's typed ask, on this platform's terms. A quiet Liquid Glass keyboard button waits at the controls' bottom left; pressing it morphs the button into a composer capsule while the centered talk button moves and shrinks into the microphone at the capsule's side. The send opens the same explicitly armed, tool-carrying turn a press does, with no microphone anywhere in it.

## How

- **`RealtimeSession.sendTypedAsk`** mirrors the desktop's typed path: trimmed and cut at the session-message bound, refused while the microphone is open, and held while the channel connects. A shared send queue serializes an interrupted response, its cancellation, the typed item, and the new `response.create`, so superseding a spoken or in-flight response cannot create overlapping socket turns.
- **`VoiceConversationThread`** records typed asks as their own turns, and a late voice transcript can no longer overwrite typed words. The context re-feed leads with "the developer typed", matching the desktop history's vocabulary.
- **Morphing** uses one `GlassEffectContainer` and the system matched-geometry glass transition for the keyboard-button-to-composer change. The mic is one persistent talk button whose position and size animate between the centered resting state and the composer's trailing edge. Pre-iOS-26 keeps the same layout with standard matched geometry.
- **Keyboard focus** is requested from the inserted `TextField` after it appears. Dismissing the software keyboard or pressing the side mic no longer tears down the composer; a successful send dismisses it explicitly.
- **The side mic is the regular mic button**, with the same hold-to-talk, tap-to-latch, tinting, waveform swap, and VoiceOver behavior, so a spoken turn works mid-compose without losing the draft.

## Posture

The typed draft stays masked from session replay by the recording SDK's default input masking, and the sent bubble reuses the already-masked `DeveloperMessageBubble`. `PRIVACY.md` already discloses typed turns ("a typed turn sends your words"). No analytics events were added. The keyboard button hides while the microphone is open, where a typed ask could only be refused.

## Testing

- `./scripts/check.sh` passes (portable repository, type, test, and build checks).
- `swift test` in `apps/ios/LukeKit`: 254 tests pass, including a deterministic regression that blocks the old response request and verifies old request → cancel → typed item → new request ordering.
- `xcodebuild test` passes all 14 app tests on the iPhone 17 Pro simulator (iOS 26.5).
- The keyboard appeared on 3/3 fresh simulator launches using the inserted-field `FocusState` path.
- GitHub CI, CodeQL, Bugbot, security review, and the Vercel preview passed on the behavioral-fix head; the final source-comment-only head is re-running the same checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/33913989581/artifacts/9952513111) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/33913989581)

- Commit: `e34d3cfded66cbc7940f5f5ec69184c4dcef66a6`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
