### PR TITLE
refactor(brain): inline transcript identity deduplication

### DIFF
--- a/packages/brain/src/brain-agent.test.ts
+++ b/packages/brain/src/brain-agent.test.ts
@@ -370,6 +370,33 @@ test("wakes inside the window open one turn, with each session's delta read once
   assert.equal(h.traces[0]?.transcriptBytes, `${TRANSCRIPT_SECRET} for abc`.length * 2);
 });
 
+test("the same session id under two providers is two identities, each read once", async () => {
+  const codexAbc: SessionIdentity = { providerId: "codex", providerSessionId: "abc" };
+  const h = harness({
+    roster: () => ({ text: "roster", identities: [ABC, codexAbc] }),
+  });
+  h.agent.wake([edge(ABC), edge(codexAbc), edge(ABC, NOW + 500)]);
+  await h.clock.advance(NOW + 3_000);
+
+  assert.equal(h.client.inputs.length, 1);
+  assert.deepEqual(h.sinceReads, [
+    { identity: ABC, cursor: undefined },
+    { identity: codexAbc, cursor: undefined },
+  ]);
+  assert.deepEqual(h.persisted[0]?.cursors, {
+    "claude-code": { abc: "abc-cursor" },
+    codex: { abc: "abc-cursor" },
+  });
+  const wake = itemText((h.client.inputs[0] ?? [])[0]);
+  const body = wireRecord(unparsedWire(JSON.parse(wake.slice(wake.indexOf("\n") + 1))));
+  assert.ok(body && Array.isArray(body.events));
+  assert.deepEqual(
+    body.events.map((event) => wireRecord(unparsedWire(event))?.provider_id),
+    [claude.id, "codex", claude.id],
+  );
+  assert.equal(h.traces[0]?.transcriptBytes, `${TRANSCRIPT_SECRET} for abc`.length * 2);
+});
+
 test("an announce is delivered trimmed, and every output item is remembered", async () => {
   const h = harness();
   h.client.answers.push(

--- a/packages/brain/src/brain-agent.ts
+++ b/packages/brain/src/brain-agent.ts
@@ -417,21 +417,6 @@ function rejection(reason: string): WireRecord {
   return { status: ACT_RESULT_STATUS.REJECTED, reason };
 }
 
-/** Identities collected without a composite key: one list, membership by both fields. */
-class IdentitySet {
-  readonly #identities: SessionIdentity[] = [];
-
-  add(identity: SessionIdentity): void {
-    if (!this.#identities.some((held) => sameIdentity(held, identity))) {
-      this.#identities.push({ ...identity });
-    }
-  }
-
-  list(): readonly SessionIdentity[] {
-    return [...this.#identities];
-  }
-}
-
 function generationFrom(state: BrainPersistedState): Generation {
   return {
     id: state.generationId,
@@ -1544,16 +1529,16 @@ export class BrainAgent {
     events: readonly BrainWakeEvent[],
     context: TurnContext,
   ): Promise<{ events: readonly BrainWakeEvent[]; transcriptBytes: number }> {
-    const read = new IdentitySet();
+    const read: SessionIdentity[] = [];
     let transcriptBytes = 0;
     const attached: BrainWakeEvent[] = [];
     for (const event of events) {
       if (this.#revoked(context)) break;
-      if (read.list().some((identity) => sameIdentity(identity, event.identity))) {
+      if (read.some((identity) => sameIdentity(identity, event.identity))) {
         attached.push({ ...event });
         continue;
       }
-      read.add(event.identity);
+      read.push({ ...event.identity });
       const delta = await this.#readDelta(event.identity, context);
       if (!delta) break;
       transcriptBytes += delta.text.length;


### PR DESCRIPTION
## What changed

- `packages/brain/src/brain-agent.ts`: removed the `IdentitySet` class. `#attachDeltas` now keeps a local `SessionIdentity[]`, checks membership once with the existing `sameIdentity` comparison (both `providerId` and `providerSessionId`), and pushes a copied identity before reading its delta. Event order, one read per identity per batch, the revocation early-break and context-carrying delta read from #721, cursor handling, and transcript byte accounting are unchanged.
- `packages/brain/src/brain-agent.test.ts`: new test asserting that the same session id under two providers is two identities, each read once, with both cursors persisted and event order preserved. The existing coalescing test already covers duplicate events for one identity; the failure/cursor rollback tests are unchanged.

Behavior-preserving. Delivery source metadata and tool schemas are untouched here (handled by #727 and its siblings).

## Base

Rebased onto `origin/brain-spike` at `a471d26` (#727), so this branch carries the request-lifecycle correctness change (#721) and all six sibling cleanups (#722, #723, #724, #726, #727, #728). The rebase applied cleanly with no conflicts. Diff against the base is confined to the two brain files above (30 insertions, 18 deletions).

## Verification (combined result, on this rebased head)

- `pnpm --filter @sidecar/brain test`: 82 tests, 82 pass, 0 fail.
- `./scripts/check.sh`: exit 0 (repository lint, typecheck, all package tests, web and desktop builds).
- Run on Linux; no macOS verification or physical-notch check performed. No rendering or platform code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34073327826/artifacts/10001257089) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34073327826)

- Commit: `435f64b526622950f4252d090a1dc400dec4eceb`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->


## Final integration review

Reviewed head `435f64b526622950f4252d090a1dc400dec4eceb` on base `a471d269f20589defd35716acbd28403bd765cae`, containing all six other cleanups plus #721. [Combined CI run 34073327826](https://github.com/ReviewStage/luke/actions/runs/34073327826) passed portable `./scripts/check.sh` and macOS `./scripts/verify.sh`. Downloaded all six final fixture captures; each matches the visually inspected PR #723 capture byte for byte. Physical-notch check was not performed.

The seven cleanup PRs together change 17 files, with 120 insertions and 434 deletions. The final IdentitySet diff preserves the request-lifecycle revocation guards and changes only its two intended brain files.
