### PR TITLE
chore(ios): prepare the TestFlight archive without naming a team

### DIFF
--- a/apps/ios/ExportOptions.plist
+++ b/apps/ios/ExportOptions.plist
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<!-- xcodebuild -exportArchive reads this to sign the archive for App Store
+	     Connect and upload it in the same step. It names no team: the archive
+	     already carries the project's DEVELOPMENT_TEAM, and the App Store
+	     Connect API key passed on the command line is what authorizes the
+	     signing and the upload. The build number is the archive's own, set by
+	     CURRENT_PROJECT_VERSION at archive time, so App Store Connect is told
+	     not to rewrite it. -->
+	<key>method</key>
+	<string>app-store-connect</string>
+	<key>destination</key>
+	<string>upload</string>
+	<key>signingStyle</key>
+	<string>automatic</string>
+	<key>uploadSymbols</key>
+	<true/>
+	<key>manageAppVersionAndBuildNumber</key>
+	<false/>
+</dict>
+</plist>

--- a/apps/ios/Luke.xcodeproj/project.pbxproj
+++ b/apps/ios/Luke.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		AABBCC000000000000000020 /* LukeApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABBCC000000000000000012 /* LukeApp.swift */; };
 		AABBCC000000000000000021 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABBCC000000000000000013 /* ContentView.swift */; };
 		AABBCC000000000000000022 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = AABBCC000000000000000014 /* Assets.xcassets */; };
+		AABBCC000000000000000102 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = AABBCC000000000000000104 /* PrivacyInfo.xcprivacy */; };
 		AABBCC000000000000000023 /* LukeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABBCC000000000000000015 /* LukeTests.swift */; };
 		AABBCC000000000000000083 /* LukeKit in Frameworks */ = {isa = PBXBuildFile; productRef = AABBCC000000000000000081 /* LukeKit */; };
 		AABBCC000000000000000084 /* LukeKit in Frameworks */ = {isa = PBXBuildFile; productRef = AABBCC000000000000000082 /* LukeKit */; };
@@ -28,6 +29,7 @@
 		AABBCC0000000000000000B4 /* LukeWatchApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABBCC0000000000000000B0 /* LukeWatchApp.swift */; };
 		AABBCC0000000000000000B5 /* LukeWatchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABBCC0000000000000000B1 /* LukeWatchView.swift */; };
 		AABBCC0000000000000000B6 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = AABBCC0000000000000000B2 /* Assets.xcassets */; };
+		AABBCC000000000000000103 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = AABBCC000000000000000105 /* PrivacyInfo.xcprivacy */; };
 		AABBCC0000000000000000B7 /* LukeKit in Frameworks */ = {isa = PBXBuildFile; productRef = AABBCC0000000000000000C0 /* LukeKit */; };
 		AABBCC0000000000000000C7 /* WatchTokenStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABBCC0000000000000000C1 /* WatchTokenStore.swift */; };
 		AABBCC0000000000000000FB /* WatchNetwork.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABBCC0000000000000000FA /* WatchNetwork.swift */; };
@@ -94,6 +96,7 @@
 		AABBCC00000000000000001A /* CanvasInkTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CanvasInkTests.swift; sourceTree = "<group>"; };
 		AABBCC00000000000000001B /* SessionsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionsView.swift; sourceTree = "<group>"; };
 		AABBCC00000000000000001C /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		AABBCC000000000000000104 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		AABBCC00000000000000001D /* SessionDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionDetailView.swift; sourceTree = "<group>"; };
 		AABBCC00000000000000001E /* WorkspaceCreatorSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceCreatorSheet.swift; sourceTree = "<group>"; };
 		AABBCC00000000000000001F /* SessionReplay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionReplay.swift; sourceTree = "<group>"; };
@@ -108,6 +111,7 @@
 		AABBCC0000000000000000FC /* WatchVoiceAudioSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchVoiceAudioSession.swift; sourceTree = "<group>"; };
 		AABBCC0000000000000000FF /* WatchWebSocketChannel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchWebSocketChannel.swift; sourceTree = "<group>"; };
 		AABBCC0000000000000000FE /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		AABBCC000000000000000105 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		AABBCC0000000000000000C2 /* WatchAccountSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchAccountSession.swift; sourceTree = "<group>"; };
 		AABBCC0000000000000000C3 /* WatchConnectivityReceiver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchConnectivityReceiver.swift; sourceTree = "<group>"; };
 		AABBCC0000000000000000E1 /* WatchRosterStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchRosterStore.swift; sourceTree = "<group>"; };
@@ -203,6 +207,7 @@
 				AABBCC0000000000000000D8 /* VoiceSettingsSheet.swift */,
 				AABBCC000000000000000014 /* Assets.xcassets */,
 				AABBCC00000000000000001C /* Info.plist */,
+				AABBCC000000000000000104 /* PrivacyInfo.xcprivacy */,
 			);
 			path = Luke;
 			sourceTree = "<group>";
@@ -226,6 +231,7 @@
 				AABBCC0000000000000000FC /* WatchVoiceAudioSession.swift */,
 				AABBCC0000000000000000FF /* WatchWebSocketChannel.swift */,
 				AABBCC0000000000000000FE /* Info.plist */,
+				AABBCC000000000000000105 /* PrivacyInfo.xcprivacy */,
 				AABBCC0000000000000000C2 /* WatchAccountSession.swift */,
 				AABBCC0000000000000000C3 /* WatchConnectivityReceiver.swift */,
 				AABBCC0000000000000000E1 /* WatchRosterStore.swift */,
@@ -368,6 +374,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				AABBCC000000000000000022 /* Assets.xcassets in Resources */,
+				AABBCC000000000000000102 /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -383,6 +390,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				AABBCC0000000000000000B6 /* Assets.xcassets in Resources */,
+				AABBCC000000000000000103 /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -493,6 +501,7 @@
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
@@ -513,6 +522,7 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MARKETING_VERSION = 0.1.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -556,6 +566,7 @@
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
@@ -570,6 +581,7 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MARKETING_VERSION = 0.1.0;
 				MTL_FAST_MATH = YES;
 				SDKROOT = iphoneos;
 				SWIFT_COMPILATION_MODE = wholemodule;
@@ -585,23 +597,21 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 7UHHCDBUK2;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Luke/Info.plist;
+				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				INFOPLIST_KEY_NSMicrophoneUsageDescription = "Luke uses the microphone to hear your voice when you hold the talk button.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
-				INFOPLIST_KEY_NSMicrophoneUsageDescription = "Luke uses the microphone to hear your voice when you hold the talk button.";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.1.1;
 				POSTHOG_PROJECT_API_KEY = "";
 				PRODUCT_BUNDLE_IDENTIFIER = dev.tryluke.ios;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -619,23 +629,21 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 7UHHCDBUK2;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Luke/Info.plist;
+				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				INFOPLIST_KEY_NSMicrophoneUsageDescription = "Luke uses the microphone to hear your voice when you hold the talk button.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
-				INFOPLIST_KEY_NSMicrophoneUsageDescription = "Luke uses the microphone to hear your voice when you hold the talk button.";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.1.1;
 				POSTHOG_PROJECT_API_KEY = "";
 				PRODUCT_BUNDLE_IDENTIFIER = dev.tryluke.ios;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -651,9 +659,7 @@
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "-";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
-				MARKETING_VERSION = 0.1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.tryluke.ios.LukeTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
@@ -667,9 +673,7 @@
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "-";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
-				MARKETING_VERSION = 0.1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.tryluke.ios.LukeTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
@@ -685,19 +689,18 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 7UHHCDBUK2;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = LukeWatch/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = Luke;
+				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				INFOPLIST_KEY_NSMicrophoneUsageDescription = "Luke uses the microphone to hear your voice when you hold the talk button.";
 				INFOPLIST_KEY_WKCompanionAppBundleIdentifier = dev.tryluke.ios;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.tryluke.ios.watchkitapp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -715,19 +718,18 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 7UHHCDBUK2;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = LukeWatch/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = Luke;
+				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				INFOPLIST_KEY_NSMicrophoneUsageDescription = "Luke uses the microphone to hear your voice when you hold the talk button.";
 				INFOPLIST_KEY_WKCompanionAppBundleIdentifier = dev.tryluke.ios;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.tryluke.ios.watchkitapp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;

--- a/apps/ios/Luke/PrivacyInfo.xcprivacy
+++ b/apps/ios/Luke/PrivacyInfo.xcprivacy
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<!-- App Store Connect refuses an upload that calls a required-reason API
+	     without declaring it here, and scripts/ios-project.test.mjs holds this
+	     list equal to what the app and LukeKit sources actually call, so an API
+	     cannot be added or dropped without the declaration following. Both
+	     apps carry the same list because both link LukeKit. UserDefaults holds
+	     the app's own settings and nothing read from another app (CA92.1);
+	     the system uptime clock measures elapsed time inside the app, a
+	     talk-key hold and a Realtime call's idle timer, never a fingerprint
+	     (35F9.1). Nothing here tracks: the counted events and the recording
+	     are disclosed in PRIVACY.md and travel to no tracking domain. -->
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>CA92.1</string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategorySystemBootTime</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>35F9.1</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/apps/ios/LukeWatch/PrivacyInfo.xcprivacy
+++ b/apps/ios/LukeWatch/PrivacyInfo.xcprivacy
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<!-- App Store Connect refuses an upload that calls a required-reason API
+	     without declaring it here, and scripts/ios-project.test.mjs holds this
+	     list equal to what the app and LukeKit sources actually call, so an API
+	     cannot be added or dropped without the declaration following. Both
+	     apps carry the same list because both link LukeKit. UserDefaults holds
+	     the app's own settings and nothing read from another app (CA92.1);
+	     the system uptime clock measures elapsed time inside the app, a
+	     talk-key hold and a Realtime call's idle timer, never a fingerprint
+	     (35F9.1). Nothing here tracks: the counted events and the recording
+	     are disclosed in PRIVACY.md and travel to no tracking domain. -->
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>CA92.1</string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategorySystemBootTime</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>35F9.1</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/apps/ios/README.md
+++ b/apps/ios/README.md
@@ -36,6 +36,69 @@ pick up an SPM test target from this app scheme — neither as a testable
 reference nor through a test plan — so a scheme entry would claim coverage the
 simulator run does not deliver.
 
+## TestFlight
+
+The iPhone app and the Watch app inside it ship as one archive, and the
+project keeps everything the archive needs that does not name a team:
+
+- **One version for both apps.** `MARKETING_VERSION` and
+  `CURRENT_PROJECT_VERSION` are set once, on the project, and inherited by
+  every target, because watchOS refuses an embedded Watch app whose version
+  differs from its companion's. The marketing version is the phone's own,
+  independent of the desktop's, and is bumped by hand in the project. The
+  build number checked in is `1` and is meant to be overridden at archive time,
+  since App Store Connect refuses a build number it has already seen under
+  the same version, and `ExportOptions.plist` tells it not to rewrite the one
+  the archive carries.
+- **Export compliance answered in the build.** Both apps set
+  `ITSAppUsesNonExemptEncryption` to `NO`: they use only TLS through the
+  system's own networking, which is exempt, and without the key every upload
+  waits on the same question in App Store Connect before anyone can install
+  it.
+- **A privacy manifest in each app.** `Luke/PrivacyInfo.xcprivacy` and
+  `LukeWatch/PrivacyInfo.xcprivacy` declare the required-reason APIs the apps
+  and `LukeKit` call, and `scripts/ios-project.test.mjs` holds the
+  declarations equal to what the sources actually call.
+
+What the archive still needs from outside the tree is the team: the
+`DEVELOPMENT_TEAM` in the project must be the team that holds the App Store
+Connect record for `dev.tryluke.ios`, and the upload is authorized by an App
+Store Connect API key of that team with the App Manager role, passed on the
+command line and never committed. With Xcode 26 selected, from the repository
+root:
+
+```sh
+xcodebuild \
+  -project apps/ios/Luke.xcodeproj \
+  -scheme Luke \
+  -configuration Release \
+  -destination 'generic/platform=iOS' \
+  -archivePath artifacts/ios/Luke.xcarchive \
+  -allowProvisioningUpdates \
+  -authenticationKeyPath /path/to/AuthKey_KEYID.p8 \
+  -authenticationKeyID KEYID \
+  -authenticationKeyIssuerID ISSUER_UUID \
+  CURRENT_PROJECT_VERSION=42 \
+  POSTHOG_PROJECT_API_KEY=phc_your_project_key \
+  archive
+
+xcodebuild -exportArchive \
+  -archivePath artifacts/ios/Luke.xcarchive \
+  -exportOptionsPlist apps/ios/ExportOptions.plist \
+  -exportPath artifacts/ios/export \
+  -allowProvisioningUpdates \
+  -authenticationKeyPath /path/to/AuthKey_KEYID.p8 \
+  -authenticationKeyID KEYID \
+  -authenticationKeyIssuerID ISSUER_UUID
+```
+
+The first command builds and signs the archive, creating the distribution
+certificate and profiles through the API key if the team has none yet. The
+second signs it for App Store Connect and uploads it. Once App Store Connect
+finishes processing, the build is offered to internal testers at once and to
+external groups after Beta App Review. The Watch app installs on a paired
+watch with the iPhone build; it needs no record or upload of its own.
+
 ## Voice acts
 
 The voice screen carries the same acts the desktop's conversation does,

--- a/scripts/ios-project.test.mjs
+++ b/scripts/ios-project.test.mjs
@@ -167,3 +167,92 @@ test("outgoing Watch messages remain visible without a readable transcript", () 
     /Conversation unavailable for this session\.[\s\S]*?ForEach\(outgoing\)[\s\S]*?if session\.canReceiveMessage/,
   );
 });
+
+const phonePrivacyManifest = fs.readFileSync(
+  path.join(repoRoot, "apps", "ios", "Luke", "PrivacyInfo.xcprivacy"),
+  "utf8",
+);
+const watchPrivacyManifest = fs.readFileSync(
+  path.join(repoRoot, "apps", "ios", "LukeWatch", "PrivacyInfo.xcprivacy"),
+  "utf8",
+);
+const exportOptions = fs.readFileSync(
+  path.join(repoRoot, "apps", "ios", "ExportOptions.plist"),
+  "utf8",
+);
+
+function swiftSources(directory) {
+  return fs
+    .readdirSync(directory, { withFileTypes: true, recursive: true })
+    .filter((entry) => entry.isFile() && entry.name.endsWith(".swift"))
+    .map((entry) => fs.readFileSync(path.join(entry.parentPath, entry.name), "utf8"))
+    .join("\n");
+}
+
+const shippedSwift = [
+  path.join(repoRoot, "apps", "ios", "Luke"),
+  path.join(repoRoot, "apps", "ios", "LukeWatch"),
+  path.join(repoRoot, "apps", "ios", "LukeKit", "Sources"),
+]
+  .map(swiftSources)
+  .join("\n");
+
+// Apple's required-reason API list, as the symbols each category covers in
+// Swift. A category the shipped sources call must be declared in both
+// manifests, and a declared category must still be called, so the manifests
+// say exactly what the code does.
+const REQUIRED_REASON_APIS = {
+  NSPrivacyAccessedAPICategoryUserDefaults: /\bUserDefaults\b/,
+  NSPrivacyAccessedAPICategorySystemBootTime: /\bsystemUptime\b|\bmach_absolute_time\b/,
+  NSPrivacyAccessedAPICategoryFileTimestamp:
+    /\bcreationDate\b|\bmodificationDate\b|\bcontentModificationDate(?:Key)?\b|\bfileModificationDate\b|\b[fl]?stat\(|\bgetattrlist\(/,
+  NSPrivacyAccessedAPICategoryDiskSpace:
+    /\bvolumeAvailableCapacity\w*\b|\bvolumeTotalCapacity\b|\bsystemFreeSize\b|\bsystemSize\b|\bstatfs\(/,
+  NSPrivacyAccessedAPICategoryActiveKeyboards: /\bactiveInputModes\b/,
+};
+
+test("the iPhone and Watch apps share one version and build number", () => {
+  const versions = [...project.matchAll(/MARKETING_VERSION = ([^;]+);/g)].map((match) => match[1]);
+  const builds = [...project.matchAll(/CURRENT_PROJECT_VERSION = ([^;]+);/g)].map(
+    (match) => match[1],
+  );
+  assert.equal(versions.length, 2);
+  assert.equal(builds.length, 2);
+  assert.equal(new Set(versions).size, 1);
+  assert.equal(new Set(builds).size, 1);
+  const projectConfigurations = project.slice(
+    project.indexOf("/* Begin XCBuildConfiguration section */"),
+    project.indexOf("AABBCC000000000000000072 /* Debug */ = {"),
+  );
+  assert.equal(projectConfigurations.match(/MARKETING_VERSION = /g)?.length, 2);
+  assert.equal(projectConfigurations.match(/CURRENT_PROJECT_VERSION = /g)?.length, 2);
+  assert.match(exportOptions, /<key>manageAppVersionAndBuildNumber<\/key>\s*<false\/>/);
+});
+
+test("both apps declare exempt encryption so every build can be tested at once", () => {
+  assert.equal(project.match(/INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;/g)?.length, 4);
+});
+
+test("both apps ship a privacy manifest that matches the APIs the code calls", () => {
+  assert.match(project, /AABBCC000000000000000102 \/\* PrivacyInfo\.xcprivacy in Resources \*\/,/);
+  assert.match(project, /AABBCC000000000000000103 \/\* PrivacyInfo\.xcprivacy in Resources \*\/,/);
+  assert.match(project, /path = PrivacyInfo\.xcprivacy;[\s\S]*?path = PrivacyInfo\.xcprivacy;/);
+  for (const manifest of [phonePrivacyManifest, watchPrivacyManifest]) {
+    assert.match(manifest, /<key>NSPrivacyTracking<\/key>\s*<false\/>/);
+    assert.match(manifest, /<key>NSPrivacyTrackingDomains<\/key>\s*<array\/>/);
+    for (const [category, symbols] of Object.entries(REQUIRED_REASON_APIS)) {
+      assert.equal(
+        manifest.includes(`<string>${category}</string>`),
+        symbols.test(shippedSwift),
+        category,
+      );
+    }
+  }
+});
+
+test("the export options upload to App Store Connect without naming a team", () => {
+  assert.match(exportOptions, /<key>method<\/key>\s*<string>app-store-connect<\/string>/);
+  assert.match(exportOptions, /<key>destination<\/key>\s*<string>upload<\/string>/);
+  assert.match(exportOptions, /<key>signingStyle<\/key>\s*<string>automatic<\/string>/);
+  assert.doesNotMatch(exportOptions, /teamID/);
+});


### PR DESCRIPTION
## Summary

Everything an App Store Connect upload of the iPhone and Watch apps needs that does not depend on which team signs, ahead of the Stage Inc developer account.

- **Privacy manifests** for `Luke` and `LukeWatch`, declaring the two required-reason APIs the code calls (UserDefaults, `CA92.1`; system uptime, `35F9.1`) with tracking off. A new guard test scans every shipped Swift source and holds each manifest equal to the categories the code actually calls.
- **Export compliance answered in the build.** Both apps set `ITSAppUsesNonExemptEncryption` to `NO`.
- **One version for both apps.** `MARKETING_VERSION` and `CURRENT_PROJECT_VERSION` move from the six target configurations to the project, at `0.1.0 (1)`, with the build number meant to be overridden at archive time.
- **`apps/ios/ExportOptions.plist`** signs for App Store Connect and uploads in one step, tells App Store Connect not to rewrite the build number, and names no team.
- **iOS README** gains a TestFlight section with the version scheme and the archive and upload commands.
- Incidental: the iPhone target's duplicated microphone usage description is listed once.

Not in this PR: the `DEVELOPMENT_TEAM` change, which lands once the Stage Inc account exists.

## Verification

- `./scripts/check.sh` passes, including the fifteen iOS project tests.
- The three new plist files parse.
- CI does not build the iOS project. Before merging, build the branch in Xcode 26 on a Mac and confirm both targets report `0.1.0 (1)` and copy `PrivacyInfo.xcprivacy` into `Luke.app` and its embedded `Watch/LukeWatch.app`. No UI changed, so no visual evidence or physical-notch check applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/db2be82f-c063-4a60-bf1d-d0186d9b7231)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34173587648/artifacts/10036564034) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34173587648)

- Commit: `50a51551ee3dfd047df23fee3d88875be33eb009`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
