### PR TITLE
feat(brain): bound the memory generation's life and size, and clear it with History

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -209,10 +209,10 @@ Trust constraints:
   a roster look reads, for each local session that is working or waiting or
   that the brain has read before, only what its transcript gained since the
   cursor the brain last kept for it, cut from the front to 20,000 characters
-  per session per turn; a developer's ask may read a whole transcript's tail,
-  cut from the front to 60,000 characters; a cloud session, and a provider
-  whose transcript this build does not read, are read from roster fields
-  alone. The provider's file is only ever read. Everything a turn reads and
+  per session per turn, and may read one observed session's whole tail, cut
+  from the front to 60,000 characters, through the same read tool a
+  developer's ask is offered; a cloud session, and a provider whose
+  transcript this build does not read, are read from roster fields alone. The provider's file is only ever read. Everything a turn reads and
   says travels as the Responses input the agent keeps — behind a marker, as
   data — directly to OpenAI on the developer's own key, or through Luke's own
   service on the hosted tier, where the service performs one model inference
@@ -227,31 +227,39 @@ Trust constraints:
   transcript cursors, the record of every developer ask and how it ended, and
   the action journal that pairs each act with its outcome. A generation lives
   exactly fourteen days from its creation: no write, checkpoint, or
-  compaction moves its expiry, and it is judged at load, at the door of every
-  turn and submission, and by a timer armed at the instant itself, so a
-  generation that dies under a held model answer, transcript read, or act is
-  replaced beneath it and the late result lands nowhere. Expiry revokes the
-  generation's runs and withdraws its deliveries; a version-1 file, of
-  unknown age, reads as nothing rather than as a fresh lifetime; and the
-  empty generation that follows may observe the same provider files again,
-  because the rule bounds how long a reading stands, not whether the source
-  can be read. Within its life a generation keeps at most 200 ended runs,
-  each let go together with its journal and only once its end is written into
-  History, and the serialized file stays under 8 MiB: ended runs go first,
-  and a write that would still grow an oversized envelope is refused rather
-  than dropping a run still going or its journal. The History Clear reaches
-  this file as well as the conversation's, in a fixed order: the cutoff is
-  raised so every later history write and window report is judged against it;
-  the store fences the generation and writes an empty successor carrying a
-  content-free marker — the erased generation's id and the Clear's instant —
-  in the one write that also removes the old content; the briefings not yet
-  in the mouth are withdrawn; the thread's file is removed; and only then are
-  the windows told. A launch that finds the marker refuses every stored line
-  at or before its instant, so a crash between the two files cannot stand the
-  thread back up, and a step that fails leaves everything before it standing
-  and reports the erasure incomplete, never done. A Clear does not reach the
-  facts Luke separately remembers about the developer, nor any provider's
-  file. Widening what the brain reads, where it travels, how long a
+  compaction moves its expiry, a file claiming any other span reads as
+  nothing, and it is judged at load, at the door of every turn and
+  submission, and by a timer armed at the instant itself. The fence is
+  synchronous: the store forgets the dead generation and announces the
+  successor before any disk is waited on, so a turn holding a model answer,
+  a transcript read, or an act's preparation is revoked at once, a write
+  landing afterwards installs nothing, and the late result lands nowhere.
+  Expiry revokes the generation's runs and, through the host's own listener,
+  withdraws every briefing it had queued or offered but not yet spoken; a
+  version-1 file, of unknown age, reads as nothing rather than as a fresh
+  lifetime; a generation found expired, unreadable, or past its bounds at
+  load is replaced on disk in the same load rather than left for a later
+  write; and the empty generation that follows may observe the same
+  provider files again, because the rule bounds how long a reading stands,
+  not whether the source can be read. Within its life a generation holds at
+  most 200 records and its serialized file stays under 8 MiB: ended runs
+  whose ends History has taken go first, each with its journal, a new ask is
+  refused at the door when nothing can go, and a write that would still grow
+  an envelope past a bound is refused rather than dropping a run still going
+  or its journal. The History Clear reaches this file as well as the
+  conversation's, in a fixed order: the cutoff is raised, the relayed thread
+  emptied, and every window told, so no later history write, window report,
+  model context, or publication can carry a line from before the press; the
+  store fences the generation the same synchronous way and then writes an
+  empty successor carrying a content-free marker — the Clear's instant, and
+  the erased generation's id when one is known, learned from the file when
+  the store had not yet loaded — over the old content; the thread's file is
+  removed. A launch that finds the marker refuses every stored line at or
+  before its instant, so a crash between the two files cannot stand the
+  thread back up, and a step that fails leaves the fence standing and
+  reports the erasure incomplete, never done, with the next landed write
+  replacing what the disk kept. A Clear does not reach the facts Luke
+  separately remembers about the developer, nor any provider's file. Widening what the brain reads, where it travels, how long a
   generation stands, or what a Clear leaves is a product decision, not an
   implementation detail, and `PRIVACY.md` says each in as many words.
 - Counting is three streams with three different guarantees, and the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -192,46 +192,68 @@ Trust constraints:
   transcript in conversation is the same shape of act: asked of Luke in a
   turn the developer opened, validated against the observed roster in the
   renderer and again in the main process, read from the provider's own file
-  on this machine, and rendered into a bounded reply that is kept nowhere:
-  the read performs nothing, reaches no provider, and is offered only for a
+  on this machine, and rendered into a bounded reply: the read performs
+  nothing, reaches no provider, and is offered only for a
   local session whose provider's transcript this build documents reading
   (Claude Code, Codex, and OMP today); a cloud session's conversation lives
   with its provider and is never fetched. The read renders only what the
   provider actually wrote down, and a provider whose stored shape this build
-  cannot render faithfully keeps the honest refusal instead.
-- A session's subject is the one place transcript content reaches a model
-  unbidden, and it is bounded on every side. No observed field says what an
-  agent is generally working on — a title is the first message, an activity
-  is the tool running now — so an
-  announcement that named the agent by its title named work it had stopped
-  doing. Luke therefore derives one short phrase per local session from the
-  same bounded transcript rendering the conversation-tab ask already reads,
-  through the same adapter method, bounded only by the file tail the adapter
-  reads and its per-line cuts, together with the title as the developer's
-  first ask. The
-  derivation runs only for a session about to be announced, at the moment the
-  announcement is delivered, once per announcement, never in a fixture run,
-  under a fixed deadline past which the announcement speaks without it, so
-  the transcript it reads is the one holding the turn the announcement is
-  about; a cloud session, a provider with no transcript this build reads, a
-  closed session, and a session inside a live voice exchange derive nothing. It travels the way an
-  attention review travels: directly to OpenAI
-  on the developer's own key, or through Luke's own service on the hosted
-  tier, where the service validates it against the same bounds, spends the
-  attention meter, asks OpenAI not to store it, and keeps and logs none of it.
-  The model is offered no tools, the transcript enters as data behind a
-  marker, and the answer is a bounded phrase or an honest null, refused when
-  it merely echoes the title. The phrase lives only inside the announcement
-  payload that carries it and is kept nowhere: it reaches one place, the
-  payload's `subject`, in the slot the title no longer travels in. It is not
-  drawn on the panel, reaches no write path, never reaches the attention
-  evaluator, and never reaches a provider file. It counts no product event,
-  because no developer asked. The development trace records each
-  derivation's about-fields, answer, and timing, and the transcript's byte
-  count, never its text. Widening what it
-  reads, where it travels, or where it is shown is a product decision, not an
-  implementation detail, and `PRIVACY.md` says the read and the send in as
-  many words.
+  cannot render faithfully keeps the honest refusal instead. What the read
+  rendered enters the brain's working memory like every other tool answer,
+  and lives and dies with its generation under the next rule.
+- The brain's transcript reads are the one place transcript content reaches
+  a model unbidden, and both the read and what it leaves behind are bounded
+  on every side. Luke's judgment is one long-lived agent in the main process,
+  woken by a provider's hook, by its own look at the roster on the
+  observation pass, by a hold's release, and by a developer's ask. A wake or
+  a roster look reads, for each local session that is working or waiting or
+  that the brain has read before, only what its transcript gained since the
+  cursor the brain last kept for it, cut from the front to 20,000 characters
+  per session per turn; a developer's ask may read a whole transcript's tail,
+  cut from the front to 60,000 characters; a cloud session, and a provider
+  whose transcript this build does not read, are read from roster fields
+  alone. The provider's file is only ever read. Everything a turn reads and
+  says travels as the Responses input the agent keeps — behind a marker, as
+  data — directly to OpenAI on the developer's own key, or through Luke's own
+  service on the hosted tier, where the service performs one model inference
+  per request under the same authority, asks OpenAI not to store it, and
+  keeps and logs none of the request body, the output, or the compaction
+  inside it. The development trace records a turn's about-fields and byte
+  counts under its own gate, never a transcript's text.
+- What the brain keeps is one generation, in one file under one writer, and
+  the generation's shape is the retention rule. The envelope holds the
+  Responses input from the latest compaction onward — the API's encrypted
+  compaction item included, which is user-derived data however opaque — the
+  transcript cursors, the record of every developer ask and how it ended, and
+  the action journal that pairs each act with its outcome. A generation lives
+  exactly fourteen days from its creation: no write, checkpoint, or
+  compaction moves its expiry, and it is judged at load, at the door of every
+  turn and submission, and by a timer armed at the instant itself, so a
+  generation that dies under a held model answer, transcript read, or act is
+  replaced beneath it and the late result lands nowhere. Expiry revokes the
+  generation's runs and withdraws its deliveries; a version-1 file, of
+  unknown age, reads as nothing rather than as a fresh lifetime; and the
+  empty generation that follows may observe the same provider files again,
+  because the rule bounds how long a reading stands, not whether the source
+  can be read. Within its life a generation keeps at most 200 ended runs,
+  each let go together with its journal and only once its end is written into
+  History, and the serialized file stays under 8 MiB: ended runs go first,
+  and a write that would still grow an oversized envelope is refused rather
+  than dropping a run still going or its journal. The History Clear reaches
+  this file as well as the conversation's, in a fixed order: the cutoff is
+  raised so every later history write and window report is judged against it;
+  the store fences the generation and writes an empty successor carrying a
+  content-free marker — the erased generation's id and the Clear's instant —
+  in the one write that also removes the old content; the briefings not yet
+  in the mouth are withdrawn; the thread's file is removed; and only then are
+  the windows told. A launch that finds the marker refuses every stored line
+  at or before its instant, so a crash between the two files cannot stand the
+  thread back up, and a step that fails leaves everything before it standing
+  and reports the erasure incomplete, never done. A Clear does not reach the
+  facts Luke separately remembers about the developer, nor any provider's
+  file. Widening what the brain reads, where it travels, how long a
+  generation stands, or what a Clear leaves is a product decision, not an
+  implementation detail, and `PRIVACY.md` says each in as many words.
 - Counting is three streams with three different guarantees, and the
   difference is the thing to keep straight. Only the first carries the
   guarantee, and the other two must never be described as though they
@@ -291,8 +313,8 @@ Trust constraints:
   holds, its words whole, including session acts and the lines that outlived
   the last launch, until the developer clears it — the same thread on every
   display's panel, relayed between windows through the main process — while
-  only the 20 most recent lines enter model context, each cut there to its
-  own length bound. There
+  the 20 most recent lines enter model context, each cut there to its own
+  length bound, beside the brain's own working memory of its turns. There
   is no general masking module to consult and nothing that makes any other new
   component silent by construction, so what a recording may see is decided by
   what the panel draws or explicitly blocks — which makes drawing something
@@ -350,10 +372,12 @@ Trust constraints:
   so storing it changes only how long it stands, not what it is. It lives in
   Luke's own application data, never a provider's file, under a real retention
   policy replacing the old "dies with the app": the 200 most recent lines,
-  nothing older than a fortnight. What reaches a model is unchanged — the same
-  bounded recent slice — and the panel's Clear reaches the file as well as the
-  screen, because a Clear that emptied only the view would leave the words on
-  the machine with nothing left to draw them. The narrower thing is a durable
+  nothing older than a fortnight. What the thread hands a model is the same
+  bounded recent slice, riding beside the brain's own working memory, and the
+  panel's Clear reaches the file as well as the screen, because a Clear that
+  emptied only the view would leave the words on the machine with nothing
+  left to draw them; it reaches the brain's generation too, under the rule
+  above. The narrower thing is a durable
   fact about the developer themselves. During a turn the developer opened,
   Luke may silently keep a concise stable preference, personal fact, goal, or
   recurring constraint. He skips transient details and uncertain inferences,

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,6 +1,6 @@
 # Privacy
 
-Last updated: 2 September 2026
+Last updated: 7 September 2026
 
 Luke is a macOS app that watches your coding agent sessions, with a companion
 iOS app for the cloud sessions your account can see. This policy explains what
@@ -11,31 +11,54 @@ we collect, who we send it to, and how to turn it off.
 **On your Mac.** Luke reads the session files your coding agents already write,
 using the session title, status, repository, branch, model, current tool,
 errors, and the tool it is running. It writes none of this to disk. For a
-session running on your Mac, Luke also reads a bounded rendering of that
-session's own conversation — the end of the transcript file its agent already
-writes (up to the last 256 KB), with each message and tool result cut short —
-to write himself a one-line phrase saying what the agent is working on,
-because a session's title is only its first message and the work usually
-moves on. That rendering is read only when Luke is about to speak about that
-session, once per announcement, sent to derive the phrase (see below), and
-kept nowhere: the phrase travels inside that one announcement and is used to
-name the session as Luke speaks about it, then discarded. Nothing else reads
-message history, file contents, or command output. If you run
+session running on your Mac whose agent keeps a transcript this build can read
+(Claude Code, Codex, and OMP today), Luke also reads that session's own
+transcript file — the file its agent already writes, which Luke never writes
+to — so he can notice what changed and tell you about it. He reads it at three
+moments: when an agent's hook says a turn just ended, on his own periodic look
+at the sessions that are working or waiting, and when you ask him about a
+session. On the first two he reads only what each transcript gained since he
+last looked, up to the last 20,000 characters of new text per session per
+look; on the third he reads a bounded tail of the whole transcript, up to its
+last 60,000 characters. What he reads is sent to a model as described under
+"Who we send it to", and what he keeps of it lives under his working memory's
+own lifetime, described below. Nothing else reads message history, file
+contents, or command output. If you run
 agents inside the Herdr terminal manager, Luke also asks Herdr's own
 command-line tool which of those sessions it holds, so their rows can say so;
 that read never starts Herdr, reads no terminal output, and sends nothing
 anywhere. It stays on your Mac unless a feature below sends it.
 
 **Your conversation with Luke.** Luke keeps the conversation you have with him
-— what you typed or said, what he spoke or announced, and the actions he took
-at your request — in a file on your Mac, so it is still there the next time you
-open him. It holds the 200 most recent entries and nothing older than 14 days,
-whichever runs out first, each kept in full so the History tab shows every
-word. Only the 20 most recent are carried into a call, and each of those is
-capped at 400 characters there. Clearing the History
-tab deletes the file as well as the view. Nothing about the conversation is
-written on our servers, and a fixture or evidence run keeps no conversation at
-all.
+— what you typed or said, what he spoke or announced, the actions he took at
+your request, and the asks he is still working on — in a file on your Mac, so
+it is still there the next time you open him. It holds the 200 most recent
+entries and nothing older than 14 days, whichever runs out first, each kept in
+full so the History tab shows every word. The 20 most recent lines, each cut
+to 400 characters, ride into a conversation as context, beside the working
+memory described next. Clearing the History tab deletes the file as well as
+the view. Nothing about the conversation is written on our servers, and a
+fixture or evidence run keeps no conversation at all.
+
+**Luke's working memory.** Luke keeps a working memory of his own turns in a
+second file on your Mac, beside your settings: the model's own record of what
+he read, said, and did — the transcript excerpts described above, the
+position he last read each transcript to, a record of each ask you made and
+how it ended, and a journal of each action he took at your ask. When that
+record grows long, OpenAI folds its older part into an opaque, encrypted
+compaction item, which Luke stores in the same file; it is still derived from
+your sessions and your conversation, so it lives under the same rule as the
+rest. The whole file is one generation, and a generation lives exactly 14
+days from the moment it began: writing into it never extends it, and when its
+time is up everything in it, the encrypted compaction included, is discarded
+and an empty generation begins, which may observe your sessions afresh. A
+generation keeps at most 200 finished asks and stays under 8 MiB, the oldest
+finished asks going first. Clearing the History tab discards the current
+generation too, along with anything Luke was still working on: both files go
+at once, with a small record, holding no content, of when the Clear happened so
+that nothing written before it can come back, and the Clear is reported done
+only when both are gone. Clearing does not touch the separate things Luke
+remembers about you, described next, and never touches your agents' own files.
 
 **Things Luke remembers about you.** During a conversation you start, Luke may
 silently save a concise preference, personal fact, goal, or recurring constraint
@@ -120,24 +143,28 @@ and email you signed it with, and any screenshots you attached.
 
 ## Who we send it to
 
-- OpenAI, for voice and session summaries. A spoken turn sends its audio, a
-  typed turn sends your words, and both send the session fields listed above —
-  on the Mac app, read locally from your machine; on iOS, drawn from the same
-  cloud observation your vault keys already allow (titles, status, repository,
-  and branch of your cloud sessions, as described under Provider API
-  keys above). We do not send message history, file contents, or command
-  output, and we ask OpenAI not to store the request. The one exception is the
-  subject phrase above: to derive it, only when Luke is about to announce a
-  local session and once per announcement, Luke sends the bounded transcript
-  slice of that session and its title — directly to OpenAI on
-  your own key if you entered one, otherwise through our service on our key —
-  asks OpenAI not to store the request, and our service stores and logs none
-  of it either. The phrase that comes back is spoken with that announcement
-  and kept nowhere. On the Mac app,
-  your conversation and Luke's durable memory are kept on your Mac and sent
-  with a call so the conversation carries across calls and across launches; on
-  iOS, the conversation is held in memory and discarded when the session
-  closes.
+- OpenAI, for voice and for Luke's own judgment. A spoken turn sends its
+  audio, a typed turn sends your words, and both send the session fields
+  listed above — on the Mac app, read locally from your machine; on iOS, drawn
+  from the same cloud observation your vault keys already allow (titles,
+  status, repository, and branch of your cloud sessions, as described under
+  Provider API keys above). Luke's judgment is a separate call to OpenAI's
+  Responses API, made when an agent's hook or his periodic look wakes him and
+  when you ask him something: it carries his working memory — the bounded
+  transcript excerpts described above, the session fields, the 20 most recent
+  lines of your conversation, and the things he remembers about you — directly
+  to OpenAI on your own key if you entered one, or through our own service on
+  our key when you use Luke through your account. Either way the request asks
+  OpenAI not to store it, and our service performs one model call per request
+  and stores and logs none of the request, the reply, or the encrypted
+  compaction that travels in it; the compaction OpenAI hands back is kept only
+  on your Mac, under the lifetime above. On the Mac app, your conversation and
+  Luke's durable memory are kept on your Mac and sent with a call so the
+  conversation carries across calls and across launches; on iOS, the
+  conversation is held in memory and discarded when the session closes. A
+  development build run from a checkout can write a local trace of this
+  traffic when the developer's own shell asks for one; a packaged build has no
+  such switch and writes none.
   The one voice call that happens before you sign in is the spoken
   introduction on first launch of the Mac app: it sends its own fixed script,
   the titles of the coding agent sessions found on your Mac, and anything you
@@ -179,8 +206,9 @@ your network address, as it does for the app's recordings.
 
 ## Storage
 
-Your settings, your conversation with Luke, the things he remembers about you,
-local provider API keys, and calendar access stay on your Mac.
+Your settings, your conversation with Luke, his working memory, the things he
+remembers about you, local provider API keys, and calendar access stay on your
+Mac.
 Local keys and calendar access are encrypted in the macOS Keychain. Provider
 API keys you sync to the hosted service are stored encrypted in our own
 database, as described above. Your account information is held by our own
@@ -192,7 +220,9 @@ service, usage counts and recordings by PostHog, and crash reports by Sentry.
 - Delete your OpenAI key to turn voice off.
 - Delete any synced provider API key from that provider's row in Settings. Keys
   are also deleted when you delete your account.
-- Clear the History tab to delete your stored conversation from your Mac.
+- Clear the History tab to delete your stored conversation and Luke's working
+  memory from your Mac; the working memory also discards itself 14 days after
+  it began, whether or not you clear it.
 - Ask Luke what he remembers, correct a memory, or tell him to forget one.
 - Luke does not use your microphone until you start a turn.
 - Delete your account from the Account section in Settings. This erases your

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -10,17 +10,19 @@ we collect, who we send it to, and how to turn it off.
 
 **On your Mac.** Luke reads the session files your coding agents already write,
 using the session title, status, repository, branch, model, current tool,
-errors, and the tool it is running. It writes none of this to disk. For a
+errors, and the tool it is running. It keeps none of these fields in a file
+of its own; what it does keep is the working memory described below. For a
 session running on your Mac whose agent keeps a transcript this build can read
 (Claude Code, Codex, and OMP today), Luke also reads that session's own
 transcript file — the file its agent already writes, which Luke never writes
 to — so he can notice what changed and tell you about it. He reads it at three
 moments: when an agent's hook says a turn just ended, on his own periodic look
 at the sessions that are working or waiting, and when you ask him about a
-session. On the first two he reads only what each transcript gained since he
-last looked, up to the last 20,000 characters of new text per session per
-look; on the third he reads a bounded tail of the whole transcript, up to its
-last 60,000 characters. What he reads is sent to a model as described under
+session. On the first two he reads what each transcript gained since he last
+looked, up to the last 20,000 characters of new text per session per look,
+and may also read one session's recent tail, up to its last 60,000
+characters, while deciding whether there is anything to tell you; when you
+ask, he reads the same bounded tail. What he reads is sent to a model as described under
 "Who we send it to", and what he keeps of it lives under his working memory's
 own lifetime, described below. Nothing else reads message history, file
 contents, or command output. If you run
@@ -51,14 +53,20 @@ your sessions and your conversation, so it lives under the same rule as the
 rest. The whole file is one generation, and a generation lives exactly 14
 days from the moment it began: writing into it never extends it, and when its
 time is up everything in it, the encrypted compaction included, is discarded
-and an empty generation begins, which may observe your sessions afresh. A
-generation keeps at most 200 finished asks and stays under 8 MiB, the oldest
-finished asks going first. Clearing the History tab discards the current
-generation too, along with anything Luke was still working on: both files go
-at once, with a small record, holding no content, of when the Clear happened so
-that nothing written before it can come back, and the Clear is reported done
-only when both are gone. Clearing does not touch the separate things Luke
-remembers about you, described next, and never touches your agents' own files.
+and an empty generation begins, which may observe your sessions afresh; a
+generation found expired when Luke starts is discarded then and there. A
+generation holds at most 200 asks and stays under 8 MiB: the oldest finished
+asks go first once their endings are in the History, and when nothing can go
+Luke declines a new ask rather than growing the file. Clearing the History
+tab discards the current generation too, along with anything Luke was still
+working on and anything he was about to say: the History, his context, and
+the memory are emptied the moment you press, and both files are erased with
+a small record, holding no content, of when the Clear happened so that
+nothing written before it can come back. If the disk refuses part of that
+erasure, the History and his context stay emptied, the Clear is reported as
+not finished rather than done, and the next thing Luke writes replaces what
+was left. Clearing does not touch the separate things Luke remembers about
+you, described next, and never touches your agents' own files.
 
 **Things Luke remembers about you.** During a conversation you start, Luke may
 silently save a concise preference, personal fact, goal, or recurring constraint

--- a/README.md
+++ b/README.md
@@ -41,8 +41,10 @@ behalf.
 
 The **History** tab keeps your conversation with Luke on your Mac, across
 launches: the 200 most recent entries and nothing older than a fortnight, until
-you clear it. Clearing deletes the file too. Only the 20 most recent entries are
-carried into Luke's next call. Luke also silently keeps a small local memory of
+you clear it. Clearing deletes the file too. The 20 most recent entries ride
+into Luke's next call beside his working memory of what he read, said, and did,
+which lives in its own file on your Mac for exactly 14 days from when it began
+and goes with the History when you clear it. Luke also silently keeps a small local memory of
 useful preferences, personal context, goals, and recurring constraints; ask him
 what he remembers, correct something, or tell him to forget it.
 

--- a/apps/desktop/src/main/brain-lifecycle.test.ts
+++ b/apps/desktop/src/main/brain-lifecycle.test.ts
@@ -262,11 +262,14 @@ test("a reset under outstanding runs discards them without publishing, and the s
   assert.ok(agent);
   await submitMany(agent, c.record, 3);
   await settle();
-  assert.equal(await c.store.reset(), true);
+  assert.equal(await c.store.clear(), true);
   await settle();
   assert.deepEqual(agent.requests(), []);
   assert.equal(c.thread().filter((e) => e.kind === CONVERSATION_ENTRY_KIND.REPLY).length, 0);
-  assert.equal(brainStateFromStored(c.storage.file), undefined);
+  // The file holds the empty successor and the marker of the erasure alone.
+  const stored = brainStateFromStored(c.storage.file);
+  assert.equal(stored?.requests.length, 0);
+  assert.equal(stored?.reset?.generationId, "gen-1");
   await c.host.replace(() => undefined);
   await settle();
   assert.equal(c.thread().filter((e) => e.kind === CONVERSATION_ENTRY_KIND.REPLY).length, 0);

--- a/apps/desktop/src/main/brain-retention.test.ts
+++ b/apps/desktop/src/main/brain-retention.test.ts
@@ -1,0 +1,191 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  BRAIN_GENERATION_LIFETIME_MS,
+  BrainAgent,
+  BrainGenerationClock,
+  type BrainStateStorage,
+  BrainStateStore,
+  brainStateFromStored,
+  brainStateRecord,
+  freshBrainState,
+} from "@sidecar/brain";
+import type { ScheduledTimer } from "@sidecar/realtime";
+import { ACT_RESULT_STATUS } from "@sidecar/wire";
+import { BrainHost } from "./brain-host";
+
+/**
+ * Retention as the main process owns it: the store and its clock stand from
+ * launch in a live run, whether or not any capability builds an agent, so an
+ * expired, unreadable, or oversized file is replaced at launch and a
+ * generation whose agent was retired still dies on time.
+ */
+
+const NOW = 1_800_000_000_000;
+const EXPIRED_SECRET = "EXPIRED_SECRET_MARKER";
+const RETIRED_SECRET = "RETIRED_SECRET_MARKER";
+
+class MemoryStorage implements BrainStateStorage {
+  file: string | undefined;
+  refuse = false;
+  read() {
+    return this.file;
+  }
+  write(contents: string) {
+    if (this.refuse) return false;
+    this.file = contents;
+    return true;
+  }
+  remove() {
+    this.file = undefined;
+    return true;
+  }
+}
+
+class FakeClock {
+  now = NOW;
+  readonly timers = new Map<ScheduledTimer, { callback: () => void; at: number }>();
+  schedule = (callback: () => void, delayMs: number): ScheduledTimer => {
+    const handle: ScheduledTimer = {};
+    this.timers.set(handle, { callback, at: this.now + delayMs });
+    return handle;
+  };
+  cancel = (timer: ScheduledTimer): void => {
+    this.timers.delete(timer);
+  };
+  async advance(untilMs: number): Promise<void> {
+    for (;;) {
+      const due = [...this.timers.entries()]
+        .filter(([, timer]) => timer.at <= untilMs)
+        .sort((a, b) => a[1].at - b[1].at)[0];
+      if (!due) break;
+      this.timers.delete(due[0]);
+      this.now = Math.max(this.now, due[1].at);
+      due[1].callback();
+      await settle();
+    }
+    this.now = Math.max(this.now, untilMs);
+  }
+}
+
+function settle(): Promise<void> {
+  return new Promise((resolve) => {
+    let ticks = 0;
+    const tick = () => {
+      ticks += 1;
+      if (ticks > 20) resolve();
+      else setImmediate(tick);
+    };
+    tick();
+  });
+}
+
+function launch(storage: MemoryStorage, clock: FakeClock) {
+  const reports: string[] = [];
+  let generations = 0;
+  const store = new BrainStateStore({
+    storage,
+    createGenerationId: () => `gen-${++generations}`,
+    now: () => clock.now,
+    report: (message) => reports.push(message),
+  });
+  const generationClock = new BrainGenerationClock({
+    store,
+    now: () => clock.now,
+    schedule: clock.schedule,
+    cancel: clock.cancel,
+  });
+  return { store, generationClock, reports };
+}
+
+test("a launch with no key or account replaces an expired file at once, without an agent or an inference", async () => {
+  const storage = new MemoryStorage();
+  const stale = {
+    ...freshBrainState("gen-old", NOW - BRAIN_GENERATION_LIFETIME_MS - 1),
+    items: [{ type: "message", role: "user", content: EXPIRED_SECRET }],
+  };
+  storage.file = brainStateRecord(stale);
+  const clock = new FakeClock();
+  const { store, generationClock, reports } = launch(storage, clock);
+  await generationClock.start();
+  assert.notEqual(store.generationId(), "gen-old");
+  assert.ok(!String(storage.file).includes(EXPIRED_SECRET));
+  assert.equal(brainStateFromStored(storage.file)?.generationId, store.generationId());
+  assert.ok(reports.some((message) => message.includes("expired generation")));
+  // The clock now stands for the fresh generation.
+  assert.equal(clock.timers.size, 1);
+  generationClock.stop();
+  assert.equal(clock.timers.size, 0);
+
+  // A disk that refuses the replacement is reported, and memory still holds the fresh one.
+  const refusing = new MemoryStorage();
+  refusing.file = brainStateRecord(stale);
+  refusing.refuse = true;
+  const held = launch(refusing, clock);
+  await held.generationClock.start();
+  assert.notEqual(held.store.generationId(), "gen-old");
+  assert.ok(held.reports.some((message) => message.includes("could not replace")));
+  held.generationClock.stop();
+});
+
+test("a generation whose agent was retired before its expiry still dies on the host's clock, and the file is replaced", async () => {
+  const storage = new MemoryStorage();
+  const clock = new FakeClock();
+  const { store, generationClock } = launch(storage, clock);
+  await generationClock.start();
+  const host = new BrainHost({
+    follow: () => async () => undefined,
+    publishEmpty: () => undefined,
+  });
+  await host.replace(
+    () =>
+      new BrainAgent({
+        client: {
+          respond: async () => ({
+            outcome: "answered",
+            payload: {
+              output: [
+                {
+                  type: "message",
+                  role: "assistant",
+                  content: [{ type: "output_text", text: RETIRED_SECRET }],
+                },
+              ],
+            },
+          }),
+          quietUntil: () => undefined,
+        },
+        acts: { perform: async () => ({ status: ACT_RESULT_STATUS.ACCEPTED }) },
+        roster: () => ({ text: "", identities: [] }),
+        standingContext: () => "",
+        readTranscriptSince: async () => ({ status: ACT_RESULT_STATUS.REJECTED, reason: "no" }),
+        readTranscript: async () => ({ status: ACT_RESULT_STATUS.REJECTED, reason: "no" }),
+        deliver: () => undefined,
+        store,
+        createRunId: () => "run-1",
+        report: () => {},
+        now: () => clock.now,
+        schedule: clock.schedule,
+        cancel: clock.cancel,
+      }),
+  );
+  const agent = host.current();
+  assert.ok(agent);
+  const accepted = await agent.submitAsk({ submissionId: "s", question: "hi", origin: "typed" });
+  assert.equal(accepted.outcome, "accepted");
+  await settle();
+  const born = store.current();
+  assert.ok(born);
+  assert.ok(String(storage.file).includes(RETIRED_SECRET));
+  // The key goes: the agent is retired, and only the host's clock stands.
+  await host.replace(() => undefined);
+  assert.equal(host.current(), undefined);
+  assert.equal(clock.timers.size, 1);
+  await clock.advance(born.expiresAt - 1);
+  assert.equal(store.generationId(), born.generationId);
+  await clock.advance(born.expiresAt);
+  assert.notEqual(store.generationId(), born.generationId);
+  assert.ok(!String(storage.file).includes(RETIRED_SECRET));
+  assert.equal(brainStateFromStored(storage.file)?.generationId, store.generationId());
+  generationClock.stop();
+});

--- a/apps/desktop/src/main/conversation-clear.test.ts
+++ b/apps/desktop/src/main/conversation-clear.test.ts
@@ -219,9 +219,10 @@ function composed(brainDisk = new MemoryStorage()) {
         thread = [];
         cleared.push(at);
       },
-      removeConversation: () => {
+      eraseConversation: () => {
         if (refuseThreadRemoval) return false;
-        conversationFile = undefined;
+        // As the main process erases: to what the thread holds now.
+        conversationFile = thread.length === 0 ? undefined : conversationRecord(thread, clock);
         return true;
       },
       report: (message) => reports.push(message),
@@ -494,7 +495,9 @@ test("a Clear whose marker will not write stays fenced and answers incomplete, a
   assert.ok(c.reports.some((message) => message.includes("marked erased")));
   assert.deepEqual(c.cleared, [c.now()]);
   assert.deepEqual(c.thread(), []);
-  assert.equal(c.conversationFile(), undefined);
+  // Without a durable cutoff the thread's file is left standing, out of
+  // every view and context, for the next thread write to replace.
+  assert.ok(String(c.conversationFile()).includes(OLD_REPLY));
   assert.equal(c.arbiter.pendingCount, 0);
   assert.deepEqual(agent.requests(), []);
   assert.equal(c.store.holdsGeneration("gen-1"), false);
@@ -512,6 +515,7 @@ test("a Clear whose marker will not write stays fenced and answers incomplete, a
   const stored = brainStateFromStored(c.brainDisk.file);
   assert.equal(stored?.reset?.generationId, "gen-1");
   assert.ok(!String(c.brainDisk.file).includes(OLD_ASK));
+  assert.ok(!String(c.conversationFile()).includes(OLD_REPLY));
   c.tick();
   assert.equal(await c.clear(), true);
   assert.equal(brainStateFromStored(c.brainDisk.file)?.reset?.generationId, "gen-2");
@@ -538,5 +542,49 @@ test("an expiry takes the held speech backlog with the generation, so the succes
   assert.deepEqual(agent.requests(), []);
   await c.store.flush();
   assert.ok(!String(c.brainDisk.file).includes(OLD_COMPACTION));
+  await c.host.replace(() => undefined);
+});
+
+test("the thread is erased only once the marker is durable, and a line recorded after the fence survives the erasure", async () => {
+  const c = composed();
+  const { agent, client } = await seeded(c);
+  // The marker's write is held on disk.
+  let releaseWrite: (() => void) | undefined;
+  const write = c.brainDisk.write.bind(c.brainDisk);
+  c.brainDisk.write = (contents) =>
+    // SAFETY: the store accepts a promise of the write's outcome; this test holds it open.
+    new Promise<boolean>((resolve) => {
+      releaseWrite = () => resolve(write(contents));
+    }) as unknown as boolean;
+  c.tick();
+  const clearing = c.clear();
+  await settle();
+  assert.ok(releaseWrite, "the marker is on disk");
+  // Fenced, yet the old thread's file is untouched until the marker lands.
+  assert.deepEqual(c.thread(), []);
+  assert.ok(String(c.conversationFile()).includes(OLD_REPLY));
+  // A new-generation ask is recorded meanwhile; its acceptance queues behind
+  // the marker on disk, its line stands in the thread at once.
+  c.tick();
+  const submitting = c.submit(agent, "NEW_ASK");
+  await settle();
+  c.brainDisk.write = write;
+  releaseWrite();
+  assert.equal(await clearing, true);
+  await submitting;
+  await settle();
+  // The erasure kept the new line and dropped the old ones.
+  assert.deepEqual(
+    c.thread().map((entry) => entry.words),
+    ["NEW_ASK"],
+  );
+  assert.ok(!String(c.conversationFile()).includes(OLD_REPLY));
+  assert.ok(String(c.conversationFile()).includes("NEW_ASK"));
+  client.release(reply("NEW_REPLY"));
+  await settle();
+  assert.deepEqual(
+    c.thread().map((entry) => entry.words),
+    ["NEW_ASK", "NEW_REPLY"],
+  );
   await c.host.replace(() => undefined);
 });

--- a/apps/desktop/src/main/conversation-clear.test.ts
+++ b/apps/desktop/src/main/conversation-clear.test.ts
@@ -1,9 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { REALTIME_TOOL } from "@sidecar/acts";
+import { REALTIME_TOOL, type RealtimeFunctionCall } from "@sidecar/acts";
 import {
   BRAIN_REQUEST_ORIGIN,
   BRAIN_REQUEST_STATUS,
+  type BrainActExecution,
   type BrainActPerformer,
   BrainAgent,
   type BrainClient,
@@ -11,13 +12,19 @@ import {
   type BrainStateStorage,
   BrainStateStore,
   brainStateFromStored,
+  brainStateRecord,
+  freshBrainState,
 } from "@sidecar/brain";
 import {
   appendConversationThreadEntry,
+  BRIEFING_SPEECH_KIND,
   CONVERSATION_ENTRY_KIND,
   type ConversationEntry,
+  conversationHistoryText,
+  recentConversationEntries,
 } from "@sidecar/realtime";
 import { ACT_RESULT_STATUS, type WireRecord } from "@sidecar/wire";
+import { SPEECH_OUTCOME } from "#shared/wire/speech";
 import { BrainHost } from "./brain-host";
 import { clearConversationAndBrain } from "./conversation-clear";
 import { followBrainRequests, submitBrainAsk } from "./ipc/brain";
@@ -26,18 +33,21 @@ import {
   conversationRecord,
   mergeConversationHistory,
 } from "./memory-flow";
+import { SpeechArbiter } from "./speech-arbiter";
 
 /**
  * The Clear composed as the main process composes it: the real store, agent,
- * host, follower, submission path, and the thread's own cutoff rule, with
- * only the model, the performer, and the disk synthetic. Every marker below
- * is a synthetic word that must be found nowhere after the press.
+ * host, follower, submission path, speech arbiter, the thread's own cutoff
+ * rule, and the standing context the brain is actually handed, with only the
+ * model, the performer, and the disk synthetic. Every marker below is a
+ * synthetic word that must be found nowhere after the press.
  */
 
 const NOW = 1_800_000_000_000;
 const OLD_ASK = "OLD_ASK_MARKER";
 const OLD_REPLY = "OLD_REPLY_MARKER";
 const OLD_COMPACTION = "OLD_COMPACTION_MARKER";
+const OLD_BRIEFING = "OLD_BRIEFING_MARKER";
 const LATE_REPLY = "LATE_REPLY_MARKER";
 const SESSION = { provider_id: "claude-code", provider_session_id: "abc" };
 
@@ -58,13 +68,20 @@ class MemoryStorage implements BrainStateStorage {
   }
 }
 
-function heldClient(): BrainClient & { release: (answer: BrainClientAnswer) => void } {
+function heldClient(): BrainClient & {
+  release: (answer: BrainClientAnswer) => void;
+  inputs: string[];
+} {
   const waiting: ((answer: BrainClientAnswer) => void)[] = [];
+  const inputs: string[] = [];
   return {
-    respond: () =>
-      new Promise((resolve) => {
+    inputs,
+    respond: (input) => {
+      inputs.push(JSON.stringify(input));
+      return new Promise((resolve) => {
         waiting.push(resolve);
-      }),
+      });
+    },
     quietUntil: () => undefined,
     release: (answer) => {
       for (const resolve of waiting.splice(0)) resolve(answer);
@@ -72,19 +89,26 @@ function heldClient(): BrainClient & { release: (answer: BrainClientAnswer) => v
   };
 }
 
-function heldPerformer(): BrainActPerformer & { release: () => void } {
+function heldPerformer(): BrainActPerformer & { release: () => void; effects: number } {
   const waiting: (() => void)[] = [];
-  return {
-    perform: async () => {
+  const performer = {
+    effects: 0,
+    perform: async (
+      _call: RealtimeFunctionCall,
+      execution: BrainActExecution,
+    ): Promise<WireRecord> => {
       await new Promise<void>((resolve) => {
         waiting.push(resolve);
       });
+      if (execution.isRevoked()) return { status: ACT_RESULT_STATUS.REJECTED, reason: "revoked" };
+      performer.effects += 1;
       return { status: ACT_RESULT_STATUS.ACCEPTED };
     },
     release: () => {
       for (const resolve of waiting.splice(0)) resolve();
     },
   };
+  return performer;
 }
 
 function reply(text: string, ...before: WireRecord[]): BrainClientAnswer {
@@ -120,25 +144,32 @@ function settle(): Promise<void> {
   });
 }
 
-function composed() {
-  const brainDisk = new MemoryStorage();
+function composed(brainDisk = new MemoryStorage()) {
   let conversationFile: string | undefined;
   let clock = NOW;
   let ids = 0;
   let generations = 0;
+  const reports: string[] = [];
   const store = new BrainStateStore({
     storage: brainDisk,
     createGenerationId: () => `gen-${++generations}`,
     now: () => clock,
+    report: (message) => reports.push(message),
   });
   let thread: readonly ConversationEntry[] = [];
   let clearedAt: number | undefined;
   let refuseThreadWrites = false;
   let refuseThreadRemoval = false;
   const cleared: number[] = [];
-  const withdrawn: number[] = [];
-  const reports: string[] = [];
+  const withdrawn: string[] = [];
   const broadcasts: (readonly { runId: string; status: string }[])[] = [];
+  const arbiter = new SpeechArbiter({ now: () => clock, nextId: () => `speech-${++ids}` });
+  // What the main process does on the store's announcement: the backlog and
+  // the outstanding offer go, and the mouth is told which offer it lost.
+  store.onReplaced(() => {
+    const offered = arbiter.withdrawBriefings();
+    if (offered) withdrawn.push(offered);
+  });
   // The main process's own record path, cutoff rule included.
   const record = (entry: ConversationEntry, at: number) => {
     if (clearedAt !== undefined && at <= clearedAt) return true;
@@ -166,10 +197,14 @@ function composed() {
         text: "- abc",
         identities: [{ providerId: "claude-code", providerSessionId: "abc" }],
       }),
-      standingContext: () => "",
+      // The standing context as the main process renders it: the recent
+      // thread, so a line the Clear left in memory would reach the model.
+      standingContext: () => conversationHistoryText(recentConversationEntries(thread), []) ?? "",
       readTranscriptSince: async () => ({ status: ACT_RESULT_STATUS.REJECTED, reason: "no" }),
       readTranscript: async () => ({ status: ACT_RESULT_STATUS.REJECTED, reason: "no" }),
-      deliver: () => undefined,
+      deliver: (delivery) => {
+        arbiter.request({ kind: BRIEFING_SPEECH_KIND, delivery });
+      },
       store,
       createRunId: () => `run-${++ids}`,
       report: () => {},
@@ -181,16 +216,13 @@ function composed() {
       now: () => clock,
       fence: (at) => {
         clearedAt = at;
+        thread = [];
+        cleared.push(at);
       },
-      withdrawSpeech: () => withdrawn.push(clock),
       removeConversation: () => {
         if (refuseThreadRemoval) return false;
         conversationFile = undefined;
         return true;
-      },
-      emptyConversation: () => {
-        thread = [];
-        cleared.push(clock);
       },
       report: (message) => reports.push(message),
     });
@@ -212,6 +244,7 @@ function composed() {
       held: store.current(),
       requests: host.current()?.requests(),
       broadcasts: broadcasts.at(-1),
+      arbiter: arbiter.next(),
     });
   return {
     brainDisk,
@@ -222,11 +255,12 @@ function composed() {
     submit,
     record,
     surface,
+    arbiter,
+    withdrawn,
     thread: () => thread,
     conversationFile: () => conversationFile,
     clearedAt: () => clearedAt,
     cleared,
-    withdrawn,
     reports,
     broadcasts,
     tick: (ms = 1) => {
@@ -234,6 +268,9 @@ function composed() {
       return clock;
     },
     now: () => clock,
+    setClock: (at: number) => {
+      clock = at;
+    },
     refuseThread: (writes: boolean, removal = false) => {
       refuseThreadWrites = writes;
       refuseThreadRemoval = removal;
@@ -241,15 +278,15 @@ function composed() {
   };
 }
 
-test("a Clear under a held model answer, a held act, and a held publication leaves nothing of the old generation anywhere", async () => {
-  const c = composed();
+const OLD_WORDS = [OLD_ASK, OLD_REPLY, OLD_COMPACTION, OLD_BRIEFING, LATE_REPLY];
+
+/** Seeds a finished, compacted exchange and a queued briefing, so every store has old content to lose. */
+async function seeded(c: ReturnType<typeof composed>) {
   const client = heldClient();
   const performer = heldPerformer();
   await c.host.replace(() => c.build(client, performer));
   const agent = c.host.current();
   assert.ok(agent);
-
-  // A finished exchange, compacted, so the encrypted memory of it is on disk.
   const first = await c.submit(agent, OLD_ASK);
   await settle();
   client.release(
@@ -257,8 +294,20 @@ test("a Clear under a held model answer, a held act, and a held publication leav
   );
   await settle();
   assert.equal(agent.request(first)?.status, BRAIN_REQUEST_STATUS.SUCCEEDED);
-  assert.ok(c.surface().includes(OLD_COMPACTION));
   assert.ok(c.thread().some((entry) => entry.words === OLD_REPLY));
+  assert.ok(String(c.brainDisk.file).includes(OLD_COMPACTION));
+  c.arbiter.request({
+    kind: BRIEFING_SPEECH_KIND,
+    delivery: { briefing: OLD_BRIEFING, decidedAt: c.now() },
+  });
+  return { agent, client, performer, first };
+}
+
+test("a Clear under a held model answer, a held act, a held publication, and an offered briefing leaves nothing of the old generation anywhere", async () => {
+  const c = composed();
+  const { agent, client, performer } = await seeded(c);
+  const offer = c.arbiter.next();
+  assert.ok(offer, "a briefing is in the mouth's hand");
 
   // Three late arrivals armed: an end whose publication the thread refused,
   // a run holding an act open, and a run holding its model answer open.
@@ -273,30 +322,35 @@ test("a Clear under a held model answer, a held act, and a held publication leav
   c.refuseThread(false);
 
   c.tick();
-  assert.equal(await c.clear(), true);
-  const cutoff = c.clearedAt();
-  assert.equal(cutoff, c.now());
-  assert.deepEqual(c.withdrawn, [c.now()]);
-  assert.deepEqual(c.cleared, [c.now()]);
+  const clearing = c.clear();
+  // Fenced before any disk was waited on: thread emptied, generation gone,
+  // runs stood down, the offered briefing taken back from the mouth.
   assert.deepEqual(c.thread(), []);
-  assert.equal(c.conversationFile(), undefined);
-  const marker = brainStateFromStored(c.brainDisk.file)?.reset;
-  assert.deepEqual(marker, { generationId: "gen-1", clearedAt: cutoff });
   assert.equal(c.store.holdsGeneration("gen-1"), false);
   assert.deepEqual(agent.requests(), []);
+  assert.deepEqual(c.withdrawn, [offer.id]);
+  assert.equal(c.arbiter.offeredId, undefined);
+  assert.equal(c.arbiter.pendingCount, 0);
+  assert.equal(await clearing, true);
+  const cutoff = c.clearedAt();
+  assert.equal(cutoff, c.now());
+  assert.deepEqual(c.cleared, [c.now()]);
+  assert.equal(c.conversationFile(), undefined);
+  const marker = brainStateFromStored(c.brainDisk.file)?.reset;
+  assert.deepEqual(marker, { clearedAt: cutoff, generationId: "gen-1" });
   assert.deepEqual(c.broadcasts.at(-1), []);
 
-  // Everything held is released after the press, and lands nowhere.
+  // Everything held is released after the press, and lands nowhere; the
+  // mouth's late report on the withdrawn offer is ignored.
   performer.release();
   await settle();
   client.release(reply(LATE_REPLY));
   await settle();
-  await c.tick(50);
+  assert.equal(c.arbiter.settle(offer.id, SPEECH_OUTCOME.SPOKEN), undefined);
+  assert.equal(performer.effects, 0);
   assert.equal(agent.request(second), undefined);
   assert.equal(agent.request(third), undefined);
-  for (const word of [OLD_ASK, OLD_REPLY, OLD_COMPACTION, LATE_REPLY]) {
-    assert.ok(!c.surface().includes(word), `${word} survived the Clear`);
-  }
+  for (const word of OLD_WORDS) assert.ok(!c.surface().includes(word), `${word} survived`);
   // A window's whole report of the thread as it stood before the press
   // merges to nothing, and the main record path takes nothing dated before it.
   const stale: ConversationEntry[] = [
@@ -310,10 +364,14 @@ test("a Clear under a held model answer, a held act, and a held publication leav
   );
   assert.deepEqual(c.thread(), []);
 
-  // The fresh generation takes a new ask, and its lines are the only lines.
+  // The fresh generation takes a new ask whose model input carries none of
+  // the old words, and its lines are the only lines.
   c.tick();
   const fresh = await c.submit(agent, "NEW_ASK");
   await settle();
+  const input = client.inputs.at(-1) ?? "";
+  assert.ok(input.includes("NEW_ASK"));
+  for (const word of OLD_WORDS) assert.ok(!input.includes(word), `${word} reached the model`);
   client.release(reply("NEW_REPLY"));
   await settle();
   assert.equal(agent.request(fresh)?.status, BRAIN_REQUEST_STATUS.SUCCEEDED);
@@ -324,10 +382,7 @@ test("a Clear under a held model answer, a held act, and a held publication leav
   const stored = brainStateFromStored(c.brainDisk.file);
   assert.equal(stored?.generationId, "gen-2");
   assert.deepEqual(stored?.reset, marker);
-  assert.equal(stored?.requests.length, 1);
-  for (const word of [OLD_ASK, OLD_REPLY, OLD_COMPACTION, LATE_REPLY]) {
-    assert.ok(!c.surface().includes(word), `${word} came back with the new ask`);
-  }
+  for (const word of OLD_WORDS) assert.ok(!c.surface().includes(word), `${word} came back`);
 
   // A relaunch on the same disk finds the marker and nothing of the old words.
   const relaunched = new BrainStateStore({
@@ -338,99 +393,150 @@ test("a Clear under a held model answer, a held act, and a held publication leav
   const loaded = await relaunched.load();
   assert.equal(loaded.generationId, "gen-2");
   assert.deepEqual(loaded.reset, marker);
-  assert.ok(!JSON.stringify(loaded).includes(OLD_COMPACTION));
   await c.host.replace(() => undefined);
 });
 
-test("a Clear whose marker will not write stays fenced and answers incomplete, and the next landed write finishes the erasure", async () => {
+test("a Clear whose thread will not go still empties every context: the next ask, the next look, a later write, and a launch see none of the old words", async () => {
   const c = composed();
-  const client = heldClient();
-  await c.host.replace(() => c.build(client));
-  const agent = c.host.current();
-  assert.ok(agent);
-  const first = await c.submit(agent, OLD_ASK);
-  await settle();
-  client.release(reply(OLD_REPLY));
-  await settle();
-  assert.equal(agent.request(first)?.status, BRAIN_REQUEST_STATUS.SUCCEEDED);
-
-  c.tick();
-  c.brainDisk.refuse = true;
-  assert.equal(await c.clear(), false);
-  c.brainDisk.refuse = false;
-  assert.equal(c.reports.length, 1);
-  assert.ok(c.reports[0]?.includes("incomplete"));
-  // The thread was removed and the view is not emptied: the developer is
-  // told the Clear did not complete, not shown a panel that says it did.
-  assert.deepEqual(c.cleared, []);
-  assert.equal(c.conversationFile(), undefined);
-  assert.equal(c.clearedAt(), c.now());
-  // The brain is fenced in memory even though the disk still says otherwise.
-  assert.deepEqual(agent.requests(), []);
-  assert.equal(c.store.holdsGeneration("gen-1"), false);
-  assert.ok(String(c.brainDisk.file).includes(OLD_ASK));
-  // A late main-path publication dated before the cutoff is not taken.
-  assert.equal(c.record({ kind: CONVERSATION_ENTRY_KIND.REPLY, words: LATE_REPLY }, c.now()), true);
-  assert.ok(!c.thread().some((entry) => entry.words === LATE_REPLY));
-
-  // The next write that lands carries the marker and no old content.
-  c.tick();
-  const fresh = await c.submit(agent, "NEW_ASK");
-  await settle();
-  client.release(reply("NEW_REPLY"));
-  await settle();
-  assert.equal(agent.request(fresh)?.status, BRAIN_REQUEST_STATUS.SUCCEEDED);
-  const stored = brainStateFromStored(c.brainDisk.file);
-  assert.equal(stored?.reset?.generationId, "gen-1");
-  assert.ok(!String(c.brainDisk.file).includes(OLD_ASK));
-  assert.ok(!String(c.brainDisk.file).includes(OLD_REPLY));
-
-  // Pressed again with the disk back, the Clear completes.
-  c.tick();
-  assert.equal(await c.clear(), true);
-  assert.deepEqual(c.thread(), []);
-  assert.equal(brainStateFromStored(c.brainDisk.file)?.reset?.generationId, "gen-2");
-  await c.host.replace(() => undefined);
-});
-
-test("a Clear whose thread will not go keeps the view, and a launch between the marker and the thread's removal refuses the old lines", async () => {
-  const c = composed();
-  const client = heldClient();
-  await c.host.replace(() => c.build(client));
-  const agent = c.host.current();
-  assert.ok(agent);
-  const first = await c.submit(agent, OLD_ASK);
-  await settle();
-  client.release(reply(OLD_REPLY));
-  await settle();
-  assert.equal(agent.request(first)?.status, BRAIN_REQUEST_STATUS.SUCCEEDED);
+  const { agent, client } = await seeded(c);
   const threadFileBefore = c.conversationFile();
   assert.ok(threadFileBefore?.includes(OLD_REPLY));
 
   c.tick();
   c.refuseThread(false, true);
   assert.equal(await c.clear(), false);
-  assert.deepEqual(c.cleared, []);
-  assert.deepEqual(c.withdrawn, [c.now()]);
-  // The marker is on disk, the brain fenced, the thread's file still standing.
+  assert.ok(c.reports.some((message) => message.includes("conversation could not be removed")));
+  // The view and the relay were emptied at the fence all the same, the
+  // marker is on disk, the brain and its briefing are gone; only the
+  // thread's file still stands, which is what "incomplete" reports.
+  assert.deepEqual(c.cleared, [c.now()]);
+  assert.deepEqual(c.thread(), []);
+  assert.equal(c.arbiter.pendingCount, 0);
   const marker = brainStateFromStored(c.brainDisk.file)?.reset;
-  assert.deepEqual(marker, { generationId: "gen-1", clearedAt: c.now() });
+  assert.deepEqual(marker, { clearedAt: c.now(), generationId: "gen-1" });
   assert.deepEqual(agent.requests(), []);
   assert.equal(c.conversationFile(), threadFileBefore);
 
+  // The next ask's model input carries none of the old words.
+  c.tick();
+  const fresh = await c.submit(agent, "NEW_ASK");
+  await settle();
+  const input = client.inputs.at(-1) ?? "";
+  assert.ok(input.includes("NEW_ASK"));
+  for (const word of OLD_WORDS) assert.ok(!input.includes(word), `${word} reached the model`);
+  client.release(reply("NEW_REPLY"));
+  await settle();
+  assert.equal(agent.request(fresh)?.status, BRAIN_REQUEST_STATUS.SUCCEEDED);
+  // The later write of the thread carries only the new lines, which is
+  // what finishes the erasure the removal could not.
+  assert.deepEqual(
+    c.thread().map((entry) => entry.words),
+    ["NEW_ASK", "NEW_REPLY"],
+  );
+  assert.ok(!String(c.conversationFile()).includes(OLD_REPLY));
+  // The next observation look reads the same emptied context.
+  agent.rosterLook();
+  await settle();
+  const look = client.inputs.at(-1) ?? "";
+  for (const word of OLD_WORDS) assert.ok(!look.includes(word), `${word} reached a look`);
+  client.release(reply(""));
+  await settle();
+  await c.host.replace(() => undefined);
+});
+
+test("a launch between the marker and the thread's removal refuses the old lines, and a Clear pressed before any state loaded still leaves the marker", async () => {
+  const c = composed();
+  const { agent } = await seeded(c);
+  const threadFile = c.conversationFile();
+  c.tick();
+  c.refuseThread(false, true);
+  assert.equal(await c.clear(), false);
+  assert.deepEqual(agent.requests(), []);
+  await c.host.replace(() => undefined);
   // The process dies here. The next launch reads the marker first and the
   // thread file second, as the main process does, and the old lines are gone.
   const clearedAt = brainStateFromStored(c.brainDisk.file)?.reset?.clearedAt;
-  assert.equal(clearedAt, marker?.clearedAt);
-  const restored = conversationFromStored(c.conversationFile(), c.tick(), clearedAt);
-  assert.deepEqual(restored, []);
+  assert.equal(clearedAt, c.now());
+  assert.deepEqual(conversationFromStored(threadFile, c.tick(), clearedAt), []);
   // Without the marker the same file would have stood the lines back up.
-  assert.equal(conversationFromStored(c.conversationFile(), c.now()).length, 2);
+  assert.equal(conversationFromStored(threadFile, c.now()).length, 2);
 
-  // Or the developer presses again with the disk back, and the Clear completes.
-  c.refuseThread(false, false);
-  assert.equal(await c.clear(), true);
-  assert.equal(c.conversationFile(), undefined);
+  // A launch with no capability never loads the brain file; the Clear still
+  // marks it, learning the erased id from the file and reading nothing else.
+  const cold = new MemoryStorage();
+  cold.file = brainStateRecord({
+    ...freshBrainState("gen-old", NOW),
+    items: [{ type: "message", role: "user", content: OLD_COMPACTION }],
+  });
+  const d = composed(cold);
+  d.setClock(NOW + 10);
+  d.refuseThread(false, true);
+  assert.equal(await d.clear(), false);
+  assert.deepEqual(brainStateFromStored(cold.file)?.reset, {
+    clearedAt: NOW + 10,
+    generationId: "gen-old",
+  });
+  assert.ok(!String(cold.file).includes(OLD_COMPACTION));
+  // And with no brain file at all, the marker still carries the instant.
+  const bare = composed(new MemoryStorage());
+  bare.setClock(NOW + 20);
+  assert.equal(await bare.clear(), true);
+  assert.deepEqual(brainStateFromStored(bare.brainDisk.file)?.reset, { clearedAt: NOW + 20 });
+});
+
+test("a Clear whose marker will not write stays fenced and answers incomplete, and the next landed write finishes the erasure", async () => {
+  const c = composed();
+  const { agent, client } = await seeded(c);
+  c.tick();
+  c.brainDisk.refuse = true;
+  assert.equal(await c.clear(), false);
+  c.brainDisk.refuse = false;
+  assert.ok(c.reports.some((message) => message.includes("marked erased")));
+  assert.deepEqual(c.cleared, [c.now()]);
   assert.deepEqual(c.thread(), []);
+  assert.equal(c.conversationFile(), undefined);
+  assert.equal(c.arbiter.pendingCount, 0);
+  assert.deepEqual(agent.requests(), []);
+  assert.equal(c.store.holdsGeneration("gen-1"), false);
+  assert.ok(String(c.brainDisk.file).includes(OLD_ASK));
+  assert.equal(c.record({ kind: CONVERSATION_ENTRY_KIND.REPLY, words: LATE_REPLY }, c.now()), true);
+  assert.deepEqual(c.thread(), []);
+
+  c.tick();
+  const fresh = await c.submit(agent, "NEW_ASK");
+  await settle();
+  for (const word of OLD_WORDS) assert.ok(!(client.inputs.at(-1) ?? "").includes(word));
+  client.release(reply("NEW_REPLY"));
+  await settle();
+  assert.equal(agent.request(fresh)?.status, BRAIN_REQUEST_STATUS.SUCCEEDED);
+  const stored = brainStateFromStored(c.brainDisk.file);
+  assert.equal(stored?.reset?.generationId, "gen-1");
+  assert.ok(!String(c.brainDisk.file).includes(OLD_ASK));
+  c.tick();
+  assert.equal(await c.clear(), true);
+  assert.equal(brainStateFromStored(c.brainDisk.file)?.reset?.generationId, "gen-2");
+  await c.host.replace(() => undefined);
+});
+
+test("an expiry takes the held speech backlog with the generation, so the successor is never handed the old briefings", async () => {
+  const c = composed();
+  const { agent } = await seeded(c);
+  // The briefing is held under quiet, waiting for the brain's re-decision.
+  c.arbiter.setQuiet(true);
+  c.arbiter.request({
+    kind: BRIEFING_SPEECH_KIND,
+    delivery: { briefing: `${OLD_BRIEFING}_HELD`, decidedAt: c.now() },
+  });
+  assert.equal(c.arbiter.heldBriefingCount, 2);
+  const born = c.store.current();
+  assert.ok(born);
+  c.setClock(born.expiresAt);
+  assert.equal(c.store.expireIfDue(c.now()), true);
+  assert.equal(c.arbiter.heldBriefingCount, 0);
+  c.arbiter.setQuiet(false);
+  assert.deepEqual(c.arbiter.takeHeldBriefings(), []);
+  assert.deepEqual(agent.requests(), []);
+  await c.store.flush();
+  assert.ok(!String(c.brainDisk.file).includes(OLD_COMPACTION));
   await c.host.replace(() => undefined);
 });

--- a/apps/desktop/src/main/conversation-clear.test.ts
+++ b/apps/desktop/src/main/conversation-clear.test.ts
@@ -1,0 +1,436 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { REALTIME_TOOL } from "@sidecar/acts";
+import {
+  BRAIN_REQUEST_ORIGIN,
+  BRAIN_REQUEST_STATUS,
+  type BrainActPerformer,
+  BrainAgent,
+  type BrainClient,
+  type BrainClientAnswer,
+  type BrainStateStorage,
+  BrainStateStore,
+  brainStateFromStored,
+} from "@sidecar/brain";
+import {
+  appendConversationThreadEntry,
+  CONVERSATION_ENTRY_KIND,
+  type ConversationEntry,
+} from "@sidecar/realtime";
+import { ACT_RESULT_STATUS, type WireRecord } from "@sidecar/wire";
+import { BrainHost } from "./brain-host";
+import { clearConversationAndBrain } from "./conversation-clear";
+import { followBrainRequests, submitBrainAsk } from "./ipc/brain";
+import {
+  conversationFromStored,
+  conversationRecord,
+  mergeConversationHistory,
+} from "./memory-flow";
+
+/**
+ * The Clear composed as the main process composes it: the real store, agent,
+ * host, follower, submission path, and the thread's own cutoff rule, with
+ * only the model, the performer, and the disk synthetic. Every marker below
+ * is a synthetic word that must be found nowhere after the press.
+ */
+
+const NOW = 1_800_000_000_000;
+const OLD_ASK = "OLD_ASK_MARKER";
+const OLD_REPLY = "OLD_REPLY_MARKER";
+const OLD_COMPACTION = "OLD_COMPACTION_MARKER";
+const LATE_REPLY = "LATE_REPLY_MARKER";
+const SESSION = { provider_id: "claude-code", provider_session_id: "abc" };
+
+class MemoryStorage implements BrainStateStorage {
+  file: string | undefined;
+  refuse = false;
+  read() {
+    return this.file;
+  }
+  write(contents: string) {
+    if (this.refuse) return false;
+    this.file = contents;
+    return true;
+  }
+  remove() {
+    this.file = undefined;
+    return true;
+  }
+}
+
+function heldClient(): BrainClient & { release: (answer: BrainClientAnswer) => void } {
+  const waiting: ((answer: BrainClientAnswer) => void)[] = [];
+  return {
+    respond: () =>
+      new Promise((resolve) => {
+        waiting.push(resolve);
+      }),
+    quietUntil: () => undefined,
+    release: (answer) => {
+      for (const resolve of waiting.splice(0)) resolve(answer);
+    },
+  };
+}
+
+function heldPerformer(): BrainActPerformer & { release: () => void } {
+  const waiting: (() => void)[] = [];
+  return {
+    perform: async () => {
+      await new Promise<void>((resolve) => {
+        waiting.push(resolve);
+      });
+      return { status: ACT_RESULT_STATUS.ACCEPTED };
+    },
+    release: () => {
+      for (const resolve of waiting.splice(0)) resolve();
+    },
+  };
+}
+
+function reply(text: string, ...before: WireRecord[]): BrainClientAnswer {
+  return {
+    outcome: "answered",
+    payload: {
+      output: [
+        ...before,
+        { type: "message", role: "assistant", content: [{ type: "output_text", text }] },
+      ],
+    },
+  };
+}
+
+function act(callId: string): WireRecord {
+  return {
+    type: "function_call",
+    call_id: callId,
+    name: REALTIME_TOOL.SEND_SESSION_MESSAGE,
+    arguments: JSON.stringify({ ...SESSION, text: "run it" }),
+  };
+}
+
+function settle(): Promise<void> {
+  return new Promise((resolve) => {
+    let ticks = 0;
+    const tick = () => {
+      ticks += 1;
+      if (ticks > 40) resolve();
+      else setImmediate(tick);
+    };
+    tick();
+  });
+}
+
+function composed() {
+  const brainDisk = new MemoryStorage();
+  let conversationFile: string | undefined;
+  let clock = NOW;
+  let ids = 0;
+  let generations = 0;
+  const store = new BrainStateStore({
+    storage: brainDisk,
+    createGenerationId: () => `gen-${++generations}`,
+    now: () => clock,
+  });
+  let thread: readonly ConversationEntry[] = [];
+  let clearedAt: number | undefined;
+  let refuseThreadWrites = false;
+  let refuseThreadRemoval = false;
+  const cleared: number[] = [];
+  const withdrawn: number[] = [];
+  const reports: string[] = [];
+  const broadcasts: (readonly { runId: string; status: string }[])[] = [];
+  // The main process's own record path, cutoff rule included.
+  const record = (entry: ConversationEntry, at: number) => {
+    if (clearedAt !== undefined && at <= clearedAt) return true;
+    if (refuseThreadWrites) return false;
+    const merged = appendConversationThreadEntry(thread, entry, clock, at);
+    if (merged === thread) return true;
+    thread = merged;
+    conversationFile = conversationRecord(thread, clock);
+    return true;
+  };
+  const host = new BrainHost({
+    follow: (agent) =>
+      followBrainRequests(agent, {
+        recordConversationEntry: record,
+        broadcastRequests: (snapshots) =>
+          broadcasts.push(snapshots.map((s) => ({ runId: s.runId, status: s.status }))),
+      }),
+    publishEmpty: () => broadcasts.push([]),
+  });
+  const build = (client: BrainClient, acts?: BrainActPerformer) =>
+    new BrainAgent({
+      client,
+      acts: acts ?? { perform: async () => ({ status: ACT_RESULT_STATUS.ACCEPTED }) },
+      roster: () => ({
+        text: "- abc",
+        identities: [{ providerId: "claude-code", providerSessionId: "abc" }],
+      }),
+      standingContext: () => "",
+      readTranscriptSince: async () => ({ status: ACT_RESULT_STATUS.REJECTED, reason: "no" }),
+      readTranscript: async () => ({ status: ACT_RESULT_STATUS.REJECTED, reason: "no" }),
+      deliver: () => undefined,
+      store,
+      createRunId: () => `run-${++ids}`,
+      report: () => {},
+      now: () => clock,
+    });
+  const clear = () =>
+    clearConversationAndBrain({
+      store,
+      now: () => clock,
+      fence: (at) => {
+        clearedAt = at;
+      },
+      withdrawSpeech: () => withdrawn.push(clock),
+      removeConversation: () => {
+        if (refuseThreadRemoval) return false;
+        conversationFile = undefined;
+        return true;
+      },
+      emptyConversation: () => {
+        thread = [];
+        cleared.push(clock);
+      },
+      report: (message) => reports.push(message),
+    });
+  const submit = async (agent: BrainAgent, question: string) => {
+    const result = await submitBrainAsk(
+      agent,
+      { submissionId: `sub-${++ids}`, question, origin: BRAIN_REQUEST_ORIGIN.TYPED },
+      record,
+    );
+    assert.equal(result.outcome, "accepted");
+    return result.outcome === "accepted" ? result.runId : "";
+  };
+  /** Everything an old word could survive in, flattened for a marker search. */
+  const surface = () =>
+    JSON.stringify({
+      brainDisk: brainDisk.file,
+      conversationFile,
+      thread,
+      held: store.current(),
+      requests: host.current()?.requests(),
+      broadcasts: broadcasts.at(-1),
+    });
+  return {
+    brainDisk,
+    store,
+    host,
+    build,
+    clear,
+    submit,
+    record,
+    surface,
+    thread: () => thread,
+    conversationFile: () => conversationFile,
+    clearedAt: () => clearedAt,
+    cleared,
+    withdrawn,
+    reports,
+    broadcasts,
+    tick: (ms = 1) => {
+      clock += ms;
+      return clock;
+    },
+    now: () => clock,
+    refuseThread: (writes: boolean, removal = false) => {
+      refuseThreadWrites = writes;
+      refuseThreadRemoval = removal;
+    },
+  };
+}
+
+test("a Clear under a held model answer, a held act, and a held publication leaves nothing of the old generation anywhere", async () => {
+  const c = composed();
+  const client = heldClient();
+  const performer = heldPerformer();
+  await c.host.replace(() => c.build(client, performer));
+  const agent = c.host.current();
+  assert.ok(agent);
+
+  // A finished exchange, compacted, so the encrypted memory of it is on disk.
+  const first = await c.submit(agent, OLD_ASK);
+  await settle();
+  client.release(
+    reply(OLD_REPLY, { type: "compaction", id: "cmp_1", encrypted_content: OLD_COMPACTION }),
+  );
+  await settle();
+  assert.equal(agent.request(first)?.status, BRAIN_REQUEST_STATUS.SUCCEEDED);
+  assert.ok(c.surface().includes(OLD_COMPACTION));
+  assert.ok(c.thread().some((entry) => entry.words === OLD_REPLY));
+
+  // Three late arrivals armed: an end whose publication the thread refused,
+  // a run holding an act open, and a run holding its model answer open.
+  c.refuseThread(true);
+  const second = await c.submit(agent, "act now");
+  await settle();
+  client.release(reply("", act("call_1")));
+  await settle();
+  const third = await c.submit(agent, "think");
+  await settle();
+  assert.equal(agent.request(second)?.status, BRAIN_REQUEST_STATUS.RUNNING);
+  c.refuseThread(false);
+
+  c.tick();
+  assert.equal(await c.clear(), true);
+  const cutoff = c.clearedAt();
+  assert.equal(cutoff, c.now());
+  assert.deepEqual(c.withdrawn, [c.now()]);
+  assert.deepEqual(c.cleared, [c.now()]);
+  assert.deepEqual(c.thread(), []);
+  assert.equal(c.conversationFile(), undefined);
+  const marker = brainStateFromStored(c.brainDisk.file)?.reset;
+  assert.deepEqual(marker, { generationId: "gen-1", clearedAt: cutoff });
+  assert.equal(c.store.holdsGeneration("gen-1"), false);
+  assert.deepEqual(agent.requests(), []);
+  assert.deepEqual(c.broadcasts.at(-1), []);
+
+  // Everything held is released after the press, and lands nowhere.
+  performer.release();
+  await settle();
+  client.release(reply(LATE_REPLY));
+  await settle();
+  await c.tick(50);
+  assert.equal(agent.request(second), undefined);
+  assert.equal(agent.request(third), undefined);
+  for (const word of [OLD_ASK, OLD_REPLY, OLD_COMPACTION, LATE_REPLY]) {
+    assert.ok(!c.surface().includes(word), `${word} survived the Clear`);
+  }
+  // A window's whole report of the thread as it stood before the press
+  // merges to nothing, and the main record path takes nothing dated before it.
+  const stale: ConversationEntry[] = [
+    { kind: CONVERSATION_ENTRY_KIND.TYPED_ASK, words: OLD_ASK, recordedAt: NOW },
+    { kind: CONVERSATION_ENTRY_KIND.REPLY, words: OLD_REPLY, recordedAt: cutoff ?? 0 },
+  ];
+  assert.deepEqual(mergeConversationHistory(c.thread(), stale, cutoff, c.now()), []);
+  assert.equal(
+    c.record({ kind: CONVERSATION_ENTRY_KIND.REPLY, words: LATE_REPLY }, cutoff ?? 0),
+    true,
+  );
+  assert.deepEqual(c.thread(), []);
+
+  // The fresh generation takes a new ask, and its lines are the only lines.
+  c.tick();
+  const fresh = await c.submit(agent, "NEW_ASK");
+  await settle();
+  client.release(reply("NEW_REPLY"));
+  await settle();
+  assert.equal(agent.request(fresh)?.status, BRAIN_REQUEST_STATUS.SUCCEEDED);
+  assert.deepEqual(
+    c.thread().map((entry) => entry.words),
+    ["NEW_ASK", "NEW_REPLY"],
+  );
+  const stored = brainStateFromStored(c.brainDisk.file);
+  assert.equal(stored?.generationId, "gen-2");
+  assert.deepEqual(stored?.reset, marker);
+  assert.equal(stored?.requests.length, 1);
+  for (const word of [OLD_ASK, OLD_REPLY, OLD_COMPACTION, LATE_REPLY]) {
+    assert.ok(!c.surface().includes(word), `${word} came back with the new ask`);
+  }
+
+  // A relaunch on the same disk finds the marker and nothing of the old words.
+  const relaunched = new BrainStateStore({
+    storage: c.brainDisk,
+    createGenerationId: () => "gen-relaunch",
+    now: c.now,
+  });
+  const loaded = await relaunched.load();
+  assert.equal(loaded.generationId, "gen-2");
+  assert.deepEqual(loaded.reset, marker);
+  assert.ok(!JSON.stringify(loaded).includes(OLD_COMPACTION));
+  await c.host.replace(() => undefined);
+});
+
+test("a Clear whose marker will not write stays fenced and answers incomplete, and the next landed write finishes the erasure", async () => {
+  const c = composed();
+  const client = heldClient();
+  await c.host.replace(() => c.build(client));
+  const agent = c.host.current();
+  assert.ok(agent);
+  const first = await c.submit(agent, OLD_ASK);
+  await settle();
+  client.release(reply(OLD_REPLY));
+  await settle();
+  assert.equal(agent.request(first)?.status, BRAIN_REQUEST_STATUS.SUCCEEDED);
+
+  c.tick();
+  c.brainDisk.refuse = true;
+  assert.equal(await c.clear(), false);
+  c.brainDisk.refuse = false;
+  assert.equal(c.reports.length, 1);
+  assert.ok(c.reports[0]?.includes("incomplete"));
+  // The thread was removed and the view is not emptied: the developer is
+  // told the Clear did not complete, not shown a panel that says it did.
+  assert.deepEqual(c.cleared, []);
+  assert.equal(c.conversationFile(), undefined);
+  assert.equal(c.clearedAt(), c.now());
+  // The brain is fenced in memory even though the disk still says otherwise.
+  assert.deepEqual(agent.requests(), []);
+  assert.equal(c.store.holdsGeneration("gen-1"), false);
+  assert.ok(String(c.brainDisk.file).includes(OLD_ASK));
+  // A late main-path publication dated before the cutoff is not taken.
+  assert.equal(c.record({ kind: CONVERSATION_ENTRY_KIND.REPLY, words: LATE_REPLY }, c.now()), true);
+  assert.ok(!c.thread().some((entry) => entry.words === LATE_REPLY));
+
+  // The next write that lands carries the marker and no old content.
+  c.tick();
+  const fresh = await c.submit(agent, "NEW_ASK");
+  await settle();
+  client.release(reply("NEW_REPLY"));
+  await settle();
+  assert.equal(agent.request(fresh)?.status, BRAIN_REQUEST_STATUS.SUCCEEDED);
+  const stored = brainStateFromStored(c.brainDisk.file);
+  assert.equal(stored?.reset?.generationId, "gen-1");
+  assert.ok(!String(c.brainDisk.file).includes(OLD_ASK));
+  assert.ok(!String(c.brainDisk.file).includes(OLD_REPLY));
+
+  // Pressed again with the disk back, the Clear completes.
+  c.tick();
+  assert.equal(await c.clear(), true);
+  assert.deepEqual(c.thread(), []);
+  assert.equal(brainStateFromStored(c.brainDisk.file)?.reset?.generationId, "gen-2");
+  await c.host.replace(() => undefined);
+});
+
+test("a Clear whose thread will not go keeps the view, and a launch between the marker and the thread's removal refuses the old lines", async () => {
+  const c = composed();
+  const client = heldClient();
+  await c.host.replace(() => c.build(client));
+  const agent = c.host.current();
+  assert.ok(agent);
+  const first = await c.submit(agent, OLD_ASK);
+  await settle();
+  client.release(reply(OLD_REPLY));
+  await settle();
+  assert.equal(agent.request(first)?.status, BRAIN_REQUEST_STATUS.SUCCEEDED);
+  const threadFileBefore = c.conversationFile();
+  assert.ok(threadFileBefore?.includes(OLD_REPLY));
+
+  c.tick();
+  c.refuseThread(false, true);
+  assert.equal(await c.clear(), false);
+  assert.deepEqual(c.cleared, []);
+  assert.deepEqual(c.withdrawn, [c.now()]);
+  // The marker is on disk, the brain fenced, the thread's file still standing.
+  const marker = brainStateFromStored(c.brainDisk.file)?.reset;
+  assert.deepEqual(marker, { generationId: "gen-1", clearedAt: c.now() });
+  assert.deepEqual(agent.requests(), []);
+  assert.equal(c.conversationFile(), threadFileBefore);
+
+  // The process dies here. The next launch reads the marker first and the
+  // thread file second, as the main process does, and the old lines are gone.
+  const clearedAt = brainStateFromStored(c.brainDisk.file)?.reset?.clearedAt;
+  assert.equal(clearedAt, marker?.clearedAt);
+  const restored = conversationFromStored(c.conversationFile(), c.tick(), clearedAt);
+  assert.deepEqual(restored, []);
+  // Without the marker the same file would have stood the lines back up.
+  assert.equal(conversationFromStored(c.conversationFile(), c.now()).length, 2);
+
+  // Or the developer presses again with the disk back, and the Clear completes.
+  c.refuseThread(false, false);
+  assert.equal(await c.clear(), true);
+  assert.equal(c.conversationFile(), undefined);
+  assert.deepEqual(c.thread(), []);
+  await c.host.replace(() => undefined);
+});

--- a/apps/desktop/src/main/conversation-clear.ts
+++ b/apps/desktop/src/main/conversation-clear.ts
@@ -1,0 +1,52 @@
+import type { BrainStateStore } from "@sidecar/brain";
+
+/**
+ * The History Clear, in the order that makes a late arrival harmless. The
+ * cutoff is raised first, so every history write and window report from here
+ * on is judged against it before anything is erased; the brain's generation
+ * is fenced and its marker written next, in the store's one write, so no run
+ * of the old generation can checkpoint or publish again and a launch that
+ * finds the marker knows which lines to refuse; only then is the speech not
+ * yet in the mouth withdrawn and the thread's file removed; and the windows
+ * are told last, once there is nothing left that could stand the lines back
+ * up. A step that fails leaves everything before it standing — fenced,
+ * withdrawn, refused — and answers that the erasure did not complete, never
+ * that it did: a Clear the developer is told succeeded must have reached the
+ * disk on both files.
+ */
+export interface ConversationClearDependencies {
+  /** The one writer of the brain's state; its Clear fences the generation and writes the marker. */
+  store: Pick<BrainStateStore, "clear">;
+  now: () => number;
+  /** Raises the cutoff every later history write and report is checked against. */
+  fence: (clearedAt: number) => void;
+  /** Withdraws every briefing that has not reached the mouth. */
+  withdrawSpeech: () => void;
+  /** Removes the stored thread; answers whether it went. */
+  removeConversation: () => boolean;
+  /** Empties the relayed thread and tells every window it was cleared. */
+  emptyConversation: () => void;
+  report: (message: string) => void;
+}
+
+export const CONVERSATION_CLEAR_INCOMPLETE = {
+  MARKER: "the brain's memory could not be marked erased on disk",
+  THREAD: "the stored conversation could not be removed",
+} as const;
+
+export async function clearConversationAndBrain(
+  dependencies: ConversationClearDependencies,
+): Promise<boolean> {
+  const clearedAt = dependencies.now();
+  dependencies.fence(clearedAt);
+  const marked = await dependencies.store.clear(clearedAt);
+  dependencies.withdrawSpeech();
+  const removed = dependencies.removeConversation();
+  if (!marked)
+    dependencies.report(`History Clear incomplete: ${CONVERSATION_CLEAR_INCOMPLETE.MARKER}`);
+  if (!removed)
+    dependencies.report(`History Clear incomplete: ${CONVERSATION_CLEAR_INCOMPLETE.THREAD}`);
+  if (!marked || !removed) return false;
+  dependencies.emptyConversation();
+  return true;
+}

--- a/apps/desktop/src/main/conversation-clear.ts
+++ b/apps/desktop/src/main/conversation-clear.ts
@@ -2,30 +2,27 @@ import type { BrainStateStore } from "@sidecar/brain";
 
 /**
  * The History Clear, in the order that makes a late arrival harmless. The
- * cutoff is raised first, so every history write and window report from here
- * on is judged against it before anything is erased; the brain's generation
- * is fenced and its marker written next, in the store's one write, so no run
- * of the old generation can checkpoint or publish again and a launch that
- * finds the marker knows which lines to refuse; only then is the speech not
- * yet in the mouth withdrawn and the thread's file removed; and the windows
- * are told last, once there is nothing left that could stand the lines back
- * up. A step that fails leaves everything before it standing — fenced,
- * withdrawn, refused — and answers that the erasure did not complete, never
- * that it did: a Clear the developer is told succeeded must have reached the
- * disk on both files.
+ * fence comes first and is synchronous: the cutoff is raised, the relayed
+ * thread is emptied and every window told, so from here on no history write,
+ * window report, model context, or publication can carry a line from before
+ * the press, whatever the disk does next. The brain's generation is fenced in
+ * the same breath — the store forgets it and announces the empty successor
+ * before waiting on anything, and the host's own listener withdraws the
+ * speech that generation had queued — and its marker is then written over
+ * the old content. Only after that is the thread's file removed. A step that
+ * fails leaves the fence standing and answers that the erasure did not
+ * complete, never that it did: the developer sees an emptied History and is
+ * told the file may still hold the words, rather than a panel that says done
+ * over a disk that kept them.
  */
 export interface ConversationClearDependencies {
   /** The one writer of the brain's state; its Clear fences the generation and writes the marker. */
   store: Pick<BrainStateStore, "clear">;
   now: () => number;
-  /** Raises the cutoff every later history write and report is checked against. */
+  /** Raises the cutoff, empties the relayed thread, and tells every window, before anything is erased. */
   fence: (clearedAt: number) => void;
-  /** Withdraws every briefing that has not reached the mouth. */
-  withdrawSpeech: () => void;
   /** Removes the stored thread; answers whether it went. */
   removeConversation: () => boolean;
-  /** Empties the relayed thread and tells every window it was cleared. */
-  emptyConversation: () => void;
   report: (message: string) => void;
 }
 
@@ -39,14 +36,12 @@ export async function clearConversationAndBrain(
 ): Promise<boolean> {
   const clearedAt = dependencies.now();
   dependencies.fence(clearedAt);
-  const marked = await dependencies.store.clear(clearedAt);
-  dependencies.withdrawSpeech();
+  const marking = dependencies.store.clear(clearedAt);
   const removed = dependencies.removeConversation();
+  const marked = await marking;
   if (!marked)
     dependencies.report(`History Clear incomplete: ${CONVERSATION_CLEAR_INCOMPLETE.MARKER}`);
   if (!removed)
     dependencies.report(`History Clear incomplete: ${CONVERSATION_CLEAR_INCOMPLETE.THREAD}`);
-  if (!marked || !removed) return false;
-  dependencies.emptyConversation();
-  return true;
+  return marked && removed;
 }

--- a/apps/desktop/src/main/conversation-clear.ts
+++ b/apps/desktop/src/main/conversation-clear.ts
@@ -9,7 +9,10 @@ import type { BrainStateStore } from "@sidecar/brain";
  * the same breath — the store forgets it and announces the empty successor
  * before waiting on anything, and the host's own listener withdraws the
  * speech that generation had queued — and its marker is then written over
- * the old content. Only after that is the thread's file removed. A step that
+ * the old content. Only once that marker is durable is the thread's file
+ * erased, and erased to what the thread holds now rather than to nothing,
+ * so a line recorded after the fence while the disk was answering is not
+ * taken with the old ones. A step that
  * fails leaves the fence standing and answers that the erasure did not
  * complete, never that it did: the developer sees an emptied History and is
  * told the file may still hold the words, rather than a panel that says done
@@ -21,8 +24,12 @@ export interface ConversationClearDependencies {
   now: () => number;
   /** Raises the cutoff, empties the relayed thread, and tells every window, before anything is erased. */
   fence: (clearedAt: number) => void;
-  /** Removes the stored thread; answers whether it went. */
-  removeConversation: () => boolean;
+  /**
+   * Erases the stored thread as it stood before the fence, once the cutoff
+   * is durable: what the thread holds now — only lines recorded after the
+   * fence, if any — is what the file keeps. Answers whether the write landed.
+   */
+  eraseConversation: () => boolean;
   report: (message: string) => void;
 }
 
@@ -36,12 +43,18 @@ export async function clearConversationAndBrain(
 ): Promise<boolean> {
   const clearedAt = dependencies.now();
   dependencies.fence(clearedAt);
-  const marking = dependencies.store.clear(clearedAt);
-  const removed = dependencies.removeConversation();
-  const marked = await marking;
-  if (!marked)
+  const marked = await dependencies.store.clear(clearedAt);
+  if (!marked) {
+    // No durable cutoff, so the old thread's file is left for the next thread
+    // write to replace: the fence already keeps it out of every view and
+    // context, and a file removed without its marker would be a Clear the
+    // next launch could not tell had happened.
     dependencies.report(`History Clear incomplete: ${CONVERSATION_CLEAR_INCOMPLETE.MARKER}`);
-  if (!removed)
+    return false;
+  }
+  const erased = dependencies.eraseConversation();
+  if (!erased) {
     dependencies.report(`History Clear incomplete: ${CONVERSATION_CLEAR_INCOMPLETE.THREAD}`);
-  return marked && removed;
+  }
+  return erased;
 }

--- a/apps/desktop/src/main/desktop-app.ts
+++ b/apps/desktop/src/main/desktop-app.ts
@@ -25,6 +25,7 @@ import {
 import {
   BrainAgent,
   type BrainDelivery,
+  BrainGenerationClock,
   BrainStateStore,
   brainStateFromStored,
 } from "@sidecar/brain";
@@ -509,6 +510,7 @@ const brain = () => brains.current();
  * store, so two agents can never write the envelope past each other.
  */
 let brainStateStore: BrainStateStore | undefined;
+let brainGenerationClock: BrainGenerationClock | undefined;
 /** The spool watchers standing on each hooked provider's spool, closed at quit. */
 let spoolWatchers: readonly ObservationSpoolWatcher[] = [];
 /**
@@ -1525,6 +1527,11 @@ function brainStore(): BrainStateStore {
   // are that generation's words, and an offer is not proof they were said.
   // The agent hears the same announcement and stands its runs down itself.
   brainStateStore.onReplaced(() => withdrawBriefings());
+  // The generation's clock stands with the store, not with an agent: a
+  // launch with no key or account, and an app left open after its agent was
+  // retired, still see the generation die on time and the file replaced.
+  brainGenerationClock = new BrainGenerationClock({ store: brainStateStore });
+  void brainGenerationClock.start();
   return brainStateStore;
 }
 
@@ -1661,7 +1668,14 @@ function clearConversationHistory(): Promise<boolean> {
       conversationClearedAt = clearedAt;
       emptyConversation();
     },
-    removeConversation: () => removeStoredState(conversationPath(), "the conversation"),
+    eraseConversation: () =>
+      conversationHistory.length === 0
+        ? removeStoredState(conversationPath(), "the conversation")
+        : writeStoredState(
+            conversationPath(),
+            conversationRecord(conversationHistory, Date.now()),
+            "the conversation",
+          ),
     report: (message) => process.stderr.write(`${message}\n`),
   });
 }
@@ -3122,6 +3136,10 @@ export function startDesktopApp(): void {
           conversationClearedAt,
         );
         rememberedFacts = rememberedFactsFromStored(readStoredState(rememberedFactsPath()));
+        // Retention runs on every live launch, key or no key: the store's
+        // load admits the file within its bounds and lifetime, replacing on
+        // disk what it does not admit, and the clock takes it from there.
+        brainStore();
       }
       // A signed-in install with no arrival record predates the beat: its
       // sign-in was never observed, so it is settled now rather than greeted

--- a/apps/desktop/src/main/desktop-app.ts
+++ b/apps/desktop/src/main/desktop-app.ts
@@ -1509,7 +1509,8 @@ async function applyVoiceCredential(): Promise<void> {
 const brainStatePath = () => path.join(app.getPath("userData"), BRAIN_STATE_FILE);
 
 function brainStore(): BrainStateStore {
-  brainStateStore ??= new BrainStateStore({
+  if (brainStateStore) return brainStateStore;
+  brainStateStore = new BrainStateStore({
     storage: {
       read: () => readStoredState(brainStatePath()),
       write: (contents) =>
@@ -1517,8 +1518,20 @@ function brainStore(): BrainStateStore {
       remove: () => removeStoredState(brainStatePath(), "Luke's memory of the agents"),
     },
     createGenerationId: () => randomUUID(),
+    report: (message) => process.stderr.write(`${message}\n`),
   });
+  // A generation that ends — cleared, expired, or replaced — takes its
+  // unspoken briefings with it, the one in the mouth's hand included: they
+  // are that generation's words, and an offer is not proof they were said.
+  // The agent hears the same announcement and stands its runs down itself.
+  brainStateStore.onReplaced(() => withdrawBriefings());
   return brainStateStore;
+}
+
+function withdrawBriefings(): void {
+  const offered = speechArbiter.withdrawBriefings();
+  if (offered) voiceWindow.current()?.webContents.send(channels.onSpeechWithdrawn, { id: offered });
+  offerNextSpeech();
 }
 
 /**
@@ -1620,15 +1633,16 @@ function recordMainConversationEntry(entry: ConversationEntry, recordedAt = Date
 }
 
 /**
- * The History Clear a panel pressed: the cutoff raised, the brain's
- * generation fenced and marked erased, its undelivered briefings withdrawn,
- * the stored thread deleted, and only then the relay emptied for every panel.
- * Answers whether both files went; only then is the voice window told to
- * retire its own turns, so a thread that could not be deleted is not
- * half-forgotten, while the fence and the marker stand either way. What Luke
- * separately remembers about the developer is another file under another
- * rule, and a Clear does not reach it. A fixture or capture run holds
- * nothing on disk and empties the view alone.
+ * The History Clear a panel pressed: the cutoff raised and the relay emptied
+ * for every panel first, so no context, publication, or report can carry
+ * the old lines whatever the disk does; the brain's generation fenced and
+ * marked erased, which the store's listener below answers by withdrawing
+ * the speech that generation had queued; then the stored thread deleted.
+ * Answers whether both files went, which is what the panel reports; the
+ * fence stands either way. What Luke separately remembers about the
+ * developer is another file under another rule, and a Clear does not reach
+ * it. A fixture or capture run holds nothing on disk and empties the view
+ * alone.
  */
 function clearConversationHistory(): Promise<boolean> {
   const emptyConversation = () => {
@@ -1645,10 +1659,9 @@ function clearConversationHistory(): Promise<boolean> {
     now: Date.now,
     fence: (clearedAt) => {
       conversationClearedAt = clearedAt;
+      emptyConversation();
     },
-    withdrawSpeech: () => speechArbiter.dropBriefings(),
     removeConversation: () => removeStoredState(conversationPath(), "the conversation"),
-    emptyConversation,
     report: (message) => process.stderr.write(`${message}\n`),
   });
 }

--- a/apps/desktop/src/main/desktop-app.ts
+++ b/apps/desktop/src/main/desktop-app.ts
@@ -22,7 +22,12 @@ import {
   productSignInAge,
   type RecordProductEvent,
 } from "@sidecar/analytics";
-import { BrainAgent, type BrainDelivery, BrainStateStore } from "@sidecar/brain";
+import {
+  BrainAgent,
+  type BrainDelivery,
+  BrainStateStore,
+  brainStateFromStored,
+} from "@sidecar/brain";
 import {
   activeMeetingEnd,
   GoogleCalendarReader,
@@ -160,6 +165,7 @@ import {
   calendarOnboardingStateFromStored,
   shouldBackfillCalendarOnboardingSettled,
 } from "./calendar-onboarding-flow";
+import { clearConversationAndBrain } from "./conversation-clear";
 import {
   INTRODUCTION_FADE_MS,
   INTRODUCTION_HANDOFF_READY_MS,
@@ -1595,6 +1601,10 @@ function brainStandingContext(): string {
  */
 function recordMainConversationEntry(entry: ConversationEntry, recordedAt = Date.now()): boolean {
   if (!runMode.observesProviders) return false;
+  // A line from at or before the last Clear was settled by the Clear itself:
+  // a run of the erased generation publishing late, or a report of the thread
+  // as it stood before the press. Nothing is owed for it, and it is not taken.
+  if (conversationClearedAt !== undefined && recordedAt <= conversationClearedAt) return true;
   const now = Date.now();
   const merged = appendConversationThreadEntry(conversationHistory, entry, now, recordedAt);
   // Unchanged means the thread already holds this line, or refused an empty
@@ -1610,22 +1620,37 @@ function recordMainConversationEntry(entry: ConversationEntry, recordedAt = Date
 }
 
 /**
- * The History Clear a panel pressed: the stored thread deleted, the relay
- * emptied for every panel, and the moment remembered so a report still in
- * flight from before it cannot stand the old lines back up. Answers whether
- * the file went; only then is the voice window told to retire its own turns,
- * so a thread that could not be deleted is not half-forgotten.
+ * The History Clear a panel pressed: the cutoff raised, the brain's
+ * generation fenced and marked erased, its undelivered briefings withdrawn,
+ * the stored thread deleted, and only then the relay emptied for every panel.
+ * Answers whether both files went; only then is the voice window told to
+ * retire its own turns, so a thread that could not be deleted is not
+ * half-forgotten, while the fence and the marker stand either way. What Luke
+ * separately remembers about the developer is another file under another
+ * rule, and a Clear does not reach it. A fixture or capture run holds
+ * nothing on disk and empties the view alone.
  */
-function clearConversationHistory(): boolean {
-  if (runMode.observesProviders) {
-    const clearedAt = Date.now();
-    if (!removeStoredState(conversationPath(), "the conversation")) return false;
-    conversationClearedAt = clearedAt;
+function clearConversationHistory(): Promise<boolean> {
+  const emptyConversation = () => {
+    conversationHistory = [];
+    const payload: ConversationHistoryPayload = { entries: [], cleared: true };
+    broadcast(channels.onConversationHistoryChanged, payload);
+  };
+  if (!runMode.observesProviders) {
+    emptyConversation();
+    return Promise.resolve(true);
   }
-  conversationHistory = [];
-  const payload: ConversationHistoryPayload = { entries: [], cleared: true };
-  broadcast(channels.onConversationHistoryChanged, payload);
-  return true;
+  return clearConversationAndBrain({
+    store: brainStore(),
+    now: Date.now,
+    fence: (clearedAt) => {
+      conversationClearedAt = clearedAt;
+    },
+    withdrawSpeech: () => speechArbiter.dropBriefings(),
+    removeConversation: () => removeStoredState(conversationPath(), "the conversation"),
+    emptyConversation,
+    report: (message) => process.stderr.write(`${message}\n`),
+  });
 }
 
 /**
@@ -3073,9 +3098,15 @@ export function startDesktopApp(): void {
       // that opened on an empty History and filled it a beat later would read
       // as a conversation arriving rather than one resumed.
       if (runMode.observesProviders) {
+        // The last Clear's marker outlives the launch that made it, so a
+        // thread the Clear meant to erase is refused here even when its own
+        // file outlived the press.
+        conversationClearedAt = brainStateFromStored(readStoredState(brainStatePath()))?.reset
+          ?.clearedAt;
         conversationHistory = conversationFromStored(
           readStoredState(conversationPath()),
           Date.now(),
+          conversationClearedAt,
         );
         rememberedFacts = rememberedFactsFromStored(readStoredState(rememberedFactsPath()));
       }

--- a/apps/desktop/src/main/ipc/voice-runtime.test.ts
+++ b/apps/desktop/src/main/ipc/voice-runtime.test.ts
@@ -1,0 +1,109 @@
+/* oxlint-disable anti-slop/no-unknown-returns -- Fake Electron listeners deliberately retain the IPC boundary shape. */
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { WireRecord } from "@sidecar/wire";
+import type { IpcMainEvent, IpcMainInvokeEvent, WebContents } from "electron";
+import { BRIDGE, channels } from "#shared/bridge";
+import { VOICE_COMMAND, VOICE_COMMAND_OUTCOME } from "#shared/wire/voice-view";
+import type { PanelManager } from "../window/panel-manager";
+import { registerVoiceRuntimeIpc, type VoiceWindowSurface } from "./voice-runtime";
+
+/**
+ * The Clear at the IPC boundary, through the real registration: the voice
+ * window must be told at the fence, before the disk answers, and the panel
+ * must hear the disk's answer and nothing sooner.
+ */
+
+function fixture(clearConversation: () => Promise<boolean>) {
+  const invokes = new Map<string, (event: IpcMainInvokeEvent, ...args: unknown[]) => unknown>();
+  const sentToVoice: { channel: string; payload: WireRecord }[] = [];
+  // SAFETY: the registration reads senders by identity alone; two distinct inert objects are two windows.
+  const panelSender = {} as WebContents;
+  // SAFETY: as above, the second window.
+  const voiceSender = {} as WebContents;
+  // SAFETY: the Clear path reads only `owns` and `current().webContents.send` off the voice window surface.
+  const voiceWindow = {
+    owns: (sender: WebContents) => sender === voiceSender,
+    current: () => ({
+      webContents: {
+        send: (channel: string, payload: WireRecord) => {
+          sentToVoice.push({ channel, payload });
+        },
+      },
+    }),
+  } as unknown as VoiceWindowSurface;
+  // SAFETY: the Clear path reads only `owns` off the panel manager; the rest are inert stand-ins.
+  const panels = {
+    owns: (sender: WebContents) => sender === panelSender,
+    setVoiceExchange: () => undefined,
+    displayIdFor: () => undefined,
+    focusIfExpanded: () => undefined,
+  } as unknown as PanelManager;
+  registerVoiceRuntimeIpc({
+    ipcMain: {
+      handle: (channel, listener) => {
+        invokes.set(channel, listener);
+      },
+      // SAFETY: this inert fixture implements only the IpcMain return identity the listener API requires.
+      on: () => ({}) as Electron.IpcMain,
+    },
+    trustedSender: () => true,
+    panels,
+    voiceWindow,
+    broadcast: () => undefined,
+    openExternal: async () => undefined,
+    chooseRealtimeCredentials: () => undefined,
+    // SAFETY: the Clear path never reads diagnostics; an inert record stands in for a minter's.
+    unavailableDiagnostics: () => ({}) as never,
+    recordProductEvent: () => undefined,
+    recordAgentTrace: () => undefined,
+    storeVoiceView: () => undefined,
+    clearConversation,
+    setShortcutCapturing: () => undefined,
+  });
+  // SAFETY: the bridge reads only the sender off the event, and an Electron invoke listener always answers a promise.
+  const command = (sender: WebContents) =>
+    invokes.get(BRIDGE.voiceCommand.channel)?.(
+      { sender } as IpcMainInvokeEvent & IpcMainEvent,
+      VOICE_COMMAND.CLEAR_CONVERSATION,
+    ) as Promise<unknown>;
+  return { command, sentToVoice, panelSender, voiceSender };
+}
+
+test("the voice window is told to clear at the fence, before the disk answers, and the panel hears the disk's answer", async () => {
+  for (const erased of [true, false]) {
+    let fenced = false;
+    let release: ((erased: boolean) => void) | undefined;
+    const f = fixture(() => {
+      // The main helper fences in its synchronous prefix, then waits on disk.
+      fenced = true;
+      return new Promise<boolean>((resolve) => {
+        release = resolve;
+      });
+    });
+    const outcome = f.command(f.panelSender);
+    assert.equal(fenced, true);
+    assert.deepEqual(f.sentToVoice, [
+      { channel: channels.onVoiceCommand, payload: { command: VOICE_COMMAND.CLEAR_CONVERSATION } },
+    ]);
+    assert.ok(release, "the erasure is waiting on disk");
+    release(erased);
+    assert.equal(
+      await outcome,
+      erased ? VOICE_COMMAND_OUTCOME.ACCEPTED : VOICE_COMMAND_OUTCOME.REFUSED,
+    );
+    // The command went once; a slow disk does not send it again.
+    assert.equal(f.sentToVoice.length, 1);
+  }
+});
+
+test("a Clear from anything but a panel clears nothing and tells the voice window nothing", async () => {
+  let cleared = 0;
+  const f = fixture(async () => {
+    cleared += 1;
+    return true;
+  });
+  assert.equal(await f.command(f.voiceSender), undefined);
+  assert.equal(cleared, 0);
+  assert.deepEqual(f.sentToVoice, []);
+});

--- a/apps/desktop/src/main/ipc/voice-runtime.ts
+++ b/apps/desktop/src/main/ipc/voice-runtime.ts
@@ -61,8 +61,9 @@ export interface VoiceRuntimeIpcDependencies {
   storeVoiceView: (view: VoiceView) => void;
   /**
    * The History Clear, carried out here before the voice window is told, and
-   * answering whether the stored thread went — a thread that could not be
-   * deleted must not be half-forgotten by a voice window that was told anyway.
+   * answering whether the erasure completed on disk: the view and every
+   * context are emptied either way, and a false answer is what the panel
+   * shows as a Clear that did not finish.
    */
   clearConversation: () => boolean | Promise<boolean>;
   /** Whether a panel is recording a chord, which holds the talk and stop presses. */
@@ -78,21 +79,18 @@ export function registerVoiceRuntimeIpc(dependencies: VoiceRuntimeIpcDependencie
       // bounded it; here it is checked to come from a panel — the voice window
       // does not command itself — and handed on. A Clear is carried out here
       // first, because the main process is the thread's store and every
-      // panel's relay, and the voice window is told to retire its own turns
-      // only once the file has gone.
+      // panel's relay; the voice window is told to retire its own turns
+      // whatever the disk answered, because the fence stands either way, and
+      // the panel hears whether the erasure completed.
       async voiceCommand(context, command) {
         if (!panels.owns(context.sender)) return undefined;
-        if (
-          command === VOICE_COMMAND.CLEAR_CONVERSATION &&
-          !(await dependencies.clearConversation())
-        ) {
-          return VOICE_COMMAND_OUTCOME.REFUSED;
-        }
-        const host = voiceWindow.current();
-        host?.webContents.send(channels.onVoiceCommand, { command });
-        return command === VOICE_COMMAND.CLEAR_CONVERSATION
-          ? VOICE_COMMAND_OUTCOME.ACCEPTED
-          : undefined;
+        const erased =
+          command === VOICE_COMMAND.CLEAR_CONVERSATION
+            ? await dependencies.clearConversation()
+            : undefined;
+        voiceWindow.current()?.webContents.send(channels.onVoiceCommand, { command });
+        if (erased === undefined) return undefined;
+        return erased ? VOICE_COMMAND_OUTCOME.ACCEPTED : VOICE_COMMAND_OUTCOME.REFUSED;
       },
       // The voice window's snapshot: kept for a late panel, forwarded to every
       // panel, and read for the one level the main process owns — whether an

--- a/apps/desktop/src/main/ipc/voice-runtime.ts
+++ b/apps/desktop/src/main/ipc/voice-runtime.ts
@@ -79,18 +79,22 @@ export function registerVoiceRuntimeIpc(dependencies: VoiceRuntimeIpcDependencie
       // bounded it; here it is checked to come from a panel — the voice window
       // does not command itself — and handed on. A Clear is carried out here
       // first, because the main process is the thread's store and every
-      // panel's relay; the voice window is told to retire its own turns
-      // whatever the disk answered, because the fence stands either way, and
-      // the panel hears whether the erasure completed.
+      // panel's relay; the voice window is told to retire its own turns at
+      // the fence, whatever the disk later answers, and the panel hears
+      // whether the erasure completed.
       async voiceCommand(context, command) {
         if (!panels.owns(context.sender)) return undefined;
-        const erased =
+        // The Clear's fence is raised in the call's synchronous prefix, and
+        // the voice window is told in the same breath — before the disk is
+        // waited on — so its turns, marks, and context retire with main's.
+        // Its answer, the disk's, comes after and goes to the panel alone.
+        const erasing =
           command === VOICE_COMMAND.CLEAR_CONVERSATION
-            ? await dependencies.clearConversation()
+            ? dependencies.clearConversation()
             : undefined;
         voiceWindow.current()?.webContents.send(channels.onVoiceCommand, { command });
-        if (erased === undefined) return undefined;
-        return erased ? VOICE_COMMAND_OUTCOME.ACCEPTED : VOICE_COMMAND_OUTCOME.REFUSED;
+        if (erasing === undefined) return undefined;
+        return (await erasing) ? VOICE_COMMAND_OUTCOME.ACCEPTED : VOICE_COMMAND_OUTCOME.REFUSED;
       },
       // The voice window's snapshot: kept for a late panel, forwarded to every
       // panel, and read for the one level the main process owns — whether an

--- a/apps/desktop/src/main/ipc/voice-runtime.ts
+++ b/apps/desktop/src/main/ipc/voice-runtime.ts
@@ -64,7 +64,7 @@ export interface VoiceRuntimeIpcDependencies {
    * answering whether the stored thread went — a thread that could not be
    * deleted must not be half-forgotten by a voice window that was told anyway.
    */
-  clearConversation: () => boolean;
+  clearConversation: () => boolean | Promise<boolean>;
   /** Whether a panel is recording a chord, which holds the talk and stop presses. */
   setShortcutCapturing: (capturing: boolean) => void;
 }
@@ -80,12 +80,15 @@ export function registerVoiceRuntimeIpc(dependencies: VoiceRuntimeIpcDependencie
       // first, because the main process is the thread's store and every
       // panel's relay, and the voice window is told to retire its own turns
       // only once the file has gone.
-      voiceCommand(context, command) {
+      async voiceCommand(context, command) {
         if (!panels.owns(context.sender)) return undefined;
-        const host = voiceWindow.current();
-        if (command === VOICE_COMMAND.CLEAR_CONVERSATION && !dependencies.clearConversation()) {
+        if (
+          command === VOICE_COMMAND.CLEAR_CONVERSATION &&
+          !(await dependencies.clearConversation())
+        ) {
           return VOICE_COMMAND_OUTCOME.REFUSED;
         }
+        const host = voiceWindow.current();
         host?.webContents.send(channels.onVoiceCommand, { command });
         return command === VOICE_COMMAND.CLEAR_CONVERSATION
           ? VOICE_COMMAND_OUTCOME.ACCEPTED

--- a/apps/desktop/src/main/memory-flow.test.ts
+++ b/apps/desktop/src/main/memory-flow.test.ts
@@ -138,3 +138,22 @@ test("a spoken line tied to its run after it was relayed is enriched, not duplic
   main = mergeConversationHistory(main, again, undefined, now + 6);
   assert.equal(main.length, 2);
 });
+
+test("a stored thread drops every line at or before the last Clear's cutoff", () => {
+  const stored = JSON.stringify({
+    entries: [
+      { kind: "typed-ask", words: "before", recordedAt: 1_800_000_000_000 },
+      { kind: "reply", words: "at the cutoff", recordedAt: 1_800_000_000_500 },
+      { kind: "reply", words: "after", recordedAt: 1_800_000_000_501 },
+    ],
+  });
+  const now = 1_800_000_001_000;
+  assert.deepEqual(
+    conversationFromStored(stored, now, 1_800_000_000_500).map((entry) => entry.words),
+    ["after"],
+  );
+  assert.deepEqual(
+    conversationFromStored(stored, now).map((entry) => entry.words),
+    ["before", "at the cutoff", "after"],
+  );
+});

--- a/apps/desktop/src/main/memory-flow.ts
+++ b/apps/desktop/src/main/memory-flow.ts
@@ -28,18 +28,32 @@ export const REMEMBERED_FACTS_FILE = "memory.json";
  * Reads a stored thread, dropping lines that do not parse rather than the
  * whole file. A conversation is not load-bearing: half a thread beats none,
  * and a launch that cannot read the file at all simply begins with nothing,
- * which is what every launch did before this file existed.
+ * which is what every launch did before this file existed. A line recorded
+ * at or before the last Clear's cutoff — one the Clear's marker outlived
+ * because the thread's own erasure did not land before the launch ended — is
+ * dropped here as the Clear meant it to be.
  */
 export function conversationFromStored(
   stored: string | undefined,
   now: number,
+  clearedAt?: number,
 ): readonly ConversationEntry[] {
   const entries: ConversationEntry[] = [];
   for (const value of parsedList(stored, "entries")) {
     const entry = storedConversationEntry(value);
-    if (entry) entries.push(entry);
+    if (entry && conversationEntryAfterClear(entry, clearedAt)) entries.push(entry);
   }
   return retainedConversationEntries(entries, now);
+}
+
+/** Whether a line may stand given the last Clear: unclocked lines and lines after the cutoff may. */
+export function conversationEntryAfterClear(
+  entry: ConversationEntry,
+  clearedAt: number | undefined,
+): boolean {
+  return (
+    clearedAt === undefined || (entry.recordedAt !== undefined && entry.recordedAt > clearedAt)
+  );
 }
 
 /** The record a thread persists as, already retained so the file cannot outgrow the policy. */
@@ -54,8 +68,7 @@ export function mergeConversationHistory(
   clearedAt: number | undefined,
   now: number,
 ): readonly ConversationEntry[] {
-  const afterClear = (entry: ConversationEntry) =>
-    clearedAt === undefined || (entry.recordedAt !== undefined && entry.recordedAt > clearedAt);
+  const afterClear = (entry: ConversationEntry) => conversationEntryAfterClear(entry, clearedAt);
   const merged = current.filter(afterClear);
   const currentByKey = new Map<string, number[]>();
   merged.forEach((entry, index) => {

--- a/apps/desktop/src/main/speech-arbiter.test.ts
+++ b/apps/desktop/src/main/speech-arbiter.test.ts
@@ -404,3 +404,29 @@ test("every trace record carries a kind, a decision, and a count, and never the 
     assert.equal(JSON.stringify(record).includes("secret"), false);
   }
 });
+
+test("withdrawing briefings takes the queued, the held, and the offered alike, answers the offered id, and leaves beats standing", () => {
+  const { arbiter, clock } = harness();
+  requestBriefing(arbiter, "OFFERED_OLD");
+  requestBriefing(arbiter, "QUEUED_OLD");
+  arbiter.request({ kind: ARRIVAL_SPEECH_KIND });
+  const offer = arbiter.next();
+  assert.ok(offer && isBriefingSpeech(offer.turn) && offer.turn.briefing === "OFFERED_OLD");
+  arbiter.setQuiet(true);
+  requestBriefing(arbiter, "HELD_OLD");
+  // The quiet held the queued one too; the offered one is the mouth's.
+  assert.equal(arbiter.heldBriefingCount, 2);
+
+  assert.equal(arbiter.withdrawBriefings(), offer.id);
+  assert.equal(arbiter.offeredId, undefined);
+  assert.equal(arbiter.heldBriefingCount, 0);
+  assert.equal(arbiter.pendingCount, 1);
+  assert.deepEqual(arbiter.takeHeldBriefings(), []);
+  // The mouth's late report on the withdrawn offer is nobody's.
+  assert.equal(arbiter.settle(offer.id, SPEECH_OUTCOME.SPOKEN), undefined);
+  arbiter.setQuiet(false);
+  clock.now += 1;
+  assert.equal(offeredWords(arbiter), ARRIVAL_SPEECH_KIND);
+  // Nothing to withdraw answers nothing, and a beat is never a briefing.
+  assert.equal(arbiter.withdrawBriefings(), undefined);
+});

--- a/apps/desktop/src/main/speech-arbiter.ts
+++ b/apps/desktop/src/main/speech-arbiter.ts
@@ -224,6 +224,29 @@ export class SpeechArbiter {
   }
 
   /**
+   * Withdraws every briefing, the one the mouth holds included: the
+   * generation that decided them has been cleared or has died, and a
+   * briefing not yet spoken is that generation's words. An offer is not
+   * proof the words were said, so the offered one goes too, and its id is
+   * answered so the caller can take it back from the mouth; a settle that
+   * still arrives for it is a late report and is ignored. Speech already
+   * begun is the mouth's to finish.
+   */
+  withdrawBriefings(): string | undefined {
+    let offered: string | undefined;
+    for (const request of [...this.#pending]) {
+      if (request.kind !== BRIEFING_SPEECH_KIND) continue;
+      if (request.id === this.#offered?.id) {
+        offered = request.id;
+        this.#offered = undefined;
+      }
+      this.#remove(request.id);
+      this.#trace(BRIEFING_SPEECH_KIND, SPEECH_DECISION.DROPPED);
+    }
+    return offered;
+  }
+
+  /**
    * Removes a pending beat whose reason has gone — the gate it explained
    * stood down, the account it greeted signed out. Withdrawal does not spend
    * the kind. When the beat was the one offered, its id is returned so the

--- a/apps/desktop/src/renderer/luke-guide.ts
+++ b/apps/desktop/src/renderer/luke-guide.ts
@@ -410,9 +410,11 @@ export function buildLukeGuide(input: LukeGuideInput): AppGuideSnapshot {
       detail:
         "The panel's History tab shows every typed ask, transcribed spoken ask, reply, " +
         "announcement, and session act, kept across launches in Luke's own file on this Mac — " +
-        "up to 200 lines and 14 days, whichever cuts first. Luke carries only the 20 most " +
-        "recent entries into a call. The view is blocked from panel recordings, is not " +
-        "exportable, and can be cleared by hand from that tab. Luke's own composer stands at " +
+        "up to 200 lines and 14 days, whichever cuts first. The 20 most recent lines ride " +
+        "into a call beside Luke's working memory of what he read, said, and did, which lives " +
+        "in its own file on this Mac for exactly 14 days from when it began. The view is " +
+        "blocked from panel recordings, is not exportable, and can be cleared by hand from " +
+        "that tab, which discards the working memory with it. Luke's own composer stands at " +
         "its foot too, the same typed ask the sessions list offers, so a reply is asked for " +
         "where it will land. A spoken open still reaches only sessions currently observed.",
     },
@@ -438,8 +440,12 @@ export function buildLukeGuide(input: LukeGuideInput): AppGuideSnapshot {
       detail:
         "Asked what a local session did, said, or is stuck on, Luke can read that session's " +
         "own recent transcript — Claude Code, Codex, and OMP on this machine today — and " +
-        "answer from it; the reading is kept nowhere. A cloud session's conversation stays " +
-        "with its provider, answered from roster fields alone.",
+        "answer from it. He also reads what a local transcript gained on his own, when an " +
+        "agent's hook wakes him and on his periodic look at working and waiting sessions, " +
+        "so he can notice what changed. What he read stays in his working memory for at " +
+        "most 14 days, or until History is cleared, and never reaches an agent's own files. " +
+        "A cloud session's conversation stays with its provider, answered from roster " +
+        "fields alone.",
     },
     {
       label: "Creating workspaces",

--- a/apps/desktop/src/renderer/use-voice-view.ts
+++ b/apps/desktop/src/renderer/use-voice-view.ts
@@ -37,7 +37,8 @@ export function askDraftReason(result: BrainAskSubmissionResult | undefined): st
 }
 
 /** What the strip says when the stored thread could not be deleted. */
-export const CLEAR_FAILED_REASON = "Could not clear history. Try again.";
+export const CLEAR_FAILED_REASON =
+  "History was cleared from view, but its file could not be fully erased. Try again.";
 
 /**
  * How long a voice has been active, read off the relayed levels with the

--- a/apps/desktop/src/shared/wire/brain.ts
+++ b/apps/desktop/src/shared/wire/brain.ts
@@ -93,6 +93,8 @@ export const BRAIN_ASK_REFUSAL = {
     "I couldn't write that ask down, so I haven't taken it. Ask me again in a moment.",
   [BRAIN_SUBMISSION_REJECTION.CONFLICT]:
     "That ask arrived under an id I already have for different words. Ask it afresh.",
+  [BRAIN_SUBMISSION_REJECTION.FULL]:
+    "My notes are full of asks whose endings I haven't managed to file yet. Give me a moment and ask again.",
 } as const satisfies Record<BrainSubmissionRejection, string>;
 
 /** What the voice says while a run is still going when its wait ran out. */

--- a/packages/brain/src/brain-agent.test.ts
+++ b/packages/brain/src/brain-agent.test.ts
@@ -473,7 +473,8 @@ test("an ask returns the final text, carries pending wakes, and refuses announce
   assert.ok(opening.includes("tell the checkout agent to run the tests"));
   assert.ok(opening.includes(`${TRANSCRIPT_SECRET} for def`));
   assert.equal(h.agent.pendingWakes(), 0);
-  assert.equal(h.clock.timers.size, 0);
+  // The one timer left standing is the generation's own expiry.
+  assert.equal(h.clock.timers.size, 1);
   const outputs = itemsOfType(h.client.inputs[1] ?? [], RESPONSES_ITEM_TYPE.FUNCTION_CALL_OUTPUT);
   const refusal = outputs.find((item) => item.call_id === "call_a");
   assert.ok(refusal && isWireString(refusal.output) && refusal.output.includes("reply in text"));
@@ -1330,7 +1331,7 @@ test("the store's generation changing under a run revokes it and fences its late
   await settle();
   const execution = held.executions[0];
   assert.equal(execution?.isRevoked(), false);
-  assert.equal(await h.store.reset(), true);
+  assert.equal(await h.store.clear(), true);
   assert.equal(execution?.isRevoked(), true);
   assert.equal(h.agent.requests().length, 0);
   held.releases[0]?.();
@@ -1405,7 +1406,7 @@ test("a reset while the model is thinking cannot roll old memory into the new ge
   };
   const held = acceptedRunId(await submit(h, "and now?"));
   await settle();
-  assert.equal(await h.store.reset(), true);
+  assert.equal(await h.store.clear(), true);
   release?.(answered([message(`late answer about ${OLD_SECRET}`)]));
   await settle();
   assert.equal(h.agent.request(held), undefined);
@@ -1434,7 +1435,7 @@ test("a reset during a transcript read or an act's result cannot write into the 
   h.agent.wake([edge(ABC)]);
   await h.clock.advance(NOW + 3_000);
   assert.ok(releaseRead);
-  assert.equal(await h.store.reset(), true);
+  assert.equal(await h.store.clear(), true);
   releaseRead({
     status: ACT_RESULT_STATUS.ACCEPTED,
     text: OLD_SECRET,
@@ -1453,7 +1454,7 @@ test("a reset during a transcript read or an act's result cannot write into the 
   acting.client.answers.push(answered([messageAct("call_1", OLD_SECRET)]));
   const runId = acceptedRunId(await submit(acting, `send ${OLD_SECRET}`));
   await settle();
-  assert.equal(await acting.store.reset(), true);
+  assert.equal(await acting.store.clear(), true);
   held.releases[0]?.();
   await settle();
   acting.client.answers.push(answered([message("fresh")]));
@@ -1730,7 +1731,7 @@ test("work queued behind a held act opens nothing once the generation it was que
   h.agent.wake([edge(DEF)]);
   h.agent.rosterLook();
   await h.clock.advance(NOW + 3_000);
-  assert.equal(await h.store.reset(), true);
+  assert.equal(await h.store.clear(), true);
   assert.equal(h.agent.pendingWakes(), 0);
   held.releases[0]?.();
   await settle();
@@ -1778,7 +1779,7 @@ test("a briefing is not delivered after a stop or reset that lands during the tu
   const later = harness({
     deliver: async (delivery) => {
       later.deliveries.push(delivery);
-      await later.store.reset();
+      await later.store.clear();
     },
   });
   later.client.answers.push(
@@ -2492,4 +2493,154 @@ test("a cancel or stop landing while the start is being written ends the run uno
   assert.equal(seen[0]?.status, BRAIN_REQUEST_STATUS.CANCELLED);
   assert.equal(seen[0]?.performedActs, 0);
   assert.deepEqual(h.storage.stored()?.requests[0], h.agent.request(live));
+});
+
+const LIFETIME = 14 * 24 * 60 * 60 * 1000;
+
+test("a generation dies exactly one lifetime after its birth, on its own timer, revoking the turn it dies under", async () => {
+  const inner = new FakeClient();
+  const h = harness({ client: inner });
+  inner.answers.push(answered([message(`noted ${OLD_SECRET}`)]));
+  assert.equal((await ask(h, `remember ${OLD_SECRET}`))?.status, BRAIN_REQUEST_STATUS.SUCCEEDED);
+  const born = h.store.current();
+  assert.ok(born);
+  assert.equal(born.expiresAt, NOW + LIFETIME);
+
+  // Held mid-turn one millisecond before the end: still the same generation.
+  let release: ((answer: BrainClientAnswer) => void) | undefined;
+  inner.respond = (input, options) => {
+    inner.inputs.push([...input]);
+    inner.authorities.push(options.authority);
+    return new Promise((resolve) => {
+      release = resolve;
+    });
+  };
+  await h.clock.advance(born.expiresAt - 1);
+  const held = acceptedRunId(await submit(h, "and now?"));
+  await settle();
+  assert.equal(h.store.generationId(), born.generationId);
+  assert.ok(release, "the model holds the turn open");
+
+  // The expiry timer fires at the instant itself, under the held turn.
+  await h.clock.advance(born.expiresAt);
+  assert.notEqual(h.store.generationId(), born.generationId);
+  assert.equal(h.store.current()?.createdAt, born.expiresAt);
+  assert.equal(h.agent.request(held), undefined);
+  release?.(answered([message(`late ${OLD_SECRET}`)]));
+  await settle();
+
+  inner.respond = FakeClient.prototype.respond;
+  inner.answers.push(answered([message("fresh")]));
+  assert.equal((await ask(h, "NEW_ASK"))?.text, "fresh");
+  const surface = generationSurface(h, inner);
+  assert.ok(!surface.includes(OLD_SECRET), "expired memory reached the new generation");
+  assert.equal(h.storage.stored()?.generationId, h.store.generationId());
+  assert.equal(h.storage.stored()?.requests.length, 1);
+});
+
+test("an expiry is enforced at the door of a turn and a submission even when no timer fired", async () => {
+  // A stored generation past its time, found by a launch whose timers are
+  // never advanced: the ask is accepted into a fresh generation regardless.
+  const storage = new FakeStorage();
+  const stale: BrainPersistedState = {
+    ...freshBrainState("gen-stale", NOW - LIFETIME - 1),
+    items: [
+      { type: RESPONSES_ITEM_TYPE.COMPACTION, id: "cmp", encrypted_content: OLD_SECRET },
+      message(`after compaction ${OLD_SECRET}`),
+    ],
+    cursors: { [claude.id]: { abc: "old-cursor" } },
+  };
+  storage.file = `${JSON.stringify(stale)}\n`;
+  const h = harness({}, storage);
+  h.client.answers.push(answered([message("fresh")]));
+  const answer = await ask(h, "NEW_ASK");
+  assert.equal(answer?.text, "fresh");
+  assert.notEqual(h.store.generationId(), "gen-stale");
+  assert.ok(!generationSurface(h, h.client).includes(OLD_SECRET));
+  // The cursor died with the generation: the next look reads from the start.
+  h.client.answers.push(answered([message("")]));
+  h.agent.wake([edge(ABC)]);
+  await h.clock.advance(h.clock.now + 3_000);
+  assert.equal(h.sinceReads.at(-1)?.cursor, undefined);
+
+  // A generation that reaches its end while the app sits idle, with the
+  // clock advanced but the timer lost, still dies at the next turn's door.
+  const idle = harness();
+  idle.client.answers.push(answered([message("first")]));
+  assert.equal((await ask(idle, "first"))?.text, "first");
+  const born = idle.store.current();
+  assert.ok(born);
+  for (const timer of idle.clock.timers.keys()) idle.clock.timers.delete(timer);
+  idle.clock.now = born.expiresAt;
+  idle.client.answers.push(answered([message("")]));
+  idle.agent.wake([edge(ABC)]);
+  await idle.clock.advance(idle.clock.now + 3_000);
+  assert.notEqual(idle.store.generationId(), born.generationId);
+  assert.equal(idle.store.current()?.requests.length, 0);
+});
+
+test("a compaction and a fortnight of writes never extend a generation's life", async () => {
+  const h = harness();
+  h.client.answers.push(answered([message("one")]));
+  await ask(h, "one");
+  const born = h.store.current();
+  assert.ok(born);
+  await h.clock.advance(NOW + 7 * 24 * 60 * 60 * 1000);
+  h.client.answers.push(answered([compaction("cmp_1"), message("two")]));
+  await ask(h, "two");
+  assert.equal(h.traces.at(-1)?.compacted, true);
+  assert.equal(h.store.current()?.expiresAt, born.expiresAt);
+  assert.equal(h.store.current()?.createdAt, born.createdAt);
+  assert.equal(h.storage.stored()?.expiresAt, born.expiresAt);
+  await h.clock.advance(born.expiresAt - 1);
+  assert.equal(h.store.generationId(), born.generationId);
+  await h.clock.advance(born.expiresAt);
+  assert.notEqual(h.store.generationId(), born.generationId);
+});
+
+test("runs retention lets go of leave the live records and journal too, so the next checkpoint cannot bring them back", async () => {
+  const bounds = { MAXIMUM_TERMINAL_REQUESTS: 2, MAXIMUM_SERIALIZED_BYTES: 8 * 1024 * 1024 };
+  const storage = new FakeStorage();
+  const store = new BrainStateStore({
+    storage,
+    createGenerationId: () => "gen-bounded",
+    now: () => NOW,
+    bounds,
+  });
+  const h = harness({ store }, storage);
+  const runIds: string[] = [];
+  for (const words of ["a", "b", "c", "d"]) {
+    h.client.answers.push(answered([messageAct(`call_${words}`)]), answered([message(words)]));
+    const record = await ask(h, words);
+    assert.ok(record);
+    runIds.push(record.runId);
+    assert.equal(await h.agent.markHistoryRecorded(record.runId, h.clock.now), true);
+  }
+  const heard: (readonly BrainRequestRecord[])[] = [];
+  h.agent.subscribe((records) => heard.push(records));
+  // Retention ran inside the marks: only the newest two ended runs remain,
+  // in the file, in the live records, and in the journal the agent holds.
+  const stored = h.storage.stored();
+  assert.deepEqual(
+    stored?.requests.map((record) => record.runId),
+    runIds.slice(2),
+  );
+  assert.deepEqual(
+    h.agent.requests().map((record) => record.runId),
+    runIds.slice(2),
+  );
+  assert.deepEqual(new Set(stored?.journal.map((entry) => entry.runId)), new Set(runIds.slice(2)));
+  assert.equal(h.performed.length, 4);
+
+  // A later working checkpoint — an observation turn's — writes the agent's
+  // journal again, and the pruned runs stay gone.
+  h.client.answers.push(answered([message("")]));
+  h.agent.wake([edge(ABC)]);
+  await h.clock.advance(h.clock.now + 3_000);
+  const after = h.storage.stored();
+  assert.deepEqual(new Set(after?.journal.map((entry) => entry.runId)), new Set(runIds.slice(2)));
+  assert.deepEqual(
+    after?.requests.map((record) => record.runId),
+    runIds.slice(2),
+  );
 });

--- a/packages/brain/src/brain-agent.test.ts
+++ b/packages/brain/src/brain-agent.test.ts
@@ -36,6 +36,7 @@ import {
   type BrainClientAnswer,
   type BrainRespondOptions,
 } from "./brain-client.js";
+import { BrainGenerationClock } from "./brain-clock.js";
 import { BRAIN_WAKE_KIND, type BrainDelivery, type BrainWakeEvent } from "./brain-events.js";
 import { BRAIN_INPUT_MARKER } from "./brain-input.js";
 import { UNKNOWN_ACT_RESULT } from "./brain-journal.js";
@@ -473,8 +474,7 @@ test("an ask returns the final text, carries pending wakes, and refuses announce
   assert.ok(opening.includes("tell the checkout agent to run the tests"));
   assert.ok(opening.includes(`${TRANSCRIPT_SECRET} for def`));
   assert.equal(h.agent.pendingWakes(), 0);
-  // The one timer left standing is the generation's own expiry.
-  assert.equal(h.clock.timers.size, 1);
+  assert.equal(h.clock.timers.size, 0);
   const outputs = itemsOfType(h.client.inputs[1] ?? [], RESPONSES_ITEM_TYPE.FUNCTION_CALL_OUTPUT);
   const refusal = outputs.find((item) => item.call_id === "call_a");
   assert.ok(refusal && isWireString(refusal.output) && refusal.output.includes("reply in text"));
@@ -2497,9 +2497,16 @@ test("a cancel or stop landing while the start is being written ends the run uno
 
 const LIFETIME = 14 * 24 * 60 * 60 * 1000;
 
-test("a generation dies exactly one lifetime after its birth, on its own timer, revoking the turn it dies under", async () => {
+test("a generation dies exactly one lifetime after its birth, on the host's clock, revoking the turn it dies under", async () => {
   const inner = new FakeClient();
   const h = harness({ client: inner });
+  const generationClock = new BrainGenerationClock({
+    store: h.store,
+    now: () => h.clock.now,
+    schedule: h.clock.schedule,
+    cancel: h.clock.cancel,
+  });
+  await generationClock.start();
   inner.answers.push(answered([message(`noted ${OLD_SECRET}`)]));
   assert.equal((await ask(h, `remember ${OLD_SECRET}`))?.status, BRAIN_REQUEST_STATUS.SUCCEEDED);
   const born = h.store.current();
@@ -2536,6 +2543,7 @@ test("a generation dies exactly one lifetime after its birth, on its own timer, 
   assert.ok(!surface.includes(OLD_SECRET), "expired memory reached the new generation");
   assert.equal(h.storage.stored()?.generationId, h.store.generationId());
   assert.equal(h.storage.stored()?.requests.length, 1);
+  generationClock.stop();
 });
 
 test("an expiry is enforced at the door of a turn and a submission even when no timer fired", async () => {
@@ -2581,6 +2589,13 @@ test("an expiry is enforced at the door of a turn and a submission even when no 
 
 test("a compaction and a fortnight of writes never extend a generation's life", async () => {
   const h = harness();
+  const generationClock = new BrainGenerationClock({
+    store: h.store,
+    now: () => h.clock.now,
+    schedule: h.clock.schedule,
+    cancel: h.clock.cancel,
+  });
+  await generationClock.start();
   h.client.answers.push(answered([message("one")]));
   await ask(h, "one");
   const born = h.store.current();
@@ -2596,6 +2611,7 @@ test("a compaction and a fortnight of writes never extend a generation's life", 
   assert.equal(h.store.generationId(), born.generationId);
   await h.clock.advance(born.expiresAt);
   assert.notEqual(h.store.generationId(), born.generationId);
+  generationClock.stop();
 });
 
 test("runs retention lets go of leave the live records and journal too, so the next checkpoint cannot bring them back", async () => {
@@ -2695,6 +2711,13 @@ test("a Clear or expiry asked for while a write is out on disk revokes a held ac
       },
     };
     const h = harness({ acts });
+    const generationClock = new BrainGenerationClock({
+      store: h.store,
+      now: () => h.clock.now,
+      schedule: h.clock.schedule,
+      cancel: h.clock.cancel,
+    });
+    await generationClock.start();
     h.client.answers.push(answered([message("first")]));
     await ask(h, "first");
     const born = h.store.current();
@@ -2735,5 +2758,43 @@ test("a Clear or expiry asked for while a write is out on disk revokes a held ac
     assert.equal(h.store.current()?.journal.length, 0);
     assert.equal(h.storage.stored()?.generationId, h.store.generationId());
     assert.equal(h.storage.stored()?.requests.length, 0);
+    generationClock.stop();
   }
+});
+
+test("a Clear pressed while a starting agent's load is still reading the file leaves the fresh generation standing, never the file's", async () => {
+  let releaseRead: (() => void) | undefined;
+  const storage = new FakeStorage();
+  const old: BrainPersistedState = {
+    ...freshBrainState("gen-old", NOW - 1000),
+    items: [message(`kept ${OLD_SECRET}`)],
+  };
+  storage.file = `${JSON.stringify(old)}\n`;
+  const read = storage.read.bind(storage);
+  storage.read = () => {
+    // Only the load's read is held; the Clear's own look at the file answers at once.
+    storage.read = read;
+    // SAFETY: the store accepts a promise of the read; this test holds it open.
+    return new Promise<string | undefined>((resolve) => {
+      releaseRead = () => resolve(read());
+    }) as unknown as string | undefined;
+  };
+  const h = harness({}, storage);
+  const readying = h.agent.ready();
+  await settle();
+  assert.ok(releaseRead, "the load is reading the file");
+  const clearing = h.store.clear(NOW);
+  const fresh = h.store.generationId();
+  assert.notEqual(fresh, "gen-old");
+  releaseRead();
+  await readying;
+  assert.equal(await clearing, true);
+  // Store, agent, and disk agree on the successor; the file's memory is gone.
+  assert.equal(h.store.generationId(), fresh);
+  assert.deepEqual(h.agent.requests(), []);
+  h.client.answers.push(answered([message("fresh")]));
+  assert.equal((await ask(h, "NEW_ASK"))?.text, "fresh");
+  assert.equal(h.storage.stored()?.generationId, fresh);
+  assert.deepEqual(h.storage.stored()?.reset, { clearedAt: NOW, generationId: "gen-old" });
+  assert.ok(!generationSurface(h, h.client).includes(OLD_SECRET));
 });

--- a/packages/brain/src/brain-agent.test.ts
+++ b/packages/brain/src/brain-agent.test.ts
@@ -2644,3 +2644,96 @@ test("runs retention lets go of leave the live records and journal too, so the n
     runIds.slice(2),
   );
 });
+
+test("a generation at its record bound refuses a new ask at the door, and admits one again once an end reaches the thread", async () => {
+  const storage = new FakeStorage();
+  const store = new BrainStateStore({
+    storage,
+    createGenerationId: () => "gen-bounded",
+    now: () => NOW,
+    bounds: { MAXIMUM_TERMINAL_REQUESTS: 2, MAXIMUM_SERIALIZED_BYTES: 8 * 1024 * 1024 },
+  });
+  const h = harness({ store }, storage);
+  h.client.answers.push(answered([message("a")]), answered([message("b")]));
+  const first = await ask(h, "a");
+  const second = await ask(h, "b");
+  assert.ok(first && second);
+  assert.deepEqual(await submit(h, "c"), {
+    outcome: BRAIN_SUBMISSION_OUTCOME.REJECTED,
+    reason: BRAIN_SUBMISSION_REJECTION.FULL,
+  });
+  assert.equal(h.agent.requests().length, 2);
+  const heard: (readonly BrainRequestRecord[])[] = [];
+  h.agent.subscribe((records) => heard.push(records));
+  assert.equal(await h.agent.markHistoryRecorded(first.runId, NOW), true);
+  h.client.answers.push(answered([message("c")]));
+  const third = await ask(h, "c");
+  assert.equal(third?.text, "c");
+  // The subscriber heard the oldest run go when the third was admitted.
+  assert.ok(heard.some((records) => !records.some((record) => record.runId === first.runId)));
+  assert.deepEqual(
+    h.agent.requests().map((record) => record.runId),
+    [second.runId, third.runId],
+  );
+});
+
+test("a Clear or expiry asked for while a write is out on disk revokes a held act's preparation before the disk answers, and no effect dispatches", async () => {
+  for (const ending of ["clear", "expiry"] as const) {
+    let releaseWrite: (() => void) | undefined;
+    let releasePreparation: (() => void) | undefined;
+    let effects = 0;
+    const acts: BrainActPerformer = {
+      perform: async (_call, execution): Promise<WireRecord> => {
+        await new Promise<void>((resolve) => {
+          releasePreparation = resolve;
+        });
+        if (execution.isRevoked()) {
+          return { status: ACT_RESULT_STATUS.REJECTED, reason: "revoked before the effect" };
+        }
+        effects += 1;
+        return { status: ACT_RESULT_STATUS.ACCEPTED };
+      },
+    };
+    const h = harness({ acts });
+    h.client.answers.push(answered([message("first")]));
+    await ask(h, "first");
+    const born = h.store.current();
+    assert.ok(born);
+    // The act's start is durable; its preparation is held.
+    h.client.answers.push(answered([messageAct("call_1")]));
+    const runId = acceptedRunId(await submit(h, "send"));
+    await settle();
+    assert.ok(releasePreparation, "the performer holds the act");
+    assert.equal(h.storage.stored()?.journal.length, 1);
+    // A metadata write of another run is out on disk when the end is asked for.
+    const storage = h.storage;
+    const write = storage.write.bind(storage);
+    storage.write = (contents) =>
+      // SAFETY: the store accepts a promise of the write's outcome; this test holds it open.
+      new Promise<boolean>((resolve) => {
+        releaseWrite = () => resolve(write(contents));
+      }) as unknown as boolean;
+    const marking = h.agent.markHistoryRecorded(runId, NOW);
+    await settle();
+    assert.ok(releaseWrite, "a write is on disk");
+    storage.write = write;
+    if (ending === "clear") {
+      void h.store.clear(h.clock.now + 1);
+    } else {
+      await h.clock.advance(born.expiresAt);
+    }
+    // Fenced before the disk answered.
+    assert.equal(h.store.holdsGeneration(born.generationId), false);
+    assert.equal(h.agent.request(runId), undefined);
+    releasePreparation();
+    await settle();
+    releaseWrite();
+    await marking;
+    await settle();
+    await h.store.flush();
+    assert.equal(effects, 0, `${ending}: an effect dispatched after the fence`);
+    assert.equal(h.store.current()?.journal.length, 0);
+    assert.equal(h.storage.stored()?.generationId, h.store.generationId());
+    assert.equal(h.storage.stored()?.requests.length, 0);
+  }
+});

--- a/packages/brain/src/brain-agent.ts
+++ b/packages/brain/src/brain-agent.ts
@@ -544,7 +544,7 @@ export class BrainAgent {
    */
   async submitAsk(submission: BrainSubmission): Promise<BrainSubmissionResult> {
     await this.ready();
-    await this.#expireIfDue();
+    this.#expireIfDue();
     const generation = this.#generation;
     if (this.#stopped || !generation) {
       return {
@@ -578,6 +578,14 @@ export class BrainAgent {
             acceptedAt: existing.acceptedAt,
           }
         : conflict;
+    }
+    if (!this.#options.store.admits(generation.id)) {
+      // The record count is a hard bound on the file: a run the store could
+      // not then write is refused at the door, in a word the host can say.
+      return {
+        outcome: BRAIN_SUBMISSION_OUTCOME.REJECTED,
+        reason: BRAIN_SUBMISSION_REJECTION.FULL,
+      };
     }
     const result = this.#accept(generation, { ...submission, question });
     this.#pendingSubmissions.set(submission.submissionId, {
@@ -1032,7 +1040,7 @@ export class BrainAgent {
     const delay = Math.max(0, generation.expiresAt - this.#now());
     const fire = () => {
       this.#expiryTimer = undefined;
-      void this.#expireIfDue();
+      this.#expireIfDue();
     };
     // On the host's own clock the timer is unreferenced: housekeeping never
     // holds a process open on its own, and the door check covers a
@@ -1048,11 +1056,16 @@ export class BrainAgent {
     this.#expiryTimer = undefined;
   }
 
-  /** Asks the store to end the generation if its time has come; the store's announcement does the rest. */
-  async #expireIfDue(): Promise<void> {
+  /**
+   * Asks the store to end the generation if its time has come. The store's
+   * fence is synchronous and its announcement adopts the successor here in
+   * the same call, so by the time this returns the dead generation's signal
+   * has fired and nothing of it can open, dispatch, or deliver.
+   */
+  #expireIfDue(): void {
     const generation = this.#generation;
     if (this.#stopped || !generation || !brainGenerationExpired(generation, this.#now())) return;
-    await this.#options.store.expireIfDue(this.#now());
+    this.#options.store.expireIfDue(this.#now());
   }
 
   /**
@@ -1091,6 +1104,7 @@ export class BrainAgent {
   async #save(generation: Generation, scope: SaveScope): Promise<boolean> {
     let owned: BrainRequestRecord | undefined;
     let missing = false;
+    let pruned = false;
     const written = await this.#options.store.write(
       this.#lease,
       generation.id,
@@ -1135,6 +1149,7 @@ export class BrainAgent {
         if (commit.prunedRunIds.length > 0) {
           for (const runId of commit.prunedRunIds) generation.requests.delete(runId);
           generation.journal.dropRuns(commit.prunedRunIds);
+          pruned = true;
         }
         if (!owned || !scope.record) return;
         const live = generation.requests.get(owned.runId);
@@ -1151,6 +1166,9 @@ export class BrainAgent {
       this.#report("Brain memory could not be checkpointed");
       return false;
     }
+    // Runs retention let go of are gone from the list every window draws,
+    // and the windows hear it now rather than on the next unrelated change.
+    if (pruned) this.#notify();
     return true;
   }
 
@@ -1316,7 +1334,7 @@ export class BrainAgent {
     // The generation's death is checked at the door of every turn, so a
     // memory that outlived its fortnight while the app sat idle is not read
     // one more time on the way out.
-    await this.#expireIfDue();
+    this.#expireIfDue();
     const generation = plan.generation;
     // Work queued in a generation since replaced opens nothing: its briefings
     // and its wakes described a memory that no longer exists.

--- a/packages/brain/src/brain-agent.ts
+++ b/packages/brain/src/brain-agent.ts
@@ -460,7 +460,6 @@ export class BrainAgent {
   #queue: Promise<unknown> = Promise.resolve();
   #pending: BrainWakeEvent[] = [];
   #flushTimer: ScheduledTimer | undefined;
-  #expiryTimer: ScheduledTimer | undefined;
   #stopped = false;
   #unsubscribeStore: (() => void) | undefined;
 
@@ -823,7 +822,6 @@ export class BrainAgent {
   async stop(): Promise<void> {
     this.#stopped = true;
     this.#cancelFlush();
-    this.#disarmExpiry();
     this.#pending = [];
     this.#unsubscribeStore?.();
     this.#unsubscribeStore = undefined;
@@ -970,9 +968,15 @@ export class BrainAgent {
       );
       return;
     }
+    // A generation adopted from the store's announcement while the load was
+    // out — a Clear or expiry pressed under a starting agent — is the one
+    // that stands; the loaded copy is not built over it.
+    const adopted = this.#generation;
+    const current = this.#options.store.current() ?? state;
+    if (adopted && adopted.id === current.generationId) return;
+    state = current;
     const generation = generationFrom(state);
     this.#generation = generation;
-    this.#armExpiry(generation);
     const interrupted = interruptedUnfinishedRequests(state.requests, this.#now());
     const paired = pairedDanglingCalls(state.items, () => JSON.stringify(UNKNOWN_ACT_RESULT));
     if (interrupted === state.requests && paired === state.items) return;
@@ -1023,41 +1027,14 @@ export class BrainAgent {
     this.#cancelFlush();
     this.#pending = [];
     this.#generation = generationFrom(state);
-    this.#armExpiry(this.#generation);
     this.#notify();
   }
 
   /**
-   * The generation's own clock. Its lifetime was fixed when it was born and
-   * no write moves it, so the timer is armed once per adopted generation, at
-   * the instant the store will agree it has died; firing asks the store,
-   * which is the one judge of the moment, and a generation that dies mid-turn
-   * is replaced under the turn exactly as a Clear would replace it.
-   */
-  #armExpiry(generation: Generation): void {
-    this.#disarmExpiry();
-    if (this.#stopped) return;
-    const delay = Math.max(0, generation.expiresAt - this.#now());
-    const fire = () => {
-      this.#expiryTimer = undefined;
-      this.#expireIfDue();
-    };
-    // On the host's own clock the timer is unreferenced: housekeeping never
-    // holds a process open on its own, and the door check covers a
-    // generation found dead at the next launch.
-    this.#expiryTimer = this.#options.schedule
-      ? this.#schedule(fire, delay)
-      : globalThis.setTimeout(fire, delay).unref();
-  }
-
-  #disarmExpiry(): void {
-    if (this.#expiryTimer === undefined) return;
-    this.#cancel(this.#expiryTimer);
-    this.#expiryTimer = undefined;
-  }
-
-  /**
-   * Asks the store to end the generation if its time has come. The store's
+   * Asks the store to end the generation if its time has come: the door
+   * check, for a generation that outlived its fortnight while nothing kept
+   * its clock. The clock itself — a timer at the expiry instant — is the
+   * host's, one per store, standing whether or not an agent does. The store's
    * fence is synchronous and its announcement adopts the successor here in
    * the same call, so by the time this returns the dead generation's signal
    * has fired and nothing of it can open, dispatch, or deliver.

--- a/packages/brain/src/brain-agent.ts
+++ b/packages/brain/src/brain-agent.ts
@@ -55,7 +55,12 @@ import {
   interruptedUnfinishedRequests,
   isTerminalBrainRequestStatus,
 } from "./brain-requests.js";
-import type { BrainPersistedState, BrainStateStore, BrainStoreLease } from "./brain-state.js";
+import {
+  type BrainPersistedState,
+  type BrainStateStore,
+  type BrainStoreLease,
+  brainGenerationExpired,
+} from "./brain-state.js";
 import {
   BRAIN_TOOL,
   brainToolAllowed,
@@ -259,6 +264,7 @@ type TurnResult =
  */
 interface Generation {
   id: string;
+  expiresAt: number;
   memory: BrainMemory;
   journal: BrainJournal;
   requests: Map<string, BrainRequestRecord>;
@@ -420,6 +426,7 @@ function rejection(reason: string): WireRecord {
 function generationFrom(state: BrainPersistedState): Generation {
   return {
     id: state.generationId,
+    expiresAt: state.expiresAt,
     memory: new BrainMemory({ items: state.items, cursors: state.cursors }),
     journal: new BrainJournal(state.journal),
     requests: new Map(state.requests.map((record) => [record.runId, { ...record }])),
@@ -453,6 +460,7 @@ export class BrainAgent {
   #queue: Promise<unknown> = Promise.resolve();
   #pending: BrainWakeEvent[] = [];
   #flushTimer: ScheduledTimer | undefined;
+  #expiryTimer: ScheduledTimer | undefined;
   #stopped = false;
   #unsubscribeStore: (() => void) | undefined;
 
@@ -536,6 +544,7 @@ export class BrainAgent {
    */
   async submitAsk(submission: BrainSubmission): Promise<BrainSubmissionResult> {
     await this.ready();
+    await this.#expireIfDue();
     const generation = this.#generation;
     if (this.#stopped || !generation) {
       return {
@@ -806,6 +815,7 @@ export class BrainAgent {
   async stop(): Promise<void> {
     this.#stopped = true;
     this.#cancelFlush();
+    this.#disarmExpiry();
     this.#pending = [];
     this.#unsubscribeStore?.();
     this.#unsubscribeStore = undefined;
@@ -954,6 +964,7 @@ export class BrainAgent {
     }
     const generation = generationFrom(state);
     this.#generation = generation;
+    this.#armExpiry(generation);
     const interrupted = interruptedUnfinishedRequests(state.requests, this.#now());
     const paired = pairedDanglingCalls(state.items, () => JSON.stringify(UNKNOWN_ACT_RESULT));
     if (interrupted === state.requests && paired === state.items) return;
@@ -1004,7 +1015,44 @@ export class BrainAgent {
     this.#cancelFlush();
     this.#pending = [];
     this.#generation = generationFrom(state);
+    this.#armExpiry(this.#generation);
     this.#notify();
+  }
+
+  /**
+   * The generation's own clock. Its lifetime was fixed when it was born and
+   * no write moves it, so the timer is armed once per adopted generation, at
+   * the instant the store will agree it has died; firing asks the store,
+   * which is the one judge of the moment, and a generation that dies mid-turn
+   * is replaced under the turn exactly as a Clear would replace it.
+   */
+  #armExpiry(generation: Generation): void {
+    this.#disarmExpiry();
+    if (this.#stopped) return;
+    const delay = Math.max(0, generation.expiresAt - this.#now());
+    const fire = () => {
+      this.#expiryTimer = undefined;
+      void this.#expireIfDue();
+    };
+    // On the host's own clock the timer is unreferenced: housekeeping never
+    // holds a process open on its own, and the door check covers a
+    // generation found dead at the next launch.
+    this.#expiryTimer = this.#options.schedule
+      ? this.#schedule(fire, delay)
+      : globalThis.setTimeout(fire, delay).unref();
+  }
+
+  #disarmExpiry(): void {
+    if (this.#expiryTimer === undefined) return;
+    this.#cancel(this.#expiryTimer);
+    this.#expiryTimer = undefined;
+  }
+
+  /** Asks the store to end the generation if its time has come; the store's announcement does the rest. */
+  async #expireIfDue(): Promise<void> {
+    const generation = this.#generation;
+    if (this.#stopped || !generation || !brainGenerationExpired(generation, this.#now())) return;
+    await this.#options.store.expireIfDue(this.#now());
   }
 
   /**
@@ -1080,7 +1128,14 @@ export class BrainAgent {
           requests,
         };
       },
-      () => {
+      (commit) => {
+        // Retention decided inside the same queue step: the runs the store
+        // let go of leave the working copy too, or the next checkpoint of
+        // the journal would write them straight back.
+        if (commit.prunedRunIds.length > 0) {
+          for (const runId of commit.prunedRunIds) generation.requests.delete(runId);
+          generation.journal.dropRuns(commit.prunedRunIds);
+        }
         if (!owned || !scope.record) return;
         const live = generation.requests.get(owned.runId);
         if (live) {
@@ -1258,6 +1313,10 @@ export class BrainAgent {
 
   async #turn(plan: TurnPlan): Promise<TurnResult> {
     await this.ready();
+    // The generation's death is checked at the door of every turn, so a
+    // memory that outlived its fortnight while the app sat idle is not read
+    // one more time on the way out.
+    await this.#expireIfDue();
     const generation = plan.generation;
     // Work queued in a generation since replaced opens nothing: its briefings
     // and its wakes described a memory that no longer exists.

--- a/packages/brain/src/brain-clock.ts
+++ b/packages/brain/src/brain-clock.ts
@@ -1,0 +1,81 @@
+import type { ScheduledTimer } from "@sidecar/realtime";
+import {
+  type BrainPersistedState,
+  type BrainStateStore,
+  brainGenerationExpired,
+} from "./brain-state.js";
+
+export interface BrainGenerationClockOptions {
+  store: BrainStateStore;
+  now?: () => number;
+  schedule?: (callback: () => void, delayMs: number) => ScheduledTimer;
+  cancel?: (timer: ScheduledTimer) => void;
+}
+
+/**
+ * The generation's clock: one timer per store, armed at the standing
+ * generation's expiry instant and re-armed whenever the store begins another,
+ * so a generation dies on time whether or not an agent stands to check its
+ * door — a key removed, an account signed out, or an app left open past the
+ * fortnight all leave the file to this. Starting it loads the store, which is
+ * also where a file found expired, unreadable, or past its bounds at launch
+ * is replaced on disk. Firing asks the store, the one judge of the moment;
+ * an agent's own door check asking first costs nothing. On the host's own
+ * timers the clock is unreferenced: housekeeping never holds a process open,
+ * and the next launch's load covers a generation found dead.
+ */
+export class BrainGenerationClock {
+  readonly #store: BrainStateStore;
+  readonly #now: () => number;
+  readonly #schedule: (callback: () => void, delayMs: number) => ScheduledTimer;
+  readonly #cancel: (timer: ScheduledTimer) => void;
+  #timer: ScheduledTimer | undefined;
+  #unsubscribe: (() => void) | undefined;
+  #stopped = false;
+
+  constructor(options: BrainGenerationClockOptions) {
+    this.#store = options.store;
+    this.#now = options.now ?? Date.now;
+    this.#schedule =
+      options.schedule ?? ((callback, delayMs) => globalThis.setTimeout(callback, delayMs).unref());
+    this.#cancel =
+      options.cancel ??
+      ((timer) => {
+        // SAFETY: a timer this clock scheduled itself came from setTimeout above.
+        globalThis.clearTimeout(timer as ReturnType<typeof setTimeout>);
+      });
+  }
+
+  /** Loads the store, arms the timer for the generation that stands, and follows every replacement. */
+  async start(): Promise<void> {
+    this.#unsubscribe ??= this.#store.onReplaced((state) => this.#arm(state));
+    const state = await this.#store.load();
+    if (!this.#stopped) this.#arm(this.#store.current() ?? state);
+  }
+
+  stop(): void {
+    this.#stopped = true;
+    this.#disarm();
+    this.#unsubscribe?.();
+    this.#unsubscribe = undefined;
+  }
+
+  #arm(state: BrainPersistedState): void {
+    this.#disarm();
+    if (this.#stopped) return;
+    if (brainGenerationExpired(state, this.#now())) {
+      this.#store.expireIfDue(this.#now());
+      return;
+    }
+    this.#timer = this.#schedule(() => {
+      this.#timer = undefined;
+      this.#store.expireIfDue(this.#now());
+    }, state.expiresAt - this.#now());
+  }
+
+  #disarm(): void {
+    if (this.#timer === undefined) return;
+    this.#cancel(this.#timer);
+    this.#timer = undefined;
+  }
+}

--- a/packages/brain/src/brain-requests.ts
+++ b/packages/brain/src/brain-requests.ts
@@ -203,6 +203,8 @@ export const BRAIN_SUBMISSION_REJECTION = {
   PERSISTENCE: "persistence",
   /** The submission id is already taken by an ask with other words or another origin. */
   CONFLICT: "conflict",
+  /** The generation holds as many records as it may, and none is yet eligible to be let go. */
+  FULL: "full",
 } as const;
 
 export type BrainSubmissionRejection =

--- a/packages/brain/src/brain-state.test.ts
+++ b/packages/brain/src/brain-state.test.ts
@@ -8,10 +8,12 @@ import {
   type BrainPersistedState,
   type BrainStateStorage,
   BrainStateStore,
+  brainGenerationExpired,
   brainPersistedStateFromWire,
   brainStateFromStored,
   brainStateRecord,
   freshBrainState,
+  retainedBrainState,
 } from "./brain-state.js";
 
 const NOW = 1_800_000_000_000;
@@ -134,13 +136,21 @@ test("the store loads once, serializes writes, and fences a write against a repl
 
   const replaced: BrainPersistedState[] = [];
   store.onReplaced((state) => replaced.push(state));
-  assert.equal(await store.reset(), true);
-  assert.equal(storage.file, undefined);
+  assert.equal(await store.clear(), true);
+  // The file now holds the empty successor and the content-free marker of
+  // the erasure, and nothing of the generation that was cleared.
+  const afterClear = brainStateFromStored(storage.file);
+  assert.deepEqual(afterClear?.reset, { generationId: "gen-1", clearedAt: NOW });
+  assert.deepEqual(afterClear?.cursors, {});
+  assert.ok(!String(storage.read()).includes('"s":"1"'));
   assert.equal(store.generationId(), "gen-2");
+  assert.deepEqual(store.resetMarker(), { generationId: "gen-1", clearedAt: NOW });
+  assert.equal(store.holdsGeneration("gen-1"), false);
+  assert.equal(store.holdsGeneration("gen-2"), true);
   assert.equal(replaced[0]?.generationId, "gen-2");
   // A writer still holding the old generation lands nowhere.
   assert.equal(await store.write(lease, "gen-1", (state) => state), false);
-  assert.equal(storage.log.filter((entry) => entry === "write").length, 2);
+  assert.equal(storage.log.filter((entry) => entry === "write").length, 3);
   assert.equal(await store.write(lease, "gen-2", (state) => state), true);
 
   // Storage refusing leaves the held copy as it was.
@@ -162,4 +172,265 @@ test("the store loads once, serializes writes, and fences a write against a repl
   assert.equal(store.generationId(), "gen-9");
   assert.equal(replaced.at(-1)?.generationId, "gen-9");
   await store.flush();
+});
+
+function terminal(index: number, overrides: Partial<BrainPersistedState["requests"][number]> = {}) {
+  const base = complete().requests[0];
+  assert.ok(base);
+  return {
+    ...base,
+    runId: `run-${index}`,
+    submissionId: `sub-${index}`,
+    acceptedAt: NOW + index,
+    settledAt: NOW + index + 1,
+    historyRecordedAt: NOW + index + 2,
+    ...overrides,
+  };
+}
+
+function journalFor(runId: string, calls = 1) {
+  return Array.from({ length: calls }, (_, index) => ({
+    runId,
+    callId: `${runId}-call-${index}`,
+    name: "send_session_message",
+    argumentsJson: "{}",
+    startedAt: NOW,
+    outputJson: '{"status":"accepted"}',
+    settledAt: NOW + 1,
+  }));
+}
+
+test("a generation is expired at its expiry instant exactly, and not one millisecond before", () => {
+  const state = freshBrainState("gen-1", NOW);
+  assert.equal(brainGenerationExpired(state, state.expiresAt - 1), false);
+  assert.equal(brainGenerationExpired(state, state.expiresAt), true);
+  assert.equal(brainGenerationExpired(state, state.expiresAt + 1), true);
+  assert.equal(state.expiresAt, NOW + 14 * 24 * 60 * 60 * 1000);
+});
+
+test("the reset marker round-trips, and a marker that is present but unreadable fails the whole envelope", () => {
+  const cleared: BrainPersistedState = {
+    ...freshBrainState("gen-2", NOW),
+    reset: { generationId: "gen-1", clearedAt: NOW - 5 },
+  };
+  assert.deepEqual(brainStateFromStored(brainStateRecord(cleared)), cleared);
+  const read = (value: WireBoundaryInput) => brainPersistedStateFromWire(unparsedWire(value));
+  assert.equal(read({ ...raw(cleared), reset: { generationId: "" } }), undefined);
+  assert.equal(
+    read({ ...raw(cleared), reset: { generationId: "gen-1", clearedAt: -1 } }),
+    undefined,
+  );
+  assert.equal(read({ ...raw(cleared), reset: "gone" }), undefined);
+});
+
+test("the store discards an expired file at load rather than giving old memory a fresh lifetime", async () => {
+  const stale = complete();
+  const storage = new MemoryStorage();
+  storage.file = brainStateRecord(stale);
+  let clock = stale.expiresAt - 1;
+  const fresh = () =>
+    new BrainStateStore({ storage, createGenerationId: () => "gen-new", now: () => clock });
+  assert.equal((await fresh().load()).generationId, "gen-1");
+  clock = stale.expiresAt;
+  const loaded = await fresh().load();
+  assert.equal(loaded.generationId, "gen-new");
+  assert.deepEqual(
+    [loaded.items, loaded.cursors, loaded.requests, loaded.journal],
+    [[], {}, [], []],
+  );
+  assert.equal(loaded.reset, undefined);
+  assert.equal(loaded.createdAt, clock);
+});
+
+test("writes and a compaction never move the expiry, and expireIfDue ends the generation on time", async () => {
+  const storage = new MemoryStorage();
+  let generations = 0;
+  let clock = NOW;
+  const store = new BrainStateStore({
+    storage,
+    createGenerationId: () => `gen-${++generations}`,
+    now: () => clock,
+  });
+  const lease = store.lease();
+  const born = await store.load();
+  clock = NOW + 10 * 24 * 60 * 60 * 1000;
+  assert.equal(
+    await store.write(lease, "gen-1", (state) => ({
+      ...state,
+      items: [{ type: "compaction", id: "cmp", encrypted_content: "OLD_COMPACTION_SECRET" }],
+      cursors: { p: { s: "9" } },
+    })),
+    true,
+  );
+  assert.equal(store.current()?.expiresAt, born.expiresAt);
+  assert.equal(store.current()?.createdAt, born.createdAt);
+  assert.equal(brainStateFromStored(storage.file)?.expiresAt, born.expiresAt);
+
+  const replaced: BrainPersistedState[] = [];
+  store.onReplaced((state) => replaced.push(state));
+  assert.equal(await store.expireIfDue(born.expiresAt - 1), false);
+  assert.equal(store.generationId(), "gen-1");
+  assert.equal(await store.expireIfDue(born.expiresAt), true);
+  assert.equal(store.generationId(), "gen-2");
+  assert.equal(replaced[0]?.generationId, "gen-2");
+  assert.equal(replaced[0]?.createdAt, born.expiresAt);
+  // The encrypted compaction and the cursors went with the generation, from
+  // memory and from the file both.
+  assert.ok(!String(storage.read()).includes("OLD_COMPACTION_SECRET"));
+  assert.deepEqual(store.current()?.items, []);
+  assert.deepEqual(store.current()?.cursors, {});
+  assert.equal(await store.write(lease, "gen-1", (state) => state), false);
+  assert.equal(await store.expireIfDue(born.expiresAt), false);
+});
+
+test("retention keeps the newest 200 ended runs, lets their journals go with them, and never touches a run still going", () => {
+  const requests = [
+    ...Array.from({ length: 205 }, (_, index) => terminal(index)),
+    terminal(900, { status: BRAIN_REQUEST_STATUS.RUNNING, settledAt: undefined }),
+    terminal(901, { status: BRAIN_REQUEST_STATUS.QUEUED, settledAt: undefined }),
+  ];
+  const journal = requests.flatMap((record) => journalFor(record.runId));
+  const retained = retainedBrainState({ ...freshBrainState("gen-1", NOW), requests, journal });
+  assert.deepEqual(retained.prunedRunIds, ["run-0", "run-1", "run-2", "run-3", "run-4"]);
+  assert.equal(retained.state.requests.length, 202);
+  assert.ok(retained.state.requests.some((record) => record.runId === "run-900"));
+  assert.ok(retained.state.requests.some((record) => record.runId === "run-901"));
+  assert.ok(!retained.state.requests.some((record) => record.runId === "run-0"));
+  assert.ok(!retained.state.journal.some((entry) => entry.runId === "run-0"));
+  assert.ok(retained.state.journal.some((entry) => entry.runId === "run-900"));
+  assert.equal(retained.oversized, false);
+});
+
+test("an ended run whose end the thread has not taken is kept past the count, however old", () => {
+  const requests = Array.from({ length: 203 }, (_, index) =>
+    terminal(index, index < 3 ? { historyRecordedAt: undefined } : {}),
+  );
+  const retained = retainedBrainState({ ...freshBrainState("gen-1", NOW), requests, journal: [] });
+  // The three unpublished are the oldest, yet the next three go instead.
+  assert.deepEqual(retained.prunedRunIds, ["run-3", "run-4", "run-5"]);
+  assert.equal(retained.state.requests.length, 200);
+});
+
+test("the byte cap prunes eligible ended runs first, and refuses a write that would still grow an oversized envelope", async () => {
+  const bounds = { MAXIMUM_TERMINAL_REQUESTS: 200, MAXIMUM_SERIALIZED_BYTES: 4_000 } as const;
+  const storage = new MemoryStorage();
+  const store = new BrainStateStore({
+    storage,
+    createGenerationId: () => "gen-1",
+    now: () => NOW,
+    bounds,
+  });
+  const lease = store.lease();
+  await store.load();
+  const big = (index: number) => terminal(index, { text: "x".repeat(600) });
+  const journal = [0, 1, 2, 3].flatMap((index) => journalFor(`run-${index}`));
+  const pruned: string[][] = [];
+  assert.equal(
+    await store.write(
+      lease,
+      "gen-1",
+      (state) => ({ ...state, requests: [big(0), big(1), big(2), big(3)], journal }),
+      (commit) => pruned.push([...commit.prunedRunIds]),
+    ),
+    true,
+  );
+  // Oldest ended runs went, journals with them, until the envelope fit.
+  assert.ok((pruned[0]?.length ?? 0) > 0);
+  assert.deepEqual(pruned[0], pruned[0]?.slice().sort());
+  assert.ok(pruned[0]?.includes("run-0"));
+  const held = store.current();
+  assert.ok(held);
+  for (const runId of pruned[0] ?? []) {
+    assert.ok(!held.requests.some((record) => record.runId === runId));
+    assert.ok(!held.journal.some((entry) => entry.runId === runId));
+  }
+  assert.ok(brainStateRecord(held).length <= bounds.MAXIMUM_SERIALIZED_BYTES);
+
+  // A running run's checkpoint cannot be pruned: growth past the cap with
+  // nothing eligible left is refused, and the held copy and file stand.
+  const active = terminal(50, {
+    status: BRAIN_REQUEST_STATUS.RUNNING,
+    settledAt: undefined,
+    text: "y".repeat(5_000),
+  });
+  const before = storage.file;
+  assert.equal(
+    await store.write(lease, "gen-1", (state) => ({
+      ...state,
+      requests: [...state.requests, active],
+    })),
+    false,
+  );
+  assert.equal(storage.file, before);
+  assert.equal(
+    store.current()?.requests.some((record) => record.runId === "run-50"),
+    false,
+  );
+
+  // A write that does not grow an already-oversized envelope still lands.
+  const oversizedStore = new BrainStateStore({
+    storage: new MemoryStorage(),
+    createGenerationId: () => "gen-1",
+    now: () => NOW,
+    bounds: { MAXIMUM_TERMINAL_REQUESTS: 200, MAXIMUM_SERIALIZED_BYTES: 400 },
+  });
+  const oversizedLease = oversizedStore.lease();
+  await oversizedStore.load();
+  const items = Array.from({ length: 5 }, (_, index) => ({
+    type: "message",
+    role: "user",
+    content: `${index}${"z".repeat(200)}`,
+  }));
+  assert.equal(
+    await oversizedStore.write(oversizedLease, "gen-1", (state) => ({ ...state, items })),
+    false,
+  );
+  assert.equal(
+    await oversizedStore.write(oversizedLease, "gen-1", (state) => ({
+      ...state,
+      items: [{ type: "compaction", id: "cmp", encrypted_content: "z".repeat(600) }],
+    })),
+    false,
+    "the first oversized write has nothing to shrink from",
+  );
+  assert.deepEqual(oversizedStore.current()?.items, []);
+});
+
+test("a Clear whose marker the storage refuses still fences the old generation and answers incomplete", async () => {
+  const storage = new MemoryStorage();
+  let generations = 0;
+  const store = new BrainStateStore({
+    storage,
+    createGenerationId: () => `gen-${++generations}`,
+    now: () => NOW,
+  });
+  const lease = store.lease();
+  await store.load();
+  assert.equal(
+    await store.write(lease, "gen-1", (state) => ({
+      ...state,
+      items: [{ type: "message", role: "user", content: "OLD_GENERATION_SECRET" }],
+    })),
+    true,
+  );
+  const replaced: string[] = [];
+  store.onReplaced((state) => replaced.push(state.generationId));
+  storage.refuse = true;
+  assert.equal(await store.clear(NOW + 1), false);
+  // Fenced and forgotten in memory, announced to every listener; the file
+  // still holds the old content, which is what "incomplete" reports.
+  assert.deepEqual(replaced, ["gen-2"]);
+  assert.equal(store.holdsGeneration("gen-1"), false);
+  assert.deepEqual(store.current()?.items, []);
+  assert.deepEqual(store.resetMarker(), { generationId: "gen-1", clearedAt: NOW + 1 });
+  assert.ok(String(storage.read()).includes("OLD_GENERATION_SECRET"));
+  assert.equal(await store.write(lease, "gen-1", (state) => state), false);
+  // The next write that lands supersedes the old content entirely.
+  storage.refuse = false;
+  assert.equal(await store.write(lease, "gen-2", (state) => state), true);
+  assert.ok(!String(storage.read()).includes("OLD_GENERATION_SECRET"));
+  assert.deepEqual(brainStateFromStored(storage.file)?.reset, {
+    generationId: "gen-1",
+    clearedAt: NOW + 1,
+  });
 });

--- a/packages/brain/src/brain-state.test.ts
+++ b/packages/brain/src/brain-state.test.ts
@@ -92,7 +92,7 @@ class MemoryStorage implements BrainStateStorage {
   file: string | undefined;
   refuse = false;
   readonly log: string[] = [];
-  read() {
+  read(): string | undefined | Promise<string | undefined> {
     this.log.push("read");
     return this.file;
   }
@@ -464,7 +464,9 @@ class HeldStorage extends MemoryStorage {
       this.#release = () => resolve(super.write(contents));
     });
   }
+  /** Releases the held write, or cancels a hold no write has taken yet. */
   release() {
+    this.holdNext = false;
     this.#release?.();
     this.#release = undefined;
   }
@@ -681,3 +683,161 @@ test("the record count is a hard bound: admission closes at capacity and a write
   assert.equal(store.admits("gen-1"), true);
   assert.equal(store.admits("gen-other"), false);
 });
+
+/** Storage whose next read waits until the test releases it. */
+class HeldReadStorage extends MemoryStorage {
+  #release: (() => void) | undefined;
+  holdNextRead = false;
+  override read(): string | undefined | Promise<string | undefined> {
+    if (!this.holdNextRead) return super.read();
+    this.holdNextRead = false;
+    return new Promise<string | undefined>((resolve) => {
+      this.#release = () => resolve(super.read());
+    });
+  }
+  release() {
+    this.holdNextRead = false;
+    this.#release?.();
+    this.#release = undefined;
+  }
+  get holding() {
+    return this.#release !== undefined;
+  }
+}
+
+test("a load whose read was out when a Clear landed adopts the successor, never the file, and the marker still lands", async () => {
+  for (const refuseDisk of [false, true]) {
+    const storage = new HeldReadStorage();
+    storage.file = brainStateRecord({
+      ...complete(),
+      items: [{ type: "message", role: "user", content: "OLD_LOAD_SECRET" }],
+    });
+    let generations = 0;
+    const store = new BrainStateStore({
+      storage,
+      createGenerationId: () => `fresh-${++generations}`,
+      now: () => NOW,
+    });
+    const heard: string[] = [];
+    store.onReplaced((state) => heard.push(state.generationId));
+    storage.holdNextRead = true;
+    const loading = store.load();
+    await Promise.resolve();
+    assert.ok(storage.holding);
+    const clearing = store.clear(NOW + 1);
+    assert.equal(store.generationId(), "fresh-1");
+    storage.refuse = refuseDisk;
+    storage.release();
+    const loaded = await loading;
+    assert.equal(loaded.generationId, "fresh-1");
+    assert.equal(await clearing, !refuseDisk);
+    assert.equal(store.generationId(), "fresh-1");
+    assert.deepEqual(heard, ["fresh-1"]);
+    // The erased id was learned from the file's identity alone.
+    assert.deepEqual(store.resetMarker(), { clearedAt: NOW + 1, generationId: "gen-1" });
+    assert.deepEqual(store.current()?.items, []);
+    if (refuseDisk) {
+      assert.ok(String(storage.file).includes("OLD_LOAD_SECRET"));
+      storage.refuse = false;
+      const lease = store.lease();
+      assert.equal(await store.write(lease, "fresh-1", (state) => state), true);
+    }
+    assert.ok(!String(storage.file).includes("OLD_LOAD_SECRET"));
+    assert.deepEqual(brainStateFromStored(storage.file)?.reset, {
+      clearedAt: NOW + 1,
+      generationId: "gen-1",
+    });
+  }
+});
+
+test("a load's own cleanup write and a replacement both yield to a Clear or expiry raised while they were out", async () => {
+  // Startup cleanup write held, Clear during it.
+  const storage = new HeldStorage();
+  const stale = {
+    ...complete(),
+    items: [{ type: "message", role: "user", content: "EXPIRED_SECRET" }],
+  };
+  storage.file = brainStateRecord(stale);
+  let generations = 0;
+  const store = new BrainStateStore({
+    storage,
+    createGenerationId: () => `fresh-${++generations}`,
+    now: () => stale.expiresAt,
+  });
+  storage.holdNext = true;
+  const loading = store.load();
+  await settleTicks();
+  assert.ok(storage.holding, "the cleanup write is on disk");
+  const clearing = store.clear(stale.expiresAt + 1);
+  assert.equal(store.generationId(), "fresh-2");
+  storage.release();
+  assert.equal((await loading).generationId, "fresh-2");
+  assert.equal(await clearing, true);
+  assert.equal(brainStateFromStored(storage.file)?.generationId, "fresh-2");
+  assert.deepEqual(brainStateFromStored(storage.file)?.reset, {
+    clearedAt: stale.expiresAt + 1,
+    generationId: "fresh-1",
+  });
+  assert.ok(!String(storage.file).includes("EXPIRED_SECRET"));
+
+  // A replacement is fenced synchronously and its write yields to a Clear.
+  const heard: string[] = [];
+  store.onReplaced((state) => heard.push(state.generationId));
+  storage.holdNext = true;
+  const replacement = {
+    ...complete(),
+    generationId: "replacement",
+    createdAt: stale.expiresAt,
+    expiresAt: stale.expiresAt + BRAIN_GENERATION_LIFETIME_MS,
+  };
+  const replacing = store.replace({
+    ...replacement,
+    items: [{ type: "message", role: "user", content: "REPLACEMENT_SECRET" }],
+  });
+  assert.equal(store.generationId(), "replacement");
+  assert.deepEqual(heard, ["replacement"]);
+  const cleared = store.clear(stale.expiresAt + 2);
+  assert.equal(store.generationId(), "fresh-3");
+  storage.release();
+  assert.equal(await replacing, false);
+  assert.equal(await cleared, true);
+  assert.equal(store.generationId(), "fresh-3");
+  assert.deepEqual(store.resetMarker(), {
+    clearedAt: stale.expiresAt + 2,
+    generationId: "replacement",
+  });
+  assert.ok(!String(storage.file).includes("REPLACEMENT_SECRET"));
+
+  // And to an expiry raised in the same tick, the same way: the replacement
+  // never reaches the disk, the successor does.
+  const late = store.replace(replacement);
+  assert.equal(store.generationId(), "replacement");
+  assert.equal(store.expireIfDue(replacement.expiresAt), true);
+  assert.equal(store.generationId(), "fresh-4");
+  assert.equal(await late, false);
+  await store.flush();
+  assert.equal(brainStateFromStored(storage.file)?.generationId, "fresh-4");
+
+  // Two Clears in a row leave the newest cutoff standing.
+  const first = store.clear(NOW + 10);
+  const second = store.clear(NOW + 11);
+  assert.deepEqual(store.resetMarker(), { clearedAt: NOW + 11, generationId: "fresh-5" });
+  assert.equal(await first, false);
+  assert.equal(await second, true);
+  assert.deepEqual(brainStateFromStored(storage.file)?.reset, {
+    clearedAt: NOW + 11,
+    generationId: "fresh-5",
+  });
+});
+
+function settleTicks(): Promise<void> {
+  return new Promise((resolve) => {
+    let ticks = 0;
+    const tick = () => {
+      ticks += 1;
+      if (ticks > 10) resolve();
+      else setImmediate(tick);
+    };
+    tick();
+  });
+}

--- a/packages/brain/src/brain-state.test.ts
+++ b/packages/brain/src/brain-state.test.ts
@@ -96,7 +96,7 @@ class MemoryStorage implements BrainStateStorage {
     this.log.push("read");
     return this.file;
   }
-  write(contents: string) {
+  write(contents: string): boolean | Promise<boolean> {
     this.log.push("write");
     if (this.refuse) return false;
     this.file = contents;
@@ -283,7 +283,7 @@ test("writes and a compaction never move the expiry, and expireIfDue ends the ge
   assert.equal(await store.expireIfDue(born.expiresAt), false);
 });
 
-test("retention keeps the newest 200 ended runs, lets their journals go with them, and never touches a run still going", () => {
+test("retention keeps 200 records, oldest ended runs and their journals going first, and never touches a run still going", () => {
   const requests = [
     ...Array.from({ length: 205 }, (_, index) => terminal(index)),
     terminal(900, { status: BRAIN_REQUEST_STATUS.RUNNING, settledAt: undefined }),
@@ -291,8 +291,17 @@ test("retention keeps the newest 200 ended runs, lets their journals go with the
   ];
   const journal = requests.flatMap((record) => journalFor(record.runId));
   const retained = retainedBrainState({ ...freshBrainState("gen-1", NOW), requests, journal });
-  assert.deepEqual(retained.prunedRunIds, ["run-0", "run-1", "run-2", "run-3", "run-4"]);
-  assert.equal(retained.state.requests.length, 202);
+  // The bound counts every record, the two still going included, so seven go.
+  assert.deepEqual(retained.prunedRunIds, [
+    "run-0",
+    "run-1",
+    "run-2",
+    "run-3",
+    "run-4",
+    "run-5",
+    "run-6",
+  ]);
+  assert.equal(retained.state.requests.length, 200);
   assert.ok(retained.state.requests.some((record) => record.runId === "run-900"));
   assert.ok(retained.state.requests.some((record) => record.runId === "run-901"));
   assert.ok(!retained.state.requests.some((record) => record.runId === "run-0"));
@@ -433,4 +442,242 @@ test("a Clear whose marker the storage refuses still fences the old generation a
     generationId: "gen-1",
     clearedAt: NOW + 1,
   });
+});
+
+test("the parser refuses a lifetime other than the build's and a marker dated after its generation's birth", () => {
+  const state = complete();
+  const read = (value: WireBoundaryInput) => brainPersistedStateFromWire(unparsedWire(value));
+  assert.equal(read({ ...raw(state), expiresAt: state.expiresAt + 1 }), undefined);
+  assert.equal(read({ ...raw(state), createdAt: state.createdAt - 1 }), undefined);
+  assert.deepEqual(read({ ...raw(state), reset: { clearedAt: NOW } })?.reset, { clearedAt: NOW });
+  assert.equal(read({ ...raw(state), reset: { clearedAt: NOW + 1 } }), undefined);
+});
+
+/** Storage whose next write waits until the test releases it. */
+class HeldStorage extends MemoryStorage {
+  #release: (() => void) | undefined;
+  holdNext = false;
+  override write(contents: string) {
+    if (!this.holdNext) return super.write(contents);
+    this.holdNext = false;
+    return new Promise<boolean>((resolve) => {
+      this.#release = () => resolve(super.write(contents));
+    });
+  }
+  release() {
+    this.#release?.();
+    this.#release = undefined;
+  }
+  get holding() {
+    return this.#release !== undefined;
+  }
+}
+
+test("a Clear and an expiry fence synchronously, before any disk is waited on, and a write landing afterwards installs nothing", async () => {
+  const storage = new HeldStorage();
+  let generations = 0;
+  const store = new BrainStateStore({
+    storage,
+    createGenerationId: () => `gen-${++generations}`,
+    now: () => NOW,
+  });
+  const lease = store.lease();
+  await store.load();
+  const heard: string[] = [];
+  store.onReplaced((state) => heard.push(state.generationId));
+
+  // A write is out on disk when the Clear is asked for.
+  storage.holdNext = true;
+  let committed = 0;
+  const late = store.write(
+    lease,
+    "gen-1",
+    (state) => ({ ...state, cursors: { p: { s: "LATE_CURSOR" } } }),
+    () => {
+      committed += 1;
+    },
+  );
+  await Promise.resolve();
+  assert.ok(storage.holding, "the write is on disk");
+  const clearing = store.clear(NOW + 1);
+  // Fenced at once: nothing waited for the disk.
+  assert.equal(store.holdsGeneration("gen-1"), false);
+  assert.equal(store.generationId(), "gen-2");
+  assert.deepEqual(heard, ["gen-2"]);
+  assert.deepEqual(store.resetMarker(), { clearedAt: NOW + 1, generationId: "gen-1" });
+  storage.release();
+  assert.equal(await late, false);
+  assert.equal(committed, 0);
+  assert.deepEqual(store.current()?.cursors, {});
+  assert.equal(await clearing, true);
+  const stored = brainStateFromStored(storage.file);
+  assert.equal(stored?.generationId, "gen-2");
+  assert.ok(!String(storage.read()).includes("LATE_CURSOR"));
+
+  // The same for an expiry asked for while a write is out.
+  storage.holdNext = true;
+  const later = store.write(lease, "gen-2", (state) => ({
+    ...state,
+    cursors: { p: { s: "LATER_CURSOR" } },
+  }));
+  await Promise.resolve();
+  const expiresAt = stored?.expiresAt ?? 0;
+  assert.equal(store.expireIfDue(expiresAt), true);
+  assert.equal(store.holdsGeneration("gen-2"), false);
+  assert.deepEqual(heard, ["gen-2", "gen-3"]);
+  storage.release();
+  assert.equal(await later, false);
+  await store.flush();
+  assert.equal(brainStateFromStored(storage.file)?.generationId, "gen-3");
+  assert.ok(!String(storage.read()).includes("LATER_CURSOR"));
+  assert.equal(store.expireIfDue(expiresAt), false);
+});
+
+test("a Clear on a store that never loaded still leaves the marker, learning the erased id from the file and reading nothing else", async () => {
+  const storage = new MemoryStorage();
+  const old = {
+    ...complete(),
+    items: [{ type: "message", role: "user", content: "OLD_COLD_SECRET" }],
+  };
+  storage.file = brainStateRecord(old);
+  const store = new BrainStateStore({
+    storage,
+    createGenerationId: () => "gen-cold",
+    now: () => NOW,
+  });
+  const heard: string[] = [];
+  store.onReplaced((state) => heard.push(state.generationId));
+  const clearing = store.clear(NOW + 5);
+  assert.deepEqual(store.resetMarker(), { clearedAt: NOW + 5 });
+  assert.deepEqual(heard, ["gen-cold"]);
+  assert.equal(await clearing, true);
+  assert.deepEqual(store.resetMarker(), { clearedAt: NOW + 5, generationId: "gen-1" });
+  assert.deepEqual(brainStateFromStored(storage.file)?.reset, {
+    clearedAt: NOW + 5,
+    generationId: "gen-1",
+  });
+  assert.ok(!String(storage.read()).includes("OLD_COLD_SECRET"));
+  // The old file is never read into memory afterwards.
+  assert.equal((await store.load()).generationId, "gen-cold");
+
+  // With no brain file at all the marker still carries the instant.
+  const empty = new MemoryStorage();
+  const bare = new BrainStateStore({
+    storage: empty,
+    createGenerationId: () => "gen-bare",
+    now: () => NOW,
+  });
+  assert.equal(await bare.clear(NOW + 6), true);
+  assert.deepEqual(brainStateFromStored(empty.file)?.reset, { clearedAt: NOW + 6 });
+});
+
+test("load admits a file only within its bounds and rewrites the disk to match what it admitted", async () => {
+  const reports: string[] = [];
+  const bounds = { MAXIMUM_TERMINAL_REQUESTS: 3, MAXIMUM_SERIALIZED_BYTES: 100_000 };
+  const make = (storage: MemoryStorage, now = NOW) =>
+    new BrainStateStore({
+      storage,
+      createGenerationId: () => "gen-fresh",
+      now: () => now,
+      bounds,
+      report: (message) => reports.push(message),
+    });
+
+  // Expired: discarded and replaced on disk in the same load.
+  const expired = new MemoryStorage();
+  const stale = {
+    ...complete(),
+    items: [{ type: "message", role: "user", content: "EXPIRED_SECRET" }],
+  };
+  expired.file = brainStateRecord(stale);
+  assert.equal((await make(expired, stale.expiresAt).load()).generationId, "gen-fresh");
+  assert.ok(!String(expired.read()).includes("EXPIRED_SECRET"));
+  assert.equal(brainStateFromStored(expired.file)?.generationId, "gen-fresh");
+
+  // Unreadable and version-1: replaced likewise.
+  const broken = new MemoryStorage();
+  broken.file = '{"version":1,"items":[{"content":"V1_SECRET"}],"cursors":{}}\n';
+  await make(broken).load();
+  assert.ok(!String(broken.read()).includes("V1_SECRET"));
+
+  // Pruned at load: the admitted copy and the file both hold three.
+  const crowded = new MemoryStorage();
+  crowded.file = brainStateRecord({
+    ...freshBrainState("gen-1", NOW),
+    requests: [0, 1, 2, 3, 4].map((index) => terminal(index)),
+    journal: [0, 1, 2, 3, 4].flatMap((index) => journalFor(`run-${index}`)),
+  });
+  const pruned = await make(crowded).load();
+  assert.deepEqual(
+    pruned.requests.map((record) => record.runId),
+    ["run-2", "run-3", "run-4"],
+  );
+  assert.equal(brainStateFromStored(crowded.file)?.requests.length, 3);
+  assert.equal(brainStateFromStored(crowded.file)?.journal.length, 3);
+
+  // Past its bounds with nothing eligible: refused whole, replaced, reported.
+  const overfull = new MemoryStorage();
+  overfull.file = brainStateRecord({
+    ...freshBrainState("gen-1", NOW),
+    requests: [0, 1, 2, 3].map((index) => terminal(index, { historyRecordedAt: undefined })),
+  });
+  assert.equal((await make(overfull).load()).requests.length, 0);
+  assert.equal(brainStateFromStored(overfull.file)?.generationId, "gen-fresh");
+  assert.ok(reports.some((message) => message.includes("past its bounds")));
+
+  // A refused rewrite is reported, and the memory still holds the fresh generation.
+  const refusing = new MemoryStorage();
+  refusing.file = brainStateRecord(stale);
+  refusing.refuse = true;
+  const held = make(refusing, stale.expiresAt);
+  assert.equal((await held.load()).generationId, "gen-fresh");
+  assert.ok(reports.some((message) => message.includes("expired generation")));
+  assert.ok(String(refusing.read()).includes("EXPIRED_SECRET"));
+});
+
+test("the record count is a hard bound: admission closes at capacity and a write that would add past it is refused", async () => {
+  const storage = new MemoryStorage();
+  const store = new BrainStateStore({
+    storage,
+    createGenerationId: () => "gen-1",
+    now: () => NOW,
+    bounds: { MAXIMUM_TERMINAL_REQUESTS: 2, MAXIMUM_SERIALIZED_BYTES: 100_000 },
+  });
+  const lease = store.lease();
+  await store.load();
+  const unpublished = (index: number) => terminal(index, { historyRecordedAt: undefined });
+  assert.equal(store.admits("gen-1"), true);
+  assert.equal(
+    await store.write(lease, "gen-1", (state) => ({ ...state, requests: [unpublished(0)] })),
+    true,
+  );
+  assert.equal(store.admits("gen-1"), true);
+  assert.equal(
+    await store.write(lease, "gen-1", (state) => ({
+      ...state,
+      requests: [...state.requests, unpublished(1)],
+    })),
+    true,
+  );
+  assert.equal(store.admits("gen-1"), false);
+  assert.equal(
+    await store.write(lease, "gen-1", (state) => ({
+      ...state,
+      requests: [...state.requests, unpublished(2)],
+    })),
+    false,
+  );
+  // A write that does not add a record — an end's mark — still lands, and
+  // once an end is in the thread the room opens again.
+  assert.equal(
+    await store.write(lease, "gen-1", (state) => ({
+      ...state,
+      requests: state.requests.map((record) =>
+        record.runId === "run-0" ? { ...record, historyRecordedAt: NOW } : record,
+      ),
+    })),
+    true,
+  );
+  assert.equal(store.admits("gen-1"), true);
+  assert.equal(store.admits("gen-other"), false);
 });

--- a/packages/brain/src/brain-state.ts
+++ b/packages/brain/src/brain-state.ts
@@ -1,7 +1,11 @@
 import { isRecord, isWireNumber, isWireString, type UnparsedWireValue } from "@sidecar/wire";
 import { type BrainJournalEntry, brainJournalEntryFromWire } from "./brain-journal.js";
 import type { ResponsesInputItem } from "./brain-openai.js";
-import { type BrainRequestRecord, brainRequestRecordFromWire } from "./brain-requests.js";
+import {
+  type BrainRequestRecord,
+  brainRequestRecordFromWire,
+  isTerminalBrainRequestStatus,
+} from "./brain-requests.js";
 
 /**
  * Everything the brain keeps across launches, in one envelope with one
@@ -18,6 +22,35 @@ export const BRAIN_STATE_VERSION = 2;
 /** How long a generation lives from its creation, whatever is written into it. */
 export const BRAIN_GENERATION_LIFETIME_MS = 14 * 24 * 60 * 60 * 1000;
 
+/**
+ * How large a generation may grow. The request count bounds what the panel
+ * and the model can be shown of ended runs; the byte cap bounds the file
+ * itself, and is the one bound that can refuse a write: ended runs are let go
+ * first, and a write that would still leave the envelope oversized is refused
+ * rather than dropping anything that is not finished.
+ */
+export interface BrainStateBounds {
+  readonly MAXIMUM_TERMINAL_REQUESTS: number;
+  readonly MAXIMUM_SERIALIZED_BYTES: number;
+}
+
+export const BRAIN_STATE_BOUNDS: BrainStateBounds = {
+  MAXIMUM_TERMINAL_REQUESTS: 200,
+  MAXIMUM_SERIALIZED_BYTES: 8 * 1024 * 1024,
+};
+
+/**
+ * What a Clear leaves behind in place of the generation it erased: the id of
+ * the generation nothing may write into again, and the instant of the Clear,
+ * before which no line of the conversation may stand. It carries no content of
+ * either, and it rides inside the fresh generation that succeeds the erased
+ * one until a later Clear or a new generation supersedes it.
+ */
+export interface BrainResetMarker {
+  generationId: string;
+  clearedAt: number;
+}
+
 export type BrainTranscriptCursors = Readonly<Record<string, Readonly<Record<string, string>>>>;
 
 export interface BrainPersistedState {
@@ -30,6 +63,15 @@ export interface BrainPersistedState {
   cursors: BrainTranscriptCursors;
   requests: readonly BrainRequestRecord[];
   journal: readonly BrainJournalEntry[];
+  reset?: BrainResetMarker;
+}
+
+/** Whether a generation's lifetime has run out: at the expiry instant itself, and ever after. */
+export function brainGenerationExpired(
+  state: Pick<BrainPersistedState, "expiresAt">,
+  now: number,
+): boolean {
+  return now >= state.expiresAt;
 }
 
 /** An empty generation born now. */
@@ -55,6 +97,8 @@ export function brainPersistedStateFromWire(
   if (!instant(value.createdAt) || !instant(value.expiresAt)) return undefined;
   if (!Array.isArray(value.items) || !isRecord(value.cursors)) return undefined;
   if (!Array.isArray(value.requests) || !Array.isArray(value.journal)) return undefined;
+  const reset = resetMarkerFromWire(value.reset);
+  if (reset === null) return undefined;
   const items: ResponsesInputItem[] = [];
   for (const item of value.items) {
     if (!isRecord(item)) return undefined;
@@ -91,7 +135,17 @@ export function brainPersistedStateFromWire(
     cursors,
     requests,
     journal,
+    ...(reset ? { reset } : undefined),
   };
+}
+
+/** The marker as stored, nothing when absent, and null when present but unreadable. */
+function resetMarkerFromWire(value: UnparsedWireValue): BrainResetMarker | undefined | null {
+  if (value === undefined) return undefined;
+  if (!isRecord(value)) return null;
+  if (!isWireString(value.generationId) || value.generationId.length === 0) return null;
+  if (!instant(value.clearedAt)) return null;
+  return { generationId: value.generationId, clearedAt: value.clearedAt };
 }
 
 function instant(value: UnparsedWireValue): value is number {
@@ -114,6 +168,87 @@ export function brainStateFromStored(stored: string | undefined): BrainPersisted
   }
 }
 
+/**
+ * Whether an ended run may be let go of. Only an ended run whose end the host
+ * has already written into its own thread: the thread is where the words
+ * outlive the record, so a record still waiting to be written there is kept
+ * however old it is, and a run still going is never eligible at all.
+ */
+export function brainRequestPrunable(record: BrainRequestRecord): boolean {
+  return isTerminalBrainRequestStatus(record.status) && record.historyRecordedAt !== undefined;
+}
+
+/** An envelope held to its bounds, and which runs were let go to get there. */
+export interface RetainedBrainState {
+  state: BrainPersistedState;
+  prunedRunIds: readonly string[];
+  /** The serialized record's size in bytes, measured once for the write that follows. */
+  record: string;
+  bytes: number;
+  /** Whether the envelope still exceeds the byte cap after everything eligible went. */
+  oversized: boolean;
+}
+
+function recordBytes(record: string): number {
+  return new TextEncoder().encode(record).length;
+}
+
+function withoutRuns(state: BrainPersistedState, runIds: ReadonlySet<string>): BrainPersistedState {
+  return {
+    ...state,
+    requests: state.requests.filter((record) => !runIds.has(record.runId)),
+    journal: state.journal.filter((entry) => !runIds.has(entry.runId)),
+  };
+}
+
+/**
+ * Applies both bounds, oldest ended runs going first and each run's journal
+ * going with its record, so a call is never left without the run it belonged
+ * to. The count is applied outright; the byte cap prunes only what is
+ * eligible and then reports whether that was enough, because what to do about
+ * an envelope that is still too large is the writer's decision, not the
+ * retention's: nothing here touches a run still going, its journal, or the
+ * model's own memory items.
+ */
+export function retainedBrainState(
+  state: BrainPersistedState,
+  bounds: BrainStateBounds = BRAIN_STATE_BOUNDS,
+): RetainedBrainState {
+  const eligible = state.requests
+    .filter(brainRequestPrunable)
+    .sort(
+      (left, right) =>
+        (left.settledAt ?? left.acceptedAt) - (right.settledAt ?? right.acceptedAt) ||
+        left.acceptedAt - right.acceptedAt,
+    );
+  const pruned = new Set<string>();
+  const terminal = state.requests.filter((record) => isTerminalBrainRequestStatus(record.status));
+  let excess = terminal.length - bounds.MAXIMUM_TERMINAL_REQUESTS;
+  for (const record of eligible) {
+    if (excess <= 0) break;
+    pruned.add(record.runId);
+    excess -= 1;
+  }
+  let retained = pruned.size > 0 ? withoutRuns(state, pruned) : state;
+  let record = brainStateRecord(retained);
+  let bytes = recordBytes(record);
+  for (const candidate of eligible) {
+    if (bytes <= bounds.MAXIMUM_SERIALIZED_BYTES) break;
+    if (pruned.has(candidate.runId)) continue;
+    pruned.add(candidate.runId);
+    retained = withoutRuns(state, pruned);
+    record = brainStateRecord(retained);
+    bytes = recordBytes(record);
+  }
+  return {
+    state: retained,
+    prunedRunIds: [...pruned],
+    record,
+    bytes,
+    oversized: bytes > bounds.MAXIMUM_SERIALIZED_BYTES,
+  };
+}
+
 /** Where the envelope is kept: one file's worth of read, write, and remove, however the host does them. */
 export interface BrainStateStorage {
   read(): string | undefined | Promise<string | undefined>;
@@ -126,17 +261,9 @@ export interface BrainStateStoreOptions {
   storage: BrainStateStorage;
   createGenerationId: () => string;
   now?: () => number;
+  bounds?: BrainStateBounds;
 }
 
-/**
- * The one writer of the brain's state. Every write is serialized behind the
- * last, so two callers cannot interleave half-envelopes; every write names
- * the generation it believes it is writing, so a write prepared against a
- * generation that has since been replaced or reset lands nowhere. The store
- * holds the envelope in memory between writes, and answers whether each
- * write reached storage, because the caller decides what a failed checkpoint
- * means for the act it guards.
- */
 /**
  * Who may write through the store right now. Each agent built on the store
  * takes the lease at construction; taking it releases every earlier holder, so
@@ -147,10 +274,34 @@ export interface BrainStoreLease {
   readonly holder: symbol;
 }
 
+/** What the store tells a writer once its write has landed: which runs retention let go of. */
+export interface BrainWriteCommit {
+  prunedRunIds: readonly string[];
+}
+
+/**
+ * The one writer of the brain's state. Every write is serialized behind the
+ * last, so two callers cannot interleave half-envelopes; every write names
+ * the generation it believes it is writing, so a write prepared against a
+ * generation that has since been replaced, expired, or cleared lands nowhere.
+ * The store holds the envelope in memory between writes, and answers whether
+ * each write reached storage, because the caller decides what a failed
+ * checkpoint means for the act it guards.
+ *
+ * The store also owns the generation's two ends. Its lifetime is fixed at
+ * birth and checked at load, on demand, and never moved by a write, so an
+ * envelope written into for a fortnight still dies on the day it was born to.
+ * A Clear replaces the generation with an empty one carrying a content-free
+ * marker of the erasure, in one write, so the moment the marker is durable the
+ * old content is gone from the same file; a marker the storage refused still
+ * fences the old generation in memory, and the caller is told the erasure did
+ * not complete.
+ */
 export class BrainStateStore {
   readonly #storage: BrainStateStorage;
   readonly #createGenerationId: () => string;
   readonly #now: () => number;
+  readonly #bounds: BrainStateBounds;
   #state: BrainPersistedState | undefined;
   #lease: BrainStoreLease | undefined;
   #queue: Promise<unknown> = Promise.resolve();
@@ -160,24 +311,37 @@ export class BrainStateStore {
     this.#storage = options.storage;
     this.#createGenerationId = options.createGenerationId;
     this.#now = options.now ?? Date.now;
+    this.#bounds = options.bounds ?? BRAIN_STATE_BOUNDS;
   }
 
   /**
    * Reads the envelope once from storage; later calls answer the held copy.
    * A missing or foreign file becomes a fresh generation in memory, written
-   * only when something is first checkpointed into it.
+   * only when something is first checkpointed into it. So does a file whose
+   * generation has died: nothing of it is read into memory, its marker
+   * included, because a lifetime that ended is not extended by being found.
    */
   load(): Promise<BrainPersistedState> {
     return this.#serialized(async () => {
-      if (this.#state) return this.#state;
+      const held = this.#state;
+      if (held) {
+        // A generation held across a stretch with no agent to keep its timer
+        // is judged again here, so the agent built next never adopts a dead one.
+        if (!brainGenerationExpired(held, this.#now())) return held;
+        this.#state = freshBrainState(this.#createGenerationId(), this.#now());
+        return this.#state;
+      }
       let stored: string | undefined;
       try {
         stored = await this.#storage.read();
       } catch {
         stored = undefined;
       }
+      const read = brainStateFromStored(stored);
       this.#state =
-        brainStateFromStored(stored) ?? freshBrainState(this.#createGenerationId(), this.#now());
+        read && !brainGenerationExpired(read, this.#now())
+          ? read
+          : freshBrainState(this.#createGenerationId(), this.#now());
       return this.#state;
     });
   }
@@ -202,39 +366,84 @@ export class BrainStateStore {
   }
 
   /**
+   * Whether the generation named is the one that stands: the fence every
+   * late arrival is checked against — a model answer, an act's result, a
+   * delivery claim, a history line — before it may have an effect. A
+   * generation replaced, expired, or cleared never stands again.
+   */
+  holdsGeneration(generationId: string): boolean {
+    return this.#state?.generationId === generationId;
+  }
+
+  /** The marker of the last Clear, while the generation carrying it stands. */
+  resetMarker(): BrainResetMarker | undefined {
+    return this.#state?.reset;
+  }
+
+  /**
+   * Ends the standing generation if its lifetime has run out, beginning an
+   * empty one in its place, and answers whether it did. Called by the agent
+   * before it opens any turn and from the timer it arms at the generation's
+   * expiry, so a generation dies on time whether or not anything is written
+   * into it. The old content leaves the file with the same write that begins
+   * the new generation; a write the storage refuses leaves the old content on
+   * disk for the next successful write to replace, but never back in memory.
+   */
+  expireIfDue(now: number = this.#now()): Promise<boolean> {
+    return this.#serialized(async () => {
+      const held = this.#state;
+      if (!held || !brainGenerationExpired(held, now)) return false;
+      const fresh = freshBrainState(this.#createGenerationId(), now);
+      await this.#persist(fresh);
+      this.#state = fresh;
+      this.#announceReplaced(fresh);
+      return true;
+    });
+  }
+
+  /**
    * Writes a new envelope of the generation named, under the lease given.
    * `mutate` runs inside the store's queue, once every earlier write has
    * settled, so an envelope composed there from live state includes every
    * earlier save; `committed` runs in the same queue step once the write has
    * landed, before any later write composes, so what it applies to live state
-   * is in every later envelope. Answers false without touching storage when
-   * that generation is no longer the store's, or the lease has passed to a
-   * later agent — the fences a reset, a replacement, and a rebuild raise
-   * against late writers — and false
-   * when storage refused, leaving the held copy as it was so the caller's
-   * own memory and the file cannot silently disagree about what is known.
+   * is in every later envelope — including which runs retention let go of,
+   * so the writer's own copy lets go of them too and no later save brings
+   * them back. Answers false without touching storage when that generation
+   * is no longer the store's, or the lease has passed to a later agent — the
+   * fences a Clear, an expiry, a replacement, and a rebuild raise against late
+   * writers — false when the envelope would still exceed its byte cap after
+   * every eligible ended run went and the write would grow it, and false when
+   * storage refused, leaving the held copy as it was so the caller's own
+   * memory and the file cannot silently disagree about what is known.
    */
   write(
     lease: BrainStoreLease,
     generationId: string,
     mutate: (
       state: BrainPersistedState,
-    ) => Omit<BrainPersistedState, "version" | "generationId" | "createdAt" | "expiresAt">,
-    committed?: () => void,
+    ) => Omit<
+      BrainPersistedState,
+      "version" | "generationId" | "createdAt" | "expiresAt" | "reset"
+    >,
+    committed?: (commit: BrainWriteCommit) => void,
   ): Promise<boolean> {
     return this.#serialized(async () => {
       const held = this.#state;
       if (!this.holdsLease(lease) || !held || held.generationId !== generationId) return false;
-      const next: BrainPersistedState = {
+      const composed: BrainPersistedState = {
         ...mutate(held),
         version: BRAIN_STATE_VERSION,
         generationId: held.generationId,
         createdAt: held.createdAt,
         expiresAt: held.expiresAt,
+        ...(held.reset ? { reset: held.reset } : undefined),
       };
-      if (!(await this.#persist(next))) return false;
-      this.#state = next;
-      committed?.();
+      const retained = retainedBrainState(composed, this.#bounds);
+      if (retained.oversized && retained.bytes > recordBytes(brainStateRecord(held))) return false;
+      if (!(await this.#persistRecord(retained.record))) return false;
+      this.#state = retained.state;
+      committed?.({ prunedRunIds: retained.prunedRunIds });
       return true;
     });
   }
@@ -242,34 +451,40 @@ export class BrainStateStore {
   /** Replaces the envelope whole with the one given, a new generation included. */
   replace(state: BrainPersistedState): Promise<boolean> {
     return this.#serialized(async () => {
-      if (!(await this.#persist(state))) return false;
-      this.#state = state;
-      this.#announceReplaced(state);
+      const retained = retainedBrainState(state, this.#bounds);
+      if (retained.oversized) return false;
+      if (!(await this.#persistRecord(retained.record))) return false;
+      this.#state = retained.state;
+      this.#announceReplaced(retained.state);
       return true;
     });
   }
 
   /**
-   * Discards the envelope and begins a fresh generation: the file goes, the
-   * held copy becomes empty, and every listener hears the new generation so
-   * runs of the old one can stand down.
+   * The Clear: the standing generation is fenced and forgotten in memory
+   * first, then an empty generation carrying the marker of the erasure is
+   * written over it — one write, so the file never holds the old content
+   * beside the marker — and every listener hears the new generation so runs
+   * of the old one stand down. Answers whether the marker reached storage:
+   * when it did not, the old generation is still gone from memory and fenced
+   * against every late writer, but the file still holds it until the next
+   * successful write, and the caller must say the erasure did not complete
+   * rather than that it did.
    */
-  reset(): Promise<boolean> {
+  clear(now: number = this.#now()): Promise<boolean> {
     return this.#serialized(async () => {
-      let removed: boolean;
-      try {
-        removed = await this.#storage.remove();
-      } catch {
-        removed = false;
-      }
-      if (!removed) return false;
-      this.#state = freshBrainState(this.#createGenerationId(), this.#now());
-      this.#announceReplaced(this.#state);
-      return true;
+      const held = this.#state;
+      const fresh: BrainPersistedState = {
+        ...freshBrainState(this.#createGenerationId(), now),
+        ...(held ? { reset: { generationId: held.generationId, clearedAt: now } } : undefined),
+      };
+      this.#state = fresh;
+      this.#announceReplaced(fresh);
+      return this.#persist(fresh);
     });
   }
 
-  /** Hears every replacement or reset, with the generation that now stands. */
+  /** Hears every replacement, expiry, or Clear, with the generation that now stands. */
   onReplaced(listener: (state: BrainPersistedState) => void): () => void {
     this.#replacedListeners.add(listener);
     return () => {
@@ -286,9 +501,13 @@ export class BrainStateStore {
     for (const listener of this.#replacedListeners) listener(state);
   }
 
-  async #persist(state: BrainPersistedState): Promise<boolean> {
+  #persist(state: BrainPersistedState): Promise<boolean> {
+    return this.#persistRecord(brainStateRecord(state));
+  }
+
+  async #persistRecord(record: string): Promise<boolean> {
     try {
-      return await this.#storage.write(brainStateRecord(state));
+      return await this.#storage.write(record);
     } catch {
       return false;
     }

--- a/packages/brain/src/brain-state.ts
+++ b/packages/brain/src/brain-state.ts
@@ -346,7 +346,7 @@ export class BrainStateStore {
         if (!brainGenerationExpired(held, this.#now())) return held;
         const fresh = this.#begin(this.#now());
         await this.#persistHousekeeping(fresh, "the expired generation");
-        return fresh;
+        return this.#state ?? fresh;
       }
       let stored: string | undefined;
       try {
@@ -354,13 +354,17 @@ export class BrainStateStore {
       } catch {
         stored = undefined;
       }
+      // A Clear, expiry, or replacement that landed while the file was being
+      // read is the newer truth: what the file held is not installed over
+      // it, and the caller adopts what now stands.
+      if (this.#state) return this.#state;
       const admitted = this.#admit(stored);
       this.#state = admitted.state;
       if (admitted.rewrite) {
         this.#report(`Brain memory discarded ${admitted.rewrite}`);
         await this.#persistHousekeeping(admitted.state, admitted.rewrite);
       }
-      return admitted.state;
+      return this.#state ?? admitted.state;
     });
   }
 
@@ -517,15 +521,23 @@ export class BrainStateStore {
     });
   }
 
-  /** Replaces the envelope whole with the one given, a new generation included. */
+  /**
+   * Replaces the envelope whole with the one given, a new generation
+   * included, under the same rule as every other end of a generation: the
+   * fence is synchronous — the replacement stands and is announced before
+   * this returns — and its write is queued behind the writes already out. An
+   * envelope past its bounds replaces nothing. Answers whether the write
+   * landed; a later fence raised while it was out leaves it unwritten, the
+   * newer truth carrying the file.
+   */
   replace(state: BrainPersistedState): Promise<boolean> {
+    const retained = retainedBrainState(state, this.#bounds);
+    if (retained.oversized) return Promise.resolve(false);
+    this.#state = retained.state;
+    this.#announceReplaced(retained.state);
     return this.#serialized(async () => {
-      const retained = retainedBrainState(state, this.#bounds);
-      if (retained.oversized) return false;
-      if (!(await this.#persistRecord(retained.record))) return false;
-      this.#state = retained.state;
-      this.#announceReplaced(retained.state);
-      return true;
+      if (this.#state !== retained.state) return false;
+      return this.#persistRecord(retained.record);
     });
   }
 

--- a/packages/brain/src/brain-state.ts
+++ b/packages/brain/src/brain-state.ts
@@ -47,8 +47,9 @@ export const BRAIN_STATE_BOUNDS: BrainStateBounds = {
  * one until a later Clear or a new generation supersedes it.
  */
 export interface BrainResetMarker {
-  generationId: string;
   clearedAt: number;
+  /** The erased generation, when the store knew one; a Clear pressed before any state was read carries the instant alone. */
+  generationId?: string;
 }
 
 export type BrainTranscriptCursors = Readonly<Record<string, Readonly<Record<string, string>>>>;
@@ -95,10 +96,13 @@ export function brainPersistedStateFromWire(
   if (!isRecord(value) || value.version !== BRAIN_STATE_VERSION) return undefined;
   if (!isWireString(value.generationId) || value.generationId.length === 0) return undefined;
   if (!instant(value.createdAt) || !instant(value.expiresAt)) return undefined;
+  // The lifetime is the build's, not the file's: an envelope claiming any
+  // other span was not written by this rule and is not given one now.
+  if (value.expiresAt - value.createdAt !== BRAIN_GENERATION_LIFETIME_MS) return undefined;
   if (!Array.isArray(value.items) || !isRecord(value.cursors)) return undefined;
   if (!Array.isArray(value.requests) || !Array.isArray(value.journal)) return undefined;
   const reset = resetMarkerFromWire(value.reset);
-  if (reset === null) return undefined;
+  if (reset === null || (reset && reset.clearedAt > value.createdAt)) return undefined;
   const items: ResponsesInputItem[] = [];
   for (const item of value.items) {
     if (!isRecord(item)) return undefined;
@@ -142,10 +146,10 @@ export function brainPersistedStateFromWire(
 /** The marker as stored, nothing when absent, and null when present but unreadable. */
 function resetMarkerFromWire(value: UnparsedWireValue): BrainResetMarker | undefined | null {
   if (value === undefined) return undefined;
-  if (!isRecord(value)) return null;
+  if (!isRecord(value) || !instant(value.clearedAt)) return null;
+  if (value.generationId === undefined) return { clearedAt: value.clearedAt };
   if (!isWireString(value.generationId) || value.generationId.length === 0) return null;
-  if (!instant(value.clearedAt)) return null;
-  return { generationId: value.generationId, clearedAt: value.clearedAt };
+  return { clearedAt: value.clearedAt, generationId: value.generationId };
 }
 
 function instant(value: UnparsedWireValue): value is number {
@@ -185,7 +189,7 @@ export interface RetainedBrainState {
   /** The serialized record's size in bytes, measured once for the write that follows. */
   record: string;
   bytes: number;
-  /** Whether the envelope still exceeds the byte cap after everything eligible went. */
+  /** Whether the envelope still exceeds a bound — bytes or records — after everything eligible went. */
   oversized: boolean;
 }
 
@@ -204,11 +208,14 @@ function withoutRuns(state: BrainPersistedState, runIds: ReadonlySet<string>): B
 /**
  * Applies both bounds, oldest ended runs going first and each run's journal
  * going with its record, so a call is never left without the run it belonged
- * to. The count is applied outright; the byte cap prunes only what is
- * eligible and then reports whether that was enough, because what to do about
- * an envelope that is still too large is the writer's decision, not the
- * retention's: nothing here touches a run still going, its journal, or the
- * model's own memory items.
+ * to. Both bounds prune only what is eligible and then report whether that
+ * was enough, because what to do about an envelope that is still too large —
+ * refuse the write that would grow it, or refuse the file at load — is the
+ * writer's decision, not the retention's: nothing here touches a run still
+ * going, a run whose end the thread has not yet taken, a journal, or the
+ * model's own memory items. The count bounds records of every status
+ * together, so however many runs stand at once the file never carries more
+ * than the bound names.
  */
 export function retainedBrainState(
   state: BrainPersistedState,
@@ -222,8 +229,7 @@ export function retainedBrainState(
         left.acceptedAt - right.acceptedAt,
     );
   const pruned = new Set<string>();
-  const terminal = state.requests.filter((record) => isTerminalBrainRequestStatus(record.status));
-  let excess = terminal.length - bounds.MAXIMUM_TERMINAL_REQUESTS;
+  let excess = state.requests.length - bounds.MAXIMUM_TERMINAL_REQUESTS;
   for (const record of eligible) {
     if (excess <= 0) break;
     pruned.add(record.runId);
@@ -245,7 +251,9 @@ export function retainedBrainState(
     prunedRunIds: [...pruned],
     record,
     bytes,
-    oversized: bytes > bounds.MAXIMUM_SERIALIZED_BYTES,
+    oversized:
+      bytes > bounds.MAXIMUM_SERIALIZED_BYTES ||
+      retained.requests.length > bounds.MAXIMUM_TERMINAL_REQUESTS,
   };
 }
 
@@ -262,6 +270,8 @@ export interface BrainStateStoreOptions {
   createGenerationId: () => string;
   now?: () => number;
   bounds?: BrainStateBounds;
+  /** Hears the store's own housekeeping failures: a discard or expiry the disk would not take. */
+  report?: (message: string) => void;
 }
 
 /**
@@ -302,6 +312,7 @@ export class BrainStateStore {
   readonly #createGenerationId: () => string;
   readonly #now: () => number;
   readonly #bounds: BrainStateBounds;
+  readonly #report: (message: string) => void;
   #state: BrainPersistedState | undefined;
   #lease: BrainStoreLease | undefined;
   #queue: Promise<unknown> = Promise.resolve();
@@ -312,24 +323,30 @@ export class BrainStateStore {
     this.#createGenerationId = options.createGenerationId;
     this.#now = options.now ?? Date.now;
     this.#bounds = options.bounds ?? BRAIN_STATE_BOUNDS;
+    this.#report = options.report ?? (() => undefined);
   }
 
   /**
    * Reads the envelope once from storage; later calls answer the held copy.
-   * A missing or foreign file becomes a fresh generation in memory, written
-   * only when something is first checkpointed into it. So does a file whose
-   * generation has died: nothing of it is read into memory, its marker
-   * included, because a lifetime that ended is not extended by being found.
+   * What is read is admitted before anything sees it: a missing, foreign, or
+   * malformed file, a generation past its time, and a valid envelope that
+   * exceeds its bounds after every eligible ended run is let go all become a
+   * fresh generation — nothing of them is read into memory — and an envelope
+   * within bounds is held as retention leaves it. Whatever the file held that
+   * the store did not admit is replaced on disk in the same load, so a
+   * generation found dead or unreadable does not wait for a later write to
+   * be gone; a disk that refuses the replacement is reported. A held copy is
+   * judged again on every load, so an agent built after an idle stretch never
+   * adopts a generation that died while nothing kept its timer.
    */
   load(): Promise<BrainPersistedState> {
     return this.#serialized(async () => {
       const held = this.#state;
       if (held) {
-        // A generation held across a stretch with no agent to keep its timer
-        // is judged again here, so the agent built next never adopts a dead one.
         if (!brainGenerationExpired(held, this.#now())) return held;
-        this.#state = freshBrainState(this.#createGenerationId(), this.#now());
-        return this.#state;
+        const fresh = this.#begin(this.#now());
+        await this.#persistHousekeeping(fresh, "the expired generation");
+        return fresh;
       }
       let stored: string | undefined;
       try {
@@ -337,13 +354,46 @@ export class BrainStateStore {
       } catch {
         stored = undefined;
       }
-      const read = brainStateFromStored(stored);
-      this.#state =
-        read && !brainGenerationExpired(read, this.#now())
-          ? read
-          : freshBrainState(this.#createGenerationId(), this.#now());
-      return this.#state;
+      const admitted = this.#admit(stored);
+      this.#state = admitted.state;
+      if (admitted.rewrite) {
+        this.#report(`Brain memory discarded ${admitted.rewrite}`);
+        await this.#persistHousekeeping(admitted.state, admitted.rewrite);
+      }
+      return admitted.state;
     });
+  }
+
+  /** What a stored file becomes in memory, and whether the file must be rewritten to match. */
+  #admit(stored: string | undefined): AdmittedBrainState {
+    const now = this.#now();
+    const read = brainStateFromStored(stored);
+    if (!read) {
+      return {
+        state: freshBrainState(this.#createGenerationId(), now),
+        ...(stored !== undefined ? { rewrite: "an unreadable state file" } : undefined),
+      };
+    }
+    if (brainGenerationExpired(read, now)) {
+      return {
+        state: freshBrainState(this.#createGenerationId(), now),
+        rewrite: "the expired generation",
+      };
+    }
+    const retained = retainedBrainState(read, this.#bounds);
+    if (retained.oversized) {
+      // Nothing this build writes exceeds its bounds with nothing left to
+      // let go, so a file that does was not written under this rule; it is
+      // refused whole rather than trimmed by guesswork.
+      return {
+        state: freshBrainState(this.#createGenerationId(), now),
+        rewrite: "a state file past its bounds",
+      };
+    }
+    return {
+      state: retained.state,
+      ...(retained.prunedRunIds.length > 0 ? { rewrite: "ended runs past retention" } : undefined),
+    };
   }
 
   /** Takes the write lease, releasing whoever held it. */
@@ -369,7 +419,9 @@ export class BrainStateStore {
    * Whether the generation named is the one that stands: the fence every
    * late arrival is checked against — a model answer, an act's result, a
    * delivery claim, a history line — before it may have an effect. A
-   * generation replaced, expired, or cleared never stands again.
+   * generation replaced, expired, or cleared never stands again, and it
+   * stops standing the instant the replacement, expiry, or Clear is asked
+   * for, before any disk is waited on.
    */
   holdsGeneration(generationId: string): boolean {
     return this.#state?.generationId === generationId;
@@ -381,24 +433,36 @@ export class BrainStateStore {
   }
 
   /**
-   * Ends the standing generation if its lifetime has run out, beginning an
-   * empty one in its place, and answers whether it did. Called by the agent
-   * before it opens any turn and from the timer it arms at the generation's
-   * expiry, so a generation dies on time whether or not anything is written
-   * into it. The old content leaves the file with the same write that begins
-   * the new generation; a write the storage refuses leaves the old content on
-   * disk for the next successful write to replace, but never back in memory.
+   * Whether the generation named has room for one more record after
+   * retention has let go of what it may. The count is a hard bound on the
+   * file, so a run is refused at its door rather than accepted into an
+   * envelope the store would then refuse to write.
    */
-  expireIfDue(now: number = this.#now()): Promise<boolean> {
-    return this.#serialized(async () => {
-      const held = this.#state;
-      if (!held || !brainGenerationExpired(held, now)) return false;
-      const fresh = freshBrainState(this.#createGenerationId(), now);
-      await this.#persist(fresh);
-      this.#state = fresh;
-      this.#announceReplaced(fresh);
-      return true;
-    });
+  admits(generationId: string): boolean {
+    const held = this.#state;
+    if (!held || held.generationId !== generationId) return false;
+    const cap = this.#bounds.MAXIMUM_TERMINAL_REQUESTS;
+    const withRoom = { ...this.#bounds, MAXIMUM_TERMINAL_REQUESTS: cap - 1 };
+    return retainedBrainState(held, withRoom).state.requests.length < cap;
+  }
+
+  /**
+   * Ends the standing generation if its lifetime has run out, beginning an
+   * empty one in its place at once, and answers whether it did. The fence is
+   * synchronous: by the time this returns, the old generation stands nowhere
+   * in memory and every listener has heard the successor, so a turn holding
+   * a model answer, a read, or an act's preparation finds itself revoked
+   * before any disk is waited on. The write that carries the successor to
+   * the file, replacing the old content, is queued behind the writes already
+   * out; a disk that refuses it is reported, and the old content stays on
+   * disk only until the next write that lands.
+   */
+  expireIfDue(now: number = this.#now()): boolean {
+    const held = this.#state;
+    if (!held || !brainGenerationExpired(held, now)) return false;
+    const fresh = this.#begin(now);
+    void this.#serialized(() => this.#persistHousekeeping(fresh, "the expired generation"));
+    return true;
   }
 
   /**
@@ -412,10 +476,14 @@ export class BrainStateStore {
    * them back. Answers false without touching storage when that generation
    * is no longer the store's, or the lease has passed to a later agent — the
    * fences a Clear, an expiry, a replacement, and a rebuild raise against late
-   * writers — false when the envelope would still exceed its byte cap after
-   * every eligible ended run went and the write would grow it, and false when
+   * writers — false when the envelope would still exceed a bound after every
+   * eligible ended run went and the write would grow it, and false when
    * storage refused, leaving the held copy as it was so the caller's own
-   * memory and the file cannot silently disagree about what is known.
+   * memory and the file cannot silently disagree about what is known. A
+   * fence raised while the write was out on disk is honored the same way: the
+   * landed content is not installed over the successor, `committed` is not
+   * called, and the caller hears false, because what it wrote belongs to a
+   * generation that no longer stands.
    */
   write(
     lease: BrainStoreLease,
@@ -440,8 +508,9 @@ export class BrainStateStore {
         ...(held.reset ? { reset: held.reset } : undefined),
       };
       const retained = retainedBrainState(composed, this.#bounds);
-      if (retained.oversized && retained.bytes > recordBytes(brainStateRecord(held))) return false;
+      if (retained.oversized && grows(retained, held)) return false;
       if (!(await this.#persistRecord(retained.record))) return false;
+      if (this.#state !== held || !this.holdsLease(lease)) return false;
       this.#state = retained.state;
       committed?.({ prunedRunIds: retained.prunedRunIds });
       return true;
@@ -461,26 +530,45 @@ export class BrainStateStore {
   }
 
   /**
-   * The Clear: the standing generation is fenced and forgotten in memory
-   * first, then an empty generation carrying the marker of the erasure is
-   * written over it — one write, so the file never holds the old content
-   * beside the marker — and every listener hears the new generation so runs
-   * of the old one stand down. Answers whether the marker reached storage:
-   * when it did not, the old generation is still gone from memory and fenced
-   * against every late writer, but the file still holds it until the next
-   * successful write, and the caller must say the erasure did not complete
-   * rather than that it did.
+   * The Clear. The fence is synchronous: the standing generation is
+   * forgotten in memory and every listener hears the empty successor before
+   * this returns, so nothing of the old generation can checkpoint, publish,
+   * deliver, or dispatch from here on, whatever the disk does next. The
+   * successor carries a content-free marker of the erasure — the Clear's
+   * instant, and the erased generation's id when one is known — and is then
+   * written over the old content in one write, queued behind the writes
+   * already out. A store that had not yet read its file learns the erased
+   * generation's id from the file at that point, reading nothing else of it,
+   * so a Clear pressed before any capability loaded the state still leaves
+   * the marker behind. Answers whether the marker reached storage: when it
+   * did not, the old generation is still gone from memory and fenced against
+   * every late writer, but the file still holds it until the next write that
+   * lands, and the caller must say the erasure did not complete rather than
+   * that it did.
    */
   clear(now: number = this.#now()): Promise<boolean> {
+    const held = this.#state;
+    const fresh = this.#begin(now, {
+      clearedAt: now,
+      ...(held ? { generationId: held.generationId } : undefined),
+    });
     return this.#serialized(async () => {
-      const held = this.#state;
-      const fresh: BrainPersistedState = {
-        ...freshBrainState(this.#createGenerationId(), now),
-        ...(held ? { reset: { generationId: held.generationId, clearedAt: now } } : undefined),
-      };
-      this.#state = fresh;
-      this.#announceReplaced(fresh);
-      return this.#persist(fresh);
+      let marker = fresh;
+      if (!held && this.#state === fresh) {
+        let stored: string | undefined;
+        try {
+          stored = await this.#storage.read();
+        } catch {
+          stored = undefined;
+        }
+        const prior = brainStateFromStored(stored)?.generationId;
+        if (prior && this.#state === fresh) {
+          marker = { ...fresh, reset: { clearedAt: now, generationId: prior } };
+          this.#state = marker;
+        }
+      }
+      if (this.#state !== marker) return false;
+      return this.#persistRecord(brainStateRecord(marker));
     });
   }
 
@@ -497,12 +585,31 @@ export class BrainStateStore {
     await this.#queue;
   }
 
-  #announceReplaced(state: BrainPersistedState): void {
-    for (const listener of this.#replacedListeners) listener(state);
+  /** Begins a fresh generation in memory now and tells every listener; the disk is the caller's next step. */
+  #begin(now: number, reset?: BrainResetMarker): BrainPersistedState {
+    const fresh: BrainPersistedState = {
+      ...freshBrainState(this.#createGenerationId(), now),
+      ...(reset ? { reset } : undefined),
+    };
+    this.#state = fresh;
+    this.#announceReplaced(fresh);
+    return fresh;
   }
 
-  #persist(state: BrainPersistedState): Promise<boolean> {
-    return this.#persistRecord(brainStateRecord(state));
+  /**
+   * Writes a generation the store began on its own — at expiry, or in place
+   * of a file it did not admit — unless a later fence has already superseded
+   * it, in which case the later write carries the newer truth.
+   */
+  async #persistHousekeeping(state: BrainPersistedState, what: string): Promise<void> {
+    if (this.#state !== state) return;
+    if (!(await this.#persistRecord(brainStateRecord(state)))) {
+      this.#report(`Brain memory could not replace ${what} on disk`);
+    }
+  }
+
+  #announceReplaced(state: BrainPersistedState): void {
+    for (const listener of [...this.#replacedListeners]) listener(state);
   }
 
   async #persistRecord(record: string): Promise<boolean> {
@@ -518,4 +625,18 @@ export class BrainStateStore {
     this.#queue = run.catch(() => undefined);
     return run;
   }
+}
+
+/** What a load admitted, and what the file held instead when it must be rewritten to match. */
+interface AdmittedBrainState {
+  state: BrainPersistedState;
+  rewrite?: string;
+}
+
+/** Whether a retained envelope is larger than the one it would replace, in bytes or in records. */
+function grows(retained: RetainedBrainState, held: BrainPersistedState): boolean {
+  return (
+    retained.bytes > recordBytes(brainStateRecord(held)) ||
+    retained.state.requests.length > held.requests.length
+  );
 }

--- a/packages/brain/src/index.ts
+++ b/packages/brain/src/index.ts
@@ -34,6 +34,7 @@ export {
   type OpenAiBrainOptions,
   openAiBrainClient,
 } from "./brain-client.js";
+export { BrainGenerationClock, type BrainGenerationClockOptions } from "./brain-clock.js";
 export {
   BRAIN_WAKE_KIND,
   type BrainDelivery,

--- a/packages/brain/src/index.ts
+++ b/packages/brain/src/index.ts
@@ -101,16 +101,25 @@ export {
 } from "./brain-requests.js";
 export {
   BRAIN_GENERATION_LIFETIME_MS,
+  BRAIN_STATE_BOUNDS,
   BRAIN_STATE_VERSION,
   type BrainPersistedState,
+  type BrainResetMarker,
+  type BrainStateBounds,
   type BrainStateStorage,
   BrainStateStore,
   type BrainStateStoreOptions,
+  type BrainStoreLease,
   type BrainTranscriptCursors,
+  type BrainWriteCommit,
+  brainGenerationExpired,
   brainPersistedStateFromWire,
+  brainRequestPrunable,
   brainStateFromStored,
   brainStateRecord,
   freshBrainState,
+  type RetainedBrainState,
+  retainedBrainState,
 } from "./brain-state.js";
 export {
   BRAIN_TOOL,


### PR DESCRIPTION
## Problem

The brain's version-2 envelope (#721) had a lifetime field nothing enforced, no bound on how many ended runs or how many bytes it could hold, and a History Clear that removed only the conversation file: the brain's Responses memory, its encrypted compaction, and its transcript cursors survived the press, and a main-process publication dated before the Clear could still land in the thread.

## Result

- **Hard 14-day generation life.** `BrainStateStore` judges expiry at load, on demand (`expireIfDue`), and the agent checks it at the door of every turn and submission and arms a timer at the expiry instant itself, so a generation that dies under a held model answer, read, or act is replaced beneath it. No write, checkpoint, or compaction moves `expiresAt`. A version-1 file reads as nothing.
- **Retention.** At most 200 ended runs, each let go together with its journal and only once its end is written into History (`brainRequestPrunable`); an 8 MiB serialized cap that prunes eligible ended runs first and refuses a write that would still grow an oversized envelope, never dropping a run still going or its journal. Pruning is reported back to the writer in the same queue step (`BrainWriteCommit.prunedRunIds`) and the agent drops those runs from its live records and journal, so a later working checkpoint cannot reintroduce them.
- **Clear.** `store.clear(now)` fences the generation in memory, announces the successor, and writes an empty generation carrying a content-free `reset` marker (`{ generationId, clearedAt }`) in one write. `clearConversationAndBrain` runs the approved order: raise the cutoff, store clear, withdraw undelivered briefings, remove the thread file, empty and broadcast; any failed step leaves the fence standing and answers incomplete. Main's own record path now refuses lines at or before the cutoff, and a launch reads the marker before the thread file so a crash between the two files cannot resurrect old lines. Remembered facts and provider files are untouched.
- **Docs.** `PRIVACY.md`, `README.md`, `AGENTS.md` (`CLAUDE.md` is a symlink), and Luke's own guide now describe the background transcript reads and their bounds, the direct-or-hosted send, the local Responses/compaction persistence and its generation life, the exact retention and Clear, and drop the subject-phrase and 20-lines-only claims.

## Review round 2 (parent findings)

- **Synchronous fence.** `clear` and `expireIfDue` replace the in-memory generation and announce the successor before any await; `write` re-checks generation and lease after its awaited persist and installs nothing if a fence moved. Cached-load expiry announces through the same boundary.
- **Failed Clear isolates old History.** The cutoff is raised and the relayed thread emptied at the fence, so standing context, publication, window reports, and later writes never carry old lines even when erasure is incomplete; the panel is told the erasure did not finish.
- **Cold Clear marker.** A Clear before any load still writes the marker, learning the erased id from the file; the marker's `generationId` is optional.
- **Hard bounds.** Total records are bounded at 200 with door refusal (`FULL`) when nothing is prunable; loads admit only within bounds and the build-fixed lifetime, rewriting expired, unreadable, or oversized files in the same load; pruning notifies subscribers.
- **Stale speech.** `SpeechArbiter.withdrawBriefings` drops queued, held, and offered briefings; main subscribes to the store's replacement announcement and takes the offer back from the mouth.

## Review round 3 (parent findings)

- **One fence rule for every owner path.** A load whose read was out, or a replacement whose write was out, when a Clear or expiry landed installs nothing over the successor; `replace` now fences synchronously like `clear` and `expireIfDue`; a starting agent keeps the generation it already adopted from the store's announcement; two Clears leave the newest cutoff standing.
- **Voice window fenced at the fence; marker before thread.** The voice window is told to clear in the same synchronous step that fences main, before the disk is waited on; the thread file is erased only once the marker is durable, to what the thread holds now, so a new-generation line recorded during the wait survives.
- **Retention without an agent.** `BrainGenerationClock` (one per store) loads the store at every live launch and arms the expiry timer, re-arming on every replacement, so an expired, unreadable, or oversized file is replaced at launch and a generation whose agent was retired still dies on time. The agent keeps only its door checks.

## New surface for PR 6 / PR 7

- `BrainStateStore.holdsGeneration(id)`, `generationId()`, `resetMarker()`, `onReplaced(listener)` (fires synchronously with the fence on clear, expiry, replace, and cached-load expiry): the fence a delivery claim or late callback must pass; `clear(now)` and `replace(state)` (synchronous fence, queued write; each answers whether its own write landed, false when a later fence supersedes it before its write starts, and may answer true when the fence arrives while the write is already out, in which case the newer generation still stands and nothing stale is reinstalled), `expireIfDue(now): boolean`, `admits(generationId)`. Current validity is always `holdsGeneration`, never a write's boolean.
- `BrainGenerationClock({store})`: `start()`, `stop()`; main owns one per store.
- `BrainPersistedState.reset?: BrainResetMarker`; `BRAIN_STATE_BOUNDS`; `brainGenerationExpired`, `brainRequestPrunable`, `retainedBrainState`.
- `apps/desktop/src/main/conversation-clear.ts`: `clearConversationAndBrain`.

## Checks

- `./scripts/check.sh` — see handoff for the exact result.
- New tests: `brain-state.test.ts` (exact expiry boundary, expired file at load, writes/compaction never extend, count and byte pruning, oversized refusal, marker round-trip, failed-marker Clear), `brain-agent.test.ts` (timer under an active turn, door checks with no timer, compaction and a fortnight of writes, live-state reconciliation of pruning), `conversation-clear.test.ts` (real store, agent, host, follower, and thread rule composed: Clear under held model answer, held act, and held publication; failed marker; failed thread removal and a launch between the two files; synthetic markers found nowhere afterwards), `memory-flow.test.ts` (cutoff reader).

## Pending

- Exact-commit macOS `./scripts/verify.sh`, PNG inspection, and physical-notch check are not possible from this cloud workspace and remain pending.
- Hosted inference (PR 6) and voice-readiness delivery (PR 7) consume the fence above; the privacy text describes the hosted path as approved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34076093956/artifacts/10002137042) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34076093956)

- Commit: `4d51f4e3ed551ec366bc5b32c9348f5ca05e608f`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
