### PR TITLE
fix(ios): open the watch's Realtime socket where watchOS grants it

### DIFF
--- a/apps/ios/Luke.xcodeproj/project.pbxproj
+++ b/apps/ios/Luke.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		AABBCC0000000000000000C7 /* WatchTokenStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABBCC0000000000000000C1 /* WatchTokenStore.swift */; };
 		AABBCC0000000000000000FB /* WatchNetwork.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABBCC0000000000000000FA /* WatchNetwork.swift */; };
 		AABBCC0000000000000000FD /* WatchVoiceAudioSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABBCC0000000000000000FC /* WatchVoiceAudioSession.swift */; };
+		AABBCC0000000000000000F7 /* WatchWebSocketChannel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABBCC0000000000000000FF /* WatchWebSocketChannel.swift */; };
 		AABBCC0000000000000000C8 /* WatchAccountSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABBCC0000000000000000C2 /* WatchAccountSession.swift */; };
 		AABBCC0000000000000000C9 /* WatchConnectivityReceiver.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABBCC0000000000000000C3 /* WatchConnectivityReceiver.swift */; };
 		AABBCC0000000000000000CA /* PhoneSessionRelay.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABBCC0000000000000000C4 /* PhoneSessionRelay.swift */; };
@@ -104,6 +105,7 @@
 		AABBCC0000000000000000C1 /* WatchTokenStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchTokenStore.swift; sourceTree = "<group>"; };
 		AABBCC0000000000000000FA /* WatchNetwork.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchNetwork.swift; sourceTree = "<group>"; };
 		AABBCC0000000000000000FC /* WatchVoiceAudioSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchVoiceAudioSession.swift; sourceTree = "<group>"; };
+		AABBCC0000000000000000FF /* WatchWebSocketChannel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchWebSocketChannel.swift; sourceTree = "<group>"; };
 		AABBCC0000000000000000FE /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		AABBCC0000000000000000C2 /* WatchAccountSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchAccountSession.swift; sourceTree = "<group>"; };
 		AABBCC0000000000000000C3 /* WatchConnectivityReceiver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchConnectivityReceiver.swift; sourceTree = "<group>"; };
@@ -220,6 +222,7 @@
 				AABBCC0000000000000000C1 /* WatchTokenStore.swift */,
 				AABBCC0000000000000000FA /* WatchNetwork.swift */,
 				AABBCC0000000000000000FC /* WatchVoiceAudioSession.swift */,
+				AABBCC0000000000000000FF /* WatchWebSocketChannel.swift */,
 				AABBCC0000000000000000FE /* Info.plist */,
 				AABBCC0000000000000000C2 /* WatchAccountSession.swift */,
 				AABBCC0000000000000000C3 /* WatchConnectivityReceiver.swift */,
@@ -426,6 +429,7 @@
 				AABBCC0000000000000000C7 /* WatchTokenStore.swift in Sources */,
 				AABBCC0000000000000000FB /* WatchNetwork.swift in Sources */,
 				AABBCC0000000000000000FD /* WatchVoiceAudioSession.swift in Sources */,
+				AABBCC0000000000000000F7 /* WatchWebSocketChannel.swift in Sources */,
 				AABBCC0000000000000000C8 /* WatchAccountSession.swift in Sources */,
 				AABBCC0000000000000000C9 /* WatchConnectivityReceiver.swift in Sources */,
 				AABBCC0000000000000000E2 /* WatchRosterStore.swift in Sources */,

--- a/apps/ios/Luke.xcodeproj/project.pbxproj
+++ b/apps/ios/Luke.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		AABBCC0000000000000000B6 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = AABBCC0000000000000000B2 /* Assets.xcassets */; };
 		AABBCC0000000000000000B7 /* LukeKit in Frameworks */ = {isa = PBXBuildFile; productRef = AABBCC0000000000000000C0 /* LukeKit */; };
 		AABBCC0000000000000000C7 /* WatchTokenStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABBCC0000000000000000C1 /* WatchTokenStore.swift */; };
+		AABBCC0000000000000000FB /* WatchNetwork.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABBCC0000000000000000FA /* WatchNetwork.swift */; };
 		AABBCC0000000000000000C8 /* WatchAccountSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABBCC0000000000000000C2 /* WatchAccountSession.swift */; };
 		AABBCC0000000000000000C9 /* WatchConnectivityReceiver.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABBCC0000000000000000C3 /* WatchConnectivityReceiver.swift */; };
 		AABBCC0000000000000000CA /* PhoneSessionRelay.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABBCC0000000000000000C4 /* PhoneSessionRelay.swift */; };
@@ -100,6 +101,7 @@
 		AABBCC0000000000000000B2 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		AABBCC0000000000000000B3 /* LukeWatch.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = LukeWatch.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		AABBCC0000000000000000C1 /* WatchTokenStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchTokenStore.swift; sourceTree = "<group>"; };
+		AABBCC0000000000000000FA /* WatchNetwork.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchNetwork.swift; sourceTree = "<group>"; };
 		AABBCC0000000000000000C2 /* WatchAccountSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchAccountSession.swift; sourceTree = "<group>"; };
 		AABBCC0000000000000000C3 /* WatchConnectivityReceiver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchConnectivityReceiver.swift; sourceTree = "<group>"; };
 		AABBCC0000000000000000E1 /* WatchRosterStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchRosterStore.swift; sourceTree = "<group>"; };
@@ -213,6 +215,7 @@
 				AABBCC0000000000000000B0 /* LukeWatchApp.swift */,
 				AABBCC0000000000000000B1 /* LukeWatchView.swift */,
 				AABBCC0000000000000000C1 /* WatchTokenStore.swift */,
+				AABBCC0000000000000000FA /* WatchNetwork.swift */,
 				AABBCC0000000000000000C2 /* WatchAccountSession.swift */,
 				AABBCC0000000000000000C3 /* WatchConnectivityReceiver.swift */,
 				AABBCC0000000000000000E1 /* WatchRosterStore.swift */,
@@ -416,6 +419,7 @@
 				AABBCC0000000000000000B4 /* LukeWatchApp.swift in Sources */,
 				AABBCC0000000000000000B5 /* LukeWatchView.swift in Sources */,
 				AABBCC0000000000000000C7 /* WatchTokenStore.swift in Sources */,
+				AABBCC0000000000000000FB /* WatchNetwork.swift in Sources */,
 				AABBCC0000000000000000C8 /* WatchAccountSession.swift in Sources */,
 				AABBCC0000000000000000C9 /* WatchConnectivityReceiver.swift in Sources */,
 				AABBCC0000000000000000E2 /* WatchRosterStore.swift in Sources */,

--- a/apps/ios/Luke.xcodeproj/project.pbxproj
+++ b/apps/ios/Luke.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		AABBCC0000000000000000B7 /* LukeKit in Frameworks */ = {isa = PBXBuildFile; productRef = AABBCC0000000000000000C0 /* LukeKit */; };
 		AABBCC0000000000000000C7 /* WatchTokenStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABBCC0000000000000000C1 /* WatchTokenStore.swift */; };
 		AABBCC0000000000000000FB /* WatchNetwork.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABBCC0000000000000000FA /* WatchNetwork.swift */; };
+		AABBCC0000000000000000FD /* WatchVoiceAudioSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABBCC0000000000000000FC /* WatchVoiceAudioSession.swift */; };
 		AABBCC0000000000000000C8 /* WatchAccountSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABBCC0000000000000000C2 /* WatchAccountSession.swift */; };
 		AABBCC0000000000000000C9 /* WatchConnectivityReceiver.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABBCC0000000000000000C3 /* WatchConnectivityReceiver.swift */; };
 		AABBCC0000000000000000CA /* PhoneSessionRelay.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABBCC0000000000000000C4 /* PhoneSessionRelay.swift */; };
@@ -102,6 +103,8 @@
 		AABBCC0000000000000000B3 /* LukeWatch.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = LukeWatch.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		AABBCC0000000000000000C1 /* WatchTokenStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchTokenStore.swift; sourceTree = "<group>"; };
 		AABBCC0000000000000000FA /* WatchNetwork.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchNetwork.swift; sourceTree = "<group>"; };
+		AABBCC0000000000000000FC /* WatchVoiceAudioSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchVoiceAudioSession.swift; sourceTree = "<group>"; };
+		AABBCC0000000000000000FE /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		AABBCC0000000000000000C2 /* WatchAccountSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchAccountSession.swift; sourceTree = "<group>"; };
 		AABBCC0000000000000000C3 /* WatchConnectivityReceiver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchConnectivityReceiver.swift; sourceTree = "<group>"; };
 		AABBCC0000000000000000E1 /* WatchRosterStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchRosterStore.swift; sourceTree = "<group>"; };
@@ -216,6 +219,8 @@
 				AABBCC0000000000000000B1 /* LukeWatchView.swift */,
 				AABBCC0000000000000000C1 /* WatchTokenStore.swift */,
 				AABBCC0000000000000000FA /* WatchNetwork.swift */,
+				AABBCC0000000000000000FC /* WatchVoiceAudioSession.swift */,
+				AABBCC0000000000000000FE /* Info.plist */,
 				AABBCC0000000000000000C2 /* WatchAccountSession.swift */,
 				AABBCC0000000000000000C3 /* WatchConnectivityReceiver.swift */,
 				AABBCC0000000000000000E1 /* WatchRosterStore.swift */,
@@ -420,6 +425,7 @@
 				AABBCC0000000000000000B5 /* LukeWatchView.swift in Sources */,
 				AABBCC0000000000000000C7 /* WatchTokenStore.swift in Sources */,
 				AABBCC0000000000000000FB /* WatchNetwork.swift in Sources */,
+				AABBCC0000000000000000FD /* WatchVoiceAudioSession.swift in Sources */,
 				AABBCC0000000000000000C8 /* WatchAccountSession.swift in Sources */,
 				AABBCC0000000000000000C9 /* WatchConnectivityReceiver.swift in Sources */,
 				AABBCC0000000000000000E2 /* WatchRosterStore.swift in Sources */,
@@ -675,6 +681,7 @@
 				DEVELOPMENT_TEAM = 7UHHCDBUK2;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = LukeWatch/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = Luke;
 				INFOPLIST_KEY_NSMicrophoneUsageDescription = "Luke uses the microphone to hear your voice when you hold the talk button.";
 				INFOPLIST_KEY_WKCompanionAppBundleIdentifier = dev.tryluke.ios;
@@ -704,6 +711,7 @@
 				DEVELOPMENT_TEAM = 7UHHCDBUK2;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = LukeWatch/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = Luke;
 				INFOPLIST_KEY_NSMicrophoneUsageDescription = "Luke uses the microphone to hear your voice when you hold the talk button.";
 				INFOPLIST_KEY_WKCompanionAppBundleIdentifier = dev.tryluke.ios;

--- a/apps/ios/LukeKit/Sources/LukeKit/RealtimeSession.swift
+++ b/apps/ios/LukeKit/Sources/LukeKit/RealtimeSession.swift
@@ -929,6 +929,8 @@ private final class URLSessionWebSocketChannel: WebSocketTask, @unchecked Sendab
     }
 }
 
-func realtimeWebSocketProtocols(ephemeralKey: String) -> [String] {
+/// The subprotocols that carry the ephemeral key on the Realtime handshake,
+/// for every channel implementation the session may be handed.
+public func realtimeWebSocketProtocols(ephemeralKey: String) -> [String] {
     ["realtime", "openai-insecure-api-key.\(ephemeralKey)"]
 }

--- a/apps/ios/LukeWatch/Info.plist
+++ b/apps/ios/LukeWatch/Info.plist
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<!-- Merged into the generated Info.plist. watchOS grants a WebSocket, which
+	     it counts as low-level networking, only to an audio streaming app while
+	     its audio session is active (TN3135; WWDC 2019 session 716). Luke's
+	     voice call is a streamed spoken exchange over the Realtime socket, and
+	     this mode is what lets the watch open it. -->
+	<key>WKBackgroundModes</key>
+	<array>
+		<string>audio</string>
+	</array>
+</dict>
+</plist>

--- a/apps/ios/LukeWatch/WatchAudioCapturer.swift
+++ b/apps/ios/LukeWatch/WatchAudioCapturer.swift
@@ -18,9 +18,7 @@ final class WatchAudioCapturer: AudioCapturer, @unchecked Sendable {
             throw CocoaError(.fileReadUnknown)
         }
 
-        let audioSession = AVAudioSession.sharedInstance()
-        try audioSession.setCategory(.playAndRecord, mode: .default)
-        try audioSession.setActive(true)
+        try WatchVoiceAudioSession.activate()
 
         let inputNode = engine.inputNode
         let hwFormat = inputNode.outputFormat(forBus: 0)
@@ -89,6 +87,5 @@ final class WatchAudioCapturer: AudioCapturer, @unchecked Sendable {
             hasTap = false
         }
         engine.stop()
-        try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
     }
 }

--- a/apps/ios/LukeWatch/WatchAudioCapturer.swift
+++ b/apps/ios/LukeWatch/WatchAudioCapturer.swift
@@ -5,6 +5,9 @@ import LukeKit
 /// Mirror of VoiceAudioCapturer without allowBluetoothHFP, which is unnecessary
 /// on watchOS where the watch owns its own Bluetooth audio routing.
 ///
+/// The audio session is `WatchVoiceAudioSession`'s, active for the whole call
+/// before this starts; nothing here activates or deactivates it.
+///
 /// Callers should request microphone permission before this is instantiated;
 /// on watchOS 10 the system presents the permission sheet when the engine tap
 /// begins if permission is undetermined, and engine.start() raises an error
@@ -17,8 +20,6 @@ final class WatchAudioCapturer: AudioCapturer, @unchecked Sendable {
         guard AVAudioApplication.shared.recordPermission != .denied else {
             throw CocoaError(.fileReadUnknown)
         }
-
-        try WatchVoiceAudioSession.activate()
 
         let inputNode = engine.inputNode
         let hwFormat = inputNode.outputFormat(forBus: 0)

--- a/apps/ios/LukeWatch/WatchAudioPlayer.swift
+++ b/apps/ios/LukeWatch/WatchAudioPlayer.swift
@@ -10,9 +10,7 @@ final class WatchAudioPlayer: AudioPlayer, @unchecked Sendable {
     private let format: AVAudioFormat
 
     init() {
-        let audioSession = AVAudioSession.sharedInstance()
-        try? audioSession.setCategory(.playAndRecord, mode: .default)
-        try? audioSession.setActive(true)
+        try? WatchVoiceAudioSession.activate()
         format = AVAudioFormat(
             commonFormat: .pcmFormatFloat32,
             sampleRate: Double(PressAudioBuffer.sampleRate),
@@ -55,6 +53,5 @@ final class WatchAudioPlayer: AudioPlayer, @unchecked Sendable {
     func stop() {
         playerNode.stop()
         engine.stop()
-        try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
     }
 }

--- a/apps/ios/LukeWatch/WatchAudioPlayer.swift
+++ b/apps/ios/LukeWatch/WatchAudioPlayer.swift
@@ -3,14 +3,15 @@ import LukeKit
 
 /// Plays 24 kHz PCM16 mono audio through the speaker using AVAudioPlayerNode.
 /// Mirror of VoiceAudioPlayer without allowBluetoothHFP, which is unnecessary
-/// on watchOS where the watch owns its own Bluetooth audio routing.
+/// on watchOS where the watch owns its own Bluetooth audio routing. The audio
+/// session is `WatchVoiceAudioSession`'s, active for the whole call before
+/// this exists; nothing here activates or deactivates it.
 final class WatchAudioPlayer: AudioPlayer, @unchecked Sendable {
     private let engine = AVAudioEngine()
     private let playerNode = AVAudioPlayerNode()
     private let format: AVAudioFormat
 
     init() {
-        try? WatchVoiceAudioSession.activate()
         format = AVAudioFormat(
             commonFormat: .pcmFormatFloat32,
             sampleRate: Double(PressAudioBuffer.sampleRate),

--- a/apps/ios/LukeWatch/WatchNetwork.swift
+++ b/apps/ios/LukeWatch/WatchNetwork.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Network
 
 /// The one URLSession every hosted read and act on the watch travels on.
 ///
@@ -32,23 +33,36 @@ enum WatchNetwork {
     /// says only what both have in common: Luke was not reached, and the
     /// phone or Wi-Fi is where a path comes from.
     static func describe(_ error: any Error) -> String {
-        guard let urlError = error as? URLError else { return error.localizedDescription }
-        switch urlError.code {
-        case .notConnectedToInternet, .networkConnectionLost, .timedOut,
-             .cannotConnectToHost, .cannotFindHost, .dnsLookupFailed:
-            return "Couldn't reach Luke. Keep your iPhone nearby, or join Wi-Fi."
-        default:
-            return urlError.localizedDescription
+        if let urlError = error as? URLError {
+            switch urlError.code {
+            case .notConnectedToInternet, .networkConnectionLost, .timedOut,
+                 .cannotConnectToHost, .cannotFindHost, .dnsLookupFailed:
+                return unreachable
+            default:
+                return urlError.localizedDescription
+            }
         }
+        if let nwError = error as? NWError {
+            switch nwError {
+            case .posix(.ENETDOWN), .posix(.ENETUNREACH), .posix(.EHOSTUNREACH),
+                 .posix(.ETIMEDOUT), .posix(.ECONNREFUSED), .posix(.ECONNRESET), .dns:
+                return unreachable
+            default:
+                return nwError.localizedDescription
+            }
+        }
+        return error.localizedDescription
     }
+
+    private static let unreachable = "Couldn't reach Luke. Keep your iPhone nearby, or join Wi-Fi."
 }
 
-/// A connection failure carrying the wrist's own wording, for the one caller
-/// that receives words rather than the error: the voice session's `onError`.
+/// A connection failure carrying the wrist's own wording, for the callers
+/// that receive words rather than the error: the voice session's `onError`.
 struct WatchNetworkFailure: LocalizedError {
     let errorDescription: String?
 
-    init(_ error: URLError) {
+    init(_ error: any Error) {
         errorDescription = WatchNetwork.describe(error)
     }
 }

--- a/apps/ios/LukeWatch/WatchNetwork.swift
+++ b/apps/ios/LukeWatch/WatchNetwork.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+/// The one URLSession every hosted read and act on the watch travels on.
+///
+/// watchOS brings its network path up on demand and chooses it itself: the
+/// paired iPhone's connection, tunneled over Bluetooth, whenever the phone is
+/// in range; this watch's own Wi-Fi or cellular only when it is not. Nothing
+/// an app does changes that order. What an app does decide is what happens
+/// in the moment before a path is up: `URLSession.shared` fails the request
+/// at once, which on the wrist reads as "The Internet connection appears to
+/// be offline" with the iPhone in the same pocket. This session waits for a
+/// path instead, bounded so a watch that truly has none still answers.
+enum WatchNetwork {
+    static let waitForPathSeconds: TimeInterval = 20
+
+    static let session: URLSession = {
+        let configuration = URLSessionConfiguration.default
+        configuration.waitsForConnectivity = true
+        configuration.timeoutIntervalForResource = waitForPathSeconds
+        return URLSession(configuration: configuration)
+    }()
+
+    /// Words a failed request by what the wearer can do about it. A request
+    /// that found no path within the wait surfaces as `.timedOut`, so that
+    /// code belongs with the connection failures rather than the server's.
+    static func describe(_ error: any Error) -> String {
+        guard let urlError = error as? URLError else { return error.localizedDescription }
+        switch urlError.code {
+        case .notConnectedToInternet, .networkConnectionLost, .timedOut,
+             .cannotConnectToHost, .cannotFindHost, .dnsLookupFailed:
+            return "Couldn't reach Luke. Keep your iPhone nearby, or join Wi-Fi."
+        default:
+            return urlError.localizedDescription
+        }
+    }
+}
+
+/// A connection failure carrying the wrist's own wording, for the one caller
+/// that receives words rather than the error: the voice session's `onError`.
+struct WatchNetworkFailure: LocalizedError {
+    let errorDescription: String?
+
+    init(_ error: URLError) {
+        errorDescription = WatchNetwork.describe(error)
+    }
+}

--- a/apps/ios/LukeWatch/WatchNetwork.swift
+++ b/apps/ios/LukeWatch/WatchNetwork.swift
@@ -2,14 +2,15 @@ import Foundation
 
 /// The one URLSession every hosted read and act on the watch travels on.
 ///
-/// watchOS brings its network path up on demand and chooses it itself: the
-/// paired iPhone's connection, tunneled over Bluetooth, whenever the phone is
-/// in range; this watch's own Wi-Fi or cellular only when it is not. Nothing
-/// an app does changes that order. What an app does decide is what happens
-/// in the moment before a path is up: `URLSession.shared` fails the request
-/// at once, which on the wrist reads as "The Internet connection appears to
-/// be offline" with the iPhone in the same pocket. This session waits for a
-/// path instead, bounded so a watch that truly has none still answers.
+/// HTTP through URLSession is the networking watchOS opens to every app; the
+/// Realtime socket is the exception, and `WatchVoiceAudioSession` says on
+/// what terms. watchOS brings the path up on demand and chooses it itself:
+/// the paired iPhone's connection, tunneled over Bluetooth, whenever the
+/// phone is in range; this watch's own Wi-Fi or cellular only when it is not.
+/// What an app decides is the moment before a path is up: `URLSession.shared`
+/// fails the request at once, which reads as offline with the iPhone in the
+/// same pocket. This session waits for a path instead, bounded so a watch
+/// that truly has none still answers.
 enum WatchNetwork {
     /// The bound on one whole request, the wait for a path and the transfer
     /// that follows it together: URLSession offers no bound on the wait

--- a/apps/ios/LukeWatch/WatchNetwork.swift
+++ b/apps/ios/LukeWatch/WatchNetwork.swift
@@ -11,18 +11,25 @@ import Foundation
 /// be offline" with the iPhone in the same pocket. This session waits for a
 /// path instead, bounded so a watch that truly has none still answers.
 enum WatchNetwork {
-    static let waitForPathSeconds: TimeInterval = 20
+    /// The bound on one whole request, the wait for a path and the transfer
+    /// that follows it together: URLSession offers no bound on the wait
+    /// alone. It is long enough for a hosted observe or conversation read
+    /// to cross a Bluetooth tunnel, and shorter than the wearer's patience
+    /// with a screen that has said nothing.
+    static let requestBoundSeconds: TimeInterval = 45
 
     static let session: URLSession = {
         let configuration = URLSessionConfiguration.default
         configuration.waitsForConnectivity = true
-        configuration.timeoutIntervalForResource = waitForPathSeconds
+        configuration.timeoutIntervalForResource = requestBoundSeconds
         return URLSession(configuration: configuration)
     }()
 
     /// Words a failed request by what the wearer can do about it. A request
-    /// that found no path within the wait surfaces as `.timedOut`, so that
-    /// code belongs with the connection failures rather than the server's.
+    /// that found no path within the bound surfaces as `.timedOut`, the same
+    /// code a transfer that stalled on a live path ends in, so the sentence
+    /// says only what both have in common: Luke was not reached, and the
+    /// phone or Wi-Fi is where a path comes from.
     static func describe(_ error: any Error) -> String {
         guard let urlError = error as? URLError else { return error.localizedDescription }
         switch urlError.code {

--- a/apps/ios/LukeWatch/WatchRosterStore.swift
+++ b/apps/ios/LukeWatch/WatchRosterStore.swift
@@ -23,7 +23,9 @@ final class WatchRosterStore {
 
     private let session: WatchAccountSession
     private let events: ProductEventSender
-    private let client = RosterClient(serviceURL: AccountConstants.serviceURL)
+    private let client = RosterClient(
+        serviceURL: AccountConstants.serviceURL, http: WatchNetwork.session
+    )
     private var reloadRequested = true
     private var loadGeneration = 0
 
@@ -97,7 +99,7 @@ final class WatchRosterStore {
             } catch {
                 guard generation == loadGeneration else { return }
                 guard !Task.isCancelled else { return }
-                loadError = error.localizedDescription
+                loadError = WatchNetwork.describe(error)
                 completedRequest = true
             }
         }

--- a/apps/ios/LukeWatch/WatchRosterView.swift
+++ b/apps/ios/LukeWatch/WatchRosterView.swift
@@ -7,7 +7,9 @@ struct WatchRosterView: View {
     @Environment(ProductEventSender.self) private var events
     @State private var archiveFailure: String?
 
-    private let actClient = ActClient(baseURL: AccountConstants.serviceURL)
+    private let actClient = ActClient(
+        baseURL: AccountConstants.serviceURL, http: WatchNetwork.session
+    )
 
     var body: some View {
         List {
@@ -201,8 +203,12 @@ struct WatchSessionDetailView: View {
     @State private var claimedCopyIds: Set<String> = []
     @State private var conversationGeneration = 0
 
-    private let conversationClient = ConversationClient(serviceURL: AccountConstants.serviceURL)
-    private let actClient = ActClient(baseURL: AccountConstants.serviceURL)
+    private let conversationClient = ConversationClient(
+        serviceURL: AccountConstants.serviceURL, http: WatchNetwork.session
+    )
+    private let actClient = ActClient(
+        baseURL: AccountConstants.serviceURL, http: WatchNetwork.session
+    )
 
     private enum ScrollIntent: Equatable {
         case end
@@ -405,7 +411,7 @@ struct WatchSessionDetailView: View {
             account.signOut()
         } catch {
             guard generation == conversationGeneration else { return }
-            loadError = error.localizedDescription
+            loadError = WatchNetwork.describe(error)
         }
     }
 
@@ -458,7 +464,7 @@ struct WatchSessionDetailView: View {
             }
         } catch {
             guard generation == conversationGeneration else { return }
-            loadError = error.localizedDescription
+            loadError = WatchNetwork.describe(error)
         }
     }
 
@@ -585,7 +591,9 @@ private struct WatchSessionInfoView: View {
     @State private var agentShown = false
     @State private var actFailure: String?
 
-    private let actClient = ActClient(baseURL: AccountConstants.serviceURL)
+    private let actClient = ActClient(
+        baseURL: AccountConstants.serviceURL, http: WatchNetwork.session
+    )
 
     private enum RenameTarget: String, Identifiable {
         case session

--- a/apps/ios/LukeWatch/WatchVoiceAudioSession.swift
+++ b/apps/ios/LukeWatch/WatchVoiceAudioSession.swift
@@ -1,0 +1,22 @@
+import AVFoundation
+
+/// The audio session behind one voice call, held active for the call's life.
+///
+/// watchOS lets every app speak HTTP through URLSession, but counts a
+/// WebSocket as low-level networking and grants it only to an audio streaming
+/// app while its audio session is active (TN3135; WWDC 2019 session 716).
+/// The watch app declares the audio background mode for that reason, and
+/// this is the other half: the session goes active before the Realtime
+/// socket opens and stays active until the call closes. A capturer or player
+/// that deactivated it between turns would cut the socket under the call.
+enum WatchVoiceAudioSession {
+    static func activate() throws {
+        let audioSession = AVAudioSession.sharedInstance()
+        try audioSession.setCategory(.playAndRecord, mode: .default)
+        try audioSession.setActive(true)
+    }
+
+    static func deactivate() {
+        try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
+    }
+}

--- a/apps/ios/LukeWatch/WatchVoiceAudioSession.swift
+++ b/apps/ios/LukeWatch/WatchVoiceAudioSession.swift
@@ -9,11 +9,16 @@ import AVFoundation
 /// this is the other half: the session goes active before the Realtime
 /// socket opens and stays active until the call closes. A capturer or player
 /// that deactivated it between turns would cut the socket under the call.
+///
+/// Activation is the asynchronous call watchOS added for itself. The
+/// synchronous `setActive(true)` returns without error on a watch and does
+/// not earn the grant; the asynchronous one does (Apple DTS, developer forum
+/// thread 773362, confirmed on watchOS 26).
 enum WatchVoiceAudioSession {
-    static func activate() throws {
+    static func activate() async throws {
         let audioSession = AVAudioSession.sharedInstance()
         try audioSession.setCategory(.playAndRecord, mode: .default)
-        try audioSession.setActive(true)
+        _ = try await audioSession.activate(options: [])
     }
 
     static func deactivate() {

--- a/apps/ios/LukeWatch/WatchVoiceSessionModel.swift
+++ b/apps/ios/LukeWatch/WatchVoiceSessionModel.swift
@@ -70,10 +70,13 @@ final class WatchVoiceSessionModel {
         }
         // stop() may have run while activation was in flight: it has already
         // cleared the account and deactivated, and the activation that just
-        // landed put the session back up, so it goes down again here rather
-        // than opening a call nobody is holding.
+        // landed put the session back up. It goes down again here only if no
+        // newer press is holding or opening a call, since the audio session
+        // is shared and taking it down would refuse that call's socket.
         guard !Task.isCancelled, self.accountSession != nil, session == nil else {
-            WatchVoiceAudioSession.deactivate()
+            if session == nil, !connectingForTurn {
+                WatchVoiceAudioSession.deactivate()
+            }
             return
         }
 

--- a/apps/ios/LukeWatch/WatchVoiceSessionModel.swift
+++ b/apps/ios/LukeWatch/WatchVoiceSessionModel.swift
@@ -68,7 +68,14 @@ final class WatchVoiceSessionModel {
             status = .idle
             return
         }
-        guard session == nil else { return }
+        // stop() may have run while activation was in flight: it has already
+        // cleared the account and deactivated, and the activation that just
+        // landed put the session back up, so it goes down again here rather
+        // than opening a call nobody is holding.
+        guard !Task.isCancelled, self.accountSession != nil, session == nil else {
+            WatchVoiceAudioSession.deactivate()
+            return
+        }
 
         let opts = RealtimeSessionOptions(
             requestConnection: { [weak accountSession, weak self] in

--- a/apps/ios/LukeWatch/WatchVoiceSessionModel.swift
+++ b/apps/ios/LukeWatch/WatchVoiceSessionModel.swift
@@ -69,14 +69,23 @@ final class WatchVoiceSessionModel {
                 // Fetched beside the mint rather than after it: the projects
                 // item is sent at channel open, and the ephemeral key's
                 // minute is not to be spent waiting on a second round trip.
-                async let projects = try? ProjectsClient(serviceURL: AccountConstants.serviceURL)
-                    .projects(bearerToken: token)
-                let connection = try await VoiceMintClient(baseURL: AccountConstants.serviceURL)
+                async let projects = try? ProjectsClient(
+                    serviceURL: AccountConstants.serviceURL, http: WatchNetwork.session
+                )
+                .projects(bearerToken: token)
+                let connection: VoiceConnection
+                do {
+                    connection = try await VoiceMintClient(
+                        baseURL: AccountConstants.serviceURL, http: WatchNetwork.session
+                    )
                     .mint(
                         accessToken: token,
                         voice: RealtimeVoice.default.rawValue,
                         speed: RealtimeVoiceSpeed.default.multiplier
                     )
+                } catch let error as URLError {
+                    throw WatchNetworkFailure(error)
+                }
                 if let answer = await projects {
                     await MainActor.run { [weak self] in self?.projects = answer }
                 }

--- a/apps/ios/LukeWatch/WatchVoiceSessionModel.swift
+++ b/apps/ios/LukeWatch/WatchVoiceSessionModel.swift
@@ -62,12 +62,13 @@ final class WatchVoiceSessionModel {
         guard session == nil, let accountSession else { return }
         errorMessage = nil
         do {
-            try WatchVoiceAudioSession.activate()
+            try await WatchVoiceAudioSession.activate()
         } catch {
             errorMessage = "Couldn't start audio on the watch."
             status = .idle
             return
         }
+        guard session == nil else { return }
 
         let opts = RealtimeSessionOptions(
             requestConnection: { [weak accountSession, weak self] in
@@ -156,6 +157,9 @@ final class WatchVoiceSessionModel {
                     )
                 }
                 return items
+            },
+            makeWebSocket: { url, ephemeralKey in
+                WatchWebSocketChannel(url: url, ephemeralKey: ephemeralKey)
             },
             makeAudioCapturer: { WatchAudioCapturer() },
             makeAudioPlayer: { WatchAudioPlayer() }

--- a/apps/ios/LukeWatch/WatchVoiceSessionModel.swift
+++ b/apps/ios/LukeWatch/WatchVoiceSessionModel.swift
@@ -61,6 +61,13 @@ final class WatchVoiceSessionModel {
     private func connect(startWithTurn: Bool) async {
         guard session == nil, let accountSession else { return }
         errorMessage = nil
+        do {
+            try WatchVoiceAudioSession.activate()
+        } catch {
+            errorMessage = "Couldn't start audio on the watch."
+            status = .idle
+            return
+        }
 
         let opts = RealtimeSessionOptions(
             requestConnection: { [weak accountSession, weak self] in
@@ -95,7 +102,10 @@ final class WatchVoiceSessionModel {
                 self?.status = newStatus
                 // An idle timeout releases the socket so the next button press
                 // remints rather than sending on a stale connection.
-                if newStatus == .idle { self?.session = nil }
+                if newStatus == .idle {
+                    self?.session = nil
+                    WatchVoiceAudioSession.deactivate()
+                }
             },
             onCaption: { [weak self] text in self?.thread?.recordCaption(text) },
             onSpokenAsk: { [weak self] text in self?.thread?.recordSpokenAsk(text) },
@@ -163,6 +173,7 @@ final class WatchVoiceSessionModel {
         // so. Only a new press supersedes it.
         session?.close()
         session = nil
+        WatchVoiceAudioSession.deactivate()
     }
 
     func beginTurn() {

--- a/apps/ios/LukeWatch/WatchVoiceSessionModel.swift
+++ b/apps/ios/LukeWatch/WatchVoiceSessionModel.swift
@@ -101,8 +101,14 @@ final class WatchVoiceSessionModel {
             onStatus: { [weak self] newStatus in
                 self?.status = newStatus
                 // An idle timeout releases the socket so the next button press
-                // remints rather than sending on a stale connection.
+                // remints rather than sending on a stale connection. A mint
+                // that failed publishes idle without closing, leaving the
+                // capturer the press started still running, so the session is
+                // closed here first: closing one already closed changes
+                // nothing, and the audio session goes down only once the
+                // engines have stopped.
                 if newStatus == .idle {
+                    self?.session?.close()
                     self?.session = nil
                     WatchVoiceAudioSession.deactivate()
                 }

--- a/apps/ios/LukeWatch/WatchWebSocketChannel.swift
+++ b/apps/ios/LukeWatch/WatchWebSocketChannel.swift
@@ -1,0 +1,145 @@
+import Foundation
+import LukeKit
+import Network
+
+/// The Realtime socket on the watch, opened through Network framework.
+///
+/// watchOS grants low-level networking to an audio streaming app by process,
+/// and URLSession on watchOS does its work in a system process of its own,
+/// so a `URLSessionWebSocketTask` never carries the grant this app's active
+/// audio session earned: the flow is denied by policy and reported as
+/// offline. Network framework opens the socket from this process, where the
+/// grant lives (TN3135; Apple DTS on developer forum thread 773362).
+final class WatchWebSocketChannel: WebSocketTask, @unchecked Sendable {
+    private let connection: NWConnection
+    private let queue = DispatchQueue(label: "dev.tryluke.watchos.realtime-socket")
+    private var isReady = false
+    private var failure: (any Error)?
+    private var readyWaiters: [CheckedContinuation<Void, any Error>] = []
+
+    init(url: URL, ephemeralKey: String) {
+        let webSocket = NWProtocolWebSocket.Options()
+        webSocket.autoReplyPing = true
+        webSocket.setSubprotocols(realtimeWebSocketProtocols(ephemeralKey: ephemeralKey))
+        let parameters = NWParameters.tls
+        parameters.defaultProtocolStack.applicationProtocols.insert(webSocket, at: 0)
+        connection = NWConnection(to: .url(url), using: parameters)
+    }
+
+    func resume() {
+        connection.stateUpdateHandler = { [weak self] state in
+            guard let self else { return }
+            switch state {
+            case .ready:
+                self.settle(nil)
+            case .failed(let error):
+                self.settle(WatchNetworkFailure(error))
+            case .waiting(let error):
+                // Waiting means no path will carry this flow now. The mint
+                // just crossed on HTTP, so a path exists; a socket left
+                // waiting here is one watchOS refused, and it would wait
+                // forever rather than fail on its own.
+                self.settle(WatchNetworkFailure(error))
+            case .cancelled:
+                self.settle(CancellationError())
+            default:
+                break
+            }
+        }
+        connection.start(queue: queue)
+    }
+
+    func sendText(_ text: String) async throws {
+        try await ready()
+        let metadata = NWProtocolWebSocket.Metadata(opcode: .text)
+        let context = NWConnection.ContentContext(identifier: "text", metadata: [metadata])
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, any Error>) in
+            connection.send(
+                content: Data(text.utf8),
+                contentContext: context,
+                isComplete: true,
+                completion: .contentProcessed { error in
+                    if let error {
+                        continuation.resume(throwing: WatchNetworkFailure(error))
+                    } else {
+                        continuation.resume()
+                    }
+                }
+            )
+        }
+    }
+
+    func receiveText() async throws -> String {
+        try await ready()
+        while true {
+            let (data, metadata) = try await receiveMessage()
+            switch metadata?.opcode {
+            case .text, .binary:
+                return String(decoding: data, as: UTF8.self)
+            case .close:
+                throw WatchNetworkFailure(NWError.posix(.ECONNRESET))
+            default:
+                continue
+            }
+        }
+    }
+
+    func close() {
+        let metadata = NWProtocolWebSocket.Metadata(opcode: .close)
+        metadata.closeCode = .protocolCode(.normalClosure)
+        let context = NWConnection.ContentContext(identifier: "close", metadata: [metadata])
+        connection.send(
+            content: nil,
+            contentContext: context,
+            isComplete: true,
+            completion: .contentProcessed { [connection] _ in connection.cancel() }
+        )
+    }
+
+    // MARK: - Private
+
+    private func settle(_ error: (any Error)?) {
+        if let error {
+            failure = error
+        } else {
+            isReady = true
+        }
+        let waiters = readyWaiters
+        readyWaiters.removeAll()
+        for waiter in waiters {
+            if let error {
+                waiter.resume(throwing: error)
+            } else {
+                waiter.resume()
+            }
+        }
+    }
+
+    private func ready() async throws {
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, any Error>) in
+            queue.async {
+                if let failure = self.failure {
+                    continuation.resume(throwing: failure)
+                } else if self.isReady {
+                    continuation.resume()
+                } else {
+                    self.readyWaiters.append(continuation)
+                }
+            }
+        }
+    }
+
+    private func receiveMessage() async throws -> (Data, NWProtocolWebSocket.Metadata?) {
+        try await withCheckedThrowingContinuation { continuation in
+            connection.receiveMessage { data, context, _, error in
+                if let error {
+                    continuation.resume(throwing: WatchNetworkFailure(error))
+                    return
+                }
+                let metadata = context?.protocolMetadata(definition: NWProtocolWebSocket.definition)
+                    as? NWProtocolWebSocket.Metadata
+                continuation.resume(returning: (data ?? Data(), metadata))
+            }
+        }
+    }
+}

--- a/apps/ios/LukeWatch/WatchWebSocketChannel.swift
+++ b/apps/ios/LukeWatch/WatchWebSocketChannel.swift
@@ -85,15 +85,24 @@ final class WatchWebSocketChannel: WebSocketTask, @unchecked Sendable {
     }
 
     func close() {
-        let metadata = NWProtocolWebSocket.Metadata(opcode: .close)
-        metadata.closeCode = .protocolCode(.normalClosure)
-        let context = NWConnection.ContentContext(identifier: "close", metadata: [metadata])
-        connection.send(
-            content: nil,
-            contentContext: context,
-            isComplete: true,
-            completion: .contentProcessed { [connection] _ in connection.cancel() }
-        )
+        queue.async { [self] in
+            // A close frame is owed only to a peer that was reached. A socket
+            // still waiting or refused has nothing to send it to, and a send
+            // queued on it would never complete, so it is cancelled outright.
+            guard isReady else {
+                connection.cancel()
+                return
+            }
+            let metadata = NWProtocolWebSocket.Metadata(opcode: .close)
+            metadata.closeCode = .protocolCode(.normalClosure)
+            let context = NWConnection.ContentContext(identifier: "close", metadata: [metadata])
+            connection.send(
+                content: nil,
+                contentContext: context,
+                isComplete: true,
+                completion: .contentProcessed { [connection] _ in connection.cancel() }
+            )
+        }
     }
 
     // MARK: - Private

--- a/apps/ios/README.md
+++ b/apps/ios/README.md
@@ -133,6 +133,12 @@ that opens one that the Internet connection appears to be offline, with the
 phone in the same pocket. Luke's voice call is a streamed spoken exchange, so
 the watch app declares the `audio` background mode in `LukeWatch/Info.plist`
 and holds its audio session active from before the Realtime socket opens
-until the call closes, in `WatchVoiceAudioSession`. The call still opens only
-at the developer's press and closes on the same idle timer as before; the
-mode changes what watchOS lets the socket do, not when Luke listens.
+until the call closes, in `WatchVoiceAudioSession`. Two details of that grant
+are watchOS's own and are easy to miss: the session must be activated with
+the asynchronous `activate(options:)` call, because the synchronous
+`setActive(true)` returns without error on a watch and earns nothing, and the
+socket must be opened from the app's own process through Network framework,
+in `WatchWebSocketChannel`, because URLSession on watchOS does its work in a
+system process that never inherits the grant. The call still opens only at
+the developer's press and closes on the same idle timer as before; the mode
+changes what watchOS lets the socket do, not when Luke listens.

--- a/apps/ios/README.md
+++ b/apps/ios/README.md
@@ -124,8 +124,9 @@ the paired iPhone's connection tunneled over Bluetooth whenever the phone is
 in range, the watch's own Wi-Fi or cellular only when it is not, so the
 phone's connection is already what carries the watch's traffic whenever it
 can. Every request goes through `WatchNetwork.session`, which waits for that
-path to come up, bounded to a fixed number of seconds, instead of failing the
-instant no path is up the way `URLSession.shared` does, because on a wrist
-that instant failure reads as being offline with the iPhone in the same
-pocket. A request that finds no path in time is worded as one the wearer can
-act on: keep the iPhone nearby, or join Wi-Fi.
+path to come up instead of failing the instant no path is up the way
+`URLSession.shared` does, because on a wrist that instant failure reads as
+being offline with the iPhone in the same pocket. The wait and the transfer
+after it share one fixed bound, since URLSession offers no bound on the wait
+alone, and a request that runs out of it is worded as one the wearer can act
+on: keep the iPhone nearby, or join Wi-Fi.

--- a/apps/ios/README.md
+++ b/apps/ios/README.md
@@ -121,12 +121,18 @@ nothing else; the sessions list, a session's conversation, the messages and
 controls sent from the wrist, and the voice call's mint and Realtime socket
 all leave the watch itself. watchOS chooses the path and prefers the phone:
 the paired iPhone's connection tunneled over Bluetooth whenever the phone is
-in range, the watch's own Wi-Fi or cellular only when it is not, so the
-phone's connection is already what carries the watch's traffic whenever it
-can. Every request goes through `WatchNetwork.session`, which waits for that
-path to come up instead of failing the instant no path is up the way
-`URLSession.shared` does, because on a wrist that instant failure reads as
-being offline with the iPhone in the same pocket. The wait and the transfer
-after it share one fixed bound, since URLSession offers no bound on the wait
-alone, and a request that runs out of it is worded as one the wearer can act
-on: keep the iPhone nearby, or join Wi-Fi.
+in range, the watch's own Wi-Fi or cellular only when it is not.
+
+watchOS draws one line through that traffic. HTTP over `URLSession` is open
+to every app, and every hosted read and act on the watch travels that way,
+through `WatchNetwork.session`, which waits for a path to come up instead of
+failing the instant none is up. A WebSocket is low-level networking, which
+watchOS grants only to an audio streaming app while its audio session is
+active (Apple's TN3135 and WWDC 2019 session 716), and tells anything else
+that opens one that the Internet connection appears to be offline, with the
+phone in the same pocket. Luke's voice call is a streamed spoken exchange, so
+the watch app declares the `audio` background mode in `LukeWatch/Info.plist`
+and holds its audio session active from before the Realtime socket opens
+until the call closes, in `WatchVoiceAudioSession`. The call still opens only
+at the developer's press and closes on the same idle timer as before; the
+mode changes what watchOS lets the socket do, not when Luke listens.

--- a/apps/ios/README.md
+++ b/apps/ios/README.md
@@ -112,3 +112,20 @@ A DEBUG run may set `LUKE_POSTHOG_PROJECT_API_KEY` in the scheme's environment
 instead, the same door the service address overrides use. XCTest runs neither
 record nor count: the app detects its launch as a test host and stands both
 streams down.
+
+## Watch
+
+`LukeWatch` is its own client of the hosted service, not a view the iPhone
+feeds. The phone hands it the account's tokens over WatchConnectivity and
+nothing else; the sessions list, a session's conversation, the messages and
+controls sent from the wrist, and the voice call's mint and Realtime socket
+all leave the watch itself. watchOS chooses the path and prefers the phone:
+the paired iPhone's connection tunneled over Bluetooth whenever the phone is
+in range, the watch's own Wi-Fi or cellular only when it is not, so the
+phone's connection is already what carries the watch's traffic whenever it
+can. Every request goes through `WatchNetwork.session`, which waits for that
+path to come up, bounded to a fixed number of seconds, instead of failing the
+instant no path is up the way `URLSession.shared` does, because on a wrist
+that instant failure reads as being offline with the iPhone in the same
+pocket. A request that finds no path in time is worded as one the wearer can
+act on: keep the iPhone nearby, or join Wi-Fi.


### PR DESCRIPTION
## Summary

On a real Apple Watch, the Luke voice screen reported "The Internet connection appears to be offline." after pressing talk, while the sessions list worked. The device log named the cause:

```
nw_endpoint_flow_failed_with_error [C1 api.openai.com:443 failed parent-flow (unsatisfied (Path was denied by NECP policy), interface: ipsec1, ipv4, ipv6, proxy)]
```

watchOS opens HTTP through `URLSession` to every app, which is how the sessions list, conversation reads, sends, controls, and the voice mint travel. A WebSocket is low-level networking, which watchOS grants only to an audio streaming app while its audio session is active ([TN3135](https://developer.apple.com/documentation/technotes/tn3135-low-level-networking-on-watchos), [WWDC 2019 session 716](https://asciiwwdc.com/2019/sessions/716)). Two details of that grant are watchOS's own, and Apple DTS spelled them out on a [forum thread](https://developer.apple.com/forums/thread/773362) where the developer confirmed the fix on watchOS 26:

- The audio session must be activated with the asynchronous `activate(options:)` call. The synchronous `setActive(true)` returns without error on a watch and earns nothing.
- The socket must be opened from the app's own process. URLSession on watchOS does its work in a system process that never inherits the grant, so `URLSessionWebSocketTask` is denied by policy regardless.

## Changes

- `LukeWatch/Info.plist` declares the `audio` background mode, merged into the generated plist the way the iOS app's is.
- `WatchVoiceAudioSession` activates the session asynchronously before the Realtime socket opens and deactivates it when the call closes or idles out. The capturer and player no longer touch the session.
- `WatchWebSocketChannel` opens the Realtime socket through Network framework with the same subprotocols the URLSession channel sends, injected through the `makeWebSocket` seam `RealtimeSession` already exposes for tests. `realtimeWebSocketProtocols` becomes public in `LukeKit` so both channels share one list. A socket left `.waiting` is treated as refused rather than waited on, because the mint has just proven a path exists.
- Every hosted HTTP client on the watch goes through `WatchNetwork.session`, one `URLSession` that waits for a path instead of failing at once, bounded by a resource timeout. Failures are worded by what the wearer can do about them, for `URLError` and `NWError` alike.
- `apps/ios/README.md` gains a Watch section explaining the network posture and the grant's two details.

## Test plan

- [x] `xcodebuild -scheme LukeWatch` builds for a watchOS simulator
- [x] `xcodebuild -scheme Luke` builds for an iOS simulator
- [x] `swift test` in `LukeKit`
- [ ] On a physical watch with the iPhone nearby, hold to talk: the call connects and Luke answers
- [ ] Release and press again within the idle window: the second turn reuses the call
- [ ] The sessions list loads with the iPhone nearby and watch Wi-Fi off

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/33934881069/artifacts/9959863244) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/33934881069)

- Commit: `cea2a5d0e83750cf8acee5c7b81e499808423563`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
