### PR TITLE
refactor(brain): reuse act tool schema types

### DIFF
--- a/packages/brain/src/brain-openai.ts
+++ b/packages/brain/src/brain-openai.ts
@@ -1,3 +1,4 @@
+import type { RealtimeToolWireDefinition } from "@sidecar/acts";
 import {
   isRecord,
   isWireString,
@@ -6,7 +7,6 @@ import {
   type WireRecord,
   wholeNumber,
 } from "@sidecar/wire";
-import type { BrainToolWireDefinition } from "./brain-tools.js";
 
 /**
  * The one OpenAI Responses request a brain turn may be, and the one reading of
@@ -68,7 +68,7 @@ export type BrainReasoningEffort =
 export interface BrainResponsesOptions {
   model: string;
   instructions: string;
-  tools: readonly BrainToolWireDefinition[];
+  tools: readonly RealtimeToolWireDefinition[];
   maximumOutputTokens: number;
   reasoningEffort: BrainReasoningEffort;
 }

--- a/packages/brain/src/brain-tools.ts
+++ b/packages/brain/src/brain-tools.ts
@@ -1,4 +1,8 @@
-import { REALTIME_TOOL, realtimeToolDefinitions } from "@sidecar/acts";
+import {
+  REALTIME_TOOL,
+  type RealtimeToolWireDefinition,
+  realtimeToolDefinitions,
+} from "@sidecar/acts";
 import { BRAIN_TURN_AUTHORITY, type BrainTurnAuthority } from "@sidecar/hosted";
 
 /**
@@ -38,39 +42,7 @@ export type BrainToolName = (typeof BRAIN_TOOL)[keyof typeof BRAIN_TOOL];
 /** The longest briefing the mouth is handed; a briefing is a breath, not a report. */
 export const maximumBriefingLength = 600;
 
-/** The JSON Schema a brain tool's parameters are described in: the acts table's own vocabulary. */
-export type BrainSchemaProperty =
-  | { type: "string"; description?: string; enum?: readonly string[] }
-  | {
-      type: "object";
-      description?: string;
-      properties?: BrainSchemaPropertyMap;
-      required?: readonly string[];
-      additionalProperties?: boolean;
-    }
-  | {
-      type: "array";
-      description?: string;
-      items: { type: "string"; description?: string; enum?: readonly string[] };
-    };
-
-export type BrainSchemaPropertyMap = { readonly [key: string]: BrainSchemaProperty };
-
-export interface BrainToolParameters {
-  type: "object";
-  properties: BrainSchemaPropertyMap;
-  required: readonly string[];
-}
-
-/** A function tool as the Responses API takes it. */
-export interface BrainToolWireDefinition {
-  type: typeof BRAIN_TOOL_TYPE;
-  name: string;
-  description: string;
-  parameters: BrainToolParameters;
-}
-
-const BRAIN_ONLY_TOOLS: readonly BrainToolWireDefinition[] = [
+const BRAIN_ONLY_TOOLS: readonly RealtimeToolWireDefinition[] = [
   {
     type: BRAIN_TOOL_TYPE,
     name: BRAIN_TOOL.LIST_SESSIONS,
@@ -129,23 +101,14 @@ const BRAIN_ONLY_TOOLS_BY_AUTHORITY = {
   ]),
 } as const satisfies Record<BrainTurnAuthority, ReadonlySet<string>>;
 
-function actToolDefinitions(): readonly BrainToolWireDefinition[] {
-  return realtimeToolDefinitions()
-    .filter((tool) => !EXCLUDED_ACT_TOOLS.has(tool.name))
-    .map(
-      (tool): BrainToolWireDefinition => ({
-        type: BRAIN_TOOL_TYPE,
-        name: tool.name,
-        description: tool.description,
-        parameters: tool.parameters,
-      }),
-    );
+function actToolDefinitions(): readonly RealtimeToolWireDefinition[] {
+  return realtimeToolDefinitions().filter((tool) => !EXCLUDED_ACT_TOOLS.has(tool.name));
 }
 
 /** The tool schemas one brain turn is configured with, fixed by the turn's authority. */
 export function brainToolDefinitions(
   authority: BrainTurnAuthority,
-): readonly BrainToolWireDefinition[] {
+): readonly RealtimeToolWireDefinition[] {
   const own = BRAIN_ONLY_TOOLS.filter((tool) =>
     BRAIN_ONLY_TOOLS_BY_AUTHORITY[authority].has(tool.name),
   );

--- a/packages/brain/src/index.ts
+++ b/packages/brain/src/index.ts
@@ -76,11 +76,7 @@ export {
 } from "./brain-openai.js";
 export {
   BRAIN_TOOL,
-  type BrainSchemaProperty,
-  type BrainSchemaPropertyMap,
   type BrainToolName,
-  type BrainToolParameters,
-  type BrainToolWireDefinition,
   brainToolAllowed,
   brainToolDefinitions,
   isBrainOnlyTool,


### PR DESCRIPTION
## What changed

`packages/brain/src/brain-tools.ts` declared its own `BrainSchemaProperty`, `BrainSchemaPropertyMap`, `BrainToolParameters`, and `BrainToolWireDefinition`, structurally identical to `RealtimeToolWireDefinition` in `@sidecar/acts`, and rebuilt every act tool row through a field-by-field `map` into that duplicate shape.

- `brain-tools.ts` now imports `RealtimeToolWireDefinition` from `@sidecar/acts` and uses it for the brain-only tool table, `actToolDefinitions`, and `brainToolDefinitions`. The duplicated type declarations are deleted.
- `actToolDefinitions` filters `realtimeToolDefinitions()` directly instead of mapping to identical objects.
- `brain-openai.ts` types `BrainResponsesOptions.tools` as `readonly RealtimeToolWireDefinition[]`.
- The brain barrel drops the four obsolete type exports. No external consumer referenced them.

Behavior is preserved: tool order, descriptions, `read_session_transcript` exclusion, and authority filtering are unchanged. Developer turns keep their permitted acts plus `list_sessions` and `read_transcript`; observation turns get only the two reads and `announce`. No compatibility aliases were added and no types moved across package boundaries.

## Verification

- `./scripts/check.sh`: passed (repository, type, test, and build checks).
- `pnpm --filter @sidecar/brain test`: 40 pass, 0 fail, including the runtime tool-authorization tests.
- Linux workspace: no macOS packaging, `verify.sh`, or physical-notch check was performed. This change is type-level and renders nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/8e47df8a-7ee7-4e62-8ee6-1609285f467c)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34072683465/artifacts/10001035450) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34072683465)

- Commit: `139d2cf5fe664cb9858ef43067f4d03697234818`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
