### PR TITLE
fix(brain): withdraw a cancelled queued ask's words before its turn opens

### DIFF
--- a/packages/brain/src/agent.test.ts
+++ b/packages/brain/src/agent.test.ts
@@ -3872,6 +3872,118 @@ test("a queued ask cancelled before its turn opens settles cancelled and the dra
   assert.equal(h.agent.request(second)?.text, undefined);
 });
 
+test("a collected ask cancelled before the window closes leaves no trace of its words in the model's input", async () => {
+  const { QUEUE_MODE } = await import("@sidecar/runtime");
+  const h = harness({ queueMode: QUEUE_MODE.COLLECT, queueDebounceMs: 500 });
+  h.client.answers.push(answered([message("answered for the rest")]));
+  const first = acceptedRunId(await submit(h, "first, kept"));
+  const second = acceptedRunId(await submit(h, "second, withdrawn-marker-7f3a"));
+  const third = acceptedRunId(await submit(h, "third, kept"));
+  assert.equal((await h.agent.cancelAsk(second))?.status, BRAIN_REQUEST_STATUS.CANCELLED);
+  await h.clock.advance(NOW + 500);
+  await settle();
+  assert.equal(h.client.inputs.length, 1);
+  const opening = itemText((h.client.inputs[0] ?? [])[0]);
+  assert.ok(opening.includes("first, kept"));
+  assert.ok(opening.includes("third, kept"));
+  assert.ok(!opening.includes("withdrawn-marker-7f3a"));
+  assert.equal((await h.agent.waitAsk(first, 1))?.text, "answered for the rest");
+  assert.equal((await h.agent.waitAsk(third, 1))?.text, "answered for the rest");
+  // The cancellation withdrew unsent model input and nothing else: the ask
+  // stands on its own record as accepted, with the words the developer typed.
+  const cancelled = h.agent.request(second);
+  assert.equal(cancelled?.status, BRAIN_REQUEST_STATUS.CANCELLED);
+  assert.equal(cancelled?.question, "second, withdrawn-marker-7f3a");
+  assert.equal(cancelled?.text, undefined);
+
+  // The same cancel with the primary alone left: the collected turn opens for
+  // the one ask still standing, with only its words.
+  const alone = harness({ queueMode: QUEUE_MODE.COLLECT, queueDebounceMs: 500 });
+  alone.client.answers.push(answered([message("just the one")]));
+  const kept = acceptedRunId(await submit(alone, "kept alone"));
+  const gone = acceptedRunId(await submit(alone, "gone-marker-9c1d"));
+  await alone.agent.cancelAsk(gone);
+  await alone.clock.advance(NOW + 500);
+  await settle();
+  assert.equal(alone.client.inputs.length, 1);
+  const only = itemText((alone.client.inputs[0] ?? [])[0]);
+  assert.ok(only.includes("kept alone") && !only.includes("gone-marker-9c1d"));
+  assert.equal((await alone.agent.waitAsk(kept, 1))?.text, "just the one");
+});
+
+test("an overflow-summarized ask cancelled before the drain leaves the summary without its line, and no summary at all when it was the only one folded", async () => {
+  const { QUEUE_MODE, QUEUE_DEFAULTS } = await import("@sidecar/runtime");
+  const h = harness({ queueMode: QUEUE_MODE.COLLECT, queueDebounceMs: 500 });
+  h.client.answers.push(answered([message("one reply for the rest")]));
+  const folded = acceptedRunId(await submit(h, "folded-marker-2b8e, the oldest"));
+  const kept: string[] = [];
+  for (let index = 1; index <= QUEUE_DEFAULTS.CAPACITY; index += 1) {
+    kept.push(acceptedRunId(await submit(h, `ask ${index}?`)));
+  }
+  // The oldest is already folded into the summary when the developer cancels it.
+  assert.equal((await h.agent.cancelAsk(folded))?.status, BRAIN_REQUEST_STATUS.CANCELLED);
+  await h.clock.advance(NOW + 500);
+  await settle();
+  assert.equal(h.client.inputs.length, 1);
+  const opening = itemText((h.client.inputs[0] ?? [])[0]);
+  assert.ok(!opening.includes("folded-marker-2b8e"));
+  assert.ok(!opening.includes("summarized because the queue was full"));
+  assert.ok(opening.includes("ask 1?") && opening.includes(`ask ${QUEUE_DEFAULTS.CAPACITY}?`));
+  for (const runId of kept) {
+    assert.equal((await h.agent.waitAsk(runId, 1))?.text, "one reply for the rest");
+  }
+  assert.equal(h.agent.request(folded)?.question, "folded-marker-2b8e, the oldest");
+  assert.equal(h.agent.request(folded)?.text, undefined);
+
+  // With two folded and one of them cancelled, the summary still opens the
+  // turn, counting and naming only the ask that stands.
+  const two = harness({ queueMode: QUEUE_MODE.COLLECT, queueDebounceMs: 500 });
+  two.client.answers.push(answered([message("reply")]));
+  const standing = acceptedRunId(await submit(two, "standing-fold-4d0f"));
+  const withdrawn = acceptedRunId(await submit(two, "withdrawn-fold-6a2c"));
+  for (let index = 0; index < QUEUE_DEFAULTS.CAPACITY; index += 1) {
+    acceptedRunId(await submit(two, `later ${index}`));
+  }
+  await two.agent.cancelAsk(withdrawn);
+  await two.clock.advance(NOW + 500);
+  await settle();
+  const summary = itemText((two.client.inputs[0] ?? [])[0]);
+  assert.ok(summary.includes("1 earlier input was summarized because the queue was full"));
+  assert.ok(summary.includes("standing-fold-4d0f"));
+  assert.ok(!summary.includes("withdrawn-fold-6a2c"));
+  assert.equal((await two.agent.waitAsk(standing, 1))?.text, "reply");
+  assert.equal(two.agent.request(withdrawn)?.status, BRAIN_REQUEST_STATUS.CANCELLED);
+});
+
+test("an ask already drained but waiting behind another turn takes its words with it when cancelled", async () => {
+  const { QUEUE_MODE } = await import("@sidecar/runtime");
+  const inner = new FakeClient();
+  const gated = gatedClient(inner);
+  const h = harness({ client: gated.client, queueMode: QUEUE_MODE.COLLECT, queueDebounceMs: 500 });
+  inner.answers.push(answered([message("first")]), answered([message("for the kept one")]));
+  const first = acceptedRunId(await submit(h, "first?"));
+  await h.clock.advance(NOW + 500);
+  await settle();
+  // The first turn is at the model behind the gate; two more asks collect and
+  // drain into a turn that waits behind it.
+  const keptRun = acceptedRunId(await submit(h, "kept-behind-1e9b"));
+  const cancelledRun = acceptedRunId(await submit(h, "cancelled-behind-5c7d"));
+  await h.clock.advance(NOW + 1000);
+  await settle();
+  assert.equal(h.agent.request(first)?.status, BRAIN_REQUEST_STATUS.RUNNING);
+  assert.equal(h.agent.request(cancelledRun)?.status, BRAIN_REQUEST_STATUS.QUEUED);
+  assert.equal((await h.agent.cancelAsk(cancelledRun))?.status, BRAIN_REQUEST_STATUS.CANCELLED);
+  gated.open();
+  await settle();
+  assert.equal((await h.agent.waitAsk(first, 1))?.text, "first");
+  assert.equal((await h.agent.waitAsk(keptRun, 1))?.text, "for the kept one");
+  assert.equal(inner.inputs.length, 2);
+  const secondTurn = (inner.inputs[1] ?? []).map((item) => JSON.stringify(item)).join("\n");
+  assert.ok(secondTurn.includes("kept-behind-1e9b"));
+  assert.ok(!secondTurn.includes("cancelled-behind-5c7d"));
+  assert.equal(h.agent.request(cancelledRun)?.question, "cancelled-behind-5c7d");
+});
+
 test("a refused final checkpoint fails a drained batch's primary and its riders alike", async () => {
   const { QUEUE_MODE } = await import("@sidecar/runtime");
   const inner = new FakeClient();

--- a/packages/brain/src/agent.test.ts
+++ b/packages/brain/src/agent.test.ts
@@ -3984,6 +3984,66 @@ test("an ask already drained but waiting behind another turn takes its words wit
   assert.equal(h.agent.request(cancelledRun)?.question, "cancelled-behind-5c7d");
 });
 
+test("folded asks left alone by cancelling every ordinary one still open their turn, in follow-up mode too", async () => {
+  const { QUEUE_MODE, QUEUE_DEFAULTS } = await import("@sidecar/runtime");
+  const inner = new FakeClient();
+  const gated = gatedClient(inner);
+  const h = harness({ client: gated.client, queueMode: QUEUE_MODE.FOLLOWUP });
+  inner.answers.push(answered([message("first")]), answered([message("for the folded one")]));
+  const first = acceptedRunId(await submit(h, "first?"));
+  await settle();
+  // The queue fills behind the running turn; the oldest waiting ask folds into the summary.
+  const folded = acceptedRunId(await submit(h, "folded-survivor-3e1a"));
+  const ordinary: string[] = [];
+  for (let index = 0; index < QUEUE_DEFAULTS.CAPACITY; index += 1) {
+    ordinary.push(acceptedRunId(await submit(h, `ordinary ${index} marker-0d4c`)));
+  }
+  await settle();
+  for (const runId of ordinary) {
+    assert.equal((await h.agent.cancelAsk(runId))?.status, BRAIN_REQUEST_STATUS.CANCELLED);
+  }
+  assert.equal(h.agent.request(folded)?.status, BRAIN_REQUEST_STATUS.QUEUED);
+  assert.equal(h.agent.busy(), true);
+  gated.open();
+  await settle();
+  assert.equal((await h.agent.waitAsk(first, 1))?.text, "first");
+  // The folded ask is not left queued forever: the summary alone opens its turn.
+  assert.equal((await h.agent.waitAsk(folded, 1))?.text, "for the folded one");
+  assert.equal(inner.inputs.length, 2);
+  const secondTurn = (inner.inputs[1] ?? []).map((item) => JSON.stringify(item)).join("\n");
+  assert.ok(secondTurn.includes("1 earlier input was summarized because the queue was full"));
+  assert.ok(secondTurn.includes("folded-survivor-3e1a"));
+  assert.ok(!secondTurn.includes("marker-0d4c"));
+  assert.equal(h.agent.busy(), false);
+});
+
+test("cancelling every waiting ask, folded ones included, leaves nothing queued, no turn to open, and the conversation idle", async () => {
+  const { QUEUE_MODE, QUEUE_DEFAULTS } = await import("@sidecar/runtime");
+  const h = harness({ queueMode: QUEUE_MODE.COLLECT, queueDebounceMs: 500 });
+  const all: string[] = [];
+  for (let index = 0; index <= QUEUE_DEFAULTS.CAPACITY + 1; index += 1) {
+    all.push(acceptedRunId(await submit(h, `ask ${index}`)));
+  }
+  assert.equal(h.agent.busy(), true);
+  // The two oldest are folded; cancel them first, then everything the queue still holds.
+  for (const runId of all) {
+    assert.equal((await h.agent.cancelAsk(runId))?.status, BRAIN_REQUEST_STATUS.CANCELLED);
+  }
+  assert.equal(h.agent.busy(), false);
+  assert.equal(h.clock.timers.size, 0);
+  await h.clock.advance(NOW + 500);
+  await settle();
+  assert.equal(h.client.inputs.length, 0);
+  // Stale summary metadata does not hold the conversation: the next ask opens its own turn at once.
+  h.client.answers.push(answered([message("fresh")]));
+  const next = acceptedRunId(await submit(h, "after all of them"));
+  await h.clock.advance(NOW + 1000);
+  await settle();
+  assert.equal((await h.agent.waitAsk(next, 1))?.text, "fresh");
+  const opening = itemText((h.client.inputs[0] ?? [])[0]);
+  assert.ok(!opening.includes("summarized because the queue was full"));
+});
+
 test("a refused final checkpoint fails a drained batch's primary and its riders alike", async () => {
   const { QUEUE_MODE } = await import("@sidecar/runtime");
   const inner = new FakeClient();

--- a/packages/brain/src/agent.ts
+++ b/packages/brain/src/agent.ts
@@ -8,6 +8,8 @@ import {
   type QueueBatch,
   type QueuedInput,
   type QueueMode,
+  queueSummaryLine,
+  queueSummaryText,
 } from "@sidecar/runtime";
 import {
   type AgentRuntime,
@@ -340,6 +342,31 @@ interface PendingSubmission {
 
 export type BrainRequestsListener = (records: readonly BrainRequestRecord[]) => void;
 
+/**
+ * One ask as its turn reads it: the run that records it and the words the
+ * model is shown for it, its question or, once the overflow folded it, the
+ * one summary line the queue cut it to.
+ */
+interface AskInput {
+  readonly run: RunControl;
+  readonly text: string;
+  readonly folded: boolean;
+}
+
+/** The question one turn opens with for the asks that opened it: the overflow's summary first, then each ask's words. */
+function askQuestion(opened: readonly AskInput[]): string {
+  const summaryLines = opened.filter((input) => input.folded).map((input) => input.text);
+  const summary = queueSummaryText({
+    entries: [],
+    summaryLines,
+    summarizedCount: summaryLines.length,
+  });
+  return [
+    ...(summary === undefined ? [] : [summary]),
+    ...opened.filter((input) => !input.folded).map((input) => input.text),
+  ].join("\n\n");
+}
+
 export class BrainAgent {
   readonly #options: BrainAgentOptions;
   readonly #now: () => number;
@@ -371,9 +398,14 @@ export class BrainAgent {
    * Asks the overflow folded into a summary line: their words reach the model
    * as that line, and their records settle with the turn that carries it.
    */
-  #summarized: RunControl[] = [];
+  #summarized: AskInput[] = [];
   readonly #subject: LookSubject;
-  /** Each session as it last looked when an observation was captured, for the unchanged-look suppression. */
+  /**
+   * Each session as it last looked when an observation was captured, for the
+   * unchanged-look suppression. Held in memory alone: the first look after a
+   * launch is captured even with no transcript gained, because a status that
+   * changed while Luke was closed is still a change worth one look.
+   */
   readonly #lastLook = new BySession<string>();
   /** Captures run one after another, so two reads of one session never race each other's cursor. */
   #capturing: Promise<unknown> = Promise.resolve();
@@ -672,7 +704,7 @@ export class BrainAgent {
   #admitAsk(run: RunControl, question: string): void {
     const mode = this.#asks.settings.mode;
     if (!this.#active && this.#asks.size === 0 && mode !== QUEUE_MODE.COLLECT) {
-      this.#openAsks([run], question);
+      this.#openAsks([{ run, text: question, folded: false }]);
       return;
     }
     const held = this.#asks.state.entries;
@@ -700,7 +732,7 @@ export class BrainAgent {
     for (const entry of evicted) {
       const run = this.#runs.get(entry.id);
       if (!run) continue;
-      if (folded) this.#summarized.push(run);
+      if (folded) this.#summarized.push({ run, text: queueSummaryLine(entry), folded: true });
       else dropped.push(run);
     }
     if (dropped.length > 0) void this.#settleWaiting(dropped);
@@ -742,27 +774,29 @@ export class BrainAgent {
    * Opens the turns the queue drained, in order. The batch that carries the
    * overflow's summary carries the summarized runs with it, so an ask whose
    * words reached the model only as a summary line still settles with the
-   * turn that read it.
+   * turn that read it. Each ask travels with its own words rather than in a
+   * question joined here: what the model reads is composed when the turn
+   * opens, from the asks that still open it, so an ask cancelled between the
+   * drain and the turn takes its words with it.
    */
   #openBatches(batches: readonly QueueBatch[]): void {
     for (const batch of batches) {
-      const runs = batch.inputs.flatMap((input) => this.#runs.get(input.id) ?? []);
+      const inputs = batch.inputs.flatMap((input) => {
+        const run = this.#runs.get(input.id);
+        return run ? [{ run, text: input.text, folded: false }] : [];
+      });
       const riders = batch.summary === undefined ? [] : this.#summarized.splice(0);
-      const question = [
-        ...(batch.summary === undefined ? [] : [batch.summary]),
-        ...batch.inputs.map((input) => input.text),
-      ].join("\n\n");
-      this.#openAsks([...runs, ...riders], question);
+      this.#openAsks([...inputs, ...riders]);
     }
   }
 
   /** Queues one turn for the asks given, the first that can open it standing as its run. */
-  #openAsks(runs: readonly RunControl[], question: string): void {
-    if (runs.length === 0) return;
+  #openAsks(inputs: readonly AskInput[]): void {
+    if (inputs.length === 0) return;
     // The ask's turn opens with the inbox as it stands, so the window a wake
     // armed has nothing left to open and is disarmed.
     this.#wakes.take();
-    void this.#queueTurn(BRAIN_TURN_TRIGGER.ASK, () => this.#runAsk(runs, question));
+    void this.#queueTurn(BRAIN_TURN_TRIGGER.ASK, () => this.#runAsk(inputs));
   }
 
   /**
@@ -789,7 +823,7 @@ export class BrainAgent {
   #takeWaiting(): readonly RunControl[] {
     const waiting = [
       ...this.#asks.state.entries.flatMap((entry) => this.#runs.get(entry.id) ?? []),
-      ...this.#summarized.splice(0),
+      ...this.#summarized.splice(0).map((input) => input.run),
     ];
     this.#asks.clear();
     return waiting;
@@ -849,6 +883,11 @@ export class BrainAgent {
       return this.request(runId);
     }
     if (record.status === BRAIN_REQUEST_STATUS.QUEUED && this.#generation) {
+      // Words still waiting for a turn are withdrawn before any turn composes
+      // its question from them; words already steered were said to the model
+      // and cannot be unsaid. The record keeps the ask as accepted either way.
+      this.#asks.withdraw(runId);
+      this.#summarized = this.#summarized.filter((input) => input.run.runId !== runId);
       await this.#ledger.settleRun(this.#generation, runId, BRAIN_REQUEST_STATUS.CANCELLED, {});
     }
     return this.request(runId);
@@ -1493,13 +1532,16 @@ export class BrainAgent {
    * can still open stands as the turn's run and the rest ride inside it; an
    * ask already revoked, or one whose start the store refuses, settles here
    * and leaves the turn to the next, so asks behind a run that never opened
-   * are not lost.
+   * are not lost. The question the model reads is composed here from the
+   * asks that opened, and from no other: the overflow's summary from the
+   * folded ones, then each ask's own words.
    */
-  async #runAsk(runs: readonly RunControl[], question: string): Promise<void> {
-    const waiting = [...runs];
+  async #runAsk(inputs: readonly AskInput[]): Promise<void> {
+    const waiting = [...inputs];
     while (waiting.length > 0) {
-      const run = waiting.shift();
-      if (!run || !(await this.#opens(run))) continue;
+      const primary = waiting.shift();
+      if (!primary || !(await this.#opens(primary.run))) continue;
+      const run = primary.run;
       const generation = run.generation;
       // The start is durable before any work opens: a run the file does not
       // show running is one a relaunch would find queued while its acts had
@@ -1533,15 +1575,18 @@ export class BrainAgent {
         continue;
       }
       const riders: RunControl[] = [];
+      const opened: AskInput[] = [primary];
       for (const rider of waiting.splice(0)) {
-        if (!(await this.#opens(rider))) continue;
-        riders.push(rider);
-        await this.#ledger.commit(rider.generation, rider.runId, {
+        if (!(await this.#opens(rider.run))) continue;
+        riders.push(rider.run);
+        opened.push(rider);
+        await this.#ledger.commit(rider.run.generation, rider.run.runId, {
           status: BRAIN_REQUEST_STATUS.RUNNING,
           startedAt: this.#now(),
         });
       }
       if (riders.length > 0) this.#notify();
+      const question = askQuestion(opened);
       run.deadline = this.#schedule(() => {
         run.timedOut = true;
         run.abort.abort();

--- a/packages/brain/src/agent.ts
+++ b/packages/brain/src/agent.ts
@@ -886,8 +886,15 @@ export class BrainAgent {
       // Words still waiting for a turn are withdrawn before any turn composes
       // its question from them; words already steered were said to the model
       // and cannot be unsaid. The record keeps the ask as accepted either way.
-      this.#asks.withdraw(runId);
-      this.#summarized = this.#summarized.filter((input) => input.run.runId !== runId);
+      if (!this.#asks.withdraw(runId)) {
+        // The summarized list and the queue's summary are kept in one fold
+        // order, so the ask's place in one is its place in the other.
+        const folded = this.#summarized.findIndex((input) => input.run.runId === runId);
+        if (folded >= 0) {
+          this.#summarized.splice(folded, 1);
+          this.#asks.withdrawSummarized(folded);
+        }
+      }
       await this.#ledger.settleRun(this.#generation, runId, BRAIN_REQUEST_STATUS.CANCELLED, {});
     }
     return this.request(runId);

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -77,6 +77,7 @@ export {
   type QueueMode,
   type QueueOverflow,
   type QueueSettings,
+  queueSummaryLine,
   queueSummaryText,
 } from "./queue.js";
 export {

--- a/packages/runtime/src/queue.test.ts
+++ b/packages/runtime/src/queue.test.ts
@@ -178,3 +178,21 @@ test("clear forgets the queue and its timer", () => {
   clock.fire();
   assert.deepEqual(flushed, []);
 });
+
+test("withdraw takes one queued input back before the drain, and disarms the timer when nothing is left", () => {
+  const clock = fakeClock();
+  const { queue, flushed } = queueWith(clock, () => false, QUEUE_MODE.COLLECT);
+  queue.push(input("a"));
+  queue.push(input("b"));
+  assert.equal(queue.withdraw("a"), true);
+  assert.equal(queue.withdraw("a"), false);
+  assert.equal(queue.withdraw("never-queued"), false);
+  assert.equal(clock.timers.size, 1);
+  clock.fire();
+  assert.deepEqual(flushed, [["b"]]);
+  queue.push(input("c"));
+  assert.equal(clock.timers.size, 1);
+  assert.equal(queue.withdraw("c"), true);
+  assert.equal(clock.timers.size, 0);
+  assert.deepEqual(flushed, [["b"]]);
+});

--- a/packages/runtime/src/queue.test.ts
+++ b/packages/runtime/src/queue.test.ts
@@ -196,3 +196,56 @@ test("withdraw takes one queued input back before the drain, and disarms the tim
   assert.equal(clock.timers.size, 0);
   assert.deepEqual(flushed, [["b"]]);
 });
+
+test("a queue holding only folded asks still drains one turn for them, in follow-up as in collect", () => {
+  let state: PendingQueueState = EMPTY_QUEUE;
+  const settings = { capacity: 1, overflow: QUEUE_OVERFLOW.SUMMARIZE };
+  state = admitToQueue(state, input("a"), settings).state;
+  state = admitToQueue(state, input("b"), settings).state;
+  state = { ...state, entries: [] };
+  assert.equal(state.summarizedCount, 1);
+  for (const mode of [QUEUE_MODE.FOLLOWUP, QUEUE_MODE.COLLECT, QUEUE_MODE.STEER]) {
+    const batches = drainQueue(state, mode);
+    assert.equal(batches.length, 1);
+    assert.deepEqual(batches[0]?.inputs, []);
+    assert.ok(batches[0]?.summary?.includes("1 earlier input was summarized"));
+  }
+});
+
+test("withdrawing a folded ask by its place in the summary leaves the queue empty and disarmed when nothing else waits", () => {
+  const clock = fakeClock();
+  const flushed: string[][] = [];
+  const full = new PendingInputQueue({
+    settings: { mode: QUEUE_MODE.COLLECT, capacity: 1, overflow: QUEUE_OVERFLOW.SUMMARIZE },
+    steer: () => false,
+    interrupt: () => undefined,
+    flush: (batches) => {
+      for (const batch of batches) flushed.push(batch.inputs.map((entry) => entry.id));
+    },
+    schedule: (callback) => {
+      const id = clock.next++;
+      clock.timers.set(id, callback);
+      return id;
+    },
+    // SAFETY: every timer this test's clock hands out is the number it minted above.
+    cancel: (timer) => void clock.timers.delete(timer as number),
+  });
+  full.push(input("a"));
+  full.push(input("b"));
+  full.push(input("c"));
+  assert.equal(full.size, 3);
+  assert.equal(full.state.summaryLines.length, 2);
+  // The one entry withdrawn: the two folded asks still hold the turn and count as waiting.
+  assert.equal(full.withdraw("c"), true);
+  assert.equal(full.size, 2);
+  assert.equal(clock.timers.size, 1);
+  assert.equal(full.withdrawSummarized(5), false);
+  assert.equal(full.withdrawSummarized(0), true);
+  assert.equal(full.state.summarizedCount, 1);
+  assert.equal(full.withdrawSummarized(0), true);
+  assert.equal(full.size, 0);
+  assert.equal(clock.timers.size, 0);
+  assert.equal(full.withdrawSummarized(0), false);
+  clock.fire();
+  assert.deepEqual(flushed, []);
+});

--- a/packages/runtime/src/queue.ts
+++ b/packages/runtime/src/queue.ts
@@ -157,7 +157,7 @@ export interface QueueBatch {
 export function drainQueue(state: PendingQueueState, mode: QueueMode): readonly QueueBatch[] {
   if (state.entries.length === 0 && state.summarizedCount === 0) return [];
   const summary = queueSummaryText(state);
-  if (mode === QUEUE_MODE.FOLLOWUP) {
+  if (mode === QUEUE_MODE.FOLLOWUP && state.entries.length > 0) {
     return state.entries.map((input, index) => ({
       inputs: [input],
       ...(index === 0 && summary ? { summary } : undefined),
@@ -214,8 +214,9 @@ export class PendingInputQueue {
     return this.#state;
   }
 
+  /** How many asks wait here for a turn: the entries and the ones folded into the summary alike. */
   get size(): number {
-    return this.#state.entries.length;
+    return this.#state.entries.length + this.#state.summarizedCount;
   }
 
   /**
@@ -252,6 +253,23 @@ export class PendingInputQueue {
     if (entries.length === this.#state.entries.length) return false;
     this.#state = { ...this.#state, entries };
     if (entries.length === 0 && this.#state.summarizedCount === 0) this.#disarm();
+    return true;
+  }
+
+  /**
+   * Withdraws one input the overflow already folded, by its place in the
+   * summary (fold order, oldest first), so a summary whose asks were all
+   * taken back holds no turn open and counts nothing waiting.
+   */
+  withdrawSummarized(index: number): boolean {
+    const lines = this.#state.summaryLines;
+    if (!Number.isInteger(index) || index < 0 || index >= lines.length) return false;
+    this.#state = {
+      ...this.#state,
+      summaryLines: lines.filter((_, at) => at !== index),
+      summarizedCount: this.#state.summarizedCount - 1,
+    };
+    if (this.#state.entries.length === 0 && this.#state.summarizedCount === 0) this.#disarm();
     return true;
   }
 

--- a/packages/runtime/src/queue.ts
+++ b/packages/runtime/src/queue.ts
@@ -84,7 +84,8 @@ export interface QueueAdmission {
   readonly evicted: readonly QueuedInput[];
 }
 
-function summaryLine(input: QueuedInput): string {
+/** The one line an input folded by the overflow keeps: the head of its words, whitespace collapsed. */
+export function queueSummaryLine(input: QueuedInput): string {
   const head = input.text.replace(/\s+/g, " ").trim();
   return head.length > QUEUE_DEFAULTS.SUMMARY_HEAD_CHARS
     ? `${head.slice(0, QUEUE_DEFAULTS.SUMMARY_HEAD_CHARS)}…`
@@ -126,7 +127,7 @@ export function admitToQueue(
       return {
         state: {
           entries: [...rest, input],
-          summaryLines: [...state.summaryLines, summaryLine(oldest)],
+          summaryLines: [...state.summaryLines, queueSummaryLine(oldest)],
           summarizedCount: state.summarizedCount + 1,
         },
         admitted: true,
@@ -239,6 +240,19 @@ export class PendingInputQueue {
   /** Drains everything now, in the mode given; a caller uses it when a run ends with input waiting. */
   flush(mode: QueueMode = this.#settings.mode): void {
     this.#flushNow(mode);
+  }
+
+  /**
+   * Withdraws one queued input before it is drained, so words the developer
+   * took back never open a turn. Answers whether it was still waiting here;
+   * an input already steered or drained is past withdrawing.
+   */
+  withdraw(id: string): boolean {
+    const entries = this.#state.entries.filter((entry) => entry.id !== id);
+    if (entries.length === this.#state.entries.length) return false;
+    this.#state = { ...this.#state, entries };
+    if (entries.length === 0 && this.#state.summarizedCount === 0) this.#disarm();
+    return true;
   }
 
   /** Forgets everything queued; the timer goes with it. */


### PR DESCRIPTION
Cancelling an ask before its turn now removes its unsent text from collected and overflow-summarized model input while preserving its accepted History record. Follow-up to #751; two commits over PR5 squash `0e1ed0b`.

## What changed

**Queued cancellation now withdraws unsent model input.** A drained batch used to join every queued ask's text into one question before the turn filtered out runs that could no longer open, so an ask cancelled while it waited still reached the model inside the surviving asks' question. Now:

- Each ask travels to its turn with its own words (`AskInput`), and the question is composed when the turn opens, only from the asks that actually open it: the overflow summary from the folded asks still standing, then each remaining ask's text.
- `cancelAsk` on a queued record also withdraws the input from `PendingInputQueue` (new `withdraw`) and drops it from the summarized list, so the drain never carries it.
- The accepted record is unchanged: the developer's words stay on it uncut, status cancelled, no reply. Words already steered into a running turn were said to the model and cannot be unsaid, exactly as before.
- A queue holding only overflow-folded asks still opens one summary-only turn, including in follow-up mode. Folded asks count as waiting; cancelling all of them clears the summary and timer. No UI changes.

**Restart unchanged-look suppression: no code change, by disposition.** After a relaunch the memory-only look fingerprint is empty while the persisted capture cursor stands, so each live session's first roster look is captured with an empty delta and runs one inference. That is bounded to one inference per live session per launch and is a legitimate first observation: suppressing on "cursor exists, delta empty" would hide a status that changed while Luke was closed, and a persisted fingerprint would add schema for no correctness gain. The fingerprint's doc comment now names this boundary. Thread: PRRT_kwDOT0q88c6gWUKm.

## Tests

- runtime `queue.test.ts`: `withdraw` takes one input back, refuses one not queued, and disarms the timer when nothing is left.
- brain `agent.test.ts`: three regressions asserting a unique cancelled marker is absent from model input while the other asks still run and are answered: a collected ask cancelled before the window closes (also the case where the primary is left alone); an overflow-summarized ask cancelled before the drain (summary disappears when it was the only fold, and names only the standing fold otherwise); an ask already drained but waiting behind another gated turn.

Validation at `5eee327`: `./scripts/check.sh` passes (runtime 42/42, brain agent 102/102); required TypeScript and macOS app/evidence CI pass in run 34262276846. Added regressions cover a surviving summary-only ask and cancellation of every ordinary and folded ask. All six fixture PNGs are byte-identical to PR6. Physical Mac `./scripts/verify.sh` passed at the earlier, tree-equivalent first-commit head `0987995`; the final summary-only correction is covered by final-head CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/867f8a6f-54ab-4c8e-926d-45faf04e3bba)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34262276846/artifacts/10070504434) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34262276846)

- Commit: `5eee327cfa9e01036b533f8c2334bfe8d8f543ac`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

