### PR TITLE
refactor(desktop): give the hidden voice window its own narrow bootstrap

### DIFF
--- a/apps/desktop/src/main/desktop-app.ts
+++ b/apps/desktop/src/main/desktop-app.ts
@@ -134,6 +134,7 @@ import {
   type SessionRosterPayload,
   SUPERSET_SIGN_IN_STAGE,
   SUPERSET_WORKSPACE_PROVIDER_ID,
+  type VoiceBootstrap,
   WINDOW_ROLE,
 } from "#shared/contracts";
 import { VOICE_SOURCE_COUNTED_AS } from "#shared/product-vocabulary";
@@ -1908,6 +1909,38 @@ function registerIpc(): void {
     snapshot: () => settingsStore.snapshot(),
     broadcast: (settings, except) => broadcast(channels.onSettingsChanged, settings, except),
   });
+  /**
+   * The fields the hidden voice window reads, assembled for it alone or
+   * inside a panel's bootstrap: the settings that shape a call, the roster
+   * the arrival beat is worded from, the thread the last launch left, the
+   * talk key, the microphone and output state, the trace gate, and — only
+   * for the voice window itself — the receiver epoch its readiness report
+   * must name. Nothing here waits on the Superset CLI, the account, a
+   * project default, or the recording identity, which the voice never reads.
+   */
+  const voiceBootstrapFields = async (context: BridgeContext): Promise<VoiceBootstrap> => ({
+    agentTraceEnabled: agentTrace !== undefined,
+    microphoneStatus: microphoneStatus(),
+    ...(voiceWindow.owns(context.sender) ? { voiceEpoch: voiceReceiver.epoch() } : undefined),
+    // Both keys travel as accelerators rather than labels: the renderer needs
+    // both spellings — the keycaps' ⌥ and L drawn apart, and aria's Alt+L —
+    // and only the accelerator can produce the pair.
+    ...(hotkeys.talk ? { voiceHotkey: hotkeys.talk } : undefined),
+    ...(outputAudio ? { outputAudio } : undefined),
+    // Bootstrapped through the same relevance gate every broadcast passes:
+    // a window that opens late must not learn of rows the roster has already
+    // let go and then hold them past the next broadcast's dedupe.
+    sessionRoster:
+      runMode.observesProviders && accountCapabilitiesActive()
+        ? { sessions: sessionRegistry.list() }
+        : { sessions: [] },
+    // Computed rather than read from the cached flag: at launch nothing
+    // has recomputed it yet, so a persisted pause would draw a waking face.
+    announcementsHeld: accountCapabilitiesActive() && (await announcementsQuietNow(Date.now())),
+    conversationHistory,
+    settings: await settingsStore.snapshot(),
+  });
+  registerContextHandler(BRIDGE.getVoiceBootstrap, voiceBootstrapFields);
   registerContextHandler(
     BRIDGE.getBootstrap,
     async (context: BridgeContext): Promise<AppBootstrap> => {
@@ -1920,11 +1953,13 @@ function registerIpc(): void {
         ? undefined
         : ((displayId !== undefined ? panels.display(displayId) : undefined) ??
           screen.getPrimaryDisplay());
-      const [supersetInstalled, supersetConnected] = await Promise.all([
+      const [supersetInstalled, supersetConnected, voiceFields] = await Promise.all([
         supersetCli.installed(),
         supersetCli.connected(),
+        voiceBootstrapFields(context),
       ]);
       return {
+        ...voiceFields,
         mode: displayId !== undefined ? panels.modeFor(displayId) : panels.initialMode,
         startPeeked,
         startInSlot,
@@ -1932,32 +1967,17 @@ function registerIpc(): void {
         fixture,
         captureMode,
         fixtureMode,
-        agentTraceEnabled: agentTrace !== undefined,
         supersetInstalled,
         supersetConnected,
         accountRequired: runMode.requiresAccount,
         account,
         packaged: app.isPackaged,
         platform: process.platform,
-        microphoneStatus: microphoneStatus(),
-        ...(voiceWindow.owns(context.sender) ? { voiceEpoch: voiceReceiver.epoch() } : undefined),
-        // Both keys travel as accelerators rather than labels: the renderer needs
-        // both spellings — the keycaps' ⌥ and L drawn apart, and aria's Alt+L —
-        // and only the accelerator can produce the pair.
-        ...(hotkeys.talk ? { voiceHotkey: hotkeys.talk } : undefined),
         voiceHotkeyHeld: hotkeys.held,
         ...(hotkeys.ask ? { askHotkey: hotkeys.ask } : undefined),
         ...(hotkeys.stop ? { stopHotkey: hotkeys.stop } : undefined),
-        ...(outputAudio ? { outputAudio } : undefined),
         display: display ? panels.diagnostic(display) : undefined,
         update: updateService.snapshot(),
-        // Bootstrapped through the same relevance gate every broadcast passes:
-        // a panel that opens late must not learn of rows the roster has already
-        // let go and then hold them past the next broadcast's dedupe.
-        sessionRoster:
-          runMode.observesProviders && accountCapabilitiesActive()
-            ? { sessions: sessionRegistry.list() }
-            : { sessions: [] },
         // A live run's roster has settled once it has been broadcast at all —
         // the first pass publishes even an empty reading — so before that, the
         // empty list above means "not looked yet" and the face must not sleep
@@ -1973,14 +1993,9 @@ function registerIpc(): void {
         // The calendar is a capability like the rosters: nothing of it is
         // shown, or held quiet, before the account gate opens.
         calendars: accountCapabilitiesActive() ? observedCalendars : [],
-        // Computed rather than read from the cached flag: at launch nothing
-        // has recomputed it yet, so a persisted pause would draw a waking face.
-        announcementsHeld: accountCapabilitiesActive() && (await announcementsQuietNow(Date.now())),
-        conversationHistory,
         voiceView: latestVoiceView,
         calendarOnboardingOwed: calendarOnboardingGateOwed(),
         sessionReplay: await sessionReplayBootstrap(),
-        settings: await settingsStore.snapshot(),
       };
     },
   );

--- a/apps/desktop/src/renderer/voice/use-voice-session.test.ts
+++ b/apps/desktop/src/renderer/voice/use-voice-session.test.ts
@@ -15,6 +15,7 @@ import { type AppSettings, appSettingsView, CLI_CONNECTION } from "#shared/wire/
 import { REPLY_KIND } from "./realtime-session";
 import {
   activeVoiceStream,
+  applyVoiceBootstrap,
   conversationEntryBelongsToConversation,
   liveConversationEntries,
   liveSpeedApplies,
@@ -27,7 +28,6 @@ import {
   typedAskHolds,
   VOICE_RESTART,
   voiceRestartAction,
-  voiceSurroundingsFromBootstrap,
   waitForConversationContext,
 } from "./use-voice-session";
 import { VOICE_READINESS_PART, VoiceReadiness } from "./voice-readiness";
@@ -330,19 +330,23 @@ const NOTHING_PUSHED = {
   announcementsHeld: false,
 };
 
+const NOTHING_PUSHED_YET = { sessions: false, announcementsHeld: false, microphoneStatus: false };
+
 test("the voice bootstrap fills only what no push has said yet", () => {
   // Nothing pushed: the snapshot is the whole answer, and the first turn may open.
-  const fresh = voiceSurroundingsFromBootstrap(NOTHING_PUSHED, VOICE_BOOTSTRAP, false);
-  assert.equal(fresh.settings?.voiceCaptions, true);
-  assert.deepEqual(fresh.sessions, []);
-  assert.deepEqual(fresh.outputAudio, { muted: false, volume: 0.5 });
-  assert.equal(fresh.announcementsHeld, true);
-  assert.equal(fresh.bootstrapVoiceHotkey, "Alt+Space");
-  assert.equal(fresh.conversationContextReady, true);
+  const fresh = applyVoiceBootstrap(NOTHING_PUSHED, VOICE_BOOTSTRAP, NOTHING_PUSHED_YET);
+  assert.equal(fresh.surroundings.settings?.voiceCaptions, true);
+  assert.deepEqual(fresh.surroundings.sessions, []);
+  assert.deepEqual(fresh.surroundings.outputAudio, { muted: false, volume: 0.5 });
+  assert.equal(fresh.surroundings.announcementsHeld, true);
+  assert.equal(fresh.surroundings.bootstrapVoiceHotkey, "Alt+Space");
+  assert.equal(fresh.surroundings.conversationContextReady, true);
+  assert.equal(fresh.microphoneStatus, "granted");
 
   // Every push that raced past the bootstrap is newer than it and is kept:
-  // a settings change, a roster, an output edge, and a hold released to
-  // `false`, which is a real value and not a gap for the snapshot to fill.
+  // a settings change, a roster, an output edge, a hold released to
+  // `false`, and a permission the developer answered, none of which is a gap
+  // for the snapshot to fill.
   const pushedSettings = appSettingsView({
     ...BOOTSTRAP_SETTINGS,
     stored: { ...BOOTSTRAP_SETTINGS.stored, voiceCaptions: false },
@@ -356,7 +360,7 @@ test("the voice bootstrap fills only what no push has said yet", () => {
       lastActivityAt: 1_800_000_000_000,
     },
   );
-  const raced = voiceSurroundingsFromBootstrap(
+  const raced = applyVoiceBootstrap(
     {
       settings: pushedSettings,
       sessions: [pushedSession],
@@ -364,16 +368,49 @@ test("the voice bootstrap fills only what no push has said yet", () => {
       announcementsHeld: false,
     },
     VOICE_BOOTSTRAP,
-    true,
+    { sessions: true, announcementsHeld: true, microphoneStatus: true },
   );
-  assert.equal(raced.settings, pushedSettings);
-  assert.deepEqual(raced.sessions, [pushedSession]);
-  assert.deepEqual(raced.outputAudio, { muted: true, volume: 0 });
-  assert.equal(raced.announcementsHeld, false);
+  assert.equal(raced.surroundings.settings, pushedSettings);
+  assert.deepEqual(raced.surroundings.sessions, [pushedSession]);
+  assert.deepEqual(raced.surroundings.outputAudio, { muted: true, volume: 0 });
+  assert.equal(raced.surroundings.announcementsHeld, false);
+  assert.equal(raced.microphoneStatus, undefined);
   // The gate and the key's name come from the bootstrap alone; no push carries them.
-  assert.equal(raced.agentTraceEnabled, false);
-  assert.equal(raced.bootstrapVoiceHotkey, "Alt+Space");
-  assert.equal(raced.conversationContextReady, true);
+  assert.equal(raced.surroundings.agentTraceEnabled, false);
+  assert.equal(raced.surroundings.bootstrapVoiceHotkey, "Alt+Space");
+  assert.equal(raced.surroundings.conversationContextReady, true);
+});
+
+test("a roster pushed empty, or a permission pushed back, is not undone by a stale bootstrap", () => {
+  // The bootstrap was captured while a session stood; the roster then pushed
+  // [] — the last row gone, or a sign-out — before the bootstrap landed. An
+  // empty push is an observation, not an absence, so the stale row must not
+  // come back; the same for a permission a push has since moved.
+  const staleSession = normalizeSession(
+    { id: "codex", displayName: "Codex" },
+    {
+      providerSessionId: "thread-1",
+      title: "gone already",
+      status: SESSION_STATUS.WAITING,
+      lastActivityAt: 1_800_000_000_000,
+    },
+  );
+  const stale: VoiceBootstrap = {
+    ...VOICE_BOOTSTRAP,
+    sessionRoster: { sessions: [staleSession] },
+    microphoneStatus: "not-determined",
+  };
+  const applied = applyVoiceBootstrap({ ...NOTHING_PUSHED, sessions: [] }, stale, {
+    sessions: true,
+    announcementsHeld: false,
+    microphoneStatus: true,
+  });
+  assert.deepEqual(applied.surroundings.sessions, []);
+  assert.equal(applied.microphoneStatus, undefined);
+  // With no roster push at all, the bootstrap's row is the only reading and stands.
+  const unpushed = applyVoiceBootstrap(NOTHING_PUSHED, stale, NOTHING_PUSHED_YET);
+  assert.deepEqual(unpushed.surroundings.sessions, [staleSession]);
+  assert.equal(unpushed.microphoneStatus, "not-determined");
 });
 
 test("the readiness report names the voice bootstrap's epoch however the pushes and subscriptions raced it", () => {

--- a/apps/desktop/src/renderer/voice/use-voice-session.test.ts
+++ b/apps/desktop/src/renderer/voice/use-voice-session.test.ts
@@ -1,11 +1,17 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import { CREDENTIAL_PROVIDER_ID } from "@sidecar/credentials/vocabulary";
 import {
   CONVERSATION_ENTRY_KIND,
   REALTIME_STATUS,
   REALTIME_VOICE,
   REALTIME_VOICE_SPEED,
 } from "@sidecar/realtime";
+import { normalizeSession, SESSION_STATUS } from "@sidecar/session";
+import { APP_SETTING_DEFAULTS } from "@sidecar/settings";
+import { CREDENTIAL_SOURCE, SECRET_STORAGE } from "#shared/wire/account";
+import type { VoiceBootstrap } from "#shared/wire/session";
+import { type AppSettings, appSettingsView, CLI_CONNECTION } from "#shared/wire/settings";
 import { REPLY_KIND } from "./realtime-session";
 import {
   activeVoiceStream,
@@ -21,8 +27,10 @@ import {
   typedAskHolds,
   VOICE_RESTART,
   voiceRestartAction,
+  voiceSurroundingsFromBootstrap,
   waitForConversationContext,
 } from "./use-voice-session";
+import { VOICE_READINESS_PART, VoiceReadiness } from "./voice-readiness";
 
 test("a delayed transcription cannot repopulate history after Clear", () => {
   assert.equal(spokenAskBelongsToConversation(3, 4), false);
@@ -283,4 +291,109 @@ test("a connecting call counts as one to reopen: its credential may already be t
     }),
     { due: true, action: VOICE_RESTART.WAIT },
   );
+});
+
+const BOOTSTRAP_SETTINGS: AppSettings = {
+  stored: { ...APP_SETTING_DEFAULTS, voiceCaptions: true },
+  status: {
+    credentialSources: {
+      [CREDENTIAL_PROVIDER_ID.CONDUCTOR]: CREDENTIAL_SOURCE.NONE,
+      [CREDENTIAL_PROVIDER_ID.LINEAR]: CREDENTIAL_SOURCE.NONE,
+      [CREDENTIAL_PROVIDER_ID.OPENAI]: CREDENTIAL_SOURCE.NONE,
+    },
+    codexCloudConnection: CLI_CONNECTION.UNKNOWN,
+    secretStorage: SECRET_STORAGE.UNKNOWN,
+    voiceAvailable: false,
+    calendarSignInAvailable: false,
+    linearSignInAvailable: false,
+    calendarAccounts: [],
+    appleCalendarAvailable: false,
+  },
+};
+
+const VOICE_BOOTSTRAP: VoiceBootstrap = {
+  agentTraceEnabled: false,
+  microphoneStatus: "granted",
+  voiceEpoch: 3,
+  voiceHotkey: "Alt+Space",
+  outputAudio: { muted: false, volume: 0.5 },
+  sessionRoster: { sessions: [] },
+  announcementsHeld: true,
+  conversationHistory: [],
+  settings: BOOTSTRAP_SETTINGS,
+};
+
+const NOTHING_PUSHED = {
+  settings: undefined,
+  sessions: [],
+  outputAudio: undefined,
+  announcementsHeld: false,
+};
+
+test("the voice bootstrap fills only what no push has said yet", () => {
+  // Nothing pushed: the snapshot is the whole answer, and the first turn may open.
+  const fresh = voiceSurroundingsFromBootstrap(NOTHING_PUSHED, VOICE_BOOTSTRAP, false);
+  assert.equal(fresh.settings?.voiceCaptions, true);
+  assert.deepEqual(fresh.sessions, []);
+  assert.deepEqual(fresh.outputAudio, { muted: false, volume: 0.5 });
+  assert.equal(fresh.announcementsHeld, true);
+  assert.equal(fresh.bootstrapVoiceHotkey, "Alt+Space");
+  assert.equal(fresh.conversationContextReady, true);
+
+  // Every push that raced past the bootstrap is newer than it and is kept:
+  // a settings change, a roster, an output edge, and a hold released to
+  // `false`, which is a real value and not a gap for the snapshot to fill.
+  const pushedSettings = appSettingsView({
+    ...BOOTSTRAP_SETTINGS,
+    stored: { ...BOOTSTRAP_SETTINGS.stored, voiceCaptions: false },
+  });
+  const pushedSession = normalizeSession(
+    { id: "claude-code", displayName: "Claude Code" },
+    {
+      providerSessionId: "s-1",
+      title: "checkout",
+      status: SESSION_STATUS.WORKING,
+      lastActivityAt: 1_800_000_000_000,
+    },
+  );
+  const raced = voiceSurroundingsFromBootstrap(
+    {
+      settings: pushedSettings,
+      sessions: [pushedSession],
+      outputAudio: { muted: true, volume: 0 },
+      announcementsHeld: false,
+    },
+    VOICE_BOOTSTRAP,
+    true,
+  );
+  assert.equal(raced.settings, pushedSettings);
+  assert.deepEqual(raced.sessions, [pushedSession]);
+  assert.deepEqual(raced.outputAudio, { muted: true, volume: 0 });
+  assert.equal(raced.announcementsHeld, false);
+  // The gate and the key's name come from the bootstrap alone; no push carries them.
+  assert.equal(raced.agentTraceEnabled, false);
+  assert.equal(raced.bootstrapVoiceHotkey, "Alt+Space");
+  assert.equal(raced.conversationContextReady, true);
+});
+
+test("the readiness report names the voice bootstrap's epoch however the pushes and subscriptions raced it", () => {
+  const reported: number[] = [];
+  const readiness = new VoiceReadiness((epoch) => reported.push(epoch));
+  // Every subscription stood before the narrow bootstrap answered, as when the
+  // main process's pushes all beat it: nothing is reported until the epoch lands.
+  for (const part of Object.values(VOICE_READINESS_PART)) readiness.installed(part);
+  assert.deepEqual(reported, []);
+  readiness.bootstrapped(VOICE_BOOTSTRAP.voiceEpoch);
+  assert.deepEqual(reported, [3]);
+
+  // The other order — bootstrap first, subscriptions after — reports once too,
+  // under the same epoch, and a later epoch cannot re-report a settled window.
+  const late: number[] = [];
+  const lateReadiness = new VoiceReadiness((epoch) => late.push(epoch));
+  lateReadiness.bootstrapped(VOICE_BOOTSTRAP.voiceEpoch);
+  assert.deepEqual(late, []);
+  for (const part of Object.values(VOICE_READINESS_PART)) lateReadiness.installed(part);
+  assert.deepEqual(late, [3]);
+  lateReadiness.bootstrapped(4);
+  assert.deepEqual(late, [3]);
 });

--- a/apps/desktop/src/renderer/voice/use-voice-session.ts
+++ b/apps/desktop/src/renderer/voice/use-voice-session.ts
@@ -33,7 +33,7 @@ import {
   brainReplyWords,
   brainRequestPending,
 } from "#shared/wire/brain";
-import type { AppBootstrap } from "#shared/wire/session";
+import type { VoiceBootstrap } from "#shared/wire/session";
 import { type AppSettingsView, appSettingsView } from "#shared/wire/settings";
 import {
   VOICE_COMMAND,
@@ -330,6 +330,31 @@ const INITIAL_SURROUNDINGS: VoiceSurroundings = {
   announcementsHeld: false,
   conversationContextReady: false,
 };
+
+/**
+ * What the bootstrap may fill in once it lands. A push is newer than any
+ * bootstrap still in flight, so a value a push has already set is kept and
+ * only the gaps are taken from the snapshot: merged the other way, a false
+ * push would be overwritten back to held, or a roster push back to empty.
+ * The hold needs its own flag because `false` is a real pushed value.
+ */
+export function voiceSurroundingsFromBootstrap(
+  current: Pick<VoiceSurroundings, "settings" | "sessions" | "outputAudio" | "announcementsHeld">,
+  bootstrap: VoiceBootstrap,
+  announcementsHeldPushed: boolean,
+): Partial<VoiceSurroundings> {
+  return {
+    settings: current.settings ?? appSettingsView(bootstrap.settings),
+    agentTraceEnabled: bootstrap.agentTraceEnabled,
+    sessions: current.sessions.length > 0 ? current.sessions : bootstrap.sessionRoster.sessions,
+    bootstrapVoiceHotkey: bootstrap.voiceHotkey,
+    outputAudio: current.outputAudio ?? bootstrap.outputAudio,
+    announcementsHeld: announcementsHeldPushed
+      ? current.announcementsHeld
+      : bootstrap.announcementsHeld,
+    conversationContextReady: true,
+  };
+}
 
 /**
  * Where one spoken turn belongs in the thread, and what it has since become:
@@ -1214,30 +1239,19 @@ export function useVoiceSession(remoteAudio: RefObject<HTMLAudioElement | null>)
     voiceSession.current?.stopListening(false);
   }, []);
 
-  // The bootstrap, read once: the settings that shape a call, the thread the
-  // last launch left, and the facts pushes will keep current from here on.
-  // The voice window stands on no display and never announces itself ready;
-  // the panel-only fields are simply not read.
+  // The voice's own bootstrap, read once: the settings that shape a call,
+  // the thread the last launch left, and the facts pushes will keep current
+  // from here on. It is the voice's narrow bootstrap rather than the panel's,
+  // so the readiness report is not held behind reads the voice never uses.
   useEffect(() => {
     let cancelled = false;
-    void window.sidecar.getBootstrap().then((value: AppBootstrap) => {
+    void window.sidecar.getVoiceBootstrap().then((value: VoiceBootstrap) => {
       if (cancelled) return;
       seedConversationHistory(value.conversationHistory);
       setMicrophoneStatus(value.microphoneStatus);
-      const current = surroundingsNow();
-      // Only fill in what no push has said yet: the bootstrap snapshot is
-      // older than any change that raced past it.
-      amend({
-        settings: current.settings ?? appSettingsView(value.settings),
-        agentTraceEnabled: value.agentTraceEnabled,
-        sessions: current.sessions.length > 0 ? current.sessions : value.sessionRoster.sessions,
-        bootstrapVoiceHotkey: value.voiceHotkey,
-        outputAudio: current.outputAudio ?? value.outputAudio,
-        announcementsHeld: announcementsHeldPushed.current
-          ? current.announcementsHeld
-          : value.announcementsHeld,
-        conversationContextReady: true,
-      });
+      amend(
+        voiceSurroundingsFromBootstrap(surroundingsNow(), value, announcementsHeldPushed.current),
+      );
       // Applied, so the readiness report may name the epoch this load was given.
       voiceEpochRef.current = value.voiceEpoch;
       readiness.current?.bootstrapped(value.voiceEpoch);

--- a/apps/desktop/src/renderer/voice/use-voice-session.ts
+++ b/apps/desktop/src/renderer/voice/use-voice-session.ts
@@ -332,27 +332,51 @@ const INITIAL_SURROUNDINGS: VoiceSurroundings = {
 };
 
 /**
- * What the bootstrap may fill in once it lands. A push is newer than any
- * bootstrap still in flight, so a value a push has already set is kept and
- * only the gaps are taken from the snapshot: merged the other way, a false
- * push would be overwritten back to held, or a roster push back to empty.
- * The hold needs its own flag because `false` is a real pushed value.
+ * Which values a push, or this window's own act, has already set while the
+ * bootstrap was still in flight. Each is tracked as a flag rather than read
+ * off the value, because the pushed value may look like an absence: an empty
+ * roster is a real observation (the last row gone, or a sign-out), a hold
+ * released is `false`, and a permission can be pushed back to undetermined.
  */
-export function voiceSurroundingsFromBootstrap(
+export interface VoiceValuesPushedBeforeBootstrap {
+  sessions: boolean;
+  announcementsHeld: boolean;
+  microphoneStatus: boolean;
+}
+
+/**
+ * What the bootstrap may fill in once it lands. A push is newer than any
+ * bootstrap still in flight, so a value already pushed is kept and only the
+ * gaps are taken from the snapshot: merged the other way, a false push would
+ * be overwritten back to held, an emptied roster back to a session that has
+ * gone, or a permission the developer just granted back to its old answer.
+ * The microphone status is answered separately because it is not a
+ * surrounding: `undefined` says the bootstrap has nothing to set.
+ */
+export interface VoiceBootstrapApplication {
+  surroundings: Partial<VoiceSurroundings>;
+  /** Absent when a push or this window's own ask already answered it. */
+  microphoneStatus: MicrophoneStatus | undefined;
+}
+
+export function applyVoiceBootstrap(
   current: Pick<VoiceSurroundings, "settings" | "sessions" | "outputAudio" | "announcementsHeld">,
   bootstrap: VoiceBootstrap,
-  announcementsHeldPushed: boolean,
-): Partial<VoiceSurroundings> {
+  pushed: VoiceValuesPushedBeforeBootstrap,
+): VoiceBootstrapApplication {
   return {
-    settings: current.settings ?? appSettingsView(bootstrap.settings),
-    agentTraceEnabled: bootstrap.agentTraceEnabled,
-    sessions: current.sessions.length > 0 ? current.sessions : bootstrap.sessionRoster.sessions,
-    bootstrapVoiceHotkey: bootstrap.voiceHotkey,
-    outputAudio: current.outputAudio ?? bootstrap.outputAudio,
-    announcementsHeld: announcementsHeldPushed
-      ? current.announcementsHeld
-      : bootstrap.announcementsHeld,
-    conversationContextReady: true,
+    surroundings: {
+      settings: current.settings ?? appSettingsView(bootstrap.settings),
+      agentTraceEnabled: bootstrap.agentTraceEnabled,
+      sessions: pushed.sessions ? current.sessions : bootstrap.sessionRoster.sessions,
+      bootstrapVoiceHotkey: bootstrap.voiceHotkey,
+      outputAudio: current.outputAudio ?? bootstrap.outputAudio,
+      announcementsHeld: pushed.announcementsHeld
+        ? current.announcementsHeld
+        : bootstrap.announcementsHeld,
+      conversationContextReady: true,
+    },
+    microphoneStatus: pushed.microphoneStatus ? undefined : bootstrap.microphoneStatus,
   };
 }
 
@@ -381,11 +405,15 @@ export function useVoiceSession(remoteAudio: RefObject<HTMLAudioElement | null>)
   const [surroundings, setSurroundings, surroundingsNow] =
     useStateWithRef<VoiceSurroundings>(INITIAL_SURROUNDINGS);
   /**
-   * Whether the hold has been pushed at all. A push is newer than any
-   * bootstrap still in flight, so once one has landed the bootstrap's answer
-   * is not read: merged, a false push would be overwritten back to held.
+   * Which values have been pushed, or set by this window's own act, before
+   * the bootstrap answered. A push is newer than any bootstrap still in
+   * flight, so once one has landed the bootstrap's answer for it is not read.
    */
-  const announcementsHeldPushed = useRef(false);
+  const pushedBeforeBootstrap = useRef<VoiceValuesPushedBeforeBootstrap>({
+    sessions: false,
+    announcementsHeld: false,
+    microphoneStatus: false,
+  });
   const amend = useCallback(
     (change: Partial<VoiceSurroundings>) => {
       setSurroundings({ ...surroundingsNow(), ...change });
@@ -396,6 +424,14 @@ export function useVoiceSession(remoteAudio: RefObject<HTMLAudioElement | null>)
   // Read only inside the press's own closure, so the ref is the half that matters.
   const [, setMicrophoneStatus, microphoneStatusNow] =
     useStateWithRef<MicrophoneStatus>("not-determined");
+  /** A status learned from a push or this window's own ask, which a late bootstrap must not undo. */
+  const learnMicrophoneStatus = useCallback(
+    (status: MicrophoneStatus) => {
+      pushedBeforeBootstrap.current.microphoneStatus = true;
+      setMicrophoneStatus(status);
+    },
+    [setMicrophoneStatus],
+  );
   const [voiceError, setVoiceError] = useState<string>();
   const [voiceNotice, setVoiceNotice] = useState<string>();
   const [voiceStatus, setVoiceStatus, voiceStatusNow] = useStateWithRef<RealtimeStatus>(
@@ -1007,7 +1043,7 @@ export function useVoiceSession(remoteAudio: RefObject<HTMLAudioElement | null>)
     setVoiceError(undefined);
     const session = ensureVoiceSession();
     const permission = await window.sidecar.requestMicrophone();
-    setMicrophoneStatus(permission);
+    learnMicrophoneStatus(permission);
     if (permission !== "granted") {
       // The press that asked for this is still waiting for a call that is now
       // not coming. The status never changes on this path, so the meter the
@@ -1018,7 +1054,7 @@ export function useVoiceSession(remoteAudio: RefObject<HTMLAudioElement | null>)
     }
     await startConversation();
     return permission;
-  }, [ensureVoiceSession, setMicrophoneStatus, startConversation]);
+  }, [ensureVoiceSession, learnMicrophoneStatus, startConversation]);
 
   /** The neutral note used when the hosted service's emergency brake refuses a call. */
   const hostedUnavailableNote = useCallback(async (): Promise<string | undefined> => {
@@ -1032,8 +1068,8 @@ export function useVoiceSession(remoteAudio: RefObject<HTMLAudioElement | null>)
    * and the panel's row must not be a second way to it.
    */
   const requestMicrophoneAccess = useCallback(async () => {
-    setMicrophoneStatus(await window.sidecar.requestMicrophone());
-  }, [setMicrophoneStatus]);
+    learnMicrophoneStatus(await window.sidecar.requestMicrophone());
+  }, [learnMicrophoneStatus]);
 
   /**
    * What the talk key means, wherever it was pressed. A first press has to open
@@ -1063,7 +1099,7 @@ export function useVoiceSession(remoteAudio: RefObject<HTMLAudioElement | null>)
     if (microphoneStatusNow() !== "granted") {
       const pressedAt = talkPressedAt.current;
       const permission = await window.sidecar.requestMicrophone();
-      setMicrophoneStatus(permission);
+      learnMicrophoneStatus(permission);
       if (permission !== "granted") {
         // Said where the device failure used to land it: the caption strip.
         setVoiceError(
@@ -1109,8 +1145,8 @@ export function useVoiceSession(remoteAudio: RefObject<HTMLAudioElement | null>)
   }, [
     ensureVoiceSession,
     hostedUnavailableNote,
+    learnMicrophoneStatus,
     microphoneStatusNow,
-    setMicrophoneStatus,
     startMicrophone,
   ]);
 
@@ -1248,10 +1284,9 @@ export function useVoiceSession(remoteAudio: RefObject<HTMLAudioElement | null>)
     void window.sidecar.getVoiceBootstrap().then((value: VoiceBootstrap) => {
       if (cancelled) return;
       seedConversationHistory(value.conversationHistory);
-      setMicrophoneStatus(value.microphoneStatus);
-      amend(
-        voiceSurroundingsFromBootstrap(surroundingsNow(), value, announcementsHeldPushed.current),
-      );
+      const applied = applyVoiceBootstrap(surroundingsNow(), value, pushedBeforeBootstrap.current);
+      if (applied.microphoneStatus !== undefined) setMicrophoneStatus(applied.microphoneStatus);
+      amend(applied.surroundings);
       // Applied, so the readiness report may name the epoch this load was given.
       voiceEpochRef.current = value.voiceEpoch;
       readiness.current?.bootstrapped(value.voiceEpoch);
@@ -1267,13 +1302,17 @@ export function useVoiceSession(remoteAudio: RefObject<HTMLAudioElement | null>)
     [amend],
   );
   useEffect(
-    () => window.sidecar.onSessionsChanged((pushed) => amend({ sessions: pushed.sessions })),
+    () =>
+      window.sidecar.onSessionsChanged((pushed) => {
+        pushedBeforeBootstrap.current.sessions = true;
+        amend({ sessions: pushed.sessions });
+      }),
     [amend],
   );
   useEffect(
     () =>
       window.sidecar.onAnnouncementsHeldChanged((held) => {
-        announcementsHeldPushed.current = true;
+        pushedBeforeBootstrap.current.announcementsHeld = true;
         amend({ announcementsHeld: held });
       }),
     [amend],
@@ -1290,8 +1329,8 @@ export function useVoiceSession(remoteAudio: RefObject<HTMLAudioElement | null>)
   // asked, or this window's own press did — so a press here reads the same
   // status the rows draw.
   useEffect(
-    () => window.sidecar.onMicrophoneStatusChanged(setMicrophoneStatus),
-    [setMicrophoneStatus],
+    () => window.sidecar.onMicrophoneStatusChanged(learnMicrophoneStatus),
+    [learnMicrophoneStatus],
   );
 
   // A panel's ask, validated and forwarded by the main process. Each command

--- a/apps/desktop/src/shared/bridge.test.ts
+++ b/apps/desktop/src/shared/bridge.test.ts
@@ -48,6 +48,13 @@ test("a conversation history report carries only well-formed history lines", () 
   assert.equal(guard([[{ ...ask, recordedAt: Number.POSITIVE_INFINITY }]]), false);
 });
 
+test("the voice bootstraps through its own invoke, taking no arguments", () => {
+  assert.equal(BRIDGE.getVoiceBootstrap.kind, "invoke");
+  assert.notEqual(BRIDGE.getVoiceBootstrap.channel, BRIDGE.getBootstrap.channel);
+  assert.equal(BRIDGE.getVoiceBootstrap.args([]), true);
+  assert.equal(BRIDGE.getVoiceBootstrap.args(["voice"]), false);
+});
+
 test("a brain ask is one submission with an id, bounded words, and an origin", () => {
   assert.equal(BRIDGE.submitBrainAsk.kind, "invoke");
   const guard = BRIDGE.submitBrainAsk.args;

--- a/apps/desktop/src/shared/bridge.ts
+++ b/apps/desktop/src/shared/bridge.ts
@@ -93,6 +93,7 @@ import {
   type SessionOpenResult,
   type SessionReplayBootstrap,
   type SessionRosterPayload,
+  type VoiceBootstrap,
   WINDOW_ROLE,
   type WindowRole,
 } from "./wire/session";
@@ -244,6 +245,12 @@ export const BRIDGE = {
     channel: "app:bootstrap",
     args: noArgs,
     result: result<AppBootstrap>(),
+  }),
+  getVoiceBootstrap: entry({
+    kind: "invoke",
+    channel: "app:voice-bootstrap",
+    args: noArgs,
+    result: result<VoiceBootstrap>(),
   }),
   beginSignIn: entry({
     kind: "invoke",

--- a/apps/desktop/src/shared/wire/session.ts
+++ b/apps/desktop/src/shared/wire/session.ts
@@ -220,6 +220,28 @@ export interface AppBootstrap {
   settings: AppSettings;
 }
 
+/**
+ * What the hidden voice window bootstraps with: only the fields it reads. It
+ * stands on no display, draws no panel, and records nothing, so the panel's
+ * display, account, Superset, project, issue, calendar, and recording fields
+ * are neither read nor waited for — a voice window held on a Superset CLI
+ * probe or an account read would report itself ready that much later for
+ * nothing. Every field here is the same value the panel bootstrap carries,
+ * read from the same source at the same moment.
+ */
+export type VoiceBootstrap = Pick<
+  AppBootstrap,
+  | "agentTraceEnabled"
+  | "microphoneStatus"
+  | "voiceEpoch"
+  | "voiceHotkey"
+  | "outputAudio"
+  | "sessionRoster"
+  | "announcementsHeld"
+  | "conversationHistory"
+  | "settings"
+>;
+
 /** The complete session state one observation revision publishes to a desktop surface. */
 export interface SessionRosterPayload {
   sessions: readonly Session[];


### PR DESCRIPTION
## Summary

Audit group 10, plus two startup races found while touching the same path. The hidden voice window called the panel's full `getBootstrap` and ignored its panel-only fields, while its readiness report waited behind the Superset CLI installation and login probes (which can invoke the bounded `plutil` read), the project-default read, and the session-recording identity read. None of those answers reach the voice. This removes the unnecessary startup dependencies; it is not a measured performance fix, and no slowdown was reproduced.

- **`VoiceBootstrap`** (`apps/desktop/src/shared/wire/session.ts`): a `Pick` of the panel bootstrap naming exactly the fields the voice reads: settings, trace gate, roster for the arrival beat, conversation thread, talk key, microphone and output state, and the receiver epoch.
- **`getVoiceBootstrap`** bridge invoke (`app:voice-bootstrap`), exposed by the preload's manifest loop like every other entry.
- **Main process:** one `voiceBootstrapFields(context)` assembler answers the new invoke and is spread into the panel bootstrap, so the two cannot drift. The epoch is still given only when the sender is the voice window (`voiceWindow.owns`), unchanged. The panel bootstrap still reads Superset, project defaults, and replay identity for the panels and introduction that use them.
- **Renderer:** `use-voice-session.ts` calls the narrow invoke. The "a push landing first is kept, the bootstrap fills only the gaps" merge is the exported `applyVoiceBootstrap`, answering the surroundings and a separate optional microphone status, so the race rule is tested rather than implied. Readiness reporting is untouched and still names the bootstrap's epoch; the cancellation guard on the in-flight bootstrap is unchanged.

### Additional findings, fixed here (pre-existing on main, not introduced by the refactor)

Both were in the inline predecessor and are recorded as discoveries made during this cleanup:

1. **Empty roster push lost to a stale bootstrap.** The merge kept a pushed roster only when it was non-empty, so a session that had gone (last row leaving, or a sign-out) came back when a slower bootstrap landed with it still inside. Roster pushes are now tracked as a flag beside the announcements hold, and an empty pushed roster is kept as the observation it is.
2. **Microphone status overwritten by a stale bootstrap.** The status was set from the bootstrap unconditionally, so a permission the developer had just answered (pushed from main, or asked by this window's own press) could be set back. Every non-bootstrap write goes through `learnMicrophoneStatus`, which marks it, and the bootstrap sets the status only when nothing has.

## Evidence

- Platform-independent checks: full clean-install `./scripts/bootstrap.sh` + `./scripts/check.sh` **passed at bc1b6bb** (exit 0) in the cloud workspace, on main 1f0f894 (after #739 and #741). Desktop tests: 927 pass, including:
  - bootstrap/push race: settings, roster, output audio, an announcements hold released to `false`, and an answered permission all survive a bootstrap that lands after them; untouched surroundings take the snapshot whole and ready the first turn;
  - the two additional races: non-empty bootstrap + pushed empty roster stays empty; pushed permission is not undone; with no roster push the bootstrap's row still stands;
  - readiness: the report names the voice bootstrap's epoch whether subscriptions or the bootstrap land first, exactly once, and a later epoch cannot re-report;
  - bridge: the new entry is an argument-less invoke on its own channel.
- macOS Electron verification (`./scripts/verify.sh`): **passed (exit 0) at bc1b6bb** on the orchestrator's physical Mac; all six fresh fixture captures hash-identical to the previously reviewed Mac set, no visual blocker. Fixture runs raise no voice window, so this checks the panel bootstrap path. The orchestrator's independent focused tests: 30/30 pass, and the original synthetic empty-roster reproducer now returns `[]`.
- **Not validated:** live voice readiness and speech on a signed-in launch, and any physical-notch interaction. Explicitly untested; no user credentials, live provider calls, or paid live calls are used for this cleanup.

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34160415769/artifacts/10032479138) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34160415769)

- Commit: `bc1b6bbc0804d103a1d913e1e55f11e13f3f300d`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

### Physical-device evidence

- Screenshot or screen recording: `not attached`
- Physical-notch check: `not performed`
- Device/display configuration: orchestrator's Mac, isolated checkout

## Notes

- Based on main 1f0f894; #739's removal of the `rememberedFacts`, `issues`, and version bootstrap fields and the facts/issues bridge feeds is preserved through the rebase.
- Blockers or follow-up verification: live voice check remains the one untested surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)