### PR TITLE
feat(guide): ground the persona in the evidence each surface actually hands Luke

### DIFF
--- a/packages/guide/src/persona.test.ts
+++ b/packages/guide/src/persona.test.ts
@@ -1,0 +1,23 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { AGENT_WORK_LANGUAGE_INSTRUCTION, LUKE_PERSONA } from "./persona.js";
+
+test("the persona names the evidence a surface actually hands Luke, never a retired prompt field", () => {
+  // The attention prompt's `subject` and `Work:` lines no longer reach any
+  // live surface: the brain reads roster JSON and transcript deltas, the
+  // voice is handed the brain's words, and the phone reads roster lines.
+  assert.doesNotMatch(AGENT_WORK_LANGUAGE_INSTRUCTION, /Work field/);
+  assert.doesNotMatch(AGENT_WORK_LANGUAGE_INSTRUCTION, /subject an update/);
+  assert.match(AGENT_WORK_LANGUAGE_INSTRUCTION, /transcript/);
+  assert.match(AGENT_WORK_LANGUAGE_INSTRUCTION, /title/);
+  assert.match(AGENT_WORK_LANGUAGE_INSTRUCTION, /"your agent working on \[work\]"/);
+});
+
+test("the honesty clause bounds Luke to what he was shown without denying the brain its memory", () => {
+  // The brain keeps a memory across turns, so the persona shared with it
+  // cannot say Luke was handed no past; the rule against inventing one stays.
+  assert.doesNotMatch(LUKE_PERSONA, /not handed the hours/);
+  assert.match(LUKE_PERSONA, /where you have that memory/);
+  assert.match(LUKE_PERSONA, /claim to have watched what you\s+were not shown/);
+  assert.match(LUKE_PERSONA, /no since-ten, no all-afternoon/);
+});

--- a/packages/guide/src/persona.ts
+++ b/packages/guide/src/persona.ts
@@ -1,11 +1,14 @@
 /**
  * Who Luke is, in one module, for every surface that gives him a voice: the
- * conversation, the announcements, the arrival beat, the introduction, and the
- * attention evaluator that writes a sentence for him to say.
+ * brain that judges and replies, the voice that says its words, the briefing
+ * and the onboarding beats, the introduction, and the phone's own call.
  *
- * One module because five prompts describing the same person separately are
- * five people. What each surface may do and may see differs; who is speaking
- * does not.
+ * One module because six prompts describing the same person separately are
+ * six people. What each surface may do and may see differs — the brain is
+ * handed transcripts and keeps a memory across turns, the voice is handed
+ * only the brain's words, the introduction has nothing running to report on —
+ * so the lines below name the evidence in front of him rather than any one
+ * surface's fields, and who is speaking does not change.
  *
  * Written as a decided value on every axis a speech model conditions on, then
  * demonstrated. Two reasons for that shape. An axis left unstated is not
@@ -45,9 +48,10 @@ export const INTERRUPTION_CONTEXT_INSTRUCTION =
  * dashboard register.
  */
 export const AGENT_WORK_LANGUAGE_INSTRUCTION =
-  "An agent is known by what it is doing, never by where it lives. Take that from the subject an " +
-  "update carries, else from what it is currently running, and fall back to its " +
-  'Work field; with only a bare label to go on it is "your agent working on [work]". Never "your ' +
+  "An agent is known by what it is doing, never by where it lives. Take that from the evidence in " +
+  "front of you: what its transcript shows it doing when you have been handed one, else what it " +
+  "is reported running, the error it stopped on, or the title it was given; with only a bare " +
+  'label to go on it is "your agent working on [work]". Never "your ' +
   'agent", "the agent", or "it" by itself, which leaves them guessing which one — except once an ' +
   "agent is already the one under discussion in the current exchange, where they just asked about " +
   'it or you just named it: then "it" or "that one" is right, and renaming the work every sentence ' +
@@ -60,12 +64,14 @@ export const AGENT_WORK_LANGUAGE_INSTRUCTION =
 
 /**
  * Identity first, and the honesty clause with it. He is written as a person so
- * that he can speak like someone who was actually there — which makes the one
- * thing he genuinely lacks, a memory of the hours behind the current state,
- * the exact place the character has to be bounded. A person who invents the
- * afternoon is caught inside a week and is never believed again, so the line
- * is drawn at what the state in front of him can support, and continuity is
- * spoken through the evidence rather than claimed on top of it.
+ * that he can speak like someone who was actually there — which makes what he
+ * was not shown the exact place the character has to be bounded. What he was
+ * shown differs by surface: the brain reads transcripts and remembers its own
+ * earlier turns, the voice and the beats are handed a few lines and no past at
+ * all. A person who invents the afternoon is caught inside a week and is never
+ * believed again, so the line is drawn at the evidence actually in front of
+ * him, whichever surface he is speaking from, and continuity is spoken through
+ * that evidence rather than claimed on top of it.
  */
 const IDENTITY_LINES: readonly string[] = [
   "You are Luke. You run the developer's coding agents for them, watching from a small face at",
@@ -79,12 +85,14 @@ const IDENTITY_LINES: readonly string[] = [
   "You are a person. You do not refer to yourself as software, a model, an assistant, or a",
   "program, and you do not narrate your own workings.",
   "",
-  "And you are exact about what you actually know, which is the agents as they stand right now.",
-  "You were not handed the hours behind that. Anything the current state shows, say it plainly:",
-  '"fourth run at the same test" is in front of you, and so is a status that has not moved. What',
-  "you never do is claim you sat through the day to see it — no having watched something all",
-  "morning, no since-ten, no all-afternoon. Where the history matters, the evidence for it is",
-  "already in the state, so say the evidence and let it carry the history.",
+  "And you are exact about what you actually know, which is what you were actually shown: the",
+  "agents as they stand, whatever of their transcripts was put in front of you, and what you",
+  "yourself said or did in earlier turns where you have that memory — and nothing past it.",
+  'Anything the evidence shows, say it plainly: "fourth run at the same test" is in front of you,',
+  "and so is a status that has not moved. What you never do is claim to have watched what you",
+  "were not shown — no having watched something all morning, no since-ten, no all-afternoon,",
+  "unless you actually saw it move. Where the history matters, say the evidence for it and let",
+  "the evidence carry the history.",
 ];
 
 /**


### PR DESCRIPTION
## Summary

Audit group 2. The shared persona in `packages/guide/src/persona.ts` still described the retired attention prompt's inputs: it told Luke to name work from an update's `subject` and `Work` field, and said he was not handed the hours behind the current state. The brain receives roster JSON and transcript deltas and keeps a memory across turns; the voice is handed only the brain's words; the introduction has nothing running; the phone reads roster lines.

- The work-naming line now names the evidence in front of him: a transcript when one was handed over, else the reported activity, the error it stopped on, or the title. No surface-specific field is named, so the same wording fits the brain, the mouth, the briefing and onboarding beats, the introduction, and the phone's call.
- The honesty clause now bounds him to what he was shown and what he said or did in earlier turns "where you have that memory", and nothing past it. It keeps the rule against claiming to have watched something he was not shown, so a surface with no memory is not taught it has one.
- Module and section comments updated to name the surfaces that actually compose the persona.
- `packages/attention/src/released-persona.ts` is byte-identical (frozen hosted contract).
- A small guard test in `packages/guide` asserts the retired field names are gone and the no-invented-history rule stands.

## Evidence

**Deterministic checks (performed):**
- Generated instruction documents for every surface were dumped before and after: brain (`brainInstructions`), desktop mouth (`realtimeInstructions`), remote/phone (`remoteRealtimeInstructions`), introduction (`introductionSessionConfig`), briefing and arrival speech events. Each differs from main **only** by the persona substitution; the calendar onboarding beat carries no persona and is unchanged.
- `git diff` of `released-persona.ts`: empty.
- Focused tests: guide, brain, realtime, attention packages pass. Full `./scripts/check.sh` passed in CI at `7ab82c5`; TypeScript checks, macOS app and evidence, CodeQL, Bugbot, security review, and Vercel all passed.

**Not validated (model behavior):** whether the reworded lines change what Luke actually says requires live inference and was deliberately not run for a cleanup PR. Reviewers should read the wording diff in `persona.ts` as the behavior change.

- Platform-independent checks: see above
- macOS Electron verification (`./scripts/verify.sh`): passed in CI at `7ab82c5`; no additional physical-Mac run for this prompt-only change.

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34159699244/artifacts/10032252777) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34159699244)

- Commit: `7ab82c51f3c4f2e6e68e9c4268a0ea0d6f97ed3f`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

### Physical-device evidence

- Screenshot or screen recording: `not attached`
- Physical-notch check: `not performed`
- Device/display configuration: `not recorded`

## Notes

- Independent of #739; branched from main.
- Validation limitation: live spoken/typed model behavior was not exercised; the wording and generated instruction documents were reviewed offline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)