### PR TITLE
Add watchOS voice settings button

### DIFF
--- a/apps/ios/Luke.xcodeproj/project.pbxproj
+++ b/apps/ios/Luke.xcodeproj/project.pbxproj
@@ -53,6 +53,7 @@
 		AABBCC0000000000000000EC /* WatchAudioPlayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABBCC0000000000000000EB /* WatchAudioPlayer.swift */; };
 		AABBCC0000000000000000EE /* WatchLukeMark.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABBCC0000000000000000ED /* WatchLukeMark.swift */; };
 		AABBCC0000000000000000F6 /* WatchNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABBCC0000000000000000F5 /* WatchNavigation.swift */; };
+		AABBCC000000000000000100 /* WatchVoiceSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABBCC000000000000000101 /* WatchVoiceSettingsView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -124,6 +125,7 @@
 		AABBCC0000000000000000EB /* WatchAudioPlayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchAudioPlayer.swift; sourceTree = "<group>"; };
 		AABBCC0000000000000000ED /* WatchLukeMark.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchLukeMark.swift; sourceTree = "<group>"; };
 		AABBCC0000000000000000F5 /* WatchNavigation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchNavigation.swift; sourceTree = "<group>"; };
+		AABBCC000000000000000101 /* WatchVoiceSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchVoiceSettingsView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -229,6 +231,7 @@
 				AABBCC0000000000000000E1 /* WatchRosterStore.swift */,
 				AABBCC0000000000000000E3 /* WatchRosterView.swift */,
 				AABBCC0000000000000000E5 /* WatchVoiceView.swift */,
+				AABBCC000000000000000101 /* WatchVoiceSettingsView.swift */,
 				AABBCC0000000000000000E7 /* WatchVoiceSessionModel.swift */,
 				AABBCC0000000000000000E9 /* WatchAudioCapturer.swift */,
 				AABBCC0000000000000000EB /* WatchAudioPlayer.swift */,
@@ -435,6 +438,7 @@
 				AABBCC0000000000000000E2 /* WatchRosterStore.swift in Sources */,
 				AABBCC0000000000000000E4 /* WatchRosterView.swift in Sources */,
 				AABBCC0000000000000000E6 /* WatchVoiceView.swift in Sources */,
+				AABBCC000000000000000100 /* WatchVoiceSettingsView.swift in Sources */,
 				AABBCC0000000000000000E8 /* WatchVoiceSessionModel.swift in Sources */,
 				AABBCC0000000000000000EA /* WatchAudioCapturer.swift in Sources */,
 				AABBCC0000000000000000EC /* WatchAudioPlayer.swift in Sources */,

--- a/apps/ios/LukeWatch/LukeWatchView.swift
+++ b/apps/ios/LukeWatch/LukeWatchView.swift
@@ -28,8 +28,10 @@ struct LukeWatchView: View {
     private var signedInPages: some View {
         @Bindable var navigation = navigation
         return TabView(selection: $navigation.page) {
-            WatchVoiceView()
-                .tag(WatchPage.voice)
+            NavigationStack {
+                WatchVoiceView()
+            }
+            .tag(WatchPage.voice)
             NavigationStack(path: $navigation.path) {
                 WatchRosterView()
             }

--- a/apps/ios/LukeWatch/WatchVoiceSessionModel.swift
+++ b/apps/ios/LukeWatch/WatchVoiceSessionModel.swift
@@ -26,6 +26,9 @@ enum WatchPendingNavigation {
 final class WatchVoiceSessionModel {
     var status: RealtimeStatus = .idle
     var errorMessage: String?
+    // Read at each mint, so the watch uses the latest local voice settings.
+    var voice = RealtimeVoice.default
+    var speed = RealtimeVoiceSpeed.default
     var pendingNavigation: WatchPendingNavigation?
     /// The tools the service minted the latest call with, as the server
     /// confirmed them at channel open; nil until a call has connected.
@@ -79,6 +82,8 @@ final class WatchVoiceSessionModel {
             }
             return
         }
+        let mintVoice = voice.rawValue
+        let mintSpeed = speed.multiplier
 
         let opts = RealtimeSessionOptions(
             requestConnection: { [weak accountSession, weak self] in
@@ -98,8 +103,8 @@ final class WatchVoiceSessionModel {
                     )
                     .mint(
                         accessToken: token,
-                        voice: RealtimeVoice.default.rawValue,
-                        speed: RealtimeVoiceSpeed.default.multiplier
+                        voice: mintVoice,
+                        speed: mintSpeed
                     )
                 } catch let error as URLError {
                     throw WatchNetworkFailure(error)
@@ -236,5 +241,28 @@ final class WatchVoiceSessionModel {
         } else {
             session?.endTurn()
         }
+    }
+
+    /// Voice is fixed at mint time. The watch opens sockets only when the
+    /// developer presses, so a changed voice closes the current one and lets
+    /// the next press mint with the new choice.
+    func changeVoice(_ newVoice: RealtimeVoice) {
+        guard newVoice != voice else { return }
+        voice = newVoice
+        guard session != nil || connectTask != nil else { return }
+        connectTask?.cancel()
+        connectTask = nil
+        connectingForTurn = false
+        endTurnAfterConnect = false
+        session?.close()
+        session = nil
+        WatchVoiceAudioSession.deactivate()
+        status = .idle
+    }
+
+    func changeSpeed(_ newSpeed: RealtimeVoiceSpeed) {
+        guard newSpeed != speed else { return }
+        speed = newSpeed
+        session?.applySpeed(newSpeed.multiplier)
     }
 }

--- a/apps/ios/LukeWatch/WatchVoiceSettingsView.swift
+++ b/apps/ios/LukeWatch/WatchVoiceSettingsView.swift
@@ -1,0 +1,107 @@
+import LukeKit
+import SwiftUI
+
+/// The watch's copy of the voice settings the phone draws: the voice used for
+/// the next mint, the speed heard from the next reply, and the debug tool list
+/// read from the current watch call and roster.
+struct WatchVoiceSettingsView: View {
+    let toolReport: VoiceToolReport
+
+    @AppStorage(VoiceSettingsKey.voice) private var voice = RealtimeVoice.default
+    @AppStorage(VoiceSettingsKey.speed) private var speed = RealtimeVoiceSpeed.default
+    @Environment(ProductEventSender.self) private var events
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section {
+                    Picker("Voice", selection: voiceChoice) {
+                        ForEach(RealtimeVoice.allCases) { candidate in
+                            Text(candidate.displayName).tag(candidate)
+                        }
+                    }
+                }
+
+                Section {
+                    Picker("Speed", selection: speedChoice) {
+                        ForEach(RealtimeVoiceSpeed.allCases) { candidate in
+                            Text(candidate.multipleLabel).tag(candidate)
+                        }
+                    }
+                }
+
+                if isChanged {
+                    Section {
+                        Button("Reset to Defaults") { resetToDefaults() }
+                    }
+                }
+
+                Section {
+                    ForEach(toolReport.standings) { standing in
+                        toolRow(standing)
+                    }
+                } header: {
+                    Text("Debug")
+                } footer: {
+                    Text(
+                        toolReport.mintedKnown
+                            ? "Every tool Luke can be asked for on the Mac, and why one is not available here right now."
+                            : "Which tools the service minted is known once a call connects."
+                    )
+                }
+            }
+            .animation(.default, value: isChanged)
+            .navigationTitle("Voice Settings")
+        }
+    }
+
+    private var isChanged: Bool {
+        voice != RealtimeVoice.default || speed != RealtimeVoiceSpeed.default
+    }
+
+    private func toolRow(_ standing: VoiceToolStanding) -> some View {
+        HStack(alignment: .firstTextBaseline, spacing: 8) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(standing.name)
+                    .font(.caption2.monospaced())
+                Text(standing.unavailableReason ?? standing.summary)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer(minLength: 0)
+            Image(systemName: standing.isAvailable ? "checkmark.circle.fill" : "minus.circle")
+                .foregroundStyle(standing.isAvailable ? Color.green : Color.secondary)
+                .accessibilityHidden(true)
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityValue(standing.isAvailable ? "Available" : "Not available")
+    }
+
+    private var voiceChoice: Binding<RealtimeVoice> {
+        Binding(
+            get: { voice },
+            set: { chosen in
+                guard chosen != voice else { return }
+                voice = chosen
+                events.record(.settingUpdate(setting: .voice, value: .set))
+            }
+        )
+    }
+
+    private var speedChoice: Binding<RealtimeVoiceSpeed> {
+        Binding(
+            get: { speed },
+            set: { chosen in
+                guard chosen != speed else { return }
+                speed = chosen
+                events.record(.settingUpdate(setting: .voiceSpeed, value: .set))
+            }
+        )
+    }
+
+    private func resetToDefaults() {
+        voice = RealtimeVoice.default
+        speed = RealtimeVoiceSpeed.default
+        events.record(.settingsReset)
+    }
+}

--- a/apps/ios/LukeWatch/WatchVoiceView.swift
+++ b/apps/ios/LukeWatch/WatchVoiceView.swift
@@ -12,8 +12,11 @@ struct WatchVoiceView: View {
     @Environment(WatchNavigation.self) private var navigation
     @Environment(VoiceConversationThread.self) private var conversation
     @Environment(ProductEventSender.self) private var events
+    @AppStorage(VoiceSettingsKey.voice) private var voice = RealtimeVoice.default
+    @AppStorage(VoiceSettingsKey.speed) private var speed = RealtimeVoiceSpeed.default
     @State private var model = WatchVoiceSessionModel()
     @State private var isPressing = false
+    @State private var settingsShown = false
     private let actClient = ActClient(baseURL: AccountConstants.serviceURL)
 
     var body: some View {
@@ -22,6 +25,8 @@ struct WatchVoiceView: View {
             floatingControls
         }
         .task {
+            model.voice = voice
+            model.speed = speed
             model.prepare(
                 accountSession: accountSession, thread: conversation, actContext: makeActContext
             )
@@ -35,8 +40,23 @@ struct WatchVoiceView: View {
                 performPendingNavigation()
             }
         }
+        .onChange(of: voice) { _, newVoice in model.changeVoice(newVoice) }
+        .onChange(of: speed) { _, newSpeed in model.changeSpeed(newSpeed) }
         .onDisappear {
             model.stop()
+        }
+        .navigationTitle("Luke")
+        .toolbar {
+            ToolbarItem(placement: .topBarLeading) { settingsButton }
+        }
+        .sheet(isPresented: $settingsShown) {
+            WatchVoiceSettingsView(
+                toolReport: VoiceToolAvailability.report(
+                    mintedTools: model.mintedTools,
+                    sessions: store.sessions,
+                    projects: model.projects
+                )
+            )
         }
     }
 
@@ -120,6 +140,15 @@ struct WatchVoiceView: View {
     }
 
     // MARK: - Floating controls
+
+    private var settingsButton: some View {
+        Button {
+            settingsShown = true
+        } label: {
+            Label("Voice Settings", systemImage: "gearshape")
+        }
+        .accessibilityLabel("Voice Settings")
+    }
 
     private var floatingControls: some View {
         VStack(spacing: 4) {

--- a/apps/ios/README.md
+++ b/apps/ios/README.md
@@ -73,9 +73,9 @@ on the watch's own: `open_session` swipes to the sessions page and pushes the
 session's screen once Luke's reply has finished, and `show_panel` narrows,
 sorts, or searches the watch list the same way, drawing a Show All row above
 the rows a narrowing leaves so a list Luke narrowed never hides a session
-without saying so. The watch posts no product events, so a spoken act counts
-nothing there, and it draws no settings sheet, so the Debug tool list is the
-phone's alone.
+without saying so. The watch voice page also has the phone's Settings pattern:
+a gear button opens voice and speed controls, plus the Debug tool list read
+from the watch call and roster.
 
 ## Analytics
 

--- a/scripts/ios-project.test.mjs
+++ b/scripts/ios-project.test.mjs
@@ -26,6 +26,18 @@ const watchRoster = fs.readFileSync(
   path.join(repoRoot, "apps", "ios", "LukeWatch", "WatchRosterView.swift"),
   "utf8",
 );
+const watchVoice = fs.readFileSync(
+  path.join(repoRoot, "apps", "ios", "LukeWatch", "WatchVoiceView.swift"),
+  "utf8",
+);
+const watchVoiceModel = fs.readFileSync(
+  path.join(repoRoot, "apps", "ios", "LukeWatch", "WatchVoiceSessionModel.swift"),
+  "utf8",
+);
+const watchVoiceSettings = fs.readFileSync(
+  path.join(repoRoot, "apps", "ios", "LukeWatch", "WatchVoiceSettingsView.swift"),
+  "utf8",
+);
 const watchAccount = fs.readFileSync(
   path.join(repoRoot, "apps", "ios", "LukeWatch", "WatchAccountSession.swift"),
   "utf8",
@@ -42,6 +54,14 @@ const watchConnectivity = fs.readFileSync(
   path.join(repoRoot, "apps", "ios", "LukeWatch", "WatchConnectivityReceiver.swift"),
   "utf8",
 );
+
+test("the Xcode project has unique object identifiers", () => {
+  const definitions = [...project.matchAll(/^\t\t([A-F0-9]{24}) (?:\/\* .* \*\/ )?= /gm)].map(
+    (match) => match[1],
+  );
+  const duplicates = definitions.filter((id, index) => definitions.indexOf(id) !== index);
+  assert.deepEqual(duplicates, []);
+});
 
 test("the iPhone app embeds and depends on the Watch app", () => {
   assert.match(project, /LukeWatch\.app in Embed Watch Content/);
@@ -84,6 +104,35 @@ test("the Watch tears down account-scoped UI when the paired account changes", (
   assert.match(watchAccount, /func signOut\(\)[\s\S]*?accountScope = nil/);
   assert.match(watchRoot, /NavigationStack[\s\S]*?\.id\(watchSession\.accountScope\)/);
   assert.match(watchRoot, /\.onChange\(of: watchSession\.accountScope\)/);
+});
+
+test("the Watch voice page exposes settings and applies them to mints", () => {
+  assert.match(
+    watchRoot,
+    /NavigationStack \{[\s\S]*?WatchVoiceView\(\)[\s\S]*?\.tag\(WatchPage\.voice\)/,
+  );
+  assert.match(watchVoice, /ToolbarItem\(placement: \.topBarLeading\) \{ settingsButton \}/);
+  assert.match(watchVoice, /WatchVoiceSettingsView\([\s\S]*?VoiceToolAvailability\.report/);
+  assert.doesNotMatch(watchVoiceSettings, /Button\("Done"\)/);
+  assert.doesNotMatch(watchVoiceSettings, /placement: \.confirmationAction/);
+  assert.match(watchVoiceSettings, /Picker\("Voice", selection: voiceChoice\)/);
+  assert.match(watchVoiceSettings, /Picker\("Speed", selection: speedChoice\)/);
+  assert.match(
+    watchVoiceSettings,
+    /events\.record\(\.settingUpdate\(setting: \.voice, value: \.set\)\)/,
+  );
+  assert.match(
+    watchVoiceSettings,
+    /events\.record\(\.settingUpdate\(setting: \.voiceSpeed, value: \.set\)\)/,
+  );
+  assert.match(watchVoiceModel, /let mintVoice = voice\.rawValue/);
+  assert.match(watchVoiceModel, /let mintSpeed = speed\.multiplier/);
+  assert.match(watchVoiceModel, /voice: mintVoice/);
+  assert.match(watchVoiceModel, /speed: mintSpeed/);
+  assert.match(
+    watchVoiceModel,
+    /func changeSpeed\(_ newSpeed: RealtimeVoiceSpeed\)[\s\S]*?session\?\.applySpeed\(newSpeed\.multiplier\)/,
+  );
 });
 
 test("cancelled Watch roster reads do not become completed empty states", () => {


### PR DESCRIPTION
## Summary
- Add a top-left gear button to the watchOS Voice page, matching the iOS Voice settings affordance while fitting watchOS placement.
- Add a watchOS Voice Settings sheet with voice, speed, reset, and Debug tool availability sections; closing relies on the single system X, with no separate Done button.
- Apply the selected watch voice and speed to realtime mints, and update the iOS README for the new watch behavior.

## Checklist
- [x] Watch Voice page exposes Settings from the top-left navigation bar.
- [x] Voice Settings detail uses only the system X close affordance, with no separate Done button.
- [x] Settings changes are persisted with the shared voice settings keys.
- [x] Watch realtime sessions mint with the selected voice and speed.
- [x] Project file includes the new watch settings view in the watch target.
- [x] Portable iOS project contract test covers the new watch settings wiring.
- [x] `./scripts/check.sh` passes after `./scripts/bootstrap.sh`.
- [ ] Xcode/watchOS target build verified on a local Mac or dedicated iOS/watchOS CI.

## Validation
- `./scripts/bootstrap.sh`
- `node --test scripts/ios-project.test.mjs`
- `./scripts/check.sh`

Swift/Xcode validation was not run locally because this cloud Linux VM does not have `swift` or `xcodebuild` installed.

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/33937134384/artifacts/9960591758) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/33937134384)

- Commit: `10f461b1fb46058acb52c3517cd5e3c496c04621`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
