### PR TITLE
refactor(desktop): drop the roster's spoken tally sentence

### DIFF
--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -121,7 +121,6 @@ import {
   sessionFiltersFromSpoken,
   sessionTally,
   spokenSearchOutcome,
-  tallySummary,
 } from "./session-model";
 import { parsePixels } from "./session-motion";
 import { SESSION_OPTIONS_CONTROL_ID, SESSION_OPTIONS_ID } from "./session-parts";
@@ -2606,16 +2605,6 @@ export function App(): React.JSX.Element {
   // Luke is watching, not what the panel is currently showing — but it reads
   // in the list's own sort, so the wing's marks sit in the order the rows do.
   const tally = sessionTally(visibleSessions, sessionView.sort);
-  // The one sentence the wing states about the roster, derived here so the
-  // capsule button's label and the wing's live region can never drift. Until
-  // the first roster reading lands, an unread zero is "checking", never "none
-  // tracked" — assistive tech must not hear a claim the wing is not making —
-  // and a gated Luke is not checking anything.
-  const tallyAnnouncement = accountGated
-    ? "Sign in"
-    : !sessionsSettled && tally.total === 0
-      ? "Checking for sessions"
-      : tallySummary(tally);
   const list = arrangeSessions(visibleSessions, sessionView);
   // Dropping an emptied selection is a change of view, not a way of drawing
   // one. Left in state it would lie dormant behind a list that only looks
@@ -3038,7 +3027,6 @@ export function App(): React.JSX.Element {
         presentation={presentation}
         housingWidth={display.notch.housingWidth}
         accountGated={accountGated}
-        statusLabel={tallyAnnouncement}
       />
 
       {/* The one signed-out Luke. Like the caption, he is a single element in
@@ -3127,7 +3115,7 @@ export function App(): React.JSX.Element {
           className="compact-hover-target"
           data-hit-region={HIT_REGION.CAPSULE}
           aria-expanded={panelOpen}
-          aria-label={`${tallyAnnouncement}. ${panelOpen ? "Close" : "Open"} the panel`}
+          aria-label={panelOpen ? "Close the panel" : "Open the panel"}
           // Keeps the press from moving focus here at all, so nothing is drawn
           // around the notch strip and a focused settings field keeps the caret.
           onMouseDown={(event) => event.preventDefault()}

--- a/apps/desktop/src/renderer/introduction/introduction-takeover.tsx
+++ b/apps/desktop/src/renderer/introduction/introduction-takeover.tsx
@@ -19,7 +19,7 @@ import { usePrefersReducedMotion } from "../luke-face-mood";
 import { NotchWings } from "../notch-wings";
 import { SessionRow, type SessionWriteHandlers } from "../panel-body";
 import { PANEL_PRESENTATION } from "../panel-state";
-import { displaySessions, type SessionView, sessionTally, tallySummary } from "../session-model";
+import { displaySessions, type SessionView, sessionTally } from "../session-model";
 import { parseMilliseconds, useSessionReorderMotion } from "../session-motion";
 import { MicrophoneIcon } from "../settings-icons";
 import { useSignInFaceCycle } from "../sign-in-gate";
@@ -860,7 +860,6 @@ export function IntroductionTakeover({
           presentation={presentation}
           housingWidth={bootstrap.display.notch.housingWidth}
           accountGated={standingDown}
-          statusLabel={standingDown ? "Sign in" : tallySummary(stagedTally)}
         />
       ) : null}
       {/* The app's own signed-out Luke, at the wing spot the capsule pose

--- a/apps/desktop/src/renderer/notch-wings.tsx
+++ b/apps/desktop/src/renderer/notch-wings.tsx
@@ -66,12 +66,6 @@ interface NotchWingsProps {
    * the one thing introducing him.
    */
   accountGated: boolean;
-  /**
-   * The one sentence the wing states about the roster, derived where the
-   * capsule button's own label is so the two can never drift. The live region
-   * below is what speaks it as it changes.
-   */
-  statusLabel: string;
 }
 
 /**
@@ -152,7 +146,6 @@ export function NotchWings({
   presentation,
   housingWidth,
   accountGated,
-  statusLabel,
 }: NotchWingsProps): React.JSX.Element {
   // A measured stream reports its own edges; a relayed level arrives with them.
   const [measuredVoiceActive, setMeasuredVoiceActive] = useState(false);
@@ -286,10 +279,9 @@ export function NotchWings({
               side has room for one, so at rest it draws the app whose session
               needs a person soonest and the rest wait behind it; the peek and
               the panel lay the whole strip out flat. Drawn in every state but
-              the gate, which takes this place for the label below. Decorative —
-              the live region beside them already states everything they show,
-              and the panel's own filter chips are what filtering is done
-              with. */}
+              the gate, which takes this place for the label below. Decorative:
+              the panel's own rows and filter chips are where the roster is
+              read and filtered. */}
           <span
             className="wing-marks"
             ref={marksRef}
@@ -328,12 +320,6 @@ export function NotchWings({
               Sign in
             </span>
           )}
-          {/* The roster's own sentence, spoken rather than drawn. It rides its
-              own element rather than the label's, which is rendered only while
-              signed out and would take every later announcement down with it. */}
-          <span className="wing-status" role="status" aria-live="polite">
-            {statusLabel}
-          </span>
         </div>
       </div>
     </>

--- a/apps/desktop/src/renderer/session-model.test.ts
+++ b/apps/desktop/src/renderer/session-model.test.ts
@@ -28,7 +28,6 @@ import {
   sessionRunKeys,
   sessionTally,
   spokenSearchOutcome,
-  tallySummary,
   toggledSessionFilters,
   workspaceTrayChange,
 } from "./session-model";
@@ -300,19 +299,6 @@ test("the apps re-seat with the rows when the other sort is chosen", () => {
     { ...recent, providers: undefined },
     { ...sessionTally(FIXTURE_SESSIONS), providers: undefined },
   );
-});
-
-test("the spoken summary names the state its own number counts", () => {
-  const tally = sessionTally(displaySessions(bootstrap(true), []));
-
-  assert.equal(tallySummary(tally), "1 session needs you");
-  assert.equal(tallySummary({ ...tally, attention: 0, working: 3 }), "3 sessions working");
-  assert.equal(tallySummary({ ...tally, attention: 0, working: 0 }), "1 session complete");
-  assert.equal(
-    tallySummary({ ...tally, attention: 0, working: 0, complete: 0 }),
-    "6 sessions tracked",
-  );
-  assert.equal(tallySummary(sessionTally([])), "No sessions tracked");
 });
 
 test("the filters offered are grouped by axis, coarse to fine, counted", () => {

--- a/apps/desktop/src/renderer/session-model.ts
+++ b/apps/desktop/src/renderer/session-model.ts
@@ -985,21 +985,6 @@ export function sessionTally(
   };
 }
 
-/** One sentence that reads correctly for a screen reader in either mode. */
-export function tallySummary(tally: SessionTally): string {
-  if (tally.total === 0) return "No sessions tracked";
-  if (tally.attention > 0) {
-    return `${tally.attention} ${tally.attention === 1 ? "session needs" : "sessions need"} you`;
-  }
-  if (tally.working > 0) {
-    return `${tally.working} ${tally.working === 1 ? "session" : "sessions"} working`;
-  }
-  if (tally.complete > 0) {
-    return `${tally.complete} ${tally.complete === 1 ? "session" : "sessions"} complete`;
-  }
-  return `${tally.total} ${tally.total === 1 ? "session" : "sessions"} tracked`;
-}
-
 /**
  * How long ago a session was last seen, in the coarsest unit that has begun,
  * because the label answers "is this thing alive" rather than telling time.

--- a/apps/desktop/src/renderer/styles/base.css
+++ b/apps/desktop/src/renderer/styles/base.css
@@ -1298,17 +1298,6 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
   opacity: 1;
 }
 
-/* The roster's sentence is spoken, never drawn: assistive tech reads it out of
-   the live region while the wing draws the marks. */
-.wing-status {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  overflow: hidden;
-  clip-path: inset(50%);
-  white-space: nowrap;
-}
-
 /* Voice caption ----------------------------------------------------------- */
 
 /* Luke's words, wrapping as they stream so the whole reply can be read — the


### PR DESCRIPTION
## Summary

Removes the roster's one hidden sentence ("2 sessions need you", "3 sessions working", "No sessions tracked") and everything that carried it:

- `tallySummary` in `session-model.ts` and its unit test
- the `tallyAnnouncement` derivation in `app.tsx` and the `statusLabel` prop threaded into `NotchWings` from both the panel and the introduction takeover
- the `.wing-status` visually hidden live region and its stylesheet rule

The capsule button's `aria-label` becomes a plain "Open the panel" / "Close the panel". `SessionTally` and `sessionTally` stay untouched: the face's mood and the wing's provider marks still read them.

## Why

#577 took the drawn count out of the top right because one number changed meaning with the tally's state. The spoken sentence kept the same figure alive for screen readers only, at the cost of a derived string, a prop, a hidden span, and a CSS rule that did nothing for anyone else. Six files, net -67 lines.

## Verification

- `./scripts/check.sh` passes (repository, type, test, and build checks).
- No macOS `verify.sh` run: this sandbox is Linux. The only visible change is the capsule button's accessible name; nothing drawn moves, so no physical-notch check was performed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/0973e62a-e86c-436a-8e35-408e9d230696)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34160503545/artifacts/10032488575) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34160503545)

- Commit: `961d940157997ffc29686b2203137246271fe4ea`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
