### PR TITLE
fix(desktop): open a bubble's popups on the pill's own strip height

### DIFF
--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -3179,6 +3179,9 @@ export function App(): React.JSX.Element {
       // surface waits for the content it is carrying instead of leading it.
       data-leaving-panel={String(leavingPanel)}
       data-notch={String(display.notch.hasNotch)}
+      // Whether sign-in still stands between Luke and anything to watch, so the
+      // stylesheet knows the strip holds nothing while a popup is drawn.
+      data-gated={String(accountGated)}
       data-capture={String(bootstrap.captureMode)}
       style={{
         ...notchStyle(display),

--- a/apps/desktop/src/renderer/styles/base.css
+++ b/apps/desktop/src/renderer/styles/base.css
@@ -2325,7 +2325,10 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
   max-height: var(--panel-height-max);
   flex-direction: column;
   gap: 8px;
-  padding: calc(max(var(--notch-top-inset), 32px) + 12px) 16px 15px;
+  /* The strip above the first row is the pill's own height, as the key slot
+     measures it, so a bubble's composer opens no taller above its words than
+     one beside a housing does. */
+  padding: calc(var(--capsule-height) - var(--shape-top, 0px) * 2 + 12px) 16px 15px;
   border-radius: 0 0 var(--slot-radius) var(--slot-radius);
 }
 
@@ -2771,7 +2774,13 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
   width: var(--slot-width);
   flex-direction: column;
   gap: 7px;
-  padding: calc(max(var(--notch-top-inset), 32px) + 12px) 16px 15px;
+  /* The room above the first row is the strip the wings are drawn in plus one
+     gap, and the strip is the pill's own height: the full capsule beside a
+     housing, the capsule less the lift on both edges on a display without one,
+     the same height the wings and the hover target take there. Measured off
+     the capsule alone, a bubble's slot opened on twice the lift of empty black
+     above its words. */
+  padding: calc(var(--capsule-height) - var(--shape-top, 0px) * 2 + 12px) 16px 15px;
   border-radius: 0 0 var(--slot-radius) var(--slot-radius);
 }
 

--- a/apps/desktop/src/renderer/styles/base.css
+++ b/apps/desktop/src/renderer/styles/base.css
@@ -1232,6 +1232,21 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
   border-radius: calc((var(--capsule-height) - var(--shape-top) * 2) / 2);
 }
 
+/* Signed out, the strip above a popup holds nothing: the wings draw neither
+   the face nor the marks while the gate stands, the "Sign in" label reads only
+   in the compact shapes, and the signed-out Luke steps out of the popup's way.
+   Beside a housing the band stays black regardless, because the housing sits
+   in it; a bubble has no housing to wrap, so an empty band there is only room
+   above the words. The row takes the gap alone, and the strip's press target
+   stands down with the strip, or it would take the row's own presses. */
+.app-stage[data-notch="false"][data-gated="true"] .key-slot {
+  padding-top: 12px;
+}
+
+.app-stage[data-notch="false"][data-gated="true"][data-presentation="slot"] .compact-hover-target {
+  pointer-events: none;
+}
+
 /* Inside an open panel the strip is surrounded by the shape rather than
    bounding it, so it has no corner of its own to follow. This has to follow
    the non-notch pill: the two are equal specificity. */

--- a/apps/desktop/src/renderer/styles/base.css
+++ b/apps/desktop/src/renderer/styles/base.css
@@ -181,6 +181,12 @@
      reserved. */
   --capsule-width: calc(var(--notch-housing-width) + 72px);
   --capsule-height: max(var(--notch-top-inset), 32px);
+  /* The strip the wings are drawn in, and so the room every shape opened below
+     it reserves above its first row: the whole capsule beside a housing, and on
+     a display without one the capsule less the lift on both edges, restated
+     where the lift is. The pill at rest is exactly it, the wings and the press
+     target are as tall as it, and every popup and the panel pad by it. */
+  --strip-height: var(--capsule-height);
   --peek-width: max(calc(var(--notch-housing-width) + 248px), 458px);
   /* The capsule with room for the meter beside the face rather than instead of
      it. Only the left wing needs it — that is where both are drawn — so only
@@ -371,13 +377,13 @@ button:disabled {
   top: 0;
   left: 50%;
   width: var(--capsule-width);
-  height: calc(var(--capsule-height) + var(--caption-growth));
+  height: calc(var(--strip-height) + var(--caption-growth));
   /* The spring undershoots on the way back, and the capsule is the floor: a
      shape that dips inside the housing's footprint opens a gap where there is
      a physical camera, not a screen. Clamping the used size lets the spring
      keep its overshoot in the direction where there is room for it. */
   min-width: var(--capsule-width);
-  min-height: var(--capsule-height);
+  min-height: var(--strip-height);
   border-radius: 0 0 var(--notch-convex-radius) var(--notch-convex-radius);
   background: var(--surface-fill);
   /* The lift off the top edge is carried here rather than by `top`, so that on a
@@ -586,18 +592,11 @@ button:disabled {
    the pointer. Without this the block belongs to the stage around the strip,
    which carries no hit region, so resting on the words read as leaving the
    shape — collapsing the peek under the cursor. Like every hover-target rule
-   it snaps rather than animating, and the pill's variant carries the lift the
-   way the pill's own height does, so the target ends where the shape ends. */
+   it snaps rather than animating, and the strip's height already carries the
+   pill's lift, so the target ends where the shape ends. */
 .app-stage[data-presentation="capsule"][data-caption="true"] .compact-hover-target,
 .app-stage[data-presentation="peek"][data-caption="true"] .compact-hover-target {
-  height: calc(var(--capsule-height) + var(--caption-growth));
-}
-
-.app-stage[data-notch="false"][data-presentation="capsule"][data-caption="true"]
-  .compact-hover-target,
-.app-stage[data-notch="false"][data-presentation="peek"][data-caption="true"]
-  .compact-hover-target {
-  height: calc(var(--capsule-height) - var(--shape-top) * 2 + var(--caption-growth));
+  height: calc(var(--strip-height) + var(--caption-growth));
 }
 
 /* Under the pointer: wide enough to spread the marks out flat. */
@@ -633,7 +632,7 @@ button:disabled {
   top: 0;
   left: 50%;
   width: var(--capsule-width);
-  height: var(--capsule-height);
+  height: var(--strip-height);
   padding: 0;
   border: 0;
   /* The same corner the capsule is drawn with, for the same reason the panel
@@ -684,7 +683,6 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
    so every part of that band means the same thing and answers the same way. */
 .app-stage[data-presentation="panel"] .compact-hover-target {
   width: var(--panel-width);
-  height: max(var(--notch-top-inset), 32px);
   cursor: pointer;
   pointer-events: auto;
 }
@@ -703,7 +701,7 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
   z-index: 5;
   top: var(--shape-top, 0px);
   display: flex;
-  height: calc(var(--capsule-height) - var(--shape-top, 0px) * 2);
+  height: var(--strip-height);
   align-items: center;
   overflow: hidden;
   pointer-events: none;
@@ -1153,11 +1151,23 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
    strip minus 4px each side is exactly that 24. */
 .app-stage[data-notch="false"] {
   --shape-top: var(--bubble-lift);
+  --strip-height: calc(var(--capsule-height) - var(--shape-top) * 2);
+}
+
+/* Signed out, the strip above the sign-in popup holds nothing: the wings draw
+   neither the face nor the marks while the gate stands, the "Sign in" label
+   reads only in the compact shapes, and the signed-out Luke steps out of the
+   popup's way. Beside a housing the band stays black regardless, because the
+   housing sits in it; a bubble has no housing to wrap, so an empty band there
+   is only room above the words, and the popup opens on no strip at all — its
+   row one gap under the pill's edge, and the strip's press target gone with
+   the strip rather than left over the row. The open panel keeps its strip
+   even signed out, because pressing it is how the panel closes. */
+.app-stage[data-notch="false"][data-gated="true"][data-presentation="slot"] {
+  --strip-height: 0px;
 }
 
 .app-stage[data-notch="false"] .panel-surface {
-  height: calc(var(--capsule-height) - var(--shape-top) * 2 + var(--caption-growth));
-  min-height: calc(var(--capsule-height) - var(--shape-top) * 2);
   /* Half the resting strip, stated as that number rather than an overlarge
      one: at rest the two draw the same pill, but an overlarge radius scales
      with whatever box it is given, so a shape grown for captions or chips
@@ -1165,7 +1175,7 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
      resting corner, whose first line ran past the curve onto the desktop.
      Stated once here, the growth extends the pill downward with the corners
      it had, the same way the notch capsule keeps its convex radius. */
-  border-radius: calc((var(--capsule-height) - var(--shape-top) * 2) / 2);
+  border-radius: calc(var(--strip-height) / 2);
 }
 
 /* The panel and the slot keep the pill's lift rather than gluing themselves to
@@ -1218,33 +1228,12 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
   transform: translateX(-50%) translateY(var(--shape-top));
 }
 
-.app-stage[data-notch="false"] .wing {
-  top: var(--shape-top);
-  height: calc(var(--capsule-height) - var(--shape-top) * 2);
-}
-
 .app-stage[data-notch="false"] .compact-hover-target {
   top: var(--shape-top);
-  height: calc(var(--capsule-height) - var(--shape-top) * 2);
   /* The surface's own radius above, for the surface's reason: the captioned
      target grows with the shape, and an overlarge radius would round its hit
      region past the corners the shape actually draws. */
-  border-radius: calc((var(--capsule-height) - var(--shape-top) * 2) / 2);
-}
-
-/* Signed out, the strip above a popup holds nothing: the wings draw neither
-   the face nor the marks while the gate stands, the "Sign in" label reads only
-   in the compact shapes, and the signed-out Luke steps out of the popup's way.
-   Beside a housing the band stays black regardless, because the housing sits
-   in it; a bubble has no housing to wrap, so an empty band there is only room
-   above the words. The row takes the gap alone, and the strip's press target
-   stands down with the strip, or it would take the row's own presses. */
-.app-stage[data-notch="false"][data-gated="true"] .key-slot {
-  padding-top: 12px;
-}
-
-.app-stage[data-notch="false"][data-gated="true"][data-presentation="slot"] .compact-hover-target {
-  pointer-events: none;
+  border-radius: calc(var(--strip-height) / 2);
 }
 
 /* Inside an open panel the strip is surrounded by the shape rather than
@@ -1638,13 +1627,7 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
    is over must keep taking the pointer. */
 .app-stage[data-presentation="capsule"][data-notice="true"] .compact-hover-target,
 .app-stage[data-presentation="peek"][data-notice="true"] .compact-hover-target {
-  height: calc(var(--capsule-height) + var(--caption-growth));
-}
-
-.app-stage[data-notch="false"][data-presentation="capsule"][data-notice="true"]
-  .compact-hover-target,
-.app-stage[data-notch="false"][data-presentation="peek"][data-notice="true"] .compact-hover-target {
-  height: calc(var(--capsule-height) - var(--shape-top) * 2 + var(--caption-growth));
+  height: calc(var(--strip-height) + var(--caption-growth));
 }
 
 /* The band the chips share: centred wrapped rows. In the compact states it
@@ -2067,7 +2050,7 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
   display: flex;
   max-height: var(--panel-height-max);
   flex-direction: column;
-  padding: calc(max(var(--notch-top-inset), 32px) + 14px) var(--panel-inset) 18px;
+  padding: calc(var(--strip-height) + 14px) var(--panel-inset) 18px;
   border-radius: 0 0 var(--panel-radius) var(--panel-radius);
   /* A page lands in layout at once, while the black surface takes one spring
      to its new height. The panel follows that same edge so newly mounted rows
@@ -2340,10 +2323,7 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
   max-height: var(--panel-height-max);
   flex-direction: column;
   gap: 8px;
-  /* The strip above the first row is the pill's own height, as the key slot
-     measures it, so a bubble's composer opens no taller above its words than
-     one beside a housing does. */
-  padding: calc(var(--capsule-height) - var(--shape-top, 0px) * 2 + 12px) 16px 15px;
+  padding: calc(var(--strip-height) + 12px) 16px 15px;
   border-radius: 0 0 var(--slot-radius) var(--slot-radius);
 }
 
@@ -2789,13 +2769,7 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
   width: var(--slot-width);
   flex-direction: column;
   gap: 7px;
-  /* The room above the first row is the strip the wings are drawn in plus one
-     gap, and the strip is the pill's own height: the full capsule beside a
-     housing, the capsule less the lift on both edges on a display without one,
-     the same height the wings and the hover target take there. Measured off
-     the capsule alone, a bubble's slot opened on twice the lift of empty black
-     above its words. */
-  padding: calc(var(--capsule-height) - var(--shape-top, 0px) * 2 + 12px) 16px 15px;
+  padding: calc(var(--strip-height) + 12px) 16px 15px;
   border-radius: 0 0 var(--slot-radius) var(--slot-radius);
 }
 

--- a/apps/desktop/src/renderer/styles/base.css
+++ b/apps/desktop/src/renderer/styles/base.css
@@ -251,6 +251,12 @@
      fields share a line — and narrower than the panel, so the composer reads as
      the panel stood down to one thing rather than as the panel refilled. */
   --feedback-width: max(520px, calc(var(--notch-housing-width) + 340px));
+  /* A popup's one vertical inset, above its first row and below its last. The
+     same number on both edges, because the two edges are the same edge: beside
+     a housing the first row sits one inset under the strip, and where the
+     strip is nothing the row sits one inset from each curved edge of the pill,
+     so the row is centred by construction rather than by a second number. */
+  --slot-inset: 12px;
   /* The mark sits outside the field's column, so everything else in the slot is
      indented past it by the same amount. */
   --slot-mark-size: 22px;
@@ -2323,7 +2329,7 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
   max-height: var(--panel-height-max);
   flex-direction: column;
   gap: 8px;
-  padding: calc(var(--strip-height) + 12px) 16px 15px;
+  padding: calc(var(--strip-height) + var(--slot-inset)) 16px var(--slot-inset);
   border-radius: 0 0 var(--slot-radius) var(--slot-radius);
 }
 
@@ -2769,7 +2775,7 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
   width: var(--slot-width);
   flex-direction: column;
   gap: 7px;
-  padding: calc(var(--strip-height) + 12px) 16px 15px;
+  padding: calc(var(--strip-height) + var(--slot-inset)) 16px var(--slot-inset);
   border-radius: 0 0 var(--slot-radius) var(--slot-radius);
 }
 

--- a/apps/desktop/src/renderer/styles/sign-in.css
+++ b/apps/desktop/src/renderer/styles/sign-in.css
@@ -34,15 +34,16 @@
 
 /* The one signed-out Luke, like the caption a single element in every state so
    the morph carries him rather than trading two copies. At rest he stands over
-   the gate's reserved box — `--sign-in-face-rest` is that box's top, restated
-   from the panel's own padding (14px) plus the gate's (4px) and the box's
-   margin (4px) — and in the compact shapes he takes the wing spot the authed
-   face holds: against the housing, past `--wing-inset` and half his drawn
-   width, at the strip's centre. Only `transform` and `opacity` move him, on
-   the caption's own beat: leaving a state, he travels with the shape rather
-   than ahead of it. 0.3214 is 18/56 — the wing face's size over the gate's. */
+   the gate's reserved box — `--sign-in-face-rest` is that box's top: the lift
+   the panel stands off the edge, the strip, then the panel's own padding
+   (14px) plus the gate's (4px) and the box's margin (4px) — and in the compact
+   shapes he takes the wing spot the authed face holds: against the housing,
+   past `--wing-inset` and half his drawn width, at the strip's centre. Only
+   `transform` and `opacity` move him, on the caption's own beat: leaving a
+   state, he travels with the shape rather than ahead of it. 0.3214 is 18/56 —
+   the wing face's size over the gate's. */
 .sign-in-luke {
-  --sign-in-face-rest: calc(var(--capsule-height) + 22px);
+  --sign-in-face-rest: calc(var(--shape-top, 0px) + var(--strip-height) + 22px);
 
   position: absolute;
   z-index: 3;
@@ -57,12 +58,6 @@
     opacity var(--duration-exit) var(--motion-exit),
     transform var(--duration-shape) var(--spring) var(--duration-exit);
   will-change: transform;
-}
-
-/* A notchless display shifts the drawn shapes down by `--shape-top`; the rest
-   pose follows the panel it stands over. */
-.app-stage[data-notch="false"] .sign-in-luke {
-  --sign-in-face-rest: calc(var(--capsule-height) + 22px + var(--shape-top, 0px));
 }
 
 .sign-in-luke .luke-face {


### PR DESCRIPTION
## Summary

Popups and the panel open too tall above their words in bubble mode (a display without a housing, or the bubble chosen in settings), and the signed-out popup's row sat high in its pill. Beside a housing, the only visible change is the popups closing 3px sooner under their last row.

- **One token for the strip's height.** The strip the wings are drawn in was spelled out at every site that needed its height, each with its own notchless override. `--strip-height` now carries it once: the whole capsule beside a housing, the capsule less the lift on both edges on a bubble. The pill, the wings, the press target, the panel, and every popup pad or size by it, and the notchless overrides that only restated it are gone (net fewer lines).
- **Signed-in popups and the panel.** The key slot (API key, Superset, calendar "Waiting for Google…" popups), the feedback composer, and the expanded panel padded their first row below the full capsule height, so a bubble opened on twice the lift of empty black between the strip and its words. Each now pads by the token. The signed-out face's rest pose follows from one rule instead of two.
- **Signed-out sign-in popup (Google/GitHub).** While the account gate stands, nothing is drawn in the strip: the wings draw neither the face nor the marks, the "Sign in" label reads only in the compact shapes, and the signed-out Luke steps out of the popup's way. Beside a housing the band stays black because the housing sits in it, but a bubble has no housing to wrap, so the whole band was empty room above the words. The stage now carries `data-gated`, and a gated bubble popup is one more value of the same token, zero: its row sits one inset under the pill's edge, and the strip's press target collapses with the strip so it cannot take the row's presses. The open panel keeps its strip even signed out, because pressing it is how the panel closes.
- **One vertical inset, both edges.** The popups padded 12px above their first row and 15px below their last, numbers eyeballed beside a housing where only the bottom edge was visible. With no strip above the signed-out bubble popup the row sat 1.5px high between two identical curved edges. `--slot-inset` (12px) now carries the inset once, applied above the strip and below the last row alike, so the row is centred by construction in every form factor.

## Evidence

- Platform-independent checks: `./scripts/check.sh` passed (repository checks, types, tests, builds)
- macOS Electron verification (`./scripts/verify.sh`): `not run` (authored on a Linux cloud workspace; CI's macOS evidence covers the housing captures)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34066510520/artifacts/9999140738) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34066510520)

- Commit: `d4ee95faf9926bcbf46d6de458a7fa4c8cb1cd9b`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

### Physical-device evidence

- Screenshot or screen recording: `not attached`
- Physical-notch check: `not performed`
- Device/display configuration: `not recorded`

## Notes

- Blockers or follow-up verification: The CI captures run signed in beside a simulated housing, where the strip token equals the capsule height and only the inset change is visible: the slot capture should differ from main by the 3px its bottom padding lost. The bubble cases want a look on a Mac with the bubble form factor chosen (Settings) or an external display: the panel and a signed-in popup for the lift, and the Google/GitHub popup signed out for both the strip and the centring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
