### PR TITLE
fix(ios): center the sessions list's empty states

### DIFF
--- a/apps/ios/Luke/SessionsView.swift
+++ b/apps/ios/Luke/SessionsView.swift
@@ -132,26 +132,16 @@ struct SessionsView: View {
             matched.filter { matchesFilterSelection(store.filters, session: $0) },
             by: store.sort
         )
+        let awaitingSkeleton =
+            store.awaitingFirstRoster && store.sessions.isEmpty && store.fetchError == nil
         return List {
-            if store.awaitingFirstRoster && store.sessions.isEmpty && store.fetchError == nil {
+            if awaitingSkeleton {
                 ForEach(0 ..< 3, id: \.self) { _ in
                     SkeletonRow()
                         .listRowBackground(Color.clear)
                         .listRowSeparator(.hidden)
                         .listRowInsets(rowInsets)
                 }
-            } else if store.sessions.isEmpty {
-                emptyRow
-                    .listRowBackground(Color.clear)
-                    .listRowSeparator(.hidden)
-            } else if matched.isEmpty {
-                ContentUnavailableView.search(text: store.searchQuery)
-                    .listRowBackground(Color.clear)
-                    .listRowSeparator(.hidden)
-            } else if visible.isEmpty {
-                filteredOutRow(hiddenCount: matched.count)
-                    .listRowBackground(Color.clear)
-                    .listRowSeparator(.hidden)
             } else {
                 ForEach(visible) { s in
                     sessionItem(s)
@@ -164,6 +154,20 @@ struct SessionsView: View {
         .listStyle(.plain)
         .scrollContentBackground(.hidden)
         .background(Color.ground.ignoresSafeArea())
+        // Over the list rather than in it: a row sits at the top of an
+        // otherwise empty list, while an overlay centers in the whole area,
+        // and the list beneath keeps its pull-to-refresh.
+        .overlay {
+            if !awaitingSkeleton {
+                if store.sessions.isEmpty {
+                    emptyState
+                } else if matched.isEmpty {
+                    ContentUnavailableView.search(text: store.searchQuery)
+                } else if visible.isEmpty {
+                    filteredOutState(hiddenCount: matched.count)
+                }
+            }
+        }
         .searchable(text: $store.searchQuery, isPresented: $store.searchPresented, prompt: "Search sessions")
         .toolbar {
             // Search and list options flank the primary voice action. Keeping
@@ -237,7 +241,7 @@ struct SessionsView: View {
         .tint(Color.ink)
     }
 
-    private func filteredOutRow(hiddenCount: Int) -> some View {
+    private func filteredOutState(hiddenCount: Int) -> some View {
         ContentUnavailableView {
             Label("No matching sessions", systemImage: "line.3.horizontal.decrease")
         } description: {
@@ -246,7 +250,6 @@ struct SessionsView: View {
             Button("Clear Filters") { store.filters.removeAll() }
                 .tint(Color.ink)
         }
-        .padding(.top, 40)
     }
 
     private let rowInsets = EdgeInsets(top: 4, leading: 16, bottom: 4, trailing: 16)
@@ -439,28 +442,25 @@ struct SessionsView: View {
     }
 
     @ViewBuilder
-    private var emptyRow: some View {
-        Group {
-            if let error = store.fetchError {
-                ContentUnavailableView {
-                    Label("Couldn't Load Sessions", systemImage: "exclamationmark.triangle")
-                } description: {
-                    Text(error)
-                } actions: {
-                    Button("Try Again") {
-                        Task { await refreshSessions() }
-                    }
-                    .tint(Color.ink)
+    private var emptyState: some View {
+        if let error = store.fetchError {
+            ContentUnavailableView {
+                Label("Couldn't Load Sessions", systemImage: "exclamationmark.triangle")
+            } description: {
+                Text(error)
+            } actions: {
+                Button("Try Again") {
+                    Task { await refreshSessions() }
                 }
-            } else {
-                ContentUnavailableView {
-                    Label("No Active Sessions", systemImage: "tray")
-                } description: {
-                    Text("Sessions from providers with stored keys appear here.")
-                }
+                .tint(Color.ink)
+            }
+        } else {
+            ContentUnavailableView {
+                Label("No Active Sessions", systemImage: "tray")
+            } description: {
+                Text("Sessions from providers with stored keys appear here.")
             }
         }
-        .padding(.top, 40)
     }
 
     private func refreshSessions() async {


### PR DESCRIPTION
## What

The iOS sessions screen's empty states now center in the screen instead of sitting near the top. The screenshot that prompted this showed "No Active Sessions" hanging under the toolbar with the rest of the screen blank.

## How

The empty, load-error, no-search-match, and filtered-out states were rows inside the `List`, so each took only its own height at the top of an otherwise empty list, propped up by a fixed top padding. They now draw in an `.overlay` on the `List`, the idiom Apple's own `ContentUnavailableView` documentation shows and the one the watch roster already uses, so the view centers itself in the whole list area while the list beneath keeps its pull-to-refresh. The skeleton rows stay in the list, and the overlay draws nothing while they show.

Other iOS empty states were checked and left as they are: the workspace creator's "No Projects" and load-error states already fill their sheet and center, the voice screen's empty-state face is already an overlay, and the session detail thread's placeholder is an inline footnote in a chat thread rather than a screen-level empty state.

## Testing

- `./scripts/check.sh` passes.
- `xcodebuild build` of the `Luke` scheme for the iOS Simulator succeeds on Xcode 26.6.
- No simulator screenshot was taken, since the empty state needs a signed-in account with no sessions.
- Physical-notch check: not performed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/33917907776/artifacts/9953971326) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/33917907776)

- Commit: `6fffd228b46693e73082db6c527b872c0adc5178`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
