### PR TITLE
refactor(desktop): drop the voice hook's unread options and name the primary panel

### DIFF
--- a/apps/desktop/src/main/desktop-app.ts
+++ b/apps/desktop/src/main/desktop-app.ts
@@ -1499,13 +1499,13 @@ function recordMainConversationEntry(entry: ConversationEntry): void {
 
 /**
  * Carries an app act only a renderer can perform — a settings change, the
- * panel shown, the feedback composer, the Updates row's button — to the voice
- * host, already validated here against the guide it reported, and waits for
+ * panel shown, the feedback composer, the Updates row's button — to the
+ * primary panel, already validated here against the guide it reported, and waits for
  * its answer. A panel that does not answer within the round trip refuses the
  * act on a clock rather than holding the brain's turn open.
  */
 function performBrainAppAct(action: BrainAppActRequest["action"]): Promise<WireRecord> {
-  const host = panels.voiceHost();
+  const host = panels.primaryPanel();
   if (!host) {
     return Promise.resolve({
       status: ACT_RESULT_STATUS.REJECTED,
@@ -3087,7 +3087,7 @@ export function startDesktopApp(): void {
             return;
           }
           if (argv.includes("--expanded")) {
-            const host = panels.voiceHost();
+            const host = panels.primaryPanel();
             const displayId = host ? panels.displayIdFor(host.webContents) : undefined;
             if (displayId !== undefined) panels.setMode(displayId, "expanded", true);
             return;

--- a/apps/desktop/src/main/window/panel-manager.ts
+++ b/apps/desktop/src/main/window/panel-manager.ts
@@ -192,21 +192,32 @@ export class PanelManager {
   }
 
   /**
-   * The one window a spoken conversation lives in. Voice is a single thing —
-   * one microphone, one reply, one face speaking — so the talk key and the
-   * briefings go to a single renderer rather than opening one
-   * conversation per display: the main display's window when Luke stands there,
-   * else the first window standing anywhere. The thread the exchange leaves
-   * behind is not the host's alone: each appended line comes back through the
-   * conversation history relay, so every display's History reads the same.
+   * The one panel an act aimed at the panel itself lands on — a settings
+   * change the brain asks for, the panel expanded from a second launch: the
+   * main display's window when Luke stands there, else the first window
+   * standing anywhere, so an act about the app has one drawn surface to
+   * answer from rather than one per display.
    */
-  voiceHost(): BrowserWindow | undefined {
+  primaryPanel(): BrowserWindow | undefined {
     const primary = this.#windows.get(screen.getPrimaryDisplay().id);
     if (primary && !primary.isDestroyed()) return primary;
     for (const window of this.#windows.values()) {
       if (!window.isDestroyed()) return window;
     }
     return undefined;
+  }
+
+  /**
+   * The one window a spoken conversation lives in. Voice is a single thing —
+   * one microphone, one reply, one face speaking — so the talk key and the
+   * briefings go to a single renderer rather than opening one
+   * conversation per display. Today that is the primary panel; the thread the
+   * exchange leaves behind is not the host's alone, since each appended line
+   * comes back through the conversation history relay, so every display's
+   * History reads the same.
+   */
+  voiceHost(): BrowserWindow | undefined {
+    return this.primaryPanel();
   }
 
   /** The display a renderer message came from, so each window answers for itself. */

--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -1,4 +1,4 @@
-import { APP_TOOL_KIND, dispatchByKind, type RememberedFact } from "@sidecar/acts";
+import { APP_TOOL_KIND, dispatchByKind } from "@sidecar/acts";
 import {
   PRODUCT_PANEL_SOURCE,
   PRODUCT_SEARCH_SURFACE,
@@ -19,7 +19,6 @@ import { REALTIME_STATUS } from "@sidecar/realtime";
 import {
   type ObservedWorkspaceProject,
   type SessionApplicationId,
-  type SessionIdentity,
   workspaceProjectSelectionId,
 } from "@sidecar/session";
 import {
@@ -49,7 +48,6 @@ import type { ObservedAccountCalendars } from "#shared/wire/calendar";
 import type {
   AppBootstrap,
   DisplayDiagnostic,
-  SessionOpenResult,
   SessionReplayBootstrap,
   SessionRosterPayload,
   SupersetSignInSnapshot,
@@ -337,8 +335,6 @@ export function App(): React.JSX.Element {
   // so a bootstrap replying "not yet" after a push raced past it clobbers
   // nothing, and the wing stops saying "loading" the moment either arrives.
   const [sessionsSettled, setSessionsSettled] = useState(false);
-  /** The main process's durable memory, mirrored here only to update conversation context. */
-  const [rememberedFacts, setRememberedFacts] = useState<readonly RememberedFact[]>([]);
   const [workspaceProjects, setWorkspaceProjects] = useState<readonly ObservedWorkspaceProject[]>(
     [],
   );
@@ -1579,50 +1575,6 @@ export function App(): React.JSX.Element {
   );
 
   /**
-   * The same press asked for out loud. It stands the panel down for the same
-   * reason the pressed row does — Luke floats above the very chat he was asked
-   * to bring forward — but only once something actually opened, and only if the
-   * panel is up at all: a spoken ask usually arrives with the panel away.
-   */
-  const openSessionAloud = useCallback(
-    async (identity: SessionIdentity): Promise<SessionOpenResult> => {
-      const result = await window.sidecar.openSession(identity);
-      if (
-        result.status === ACT_RESULT_STATUS.ACCEPTED &&
-        presentationOf() === PANEL_PRESENTATION.PANEL
-      ) {
-        cancelHover();
-        void changeMode(false);
-      }
-      return result;
-    },
-    [cancelHover, changeMode, presentationOf],
-  );
-
-  /**
-   * The same spoken press aimed at one app mark, for an open ask that named
-   * the app: the same bridge call the mark's own button makes, standing the
-   * panel down on the same terms as {@link openSessionAloud}.
-   */
-  const openSessionApplicationAloud = useCallback(
-    async (
-      identity: SessionIdentity,
-      applicationId: SessionApplicationId,
-    ): Promise<SessionOpenResult> => {
-      const result = await window.sidecar.openSessionApplication(identity, applicationId);
-      if (
-        result.status === ACT_RESULT_STATUS.ACCEPTED &&
-        presentationOf() === PANEL_PRESENTATION.PANEL
-      ) {
-        cancelHover();
-        void changeMode(false);
-      }
-      return result;
-    },
-    [cancelHover, changeMode, presentationOf],
-  );
-
-  /**
    * The ask key, pressed anywhere on the system. The main process has already
    * stood the panel up focused; what is left is the caret — or the dismissal,
    * because a summons repeated over its own open field is someone asking the
@@ -1994,8 +1946,6 @@ export function App(): React.JSX.Element {
     ],
   );
 
-  const defaultWorkspaceProvider = (settings ?? bootstrapSettings)?.defaultWorkspaceProvider;
-  const workspaceProjectDefaults = (settings ?? bootstrapSettings)?.workspaceProjectDefaults;
   // The muted evidence run is the speaking run with the hint drawn over it: a
   // capture has no system output to read, so the state is asked for directly.
   const fixtureMuted = bootstrap?.profile === "muted";
@@ -2023,14 +1973,10 @@ export function App(): React.JSX.Element {
     remoteAudio,
     discardListening,
     stopSpeaking,
-    syncGuide,
   } = useVoiceConversation({
     preferBuiltInMicrophone: (settings ?? bootstrapSettings)?.preferBuiltInMicrophone ?? true,
     agentTraceEnabled: bootstrap?.agentTraceEnabled === true,
     sessions,
-    workspaceProjects,
-    defaultWorkspaceProvider,
-    workspaceProjectDefaults,
     voice: settings?.voice,
     voiceSpeed: settings?.voiceSpeed,
     voiceCaptions: settings?.voiceCaptions === true,
@@ -2040,11 +1986,8 @@ export function App(): React.JSX.Element {
     announcementsHeld,
     fixtureSpeaking,
     capturingShortcut: () => shortcutCapture.current,
-    openSession: openSessionAloud,
-    openSessionApplication: openSessionApplicationAloud,
     carryAppAction,
     conversationContextReady: bootstrap !== undefined,
-    rememberedFacts,
   });
 
   // A failed call is reported where its reply would have landed: on the
@@ -2192,10 +2135,6 @@ export function App(): React.JSX.Element {
       }),
     applySettings,
   );
-  const acceptRememberedFactsBootstrap = useBootstrapRacedChannel(
-    (onChange) => window.sidecar.onRememberedFactsChanged(onChange),
-    setRememberedFacts,
-  );
   const acceptAccountBootstrap = useBootstrapRacedChannel(
     (onChange) => window.sidecar.onAccountChanged(onChange),
     setAccount,
@@ -2291,7 +2230,6 @@ export function App(): React.JSX.Element {
       setBootstrap(value);
       acceptSessionsBootstrap(value.sessionRoster);
       if (value.sessionsSettled) setSessionsSettled(true);
-      acceptRememberedFactsBootstrap(value.rememberedFacts);
       // Only fill in what no push has said yet: the bootstrap snapshot is
       // older than any change that raced past it, and the main process will
       // not repeat a list it believes it already announced.
@@ -2398,7 +2336,6 @@ export function App(): React.JSX.Element {
     acceptAnnouncementsHeldBootstrap,
     acceptOutputAudioBootstrap,
     acceptProjectsBootstrap,
-    acceptRememberedFactsBootstrap,
     acceptSessionReplayBootstrap,
     acceptSessionsBootstrap,
     acceptSettingsBootstrap,
@@ -2484,18 +2421,12 @@ export function App(): React.JSX.Element {
         ...(stopAccelerator ? { stopKey: voiceHotkeyLabel(stopAccelerator) } : undefined),
         stopKeyRemoved: current.stopHotkey === VOICE_HOTKEY_NONE,
       });
-      syncGuide(guide);
+      // The guide goes to the main process, where the brain reads it and an
+      // app act the brain asks for is validated against it; the voice itself
+      // is told nothing about the app.
+      window.sidecar.reportAppGuide(guide);
     },
-    [
-      bootstrap,
-      account,
-      update,
-      microphoneStatus,
-      voiceHotkey,
-      askHotkeyChange,
-      stopHotkeyChange,
-      syncGuide,
-    ],
+    [bootstrap, account, update, microphoneStatus, voiceHotkey, askHotkeyChange, stopHotkeyChange],
   );
   useEffect(() => {
     if (!bootstrap) return;

--- a/apps/desktop/src/renderer/use-voice-conversation.ts
+++ b/apps/desktop/src/renderer/use-voice-conversation.ts
@@ -1,8 +1,6 @@
-import type { RememberedFact } from "@sidecar/acts";
 import { PRODUCT_EXCHANGE_KIND, type ProductExchangeKind } from "@sidecar/analytics";
 import { sanitizedTraceEvent } from "@sidecar/devtrace/vocabulary";
 import { FIXTURE_SPEAKING_CAPTION } from "@sidecar/fixtures";
-import type { AppGuideSnapshot } from "@sidecar/guide";
 import {
   type ArrivalSpeech,
   adoptConversationThread,
@@ -22,22 +20,12 @@ import {
   storedConversationMaximumAgeMs,
   streamingConversationEntry,
 } from "@sidecar/realtime";
-import {
-  type ObservedWorkspaceProject,
-  SESSION_STATUS,
-  type Session,
-  type SessionApplicationId,
-  type SessionIdentity,
-} from "@sidecar/session";
+import { SESSION_STATUS, type Session } from "@sidecar/session";
 import { TALK_KEY_RELEASE, talkKeyRelease, voiceHotkeyLabel } from "@sidecar/settings";
 import { ACT_RESULT_STATUS } from "@sidecar/wire";
 import { type RefObject, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { MicrophoneStatus, VoiceHotkeyState } from "#shared/wire/audio";
-import type {
-  ConversationHistoryPayload,
-  SessionOpenResult,
-  WorkspaceProviderId,
-} from "#shared/wire/session";
+import type { ConversationHistoryPayload } from "#shared/wire/session";
 import { hostedVoiceUnavailableNote } from "./microphone-access";
 import { openPreferredMicrophone } from "./microphone-choice";
 import {
@@ -401,10 +389,6 @@ export interface VoiceConversationOptions {
    */
   agentTraceEnabled: boolean;
   sessions: readonly Session[];
-  workspaceProjects: readonly ObservedWorkspaceProject[];
-  defaultWorkspaceProvider: WorkspaceProviderId | undefined;
-  /** The per-provider default projects, riding the projects context they steer. */
-  workspaceProjectDefaults: Readonly<Partial<Record<WorkspaceProviderId, string>>> | undefined;
   voice: RealtimeVoice | undefined;
   voiceSpeed: RealtimeVoiceSpeed | undefined;
   voiceCaptions: boolean;
@@ -437,28 +421,13 @@ export interface VoiceConversationOptions {
    */
   capturingShortcut: () => boolean;
   /**
-   * The spoken form of pressing a row. Passed in rather than reached through a
-   * ref: this hook is called after the handler exists, so there is no
+   * The spoken asks about Luke himself. Passed in rather than reached through
+   * a ref: this hook is called after the handler exists, so there is no
    * declaration-order cycle to break.
-   */
-  openSession: (identity: SessionIdentity) => Promise<SessionOpenResult>;
-  /**
-   * The spoken form of pressing one app mark on a row, for an open that named
-   * the app. Passed in on the same terms as {@link openSession}.
-   */
-  openSessionApplication: (
-    identity: SessionIdentity,
-    applicationId: SessionApplicationId,
-  ) => Promise<SessionOpenResult>;
-  /**
-   * The spoken asks about Luke himself. Passed in on the same terms as
-   * {@link openSession}.
    */
   carryAppAction: AppActionCarrier;
   /** Whether restored history and personal memory are ready for the first turn. */
   conversationContextReady: boolean;
-  /** Durable personal memory supplied at bootstrap and kept current by pushes. */
-  rememberedFacts: readonly RememberedFact[];
 }
 
 export interface VoiceConversation {
@@ -474,7 +443,6 @@ export interface VoiceConversation {
   /** A temporary state shown on the caption strip in its quieter notice tone. */
   voiceNotice: string | undefined;
   voiceStatus: RealtimeStatus;
-  setVoiceStatus: (status: RealtimeStatus) => void;
   talkOpening: boolean;
   voiceHotkey: VoiceHotkeyState | undefined;
   handleVoiceActivity: (active: boolean) => void;
@@ -517,7 +485,6 @@ export interface VoiceConversation {
   /** Escape out of an open turn: forget the press and the latch, and stop listening. */
   discardListening: () => void;
   stopSpeaking: () => boolean;
-  syncGuide: (guide: AppGuideSnapshot) => void;
 }
 
 /**
@@ -1308,13 +1275,6 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
 
   const stopSpeaking = useCallback(() => voiceSession.current?.stopSpeaking() === true, []);
 
-  // The guide goes to the main process, where the brain reads it and an app
-  // act the brain asks for is validated against it; the voice itself is told
-  // nothing about the app.
-  const syncGuide = useCallback((guide: AppGuideSnapshot) => {
-    window.sidecar.reportAppGuide(guide);
-  }, []);
-
   const heardSpeed = useRef<RealtimeVoiceSpeed | undefined>(undefined);
   useEffect(() => {
     const speed = options.voiceSpeed;
@@ -1604,7 +1564,6 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
     voiceError,
     voiceNotice,
     voiceStatus,
-    setVoiceStatus,
     talkOpening,
     voiceHotkey,
     handleVoiceActivity,
@@ -1621,6 +1580,5 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
     remoteAudio,
     discardListening,
     stopSpeaking,
-    syncGuide,
   };
 }


### PR DESCRIPTION
Phase 2, Step 1 of the voice-window plan: dead-weight removal with no behavior change, shrinking the surface the later steps move.

## What this step did

- **`use-voice-conversation.ts` / `app.tsx`**: deleted six `VoiceConversationOptions` the hook never reads (`workspaceProjects`, `defaultWorkspaceProvider`, `workspaceProjectDefaults`, `openSession`, `openSessionApplication`, `rememberedFacts`) and the never-destructured `setVoiceStatus` return. The `app.tsx` locals that existed only to feed them (`openSessionAloud`, `openSessionApplicationAloud`, the two settings-derived workspace consts, and the `rememberedFacts` mirror state with its bootstrap channel) went with them, since Biome's `noUnusedVariables` would otherwise fail.
- **Kept `sessions`**: the plan listed it as unread, but the hook does read it. `sessionsRef` mirrors it and the arrival-beat wording (`wordedArrival`) searches it for a working session's title. It stays.
- **`syncGuide` lifted out of the hook**: `app.tsx` now calls `window.sidecar.reportAppGuide(guide)` directly inside its guide effect; the hook no longer knows about the guide.
- **`panel-manager.ts`**: added `primaryPanel()` (the former `voiceHost()` body, documented as the panel-UI target). `voiceHost()` remains, returning `primaryPanel()`, for the voice-bound sends (`offerNextSpeech`, `withdrawBeat`, the hotkey host); a later step retargets those.
- **`desktop-app.ts`**: `performBrainAppAct` and the `second-instance --expanded` handler now target `panels.primaryPanel()`.

## Synchronous session-state branches in `app.tsx` (survey, unchanged)

Besides the Escape handler's `stopSpeaking()` boolean, the only place `app.tsx` branches synchronously on session state is the same Escape handler's preceding check, `voiceStatus === REALTIME_STATUS.LISTENING` → `discardListening()`. That reads React state already, so it will read the snapshot unchanged in Phase 2. `voiceStatus`, `talkOpening`, and `microphoneStatus` are otherwise only passed as props or fed into the guide build. The unmount cleanup's `stopMicrophone()` call is an act, not a branch, and the plan already drops it.

## Behavior changes

None intended. Of the plan's §2.5 list, nothing is realized by this step.

## Verification

`./scripts/check.sh`: exit 0 (repository checks, typecheck, all package and desktop tests, web and desktop builds pass).

`./scripts/verify.sh` (macOS) was not run because this is a Linux sandbox. The change draws nothing new; no physical-notch check was performed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/486dee02-5213-4d9f-8b45-3114052d87d3)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/33932196074/artifacts/9958975924) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/33932196074)

- Commit: `6375ba5c59a92660fe70f23f8ff0a9669a4b9ea2`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
