### PR TITLE
feat(ios): carry the phone's voice tools on the watch

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,10 +1,10 @@
 # Privacy
 
-Last updated: 3 September 2026
+Last updated: 4 September 2026
 
-Luke is a macOS app that watches your coding agent sessions, with a companion
-iOS app for the cloud sessions your account can see. This policy explains what
-we collect, who we send it to, and how to turn it off.
+Luke is a macOS app that watches your coding agent sessions, with companion
+iOS and Apple Watch apps for the cloud sessions your account can see. This
+policy explains what we collect, who we send it to, and how to turn it off.
 
 ## What we collect
 
@@ -135,10 +135,10 @@ and email you signed it with, and any screenshots you attached.
 
 - OpenAI, for voice and session summaries. A spoken turn sends its audio, a
   typed turn sends your words, and both send the session fields listed above —
-  on the Mac app, read locally from your machine; on iOS, drawn from the same
-  cloud observation your vault keys already allow (titles, status, repository,
-  and branch of your cloud sessions, as described under Provider API
-  keys above). We do not send message history, file contents, or command
+  on the Mac app, read locally from your machine; on iOS and Apple Watch,
+  drawn from the same cloud observation your vault keys already allow
+  (titles, status, repository, and branch of your cloud sessions, as
+  described under Provider API keys above). We do not send message history, file contents, or command
   output, and we ask OpenAI not to store the request. The one exception is the
   subject phrase above: to derive it, only when Luke is about to announce a
   local session and once per announcement, Luke sends the bounded transcript
@@ -148,10 +148,11 @@ and email you signed it with, and any screenshots you attached.
   of it either. The phrase that comes back is spoken with that announcement
   and kept nowhere. On the Mac app, your conversation and Luke's durable
   memory are kept on your Mac and sent with a call so the conversation carries
-  across calls and across launches; on iOS, a call also carries the list of
-  projects your synced keys can create a workspace in, while the conversation
-  itself is held in memory until the app quits or you sign out, sent with a
-  call so it carries across calls, and never stored on the phone.
+  across calls and across launches; on iOS and Apple Watch, a call also
+  carries the list of projects your synced keys can create a workspace in,
+  while the conversation itself is held in memory until the app quits or you
+  sign out, sent with a call so it carries across calls, and never stored on
+  the phone or the watch.
   The one voice call that happens before you sign in is the spoken
   introduction on first launch of the Mac app: it sends its own fixed script,
   the titles of the coding agent sessions found on your Mac, and anything you

--- a/apps/ios/Luke.xcodeproj/project.pbxproj
+++ b/apps/ios/Luke.xcodeproj/project.pbxproj
@@ -42,7 +42,6 @@
 		AABBCC0000000000000000D4 /* VoiceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABBCC0000000000000000D0 /* VoiceView.swift */; };
 		AABBCC0000000000000000D5 /* VoiceAudioCapturer.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABBCC0000000000000000D1 /* VoiceAudioCapturer.swift */; };
 		AABBCC0000000000000000D6 /* VoiceAudioPlayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABBCC0000000000000000D2 /* VoiceAudioPlayer.swift */; };
-		AABBCC0000000000000000D7 /* VoiceActDispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABBCC0000000000000000D3 /* VoiceActDispatcher.swift */; };
 		AABBCC0000000000000000D9 /* VoiceSettingsSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABBCC0000000000000000D8 /* VoiceSettingsSheet.swift */; };
 		AABBCC0000000000000000F9 /* SessionsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABBCC0000000000000000F8 /* SessionsStore.swift */; };
 		AABBCC0000000000000000E6 /* WatchVoiceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABBCC0000000000000000E5 /* WatchVoiceView.swift */; };
@@ -50,6 +49,7 @@
 		AABBCC0000000000000000EA /* WatchAudioCapturer.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABBCC0000000000000000E9 /* WatchAudioCapturer.swift */; };
 		AABBCC0000000000000000EC /* WatchAudioPlayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABBCC0000000000000000EB /* WatchAudioPlayer.swift */; };
 		AABBCC0000000000000000EE /* WatchLukeMark.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABBCC0000000000000000ED /* WatchLukeMark.swift */; };
+		AABBCC0000000000000000F6 /* WatchNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABBCC0000000000000000F5 /* WatchNavigation.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -109,7 +109,6 @@
 		AABBCC0000000000000000D0 /* VoiceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceView.swift; sourceTree = "<group>"; };
 		AABBCC0000000000000000D1 /* VoiceAudioCapturer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceAudioCapturer.swift; sourceTree = "<group>"; };
 		AABBCC0000000000000000D2 /* VoiceAudioPlayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceAudioPlayer.swift; sourceTree = "<group>"; };
-		AABBCC0000000000000000D3 /* VoiceActDispatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceActDispatcher.swift; sourceTree = "<group>"; };
 		AABBCC0000000000000000D8 /* VoiceSettingsSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceSettingsSheet.swift; sourceTree = "<group>"; };
 		AABBCC0000000000000000F8 /* SessionsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionsStore.swift; sourceTree = "<group>"; };
 		AABBCC0000000000000000E5 /* WatchVoiceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchVoiceView.swift; sourceTree = "<group>"; };
@@ -117,6 +116,7 @@
 		AABBCC0000000000000000E9 /* WatchAudioCapturer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchAudioCapturer.swift; sourceTree = "<group>"; };
 		AABBCC0000000000000000EB /* WatchAudioPlayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchAudioPlayer.swift; sourceTree = "<group>"; };
 		AABBCC0000000000000000ED /* WatchLukeMark.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchLukeMark.swift; sourceTree = "<group>"; };
+		AABBCC0000000000000000F5 /* WatchNavigation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchNavigation.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -191,7 +191,6 @@
 				AABBCC0000000000000000D0 /* VoiceView.swift */,
 				AABBCC0000000000000000D1 /* VoiceAudioCapturer.swift */,
 				AABBCC0000000000000000D2 /* VoiceAudioPlayer.swift */,
-				AABBCC0000000000000000D3 /* VoiceActDispatcher.swift */,
 				AABBCC0000000000000000D8 /* VoiceSettingsSheet.swift */,
 				AABBCC000000000000000014 /* Assets.xcassets */,
 				AABBCC00000000000000001C /* Info.plist */,
@@ -223,6 +222,7 @@
 				AABBCC0000000000000000E9 /* WatchAudioCapturer.swift */,
 				AABBCC0000000000000000EB /* WatchAudioPlayer.swift */,
 				AABBCC0000000000000000ED /* WatchLukeMark.swift */,
+				AABBCC0000000000000000F5 /* WatchNavigation.swift */,
 				AABBCC0000000000000000B2 /* Assets.xcassets */,
 			);
 			path = LukeWatch;
@@ -396,7 +396,6 @@
 				AABBCC0000000000000000D4 /* VoiceView.swift in Sources */,
 				AABBCC0000000000000000D5 /* VoiceAudioCapturer.swift in Sources */,
 				AABBCC0000000000000000D6 /* VoiceAudioPlayer.swift in Sources */,
-				AABBCC0000000000000000D7 /* VoiceActDispatcher.swift in Sources */,
 				AABBCC0000000000000000D9 /* VoiceSettingsSheet.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -426,6 +425,7 @@
 				AABBCC0000000000000000EA /* WatchAudioCapturer.swift in Sources */,
 				AABBCC0000000000000000EC /* WatchAudioPlayer.swift in Sources */,
 				AABBCC0000000000000000EE /* WatchLukeMark.swift in Sources */,
+				AABBCC0000000000000000F6 /* WatchNavigation.swift in Sources */,
 				AABBCC0000000000000000F4 /* MarkdownMessageView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/apps/ios/LukeKit/Sources/LukeKit/VoiceActDispatcher.swift
+++ b/apps/ios/LukeKit/Sources/LukeKit/VoiceActDispatcher.swift
@@ -1,39 +1,64 @@
 import Foundation
-import LukeKit
 
 /// What a tool call is carried against: the roster and projects the
 /// conversation was shown, the account's bearer, and the two presses the
-/// list offers that a spoken ask may take instead. Every value here is read at the moment of the call, so an act is
-/// validated against the roster as it stands then, never as it stood when
-/// the call was minted.
+/// list offers that a spoken ask may take instead. Every value here is read
+/// at the moment of the call, so an act is validated against the roster as
+/// it stands then, never as it stood when the call was minted. The phone and
+/// the watch each build one from their own screens; the gauntlet below is
+/// the same on both.
 @MainActor
-struct VoiceActContext {
+public struct VoiceActContext {
     /// The tools the service minted the call with, as the server confirmed
     /// them at channel open; nil before a call has connected. A call naming
     /// a tool outside the set, or arriving before the set is known, is
     /// refused before it is looked at.
-    let mintedTools: [String]?
-    let sessions: [RosterSession]
-    let projects: ProjectsAnswer?
-    let defaults: WorkspaceCreationDefaults
-    let actClient: ActClient
-    let accessToken: () async throws -> String
+    public let mintedTools: [String]?
+    public let sessions: [RosterSession]
+    public let projects: ProjectsAnswer?
+    public let defaults: WorkspaceCreationDefaults
+    public let actClient: ActClient
+    public let accessToken: () async throws -> String
     /// Counts an act a provider accepted, under its allowlisted name alone.
-    let count: (ProductSessionAct, _ providerId: String) -> Void
-    let refreshRoster: () async -> Void
-    let open: (RosterSession) -> Void
-    let showList: (VoiceAsks.SessionListAsk) -> Void
+    public let count: (ProductSessionAct, _ providerId: String) -> Void
+    public let refreshRoster: () async -> Void
+    public let open: (RosterSession) -> Void
+    public let showList: (VoiceAsks.SessionListAsk) -> Void
+
+    public init(
+        mintedTools: [String]?,
+        sessions: [RosterSession],
+        projects: ProjectsAnswer?,
+        defaults: WorkspaceCreationDefaults,
+        actClient: ActClient,
+        accessToken: @escaping () async throws -> String,
+        count: @escaping (ProductSessionAct, _ providerId: String) -> Void,
+        refreshRoster: @escaping () async -> Void,
+        open: @escaping (RosterSession) -> Void,
+        showList: @escaping (VoiceAsks.SessionListAsk) -> Void
+    ) {
+        self.mintedTools = mintedTools
+        self.sessions = sessions
+        self.projects = projects
+        self.defaults = defaults
+        self.actClient = actClient
+        self.accessToken = accessToken
+        self.count = count
+        self.refreshRoster = refreshRoster
+        self.open = open
+        self.showList = showList
+    }
 }
 
 /// Carries one tool call the model composed in a turn the developer opened.
-/// Each act is validated on the phone against what the conversation was
+/// Each act is validated on the device against what the conversation was
 /// shown, then either performed here — an open, or the list — or sent
 /// to the hosted act endpoint that serves it, which re-observes and validates
 /// it again before anything is written. The answer is the JSON the model
 /// reads back as the call's output: an outcome and, on a refusal, the reason
 /// Luke can say aloud.
 @MainActor
-func dispatchVoiceToolCall(
+public func dispatchVoiceToolCall(
     name: String,
     arguments: [String: Any],
     context: VoiceActContext
@@ -42,7 +67,7 @@ func dispatchVoiceToolCall(
         return refusal("No such tool exists.")
     }
     // The minted set is the service's word on what this call may ask for;
-    // the phone honors it even for a tool it knows how to carry, and a call
+    // the device honors it even for a tool it knows how to carry, and a call
     // arriving before the set is known is refused rather than trusted.
     guard let minted = context.mintedTools else {
         return refusal("The call's minted tools are not known yet.")

--- a/apps/ios/LukeKit/Tests/LukeKitTests/VoiceActDispatcherTests.swift
+++ b/apps/ios/LukeKit/Tests/LukeKitTests/VoiceActDispatcherTests.swift
@@ -1,0 +1,244 @@
+import Foundation
+import XCTest
+
+@testable import LukeKit
+
+private func makeResponse(url: URL, status: Int) -> HTTPURLResponse {
+    HTTPURLResponse(url: url, statusCode: status, httpVersion: nil, headerFields: nil)!
+}
+
+private func jsonData(_ dict: [String: Any]) -> Data {
+    try! JSONSerialization.data(withJSONObject: dict)
+}
+
+private func identity(_ id: String = "s1", provider: String = "conductor") -> [String: Any] {
+    ["provider_id": provider, "provider_session_id": id]
+}
+
+/// The gauntlet every spoken act runs on the phone and the watch alike,
+/// exercised once here so the two surfaces cannot drift apart.
+@MainActor
+final class VoiceActDispatcherTests: XCTestCase {
+    private let base = URL(string: "https://example.com")!
+    private let everyTool = VoiceToolName.allCases.map(\.rawValue)
+
+    private func context(
+        mintedTools: [String]?,
+        sessions: [RosterSession] = [],
+        projects: ProjectsAnswer? = nil,
+        http: StubHTTPClient = StubHTTPClient { _ in throw URLError(.notConnectedToInternet) },
+        accessToken: @escaping () async throws -> String = { "token" },
+        count: @escaping (ProductSessionAct, String) -> Void = { _, _ in },
+        refreshRoster: @escaping () async -> Void = {},
+        open: @escaping (RosterSession) -> Void = { _ in },
+        showList: @escaping (VoiceAsks.SessionListAsk) -> Void = { _ in }
+    ) -> VoiceActContext {
+        VoiceActContext(
+            mintedTools: mintedTools,
+            sessions: sessions,
+            projects: projects,
+            defaults: WorkspaceCreationDefaults(
+                store: UserDefaults(suiteName: "VoiceActDispatcherTests.\(UUID().uuidString)")!
+            ),
+            actClient: ActClient(baseURL: base, http: http),
+            accessToken: accessToken,
+            count: count,
+            refreshRoster: refreshRoster,
+            open: open,
+            showList: showList
+        )
+    }
+
+    func testAToolOutsideTheVocabularyIsRefused() async {
+        let output = await dispatchVoiceToolCall(
+            name: "remember_fact", arguments: [:], context: context(mintedTools: everyTool)
+        )
+        XCTAssertEqual(output, #"{"reason":"No such tool exists.","result":"rejected"}"#)
+    }
+
+    func testACallBeforeTheMintedSetIsKnownIsRefused() async {
+        let output = await dispatchVoiceToolCall(
+            name: VoiceToolName.openSession.rawValue,
+            arguments: identity(),
+            context: context(mintedTools: nil, sessions: [RosterSession(id: "s1")])
+        )
+        XCTAssertEqual(
+            output, #"{"reason":"The call's minted tools are not known yet.","result":"rejected"}"#
+        )
+    }
+
+    func testAToolTheServiceDidNotMintIsRefusedEvenWhenCarried() async {
+        var opened: [RosterSession] = []
+        let output = await dispatchVoiceToolCall(
+            name: VoiceToolName.openSession.rawValue,
+            arguments: identity(),
+            context: context(
+                mintedTools: [VoiceToolName.showPanel.rawValue],
+                sessions: [RosterSession(id: "s1")],
+                open: { opened.append($0) }
+            )
+        )
+        XCTAssertEqual(
+            output, #"{"reason":"The service did not mint that tool for this call.","result":"rejected"}"#
+        )
+        XCTAssertTrue(opened.isEmpty)
+    }
+
+    func testAnOpenLandsOnlyOnARosterSessionAndIsCounted() async {
+        var opened: [RosterSession] = []
+        var counted: [(ProductSessionAct, String)] = []
+        let ctx = context(
+            mintedTools: everyTool,
+            sessions: [RosterSession(id: "s1")],
+            count: { counted.append(($0, $1)) },
+            open: { opened.append($0) }
+        )
+        let refused = await dispatchVoiceToolCall(
+            name: VoiceToolName.openSession.rawValue, arguments: identity("other"), context: ctx
+        )
+        XCTAssertEqual(
+            refused, #"{"reason":"No observed session matches that identity.","result":"rejected"}"#
+        )
+        XCTAssertTrue(opened.isEmpty)
+
+        let accepted = await dispatchVoiceToolCall(
+            name: VoiceToolName.openSession.rawValue, arguments: identity(), context: ctx
+        )
+        XCTAssertEqual(accepted, #"{"result":"accepted"}"#)
+        XCTAssertEqual(opened.map(\.sessionId), ["s1"])
+        XCTAssertEqual(counted.count, 1)
+        XCTAssertEqual(counted.first?.0, .sessionOpen)
+        XCTAssertEqual(counted.first?.1, "conductor")
+    }
+
+    func testAListAskIsValidatedBeforeItIsShown() async {
+        var shown: [VoiceAsks.SessionListAsk] = []
+        let ctx = context(
+            mintedTools: everyTool,
+            sessions: [RosterSession(id: "s1", status: "waiting"), RosterSession(id: "s2")],
+            showList: { shown.append($0) }
+        )
+        let refused = await dispatchVoiceToolCall(
+            name: VoiceToolName.showPanel.rawValue, arguments: ["sort": "sideways"], context: ctx
+        )
+        XCTAssertEqual(
+            refused, #"{"reason":"The list orders by urgency or by recency.","result":"rejected"}"#
+        )
+        XCTAssertTrue(shown.isEmpty)
+
+        let accepted = await dispatchVoiceToolCall(
+            name: VoiceToolName.showPanel.rawValue,
+            arguments: ["filters": ["waiting"], "sort": "recency"],
+            context: ctx
+        )
+        XCTAssertEqual(accepted, #"{"result":"accepted"}"#)
+        XCTAssertEqual(shown, [VoiceAsks.SessionListAsk(filters: [.status("waiting")], sort: .recency)])
+    }
+
+    func testAMessageIsCarriedToTheActEndpointCountedAndFollowedByARefresh() async {
+        let http = StubHTTPClient { request in
+            XCTAssertEqual(request.url?.path, "/api/acts/message")
+            XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer token")
+            let body = try JSONSerialization.jsonObject(with: request.httpBody ?? Data()) as? [String: String]
+            XCTAssertEqual(
+                body, ["providerId": "conductor", "providerSessionId": "s1", "text": "ship it"]
+            )
+            return (jsonData(["result": "accepted"]), makeResponse(url: request.url!, status: 200))
+        }
+        var counted: [(ProductSessionAct, String)] = []
+        var refreshes = 0
+        let output = await dispatchVoiceToolCall(
+            name: VoiceToolName.sendSessionMessage.rawValue,
+            arguments: identity().merging(["text": " ship it "]) { $1 },
+            context: context(
+                mintedTools: everyTool,
+                sessions: [RosterSession(id: "s1", canReceiveMessage: true)],
+                http: http,
+                count: { counted.append(($0, $1)) },
+                refreshRoster: { refreshes += 1 }
+            )
+        )
+        XCTAssertEqual(output, #"{"result":"accepted"}"#)
+        XCTAssertEqual(counted.count, 1)
+        XCTAssertEqual(counted.first?.0, .messageSend)
+        XCTAssertEqual(counted.first?.1, "conductor")
+        XCTAssertEqual(refreshes, 1)
+    }
+
+    func testAMessageTheServerRefusedCarriesItsReasonAndCountsNothing() async {
+        let http = StubHTTPClient { request in
+            (
+                jsonData(["result": "rejected", "reason": "The session moved on."]),
+                makeResponse(url: request.url!, status: 200)
+            )
+        }
+        var counted = 0
+        var refreshes = 0
+        let output = await dispatchVoiceToolCall(
+            name: VoiceToolName.sendSessionMessage.rawValue,
+            arguments: identity().merging(["text": "hello"]) { $1 },
+            context: context(
+                mintedTools: everyTool,
+                sessions: [RosterSession(id: "s1", canReceiveMessage: true)],
+                http: http,
+                count: { _, _ in counted += 1 },
+                refreshRoster: { refreshes += 1 }
+            )
+        )
+        XCTAssertEqual(output, #"{"reason":"The session moved on.","result":"rejected"}"#)
+        XCTAssertEqual(counted, 0)
+        XCTAssertEqual(refreshes, 0)
+    }
+
+    func testAMessageToAClosedInboxNeverReachesTheEndpoint() async {
+        let http = StubHTTPClient { _ in
+            XCTFail("A refused ask must not be sent.")
+            throw URLError(.badServerResponse)
+        }
+        let output = await dispatchVoiceToolCall(
+            name: VoiceToolName.sendSessionMessage.rawValue,
+            arguments: identity().merging(["text": "hello"]) { $1 },
+            context: context(mintedTools: everyTool, sessions: [RosterSession(id: "s1")], http: http)
+        )
+        XCTAssertEqual(
+            output, #"{"reason":"That session does not take messages right now.","result":"rejected"}"#
+        )
+    }
+
+    func testASignedOutCredentialIsSaidAsSuch() async {
+        let output = await dispatchVoiceToolCall(
+            name: VoiceToolName.sendSessionMessage.rawValue,
+            arguments: identity().merging(["text": "hello"]) { $1 },
+            context: context(
+                mintedTools: everyTool,
+                sessions: [RosterSession(id: "s1", canReceiveMessage: true)],
+                accessToken: { throw AccountSessionError.signedOut }
+            )
+        )
+        XCTAssertEqual(output, #"{"error":"signed out"}"#)
+    }
+
+    func testACreationAskWaitsForTheProjectsAnswer() async {
+        let output = await dispatchVoiceToolCall(
+            name: VoiceToolName.createWorkspace.rawValue,
+            arguments: ["provider_id": "conductor", "project_id": "p1"],
+            context: context(mintedTools: everyTool)
+        )
+        XCTAssertEqual(
+            output,
+            #"{"reason":"The projects a workspace can be created in have not loaded yet.","result":"rejected"}"#
+        )
+    }
+}
+
+private extension RosterSession {
+    init(id: String, status: String = "working", canReceiveMessage: Bool = false) {
+        self.init(
+            providerId: "conductor",
+            sessionId: id,
+            title: "Session \(id)",
+            status: status,
+            canReceiveMessage: canReceiveMessage
+        )
+    }
+}

--- a/apps/ios/LukeWatch/LukeWatchApp.swift
+++ b/apps/ios/LukeWatch/LukeWatchApp.swift
@@ -1,9 +1,12 @@
+import LukeKit
 import SwiftUI
 
 @main
 struct LukeWatchApp: App {
     @State private var watchSession: WatchAccountSession
     @State private var rosterStore: WatchRosterStore
+    @State private var navigation = WatchNavigation()
+    @State private var conversation = VoiceConversationThread()
     // Held for its lifetime — the delegate must not be deallocated.
     private let connectivity: WatchConnectivityReceiver
 
@@ -19,6 +22,8 @@ struct LukeWatchApp: App {
             LukeWatchView()
                 .environment(watchSession)
                 .environment(rosterStore)
+                .environment(navigation)
+                .environment(conversation)
         }
     }
 }

--- a/apps/ios/LukeWatch/LukeWatchView.swift
+++ b/apps/ios/LukeWatch/LukeWatchView.swift
@@ -14,7 +14,6 @@ struct LukeWatchView: View {
                 SignedOutView()
             case .signedIn:
                 signedInPages
-                    .id(watchSession.accountScope)
             }
         }
         .onChange(of: watchSession.accountScope) {
@@ -37,6 +36,9 @@ struct LukeWatchView: View {
             .tag(WatchPage.sessions)
         }
         .tabViewStyle(.page)
+        // The pages and the stack above the list are the signed-in
+        // developer's own: a changed account rebuilds them from nothing.
+        .id(watchSession.accountScope)
     }
 }
 

--- a/apps/ios/LukeWatch/LukeWatchView.swift
+++ b/apps/ios/LukeWatch/LukeWatchView.swift
@@ -1,9 +1,11 @@
+import LukeKit
 import SwiftUI
 
 struct LukeWatchView: View {
     @Environment(WatchAccountSession.self) private var watchSession
     @Environment(WatchRosterStore.self) private var rosterStore
-    @State private var selectedTab = 0
+    @Environment(WatchNavigation.self) private var navigation
+    @Environment(VoiceConversationThread.self) private var conversation
 
     var body: some View {
         Group {
@@ -11,21 +13,30 @@ struct LukeWatchView: View {
             case .signedOut:
                 SignedOutView()
             case .signedIn:
-                TabView(selection: $selectedTab) {
-                    WatchVoiceView()
-                        .tag(0)
-                    NavigationStack {
-                        WatchRosterView()
-                    }
-                    .tag(1)
-                }
-                .tabViewStyle(.page)
-                .id(watchSession.accountScope)
+                signedInPages
+                    .id(watchSession.accountScope)
             }
         }
         .onChange(of: watchSession.accountScope) {
+            // The roster, the conversation, and where the watch stood are
+            // the signed-in developer's own: the next account starts clean.
             rosterStore.reset()
+            conversation.clear()
+            navigation.reset()
         }
+    }
+
+    private var signedInPages: some View {
+        @Bindable var navigation = navigation
+        return TabView(selection: $navigation.page) {
+            WatchVoiceView()
+                .tag(WatchPage.voice)
+            NavigationStack(path: $navigation.path) {
+                WatchRosterView()
+            }
+            .tag(WatchPage.sessions)
+        }
+        .tabViewStyle(.page)
     }
 }
 

--- a/apps/ios/LukeWatch/WatchNavigation.swift
+++ b/apps/ios/LukeWatch/WatchNavigation.swift
@@ -1,0 +1,37 @@
+import LukeKit
+import Observation
+
+/// The two pages the signed-in watch swipes between.
+enum WatchPage: Hashable {
+    case voice
+    case sessions
+}
+
+/// Where the watch stands: the page showing, and the session screen pushed
+/// over the list. Held at app scope rather than inside the pages because an
+/// open or a list asked of Luke in conversation lands on the sessions page
+/// the way a row press does, and the voice page has to be able to reach it.
+@MainActor
+@Observable
+final class WatchNavigation {
+    var page: WatchPage = .voice
+    var path: [RosterSession] = []
+
+    /// Pushes a session's own screen over the list, the same press a row takes.
+    func open(_ session: RosterSession) {
+        path = [session]
+        page = .sessions
+    }
+
+    /// Shows the list itself, with nothing pushed over it.
+    func showList() {
+        path.removeAll()
+        page = .sessions
+    }
+
+    /// Where a fresh account starts: the voice page, with nothing pushed.
+    func reset() {
+        path.removeAll()
+        page = .voice
+    }
+}

--- a/apps/ios/LukeWatch/WatchRosterStore.swift
+++ b/apps/ios/LukeWatch/WatchRosterStore.swift
@@ -13,6 +13,13 @@ final class WatchRosterStore {
     private(set) var isLoading = false
     private(set) var hasLoaded = false
     private(set) var loadError: String?
+    /// How the list is narrowed and ordered. The watch draws no filter sheet
+    /// or search field of its own: these are set by a list ask Luke carries
+    /// in conversation, and a narrowing that stands is always drawn as a row
+    /// the developer can lift, never applied silently.
+    var filters: Set<SessionFilter> = []
+    var sort: SessionSort = .urgency
+    var searchQuery = ""
 
     private let session: WatchAccountSession
     private let client = RosterClient(serviceURL: AccountConstants.serviceURL)
@@ -21,6 +28,38 @@ final class WatchRosterStore {
 
     init(session: WatchAccountSession) {
         self.session = session
+    }
+
+    /// Whether anything hides a row: a filter, or a query with words in it.
+    /// A sort alone hides nothing.
+    var isNarrowed: Bool {
+        !filters.isEmpty || !SessionSearch.tokens(from: searchQuery).isEmpty
+    }
+
+    /// The rows the narrowing leaves, in the order the sort names — the
+    /// phone list's own pass, so the two surfaces show one ask the same way.
+    var visibleSessions: [RosterSession] {
+        let tokens = SessionSearch.tokens(from: searchQuery)
+        let matched = tokens.isEmpty
+            ? sessions : sessions.filter { SessionSearch.matches($0, tokens: tokens) }
+        return sortedSessions(
+            matched.filter { matchesFilterSelection(filters, session: $0) },
+            by: sort
+        )
+    }
+
+    /// Shows the list as a spoken ask narrowed, ordered, or searched it. The
+    /// ask arrives validated against the roster; this only applies it.
+    func showList(_ ask: VoiceAsks.SessionListAsk) {
+        if let filters = ask.filters { self.filters = filters }
+        if let sort = ask.sort { self.sort = sort }
+        if let query = ask.query { searchQuery = query }
+    }
+
+    /// Lifts every narrowing at once, the Show All row's press.
+    func showAll() {
+        filters.removeAll()
+        searchQuery = ""
     }
 
     func load() async {
@@ -70,6 +109,9 @@ final class WatchRosterStore {
         reloadRequested = true
         hasLoaded = false
         isLoading = false
+        filters.removeAll()
+        sort = .urgency
+        searchQuery = ""
     }
 
     /// Polls every 15 seconds. Called from `.task` on `WatchRosterView` so

--- a/apps/ios/LukeWatch/WatchRosterView.swift
+++ b/apps/ios/LukeWatch/WatchRosterView.swift
@@ -16,7 +16,10 @@ struct WatchRosterView: View {
                         .redacted(reason: .placeholder)
                 }
             } else {
-                ForEach(store.sessions) { session in
+                if store.isNarrowed {
+                    narrowingRow
+                }
+                ForEach(store.visibleSessions) { session in
                     NavigationLink(value: session) {
                         WatchSessionRow(session: session)
                     }
@@ -64,6 +67,46 @@ struct WatchRosterView: View {
         } message: {
             Text(archiveFailure ?? "")
         }
+    }
+
+    /// The narrowing a list ask left standing, said in the words the rows
+    /// draw, with the one press that lifts it. Drawn above the rows it leaves
+    /// so a list Luke narrowed never hides a session without saying so.
+    private var narrowingRow: some View {
+        Button {
+            store.showAll()
+        } label: {
+            VStack(alignment: .leading, spacing: 3) {
+                Text(narrowingLabel)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(2)
+                Label("Show All", systemImage: "line.3.horizontal.decrease.circle.fill")
+                    .font(.caption)
+                    .foregroundStyle(Color.accentColor)
+                if store.visibleSessions.isEmpty {
+                    Text("No sessions match.")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+        .accessibilityLabel("Show all sessions")
+        .accessibilityHint("Filtered to \(narrowingLabel)")
+    }
+
+    private var narrowingLabel: String {
+        var parts = store.filters
+            .map { filter -> String in
+                switch filter {
+                case .provider(let providerId): VaultProviderID.displayLabel(forWireId: providerId)
+                case .status(let status): status.capitalized
+                }
+            }
+            .sorted()
+        let query = store.searchQuery.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !query.isEmpty { parts.append("\u{201C}\(query)\u{201D}") }
+        return parts.joined(separator: " \u{00B7} ")
     }
 
     private func archiveControl(_ session: RosterSession) -> RosterSessionControl? {

--- a/apps/ios/LukeWatch/WatchVoiceSessionModel.swift
+++ b/apps/ios/LukeWatch/WatchVoiceSessionModel.swift
@@ -2,42 +2,60 @@ import Foundation
 import LukeKit
 import Observation
 
-struct WatchVoiceMessage: Identifiable {
-    enum Speaker { case user, luke }
-    let id = UUID()
-    let speaker: Speaker
-    var text: String
+/// Where a spoken act asked to take the developer once Luke has finished
+/// saying so: a session's own screen, or the list narrowed as asked. Held
+/// until the reply settles, because moving the page mid-sentence would close
+/// the call that is still speaking.
+enum WatchPendingNavigation {
+    case open(RosterSession)
+    case list(VoiceAsks.SessionListAsk)
 }
 
-/// Observable session state for the watch voice screen. Drives one RealtimeSession
-/// with a tool-free configuration — the watch carries no armed-act infrastructure,
-/// so dispatchToolCall always refuses and contextItems is always empty.
+/// Observable session state for the watch voice screen. Drives one
+/// RealtimeSession carrying the same tools the phone's conversation does,
+/// each call dispatched through the shared gauntlet in LukeKit against the
+/// roster the watch list draws. The conversation itself is not here: it lives
+/// in the app-scoped VoiceConversationThread this model records into, so the
+/// words survive a swipe to the sessions page while the call does not.
 ///
 /// The session is not minted until the developer presses the talk button
-/// (beginTurn). prepare(accountSession:) is called on view appear to store the
-/// credential reference without opening any connection.
+/// (beginTurn). prepare is called on view appear to store the credential
+/// reference and the act context without opening any connection.
 @Observable
 @MainActor
 final class WatchVoiceSessionModel {
-    var messages: [WatchVoiceMessage] = []
     var status: RealtimeStatus = .idle
     var errorMessage: String?
+    var pendingNavigation: WatchPendingNavigation?
+    /// The tools the service minted the latest call with, as the server
+    /// confirmed them at channel open; nil until a call has connected.
+    private(set) var mintedTools: [String]?
+    /// Where a workspace can be created, fetched beside the mint so the
+    /// conversation is told it at channel open and a creation ask can be
+    /// validated against it. Nil until an answer lands, and left nil when
+    /// the fetch fails, so the conversation is told nothing rather than
+    /// told there is nowhere.
+    private(set) var projects: ProjectsAnswer?
+    /// The New Workspace choices this watch remembers, read at the moment a
+    /// call opens or an act lands.
+    let defaults = WorkspaceCreationDefaults()
 
     private var accountSession: WatchAccountSession?
+    private var thread: VoiceConversationThread?
+    private var makeActContext: (@MainActor () -> VoiceActContext)?
     private var session: RealtimeSession?
     private var connectingForTurn = false
     private var endTurnAfterConnect = false
     private var connectTask: Task<Void, Never>?
-    // Tracks whether we are mid-caption-segment for the current luke reply.
-    // nil from onCaption closes the segment so the next text starts a new bubble.
-    private var lukeReplyOpen = false
-    // Index into messages[] where the current turn began. onSpokenAsk inserts the
-    // user bubble here rather than appending, because the realtime service delivers
-    // the transcript after captions have already started arriving.
-    private var turnStartIndex = 0
 
-    func prepare(accountSession: WatchAccountSession) {
+    func prepare(
+        accountSession: WatchAccountSession,
+        thread: VoiceConversationThread,
+        actContext: @escaping @MainActor () -> VoiceActContext
+    ) {
         self.accountSession = accountSession
+        self.thread = thread
+        makeActContext = actContext
     }
 
     private func connect(startWithTurn: Bool) async {
@@ -45,15 +63,24 @@ final class WatchVoiceSessionModel {
         errorMessage = nil
 
         let opts = RealtimeSessionOptions(
-            requestConnection: { [weak accountSession] in
+            requestConnection: { [weak accountSession, weak self] in
                 guard let accountSession else { throw AccountSessionError.signedOut }
                 let token = try await accountSession.validAccessToken()
-                return try await VoiceMintClient(baseURL: AccountConstants.serviceURL)
+                // Fetched beside the mint rather than after it: the projects
+                // item is sent at channel open, and the ephemeral key's
+                // minute is not to be spent waiting on a second round trip.
+                async let projects = try? ProjectsClient(serviceURL: AccountConstants.serviceURL)
+                    .projects(bearerToken: token)
+                let connection = try await VoiceMintClient(baseURL: AccountConstants.serviceURL)
                     .mint(
                         accessToken: token,
                         voice: RealtimeVoice.default.rawValue,
                         speed: RealtimeVoiceSpeed.default.multiplier
                     )
+                if let answer = await projects {
+                    await MainActor.run { [weak self] in self?.projects = answer }
+                }
+                return connection
             },
             onStatus: { [weak self] newStatus in
                 self?.status = newStatus
@@ -61,36 +88,8 @@ final class WatchVoiceSessionModel {
                 // remints rather than sending on a stale connection.
                 if newStatus == .idle { self?.session = nil }
             },
-            onCaption: { [weak self] text in
-                guard let self else { return }
-                if let text {
-                    // Mid-segment: grow the current luke bubble.
-                    // New segment (lukeReplyOpen == false): always append a fresh bubble
-                    // so a multi-segment reply does not overwrite its own earlier segments.
-                    if self.lukeReplyOpen,
-                       let lastIndex = self.messages.indices.last,
-                       self.messages[lastIndex].speaker == .luke
-                    {
-                        self.messages[lastIndex].text = text
-                    } else {
-                        self.messages.append(WatchVoiceMessage(speaker: .luke, text: text))
-                        self.lukeReplyOpen = true
-                    }
-                } else {
-                    // nil signals segment end — the next caption begins a new bubble.
-                    self.lukeReplyOpen = false
-                }
-            },
-            onSpokenAsk: { [weak self] text in
-                guard let self else { return }
-                // Insert at turnStartIndex, not at the end: captions typically
-                // arrive before the transcript, so the user bubble must be placed
-                // before Luke's reply rather than after it.
-                let insertAt = min(self.turnStartIndex, self.messages.count)
-                self.messages.insert(WatchVoiceMessage(speaker: .user, text: text), at: insertAt)
-                // Leave lukeReplyOpen as-is: the reply segment that started before
-                // the transcript arrived should keep growing from the last bubble.
-            },
+            onCaption: { [weak self] text in self?.thread?.recordCaption(text) },
+            onSpokenAsk: { [weak self] text in self?.thread?.recordSpokenAsk(text) },
             onError: { [weak self, weak accountSession] message in
                 guard let self else { return }
                 // Surface a credential failure as an actionable prompt rather
@@ -102,13 +101,37 @@ final class WatchVoiceSessionModel {
                 }
             },
             onRecoverableError: { [weak self] message in self?.errorMessage = message },
-            onSessionTools: { _ in },
-            dispatchToolCall: { _, _, _ in
-                // The watch carries no armed-act infrastructure. Tool calls are
-                // refused here rather than implementing a partial gate.
-                #"{"error":"not authorized"}"#
+            onSessionTools: { [weak self] names in self?.mintedTools = names },
+            dispatchToolCall: { [weak self] name, arguments, _ in
+                guard let self, let makeActContext = self.makeActContext else {
+                    return #"{"error":"not authorized"}"#
+                }
+                return await dispatchVoiceToolCall(
+                    name: name,
+                    arguments: arguments,
+                    context: makeActContext()
+                )
             },
-            contextItems: { [] },
+            contextItems: { [weak self] in
+                guard let self else { return [] }
+                var items: [VoiceContextItem] = []
+                // Conversation before projects, the desktop's flush order.
+                if let thread = self.thread,
+                   let conversation = ConversationContext.item(messages: thread.messages)
+                {
+                    items.append(conversation)
+                }
+                if let projects = self.projects {
+                    items.append(
+                        WorkspaceProjectsContext.item(
+                            answer: projects,
+                            defaultProviderId: self.defaults.lastProviderId,
+                            defaultProjectIds: self.defaults.lastProjectIds
+                        )
+                    )
+                }
+                return items
+            },
             makeAudioCapturer: { WatchAudioCapturer() },
             makeAudioPlayer: { WatchAudioPlayer() }
         )
@@ -122,16 +145,20 @@ final class WatchVoiceSessionModel {
         connectTask = nil
         connectingForTurn = false
         endTurnAfterConnect = false
-        lukeReplyOpen = false
-        turnStartIndex = 0
+        pendingNavigation = nil
         accountSession = nil
+        thread = nil
+        makeActContext = nil
         session?.close()
         session = nil
     }
 
     func beginTurn() {
         errorMessage = nil
-        turnStartIndex = messages.count
+        // A new press supersedes what the last reply was about to do: an open
+        // the developer talked over is an open they no longer want taken.
+        pendingNavigation = nil
+        thread?.beginTurn()
         if let session {
             session.beginTurn()
             return

--- a/apps/ios/LukeWatch/WatchVoiceSessionModel.swift
+++ b/apps/ios/LukeWatch/WatchVoiceSessionModel.swift
@@ -145,10 +145,13 @@ final class WatchVoiceSessionModel {
         connectTask = nil
         connectingForTurn = false
         endTurnAfterConnect = false
-        pendingNavigation = nil
         accountSession = nil
         thread = nil
         makeActContext = nil
+        // The pending navigation is left standing: closing publishes the idle
+        // edge the screen performs it on, so an open accepted mid-reply still
+        // lands when the developer swipes away before Luke finishes saying
+        // so. Only a new press supersedes it.
         session?.close()
         session = nil
     }

--- a/apps/ios/LukeWatch/WatchVoiceView.swift
+++ b/apps/ios/LukeWatch/WatchVoiceView.swift
@@ -2,15 +2,18 @@ import LukeKit
 import SwiftUI
 
 /// Hold-to-talk voice screen for Apple Watch. Drives WatchVoiceSessionModel,
-/// which in turn drives a RealtimeSession.
-///
-/// The watch ships tool-free: dispatchToolCall always refuses since the armed-act
-/// infrastructure (roster validation, ActClient, ProjectsAnswer) lives on the
-/// phone. The PR notes this explicitly; a future PR may add a bounded act set.
+/// which in turn drives a RealtimeSession carrying the same tools the phone's
+/// conversation does: each call is validated through LukeKit's shared
+/// dispatcher against the roster the sessions page draws, and an open or a
+/// list ask lands on that page once Luke has finished speaking.
 struct WatchVoiceView: View {
     @Environment(WatchAccountSession.self) private var accountSession
+    @Environment(WatchRosterStore.self) private var store
+    @Environment(WatchNavigation.self) private var navigation
+    @Environment(VoiceConversationThread.self) private var conversation
     @State private var model = WatchVoiceSessionModel()
     @State private var isPressing = false
+    private let actClient = ActClient(baseURL: AccountConstants.serviceURL)
 
     var body: some View {
         ZStack(alignment: .bottom) {
@@ -18,10 +21,59 @@ struct WatchVoiceView: View {
             floatingControls
         }
         .task {
-            model.prepare(accountSession: accountSession)
+            model.prepare(
+                accountSession: accountSession, thread: conversation, actContext: makeActContext
+            )
+            // The roster the acts are validated against is the list's own,
+            // refreshed as this page opens so a session archived since the
+            // list last polled is not offered as somewhere to act.
+            await store.load()
+        }
+        .onChange(of: model.status) { _, newStatus in
+            if newStatus == .ready || newStatus == .idle {
+                performPendingNavigation()
+            }
         }
         .onDisappear {
             model.stop()
+        }
+    }
+
+    /// What a tool call is carried against, read at the moment of the call.
+    /// An open or a list ask is held for the reply to finish rather than
+    /// performed at once: the page moving mid-sentence would close the call
+    /// still speaking the words that announce it.
+    private func makeActContext() -> VoiceActContext {
+        VoiceActContext(
+            mintedTools: model.mintedTools,
+            sessions: store.sessions,
+            projects: model.projects,
+            defaults: model.defaults,
+            actClient: actClient,
+            accessToken: { [accountSession] in try await accountSession.validAccessToken() },
+            // The watch posts no product events — none of the acts its own
+            // screens carry count either — so a spoken act counts nothing
+            // here rather than posting under another app's tag.
+            count: { _, _ in },
+            refreshRoster: { [store] in await store.load() },
+            // One page, so the last open a reply names is the one taken.
+            open: { [model] session in model.pendingNavigation = .open(session) },
+            showList: { [model] ask in model.pendingNavigation = .list(ask) }
+        )
+    }
+
+    /// Takes the developer where the settled reply said they were going. The
+    /// page changes either way, and this view's `onDisappear` closes the
+    /// call behind it.
+    private func performPendingNavigation() {
+        guard let pending = model.pendingNavigation else { return }
+        model.pendingNavigation = nil
+        switch pending {
+        case .open(let session):
+            navigation.open(session)
+        case .list(let ask):
+            store.showList(ask)
+            navigation.showList()
         }
     }
 
@@ -31,14 +83,14 @@ struct WatchVoiceView: View {
         ScrollViewReader { proxy in
             ScrollView {
                 VStack(spacing: 6) {
-                    if model.messages.isEmpty {
+                    if conversation.messages.isEmpty {
                         WatchLukeMark()
                             .foregroundStyle(.secondary)
                             .frame(width: 44, height: 40)
                             .frame(maxWidth: .infinity, minHeight: 80, alignment: .center)
                             .opacity(model.status == .connecting ? 0.4 : 1)
                     } else {
-                        ForEach(model.messages) { message in
+                        ForEach(conversation.messages) { message in
                             WatchVoiceBubble(message: message)
                                 .id(message.id)
                         }
@@ -51,13 +103,14 @@ struct WatchVoiceView: View {
                 .padding(.bottom, 88)
                 .frame(maxWidth: .infinity)
             }
-            .onChange(of: model.messages.count) {
-                guard let last = model.messages.last else { return }
+            .onChange(of: conversation.messages) {
+                guard let last = conversation.messages.last else { return }
                 withAnimation { proxy.scrollTo(last.id, anchor: .bottom) }
             }
-            .onChange(of: model.messages.last?.text) {
-                guard let last = model.messages.last else { return }
-                proxy.scrollTo(last.id, anchor: .bottom)
+            .onAppear {
+                if let last = conversation.messages.last {
+                    proxy.scrollTo(last.id, anchor: .bottom)
+                }
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -182,23 +235,21 @@ struct WatchVoiceView: View {
 // MARK: - Message bubble
 
 private struct WatchVoiceBubble: View {
-    let message: WatchVoiceMessage
+    let message: VoiceConversationMessage
+
+    private var isDeveloper: Bool { message.speaker == .developer }
 
     var body: some View {
-        Text(message.text)
+        Text(message.words)
             .font(.system(size: 13))
-            .foregroundStyle(message.speaker == .user ? Color.white : Color.primary)
+            .foregroundStyle(isDeveloper ? Color.white : Color.primary)
             .multilineTextAlignment(.leading)
             .padding(.horizontal, 9)
             .padding(.vertical, 7)
             .background {
                 RoundedRectangle(cornerRadius: 12)
-                    .fill(
-                        message.speaker == .user
-                            ? Color.accentColor
-                            : Color.secondary.opacity(0.18)
-                    )
+                    .fill(isDeveloper ? Color.accentColor : Color.secondary.opacity(0.18))
             }
-            .frame(maxWidth: .infinity, alignment: message.speaker == .user ? .trailing : .leading)
+            .frame(maxWidth: .infinity, alignment: isDeveloper ? .trailing : .leading)
     }
 }

--- a/apps/ios/README.md
+++ b/apps/ios/README.md
@@ -64,6 +64,19 @@ the issue acts (no tracker is connected here), `remember_fact` and
 `forget_fact` (the phone keeps no memory; Luke's durable facts live on the
 Mac), `change_app_setting`, the feedback composer, and the Updates row.
 
+The watch app's hold-to-talk screen carries the same eight tools. The
+dispatcher they run through, `dispatchVoiceToolCall` in `LukeKit`, is shared
+with the phone, so a call is validated the same way — against the roster the
+watch's sessions page draws and the projects answer fetched beside the mint —
+and sent to the same hosted act endpoints. The two that land on a screen land
+on the watch's own: `open_session` swipes to the sessions page and pushes the
+session's screen once Luke's reply has finished, and `show_panel` narrows,
+sorts, or searches the watch list the same way, drawing a Show All row above
+the rows a narrowing leaves so a list Luke narrowed never hides a session
+without saying so. The watch posts no product events, so a spoken act counts
+nothing there, and it draws no settings sheet, so the Debug tool list is the
+phone's alone.
+
 ## Analytics
 
 The app runs the desktop's two analytics streams on this platform's terms,


### PR DESCRIPTION
## Summary

The watch's hold-to-talk screen minted a call the service armed with the phone's eight tools, then refused every one with `{"error":"not authorized"}`: the watch shipped tool-free while the model was told it could act. This PR gives the watch the same tools the iOS app carries, through the same gauntlet.

- **Shared dispatcher.** `VoiceActContext` and `dispatchVoiceToolCall` move from the phone target into `LukeKit` (`apps/ios/LukeKit/Sources/LukeKit/VoiceActDispatcher.swift`), public, so the phone and the watch validate and carry a spoken act the same way. The phone's `VoiceView` calls the same API with no behavior change.
- **Watch voice screen.** `WatchVoiceSessionModel` now fetches the projects answer beside the mint, records the minted tool set, sends the conversation and projects context items at channel open, and dispatches tool calls through the shared gauntlet against the roster the watch's sessions page draws. The conversation moves into an app-scoped `VoiceConversationThread`, as on the phone, so it survives page swipes and re-feeds a reminted call.
- **`open_session` / `show_panel` on the watch.** A new `WatchNavigation` holds the page and the stack above the list, so an open pushes the session's screen once Luke's reply settles, the same way the phone waits. A list ask narrows, sorts, or searches the watch list through `WatchRosterStore`; because the watch draws no filter sheet or search field, a standing narrowing is drawn as a row naming it with a **Show All** press, never applied silently.
- **Tests.** `VoiceActDispatcherTests` in LukeKit covers the gauntlet once for both surfaces: unknown and unminted tools refused, an open landing only on a roster session and counted, a list ask validated before it is shown, a message carried to `/api/acts/message` then counted and followed by a roster refresh, a server refusal carrying its reason and counting nothing, a closed inbox never reaching the endpoint, a signed-out credential, and a creation ask waiting for the projects answer.
- **Docs.** `apps/ios/README.md` describes the watch's voice acts; `PRIVACY.md` now says the watch, like the phone, sends the projects list and the in-memory conversation on a call, and holds neither on the device.

## Notes for review

- The watch list now sorts by urgency by default, the phone's and desktop's default, where it previously drew the wire order. Say if you'd rather the wire order stand until a sort is asked.
- The watch posts no product events (none of its hand-pressed acts count today either), so a spoken act on the watch counts nothing rather than posting under the phone's `$lib` tag. Widening that is a product decision.
- The watch has no settings sheet, so the phone's Debug tool list is not drawn there.

## Verification

Run on a Mac (Xcode 26.6) against a fresh clone of this branch:

- `cd apps/ios/LukeKit && swift test`: 268 tests, 0 failures (includes the 9 new `VoiceActDispatcherTests`).
- `xcodebuild -scheme LukeWatch -destination 'platform=watchOS Simulator,name=Apple Watch Series 11 (46mm)' build`: BUILD SUCCEEDED.
- `xcodebuild -scheme Luke -destination 'platform=iOS Simulator,name=iPhone 17' build`: BUILD SUCCEEDED.
- `./scripts/check.sh` and `./scripts/verify.sh` pass in CI; the first push failed the `scripts/ios-project.test.mjs` source assertion on where the watch root's account-scope `.id` sits, fixed by moving the modifier onto the TabView.

No macOS or desktop UI changed, so no physical-notch check was performed and no screenshots were captured. The watch screens were not exercised in the simulator, only compiled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/944bd715-6763-4d4d-8bcf-6465190bd95c)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/33927293824/artifacts/9957323917) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/33927293824)

- Commit: `80cbb374839335b6b224d1693dd09fb78e63726e`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

