### PR TITLE
feat(ios): add bottom tab navigation with Sessions, Luke, and New

### DIFF
--- a/apps/ios/Luke/ContentView.swift
+++ b/apps/ios/Luke/ContentView.swift
@@ -170,38 +170,88 @@ struct ContentView: View {
 /// sign-in starts with the sheet closed rather than inheriting a stale true.
 private struct SignedInView: View {
     @Environment(AccountSession.self) private var session
+    @Environment(ProductEventSender.self) private var events
     let identity: AccountIdentity
     @State private var profileShown = false
-    /// The list's state and the stack above it, owned here so the voice
-    /// screen can drive the same presses the list offers by hand, and torn
-    /// down with the signed-in hierarchy like the profile flag.
+    @State private var creatorShown = false
+    /// The list's state, the stack above it, and the tab selection, owned
+    /// here so the voice screen can drive the same presses the list offers
+    /// by hand, and torn down with the signed-in hierarchy like the profile
+    /// flag.
     @State private var store = SessionsStore(
         rosterClient: RosterClient(serviceURL: AccountConstants.serviceURL)
     )
 
+    private let actClient = ActClient(baseURL: AccountConstants.serviceURL)
+    private let projectsClient = ProjectsClient(serviceURL: AccountConstants.serviceURL)
+
     var body: some View {
         @Bindable var store = store
-        return NavigationStack(path: $store.path) {
-            SessionsView()
-                .toolbar {
-                    if #available(iOS 26.0, *) {
-                        ToolbarItem(placement: .topBarLeading) {
-                            profileButton
-                        }
-                        // Separated from the bar's shared glass, which hugs an
-                        // item as a capsule: the avatar's own circle is the
-                        // whole control.
-                        .sharedBackgroundVisibility(.hidden)
-                    } else {
-                        ToolbarItem(placement: .topBarLeading) {
-                            profileButton
-                        }
-                    }
-                }
+        return TabView(selection: tabSelection) {
+            NavigationStack(path: $store.path) {
+                SessionsView()
+                    .toolbar { profileToolbar }
+            }
+            .tabItem { Label("Sessions", systemImage: "list.bullet") }
+            .tag(AppTab.sessions)
+
+            NavigationStack {
+                VoiceView()
+                    .toolbar { profileToolbar }
+            }
+            .tabItem { Label("Luke", systemImage: "waveform") }
+            .tag(AppTab.luke)
+
+            // Never shown: selecting this tab presents the creator sheet
+            // instead of changing the selection.
+            Color.ground
+                .ignoresSafeArea()
+                .tabItem { Label("New", systemImage: "plus") }
+                .tag(AppTab.create)
         }
         .environment(store)
         .sheet(isPresented: $profileShown) {
             ProfileSheet(identity: identity)
+        }
+        .sheet(isPresented: $creatorShown) {
+            WorkspaceCreatorSheet(actClient: actClient, projectsClient: projectsClient) {
+                creatorShown = false
+                store.tab = .sessions
+                Task { await store.refresh(account: session, events: events) }
+            }
+        }
+    }
+
+    /// The New tab is a button in the bar: its selection opens the creator
+    /// sheet and the selection stays where it was, so dismissing the sheet
+    /// leaves the developer on the screen they were reading.
+    private var tabSelection: Binding<AppTab> {
+        Binding(
+            get: { store.tab },
+            set: { selected in
+                if selected == .create {
+                    creatorShown = true
+                } else {
+                    store.tab = selected
+                }
+            }
+        )
+    }
+
+    @ToolbarContentBuilder
+    private var profileToolbar: some ToolbarContent {
+        if #available(iOS 26.0, *) {
+            ToolbarItem(placement: .topBarLeading) {
+                profileButton
+            }
+            // Separated from the bar's shared glass, which hugs an
+            // item as a capsule: the avatar's own circle is the
+            // whole control.
+            .sharedBackgroundVisibility(.hidden)
+        } else {
+            ToolbarItem(placement: .topBarLeading) {
+                profileButton
+            }
         }
     }
 

--- a/apps/ios/Luke/ContentView.swift
+++ b/apps/ios/Luke/ContentView.swift
@@ -222,7 +222,10 @@ private struct SignedInView: View {
         .sheet(isPresented: $creatorShown) {
             WorkspaceCreatorSheet(actClient: actClient, projectsClient: projectsClient) {
                 creatorShown = false
+                // The list is the one place the new workspace appears, so a
+                // session screen still stacked above it pops as well.
                 store.tab = .sessions
+                store.path.removeAll()
                 Task { await store.refresh(account: session, events: events) }
             }
         }

--- a/apps/ios/Luke/ContentView.swift
+++ b/apps/ios/Luke/ContentView.swift
@@ -199,7 +199,13 @@ private struct SignedInView: View {
                 VoiceView()
                     .toolbar { profileToolbar }
             }
-            .tabItem { Label("Luke", systemImage: "waveform") }
+            .tabItem {
+                Label {
+                    Text("Luke")
+                } icon: {
+                    Image(uiImage: LukeMark.tabIcon)
+                }
+            }
             .tag(AppTab.luke)
 
             // Never shown: selecting this tab presents the creator sheet

--- a/apps/ios/Luke/Marks.swift
+++ b/apps/ios/Luke/Marks.swift
@@ -81,6 +81,38 @@ struct LukeMark: View {
         }
         .aspectRatio(FaceArt.markBox.width / FaceArt.markBox.height, contentMode: .fit)
     }
+
+    /// The face rasterized for the tab bar, which — like a `UIMenu` row —
+    /// draws only an image beside each title and drops a custom label view,
+    /// so the Canvas above can never appear there. The template rendering
+    /// lets the bar ink the face selected and unselected the way it inks an
+    /// SF Symbol.
+    static let tabIcon: UIImage = {
+        let box = FaceArt.markBox
+        let height: CGFloat = 24
+        let size = CGSize(width: height * box.width / box.height, height: height)
+        let scale = height / box.height
+        let placement = CGAffineTransform(scaleX: scale, y: scale)
+            .translatedBy(x: -box.minX, y: -box.minY)
+        let image = UIGraphicsImageRenderer(size: size).image { rendererContext in
+            let ctx = rendererContext.cgContext
+            // The CTM carries the tilt and placement, so the stroke width and
+            // eye rects stay in the artwork's own canvas coordinates.
+            ctx.concatenate(FaceArt.tilt.concatenating(placement))
+            ctx.setLineWidth(FaceArt.strokeWidth)
+            ctx.setLineCap(.round)
+            ctx.setLineJoin(.round)
+            ctx.addPath(FaceArt.smile.cgPath)
+            ctx.strokePath()
+            for eyeX in FaceArt.eyeXs {
+                ctx.fillEllipse(in: CGRect(
+                    x: eyeX - FaceArt.eyeRadius, y: FaceArt.eyeY - FaceArt.eyeRadius,
+                    width: FaceArt.eyeRadius * 2, height: FaceArt.eyeRadius * 2
+                ))
+            }
+        }
+        return image.withRenderingMode(.alwaysTemplate)
+    }()
 }
 
 // MARK: - Google G mark (official brand geometry, viewBox 0 0 18 18)

--- a/apps/ios/Luke/SessionsStore.swift
+++ b/apps/ios/Luke/SessionsStore.swift
@@ -2,12 +2,20 @@ import LukeKit
 import Observation
 import SwiftUI
 
-/// Where the signed-in hierarchy can stand beyond the list: on the voice
-/// screen, or on one session's own screen. A route carries the observed row
-/// it was opened from, so a screen whose session a later refresh no longer
-/// reports keeps its last observed word rather than going blank.
+/// The signed-in tab bar's destinations. `create` is a button wearing a
+/// tab's clothes: selecting it presents the New Workspace sheet while the
+/// selection stays on the tab already showing.
+enum AppTab: Hashable {
+    case sessions
+    case luke
+    case create
+}
+
+/// Where the sessions tab can stand beyond the list: on one session's own
+/// screen. A route carries the observed row it was opened from, so a screen
+/// whose session a later refresh no longer reports keeps its last observed
+/// word rather than going blank.
 enum SessionsRoute: Hashable {
-    case voice
     case session(RosterSession)
 }
 
@@ -36,6 +44,9 @@ final class SessionsStore {
     var searchPresented = false
     var filters: Set<SessionFilter> = []
     var sort: SessionSort = .urgency
+    /// Which tab the signed-in hierarchy shows; the conversation with Luke is
+    /// where a launch lands.
+    var tab: AppTab = .luke
     var path: [SessionsRoute] = []
 
     /// Counts refresh passes so a stale answer cannot outrank a newer one:
@@ -65,12 +76,11 @@ final class SessionsStore {
     }
 
     /// Opens a session's screen in the conversation's place: an open asked of
-    /// Luke leaves the conversation the way the desktop's open leaves the
-    /// panel for the provider's app. Covering the voice screen instead would
-    /// close its call and then mint another the moment the developer swiped
-    /// back, spending a voice session nobody asked for.
+    /// Luke leaves the Luke tab for the sessions tab the way the desktop's
+    /// open leaves the panel for the provider's app, and the voice screen
+    /// disappearing is what closes its call.
     func openLeavingConversation(_ session: RosterSession) {
-        path.removeAll { $0 == .voice }
+        tab = .sessions
         path.append(.session(session))
     }
 
@@ -104,7 +114,7 @@ final class SessionsStore {
 
     /// Shows the list as a spoken ask narrowed, ordered, or searched it, the
     /// way the filter sheet and the search field would have. The ask arrives
-    /// validated against the roster; this only applies it and pops to the list.
+    /// validated against the roster; this only applies it and shows the list.
     func showList(_ ask: VoiceAsks.SessionListAsk) {
         if let filters = ask.filters { self.filters = filters }
         if let sort = ask.sort { self.sort = sort }
@@ -112,6 +122,7 @@ final class SessionsStore {
             searchQuery = query
             searchPresented = true
         }
+        tab = .sessions
         path.removeAll()
     }
 

--- a/apps/ios/Luke/SessionsView.swift
+++ b/apps/ios/Luke/SessionsView.swift
@@ -18,7 +18,6 @@ struct SessionsView: View {
     @State private var spawningSession: RosterSession?
     @State private var renaming: RenameTarget?
     @State private var renameText = ""
-    @State private var creatorShown = false
     @State private var actFailure: String?
 
     /// Which advertised rename a menu press opened: the session itself, or
@@ -34,24 +33,12 @@ struct SessionsView: View {
     }
 
     private let actClient = ActClient(baseURL: AccountConstants.serviceURL)
-    private let projectsClient = ProjectsClient(serviceURL: AccountConstants.serviceURL)
     private let conversationClient = ConversationClient(serviceURL: AccountConstants.serviceURL)
 
     var body: some View {
-        Group {
-            if #available(iOS 26.0, *) {
-                // Minimized, the search is the magnifier button in the bar until
-                // pressed; earlier systems keep the field the bar draws for a
-                // searchable list.
-                searchableList.searchToolbarBehavior(.minimize)
-            } else {
-                searchableList
-            }
-        }
+        searchableList
         .navigationDestination(for: SessionsRoute.self) { route in
             switch route {
-            case .voice:
-                VoiceView()
             case .session(let opened):
                 // The freshest observation of the opened session wins, so a
                 // refresh behind the screen updates the words it draws; a
@@ -82,12 +69,6 @@ struct SessionsView: View {
         .sheet(item: $spawningSession) { s in
             AgentSpawnerSheet(session: s, actClient: actClient) {
                 spawningSession = nil
-                Task { await refreshSessions() }
-            }
-        }
-        .sheet(isPresented: $creatorShown) {
-            WorkspaceCreatorSheet(actClient: actClient, projectsClient: projectsClient) {
-                creatorShown = false
                 Task { await refreshSessions() }
             }
         }
@@ -168,31 +149,19 @@ struct SessionsView: View {
                 }
             }
         }
-        .searchable(text: $store.searchQuery, isPresented: $store.searchPresented, prompt: "Search sessions")
+        // The drawer keeps the field at the top of the list, summoned by the
+        // bar's own search button, rather than iOS 26's bottom-edge default,
+        // which would crowd the tab bar.
+        .searchable(
+            text: $store.searchQuery,
+            isPresented: $store.searchPresented,
+            placement: .navigationBarDrawer(displayMode: .automatic),
+            prompt: "Search sessions"
+        )
         .toolbar {
-            // Search and list options flank the primary voice action. Keeping
-            // all three in the system bar gives each control native Liquid
-            // Glass while Luke remains centered and easy to reach.
-            if #available(iOS 26.0, *) {
-                DefaultToolbarItem(kind: .search, placement: .bottomBar)
-                ToolbarSpacer(.flexible, placement: .bottomBar)
-                ToolbarItem(placement: .bottomBar) {
-                    voiceButton
-                }
-                ToolbarSpacer(.flexible, placement: .bottomBar)
-                ToolbarItem(placement: .bottomBar) {
-                    optionsButton
-                }
-            } else {
-                ToolbarItem(placement: .topBarTrailing) {
-                    voiceButton
-                }
-                ToolbarItem(placement: .topBarTrailing) {
-                    optionsButton
-                }
-            }
-            ToolbarItem(placement: .topBarTrailing) {
-                newWorkspaceButton
+            ToolbarItemGroup(placement: .topBarTrailing) {
+                searchButton
+                optionsButton
             }
         }
         .sheet(isPresented: $optionsShown) {
@@ -213,30 +182,11 @@ struct SessionsView: View {
         .tint(Color.ink)
     }
 
-    @ViewBuilder
-    private var voiceButton: some View {
-        if #available(iOS 26.0, *) {
-            NavigationLink(value: SessionsRoute.voice) {
-                LukeMark()
-                    .foregroundStyle(Color.ink)
-                    .frame(width: 22, height: 20)
-            }
-            .accessibilityLabel("Talk to Luke")
-        } else {
-            NavigationLink(value: SessionsRoute.voice) {
-                LukeMark()
-                    .foregroundStyle(Color.ink)
-                    .frame(width: 22, height: 20)
-            }
-            .accessibilityLabel("Talk to Luke")
-        }
-    }
-
-    private var newWorkspaceButton: some View {
+    private var searchButton: some View {
         Button {
-            creatorShown = true
+            store.searchPresented = true
         } label: {
-            Label("New Workspace", systemImage: "plus")
+            Label("Search", systemImage: "magnifyingglass")
         }
         .tint(Color.ink)
     }
@@ -486,7 +436,7 @@ private func optionTitle(_ filter: SessionFilter) -> String {
     }
 }
 
-/// The half sheet the search bar's filter button opens, in the system's own
+/// The half sheet the top bar's filter button opens, in the system's own
 /// grouped-sheet vocabulary (the profile sheet's): the sort as a checkmark
 /// list, one drill-in page per filter axis with the selection named on its
 /// row, and a clear action only while something is selected. The list behind

--- a/apps/ios/Luke/VoiceView.swift
+++ b/apps/ios/Luke/VoiceView.swift
@@ -260,6 +260,7 @@ struct VoiceView: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(Color.ground.ignoresSafeArea())
+        .navigationTitle("Luke")
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
             ToolbarItem(placement: .topBarTrailing) { settingsButton }
@@ -329,7 +330,7 @@ struct VoiceView: View {
     }
 
     /// Takes the developer where the settled reply said they were going. The
-    /// voice screen leaves the stack either way, and this screen's
+    /// selection leaves the Luke tab either way, and this screen's
     /// `onDisappear` closes the call behind it.
     private func performPendingNavigation() {
         guard let pending = model.pendingNavigation else { return }

--- a/apps/ios/README.md
+++ b/apps/ios/README.md
@@ -51,8 +51,8 @@ roster and projects the conversation was shown before anything is sent:
 | Tool | What happens on the phone |
 | --- | --- |
 | `send_session_message`, `run_session_control`, `add_workspace_agent`, `rename_session`, `rename_workspace`, `create_workspace` | Validated against the observed roster or projects answer, then sent to the hosted act endpoint, which re-observes and validates again |
-| `open_session` | Pushes the session's own screen once Luke's reply has finished |
-| `show_panel` | Pops to the list and applies the filters, sort, or search the ask named, as the filter sheet and search field would |
+| `open_session` | Switches to the Sessions tab and pushes the session's own screen once Luke's reply has finished |
+| `show_panel` | Switches to the Sessions tab and applies the filters, sort, or search the ask named, as the filter sheet and search field would |
 
 The voice settings sheet ends in a Debug section listing every tool the
 desktop's conversation carries, marked available or not, with the reason:


### PR DESCRIPTION
## What

Reworks the iOS app's top-level layout and navigation:

- **Top bar**: the New (workspace) button leaves the top right; Search and Filter buttons stand there instead. The search field stays in the navigation bar drawer (summoned by the Search button or a pull-down) rather than iOS 26's bottom-edge default, which would crowd the new tab bar.
- **Bottom navigation**: the signed-in hierarchy becomes a standard `TabView` with three tabs — **Sessions** on the left, **Luke** (the voice/conversation screen) in the middle as the default tab, and **New** on the right.
- **New tab as a button**: selecting New presents the existing `WorkspaceCreatorSheet` while the selection stays where it was (a custom `Binding` setter intercepts it), so dismissing the sheet leaves the developer on the screen they were reading. A successful creation switches to the Sessions tab and refreshes the roster.
- **Navigation wiring**: `SessionsRoute.voice` is gone — the voice screen is no longer pushed onto the sessions stack; it lives at the Luke tab's root in its own `NavigationStack` with a "Luke" inline title. The store gains a `tab` selection, and a voice-driven `open_session` / `show_panel` now switches to the Sessions tab (which is also what closes the voice call, via the screen's existing `onDisappear`). The profile avatar appears on both the Sessions and Luke navigation bars.

Everything uses plain native SwiftUI (`TabView` + `.tabItem`/`.tag`, `searchable` with `navigationBarDrawer` placement) against the existing iOS 17 deployment target; the iOS 26 Liquid Glass bottom-bar toolbar arrangement in the list is removed since the tab bar now owns that edge.

## Behavior notes

- Luke being the default tab means the voice screen — and therefore its call mint — comes up at launch, the same connection the screen has always opened on appear; it still closes on any tab switch or idle timeout.
- The list's own `.task` roster refresh now runs on first visit to the Sessions tab, but the voice screen's opening refresh covers the launch tab, so the roster is fetched at launch either way.

## Testing

- `./scripts/check.sh` passes (exit 0).
- This change is iOS-only; CI does not build the iOS project and this workspace is a Linux sandbox, so no simulator build, screenshot, or physical-device check was performed here — a local `xcodebuild` build/test pass and a visual look at the tab bar, search drawer, and creator sheet are the remaining verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/33920384322/artifacts/9954895827) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/33920384322)

- Commit: `5c49f0a8fbeff8add2e15036641edd2766f23bce`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
