### PR TITLE
fix(ios): restore controls after keyboard dismissal

### DIFF
--- a/apps/ios/Luke/VoiceView.swift
+++ b/apps/ios/Luke/VoiceView.swift
@@ -2,6 +2,7 @@ import Foundation
 import LukeKit
 import Observation
 import SwiftUI
+import UIKit
 
 // MARK: - Observable session state
 
@@ -298,6 +299,12 @@ struct VoiceView: View {
                 isLatched = false
                 performPendingNavigation()
             }
+        }
+        .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardDidHideNotification)) {
+            _ in
+            guard composerShown else { return }
+            composing = false
+            hideComposer()
         }
         .onDisappear { model.stop() }
     }

--- a/apps/ios/Luke/VoiceView.swift
+++ b/apps/ios/Luke/VoiceView.swift
@@ -300,9 +300,9 @@ struct VoiceView: View {
                 performPendingNavigation()
             }
         }
-        .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardDidHideNotification)) {
+        .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardWillHideNotification)) {
             _ in
-            guard composerShown else { return }
+            guard composerShown, composing else { return }
             composing = false
             hideComposer()
         }

--- a/apps/ios/Luke/VoiceView.swift
+++ b/apps/ios/Luke/VoiceView.swift
@@ -302,7 +302,7 @@ struct VoiceView: View {
         }
         .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardWillHideNotification)) {
             _ in
-            guard composerShown, composing else { return }
+            guard composerShown else { return }
             composing = false
             hideComposer()
         }


### PR DESCRIPTION
## Summary

- Collapse the Luke tab's typed composer whenever iOS finishes hiding the software keyboard
- Restore the keyboard control to the bottom-left and the microphone to its large centered state after dismissal
- Preserve the typed draft while synchronizing SwiftUI focus and composer presentation state

## Verification

- Verified on an iPhone 17 Pro simulator running iOS 26.5
- Reproduced the stale composer/small trailing microphone before the change
- After the change, a system keyboard dismissal restored `Type to Luke` at bottom-left, `Talk to Luke` centered, and the “Tap or hold to talk” label
- Captured and visually inspected before/after simulator evidence locally; screenshots are intentionally not committed per repository policy
- Physical-notch check: not performed (iOS-only control layout change)

## Test coverage

- `xcodebuild -project apps/ios/Luke.xcodeproj -scheme Luke -destination "platform=iOS Simulator,id=256C1AB4-E70C-4533-AB83-15E28FEB7556" test` — 14 passed
- `swift test` in `apps/ios/LukeKit` — 268 passed
- `./scripts/check.sh` — passed, including lint, typecheck, portable tests, 841 desktop tests, and builds
- No iOS UI-test target exists, so this UIKit notification / SwiftUI layout seam remains manually verified rather than executable UI coverage (AI-assessed automated coverage: 30%)

## Review

- Pre-landing review: no issues found
- Adversarial review: no security, lifecycle, race, or trust-boundary findings
- Cursor Bugbot findings were fixed in `b5aa6b24` and `10c55c73`; final handling reacts at will-hide and collapses any visible Luke composer without relying on `FocusState` timing
- Scope check: clean; one seven-line source change
- Plan completion: no plan file detected
- Documentation: current; no updates needed

## Base

Rebased on `origin/main` at `27674181696845d321c3bb1ad67b4ccab4e4ac11` before push.

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/33931695440/artifacts/9958809927) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/33931695440)

- Commit: `10c55c7361c7cdf762092caa7fb0b820b51909e8`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
