### PR TITLE
fix(scripts): expect the shrunk compact evidence height

### DIFF
--- a/scripts/evidence.sh
+++ b/scripts/evidence.sh
@@ -84,18 +84,18 @@ validate_evidence() {
 
 # The window is a stage, not the shape: every window holds the panel's width,
 # so a mode change never moves it, and a compact one still holds the peek the
-# capsule grows into, the caption block a whole reply is shown in, every chip
-# row the notice band can wrap into, the inset that closes the stack against
-# the shape's bottom edge, and room for a spring to overshoot —
-# 38 + 210 + 26 × 3 + 6 + 40 tall on the pinned housing.
+# capsule grows into, the caption block a whole reply is shown in, the inset
+# that closes the stack against the shape's bottom edge, and room for a
+# spring to overshoot — 38 + 210 + 6 + 40 tall on the pinned housing. The
+# notice band draws no chip rows since #685, so none are held for.
 validate_evidence "$SIDECAR_EXPANDED_EVIDENCE_PATH" 700 560
-validate_evidence "$SIDECAR_COMPACT_EVIDENCE_PATH" 700 372
-validate_evidence "$SIDECAR_PEEK_EVIDENCE_PATH" 700 372
+validate_evidence "$SIDECAR_COMPACT_EVIDENCE_PATH" 700 294
+validate_evidence "$SIDECAR_PEEK_EVIDENCE_PATH" 700 294
 # The slot is drawn in the expanded window, which is why stepping aside for a
 # browser costs no resize at all.
 validate_evidence "$SIDECAR_SLOT_EVIDENCE_PATH" 700 560
-validate_evidence "$SIDECAR_SPEAKING_EVIDENCE_PATH" 700 372
-validate_evidence "$SIDECAR_MUTED_EVIDENCE_PATH" 700 372
+validate_evidence "$SIDECAR_SPEAKING_EVIDENCE_PATH" 700 294
+validate_evidence "$SIDECAR_MUTED_EVIDENCE_PATH" 700 294
 
 printf 'Expanded visual evidence: %s\n' "$SIDECAR_EXPANDED_EVIDENCE_PATH"
 printf 'Compact visual evidence: %s\n' "$SIDECAR_COMPACT_EVIDENCE_PATH"


### PR DESCRIPTION
## Problem / result

`scripts/evidence.sh` still validated the compact, peek, speaking, and muted captures at 700×372, so every macOS evidence run failed after #685 removed the notice band's session and issue chips. Those windows are now `38 + 210 + 6 + 40 = 294` tall (top inset, caption block, band inset, surface margin), which is what `packages/surface/src/geometry.ts` computes for compact mode. The four expected heights now read 294 and the explanatory comment states the sum without the three 26px chip rows. No harness refactor, no dynamic dimensions; expanded and slot stay 560.

## Checks run

- `./scripts/check.sh` on Linux: passed.
- CI run [34065488065](https://github.com/ReviewStage/luke/actions/runs/34065488065) at b23bd0e: TypeScript checks and macOS app and evidence both succeeded.
- Hosted macOS evidence (artifact `app-visual-evidence-718`) inspected: compact, peek, speaking, and muted PNGs are 700×294 each; expanded and slot 700×560. The compact and peek capsules sit against the top edge with clear margin below; the speaking caption and the muted "Unmute your Mac to hear Luke / Got it" hint are fully inside the shape with nothing clipped.

## Pending platform checks

- **Physical-notch check: not performed.** The inspected captures come from GitHub's hosted macOS runner, which simulates the housing. Nobody has run `./scripts/verify.sh` on a physical notched Mac at this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
