### PR TITLE
fix(desktop): leave a closing conversation to its close, and reopen only after it

### DIFF
--- a/apps/desktop/src/main/brain/wiring-routing.test.ts
+++ b/apps/desktop/src/main/brain/wiring-routing.test.ts
@@ -24,6 +24,7 @@ import {
   observedSessionKey,
   observedSessionRefOf,
   type SessionKey,
+  threadSessionKey,
 } from "@sidecar/runtime-contracts";
 import {
   normalizeSession,
@@ -127,6 +128,10 @@ interface Composed {
   recorded: { sessionKey: SessionKey; kind: string }[];
   /** How many stores were built per conversation. */
   repositories: Map<SessionKey, number>;
+  /** How many writes each conversation's envelope took. */
+  writes: Map<SessionKey, number>;
+  /** How many times the credential was resolved: once at construction, then once per brain built. */
+  builds: () => number;
 }
 
 interface Gate {
@@ -158,12 +163,14 @@ function composed(gate?: Gate): Composed {
   const model = bareModelAdapter(client);
   const storages = new Map<SessionKey, MemoryStorage>();
   const repositories = new Map<SessionKey, number>();
+  const writes = new Map<SessionKey, number>();
   const ensured: Composed["ensured"] = [];
   const deliveries: BrainDelivery[] = [];
   const reads: SessionIdentity[] = [];
   const recorded: Composed["recorded"] = [];
   const roster: Session[] = [session("abc"), session("def")];
   let ids = 0;
+  let builds = 0;
   const workspace = fs.mkdtempSync(path.join(os.tmpdir(), "luke-wiring-"));
   const wiring = wireBrain({
     repositoryFor: (sessionKey) => {
@@ -173,7 +180,14 @@ function composed(gate?: Gate): Composed {
         storage = new MemoryStorage();
         storages.set(sessionKey, storage);
       }
-      return brainStateRepositoryFromStorage(storage);
+      const repository = brainStateRepositoryFromStorage(storage);
+      return {
+        load: () => repository.load(),
+        save: (state, transcript) => {
+          writes.set(sessionKey, (writes.get(sessionKey) ?? 0) + 1);
+          return repository.save(state, transcript);
+        },
+      };
     },
     ensureObservedConversation: async (sessionKey, name) => {
       ensured.push({ sessionKey, name });
@@ -233,13 +247,27 @@ function composed(gate?: Gate): Composed {
       deliveries.push(delivery);
     },
     model: () => model,
-    credential: () => ({ kind: CREDENTIAL_REFERENCE_KIND.PROVIDER_KEY, providerId: "openai" }),
+    credential: () => {
+      builds += 1;
+      return { kind: CREDENTIAL_REFERENCE_KIND.PROVIDER_KEY, providerId: "openai" };
+    },
     workspaceDirectory: () => workspace,
     skillRoots: () => [],
     runnable: () => true,
     dropBriefings: () => undefined,
   });
-  return { wiring, inputs, ensured, deliveries, reads, roster, recorded, repositories };
+  return {
+    wiring,
+    inputs,
+    ensured,
+    deliveries,
+    reads,
+    roster,
+    recorded,
+    repositories,
+    writes,
+    builds: () => builds,
+  };
 }
 
 test("a roster look opens one conversation per observed session, each reading only its own transcript, and main reads notices instead", async () => {
@@ -436,6 +464,65 @@ test("a hook for a session whose conversation is standing down waits for the clo
   // first was let go of before the second was opened.
   assert.ok(c.wiring.current(abcKey));
   assert.equal(c.repositories.get(abcKey), 2);
+  c.wiring.retire();
+  await c.wiring.rebuild();
+});
+
+test("a rebuild landing while a conversation stands down leaves the closing host to its close, and the reopen owns the sole store", async () => {
+  const c = composed();
+  await c.wiring.rebuild();
+  const abcKey = observedSessionKey(ABC);
+  c.wiring.rosterLook();
+  await until(() => c.wiring.pendingNotices().length === 2);
+  await until(() => !(c.wiring.current(abcKey)?.busy() ?? true));
+  assert.equal(c.repositories.get(abcKey), 1);
+  const writesBefore = c.writes.get(abcKey) ?? 0;
+  const buildsBefore = c.builds();
+  // The close has begun and is awaiting its drain when the rebuild lands in
+  // the same tick: the interleave is fixed by construction, not by timing.
+  const closing = c.wiring.closeConversation(abcKey);
+  await c.wiring.rebuild();
+  await closing;
+  assert.equal(c.wiring.current(abcKey), undefined);
+  // The rebuild built main's brain and def's, and nothing onto the host the
+  // close was about to discard, where no retire could ever reach it; the
+  // first envelope took no write after its conversation stood down.
+  await settle();
+  assert.equal(c.builds() - buildsBefore, 2);
+  assert.equal(c.writes.get(abcKey) ?? 0, writesBefore);
+  // Reopened for a hook, the session's conversation stands on a second store
+  // built after the first was let go, and it is the only one.
+  c.wiring.wake([
+    {
+      kind: BRAIN_WAKE_KIND.HOOK,
+      hookEvent: "Stop",
+      identity: ABC,
+      session: session("abc"),
+      atMs: 2,
+    },
+  ]);
+  await until(() => c.wiring.pendingNotices().length === 3);
+  assert.ok(c.wiring.current(abcKey));
+  assert.equal(c.repositories.get(abcKey), 2);
+  c.wiring.retire();
+  await c.wiring.rebuild();
+});
+
+test("a conversation reopened while it stands down waits for the close and stands on its own new store", async () => {
+  const c = composed();
+  await c.wiring.rebuild();
+  const threadKey = threadSessionKey("t-1");
+  await c.wiring.openConversation(threadKey);
+  assert.ok(c.wiring.current(threadKey));
+  assert.equal(c.repositories.get(threadKey), 1);
+  // Archive then unarchive before the close has drained.
+  const closing = c.wiring.closeConversation(threadKey);
+  const reopening = c.wiring.openConversation(threadKey);
+  await Promise.all([closing, reopening]);
+  // The reopen built on nothing the close discards: its brain stands in the
+  // directory, on the second store, and the first is gone.
+  assert.ok(c.wiring.current(threadKey));
+  assert.equal(c.repositories.get(threadKey), 2);
   c.wiring.retire();
   await c.wiring.rebuild();
 });

--- a/apps/desktop/src/main/brain/wiring.ts
+++ b/apps/desktop/src/main/brain/wiring.ts
@@ -582,15 +582,22 @@ export function wireBrain(dependencies: BrainWiringDependencies): BrainWiring {
       );
     });
 
+  // Conversations standing down, until their store is let go.
+  const closings = new Map<SessionKey, Promise<void>>();
   const rebuild = async (): Promise<void> => {
     const model = liveModel();
     // Main's conversation is opened the moment a brain may stand on it, and
     // not before: a launch with nothing to run leaves the store untouched.
     if (model) openConversation(MAIN_SESSION_KEY);
+    // A conversation standing down is left to its close: a rebuild landing
+    // while its drain is awaited would be the newer transition, and would
+    // install a live agent on a host the close is about to drop from the
+    // directory, where nothing could ever retire it. The reopen that follows
+    // the close builds on the model then standing.
     await Promise.all(
-      [...conversations.entries()].map(([sessionKey, opened]) =>
-        rebuildOne(sessionKey, opened, model),
-      ),
+      [...conversations.entries()]
+        .filter(([sessionKey]) => !closings.has(sessionKey))
+        .map(([sessionKey, opened]) => rebuildOne(sessionKey, opened, model)),
     );
   };
 
@@ -605,8 +612,6 @@ export function wireBrain(dependencies: BrainWiringDependencies): BrainWiring {
    * one conversation, not two.
    */
   const observedOpenings = new Map<SessionKey, Promise<BrainAgent | undefined>>();
-  // Conversations standing down, until their store is let go.
-  const closings = new Map<SessionKey, Promise<void>>();
   const openObserved = (identity: SessionIdentity): Promise<BrainAgent | undefined> => {
     const sessionKey = observedSessionKey(identity);
     const standing = conversations.get(sessionKey)?.host.current();
@@ -778,6 +783,10 @@ export function wireBrain(dependencies: BrainWiringDependencies): BrainWiring {
     rebuild,
     retire,
     openConversation: async (sessionKey) => {
+      // The same wait an observed opening keeps: a conversation still
+      // standing down is let go of before it is opened again, so the reopen
+      // never builds onto the host the close will discard.
+      await closings.get(sessionKey);
       const opened = openConversation(sessionKey);
       if (!opened.host.current()) await rebuildOne(sessionKey, opened, liveModel());
     },


### PR DESCRIPTION
Follow-up to #751, scoped to the rebuild-versus-close lifecycle race raised in review thread PRRT_kwDOT0q88c6gWxMT.

## What was wrong

`closeConversation` keeps a conversation's directory entry until the host's replacement with nothing has drained, so an observed opening that lands meanwhile waits on the close. `rebuild` still walked the whole directory: its `replace(build)` on a closing host became the newer transition and installed a fresh agent, and the close then dropped that host from the directory with a live agent on it that no retire could ever reach. A reopen afterwards built a second store on the same envelope. The public `openConversation` (thread unarchive) had the same shape: it rebuilt onto the closing entry, and the reopened thread ended with no brain.

## Fix

- `rebuild` skips a conversation whose close is pending. The reopen that follows the close builds on whatever model then stands, so a credential rebuild still reaches every standing conversation.
- The public `openConversation` awaits a pending close for its key before opening, as `openObserved` already does.
- No change to `closeConversation`, `rebuildOne`, `BrainHost`, or what the `closings` map holds.

## Tests

Two regressions in `wiring-routing.test.ts`, gated by construction (the close has begun and is awaiting its drain when the rebuild or reopen lands in the same tick), no sleeps:

- a rebuild during a close builds main's and the other observed brain only, writes nothing onto the discarded envelope, and the hook that reopens the session stands on the sole second store;
- a thread reopened during its close waits for it and stands on its own new store with a brain.

Both fail on `main` without the fix (3 builds instead of 2; reopened thread has no brain) and pass with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34262159771/artifacts/10070452080) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34262159771)

- Commit: `cc4b8d5cd0087e8362c9f6547b0b51a0f94f4833`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

Validation at `cc4b8d5`: `./scripts/check.sh` passes; required TypeScript and macOS app/evidence CI pass in run 34262159771. All six fixture PNGs are byte-identical to PR6. No UI changes.
