### PR TITLE
fix(ios): improve Markdown rendering

### DIFF
--- a/apps/ios/Luke/MarkdownMessageView.swift
+++ b/apps/ios/Luke/MarkdownMessageView.swift
@@ -4,7 +4,7 @@ import SwiftUI
 /// A message's words drawn as the Markdown they were written in, the way
 /// Notes and Messages draw rich text: system text styles that follow Dynamic
 /// Type, `Text`'s own inline rendering for emphasis, code, strikethrough, and
-/// tappable links, and the blocks `Text` cannot draw by itself — lists,
+/// safe web links, and the blocks `Text` cannot draw by itself — lists,
 /// quotes, fenced code, tables, rules — composed from system parts around it.
 /// Every colour is hierarchical off the bubble's foreground, so the same view
 /// reads on the agent's card fill and on the developer's accent bubble.
@@ -90,6 +90,9 @@ private struct MarkdownBlockView: View {
     private func inlineText(_ text: AttributedString, font: Font) -> some View {
         var styled = text
         for run in text.runs {
+            if run.link != nil {
+                styled[run.range].underlineStyle = .single
+            }
             guard let intent = run.inlinePresentationIntent,
                   intent.contains(.stronglyEmphasized), intent.contains(.emphasized)
             else { continue }
@@ -100,14 +103,17 @@ private struct MarkdownBlockView: View {
             .fixedSize(horizontal: false, vertical: true)
     }
 
-    /// The three sizes a message can afford under a chat title: the top
-    /// level a small title, the second a headline, anything deeper the body's
-    /// own size given weight alone.
+    /// Each Markdown level maps directly to a compact system text style. This
+    /// keeps all six levels distinct while still following Dynamic Type on a
+    /// phone and the much narrower watch face.
     private func headingFont(_ level: Int) -> Font {
         switch level {
         case 1: .title3.weight(.semibold)
         case 2: .headline
-        default: .subheadline.weight(.semibold)
+        case 3: .subheadline.weight(.semibold)
+        case 4: .footnote.weight(.semibold)
+        case 5: .caption.weight(.semibold)
+        default: .caption2.weight(.semibold)
         }
     }
 
@@ -134,26 +140,30 @@ private struct MarkdownBlockView: View {
         alignments: [MarkdownTableAlignment],
         rows: [[AttributedString]]
     ) -> some View {
-        Grid(alignment: .topLeading, horizontalSpacing: 14, verticalSpacing: 6) {
-            if !header.isEmpty {
-                GridRow {
-                    ForEach(Array(header.enumerated()), id: \.offset) { column, cell in
-                        inlineText(cell, font: .subheadline.weight(.semibold))
-                            .multilineTextAlignment(textAlignment(for: alignments, column: column))
-                            .gridColumnAlignment(columnAlignment(for: alignments, column: column))
+        ScrollView(.horizontal) {
+            Grid(alignment: .topLeading, horizontalSpacing: 14, verticalSpacing: 6) {
+                if !header.isEmpty {
+                    GridRow {
+                        ForEach(Array(header.enumerated()), id: \.offset) { column, cell in
+                            inlineText(cell, font: .subheadline.weight(.semibold))
+                                .multilineTextAlignment(textAlignment(for: alignments, column: column))
+                                .gridColumnAlignment(columnAlignment(for: alignments, column: column))
+                        }
                     }
+                    Divider()
                 }
-                Divider()
-            }
-            ForEach(Array(rows.enumerated()), id: \.offset) { _, row in
-                GridRow {
-                    ForEach(Array(row.enumerated()), id: \.offset) { column, cell in
-                        inlineText(cell, font: .subheadline)
-                            .multilineTextAlignment(textAlignment(for: alignments, column: column))
+                ForEach(Array(rows.enumerated()), id: \.offset) { _, row in
+                    GridRow {
+                        ForEach(Array(row.enumerated()), id: \.offset) { column, cell in
+                            inlineText(cell, font: .subheadline)
+                                .multilineTextAlignment(textAlignment(for: alignments, column: column))
+                        }
                     }
                 }
             }
         }
+        .scrollIndicators(.hidden)
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 
     private func columnAlignment(

--- a/apps/ios/LukeKit/Sources/LukeKit/MarkdownBlock.swift
+++ b/apps/ios/LukeKit/Sources/LukeKit/MarkdownBlock.swift
@@ -98,7 +98,7 @@ extension MarkdownBlock {
             node.text.append(inlinePiece(String(parsed[run.range].characters), run: run))
         }
         let blocks = root.children.flatMap { $0.blocks() }
-        return (blocks.isEmpty ? fallback(text) : blocks).map { $0.withoutLinks() }
+        return (blocks.isEmpty ? fallback(text) : blocks).map { $0.withSafeLinks() }
     }
 
     private static func fallback(_ text: String) -> [MarkdownBlock] {
@@ -108,9 +108,8 @@ extension MarkdownBlock {
 
     /// A run's words carrying the inline styles `Text` draws. Links remain
     /// briefly so structural reads can distinguish a linked `[x]` from a task
-    /// box, then `parse` removes every destination before exposing its blocks:
-    /// messages come from observed agent output, so their Markdown must never
-    /// become an outbound control. The block intent is now the enum case
+    /// box. `parse` later keeps only HTTP and HTTPS destinations; custom URL
+    /// schemes never become controls. The block intent is now the enum case
     /// around the words, and the parser's other bookkeeping (a list item's
     /// delimiter) is nothing a bubble draws. A line break in the source is
     /// kept as one line break: a message is a chat's words, where a new line
@@ -125,16 +124,16 @@ extension MarkdownBlock {
         return piece
     }
 
-    private func withoutLinks() -> MarkdownBlock {
+    private func withSafeLinks() -> MarkdownBlock {
         switch self {
         case .paragraph(let words):
-            return .paragraph(Self.inert(words))
+            return .paragraph(Self.safeLinks(in: words))
         case .heading(let level, let words):
-            return .heading(level: level, Self.inert(words))
+            return .heading(level: level, Self.safeLinks(in: words))
         case .code, .rule:
             return self
         case .quote(let blocks):
-            return .quote(blocks.map { $0.withoutLinks() })
+            return .quote(blocks.map { $0.withSafeLinks() })
         case .list(let ordered, let items):
             return .list(
                 ordered: ordered,
@@ -142,23 +141,31 @@ extension MarkdownBlock {
                     MarkdownListItem(
                         ordinal: item.ordinal,
                         checked: item.checked,
-                        blocks: item.blocks.map { $0.withoutLinks() }
+                        blocks: item.blocks.map { $0.withSafeLinks() }
                     )
                 }
             )
         case .table(let header, let alignments, let rows):
             return .table(
-                header: header.map(Self.inert),
+                header: header.map { Self.safeLinks(in: $0) },
                 alignments: alignments,
-                rows: rows.map { $0.map(Self.inert) }
+                rows: rows.map { $0.map { Self.safeLinks(in: $0) } }
             )
         }
     }
 
-    private static func inert(_ words: AttributedString) -> AttributedString {
-        var inert = words
-        inert.link = nil
-        return inert
+    private static func safeLinks(in words: AttributedString) -> AttributedString {
+        var safe = words
+        let links = words.runs.compactMap { run in
+            run.link.map { (run.range, $0) }
+        }
+        for (range, destination) in links {
+            guard let scheme = destination.scheme?.lowercased(), ["http", "https"].contains(scheme) else {
+                safe[range].link = nil
+                continue
+            }
+        }
+        return safe
     }
 }
 

--- a/apps/ios/LukeKit/Tests/LukeKitTests/MarkdownBlockTests.swift
+++ b/apps/ios/LukeKit/Tests/LukeKitTests/MarkdownBlockTests.swift
@@ -28,7 +28,7 @@ final class MarkdownBlockTests: XCTestCase {
         XCTAssertEqual(paragraphWords(blocks[1]), "Second paragraph")
     }
 
-    func testInlineStylesSurviveWithoutBlockIntentAndLinksStayInert() throws {
+    func testInlineStylesSurviveWithoutBlockIntent() throws {
         let blocks = MarkdownBlock.parse("Ran **all** tests with `pnpm test` at [the repo](https://example.com).")
         guard case .paragraph(let text) = try XCTUnwrap(blocks.first) else {
             return XCTFail("expected a paragraph, got \(blocks)")
@@ -40,10 +40,10 @@ final class MarkdownBlockTests: XCTestCase {
         XCTAssertTrue(styles.allSatisfy { $0.3 == nil })
         XCTAssertEqual(styles.first { $0.0 == "all" }?.1, .stronglyEmphasized)
         XCTAssertEqual(styles.first { $0.0 == "pnpm test" }?.1, .code)
-        XCTAssertNil(styles.first { $0.0 == "the repo" }?.2)
+        XCTAssertEqual(styles.first { $0.0 == "the repo" }?.2, URL(string: "https://example.com"))
     }
 
-    func testAgentControlledLinkDestinationsNeverBecomeControls() throws {
+    func testCustomSchemeLinkDestinationsNeverBecomeControls() throws {
         let blocks = MarkdownBlock.parse("[review this](custom-scheme://run-action)")
         guard case .paragraph(let text) = try XCTUnwrap(blocks.first) else {
             return XCTFail("expected a paragraph, got \(blocks)")
@@ -52,11 +52,35 @@ final class MarkdownBlockTests: XCTestCase {
         XCTAssertTrue(text.runs.allSatisfy { $0.link == nil })
     }
 
-    func testHeadingsCarryTheirLevel() {
-        let blocks = MarkdownBlock.parse("# Summary\n\n### Details")
+    func testWebLinkFormsRetainSafeDestinations() throws {
+        let source = """
+        [Inline](https://example.com)
+        [Title](https://example.com "Example")
+        <https://example.com>
+        [Reference][example]
+
+        [example]: https://example.com
+        """
+        let blocks = MarkdownBlock.parse(source)
+        guard case .paragraph(let text) = try XCTUnwrap(blocks.first) else {
+            return XCTFail("expected a paragraph, got \(blocks)")
+        }
+        XCTAssertEqual(words(text), "Inline\nTitle\nhttps://example.com\nReference")
+        XCTAssertEqual(
+            text.runs.compactMap(\.link),
+            Array(repeating: URL(string: "https://example.com")!, count: 4)
+        )
+    }
+
+    func testHeadingsCarryAllSixLevels() {
+        let blocks = MarkdownBlock.parse("# One\n\n## Two\n\n### Three\n\n#### Four\n\n##### Five\n\n###### Six")
         XCTAssertEqual(blocks, [
-            .heading(level: 1, AttributedString("Summary")),
-            .heading(level: 3, AttributedString("Details")),
+            .heading(level: 1, AttributedString("One")),
+            .heading(level: 2, AttributedString("Two")),
+            .heading(level: 3, AttributedString("Three")),
+            .heading(level: 4, AttributedString("Four")),
+            .heading(level: 5, AttributedString("Five")),
+            .heading(level: 6, AttributedString("Six")),
         ])
     }
 
@@ -67,6 +91,13 @@ final class MarkdownBlockTests: XCTestCase {
 
     func testFencedCodeWithoutLanguageHasNone() {
         XCTAssertEqual(MarkdownBlock.parse("```\nls -la\n```"), [.code(language: nil, "ls -la")])
+    }
+
+    func testIndentedCodeBecomesACodeBlock() {
+        XCTAssertEqual(
+            MarkdownBlock.parse("    let value = 1\n    print(value)"),
+            [.code(language: nil, "let value = 1\nprint(value)")]
+        )
     }
 
     func testUnorderedListNestsAnOrderedList() throws {
@@ -146,6 +177,46 @@ final class MarkdownBlockTests: XCTestCase {
                 rows: [[AttributedString("a"), AttributedString("b"), AttributedString("c")]]
             ),
         ])
+    }
+
+    func testTableKeepsAnEscapedPipeInsideCode() throws {
+        let blocks = MarkdownBlock.parse("| Expression | Result |\n|---|---|\n| `a \\| b` | pipe |")
+        guard case .table(_, _, let rows) = try XCTUnwrap(blocks.first) else {
+            return XCTFail("expected a table, got \(blocks)")
+        }
+        XCTAssertEqual(rows.map { $0.map(words) }, [["a | b", "pipe"]])
+        XCTAssertEqual(rows[0][0].runs.first?.inlinePresentationIntent, .code)
+    }
+
+    func testUnsupportedExtensionsStayReadableWithoutCustomRenderers() {
+        XCTAssertEqual(
+            MarkdownBlock.parse("![Image unavailable](https://example.com/image.png)"),
+            [.paragraph(AttributedString("Image unavailable"))]
+        )
+        XCTAssertEqual(
+            MarkdownBlock.parse("Here is a note[^1].\n\n[^1]: Footnote body.").compactMap(paragraphWords),
+            ["Here is a note[^1].", "[^1]: Footnote body."]
+        )
+        XCTAssertEqual(
+            MarkdownBlock.parse("Term\n: Definition").compactMap(paragraphWords),
+            ["Term\n: Definition"]
+        )
+        XCTAssertEqual(
+            MarkdownBlock.parse("<kbd>Ctrl</kbd> <mark>highlighted</mark>").compactMap(paragraphWords),
+            ["<kbd>Ctrl</kbd> <mark>highlighted</mark>"]
+        )
+        XCTAssertEqual(
+            MarkdownBlock.parse("Inline $E = mc^2$\n\n$$x^2$$").compactMap(paragraphWords),
+            ["Inline $E = mc^2$", "$$x^2$$"]
+        )
+        XCTAssertEqual(
+            MarkdownBlock.parse("H~2~O and X^2^").compactMap(paragraphWords),
+            ["H2O and X^2^"]
+        )
+        XCTAssertEqual(
+            MarkdownBlock.parse("```mermaid\ngraph TD\nA --> B\n```"),
+            [.code(language: "mermaid", "graph TD\nA --> B")]
+        )
     }
 
     func testThematicBreakIsARule() {


### PR DESCRIPTION
## What

iOS and watchOS now render the Markdown examples with complete standard block coverage: safe web links are visibly tappable, all six heading levels are distinct, indented code is preserved, and wide tables scroll horizontally instead of compressing the conversation.

## How

- Retain only `http` and `https` destinations from Foundation's Markdown parser. Custom schemes remain plain inert text, so agent output cannot become an app control.
- Underline retained links in the shared SwiftUI renderer, which makes the same link behavior available on iPhone and Apple Watch.
- Map H1–H6 to compact Dynamic Type styles appropriate for both screen sizes.
- Put tables in a horizontal `ScrollView`, matching fenced code blocks and protecting narrow watch layouts.
- Expand parser tests for standard link forms, every heading level, indented code, escaped pipes in tables, and readable fallbacks.

## Intentional fallbacks

Images, footnotes, definition lists, inline HTML, LaTeX, Mermaid rendering, and subscript/superscript remain unsupported where Foundation does not provide a standard native renderer. Their useful text stays readable; Mermaid remains a labeled code block.

## Review

- Pre-landing testing, maintainability, and simplification reviews found no issues.
- Adversarial review identified and fixed a misleading affordance: rejected custom-scheme links are no longer underlined.
- Coverage audit: 84% of assessed new paths; the remaining gap is Watch link activation automation, covered manually in the simulator for rendering.

## Testing

- `./scripts/check.sh` passes.
- `swift test` in `apps/ios/LukeKit`: 258 tests pass.
- `xcodebuild test` passes all 14 app tests on the iPhone 17 Pro Max simulator.
- The Luke scheme builds on iPhone 17 Pro Max.
- The LukeWatch scheme builds on Apple Watch Series 11 (42mm).
- A real tap on an HTTPS Markdown link opened the system browser on the iPhone 17 Pro Max simulator.

🤖 Generated with Codex

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/33919422486/artifacts/9954528783) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/33919422486)

- Commit: `3f162e10e0ec9ccb6fd0a52d38af4c00a04b7b61`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
