### PR TITLE
refactor(providers): remove dormant Conductor transcript override

### DIFF
--- a/packages/providers/src/conductor/adapter.test.ts
+++ b/packages/providers/src/conductor/adapter.test.ts
@@ -2566,41 +2566,18 @@ test("a poll walks the store's pages to the fixed bounds and answers hasMore hon
   assert.equal(reads[2]?.searchParams.get("after"), STORED_MESSAGE_UUIDS[6]);
 });
 
-test("an incremental transcript read rides the conversation read and its cursor", async () => {
+test("an incremental transcript read keeps the inherited unsupported answer and reads nothing", async () => {
   const api = conversationApi();
   const adapter = adapterFor(api.fetch);
-  const observed = (await adapter.observe()).find(
-    (observation) => observation.providerSessionId === IDLE_SESSION_UUID,
-  );
-  const agentName = observed?.agent?.displayName ?? "Agent";
+  await adapter.observe();
+  const requestsBefore = api.requests.length;
 
   const opening = await adapter.readTranscriptSince(IDLE_SESSION_UUID);
-
-  assert.equal(opening.status, "accepted");
-  if (opening.status !== "accepted") return;
-  assert.equal(
-    opening.text,
-    [
-      "Developer: Fix the flaky roster test",
-      `${agentName}: Looking at the test now. It races the clock.`,
-      `${agentName}: Fixed: the test now stubs the clock.`,
-    ].join("\n"),
-  );
-  assert.equal(opening.cursor, STORED_MESSAGE_UUIDS[7]);
-  assert.equal(opening.truncated, false);
-
   const poll = await adapter.readTranscriptSince(IDLE_SESSION_UUID, STORED_MESSAGE_UUIDS[2]);
 
-  assert.equal(poll.status, "accepted");
-  if (poll.status !== "accepted") return;
-  assert.equal(poll.text, `${agentName}: Fixed: the test now stubs the clock.`);
-  assert.equal(poll.cursor, STORED_MESSAGE_UUIDS[7]);
-  assert.equal(api.requests.at(-1)?.searchParams.get("after"), STORED_MESSAGE_UUIDS[2]);
-
-  const badCursor = await adapter.readTranscriptSince(IDLE_SESSION_UUID, "not-a-message-id");
-  assert.equal(badCursor.status, "rejected");
-  const unobserved = await adapter.readTranscriptSince("99999999-9999-4999-8999-999999999999");
-  assert.equal(unobserved.status, "unsupported");
+  assert.equal(opening.status, "unsupported");
+  assert.equal(poll.status, "unsupported");
+  assert.equal(api.requests.length, requestsBefore);
 });
 
 test("refuses a conversation read for anything the latest pass did not stand behind", async () => {

--- a/packages/providers/src/conductor/adapter.ts
+++ b/packages/providers/src/conductor/adapter.ts
@@ -11,7 +11,6 @@ import {
   type ProviderConversationRequest,
   type ProviderConversationResult,
   type ProviderSessionObservation,
-  type ProviderTranscriptSinceResult,
   type ProviderWorkspaceAgentRequest,
   SESSION_APPLICATION_ID,
   SESSION_APPLICATION_SCOPE,
@@ -25,7 +24,7 @@ import {
   type WorkspaceProject,
   workspaceAgentModels,
 } from "@sidecar/session";
-import { isRecord, oneLine, text, type UnparsedWireValue, type WireRecord } from "@sidecar/wire";
+import { isRecord, text, type UnparsedWireValue, type WireRecord } from "@sidecar/wire";
 import {
   CLOUD_ADAPTER_DEFAULTS,
   CLOUD_FAILURE,
@@ -41,16 +40,12 @@ import {
   textFromRecord,
   timestampFromRecord,
 } from "../shared/cloud-session-adapter.js";
-import { TRANSCRIPT_BOUNDS, transcriptLine } from "../shared/local-transcript.js";
 import { CONDUCTOR_AGENT_BY_TYPE } from "./session-applications.js";
 
 // Shared with the credential registry so the key the user saves and the
 // provider Luke observes with it can never name different things.
 const CONDUCTOR_PROVIDER_ID = CREDENTIAL_PROVIDER_ID.CONDUCTOR;
 const CONDUCTOR_PROVIDER_NAME = CREDENTIAL_PROVIDERS[CREDENTIAL_PROVIDER_ID.CONDUCTOR].displayName;
-
-/** The speaker a chat's lines wear when the roster maps no agent kind for it. */
-const CONDUCTOR_AGENT_FALLBACK_NAME = "Agent";
 
 const CONDUCTOR_ENVIRONMENT = {
   API_URL: "CONDUCTOR_API_URL",
@@ -998,41 +993,6 @@ export class ConductorSessionAdapter extends CloudSessionAdapter {
       }
       throw error;
     }
-  }
-
-  /**
-   * The same documented read, rendered as transcript lines for a reader that
-   * walks a chat incrementally: without a cursor, the latest page; with one,
-   * only what is newer than the message it names. The cursor to continue
-   * from is the newest stored message the page consumed, and `truncated`
-   * says whether newer messages still stand beyond the page's bounds.
-   */
-  override async readTranscriptSince(
-    providerSessionId: string,
-    cursor?: string,
-  ): Promise<ProviderTranscriptSinceResult> {
-    const conversation = await this.readConversation({
-      providerSessionId,
-      ...(cursor !== undefined ? { afterMessageId: cursor } : undefined),
-    });
-    if (conversation.status !== ACT_RESULT_STATUS.ACCEPTED) return conversation;
-    const agentName =
-      this.latestObservation(providerSessionId)?.agent?.displayName ??
-      CONDUCTOR_AGENT_FALLBACK_NAME;
-    const lines = conversation.messages.flatMap((message) => {
-      const words = oneLine(message.text, TRANSCRIPT_BOUNDS.MAXIMUM_MESSAGE_LENGTH);
-      if (!words) return [];
-      return message.author === CONVERSATION_MESSAGE_AUTHOR.USER
-        ? [transcriptLine.developer(words)]
-        : [transcriptLine.agent(agentName, words)];
-    });
-    const nextCursor = conversation.lastMessageId ?? cursor;
-    return {
-      status: ACT_RESULT_STATUS.ACCEPTED,
-      text: lines.join("\n"),
-      ...(nextCursor !== undefined ? { cursor: nextCursor } : undefined),
-      truncated: conversation.hasMore,
-    };
   }
 
   /** One documented stored-messages read, with the query the mode composed. */


### PR DESCRIPTION
## What changed

- Removed `readTranscriptSince` from `packages/providers/src/conductor/adapter.ts`. Conductor now inherits the base adapter's `UNSUPPORTED` answer for incremental transcript reads.
- Dropped the imports and constant only that rendering used: `oneLine`, `TRANSCRIPT_BOUNDS`, `transcriptLine`, `ProviderTranscriptSinceResult`, and the agent fallback name.
- Replaced the override-specific test with one asserting that opening and cursored incremental transcript reads return `unsupported` and issue no network request.

## Why

Scheduled brain transcript reads select local sessions, and hook wakes come from Claude Code and Codex, so this cloud override had no production route. The shared adapter seam, the local-provider implementations, and Conductor's `readConversation` pagination, polling, cursor, credential, and observed-session behavior are untouched, as are their existing tests. No new cloud transcript reads and no privacy change; `PRIVACY.md` never described this path.

## Verification

- `./scripts/bootstrap.sh` then `./scripts/check.sh`: exit 0 (repository, type, test, and build checks all pass on Linux).
- No macOS verification or physical-notch check was performed; this workspace is a Linux sandbox and the change touches no rendering or platform code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/c27ca2eb-afe1-4f01-abab-927da34f6f1f)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34072769666/artifacts/10001047695) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34072769666)

- Commit: `65ed8e1f857db6ec1e16069175ffead533c4ace9`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
