### PR TITLE
Add Conductor GPT-6 Astra support

### DIFF
--- a/apps/desktop/src/renderer/luke-guide.test.ts
+++ b/apps/desktop/src/renderer/luke-guide.test.ts
@@ -472,6 +472,22 @@ test("the guide offers what a new Conductor agent runs, by the names people know
   );
 });
 
+test("the guide offers GPT-6 Astra for new Conductor agents", () => {
+  const unset = guideSetting(APP_SETTING_ID.WORKSPACE_AGENT_MODEL);
+
+  assert.ok(unset.choices?.includes("GPT-6 Astra"));
+  assert.equal(unset.choices?.includes("gpt-6-astra"), false);
+  assert.deepEqual(unset.efforts?.["GPT-6 Astra"], [
+    "none",
+    "low",
+    "medium",
+    "high",
+    "xhigh",
+    "max",
+    "ultra",
+  ]);
+});
+
 test("a spoken model or effort change composes the one stored selection", async () => {
   const carried: (WorkspaceAgentSelection | undefined)[] = [];
   const bridge = spokenSettingBridge({

--- a/apps/ios/LukeKit/Tests/LukeKitTests/ProjectsClientTests.swift
+++ b/apps/ios/LukeKit/Tests/LukeKitTests/ProjectsClientTests.swift
@@ -103,6 +103,18 @@ final class WorkspaceAgentOptionTests: XCTestCase {
             ])
         )
     }
+
+    func testDecodesGPT6Astra() {
+        let option = WorkspaceAgentOption(json: [
+            "providerId": "conductor",
+            "agent": "codex",
+            "models": [["id": "gpt-6-astra", "label": "GPT-6 Astra"]],
+            "efforts": ["ultra"],
+        ])
+
+        XCTAssertEqual(option?.models, [WorkspaceAgentModelChoice(id: "gpt-6-astra", label: "GPT-6 Astra")])
+        XCTAssertEqual(option?.efforts, ["ultra"])
+    }
 }
 
 // MARK: - ProjectsClient

--- a/apps/ios/LukeKit/Tests/LukeKitTests/WorkspaceProjectsContextTests.swift
+++ b/apps/ios/LukeKit/Tests/LukeKitTests/WorkspaceProjectsContextTests.swift
@@ -73,6 +73,23 @@ final class WorkspaceProjectsContextTests: XCTestCase {
         )
     }
 
+    func testAgentOptionsRenderGPT6AstraForPhoneAndWatchVoiceContext() {
+        let answer = ProjectsAnswer(
+            projects: [project("p1", repository: "acme/web")],
+            agentModels: [
+                WorkspaceAgentOption(
+                    providerId: "conductor", agent: "codex",
+                    models: [WorkspaceAgentModelChoice(id: "gpt-6-astra", label: "GPT-6 Astra")],
+                    efforts: ["ultra"]
+                )
+            ]
+        )
+
+        let text = WorkspaceProjectsContext.text(
+            answer: answer, defaultProviderId: nil, defaultProjectIds: [:])
+        XCTAssertTrue(text.contains("codex — models GPT-6 Astra (gpt-6-astra); efforts ultra"))
+    }
+
     func testTheCapKeepsTheDefaultProjectPastTheCut() {
         let projects = (0 ..< 12).map { project("p\($0)", repository: "repo-\($0)") }
         let listed = WorkspaceProjectsContext.listedProjects(projects, defaultProjectIds: ["conductor": "p11"])

--- a/apps/web/tests/hosted-projects.test.ts
+++ b/apps/web/tests/hosted-projects.test.ts
@@ -158,4 +158,8 @@ test("a provider that offered a project carries its agent table on the answer", 
   const answer = hostedProjectsAnswerFromWire(body);
   assert.ok(answer);
   assert.equal(answer.agentModels.length, 3);
+  const codex = answer.agentModels.find((entry) => entry.agent === "codex");
+  assert.ok(
+    codex?.models.some((model) => model.id === "gpt-6-astra" && model.label === "GPT-6 Astra"),
+  );
 });

--- a/packages/session/src/workspace-agents.ts
+++ b/packages/session/src/workspace-agents.ts
@@ -63,6 +63,7 @@ export const WORKSPACE_AGENT_MODELS = {
         { id: "gpt-5.3-codex-spark", label: "GPT-5.3 Codex Spark" },
         { id: "gpt-5.3-codex", label: "GPT-5.3 Codex" },
         { id: "gpt-5.2-codex", label: "GPT-5.2 Codex" },
+        { id: "gpt-6-astra", label: "GPT-6 Astra" },
       ],
       efforts: ["none", "low", "medium", "high", "xhigh", "max", "ultra"],
     },


### PR DESCRIPTION
## Summary
- add Conductor's gpt-6-astra model to the shared workspace agent model table
- update desktop guide and hosted projects coverage for GPT-6 Astra
- update LukeKit project decoding/context tests so iOS and watchOS voice flows consume the option from /api/projects

## Investigation
- conductor --json model exposes a machine-readable roster and currently lists gpt-6-astra.
- conductor --json --debug model emitted no HTTP trace in this environment, matching a CLI-compiled roster rather than a dynamic hosted API Luke can consume.
- Luke's hosted /api/projects payload is still built from WORKSPACE_AGENT_MODELS, so static coverage is required for now.

## Tests
- pnpm --filter @sidecar/session test
- pnpm --filter @luke/desktop test
- pnpm --filter @luke/web test
- pnpm lint

## Not run
- swift test in apps/ios/LukeKit because this Linux sandbox does not have swift installed.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/62c01c05-d164-43fe-b048-294bd1ef2c45)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34256360838/artifacts/10068158264) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34256360838)

- Commit: `3faf359d040f3212b261cb3b16bcc2e767289a36`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
