### PR TITLE
feat(history): date the thread over long silences the way iMessage does

### DIFF
--- a/apps/desktop/src/renderer/conversation-history-panel.test.ts
+++ b/apps/desktop/src/renderer/conversation-history-panel.test.ts
@@ -10,6 +10,10 @@ import {
   historyEntryPresentation,
 } from "./conversation-history-panel";
 
+const NOW = Date.parse("2026-09-08T17:30:00.000Z");
+const HOUR_MS = 60 * 60_000;
+const DAY_MS = 24 * HOUR_MS;
+
 test("conversation asks are shown as the developer's own words", () => {
   assert.deepEqual(historyEntryPresentation(CONVERSATION_ENTRY_KIND.TYPED_ASK), {
     speaker: HISTORY_ENTRY_SPEAKER.YOU,
@@ -55,6 +59,7 @@ test("an announcement shows its spoken transcript", () => {
           words: "Checkout is ready.",
         },
       ],
+      now: NOW,
       onClear: () => undefined,
       ask: async () => undefined,
       onAskEngaged: () => undefined,
@@ -74,6 +79,7 @@ test("a reply keeps its lines through the thread and draws as the Markdown it wa
   const markup = renderToStaticMarkup(
     createElement(ConversationHistoryPanel, {
       entries,
+      now: NOW,
       onClear: () => undefined,
       ask: async () => undefined,
       onAskEngaged: () => undefined,
@@ -96,6 +102,7 @@ test("a recorded entry keeps its local time at the row's edge, outside the bubbl
           recordedAt: Date.parse("2026-01-02T03:04:00.000Z"),
         },
       ],
+      now: NOW,
       onClear: () => undefined,
       ask: async () => undefined,
       onAskEngaged: () => undefined,
@@ -119,6 +126,7 @@ test("conversation history is blocked from optional panel recordings", () => {
   const markup = renderToStaticMarkup(
     createElement(ConversationHistoryPanel, {
       entries: [{ kind: CONVERSATION_ENTRY_KIND.TYPED_ASK, words: "private words" }],
+      now: NOW,
       onClear: () => undefined,
       ask: async () => undefined,
       onAskEngaged: () => undefined,
@@ -138,6 +146,7 @@ test("messages offer a copy control while quiet events offer none", () => {
         { kind: CONVERSATION_ENTRY_KIND.REPLY, words: "Shipping." },
         { kind: CONVERSATION_ENTRY_KIND.ACT, words: "Sent to Codex." },
       ],
+      now: NOW,
       onClear: () => undefined,
       ask: async () => undefined,
       onAskEngaged: () => undefined,
@@ -160,6 +169,7 @@ test("a line still being said draws as the bubble it will settle into", () => {
         },
       ],
       live: [{ kind: CONVERSATION_ENTRY_KIND.ANNOUNCEMENT, words: "Checkout is" }],
+      now: NOW,
       onClear: () => undefined,
       ask: async () => undefined,
       onAskEngaged: () => undefined,
@@ -179,6 +189,7 @@ test("words still arriving stand the thread up without a settled line", () => {
     createElement(ConversationHistoryPanel, {
       entries: [],
       live: [{ kind: CONVERSATION_ENTRY_KIND.REPLY, words: "Looking now." }],
+      now: NOW,
       onClear: () => undefined,
       ask: async () => undefined,
       onAskEngaged: () => undefined,
@@ -195,6 +206,7 @@ test("the empty history reports only its state", () => {
   const markup = renderToStaticMarkup(
     createElement(ConversationHistoryPanel, {
       entries: [],
+      now: NOW,
       onClear: () => undefined,
       ask: async () => undefined,
       onAskEngaged: () => undefined,
@@ -209,6 +221,7 @@ test("the composer stands at the foot of the thread, empty or not", () => {
   const empty = renderToStaticMarkup(
     createElement(ConversationHistoryPanel, {
       entries: [],
+      now: NOW,
       onClear: () => undefined,
       ask: async () => undefined,
       onAskEngaged: () => undefined,
@@ -221,6 +234,7 @@ test("the composer stands at the foot of the thread, empty or not", () => {
   const threaded = renderToStaticMarkup(
     createElement(ConversationHistoryPanel, {
       entries: [{ kind: CONVERSATION_ENTRY_KIND.TYPED_ASK, words: "ship it" }],
+      now: NOW,
       onClear: () => undefined,
       ask: async () => undefined,
       onAskEngaged: () => undefined,
@@ -253,6 +267,7 @@ test("an ask whose run is still going waits beside its words and offers a cancel
         ],
         requests: [{ ...run, status }],
         onCancelRequest: (runId) => cancelled.push(runId),
+        now: NOW,
         onClear: () => undefined,
         ask: async () => undefined,
         onAskEngaged: () => undefined,
@@ -274,10 +289,85 @@ test("an ask whose run is still going waits beside its words and offers a cancel
       entries: [{ kind: CONVERSATION_ENTRY_KIND.SPOKEN_ASK, words: "ship it", requestId: "run-1" }],
       requests: [{ ...run, origin: "spoken", status: "running" }],
       onCancelRequest: (runId) => cancelled.push(runId),
+      now: NOW,
       onClear: () => undefined,
       ask: async () => undefined,
       onAskEngaged: () => undefined,
     }),
   );
   assert.match(spoken, /class="history-cancel"/);
+});
+
+test("a line that followed a long silence is dated over it, in the quiet event voice", () => {
+  const markup = renderToStaticMarkup(
+    createElement(ConversationHistoryPanel, {
+      entries: [
+        { kind: CONVERSATION_ENTRY_KIND.TYPED_ASK, words: "ship it", recordedAt: NOW - 9 * DAY_MS },
+        { kind: CONVERSATION_ENTRY_KIND.REPLY, words: "Shipping.", recordedAt: NOW - 9 * DAY_MS },
+        {
+          kind: CONVERSATION_ENTRY_KIND.ACT,
+          words: "Sent to Codex.",
+          recordedAt: NOW - 2 * DAY_MS,
+        },
+        {
+          kind: CONVERSATION_ENTRY_KIND.TYPED_ASK,
+          words: "status?",
+          recordedAt: NOW - HOUR_MS / 2,
+        },
+        { kind: CONVERSATION_ENTRY_KIND.REPLY, words: "Quiet.", recordedAt: NOW - HOUR_MS / 4 },
+      ],
+      now: NOW,
+      onClear: () => undefined,
+      ask: async () => undefined,
+      onAskEngaged: () => undefined,
+    }),
+  );
+
+  // The first recorded line is dated, then every line an hour or more after
+  // the one before it; a reply half an hour on answers the ask and draws none.
+  const breaks = [...markup.matchAll(/<li class="history-break">/g)];
+  assert.equal(breaks.length, 3);
+  assert.ok(markup.indexOf('<li class="history-break">') < markup.indexOf("history-entry"));
+  const dates = [...markup.matchAll(/dateTime="([^"]+)"[^>]*><strong>([^<]+)<\/strong>/g)].map(
+    (match) => [match[1], match[2]],
+  );
+  assert.deepEqual(dates, [
+    [
+      new Date(NOW - 9 * DAY_MS).toISOString(),
+      new Date(NOW - 9 * DAY_MS).toLocaleDateString(undefined, {
+        weekday: "short",
+        month: "short",
+        day: "numeric",
+      }),
+    ],
+    [
+      new Date(NOW - 2 * DAY_MS).toISOString(),
+      new Date(NOW - 2 * DAY_MS).toLocaleDateString(undefined, { weekday: "long" }),
+    ],
+    [new Date(NOW - HOUR_MS / 2).toISOString(), "Today"],
+  ]);
+  // The date is the thread's own line, never a message: no bubble, no copy control.
+  assert.match(
+    markup,
+    /<li class="history-break"><time class="history-break-time" dateTime="[^"]+"><strong>/,
+  );
+  assert.equal(markup.match(/class="history-copy"/g)?.length, 4);
+});
+
+test("lines with no stamp draw no date over them", () => {
+  const markup = renderToStaticMarkup(
+    createElement(ConversationHistoryPanel, {
+      entries: [
+        { kind: CONVERSATION_ENTRY_KIND.TYPED_ASK, words: "ship it" },
+        { kind: CONVERSATION_ENTRY_KIND.REPLY, words: "Shipping." },
+      ],
+      live: [{ kind: CONVERSATION_ENTRY_KIND.REPLY, words: "Still" }],
+      now: NOW,
+      onClear: () => undefined,
+      ask: async () => undefined,
+      onAskEngaged: () => undefined,
+    }),
+  );
+
+  assert.doesNotMatch(markup, /history-break/);
 });

--- a/apps/desktop/src/renderer/conversation-history-panel.tsx
+++ b/apps/desktop/src/renderer/conversation-history-panel.tsx
@@ -7,6 +7,7 @@ import {
 import { useEffect, useRef, useState } from "react";
 import { type BrainRequestSnapshot, brainRequestPending } from "#shared/wire/brain";
 import { type AskHandler, AskLuke } from "./ask-luke";
+import { createHistoryTimeBreakFormatter, opensHistoryTimeBreak } from "./history-time-break";
 import { MarkdownMessage } from "./markdown-message";
 import { PANEL_TAB, panelPanelId, panelTabId } from "./panel-tabs";
 import { CheckIcon, CopyIcon } from "./settings-icons";
@@ -44,6 +45,8 @@ export function historyEntryPresentation(kind: ConversationEntryKind): HistoryEn
 const COPY_CONFIRMATION_MS = 1500;
 
 const ENTRY_TIME = new Intl.DateTimeFormat(undefined, { hour: "numeric", minute: "2-digit" });
+
+const timeBreakLabel = createHistoryTimeBreakFormatter();
 
 /** What History says under an ask whose run has not ended yet. */
 export const HISTORY_PENDING_LABEL = "Luke is working on this…";
@@ -125,14 +128,36 @@ function HistoryEntryRow({
   );
 }
 
+/**
+ * The moment a line was said, set over it the way iMessage dates a message
+ * that followed a long silence. It is the thread's line, not a message: it
+ * reads in the quiet voice the requested acts use, and it stands still under
+ * the pull like Luke's rows do, so uncovering the stamp column never pushes
+ * a date off the screen.
+ */
+function HistoryTimeBreak({ recordedAt, now }: { recordedAt: number; now: number }) {
+  const at = new Date(recordedAt);
+  const label = timeBreakLabel(recordedAt, now);
+  return (
+    <li className="history-break">
+      <time className="history-break-time" dateTime={at.toISOString()}>
+        <strong>{label.day}</strong> {label.time}
+      </time>
+    </li>
+  );
+}
+
 /** Stable enough for repeated identical lines without pretending the record has durable ids. */
 function keyedHistoryEntries(entries: readonly ConversationEntry[]) {
   const occurrences = new Map<string, number>();
+  let previousRecordedAt: number | undefined;
   return entries.map((entry) => {
     const base = conversationEntryKey(entry);
     const occurrence = (occurrences.get(base) ?? 0) + 1;
     occurrences.set(base, occurrence);
-    return { entry, key: `${base}:${occurrence}` };
+    const opensBreak = opensHistoryTimeBreak(previousRecordedAt, entry.recordedAt);
+    if (entry.recordedAt !== undefined) previousRecordedAt = entry.recordedAt;
+    return { entry, key: `${base}:${occurrence}`, opensBreak };
   });
 }
 
@@ -155,6 +180,7 @@ export function ConversationHistoryPanel({
   entries,
   live = [],
   requests = [],
+  now,
   onCancelRequest,
   onClear,
   ask,
@@ -162,6 +188,12 @@ export function ConversationHistoryPanel({
   askShortcut,
 }: {
   entries: readonly ConversationEntry[];
+  /**
+   * The instant the thread's dates are read against, so a line from earlier
+   * today says Today and one from last week says which day. Passed down like
+   * the rows' ages are, because only the app knows which clock is honest.
+   */
+  now: number;
   /**
    * The brain's runs, so an ask whose run is still going is drawn waiting,
    * with the cancel the developer holds. Read here from the records alone;
@@ -257,14 +289,14 @@ export function ConversationHistoryPanel({
               moment the fingers lift, which only the browser can see. */}
           <div className="history-pull">
             <ol className="history-list">
-              {keyedHistoryEntries(entries).map(({ entry, key }) => {
+              {keyedHistoryEntries(entries).flatMap(({ entry, key, opensBreak }) => {
                 const runId = entry.requestId;
                 const pending =
                   runId !== undefined &&
                   (entry.kind === CONVERSATION_ENTRY_KIND.TYPED_ASK ||
                     entry.kind === CONVERSATION_ENTRY_KIND.SPOKEN_ASK) &&
                   pendingRuns.has(runId);
-                return (
+                const row = (
                   <HistoryEntryRow
                     key={key}
                     entry={entry}
@@ -274,6 +306,16 @@ export function ConversationHistoryPanel({
                       : undefined)}
                   />
                 );
+                return opensBreak && entry.recordedAt !== undefined
+                  ? [
+                      <HistoryTimeBreak
+                        key={`${key}:break`}
+                        recordedAt={entry.recordedAt}
+                        now={now}
+                      />,
+                      row,
+                    ]
+                  : [row];
               })}
               {live.map((entry, index) => (
                 <HistoryEntryRow

--- a/apps/desktop/src/renderer/history-time-break.test.ts
+++ b/apps/desktop/src/renderer/history-time-break.test.ts
@@ -1,0 +1,55 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  createHistoryTimeBreakFormatter,
+  HISTORY_TIME_BREAK_MS,
+  opensHistoryTimeBreak,
+} from "./history-time-break";
+
+const NOW = Date.parse("2026-09-08T17:30:00.000Z");
+const MINUTE_MS = 60_000;
+const DAY_MS = 24 * 60 * MINUTE_MS;
+
+test("the first recorded line opens a break, and a silence of an hour opens the next", () => {
+  assert.equal(opensHistoryTimeBreak(undefined, NOW), true);
+  assert.equal(opensHistoryTimeBreak(NOW, NOW + 59 * MINUTE_MS), false);
+  assert.equal(opensHistoryTimeBreak(NOW, NOW + HISTORY_TIME_BREAK_MS), true);
+  assert.equal(opensHistoryTimeBreak(NOW, NOW + DAY_MS), true);
+});
+
+test("a line with no stamp opens no break", () => {
+  assert.equal(opensHistoryTimeBreak(undefined, undefined), false);
+  assert.equal(opensHistoryTimeBreak(NOW, undefined), false);
+});
+
+const label = createHistoryTimeBreakFormatter({ locale: "en-US", timeZone: "America/Los_Angeles" });
+
+test("a line from today is named by its time alone under Today", () => {
+  assert.deepEqual(label(NOW - 3 * 60 * MINUTE_MS, NOW), { day: "Today", time: "7:30 AM" });
+});
+
+test("the calendar day is read in the reader's zone, not UTC", () => {
+  // 03:00 UTC on the 8th is still the evening of the 7th in Los Angeles.
+  assert.deepEqual(label(Date.parse("2026-09-08T03:00:00.000Z"), NOW), {
+    day: "Yesterday",
+    time: "8:00 PM",
+  });
+});
+
+test("the past week's days are named by weekday, and a week on by date", () => {
+  assert.equal(label(NOW - 2 * DAY_MS, NOW).day, "Sunday");
+  assert.equal(label(NOW - 6 * DAY_MS, NOW).day, "Wednesday");
+  assert.equal(label(NOW - 7 * DAY_MS, NOW).day, "Tue, Sep 1");
+  assert.equal(label(NOW - 14 * DAY_MS, NOW).day, "Tue, Aug 25");
+});
+
+test("a line from another year carries the year", () => {
+  assert.deepEqual(label(Date.parse("2025-12-31T20:15:00.000Z"), NOW), {
+    day: "Dec 31, 2025",
+    time: "12:15 PM",
+  });
+});
+
+test("a stamp ahead of the clock is dated rather than called Today", () => {
+  assert.equal(label(NOW + 2 * DAY_MS, NOW).day, "Thu, Sep 10");
+});

--- a/apps/desktop/src/renderer/history-time-break.ts
+++ b/apps/desktop/src/renderer/history-time-break.ts
@@ -1,0 +1,105 @@
+/**
+ * How long a silence between two recorded lines has to be before the thread
+ * names the moment the next one was said, the way iMessage sets a date over
+ * a message that followed a long break. An hour is iMessage's own threshold:
+ * closer than that, a message answers the one before it, and the row's own
+ * stamp in the pull column is enough.
+ */
+export const HISTORY_TIME_BREAK_MS = 60 * 60_000;
+
+const DAY_MS = 24 * 60 * 60_000;
+
+/** The past week's weekdays are unambiguous by name; a week on they are not. */
+const WEEKDAY_NAME_DAYS = 7;
+
+/**
+ * Whether the line recorded at `recordedAt` opens a break: the thread's first
+ * recorded line always does, since the date of what the reader is looking at
+ * is the whole question, and a later one does when the silence before it
+ * reached the threshold. A line with no stamp neither opens a break nor
+ * stands as the one before the next.
+ */
+export function opensHistoryTimeBreak(
+  previousRecordedAt: number | undefined,
+  recordedAt: number | undefined,
+): boolean {
+  if (recordedAt === undefined) return false;
+  if (previousRecordedAt === undefined) return true;
+  return recordedAt - previousRecordedAt >= HISTORY_TIME_BREAK_MS;
+}
+
+export interface HistoryTimeBreakLabel {
+  /** The day, as a reader would name it: Today, Yesterday, a weekday, or a date. */
+  day: string;
+  /** The clock time on that day. */
+  time: string;
+}
+
+export interface HistoryTimeBreakFormatterOptions {
+  locale?: string;
+  timeZone?: string;
+}
+
+/**
+ * Names the moment a break's line was said, read against `now`. The day is
+ * relative only while relative is exact — Today, Yesterday, then the weekday
+ * for the rest of the past week — and a date after that, with the year once
+ * the year is not this one, because the thread exists to say what date an
+ * old line is from and a bare weekday a fortnight on says nothing.
+ */
+export function createHistoryTimeBreakFormatter({
+  locale,
+  timeZone,
+}: HistoryTimeBreakFormatterOptions = {}): (
+  recordedAt: number,
+  now: number,
+) => HistoryTimeBreakLabel {
+  const zone = timeZone === undefined ? {} : { timeZone };
+  const calendar = new Intl.DateTimeFormat("en-US", {
+    ...zone,
+    year: "numeric",
+    month: "numeric",
+    day: "numeric",
+  });
+  const time = new Intl.DateTimeFormat(locale, { ...zone, hour: "numeric", minute: "2-digit" });
+  const weekday = new Intl.DateTimeFormat(locale, { ...zone, weekday: "long" });
+  const dateThisYear = new Intl.DateTimeFormat(locale, {
+    ...zone,
+    weekday: "short",
+    month: "short",
+    day: "numeric",
+  });
+  const datedYear = new Intl.DateTimeFormat(locale, {
+    ...zone,
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+
+  const calendarDay = (at: Date) => {
+    const parts = new Map(calendar.formatToParts(at).map((part) => [part.type, part.value]));
+    const year = Number(parts.get("year"));
+    return {
+      year,
+      ordinal: Date.UTC(year, Number(parts.get("month")) - 1, Number(parts.get("day"))) / DAY_MS,
+    };
+  };
+
+  return (recordedAt, now) => {
+    const at = new Date(recordedAt);
+    const said = calendarDay(at);
+    const today = calendarDay(new Date(now));
+    const daysAgo = today.ordinal - said.ordinal;
+    const day =
+      daysAgo === 0
+        ? "Today"
+        : daysAgo === 1
+          ? "Yesterday"
+          : daysAgo > 1 && daysAgo < WEEKDAY_NAME_DAYS
+            ? weekday.format(at)
+            : said.year === today.year
+              ? dateThisYear.format(at)
+              : datedYear.format(at);
+    return { day, time: time.format(at) };
+  };
+}

--- a/apps/desktop/src/renderer/panel-body.tsx
+++ b/apps/desktop/src/renderer/panel-body.tsx
@@ -699,6 +699,7 @@ export function PanelBody({
           entries={conversationHistory}
           live={liveConversationEntries}
           requests={brainRequests}
+          now={now}
           onCancelRequest={onCancelBrainRequest}
           onClear={onClearConversationHistory}
           ask={ask}

--- a/apps/desktop/src/renderer/styles/history.css
+++ b/apps/desktop/src/renderer/styles/history.css
@@ -308,14 +308,17 @@
   display: flex;
   width: 100%;
   flex: 0 0 auto;
-  justify-content: center;
-  padding: 10px 12px 4px;
 }
 
+/* The label starts at the view's left edge, exactly as Luke's rows do, and
+   centers its words within itself: a label centered by its row instead would
+   begin half a column in, and the pull would carry it that far before sticky
+   could take hold. */
 .history-break-time {
   position: sticky;
   left: 0;
   width: calc(100% - var(--history-time-column));
+  padding: 10px 12px 4px;
   color: var(--text-secondary);
   font-size: 10.5px;
   font-variant-numeric: tabular-nums;
@@ -329,7 +332,7 @@
 }
 
 /* The thread's first date needs no pause above it. */
-.history-list > .history-break:first-child {
+.history-list > .history-break:first-child .history-break-time {
   padding-top: 2px;
 }
 

--- a/apps/desktop/src/renderer/styles/history.css
+++ b/apps/desktop/src/renderer/styles/history.css
@@ -299,6 +299,40 @@
   line-height: 1.4;
 }
 
+/* The date over a line that followed a long silence, in the quiet voice the
+   requested acts use, with the day set apart from the time the way iMessage
+   sets it. It stands still under the pull as Luke's rows do, in the room the
+   view has before the stamp column, so a swipe that uncovers the times never
+   pushes a date off the screen. */
+.history-break {
+  display: flex;
+  width: 100%;
+  flex: 0 0 auto;
+  justify-content: center;
+  padding: 10px 12px 4px;
+}
+
+.history-break-time {
+  position: sticky;
+  left: 0;
+  width: calc(100% - var(--history-time-column));
+  color: var(--text-secondary);
+  font-size: 10.5px;
+  font-variant-numeric: tabular-nums;
+  line-height: 1.4;
+  text-align: center;
+}
+
+.history-break-time strong {
+  color: var(--text-secondary);
+  font-weight: 620;
+}
+
+/* The thread's first date needs no pause above it. */
+.history-list > .history-break:first-child {
+  padding-top: 2px;
+}
+
 /* Consecutive bubbles stay conversationally tight. A speaker change gets the
    small pause chat apps use instead of repeating names above every message. */
 .history-entry[data-speaker="you"] + .history-entry[data-speaker="luke"],


### PR DESCRIPTION
## Summary

The History tab keeps a fortnight of lines, and a line's own stamp in the pull column says only its clock time, so there was no way to tell what **date** an old message was from. This adds iMessage-style date separators to the thread.

**UX**

- A date is set over the thread's first recorded line, and over every line that followed a silence of an hour or more (iMessage's own threshold). Lines closer together than that are answers to each other and draw none.
- The label is relative only while relative is exact, and always carries a date once it isn't today: **Today** 2:14 PM, **Yesterday** 9:03 AM, **Sunday** 4:10 PM for the rest of the past week, then **Tue, Sep 1** 3:00 PM, and **Dec 31, 2025** 12:15 PM once the year is not this one. The day is bold and the time regular, as iMessage sets it.
- Styled in the quiet centered voice the requested-act ("At your request") lines already use: `--text-secondary`, 10.5px, centered, tabular numerals.
- It stands still under the pull like Luke's rows do (sticky at the view's left edge, sized to the view minus the stamp column), so swiping the stamp column in never pushes a date off screen.
- Calendar day is computed in the reader's own time zone, not UTC, and the date is read against the same `now` the session rows' ages use, so a fixture run stays fixed to its epoch and the existing 30s clock tick keeps "Today" honest across midnight.
- Lines with no stamp (legacy or still streaming) draw no date and don't reset the silence.

The per-row time stamp in the pull column is unchanged; the separators complement it the way iMessage does both.

**Files**

- `apps/desktop/src/renderer/history-time-break.ts` — pure break/label logic (`opensHistoryTimeBreak`, `createHistoryTimeBreakFormatter`)
- `apps/desktop/src/renderer/conversation-history-panel.tsx` — `HistoryTimeBreak` row, `now` prop
- `apps/desktop/src/renderer/styles/history.css` — `.history-break` styling
- `apps/desktop/src/renderer/panel-body.tsx` — passes the app's `now` down

## Test plan

- [x] `./scripts/check.sh` equivalent on Linux: Biome clean, `pnpm typecheck` clean, desktop suite 959/959 passing (one unrelated native microphone-route test flaked once under the parallel run and passes in isolation and on rerun), `pnpm build` succeeds
- [x] New unit tests cover the hour threshold, first-line break, unstamped lines, time-zone-correct day boundaries, weekday vs. dated labels, other-year labels, and future stamps
- [x] Panel markup tests cover break placement, count, label content, and that a break is the thread's own line with no bubble or copy control
- [ ] Visual check on macOS (`./scripts/verify.sh`): this branch was authored in a Linux sandbox, so no capture was taken and no physical-notch check was performed. The fixture thread has no History lines, so the fixture PNG is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/9bd134d6-a0cc-44cb-a8dd-7b7f8a6c8ce7)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34261331332/artifacts/10070125644) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34261331332)

- Commit: `e51ff8d9a07667fec7f1c83382851ffb8ff4f2f5`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
