### PR TITLE
feat(ios): keep the phone's and watch's settings equal over WatchConnectivity

### DIFF
--- a/apps/ios/Luke/PhoneSessionRelay.swift
+++ b/apps/ios/Luke/PhoneSessionRelay.swift
@@ -18,7 +18,7 @@ final class PhoneSessionRelay: NSObject, WCSessionDelegate {
     @MainActor
     init(accountSession: AccountSession) {
         self.accountSession = accountSession
-        settings = DeviceSettingsSync(publish: Self.publishSettings)
+        settings = DeviceSettingsSync(role: .primary, publish: Self.publishSettings)
         super.init()
         settings.start()
         accountSession.onTokensRefreshed = { [weak self] in

--- a/apps/ios/Luke/PhoneSessionRelay.swift
+++ b/apps/ios/Luke/PhoneSessionRelay.swift
@@ -2,18 +2,25 @@ import LukeKit
 import WatchConnectivity
 
 /// Sends the signed-in account's tokens to the paired Apple Watch via
-/// WatchConnectivity, and responds to on-demand token requests from the watch.
+/// WatchConnectivity, responds to on-demand token requests from the watch, and
+/// keeps this phone's device settings and the watch's equal through the
+/// session's application context.
 ///
 /// Tokens are pushed proactively on sign-in, after each token rotation, and
 /// when the WatchConnectivity session becomes reachable or the watch state
-/// changes, so the watch never works with a stale refresh token.
+/// changes, so the watch never works with a stale refresh token. Settings
+/// travel as one snapshot each way, sent on every local change and at
+/// activation, and the newest change wins on both devices.
 final class PhoneSessionRelay: NSObject, WCSessionDelegate {
     private let accountSession: AccountSession
+    private let settings: DeviceSettingsSync
 
     @MainActor
     init(accountSession: AccountSession) {
         self.accountSession = accountSession
+        settings = DeviceSettingsSync(publish: Self.publishSettings)
         super.init()
+        settings.start()
         accountSession.onTokensRefreshed = { [weak self] in
             Task { @MainActor [weak self] in self?.push() }
         }
@@ -42,6 +49,14 @@ final class PhoneSessionRelay: NSObject, WCSessionDelegate {
         s.transferUserInfo(["event": "signedOut"])
     }
 
+    /// The application context holds only the latest snapshot, so a change
+    /// made while the watch is away is still the one it reads on reconnect.
+    private static func publishSettings(_ payload: [String: Any]) {
+        let s = WCSession.default
+        guard s.activationState == .activated, s.isPaired else { return }
+        try? s.updateApplicationContext(payload)
+    }
+
     // MARK: WCSessionDelegate
 
     func session(
@@ -50,8 +65,11 @@ final class PhoneSessionRelay: NSObject, WCSessionDelegate {
         error: (any Error)?
     ) {
         guard activationState == .activated else { return }
+        let received = session.receivedApplicationContext
         Task { @MainActor [weak self] in
             guard let self else { return }
+            settings.receive(received)
+            settings.publishCurrent()
             if accountSession.tokenPayload() != nil {
                 push()
             } else {
@@ -74,8 +92,15 @@ final class PhoneSessionRelay: NSObject, WCSessionDelegate {
         }
     }
 
+    func session(_ session: WCSession, didReceiveApplicationContext context: [String: Any]) {
+        Task { @MainActor [weak self] in self?.settings.receive(context) }
+    }
+
     func sessionWatchStateDidChange(_ session: WCSession) {
-        Task { @MainActor [weak self] in self?.push() }
+        Task { @MainActor [weak self] in
+            self?.settings.publishCurrent()
+            self?.push()
+        }
     }
 
     func sessionReachabilityDidChange(_ session: WCSession) {

--- a/apps/ios/LukeKit/Sources/LukeKit/DeviceSettingsSync.swift
+++ b/apps/ios/LukeKit/Sources/LukeKit/DeviceSettingsSync.swift
@@ -63,6 +63,24 @@ public struct DeviceSettingsSnapshot: Equatable, Sendable {
 /// the other device's older copy, whichever of the two activates first.
 @MainActor
 public final class DeviceSettingsSync {
+    /// Which of the pair this device is. Settings changed before a device ever
+    /// synced carry no stamp of their own, so the two copies are ranked by
+    /// role instead: the primary's copy wins over the secondary's, and both
+    /// lose to any change made once syncing, whichever device activates
+    /// first.
+    public enum Role: Sendable {
+        case primary
+        case secondary
+
+        /// Later than never-changed, earlier than any real change.
+        var preSyncStamp: Date {
+            switch self {
+            case .primary: Date(timeIntervalSinceReferenceDate: 2)
+            case .secondary: Date(timeIntervalSinceReferenceDate: 1)
+            }
+        }
+    }
+
     /// Bumped when a field changes meaning or type; a payload from another
     /// version is ignored rather than half-read.
     public static let payloadVersion = 1
@@ -83,6 +101,7 @@ public final class DeviceSettingsSync {
     private static let changedAtKey = "deviceSettings.changedAt"
 
     private let store: UserDefaults
+    private let role: Role
     private let now: () -> Date
     private let publish: ([String: Any]) -> Void
     private var known: DeviceSettingsSnapshot
@@ -91,10 +110,12 @@ public final class DeviceSettingsSync {
 
     public init(
         store: UserDefaults = .standard,
+        role: Role,
         now: @escaping () -> Date = Date.init,
         publish: @escaping ([String: Any]) -> Void
     ) {
         self.store = store
+        self.role = role
         self.now = now
         self.publish = publish
         known = DeviceSettingsSnapshot.read(from: store)
@@ -105,12 +126,13 @@ public final class DeviceSettingsSync {
     }
 
     /// Begins following the store. A device whose settings were already
-    /// changed before it ever synced has no stamp for them; they are stamped
-    /// now, so a fresh pair learns them rather than overwriting them with
-    /// its own untouched defaults.
+    /// changed before it ever synced has no stamp for them; they take the
+    /// role's pre-sync stamp, so a fresh pair learns them rather than
+    /// overwriting them with its own untouched defaults, and two devices
+    /// that each hold such a copy settle on the primary's.
     public func start() {
         if changedAt == nil, known != DeviceSettingsSnapshot() {
-            changedAt = now()
+            changedAt = role.preSyncStamp
         }
         observer = NotificationCenter.default.addObserver(
             forName: UserDefaults.didChangeNotification, object: store, queue: nil

--- a/apps/ios/LukeKit/Sources/LukeKit/DeviceSettingsSync.swift
+++ b/apps/ios/LukeKit/Sources/LukeKit/DeviceSettingsSync.swift
@@ -1,0 +1,215 @@
+import Foundation
+
+/// Every setting the phone and the watch both hold, read from and written to
+/// the same UserDefaults keys each app's own controls use: the voice and pace
+/// the next mint asks for, and the New Workspace choices remembered per
+/// provider. Nothing here is account data, a credential, or anything a
+/// provider wrote; it is the developer's own choices about their own devices.
+public struct DeviceSettingsSnapshot: Equatable, Sendable {
+    public var voice: RealtimeVoice
+    public var speed: RealtimeVoiceSpeed
+    public var workspaceProviderId: String?
+    public var workspaceProjectIds: [String: String]
+    public var workspaceAgentDefaults: [String: WorkspaceAgentDefault]
+
+    public init(
+        voice: RealtimeVoice = .default,
+        speed: RealtimeVoiceSpeed = .default,
+        workspaceProviderId: String? = nil,
+        workspaceProjectIds: [String: String] = [:],
+        workspaceAgentDefaults: [String: WorkspaceAgentDefault] = [:]
+    ) {
+        self.voice = voice
+        self.speed = speed
+        self.workspaceProviderId = workspaceProviderId
+        self.workspaceProjectIds = workspaceProjectIds
+        self.workspaceAgentDefaults = workspaceAgentDefaults
+    }
+
+    public static func read(from store: UserDefaults) -> DeviceSettingsSnapshot {
+        let defaults = WorkspaceCreationDefaults(store: store)
+        return DeviceSettingsSnapshot(
+            voice: store.string(forKey: VoiceSettingsKey.voice).flatMap(RealtimeVoice.init(rawValue:))
+                ?? .default,
+            speed: store.string(forKey: VoiceSettingsKey.speed).flatMap(RealtimeVoiceSpeed.init(rawValue:))
+                ?? .default,
+            workspaceProviderId: defaults.lastProviderId,
+            workspaceProjectIds: defaults.lastProjectIds,
+            workspaceAgentDefaults: defaults.agentDefaults
+        )
+    }
+
+    public func write(to store: UserDefaults) {
+        store.set(voice.rawValue, forKey: VoiceSettingsKey.voice)
+        store.set(speed.rawValue, forKey: VoiceSettingsKey.speed)
+        let defaults = WorkspaceCreationDefaults(store: store)
+        defaults.lastProviderId = workspaceProviderId
+        defaults.setLastProjectIds(workspaceProjectIds)
+        defaults.setAgentDefaults(workspaceAgentDefaults)
+    }
+}
+
+/// Keeps one device's settings equal to its paired device's over a channel
+/// that carries only the latest snapshot each way — WatchConnectivity's
+/// application context, which is what Apple built for exactly this: it is
+/// delivered whenever the pair next connects, and the last one received
+/// survives a relaunch. The engine itself knows nothing of the channel; the
+/// two relays hand it what arrived and send what it publishes.
+///
+/// Two copies converge by the newest change winning. Every local change
+/// stamps the moment it was made, the stamp travels with the snapshot, and an
+/// arriving snapshot is applied only when it is newer than the last change
+/// made here, so a change made while the pair was apart is never undone by
+/// the other device's older copy, whichever of the two activates first.
+@MainActor
+public final class DeviceSettingsSync {
+    /// Bumped when a field changes meaning or type; a payload from another
+    /// version is ignored rather than half-read.
+    public static let payloadVersion = 1
+
+    private enum Field {
+        static let version = "settingsVersion"
+        static let changedAt = "changedAt"
+        static let voice = "voice"
+        static let speed = "speed"
+        static let workspaceProvider = "workspaceProviderId"
+        static let workspaceProjects = "workspaceProjectIds"
+        static let workspaceAgents = "workspaceAgentDefaults"
+        static let agent = "agent"
+        static let model = "model"
+        static let effort = "effort"
+    }
+
+    private static let changedAtKey = "deviceSettings.changedAt"
+
+    private let store: UserDefaults
+    private let now: () -> Date
+    private let publish: ([String: Any]) -> Void
+    private var known: DeviceSettingsSnapshot
+    private var applying = false
+    private var observer: (any NSObjectProtocol)?
+
+    public init(
+        store: UserDefaults = .standard,
+        now: @escaping () -> Date = Date.init,
+        publish: @escaping ([String: Any]) -> Void
+    ) {
+        self.store = store
+        self.now = now
+        self.publish = publish
+        known = DeviceSettingsSnapshot.read(from: store)
+    }
+
+    deinit {
+        if let observer { NotificationCenter.default.removeObserver(observer) }
+    }
+
+    /// Begins following the store. A device whose settings were already
+    /// changed before it ever synced has no stamp for them; they are stamped
+    /// now, so a fresh pair learns them rather than overwriting them with
+    /// its own untouched defaults.
+    public func start() {
+        if changedAt == nil, known != DeviceSettingsSnapshot() {
+            changedAt = now()
+        }
+        observer = NotificationCenter.default.addObserver(
+            forName: UserDefaults.didChangeNotification, object: store, queue: nil
+        ) { [weak self] _ in
+            if Thread.isMainThread {
+                MainActor.assumeIsolated { self?.noteLocalChange() }
+            } else {
+                Task { @MainActor [weak self] in self?.noteLocalChange() }
+            }
+        }
+    }
+
+    /// Sends what this device holds now, for the edges where the pair may
+    /// have missed a change: activation and a new pairing.
+    public func publishCurrent() {
+        publish(payload(for: known))
+    }
+
+    /// Applies a paired device's snapshot when it is newer than the last
+    /// change made here; anything older or unreadable is left alone.
+    public func receive(_ payload: [String: Any]) {
+        guard payload[Field.version] as? Int == Self.payloadVersion,
+              let stamp = payload[Field.changedAt] as? Double,
+              let incoming = Self.snapshot(from: payload)
+        else { return }
+        let incomingChangedAt = Date(timeIntervalSinceReferenceDate: stamp)
+        if let changedAt, incomingChangedAt <= changedAt { return }
+        changedAt = incomingChangedAt
+        guard incoming != known else { return }
+        known = incoming
+        applying = true
+        incoming.write(to: store)
+        applying = false
+    }
+
+    private func noteLocalChange() {
+        guard !applying else { return }
+        let current = DeviceSettingsSnapshot.read(from: store)
+        guard current != known else { return }
+        known = current
+        changedAt = now()
+        publish(payload(for: current))
+    }
+
+    private var changedAt: Date? {
+        get {
+            guard let stamp = store.object(forKey: Self.changedAtKey) as? Double else { return nil }
+            return Date(timeIntervalSinceReferenceDate: stamp)
+        }
+        set {
+            applying = true
+            if let newValue {
+                store.set(newValue.timeIntervalSinceReferenceDate, forKey: Self.changedAtKey)
+            } else {
+                store.removeObject(forKey: Self.changedAtKey)
+            }
+            applying = false
+        }
+    }
+
+    private func payload(for snapshot: DeviceSettingsSnapshot) -> [String: Any] {
+        var payload: [String: Any] = [
+            Field.version: Self.payloadVersion,
+            Field.changedAt: (changedAt ?? Date(timeIntervalSinceReferenceDate: 0))
+                .timeIntervalSinceReferenceDate,
+            Field.voice: snapshot.voice.rawValue,
+            Field.speed: snapshot.speed.rawValue,
+            Field.workspaceProjects: snapshot.workspaceProjectIds,
+            Field.workspaceAgents: snapshot.workspaceAgentDefaults.mapValues { selection in
+                var fields = [Field.agent: selection.agent, Field.model: selection.model]
+                if let effort = selection.effort { fields[Field.effort] = effort }
+                return fields
+            },
+        ]
+        if let provider = snapshot.workspaceProviderId {
+            payload[Field.workspaceProvider] = provider
+        }
+        return payload
+    }
+
+    /// A voice or pace the vocabulary no longer names falls to the default,
+    /// the same answer each app's own controls give an unknown stored value.
+    private static func snapshot(from payload: [String: Any]) -> DeviceSettingsSnapshot? {
+        guard let voice = payload[Field.voice] as? String,
+              let speed = payload[Field.speed] as? String
+        else { return nil }
+        let agents = (payload[Field.workspaceAgents] as? [String: [String: String]] ?? [:])
+            .compactMapValues { fields -> WorkspaceAgentDefault? in
+                guard let agent = fields[Field.agent], let model = fields[Field.model] else {
+                    return nil
+                }
+                return WorkspaceAgentDefault(agent: agent, model: model, effort: fields[Field.effort])
+            }
+        return DeviceSettingsSnapshot(
+            voice: RealtimeVoice(rawValue: voice) ?? .default,
+            speed: RealtimeVoiceSpeed(rawValue: speed) ?? .default,
+            workspaceProviderId: payload[Field.workspaceProvider] as? String,
+            workspaceProjectIds: payload[Field.workspaceProjects] as? [String: String] ?? [:],
+            workspaceAgentDefaults: agents
+        )
+    }
+}

--- a/apps/ios/LukeKit/Sources/LukeKit/WorkspaceCreationDefaults.swift
+++ b/apps/ios/LukeKit/Sources/LukeKit/WorkspaceCreationDefaults.swift
@@ -62,24 +62,40 @@ public final class WorkspaceCreationDefaults {
         store.set(held, forKey: Key.projectByProvider)
     }
 
+    /// Replaces every provider's remembered project at once — the shape a
+    /// paired device's copy of these choices arrives in.
+    public func setLastProjectIds(_ projectIds: [String: String]) {
+        if projectIds.isEmpty {
+            store.removeObject(forKey: Key.projectByProvider)
+        } else {
+            store.set(projectIds, forKey: Key.projectByProvider)
+        }
+    }
+
+    /// Every provider's remembered agent selection at once, keyed by provider id.
+    public var agentDefaults: [String: WorkspaceAgentDefault] {
+        agentsByProvider().compactMapValues(Self.agentDefault(fields:))
+    }
+
+    /// Replaces every provider's remembered agent selection at once.
+    public func setAgentDefaults(_ selections: [String: WorkspaceAgentDefault]) {
+        if selections.isEmpty {
+            store.removeObject(forKey: Key.agentByProvider)
+        } else {
+            store.set(selections.mapValues(Self.fields(of:)), forKey: Key.agentByProvider)
+        }
+    }
+
     public func agentDefault(for providerId: String) -> WorkspaceAgentDefault? {
-        guard
-            let held = store.dictionary(forKey: Key.agentByProvider) as? [String: [String: String]],
-            let fields = held[providerId],
-            let agent = fields["agent"],
-            let model = fields["model"]
-        else { return nil }
-        return WorkspaceAgentDefault(agent: agent, model: model, effort: fields["effort"])
+        agentsByProvider()[providerId].flatMap(Self.agentDefault(fields:))
     }
 
     /// Passing nil forgets the provider's stored choice, so choosing the
     /// provider's own default again is remembered as exactly that.
     public func setAgentDefault(_ selection: WorkspaceAgentDefault?, for providerId: String) {
-        var held = store.dictionary(forKey: Key.agentByProvider) as? [String: [String: String]] ?? [:]
+        var held = agentsByProvider()
         if let selection {
-            var fields = ["agent": selection.agent, "model": selection.model]
-            if let effort = selection.effort { fields["effort"] = effort }
-            held[providerId] = fields
+            held[providerId] = Self.fields(of: selection)
         } else {
             held.removeValue(forKey: providerId)
         }
@@ -88,5 +104,20 @@ public final class WorkspaceCreationDefaults {
 
     private func projectsByProvider() -> [String: String] {
         store.dictionary(forKey: Key.projectByProvider) as? [String: String] ?? [:]
+    }
+
+    private func agentsByProvider() -> [String: [String: String]] {
+        store.dictionary(forKey: Key.agentByProvider) as? [String: [String: String]] ?? [:]
+    }
+
+    private static func agentDefault(fields: [String: String]) -> WorkspaceAgentDefault? {
+        guard let agent = fields["agent"], let model = fields["model"] else { return nil }
+        return WorkspaceAgentDefault(agent: agent, model: model, effort: fields["effort"])
+    }
+
+    private static func fields(of selection: WorkspaceAgentDefault) -> [String: String] {
+        var fields = ["agent": selection.agent, "model": selection.model]
+        if let effort = selection.effort { fields["effort"] = effort }
+        return fields
     }
 }

--- a/apps/ios/LukeKit/Tests/LukeKitTests/DeviceSettingsSyncTests.swift
+++ b/apps/ios/LukeKit/Tests/LukeKitTests/DeviceSettingsSyncTests.swift
@@ -1,0 +1,170 @@
+import Foundation
+import XCTest
+
+@testable import LukeKit
+
+@MainActor
+final class DeviceSettingsSyncTests: XCTestCase {
+    private var suites: [String] = []
+    private var clock = Date(timeIntervalSinceReferenceDate: 1_000)
+
+    override func tearDown() {
+        for suite in suites { UserDefaults(suiteName: suite)?.removePersistentDomain(forName: suite) }
+        super.tearDown()
+    }
+
+    private func makeStore() -> UserDefaults {
+        let suite = "device-settings-sync-tests-\(UUID().uuidString)"
+        suites.append(suite)
+        return UserDefaults(suiteName: suite)!
+    }
+
+    private func tick() -> Date {
+        clock = clock.addingTimeInterval(1)
+        return clock
+    }
+
+    private let changed = DeviceSettingsSnapshot(
+        voice: .coral,
+        speed: .fast,
+        workspaceProviderId: "conductor",
+        workspaceProjectIds: ["conductor": "proj-1", "codex": "https://github.com/o/r"],
+        workspaceAgentDefaults: [
+            "conductor": WorkspaceAgentDefault(agent: "claude", model: "fable-5", effort: "high"),
+            "codex": WorkspaceAgentDefault(agent: "codex", model: "gpt"),
+        ]
+    )
+
+    func testSnapshotRoundTripsThroughTheStore() {
+        let store = makeStore()
+        XCTAssertEqual(DeviceSettingsSnapshot.read(from: store), DeviceSettingsSnapshot())
+        changed.write(to: store)
+        XCTAssertEqual(DeviceSettingsSnapshot.read(from: store), changed)
+        XCTAssertEqual(store.string(forKey: VoiceSettingsKey.voice), "coral")
+        XCTAssertEqual(WorkspaceCreationDefaults(store: store).agentDefault(for: "codex")?.model, "gpt")
+
+        DeviceSettingsSnapshot().write(to: store)
+        XCTAssertEqual(DeviceSettingsSnapshot.read(from: store), DeviceSettingsSnapshot())
+        XCTAssertNil(WorkspaceCreationDefaults(store: store).lastProviderId)
+    }
+
+    func testALocalChangePublishesOnceAndTheOtherDeviceApplies() {
+        let phoneStore = makeStore()
+        let watchStore = makeStore()
+        var phonePublished: [[String: Any]] = []
+        var watchPublished: [[String: Any]] = []
+        let phone = DeviceSettingsSync(store: phoneStore, now: tick) { phonePublished.append($0) }
+        let watch = DeviceSettingsSync(store: watchStore, now: tick) { watchPublished.append($0) }
+        phone.start()
+        watch.start()
+
+        phoneStore.set(RealtimeVoice.sage.rawValue, forKey: VoiceSettingsKey.voice)
+        XCTAssertEqual(phonePublished.count, 1)
+        XCTAssertEqual(phonePublished[0]["voice"] as? String, "sage")
+        XCTAssertEqual(phonePublished[0]["settingsVersion"] as? Int, DeviceSettingsSync.payloadVersion)
+
+        watch.receive(phonePublished[0])
+        XCTAssertEqual(DeviceSettingsSnapshot.read(from: watchStore).voice, .sage)
+        XCTAssertTrue(watchPublished.isEmpty, "applying a received snapshot must not echo it back")
+    }
+
+    func testEveryFieldTravels() {
+        let phoneStore = makeStore()
+        let watchStore = makeStore()
+        var published: [[String: Any]] = []
+        let phone = DeviceSettingsSync(store: phoneStore, now: tick) { published.append($0) }
+        let watch = DeviceSettingsSync(store: watchStore, now: tick) { _ in }
+        phone.start()
+        watch.start()
+
+        changed.write(to: phoneStore)
+        XCTAssertFalse(published.isEmpty)
+        watch.receive(published.last!)
+        XCTAssertEqual(DeviceSettingsSnapshot.read(from: watchStore), changed)
+    }
+
+    func testAnOlderSnapshotIsIgnored() {
+        let phoneStore = makeStore()
+        let watchStore = makeStore()
+        var phonePublished: [[String: Any]] = []
+        var watchPublished: [[String: Any]] = []
+        let phone = DeviceSettingsSync(store: phoneStore, now: tick) { phonePublished.append($0) }
+        let watch = DeviceSettingsSync(store: watchStore, now: tick) { watchPublished.append($0) }
+        phone.start()
+        watch.start()
+
+        phoneStore.set(RealtimeVoice.sage.rawValue, forKey: VoiceSettingsKey.voice)
+        watchStore.set(RealtimeVoiceSpeed.slow.rawValue, forKey: VoiceSettingsKey.speed)
+
+        phone.receive(watchPublished.last!)
+        XCTAssertEqual(DeviceSettingsSnapshot.read(from: phoneStore).speed, .slow)
+        XCTAssertEqual(DeviceSettingsSnapshot.read(from: phoneStore).voice, .default)
+
+        watch.receive(phonePublished.last!)
+        XCTAssertEqual(DeviceSettingsSnapshot.read(from: watchStore).speed, .slow)
+        XCTAssertEqual(DeviceSettingsSnapshot.read(from: watchStore).voice, .default)
+    }
+
+    func testSettingsChangedBeforeEverSyncingWinOverAFreshPair() {
+        let phoneStore = makeStore()
+        changed.write(to: phoneStore)
+        let watchStore = makeStore()
+        var phonePublished: [[String: Any]] = []
+        let phone = DeviceSettingsSync(store: phoneStore, now: tick) { phonePublished.append($0) }
+        let watch = DeviceSettingsSync(store: watchStore, now: tick) { _ in }
+        phone.start()
+        watch.start()
+
+        phone.publishCurrent()
+        watch.receive(phonePublished.last!)
+        XCTAssertEqual(DeviceSettingsSnapshot.read(from: watchStore), changed)
+    }
+
+    func testAnUntouchedDeviceNeverOverwritesAChangedOne() {
+        let phoneStore = makeStore()
+        let watchStore = makeStore()
+        var watchPublished: [[String: Any]] = []
+        let phone = DeviceSettingsSync(store: phoneStore, now: tick) { _ in }
+        let watch = DeviceSettingsSync(store: watchStore, now: tick) { watchPublished.append($0) }
+        phone.start()
+        watch.start()
+
+        phoneStore.set(RealtimeVoice.sage.rawValue, forKey: VoiceSettingsKey.voice)
+        watch.publishCurrent()
+        phone.receive(watchPublished.last!)
+        XCTAssertEqual(DeviceSettingsSnapshot.read(from: phoneStore).voice, .sage)
+    }
+
+    func testTheStampSurvivesARelaunch() {
+        let phoneStore = makeStore()
+        let watchStore = makeStore()
+        var watchPublished: [[String: Any]] = []
+        let watch = DeviceSettingsSync(store: watchStore, now: tick) { watchPublished.append($0) }
+        watch.start()
+        watchStore.set(RealtimeVoice.sage.rawValue, forKey: VoiceSettingsKey.voice)
+        let stale = watchPublished.last!
+
+        var phone: DeviceSettingsSync? = DeviceSettingsSync(store: phoneStore, now: tick) { _ in }
+        phone?.start()
+        phoneStore.set(RealtimeVoice.ash.rawValue, forKey: VoiceSettingsKey.voice)
+        phone = nil
+
+        let relaunched = DeviceSettingsSync(store: phoneStore, now: tick) { _ in }
+        relaunched.start()
+        relaunched.receive(stale)
+        XCTAssertEqual(DeviceSettingsSnapshot.read(from: phoneStore).voice, .ash)
+    }
+
+    func testUnreadablePayloadsAreIgnored() {
+        let store = makeStore()
+        let sync = DeviceSettingsSync(store: store, now: tick) { _ in }
+        sync.start()
+        sync.receive(["settingsVersion": 99, "changedAt": 5.0, "voice": "coral", "speed": "fast"])
+        sync.receive(["settingsVersion": 1, "voice": "coral", "speed": "fast"])
+        sync.receive(["settingsVersion": 1, "changedAt": 5.0, "voice": "coral"])
+        XCTAssertEqual(DeviceSettingsSnapshot.read(from: store), DeviceSettingsSnapshot())
+
+        sync.receive(["settingsVersion": 1, "changedAt": 5.0, "voice": "nobody", "speed": "warp"])
+        XCTAssertEqual(DeviceSettingsSnapshot.read(from: store), DeviceSettingsSnapshot())
+    }
+}

--- a/apps/ios/LukeKit/Tests/LukeKitTests/DeviceSettingsSyncTests.swift
+++ b/apps/ios/LukeKit/Tests/LukeKitTests/DeviceSettingsSyncTests.swift
@@ -53,8 +53,8 @@ final class DeviceSettingsSyncTests: XCTestCase {
         let watchStore = makeStore()
         var phonePublished: [[String: Any]] = []
         var watchPublished: [[String: Any]] = []
-        let phone = DeviceSettingsSync(store: phoneStore, now: tick) { phonePublished.append($0) }
-        let watch = DeviceSettingsSync(store: watchStore, now: tick) { watchPublished.append($0) }
+        let phone = DeviceSettingsSync(store: phoneStore, role: .primary, now: tick) { phonePublished.append($0) }
+        let watch = DeviceSettingsSync(store: watchStore, role: .secondary, now: tick) { watchPublished.append($0) }
         phone.start()
         watch.start()
 
@@ -72,8 +72,8 @@ final class DeviceSettingsSyncTests: XCTestCase {
         let phoneStore = makeStore()
         let watchStore = makeStore()
         var published: [[String: Any]] = []
-        let phone = DeviceSettingsSync(store: phoneStore, now: tick) { published.append($0) }
-        let watch = DeviceSettingsSync(store: watchStore, now: tick) { _ in }
+        let phone = DeviceSettingsSync(store: phoneStore, role: .primary, now: tick) { published.append($0) }
+        let watch = DeviceSettingsSync(store: watchStore, role: .secondary, now: tick) { _ in }
         phone.start()
         watch.start()
 
@@ -88,8 +88,8 @@ final class DeviceSettingsSyncTests: XCTestCase {
         let watchStore = makeStore()
         var phonePublished: [[String: Any]] = []
         var watchPublished: [[String: Any]] = []
-        let phone = DeviceSettingsSync(store: phoneStore, now: tick) { phonePublished.append($0) }
-        let watch = DeviceSettingsSync(store: watchStore, now: tick) { watchPublished.append($0) }
+        let phone = DeviceSettingsSync(store: phoneStore, role: .primary, now: tick) { phonePublished.append($0) }
+        let watch = DeviceSettingsSync(store: watchStore, role: .secondary, now: tick) { watchPublished.append($0) }
         phone.start()
         watch.start()
 
@@ -110,8 +110,8 @@ final class DeviceSettingsSyncTests: XCTestCase {
         changed.write(to: phoneStore)
         let watchStore = makeStore()
         var phonePublished: [[String: Any]] = []
-        let phone = DeviceSettingsSync(store: phoneStore, now: tick) { phonePublished.append($0) }
-        let watch = DeviceSettingsSync(store: watchStore, now: tick) { _ in }
+        let phone = DeviceSettingsSync(store: phoneStore, role: .primary, now: tick) { phonePublished.append($0) }
+        let watch = DeviceSettingsSync(store: watchStore, role: .secondary, now: tick) { _ in }
         phone.start()
         watch.start()
 
@@ -120,12 +120,69 @@ final class DeviceSettingsSyncTests: XCTestCase {
         XCTAssertEqual(DeviceSettingsSnapshot.read(from: watchStore), changed)
     }
 
+    func testTwoPreSyncCopiesSettleOnThePrimaryWhicheverActivatesFirst() {
+        for primaryFirst in [true, false] {
+            let phoneStore = makeStore()
+            let watchStore = makeStore()
+            changed.write(to: phoneStore)
+            var onWatch = changed
+            onWatch.voice = .verse
+            onWatch.workspaceProviderId = "codex"
+            onWatch.write(to: watchStore)
+            var phonePublished: [[String: Any]] = []
+            var watchPublished: [[String: Any]] = []
+            let phone = DeviceSettingsSync(store: phoneStore, role: .primary, now: tick) {
+                phonePublished.append($0)
+            }
+            let watch = DeviceSettingsSync(store: watchStore, role: .secondary, now: tick) {
+                watchPublished.append($0)
+            }
+            if primaryFirst {
+                phone.start()
+                watch.start()
+            } else {
+                watch.start()
+                phone.start()
+            }
+
+            phone.publishCurrent()
+            watch.publishCurrent()
+            phone.receive(watchPublished.last!)
+            watch.receive(phonePublished.last!)
+            XCTAssertEqual(DeviceSettingsSnapshot.read(from: phoneStore), changed)
+            XCTAssertEqual(DeviceSettingsSnapshot.read(from: watchStore), changed)
+        }
+    }
+
+    func testAChangeMadeAfterSyncingBeatsAPreSyncCopy() {
+        let phoneStore = makeStore()
+        let watchStore = makeStore()
+        changed.write(to: phoneStore)
+        var phonePublished: [[String: Any]] = []
+        var watchPublished: [[String: Any]] = []
+        let phone = DeviceSettingsSync(store: phoneStore, role: .primary, now: tick) {
+            phonePublished.append($0)
+        }
+        let watch = DeviceSettingsSync(store: watchStore, role: .secondary, now: tick) {
+            watchPublished.append($0)
+        }
+        watch.start()
+        watchStore.set(RealtimeVoice.verse.rawValue, forKey: VoiceSettingsKey.voice)
+        phone.start()
+
+        phone.publishCurrent()
+        watch.receive(phonePublished.last!)
+        phone.receive(watchPublished.last!)
+        XCTAssertEqual(DeviceSettingsSnapshot.read(from: watchStore).voice, .verse)
+        XCTAssertEqual(DeviceSettingsSnapshot.read(from: phoneStore).voice, .verse)
+    }
+
     func testAnUntouchedDeviceNeverOverwritesAChangedOne() {
         let phoneStore = makeStore()
         let watchStore = makeStore()
         var watchPublished: [[String: Any]] = []
-        let phone = DeviceSettingsSync(store: phoneStore, now: tick) { _ in }
-        let watch = DeviceSettingsSync(store: watchStore, now: tick) { watchPublished.append($0) }
+        let phone = DeviceSettingsSync(store: phoneStore, role: .primary, now: tick) { _ in }
+        let watch = DeviceSettingsSync(store: watchStore, role: .secondary, now: tick) { watchPublished.append($0) }
         phone.start()
         watch.start()
 
@@ -139,17 +196,17 @@ final class DeviceSettingsSyncTests: XCTestCase {
         let phoneStore = makeStore()
         let watchStore = makeStore()
         var watchPublished: [[String: Any]] = []
-        let watch = DeviceSettingsSync(store: watchStore, now: tick) { watchPublished.append($0) }
+        let watch = DeviceSettingsSync(store: watchStore, role: .secondary, now: tick) { watchPublished.append($0) }
         watch.start()
         watchStore.set(RealtimeVoice.sage.rawValue, forKey: VoiceSettingsKey.voice)
         let stale = watchPublished.last!
 
-        var phone: DeviceSettingsSync? = DeviceSettingsSync(store: phoneStore, now: tick) { _ in }
+        var phone: DeviceSettingsSync? = DeviceSettingsSync(store: phoneStore, role: .primary, now: tick) { _ in }
         phone?.start()
         phoneStore.set(RealtimeVoice.ash.rawValue, forKey: VoiceSettingsKey.voice)
         phone = nil
 
-        let relaunched = DeviceSettingsSync(store: phoneStore, now: tick) { _ in }
+        let relaunched = DeviceSettingsSync(store: phoneStore, role: .primary, now: tick) { _ in }
         relaunched.start()
         relaunched.receive(stale)
         XCTAssertEqual(DeviceSettingsSnapshot.read(from: phoneStore).voice, .ash)
@@ -157,7 +214,7 @@ final class DeviceSettingsSyncTests: XCTestCase {
 
     func testUnreadablePayloadsAreIgnored() {
         let store = makeStore()
-        let sync = DeviceSettingsSync(store: store, now: tick) { _ in }
+        let sync = DeviceSettingsSync(store: store, role: .primary, now: tick) { _ in }
         sync.start()
         sync.receive(["settingsVersion": 99, "changedAt": 5.0, "voice": "coral", "speed": "fast"])
         sync.receive(["settingsVersion": 1, "voice": "coral", "speed": "fast"])

--- a/apps/ios/LukeWatch/WatchConnectivityReceiver.swift
+++ b/apps/ios/LukeWatch/WatchConnectivityReceiver.swift
@@ -13,7 +13,7 @@ final class WatchConnectivityReceiver: NSObject, WCSessionDelegate {
     @MainActor
     init(watchSession: WatchAccountSession) {
         self.watchSession = watchSession
-        settings = DeviceSettingsSync(publish: Self.publishSettings)
+        settings = DeviceSettingsSync(role: .secondary, publish: Self.publishSettings)
         super.init()
         settings.start()
         watchSession.onCredentialsNeeded = { [weak self] in

--- a/apps/ios/LukeWatch/WatchConnectivityReceiver.swift
+++ b/apps/ios/LukeWatch/WatchConnectivityReceiver.swift
@@ -1,14 +1,21 @@
+import LukeKit
 import WatchConnectivity
 
 /// Activates WatchConnectivity on the watch, requests tokens from the paired
-/// iPhone on first launch, and feeds every inbound payload to WatchAccountSession.
+/// iPhone on first launch, feeds every inbound payload to WatchAccountSession,
+/// and keeps this watch's device settings and the phone's equal through the
+/// session's application context: the phone's latest snapshot is applied as
+/// it arrives, and a change made on the wrist is sent back the same way.
 final class WatchConnectivityReceiver: NSObject, WCSessionDelegate {
     private let watchSession: WatchAccountSession
+    private let settings: DeviceSettingsSync
 
     @MainActor
     init(watchSession: WatchAccountSession) {
         self.watchSession = watchSession
+        settings = DeviceSettingsSync(publish: Self.publishSettings)
         super.init()
+        settings.start()
         watchSession.onCredentialsNeeded = { [weak self] in
             self?.requestTokensIfNeeded()
         }
@@ -25,6 +32,11 @@ final class WatchConnectivityReceiver: NSObject, WCSessionDelegate {
         error: (any Error)?
     ) {
         guard activationState == .activated else { return }
+        let received = session.receivedApplicationContext
+        Task { @MainActor [weak self] in
+            self?.settings.receive(received)
+            self?.settings.publishCurrent()
+        }
         requestTokensIfNeeded()
     }
 
@@ -49,7 +61,17 @@ final class WatchConnectivityReceiver: NSObject, WCSessionDelegate {
         replyHandler([:])
     }
 
+    func session(_ session: WCSession, didReceiveApplicationContext context: [String: Any]) {
+        Task { @MainActor [weak self] in self?.settings.receive(context) }
+    }
+
     // MARK: - Private
+
+    private static func publishSettings(_ payload: [String: Any]) {
+        let s = WCSession.default
+        guard s.activationState == .activated else { return }
+        try? s.updateApplicationContext(payload)
+    }
 
     private func requestTokensIfNeeded() {
         Task { @MainActor [weak self] in

--- a/apps/ios/README.md
+++ b/apps/ios/README.md
@@ -75,7 +75,9 @@ sorts, or searches the watch list the same way, drawing a Show All row above
 the rows a narrowing leaves so a list Luke narrowed never hides a session
 without saying so. The watch voice page also has the phone's Settings pattern:
 a gear button opens voice and speed controls, plus the Debug tool list read
-from the watch call and roster.
+from the watch call and roster. The voice and speed chosen there are the
+phone's own, kept equal through the settings sync described under Watch below,
+so the wrist is a quick way to change them and never a second copy.
 
 ## Analytics
 
@@ -116,12 +118,27 @@ streams down.
 ## Watch
 
 `LukeWatch` is its own client of the hosted service, not a view the iPhone
-feeds. The phone hands it the account's tokens over WatchConnectivity and
-nothing else; the sessions list, a session's conversation, the messages and
-controls sent from the wrist, and the voice call's mint and Realtime socket
-all leave the watch itself. watchOS chooses the path and prefers the phone:
+feeds. The phone hands it the account's tokens over WatchConnectivity, and the
+two exchange one more thing over the same channel, described next; the
+sessions list, a session's conversation, the messages and controls sent from
+the wrist, and the voice call's mint and Realtime socket all leave the watch
+itself. watchOS chooses the path and prefers the phone:
 the paired iPhone's connection tunneled over Bluetooth whenever the phone is
 in range, the watch's own Wi-Fi or cellular only when it is not.
+
+The settings the two apps both hold — the voice and speed the next mint asks
+for, and the New Workspace choices remembered per provider — are kept equal
+through WatchConnectivity's application context, in `DeviceSettingsSync` in
+`LukeKit` with `PhoneSessionRelay` and `WatchConnectivityReceiver` as its two
+ends. Each app keeps reading and writing its own UserDefaults keys; the sync
+follows those keys, sends one whole snapshot on every local change and at
+activation, and applies an arriving snapshot only when it is newer than the
+last change made on the receiving device, so a choice made while the pair was
+apart is never undone by the other device's older copy. The application
+context is the right channel because it holds only the latest snapshot,
+delivers it whenever the pair next connects, and keeps the last one received
+across a relaunch. Nothing in it is account data: no token, key, or anything
+a provider wrote travels this way, and it leaves neither device.
 
 watchOS draws one line through that traffic. HTTP over `URLSession` is open
 to every app, and every hosted read and act on the watch travels that way,

--- a/apps/ios/README.md
+++ b/apps/ios/README.md
@@ -134,7 +134,10 @@ ends. Each app keeps reading and writing its own UserDefaults keys; the sync
 follows those keys, sends one whole snapshot on every local change and at
 activation, and applies an arriving snapshot only when it is newer than the
 last change made on the receiving device, so a choice made while the pair was
-apart is never undone by the other device's older copy. The application
+apart is never undone by the other device's older copy. Settings changed before
+a device ever synced carry no stamp, so those copies are ranked by role
+instead, the phone's over the watch's, and both lose to any change made once
+syncing. The application
 context is the right channel because it holds only the latest snapshot,
 delivers it whenever the pair next connects, and keeps the last one received
 across a relaunch. Nothing in it is account data: no token, key, or anything


### PR DESCRIPTION
## Summary

The iOS app and the watch app each kept their own copy of the device settings, so the wrist-sized picker was the only way to change anything on the watch, and a change made on the phone never reached it. This PR keeps the two equal over WatchConnectivity's application context, the standard channel for exactly this: it holds only the latest snapshot each way, is delivered whenever the pair next connects, and keeps the last one received across a relaunch.

What travels is everything the two apps both hold, and nothing else:

- the voice and speed the next mint asks for (`VoiceSettingsKey`)
- the New Workspace choices remembered per provider: last provider, project per provider, and agent/model/effort per provider (`WorkspaceCreationDefaults`)

The watch keeps its own settings page for quick access; its voice and speed are now the phone's own rather than a second copy.

## How it works

- `DeviceSettingsSync` in `LukeKit` is the engine, with `PhoneSessionRelay` and `WatchConnectivityReceiver` as its two ends. Each app keeps reading and writing its own UserDefaults keys; the sync follows those keys through `UserDefaults.didChangeNotification`.
- One whole snapshot is sent on every local change and at activation, stamped with the moment of the last local change. The stamp is persisted, so it survives a relaunch.
- An arriving snapshot is applied only when it is newer than the last change made on the receiving device, so a choice made while the pair was apart is never undone by the other device's older copy, whichever side activates first. Applying a snapshot never echoes it back.
- Settings changed before this build ever synced have no stamp; they take a fixed pre-sync stamp by role, the phone's above the watch's and both below any real change, so a fresh pair learns them instead of overwriting them with untouched defaults, and two pre-sync copies settle on the phone's whichever device activates first.
- A payload from another schema version, or one missing its stamp or fields, is ignored rather than half-read. An unknown voice or speed falls to the default, as each app's own controls already do.
- Synced writes bypass the pickers' bindings, so a settings change is counted only on the device where the developer made it.

Nothing here is account data: no token, key, or anything a provider wrote travels this way, and it leaves neither device. `apps/ios/README.md` describes the sync beside the token relay.

## Verification

CI does not compile the Swift targets, so these ran on a Mac with Xcode 26.6 against this branch:

- `swift test` in `apps/ios/LukeKit`: all suites pass, including the 10 new `DeviceSettingsSyncTests` (round trip, single publish with no echo, every field travels, older snapshot ignored, pre-sync settings win over a fresh pair, two pre-sync copies settle on the phone's whichever side activates first, a change made after syncing beats a pre-sync copy, untouched device never overwrites a changed one, stamp survives relaunch, unreadable payloads ignored).
- `xcodebuild build` for the `Luke` scheme (iOS Simulator) and the `LukeWatch` scheme (watchOS Simulator): both succeed with no new warnings.
- `./scripts/check.sh` for the portable change (the README).

Not performed: a paired iPhone and Apple Watch run of the live sync. No UI moved, so there is no visual evidence and no physical-notch check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34082171966/artifacts/10004075682) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34082171966)

- Commit: `23d8fb36b45f2426e11fb96e0b20a268b83bf3ea`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->