### PR TITLE
feat(ios): count product events from the watch app like the phone

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -251,7 +251,11 @@ Trust constraints:
   enums make free text unrepresentable, the service reads its batches against
   the TypeScript allowlist exactly as it reads the desktop's, and the one
   thing naming which app posted is a header whose value only selects between
-  fixed `$lib` tags — absent or unrecognized means the desktop. The service attaches the account's own name and address to
+  fixed `$lib` tags — absent or unrecognized means the desktop. The watch app
+  counts through the same Swift sender under its own fixed client value and
+  runs no other stream: the SDK's replay and crash autocapture do not build
+  for watchOS, so the watch posts nothing to the analytics provider directly.
+  The service attaches the account's own name and address to
   the analytics person record, read from its own user row, never from the
   request, and never onto an event, because an event property is what the
   allowlist governs and a person property is not. The renderer has one narrow
@@ -317,7 +321,7 @@ Trust constraints:
   sees SwiftUI at all, begun at first paint before any account, joined to the
   person by the same account id at sign-in, and reset to anonymous at
   sign-out; it has no account deletion surface, so the desktop's deletion is
-  what erases its recordings too.
+  what erases its recordings too. The watch app does not record at all.
   None of the three sends anything in a fixture or evidence run, and nothing
   else stands in front of any of them: there is no switch, and the run mode is
   the whole of the gate. On iOS, which has no fixture runs, the same gate is

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -56,11 +56,12 @@ our own service, and they are never used to decide anything on your behalf.
 address, and which of the two you used. We also keep the records that keep you
 signed in, and a daily count of how much voice and review you have used.
 
-**Usage data.** We count how Luke's features are used, on the Mac and in the
-iOS app, and attach your name and email to that record. The counts are event
-names and values from a fixed list, and each one says which of the two apps it
-came from. Nothing you type or say and nothing from a session can appear in
-one: no titles, branches, file paths, prompts, or error text.
+**Usage data.** We count how Luke's features are used, on the Mac, in the
+iOS app, and in the Apple Watch app, and attach your name and email to that
+record. The counts are event names and values from a fixed list, and each one
+says which of the three apps it came from. Nothing you type or say and nothing
+from a session can appear in one: no titles, branches, file paths, prompts, or
+error text.
 
 **Screen recordings.** Luke records what his own panel draws, and never your
 screen, your editor, your terminal, or any other app. A recording shows whatever
@@ -101,6 +102,9 @@ message and code path. Unlike the Mac
 app, taps are not separately reported with their text — only the recording
 itself shows what was pressed. Signing in attaches the running recording to
 your account, and signing out starts a fresh anonymous one.
+
+The Apple Watch app records nothing and reports no crashes. It counts its use
+through the same fixed list as the other two apps, and nothing else leaves it.
 
 **Provider API keys (server-side vault).** While the "Sync provider keys"
 switch in Settings > Connections is on — it starts on — the provider API keys
@@ -173,9 +177,10 @@ and email you signed it with, and any screenshots you attached.
 - Google, if you connect Google Calendar. We request your calendar list and your
   availability. Google returns busy times only, so event titles and attendees
   are never available to Luke.
-- PostHog, for usage data and screen recordings, from the Mac and iOS apps
-  both. The counts go through our own service; the recordings, desktop clicks,
-  and iOS errors that ride with them go from Luke to PostHog directly.
+- PostHog, for usage data and screen recordings, from the Mac, iOS, and
+  Apple Watch apps. The counts go through our own service; the recordings,
+  desktop clicks, and iOS errors that ride with them go from Luke to PostHog
+  directly, and the watch app sends PostHog nothing directly.
 - Sentry, for the anonymous exception, process-session, and native crash reports
   described above.
 - GitHub, to check for updates. These requests are unauthenticated and carry
@@ -213,7 +218,7 @@ service, usage counts and recordings by PostHog, and crash reports by Sentry.
 - Delete your account from the Account section in Settings. This erases your
   account, your sign-in records, your usage counts, and any provider API keys
   you synced to the hosted service, and asks PostHog to erase your usage data
-  and recordings, including the iOS app's. It does not reach a recording that was
+  and recordings, including the iOS and Apple Watch apps'. It does not reach a recording that was
   never attached to your account, as described above. Luke stops recording for
   the rest of the session, and starts again the next time you open it or sign
   in. Sentry reporting continues after deletion, and prior anonymous crash

--- a/apps/ios/Luke/LukeApp.swift
+++ b/apps/ios/Luke/LukeApp.swift
@@ -31,6 +31,7 @@ struct LukeApp: App {
         let events = ProductEventSender(
             serviceURL: AccountConstants.serviceURL,
             appVersion: Self.appVersion,
+            client: .iOS,
             sends: !testing,
             session: session
         )

--- a/apps/ios/LukeKit/Sources/LukeKit/ProductEventSender.swift
+++ b/apps/ios/LukeKit/Sources/LukeKit/ProductEventSender.swift
@@ -139,6 +139,13 @@ public final class ProductEventSender {
         queue.removeAll()
     }
 
+    /// Drops what is queued and the day markers at an account change, so a
+    /// count recorded under one account never posts as the next.
+    public func reset() {
+        queue.removeAll()
+        recordedDays.removeAll()
+    }
+
     /// Sends what is queued, at most one request at a time. Never throws: a
     /// failure is a count nobody has, which is the trade this whole pipeline
     /// makes. A flush called mid-request chains behind it rather than

--- a/apps/ios/LukeKit/Sources/LukeKit/ProductEventSender.swift
+++ b/apps/ios/LukeKit/Sources/LukeKit/ProductEventSender.swift
@@ -42,8 +42,6 @@ public final class ProductEventSender {
     private struct QueuedEvent {
         let event: ProductEvent
         let at: Date
-        /// Who was signed in when it was recorded; nil waits for whoever signs in.
-        let account: String?
     }
 
     private let endpoint: URL
@@ -61,8 +59,8 @@ public final class ProductEventSender {
     private var queue: [QueuedEvent] = []
     /// Nested rather than an interpolated key: the name and the discriminator stay apart.
     private var recordedDays: [String: [String: String]] = [:]
-    /// Whose days those are; a different account signing in starts its own.
-    private var recordedDaysAccount: String?
+    /// Whose queue and day marks these are, once anyone has signed in.
+    private var recordedFor: String?
     private var armed = false
     private var timer: Timer?
     private var inFlight: Task<Void, Never>?
@@ -93,7 +91,8 @@ public final class ProductEventSender {
     /// sit on any path without ordering itself around it.
     public func record(_ event: ProductEvent) {
         guard allowed else { return }
-        queue.append(QueuedEvent(event: event, at: now(), account: session.accountEmail))
+        adoptAccount()
+        queue.append(QueuedEvent(event: event, at: now()))
         if queue.count > queueLimit {
             queue.removeFirst(queue.count - queueLimit)
         }
@@ -109,12 +108,7 @@ public final class ProductEventSender {
     /// provider per day is the fact worth having, not a count of refreshes.
     public func recordOncePerDay(_ event: ProductEvent, discriminator: String) {
         guard allowed else { return }
-        if let account = session.accountEmail {
-            if let recordedFor = recordedDaysAccount, recordedFor != account {
-                recordedDays.removeAll()
-            }
-            recordedDaysAccount = account
-        }
+        adoptAccount()
         let today = Self.dayFormatter.string(from: now())
         if recordedDays[event.name]?[discriminator] == today { return }
         recordedDays[event.name, default: [:]][discriminator] = today
@@ -175,15 +169,25 @@ public final class ProductEventSender {
         sends && armed
     }
 
+    /// A different account signing in starts clean: whatever the previous
+    /// one left queued or marked is dropped rather than posted as the new
+    /// one. Counts recorded before anyone signed in go to the first account,
+    /// and the same account signing back in keeps everything.
+    private func adoptAccount() {
+        guard let account = session.accountEmail, account != recordedFor else { return }
+        if recordedFor != nil {
+            queue.removeAll()
+            recordedDays.removeAll()
+        }
+        recordedFor = account
+    }
+
     private func send() async {
         guard !queue.isEmpty else { return }
         // Signed out is temporary and nobody's fault, so the queue waits
         // rather than being spent against a request that cannot authenticate.
         guard let token = try? await session.validAccessToken() else { return }
-        // A count recorded under one account never posts as another: what a
-        // sign-out left waiting is dropped once a different account signs in.
-        let account = session.accountEmail
-        queue.removeAll { $0.account != nil && $0.account != account }
+        adoptAccount()
         guard !queue.isEmpty else { return }
         // Taken only once a request will actually be made, and gone whatever
         // becomes of it.

--- a/apps/ios/LukeKit/Sources/LukeKit/ProductEventSender.swift
+++ b/apps/ios/LukeKit/Sources/LukeKit/ProductEventSender.swift
@@ -3,10 +3,10 @@ import Observation
 
 /// Counts how Luke's own features are used, and sends nothing else — the
 /// desktop's `ProductEventSender` (`packages/analytics/src/sender.ts`)
-/// rebuilt on this platform, keeping every posture it keeps. Events go to
-/// Luke's own `/api/events`, never to an analytics provider, and the batch
-/// carries no identity: the service resolves the account from the same
-/// bearer token every other hosted call rides, and the one thing named
+/// rebuilt for the iOS and watchOS apps, keeping every posture it keeps.
+/// Events go to Luke's own `/api/events`, never to an analytics provider, and
+/// the batch carries no identity: the service resolves the account from the
+/// same bearer token every other hosted call rides, and the one thing named
 /// beyond the events is which of Luke's own apps is posting, as a fixed
 /// header value the service maps onto an equally fixed `$lib` tag.
 ///
@@ -33,9 +33,8 @@ public final class ProductEventSender {
         static let batchLimit = 50
     }
 
-    /// Mirrors `PRODUCT_EVENT_CLIENT_HEADER` and `PRODUCT_EVENT_CLIENT.IOS`.
+    /// Mirrors `PRODUCT_EVENT_CLIENT_HEADER`.
     static let clientHeader = "x-luke-client"
-    static let clientName = "ios"
 
     /// The one discriminator the day marker dedups on.
     private static let dayActiveKey = "day"
@@ -47,6 +46,7 @@ public final class ProductEventSender {
 
     private let endpoint: URL
     private let appVersion: String
+    private let client: ProductEventClient
     /// False makes every record a no-op — the test-run and capture gate, the
     /// desktop's `runMode.sendsNetwork` at this app's one seam.
     private let sends: Bool
@@ -66,6 +66,7 @@ public final class ProductEventSender {
     public init(
         serviceURL: URL,
         appVersion: String,
+        client: ProductEventClient,
         sends: Bool,
         session: any AccountTokenProviding,
         http: HTTPClient = URLSession.shared,
@@ -75,6 +76,7 @@ public final class ProductEventSender {
     ) {
         endpoint = serviceURL.appendingPathComponent("api/events")
         self.appVersion = appVersion
+        self.client = client
         self.sends = sends
         self.session = session
         self.http = http
@@ -186,7 +188,7 @@ public final class ProductEventSender {
         request.httpMethod = "POST"
         request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.setValue(Self.clientName, forHTTPHeaderField: Self.clientHeader)
+        request.setValue(client.rawValue, forHTTPHeaderField: Self.clientHeader)
         let body: [String: Any] = ["events": events.map(wireEvent)]
         guard let data = try? JSONSerialization.data(withJSONObject: body) else { return nil }
         request.httpBody = data

--- a/apps/ios/LukeKit/Sources/LukeKit/ProductEventSender.swift
+++ b/apps/ios/LukeKit/Sources/LukeKit/ProductEventSender.swift
@@ -61,6 +61,8 @@ public final class ProductEventSender {
     private var queue: [QueuedEvent] = []
     /// Nested rather than an interpolated key: the name and the discriminator stay apart.
     private var recordedDays: [String: [String: String]] = [:]
+    /// Whose days those are; a different account signing in starts its own.
+    private var recordedDaysAccount: String?
     private var armed = false
     private var timer: Timer?
     private var inFlight: Task<Void, Never>?
@@ -107,6 +109,12 @@ public final class ProductEventSender {
     /// provider per day is the fact worth having, not a count of refreshes.
     public func recordOncePerDay(_ event: ProductEvent, discriminator: String) {
         guard allowed else { return }
+        if let account = session.accountEmail {
+            if let recordedFor = recordedDaysAccount, recordedFor != account {
+                recordedDays.removeAll()
+            }
+            recordedDaysAccount = account
+        }
         let today = Self.dayFormatter.string(from: now())
         if recordedDays[event.name]?[discriminator] == today { return }
         recordedDays[event.name, default: [:]][discriminator] = today

--- a/apps/ios/LukeKit/Sources/LukeKit/ProductEventSender.swift
+++ b/apps/ios/LukeKit/Sources/LukeKit/ProductEventSender.swift
@@ -42,6 +42,8 @@ public final class ProductEventSender {
     private struct QueuedEvent {
         let event: ProductEvent
         let at: Date
+        /// Who was signed in when it was recorded; nil waits for whoever signs in.
+        let account: String?
     }
 
     private let endpoint: URL
@@ -89,7 +91,7 @@ public final class ProductEventSender {
     /// sit on any path without ordering itself around it.
     public func record(_ event: ProductEvent) {
         guard allowed else { return }
-        queue.append(QueuedEvent(event: event, at: now()))
+        queue.append(QueuedEvent(event: event, at: now(), account: session.accountEmail))
         if queue.count > queueLimit {
             queue.removeFirst(queue.count - queueLimit)
         }
@@ -139,13 +141,6 @@ public final class ProductEventSender {
         queue.removeAll()
     }
 
-    /// Drops what is queued and the day markers at an account change, so a
-    /// count recorded under one account never posts as the next.
-    public func reset() {
-        queue.removeAll()
-        recordedDays.removeAll()
-    }
-
     /// Sends what is queued, at most one request at a time. Never throws: a
     /// failure is a count nobody has, which is the trade this whole pipeline
     /// makes. A flush called mid-request chains behind it rather than
@@ -177,6 +172,11 @@ public final class ProductEventSender {
         // Signed out is temporary and nobody's fault, so the queue waits
         // rather than being spent against a request that cannot authenticate.
         guard let token = try? await session.validAccessToken() else { return }
+        // A count recorded under one account never posts as another: what a
+        // sign-out left waiting is dropped once a different account signs in.
+        let account = session.accountEmail
+        queue.removeAll { $0.account != nil && $0.account != account }
+        guard !queue.isEmpty else { return }
         // Taken only once a request will actually be made, and gone whatever
         // becomes of it.
         let events = Array(queue.prefix(Defaults.batchLimit))

--- a/apps/ios/LukeKit/Sources/LukeKit/ProductEvents.swift
+++ b/apps/ios/LukeKit/Sources/LukeKit/ProductEvents.swift
@@ -10,6 +10,12 @@ import Foundation
 /// version, so a session title, a branch, or anything typed has no shape it
 /// could travel in.
 
+/// Which app is posting, as `PRODUCT_EVENT_CLIENT` names the Swift ones.
+public enum ProductEventClient: String, Sendable {
+    case iOS = "ios"
+    case watchOS = "watchos"
+}
+
 /// Every provider the shared vocabulary names (`PROVIDER_ID` in
 /// `packages/session`). A roster row's provider id is read back through this
 /// set before it may reach a count, so an id the vocabulary has not answered

--- a/apps/ios/LukeKit/Tests/LukeKitTests/ProductEventSenderTests.swift
+++ b/apps/ios/LukeKit/Tests/LukeKitTests/ProductEventSenderTests.swift
@@ -405,52 +405,58 @@ final class ProductEventSenderTests: XCTestCase {
         XCTAssertEqual(peak, 1)
     }
 
-    func testADifferentAccountGetsItsOwnDayMarkerAndTheSameOneDoesNot() async {
-        let tokens = StubTokens()
-        let (sender, log) = makeSender(tokens: tokens)
-        sender.arm()
-        sender.markDayActive()
-        await sender.flush().value
-
-        tokens.accountEmail = "other@example.com"
-        sender.markDayActive()
-        await sender.flush().value
-
-        tokens.accountEmail = nil
-        tokens.valid = nil
-        sender.markDayActive()
-        tokens.accountEmail = "other@example.com"
-        tokens.valid = "at-1"
-        sender.markDayActive()
-        await sender.flush().value
-
-        let requests = await log.requests
-        XCTAssertEqual(requests.count, 2)
-    }
-
-    func testCountsRecordedUnderOneAccountNeverPostAsAnother() async {
+    func testCountsRecordedBeforeAnyoneSignedInGoToTheFirstAccount() async {
         let tokens = StubTokens(valid: nil)
         tokens.accountEmail = nil
         let (sender, log) = makeSender(tokens: tokens)
         sender.arm()
         sender.record(.appLaunch)
+        sender.markDayActive()
         tokens.accountEmail = "dev@example.com"
         tokens.valid = "at-1"
+        sender.markDayActive()
+        await sender.flush().value
+
+        let requests = await log.requests
+        XCTAssertEqual(
+            sentEvents(requests[0]).map { $0["name"] as? String },
+            ["app:launch", "app:day_active"]
+        )
+    }
+
+    func testADifferentAccountStartsCleanAndTheSameAccountKeepsItsMarks() async {
+        let tokens = StubTokens()
+        let (sender, log) = makeSender(tokens: tokens)
+        sender.arm()
+        sender.markDayActive()
+        await sender.flush().value
         sender.record(.accountSignIn)
+
+        // Signed out before the flush, then a different account: what waited
+        // is dropped, and the new account marks its own day.
         tokens.accountEmail = nil
         tokens.valid = nil
-        await sender.flush().value
-        var requests = await log.requests
-        XCTAssertTrue(requests.isEmpty)
-
-        // A different account signs in: only the count recorded signed out,
-        // which belongs to nobody yet, may travel.
+        sender.markDayActive()
         tokens.accountEmail = "other@example.com"
         tokens.valid = "at-2"
         await sender.flush().value
-        requests = await log.requests
+        var requests = await log.requests
         XCTAssertEqual(requests.count, 1)
-        XCTAssertEqual(sentEvents(requests[0]).map { $0["name"] as? String }, ["app:launch"])
+        sender.markDayActive()
+        await sender.flush().value
+        requests = await log.requests
+        XCTAssertEqual(requests.count, 2)
+        XCTAssertEqual(sentEvents(requests[1]).map { $0["name"] as? String }, ["app:day_active"])
+
+        // The same account back keeps its marks: nothing more today.
+        tokens.accountEmail = nil
+        tokens.valid = nil
+        tokens.accountEmail = "other@example.com"
+        tokens.valid = "at-2"
+        sender.markDayActive()
+        await sender.flush().value
+        requests = await log.requests
+        XCTAssertEqual(requests.count, 2)
     }
 
     func testStoppingDropsWhatWasQueuedRatherThanHoldingTheQuitOpen() async {

--- a/apps/ios/LukeKit/Tests/LukeKitTests/ProductEventSenderTests.swift
+++ b/apps/ios/LukeKit/Tests/LukeKitTests/ProductEventSenderTests.swift
@@ -405,6 +405,29 @@ final class ProductEventSenderTests: XCTestCase {
         XCTAssertEqual(peak, 1)
     }
 
+    func testADifferentAccountGetsItsOwnDayMarkerAndTheSameOneDoesNot() async {
+        let tokens = StubTokens()
+        let (sender, log) = makeSender(tokens: tokens)
+        sender.arm()
+        sender.markDayActive()
+        await sender.flush().value
+
+        tokens.accountEmail = "other@example.com"
+        sender.markDayActive()
+        await sender.flush().value
+
+        tokens.accountEmail = nil
+        tokens.valid = nil
+        sender.markDayActive()
+        tokens.accountEmail = "other@example.com"
+        tokens.valid = "at-1"
+        sender.markDayActive()
+        await sender.flush().value
+
+        let requests = await log.requests
+        XCTAssertEqual(requests.count, 2)
+    }
+
     func testCountsRecordedUnderOneAccountNeverPostAsAnother() async {
         let tokens = StubTokens(valid: nil)
         tokens.accountEmail = nil

--- a/apps/ios/LukeKit/Tests/LukeKitTests/ProductEventSenderTests.swift
+++ b/apps/ios/LukeKit/Tests/LukeKitTests/ProductEventSenderTests.swift
@@ -405,23 +405,29 @@ final class ProductEventSenderTests: XCTestCase {
         XCTAssertEqual(peak, 1)
     }
 
-    func testResettingDropsTheQueueAndLetsTheDayBeMarkedAgain() async {
-        let (sender, log) = makeSender()
+    func testCountsRecordedUnderOneAccountNeverPostAsAnother() async {
+        let tokens = StubTokens(valid: nil)
+        tokens.accountEmail = nil
+        let (sender, log) = makeSender(tokens: tokens)
         sender.arm()
         sender.record(.appLaunch)
-        sender.markDayActive()
-        sender.reset()
+        tokens.accountEmail = "dev@example.com"
+        tokens.valid = "at-1"
+        sender.record(.accountSignIn)
+        tokens.accountEmail = nil
+        tokens.valid = nil
         await sender.flush().value
         var requests = await log.requests
         XCTAssertTrue(requests.isEmpty)
 
-        sender.markDayActive()
+        // A different account signs in: only the count recorded signed out,
+        // which belongs to nobody yet, may travel.
+        tokens.accountEmail = "other@example.com"
+        tokens.valid = "at-2"
         await sender.flush().value
         requests = await log.requests
-        XCTAssertEqual(
-            sentEvents(requests[0]).map { $0["name"] as? String },
-            ["app:day_active"]
-        )
+        XCTAssertEqual(requests.count, 1)
+        XCTAssertEqual(sentEvents(requests[0]).map { $0["name"] as? String }, ["app:launch"])
     }
 
     func testStoppingDropsWhatWasQueuedRatherThanHoldingTheQuitOpen() async {

--- a/apps/ios/LukeKit/Tests/LukeKitTests/ProductEventSenderTests.swift
+++ b/apps/ios/LukeKit/Tests/LukeKitTests/ProductEventSenderTests.swift
@@ -100,6 +100,7 @@ final class ProductEventSenderTests: XCTestCase {
     private let serviceURL = URL(string: "https://luke.test")!
 
     private func makeSender(
+        client: ProductEventClient = .iOS,
         sends: Bool = true,
         tokens: StubTokens = StubTokens(),
         clock: Clock = Clock(),
@@ -116,6 +117,7 @@ final class ProductEventSenderTests: XCTestCase {
         let sender = ProductEventSender(
             serviceURL: serviceURL,
             appVersion: "0.1.1",
+            client: client,
             sends: sends,
             session: tokens,
             http: http,
@@ -172,6 +174,18 @@ final class ProductEventSenderTests: XCTestCase {
         await sender.flush().value
         requests = await log.requests
         XCTAssertEqual(requests.count, 1)
+    }
+
+    /// The header only ever carries a member of the client set, so a watch
+    /// batch is stamped as the watch's and never mistaken for the phone's.
+    func testTheClientHeaderNamesTheAppThatPosted() async {
+        let (sender, log) = makeSender(client: .watchOS)
+        sender.arm()
+        sender.record(.appLaunch)
+        await sender.flush().value
+        let requests = await log.requests
+        XCTAssertEqual(requests.count, 1)
+        XCTAssertEqual(requests[0].value(forHTTPHeaderField: "x-luke-client"), "watchos")
     }
 
     func testA401RefreshesAndRetriesOnceAndTheSameTokenTwiceDoesNot() async {

--- a/apps/ios/LukeKit/Tests/LukeKitTests/ProductEventSenderTests.swift
+++ b/apps/ios/LukeKit/Tests/LukeKitTests/ProductEventSenderTests.swift
@@ -405,6 +405,25 @@ final class ProductEventSenderTests: XCTestCase {
         XCTAssertEqual(peak, 1)
     }
 
+    func testResettingDropsTheQueueAndLetsTheDayBeMarkedAgain() async {
+        let (sender, log) = makeSender()
+        sender.arm()
+        sender.record(.appLaunch)
+        sender.markDayActive()
+        sender.reset()
+        await sender.flush().value
+        var requests = await log.requests
+        XCTAssertTrue(requests.isEmpty)
+
+        sender.markDayActive()
+        await sender.flush().value
+        requests = await log.requests
+        XCTAssertEqual(
+            sentEvents(requests[0]).map { $0["name"] as? String },
+            ["app:day_active"]
+        )
+    }
+
     func testStoppingDropsWhatWasQueuedRatherThanHoldingTheQuitOpen() async {
         let (sender, log) = makeSender()
         sender.arm()

--- a/apps/ios/LukeWatch/LukeWatchApp.swift
+++ b/apps/ios/LukeWatch/LukeWatchApp.swift
@@ -5,8 +5,10 @@ import SwiftUI
 struct LukeWatchApp: App {
     @State private var watchSession: WatchAccountSession
     @State private var rosterStore: WatchRosterStore
+    @State private var events: ProductEventSender
     @State private var navigation = WatchNavigation()
     @State private var conversation = VoiceConversationThread()
+    @Environment(\.scenePhase) private var scenePhase
     // Held for its lifetime — the delegate must not be deallocated.
     private let connectivity: WatchConnectivityReceiver
 
@@ -14,7 +16,21 @@ struct LukeWatchApp: App {
         let watchSession = WatchAccountSession()
         _watchSession = State(initialValue: watchSession)
         connectivity = WatchConnectivityReceiver(watchSession: watchSession)
-        _rosterStore = State(initialValue: WatchRosterStore(session: watchSession))
+        let events = ProductEventSender(
+            serviceURL: AccountConstants.serviceURL,
+            appVersion: Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "0.0.0",
+            client: .watchOS,
+            sends: true,
+            session: WatchCountingTokens(session: watchSession)
+        )
+        _events = State(initialValue: events)
+        _rosterStore = State(initialValue: WatchRosterStore(session: watchSession, events: events))
+        // Account edges are not counted here: a sign-in on the watch is the
+        // phone's relay, and the phone already counted it.
+        events.arm()
+        events.record(.appLaunch)
+        events.markDayActive()
+        events.start()
     }
 
     var body: some Scene {
@@ -22,8 +38,12 @@ struct LukeWatchApp: App {
             LukeWatchView()
                 .environment(watchSession)
                 .environment(rosterStore)
+                .environment(events)
                 .environment(navigation)
                 .environment(conversation)
+        }
+        .onChange(of: scenePhase) { _, phase in
+            if phase == .background { events.flush() }
         }
     }
 }

--- a/apps/ios/LukeWatch/LukeWatchView.swift
+++ b/apps/ios/LukeWatch/LukeWatchView.swift
@@ -6,7 +6,6 @@ struct LukeWatchView: View {
     @Environment(WatchRosterStore.self) private var rosterStore
     @Environment(WatchNavigation.self) private var navigation
     @Environment(VoiceConversationThread.self) private var conversation
-    @Environment(ProductEventSender.self) private var events
 
     var body: some View {
         Group {
@@ -23,7 +22,6 @@ struct LukeWatchView: View {
             rosterStore.reset()
             conversation.clear()
             navigation.reset()
-            events.reset()
         }
     }
 

--- a/apps/ios/LukeWatch/LukeWatchView.swift
+++ b/apps/ios/LukeWatch/LukeWatchView.swift
@@ -6,6 +6,7 @@ struct LukeWatchView: View {
     @Environment(WatchRosterStore.self) private var rosterStore
     @Environment(WatchNavigation.self) private var navigation
     @Environment(VoiceConversationThread.self) private var conversation
+    @Environment(ProductEventSender.self) private var events
 
     var body: some View {
         Group {
@@ -22,6 +23,7 @@ struct LukeWatchView: View {
             rosterStore.reset()
             conversation.clear()
             navigation.reset()
+            events.reset()
         }
     }
 

--- a/apps/ios/LukeWatch/WatchAccountSession.swift
+++ b/apps/ios/LukeWatch/WatchAccountSession.swift
@@ -90,6 +90,12 @@ final class WatchAccountSession {
         return accessToken
     }
 
+    /// The token while signed in and not near expiry; never signs out.
+    var standingAccessToken: String? {
+        guard case .signedIn = state, let accessToken, !tokenNearExpiry else { return nil }
+        return accessToken
+    }
+
     // MARK: - Private
 
     private var tokenNearExpiry: Bool {
@@ -136,6 +142,32 @@ extension WatchAccountSession: AccountTokenProviding {
     /// to push a fresh pair rather than attempting a refresh.
     func refreshAccessToken() async throws -> String {
         invalidateCredentialsAndRequestReplacement()
+        throw AccountSessionError.signedOut
+    }
+}
+
+// MARK: - Counting
+
+/// Tokens for the product-event sender. `validAccessToken()` on the session
+/// signs the watch out at near-expiry to summon fresh tokens from the phone;
+/// a timed or background flush of counts must not do that, so the counts
+/// wait for a standing token instead, and a 401 drops the batch.
+@MainActor
+final class WatchCountingTokens: AccountTokenProviding {
+    private let session: WatchAccountSession
+
+    init(session: WatchAccountSession) {
+        self.session = session
+    }
+
+    var accountEmail: String? { session.accountEmail }
+
+    func validAccessToken() async throws -> String {
+        guard let token = session.standingAccessToken else { throw AccountSessionError.signedOut }
+        return token
+    }
+
+    func refreshAccessToken() async throws -> String {
         throw AccountSessionError.signedOut
     }
 }

--- a/apps/ios/LukeWatch/WatchRosterStore.swift
+++ b/apps/ios/LukeWatch/WatchRosterStore.swift
@@ -22,12 +22,14 @@ final class WatchRosterStore {
     var searchQuery = ""
 
     private let session: WatchAccountSession
+    private let events: ProductEventSender
     private let client = RosterClient(serviceURL: AccountConstants.serviceURL)
     private var reloadRequested = true
     private var loadGeneration = 0
 
-    init(session: WatchAccountSession) {
+    init(session: WatchAccountSession, events: ProductEventSender) {
         self.session = session
+        self.events = events
     }
 
     /// Whether anything hides a row: a filter, or a query with words in it.
@@ -87,6 +89,7 @@ final class WatchRosterStore {
                 guard generation == loadGeneration else { return }
                 sessions = fetched
                 completedRequest = true
+                recordObservation(fetched)
             } catch is AccountSessionError {
                 guard generation == loadGeneration else { return }
                 session.signOut()
@@ -122,6 +125,20 @@ final class WatchRosterStore {
             try? await Task.sleep(for: .seconds(15))
             guard !Task.isCancelled else { break }
             await load()
+        }
+    }
+
+    /// One count per provider per day, in buckets — polling is not using.
+    /// A provider id the shared vocabulary has not answered for is left
+    /// uncounted rather than sent to be refused.
+    private func recordObservation(_ sessions: [RosterSession]) {
+        let rowsByProvider = Dictionary(grouping: sessions, by: \.providerId)
+        for (providerId, rows) in rowsByProvider {
+            guard let provider = ProductProviderID(rawValue: providerId) else { continue }
+            events.recordOncePerDay(
+                .sessionObserve(provider: provider, sessions: .bucket(for: rows.count)),
+                discriminator: providerId
+            )
         }
     }
 }

--- a/apps/ios/LukeWatch/WatchRosterView.swift
+++ b/apps/ios/LukeWatch/WatchRosterView.swift
@@ -4,6 +4,7 @@ import SwiftUI
 struct WatchRosterView: View {
     @Environment(WatchRosterStore.self) private var store
     @Environment(WatchAccountSession.self) private var account
+    @Environment(ProductEventSender.self) private var events
     @State private var archiveFailure: String?
 
     private let actClient = ActClient(baseURL: AccountConstants.serviceURL)
@@ -115,25 +116,26 @@ struct WatchRosterView: View {
 
     private func archiveSession(_ session: RosterSession, control: RosterSessionControl) {
         Task {
-            do {
-                let answer = try await account.authorized { token in
-                    try await actClient.executeControl(
-                        accessToken: token,
-                        providerId: session.providerId,
-                        providerSessionId: session.sessionId,
-                        controlId: control.id
-                    )
-                }
-                switch answer.result {
-                case .accepted:
-                    await store.load()
-                case .rejected, .unsupported:
-                    archiveFailure = answer.reason ?? "The session was not archived."
-                }
-            } catch is AccountSessionError {
-                ()
-            } catch {
-                archiveFailure = error.localizedDescription
+            let outcome = await account.performAct(
+                counting: .controlRun,
+                provider: session.providerId,
+                events: events,
+                fallbackReason: "The session was not archived."
+            ) { token in
+                try await actClient.executeControl(
+                    accessToken: token,
+                    providerId: session.providerId,
+                    providerSessionId: session.sessionId,
+                    controlId: control.id
+                )
+            }
+            switch outcome {
+            case .delivered:
+                await store.load()
+            case .refused(let reason):
+                archiveFailure = reason
+            case .signedOut:
+                break
             }
         }
     }
@@ -184,6 +186,7 @@ struct WatchSessionDetailView: View {
 
     @Environment(WatchAccountSession.self) private var account
     @Environment(WatchRosterStore.self) private var store
+    @Environment(ProductEventSender.self) private var events
     @Environment(\.dismiss) private var dismiss
     @State private var conversation: [ConversationMessage] = []
     @State private var forwardCursor: String?
@@ -505,23 +508,24 @@ struct WatchSessionDetailView: View {
         outgoing.append(message)
         scrollIntent = .end
         Task {
+            let outcome = await account.performAct(
+                counting: .messageSend,
+                provider: session.providerId,
+                events: events,
+                fallbackReason: "The message was not delivered."
+            ) { token in
+                try await actClient.sendMessage(
+                    accessToken: token,
+                    providerId: session.providerId,
+                    providerSessionId: session.sessionId,
+                    text: message.text
+                )
+            }
             let delivery: WatchOutgoingMessage.Delivery
-            do {
-                let answer = try await account.authorized { token in
-                    try await actClient.sendMessage(
-                        accessToken: token,
-                        providerId: session.providerId,
-                        providerSessionId: session.sessionId,
-                        text: message.text
-                    )
-                }
-                delivery = answer.result == .accepted
-                    ? .sent
-                    : .failed(reason: answer.reason ?? "The message was not delivered.")
-            } catch is AccountSessionError {
-                delivery = .failed(reason: "Signed out.")
-            } catch {
-                delivery = .failed(reason: error.localizedDescription)
+            switch outcome {
+            case .delivered: delivery = .sent
+            case .refused(let reason): delivery = .failed(reason: reason)
+            case .signedOut: delivery = .failed(reason: "Signed out.")
             }
 
             guard let index = outgoing.firstIndex(where: { $0.id == message.id }) else { return }
@@ -573,6 +577,7 @@ private struct WatchSessionInfoView: View {
 
     @Environment(WatchAccountSession.self) private var account
     @Environment(WatchRosterStore.self) private var store
+    @Environment(ProductEventSender.self) private var events
     @Environment(\.openURL) private var openURL
     @State private var runningControl: String?
     @State private var renameTarget: RenameTarget?
@@ -794,7 +799,7 @@ private struct WatchSessionInfoView: View {
         let name = renameText
         renameTarget = nil
         Task {
-            await performAct {
+            await performAct(counting: target == .session ? .sessionRename : .workspaceRename) {
                 switch target {
                 case .session:
                     try await actClient.renameSession(
@@ -818,7 +823,7 @@ private struct WatchSessionInfoView: View {
     private func runControl(_ control: RosterSessionControl) {
         runningControl = control.id
         Task {
-            let delivered = await performAct {
+            let delivered = await performAct(counting: .controlRun) {
                 try await actClient.executeControl(
                     accessToken: $0,
                     providerId: session.providerId,
@@ -834,23 +839,25 @@ private struct WatchSessionInfoView: View {
     }
 
     @discardableResult
-    private func performAct(
-        _ call: (String) async throws -> ActMessageAnswer
+    private func performAct<Answer: ActAnswer>(
+        counting act: ProductSessionAct,
+        _ call: (String) async throws -> Answer
     ) async -> Bool {
-        do {
-            let answer = try await account.authorized(call)
-            switch answer.result {
-            case .accepted:
-                await store.load()
-                return true
-            case .rejected, .unsupported:
-                actFailure = answer.reason ?? "The action was not delivered."
-                return false
-            }
-        } catch is AccountSessionError {
+        let outcome = await account.performAct(
+            counting: act,
+            provider: session.providerId,
+            events: events,
+            fallbackReason: "The action was not delivered.",
+            call
+        )
+        switch outcome {
+        case .delivered:
+            await store.load()
+            return true
+        case .refused(let reason):
+            actFailure = reason
             return false
-        } catch {
-            actFailure = error.localizedDescription
+        case .signedOut:
             return false
         }
     }
@@ -862,6 +869,7 @@ private struct WatchAgentSpawnerView: View {
     let onDone: () async -> Void
 
     @Environment(WatchAccountSession.self) private var account
+    @Environment(ProductEventSender.self) private var events
     @Environment(\.dismiss) private var dismiss
     @State private var agent: String
     @State private var name = ""
@@ -923,28 +931,29 @@ private struct WatchAgentSpawnerView: View {
         spawning = true
         Task {
             defer { spawning = false }
-            do {
-                let answer = try await account.authorized { token in
-                    try await actClient.spawnAgent(
-                        accessToken: token,
-                        providerId: session.providerId,
-                        providerSessionId: session.sessionId,
-                        agent: agentKind,
-                        name: nameValue.isEmpty ? nil : nameValue,
-                        task: taskValue.isEmpty ? nil : taskValue
-                    )
-                }
-                switch answer.result {
-                case .accepted:
-                    await onDone()
-                    dismiss()
-                case .rejected, .unsupported:
-                    failure = answer.reason ?? "The agent was not started."
-                }
-            } catch is AccountSessionError {
+            let outcome = await account.performAct(
+                counting: .agentAdd,
+                provider: session.providerId,
+                events: events,
+                fallbackReason: "The agent was not started."
+            ) { token in
+                try await actClient.spawnAgent(
+                    accessToken: token,
+                    providerId: session.providerId,
+                    providerSessionId: session.sessionId,
+                    agent: agentKind,
+                    name: nameValue.isEmpty ? nil : nameValue,
+                    task: taskValue.isEmpty ? nil : taskValue
+                )
+            }
+            switch outcome {
+            case .delivered:
+                await onDone()
                 dismiss()
-            } catch {
-                failure = error.localizedDescription
+            case .refused(let reason):
+                failure = reason
+            case .signedOut:
+                dismiss()
             }
         }
     }

--- a/apps/ios/LukeWatch/WatchVoiceView.swift
+++ b/apps/ios/LukeWatch/WatchVoiceView.swift
@@ -11,6 +11,7 @@ struct WatchVoiceView: View {
     @Environment(WatchRosterStore.self) private var store
     @Environment(WatchNavigation.self) private var navigation
     @Environment(VoiceConversationThread.self) private var conversation
+    @Environment(ProductEventSender.self) private var events
     @State private var model = WatchVoiceSessionModel()
     @State private var isPressing = false
     private let actClient = ActClient(baseURL: AccountConstants.serviceURL)
@@ -51,10 +52,12 @@ struct WatchVoiceView: View {
             defaults: model.defaults,
             actClient: actClient,
             accessToken: { [accountSession] in try await accountSession.validAccessToken() },
-            // The watch posts no product events — none of the acts its own
-            // screens carry count either — so a spoken act counts nothing
-            // here rather than posting under another app's tag.
-            count: { _, _ in },
+            count: { [events] act, providerId in
+                // A provider id the shared vocabulary has not answered for is
+                // left uncounted rather than sent to be refused.
+                guard let provider = ProductProviderID(rawValue: providerId) else { return }
+                events.record(.sessionActSend(provider: provider, act: act))
+            },
             refreshRoster: { [store] in await store.load() },
             // One page, so the last open a reply names is the one taken.
             open: { [model] session in model.pendingNavigation = .open(session) },

--- a/apps/ios/README.md
+++ b/apps/ios/README.md
@@ -89,6 +89,13 @@ batch against the TypeScript vocabulary, so the transcription must stay a
 subset of it. Session replay posts to PostHog directly from
 `Luke/SessionReplay.swift` under the `PostHog` SwiftPM package.
 
+The watch app runs the counted stream alone, through the same sender with
+client `watchos` (stamped `luke-watchos` by the service). It does not link the
+PostHog SDK: `posthog-ios` builds session replay only for iOS and crash
+autocapture only for iOS, macOS, and tvOS, so there is no watch recording and
+no watch crash reporting. Account edges are not counted on the watch, because
+a sign-in there is the phone's relay and the phone already counted it.
+
 The PostHog project key rides the `POSTHOG_PROJECT_API_KEY` build setting into
 `Info.plist`, empty by default — and empty means the recording client is never
 configured. A distributing build injects it:

--- a/apps/web/tests/hosted-events.test.ts
+++ b/apps/web/tests/hosted-events.test.ts
@@ -242,25 +242,27 @@ test("the forwarded document matches the processor's documented batch shape", as
 });
 
 test("the client header selects the $lib tag, and anything else is the desktop", async () => {
-  const mobile = upstream();
-  await handleEvents(
-    options({
-      request: new Request("https://luke.test/api/events", {
-        method: "POST",
-        headers: {
-          authorization: "Bearer token-1",
-          [PRODUCT_EVENT_CLIENT_HEADER]: PRODUCT_EVENT_CLIENT.IOS,
-        },
-        body: JSON.stringify({ events: [LAUNCH] }),
+  for (const client of [PRODUCT_EVENT_CLIENT.IOS, PRODUCT_EVENT_CLIENT.WATCHOS]) {
+    const posted = upstream();
+    await handleEvents(
+      options({
+        request: new Request("https://luke.test/api/events", {
+          method: "POST",
+          headers: {
+            authorization: "Bearer token-1",
+            [PRODUCT_EVENT_CLIENT_HEADER]: client,
+          },
+          body: JSON.stringify({ events: [LAUNCH] }),
+        }),
+        fetch: posted.fetch,
+        resolveUserId: freshUser(),
       }),
-      fetch: mobile.fetch,
-      resolveUserId: freshUser(),
-    }),
-  );
-  assert.equal(
-    itemAt(onlyBatch(mobile.forwarded).items, 0).properties.$lib,
-    PRODUCT_EVENT_CLIENT_LIB[PRODUCT_EVENT_CLIENT.IOS],
-  );
+    );
+    assert.equal(
+      itemAt(onlyBatch(posted.forwarded).items, 0).properties.$lib,
+      PRODUCT_EVENT_CLIENT_LIB[client],
+    );
+  }
 
   // A header outside the set cannot put its own words in the tag.
   const forged = upstream();

--- a/packages/analytics/AGENTS.md
+++ b/packages/analytics/AGENTS.md
@@ -15,17 +15,19 @@ second time there; everything in the section below reaches the project without
 passing it. So the guarantee is "nothing observed can travel in a counted
 event", never "nothing observed reaches the project".
 
-The endpoint has two clients, and the second is a transcription. The iOS app
-emits through its own Swift sender (`apps/ios/LukeKit/Sources/LukeKit/
-ProductEvents.swift` and `ProductEventSender.swift`), a hand-kept subset of
-this vocabulary whose enums make free text unrepresentable the way the `as
-const` sets do here. This file stays the source of truth: the service reads
-every batch against this allowlist regardless of who posted it, so a
+The endpoint has three clients, and the other two share a transcription. The
+iOS and watchOS apps emit through one Swift sender (`apps/ios/LukeKit/Sources/
+LukeKit/ProductEvents.swift` and `ProductEventSender.swift`), a hand-kept
+subset of this vocabulary whose enums make free text unrepresentable the way
+the `as const` sets do here. This file stays the source of truth: the service
+reads every batch against this allowlist regardless of who posted it, so a
 transcription that drifts shows up as a refused batch, never as a value that
 traveled. Which app posted travels as `PRODUCT_EVENT_CLIENT_HEADER`, a header
 whose value only selects between the fixed `$lib` tags in
 `PRODUCT_EVENT_CLIENT_LIB` — absent or unrecognized means the desktop, because
-desktop builds from before the header already post without one.
+desktop builds from before the header already post without one. The Swift
+sender takes its member of that set at construction, so each app names itself
+once and no call site can mislabel a batch.
 
 That construction is the guard, not a document that lists the events. Widening
 the event list or a property's value set is still a product decision rather
@@ -49,7 +51,10 @@ compromised renderer reaches none of the acts.
 the desktop runs, and `apps/ios/Luke/SessionReplay.swift` its iOS
 counterpart — each on its library's own configuration, and nothing in this
 package governs a byte of either. Do not let this file's promise be read as
-covering them. Three things leave that way and none is validated here:
+covering them. The watch app has no such client: the SDK's replay and crash
+autocapture do not build for watchOS, so the counted stream is the whole of
+what leaves it. Three things leave the other two that way and none is
+validated here:
 
 - The recording itself, which is the rendered panel except for the History
   tab's explicitly blocked `ph-no-capture` subtree — a session's title, branch,

--- a/packages/analytics/src/product-events.ts
+++ b/packages/analytics/src/product-events.ts
@@ -582,6 +582,7 @@ export const PRODUCT_EVENT_CLIENT_HEADER = "x-luke-client";
 export const PRODUCT_EVENT_CLIENT = {
   DESKTOP: "desktop",
   IOS: "ios",
+  WATCHOS: "watchos",
 } as const;
 
 export type ProductEventClient = (typeof PRODUCT_EVENT_CLIENT)[keyof typeof PRODUCT_EVENT_CLIENT];
@@ -590,6 +591,7 @@ export type ProductEventClient = (typeof PRODUCT_EVENT_CLIENT)[keyof typeof PROD
 export const PRODUCT_EVENT_CLIENT_LIB = {
   [PRODUCT_EVENT_CLIENT.DESKTOP]: "luke-desktop",
   [PRODUCT_EVENT_CLIENT.IOS]: "luke-ios",
+  [PRODUCT_EVENT_CLIENT.WATCHOS]: "luke-watchos",
 } as const satisfies Record<ProductEventClient, string>;
 
 const PRODUCT_EVENT_CLIENTS: ReadonlySet<string> = new Set(Object.values(PRODUCT_EVENT_CLIENT));


### PR DESCRIPTION
## Summary

- The watch app ran no analytics. It now counts through the same Swift `ProductEventSender` the phone uses, posting to Luke's own `/api/events` under the bearer token it already holds. A new client value (`watchos`) is stamped `luke-watchos` by the service; the sender takes its client at construction.
- The watch counts launch, the day marker, one observation per provider per day, and its session acts (controls, messages, renames, agent adds, and spoken acts), every act through the shared `performAct` helper. Account edges are not counted on the watch, because a sign-in there is the phone's relay and the phone already counted it.
- Counting reads tokens through `WatchCountingTokens`, which never signs the account out, so a timed or background flush cannot tear down the signed-in screen. A different account signing in starts the sender clean, so nothing queued or marked under one account posts as another or counts a day twice (all three found by Bugbot on this PR).
- No PostHog SDK on the watch: `posthog-ios` 3.71.0 builds session replay only for iOS and crash autocapture only for iOS, macOS, and tvOS, so the watch target does not link it. `PRIVACY.md`, `AGENTS.md`, `packages/analytics/AGENTS.md`, and `apps/ios/README.md` say so.

## Evidence

- Platform-independent checks: `./scripts/check.sh` passed; CI TypeScript checks green on the final commit
- macOS Electron verification (`./scripts/verify.sh`): `not run locally` (no desktop change; CI's macOS job passed)
- LukeKit `swift test` on a Mac (Xcode 26.6), final commit 968ca8b: 271 tests, 0 failures
- `xcodebuild -scheme LukeWatch` (watchOS Simulator) and `xcodebuild -scheme Luke` (iOS Simulator, embeds the watch app), final commit: both `BUILD SUCCEEDED`

<!-- automated-visual-evidence:start -->
### Automated visual evidence

CI will replace this block with a link to the deterministic macOS screenshots.
<!-- automated-visual-evidence:end -->

### Physical-device evidence

- Screenshot or screen recording: `not attached`
- Physical-notch check: `not performed` (no desktop UI change)
- Device/display configuration: `not recorded`

## Notes

- Blockers or follow-up verification: None. Worth doing separately: an iOS/watchOS build step in CI, since nothing in CI compiles the Xcode project today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
