### PR TITLE
feat(desktop): add the hidden voice window shell and role, routed to nothing

### DIFF
--- a/apps/desktop/src/main/desktop-app.ts
+++ b/apps/desktop/src/main/desktop-app.ts
@@ -806,6 +806,7 @@ const introductionWindow = new IntroductionWindow({
     process.stderr.write(`Introduction abandoned: ${reason}\n`);
     void abandonIntroduction();
   },
+  onClosed: () => quitUnlessPanelStands(),
 });
 /**
  * The hidden window that will hold the live conversation, so that no panel
@@ -827,6 +828,21 @@ const voiceWindow = new VoiceWindow({
   },
 });
 const voiceWindowWanted = runMode.registersGlobalKeys || runMode.sendsNetwork;
+
+/**
+ * The invariant the hidden window lives under: it never keeps the process
+ * alive. It is raised only once a panel stands, so it is never the only
+ * window, and whenever the takeover — the one other window that can stand
+ * with no panel — goes down by any route, a run with no panel ends here
+ * rather than living on invisibly.
+ */
+function raiseVoiceWindow(): void {
+  if (voiceWindowWanted && panels.standing > 0) voiceWindow.open();
+}
+
+function quitUnlessPanelStands(): void {
+  if (panels.standing === 0) app.quit();
+}
 /**
  * Whether the takeover's renderer ever reported mounting. A takeover that
  * never draws is a fullscreen window swallowing every click with nothing on
@@ -1118,6 +1134,7 @@ async function finishIntroduction(given: boolean): Promise<void> {
   // expands the gate — the same morph, Luke riding from the wing spot into
   // the gate's face, that every later signed-out launch plays.
   panels.reconcile();
+  raiseVoiceWindow();
   await Promise.race([
     panelReady,
     new Promise((resolve) => setTimeout(resolve, INTRODUCTION_HANDOFF_READY_MS)),
@@ -1143,6 +1160,7 @@ async function abandonIntroduction(): Promise<void> {
   // answered by the introduction's standing while it is being stood down.
   introductionWindow.retire();
   panels.reconcile();
+  raiseVoiceWindow();
   panels.showInactiveAll();
   introductionWindow.close();
   await hotkeys.reapply(HOTKEY_RANK.TALK);
@@ -3085,10 +3103,9 @@ export function startDesktopApp(): void {
       // The introduction owns the screen alone until it completes or is
       // abandoned; both of its endings reconcile the panels themselves.
       if (!introductionWindow.active) panels.reconcile();
-      // Raised after the panels, so it is never the only window standing: the
-      // panels closing is how this process decides it is done, and a hidden
-      // window that stood alone would keep an app nobody can see alive.
-      if (voiceWindowWanted) voiceWindow.open();
+      // Raised only once a panel stands; during the introduction, its ending
+      // is what raises the panels and the voice window with them.
+      raiseVoiceWindow();
       configurePermissions();
       startSessionObservation();
       startCalendarObservation();

--- a/apps/desktop/src/main/desktop-app.ts
+++ b/apps/desktop/src/main/desktop-app.ts
@@ -812,7 +812,7 @@ const introductionWindow = new IntroductionWindow({
  * does. It stands for the whole run on any launch that could speak — an
  * interactive one, or one that reaches the network — and never in a fixture or
  * capture run, where nothing would. A renderer that dies is stood up again by
- * the main process; nothing drawn depends on it.
+ * the window itself, within its own bound; nothing drawn depends on it.
  */
 const voiceWindow = new VoiceWindow({
   runMode,
@@ -821,16 +821,12 @@ const voiceWindow = new VoiceWindow({
   rendererUrl: rendererUrl(),
   onGone: (reason) => {
     process.stderr.write(`Voice window replaced: ${reason}\n`);
-    voiceWindow.close();
-    if (!quitting) voiceWindow.open();
+  },
+  onGaveUp: (reason) => {
+    process.stderr.write(`Voice window abandoned: ${reason}\n`);
   },
 });
 const voiceWindowWanted = runMode.registersGlobalKeys || runMode.sendsNetwork;
-/**
- * Set at the first quit signal so a voice renderer going down during the quit
- * itself is not stood up again behind the app's back.
- */
-let quitting = false;
 /**
  * Whether the takeover's renderer ever reported mounting. A takeover that
  * never draws is a fullscreen window swallowing every click with nothing on
@@ -3175,10 +3171,9 @@ export function startDesktopApp(): void {
   });
 
   app.on("before-quit", () => {
-    quitting = true;
     // Closed by the main process, never waited on: the panels closing is what
     // decides the app is done, and this window was never one of them.
-    voiceWindow.close();
+    voiceWindow.closeForGood();
     observationSupervisor.setEnabled(false);
     stopCalendarObservation();
     for (const watcher of spoolWatchers) watcher.close();

--- a/apps/desktop/src/main/desktop-app.ts
+++ b/apps/desktop/src/main/desktop-app.ts
@@ -206,6 +206,7 @@ import { DockPresence } from "./window/dock-presence";
 import { HOTKEY_RANK, HotkeyRegistrar } from "./window/hotkey-registrar";
 import { IntroductionWindow } from "./window/introduction-window";
 import { PanelManager } from "./window/panel-manager";
+import { VoiceWindow } from "./window/voice-window";
 
 // Which Luke this process is decides where its state lives and which Keychain
 // entry protects its credentials; see app-identity.ts for why a development
@@ -783,6 +784,9 @@ const panels = new PanelManager({
   preloadPath: path.join(__dirname, "preload.js"),
   rendererHtmlPath: path.join(__dirname, "renderer", "index.html"),
   rendererUrl: rendererUrl(),
+  // The hidden voice window outlives the panels, so the panels say for
+  // themselves when the last of them is gone.
+  onAllClosed: () => app.quit(),
 });
 // The one-time spoken introduction: a fullscreen takeover on the first
 // interactive launch, before any account exists. Its voice runs on the hosted
@@ -803,6 +807,30 @@ const introductionWindow = new IntroductionWindow({
     void abandonIntroduction();
   },
 });
+/**
+ * The hidden window that will hold the live conversation, so that no panel
+ * does. It stands for the whole run on any launch that could speak — an
+ * interactive one, or one that reaches the network — and never in a fixture or
+ * capture run, where nothing would. A renderer that dies is stood up again by
+ * the main process; nothing drawn depends on it.
+ */
+const voiceWindow = new VoiceWindow({
+  runMode,
+  preloadPath: path.join(__dirname, "preload.js"),
+  rendererHtmlPath: path.join(__dirname, "renderer", "index.html"),
+  rendererUrl: rendererUrl(),
+  onGone: (reason) => {
+    process.stderr.write(`Voice window replaced: ${reason}\n`);
+    voiceWindow.close();
+    if (!quitting) voiceWindow.open();
+  },
+});
+const voiceWindowWanted = runMode.registersGlobalKeys || runMode.sendsNetwork;
+/**
+ * Set at the first quit signal so a voice renderer going down during the quit
+ * itself is not stood up again behind the app's back.
+ */
+let quitting = false;
 /**
  * Whether the takeover's renderer ever reported mounting. A takeover that
  * never draws is a fullscreen window swallowing every click with nothing on
@@ -1792,9 +1820,12 @@ function registerIpc(): void {
       // Each window bootstraps as itself: its own display, its own mode. The
       // roster and the settings are the same everywhere.
       const displayId = panels.displayIdFor(context.sender);
-      const display =
-        (displayId !== undefined ? panels.display(displayId) : undefined) ??
-        screen.getPrimaryDisplay();
+      // The voice window stands on no display and ignores the panel-only
+      // fields; everything else is fabricated a display as before.
+      const display = voiceWindow.owns(context.sender)
+        ? undefined
+        : ((displayId !== undefined ? panels.display(displayId) : undefined) ??
+          screen.getPrimaryDisplay());
       const [supersetInstalled, supersetConnected] = await Promise.all([
         supersetCli.installed(),
         supersetCli.connected(),
@@ -1826,7 +1857,7 @@ function registerIpc(): void {
         ...(hotkeys.ask ? { askHotkey: hotkeys.ask } : undefined),
         ...(hotkeys.stop ? { stopHotkey: hotkeys.stop } : undefined),
         ...(outputAudio ? { outputAudio } : undefined),
-        display: panels.diagnostic(display),
+        display: display ? panels.diagnostic(display) : undefined,
         update: updateService.snapshot(),
         // Bootstrapped through the same relevance gate every broadcast passes:
         // a panel that opens late must not learn of rows the roster has already
@@ -2148,7 +2179,11 @@ function registerIpc(): void {
   // Which surface a window draws, decided by which window asked — never by
   // anything the renderer could claim about itself.
   registerContextHandler(BRIDGE.getWindowRole, (context: BridgeContext) =>
-    introductionWindow.owns(context.sender) ? WINDOW_ROLE.INTRODUCTION : WINDOW_ROLE.PANEL,
+    introductionWindow.owns(context.sender)
+      ? WINDOW_ROLE.INTRODUCTION
+      : voiceWindow.owns(context.sender)
+        ? WINDOW_ROLE.VOICE
+        : WINDOW_ROLE.PANEL,
   );
 
   // The introduction's one-shot keyless read of this machine's local
@@ -2824,11 +2859,13 @@ function stopIssueObservation(): void {
 }
 
 function configurePermissions(): void {
-  // The takeover is a window of Luke's own under the same hardening as the
-  // panels, and its practice beat is a real spoken turn, so it is owed the
-  // same audio-only answer.
+  // The takeover and the voice window are windows of Luke's own under the
+  // same hardening as the panels, and each speaks a real spoken turn, so they
+  // are owed the same audio-only answer.
   const ownWindow = (webContents: Electron.WebContents) =>
-    panels.owns(webContents) || introductionWindow.owns(webContents);
+    panels.owns(webContents) ||
+    introductionWindow.owns(webContents) ||
+    voiceWindow.owns(webContents);
   session.defaultSession.setPermissionCheckHandler(
     (webContents, permission, _origin, details) =>
       webContents !== null &&
@@ -3052,6 +3089,10 @@ export function startDesktopApp(): void {
       // The introduction owns the screen alone until it completes or is
       // abandoned; both of its endings reconcile the panels themselves.
       if (!introductionWindow.active) panels.reconcile();
+      // Raised after the panels, so it is never the only window standing: the
+      // panels closing is how this process decides it is done, and a hidden
+      // window that stood alone would keep an app nobody can see alive.
+      if (voiceWindowWanted) voiceWindow.open();
       configurePermissions();
       startSessionObservation();
       startCalendarObservation();
@@ -3134,6 +3175,10 @@ export function startDesktopApp(): void {
   });
 
   app.on("before-quit", () => {
+    quitting = true;
+    // Closed by the main process, never waited on: the panels closing is what
+    // decides the app is done, and this window was never one of them.
+    voiceWindow.close();
     observationSupervisor.setEnabled(false);
     stopCalendarObservation();
     for (const watcher of spoolWatchers) watcher.close();
@@ -3146,5 +3191,8 @@ export function startDesktopApp(): void {
     panels.clearCollapseTimers();
   });
 
+  // Fires only once every BrowserWindow is gone, the hidden voice window
+  // included, so the panels report their own last closing above; this stays
+  // for a run that never raised a voice window.
   app.on("window-all-closed", () => app.quit());
 }

--- a/apps/desktop/src/main/window/introduction-window.ts
+++ b/apps/desktop/src/main/window/introduction-window.ts
@@ -14,6 +14,12 @@ export interface IntroductionWindowOptions {
    * worst failure this feature has.
    */
   onGone: (reason: string) => void;
+  /**
+   * The takeover's window is gone by any route — its own `close()`, or a
+   * teardown that never passed through `onGone` — so whoever decides the
+   * process's lifetime can check that something visible still stands.
+   */
+  onClosed: () => void;
 }
 
 /**
@@ -85,6 +91,7 @@ export class IntroductionWindow {
     window.webContents.on("did-fail-load", (_event, _code, description) => {
       this.#options.onGone(`The takeover failed to load: ${description}`);
     });
+    window.on("closed", () => this.#options.onClosed());
     window.once("ready-to-show", () => {
       if (window.isDestroyed() || this.#retired) return;
       window.show();

--- a/apps/desktop/src/main/window/panel-manager.ts
+++ b/apps/desktop/src/main/window/panel-manager.ts
@@ -31,6 +31,12 @@ export interface PanelManagerOptions {
   rendererHtmlPath: string;
   rendererUrl: string;
   argv?: readonly string[];
+  /**
+   * The last panel window went down on its own. All panels closed is how
+   * this process decides it is done, and `window-all-closed` can no longer
+   * say so once a hidden window of Luke's own stands beside them.
+   */
+  onAllClosed?: () => void;
 }
 
 /**
@@ -61,6 +67,7 @@ export class PanelManager {
   readonly #preloadPath: string;
   readonly #rendererHtmlPath: string;
   readonly #rendererUrl: string;
+  readonly #onAllClosed: (() => void) | undefined;
   readonly initialMode: WindowMode;
   /**
    * One panel window per display Luke stands on, keyed by the display's id, each
@@ -95,6 +102,7 @@ export class PanelManager {
     this.#preloadPath = options.preloadPath;
     this.#rendererHtmlPath = options.rendererHtmlPath;
     this.#rendererUrl = options.rendererUrl;
+    this.#onAllClosed = options.onAllClosed;
     this.initialMode = initialWindowMode(options.runMode, options.argv ?? process.argv);
   }
 
@@ -491,6 +499,7 @@ export class PanelManager {
         this.#voiceExchanges.delete(id);
         this.#applyVoiceExchanges();
       }
+      if (this.#windows.size === 0) this.#onAllClosed?.();
     });
     void window.loadFile(this.#rendererHtmlPath);
   }

--- a/apps/desktop/src/main/window/panel-manager.ts
+++ b/apps/desktop/src/main/window/panel-manager.ts
@@ -306,6 +306,13 @@ export class PanelManager {
     this.#applyVoiceExchanges();
   }
 
+  /** How many panel windows stand — the count the process's lifetime is decided by. */
+  get standing(): number {
+    let count = 0;
+    for (const window of this.#windows.values()) if (!window.isDestroyed()) count += 1;
+    return count;
+  }
+
   /** Whether some panel window's renderer is asking, whichever display it is on. */
   owns(webContents: WebContents): boolean {
     for (const window of this.#windows.values()) {

--- a/apps/desktop/src/main/window/voice-window.ts
+++ b/apps/desktop/src/main/window/voice-window.ts
@@ -8,12 +8,24 @@ export interface VoiceWindowOptions {
   rendererHtmlPath: string;
   rendererUrl: string;
   /**
-   * The voice renderer died or hung. Nothing drawn depends on it, so the main
-   * process simply stands a fresh one up; an outstanding speech offer recovers
-   * by its own deadline.
+   * The voice renderer died or hung and a fresh one is about to be stood up,
+   * or the bound below has been reached and none will be. Nothing drawn
+   * depends on it; an outstanding speech offer recovers by its own deadline.
    */
   onGone: (reason: string) => void;
+  /**
+   * Reopening has stopped for this run: the renderer went down
+   * `MAXIMUM_REOPENS_PER_RUN` times without once finishing a load. A hidden
+   * window that crash-looped would be seen by nobody, so it is reported once
+   * and stood down, the way the trace writer answers a full disk.
+   */
+  onGaveUp: (reason: string) => void;
 }
+
+/** How many times a run may stand the voice renderer back up before a load succeeds. */
+export const MAXIMUM_REOPENS_PER_RUN = 3;
+/** The pause before a replacement, so a renderer dying on load cannot spin the process. */
+export const REOPEN_DELAY_MS = 1_000;
 
 /**
  * The one hidden window that will hold the live conversation, so that it
@@ -26,11 +38,18 @@ export interface VoiceWindowOptions {
  *
  * It does not count toward the app's lifetime: the panels closing is how this
  * process decides it is done, and this window is destroyed by the main process
- * on the way out rather than waited on.
+ * on the way out rather than waited on. It owns its own lifetime otherwise: a
+ * renderer that dies is replaced after a pause, at most a few times per run
+ * before a load succeeds, so a renderer that dies on load cannot crash-loop
+ * a window nobody can see.
  */
 export class VoiceWindow {
   readonly #options: VoiceWindowOptions;
   #window: BrowserWindow | undefined;
+  /** Reopens since the last load that finished; reset only by `did-finish-load`. */
+  #reopens = 0;
+  #reopenTimer: ReturnType<typeof setTimeout> | undefined;
+  #closedForGood = false;
 
   constructor(options: VoiceWindowOptions) {
     this.#options = options;
@@ -53,16 +72,43 @@ export class VoiceWindow {
     });
     this.#window = window;
     refuseForeignNavigation(window, this.#options.rendererUrl);
+    window.webContents.on("did-finish-load", () => {
+      this.#reopens = 0;
+    });
     window.webContents.on("render-process-gone", (_event, details) => {
-      this.#options.onGone(`The voice renderer went: ${details.reason}`);
+      this.#replace(window, `The voice renderer went: ${details.reason}`);
     });
     window.on("unresponsive", () => {
-      this.#options.onGone("The voice renderer stopped responding.");
+      this.#replace(window, "The voice renderer stopped responding.");
     });
     window.webContents.on("did-fail-load", (_event, _code, description) => {
-      this.#options.onGone(`The voice renderer failed to load: ${description}`);
+      this.#replace(window, `The voice renderer failed to load: ${description}`);
     });
     void window.loadFile(this.#options.rendererHtmlPath);
+  }
+
+  /**
+   * Stands a fresh renderer up in place of one that died, after a short pause
+   * and only within the bound. A window `close()` already retired reports
+   * nothing: its listeners can still fire as it is torn down.
+   */
+  #replace(window: BrowserWindow, reason: string): void {
+    if (this.#closedForGood || window !== this.#window || this.#reopenTimer) return;
+    this.close();
+    if (this.#reopens >= MAXIMUM_REOPENS_PER_RUN) {
+      this.#closedForGood = true;
+      this.#options.onGaveUp(
+        `${reason} It was replaced ${MAXIMUM_REOPENS_PER_RUN} times without loading, so it stays down for this run.`,
+      );
+      return;
+    }
+    this.#reopens += 1;
+    this.#options.onGone(reason);
+    this.#reopenTimer = setTimeout(() => {
+      this.#reopenTimer = undefined;
+      if (!this.#closedForGood) this.open();
+    }, REOPEN_DELAY_MS);
+    this.#reopenTimer.unref?.();
   }
 
   current(): BrowserWindow | undefined {
@@ -78,5 +124,13 @@ export class VoiceWindow {
     const window = this.#window;
     this.#window = undefined;
     if (window && !window.isDestroyed()) window.destroy();
+  }
+
+  /** The quit's own close: nothing is stood back up after it. */
+  closeForGood(): void {
+    this.#closedForGood = true;
+    if (this.#reopenTimer) clearTimeout(this.#reopenTimer);
+    this.#reopenTimer = undefined;
+    this.close();
   }
 }

--- a/apps/desktop/src/main/window/voice-window.ts
+++ b/apps/desktop/src/main/window/voice-window.ts
@@ -1,0 +1,82 @@
+import { BrowserWindow, type WebContents } from "electron";
+import type { RunMode } from "../run-mode";
+import { hardenedWebPreferences, refuseForeignNavigation } from "./hardened-window";
+
+export interface VoiceWindowOptions {
+  runMode: RunMode;
+  preloadPath: string;
+  rendererHtmlPath: string;
+  rendererUrl: string;
+  /**
+   * The voice renderer died or hung. Nothing drawn depends on it, so the main
+   * process simply stands a fresh one up; an outstanding speech offer recovers
+   * by its own deadline.
+   */
+  onGone: (reason: string) => void;
+}
+
+/**
+ * The one hidden window that will hold the live conversation, so that it
+ * outlives every panel: a panel reload, close, or display change must not end
+ * an exchange. It loads the same renderer bundle as the panels under the same
+ * hardening, differing only in its bootstrap role, and it is never shown,
+ * never focused, and never a target for anything drawn. It exists at most
+ * once, and everything it may ask of the main process is answered against
+ * `owns()` rather than against anything the renderer claims.
+ *
+ * It does not count toward the app's lifetime: the panels closing is how this
+ * process decides it is done, and this window is destroyed by the main process
+ * on the way out rather than waited on.
+ */
+export class VoiceWindow {
+  readonly #options: VoiceWindowOptions;
+  #window: BrowserWindow | undefined;
+
+  constructor(options: VoiceWindowOptions) {
+    this.#options = options;
+  }
+
+  open(): void {
+    if (this.current()) return;
+    const window = new BrowserWindow({
+      title: "Luke",
+      show: false,
+      width: 1,
+      height: 1,
+      frame: false,
+      skipTaskbar: true,
+      focusable: false,
+      webPreferences: hardenedWebPreferences({
+        preloadPath: this.#options.preloadPath,
+        runMode: this.#options.runMode,
+      }),
+    });
+    this.#window = window;
+    refuseForeignNavigation(window, this.#options.rendererUrl);
+    window.webContents.on("render-process-gone", (_event, details) => {
+      this.#options.onGone(`The voice renderer went: ${details.reason}`);
+    });
+    window.on("unresponsive", () => {
+      this.#options.onGone("The voice renderer stopped responding.");
+    });
+    window.webContents.on("did-fail-load", (_event, _code, description) => {
+      this.#options.onGone(`The voice renderer failed to load: ${description}`);
+    });
+    void window.loadFile(this.#options.rendererHtmlPath);
+  }
+
+  current(): BrowserWindow | undefined {
+    return this.#window !== undefined && !this.#window.isDestroyed() ? this.#window : undefined;
+  }
+
+  owns(webContents: WebContents): boolean {
+    const window = this.current();
+    return window !== undefined && window.webContents === webContents;
+  }
+
+  close(): void {
+    const window = this.#window;
+    this.#window = undefined;
+    if (window && !window.isDestroyed()) window.destroy();
+  }
+}

--- a/apps/desktop/src/renderer/index.tsx
+++ b/apps/desktop/src/renderer/index.tsx
@@ -3,6 +3,7 @@ import { createRoot } from "react-dom/client";
 import { WINDOW_ROLE } from "#shared/wire/session";
 import { App } from "./app";
 import { IntroductionTakeover } from "./introduction/introduction-takeover";
+import { VoiceHost } from "./voice/voice-host";
 
 Sentry.init();
 
@@ -12,7 +13,8 @@ const root = createRoot(rootElement);
 
 // Which surface this window draws is the main process's answer, asked before
 // anything mounts: the introduction takeover must not run the panel's hooks,
-// and the panel must not open the takeover's call. The role is its own tiny
+// the panel must not open the takeover's call, and the hidden voice window
+// draws nothing and records nothing. The role is its own tiny
 // invoke so the panel is not held on the full bootstrap twice; a role that
 // cannot be read falls back to the panel, the surface every window drew
 // before roles existed. A takeover whose bootstrap fails reports its own
@@ -24,10 +26,21 @@ void (async () => {
     if (role === WINDOW_ROLE.INTRODUCTION) {
       try {
         const bootstrap = await window.sidecar.getBootstrap();
-        root.render(<IntroductionTakeover bootstrap={bootstrap} />);
+        const { display } = bootstrap;
+        // Only the hidden voice window bootstraps without a display; a takeover
+        // handed none has nothing to cover and stands down.
+        if (display === undefined) {
+          window.sidecar.abandonIntroduction("The takeover's bootstrap named no display.");
+          return;
+        }
+        root.render(<IntroductionTakeover bootstrap={{ ...bootstrap, display }} />);
       } catch {
         window.sidecar.abandonIntroduction("The takeover could not read its bootstrap.");
       }
+      return;
+    }
+    if (role === WINDOW_ROLE.VOICE) {
+      root.render(<VoiceHost />);
       return;
     }
   } catch {

--- a/apps/desktop/src/renderer/index.tsx
+++ b/apps/desktop/src/renderer/index.tsx
@@ -16,8 +16,7 @@ const root = createRoot(rootElement);
 // the panel must not open the takeover's call, and the hidden voice window
 // draws nothing and records nothing. The role is its own tiny
 // invoke so the panel is not held on the full bootstrap twice; a role that
-// cannot be read falls back to the panel, the surface every window drew
-// before roles existed. A takeover whose bootstrap fails reports its own
+// cannot be read draws nothing, never the panel. A takeover whose bootstrap fails reports its own
 // abandonment rather than drawing the panel fullscreen — and if even that
 // report is lost, the main process's mount deadline stands the takeover down.
 void (async () => {
@@ -43,8 +42,13 @@ void (async () => {
       root.render(<VoiceHost />);
       return;
     }
-  } catch {
-    // Fall through to the panel.
+    root.render(<App />);
+  } catch (error) {
+    // A window whose role cannot be read mounts nothing. The panel is the
+    // one surface that records, so a fallback to it would let a voice window
+    // whose role call failed start recording a blank window; and a panel in
+    // the same state is already broken, since its bootstrap fails the same
+    // way, so the fallback protected nothing.
+    console.error("The window's role could not be read; nothing is drawn.", error);
   }
-  root.render(<App />);
 })();

--- a/apps/desktop/src/renderer/introduction/introduction-takeover.tsx
+++ b/apps/desktop/src/renderer/introduction/introduction-takeover.tsx
@@ -13,7 +13,7 @@ import {
 import { cssCustomProperties } from "@sidecar/surface/react-css";
 import { ACT_RESULT_STATUS } from "@sidecar/wire";
 import { type CSSProperties, useCallback, useEffect, useRef, useState } from "react";
-import type { AppBootstrap } from "#shared/wire/session";
+import type { AppBootstrap, DisplayDiagnostic } from "#shared/wire/session";
 import { Keycaps } from "../keycaps";
 import { usePrefersReducedMotion } from "../luke-face-mood";
 import { openPreferredMicrophone } from "../microphone-choice";
@@ -181,7 +181,7 @@ const STANDING_DOWN_BEATS: ReadonlySet<IntroductionBeat> = new Set([
 export function IntroductionTakeover({
   bootstrap,
 }: {
-  bootstrap: AppBootstrap;
+  bootstrap: AppBootstrap & { display: DisplayDiagnostic };
 }): React.JSX.Element {
   const [beat, setBeat] = useState<IntroductionBeat>(INTRODUCTION_BEAT.DARK);
   const beatRef = useRef<IntroductionBeat>(beat);

--- a/apps/desktop/src/renderer/use-voice-conversation.test.ts
+++ b/apps/desktop/src/renderer/use-voice-conversation.test.ts
@@ -8,6 +8,7 @@ import {
   REALTIME_VOICE,
   REALTIME_VOICE_SPEED,
 } from "@sidecar/realtime";
+import { voiceExchangeActive, voiceExchangeKind } from "#shared/wire/voice-view";
 import { REPLY_KIND } from "./realtime-session";
 import {
   activeVoiceStream,
@@ -25,8 +26,6 @@ import {
   typedAskHolds,
   VOICE_RESTART,
   voiceErrorToShow,
-  voiceExchangeActive,
-  voiceExchangeKind,
   voiceNoticeToShow,
   voiceRestartAction,
   waitForConversationContext,

--- a/apps/desktop/src/renderer/use-voice-conversation.ts
+++ b/apps/desktop/src/renderer/use-voice-conversation.ts
@@ -1,4 +1,3 @@
-import { PRODUCT_EXCHANGE_KIND, type ProductExchangeKind } from "@sidecar/analytics";
 import { sanitizedTraceEvent } from "@sidecar/devtrace/vocabulary";
 import { FIXTURE_SPEAKING_CAPTION } from "@sidecar/fixtures";
 import {
@@ -26,6 +25,7 @@ import { ACT_RESULT_STATUS } from "@sidecar/wire";
 import { type RefObject, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { MicrophoneStatus, VoiceHotkeyState } from "#shared/wire/audio";
 import type { ConversationHistoryPayload } from "#shared/wire/session";
+import { voiceExchangeActive, voiceExchangeKind } from "#shared/wire/voice-view";
 import { hostedVoiceUnavailableNote } from "./microphone-access";
 import { openPreferredMicrophone } from "./microphone-choice";
 import {
@@ -80,32 +80,6 @@ export function activeVoiceStream<T>(input: {
   if (input.status === REALTIME_STATUS.RESPONDING) return input.remote;
   if (input.status === REALTIME_STATUS.LISTENING) return input.local;
   return undefined;
-}
-
-/**
- * The exchange is live from the press to the end of the reply — the call
- * coming up, a turn being held, Luke speaking — and the media duck follows it.
- */
-export function voiceExchangeActive(status: RealtimeStatus): boolean {
-  return (
-    status === REALTIME_STATUS.CONNECTING ||
-    status === REALTIME_STATUS.LISTENING ||
-    status === REALTIME_STATUS.RESPONDING
-  );
-}
-
-/**
- * Who opened the exchange the count is about. Luke's own speak-only call has
- * no microphone to offer, which is the whole of what tells his announcement
- * from a turn the developer took; between the developer's own two ways in,
- * only the composer says so in advance, so the talk key is what is left.
- */
-export function voiceExchangeKind(input: {
-  microphoneCall: boolean;
-  typedAsk: boolean;
-}): ProductExchangeKind {
-  if (!input.microphoneCall) return PRODUCT_EXCHANGE_KIND.ANNOUNCEMENT;
-  return input.typedAsk ? PRODUCT_EXCHANGE_KIND.TYPED : PRODUCT_EXCHANGE_KIND.SPOKEN;
 }
 
 /**

--- a/apps/desktop/src/renderer/voice/voice-host.tsx
+++ b/apps/desktop/src/renderer/voice/voice-host.tsx
@@ -1,0 +1,14 @@
+/**
+ * What the hidden voice window mounts: the element Luke's voice will play
+ * through and nothing drawn. It never mounts `App` and never imports the
+ * session-replay client, because this window is not the panel and must not
+ * record; `repository-checks.sh` holds that line for everything under
+ * `renderer/voice/`.
+ */
+export function VoiceHost(): React.JSX.Element {
+  return (
+    <audio autoPlay hidden>
+      <track kind="captions" />
+    </audio>
+  );
+}

--- a/apps/desktop/src/shared/bridge.test.ts
+++ b/apps/desktop/src/shared/bridge.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import { maximumTypedAskLength } from "@sidecar/realtime";
 import { BRIDGE } from "./bridge";
 
 test("act bridge entries reject legacy and malformed outcomes", () => {
@@ -174,4 +175,97 @@ test("settling speech takes an id and one of the four outcomes", () => {
   assert.equal(guard(["one", "dropped"]), false);
   assert.equal(guard([1, "spoken"]), false);
   assert.equal(guard(["one", "spoken", "extra"]), false);
+});
+
+test("the window role guard admits the hidden voice role beside the drawn two", () => {
+  const guard = BRIDGE.getWindowRole.result;
+  assert.ok(guard);
+  assert.equal(guard("panel"), true);
+  assert.equal(guard("introduction"), true);
+  assert.equal(guard("voice"), true);
+  assert.equal(guard("takeover"), false);
+});
+
+const VOICE_VIEW = {
+  voiceStatus: "responding",
+  voiceError: undefined,
+  voiceNotice: "Listening on the built-in microphone.",
+  talkOpening: false,
+  lukeCaptions: ["Claude Code finished checkout."],
+  liveConversationEntries: [{ kind: "reply", words: "Checkout is green.", recordedAt: 12 }],
+};
+
+test("a voice view carries its six fields and nothing malformed", () => {
+  const guard = BRIDGE.onVoiceViewChanged.result;
+  assert.ok(guard);
+  assert.equal(guard(VOICE_VIEW), true);
+  assert.equal(guard({ ...VOICE_VIEW, lukeCaptions: undefined, voiceNotice: undefined }), true);
+  assert.equal(guard({ ...VOICE_VIEW, voiceStatus: "shouting" }), false);
+  assert.equal(guard({ ...VOICE_VIEW, talkOpening: "yes" }), false);
+  assert.equal(guard({ ...VOICE_VIEW, voiceError: 4 }), false);
+  assert.equal(guard({ ...VOICE_VIEW, lukeCaptions: [1] }), false);
+  assert.equal(guard({ ...VOICE_VIEW, liveConversationEntries: [{ kind: "reply" }] }), false);
+  assert.equal(guard({ ...VOICE_VIEW, liveConversationEntries: undefined }), false);
+  assert.equal(BRIDGE.reportVoiceView.args([VOICE_VIEW]), true);
+  assert.equal(BRIDGE.reportVoiceView.args([VOICE_VIEW, VOICE_VIEW]), false);
+  assert.equal(BRIDGE.reportVoiceView.args([{ ...VOICE_VIEW, voiceStatus: 1 }]), false);
+});
+
+test("a voice level is one finite number in the unit interval", () => {
+  const guard = BRIDGE.onVoiceLevelChanged.result;
+  assert.ok(guard);
+  assert.equal(guard(0), true);
+  assert.equal(guard(0.5), true);
+  assert.equal(guard(1), true);
+  assert.equal(guard(1.5), false);
+  assert.equal(guard(-0.1), false);
+  assert.equal(guard(Number.NaN), false);
+  assert.equal(guard("loud"), false);
+  assert.equal(BRIDGE.reportVoiceLevel.args([0.25]), true);
+  assert.equal(BRIDGE.reportVoiceLevel.args([]), false);
+  assert.equal(BRIDGE.reportVoiceLevel.args([0.25, 0.5]), false);
+});
+
+test("a microphone status broadcast is one of the system's five answers", () => {
+  const guard = BRIDGE.onMicrophoneStatusChanged.result;
+  assert.ok(guard);
+  for (const status of ["not-determined", "granted", "denied", "restricted", "unknown"]) {
+    assert.equal(guard(status), true);
+  }
+  assert.equal(guard("allowed"), false);
+  assert.equal(guard(undefined), false);
+});
+
+test("a voice command carries words only for a typed ask, bounded", () => {
+  assert.equal(BRIDGE.voiceCommand.kind, "invoke");
+  const guard = BRIDGE.voiceCommand.args;
+  assert.equal(guard(["ask-text", "what is checkout doing"]), true);
+  assert.equal(guard(["ask-text", "x".repeat(maximumTypedAskLength)]), true);
+  assert.equal(guard(["ask-text", "x".repeat(maximumTypedAskLength + 1)]), false);
+  assert.equal(guard(["ask-text", undefined]), false);
+  for (const command of [
+    "discard-listening",
+    "stop-speaking",
+    "request-microphone-access",
+    "clear-conversation",
+  ]) {
+    assert.equal(guard([command, undefined]), true);
+    assert.equal(guard([command, "words"]), false);
+  }
+  assert.equal(guard(["stop-microphone", undefined]), false);
+  assert.equal(guard(["stop-speaking"]), false);
+  const forwarded = BRIDGE.onVoiceCommand.result;
+  assert.ok(forwarded);
+  assert.equal(forwarded({ command: "ask-text", text: "hello" }), true);
+  assert.equal(forwarded({ command: "stop-speaking", text: undefined }), true);
+  assert.equal(forwarded({ command: "stop-speaking", text: "hello" }), false);
+  assert.equal(forwarded({ command: "ask-text", text: undefined }), false);
+  assert.equal(forwarded({ command: "dance" }), false);
+});
+
+test("shortcut capture is reported as one boolean", () => {
+  assert.equal(BRIDGE.setShortcutCapturing.kind, "send");
+  assert.equal(BRIDGE.setShortcutCapturing.args([true]), true);
+  assert.equal(BRIDGE.setShortcutCapturing.args(["true"]), false);
+  assert.equal(BRIDGE.setShortcutCapturing.args([]), false);
 });

--- a/apps/desktop/src/shared/bridge.ts
+++ b/apps/desktop/src/shared/bridge.ts
@@ -26,6 +26,7 @@ import { type AppGuideSnapshot, isAppGuideSnapshot } from "@sidecar/guide";
 import type { TrackedIssue } from "@sidecar/issues";
 import {
   type ConversationEntry,
+  maximumTypedAskLength,
   type RealtimeConnection,
   type RealtimeDiagnostics,
   storedConversationEntry,
@@ -90,6 +91,13 @@ import {
   type SpeechWithdrawal,
 } from "./wire/speech";
 import type { UpdateSnapshot } from "./wire/update";
+import {
+  isVoiceCommand,
+  isVoiceView,
+  VOICE_COMMAND,
+  type VoiceCommand,
+  type VoiceView,
+} from "./wire/voice-view";
 
 export interface WireGuard<Value> {
   // oxlint-disable-next-line anti-slop/no-unknown-parameters -- A bridge guard is the parser at the IPC boundary.
@@ -161,8 +169,26 @@ function isAccountProvider(value: UnparsedWireValue): value is AccountProvider {
   return value === ACCOUNT_PROVIDER.GOOGLE || value === ACCOUNT_PROVIDER.GITHUB;
 }
 
+function isUnitLevel(value: UnparsedWireValue): value is number {
+  return isWireNumber(value) && Number.isFinite(value) && value >= 0 && value <= 1;
+}
+
+const MICROPHONE_STATUSES: ReadonlySet<string> = new Set<MicrophoneStatus>([
+  "not-determined",
+  "granted",
+  "denied",
+  "restricted",
+  "unknown",
+]);
+
+function isMicrophoneStatus(value: UnparsedWireValue): value is MicrophoneStatus {
+  return isWireString(value) && MICROPHONE_STATUSES.has(value);
+}
+
 function isWindowRole(value: UnparsedWireValue): value is WindowRole {
-  return value === WINDOW_ROLE.PANEL || value === WINDOW_ROLE.INTRODUCTION;
+  return (
+    value === WINDOW_ROLE.PANEL || value === WINDOW_ROLE.INTRODUCTION || value === WINDOW_ROLE.VOICE
+  );
 }
 
 // oxlint-disable-next-line anti-slop/no-unknown-parameters -- This function parses an IPC field into a domain identity.
@@ -525,6 +551,55 @@ export const BRIDGE = {
     result: result<void>(),
   }),
   /**
+   * A panel's ask of the voice window, carried through the main process, which
+   * validates it and forwards it on `onVoiceCommand`. Only a typed ask carries
+   * a payload — the words themselves, bounded by the same limit the session
+   * applies — and every other command carries none.
+   */
+  voiceCommand: entry({
+    kind: "invoke",
+    channel: "app:voice-command",
+    args: args<[VoiceCommand, string | undefined]>(
+      (v) =>
+        v.length === 2 &&
+        isVoiceCommand(v[0]) &&
+        (v[0] === VOICE_COMMAND.ASK_TEXT
+          ? isWireString(v[1]) && v[1].length <= maximumTypedAskLength
+          : v[1] === undefined),
+    ),
+    result: result<void>(),
+  }),
+  /**
+   * The voice window's whole snapshot of the live conversation, reported on
+   * every edge. The main process keeps only the latest, to hand a panel that
+   * opens later, and forwards each one to every panel on `onVoiceViewChanged`.
+   */
+  reportVoiceView: entry({
+    kind: "send",
+    channel: "app:report-voice-view",
+    args: args<[VoiceView]>((v) => v.length === 1 && isVoiceView(v[0])),
+  }),
+  /**
+   * How loud whoever is talking is right now, in the unit interval, reported
+   * by the voice window at a bounded rate only while a turn is listening or
+   * responding. It rides its own channel so the snapshot stays edge-driven.
+   */
+  reportVoiceLevel: entry({
+    kind: "send",
+    channel: "app:report-voice-level",
+    args: args<[number]>((v) => v.length === 1 && isUnitLevel(v[0])),
+  }),
+  /**
+   * Whether a panel is recording a new shortcut, during which the talk key it
+   * is capturing must not open a turn. Panel state gating a global key the
+   * main process routes, so the main process is told rather than the window.
+   */
+  setShortcutCapturing: entry({
+    kind: "send",
+    channel: "app:set-shortcut-capturing",
+    args: oneBoolean,
+  }),
+  /**
    * One window's copy of the conversation history, reported whole after each
    * line it appends. The main process holds the launch's thread and mirrors
    * the report to every other panel window, so the History tab reads the same
@@ -816,6 +891,48 @@ export const BRIDGE = {
     channel: "app:speech-withdrawn",
     args: noArgs,
     result: result<SpeechWithdrawal>(isSpeechWithdrawal),
+  }),
+  /** The latest voice snapshot, forwarded by the main process to every panel. */
+  onVoiceViewChanged: entry({
+    kind: "subscribe",
+    channel: "app:voice-view-changed",
+    args: noArgs,
+    result: result<VoiceView>(isVoiceView),
+  }),
+  /** The current loudness of whoever is talking, relayed to every panel. */
+  onVoiceLevelChanged: entry({
+    kind: "subscribe",
+    channel: "app:voice-level-changed",
+    args: noArgs,
+    result: result<number>(isUnitLevel),
+  }),
+  /**
+   * The system's answer on microphone access, which the main process owns and
+   * broadcasts so no panel has to hold a microphone to know it.
+   */
+  onMicrophoneStatusChanged: entry({
+    kind: "subscribe",
+    channel: "app:microphone-status-changed",
+    args: noArgs,
+    result: result<MicrophoneStatus>(isMicrophoneStatus),
+  }),
+  /**
+   * A panel's validated command, forwarded by the main process to the voice
+   * window alone; a typed ask arrives with its words, every other command with
+   * none.
+   */
+  onVoiceCommand: entry({
+    kind: "subscribe",
+    channel: "app:voice-command-forwarded",
+    args: noArgs,
+    result: result<{ command: VoiceCommand; text: string | undefined }>(
+      (value) =>
+        isRecord(value) &&
+        isVoiceCommand(value.command) &&
+        (value.command === VOICE_COMMAND.ASK_TEXT
+          ? isWireString(value.text) && value.text.length <= maximumTypedAskLength
+          : value.text === undefined),
+    ),
   }),
   /**
    * An app act the brain decided that only the renderer can perform, already

--- a/apps/desktop/src/shared/wire/session.ts
+++ b/apps/desktop/src/shared/wire/session.ts
@@ -36,12 +36,15 @@ export type SessionOpenResult = ActResult;
 /**
  * Which surface a window exists to draw. Every window loads the same renderer
  * bundle, so the role is what tells the one fullscreen introduction takeover
- * apart from the panel windows — decided in the main process by which window
- * asked, never by anything the renderer could claim about itself.
+ * and the hidden voice window apart from the panel windows — decided in the
+ * main process by which window asked, never by anything the renderer could
+ * claim about itself.
  */
 export const WINDOW_ROLE = {
   PANEL: "panel",
   INTRODUCTION: "introduction",
+  /** The one hidden window that will hold the live conversation; it draws nothing. */
+  VOICE: "voice",
 } as const;
 
 export type WindowRole = (typeof WINDOW_ROLE)[keyof typeof WINDOW_ROLE];
@@ -170,7 +173,11 @@ export interface AppBootstrap {
    * arrives — or forever, where there is no helper to ask.
    */
   outputAudio?: OutputAudioState;
-  display: DisplayDiagnostic;
+  /**
+   * The display this window stands on. Absent for the hidden voice window,
+   * which stands on none and draws nothing that would need one.
+   */
+  display: DisplayDiagnostic | undefined;
   /** Where the app stands against the latest release, as last learned. */
   update: UpdateSnapshot;
   sessionRoster: SessionRosterPayload;

--- a/apps/desktop/src/shared/wire/voice-view.test.ts
+++ b/apps/desktop/src/shared/wire/voice-view.test.ts
@@ -1,0 +1,19 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { REALTIME_STATUS } from "@sidecar/realtime";
+import { isRealtimeStatus, isVoiceCommand, VOICE_COMMAND } from "./voice-view";
+
+test("every realtime status is recognized and nothing else is", () => {
+  for (const status of Object.values(REALTIME_STATUS)) {
+    assert.equal(isRealtimeStatus(status), true);
+  }
+  assert.equal(isRealtimeStatus("speaking"), false);
+  assert.equal(isRealtimeStatus(1), false);
+});
+
+test("the five voice commands are the whole set", () => {
+  const commands = Object.values(VOICE_COMMAND);
+  assert.equal(commands.length, 5);
+  for (const command of commands) assert.equal(isVoiceCommand(command), true);
+  assert.equal(isVoiceCommand("stop-microphone"), false);
+});

--- a/apps/desktop/src/shared/wire/voice-view.ts
+++ b/apps/desktop/src/shared/wire/voice-view.ts
@@ -1,0 +1,100 @@
+import { PRODUCT_EXCHANGE_KIND, type ProductExchangeKind } from "@sidecar/analytics";
+import {
+  type ConversationEntry,
+  REALTIME_STATUS,
+  type RealtimeStatus,
+  storedConversationEntry,
+} from "@sidecar/realtime";
+import {
+  isRecord,
+  isWireBoolean,
+  isWireString,
+  type UnparsedWireValue,
+  type WireRecord,
+} from "@sidecar/wire";
+
+/**
+ * What a panel needs to draw the live conversation and cannot derive or read
+ * elsewhere. The voice window reports the whole snapshot on every edge and the
+ * main process forwards it unchanged to every panel, so each display draws the
+ * same voice state at the same instant and holds nothing it cannot lose.
+ */
+export interface VoiceView {
+  voiceStatus: RealtimeStatus;
+  voiceError: string | undefined;
+  voiceNotice: string | undefined;
+  talkOpening: boolean;
+  lukeCaptions: readonly string[] | undefined;
+  liveConversationEntries: readonly ConversationEntry[];
+}
+
+/**
+ * The asks a panel forwards to the main process for the voice window to carry
+ * out. No press decides anything in the panel: the talk key never travels this
+ * way, because the main process routes it to the voice window directly.
+ */
+export const VOICE_COMMAND = {
+  ASK_TEXT: "ask-text",
+  DISCARD_LISTENING: "discard-listening",
+  STOP_SPEAKING: "stop-speaking",
+  REQUEST_MICROPHONE_ACCESS: "request-microphone-access",
+  CLEAR_CONVERSATION: "clear-conversation",
+} as const;
+
+export type VoiceCommand = (typeof VOICE_COMMAND)[keyof typeof VOICE_COMMAND];
+
+const REALTIME_STATUSES: ReadonlySet<string> = new Set(Object.values(REALTIME_STATUS));
+
+export function isRealtimeStatus(value: UnparsedWireValue): value is RealtimeStatus {
+  return isWireString(value) && REALTIME_STATUSES.has(value);
+}
+
+const VOICE_COMMANDS: ReadonlySet<string> = new Set(Object.values(VOICE_COMMAND));
+
+export function isVoiceCommand(value: UnparsedWireValue): value is VoiceCommand {
+  return isWireString(value) && VOICE_COMMANDS.has(value);
+}
+
+const optionalString = (value: UnparsedWireValue): boolean =>
+  value === undefined || isWireString(value);
+
+export function isVoiceView(value: UnparsedWireValue): value is VoiceView & WireRecord {
+  if (!isRecord(value)) return false;
+  if (!isRealtimeStatus(value.voiceStatus)) return false;
+  if (!optionalString(value.voiceError) || !optionalString(value.voiceNotice)) return false;
+  if (!isWireBoolean(value.talkOpening)) return false;
+  const captions = value.lukeCaptions;
+  if (captions !== undefined && !(Array.isArray(captions) && captions.every(isWireString))) {
+    return false;
+  }
+  const entries = value.liveConversationEntries;
+  return (
+    Array.isArray(entries) && entries.every((entry) => storedConversationEntry(entry) !== undefined)
+  );
+}
+
+/**
+ * The exchange is live from the press to the end of the reply — the call
+ * coming up, a turn being held, Luke speaking — and the media duck follows it.
+ */
+export function voiceExchangeActive(status: RealtimeStatus): boolean {
+  return (
+    status === REALTIME_STATUS.CONNECTING ||
+    status === REALTIME_STATUS.LISTENING ||
+    status === REALTIME_STATUS.RESPONDING
+  );
+}
+
+/**
+ * Who opened the exchange the count is about. Luke's own speak-only call has
+ * no microphone to offer, which is the whole of what tells his announcement
+ * from a turn the developer took; between the developer's own two ways in,
+ * only the composer says so in advance, so the talk key is what is left.
+ */
+export function voiceExchangeKind(input: {
+  microphoneCall: boolean;
+  typedAsk: boolean;
+}): ProductExchangeKind {
+  if (!input.microphoneCall) return PRODUCT_EXCHANGE_KIND.ANNOUNCEMENT;
+  return input.typedAsk ? PRODUCT_EXCHANGE_KIND.TYPED : PRODUCT_EXCHANGE_KIND.SPOKEN;
+}

--- a/scripts/repository-checks.sh
+++ b/scripts/repository-checks.sh
@@ -234,6 +234,16 @@ if [[ -n "$renderer_escapes" ]]; then
     exit 1
 fi
 
+# The hidden voice window mounts nothing drawn and must record nothing: the
+# session-replay client starts only inside the panel's App, and nothing under
+# the voice role may reach for it.
+voice_replay_imports=$(grep -rnaE 'from "[^"]*session-replay' "$SIDECAR_REPO_ROOT/apps/desktop/src/renderer/voice" 2>/dev/null || true)
+if [[ -n "$voice_replay_imports" ]]; then
+    printf 'error: the voice window never records — nothing under renderer/voice/ may import session-replay:\n%s\n' \
+        "$voice_replay_imports" >&2
+    exit 1
+fi
+
 # BRIDGE is the one renderer-to-main declaration, and registerBridge is the
 # one place that may attach it to Electron. A handler registered beside its
 # domain logic would bypass the manifest's sender and wire guards.


### PR DESCRIPTION
## What this step did (Phase 2, Step 2 of the voice-window plan)

Adds the hidden voice window and everything around it, wired to nothing. Behavior is unchanged for the user: an invisible window now exists on interactive and networked launches.

- `WINDOW_ROLE.VOICE` in `shared/wire/session.ts`; the `getWindowRole` guard in `bridge.ts` accepts it.
- `main/window/voice-window.ts`: `VoiceWindow`, modeled on `IntroductionWindow`. Hidden, 1×1, non-focusable, `skipTaskbar`, same `hardenedWebPreferences`, same `index.html` and `rendererUrl` (so `trustedSender` is untouched), `refuseForeignNavigation`, three failure listeners (`render-process-gone`, `unresponsive`, `did-fail-load`) → a bounded replace owned by the class (see App lifetime), with main supplying only the `onGone`/`onGaveUp` reports. Never shown, no `dressMacWindow`.
- `desktop-app.ts`: the window is constructed beside `introductionWindow` and opened at launch only when `runMode.registersGlobalKeys || runMode.sendsNetwork`, after `panels.reconcile()` so it is never the only window standing. `getWindowRole` returns `VOICE` for `voiceWindow.owns(sender)`; `configurePermissions` adds it to the media-permission union; `getBootstrap` returns the existing bootstrap with `display: undefined` for a voice-role sender. `AppBootstrap.display` is now `DisplayDiagnostic | undefined`; the panel's `setDisplay` already took undefined, and the introduction takeover's prop type requires a display, with `index.tsx` abandoning a takeover handed none.
- `renderer/index.tsx`: a window whose role cannot be read now mounts nothing and reports to the console, never `App`, so a voice window whose role call failed cannot start the panel's session replay. Third branch, `VOICE` → `<VoiceHost />` at `renderer/voice/voice-host.tsx`, which renders only the `<audio autoPlay hidden>` element, mounts no hooks, never mounts `App`, and never imports `session-replay.ts`.
- `shared/wire/voice-view.ts`: `VoiceView` (six fields), `VOICE_COMMAND` (five values), `isVoiceView`/`isVoiceCommand`/`isRealtimeStatus`, and `voiceExchangeActive`/`voiceExchangeKind` moved here from `use-voice-conversation.ts`, which now imports them (its behavior is unchanged; its test imports them from the new home).
- New bridge entries, declared with guards and tests, no handlers registered: `onVoiceViewChanged`, `onVoiceLevelChanged`, `onMicrophoneStatusChanged`, `onVoiceCommand`, `voiceCommand`, `reportVoiceView`, `reportVoiceLevel`, `setShortcutCapturing`. A typed ask's payload is bounded by `maximumTypedAskLength`; every other command refuses a payload; a level must be a finite number in `[0, 1]`.
- `scripts/repository-checks.sh`: fails on any `from "…session-replay"` import under `apps/desktop/src/renderer/voice/`.

## App lifetime: what I found and changed

Today the process ends through exactly one path: Electron's `window-all-closed` → `app.quit()` (`desktop-app.ts`, end of `bootDesktop`). `PanelManager.reconcile` never passes through zero panels by design, and its `closed` handler only tidies the map for a window that went down some other way. The introduction window is never the last window either, since both of its endings reconcile the panels before destroying it.

With a hidden voice window standing, `window-all-closed` would stop firing when the last panel goes down on its own, so:

- The voice window is raised only once a panel stands (`raiseVoiceWindow`, called after every `panels.reconcile()` that creates panels: the ordinary launch, and both endings of the introduction), so it is never the only window. The takeover's window now reports its own `closed` by any route, and main quits if no panel stands at that moment, so an introduction that goes down without the handoff cannot leave the process alive behind an invisible window. The invariant is stated once in `desktop-app.ts`: the hidden window never keeps the process alive.
- `PanelManager` takes an `onAllClosed` option, fired from the existing `closed` handler when the map empties. `desktop-app.ts` passes `() => app.quit()`, so "all panels closed" still decides the run is done regardless of the hidden window.
- `before-quit` calls `voiceWindow.closeForGood()`, so main destroys the hidden window on the way out and nothing re-creates it mid-quit.
- Reopening is bounded inside `VoiceWindow` itself: a dead renderer is replaced after `REOPEN_DELAY_MS` (1 s, unref'ed timer) at most `MAXIMUM_REOPENS_PER_RUN` (3) times per run, the count resetting only on `did-finish-load`, after which `onGaveUp` reports once to stderr and the window stays down for the run, so a renderer that dies on load cannot crash-loop a window nobody can see. No unit test: the class constructs `BrowserWindow` directly, so it cannot be exercised without Electron, matching the untested `IntroductionWindow` it is modeled on.
- `window-all-closed → app.quit()` is kept for a run that never raised a voice window (fixture and capture runs).

## Confirmations

`luke-guide.ts`, `PRIVACY.md`, and `CLAUDE.md` need nothing: nothing Luke can do, say, send, or record changes; the new window draws nothing and records nothing.

## Checks

`./scripts/check.sh`: exit 0 (repository checks, design contract checks, typecheck, all package and desktop tests, and the build all passed).

`./scripts/verify.sh` (macOS) was not run because this is a Linux sandbox. The PR's "macOS app and evidence" CI job fails on the fixture evidence PNG's dimensions; the same job fails identically on #709 and #711 on `brain-spike`, and a capture run creates no voice window, so the failure predates this change. No physical-notch check was performed; nothing drawn changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/ea5182f5-b7e2-4b3f-8b81-d0f31933ef29)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/33933630600/artifacts/9959451468) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/33933630600)

- Commit: `1f34b5199c217f8202276eff6a8579db64a19934`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->