### PR TITLE
feat(brain): track developer asks as runs and preserve action outcomes

### DIFF
--- a/apps/desktop/src/main/brain-flow.test.ts
+++ b/apps/desktop/src/main/brain-flow.test.ts
@@ -1,30 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { BRAIN_STATE_VERSION, BRAIN_WAKE_KIND } from "@sidecar/brain";
+import { BRAIN_WAKE_KIND } from "@sidecar/brain";
 import { normalizeSession, SESSION_STATUS, type Session } from "@sidecar/session";
-import { brainStateFromStored, brainStateRecord, wakeEventsFromHooks } from "./brain-flow";
+import { wakeEventsFromHooks } from "./brain-flow";
 
 const NOW = 1_800_000_000_000;
-
-test("the brain's state round-trips through its file, and anything else reads as nothing", () => {
-  const state = {
-    version: BRAIN_STATE_VERSION,
-    items: [{ type: "message", role: "user", content: [] }],
-    cursors: { "claude-code": { "session-a": "1024" } },
-  } as const;
-
-  assert.deepEqual(brainStateFromStored(brainStateRecord(state)), state);
-  assert.equal(brainStateFromStored(undefined), undefined);
-  assert.equal(brainStateFromStored("not json"), undefined);
-  assert.equal(
-    brainStateFromStored(JSON.stringify({ version: 99, items: [], cursors: {} })),
-    undefined,
-  );
-  assert.equal(
-    brainStateFromStored(JSON.stringify({ version: 1, items: "x", cursors: {} })),
-    undefined,
-  );
-});
 
 test("every hook event wakes the brain, carrying the session when the roster holds it", () => {
   const held = normalizeSession(

--- a/apps/desktop/src/main/brain-flow.ts
+++ b/apps/desktop/src/main/brain-flow.ts
@@ -1,12 +1,6 @@
-import {
-  BRAIN_WAKE_KIND,
-  type BrainPersistedState,
-  type BrainWakeEvent,
-  brainPersistedStateFromWire,
-} from "@sidecar/brain";
+import { BRAIN_WAKE_KIND, type BrainWakeEvent } from "@sidecar/brain";
 import type { ObservedSpoolEvent } from "@sidecar/providers";
 import type { Session, SessionIdentity } from "@sidecar/session";
-import type { UnparsedWireValue } from "@sidecar/wire";
 
 /**
  * What the brain keeps across launches, and how a hook's spool event becomes
@@ -14,37 +8,13 @@ import type { UnparsedWireValue } from "@sidecar/wire";
  * the memory flow's own pattern; the wiring that reads and writes the file and
  * watches the spools lives in desktop-app.
  *
- * The state file is the brain's memory: the Responses input array from the
- * latest compaction item onward, and the transcript cursor each session was
- * last read to. It lives in Luke's own application data beside the
- * conversation, never in a provider's file, and the History tab's Clear
- * deletes it along with the thread.
+ * The state file is the brain's one envelope — its Responses memory, cursors,
+ * request records, and action journal — written only through the store the
+ * main process owns. It lives in Luke's own application data beside the
+ * conversation, never in a provider's file.
  */
 
 export const BRAIN_STATE_FILE = "brain-state.json";
-
-/**
- * Reads a stored brain state, or nothing when the file is missing, from
- * another build, or malformed. The memory is not load-bearing: a launch that
- * cannot read it begins with an empty one, which is what every launch did
- * before the file existed, and the compaction the model produces rebuilds the
- * summary from what it sees next.
- */
-export function brainStateFromStored(stored: string | undefined): BrainPersistedState | undefined {
-  if (stored === undefined) return undefined;
-  try {
-    // SAFETY: JSON.parse returns a wire value; the reader below is the validation.
-    const parsed = JSON.parse(stored) as UnparsedWireValue;
-    return brainPersistedStateFromWire(parsed);
-  } catch {
-    return undefined;
-  }
-}
-
-/** The record the brain's state persists as. */
-export function brainStateRecord(state: BrainPersistedState): string {
-  return `${JSON.stringify(state)}\n`;
-}
 
 /**
  * Turns one provider's batch of spool events into wakes. Every hook event

--- a/apps/desktop/src/main/brain-host.test.ts
+++ b/apps/desktop/src/main/brain-host.test.ts
@@ -23,7 +23,9 @@ function host(log: string[]) {
   return new BrainHost({
     follow: (agent) => {
       log.push(`follow ${agent === undefined ? "none" : "agent"}`);
-      return () => log.push("unfollow");
+      return async () => {
+        log.push("unfollow");
+      };
     },
     publishEmpty: () => log.push("publish empty"),
   });

--- a/apps/desktop/src/main/brain-host.test.ts
+++ b/apps/desktop/src/main/brain-host.test.ts
@@ -1,0 +1,98 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { BrainAgent } from "@sidecar/brain";
+import { BrainHost } from "./brain-host";
+
+/** An agent whose stop the test releases, recording the order things happened in. */
+function fakeAgent(name: string, log: string[]) {
+  let release: (() => void) | undefined;
+  const stopped = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  // SAFETY: the host reads only `stop` off an agent; the fixture stands in for the rest.
+  const agent = {
+    stop: () => {
+      log.push(`stop ${name}`);
+      return stopped;
+    },
+  } as unknown as BrainAgent;
+  return { agent, release: () => release?.() };
+}
+
+function host(log: string[]) {
+  return new BrainHost({
+    follow: (agent) => {
+      log.push(`follow ${agent === undefined ? "none" : "agent"}`);
+      return () => log.push("unfollow");
+    },
+    publishEmpty: () => log.push("publish empty"),
+  });
+}
+
+test("retiring withdraws the agent at once and begins its stop before any await", () => {
+  const log: string[] = [];
+  const brains = host(log);
+  const a = fakeAgent("a", log);
+  void brains.replace(() => a.agent);
+  a.release();
+  return brains.settled().then(() => {
+    assert.equal(brains.current(), a.agent);
+    brains.retire();
+    assert.equal(brains.current(), undefined);
+    assert.deepEqual(log, ["follow agent", "unfollow", "stop a"]);
+  });
+});
+
+test("overlapping transitions install only the latest agent, once every earlier stop has settled", async () => {
+  const log: string[] = [];
+  const brains = host(log);
+  const a = fakeAgent("a", log);
+  const b = fakeAgent("b", log);
+  const c = fakeAgent("c", log);
+  await brains.replace(() => a.agent);
+  assert.equal(brains.current(), a.agent);
+  const installed = log.length;
+
+  // Transition B retires A and waits on A's slow stop; transition C arrives
+  // meanwhile. B must install nothing, and C must not install until A has
+  // stopped.
+  const second = brains.replace(() => {
+    log.push("build b");
+    return b.agent;
+  });
+  const third = brains.replace(() => {
+    log.push("build c");
+    return c.agent;
+  });
+  assert.equal(brains.current(), undefined);
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.ok(!log.includes("build b") && !log.includes("build c"));
+  a.release();
+  await Promise.all([second, third]);
+  assert.equal(brains.current(), c.agent);
+  assert.deepEqual(
+    log.slice(installed).filter((entry) => entry.startsWith("build") || entry.startsWith("follow")),
+    ["build c", "follow agent"],
+  );
+  assert.equal(log.filter((entry) => entry === "stop b").length, 0);
+});
+
+test("a build decided after a newer transition is stopped rather than installed, and no capability publishes empty", async () => {
+  const log: string[] = [];
+  const brains = host(log);
+  const a = fakeAgent("a", log);
+  let newer: Promise<void> | undefined;
+  const older = brains.replace(() => {
+    // The build itself asks for another transition — the same shape as a
+    // capability changing while the previous build is deciding.
+    newer = brains.replace(() => undefined);
+    return a.agent;
+  });
+  a.release();
+  await older;
+  await newer;
+  assert.equal(brains.current(), undefined);
+  assert.ok(log.includes("stop a"));
+  assert.ok(!log.includes("follow agent"));
+  assert.equal(log.filter((entry) => entry === "publish empty").length, 1);
+});

--- a/apps/desktop/src/main/brain-host.test.ts
+++ b/apps/desktop/src/main/brain-host.test.ts
@@ -39,7 +39,7 @@ test("retiring withdraws the agent at once and begins its stop before any await"
     assert.equal(brains.current(), a.agent);
     brains.retire();
     assert.equal(brains.current(), undefined);
-    assert.deepEqual(log, ["follow agent", "unfollow", "stop a"]);
+    assert.deepEqual(log, ["follow agent", "stop a"]);
   });
 });
 
@@ -95,4 +95,37 @@ test("a build decided after a newer transition is stopped rather than installed,
   assert.ok(log.includes("stop a"));
   assert.ok(!log.includes("follow agent"));
   assert.equal(log.filter((entry) => entry === "publish empty").length, 1);
+});
+
+test("a retirement while an earlier replacement waits on a stop leaves that build uninstalled", async () => {
+  const log: string[] = [];
+  const brains = host(log);
+  const a = fakeAgent("a", log);
+  const b = fakeAgent("b", log);
+  await brains.replace(() => a.agent);
+  const replacing = brains.replace(() => {
+    log.push("build b");
+    return b.agent;
+  });
+  // The source goes away before A has finished stopping: nothing may install.
+  brains.retire();
+  a.release();
+  await replacing;
+  assert.equal(brains.current(), undefined);
+  assert.ok(!log.includes("build b"));
+  // A later transition with no capability publishes the empty list once.
+  await brains.replace(() => undefined);
+  assert.equal(log.filter((entry) => entry === "publish empty").length, 1);
+});
+
+test("the follower outlives the stop it relays, and retires once the stop settles", async () => {
+  const log: string[] = [];
+  const brains = host(log);
+  const a = fakeAgent("a", log);
+  await brains.replace(() => a.agent);
+  brains.retire();
+  assert.deepEqual(log, ["follow agent", "stop a"]);
+  a.release();
+  await brains.replace(() => undefined);
+  assert.deepEqual(log, ["follow agent", "stop a", "unfollow", "publish empty"]);
 });

--- a/apps/desktop/src/main/brain-host.ts
+++ b/apps/desktop/src/main/brain-host.ts
@@ -1,0 +1,81 @@
+import type { BrainAgent } from "@sidecar/brain";
+
+/**
+ * Who owns the standing brain agent through a transition. A key or account
+ * change retires the agent that stands and, once the new capability is known,
+ * builds another; two transitions can overlap — an account landing while a
+ * key is still being removed — and the older one must never install an agent
+ * after the newer has decided. So retirement is synchronous and immediate,
+ * withdrawing the old agent's execution before the transition's first await,
+ * and building is serialized behind every earlier retirement and coalesced to
+ * the latest transition: when the queue reaches a build, only the newest
+ * request still owns the outcome, and every older one installs nothing.
+ */
+export interface BrainHostDependencies {
+  /** Follows a newly installed agent; answers the unfollow. */
+  follow: (agent: BrainAgent) => () => void;
+  /** Tells every window what stands when no agent does: no runs at all. */
+  publishEmpty: () => void;
+}
+
+export class BrainHost {
+  readonly #dependencies: BrainHostDependencies;
+  #agent: BrainAgent | undefined;
+  #unfollow: (() => void) | undefined;
+  #retiring: Promise<unknown>[] = [];
+  #transitions = 0;
+  #chain: Promise<void> = Promise.resolve();
+
+  constructor(dependencies: BrainHostDependencies) {
+    this.#dependencies = dependencies;
+  }
+
+  current(): BrainAgent | undefined {
+    return this.#agent;
+  }
+
+  /**
+   * Withdraws the standing agent now: nothing may ask it anything more, its
+   * follower stops relaying, and its `stop` — which revokes every run and
+   * observation turn synchronously before it awaits — is begun at once. The
+   * stop's settling is awaited by the next build, never by the caller.
+   */
+  retire(): void {
+    const previous = this.#agent;
+    this.#agent = undefined;
+    this.#unfollow?.();
+    this.#unfollow = undefined;
+    if (previous) this.#retiring.push(previous.stop().catch(() => undefined));
+  }
+
+  /**
+   * Retires whatever stands and, once every retirement has settled, installs
+   * what `build` answers — unless a newer transition has been asked for since,
+   * in which case this one installs nothing and the newer one decides. A
+   * build answering nothing stands the host down and says so to the windows.
+   */
+  replace(build: () => BrainAgent | undefined): Promise<void> {
+    this.retire();
+    const transition = ++this.#transitions;
+    this.#chain = this.#chain.then(async () => {
+      await Promise.all(this.#retiring.splice(0));
+      if (transition !== this.#transitions) return;
+      const agent = build();
+      if (transition !== this.#transitions) {
+        // Decided too late: a newer transition owns the outcome, and an
+        // agent built for this one must not stand beside its successor.
+        if (agent) await agent.stop();
+        return;
+      }
+      this.#agent = agent;
+      if (agent) this.#unfollow = this.#dependencies.follow(agent);
+      else this.#dependencies.publishEmpty();
+    });
+    return this.#chain;
+  }
+
+  /** Settles once every transition asked for so far has decided. */
+  settled(): Promise<void> {
+    return this.#chain;
+  }
+}

--- a/apps/desktop/src/main/brain-host.ts
+++ b/apps/desktop/src/main/brain-host.ts
@@ -35,17 +35,34 @@ export class BrainHost {
   }
 
   /**
-   * Withdraws the standing agent now: nothing may ask it anything more, its
-   * follower stops relaying, and its `stop` — which revokes every run and
-   * observation turn synchronously before it awaits — is begun at once. The
-   * stop's settling is awaited by the next build, never by the caller.
+   * Withdraws the standing agent now: nothing may ask it anything more, and
+   * its `stop` — which revokes every run and observation turn synchronously
+   * before it awaits — is begun at once. Its follower relays the stop's own
+   * interruptions and retires when the stop settles. The stop's settling is
+   * awaited by the next build, never by the caller.
    */
   retire(): void {
+    // Retiring is itself a transition: a build already queued for an earlier
+    // one must not install after this withdrawal, or a source that has gone
+    // away would gain an agent.
+    this.#transitions += 1;
     const previous = this.#agent;
+    const unfollow = this.#unfollow;
     this.#agent = undefined;
-    this.#unfollow?.();
     this.#unfollow = undefined;
-    if (previous) this.#retiring.push(previous.stop().catch(() => undefined));
+    if (!previous) {
+      unfollow?.();
+      return;
+    }
+    // The follower stays through the stop, so the runs the stop interrupts
+    // still reach the windows and the thread; it retires once nothing more
+    // can be reported.
+    this.#retiring.push(
+      previous
+        .stop()
+        .catch(() => undefined)
+        .finally(() => unfollow?.()),
+    );
   }
 
   /**

--- a/apps/desktop/src/main/brain-host.ts
+++ b/apps/desktop/src/main/brain-host.ts
@@ -12,8 +12,8 @@ import type { BrainAgent } from "@sidecar/brain";
  * request still owns the outcome, and every older one installs nothing.
  */
 export interface BrainHostDependencies {
-  /** Follows a newly installed agent; answers the unfollow. */
-  follow: (agent: BrainAgent) => () => void;
+  /** Follows a newly installed agent; answers the unfollow, which settles once its publication has drained. */
+  follow: (agent: BrainAgent) => () => Promise<void>;
   /** Tells every window what stands when no agent does: no runs at all. */
   publishEmpty: () => void;
 }
@@ -21,7 +21,7 @@ export interface BrainHostDependencies {
 export class BrainHost {
   readonly #dependencies: BrainHostDependencies;
   #agent: BrainAgent | undefined;
-  #unfollow: (() => void) | undefined;
+  #unfollow: (() => Promise<void>) | undefined;
   #retiring: Promise<unknown>[] = [];
   #transitions = 0;
   #chain: Promise<void> = Promise.resolve();
@@ -51,17 +51,18 @@ export class BrainHost {
     this.#agent = undefined;
     this.#unfollow = undefined;
     if (!previous) {
-      unfollow?.();
+      if (unfollow) this.#retiring.push(unfollow());
       return;
     }
     // The follower stays through the stop, so the runs the stop interrupts
-    // still reach the windows and the thread; it retires once nothing more
-    // can be reported.
+    // still reach the windows and the thread, and its publication of them
+    // drains before anything succeeds this agent: the next build, and the
+    // store's lease, wait on it.
     this.#retiring.push(
       previous
         .stop()
         .catch(() => undefined)
-        .finally(() => unfollow?.()),
+        .then(() => unfollow?.()),
     );
   }
 

--- a/apps/desktop/src/main/brain-lifecycle.test.ts
+++ b/apps/desktop/src/main/brain-lifecycle.test.ts
@@ -1,0 +1,273 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  BRAIN_REQUEST_ORIGIN,
+  BRAIN_REQUEST_STATUS,
+  BrainAgent,
+  type BrainClient,
+  type BrainClientAnswer,
+  type BrainRequestRecord,
+  type BrainStateStorage,
+  BrainStateStore,
+  brainStateFromStored,
+} from "@sidecar/brain";
+import {
+  appendConversationThreadEntry,
+  CONVERSATION_ENTRY_KIND,
+  type ConversationEntry,
+} from "@sidecar/realtime";
+import { ACT_RESULT_STATUS } from "@sidecar/wire";
+import type { BrainRequestSnapshot } from "#shared/wire/brain";
+import { BrainHost } from "./brain-host";
+import { followBrainRequests, submitBrainAsk } from "./ipc/brain";
+
+/**
+ * The real agent, store, host, follower, and submission path composed as the
+ * main process composes them, with only the model and the disk synthetic.
+ */
+
+const NOW = 1_800_000_000_000;
+
+class MemoryStorage implements BrainStateStorage {
+  file: string | undefined;
+  read() {
+    return this.file;
+  }
+  write(contents: string) {
+    this.file = contents;
+    return true;
+  }
+  remove() {
+    this.file = undefined;
+    return true;
+  }
+}
+
+/** A model that answers nothing until the test says so. */
+function heldClient(): BrainClient & { release: (answer: BrainClientAnswer) => void } {
+  const waiting: ((answer: BrainClientAnswer) => void)[] = [];
+  return {
+    respond: () =>
+      new Promise((resolve) => {
+        waiting.push(resolve);
+      }),
+    quietUntil: () => undefined,
+    release: (answer) => {
+      for (const resolve of waiting.splice(0)) resolve(answer);
+    },
+  };
+}
+
+function settle(): Promise<void> {
+  return new Promise((resolve) => {
+    let ticks = 0;
+    const tick = () => {
+      ticks += 1;
+      if (ticks > 30) resolve();
+      else setImmediate(tick);
+    };
+    tick();
+  });
+}
+
+function composed() {
+  const storage = new MemoryStorage();
+  let ids = 0;
+  const store = new BrainStateStore({
+    storage,
+    createGenerationId: () => `gen-${++ids}`,
+    now: () => NOW,
+  });
+  let thread: readonly ConversationEntry[] = [];
+  let refuseWrites = false;
+  const broadcasts: (readonly BrainRequestSnapshot[])[] = [];
+  const record = (entry: ConversationEntry, at: number) => {
+    if (refuseWrites) return false;
+    thread = appendConversationThreadEntry(thread, entry, NOW + 1000, at);
+    return true;
+  };
+  const host = new BrainHost({
+    follow: (agent) =>
+      followBrainRequests(agent, {
+        recordConversationEntry: record,
+        broadcastRequests: (snapshots) => broadcasts.push(snapshots),
+      }),
+    publishEmpty: () => broadcasts.push([]),
+  });
+  const build = (client: BrainClient) =>
+    new BrainAgent({
+      client,
+      acts: { perform: async () => ({ status: ACT_RESULT_STATUS.ACCEPTED }) },
+      roster: () => ({ text: "", identities: [] }),
+      standingContext: () => "",
+      readTranscriptSince: async () => ({ status: ACT_RESULT_STATUS.REJECTED, reason: "no" }),
+      readTranscript: async () => ({ status: ACT_RESULT_STATUS.REJECTED, reason: "no" }),
+      deliver: () => undefined,
+      store,
+      createRunId: () => `run-${++ids}`,
+      report: () => {},
+      now: () => NOW,
+    });
+  return {
+    storage,
+    store,
+    host,
+    build,
+    record,
+    thread: () => thread,
+    broadcasts,
+    refuse: (value: boolean) => {
+      refuseWrites = value;
+    },
+  };
+}
+
+async function submitMany(
+  agent: BrainAgent,
+  record: ReturnType<typeof composed>["record"],
+  count: number,
+) {
+  const runIds: string[] = [];
+  for (let index = 0; index < count; index += 1) {
+    const result = await submitBrainAsk(
+      agent,
+      {
+        submissionId: `sub-${index}`,
+        question: `ask ${index}`,
+        origin: BRAIN_REQUEST_ORIGIN.TYPED,
+      },
+      record,
+    );
+    assert.equal(result.outcome, "accepted");
+    if (result.outcome === "accepted") runIds.push(result.runId);
+  }
+  return runIds;
+}
+
+test("removing the capability under five outstanding runs leaves every run interrupted, published, and marked", async () => {
+  const c = composed();
+  const client = heldClient();
+  await c.host.replace(() => c.build(client));
+  const agent = c.host.current();
+  assert.ok(agent);
+  const runIds = await submitMany(agent, c.record, 5);
+  await settle();
+  assert.equal(c.thread().filter((e) => e.kind === CONVERSATION_ENTRY_KIND.TYPED_ASK).length, 5);
+
+  await c.host.replace(() => undefined);
+  await settle();
+  assert.equal(c.host.current(), undefined);
+  const stored = brainStateFromStored(c.storage.file);
+  assert.equal(stored?.requests.length, 5);
+  for (const runId of runIds) {
+    const kept: BrainRequestRecord | undefined = stored?.requests.find(
+      (entry) => entry.runId === runId,
+    );
+    assert.equal(kept?.status, BRAIN_REQUEST_STATUS.INTERRUPTED);
+    assert.ok(kept?.historyRecordedAt !== undefined, `${runId} marked`);
+    assert.ok(kept?.askRecordedAt !== undefined);
+    assert.equal(
+      c.thread().filter((e) => e.kind === CONVERSATION_ENTRY_KIND.REPLY && e.requestId === runId)
+        .length,
+      1,
+      `${runId} has one reply line`,
+    );
+  }
+  assert.deepEqual(c.broadcasts.at(-1), []);
+  // The old agent's late model answer changes nothing anyone can see.
+  client.release({
+    outcome: "answered",
+    payload: {
+      output: [
+        { type: "message", role: "assistant", content: [{ type: "output_text", text: "late" }] },
+      ],
+    },
+  });
+  await settle();
+  assert.equal(c.thread().filter((e) => e.words === "late").length, 0);
+  assert.equal(
+    brainStateFromStored(c.storage.file)?.requests.every(
+      (r) => r.status === BRAIN_REQUEST_STATUS.INTERRUPTED,
+    ),
+    true,
+  );
+});
+
+test("a successor replacing the agent under outstanding runs inherits a thread with every end written, and owns the store alone", async () => {
+  const c = composed();
+  const first = heldClient();
+  await c.host.replace(() => c.build(first));
+  const agent = c.host.current();
+  assert.ok(agent);
+  const runIds = await submitMany(agent, c.record, 5);
+  // An earlier publication is held: the thread refuses until the handoff.
+  c.refuse(true);
+  await settle();
+  c.refuse(false);
+  const second = heldClient();
+  await c.host.replace(() => c.build(second));
+  await settle();
+  const successor = c.host.current();
+  assert.ok(successor && successor !== agent);
+  for (const runId of runIds) {
+    assert.equal(successor.request(runId)?.status, BRAIN_REQUEST_STATUS.INTERRUPTED);
+    assert.equal(
+      c.thread().filter((e) => e.kind === CONVERSATION_ENTRY_KIND.REPLY && e.requestId === runId)
+        .length,
+      1,
+    );
+  }
+  // The successor's own run proceeds and is the only writer.
+  const result = await submitBrainAsk(
+    successor,
+    { submissionId: "fresh", question: "new ask", origin: BRAIN_REQUEST_ORIGIN.TYPED },
+    c.record,
+  );
+  assert.equal(result.outcome, "accepted");
+  second.release({
+    outcome: "answered",
+    payload: {
+      output: [
+        { type: "message", role: "assistant", content: [{ type: "output_text", text: "done" }] },
+      ],
+    },
+  });
+  await settle();
+  const fresh = brainStateFromStored(c.storage.file)?.requests.find(
+    (r) => r.question === "new ask",
+  );
+  assert.equal(fresh?.status, BRAIN_REQUEST_STATUS.SUCCEEDED);
+  assert.equal(c.thread().at(-1)?.words, "done");
+  // The retired agent takes nothing more and writes nothing more: its store
+  // lease passed to the successor with the handoff.
+  assert.equal(
+    (
+      await agent.submitAsk({
+        submissionId: "stale",
+        question: "old ask",
+        origin: BRAIN_REQUEST_ORIGIN.TYPED,
+      })
+    ).outcome,
+    "rejected",
+  );
+  assert.equal(c.store.holdsLease(agent.lease), false);
+  assert.equal(c.store.holdsLease(successor.lease), true);
+});
+
+test("a reset under outstanding runs discards them without publishing, and the successor starts clean", async () => {
+  const c = composed();
+  const client = heldClient();
+  await c.host.replace(() => c.build(client));
+  const agent = c.host.current();
+  assert.ok(agent);
+  await submitMany(agent, c.record, 3);
+  await settle();
+  assert.equal(await c.store.reset(), true);
+  await settle();
+  assert.deepEqual(agent.requests(), []);
+  assert.equal(c.thread().filter((e) => e.kind === CONVERSATION_ENTRY_KIND.REPLY).length, 0);
+  assert.equal(brainStateFromStored(c.storage.file), undefined);
+  await c.host.replace(() => undefined);
+  await settle();
+  assert.equal(c.thread().filter((e) => e.kind === CONVERSATION_ENTRY_KIND.REPLY).length, 0);
+});

--- a/apps/desktop/src/main/desktop-app.ts
+++ b/apps/desktop/src/main/desktop-app.ts
@@ -22,7 +22,7 @@ import {
   productSignInAge,
   type RecordProductEvent,
 } from "@sidecar/analytics";
-import { BrainAgent, type BrainDelivery, type BrainPersistedState } from "@sidecar/brain";
+import { BrainAgent, type BrainDelivery, BrainStateStore } from "@sidecar/brain";
 import {
   activeMeetingEnd,
   GoogleCalendarReader,
@@ -150,12 +150,7 @@ import {
   countsFirstAnnouncement,
   shouldBackfillArrivalSettled,
 } from "./arrival-flow";
-import {
-  BRAIN_STATE_FILE,
-  brainStateFromStored,
-  brainStateRecord,
-  wakeEventsFromHooks,
-} from "./brain-flow";
+import { BRAIN_STATE_FILE, wakeEventsFromHooks } from "./brain-flow";
 import {
   CALENDAR_ONBOARDING_STATE_FILE,
   type CalendarOnboardingState,
@@ -176,7 +171,7 @@ import {
   shouldRunIntroduction,
 } from "./introduction-flow";
 import { registerAccountSessionIpc } from "./ipc/account-session";
-import { registerBrainIpc } from "./ipc/brain";
+import { followBrainRequests, registerBrainIpc } from "./ipc/brain";
 import { createBrainActPerformer, type WorkspaceCreationDefaults } from "./ipc/brain-acts";
 import { registerCalendarConnectionIpc } from "./ipc/calendar-connection";
 import { createSessionActPerformer, registerSessionActsIpc } from "./ipc/session-acts";
@@ -492,6 +487,14 @@ let conversationClearedAt: number | undefined;
  * announced, and an ask is answered with the honest refusal.
  */
 let brain: BrainAgent | undefined;
+/** The subscription following the standing brain's records, retired with it. */
+let unfollowBrain: (() => void) | undefined;
+/**
+ * The one writer of the brain's state file, owned here and outliving every
+ * agent built on it: a key or account change rebuilds the agent, never the
+ * store, so two agents can never write the envelope past each other.
+ */
+let brainStateStore: BrainStateStore | undefined;
 /** The spool watchers standing on each hooked provider's spool, closed at quit. */
 let spoolWatchers: readonly ObservationSpoolWatcher[] = [];
 /**
@@ -1486,6 +1489,19 @@ async function applyVoiceCredential(): Promise<void> {
 
 const brainStatePath = () => path.join(app.getPath("userData"), BRAIN_STATE_FILE);
 
+function brainStore(): BrainStateStore {
+  brainStateStore ??= new BrainStateStore({
+    storage: {
+      read: () => readStoredState(brainStatePath()),
+      write: (contents) =>
+        writeStoredState(brainStatePath(), contents, "Luke's memory of the agents"),
+      remove: () => removeStoredState(brainStatePath(), "Luke's memory of the agents"),
+    },
+    createGenerationId: () => randomUUID(),
+  });
+  return brainStateStore;
+}
+
 /**
  * The roster as the brain is shown it and validates every act against: the
  * sessions still worth a row, less Luke's own voice, rendered with the same
@@ -1712,6 +1728,8 @@ const brainActPerformer = createBrainActPerformer({
 async function rebuildBrain(): Promise<void> {
   const previous = brain;
   brain = undefined;
+  unfollowBrain?.();
+  unfollowBrain = undefined;
   if (previous) await previous.stop();
   const client = voiceCapabilities.brainClient;
   if (
@@ -1756,12 +1774,14 @@ async function rebuildBrain(): Promise<void> {
       return adapter.readTranscript(identity.providerSessionId);
     },
     deliver: deliverBriefing,
-    persist: (state: BrainPersistedState) => {
-      writeStoredState(brainStatePath(), brainStateRecord(state), "Luke's memory of the agents");
-    },
-    restore: () => brainStateFromStored(readStoredState(brainStatePath())),
+    store: brainStore(),
+    createRunId: () => randomUUID(),
     ...(agentTrace ? { trace: (record) => agentTrace.recordBrainTurn(record) } : undefined),
     report: (message) => process.stderr.write(`${message}\n`),
+  });
+  unfollowBrain = followBrainRequests(brain, {
+    recordConversationEntry: recordMainConversationEntry,
+    broadcastRequests: (snapshots) => broadcast(channels.onBrainRequestsChanged, snapshots),
   });
 }
 
@@ -2203,7 +2223,17 @@ function registerIpc(): void {
   });
 
   registerSessionActsIpc({ ipcMain, trustedSender, performer: sessionActPerformer });
-  registerBrainIpc({ ipcMain, trustedSender, brain: () => brain });
+  registerBrainIpc({
+    ipcMain,
+    trustedSender,
+    brain: () => brain,
+    submitters: {
+      panel: (sender) => panels.owns(sender),
+      voice: (sender) => voiceWindow.owns(sender),
+    },
+    recordConversationEntry: recordMainConversationEntry,
+    broadcastRequests: (snapshots) => broadcast(channels.onBrainRequestsChanged, snapshots),
+  });
   // The renderer's description of the app, pushed whenever it changes: what an
   // app act the brain asks for is validated against here, and what the brain
   // reads as the guide.

--- a/apps/desktop/src/main/desktop-app.ts
+++ b/apps/desktop/src/main/desktop-app.ts
@@ -151,6 +151,7 @@ import {
   shouldBackfillArrivalSettled,
 } from "./arrival-flow";
 import { BRAIN_STATE_FILE, wakeEventsFromHooks } from "./brain-flow";
+import { BrainHost } from "./brain-host";
 import {
   CALENDAR_ONBOARDING_STATE_FILE,
   type CalendarOnboardingState,
@@ -486,9 +487,16 @@ let conversationClearedAt: number | undefined;
  * OpenAI key in this build: with no key there is no brain, nothing is
  * announced, and an ask is answered with the honest refusal.
  */
-let brain: BrainAgent | undefined;
-/** The subscription following the standing brain's records, retired with it. */
-let unfollowBrain: (() => void) | undefined;
+const brains = new BrainHost({
+  follow: (agent) =>
+    followBrainRequests(agent, {
+      recordConversationEntry: recordMainConversationEntry,
+      broadcastRequests: (snapshots) => broadcast(channels.onBrainRequestsChanged, snapshots),
+    }),
+  publishEmpty: () => broadcast(channels.onBrainRequestsChanged, []),
+});
+/** The brain that stands now, or nothing between transitions and on a run with no key. */
+const brain = () => brains.current();
 /**
  * The one writer of the brain's state file, owned here and outliving every
  * agent built on it: a key or account change rebuilds the agent, never the
@@ -1483,6 +1491,11 @@ async function stopAccountCapabilities(): Promise<void> {
 }
 
 async function applyVoiceCredential(): Promise<void> {
+  // The standing agent loses its execution before the transition's first
+  // await, so no run keeps the old source's authority while the new one is
+  // being decided; the rebuild behind the await installs what the new
+  // capability allows, and only the latest transition's rebuild installs.
+  brains.retire();
   await voiceCapabilities.apply();
   await rebuildBrain();
 }
@@ -1580,17 +1593,20 @@ function brainStandingContext(): string {
  * carried act was — and relays it to every panel, the way a window's own
  * report is merged and relayed. Nothing here reaches a provider.
  */
-function recordMainConversationEntry(entry: ConversationEntry): void {
-  if (!runMode.observesProviders) return;
+function recordMainConversationEntry(entry: ConversationEntry, recordedAt = Date.now()): boolean {
+  if (!runMode.observesProviders) return false;
   const now = Date.now();
-  const merged = appendConversationThreadEntry(conversationHistory, entry, now);
-  if (merged === conversationHistory) return;
+  const merged = appendConversationThreadEntry(conversationHistory, entry, now, recordedAt);
+  // Unchanged means the thread already holds this line, or refused an empty
+  // one: either way it holds everything it was asked to.
+  if (merged === conversationHistory) return true;
   if (!writeStoredState(conversationPath(), conversationRecord(merged, now), "the conversation")) {
-    return;
+    return false;
   }
   conversationHistory = merged;
   const payload: ConversationHistoryPayload = { entries: merged, cleared: false };
   broadcast(channels.onConversationHistoryChanged, payload);
+  return true;
 }
 
 /**
@@ -1725,23 +1741,24 @@ const brainActPerformer = createBrainActPerformer({
  * voice does. Never in a fixture or capture run, which observes nothing and
  * sends nothing, and never past a closed account gate.
  */
-async function rebuildBrain(): Promise<void> {
-  const previous = brain;
-  brain = undefined;
-  unfollowBrain?.();
-  unfollowBrain = undefined;
-  if (previous) await previous.stop();
-  const client = voiceCapabilities.brainClient;
-  if (
-    !client ||
-    !runMode.observesProviders ||
-    !runMode.sendsNetwork ||
-    !accountCapabilitiesActive()
-  ) {
-    speechArbiter.dropBriefings();
-    return;
-  }
-  brain = new BrainAgent({
+function rebuildBrain(): Promise<void> {
+  return brains.replace(() => {
+    const client = voiceCapabilities.brainClient;
+    if (
+      !client ||
+      !runMode.observesProviders ||
+      !runMode.sendsNetwork ||
+      !accountCapabilitiesActive()
+    ) {
+      speechArbiter.dropBriefings();
+      return undefined;
+    }
+    return buildBrain(client);
+  });
+}
+
+function buildBrain(client: NonNullable<typeof voiceCapabilities.brainClient>): BrainAgent {
+  return new BrainAgent({
     client,
     acts: brainActPerformer,
     roster: brainRoster,
@@ -1778,10 +1795,6 @@ async function rebuildBrain(): Promise<void> {
     createRunId: () => randomUUID(),
     ...(agentTrace ? { trace: (record) => agentTrace.recordBrainTurn(record) } : undefined),
     report: (message) => process.stderr.write(`${message}\n`),
-  });
-  unfollowBrain = followBrainRequests(brain, {
-    recordConversationEntry: recordMainConversationEntry,
-    broadcastRequests: (snapshots) => broadcast(channels.onBrainRequestsChanged, snapshots),
   });
 }
 
@@ -2226,7 +2239,7 @@ function registerIpc(): void {
   registerBrainIpc({
     ipcMain,
     trustedSender,
-    brain: () => brain,
+    brain,
     submitters: {
       panel: (sender) => panels.owns(sender),
       voice: (sender) => voiceWindow.owns(sender),
@@ -2423,7 +2436,7 @@ function watchObservationSpools(): void {
         onEvents: (events) => {
           void (async () => {
             await sessionObservationLoop.refresh().catch(() => undefined);
-            brain?.wake(wakeEventsFromHooks(providerId, events, sessionRegistry, Date.now()));
+            brain()?.wake(wakeEventsFromHooks(providerId, events, sessionRegistry, Date.now()));
           })();
         },
       }),
@@ -2658,8 +2671,9 @@ async function reconcileSpeech(): Promise<void> {
   const quiet = await announcementsQuietNow(Date.now());
   speechArbiter.setQuiet(quiet);
   if (!quiet && speechArbiter.heldBriefingCount > 0) {
-    if (brain && voiceCapabilities.realtimeCredentials) {
-      brain.releaseHeld(speechArbiter.takeHeldBriefings());
+    const standing = brain();
+    if (standing && voiceCapabilities.realtimeCredentials) {
+      standing.releaseHeld(speechArbiter.takeHeldBriefings());
     } else if (!voiceCapabilities.realtimeCredentials) {
       speechArbiter.dropBriefings();
     }
@@ -2775,7 +2789,7 @@ const sessionObservationLoop = new ObservationLoop({
   // is closed (observesProviders && accountCapabilitiesActive()).
   afterRun: () => {
     void broadcastCodexCloudConnection();
-    brain?.rosterLook();
+    brain()?.rosterLook();
   },
 });
 const issueObservationLoop = new ObservationLoop({
@@ -3296,7 +3310,7 @@ export function startDesktopApp(): void {
     stopCalendarObservation();
     for (const watcher of spoolWatchers) watcher.close();
     spoolWatchers = [];
-    void brain?.stop();
+    brains.retire();
     // Deliberately not a flush: a request here either delays the quit or is
     // killed mid-flight, and an instant quit is worth the last minute of
     // counts.

--- a/apps/desktop/src/main/ipc/brain-acts.test.ts
+++ b/apps/desktop/src/main/ipc/brain-acts.test.ts
@@ -18,7 +18,11 @@ const NOW = 1_800_000_000_000;
 
 /** A developer-opened turn still standing, or one revoked from the moment `revoked()` first says so. */
 function developerTurn(revoked: () => boolean = () => false): BrainActExecution {
-  return { authority: BRAIN_TURN_AUTHORITY.DEVELOPER, isRevoked: revoked };
+  return {
+    authority: BRAIN_TURN_AUTHORITY.DEVELOPER,
+    isRevoked: revoked,
+    signal: new AbortController().signal,
+  };
 }
 
 const LIVE = developerTurn();
@@ -304,4 +308,40 @@ test("an act is validated against the roster as refreshed inside the turn, not a
   const refused = await acts.perform(MESSAGE_CALL, LIVE);
   assert.equal(refused.status, ACT_RESULT_STATUS.REJECTED);
   assert.deepEqual(performed, []);
+});
+
+test("a cancel during the roster refresh or the defaults read settles the act, and the late read dispatches nothing", async () => {
+  for (const held of ["refreshSessions", "workspaceDefaults"] as const) {
+    let release: (() => void) | undefined;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const h = performer({
+      [held]: async () => {
+        await gate;
+        return {};
+      },
+    });
+    const controller = new AbortController();
+    const execution: BrainActExecution = {
+      authority: BRAIN_TURN_AUTHORITY.DEVELOPER,
+      isRevoked: () => controller.signal.aborted,
+      signal: controller.signal,
+    };
+    const pending = h.acts.perform(MESSAGE_CALL, execution);
+    let settled = false;
+    void pending.then(() => {
+      settled = true;
+    });
+    await new Promise((resolve) => setImmediate(resolve));
+    assert.equal(settled, false);
+    controller.abort();
+    const outcome = await pending;
+    assert.equal(outcome.status, ACT_RESULT_STATUS.REJECTED);
+    assert.deepEqual(h.performed, []);
+    release?.();
+    await new Promise((resolve) => setImmediate(resolve));
+    assert.deepEqual(h.performed, [], `${held}: the late read dispatched nothing`);
+    assert.deepEqual(h.recorded, []);
+  }
 });

--- a/apps/desktop/src/main/ipc/brain-acts.ts
+++ b/apps/desktop/src/main/ipc/brain-acts.ts
@@ -17,6 +17,7 @@ import {
   BRAIN_TURN_AUTHORITY,
   type BrainActExecution,
   type BrainActPerformer,
+  settledUnlessAborted,
 } from "@sidecar/brain";
 import type { AppGuideSnapshot } from "@sidecar/guide";
 import type { TrackedIssue } from "@sidecar/issues";
@@ -98,11 +99,15 @@ export function createBrainActPerformer(
     call: RealtimeFunctionCall,
     execution: BrainActExecution,
   ): Promise<WireRecord> => {
-    await dependencies.refreshSessions();
-    if (execution.isRevoked()) return rejection(REFUSAL.TURN_OVER);
+    // The reads before the effect wait only as long as the standing does: a
+    // cancel landing mid-refresh settles the act here, and the refresh's late
+    // answer dispatches nothing.
+    const refreshed = await settledUnlessAborted(dependencies.refreshSessions(), execution.signal);
+    if (refreshed.aborted || execution.isRevoked()) return rejection(REFUSAL.TURN_OVER);
     const sessions = dependencies.sessions();
-    const defaults = await dependencies.workspaceDefaults();
-    if (execution.isRevoked()) return rejection(REFUSAL.TURN_OVER);
+    const read = await settledUnlessAborted(dependencies.workspaceDefaults(), execution.signal);
+    if (read.aborted || execution.isRevoked()) return rejection(REFUSAL.TURN_OVER);
+    const defaults = read.value;
     const action = sessionToolAction(
       call,
       sessions,

--- a/apps/desktop/src/main/ipc/brain.test.ts
+++ b/apps/desktop/src/main/ipc/brain.test.ts
@@ -9,7 +9,7 @@ import {
   maximumTypedAskLength,
 } from "@sidecar/realtime";
 import { BRAIN_ASK_REFUSAL, brainReplyWords } from "#shared/wire/brain";
-import { followBrainRequests, recordEndedRuns, submitBrainAsk } from "./brain";
+import { followBrainRequests, publishRuns, submitBrainAsk } from "./brain";
 
 const NOW = 1_800_000_000_000;
 
@@ -27,6 +27,7 @@ function record(overrides: Partial<BrainRequestRecord> = {}): BrainRequestRecord
     text: "Two agents are waiting.",
     performedActs: 0,
     unknownActs: 0,
+    askRecordedAt: NOW,
     ...overrides,
   };
 }
@@ -39,9 +40,21 @@ function acceptingBrain(asked: BrainSubmission[]): BrainAgent {
       asked.push(submission);
       return { outcome: "accepted", runId: "run-1", acceptedAt: NOW };
     },
-    request: () => record({ status: BRAIN_REQUEST_STATUS.QUEUED, question: "the accepted words" }),
+    request: () =>
+      record({
+        status: BRAIN_REQUEST_STATUS.QUEUED,
+        question: "the accepted words",
+        origin: asked.at(-1)?.origin ?? BRAIN_REQUEST_ORIGIN.TYPED,
+        askRecordedAt: undefined,
+      }),
+    markAskRecorded: async (runId: string) => {
+      askMarks.push(runId);
+      return true;
+    },
   } as unknown as BrainAgent;
 }
+
+const askMarks: string[] = [];
 
 /** A thread the tests write into, as the main process's store would. */
 function thread(fail = () => false) {
@@ -60,11 +73,20 @@ function thread(fail = () => false) {
 }
 
 /** A brain that only remembers which runs were marked recorded. */
-function markingBrain(marked: string[]): Pick<BrainAgent, "markHistoryRecorded"> {
+function markingBrain(
+  marked: string[],
+  records: () => readonly BrainRequestRecord[] = () => [],
+): Pick<BrainAgent, "markHistoryRecorded" | "markAskRecorded" | "request"> {
   return {
     markHistoryRecorded: async (runId) => {
       marked.push(runId);
+      return true;
     },
+    markAskRecorded: async (runId) => {
+      marked.push(`ask ${runId}`);
+      return true;
+    },
+    request: (runId) => records().find((record) => record.runId === runId),
   };
 }
 
@@ -119,51 +141,110 @@ test("a spoken ask records nothing here: the voice service's transcript is its l
   assert.deepEqual(written.recorded, []);
 });
 
-test("a run's end reaches the thread once, at the moment it settled, and is then marked rather than re-read", async () => {
+test("a run's end reaches the thread once, at the moment it settled, decided against the live record", async () => {
   const written = thread();
   const marked: string[] = [];
-  const agent = markingBrain(marked);
-  const running = record({ status: BRAIN_REQUEST_STATUS.RUNNING, revision: 1, text: undefined });
-  await recordEndedRuns(agent, [running], written.record);
+  let live: BrainRequestRecord[] = [
+    record({ status: BRAIN_REQUEST_STATUS.RUNNING, revision: 1, text: undefined }),
+  ];
+  const agent = markingBrain(marked, () => live);
+  await publishRuns(agent, live, written.record);
   assert.equal(written.recorded.length, 0);
-  const ended = record();
-  await recordEndedRuns(agent, [ended], written.record);
+  live = [record()];
+  await publishRuns(agent, live, written.record);
   assert.equal(written.recorded.length, 1);
   const [firstWrite] = written.recorded;
   assert.equal(firstWrite?.at, NOW + 2);
   assert.equal(written.entries()[0]?.recordedAt, NOW + 2);
   assert.deepEqual(marked, ["run-1"]);
-  // Once marked, the record itself says so: an unrelated later report, a
-  // rebuilt follower, or a thread that has since let the line go all leave
-  // it alone.
-  const published = { ...ended, historyRecordedAt: NOW + 2 };
-  await recordEndedRuns(agent, [published], written.record);
-  await recordEndedRuns(
-    agent,
-    [
-      published,
-      record({ runId: "run-2", status: BRAIN_REQUEST_STATUS.CANCELLED, text: undefined }),
-    ],
-    written.record,
-  );
+  // Once marked, the live record says so: an unrelated later report, an
+  // older report captured before the mark, a rebuilt follower, or a thread
+  // that has since let the line go all leave it alone.
+  live = [{ ...record(), historyRecordedAt: NOW + 2 }];
+  await publishRuns(agent, [record()], written.record);
+  live = [
+    ...live,
+    record({ runId: "run-2", status: BRAIN_REQUEST_STATUS.CANCELLED, text: undefined }),
+  ];
+  await publishRuns(agent, live, written.record);
   assert.equal(written.recorded.length, 2);
   const [, secondWrite] = written.recorded;
   assert.equal(secondWrite?.entry.words, "Cancelled.");
   assert.deepEqual(marked, ["run-1", "run-2"]);
+  // A run the live agent no longer knows — the generation was reset — is not written.
+  live = [];
+  await publishRuns(agent, [record({ runId: "run-3" })], written.record);
+  assert.equal(written.recorded.length, 2);
+});
+
+test("a retired follower stops between two records, and the second waits for a live report", async () => {
+  const written = thread();
+  const marked: string[] = [];
+  const live = [record({ runId: "run-1" }), record({ runId: "run-2" })];
+  let holdMark: (() => void) | undefined;
+  const agent: Pick<BrainAgent, "request" | "markHistoryRecorded" | "markAskRecorded"> = {
+    request: (runId) => live.find((entry) => entry.runId === runId),
+    markAskRecorded: async () => true,
+    markHistoryRecorded: (runId) =>
+      new Promise((resolve) => {
+        marked.push(runId);
+        holdMark = () => resolve(true);
+      }),
+  };
+  let following = true;
+  const publishing = publishRuns(agent, live, written.record, () => following);
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.deepEqual(marked, ["run-1"]);
+  following = false;
+  holdMark?.();
+  await publishing;
+  assert.equal(written.recorded.length, 1);
+  assert.deepEqual(marked, ["run-1"]);
 });
 
 test("a run whose line the thread refused stays unmarked and is written on the next report", async () => {
   let refuse = true;
   const written = thread(() => refuse);
   const marked: string[] = [];
-  const agent = markingBrain(marked);
-  await recordEndedRuns(agent, [record()], written.record);
+  const live = [record()];
+  const agent = markingBrain(marked, () => live);
+  await publishRuns(agent, live, written.record);
   assert.deepEqual(marked, []);
   assert.equal(written.recorded.length, 0);
   refuse = false;
-  await recordEndedRuns(agent, [record()], written.record);
+  await publishRuns(agent, live, written.record);
   assert.deepEqual(marked, ["run-1"]);
   assert.equal(written.recorded.length, 1);
+});
+
+test("a typed ask whose line the thread refused at acceptance is written by a later report, at its acceptance", async () => {
+  let refuse = true;
+  const written = thread(() => refuse);
+  const marked: string[] = [];
+  const live = [
+    record({
+      status: BRAIN_REQUEST_STATUS.RUNNING,
+      text: undefined,
+      revision: 1,
+      askRecordedAt: undefined,
+    }),
+  ];
+  const agent = markingBrain(marked, () => live);
+  await publishRuns(agent, live, written.record);
+  assert.equal(written.recorded.length, 0);
+  refuse = false;
+  await publishRuns(agent, live, written.record);
+  assert.deepEqual(marked, ["ask run-1"]);
+  assert.equal(written.recorded[0]?.entry.kind, CONVERSATION_ENTRY_KIND.TYPED_ASK);
+  assert.equal(written.recorded[0]?.entry.words, "what needs me?");
+  assert.equal(written.recorded[0]?.at, NOW);
+  // The end, written later, still lands after the ask in the thread.
+  live[0] = { ...record(), askRecordedAt: NOW };
+  await publishRuns(agent, live, written.record);
+  assert.deepEqual(
+    written.entries().map((entry) => entry.kind),
+    [CONVERSATION_ENTRY_KIND.TYPED_ASK, CONVERSATION_ENTRY_KIND.REPLY],
+  );
 });
 
 test("an end without a reply is worded from what was done, never from a provider's words", () => {
@@ -230,8 +311,12 @@ test("an end without a reply is worded from what was done, never from a provider
 test("following a brain relays every report, writes and marks the ended runs, and stops when unfollowed", async () => {
   let listener: ((records: readonly BrainRequestRecord[]) => void) | undefined;
   const marked: string[] = [];
-  const ready = record({ status: BRAIN_REQUEST_STATUS.INTERRUPTED, text: undefined });
-  // SAFETY: the follower reads only these four members off the agent.
+  const ready = record({
+    status: BRAIN_REQUEST_STATUS.INTERRUPTED,
+    text: undefined,
+    askRecordedAt: NOW,
+  });
+  // SAFETY: the follower reads only these members off the agent.
   const agent = {
     subscribe: (next: (records: readonly BrainRequestRecord[]) => void) => {
       listener = next;
@@ -241,8 +326,11 @@ test("following a brain relays every report, writes and marks the ended runs, an
     },
     ready: () => Promise.resolve(),
     requests: () => [ready],
+    request: (runId: string) => [ready, record({ runId: "run-2" })].find((r) => r.runId === runId),
+    markAskRecorded: async () => true,
     markHistoryRecorded: async (runId: string) => {
       marked.push(runId);
+      return true;
     },
   } as unknown as BrainAgent;
   const broadcasts: (readonly BrainRequestRecord[])[] = [];
@@ -258,6 +346,7 @@ test("following a brain relays every report, writes and marks the ended runs, an
   assert.equal(written.entries()[0]?.words, "That ask was interrupted before I could finish it.");
   assert.deepEqual(marked, ["run-1"]);
   listener?.([{ ...ready, historyRecordedAt: NOW + 2 }, record({ runId: "run-2" })]);
+  await new Promise((resolve) => setImmediate(resolve));
   await new Promise((resolve) => setImmediate(resolve));
   assert.equal(broadcasts.length, 2);
   assert.equal(written.entries().length, 2);
@@ -279,7 +368,9 @@ test("a retired follower relays nothing a late report carries", async () => {
         releaseReady = resolve;
       }),
     requests: () => [record()],
-    markHistoryRecorded: async () => undefined,
+    request: () => record(),
+    markAskRecorded: async () => true,
+    markHistoryRecorded: async () => true,
   } as unknown as BrainAgent;
   const broadcasts: (readonly BrainRequestRecord[])[] = [];
   const written = thread();

--- a/apps/desktop/src/main/ipc/brain.test.ts
+++ b/apps/desktop/src/main/ipc/brain.test.ts
@@ -26,90 +26,144 @@ function record(overrides: Partial<BrainRequestRecord> = {}): BrainRequestRecord
     settledAt: NOW + 2,
     text: "Two agents are waiting.",
     performedActs: 0,
+    unknownActs: 0,
     ...overrides,
   };
 }
 
 /** A brain that accepts every submission into one run and remembers what it was asked. */
 function acceptingBrain(asked: BrainSubmission[]): BrainAgent {
-  // SAFETY: the ask path reads only `submitAsk` off the agent; the fixture stands in for the rest.
+  // SAFETY: the ask path reads only `submitAsk` and `request` off the agent; the fixture stands in for the rest.
   return {
     submitAsk: async (submission: BrainSubmission) => {
       asked.push(submission);
       return { outcome: "accepted", runId: "run-1", acceptedAt: NOW };
     },
+    request: () => record({ status: BRAIN_REQUEST_STATUS.QUEUED, question: "the accepted words" }),
   } as unknown as BrainAgent;
 }
 
+/** A thread the tests write into, as the main process's store would. */
+function thread(fail = () => false) {
+  let entries: readonly ConversationEntry[] = [];
+  const recorded: { entry: ConversationEntry; at: number }[] = [];
+  return {
+    entries: () => entries,
+    recorded,
+    record: (entry: ConversationEntry, at: number) => {
+      if (fail()) return false;
+      recorded.push({ entry, at });
+      entries = appendConversationThreadEntry(entries, entry, NOW + 100, at);
+      return true;
+    },
+  };
+}
+
+/** A brain that only remembers which runs were marked recorded. */
+function markingBrain(marked: string[]): Pick<BrainAgent, "markHistoryRecorded"> {
+  return {
+    markHistoryRecorded: async (runId) => {
+      marked.push(runId);
+    },
+  };
+}
+
 test("an ask with no brain is refused in fixed words, and nothing is recorded", async () => {
-  const recorded: ConversationEntry[] = [];
+  const written = thread();
   const result = await submitBrainAsk(
     undefined,
     { submissionId: "sub-1", question: "what needs me?", origin: BRAIN_REQUEST_ORIGIN.TYPED },
-    (entry) => recorded.push(entry),
+    written.record,
   );
   assert.deepEqual(result, { outcome: "rejected", reason: "absent" });
   assert.equal(BRAIN_ASK_REFUSAL.absent.includes("OpenAI key"), true);
-  assert.deepEqual(recorded, []);
+  assert.deepEqual(written.recorded, []);
 });
 
-test("a typed ask is bounded, handed to the brain whole, and recorded under its run", async () => {
+test("a typed ask is bounded, handed to the brain whole, and recorded in the accepted record's words", async () => {
   const asked: BrainSubmission[] = [];
-  const recorded: ConversationEntry[] = [];
+  const written = thread();
   const long = `  ${"a".repeat(maximumTypedAskLength + 50)}`;
   const result = await submitBrainAsk(
     acceptingBrain(asked),
     { submissionId: "sub-1", question: long, origin: BRAIN_REQUEST_ORIGIN.TYPED },
-    (entry) => recorded.push(entry),
+    written.record,
   );
   assert.deepEqual(result, { outcome: "accepted", runId: "run-1", acceptedAt: NOW });
   assert.equal(asked[0]?.question.length, maximumTypedAskLength);
   assert.equal(asked[0]?.submissionId, "sub-1");
-  assert.deepEqual(recorded, [
+  // The line is the run's own words at the run's own moment — what a retry
+  // that found an earlier run would otherwise misquote.
+  assert.deepEqual(written.recorded, [
     {
-      kind: CONVERSATION_ENTRY_KIND.TYPED_ASK,
-      words: "a".repeat(maximumTypedAskLength),
-      requestId: "run-1",
+      entry: {
+        kind: CONVERSATION_ENTRY_KIND.TYPED_ASK,
+        words: "the accepted words",
+        requestId: "run-1",
+      },
+      at: NOW,
     },
   ]);
+  assert.equal(written.entries()[0]?.recordedAt, NOW);
 });
 
 test("a spoken ask records nothing here: the voice service's transcript is its line", async () => {
   const asked: BrainSubmission[] = [];
-  const recorded: ConversationEntry[] = [];
+  const written = thread();
   await submitBrainAsk(
     acceptingBrain(asked),
     { submissionId: "call-1", question: "send it", origin: BRAIN_REQUEST_ORIGIN.SPOKEN },
-    (entry) => recorded.push(entry),
+    written.record,
   );
   assert.equal(asked[0]?.origin, BRAIN_REQUEST_ORIGIN.SPOKEN);
-  assert.deepEqual(recorded, []);
+  assert.deepEqual(written.recorded, []);
 });
 
-test("a run's end reaches the thread exactly once, worded by the build, however often it is reported", () => {
-  let thread: readonly ConversationEntry[] = [];
-  const recordInThread = (entry: ConversationEntry) => {
-    thread = appendConversationThreadEntry(thread, entry, NOW);
-  };
-  const line = (index: number): ConversationEntry | undefined => thread[index];
+test("a run's end reaches the thread once, at the moment it settled, and is then marked rather than re-read", async () => {
+  const written = thread();
+  const marked: string[] = [];
+  const agent = markingBrain(marked);
   const running = record({ status: BRAIN_REQUEST_STATUS.RUNNING, revision: 1, text: undefined });
-  recordEndedRuns([running], recordInThread);
-  assert.deepEqual(thread, []);
+  await recordEndedRuns(agent, [running], written.record);
+  assert.equal(written.recorded.length, 0);
   const ended = record();
-  recordEndedRuns([ended], recordInThread);
-  recordEndedRuns([ended], recordInThread);
-  recordEndedRuns([{ ...ended, revision: 4 }], recordInThread);
-  assert.equal(thread.length, 1);
-  assert.equal(line(0)?.kind, CONVERSATION_ENTRY_KIND.REPLY);
-  assert.equal(line(0)?.words, "Two agents are waiting.");
-  assert.equal(line(0)?.requestId, "run-1");
-  // A second run's end is its own line.
-  recordEndedRuns(
-    [ended, record({ runId: "run-2", status: BRAIN_REQUEST_STATUS.CANCELLED, text: undefined })],
-    recordInThread,
+  await recordEndedRuns(agent, [ended], written.record);
+  assert.equal(written.recorded.length, 1);
+  const [firstWrite] = written.recorded;
+  assert.equal(firstWrite?.at, NOW + 2);
+  assert.equal(written.entries()[0]?.recordedAt, NOW + 2);
+  assert.deepEqual(marked, ["run-1"]);
+  // Once marked, the record itself says so: an unrelated later report, a
+  // rebuilt follower, or a thread that has since let the line go all leave
+  // it alone.
+  const published = { ...ended, historyRecordedAt: NOW + 2 };
+  await recordEndedRuns(agent, [published], written.record);
+  await recordEndedRuns(
+    agent,
+    [
+      published,
+      record({ runId: "run-2", status: BRAIN_REQUEST_STATUS.CANCELLED, text: undefined }),
+    ],
+    written.record,
   );
-  assert.equal(thread.length, 2);
-  assert.equal(line(1)?.words, "Cancelled.");
+  assert.equal(written.recorded.length, 2);
+  const [, secondWrite] = written.recorded;
+  assert.equal(secondWrite?.entry.words, "Cancelled.");
+  assert.deepEqual(marked, ["run-1", "run-2"]);
+});
+
+test("a run whose line the thread refused stays unmarked and is written on the next report", async () => {
+  let refuse = true;
+  const written = thread(() => refuse);
+  const marked: string[] = [];
+  const agent = markingBrain(marked);
+  await recordEndedRuns(agent, [record()], written.record);
+  assert.deepEqual(marked, []);
+  assert.equal(written.recorded.length, 0);
+  refuse = false;
+  await recordEndedRuns(agent, [record()], written.record);
+  assert.deepEqual(marked, ["run-1"]);
+  assert.equal(written.recorded.length, 1);
 });
 
 test("an end without a reply is worded from what was done, never from a provider's words", () => {
@@ -144,15 +198,40 @@ test("an end without a reply is worded from what was done, never from a provider
     brainReplyWords(
       record({ status: BRAIN_REQUEST_STATUS.INTERRUPTED, text: undefined, performedActs: 1 }),
     ),
-    "That ask was interrupted after one thing you asked had gone through.",
+    "That ask was interrupted, though I did one thing you asked.",
   );
   assert.equal(brainReplyWords(record({ status: BRAIN_REQUEST_STATUS.QUEUED })), undefined);
+  // An act nobody confirmed is said as such, never as refused and never as done.
+  assert.equal(
+    brainReplyWords(
+      record({
+        status: BRAIN_REQUEST_STATUS.FAILED,
+        failure: "model",
+        text: undefined,
+        unknownActs: 1,
+      }),
+    ),
+    "one act may have gone through without confirming, so I won't repeat it on my own, but I couldn't put the reply into words.",
+  );
+  assert.equal(
+    brainReplyWords(
+      record({ status: BRAIN_REQUEST_STATUS.SUCCEEDED, unknownActs: 2, text: "Sent." }),
+    ),
+    "Sent. 2 acts may have gone through without confirming, so I won't repeat them on my own.",
+  );
+  assert.equal(
+    brainReplyWords(
+      record({ status: BRAIN_REQUEST_STATUS.FAILED, failure: "incomplete", text: undefined }),
+    ),
+    "I ran out of room before finishing that. Ask me again, perhaps in smaller pieces.",
+  );
 });
 
-test("following a brain relays every report and writes the ended runs, and stops when unfollowed", async () => {
+test("following a brain relays every report, writes and marks the ended runs, and stops when unfollowed", async () => {
   let listener: ((records: readonly BrainRequestRecord[]) => void) | undefined;
+  const marked: string[] = [];
   const ready = record({ status: BRAIN_REQUEST_STATUS.INTERRUPTED, text: undefined });
-  // SAFETY: the follower reads only these three members off the agent.
+  // SAFETY: the follower reads only these four members off the agent.
   const agent = {
     subscribe: (next: (records: readonly BrainRequestRecord[]) => void) => {
       listener = next;
@@ -162,22 +241,56 @@ test("following a brain relays every report and writes the ended runs, and stops
     },
     ready: () => Promise.resolve(),
     requests: () => [ready],
+    markHistoryRecorded: async (runId: string) => {
+      marked.push(runId);
+    },
   } as unknown as BrainAgent;
   const broadcasts: (readonly BrainRequestRecord[])[] = [];
-  let thread: readonly ConversationEntry[] = [];
+  const written = thread();
   const unfollow = followBrainRequests(agent, {
-    recordConversationEntry: (entry) => {
-      thread = appendConversationThreadEntry(thread, entry, NOW);
-    },
+    recordConversationEntry: written.record,
     broadcastRequests: (snapshots) => broadcasts.push(snapshots),
   });
   await new Promise((resolve) => setImmediate(resolve));
+  await new Promise((resolve) => setImmediate(resolve));
   // The launch's interrupted run is written and relayed once it is read.
   assert.equal(broadcasts.length, 1);
-  assert.equal(thread[0]?.words, "That ask was interrupted before I could finish it.");
-  listener?.([ready, record({ runId: "run-2" })]);
+  assert.equal(written.entries()[0]?.words, "That ask was interrupted before I could finish it.");
+  assert.deepEqual(marked, ["run-1"]);
+  listener?.([{ ...ready, historyRecordedAt: NOW + 2 }, record({ runId: "run-2" })]);
+  await new Promise((resolve) => setImmediate(resolve));
   assert.equal(broadcasts.length, 2);
-  assert.equal(thread.length, 2);
+  assert.equal(written.entries().length, 2);
   unfollow();
   assert.equal(listener, undefined);
+});
+
+test("a retired follower relays nothing a late report carries", async () => {
+  let listener: ((records: readonly BrainRequestRecord[]) => void) | undefined;
+  let releaseReady: (() => void) | undefined;
+  // SAFETY: the follower reads only these four members off the agent.
+  const agent = {
+    subscribe: (next: (records: readonly BrainRequestRecord[]) => void) => {
+      listener = next;
+      return () => undefined;
+    },
+    ready: () =>
+      new Promise<void>((resolve) => {
+        releaseReady = resolve;
+      }),
+    requests: () => [record()],
+    markHistoryRecorded: async () => undefined,
+  } as unknown as BrainAgent;
+  const broadcasts: (readonly BrainRequestRecord[])[] = [];
+  const written = thread();
+  const unfollow = followBrainRequests(agent, {
+    recordConversationEntry: written.record,
+    broadcastRequests: (snapshots) => broadcasts.push(snapshots),
+  });
+  unfollow();
+  releaseReady?.();
+  listener?.([record()]);
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.deepEqual(broadcasts, []);
+  assert.deepEqual(written.recorded, []);
 });

--- a/apps/desktop/src/main/ipc/brain.test.ts
+++ b/apps/desktop/src/main/ipc/brain.test.ts
@@ -1,45 +1,183 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import type { BrainAgent } from "@sidecar/brain";
-import { maximumTypedAskLength } from "@sidecar/realtime";
-import { ACT_RESULT_STATUS } from "@sidecar/wire";
-import { askBrain, BRAIN_ASK_REFUSAL } from "./brain";
+import type { BrainAgent, BrainRequestRecord, BrainSubmission } from "@sidecar/brain";
+import { BRAIN_REQUEST_ORIGIN, BRAIN_REQUEST_STATUS } from "@sidecar/brain/requests";
+import {
+  appendConversationThreadEntry,
+  CONVERSATION_ENTRY_KIND,
+  type ConversationEntry,
+  maximumTypedAskLength,
+} from "@sidecar/realtime";
+import { BRAIN_ASK_REFUSAL, brainReplyWords } from "#shared/wire/brain";
+import { followBrainRequests, recordEndedRuns, submitBrainAsk } from "./brain";
 
-function brainAnswering(answer: { text: string } | undefined, asked: string[]): BrainAgent {
-  // SAFETY: the ask path reads only `ask` off the agent; the fixture stands in for the rest.
+const NOW = 1_800_000_000_000;
+
+function record(overrides: Partial<BrainRequestRecord> = {}): BrainRequestRecord {
   return {
-    ask: async (question: string) => {
-      asked.push(question);
-      return answer ? { text: answer.text } : undefined;
+    runId: "run-1",
+    submissionId: "sub-1",
+    origin: BRAIN_REQUEST_ORIGIN.TYPED,
+    question: "what needs me?",
+    status: BRAIN_REQUEST_STATUS.SUCCEEDED,
+    revision: 3,
+    acceptedAt: NOW,
+    startedAt: NOW + 1,
+    settledAt: NOW + 2,
+    text: "Two agents are waiting.",
+    performedActs: 0,
+    ...overrides,
+  };
+}
+
+/** A brain that accepts every submission into one run and remembers what it was asked. */
+function acceptingBrain(asked: BrainSubmission[]): BrainAgent {
+  // SAFETY: the ask path reads only `submitAsk` off the agent; the fixture stands in for the rest.
+  return {
+    submitAsk: async (submission: BrainSubmission) => {
+      asked.push(submission);
+      return { outcome: "accepted", runId: "run-1", acceptedAt: NOW };
     },
   } as unknown as BrainAgent;
 }
 
-test("an ask with no brain, no words, or no answer in time is refused in fixed words", async () => {
-  const asked: string[] = [];
-  assert.deepEqual(await askBrain(undefined, "what needs me?"), {
-    status: ACT_RESULT_STATUS.REJECTED,
-    reason: BRAIN_ASK_REFUSAL.ABSENT,
-  });
-  assert.deepEqual(await askBrain(brainAnswering({ text: "x" }, asked), "   "), {
-    status: ACT_RESULT_STATUS.REJECTED,
-    reason: BRAIN_ASK_REFUSAL.EMPTY,
-  });
-  assert.deepEqual(await askBrain(brainAnswering(undefined, asked), "what needs me?"), {
-    status: ACT_RESULT_STATUS.REJECTED,
-    reason: BRAIN_ASK_REFUSAL.TIMED_OUT,
-  });
-  assert.deepEqual(asked, ["what needs me?"]);
+test("an ask with no brain is refused in fixed words, and nothing is recorded", async () => {
+  const recorded: ConversationEntry[] = [];
+  const result = await submitBrainAsk(
+    undefined,
+    { submissionId: "sub-1", question: "what needs me?", origin: BRAIN_REQUEST_ORIGIN.TYPED },
+    (entry) => recorded.push(entry),
+  );
+  assert.deepEqual(result, { outcome: "rejected", reason: "absent" });
+  assert.equal(BRAIN_ASK_REFUSAL.absent.includes("OpenAI key"), true);
+  assert.deepEqual(recorded, []);
 });
 
-test("an answered ask is bounded like a typed one and carries the reply whole", async () => {
-  const asked: string[] = [];
-  const long = "a".repeat(maximumTypedAskLength + 50);
-  const answer = await askBrain(brainAnswering({ text: "Two agents are waiting." }, asked), long);
+test("a typed ask is bounded, handed to the brain whole, and recorded under its run", async () => {
+  const asked: BrainSubmission[] = [];
+  const recorded: ConversationEntry[] = [];
+  const long = `  ${"a".repeat(maximumTypedAskLength + 50)}`;
+  const result = await submitBrainAsk(
+    acceptingBrain(asked),
+    { submissionId: "sub-1", question: long, origin: BRAIN_REQUEST_ORIGIN.TYPED },
+    (entry) => recorded.push(entry),
+  );
+  assert.deepEqual(result, { outcome: "accepted", runId: "run-1", acceptedAt: NOW });
+  assert.equal(asked[0]?.question.length, maximumTypedAskLength);
+  assert.equal(asked[0]?.submissionId, "sub-1");
+  assert.deepEqual(recorded, [
+    {
+      kind: CONVERSATION_ENTRY_KIND.TYPED_ASK,
+      words: "a".repeat(maximumTypedAskLength),
+      requestId: "run-1",
+    },
+  ]);
+});
 
-  assert.equal(asked[0]?.length, maximumTypedAskLength);
-  assert.deepEqual(answer, {
-    status: ACT_RESULT_STATUS.ACCEPTED,
-    briefing: "Two agents are waiting.",
+test("a spoken ask records nothing here: the voice service's transcript is its line", async () => {
+  const asked: BrainSubmission[] = [];
+  const recorded: ConversationEntry[] = [];
+  await submitBrainAsk(
+    acceptingBrain(asked),
+    { submissionId: "call-1", question: "send it", origin: BRAIN_REQUEST_ORIGIN.SPOKEN },
+    (entry) => recorded.push(entry),
+  );
+  assert.equal(asked[0]?.origin, BRAIN_REQUEST_ORIGIN.SPOKEN);
+  assert.deepEqual(recorded, []);
+});
+
+test("a run's end reaches the thread exactly once, worded by the build, however often it is reported", () => {
+  let thread: readonly ConversationEntry[] = [];
+  const recordInThread = (entry: ConversationEntry) => {
+    thread = appendConversationThreadEntry(thread, entry, NOW);
+  };
+  const line = (index: number): ConversationEntry | undefined => thread[index];
+  const running = record({ status: BRAIN_REQUEST_STATUS.RUNNING, revision: 1, text: undefined });
+  recordEndedRuns([running], recordInThread);
+  assert.deepEqual(thread, []);
+  const ended = record();
+  recordEndedRuns([ended], recordInThread);
+  recordEndedRuns([ended], recordInThread);
+  recordEndedRuns([{ ...ended, revision: 4 }], recordInThread);
+  assert.equal(thread.length, 1);
+  assert.equal(line(0)?.kind, CONVERSATION_ENTRY_KIND.REPLY);
+  assert.equal(line(0)?.words, "Two agents are waiting.");
+  assert.equal(line(0)?.requestId, "run-1");
+  // A second run's end is its own line.
+  recordEndedRuns(
+    [ended, record({ runId: "run-2", status: BRAIN_REQUEST_STATUS.CANCELLED, text: undefined })],
+    recordInThread,
+  );
+  assert.equal(thread.length, 2);
+  assert.equal(line(1)?.words, "Cancelled.");
+});
+
+test("an end without a reply is worded from what was done, never from a provider's words", () => {
+  const acted = { performedActs: 2, text: undefined };
+  assert.equal(
+    brainReplyWords(record({ status: BRAIN_REQUEST_STATUS.FAILED, failure: "model", ...acted })),
+    "I did 2 things you asked, but I couldn't put the reply into words.",
+  );
+  assert.equal(
+    brainReplyWords(
+      record({ status: BRAIN_REQUEST_STATUS.FAILED, failure: "model", text: undefined }),
+    ),
+    "I couldn't work that one out. Ask me again in a moment.",
+  );
+  assert.equal(
+    brainReplyWords(
+      record({ status: BRAIN_REQUEST_STATUS.FAILED, failure: "persistence", performedActs: 1 }),
+    ),
+    "Two agents are waiting. I did one thing you asked, but I couldn't save my notes about it.",
+  );
+  assert.equal(
+    brainReplyWords(
+      record({ status: BRAIN_REQUEST_STATUS.SUCCEEDED, text: undefined, performedActs: 1 }),
+    ),
+    "Done: I did one thing you asked.",
+  );
+  assert.equal(
+    brainReplyWords(record({ status: BRAIN_REQUEST_STATUS.TIMED_OUT, text: undefined })),
+    "That ask ran out of time.",
+  );
+  assert.equal(
+    brainReplyWords(
+      record({ status: BRAIN_REQUEST_STATUS.INTERRUPTED, text: undefined, performedActs: 1 }),
+    ),
+    "That ask was interrupted after one thing you asked had gone through.",
+  );
+  assert.equal(brainReplyWords(record({ status: BRAIN_REQUEST_STATUS.QUEUED })), undefined);
+});
+
+test("following a brain relays every report and writes the ended runs, and stops when unfollowed", async () => {
+  let listener: ((records: readonly BrainRequestRecord[]) => void) | undefined;
+  const ready = record({ status: BRAIN_REQUEST_STATUS.INTERRUPTED, text: undefined });
+  // SAFETY: the follower reads only these three members off the agent.
+  const agent = {
+    subscribe: (next: (records: readonly BrainRequestRecord[]) => void) => {
+      listener = next;
+      return () => {
+        listener = undefined;
+      };
+    },
+    ready: () => Promise.resolve(),
+    requests: () => [ready],
+  } as unknown as BrainAgent;
+  const broadcasts: (readonly BrainRequestRecord[])[] = [];
+  let thread: readonly ConversationEntry[] = [];
+  const unfollow = followBrainRequests(agent, {
+    recordConversationEntry: (entry) => {
+      thread = appendConversationThreadEntry(thread, entry, NOW);
+    },
+    broadcastRequests: (snapshots) => broadcasts.push(snapshots),
   });
+  await new Promise((resolve) => setImmediate(resolve));
+  // The launch's interrupted run is written and relayed once it is read.
+  assert.equal(broadcasts.length, 1);
+  assert.equal(thread[0]?.words, "That ask was interrupted before I could finish it.");
+  listener?.([ready, record({ runId: "run-2" })]);
+  assert.equal(broadcasts.length, 2);
+  assert.equal(thread.length, 2);
+  unfollow();
+  assert.equal(listener, undefined);
 });

--- a/apps/desktop/src/main/ipc/brain.ts
+++ b/apps/desktop/src/main/ipc/brain.ts
@@ -148,17 +148,20 @@ export async function publishRuns(
  * as it arrives, its records relayed to every window and its runs written to
  * the thread. The subscription is the completion channel PR 7's delivery
  * reads; the thread write here is the one History write for a run.
- * Unfollowing retires the subscription and any report still on its way, so a
- * replaced agent's late records reach neither the thread nor the windows.
+ * Unfollowing retires the subscription, drains the publication of the reports
+ * already taken, and then relays nothing more, so a replaced agent's records
+ * are all written once and its late ones reach neither the thread nor the
+ * windows.
  */
 export function followBrainRequests(
   agent: BrainAgent,
   dependencies: Pick<BrainIpcDependencies, "recordConversationEntry" | "broadcastRequests">,
-): () => void {
+): () => Promise<void> {
+  let accepting = true;
   let following = true;
   let publishing: Promise<void> = Promise.resolve();
   const listener = (records: readonly BrainRequestRecord[]) => {
-    if (!following) return;
+    if (!accepting) return;
     dependencies.broadcastRequests(records);
     // Reports are published one at a time, each against the records as they
     // then stand, so two reports of the same end cannot both find it unmarked.
@@ -168,9 +171,16 @@ export function followBrainRequests(
   };
   const unsubscribe = agent.subscribe(listener);
   void agent.ready().then(() => listener(agent.requests()));
-  return () => {
-    following = false;
+  // Unfollowing takes no more reports at once, but lets the ones already
+  // taken finish: the stop that retires an agent reports every run it
+  // interrupted, and those ends belong in the thread before the follower
+  // goes. Each write answers promptly — the store refuses rather than hangs —
+  // so the drain is bounded by the reports already queued.
+  return async () => {
+    accepting = false;
     unsubscribe();
+    await publishing;
+    following = false;
   };
 }
 

--- a/apps/desktop/src/main/ipc/brain.ts
+++ b/apps/desktop/src/main/ipc/brain.ts
@@ -54,16 +54,23 @@ const REJECTED_SUBMISSION: BrainAskSubmissionResult = {
   reason: BRAIN_SUBMISSION_REJECTION.ABSENT,
 };
 
+/** The part of the agent publication reads and marks: the live record, and the two marks. */
+export type BrainPublicationAgent = Pick<
+  BrainAgent,
+  "request" | "markHistoryRecorded" | "markAskRecorded"
+>;
+
 /**
  * Submits one ask to the brain. The words are bounded like a typed one, the
  * origin is checked against the window that sent it — a panel types, the voice
  * window speaks, and neither may claim the other — and the brain's own answer
- * is what comes back. A typed ask the brain accepted enters the thread here,
- * in the words the accepted record holds and at the moment it was accepted,
- * because the panel that typed it holds no thread of its own; a retry that
- * found an earlier run records nothing the thread does not already hold. A
- * spoken ask's words are the voice service's transcript, recorded by the
- * voice window where they were heard, so nothing is recorded for one here.
+ * is what comes back. A typed ask the brain accepted is written into the
+ * thread here, in the words the accepted record holds and at the moment it
+ * was accepted, because the panel that typed it holds no thread of its own;
+ * a write the thread refused leaves the run unmarked, and the follower's next
+ * report writes it. The acceptance itself stands whatever the thread did. A
+ * spoken ask's words are the voice service's transcript, recorded by the voice
+ * window where they were heard, so nothing is recorded for one here.
  */
 export async function submitBrainAsk(
   brain: BrainAgent | undefined,
@@ -73,50 +80,74 @@ export async function submitBrainAsk(
   if (!brain) return REJECTED_SUBMISSION;
   const question = submission.question.trim().slice(0, maximumTypedAskLength);
   const result = await brain.submitAsk({ ...submission, question });
-  if (
-    result.outcome === BRAIN_SUBMISSION_OUTCOME.ACCEPTED &&
-    submission.origin === BRAIN_REQUEST_ORIGIN.TYPED
-  ) {
-    const accepted = brain.request(result.runId);
-    if (accepted) {
-      record(typedAskConversationEntry(accepted.question, accepted.runId), accepted.acceptedAt);
-    }
+  if (result.outcome === BRAIN_SUBMISSION_OUTCOME.ACCEPTED) {
+    await publishAsk(brain, result.runId, record);
   }
   return result;
 }
 
-/**
- * The one place a run's end reaches the thread. Every record the brain
- * reports is read for runs that have ended and whose end the thread has not
- * yet taken — the record itself says so, in `historyRecordedAt`, which the
- * brain keeps across reports, rebuilt followers, and launches — and each
- * gets its reply line once, at the moment the run settled, worded from the
- * record by the build. Only a write the thread confirmed marks the run; a
- * write that failed leaves it for the next report to try again. A run the
- * thread has since let go of is not written back: the mark, not the
- * thread's contents, is what says a run was published.
- */
-export async function recordEndedRuns(
-  agent: Pick<BrainAgent, "markHistoryRecorded">,
-  snapshots: readonly BrainRequestSnapshot[],
+/** Writes a typed ask's own line once, at its acceptance, and marks the run when the thread took it. */
+async function publishAsk(
+  agent: BrainPublicationAgent,
+  runId: string,
   record: BrainIpcDependencies["recordConversationEntry"],
 ): Promise<void> {
+  const current = agent.request(runId);
+  if (!current || current.origin !== BRAIN_REQUEST_ORIGIN.TYPED) return;
+  if (current.askRecordedAt !== undefined) return;
+  if (!record(typedAskConversationEntry(current.question, current.runId), current.acceptedAt)) {
+    return;
+  }
+  await agent.markAskRecorded(runId, current.acceptedAt);
+}
+
+/** Writes a run's end once, at the moment it settled, and marks the run when the thread took it. */
+async function publishEnd(
+  agent: BrainPublicationAgent,
+  runId: string,
+  record: BrainIpcDependencies["recordConversationEntry"],
+): Promise<void> {
+  const current = agent.request(runId);
+  if (!current || !isTerminalBrainRequestStatus(current.status)) return;
+  if (current.historyRecordedAt !== undefined) return;
+  const words = brainReplyWords(current);
+  if (!words) return;
+  const at = current.settledAt ?? current.acceptedAt;
+  if (!record(replyConversationEntry(words, current.runId), at)) return;
+  await agent.markHistoryRecorded(runId, at);
+}
+
+/**
+ * The one place a run reaches the thread. Every record the brain reports is
+ * read for what the thread has not yet taken — its typed ask, its end — and
+ * the record itself says which, in marks the brain keeps across reports,
+ * rebuilt followers, and launches. Each write is decided against the record
+ * as it stands at that moment, never against the report that prompted it, so
+ * an older report cannot write what a newer one already marked, and a
+ * follower retired mid-way writes nothing more. Only a write the thread
+ * confirmed marks the run; a write that failed leaves it for the next report.
+ * The mark, not the thread's contents, is what says a run was published, so
+ * a line the thread has since let go of is never written back.
+ */
+export async function publishRuns(
+  agent: BrainPublicationAgent,
+  snapshots: readonly BrainRequestSnapshot[],
+  record: BrainIpcDependencies["recordConversationEntry"],
+  stillFollowing: () => boolean = () => true,
+): Promise<void> {
   for (const snapshot of snapshots) {
-    if (!isTerminalBrainRequestStatus(snapshot.status)) continue;
-    if (snapshot.historyRecordedAt !== undefined) continue;
-    const words = brainReplyWords(snapshot);
-    if (!words) continue;
-    const at = snapshot.settledAt ?? snapshot.acceptedAt;
-    if (!record(replyConversationEntry(words, snapshot.runId), at)) continue;
-    await agent.markHistoryRecorded(snapshot.runId, at);
+    if (!stillFollowing()) return;
+    await publishAsk(agent, snapshot.runId, record);
+    if (!stillFollowing()) return;
+    await publishEnd(agent, snapshot.runId, record);
   }
 }
 
 /**
  * Follows the brain that currently stands: each rebuilt agent is subscribed
- * as it arrives, its records relayed to every window and its ended runs
- * written to the thread. The subscription is the completion channel PR 7's
- * delivery reads; the thread write here is the one terminal History write.
+ * as it arrives, its records relayed to every window and its runs written to
+ * the thread. The subscription is the completion channel PR 7's delivery
+ * reads; the thread write here is the one History write for a run.
  * Unfollowing retires the subscription and any report still on its way, so a
  * replaced agent's late records reach neither the thread nor the windows.
  */
@@ -129,10 +160,10 @@ export function followBrainRequests(
   const listener = (records: readonly BrainRequestRecord[]) => {
     if (!following) return;
     dependencies.broadcastRequests(records);
-    // Ends are written one report at a time, so two reports of the same end
-    // cannot both find it unmarked.
+    // Reports are published one at a time, each against the records as they
+    // then stand, so two reports of the same end cannot both find it unmarked.
     publishing = publishing.then(() =>
-      following ? recordEndedRuns(agent, records, dependencies.recordConversationEntry) : undefined,
+      publishRuns(agent, records, dependencies.recordConversationEntry, () => following),
     );
   };
   const unsubscribe = agent.subscribe(listener);

--- a/apps/desktop/src/main/ipc/brain.ts
+++ b/apps/desktop/src/main/ipc/brain.ts
@@ -36,8 +36,13 @@ export interface BrainIpcDependencies {
   /** The brain as it stands now, or nothing on a run with no key to run it on. */
   brain: () => BrainAgent | undefined;
   submitters: BrainSubmitters;
-  /** Records one line in the shared thread; the main process is the thread's store. */
-  recordConversationEntry: (entry: ConversationEntry) => void;
+  /**
+   * Records one line in the shared thread at the moment given, answering
+   * whether the thread took it; the main process is the thread's store. A
+   * line the thread already holds for that run answers true, because holding
+   * it is the whole of what was asked.
+   */
+  recordConversationEntry: (entry: ConversationEntry, recordedAt: number) => boolean;
   /** Hands the whole list of records to every window. */
   broadcastRequests: (snapshots: readonly BrainRequestSnapshot[]) => void;
   /** How long one wait holds before answering the run still pending. */
@@ -54,14 +59,16 @@ const REJECTED_SUBMISSION: BrainAskSubmissionResult = {
  * origin is checked against the window that sent it — a panel types, the voice
  * window speaks, and neither may claim the other — and the brain's own answer
  * is what comes back. A typed ask the brain accepted enters the thread here,
- * under its run's id, because the panel that typed it holds no thread of its
- * own; a spoken ask's words are the voice service's transcript, recorded by
- * the voice window where they were heard, so nothing is recorded for one here.
+ * in the words the accepted record holds and at the moment it was accepted,
+ * because the panel that typed it holds no thread of its own; a retry that
+ * found an earlier run records nothing the thread does not already hold. A
+ * spoken ask's words are the voice service's transcript, recorded by the
+ * voice window where they were heard, so nothing is recorded for one here.
  */
 export async function submitBrainAsk(
   brain: BrainAgent | undefined,
   submission: BrainAskSubmission,
-  record: (entry: ConversationEntry) => void,
+  record: BrainIpcDependencies["recordConversationEntry"],
 ): Promise<BrainAskSubmissionResult> {
   if (!brain) return REJECTED_SUBMISSION;
   const question = submission.question.trim().slice(0, maximumTypedAskLength);
@@ -70,28 +77,38 @@ export async function submitBrainAsk(
     result.outcome === BRAIN_SUBMISSION_OUTCOME.ACCEPTED &&
     submission.origin === BRAIN_REQUEST_ORIGIN.TYPED
   ) {
-    record(typedAskConversationEntry(question, result.runId));
+    const accepted = brain.request(result.runId);
+    if (accepted) {
+      record(typedAskConversationEntry(accepted.question, accepted.runId), accepted.acceptedAt);
+    }
   }
   return result;
 }
 
 /**
  * The one place a run's end reaches the thread. Every record the brain
- * reports is read for the runs that have ended since the last report, and
- * each gets its reply line exactly once, worded from the record by the
- * build; the thread's own request correlation refuses a second line for the
- * same run, so a report heard twice — or a launch that finds the last one's
- * interrupted runs — adds nothing it already holds. The renderer that speaks
- * the words records none of its own for a run.
+ * reports is read for runs that have ended and whose end the thread has not
+ * yet taken — the record itself says so, in `historyRecordedAt`, which the
+ * brain keeps across reports, rebuilt followers, and launches — and each
+ * gets its reply line once, at the moment the run settled, worded from the
+ * record by the build. Only a write the thread confirmed marks the run; a
+ * write that failed leaves it for the next report to try again. A run the
+ * thread has since let go of is not written back: the mark, not the
+ * thread's contents, is what says a run was published.
  */
-export function recordEndedRuns(
+export async function recordEndedRuns(
+  agent: Pick<BrainAgent, "markHistoryRecorded">,
   snapshots: readonly BrainRequestSnapshot[],
-  record: (entry: ConversationEntry) => void,
-): void {
+  record: BrainIpcDependencies["recordConversationEntry"],
+): Promise<void> {
   for (const snapshot of snapshots) {
     if (!isTerminalBrainRequestStatus(snapshot.status)) continue;
+    if (snapshot.historyRecordedAt !== undefined) continue;
     const words = brainReplyWords(snapshot);
-    if (words) record(replyConversationEntry(words, snapshot.runId));
+    if (!words) continue;
+    const at = snapshot.settledAt ?? snapshot.acceptedAt;
+    if (!record(replyConversationEntry(words, snapshot.runId), at)) continue;
+    await agent.markHistoryRecorded(snapshot.runId, at);
   }
 }
 
@@ -100,18 +117,30 @@ export function recordEndedRuns(
  * as it arrives, its records relayed to every window and its ended runs
  * written to the thread. The subscription is the completion channel PR 7's
  * delivery reads; the thread write here is the one terminal History write.
+ * Unfollowing retires the subscription and any report still on its way, so a
+ * replaced agent's late records reach neither the thread nor the windows.
  */
 export function followBrainRequests(
   agent: BrainAgent,
   dependencies: Pick<BrainIpcDependencies, "recordConversationEntry" | "broadcastRequests">,
 ): () => void {
+  let following = true;
+  let publishing: Promise<void> = Promise.resolve();
   const listener = (records: readonly BrainRequestRecord[]) => {
-    recordEndedRuns(records, dependencies.recordConversationEntry);
+    if (!following) return;
     dependencies.broadcastRequests(records);
+    // Ends are written one report at a time, so two reports of the same end
+    // cannot both find it unmarked.
+    publishing = publishing.then(() =>
+      following ? recordEndedRuns(agent, records, dependencies.recordConversationEntry) : undefined,
+    );
   };
   const unsubscribe = agent.subscribe(listener);
   void agent.ready().then(() => listener(agent.requests()));
-  return unsubscribe;
+  return () => {
+    following = false;
+    unsubscribe();
+  };
 }
 
 export function registerBrainIpc(dependencies: BrainIpcDependencies): void {

--- a/apps/desktop/src/main/ipc/brain.ts
+++ b/apps/desktop/src/main/ipc/brain.ts
@@ -1,57 +1,137 @@
-import type { BrainAgent } from "@sidecar/brain";
-import { maximumTypedAskLength } from "@sidecar/realtime";
-import { ACT_RESULT_STATUS } from "@sidecar/wire";
-import type { IpcMain, IpcMainEvent, IpcMainInvokeEvent } from "electron";
+import type { BrainAgent, BrainRequestRecord } from "@sidecar/brain";
+import { BRAIN_DEFAULTS } from "@sidecar/brain";
+import {
+  BRAIN_REQUEST_ORIGIN,
+  BRAIN_SUBMISSION_OUTCOME,
+  BRAIN_SUBMISSION_REJECTION,
+  isTerminalBrainRequestStatus,
+} from "@sidecar/brain/requests";
+import {
+  type ConversationEntry,
+  maximumTypedAskLength,
+  replyConversationEntry,
+  typedAskConversationEntry,
+} from "@sidecar/realtime";
+import type { IpcMain, IpcMainEvent, IpcMainInvokeEvent, WebContents } from "electron";
 import { BRIDGE } from "#shared/bridge";
-import type { BrainAskResult } from "#shared/contracts";
-import { registerBridgeEntry } from "../register-bridge";
+import {
+  type BrainAskSubmission,
+  type BrainAskSubmissionResult,
+  type BrainRequestSnapshot,
+  brainReplyWords,
+} from "#shared/wire/brain";
+import { registerBridge } from "../register-bridge";
+
+/** The two kinds of window that may submit, and which origin each may claim. */
+export interface BrainSubmitters {
+  /** Whether this sender is a panel — the composer's window, which submits typed asks. */
+  panel(sender: WebContents): boolean;
+  /** Whether this sender is the hidden voice window, which relays spoken asks. */
+  voice(sender: WebContents): boolean;
+}
 
 export interface BrainIpcDependencies {
   ipcMain: Pick<IpcMain, "handle" | "on">;
   trustedSender: (event: IpcMainEvent | IpcMainInvokeEvent) => boolean;
   /** The brain as it stands now, or nothing on a run with no key to run it on. */
   brain: () => BrainAgent | undefined;
+  submitters: BrainSubmitters;
+  /** Records one line in the shared thread; the main process is the thread's store. */
+  recordConversationEntry: (entry: ConversationEntry) => void;
+  /** Hands the whole list of records to every window. */
+  broadcastRequests: (snapshots: readonly BrainRequestSnapshot[]) => void;
+  /** How long one wait holds before answering the run still pending. */
+  askWaitMs?: number;
+}
+
+const REJECTED_SUBMISSION: BrainAskSubmissionResult = {
+  outcome: BRAIN_SUBMISSION_OUTCOME.REJECTED,
+  reason: BRAIN_SUBMISSION_REJECTION.ABSENT,
+};
+
+/**
+ * Submits one ask to the brain. The words are bounded like a typed one, the
+ * origin is checked against the window that sent it — a panel types, the voice
+ * window speaks, and neither may claim the other — and the brain's own answer
+ * is what comes back. A typed ask the brain accepted enters the thread here,
+ * under its run's id, because the panel that typed it holds no thread of its
+ * own; a spoken ask's words are the voice service's transcript, recorded by
+ * the voice window where they were heard, so nothing is recorded for one here.
+ */
+export async function submitBrainAsk(
+  brain: BrainAgent | undefined,
+  submission: BrainAskSubmission,
+  record: (entry: ConversationEntry) => void,
+): Promise<BrainAskSubmissionResult> {
+  if (!brain) return REJECTED_SUBMISSION;
+  const question = submission.question.trim().slice(0, maximumTypedAskLength);
+  const result = await brain.submitAsk({ ...submission, question });
+  if (
+    result.outcome === BRAIN_SUBMISSION_OUTCOME.ACCEPTED &&
+    submission.origin === BRAIN_REQUEST_ORIGIN.TYPED
+  ) {
+    record(typedAskConversationEntry(question, result.runId));
+  }
+  return result;
 }
 
 /**
- * What the voice says when there is no brain to ask, or the brain did not
- * answer in time. Fixed by the build and never composed with the ask, so a
- * failure can only ever be reported in these words.
+ * The one place a run's end reaches the thread. Every record the brain
+ * reports is read for the runs that have ended since the last report, and
+ * each gets its reply line exactly once, worded from the record by the
+ * build; the thread's own request correlation refuses a second line for the
+ * same run, so a report heard twice — or a launch that finds the last one's
+ * interrupted runs — adds nothing it already holds. The renderer that speaks
+ * the words records none of its own for a run.
  */
-export const BRAIN_ASK_REFUSAL = {
-  ABSENT:
-    "I can't reach my judgment right now: this build thinks only on an OpenAI key, and none is connected.",
-  EMPTY: "I didn't catch an ask in that.",
-  TIMED_OUT: "I couldn't get to that in time. Ask me again in a moment.",
-} as const;
+export function recordEndedRuns(
+  snapshots: readonly BrainRequestSnapshot[],
+  record: (entry: ConversationEntry) => void,
+): void {
+  for (const snapshot of snapshots) {
+    if (!isTerminalBrainRequestStatus(snapshot.status)) continue;
+    const words = brainReplyWords(snapshot);
+    if (words) record(replyConversationEntry(words, snapshot.runId));
+  }
+}
 
 /**
- * Answers a developer ask from the brain. Both the voice's `ask_brain` tool
- * and the ⌥L composer land here: the ask is bounded like a typed one, the
- * brain's turn runs on the main process with every act still behind its own
- * validators, and the answer is the words the voice speaks. A refusal is an
- * answer rather than a throw, because the voice has to say something.
+ * Follows the brain that currently stands: each rebuilt agent is subscribed
+ * as it arrives, its records relayed to every window and its ended runs
+ * written to the thread. The subscription is the completion channel PR 7's
+ * delivery reads; the thread write here is the one terminal History write.
  */
-export async function askBrain(
-  brain: BrainAgent | undefined,
-  question: string,
-): Promise<BrainAskResult> {
-  const bounded = question.trim().slice(0, maximumTypedAskLength);
-  if (!bounded) return { status: ACT_RESULT_STATUS.REJECTED, reason: BRAIN_ASK_REFUSAL.EMPTY };
-  if (!brain) return { status: ACT_RESULT_STATUS.REJECTED, reason: BRAIN_ASK_REFUSAL.ABSENT };
-  const answer = await brain.ask(bounded);
-  if (!answer) {
-    return { status: ACT_RESULT_STATUS.REJECTED, reason: BRAIN_ASK_REFUSAL.TIMED_OUT };
-  }
-  return { status: ACT_RESULT_STATUS.ACCEPTED, briefing: answer.text };
+export function followBrainRequests(
+  agent: BrainAgent,
+  dependencies: Pick<BrainIpcDependencies, "recordConversationEntry" | "broadcastRequests">,
+): () => void {
+  const listener = (records: readonly BrainRequestRecord[]) => {
+    recordEndedRuns(records, dependencies.recordConversationEntry);
+    dependencies.broadcastRequests(records);
+  };
+  const unsubscribe = agent.subscribe(listener);
+  void agent.ready().then(() => listener(agent.requests()));
+  return unsubscribe;
 }
 
 export function registerBrainIpc(dependencies: BrainIpcDependencies): void {
-  const { ipcMain, trustedSender, brain } = dependencies;
-  registerBridgeEntry(
+  const { ipcMain, trustedSender, brain, submitters } = dependencies;
+  const askWaitMs = dependencies.askWaitMs ?? BRAIN_DEFAULTS.ASK_WAIT_MS;
+  const originAllowed = (sender: WebContents, submission: BrainAskSubmission) =>
+    submission.origin === BRAIN_REQUEST_ORIGIN.TYPED
+      ? submitters.panel(sender)
+      : submitters.voice(sender);
+  registerBridge(
     BRIDGE,
-    BRIDGE.askBrain,
-    (_context, question: string) => askBrain(brain(), question),
+    {
+      submitBrainAsk(context, submission) {
+        if (!originAllowed(context.sender, submission)) return REJECTED_SUBMISSION;
+        return submitBrainAsk(brain(), submission, dependencies.recordConversationEntry);
+      },
+      waitBrainAsk: (_context, runId) => brain()?.waitAsk(runId, askWaitMs),
+      cancelBrainAsk: (_context, runId) => brain()?.cancelAsk(runId),
+      brainRequestSnapshots: () => brain()?.requests() ?? [],
+    },
     { ipcMain, trustedSender },
   );
 }

--- a/apps/desktop/src/main/ipc/session-acts.test.ts
+++ b/apps/desktop/src/main/ipc/session-acts.test.ts
@@ -210,6 +210,31 @@ test("a spawn whose turn ends while the stored defaults are read never reaches t
   assert.deepEqual(adapter.spawns, []);
 });
 
+test("a create whose turn is cancelled while the stored defaults are read settles at once, and the late read lands nothing", async () => {
+  const adapter = new FakeAdapter();
+  const settings = heldSettings();
+  const performer = deeperPerformer(adapter, settings.store);
+  const controller = new AbortController();
+  const pending = performer.perform(CREATE, {
+    isRevoked: () => controller.signal.aborted,
+    signal: controller.signal,
+  });
+  await settleMicrotasks();
+  assert.equal(settings.reads(), 1);
+  controller.abort();
+  // Settles without the read being released.
+  const result = await pending;
+  assert.equal(result.status, ACT_RESULT_STATUS.REJECTED);
+  settings.release();
+  await settleMicrotasks();
+  assert.deepEqual(adapter.creates, []);
+  // A row's own press carries no signal and waits the read out, as before.
+  const direct = performer.perform(CREATE, { isRevoked: () => false });
+  await settleMicrotasks();
+  settings.release();
+  assert.equal((await direct).status, ACT_RESULT_STATUS.ACCEPTED);
+});
+
 test("a create and a spawn whose turn still stands after the read land on the provider", async () => {
   const adapter = new FakeAdapter();
   const settings = heldSettings();

--- a/apps/desktop/src/main/ipc/session-acts.ts
+++ b/apps/desktop/src/main/ipc/session-acts.ts
@@ -18,6 +18,7 @@ import {
   type ProductSessionAct,
   type RecordProductEvent,
 } from "@sidecar/analytics";
+import { settledUnlessAborted } from "@sidecar/brain";
 import {
   ISSUE_ACTION_KIND,
   isIssueTrackerId,
@@ -95,8 +96,25 @@ export interface SessionActPerformerDependencies {
  * stored agent defaults read before a create or a spawn — because an act
  * whose turn ended during that read must refuse rather than start the write.
  */
+/**
+ * A read awaited before an effect, held only as long as the guard's standing:
+ * once the signal fires the wait answers nothing, and the `isRevoked` check
+ * that follows every such read refuses the act before anything is dispatched.
+ * A guard with no signal — a row's own press — waits the read out.
+ */
+async function guardedRead<T>(
+  read: Promise<T>,
+  guard: ActExecutionGuard | undefined,
+): Promise<T | undefined> {
+  if (!guard?.signal) return read;
+  const settled = await settledUnlessAborted(read, guard.signal);
+  return settled.aborted ? undefined : settled.value;
+}
+
 export interface ActExecutionGuard {
   isRevoked(): boolean;
+  /** Fires on revocation, so a read awaited before the effect settles at once rather than finishing first. */
+  readonly signal?: AbortSignal;
 }
 
 export interface SessionActsIpcDependencies {
@@ -454,7 +472,12 @@ export function createSessionActPerformer(
     // validator, the stored one when it was written — and the adapter holds
     // whichever rides to its own table again before anything reaches the network.
     const stored = isProviderId(providerId)
-      ? (await settingsStore.get(APP_SETTING_SCHEMA.workspaceAgentDefaults.field))?.[providerId]
+      ? (
+          await guardedRead(
+            settingsStore.get(APP_SETTING_SCHEMA.workspaceAgentDefaults.field),
+            guard,
+          )
+        )?.[providerId]
       : undefined;
     if (guard?.isRevoked())
       return { status: ACT_RESULT_STATUS.REJECTED, reason: REFUSAL.TURN_OVER };
@@ -581,9 +604,12 @@ export function createSessionActPerformer(
     }
     return performSessionAct(identity, PRODUCT_SESSION_ACT.AGENT_ADD, async (adapter) => {
       const stored: WorkspaceAgentSelection | undefined = isProviderId(identity.providerId)
-        ? (await settingsStore.get(APP_SETTING_SCHEMA.workspaceAgentDefaults.field))?.[
-            identity.providerId
-          ]
+        ? (
+            await guardedRead(
+              settingsStore.get(APP_SETTING_SCHEMA.workspaceAgentDefaults.field),
+              guard,
+            )
+          )?.[identity.providerId]
         : undefined;
       if (guard?.isRevoked()) {
         return { status: ACT_RESULT_STATUS.REJECTED, reason: REFUSAL.TURN_OVER };

--- a/apps/desktop/src/main/ipc/voice-runtime.ts
+++ b/apps/desktop/src/main/ipc/voice-runtime.ts
@@ -1,10 +1,8 @@
-import { randomUUID } from "node:crypto";
 import {
   PRODUCT_EVENT,
   type ProductCredentialSource,
   type RecordProductEvent,
 } from "@sidecar/analytics";
-import { BRAIN_DEFAULTS } from "@sidecar/brain";
 import { CREDENTIAL_CONNECTION, CREDENTIAL_PROVIDERS } from "@sidecar/credentials";
 import type { AgentWireTrace } from "@sidecar/devtrace/vocabulary";
 import type { RealtimeCredentialMinter } from "@sidecar/voice";
@@ -19,7 +17,6 @@ import { BRIDGE, channels } from "#shared/bridge";
 import {
   VOICE_COMMAND,
   VOICE_COMMAND_OUTCOME,
-  type VoiceCommandOutcome,
   type VoiceView,
   voiceExchangeActive,
 } from "#shared/wire/voice-view";
@@ -72,72 +69,27 @@ export interface VoiceRuntimeIpcDependencies {
   setShortcutCapturing: (capturing: boolean) => void;
 }
 
-/**
- * How long a forwarded typed ask may wait for the voice window's answer: the
- * brain's own ask deadline, which the voice window awaits before answering,
- * plus the round trips around it. Past this the panel is told refused, and
- * the draft stays the developer's to retry.
- */
-export const ASK_ANSWER_TIMEOUT_MS = BRAIN_DEFAULTS.ASK_DEADLINE_MS + 10_000;
-
 export function registerVoiceRuntimeIpc(dependencies: VoiceRuntimeIpcDependencies): void {
   const { panels, voiceWindow } = dependencies;
-  const pendingAsks = new Map<string, (outcome: VoiceCommandOutcome) => void>();
-  // The same shape `performBrainAppAct` keeps for an act the panel carries:
-  // the request travels with an id, the answer comes back under it, and a
-  // window that never answers is refused on a clock rather than holding the
-  // composer open.
-  const forwardAsk = (host: BrowserWindow, text: string): Promise<VoiceCommandOutcome> => {
-    const requestId = randomUUID();
-    return new Promise((resolve) => {
-      const timer = setTimeout(() => {
-        pendingAsks.delete(requestId);
-        resolve(VOICE_COMMAND_OUTCOME.REFUSED);
-      }, ASK_ANSWER_TIMEOUT_MS);
-      pendingAsks.set(requestId, (outcome) => {
-        clearTimeout(timer);
-        pendingAsks.delete(requestId);
-        resolve(outcome);
-      });
-      host.webContents.send(channels.onVoiceCommand, {
-        command: VOICE_COMMAND.ASK_TEXT,
-        text,
-        requestId,
-      });
-    });
-  };
   registerBridge(
     BRIDGE,
     {
-      // A panel's ask of the voice window. The bridge guard has already bounded
-      // it; here it is checked to come from a panel — the voice window does
-      // not command itself — and handed on. A typed ask is answered: with no
-      // voice window standing it is refused at once, and the composer keeps
-      // the words. A Clear is carried out here first, because the main
-      // process is the thread's store and every panel's relay, and the voice
-      // window is told to retire its own turns only once the file has gone.
-      voiceCommand(context, command, text) {
+      // A panel's command to the voice window. The bridge guard has already
+      // bounded it; here it is checked to come from a panel — the voice window
+      // does not command itself — and handed on. A Clear is carried out here
+      // first, because the main process is the thread's store and every
+      // panel's relay, and the voice window is told to retire its own turns
+      // only once the file has gone.
+      voiceCommand(context, command) {
         if (!panels.owns(context.sender)) return undefined;
         const host = voiceWindow.current();
-        if (command === VOICE_COMMAND.ASK_TEXT) {
-          if (!host || text === undefined) return VOICE_COMMAND_OUTCOME.REFUSED;
-          return forwardAsk(host, text);
-        }
         if (command === VOICE_COMMAND.CLEAR_CONVERSATION && !dependencies.clearConversation()) {
           return VOICE_COMMAND_OUTCOME.REFUSED;
         }
-        host?.webContents.send(channels.onVoiceCommand, {
-          command,
-          text: undefined,
-          requestId: undefined,
-        });
+        host?.webContents.send(channels.onVoiceCommand, { command });
         return command === VOICE_COMMAND.CLEAR_CONVERSATION
           ? VOICE_COMMAND_OUTCOME.ACCEPTED
           : undefined;
-      },
-      answerVoiceAsk(context, requestId, outcome) {
-        if (!voiceWindow.owns(context.sender)) return;
-        pendingAsks.get(requestId)?.(outcome);
       },
       // The voice window's snapshot: kept for a late panel, forwarded to every
       // panel, and read for the one level the main process owns — whether an

--- a/apps/desktop/src/main/memory-flow.test.ts
+++ b/apps/desktop/src/main/memory-flow.test.ts
@@ -2,8 +2,10 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
   CONVERSATION_ENTRY_KIND,
+  insertSpokenAskThreadEntry,
   maximumStoredConversationEntries,
   storedConversationMaximumAgeMs,
+  withConversationEntryRequest,
 } from "@sidecar/realtime";
 import {
   conversationFromStored,
@@ -113,4 +115,26 @@ test("stored memory drops noncanonical and duplicate entries", () => {
     ],
   });
   assert.deepEqual(rememberedFactsFromStored(stored), [{ id: "one", words: "kept" }]);
+});
+
+test("a spoken line tied to its run after it was relayed is enriched, not duplicated", () => {
+  const now = 1_800_000_000_000;
+  const spoken = insertSpokenAskThreadEntry([], "the exact spoken words", undefined, now);
+  const [line] = spoken;
+  assert.ok(line);
+  let main = mergeConversationHistory([], spoken, undefined, now + 1);
+  const tied = withConversationEntryRequest(spoken, line, "run-1");
+  main = mergeConversationHistory(main, tied, undefined, now + 2);
+  assert.equal(main.length, 1);
+  assert.equal(main[0]?.requestId, "run-1");
+  assert.equal(main[0]?.words, "the exact spoken words");
+  // A stale window still reporting the uncorrelated copy neither doubles the
+  // line nor takes the run back off it.
+  main = mergeConversationHistory(main, spoken, undefined, now + 3);
+  assert.equal(main.length, 1);
+  assert.equal(main[0]?.requestId, "run-1");
+  // Two utterances with the same words at different moments stay two lines.
+  const again = insertSpokenAskThreadEntry(tied, "the exact spoken words", tied[0], now + 5);
+  main = mergeConversationHistory(main, again, undefined, now + 6);
+  assert.equal(main.length, 2);
 });

--- a/apps/desktop/src/main/memory-flow.ts
+++ b/apps/desktop/src/main/memory-flow.ts
@@ -2,6 +2,7 @@ import { isRememberedFact, maximumRememberedFacts, type RememberedFact } from "@
 import {
   type ConversationEntry,
   conversationEntryKey,
+  enrichedConversationEntry,
   retainedConversationEntries,
   storedConversationEntry,
 } from "@sidecar/realtime";
@@ -56,17 +57,24 @@ export function mergeConversationHistory(
   const afterClear = (entry: ConversationEntry) =>
     clearedAt === undefined || (entry.recordedAt !== undefined && entry.recordedAt > clearedAt);
   const merged = current.filter(afterClear);
-  const currentCounts = new Map<string, number>();
-  for (const entry of merged) {
+  const currentByKey = new Map<string, number[]>();
+  merged.forEach((entry, index) => {
     const key = conversationEntryKey(entry);
-    currentCounts.set(key, (currentCounts.get(key) ?? 0) + 1);
-  }
+    currentByKey.set(key, [...(currentByKey.get(key) ?? []), index]);
+  });
   const incomingCounts = new Map<string, number>();
   for (const entry of incoming.filter(afterClear)) {
     const key = conversationEntryKey(entry);
-    const count = (incomingCounts.get(key) ?? 0) + 1;
-    incomingCounts.set(key, count);
-    if (count > (currentCounts.get(key) ?? 0)) merged.push(entry);
+    const seen = incomingCounts.get(key) ?? 0;
+    incomingCounts.set(key, seen + 1);
+    const held = currentByKey.get(key)?.[seen];
+    if (held === undefined) {
+      merged.push(entry);
+      continue;
+    }
+    // The same line again: it may now know the run it opened.
+    const current = merged[held];
+    if (current) merged[held] = enrichedConversationEntry(current, entry);
   }
   return retainedConversationEntries(
     merged.sort((left, right) => (left.recordedAt ?? now) - (right.recordedAt ?? now)),

--- a/apps/desktop/src/main/register-bridge.test.ts
+++ b/apps/desktop/src/main/register-bridge.test.ts
@@ -1,7 +1,6 @@
 /* oxlint-disable anti-slop/no-unknown-returns -- Fake Electron listeners deliberately retain the IPC boundary shape. */
 import assert from "node:assert/strict";
 import test from "node:test";
-import { ACT_RESULT_STATUS } from "@sidecar/wire";
 import type { IpcMainEvent, IpcMainInvokeEvent } from "electron";
 import { BRIDGE } from "#shared/bridge";
 import { registerBridge } from "./register-bridge";
@@ -88,26 +87,30 @@ test("a validated request reaches its domain handler", async () => {
   assert.equal(await fixture.invokes.get(BRIDGE.setExpanded.channel)?.(event, true), "expanded");
 });
 
-test("a brain ask crosses the bridge as one string and answers a bounded result", async () => {
+test("a brain ask crosses the bridge as one submission and answers the run it opened", async () => {
   const fixture = fixtureHost(true);
   registerBridge(
     BRIDGE,
     {
-      askBrain: (_context, question) => ({
-        status: ACT_RESULT_STATUS.ACCEPTED,
-        briefing: `heard: ${question}`,
+      submitBrainAsk: (_context, submission) => ({
+        outcome: "accepted",
+        runId: `run for ${submission.submissionId}`,
+        acceptedAt: 1,
       }),
     },
     fixture.host,
   );
   // SAFETY: registerBridge reads only the sender field supplied by this focused fixture.
   const event = { sender: {} } as IpcMainInvokeEvent;
-  const invoke = fixture.invokes.get(BRIDGE.askBrain.channel);
+  const invoke = fixture.invokes.get(BRIDGE.submitBrainAsk.channel);
+  assert.ok(invoke);
 
-  assert.deepEqual(await invoke?.(event, "what needs me?"), {
-    status: ACT_RESULT_STATUS.ACCEPTED,
-    briefing: "heard: what needs me?",
-  });
+  assert.deepEqual(
+    await invoke(event, { submissionId: "sub-1", question: "what needs me?", origin: "typed" }),
+    { outcome: "accepted", runId: "run for sub-1", acceptedAt: 1 },
+  );
+  // SAFETY: Electron invoke listeners always return promises; the fixture retains the erased host signature only.
+  await assert.rejects(() => invoke(event, "what needs me?") as Promise<unknown>);
 });
 
 test("an omitted optional argument cannot steal the bridge context", async () => {

--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -1980,6 +1980,8 @@ export function App(): React.JSX.Element {
     conversationHistory,
     acceptBootstrap: acceptVoiceBootstrap,
     askLuke,
+    brainRequests,
+    cancelBrainAsk,
     discardListening,
     stopSpeaking,
     requestMicrophoneAccess,
@@ -2842,6 +2844,8 @@ export function App(): React.JSX.Element {
             conversationHistory={conversationHistory}
             liveConversationEntries={liveConversationEntries}
             onClearConversationHistory={clearConversationHistory}
+            brainRequests={brainRequests}
+            onCancelBrainRequest={cancelBrainAsk}
             ask={askLuke}
             onAskEngaged={changeAskEngagement}
             {...(shownAskHotkey ? { askShortcut: shownAskHotkey } : undefined)}

--- a/apps/desktop/src/renderer/conversation-history-panel.test.ts
+++ b/apps/desktop/src/renderer/conversation-history-panel.test.ts
@@ -209,6 +209,7 @@ test("an ask whose run is still going waits beside its words and offers a cancel
     revision: 1,
     acceptedAt: 1,
     performedActs: 0,
+    unknownActs: 0,
   } as const;
   const render = (status: "running" | "succeeded") =>
     renderToStaticMarkup(
@@ -230,4 +231,16 @@ test("an ask whose run is still going waits beside its words and offers a cancel
   assert.match(pending, /ph-no-capture/);
   const settled = render("succeeded");
   assert.doesNotMatch(settled, /history-cancel|history-pending/);
+  // A spoken ask is the same lifecycle: its transcript, tied to its run, waits too.
+  const spoken = renderToStaticMarkup(
+    createElement(ConversationHistoryPanel, {
+      entries: [{ kind: CONVERSATION_ENTRY_KIND.SPOKEN_ASK, words: "ship it", requestId: "run-1" }],
+      requests: [{ ...run, origin: "spoken", status: "running" }],
+      onCancelRequest: (runId) => cancelled.push(runId),
+      onClear: () => undefined,
+      ask: async () => undefined,
+      onAskEngaged: () => undefined,
+    }),
+  );
+  assert.match(spoken, /class="history-cancel"/);
 });

--- a/apps/desktop/src/renderer/conversation-history-panel.test.ts
+++ b/apps/desktop/src/renderer/conversation-history-panel.test.ts
@@ -6,6 +6,7 @@ import { renderToStaticMarkup } from "react-dom/server";
 import {
   ConversationHistoryPanel,
   HISTORY_ENTRY_SPEAKER,
+  HISTORY_PENDING_LABEL,
   historyEntryPresentation,
 } from "./conversation-history-panel";
 
@@ -196,4 +197,37 @@ test("the composer stands at the foot of the thread, empty or not", () => {
   assert.equal(threaded.match(/id="ask-luke-input"/g)?.length, 1);
   assert.ok(threaded.indexOf("</ol>") < threaded.indexOf('id="ask-luke-input"'));
   assert.match(threaded, /aria-keyshortcuts="Alt\+Space"/);
+});
+
+test("an ask whose run is still going waits beside its words and offers a cancel", () => {
+  const cancelled: string[] = [];
+  const run = {
+    runId: "run-1",
+    submissionId: "sub-1",
+    origin: "typed",
+    question: "ship it",
+    revision: 1,
+    acceptedAt: 1,
+    performedActs: 0,
+  } as const;
+  const render = (status: "running" | "succeeded") =>
+    renderToStaticMarkup(
+      createElement(ConversationHistoryPanel, {
+        entries: [
+          { kind: CONVERSATION_ENTRY_KIND.TYPED_ASK, words: "ship it", requestId: "run-1" },
+        ],
+        requests: [{ ...run, status }],
+        onCancelRequest: (runId) => cancelled.push(runId),
+        onClear: () => undefined,
+        ask: async () => undefined,
+        onAskEngaged: () => undefined,
+      }),
+    );
+  const pending = render("running");
+  assert.match(pending, new RegExp(HISTORY_PENDING_LABEL));
+  assert.match(pending, /class="history-cancel"/);
+  // Still inside the blocked subtree: a wait is drawn beside words a recording never sees.
+  assert.match(pending, /ph-no-capture/);
+  const settled = render("succeeded");
+  assert.doesNotMatch(settled, /history-cancel|history-pending/);
 });

--- a/apps/desktop/src/renderer/conversation-history-panel.tsx
+++ b/apps/desktop/src/renderer/conversation-history-panel.tsx
@@ -5,6 +5,7 @@ import {
   conversationEntryKey,
 } from "@sidecar/realtime";
 import { useEffect, useRef, useState } from "react";
+import { type BrainRequestSnapshot, brainRequestPending } from "#shared/wire/brain";
 import { type AskHandler, AskLuke } from "./ask-luke";
 import { PANEL_TAB, panelPanelId, panelTabId } from "./panel-tabs";
 import { CheckIcon, CopyIcon } from "./settings-icons";
@@ -40,12 +41,20 @@ const COPY_CONFIRMATION_MS = 1500;
 
 const ENTRY_TIME = new Intl.DateTimeFormat(undefined, { hour: "numeric", minute: "2-digit" });
 
+/** What History says under an ask whose run has not ended yet. */
+export const HISTORY_PENDING_LABEL = "Luke is working on this…";
+
 function HistoryEntryRow({
   entry,
   streaming,
+  pending,
+  onCancel,
 }: {
   entry: ConversationEntry;
   streaming?: boolean;
+  /** Whether the run this ask opened is still going, which draws the wait and the cancel. */
+  pending?: boolean;
+  onCancel?: () => void;
 }): React.JSX.Element {
   const presentation = historyEntryPresentation(entry.kind);
   const words = entry.words;
@@ -75,6 +84,16 @@ function HistoryEntryRow({
             </time>
           ) : null}
         </p>
+        {pending ? (
+          <span className="history-pending" role="status">
+            <span className="history-pending-label">{HISTORY_PENDING_LABEL}</span>
+            {onCancel ? (
+              <button type="button" className="history-cancel" onClick={onCancel}>
+                Cancel
+              </button>
+            ) : null}
+          </span>
+        ) : null}
         {/* Copying words still arriving would copy half a sentence; the control
             appears with the settled line the same words become. */}
         {presentation.speaker === HISTORY_ENTRY_SPEAKER.EVENT || streaming ? null : (
@@ -127,12 +146,21 @@ const HISTORY_COMPOSER_ROW_INDEX = 1;
 export function ConversationHistoryPanel({
   entries,
   live = [],
+  requests = [],
+  onCancelRequest,
   onClear,
   ask,
   onAskEngaged,
   askShortcut,
 }: {
   entries: readonly ConversationEntry[];
+  /**
+   * The brain's runs, so an ask whose run is still going is drawn waiting,
+   * with the cancel the developer holds. Read here from the records alone;
+   * the reply's own line arrives when the run ends.
+   */
+  requests?: readonly BrainRequestSnapshot[];
+  onCancelRequest?: (runId: string) => void;
   /**
    * The lines still being said, drawn under the settled thread as the same
    * bubbles they will settle into — words growing, no timestamp, no copy.
@@ -148,6 +176,9 @@ export function ConversationHistoryPanel({
   const list = useRef<HTMLOListElement | null>(null);
   const entryCount = entries.length;
   const liveLength = live.reduce((total, entry) => total + entry.words.length, 0);
+  const pendingRuns = new Set(
+    requests.filter(brainRequestPending).map((snapshot) => snapshot.runId),
+  );
 
   useEffect(() => {
     // Reading the count binds the scroll to an append or clear, not to an
@@ -214,9 +245,23 @@ export function ConversationHistoryPanel({
         </div>
       ) : (
         <ol className="history-list" ref={list}>
-          {keyedHistoryEntries(entries).map(({ entry, key }) => (
-            <HistoryEntryRow key={key} entry={entry} />
-          ))}
+          {keyedHistoryEntries(entries).map(({ entry, key }) => {
+            const runId = entry.requestId;
+            const pending =
+              runId !== undefined &&
+              entry.kind === CONVERSATION_ENTRY_KIND.TYPED_ASK &&
+              pendingRuns.has(runId);
+            return (
+              <HistoryEntryRow
+                key={key}
+                entry={entry}
+                pending={pending}
+                {...(pending && runId !== undefined && onCancelRequest
+                  ? { onCancel: () => onCancelRequest(runId) }
+                  : undefined)}
+              />
+            );
+          })}
           {live.map((entry, index) => (
             <HistoryEntryRow
               // biome-ignore lint/suspicious/noArrayIndexKey: A line still being said has no durable id, and its words change on every delta — a key made of either would remount the bubble mid-sentence, while its position holds still for exactly as long as the line does.

--- a/apps/desktop/src/renderer/conversation-history-panel.tsx
+++ b/apps/desktop/src/renderer/conversation-history-panel.tsx
@@ -249,7 +249,8 @@ export function ConversationHistoryPanel({
             const runId = entry.requestId;
             const pending =
               runId !== undefined &&
-              entry.kind === CONVERSATION_ENTRY_KIND.TYPED_ASK &&
+              (entry.kind === CONVERSATION_ENTRY_KIND.TYPED_ASK ||
+                entry.kind === CONVERSATION_ENTRY_KIND.SPOKEN_ASK) &&
               pendingRuns.has(runId);
             return (
               <HistoryEntryRow

--- a/apps/desktop/src/renderer/panel-body.tsx
+++ b/apps/desktop/src/renderer/panel-body.tsx
@@ -11,6 +11,7 @@ import { cssCustomProperties } from "@sidecar/surface/react-css";
 import { ACT_RESULT_STATUS } from "@sidecar/wire";
 import { useCallback, useState } from "react";
 import { ACCOUNT_STATUS, type AccountProvider, type AccountSnapshot } from "#shared/wire/account";
+import type { BrainRequestSnapshot } from "#shared/wire/brain";
 import type { SessionOpenResult } from "#shared/wire/session";
 import { type AskHandler, AskLuke } from "./ask-luke";
 import { CalendarGate, type CalendarGateControl } from "./calendar-gate";
@@ -523,6 +524,10 @@ export interface PanelBodyProps {
   liveConversationEntries: readonly ConversationEntry[];
   /** Clears that same thread from the view, Luke's next context, and the stored file. */
   onClearConversationHistory: () => void;
+  /** The brain's runs, so History draws an ask still being worked on beside its words. */
+  brainRequests: readonly BrainRequestSnapshot[];
+  /** Cancels one of those runs at the developer's press. */
+  onCancelBrainRequest: (runId: string) => void;
   /** Carries a typed ask to Luke's own conversation, answering why it could not go. */
   ask: AskHandler;
   /** Reports someone being part-way through an ask, so the panel holds for them. */
@@ -575,6 +580,8 @@ export function PanelBody({
   conversationHistory,
   liveConversationEntries,
   onClearConversationHistory,
+  brainRequests,
+  onCancelBrainRequest,
   ask,
   onAskEngaged,
   askShortcut,
@@ -691,6 +698,8 @@ export function PanelBody({
         <ConversationHistoryPanel
           entries={conversationHistory}
           live={liveConversationEntries}
+          requests={brainRequests}
+          onCancelRequest={onCancelBrainRequest}
           onClear={onClearConversationHistory}
           ask={ask}
           onAskEngaged={onAskEngaged}

--- a/apps/desktop/src/renderer/styles/history.css
+++ b/apps/desktop/src/renderer/styles/history.css
@@ -131,6 +131,30 @@
   color: var(--text-primary);
 }
 
+/* The wait under an ask still running, and the one control it offers: quiet,
+   in the bubble's own column, gone the moment the reply's line arrives. */
+.history-pending {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 0 10px 7px;
+  color: var(--text-secondary);
+  font-size: 11.5px;
+}
+
+.history-cancel {
+  padding: 1px 8px;
+  border-radius: 999px;
+  background: var(--raised);
+  color: var(--text-primary);
+  font-size: 11px;
+}
+
+.history-cancel:hover {
+  background: var(--text-secondary);
+  color: var(--surface);
+}
+
 .history-entry p {
   margin: 0;
   padding: 7px 10px 8px;

--- a/apps/desktop/src/renderer/use-voice-view.test.ts
+++ b/apps/desktop/src/renderer/use-voice-view.test.ts
@@ -1,13 +1,11 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { BRAIN_REQUEST_ORIGIN, BRAIN_REQUEST_STATUS } from "@sidecar/brain/requests";
 import { REALTIME_STATUS } from "@sidecar/realtime";
-import { BRAIN_ASK_REFUSAL, type BrainRequestSnapshot } from "#shared/wire/brain";
+import { BRAIN_ASK_REFUSAL } from "#shared/wire/brain";
 import { IDLE_VOICE_VIEW } from "#shared/wire/voice-view";
 import {
   ASK_UNSENT_REASON,
   askDraftReason,
-  reconciledBrainRequests,
   voiceActiveFor,
   voiceErrorToShow,
   voiceNoticeToShow,
@@ -93,32 +91,6 @@ test("a refused or unanswered typed ask keeps its draft; an accepted one clears 
     ASK_UNSENT_REASON,
     "an ask nobody answered is the developer's words to retry, not to lose",
   );
-});
-
-test("records are reconciled by run, the higher revision winning whichever arrived last", () => {
-  const record = (runId: string, revision: number, acceptedAt: number): BrainRequestSnapshot => ({
-    runId,
-    submissionId: `sub-${runId}`,
-    origin: BRAIN_REQUEST_ORIGIN.TYPED,
-    question: "?",
-    status: revision > 1 ? BRAIN_REQUEST_STATUS.SUCCEEDED : BRAIN_REQUEST_STATUS.RUNNING,
-    revision,
-    acceptedAt,
-    performedActs: 0,
-    unknownActs: 0,
-  });
-  // The push landed first with the newer revision; the bootstrap's older read
-  // must not roll it back, while a run only the bootstrap knew is kept.
-  const pushed = reconciledBrainRequests([], [record("b", 3, 2)]);
-  const merged = reconciledBrainRequests(pushed, [record("a", 1, 1), record("b", 2, 2)]);
-  assert.deepEqual(
-    merged.map((snapshot) => [snapshot.runId, snapshot.revision]),
-    [
-      ["a", 1],
-      ["b", 3],
-    ],
-  );
-  assert.equal(reconciledBrainRequests(merged, [record("a", 2, 1)])[0]?.revision, 2);
 });
 
 test("a quiet level lets the hangover run out from the last loud one, never past it", () => {

--- a/apps/desktop/src/renderer/use-voice-view.test.ts
+++ b/apps/desktop/src/renderer/use-voice-view.test.ts
@@ -1,10 +1,13 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import { BRAIN_REQUEST_ORIGIN, BRAIN_REQUEST_STATUS } from "@sidecar/brain/requests";
 import { REALTIME_STATUS } from "@sidecar/realtime";
-import { IDLE_VOICE_VIEW, VOICE_COMMAND_OUTCOME } from "#shared/wire/voice-view";
+import { BRAIN_ASK_REFUSAL, type BrainRequestSnapshot } from "#shared/wire/brain";
+import { IDLE_VOICE_VIEW } from "#shared/wire/voice-view";
 import {
   ASK_UNSENT_REASON,
   askDraftReason,
+  reconciledBrainRequests,
   voiceActiveFor,
   voiceErrorToShow,
   voiceNoticeToShow,
@@ -83,13 +86,38 @@ test("a notice yields to Luke's turn alone, because the developer's draws nothin
 test("a refused or unanswered typed ask keeps its draft; an accepted one clears it", () => {
   // The composer clears the field only on a falsy answer, so an accepted ask
   // must answer nothing and every other outcome must answer a reason.
-  assert.equal(askDraftReason(VOICE_COMMAND_OUTCOME.ACCEPTED), undefined);
-  assert.equal(askDraftReason(VOICE_COMMAND_OUTCOME.REFUSED), ASK_UNSENT_REASON);
+  assert.equal(askDraftReason({ outcome: "accepted", runId: "run-1", acceptedAt: 1 }), undefined);
+  assert.equal(askDraftReason({ outcome: "rejected", reason: "absent" }), BRAIN_ASK_REFUSAL.absent);
   assert.equal(
     askDraftReason(undefined),
     ASK_UNSENT_REASON,
     "an ask nobody answered is the developer's words to retry, not to lose",
   );
+});
+
+test("records are reconciled by run, the higher revision winning whichever arrived last", () => {
+  const record = (runId: string, revision: number, acceptedAt: number): BrainRequestSnapshot => ({
+    runId,
+    submissionId: `sub-${runId}`,
+    origin: BRAIN_REQUEST_ORIGIN.TYPED,
+    question: "?",
+    status: revision > 1 ? BRAIN_REQUEST_STATUS.SUCCEEDED : BRAIN_REQUEST_STATUS.RUNNING,
+    revision,
+    acceptedAt,
+    performedActs: 0,
+  });
+  // The push landed first with the newer revision; the bootstrap's older read
+  // must not roll it back, while a run only the bootstrap knew is kept.
+  const pushed = reconciledBrainRequests([], [record("b", 3, 2)]);
+  const merged = reconciledBrainRequests(pushed, [record("a", 1, 1), record("b", 2, 2)]);
+  assert.deepEqual(
+    merged.map((snapshot) => [snapshot.runId, snapshot.revision]),
+    [
+      ["a", 1],
+      ["b", 3],
+    ],
+  );
+  assert.equal(reconciledBrainRequests(merged, [record("a", 2, 1)])[0]?.revision, 2);
 });
 
 test("a quiet level lets the hangover run out from the last loud one, never past it", () => {

--- a/apps/desktop/src/renderer/use-voice-view.test.ts
+++ b/apps/desktop/src/renderer/use-voice-view.test.ts
@@ -105,6 +105,7 @@ test("records are reconciled by run, the higher revision winning whichever arriv
     revision,
     acceptedAt,
     performedActs: 0,
+    unknownActs: 0,
   });
   // The push landed first with the newer revision; the bootstrap's older read
   // must not roll it back, while a run only the bootstrap knew is kept.

--- a/apps/desktop/src/renderer/use-voice-view.ts
+++ b/apps/desktop/src/renderer/use-voice-view.ts
@@ -36,24 +36,6 @@ export function askDraftReason(result: BrainAskSubmissionResult | undefined): st
     : BRAIN_ASK_REFUSAL[result.reason];
 }
 
-/**
- * Takes one report of the brain's records into the list a panel draws. The
- * push and the bootstrap read race, so records are reconciled by run: the
- * higher revision of a run wins whichever arrived last, and a run one side
- * never mentioned is kept from the other.
- */
-export function reconciledBrainRequests(
-  current: readonly BrainRequestSnapshot[],
-  incoming: readonly BrainRequestSnapshot[],
-): readonly BrainRequestSnapshot[] {
-  const byRun = new Map(current.map((snapshot) => [snapshot.runId, snapshot]));
-  for (const snapshot of incoming) {
-    const held = byRun.get(snapshot.runId);
-    if (!held || held.revision <= snapshot.revision) byRun.set(snapshot.runId, snapshot);
-  }
-  return [...byRun.values()].sort((left, right) => left.acceptedAt - right.acceptedAt);
-}
-
 /** What the strip says when the stored thread could not be deleted. */
 export const CLEAR_FAILED_REASON = "Could not clear history. Try again.";
 
@@ -253,17 +235,20 @@ export function useVoiceView(): VoiceViewState {
   );
   // Subscribed before the snapshots are read, and reconciled by run, so a
   // change landing between the two is never overwritten by the older read.
+  // Every push is the whole list the standing brain holds — a run absent
+  // from it is one no current brain can find, so its row must go — and the
+  // bootstrap read applies only where no push has spoken yet.
   const [brainRequests, setBrainRequests] = useState<readonly BrainRequestSnapshot[]>([]);
+  const acceptRequestsBootstrap = useBootstrapRacedChannel(
+    (onChange) => window.sidecar.onBrainRequestsChanged(onChange),
+    setBrainRequests,
+  );
   useEffect(() => {
-    const unsubscribe = window.sidecar.onBrainRequestsChanged((records) =>
-      setBrainRequests((current) => reconciledBrainRequests(current, records)),
-    );
     void window.sidecar
       .brainRequestSnapshots()
-      .then((records) => setBrainRequests((current) => reconciledBrainRequests(current, records)))
+      .then((records) => acceptRequestsBootstrap(records))
       .catch(() => undefined);
-    return unsubscribe;
-  }, []);
+  }, [acceptRequestsBootstrap]);
   const cancelBrainAsk = useCallback((runId: string) => {
     void window.sidecar.cancelBrainAsk(runId).catch(() => undefined);
   }, []);

--- a/apps/desktop/src/renderer/use-voice-view.ts
+++ b/apps/desktop/src/renderer/use-voice-view.ts
@@ -1,6 +1,12 @@
+import { BRAIN_REQUEST_ORIGIN, BRAIN_SUBMISSION_OUTCOME } from "@sidecar/brain/requests";
 import { type ConversationEntry, REALTIME_STATUS, type RealtimeStatus } from "@sidecar/realtime";
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { MicrophoneStatus, VoiceHotkeyState } from "#shared/wire/audio";
+import {
+  BRAIN_ASK_REFUSAL,
+  type BrainAskSubmissionResult,
+  type BrainRequestSnapshot,
+} from "#shared/wire/brain";
 import type { AppBootstrap } from "#shared/wire/session";
 import {
   IDLE_VOICE_VIEW,
@@ -15,17 +21,37 @@ import { VOICE_ACTIVITY_HANGOVER_MS, VOICE_ACTIVITY_THRESHOLD } from "./voice/vo
 import { WAVEFORM_VOICE, type WaveformVoice } from "./waveform";
 
 /**
- * What the composer hears back from a typed ask: nothing when the ask reached
- * a conversation, so the draft clears, and a reason when it did not, so the
- * developer's words stay theirs to retry. An ask nobody answered — the voice
- * window gone, the wait run out — is refused too: words lost on a silence
- * would be the one outcome nobody chose. The strip already carries the
- * specific refusal through the view, so this only has to be true.
+ * What the composer hears back from a typed ask: nothing when the brain
+ * accepted it into a run, so the draft clears, and a reason when it did not,
+ * so the developer's words stay theirs to retry. An ask nobody answered — the
+ * bridge throwing, the main process gone — is refused too: words lost on a
+ * silence would be the one outcome nobody chose.
  */
 export const ASK_UNSENT_REASON = "Luke could not take that ask. Try again.";
 
-export function askDraftReason(outcome: VoiceCommandOutcome | undefined): string | undefined {
-  return outcome === VOICE_COMMAND_OUTCOME.ACCEPTED ? undefined : ASK_UNSENT_REASON;
+export function askDraftReason(result: BrainAskSubmissionResult | undefined): string | undefined {
+  if (result === undefined) return ASK_UNSENT_REASON;
+  return result.outcome === BRAIN_SUBMISSION_OUTCOME.ACCEPTED
+    ? undefined
+    : BRAIN_ASK_REFUSAL[result.reason];
+}
+
+/**
+ * Takes one report of the brain's records into the list a panel draws. The
+ * push and the bootstrap read race, so records are reconciled by run: the
+ * higher revision of a run wins whichever arrived last, and a run one side
+ * never mentioned is kept from the other.
+ */
+export function reconciledBrainRequests(
+  current: readonly BrainRequestSnapshot[],
+  incoming: readonly BrainRequestSnapshot[],
+): readonly BrainRequestSnapshot[] {
+  const byRun = new Map(current.map((snapshot) => [snapshot.runId, snapshot]));
+  for (const snapshot of incoming) {
+    const held = byRun.get(snapshot.runId);
+    if (!held || held.revision <= snapshot.revision) byRun.set(snapshot.runId, snapshot);
+  }
+  return [...byRun.values()].sort((left, right) => left.acceptedAt - right.acceptedAt);
 }
 
 /** What the strip says when the stored thread could not be deleted. */
@@ -118,12 +144,16 @@ export interface VoiceViewState {
   /** The bootstrap's snapshots, applied only where no push has spoken yet. */
   acceptBootstrap: (bootstrap: AppBootstrap) => void;
   /**
-   * A typed ask to Luke, forwarded to the voice window and answered with
-   * whether it reached a conversation: nothing when it did, a reason when it
-   * did not, so the composer keeps a refused draft. The specific refusal
-   * lands on the strip through the view.
+   * A typed ask to Luke, submitted to the brain in the main process and
+   * answered with whether it was accepted into a run: nothing when it was, a
+   * reason when it was not, so the composer keeps a refused draft. The reply
+   * arrives later, in the thread and in the voice.
    */
   askLuke: (text: string) => Promise<string | undefined>;
+  /** Every run the brain holds, for History to draw a pending ask beside its words. */
+  brainRequests: readonly BrainRequestSnapshot[];
+  /** Cancels one run the developer no longer wants. */
+  cancelBrainAsk: (runId: string) => void;
   /** Escape out of an open turn: forget the press and the latch, and stop listening. */
   discardListening: () => void;
   stopSpeaking: () => void;
@@ -206,23 +236,45 @@ export function useVoiceView(): VoiceViewState {
   // or bootstrap's old chord would keep winning for the rest of the session.
   useEffect(() => window.sidecar.onVoiceHotkeyChanged(setVoiceHotkey), []);
 
+  // One submission id per press of Send: the id is what makes a retry of
+  // this very ask the same run and a second deliberate ask a new one.
   const askLuke = useCallback(
     async (text: string): Promise<string | undefined> =>
       askDraftReason(
         await window.sidecar
-          .voiceCommand(VOICE_COMMAND.ASK_TEXT, text)
-          .catch((): VoiceCommandOutcome => VOICE_COMMAND_OUTCOME.REFUSED),
+          .submitBrainAsk({
+            submissionId: crypto.randomUUID(),
+            question: text,
+            origin: BRAIN_REQUEST_ORIGIN.TYPED,
+          })
+          .catch((): BrainAskSubmissionResult | undefined => undefined),
       ),
     [],
   );
+  // Subscribed before the snapshots are read, and reconciled by run, so a
+  // change landing between the two is never overwritten by the older read.
+  const [brainRequests, setBrainRequests] = useState<readonly BrainRequestSnapshot[]>([]);
+  useEffect(() => {
+    const unsubscribe = window.sidecar.onBrainRequestsChanged((records) =>
+      setBrainRequests((current) => reconciledBrainRequests(current, records)),
+    );
+    void window.sidecar
+      .brainRequestSnapshots()
+      .then((records) => setBrainRequests((current) => reconciledBrainRequests(current, records)))
+      .catch(() => undefined);
+    return unsubscribe;
+  }, []);
+  const cancelBrainAsk = useCallback((runId: string) => {
+    void window.sidecar.cancelBrainAsk(runId).catch(() => undefined);
+  }, []);
   const discardListening = useCallback(() => {
-    void window.sidecar.voiceCommand(VOICE_COMMAND.DISCARD_LISTENING, undefined);
+    void window.sidecar.voiceCommand(VOICE_COMMAND.DISCARD_LISTENING);
   }, []);
   const stopSpeaking = useCallback(() => {
-    void window.sidecar.voiceCommand(VOICE_COMMAND.STOP_SPEAKING, undefined);
+    void window.sidecar.voiceCommand(VOICE_COMMAND.STOP_SPEAKING);
   }, []);
   const requestMicrophoneAccess = useCallback(() => {
-    void window.sidecar.voiceCommand(VOICE_COMMAND.REQUEST_MICROPHONE_ACCESS, undefined);
+    void window.sidecar.voiceCommand(VOICE_COMMAND.REQUEST_MICROPHONE_ACCESS);
   }, []);
   // The one failure the panel reports itself: the stored thread refusing to
   // go is the main process's answer to this press, not anything the voice
@@ -235,7 +287,7 @@ export function useVoiceView(): VoiceViewState {
   }, [localError]);
   const clearConversationHistory = useCallback(() => {
     void window.sidecar
-      .voiceCommand(VOICE_COMMAND.CLEAR_CONVERSATION, undefined)
+      .voiceCommand(VOICE_COMMAND.CLEAR_CONVERSATION)
       .catch((): VoiceCommandOutcome => VOICE_COMMAND_OUTCOME.REFUSED)
       .then((outcome) => {
         if (outcome === VOICE_COMMAND_OUTCOME.REFUSED) setLocalError(CLEAR_FAILED_REASON);
@@ -253,6 +305,8 @@ export function useVoiceView(): VoiceViewState {
     conversationHistory,
     acceptBootstrap,
     askLuke,
+    brainRequests,
+    cancelBrainAsk,
     discardListening,
     stopSpeaking,
     requestMicrophoneAccess,

--- a/apps/desktop/src/renderer/voice/realtime-session.test.ts
+++ b/apps/desktop/src/renderer/voice/realtime-session.test.ts
@@ -17,7 +17,11 @@ import {
 } from "@sidecar/realtime";
 import { ACT_RESULT_STATUS, isRecord, text, type WireRecord } from "@sidecar/wire";
 import type { JsonValue, ParsedJsonObject } from "@sidecar/wire/testing";
-import type { BrainAskResult } from "#shared/wire/brain";
+import {
+  BRAIN_ASK_PENDING_NOTE,
+  BRAIN_ASK_PENDING_STATUS,
+  type BrainAskResult,
+} from "#shared/wire/brain";
 import {
   asMediaStream,
   asMediaTrack,
@@ -72,6 +76,8 @@ interface Harness {
   replyEndings: ReplyEnding[];
   /** The questions the voice asked the brain, in order. */
   asked: string[];
+  /** The submission id each ask travelled under: the tool call's own id. */
+  submissions: string[];
   /** The developer's spoken turns, as the service handed them back. */
   spokenAsks: string[];
   /** The growing pieces of those turns' words, in arrival order. */
@@ -117,6 +123,10 @@ function brainAnswer(briefing: string): BrainAskResult {
   return { status: ACT_RESULT_STATUS.ACCEPTED, briefing };
 }
 
+function brainPending(): BrainAskResult {
+  return { status: BRAIN_ASK_PENDING_STATUS, note: BRAIN_ASK_PENDING_NOTE };
+}
+
 function harness(
   options: {
     connection?: RealtimeConnection | undefined;
@@ -147,6 +157,7 @@ function harness(
   const captions: (readonly string[] | undefined)[] = [];
   const replyEndings: ReplyEnding[] = [];
   const asked: string[] = [];
+  const submissions: string[] = [];
   const spokenAsks: string[] = [];
   const spokenAskDeltas: { itemId: string; delta: string }[] = [];
   const spokenAskFailures: string[] = [];
@@ -370,8 +381,9 @@ function harness(
   }
   const askBrain = options.askBrain;
   if (askBrain) {
-    sessionOptions.askBrain = (question) => {
+    sessionOptions.askBrain = (question, submissionId) => {
       asked.push(question);
+      submissions.push(submissionId);
       return askBrain(question);
     };
   }
@@ -384,6 +396,7 @@ function harness(
     captions,
     replyEndings,
     asked,
+    submissions,
     spokenAsks,
     spokenAskDeltas,
     spokenAskFailures,
@@ -2800,6 +2813,29 @@ test("a typed ask interrupts the reply it arrives over", async () => {
     ],
   );
   assert.equal(context.session.status, REALTIME_STATUS.RESPONDING);
+});
+
+test("an ask the brain has not finished with is answered pending under the call's own id, and the turn is released", async () => {
+  const context = harness({ askBrain: async () => brainPending() });
+  await context.session.connect();
+  await armDeveloperTurn(context);
+  context.emit({ type: REALTIME_SERVER_EVENT.RESPONSE_CREATED, response: { id: "resp-a" } });
+  const before = context.sent.length;
+  context.emit(
+    askBrainDone("read every transcript", { callId: "call-slow", responseId: "resp-a" }),
+  );
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  // The tool call's id is the submission, so the service repeating the call
+  // finds the same run rather than opening a second one.
+  assert.deepEqual(context.asked, ["read every transcript"]);
+  assert.deepEqual(context.submissions, ["call-slow"]);
+  // The output says the run goes on; the follow-up voices that, and nothing
+  // here holds the turn open for the eventual reply.
+  assert.deepEqual(toolOutputs(context, before), [
+    { status: BRAIN_ASK_PENDING_STATUS, note: BRAIN_ASK_PENDING_NOTE },
+  ]);
+  assert.equal(responseCreates(context, before).length, 1);
 });
 
 test("a cancelled reply's late finish cannot ask the brain in the turn that replaced it", async () => {

--- a/apps/desktop/src/renderer/voice/realtime-session.ts
+++ b/apps/desktop/src/renderer/voice/realtime-session.ts
@@ -39,7 +39,11 @@ import {
   type UnparsedWireValue,
   type WireRecord,
 } from "@sidecar/wire";
-import type { BrainAppActRequest, BrainAskResult } from "#shared/contracts";
+import {
+  BRAIN_ASK_PENDING_STATUS,
+  type BrainAppActRequest,
+  type BrainAskResult,
+} from "#shared/contracts";
 import {
   type BuiltRealtimeSessionConfig,
   createAgentsRealtimeTransport,
@@ -69,8 +73,8 @@ export const REALTIME_SETTLE_TIMEOUT_MS = 20_000;
  * How long a turn that asked the brain may wait for the answer and the reply
  * voicing it. A brain turn reads transcripts and may act before it answers,
  * so the ordinary settle backstop is far too short for it; the main process's
- * own ask deadline is what ends a turn the brain never answers, and this is
- * the backstop under that.
+ * own wait answers a turn the brain has not finished with "still working",
+ * and this is the backstop under that.
  */
 export const BRAIN_ASK_SETTLE_TIMEOUT_MS = 60_000;
 
@@ -226,11 +230,13 @@ export interface MicrophoneSender {
 export interface RealtimeVoiceSessionOptions extends RealtimeVoiceSessionCallbacks {
   requestConnection(): Promise<RealtimeConnection | undefined>;
   /**
-   * Answers the voice's one tool: the developer's words go to the brain and
-   * its reply comes back for the voice to say. Absent means the voice can only
-   * speak for itself, and every ask is answered with a bounded refusal.
+   * Answers the voice's one tool: the developer's words go to the brain under
+   * the tool call's own id as the submission — so a call the service repeats
+   * finds the same run — and what comes back is the reply for the voice to
+   * say, the note that the run is still going, or a bounded refusal. Absent
+   * means the voice can only speak for itself, and every ask is refused.
    */
-  askBrain?: (question: string) => Promise<BrainAskResult>;
+  askBrain?: (question: string, submissionId: string) => Promise<BrainAskResult>;
   /** The SDK call seam, injectable so the complete transport can be tested without WebRTC. */
   createSdkTransport?: SdkTransportFactory;
   /** The full session document used by the SDK; the introduction narrows this to no tools. */
@@ -2173,12 +2179,18 @@ export class RealtimeVoiceSession {
     const epoch = this.#turnEpoch;
     let answer: BrainAskResult;
     try {
-      answer = await this.#options.askBrain(question);
+      answer = await this.#options.askBrain(question, call.callId);
     } catch {
       return {
         status: ACT_RESULT_STATUS.REJECTED,
         reason: "Luke's judgment did not answer.",
       };
+    }
+    if (answer.status === BRAIN_ASK_PENDING_STATUS) {
+      // The run goes on without this turn: the follow-up says so, and the
+      // turn is released rather than held open for a reply that may be a
+      // long time coming.
+      return { status: answer.status, note: answer.note };
     }
     if (answer.status !== ACT_RESULT_STATUS.ACCEPTED) {
       return { status: answer.status, reason: answer.reason };

--- a/apps/desktop/src/renderer/voice/use-voice-session.ts
+++ b/apps/desktop/src/renderer/voice/use-voice-session.ts
@@ -1,3 +1,4 @@
+import { BRAIN_REQUEST_ORIGIN, BRAIN_SUBMISSION_OUTCOME } from "@sidecar/brain/requests";
 import { sanitizedTraceEvent } from "@sidecar/devtrace/vocabulary";
 import {
   type ArrivalSpeech,
@@ -23,12 +24,19 @@ import { TALK_KEY_RELEASE, talkKeyRelease, voiceHotkeyLabel } from "@sidecar/set
 import { ACT_RESULT_STATUS } from "@sidecar/wire";
 import { type RefObject, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { MicrophoneStatus, OutputAudioState, VoiceHotkeyState } from "#shared/wire/audio";
+import {
+  BRAIN_ASK_PENDING_NOTE,
+  BRAIN_ASK_PENDING_STATUS,
+  BRAIN_ASK_REFUSAL,
+  type BrainAskResult,
+  type BrainRequestSnapshot,
+  brainReplyWords,
+  brainRequestPending,
+} from "#shared/wire/brain";
 import type { AppBootstrap } from "#shared/wire/session";
 import { type AppSettingsView, appSettingsView } from "#shared/wire/settings";
 import {
   VOICE_COMMAND,
-  VOICE_COMMAND_OUTCOME,
-  type VoiceCommandOutcome,
   type VoiceView,
   voiceExchangeActive,
   voiceExchangeKind,
@@ -405,6 +413,10 @@ export function useVoiceSession(remoteAudio: RefObject<HTMLAudioElement | null>)
    * edge the count is taken on.
    */
   const typedExchange = useRef(false);
+  /** The brain run whose reply the voice is speaking now, so its words are not recorded twice. */
+  const brainReplyRunRef = useRef<string | undefined>(undefined);
+  /** Each run's last status this window saw, so only an end it watched arrive is spoken. */
+  const knownRequestsRef = useRef(new Map<string, BrainRequestSnapshot["status"]>());
   /**
    * The conversation history, surviving here across calls: a call is a
    * transport that comes and goes — an announcement is often read out on
@@ -659,16 +671,33 @@ export function useVoiceSession(remoteAudio: RefObject<HTMLAudioElement | null>)
           open: (audio) => navigator.mediaDevices.getUserMedia({ audio, video: false }),
         }),
       // The voice's one tool: the developer's words go to the brain in the
-      // main process, which reads, decides, and acts behind its own validators,
-      // and the reply comes back for the voice to say. A reply to an ask the
-      // developer made is recorded when the words end, like every reply.
-      askBrain: async (question) => {
-        const generation = conversationGenerationRef.current;
-        const answer = await window.sidecar.askBrain(question);
-        if (answer.status === ACT_RESULT_STATUS.ACCEPTED) {
-          activeReplyGenerationRef.current = generation;
+      // main process, which reads, decides, and acts behind its own validators.
+      // The tool call's id is the submission, so a call the service repeats
+      // finds the run it already has. The reply the follow-up then speaks was
+      // recorded by the main process at the run's end, so the words that end
+      // here are not recorded again.
+      askBrain: async (question, submissionId): Promise<BrainAskResult> => {
+        brainReplyRunRef.current = undefined;
+        const submitted = await window.sidecar.submitBrainAsk({
+          submissionId,
+          question,
+          origin: BRAIN_REQUEST_ORIGIN.SPOKEN,
+        });
+        if (submitted.outcome !== BRAIN_SUBMISSION_OUTCOME.ACCEPTED) {
+          return {
+            status: ACT_RESULT_STATUS.REJECTED,
+            reason: BRAIN_ASK_REFUSAL[submitted.reason],
+          };
         }
-        return answer;
+        const record = await window.sidecar.waitBrainAsk(submitted.runId);
+        if (!record) {
+          return { status: ACT_RESULT_STATUS.REJECTED, reason: BRAIN_ASK_REFUSAL.absent };
+        }
+        if (brainRequestPending(record)) {
+          return { status: BRAIN_ASK_PENDING_STATUS, note: BRAIN_ASK_PENDING_NOTE };
+        }
+        brainReplyRunRef.current = record.runId;
+        return { status: ACT_RESULT_STATUS.ACCEPTED, briefing: brainReplyWords(record) ?? "" };
       },
       onStatus: setVoiceStatus,
       onLocalStream: setLocalStream,
@@ -684,6 +713,13 @@ export function useVoiceSession(remoteAudio: RefObject<HTMLAudioElement | null>)
         }
         const generation = activeReplyGenerationRef.current;
         activeReplyGenerationRef.current = undefined;
+        // A reply voicing a brain run's end is already in the thread, written
+        // by the main process from the record; the voice's rendering of it is
+        // not a second line.
+        if (brainReplyRunRef.current !== undefined) {
+          brainReplyRunRef.current = undefined;
+          return;
+        }
         rememberConversationEntry(replyConversationEntry(texts.join(" ")), generation);
       },
       onSpokenAskCommitted: (itemId) => {
@@ -1040,57 +1076,59 @@ export function useVoiceSession(remoteAudio: RefObject<HTMLAudioElement | null>)
   }, [voiceStatusNow]);
 
   /**
-   * A typed ask to Luke himself, forwarded from the panel it was typed into.
-   * The words go to the brain over the bridge — typing is the developer
-   * asking in their own words, so the brain's turn may act, behind the same
-   * validators every act runs — and the reply comes back to be spoken on the
-   * same call the talk key opens. It asks the system for nothing on the way:
-   * typing opens no capture device, and the reply arrives on the call's
-   * receiving half. A refusal lands on the strip; where voice cannot speak
-   * the reply, the words stand on the strip instead, so an ask is never
-   * answered with silence. Whether the ask reached a conversation is answered
-   * back to the panel that typed it, so a refused draft stays in its composer
-   * and the composer counts the outcome once, as it always has.
+   * Speaks the reply a typed ask's run ended in. The ask itself never passed
+   * through this window — the panel submitted it to the main process, which
+   * ran it and recorded both halves in the thread — so what arrives here is
+   * the record, and the words are spoken on the developer's own call, opened
+   * for them if none stands. Voice that cannot say it puts the words on the
+   * strip instead, so an ask is never answered with silence; nothing is
+   * recorded here either way.
    */
-  const askLuke = useCallback(
-    async (text: string): Promise<VoiceCommandOutcome> => {
-      const generation = conversationGenerationRef.current;
+  const speakTypedReply = useCallback(
+    async (runId: string, words: string): Promise<void> => {
       const session = ensureVoiceSession();
       typedExchange.current = true;
-      // The developer's own words enter the history as they were typed, so
-      // the thread holds both halves of the exchange the reply answers.
-      rememberConversationEntry(
-        { kind: CONVERSATION_ENTRY_KIND.TYPED_ASK, words: text },
-        generation,
-      );
-      // A sent ask outdates whatever refusal the strip was still reading.
       setVoiceNotice(undefined);
-      // Luke's own speak-only call cannot carry the reply to a typed ask — it
-      // is not a conversation — so it counts as no call here, and `connect`
-      // inside stands it down for the developer's own. A microphone call
-      // still connecting is awaited, not doubled.
-      const connecting =
-        !session.isConnected || !session.microphoneCall
-          ? startConversation()
-          : Promise.resolve(true);
-      const [connected, answer] = await Promise.all([connecting, window.sidecar.askBrain(text)]);
-      if (answer.status !== ACT_RESULT_STATUS.ACCEPTED) {
-        setVoiceNotice(answer.reason);
-        return VOICE_COMMAND_OUTCOME.REFUSED;
-      }
-      if (connected && session.speakReply(answer.briefing)) {
-        activeReplyGenerationRef.current = generation;
+      const connected =
+        !session.isConnected || !session.microphoneCall ? await startConversation() : true;
+      brainReplyRunRef.current = runId;
+      if (connected && session.speakReply(words)) {
         setTypedAsk(true);
-        return VOICE_COMMAND_OUTCOME.ACCEPTED;
+        return;
       }
-      // Voice cannot say it, so the words stand on the strip and enter the
-      // record as the reply they are.
-      rememberConversationEntry(replyConversationEntry(answer.briefing), generation);
-      setVoiceNotice(answer.briefing);
-      return VOICE_COMMAND_OUTCOME.ACCEPTED;
+      brainReplyRunRef.current = undefined;
+      setVoiceNotice(words);
     },
-    [rememberConversationEntry, ensureVoiceSession, startConversation],
+    [ensureVoiceSession, startConversation],
   );
+
+  // The brain's records, followed for the one edge this window answers: a
+  // typed ask's run ending while this window watched it run. A run already
+  // ended when first seen — the bootstrap after a reload, a launch finding
+  // the last one's interrupted runs — is not spoken, because its words may
+  // already have been said; the thread holds them either way. Subscribed
+  // before the snapshots are read, so no change falls between the two.
+  useEffect(() => {
+    const known = knownRequestsRef.current;
+    const heard = (records: readonly BrainRequestSnapshot[]) => {
+      for (const record of records) {
+        const previous = known.get(record.runId);
+        known.set(record.runId, record.status);
+        if (record.origin !== BRAIN_REQUEST_ORIGIN.TYPED) continue;
+        if (previous === undefined || brainRequestPending(record)) continue;
+        if (!brainRequestPending({ ...record, status: previous })) continue;
+        const words = brainReplyWords(record);
+        if (words) void speakTypedReply(record.runId, words);
+      }
+    };
+    const unsubscribe = window.sidecar.onBrainRequestsChanged(heard);
+    void window.sidecar.brainRequestSnapshots().then((records) => {
+      for (const record of records) {
+        if (!known.has(record.runId)) known.set(record.runId, record.status);
+      }
+    });
+    return unsubscribe;
+  }, [speakTypedReply]);
 
   const discardListening = useCallback(() => {
     talkLatched.current = false;
@@ -1166,21 +1204,14 @@ export function useVoiceSession(remoteAudio: RefObject<HTMLAudioElement | null>)
   // a turn the developer did not.
   useEffect(
     () =>
-      window.sidecar.onVoiceCommand(({ command, text, requestId }) => {
-        if (command === VOICE_COMMAND.ASK_TEXT) {
-          if (text === undefined || requestId === undefined) return;
-          // Answered under the forward's id however the ask ends, so the
-          // composer never waits on a throw for a draft it is owed back.
-          void askLuke(text)
-            .catch((): VoiceCommandOutcome => VOICE_COMMAND_OUTCOME.REFUSED)
-            .then((outcome) => window.sidecar.answerVoiceAsk(requestId, outcome));
-        } else if (command === VOICE_COMMAND.DISCARD_LISTENING) discardListening();
+      window.sidecar.onVoiceCommand(({ command }) => {
+        if (command === VOICE_COMMAND.DISCARD_LISTENING) discardListening();
         else if (command === VOICE_COMMAND.STOP_SPEAKING) voiceSession.current?.stopSpeaking();
         else if (command === VOICE_COMMAND.REQUEST_MICROPHONE_ACCESS)
           void requestMicrophoneAccess();
         else if (command === VOICE_COMMAND.CLEAR_CONVERSATION) clearConversation();
       }),
-    [askLuke, clearConversation, discardListening, requestMicrophoneAccess],
+    [clearConversation, discardListening, requestMicrophoneAccess],
   );
 
   const heardSpeed = useRef<RealtimeVoiceSpeed | undefined>(undefined);

--- a/apps/desktop/src/renderer/voice/use-voice-session.ts
+++ b/apps/desktop/src/renderer/voice/use-voice-session.ts
@@ -670,9 +670,15 @@ export function useVoiceSession(remoteAudio: RefObject<HTMLAudioElement | null>)
    * pending, with its cancel, beside the words actually said.
    */
   const tieSpokenTurnToRun = useCallback(
-    (runId: string) => {
-      const mark = latestSpokenTurnMarkRef.current;
-      if (!mark) return;
+    (mark: SpokenTurnMark | undefined, runId: string) => {
+      // A turn from before a Clear has no line left to tie, and must not
+      // hand its run to whatever the thread now holds in its place.
+      if (
+        !mark ||
+        !spokenAskBelongsToConversation(mark.generation, conversationGenerationRef.current)
+      ) {
+        return;
+      }
       mark.runId = runId;
       if (!mark.entry) return;
       const tied = withConversationEntryRequest(conversationRef.current, mark.entry, runId);
@@ -717,6 +723,10 @@ export function useVoiceSession(remoteAudio: RefObject<HTMLAudioElement | null>)
       // here are not recorded again.
       askBrain: async (question, submissionId): Promise<BrainAskResult> => {
         brainReplyRunRef.current = undefined;
+        // The turn this ask belongs to is the one committed when the ask was
+        // made, read before the acceptance is awaited: a turn committed while
+        // the brain is deciding is somebody else's words.
+        const spokenTurn = latestSpokenTurnMarkRef.current;
         const submitted = await window.sidecar.submitBrainAsk({
           submissionId,
           question,
@@ -728,7 +738,7 @@ export function useVoiceSession(remoteAudio: RefObject<HTMLAudioElement | null>)
             reason: BRAIN_ASK_REFUSAL[submitted.reason],
           };
         }
-        tieSpokenTurnToRun(submitted.runId);
+        tieSpokenTurnToRun(spokenTurn, submitted.runId);
         const record = await window.sidecar.waitBrainAsk(submitted.runId);
         if (!record) {
           return { status: ACT_RESULT_STATUS.REJECTED, reason: BRAIN_ASK_REFUSAL.absent };

--- a/apps/desktop/src/renderer/voice/use-voice-session.ts
+++ b/apps/desktop/src/renderer/voice/use-voice-session.ts
@@ -18,6 +18,7 @@ import {
   retainedConversationEntries,
   storedConversationMaximumAgeMs,
   streamingConversationEntry,
+  withConversationEntryRequest,
 } from "@sidecar/realtime";
 import { SESSION_STATUS, type Session } from "@sidecar/session";
 import { TALK_KEY_RELEASE, talkKeyRelease, voiceHotkeyLabel } from "@sidecar/settings";
@@ -341,6 +342,19 @@ const INITIAL_SURROUNDINGS: VoiceSurroundings = {
 };
 
 /**
+ * Where one spoken turn belongs in the thread, and what it has since become:
+ * the entry its transcript settled into, and the brain run it opened, each
+ * written onto the mark when it is known so the other can find it.
+ */
+interface SpokenTurnMark {
+  after: ConversationEntry | undefined;
+  generation: number;
+  recordedAt: number;
+  entry?: ConversationEntry;
+  runId?: string;
+}
+
+/**
  * The spoken conversation, held in the hidden voice window so no panel does:
  * the session, the microphone, the talk key's latch, the mouth that lets Luke
  * speak into silence, the level meter that ends his turn, and the thread the
@@ -445,20 +459,17 @@ export function useVoiceSession(remoteAudio: RefObject<HTMLAudioElement | null>)
     conversationContextWaitersRef.current.clear();
   }, [surroundings.conversationContextReady]);
   /** Where each server-identified spoken turn belongs when its transcript returns. */
-  const spokenTurnMarksRef = useRef(
-    new Map<
-      string,
-      { after: ConversationEntry | undefined; generation: number; recordedAt: number }
-    >(),
-  );
+  const spokenTurnMarksRef = useRef(new Map<string, SpokenTurnMark>());
   /** Local turn-close marks waiting for the server item ids that name them. */
-  const pendingSpokenTurnMarksRef = useRef<
-    { after: ConversationEntry | undefined; generation: number; recordedAt: number }[]
-  >([]);
+  const pendingSpokenTurnMarksRef = useRef<SpokenTurnMark[]>([]);
   /** The turn opened by the current talk-key press, before it closes. */
-  const activeSpokenTurnMarkRef = useRef<
-    { after: ConversationEntry | undefined; generation: number; recordedAt: number } | undefined
-  >(undefined);
+  const activeSpokenTurnMarkRef = useRef<SpokenTurnMark | undefined>(undefined);
+  /**
+   * The spoken turn whose reply is under way — the one an `ask_brain` call
+   * inside that reply belongs to — so the run it opens can be tied to the
+   * transcript, whichever of the two lands first.
+   */
+  const latestSpokenTurnMarkRef = useRef<SpokenTurnMark | undefined>(undefined);
   /** The generation of the developer-opened turn whose reply is still in flight. */
   const activeReplyGenerationRef = useRef<number | undefined>(undefined);
   /** The History generation in which the current announcement began speaking. */
@@ -555,6 +566,7 @@ export function useVoiceSession(remoteAudio: RefObject<HTMLAudioElement | null>)
     conversationRef.current = [];
     spokenTurnMarksRef.current.clear();
     pendingSpokenTurnMarksRef.current = [];
+    latestSpokenTurnMarkRef.current = undefined;
     setConversationHistory([]);
     // The previews go with the marks: a transcription still arriving belongs
     // to a turn the press just retired.
@@ -634,15 +646,42 @@ export function useVoiceSession(remoteAudio: RefObject<HTMLAudioElement | null>)
         transcript,
         mark.after,
         mark.recordedAt,
+        mark.runId,
       );
       // A transcription that came back empty ended its turn — the preview
       // and the mark are already spent — but placed no line, and a thread
       // that did not change owes the other displays no report.
       if (placed === conversationRef.current) return;
+      // The mark keeps its line, so a run accepted after the transcript can
+      // still be tied to these very words.
+      mark.entry = placed[mark.after ? placed.indexOf(mark.after) + 1 : 0];
       conversationRef.current = placed;
       publishConversation();
     },
     [dropSpokenAskPreview, publishConversation],
+  );
+
+  /**
+   * Ties the brain run a spoken ask opened to the developer's own words for
+   * it — the voice service's transcript, never the mouth's paraphrase of the
+   * question. The transcript may already stand in the thread, in which case
+   * the run is written onto that line; otherwise the mark carries the run to
+   * the transcript when it lands. Either way History can draw the ask as
+   * pending, with its cancel, beside the words actually said.
+   */
+  const tieSpokenTurnToRun = useCallback(
+    (runId: string) => {
+      const mark = latestSpokenTurnMarkRef.current;
+      if (!mark) return;
+      mark.runId = runId;
+      if (!mark.entry) return;
+      const tied = withConversationEntryRequest(conversationRef.current, mark.entry, runId);
+      if (tied === conversationRef.current) return;
+      mark.entry = tied[conversationRef.current.indexOf(mark.entry)];
+      conversationRef.current = tied;
+      publishConversation();
+    },
+    [publishConversation],
   );
 
   const ensureVoiceSession = useCallback((): RealtimeVoiceSession => {
@@ -689,6 +728,7 @@ export function useVoiceSession(remoteAudio: RefObject<HTMLAudioElement | null>)
             reason: BRAIN_ASK_REFUSAL[submitted.reason],
           };
         }
+        tieSpokenTurnToRun(submitted.runId);
         const record = await window.sidecar.waitBrainAsk(submitted.runId);
         if (!record) {
           return { status: ACT_RESULT_STATUS.REJECTED, reason: BRAIN_ASK_REFUSAL.absent };
@@ -725,6 +765,7 @@ export function useVoiceSession(remoteAudio: RefObject<HTMLAudioElement | null>)
       onSpokenAskCommitted: (itemId) => {
         const mark = pendingSpokenTurnMarksRef.current.shift();
         if (mark) spokenTurnMarksRef.current.set(itemId, mark);
+        latestSpokenTurnMarkRef.current = mark;
       },
       onSpokenAskClosed: () => {
         const mark = activeSpokenTurnMarkRef.current;
@@ -773,6 +814,7 @@ export function useVoiceSession(remoteAudio: RefObject<HTMLAudioElement | null>)
     rememberSpokenAsk,
     setVoiceStatus,
     surroundingsNow,
+    tieSpokenTurnToRun,
   ]);
 
   /**

--- a/apps/desktop/src/shared/bridge.test.ts
+++ b/apps/desktop/src/shared/bridge.test.ts
@@ -61,12 +61,53 @@ test("remembered-fact pushes enforce their complete bounded shape", () => {
   );
 });
 
-test("a brain ask is one bounded string and nothing else", () => {
-  assert.equal(BRIDGE.askBrain.kind, "invoke");
-  assert.equal(BRIDGE.askBrain.args(["what needs me?"]), true);
-  assert.equal(BRIDGE.askBrain.args([]), false);
-  assert.equal(BRIDGE.askBrain.args([3]), false);
-  assert.equal(BRIDGE.askBrain.args(["a", "b"]), false);
+test("a brain ask is one submission with an id, bounded words, and an origin", () => {
+  assert.equal(BRIDGE.submitBrainAsk.kind, "invoke");
+  const guard = BRIDGE.submitBrainAsk.args;
+  const submission = { submissionId: "sub-1", question: "what needs me?", origin: "typed" };
+  assert.equal(guard([submission]), true);
+  assert.equal(guard([{ ...submission, origin: "spoken" }]), true);
+  assert.equal(guard([{ ...submission, question: "x".repeat(maximumTypedAskLength) }]), true);
+  assert.equal(guard([{ ...submission, question: "x".repeat(maximumTypedAskLength + 1) }]), false);
+  assert.equal(guard([{ ...submission, submissionId: "" }]), false);
+  assert.equal(guard([{ ...submission, origin: "dreamt" }]), false);
+  assert.equal(guard(["what needs me?"]), false);
+  assert.equal(guard([]), false);
+  const answer = BRIDGE.submitBrainAsk.result;
+  assert.ok(answer);
+  assert.equal(answer({ outcome: "accepted", runId: "run-1", acceptedAt: 1 }), true);
+  assert.equal(answer({ outcome: "rejected", reason: "absent" }), true);
+  assert.equal(answer({ outcome: "rejected", reason: "tired" }), false);
+  assert.equal(answer({ status: "accepted", briefing: "words" }), false);
+});
+
+test("a run is waited on, cancelled, and listed by its own record shape", () => {
+  const snapshot = {
+    runId: "run-1",
+    submissionId: "sub-1",
+    origin: "typed",
+    question: "what needs me?",
+    status: "running",
+    revision: 1,
+    acceptedAt: 1,
+    startedAt: 2,
+    performedActs: 0,
+  };
+  for (const entry of [BRIDGE.waitBrainAsk, BRIDGE.cancelBrainAsk]) {
+    assert.equal(entry.kind, "invoke");
+    assert.equal(entry.args(["run-1"]), true);
+    assert.equal(entry.args([1]), false);
+    assert.ok(entry.result);
+    assert.equal(entry.result(snapshot), true);
+    assert.equal(entry.result(undefined), true);
+    assert.equal(entry.result({ ...snapshot, status: "dreaming" }), false);
+  }
+  assert.equal(BRIDGE.brainRequestSnapshots.args([]), true);
+  assert.ok(BRIDGE.brainRequestSnapshots.result);
+  assert.equal(BRIDGE.brainRequestSnapshots.result([snapshot]), true);
+  assert.equal(BRIDGE.brainRequestSnapshots.result([snapshot, { runId: "x" }]), false);
+  assert.ok(BRIDGE.onBrainRequestsChanged.result);
+  assert.equal(BRIDGE.onBrainRequestsChanged.result([]), true);
 });
 
 test("a reported guide is refused whole when any entry is malformed", () => {
@@ -246,39 +287,30 @@ test("a microphone status broadcast is one of the system's five answers", () => 
   assert.equal(guard(undefined), false);
 });
 
-test("a voice command carries words only for a typed ask, bounded", () => {
+test("a voice command is one of the four commands and carries no words", () => {
   assert.equal(BRIDGE.voiceCommand.kind, "invoke");
   const guard = BRIDGE.voiceCommand.args;
-  assert.equal(guard(["ask-text", "what is checkout doing"]), true);
-  assert.equal(guard(["ask-text", "x".repeat(maximumTypedAskLength)]), true);
-  assert.equal(guard(["ask-text", "x".repeat(maximumTypedAskLength + 1)]), false);
-  assert.equal(guard(["ask-text", undefined]), false);
   for (const command of [
     "discard-listening",
     "stop-speaking",
     "request-microphone-access",
     "clear-conversation",
   ]) {
-    assert.equal(guard([command, undefined]), true);
+    assert.equal(guard([command]), true);
     assert.equal(guard([command, "words"]), false);
   }
-  assert.equal(guard(["stop-microphone", undefined]), false);
-  assert.equal(guard(["stop-speaking"]), false);
+  // A typed ask is a brain submission now, not a command to the voice window.
+  assert.equal(guard(["ask-text"]), false);
+  assert.equal(guard(["stop-microphone"]), false);
+  assert.equal(guard([]), false);
   const forwarded = BRIDGE.onVoiceCommand.result;
   assert.ok(forwarded);
-  assert.equal(forwarded({ command: "ask-text", text: "hello", requestId: "ask-1" }), true);
-  assert.equal(forwarded({ command: "ask-text", text: "hello", requestId: undefined }), false);
-  assert.equal(
-    forwarded({ command: "stop-speaking", text: undefined, requestId: undefined }),
-    true,
-  );
-  assert.equal(forwarded({ command: "stop-speaking", text: "hello", requestId: undefined }), false);
-  assert.equal(forwarded({ command: "stop-speaking", text: undefined, requestId: "ask-1" }), false);
-  assert.equal(forwarded({ command: "ask-text", text: undefined, requestId: "ask-1" }), false);
+  assert.equal(forwarded({ command: "stop-speaking" }), true);
+  assert.equal(forwarded({ command: "ask-text" }), false);
   assert.equal(forwarded({ command: "dance" }), false);
 });
 
-test("a typed ask or a Clear is answered with its outcome, and nothing else is", () => {
+test("a Clear is answered with its outcome, and nothing else is", () => {
   const outcome = BRIDGE.voiceCommand.result;
   assert.ok(outcome);
   assert.equal(outcome("accepted"), true);
@@ -286,12 +318,6 @@ test("a typed ask or a Clear is answered with its outcome, and nothing else is",
   assert.equal(outcome(undefined), true);
   assert.equal(outcome("sent"), false);
   assert.equal(outcome(true), false);
-  assert.equal(BRIDGE.answerVoiceAsk.kind, "send");
-  assert.equal(BRIDGE.answerVoiceAsk.args(["ask-1", "accepted"]), true);
-  assert.equal(BRIDGE.answerVoiceAsk.args(["ask-1", "refused"]), true);
-  assert.equal(BRIDGE.answerVoiceAsk.args(["ask-1", "maybe"]), false);
-  assert.equal(BRIDGE.answerVoiceAsk.args([1, "accepted"]), false);
-  assert.equal(BRIDGE.answerVoiceAsk.args(["ask-1"]), false);
 });
 
 test("shortcut capture is reported as one boolean", () => {

--- a/apps/desktop/src/shared/bridge.test.ts
+++ b/apps/desktop/src/shared/bridge.test.ts
@@ -92,6 +92,7 @@ test("a run is waited on, cancelled, and listed by its own record shape", () => 
     acceptedAt: 1,
     startedAt: 2,
     performedActs: 0,
+    unknownActs: 0,
   };
   for (const entry of [BRIDGE.waitBrainAsk, BRIDGE.cancelBrainAsk]) {
     assert.equal(entry.kind, "invoke");

--- a/apps/desktop/src/shared/bridge.ts
+++ b/apps/desktop/src/shared/bridge.ts
@@ -26,7 +26,6 @@ import { type AppGuideSnapshot, isAppGuideSnapshot } from "@sidecar/guide";
 import type { TrackedIssue } from "@sidecar/issues";
 import {
   type ConversationEntry,
-  maximumTypedAskLength,
   type RealtimeConnection,
   type RealtimeDiagnostics,
   storedConversationEntry,
@@ -70,7 +69,17 @@ import type {
   OutputAudioState,
   VoiceHotkeyState,
 } from "./wire/audio";
-import type { BrainAppActAnswer, BrainAppActRequest, BrainAskResult } from "./wire/brain";
+import {
+  type BrainAppActAnswer,
+  type BrainAppActRequest,
+  type BrainAskSubmission,
+  type BrainAskSubmissionResult,
+  type BrainRequestSnapshot,
+  isBrainAskSubmission,
+  isBrainAskSubmissionResult,
+  isBrainRequestSnapshot,
+  isBrainRequestSnapshotList,
+} from "./wire/brain";
 import {
   type AppBootstrap,
   type ConversationHistoryPayload,
@@ -95,7 +104,6 @@ import {
   isVoiceCommand,
   isVoiceCommandOutcome,
   isVoiceView,
-  VOICE_COMMAND,
   type VoiceCommand,
   type VoiceCommandOutcome,
   type VoiceView,
@@ -478,15 +486,45 @@ export const BRIDGE = {
     result: result<SessionOpenResult>(),
   }),
   /**
-   * A typed ask to Luke's brain, in the developer's own words. The reply comes
-   * back as the words the voice speaks, with the observed sessions it named;
-   * a run with no brain answers a bounded refusal the voice says instead.
+   * One ask submitted to Luke's brain, typed or spoken, in the developer's own
+   * words. The answer is only whether the brain accepted it into a run, and
+   * which run: the reply arrives later, through the run's record. A run with
+   * no brain is refused with a fixed reason the voice can say instead.
    */
-  askBrain: entry({
+  submitBrainAsk: entry({
     kind: "invoke",
-    channel: "app:ask-brain",
+    channel: "app:submit-brain-ask",
+    args: args<[BrainAskSubmission]>((v) => v.length === 1 && isBrainAskSubmission(v[0])),
+    result: result<BrainAskSubmissionResult>(isBrainAskSubmissionResult),
+  }),
+  /**
+   * Waits on one run for as long as the brain's wait allows, answering the
+   * record as it then stands — ended, or still pending — or nothing for a run
+   * the brain does not know.
+   */
+  waitBrainAsk: entry({
+    kind: "invoke",
+    channel: "app:wait-brain-ask",
     args: oneString,
-    result: result<BrainAskResult>(),
+    result: result<BrainRequestSnapshot | undefined>(
+      (v) => v === undefined || isBrainRequestSnapshot(v),
+    ),
+  }),
+  /** Cancels one run the developer no longer wants, answering its record as it then stands. */
+  cancelBrainAsk: entry({
+    kind: "invoke",
+    channel: "app:cancel-brain-ask",
+    args: oneString,
+    result: result<BrainRequestSnapshot | undefined>(
+      (v) => v === undefined || isBrainRequestSnapshot(v),
+    ),
+  }),
+  /** Every run the brain holds, for a window to reconcile against the pushes it already heard. */
+  brainRequestSnapshots: entry({
+    kind: "invoke",
+    channel: "app:brain-request-snapshots",
+    args: noArgs,
+    result: result<readonly BrainRequestSnapshot[]>(isBrainRequestSnapshotList),
   }),
   /**
    * The renderer's guide snapshot, pushed whenever it changes, so the main
@@ -539,38 +577,19 @@ export const BRIDGE = {
     result: result<void>(),
   }),
   /**
-   * A panel's ask of the voice window, carried through the main process, which
-   * validates it and forwards it on `onVoiceCommand`. Only a typed ask carries
-   * a payload — the words themselves, bounded by the same limit the session
-   * applies — and every other command carries none. A typed ask is answered
-   * with whether it reached a conversation, so the composer can keep a refused
-   * draft, and a Clear with whether the stored thread was deleted; the other
-   * commands resolve with nothing.
+   * A panel's command to the voice window, carried through the main process,
+   * which validates it and forwards it on `onVoiceCommand`. A Clear is
+   * answered with whether the stored thread was deleted; the other commands
+   * resolve with nothing. A typed ask is not a command: it goes to the brain
+   * through `submitBrainAsk`, and the voice window hears of the run's end
+   * through its record.
    */
   voiceCommand: entry({
     kind: "invoke",
     channel: "app:voice-command",
-    args: args<[VoiceCommand, string | undefined]>(
-      (v) =>
-        v.length === 2 &&
-        isVoiceCommand(v[0]) &&
-        (v[0] === VOICE_COMMAND.ASK_TEXT
-          ? isWireString(v[1]) && v[1].length <= maximumTypedAskLength
-          : v[1] === undefined),
-    ),
+    args: args<[VoiceCommand]>((v) => v.length === 1 && isVoiceCommand(v[0])),
     result: result<VoiceCommandOutcome | undefined>(
       (v) => v === undefined || isVoiceCommandOutcome(v),
-    ),
-  }),
-  /**
-   * The voice window's answer to one forwarded typed ask, by the request id
-   * the forward carried, so the main process can resolve the panel's invoke.
-   */
-  answerVoiceAsk: entry({
-    kind: "send",
-    channel: "app:answer-voice-ask",
-    args: args<[string, VoiceCommandOutcome]>(
-      (v) => v.length === 2 && isWireString(v[0]) && isVoiceCommandOutcome(v[1]),
     ),
   }),
   /**
@@ -932,20 +951,16 @@ export const BRIDGE = {
     kind: "subscribe",
     channel: "app:voice-command-forwarded",
     args: noArgs,
-    result: result<{
-      command: VoiceCommand;
-      text: string | undefined;
-      requestId: string | undefined;
-    }>(
-      (value) =>
-        isRecord(value) &&
-        isVoiceCommand(value.command) &&
-        (value.command === VOICE_COMMAND.ASK_TEXT
-          ? isWireString(value.text) &&
-            value.text.length <= maximumTypedAskLength &&
-            isWireString(value.requestId)
-          : value.text === undefined && value.requestId === undefined),
+    result: result<{ command: VoiceCommand }>(
+      (value) => isRecord(value) && isVoiceCommand(value.command),
     ),
+  }),
+  /** Every run the brain holds, pushed whole whenever any record changes. */
+  onBrainRequestsChanged: entry({
+    kind: "subscribe",
+    channel: "app:brain-requests-changed",
+    args: noArgs,
+    result: result<readonly BrainRequestSnapshot[]>(isBrainRequestSnapshotList),
   }),
   /**
    * An app act the brain decided that only the renderer can perform, already

--- a/apps/desktop/src/shared/wire/brain.ts
+++ b/apps/desktop/src/shared/wire/brain.ts
@@ -1,21 +1,158 @@
 import type { CarriedAppAction } from "@sidecar/acts";
-import type { ACT_RESULT_STATUS, WireRecord } from "@sidecar/wire";
+import {
+  BRAIN_REQUEST_FAILURE,
+  type BRAIN_REQUEST_ORIGIN,
+  BRAIN_REQUEST_STATUS,
+  BRAIN_SUBMISSION_OUTCOME,
+  BRAIN_SUBMISSION_REJECTION,
+  type BrainRequestRecord,
+  type BrainSubmissionRejection,
+  brainRequestRecordFromWire,
+  isBrainRequestOrigin,
+} from "@sidecar/brain/requests";
+import { maximumTypedAskLength } from "@sidecar/realtime";
+import {
+  type ACT_RESULT_STATUS,
+  isRecord,
+  isWireNumber,
+  isWireString,
+  type UnparsedWireValue,
+  type WireRecord,
+} from "@sidecar/wire";
 
 /**
- * What crosses the bridge between the brain in the main process and the voice
- * in the renderer. The brain decides and acts on its own side; what reaches
- * the renderer is the reply to a developer's ask and the few app acts only a
- * renderer can perform. A briefing travels as a speech offer instead, from
- * the speech arbiter that decides when it may be said.
+ * What crosses the bridge between the brain in the main process and the
+ * windows. The brain decides and acts on its own side; what reaches a
+ * renderer is the record of a run it submitted or is drawing, and the few app
+ * acts only a renderer can perform. A briefing travels as a speech offer
+ * instead, from the speech arbiter that decides when it may be said.
  */
 
+/** One deliberate ask, as a renderer submits it: minted once per submission, so a retry finds the same run. */
+export interface BrainAskSubmission {
+  submissionId: string;
+  question: string;
+  origin: (typeof BRAIN_REQUEST_ORIGIN)[keyof typeof BRAIN_REQUEST_ORIGIN];
+}
+
+export function isBrainAskSubmission(value: UnparsedWireValue): boolean {
+  return (
+    isRecord(value) &&
+    isWireString(value.submissionId) &&
+    value.submissionId.length > 0 &&
+    isWireString(value.question) &&
+    value.question.length <= maximumTypedAskLength &&
+    isBrainRequestOrigin(value.origin)
+  );
+}
+
+/** The answer to a submission, as the bridge carries the brain's own result. */
+export type BrainAskSubmissionResult =
+  | { outcome: typeof BRAIN_SUBMISSION_OUTCOME.ACCEPTED; runId: string; acceptedAt: number }
+  | { outcome: typeof BRAIN_SUBMISSION_OUTCOME.REJECTED; reason: BrainSubmissionRejection };
+
+export function isBrainAskSubmissionResult(value: UnparsedWireValue): boolean {
+  if (!isRecord(value)) return false;
+  if (value.outcome === BRAIN_SUBMISSION_OUTCOME.ACCEPTED) {
+    return isWireString(value.runId) && isWireNumber(value.acceptedAt);
+  }
+  return (
+    value.outcome === BRAIN_SUBMISSION_OUTCOME.REJECTED &&
+    Object.values(BRAIN_SUBMISSION_REJECTION).some((reason) => reason === value.reason)
+  );
+}
+
+/** A run's record as a renderer draws it: the brain's own record, unchanged. */
+export type BrainRequestSnapshot = BrainRequestRecord;
+
+export function isBrainRequestSnapshot(value: UnparsedWireValue): boolean {
+  return brainRequestRecordFromWire(value) !== undefined;
+}
+
+export function isBrainRequestSnapshotList(value: UnparsedWireValue): boolean {
+  return Array.isArray(value) && value.every(isBrainRequestSnapshot);
+}
+
+/** A run the renderer may still cancel: accepted, not yet ended. */
+export function brainRequestPending(snapshot: BrainRequestSnapshot): boolean {
+  return (
+    snapshot.status === BRAIN_REQUEST_STATUS.QUEUED ||
+    snapshot.status === BRAIN_REQUEST_STATUS.RUNNING
+  );
+}
+
 /**
- * What a developer ask comes back with: the reply for the voice to say, or a
- * bounded refusal the voice can say instead — no brain in this build, an ask
- * the deadline outran, a turn that failed.
+ * What a submission's refusal says on the strip, in fixed words: never
+ * composed with the ask, so a refusal can only ever be reported in these.
+ */
+export const BRAIN_ASK_REFUSAL = {
+  [BRAIN_SUBMISSION_REJECTION.ABSENT]:
+    "I can't reach my judgment right now: this build thinks only on an OpenAI key, and none is connected.",
+  [BRAIN_SUBMISSION_REJECTION.EMPTY]: "I didn't catch an ask in that.",
+  [BRAIN_SUBMISSION_REJECTION.PERSISTENCE]:
+    "I couldn't write that ask down, so I haven't taken it. Ask me again in a moment.",
+} as const satisfies Record<BrainSubmissionRejection, string>;
+
+/** What the voice says while a run is still going when its wait ran out. */
+export const BRAIN_ASK_PENDING_NOTE = "I'm still working on that. I'll tell you when it's done.";
+
+function actsPhrase(count: number): string {
+  return count === 1 ? "one thing you asked" : `${count} things you asked`;
+}
+
+/**
+ * The words a run's end leaves in the thread and in the voice's mouth, built
+ * from the record alone. A reply the model reached is said as it stands; an
+ * end without one is worded here in fixed sentences that say what was done
+ * before it, so an act that went through is never reported as nothing having
+ * happened, and a reply that failed to form is never reported as the acts
+ * failing. Nothing a model or a provider wrote enters except the reply text.
+ */
+export function brainReplyWords(snapshot: BrainRequestSnapshot): string | undefined {
+  const done = snapshot.performedActs;
+  switch (snapshot.status) {
+    case BRAIN_REQUEST_STATUS.QUEUED:
+    case BRAIN_REQUEST_STATUS.RUNNING:
+      return undefined;
+    case BRAIN_REQUEST_STATUS.SUCCEEDED:
+      if (snapshot.text) return snapshot.text;
+      return done > 0 ? `Done: I did ${actsPhrase(done)}.` : "I had nothing to add to that.";
+    case BRAIN_REQUEST_STATUS.FAILED:
+      if (snapshot.failure === BRAIN_REQUEST_FAILURE.PERSISTENCE) {
+        const said = snapshot.text ? `${snapshot.text} ` : "";
+        return done > 0
+          ? `${said}I did ${actsPhrase(done)}, but I couldn't save my notes about it.`
+          : `${said}I couldn't save my notes about that ask, so I stopped before doing anything.`;
+      }
+      return done > 0
+        ? `I did ${actsPhrase(done)}, but I couldn't put the reply into words.`
+        : "I couldn't work that one out. Ask me again in a moment.";
+    case BRAIN_REQUEST_STATUS.CANCELLED:
+      return done > 0
+        ? `Cancelled, though ${actsPhrase(done)} had already gone through.`
+        : "Cancelled.";
+    case BRAIN_REQUEST_STATUS.TIMED_OUT:
+      return done > 0
+        ? `That ask ran out of time after ${actsPhrase(done)} had gone through.`
+        : "That ask ran out of time.";
+    case BRAIN_REQUEST_STATUS.INTERRUPTED:
+      return done > 0
+        ? `That ask was interrupted after ${actsPhrase(done)} had gone through.`
+        : "That ask was interrupted before I could finish it.";
+  }
+}
+
+/** The tool output's status when the run is still going: neither an answer nor a refusal. */
+export const BRAIN_ASK_PENDING_STATUS = "pending";
+
+/**
+ * What the voice's `ask_brain` tool comes back with: the reply for the voice
+ * to say, the honest note that the run is still going, or a bounded refusal
+ * the voice can say instead.
  */
 export type BrainAskResult =
   | { status: typeof ACT_RESULT_STATUS.ACCEPTED; briefing: string }
+  | { status: typeof BRAIN_ASK_PENDING_STATUS; note: string }
   | { status: typeof ACT_RESULT_STATUS.REJECTED; reason: string };
 
 /**

--- a/apps/desktop/src/shared/wire/brain.ts
+++ b/apps/desktop/src/shared/wire/brain.ts
@@ -91,6 +91,8 @@ export const BRAIN_ASK_REFUSAL = {
   [BRAIN_SUBMISSION_REJECTION.EMPTY]: "I didn't catch an ask in that.",
   [BRAIN_SUBMISSION_REJECTION.PERSISTENCE]:
     "I couldn't write that ask down, so I haven't taken it. Ask me again in a moment.",
+  [BRAIN_SUBMISSION_REJECTION.CONFLICT]:
+    "That ask arrived under an id I already have for different words. Ask it afresh.",
 } as const satisfies Record<BrainSubmissionRejection, string>;
 
 /** What the voice says while a run is still going when its wait ran out. */
@@ -101,43 +103,65 @@ function actsPhrase(count: number): string {
 }
 
 /**
+ * What the record can vouch for about acts: what went through, and what was
+ * dispatched but never answered — which may have happened, so it is said as
+ * such and never retried on Luke's own initiative.
+ */
+function actsAccount(snapshot: BrainRequestSnapshot): string {
+  const done = snapshot.performedActs;
+  const unsure = snapshot.unknownActs;
+  const parts: string[] = [];
+  if (done > 0) parts.push(`I did ${actsPhrase(done)}`);
+  if (unsure > 0) {
+    parts.push(
+      `${unsure === 1 ? "one act" : `${unsure} acts`} may have gone through without confirming, so I won't repeat ${unsure === 1 ? "it" : "them"} on my own`,
+    );
+  }
+  return parts.join(", and ");
+}
+
+/**
  * The words a run's end leaves in the thread and in the voice's mouth, built
  * from the record alone. A reply the model reached is said as it stands; an
  * end without one is worded here in fixed sentences that say what was done
  * before it, so an act that went through is never reported as nothing having
- * happened, and a reply that failed to form is never reported as the acts
- * failing. Nothing a model or a provider wrote enters except the reply text.
+ * happened, an act nobody confirmed is never reported as refused, and a reply
+ * that failed to form is never reported as the acts failing. Nothing a model
+ * or a provider wrote enters except the reply text.
  */
 export function brainReplyWords(snapshot: BrainRequestSnapshot): string | undefined {
-  const done = snapshot.performedActs;
+  const account = actsAccount(snapshot);
+  const acted = account.length > 0;
+  const said = snapshot.text ? `${snapshot.text} ` : "";
   switch (snapshot.status) {
     case BRAIN_REQUEST_STATUS.QUEUED:
     case BRAIN_REQUEST_STATUS.RUNNING:
       return undefined;
     case BRAIN_REQUEST_STATUS.SUCCEEDED:
-      if (snapshot.text) return snapshot.text;
-      return done > 0 ? `Done: I did ${actsPhrase(done)}.` : "I had nothing to add to that.";
+      if (snapshot.text)
+        return acted && snapshot.unknownActs > 0 ? `${said}${account}.` : snapshot.text;
+      return acted ? `Done: ${account}.` : "I had nothing to add to that.";
     case BRAIN_REQUEST_STATUS.FAILED:
       if (snapshot.failure === BRAIN_REQUEST_FAILURE.PERSISTENCE) {
-        const said = snapshot.text ? `${snapshot.text} ` : "";
-        return done > 0
-          ? `${said}I did ${actsPhrase(done)}, but I couldn't save my notes about it.`
+        return acted
+          ? `${said}${account}, but I couldn't save my notes about it.`
           : `${said}I couldn't save my notes about that ask, so I stopped before doing anything.`;
       }
-      return done > 0
-        ? `I did ${actsPhrase(done)}, but I couldn't put the reply into words.`
+      if (snapshot.failure === BRAIN_REQUEST_FAILURE.INCOMPLETE) {
+        return acted
+          ? `${account}, but I ran out of room before finishing the reply.`
+          : "I ran out of room before finishing that. Ask me again, perhaps in smaller pieces.";
+      }
+      return acted
+        ? `${account}, but I couldn't put the reply into words.`
         : "I couldn't work that one out. Ask me again in a moment.";
     case BRAIN_REQUEST_STATUS.CANCELLED:
-      return done > 0
-        ? `Cancelled, though ${actsPhrase(done)} had already gone through.`
-        : "Cancelled.";
+      return acted ? `Cancelled, though ${account}.` : "Cancelled.";
     case BRAIN_REQUEST_STATUS.TIMED_OUT:
-      return done > 0
-        ? `That ask ran out of time after ${actsPhrase(done)} had gone through.`
-        : "That ask ran out of time.";
+      return acted ? `That ask ran out of time, though ${account}.` : "That ask ran out of time.";
     case BRAIN_REQUEST_STATUS.INTERRUPTED:
-      return done > 0
-        ? `That ask was interrupted after ${actsPhrase(done)} had gone through.`
+      return acted
+        ? `That ask was interrupted, though ${account}.`
         : "That ask was interrupted before I could finish it.";
   }
 }

--- a/apps/desktop/src/shared/wire/voice-view.test.ts
+++ b/apps/desktop/src/shared/wire/voice-view.test.ts
@@ -11,9 +11,10 @@ test("every realtime status is recognized and nothing else is", () => {
   assert.equal(isRealtimeStatus(1), false);
 });
 
-test("the five voice commands are the whole set", () => {
+test("the four voice commands are the whole set; a typed ask is a brain submission, not one", () => {
   const commands = Object.values(VOICE_COMMAND);
-  assert.equal(commands.length, 5);
+  assert.equal(commands.length, 4);
+  assert.equal(isVoiceCommand("ask-text"), false);
   for (const command of commands) assert.equal(isVoiceCommand(command), true);
   assert.equal(isVoiceCommand("stop-microphone"), false);
 });

--- a/apps/desktop/src/shared/wire/voice-view.ts
+++ b/apps/desktop/src/shared/wire/voice-view.ts
@@ -34,7 +34,6 @@ export interface VoiceView {
  * way, because the main process routes it to the voice window directly.
  */
 export const VOICE_COMMAND = {
-  ASK_TEXT: "ask-text",
   DISCARD_LISTENING: "discard-listening",
   STOP_SPEAKING: "stop-speaking",
   REQUEST_MICROPHONE_ACCESS: "request-microphone-access",

--- a/packages/brain/package.json
+++ b/packages/brain/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "type": "module",
   "exports": {
-    ".": "./src/index.js"
+    ".": "./src/index.js",
+    "./requests": "./src/brain-requests.js"
   },
   "types": "./src/index.ts",
   "scripts": {

--- a/packages/brain/src/brain-agent.test.ts
+++ b/packages/brain/src/brain-agent.test.ts
@@ -1915,3 +1915,146 @@ test("a history mark the store refused is not held either, and the next attempt 
   h.storage.failWrites = false;
   assert.equal(await h.agent.markAskRecorded(record.runId, NOW), true);
 });
+
+test("a mark is not visible or acknowledged before its write lands, and marking the same field twice shares one answer", async () => {
+  const h = harness();
+  h.client.answers.push(answered([message("Hi.")]));
+  const record = await ask(h, "hello");
+  assert.ok(record);
+  let releaseWrite: ((written: boolean) => void) | undefined;
+  const storage = h.storage;
+  const write = storage.write.bind(storage);
+  storage.write = (contents) =>
+    // SAFETY: the store accepts a promise of the write's outcome; this test holds it open.
+    new Promise<boolean>((resolve) => {
+      releaseWrite = (written) => resolve(written && write(contents));
+    }) as unknown as boolean;
+  const first = h.agent.markHistoryRecorded(record.runId, NOW + 5);
+  await settle();
+  // Nothing reads the mark while the write is out, and a second caller waits
+  // on the same write rather than being told yes.
+  assert.equal(h.agent.request(record.runId)?.historyRecordedAt, undefined);
+  let secondAnswered = false;
+  const second = h.agent.markHistoryRecorded(record.runId, NOW + 7).then((written) => {
+    secondAnswered = true;
+    return written;
+  });
+  // The ask marker is another field: it stages its own write and touches
+  // nothing of the history marker's.
+  const other = h.agent.markAskRecorded(record.runId, NOW);
+  await settle();
+  assert.equal(secondAnswered, false);
+  storage.write = write;
+  releaseWrite?.(false);
+  assert.deepEqual(await Promise.all([first, second]), [false, false]);
+  assert.equal(h.agent.request(record.runId)?.historyRecordedAt, undefined);
+  assert.equal(h.storage.stored()?.requests[0]?.historyRecordedAt, undefined);
+  // The ask marker's write queued behind the held one and landed on its own
+  // terms once storage answered again: one marker's refusal is not the other's.
+  assert.equal(await other, true);
+  assert.equal(h.agent.request(record.runId)?.askRecordedAt, NOW);
+  // A retry after storage recovers writes the mark, and lands beside fields
+  // that advanced meanwhile rather than over them.
+  assert.equal(await h.agent.markHistoryRecorded(record.runId, NOW + 9), true);
+  const marked = h.agent.request(record.runId);
+  assert.equal(marked?.historyRecordedAt, NOW + 9);
+  assert.equal(marked?.askRecordedAt, NOW);
+  assert.equal(marked?.text, "Hi.");
+  assert.deepEqual(h.storage.stored()?.requests[0], marked);
+});
+
+test("a run's success is seen by no reader before the write that keeps it has landed", async () => {
+  let releaseWrite: ((written: boolean) => void) | undefined;
+  const inner = new FakeClient();
+  inner.answers.push(answered([message("hi")]));
+  const gated = gatedClient(inner);
+  const h = harness({ client: gated.client });
+  await h.agent.ready();
+  const storage = h.storage;
+  const write = storage.write.bind(storage);
+  const runId = acceptedRunId(await submit(h, "hello"));
+  const seen: BrainRequestRecord["status"][] = [];
+  h.agent.subscribe((records) => {
+    const record = records.find((entry) => entry.runId === runId);
+    if (record) seen.push(record.status);
+  });
+  await settle();
+  // Hold the write that would carry the success; the turn's own end
+  // checkpoint lands first, so the held one is the settle.
+  let writes = 0;
+  storage.write = (contents) => {
+    writes += 1;
+    if (writes < 2) return write(contents);
+    // SAFETY: the store accepts a promise of the write's outcome; this test holds it open.
+    return new Promise<boolean>((resolve) => {
+      releaseWrite = (written) => resolve(written && write(contents));
+    }) as unknown as boolean;
+  };
+  gated.open();
+  await settle();
+  assert.ok(releaseWrite, "the settle write is held");
+  // Every public reader still sees the run under way.
+  assert.equal(h.agent.request(runId)?.status, BRAIN_REQUEST_STATUS.RUNNING);
+  assert.equal(h.agent.requests()[0]?.status, BRAIN_REQUEST_STATUS.RUNNING);
+  const waited = h.agent.waitAsk(runId, 1_000);
+  await settle();
+  await h.clock.advance(h.clock.now + 1_000);
+  assert.equal((await waited)?.status, BRAIN_REQUEST_STATUS.RUNNING);
+  assert.ok(!seen.includes(BRAIN_REQUEST_STATUS.SUCCEEDED));
+  assert.equal(h.storage.stored()?.requests[0]?.status, BRAIN_REQUEST_STATUS.RUNNING);
+  // The write fails: the run ends as the persistence failure it is, the reply
+  // kept, and that is the first terminal state anyone sees.
+  storage.write = write;
+  releaseWrite(false);
+  await settle();
+  const ended = h.agent.request(runId);
+  assert.equal(ended?.status, BRAIN_REQUEST_STATUS.FAILED);
+  assert.equal(ended?.failure, BRAIN_REQUEST_FAILURE.PERSISTENCE);
+  assert.equal(ended?.text, "hi");
+  assert.equal(seen.at(-1), BRAIN_REQUEST_STATUS.FAILED);
+  assert.ok(!seen.includes(BRAIN_REQUEST_STATUS.SUCCEEDED));
+  assert.equal(h.storage.stored()?.requests[0]?.status, BRAIN_REQUEST_STATUS.FAILED);
+
+  // The write lands: success is seen only then, and only as success.
+  const okInner = new FakeClient();
+  okInner.answers.push(answered([message("hi")]));
+  const okGate = gatedClient(okInner);
+  const ok = harness({ client: okGate.client });
+  await ok.agent.ready();
+  const okWrite = ok.storage.write.bind(ok.storage);
+  const okRun = acceptedRunId(await submit(ok, "hello"));
+  await settle();
+  let okRelease: (() => void) | undefined;
+  let okWrites = 0;
+  ok.storage.write = (contents) => {
+    okWrites += 1;
+    if (okWrites < 2) return okWrite(contents);
+    // SAFETY: the store accepts a promise of the write's outcome; this test holds it open.
+    return new Promise<boolean>((resolve) => {
+      okRelease = () => resolve(okWrite(contents));
+    }) as unknown as boolean;
+  };
+  okGate.open();
+  await settle();
+  assert.equal(ok.agent.request(okRun)?.status, BRAIN_REQUEST_STATUS.RUNNING);
+  ok.storage.write = okWrite;
+  okRelease?.();
+  await settle();
+  assert.equal(ok.agent.request(okRun)?.status, BRAIN_REQUEST_STATUS.SUCCEEDED);
+  assert.equal(ok.storage.stored()?.requests[0]?.status, BRAIN_REQUEST_STATUS.SUCCEEDED);
+
+  // Disk stays unavailable: the failure still stands in memory for everyone.
+  const darkInner = new FakeClient();
+  darkInner.answers.push(answered([message("hi")]));
+  const darkGate = gatedClient(darkInner);
+  const dark = harness({ client: darkGate.client });
+  await dark.agent.ready();
+  const darkRun = acceptedRunId(await submit(dark, "hello"));
+  await settle();
+  dark.storage.failWrites = true;
+  darkGate.open();
+  await settle();
+  const darkEnd = await dark.agent.waitAsk(darkRun, 1);
+  assert.equal(darkEnd?.status, BRAIN_REQUEST_STATUS.FAILED);
+  assert.equal(darkEnd?.failure, BRAIN_REQUEST_FAILURE.PERSISTENCE);
+});

--- a/packages/brain/src/brain-agent.test.ts
+++ b/packages/brain/src/brain-agent.test.ts
@@ -24,6 +24,7 @@ import {
 import {
   BRAIN_TURN_TRIGGER,
   type BrainActExecution,
+  type BrainActPerformer,
   BrainAgent,
   type BrainAgentOptions,
   type BrainTurnTraceRecord,
@@ -42,8 +43,24 @@ import {
   type BrainWakeEvent,
 } from "./brain-events.js";
 import { BRAIN_INPUT_MARKER } from "./brain-input.js";
-import type { BrainPersistedState } from "./brain-memory.js";
+import { UNKNOWN_ACT_RESULT } from "./brain-journal.js";
 import { RESPONSES_ITEM_TYPE, type ResponsesInputItem } from "./brain-openai.js";
+import {
+  BRAIN_REQUEST_FAILURE,
+  BRAIN_REQUEST_ORIGIN,
+  BRAIN_REQUEST_STATUS,
+  BRAIN_SUBMISSION_OUTCOME,
+  BRAIN_SUBMISSION_REJECTION,
+  type BrainRequestRecord,
+  type BrainSubmissionResult,
+} from "./brain-requests.js";
+import {
+  type BrainPersistedState,
+  type BrainStateStorage,
+  BrainStateStore,
+  brainStateFromStored,
+  freshBrainState,
+} from "./brain-state.js";
 import { BRAIN_TOOL } from "./brain-tools.js";
 
 const NOW = 1_800_000_000_000;
@@ -158,10 +175,42 @@ async function settle(): Promise<void> {
   for (let index = 0; index < 20; index += 1) await new Promise((resolve) => setImmediate(resolve));
 }
 
+/**
+ * Storage a test can break: every write lands in `writes` and is the store's
+ * held file, unless `failWrites` says the disk refused it.
+ */
+class FakeStorage implements BrainStateStorage {
+  file: string | undefined;
+  failWrites = false;
+  writes = 0;
+  constructor(file?: string) {
+    this.file = file;
+  }
+  read() {
+    return this.file;
+  }
+  write(contents: string) {
+    if (this.failWrites) return false;
+    this.writes += 1;
+    this.file = contents;
+    return true;
+  }
+  remove() {
+    this.file = undefined;
+    return true;
+  }
+  /** Every state the file has held, newest last, as the tests read "persisted". */
+  stored(): BrainPersistedState | undefined {
+    return brainStateFromStored(this.file);
+  }
+}
+
 interface Harness {
   agent: BrainAgent;
   client: FakeClient;
   clock: FakeClock;
+  storage: FakeStorage;
+  store: BrainStateStore;
   deliveries: BrainDelivery[];
   persisted: BrainPersistedState[];
   performed: RealtimeFunctionCall[];
@@ -171,11 +220,27 @@ interface Harness {
   wholeReads: SessionIdentity[];
 }
 
-function harness(overrides: Partial<BrainAgentOptions> = {}): Harness {
+let runIds = 0;
+
+function harness(overrides: Partial<BrainAgentOptions> = {}, storage = new FakeStorage()): Harness {
   const client = new FakeClient();
   const clock = new FakeClock();
   const deliveries: BrainDelivery[] = [];
   const persisted: BrainPersistedState[] = [];
+  const store = new BrainStateStore({
+    storage: {
+      read: () => storage.read(),
+      write: (contents) => {
+        const written = storage.write(contents);
+        const state = brainStateFromStored(contents);
+        if (written && state) persisted.push(state);
+        return written;
+      },
+      remove: () => storage.remove(),
+    },
+    createGenerationId: () => `gen-${runIds++}`,
+    now: () => clock.now,
+  });
   const performed: RealtimeFunctionCall[] = [];
   const executions: BrainActExecution[] = [];
   const traces: BrainTurnTraceRecord[] = [];
@@ -208,10 +273,8 @@ function harness(overrides: Partial<BrainAgentOptions> = {}): Harness {
     deliver: (delivery) => {
       deliveries.push(delivery);
     },
-    persist: (state) => {
-      persisted.push(state);
-    },
-    restore: () => undefined,
+    store,
+    createRunId: () => `run-${runIds++}`,
     trace: (record) => {
       traces.push(record);
     },
@@ -226,6 +289,8 @@ function harness(overrides: Partial<BrainAgentOptions> = {}): Harness {
     agent,
     client,
     clock,
+    storage,
+    store,
     deliveries,
     persisted,
     performed,
@@ -234,6 +299,32 @@ function harness(overrides: Partial<BrainAgentOptions> = {}): Harness {
     sinceReads,
     wholeReads,
   };
+}
+
+let submissions = 0;
+
+/** Submits a typed ask and waits as long as it takes, answering the terminal record. */
+async function ask(h: Harness, question: string): Promise<BrainRequestRecord | undefined> {
+  const accepted = await submit(h, question);
+  if (accepted.outcome !== BRAIN_SUBMISSION_OUTCOME.ACCEPTED) return undefined;
+  return h.agent.waitAsk(accepted.runId, 10 * 24 * 60 * 60 * 1000);
+}
+
+function submit(
+  h: Harness,
+  question: string,
+  submissionId?: string,
+): Promise<BrainSubmissionResult> {
+  return h.agent.submitAsk({
+    submissionId: submissionId ?? `submission-${submissions++}`,
+    question,
+    origin: BRAIN_REQUEST_ORIGIN.TYPED,
+  });
+}
+
+function acceptedRunId(result: BrainSubmissionResult): string {
+  assert.equal(result.outcome, BRAIN_SUBMISSION_OUTCOME.ACCEPTED);
+  return result.outcome === BRAIN_SUBMISSION_OUTCOME.ACCEPTED ? result.runId : "";
 }
 
 function itemText(item: ResponsesInputItem | undefined): string {
@@ -338,9 +429,11 @@ test("an ask returns the final text, carries pending wakes, and refuses announce
     ]),
     answered([message("Sent.")]),
   );
-  const answer = await h.agent.ask("tell the checkout agent to run the tests");
+  const answer = await ask(h, "tell the checkout agent to run the tests");
 
-  assert.deepEqual(answer, { text: "Sent." });
+  assert.equal(answer?.status, BRAIN_REQUEST_STATUS.SUCCEEDED);
+  assert.equal(answer?.text, "Sent.");
+  assert.equal(answer?.performedActs, 1);
   assert.deepEqual(h.deliveries, []);
   assert.deepEqual(h.performed, [
     {
@@ -353,10 +446,10 @@ test("an ask returns the final text, carries pending wakes, and refuses announce
     },
   ]);
   const first = h.client.inputs[0] ?? [];
-  const ask = itemText(first[0]);
-  assert.ok(ask.startsWith(`${BRAIN_INPUT_MARKER.DEVELOPER_ASK} `));
-  assert.ok(ask.includes("tell the checkout agent to run the tests"));
-  assert.ok(ask.includes(`${TRANSCRIPT_SECRET} for def`));
+  const opening = itemText(first[0]);
+  assert.ok(opening.startsWith(`${BRAIN_INPUT_MARKER.DEVELOPER_ASK} `));
+  assert.ok(opening.includes("tell the checkout agent to run the tests"));
+  assert.ok(opening.includes(`${TRANSCRIPT_SECRET} for def`));
   assert.equal(h.agent.pendingWakes(), 0);
   assert.equal(h.clock.timers.size, 0);
   const outputs = itemsOfType(h.client.inputs[1] ?? [], RESPONSES_ITEM_TYPE.FUNCTION_CALL_OUTPUT);
@@ -375,27 +468,52 @@ test("an ask returns the final text, carries pending wakes, and refuses announce
   assert.equal(h.executions[0]?.isRevoked(), true);
 });
 
-test("an ask past its deadline answers nothing while the turn still finishes and persists", async () => {
-  const h = harness({ askDeadlineMs: 1_000 });
+test("a wait that runs out answers the run still pending, and the same run finishes once", async () => {
   let release: (() => void) | undefined;
   const gate = new Promise<void>((resolve) => {
     release = resolve;
   });
+  const inner = new FakeClient();
+  inner.answers.push(answered([message("Done at last.")]));
   const slow: BrainClient = {
     respond: async (input, options) => {
       await gate;
-      return h.client.respond(input, options);
+      return inner.respond(input, options);
     },
     quietUntil: () => undefined,
   };
-  const slowHarness = harness({ client: slow, askDeadlineMs: 1_000 });
-  const pending = slowHarness.agent.ask("anything?");
+  const h = harness({ client: slow });
+  const accepted = await submit(h, "anything?", "sub-1");
+  const runId = acceptedRunId(accepted);
   await settle();
-  await slowHarness.clock.advance(NOW + 1_000);
-  assert.equal(await pending, undefined);
+  // The transport retries the same submission: the same run, no second turn.
+  assert.deepEqual(await submit(h, "anything?", "sub-1"), accepted);
+  const firstWait = h.agent.waitAsk(runId, 30_000);
+  await settle();
+  await h.clock.advance(NOW + 30_000);
+  const pending = await firstWait;
+  assert.equal(pending?.status, BRAIN_REQUEST_STATUS.RUNNING);
+  assert.equal(pending?.runId, runId);
+  // A second wait, well past the old 45-second deadline: still the one run.
+  const secondWait = h.agent.waitAsk(runId, 30_000);
+  await settle();
+  await h.clock.advance(NOW + 60_000);
+  assert.equal((await secondWait)?.status, BRAIN_REQUEST_STATUS.RUNNING);
   release?.();
   await settle();
-  assert.equal(slowHarness.persisted.length, 1);
+  const done = await h.agent.waitAsk(runId, 1);
+  assert.equal(done?.status, BRAIN_REQUEST_STATUS.SUCCEEDED);
+  assert.equal(done?.text, "Done at last.");
+  assert.equal(inner.inputs.length, 1);
+  assert.equal(h.agent.requests().length, 1);
+  const stored = h.storage.stored();
+  assert.equal(stored?.requests[0]?.status, BRAIN_REQUEST_STATUS.SUCCEEDED);
+  // The record's own history: queued, running, and succeeded each checkpointed.
+  const statuses = h.persisted.map((state) => state.requests[0]?.status);
+  assert.deepEqual(
+    statuses.filter((status, index) => status !== statuses[index - 1]),
+    [BRAIN_REQUEST_STATUS.QUEUED, BRAIN_REQUEST_STATUS.RUNNING, BRAIN_REQUEST_STATUS.SUCCEEDED],
+  );
 });
 
 test("the tool loop stops at its cap with every call answered, so no function_call dangles", async () => {
@@ -545,13 +663,14 @@ test("a delta longer than its bound is cut from the front and marked truncated",
 
 test("restored memory opens the next turn, and held briefings are re-decided from their own item", async () => {
   const prior = [compaction("cmp_0"), message("earlier")];
-  const h = harness({
-    restore: () => ({
-      version: 1,
+  const storage = new FakeStorage(
+    JSON.stringify({
+      ...freshBrainState("gen-prior", NOW - 1),
       items: prior,
       cursors: { "claude-code": { abc: "old" } },
     }),
-  });
+  );
+  const h = harness({}, storage);
   h.client.answers.push(
     answered([call("call_1", BRAIN_TOOL.ANNOUNCE, { briefing: "Still waiting on you." })]),
     answered([message("")]),
@@ -576,7 +695,10 @@ test("stop drops pending wakes and takes nothing more", async () => {
   assert.equal(h.agent.pendingWakes(), 0);
   await h.clock.advance(NOW + 10_000);
   assert.equal(h.client.inputs.length, 0);
-  assert.equal(await h.agent.ask("hello?"), undefined);
+  assert.deepEqual(await submit(h, "hello?"), {
+    outcome: BRAIN_SUBMISSION_OUTCOME.REJECTED,
+    reason: BRAIN_SUBMISSION_REJECTION.ABSENT,
+  });
 });
 
 test("a roster look carries the roster and only the transcripts that grew", async () => {
@@ -664,13 +786,13 @@ test("a roster look is skipped while the client is quiet or a turn is in flight"
     await slow;
     return respond(input, options);
   };
-  const ask = h.agent.ask("what's up?");
+  const asked = ask(h, "what's up?");
   await settle();
   h.agent.rosterLook();
   await settle();
   assert.equal(h.client.inputs.length, 0);
   release?.();
-  await ask;
+  await asked;
   await settle();
   assert.equal(h.client.inputs.length, 1);
 
@@ -823,7 +945,7 @@ test("a developer ask carries every act with a live execution, revoked once the 
   const [messageAct] = FORBIDDEN_ACTS;
   assert.ok(messageAct);
   h.client.answers.push(answered([messageAct]), answered([message("Done.")]));
-  const asked = h.agent.ask("send it");
+  const asked = ask(h, "send it");
   await settle();
   assert.equal(performedLate.length, 1);
   const [late] = performedLate;
@@ -837,7 +959,399 @@ test("a developer ask carries every act with a live execution, revoked once the 
   release?.();
   await stopping;
   const answer = await asked;
-  assert.equal(answer?.text, "Done.");
-  const outputs = functionOutputs(h.client.inputs[1] ?? []);
+  // The agent stopped under the run: the record says interrupted, and the
+  // refused act's output is paired in memory rather than a second call made.
+  assert.equal(answer?.status, BRAIN_REQUEST_STATUS.INTERRUPTED);
+  assert.equal(h.client.inputs.length, 1);
+  const stored = h.storage.stored();
+  const outputs = functionOutputs(stored?.items ?? []);
   assert.ok(outputs[0]?.output.includes("turn over"));
+});
+
+/** A message act on the observed session `ABC`, under the call id given. */
+function messageAct(callId: string, words = "run the tests"): WireRecord {
+  return call(callId, REALTIME_TOOL.SEND_SESSION_MESSAGE, {
+    provider_id: ABC.providerId,
+    provider_session_id: ABC.providerSessionId,
+    text: words,
+  });
+}
+
+/** A performer whose acts hold until the test releases each one, in order. */
+function heldPerformer() {
+  const releases: (() => void)[] = [];
+  const performed: RealtimeFunctionCall[] = [];
+  const executions: BrainActExecution[] = [];
+  const acts: BrainActPerformer = {
+    perform: async (functionCall, execution): Promise<WireRecord> => {
+      performed.push(functionCall);
+      executions.push(execution);
+      await new Promise<void>((resolve) => {
+        releases.push(resolve);
+      });
+      return execution.isRevoked()
+        ? { status: ACT_RESULT_STATUS.REJECTED, reason: "turn over" }
+        : { status: ACT_RESULT_STATUS.ACCEPTED };
+    },
+  };
+  return { acts, releases, performed, executions };
+}
+
+/** A client whose every answer waits for the test to open the gate. */
+function gatedClient(inner: FakeClient) {
+  let open: (() => void) | undefined;
+  const gate = new Promise<void>((resolve) => {
+    open = resolve;
+  });
+  const client: BrainClient = {
+    respond: async (input, options) => {
+      await gate;
+      return inner.respond(input, options);
+    },
+    quietUntil: () => undefined,
+  };
+  return { client, open: () => open?.() };
+}
+
+test("a queued ask cancelled before its turn never starts, and its record says cancelled", async () => {
+  let release: (() => void) | undefined;
+  const gate = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  const inner = new FakeClient();
+  inner.answers.push(answered([message("first")]), answered([message("second")]));
+  const h = harness({
+    client: {
+      respond: async (input, options) => {
+        await gate;
+        return inner.respond(input, options);
+      },
+      quietUntil: () => undefined,
+    },
+  });
+  const first = acceptedRunId(await submit(h, "first?"));
+  const second = acceptedRunId(await submit(h, "second?"));
+  await settle();
+  const cancelled = await h.agent.cancelAsk(second);
+  assert.equal(cancelled?.status, BRAIN_REQUEST_STATUS.CANCELLED);
+  release?.();
+  await settle();
+  assert.equal((await h.agent.waitAsk(first, 1))?.status, BRAIN_REQUEST_STATUS.SUCCEEDED);
+  assert.equal(inner.inputs.length, 1);
+  assert.equal(h.storage.stored()?.requests[1]?.status, BRAIN_REQUEST_STATUS.CANCELLED);
+  // Cancelling a finished run changes nothing.
+  assert.equal((await h.agent.cancelAsk(first))?.status, BRAIN_REQUEST_STATUS.SUCCEEDED);
+  assert.equal(await h.agent.cancelAsk("no-such-run"), undefined);
+});
+
+test("a cancel while the model is thinking aborts the request and settles the run cancelled", async () => {
+  const signals: (AbortSignal | undefined)[] = [];
+  let reject: ((error: Error) => void) | undefined;
+  const h = harness({
+    client: {
+      respond: (_input, options) => {
+        signals.push(options.signal);
+        return new Promise((_resolve, rejectRespond) => {
+          reject = rejectRespond;
+          options.signal?.addEventListener("abort", () => rejectRespond(new Error("aborted")));
+        });
+      },
+      quietUntil: () => undefined,
+    },
+  });
+  const runId = acceptedRunId(await submit(h, "slow?"));
+  await settle();
+  assert.equal(signals[0]?.aborted, false);
+  const cancelled = await h.agent.cancelAsk(runId);
+  assert.equal(signals[0]?.aborted, true);
+  assert.equal(cancelled?.status, BRAIN_REQUEST_STATUS.RUNNING);
+  await settle();
+  assert.equal(h.agent.request(runId)?.status, BRAIN_REQUEST_STATUS.CANCELLED);
+  assert.equal(h.storage.stored()?.requests[0]?.status, BRAIN_REQUEST_STATUS.CANCELLED);
+  assert.equal(h.storage.stored()?.items.length, 0);
+  assert.ok(reject);
+});
+
+test("a cancel between two acts keeps the first's result and refuses the second, never undoing the first", async () => {
+  const held = heldPerformer();
+  const performed = held.performed;
+  const h = harness({ acts: held.acts });
+  h.client.answers.push(
+    answered([messageAct("call_1", "one"), messageAct("call_2", "two")]),
+    answered([message("Both sent.")]),
+  );
+  const runId = acceptedRunId(await submit(h, "send both"));
+  await settle();
+  assert.equal(performed.length, 1);
+  held.releases[0]?.();
+  await settle();
+  // The first act's result is journaled and checkpointed before the second starts.
+  const journaled = h.storage.stored()?.journal ?? [];
+  assert.equal(journaled.length, 2);
+  assert.ok(journaled[0]?.outputJson?.includes(ACT_RESULT_STATUS.ACCEPTED));
+  assert.equal(journaled[1]?.outputJson, undefined);
+  await h.agent.cancelAsk(runId);
+  held.releases[1]?.();
+  await settle();
+  const record = h.agent.request(runId);
+  assert.equal(record?.status, BRAIN_REQUEST_STATUS.CANCELLED);
+  assert.equal(record?.performedActs, 1);
+  const outputs = functionOutputs(h.storage.stored()?.items ?? []);
+  assert.equal(outputs.length, 2);
+  assert.ok(outputs[0]?.output.includes(ACT_RESULT_STATUS.ACCEPTED));
+  assert.ok(outputs[1]?.output.includes("turn over"));
+  // No follow-up inference ran for a cancelled run.
+  assert.equal(h.client.inputs.length, 1);
+});
+
+test("an act that succeeded survives the follow-up model failing, in the record and in memory", async () => {
+  const h = harness();
+  h.client.answers.push(answered([messageAct("call_1")]), {
+    outcome: BRAIN_CLIENT_OUTCOME.FAILED,
+    reason: "network",
+  });
+  const record = await ask(h, "send it");
+  assert.equal(record?.status, BRAIN_REQUEST_STATUS.FAILED);
+  assert.equal(record?.failure, BRAIN_REQUEST_FAILURE.MODEL);
+  assert.equal(record?.performedActs, 1);
+  assert.equal(record?.text, undefined);
+  assert.equal(h.performed.length, 1);
+  // The call and its output stand in the stored memory, paired, so the next
+  // turn's model sees what was done rather than doing it again.
+  const items = h.storage.stored()?.items ?? [];
+  assert.equal(itemsOfType(items, RESPONSES_ITEM_TYPE.FUNCTION_CALL).length, 1);
+  assert.equal(functionOutputs(items).length, 1);
+  h.client.answers.push(answered([message("As I said, sent.")]));
+  await ask(h, "did you?");
+  const next = h.client.inputs[2] ?? [];
+  assert.equal(itemsOfType(next, RESPONSES_ITEM_TYPE.FUNCTION_CALL).length, 1);
+  assert.equal(h.performed.length, 1);
+});
+
+test("a repeated call id answers the recorded result once; the same id with other arguments is refused", async () => {
+  const h = harness();
+  h.client.answers.push(
+    answered([messageAct("call_1", "one")]),
+    answered([
+      messageAct("call_1", "one"),
+      messageAct("call_1", "changed"),
+      messageAct("call_2", "two"),
+    ]),
+    answered([message("Done.")]),
+  );
+  const record = await ask(h, "send");
+  assert.equal(record?.status, BRAIN_REQUEST_STATUS.SUCCEEDED);
+  assert.deepEqual(
+    h.performed.map((functionCall) => JSON.parse(functionCall.argumentsJson).text),
+    ["one", "two"],
+  );
+  const outputs = functionOutputs(h.client.inputs[2] ?? []);
+  const repeated = outputs.filter((output) => output.callId === "call_1");
+  assert.equal(repeated.length, 3);
+  assert.ok(repeated[1]?.output.includes(ACT_RESULT_STATUS.ACCEPTED));
+  assert.ok(repeated[2]?.output.includes("already used with different arguments"));
+  assert.equal(record?.performedActs, 2);
+});
+
+test("acts run one at a time in the order the model emitted them", async () => {
+  const held = heldPerformer();
+  const order: string[] = [];
+  const h = harness({
+    acts: {
+      perform: async (functionCall, execution) => {
+        order.push(`start ${JSON.parse(functionCall.argumentsJson).text}`);
+        const output = await held.acts.perform(functionCall, execution);
+        order.push(`end ${JSON.parse(functionCall.argumentsJson).text}`);
+        return output;
+      },
+    },
+  });
+  h.client.answers.push(
+    answered([messageAct("c1", "a"), messageAct("c2", "b"), messageAct("c3", "c")]),
+    answered([message("Three sent.")]),
+  );
+  const asked = ask(h, "send three");
+  await settle();
+  assert.deepEqual(order, ["start a"]);
+  held.releases[0]?.();
+  await settle();
+  assert.deepEqual(order, ["start a", "end a", "start b"]);
+  held.releases[1]?.();
+  await settle();
+  held.releases[2]?.();
+  const record = await asked;
+  assert.deepEqual(order, ["start a", "end a", "start b", "end b", "start c", "end c"]);
+  assert.equal(record?.performedActs, 3);
+});
+
+test("a checkpoint that fails before an act refuses it, and acceptance itself needs the record written", async () => {
+  const inner = new FakeClient();
+  inner.answers.push(answered([messageAct("call_1", "one")]), answered([message("Nothing sent.")]));
+  const gated = gatedClient(inner);
+  const h = harness({ client: gated.client });
+  h.storage.failWrites = true;
+  assert.deepEqual(await submit(h, "send"), {
+    outcome: BRAIN_SUBMISSION_OUTCOME.REJECTED,
+    reason: BRAIN_SUBMISSION_REJECTION.PERSISTENCE,
+  });
+  assert.equal(h.agent.requests().length, 0);
+  h.storage.failWrites = false;
+  const runId = acceptedRunId(await submit(h, "send"));
+  await settle();
+  h.storage.failWrites = true;
+  gated.open();
+  await settle();
+  const record = h.agent.request(runId);
+  assert.equal(record?.status, BRAIN_REQUEST_STATUS.FAILED);
+  assert.equal(record?.failure, BRAIN_REQUEST_FAILURE.PERSISTENCE);
+  assert.equal(record?.performedActs, 0);
+  assert.equal(h.performed.length, 0);
+  const refusal = functionOutputs(inner.inputs[1] ?? [])[0];
+  assert.ok(refusal?.output.includes("could not be recorded before running"));
+  // The disk never saw a started act it could mistake for one that ran.
+  assert.equal(h.storage.stored()?.journal.length, 0);
+});
+
+test("a checkpoint that fails after an act keeps its result in memory, blocks further acts, and reports the failure", async () => {
+  let acted = 0;
+  let storage: FakeStorage | undefined;
+  const h = harness({
+    acts: {
+      perform: async (): Promise<WireRecord> => {
+        acted += 1;
+        // The disk goes away from the moment the first effect has happened.
+        if (storage) storage.failWrites = true;
+        return { status: ACT_RESULT_STATUS.ACCEPTED };
+      },
+    },
+  });
+  storage = h.storage;
+  h.client.answers.push(
+    answered([messageAct("call_1", "one"), messageAct("call_2", "two")]),
+    answered([message("Sent.")]),
+  );
+  const record = await ask(h, "send two");
+  assert.equal(acted, 1);
+  assert.equal(record?.status, BRAIN_REQUEST_STATUS.FAILED);
+  assert.equal(record?.failure, BRAIN_REQUEST_FAILURE.PERSISTENCE);
+  assert.equal(record?.performedActs, 1);
+  assert.equal(record?.text, "Sent.");
+  const outputs = functionOutputs(h.client.inputs[1] ?? []);
+  assert.ok(outputs[0]?.output.includes(ACT_RESULT_STATUS.ACCEPTED));
+  assert.ok(outputs[1]?.output.includes("could not be recorded"));
+  // The disk holds the started entry with no result, which a restart reads as unknown.
+  const stored = h.storage.stored();
+  assert.equal(stored?.journal.length, 1);
+  assert.equal(stored?.journal[0]?.outputJson, undefined);
+  assert.equal(stored?.requests[0]?.status, BRAIN_REQUEST_STATUS.RUNNING);
+});
+
+test("a restart marks unfinished runs interrupted and pairs a started act as unknown, never replaying it", async () => {
+  const held = heldPerformer();
+  const h = harness({ acts: held.acts });
+  h.client.answers.push(answered([messageAct("call_1")]), answered([message("Sent.")]));
+  const runId = acceptedRunId(await submit(h, "send"));
+  await settle();
+  // The process dies here: the act has started, its result never recorded.
+  const file = h.storage.file;
+  const stored = brainStateFromStored(file);
+  assert.equal(stored?.requests[0]?.status, BRAIN_REQUEST_STATUS.RUNNING);
+  assert.equal(stored?.journal[0]?.outputJson, undefined);
+  assert.equal(functionOutputs(stored?.items ?? []).length, 0);
+
+  const relaunched = harness({}, new FakeStorage(file));
+  await relaunched.agent.ready();
+  const record = relaunched.agent.request(runId);
+  assert.equal(record?.status, BRAIN_REQUEST_STATUS.INTERRUPTED);
+  assert.equal(relaunched.performed.length, 0);
+  const restored = relaunched.storage.stored();
+  assert.equal(restored?.requests[0]?.status, BRAIN_REQUEST_STATUS.INTERRUPTED);
+  const paired = functionOutputs(restored?.items ?? []);
+  assert.equal(paired.length, 1);
+  assert.ok(paired[0]?.output.includes(UNKNOWN_ACT_RESULT.status));
+  // The next ask opens on a memory with no dangling call, and runs no old act.
+  relaunched.client.answers.push(answered([message("Hello.")]));
+  const next = await ask(relaunched, "hi");
+  assert.equal(next?.status, BRAIN_REQUEST_STATUS.SUCCEEDED);
+  assert.equal(relaunched.performed.length, 0);
+  assert.equal(
+    itemsOfType(relaunched.client.inputs[0] ?? [], RESPONSES_ITEM_TYPE.FUNCTION_CALL_OUTPUT).length,
+    1,
+  );
+  // A wait on the interrupted run answers at once; a wait on an unknown run answers nothing.
+  assert.equal(
+    (await relaunched.agent.waitAsk(runId, 1))?.status,
+    BRAIN_REQUEST_STATUS.INTERRUPTED,
+  );
+  assert.equal(await relaunched.agent.waitAsk("never", 1), undefined);
+});
+
+test("a run past its execution deadline is timed out and its act refused", async () => {
+  const held = heldPerformer();
+  const h = harness({ acts: held.acts, executionDeadlineMs: 60_000 });
+  h.client.answers.push(answered([messageAct("call_1")]), answered([message("Sent.")]));
+  const runId = acceptedRunId(await submit(h, "send"));
+  await settle();
+  await h.clock.advance(NOW + 60_000);
+  held.releases[0]?.();
+  await settle();
+  const record = h.agent.request(runId);
+  assert.equal(record?.status, BRAIN_REQUEST_STATUS.TIMED_OUT);
+  assert.equal(record?.failure, BRAIN_REQUEST_FAILURE.DEADLINE);
+  assert.equal(record?.performedActs, 0);
+  assert.equal(h.client.inputs.length, 1);
+});
+
+test("the store's generation changing under a run revokes it and fences its late checkpoints", async () => {
+  const held = heldPerformer();
+  const h = harness({ acts: held.acts });
+  // Only the act is answered: a revoked run asks the model for no follow-up.
+  h.client.answers.push(answered([messageAct("call_1")]));
+  const runId = acceptedRunId(await submit(h, "send"));
+  await settle();
+  const execution = held.executions[0];
+  assert.equal(execution?.isRevoked(), false);
+  assert.equal(await h.store.reset(), true);
+  assert.equal(execution?.isRevoked(), true);
+  assert.equal(h.agent.requests().length, 0);
+  held.releases[0]?.();
+  await settle();
+  // Nothing of the old generation reached the new envelope.
+  const fresh = h.store.current();
+  assert.equal(fresh?.requests.length, 0);
+  assert.equal(fresh?.items.length, 0);
+  assert.equal(fresh?.journal.length, 0);
+  assert.equal(h.agent.request(runId), undefined);
+  // The new generation takes asks as before.
+  h.client.answers.push(answered([message("Fresh start.")]));
+  assert.equal((await ask(h, "hello"))?.text, "Fresh start.");
+});
+
+test("a spoken submission keeps its origin, and an empty ask is refused without a record", async () => {
+  const h = harness();
+  assert.deepEqual(
+    await h.agent.submitAsk({
+      submissionId: "s",
+      question: "   ",
+      origin: BRAIN_REQUEST_ORIGIN.SPOKEN,
+    }),
+    { outcome: BRAIN_SUBMISSION_OUTCOME.REJECTED, reason: BRAIN_SUBMISSION_REJECTION.EMPTY },
+  );
+  assert.equal(h.agent.requests().length, 0);
+  h.client.answers.push(answered([message("Hi.")]));
+  const accepted = await h.agent.submitAsk({
+    submissionId: "s",
+    question: "hello there",
+    origin: BRAIN_REQUEST_ORIGIN.SPOKEN,
+  });
+  const runId = acceptedRunId(accepted);
+  const heard: (readonly BrainRequestRecord[])[] = [];
+  const unsubscribe = h.agent.subscribe((records) => heard.push(records));
+  const record = await h.agent.waitAsk(runId, 60_000);
+  unsubscribe();
+  assert.equal(record?.origin, BRAIN_REQUEST_ORIGIN.SPOKEN);
+  assert.equal(record?.question, "hello there");
+  assert.ok(heard.length > 0);
+  assert.ok(heard.every((records) => records[0]?.runId === runId));
+  assert.ok((heard.at(-1)?.[0]?.revision ?? 0) > 0);
 });

--- a/packages/brain/src/brain-agent.test.ts
+++ b/packages/brain/src/brain-agent.test.ts
@@ -1698,3 +1698,220 @@ test("a run's history mark is kept once and survives a relaunch", async () => {
   await relaunched.agent.ready();
   assert.equal(relaunched.agent.request(record.runId)?.historyRecordedAt, NOW + 5);
 });
+
+test("work queued behind a held act opens nothing once the generation it was queued in is reset", async () => {
+  const held = heldPerformer();
+  const h = harness({ acts: held.acts });
+  h.client.answers.push(answered([messageAct("call_1")]));
+  await submit(h, "send");
+  await settle();
+  // Every observation kind queues behind the held act: a hold release with an
+  // old briefing, a roster look, a coalesced wake, and a quiet retry's wakes.
+  h.agent.releaseHeld([{ briefing: "OLD_SECRET_QUEUED_BRIEFING", decidedAt: NOW, source: "wake" }]);
+  h.agent.wake([edge(DEF)]);
+  h.agent.rosterLook();
+  await h.clock.advance(NOW + 3_000);
+  assert.equal(await h.store.reset(), true);
+  assert.equal(h.agent.pendingWakes(), 0);
+  held.releases[0]?.();
+  await settle();
+  await h.clock.advance(NOW + 10_000);
+  // The only inference was the held ask's own, in the old generation.
+  assert.equal(h.client.inputs.length, 1);
+  const surface = generationSurface(h, h.client);
+  assert.ok(!surface.includes("OLD_SECRET_QUEUED_BRIEFING"));
+  assert.deepEqual(h.store.current()?.cursors, {});
+  assert.deepEqual(h.deliveries, []);
+  // The new generation still takes fresh work.
+  h.client.answers.push(answered([message("fresh")]));
+  assert.equal((await ask(h, "NEW_ASK"))?.text, "fresh");
+});
+
+test("a briefing is not delivered after a stop or reset that lands during the turn's final write or an earlier delivery", async () => {
+  let releaseWrite: (() => void) | undefined;
+  const h = harness();
+  await h.agent.ready();
+  const storage = h.storage;
+  const write = storage.write.bind(storage);
+  h.client.answers.push(
+    answered([
+      call("a1", BRAIN_TOOL.ANNOUNCE, { briefing: "OLD_STALE_ANNOUNCEMENT" }),
+      call("a2", BRAIN_TOOL.ANNOUNCE, { briefing: "SECOND_STALE_ANNOUNCEMENT" }),
+    ]),
+    answered([message("")]),
+  );
+  storage.write = (contents) =>
+    // SAFETY: the store accepts a promise of the write's outcome; this test holds it open.
+    new Promise<boolean>((resolve) => {
+      releaseWrite = () => resolve(write(contents));
+    }) as unknown as boolean;
+  h.agent.wake([edge(ABC)]);
+  await h.clock.advance(NOW + 3_000);
+  assert.ok(releaseWrite, "the turn is in its final write");
+  const stopping = h.agent.stop();
+  storage.write = write;
+  releaseWrite();
+  await stopping;
+  await settle();
+  assert.deepEqual(h.deliveries, []);
+
+  // A reset between two deliveries withdraws the second.
+  const later = harness({
+    deliver: async (delivery) => {
+      later.deliveries.push(delivery);
+      await later.store.reset();
+    },
+  });
+  later.client.answers.push(
+    answered([
+      call("b1", BRAIN_TOOL.ANNOUNCE, { briefing: "first" }),
+      call("b2", BRAIN_TOOL.ANNOUNCE, { briefing: "second" }),
+    ]),
+    answered([message("")]),
+  );
+  later.agent.wake([edge(ABC)]);
+  await later.clock.advance(NOW + 3_000);
+  assert.deepEqual(
+    later.deliveries.map((delivery) => delivery.briefing),
+    ["first"],
+  );
+});
+
+test("stop settles only after a held acceptance, which the successor then finds interrupted and cannot be written over", async () => {
+  let releaseWrite: (() => void) | undefined;
+  const h = harness();
+  await h.agent.ready();
+  const storage = h.storage;
+  const write = storage.write.bind(storage);
+  storage.write = (contents) =>
+    // SAFETY: the store accepts a promise of the write's outcome; this test holds it open.
+    new Promise<boolean>((resolve) => {
+      releaseWrite = () => resolve(write(contents));
+    }) as unknown as boolean;
+  const pending = submit(h, "send", "sub-1");
+  await settle();
+  let stopped = false;
+  const stopping = h.agent.stop().then(() => {
+    stopped = true;
+  });
+  await settle();
+  assert.equal(stopped, false, "stop waits for the acceptance to settle");
+  storage.write = write;
+  releaseWrite?.();
+  await stopping;
+  assert.equal((await pending).outcome, BRAIN_SUBMISSION_OUTCOME.ACCEPTED);
+  assert.equal(h.agent.requests()[0]?.status, BRAIN_REQUEST_STATUS.INTERRUPTED);
+  assert.equal(h.client.inputs.length, 0);
+
+  // The successor takes the store's lease: the old agent's late checkpoint
+  // — here, a mark — lands nowhere, while the successor's own writes do.
+  const successor = new BrainAgent({
+    client: new FakeClient(),
+    acts: { perform: async () => ({ status: ACT_RESULT_STATUS.ACCEPTED }) },
+    roster: () => ({ text: "", identities: [] }),
+    standingContext: () => "",
+    readTranscriptSince: async () => ({ status: ACT_RESULT_STATUS.REJECTED, reason: "no" }),
+    readTranscript: async () => ({ status: ACT_RESULT_STATUS.REJECTED, reason: "no" }),
+    deliver: () => undefined,
+    store: h.store,
+    createRunId: () => `successor-${runIds++}`,
+    report: () => {},
+    now: () => h.clock.now,
+    schedule: h.clock.schedule,
+    cancel: h.clock.cancel,
+  });
+  await successor.ready();
+  const runId = h.agent.requests()[0]?.runId ?? "";
+  assert.equal(await h.agent.markHistoryRecorded(runId, NOW + 1), false);
+  assert.equal(h.storage.stored()?.requests[0]?.historyRecordedAt, undefined);
+  assert.equal(await successor.markHistoryRecorded(runId, NOW + 1), true);
+  assert.equal(h.storage.stored()?.requests[0]?.historyRecordedAt, NOW + 1);
+  await successor.stop();
+});
+
+test("a copy taken before the second model answer already carries the acts the journal established", async () => {
+  // One accepted act, then a held model call.
+  const inner = new FakeClient();
+  inner.answers.push(answered([messageAct("call_1", "one")]));
+  let release: ((answer: BrainClientAnswer) => void) | undefined;
+  let calls = 0;
+  const client: BrainClient = {
+    respond: (input, options) => {
+      calls += 1;
+      if (calls === 1) return inner.respond(input, options);
+      return new Promise((resolve) => {
+        release = resolve;
+      });
+    },
+    quietUntil: () => undefined,
+  };
+  const h = harness({ client });
+  await submit(h, "send");
+  await settle();
+  assert.ok(release, "the second model call is held");
+  const copy = h.storage.file;
+  const stored = brainStateFromStored(copy);
+  assert.equal(stored?.requests[0]?.status, BRAIN_REQUEST_STATUS.RUNNING);
+  assert.equal(stored?.requests[0]?.performedActs, 1);
+  const relaunched = harness({}, new FakeStorage(copy));
+  await relaunched.agent.ready();
+  const record = relaunched.agent.requests()[0];
+  assert.equal(record?.status, BRAIN_REQUEST_STATUS.INTERRUPTED);
+  assert.equal(record?.performedActs, 1);
+  assert.equal(record?.unknownActs, 0);
+  // A second relaunch of the recovered file says the same.
+  const again = harness({}, new FakeStorage(relaunched.storage.file));
+  await again.agent.ready();
+  assert.equal(again.agent.requests()[0]?.performedActs, 1);
+
+  // One explicitly unknown act, one confirmed refusal, one started-unanswered
+  // act, then the crash: each counted once from the journal.
+  const held = heldPerformer();
+  let dispatched = 0;
+  const mixed = harness({
+    acts: {
+      perform: (functionCall, execution) => {
+        dispatched += 1;
+        if (dispatched === 1) return Promise.reject(new Error("socket closed after send"));
+        if (dispatched === 2) {
+          return Promise.resolve({ status: ACT_RESULT_STATUS.REJECTED, reason: "not observed" });
+        }
+        return held.acts.perform(functionCall, execution);
+      },
+    },
+  });
+  mixed.client.answers.push(
+    answered([messageAct("m1", "one"), messageAct("m2", "two"), messageAct("m3", "three")]),
+  );
+  await submit(mixed, "send three");
+  await settle();
+  const midway = brainStateFromStored(mixed.storage.file);
+  assert.equal(midway?.requests[0]?.unknownActs, 1);
+  assert.equal(midway?.journal.length, 3);
+  const recovered = harness({}, new FakeStorage(mixed.storage.file));
+  await recovered.agent.ready();
+  const mixedRecord = recovered.agent.requests()[0];
+  assert.equal(mixedRecord?.status, BRAIN_REQUEST_STATUS.INTERRUPTED);
+  assert.equal(mixedRecord?.performedActs, 0);
+  assert.equal(mixedRecord?.unknownActs, 2);
+});
+
+test("a history mark the store refused is not held either, and the next attempt writes it", async () => {
+  const h = harness();
+  h.client.answers.push(answered([message("Hi.")]));
+  const record = await ask(h, "hello");
+  assert.ok(record);
+  h.storage.failWrites = true;
+  assert.equal(await h.agent.markHistoryRecorded(record.runId, NOW + 5), false);
+  assert.equal(h.agent.request(record.runId)?.historyRecordedAt, undefined);
+  h.storage.failWrites = false;
+  assert.equal(await h.agent.markHistoryRecorded(record.runId, NOW + 6), true);
+  assert.equal(h.agent.request(record.runId)?.historyRecordedAt, NOW + 6);
+  assert.equal(h.storage.stored()?.requests[0]?.historyRecordedAt, NOW + 6);
+  // The same terms for the ask's own mark.
+  h.storage.failWrites = true;
+  assert.equal(await h.agent.markAskRecorded(record.runId, NOW), false);
+  assert.equal(h.agent.request(record.runId)?.askRecordedAt, undefined);
+  h.storage.failWrites = false;
+  assert.equal(await h.agent.markAskRecorded(record.runId, NOW), true);
+});

--- a/packages/brain/src/brain-agent.test.ts
+++ b/packages/brain/src/brain-agent.test.ts
@@ -2058,3 +2058,141 @@ test("a run's success is seen by no reader before the write that keeps it has la
   assert.equal(darkEnd?.status, BRAIN_REQUEST_STATUS.FAILED);
   assert.equal(darkEnd?.failure, BRAIN_REQUEST_FAILURE.PERSISTENCE);
 });
+
+/** A completed run on a harness whose storage never refuses, for the save-ordering regressions. */
+async function completedRun(h: Harness, question = "hello"): Promise<string> {
+  h.client.answers.push(answered([message("Hi.")]));
+  const record = await ask(h, question);
+  assert.ok(record);
+  return record.runId;
+}
+
+test("two different markers saved concurrently both survive, in either order, on one run or two", async () => {
+  for (const historyFirst of [true, false]) {
+    const h = harness();
+    const runId = await completedRun(h);
+    const marks = [
+      () => h.agent.markHistoryRecorded(runId, NOW + 1),
+      () => h.agent.markAskRecorded(runId, NOW),
+    ];
+    const results = await Promise.all(
+      historyFirst ? marks.map((m) => m()) : marks.reverse().map((m) => m()),
+    );
+    assert.deepEqual(results, [true, true]);
+    const live = h.agent.request(runId);
+    const stored = h.storage.stored()?.requests.find((r) => r.runId === runId);
+    assert.equal(live?.historyRecordedAt, NOW + 1);
+    assert.equal(live?.askRecordedAt, NOW);
+    assert.deepEqual(stored, live);
+  }
+  // Two runs marked at once: each keeps its own.
+  const h = harness();
+  const first = await completedRun(h, "one");
+  const second = await completedRun(h, "two");
+  assert.deepEqual(
+    await Promise.all([
+      h.agent.markHistoryRecorded(first, NOW + 1),
+      h.agent.markHistoryRecorded(second, NOW + 2),
+      h.agent.markAskRecorded(second, NOW),
+    ]),
+    [true, true, true],
+  );
+  assert.deepEqual(h.storage.stored()?.requests, h.agent.requests());
+  assert.equal(h.storage.stored()?.requests[1]?.historyRecordedAt, NOW + 2);
+});
+
+test("an ordinary observation checkpoint composed behind a held mark keeps the mark", async () => {
+  let releaseWrite: (() => void) | undefined;
+  const h = harness();
+  const runId = await completedRun(h);
+  const storage = h.storage;
+  const write = storage.write.bind(storage);
+  storage.write = (contents) => {
+    storage.write = write;
+    // SAFETY: the store accepts a promise of the write's outcome; this test holds it open.
+    return new Promise<boolean>((resolve) => {
+      releaseWrite = () => resolve(write(contents));
+    }) as unknown as boolean;
+  };
+  const marking = h.agent.markHistoryRecorded(runId, NOW + 1);
+  await settle();
+  // Periodic observation races the publication: its inference and checkpoint
+  // queue behind the held mark write.
+  h.client.answers.push(answered([message("noted")]));
+  h.agent.rosterLook();
+  await settle();
+  releaseWrite?.();
+  assert.equal(await marking, true);
+  await settle();
+  assert.equal(h.client.inputs.length, 2);
+  assert.equal(h.agent.request(runId)?.historyRecordedAt, NOW + 1);
+  assert.equal(h.storage.stored()?.requests[0]?.historyRecordedAt, NOW + 1);
+  assert.equal(h.storage.stored()?.items.length, 4);
+});
+
+test("a terminal end and its marks overlapping a new submission and a checkpoint regress nothing", async () => {
+  const inner = new FakeClient();
+  inner.answers.push(answered([messageAct("call_1")]), answered([message("Sent.")]));
+  const gated = gatedClient(inner);
+  const h = harness({ client: gated.client });
+  const first = acceptedRunId(await submit(h, "send"));
+  await settle();
+  gated.open();
+  // While the first run's end and marks are being saved, a second ask is
+  // accepted and an observation wakes: every save composes on the last.
+  const [second, end, marked, askMarked] = await Promise.all([
+    submit(h, "second"),
+    h.agent.waitAsk(first, 60_000),
+    h.agent.waitAsk(first, 60_000).then(() => h.agent.markHistoryRecorded(first, NOW + 9)),
+    h.agent.markAskRecorded(first, NOW),
+  ]);
+  h.agent.wake([edge(ABC)]);
+  await h.clock.advance(h.clock.now + 3_000);
+  assert.equal(second.outcome, BRAIN_SUBMISSION_OUTCOME.ACCEPTED);
+  assert.equal(end?.status, BRAIN_REQUEST_STATUS.SUCCEEDED);
+  assert.deepEqual([marked, askMarked], [true, true]);
+  const stored = h.storage.stored();
+  const kept = stored?.requests.find((r) => r.runId === first);
+  assert.equal(kept?.status, BRAIN_REQUEST_STATUS.SUCCEEDED);
+  assert.equal(kept?.text, "Sent.");
+  assert.equal(kept?.performedActs, 1);
+  assert.equal(kept?.historyRecordedAt, NOW + 9);
+  assert.equal(kept?.askRecordedAt, NOW);
+  assert.equal(stored?.journal[0]?.outputJson?.includes(ACT_RESULT_STATUS.ACCEPTED), true);
+  assert.equal(stored?.requests.length, 2);
+  assert.deepEqual(stored?.requests, h.agent.requests());
+  assert.equal(
+    functionOutputs(stored?.items ?? []).length,
+    itemsOfType(stored?.items ?? [], RESPONSES_ITEM_TYPE.FUNCTION_CALL).length,
+  );
+});
+
+test("a failure among overlapping saves leaves the others kept, and a retry lands beside them", async () => {
+  const h = harness();
+  const runId = await completedRun(h);
+  const storage = h.storage;
+  const write = storage.write.bind(storage);
+  let writes = 0;
+  storage.write = (contents) => {
+    writes += 1;
+    // The second of the overlapping saves is refused.
+    return writes === 2 ? false : write(contents);
+  };
+  const results = await Promise.all([
+    h.agent.markHistoryRecorded(runId, NOW + 1),
+    h.agent.markAskRecorded(runId, NOW),
+  ]);
+  assert.deepEqual(results, [true, false]);
+  storage.write = write;
+  let live = h.agent.request(runId);
+  let stored = h.storage.stored()?.requests[0];
+  assert.equal(live?.historyRecordedAt, NOW + 1);
+  assert.equal(live?.askRecordedAt, undefined);
+  assert.deepEqual(stored, live);
+  assert.equal(await h.agent.markAskRecorded(runId, NOW), true);
+  live = h.agent.request(runId);
+  stored = h.storage.stored()?.requests[0];
+  assert.equal(live?.askRecordedAt, NOW);
+  assert.equal(live?.historyRecordedAt, NOW + 1);
+  assert.deepEqual(stored, live);
+});

--- a/packages/brain/src/brain-agent.test.ts
+++ b/packages/brain/src/brain-agent.test.ts
@@ -1355,3 +1355,346 @@ test("a spoken submission keeps its origin, and an empty ask is refused without 
   assert.ok(heard.every((records) => records[0]?.runId === runId));
   assert.ok((heard.at(-1)?.[0]?.revision ?? 0) > 0);
 });
+
+const OLD_SECRET = "OLD_SECRET_FROM_PRIOR_GENERATION";
+
+/** Everything a later generation could have been polluted through, flattened for a marker search. */
+function generationSurface(h: Harness, inner: FakeClient): string {
+  return JSON.stringify({
+    inputs: inner.inputs.at(-1),
+    stored: h.storage.stored(),
+    held: h.store.current(),
+    deliveries: h.deliveries,
+  });
+}
+
+test("a reset while the model is thinking cannot roll old memory into the new generation", async () => {
+  const inner = new FakeClient();
+  inner.answers.push(answered([message(`noted: ${OLD_SECRET}`)]));
+  const h = harness({ client: inner });
+  assert.equal((await ask(h, `remember ${OLD_SECRET}`))?.status, BRAIN_REQUEST_STATUS.SUCCEEDED);
+  assert.ok(JSON.stringify(h.storage.stored()?.items).includes(OLD_SECRET));
+
+  // A second ask holds its model answer open across the reset.
+  let release: ((answer: BrainClientAnswer) => void) | undefined;
+  inner.respond = (input, options) => {
+    inner.inputs.push([...input]);
+    inner.authorities.push(options.authority);
+    return new Promise((resolve) => {
+      release = resolve;
+    });
+  };
+  const held = acceptedRunId(await submit(h, "and now?"));
+  await settle();
+  assert.equal(await h.store.reset(), true);
+  release?.(answered([message(`late answer about ${OLD_SECRET}`)]));
+  await settle();
+  assert.equal(h.agent.request(held), undefined);
+
+  // The new generation's first ask sees nothing of the old one anywhere.
+  inner.respond = FakeClient.prototype.respond;
+  inner.answers.push(answered([message("fresh")]));
+  assert.equal((await ask(h, "NEW_ASK"))?.text, "fresh");
+  const surface = generationSurface(h, inner);
+  assert.ok(!surface.includes(OLD_SECRET), "old memory reached the new generation");
+  assert.ok(!surface.includes("late answer"));
+  assert.equal(h.storage.stored()?.requests.length, 1);
+  assert.equal(h.storage.stored()?.requests[0]?.question, "NEW_ASK");
+});
+
+test("a reset during a transcript read or an act's result cannot write into the new generation", async () => {
+  // Held delta read on an observation turn.
+  let releaseRead: ((result: ProviderTranscriptSinceResult) => void) | undefined;
+  const h = harness({
+    readTranscriptSince: () =>
+      new Promise((resolve) => {
+        releaseRead = resolve;
+      }),
+  });
+  h.client.answers.push(answered([message("seen")]));
+  h.agent.wake([edge(ABC)]);
+  await h.clock.advance(NOW + 3_000);
+  assert.ok(releaseRead);
+  assert.equal(await h.store.reset(), true);
+  releaseRead({
+    status: ACT_RESULT_STATUS.ACCEPTED,
+    text: OLD_SECRET,
+    cursor: "old-cursor",
+    truncated: false,
+  });
+  await settle();
+  // No inference opened on a withdrawn turn, and the new generation holds no cursor from it.
+  assert.equal(h.client.inputs.length, 0);
+  assert.deepEqual(h.store.current()?.cursors, {});
+  assert.deepEqual(h.deliveries, []);
+
+  // Held act result on a developer run, then a new ask in the new generation.
+  const held = heldPerformer();
+  const acting = harness({ acts: held.acts });
+  acting.client.answers.push(answered([messageAct("call_1", OLD_SECRET)]));
+  const runId = acceptedRunId(await submit(acting, `send ${OLD_SECRET}`));
+  await settle();
+  assert.equal(await acting.store.reset(), true);
+  held.releases[0]?.();
+  await settle();
+  acting.client.answers.push(answered([message("fresh")]));
+  assert.equal((await ask(acting, "NEW_ASK"))?.text, "fresh");
+  const surface = generationSurface(acting, acting.client);
+  assert.ok(!surface.includes(OLD_SECRET));
+  assert.equal(acting.store.current()?.journal.length, 0);
+  assert.equal(acting.agent.request(runId), undefined);
+  assert.equal(acting.client.inputs.length, 2);
+});
+
+test("a retry of a submission whose acceptance is still being written awaits the same answer", async () => {
+  let releaseWrite: ((written: boolean) => void) | undefined;
+  const h = harness();
+  await h.agent.ready();
+  const storage = h.storage;
+  const write = storage.write.bind(storage);
+  storage.write = (contents) =>
+    // SAFETY: the store accepts a promise of the write's outcome; this test holds it open.
+    new Promise<boolean>((resolve) => {
+      releaseWrite = (written) => resolve(written && write(contents));
+    }) as unknown as boolean;
+  h.client.answers.push(answered([message("once")]));
+
+  const first = submit(h, "send", "sub-1");
+  await settle();
+  const retry = submit(h, "send", "sub-1");
+  const other = submit(h, "send", "sub-1").then(() => h.agent.requests().length);
+  await settle();
+  // Nobody has been told anything yet, and no run stands to be found.
+  assert.equal(h.agent.requests().length, 0);
+  // The write refuses: every caller hears the same refusal, and no run remains.
+  storage.write = write;
+  releaseWrite?.(false);
+  const answers = await Promise.all([first, retry]);
+  assert.deepEqual(answers, [
+    { outcome: BRAIN_SUBMISSION_OUTCOME.REJECTED, reason: BRAIN_SUBMISSION_REJECTION.PERSISTENCE },
+    { outcome: BRAIN_SUBMISSION_OUTCOME.REJECTED, reason: BRAIN_SUBMISSION_REJECTION.PERSISTENCE },
+  ]);
+  assert.equal(await other, 0);
+  assert.equal(h.agent.requests().length, 0);
+
+  // The write lands: both callers hear the one run, which executes once.
+  const accepted = await Promise.all([submit(h, "send", "sub-1"), submit(h, "send", "sub-1")]);
+  assert.equal(accepted[0]?.outcome, BRAIN_SUBMISSION_OUTCOME.ACCEPTED);
+  assert.deepEqual(accepted[0], accepted[1]);
+  await settle();
+  assert.equal(h.client.inputs.length, 1);
+  assert.equal(h.agent.requests().length, 1);
+  // The same id with other words, or another origin, is a conflict, not a retry.
+  assert.deepEqual(await submit(h, "send something else", "sub-1"), {
+    outcome: BRAIN_SUBMISSION_OUTCOME.REJECTED,
+    reason: BRAIN_SUBMISSION_REJECTION.CONFLICT,
+  });
+  assert.equal(
+    (
+      await h.agent.submitAsk({
+        submissionId: "sub-1",
+        question: "send",
+        origin: BRAIN_REQUEST_ORIGIN.SPOKEN,
+      })
+    ).outcome,
+    BRAIN_SUBMISSION_OUTCOME.REJECTED,
+  );
+});
+
+test("a stop while an acceptance is being written interrupts the run it accepted", async () => {
+  let releaseWrite: (() => void) | undefined;
+  const h = harness();
+  await h.agent.ready();
+  const storage = h.storage;
+  const write = storage.write.bind(storage);
+  storage.write = (contents) =>
+    // SAFETY: the store accepts a promise of the write's outcome; this test holds it open.
+    new Promise<boolean>((resolve) => {
+      releaseWrite = () => resolve(write(contents));
+    }) as unknown as boolean;
+  const pending = submit(h, "send", "sub-1");
+  await settle();
+  const stopping = h.agent.stop();
+  storage.write = write;
+  releaseWrite?.();
+  const accepted = await pending;
+  await stopping;
+  assert.equal(accepted.outcome, BRAIN_SUBMISSION_OUTCOME.ACCEPTED);
+  await settle();
+  const record = h.agent.requests()[0];
+  assert.equal(record?.status, BRAIN_REQUEST_STATUS.INTERRUPTED);
+  assert.equal(h.client.inputs.length, 0);
+});
+
+test("a cancel, a deadline, or a stop settles a held read at once, and the next ask proceeds", async () => {
+  const reads: ((result: ProviderTranscriptResult) => void)[] = [];
+  const deltas: ((result: ProviderTranscriptSinceResult) => void)[] = [];
+  const h = harness({
+    executionDeadlineMs: 60_000,
+    readTranscript: () =>
+      new Promise((resolve) => {
+        reads.push(resolve);
+      }),
+    readTranscriptSince: () =>
+      new Promise((resolve) => {
+        deltas.push(resolve);
+      }),
+  });
+  // Cancel while a full read is out: the run settles without waiting on it.
+  h.client.answers.push(
+    answered([
+      call("read_1", BRAIN_TOOL.READ_TRANSCRIPT, {
+        provider_id: ABC.providerId,
+        provider_session_id: ABC.providerSessionId,
+      }),
+    ]),
+  );
+  const first = acceptedRunId(await submit(h, "read it"));
+  await settle();
+  assert.equal(reads.length, 1);
+  await h.agent.cancelAsk(first);
+  await settle();
+  assert.equal(h.agent.request(first)?.status, BRAIN_REQUEST_STATUS.CANCELLED);
+  assert.equal(h.client.inputs.length, 1);
+
+  // Deadline while the opening delta read is out: no inference follows it.
+  h.agent.wake([edge(DEF)]);
+  h.client.answers.push(answered([message("never sent")]));
+  const second = acceptedRunId(await submit(h, "and this?"));
+  await settle();
+  assert.equal(deltas.length, 1);
+  await h.clock.advance(NOW + 60_000);
+  await settle();
+  assert.equal(h.agent.request(second)?.status, BRAIN_REQUEST_STATUS.TIMED_OUT);
+  assert.equal(h.client.inputs.length, 1);
+  // The late read lands on nothing: no cursor, no inference.
+  deltas[0]?.({ status: ACT_RESULT_STATUS.ACCEPTED, text: "late", cursor: "c", truncated: false });
+  reads[0]?.({ status: ACT_RESULT_STATUS.ACCEPTED, transcript: "late" });
+  await settle();
+  assert.deepEqual(h.storage.stored()?.cursors, {});
+  assert.equal(h.client.inputs.length, 1);
+
+  // The next valid ask runs on the same queue without waiting on either read.
+  h.client.answers.shift();
+  h.client.answers.push(answered([message("proceeding")]));
+  assert.equal((await ask(h, "still there?"))?.text, "proceeding");
+
+  // A stop settles a held read too, and the queue drains behind it.
+  h.agent.wake([edge(ABC)]);
+  await h.clock.advance(NOW + 70_000);
+  assert.equal(deltas.length, 2);
+  await h.agent.stop();
+});
+
+test("a performer that throws after dispatch leaves an unknown act, kept through a later model failure and a restart", async () => {
+  const h = harness({
+    acts: {
+      perform: () => Promise.reject(new Error("socket closed after send")),
+    },
+  });
+  h.client.answers.push(answered([messageAct("call_1")]), {
+    outcome: BRAIN_CLIENT_OUTCOME.FAILED,
+    reason: "network",
+  });
+  const record = await ask(h, "send it");
+  assert.equal(record?.status, BRAIN_REQUEST_STATUS.FAILED);
+  assert.equal(record?.failure, BRAIN_REQUEST_FAILURE.MODEL);
+  assert.equal(record?.performedActs, 0);
+  assert.equal(record?.unknownActs, 1);
+  const journaled = h.storage.stored()?.journal[0];
+  assert.ok(journaled?.outputJson?.includes(UNKNOWN_ACT_RESULT.status));
+  assert.ok(!journaled?.outputJson?.includes(ACT_RESULT_STATUS.REJECTED));
+  // The model reads the unknown, not a refusal, and the journal answers the
+  // same call id with it rather than dispatching again.
+  const outputs = functionOutputs(h.storage.stored()?.items ?? []);
+  assert.ok(outputs[0]?.output.includes("may have happened"));
+
+  const relaunched = harness({}, new FakeStorage(h.storage.file));
+  await relaunched.agent.ready();
+  assert.equal(relaunched.agent.requests()[0]?.unknownActs, 1);
+
+  // A confirmed refusal, by contrast, is a refusal: nothing unknown about it.
+  const refusing = harness({
+    acts: {
+      perform: async () => ({ status: ACT_RESULT_STATUS.REJECTED, reason: "not observed" }),
+    },
+  });
+  refusing.client.answers.push(answered([messageAct("call_1")]), answered([message("Refused.")]));
+  const refused = await ask(refusing, "send it");
+  assert.equal(refused?.status, BRAIN_REQUEST_STATUS.SUCCEEDED);
+  assert.equal(refused?.unknownActs, 0);
+  assert.equal(refused?.performedActs, 0);
+});
+
+test("an interrupted run's started acts are counted unknown at the next launch", async () => {
+  const held = heldPerformer();
+  const h = harness({ acts: held.acts });
+  h.client.answers.push(answered([messageAct("call_1")]));
+  await submit(h, "send");
+  await settle();
+  const relaunched = harness({}, new FakeStorage(h.storage.file));
+  await relaunched.agent.ready();
+  const record = relaunched.agent.requests()[0];
+  assert.equal(record?.status, BRAIN_REQUEST_STATUS.INTERRUPTED);
+  assert.equal(record?.unknownActs, 1);
+  assert.equal(record?.performedActs, 0);
+});
+
+test("an incomplete reply, a spent tool budget, and a failed final checkpoint are not reported as success", async () => {
+  const h = harness({ maxToolIterations: 1 });
+  h.client.answers.push({
+    outcome: BRAIN_CLIENT_OUTCOME.ANSWERED,
+    payload: {
+      output: [],
+      status: "incomplete",
+      incomplete_details: { reason: "max_output_tokens" },
+    },
+  });
+  const incomplete = await ask(h, "explain");
+  assert.equal(incomplete?.status, BRAIN_REQUEST_STATUS.FAILED);
+  assert.equal(incomplete?.failure, BRAIN_REQUEST_FAILURE.INCOMPLETE);
+
+  h.client.answers.push(
+    answered([messageAct("call_1")]),
+    answered([messageAct("call_2", "again")]),
+  );
+  const spent = await ask(h, "send twice");
+  assert.equal(spent?.status, BRAIN_REQUEST_STATUS.FAILED);
+  assert.equal(spent?.failure, BRAIN_REQUEST_FAILURE.INCOMPLETE);
+  assert.equal(spent?.performedActs, 1);
+  // Every call is still paired in the stored memory.
+  const items = h.storage.stored()?.items ?? [];
+  assert.equal(
+    itemsOfType(items, RESPONSES_ITEM_TYPE.FUNCTION_CALL).length,
+    functionOutputs(items).length,
+  );
+
+  // Only the final checkpoint fails: the reply travels, but not as a success.
+  const late = harness();
+  late.client.answers.push(answered([message("Done.")]));
+  const original = late.storage.write.bind(late.storage);
+  let writes = 0;
+  late.storage.write = (contents) => {
+    writes += 1;
+    // Acceptance, running, and the turn's end land; the settle does not.
+    return writes >= 4 ? false : original(contents);
+  };
+  const record = await ask(late, "hello");
+  assert.equal(record?.status, BRAIN_REQUEST_STATUS.FAILED);
+  assert.equal(record?.failure, BRAIN_REQUEST_FAILURE.PERSISTENCE);
+  assert.equal(record?.text, "Done.");
+});
+
+test("a run's history mark is kept once and survives a relaunch", async () => {
+  const h = harness();
+  h.client.answers.push(answered([message("Hi.")]));
+  const record = await ask(h, "hello");
+  assert.ok(record);
+  assert.equal(record.historyRecordedAt, undefined);
+  await h.agent.markHistoryRecorded(record.runId, NOW + 5);
+  await h.agent.markHistoryRecorded(record.runId, NOW + 9);
+  assert.equal(h.agent.request(record.runId)?.historyRecordedAt, NOW + 5);
+  const relaunched = harness({}, new FakeStorage(h.storage.file));
+  await relaunched.agent.ready();
+  assert.equal(relaunched.agent.request(record.runId)?.historyRecordedAt, NOW + 5);
+});

--- a/packages/brain/src/brain-agent.test.ts
+++ b/packages/brain/src/brain-agent.test.ts
@@ -53,6 +53,7 @@ import {
   BRAIN_SUBMISSION_REJECTION,
   type BrainRequestRecord,
   type BrainSubmissionResult,
+  isTerminalBrainRequestStatus,
 } from "./brain-requests.js";
 import {
   type BrainPersistedState,
@@ -2363,4 +2364,116 @@ test("an observation in flight is not made durable by an unrelated mark or accep
     brainStateFromStored(observing.storage.file)?.cursors["claude-code"]?.abc,
     "abc-cursor",
   );
+});
+
+test("a run whose start the store refuses opens no work and ends as a persistence failure", async () => {
+  const h = harness({
+    acts: { perform: async () => ({ status: ACT_RESULT_STATUS.ACCEPTED }) },
+  });
+  await h.agent.ready();
+  h.client.answers.push(answered([messageAct("call_1")]), answered([message("Sent.")]));
+  const write = h.storage.write.bind(h.storage);
+  h.storage.write = (contents) => {
+    if (contents.includes(`"status":"${BRAIN_REQUEST_STATUS.RUNNING}"`)) {
+      h.storage.write = write;
+      return false;
+    }
+    return write(contents);
+  };
+  const runId = acceptedRunId(await submit(h, "send"));
+  const record = await h.agent.waitAsk(runId, 60_000);
+  assert.equal(record?.status, BRAIN_REQUEST_STATUS.FAILED);
+  assert.equal(record?.failure, BRAIN_REQUEST_FAILURE.PERSISTENCE);
+  assert.equal(record?.performedActs, 0);
+  assert.equal(h.client.inputs.length, 0, "no model call");
+  assert.deepEqual(h.performed, []);
+  assert.deepEqual(h.storage.stored()?.requests[0], record);
+  assert.equal(h.agent.requests().length, 1);
+  const relaunched = harness({}, new FakeStorage(h.storage.file));
+  await relaunched.agent.ready();
+  assert.deepEqual(relaunched.agent.requests()[0], record);
+});
+
+/** Holds the first storage write whose contents match, until released; every other write passes. */
+function holdWriteMatching(storage: FakeStorage, marker: string) {
+  const write = storage.write.bind(storage);
+  let release: ((written?: boolean) => void) | undefined;
+  storage.write = (contents) => {
+    if (!contents.includes(marker)) return write(contents);
+    storage.write = write;
+    // SAFETY: the store accepts a promise of the write's outcome; this test holds it open.
+    return new Promise<boolean>((resolve) => {
+      release = (written = true) => resolve(written && write(contents));
+    }) as unknown as boolean;
+  };
+  return {
+    held: () => release !== undefined,
+    release: (written?: boolean) => release?.(written),
+  };
+}
+
+const RUNNING_MARKER = `"status":"${BRAIN_REQUEST_STATUS.RUNNING}"`;
+
+test("a cancel or stop landing while the start is being written ends the run unopened, and work starts only once the start has landed", async () => {
+  // Cancel during the held start write.
+  const cancelling = harness();
+  await cancelling.agent.ready();
+  cancelling.client.answers.push(answered([messageAct("call_1")]));
+  const heldStart = holdWriteMatching(cancelling.storage, RUNNING_MARKER);
+  const runId = acceptedRunId(await submit(cancelling, "send"));
+  await settle();
+  assert.equal(heldStart.held(), true);
+  const cancelled = cancelling.agent.cancelAsk(runId);
+  await settle();
+  heldStart.release(true);
+  await cancelled;
+  await settle();
+  assert.equal(cancelling.agent.request(runId)?.status, BRAIN_REQUEST_STATUS.CANCELLED);
+  assert.equal(cancelling.client.inputs.length, 0);
+  assert.deepEqual(cancelling.performed, []);
+  assert.deepEqual(cancelling.storage.stored()?.requests[0], cancelling.agent.request(runId));
+
+  // Stop during a start that is then refused.
+  const stopping = harness();
+  await stopping.agent.ready();
+  stopping.client.answers.push(answered([messageAct("call_1")]));
+  const refusedStart = holdWriteMatching(stopping.storage, RUNNING_MARKER);
+  const stopRun = acceptedRunId(await submit(stopping, "send"));
+  await settle();
+  assert.equal(refusedStart.held(), true);
+  const stopped = stopping.agent.stop();
+  refusedStart.release(false);
+  await stopped;
+  assert.equal(stopping.agent.request(stopRun)?.status, BRAIN_REQUEST_STATUS.INTERRUPTED);
+  assert.equal(stopping.client.inputs.length, 0);
+  assert.deepEqual(stopping.performed, []);
+
+  // Positive control: the model is called only after the start has landed,
+  // and a cancel over a dispatched act still waits to publish the counted end.
+  const held = heldPerformer();
+  const h = harness({ acts: held.acts });
+  await h.agent.ready();
+  h.client.answers.push(answered([messageAct("call_1")]));
+  const start = holdWriteMatching(h.storage, RUNNING_MARKER);
+  const live = acceptedRunId(await submit(h, "send"));
+  await settle();
+  assert.equal(start.held(), true);
+  assert.equal(h.client.inputs.length, 0);
+  start.release(true);
+  await settle();
+  assert.equal(h.client.inputs.length, 1);
+  assert.equal(held.performed.length, 1);
+  const cancelledLate = await h.agent.cancelAsk(live);
+  assert.equal(cancelledLate?.status, BRAIN_REQUEST_STATUS.RUNNING);
+  const seen: BrainRequestRecord[] = [];
+  h.agent.subscribe((records) => {
+    const record = records.find((entry) => entry.runId === live);
+    if (record && isTerminalBrainRequestStatus(record.status)) seen.push(record);
+  });
+  held.releases[0]?.();
+  await settle();
+  assert.equal(seen.length, 1);
+  assert.equal(seen[0]?.status, BRAIN_REQUEST_STATUS.CANCELLED);
+  assert.equal(seen[0]?.performedActs, 0);
+  assert.deepEqual(h.storage.stored()?.requests[0], h.agent.request(live));
 });

--- a/packages/brain/src/brain-agent.test.ts
+++ b/packages/brain/src/brain-agent.test.ts
@@ -2196,3 +2196,171 @@ test("a failure among overlapping saves leaves the others kept, and a retry land
   assert.equal(live?.historyRecordedAt, NOW + 1);
   assert.deepEqual(stored, live);
 });
+
+/** Holds the next storage write until released, answering true; later writes pass through. */
+function holdNextWrite(storage: FakeStorage) {
+  const write = storage.write.bind(storage);
+  let release: ((written?: boolean) => void) | undefined;
+  storage.write = (contents) => {
+    storage.write = write;
+    // SAFETY: the store accepts a promise of the write's outcome; this test holds it open.
+    return new Promise<boolean>((resolve) => {
+      release = (written = true) => resolve(written && write(contents));
+    }) as unknown as boolean;
+  };
+  return { release: (written?: boolean) => release?.(written) };
+}
+
+test("a refused acceptance is never saved by an unrelated mark, and never comes back at relaunch", async () => {
+  const h = harness();
+  const a = await completedRun(h, "s");
+  const held = holdNextWrite(h.storage);
+  const firstMark = h.agent.markHistoryRecorded(a, NOW + 1);
+  await settle();
+  const secondMark = h.agent.markAskRecorded(a, NOW);
+  // B is provisional while its own acceptance write waits behind the marks.
+  const rejectedB = submit(h, "ASK_THAT_WAS_REJECTED", "rejected-b");
+  await settle();
+  // Behind the held write: A's second mark lands, B's own write is refused.
+  const write = h.storage.write.bind(h.storage);
+  let later = 0;
+  h.storage.write = (contents) => {
+    later += 1;
+    return later === 2 ? false : write(contents);
+  };
+  held.release(true);
+  const [first, second, b] = await Promise.all([firstMark, secondMark, rejectedB]);
+  h.storage.write = write;
+  assert.deepEqual([first, second], [true, true]);
+  assert.deepEqual(b, {
+    outcome: BRAIN_SUBMISSION_OUTCOME.REJECTED,
+    reason: BRAIN_SUBMISSION_REJECTION.PERSISTENCE,
+  });
+  await settle();
+  assert.equal(h.client.inputs.length, 1, "no effect ran for the refused ask");
+  assert.deepEqual(
+    h.agent.requests().map((r) => r.runId),
+    [a],
+  );
+  assert.deepEqual(
+    h.storage.stored()?.requests.map((r) => r.runId),
+    [a],
+  );
+  assert.equal(h.storage.stored()?.requests[0]?.historyRecordedAt, NOW + 1);
+  assert.equal(h.storage.stored()?.requests[0]?.askRecordedAt, NOW);
+  const relaunched = harness({}, new FakeStorage(h.storage.file));
+  await relaunched.agent.ready();
+  assert.deepEqual(
+    relaunched.agent.requests().map((r) => r.submissionId),
+    ["submission-" + (submissions - 3)].map(() => relaunched.agent.requests()[0]?.submissionId),
+  );
+  assert.equal(relaunched.agent.requests().length, 1);
+  assert.ok(!JSON.stringify(relaunched.storage.file).includes("rejected-b"));
+  // The refused submission retried lands as a fresh acceptance, once.
+  relaunched.client.answers.push(answered([message("now")]));
+  const retried = await relaunched.agent.submitAsk({
+    submissionId: "rejected-b",
+    question: "ASK_THAT_WAS_REJECTED",
+    origin: BRAIN_REQUEST_ORIGIN.TYPED,
+  });
+  assert.equal(retried.outcome, BRAIN_SUBMISSION_OUTCOME.ACCEPTED);
+  await settle();
+  assert.equal(relaunched.storage.stored()?.requests.length, 2);
+});
+
+test("two overlapping submissions, one refused, leave no ghost run and execute the accepted one once", async () => {
+  const h = harness();
+  await h.agent.ready();
+  const write = h.storage.write.bind(h.storage);
+  let writes = 0;
+  h.storage.write = (contents) => {
+    writes += 1;
+    return writes === 2 ? false : write(contents);
+  };
+  h.client.answers.push(answered([message("one")]), answered([message("two")]));
+  const [first, second] = await Promise.all([submit(h, "first", "a"), submit(h, "second", "b")]);
+  h.storage.write = write;
+  assert.equal(first.outcome, BRAIN_SUBMISSION_OUTCOME.ACCEPTED);
+  assert.deepEqual(second, {
+    outcome: BRAIN_SUBMISSION_OUTCOME.REJECTED,
+    reason: BRAIN_SUBMISSION_REJECTION.PERSISTENCE,
+  });
+  await settle();
+  assert.equal(h.client.inputs.length, 1);
+  assert.deepEqual(
+    h.storage.stored()?.requests.map((r) => r.submissionId),
+    ["a"],
+  );
+  assert.deepEqual(
+    h.agent.requests().map((r) => r.submissionId),
+    ["a"],
+  );
+  // The refused one retried is a fresh run, and the accepted one ran once.
+  assert.equal((await submit(h, "second", "b")).outcome, BRAIN_SUBMISSION_OUTCOME.ACCEPTED);
+  await settle();
+  assert.equal(h.client.inputs.length, 2);
+  assert.deepEqual(
+    h.storage.stored()?.requests.map((r) => r.submissionId),
+    ["a", "b"],
+  );
+});
+
+test("an observation in flight is not made durable by an unrelated mark or acceptance, and its failed delta is reread", async () => {
+  const inner = new FakeClient();
+  const gated = gatedClient(inner);
+  const h = harness({ client: gated.client });
+  // A completed run, answered before the gate closes on the observation.
+  gated.open();
+  const a = await completedRun(h, "hello");
+  const regate = gatedClient(inner);
+  // Swap the client for the observation only.
+  const observing = harness({ client: regate.client }, h.storage);
+  await observing.agent.ready();
+  // The pending wake rides in the hold release's turn: one observation that
+  // reads a real delta, moves a cursor, and then waits on the model.
+  observing.agent.wake([edge(ABC)]);
+  observing.agent.releaseHeld([
+    { briefing: "UNCOMMITTED_OBSERVATION", decidedAt: NOW, source: "wake" },
+  ]);
+  await settle();
+  // The delta was read into working memory and its cursor moved; the model is held.
+  assert.equal(observing.sinceReads.length, 1);
+  const before = brainStateFromStored(observing.storage.file);
+  assert.ok(!JSON.stringify(before?.items).includes("UNCOMMITTED_OBSERVATION"));
+  // Unrelated publication and acceptance land while the observation is out.
+  assert.equal(await observing.agent.markHistoryRecorded(a, NOW + 1), true);
+  inner.answers.push(answered([message("later")]));
+  const accepted = await submit(observing, "another ask");
+  assert.equal(accepted.outcome, BRAIN_SUBMISSION_OUTCOME.ACCEPTED);
+  const during = brainStateFromStored(observing.storage.file);
+  assert.ok(!JSON.stringify(during?.items).includes("UNCOMMITTED_OBSERVATION"));
+  assert.deepEqual(during?.cursors, before?.cursors);
+  assert.equal(during?.requests.find((r) => r.runId === a)?.historyRecordedAt, NOW + 1);
+  // A crash copy taken now restores nothing of the observation.
+  const crashed = harness({}, new FakeStorage(observing.storage.file));
+  await crashed.agent.ready();
+  assert.ok(!JSON.stringify(crashed.storage.file).includes("UNCOMMITTED_OBSERVATION"));
+  assert.deepEqual(crashed.storage.stored()?.cursors, before?.cursors);
+  // The observation fails: durable memory and cursors never advanced, and the
+  // same delta is read again on the next wake.
+  inner.answers.unshift({ outcome: BRAIN_CLIENT_OUTCOME.FAILED, reason: "network" });
+  regate.open();
+  await settle();
+  const after = brainStateFromStored(observing.storage.file);
+  assert.ok(!JSON.stringify(after?.items).includes("UNCOMMITTED_OBSERVATION"));
+  assert.deepEqual(after?.cursors, before?.cursors);
+  // The success control: the next observation reads the same delta again
+  // and, answered, commits the cursor it owns.
+  inner.answers.push(answered([message("seen")]));
+  observing.agent.wake([edge(ABC)]);
+  await observing.clock.advance(observing.clock.now + 3_000);
+  await settle();
+  assert.deepEqual(
+    observing.sinceReads.map((read) => read.cursor),
+    [undefined, undefined],
+  );
+  assert.equal(
+    brainStateFromStored(observing.storage.file)?.cursors["claude-code"]?.abc,
+    "abc-cursor",
+  );
+});

--- a/packages/brain/src/brain-agent.ts
+++ b/packages/brain/src/brain-agent.ts
@@ -33,7 +33,6 @@ import {
 } from "./brain-input.js";
 import {
   BrainJournal,
-  type BrainJournalEntry,
   journalActCounts,
   UNCONFIRMED_ACT_RESULT,
   UNKNOWN_ACT_RESULT,
@@ -743,36 +742,23 @@ export class BrainAgent {
   }
 
   /**
-   * A staged write of some fields of one record: the store is handed the
-   * generation as it stands with those fields applied, and the live record
-   * takes them only once the store has. Nothing reads the fields in between,
-   * so no caller — a wait, a snapshot, a follower — can act on a state the
-   * file may yet refuse.
+   * A staged write of some fields of one record. The envelope is composed
+   * inside the store's queue from the generation as it then stands, with the
+   * fields applied to that record, and the live record takes them in the same
+   * queue step once the store has — so no save assembled from older state can
+   * follow and undo them, and nothing reads the fields before they are kept.
    */
-  async #commit(
+  #commit(
     generation: Generation,
     runId: string,
     changes: Partial<Omit<BrainRequestRecord, "runId" | "revision">>,
   ): Promise<boolean> {
-    const memory = generation.memory.persisted();
-    const journal: readonly BrainJournalEntry[] = generation.journal.entries();
-    const staged = [...generation.requests.values()].map((record) =>
-      record.runId === runId
-        ? { ...record, ...changes, revision: record.revision + 1 }
-        : { ...record },
+    return this.#save(
+      generation,
+      (record) =>
+        record.runId === runId ? { ...record, ...changes, revision: record.revision + 1 } : record,
+      () => this.#update(generation, runId, changes),
     );
-    const written = await this.#options.store.write(this.#lease, generation.id, () => ({
-      items: memory.items,
-      cursors: memory.cursors,
-      requests: staged,
-      journal,
-    }));
-    if (!written) {
-      this.#report("Brain memory could not be checkpointed");
-      return false;
-    }
-    this.#update(generation, runId, changes);
-    return true;
   }
 
   /**
@@ -1039,16 +1025,36 @@ export class BrainAgent {
    * False means the file does not hold what that copy holds — refused by the
    * fence or by storage — and the caller decides what that forbids.
    */
-  async #checkpoint(generation: Generation): Promise<boolean> {
-    const memory = generation.memory.persisted();
-    const requests = [...generation.requests.values()].map((record) => ({ ...record }));
-    const journal: readonly BrainJournalEntry[] = generation.journal.entries();
-    const written = await this.#options.store.write(this.#lease, generation.id, () => ({
-      items: memory.items,
-      cursors: memory.cursors,
-      requests,
-      journal,
-    }));
+  #checkpoint(generation: Generation): Promise<boolean> {
+    return this.#save(generation, (record) => record);
+  }
+
+  /**
+   * The one way a generation reaches the store. Every envelope is composed
+   * inside the store's serialized queue from the generation's live memory,
+   * journal, and records at that moment — never from a copy taken before
+   * entering the queue — so a save can only add to what the saves before it
+   * kept, and an acknowledged field is in every envelope that follows.
+   */
+  async #save(
+    generation: Generation,
+    project: (record: BrainRequestRecord) => BrainRequestRecord,
+    committed?: () => void,
+  ): Promise<boolean> {
+    const written = await this.#options.store.write(
+      this.#lease,
+      generation.id,
+      () => {
+        const memory = generation.memory.persisted();
+        return {
+          items: memory.items,
+          cursors: memory.cursors,
+          requests: [...generation.requests.values()].map((record) => project({ ...record })),
+          journal: generation.journal.entries(),
+        };
+      },
+      committed,
+    );
     if (!written) this.#report("Brain memory could not be checkpointed");
     return written;
   }

--- a/packages/brain/src/brain-agent.ts
+++ b/packages/brain/src/brain-agent.ts
@@ -31,7 +31,13 @@ import {
   standingContextItem,
   wakeInputItem,
 } from "./brain-input.js";
-import { BrainJournal, type BrainJournalEntry, UNKNOWN_ACT_RESULT } from "./brain-journal.js";
+import {
+  BrainJournal,
+  type BrainJournalEntry,
+  UNCONFIRMED_ACT_RESULT,
+  UNKNOWN_ACT_RESULT,
+  unknownActCount,
+} from "./brain-journal.js";
 import { BrainMemory, pairedDanglingCalls } from "./brain-memory.js";
 import {
   type BrainFunctionCall,
@@ -226,6 +232,8 @@ const TURN_OUTCOME = {
   DONE: "done",
   QUIET: "quiet",
   FAILED: "failed",
+  /** The model stopped without a reply: an incomplete output, or the tool budget spent. */
+  INCOMPLETE: "incomplete",
   REVOKED: "revoked",
 } as const;
 
@@ -233,7 +241,27 @@ type TurnResult =
   | { outcome: typeof TURN_OUTCOME.DONE; text: string }
   | { outcome: typeof TURN_OUTCOME.QUIET; until: number }
   | { outcome: typeof TURN_OUTCOME.FAILED }
+  | { outcome: typeof TURN_OUTCOME.INCOMPLETE }
   | { outcome: typeof TURN_OUTCOME.REVOKED };
+
+/**
+ * One envelope's working copy, alive from the moment the agent adopts it to
+ * the moment the store replaces it. Every turn captures the generation it
+ * opened in and works on that object alone: a turn still awaiting a model, a
+ * read, or an act when the generation is replaced finishes against the
+ * orphaned copy, whose checkpoints the store then fences, and can neither
+ * append to nor roll back the generation that succeeded it. The signal fires
+ * on replacement and on stop, and every wait of the generation settles on it.
+ */
+interface Generation {
+  id: string;
+  memory: BrainMemory;
+  journal: BrainJournal;
+  requests: Map<string, BrainRequestRecord>;
+  /** Runs accepted in memory but not yet checkpointed; not yet acknowledged to anyone. */
+  provisional: Set<string>;
+  abort: AbortController;
+}
 
 /**
  * One developer run's live controls: the signal its model and read work are
@@ -243,7 +271,7 @@ type TurnResult =
  */
 interface RunControl {
   runId: string;
-  generationId: string;
+  generation: Generation;
   abort: AbortController;
   cancelled: boolean;
   timedOut: boolean;
@@ -251,6 +279,7 @@ interface RunControl {
   /** Whether a checkpoint failed inside this run, after which no further act may be dispatched. */
   checkpointFailed: boolean;
   performedActs: number;
+  unknownActs: number;
 }
 
 interface TurnPlan {
@@ -262,6 +291,13 @@ interface TurnPlan {
   /** Whether a roster look's events with nothing new in their transcript are left out. */
   dropEmptyRosterDeltas?: boolean;
   run?: RunControl;
+}
+
+/** The generation a turn opened in and the one signal every wait of the turn settles on. */
+interface TurnContext {
+  generation: Generation;
+  run?: RunControl;
+  signal: AbortSignal;
 }
 
 interface DispatchOutcome {
@@ -283,8 +319,40 @@ interface LoopHooks {
   onOutput: (output: BrainResponsesOutput) => void;
   onError: (reason: string) => void;
   advanceMark: () => Promise<void>;
-  revoked: () => boolean;
-  revocation: () => TurnResult;
+}
+
+/** A pending submission, held so a retry of the same id awaits the same durable answer. */
+interface PendingSubmission {
+  question: string;
+  origin: BrainSubmission["origin"];
+  result: Promise<BrainSubmissionResult>;
+}
+
+type Settled<T> = { aborted: true } | { aborted: false; value: T };
+
+/**
+ * Waits on a promise only as long as the signal stands. Once it fires the
+ * wait settles as aborted at once and the promise's eventual value is
+ * dropped unread — a late model answer or transcript can then reach nothing.
+ * The promise's own rejection still propagates.
+ */
+async function settledUnlessAborted<T>(
+  promise: Promise<T>,
+  signal: AbortSignal,
+): Promise<Settled<T>> {
+  if (signal.aborted) return { aborted: true };
+  // A rejection after the abort has already answered would otherwise be
+  // nobody's to handle; this branch takes it and the race below still sees
+  // the rejection first when the promise settles before the signal.
+  promise.catch(() => undefined);
+  const aborted = new Promise<Settled<T>>((resolve) => {
+    signal.addEventListener("abort", () => resolve({ aborted: true }), { once: true });
+  });
+  const settled = await Promise.race([
+    promise.then((value): Settled<T> => ({ aborted: false, value })),
+    aborted,
+  ]);
+  return signal.aborted ? { aborted: true } : settled;
 }
 
 /** A transcript held to a bound from the front, and whether anything was cut. */
@@ -341,6 +409,17 @@ class IdentitySet {
   }
 }
 
+function generationFrom(state: BrainPersistedState): Generation {
+  return {
+    id: state.generationId,
+    memory: new BrainMemory({ items: state.items, cursors: state.cursors }),
+    journal: new BrainJournal(state.journal),
+    requests: new Map(state.requests.map((record) => [record.runId, { ...record }])),
+    provisional: new Set(),
+    abort: new AbortController(),
+  };
+}
+
 export type BrainRequestsListener = (records: readonly BrainRequestRecord[]) => void;
 
 export class BrainAgent {
@@ -355,12 +434,10 @@ export class BrainAgent {
   readonly #executionDeadlineMs: number;
   readonly #deltaPerSessionChars: number;
   readonly #fullTranscriptChars: number;
-  #memory = new BrainMemory();
-  #journal = new BrainJournal();
-  #requests = new Map<string, BrainRequestRecord>();
+  #generation: Generation | undefined;
   readonly #runs = new Map<string, RunControl>();
+  readonly #pendingSubmissions = new Map<string, PendingSubmission>();
   readonly #listeners = new Set<BrainRequestsListener>();
-  #generationId: string | undefined;
   #turnInFlight = false;
   #restored: Promise<void> | undefined;
   #queue: Promise<unknown> = Promise.resolve();
@@ -407,13 +484,19 @@ export class BrainAgent {
     return this.#restored;
   }
 
-  /** Every run this generation holds, oldest acceptance first. */
+  /** Every acknowledged run this generation holds, oldest acceptance first. */
   requests(): readonly BrainRequestRecord[] {
-    return [...this.#requests.values()].map((record) => ({ ...record }));
+    const generation = this.#generation;
+    if (!generation) return [];
+    return [...generation.requests.values()]
+      .filter((record) => !generation.provisional.has(record.runId))
+      .map((record) => ({ ...record }));
   }
 
   request(runId: string): BrainRequestRecord | undefined {
-    const record = this.#requests.get(runId);
+    const generation = this.#generation;
+    if (!generation || generation.provisional.has(runId)) return undefined;
+    const record = generation.requests.get(runId);
     return record ? { ...record } : undefined;
   }
 
@@ -427,16 +510,18 @@ export class BrainAgent {
 
   /**
    * Accepts a developer ask into a run, or answers why not. The same
-   * submission asked twice — a transport retrying — finds the run it already
-   * has; a new submission id is a new run, however alike the words. Acceptance
-   * is answered only once the record is checkpointed, so a caller told
-   * "accepted" can find the run again after a crash. Pending wakes ride in
-   * the run's turn, so the reply knows what just changed.
+   * submission asked twice — a transport retrying — awaits the same durable
+   * answer as the first: an acceptance is acknowledged to nobody until its
+   * record is checkpointed, so no caller is told of a run that a failed write
+   * then takes away, and a retry that arrives while the write is out is given
+   * the write's own outcome. A new submission id is a new run, however alike
+   * the words; the same id with other words or another origin is refused as a
+   * conflict rather than guessed at. Pending wakes ride in the run's turn.
    */
   async submitAsk(submission: BrainSubmission): Promise<BrainSubmissionResult> {
     await this.ready();
-    const generationId = this.#generationId;
-    if (this.#stopped || generationId === undefined) {
+    const generation = this.#generation;
+    if (this.#stopped || !generation) {
       return {
         outcome: BRAIN_SUBMISSION_OUTCOME.REJECTED,
         reason: BRAIN_SUBMISSION_REJECTION.ABSENT,
@@ -449,30 +534,61 @@ export class BrainAgent {
         reason: BRAIN_SUBMISSION_REJECTION.EMPTY,
       };
     }
-    const existing = [...this.#requests.values()].find(
+    const sameAsk = (held: { question: string; origin: BrainSubmission["origin"] }) =>
+      held.question === question && held.origin === submission.origin;
+    const conflict: BrainSubmissionResult = {
+      outcome: BRAIN_SUBMISSION_OUTCOME.REJECTED,
+      reason: BRAIN_SUBMISSION_REJECTION.CONFLICT,
+    };
+    const pending = this.#pendingSubmissions.get(submission.submissionId);
+    if (pending) return sameAsk(pending) ? pending.result : conflict;
+    const existing = this.requests().find(
       (record) => record.submissionId === submission.submissionId,
     );
     if (existing) {
-      return {
-        outcome: BRAIN_SUBMISSION_OUTCOME.ACCEPTED,
-        runId: existing.runId,
-        acceptedAt: existing.acceptedAt,
-      };
+      return sameAsk(existing)
+        ? {
+            outcome: BRAIN_SUBMISSION_OUTCOME.ACCEPTED,
+            runId: existing.runId,
+            acceptedAt: existing.acceptedAt,
+          }
+        : conflict;
     }
+    const result = this.#accept(generation, { ...submission, question });
+    this.#pendingSubmissions.set(submission.submissionId, {
+      question,
+      origin: submission.origin,
+      result,
+    });
+    try {
+      return await result;
+    } finally {
+      this.#pendingSubmissions.delete(submission.submissionId);
+    }
+  }
+
+  async #accept(
+    generation: Generation,
+    submission: BrainSubmission,
+  ): Promise<BrainSubmissionResult> {
     const acceptedAt = this.#now();
     const record: BrainRequestRecord = {
       runId: this.#options.createRunId(),
       submissionId: submission.submissionId,
       origin: submission.origin,
-      question,
+      question: submission.question,
       status: BRAIN_REQUEST_STATUS.QUEUED,
       revision: 0,
       acceptedAt,
       performedActs: 0,
+      unknownActs: 0,
     };
-    this.#requests.set(record.runId, record);
-    if (!(await this.#checkpoint(generationId))) {
-      this.#requests.delete(record.runId);
+    generation.provisional.add(record.runId);
+    generation.requests.set(record.runId, record);
+    const written = await this.#checkpoint(generation);
+    generation.provisional.delete(record.runId);
+    if (!written) {
+      generation.requests.delete(record.runId);
       return {
         outcome: BRAIN_SUBMISSION_OUTCOME.REJECTED,
         reason: BRAIN_SUBMISSION_REJECTION.PERSISTENCE,
@@ -481,17 +597,18 @@ export class BrainAgent {
     this.#notify();
     const run: RunControl = {
       runId: record.runId,
-      generationId,
+      generation,
       abort: new AbortController(),
       cancelled: false,
       timedOut: false,
       checkpointFailed: false,
       performedActs: 0,
+      unknownActs: 0,
     };
     this.#runs.set(run.runId, run);
     this.#cancelFlush();
     const events = this.#takePending();
-    void this.#enqueue(() => this.#runAsk(run, question, events));
+    void this.#enqueue(() => this.#runAsk(run, submission.question, events));
     return { outcome: BRAIN_SUBMISSION_OUTCOME.ACCEPTED, runId: record.runId, acceptedAt };
   }
 
@@ -502,19 +619,18 @@ export class BrainAgent {
    */
   async waitAsk(runId: string, timeoutMs: number): Promise<BrainRequestRecord | undefined> {
     await this.ready();
-    const record = this.#requests.get(runId);
+    const record = this.request(runId);
     if (!record) return undefined;
-    if (isTerminalBrainRequestStatus(record.status)) return { ...record };
+    if (isTerminalBrainRequestStatus(record.status)) return record;
     return new Promise((resolve) => {
       let timer: ScheduledTimer | undefined;
       const finish = () => {
         unsubscribe();
         if (timer !== undefined) this.#cancel(timer);
-        const current = this.#requests.get(runId);
-        resolve(current ? { ...current } : undefined);
+        resolve(this.request(runId));
       };
       const unsubscribe = this.subscribe(() => {
-        const current = this.#requests.get(runId);
+        const current = this.request(runId);
         if (!current || isTerminalBrainRequestStatus(current.status)) finish();
       });
       timer = this.#schedule(finish, timeoutMs);
@@ -530,18 +646,33 @@ export class BrainAgent {
    */
   async cancelAsk(runId: string): Promise<BrainRequestRecord | undefined> {
     await this.ready();
-    const record = this.#requests.get(runId);
+    const record = this.request(runId);
     if (!record) return undefined;
-    if (isTerminalBrainRequestStatus(record.status)) return { ...record };
+    if (isTerminalBrainRequestStatus(record.status)) return record;
     const run = this.#runs.get(runId);
     if (run) {
       run.cancelled = true;
       run.abort.abort();
     }
-    if (record.status === BRAIN_REQUEST_STATUS.QUEUED) {
-      await this.#settleRun(runId, BRAIN_REQUEST_STATUS.CANCELLED, {});
+    if (record.status === BRAIN_REQUEST_STATUS.QUEUED && this.#generation) {
+      await this.#settleRun(this.#generation, runId, BRAIN_REQUEST_STATUS.CANCELLED, {});
     }
     return this.request(runId);
+  }
+
+  /**
+   * Marks a run's end as written into the host's thread, so a later report,
+   * a rebuilt follower, or the next launch never writes it a second time. The
+   * host calls this only after its own write succeeded; a write that failed
+   * leaves the run unmarked and the next report tries again.
+   */
+  async markHistoryRecorded(runId: string, recordedAt: number): Promise<void> {
+    await this.ready();
+    const generation = this.#generation;
+    const record = generation?.requests.get(runId);
+    if (!generation || !record || record.historyRecordedAt !== undefined) return;
+    this.#update(generation, runId, { historyRecordedAt: recordedAt });
+    await this.#checkpoint(generation);
   }
 
   /**
@@ -580,10 +711,14 @@ export class BrainAgent {
   }
 
   /**
-   * Drops pending wakes, revokes every run's execution, lets the running turn
-   * wind down, and takes nothing more. Unfinished runs are recorded as
-   * interrupted: the agent stopping — a key or account changing, the app
-   * quitting — is not the developer's cancel, and the record says which.
+   * Revokes every execution at once and takes nothing more: the generation's
+   * signal fires, so every wait the agent holds — a model answer, a
+   * transcript read, a run's own act preparation — settles, and the queue
+   * drains behind it. Unfinished runs are recorded as interrupted: the agent
+   * stopping — a key or account changing, the app quitting — is not the
+   * developer's cancel, and the record says which. Synchronous up to the
+   * revocation, so a host can withdraw the old agent's standing before its
+   * first await of a transition.
    */
   async stop(): Promise<void> {
     this.#stopped = true;
@@ -591,10 +726,14 @@ export class BrainAgent {
     this.#pending = [];
     this.#unsubscribeStore?.();
     this.#unsubscribeStore = undefined;
+    this.#generation?.abort.abort();
     for (const run of this.#runs.values()) run.abort.abort();
-    for (const record of this.requests()) {
-      if (record.status === BRAIN_REQUEST_STATUS.QUEUED) {
-        await this.#settleRun(record.runId, BRAIN_REQUEST_STATUS.INTERRUPTED, {});
+    const generation = this.#generation;
+    if (generation) {
+      for (const record of this.requests()) {
+        if (record.status === BRAIN_REQUEST_STATUS.QUEUED) {
+          await this.#settleRun(generation, record.runId, BRAIN_REQUEST_STATUS.INTERRUPTED, {});
+        }
       }
     }
     await this.#queue;
@@ -614,12 +753,13 @@ export class BrainAgent {
     if (this.#options.client.quietUntil() !== undefined) return;
     const roster = this.#options.roster();
     const now = this.#now();
+    const memory = this.#generation?.memory;
     const looks: BrainWakeEvent[] = (roster.sessions ?? []).flatMap((session) => {
       const identity: SessionIdentity = {
         providerId: session.providerId,
         providerSessionId: session.providerSessionId,
       };
-      const readBefore = this.#memory.cursor(identity) !== undefined;
+      const readBefore = memory?.cursor(identity) !== undefined;
       const live =
         session.status === SESSION_STATUS.WORKING || session.status === SESSION_STATUS.WAITING;
       if (session.location !== SESSION_LOCATION.LOCAL || !(readBefore || live)) return [];
@@ -706,51 +846,66 @@ export class BrainAgent {
       );
       return;
     }
-    this.#adopt(state);
+    const generation = generationFrom(state);
+    this.#generation = generation;
     const interrupted = interruptedUnfinishedRequests(state.requests, this.#now());
     const paired = pairedDanglingCalls(state.items, () => JSON.stringify(UNKNOWN_ACT_RESULT));
     if (interrupted === state.requests && paired === state.items) return;
-    this.#requests = new Map(interrupted.map((record) => [record.runId, record]));
-    this.#memory = new BrainMemory({ items: paired, cursors: state.cursors });
-    await this.#checkpoint(state.generationId);
+    // An act found started with no result may have happened: the interrupted
+    // run says so in its count, and its output stands as unknown, never as a
+    // call to make again.
+    const unfinished = new Set(
+      state.requests
+        .filter((record) => !isTerminalBrainRequestStatus(record.status))
+        .map((record) => record.runId),
+    );
+    generation.requests = new Map(
+      interrupted.map((record) => [
+        record.runId,
+        unfinished.has(record.runId)
+          ? {
+              ...record,
+              unknownActs: record.unknownActs + unknownActCount(state.journal, record.runId),
+            }
+          : record,
+      ]),
+    );
+    generation.memory = new BrainMemory({ items: paired, cursors: state.cursors });
+    await this.#checkpoint(generation);
     this.#notify();
-  }
-
-  /** Takes an envelope as the agent's working copy: memory, journal, and records alike. */
-  #adopt(state: BrainPersistedState): void {
-    this.#generationId = state.generationId;
-    this.#memory = new BrainMemory({ items: state.items, cursors: state.cursors });
-    this.#journal = new BrainJournal(state.journal);
-    this.#requests = new Map(state.requests.map((record) => [record.runId, { ...record }]));
   }
 
   /**
    * The store's generation changed under this agent — a reset or a
-   * replacement. Every run of the old generation loses its execution at once:
-   * its signal fires, its `isRevoked` answers true, and its late checkpoints
-   * land nowhere because the store fences them by generation. The agent then
-   * works from the new envelope, which holds no record of those runs.
+   * replacement. The old generation's signal fires, so every run and every
+   * observation turn of it loses its execution at once, and whatever they
+   * still do happens to the orphaned copy, whose checkpoints the store
+   * fences. The agent then works from the new envelope, which holds no record
+   * of those runs.
    */
   #adoptGeneration(state: BrainPersistedState): void {
-    if (state.generationId === this.#generationId) return;
+    const previous = this.#generation;
+    if (previous?.id === state.generationId) return;
+    previous?.abort.abort();
     for (const run of this.#runs.values()) {
       run.cancelled = true;
       run.abort.abort();
     }
-    this.#adopt(state);
+    this.#runs.clear();
+    this.#generation = generationFrom(state);
     this.#notify();
   }
 
   /**
-   * Writes the working copy through the store under the generation it belongs
-   * to. False means the file does not hold what memory holds — refused by the
+   * Writes one generation's working copy through the store under its own id.
+   * False means the file does not hold what that copy holds — refused by the
    * fence or by storage — and the caller decides what that forbids.
    */
-  async #checkpoint(generationId: string): Promise<boolean> {
-    const memory = this.#memory.persisted();
-    const requests = this.requests();
-    const journal: readonly BrainJournalEntry[] = this.#journal.entries();
-    const written = await this.#options.store.write(generationId, () => ({
+  async #checkpoint(generation: Generation): Promise<boolean> {
+    const memory = generation.memory.persisted();
+    const requests = [...generation.requests.values()].map((record) => ({ ...record }));
+    const journal: readonly BrainJournalEntry[] = generation.journal.entries();
+    const written = await this.#options.store.write(generation.id, () => ({
       items: memory.items,
       cursors: memory.cursors,
       requests,
@@ -761,9 +916,7 @@ export class BrainAgent {
   }
 
   #runRevoked(run: RunControl): boolean {
-    return (
-      run.cancelled || run.timedOut || this.#stopped || run.generationId !== this.#generationId
-    );
+    return run.cancelled || run.timedOut || this.#stopped || run.generation.abort.signal.aborted;
   }
 
   async #runAsk(
@@ -771,20 +924,25 @@ export class BrainAgent {
     question: string,
     events: readonly BrainWakeEvent[],
   ): Promise<void> {
-    const record = this.#requests.get(run.runId);
+    const generation = run.generation;
+    const record = generation.requests.get(run.runId);
     if (!record || record.status !== BRAIN_REQUEST_STATUS.QUEUED || this.#runRevoked(run)) {
       if (record?.status === BRAIN_REQUEST_STATUS.QUEUED) {
         await this.#settleRun(
+          generation,
           run.runId,
-          this.#stopped ? BRAIN_REQUEST_STATUS.INTERRUPTED : BRAIN_REQUEST_STATUS.CANCELLED,
+          run.cancelled ? BRAIN_REQUEST_STATUS.CANCELLED : BRAIN_REQUEST_STATUS.INTERRUPTED,
           {},
         );
       }
       this.#runs.delete(run.runId);
       return;
     }
-    this.#update(run.runId, { status: BRAIN_REQUEST_STATUS.RUNNING, startedAt: this.#now() });
-    await this.#checkpoint(run.generationId);
+    this.#update(generation, run.runId, {
+      status: BRAIN_REQUEST_STATUS.RUNNING,
+      startedAt: this.#now(),
+    });
+    await this.#checkpoint(generation);
     this.#notify();
     run.deadline = this.#schedule(() => {
       run.timedOut = true;
@@ -811,69 +969,109 @@ export class BrainAgent {
       end.failure = BRAIN_REQUEST_FAILURE.DEADLINE;
     } else if (run.cancelled) {
       status = BRAIN_REQUEST_STATUS.CANCELLED;
-    } else if (this.#stopped || run.generationId !== this.#generationId) {
+    } else if (this.#stopped || generation.abort.signal.aborted) {
       status = BRAIN_REQUEST_STATUS.INTERRUPTED;
+    } else if (run.checkpointFailed) {
+      // What the run did may be unrecorded; that outranks whatever the model
+      // did afterwards, and the reply, if one formed, still travels.
+      status = BRAIN_REQUEST_STATUS.FAILED;
+      end.failure = BRAIN_REQUEST_FAILURE.PERSISTENCE;
+      if (result.outcome === TURN_OUTCOME.DONE && result.text) end.text = result.text;
+    } else if (result.outcome === TURN_OUTCOME.INCOMPLETE) {
+      status = BRAIN_REQUEST_STATUS.FAILED;
+      end.failure = BRAIN_REQUEST_FAILURE.INCOMPLETE;
     } else if (result.outcome !== TURN_OUTCOME.DONE) {
       status = BRAIN_REQUEST_STATUS.FAILED;
       end.failure = BRAIN_REQUEST_FAILURE.MODEL;
-    } else if (run.checkpointFailed) {
-      status = BRAIN_REQUEST_STATUS.FAILED;
-      end.failure = BRAIN_REQUEST_FAILURE.PERSISTENCE;
-      if (result.text) end.text = result.text;
     } else {
       status = BRAIN_REQUEST_STATUS.SUCCEEDED;
       if (result.text) end.text = result.text;
     }
-    await this.#settleRun(run.runId, status, end, run.performedActs, run.generationId);
+    await this.#settleRun(generation, run.runId, status, end, run);
   }
 
-  #update(runId: string, changes: Partial<Omit<BrainRequestRecord, "runId" | "revision">>): void {
-    const record = this.#requests.get(runId);
+  #update(
+    generation: Generation,
+    runId: string,
+    changes: Partial<Omit<BrainRequestRecord, "runId" | "revision">>,
+  ): void {
+    const record = generation.requests.get(runId);
     if (!record) return;
-    this.#requests.set(runId, { ...record, ...changes, revision: record.revision + 1 });
+    generation.requests.set(runId, { ...record, ...changes, revision: record.revision + 1 });
   }
 
+  /**
+   * Ends a run in its record and checkpoints the end. A success whose end
+   * cannot be written is not a success anyone can find again, so it is
+   * downgraded to a persistence failure — the reply still travels — and the
+   * write is tried once more; a failed end that will not write is reported
+   * and stands in memory alone.
+   */
   async #settleRun(
+    generation: Generation,
     runId: string,
     status: BrainRequestRecord["status"],
     end: RunEnd,
-    performedActs?: number,
-    generationId = this.#generationId,
+    run?: RunControl,
   ): Promise<void> {
-    const record = this.#requests.get(runId);
+    const record = generation.requests.get(runId);
     if (!record || isTerminalBrainRequestStatus(record.status)) return;
-    this.#update(runId, {
+    this.#update(generation, runId, {
       status,
       settledAt: this.#now(),
       ...(end.text !== undefined ? { text: end.text } : undefined),
       ...(end.failure !== undefined ? { failure: end.failure } : undefined),
-      ...(performedActs !== undefined ? { performedActs } : undefined),
+      ...(run ? { performedActs: run.performedActs, unknownActs: run.unknownActs } : undefined),
     });
-    if (generationId !== undefined) await this.#checkpoint(generationId);
+    if (!(await this.#checkpoint(generation)) && status === BRAIN_REQUEST_STATUS.SUCCEEDED) {
+      this.#update(generation, runId, {
+        status: BRAIN_REQUEST_STATUS.FAILED,
+        failure: BRAIN_REQUEST_FAILURE.PERSISTENCE,
+      });
+      await this.#checkpoint(generation);
+    }
     this.#notify();
   }
 
   async #turn(plan: TurnPlan): Promise<TurnResult> {
+    await this.ready();
+    const generation = this.#generation;
+    if (!generation) return { outcome: TURN_OUTCOME.FAILED };
+    const run = plan.run;
+    const context: TurnContext = {
+      generation,
+      ...(run ? { run } : undefined),
+      signal: run
+        ? AbortSignal.any([generation.abort.signal, run.abort.signal])
+        : generation.abort.signal,
+    };
     this.#turnInFlight = true;
     let ended = false;
-    const run = plan.run;
     const execution: BrainActExecution = {
       authority: BRAIN_TURN_AUTHORITY.DEVELOPER,
-      isRevoked: () => ended || this.#stopped || (run !== undefined && this.#runRevoked(run)),
+      isRevoked: () => ended || this.#revoked(context),
     };
     try {
-      return await this.#runTurn(plan, execution);
+      return await this.#runTurn(plan, context, execution);
     } finally {
       ended = true;
       this.#turnInFlight = false;
     }
   }
 
-  async #runTurn(plan: TurnPlan, execution: BrainActExecution): Promise<TurnResult> {
-    await this.ready();
-    const run = plan.run;
+  #revoked(context: TurnContext): boolean {
+    return this.#stopped || context.signal.aborted;
+  }
+
+  async #runTurn(
+    plan: TurnPlan,
+    context: TurnContext,
+    execution: BrainActExecution,
+  ): Promise<TurnResult> {
+    const { generation, run } = context;
+    const memory = generation.memory;
     const startedAt = this.#now();
-    let mark = this.#memory.mark();
+    let mark = memory.mark();
     const appendedKinds: string[] = [];
     const toolCalls: BrainToolCallTrace[] = [];
     const deliveries: BrainDelivery[] = [];
@@ -883,73 +1081,75 @@ export class BrainAgent {
     let outputText = "";
     let error: string | undefined;
 
-    const revoked = () => run !== undefined && this.#runRevoked(run);
     const revocation = (): TurnResult => {
-      error = run?.timedOut ? "execution deadline passed" : "run revoked";
+      error = run?.timedOut ? "execution deadline passed" : "turn revoked";
       return { outcome: TURN_OUTCOME.REVOKED };
     };
-    if (revoked()) return revocation();
+    if (this.#revoked(context)) return revocation();
 
-    const attachedDeltas = await this.#attachDeltas(plan.events);
+    const attachedDeltas = await this.#attachDeltas(plan.events, context);
     const transcriptBytes = attachedDeltas.transcriptBytes;
-    const events = plan.dropEmptyRosterDeltas
-      ? attachedDeltas.events.filter(
-          (event) => event.kind !== BRAIN_WAKE_KIND.ROSTER || Boolean(event.transcriptDelta?.text),
-        )
-      : attachedDeltas.events;
-    const append = (items: readonly ResponsesInputItem[]) => {
-      this.#memory.append(items);
-      for (const item of items) appendedKinds.push(text(item.type) ?? "unknown");
-    };
-    append(plan.open(events, startedAt));
-
     let failure: TurnResult | undefined;
-    try {
-      failure = await this.#loop(plan, execution, {
-        append,
-        toolCalls,
-        deliveries,
-        onIteration: () => {
-          iterations += 1;
-        },
-        onOutput: (output) => {
-          if (output.compacted) {
-            this.#memory.dropBeforeLatestCompaction();
-            compacted = true;
-          }
-          if (output.inputTokens !== undefined) inputTokens = output.inputTokens;
-          outputText = output.outputText;
-        },
-        onError: (reason) => {
-          error = reason;
-        },
-        // Only a developer run advances its rollback point: each answered act
-        // is checkpointed and the mark moves past it, so a later failure returns
-        // the memory to the last paired state and never to before an act that
-        // already happened. An observation turn still rolls back whole, so the
-        // deltas it read are read again next time rather than skipped.
-        advanceMark: async () => {
-          if (!run) return;
-          if (!(await this.#checkpoint(run.generationId))) run.checkpointFailed = true;
-          mark = this.#memory.mark();
-        },
-        revoked,
-        revocation,
-      });
-    } catch (loopError) {
-      // A client or performer that threw instead of answering: the turn fails
-      // like one whose model failed, and rolls back to the last paired state.
-      error = loopError instanceof Error ? loopError.name : "unknown error";
-      failure = revoked() ? revocation() : { outcome: TURN_OUTCOME.FAILED };
+    if (this.#revoked(context)) {
+      // Nothing the reads gained opens an inference the developer or the
+      // host has already withdrawn; the cursors go back with the memory.
+      failure = revocation();
+    } else {
+      const events = plan.dropEmptyRosterDeltas
+        ? attachedDeltas.events.filter(
+            (event) =>
+              event.kind !== BRAIN_WAKE_KIND.ROSTER || Boolean(event.transcriptDelta?.text),
+          )
+        : attachedDeltas.events;
+      const append = (items: readonly ResponsesInputItem[]) => {
+        memory.append(items);
+        for (const item of items) appendedKinds.push(text(item.type) ?? "unknown");
+      };
+      append(plan.open(events, startedAt));
+      try {
+        failure = await this.#loop(plan, context, execution, {
+          append,
+          toolCalls,
+          deliveries,
+          onIteration: () => {
+            iterations += 1;
+          },
+          onOutput: (output) => {
+            if (output.compacted) {
+              memory.dropBeforeLatestCompaction();
+              compacted = true;
+            }
+            if (output.inputTokens !== undefined) inputTokens = output.inputTokens;
+            outputText = output.outputText;
+          },
+          onError: (reason) => {
+            error = reason;
+          },
+          // Only a developer run advances its rollback point: each answered
+          // act is checkpointed and the mark moves past it, so a later failure
+          // returns the memory to the last paired state and never to before an
+          // act that already happened. An observation turn still rolls back
+          // whole, so the deltas it read are read again rather than skipped.
+          advanceMark: async () => {
+            if (!run) return;
+            if (!(await this.#checkpoint(generation))) run.checkpointFailed = true;
+            mark = memory.mark();
+          },
+        });
+      } catch (loopError) {
+        // A client that threw instead of answering: the turn fails like one
+        // whose model failed, and rolls back to the last paired state.
+        error = loopError instanceof Error ? loopError.name : "unknown error";
+        failure = this.#revoked(context) ? revocation() : { outcome: TURN_OUTCOME.FAILED };
+      }
     }
 
     if (failure) {
-      this.#memory.rollback(mark);
+      memory.rollback(mark);
       this.#report(`Brain ${plan.trigger} turn did not complete: ${error}`);
     } else {
-      this.#memory.retainCursors(this.#options.roster().identities);
-      const generationId = run?.generationId ?? this.#generationId;
-      const written = generationId !== undefined && (await this.#checkpoint(generationId));
+      memory.retainCursors(this.#options.roster().identities);
+      const written = await this.#checkpoint(generation);
       if (!written && run) run.checkpointFailed = true;
       for (const delivery of deliveries) {
         try {
@@ -984,23 +1184,33 @@ export class BrainAgent {
   /** The model loop: answers a failure to roll back to, or nothing when the turn reached its text. */
   async #loop(
     plan: TurnPlan,
+    context: TurnContext,
     execution: BrainActExecution,
     hooks: LoopHooks,
   ): Promise<TurnResult | undefined> {
+    const { generation } = context;
+    const revocation = (): TurnResult => {
+      hooks.onError(context.run?.timedOut ? "execution deadline passed" : "turn revoked");
+      return { outcome: TURN_OUTCOME.REVOKED };
+    };
     let iterations = 0;
     for (;;) {
       const roster = this.#options.roster();
-      const context = standingContextItem(
+      const standing = standingContextItem(
         roster.text,
         this.#options.standingContext(),
         this.#now(),
       );
-      const answer = await this.#options.client.respond([...this.#memory.items(), context], {
-        authority: plan.authority,
-        maximumOutputTokens: this.#maximumOutputTokens,
-        ...(plan.run ? { signal: plan.run.abort.signal } : undefined),
-      });
-      if (hooks.revoked()) return hooks.revocation();
+      const answered = await settledUnlessAborted(
+        this.#options.client.respond([...generation.memory.items(), standing], {
+          authority: plan.authority,
+          maximumOutputTokens: this.#maximumOutputTokens,
+          signal: context.signal,
+        }),
+        context.signal,
+      );
+      if (answered.aborted || this.#revoked(context)) return revocation();
+      const answer = answered.value;
       if (answer.outcome === BRAIN_CLIENT_OUTCOME.QUIET) {
         hooks.onError("quiet");
         return { outcome: TURN_OUTCOME.QUIET, until: answer.until };
@@ -1018,7 +1228,11 @@ export class BrainAgent {
       hooks.onOutput(output);
       if (output.functionCalls.length === 0) {
         if (output.incompleteReason && !output.outputText) {
+          // The model stopped short of any words. A run says it fell short
+          // rather than claiming a reply; an observation turn has nobody to
+          // answer, and keeps what it read so the deltas are not read twice.
           hooks.onError(`${output.status ?? "incomplete"}: ${output.incompleteReason}`);
+          return context.run ? { outcome: TURN_OUTCOME.INCOMPLETE } : undefined;
         }
         return undefined;
       }
@@ -1027,7 +1241,8 @@ export class BrainAgent {
       hooks.onIteration();
       if (iterations > this.#maxToolIterations) {
         // Every call still gets its output so the memory never holds a
-        // dangling function_call; the model reads the refusals next turn.
+        // dangling function_call; the model reads the refusals next turn. The
+        // turn itself fell short of a reply, and is reported as such.
         hooks.append(
           output.functionCalls.map((call) => {
             hooks.toolCalls.push({
@@ -1043,24 +1258,26 @@ export class BrainAgent {
         );
         hooks.onError("tool iteration budget spent");
         await hooks.advanceMark();
-        return undefined;
+        return context.run ? { outcome: TURN_OUTCOME.INCOMPLETE } : undefined;
       }
 
       // Calls run in the order the model emitted them, one at a time: an act
       // is journaled and checkpointed before the next one starts, and a
       // cancel landing between two refuses the second rather than racing it.
       for (const call of output.functionCalls) {
-        const outcome = await this.#dispatch(call, roster, plan, execution, hooks.deliveries);
+        const outcome = await this.#dispatch(call, roster, plan, context, execution, hooks);
         hooks.toolCalls.push({
           name: call.name,
           argumentsChars: call.argumentsJson.length,
           outcomeStatus: text(outcome.output.status) ?? "answered",
         });
         hooks.append([functionCallOutputItem(outcome.callId, JSON.stringify(outcome.output))]);
-        if (plan.run && this.#journal.get(plan.run.runId, call.callId)) await hooks.advanceMark();
+        if (context.run && generation.journal.get(context.run.runId, call.callId)) {
+          await hooks.advanceMark();
+        }
       }
       await hooks.advanceMark();
-      if (hooks.revoked()) return hooks.revocation();
+      if (this.#revoked(context)) return revocation();
     }
   }
 
@@ -1068,38 +1285,52 @@ export class BrainAgent {
    * Reads what each woken session's transcript gained since the brain last
    * looked, once per session however many events name it, and moves the
    * cursor. The cursor moves with the memory: a turn that fails rolls both
-   * back, so the same delta is read again rather than skipped.
+   * back, so the same delta is read again rather than skipped. A read still
+   * out when the turn is revoked is left unread: the wait settles, and the
+   * turn goes on to its rollback without it.
    */
   async #attachDeltas(
     events: readonly BrainWakeEvent[],
+    context: TurnContext,
   ): Promise<{ events: readonly BrainWakeEvent[]; transcriptBytes: number }> {
     const read = new IdentitySet();
     let transcriptBytes = 0;
     const attached: BrainWakeEvent[] = [];
     for (const event of events) {
+      if (this.#revoked(context)) break;
       if (read.list().some((identity) => sameIdentity(identity, event.identity))) {
         attached.push({ ...event });
         continue;
       }
       read.add(event.identity);
-      const delta = await this.#readDelta(event.identity);
+      const delta = await this.#readDelta(event.identity, context);
+      if (!delta) break;
       transcriptBytes += delta.text.length;
       attached.push({ ...event, transcriptDelta: delta });
     }
     return { events: attached, transcriptBytes };
   }
 
-  async #readDelta(identity: SessionIdentity): Promise<BrainTranscriptDelta> {
-    let result: ProviderTranscriptSinceResult;
+  async #readDelta(
+    identity: SessionIdentity,
+    context: TurnContext,
+  ): Promise<BrainTranscriptDelta | undefined> {
+    const memory = context.generation.memory;
+    let read: Settled<ProviderTranscriptSinceResult>;
     try {
-      result = await this.#options.readTranscriptSince(identity, this.#memory.cursor(identity));
+      read = await settledUnlessAborted(
+        this.#options.readTranscriptSince(identity, memory.cursor(identity)),
+        context.signal,
+      );
     } catch {
       return { text: "", truncated: false, status: ACT_RESULT_STATUS.REJECTED };
     }
+    if (read.aborted) return undefined;
+    const result = read.value;
     if (result.status !== ACT_RESULT_STATUS.ACCEPTED) {
       return { text: "", truncated: false, status: result.status };
     }
-    if (result.cursor !== undefined) this.#memory.setCursor(identity, result.cursor);
+    if (result.cursor !== undefined) memory.setCursor(identity, result.cursor);
     const bounded = cutFront(result.text, this.#deltaPerSessionChars);
     return {
       text: bounded.text,
@@ -1128,8 +1359,9 @@ export class BrainAgent {
     call: BrainFunctionCall,
     roster: BrainRoster,
     plan: TurnPlan,
+    context: TurnContext,
     execution: BrainActExecution,
-    deliveries: BrainDelivery[],
+    hooks: LoopHooks,
   ): Promise<DispatchOutcome> {
     const refused = this.#refusalForAuthority(plan, call.name);
     if (refused) return { callId: call.callId, output: refused };
@@ -1140,12 +1372,12 @@ export class BrainAgent {
     const named = identityFromRecord(args);
 
     if (!isBrainOnlyTool(call.name)) {
-      if (plan.authority !== BRAIN_TURN_AUTHORITY.DEVELOPER || !plan.run) {
+      if (plan.authority !== BRAIN_TURN_AUTHORITY.DEVELOPER || !context.run) {
         return { callId: call.callId, output: rejection(REFUSAL_REASON.ACT_IN_OBSERVATION) };
       }
       return {
         callId: call.callId,
-        output: await this.#performJournaled(call, plan.run, execution),
+        output: await this.#performJournaled(call, context.run, execution),
       };
     }
 
@@ -1156,10 +1388,7 @@ export class BrainAgent {
         if (!named || !observed(named)) {
           return { callId: call.callId, output: rejection(REFUSAL_REASON.UNOBSERVED_SESSION) };
         }
-        if (plan.run && this.#runRevoked(plan.run)) {
-          return { callId: call.callId, output: rejection(REFUSAL_REASON.RUN_REVOKED) };
-        }
-        return { callId: call.callId, output: await this.#readWhole(named) };
+        return { callId: call.callId, output: await this.#readWhole(named, context) };
       }
       case BRAIN_TOOL.ANNOUNCE: {
         if (plan.deliverySource === undefined) {
@@ -1169,7 +1398,7 @@ export class BrainAgent {
         if (!briefing) {
           return { callId: call.callId, output: rejection(REFUSAL_REASON.EMPTY_BRIEFING) };
         }
-        deliveries.push({ briefing, decidedAt: this.#now(), source: plan.deliverySource });
+        hooks.deliveries.push({ briefing, decidedAt: this.#now(), source: plan.deliverySource });
         return { callId: call.callId, output: { status: ACT_RESULT_STATUS.ACCEPTED } };
       }
     }
@@ -1183,15 +1412,18 @@ export class BrainAgent {
    * started and checkpointed before the performer sees it, so a crash mid-act
    * is found as an act of unknown result and never replayed; a checkpoint
    * that will not land refuses the act instead, because an act nobody could
-   * find afterwards is one the developer could not account for.
+   * find afterwards is one the developer could not account for. A performer
+   * that throws after dispatch has answered nothing about the effect: the
+   * outcome is unknown, counted as such, and never a refusal.
    */
   async #performJournaled(
     call: BrainFunctionCall,
     run: RunControl,
     execution: BrainActExecution,
   ): Promise<WireRecord> {
+    const { generation } = run;
     if (this.#runRevoked(run)) return rejection(REFUSAL_REASON.RUN_REVOKED);
-    const recorded = this.#journal.get(run.runId, call.callId);
+    const recorded = generation.journal.get(run.runId, call.callId);
     if (recorded) {
       if (recorded.argumentsJson !== call.argumentsJson) {
         return rejection(REFUSAL_REASON.CALL_ID_REUSED);
@@ -1201,15 +1433,15 @@ export class BrainAgent {
         : parsedRecord(recorded.outputJson);
     }
     if (run.checkpointFailed) return rejection(REFUSAL_REASON.NOT_CHECKPOINTED);
-    this.#journal.start({
+    generation.journal.start({
       runId: run.runId,
       callId: call.callId,
       name: call.name,
       argumentsJson: call.argumentsJson,
       startedAt: this.#now(),
     });
-    if (!(await this.#checkpoint(run.generationId))) {
-      this.#journal.forget(run.runId, call.callId);
+    if (!(await this.#checkpoint(generation))) {
+      generation.journal.forget(run.runId, call.callId);
       run.checkpointFailed = true;
       return rejection(REFUSAL_REASON.NOT_CHECKPOINTED);
     }
@@ -1220,20 +1452,23 @@ export class BrainAgent {
         execution,
       );
     } catch {
-      output = rejection(REFUSAL_REASON.ACT_FAILED);
+      output = { ...UNCONFIRMED_ACT_RESULT };
     }
     if (output.status === ACT_RESULT_STATUS.ACCEPTED) run.performedActs += 1;
-    this.#journal.settle(run.runId, call.callId, JSON.stringify(output), this.#now());
+    if (output.status === UNCONFIRMED_ACT_RESULT.status) run.unknownActs += 1;
+    generation.journal.settle(run.runId, call.callId, JSON.stringify(output), this.#now());
     return output;
   }
 
-  async #readWhole(identity: SessionIdentity): Promise<WireRecord> {
-    let result: ProviderTranscriptResult;
+  async #readWhole(identity: SessionIdentity, context: TurnContext): Promise<WireRecord> {
+    let read: Settled<ProviderTranscriptResult>;
     try {
-      result = await this.#options.readTranscript(identity);
+      read = await settledUnlessAborted(this.#options.readTranscript(identity), context.signal);
     } catch {
       return rejection(REFUSAL_REASON.READ_FAILED);
     }
+    if (read.aborted) return rejection(REFUSAL_REASON.RUN_REVOKED);
+    const result = read.value;
     if (result.status !== ACT_RESULT_STATUS.ACCEPTED) {
       return { status: result.status, reason: result.reason };
     }

--- a/packages/brain/src/brain-agent.ts
+++ b/packages/brain/src/brain-agent.ts
@@ -34,9 +34,9 @@ import {
 import {
   BrainJournal,
   type BrainJournalEntry,
+  journalActCounts,
   UNCONFIRMED_ACT_RESULT,
   UNKNOWN_ACT_RESULT,
-  unknownActCount,
 } from "./brain-journal.js";
 import { BrainMemory, pairedDanglingCalls } from "./brain-memory.js";
 import {
@@ -58,7 +58,7 @@ import {
   interruptedUnfinishedRequests,
   isTerminalBrainRequestStatus,
 } from "./brain-requests.js";
-import type { BrainPersistedState, BrainStateStore } from "./brain-state.js";
+import type { BrainPersistedState, BrainStateStore, BrainStoreLease } from "./brain-state.js";
 import {
   BRAIN_TOOL,
   brainToolAllowed,
@@ -165,6 +165,13 @@ export interface BrainRoster {
 export interface BrainActExecution {
   readonly authority: typeof BRAIN_TURN_AUTHORITY.DEVELOPER;
   isRevoked(): boolean;
+  /**
+   * Fires the moment the standing is revoked, so a performer can settle a
+   * read it is waiting on — a roster refresh, a settings read — rather than
+   * finishing it first. It reaches no provider write: an effect already
+   * dispatched is awaited for its result whatever the signal says.
+   */
+  readonly signal: AbortSignal;
 }
 
 /** Carries one act for the host to validate and perform; answers what happened as a record. */
@@ -291,6 +298,12 @@ interface TurnPlan {
   /** Whether a roster look's events with nothing new in their transcript are left out. */
   dropEmptyRosterDeltas?: boolean;
   run?: RunControl;
+  /**
+   * The generation the work was queued in. A turn that reaches the front of
+   * the queue in another generation is obsolete — a held briefing or a wake
+   * of a memory that has since been discarded — and opens nothing.
+   */
+  generation: Generation;
 }
 
 /** The generation a turn opened in and the one signal every wait of the turn settles on. */
@@ -328,7 +341,7 @@ interface PendingSubmission {
   result: Promise<BrainSubmissionResult>;
 }
 
-type Settled<T> = { aborted: true } | { aborted: false; value: T };
+export type Settled<T> = { aborted: true } | { aborted: false; value: T };
 
 /**
  * Waits on a promise only as long as the signal stands. Once it fires the
@@ -336,7 +349,7 @@ type Settled<T> = { aborted: true } | { aborted: false; value: T };
  * dropped unread — a late model answer or transcript can then reach nothing.
  * The promise's own rejection still propagates.
  */
-async function settledUnlessAborted<T>(
+export async function settledUnlessAborted<T>(
   promise: Promise<T>,
   signal: AbortSignal,
 ): Promise<Settled<T>> {
@@ -435,6 +448,7 @@ export class BrainAgent {
   readonly #deltaPerSessionChars: number;
   readonly #fullTranscriptChars: number;
   #generation: Generation | undefined;
+  readonly #lease: BrainStoreLease;
   readonly #runs = new Map<string, RunControl>();
   readonly #pendingSubmissions = new Map<string, PendingSubmission>();
   readonly #listeners = new Set<BrainRequestsListener>();
@@ -465,6 +479,7 @@ export class BrainAgent {
     this.#deltaPerSessionChars =
       options.deltaPerSessionChars ?? BRAIN_DEFAULTS.DELTA_PER_SESSION_CHARS;
     this.#fullTranscriptChars = options.fullTranscriptChars ?? BRAIN_DEFAULTS.FULL_TRANSCRIPT_CHARS;
+    this.#lease = options.store.lease();
     this.#unsubscribeStore = options.store.onReplaced((state) => this.#adoptGeneration(state));
   }
 
@@ -595,6 +610,18 @@ export class BrainAgent {
       };
     }
     this.#notify();
+    const accepted: BrainSubmissionResult = {
+      outcome: BRAIN_SUBMISSION_OUTCOME.ACCEPTED,
+      runId: record.runId,
+      acceptedAt,
+    };
+    if (this.#stopped || generation.abort.signal.aborted) {
+      // Accepted durably, but into an agent that stopped while the write was
+      // out: the run is the developer's to see, and it ends here rather than
+      // being scheduled on an agent the host has already replaced.
+      await this.#settleRun(generation, record.runId, BRAIN_REQUEST_STATUS.INTERRUPTED, {});
+      return accepted;
+    }
     const run: RunControl = {
       runId: record.runId,
       generation,
@@ -609,7 +636,7 @@ export class BrainAgent {
     this.#cancelFlush();
     const events = this.#takePending();
     void this.#enqueue(() => this.#runAsk(run, submission.question, events));
-    return { outcome: BRAIN_SUBMISSION_OUTCOME.ACCEPTED, runId: record.runId, acceptedAt };
+    return accepted;
   }
 
   /**
@@ -663,16 +690,37 @@ export class BrainAgent {
   /**
    * Marks a run's end as written into the host's thread, so a later report,
    * a rebuilt follower, or the next launch never writes it a second time. The
-   * host calls this only after its own write succeeded; a write that failed
-   * leaves the run unmarked and the next report tries again.
+   * host calls this only after its own write succeeded, and the mark stands
+   * only once it is itself written: a mark the store refused is not held in
+   * memory either, so the next report tries the whole step again.
    */
-  async markHistoryRecorded(runId: string, recordedAt: number): Promise<void> {
+  markHistoryRecorded(runId: string, recordedAt: number): Promise<boolean> {
+    return this.#mark(runId, (record) =>
+      record.historyRecordedAt === undefined ? { historyRecordedAt: recordedAt } : undefined,
+    );
+  }
+
+  /** Marks a run's own ask as written into the host's thread, on the same terms. */
+  markAskRecorded(runId: string, recordedAt: number): Promise<boolean> {
+    return this.#mark(runId, (record) =>
+      record.askRecordedAt === undefined ? { askRecordedAt: recordedAt } : undefined,
+    );
+  }
+
+  async #mark(
+    runId: string,
+    change: (record: BrainRequestRecord) => Partial<BrainRequestRecord> | undefined,
+  ): Promise<boolean> {
     await this.ready();
     const generation = this.#generation;
     const record = generation?.requests.get(runId);
-    if (!generation || !record || record.historyRecordedAt !== undefined) return;
-    this.#update(generation, runId, { historyRecordedAt: recordedAt });
-    await this.#checkpoint(generation);
+    if (!generation || !record) return false;
+    const changes = change(record);
+    if (!changes) return true;
+    this.#update(generation, runId, changes);
+    if (await this.#checkpoint(generation)) return true;
+    generation.requests.set(runId, record);
+    return false;
   }
 
   /**
@@ -694,10 +742,18 @@ export class BrainAgent {
    */
   releaseHeld(held: readonly BrainDelivery[]): void {
     if (this.#stopped || held.length === 0) return;
+    const generation = this.#generation;
+    if (!generation) {
+      // The state is still loading: the briefings wait for the generation
+      // they will be re-decided in.
+      void this.ready().then(() => this.releaseHeld(held));
+      return;
+    }
     this.#cancelFlush();
     const events = this.#takePending();
     void this.#enqueue(() =>
       this.#turn({
+        generation,
         trigger: BRAIN_TURN_TRIGGER.HOLD_RELEASED,
         authority: BRAIN_TURN_AUTHORITY.OBSERVATION,
         events,
@@ -728,6 +784,14 @@ export class BrainAgent {
     this.#unsubscribeStore = undefined;
     this.#generation?.abort.abort();
     for (const run of this.#runs.values()) run.abort.abort();
+    // An acceptance whose write is still out settles before the stop does:
+    // its caller hears the durable answer, its run is recorded interrupted,
+    // and nothing of it is left to land on the agent that comes next.
+    await Promise.all(
+      [...this.#pendingSubmissions.values()].map((pending) =>
+        pending.result.catch(() => undefined),
+      ),
+    );
     const generation = this.#generation;
     if (generation) {
       for (const record of this.requests()) {
@@ -750,16 +814,21 @@ export class BrainAgent {
    */
   rosterLook(): void {
     if (this.#stopped || this.#turnInFlight) return;
+    const generation = this.#generation;
+    if (!generation) {
+      void this.ready().then(() => this.rosterLook());
+      return;
+    }
     if (this.#options.client.quietUntil() !== undefined) return;
     const roster = this.#options.roster();
     const now = this.#now();
-    const memory = this.#generation?.memory;
+    const memory = generation.memory;
     const looks: BrainWakeEvent[] = (roster.sessions ?? []).flatMap((session) => {
       const identity: SessionIdentity = {
         providerId: session.providerId,
         providerSessionId: session.providerSessionId,
       };
-      const readBefore = memory?.cursor(identity) !== undefined;
+      const readBefore = memory.cursor(identity) !== undefined;
       const live =
         session.status === SESSION_STATUS.WORKING || session.status === SESSION_STATUS.WAITING;
       if (session.location !== SESSION_LOCATION.LOCAL || !(readBefore || live)) return [];
@@ -769,6 +838,7 @@ export class BrainAgent {
     const events = [...this.#takePending(), ...looks];
     void this.#enqueue(() =>
       this.#turn({
+        generation,
         trigger: BRAIN_TURN_TRIGGER.ROSTER,
         authority: BRAIN_TURN_AUTHORITY.OBSERVATION,
         events,
@@ -800,17 +870,28 @@ export class BrainAgent {
       this.#scheduleFlush(Math.max(quietUntil - this.#now(), this.#wakeCoalesceMs));
       return;
     }
+    const generation = this.#generation;
+    if (!generation) {
+      // Nothing to open a turn in yet: the wakes wait for the state to load.
+      void this.ready().then(() => this.#scheduleFlush(0));
+      return;
+    }
     const events = this.#takePending();
     if (events.length === 0) return;
     void this.#enqueue(async () => {
       const result = await this.#turn({
+        generation,
         trigger: BRAIN_TURN_TRIGGER.WAKE,
         authority: BRAIN_TURN_AUTHORITY.OBSERVATION,
         events,
         open: (attached, now) => [wakeInputItem(attached, now)],
         deliverySource: BRAIN_DELIVERY_SOURCE.WAKE,
       });
-      if (result.outcome === TURN_OUTCOME.QUIET && !this.#stopped) {
+      if (
+        result.outcome === TURN_OUTCOME.QUIET &&
+        !this.#stopped &&
+        generation === this.#generation
+      ) {
         // The turn sent nothing, so the wakes are still news: they go back
         // to the front of the queue and open together once the quiet ends.
         this.#pending.unshift(...events);
@@ -859,14 +940,15 @@ export class BrainAgent {
         .filter((record) => !isTerminalBrainRequestStatus(record.status))
         .map((record) => record.runId),
     );
+    // An interrupted run's accounting is what its journal established: acts
+    // whose result was accepted went through, acts whose result says unknown
+    // or never arrived may have. Counted from the journal alone, so a copy
+    // taken mid-run and a copy taken after it both say the same.
     generation.requests = new Map(
       interrupted.map((record) => [
         record.runId,
         unfinished.has(record.runId)
-          ? {
-              ...record,
-              unknownActs: record.unknownActs + unknownActCount(state.journal, record.runId),
-            }
+          ? { ...record, ...journalActCounts(state.journal, record.runId) }
           : record,
       ]),
     );
@@ -892,6 +974,10 @@ export class BrainAgent {
       run.abort.abort();
     }
     this.#runs.clear();
+    // Wakes coalesced against the old memory — including a quiet retry's —
+    // are that generation's work, and go with it.
+    this.#cancelFlush();
+    this.#pending = [];
     this.#generation = generationFrom(state);
     this.#notify();
   }
@@ -905,7 +991,7 @@ export class BrainAgent {
     const memory = generation.memory.persisted();
     const requests = [...generation.requests.values()].map((record) => ({ ...record }));
     const journal: readonly BrainJournalEntry[] = generation.journal.entries();
-    const written = await this.#options.store.write(generation.id, () => ({
+    const written = await this.#options.store.write(this.#lease, generation.id, () => ({
       items: memory.items,
       cursors: memory.cursors,
       requests,
@@ -951,6 +1037,7 @@ export class BrainAgent {
     let result: TurnResult;
     try {
       result = await this.#turn({
+        generation,
         trigger: BRAIN_TURN_TRIGGER.ASK,
         authority: BRAIN_TURN_AUTHORITY.DEVELOPER,
         events,
@@ -1035,8 +1122,12 @@ export class BrainAgent {
 
   async #turn(plan: TurnPlan): Promise<TurnResult> {
     await this.ready();
-    const generation = this.#generation;
-    if (!generation) return { outcome: TURN_OUTCOME.FAILED };
+    const generation = plan.generation;
+    // Work queued in a generation since replaced opens nothing: its briefings
+    // and its wakes described a memory that no longer exists.
+    if (generation !== this.#generation || generation.abort.signal.aborted) {
+      return { outcome: TURN_OUTCOME.REVOKED };
+    }
     const run = plan.run;
     const context: TurnContext = {
       generation,
@@ -1050,6 +1141,7 @@ export class BrainAgent {
     const execution: BrainActExecution = {
       authority: BRAIN_TURN_AUTHORITY.DEVELOPER,
       isRevoked: () => ended || this.#revoked(context),
+      signal: context.signal,
     };
     try {
       return await this.#runTurn(plan, context, execution);
@@ -1151,7 +1243,15 @@ export class BrainAgent {
       memory.retainCursors(this.#options.roster().identities);
       const written = await this.#checkpoint(generation);
       if (!written && run) run.checkpointFailed = true;
+      // A briefing leaves only from a turn that still stands: the stop or the
+      // replacement that landed during the write — or during an earlier
+      // briefing — withdraws every one not yet handed over, and a checkpoint
+      // the store refused is one such withdrawal made visible.
       for (const delivery of deliveries) {
+        if (this.#revoked(context) || !written) {
+          error = "turn revoked before delivery";
+          break;
+        }
         try {
           await this.#options.deliver(delivery);
         } catch (deliverError) {
@@ -1457,6 +1557,13 @@ export class BrainAgent {
     if (output.status === ACT_RESULT_STATUS.ACCEPTED) run.performedActs += 1;
     if (output.status === UNCONFIRMED_ACT_RESULT.status) run.unknownActs += 1;
     generation.journal.settle(run.runId, call.callId, JSON.stringify(output), this.#now());
+    // The record's accounting moves with the journal, in the same checkpoint
+    // that follows, so a copy taken before the next inference already says
+    // what was done.
+    this.#update(generation, run.runId, {
+      performedActs: run.performedActs,
+      unknownActs: run.unknownActs,
+    });
     return output;
   }
 

--- a/packages/brain/src/brain-agent.ts
+++ b/packages/brain/src/brain-agent.ts
@@ -317,6 +317,20 @@ interface DispatchOutcome {
   output: WireRecord;
 }
 
+type RecordChanges = Partial<Omit<BrainRequestRecord, "runId" | "revision">>;
+
+/**
+ * What one save owns. A record scope changes one record's fields over the
+ * committed record — or inserts the record, for its own acceptance. A working
+ * scope commits the turn's memory, cursors, and journal. The whole scope is
+ * the restore's alone.
+ */
+interface SaveScope {
+  working?: boolean;
+  whole?: boolean;
+  record?: { runId: string; changes: RecordChanges; insert?: BrainRequestRecord };
+}
+
 /** What a run's end carries into its record beyond the status. */
 interface RunEnd {
   text?: string;
@@ -605,7 +619,9 @@ export class BrainAgent {
     };
     generation.provisional.add(record.runId);
     generation.requests.set(record.runId, record);
-    const written = await this.#checkpoint(generation);
+    const written = await this.#save(generation, {
+      record: { runId: record.runId, changes: {}, insert: record },
+    });
     generation.provisional.delete(record.runId);
     if (!written) {
       generation.requests.delete(record.runId);
@@ -742,23 +758,15 @@ export class BrainAgent {
   }
 
   /**
-   * A staged write of some fields of one record. The envelope is composed
-   * inside the store's queue from the generation as it then stands, with the
-   * fields applied to that record, and the live record takes them in the same
-   * queue step once the store has — so no save assembled from older state can
-   * follow and undo them, and nothing reads the fields before they are kept.
+   * A staged write of some fields of one record, owning nothing else: the
+   * envelope is the store's committed state with the fields applied to that
+   * record alone, and the live record takes them in the same queue step once
+   * the store has — so no save assembled from older state can follow and undo
+   * them, nothing reads the fields before they are kept, and nothing of any
+   * other record or of a turn still in flight rides along.
    */
-  #commit(
-    generation: Generation,
-    runId: string,
-    changes: Partial<Omit<BrainRequestRecord, "runId" | "revision">>,
-  ): Promise<boolean> {
-    return this.#save(
-      generation,
-      (record) =>
-        record.runId === runId ? { ...record, ...changes, revision: record.revision + 1 } : record,
-      () => this.#update(generation, runId, changes),
-    );
+  #commit(generation: Generation, runId: string, changes: RecordChanges): Promise<boolean> {
+    return this.#save(generation, { record: { runId, changes } });
   }
 
   /**
@@ -991,7 +999,7 @@ export class BrainAgent {
       ]),
     );
     generation.memory = new BrainMemory({ items: paired, cursors: state.cursors });
-    await this.#checkpoint(generation);
+    await this.#save(generation, { whole: true });
     this.#notify();
   }
 
@@ -1021,42 +1029,95 @@ export class BrainAgent {
   }
 
   /**
-   * Writes one generation's working copy through the store under its own id.
-   * False means the file does not hold what that copy holds — refused by the
-   * fence or by storage — and the caller decides what that forbids.
+   * A turn's or an act's checkpoint: the working memory, cursors, and journal
+   * this turn owns become the committed ones, together with the run's own
+   * accounting when a run owns the turn. Nothing else changes: every other
+   * record stays as committed, so a request accepted or marked meanwhile is
+   * untouched and a request still provisional is not published.
    */
-  #checkpoint(generation: Generation): Promise<boolean> {
-    return this.#save(generation, (record) => record);
+  #checkpoint(generation: Generation, run?: RunControl): Promise<boolean> {
+    return this.#save(generation, {
+      working: true,
+      ...(run
+        ? {
+            record: {
+              runId: run.runId,
+              changes: { performedActs: run.performedActs, unknownActs: run.unknownActs },
+            },
+          }
+        : undefined),
+    });
   }
 
   /**
-   * The one way a generation reaches the store. Every envelope is composed
-   * inside the store's serialized queue from the generation's live memory,
-   * journal, and records at that moment — never from a copy taken before
-   * entering the queue — so a save can only add to what the saves before it
-   * kept, and an acknowledged field is in every envelope that follows.
+   * The one way a generation reaches the store, and the one place the scope
+   * of a save is decided. Every envelope is composed inside the store's
+   * serialized queue from the store's committed state — never from a copy
+   * taken before entering the queue, and never from live state the save does
+   * not own — so a save can only add what it owns to what the saves before it
+   * kept. What a save may own: the working memory, cursors, and journal, when
+   * it is the checkpoint of the turn holding them; one record's fields, when
+   * it is that record's acceptance, transition, accounting, end, or mark; or
+   * the whole generation, when it is the restore that just loaded it. Owned
+   * record fields land on the live record in the queue step that keeps them.
    */
-  async #save(
-    generation: Generation,
-    project: (record: BrainRequestRecord) => BrainRequestRecord,
-    committed?: () => void,
-  ): Promise<boolean> {
+  async #save(generation: Generation, scope: SaveScope): Promise<boolean> {
+    let owned: BrainRequestRecord | undefined;
+    let missing = false;
     const written = await this.#options.store.write(
       this.#lease,
       generation.id,
-      () => {
+      (state) => {
         const memory = generation.memory.persisted();
+        const working = scope.working === true || scope.whole === true;
+        let requests: readonly BrainRequestRecord[];
+        if (scope.whole) {
+          requests = [...generation.requests.values()].map((record) => ({ ...record }));
+        } else if (scope.record) {
+          const { runId, changes } = scope.record;
+          const committed = state.requests.find((record) => record.runId === runId);
+          if (committed) {
+            const changed: BrainRequestRecord = {
+              ...committed,
+              ...changes,
+              revision: committed.revision + 1,
+            };
+            owned = changed;
+            requests = state.requests.map((record) => (record.runId === runId ? changed : record));
+          } else if (scope.record.insert) {
+            owned = { ...scope.record.insert };
+            requests = [...state.requests, owned];
+          } else {
+            missing = true;
+            requests = state.requests;
+          }
+        } else {
+          requests = state.requests;
+        }
         return {
-          items: memory.items,
-          cursors: memory.cursors,
-          requests: [...generation.requests.values()].map((record) => project({ ...record })),
-          journal: generation.journal.entries(),
+          items: working ? memory.items : state.items,
+          cursors: working ? memory.cursors : state.cursors,
+          journal: working ? generation.journal.entries() : state.journal,
+          requests,
         };
       },
-      committed,
+      () => {
+        if (!owned || !scope.record) return;
+        const live = generation.requests.get(owned.runId);
+        if (live) {
+          generation.requests.set(owned.runId, {
+            ...live,
+            ...scope.record.changes,
+            revision: owned.revision,
+          });
+        }
+      },
     );
-    if (!written) this.#report("Brain memory could not be checkpointed");
-    return written;
+    if (!written || missing) {
+      this.#report("Brain memory could not be checkpointed");
+      return false;
+    }
+    return true;
   }
 
   #runRevoked(run: RunControl): boolean {
@@ -1082,11 +1143,10 @@ export class BrainAgent {
       this.#runs.delete(run.runId);
       return;
     }
-    this.#update(generation, run.runId, {
+    await this.#commit(generation, run.runId, {
       status: BRAIN_REQUEST_STATUS.RUNNING,
       startedAt: this.#now(),
     });
-    await this.#checkpoint(generation);
     this.#notify();
     run.deadline = this.#schedule(() => {
       run.timedOut = true;
@@ -1135,11 +1195,7 @@ export class BrainAgent {
     await this.#settleRun(generation, run.runId, status, end, run);
   }
 
-  #update(
-    generation: Generation,
-    runId: string,
-    changes: Partial<Omit<BrainRequestRecord, "runId" | "revision">>,
-  ): void {
+  #update(generation: Generation, runId: string, changes: RecordChanges): void {
     const record = generation.requests.get(runId);
     if (!record) return;
     generation.requests.set(runId, { ...record, ...changes, revision: record.revision + 1 });
@@ -1170,7 +1226,7 @@ export class BrainAgent {
   ): Promise<void> {
     const record = generation.requests.get(runId);
     if (!record || isTerminalBrainRequestStatus(record.status)) return;
-    const settled: Partial<Omit<BrainRequestRecord, "runId" | "revision">> = {
+    const settled: RecordChanges = {
       status,
       settledAt: this.#now(),
       ...(end.text !== undefined ? { text: end.text } : undefined),
@@ -1299,7 +1355,7 @@ export class BrainAgent {
           // whole, so the deltas it read are read again rather than skipped.
           advanceMark: async () => {
             if (!run) return;
-            if (!(await this.#checkpoint(generation))) run.checkpointFailed = true;
+            if (!(await this.#checkpoint(generation, run))) run.checkpointFailed = true;
             mark = memory.mark();
           },
         });
@@ -1316,7 +1372,7 @@ export class BrainAgent {
       this.#report(`Brain ${plan.trigger} turn did not complete: ${error}`);
     } else {
       memory.retainCursors(this.#options.roster().identities);
-      const written = await this.#checkpoint(generation);
+      const written = await this.#checkpoint(generation, run);
       if (!written && run) run.checkpointFailed = true;
       // A briefing leaves only from a turn that still stands: the stop or the
       // replacement that landed during the write — or during an earlier
@@ -1615,7 +1671,7 @@ export class BrainAgent {
       argumentsJson: call.argumentsJson,
       startedAt: this.#now(),
     });
-    if (!(await this.#checkpoint(generation))) {
+    if (!(await this.#checkpoint(generation, run))) {
       generation.journal.forget(run.runId, call.callId);
       run.checkpointFailed = true;
       return rejection(REFUSAL_REASON.NOT_CHECKPOINTED);
@@ -1632,13 +1688,9 @@ export class BrainAgent {
     if (output.status === ACT_RESULT_STATUS.ACCEPTED) run.performedActs += 1;
     if (output.status === UNCONFIRMED_ACT_RESULT.status) run.unknownActs += 1;
     generation.journal.settle(run.runId, call.callId, JSON.stringify(output), this.#now());
-    // The record's accounting moves with the journal, in the same checkpoint
-    // that follows, so a copy taken before the next inference already says
-    // what was done.
-    this.#update(generation, run.runId, {
-      performedActs: run.performedActs,
-      unknownActs: run.unknownActs,
-    });
+    // The record's accounting travels with the checkpoint that follows the
+    // result, owned by the run, so a copy taken before the next inference
+    // already says what was done.
     return output;
   }
 

--- a/packages/brain/src/brain-agent.ts
+++ b/packages/brain/src/brain-agent.ts
@@ -31,13 +31,28 @@ import {
   standingContextItem,
   wakeInputItem,
 } from "./brain-input.js";
-import { BrainMemory, type BrainPersistedState } from "./brain-memory.js";
+import { BrainJournal, type BrainJournalEntry, UNKNOWN_ACT_RESULT } from "./brain-journal.js";
+import { BrainMemory, pairedDanglingCalls } from "./brain-memory.js";
 import {
   type BrainFunctionCall,
+  type BrainResponsesOutput,
   brainResponsesOutput,
   functionCallOutputItem,
   type ResponsesInputItem,
 } from "./brain-openai.js";
+import {
+  BRAIN_REQUEST_FAILURE,
+  BRAIN_REQUEST_STATUS,
+  BRAIN_SUBMISSION_OUTCOME,
+  BRAIN_SUBMISSION_REJECTION,
+  type BrainRequestFailure,
+  type BrainRequestRecord,
+  type BrainSubmission,
+  type BrainSubmissionResult,
+  interruptedUnfinishedRequests,
+  isTerminalBrainRequestStatus,
+} from "./brain-requests.js";
+import type { BrainPersistedState, BrainStateStore } from "./brain-state.js";
 import {
   BRAIN_TOOL,
   brainToolAllowed,
@@ -64,6 +79,15 @@ import {
  * a wake, a roster look, or a hold release is observation — so the toolset a
  * model is offered and the gate every emitted call meets are both decided
  * before the model reads a word, and nothing it reads can move them.
+ *
+ * A developer ask is a run with a record: accepted once its record is
+ * checkpointed, queued behind the turns ahead of it, running under an
+ * execution deadline and a cancellation the developer holds, and ended in one
+ * of the terminal statuses the record vocabulary names. Every act the run
+ * dispatches is journaled before the performer sees it and again with its
+ * result before the model does, and the memory's rollback point advances
+ * past each answered act, so a reply the model then fails to produce cannot
+ * erase an act that already happened.
  */
 
 export const BRAIN_DEFAULTS = {
@@ -71,8 +95,14 @@ export const BRAIN_DEFAULTS = {
   MAX_TOOL_ITERATIONS: 8,
   /** Wakes inside this window open one turn together: a hook and the poll's edge for the same stop. */
   WAKE_COALESCE_MS: 3_000,
-  /** How long an ask waits for its reply before the voice is told there is none. */
-  ASK_DEADLINE_MS: 45_000,
+  /**
+   * How long a caller waits on a run before being answered with the run still
+   * pending. The run is not abandoned at this edge: it keeps going, and the
+   * record answers the caller's next wait.
+   */
+  ASK_WAIT_MS: 30_000,
+  /** How long a run may execute once it starts before it is timed out and its execution revoked. */
+  EXECUTION_DEADLINE_MS: 48 * 60 * 60 * 1000,
   /** The most of one session's new transcript one wake carries, cut from the front. */
   DELTA_PER_SESSION_CHARS: 20_000,
   /** The most of a whole transcript one read answers with, cut from the front. */
@@ -101,6 +131,9 @@ const REFUSAL_REASON = {
   BUDGET_SPENT: "not run: this turn's tool budget is spent",
   ACT_FAILED: "the act did not complete",
   READ_FAILED: "the transcript could not be read",
+  RUN_REVOKED: "not run: this ask was cancelled or its run ended",
+  NOT_CHECKPOINTED: "not run: the act could not be recorded before running, so it was not run",
+  CALL_ID_REUSED: "not run: this call id was already used with different arguments",
 } as const;
 
 /**
@@ -131,11 +164,6 @@ export interface BrainActExecution {
 /** Carries one act for the host to validate and perform; answers what happened as a record. */
 export interface BrainActPerformer {
   perform(call: RealtimeFunctionCall, execution: BrainActExecution): Promise<WireRecord>;
-}
-
-export interface BrainAskAnswer {
-  /** The reply, as the voice speaks it. */
-  text: string;
 }
 
 export interface BrainToolCallTrace {
@@ -178,8 +206,9 @@ export interface BrainAgentOptions {
   ) => Promise<ProviderTranscriptSinceResult>;
   readTranscript: (identity: SessionIdentity) => Promise<ProviderTranscriptResult>;
   deliver: (delivery: BrainDelivery) => void | Promise<void>;
-  persist: (state: BrainPersistedState) => void | Promise<void>;
-  restore: () => BrainPersistedState | undefined | Promise<BrainPersistedState | undefined>;
+  /** The one writer of the brain's state, owned by the host and outliving any one agent. */
+  store: BrainStateStore;
+  createRunId: () => string;
   trace?: (record: BrainTurnTraceRecord) => void;
   report?: (message: string) => void;
   now?: () => number;
@@ -188,7 +217,7 @@ export interface BrainAgentOptions {
   maximumOutputTokens?: number;
   maxToolIterations?: number;
   wakeCoalesceMs?: number;
-  askDeadlineMs?: number;
+  executionDeadlineMs?: number;
   deltaPerSessionChars?: number;
   fullTranscriptChars?: number;
 }
@@ -197,12 +226,32 @@ const TURN_OUTCOME = {
   DONE: "done",
   QUIET: "quiet",
   FAILED: "failed",
+  REVOKED: "revoked",
 } as const;
 
 type TurnResult =
   | { outcome: typeof TURN_OUTCOME.DONE; text: string }
   | { outcome: typeof TURN_OUTCOME.QUIET; until: number }
-  | { outcome: typeof TURN_OUTCOME.FAILED };
+  | { outcome: typeof TURN_OUTCOME.FAILED }
+  | { outcome: typeof TURN_OUTCOME.REVOKED };
+
+/**
+ * One developer run's live controls: the signal its model and read work are
+ * aborted through, and the flags every `isRevoked` reads. A run's execution
+ * is revoked by the developer's cancel, by the deadline, by the agent
+ * stopping, and by the store's generation being replaced under it.
+ */
+interface RunControl {
+  runId: string;
+  generationId: string;
+  abort: AbortController;
+  cancelled: boolean;
+  timedOut: boolean;
+  deadline?: ScheduledTimer;
+  /** Whether a checkpoint failed inside this run, after which no further act may be dispatched. */
+  checkpointFailed: boolean;
+  performedActs: number;
+}
 
 interface TurnPlan {
   trigger: BrainTurnTrigger;
@@ -212,11 +261,30 @@ interface TurnPlan {
   deliverySource?: BrainDeliverySource;
   /** Whether a roster look's events with nothing new in their transcript are left out. */
   dropEmptyRosterDeltas?: boolean;
+  run?: RunControl;
 }
 
 interface DispatchOutcome {
   callId: string;
   output: WireRecord;
+}
+
+/** What a run's end carries into its record beyond the status. */
+interface RunEnd {
+  text?: string;
+  failure?: BrainRequestFailure;
+}
+
+interface LoopHooks {
+  append: (items: readonly ResponsesInputItem[]) => void;
+  toolCalls: BrainToolCallTrace[];
+  deliveries: BrainDelivery[];
+  onIteration: () => void;
+  onOutput: (output: BrainResponsesOutput) => void;
+  onError: (reason: string) => void;
+  advanceMark: () => Promise<void>;
+  revoked: () => boolean;
+  revocation: () => TurnResult;
 }
 
 /** A transcript held to a bound from the front, and whether anything was cut. */
@@ -231,10 +299,10 @@ function cutFront(value: string, maximumChars: number): FrontCut {
   return { text: `${OMISSION_MARKER}\n${value.slice(value.length - keep)}`, cut: true };
 }
 
-function parsedArguments(argumentsJson: string): WireRecord {
+function parsedRecord(json: string): WireRecord {
   try {
     // SAFETY: JSON.parse returns a wire value; the record check below is the validation.
-    const parsed = JSON.parse(argumentsJson) as UnparsedWireValue;
+    const parsed = JSON.parse(json) as UnparsedWireValue;
     return isRecord(parsed) ? parsed : {};
   } catch {
     return {};
@@ -273,6 +341,8 @@ class IdentitySet {
   }
 }
 
+export type BrainRequestsListener = (records: readonly BrainRequestRecord[]) => void;
+
 export class BrainAgent {
   readonly #options: BrainAgentOptions;
   readonly #now: () => number;
@@ -282,16 +352,22 @@ export class BrainAgent {
   readonly #maximumOutputTokens: number;
   readonly #maxToolIterations: number;
   readonly #wakeCoalesceMs: number;
-  readonly #askDeadlineMs: number;
+  readonly #executionDeadlineMs: number;
   readonly #deltaPerSessionChars: number;
   readonly #fullTranscriptChars: number;
   #memory = new BrainMemory();
+  #journal = new BrainJournal();
+  #requests = new Map<string, BrainRequestRecord>();
+  readonly #runs = new Map<string, RunControl>();
+  readonly #listeners = new Set<BrainRequestsListener>();
+  #generationId: string | undefined;
   #turnInFlight = false;
   #restored: Promise<void> | undefined;
   #queue: Promise<unknown> = Promise.resolve();
   #pending: BrainWakeEvent[] = [];
   #flushTimer: ScheduledTimer | undefined;
   #stopped = false;
+  #unsubscribeStore: (() => void) | undefined;
 
   constructor(options: BrainAgentOptions) {
     this.#options = options;
@@ -308,15 +384,164 @@ export class BrainAgent {
     this.#maximumOutputTokens = options.maximumOutputTokens ?? BRAIN_DEFAULTS.MAXIMUM_OUTPUT_TOKENS;
     this.#maxToolIterations = options.maxToolIterations ?? BRAIN_DEFAULTS.MAX_TOOL_ITERATIONS;
     this.#wakeCoalesceMs = options.wakeCoalesceMs ?? BRAIN_DEFAULTS.WAKE_COALESCE_MS;
-    this.#askDeadlineMs = options.askDeadlineMs ?? BRAIN_DEFAULTS.ASK_DEADLINE_MS;
+    this.#executionDeadlineMs = options.executionDeadlineMs ?? BRAIN_DEFAULTS.EXECUTION_DEADLINE_MS;
     this.#deltaPerSessionChars =
       options.deltaPerSessionChars ?? BRAIN_DEFAULTS.DELTA_PER_SESSION_CHARS;
     this.#fullTranscriptChars = options.fullTranscriptChars ?? BRAIN_DEFAULTS.FULL_TRANSCRIPT_CHARS;
+    this.#unsubscribeStore = options.store.onReplaced((state) => this.#adoptGeneration(state));
   }
 
   /** How many wakes are waiting for their turn to open. */
   pendingWakes(): number {
     return this.#pending.length;
+  }
+
+  /**
+   * Settles once the stored state has been read: the last launch's unfinished
+   * runs marked interrupted, dangling calls paired, and both checkpointed.
+   * Every entry point awaits this itself; a host that wants the records
+   * before its first ask awaits it here.
+   */
+  ready(): Promise<void> {
+    this.#restored ??= this.#restore();
+    return this.#restored;
+  }
+
+  /** Every run this generation holds, oldest acceptance first. */
+  requests(): readonly BrainRequestRecord[] {
+    return [...this.#requests.values()].map((record) => ({ ...record }));
+  }
+
+  request(runId: string): BrainRequestRecord | undefined {
+    const record = this.#requests.get(runId);
+    return record ? { ...record } : undefined;
+  }
+
+  /** Hears the whole list on every change to any record. */
+  subscribe(listener: BrainRequestsListener): () => void {
+    this.#listeners.add(listener);
+    return () => {
+      this.#listeners.delete(listener);
+    };
+  }
+
+  /**
+   * Accepts a developer ask into a run, or answers why not. The same
+   * submission asked twice — a transport retrying — finds the run it already
+   * has; a new submission id is a new run, however alike the words. Acceptance
+   * is answered only once the record is checkpointed, so a caller told
+   * "accepted" can find the run again after a crash. Pending wakes ride in
+   * the run's turn, so the reply knows what just changed.
+   */
+  async submitAsk(submission: BrainSubmission): Promise<BrainSubmissionResult> {
+    await this.ready();
+    const generationId = this.#generationId;
+    if (this.#stopped || generationId === undefined) {
+      return {
+        outcome: BRAIN_SUBMISSION_OUTCOME.REJECTED,
+        reason: BRAIN_SUBMISSION_REJECTION.ABSENT,
+      };
+    }
+    const question = submission.question.trim();
+    if (!question) {
+      return {
+        outcome: BRAIN_SUBMISSION_OUTCOME.REJECTED,
+        reason: BRAIN_SUBMISSION_REJECTION.EMPTY,
+      };
+    }
+    const existing = [...this.#requests.values()].find(
+      (record) => record.submissionId === submission.submissionId,
+    );
+    if (existing) {
+      return {
+        outcome: BRAIN_SUBMISSION_OUTCOME.ACCEPTED,
+        runId: existing.runId,
+        acceptedAt: existing.acceptedAt,
+      };
+    }
+    const acceptedAt = this.#now();
+    const record: BrainRequestRecord = {
+      runId: this.#options.createRunId(),
+      submissionId: submission.submissionId,
+      origin: submission.origin,
+      question,
+      status: BRAIN_REQUEST_STATUS.QUEUED,
+      revision: 0,
+      acceptedAt,
+      performedActs: 0,
+    };
+    this.#requests.set(record.runId, record);
+    if (!(await this.#checkpoint(generationId))) {
+      this.#requests.delete(record.runId);
+      return {
+        outcome: BRAIN_SUBMISSION_OUTCOME.REJECTED,
+        reason: BRAIN_SUBMISSION_REJECTION.PERSISTENCE,
+      };
+    }
+    this.#notify();
+    const run: RunControl = {
+      runId: record.runId,
+      generationId,
+      abort: new AbortController(),
+      cancelled: false,
+      timedOut: false,
+      checkpointFailed: false,
+      performedActs: 0,
+    };
+    this.#runs.set(run.runId, run);
+    this.#cancelFlush();
+    const events = this.#takePending();
+    void this.#enqueue(() => this.#runAsk(run, question, events));
+    return { outcome: BRAIN_SUBMISSION_OUTCOME.ACCEPTED, runId: record.runId, acceptedAt };
+  }
+
+  /**
+   * Answers the record once the run ends, or as it stands when the wait runs
+   * out first. A wait that runs out changes nothing about the run, and a run
+   * this generation does not know answers nothing.
+   */
+  async waitAsk(runId: string, timeoutMs: number): Promise<BrainRequestRecord | undefined> {
+    await this.ready();
+    const record = this.#requests.get(runId);
+    if (!record) return undefined;
+    if (isTerminalBrainRequestStatus(record.status)) return { ...record };
+    return new Promise((resolve) => {
+      let timer: ScheduledTimer | undefined;
+      const finish = () => {
+        unsubscribe();
+        if (timer !== undefined) this.#cancel(timer);
+        const current = this.#requests.get(runId);
+        resolve(current ? { ...current } : undefined);
+      };
+      const unsubscribe = this.subscribe(() => {
+        const current = this.#requests.get(runId);
+        if (!current || isTerminalBrainRequestStatus(current.status)) finish();
+      });
+      timer = this.#schedule(finish, timeoutMs);
+    });
+  }
+
+  /**
+   * Cancels a run: a queued one never starts, a running one has its model and
+   * read work aborted and every act not yet dispatched refused. An act whose
+   * effect is already under way is neither retried nor aborted — its result
+   * is kept, known or unknown — because cancelling cannot undo a message
+   * already sent.
+   */
+  async cancelAsk(runId: string): Promise<BrainRequestRecord | undefined> {
+    await this.ready();
+    const record = this.#requests.get(runId);
+    if (!record) return undefined;
+    if (isTerminalBrainRequestStatus(record.status)) return { ...record };
+    const run = this.#runs.get(runId);
+    if (run) {
+      run.cancelled = true;
+      run.abort.abort();
+    }
+    if (record.status === BRAIN_REQUEST_STATUS.QUEUED) {
+      await this.#settleRun(runId, BRAIN_REQUEST_STATUS.CANCELLED, {});
+    }
+    return this.request(runId);
   }
 
   /**
@@ -328,34 +553,6 @@ export class BrainAgent {
     if (this.#stopped || events.length === 0) return;
     this.#pending.push(...events);
     this.#scheduleFlush(this.#wakeCoalesceMs);
-  }
-
-  /**
-   * Asks the brain on the developer's behalf. Pending wakes ride in the same
-   * turn so the reply knows what just changed. Resolves with nothing when the
-   * turn failed or the deadline passed; the turn itself still runs to its end
-   * so the memory never holds half of one.
-   */
-  async ask(question: string): Promise<BrainAskAnswer | undefined> {
-    if (this.#stopped) return undefined;
-    this.#cancelFlush();
-    const events = this.#takePending();
-    const turn = this.#enqueue(() =>
-      this.#turn({
-        trigger: BRAIN_TURN_TRIGGER.ASK,
-        authority: BRAIN_TURN_AUTHORITY.DEVELOPER,
-        events,
-        open: (attached, now) => [askInputItem(question, attached, now)],
-      }),
-    );
-    let deadline: ScheduledTimer | undefined;
-    const timedOut = new Promise<undefined>((resolve) => {
-      deadline = this.#schedule(() => resolve(undefined), this.#askDeadlineMs);
-    });
-    const result = await Promise.race([turn, timedOut]);
-    if (deadline !== undefined) this.#cancel(deadline);
-    if (result?.outcome !== TURN_OUTCOME.DONE) return undefined;
-    return { text: result.text };
   }
 
   /**
@@ -382,11 +579,24 @@ export class BrainAgent {
     );
   }
 
-  /** Drops pending wakes, lets the running turn finish, and takes nothing more. */
+  /**
+   * Drops pending wakes, revokes every run's execution, lets the running turn
+   * wind down, and takes nothing more. Unfinished runs are recorded as
+   * interrupted: the agent stopping — a key or account changing, the app
+   * quitting — is not the developer's cancel, and the record says which.
+   */
   async stop(): Promise<void> {
     this.#stopped = true;
     this.#cancelFlush();
     this.#pending = [];
+    this.#unsubscribeStore?.();
+    this.#unsubscribeStore = undefined;
+    for (const run of this.#runs.values()) run.abort.abort();
+    for (const record of this.requests()) {
+      if (record.status === BRAIN_REQUEST_STATUS.QUEUED) {
+        await this.#settleRun(record.runId, BRAIN_REQUEST_STATUS.INTERRUPTED, {});
+      }
+    }
     await this.#queue;
   }
 
@@ -481,26 +691,175 @@ export class BrainAgent {
     return run;
   }
 
-  #ready(): Promise<void> {
-    this.#restored ??= (async () => {
-      try {
-        const state = await this.#options.restore();
-        if (state) this.#memory = new BrainMemory(state);
-      } catch (error) {
-        this.#report(
-          `Brain memory could not be restored: ${error instanceof Error ? error.name : "unknown error"}`,
+  #notify(): void {
+    const records = this.requests();
+    for (const listener of [...this.#listeners]) listener(records);
+  }
+
+  async #restore(): Promise<void> {
+    let state: BrainPersistedState;
+    try {
+      state = await this.#options.store.load();
+    } catch (error) {
+      this.#report(
+        `Brain memory could not be restored: ${error instanceof Error ? error.name : "unknown error"}`,
+      );
+      return;
+    }
+    this.#adopt(state);
+    const interrupted = interruptedUnfinishedRequests(state.requests, this.#now());
+    const paired = pairedDanglingCalls(state.items, () => JSON.stringify(UNKNOWN_ACT_RESULT));
+    if (interrupted === state.requests && paired === state.items) return;
+    this.#requests = new Map(interrupted.map((record) => [record.runId, record]));
+    this.#memory = new BrainMemory({ items: paired, cursors: state.cursors });
+    await this.#checkpoint(state.generationId);
+    this.#notify();
+  }
+
+  /** Takes an envelope as the agent's working copy: memory, journal, and records alike. */
+  #adopt(state: BrainPersistedState): void {
+    this.#generationId = state.generationId;
+    this.#memory = new BrainMemory({ items: state.items, cursors: state.cursors });
+    this.#journal = new BrainJournal(state.journal);
+    this.#requests = new Map(state.requests.map((record) => [record.runId, { ...record }]));
+  }
+
+  /**
+   * The store's generation changed under this agent — a reset or a
+   * replacement. Every run of the old generation loses its execution at once:
+   * its signal fires, its `isRevoked` answers true, and its late checkpoints
+   * land nowhere because the store fences them by generation. The agent then
+   * works from the new envelope, which holds no record of those runs.
+   */
+  #adoptGeneration(state: BrainPersistedState): void {
+    if (state.generationId === this.#generationId) return;
+    for (const run of this.#runs.values()) {
+      run.cancelled = true;
+      run.abort.abort();
+    }
+    this.#adopt(state);
+    this.#notify();
+  }
+
+  /**
+   * Writes the working copy through the store under the generation it belongs
+   * to. False means the file does not hold what memory holds — refused by the
+   * fence or by storage — and the caller decides what that forbids.
+   */
+  async #checkpoint(generationId: string): Promise<boolean> {
+    const memory = this.#memory.persisted();
+    const requests = this.requests();
+    const journal: readonly BrainJournalEntry[] = this.#journal.entries();
+    const written = await this.#options.store.write(generationId, () => ({
+      items: memory.items,
+      cursors: memory.cursors,
+      requests,
+      journal,
+    }));
+    if (!written) this.#report("Brain memory could not be checkpointed");
+    return written;
+  }
+
+  #runRevoked(run: RunControl): boolean {
+    return (
+      run.cancelled || run.timedOut || this.#stopped || run.generationId !== this.#generationId
+    );
+  }
+
+  async #runAsk(
+    run: RunControl,
+    question: string,
+    events: readonly BrainWakeEvent[],
+  ): Promise<void> {
+    const record = this.#requests.get(run.runId);
+    if (!record || record.status !== BRAIN_REQUEST_STATUS.QUEUED || this.#runRevoked(run)) {
+      if (record?.status === BRAIN_REQUEST_STATUS.QUEUED) {
+        await this.#settleRun(
+          run.runId,
+          this.#stopped ? BRAIN_REQUEST_STATUS.INTERRUPTED : BRAIN_REQUEST_STATUS.CANCELLED,
+          {},
         );
       }
-    })();
-    return this.#restored;
+      this.#runs.delete(run.runId);
+      return;
+    }
+    this.#update(run.runId, { status: BRAIN_REQUEST_STATUS.RUNNING, startedAt: this.#now() });
+    await this.#checkpoint(run.generationId);
+    this.#notify();
+    run.deadline = this.#schedule(() => {
+      run.timedOut = true;
+      run.abort.abort();
+    }, this.#executionDeadlineMs);
+    let result: TurnResult;
+    try {
+      result = await this.#turn({
+        trigger: BRAIN_TURN_TRIGGER.ASK,
+        authority: BRAIN_TURN_AUTHORITY.DEVELOPER,
+        events,
+        open: (attached, now) => [askInputItem(question, attached, now)],
+        run,
+      });
+    } catch {
+      result = { outcome: TURN_OUTCOME.FAILED };
+    }
+    if (run.deadline !== undefined) this.#cancel(run.deadline);
+    this.#runs.delete(run.runId);
+    const end: RunEnd = {};
+    let status: BrainRequestRecord["status"];
+    if (run.timedOut) {
+      status = BRAIN_REQUEST_STATUS.TIMED_OUT;
+      end.failure = BRAIN_REQUEST_FAILURE.DEADLINE;
+    } else if (run.cancelled) {
+      status = BRAIN_REQUEST_STATUS.CANCELLED;
+    } else if (this.#stopped || run.generationId !== this.#generationId) {
+      status = BRAIN_REQUEST_STATUS.INTERRUPTED;
+    } else if (result.outcome !== TURN_OUTCOME.DONE) {
+      status = BRAIN_REQUEST_STATUS.FAILED;
+      end.failure = BRAIN_REQUEST_FAILURE.MODEL;
+    } else if (run.checkpointFailed) {
+      status = BRAIN_REQUEST_STATUS.FAILED;
+      end.failure = BRAIN_REQUEST_FAILURE.PERSISTENCE;
+      if (result.text) end.text = result.text;
+    } else {
+      status = BRAIN_REQUEST_STATUS.SUCCEEDED;
+      if (result.text) end.text = result.text;
+    }
+    await this.#settleRun(run.runId, status, end, run.performedActs, run.generationId);
+  }
+
+  #update(runId: string, changes: Partial<Omit<BrainRequestRecord, "runId" | "revision">>): void {
+    const record = this.#requests.get(runId);
+    if (!record) return;
+    this.#requests.set(runId, { ...record, ...changes, revision: record.revision + 1 });
+  }
+
+  async #settleRun(
+    runId: string,
+    status: BrainRequestRecord["status"],
+    end: RunEnd,
+    performedActs?: number,
+    generationId = this.#generationId,
+  ): Promise<void> {
+    const record = this.#requests.get(runId);
+    if (!record || isTerminalBrainRequestStatus(record.status)) return;
+    this.#update(runId, {
+      status,
+      settledAt: this.#now(),
+      ...(end.text !== undefined ? { text: end.text } : undefined),
+      ...(end.failure !== undefined ? { failure: end.failure } : undefined),
+      ...(performedActs !== undefined ? { performedActs } : undefined),
+    });
+    if (generationId !== undefined) await this.#checkpoint(generationId);
+    this.#notify();
   }
 
   async #turn(plan: TurnPlan): Promise<TurnResult> {
     this.#turnInFlight = true;
     let ended = false;
+    const run = plan.run;
     const execution: BrainActExecution = {
       authority: BRAIN_TURN_AUTHORITY.DEVELOPER,
-      isRevoked: () => ended || this.#stopped,
+      isRevoked: () => ended || this.#stopped || (run !== undefined && this.#runRevoked(run)),
     };
     try {
       return await this.#runTurn(plan, execution);
@@ -511,9 +870,10 @@ export class BrainAgent {
   }
 
   async #runTurn(plan: TurnPlan, execution: BrainActExecution): Promise<TurnResult> {
-    await this.#ready();
+    await this.ready();
+    const run = plan.run;
     const startedAt = this.#now();
-    const mark = this.#memory.mark();
+    let mark = this.#memory.mark();
     const appendedKinds: string[] = [];
     const toolCalls: BrainToolCallTrace[] = [];
     const deliveries: BrainDelivery[] = [];
@@ -521,13 +881,14 @@ export class BrainAgent {
     let compacted = false;
     let inputTokens: number | undefined;
     let outputText = "";
-    let failure: TurnResult | undefined;
     let error: string | undefined;
 
-    const append = (items: readonly ResponsesInputItem[]) => {
-      this.#memory.append(items);
-      for (const item of items) appendedKinds.push(text(item.type) ?? "unknown");
+    const revoked = () => run !== undefined && this.#runRevoked(run);
+    const revocation = (): TurnResult => {
+      error = run?.timedOut ? "execution deadline passed" : "run revoked";
+      return { outcome: TURN_OUTCOME.REVOKED };
     };
+    if (revoked()) return revocation();
 
     const attachedDeltas = await this.#attachDeltas(plan.events);
     const transcriptBytes = attachedDeltas.transcriptBytes;
@@ -536,87 +897,50 @@ export class BrainAgent {
           (event) => event.kind !== BRAIN_WAKE_KIND.ROSTER || Boolean(event.transcriptDelta?.text),
         )
       : attachedDeltas.events;
+    const append = (items: readonly ResponsesInputItem[]) => {
+      this.#memory.append(items);
+      for (const item of items) appendedKinds.push(text(item.type) ?? "unknown");
+    };
     append(plan.open(events, startedAt));
 
-    for (;;) {
-      const roster = this.#options.roster();
-      const context = standingContextItem(
-        roster.text,
-        this.#options.standingContext(),
-        this.#now(),
-      );
-      const answer = await this.#options.client.respond([...this.#memory.items(), context], {
-        authority: plan.authority,
-        maximumOutputTokens: this.#maximumOutputTokens,
+    let failure: TurnResult | undefined;
+    try {
+      failure = await this.#loop(plan, execution, {
+        append,
+        toolCalls,
+        deliveries,
+        onIteration: () => {
+          iterations += 1;
+        },
+        onOutput: (output) => {
+          if (output.compacted) {
+            this.#memory.dropBeforeLatestCompaction();
+            compacted = true;
+          }
+          if (output.inputTokens !== undefined) inputTokens = output.inputTokens;
+          outputText = output.outputText;
+        },
+        onError: (reason) => {
+          error = reason;
+        },
+        // Only a developer run advances its rollback point: each answered act
+        // is checkpointed and the mark moves past it, so a later failure returns
+        // the memory to the last paired state and never to before an act that
+        // already happened. An observation turn still rolls back whole, so the
+        // deltas it read are read again next time rather than skipped.
+        advanceMark: async () => {
+          if (!run) return;
+          if (!(await this.#checkpoint(run.generationId))) run.checkpointFailed = true;
+          mark = this.#memory.mark();
+        },
+        revoked,
+        revocation,
       });
-      if (answer.outcome === BRAIN_CLIENT_OUTCOME.QUIET) {
-        failure = { outcome: TURN_OUTCOME.QUIET, until: answer.until };
-        error = "quiet";
-        break;
-      }
-      if (answer.outcome === BRAIN_CLIENT_OUTCOME.FAILED) {
-        failure = { outcome: TURN_OUTCOME.FAILED };
-        error = answer.reason;
-        break;
-      }
-      const output = brainResponsesOutput(answer.payload);
-      if (!output) {
-        failure = { outcome: TURN_OUTCOME.FAILED };
-        error = "response carried no output";
-        break;
-      }
-      append(output.items);
-      if (output.compacted) {
-        this.#memory.dropBeforeLatestCompaction();
-        compacted = true;
-      }
-      if (output.inputTokens !== undefined) inputTokens = output.inputTokens;
-      outputText = output.outputText;
-      if (output.functionCalls.length === 0) {
-        if (output.incompleteReason && !outputText) {
-          error = `${output.status ?? "incomplete"}: ${output.incompleteReason}`;
-        }
-        break;
-      }
-
-      iterations += 1;
-      if (iterations > this.#maxToolIterations) {
-        // Every call still gets its output so the memory never holds a
-        // dangling function_call; the model reads the refusals next turn.
-        append(
-          output.functionCalls.map((call) => {
-            toolCalls.push({
-              name: call.name,
-              argumentsChars: call.argumentsJson.length,
-              outcomeStatus: ACT_RESULT_STATUS.REJECTED,
-            });
-            return functionCallOutputItem(
-              call.callId,
-              JSON.stringify(rejection(REFUSAL_REASON.BUDGET_SPENT)),
-            );
-          }),
-        );
-        error = "tool iteration budget spent";
-        break;
-      }
-
-      const outcomes = await Promise.all(
-        output.functionCalls.map((call) =>
-          this.#dispatch(call, roster, plan, execution, deliveries).then((outcome) => {
-            toolCalls.push({
-              name: call.name,
-              argumentsChars: call.argumentsJson.length,
-              outcomeStatus: text(outcome.output.status) ?? "answered",
-            });
-            return outcome;
-          }),
-        ),
-      );
-      append(
-        outcomes.map((outcome) =>
-          functionCallOutputItem(outcome.callId, JSON.stringify(outcome.output)),
-        ),
-      );
+    } catch (loopError) {
+      // A client or performer that threw instead of answering: the turn fails
+      // like one whose model failed, and rolls back to the last paired state.
+      error = loopError instanceof Error ? loopError.name : "unknown error";
+      failure = revoked() ? revocation() : { outcome: TURN_OUTCOME.FAILED };
     }
 
     if (failure) {
@@ -624,13 +948,9 @@ export class BrainAgent {
       this.#report(`Brain ${plan.trigger} turn did not complete: ${error}`);
     } else {
       this.#memory.retainCursors(this.#options.roster().identities);
-      try {
-        await this.#options.persist(this.#memory.persisted());
-      } catch (persistError) {
-        this.#report(
-          `Brain memory could not be persisted: ${persistError instanceof Error ? persistError.name : "unknown error"}`,
-        );
-      }
+      const generationId = run?.generationId ?? this.#generationId;
+      const written = generationId !== undefined && (await this.#checkpoint(generationId));
+      if (!written && run) run.checkpointFailed = true;
       for (const delivery of deliveries) {
         try {
           await this.#options.deliver(delivery);
@@ -659,6 +979,89 @@ export class BrainAgent {
     });
 
     return failure ?? { outcome: TURN_OUTCOME.DONE, text: outputText };
+  }
+
+  /** The model loop: answers a failure to roll back to, or nothing when the turn reached its text. */
+  async #loop(
+    plan: TurnPlan,
+    execution: BrainActExecution,
+    hooks: LoopHooks,
+  ): Promise<TurnResult | undefined> {
+    let iterations = 0;
+    for (;;) {
+      const roster = this.#options.roster();
+      const context = standingContextItem(
+        roster.text,
+        this.#options.standingContext(),
+        this.#now(),
+      );
+      const answer = await this.#options.client.respond([...this.#memory.items(), context], {
+        authority: plan.authority,
+        maximumOutputTokens: this.#maximumOutputTokens,
+        ...(plan.run ? { signal: plan.run.abort.signal } : undefined),
+      });
+      if (hooks.revoked()) return hooks.revocation();
+      if (answer.outcome === BRAIN_CLIENT_OUTCOME.QUIET) {
+        hooks.onError("quiet");
+        return { outcome: TURN_OUTCOME.QUIET, until: answer.until };
+      }
+      if (answer.outcome === BRAIN_CLIENT_OUTCOME.FAILED) {
+        hooks.onError(answer.reason);
+        return { outcome: TURN_OUTCOME.FAILED };
+      }
+      const output = brainResponsesOutput(answer.payload);
+      if (!output) {
+        hooks.onError("response carried no output");
+        return { outcome: TURN_OUTCOME.FAILED };
+      }
+      hooks.append(output.items);
+      hooks.onOutput(output);
+      if (output.functionCalls.length === 0) {
+        if (output.incompleteReason && !output.outputText) {
+          hooks.onError(`${output.status ?? "incomplete"}: ${output.incompleteReason}`);
+        }
+        return undefined;
+      }
+
+      iterations += 1;
+      hooks.onIteration();
+      if (iterations > this.#maxToolIterations) {
+        // Every call still gets its output so the memory never holds a
+        // dangling function_call; the model reads the refusals next turn.
+        hooks.append(
+          output.functionCalls.map((call) => {
+            hooks.toolCalls.push({
+              name: call.name,
+              argumentsChars: call.argumentsJson.length,
+              outcomeStatus: ACT_RESULT_STATUS.REJECTED,
+            });
+            return functionCallOutputItem(
+              call.callId,
+              JSON.stringify(rejection(REFUSAL_REASON.BUDGET_SPENT)),
+            );
+          }),
+        );
+        hooks.onError("tool iteration budget spent");
+        await hooks.advanceMark();
+        return undefined;
+      }
+
+      // Calls run in the order the model emitted them, one at a time: an act
+      // is journaled and checkpointed before the next one starts, and a
+      // cancel landing between two refuses the second rather than racing it.
+      for (const call of output.functionCalls) {
+        const outcome = await this.#dispatch(call, roster, plan, execution, hooks.deliveries);
+        hooks.toolCalls.push({
+          name: call.name,
+          argumentsChars: call.argumentsJson.length,
+          outcomeStatus: text(outcome.output.status) ?? "answered",
+        });
+        hooks.append([functionCallOutputItem(outcome.callId, JSON.stringify(outcome.output))]);
+        if (plan.run && this.#journal.get(plan.run.runId, call.callId)) await hooks.advanceMark();
+      }
+      await hooks.advanceMark();
+      if (hooks.revoked()) return hooks.revocation();
+    }
   }
 
   /**
@@ -731,25 +1134,19 @@ export class BrainAgent {
     const refused = this.#refusalForAuthority(plan, call.name);
     if (refused) return { callId: call.callId, output: refused };
 
-    const args = parsedArguments(call.argumentsJson);
+    const args = parsedRecord(call.argumentsJson);
     const observed = (identity: SessionIdentity) =>
       roster.identities.some((listed) => sameIdentity(listed, identity));
     const named = identityFromRecord(args);
 
     if (!isBrainOnlyTool(call.name)) {
-      if (plan.authority !== BRAIN_TURN_AUTHORITY.DEVELOPER) {
+      if (plan.authority !== BRAIN_TURN_AUTHORITY.DEVELOPER || !plan.run) {
         return { callId: call.callId, output: rejection(REFUSAL_REASON.ACT_IN_OBSERVATION) };
       }
-      let output: WireRecord;
-      try {
-        output = await this.#options.acts.perform(
-          { name: call.name, argumentsJson: call.argumentsJson },
-          execution,
-        );
-      } catch {
-        output = rejection(REFUSAL_REASON.ACT_FAILED);
-      }
-      return { callId: call.callId, output };
+      return {
+        callId: call.callId,
+        output: await this.#performJournaled(call, plan.run, execution),
+      };
     }
 
     switch (call.name) {
@@ -758,6 +1155,9 @@ export class BrainAgent {
       case BRAIN_TOOL.READ_TRANSCRIPT: {
         if (!named || !observed(named)) {
           return { callId: call.callId, output: rejection(REFUSAL_REASON.UNOBSERVED_SESSION) };
+        }
+        if (plan.run && this.#runRevoked(plan.run)) {
+          return { callId: call.callId, output: rejection(REFUSAL_REASON.RUN_REVOKED) };
         }
         return { callId: call.callId, output: await this.#readWhole(named) };
       }
@@ -773,6 +1173,58 @@ export class BrainAgent {
         return { callId: call.callId, output: { status: ACT_RESULT_STATUS.ACCEPTED } };
       }
     }
+  }
+
+  /**
+   * One act through the journal. A call id the run already answered gets its
+   * recorded result back rather than a second effect — or the honest unknown,
+   * when the act started and its result was lost — and the same id with other
+   * arguments is refused rather than guessed at. A fresh call is written as
+   * started and checkpointed before the performer sees it, so a crash mid-act
+   * is found as an act of unknown result and never replayed; a checkpoint
+   * that will not land refuses the act instead, because an act nobody could
+   * find afterwards is one the developer could not account for.
+   */
+  async #performJournaled(
+    call: BrainFunctionCall,
+    run: RunControl,
+    execution: BrainActExecution,
+  ): Promise<WireRecord> {
+    if (this.#runRevoked(run)) return rejection(REFUSAL_REASON.RUN_REVOKED);
+    const recorded = this.#journal.get(run.runId, call.callId);
+    if (recorded) {
+      if (recorded.argumentsJson !== call.argumentsJson) {
+        return rejection(REFUSAL_REASON.CALL_ID_REUSED);
+      }
+      return recorded.outputJson === undefined
+        ? { ...UNKNOWN_ACT_RESULT }
+        : parsedRecord(recorded.outputJson);
+    }
+    if (run.checkpointFailed) return rejection(REFUSAL_REASON.NOT_CHECKPOINTED);
+    this.#journal.start({
+      runId: run.runId,
+      callId: call.callId,
+      name: call.name,
+      argumentsJson: call.argumentsJson,
+      startedAt: this.#now(),
+    });
+    if (!(await this.#checkpoint(run.generationId))) {
+      this.#journal.forget(run.runId, call.callId);
+      run.checkpointFailed = true;
+      return rejection(REFUSAL_REASON.NOT_CHECKPOINTED);
+    }
+    let output: WireRecord;
+    try {
+      output = await this.#options.acts.perform(
+        { name: call.name, argumentsJson: call.argumentsJson },
+        execution,
+      );
+    } catch {
+      output = rejection(REFUSAL_REASON.ACT_FAILED);
+    }
+    if (output.status === ACT_RESULT_STATUS.ACCEPTED) run.performedActs += 1;
+    this.#journal.settle(run.runId, call.callId, JSON.stringify(output), this.#now());
+    return output;
   }
 
   async #readWhole(identity: SessionIdentity): Promise<WireRecord> {

--- a/packages/brain/src/brain-agent.ts
+++ b/packages/brain/src/brain-agent.ts
@@ -451,6 +451,7 @@ export class BrainAgent {
   readonly #lease: BrainStoreLease;
   readonly #runs = new Map<string, RunControl>();
   readonly #pendingSubmissions = new Map<string, PendingSubmission>();
+  readonly #pendingMarks = new Map<string, Promise<boolean>>();
   readonly #listeners = new Set<BrainRequestsListener>();
   #turnInFlight = false;
   #restored: Promise<void> | undefined;
@@ -481,6 +482,11 @@ export class BrainAgent {
     this.#fullTranscriptChars = options.fullTranscriptChars ?? BRAIN_DEFAULTS.FULL_TRANSCRIPT_CHARS;
     this.#lease = options.store.lease();
     this.#unsubscribeStore = options.store.onReplaced((state) => this.#adoptGeneration(state));
+  }
+
+  /** The store lease this agent writes under, for a host to check who owns the store. */
+  get lease(): BrainStoreLease {
+    return this.#lease;
   }
 
   /** How many wakes are waiting for their turn to open. */
@@ -695,32 +701,78 @@ export class BrainAgent {
    * memory either, so the next report tries the whole step again.
    */
   markHistoryRecorded(runId: string, recordedAt: number): Promise<boolean> {
-    return this.#mark(runId, (record) =>
-      record.historyRecordedAt === undefined ? { historyRecordedAt: recordedAt } : undefined,
-    );
+    return this.#mark(runId, "historyRecordedAt", recordedAt);
   }
 
   /** Marks a run's own ask as written into the host's thread, on the same terms. */
   markAskRecorded(runId: string, recordedAt: number): Promise<boolean> {
-    return this.#mark(runId, (record) =>
-      record.askRecordedAt === undefined ? { askRecordedAt: recordedAt } : undefined,
-    );
+    return this.#mark(runId, "askRecordedAt", recordedAt);
   }
 
+  /**
+   * Writes one marker onto a run without the marker ever standing in memory
+   * before it stands on disk: the write carries the record as it would read
+   * with the marker, and only a write that landed puts the marker on the live
+   * record — merged onto whatever else has advanced meanwhile, never a
+   * captured copy rolled over it. Callers marking the same field of the same
+   * run while a write is out share that write's answer, the way retried
+   * submissions share one acceptance.
+   */
   async #mark(
     runId: string,
-    change: (record: BrainRequestRecord) => Partial<BrainRequestRecord> | undefined,
+    field: "askRecordedAt" | "historyRecordedAt",
+    recordedAt: number,
   ): Promise<boolean> {
-    await this.ready();
-    const generation = this.#generation;
-    const record = generation?.requests.get(runId);
-    if (!generation || !record) return false;
-    const changes = change(record);
-    if (!changes) return true;
+    const key = `${runId}\u0000${field}`;
+    const pending = this.#pendingMarks.get(key);
+    if (pending) return pending;
+    const marking = (async () => {
+      await this.ready();
+      const generation = this.#generation;
+      const record = generation?.requests.get(runId);
+      if (!generation || !record) return false;
+      if (record[field] !== undefined) return true;
+      return this.#commit(generation, runId, { [field]: recordedAt });
+    })();
+    this.#pendingMarks.set(key, marking);
+    try {
+      return await marking;
+    } finally {
+      this.#pendingMarks.delete(key);
+    }
+  }
+
+  /**
+   * A staged write of some fields of one record: the store is handed the
+   * generation as it stands with those fields applied, and the live record
+   * takes them only once the store has. Nothing reads the fields in between,
+   * so no caller — a wait, a snapshot, a follower — can act on a state the
+   * file may yet refuse.
+   */
+  async #commit(
+    generation: Generation,
+    runId: string,
+    changes: Partial<Omit<BrainRequestRecord, "runId" | "revision">>,
+  ): Promise<boolean> {
+    const memory = generation.memory.persisted();
+    const journal: readonly BrainJournalEntry[] = generation.journal.entries();
+    const staged = [...generation.requests.values()].map((record) =>
+      record.runId === runId
+        ? { ...record, ...changes, revision: record.revision + 1 }
+        : { ...record },
+    );
+    const written = await this.#options.store.write(this.#lease, generation.id, () => ({
+      items: memory.items,
+      cursors: memory.cursors,
+      requests: staged,
+      journal,
+    }));
+    if (!written) {
+      this.#report("Brain memory could not be checkpointed");
+      return false;
+    }
     this.#update(generation, runId, changes);
-    if (await this.#checkpoint(generation)) return true;
-    generation.requests.set(runId, record);
-    return false;
+    return true;
   }
 
   /**
@@ -1094,6 +1146,15 @@ export class BrainAgent {
    * write is tried once more; a failed end that will not write is reported
    * and stands in memory alone.
    */
+  /**
+   * Ends a run in its record, staged behind the write that keeps it: until
+   * the store has answered, every reader — a wait, a snapshot, the follower —
+   * still sees the run under way, so no success is spoken or written that the
+   * file may yet refuse. A success the store refuses is downgraded to a
+   * persistence failure, the reply kept, and written once more; an end the
+   * store will not take at all stands in memory alone, as the failure it is,
+   * so the run still finishes for everyone watching it.
+   */
   async #settleRun(
     generation: Generation,
     runId: string,
@@ -1103,19 +1164,27 @@ export class BrainAgent {
   ): Promise<void> {
     const record = generation.requests.get(runId);
     if (!record || isTerminalBrainRequestStatus(record.status)) return;
-    this.#update(generation, runId, {
+    const settled: Partial<Omit<BrainRequestRecord, "runId" | "revision">> = {
       status,
       settledAt: this.#now(),
       ...(end.text !== undefined ? { text: end.text } : undefined),
       ...(end.failure !== undefined ? { failure: end.failure } : undefined),
       ...(run ? { performedActs: run.performedActs, unknownActs: run.unknownActs } : undefined),
-    });
-    if (!(await this.#checkpoint(generation)) && status === BRAIN_REQUEST_STATUS.SUCCEEDED) {
-      this.#update(generation, runId, {
-        status: BRAIN_REQUEST_STATUS.FAILED,
-        failure: BRAIN_REQUEST_FAILURE.PERSISTENCE,
-      });
-      await this.#checkpoint(generation);
+    };
+    if (await this.#commit(generation, runId, settled)) {
+      this.#notify();
+      return;
+    }
+    const fallback =
+      status === BRAIN_REQUEST_STATUS.SUCCEEDED
+        ? {
+            ...settled,
+            status: BRAIN_REQUEST_STATUS.FAILED,
+            failure: BRAIN_REQUEST_FAILURE.PERSISTENCE,
+          }
+        : settled;
+    if (!(await this.#commit(generation, runId, fallback))) {
+      this.#update(generation, runId, fallback);
     }
     this.#notify();
   }

--- a/packages/brain/src/brain-agent.ts
+++ b/packages/brain/src/brain-agent.ts
@@ -1143,11 +1143,37 @@ export class BrainAgent {
       this.#runs.delete(run.runId);
       return;
     }
-    await this.#commit(generation, run.runId, {
+    // The start is durable before any work opens: a run the file does not
+    // show running is one a relaunch would find queued while its acts had
+    // begun, and a cancel would settle on the queued path under a dispatched
+    // effect. A start the store refuses ends the run as the persistence
+    // failure it is, with nothing called; a revocation that landed while the
+    // start was being written ends it on its own terms, likewise unopened.
+    const started = await this.#commit(generation, run.runId, {
       status: BRAIN_REQUEST_STATUS.RUNNING,
       startedAt: this.#now(),
     });
     this.#notify();
+    if (!started || this.#runRevoked(run)) {
+      this.#runs.delete(run.runId);
+      if (this.#runRevoked(run)) {
+        await this.#settleRun(
+          generation,
+          run.runId,
+          run.cancelled ? BRAIN_REQUEST_STATUS.CANCELLED : BRAIN_REQUEST_STATUS.INTERRUPTED,
+          {},
+        );
+        return;
+      }
+      await this.#settleRun(
+        generation,
+        run.runId,
+        BRAIN_REQUEST_STATUS.FAILED,
+        { failure: BRAIN_REQUEST_FAILURE.PERSISTENCE },
+        run,
+      );
+      return;
+    }
     run.deadline = this.#schedule(() => {
       run.timedOut = true;
       run.abort.abort();

--- a/packages/brain/src/brain-client.ts
+++ b/packages/brain/src/brain-client.ts
@@ -47,6 +47,8 @@ export interface BrainRespondOptions {
   /** Who opened the turn; it fixes the toolset and is never inferred from the input. */
   authority: BrainTurnAuthority;
   maximumOutputTokens: number;
+  /** Fires when the run this turn belongs to is cancelled or times out; the request is dropped with it. */
+  signal?: AbortSignal;
 }
 
 export interface BrainClient {
@@ -90,6 +92,12 @@ type FetchLike = (input: string, init: RequestInit) => Promise<Response>;
 
 function withoutTrailingSlash(value: string): string {
   return value.endsWith("/") ? value.slice(0, -1) : value;
+}
+
+/** The per-request timeout, joined with the run's own cancellation when the turn belongs to one. */
+function requestSignal(timeoutMs: number, cancellation: AbortSignal | undefined): AbortSignal {
+  const timeout = AbortSignal.timeout(timeoutMs);
+  return cancellation ? AbortSignal.any([timeout, cancellation]) : timeout;
 }
 
 function failed(reason: string): BrainClientAnswer {
@@ -178,7 +186,7 @@ export class OpenAiBrainClient implements BrainClient {
             reasoningEffort: this.#reasoningEffort,
           }),
         ),
-        signal: AbortSignal.timeout(this.#requestTimeoutMs),
+        signal: requestSignal(this.#requestTimeoutMs, options.signal),
       });
     } catch (error) {
       return failed(
@@ -289,13 +297,15 @@ export class HostedBrainClient implements BrainClient {
       input,
       max_output_tokens: options.maximumOutputTokens,
     };
-    let response = await this.#request(token, request);
+    let response = await this.#request(token, request, options.signal);
     if (response?.status === UNAUTHORIZED_STATUS) {
       // Routine expiry of an hour-lived token inside a day-lived app: refresh
       // and retry once, like the hosted mint.
       await this.#refreshAccount().catch(() => undefined);
       const refreshed = await this.#readAccessToken();
-      if (refreshed && refreshed !== token) response = await this.#request(refreshed, request);
+      if (refreshed && refreshed !== token) {
+        response = await this.#request(refreshed, request, options.signal);
+      }
     }
     if (!response) return failed("request did not complete");
     if (response.status === RATE_LIMIT_STATUS) return this.#quiet(response);
@@ -303,7 +313,11 @@ export class HostedBrainClient implements BrainClient {
     return answered(response);
   }
 
-  async #request(token: string, request: HostedBrainRequest): Promise<Response | undefined> {
+  async #request(
+    token: string,
+    request: HostedBrainRequest,
+    signal: AbortSignal | undefined,
+  ): Promise<Response | undefined> {
     try {
       return await this.#fetch(this.#endpoint, {
         method: "POST",
@@ -312,7 +326,7 @@ export class HostedBrainClient implements BrainClient {
           "content-type": "application/json",
         },
         body: JSON.stringify(request),
-        signal: AbortSignal.timeout(this.#requestTimeoutMs),
+        signal: requestSignal(this.#requestTimeoutMs, signal),
       });
     } catch {
       return undefined;

--- a/packages/brain/src/brain-journal.ts
+++ b/packages/brain/src/brain-journal.ts
@@ -45,11 +45,29 @@ export function brainJournalEntryFromWire(value: UnparsedWireValue): BrainJourna
   return entry;
 }
 
+/** The status an act's output carries when whether it happened cannot be established. */
+export const UNKNOWN_ACT_STATUS = "unknown";
+
 /** What a model is told about a call whose act ran but whose result never reached the journal. */
 export const UNKNOWN_ACT_RESULT = {
-  status: "unknown",
+  status: UNKNOWN_ACT_STATUS,
   reason: "the act was started but its result was lost before it was recorded",
 } as const;
+
+/**
+ * What a model is told about a call whose performer threw after dispatch: the
+ * provider may have taken the write, so it is neither a refusal nor a result,
+ * and it is never retried on the model's own initiative.
+ */
+export const UNCONFIRMED_ACT_RESULT = {
+  status: UNKNOWN_ACT_STATUS,
+  reason: "the act was dispatched but did not answer; it may have happened, so do not repeat it",
+} as const;
+
+/** How many of a run's journaled acts have no recorded result. */
+export function unknownActCount(entries: readonly BrainJournalEntry[], runId: string): number {
+  return entries.filter((entry) => entry.runId === runId && entry.outputJson === undefined).length;
+}
 
 /**
  * Journal entries as one run reads them: by call id, with the two questions

--- a/packages/brain/src/brain-journal.ts
+++ b/packages/brain/src/brain-journal.ts
@@ -1,0 +1,106 @@
+import { isRecord, isWireNumber, isWireString, type UnparsedWireValue } from "@sidecar/wire";
+
+/**
+ * The action journal: one entry per act a developer ask dispatched, keyed by
+ * the run and the model's own call id. An entry is written before the
+ * performer is called and completed with the act's result before the model
+ * hears it, so a crash between the two leaves a started entry whose result is
+ * unknown — never replayed, and answered to the model as exactly that.
+ */
+
+export interface BrainJournalEntry {
+  runId: string;
+  callId: string;
+  name: string;
+  argumentsJson: string;
+  startedAt: number;
+  /** The act's outcome as a JSON record, once the performer answered. */
+  outputJson?: string;
+  settledAt?: number;
+}
+
+export function brainJournalEntryFromWire(value: UnparsedWireValue): BrainJournalEntry | undefined {
+  if (!isRecord(value)) return undefined;
+  if (!isWireString(value.runId) || !isWireString(value.callId) || !isWireString(value.name)) {
+    return undefined;
+  }
+  if (!isWireString(value.argumentsJson)) return undefined;
+  if (!isWireNumber(value.startedAt) || !Number.isFinite(value.startedAt)) return undefined;
+  if (value.outputJson !== undefined && !isWireString(value.outputJson)) return undefined;
+  if (
+    value.settledAt !== undefined &&
+    !(isWireNumber(value.settledAt) && Number.isFinite(value.settledAt))
+  ) {
+    return undefined;
+  }
+  const entry: BrainJournalEntry = {
+    runId: value.runId,
+    callId: value.callId,
+    name: value.name,
+    argumentsJson: value.argumentsJson,
+    startedAt: value.startedAt,
+  };
+  if (value.outputJson !== undefined) entry.outputJson = value.outputJson;
+  if (value.settledAt !== undefined) entry.settledAt = value.settledAt;
+  return entry;
+}
+
+/** What a model is told about a call whose act ran but whose result never reached the journal. */
+export const UNKNOWN_ACT_RESULT = {
+  status: "unknown",
+  reason: "the act was started but its result was lost before it was recorded",
+} as const;
+
+/**
+ * Journal entries as one run reads them: by call id, with the two questions
+ * the dispatch asks — has this call already been answered, and does a repeated
+ * id carry the same arguments it did the first time.
+ */
+export class BrainJournal {
+  readonly #entries = new Map<string, Map<string, BrainJournalEntry>>();
+
+  constructor(entries: readonly BrainJournalEntry[] = []) {
+    for (const entry of entries) this.#run(entry.runId).set(entry.callId, { ...entry });
+  }
+
+  #run(runId: string): Map<string, BrainJournalEntry> {
+    let run = this.#entries.get(runId);
+    if (!run) {
+      run = new Map();
+      this.#entries.set(runId, run);
+    }
+    return run;
+  }
+
+  get(runId: string, callId: string): BrainJournalEntry | undefined {
+    return this.#entries.get(runId)?.get(callId);
+  }
+
+  start(entry: Omit<BrainJournalEntry, "outputJson" | "settledAt">): void {
+    this.#run(entry.runId).set(entry.callId, { ...entry });
+  }
+
+  settle(runId: string, callId: string, outputJson: string, settledAt: number): void {
+    const entry = this.get(runId, callId);
+    if (!entry) return;
+    entry.outputJson = outputJson;
+    entry.settledAt = settledAt;
+  }
+
+  /** Every entry, runs in insertion order and calls in dispatch order. */
+  entries(): readonly BrainJournalEntry[] {
+    return [...this.#entries.values()].flatMap((run) => [...run.values()].map((e) => ({ ...e })));
+  }
+
+  /** Drops one entry whose start could not be checkpointed, so it never reads as an act that ran. */
+  forget(runId: string, callId: string): void {
+    const run = this.#entries.get(runId);
+    run?.delete(callId);
+    if (run?.size === 0) this.#entries.delete(runId);
+  }
+
+  /** Drops the journals of the runs named, for the host's retention to call. */
+  dropRuns(runIds: Iterable<string>): void {
+    for (const runId of runIds) this.#entries.delete(runId);
+  }
+}

--- a/packages/brain/src/brain-journal.ts
+++ b/packages/brain/src/brain-journal.ts
@@ -64,9 +64,45 @@ export const UNCONFIRMED_ACT_RESULT = {
   reason: "the act was dispatched but did not answer; it may have happened, so do not repeat it",
 } as const;
 
-/** How many of a run's journaled acts have no recorded result. */
-export function unknownActCount(entries: readonly BrainJournalEntry[], runId: string): number {
-  return entries.filter((entry) => entry.runId === runId && entry.outputJson === undefined).length;
+/** What a run's journal can vouch for: acts that went through, and acts whose outcome is not known. */
+export interface JournalActCounts {
+  performedActs: number;
+  unknownActs: number;
+}
+
+/**
+ * Reads a run's accounting from its journal alone: an entry whose result was
+ * accepted went through; one whose result says unknown, or that has no result
+ * at all, may have. Counting from the journal rather than from a running
+ * tally means a launch that finds the run mid-flight reports exactly what
+ * the acts before the crash established, no more and no less.
+ */
+export function journalActCounts(
+  entries: readonly BrainJournalEntry[],
+  runId: string,
+): JournalActCounts {
+  const counts: JournalActCounts = { performedActs: 0, unknownActs: 0 };
+  for (const entry of entries) {
+    if (entry.runId !== runId) continue;
+    if (entry.outputJson === undefined) {
+      counts.unknownActs += 1;
+      continue;
+    }
+    const status = outputStatus(entry.outputJson);
+    if (status === "accepted") counts.performedActs += 1;
+    else if (status === UNKNOWN_ACT_STATUS) counts.unknownActs += 1;
+  }
+  return counts;
+}
+
+function outputStatus(outputJson: string): string | undefined {
+  try {
+    // SAFETY: JSON.parse returns a wire value; the record and string guards are the validation.
+    const parsed = JSON.parse(outputJson) as UnparsedWireValue;
+    return isRecord(parsed) && isWireString(parsed.status) ? parsed.status : undefined;
+  } catch {
+    return undefined;
+  }
 }
 
 /**

--- a/packages/brain/src/brain-memory.test.ts
+++ b/packages/brain/src/brain-memory.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { BRAIN_STATE_VERSION, BrainMemory, brainPersistedStateFromWire } from "./brain-memory.js";
-import { userMessageItem } from "./brain-openai.js";
+import { BrainMemory, pairedDanglingCalls } from "./brain-memory.js";
+import { functionCallOutputItem, userMessageItem } from "./brain-openai.js";
 
 const IDENTITY = { providerId: "claude-code", providerSessionId: "abc" };
 const COMPACTION = { type: "compaction", id: "cmp_1", encrypted_content: "folded" };
@@ -31,21 +31,28 @@ test("a mark rolls back items and cursors together, even across a compaction dro
   assert.equal(memory.cursor(IDENTITY), "10");
 });
 
-test("the persisted shape round-trips through the wire reader and refuses other versions", () => {
+test("the working copy round-trips through its persisted shape", () => {
   const memory = new BrainMemory();
   memory.append([COMPACTION, userMessageItem("after")]);
   memory.setCursor(IDENTITY, "42");
   const state = memory.persisted();
-  assert.equal(state.version, BRAIN_STATE_VERSION);
   assert.deepEqual(state.cursors, { "claude-code": { abc: "42" } });
-  const parsed = brainPersistedStateFromWire(JSON.parse(JSON.stringify(state)));
-  assert.deepEqual(parsed, state);
-  const restored = new BrainMemory(parsed);
+  const restored = new BrainMemory(state);
   assert.equal(restored.cursor(IDENTITY), "42");
   assert.deepEqual(restored.items(), state.items);
-  assert.equal(brainPersistedStateFromWire({ ...state, version: 2 }), undefined);
-  assert.equal(brainPersistedStateFromWire({ ...state, items: ["text"] }), undefined);
-  assert.equal(brainPersistedStateFromWire({ ...state, cursors: { a: { b: 1 } } }), undefined);
+});
+
+test("a function_call with no output anywhere after it is paired, and a paired one left alone", () => {
+  const call = (id: string) => ({ type: "function_call", call_id: id, name: "x", arguments: "{}" });
+  const items = [call("a"), functionCallOutputItem("a", "done"), call("b"), userMessageItem("x")];
+  const paired = pairedDanglingCalls(items, (callId) => `unknown:${callId}`);
+  assert.deepEqual(paired.slice(0, 4), items);
+  assert.deepEqual(paired[4], functionCallOutputItem("b", "unknown:b"));
+  const settled = [call("a"), functionCallOutputItem("a", "done")];
+  assert.equal(
+    pairedDanglingCalls(settled, () => ""),
+    settled,
+  );
 });
 
 test("cursors of sessions the roster no longer holds are forgotten", () => {

--- a/packages/brain/src/brain-memory.ts
+++ b/packages/brain/src/brain-memory.ts
@@ -1,48 +1,50 @@
 import type { SessionIdentity } from "@sidecar/session";
-import { isRecord, isWireString, type UnparsedWireValue } from "@sidecar/wire";
-import { isCompactionItem, type ResponsesInputItem } from "./brain-openai.js";
+import { isWireString } from "@sidecar/wire";
+import { isCompactionItem, RESPONSES_ITEM_TYPE, type ResponsesInputItem } from "./brain-openai.js";
+import type { BrainTranscriptCursors } from "./brain-state.js";
 
 /**
  * What the brain remembers between turns and across launches: the input array
  * from the latest compaction item onward, and the transcript cursor each
  * session was last read to. No summary of its own is kept — the API's
  * compaction item is the memory of everything before it, opaque and safe to
- * store — so the shape is the array itself.
+ * store — so the shape is the array itself. The envelope that carries both
+ * across launches is `brain-state`; this is the working copy one agent holds.
  */
 
-export const BRAIN_STATE_VERSION = 1;
-
-export type BrainTranscriptCursors = Readonly<Record<string, Readonly<Record<string, string>>>>;
-
-export interface BrainPersistedState {
-  version: typeof BRAIN_STATE_VERSION;
+export interface BrainMemoryState {
   items: readonly ResponsesInputItem[];
-  /** Keyed by provider id, then by provider session id. */
   cursors: BrainTranscriptCursors;
 }
 
-/** Reads a persisted state, or nothing when the file is from another build or malformed. */
-export function brainPersistedStateFromWire(
-  value: UnparsedWireValue,
-): BrainPersistedState | undefined {
-  if (!isRecord(value) || value.version !== BRAIN_STATE_VERSION) return undefined;
-  if (!Array.isArray(value.items) || !isRecord(value.cursors)) return undefined;
-  const items: ResponsesInputItem[] = [];
-  for (const item of value.items) {
-    if (!isRecord(item)) return undefined;
-    items.push(item);
-  }
-  const cursors: Record<string, Record<string, string>> = {};
-  for (const [providerId, sessions] of Object.entries(value.cursors)) {
-    if (!isRecord(sessions)) return undefined;
-    const provider: Record<string, string> = {};
-    for (const [providerSessionId, cursor] of Object.entries(sessions)) {
-      if (!isWireString(cursor)) return undefined;
-      provider[providerSessionId] = cursor;
+/**
+ * Answers every `function_call` in the array that has no `function_call_output`
+ * anywhere in it with the output given, so a memory restored from a checkpoint
+ * taken between an act's start and its result never replays the call and
+ * never hands the model a dangling one.
+ */
+export function pairedDanglingCalls(
+  items: readonly ResponsesInputItem[],
+  outputFor: (callId: string) => string,
+): readonly ResponsesInputItem[] {
+  const answered = new Set<string>();
+  for (const item of items) {
+    if (item.type === RESPONSES_ITEM_TYPE.FUNCTION_CALL_OUTPUT && isWireString(item.call_id)) {
+      answered.add(item.call_id);
     }
-    cursors[providerId] = provider;
   }
-  return { version: BRAIN_STATE_VERSION, items, cursors };
+  const dangling: ResponsesInputItem[] = [];
+  for (const item of items) {
+    if (item.type !== RESPONSES_ITEM_TYPE.FUNCTION_CALL || !isWireString(item.call_id)) continue;
+    if (answered.has(item.call_id)) continue;
+    answered.add(item.call_id);
+    dangling.push({
+      type: RESPONSES_ITEM_TYPE.FUNCTION_CALL_OUTPUT,
+      call_id: item.call_id,
+      output: outputFor(item.call_id),
+    });
+  }
+  return dangling.length === 0 ? items : [...items, ...dangling];
 }
 
 /** Everything a failed turn is rolled back to, taken before the turn appends anything. */
@@ -79,7 +81,7 @@ export class BrainMemory {
   #items: ResponsesInputItem[];
   #cursors: Map<string, Map<string, string>>;
 
-  constructor(state?: BrainPersistedState) {
+  constructor(state?: BrainMemoryState) {
     this.#items = state ? [...state.items] : [];
     this.#cursors = state ? cursorMap(state.cursors) : new Map();
   }
@@ -142,9 +144,8 @@ export class BrainMemory {
     }
   }
 
-  persisted(): BrainPersistedState {
+  persisted(): BrainMemoryState {
     return {
-      version: BRAIN_STATE_VERSION,
       items: [...this.#items],
       cursors: cursorRecord(this.#cursors),
     };

--- a/packages/brain/src/brain-requests.ts
+++ b/packages/brain/src/brain-requests.ts
@@ -115,6 +115,8 @@ export interface BrainRequestRecord {
    * happened, so none is retried and the developer is told as much.
    */
   unknownActs: number;
+  /** When the host recorded the ask itself in the thread, for an origin whose words the host records. */
+  askRecordedAt?: number;
   /** When the host recorded the run's end in the thread, so it is recorded exactly once. */
   historyRecordedAt?: number;
 }
@@ -137,6 +139,7 @@ export function brainRequestRecordFromWire(
   if (value.historyRecordedAt !== undefined && !finiteNumber(value.historyRecordedAt)) {
     return undefined;
   }
+  if (value.askRecordedAt !== undefined && !finiteNumber(value.askRecordedAt)) return undefined;
   if (value.startedAt !== undefined && !finiteNumber(value.startedAt)) return undefined;
   if (value.settledAt !== undefined && !finiteNumber(value.settledAt)) return undefined;
   if (value.text !== undefined && !isWireString(value.text)) return undefined;
@@ -153,6 +156,7 @@ export function brainRequestRecordFromWire(
     unknownActs: value.unknownActs,
   };
   if (value.historyRecordedAt !== undefined) record.historyRecordedAt = value.historyRecordedAt;
+  if (value.askRecordedAt !== undefined) record.askRecordedAt = value.askRecordedAt;
   if (value.startedAt !== undefined) record.startedAt = value.startedAt;
   if (value.settledAt !== undefined) record.settledAt = value.settledAt;
   if (value.text !== undefined) record.text = value.text;

--- a/packages/brain/src/brain-requests.ts
+++ b/packages/brain/src/brain-requests.ts
@@ -74,6 +74,8 @@ export const BRAIN_REQUEST_FAILURE = {
   PERSISTENCE: "persistence",
   /** The run reached its execution deadline. */
   DEADLINE: "deadline",
+  /** The model stopped before a reply formed: an incomplete output, or the tool budget spent. */
+  INCOMPLETE: "incomplete",
 } as const;
 
 export type BrainRequestFailure =
@@ -106,6 +108,15 @@ export interface BrainRequestRecord {
   failure?: BrainRequestFailure;
   /** How many acts the run performed to completion, so a failed reply still says what was done. */
   performedActs: number;
+  /**
+   * How many acts were dispatched whose result never came back: a performer
+   * that threw after the provider may have accepted the write, or a launch
+   * that found the act started and its result unrecorded. Each may have
+   * happened, so none is retried and the developer is told as much.
+   */
+  unknownActs: number;
+  /** When the host recorded the run's end in the thread, so it is recorded exactly once. */
+  historyRecordedAt?: number;
 }
 
 /** Reads a stored record, or nothing for one this build cannot vouch for. */
@@ -122,7 +133,10 @@ export function brainRequestRecordFromWire(
   if (!isBrainRequestOrigin(value.origin) || !isBrainRequestStatus(value.status)) return undefined;
   if (!isWireString(value.question)) return undefined;
   if (!finiteNumber(value.acceptedAt) || !finiteNumber(value.revision)) return undefined;
-  if (!finiteNumber(value.performedActs)) return undefined;
+  if (!finiteNumber(value.performedActs) || !finiteNumber(value.unknownActs)) return undefined;
+  if (value.historyRecordedAt !== undefined && !finiteNumber(value.historyRecordedAt)) {
+    return undefined;
+  }
   if (value.startedAt !== undefined && !finiteNumber(value.startedAt)) return undefined;
   if (value.settledAt !== undefined && !finiteNumber(value.settledAt)) return undefined;
   if (value.text !== undefined && !isWireString(value.text)) return undefined;
@@ -136,7 +150,9 @@ export function brainRequestRecordFromWire(
     revision: value.revision,
     acceptedAt: value.acceptedAt,
     performedActs: value.performedActs,
+    unknownActs: value.unknownActs,
   };
+  if (value.historyRecordedAt !== undefined) record.historyRecordedAt = value.historyRecordedAt;
   if (value.startedAt !== undefined) record.startedAt = value.startedAt;
   if (value.settledAt !== undefined) record.settledAt = value.settledAt;
   if (value.text !== undefined) record.text = value.text;
@@ -181,6 +197,8 @@ export const BRAIN_SUBMISSION_REJECTION = {
   EMPTY: "empty",
   ABSENT: "absent",
   PERSISTENCE: "persistence",
+  /** The submission id is already taken by an ask with other words or another origin. */
+  CONFLICT: "conflict",
 } as const;
 
 export type BrainSubmissionRejection =

--- a/packages/brain/src/brain-requests.ts
+++ b/packages/brain/src/brain-requests.ts
@@ -1,0 +1,202 @@
+import { isRecord, isWireNumber, isWireString, type UnparsedWireValue } from "@sidecar/wire";
+
+/**
+ * A developer ask as the brain owns it from acceptance to its end. The record
+ * outlives the call that asked, the renderer that showed it, and the launch
+ * that ran it: a submission is acknowledged only once its record is on disk,
+ * a wait answers with the record as it stands rather than abandoning the run,
+ * and a restart finds every unfinished record and marks it interrupted rather
+ * than resuming an act it cannot know the state of.
+ */
+
+export const BRAIN_REQUEST_STATUS = {
+  QUEUED: "queued",
+  RUNNING: "running",
+  SUCCEEDED: "succeeded",
+  FAILED: "failed",
+  CANCELLED: "cancelled",
+  TIMED_OUT: "timed_out",
+  INTERRUPTED: "interrupted",
+} as const;
+
+export type BrainRequestStatus = (typeof BRAIN_REQUEST_STATUS)[keyof typeof BRAIN_REQUEST_STATUS];
+
+const BRAIN_REQUEST_STATUS_LIST: readonly BrainRequestStatus[] =
+  Object.values(BRAIN_REQUEST_STATUS);
+
+export const BRAIN_REQUEST_TERMINAL_STATUS: ReadonlySet<BrainRequestStatus> = new Set([
+  BRAIN_REQUEST_STATUS.SUCCEEDED,
+  BRAIN_REQUEST_STATUS.FAILED,
+  BRAIN_REQUEST_STATUS.CANCELLED,
+  BRAIN_REQUEST_STATUS.TIMED_OUT,
+  BRAIN_REQUEST_STATUS.INTERRUPTED,
+]);
+
+export function isBrainRequestStatus(value: UnparsedWireValue): value is BrainRequestStatus {
+  return (
+    isWireString(value) &&
+    // SAFETY: value is a string; list membership is the vocabulary check.
+    BRAIN_REQUEST_STATUS_LIST.includes(value as BrainRequestStatus)
+  );
+}
+
+export function isTerminalBrainRequestStatus(status: BrainRequestStatus): boolean {
+  return BRAIN_REQUEST_TERMINAL_STATUS.has(status);
+}
+
+/** Where the ask came from, which decides who records its words in the thread. */
+export const BRAIN_REQUEST_ORIGIN = {
+  /** Typed into a composer; the words travel with the submission and the host records them. */
+  TYPED: "typed",
+  /** Spoken; the voice service's own transcript is the record, and the question here is the mouth's relay. */
+  SPOKEN: "spoken",
+} as const;
+
+export type BrainRequestOrigin = (typeof BRAIN_REQUEST_ORIGIN)[keyof typeof BRAIN_REQUEST_ORIGIN];
+
+const BRAIN_REQUEST_ORIGIN_LIST: readonly BrainRequestOrigin[] =
+  Object.values(BRAIN_REQUEST_ORIGIN);
+
+export function isBrainRequestOrigin(value: UnparsedWireValue): value is BrainRequestOrigin {
+  // SAFETY: value is a string; list membership is the vocabulary check.
+  return isWireString(value) && BRAIN_REQUEST_ORIGIN_LIST.includes(value as BrainRequestOrigin);
+}
+
+/**
+ * Why a run ended without a reply, as a fixed word rather than a provider's
+ * sentence: the host words each one for the thread, so no raw model or
+ * network output reaches the developer's record.
+ */
+export const BRAIN_REQUEST_FAILURE = {
+  /** The model did not answer, or answered nothing readable. */
+  MODEL: "model",
+  /** A checkpoint could not be written, so the run stopped before or after an act. */
+  PERSISTENCE: "persistence",
+  /** The run reached its execution deadline. */
+  DEADLINE: "deadline",
+} as const;
+
+export type BrainRequestFailure =
+  (typeof BRAIN_REQUEST_FAILURE)[keyof typeof BRAIN_REQUEST_FAILURE];
+
+const BRAIN_REQUEST_FAILURE_LIST: readonly BrainRequestFailure[] =
+  Object.values(BRAIN_REQUEST_FAILURE);
+
+export function isBrainRequestFailure(value: UnparsedWireValue): value is BrainRequestFailure {
+  // SAFETY: value is a string; list membership is the vocabulary check.
+  return isWireString(value) && BRAIN_REQUEST_FAILURE_LIST.includes(value as BrainRequestFailure);
+}
+
+export interface BrainRequestRecord {
+  /** The run's own id, minted by the brain at acceptance. */
+  runId: string;
+  /** The caller's id for one deliberate submission; a retry of the same submission finds the same run. */
+  submissionId: string;
+  origin: BrainRequestOrigin;
+  /** The ask as the brain was handed it, bounded by the host. */
+  question: string;
+  status: BrainRequestStatus;
+  /** Bumped on every change, so two snapshots of one run can be ordered without a clock. */
+  revision: number;
+  acceptedAt: number;
+  startedAt?: number;
+  settledAt?: number;
+  /** The reply, when the run reached one. */
+  text?: string;
+  failure?: BrainRequestFailure;
+  /** How many acts the run performed to completion, so a failed reply still says what was done. */
+  performedActs: number;
+}
+
+/** Reads a stored record, or nothing for one this build cannot vouch for. */
+export function brainRequestRecordFromWire(
+  value: UnparsedWireValue,
+): BrainRequestRecord | undefined {
+  if (!isRecord(value)) return undefined;
+  const runId = isWireString(value.runId) && value.runId.length > 0 ? value.runId : undefined;
+  const submissionId =
+    isWireString(value.submissionId) && value.submissionId.length > 0
+      ? value.submissionId
+      : undefined;
+  if (!runId || !submissionId) return undefined;
+  if (!isBrainRequestOrigin(value.origin) || !isBrainRequestStatus(value.status)) return undefined;
+  if (!isWireString(value.question)) return undefined;
+  if (!finiteNumber(value.acceptedAt) || !finiteNumber(value.revision)) return undefined;
+  if (!finiteNumber(value.performedActs)) return undefined;
+  if (value.startedAt !== undefined && !finiteNumber(value.startedAt)) return undefined;
+  if (value.settledAt !== undefined && !finiteNumber(value.settledAt)) return undefined;
+  if (value.text !== undefined && !isWireString(value.text)) return undefined;
+  if (value.failure !== undefined && !isBrainRequestFailure(value.failure)) return undefined;
+  const record: BrainRequestRecord = {
+    runId,
+    submissionId,
+    origin: value.origin,
+    question: value.question,
+    status: value.status,
+    revision: value.revision,
+    acceptedAt: value.acceptedAt,
+    performedActs: value.performedActs,
+  };
+  if (value.startedAt !== undefined) record.startedAt = value.startedAt;
+  if (value.settledAt !== undefined) record.settledAt = value.settledAt;
+  if (value.text !== undefined) record.text = value.text;
+  if (value.failure !== undefined) record.failure = value.failure;
+  return record;
+}
+
+function finiteNumber(value: UnparsedWireValue): value is number {
+  return isWireNumber(value) && Number.isFinite(value) && value >= 0;
+}
+
+/**
+ * What a launch does to the records the last one left unfinished: nothing it
+ * was doing is resumed, because an act mid-flight when the process died is
+ * one whose effect it cannot know, and a queued ask is answered with the
+ * honest interruption rather than run against a roster the developer has not
+ * looked at since.
+ */
+export function interruptedUnfinishedRequests(
+  records: readonly BrainRequestRecord[],
+  now: number,
+): readonly BrainRequestRecord[] {
+  if (records.every((record) => isTerminalBrainRequestStatus(record.status))) return records;
+  return records.map((record) =>
+    isTerminalBrainRequestStatus(record.status)
+      ? record
+      : {
+          ...record,
+          status: BRAIN_REQUEST_STATUS.INTERRUPTED,
+          revision: record.revision + 1,
+          settledAt: now,
+        },
+  );
+}
+
+/**
+ * The answer to a submission. Accepted names the run — the same run for a
+ * retry of the same submission — and rejected says why in a word the host
+ * words for the developer.
+ */
+export const BRAIN_SUBMISSION_REJECTION = {
+  EMPTY: "empty",
+  ABSENT: "absent",
+  PERSISTENCE: "persistence",
+} as const;
+
+export type BrainSubmissionRejection =
+  (typeof BRAIN_SUBMISSION_REJECTION)[keyof typeof BRAIN_SUBMISSION_REJECTION];
+
+export const BRAIN_SUBMISSION_OUTCOME = {
+  ACCEPTED: "accepted",
+  REJECTED: "rejected",
+} as const;
+
+export type BrainSubmissionResult =
+  | { outcome: typeof BRAIN_SUBMISSION_OUTCOME.ACCEPTED; runId: string; acceptedAt: number }
+  | { outcome: typeof BRAIN_SUBMISSION_OUTCOME.REJECTED; reason: BrainSubmissionRejection };
+
+export interface BrainSubmission {
+  submissionId: string;
+  question: string;
+  origin: BrainRequestOrigin;
+}

--- a/packages/brain/src/brain-state.test.ts
+++ b/packages/brain/src/brain-state.test.ts
@@ -1,0 +1,157 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { unparsedWire, type WireBoundaryInput } from "@sidecar/wire";
+import { BRAIN_REQUEST_ORIGIN, BRAIN_REQUEST_STATUS } from "./brain-requests.js";
+import {
+  BRAIN_GENERATION_LIFETIME_MS,
+  BRAIN_STATE_VERSION,
+  type BrainPersistedState,
+  type BrainStateStorage,
+  BrainStateStore,
+  brainPersistedStateFromWire,
+  brainStateFromStored,
+  brainStateRecord,
+  freshBrainState,
+} from "./brain-state.js";
+
+const NOW = 1_800_000_000_000;
+
+/** A record as it would come off the wire: the same fields, with no domain type attached. */
+function raw(value: BrainPersistedState | BrainPersistedState["requests"][number] | undefined) {
+  // SAFETY: a JSON round trip of a plain record is boundary input by construction.
+  return JSON.parse(JSON.stringify(value)) as Record<string, WireBoundaryInput>;
+}
+
+function complete(): BrainPersistedState {
+  return {
+    ...freshBrainState("gen-1", NOW),
+    items: [{ type: "message", role: "user", content: [] }],
+    cursors: { "claude-code": { abc: "7" } },
+    requests: [
+      {
+        runId: "run-1",
+        submissionId: "sub-1",
+        origin: BRAIN_REQUEST_ORIGIN.TYPED,
+        question: "what's up?",
+        status: BRAIN_REQUEST_STATUS.SUCCEEDED,
+        revision: 3,
+        acceptedAt: NOW,
+        startedAt: NOW + 1,
+        settledAt: NOW + 2,
+        text: "Nothing much.",
+        performedActs: 0,
+      },
+    ],
+    journal: [
+      {
+        runId: "run-1",
+        callId: "call-1",
+        name: "send_session_message",
+        argumentsJson: "{}",
+        startedAt: NOW + 1,
+        outputJson: '{"status":"accepted"}',
+        settledAt: NOW + 2,
+      },
+    ],
+  };
+}
+
+test("a fresh generation is born now and expires exactly one lifetime later", () => {
+  const state = freshBrainState("gen-1", NOW);
+  assert.equal(state.version, BRAIN_STATE_VERSION);
+  assert.equal(state.expiresAt - state.createdAt, BRAIN_GENERATION_LIFETIME_MS);
+  assert.deepEqual([state.items, state.requests, state.journal], [[], [], []]);
+});
+
+test("the envelope round-trips, and anything from another shape reads as nothing", () => {
+  const state = complete();
+  assert.deepEqual(brainStateFromStored(brainStateRecord(state)), state);
+  assert.equal(brainStateFromStored(undefined), undefined);
+  assert.equal(brainStateFromStored("not json"), undefined);
+  // The version-1 file — items and cursors alone, of unknown age — is not
+  // given a fresh lifetime; it reads as no state.
+  const read = (value: WireBoundaryInput) => brainPersistedStateFromWire(unparsedWire(value));
+  assert.equal(read({ version: 1, items: [], cursors: {} }), undefined);
+  assert.equal(read({ ...raw(state), generationId: "" }), undefined);
+  assert.equal(read({ ...raw(state), expiresAt: "soon" }), undefined);
+  assert.equal(read({ ...raw(state), items: ["text"] }), undefined);
+  assert.equal(read({ ...raw(state), cursors: { a: { b: 1 } } }), undefined);
+  assert.equal(read({ ...raw(state), requests: [{ runId: "x" }] }), undefined);
+  assert.equal(
+    read({ ...raw(state), requests: [{ ...raw(state.requests[0]), status: "sleeping" }] }),
+    undefined,
+  );
+  assert.equal(read({ ...raw(state), journal: [{ runId: "x" }] }), undefined);
+});
+
+class MemoryStorage implements BrainStateStorage {
+  file: string | undefined;
+  refuse = false;
+  readonly log: string[] = [];
+  read() {
+    this.log.push("read");
+    return this.file;
+  }
+  write(contents: string) {
+    this.log.push("write");
+    if (this.refuse) return false;
+    this.file = contents;
+    return true;
+  }
+  remove() {
+    this.log.push("remove");
+    this.file = undefined;
+    return true;
+  }
+}
+
+test("the store loads once, serializes writes, and fences a write against a replaced generation", async () => {
+  const storage = new MemoryStorage();
+  let generations = 0;
+  const store = new BrainStateStore({
+    storage,
+    createGenerationId: () => `gen-${++generations}`,
+    now: () => NOW,
+  });
+  assert.equal(store.current(), undefined);
+  const loaded = await store.load();
+  assert.equal(loaded.generationId, "gen-1");
+  assert.equal(storage.file, undefined);
+  await store.load();
+  assert.deepEqual(storage.log, ["read"]);
+
+  const first = store.write("gen-1", (state) => ({ ...state, cursors: { p: { s: "1" } } }));
+  const second = store.write("gen-1", (state) => ({
+    ...state,
+    cursors: { ...state.cursors, q: { t: "2" } },
+  }));
+  assert.deepEqual(await Promise.all([first, second]), [true, true]);
+  assert.deepEqual(store.current()?.cursors, { p: { s: "1" }, q: { t: "2" } });
+  assert.equal(brainStateFromStored(storage.file)?.cursors.q?.t, "2");
+
+  const replaced: BrainPersistedState[] = [];
+  store.onReplaced((state) => replaced.push(state));
+  assert.equal(await store.reset(), true);
+  assert.equal(storage.file, undefined);
+  assert.equal(store.generationId(), "gen-2");
+  assert.equal(replaced[0]?.generationId, "gen-2");
+  // A writer still holding the old generation lands nowhere.
+  assert.equal(await store.write("gen-1", (state) => state), false);
+  assert.equal(storage.log.filter((entry) => entry === "write").length, 2);
+  assert.equal(await store.write("gen-2", (state) => state), true);
+
+  // Storage refusing leaves the held copy as it was.
+  storage.refuse = true;
+  assert.equal(
+    await store.write("gen-2", (state) => ({ ...state, cursors: { z: { z: "z" } } })),
+    false,
+  );
+  assert.deepEqual(store.current()?.cursors, {});
+  storage.refuse = false;
+
+  const whole = { ...complete(), generationId: "gen-9" };
+  assert.equal(await store.replace(whole), true);
+  assert.equal(store.generationId(), "gen-9");
+  assert.equal(replaced.at(-1)?.generationId, "gen-9");
+  await store.flush();
+});

--- a/packages/brain/src/brain-state.test.ts
+++ b/packages/brain/src/brain-state.test.ts
@@ -116,14 +116,15 @@ test("the store loads once, serializes writes, and fences a write against a repl
     now: () => NOW,
   });
   assert.equal(store.current(), undefined);
+  const lease = store.lease();
   const loaded = await store.load();
   assert.equal(loaded.generationId, "gen-1");
   assert.equal(storage.file, undefined);
   await store.load();
   assert.deepEqual(storage.log, ["read"]);
 
-  const first = store.write("gen-1", (state) => ({ ...state, cursors: { p: { s: "1" } } }));
-  const second = store.write("gen-1", (state) => ({
+  const first = store.write(lease, "gen-1", (state) => ({ ...state, cursors: { p: { s: "1" } } }));
+  const second = store.write(lease, "gen-1", (state) => ({
     ...state,
     cursors: { ...state.cursors, q: { t: "2" } },
   }));
@@ -138,18 +139,23 @@ test("the store loads once, serializes writes, and fences a write against a repl
   assert.equal(store.generationId(), "gen-2");
   assert.equal(replaced[0]?.generationId, "gen-2");
   // A writer still holding the old generation lands nowhere.
-  assert.equal(await store.write("gen-1", (state) => state), false);
+  assert.equal(await store.write(lease, "gen-1", (state) => state), false);
   assert.equal(storage.log.filter((entry) => entry === "write").length, 2);
-  assert.equal(await store.write("gen-2", (state) => state), true);
+  assert.equal(await store.write(lease, "gen-2", (state) => state), true);
 
   // Storage refusing leaves the held copy as it was.
   storage.refuse = true;
   assert.equal(
-    await store.write("gen-2", (state) => ({ ...state, cursors: { z: { z: "z" } } })),
+    await store.write(lease, "gen-2", (state) => ({ ...state, cursors: { z: { z: "z" } } })),
     false,
   );
   assert.deepEqual(store.current()?.cursors, {});
   storage.refuse = false;
+
+  // A later holder taking the lease fences the earlier one, generation or not.
+  const successor = store.lease();
+  assert.equal(await store.write(lease, "gen-2", (state) => state), false);
+  assert.equal(await store.write(successor, "gen-2", (state) => state), true);
 
   const whole = { ...complete(), generationId: "gen-9" };
   assert.equal(await store.replace(whole), true);

--- a/packages/brain/src/brain-state.test.ts
+++ b/packages/brain/src/brain-state.test.ts
@@ -40,6 +40,8 @@ function complete(): BrainPersistedState {
         settledAt: NOW + 2,
         text: "Nothing much.",
         performedActs: 0,
+        unknownActs: 0,
+        historyRecordedAt: NOW + 3,
       },
     ],
     journal: [

--- a/packages/brain/src/brain-state.ts
+++ b/packages/brain/src/brain-state.ts
@@ -137,11 +137,22 @@ export interface BrainStateStoreOptions {
  * write reached storage, because the caller decides what a failed checkpoint
  * means for the act it guards.
  */
+/**
+ * Who may write through the store right now. Each agent built on the store
+ * takes the lease at construction; taking it releases every earlier holder, so
+ * a replaced agent's late checkpoint — drained or not — lands nowhere once its
+ * successor holds the store, even inside the same generation.
+ */
+export interface BrainStoreLease {
+  readonly holder: symbol;
+}
+
 export class BrainStateStore {
   readonly #storage: BrainStateStorage;
   readonly #createGenerationId: () => string;
   readonly #now: () => number;
   #state: BrainPersistedState | undefined;
+  #lease: BrainStoreLease | undefined;
   #queue: Promise<unknown> = Promise.resolve();
   readonly #replacedListeners = new Set<(state: BrainPersistedState) => void>();
 
@@ -171,6 +182,16 @@ export class BrainStateStore {
     });
   }
 
+  /** Takes the write lease, releasing whoever held it. */
+  lease(): BrainStoreLease {
+    this.#lease = { holder: Symbol("brain store lease") };
+    return this.#lease;
+  }
+
+  holdsLease(lease: BrainStoreLease): boolean {
+    return this.#lease === lease;
+  }
+
   /** The envelope as last loaded or written, or nothing before the first load. */
   current(): BrainPersistedState | undefined {
     return this.#state;
@@ -181,13 +202,15 @@ export class BrainStateStore {
   }
 
   /**
-   * Writes a new envelope of the generation named. Answers false without
-   * touching storage when that generation is no longer the store's — the
-   * fence a reset or replacement raises against late writers — and false
+   * Writes a new envelope of the generation named, under the lease given.
+   * Answers false without touching storage when that generation is no longer
+   * the store's, or the lease has passed to a later agent — the fences a
+   * reset, a replacement, and a rebuild raise against late writers — and false
    * when storage refused, leaving the held copy as it was so the caller's
    * own memory and the file cannot silently disagree about what is known.
    */
   write(
+    lease: BrainStoreLease,
     generationId: string,
     mutate: (
       state: BrainPersistedState,
@@ -195,7 +218,7 @@ export class BrainStateStore {
   ): Promise<boolean> {
     return this.#serialized(async () => {
       const held = this.#state;
-      if (!held || held.generationId !== generationId) return false;
+      if (!this.holdsLease(lease) || !held || held.generationId !== generationId) return false;
       const next: BrainPersistedState = {
         ...mutate(held),
         version: BRAIN_STATE_VERSION,

--- a/packages/brain/src/brain-state.ts
+++ b/packages/brain/src/brain-state.ts
@@ -1,0 +1,272 @@
+import { isRecord, isWireNumber, isWireString, type UnparsedWireValue } from "@sidecar/wire";
+import { type BrainJournalEntry, brainJournalEntryFromWire } from "./brain-journal.js";
+import type { ResponsesInputItem } from "./brain-openai.js";
+import { type BrainRequestRecord, brainRequestRecordFromWire } from "./brain-requests.js";
+
+/**
+ * Everything the brain keeps across launches, in one envelope with one
+ * writer. The envelope is a generation: it is born at a moment, it dies at a
+ * fixed age or at the developer's Clear, and everything inside it — the
+ * Responses input array from the latest compaction onward, the transcript
+ * cursors, the request records, and the action journal — lives and dies
+ * with it. A state file from another build or another shape reads as no
+ * state, never as a fresh lifetime for old data.
+ */
+
+export const BRAIN_STATE_VERSION = 2;
+
+/** How long a generation lives from its creation, whatever is written into it. */
+export const BRAIN_GENERATION_LIFETIME_MS = 14 * 24 * 60 * 60 * 1000;
+
+export type BrainTranscriptCursors = Readonly<Record<string, Readonly<Record<string, string>>>>;
+
+export interface BrainPersistedState {
+  version: typeof BRAIN_STATE_VERSION;
+  generationId: string;
+  createdAt: number;
+  expiresAt: number;
+  items: readonly ResponsesInputItem[];
+  /** Keyed by provider id, then by provider session id. */
+  cursors: BrainTranscriptCursors;
+  requests: readonly BrainRequestRecord[];
+  journal: readonly BrainJournalEntry[];
+}
+
+/** An empty generation born now. */
+export function freshBrainState(generationId: string, now: number): BrainPersistedState {
+  return {
+    version: BRAIN_STATE_VERSION,
+    generationId,
+    createdAt: now,
+    expiresAt: now + BRAIN_GENERATION_LIFETIME_MS,
+    items: [],
+    cursors: {},
+    requests: [],
+    journal: [],
+  };
+}
+
+/** Reads a persisted state, or nothing when the file is from another build or malformed. */
+export function brainPersistedStateFromWire(
+  value: UnparsedWireValue,
+): BrainPersistedState | undefined {
+  if (!isRecord(value) || value.version !== BRAIN_STATE_VERSION) return undefined;
+  if (!isWireString(value.generationId) || value.generationId.length === 0) return undefined;
+  if (!instant(value.createdAt) || !instant(value.expiresAt)) return undefined;
+  if (!Array.isArray(value.items) || !isRecord(value.cursors)) return undefined;
+  if (!Array.isArray(value.requests) || !Array.isArray(value.journal)) return undefined;
+  const items: ResponsesInputItem[] = [];
+  for (const item of value.items) {
+    if (!isRecord(item)) return undefined;
+    items.push(item);
+  }
+  const cursors: Record<string, Record<string, string>> = {};
+  for (const [providerId, sessions] of Object.entries(value.cursors)) {
+    if (!isRecord(sessions)) return undefined;
+    const provider: Record<string, string> = {};
+    for (const [providerSessionId, cursor] of Object.entries(sessions)) {
+      if (!isWireString(cursor)) return undefined;
+      provider[providerSessionId] = cursor;
+    }
+    cursors[providerId] = provider;
+  }
+  const requests: BrainRequestRecord[] = [];
+  for (const request of value.requests) {
+    const record = brainRequestRecordFromWire(request);
+    if (!record) return undefined;
+    requests.push(record);
+  }
+  const journal: BrainJournalEntry[] = [];
+  for (const entry of value.journal) {
+    const parsed = brainJournalEntryFromWire(entry);
+    if (!parsed) return undefined;
+    journal.push(parsed);
+  }
+  return {
+    version: BRAIN_STATE_VERSION,
+    generationId: value.generationId,
+    createdAt: value.createdAt,
+    expiresAt: value.expiresAt,
+    items,
+    cursors,
+    requests,
+    journal,
+  };
+}
+
+function instant(value: UnparsedWireValue): value is number {
+  return isWireNumber(value) && Number.isFinite(value) && value >= 0;
+}
+
+/** The record the state persists as. */
+export function brainStateRecord(state: BrainPersistedState): string {
+  return `${JSON.stringify(state)}\n`;
+}
+
+/** Reads a stored record back, or nothing for a missing, unparseable, or foreign file. */
+export function brainStateFromStored(stored: string | undefined): BrainPersistedState | undefined {
+  if (stored === undefined) return undefined;
+  try {
+    // SAFETY: JSON.parse returns a wire value; the reader is the validation.
+    return brainPersistedStateFromWire(JSON.parse(stored) as UnparsedWireValue);
+  } catch {
+    return undefined;
+  }
+}
+
+/** Where the envelope is kept: one file's worth of read, write, and remove, however the host does them. */
+export interface BrainStateStorage {
+  read(): string | undefined | Promise<string | undefined>;
+  /** Answers whether the write landed; a store that throws is read as one that did not. */
+  write(contents: string): boolean | Promise<boolean>;
+  remove(): boolean | Promise<boolean>;
+}
+
+export interface BrainStateStoreOptions {
+  storage: BrainStateStorage;
+  createGenerationId: () => string;
+  now?: () => number;
+}
+
+/**
+ * The one writer of the brain's state. Every write is serialized behind the
+ * last, so two callers cannot interleave half-envelopes; every write names
+ * the generation it believes it is writing, so a write prepared against a
+ * generation that has since been replaced or reset lands nowhere. The store
+ * holds the envelope in memory between writes, and answers whether each
+ * write reached storage, because the caller decides what a failed checkpoint
+ * means for the act it guards.
+ */
+export class BrainStateStore {
+  readonly #storage: BrainStateStorage;
+  readonly #createGenerationId: () => string;
+  readonly #now: () => number;
+  #state: BrainPersistedState | undefined;
+  #queue: Promise<unknown> = Promise.resolve();
+  readonly #replacedListeners = new Set<(state: BrainPersistedState) => void>();
+
+  constructor(options: BrainStateStoreOptions) {
+    this.#storage = options.storage;
+    this.#createGenerationId = options.createGenerationId;
+    this.#now = options.now ?? Date.now;
+  }
+
+  /**
+   * Reads the envelope once from storage; later calls answer the held copy.
+   * A missing or foreign file becomes a fresh generation in memory, written
+   * only when something is first checkpointed into it.
+   */
+  load(): Promise<BrainPersistedState> {
+    return this.#serialized(async () => {
+      if (this.#state) return this.#state;
+      let stored: string | undefined;
+      try {
+        stored = await this.#storage.read();
+      } catch {
+        stored = undefined;
+      }
+      this.#state =
+        brainStateFromStored(stored) ?? freshBrainState(this.#createGenerationId(), this.#now());
+      return this.#state;
+    });
+  }
+
+  /** The envelope as last loaded or written, or nothing before the first load. */
+  current(): BrainPersistedState | undefined {
+    return this.#state;
+  }
+
+  generationId(): string | undefined {
+    return this.#state?.generationId;
+  }
+
+  /**
+   * Writes a new envelope of the generation named. Answers false without
+   * touching storage when that generation is no longer the store's — the
+   * fence a reset or replacement raises against late writers — and false
+   * when storage refused, leaving the held copy as it was so the caller's
+   * own memory and the file cannot silently disagree about what is known.
+   */
+  write(
+    generationId: string,
+    mutate: (
+      state: BrainPersistedState,
+    ) => Omit<BrainPersistedState, "version" | "generationId" | "createdAt" | "expiresAt">,
+  ): Promise<boolean> {
+    return this.#serialized(async () => {
+      const held = this.#state;
+      if (!held || held.generationId !== generationId) return false;
+      const next: BrainPersistedState = {
+        ...mutate(held),
+        version: BRAIN_STATE_VERSION,
+        generationId: held.generationId,
+        createdAt: held.createdAt,
+        expiresAt: held.expiresAt,
+      };
+      if (!(await this.#persist(next))) return false;
+      this.#state = next;
+      return true;
+    });
+  }
+
+  /** Replaces the envelope whole with the one given, a new generation included. */
+  replace(state: BrainPersistedState): Promise<boolean> {
+    return this.#serialized(async () => {
+      if (!(await this.#persist(state))) return false;
+      this.#state = state;
+      this.#announceReplaced(state);
+      return true;
+    });
+  }
+
+  /**
+   * Discards the envelope and begins a fresh generation: the file goes, the
+   * held copy becomes empty, and every listener hears the new generation so
+   * runs of the old one can stand down.
+   */
+  reset(): Promise<boolean> {
+    return this.#serialized(async () => {
+      let removed: boolean;
+      try {
+        removed = await this.#storage.remove();
+      } catch {
+        removed = false;
+      }
+      if (!removed) return false;
+      this.#state = freshBrainState(this.#createGenerationId(), this.#now());
+      this.#announceReplaced(this.#state);
+      return true;
+    });
+  }
+
+  /** Hears every replacement or reset, with the generation that now stands. */
+  onReplaced(listener: (state: BrainPersistedState) => void): () => void {
+    this.#replacedListeners.add(listener);
+    return () => {
+      this.#replacedListeners.delete(listener);
+    };
+  }
+
+  /** Settles once every write queued so far has landed or been refused. */
+  async flush(): Promise<void> {
+    await this.#queue;
+  }
+
+  #announceReplaced(state: BrainPersistedState): void {
+    for (const listener of this.#replacedListeners) listener(state);
+  }
+
+  async #persist(state: BrainPersistedState): Promise<boolean> {
+    try {
+      return await this.#storage.write(brainStateRecord(state));
+    } catch {
+      return false;
+    }
+  }
+
+  #serialized<T>(work: () => Promise<T>): Promise<T> {
+    const run = this.#queue.then(work, work);
+    this.#queue = run.catch(() => undefined);
+    return run;
+  }
+}

--- a/packages/brain/src/brain-state.ts
+++ b/packages/brain/src/brain-state.ts
@@ -203,9 +203,14 @@ export class BrainStateStore {
 
   /**
    * Writes a new envelope of the generation named, under the lease given.
-   * Answers false without touching storage when that generation is no longer
-   * the store's, or the lease has passed to a later agent — the fences a
-   * reset, a replacement, and a rebuild raise against late writers — and false
+   * `mutate` runs inside the store's queue, once every earlier write has
+   * settled, so an envelope composed there from live state includes every
+   * earlier save; `committed` runs in the same queue step once the write has
+   * landed, before any later write composes, so what it applies to live state
+   * is in every later envelope. Answers false without touching storage when
+   * that generation is no longer the store's, or the lease has passed to a
+   * later agent — the fences a reset, a replacement, and a rebuild raise
+   * against late writers — and false
    * when storage refused, leaving the held copy as it was so the caller's
    * own memory and the file cannot silently disagree about what is known.
    */
@@ -215,6 +220,7 @@ export class BrainStateStore {
     mutate: (
       state: BrainPersistedState,
     ) => Omit<BrainPersistedState, "version" | "generationId" | "createdAt" | "expiresAt">,
+    committed?: () => void,
   ): Promise<boolean> {
     return this.#serialized(async () => {
       const held = this.#state;
@@ -228,6 +234,7 @@ export class BrainStateStore {
       };
       if (!(await this.#persist(next))) return false;
       this.#state = next;
+      committed?.();
       return true;
     });
   }

--- a/packages/brain/src/index.ts
+++ b/packages/brain/src/index.ts
@@ -16,6 +16,8 @@ export {
   type BrainTurnTraceRecord,
   type BrainTurnTrigger,
   OMISSION_MARKER,
+  type Settled,
+  settledUnlessAborted,
 } from "./brain-agent.js";
 export {
   BRAIN_CLIENT_OUTCOME,

--- a/packages/brain/src/index.ts
+++ b/packages/brain/src/index.ts
@@ -10,7 +10,7 @@ export {
   type BrainActPerformer,
   BrainAgent,
   type BrainAgentOptions,
-  type BrainAskAnswer,
+  type BrainRequestsListener,
   type BrainRoster,
   type BrainToolCallTrace,
   type BrainTurnTraceRecord,
@@ -51,12 +51,16 @@ export {
 } from "./brain-input.js";
 export { brainInstructions } from "./brain-instructions.js";
 export {
-  BRAIN_STATE_VERSION,
+  BrainJournal,
+  type BrainJournalEntry,
+  brainJournalEntryFromWire,
+  UNKNOWN_ACT_RESULT,
+} from "./brain-journal.js";
+export {
   BrainMemory,
   type BrainMemoryMark,
-  type BrainPersistedState,
-  type BrainTranscriptCursors,
-  brainPersistedStateFromWire,
+  type BrainMemoryState,
+  pairedDanglingCalls,
 } from "./brain-memory.js";
 export {
   BRAIN_REASONING_EFFORT,
@@ -74,6 +78,40 @@ export {
   type ResponsesInputItem,
   userMessageItem,
 } from "./brain-openai.js";
+export {
+  BRAIN_REQUEST_FAILURE,
+  BRAIN_REQUEST_ORIGIN,
+  BRAIN_REQUEST_STATUS,
+  BRAIN_REQUEST_TERMINAL_STATUS,
+  BRAIN_SUBMISSION_OUTCOME,
+  BRAIN_SUBMISSION_REJECTION,
+  type BrainRequestFailure,
+  type BrainRequestOrigin,
+  type BrainRequestRecord,
+  type BrainRequestStatus,
+  type BrainSubmission,
+  type BrainSubmissionRejection,
+  type BrainSubmissionResult,
+  brainRequestRecordFromWire,
+  interruptedUnfinishedRequests,
+  isBrainRequestFailure,
+  isBrainRequestOrigin,
+  isBrainRequestStatus,
+  isTerminalBrainRequestStatus,
+} from "./brain-requests.js";
+export {
+  BRAIN_GENERATION_LIFETIME_MS,
+  BRAIN_STATE_VERSION,
+  type BrainPersistedState,
+  type BrainStateStorage,
+  BrainStateStore,
+  type BrainStateStoreOptions,
+  type BrainTranscriptCursors,
+  brainPersistedStateFromWire,
+  brainStateFromStored,
+  brainStateRecord,
+  freshBrainState,
+} from "./brain-state.js";
 export {
   BRAIN_TOOL,
   type BrainSchemaProperty,

--- a/packages/realtime/src/conversation-history.test.ts
+++ b/packages/realtime/src/conversation-history.test.ts
@@ -15,7 +15,9 @@ import {
   appendConversationThreadEntry,
   CONVERSATION_ENTRY_KIND,
   type ConversationEntry,
+  conversationEntryKey,
   conversationHistoryText,
+  hasConversationEntryForRequest,
   insertSpokenAskEntry,
   insertSpokenAskThreadEntry,
   isConversationEntryKind,
@@ -29,6 +31,7 @@ import {
   storedConversationEntry,
   storedConversationMaximumAgeMs,
   streamingConversationEntry,
+  typedAskConversationEntry,
 } from "./conversation-history.js";
 import { SESSION_NO_LONGER_OBSERVED_NOTE } from "./realtime-protocol.js";
 
@@ -557,4 +560,56 @@ test("adopting another window's thread reuses the entry objects already held", (
   // A cleared or diverged thread is taken as reported: entries the report no
   // longer carries do not survive the adoption.
   assert.deepEqual(adoptConversationThread([ask, reply], []), []);
+});
+
+test("a line tied to a run is recorded once per kind, and its run survives storage", () => {
+  const now = Date.parse("2026-01-02T03:04:05.000Z");
+  let thread = appendConversationThreadEntry(
+    [],
+    typedAskConversationEntry("ship it", "run-1"),
+    now,
+  );
+  thread = appendConversationThreadEntry(
+    thread,
+    typedAskConversationEntry("ship it", "run-1"),
+    now,
+  );
+  thread = appendConversationThreadEntry(thread, replyConversationEntry("Shipping.", "run-1"), now);
+  thread = appendConversationThreadEntry(
+    thread,
+    replyConversationEntry("Shipping, I said.", "run-1"),
+    now + 1,
+  );
+  // The same words for another run are another line.
+  thread = appendConversationThreadEntry(thread, replyConversationEntry("Shipping.", "run-2"), now);
+  assert.deepEqual(
+    thread.map((entry) => [entry.kind, entry.words, entry.requestId]),
+    [
+      [CONVERSATION_ENTRY_KIND.TYPED_ASK, "ship it", "run-1"],
+      [CONVERSATION_ENTRY_KIND.REPLY, "Shipping.", "run-1"],
+      [CONVERSATION_ENTRY_KIND.REPLY, "Shipping.", "run-2"],
+    ],
+  );
+  assert.equal(
+    hasConversationEntryForRequest(thread, "run-1", CONVERSATION_ENTRY_KIND.REPLY),
+    true,
+  );
+  assert.equal(
+    hasConversationEntryForRequest(thread, "run-3", CONVERSATION_ENTRY_KIND.REPLY),
+    false,
+  );
+  // The run rides through storage and tells two otherwise equal lines apart.
+  const stored = thread.map((entry) => storedConversationEntry(JSON.parse(JSON.stringify(entry))));
+  assert.deepEqual(stored, thread);
+  const [, firstReply, secondReply] = thread;
+  assert.ok(firstReply && secondReply);
+  assert.notEqual(conversationEntryKey(firstReply), conversationEntryKey(secondReply));
+  assert.equal(
+    storedConversationEntry({ kind: "reply", words: "x", recordedAt: now, requestId: "" }),
+    undefined,
+  );
+  assert.equal(
+    storedConversationEntry({ kind: "reply", words: "x", recordedAt: now, requestId: 7 }),
+    undefined,
+  );
 });

--- a/packages/realtime/src/conversation-history.test.ts
+++ b/packages/realtime/src/conversation-history.test.ts
@@ -17,6 +17,7 @@ import {
   type ConversationEntry,
   conversationEntryKey,
   conversationHistoryText,
+  enrichedConversationEntry,
   hasConversationEntryForRequest,
   insertSpokenAskEntry,
   insertSpokenAskThreadEntry,
@@ -602,9 +603,14 @@ test("a line tied to a run is recorded once per kind, and its run survives stora
   // The run rides through storage and tells two otherwise equal lines apart.
   const stored = thread.map((entry) => storedConversationEntry(JSON.parse(JSON.stringify(entry))));
   assert.deepEqual(stored, thread);
+  // The run is not part of a line's identity — the same line, later tied to
+  // its run, is still that line — so the better-informed copy is chosen.
   const [, firstReply, secondReply] = thread;
   assert.ok(firstReply && secondReply);
-  assert.notEqual(conversationEntryKey(firstReply), conversationEntryKey(secondReply));
+  assert.equal(conversationEntryKey(firstReply), conversationEntryKey(secondReply));
+  const untied = { ...firstReply, requestId: undefined };
+  assert.equal(enrichedConversationEntry(untied, firstReply), firstReply);
+  assert.equal(enrichedConversationEntry(firstReply, untied), firstReply);
   assert.equal(
     storedConversationEntry({ kind: "reply", words: "x", recordedAt: now, requestId: "" }),
     undefined,

--- a/packages/realtime/src/conversation-history.test.ts
+++ b/packages/realtime/src/conversation-history.test.ts
@@ -32,6 +32,7 @@ import {
   storedConversationMaximumAgeMs,
   streamingConversationEntry,
   typedAskConversationEntry,
+  withConversationEntryRequest,
 } from "./conversation-history.js";
 import { SESSION_NO_LONGER_OBSERVED_NOTE } from "./realtime-protocol.js";
 
@@ -612,4 +613,36 @@ test("a line tied to a run is recorded once per kind, and its run survives stora
     storedConversationEntry({ kind: "reply", words: "x", recordedAt: now, requestId: 7 }),
     undefined,
   );
+});
+
+test("a spoken ask is tied to its run whichever lands first, its words untouched", () => {
+  const now = Date.parse("2026-01-02T03:04:05.000Z");
+  // The run was accepted before the transcript arrived: the line carries it.
+  const early = insertSpokenAskThreadEntry([], "  ship   it ", undefined, now, "run-1");
+  assert.deepEqual(early, [
+    {
+      kind: CONVERSATION_ENTRY_KIND.SPOKEN_ASK,
+      words: "ship it",
+      recordedAt: now,
+      requestId: "run-1",
+    },
+  ]);
+  // The transcript arrived first: the run is written onto that very line.
+  const late = insertSpokenAskThreadEntry([], "ship it", undefined, now);
+  const [line] = late;
+  assert.ok(line);
+  const tied = withConversationEntryRequest(late, line, "run-2");
+  assert.deepEqual(tied, [
+    {
+      kind: CONVERSATION_ENTRY_KIND.SPOKEN_ASK,
+      words: "ship it",
+      recordedAt: now,
+      requestId: "run-2",
+    },
+  ]);
+  // Tying is idempotent, and a line the thread no longer holds ties nothing.
+  const [tiedLine] = tied;
+  assert.ok(tiedLine);
+  assert.equal(withConversationEntryRequest(tied, tiedLine, "run-2"), tied);
+  assert.equal(withConversationEntryRequest([], line, "run-2").length, 0);
 });

--- a/packages/realtime/src/conversation-history.ts
+++ b/packages/realtime/src/conversation-history.ts
@@ -153,7 +153,17 @@ export function appendConversationThreadEntry(
   const appended: ConversationEntry = { kind: entry.kind, words, recordedAt };
   if (entry.identity) appended.identity = entry.identity;
   if (entry.requestId !== undefined) appended.requestId = entry.requestId;
-  return retainedConversationEntries([...entries, appended], now);
+  // A line stamped earlier than the tail goes where it happened: after the
+  // last line that happened no later than it.
+  let at = entries.length;
+  while (at > 0) {
+    const before = entries[at - 1]?.recordedAt;
+    if (before === undefined || before <= recordedAt) break;
+    at -= 1;
+  }
+  const placed = [...entries];
+  placed.splice(at, 0, appended);
+  return retainedConversationEntries(placed, now);
 }
 
 /**
@@ -194,15 +204,32 @@ function sameConversationEntry(a: ConversationEntry, b: ConversationEntry): bool
   return conversationEntryKey(a) === conversationEntryKey(b);
 }
 
-/** Stable value identity shared by renderer adoption and main-process merging. */
+/**
+ * Stable value identity shared by renderer adoption and main-process merging.
+ * The run a line was later tied to is not part of it: a spoken ask's
+ * transcript and the same transcript once its run is known are one line, so
+ * the correlation enriches the line rather than standing beside it.
+ */
 export function conversationEntryKey(entry: ConversationEntry): string {
   return JSON.stringify([
     entry.kind,
     entry.words,
     entry.recordedAt,
     entry.identity ? [entry.identity.providerId, entry.identity.providerSessionId] : undefined,
-    entry.requestId,
   ]);
+}
+
+/**
+ * The better-informed of two copies of one line: the one that knows its run.
+ * Nothing else about a line changes after it is recorded, so a copy without
+ * the run is the older one, and a stale window snapshot cannot take the
+ * correlation back off.
+ */
+export function enrichedConversationEntry(
+  held: ConversationEntry,
+  incoming: ConversationEntry,
+): ConversationEntry {
+  return held.requestId === undefined && incoming.requestId !== undefined ? incoming : held;
 }
 
 /** The recent slice safe to place back into the model's context window. */

--- a/packages/realtime/src/conversation-history.ts
+++ b/packages/realtime/src/conversation-history.ts
@@ -118,6 +118,14 @@ export interface ConversationEntry {
    * retention's clock and never enters model context.
    */
   recordedAt?: number;
+  /**
+   * The brain run this line belongs to, when it is an ask the brain took or
+   * the reply that run ended in. It is what lets a reply be recorded exactly
+   * once however many windows hear of the run's end, and what lets History
+   * draw a run still working beside the ask that opened it. Never rendered
+   * into model context.
+   */
+  requestId?: string;
 }
 
 /**
@@ -132,9 +140,30 @@ export function appendConversationThreadEntry(
 ): readonly ConversationEntry[] {
   const words = flattenedEntryWords(entry.words);
   if (!words) return entries;
+  if (
+    entry.requestId !== undefined &&
+    hasConversationEntryForRequest(entries, entry.requestId, entry.kind)
+  ) {
+    return entries;
+  }
   const appended: ConversationEntry = { kind: entry.kind, words, recordedAt: now };
   if (entry.identity) appended.identity = entry.identity;
+  if (entry.requestId !== undefined) appended.requestId = entry.requestId;
   return retainedConversationEntries([...entries, appended], now);
+}
+
+/**
+ * Whether the thread already holds this kind of line for this run. A run's
+ * ask and its reply are each recorded once: the main process records the
+ * reply at the run's end, and a window that also heard the end must not add
+ * a second line for it.
+ */
+export function hasConversationEntryForRequest(
+  entries: readonly ConversationEntry[],
+  requestId: string,
+  kind: ConversationEntryKind,
+): boolean {
+  return entries.some((entry) => entry.requestId === requestId && entry.kind === kind);
 }
 
 /**
@@ -168,6 +197,7 @@ export function conversationEntryKey(entry: ConversationEntry): string {
     entry.words,
     entry.recordedAt,
     entry.identity ? [entry.identity.providerId, entry.identity.providerSessionId] : undefined,
+    entry.requestId,
   ]);
 }
 
@@ -281,8 +311,17 @@ export function announcementConversationEntry(words: string): ConversationEntry 
  * The history line a conversation reply leaves behind. A reply carries no
  * subject of its own: only an act names the session it was about.
  */
-export function replyConversationEntry(words: string): ConversationEntry {
-  return { kind: CONVERSATION_ENTRY_KIND.REPLY, words };
+export function replyConversationEntry(words: string, requestId?: string): ConversationEntry {
+  return {
+    kind: CONVERSATION_ENTRY_KIND.REPLY,
+    words,
+    ...(requestId !== undefined ? { requestId } : undefined),
+  };
+}
+
+/** The history line a typed ask the brain accepted leaves behind, tied to its run. */
+export function typedAskConversationEntry(words: string, requestId: string): ConversationEntry {
+  return { kind: CONVERSATION_ENTRY_KIND.TYPED_ASK, words, requestId };
 }
 
 /**
@@ -358,6 +397,9 @@ export function storedConversationEntry(value: UnparsedWireValue): ConversationE
       ? value.recordedAt
       : undefined;
   if (recordedAt === undefined || recordedAt < 0) return undefined;
+  if (value.requestId !== undefined && !(isWireString(value.requestId) && value.requestId)) {
+    return undefined;
+  }
   const identity = value.identity;
   const providerId = isRecord(identity) ? identity.providerId : undefined;
   const providerSessionId = isRecord(identity) ? identity.providerSessionId : undefined;
@@ -377,6 +419,7 @@ export function storedConversationEntry(value: UnparsedWireValue): ConversationE
     ...(isWireString(providerId) && isWireString(providerSessionId)
       ? { identity: { providerId, providerSessionId } }
       : undefined),
+    ...(isWireString(value.requestId) ? { requestId: value.requestId } : undefined),
   };
 }
 

--- a/packages/realtime/src/conversation-history.ts
+++ b/packages/realtime/src/conversation-history.ts
@@ -131,12 +131,16 @@ export interface ConversationEntry {
 /**
  * Appends one flattened line to the retained thread. An entry with
  * nothing left after flattening appends nothing: an empty line says nothing
- * worth keeping or spending model-window space on.
+ * worth keeping or spending model-window space on. A line recorded after the
+ * fact — a run's end written once its record is read — may carry the moment
+ * it happened rather than the moment it was written, so the thread keeps the
+ * order things occurred in; retention still runs on `now`.
  */
 export function appendConversationThreadEntry(
   entries: readonly ConversationEntry[],
   entry: ConversationEntry,
   now: number = Date.now(),
+  recordedAt: number = now,
 ): readonly ConversationEntry[] {
   const words = flattenedEntryWords(entry.words);
   if (!words) return entries;
@@ -146,7 +150,7 @@ export function appendConversationThreadEntry(
   ) {
     return entries;
   }
-  const appended: ConversationEntry = { kind: entry.kind, words, recordedAt: now };
+  const appended: ConversationEntry = { kind: entry.kind, words, recordedAt };
   if (entry.identity) appended.identity = entry.identity;
   if (entry.requestId !== undefined) appended.requestId = entry.requestId;
   return retainedConversationEntries([...entries, appended], now);
@@ -260,6 +264,7 @@ export function insertSpokenAskThreadEntry(
   words: string,
   after: ConversationEntry | undefined,
   recordedAt: number = Date.now(),
+  requestId?: string,
 ): readonly ConversationEntry[] {
   const flattened = flattenedEntryWords(words);
   if (!flattened) return entries;
@@ -271,8 +276,27 @@ export function insertSpokenAskThreadEntry(
     kind: CONVERSATION_ENTRY_KIND.SPOKEN_ASK,
     words: flattened,
     recordedAt,
+    ...(requestId !== undefined ? { requestId } : undefined),
   });
   return placed;
+}
+
+/**
+ * Ties a line already in the thread to the run it turned out to open: a
+ * spoken ask's transcript can land before the brain has accepted the ask,
+ * and the correlation is then written onto the very entry, words untouched.
+ * A thread that does not hold the entry is returned as it was.
+ */
+export function withConversationEntryRequest(
+  entries: readonly ConversationEntry[],
+  entry: ConversationEntry,
+  requestId: string,
+): readonly ConversationEntry[] {
+  const at = entries.indexOf(entry);
+  if (at === -1 || entry.requestId === requestId) return entries;
+  const tied = [...entries];
+  tied[at] = { ...entry, requestId };
+  return tied;
 }
 
 /** Places a spoken ask into the recent model context and retires old lines. */

--- a/packages/realtime/src/index.ts
+++ b/packages/realtime/src/index.ts
@@ -14,6 +14,7 @@ export {
   type ConversationEntryKind,
   conversationEntryKey,
   conversationHistoryText,
+  enrichedConversationEntry,
   hasConversationEntryForRequest,
   insertSpokenAskEntry,
   insertSpokenAskThreadEntry,

--- a/packages/realtime/src/index.ts
+++ b/packages/realtime/src/index.ts
@@ -14,6 +14,7 @@ export {
   type ConversationEntryKind,
   conversationEntryKey,
   conversationHistoryText,
+  hasConversationEntryForRequest,
   insertSpokenAskEntry,
   insertSpokenAskThreadEntry,
   isConversationEntryKind,
@@ -27,6 +28,7 @@ export {
   storedConversationEntry,
   storedConversationMaximumAgeMs,
   streamingConversationEntry,
+  typedAskConversationEntry,
 } from "./conversation-history.js";
 export {
   type IntroductionLine,

--- a/packages/realtime/src/index.ts
+++ b/packages/realtime/src/index.ts
@@ -29,6 +29,7 @@ export {
   storedConversationMaximumAgeMs,
   streamingConversationEntry,
   typedAskConversationEntry,
+  withConversationEntryRequest,
 } from "./conversation-history.js";
 export {
   type IntroductionLine,


### PR DESCRIPTION
## Problem

A developer ask to the brain was one blocking `askBrain` call: it raced a single turn against a 45-second deadline, dropped the reply text on timeout while the turn kept running, dispatched tool calls with `Promise.all`, and rolled the whole memory back when the model failed after an act had already happened. Typed asks travelled panel → main → voice window → main and depended on the voice window standing. Nothing survived a restart, a reload, or a cancel with an honest record.

## Result

A developer ask is a run the main process owns from acceptance to its end, and the brain's state is one envelope with one writer.

**packages/brain**
- `brain-requests.ts`: `BRAIN_REQUEST_STATUS` (`queued`, `running`, `succeeded`, `failed`, `cancelled`, `timed_out`, `interrupted`), `BRAIN_REQUEST_ORIGIN` (`typed`, `spoken`), `BRAIN_REQUEST_FAILURE` (`model`, `persistence`, `deadline`, `incomplete`), `BRAIN_SUBMISSION_REJECTION` (`empty`, `absent`, `persistence`, `conflict`), `BrainRequestRecord` (`runId`, `submissionId`, `origin`, `question`, `status`, `revision`, `acceptedAt`, `startedAt?`, `settledAt?`, `text?`, `failure?`, `performedActs`, `unknownActs`, `askRecordedAt?`, `historyRecordedAt?`). Exported at `@sidecar/brain/requests` so the renderer reads the vocabulary without the barrel.
- `brain-journal.ts`: `BrainJournalEntry` keyed by `runId` + `callId` (`name`, `argumentsJson`, `startedAt`, `outputJson?`, `settledAt?`), `BrainJournal`, `UNKNOWN_ACT_RESULT` (started, result lost), `UNCONFIRMED_ACT_RESULT` (dispatched, performer threw), `journalActCounts(entries, runId)` → `{ performedActs, unknownActs }`.
- `brain-state.ts`: the **version 2 envelope** `{ version: 2, generationId, createdAt, expiresAt, items, cursors, requests, journal }`, `freshBrainState`, `BRAIN_GENERATION_LIFETIME_MS` (14 days; fields set here, enforcement is PR 4), a parser that reads v1 as nothing, and **`BrainStateStore`**: the single persistence owner with `lease()`, `holdsLease(lease)`, `load()`, `current()`, `generationId()`, `write(lease, generationId, mutate, committed?)` (serialized; `mutate` and `committed` run inside the queue; fenced by generation and lease; false on refusal), `replace(state)`, `reset()`, `onReplaced(listener)`, `flush()`.
- `BrainAgent`: `ask()` is gone. `submitAsk`, `waitAsk(runId, timeoutMs)`, `cancelAsk`, `requests()`, `request(runId)`, `subscribe(listener)`, `ready()`, `markAskRecorded(runId, at): Promise<boolean>`, `markHistoryRecorded(runId, at): Promise<boolean>` (true only once the mark is written), `lease` getter, `stop()`.
  - **Generation-scoped turns.** Every turn captures the `Generation` it was *queued* in (memory, journal, records, abort signal) and works on that object alone; work reaching the front of the queue in another generation opens nothing, and pending coalesced wakes are dropped at replacement. A store `reset`/`replace` fires the old generation's signal: runs and observation turns alike are revoked, their late model answers, reads, tool outputs, and rollbacks land only on the orphaned copy, the store fences their checkpoints, and a briefing is delivered only from a turn still standing after its final write, rechecked before each delivery.
  - **Abortable waits.** Model answers, transcript deltas, and full reads settle at once on cancel, deadline, stop, or replacement; a late completion is dropped unread and opens no inference. An act already dispatched is neither aborted nor retried: its result is kept, known or unknown.
  - **Durable acceptance.** A submission is acknowledged only once its record is checkpointed; a retry of the same id while the write is out awaits the same result, and no caller is told of a run a failed write removes. Same id with other words or another origin is a `conflict`. `stop()` drains held acceptances before it settles, and one accepted into a stopped agent is recorded `interrupted` rather than scheduled.
  - **Staged settlement.** A run's terminal record is written before it is shown: `request()`, `requests()`, `waitAsk`, and subscribers keep seeing the run under way until the store answers, then see the finalized status once (success only if written; otherwise `failed`/`persistence` with the reply kept, standing in memory if the disk stays unavailable). A finite `waitAsk` during the write answers pending. Marks (`markAskRecorded`, `markHistoryRecorded`) are staged the same way, merged onto the live record on success rather than rolling a captured copy back, and concurrent marks of one field share one write.
  - **Durable start.** A run opens no model call and no act until its `running` transition is written; a refused start ends the run `failed`/`persistence` with nothing called, and a cancel, stop, or reset that lands while the start is being written ends it on its own terms, likewise unopened.
  - **One save path, scoped to what it owns.** Every envelope is composed *inside* the store's serialized queue (`BrainStateStore.write(lease, generationId, mutate, committed?)`), starting from the store's **committed** state, never from a copy taken before the queue and never from live state the save does not own. A record write (acceptance inserts its own record; the running transition, act accounting, terminal end, and the two marks change one record's fields) carries only that record over the committed requests and the committed memory, cursors, and journal, so an unrelated mark or acceptance cannot publish another request still provisional or a turn's uncommitted working memory. A turn or act checkpoint owns the working memory, cursors, and journal and, for a run, that run's accounting, and leaves every other record as committed. A failed turn keeps its rollback and its unread cursor. Owned record fields land on the live record in the same queue step that keeps them, so a later save can only add to what earlier saves kept.
  - **Store lease.** Each agent takes `BrainStateStore.lease()` at construction; `write(lease, generationId, mutate, committed?)` refuses a lease a later agent has superseded, so a replaced agent cannot write over its successor even inside one generation.
  - **Outcomes.** Acts run in response order one at a time, journaled and checkpointed before the performer and again with the result before the next inference; the rollback mark advances past every answered act. A performer that throws after dispatch yields an unknown outcome (`unknownActs`), never a refusal. Incomplete output, a spent tool budget, and a failed final checkpoint end a run `failed` (`incomplete` / `persistence`) rather than `succeeded`; a checkpoint failure outranks a later model failure. The record's `performedActs`/`unknownActs` move with the journal in the same checkpoint, and restart rebuilds them from the journal alone (`journalActCounts`: accepted results, explicit unknown results, started-unanswered entries), so a copy taken mid-run reports what was done or may have been. Dangling calls are paired with `UNKNOWN_ACT_RESULT`.
  - `BrainActExecution.signal` (additive to PR 2's `{authority, isRevoked}`): the real performers race `refreshSessions`, `workspaceDefaults`, and the deeper `settingsStore.get` against it, so a cancel mid-preparation settles at once and a late read dispatches nothing; a row's own press carries no signal and behaves as before.
- `BrainRespondOptions.signal?: AbortSignal`: honoured by both clients, joined with the per-request timeout (PR 6 reuses it).

**Desktop**
- Bridge: `submitBrainAsk`, `waitBrainAsk`, `cancelBrainAsk`, `brainRequestSnapshots` (invoke) and `onBrainRequestsChanged` (subscribe, whole list). `askBrain`, `answerVoiceAsk`, and the `ask-text` voice command are removed.
- `main/brain-host.ts` (**`BrainHost`**): owns the standing agent through source/account transitions. `retire()` is synchronous, counts as a transition (a build still waiting on an earlier stop installs nothing), and begins the old agent's `stop()`; the follower stays through the stop so the interruptions it records reach the windows and the thread, then retires. `replace(build)` serializes behind every earlier retirement and coalesces to the latest transition; no capability publishes an empty snapshot list. `applyVoiceCredential` retires **before** awaiting `voiceCapabilities.apply()`.
- `main/ipc/brain.ts`: origin checked against the sender. **History write point:** `publishRuns` decides each write against the *live* record (`agent.request`), never the captured snapshot: a typed ask is written once at `acceptedAt` and marked with `markAskRecorded`; an end is written once at `settledAt` and marked with `markHistoryRecorded`. Marks are held only once their checkpoint lands (a refused mark is not held in memory either), and a refused History write leaves the run unmarked for the next report, so a missed typed-ask line or reply line recovers, while eviction, rebuilt followers, repeated snapshots, and restarts cannot replay a published one. `followBrainRequests` publishes reports serially and fences each iteration on retirement; its unfollow takes no new reports at once but drains the publication already taken, and `BrainHost` awaits that drain (after the old agent's `stop()`) before building a successor, so every run a stop interrupts has its end in the thread and its mark on disk before any new agent or lease exists.
- `ConversationEntry.requestId?` with parser, append dedupe, and a `recordedAt` override on append that places the line in chronological order. The run is **not** part of `conversationEntryKey`: the same spoken line before and after its run is known is one line, and `mergeConversationHistory` enriches the held copy (`enrichedConversationEntry`) instead of adding a second, so a stale window snapshot cannot double it or take the correlation off. `typedAskConversationEntry`, `replyConversationEntry(words, requestId?)`, `withConversationEntryRequest`, `insertSpokenAskThreadEntry(…, requestId?)`.
- Renderer: the composer submits with a fresh `submissionId` per Send and clears on acceptance. The voice window's `ask_brain` tool submits under the Realtime call id, waits 30 s, returns `pending` tool output when the run is still going, and ties the run to the developer's own transcript (the voice service's words, never the mouth's paraphrase), whichever of transcript and acceptance lands first. History draws a pending typed **or spoken** ask with **Cancel** inside the `ph-no-capture` subtree; each pushed list is authoritative (a run absent from it has no row), and the bootstrap read applies only where no push has spoken. The spoken turn an ask belongs to is captured before the acceptance is awaited, and a turn from before a Clear ties nothing. The voice window speaks a typed run's reply only on an end it watched arrive and records nothing for a run's reply.

## Handoff seams

- **PR 4:** `BrainStateStore.{lease,holdsLease,load,current,generationId,write(lease, generationId, mutate, committed?),replace,reset,onReplaced,flush}`; envelope fields above; `BRAIN_REQUEST_TERMINAL_STATUS`; journal types; `BrainAgent.stop()` and the store's `onReplaced` as the cancel/revoke/generation-invalidation hooks (the agent revokes every run and observation turn of the old generation and adopts the new envelope; late checkpoints are fenced; `BrainHost.retire()` is the main-process handle).
- **PR 6:** `BrainRespondOptions.signal`.
- **PR 7:** bootstrap `BRIDGE.brainRequestSnapshots`, subscription `BRIDGE.onBrainRequestsChanged` (whole list, authoritative), main follower `followBrainRequests(agent, deps): () => Promise<void>` (the returned unfollow drains queued publication before resolving) / `BrainAgent.subscribe`; History writes are `publishRuns`, marks `markAskRecorded`/`markHistoryRecorded` (boolean), in `apps/desktop/src/main/ipc/brain.ts`, with `askRecordedAt`/`historyRecordedAt` on the record and `requestId` on entries as the once-only keys.

## Checks run

- `./scripts/check.sh` passes (biome, oxlint, typecheck, all package and desktop tests, desktop build).
- Sixth-review regressions (real agent + store): durable acceptance then a refused `running` write → no model call, no act, one `failed`/`persistence` record equal in live, saved, and relaunched state; cancel during a held start and stop during a refused start → run ends cancelled/interrupted unopened; positive control: model called only after the start lands, and a cancel over a dispatched held act still publishes one counted terminal record.
- Fifth-review regressions (real agent + store): a held mark, a queued second mark, and a provisional acceptance whose own write is refused → the refused request is in no unrelated write, the final file, or the relaunch, no effect runs, and the same submission retried afterwards is a fresh acceptance; two overlapping submissions with one refused → no ghost run, the accepted one executes once; an observation holding a real delta and cursor while an unrelated run is marked and another ask accepted → the file and a crash copy carry neither the observation's items nor its cursor, on failure the delta is reread, and the success control commits the cursor.
- Fourth-review regressions (real agent + store): both markers concurrently in both orders on one run and across two runs, live and stored records equal; held successful mark then a roster-look checkpoint keeps the mark on disk; terminal settle + both marks overlapping a new submission and a wake checkpoint keep status, text, accounting, marks, memory pairing, and journal result; a refused save among overlapping ones leaves the others kept and a retry lands beside them.
- Third-review regressions, composed from the real `BrainAgent` + `BrainStateStore` + `BrainHost` + `followBrainRequests` + `submitBrainAsk` (`apps/desktop/src/main/brain-lifecycle.test.ts`): five outstanding runs under capability removal → all interrupted, each with one reply line and marks on disk, late model answer inert; five runs under successor replacement with an earlier refused publication → all written before the successor, which alone holds the lease and proceeds; reset under outstanding runs publishes nothing. Agent-level: a held mark write is invisible and unacknowledged to a concurrent same-field caller until storage answers, both hear the same refusal, another marker lands on its own terms, and a retry lands beside advanced fields; a held terminal-success write is seen by no reader (request/requests/waitAsk/subscription) and on refusal the first terminal state seen is `failed`/`persistence` with the reply, on success `succeeded`, with disk permanently unavailable the failure stands in memory.
- Second-review regressions: held act + queued hold-release/roster/wake + reset (no old briefing, cursor, or delivery in the successor); stop during the final write and reset between two deliveries; stop waiting on a held acceptance, then the successor's lease fencing the old agent's mark; retire while a replacement waits on a held stop (nothing installs), follower outliving the stop; crash copies before the second model answer with an accepted act, and with unknown + refused + started-unanswered acts, across two relaunches; refused mark not held and retried; typed-ask line refused at acceptance and recovered by a later report at `acceptedAt`, ordered before its reply; publication decided against live records (older snapshot cannot rewrite, unknown run not written, retirement between two records); spoken line enriched through `mergeConversationHistory` without duplication, stale copy ignored, distinct utterances kept; real performer held `refreshSessions`/`workspaceDefaults` and deeper held `settingsStore.get` settling on cancel with zero effects.
- First-review regressions: seeded prior memory + reset during held inference, held delta read, and held act result (no old marker in new input/store/cursors/journal/deliveries); concurrent retry with held acceptance write (both callers share one durable answer, no run remains on failure, conflict on other words/origin, stop during pending acceptance); cancel/deadline/stop settling held full and delta reads with no following inference and the next ask proceeding; post-dispatch throw kept as unknown through model failure and restart, confirmed-refusal control, interrupted run's started acts counted unknown; incomplete reply, spent budget, and final-only checkpoint failure not reported as success; history mark once and across relaunch; once-per-run publication at settle time with refused-write retry; retired follower relays nothing; `BrainHost` overlap and late-build stop; spoken ask tied to its run before/after transcript; pending row for spoken asks.

## Pending

- macOS `./scripts/verify.sh`, PNG inspection, and the physical-notch check were **not** performed from this Linux cloud workspace. The History pending row and Cancel control are a UI change that the six canonical fixture captures do not show, so they need a separate live check beyond those captures.
- PR 4 enforces expiry/reset-marker/pruning on the envelope; PR 7 delivers a pending spoken ask's eventual reply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34072684912/artifacts/10001018880) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34072684912)

- Commit: `1cd06b35a0bdf7c62fff60472ee5bd73019e1d92`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
