### PR TITLE
fix(ios): match watch talk prompt

### DIFF
--- a/apps/ios/Luke/VoiceView.swift
+++ b/apps/ios/Luke/VoiceView.swift
@@ -360,10 +360,41 @@ struct VoiceView: View {
     }
 
     private var statusLabel: some View {
-        Text(statusText)
-            .font(.system(size: 15, weight: .medium))
-            .foregroundStyle(Color.inkSecondary)
-            .animation(.easeInOut(duration: 0.2), value: model.status)
+        HStack(spacing: 5) {
+            statusGlyph
+            Text(statusText)
+                .font(.system(size: 15, weight: .medium))
+                .foregroundStyle(Color.inkSecondary)
+        }
+        .animation(.easeInOut(duration: 0.15), value: model.status)
+    }
+
+    @ViewBuilder
+    private var statusGlyph: some View {
+        switch model.status {
+        case .connecting:
+            ProgressView()
+                .tint(Color.inkSecondary)
+                .scaleEffect(0.7)
+                .frame(width: 16, height: 16)
+        case .listening:
+            Image(systemName: "waveform")
+                .font(.system(size: 13, weight: .medium))
+                .foregroundStyle(Color(red: 0.25, green: 0.55, blue: 1.0))
+                .symbolEffect(.variableColor.iterative, isActive: true)
+        case .thinking:
+            Image(systemName: "ellipsis")
+                .font(.system(size: 13, weight: .medium))
+                .foregroundStyle(Color(red: 0.9, green: 0.7, blue: 0.2))
+                .symbolEffect(.variableColor.iterative, isActive: true)
+        case .speaking:
+            Image(systemName: "speaker.wave.2")
+                .font(.system(size: 13, weight: .medium))
+                .foregroundStyle(Color(red: 0.2, green: 0.8, blue: 0.5))
+                .symbolEffect(.variableColor.iterative, isActive: true)
+        default:
+            EmptyView()
+        }
     }
 
     private var conversationHistory: some View {
@@ -713,9 +744,9 @@ struct VoiceView: View {
 
     private var statusText: String {
         switch model.status {
-        case .idle: return model.errorMessage != nil ? "Connection failed" : "Tap or hold to talk"
+        case .idle: return model.errorMessage != nil ? "Connection failed" : "Hold to talk"
         case .connecting: return "Connecting…"
-        case .ready: return "Tap or hold to talk"
+        case .ready: return "Hold to talk"
         case .listening: return "Listening…"
         case .thinking: return "Thinking…"
         case .speaking: return "Speaking…"


### PR DESCRIPTION
## Summary
- Match the iOS mic prompt wording to watchOS with `Hold to talk`
- Add the same animated status glyph treatment above the iOS mic button for connecting, listening, thinking, and speaking states

## Checks
- `./scripts/check.sh`

## Notes
- iOS simulator/Xcode validation is not available in this Linux cloud workspace.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/bd1057df-7088-488a-b67d-578c6262b270)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34054387814/artifacts/9995571586) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34054387814)

- Commit: `e290b58164de2e042cb94a5da499fce4d999ee33`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
