### PR TITLE
feat(desktop): add speech arbiter, mouth, and wire vocabulary, unwired

### DIFF
--- a/apps/desktop/src/main/speech-arbiter.test.ts
+++ b/apps/desktop/src/main/speech-arbiter.test.ts
@@ -1,0 +1,392 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { BRAIN_DELIVERY_SOURCE, type BrainDelivery } from "@sidecar/brain";
+import type { SpeechTraceRecord } from "@sidecar/devtrace";
+import {
+  ARRIVAL_SPEECH_KIND,
+  BRIEFING_SPEECH_KIND,
+  CALENDAR_ONBOARDING_SPEECH_KIND,
+  isBriefingSpeech,
+} from "@sidecar/realtime";
+import { SPEECH_OUTCOME } from "#shared/wire/speech";
+import {
+  MAXIMUM_PENDING_BRIEFINGS,
+  SPEECH_DECISION,
+  SPOKEN_NOTICE_MAX_AGE_MS,
+  SpeechArbiter,
+} from "./speech-arbiter";
+
+function delivery(briefing: string, decidedAt = 1_000): BrainDelivery {
+  return { briefing, decidedAt, source: BRAIN_DELIVERY_SOURCE.WAKE };
+}
+
+interface Harness {
+  arbiter: SpeechArbiter;
+  traces: SpeechTraceRecord[];
+  clock: { now: number };
+}
+
+function harness(now = 1_000): Harness {
+  const clock = { now };
+  const traces: SpeechTraceRecord[] = [];
+  let id = 0;
+  const arbiter = new SpeechArbiter({
+    now: () => clock.now,
+    nextId: () => {
+      id += 1;
+      return `id-${id}`;
+    },
+    trace: (record) => traces.push(record),
+  });
+  return { arbiter, traces, clock };
+}
+
+function requestBriefing(arbiter: SpeechArbiter, text: string, decidedAt = 1_000): void {
+  arbiter.request({ kind: BRIEFING_SPEECH_KIND, delivery: delivery(text, decidedAt) });
+}
+
+/** The briefing an offer carries, or the beat kind it names. */
+function offeredWords(arbiter: SpeechArbiter): string | undefined {
+  const offer = arbiter.next();
+  if (!offer) return undefined;
+  return isBriefingSpeech(offer.turn) ? offer.turn.briefing : offer.turn.kind;
+}
+
+test("a beat is requested once: pending, offered, or spent, the repeat is dropped", () => {
+  const { arbiter, traces } = harness();
+  arbiter.request({ kind: ARRIVAL_SPEECH_KIND });
+  arbiter.request({ kind: ARRIVAL_SPEECH_KIND });
+  assert.equal(arbiter.pendingCount, 1);
+  assert.equal(traces.at(-1)?.decision, SPEECH_DECISION.DROPPED);
+
+  const offer = arbiter.next();
+  assert.ok(offer);
+  arbiter.request({ kind: ARRIVAL_SPEECH_KIND });
+  assert.equal(arbiter.pendingCount, 1, "offered still counts as pending");
+
+  arbiter.settle(offer.id, SPEECH_OUTCOME.SPOKEN);
+  arbiter.request({ kind: ARRIVAL_SPEECH_KIND });
+  assert.equal(arbiter.pendingCount, 0, "a spoken beat is spent for the run");
+  // A different beat is its own line and is not deduped against the first.
+  arbiter.request({ kind: CALENDAR_ONBOARDING_SPEECH_KIND });
+  assert.equal(arbiter.pendingCount, 1);
+});
+
+test("the briefing backlog sheds its oldest whole past the bound", () => {
+  const { arbiter } = harness();
+  for (let index = 0; index < MAXIMUM_PENDING_BRIEFINGS + 2; index += 1) {
+    requestBriefing(arbiter, `briefing ${index}`);
+  }
+  assert.equal(arbiter.pendingCount, MAXIMUM_PENDING_BRIEFINGS);
+
+  arbiter.setQuiet(true);
+  const held = arbiter.takeHeldBriefings();
+  assert.equal(held.length, MAXIMUM_PENDING_BRIEFINGS);
+  // The oldest went first: a backlog re-decided in one turn wants the recent few.
+  assert.equal(held[0]?.briefing, "briefing 2");
+  assert.equal(held.at(-1)?.briefing, `briefing ${MAXIMUM_PENDING_BRIEFINGS + 1}`);
+  assert.equal(held[0]?.source, BRAIN_DELIVERY_SOURCE.WAKE);
+  assert.equal(arbiter.pendingCount, 0);
+  assert.deepEqual(arbiter.takeHeldBriefings(), []);
+});
+
+test("the bound never sheds the briefing the mouth already holds", () => {
+  const { arbiter } = harness();
+  requestBriefing(arbiter, "offered");
+  const offer = arbiter.next();
+  assert.ok(offer);
+  for (let index = 0; index < MAXIMUM_PENDING_BRIEFINGS + 1; index += 1) {
+    requestBriefing(arbiter, `later ${index}`);
+  }
+  assert.equal(arbiter.pendingCount, MAXIMUM_PENDING_BRIEFINGS);
+  assert.equal(arbiter.offeredId, offer.id);
+  // Settling the held one still lands: it was never taken out from under the mouth.
+  assert.equal(arbiter.settle(offer.id, SPEECH_OUTCOME.SPOKEN)?.kind, BRIEFING_SPEECH_KIND);
+  assert.equal(offeredWords(arbiter), "later 2");
+});
+
+test("a request arriving under quiet enters held, and nothing is offered", () => {
+  const { arbiter } = harness();
+  arbiter.setQuiet(true);
+  requestBriefing(arbiter, "quiet news");
+  arbiter.request({ kind: ARRIVAL_SPEECH_KIND });
+  assert.equal(arbiter.heldBriefingCount, 1);
+  assert.equal(arbiter.next(), undefined);
+  assert.equal(arbiter.pendingCount, 2);
+});
+
+test("quiet beginning holds every pending request; quiet ending releases the beats alone", () => {
+  const { arbiter, clock } = harness();
+  requestBriefing(arbiter, "before");
+  arbiter.request({ kind: CALENDAR_ONBOARDING_SPEECH_KIND });
+  assert.equal(arbiter.heldBriefingCount, 0);
+
+  arbiter.setQuiet(true);
+  assert.equal(arbiter.heldBriefingCount, 1);
+  assert.equal(arbiter.next(), undefined);
+
+  // The meeting runs long past the news window; a held request does not age.
+  clock.now += SPOKEN_NOTICE_MAX_AGE_MS * 3;
+  arbiter.setQuiet(false);
+  assert.equal(arbiter.heldBriefingCount, 1, "briefings wait for the brain, not the mouth");
+  // The beat is released on a fresh clock: it is offered, not aged out, and
+  // its deadline runs from the release.
+  const offer = arbiter.next();
+  assert.ok(offer);
+  assert.equal(offer.turn.kind, CALENDAR_ONBOARDING_SPEECH_KIND);
+  assert.equal(offer.turn.decidedAt, clock.now);
+  assert.equal(offer.speakBy, clock.now + SPOKEN_NOTICE_MAX_AGE_MS);
+});
+
+test("held briefings are taken in order with their source intact, once", () => {
+  const { arbiter } = harness();
+  arbiter.setQuiet(true);
+  requestBriefing(arbiter, "first");
+  requestBriefing(arbiter, "second");
+  arbiter.request({ kind: ARRIVAL_SPEECH_KIND });
+  arbiter.setQuiet(false);
+
+  const taken = arbiter.takeHeldBriefings();
+  assert.deepEqual(
+    taken.map((item) => item.briefing),
+    ["first", "second"],
+  );
+  assert.ok(taken.every((item) => item.source === BRAIN_DELIVERY_SOURCE.WAKE));
+  assert.equal(arbiter.heldBriefingCount, 0);
+  assert.equal(arbiter.pendingCount, 1, "the beat is not a briefing and stays");
+  assert.deepEqual(arbiter.takeHeldBriefings(), []);
+});
+
+test("dropBriefings discards every waiting briefing and nothing else", () => {
+  const { arbiter, traces } = harness();
+  requestBriefing(arbiter, "a");
+  requestBriefing(arbiter, "b");
+  arbiter.request({ kind: ARRIVAL_SPEECH_KIND });
+  arbiter.dropBriefings();
+  assert.equal(arbiter.pendingCount, 1);
+  assert.equal(offeredWords(arbiter), ARRIVAL_SPEECH_KIND);
+  assert.equal(traces.filter((record) => record.decision === SPEECH_DECISION.DROPPED).length, 2);
+});
+
+test("nothing is offered while quiet or while an offer is outstanding", () => {
+  const { arbiter } = harness();
+  requestBriefing(arbiter, "a");
+  requestBriefing(arbiter, "b");
+  const first = arbiter.next();
+  assert.ok(first);
+  assert.equal(arbiter.next(), undefined, "one offer at a time");
+  assert.equal(arbiter.offeredId, first.id);
+
+  arbiter.settle(first.id, SPEECH_OUTCOME.SPOKEN);
+  arbiter.setQuiet(true);
+  assert.equal(arbiter.next(), undefined, "nothing under quiet");
+  arbiter.setQuiet(false);
+  // The briefing that stood when the quiet began is held for the brain.
+  assert.equal(arbiter.next(), undefined);
+  assert.equal(arbiter.heldBriefingCount, 1);
+});
+
+test("offers go out FIFO across kinds, each with its deadline from its own decision", () => {
+  const { arbiter, clock } = harness(5_000);
+  requestBriefing(arbiter, "news", 4_000);
+  arbiter.request({ kind: ARRIVAL_SPEECH_KIND });
+  clock.now = 6_000;
+  arbiter.request({ kind: CALENDAR_ONBOARDING_SPEECH_KIND });
+
+  const first = arbiter.next();
+  assert.ok(first && isBriefingSpeech(first.turn));
+  assert.equal(first.turn.briefing, "news");
+  assert.equal(first.turn.decidedAt, 4_000);
+  assert.equal(first.speakBy, 4_000 + SPOKEN_NOTICE_MAX_AGE_MS);
+  arbiter.settle(first.id, SPEECH_OUTCOME.SPOKEN);
+
+  const second = arbiter.next();
+  assert.ok(second);
+  assert.equal(second.turn.kind, ARRIVAL_SPEECH_KIND);
+  assert.equal(second.turn.decidedAt, 5_000);
+  assert.equal(second.speakBy, 5_000 + SPOKEN_NOTICE_MAX_AGE_MS);
+  arbiter.settle(second.id, SPEECH_OUTCOME.SPOKEN);
+
+  const third = arbiter.next();
+  assert.ok(third);
+  assert.equal(third.turn.kind, CALENDAR_ONBOARDING_SPEECH_KIND);
+  assert.equal(third.turn.decidedAt, 6_000);
+  assert.equal(third.speakBy, 6_000 + SPOKEN_NOTICE_MAX_AGE_MS);
+  assert.notEqual(first.id, second.id);
+  assert.notEqual(second.id, third.id);
+});
+
+test("next ages out unheld requests, spends a stale beat, and never ages a held one", () => {
+  const { arbiter, clock, traces } = harness(10_000);
+  arbiter.setQuiet(true);
+  requestBriefing(arbiter, "held", 10_000);
+  arbiter.setQuiet(false);
+  requestBriefing(arbiter, "old", 5_000);
+  arbiter.request({ kind: ARRIVAL_SPEECH_KIND });
+  clock.now = 5_000 + SPOKEN_NOTICE_MAX_AGE_MS + 1;
+
+  // Nothing arrives at the mouth stale: the aged briefing is settled here,
+  // the beat requested later still stands, and the held briefing waits out
+  // the hold rather than the clock.
+  const offer = arbiter.next();
+  assert.ok(offer);
+  assert.equal(offer.turn.kind, ARRIVAL_SPEECH_KIND);
+  assert.equal(arbiter.heldBriefingCount, 1);
+  assert.equal(traces.filter((record) => record.decision === SPEECH_OUTCOME.STALE).length, 1);
+
+  // A beat that ages out is spent for the run.
+  arbiter.settle(offer.id, SPEECH_OUTCOME.HELD);
+  arbiter.setQuiet(true);
+  arbiter.setQuiet(false);
+  clock.now += SPOKEN_NOTICE_MAX_AGE_MS + 1;
+  assert.equal(arbiter.next(), undefined);
+  arbiter.request({ kind: ARRIVAL_SPEECH_KIND });
+  assert.equal(arbiter.pendingCount, 1, "only the held briefing stands; the beat is spent");
+  assert.equal(arbiter.heldBriefingCount, 1);
+});
+
+test("settle SPOKEN ends the request and spends a beat; the next is then offered", () => {
+  const { arbiter } = harness();
+  arbiter.request({ kind: ARRIVAL_SPEECH_KIND });
+  requestBriefing(arbiter, "after");
+  const offer = arbiter.next();
+  assert.ok(offer);
+  const settled = arbiter.settle(offer.id, SPEECH_OUTCOME.SPOKEN);
+  assert.equal(settled?.kind, ARRIVAL_SPEECH_KIND);
+  assert.equal(settled?.outcome, SPEECH_OUTCOME.SPOKEN);
+  assert.equal(settled?.request.id, offer.id);
+  assert.equal(arbiter.offeredId, undefined);
+  assert.equal(offeredWords(arbiter), "after");
+});
+
+test("settle HELD returns the request to the head, held, unspent", () => {
+  const { arbiter } = harness();
+  arbiter.request({ kind: ARRIVAL_SPEECH_KIND });
+  requestBriefing(arbiter, "later");
+  const offer = arbiter.next();
+  assert.ok(offer);
+  arbiter.setQuiet(true);
+  assert.equal(arbiter.settle(offer.id, SPEECH_OUTCOME.HELD)?.outcome, SPEECH_OUTCOME.HELD);
+  assert.equal(arbiter.pendingCount, 2);
+  assert.equal(arbiter.offeredId, undefined);
+
+  arbiter.setQuiet(false);
+  // The beat is offered again, ahead of the briefing behind it, with a new deadline.
+  const again = arbiter.next();
+  assert.ok(again);
+  assert.equal(again.id, offer.id);
+  assert.equal(again.turn.kind, ARRIVAL_SPEECH_KIND);
+  // A held beat was not spent: had it been, the repeat request would be dropped
+  // — instead it is deduped against the pending one, and the count holds.
+  arbiter.request({ kind: ARRIVAL_SPEECH_KIND });
+  assert.equal(arbiter.pendingCount, 2);
+});
+
+test("settle STALE ends the request and spends a beat", () => {
+  const { arbiter } = harness();
+  arbiter.request({ kind: CALENDAR_ONBOARDING_SPEECH_KIND });
+  const offer = arbiter.next();
+  assert.ok(offer);
+  assert.equal(arbiter.settle(offer.id, SPEECH_OUTCOME.STALE)?.outcome, SPEECH_OUTCOME.STALE);
+  assert.equal(arbiter.pendingCount, 0);
+  arbiter.request({ kind: CALENDAR_ONBOARDING_SPEECH_KIND });
+  assert.equal(arbiter.pendingCount, 0, "spent for the run");
+});
+
+test("settle REFUSED ends every pending request and spends the pending beats", () => {
+  const { arbiter, traces } = harness();
+  requestBriefing(arbiter, "a");
+  requestBriefing(arbiter, "b");
+  arbiter.request({ kind: ARRIVAL_SPEECH_KIND });
+  const offer = arbiter.next();
+  assert.ok(offer);
+  const settled = arbiter.settle(offer.id, SPEECH_OUTCOME.REFUSED);
+  assert.equal(settled?.outcome, SPEECH_OUTCOME.REFUSED);
+  assert.equal(arbiter.pendingCount, 0);
+  assert.equal(traces.filter((record) => record.decision === SPEECH_OUTCOME.REFUSED).length, 3);
+  arbiter.request({ kind: ARRIVAL_SPEECH_KIND });
+  assert.equal(arbiter.pendingCount, 0, "a refused beat is spent for the run");
+  // Fresh news starts a fresh backlog.
+  requestBriefing(arbiter, "c");
+  assert.equal(offeredWords(arbiter), "c");
+});
+
+test("an unknown id is ignored, whether never offered, withdrawn, or already settled", () => {
+  const { arbiter } = harness();
+  requestBriefing(arbiter, "a");
+  assert.equal(arbiter.settle("nobody", SPEECH_OUTCOME.SPOKEN), undefined);
+  const offer = arbiter.next();
+  assert.ok(offer);
+  assert.equal(arbiter.settle("nobody", SPEECH_OUTCOME.SPOKEN), undefined);
+  assert.equal(arbiter.offeredId, offer.id, "a stray report does not clear the real offer");
+  arbiter.settle(offer.id, SPEECH_OUTCOME.SPOKEN);
+  assert.equal(arbiter.settle(offer.id, SPEECH_OUTCOME.REFUSED), undefined);
+});
+
+test("retract removes a pending beat silently and names an offered one for withdrawal", () => {
+  const { arbiter } = harness();
+  arbiter.request({ kind: CALENDAR_ONBOARDING_SPEECH_KIND });
+  assert.equal(arbiter.retract(CALENDAR_ONBOARDING_SPEECH_KIND), undefined);
+  assert.equal(arbiter.pendingCount, 0);
+  assert.equal(arbiter.retract(CALENDAR_ONBOARDING_SPEECH_KIND), undefined);
+
+  arbiter.request({ kind: CALENDAR_ONBOARDING_SPEECH_KIND });
+  const offer = arbiter.next();
+  assert.ok(offer);
+  assert.equal(arbiter.retract(CALENDAR_ONBOARDING_SPEECH_KIND), offer.id);
+  assert.equal(arbiter.offeredId, undefined);
+  // A late settle for the withdrawn offer is ignored; withdrawal spent nothing.
+  assert.equal(arbiter.settle(offer.id, SPEECH_OUTCOME.SPOKEN), undefined);
+  arbiter.request({ kind: CALENDAR_ONBOARDING_SPEECH_KIND });
+  assert.equal(arbiter.pendingCount, 1);
+});
+
+test("an offer past its deadline with no settle is reclaimed stale and the head re-offered", () => {
+  const { arbiter, clock, traces } = harness(1_000);
+  requestBriefing(arbiter, "lost", 1_000);
+  clock.now = 1_500;
+  requestBriefing(arbiter, "next", 1_500);
+  const lost = arbiter.next();
+  assert.ok(lost);
+  // The renderer reloaded: no settle ever comes. Before the deadline, the
+  // arbiter waits on it.
+  clock.now = lost.speakBy;
+  assert.equal(arbiter.next(), undefined);
+
+  clock.now = lost.speakBy + 1;
+  const reoffered = arbiter.next();
+  assert.ok(reoffered && isBriefingSpeech(reoffered.turn));
+  assert.equal(reoffered.turn.briefing, "next");
+  assert.notEqual(reoffered.id, lost.id);
+  assert.equal(traces.filter((record) => record.decision === SPEECH_OUTCOME.STALE).length, 1);
+  assert.equal(
+    arbiter.settle(lost.id, SPEECH_OUTCOME.SPOKEN),
+    undefined,
+    "the late report is ignored",
+  );
+});
+
+test("every trace record carries a kind, a decision, and a count, and never the words", () => {
+  const { arbiter, clock, traces } = harness();
+  requestBriefing(arbiter, "the secret sentence");
+  arbiter.request({ kind: ARRIVAL_SPEECH_KIND });
+  arbiter.request({ kind: ARRIVAL_SPEECH_KIND });
+  const offer = arbiter.next();
+  assert.ok(offer);
+  arbiter.settle(offer.id, SPEECH_OUTCOME.SPOKEN);
+  arbiter.setQuiet(true);
+  arbiter.setQuiet(false);
+  clock.now += SPOKEN_NOTICE_MAX_AGE_MS + 1;
+  arbiter.next();
+  arbiter.dropBriefings();
+
+  assert.ok(traces.length >= 5);
+  const decisions = new Set<string>(Object.values(SPEECH_DECISION));
+  for (const record of traces) {
+    assert.deepEqual(Object.keys(record).sort(), ["decision", "kind", "pendingCount"]);
+    assert.ok(decisions.has(record.decision));
+    assert.ok(Number.isInteger(record.pendingCount) && record.pendingCount >= 0);
+    assert.equal("briefing" in record, false);
+    assert.equal(JSON.stringify(record).includes("secret"), false);
+  }
+});

--- a/apps/desktop/src/main/speech-arbiter.ts
+++ b/apps/desktop/src/main/speech-arbiter.ts
@@ -1,0 +1,355 @@
+import type { BrainDelivery } from "@sidecar/brain";
+import type { SpeechTraceRecord } from "@sidecar/devtrace";
+import {
+  ARRIVAL_SPEECH_KIND,
+  BRIEFING_SPEECH_KIND,
+  CALENDAR_ONBOARDING_SPEECH_KIND,
+  type ProactiveSpeechTurn,
+} from "@sidecar/realtime";
+import { SPEECH_OUTCOME, type SpeechOffer, type SpeechOutcome } from "#shared/wire/speech";
+
+/**
+ * How long a proactive turn stays worth saying. News about a session is news
+ * for minutes, not for whenever a long conversation happens to end: a request
+ * older than this is settled stale rather than read out as though it just
+ * happened — the panel has shown the state the whole time. The same window
+ * is the offer's deadline: an offer the mouth never settled, because the
+ * renderer that held it reloaded or crashed, is reclaimed here when it
+ * passes, and the next request is offered in its place.
+ */
+export const SPOKEN_NOTICE_MAX_AGE_MS = 2 * 60_000;
+
+/**
+ * How many briefings wait, whether through a meeting's quiet or behind a long
+ * reply. A backlog that outlives the news is a backlog that would replay the
+ * morning: the brain re-decides a held backlog in one turn at the release and
+ * the mouth reads a live one in order, and either wants the recent few.
+ */
+export const MAXIMUM_PENDING_BRIEFINGS = 8;
+
+export type SpeechKind = ProactiveSpeechTurn["kind"];
+
+/** The scripted beats, each spoken at most once to the end per run. */
+export type OnboardingBeatKind = Exclude<SpeechKind, typeof BRIEFING_SPEECH_KIND>;
+
+/**
+ * What the arbiter decided about a request, as the development trace records
+ * it: the four outcomes the mouth can report, plus the three moments only the
+ * arbiter sees. Nothing worded is ever traced beside one.
+ */
+export const SPEECH_DECISION = {
+  REQUESTED: "requested",
+  OFFERED: "offered",
+  DROPPED: "dropped",
+  ...SPEECH_OUTCOME,
+} as const;
+
+export type SpeechDecision = (typeof SPEECH_DECISION)[keyof typeof SPEECH_DECISION];
+
+/**
+ * One proactive turn waiting to be offered. A briefing keeps the whole
+ * delivery so the brain's hold release receives exactly what it decided; a
+ * beat is its kind alone, worded by the mouth at speak time from what the
+ * renderer already draws.
+ */
+export type SpeechRequest = {
+  id: string;
+  requestedAt: number;
+  /** Whether the request waits out the announcement hold rather than the clock. */
+  held: boolean;
+} & (
+  | { kind: typeof BRIEFING_SPEECH_KIND; delivery: BrainDelivery }
+  | { kind: typeof ARRIVAL_SPEECH_KIND }
+  | { kind: typeof CALENDAR_ONBOARDING_SPEECH_KIND }
+);
+
+export type SpeechRequestInput =
+  | { kind: typeof BRIEFING_SPEECH_KIND; delivery: BrainDelivery }
+  | { kind: OnboardingBeatKind };
+
+export interface SpeechSettlement {
+  kind: SpeechKind;
+  outcome: SpeechOutcome;
+  request: SpeechRequest;
+}
+
+export interface SpeechArbiterOptions {
+  now: () => number;
+  nextId: () => string;
+  trace?: (record: SpeechTraceRecord) => void;
+}
+
+function isBeat(request: SpeechRequest): request is SpeechRequest & { kind: OnboardingBeatKind } {
+  return request.kind !== BRIEFING_SPEECH_KIND;
+}
+
+/**
+ * The one owner of everything Luke says unprompted: which requests stand,
+ * in what order, whether now, and what became of each. The mouth in the
+ * renderer holds at most one offer at a time and reports its outcome by id;
+ * only then is the next offered. A renderer therefore holds nothing a reload
+ * or a hold can destroy, and a request that reached the mouth and came back
+ * held rejoins the head rather than dying in a queue the hold emptied.
+ *
+ * Quiet — the developer's pause or a meeting's — is applied here and only
+ * here: a request arriving under it, or standing when it begins, is marked
+ * held. A held beat is released with a fresh clock when the quiet ends. A
+ * held briefing is not spoken as it stood: it is handed back to the brain for
+ * one re-decision, because the sessions may have moved on while the meeting
+ * ran, and what the brain decides afresh arrives as a new request.
+ *
+ * A beat is spent for the run only by a terminal outcome — spoken, refused,
+ * or stale — never by being sent, held, or withdrawn, so a beat a meeting
+ * silenced speaks after the meeting instead of waiting for the next launch.
+ */
+export class SpeechArbiter {
+  readonly #options: SpeechArbiterOptions;
+  #pending: SpeechRequest[] = [];
+  /** The head request the mouth holds, and the deadline it was offered under. */
+  #offered: { id: string; speakBy: number } | undefined;
+  #quiet = false;
+  readonly #spentThisRun = new Set<OnboardingBeatKind>();
+
+  constructor(options: SpeechArbiterOptions) {
+    this.#options = options;
+  }
+
+  get quiet(): boolean {
+    return this.#quiet;
+  }
+
+  get pendingCount(): number {
+    return this.#pending.length;
+  }
+
+  get heldBriefingCount(): number {
+    return this.#heldBriefings().length;
+  }
+
+  get offeredId(): string | undefined {
+    return this.#offered?.id;
+  }
+
+  /**
+   * Takes one turn something decided to voice. A beat already pending,
+   * offered, or spent this run is dropped: each is one line, said once. A
+   * briefing joins the backlog, and the backlog sheds its oldest whole past
+   * the bound — a briefing is one sentence the brain already worded, with no
+   * half to keep — except the one the mouth already holds, which is settled
+   * by the mouth and never taken out from under it.
+   */
+  request(input: SpeechRequestInput): void {
+    const now = this.#options.now();
+    if (input.kind !== BRIEFING_SPEECH_KIND) {
+      const duplicate =
+        this.#spentThisRun.has(input.kind) ||
+        this.#pending.some((request) => request.kind === input.kind);
+      if (duplicate) {
+        this.#trace(input.kind, SPEECH_DECISION.DROPPED);
+        return;
+      }
+      this.#pending.push({
+        id: this.#options.nextId(),
+        requestedAt: now,
+        held: this.#quiet,
+        kind: input.kind,
+      });
+      this.#trace(input.kind, SPEECH_DECISION.REQUESTED);
+      return;
+    }
+    this.#pending.push({
+      id: this.#options.nextId(),
+      requestedAt: now,
+      held: this.#quiet,
+      kind: BRIEFING_SPEECH_KIND,
+      delivery: input.delivery,
+    });
+    this.#trace(BRIEFING_SPEECH_KIND, SPEECH_DECISION.REQUESTED);
+    let excess = this.#briefingCount() - MAXIMUM_PENDING_BRIEFINGS;
+    while (excess > 0) {
+      const oldest = this.#pending.find(
+        (request) => request.kind === BRIEFING_SPEECH_KIND && request.id !== this.#offered?.id,
+      );
+      if (!oldest) return;
+      this.#remove(oldest.id);
+      this.#trace(BRIEFING_SPEECH_KIND, SPEECH_DECISION.DROPPED);
+      excess -= 1;
+    }
+  }
+
+  /**
+   * Follows the announcement hold. Quiet beginning marks every pending
+   * request held; the one the mouth holds comes back through its HELD
+   * settle. Quiet ending releases the beats with a fresh clock, so a beat
+   * that waited out a meeting is not stale the moment it may speak; the
+   * briefings stay held until the brain takes them for its re-decision.
+   */
+  setQuiet(quiet: boolean): void {
+    if (quiet === this.#quiet) return;
+    this.#quiet = quiet;
+    if (quiet) {
+      for (const request of this.#pending) request.held = true;
+      return;
+    }
+    const now = this.#options.now();
+    for (const request of this.#pending) {
+      if (!isBeat(request)) continue;
+      request.held = false;
+      request.requestedAt = now;
+    }
+  }
+
+  /**
+   * Removes and returns the held briefings in the order they were decided,
+   * for the brain to re-decide as one backlog. One the mouth still holds is
+   * left for its settle, and is taken on the pass after it comes back.
+   */
+  takeHeldBriefings(): readonly BrainDelivery[] {
+    const taken = this.#heldBriefings();
+    for (const request of taken) this.#remove(request.id);
+    return taken.map((request) => request.delivery);
+  }
+
+  /**
+   * Discards every briefing that has not reached the mouth: no brain can
+   * stand to re-decide them, or the quiet that held them has lost its
+   * reason. One the mouth holds is settled by the mouth.
+   */
+  dropBriefings(): void {
+    for (const request of [...this.#pending]) {
+      if (request.kind !== BRIEFING_SPEECH_KIND || request.id === this.#offered?.id) continue;
+      this.#remove(request.id);
+      this.#trace(BRIEFING_SPEECH_KIND, SPEECH_DECISION.DROPPED);
+    }
+  }
+
+  /**
+   * Removes a pending beat whose reason has gone — the gate it explained
+   * stood down, the account it greeted signed out. Withdrawal does not spend
+   * the kind. When the beat was the one offered, its id is returned so the
+   * caller can take it back from the mouth as well.
+   */
+  retract(kind: OnboardingBeatKind): string | undefined {
+    const request = this.#pending.find((candidate) => candidate.kind === kind);
+    if (!request) return undefined;
+    const wasOffered = this.#offered?.id === request.id;
+    if (wasOffered) this.#offered = undefined;
+    this.#remove(request.id);
+    this.#trace(kind, SPEECH_DECISION.DROPPED);
+    return wasOffered ? request.id : undefined;
+  }
+
+  /**
+   * Offers the head request, or nothing. An outstanding offer whose deadline
+   * has passed unsettled is settled stale here first: this is the whole
+   * recovery from a renderer that reloaded, crashed, or lost the settle.
+   * Nothing is offered under quiet or while an offer stands. Unheld requests
+   * past their age are settled stale on the way; a held one waits out the
+   * hold, not the clock, and is never offered: a held beat is released by the
+   * quiet ending, and a held briefing belongs to the brain's re-decision.
+   */
+  next(): SpeechOffer | undefined {
+    const now = this.#options.now();
+    if (this.#offered && now > this.#offered.speakBy) {
+      this.#settleTerminal(this.#offered.id, SPEECH_OUTCOME.STALE);
+      this.#offered = undefined;
+    }
+    if (this.#quiet || this.#offered) return undefined;
+    for (const request of [...this.#pending]) {
+      if (request.held || now - this.#decidedAt(request) <= SPOKEN_NOTICE_MAX_AGE_MS) continue;
+      this.#settleTerminal(request.id, SPEECH_OUTCOME.STALE);
+    }
+    const head = this.#pending.find((request) => !request.held);
+    if (!head) return undefined;
+    const decidedAt = this.#decidedAt(head);
+    const offer: SpeechOffer = {
+      id: head.id,
+      speakBy: decidedAt + SPOKEN_NOTICE_MAX_AGE_MS,
+      turn: this.#turn(head),
+    };
+    this.#offered = { id: offer.id, speakBy: offer.speakBy };
+    this.#trace(head.kind, SPEECH_DECISION.OFFERED);
+    return offer;
+  }
+
+  /**
+   * Takes the mouth's report on the offer it holds. An id no longer known —
+   * withdrawn, or reclaimed at its deadline — is a late report and is
+   * ignored. SPOKEN and STALE end the request and spend a beat's kind. HELD
+   * keeps it at the head for the release. REFUSED is a call that could not
+   * be opened within its attempts, which ends every pending request: each is
+   * still standing in the panel, and a fresh request starts a fresh backlog.
+   */
+  settle(id: string, outcome: SpeechOutcome): SpeechSettlement | undefined {
+    if (this.#offered?.id !== id) return undefined;
+    const request = this.#pending.find((candidate) => candidate.id === id);
+    this.#offered = undefined;
+    if (!request) return undefined;
+    switch (outcome) {
+      case SPEECH_OUTCOME.HELD:
+        request.held = true;
+        this.#trace(request.kind, SPEECH_OUTCOME.HELD);
+        break;
+      case SPEECH_OUTCOME.SPOKEN:
+      case SPEECH_OUTCOME.STALE:
+        this.#settleTerminal(id, outcome);
+        break;
+      case SPEECH_OUTCOME.REFUSED:
+        for (const pending of [...this.#pending]) {
+          this.#settleTerminal(pending.id, SPEECH_OUTCOME.REFUSED);
+        }
+        break;
+    }
+    return { kind: request.kind, outcome, request };
+  }
+
+  #settleTerminal(id: string, outcome: SpeechOutcome): void {
+    const request = this.#pending.find((candidate) => candidate.id === id);
+    if (!request) return;
+    this.#remove(id);
+    if (isBeat(request)) this.#spentThisRun.add(request.kind);
+    this.#trace(request.kind, outcome);
+  }
+
+  #remove(id: string): void {
+    this.#pending = this.#pending.filter((request) => request.id !== id);
+  }
+
+  #briefingCount(): number {
+    return this.#pending.filter((request) => request.kind === BRIEFING_SPEECH_KIND).length;
+  }
+
+  #heldBriefings(): Array<SpeechRequest & { kind: typeof BRIEFING_SPEECH_KIND }> {
+    const held: Array<SpeechRequest & { kind: typeof BRIEFING_SPEECH_KIND }> = [];
+    for (const request of this.#pending) {
+      if (request.kind !== BRIEFING_SPEECH_KIND || !request.held) continue;
+      if (request.id === this.#offered?.id) continue;
+      held.push(request);
+    }
+    return held;
+  }
+
+  /** When the request became news: a briefing's decision, a beat's request. */
+  #decidedAt(request: SpeechRequest): number {
+    return request.kind === BRIEFING_SPEECH_KIND ? request.delivery.decidedAt : request.requestedAt;
+  }
+
+  #turn(request: SpeechRequest): ProactiveSpeechTurn {
+    switch (request.kind) {
+      case BRIEFING_SPEECH_KIND:
+        return {
+          kind: BRIEFING_SPEECH_KIND,
+          briefing: request.delivery.briefing,
+          decidedAt: request.delivery.decidedAt,
+        };
+      case ARRIVAL_SPEECH_KIND:
+        return { kind: ARRIVAL_SPEECH_KIND, decidedAt: request.requestedAt };
+      case CALENDAR_ONBOARDING_SPEECH_KIND:
+        return { kind: CALENDAR_ONBOARDING_SPEECH_KIND, decidedAt: request.requestedAt };
+    }
+  }
+
+  #trace(kind: SpeechKind, decision: SpeechDecision): void {
+    this.#options.trace?.({ kind, decision, pendingCount: this.#pending.length });
+  }
+}

--- a/apps/desktop/src/renderer/speech-mouth.test.ts
+++ b/apps/desktop/src/renderer/speech-mouth.test.ts
@@ -1,0 +1,636 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type {
+  BriefingSpeech,
+  ProactiveSpeechTurn,
+  RealtimeStatus,
+  ScheduledTimer,
+} from "@sidecar/realtime";
+import {
+  BRIEFING_SPEECH_KIND,
+  CALENDAR_ONBOARDING_SPEECH_KIND,
+  isBriefingSpeech,
+  REALTIME_STATUS,
+} from "@sidecar/realtime";
+import { SPEECH_OUTCOME, type SpeechOffer, type SpeechOutcome } from "#shared/wire/speech";
+import {
+  ANNOUNCER_GRACE_MS,
+  ANNOUNCER_LINGER_MS,
+  ANNOUNCER_RETRY_DELAY_MS,
+  MAXIMUM_CONNECT_ATTEMPTS,
+  SpeechMouth,
+  type SpeechMouthSession,
+} from "./speech-mouth";
+
+const FAR_DEADLINE = Number.MAX_SAFE_INTEGER;
+
+function speech(id: string, decidedAt = 1_000): BriefingSpeech {
+  return {
+    kind: BRIEFING_SPEECH_KIND,
+    briefing: `Claude Code finished ${id}.`,
+    decidedAt,
+  };
+}
+
+function offer(id: string, turn: ProactiveSpeechTurn = speech(id), speakBy = FAR_DEADLINE) {
+  return { id, speakBy, turn } satisfies SpeechOffer;
+}
+
+/** The ids the spoken briefings were worded about, in the order they were said. */
+function spokenIds(session: FakeSession): string[] {
+  return session.spoken.map((item) => /finished (.+)\.$/.exec(item.briefing)?.[1] ?? "");
+}
+
+interface FakeSession extends SpeechMouthSession {
+  spoken: BriefingSpeech[];
+  connects: number;
+  closes: number;
+  stops: number;
+  /** What the next connect resolves to; the call opens when it does. */
+  connectOpens: boolean;
+  setStatus(status: RealtimeStatus): void;
+  microphone: boolean;
+}
+
+function fakeSession(): FakeSession {
+  const session: FakeSession = {
+    spoken: [],
+    connects: 0,
+    closes: 0,
+    stops: 0,
+    connectOpens: true,
+    microphone: false,
+    status: REALTIME_STATUS.IDLE,
+    get isConnected() {
+      return this.status === REALTIME_STATUS.READY || this.status === REALTIME_STATUS.RESPONDING;
+    },
+    get isConnecting() {
+      return this.status === REALTIME_STATUS.CONNECTING;
+    },
+    get microphoneCall() {
+      return this.microphone;
+    },
+    setStatus(status: RealtimeStatus) {
+      // SAFETY: Fixture value matches the narrowed runtime shape this test exercises.
+      (this as { status: RealtimeStatus }).status = status;
+    },
+    async connect() {
+      this.connects += 1;
+      this.setStatus(this.connectOpens ? REALTIME_STATUS.READY : REALTIME_STATUS.UNAVAILABLE);
+      return this.connectOpens;
+    },
+    speak(item: ProactiveSpeechTurn) {
+      if (!this.isConnected || this.status === REALTIME_STATUS.RESPONDING) return false;
+      if (isBriefingSpeech(item)) this.spoken.push(item);
+      this.setStatus(REALTIME_STATUS.RESPONDING);
+      return true;
+    },
+    stopSpeaking() {
+      if (this.status !== REALTIME_STATUS.RESPONDING) return false;
+      this.stops += 1;
+      this.setStatus(REALTIME_STATUS.READY);
+      return true;
+    },
+    async close() {
+      this.closes += 1;
+      this.setStatus(REALTIME_STATUS.IDLE);
+    },
+  };
+  return session;
+}
+
+interface Timers {
+  schedule: (callback: () => void, delayMs: number) => ScheduledTimer;
+  cancel: (timer: ScheduledTimer) => void;
+  fire: () => void;
+  armed: () => number;
+  delays: number[];
+}
+
+function fakeTimers(): Timers {
+  const pending = new Map<ScheduledTimer, () => void>();
+  const delays: number[] = [];
+  let key = 0;
+  return {
+    schedule: (callback, delayMs) => {
+      delays.push(delayMs);
+      key += 1;
+      pending.set(key, callback);
+      return key;
+    },
+    cancel: (timer) => {
+      pending.delete(timer);
+    },
+    fire: () => {
+      for (const [id, callback] of [...pending]) {
+        pending.delete(id);
+        callback();
+      }
+    },
+    armed: () => pending.size,
+    delays,
+  };
+}
+
+interface Settlement {
+  id: string;
+  outcome: SpeechOutcome;
+}
+
+function mouth(session: FakeSession, timers: Timers, now = () => 1_000) {
+  const settled: Settlement[] = [];
+  const subject = new SpeechMouth({
+    session: () => session,
+    settle: (id, outcome) => settled.push({ id, outcome }),
+    now,
+    schedule: timers.schedule,
+    cancel: timers.cancel,
+  });
+  return { subject, settled };
+}
+
+test("an offer arriving into silence opens Luke's own call, is spoken, and settles SPOKEN", async () => {
+  const session = fakeSession();
+  const timers = fakeTimers();
+  const { subject, settled } = mouth(session, timers);
+
+  subject.offer(offer("a"));
+  assert.deepEqual(settled, [], "nothing is settled before the reply begins");
+  // Opening the call is a promise away, and only then is the offer flushed.
+  await Promise.resolve();
+
+  assert.equal(session.connects, 1);
+  assert.deepEqual(spokenIds(session), ["a"]);
+  assert.deepEqual(settled, [{ id: "a", outcome: SPEECH_OUTCOME.SPOKEN }]);
+});
+
+test("offers speak one per reply, in order, on one call", async () => {
+  const session = fakeSession();
+  const timers = fakeTimers();
+  const { subject, settled } = mouth(session, timers);
+
+  subject.offer(offer("a"));
+  await Promise.resolve();
+  assert.deepEqual(spokenIds(session), ["a"]);
+  // The arbiter offers the next once the first is settled; the reply is still
+  // under way, so the second waits for the READY edge.
+  assert.equal(settled.length, 1);
+  subject.offer(offer("b"));
+  assert.deepEqual(spokenIds(session), ["a"]);
+
+  session.setStatus(REALTIME_STATUS.READY);
+  subject.onStatus(REALTIME_STATUS.READY);
+  assert.deepEqual(spokenIds(session), ["a", "b"]);
+  // One call served both.
+  assert.equal(session.connects, 1);
+  assert.deepEqual(
+    settled.map((item) => item.id),
+    ["a", "b"],
+  );
+});
+
+test("the same offer again is the same offer", async () => {
+  const session = fakeSession();
+  const timers = fakeTimers();
+  const { subject, settled } = mouth(session, timers);
+
+  subject.offer(offer("a"));
+  subject.offer(offer("a"));
+  await Promise.resolve();
+  assert.equal(session.connects, 1);
+  assert.deepEqual(spokenIds(session), ["a"]);
+  assert.equal(settled.length, 1);
+});
+
+test("an offer whose deadline passed settles STALE without speaking", () => {
+  const session = fakeSession();
+  session.setStatus(REALTIME_STATUS.RESPONDING);
+  session.microphone = true;
+  const timers = fakeTimers();
+  let now = 10_000;
+  const { subject, settled } = mouth(session, timers, () => now);
+
+  // Arrives during a long reply and waits.
+  subject.offer(offer("a", speech("a", 10_000), 10_000 + 120_000));
+  assert.deepEqual(spokenIds(session), []);
+  assert.deepEqual(settled, []);
+
+  // By the time the turn ends, the news is old; the panel has shown the
+  // state the whole time, and the arbiter hears it went stale.
+  now = 10_000 + 120_000 + 1;
+  session.setStatus(REALTIME_STATUS.READY);
+  subject.onStatus(REALTIME_STATUS.READY);
+  assert.deepEqual(spokenIds(session), []);
+  assert.deepEqual(settled, [{ id: "a", outcome: SPEECH_OUTCOME.STALE }]);
+  // The retry clock armed mid-reply fires into an empty hand and says nothing.
+  timers.fire();
+  assert.deepEqual(spokenIds(session), []);
+  assert.equal(settled.length, 1);
+});
+
+test("withdraw drops an unspoken offer without a settle and leaves a begun reply alone", async () => {
+  const session = fakeSession();
+  const timers = fakeTimers();
+  const { subject, settled } = mouth(session, timers);
+
+  subject.offer(offer("beat", { kind: CALENDAR_ONBOARDING_SPEECH_KIND, decidedAt: 1_000 }));
+  await Promise.resolve();
+  // The beat began; withdrawing an id that already settled changes nothing.
+  assert.deepEqual(settled, [{ id: "beat", outcome: SPEECH_OUTCOME.SPOKEN }]);
+  subject.withdraw("beat");
+  assert.equal(session.stops, 0, "a reply begun is delivered");
+
+  // The next offer waits behind the reply; the gate settles before it can
+  // speak, and it is taken back unsaid and unsettled.
+  subject.offer(offer("second", { kind: CALENDAR_ONBOARDING_SPEECH_KIND, decidedAt: 1_000 }));
+  subject.withdraw("second");
+  session.setStatus(REALTIME_STATUS.READY);
+  subject.onStatus(REALTIME_STATUS.READY);
+  assert.equal(settled.length, 1);
+  assert.equal(session.status, REALTIME_STATUS.READY, "nothing spoke into the empty hand");
+  // An empty hand on Luke's own call starts the linger, as an empty queue did.
+  assert.deepEqual(timers.delays.slice(-1), [ANNOUNCER_LINGER_MS]);
+});
+
+test("the call Luke opened lingers for stragglers, then closes itself", async () => {
+  const session = fakeSession();
+  const timers = fakeTimers();
+  const { subject } = mouth(session, timers);
+
+  subject.offer(offer("a"));
+  await Promise.resolve();
+  session.setStatus(REALTIME_STATUS.READY);
+  subject.onStatus(REALTIME_STATUS.READY);
+
+  // Everything said: the linger is armed rather than the call slammed shut.
+  assert.equal(timers.armed(), 1);
+  assert.deepEqual(timers.delays, [ANNOUNCER_LINGER_MS]);
+  assert.equal(session.closes, 0);
+
+  // A straggler cancels the linger and rides the same call.
+  subject.offer(offer("b"));
+  assert.equal(timers.armed(), 0);
+  assert.equal(session.connects, 1);
+
+  session.setStatus(REALTIME_STATUS.READY);
+  subject.onStatus(REALTIME_STATUS.READY);
+  timers.fire();
+  assert.equal(session.closes, 1);
+});
+
+test("an offer riding the developer's call never closes it", () => {
+  const session = fakeSession();
+  session.microphone = true;
+  session.setStatus(REALTIME_STATUS.READY);
+  const timers = fakeTimers();
+  const { subject } = mouth(session, timers);
+
+  subject.offer(offer("a"));
+  assert.equal(session.connects, 0, "the open call is used, not replaced");
+  assert.deepEqual(spokenIds(session), ["a"]);
+
+  session.setStatus(REALTIME_STATUS.READY);
+  subject.onStatus(REALTIME_STATUS.READY);
+  // No linger is ever armed against the developer's own call.
+  assert.equal(timers.armed(), 0);
+  timers.fire();
+  assert.equal(session.closes, 0);
+});
+
+test("a refused call keeps the offer and speaks it on the retry", async () => {
+  const session = fakeSession();
+  session.connectOpens = false;
+  const timers = fakeTimers();
+  const { subject, settled } = mouth(session, timers);
+
+  subject.offer(offer("a"));
+  await Promise.resolve();
+  subject.onStatus(REALTIME_STATUS.UNAVAILABLE);
+
+  // The refusal armed the retry clock instead of settling the offer.
+  assert.equal(session.connects, 1);
+  assert.equal(timers.armed(), 1);
+  assert.deepEqual(timers.delays, [ANNOUNCER_RETRY_DELAY_MS]);
+  assert.deepEqual(settled, []);
+
+  // The rate limit lifted; the retry delivers the same offer.
+  session.connectOpens = true;
+  timers.fire();
+  await Promise.resolve();
+  assert.equal(session.connects, 2);
+  assert.deepEqual(spokenIds(session), ["a"]);
+  assert.deepEqual(settled, [{ id: "a", outcome: SPEECH_OUTCOME.SPOKEN }]);
+});
+
+test("an offer that outlives its attempts settles REFUSED, not retried into a loop", async () => {
+  const session = fakeSession();
+  session.connectOpens = false;
+  const timers = fakeTimers();
+  const { subject, settled } = mouth(session, timers);
+
+  subject.offer(offer("a"));
+  await Promise.resolve();
+  subject.onStatus(REALTIME_STATUS.UNAVAILABLE);
+  for (let attempt = 1; attempt < MAXIMUM_CONNECT_ATTEMPTS; attempt += 1) {
+    timers.fire();
+    await Promise.resolve();
+    subject.onStatus(REALTIME_STATUS.UNAVAILABLE);
+  }
+  assert.equal(session.connects, MAXIMUM_CONNECT_ATTEMPTS);
+
+  // The final refusal spent the attempts: the offer is handed back refused
+  // and no clock is left ticking for it.
+  assert.deepEqual(settled, [{ id: "a", outcome: SPEECH_OUTCOME.REFUSED }]);
+  assert.equal(timers.armed(), 0);
+  timers.fire();
+  await Promise.resolve();
+  assert.equal(session.connects, MAXIMUM_CONNECT_ATTEMPTS);
+
+  // A later offer starts with fresh attempts.
+  session.connectOpens = true;
+  subject.offer(offer("b"));
+  await Promise.resolve();
+  assert.deepEqual(spokenIds(session), ["b"]);
+});
+
+test("an offer arriving right after a refused one is kept, not refused with it", async () => {
+  const session = fakeSession();
+  session.connectOpens = false;
+  const timers = fakeTimers();
+  const { subject, settled } = mouth(session, timers);
+
+  subject.offer(offer("a"));
+  await Promise.resolve();
+  for (let attempt = 1; attempt < MAXIMUM_CONNECT_ATTEMPTS; attempt += 1) {
+    timers.fire();
+    await Promise.resolve();
+  }
+  assert.equal(session.connects, MAXIMUM_CONNECT_ATTEMPTS);
+  assert.deepEqual(settled, [{ id: "a", outcome: SPEECH_OUTCOME.REFUSED }]);
+
+  // Fresh news arriving before any clock ticks must find a fresh counter,
+  // not die against the one the refused offer left behind.
+  session.connectOpens = true;
+  subject.offer(offer("b"));
+  await Promise.resolve();
+  assert.deepEqual(spokenIds(session), ["b"]);
+});
+
+test("an offer stranded by a call that ended is picked up by the retry clock", async () => {
+  const session = fakeSession();
+  session.microphone = true;
+  session.setStatus(REALTIME_STATUS.RESPONDING);
+  const timers = fakeTimers();
+  const { subject } = mouth(session, timers);
+
+  // Arrives mid-reply on the developer's call and waits its turn.
+  subject.offer(offer("a"));
+  assert.deepEqual(spokenIds(session), []);
+
+  // The developer hangs up before the turn ends; the offer survives.
+  session.microphone = false;
+  session.setStatus(REALTIME_STATUS.IDLE);
+  subject.onStatus(REALTIME_STATUS.IDLE);
+  assert.equal(timers.armed(), 1);
+
+  timers.fire();
+  await Promise.resolve();
+  assert.equal(session.connects, 1);
+  assert.deepEqual(spokenIds(session), ["a"]);
+});
+
+test("an offer refused mid-reply keeps a clock of its own beside the READY edge", () => {
+  const session = fakeSession();
+  session.microphone = true;
+  session.setStatus(REALTIME_STATUS.RESPONDING);
+  const timers = fakeTimers();
+  const { subject } = mouth(session, timers);
+
+  // Arrives mid-reply and is refused the turn. The READY edge is the
+  // session's promise, not this class's, so the offer arms its own retry
+  // rather than depending on that edge alone.
+  subject.offer(offer("a"));
+  assert.deepEqual(spokenIds(session), []);
+  assert.equal(timers.armed(), 1);
+  assert.deepEqual(timers.delays, [ANNOUNCER_RETRY_DELAY_MS]);
+
+  // The edge never lands; the clock fires into a call that has since settled
+  // and the offer is spoken rather than stranded.
+  session.setStatus(REALTIME_STATUS.READY);
+  timers.fire();
+  assert.deepEqual(spokenIds(session), ["a"]);
+});
+
+test("quiet beginning cuts the reply mid-sentence, closes Luke's own call, and hands back the unspoken offer HELD", async () => {
+  const session = fakeSession();
+  const timers = fakeTimers();
+  const { subject, settled } = mouth(session, timers);
+
+  // Mid-briefing on Luke's own call, with the next offer waiting behind it.
+  subject.offer(offer("a"));
+  await Promise.resolve();
+  subject.offer(offer("b"));
+  assert.equal(session.status, REALTIME_STATUS.RESPONDING);
+
+  subject.setHeld(true);
+  assert.equal(session.stops, 1, "the reply under way is cut off");
+  assert.equal(session.closes, 1, "the call Luke opened is closed");
+  // The spoken one was already settled; the unspoken one goes back held
+  // rather than being dropped, for the arbiter to keep until the release.
+  assert.deepEqual(settled, [
+    { id: "a", outcome: SPEECH_OUTCOME.SPOKEN },
+    { id: "b", outcome: SPEECH_OUTCOME.HELD },
+  ]);
+
+  // Quiet ending finds nothing in hand and no clock ticking.
+  subject.onStatus(REALTIME_STATUS.IDLE);
+  subject.setHeld(false);
+  assert.equal(timers.armed(), 0);
+  assert.equal(session.connects, 1);
+  assert.deepEqual(spokenIds(session), ["a"]);
+
+  // Quiet over, the arbiter offers again — the release arrives exactly here.
+  subject.offer(offer("c"));
+  await Promise.resolve();
+  assert.deepEqual(spokenIds(session), ["a", "c"]);
+});
+
+test("an offer arriving under the quiet never opens a call and is handed back HELD", async () => {
+  const session = fakeSession();
+  const timers = fakeTimers();
+  const { subject, settled } = mouth(session, timers);
+
+  subject.setHeld(true);
+  subject.offer(offer("a"));
+  await Promise.resolve();
+
+  assert.equal(session.connects, 0);
+  assert.deepEqual(spokenIds(session), []);
+  assert.equal(timers.armed(), 0);
+  assert.deepEqual(settled, [{ id: "a", outcome: SPEECH_OUTCOME.HELD }]);
+});
+
+test("quiet beginning never touches the developer's own call", () => {
+  const session = fakeSession();
+  session.microphone = true;
+  session.setStatus(REALTIME_STATUS.RESPONDING);
+  const timers = fakeTimers();
+  const { subject, settled } = mouth(session, timers);
+
+  // Waiting out the developer's reply when the quiet lands.
+  subject.offer(offer("a"));
+  assert.deepEqual(spokenIds(session), []);
+
+  subject.setHeld(true);
+  assert.equal(session.stops, 0, "the developer's reply is theirs to finish");
+  assert.equal(session.closes, 0);
+
+  // The waiting offer is handed back held rather than read after the reply.
+  assert.deepEqual(settled, [{ id: "a", outcome: SPEECH_OUTCOME.HELD }]);
+  assert.equal(timers.armed(), 0);
+  session.setStatus(REALTIME_STATUS.READY);
+  subject.onStatus(REALTIME_STATUS.READY);
+  assert.deepEqual(spokenIds(session), []);
+});
+
+test("an offer waits out the developer's floor after Luke answers them", () => {
+  const session = fakeSession();
+  session.microphone = true;
+  const timers = fakeTimers();
+  let now = 1_000;
+  const { subject } = mouth(session, timers, () => now);
+
+  // A full exchange: the developer asks, Luke answers, the reply ends.
+  session.setStatus(REALTIME_STATUS.LISTENING);
+  subject.onStatus(REALTIME_STATUS.LISTENING);
+  session.setStatus(REALTIME_STATUS.RESPONDING);
+  subject.onStatus(REALTIME_STATUS.RESPONDING);
+
+  // News arrives mid-reply: the pause belongs to the developer's next ask,
+  // not to the offer.
+  subject.offer(offer("a"));
+  session.setStatus(REALTIME_STATUS.READY);
+  subject.onStatus(REALTIME_STATUS.READY);
+  assert.deepEqual(spokenIds(session), []);
+
+  // Half the window passes in silence; the offer still may not speak.
+  now = 1_000 + ANNOUNCER_GRACE_MS / 2;
+  timers.fire();
+  assert.deepEqual(spokenIds(session), []);
+
+  // The developer left the pause empty; the waiting offer takes it.
+  now = 1_000 + ANNOUNCER_GRACE_MS;
+  timers.fire();
+  assert.deepEqual(spokenIds(session), ["a"]);
+
+  // The next offer keeps its own readout after the first one ends.
+  subject.offer(offer("b"));
+  session.setStatus(REALTIME_STATUS.READY);
+  subject.onStatus(REALTIME_STATUS.READY);
+  assert.deepEqual(spokenIds(session), ["a", "b"]);
+});
+
+test("the developer speaking inside the window keeps the floor theirs", () => {
+  const session = fakeSession();
+  session.microphone = true;
+  const timers = fakeTimers();
+  let now = 1_000;
+  const { subject } = mouth(session, timers, () => now);
+
+  session.setStatus(REALTIME_STATUS.RESPONDING);
+  subject.onStatus(REALTIME_STATUS.RESPONDING);
+  subject.offer(offer("s"));
+  session.setStatus(REALTIME_STATUS.READY);
+  subject.onStatus(REALTIME_STATUS.READY);
+  assert.deepEqual(spokenIds(session), []);
+
+  // The developer takes the turn inside the window — the grace did its job —
+  // and Luke's answer to them ends with a fresh window, not a spent one.
+  now = 1_000 + ANNOUNCER_GRACE_MS / 2;
+  session.setStatus(REALTIME_STATUS.LISTENING);
+  subject.onStatus(REALTIME_STATUS.LISTENING);
+  session.setStatus(REALTIME_STATUS.RESPONDING);
+  subject.onStatus(REALTIME_STATUS.RESPONDING);
+  session.setStatus(REALTIME_STATUS.READY);
+  subject.onStatus(REALTIME_STATUS.READY);
+  timers.fire();
+  assert.deepEqual(spokenIds(session), []);
+
+  // Only the pause after the second answer, left empty, is spoken into.
+  now = 1_000 + ANNOUNCER_GRACE_MS / 2 + ANNOUNCER_GRACE_MS;
+  timers.fire();
+  assert.deepEqual(spokenIds(session), ["s"]);
+});
+
+test("the retry clock respects the developer's floor", () => {
+  const session = fakeSession();
+  session.microphone = true;
+  session.setStatus(REALTIME_STATUS.RESPONDING);
+  const timers = fakeTimers();
+  let now = 1_000;
+  const { subject } = mouth(session, timers, () => now);
+
+  subject.onStatus(REALTIME_STATUS.RESPONDING);
+  subject.offer(offer("a"));
+  session.setStatus(REALTIME_STATUS.READY);
+  subject.onStatus(REALTIME_STATUS.READY);
+
+  // Every armed clock firing inside the window still finds the floor held.
+  now = 1_000 + ANNOUNCER_GRACE_MS - 1;
+  timers.fire();
+  assert.deepEqual(spokenIds(session), []);
+
+  now = 1_000 + ANNOUNCER_GRACE_MS;
+  timers.fire();
+  assert.deepEqual(spokenIds(session), ["a"]);
+});
+
+test("an offer on Luke's own call speaks without the developer's window", async () => {
+  const session = fakeSession();
+  const timers = fakeTimers();
+  const { subject } = mouth(session, timers);
+
+  // Nobody is conversing: the window guards the developer's next ask, and
+  // on Luke's own call there is no ask to guard.
+  subject.offer(offer("a"));
+  await Promise.resolve();
+  subject.onStatus(REALTIME_STATUS.READY);
+  assert.deepEqual(spokenIds(session), ["a"]);
+});
+
+test("the developer taking the turn stands the grace clock down", () => {
+  const session = fakeSession();
+  session.microphone = true;
+  const timers = fakeTimers();
+  let now = 1_000;
+  const { subject } = mouth(session, timers, () => now);
+
+  session.setStatus(REALTIME_STATUS.RESPONDING);
+  subject.onStatus(REALTIME_STATUS.RESPONDING);
+  subject.offer(offer("a"));
+  session.setStatus(REALTIME_STATUS.READY);
+  subject.onStatus(REALTIME_STATUS.READY);
+  const armedDuringWindow = timers.armed();
+
+  // The press is what the window waited for: the clock aimed at the pause
+  // stands down rather than firing into the developer's own turn.
+  session.setStatus(REALTIME_STATUS.LISTENING);
+  subject.onStatus(REALTIME_STATUS.LISTENING);
+  assert.ok(timers.armed() < armedDuringWindow);
+
+  // Every clock still standing fires into the busy turn and speaks nothing.
+  session.setStatus(REALTIME_STATUS.RESPONDING);
+  subject.onStatus(REALTIME_STATUS.RESPONDING);
+  now = 1_000 + ANNOUNCER_GRACE_MS * 2;
+  timers.fire();
+  assert.deepEqual(spokenIds(session), []);
+
+  // The answer's own end opens the next window, on a clock of its own.
+  session.setStatus(REALTIME_STATUS.READY);
+  subject.onStatus(REALTIME_STATUS.READY);
+  timers.fire();
+  assert.deepEqual(spokenIds(session), []);
+  now = 1_000 + ANNOUNCER_GRACE_MS * 3;
+  timers.fire();
+  assert.deepEqual(spokenIds(session), ["a"]);
+});

--- a/apps/desktop/src/renderer/speech-mouth.ts
+++ b/apps/desktop/src/renderer/speech-mouth.ts
@@ -1,0 +1,395 @@
+import type { ProactiveSpeechTurn, RealtimeStatus, ScheduledTimer } from "@sidecar/realtime";
+import { REALTIME_STATUS } from "@sidecar/realtime";
+import { SPEECH_OUTCOME, type SpeechOffer, type SpeechOutcome } from "#shared/wire/speech";
+
+/**
+ * How long Luke's own call lingers once what it was opened for has been said.
+ * Sessions finish in clusters — one merge often ends three agents — so the
+ * call waits for the stragglers rather than paying the handshake three times,
+ * and then puts itself away.
+ */
+export const ANNOUNCER_LINGER_MS = 60_000;
+
+/**
+ * How long an offer waits after a refused call before trying again. The
+ * refusal this exists for is the transient kind — a rate limit at the voice
+ * service, a network mid-blink — where seconds are the difference between an
+ * announcement arriving late and not arriving at all.
+ */
+export const ANNOUNCER_RETRY_DELAY_MS = 20_000;
+
+/**
+ * How many times one offer may try to open Luke's own call. Together with the
+ * offer's own deadline this is what keeps a persistent refusal from becoming
+ * a loop: the attempts run out and the offer is settled refused, and anything
+ * the arbiter still holds has aged out of being news long before a fourth try
+ * could matter.
+ */
+export const MAXIMUM_CONNECT_ATTEMPTS = 3;
+
+/**
+ * How long the developer keeps the floor once Luke has answered them. A reply
+ * invites the next ask, and an announcement speaking into that pause takes
+ * the very turn the developer was about to open — so the mouth waits, and
+ * only a pause the developer leaves empty is announced into. Luke's own
+ * announcements chain without waiting: the readout is already his turn, and
+ * a backlog read one sentence per window would outlive its own news.
+ */
+export const ANNOUNCER_GRACE_MS = 10_000;
+
+/**
+ * The slice of the voice session the mouth drives. `microphoneCall` is the
+ * ownership question: true means the call up or coming is the developer's own,
+ * which the mouth may speak on but must never close.
+ */
+export interface SpeechMouthSession {
+  readonly isConnected: boolean;
+  readonly isConnecting: boolean;
+  readonly status: RealtimeStatus;
+  readonly microphoneCall: boolean;
+  connect(options: { microphone: false }): Promise<boolean>;
+  speak(speech: ProactiveSpeechTurn): boolean;
+  stopSpeaking(): boolean;
+  close(): Promise<void>;
+}
+
+export interface SpeechMouthOptions {
+  session: () => SpeechMouthSession;
+  /** Reports what became of an offer, by its id, so the arbiter can offer the next. */
+  settle: (id: string, outcome: SpeechOutcome) => void;
+  now?: () => number;
+  schedule?: (callback: () => void, delayMs: number) => ScheduledTimer;
+  cancel?: (timer: ScheduledTimer) => void;
+}
+
+/**
+ * Speaks the one proactive turn the speech arbiter has offered, whether or
+ * not a conversation is open, and reports what became of it. The mouth holds
+ * no backlog: the arbiter in the main process owns every pending request and
+ * offers the next only once this one is settled, so nothing a reload, a
+ * hold, or a refused call meets here is anything but the one offer in hand.
+ *
+ * An offer arriving while the developer's call is up rides it. One arriving
+ * into silence is what this class exists for: it opens a call of Luke's own —
+ * speak-only, no microphone, no context — says the turn as one reply, lingers
+ * briefly for the next offer the same cluster of finishes usually brings, and
+ * closes the call it opened. It never closes the developer's call.
+ *
+ * A call that is refused keeps the offer and tries again on a short clock,
+ * because the refusal this path actually meets is transient — a rate limit,
+ * a network mid-blink — and a first-try-only mouth turns each one into
+ * permanent silence. The retry cannot become a loop: the attempts are capped
+ * per offer, and past them the offer is settled refused rather than kept.
+ *
+ * The announcement hold reaches it through {@link setHeld}: a hold beginning
+ * — the developer's pause or a meeting's quiet — silences it at once, the
+ * announcement mid-sentence on Luke's own call included, and hands an offer
+ * not yet begun back to the arbiter as held, where it waits for the release.
+ *
+ * On the developer's own call, a reply Luke just gave them holds the offer
+ * for {@link ANNOUNCER_GRACE_MS}: the pause after an answer is where the
+ * developer's next ask lives, and an announcement speaking into it takes
+ * that turn from them. Luke's own announcements chain without the wait — the
+ * readout is already his turn.
+ */
+export class SpeechMouth {
+  readonly #options: SpeechMouthOptions;
+  /** The one offer in hand, until it is spoken, refused, held, stale, or withdrawn. */
+  #current: SpeechOffer | undefined;
+  /** Whether the call now up is one this mouth opened, and so must close. */
+  #ownsCall = false;
+  /** The last status seen, which tells a reply's READY from a connect's. */
+  #lastStatus: RealtimeStatus | undefined;
+  /** Whether the reply now under way — or just ended — is one this mouth spoke. */
+  #ownReply = false;
+  /** Until when the developer keeps the floor, as the injected clock reads it. */
+  #holdUntil = 0;
+  #holdTimer: unknown;
+  #lingerTimer: unknown;
+  /** How many times the offer now in hand has tried to open Luke's own call. */
+  #connectAttempts = 0;
+  #retryTimer: unknown;
+  /** Whether the meeting quiet is holding, which silences this mouth. */
+  #quiet = false;
+
+  constructor(options: SpeechMouthOptions) {
+    this.#options = options;
+  }
+
+  /**
+   * Follows the announcement hold the main process decided. A hold beginning
+   * — the pause switched on, the quiet switched on mid-meeting, or a meeting
+   * starting under it — is asked-for silence right now: the announcement
+   * mid-sentence on Luke's own call is cut off and the call closed rather
+   * than left lingering into the hold, and an offer not yet begun goes back
+   * to the arbiter as held rather than being dropped — it is the arbiter's
+   * to keep for the release. The developer's own call is never touched: a
+   * conversation they are holding passes, held or not. A hold ending needs
+   * no act here — the arbiter offers what it held when the quiet ends.
+   */
+  setHeld(active: boolean): void {
+    this.#quiet = active;
+    if (!active) return;
+    this.#settleCurrent(SPEECH_OUTCOME.HELD);
+    this.#connectAttempts = 0;
+    this.#cancelRetry();
+    this.#cancelHold();
+    this.#cancelLinger();
+    if (!this.#ownsCall) return;
+    this.#ownsCall = false;
+    const session = this.#options.session();
+    if (session.microphoneCall) return;
+    session.stopSpeaking();
+    void session.close();
+  }
+
+  /**
+   * Takes the one turn the arbiter decided to voice, and starts saying it. The
+   * same offer again is the same offer; the arbiter never sends a second while
+   * one is outstanding, so there is no displacement to decide. Under quiet
+   * the offer is handed straight back as held.
+   */
+  offer(offer: SpeechOffer): void {
+    if (this.#current?.id === offer.id) return;
+    if (this.#quiet) {
+      this.#options.settle(offer.id, SPEECH_OUTCOME.HELD);
+      return;
+    }
+    this.#current = offer;
+    this.#connectAttempts = 0;
+    this.#cancelLinger();
+    this.#flush();
+  }
+
+  /**
+   * Takes back an offer not yet begun: the beat's reason has gone, and a
+   * sentence asking for what was just given would speak over the answer. No
+   * settle is reported — the arbiter already forgot the id. A reply already
+   * begun is not this offer any more and finishes.
+   */
+  withdraw(id: string): void {
+    if (this.#current?.id !== id) return;
+    this.#current = undefined;
+    this.#connectAttempts = 0;
+    this.#cancelRetry();
+    this.#armLinger();
+  }
+
+  /**
+   * Follows the session's status, which is the mouth's only clock: READY
+   * is when the offer in hand can be spoken and when an empty hand starts the
+   * linger toward closing Luke's own call.
+   */
+  onStatus(status: RealtimeStatus): void {
+    const previous = this.#lastStatus;
+    this.#lastStatus = status;
+    // The developer's call replaced or absorbed Luke's; nothing here may
+    // close it, however it ends.
+    if (this.#options.session().microphoneCall) {
+      this.#ownsCall = false;
+      this.#cancelLinger();
+    }
+    // The developer taking the turn is the very act the floor was theirs for:
+    // whatever reply follows is an answer to them, not a readout, and the
+    // clock waiting to speak into their pause has nothing left to wait for —
+    // the reply's own end starts the next window.
+    if (status === REALTIME_STATUS.LISTENING) {
+      this.#ownReply = false;
+      this.#cancelHold();
+      return;
+    }
+    if (status === REALTIME_STATUS.READY) {
+      const own = this.#ownReply;
+      this.#ownReply = false;
+      // A reply to the developer invites their next ask, and an announcement
+      // speaking into that pause takes the very turn they were about to
+      // open: the floor stays the developer's for the grace window, and only
+      // a pause they leave empty is announced into. Only a READY that ends a
+      // reply holds the floor — one that opens the call has answered nothing.
+      if (
+        !own &&
+        previous === REALTIME_STATUS.RESPONDING &&
+        this.#options.session().microphoneCall
+      ) {
+        this.#holdUntil = (this.#options.now?.() ?? Date.now()) + ANNOUNCER_GRACE_MS;
+        // A fresh window gets a fresh clock: one still armed for an older
+        // window would come back early and find the floor still held.
+        this.#cancelHold();
+      }
+      this.#flush();
+      return;
+    }
+    if (
+      status === REALTIME_STATUS.IDLE ||
+      status === REALTIME_STATUS.FAILED ||
+      status === REALTIME_STATUS.UNAVAILABLE
+    ) {
+      this.#cancelLinger();
+      // The conversation the floor was being held for is gone with the call.
+      this.#cancelHold();
+      this.#holdUntil = 0;
+      this.#ownReply = false;
+      this.#ownsCall = false;
+      // The offer survives the call it was waiting on — a developer's call
+      // that ended mid-wait, or Luke's own that dropped — and the retry clock
+      // is what picks it back up. The connect path arms the same clock when an
+      // open is refused, so arming here is idempotent.
+      this.#armRetry();
+    }
+  }
+
+  #flush(): void {
+    // Quiet holds everything: nothing may speak, and an empty hand must not
+    // start the linger toward closing a call the quiet already closed.
+    if (this.#quiet) return;
+    const now = this.#options.now?.() ?? Date.now();
+    // The deadline is read at the last moment, so news that waited out a long
+    // reply is settled stale rather than read as though it just happened.
+    if (this.#current && now > this.#current.speakBy) {
+      this.#settleCurrent(SPEECH_OUTCOME.STALE);
+    }
+    const session = this.#options.session();
+    if (!this.#current) {
+      this.#connectAttempts = 0;
+      this.#armLinger();
+      return;
+    }
+    if (session.isConnected) {
+      // The developer keeps the floor for the grace window after Luke answers
+      // them; the offer comes back when the window closes.
+      const floorHeld = this.#holdUntil - now;
+      if (floorHeld > 0 && session.microphoneCall) {
+        this.#armHold(floorHeld);
+        return;
+      }
+      if (session.speak(this.#current.turn)) {
+        this.#ownReply = true;
+        this.#settleCurrent(SPEECH_OUTCOME.SPOKEN);
+        return;
+      }
+      // An offer waiting on a refused speak is normally resumed by the READY
+      // edge, but that edge is the session's promise, not this class's: the
+      // retry clock keeps the offer from depending on it. Redundant on the
+      // ordinary path — the edge lands first and says everything — and what
+      // stands between an announcement and permanent silence when it does not.
+      this.#armRetry();
+      return;
+    }
+    if (session.isConnecting) return;
+    // Silence, and something to say into it: open a call of Luke's own.
+    this.#connectAttempts += 1;
+    this.#ownsCall = true;
+    void session
+      .connect({ microphone: false })
+      .then((opened) => {
+        if (opened) {
+          this.#connectAttempts = 0;
+          this.#flush();
+          return;
+        }
+        this.#ownsCall = false;
+        this.#retreatOrRetry();
+      })
+      .catch(() => {
+        this.#ownsCall = false;
+        this.#retreatOrRetry();
+      });
+  }
+
+  /**
+   * Decides what a refused connect leaves behind. An offer still owed a try
+   * keeps it, on the retry clock; one that has had its tries is settled
+   * refused here, at the moment of the final refusal, so the next offer
+   * starts with tries of its own rather than dying against a spent counter.
+   * What is refused is still standing in the panel.
+   */
+  #retreatOrRetry(): void {
+    if (this.#connectAttempts >= MAXIMUM_CONNECT_ATTEMPTS) {
+      this.#settleCurrent(SPEECH_OUTCOME.REFUSED);
+      this.#connectAttempts = 0;
+      return;
+    }
+    this.#armRetry();
+  }
+
+  /** Hands the offer in hand back to the arbiter with its outcome, and empties the hand. */
+  #settleCurrent(outcome: SpeechOutcome): void {
+    const current = this.#current;
+    if (!current) return;
+    this.#current = undefined;
+    this.#options.settle(current.id, outcome);
+  }
+
+  /**
+   * Starts the clock on another try at an offer whose call could not open or
+   * did not last. Idempotent, because a refused connect and the failed status
+   * it causes both land here; the offer's own deadline and the attempt cap
+   * in {@link #retreatOrRetry} are what keep the clock from ticking forever.
+   */
+  #armRetry(): void {
+    if (!this.#current) return;
+    this.#retryTimer ??= (this.#options.schedule ?? setTimeout)(() => {
+      this.#retryTimer = undefined;
+      this.#flush();
+    }, ANNOUNCER_RETRY_DELAY_MS);
+  }
+
+  /** Comes back for the offer once the developer's floor window closes. */
+  #armHold(delayMs: number): void {
+    this.#holdTimer ??= (this.#options.schedule ?? setTimeout)(() => {
+      this.#holdTimer = undefined;
+      this.#flush();
+    }, delayMs);
+  }
+
+  #cancelHold(): void {
+    if (this.#holdTimer === undefined) return;
+    // SAFETY: The handle is whatever `schedule ?? setTimeout` returned, and the
+    // fallbacks are paired — a handle from `setTimeout` can only reach
+    // `clearTimeout`. The cast satisfies that signature; nothing reads it as a
+    // number.
+    (this.#options.cancel ?? clearTimeout)(this.#holdTimer as number);
+    this.#holdTimer = undefined;
+  }
+
+  #cancelRetry(): void {
+    if (this.#retryTimer === undefined) return;
+    // SAFETY: The handle is whatever `schedule ?? setTimeout` returned, and the
+    // fallbacks are paired — a handle from `setTimeout` can only reach
+    // `clearTimeout`. The cast satisfies that signature; nothing reads it as a
+    // number.
+    (this.#options.cancel ?? clearTimeout)(this.#retryTimer as number);
+    this.#retryTimer = undefined;
+  }
+
+  #armLinger(): void {
+    const session = this.#options.session();
+    if (!this.#ownsCall || !session.isConnected || session.microphoneCall) return;
+    if (session.status !== REALTIME_STATUS.READY) return;
+    this.#lingerTimer ??= (this.#options.schedule ?? setTimeout)(() => {
+      this.#lingerTimer = undefined;
+      this.#closeOwnCall();
+    }, ANNOUNCER_LINGER_MS);
+  }
+
+  #cancelLinger(): void {
+    if (this.#lingerTimer === undefined) return;
+    // SAFETY: The handle is whatever `schedule ?? setTimeout` returned, and the
+    // fallbacks are paired — a handle from `setTimeout` can only reach
+    // `clearTimeout`. The cast satisfies that signature; nothing reads it as a
+    // number.
+    (this.#options.cancel ?? clearTimeout)(this.#lingerTimer as number);
+    this.#lingerTimer = undefined;
+  }
+
+  #closeOwnCall(): void {
+    const session = this.#options.session();
+    // Everything is re-checked at the moment of closing, because a minute is
+    // long: the developer may have taken the call, or something new may be
+    // offered and about to speak.
+    if (!this.#ownsCall || !session.isConnected || session.microphoneCall) return;
+    if (this.#current !== undefined || session.status !== REALTIME_STATUS.READY) return;
+    this.#ownsCall = false;
+    void session.close();
+  }
+}

--- a/apps/desktop/src/shared/bridge.test.ts
+++ b/apps/desktop/src/shared/bridge.test.ts
@@ -115,3 +115,63 @@ test("an app act pushed to the renderer never carries a memory write", () => {
   assert.equal(guard({ requestId: "r1", action: { kind: "forget", id: "f" } }), false);
   assert.equal(guard({ action: { kind: "panel", tab: "sessions" } }), false);
 });
+
+test("a speech offer carries an id, a deadline, and one well-formed turn", () => {
+  const guard = BRIDGE.onSpeechOffered.result;
+  assert.ok(guard);
+  const briefing = { kind: "briefing", briefing: "Claude Code finished checkout.", decidedAt: 1 };
+  assert.equal(guard({ id: "one", speakBy: 120_001, turn: briefing }), true);
+  assert.equal(guard({ id: "two", speakBy: 5, turn: { kind: "arrival", decidedAt: 2 } }), true);
+  assert.equal(
+    guard({
+      id: "three",
+      speakBy: 5,
+      turn: { kind: "arrival", decidedAt: 2, sessionTitle: "checkout", talkKeyLabel: "F5" },
+    }),
+    true,
+  );
+  assert.equal(
+    guard({ id: "four", speakBy: 5, turn: { kind: "calendar-onboarding", decidedAt: 3 } }),
+    true,
+  );
+  assert.equal(guard({ speakBy: 5, turn: briefing }), false);
+  assert.equal(guard({ id: "", speakBy: 5, turn: briefing }), false);
+  assert.equal(guard({ id: "five", turn: briefing }), false);
+  assert.equal(guard({ id: "five", speakBy: "soon", turn: briefing }), false);
+  assert.equal(guard({ id: "six", speakBy: 5, turn: { kind: "edge", decidedAt: 1 } }), false);
+  assert.equal(
+    guard({ id: "seven", speakBy: 5, turn: { kind: "briefing", briefing: 3, decidedAt: 1 } }),
+    false,
+  );
+  assert.equal(
+    guard({ id: "eight", speakBy: 5, turn: { kind: "briefing", briefing: "x", decidedAt: "1" } }),
+    false,
+  );
+  assert.equal(
+    guard({ id: "nine", speakBy: 5, turn: { kind: "arrival", decidedAt: 1, sessionTitle: 4 } }),
+    false,
+  );
+  assert.equal(guard({ id: "ten", speakBy: 5 }), false);
+});
+
+test("a speech withdrawal names the offer by a string id", () => {
+  const guard = BRIDGE.onSpeechWithdrawn.result;
+  assert.ok(guard);
+  assert.equal(guard({ id: "one" }), true);
+  assert.equal(guard({ id: "" }), false);
+  assert.equal(guard({ id: 1 }), false);
+  assert.equal(guard({}), false);
+  assert.equal(guard("one"), false);
+});
+
+test("settling speech takes an id and one of the four outcomes", () => {
+  assert.equal(BRIDGE.settleSpeech.kind, "invoke");
+  const guard = BRIDGE.settleSpeech.args;
+  for (const outcome of ["spoken", "refused", "held", "stale"]) {
+    assert.equal(guard(["one", outcome]), true);
+  }
+  assert.equal(guard(["one"]), false);
+  assert.equal(guard(["one", "dropped"]), false);
+  assert.equal(guard([1, "spoken"]), false);
+  assert.equal(guard(["one", "spoken", "extra"]), false);
+});

--- a/apps/desktop/src/shared/bridge.ts
+++ b/apps/desktop/src/shared/bridge.ts
@@ -86,6 +86,14 @@ import {
   type WindowRole,
 } from "./wire/session";
 import type { AppSettings, SettingsUpdateResult } from "./wire/settings";
+import {
+  isSpeechOffer,
+  isSpeechOutcome,
+  isSpeechWithdrawal,
+  type SpeechOffer,
+  type SpeechOutcome,
+  type SpeechWithdrawal,
+} from "./wire/speech";
 import type { UpdateSnapshot } from "./wire/update";
 
 export interface WireGuard<Value> {
@@ -521,6 +529,20 @@ export const BRIDGE = {
     result: result<void>(),
   }),
   /**
+   * The mouth reporting what became of one speech offer, by the id the offer
+   * carried: spoken, refused, held, or stale. The arbiter offers the next turn
+   * only once this lands, and an id it no longer knows — withdrawn, or past
+   * its deadline — is ignored rather than acted on.
+   */
+  settleSpeech: entry({
+    kind: "invoke",
+    channel: "app:settle-speech",
+    args: args<[string, SpeechOutcome]>(
+      (v) => v.length === 2 && isWireString(v[0]) && isSpeechOutcome(v[1]),
+    ),
+    result: result<void>(),
+  }),
+  /**
    * One window's copy of the conversation history, reported whole after each
    * line it appends. The main process holds the launch's thread and mirrors
    * the report to every other panel window, so the History tab reads the same
@@ -823,6 +845,25 @@ export const BRIDGE = {
     channel: "app:briefing",
     args: noArgs,
     result: result<BriefingPayload>(),
+  }),
+  /**
+   * One proactive turn the speech arbiter decided to voice now — a briefing
+   * or an onboarding beat — with its id and the deadline past which it is
+   * stale. At most one is outstanding: the next is offered only after the
+   * mouth settles this one.
+   */
+  onSpeechOffered: entry({
+    kind: "subscribe",
+    channel: "app:speech-offered",
+    args: noArgs,
+    result: result<SpeechOffer>(isSpeechOffer),
+  }),
+  /** The arbiter taking back an offer the mouth has not yet begun to speak. */
+  onSpeechWithdrawn: entry({
+    kind: "subscribe",
+    channel: "app:speech-withdrawn",
+    args: noArgs,
+    result: result<SpeechWithdrawal>(isSpeechWithdrawal),
   }),
   /**
    * An app act the brain decided that only the renderer can perform, already

--- a/apps/desktop/src/shared/wire/speech.ts
+++ b/apps/desktop/src/shared/wire/speech.ts
@@ -1,0 +1,100 @@
+import {
+  ARRIVAL_SPEECH_KIND,
+  BRIEFING_SPEECH_KIND,
+  CALENDAR_ONBOARDING_SPEECH_KIND,
+  type ProactiveSpeechTurn,
+} from "@sidecar/realtime";
+import {
+  isRecord,
+  isWireNumber,
+  isWireString,
+  type UnparsedWireValue,
+  type WireRecord,
+} from "@sidecar/wire";
+
+/**
+ * What crosses the bridge between the speech arbiter in the main process and
+ * the mouth in the renderer. The arbiter owns every decision about what Luke
+ * says unprompted and whether now; the mouth holds at most one offer at a
+ * time and reports what became of it, by id, so the arbiter can offer the
+ * next. No backlog ever stands in a renderer, and so none can be lost with one.
+ */
+
+/**
+ * One turn the main process has decided to voice, handed to the mouth with an
+ * absolute deadline. `speakBy` is read against the mouth's clock at the last
+ * moment: news past it is settled stale rather than read out as though it
+ * just happened, because the panel has shown the state the whole time.
+ */
+export interface SpeechOffer {
+  id: string;
+  speakBy: number;
+  turn: ProactiveSpeechTurn;
+}
+
+/** The main process taking back an offer the mouth has not yet begun to speak. */
+export interface SpeechWithdrawal {
+  id: string;
+}
+
+/**
+ * What the mouth reports of one offer. SPOKEN: the reply began. REFUSED: the
+ * call could not be opened within its attempts. HELD: the announcement hold
+ * began before the words were said, and the arbiter keeps the request for the
+ * release. STALE: the deadline passed unspoken.
+ */
+export const SPEECH_OUTCOME = {
+  SPOKEN: "spoken",
+  REFUSED: "refused",
+  HELD: "held",
+  STALE: "stale",
+} as const;
+
+export type SpeechOutcome = (typeof SPEECH_OUTCOME)[keyof typeof SPEECH_OUTCOME];
+
+const optionalString = (value: UnparsedWireValue): boolean =>
+  value === undefined || isWireString(value);
+
+export function isProactiveSpeechTurn(
+  value: UnparsedWireValue,
+): value is ProactiveSpeechTurn & WireRecord {
+  if (!isRecord(value) || !isWireNumber(value.decidedAt) || !Number.isFinite(value.decidedAt)) {
+    return false;
+  }
+  switch (value.kind) {
+    case BRIEFING_SPEECH_KIND:
+      return isWireString(value.briefing);
+    case ARRIVAL_SPEECH_KIND:
+      return optionalString(value.sessionTitle) && optionalString(value.talkKeyLabel);
+    case CALENDAR_ONBOARDING_SPEECH_KIND:
+      return true;
+    default:
+      return false;
+  }
+}
+
+export function isSpeechOffer(value: UnparsedWireValue): value is SpeechOffer & WireRecord {
+  return (
+    isRecord(value) &&
+    isWireString(value.id) &&
+    value.id.length > 0 &&
+    isWireNumber(value.speakBy) &&
+    Number.isFinite(value.speakBy) &&
+    isProactiveSpeechTurn(value.turn)
+  );
+}
+
+export function isSpeechWithdrawal(
+  value: UnparsedWireValue,
+): value is SpeechWithdrawal & WireRecord {
+  return isRecord(value) && isWireString(value.id) && value.id.length > 0;
+}
+
+export function isSpeechOutcome(value: UnparsedWireValue): value is SpeechOutcome {
+  return (
+    value === SPEECH_OUTCOME.SPOKEN ||
+    value === SPEECH_OUTCOME.REFUSED ||
+    value === SPEECH_OUTCOME.HELD ||
+    value === SPEECH_OUTCOME.STALE
+  );
+}

--- a/packages/devtrace/src/index.ts
+++ b/packages/devtrace/src/index.ts
@@ -6,6 +6,7 @@ export {
   AgentTraceWriter,
   type AgentTraceWriterOptions,
   type BrainRequestTraceRecord,
+  type SpeechTraceRecord,
   TRACE_ENTRY_KIND,
   type TraceEntryKind,
 } from "./trace-writer.js";

--- a/packages/devtrace/src/trace-writer.test.ts
+++ b/packages/devtrace/src/trace-writer.test.ts
@@ -43,10 +43,11 @@ test("lines land in the named file, stamped, in the order they were recorded", a
     iterations: 1,
     compacted: false,
   });
+  writer.recordSpeechDecision({ kind: "briefing", decision: "offered", pendingCount: 2 });
   await writer.settled();
   const lines = (await readFile(writer.file, "utf8")).split("\n").filter((line) => line.length > 0);
   const entries = lines.map(recordFromJsonLine);
-  assert.equal(entries.length, 3);
+  assert.equal(entries.length, 4);
   assert.equal(entries[0]?.kind, TRACE_ENTRY_KIND.WIRE);
   assert.equal(entries[0]?.direction, TRACE_DIRECTION.CLIENT);
   assert.equal(entries[1]?.kind, TRACE_ENTRY_KIND.BRAIN_REQUEST);
@@ -58,6 +59,8 @@ test("lines land in the named file, stamped, in the order they were recorded", a
   assert.equal(entries[2]?.elapsedMs, 1_250);
   const toolCalls = entries[2]?.toolCalls;
   assert.ok(Array.isArray(toolCalls) && isRecord(toolCalls[0]));
+  assert.equal(entries[3]?.kind, TRACE_ENTRY_KIND.SPEECH);
+  assert.deepEqual(entries[3]?.speech, { kind: "briefing", decision: "offered", pendingCount: 2 });
   for (const entry of entries) {
     assert.ok(isWireString(entry?.at));
   }

--- a/packages/devtrace/src/trace-writer.ts
+++ b/packages/devtrace/src/trace-writer.ts
@@ -24,10 +24,23 @@ export interface BrainRequestTraceRecord {
   error?: string;
 }
 
+/**
+ * One decision the speech arbiter took about a proactive turn: which kind of
+ * turn, what was decided of it, and how many requests stood pending after.
+ * Nothing worded travels — a briefing's text is transcript-derived, and the
+ * trace widening to it is a product decision.
+ */
+export interface SpeechTraceRecord {
+  kind: string;
+  decision: string;
+  pendingCount: number;
+}
+
 export const TRACE_ENTRY_KIND = {
   WIRE: "wire",
   BRAIN: "brain",
   BRAIN_REQUEST: "brain-request",
+  SPEECH: "speech",
 } as const;
 
 export type TraceEntryKind = (typeof TRACE_ENTRY_KIND)[keyof typeof TRACE_ENTRY_KIND];
@@ -40,7 +53,8 @@ export type TraceEntryKind = (typeof TRACE_ENTRY_KIND)[keyof typeof TRACE_ENTRY_
 type PendingTraceEntry =
   | ({ kind: typeof TRACE_ENTRY_KIND.WIRE } & AgentWireTrace)
   | ({ kind: typeof TRACE_ENTRY_KIND.BRAIN } & BrainTurnTraceRecord)
-  | ({ kind: typeof TRACE_ENTRY_KIND.BRAIN_REQUEST } & BrainRequestTraceRecord);
+  | ({ kind: typeof TRACE_ENTRY_KIND.BRAIN_REQUEST } & BrainRequestTraceRecord)
+  | { kind: typeof TRACE_ENTRY_KIND.SPEECH; speech: SpeechTraceRecord };
 
 export interface AgentTraceWriterOptions {
   /** Where the trace lands, created on the first line rather than up front. */
@@ -94,6 +108,14 @@ export class AgentTraceWriter {
 
   recordBrainRequest(record: BrainRequestTraceRecord): void {
     this.#append({ kind: TRACE_ENTRY_KIND.BRAIN_REQUEST, ...record });
+  }
+
+  /**
+   * Nested rather than spread: the record's own `kind` names the speech turn,
+   * and the line's `kind` names the entry, and the two must not collide.
+   */
+  recordSpeechDecision(record: SpeechTraceRecord): void {
+    this.#append({ kind: TRACE_ENTRY_KIND.SPEECH, speech: record });
   }
 
   /** The queue drained, for a test to await what `record*` fired and forgot. */


### PR DESCRIPTION
## What this step did

Phase 1, Step 1 of the speech-arbiter plan: foundations only, nothing wired. The old `BriefingHold` and `BriefingQueue` keep running untouched; `desktop-app.ts`, `use-voice-conversation.ts`, and `settings-rows.ts` are unchanged. Runtime behavior is identical to `brain-spike`.

Added, each with tests:

- `apps/desktop/src/shared/wire/speech.ts`: `SpeechOffer`, `SpeechWithdrawal`, `SPEECH_OUTCOME`, and the guards `isProactiveSpeechTurn`, `isSpeechOffer`, `isSpeechWithdrawal`, `isSpeechOutcome`.
- `apps/desktop/src/shared/bridge.ts`: `onSpeechOffered`, `onSpeechWithdrawn`, `settleSpeech`, added beside the existing `onBriefing`, `onArrivalSpeech`, `onCalendarOnboardingSpeech`, and `completeArrivalBeat`. No handlers registered. Guard tests in `bridge.test.ts`.
- `packages/devtrace`: `TRACE_ENTRY_KIND.SPEECH`, `SpeechTraceRecord`, `AgentTraceWriter.recordSpeechDecision`, exported from the barrel. The record is nested under a `speech` key on the line rather than spread, because the record's own `kind` names the turn kind and the line's `kind` names the entry. One test line added.
- `apps/desktop/src/main/speech-arbiter.ts`: the pure `SpeechArbiter` per plan §1.3, including the deadline rule in `next()`. One detail the plan left implicit is made explicit: a held request is never offered. A held beat is released by quiet ending, and a held briefing belongs to the brain's re-decision, so `next()` offers the first unheld request. The bound and `dropBriefings` also leave the offered briefing alone, since the mouth holds it and settles it.
- `apps/desktop/src/renderer/speech-mouth.ts`: `SpeechMouth`, copied from `briefing-queue.ts` and transformed: one `#current` in place of the queue, a `settle` callback, `offer`/`withdraw` in place of `enqueue`/`dropCalendarOnboardingSpeech`. `briefing-queue.ts` is not modified or deleted in this step.

## Behavior changes realized in this step

None. This PR adds code and tests only. The plan's §1.6 behavior changes land in Step 2 when the arbiter is wired in.

## Verification

`./scripts/check.sh`: passed, exit 0. All suites green, 2007 tests passed and 0 failed across the workspace, including the new `speech-arbiter.test.ts` (18 tests), `speech-mouth.test.ts` (20 tests), three new `bridge.test.ts` cases, and the extended `trace-writer.test.ts`.

`./scripts/verify.sh` (macOS) was not run: this is a Linux sandbox. The change draws nothing on the panel, so no visual evidence applies and no physical-notch check was performed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/6a9da0a5-5198-4c0c-9bbc-d140a1b9d5b2)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/33930300726/artifacts/9958408649) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/33930300726)

- Commit: `6cb868fafa5795b788f6a4a30ecd2afb9db33b91`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
