### PR TITLE
refactor(desktop): remove obsolete conversation entrypoints

### DIFF
--- a/apps/desktop/src/renderer/voice/realtime-session.test.ts
+++ b/apps/desktop/src/renderer/voice/realtime-session.test.ts
@@ -2665,7 +2665,7 @@ test("a stop that races the reply's confirmation still holds", async () => {
   assert.deepEqual(responseCreates(context, before), []);
 
   // The next reply the developer actually asks for is heard again.
-  context.session.sendText("what needs me?");
+  assert.equal(context.session.speakReply("Two sessions need you."), true);
   context.emit({ type: REALTIME_SERVER_EVENT.RESPONSE_CREATED, response: { id: "resp-b" } });
   assert.equal(context.lukeAudible(), true);
 });
@@ -2712,7 +2712,7 @@ test("closing stops the microphone track", async () => {
 test("clearing a conversation retires its call before another turn can begin", async () => {
   const context = harness();
   await context.session.connect();
-  assert.equal(context.session.sendText("This real turn belongs to the old call."), true);
+  assert.equal(context.session.speakReply("This real reply belongs to the old call."), true);
 
   context.session.clearConversation();
 
@@ -2727,43 +2727,7 @@ test("clearing a conversation retires its call before another turn can begin", a
   assert.equal(context.session.status, REALTIME_STATUS.RESPONDING);
 });
 
-test("a typed ask opens a developer turn and asks for the reply to it", async () => {
-  const context = harness();
-  await context.session.connect();
-  const sentBefore = context.sent.length;
-
-  assert.equal(context.session.sendText("What needs me right now?"), true);
-  assert.equal(context.session.status, REALTIME_STATUS.RESPONDING);
-  // SAFETY: Fixture value matches the narrowed runtime shape this test exercises.
-  // The microphone stays exactly as it was: typing never opens the device.
-  assert.equal(context.microphoneEnabled(), false);
-  const events = context.sent.slice(sentBefore);
-  assert.deepEqual(
-    events.map((event) => event.type),
-    [REALTIME_CLIENT_EVENT.CONVERSATION_ITEM_CREATE, REALTIME_CLIENT_EVENT.RESPONSE_CREATE],
-  );
-  // SAFETY: Fixture value matches the narrowed runtime shape this test exercises.
-  const item = events[0]?.item as { role?: string; content?: { text?: string }[] };
-  assert.equal(item.role, "user");
-  assert.equal(item.content?.[0]?.text, "What needs me right now?");
-});
-
-test("a typed ask's reply can ask the brain, exactly as a spoken one's can", async () => {
-  const context = harness({ askBrain: async () => brainAnswer("Asked.") });
-  await context.session.connect();
-  // The turn is opened by typing rather than by the talk key: both are the
-  // developer's own ask, and the voice's one tool answers in either.
-  context.session.sendText("ask claude code to add tests");
-
-  context.emit(askBrainDone("ask claude code to add tests"));
-  await new Promise((resolve) => setTimeout(resolve, 0));
-
-  assert.deepEqual(context.asked, ["ask claude code to add tests"]);
-  // The answer is voiced, exactly as a spoken ask's would be.
-  assert.equal(context.session.status, REALTIME_STATUS.RESPONDING);
-});
-
-test("a typed ask interrupts the reply it arrives over", async () => {
+test("a typed ask's reply trims the interrupted reply to what was heard", async () => {
   let now = 10_000;
   const context = harness({ now: () => now });
   await context.session.connect();
@@ -2782,20 +2746,17 @@ test("a typed ask interrupts the reply it arrives over", async () => {
   now = 11_200;
   const sentBefore = context.sent.length;
 
-  assert.equal(context.session.sendText("open the codex one"), true);
+  assert.equal(context.session.speakReply("Opening the Codex one."), true);
 
   // The reply being talked over is cut the way holding the talk key cuts it:
   // silenced at once, cancelled, and trimmed to what was actually heard.
   assert.equal(context.lukeAudible(), false);
-  assert.equal(context.captions.at(-1), undefined);
-  const events = context.sent.slice(sentBefore);
   assert.deepEqual(
-    events.map((event) => event.type),
+    context.sent.slice(sentBefore).map((event) => event.type),
     [
       REALTIME_CLIENT_EVENT.RESPONSE_CANCEL,
       REALTIME_CLIENT_EVENT.OUTPUT_AUDIO_BUFFER_CLEAR,
       REALTIME_CLIENT_EVENT.CONVERSATION_ITEM_TRUNCATE,
-      REALTIME_CLIENT_EVENT.CONVERSATION_ITEM_CREATE,
       REALTIME_CLIENT_EVENT.RESPONSE_CREATE,
     ],
   );
@@ -2808,8 +2769,8 @@ test("a cancelled reply's late finish cannot ask the brain in the turn that repl
   // A spoken turn opens reply A, and the server confirms it by name.
   await armDeveloperTurn(context);
   context.emit({ type: REALTIME_SERVER_EVENT.RESPONSE_CREATED, response: { id: "resp-a" } });
-  // The developer types over it, opening a new turn.
-  assert.equal(context.session.sendText("never mind — what needs me?"), true);
+  // The developer speaks over it, opening a new turn.
+  await armDeveloperTurn(context);
   const sentBefore = context.sent.length;
 
   // Reply A's finished form arrives late — the server had completed it before
@@ -2831,7 +2792,7 @@ test("a cancelled reply's late finish cannot ask the brain in the turn that repl
   assert.deepEqual(responseCreates(context, sentBefore), []);
   assert.equal(context.session.status, REALTIME_STATUS.RESPONDING);
 
-  // The reply the typed ask actually asked for still asks in full.
+  // The reply the new turn actually asked for still asks in full.
   context.emit({ type: REALTIME_SERVER_EVENT.RESPONSE_CREATED, response: { id: "resp-b" } });
   context.emit(askBrainDone("status?", { callId: "call-fresh", responseId: "resp-b" }));
   await new Promise((resolve) => setTimeout(resolve, 0));
@@ -2844,7 +2805,7 @@ test("a cancelled reply's late finish does not end the turn that replaced it", a
   context.deliverRemoteTrack();
   await armDeveloperTurn(context);
   context.emit({ type: REALTIME_SERVER_EVENT.RESPONSE_CREATED, response: { id: "resp-a" } });
-  context.session.sendText("actually, open the codex session");
+  assert.equal(context.session.speakReply("Two sessions need you."), true);
 
   // Reply A finishes late with nothing to say, while reply B is still in the
   // quiet gap before its first word.
@@ -2856,34 +2817,10 @@ test("a cancelled reply's late finish does not end the turn that replaced it", a
   assert.equal(context.session.status, REALTIME_STATUS.RESPONDING);
 });
 
-test("a typed ask does not interrupt the developer's own open microphone", async () => {
-  const context = harness();
-  await context.session.connect();
-  await holdTurn(context);
-  const sentBefore = context.sent.length;
-
-  // Half a spoken question is still theirs: the keystroke is refused rather
-  // than the microphone's turn being discarded under them.
-  assert.equal(context.session.sendText("hello"), false);
-  assert.equal(context.session.status, REALTIME_STATUS.LISTENING);
-  assert.equal(context.microphoneEnabled(), true);
-  assert.deepEqual(context.sent.slice(sentBefore), []);
-});
-
-test("a typed ask with nothing in it opens nothing", async () => {
-  const context = harness();
-  await context.session.connect();
-  const sentBefore = context.sent.length;
-
-  assert.equal(context.session.sendText("   "), false);
-  assert.equal(context.session.status, REALTIME_STATUS.READY);
-  assert.deepEqual(context.sent.slice(sentBefore), []);
-});
-
-test("a typed ask before the call is open reports it could not go", () => {
+test("a typed ask's reply before the call is open reports it could not go", () => {
   const context = harness();
 
-  assert.equal(context.session.sendText("What needs me?"), false);
+  assert.equal(context.session.speakReply("Two sessions need you."), false);
   assert.deepEqual<ParsedJsonObject[]>(context.sent, []);
 });
 
@@ -3588,7 +3525,7 @@ test("a speak-only connect never asks for the microphone", async () => {
   assert.equal(context.session.microphoneCall, false);
 });
 
-test("a speak-only call reads a briefing out but refuses a typed ask and its reply", async () => {
+test("a speak-only call reads a briefing out but refuses the reply to a typed ask", async () => {
   const context = harness();
   await context.session.connect({ microphone: false });
   const sentAfterConnect = context.sent.length;
@@ -3601,9 +3538,8 @@ test("a speak-only call reads a briefing out but refuses a typed ask and its rep
   settleReply(context);
 
   // A typed ask is a conversation, and Luke's own call is not one: the caller
-  // stands the call down and opens the developer's own. The brain's reply to
-  // a typed ask is refused on the same terms.
-  assert.equal(context.session.sendText("stop the deploy"), false);
+  // stands the call down and opens the developer's own, so the brain's reply
+  // to a typed ask is refused here.
   assert.equal(context.session.speakReply("Stopped."), false);
 });
 
@@ -3691,10 +3627,10 @@ test("typing never opens the device", async () => {
   const context = harness();
   await context.session.connect();
 
-  assert.equal(context.session.sendText("How is the checkout fix going?"), true);
+  assert.equal(context.session.speakReply("The checkout fix is on its tests."), true);
 
-  // A typed ask needs no capture device: the ask went, and the device — the
-  // part other audio can hear — was never touched.
+  // A typed ask needs no capture device: its reply is all the call carries,
+  // and the device — the part other audio can hear — was never touched.
   assert.ok(!context.calls.includes("microphone-requested"));
   assert.equal(context.session.status, REALTIME_STATUS.RESPONDING);
 });

--- a/apps/desktop/src/renderer/voice/realtime-session.ts
+++ b/apps/desktop/src/renderer/voice/realtime-session.ts
@@ -1236,32 +1236,6 @@ export class RealtimeVoiceSession {
   }
 
   /**
-   * Sends a typed ask and requests the reply to it, reporting whether it
-   * could. Typing is the developer opening a turn, exactly as holding the talk
-   * key is, so the turn is armed for tools on the same terms as a push-to-talk
-   * commit: a write out of it is the developer's own request, made in their
-   * own words.
-   *
-   * An ask arriving over a reply interrupts it — the developer's turn always
-   * wins, however it is taken. The one thing it will not interrupt is the
-   * developer's own open microphone: half a spoken question is still theirs,
-   * and a keystroke is no reason to discard it.
-   */
-  sendText(text: string): boolean {
-    // A typed ask runs only on the developer's own call: Luke's speak-only
-    // call exists to say one thing and is not a conversation. A typed ask
-    // needs no capture device, so one this call put away stays put away.
-    if (!this.isConnected || !this.#withMicrophone) return false;
-    if (this.#status === REALTIME_STATUS.LISTENING) return false;
-    const ask = text.trim().slice(0, maximumTypedAskLength);
-    if (!ask) return false;
-    if (this.#status === REALTIME_STATUS.RESPONDING) this.#interruptReply();
-    this.#startResponse([]);
-    this.#sdkTransport?.sendMessage(ask);
-    return true;
-  }
-
-  /**
    * Speaks the brain's reply to a typed ask, reporting whether it could. The
    * ask itself went to the brain over the bridge — the voice never saw it —
    * so what the call is handed is the finished reply, on the briefing's own

--- a/apps/desktop/src/renderer/voice/use-voice-session.test.ts
+++ b/apps/desktop/src/renderer/voice/use-voice-session.test.ts
@@ -9,7 +9,6 @@ import {
 import { REPLY_KIND } from "./realtime-session";
 import {
   activeVoiceStream,
-  authorizeConversationAct,
   conversationEntryBelongsToConversation,
   liveConversationEntries,
   liveSpeedApplies,
@@ -129,38 +128,6 @@ test("the first call waits for durable conversation context", async () => {
   const readyWaiters = new Set<() => void>();
   await waitForConversationContext(true, readyWaiters);
   assert.equal(readyWaiters.size, 0);
-});
-
-test("an authorization that outlives Clear cannot record its act", async () => {
-  let resolveAuthorization: ((value: string) => void) | undefined;
-  const authorization = new Promise<string>((resolve) => {
-    resolveAuthorization = resolve;
-  });
-  let activeReplyGeneration: number | undefined = 3;
-  const activeReply = {
-    get current(): number | undefined {
-      return activeReplyGeneration;
-    },
-  };
-  let conversationGeneration = 3;
-  const history: string[] = [];
-  const pending = authorizeConversationAct(activeReply, () => authorization);
-
-  conversationGeneration = 4;
-  activeReplyGeneration = undefined;
-  resolveAuthorization?.("accepted");
-  const stale = await pending;
-  if (conversationEntryBelongsToConversation(stale.generation, conversationGeneration)) {
-    history.push("stale act");
-  }
-  assert.equal(history.length, 0);
-
-  activeReplyGeneration = conversationGeneration;
-  const current = await authorizeConversationAct(activeReply, async () => "accepted");
-  if (conversationEntryBelongsToConversation(current.generation, conversationGeneration)) {
-    history.push("current act");
-  }
-  assert.deepEqual(history, ["current act"]);
 });
 
 test("the meter listens to the stream of whoever holds the turn", () => {

--- a/apps/desktop/src/renderer/voice/use-voice-session.ts
+++ b/apps/desktop/src/renderer/voice/use-voice-session.ts
@@ -293,15 +293,6 @@ export function waitForConversationContext(
   return new Promise((resolve) => waiters.add(resolve));
 }
 
-/** Captures the reply that owns an act before main-process authorization can pause it. */
-export async function authorizeConversationAct<T>(
-  activeReplyGeneration: { readonly current: number | undefined },
-  authorize: () => Promise<T>,
-): Promise<{ authorization: T; generation: number | undefined }> {
-  const generation = activeReplyGeneration.current;
-  return { authorization: await authorize(), generation };
-}
-
 /**
  * The state the voice window reads from the main process rather than owns:
  * the settings that shape a call, the roster the arrival beat is worded from,


### PR DESCRIPTION
## What changed

Behavior-preserving cleanup in `apps/desktop/src/renderer/voice/`:

- Deleted `RealtimeVoiceSession.sendText()` in `realtime-session.ts`. Typed asks reach the brain over the bridge (`window.sidecar.askBrain`) and their finished replies arrive through `speakReply()`; the direct-to-Realtime text path had only test callers. The `maximumTypedAskLength` import stays, since `askBrain`'s question parser still uses it.
- Deleted `authorizeConversationAct()` in `use-voice-session.ts`. It was exported for one test only; production captures the conversation generation inline in the `askBrain` callback and `askLuke`.
- Tests: removed the four tests specific to the retired path (item-create wiring, a typed reply asking the brain, refusal over an open microphone, and an empty ask), each of which `speakReply()` already covers where it still applies. Migrated the remaining `sendText` callers to `speakReply()` or a second spoken turn, keeping coverage for interruption and truncation, late `response.done` and stale tool calls, Clear retiring the call, disconnected and speak-only calls, microphone ownership, and typed asks opening no capture device. Removed the `authorizeConversationAct` race test; its stale-generation predicate is still covered by the existing `conversationEntryBelongsToConversation` test, and no replacement helper was added.

Production generation and authorization guards are untouched. iOS `sendText` methods and `transcriptSpoken` are out of scope.

## Verification

- `./scripts/check.sh`: exit 0 (lint, typecheck, all package and app tests, build). Every suite reports `fail 0`; `apps/desktop` voice suites run 162 tests passing.
- No macOS verification or physical-notch check was performed (Linux workspace). No rendering or platform behavior is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/b5fd4659-4ce1-4033-94d4-e7c4b6366c8d)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34072874107/artifacts/10001084143) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34072874107)

- Commit: `48a76c21fc510427203305b88586ae56ed83581b`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->


## Integration review

Reviewed the complete diff at `48a76c21fc510427203305b88586ae56ed83581b`. Portable CI and macOS `./scripts/verify.sh` passed in [CI run 34072874107](https://github.com/ReviewStage/luke/actions/runs/34072874107). All six generated fixture captures match the visually inspected PR #723 captures byte for byte. Physical-notch check was not performed.
