### PR TITLE
refactor(desktop): remove inactive transcript suppression

### DIFF
--- a/apps/desktop/src/renderer/voice/use-voice-session.test.ts
+++ b/apps/desktop/src/renderer/voice/use-voice-session.test.ts
@@ -45,7 +45,6 @@ test("the live lines mirror exactly what their recording paths will keep", () =>
     ]),
     captions: ["Checkout is", "nearly done."],
     kind: undefined,
-    transcriptSpoken: false,
   });
 
   // The asks precede the answer, and the reply's segments join into the one
@@ -62,13 +61,12 @@ test("the live lines mirror exactly what their recording paths will keep", () =>
   assert.ok(lines.every((line) => line.recordedAt === undefined));
 });
 
-test("a briefing's live line settles as an announcement, a transcript reading notwithstanding", () => {
+test("a briefing's live line settles as an announcement", () => {
   assert.deepEqual(
     liveConversationEntries({
       spokenAskPreviews: new Map(),
       captions: ["Claude Code finished checkout-service."],
       kind: REPLY_KIND.BRIEFING,
-      transcriptSpoken: true,
     }),
     [
       {
@@ -76,20 +74,6 @@ test("a briefing's live line settles as an announcement, a transcript reading no
         words: "Claude Code finished checkout-service.",
       },
     ],
-  );
-});
-
-test("a transcript reading's reply previews nothing it may never record", () => {
-  // The record keeps the act and not a word of the rendering, so the live
-  // line keeps the same silence the settled thread will.
-  assert.deepEqual(
-    liveConversationEntries({
-      spokenAskPreviews: new Map(),
-      captions: ["The session said the tests pass."],
-      kind: undefined,
-      transcriptSpoken: true,
-    }),
-    [],
   );
 });
 

--- a/apps/desktop/src/renderer/voice/use-voice-session.ts
+++ b/apps/desktop/src/renderer/voice/use-voice-session.ts
@@ -250,15 +250,13 @@ const NO_SPOKEN_ASK_PREVIEWS: ReadonlyMap<string, string> = new Map();
  * the developer's spoken turns as the service transcribes them, then the
  * reply or announcement as its words are generated — the ask precedes its
  * answer. Presentation only, so each line mirrors exactly what its own
- * recording path will keep: a briefing settles as an announcement, and the
- * reply that is voicing a transcript reading draws nothing, because the
- * record keeps the act and never a word of the rendering.
+ * recording path will keep: a briefing settles as an announcement, and any
+ * other caption settles as a reply.
  */
 export function liveConversationEntries(input: {
   spokenAskPreviews: ReadonlyMap<string, string>;
   captions: readonly string[] | undefined;
   kind: ReplyKind | undefined;
-  transcriptSpoken: boolean;
 }): readonly ConversationEntry[] {
   const lines: ConversationEntry[] = [];
   for (const words of input.spokenAskPreviews.values()) {
@@ -266,7 +264,7 @@ export function liveConversationEntries(input: {
     if (ask) lines.push(ask);
   }
   const briefing = input.kind === REPLY_KIND.BRIEFING;
-  if (input.captions && (briefing || !input.transcriptSpoken)) {
+  if (input.captions) {
     const speech = streamingConversationEntry(
       briefing ? CONVERSATION_ENTRY_KIND.ANNOUNCEMENT : CONVERSATION_ENTRY_KIND.REPLY,
       input.captions.join(" "),
@@ -451,20 +449,6 @@ export function useVoiceSession(remoteAudio: RefObject<HTMLAudioElement | null>)
   const activeReplyGenerationRef = useRef<number | undefined>(undefined);
   /** The History generation in which the current announcement began speaking. */
   const activeAnnouncementGenerationRef = useRef<number | undefined>(undefined);
-  /**
-   * Whether the turn under way read a transcript aloud. The rendering travels
-   * only in the turn that asked for it, so the reply that spoke it must not
-   * be recorded: the record keeps the act — already recorded at the carry —
-   * and not a word of what it rendered.
-   */
-  const transcriptSpokenRef = useRef(false);
-  // State beside the ref, because the session's callbacks read the flag
-  // synchronously while History's live line derives from what React can see.
-  const [transcriptSpoken, setTranscriptSpoken] = useState(false);
-  const markTranscriptSpoken = useCallback((value: boolean) => {
-    transcriptSpokenRef.current = value;
-    setTranscriptSpoken(value);
-  }, []);
   /**
    * The developer's spoken turns still being transcribed, keyed by the server
    * item that names each turn: the preview History draws while the completed
@@ -1247,13 +1231,6 @@ export function useVoiceSession(remoteAudio: RefObject<HTMLAudioElement | null>)
     if (!typedAskHolds(voiceStatus)) {
       setTypedAsk(false);
     }
-    // The transcript skip belongs to the turn that read the transcript, and a
-    // reply abandoned wordless never fires the handover that consumes it — so
-    // a new spoken turn opening lets it go, or the flag would swallow the
-    // next reply from the history.
-    if (voiceStatus === REALTIME_STATUS.LISTENING) {
-      markTranscriptSpoken(false);
-    }
     // The call gone takes its half-transcribed turns with it: no completed
     // transcript can arrive to settle a preview, so none may keep streaming.
     if (!spokenAskPreviewSurvives(voiceStatus)) {
@@ -1272,7 +1249,7 @@ export function useVoiceSession(remoteAudio: RefObject<HTMLAudioElement | null>)
     ) {
       setTalkOpening(false);
     }
-  }, [markTranscriptSpoken, voiceStatus]);
+  }, [voiceStatus]);
 
   // The strip the error is drawn on takes no pointer, so nothing but time can
   // dismiss it: a fault left up would sit on the desktop all afternoon. A new
@@ -1397,9 +1374,8 @@ export function useVoiceSession(remoteAudio: RefObject<HTMLAudioElement | null>)
         spokenAskPreviews,
         captions: voiceCaption.texts,
         kind: voiceCaption.kind,
-        transcriptSpoken,
       }),
-    [spokenAskPreviews, transcriptSpoken, voiceCaption],
+    [spokenAskPreviews, voiceCaption],
   );
 
   const lukeCaptions = lukeCaptionsToShow({


### PR DESCRIPTION
## What changed

Behavior-preserving cleanup in `apps/desktop/src/renderer/voice/use-voice-session.ts`:

- Removed the `transcriptSpoken` state, the write-only `transcriptSpokenRef`, and the `markTranscriptSpoken` callback (including its reset on `LISTENING` and its effect dependency).
- Removed `transcriptSpoken` from `liveConversationEntries` input and dropped the suppression branch, which nothing in production could reach because the flag was never set true.
- Reworded the doc comment to the current behavior: spoken asks precede captions; captions settle as a reply, or as an announcement for a briefing.

Tests in `use-voice-session.test.ts`:

- Dropped the `transcriptSpoken` argument from the remaining `liveConversationEntries` tests and renamed the briefing test.
- Removed the one test that manufactured the unreachable suppression state.
- Blank-caption behavior, preview cleanup on a gone call, announcement classification, and the history-generation checks after Clear are unchanged and still covered.

No retention, privacy, or rendering change; `useCallback`, `useState`, and `useRef` imports remain in use elsewhere in the hook.

## Verification

`./scripts/check.sh` on Linux: exit 0. `apps/desktop test`: 840 tests, 840 pass, 0 fail. The voice test file alone: 21 pass, 0 fail.

Not run: `./scripts/verify.sh` and any macOS or physical-notch check (Linux cloud workspace). The change is renderer state removal with no rendering path touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34072707922/artifacts/10001036303) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34072707922)

- Commit: `cde29333dcc592bd2e91ae471be0924706dd4629`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->


## Integration review

Reviewed the complete diff at `cde29333dcc592bd2e91ae471be0924706dd4629`. Portable CI and macOS `./scripts/verify.sh` passed in [CI run 34072707922](https://github.com/ReviewStage/luke/actions/runs/34072707922). Inspected all six generated fixture captures (expanded, compact, peek, slot, speaking, muted); no visual issue found. Physical-notch check was not performed.
