### PR TITLE
feat(brain): default to no automatic session reset, keeping stored history and old checkpoints

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -351,23 +351,32 @@ Trust constraints:
   folded, written in the same transaction as the checkpoint that carries
   them, attributed to the lifetime that wrote them and cascading with none:
   a compaction changes the projection and erases nothing on record, and the
-  record stays searchable. A generation lives exactly fourteen days from its
-  creation: no write, checkpoint, or compaction moves its expiry, a file
-  claiming any other span reads as nothing, and it is judged at load, at the
-  door of every turn and submission, and by a timer armed at the instant
-  itself. The fence is synchronous: the store forgets the dead generation
+  record stays searchable. A generation does not reset on its own: the
+  default reset policy is none, as the pinned OpenClaw has it, so a
+  generation stands until Clear or Start fresh replaces it, however old its
+  checkpoint. Every generation is still stamped with a deadline fourteen
+  days from its creation, kept as the stored envelope's shape: no write,
+  checkpoint, or compaction moves it, a file claiming any other span reads
+  as nothing, and a checkpoint loaded past it keeps its identity and its
+  context whole. Only a store whose automatic reset was explicitly enabled
+  enforces that deadline, at load, at the door of every turn and
+  submission, and by a timer armed at the instant itself; the store this
+  build wires enables none, so the clock arms nothing. Where a generation
+  does end, by that opt-in expiry or by an explicit replacement, the fence
+  is synchronous: the store forgets the dead generation
   and announces the successor before any disk is waited on, so a turn
   holding a model answer, a transcript read, or an act's preparation is
   revoked at once, a write landing afterwards installs nothing, and the late
   result lands nowhere. The conversation's lines answer to their own
   retention, not the generation's: each line is stamped with the generation
   that stood when it was written, for attribution alone, and a generation's
-  expiry erases no line. Expiry revokes the generation's runs and, through
+  end erases no line. A generation's end revokes its runs and, through
   the host's own listener, withdraws every briefing it had queued or offered
   but not yet spoken; a version-1 file, of unknown age, reads as nothing
-  rather than as a fresh lifetime; a generation found expired, unreadable,
-  or past its bounds at load is replaced on disk in the same load rather
-  than left for a later write; and the empty generation that follows may
+  rather than as a fresh lifetime; a generation found unreadable or past its
+  bounds at load (or expired, under the opt-in policy) is replaced on disk
+  in the same load rather than left for a later write; and the empty
+  generation that follows may
   observe the same provider files again, because the rule bounds how long a
   reading stands, not whether the source can be read. Within its life a
   generation holds at most 200 records and its serialized file stays under 8
@@ -563,8 +572,11 @@ Trust constraints:
   ask — each of which reached the voice service once on the call that said it,
   so storing it changes only how long it stands, not what it is. It lives in
   Luke's own application data, never a provider's file, under a real retention
-  policy replacing the old "dies with the app": the 200 most recent lines,
-  nothing older than a fortnight, in the runtime store's own table. Each line
+  policy replacing the old "dies with the app": every admitted line stands
+  in the runtime store's own table until Delete history or the conversation
+  maintenance below removes it, and what the panel draws and the model is
+  handed is a projection over that record, the 200 most recent lines and
+  nothing older than a fortnight. Each line
   carries an id its writer minted, and the store's append is idempotent on
   it: a window reports only the lines it added, never the whole thread, so a
   report can add to the thread and never replace it, a line delivered twice

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -40,9 +40,10 @@ him — what you typed or said, what he spoke or announced, the actions he took
 at your request, and the asks he is still working on — in a database on your
 Mac, so they are still there the next time you open him. The History tab
 shows the main conversation, the one the talk key and every observation
-reach. Each conversation's History holds its 200 most recent
-entries and nothing older than 14 days, whichever runs out first, each kept in
-full so the tab shows every word. Beside the History, Luke keeps a transcript
+reach. The tab draws a conversation's 200 most recent entries and nothing
+older than 14 days, each in full; that is what is shown, not what is kept.
+Every entry stays in the database until you clear the conversation or the
+housekeeping described below removes it. Beside the History, Luke keeps a transcript
 of each conversation's turns in the same database: every input the model was
 shown and every point at which his working context was folded. The transcript
 is a record, not a limit: folding the context changes what the model sees
@@ -79,11 +80,10 @@ written summary and keeps that instead. Either is still derived from your
 sessions and your conversation and lives under the same rule as the rest. The
 folding is Luke's own decision, made when the record nears the model's
 window or the size a request may be; OpenAI is not asked to compact on its
-own. The whole record is one generation, and a generation lives exactly 14
-days from the moment it began: writing into it never extends it, and when its
-time is up everything in it, the encrypted compaction included, is discarded
-and an empty generation begins, which may observe your sessions afresh; a
-generation found expired when Luke starts is discarded then and there. A
+own. The whole record is one generation, and a generation does not reset
+on its own, on the terms OpenClaw's sessions keep: it stands, the encrypted
+compaction included, until you clear the conversation, and an old one is
+loaded whole however long ago it began. A
 generation holds at most 200 asks and stays under 8 MiB: the oldest finished
 asks go first once their endings are in the History, and when nothing can go
 Luke declines a new ask rather than growing the record.
@@ -314,8 +314,8 @@ service, usage counts and recordings by PostHog, and crash reports by Sentry.
 - Delete any synced provider API key from that provider's row in Settings. Keys
   are also deleted when you delete your account.
 - Clear the History tab to remove the stored conversation and Luke's working
-  memory of it behind a recovery archive on your Mac; the working memory also
-  discards itself 14 days after it began, whatever you do.
+  memory of it behind a recovery archive on your Mac. Nothing discards them
+  on a schedule: a conversation stands until you clear it.
 - Ask Luke what he remembers, correct a memory, or tell him to forget one.
 - Edit or delete any of Luke's workspace files yourself; Luke never overwrites
   your edit, and clearing the History tab does not touch them.

--- a/README.md
+++ b/README.md
@@ -40,12 +40,13 @@ status of your agents, kick fresh ones off for you, or message them on your
 behalf.
 
 The **History** tab keeps your conversations with Luke on your Mac, across
-launches, holding its 200 most recent entries and nothing older than a
-fortnight, beside a transcript of Luke's own turns that a compaction never
-erases. Its one control, Clear, removes the conversation behind a compressed
-recovery archive kept on your Mac. The 20 most recent entries ride into Luke's next call beside
-his working memory of what he read, said, and did, which lives in the same
-database for exactly 14 days from when it began. Luke also silently keeps a
+launches, drawing its 200 most recent entries and nothing older than a
+fortnight while keeping every entry stored, beside a transcript of Luke's own
+turns that a compaction never erases. Its one control, Clear, removes the
+conversation behind a compressed recovery archive kept on your Mac. The 20
+most recent entries ride into Luke's next call beside his working memory of
+what he read, said, and did, which lives in the same database and never
+resets on its own: it stands until you clear it. Luke also silently keeps a
 small local memory of useful preferences, personal context, goals, and
 recurring constraints; ask him what he remembers, correct something, or tell
 him to forget it.

--- a/apps/desktop/src/main/brain/host-retention.test.ts
+++ b/apps/desktop/src/main/brain/host-retention.test.ts
@@ -19,8 +19,11 @@ import { BrainHost } from "./host";
 /**
  * Retention as the main process owns it: the store and its clock stand from
  * launch in a live run, whether or not any capability builds an agent, so an
- * expired, unreadable, or oversized file is replaced at launch and a
- * generation whose agent was retired still dies on time.
+ * unreadable or oversized file is replaced at launch. Under the default
+ * policy of no automatic reset an old checkpoint is loaded whole and the
+ * clock arms nothing; the tests that opt into the legacy expiry show an
+ * expired file replaced at launch and a generation whose agent was retired
+ * still dying on time.
  */
 
 const NOW = 1_800_000_000_000;
@@ -78,10 +81,11 @@ function settle(): Promise<void> {
   });
 }
 
-function launch(storage: MemoryStorage, clock: FakeClock) {
+function launch(storage: MemoryStorage, clock: FakeClock, automaticReset = false) {
   const reports: string[] = [];
   let generations = 0;
   const store = new BrainStateStore({
+    automaticReset,
     storage,
     createGenerationId: () => `gen-${++generations}`,
     now: () => clock.now,
@@ -96,7 +100,7 @@ function launch(storage: MemoryStorage, clock: FakeClock) {
   return { store, generationClock, reports };
 }
 
-test("a launch with no key or account replaces an expired file at once, without an agent or an inference", async () => {
+test("a launch under the default policy keeps a checkpoint past its stamped deadline and arms no clock", async () => {
   const storage = new MemoryStorage();
   const stale = {
     ...freshBrainState("gen-old", NOW - BRAIN_GENERATION_LIFETIME_MS - 1),
@@ -105,6 +109,26 @@ test("a launch with no key or account replaces an expired file at once, without 
   storage.file = brainStateRecord(stale);
   const clock = new FakeClock();
   const { store, generationClock, reports } = launch(storage, clock);
+  await generationClock.start();
+  assert.equal(store.generationId(), "gen-old");
+  assert.deepEqual(store.current()?.items, stale.items);
+  assert.ok(String(storage.file).includes(EXPIRED_SECRET));
+  assert.equal(reports.length, 0);
+  assert.equal(clock.timers.size, 0);
+  await clock.advance(NOW + BRAIN_GENERATION_LIFETIME_MS);
+  assert.equal(store.generationId(), "gen-old");
+  generationClock.stop();
+});
+
+test("with the legacy expiry enabled, a launch with no key or account replaces an expired file at once, without an agent or an inference", async () => {
+  const storage = new MemoryStorage();
+  const stale = {
+    ...freshBrainState("gen-old", NOW - BRAIN_GENERATION_LIFETIME_MS - 1),
+    items: [{ type: "message", role: "user", content: EXPIRED_SECRET }],
+  };
+  storage.file = brainStateRecord(stale);
+  const clock = new FakeClock();
+  const { store, generationClock, reports } = launch(storage, clock, true);
   await generationClock.start();
   assert.notEqual(store.generationId(), "gen-old");
   assert.ok(!String(storage.file).includes(EXPIRED_SECRET));
@@ -119,17 +143,17 @@ test("a launch with no key or account replaces an expired file at once, without 
   const refusing = new MemoryStorage();
   refusing.file = brainStateRecord(stale);
   refusing.refuse = true;
-  const held = launch(refusing, clock);
+  const held = launch(refusing, clock, true);
   await held.generationClock.start();
   assert.notEqual(held.store.generationId(), "gen-old");
   assert.ok(held.reports.some((message) => message.includes("could not replace")));
   held.generationClock.stop();
 });
 
-test("a generation whose agent was retired before its expiry still dies on the host's clock, and the file is replaced", async () => {
+test("with the legacy expiry enabled, a generation whose agent was retired before its expiry still dies on the host's clock, and the file is replaced", async () => {
   const storage = new MemoryStorage();
   const clock = new FakeClock();
-  const { store, generationClock } = launch(storage, clock);
+  const { store, generationClock } = launch(storage, clock, true);
   await generationClock.start();
   const host = new BrainHost({
     follow: () => async () => undefined,

--- a/apps/desktop/src/main/brain/wiring.ts
+++ b/apps/desktop/src/main/brain/wiring.ts
@@ -250,9 +250,10 @@ export function wireBrain(dependencies: BrainWiringDependencies): BrainWiring {
     // they were said. The agent hears the same announcement and stands its
     // runs down itself.
     const unsubscribe = store.onReplaced(() => dependencies.onGenerationReplaced(sessionKey));
-    // The generation's clock stands with the store, not with an agent: a
-    // launch with no key or account, and an app left open after its agent was
-    // retired, still see the generation die on time and the file replaced.
+    // The generation's clock stands with the store, not with an agent, so a
+    // store whose automatic reset is enabled sees the generation die on time
+    // through a launch with no key or account, and after its agent was
+    // retired. Under the default policy of no automatic reset it arms nothing.
     const clock = new BrainGenerationClock({ store });
     void clock.start();
     const opened: OpenConversation = { host, store, clock, unsubscribe };

--- a/packages/brain/src/agent.test.ts
+++ b/packages/brain/src/agent.test.ts
@@ -315,6 +315,7 @@ function harness(overrides: HarnessOverrides = {}, storage = new FakeStorage()):
   const deliveries: BrainDelivery[] = [];
   const persisted: BrainPersistedState[] = [];
   const store = new BrainStateStore({
+    automaticReset: true,
     storage: {
       read: () => storage.read(),
       write: (contents) => {
@@ -2809,6 +2810,7 @@ test("runs retention lets go of leave the live records and journal too, so the n
   const bounds = { MAXIMUM_TERMINAL_REQUESTS: 2, MAXIMUM_SERIALIZED_BYTES: 8 * 1024 * 1024 };
   const storage = new FakeStorage();
   const store = new BrainStateStore({
+    automaticReset: true,
     storage,
     createGenerationId: () => "gen-bounded",
     now: () => NOW,
@@ -2855,6 +2857,7 @@ test("runs retention lets go of leave the live records and journal too, so the n
 test("a generation at its record bound refuses a new ask at the door, and admits one again once an end reaches the thread", async () => {
   const storage = new FakeStorage();
   const store = new BrainStateStore({
+    automaticReset: true,
     storage,
     createGenerationId: () => "gen-bounded",
     now: () => NOW,

--- a/packages/brain/src/agent.ts
+++ b/packages/brain/src/agent.ts
@@ -932,12 +932,14 @@ export class BrainAgent {
 
   /**
    * Asks the store to end the generation if its time has come: the door
-   * check, for a generation that outlived its fortnight while nothing kept
-   * its clock. The clock itself — a timer at the expiry instant — is the
-   * host's, one per store, standing whether or not an agent does. The store's
-   * fence is synchronous and its announcement adopts the successor here in
-   * the same call, so by the time this returns the dead generation's signal
-   * has fired and nothing of it can open, dispatch, or deliver.
+   * check, for a store whose automatic reset is enabled and whose generation
+   * outlived its deadline while nothing kept its clock. Under the default
+   * policy of no automatic reset the store declines and the generation
+   * stands. The clock itself — a timer at the expiry instant — is the host's,
+   * one per store, standing whether or not an agent does. The store's fence
+   * is synchronous and its announcement adopts the successor here in the
+   * same call, so by the time this returns the dead generation's signal has
+   * fired and nothing of it can open, dispatch, or deliver.
    */
   #expireIfDue(): void {
     const generation = this.#generation;

--- a/packages/brain/src/generation-clock.ts
+++ b/packages/brain/src/generation-clock.ts
@@ -13,7 +13,8 @@ export interface BrainGenerationClockOptions {
 }
 
 /**
- * The generation's clock: one timer per store, armed at the standing
+ * The generation's clock, for a store whose automatic reset is enabled; under
+ * the default policy it arms nothing. Otherwise one timer per store is armed at the standing
  * generation's expiry instant and re-armed whenever the store begins another,
  * so a generation dies on time whether or not an agent stands to check its
  * door — a key removed, an account signed out, or an app left open past the
@@ -62,7 +63,7 @@ export class BrainGenerationClock {
 
   #arm(state: BrainPersistedState): void {
     this.#disarm();
-    if (this.#stopped) return;
+    if (this.#stopped || !this.#store.automaticReset) return;
     if (brainGenerationExpired(state, this.#now())) {
       this.#store.expireIfDue(this.#now());
       return;

--- a/packages/brain/src/state-store.test.ts
+++ b/packages/brain/src/state-store.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { unparsedWire, type WireBoundaryInput } from "@sidecar/wire";
+import { BrainGenerationClock } from "./generation-clock.js";
 import { BRAIN_REQUEST_ORIGIN, BRAIN_REQUEST_STATUS } from "./requests.js";
 import {
   BRAIN_GENERATION_LIFETIME_MS,
@@ -127,6 +128,7 @@ test("the store loads once, serializes writes, and fences a write against a repl
   const storage = new MemoryStorage();
   let generations = 0;
   const store = new BrainStateStore({
+    automaticReset: true,
     storage,
     createGenerationId: () => `gen-${++generations}`,
     now: () => NOW,
@@ -243,7 +245,12 @@ test("the store discards an expired file at load rather than giving old memory a
   storage.file = brainStateRecord(stale);
   let clock = stale.expiresAt - 1;
   const fresh = () =>
-    new BrainStateStore({ storage, createGenerationId: () => "gen-new", now: () => clock });
+    new BrainStateStore({
+      automaticReset: true,
+      storage,
+      createGenerationId: () => "gen-new",
+      now: () => clock,
+    });
   assert.equal((await fresh().load()).generationId, "gen-1");
   clock = stale.expiresAt;
   const loaded = await fresh().load();
@@ -261,6 +268,7 @@ test("writes and a compaction never move the expiry, and expireIfDue ends the ge
   let generations = 0;
   let clock = NOW;
   const store = new BrainStateStore({
+    automaticReset: true,
     storage,
     createGenerationId: () => `gen-${++generations}`,
     now: () => clock,
@@ -338,6 +346,7 @@ test("the byte cap prunes eligible ended runs first, and refuses a write that wo
   const bounds = { MAXIMUM_TERMINAL_REQUESTS: 200, MAXIMUM_SERIALIZED_BYTES: 4_000 } as const;
   const storage = new MemoryStorage();
   const store = new BrainStateStore({
+    automaticReset: true,
     storage,
     createGenerationId: () => "gen-1",
     now: () => NOW,
@@ -392,6 +401,7 @@ test("the byte cap prunes eligible ended runs first, and refuses a write that wo
 
   // A write that does not grow an already-oversized envelope still lands.
   const oversizedStore = new BrainStateStore({
+    automaticReset: true,
     storage: new MemoryStorage(),
     createGenerationId: () => "gen-1",
     now: () => NOW,
@@ -423,6 +433,7 @@ test("a Clear whose marker the storage refuses still fences the old generation a
   const storage = new MemoryStorage();
   let generations = 0;
   const store = new BrainStateStore({
+    automaticReset: true,
     storage,
     createGenerationId: () => `gen-${++generations}`,
     now: () => NOW,
@@ -493,6 +504,7 @@ test("a Clear and an expiry fence synchronously, before any disk is waited on, a
   const storage = new HeldStorage();
   let generations = 0;
   const store = new BrainStateStore({
+    automaticReset: true,
     storage,
     createGenerationId: () => `gen-${++generations}`,
     now: () => NOW,
@@ -557,6 +569,7 @@ test("a Clear on a store that never loaded still leaves the marker, learning the
   };
   storage.file = brainStateRecord(old);
   const store = new BrainStateStore({
+    automaticReset: true,
     storage,
     createGenerationId: () => "gen-cold",
     now: () => NOW,
@@ -579,6 +592,7 @@ test("a Clear on a store that never loaded still leaves the marker, learning the
   // With no brain file at all the marker still carries the instant.
   const empty = new MemoryStorage();
   const bare = new BrainStateStore({
+    automaticReset: true,
     storage: empty,
     createGenerationId: () => "gen-bare",
     now: () => NOW,
@@ -592,6 +606,7 @@ test("load admits a file only within its bounds and rewrites the disk to match w
   const bounds = { MAXIMUM_TERMINAL_REQUESTS: 3, MAXIMUM_SERIALIZED_BYTES: 100_000 };
   const make = (storage: MemoryStorage, now = NOW) =>
     new BrainStateStore({
+      automaticReset: true,
       storage,
       createGenerationId: () => "gen-fresh",
       now: () => now,
@@ -654,6 +669,7 @@ test("load admits a file only within its bounds and rewrites the disk to match w
 test("the record count is a hard bound: admission closes at capacity and a write that would add past it is refused", async () => {
   const storage = new MemoryStorage();
   const store = new BrainStateStore({
+    automaticReset: true,
     storage,
     createGenerationId: () => "gen-1",
     now: () => NOW,
@@ -728,6 +744,7 @@ test("a load whose read was out when a Clear landed adopts the successor, never 
     });
     let generations = 0;
     const store = new BrainStateStore({
+      automaticReset: true,
       storage,
       createGenerationId: () => `fresh-${++generations}`,
       now: () => NOW,
@@ -774,6 +791,7 @@ test("a load's own cleanup write and a replacement both yield to a Clear or expi
   storage.file = brainStateRecord(stale);
   let generations = 0;
   const store = new BrainStateStore({
+    automaticReset: true,
     storage,
     createGenerationId: () => `fresh-${++generations}`,
     now: () => stale.expiresAt,
@@ -855,3 +873,36 @@ function settleTicks(): Promise<void> {
     tick();
   });
 }
+
+test("default policy keeps an existing checkpoint beyond its legacy deadline and arms no reset timer", async () => {
+  const storage = new MemoryStorage();
+  const previous = complete();
+  storage.file = brainStateRecord(previous);
+  let now = previous.expiresAt + BRAIN_GENERATION_LIFETIME_MS;
+  const store = new BrainStateStore({
+    storage,
+    createGenerationId: () => "explicit-reset",
+    now: () => now,
+  });
+  assert.deepEqual(await store.load(), previous);
+  assert.equal(store.automaticReset, false);
+  assert.equal(store.expireIfDue(now), false);
+  let scheduled = false;
+  const clock = new BrainGenerationClock({
+    store,
+    now: () => now,
+    schedule: () => {
+      scheduled = true;
+      throw new Error("default policy must not schedule expiry");
+    },
+  });
+  await clock.start();
+  now += BRAIN_GENERATION_LIFETIME_MS;
+  assert.equal((await store.load()).generationId, previous.generationId);
+  assert.deepEqual(store.current()?.items, previous.items);
+  assert.equal(scheduled, false);
+  assert.equal(await store.reset(now), true);
+  assert.equal(store.current()?.generationId, "explicit-reset");
+  assert.deepEqual(store.current()?.items, []);
+  clock.stop();
+});

--- a/packages/brain/src/state-store.ts
+++ b/packages/brain/src/state-store.ts
@@ -25,7 +25,7 @@ import { TOOL_LOOP_RUNTIME } from "./runtime.js";
 
 export const BRAIN_STATE_VERSION = 2;
 
-/** How long a generation lives from its creation, whatever is written into it. */
+/** The span every generation is stamped with at birth; enforced only by a store whose automatic reset is enabled. */
 export const BRAIN_GENERATION_LIFETIME_MS = 14 * 24 * 60 * 60 * 1000;
 
 /**
@@ -82,6 +82,7 @@ export interface BrainPersistedState {
   version: typeof BRAIN_STATE_VERSION;
   generationId: string;
   createdAt: number;
+  /** Always stamped and validated as part of the envelope's shape; a deadline only when automatic reset is enabled. */
   expiresAt: number;
   /**
    * Whose shape the items are, as `checkpointFormatTag` writes it, carried on
@@ -367,6 +368,8 @@ export type BrainStateStoreOptions = (
 ) & {
   createGenerationId: () => string;
   now?: () => number;
+  /** Enforce the stamped deadline. Off by default, as OpenClaw's session reset policy is `none`. */
+  automaticReset?: boolean;
   bounds?: BrainStateBounds;
   /** Hears the store's own housekeeping failures: a discard or expiry the disk would not take. */
   report?: (message: string) => void;
@@ -408,9 +411,12 @@ export type BrainStateMutation = Omit<
  * each write reached storage, because the caller decides what a failed
  * checkpoint means for the act it guards.
  *
- * The store also owns the generation's two ends. Its lifetime is fixed at
- * birth and checked at load, on demand, and never moved by a write, so an
- * envelope written into for a fortnight still dies on the day it was born to.
+ * The store also owns the generation's two ends. Every generation is stamped
+ * with a deadline at birth that no write moves, but by default nothing
+ * enforces it: a generation stands until an explicit replacement, however old
+ * its checkpoint, matching OpenClaw's default of no automatic reset. Only a
+ * store constructed with `automaticReset` checks the deadline at load and on
+ * demand.
  * A Clear replaces the generation with an empty one carrying a content-free
  * marker of the erasure, in one write, so the moment the marker is durable the
  * old content is gone from the same file; a marker the storage refused still
@@ -418,6 +424,7 @@ export type BrainStateMutation = Omit<
  * not complete.
  */
 export class BrainStateStore {
+  readonly automaticReset: boolean;
   readonly #repository: BrainStateRepository;
   readonly #createGenerationId: () => string;
   readonly #now: () => number;
@@ -429,6 +436,7 @@ export class BrainStateStore {
   readonly #replacedListeners = new Set<(state: BrainPersistedState) => void>();
 
   constructor(options: BrainStateStoreOptions) {
+    this.automaticReset = options.automaticReset ?? false;
     this.#repository = options.repository ?? brainStateRepositoryFromStorage(options.storage);
     this.#createGenerationId = options.createGenerationId;
     this.#now = options.now ?? Date.now;
@@ -453,7 +461,7 @@ export class BrainStateStore {
     return this.#serialized(async () => {
       const held = this.#state;
       if (held) {
-        if (!brainGenerationExpired(held, this.#now())) return held;
+        if (!this.automaticReset || !brainGenerationExpired(held, this.#now())) return held;
         const fresh = this.#begin(this.#now());
         await this.#persistHousekeeping(fresh, "the expired generation");
         return this.#state ?? fresh;
@@ -492,7 +500,7 @@ export class BrainStateStore {
         ...(loaded.unreadable ? { rewrite: "an unreadable state file" } : undefined),
       };
     }
-    if (brainGenerationExpired(read, now)) {
+    if (this.automaticReset && brainGenerationExpired(read, now)) {
       return {
         state: freshBrainState(this.#createGenerationId(), now),
         rewrite: "the expired generation",
@@ -577,7 +585,7 @@ export class BrainStateStore {
    */
   expireIfDue(now: number = this.#now()): boolean {
     const held = this.#state;
-    if (!held || !brainGenerationExpired(held, now)) return false;
+    if (!this.automaticReset || !held || !brainGenerationExpired(held, now)) return false;
     const fresh = this.#begin(now);
     void this.#serialized(() => this.#persistHousekeeping(fresh, "the expired generation"));
     return true;

--- a/packages/runtime-store/src/database.test.ts
+++ b/packages/runtime-store/src/database.test.ts
@@ -216,7 +216,7 @@ test("the sequence counts up and is never reused after retention or a deletion",
   fs.rmSync(root, { recursive: true, force: true });
 });
 
-test("retention keeps the 200 most recent lines and nothing older than a fortnight, judged at the append", () => {
+test("the panel projection keeps 200 recent lines while canonical history keeps every admitted line", () => {
   const database = openTestDatabase();
   const old = line("old", NOW - storedConversationMaximumAgeMs - 1, { eventId: "old" });
   const many = Array.from({ length: maximumStoredConversationEntries + 10 }, (_, index) =>
@@ -225,7 +225,7 @@ test("retention keeps the 200 most recent lines and nothing older than a fortnig
   const outcome = appendHistory(database, MAIN_SESSION_KEY, [old, ...many], NOW);
   assert.equal(outcome.entries.length, maximumStoredConversationEntries);
   assert.equal(outcome.entries[0]?.words, "line 10");
-  assert.equal(inspectHistory(database, MAIN_SESSION_KEY).count, maximumStoredConversationEntries);
+  assert.equal(inspectHistory(database, MAIN_SESSION_KEY).count, many.length + 1);
   // A line stamped in the future is not admitted: the thread's clock is the store's.
   assert.equal(
     appendHistory(database, MAIN_SESSION_KEY, [line("soon", NOW + 1, { eventId: "f" })], NOW)
@@ -391,6 +391,7 @@ test("the reproduced boundary: marker written, erase failed, store load at exact
     cutoff,
   );
   const store = new BrainStateStore({
+    automaticReset: true,
     repository: repository(first),
     createGenerationId: () => `gen-${++ids}`,
     now: () => clock,

--- a/packages/runtime-store/src/history-table.ts
+++ b/packages/runtime-store/src/history-table.ts
@@ -59,7 +59,8 @@ export function appendHistory(
       if (!historyEntryAdmitted(entry, now, clearedAt)) continue;
       if (appendOne(database, sessionKey, standing?.sessionId, entry)) changed = true;
     }
-    if (changed) retainHistory(database, sessionKey, now);
+    // Nothing is removed here: stored lines answer to Delete history and
+    // conversation maintenance, and the bound is the projection's alone.
     return { changed, entries: listRetained(database, sessionKey, now, clearedAt) };
   });
 }
@@ -172,21 +173,6 @@ function published(
       .prepare("SELECT 1 FROM history_events WHERE session_key = ? AND request_id = ? AND kind = ?")
       .get(sessionKey, requestId, kind) !== undefined
   );
-}
-
-/** Lets go of lines past the age bound and beyond the count, oldest first. */
-function retainHistory(database: RuntimeDatabase, sessionKey: SessionKey, now: number): void {
-  database
-    .prepare("DELETE FROM history_events WHERE session_key = ? AND recorded_at < ?")
-    .run(sessionKey, now - storedConversationMaximumAgeMs);
-  database
-    .prepare(
-      `DELETE FROM history_events WHERE session_key = ? AND sequence IN (
-         SELECT sequence FROM history_events WHERE session_key = ?
-         ORDER BY recorded_at DESC, sequence DESC LIMIT -1 OFFSET ?
-       )`,
-    )
-    .run(sessionKey, sessionKey, maximumStoredConversationEntries);
 }
 
 /** The thread as the panel draws it: retained lines in the order they happened, oldest first. */

--- a/packages/runtime-store/src/history.ts
+++ b/packages/runtime-store/src/history.ts
@@ -3,26 +3,24 @@ import {
   conversationEntryIdentity,
   recordedAfterClear,
   storedConversationEntry,
-  storedConversationMaximumAgeMs,
 } from "@sidecar/realtime";
 import type { UnparsedWireValue } from "@sidecar/wire";
 
 /**
  * The conversation history's rules as the store applies them, shared by the
- * live append path. Retention is the thread's own: the
- * 200 most recent lines and nothing older than a fortnight, judged against
- * the store's clock. A line at or before the last Clear's cutoff is refused
- * whatever else is true of it.
+ * live append path. Canonical rows follow conversation maintenance, independently
+ * of the bounded History projection. A line at or before the last Clear cutoff
+ * is refused, and a future-dated line is never admitted.
  */
 
-/** Whether a line may stand now: recorded no later than now, within the age bound, and after any Clear. */
+/** Whether a canonical line may stand now: recorded no later than now and after any Clear. */
 export function historyEntryAdmitted(
   entry: ConversationEntry,
   now: number,
   clearedAt: number | undefined,
 ): entry is ConversationEntry & { recordedAt: number } {
   if (!recordedAfterClear(entry, clearedAt)) return false;
-  return entry.recordedAt <= now && now - entry.recordedAt <= storedConversationMaximumAgeMs;
+  return entry.recordedAt <= now;
 }
 
 const EXPLICIT_EVENT_KEY_PREFIX = "event:";

--- a/packages/runtime-store/src/lifecycle.test.ts
+++ b/packages/runtime-store/src/lifecycle.test.ts
@@ -654,3 +654,62 @@ test("a maintenance pass archives idle and stale threads in place, keeps a key i
   database.close();
   fs.rmSync(root, { recursive: true, force: true });
 });
+
+test("SQLite checkpoints survive their former fortnight deadline until explicitly reset", async () => {
+  const root = agentRoot();
+  const database = openAt(root);
+  try {
+    const prior = {
+      ...freshBrainState("existing-lifetime", NOW),
+      items: [{ type: "message", role: "user", content: "existing context" }],
+    };
+    assert.equal(repository(database).save(prior), true);
+    const store = new BrainStateStore({
+      repository: repository(database),
+      createGenerationId: () => "manual-successor",
+      now: () => NOW + 60 * DAY,
+    });
+    assert.equal((await store.load()).generationId, prior.generationId);
+    assert.deepEqual(store.current()?.items, prior.items);
+    assert.equal(store.expireIfDue(NOW + 90 * DAY), false);
+    assert.equal(
+      loadBrainEnvelope(database, MAIN_SESSION_KEY).state?.generationId,
+      prior.generationId,
+    );
+    assert.equal(await store.reset(NOW + 90 * DAY), true);
+    assert.equal(
+      loadBrainEnvelope(database, MAIN_SESSION_KEY).state?.generationId,
+      "manual-successor",
+    );
+  } finally {
+    database.close();
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("canonical history retains old and overflow lines while the existing panel projection stays bounded", () => {
+  const root = agentRoot();
+  const database = openAt(root);
+  try {
+    const now = NOW + 30 * DAY;
+    const old = line("old voice-only history", NOW, { eventId: "old-voice" });
+    appendHistory(database, MAIN_SESSION_KEY, [old], NOW);
+    const recent = Array.from({ length: 205 }, (_, i) =>
+      line(`recent ${i}`, now - 205 + i, { eventId: `recent-${i}` }),
+    );
+    appendHistory(database, MAIN_SESSION_KEY, recent, now);
+    assert.equal(listHistory(database, MAIN_SESSION_KEY, now).length, 200);
+    const archived = deleteConversationHistory(database, root, MAIN_SESSION_KEY, now);
+    assert.ok(archived?.published);
+    assert.equal(archived.archive.historyLines, 206);
+    const content = decodeArchiveContent(
+      fs.readFileSync(path.join(archiveDirectory(root), archived.archive.fileName)),
+      archived.archive.encoding,
+    );
+    assert.ok(content.includes("old voice-only history"));
+    assert.ok(content.includes('"words":"recent 0"'));
+  } finally {
+    database.close();
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Follow-up to PR3 of the OpenClaw architecture series. Matches the pinned OpenClaw `b7528507` default session reset policy (`DEFAULT_RESET_MODE = none`; `docs/concepts/session.md`: sessions are reused until a manual reset or an explicitly configured automatic one).

## What changes

- **No automatic generation reset by default.** `BrainStateStore` takes an `automaticReset` option that defaults to `false`; nothing in the build sets it. The fourteen-day deadline is still stamped on and validated against every envelope (a file claiming another span still reads as nothing), so existing SQLite checkpoints load whole past their former expiry. `load`, `expireIfDue`, and the `BrainGenerationClock` enforce the deadline only when the store opted in; the clock arms no timer by default.
- **Explicit fences unchanged.** Clear / Delete history / Start fresh replace the generation under the same synchronous fence as before.
- **Stored history follows conversation maintenance.** `appendHistory` no longer physically deletes rows past 200 lines or 14 days, and admission no longer refuses a line for age. The panel projection (`listHistory` / the returned entries) is unchanged: 200 most recent lines within a fortnight. The 20-line model slice is unchanged.
- **Docs.** AGENTS.md, PRIVACY.md (including the working-memory paragraph that still promised a 14-day discard), and the README describe the policy as it stands.

No UI changes, no new controls or copy, no legacy JSON import.

## Tests

- Existing expiry tests opt into `automaticReset: true` and are otherwise unchanged.
- New: store keeps a checkpoint past its stamped deadline and the clock schedules nothing (`state-store.test.ts`); a SQLite-backed checkpoint survives 60–90 days and is replaced only by an explicit reset (`lifecycle.test.ts`); Delete history's archive carries old and overflow lines the projection no longer draws (`lifecycle.test.ts`); the desktop launch under the default policy loads an old file whole and arms no clock (`host-retention.test.ts`).

Validated head: `fad91aec7dde3f8cf8360bf0ffa8d743109423fa`, one commit over main `3cbcc28a91d52f12d8689eddce9768c854947148` (includes PR4 #750 and #758).

- `./scripts/check.sh` passed: lint, typecheck, all package tests, build (brain 174, runtime-store 37, desktop 949).
- Root ran `./scripts/bootstrap.sh` and full `./scripts/verify.sh` successfully on the user's Mac at this exact head.
- Required TypeScript and macOS CI passed: https://github.com/ReviewStage/luke/actions/runs/34256819719.
- All six CI evidence PNGs are byte-identical to the inspected PR4 evidence. No UI changes.
- Independent retention/reset review completed; no unresolved GitHub review threads. User authorized the merge; root owns the merge queue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/738b3d54-3443-447c-a90c-93e4c3a8d1c7)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34256819719/artifacts/10068345997) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34256819719)

- Commit: `fad91aec7dde3f8cf8360bf0ffa8d743109423fa`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->