### PR TITLE
feat(desktop): wait for voice readiness and deliver brain replies through main

### DIFF
--- a/apps/desktop/src/main/brain/host-lifecycle.test.ts
+++ b/apps/desktop/src/main/brain/host-lifecycle.test.ts
@@ -11,15 +11,22 @@ import {
   BrainStateStore,
   brainStateFromStored,
 } from "@sidecar/brain";
+import { isTerminalBrainRequestStatus } from "@sidecar/brain/requests";
 import {
   appendConversationThreadEntry,
   CONVERSATION_ENTRY_KIND,
   type ConversationEntry,
 } from "@sidecar/realtime";
 import { ACT_RESULT_STATUS } from "@sidecar/wire";
-import type { BrainRequestSnapshot } from "#shared/wire/brain";
+import {
+  type BrainReplyOffer,
+  type BrainRequestSnapshot,
+  brainReplyWords,
+} from "#shared/wire/brain";
+import { VoiceReceiver } from "../voice-receiver";
 import { BrainHost } from "./host";
 import { followBrainRequests, submitBrainAsk } from "./ipc";
+import { BrainReplyDeliveries } from "./reply-delivery";
 
 /**
  * The real agent, store, host, follower, and submission path composed as the
@@ -86,14 +93,62 @@ function composed() {
     thread = appendConversationThreadEntry(thread, entry, NOW + 1000, at);
     return true;
   };
+  // The delivery owner and the receiver, composed as desktop-app composes
+  // them: every report is observed before it is broadcast, every published
+  // end is offered to a ready receiver, and readiness flushes what waited.
+  const deliveries = new BrainReplyDeliveries({ nextDeliveryId: () => `delivery-${++ids}` });
+  const receiver = new VoiceReceiver();
+  const offers: BrainReplyOffer[] = [];
+  const offerReplies = () => {
+    if (!receiver.isReady()) return;
+    const offer = deliveries.nextOffer(receiver.epoch());
+    if (offer) offers.push(offer);
+  };
+  receiver.onReady(offerReplies);
+  store.onReplaced(() => deliveries.reset());
   const host = new BrainHost({
     follow: (agent) =>
       followBrainRequests(agent, {
         recordConversationEntry: record,
-        broadcastRequests: (snapshots) => broadcasts.push(snapshots),
+        broadcastRequests: (snapshots) => {
+          deliveries.observe(snapshots);
+          broadcasts.push(snapshots);
+        },
+        onEndPublished: (ended) => {
+          const generationId = store.generationId();
+          if (generationId !== undefined) deliveries.published(ended, generationId);
+          offerReplies();
+        },
       }),
     publishEmpty: () => broadcasts.push([]),
   });
+  const claimContext = () => ({
+    receiverCurrent: (epoch: number) => receiver.isReady() && receiver.epoch() === epoch,
+    generationStands: (generationId: string) => store.holdsGeneration(generationId),
+    liveRecord: (runId: string) => host.current()?.request(runId),
+  });
+  const claim = (offer: BrainReplyOffer) =>
+    deliveries.claim(offer.runId, offer.deliveryId, offer.epoch, claimContext());
+  const acknowledge = (offer: BrainReplyOffer) => {
+    const emptied = deliveries.acknowledge(offer.runId, offer.deliveryId, offer.epoch);
+    if (emptied) offerReplies();
+    return emptied;
+  };
+  /** The wait as main's IPC answers it: publication let finish, live record re-read, the call granted or not. */
+  const waitOnCall = async (runId: string, epoch: number, timeoutMs = 1) => {
+    const agent = host.current();
+    const waited = await agent?.waitAsk(runId, timeoutMs);
+    if (!waited || !isTerminalBrainRequestStatus(waited.status))
+      return { record: waited, speak: false };
+    await settle();
+    const live = agent?.request(runId) ?? waited;
+    if (live.historyRecordedAt === undefined) return { record: live, speak: false };
+    const generationId = store.generationId() ?? "";
+    return {
+      record: live,
+      speak: deliveries.grantOnCall(live, generationId, epoch, claimContext()),
+    };
+  };
   const build = (client: BrainClient) =>
     new BrainAgent({
       client,
@@ -107,6 +162,15 @@ function composed() {
       createRunId: () => `run-${++ids}`,
       report: () => {},
       now: () => NOW,
+      // A run left in flight at a test's end must not hold the process open:
+      // its deadline timers are unreferenced, as the test's own would be.
+      schedule: (callback, delayMs) => {
+        const timer = setTimeout(callback, delayMs);
+        timer.unref();
+        return timer;
+      },
+      // SAFETY: the handle is what `schedule` above returned, which is always a `setTimeout` timer.
+      cancel: (timer) => clearTimeout(timer as ReturnType<typeof setTimeout>),
     });
   return {
     storage,
@@ -116,10 +180,29 @@ function composed() {
     record,
     thread: () => thread,
     broadcasts,
+    deliveries,
+    receiver,
+    offers,
+    claim,
+    acknowledge,
+    waitOnCall,
     refuse: (value: boolean) => {
       refuseWrites = value;
     },
   };
+}
+
+function answered(text: string): BrainClientAnswer {
+  return {
+    outcome: "answered",
+    payload: {
+      output: [{ type: "message", role: "assistant", content: [{ type: "output_text", text }] }],
+    },
+  };
+}
+
+function replies(thread: readonly ConversationEntry[], runId: string) {
+  return thread.filter((e) => e.kind === CONVERSATION_ENTRY_KIND.REPLY && e.requestId === runId);
 }
 
 async function submitMany(
@@ -273,4 +356,295 @@ test("a reset under outstanding runs discards them without publishing, and the s
   await c.host.replace(() => undefined);
   await settle();
   assert.equal(c.thread().filter((e) => e.kind === CONVERSATION_ENTRY_KIND.REPLY).length, 0);
+});
+
+test("a run ending long after its wait is offered once, to a ready receiver, only after its line and mark landed", async () => {
+  const c = composed();
+  const client = heldClient();
+  await c.host.replace(() => c.build(client));
+  const agent = c.host.current();
+  assert.ok(agent);
+  const epoch = c.receiver.begin();
+  c.receiver.markReady(epoch);
+  const [runId] = await submitMany(agent, c.record, 1);
+  assert.ok(runId);
+  // The wait comes back pending — the ask outlived its thirty seconds — and
+  // the developer's call is released with no grant. Nothing is owed yet.
+  const waited = await c.waitOnCall(runId, epoch);
+  assert.equal(waited.record?.status, BRAIN_REQUEST_STATUS.RUNNING);
+  assert.equal(waited.speak, false);
+  // The receiver goes away: the model answers, the end is written and
+  // marked, and the reply waits for a receiver rather than landing on none.
+  c.receiver.reset();
+  client.release(answered("Two agents are waiting."));
+  await settle();
+  assert.equal(replies(c.thread(), runId).length, 1);
+  assert.equal(c.deliveries.unclaimed().length, 1);
+  assert.equal(c.offers.length, 0);
+  // Readiness flushes it, exactly once, under the epoch that reported.
+  const next = c.receiver.begin();
+  assert.equal(c.receiver.markReady(next), true);
+  assert.equal(c.offers.length, 1);
+  const offer = c.offers[0];
+  assert.ok(offer);
+  assert.equal(offer.epoch, next);
+  assert.deepEqual(c.claim(offer), {
+    granted: true,
+    words: "Two agents are waiting.",
+    origin: BRAIN_REQUEST_ORIGIN.TYPED,
+  });
+  assert.equal(replies(c.thread(), runId)[0]?.words, "Two agents are waiting.");
+  // A duplicate claim, a repeated readiness, and a later report add nothing.
+  assert.deepEqual(c.claim(offer), { granted: false });
+  c.receiver.markReady(next);
+  await settle();
+  assert.equal(c.offers.length, 1);
+  assert.equal(replies(c.thread(), runId).length, 1);
+});
+
+test("a refused History write keeps the reply unoffered and ungranted until the write recovers, then it is offered once", async () => {
+  const c = composed();
+  const client = heldClient();
+  await c.host.replace(() => c.build(client));
+  const agent = c.host.current();
+  assert.ok(agent);
+  const epoch = c.receiver.begin();
+  c.receiver.markReady(epoch);
+  const spoken = await submitBrainAsk(
+    agent,
+    { submissionId: "spoken-1", question: "how are they?", origin: BRAIN_REQUEST_ORIGIN.SPOKEN },
+    c.record,
+  );
+  assert.equal(spoken.outcome, "accepted");
+  if (spoken.outcome !== "accepted") return;
+  await settle();
+  c.refuse(true);
+  client.release(answered("Done."));
+  await settle();
+  // Ended, but the thread refused the line: unmarked, not offered, and the
+  // asking call is not granted the words either — nothing is said before
+  // History holds it.
+  assert.equal(agent.request(spoken.runId)?.status, BRAIN_REQUEST_STATUS.SUCCEEDED);
+  assert.equal(agent.request(spoken.runId)?.historyRecordedAt, undefined);
+  const waited = await c.waitOnCall(spoken.runId, epoch);
+  assert.equal(waited.speak, false);
+  assert.equal(c.offers.length, 0);
+  // The thread recovers. A mark alone sends no report, so nothing happens
+  // until the records next change — another ask accepted — and that report
+  // writes the line, marks the run, and only then offers it, once.
+  c.refuse(false);
+  await settle();
+  assert.equal(c.offers.length, 0);
+  await submitMany(agent, c.record, 1);
+  await settle();
+  assert.equal(replies(c.thread(), spoken.runId).length, 1);
+  assert.deepEqual(
+    c.offers.map((offer) => offer.runId),
+    [spoken.runId],
+  );
+  const offer = c.offers[0];
+  assert.ok(offer);
+  assert.deepEqual(c.claim(offer), {
+    granted: true,
+    words: "Done.",
+    origin: BRAIN_REQUEST_ORIGIN.SPOKEN,
+  });
+  await c.host.replace(() => undefined);
+});
+
+test("two completions flushed together are offered one at a time, the second only after the first is acknowledged", async () => {
+  const c = composed();
+  const client = heldClient();
+  await c.host.replace(() => c.build(client));
+  const agent = c.host.current();
+  assert.ok(agent);
+  const [runA, runB] = await submitMany(agent, c.record, 2);
+  assert.ok(runA && runB);
+  client.release(answered("Answer."));
+  await settle();
+  client.release(answered("Answer."));
+  await settle();
+  // Both ended with no receiver; readiness offers the oldest alone.
+  const epoch = c.receiver.begin();
+  c.receiver.markReady(epoch);
+  assert.deepEqual(
+    c.offers.map((offer) => offer.runId),
+    [runA],
+  );
+  const offerA = c.offers[0];
+  assert.ok(offerA);
+  assert.equal(c.claim(offerA).granted, true);
+  // Claimed and playing: B is still not offered, so it cannot cut A off.
+  assert.equal(c.offers.length, 1);
+  // A's reply ends; only now is B offered, and only once.
+  assert.equal(c.acknowledge(offerA), true);
+  assert.deepEqual(
+    c.offers.map((offer) => offer.runId),
+    [runA, runB],
+  );
+  assert.equal(c.acknowledge(offerA), false);
+  assert.equal(c.offers.length, 2);
+});
+
+test("an offer the renderer never claimed is offered again to the next epoch; a claimed one is not, and old-epoch claims are refused", async () => {
+  const c = composed();
+  const client = heldClient();
+  await c.host.replace(() => c.build(client));
+  const agent = c.host.current();
+  assert.ok(agent);
+  const first = c.receiver.begin();
+  c.receiver.markReady(first);
+  const [runA, runB] = await submitMany(agent, c.record, 2);
+  assert.ok(runA && runB);
+  client.release(answered("Answer."));
+  await settle();
+  client.release(answered("Answer."));
+  await settle();
+  // A is offered and claimed; its renderer dies before the reply ends.
+  const offerA = c.offers[0];
+  assert.ok(offerA && offerA.runId === runA);
+  assert.equal(c.claim(offerA).granted, true);
+  c.receiver.reset();
+  const second = c.receiver.begin();
+  c.receiver.markReady(second);
+  // A, possibly already heard, is never offered again; B is offered to the new epoch.
+  const offerB = c.offers[1];
+  assert.ok(offerB && offerB.runId === runB && offerB.epoch === second);
+  // The new renderer dies with B unclaimed; the third is offered B again.
+  c.receiver.reset();
+  const third = c.receiver.begin();
+  c.receiver.markReady(third);
+  const again = c.offers[2];
+  assert.ok(again && again.runId === runB && again.epoch === third);
+  // A claim carrying the old epoch — a reloaded renderer's late invoke — is
+  // refused even though the delivery ids match; the current epoch's is granted.
+  assert.deepEqual(c.claim(offerB), { granted: false });
+  assert.equal(c.claim(again).granted, true);
+  assert.equal(replies(c.thread(), runA).length, 1);
+  assert.equal(replies(c.thread(), runB).length, 1);
+});
+
+test("a Clear invalidates every delivery: an unclaimed offer is refused, a late acknowledgement is ignored, nothing is offered again", async () => {
+  const c = composed();
+  const client = heldClient();
+  await c.host.replace(() => c.build(client));
+  const agent = c.host.current();
+  assert.ok(agent);
+  const epoch = c.receiver.begin();
+  c.receiver.markReady(epoch);
+  const [runId] = await submitMany(agent, c.record, 1);
+  assert.ok(runId);
+  client.release(answered("Before the clear."));
+  await settle();
+  assert.equal(c.offers.length, 1);
+  const offer = c.offers[0];
+  assert.ok(offer);
+  // The Clear fences synchronously; the renderer's claim lands after it.
+  const cleared = c.store.clear(NOW + 5);
+  assert.deepEqual(c.claim(offer), { granted: false });
+  assert.deepEqual(c.deliveries.unclaimed(), []);
+  await cleared;
+  await settle();
+  assert.equal(c.acknowledge(offer), false);
+  // A new renderer reporting ready is offered nothing of the erased generation.
+  c.receiver.reset();
+  c.receiver.markReady(c.receiver.begin());
+  assert.equal(c.offers.length, 1);
+});
+
+test("a launch that finds ended runs restores their words and speaks none of them", async () => {
+  const c = composed();
+  const client = heldClient();
+  await c.host.replace(() => c.build(client));
+  const agent = c.host.current();
+  assert.ok(agent);
+  await submitMany(agent, c.record, 2);
+  await c.host.replace(() => undefined);
+  await settle();
+  assert.equal(c.thread().filter((e) => e.kind === CONVERSATION_ENTRY_KIND.REPLY).length, 2);
+  // The next launch: a fresh delivery owner, a fresh receiver, the same file.
+  const next = composed();
+  next.storage.file = c.storage.file;
+  next.receiver.markReady(next.receiver.begin());
+  await next.host.replace(() => next.build(heldClient()));
+  await settle();
+  assert.equal(next.host.current()?.requests().length, 2);
+  assert.equal(next.offers.length, 0);
+  assert.deepEqual(next.thread(), []);
+  for (const record of next.host.current()?.requests() ?? []) {
+    assert.equal(record.status, BRAIN_REQUEST_STATUS.INTERRUPTED);
+    assert.ok(record.historyRecordedAt !== undefined);
+    assert.equal(brainReplyWords(record), "That ask was interrupted before I could finish it.");
+  }
+});
+
+test("a spoken ask's end is authorized exactly once across the call that asked and the offer path, whichever comes first", async () => {
+  // Publication before the wait: the run ended, was written, marked, and
+  // offered before the asking call's wait ever reached main.
+  const c = composed();
+  const client = heldClient();
+  await c.host.replace(() => c.build(client));
+  const agent = c.host.current();
+  assert.ok(agent);
+  const epoch = c.receiver.begin();
+  c.receiver.markReady(epoch);
+  const spoken = await submitBrainAsk(
+    agent,
+    { submissionId: "spoken-1", question: "how are they?", origin: BRAIN_REQUEST_ORIGIN.SPOKEN },
+    c.record,
+  );
+  assert.equal(spoken.outcome, "accepted");
+  if (spoken.outcome !== "accepted") return;
+  await settle();
+  client.release(answered("Both are waiting."));
+  await settle();
+  assert.equal(c.offers.length, 1);
+  const offer = c.offers[0];
+  assert.ok(offer);
+  // The wait arrives now, under the current epoch: the call is granted the
+  // words, and the offer already out is withdrawn — its claim is refused.
+  const waited = await c.waitOnCall(spoken.runId, epoch);
+  assert.equal(waited.speak, true);
+  assert.deepEqual(c.claim(offer), { granted: false });
+  assert.equal(c.deliveries.unclaimed().length, 0);
+  assert.equal(replies(c.thread(), spoken.runId).length, 1);
+
+  // The reverse order: the offer is claimed first, and the wait is refused.
+  const second = await submitBrainAsk(
+    agent,
+    { submissionId: "spoken-2", question: "and now?", origin: BRAIN_REQUEST_ORIGIN.SPOKEN },
+    c.record,
+  );
+  assert.equal(second.outcome, "accepted");
+  if (second.outcome !== "accepted") return;
+  await settle();
+  client.release(answered("Still waiting."));
+  await settle();
+  const secondOffer = c.offers[1];
+  assert.ok(secondOffer && secondOffer.runId === second.runId);
+  assert.equal(c.claim(secondOffer).granted, true);
+  const lateWait = await c.waitOnCall(second.runId, epoch);
+  assert.equal(lateWait.record?.status, BRAIN_REQUEST_STATUS.SUCCEEDED);
+  assert.equal(lateWait.speak, false);
+
+  // An abandoned wait from a reloaded renderer names a stale epoch: refused,
+  // and the run stays deliverable to the renderer that stands.
+  const third = await submitBrainAsk(
+    agent,
+    { submissionId: "spoken-3", question: "later?", origin: BRAIN_REQUEST_ORIGIN.SPOKEN },
+    c.record,
+  );
+  assert.equal(third.outcome, "accepted");
+  if (third.outcome !== "accepted") return;
+  c.acknowledge(secondOffer);
+  await settle();
+  client.release(answered("Later."));
+  await settle();
+  const staleWait = await c.waitOnCall(third.runId, epoch - 1);
+  assert.equal(staleWait.speak, false);
+  const thirdOffer = c.offers[2];
+  assert.ok(thirdOffer);
+  assert.equal(thirdOffer.runId, third.runId);
+  assert.equal(c.claim(thirdOffer).granted, true);
+  await c.host.replace(() => undefined);
 });

--- a/apps/desktop/src/main/brain/host-lifecycle.test.ts
+++ b/apps/desktop/src/main/brain/host-lifecycle.test.ts
@@ -144,10 +144,9 @@ function composed() {
     const live = agent?.request(runId) ?? waited;
     if (live.historyRecordedAt === undefined) return { record: live, speak: false };
     const generationId = store.generationId() ?? "";
-    return {
-      record: live,
-      speak: deliveries.grantOnCall(live, generationId, epoch, claimContext()),
-    };
+    const speak = deliveries.grantOnCall(live, generationId, epoch, claimContext());
+    if (speak) offerReplies();
+    return { record: live, speak };
   };
   const build = (client: BrainClient) =>
     new BrainAgent({
@@ -646,5 +645,49 @@ test("a spoken ask's end is authorized exactly once across the call that asked a
   assert.ok(thirdOffer);
   assert.equal(thirdOffer.runId, third.runId);
   assert.equal(c.claim(thirdOffer).granted, true);
+  await c.host.replace(() => undefined);
+});
+
+test("an on-call grant that takes the offered run out of the receiver's hand offers the next owed reply at once", async () => {
+  const c = composed();
+  const client = heldClient();
+  await c.host.replace(() => c.build(client));
+  const agent = c.host.current();
+  assert.ok(agent);
+  const epoch = c.receiver.begin();
+  c.receiver.markReady(epoch);
+  // A is spoken, B is typed; both end while the renderer is busy, so neither is claimed.
+  const spoken = await submitBrainAsk(
+    agent,
+    { submissionId: "spoken-a", question: "how are they?", origin: BRAIN_REQUEST_ORIGIN.SPOKEN },
+    c.record,
+  );
+  assert.equal(spoken.outcome, "accepted");
+  if (spoken.outcome !== "accepted") return;
+  const [typed] = await submitMany(agent, c.record, 1);
+  assert.ok(typed);
+  await settle();
+  client.release(answered("A."));
+  await settle();
+  client.release(answered("B."));
+  await settle();
+  assert.deepEqual(
+    c.offers.map((offer) => offer.runId),
+    [spoken.runId],
+  );
+  const offerA = c.offers[0];
+  assert.ok(offerA);
+  // A's own call comes back from its wait and is granted the words; with no
+  // third event, B's offer follows at once, and A's old offer is dead.
+  const waited = await c.waitOnCall(spoken.runId, epoch);
+  assert.equal(waited.speak, true);
+  assert.deepEqual(
+    c.offers.map((offer) => offer.runId),
+    [spoken.runId, typed],
+  );
+  assert.deepEqual(c.claim(offerA), { granted: false });
+  const offerB = c.offers[1];
+  assert.ok(offerB);
+  assert.equal(c.claim(offerB).granted, true);
   await c.host.replace(() => undefined);
 });

--- a/apps/desktop/src/main/brain/ipc.test.ts
+++ b/apps/desktop/src/main/brain/ipc.test.ts
@@ -1,3 +1,4 @@
+/* oxlint-disable anti-slop/no-unknown-returns -- Fake Electron listeners deliberately retain the IPC boundary shape. */
 import assert from "node:assert/strict";
 import test from "node:test";
 import type { BrainAgent, BrainRequestRecord, BrainSubmission } from "@sidecar/brain";
@@ -8,8 +9,17 @@ import {
   type ConversationEntry,
   maximumTypedAskLength,
 } from "@sidecar/realtime";
-import { BRAIN_ASK_REFUSAL, brainReplyWords } from "#shared/wire/brain";
-import { followBrainRequests, publishRuns, submitBrainAsk } from "./ipc";
+import type { IpcMainEvent, IpcMainInvokeEvent, WebContents } from "electron";
+import { BRIDGE } from "#shared/bridge";
+import {
+  BRAIN_ASK_REFUSAL,
+  type BrainAskWait,
+  type BrainReplyClaimResult,
+  brainReplyWords,
+} from "#shared/wire/brain";
+import { VoiceReceiver } from "../voice-receiver";
+import { followBrainRequests, publishRuns, registerBrainIpc, submitBrainAsk } from "./ipc";
+import { BrainReplyDeliveries } from "./reply-delivery";
 
 const NOW = 1_800_000_000_000;
 
@@ -384,4 +394,233 @@ test("a retired follower relays nothing a late report carries", async () => {
   await new Promise((resolve) => setImmediate(resolve));
   assert.deepEqual(broadcasts, []);
   assert.deepEqual(written.recorded, []);
+});
+
+test("an end is published downstream only once its line and its mark have both landed, then on every later report", async () => {
+  const published: string[] = [];
+  let markRefused = true;
+  let marked = false;
+  const live = () =>
+    record({ askRecordedAt: NOW, historyRecordedAt: marked ? NOW + 2 : undefined });
+  // SAFETY: publication reads only these members off the agent.
+  const agent = {
+    request: () => live(),
+    markAskRecorded: async () => true,
+    markHistoryRecorded: async () => {
+      if (markRefused) return false;
+      marked = true;
+      return true;
+    },
+  } as unknown as BrainAgent;
+  const written = thread();
+  const report = () =>
+    publishRuns(
+      agent,
+      [live()],
+      written.record,
+      () => true,
+      (ended) => published.push(`${ended.runId}@${ended.historyRecordedAt}`),
+    );
+  // The line was taken but the mark refused: not published downstream, and
+  // the line is not written a second time on the retry because the thread
+  // already holds it for that run.
+  await report();
+  assert.deepEqual(published, []);
+  assert.equal(written.entries().length, 1);
+  markRefused = false;
+  await report();
+  assert.deepEqual(published, ["run-1@1800000000002"]);
+  assert.equal(written.entries().length, 1);
+  // Already marked: reported downstream again, written nowhere. The retry
+  // before it offered the line a second time and the thread, holding it,
+  // took nothing.
+  await report();
+  assert.deepEqual(published, ["run-1@1800000000002", "run-1@1800000000002"]);
+  assert.equal(written.recorded.length, 2);
+  assert.equal(written.entries().length, 1);
+});
+
+test("a refused thread write publishes nothing downstream, and a retired follower publishes nothing late", async () => {
+  const published: string[] = [];
+  let refuse = true;
+  // SAFETY: publication reads only these members off the agent.
+  const agent = {
+    request: () => record({ askRecordedAt: NOW, historyRecordedAt: undefined }),
+    markAskRecorded: async () => true,
+    markHistoryRecorded: async () => true,
+  } as unknown as BrainAgent;
+  const written = thread(() => refuse);
+  await publishRuns(
+    agent,
+    [record()],
+    written.record,
+    () => true,
+    (ended) => published.push(ended.runId),
+  );
+  assert.equal(published.length, 0);
+  refuse = false;
+  let following = true;
+  // The follower retires while the mark is out: the end is written, but not
+  // handed on, because nothing may be offered on a retired follower's behalf.
+  // SAFETY: publication reads only `request` and the two marks off the agent; the fixture stands in for the rest.
+  const retiringAgent = {
+    ...agent,
+    markHistoryRecorded: async () => {
+      following = false;
+      return true;
+    },
+  } as unknown as BrainAgent;
+  await publishRuns(
+    retiringAgent,
+    [record()],
+    written.record,
+    () => following,
+    (ended) => published.push(ended.runId),
+  );
+  assert.equal(published.length, 0);
+  assert.equal(written.entries().length, 1);
+});
+
+/**
+ * The grant boundary as the IPC registration actually wires it: a real
+ * ledger and receiver behind the real `registerBrainIpc`, reached through
+ * fake `ipcMain` invokes from two senders, so what is checked is what a
+ * renderer's call can and cannot do — not the ledger's own arguments.
+ */
+function registered(live: () => BrainRequestRecord | undefined) {
+  const invokes = new Map<string, (event: IpcMainInvokeEvent, ...args: unknown[]) => unknown>();
+  const sends = new Map<string, (event: IpcMainEvent, ...args: unknown[]) => void>();
+  // SAFETY: the registration reads senders by identity alone; two distinct inert objects are two windows.
+  const voiceSender = {} as WebContents;
+  // SAFETY: as above, the panel.
+  const panelSender = {} as WebContents;
+  let ids = 0;
+  const deliveries = new BrainReplyDeliveries({ nextDeliveryId: () => `delivery-${++ids}` });
+  const receiver = new VoiceReceiver();
+  const context = () => ({
+    receiverCurrent: (epoch: number) => receiver.isReady() && receiver.epoch() === epoch,
+    generationStands: (generationId: string) => generationId === "gen-1",
+    liveRecord: () => live(),
+  });
+  const acknowledged: string[] = [];
+  // SAFETY: the grant boundary reads only `request` and `waitAsk` off the agent; the fixture stands in for the rest.
+  const agent = {
+    request: () => live(),
+    waitAsk: async () => live(),
+  } as unknown as BrainAgent;
+  registerBrainIpc({
+    ipcMain: {
+      handle: (channel, listener) => {
+        invokes.set(channel, listener);
+      },
+      on: (channel, listener) => {
+        sends.set(channel, listener);
+        // SAFETY: this inert fixture implements only the IpcMain return identity the listener API requires.
+        return {} as Electron.IpcMain;
+      },
+    },
+    trustedSender: () => true,
+    brain: () => agent,
+    submitters: {
+      panel: (sender) => sender === panelSender,
+      voice: (sender) => sender === voiceSender,
+    },
+    recordConversationEntry: () => true,
+    broadcastRequests: () => undefined,
+    publicationSettled: () => Promise.resolve(),
+    replies: {
+      claim: (runId, deliveryId, epoch) => deliveries.claim(runId, deliveryId, epoch, context()),
+      acknowledge: (runId, deliveryId, epoch) => {
+        if (deliveries.acknowledge(runId, deliveryId, epoch)) acknowledged.push(runId);
+      },
+      grantOnCall: (record, epoch) => deliveries.grantOnCall(record, "gen-1", epoch, context()),
+    },
+  });
+  // SAFETY: the bridge reads only the sender off the event, and an Electron invoke listener always answers a promise.
+  const claim = (sender: WebContents, runId: string, deliveryId: string, epoch: number) =>
+    invokes.get(BRIDGE.claimBrainReply.channel)?.(
+      { sender } as IpcMainInvokeEvent,
+      runId,
+      deliveryId,
+      epoch,
+    ) as Promise<BrainReplyClaimResult>;
+  // SAFETY: as above, for the wait.
+  const wait = (sender: WebContents, runId: string, epoch: number) =>
+    invokes.get(BRIDGE.waitBrainAsk.channel)?.(
+      { sender } as IpcMainInvokeEvent,
+      runId,
+      epoch,
+    ) as Promise<BrainAskWait>;
+  const ack = (sender: WebContents, runId: string, deliveryId: string, epoch: number) =>
+    // SAFETY: the bridge reads only the sender off the event.
+    sends.get(BRIDGE.ackBrainReply.channel)?.({ sender } as IpcMainEvent, runId, deliveryId, epoch);
+  return { deliveries, receiver, voiceSender, panelSender, claim, wait, ack, acknowledged };
+}
+
+test("a claim is granted only to the voice window, for the epoch the offer went to, while that epoch stands", async () => {
+  const ended = record({ historyRecordedAt: NOW + 2 });
+  const f = registered(() => ended);
+  const first = f.receiver.begin();
+  f.receiver.markReady(first);
+  f.deliveries.observe([record({ status: BRAIN_REQUEST_STATUS.RUNNING })]);
+  f.deliveries.published(ended, "gen-1");
+  const offer = f.deliveries.nextOffer(first);
+  assert.ok(offer);
+  // A panel naming the right ids and epoch is refused.
+  assert.deepEqual(await f.claim(f.panelSender, offer.runId, offer.deliveryId, offer.epoch), {
+    granted: false,
+  });
+  // The same WebContents reloads: a new epoch, the unclaimed offer reoffered
+  // to it. The old renderer's queued invoke carries the old epoch and is
+  // refused, however current the main process's own epoch now is.
+  f.receiver.begin();
+  const second = f.receiver.begin();
+  f.receiver.markReady(second);
+  const reoffer = f.deliveries.nextOffer(second);
+  assert.ok(reoffer && reoffer.deliveryId === offer.deliveryId);
+  assert.deepEqual(await f.claim(f.voiceSender, offer.runId, offer.deliveryId, offer.epoch), {
+    granted: false,
+  });
+  // The current renderer's claim, naming the epoch of its own offer, is granted once.
+  assert.deepEqual(await f.claim(f.voiceSender, reoffer.runId, reoffer.deliveryId, reoffer.epoch), {
+    granted: true,
+    words: "Two agents are waiting.",
+    origin: BRAIN_REQUEST_ORIGIN.TYPED,
+  });
+  assert.deepEqual(await f.claim(f.voiceSender, reoffer.runId, reoffer.deliveryId, reoffer.epoch), {
+    granted: false,
+  });
+  // A stale acknowledgement — the old epoch's, or a panel's — changes nothing; the current one empties the hand.
+  f.ack(f.voiceSender, reoffer.runId, reoffer.deliveryId, first);
+  f.ack(f.panelSender, reoffer.runId, reoffer.deliveryId, second);
+  assert.deepEqual(f.acknowledged, []);
+  f.ack(f.voiceSender, reoffer.runId, reoffer.deliveryId, second);
+  assert.deepEqual(f.acknowledged, ["run-1"]);
+});
+
+test("a wait grants the asking call the words only for the current voice renderer, once, and only after History holds them", async () => {
+  let live = record({ status: BRAIN_REQUEST_STATUS.RUNNING, historyRecordedAt: undefined });
+  const f = registered(() => live);
+  const epoch = f.receiver.begin();
+  f.receiver.markReady(epoch);
+  f.deliveries.observe([live]);
+  // Still running: the record, no grant.
+  assert.deepEqual(await f.wait(f.voiceSender, "run-1", epoch), { record: live, speak: false });
+  // Ended but not yet in History — the write was refused — the call is not granted.
+  live = record({ historyRecordedAt: undefined });
+  assert.equal((await f.wait(f.voiceSender, "run-1", epoch)).speak, false);
+  // In History now. A panel, or a renderer naming a stale epoch, is not granted and consumes nothing.
+  live = record({ historyRecordedAt: NOW + 2 });
+  assert.equal((await f.wait(f.panelSender, "run-1", epoch)).speak, false);
+  assert.equal((await f.wait(f.voiceSender, "run-1", epoch - 1)).speak, false);
+  // The offer path had already offered it; the call's grant withdraws that offer.
+  f.deliveries.published(live, "gen-1");
+  const offer = f.deliveries.nextOffer(epoch);
+  assert.ok(offer);
+  assert.deepEqual(await f.wait(f.voiceSender, "run-1", epoch), { record: live, speak: true });
+  assert.deepEqual(await f.claim(f.voiceSender, offer.runId, offer.deliveryId, offer.epoch), {
+    granted: false,
+  });
+  // The grant was the run's one: a second wait is not granted again.
+  assert.equal((await f.wait(f.voiceSender, "run-1", epoch)).speak, false);
 });

--- a/apps/desktop/src/main/brain/ipc.ts
+++ b/apps/desktop/src/main/brain/ipc.ts
@@ -17,6 +17,8 @@ import { BRIDGE } from "#shared/bridge";
 import {
   type BrainAskSubmission,
   type BrainAskSubmissionResult,
+  type BrainAskWait,
+  type BrainReplyClaimResult,
   type BrainRequestSnapshot,
   brainReplyWords,
 } from "#shared/wire/brain";
@@ -45,6 +47,33 @@ export interface BrainIpcDependencies {
   recordConversationEntry: (entry: ConversationEntry, recordedAt: number) => boolean;
   /** Hands the whole list of records to every window. */
   broadcastRequests: (snapshots: readonly BrainRequestSnapshot[]) => void;
+  /**
+   * A run's end stands in the thread, written and marked: the one moment a
+   * reply becomes deliverable to the ear, handed the live record as it then
+   * reads. Called again on later reports of the same ended run, so a receiver
+   * that missed it is not owed a report that never comes; the delivery owner
+   * decides what is new.
+   */
+  onEndPublished?: (record: BrainRequestRecord) => void;
+  /**
+   * Hands the standing follower's publication chain to whoever answers a
+   * wait, so a wait that finds its run ended can let the end reach History
+   * before the words are granted anywhere.
+   */
+  onPublication?: (settled: () => Promise<void>) => void;
+  /** Settles once the standing follower has published every report taken so far. */
+  publicationSettled?: () => Promise<void>;
+  /**
+   * The one owner of every grant to speak a run's end, reached only by the
+   * voice window: the claim on an offered delivery, its acknowledgement, and
+   * the grant to the call that asked, each under the receiver epoch the
+   * caller names — never an epoch read off the main process's own state.
+   */
+  replies?: {
+    claim: (runId: string, deliveryId: string, epoch: number) => BrainReplyClaimResult;
+    acknowledge: (runId: string, deliveryId: string, epoch: number) => void;
+    grantOnCall: (record: BrainRequestRecord, epoch: number) => boolean;
+  };
   /** How long one wait holds before answering the run still pending. */
   askWaitMs?: number;
 }
@@ -101,20 +130,31 @@ async function publishAsk(
   await agent.markAskRecorded(runId, current.acceptedAt);
 }
 
-/** Writes a run's end once, at the moment it settled, and marks the run when the thread took it. */
+/**
+ * Writes a run's end once, at the moment it settled, and marks the run when
+ * the thread took it. Answers the live record once its end stands written and
+ * marked — now, or from an earlier report — and nothing while it does not: a
+ * write the thread refused, or a mark the store refused, leaves the end
+ * unpublished for the next report, and nothing downstream may treat it as
+ * said.
+ */
 async function publishEnd(
   agent: BrainPublicationAgent,
   runId: string,
   record: BrainIpcDependencies["recordConversationEntry"],
-): Promise<void> {
+): Promise<BrainRequestRecord | undefined> {
   const current = agent.request(runId);
-  if (!current || !isTerminalBrainRequestStatus(current.status)) return;
-  if (current.historyRecordedAt !== undefined) return;
+  if (!current || !isTerminalBrainRequestStatus(current.status)) return undefined;
+  if (current.historyRecordedAt !== undefined) return current;
   const words = brainReplyWords(current);
-  if (!words) return;
+  if (!words) return undefined;
   const at = current.settledAt ?? current.acceptedAt;
-  if (!record(replyConversationEntry(words, current.runId), at)) return;
-  await agent.markHistoryRecorded(runId, at);
+  if (!record(replyConversationEntry(words, current.runId), at)) return undefined;
+  if (!(await agent.markHistoryRecorded(runId, at))) return undefined;
+  // Re-read rather than patched: the mark landed on the live record, and a
+  // Clear or a replacement in the meantime has taken the record with it.
+  const marked = agent.request(runId);
+  return marked?.historyRecordedAt !== undefined ? marked : undefined;
 }
 
 /**
@@ -134,12 +174,14 @@ export async function publishRuns(
   snapshots: readonly BrainRequestSnapshot[],
   record: BrainIpcDependencies["recordConversationEntry"],
   stillFollowing: () => boolean = () => true,
+  onEndPublished: BrainIpcDependencies["onEndPublished"] = undefined,
 ): Promise<void> {
   for (const snapshot of snapshots) {
     if (!stillFollowing()) return;
     await publishAsk(agent, snapshot.runId, record);
     if (!stillFollowing()) return;
-    await publishEnd(agent, snapshot.runId, record);
+    const published = await publishEnd(agent, snapshot.runId, record);
+    if (published && stillFollowing()) onEndPublished?.(published);
   }
 }
 
@@ -155,18 +197,28 @@ export async function publishRuns(
  */
 export function followBrainRequests(
   agent: BrainAgent,
-  dependencies: Pick<BrainIpcDependencies, "recordConversationEntry" | "broadcastRequests">,
+  dependencies: Pick<
+    BrainIpcDependencies,
+    "recordConversationEntry" | "broadcastRequests" | "onEndPublished" | "onPublication"
+  >,
 ): () => Promise<void> {
   let accepting = true;
   let following = true;
   let publishing: Promise<void> = Promise.resolve();
+  dependencies.onPublication?.(() => publishing);
   const listener = (records: readonly BrainRequestRecord[]) => {
     if (!accepting) return;
     dependencies.broadcastRequests(records);
     // Reports are published one at a time, each against the records as they
     // then stand, so two reports of the same end cannot both find it unmarked.
     publishing = publishing.then(() =>
-      publishRuns(agent, records, dependencies.recordConversationEntry, () => following),
+      publishRuns(
+        agent,
+        records,
+        dependencies.recordConversationEntry,
+        () => following,
+        dependencies.onEndPublished,
+      ),
     );
   };
   const unsubscribe = agent.subscribe(listener);
@@ -198,9 +250,37 @@ export function registerBrainIpc(dependencies: BrainIpcDependencies): void {
         if (!originAllowed(context.sender, submission)) return REJECTED_SUBMISSION;
         return submitBrainAsk(brain(), submission, dependencies.recordConversationEntry);
       },
-      waitBrainAsk: (_context, runId) => brain()?.waitAsk(runId, askWaitMs),
+      // A wait that finds its run ended does not hand the words over on the
+      // strength of the record alone: the follower's publication is let
+      // finish, the live record is re-read for its History mark, and the
+      // grant to say the words on the call is asked of the delivery owner —
+      // which refuses if an offer for the run was already claimed, and
+      // withdraws an unclaimed offer if it grants. A pending run, a refused
+      // History write, or a caller that is not the current voice renderer
+      // comes back with the record and no grant, and the eventual delivery
+      // says the words instead.
+      async waitBrainAsk(context, runId, epoch): Promise<BrainAskWait> {
+        const waited = await brain()?.waitAsk(runId, askWaitMs);
+        if (!waited || !isTerminalBrainRequestStatus(waited.status)) {
+          return { record: waited, speak: false };
+        }
+        await dependencies.publicationSettled?.();
+        const live = brain()?.request(runId) ?? waited;
+        if (!submitters.voice(context.sender) || live.historyRecordedAt === undefined) {
+          return { record: live, speak: false };
+        }
+        return { record: live, speak: dependencies.replies?.grantOnCall(live, epoch) === true };
+      },
       cancelBrainAsk: (_context, runId) => brain()?.cancelAsk(runId),
       brainRequestSnapshots: () => brain()?.requests() ?? [],
+      claimBrainReply(context, runId, deliveryId, epoch): BrainReplyClaimResult {
+        if (!submitters.voice(context.sender) || !dependencies.replies) return { granted: false };
+        return dependencies.replies.claim(runId, deliveryId, epoch);
+      },
+      ackBrainReply(context, runId, deliveryId, epoch) {
+        if (!submitters.voice(context.sender)) return;
+        dependencies.replies?.acknowledge(runId, deliveryId, epoch);
+      },
     },
     { ipcMain, trustedSender },
   );

--- a/apps/desktop/src/main/brain/reply-delivery.test.ts
+++ b/apps/desktop/src/main/brain/reply-delivery.test.ts
@@ -1,0 +1,271 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { BrainRequestRecord } from "@sidecar/brain";
+import { BRAIN_REQUEST_ORIGIN, BRAIN_REQUEST_STATUS } from "@sidecar/brain/requests";
+import { type BrainReplyClaimContext, BrainReplyDeliveries } from "./reply-delivery";
+
+const NOW = 1_800_000_000_000;
+
+function record(overrides: Partial<BrainRequestRecord> = {}): BrainRequestRecord {
+  return {
+    runId: "run-1",
+    submissionId: "sub-1",
+    origin: BRAIN_REQUEST_ORIGIN.TYPED,
+    question: "what needs me?",
+    status: BRAIN_REQUEST_STATUS.RUNNING,
+    revision: 1,
+    acceptedAt: NOW,
+    startedAt: NOW + 1,
+    performedActs: 0,
+    unknownActs: 0,
+    askRecordedAt: NOW,
+    ...overrides,
+  };
+}
+
+function ended(overrides: Partial<BrainRequestRecord> = {}): BrainRequestRecord {
+  return record({
+    status: BRAIN_REQUEST_STATUS.SUCCEEDED,
+    settledAt: NOW + 2,
+    text: "Two agents are waiting.",
+    historyRecordedAt: NOW + 2,
+    revision: 3,
+    ...overrides,
+  });
+}
+
+function ledger() {
+  let ids = 0;
+  return new BrainReplyDeliveries({ nextDeliveryId: () => `delivery-${++ids}` });
+}
+
+/** A receiver ready on the epoch given, a store holding "gen-1", and a brain holding the record given. */
+function context(live: BrainRequestRecord | undefined, epoch = 1): BrainReplyClaimContext {
+  return {
+    receiverCurrent: (candidate) => candidate === epoch,
+    generationStands: (generationId) => generationId === "gen-1",
+    liveRecord: (runId) => (live && live.runId === runId ? live : undefined),
+  };
+}
+
+test("only a run watched while it was still going becomes deliverable when its end is published", () => {
+  const deliveries = ledger();
+  // Seen ended first — the bootstrap after a launch — it may already have been heard.
+  deliveries.observe([ended({ runId: "run-old" })]);
+  assert.equal(deliveries.published(ended({ runId: "run-old" }), "gen-1"), undefined);
+  deliveries.observe([ended({ runId: "run-old" }), record()]);
+  // Ended but not yet in History: nothing is owed until the publication owner says so.
+  assert.equal(deliveries.published(ended({ historyRecordedAt: undefined }), "gen-1"), undefined);
+  const delivery = deliveries.published(ended(), "gen-1");
+  assert.deepEqual(delivery, {
+    runId: "run-1",
+    deliveryId: "delivery-1",
+    generationId: "gen-1",
+    claimed: false,
+  });
+  // The same end published again — a later report — adds no second delivery.
+  assert.equal(deliveries.published(ended(), "gen-1"), undefined);
+  assert.equal(deliveries.unclaimed().length, 1);
+});
+
+test("a receiver holds one offer at a time, and the next follows the acknowledgement under the same epoch", () => {
+  const deliveries = ledger();
+  deliveries.observe([record(), record({ runId: "run-2" })]);
+  deliveries.published(ended(), "gen-1");
+  deliveries.published(ended({ runId: "run-2" }), "gen-1");
+  // Two completions flushed together: only the oldest goes out.
+  assert.deepEqual(deliveries.nextOffer(1), { runId: "run-1", deliveryId: "delivery-1", epoch: 1 });
+  assert.equal(deliveries.nextOffer(1), undefined);
+  assert.deepEqual(deliveries.claim("run-1", "delivery-1", 1, context(ended())), {
+    granted: true,
+    words: "Two agents are waiting.",
+    origin: BRAIN_REQUEST_ORIGIN.TYPED,
+  });
+  // Claimed and playing: still nothing more for this epoch.
+  assert.equal(deliveries.nextOffer(1), undefined);
+  // An acknowledgement under the wrong epoch or delivery changes nothing.
+  assert.equal(deliveries.acknowledge("run-1", "delivery-1", 2), false);
+  assert.equal(deliveries.acknowledge("run-1", "delivery-9", 1), false);
+  assert.equal(deliveries.acknowledge("run-1", "delivery-1", 1), true);
+  assert.equal(deliveries.acknowledge("run-1", "delivery-1", 1), false);
+  assert.deepEqual(deliveries.nextOffer(1), { runId: "run-2", deliveryId: "delivery-2", epoch: 1 });
+});
+
+test("a delivery is granted once, to the epoch it was offered to, and every duplicate is refused", () => {
+  const deliveries = ledger();
+  deliveries.observe([record()]);
+  assert.ok(deliveries.published(ended(), "gen-1"));
+  // Unoffered, a claim is refused: nothing was sent to anyone.
+  assert.deepEqual(deliveries.claim("run-1", "delivery-1", 1, context(ended())), {
+    granted: false,
+  });
+  deliveries.nextOffer(1);
+  // The wrong delivery id, or a claim naming another epoch, is refused — even
+  // an epoch the receiver has since moved to.
+  assert.deepEqual(deliveries.claim("run-1", "delivery-9", 1, context(ended())), {
+    granted: false,
+  });
+  assert.deepEqual(deliveries.claim("run-1", "delivery-1", 2, context(ended(), 2)), {
+    granted: false,
+  });
+  // The right epoch, but the receiver has moved on: refused.
+  assert.deepEqual(deliveries.claim("run-1", "delivery-1", 1, context(ended(), 2)), {
+    granted: false,
+  });
+  assert.deepEqual(deliveries.claim("run-1", "delivery-1", 1, context(ended())), {
+    granted: true,
+    words: "Two agents are waiting.",
+    origin: BRAIN_REQUEST_ORIGIN.TYPED,
+  });
+  // The second claim and the re-publication find the grant spent.
+  assert.deepEqual(deliveries.claim("run-1", "delivery-1", 1, context(ended())), {
+    granted: false,
+  });
+  assert.equal(deliveries.published(ended(), "gen-1"), undefined);
+  assert.deepEqual(deliveries.unclaimed(), []);
+});
+
+test("the words granted are read from the live record, in History's own wording, never from the offer", () => {
+  const deliveries = ledger();
+  deliveries.observe([record()]);
+  deliveries.published(ended(), "gen-1");
+  deliveries.nextOffer(1);
+  const live = ended({ status: BRAIN_REQUEST_STATUS.FAILED, text: undefined, performedActs: 1 });
+  assert.deepEqual(deliveries.claim("run-1", "delivery-1", 1, context(live)), {
+    granted: true,
+    words: "I did one thing you asked, but I couldn't put the reply into words.",
+    origin: BRAIN_REQUEST_ORIGIN.TYPED,
+  });
+});
+
+test("a claim is refused, and the delivery forgotten, once the generation or the run is gone", () => {
+  const deliveries = ledger();
+  deliveries.observe([record(), record({ runId: "run-2" })]);
+  deliveries.published(ended(), "gen-1");
+  deliveries.published(ended({ runId: "run-2" }), "gen-1");
+  deliveries.nextOffer(1);
+  // The store no longer holds the generation the run ended in.
+  assert.deepEqual(
+    deliveries.claim("run-1", "delivery-1", 1, {
+      ...context(ended()),
+      generationStands: () => false,
+    }),
+    { granted: false },
+  );
+  deliveries.nextOffer(1);
+  // The brain no longer holds the run — pruned, or replaced.
+  assert.deepEqual(deliveries.claim("run-2", "delivery-2", 1, context(undefined)), {
+    granted: false,
+  });
+  assert.deepEqual(deliveries.unclaimed(), []);
+  assert.equal(deliveries.nextOffer(1), undefined);
+  assert.equal(deliveries.published(ended(), "gen-1"), undefined);
+});
+
+test("a live record whose end is no longer in History, or cannot be worded, is not granted", () => {
+  const deliveries = ledger();
+  deliveries.observe([record()]);
+  deliveries.published(ended(), "gen-1");
+  deliveries.nextOffer(1);
+  assert.deepEqual(
+    deliveries.claim("run-1", "delivery-1", 1, context(ended({ historyRecordedAt: undefined }))),
+    { granted: false },
+  );
+  assert.deepEqual(
+    deliveries.claim("run-1", "delivery-1", 1, context(record({ historyRecordedAt: NOW }))),
+    { granted: false },
+  );
+  // Still unclaimed: a refusal for a record that may yet be recorded spends nothing.
+  assert.equal(deliveries.unclaimed().length, 1);
+});
+
+test("an unclaimed offer lost with its renderer is offered to the next epoch; a claimed one never is", () => {
+  const deliveries = ledger();
+  deliveries.observe([record(), record({ runId: "run-2" })]);
+  deliveries.published(ended(), "gen-1");
+  deliveries.published(ended({ runId: "run-2" }), "gen-1");
+  // Epoch 1 is offered run-1, claims it, and dies before acknowledging.
+  deliveries.nextOffer(1);
+  deliveries.claim("run-1", "delivery-1", 1, context(ended()));
+  // Epoch 2 owes nothing to epoch 1's hand: it is offered the next unclaimed
+  // at once, and run-1 — possibly already heard — is never offered again.
+  assert.deepEqual(deliveries.nextOffer(2), { runId: "run-2", deliveryId: "delivery-2", epoch: 2 });
+  // Epoch 2 dies with run-2 offered but unclaimed; epoch 3 is offered it again.
+  assert.deepEqual(deliveries.nextOffer(3), { runId: "run-2", deliveryId: "delivery-2", epoch: 3 });
+  // The old epoch's claim, arriving late through a reloaded renderer, is refused.
+  assert.deepEqual(deliveries.claim("run-2", "delivery-2", 2, context(ended(), 3)), {
+    granted: false,
+  });
+  assert.deepEqual(
+    deliveries.claim("run-2", "delivery-2", 3, context(ended({ runId: "run-2" }), 3)),
+    { granted: true, words: "Two agents are waiting.", origin: BRAIN_REQUEST_ORIGIN.TYPED },
+  );
+});
+
+test("the call that asked may be granted the words instead, once, and the offer path then yields to it", () => {
+  const deliveries = ledger();
+  const spoken = { runId: "run-s", origin: BRAIN_REQUEST_ORIGIN.SPOKEN } as const;
+  deliveries.observe([record(spoken)]);
+  // The end reached History and was offered, but the asking call comes back first.
+  deliveries.published(ended(spoken), "gen-1");
+  deliveries.nextOffer(1);
+  assert.equal(deliveries.grantOnCall(ended(spoken), "gen-1", 1, context(ended(spoken))), true);
+  // The receiver's claim on the offer is refused: the run's one grant is spent.
+  assert.deepEqual(deliveries.claim("run-s", "delivery-1", 1, context(ended(spoken))), {
+    granted: false,
+  });
+  // Neither a second on-call grant nor a later publication owes anything more.
+  assert.equal(deliveries.grantOnCall(ended(spoken), "gen-1", 1, context(ended(spoken))), false);
+  assert.equal(deliveries.published(ended(spoken), "gen-1"), undefined);
+  assert.equal(deliveries.nextOffer(1), undefined);
+});
+
+test("the call is refused the words once an offer was claimed, or before the end stands in History", () => {
+  const deliveries = ledger();
+  const spoken = { runId: "run-s", origin: BRAIN_REQUEST_ORIGIN.SPOKEN } as const;
+  deliveries.observe([record(spoken)]);
+  // The end is not yet marked in History: nobody is granted anything.
+  assert.equal(
+    deliveries.grantOnCall(
+      ended({ ...spoken, historyRecordedAt: undefined }),
+      "gen-1",
+      1,
+      context(ended({ ...spoken, historyRecordedAt: undefined })),
+    ),
+    false,
+  );
+  deliveries.published(ended(spoken), "gen-1");
+  deliveries.nextOffer(1);
+  deliveries.claim("run-s", "delivery-1", 1, context(ended(spoken)));
+  // Claimed by the offer path: the call is refused, whatever its epoch.
+  assert.equal(deliveries.grantOnCall(ended(spoken), "gen-1", 1, context(ended(spoken))), false);
+  // A caller whose epoch is not the current one — a reloaded renderer's
+  // abandoned wait — is refused too, and consumes nothing.
+  deliveries.observe([
+    record(spoken),
+    record({ runId: "run-t", origin: BRAIN_REQUEST_ORIGIN.SPOKEN }),
+  ]);
+  const later = ended({ runId: "run-t", origin: BRAIN_REQUEST_ORIGIN.SPOKEN });
+  deliveries.published(later, "gen-1");
+  assert.equal(deliveries.grantOnCall(later, "gen-1", 1, context(later, 2)), false);
+  assert.equal(
+    deliveries.unclaimed().some((delivery) => delivery.runId === "run-t"),
+    true,
+  );
+});
+
+test("a run that leaves the brain's list, and a generation that ends, take their deliveries with them", () => {
+  const deliveries = ledger();
+  deliveries.observe([record(), record({ runId: "run-2" })]);
+  deliveries.published(ended(), "gen-1");
+  // Pruned: the list no longer carries run-1.
+  deliveries.observe([record({ runId: "run-2" })]);
+  assert.deepEqual(deliveries.unclaimed(), []);
+  assert.equal(deliveries.published(ended(), "gen-1"), undefined);
+  // run-2 is still watched and ends; then the generation is cleared.
+  assert.ok(deliveries.published(ended({ runId: "run-2" }), "gen-1"));
+  deliveries.reset();
+  assert.deepEqual(deliveries.unclaimed(), []);
+  // A run of the cleared generation is not watched by the fresh one either.
+  assert.equal(deliveries.published(ended({ runId: "run-2" }), "gen-2"), undefined);
+});

--- a/apps/desktop/src/main/brain/reply-delivery.ts
+++ b/apps/desktop/src/main/brain/reply-delivery.ts
@@ -1,0 +1,231 @@
+import { type BrainRequestRecord, isTerminalBrainRequestStatus } from "@sidecar/brain/requests";
+import {
+  type BrainReplyClaimResult,
+  type BrainReplyOffer,
+  brainReplyWords,
+} from "#shared/wire/brain";
+
+/**
+ * One reply owed to the developer's ear, after the run that produced it has
+ * ended and its words already stand in History. Never persisted: a claimed
+ * delivery may already have been audible, so a launch never replays one, and
+ * an unclaimed one is worth nothing to a launch that did not watch the run.
+ */
+export interface BrainReplyDelivery {
+  runId: string;
+  deliveryId: string;
+  /** The generation the run ended in; a claim from any other generation is refused. */
+  generationId: string;
+  claimed: boolean;
+  /** The receiver epoch the offer went to, if it was sent at all. */
+  offeredEpoch?: number;
+}
+
+export interface BrainReplyDeliveriesOptions {
+  nextDeliveryId: () => string;
+}
+
+/** What a grant is checked against at the moment it lands: the receiver, the store, and the live record. */
+export interface BrainReplyClaimContext {
+  /** Whether the receiver is ready and the epoch given is its current one. */
+  receiverCurrent: (epoch: number) => boolean;
+  /** Whether the generation named still stands in the store. */
+  generationStands: (generationId: string) => boolean;
+  /** The run's record as the standing brain holds it now, or nothing. */
+  liveRecord: (runId: string) => BrainRequestRecord | undefined;
+}
+
+/**
+ * The one owner of which brain replies may still be spoken, and to whom. A
+ * run's end reaches History through the publication owner; only once that
+ * write and its mark have landed does the run become deliverable here, and
+ * only if this process watched the run while it was still going: a run first
+ * seen ended — the bootstrap after a launch, a follower's first report — may
+ * already have been heard, and History holds its words either way.
+ *
+ * Every authorization to speak a run's end passes through here, whichever
+ * way the words travel. The call that asked a spoken question may be granted
+ * the words on the spot, in its tool's own output; otherwise the run is
+ * offered, one at a time, to the receiver epoch that stands, claimed through
+ * the main process before a word is spoken, and granted exactly once. A
+ * duplicate offer, claim, or late callback finds the grant spent, and a
+ * grant on the call spends the same one the offer would have. An offer the
+ * receiver never claimed — the renderer reloaded or crashed with it in hand
+ * — is offered again to the next epoch that reports ready; a claimed one
+ * never is, because the words may already have been audible. What is
+ * guaranteed is at most one grant per run, never that the grant was heard.
+ */
+export class BrainReplyDeliveries {
+  readonly #options: BrainReplyDeliveriesOptions;
+  /** Runs this process saw before they ended, the only ones it may deliver. */
+  readonly #watched = new Set<string>();
+  /** Runs whose words were granted to the call that asked them, and so are owed nothing more. */
+  readonly #grantedOnCall = new Set<string>();
+  readonly #deliveries = new Map<string, BrainReplyDelivery>();
+
+  constructor(options: BrainReplyDeliveriesOptions) {
+    this.#options = options;
+  }
+
+  /**
+   * Follows the whole list of records as the brain reports it. A run seen
+   * still going becomes watched; a run no longer in the list — pruned, or of
+   * a generation since gone — is forgotten along with anything owed for it.
+   */
+  observe(records: readonly BrainRequestRecord[]): void {
+    const present = new Set<string>();
+    for (const record of records) {
+      present.add(record.runId);
+      if (!isTerminalBrainRequestStatus(record.status)) this.#watched.add(record.runId);
+    }
+    for (const runId of [...this.#watched]) if (!present.has(runId)) this.#forget(runId);
+    for (const runId of [...this.#grantedOnCall]) if (!present.has(runId)) this.#forget(runId);
+    for (const runId of [...this.#deliveries.keys()]) if (!present.has(runId)) this.#forget(runId);
+  }
+
+  /**
+   * A run's end has reached History. Answers the delivery now owed for it, or
+   * nothing: a run this process never watched running, one already owed,
+   * claimed, or granted on its own call, adds nothing.
+   */
+  published(record: BrainRequestRecord, generationId: string): BrainReplyDelivery | undefined {
+    if (!this.#deliverable(record)) return undefined;
+    if (!this.#watched.has(record.runId) || this.#deliveries.has(record.runId)) return undefined;
+    if (this.#grantedOnCall.has(record.runId)) return undefined;
+    const delivery: BrainReplyDelivery = {
+      runId: record.runId,
+      deliveryId: this.#options.nextDeliveryId(),
+      generationId,
+      claimed: false,
+    };
+    this.#deliveries.set(record.runId, delivery);
+    return delivery;
+  }
+
+  /**
+   * The call that asked a spoken question, back from its wait with the run
+   * ended, asking to say the words itself. Granted on the same terms as a
+   * claim — receiver current under the epoch the caller named, generation
+   * standing, the end written and marked — and only if no offer has already
+   * been claimed for the run. The grant is the run's one: an offer already
+   * out is withdrawn from the ledger by it, so the receiver's claim on that
+   * offer is refused, and the run is never offered again.
+   */
+  grantOnCall(
+    record: BrainRequestRecord,
+    generationId: string,
+    epoch: number,
+    context: BrainReplyClaimContext,
+  ): boolean {
+    if (!this.#deliverable(record) || this.#grantedOnCall.has(record.runId)) return false;
+    if (this.#deliveries.get(record.runId)?.claimed) return false;
+    if (!context.receiverCurrent(epoch) || !context.generationStands(generationId)) return false;
+    const live = context.liveRecord(record.runId);
+    if (!live || !this.#deliverable(live)) return false;
+    this.#deliveries.delete(record.runId);
+    this.#grantedOnCall.add(record.runId);
+    return true;
+  }
+
+  /** The deliveries not yet claimed, in the order their runs ended. */
+  unclaimed(): readonly BrainReplyDelivery[] {
+    return [...this.#deliveries.values()].filter((delivery) => !delivery.claimed);
+  }
+
+  /**
+   * The one offer the receiver epoch given may hold now, or nothing. A
+   * receiver holds at most one delivery at a time — offered, or claimed and
+   * not yet acknowledged — so two completions flushed together cannot claim
+   * each other's grant or talk over each other; the next is offered when the
+   * one in hand is acknowledged. A new epoch owes nothing to the old one's
+   * outstanding offer and is offered the oldest unclaimed at once.
+   */
+  nextOffer(epoch: number): BrainReplyOffer | undefined {
+    for (const delivery of this.#deliveries.values()) {
+      if (delivery.offeredEpoch === epoch) return undefined;
+    }
+    const head = this.unclaimed()[0];
+    if (!head) return undefined;
+    head.offeredEpoch = epoch;
+    return { runId: head.runId, deliveryId: head.deliveryId, epoch };
+  }
+
+  /**
+   * The receiver asking to speak one offered delivery, naming the epoch the
+   * offer came under. Granted once, only when that epoch is the one the
+   * offer went to and is still the current ready one — an epoch is never
+   * inferred from what the main process holds now — for a run whose
+   * generation still stands and whose live record still ends the way History
+   * recorded. The words are read from that record at this moment, in the
+   * same wording History holds. Anything else is refused, and a refusal for
+   * a run the brain no longer holds forgets the delivery.
+   */
+  claim(
+    runId: string,
+    deliveryId: string,
+    epoch: number,
+    context: BrainReplyClaimContext,
+  ): BrainReplyClaimResult {
+    const delivery = this.#deliveries.get(runId);
+    if (!delivery || delivery.deliveryId !== deliveryId || delivery.claimed) {
+      return { granted: false };
+    }
+    if (delivery.offeredEpoch !== epoch || !context.receiverCurrent(epoch)) {
+      return { granted: false };
+    }
+    if (!context.generationStands(delivery.generationId)) {
+      this.#forget(runId);
+      return { granted: false };
+    }
+    const live = context.liveRecord(runId);
+    if (!live) {
+      this.#forget(runId);
+      return { granted: false };
+    }
+    const words = brainReplyWords(live);
+    if (live.historyRecordedAt === undefined || words === undefined) return { granted: false };
+    delivery.claimed = true;
+    return { granted: true, words, origin: live.origin };
+  }
+
+  /**
+   * The receiver reporting the claimed delivery it held done with — its reply
+   * ended, cut short, or shown where it could not be spoken — under the epoch
+   * it was granted to. A mismatch changes nothing. Answers whether the
+   * receiver's hand is now empty, so the next may be offered.
+   */
+  acknowledge(runId: string, deliveryId: string, epoch: number): boolean {
+    const delivery = this.#deliveries.get(runId);
+    if (
+      !delivery ||
+      delivery.deliveryId !== deliveryId ||
+      !delivery.claimed ||
+      delivery.offeredEpoch !== epoch
+    ) {
+      return false;
+    }
+    this.#forget(runId);
+    return true;
+  }
+
+  /** The generation ended — cleared, expired, or replaced — and everything owed with it. */
+  reset(): void {
+    this.#watched.clear();
+    this.#grantedOnCall.clear();
+    this.#deliveries.clear();
+  }
+
+  #deliverable(record: BrainRequestRecord): boolean {
+    return (
+      isTerminalBrainRequestStatus(record.status) &&
+      record.historyRecordedAt !== undefined &&
+      brainReplyWords(record) !== undefined
+    );
+  }
+
+  #forget(runId: string): void {
+    this.#watched.delete(runId);
+    this.#grantedOnCall.delete(runId);
+    this.#deliveries.delete(runId);
+  }
+}

--- a/apps/desktop/src/main/brain/wiring.ts
+++ b/apps/desktop/src/main/brain/wiring.ts
@@ -21,7 +21,12 @@ import type { IpcMain, IpcMainEvent, IpcMainInvokeEvent } from "electron";
 import type { BrainRequestSnapshot } from "#shared/wire/brain";
 import { type BrainActPerformerDependencies, createBrainActPerformer } from "./act-performer";
 import { BrainHost } from "./host";
-import { type BrainSubmitters, followBrainRequests, registerBrainIpc } from "./ipc";
+import {
+  type BrainIpcDependencies,
+  type BrainSubmitters,
+  followBrainRequests,
+  registerBrainIpc,
+} from "./ipc";
 
 /** What a provider adapter answers a transcript read with, by the session's own id. */
 interface TranscriptReader {
@@ -40,6 +45,10 @@ export interface BrainWiringDependencies {
   traceTurn?: (record: BrainTurnTraceRecord) => void;
   recordConversationEntry: (entry: ConversationEntry, recordedAt?: number) => boolean;
   broadcastRequests: (snapshots: readonly BrainRequestSnapshot[]) => void;
+  /** A run's end stands in History, written and marked: the moment its reply may be owed to the ear. */
+  onEndPublished?: BrainIpcDependencies["onEndPublished"];
+  /** The voice window's grants: claims and acknowledgements of offered replies, and the on-call grant. */
+  replies?: BrainIpcDependencies["replies"];
   /** A generation ended — cleared, expired, or replaced — and its unspoken briefings go with it. */
   onGenerationReplaced: () => void;
   acts: BrainActPerformerDependencies;
@@ -95,11 +104,20 @@ export interface BrainWiring {
  * announced, and an ask is answered with the honest refusal.
  */
 export function wireBrain(dependencies: BrainWiringDependencies): BrainWiring {
+  // The standing follower's publication, awaited by a wait that found its run
+  // ended: the end is said only once the follower has written and marked it.
+  let publicationSettled: () => Promise<void> = () => Promise.resolve();
   const host = new BrainHost({
     follow: (agent) =>
       followBrainRequests(agent, {
         recordConversationEntry: dependencies.recordConversationEntry,
         broadcastRequests: dependencies.broadcastRequests,
+        ...(dependencies.onEndPublished
+          ? { onEndPublished: dependencies.onEndPublished }
+          : undefined),
+        onPublication: (settled) => {
+          publicationSettled = settled;
+        },
       }),
     publishEmpty: () => dependencies.broadcastRequests([]),
   });
@@ -192,6 +210,8 @@ export function wireBrain(dependencies: BrainWiringDependencies): BrainWiring {
       brain: current,
       recordConversationEntry: dependencies.recordConversationEntry,
       broadcastRequests: dependencies.broadcastRequests,
+      publicationSettled: () => publicationSettled(),
+      ...(dependencies.replies ? { replies: dependencies.replies } : undefined),
     });
   };
 

--- a/apps/desktop/src/main/desktop-app.ts
+++ b/apps/desktop/src/main/desktop-app.ts
@@ -1741,13 +1741,19 @@ const brainWiring = wireBrain({
     acknowledge: (runId, deliveryId, epoch) => {
       if (brainReplyDeliveries.acknowledge(runId, deliveryId, epoch)) offerBrainReplies();
     },
-    grantOnCall: (record, epoch) =>
-      brainReplyDeliveries.grantOnCall(
+    grantOnCall: (record, epoch) => {
+      const granted = brainReplyDeliveries.grantOnCall(
         record,
         brainWiring.store().generationId() ?? "",
         epoch,
         brainReplyClaimContext(),
-      ),
+      );
+      // The grant took the run's offer out of the receiver's hand, and no
+      // acknowledgement will come for a reply said on the call: the next owed
+      // reply is offered now, for the receiver to take at its next quiet moment.
+      if (granted) offerBrainReplies();
+      return granted;
+    },
   },
   acts: {
     sessionActs: sessionActPerformer,

--- a/apps/desktop/src/main/desktop-app.ts
+++ b/apps/desktop/src/main/desktop-app.ts
@@ -22,7 +22,7 @@ import {
   productSignInAge,
   type RecordProductEvent,
 } from "@sidecar/analytics";
-import { type BrainDelivery, brainStateFromStored } from "@sidecar/brain";
+import { type BrainDelivery, type BrainRequestRecord, brainStateFromStored } from "@sidecar/brain";
 import {
   activeMeetingEnd,
   GoogleCalendarReader,
@@ -136,6 +136,7 @@ import {
   WINDOW_ROLE,
 } from "#shared/contracts";
 import { VOICE_SOURCE_COUNTED_AS } from "#shared/product-vocabulary";
+import type { BrainRequestSnapshot } from "#shared/wire/brain";
 import { SPEECH_OUTCOME, type SpeechOutcome } from "#shared/wire/speech";
 import { IDLE_VOICE_VIEW, type VoiceView } from "#shared/wire/voice-view";
 import { buildCarriesDeveloperIdSigning, resolveAppName } from "./app-identity";
@@ -152,6 +153,7 @@ import {
 import type { WorkspaceCreationDefaults } from "./brain/act-performer";
 import { clearConversationAndBrain } from "./brain/conversation-clear";
 import { BRAIN_STATE_FILE, wakeEventsFromHooks } from "./brain/flow";
+import { BrainReplyDeliveries } from "./brain/reply-delivery";
 import { wireBrain } from "./brain/wiring";
 import {
   CALENDAR_ONBOARDING_STATE_FILE,
@@ -200,6 +202,7 @@ import { createElectronUpdaterEngine } from "./update-installer";
 import { UPDATE_ENDPOINT, UpdateService } from "./update-service";
 import { transitionVoiceCredential } from "./voice/credential-transition";
 import { type OnboardingBeatKind, SpeechArbiter } from "./voice/speech-arbiter";
+import { VoiceReceiver } from "./voice-receiver";
 import { DockPresence } from "./window/dock-presence";
 import { HOTKEY_RANK, HotkeyRegistrar } from "./window/hotkey-registrar";
 import { IntroductionWindow } from "./window/introduction-window";
@@ -477,6 +480,19 @@ let announcementsHeld = false;
  */
 let conversationHistory: readonly ConversationEntry[] = [];
 let conversationClearedAt: number | undefined;
+/**
+ * Which ended runs are still owed to the developer's ear, and to which voice
+ * renderer. Owned here, never persisted, and emptied with the generation: a
+ * launch restores the words to History and speaks none of them.
+ */
+const brainReplyDeliveries = new BrainReplyDeliveries({ nextDeliveryId: () => randomUUID() });
+/**
+ * Whether the hidden voice renderer can receive, by the main process's own
+ * account: an epoch per load, ready only on that renderer's report. Every
+ * offer to the voice window — proactive speech and owed replies alike —
+ * waits on it, and a reset takes back what the vanished renderer held.
+ */
+const voiceReceiver = new VoiceReceiver();
 /** The spool watchers standing on each hooked provider's spool, closed at quit. */
 let spoolWatchers: readonly ObservationSpoolWatcher[] = [];
 /**
@@ -804,6 +820,7 @@ const introductionWindow = new IntroductionWindow({
  */
 const voiceWindow = new VoiceWindow({
   runMode,
+  receiver: voiceReceiver,
   preloadPath: path.join(__dirname, "preload.js"),
   rendererHtmlPath: path.join(__dirname, "renderer", "index.html"),
   rendererUrl: rendererUrl(),
@@ -1712,8 +1729,26 @@ const brainWiring = wireBrain({
   report: (message) => process.stderr.write(`${message}\n`),
   ...(agentTrace ? { traceTurn: (record) => agentTrace.recordBrainTurn(record) } : undefined),
   recordConversationEntry: recordMainConversationEntry,
-  broadcastRequests: (snapshots) => broadcast(channels.onBrainRequestsChanged, snapshots),
-  onGenerationReplaced: withdrawBriefings,
+  broadcastRequests: broadcastBrainRequests,
+  onEndPublished: offerBrainReply,
+  onGenerationReplaced: () => {
+    withdrawBriefings();
+    withdrawBrainReplies();
+  },
+  replies: {
+    claim: (runId, deliveryId, epoch) =>
+      brainReplyDeliveries.claim(runId, deliveryId, epoch, brainReplyClaimContext()),
+    acknowledge: (runId, deliveryId, epoch) => {
+      if (brainReplyDeliveries.acknowledge(runId, deliveryId, epoch)) offerBrainReplies();
+    },
+    grantOnCall: (record, epoch) =>
+      brainReplyDeliveries.grantOnCall(
+        record,
+        brainWiring.store().generationId() ?? "",
+        epoch,
+        brainReplyClaimContext(),
+      ),
+  },
   acts: {
     sessionActs: sessionActPerformer,
     sessions: brainActableSessions,
@@ -1896,6 +1931,7 @@ function registerIpc(): void {
         chromiumVersion: process.versions.chrome,
         nodeVersion: process.versions.node,
         microphoneStatus: microphoneStatus(),
+        ...(voiceWindow.owns(context.sender) ? { voiceEpoch: voiceReceiver.epoch() } : undefined),
         // Both keys travel as accelerators rather than labels: the renderer needs
         // both spellings — the keycaps' ⌥ and L drawn apart, and aria's Alt+L —
         // and only the accelerator can produce the pair.
@@ -2144,6 +2180,7 @@ function registerIpc(): void {
     trustedSender,
     panels,
     voiceWindow,
+    receiver: voiceReceiver,
     broadcast,
     storeVoiceView: (view) => {
       latestVoiceView = view;
@@ -2653,10 +2690,78 @@ function settleSpeech(id: string, outcome: SpeechOutcome): void {
  */
 function offerNextSpeech(): void {
   const host = voiceWindow.current();
-  if (!host || !voiceCapabilities.realtimeCredentials) return;
+  if (!host || !voiceReceiver.isReady() || !voiceCapabilities.realtimeCredentials) return;
   const offer = speechArbiter.next();
   if (offer) host.webContents.send(channels.onSpeechOffered, offer);
 }
+
+/**
+ * The brain's whole list of records, to every window and to the delivery
+ * owner, which reads it for the runs it watched go by while they were still
+ * going — the only ones whose ends it may ever offer to the ear.
+ */
+function broadcastBrainRequests(snapshots: readonly BrainRequestSnapshot[]): void {
+  brainReplyDeliveries.observe(snapshots);
+  broadcast(channels.onBrainRequestsChanged, snapshots);
+}
+
+/**
+ * A run's end has reached the thread, written and marked. Only now may it be
+ * owed to the ear, under the generation that stands at this moment — the one
+ * the live record was read from — and it goes out at once if a receiver is
+ * ready, or waits for the next one that reports.
+ */
+function offerBrainReply(record: BrainRequestRecord): void {
+  const generationId = brainWiring.store().generationId();
+  if (generationId === undefined) return;
+  brainReplyDeliveries.published(record, generationId);
+  offerBrainReplies();
+}
+
+/** What every grant is checked against at the moment it lands, read live rather than captured. */
+function brainReplyClaimContext() {
+  return {
+    receiverCurrent: (epoch: number) => voiceReceiver.isReady() && voiceReceiver.epoch() === epoch,
+    generationStands: (generationId: string) => brainWiring.store().holdsGeneration(generationId),
+    liveRecord: (runId: string) => brainWiring.current()?.request(runId),
+  };
+}
+
+/**
+ * The generation ended under the receiver: nothing owed of it may be spoken,
+ * and a renderer holding an offer or a grant from it is told so, in the same
+ * breath as the fence, so words already granted are not played into a thread
+ * that no longer exists.
+ */
+function withdrawBrainReplies(): void {
+  brainReplyDeliveries.reset();
+  voiceWindow.current()?.webContents.send(channels.onBrainRepliesWithdrawn, voiceReceiver.epoch());
+}
+
+/**
+ * Hands the ready receiver the one delivery it may hold now, under the epoch
+ * it is sent to; the next follows its acknowledgement. Nothing is sent to a
+ * window whose renderer has not reported, and nothing here is held by the
+ * announcement quiet: a reply to the developer's own ask is conversation,
+ * not news, and speaks under a meeting the way a reply on their call would.
+ */
+function offerBrainReplies(): void {
+  const host = voiceWindow.current();
+  if (!host || !voiceReceiver.isReady()) return;
+  const offer = brainReplyDeliveries.nextOffer(voiceReceiver.epoch());
+  if (offer) host.webContents.send(channels.onBrainReplyOffered, offer);
+}
+
+// The receiver reporting ready is the flush: whatever the arbiter holds and
+// every reply still owed goes to it now. Its epoch ending takes the arbiter's
+// outstanding offer back to the head, so the next renderer is offered it at
+// once rather than after the deadline; an owed reply the vanished renderer
+// never claimed is simply still unclaimed, and a claimed one stays claimed.
+voiceReceiver.onReady(() => {
+  offerNextSpeech();
+  offerBrainReplies();
+});
+voiceReceiver.onReset(() => speechArbiter.reclaimOffer());
 
 /**
  * Takes a pending beat back from the arbiter and, when the mouth already

--- a/apps/desktop/src/main/ipc/voice-runtime.test.ts
+++ b/apps/desktop/src/main/ipc/voice-runtime.test.ts
@@ -5,6 +5,7 @@ import type { WireRecord } from "@sidecar/wire";
 import type { IpcMainEvent, IpcMainInvokeEvent, WebContents } from "electron";
 import { BRIDGE, channels } from "#shared/bridge";
 import { VOICE_COMMAND, VOICE_COMMAND_OUTCOME } from "#shared/wire/voice-view";
+import { VoiceReceiver } from "../voice-receiver";
 import type { PanelManager } from "../window/panel-manager";
 import { registerVoiceRuntimeIpc, type VoiceWindowSurface } from "./voice-runtime";
 
@@ -39,6 +40,7 @@ function fixture(clearConversation: () => Promise<boolean>) {
     displayIdFor: () => undefined,
     focusIfExpanded: () => undefined,
   } as unknown as PanelManager;
+  const receiver = new VoiceReceiver();
   registerVoiceRuntimeIpc({
     ipcMain: {
       handle: (channel, listener) => {
@@ -50,6 +52,7 @@ function fixture(clearConversation: () => Promise<boolean>) {
     trustedSender: () => true,
     panels,
     voiceWindow,
+    receiver,
     broadcast: () => undefined,
     openExternal: async () => undefined,
     chooseRealtimeCredentials: () => undefined,
@@ -67,7 +70,13 @@ function fixture(clearConversation: () => Promise<boolean>) {
       { sender } as IpcMainInvokeEvent & IpcMainEvent,
       VOICE_COMMAND.CLEAR_CONVERSATION,
     ) as Promise<unknown>;
-  return { command, sentToVoice, panelSender, voiceSender };
+  // SAFETY: as above, for the readiness report.
+  const ready = (sender: WebContents, epoch: number) =>
+    invokes.get(BRIDGE.reportVoiceReady.channel)?.(
+      { sender } as IpcMainInvokeEvent & IpcMainEvent,
+      epoch,
+    ) as Promise<unknown>;
+  return { command, ready, receiver, sentToVoice, panelSender, voiceSender };
 }
 
 test("the voice window is told to clear at the fence, before the disk answers, and the panel hears the disk's answer", async () => {
@@ -106,4 +115,24 @@ test("a Clear from anything but a panel clears nothing and tells the voice windo
   assert.equal(await f.command(f.voiceSender), undefined);
   assert.equal(cleared, 0);
   assert.deepEqual(f.sentToVoice, []);
+});
+
+test("only the voice window may report the receiver ready, and only for the current epoch", async () => {
+  const f = fixture(async () => true);
+  const epoch = f.receiver.begin();
+  // A panel claiming to be the voice renderer readies nothing.
+  assert.equal(await f.ready(f.panelSender, epoch), false);
+  assert.equal(f.receiver.isReady(), false);
+  // The voice renderer naming a stale epoch — one before its own load — is refused.
+  assert.equal(await f.ready(f.voiceSender, epoch - 1), false);
+  assert.equal(f.receiver.isReady(), false);
+  assert.equal(await f.ready(f.voiceSender, epoch), true);
+  assert.equal(f.receiver.isReady(), true);
+  // The same report again is not a second readiness.
+  assert.equal(await f.ready(f.voiceSender, epoch), false);
+  // A reload begins a new epoch; the old renderer's report no longer counts.
+  const next = f.receiver.begin();
+  assert.equal(f.receiver.isReady(), false);
+  assert.equal(await f.ready(f.voiceSender, epoch), false);
+  assert.equal(await f.ready(f.voiceSender, next), true);
 });

--- a/apps/desktop/src/main/ipc/voice-runtime.ts
+++ b/apps/desktop/src/main/ipc/voice-runtime.ts
@@ -21,6 +21,7 @@ import {
   voiceExchangeActive,
 } from "#shared/wire/voice-view";
 import { registerBridge } from "../register-bridge";
+import type { VoiceReceiver } from "../voice-receiver";
 import type { PanelManager } from "../window/panel-manager";
 
 /**
@@ -45,6 +46,8 @@ export interface VoiceRuntimeIpcDependencies {
   trustedSender: (event: IpcMainEvent | IpcMainInvokeEvent) => boolean;
   panels: PanelManager;
   voiceWindow: VoiceWindowSurface;
+  /** Whether the voice window's renderer can receive yet, which only its own report under the current epoch decides. */
+  receiver: Pick<VoiceReceiver, "markReady">;
   /** Hands a payload to every panel and the voice window alike. */
   broadcast: <Payload>(channel: string, payload: Payload) => void;
   openExternal: (url: string) => Promise<void>;
@@ -115,6 +118,14 @@ export function registerVoiceRuntimeIpc(dependencies: VoiceRuntimeIpcDependencie
       reportVoiceLevel(context, level) {
         if (!voiceWindow.owns(context.sender)) return;
         dependencies.broadcast(channels.onVoiceLevelChanged, level);
+      },
+      // The voice renderer saying it can receive. Only the renderer the
+      // window holds now may say so, and only for the epoch its own bootstrap
+      // named: a report from a panel, or from a renderer since reloaded or
+      // replaced, is refused rather than readying a receiver that is not there.
+      reportVoiceReady(context, epoch) {
+        if (!voiceWindow.owns(context.sender)) return false;
+        return dependencies.receiver.markReady(epoch);
       },
       setShortcutCapturing(context, capturing) {
         if (!panels.owns(context.sender)) return;

--- a/apps/desktop/src/main/voice-receiver.test.ts
+++ b/apps/desktop/src/main/voice-receiver.test.ts
@@ -1,0 +1,54 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { VoiceReceiver } from "./voice-receiver";
+
+test("a receiver begins unready and becomes ready only on the current epoch's report", () => {
+  const receiver = new VoiceReceiver();
+  const readyEpochs: number[] = [];
+  receiver.onReady((epoch) => readyEpochs.push(epoch));
+  assert.equal(receiver.isReady(), false);
+  // A report before any load names an epoch that never was.
+  assert.equal(receiver.markReady(0), false);
+  const epoch = receiver.begin();
+  assert.equal(receiver.isReady(), false);
+  // A stale or future epoch readies nothing.
+  assert.equal(receiver.markReady(epoch - 1), false);
+  assert.equal(receiver.markReady(epoch + 1), false);
+  assert.equal(receiver.isReady(), false);
+  assert.equal(receiver.markReady(epoch), true);
+  assert.equal(receiver.isReady(), true);
+  // A repeat of the same report changes nothing and fires nothing again.
+  assert.equal(receiver.markReady(epoch), false);
+  assert.deepEqual(readyEpochs, [epoch]);
+});
+
+test("every reload, replacement, or close ends the epoch and makes the receiver unready", () => {
+  const receiver = new VoiceReceiver();
+  const resets: number[] = [];
+  receiver.onReset((epoch) => resets.push(epoch));
+  const first = receiver.begin();
+  receiver.markReady(first);
+  // A navigation begins a new epoch: the old renderer's readiness dies with it.
+  const second = receiver.begin();
+  assert.notEqual(second, first);
+  assert.equal(receiver.isReady(), false);
+  // The old renderer's late report is refused.
+  assert.equal(receiver.markReady(first), false);
+  assert.equal(receiver.markReady(second), true);
+  // A close ends the epoch without beginning a renderer.
+  receiver.reset();
+  assert.equal(receiver.isReady(), false);
+  assert.equal(receiver.markReady(second), false);
+  // Every ending was announced with the epoch that ended.
+  assert.deepEqual(resets, [0, first, second]);
+});
+
+test("a ready listener removed hears nothing more", () => {
+  const receiver = new VoiceReceiver();
+  const heard: number[] = [];
+  const stop = receiver.onReady((epoch) => heard.push(epoch));
+  const epoch = receiver.begin();
+  stop();
+  receiver.markReady(epoch);
+  assert.deepEqual(heard, []);
+});

--- a/apps/desktop/src/main/voice-receiver.ts
+++ b/apps/desktop/src/main/voice-receiver.ts
@@ -1,0 +1,79 @@
+/**
+ * Whether the hidden voice renderer can receive anything right now, as the
+ * main process alone decides it. A BrowserWindow standing is not a receiver:
+ * between its load and the renderer's subscriptions there is a window in
+ * which every send lands on nothing, and a reload, crash, or replacement
+ * reopens that window on a renderer the main process cannot tell from the
+ * last one by its handle alone. So each load is given an epoch here, begins
+ * unready, and becomes ready only when the renderer of that same epoch says
+ * its bootstrap is applied and its subscriptions stand. Every epoch change
+ * makes the receiver unready again; whatever was offered to the old epoch is
+ * the caller's to reoffer once a new one reports.
+ */
+export type VoiceReceiverListener = (epoch: number) => void;
+
+export class VoiceReceiver {
+  #epoch = 0;
+  /** Whether a renderer has been begun and not since ended; no report counts otherwise. */
+  #open = false;
+  #ready = false;
+  readonly #readyListeners = new Set<VoiceReceiverListener>();
+  readonly #resetListeners = new Set<VoiceReceiverListener>();
+
+  /** Begins a new epoch for a renderer about to load, unready, and answers it. */
+  begin(): number {
+    this.#end();
+    this.#epoch += 1;
+    this.#open = true;
+    return this.#epoch;
+  }
+
+  /** Ends the current epoch: the renderer is gone, reloading, or being replaced. */
+  reset(): void {
+    this.#end();
+    this.#epoch += 1;
+  }
+
+  epoch(): number {
+    return this.#epoch;
+  }
+
+  isReady(): boolean {
+    return this.#ready;
+  }
+
+  /**
+   * Takes a renderer's report that it can receive. Only the current epoch's
+   * report counts, and only its first: a stale one names a renderer that no
+   * longer stands, and a repeat changes nothing. Answers whether this report
+   * is the one that made the receiver ready.
+   */
+  markReady(epoch: number): boolean {
+    if (!this.#open || epoch !== this.#epoch || this.#ready) return false;
+    this.#ready = true;
+    for (const listener of [...this.#readyListeners]) listener(epoch);
+    return true;
+  }
+
+  onReady(listener: VoiceReceiverListener): () => void {
+    this.#readyListeners.add(listener);
+    return () => {
+      this.#readyListeners.delete(listener);
+    };
+  }
+
+  /** Hears every epoch ending, with the epoch that ended, after a reset or a new beginning. */
+  onReset(listener: VoiceReceiverListener): () => void {
+    this.#resetListeners.add(listener);
+    return () => {
+      this.#resetListeners.delete(listener);
+    };
+  }
+
+  #end(): void {
+    const ended = this.#epoch;
+    this.#open = false;
+    this.#ready = false;
+    for (const listener of [...this.#resetListeners]) listener(ended);
+  }
+}

--- a/apps/desktop/src/main/voice/speech-arbiter.test.ts
+++ b/apps/desktop/src/main/voice/speech-arbiter.test.ts
@@ -430,3 +430,33 @@ test("withdrawing briefings takes the queued, the held, and the offered alike, a
   // Nothing to withdraw answers nothing, and a beat is never a briefing.
   assert.equal(arbiter.withdrawBriefings(), undefined);
 });
+
+test("reclaiming takes the outstanding offer back to the head unspoken, so the next receiver is offered it at once", () => {
+  const { arbiter, traces, clock } = harness();
+  requestBriefing(arbiter, "first");
+  requestBriefing(arbiter, "second");
+  const offered = arbiter.next();
+  assert.equal(
+    offered && isBriefingSpeech(offered.turn) ? offered.turn.briefing : undefined,
+    "first",
+  );
+  // While the offer stands, nothing else is offered.
+  assert.equal(arbiter.next(), undefined);
+  // The renderer holding it is gone: the offer is reclaimed, not settled.
+  arbiter.reclaimOffer();
+  assert.equal(arbiter.offeredId, undefined);
+  assert.equal(arbiter.pendingCount, 2);
+  const again = arbiter.next();
+  assert.equal(again && isBriefingSpeech(again.turn) ? again.turn.briefing : undefined, "first");
+  // The reoffer carries a fresh id, so a late settle from the vanished renderer
+  // names an offer nobody holds and is ignored.
+  assert.notEqual(again?.id, offered?.id);
+  assert.equal(arbiter.settle(offered?.id ?? "", SPEECH_OUTCOME.SPOKEN), undefined);
+  assert.equal(arbiter.offeredId, again?.id);
+  assert.ok(traces.some((trace) => trace.decision === SPEECH_DECISION.RECLAIMED));
+  // Reclaiming with nothing offered is a no-op, and the clock is untouched.
+  arbiter.settle(again?.id ?? "", SPEECH_OUTCOME.SPOKEN);
+  arbiter.reclaimOffer();
+  assert.equal(arbiter.pendingCount, 1);
+  assert.equal(clock.now, 1_000);
+});

--- a/apps/desktop/src/main/voice/speech-arbiter.ts
+++ b/apps/desktop/src/main/voice/speech-arbiter.ts
@@ -41,6 +41,7 @@ export const SPEECH_DECISION = {
   REQUESTED: "requested",
   OFFERED: "offered",
   DROPPED: "dropped",
+  RECLAIMED: "reclaimed",
   ...SPEECH_OUTCOME,
 } as const;
 
@@ -260,6 +261,27 @@ export class SpeechArbiter {
     this.#remove(request.id);
     this.#trace(kind, SPEECH_DECISION.DROPPED);
     return wasOffered ? request.id : undefined;
+  }
+
+  /**
+   * Takes back the outstanding offer from a receiver that is gone — the voice
+   * renderer reloaded, crashed, or was replaced with the offer in hand — and
+   * returns the request to the head unspoken, so the next receiver is offered
+   * it at once rather than after the deadline. Nothing here says whether the
+   * words were heard: an offer is not proof of speech, and a proactive turn
+   * said twice across a crash is the price of not losing it altogether. The
+   * request takes a fresh id on the way back, so the old offer's id is dead.
+   */
+  reclaimOffer(): void {
+    const offered = this.#offered;
+    if (!offered) return;
+    this.#offered = undefined;
+    const request = this.#pending.find((candidate) => candidate.id === offered.id);
+    if (!request) return;
+    // Under a fresh id, so a settle the vanished renderer still had in flight
+    // names an offer nobody holds, rather than the one about to be made.
+    request.id = this.#options.nextId();
+    this.#trace(request.kind, SPEECH_DECISION.RECLAIMED);
   }
 
   /**

--- a/apps/desktop/src/main/window/voice-window.ts
+++ b/apps/desktop/src/main/window/voice-window.ts
@@ -1,16 +1,24 @@
 import { BrowserWindow, type WebContents } from "electron";
 import type { RunMode } from "../run-mode";
+import type { VoiceReceiver } from "../voice-receiver";
 import { hardenedWebPreferences, refuseForeignNavigation } from "./hardened-window";
 
 export interface VoiceWindowOptions {
   runMode: RunMode;
+  /**
+   * Whether the renderer inside can receive anything yet, owned by the main
+   * process: every load begins an epoch unready here, and every reload,
+   * crash, replacement, or close ends it, so nothing is sent to a renderer on
+   * the strength of its window existing.
+   */
+  receiver: VoiceReceiver;
   preloadPath: string;
   rendererHtmlPath: string;
   rendererUrl: string;
   /**
    * The voice renderer died or hung and a fresh one is about to be stood up,
    * or the bound below has been reached and none will be. Nothing drawn
-   * depends on it; an outstanding speech offer recovers by its own deadline.
+   * depends on it; the receiver's reset is what reclaims anything offered.
    */
   onGone: (reason: string) => void;
   /**
@@ -72,6 +80,13 @@ export class VoiceWindow {
     });
     this.#window = window;
     refuseForeignNavigation(window, this.#options.rendererUrl);
+    this.#options.receiver.begin();
+    // A reload — a developer's, or Chromium's own after a hang — is a new
+    // renderer behind the same handle, and the old one's readiness died with
+    // it; a same-document navigation changes no renderer and ends nothing.
+    window.webContents.on("did-start-navigation", (details) => {
+      if (details.isMainFrame && !details.isSameDocument) this.#options.receiver.begin();
+    });
     window.webContents.on("did-finish-load", () => {
       this.#reopens = 0;
     });
@@ -124,6 +139,7 @@ export class VoiceWindow {
     const window = this.#window;
     this.#window = undefined;
     if (window && !window.isDestroyed()) window.destroy();
+    this.#options.receiver.reset();
   }
 
   /** The quit's own close: nothing is stood back up after it. */

--- a/apps/desktop/src/renderer/conversation-history-panel.test.ts
+++ b/apps/desktop/src/renderer/conversation-history-panel.test.ts
@@ -227,6 +227,9 @@ test("an ask whose run is still going waits beside its words and offers a cancel
   const pending = render("running");
   assert.match(pending, new RegExp(HISTORY_PENDING_LABEL));
   assert.match(pending, /class="history-cancel"/);
+  // The wait stands beneath the words, inside the bubble, after the question's
+  // own paragraph: the bubble stacks, so the status never shares the row.
+  assert.match(pending, /<\/p><span class="history-pending" role="status">/);
   // Still inside the blocked subtree: a wait is drawn beside words a recording never sees.
   assert.match(pending, /ph-no-capture/);
   const settled = render("succeeded");

--- a/apps/desktop/src/renderer/styles/history.css
+++ b/apps/desktop/src/renderer/styles/history.css
@@ -79,12 +79,23 @@
   flex-direction: column;
 }
 
-/* The bubble is the copy control's anchor. */
+/* The bubble is the copy control's anchor. It stacks: the words, then the
+   wait an ask still running draws beneath them, so a pending label never
+   shares the row with the question and squeezes beside it into a column. */
 .history-bubble {
   position: relative;
   display: flex;
   min-width: 0;
   max-width: 100%;
+  flex-direction: column;
+}
+
+.history-entry[data-speaker="you"] .history-bubble {
+  align-items: flex-end;
+}
+
+.history-entry[data-speaker="luke"] .history-bubble {
+  align-items: flex-start;
 }
 
 /* Copy sits in the bubble's free margin, absolutely positioned so a thread
@@ -136,8 +147,9 @@
 .history-pending {
   display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 0 10px 7px;
+  flex-wrap: wrap;
+  gap: 4px 8px;
+  padding: 4px 6px 2px;
   color: var(--text-secondary);
   font-size: 11.5px;
 }

--- a/apps/desktop/src/renderer/voice/realtime-session.test.ts
+++ b/apps/desktop/src/renderer/voice/realtime-session.test.ts
@@ -64,6 +64,7 @@ const CONNECTION: RealtimeConnection = {
 interface ReplyEnding {
   texts: readonly string[];
   kind: ReplyKind | undefined;
+  runId?: string;
 }
 
 interface Harness {
@@ -119,8 +120,8 @@ interface Harness {
 }
 
 /** An answer the brain accepted: words to say. */
-function brainAnswer(briefing: string): BrainAskResult {
-  return { status: ACT_RESULT_STATUS.ACCEPTED, briefing };
+function brainAnswer(briefing: string, runId = "run-1"): BrainAskResult {
+  return { status: ACT_RESULT_STATUS.ACCEPTED, briefing, runId };
 }
 
 function brainPending(): BrainAskResult {
@@ -353,8 +354,8 @@ function harness(
     onCaption: (texts) => {
       captions.push(texts);
     },
-    onReplyEnded: (texts, kind) => {
-      replyEndings.push({ texts, kind });
+    onReplyEnded: (texts, kind, runId) => {
+      replyEndings.push({ texts, kind, ...(runId !== undefined ? { runId } : undefined) });
     },
     onSpokenAsk: (transcript) => {
       spokenAsks.push(transcript);
@@ -2898,11 +2899,12 @@ test("a spoken ask goes to the brain and its answer is voiced", async () => {
   });
   settleReply(context);
 
-  // History records the words as a reply.
+  // History records the words as a reply, naming the run whose end they voice.
   assert.deepEqual(context.replyEndings, [
     {
       texts: ["Claude Code is on the tests now."],
       kind: REPLY_KIND.REPLY,
+      runId: "run-1",
     },
   ]);
 });
@@ -3781,4 +3783,119 @@ test("the developer's call replaces Luke's own and keeps the waiting press", asy
   assert.ok(context.calls.includes("microphone-requested"));
   assert.equal(context.microphoneEnabled(), true);
   assert.equal(context.session.status, REALTIME_STATUS.LISTENING);
+});
+
+test("a reply voicing a run's end names that run when it ends, and a plain reply names none", async () => {
+  const context = harness();
+  await context.session.connect();
+  context.deliverRemoteTrack();
+  await armDeveloperTurn(context);
+  assert.equal(context.session.speakReply("Two agents are waiting.", "run-7"), true);
+  context.emit({ type: REALTIME_SERVER_EVENT.RESPONSE_CREATED, response: { id: "resp-a" } });
+  context.emit({
+    type: REALTIME_SERVER_EVENT.RESPONSE_OUTPUT_ITEM_ADDED,
+    item: { id: "item-1" },
+  });
+  context.emit({
+    type: REALTIME_SERVER_EVENT.RESPONSE_OUTPUT_AUDIO_TRANSCRIPT_DELTA,
+    item_id: "item-1",
+    delta: "Two agents are waiting.",
+  });
+  context.session.stopSpeaking();
+  assert.deepEqual(context.replyEndings, [
+    { texts: ["Two agents are waiting."], kind: REPLY_KIND.REPLY, runId: "run-7" },
+  ]);
+});
+
+test("two replies overlapping each carry their own run: the one cut off keeps its attribution, the next takes none of it", async () => {
+  const context = harness();
+  await context.session.connect();
+  context.deliverRemoteTrack();
+  await armDeveloperTurn(context);
+  assert.equal(context.session.speakReply("First answer.", "run-a"), true);
+  context.emit({ type: REALTIME_SERVER_EVENT.RESPONSE_CREATED, response: { id: "resp-a" } });
+  context.emit({
+    type: REALTIME_SERVER_EVENT.RESPONSE_OUTPUT_ITEM_ADDED,
+    item: { id: "item-a" },
+  });
+  context.emit({
+    type: REALTIME_SERVER_EVENT.RESPONSE_OUTPUT_AUDIO_TRANSCRIPT_DELTA,
+    item_id: "item-a",
+    delta: "First answer.",
+  });
+  // The second reply interrupts the first: the first ends here, as its own.
+  assert.equal(context.session.speakReply("Second answer.", "run-b"), true);
+  assert.deepEqual(context.replyEndings, [
+    { texts: ["First answer."], kind: REPLY_KIND.REPLY, runId: "run-a" },
+  ]);
+  context.emit({ type: REALTIME_SERVER_EVENT.RESPONSE_CREATED, response: { id: "resp-b" } });
+  context.emit({
+    type: REALTIME_SERVER_EVENT.RESPONSE_OUTPUT_ITEM_ADDED,
+    item: { id: "item-b" },
+  });
+  context.emit({
+    type: REALTIME_SERVER_EVENT.RESPONSE_OUTPUT_AUDIO_TRANSCRIPT_DELTA,
+    item_id: "item-b",
+    delta: "Second answer.",
+  });
+  context.session.stopSpeaking();
+  assert.deepEqual(context.replyEndings.at(-1), {
+    texts: ["Second answer."],
+    kind: REPLY_KIND.REPLY,
+    runId: "run-b",
+  });
+  // A reply nobody's run produced carries no run at all.
+  await armDeveloperTurn(context);
+  context.emit({
+    type: REALTIME_SERVER_EVENT.RESPONSE_OUTPUT_ITEM_ADDED,
+    item: { id: "item-c" },
+  });
+  context.emit({
+    type: REALTIME_SERVER_EVENT.RESPONSE_OUTPUT_AUDIO_TRANSCRIPT_DELTA,
+    item_id: "item-c",
+    delta: "Just talking.",
+  });
+  context.session.stopSpeaking();
+  assert.deepEqual(context.replyEndings.at(-1), { texts: ["Just talking."], kind: undefined });
+});
+
+test("the follow-up voicing a spoken ask's answer names the run the answer came from", async () => {
+  const context = harness({
+    askBrain: async () => brainAnswer("Claude Code is on the tests now.", "run-spoken"),
+  });
+  await context.session.connect();
+  await armDeveloperTurn(context);
+  context.emit(askBrainDone("ask claude code to add tests"));
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  context.emit({
+    type: REALTIME_SERVER_EVENT.RESPONSE_OUTPUT_ITEM_ADDED,
+    item: { id: "item-answer" },
+  });
+  context.emit({
+    type: REALTIME_SERVER_EVENT.RESPONSE_OUTPUT_AUDIO_TRANSCRIPT_DELTA,
+    item_id: "item-answer",
+    delta: "Claude Code is on the tests now.",
+  });
+  context.session.stopSpeaking();
+  assert.deepEqual(context.replyEndings.at(-1), {
+    texts: ["Claude Code is on the tests now."],
+    kind: REPLY_KIND.REPLY,
+    runId: "run-spoken",
+  });
+});
+
+test("a run's reply cut off before a word arrived still hands its ending over, so its delivery is acknowledged", async () => {
+  const context = harness();
+  await context.session.connect();
+  context.deliverRemoteTrack();
+  await armDeveloperTurn(context);
+  assert.equal(context.session.speakReply("Two agents are waiting.", "run-7"), true);
+  context.emit({ type: REALTIME_SERVER_EVENT.RESPONSE_CREATED, response: { id: "resp-a" } });
+  // The developer stops it before any transcript reached the caption.
+  context.session.stopSpeaking();
+  assert.deepEqual(context.replyEndings, [{ texts: [], kind: REPLY_KIND.REPLY, runId: "run-7" }]);
+  // A reply of nobody's run that said nothing still hands nothing over.
+  await armDeveloperTurn(context);
+  context.session.stopSpeaking();
+  assert.equal(context.replyEndings.length, 1);
 });

--- a/apps/desktop/src/renderer/voice/realtime-session.ts
+++ b/apps/desktop/src/renderer/voice/realtime-session.ts
@@ -176,9 +176,13 @@ export interface RealtimeVoiceSessionCallbacks {
    * the words were a briefing or a reply, so History records each as itself.
    * The words were already spoken toward the room (the caption runs a little
    * ahead of the audio, so a cut reply hands over slightly more than was
-   * heard); the caller records them so the thread survives the call.
+   * heard); the caller records them so the thread survives the call. A reply
+   * voicing a brain run's end names that run: its words already stand in the
+   * thread, written by the main process from the record, and the caller
+   * records nothing for it. Each reply carries its own, so two overlapping —
+   * one cut off by the next — can never trade attributions.
    */
-  onReplyEnded?(texts: readonly string[], kind: ReplyKind | undefined): void;
+  onReplyEnded?(texts: readonly string[], kind: ReplyKind | undefined, runId?: string): void;
   /**
    * The developer's own spoken turn, as the voice service transcribed it. It
    * arrives on the transcription's clock — often after the reply to it has
@@ -511,6 +515,12 @@ export class RealtimeVoiceSession {
    * cleared wherever the caption is, so it can never outlive the reply.
    */
   #captionKind: ReplyKind | undefined;
+  /**
+   * The brain run whose end the reply under way is voicing, when it is one.
+   * Set with the kind and cleared wherever the caption is, so it is exactly
+   * as long-lived as the reply it names and no other reply can inherit it.
+   */
+  #captionRunId: string | undefined;
   /**
    * Whether this call has ever reported a reply's audio running out. Once it
    * has, silence stops being evidence of anything: the server says when Luke is
@@ -1248,7 +1258,7 @@ export class RealtimeVoiceSession {
    * out-of-band terms. A reply arriving over another interrupts it: the
    * developer's turn always wins, however it is taken.
    */
-  speakReply(briefing: string): boolean {
+  speakReply(briefing: string, runId?: string): boolean {
     if (!this.isConnected || !this.#withMicrophone) return false;
     if (this.#status === REALTIME_STATUS.LISTENING) return false;
     const events = briefingSpeechEvents({
@@ -1260,6 +1270,7 @@ export class RealtimeVoiceSession {
     if (this.#status === REALTIME_STATUS.RESPONDING) this.#interruptReply();
     this.#startResponse(events);
     this.#captionKind = REPLY_KIND.REPLY;
+    this.#captionRunId = runId;
     this.#emitCaption();
     return true;
   }
@@ -1663,9 +1674,14 @@ export class RealtimeVoiceSession {
     // final and still known.
     const texts = this.#captionTexts();
     const kind = this.#captionKind;
+    const runId = this.#captionRunId;
     this.#captionSegments = [];
     this.#captionKind = undefined;
-    if (texts) this.#options.onReplyEnded?.(texts, kind);
+    this.#captionRunId = undefined;
+    // A reply that said nothing leaves no words to hand over — unless it was
+    // voicing a run's end, whose ending is owed to the delivery it was granted
+    // under however little of it was heard.
+    if (texts || runId !== undefined) this.#options.onReplyEnded?.(texts ?? [], kind, runId);
     this.#options.onCaption(undefined, undefined);
   }
 
@@ -1673,6 +1689,7 @@ export class RealtimeVoiceSession {
   #discardCaption(): void {
     this.#captionSegments = [];
     this.#captionKind = undefined;
+    this.#captionRunId = undefined;
     this.#options.onCaption(undefined, undefined);
   }
 
@@ -2177,6 +2194,7 @@ export class RealtimeVoiceSession {
     // travels, because the brain did what it says it did.
     if (epoch === this.#turnEpoch) {
       this.#captionKind = REPLY_KIND.REPLY;
+      this.#captionRunId = answer.runId;
       this.#emitCaption();
     }
     return { briefing: answer.briefing };

--- a/apps/desktop/src/renderer/voice/reply-delivery-player.test.ts
+++ b/apps/desktop/src/renderer/voice/reply-delivery-player.test.ts
@@ -232,3 +232,64 @@ test("a delivered reply carries the origin of the ask it answers, so only a type
   await tick();
   assert.deepEqual(h.log.slice(2), ["speak run-s: Later.", "speaking spoken"]);
 });
+
+test("a grant landing after the developer took the turn is held, not spoken over them, and spoken once at the next quiet status", async () => {
+  const h = harness();
+  h.session.isConnected = true;
+  h.session.microphoneCall = true;
+  h.session.status = REALTIME_STATUS.READY;
+  h.player.offer(offer("run-1"));
+  assert.deepEqual(h.log, ["claim run-1@1"]);
+  // The developer starts a turn while the claim is out.
+  h.session.status = REALTIME_STATUS.LISTENING;
+  h.player.onStatus(REALTIME_STATUS.LISTENING);
+  h.grant(granted("Held words."));
+  await tick();
+  assert.deepEqual(h.log, ["claim run-1@1"]);
+  h.session.status = REALTIME_STATUS.RESPONDING;
+  h.player.onStatus(REALTIME_STATUS.RESPONDING);
+  await tick();
+  assert.deepEqual(h.log, ["claim run-1@1"]);
+  // Their reply ends: the held grant is spoken, with no second claim.
+  h.session.status = REALTIME_STATUS.READY;
+  h.player.onStatus(REALTIME_STATUS.READY);
+  await tick();
+  assert.deepEqual(h.log.slice(1), ["speak run-1: Held words.", "speaking typed"]);
+  assert.equal(h.player.active?.runId, "run-1");
+});
+
+test("a grant whose call opened into the developer's turn is held through the connect and spoken once later", async () => {
+  const h = harness();
+  h.player.offer(offer("run-1"));
+  h.grant(granted("Held words."));
+  await tick();
+  assert.deepEqual(h.log, ["claim run-1@1", "connect"]);
+  // The call opens, but the developer is already talking on it.
+  h.connected(true);
+  h.session.status = REALTIME_STATUS.LISTENING;
+  await tick();
+  assert.deepEqual(h.log, ["claim run-1@1", "connect"]);
+  h.player.onStatus(REALTIME_STATUS.RESPONDING);
+  h.session.status = REALTIME_STATUS.READY;
+  h.player.onStatus(REALTIME_STATUS.READY);
+  await tick();
+  assert.deepEqual(h.log.slice(2), ["speak run-1: Held words.", "speaking typed"]);
+  assert.equal(h.log.filter((line) => line.startsWith("claim")).length, 1);
+});
+
+test("a held grant is voided by a withdrawal: the next quiet status speaks nothing and acknowledges nothing", async () => {
+  const h = harness();
+  h.session.isConnected = true;
+  h.session.microphoneCall = true;
+  h.session.status = REALTIME_STATUS.READY;
+  h.player.offer(offer("run-1"));
+  h.session.status = REALTIME_STATUS.RESPONDING;
+  h.player.onStatus(REALTIME_STATUS.RESPONDING);
+  h.grant(granted("Held words."));
+  await tick();
+  h.player.withdraw();
+  h.session.status = REALTIME_STATUS.READY;
+  h.player.onStatus(REALTIME_STATUS.READY);
+  await tick();
+  assert.deepEqual(h.log, ["claim run-1@1"]);
+});

--- a/apps/desktop/src/renderer/voice/reply-delivery-player.test.ts
+++ b/apps/desktop/src/renderer/voice/reply-delivery-player.test.ts
@@ -1,0 +1,234 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { BRAIN_REQUEST_ORIGIN, type BrainRequestOrigin } from "@sidecar/brain/requests";
+import { REALTIME_STATUS, type RealtimeStatus } from "@sidecar/realtime";
+import type { BrainReplyClaimResult, BrainReplyOffer } from "#shared/wire/brain";
+import { ReplyDeliveryPlayer } from "./reply-delivery-player";
+
+interface Harness {
+  player: ReplyDeliveryPlayer;
+  /** What the player did, in order: claims, connects, speaks, notices, acknowledgements. */
+  log: string[];
+  /** Answers the outstanding claim. */
+  grant: (result: BrainReplyClaimResult) => void;
+  /** Answers the outstanding connect. */
+  connected: (opened: boolean) => void;
+  session: {
+    isConnected: boolean;
+    microphoneCall: boolean;
+    status: RealtimeStatus;
+    speaks: boolean;
+  };
+  generation: { current: number };
+}
+
+function offer(runId: string, epoch = 1): BrainReplyOffer {
+  return { runId, deliveryId: `delivery-${runId}`, epoch };
+}
+
+function harness(): Harness {
+  const log: string[] = [];
+  const claims: ((result: BrainReplyClaimResult) => void)[] = [];
+  const connects: ((opened: boolean) => void)[] = [];
+  const session: Harness["session"] = {
+    isConnected: false,
+    microphoneCall: false,
+    status: REALTIME_STATUS.IDLE,
+    speaks: true,
+  };
+  const generation = { current: 1 };
+  const player = new ReplyDeliveryPlayer({
+    session: () => ({
+      get isConnected() {
+        return session.isConnected;
+      },
+      get microphoneCall() {
+        return session.microphoneCall;
+      },
+      get status() {
+        return session.status;
+      },
+      speakReply: (words, runId) => {
+        log.push(`speak ${runId}: ${words}`);
+        return session.speaks;
+      },
+    }),
+    connect: () => {
+      log.push("connect");
+      return new Promise((resolve) => {
+        connects.push(resolve);
+      });
+    },
+    claim: (candidate) => {
+      log.push(`claim ${candidate.runId}@${candidate.epoch}`);
+      return new Promise((resolve) => {
+        claims.push(resolve);
+      });
+    },
+    acknowledge: (candidate) => log.push(`ack ${candidate.runId}@${candidate.epoch}`),
+    showNotice: (words) => log.push(`notice ${words}`),
+    onSpeaking: (origin) => log.push(`speaking ${origin}`),
+    conversationGeneration: () => generation.current,
+  });
+  return {
+    player,
+    log,
+    grant: (result) => claims.shift()?.(result),
+    connected: (opened) => {
+      session.isConnected = opened;
+      session.microphoneCall = opened;
+      if (opened) session.status = REALTIME_STATUS.READY;
+      connects.shift()?.(opened);
+    },
+    session,
+    generation,
+  };
+}
+
+const tick = () => new Promise((resolve) => setImmediate(resolve));
+
+function granted(
+  words: string,
+  origin: BrainRequestOrigin = BRAIN_REQUEST_ORIGIN.TYPED,
+): BrainReplyClaimResult {
+  return { granted: true, words, origin };
+}
+
+test("an offer is claimed, the call opened, the words spoken once, and acknowledged when the reply ends", async () => {
+  const h = harness();
+  h.player.offer(offer("run-1"));
+  assert.deepEqual(h.log, ["claim run-1@1"]);
+  h.grant(granted("Two agents are waiting."));
+  await tick();
+  assert.deepEqual(h.log.slice(1), ["connect"]);
+  h.connected(true);
+  await tick();
+  assert.deepEqual(h.log.slice(2), ["speak run-1: Two agents are waiting.", "speaking typed"]);
+  assert.equal(h.player.active?.runId, "run-1");
+  // The same offer again is the same offer; another run's ending is not this one's.
+  h.player.offer(offer("run-1"));
+  h.player.onReplyEnded("run-other");
+  assert.equal(h.log.length, 4);
+  h.player.onReplyEnded("run-1");
+  assert.deepEqual(h.log.slice(4), ["ack run-1@1"]);
+  assert.equal(h.player.active, undefined);
+});
+
+test("a Clear while the claim is out leaves the granted words unspoken, unshown, and unacknowledged", async () => {
+  const h = harness();
+  h.player.offer(offer("run-1"));
+  // The History generation moves while the claim is in flight.
+  h.generation.current += 1;
+  h.player.withdraw();
+  h.grant(granted("Old words."));
+  await tick();
+  assert.deepEqual(h.log, ["claim run-1@1"]);
+  assert.equal(h.player.pending, undefined);
+  assert.equal(h.player.active, undefined);
+});
+
+test("a withdrawn generation while the call is opening leaves the words unspoken and nothing acknowledged", async () => {
+  const h = harness();
+  h.player.offer(offer("run-1"));
+  h.grant(granted("Old words."));
+  await tick();
+  assert.deepEqual(h.log, ["claim run-1@1", "connect"]);
+  // The generation ends — expiry, or a Clear from a panel — mid-connect.
+  h.player.withdraw();
+  h.connected(true);
+  await tick();
+  assert.deepEqual(h.log, ["claim run-1@1", "connect"]);
+  // A new offer, of the new generation, is claimed afresh.
+  h.player.offer(offer("run-2", 1));
+  assert.deepEqual(h.log.at(-1), "claim run-2@1");
+});
+
+test("a newer offer arriving during a claim retires the older attempt without speaking it", async () => {
+  const h = harness();
+  h.player.offer(offer("run-1"));
+  h.player.offer(offer("run-2"));
+  h.grant(granted("First."));
+  await tick();
+  // The first grant is not spoken; the pending offer is now the second, claimed next.
+  assert.deepEqual(h.log, ["claim run-1@1", "claim run-2@1"]);
+});
+
+test("a refused claim empties the hand with nothing said", async () => {
+  const h = harness();
+  h.player.offer(offer("run-1"));
+  h.grant({ granted: false });
+  await tick();
+  assert.deepEqual(h.log, ["claim run-1@1"]);
+  assert.equal(h.player.pending, undefined);
+});
+
+test("words the voice cannot say are shown once and acknowledged at once", async () => {
+  const h = harness();
+  h.session.speaks = false;
+  h.player.offer(offer("run-1"));
+  h.grant(granted("Two agents are waiting."));
+  await tick();
+  h.connected(true);
+  await tick();
+  assert.deepEqual(h.log.slice(2), [
+    "speak run-1: Two agents are waiting.",
+    "notice Two agents are waiting.",
+    "ack run-1@1",
+  ]);
+  assert.equal(h.player.active, undefined);
+});
+
+test("an offer waits for a quiet moment: not while the developer talks or a reply is under way", async () => {
+  const h = harness();
+  h.session.isConnected = true;
+  h.session.microphoneCall = true;
+  h.session.status = REALTIME_STATUS.LISTENING;
+  h.player.offer(offer("run-1"));
+  assert.deepEqual(h.log, []);
+  h.session.status = REALTIME_STATUS.RESPONDING;
+  h.player.onStatus(REALTIME_STATUS.RESPONDING);
+  assert.deepEqual(h.log, []);
+  // The developer's own reply ends; now the offer is claimed, on the open call.
+  h.session.status = REALTIME_STATUS.READY;
+  h.player.onStatus(REALTIME_STATUS.READY);
+  assert.deepEqual(h.log, ["claim run-1@1"]);
+  h.grant(granted("Now."));
+  await tick();
+  assert.deepEqual(h.log.slice(1), ["speak run-1: Now.", "speaking typed"]);
+});
+
+test("the call ending under a delivered reply acknowledges it, so the next may be offered", async () => {
+  const h = harness();
+  h.player.offer(offer("run-1"));
+  h.grant(granted("Words."));
+  await tick();
+  h.connected(true);
+  await tick();
+  assert.equal(h.player.active?.runId, "run-1");
+  h.session.status = REALTIME_STATUS.FAILED;
+  h.player.onStatus(REALTIME_STATUS.FAILED);
+  assert.deepEqual(h.log.at(-1), "ack run-1@1");
+  assert.equal(h.player.active, undefined);
+});
+
+test("a withdrawal while a delivered reply plays acknowledges nothing: the main process already let go", async () => {
+  const h = harness();
+  h.player.offer(offer("run-1"));
+  h.grant(granted("Words."));
+  await tick();
+  h.connected(true);
+  await tick();
+  h.player.withdraw();
+  h.player.onReplyEnded("run-1");
+  assert.equal(h.log.filter((line) => line.startsWith("ack")).length, 0);
+});
+
+test("a delivered reply carries the origin of the ask it answers, so only a typed one holds the composer's caption", async () => {
+  const h = harness();
+  h.player.offer(offer("run-s"));
+  h.grant(granted("Later.", BRAIN_REQUEST_ORIGIN.SPOKEN));
+  await tick();
+  h.connected(true);
+  await tick();
+  assert.deepEqual(h.log.slice(2), ["speak run-s: Later.", "speaking spoken"]);
+});

--- a/apps/desktop/src/renderer/voice/reply-delivery-player.ts
+++ b/apps/desktop/src/renderer/voice/reply-delivery-player.ts
@@ -46,9 +46,29 @@ export interface ReplyDeliveryPlayerOptions {
  * the end, cut short by the developer, lost with the call — or at once when
  * the words could only be shown, so the next owed reply can be offered.
  */
+interface HeldGrant {
+  offer: BrainReplyOffer;
+  words: string;
+  origin: BrainRequestOrigin;
+}
+
+function busy(status: RealtimeStatus): boolean {
+  return (
+    status === REALTIME_STATUS.LISTENING ||
+    status === REALTIME_STATUS.RESPONDING ||
+    status === REALTIME_STATUS.CONNECTING
+  );
+}
+
 export class ReplyDeliveryPlayer {
   readonly #options: ReplyDeliveryPlayerOptions;
   #pending: BrainReplyOffer | undefined;
+  /**
+   * Words granted but not yet spoken: the developer took the turn, or a reply
+   * was still under way, when the grant landed. Held here until a quiet
+   * status, spoken then without a second claim, and voided by a withdrawal.
+   */
+  #granted: HeldGrant | undefined;
   #active: BrainReplyOffer | undefined;
   #withdrawals = 0;
   #attempting = false;
@@ -69,6 +89,7 @@ export class ReplyDeliveryPlayer {
   offer(offer: BrainReplyOffer): void {
     if (
       this.#pending?.deliveryId === offer.deliveryId ||
+      this.#granted?.offer.deliveryId === offer.deliveryId ||
       this.#active?.deliveryId === offer.deliveryId
     ) {
       return;
@@ -86,6 +107,7 @@ export class ReplyDeliveryPlayer {
   withdraw(): void {
     this.#withdrawals += 1;
     this.#pending = undefined;
+    this.#granted = undefined;
     this.#active = undefined;
   }
 
@@ -115,47 +137,61 @@ export class ReplyDeliveryPlayer {
     if (active) this.#options.acknowledge(active);
   }
 
+  /**
+   * One pass at the offer or the held grant, at a quiet moment. The status is
+   * read again after every await, because the developer may have taken the
+   * turn while the claim or the call was out: words granted then are held,
+   * not spoken over them, and the next quiet status speaks them.
+   */
   async #attempt(): Promise<void> {
-    if (this.#attempting || this.#active || !this.#pending) return;
-    const status = this.#options.session().status;
-    if (
-      status === REALTIME_STATUS.LISTENING ||
-      status === REALTIME_STATUS.RESPONDING ||
-      status === REALTIME_STATUS.CONNECTING
-    ) {
-      return;
-    }
-    const offer = this.#pending;
+    if (this.#attempting || this.#active) return;
+    const held = this.#granted;
+    const offer = held?.offer ?? this.#pending;
+    if (!offer || busy(this.#options.session().status)) return;
     const generation = this.#options.conversationGeneration();
     const withdrawals = this.#withdrawals;
     const moved = () =>
-      this.#pending !== offer ||
-      generation !== this.#options.conversationGeneration() ||
-      withdrawals !== this.#withdrawals;
+      generation !== this.#options.conversationGeneration() || withdrawals !== this.#withdrawals;
     this.#attempting = true;
     try {
-      const claim = await this.#options.claim(offer);
-      if (moved()) return;
-      if (!claim.granted) {
+      let grant = held;
+      if (!grant) {
+        const claim = await this.#options.claim(offer);
+        if (moved() || this.#pending !== offer) return;
+        if (!claim.granted) {
+          this.#pending = undefined;
+          return;
+        }
+        grant = { offer, words: claim.words, origin: claim.origin };
+        this.#granted = grant;
         this.#pending = undefined;
-        return;
       }
       const session = this.#options.session();
-      const connected =
-        !session.isConnected || !session.microphoneCall ? await this.#options.connect() : true;
-      if (moved()) return;
-      this.#pending = undefined;
-      if (connected && this.#options.session().speakReply(claim.words, offer.runId)) {
-        this.#active = offer;
-        this.#options.onSpeaking(claim.origin);
+      if (!session.isConnected || !session.microphoneCall) {
+        const connected = await this.#options.connect();
+        if (moved() || this.#granted !== grant) return;
+        if (!connected) {
+          this.#granted = undefined;
+          this.#options.showNotice(grant.words);
+          this.#options.acknowledge(grant.offer);
+          return;
+        }
+      }
+      // The developer may have taken the turn meanwhile: the grant waits for
+      // the next quiet status rather than speaking over them.
+      if (busy(this.#options.session().status)) return;
+      this.#granted = undefined;
+      if (this.#options.session().speakReply(grant.words, grant.offer.runId)) {
+        this.#active = grant.offer;
+        this.#options.onSpeaking(grant.origin);
         return;
       }
-      this.#options.showNotice(claim.words);
-      this.#options.acknowledge(offer);
+      this.#options.showNotice(grant.words);
+      this.#options.acknowledge(grant.offer);
     } finally {
       this.#attempting = false;
       // An offer that arrived while this attempt was out is the one in hand now.
-      if (this.#pending && this.#pending !== offer) void this.#attempt();
+      if (!this.#granted && this.#pending && this.#pending !== offer) void this.#attempt();
     }
   }
 }

--- a/apps/desktop/src/renderer/voice/reply-delivery-player.ts
+++ b/apps/desktop/src/renderer/voice/reply-delivery-player.ts
@@ -1,0 +1,161 @@
+import type { BrainRequestOrigin } from "@sidecar/brain/requests";
+import { REALTIME_STATUS, type RealtimeStatus } from "@sidecar/realtime";
+import type { BrainReplyClaimResult, BrainReplyOffer } from "#shared/wire/brain";
+
+/** The slice of the voice session a delivered reply is spoken through. */
+export interface ReplyDeliverySession {
+  readonly isConnected: boolean;
+  readonly microphoneCall: boolean;
+  readonly status: RealtimeStatus;
+  speakReply(words: string, runId: string): boolean;
+}
+
+export interface ReplyDeliveryPlayerOptions {
+  session: () => ReplyDeliverySession;
+  /** Opens the developer's own call for the words when none stands; answers whether it did. */
+  connect: () => Promise<boolean>;
+  claim: (offer: BrainReplyOffer) => Promise<BrainReplyClaimResult>;
+  acknowledge: (offer: BrainReplyOffer) => void;
+  /** Puts words on the strip when the voice cannot say them. */
+  showNotice: (words: string) => void;
+  /** A delivered reply has begun speaking on the developer's call, answering an ask of the origin given. */
+  onSpeaking: (origin: BrainRequestOrigin) => void;
+  /** The History generation as this window holds it, which a Clear advances. */
+  conversationGeneration: () => number;
+}
+
+/**
+ * The receiving end of a reply delivery: the one offer this window holds from
+ * the main process, and the one grant it is playing. The main process offers
+ * one at a time and the next only after the acknowledgement, so nothing here
+ * queues; what this owns is the boundary the words cross on the way to being
+ * heard, and the checks on every side of each await.
+ *
+ * An offer is claimed only at a quiet moment — not while the developer is
+ * talking or a reply is still under way, because a delivered reply is not
+ * theirs to interrupt with, nor another reply's — and the identity of the
+ * moment is captured first: the offer in hand, the History generation, and
+ * this window's own withdrawal count. It is checked again after the claim
+ * lands, after the call opens, and immediately before a word is spoken or
+ * shown. A Clear, a withdrawn generation, or a newer offer arriving during
+ * any of those awaits means the words granted are never spoken, shown, or
+ * acknowledged: History holds them, and nothing re-stamps them with the
+ * generation that came after.
+ *
+ * A grant is acknowledged when its reply has ended by any route — spoken to
+ * the end, cut short by the developer, lost with the call — or at once when
+ * the words could only be shown, so the next owed reply can be offered.
+ */
+export class ReplyDeliveryPlayer {
+  readonly #options: ReplyDeliveryPlayerOptions;
+  #pending: BrainReplyOffer | undefined;
+  #active: BrainReplyOffer | undefined;
+  #withdrawals = 0;
+  #attempting = false;
+
+  constructor(options: ReplyDeliveryPlayerOptions) {
+    this.#options = options;
+  }
+
+  get pending(): BrainReplyOffer | undefined {
+    return this.#pending;
+  }
+
+  get active(): BrainReplyOffer | undefined {
+    return this.#active;
+  }
+
+  /** The main process offering one ended run's reply; the same offer again is the same offer. */
+  offer(offer: BrainReplyOffer): void {
+    if (
+      this.#pending?.deliveryId === offer.deliveryId ||
+      this.#active?.deliveryId === offer.deliveryId
+    ) {
+      return;
+    }
+    this.#pending = offer;
+    void this.#attempt();
+  }
+
+  /**
+   * Everything offered or granted is void: the thread was cleared, or the
+   * generation the words came from ended. Nothing is acknowledged — the main
+   * process has already let go of it — and any attempt still in flight finds
+   * its moment gone.
+   */
+  withdraw(): void {
+    this.#withdrawals += 1;
+    this.#pending = undefined;
+    this.#active = undefined;
+  }
+
+  onStatus(status: RealtimeStatus): void {
+    if (
+      this.#active &&
+      (status === REALTIME_STATUS.IDLE ||
+        status === REALTIME_STATUS.FAILED ||
+        status === REALTIME_STATUS.UNAVAILABLE)
+    ) {
+      // The call went with the reply on it: whatever was heard was heard.
+      this.#settleActive();
+    }
+    void this.#attempt();
+  }
+
+  /** A reply naming a run ended; if it was the grant in hand, the hand is empty. */
+  onReplyEnded(runId: string): void {
+    if (this.#active?.runId !== runId) return;
+    this.#settleActive();
+    void this.#attempt();
+  }
+
+  #settleActive(): void {
+    const active = this.#active;
+    this.#active = undefined;
+    if (active) this.#options.acknowledge(active);
+  }
+
+  async #attempt(): Promise<void> {
+    if (this.#attempting || this.#active || !this.#pending) return;
+    const status = this.#options.session().status;
+    if (
+      status === REALTIME_STATUS.LISTENING ||
+      status === REALTIME_STATUS.RESPONDING ||
+      status === REALTIME_STATUS.CONNECTING
+    ) {
+      return;
+    }
+    const offer = this.#pending;
+    const generation = this.#options.conversationGeneration();
+    const withdrawals = this.#withdrawals;
+    const moved = () =>
+      this.#pending !== offer ||
+      generation !== this.#options.conversationGeneration() ||
+      withdrawals !== this.#withdrawals;
+    this.#attempting = true;
+    try {
+      const claim = await this.#options.claim(offer);
+      if (moved()) return;
+      if (!claim.granted) {
+        this.#pending = undefined;
+        return;
+      }
+      const session = this.#options.session();
+      const connected =
+        !session.isConnected || !session.microphoneCall ? await this.#options.connect() : true;
+      if (moved()) return;
+      this.#pending = undefined;
+      if (connected && this.#options.session().speakReply(claim.words, offer.runId)) {
+        this.#active = offer;
+        this.#options.onSpeaking(claim.origin);
+        return;
+      }
+      this.#options.showNotice(claim.words);
+      this.#options.acknowledge(offer);
+    } finally {
+      this.#attempting = false;
+      // An offer that arrived while this attempt was out is the one in hand now.
+      if (this.#pending && this.#pending !== offer) void this.#attempt();
+    }
+  }
+}

--- a/apps/desktop/src/renderer/voice/use-voice-session.ts
+++ b/apps/desktop/src/renderer/voice/use-voice-session.ts
@@ -30,7 +30,6 @@ import {
   BRAIN_ASK_PENDING_STATUS,
   BRAIN_ASK_REFUSAL,
   type BrainAskResult,
-  type BrainRequestSnapshot,
   brainReplyWords,
   brainRequestPending,
 } from "#shared/wire/brain";
@@ -47,8 +46,10 @@ import { useStateWithRef } from "../use-state-with-ref";
 import { outputSilent } from "../volume-hint";
 import { openPreferredMicrophone } from "./microphone-choice";
 import { REPLY_KIND, RealtimeVoiceSession, type ReplyKind } from "./realtime-session";
+import { ReplyDeliveryPlayer } from "./reply-delivery-player";
 import { SpeechMouth } from "./speech-mouth";
 import { startVoiceLevelMeter } from "./voice-level-meter";
+import { VOICE_READINESS_PART, VoiceReadiness } from "./voice-readiness";
 
 /**
  * What a changed voice on a live call should do. The API locks a session's
@@ -416,10 +417,19 @@ export function useVoiceSession(remoteAudio: RefObject<HTMLAudioElement | null>)
    * edge the count is taken on.
    */
   const typedExchange = useRef(false);
-  /** The brain run whose reply the voice is speaking now, so its words are not recorded twice. */
-  const brainReplyRunRef = useRef<string | undefined>(undefined);
-  /** Each run's last status this window saw, so only an end it watched arrive is spoken. */
-  const knownRequestsRef = useRef(new Map<string, BrainRequestSnapshot["status"]>());
+  /**
+   * What this window must have standing before the main process may send it
+   * anything, reported once under the epoch the bootstrap named. Built here
+   * so the effects below can mark their subscriptions as they install.
+   */
+  const readiness = useRef<VoiceReadiness | undefined>(undefined);
+  readiness.current ??= new VoiceReadiness((epoch) => void window.sidecar.reportVoiceReady(epoch));
+  /** The receiver epoch the bootstrap gave this load, which every grant asked of the main process names. */
+  const voiceEpochRef = useRef<number | undefined>(undefined);
+  /** The receiving end of reply deliveries; built beside the session, below. */
+  const replyPlayer = useRef<ReplyDeliveryPlayer | undefined>(undefined);
+  /** Rises whenever the brain's generation ends under this window, so a grant held across it is void. */
+  const replyWithdrawalsRef = useRef(0);
   /**
    * The conversation history, surviving here across calls: a call is a
    * transport that comes and goes — an announcement is often read out on
@@ -550,6 +560,10 @@ export function useVoiceSession(remoteAudio: RefObject<HTMLAudioElement | null>)
     talkPressedAt.current = undefined;
     activeReplyGenerationRef.current = undefined;
     activeAnnouncementGenerationRef.current = undefined;
+    // A reply offered or granted before the press belongs to the cleared
+    // thread: not spoken, not shown, not acknowledged.
+    replyWithdrawalsRef.current += 1;
+    replyPlayer.current?.withdraw();
   }, []);
 
   /**
@@ -697,7 +711,6 @@ export function useVoiceSession(remoteAudio: RefObject<HTMLAudioElement | null>)
       // recorded by the main process at the run's end, so the words that end
       // here are not recorded again.
       askBrain: async (question, submissionId): Promise<BrainAskResult> => {
-        brainReplyRunRef.current = undefined;
         // The turn this ask belongs to is the one committed when the ask was
         // made, read before the acceptance is awaited: a turn committed while
         // the brain is deciding is somebody else's words.
@@ -714,22 +727,41 @@ export function useVoiceSession(remoteAudio: RefObject<HTMLAudioElement | null>)
           };
         }
         tieSpokenTurnToRun(spokenTurn, submitted.runId);
-        const record = await window.sidecar.waitBrainAsk(submitted.runId);
-        if (!record) {
+        // The wait names this load's receiver epoch: the words come back for
+        // this call to say only if the main process grants them to it, once,
+        // with the end already in History. Otherwise the run is reported as
+        // still going and its reply is delivered later, by the same owner.
+        // The moment is captured first: a Clear or a withdrawn generation
+        // while the wait is held means words granted to it are not said —
+        // the follow-up hears the pending note, and History holds nothing
+        // of the thread they answered.
+        const generation = conversationGenerationRef.current;
+        const withdrawals = replyWithdrawalsRef.current;
+        const waited = await window.sidecar.waitBrainAsk(
+          submitted.runId,
+          voiceEpochRef.current ?? 0,
+        );
+        if (!waited.record) {
           return { status: ACT_RESULT_STATUS.REJECTED, reason: BRAIN_ASK_REFUSAL.absent };
         }
-        if (brainRequestPending(record)) {
+        const moved =
+          generation !== conversationGenerationRef.current ||
+          withdrawals !== replyWithdrawalsRef.current;
+        if (brainRequestPending(waited.record) || !waited.speak || moved) {
           return { status: BRAIN_ASK_PENDING_STATUS, note: BRAIN_ASK_PENDING_NOTE };
         }
-        brainReplyRunRef.current = record.runId;
-        return { status: ACT_RESULT_STATUS.ACCEPTED, briefing: brainReplyWords(record) ?? "" };
+        return {
+          status: ACT_RESULT_STATUS.ACCEPTED,
+          briefing: brainReplyWords(waited.record) ?? "",
+          runId: waited.record.runId,
+        };
       },
       onStatus: setVoiceStatus,
       onLocalStream: setLocalStream,
       onRemoteStream: setRemoteStream,
       onError: setVoiceError,
       onCaption: (texts, kind) => setVoiceCaption({ texts, kind }),
-      onReplyEnded: (texts, kind) => {
+      onReplyEnded: (texts, kind, runId) => {
         if (kind === REPLY_KIND.BRIEFING) {
           const generation = activeAnnouncementGenerationRef.current;
           activeAnnouncementGenerationRef.current = undefined;
@@ -740,9 +772,11 @@ export function useVoiceSession(remoteAudio: RefObject<HTMLAudioElement | null>)
         activeReplyGenerationRef.current = undefined;
         // A reply voicing a brain run's end is already in the thread, written
         // by the main process from the record; the voice's rendering of it is
-        // not a second line.
-        if (brainReplyRunRef.current !== undefined) {
-          brainReplyRunRef.current = undefined;
+        // not a second line. The reply names its own run, so a reply cut off
+        // by the next one cannot hand its attribution to it, and its ending
+        // is what lets the next delivered reply be offered.
+        if (runId !== undefined) {
+          replyPlayer.current?.onReplyEnded(runId);
           return;
         }
         rememberConversationEntry(replyConversationEntry(texts.join(" ")), generation);
@@ -1103,59 +1137,76 @@ export function useVoiceSession(remoteAudio: RefObject<HTMLAudioElement | null>)
   }, [voiceStatusNow]);
 
   /**
-   * Speaks the reply a typed ask's run ended in. The ask itself never passed
-   * through this window — the panel submitted it to the main process, which
-   * ran it and recorded both halves in the thread — so what arrives here is
-   * the record, and the words are spoken on the developer's own call, opened
-   * for them if none stands. Voice that cannot say it puts the words on the
-   * strip instead, so an ask is never answered with silence; nothing is
-   * recorded here either way.
+   * The receiving end of reply deliveries: the one offer the main process has
+   * out to this window, claimed at a quiet moment and spoken on the
+   * developer's own call — opened for them if none stands — or put on the
+   * strip where the voice cannot say it, and acknowledged when its reply
+   * ends so the next may be offered. The main process granted the words
+   * once, to this epoch, from the live record; the player checks its moment
+   * again after every await, so a Clear or a withdrawn generation mid-way
+   * leaves the words unspoken. Nothing is recorded here: the thread already
+   * holds them.
    */
-  const speakTypedReply = useCallback(
-    async (runId: string, words: string): Promise<void> => {
-      const session = ensureVoiceSession();
-      typedExchange.current = true;
-      setVoiceNotice(undefined);
-      const connected =
-        !session.isConnected || !session.microphoneCall ? await startConversation() : true;
-      brainReplyRunRef.current = runId;
-      if (connected && session.speakReply(words)) {
+  const startConversationRef = useRef(startConversation);
+  startConversationRef.current = startConversation;
+  const ensureReplyPlayer = useCallback((): ReplyDeliveryPlayer => {
+    replyPlayer.current ??= new ReplyDeliveryPlayer({
+      session: () => ensureVoiceSession(),
+      connect: () => startConversationRef.current(),
+      claim: (offer) => window.sidecar.claimBrainReply(offer.runId, offer.deliveryId, offer.epoch),
+      acknowledge: (offer) =>
+        window.sidecar.ackBrainReply(offer.runId, offer.deliveryId, offer.epoch),
+      showNotice: (words) => setVoiceNotice(words),
+      // Only a typed ask's reply is the composer's exchange: it counts as one
+      // and holds the caption the composer asked for. A spoken ask answered
+      // late is the spoken exchange it always was.
+      onSpeaking: (origin) => {
+        setVoiceNotice(undefined);
+        if (origin !== BRAIN_REQUEST_ORIGIN.TYPED) return;
+        typedExchange.current = true;
         setTypedAsk(true);
-        return;
-      }
-      brainReplyRunRef.current = undefined;
-      setVoiceNotice(words);
-    },
-    [ensureVoiceSession, startConversation],
-  );
-
-  // The brain's records, followed for the one edge this window answers: a
-  // typed ask's run ending while this window watched it run. A run already
-  // ended when first seen — the bootstrap after a reload, a launch finding
-  // the last one's interrupted runs — is not spoken, because its words may
-  // already have been said; the thread holds them either way. Subscribed
-  // before the snapshots are read, so no change falls between the two.
-  useEffect(() => {
-    const known = knownRequestsRef.current;
-    const heard = (records: readonly BrainRequestSnapshot[]) => {
-      for (const record of records) {
-        const previous = known.get(record.runId);
-        known.set(record.runId, record.status);
-        if (record.origin !== BRAIN_REQUEST_ORIGIN.TYPED) continue;
-        if (previous === undefined || brainRequestPending(record)) continue;
-        if (!brainRequestPending({ ...record, status: previous })) continue;
-        const words = brainReplyWords(record);
-        if (words) void speakTypedReply(record.runId, words);
-      }
-    };
-    const unsubscribe = window.sidecar.onBrainRequestsChanged(heard);
-    void window.sidecar.brainRequestSnapshots().then((records) => {
-      for (const record of records) {
-        if (!known.has(record.runId)) known.set(record.runId, record.status);
-      }
+      },
+      conversationGeneration: () => conversationGenerationRef.current,
     });
-    return unsubscribe;
-  }, [speakTypedReply]);
+    return replyPlayer.current;
+  }, [ensureVoiceSession]);
+
+  // The main process offering an ended run's reply. It offers one at a time,
+  // only runs it watched end while this process ran, and only once their
+  // words stand in History; this window's part is to claim before speaking.
+  // Marked standing for the readiness report: an offer sent before this
+  // subscription would land on nothing, so the main process sends none until
+  // told.
+  useEffect(() => {
+    const unsubscribe = window.sidecar.onBrainReplyOffered((offer) => {
+      ensureReplyPlayer().offer(offer);
+    });
+    readiness.current?.installed(VOICE_READINESS_PART.REPLY_OFFERS);
+    return () => {
+      readiness.current?.uninstalled(VOICE_READINESS_PART.REPLY_OFFERS);
+      unsubscribe();
+    };
+  }, [ensureReplyPlayer]);
+
+  // The brain's generation ended under this window — cleared elsewhere,
+  // expired, replaced — so whatever it offered or granted is void here too.
+  useEffect(() => {
+    const unsubscribe = window.sidecar.onBrainRepliesWithdrawn(() => {
+      replyWithdrawalsRef.current += 1;
+      replyPlayer.current?.withdraw();
+    });
+    readiness.current?.installed(VOICE_READINESS_PART.REPLY_WITHDRAWALS);
+    return () => {
+      readiness.current?.uninstalled(VOICE_READINESS_PART.REPLY_WITHDRAWALS);
+      unsubscribe();
+    };
+  }, []);
+
+  // The player paces itself by the session's status: a quiet moment is when
+  // an offer in hand may be claimed, and a call ending settles the grant on it.
+  useEffect(() => {
+    replyPlayer.current?.onStatus(voiceStatus);
+  }, [voiceStatus]);
 
   const discardListening = useCallback(() => {
     talkLatched.current = false;
@@ -1187,6 +1238,9 @@ export function useVoiceSession(remoteAudio: RefObject<HTMLAudioElement | null>)
           : value.announcementsHeld,
         conversationContextReady: true,
       });
+      // Applied, so the readiness report may name the epoch this load was given.
+      voiceEpochRef.current = value.voiceEpoch;
+      readiness.current?.bootstrapped(value.voiceEpoch);
     });
     return () => {
       cancelled = true;
@@ -1229,17 +1283,19 @@ export function useVoiceSession(remoteAudio: RefObject<HTMLAudioElement | null>)
   // A panel's ask, validated and forwarded by the main process. Each command
   // is the same act the panel used to perform on its own session; none opens
   // a turn the developer did not.
-  useEffect(
-    () =>
-      window.sidecar.onVoiceCommand(({ command }) => {
-        if (command === VOICE_COMMAND.DISCARD_LISTENING) discardListening();
-        else if (command === VOICE_COMMAND.STOP_SPEAKING) voiceSession.current?.stopSpeaking();
-        else if (command === VOICE_COMMAND.REQUEST_MICROPHONE_ACCESS)
-          void requestMicrophoneAccess();
-        else if (command === VOICE_COMMAND.CLEAR_CONVERSATION) clearConversation();
-      }),
-    [clearConversation, discardListening, requestMicrophoneAccess],
-  );
+  useEffect(() => {
+    const unsubscribe = window.sidecar.onVoiceCommand(({ command }) => {
+      if (command === VOICE_COMMAND.DISCARD_LISTENING) discardListening();
+      else if (command === VOICE_COMMAND.STOP_SPEAKING) voiceSession.current?.stopSpeaking();
+      else if (command === VOICE_COMMAND.REQUEST_MICROPHONE_ACCESS) void requestMicrophoneAccess();
+      else if (command === VOICE_COMMAND.CLEAR_CONVERSATION) clearConversation();
+    });
+    readiness.current?.installed(VOICE_READINESS_PART.COMMANDS);
+    return () => {
+      readiness.current?.uninstalled(VOICE_READINESS_PART.COMMANDS);
+      unsubscribe();
+    };
+  }, [clearConversation, discardListening, requestMicrophoneAccess]);
 
   const heardSpeed = useRef<RealtimeVoiceSpeed | undefined>(undefined);
   const voiceSpeed = surroundings.settings?.voiceSpeed;
@@ -1383,17 +1439,27 @@ export function useVoiceSession(remoteAudio: RefObject<HTMLAudioElement | null>)
   // held under the quiet, and settles it stale rather than speaking it past
   // its deadline; every outcome is reported by id so the next can be offered.
   useEffect(() => {
-    return window.sidecar.onSpeechOffered((offer) => {
+    const unsubscribe = window.sidecar.onSpeechOffered((offer) => {
       ensureMouth().offer(offer);
     });
+    readiness.current?.installed(VOICE_READINESS_PART.SPEECH_OFFERS);
+    return () => {
+      readiness.current?.uninstalled(VOICE_READINESS_PART.SPEECH_OFFERS);
+      unsubscribe();
+    };
   }, [ensureMouth]);
 
   // The main process taking an offer back — the gate a beat explained stood
   // down, the account it greeted signed out — before it is spoken.
   useEffect(() => {
-    return window.sidecar.onSpeechWithdrawn(({ id }) => {
+    const unsubscribe = window.sidecar.onSpeechWithdrawn(({ id }) => {
       mouth.current?.withdraw(id);
     });
+    readiness.current?.installed(VOICE_READINESS_PART.SPEECH_WITHDRAWALS);
+    return () => {
+      readiness.current?.uninstalled(VOICE_READINESS_PART.SPEECH_WITHDRAWALS);
+      unsubscribe();
+    };
   }, []);
 
   // The mouth paces itself by the session's status: READY is when the offer

--- a/apps/desktop/src/renderer/voice/voice-readiness.test.ts
+++ b/apps/desktop/src/renderer/voice/voice-readiness.test.ts
@@ -1,0 +1,51 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { VOICE_READINESS_PART, VoiceReadiness } from "./voice-readiness";
+
+const EVERY_PART = Object.values(VOICE_READINESS_PART);
+
+test("readiness is reported once, only when every subscription stands and the bootstrap has named the epoch", () => {
+  const reported: number[] = [];
+  const readiness = new VoiceReadiness((epoch) => reported.push(epoch));
+  // Subscriptions in whatever order React installs them, the bootstrap last.
+  for (const part of EVERY_PART) readiness.installed(part);
+  assert.equal(readiness.complete, false);
+  assert.deepEqual(reported, []);
+  readiness.bootstrapped(7);
+  assert.equal(readiness.complete, true);
+  assert.deepEqual(reported, [7]);
+  // Nothing re-reports: not a repeated install, not a repeated bootstrap.
+  readiness.installed(VOICE_READINESS_PART.COMMANDS);
+  readiness.bootstrapped(7);
+  assert.deepEqual(reported, [7]);
+});
+
+test("a bootstrap that lands before the last subscription waits for it", () => {
+  const reported: number[] = [];
+  const readiness = new VoiceReadiness((epoch) => reported.push(epoch));
+  readiness.bootstrapped(3);
+  for (const part of EVERY_PART.slice(1)) readiness.installed(part);
+  assert.equal(reported.length, 0);
+  readiness.installed(VOICE_READINESS_PART.COMMANDS);
+  assert.deepEqual(reported, [3]);
+});
+
+test("a bootstrap naming no epoch — a panel's — never readies a voice receiver", () => {
+  const reported: number[] = [];
+  const readiness = new VoiceReadiness((epoch) => reported.push(epoch));
+  for (const part of EVERY_PART) readiness.installed(part);
+  readiness.bootstrapped(undefined);
+  assert.equal(readiness.complete, false);
+  assert.deepEqual(reported, []);
+});
+
+test("a subscription torn down after the report is not re-reported when it comes back", () => {
+  const reported: number[] = [];
+  const readiness = new VoiceReadiness((epoch) => reported.push(epoch));
+  for (const part of EVERY_PART) readiness.installed(part);
+  readiness.bootstrapped(1);
+  readiness.uninstalled(VOICE_READINESS_PART.SPEECH_OFFERS);
+  assert.equal(readiness.complete, false);
+  readiness.installed(VOICE_READINESS_PART.SPEECH_OFFERS);
+  assert.deepEqual(reported, [1]);
+});

--- a/apps/desktop/src/renderer/voice/voice-readiness.ts
+++ b/apps/desktop/src/renderer/voice/voice-readiness.ts
@@ -1,0 +1,58 @@
+/**
+ * What the hidden voice window must have standing before the main process
+ * may send it anything: each of these subscriptions, and the bootstrap
+ * applied. React installs effects in an order the main process cannot see and
+ * must not assume, so readiness is not "mounted" or "an effect ran": it is
+ * this ledger reporting that every named piece is in place, once, under the
+ * receiver epoch the bootstrap carried.
+ */
+export const VOICE_READINESS_PART = {
+  COMMANDS: "commands",
+  SPEECH_OFFERS: "speech-offers",
+  SPEECH_WITHDRAWALS: "speech-withdrawals",
+  REPLY_OFFERS: "reply-offers",
+  REPLY_WITHDRAWALS: "reply-withdrawals",
+} as const;
+
+export type VoiceReadinessPart = (typeof VOICE_READINESS_PART)[keyof typeof VOICE_READINESS_PART];
+
+const EVERY_PART: readonly VoiceReadinessPart[] = Object.values(VOICE_READINESS_PART);
+
+export class VoiceReadiness {
+  readonly #installed = new Set<VoiceReadinessPart>();
+  #epoch: number | undefined;
+  #reported = false;
+  readonly #report: (epoch: number) => void;
+
+  constructor(report: (epoch: number) => void) {
+    this.#report = report;
+  }
+
+  /** One subscription is standing. */
+  installed(part: VoiceReadinessPart): void {
+    this.#installed.add(part);
+    this.#settle();
+  }
+
+  /** One subscription was torn down; a later install restores it, but nothing is re-reported. */
+  uninstalled(part: VoiceReadinessPart): void {
+    this.#installed.delete(part);
+  }
+
+  /** The bootstrap has been applied, naming the epoch the main process gave this load. */
+  bootstrapped(epoch: number | undefined): void {
+    if (epoch === undefined) return;
+    this.#epoch = epoch;
+    this.#settle();
+  }
+
+  get complete(): boolean {
+    return this.#epoch !== undefined && EVERY_PART.every((part) => this.#installed.has(part));
+  }
+
+  #settle(): void {
+    if (this.#reported || !this.complete || this.#epoch === undefined) return;
+    this.#reported = true;
+    this.#report(this.#epoch);
+  }
+}

--- a/apps/desktop/src/shared/bridge.test.ts
+++ b/apps/desktop/src/shared/bridge.test.ts
@@ -94,15 +94,47 @@ test("a run is waited on, cancelled, and listed by its own record shape", () => 
     performedActs: 0,
     unknownActs: 0,
   };
-  for (const entry of [BRIDGE.waitBrainAsk, BRIDGE.cancelBrainAsk]) {
-    assert.equal(entry.kind, "invoke");
-    assert.equal(entry.args(["run-1"]), true);
-    assert.equal(entry.args([1]), false);
-    assert.ok(entry.result);
-    assert.equal(entry.result(snapshot), true);
-    assert.equal(entry.result(undefined), true);
-    assert.equal(entry.result({ ...snapshot, status: "dreaming" }), false);
-  }
+  assert.equal(BRIDGE.cancelBrainAsk.kind, "invoke");
+  assert.equal(BRIDGE.cancelBrainAsk.args(["run-1"]), true);
+  assert.equal(BRIDGE.cancelBrainAsk.args([1]), false);
+  assert.ok(BRIDGE.cancelBrainAsk.result);
+  assert.equal(BRIDGE.cancelBrainAsk.result(snapshot), true);
+  assert.equal(BRIDGE.cancelBrainAsk.result(undefined), true);
+  assert.equal(BRIDGE.cancelBrainAsk.result({ ...snapshot, status: "dreaming" }), false);
+  // A wait names the caller's receiver epoch and answers the record with the
+  // call's grant; a grant without a record, or a record of no known shape, is refused.
+  assert.equal(BRIDGE.waitBrainAsk.args(["run-1", 3]), true);
+  assert.equal(BRIDGE.waitBrainAsk.args(["run-1"]), false);
+  assert.equal(BRIDGE.waitBrainAsk.args(["run-1", -1]), false);
+  assert.ok(BRIDGE.waitBrainAsk.result);
+  assert.equal(BRIDGE.waitBrainAsk.result({ record: snapshot, speak: false }), true);
+  assert.equal(BRIDGE.waitBrainAsk.result({ record: undefined, speak: false }), true);
+  assert.equal(
+    BRIDGE.waitBrainAsk.result({ record: { ...snapshot, status: "dreaming" }, speak: true }),
+    false,
+  );
+  assert.equal(BRIDGE.waitBrainAsk.result(snapshot), false);
+  // A reply's offer, claim, and acknowledgement all carry the epoch; the grant carries the origin.
+  assert.ok(BRIDGE.onBrainReplyOffered.result);
+  assert.equal(
+    BRIDGE.onBrainReplyOffered.result({ runId: "run-1", deliveryId: "d-1", epoch: 2 }),
+    true,
+  );
+  assert.equal(BRIDGE.onBrainReplyOffered.result({ runId: "run-1", deliveryId: "d-1" }), false);
+  assert.equal(BRIDGE.claimBrainReply.args(["run-1", "d-1", 2]), true);
+  assert.equal(BRIDGE.claimBrainReply.args(["run-1", "d-1"]), false);
+  assert.ok(BRIDGE.claimBrainReply.result);
+  assert.equal(
+    BRIDGE.claimBrainReply.result({ granted: true, words: "w", origin: "spoken" }),
+    true,
+  );
+  assert.equal(BRIDGE.claimBrainReply.result({ granted: true, words: "w" }), false);
+  assert.equal(BRIDGE.claimBrainReply.result({ granted: false }), true);
+  assert.equal(BRIDGE.ackBrainReply.args(["run-1", "d-1", 2]), true);
+  assert.equal(BRIDGE.ackBrainReply.args(["run-1", "d-1", "2"]), false);
+  assert.ok(BRIDGE.onBrainRepliesWithdrawn.result);
+  assert.equal(BRIDGE.onBrainRepliesWithdrawn.result(2), true);
+  assert.equal(BRIDGE.onBrainRepliesWithdrawn.result("2"), false);
   assert.equal(BRIDGE.brainRequestSnapshots.args([]), true);
   assert.ok(BRIDGE.brainRequestSnapshots.result);
   assert.equal(BRIDGE.brainRequestSnapshots.result([snapshot]), true);

--- a/apps/desktop/src/shared/bridge.ts
+++ b/apps/desktop/src/shared/bridge.ts
@@ -74,11 +74,18 @@ import {
   type BrainAppActRequest,
   type BrainAskSubmission,
   type BrainAskSubmissionResult,
+  type BrainAskWait,
+  type BrainReplyClaimResult,
+  type BrainReplyOffer,
   type BrainRequestSnapshot,
   isBrainAskSubmission,
   isBrainAskSubmissionResult,
+  isBrainAskWait,
+  isBrainReplyClaimResult,
+  isBrainReplyOffer,
   isBrainRequestSnapshot,
   isBrainRequestSnapshotList,
+  isReceiverEpoch,
 } from "./wire/brain";
 import {
   type AppBootstrap,
@@ -500,15 +507,18 @@ export const BRIDGE = {
   /**
    * Waits on one run for as long as the brain's wait allows, answering the
    * record as it then stands — ended, or still pending — or nothing for a run
-   * the brain does not know.
+   * the brain does not know, and whether the asking call may say the words:
+   * granted only to the voice window, under the receiver epoch it names, for
+   * an end already in History, and only once per run, so the words are never
+   * both said on the call and delivered later.
    */
   waitBrainAsk: entry({
     kind: "invoke",
     channel: "app:wait-brain-ask",
-    args: oneString,
-    result: result<BrainRequestSnapshot | undefined>(
-      (v) => v === undefined || isBrainRequestSnapshot(v),
+    args: args<[string, number]>(
+      (v) => v.length === 2 && isWireString(v[0]) && isReceiverEpoch(v[1]),
     ),
+    result: result<BrainAskWait>(isBrainAskWait),
   }),
   /** Cancels one run the developer no longer wants, answering its record as it then stands. */
   cancelBrainAsk: entry({
@@ -525,6 +535,44 @@ export const BRIDGE = {
     channel: "app:brain-request-snapshots",
     args: noArgs,
     result: result<readonly BrainRequestSnapshot[]>(isBrainRequestSnapshotList),
+  }),
+  /**
+   * The voice window asking to speak one offered reply, by run and delivery.
+   * The main process grants at most once per delivery, only to the receiver
+   * epoch the offer went to, and only while the run and its generation still
+   * stand; the grant carries the words, read from the live record.
+   */
+  claimBrainReply: entry({
+    kind: "invoke",
+    channel: "app:claim-brain-reply",
+    args: args<[string, string, number]>(
+      (v) => v.length === 3 && isWireString(v[0]) && isWireString(v[1]) && isReceiverEpoch(v[2]),
+    ),
+    result: result<BrainReplyClaimResult>(isBrainReplyClaimResult),
+  }),
+  /**
+   * The voice window reporting the claimed reply it held done with — its reply
+   * ended or cut short, or shown where it could not be spoken — under the
+   * epoch it was granted to. The next owed reply is offered only after this.
+   */
+  ackBrainReply: entry({
+    kind: "send",
+    channel: "app:ack-brain-reply",
+    args: args<[string, string, number]>(
+      (v) => v.length === 3 && isWireString(v[0]) && isWireString(v[1]) && isReceiverEpoch(v[2]),
+    ),
+  }),
+  /**
+   * The voice window reporting it can receive: its bootstrap applied and its
+   * subscriptions standing, under the receiver epoch the bootstrap named. The
+   * main process accepts it only from the current voice renderer for the
+   * current epoch, and answers whether this report made the receiver ready.
+   */
+  reportVoiceReady: entry({
+    kind: "invoke",
+    channel: "app:report-voice-ready",
+    args: args<[number]>((v) => v.length === 1 && isWireNumber(v[0]) && Number.isInteger(v[0])),
+    result: result<boolean>(isWireBoolean),
   }),
   /**
    * The renderer's guide snapshot, pushed whenever it changes, so the main
@@ -954,6 +1002,29 @@ export const BRIDGE = {
     result: result<{ command: VoiceCommand }>(
       (value) => isRecord(value) && isVoiceCommand(value.command),
     ),
+  }),
+  /**
+   * One ended run whose reply the main process offers the voice window to
+   * speak. The words come with the grant, not the offer: the window claims
+   * through `claimBrainReply` before a word is said.
+   */
+  onBrainReplyOffered: entry({
+    kind: "subscribe",
+    channel: "app:brain-reply-offered",
+    args: noArgs,
+    result: result<BrainReplyOffer>(isBrainReplyOffer),
+  }),
+  /**
+   * The brain's generation ended — cleared, expired, or replaced — so every
+   * reply offered or granted from it is withdrawn: an offer in hand is
+   * dropped unclaimed, and words granted but not yet spoken are not spoken.
+   * Carries the receiver epoch it was sent under.
+   */
+  onBrainRepliesWithdrawn: entry({
+    kind: "subscribe",
+    channel: "app:brain-replies-withdrawn",
+    args: noArgs,
+    result: result<number>(isReceiverEpoch),
   }),
   /** Every run the brain holds, pushed whole whenever any record changes. */
   onBrainRequestsChanged: entry({

--- a/apps/desktop/src/shared/wire/brain.ts
+++ b/apps/desktop/src/shared/wire/brain.ts
@@ -5,6 +5,7 @@ import {
   BRAIN_REQUEST_STATUS,
   BRAIN_SUBMISSION_OUTCOME,
   BRAIN_SUBMISSION_REJECTION,
+  type BrainRequestOrigin,
   type BrainRequestRecord,
   type BrainSubmissionRejection,
   brainRequestRecordFromWire,
@@ -14,6 +15,7 @@ import { maximumTypedAskLength } from "@sidecar/realtime";
 import {
   type ACT_RESULT_STATUS,
   isRecord,
+  isWireBoolean,
   isWireNumber,
   isWireString,
   type UnparsedWireValue,
@@ -177,9 +179,75 @@ export const BRAIN_ASK_PENDING_STATUS = "pending";
  * the voice can say instead.
  */
 export type BrainAskResult =
-  | { status: typeof ACT_RESULT_STATUS.ACCEPTED; briefing: string }
+  | { status: typeof ACT_RESULT_STATUS.ACCEPTED; briefing: string; runId: string }
   | { status: typeof BRAIN_ASK_PENDING_STATUS; note: string }
   | { status: typeof ACT_RESULT_STATUS.REJECTED; reason: string };
+
+/**
+ * One ended run whose reply the main process offers the voice window to
+ * speak. The words do not travel with the offer: the window claims the
+ * delivery first, and the grant carries them, read from the live record at
+ * that moment so a run the store has since let go of is never spoken.
+ */
+export interface BrainReplyOffer {
+  runId: string;
+  deliveryId: string;
+  /** The receiver epoch the offer went to; the claim and the acknowledgement name it back. */
+  epoch: number;
+}
+
+export function isReceiverEpoch(value: UnparsedWireValue): value is number {
+  return isWireNumber(value) && Number.isInteger(value) && value >= 0;
+}
+
+export function isBrainReplyOffer(value: UnparsedWireValue): value is BrainReplyOffer & WireRecord {
+  return (
+    isRecord(value) &&
+    isWireString(value.runId) &&
+    value.runId.length > 0 &&
+    isWireString(value.deliveryId) &&
+    value.deliveryId.length > 0 &&
+    isReceiverEpoch(value.epoch)
+  );
+}
+
+/**
+ * What a wait on a spoken ask comes back with: the record as it then stands,
+ * or nothing for a run the brain does not know, and whether the call that
+ * asked has been granted the words. `speak` is true only for an ended run
+ * whose end already stands in History and whose one grant this wait took; a
+ * run still going, or one whose words another path holds, is not the
+ * call's to say.
+ */
+export interface BrainAskWait {
+  record: BrainRequestSnapshot | undefined;
+  speak: boolean;
+}
+
+export function isBrainAskWait(value: UnparsedWireValue): boolean {
+  return (
+    isRecord(value) &&
+    (value.record === undefined || isBrainRequestSnapshot(value.record)) &&
+    isWireBoolean(value.speak)
+  );
+}
+
+/** The main process's answer to a claim: the words to say, once, or nothing. */
+/**
+ * The main process's answer to a claim: the words to say, once, with the
+ * origin of the ask they answer — a typed ask's reply holds the composer's
+ * caption, a spoken one's does not — or nothing.
+ */
+export type BrainReplyClaimResult =
+  | { granted: true; words: string; origin: BrainRequestOrigin }
+  | { granted: false };
+
+export function isBrainReplyClaimResult(value: UnparsedWireValue): boolean {
+  if (!isRecord(value)) return false;
+  if (value.granted === true)
+    return isWireString(value.words) && isBrainRequestOrigin(value.origin);
+  return value.granted === false;
+}
 
 /**
  * An app act the brain decided that only the renderer can perform — a settings

--- a/apps/desktop/src/shared/wire/session.ts
+++ b/apps/desktop/src/shared/wire/session.ts
@@ -142,6 +142,12 @@ export interface AppBootstrap {
   nodeVersion: string;
   microphoneStatus: MicrophoneStatus;
   /**
+   * The receiver epoch the main process gave this load of the hidden voice
+   * window, which its readiness report must name; absent for every other
+   * window, which receives no speech.
+   */
+  voiceEpoch?: number;
+  /**
    * The accelerator the talk key was registered as, absent when the system
    * refused to register one — a shortcut nothing can trigger must not be shown
    * as though it works. Raw rather than labelled for the ask key's reason


### PR DESCRIPTION
## Problem

The hidden voice window was treated as a receiver the moment its `BrowserWindow` existed. Between its load and the renderer's subscriptions, speech offers and reply notifications landed on nothing, and a reload, crash, or replacement reopened that gap on a renderer the main process could not tell from the last one. Eventual brain replies were spoken from the renderer's own diff of request snapshots and correlated to History through one shared `brainReplyRunRef`, so overlapping typed and spoken replies could trade attributions and append a duplicate History line, and a reply's terminal text could be spoken before the publication owner had durably written it.

## Result

- **Receiver readiness, authenticated by main.** `VoiceReceiver` gives every load of the hidden voice window an epoch, begins unready, and becomes ready only when the current voice renderer reports `reportVoiceReady(epoch)` for the current epoch. `VoiceWindow` begins an epoch on open and on every main-frame navigation and resets it on close, crash, hang, or failed load. The bootstrap carries `voiceEpoch` to the voice window alone. The renderer reports through a `VoiceReadiness` ledger only after the bootstrap is applied and the command, speech offer, speech withdrawal, and reply offer subscriptions all stand, once per load. A panel, a stale epoch, or a repeat readies nothing.
- **Nothing is offered to an unready receiver.** `offerNextSpeech` requires readiness. Readiness flushes the arbiter's head and every unclaimed reply. A receiver reset reclaims the arbiter's outstanding offer back to the head under a fresh id (`SpeechArbiter.reclaimOffer`), so the next renderer is offered it at once rather than after the two-minute deadline, and a late settle from the vanished renderer names nothing.
- **One main owner for every grant to speak a run's end.** `BrainReplyDeliveries` (now `main/brain/reply-delivery.ts`) keys each delivery by `runId` plus a fresh `deliveryId`, watches only runs this process saw still going, and admits a run only when the publication owner reports its end written and marked (`followBrainRequests` hands the live record to `onEndPublished` after `publishEnd` re-reads the marked record). A refused History write or mark publishes nothing downstream, and recovery on the next report offers it once. Offers carry the receiver epoch; the claim and the acknowledgement name it back, and main validates the named epoch against the current ready receiver rather than reading its own epoch, so a reloaded renderer's queued invoke is refused after a reoffer. Main offers **one delivery at a time** per epoch and the next only after the acknowledgement, so two completions flushed together cannot claim each other's grant or cut each other off. The words are read from the live record through `brainReplyWords` at grant time. Unclaimed offers lost with a renderer are offered to the next epoch; claimed ones never are. A restart restores text and speaks nothing.
- **Spoken fast answers go through the same grant.** `waitBrainAsk(runId, epoch)` now answers `{ record, speak }`: for an ended run it lets the follower's publication settle, re-reads the live record for its History mark, and asks the ledger for the on-call grant, which succeeds only for the current voice renderer's epoch and only if no offer for the run was already claimed; granting withdraws an outstanding offer, so the receiver's claim on it is refused. A pending run, a refused History write, or a stale epoch returns no grant and the eventual delivery speaks the words instead. Exactly one authorization exists across both paths.
- **Renderer playback boundary.** `ReplyDeliveryPlayer` (`renderer/voice/reply-delivery-player.ts`) holds the one offer and the one grant, claims only at a quiet moment (not while the developer talks or a reply is under way), captures the offer, History generation, and its own withdrawal count before every await, and re-checks after the claim, after the call opens, and immediately before speaking or showing. A grant that lands after the developer took the turn is held locally until the next quiet status and spoken once then, without a second claim; a withdrawal voids the held grant. An on-call grant in main flushes the next owed offer, since no acknowledgement follows a reply said on the call. A Clear or a main-sent `onBrainRepliesWithdrawn` (store `onReplaced`: Clear, expiry, replace) during any await leaves granted words unspoken, unshown, and unacknowledged. The acknowledgement is sent when the reply ends by any route (spoken out, cut short, call lost) or at once when the words could only be shown, which is what advances main's queue. Developer reply speech is not subject to the announcement quiet or the proactive staleness deadline.
- **Inline tool path fenced too.** The ask tool captures the History generation and the window's withdrawal count before `waitBrainAsk` and returns the pending note instead of the granted words if either moved during the held wait; the realtime session also hands over a run-bound reply's ending even when no caption text arrived, so an interrupted delivery is acknowledged and the queue advances. A delivered reply carries its ask's origin, and only a typed one holds the composer's caption or counts as the composer's exchange (Bugbot finding on the old head).
- **No shared reply ref.** `RealtimeVoiceSession` stamps each reply with its own run: `speakReply(words, runId)` and the ask tool's follow-up both set it beside the caption kind, and `onReplyEnded(texts, kind, runId)` carries it, so a reply cut off by the next keeps its own attribution. The hook records nothing for a reply that names a run; main already wrote it.
- **History pending layout.** `.history-bubble` stacks its children, so the pending status and Cancel sit beneath the ask instead of squeezing into a column beside the bubble. Copy and cancel behavior are unchanged; History stays inside the replay-blocked subtree.

## Interfaces

- Bridge: `reportVoiceReady(epoch): boolean` (invoke), `waitBrainAsk(runId, epoch): { record, speak }` (invoke, changed), `claimBrainReply(runId, deliveryId, epoch): { granted: true; words; origin } | { granted: false }` (invoke; `origin` is the ask's `typed` or `spoken`, so only a typed reply holds the composer's caption), `ackBrainReply(runId, deliveryId, epoch)` (send), `onBrainReplyOffered` → `{ runId, deliveryId, epoch }` (subscribe), `onBrainRepliesWithdrawn` → epoch (subscribe).
- `AppBootstrap.voiceEpoch?: number` (voice window only). `BrainAskResult` accepted variant carries `runId`.
- `BrainIpcDependencies` gains optional `onEndPublished`, `onPublication`, `publicationSettled`, `replies` (claim, acknowledge, grantOnCall, each with the caller's epoch); `BrainWiringDependencies` passes `onEndPublished` and `replies` through. `VoiceRuntimeIpcDependencies` gains `receiver`. `VoiceWindowOptions` gains `receiver`.
- No persistence schema change: deliveries and readiness live in main-process memory only.

## Checks run

- `./scripts/check.sh` (Biome, oxlint, typecheck, tests, build) passed with exit 0 on `6c17144d371adbb1524581357e2afe8419511d7d`, the final head.
- New tests: `voice-receiver.test.ts`, `brain/reply-delivery.test.ts`, `voice/voice-readiness.test.ts`, `voice/reply-delivery-player.test.ts` (deferred claim and connect with Clear or withdrawal during each await, newer offer during a claim, quiet-moment gating, call loss acknowledges, refused claim, notice fallback); extended `brain/host-lifecycle.test.ts` (real agent, store, host, follower, ledger, receiver: late completion after a pending wait, refused History then recovery with no on-call grant before durability, two completions flushed together offered one at a time, unclaimed reoffer versus claimed no-replay with old-epoch claims refused, Clear mid-offer with late ack ignored, restart restores text without speech, exactly-one authorization across publication-before-wait, wait-before-publication, and a stale-epoch abandoned wait), `brain/ipc.test.ts` (publication-completion hook; `registerBrainIpc` boundary through fake `ipcMain`: same WebContents old epoch after reoffer refused, wrong sender, stale ack, positive grant, wait grant only for the current voice renderer after History), `ipc/voice-runtime.test.ts` (readiness IPC), `voice/speech-arbiter.test.ts` (reclaim under a fresh id), `realtime-session.test.ts` (per-reply run correlation, overlapping replies, tool follow-up), `conversation-history-panel.test.ts` (pending markup beneath the ask).

## Platform validation

CI runs `./scripts/verify.sh` on this exact head (the "macOS app and evidence" check) and produces the six canonical fixture captures; the reviewer compared the final head's six captures (artifact 10004588493 from run 34083851572) byte-for-byte against the already-inspected PR4 and PR6 evidence and found them identical, as they were for the previous head. The TypeScript and macOS verify checks succeeded on the final head. Those captures do not exercise the live History pending, Cancel, and Clear states, the voice window's reload, crash, and replacement readiness scenarios, or the physical notch. That manual validation remains pending and is not claimed here; this PR was implemented in a Linux cloud workspace with no macOS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
