### PR TITLE
fix(ios): show the Watch app as Luke

### DIFF
--- a/apps/ios/Luke.xcodeproj/project.pbxproj
+++ b/apps/ios/Luke.xcodeproj/project.pbxproj
@@ -650,6 +650,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_CFBundleDisplayName = Luke;
 				INFOPLIST_KEY_WKCompanionAppBundleIdentifier = dev.tryluke.ios;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -676,6 +677,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_CFBundleDisplayName = Luke;
 				INFOPLIST_KEY_WKCompanionAppBundleIdentifier = dev.tryluke.ios;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/scripts/ios-project.test.mjs
+++ b/scripts/ios-project.test.mjs
@@ -51,6 +51,17 @@ test("the iPhone app embeds and depends on the Watch app", () => {
   assert.match(project, /PBXTargetDependency[\s\S]*?target = [^;]+ \/\* LukeWatch \*\//);
 });
 
+test("the Watch app is shown on the watch as Luke", () => {
+  const watchConfigurations = project.match(
+    /PRODUCT_BUNDLE_IDENTIFIER = dev\.tryluke\.ios\.watchkitapp;/g,
+  );
+  assert.equal(watchConfigurations?.length, 2);
+  assert.equal(
+    project.match(/INFOPLIST_KEY_CFBundleDisplayName = Luke;[\s\S]*?SDKROOT = watchos;/g)?.length,
+    2,
+  );
+});
+
 test("the Watch scheme builds the companion and runs the Watch app", () => {
   assert.match(watchScheme, /BuildableName = "Luke\.app"[\s\S]*?BuildableName = "LukeWatch\.app"/);
   assert.match(


### PR DESCRIPTION
## Summary

The watch target's product name is `LukeWatch`, and with no display name set that is what watchOS drew under the icon. This sets `INFOPLIST_KEY_CFBundleDisplayName = Luke` on both watch configurations so the app is shown as **Luke**, and adds an assertion to the iOS project test so the name stays.

The target, scheme, and directory keep the `LukeWatch` name; only what the watch shows changes.

## Verification

- `./scripts/check.sh` passes (portable checks; no Xcode on this Linux workspace, so no device or Simulator check was performed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/33919073514/artifacts/9954393705) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/33919073514)

- Commit: `7e8b3c53d6df489d37ebdb78bb03cc5ee6817b44`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
