### PR TITLE
refactor(brain): remove unused delivery source metadata

### DIFF
--- a/apps/desktop/src/main/speech-arbiter.test.ts
+++ b/apps/desktop/src/main/speech-arbiter.test.ts
@@ -137,19 +137,18 @@ test("quiet beginning holds every pending request; quiet ending releases the bea
   assert.equal(offer.speakBy, clock.now + SPOKEN_NOTICE_MAX_AGE_MS);
 });
 
-test("held briefings are taken in order with their source intact, once", () => {
+test("held briefings are taken in order with briefing and timestamp intact, once", () => {
   const { arbiter } = harness();
   arbiter.setQuiet(true);
-  requestBriefing(arbiter, "first");
-  requestBriefing(arbiter, "second");
+  requestBriefing(arbiter, "first", 1_000);
+  requestBriefing(arbiter, "second", 2_000);
   arbiter.request({ kind: ARRIVAL_SPEECH_KIND });
   arbiter.setQuiet(false);
 
-  const taken = arbiter.takeHeldBriefings();
-  assert.deepEqual(
-    taken.map((item) => item.briefing),
-    ["first", "second"],
-  );
+  assert.deepEqual(arbiter.takeHeldBriefings(), [
+    { briefing: "first", decidedAt: 1_000 },
+    { briefing: "second", decidedAt: 2_000 },
+  ]);
   assert.equal(arbiter.heldBriefingCount, 0);
   assert.equal(arbiter.pendingCount, 1, "the beat is not a briefing and stays");
   assert.deepEqual(arbiter.takeHeldBriefings(), []);

--- a/apps/desktop/src/main/speech-arbiter.test.ts
+++ b/apps/desktop/src/main/speech-arbiter.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { BRAIN_DELIVERY_SOURCE, type BrainDelivery } from "@sidecar/brain";
+import type { BrainDelivery } from "@sidecar/brain";
 import type { SpeechTraceRecord } from "@sidecar/devtrace";
 import {
   ARRIVAL_SPEECH_KIND,
@@ -17,7 +17,7 @@ import {
 } from "./speech-arbiter";
 
 function delivery(briefing: string, decidedAt = 1_000): BrainDelivery {
-  return { briefing, decidedAt, source: BRAIN_DELIVERY_SOURCE.WAKE };
+  return { briefing, decidedAt };
 }
 
 interface Harness {
@@ -85,7 +85,6 @@ test("the briefing backlog sheds its oldest whole past the bound", () => {
   // The oldest went first: a backlog re-decided in one turn wants the recent few.
   assert.equal(held[0]?.briefing, "briefing 2");
   assert.equal(held.at(-1)?.briefing, `briefing ${MAXIMUM_PENDING_BRIEFINGS + 1}`);
-  assert.equal(held[0]?.source, BRAIN_DELIVERY_SOURCE.WAKE);
   assert.equal(arbiter.pendingCount, 0);
   assert.deepEqual(arbiter.takeHeldBriefings(), []);
 });
@@ -151,7 +150,6 @@ test("held briefings are taken in order with their source intact, once", () => {
     taken.map((item) => item.briefing),
     ["first", "second"],
   );
-  assert.ok(taken.every((item) => item.source === BRAIN_DELIVERY_SOURCE.WAKE));
   assert.equal(arbiter.heldBriefingCount, 0);
   assert.equal(arbiter.pendingCount, 1, "the beat is not a briefing and stays");
   assert.deepEqual(arbiter.takeHeldBriefings(), []);

--- a/packages/brain/src/brain-agent.test.ts
+++ b/packages/brain/src/brain-agent.test.ts
@@ -36,12 +36,7 @@ import {
   type BrainClientAnswer,
   type BrainRespondOptions,
 } from "./brain-client.js";
-import {
-  BRAIN_DELIVERY_SOURCE,
-  BRAIN_WAKE_KIND,
-  type BrainDelivery,
-  type BrainWakeEvent,
-} from "./brain-events.js";
+import { BRAIN_WAKE_KIND, type BrainDelivery, type BrainWakeEvent } from "./brain-events.js";
 import { BRAIN_INPUT_MARKER } from "./brain-input.js";
 import { UNKNOWN_ACT_RESULT } from "./brain-journal.js";
 import { RESPONSES_ITEM_TYPE, type ResponsesInputItem } from "./brain-openai.js";
@@ -392,7 +387,6 @@ test("an announce is delivered trimmed, and every output item is remembered", as
     {
       briefing: "Checkout agent wants a decision.",
       decidedAt: NOW + 3_000,
-      source: BRAIN_DELIVERY_SOURCE.WAKE,
     },
   ]);
   const second = h.client.inputs[1] ?? [];
@@ -676,14 +670,11 @@ test("restored memory opens the next turn, and held briefings are re-decided fro
     answered([call("call_1", BRAIN_TOOL.ANNOUNCE, { briefing: "Still waiting on you." })]),
     answered([message("")]),
   );
-  h.agent.releaseHeld([
-    { briefing: "Checkout wants a decision.", decidedAt: NOW - 1, source: "wake" },
-  ]);
+  h.agent.releaseHeld([{ briefing: "Checkout wants a decision.", decidedAt: NOW - 1 }]);
   await settle();
   const input = h.client.inputs[0] ?? [];
   assert.deepEqual(input.slice(0, 2), prior);
   assert.ok(itemText(input[2]).startsWith(`${BRAIN_INPUT_MARKER.HOLD_RELEASED} `));
-  assert.equal(h.deliveries[0]?.source, BRAIN_DELIVERY_SOURCE.HOLD_RELEASED);
   assert.equal(h.deliveries[0]?.briefing, "Still waiting on you.");
   assert.equal(h.traces[0]?.trigger, BRAIN_TURN_TRIGGER.HOLD_RELEASED);
   assert.equal(h.sinceReads.length, 0);
@@ -920,7 +911,7 @@ test("a roster look runs no act", async () => {
 test("a hold release runs no act", async () => {
   const h = harness();
   h.client.answers.push(answered(FORBIDDEN_ACTS), answered([message("")]));
-  h.agent.releaseHeld([{ briefing: INSTRUCTION_IN_DATA, decidedAt: NOW - 1, source: "wake" }]);
+  h.agent.releaseHeld([{ briefing: INSTRUCTION_IN_DATA, decidedAt: NOW - 1 }]);
   await settle();
   assertNoActReached(h);
   assert.equal(h.traces[0]?.trigger, BRAIN_TURN_TRIGGER.HOLD_RELEASED);
@@ -1708,7 +1699,7 @@ test("work queued behind a held act opens nothing once the generation it was que
   await settle();
   // Every observation kind queues behind the held act: a hold release with an
   // old briefing, a roster look, a coalesced wake, and a quiet retry's wakes.
-  h.agent.releaseHeld([{ briefing: "OLD_SECRET_QUEUED_BRIEFING", decidedAt: NOW, source: "wake" }]);
+  h.agent.releaseHeld([{ briefing: "OLD_SECRET_QUEUED_BRIEFING", decidedAt: NOW }]);
   h.agent.wake([edge(DEF)]);
   h.agent.rosterLook();
   await h.clock.advance(NOW + 3_000);
@@ -2320,9 +2311,7 @@ test("an observation in flight is not made durable by an unrelated mark or accep
   // The pending wake rides in the hold release's turn: one observation that
   // reads a real delta, moves a cursor, and then waits on the model.
   observing.agent.wake([edge(ABC)]);
-  observing.agent.releaseHeld([
-    { briefing: "UNCOMMITTED_OBSERVATION", decidedAt: NOW, source: "wake" },
-  ]);
+  observing.agent.releaseHeld([{ briefing: "UNCOMMITTED_OBSERVATION", decidedAt: NOW }]);
   await settle();
   // The delta was read into working memory and its cursor moved; the model is held.
   assert.equal(observing.sinceReads.length, 1);

--- a/packages/brain/src/brain-agent.ts
+++ b/packages/brain/src/brain-agent.ts
@@ -18,10 +18,8 @@ import {
 } from "@sidecar/wire";
 import { BRAIN_CLIENT_OUTCOME, type BrainClient } from "./brain-client.js";
 import {
-  BRAIN_DELIVERY_SOURCE,
   BRAIN_WAKE_KIND,
   type BrainDelivery,
-  type BrainDeliverySource,
   type BrainTranscriptDelta,
   type BrainWakeEvent,
 } from "./brain-events.js";
@@ -293,7 +291,6 @@ interface TurnPlan {
   authority: BrainTurnAuthority;
   events: readonly BrainWakeEvent[];
   open: (events: readonly BrainWakeEvent[], now: number) => readonly ResponsesInputItem[];
-  deliverySource?: BrainDeliverySource;
   /** Whether a roster look's events with nothing new in their transcript are left out. */
   dropEmptyRosterDeltas?: boolean;
   run?: RunControl;
@@ -807,7 +804,6 @@ export class BrainAgent {
           ...(attached.length > 0 ? [wakeInputItem(attached, now)] : []),
           holdReleasedInputItem(held, now),
         ],
-        deliverySource: BRAIN_DELIVERY_SOURCE.HOLD_RELEASED,
       }),
     );
   }
@@ -889,7 +885,6 @@ export class BrainAgent {
         authority: BRAIN_TURN_AUTHORITY.OBSERVATION,
         events,
         open: (attached, openedAt) => [wakeInputItem(attached, openedAt, roster.text)],
-        deliverySource: BRAIN_DELIVERY_SOURCE.WAKE,
         dropEmptyRosterDeltas: true,
       }),
     );
@@ -931,7 +926,6 @@ export class BrainAgent {
         authority: BRAIN_TURN_AUTHORITY.OBSERVATION,
         events,
         open: (attached, now) => [wakeInputItem(attached, now)],
-        deliverySource: BRAIN_DELIVERY_SOURCE.WAKE,
       });
       if (
         result.outcome === TURN_OUTCOME.QUIET &&
@@ -1648,14 +1642,11 @@ export class BrainAgent {
         return { callId: call.callId, output: await this.#readWhole(named, context) };
       }
       case BRAIN_TOOL.ANNOUNCE: {
-        if (plan.deliverySource === undefined) {
-          return { callId: call.callId, output: rejection(REFUSAL_REASON.NOT_OFFERED) };
-        }
         const briefing = text(args.briefing)?.slice(0, maximumBriefingLength);
         if (!briefing) {
           return { callId: call.callId, output: rejection(REFUSAL_REASON.EMPTY_BRIEFING) };
         }
-        hooks.deliveries.push({ briefing, decidedAt: this.#now(), source: plan.deliverySource });
+        hooks.deliveries.push({ briefing, decidedAt: this.#now() });
         return { callId: call.callId, output: { status: ACT_RESULT_STATUS.ACCEPTED } };
       }
     }

--- a/packages/brain/src/brain-events.ts
+++ b/packages/brain/src/brain-events.ts
@@ -39,16 +39,7 @@ export interface BrainWakeEvent {
   atMs: number;
 }
 
-export const BRAIN_DELIVERY_SOURCE = {
-  WAKE: "wake",
-  HOLD_RELEASED: "hold-released",
-} as const;
-
-export type BrainDeliverySource =
-  (typeof BRAIN_DELIVERY_SOURCE)[keyof typeof BRAIN_DELIVERY_SOURCE];
-
 export interface BrainDelivery {
   briefing: string;
   decidedAt: number;
-  source: BrainDeliverySource;
 }

--- a/packages/brain/src/brain-input.test.ts
+++ b/packages/brain/src/brain-input.test.ts
@@ -8,7 +8,7 @@ import {
   type SessionProvider,
 } from "@sidecar/session";
 import { isRecord, isWireString, unparsedWire, type WireRecord, wireRecord } from "@sidecar/wire";
-import { BRAIN_DELIVERY_SOURCE, BRAIN_WAKE_KIND, type BrainWakeEvent } from "./brain-events.js";
+import { BRAIN_WAKE_KIND, type BrainWakeEvent } from "./brain-events.js";
 import {
   askInputItem,
   BRAIN_INPUT_MARKER,
@@ -107,7 +107,6 @@ test("a hold-released item lists the held briefings", () => {
         {
           briefing: "Checkout agent wants a decision.",
           decidedAt: NOW - 60_000,
-          source: BRAIN_DELIVERY_SOURCE.WAKE,
         },
       ],
       NOW,

--- a/packages/brain/src/index.ts
+++ b/packages/brain/src/index.ts
@@ -35,10 +35,8 @@ export {
   openAiBrainClient,
 } from "./brain-client.js";
 export {
-  BRAIN_DELIVERY_SOURCE,
   BRAIN_WAKE_KIND,
   type BrainDelivery,
-  type BrainDeliverySource,
   type BrainTranscriptDelta,
   type BrainWakeEvent,
   type BrainWakeKind,


### PR DESCRIPTION
## What changed

Behavior-preserving cleanup in `packages/brain` and one desktop test file.

- Removed `BrainDelivery.source`, `BRAIN_DELIVERY_SOURCE`, and `BrainDeliverySource` from `brain-events.ts` and the package barrel.
- Removed `TurnPlan.deliverySource` and its assignments on the wake, roster, and hold-released turn plans in `brain-agent.ts`.
- Removed the announce dispatch's `deliverySource === undefined` guard. It was redundant: `brainToolAllowed` already refuses `announce` for developer authority, so `#refusalForAuthority` answers `NOT_OFFERED` before dispatch reaches the switch. The authority gate and the explicit developer-only acts guard are untouched.
- Deliveries are now constructed as `{ briefing, decidedAt }`.
- Tests: removed metadata-only `source` assertions and literals in `brain-agent.test.ts`, `brain-input.test.ts`, and `apps/desktop/src/main/speech-arbiter.test.ts`. Behavior assertions kept: developer asks refuse announce; wake, roster, and hold-release turns refuse acts; held deliveries preserve briefing and timestamp through hold release; traces still record trigger and authority.

No persistent-state migration and no authority redesign. Brain schema exports and IdentitySet are left to their own PRs.

## Verification

`./scripts/check.sh` on Linux: exit 0.

| Suite | Tests | Pass | Fail |
| --- | --- | --- | --- |
| packages/brain | 40 | 40 | 0 |
| apps/desktop | 841 | 841 | 0 |

All other package suites report 0 failures. Biome check clean (pre-existing CSS specificity warnings only, unchanged).

No macOS packaging, `verify.sh`, or physical-notch check was run: this workspace is a Linux sandbox and the change touches no rendering or platform code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/4b7d3781-9e4e-48de-b70a-deaf70861600)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34073024740/artifacts/10001159534) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34073024740)

- Commit: `c25664d7bcba8b6ee73f4d4d22982bfbca8a7efd`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
