### PR TITLE
feat(memory): durable flush cycle and memory maintenance cleanup (PR 8 follow-up)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -634,7 +634,18 @@ Trust constraints:
   earlier entry can be overwritten; the copy is disposed at the turn's end
   and nothing it said enters the conversation; a write stands as soon as it
   is made, and only a turn that ran to its end marks the cycle flushed, so
-  an interrupted flush runs again. The reset capture: Start fresh on an
+  an interrupted flush runs again. The cycle is durable, with one owner for
+  each half: the compaction count is the generation's own and rides on its
+  envelope with every checkpoint, and the marker saying which count was
+  flushed is maintenance state in the store's flush-state table, keyed by
+  the generation's id, read once per generation before its first assessment
+  and written after each completed flush, so a relaunch neither flushes a
+  cycle twice nor skips one, and Clear, Start fresh, and Delete history
+  begin a lifetime at cycle zero that consults no earlier marker. A marker
+  that cannot be read defers the flush; one that cannot be written after
+  three attempts is reported and leaves the cycle unflushed, never silently
+  done, and the housekeeping turn itself is never rerun to retry a write.
+  The reset capture: Start fresh on an
   eligible conversation runs the same turn first, its outcome reported
   honestly and never deciding the reset, which proceeds either way; Clear,
   Delete history, Archive, and a forget run no capture. The consolidation

--- a/apps/desktop/src/main/brain/wiring-children.test.ts
+++ b/apps/desktop/src/main/brain/wiring-children.test.ts
@@ -15,6 +15,7 @@ import {
   responsesModelAnswer,
 } from "@sidecar/brain";
 import { type BareResponsesModel, bareModelAdapter } from "@sidecar/brain/testing";
+import { MEMORY_HOUSEKEEPING_OUTCOME } from "@sidecar/memory";
 import type { ConversationEntry } from "@sidecar/realtime";
 import { type ChildStore, CREDENTIAL_REFERENCE_KIND, type ScheduledTimer } from "@sidecar/runtime";
 import {
@@ -150,7 +151,10 @@ interface Composed {
   timers: Map<ScheduledTimer, { callback: () => void; delayMs: number }>;
 }
 
-function composed(script: Script): Composed {
+function composed(
+  script: Script,
+  overrides: Partial<Parameters<typeof wireBrain>[0]> = {},
+): Composed {
   const seen: Seen[] = [];
   let calls = 0;
   const client: BareResponsesModel = {
@@ -282,6 +286,7 @@ function composed(script: Script): Composed {
     skillRoots: () => [],
     runnable: () => true,
     dropBriefings: () => undefined,
+    ...overrides,
   });
   return {
     wiring,
@@ -513,4 +518,36 @@ test("Start fresh cancels a conversation's descendants first, and their cancella
   releaseChild?.();
   c.wiring.retire();
   await c.wiring.rebuild();
+});
+
+test("a reset capture that was skipped reports nothing, while one that failed is said so; the reset proceeds either way", async () => {
+  for (const [outcome, reported] of [
+    [MEMORY_HOUSEKEEPING_OUTCOME.SKIPPED, false],
+    [MEMORY_HOUSEKEEPING_OUTCOME.FAILED, true],
+  ] as const) {
+    const reports: string[] = [];
+    let captures = 0;
+    const c = composed(() => textAnswer("ok"), {
+      report: (message) => {
+        reports.push(message);
+      },
+      beforeReset: async () => {
+        captures += 1;
+        return { outcome, writes: 0, reason: "not an eligible private conversation" };
+      },
+    });
+    await c.wiring.rebuild();
+    const main = c.wiring.current();
+    assert.ok(main);
+    const runId = await ask(c, "remember this");
+    await main.waitAsk(runId, 60_000);
+    assert.equal(await c.wiring.resetConversation(MAIN_SESSION_KEY), true);
+    assert.equal(captures, 1, "the capture ran over the context the reset let go of");
+    assert.equal(
+      reports.some((line) => line.startsWith("Reset capture did not complete")),
+      reported,
+      outcome,
+    );
+    c.wiring.retire();
+  }
 });

--- a/apps/desktop/src/main/brain/wiring.ts
+++ b/apps/desktop/src/main/brain/wiring.ts
@@ -7,6 +7,7 @@ import {
   BrainAgent,
   type BrainDelivery,
   type BrainFlushInput,
+  type BrainFlushMarkerStore,
   BrainGenerationClock,
   type BrainMemoryAccess,
   type BrainRecallAsk,
@@ -165,6 +166,8 @@ export interface BrainWiringDependencies extends ChildWiringDependencies {
   beforeCompaction?: (
     sessionKey: SessionKey,
   ) => ((input: BrainFlushInput) => Promise<MemoryHousekeepingResult>) | undefined;
+  /** Where one conversation's flush marker outlives the process; nothing for one that never flushes. */
+  flushMarker?: (sessionKey: SessionKey) => BrainFlushMarkerStore | undefined;
   /**
    * The capture run before an eligible conversation starts fresh, over a
    * copy of its context. Its outcome is reported and never decides the
@@ -504,6 +507,7 @@ export function wireBrain(dependencies: BrainWiringDependencies): BrainWiring {
   };
 
   const flushFor = (sessionKey: SessionKey) => dependencies.beforeCompaction?.(sessionKey);
+  const flushMarkerFor = (sessionKey: SessionKey) => dependencies.flushMarker?.(sessionKey);
 
   /** The skills the latest preparation listed to the model: the only ones `load_skill` may load. */
   interface ListedSkills {
@@ -612,6 +616,7 @@ export function wireBrain(dependencies: BrainWiringDependencies): BrainWiring {
       ...(memory ? { memory } : undefined),
       ...(recall ? { recall } : undefined),
       ...(flushFor(sessionKey) ? { beforeCompaction: flushFor(sessionKey) } : undefined),
+      ...(flushMarkerFor(sessionKey) ? { flushMarker: flushMarkerFor(sessionKey) } : undefined),
       runtime: runtimeDescriptor.create(model, engineDescriptor),
       acts,
       roster: dependencies.roster,

--- a/apps/desktop/src/main/brain/wiring.ts
+++ b/apps/desktop/src/main/brain/wiring.ts
@@ -34,7 +34,7 @@ import {
   TOOL_LOOP_RUNTIME,
 } from "@sidecar/brain";
 import {
-  housekeepingCompleted,
+  housekeepingFellShort,
   MEMORY_HOUSEKEEPING_OUTCOME,
   type MemoryHousekeepingResult,
 } from "@sidecar/memory";
@@ -998,7 +998,7 @@ export function wireBrain(dependencies: BrainWiringDependencies): BrainWiring {
               reason: error.message,
             }),
           );
-          if (!housekeepingCompleted(result.outcome)) {
+          if (housekeepingFellShort(result.outcome)) {
             dependencies.report(
               `Reset capture did not complete (${result.outcome}${result.reason ? `: ${result.reason}` : ""}); ${result.writes} note write(s) stand and the reset proceeds`,
             );

--- a/apps/desktop/src/main/host/runtime-host.ts
+++ b/apps/desktop/src/main/host/runtime-host.ts
@@ -1063,6 +1063,7 @@ export function composeRuntimeHost(options: RuntimeHostOptions): RuntimeHost {
     memory: (sessionKey) => memoryWiring.accessFor(sessionKey),
     recall: (sessionKey) => memoryWiring.recallFor(sessionKey),
     beforeCompaction: (sessionKey) => memoryMaintenance.flushHookFor(sessionKey),
+    flushMarker: (sessionKey) => memoryMaintenance.flushMarkerFor(sessionKey),
     beforeReset: (sessionKey, items) => memoryMaintenance.captureBeforeReset(sessionKey, items),
   });
 

--- a/apps/desktop/src/main/memory-maintenance.test.ts
+++ b/apps/desktop/src/main/memory-maintenance.test.ts
@@ -534,3 +534,45 @@ test("the flush marker is kept per conversation under the generation the brain n
   assert.equal(await marker.read("gen-1"), 2);
   h.close();
 });
+
+test("a completed dated note is staged beside a full History budget rather than starved past the lookback, and the budget is spent only once per note line", async () => {
+  const h = await harness();
+  const lines: ConversationEntry[] = [];
+  for (let index = 0; index < 250; index += 1) {
+    lines.push({
+      kind: CONVERSATION_ENTRY_KIND.TYPED_ASK,
+      words: `Distinct decision number ${index} about the deployment schedule for service ${index}`,
+      eventId: `line-${index}`,
+      recordedAt: NOW - 10_000 + index,
+    });
+  }
+  h.history.set(MAIN_SESSION_KEY, lines);
+  const note = Array.from(
+    { length: 20 },
+    (_, index) => `- Yesterday's note line ${index} about the release train for team ${index}`,
+  );
+  fs.writeFileSync(
+    path.join(h.workspace, "memory", `${YESTERDAY}.md`),
+    `# ${YESTERDAY}\n\n${note.join("\n")}\n`,
+  );
+  const notePath = `memory/${YESTERDAY}.md`;
+  const fromNote = (candidates: readonly { path: string }[]) =>
+    candidates.filter((candidate) => candidate.path === notePath).length;
+  const fromMain = (candidates: readonly { sourceSessionKey?: string }[]) =>
+    candidates.filter((candidate) => candidate.sourceSessionKey === MAIN_SESSION_KEY).length;
+  assert.ok(await h.maintenance.runConsolidation());
+  let candidates = await h.store.listMemoryCandidates();
+  assert.equal(fromNote(candidates), 20, "the note takes its share ahead of the conversations");
+  assert.equal(fromMain(candidates), 80, "the conversations take the rest of the limit");
+  assert.ok(await h.maintenance.runConsolidation());
+  candidates = await h.store.listMemoryCandidates();
+  assert.equal(
+    fromNote(candidates),
+    20,
+    "a note line already held costs no budget and is learned once",
+  );
+  assert.equal(fromMain(candidates), 180, "the whole limit goes to the lines the first sweep left");
+  assert.ok(await h.maintenance.runConsolidation());
+  assert.equal(fromMain(await h.store.listMemoryCandidates()), 250);
+  h.close();
+});

--- a/apps/desktop/src/main/memory-maintenance.test.ts
+++ b/apps/desktop/src/main/memory-maintenance.test.ts
@@ -427,6 +427,7 @@ test("the flush hook and the reset capture exist only for main and durable priva
   assert.ok(h.maintenance.flushHookFor(MAIN_SESSION_KEY));
   assert.ok(h.maintenance.flushHookFor(h.thread));
   assert.equal(h.maintenance.flushHookFor(h.temporary), undefined);
+  assert.equal(h.maintenance.flushMarkerFor(h.temporary), undefined);
   assert.equal(h.maintenance.capturesOnReset(h.temporary), false);
   const skipped = await h.maintenance.captureBeforeReset(h.temporary, [{ type: "message" }]);
   assert.equal(skipped.outcome, MEMORY_HOUSEKEEPING_OUTCOME.SKIPPED);
@@ -507,5 +508,29 @@ test("the light limit bounds one sweep and the cursor advances only over the lin
   const third = await h.maintenance.runConsolidation();
   assert.ok(third);
   assert.equal(fromMain(await h.store.listMemoryCandidates()), 105, "nothing learned twice");
+  h.close();
+});
+
+test("the flush marker is kept per conversation under the generation the brain names, and a new generation reads none", async () => {
+  const h = await harness();
+  const marker = h.maintenance.flushMarkerFor(MAIN_SESSION_KEY);
+  assert.ok(marker);
+  assert.equal(await marker.read("gen-1"), undefined);
+  await marker.write("gen-1", 2);
+  assert.equal(await marker.read("gen-1"), 2);
+  assert.equal(
+    await marker.read("gen-2"),
+    undefined,
+    "a marker from an earlier lifetime is never this cycle's",
+  );
+  const thread = h.maintenance.flushMarkerFor(h.thread);
+  assert.ok(thread);
+  assert.equal(
+    await thread.read("gen-1"),
+    undefined,
+    "one conversation's marker says nothing about another's",
+  );
+  await thread.write("gen-1", 0);
+  assert.equal(await marker.read("gen-1"), 2);
   h.close();
 });

--- a/apps/desktop/src/main/memory-maintenance.ts
+++ b/apps/desktop/src/main/memory-maintenance.ts
@@ -152,6 +152,12 @@ export const DEEP_PATH = {
 
 /** How much a day's ingestion counts for; three recurring days pass the score gate, one does not. */
 const INGESTION_SCORE = 0.8;
+/**
+ * The most of one raw note line the light phase reads before scrubbing it;
+ * a candidate is cut to its own text bound afterwards anyway, and the
+ * redaction treats a key armor the cut removed as an unterminated key.
+ */
+const NOTE_LINE_MAX_CHARS = 4_000;
 const DAY_MS = 24 * 60 * 60 * 1000;
 const DIARY_OUTPUT_TOKENS = 400;
 const CONSOLIDATION_OUTPUT_TOKENS = 4_000;
@@ -446,7 +452,9 @@ export function wireMemoryMaintenance(
       content.split("\n").forEach((line, index) => {
         const trimmed = line.trim();
         if (trimmed.length === 0 || trimmed.startsWith("#") || trimmed.startsWith("<!--")) return;
-        const prepared = prepareForIngestion(trimmed.replace(/^[-*+]\s+/u, ""));
+        const prepared = prepareForIngestion(
+          trimmed.replace(/^[-*+]\s+/u, "").slice(0, NOTE_LINE_MAX_CHARS),
+        );
         if (!prepared || prepared.text.length < 12) return;
         seeds.push({
           text: prepared.text,
@@ -482,7 +490,9 @@ export function wireMemoryMaintenance(
     const slice = lines
       .slice(Math.max(0, candidate.startLine - 1), Math.max(candidate.startLine, candidate.endLine))
       .join(" ");
-    const prepared = prepareForIngestion(slice.replace(/^[-*+]\s+/u, ""));
+    const prepared = prepareForIngestion(
+      slice.replace(/^[-*+]\s+/u, "").slice(0, NOTE_LINE_MAX_CHARS),
+    );
     return (
       prepared !== undefined &&
       candidatesDuplicate(boundCandidateText(prepared.text), candidate.text)

--- a/apps/desktop/src/main/memory-maintenance.ts
+++ b/apps/desktop/src/main/memory-maintenance.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import type { BrainFlushInput } from "@sidecar/brain";
+import type { BrainFlushInput, BrainFlushMarkerStore } from "@sidecar/brain";
 import { REFUSAL_REASON, runMemoryHousekeeping } from "@sidecar/brain";
 import {
   appendOnlyPromotion,
@@ -23,6 +23,7 @@ import {
   dreamDiaryEntry,
   type HousekeepingPrompt,
   hashText,
+  housekeepingCompleted,
   ingestionQuery,
   isConversationCandidate,
   localDayStamp,
@@ -111,6 +112,13 @@ export interface MemoryMaintenance {
   flushHookFor: (
     sessionKey: SessionKey,
   ) => ((input: BrainFlushInput) => Promise<MemoryHousekeepingResult>) | undefined;
+  /**
+   * Where one conversation's flush marker outlives the process: the store's
+   * flush-state row, read and written under the generation the brain names,
+   * so a relaunch knows which cycle was flushed and a new lifetime reads none.
+   * Nothing for a conversation that never flushes.
+   */
+  flushMarkerFor: (sessionKey: SessionKey) => BrainFlushMarkerStore | undefined;
   /** Whether a conversation's reset captures first: main and the developer's durable private threads. */
   capturesOnReset: (sessionKey: SessionKey) => boolean;
   /** The capture run before a reset, over a copy of the conversation's context; never blocks the reset's outcome. */
@@ -181,7 +189,6 @@ export function wireMemoryMaintenance(
     dependencies.persistent && interactive(sessionKey) && !dependencies.isTemporary(sessionKey);
 
   const housekeeping = async (
-    sessionKey: SessionKey,
     items: readonly WireRecord[],
     prompt: HousekeepingPrompt,
     dateStamp: string,
@@ -210,27 +217,28 @@ export function wireMemoryMaintenance(
 
   const flushHookFor: MemoryMaintenance["flushHookFor"] = (sessionKey) => {
     if (!eligible(sessionKey)) return undefined;
-    return async (input) => {
+    return (input) => {
       const day = localDayStamp(dependencies.now());
-      const result = await housekeeping(
-        sessionKey,
-        input.items,
-        memoryFlushPrompt(day),
-        day,
-        input.signal,
-      );
-      try {
-        await dependencies.client().recordMemoryFlush(sessionKey, {
-          compactionCount: input.compactionCount,
-          outcome: result.outcome,
+      return housekeeping(input.items, memoryFlushPrompt(day), day, input.signal);
+    };
+  };
+
+  const flushMarkerFor: MemoryMaintenance["flushMarkerFor"] = (sessionKey) => {
+    if (!eligible(sessionKey)) return undefined;
+    return {
+      read: async (generationId) => {
+        const state = await dependencies.client().memoryFlushState(sessionKey, generationId);
+        return state && housekeepingCompleted(state.outcome) ? state.compactionCount : undefined;
+      },
+      write: async (generationId, compactionCount) => {
+        const recorded = await dependencies.client().recordMemoryFlush(sessionKey, {
+          generationId,
+          compactionCount,
+          outcome: MEMORY_HOUSEKEEPING_OUTCOME.COMPLETED,
           flushedAt: dependencies.now(),
         });
-      } catch (error) {
-        dependencies.report(
-          `Memory flush state could not be recorded: ${error instanceof Error ? error.message : String(error)}`,
-        );
-      }
-      return result;
+        if (!recorded) throw new Error("the store refused the flush marker");
+      },
     };
   };
 
@@ -252,7 +260,7 @@ export function wireMemoryMaintenance(
       CONSOLIDATION_DEFAULTS.CONSOLIDATION_TIMEOUT_MS,
     );
     try {
-      return await housekeeping(sessionKey, items, resetCapturePrompt(day), day, controller.signal);
+      return await housekeeping(items, resetCapturePrompt(day), day, controller.signal);
     } finally {
       clearTimeout(timer);
     }
@@ -716,6 +724,7 @@ export function wireMemoryMaintenance(
 
   return {
     flushHookFor,
+    flushMarkerFor,
     capturesOnReset: eligible,
     captureBeforeReset,
     runConsolidation,

--- a/apps/desktop/src/main/memory-maintenance.ts
+++ b/apps/desktop/src/main/memory-maintenance.ts
@@ -158,6 +158,13 @@ const INGESTION_SCORE = 0.8;
  * redaction treats a key armor the cut removed as an unterminated key.
  */
 const NOTE_LINE_MAX_CHARS = 4_000;
+/**
+ * The share of the light limit the dated notes may take ahead of the
+ * conversations, so a full History budget cannot keep a completed note from
+ * being staged until it ages out of the lookback; whatever either side
+ * leaves goes to the other.
+ */
+const NOTE_BUDGET_SHARE = 0.5;
 const DAY_MS = 24 * 60 * 60 * 1000;
 const DIARY_OUTPUT_TOKENS = 400;
 const CONSOLIDATION_OUTPUT_TOKENS = 4_000;
@@ -516,10 +523,20 @@ export function wireMemoryMaintenance(
         const held = await client.listMemoryCandidates();
         // The light limit bounds what one sweep stages; the cursor and the
         // seen hashes advance only over the lines actually consumed, so what
-        // the budget left behind is read by the next sweep, never lost.
-        let budget: number = CONSOLIDATION_DEFAULTS.LIGHT_LIMIT;
+        // the budget left behind is read by the next sweep, never lost. The
+        // notes have no cursor — a note line already held costs no budget,
+        // and one not yet held is read again next sweep — so they take their
+        // share first, and the conversations the rest.
+        const noteCandidates = (await noteSeeds(now)).filter(
+          (seed) => !held.some((candidate) => candidatesDuplicate(candidate.text, seed.text)),
+        );
+        const noteShare = Math.min(
+          noteCandidates.length,
+          Math.floor(CONSOLIDATION_DEFAULTS.LIGHT_LIMIT * NOTE_BUDGET_SHARE),
+        );
+        let budget: number = CONSOLIDATION_DEFAULTS.LIGHT_LIMIT - noteShare;
         const advances: { sessionKey: SessionKey; latest: number; hashes: string[] }[] = [];
-        let gathered: CandidateSeed[] = [];
+        let gathered: CandidateSeed[] = noteCandidates.slice(0, noteShare);
         for (const sessionKey of eligibleConversations()) {
           const lines = await conversationLines(client, sessionKey, now);
           const hashes: string[] = [];
@@ -535,7 +552,9 @@ export function wireMemoryMaintenance(
           }
           if (hashes.length > 0) advances.push({ sessionKey, latest, hashes });
         }
-        gathered = gathered.concat((await noteSeeds(now)).slice(0, Math.max(0, budget)));
+        gathered = gathered.concat(
+          noteCandidates.slice(noteShare, noteShare + Math.max(0, budget)),
+        );
         const { seeds, deduped } = dedupe(gathered, held);
         const staging = await client.stageMemoryCandidates(seeds, now);
         for (const advance of advances) {

--- a/packages/brain/src/agent-flush.test.ts
+++ b/packages/brain/src/agent-flush.test.ts
@@ -1,6 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { MEMORY_HOUSEKEEPING_OUTCOME, type MemoryHousekeepingResult } from "@sidecar/memory";
+import {
+  MEMORY_FLUSH_DEFAULTS,
+  MEMORY_HOUSEKEEPING_OUTCOME,
+  type MemoryHousekeepingResult,
+} from "@sidecar/memory";
 import {
   MODEL_FAILURE,
   MODEL_RESPONSE_OUTCOME,
@@ -9,7 +13,7 @@ import {
   type ModelResponse,
 } from "@sidecar/runtime-contracts";
 import { ACT_RESULT_STATUS, type WireRecord } from "@sidecar/wire";
-import { BrainAgent, type BrainFlushInput } from "./agent.js";
+import { BrainAgent, type BrainFlushInput, type BrainFlushMarkerStore } from "./agent.js";
 import { ResponsesContextEngine } from "./context-engine.js";
 import {
   BRAIN_REQUEST_ORIGIN,
@@ -66,7 +70,8 @@ class FakeModel {
   }
 }
 
-function adapterOf(model: FakeModel): ModelAdapter {
+/** The adapter over the fake model; one that compacts answers a one-message window in place of whatever it was asked over. */
+function adapterOf(model: FakeModel, compacts = false): ModelAdapter {
   return {
     capabilities: async () => ({
       outcome: MODEL_RESPONSE_OUTCOME.ANSWERED,
@@ -80,7 +85,7 @@ function adapterOf(model: FakeModel): ModelAdapter {
         },
         contextWindowTokens: WINDOW_TOKENS,
         countsInputTokens: false,
-        compacts: false,
+        compacts,
         maximumOutputTokens: 16_000,
       },
     }),
@@ -90,11 +95,14 @@ function adapterOf(model: FakeModel): ModelAdapter {
       failure: MODEL_FAILURE.UPSTREAM,
       reason: "not counted",
     }),
-    compact: async () => ({
-      outcome: MODEL_RESPONSE_OUTCOME.FAILED,
-      failure: MODEL_FAILURE.UPSTREAM,
-      reason: "not compacted",
-    }),
+    compact: async () =>
+      compacts
+        ? { outcome: MODEL_RESPONSE_OUTCOME.ANSWERED, items: [message("folded")] }
+        : {
+            outcome: MODEL_RESPONSE_OUTCOME.FAILED,
+            failure: MODEL_FAILURE.UPSTREAM,
+            reason: "not compacted",
+          },
     quietUntil: () => undefined,
   };
 }
@@ -114,18 +122,46 @@ async function settle(): Promise<void> {
   for (let index = 0; index < 30; index += 1) await new Promise((resolve) => setImmediate(resolve));
 }
 
-function agentWith(hook: (input: BrainFlushInput) => Promise<MemoryHousekeepingResult>) {
+/** The flush marker as a store keeps it across launches, keyed by generation; its writes can be made to fail. */
+class FakeMarkerStore implements BrainFlushMarkerStore {
+  readonly markers = new Map<string, number>();
+  failWrites = false;
+  writes = 0;
+  read(generationId: string) {
+    return Promise.resolve(this.markers.get(generationId));
+  }
+  write(generationId: string, compactionCount: number) {
+    this.writes += 1;
+    if (this.failWrites) return Promise.reject(new Error("disk full"));
+    this.markers.set(generationId, compactionCount);
+    return Promise.resolve();
+  }
+}
+
+interface Launch {
+  storage?: FakeStorage;
+  marker?: FakeMarkerStore;
+  /** Whether the adapter compacts, so a context over the reserve folds in maintenance and the cycle moves. */
+  compacts?: boolean;
+}
+
+/** An agent over the given storage and marker store, as one launch of the app would build it; a second call over the same is a relaunch. */
+function agentWith(
+  hook: (input: BrainFlushInput) => Promise<MemoryHousekeepingResult>,
+  launch: Launch = {},
+) {
   const model = new FakeModel();
   const runtime = new ToolLoopAgentRuntime({
-    model: adapterOf(model),
+    model: adapterOf(model, launch.compacts ?? false),
     itemFormat: { format: RESPONSES_ITEM_FORMAT.FORMAT, version: RESPONSES_ITEM_FORMAT.VERSION },
     createContext: () => new ResponsesContextEngine(IDENTITY),
   });
   let ids = 0;
   const reports: string[] = [];
+  const storage = launch.storage ?? new FakeStorage();
   const store = new BrainStateStore({
-    storage: new FakeStorage(),
-    createGenerationId: () => `gen-${ids++}`,
+    storage,
+    createGenerationId: () => `gen-${Math.random().toString(36).slice(2)}`,
     now: () => NOW,
   });
   const agent = new BrainAgent({
@@ -144,8 +180,9 @@ function agentWith(hook: (input: BrainFlushInput) => Promise<MemoryHousekeepingR
     },
     now: () => NOW,
     beforeCompaction: hook,
+    ...(launch.marker ? { flushMarker: launch.marker } : undefined),
   });
-  return { agent, model, reports };
+  return { agent, model, reports, store, storage };
 }
 
 async function ask(agent: BrainAgent, question: string) {
@@ -169,8 +206,7 @@ test("a turn that leaves the context over the flush threshold runs the flush onc
   });
   await ask(h.agent, "short");
   assert.equal(calls.length, 0, "a small context flushes nothing");
-  // Around 3,400 characters of items: past the 750-token flush threshold, under the 1,500-token compaction threshold.
-  await ask(h.agent, "x".repeat(3_000));
+  await ask(h.agent, OVER_FLUSH_THRESHOLD);
   assert.equal(calls.length, 1);
   const [flush] = calls;
   assert.ok(flush);
@@ -213,4 +249,124 @@ test("an interrupted or failed flush is reported and runs again at the next asse
   await ask(h.agent, "once more");
   assert.equal(calls, 2);
   await h.agent.stop();
+});
+
+/** Around 3,400 characters of items: past the 750-token flush threshold, under the 1,500-token compaction threshold. */
+const OVER_FLUSH_THRESHOLD = "x".repeat(3_000);
+/** Past the 1,500-token compaction threshold, so the maintenance after the turn folds the context. */
+const OVER_COMPACTION_THRESHOLD = "z".repeat(7_000);
+
+test("restart: a flushed cycle is not flushed again after a relaunch, and a compaction then a relaunch flushes once in the new cycle", async () => {
+  const marker = new FakeMarkerStore();
+  let calls = 0;
+  const hook = async () => {
+    calls += 1;
+    return { outcome: MEMORY_HOUSEKEEPING_OUTCOME.COMPLETED, writes: 1 };
+  };
+  const first = agentWith(hook, { marker, compacts: true });
+  await ask(first.agent, OVER_FLUSH_THRESHOLD);
+  assert.equal(calls, 1);
+  const generation = first.store.generationId();
+  assert.ok(generation);
+  assert.equal(marker.markers.get(generation), 0, "the marker names the generation and cycle zero");
+  await first.agent.stop();
+
+  // The relaunch: a new store over the same file, a new agent, the same marker table.
+  const second = agentWith(hook, { storage: first.storage, marker, compacts: true });
+  await ask(second.agent, "still over the threshold");
+  assert.equal(calls, 1, "cycle zero was flushed before the relaunch");
+  assert.deepEqual(second.agent.flushCycle(), { compactionCount: 0, lastFlushCompactionCount: 0 });
+  // A turn that leaves the context over the reserve compacts it in maintenance; cycle one begins.
+  await ask(second.agent, OVER_COMPACTION_THRESHOLD);
+  assert.equal(second.agent.flushCycle().compactionCount, 1, "the compaction was counted");
+  assert.equal(calls, 1, "cycle zero flushed once; the fold itself is not a flush");
+  await second.agent.stop();
+
+  const third = agentWith(hook, { storage: first.storage, marker, compacts: true });
+  assert.equal((await third.store.load()).compactionCount, 1, "the count rode on the envelope");
+  await ask(third.agent, OVER_FLUSH_THRESHOLD);
+  assert.equal(calls, 2, "cycle one is flushed once, after the relaunch");
+  assert.equal(marker.markers.get(generation), 1);
+  await ask(third.agent, "again");
+  assert.equal(calls, 2);
+  await third.agent.stop();
+});
+
+test("reset: after Start fresh the new generation starts at cycle zero, reads no earlier marker, and flushes on its first due assessment", async () => {
+  const marker = new FakeMarkerStore();
+  let calls = 0;
+  const hook = async () => {
+    calls += 1;
+    return { outcome: MEMORY_HOUSEKEEPING_OUTCOME.COMPLETED, writes: 1 };
+  };
+  const h = agentWith(hook, { marker });
+  await ask(h.agent, OVER_FLUSH_THRESHOLD);
+  assert.equal(calls, 1);
+  const before = h.store.generationId();
+  assert.equal(await h.store.reset(), true);
+  const after = h.store.generationId();
+  assert.ok(after && after !== before);
+  assert.deepEqual(h.agent.flushCycle(), { compactionCount: 0 });
+  await ask(h.agent, OVER_FLUSH_THRESHOLD);
+  assert.equal(
+    calls,
+    2,
+    "the fresh generation's cycle zero is unflushed whatever the old marker said",
+  );
+  assert.equal(marker.markers.get(after), 0);
+  assert.equal(
+    marker.markers.get(before ?? ""),
+    0,
+    "the old lifetime's marker is untouched and unread",
+  );
+  await h.agent.stop();
+});
+
+test("failed persistence: a marker write that fails is reported and leaves the cycle unflushed; a housekeeping turn that failed writes no marker", async () => {
+  const marker = new FakeMarkerStore();
+  marker.failWrites = true;
+  let outcome: MemoryHousekeepingResult = {
+    outcome: MEMORY_HOUSEKEEPING_OUTCOME.COMPLETED,
+    writes: 1,
+  };
+  let calls = 0;
+  const h = agentWith(
+    async () => {
+      calls += 1;
+      return outcome;
+    },
+    { marker },
+  );
+  await ask(h.agent, OVER_FLUSH_THRESHOLD);
+  assert.equal(calls, 1);
+  assert.equal(
+    marker.writes,
+    MEMORY_FLUSH_DEFAULTS.MARKER_WRITE_ATTEMPTS,
+    "the write is retried a bounded number of times",
+  );
+  assert.ok(
+    h.reports.some((line) =>
+      /Memory flush completed but its marker could not be recorded after 3 attempt\(s\) \(disk full\)/u.test(
+        line,
+      ),
+    ),
+  );
+  assert.deepEqual(
+    h.agent.flushCycle(),
+    { compactionCount: 0 },
+    "not marked done in memory either",
+  );
+  marker.failWrites = false;
+  await ask(h.agent, "next assessment");
+  assert.equal(calls, 2, "the unflushed cycle is flushed again");
+  assert.deepEqual(h.agent.flushCycle(), { compactionCount: 0, lastFlushCompactionCount: 0 });
+  await h.agent.stop();
+
+  const failing = new FakeMarkerStore();
+  outcome = { outcome: MEMORY_HOUSEKEEPING_OUTCOME.FAILED, writes: 0, reason: "upstream down" };
+  const f = agentWith(async () => outcome, { marker: failing });
+  await ask(f.agent, OVER_FLUSH_THRESHOLD);
+  assert.equal(failing.writes, 0, "a turn that did not run to its end writes no marker");
+  assert.equal(failing.markers.size, 0);
+  await f.agent.stop();
 });

--- a/packages/brain/src/agent.ts
+++ b/packages/brain/src/agent.ts
@@ -1,6 +1,7 @@
 import { HOSTED_BRAIN_OPTION_BOUNDS } from "@sidecar/hosted";
 import {
   housekeepingCompleted,
+  MEMORY_FLUSH_DEFAULTS,
   MEMORY_HOUSEKEEPING_OUTCOME,
   type MemoryHousekeepingResult,
   shouldRunMemoryFlush,
@@ -25,7 +26,6 @@ import {
   type ChildCompletionRecord,
   type ChildRunRecord,
   CONTEXT_INPUT_KIND,
-  type ContextEngine,
   type ContextMark,
   type ReasoningEffort,
   RUN_END_REASON,
@@ -100,7 +100,7 @@ import {
   isTerminalBrainRequestStatus,
 } from "./requests.js";
 import { incompleteDetail, TOOL_RESULT_STATUS } from "./runtime.js";
-import { settledUnlessAborted } from "./settled.js";
+import { type Settled, settledUnlessAborted } from "./settled.js";
 import {
   type BrainPersistedState,
   type BrainStateStore,
@@ -300,6 +300,13 @@ export interface BrainAgentOptions {
    * flushed, so an interrupted flush runs again at the next assessment.
    */
   beforeCompaction?: (input: BrainFlushInput) => Promise<MemoryHousekeepingResult>;
+  /**
+   * Where the flush marker outlives this process: read once per generation
+   * before the first assessment, written after each completed flush, keyed
+   * by the generation so a marker from an earlier lifetime is never read as
+   * this cycle's. Absent, the marker stands in memory alone.
+   */
+  flushMarker?: BrainFlushMarkerStore;
   readTranscriptSince: (
     identity: SessionIdentity,
     cursor: string | undefined,
@@ -373,6 +380,19 @@ export interface BrainFlushInput {
 export interface BrainFlushCycle {
   readonly compactionCount: number;
   readonly lastFlushCompactionCount?: number;
+}
+
+/**
+ * The durable side of the flush gate. The compaction count is the
+ * generation's own and rides on its envelope; the marker saying which count
+ * was flushed is maintenance state, kept here under the generation's id. A
+ * write that rejects did not land, and the caller leaves the cycle unflushed.
+ */
+export interface BrainFlushMarkerStore {
+  /** The compaction count the generation's last completed flush ran under, or nothing when none has. */
+  read(generationId: string): Promise<number | undefined>;
+  /** Records that a flush completed under this compaction count of this generation. */
+  write(generationId: string, compactionCount: number): Promise<void>;
 }
 
 export type { BrainWorkspaceAccess } from "./tool-executor.js";
@@ -482,9 +502,6 @@ export class BrainAgent {
   readonly #pendingSubmissions = new Map<string, PendingSubmission>();
   readonly #listeners = new Set<BrainRequestsListener>();
   #turnInFlight = false;
-  /** How many times this conversation's context has folded since the agent stood up; the flush runs once per count. */
-  #compactionCount = 0;
-  #lastFlushCompactionCount: number | undefined;
   /** The execution under way, for an ask to steer into or interrupt, and the asks riding inside it. */
   #active: ActiveExecution | undefined;
   /** Where an ask that arrives while this conversation is busy waits, under the queue's own mode and bounds. */
@@ -1656,13 +1673,13 @@ export class BrainAgent {
     // The flush fires a soft margin ahead of the fold, so in maintenance it
     // usually runs on a context not yet over the reserve; at admission it
     // runs right before the compaction the request needs.
-    await this.#flushBeforeCompaction(context, assessment, signal);
+    await this.#flushBeforeCompaction(turnContext, assessment);
     if (this.#revoked(turnContext)) return { ok: true };
     if (assessment.need === COMPACTION_NEED.NONE) return { ok: true };
     const outcome = await this.#options.runtime.compact(context, { prompt, signal });
     if (this.#revoked(turnContext)) return { ok: true };
     if (!outcome.compacted) return { ok: false, reason: outcome.reason };
-    this.#compactionCount += 1;
+    turnContext.generation.compactionCount += 1;
     if (!(await this.#ledger.checkpoint(turnContext))) {
       return { ok: false, reason: "the compacted context could not be checkpointed" };
     }
@@ -1677,27 +1694,34 @@ export class BrainAgent {
    * that says it ran to its end marks the cycle flushed, and any other
    * answer — interrupted, failed, or the signal firing first — leaves the
    * cycle unflushed so the next assessment runs it again. What the hook
-   * wrote before then stands either way.
+   * wrote before then stands either way. The cycle is the generation's own
+   * compaction count, and the marker of the last completed flush is read
+   * from the marker store once per generation and written to it after each
+   * completion, so a relaunch neither flushes a cycle twice nor skips one;
+   * a marker that cannot be read defers the flush, and one that cannot be
+   * written after its bounded attempts is reported and leaves the cycle
+   * unflushed, never silently done.
    */
   async #flushBeforeCompaction(
-    context: ContextEngine,
+    turnContext: Omit<TurnContext, "run"> & { run?: RunControl },
     assessment: CompactionAssessment,
-    signal: AbortSignal,
   ): Promise<void> {
+    const { generation, context, signal } = turnContext;
     const hook = this.#options.beforeCompaction;
     if (!hook || signal.aborted) return;
+    if (!(await this.#readFlushMarker(turnContext))) return;
     const due = shouldRunMemoryFlush({
       contextTokens: assessment.contextTokens,
       contextWindowTokens: assessment.contextWindowTokens,
       reserveTokens: reserveTokens(assessment.contextWindowTokens),
       transcriptBytes: assessment.bytes,
-      compactionCount: this.#compactionCount,
-      ...(this.#lastFlushCompactionCount !== undefined
-        ? { lastFlushCompactionCount: this.#lastFlushCompactionCount }
+      compactionCount: generation.compactionCount,
+      ...(generation.flush.lastCompactionCount !== undefined
+        ? { lastFlushCompactionCount: generation.flush.lastCompactionCount }
         : undefined),
     });
     if (!due) return;
-    const cycle = this.#compactionCount;
+    const cycle = generation.compactionCount;
     const settled = await settledUnlessAborted(
       hook({
         items: [...context.checkpoint().items],
@@ -1715,22 +1739,90 @@ export class BrainAgent {
       ),
       signal,
     );
-    if (settled.aborted) return;
-    if (housekeepingCompleted(settled.value.outcome)) {
-      this.#lastFlushCompactionCount = cycle;
+    if (settled.aborted || this.#revoked(turnContext)) return;
+    if (!housekeepingCompleted(settled.value.outcome)) {
+      this.#report(
+        `Memory flush did not complete (${settled.value.outcome}${settled.value.reason ? `: ${settled.value.reason}` : ""}); it runs again at the next assessment`,
+      );
       return;
     }
-    this.#report(
-      `Memory flush did not complete (${settled.value.outcome}${settled.value.reason ? `: ${settled.value.reason}` : ""}); it runs again at the next assessment`,
-    );
+    const marked = await this.#writeFlushMarker(turnContext, cycle);
+    if (marked.aborted || this.#revoked(turnContext)) return;
+    if (!marked.value.ok) {
+      this.#report(
+        `Memory flush completed but its marker could not be recorded after ${MEMORY_FLUSH_DEFAULTS.MARKER_WRITE_ATTEMPTS} attempt(s) (${marked.value.reason}); the cycle stays unflushed and runs again at the next assessment`,
+      );
+      return;
+    }
+    generation.flush.lastCompactionCount = cycle;
   }
 
-  /** How many times the context has folded since this agent stood up, and the cycle the last completed flush ran under. */
+  /**
+   * Fills the generation's flush marker from the store the first time it is
+   * needed. Answers whether the gate may be read: a store that cannot answer
+   * defers the flush to the next assessment rather than guessing, since a
+   * guess of "unflushed" repeats a housekeeping turn and a guess of
+   * "flushed" loses one.
+   */
+  async #readFlushMarker(
+    turnContext: Pick<TurnContext, "generation" | "signal">,
+  ): Promise<boolean> {
+    const { generation, signal } = turnContext;
+    if (generation.flush.read) return true;
+    const store = this.#options.flushMarker;
+    if (!store) {
+      generation.flush.read = true;
+      return true;
+    }
+    const read = await settledUnlessAborted(
+      store.read(generation.id).then(
+        (lastCompactionCount) => ({ ok: true as const, lastCompactionCount }),
+        (error: Error) => ({ ok: false as const, reason: error.message }),
+      ),
+      signal,
+    );
+    if (read.aborted || this.#revoked(turnContext)) return false;
+    if (!read.value.ok) {
+      this.#report(
+        `Memory flush marker could not be read (${read.value.reason}); the flush waits for the next assessment`,
+      );
+      return false;
+    }
+    generation.flush = { read: true, lastCompactionCount: read.value.lastCompactionCount };
+    return true;
+  }
+
+  /** Offers the completed flush's marker to the store, a bounded number of times; the turn itself is never rerun to retry. */
+  async #writeFlushMarker(
+    turnContext: Pick<TurnContext, "generation" | "signal">,
+    cycle: number,
+  ): Promise<Settled<{ ok: true } | { ok: false; reason: string }>> {
+    const store = this.#options.flushMarker;
+    if (!store) return { aborted: false, value: { ok: true } };
+    const attempts = async (): Promise<{ ok: true } | { ok: false; reason: string }> => {
+      let reason = "";
+      for (let attempt = 0; attempt < MEMORY_FLUSH_DEFAULTS.MARKER_WRITE_ATTEMPTS; attempt += 1) {
+        if (turnContext.signal.aborted) return { ok: false, reason: "the turn was revoked" };
+        try {
+          await store.write(turnContext.generation.id, cycle);
+          return { ok: true };
+        } catch (error) {
+          reason = error instanceof Error ? error.message : String(error);
+        }
+      }
+      return { ok: false, reason };
+    };
+    return settledUnlessAborted(attempts(), turnContext.signal);
+  }
+
+  /** Where the standing generation is in its compaction cycles, and the cycle the last completed flush ran under, as read so far. */
   flushCycle(): BrainFlushCycle {
+    const generation = this.#generation;
+    if (!generation) return { compactionCount: 0 };
     return {
-      compactionCount: this.#compactionCount,
-      ...(this.#lastFlushCompactionCount !== undefined
-        ? { lastFlushCompactionCount: this.#lastFlushCompactionCount }
+      compactionCount: generation.compactionCount,
+      ...(generation.flush.lastCompactionCount !== undefined
+        ? { lastFlushCompactionCount: generation.flush.lastCompactionCount }
         : undefined),
     };
   }
@@ -2512,7 +2604,7 @@ export class BrainAgent {
           return;
         case RUNTIME_EVENT.COMPACTED:
           gathering.compacted = true;
-          this.#compactionCount += 1;
+          turnContext.generation.compactionCount += 1;
           return;
         case RUNTIME_EVENT.STEERED:
           turn.plan.deliveries.ingested();

--- a/packages/brain/src/compaction.test.ts
+++ b/packages/brain/src/compaction.test.ts
@@ -415,6 +415,7 @@ test("a required compaction that fails ends the run recoverably and leaves the c
     expiresAt: NOW + 14 * 24 * 60 * 60 * 1000,
     checkpointFormat: "tool-loop@1:openai-responses-input/1",
     items: [userMessageItem("x".repeat(500))],
+    compactionCount: 0,
     cursors: {},
     captureCursors: {},
     inbox: [],

--- a/packages/brain/src/generation.ts
+++ b/packages/brain/src/generation.ts
@@ -48,6 +48,15 @@ export interface Generation {
   captureCursors: TranscriptCursors;
   /** The observations captured and not yet consumed, as last committed. */
   inbox: readonly BrainObservationEntry[];
+  /** How many times the context has folded in this generation; persisted with every checkpoint. */
+  compactionCount: number;
+  /**
+   * The flush marker as this generation has read it: whether the store has
+   * been consulted, and the compaction count the last completed flush ran
+   * under. Filled from the marker store at the first assessment and kept in
+   * step with every marker that lands after.
+   */
+  flush: { read: boolean; lastCompactionCount?: number };
   journal: BrainJournal;
   requests: Map<string, BrainRequestRecord>;
   /** Runs accepted in memory but not yet checkpointed; not yet acknowledged to anyone. */
@@ -158,6 +167,8 @@ export function generationFrom(
     cursors: new TranscriptCursors(state.cursors),
     captureCursors: new TranscriptCursors(state.captureCursors),
     inbox: [...state.inbox],
+    compactionCount: state.compactionCount,
+    flush: { read: false },
     journal: new BrainJournal(state.journal),
     requests: new Map(state.requests.map((record) => [record.runId, { ...record }])),
     provisional: new Set(),

--- a/packages/brain/src/index.ts
+++ b/packages/brain/src/index.ts
@@ -5,6 +5,7 @@ export {
   type BrainCompletionDelivery,
   type BrainFlushCycle,
   type BrainFlushInput,
+  type BrainFlushMarkerStore,
   type BrainLane,
   type BrainOpeningNotes,
   type BrainRecallAsk,

--- a/packages/brain/src/ledger.ts
+++ b/packages/brain/src/ledger.ts
@@ -232,6 +232,7 @@ export class BrainRequestLedger {
         return {
           ...(checkpointFormat !== undefined ? { checkpointFormat } : undefined),
           items: checkpoint ? checkpoint.items : state.items,
+          compactionCount: context ? generation.compactionCount : state.compactionCount,
           cursors: context ? generation.cursors.persisted() : state.cursors,
           captureCursors:
             scope.kind === SAVE_SCOPE.CAPTURE || scope.kind === SAVE_SCOPE.WHOLE

--- a/packages/brain/src/state-store.ts
+++ b/packages/brain/src/state-store.ts
@@ -92,6 +92,12 @@ export interface BrainPersistedState {
    */
   checkpointFormat?: string;
   items: readonly ResponsesInputItem[];
+  /**
+   * How many times this generation's context has folded. A property of the
+   * context the items are, so it rides on the envelope: the pre-compaction
+   * flush's cycle is this count, and a fresh generation starts at zero.
+   */
+  compactionCount: number;
   /** Where a model has read each transcript to, keyed by provider id, then by provider session id. */
   cursors: BrainTranscriptCursors;
   /** Where the inbox has captured each transcript to; ahead of `cursors` while entries wait. */
@@ -119,6 +125,7 @@ export function freshBrainState(generationId: string, now: number): BrainPersist
     createdAt: now,
     expiresAt: now + BRAIN_GENERATION_LIFETIME_MS,
     items: [],
+    compactionCount: 0,
     cursors: {},
     captureCursors: {},
     inbox: [],
@@ -143,6 +150,12 @@ export function brainPersistedStateFromWire(
   if (checkpointFormat === null) return undefined;
   const reset = resetMarkerFromWire(value.reset);
   if (reset === null || (reset && reset.clearedAt > value.createdAt)) return undefined;
+  // An envelope written before the count existed has folded under no rule
+  // this build reads; it starts its cycles at zero rather than as unreadable.
+  const compactionCount = value.compactionCount === undefined ? 0 : value.compactionCount;
+  if (!isWireNumber(compactionCount) || !Number.isInteger(compactionCount) || compactionCount < 0) {
+    return undefined;
+  }
   const items: ResponsesInputItem[] = [];
   for (const item of value.items) {
     if (!isRecord(item)) return undefined;
@@ -183,6 +196,7 @@ export function brainPersistedStateFromWire(
     expiresAt: value.expiresAt,
     ...(checkpointFormat !== undefined ? { checkpointFormat } : undefined),
     items,
+    compactionCount,
     cursors,
     captureCursors,
     inbox,

--- a/packages/memory/src/consolidation.ts
+++ b/packages/memory/src/consolidation.ts
@@ -677,12 +677,41 @@ function counts(values: readonly string[]): Map<string, number> {
   return result;
 }
 
+/** The most of an entry line the comparison reads; a MEMORY.md line is bounded by the file's own budget and a candidate by its text bound. */
+const COMPARABLE_FACT_MAX_CHARS = 4_000;
+const COMMENT_OPEN = "<!--";
+const COMMENT_CLOSE = "-->";
+
+/** Removes every `<!-- -->` comment by scanning, so a run of them costs one pass whatever it holds. */
+function withoutComments(value: string): string {
+  let result = "";
+  let from = 0;
+  for (;;) {
+    const open = value.indexOf(COMMENT_OPEN, from);
+    if (open === -1) return result + value.slice(from);
+    const close = value.indexOf(COMMENT_CLOSE, open + COMMENT_OPEN.length);
+    if (close === -1) return result + value.slice(from, open);
+    result += value.slice(from, open);
+    from = close + COMMENT_CLOSE.length;
+  }
+}
+
+/**
+ * Two entries are the same fact when they read the same once the bullet,
+ * the comments, the trailing source reference, whitespace, and case are set
+ * aside. This is a comparison normalizer and nothing renders its answer.
+ * Whitespace is collapsed first and the text bounded before any pattern
+ * runs, so a line of whitespace costs one pass rather than a backtrack.
+ */
 function comparableFact(value: string): string {
-  return value
+  const collapsed = value
     .replace(/^[-*+]\s+/u, "")
-    .replace(/\s*<!--[\s\S]*?-->/gu, "")
-    .replace(/\s+Source:\s+\S+#L\d+-L\d+\s*$/iu, "")
     .replace(/\s+/gu, " ")
+    .trim()
+    .slice(0, COMPARABLE_FACT_MAX_CHARS);
+  return withoutComments(collapsed)
+    .replace(/ ?Source: \S+#L\d+-L\d+ ?$/iu, "")
+    .replace(/ {2,}/gu, " ")
     .trim()
     .toLowerCase();
 }

--- a/packages/memory/src/flush.ts
+++ b/packages/memory/src/flush.ts
@@ -68,6 +68,19 @@ export function housekeepingCompleted(outcome: MemoryHousekeepingOutcome): boole
 }
 
 /**
+ * Whether a housekeeping turn's end is worth reporting: it was started and
+ * did not run to its end. A skipped turn — a conversation that never
+ * captures, or no brain standing to run one — is the expected answer, not a
+ * shortfall, and is not reported as one.
+ */
+export function housekeepingFellShort(outcome: MemoryHousekeepingOutcome): boolean {
+  return (
+    outcome === MEMORY_HOUSEKEEPING_OUTCOME.INTERRUPTED ||
+    outcome === MEMORY_HOUSEKEEPING_OUTCOME.FAILED
+  );
+}
+
+/**
  * The token count at which the flush fires: the compaction threshold less
  * the soft margin, the margin itself capped at half the room the reserve
  * leaves so a small window still flushes before it compacts.

--- a/packages/memory/src/flush.ts
+++ b/packages/memory/src/flush.ts
@@ -18,6 +18,12 @@ export const MEMORY_FLUSH_DEFAULTS = {
   FORCE_TRANSCRIPT_BYTES: 2 * 1024 * 1024,
   /** The most output tokens a housekeeping turn may spend. */
   MAXIMUM_OUTPUT_TOKENS: 2_000,
+  /**
+   * How many times the marker of a completed flush is offered to its store
+   * before the cycle is left unflushed; the housekeeping turn itself is never
+   * repeated to retry a write.
+   */
+  MARKER_WRITE_ATTEMPTS: 3,
 } as const;
 
 /** The pinned reply token a housekeeping turn answers when nothing is worth storing. */

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -101,6 +101,7 @@ export {
   dailyNotePathFor,
   type HousekeepingPrompt,
   housekeepingCompleted,
+  housekeepingFellShort,
   isAppendOnlyRewrite,
   isDailyNotePathForDay,
   localDayStamp,

--- a/packages/memory/src/maintenance.test.ts
+++ b/packages/memory/src/maintenance.test.ts
@@ -32,9 +32,11 @@ import {
   validateConsolidationPlan,
 } from "./consolidation.js";
 import {
+  housekeepingFellShort,
   isAppendOnlyRewrite,
   isDailyNotePathForDay,
   MEMORY_FLUSH_DEFAULTS,
+  MEMORY_HOUSEKEEPING_OUTCOME,
   memoryFlushPrompt,
   memoryFlushThreshold,
   shouldRunMemoryFlush,
@@ -143,6 +145,46 @@ test("recalled-context blocks are stripped and sensitive material is redacted be
   assert.equal(redacted.text.includes(REDACTED_TOKEN), true);
   assert.equal(prepareForIngestion(`${RECALLED_CONTEXT_MARKER}\nonly recalled`), undefined);
   assert.equal(prepareForIngestion("password: hunter2"), undefined);
+});
+
+test("private-key armor is redacted by scanning: a terminated block whole, an unterminated or cut one to the end, and a run of headers in linear time", () => {
+  const key = "-----BEGIN RSA PRIVATE KEY-----\nMIIEow\nAAAA\n-----END RSA PRIVATE KEY-----";
+  const whole = redactSensitiveText(`before ${key} after`);
+  assert.equal(whole.text, `before ${REDACTED_TOKEN} after`);
+  assert.equal(whole.redactions, 1);
+  // A block whose closing armor was cut off — by truncation or a line bound — still redacts its body.
+  const cut = redactSensitiveText("note -----BEGIN EC PRIVATE KEY-----\nMHcCAQEE body continues");
+  assert.equal(cut.text, `note ${REDACTED_TOKEN}`);
+  assert.equal(cut.redactions, 1);
+  // Two blocks are two redactions, and text between them stands.
+  const two = redactSensitiveText(`${key} and ${key}`);
+  assert.equal(two.text, `${REDACTED_TOKEN} and ${REDACTED_TOKEN}`);
+  assert.equal(two.redactions, 2);
+  // A BEGIN of something else is not a key and is left alone.
+  assert.equal(
+    redactSensitiveText("-----BEGIN CERTIFICATE-----\nabc\n-----END CERTIFICATE-----").redactions,
+    0,
+  );
+  const startedAt = performance.now();
+  const headers = "-----BEGIN RSA PRIVATE KEY-----\n".repeat(20_000);
+  assert.equal(
+    redactSensitiveText(headers).redactions,
+    1,
+    "an unterminated run is one redaction to the end",
+  );
+  assert.equal(
+    redactSensitiveText(`-----BEGIN RSA PRIVATE KEY-----${" ".repeat(200_000)}`).text,
+    REDACTED_TOKEN,
+  );
+  assert.ok(performance.now() - startedAt < 500, "the scan is linear in the text");
+});
+
+test("only an interrupted or failed housekeeping turn fell short; a skipped one is the expected answer and reports nothing", () => {
+  assert.equal(housekeepingFellShort(MEMORY_HOUSEKEEPING_OUTCOME.SKIPPED), false);
+  assert.equal(housekeepingFellShort(MEMORY_HOUSEKEEPING_OUTCOME.COMPLETED), false);
+  assert.equal(housekeepingFellShort(MEMORY_HOUSEKEEPING_OUTCOME.NOTHING_TO_STORE), false);
+  assert.equal(housekeepingFellShort(MEMORY_HOUSEKEEPING_OUTCOME.INTERRUPTED), true);
+  assert.equal(housekeepingFellShort(MEMORY_HOUSEKEEPING_OUTCOME.FAILED), true);
 });
 
 function seed(overrides: Partial<CandidateSeed> = {}): CandidateSeed {
@@ -262,6 +304,37 @@ test("a model plan is parsed against the candidates, validated against the prior
   );
   assert.ok(performance.now() - startedAt < 500, "a malformed fence is refused in linear time");
   assert.equal(validateConsolidationPlan({ previous: existing, plan, promotions }), undefined);
+  // A merge is compared against its prior entry after whitespace is collapsed
+  // and bounded, so an entry padded with a long whitespace run, or a run of
+  // comments, is judged in linear time rather than backtracked over.
+  const padded = `- Deploys go out on${" ".repeat(100_000)}Tuesday afternoons <!-- importance: 0.5 -->`;
+  const commented = `- ${"<!-- x -->".repeat(2_000)} Deploys go out on Tuesday afternoons`;
+  const mergePlan = {
+    operations: [
+      {
+        candidateKey: durable.key,
+        action: "merged",
+        priorEntries: [padded],
+      },
+    ],
+  };
+  const merging = parseConsolidationPlan(JSON.stringify(mergePlan), promotions);
+  assert.ok(merging);
+  const compareStartedAt = performance.now();
+  for (const previous of [`# MEMORY.md\n\n${padded}\n`, `# MEMORY.md\n\n${commented}\n`]) {
+    const [entry] = previous.split("\n").filter((line) => line.startsWith("- "));
+    assert.ok(entry);
+    const plan = parseConsolidationPlan(
+      JSON.stringify({ operations: [{ ...mergePlan.operations[0], priorEntries: [entry] }] }),
+      promotions,
+    );
+    assert.ok(plan);
+    assert.match(
+      validateConsolidationPlan({ previous, plan, promotions }) ?? "",
+      /unrelated prior entry/u,
+    );
+  }
+  assert.ok(performance.now() - compareStartedAt < 500, "the comparison is linear in the entry");
   const applied = applyConsolidationPlan({ existingMemory: existing, plan, day: "2026-09-08" });
   assert.ok(applied);
   assert.equal(applied.added, 1);

--- a/packages/memory/src/redaction.ts
+++ b/packages/memory/src/redaction.ts
@@ -49,8 +49,44 @@ const SENSITIVE_PATTERNS: readonly RegExp[] = [
   /\b(?:password|passwd|secret|token|api[_-]?key)\s*[:=]\s*\S+/giu,
   /\b(?:\d[ -]?){13,19}\b/gu,
   /\+?\b\d{1,3}[ .-]?\(?\d{2,4}\)?[ .-]?\d{3,4}[ .-]?\d{3,4}\b/gu,
-  /-----BEGIN [A-Z ]+PRIVATE KEY-----[\s\S]*?-----END [A-Z ]+PRIVATE KEY-----/gu,
 ];
+
+const PEM_BEGIN = "-----BEGIN ";
+const PEM_END = "-----END ";
+const PEM_HEADER_REST = /^[A-Z ]{1,64}PRIVATE KEY-----/u;
+
+/**
+ * Redacts private-key blocks by scanning for their armor rather than
+ * matching across their body: from each `BEGIN ... PRIVATE KEY` header to
+ * the end of the matching `END` header, or, when no END follows — the block
+ * truncated, or a line cut before it — conservatively to the end of the
+ * text, so a key body never passes because its closing armor did not.
+ */
+function redactPrivateKeys(text: string): RedactionResult {
+  let redactions = 0;
+  let result = "";
+  let from = 0;
+  for (;;) {
+    const begin = text.indexOf(PEM_BEGIN, from);
+    if (begin === -1) return { text: result + text.slice(from), redactions };
+    const header = PEM_HEADER_REST.exec(text.slice(begin + PEM_BEGIN.length, begin + 128));
+    if (!header) {
+      result += text.slice(from, begin + PEM_BEGIN.length);
+      from = begin + PEM_BEGIN.length;
+      continue;
+    }
+    const bodyFrom = begin + PEM_BEGIN.length + header[0].length;
+    let end = text.indexOf(PEM_END, bodyFrom);
+    while (end !== -1 && !PEM_HEADER_REST.test(text.slice(end + PEM_END.length, end + 128))) {
+      end = text.indexOf(PEM_END, end + PEM_END.length);
+    }
+    redactions += 1;
+    result += `${text.slice(from, begin)}${REDACTED_TOKEN}`;
+    if (end === -1) return { text: result, redactions };
+    const closing = PEM_HEADER_REST.exec(text.slice(end + PEM_END.length, end + 128));
+    from = end + PEM_END.length + (closing?.[0].length ?? 0);
+  }
+}
 
 export interface RedactionResult {
   readonly text: string;
@@ -59,8 +95,9 @@ export interface RedactionResult {
 
 /** Replaces every sensitive match with the fixed token and counts the replacements. */
 export function redactSensitiveText(text: string): RedactionResult {
-  let redactions = 0;
-  let scrubbed = text;
+  const keys = redactPrivateKeys(text);
+  let redactions = keys.redactions;
+  let scrubbed = keys.text;
   for (const pattern of SENSITIVE_PATTERNS) {
     scrubbed = scrubbed.replace(pattern, () => {
       redactions += 1;

--- a/packages/runtime-store/src/brain-envelope.ts
+++ b/packages/runtime-store/src/brain-envelope.ts
@@ -38,6 +38,7 @@ export interface StandingGeneration {
   expiresAt: number;
   resetClearedAt: number | undefined;
   resetGenerationId: string | undefined;
+  compactionCount: number;
 }
 
 export function standingGeneration(
@@ -47,7 +48,7 @@ export function standingGeneration(
   // SAFETY: the columns selected are the ones the row type names, typed by the schema.
   const row = database
     .prepare(
-      `SELECT session_id, created_at, expires_at, reset_cleared_at, reset_generation_id, checkpoint_format
+      `SELECT session_id, created_at, expires_at, reset_cleared_at, reset_generation_id, checkpoint_format, compaction_count
        FROM conversation_sessions WHERE session_key = ?`,
     )
     .get(sessionKey) as
@@ -58,6 +59,7 @@ export function standingGeneration(
         reset_cleared_at: number | null;
         reset_generation_id: string | null;
         checkpoint_format: string | null;
+        compaction_count: number;
       }
     | undefined;
   if (!row) return undefined;
@@ -68,6 +70,7 @@ export function standingGeneration(
     expiresAt: row.expires_at,
     resetClearedAt: row.reset_cleared_at ?? undefined,
     resetGenerationId: row.reset_generation_id ?? undefined,
+    compactionCount: row.compaction_count,
   };
 }
 
@@ -141,6 +144,7 @@ export function loadBrainEnvelope(database: RuntimeDatabase, sessionKey: Session
     expiresAt: session.expiresAt,
     ...(stamp !== undefined ? { checkpointFormat: stamp } : undefined),
     items: parsedItems,
+    compactionCount: session.compactionCount,
     cursors,
     captureCursors,
     inbox,
@@ -192,6 +196,11 @@ export function saveBrainEnvelope(
         .prepare("UPDATE conversation_sessions SET checkpoint_format = ? WHERE session_id = ?")
         .run(nullable(delta.checkpointFormat.stamp), sessionId);
     }
+    if (delta.compactionCount !== undefined) {
+      database
+        .prepare("UPDATE conversation_sessions SET compaction_count = ? WHERE session_id = ?")
+        .run(delta.compactionCount, sessionId);
+    }
     if (delta.items) {
       database
         .prepare("DELETE FROM runtime_checkpoints WHERE session_id = ? AND sequence >= ?")
@@ -241,8 +250,8 @@ function replaceGeneration(
   database
     .prepare(
       `INSERT INTO conversation_sessions
-         (session_id, session_key, created_at, expires_at, reset_cleared_at, reset_generation_id, checkpoint_format)
-       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+         (session_id, session_key, created_at, expires_at, reset_cleared_at, reset_generation_id, checkpoint_format, compaction_count)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
     )
     .run(
       state.generationId,
@@ -252,6 +261,7 @@ function replaceGeneration(
       nullable(state.reset?.clearedAt),
       nullable(state.reset?.generationId),
       nullable(stampOf(state)),
+      state.compactionCount,
     );
   if (state.reset) raiseHistoryCutoff(database, sessionKey, state.reset.clearedAt);
   insertItems(database, state.generationId, state.items, 0);

--- a/packages/runtime-store/src/client.ts
+++ b/packages/runtime-store/src/client.ts
@@ -302,8 +302,8 @@ export class RuntimeStoreClient {
     return this.request(RUNTIME_STORE_METHOD.MEMORY_REWRITES_LIST, {});
   }
 
-  memoryFlushState(sessionKey: SessionKey): Promise<FlushState | undefined> {
-    return this.request(RUNTIME_STORE_METHOD.MEMORY_FLUSH_STATE_GET, { sessionKey });
+  memoryFlushState(sessionKey: SessionKey, generationId: string): Promise<FlushState | undefined> {
+    return this.request(RUNTIME_STORE_METHOD.MEMORY_FLUSH_STATE_GET, { sessionKey, generationId });
   }
 
   recordMemoryFlush(sessionKey: SessionKey, state: FlushState): Promise<boolean> {

--- a/packages/runtime-store/src/envelope.ts
+++ b/packages/runtime-store/src/envelope.ts
@@ -39,6 +39,8 @@ export interface BrainStateDelta {
   /** The generation's stamp, when this save sets, changes, or clears it. */
   checkpointFormat?: { stamp: string | undefined };
   items?: BrainItemsDelta;
+  /** The generation's compaction count, when this save moved it. */
+  compactionCount?: number;
   cursors?: BrainTranscriptCursors;
   captureCursors?: BrainTranscriptCursors;
   /** The inbox whole, when it changed; it is small by construction and replaced rather than diffed. */
@@ -165,6 +167,9 @@ export function brainStateSave(
   if (items) delta.items = items;
   if (next.checkpointFormat !== previous.checkpointFormat) {
     delta.checkpointFormat = { stamp: next.checkpointFormat };
+  }
+  if (previous.compactionCount !== next.compactionCount) {
+    delta.compactionCount = next.compactionCount;
   }
   if (!sameJson(previous.cursors, next.cursors)) delta.cursors = next.cursors;
   if (!sameJson(previous.captureCursors, next.captureCursors)) {

--- a/packages/runtime-store/src/memory-maintenance-table.test.ts
+++ b/packages/runtime-store/src/memory-maintenance-table.test.ts
@@ -293,6 +293,7 @@ test("a schema 7 database gains the maintenance tables and the compaction count 
     }[]
   ).map((row) => row.name);
   assert.ok(columns.includes("compaction_count"));
+  // SAFETY: as above, for the flush-state table.
   const flushColumns = (
     eight.prepare("SELECT name FROM pragma_table_info('memory_flush_state')").all() as {
       name: string;

--- a/packages/runtime-store/src/memory-maintenance-table.test.ts
+++ b/packages/runtime-store/src/memory-maintenance-table.test.ts
@@ -165,19 +165,35 @@ test("a rewrite is published only over the content it was planned on, with its p
   );
 });
 
-test("flush state is recorded per conversation", () => {
+test("the flush marker is recorded per conversation and answers only for the generation it was written under", () => {
   const database = openTestDatabase();
-  assert.equal(flushState(database, MAIN_SESSION_KEY), undefined);
+  assert.equal(flushState(database, MAIN_SESSION_KEY, "gen-1"), undefined);
   recordFlush(database, MAIN_SESSION_KEY, {
+    generationId: "gen-1",
     compactionCount: 2,
-    outcome: MEMORY_HOUSEKEEPING_OUTCOME.INTERRUPTED,
+    outcome: MEMORY_HOUSEKEEPING_OUTCOME.COMPLETED,
     flushedAt: NOW,
   });
-  assert.deepEqual(flushState(database, MAIN_SESSION_KEY), {
+  assert.deepEqual(flushState(database, MAIN_SESSION_KEY, "gen-1"), {
+    generationId: "gen-1",
     compactionCount: 2,
-    outcome: MEMORY_HOUSEKEEPING_OUTCOME.INTERRUPTED,
+    outcome: MEMORY_HOUSEKEEPING_OUTCOME.COMPLETED,
     flushedAt: NOW,
   });
+  // A generation that replaced gen-1 reads no marker from it: its cycles start unflushed.
+  assert.equal(flushState(database, MAIN_SESSION_KEY, "gen-2"), undefined);
+  recordFlush(database, MAIN_SESSION_KEY, {
+    generationId: "gen-2",
+    compactionCount: 0,
+    outcome: MEMORY_HOUSEKEEPING_OUTCOME.NOTHING_TO_STORE,
+    flushedAt: NOW + 1,
+  });
+  assert.equal(flushState(database, MAIN_SESSION_KEY, "gen-2")?.compactionCount, 0);
+  assert.equal(
+    flushState(database, MAIN_SESSION_KEY, "gen-1"),
+    undefined,
+    "one marker per conversation",
+  );
 });
 
 test("forgetting a source removes its candidates and the MEMORY.md entries they produced, tombstones it against relearning, and reports what a hand edit left unattributable", () => {
@@ -253,7 +269,7 @@ test("forgetting a source removes its candidates and the MEMORY.md entries they 
   assert.equal(listMemoryRewrites(database).length, 1, "the scrub kept its preimage");
 });
 
-test("a schema 7 database gains the maintenance tables at open and reads as schema 8", () => {
+test("a schema 7 database gains the maintenance tables and the compaction count at open and reads as schema 9", () => {
   const file = path.join(workspace(), "agent.sqlite");
   const seven = RuntimeDatabase.open(file);
   seven.exec("DROP TABLE memory_candidates");
@@ -262,13 +278,27 @@ test("a schema 7 database gains the maintenance tables at open and reads as sche
   seven.exec("DROP TABLE memory_forgotten_sources");
   seven.exec("DROP TABLE memory_rewrites");
   seven.exec("DROP TABLE memory_flush_state");
+  seven.exec("ALTER TABLE conversation_sessions DROP COLUMN compaction_count");
   seven.exec("UPDATE schema_version SET version = 7");
   seven.close();
   const eight = RuntimeDatabase.open(file);
   // SAFETY: the schema_version table has one integer column.
   const version = eight.prepare("SELECT version FROM schema_version").get() as { version: number };
   assert.equal(version.version, RUNTIME_SCHEMA_VERSION);
-  assert.equal(RUNTIME_SCHEMA_VERSION, 8);
+  assert.equal(RUNTIME_SCHEMA_VERSION, 9);
+  // SAFETY: pragma table_info answers one row per column with its name as text.
+  const columns = (
+    eight.prepare("SELECT name FROM pragma_table_info('conversation_sessions')").all() as {
+      name: string;
+    }[]
+  ).map((row) => row.name);
+  assert.ok(columns.includes("compaction_count"));
+  const flushColumns = (
+    eight.prepare("SELECT name FROM pragma_table_info('memory_flush_state')").all() as {
+      name: string;
+    }[]
+  ).map((row) => row.name);
+  assert.ok(flushColumns.includes("generation_id"));
   // SAFETY: sqlite_master's name column is text.
   const tables = (
     eight

--- a/packages/runtime-store/src/memory-maintenance-table.ts
+++ b/packages/runtime-store/src/memory-maintenance-table.ts
@@ -554,29 +554,39 @@ export function readDurableMemoryFile(
   return { content, hash: hashText(content) };
 }
 
+/** A conversation's last recorded flush: the generation and compaction cycle it ran under, and how it ended. */
 export interface FlushState {
+  readonly generationId: string;
   readonly compactionCount: number;
   readonly outcome: MemoryHousekeepingOutcome;
   readonly flushedAt: number;
 }
 
+/** The conversation's flush marker, only when it was written under the generation asked about. */
 export function flushState(
   database: RuntimeDatabase,
   sessionKey: SessionKey,
+  generationId: string,
 ): FlushState | undefined {
   // SAFETY: the columns selected are the ones the row type names.
   const row = database
     .prepare(
-      "SELECT compaction_count, outcome, flushed_at FROM memory_flush_state WHERE session_key = ?",
+      `SELECT generation_id, compaction_count, outcome, flushed_at FROM memory_flush_state
+       WHERE session_key = ? AND generation_id = ?`,
     )
-    .get(sessionKey) as
-    | { compaction_count: number; outcome: string; flushed_at: number }
+    .get(sessionKey, generationId) as
+    | { generation_id: string; compaction_count: number; outcome: string; flushed_at: number }
     | undefined;
   if (!row) return undefined;
   const outcome = OUTCOMES.find((candidate) => candidate === row.outcome);
   // An outcome this build does not name reads as no recorded flush rather than as a failed one.
   if (!outcome) return undefined;
-  return { compactionCount: row.compaction_count, outcome, flushedAt: row.flushed_at };
+  return {
+    generationId: row.generation_id,
+    compactionCount: row.compaction_count,
+    outcome,
+    flushedAt: row.flushed_at,
+  };
 }
 
 export function recordFlush(
@@ -586,12 +596,13 @@ export function recordFlush(
 ): void {
   database
     .prepare(
-      `INSERT INTO memory_flush_state (session_key, compaction_count, outcome, flushed_at)
-       VALUES (?, ?, ?, ?)
-       ON CONFLICT(session_key) DO UPDATE SET compaction_count = excluded.compaction_count,
+      `INSERT INTO memory_flush_state (session_key, generation_id, compaction_count, outcome, flushed_at)
+       VALUES (?, ?, ?, ?, ?)
+       ON CONFLICT(session_key) DO UPDATE SET generation_id = excluded.generation_id,
+         compaction_count = excluded.compaction_count,
          outcome = excluded.outcome, flushed_at = excluded.flushed_at`,
     )
-    .run(sessionKey, state.compactionCount, state.outcome, state.flushedAt);
+    .run(sessionKey, state.generationId, state.compactionCount, state.outcome, state.flushedAt);
 }
 
 export interface MemoryForgetAsk {

--- a/packages/runtime-store/src/protocol.ts
+++ b/packages/runtime-store/src/protocol.ts
@@ -248,7 +248,7 @@ export interface RuntimeStoreMethods {
     result: readonly MemoryRewriteRecord[];
   };
   [RUNTIME_STORE_METHOD.MEMORY_FLUSH_STATE_GET]: {
-    params: { sessionKey: SessionKey };
+    params: { sessionKey: SessionKey; generationId: string };
     result: FlushState | undefined;
   };
   [RUNTIME_STORE_METHOD.MEMORY_FLUSH_STATE_PUT]: {

--- a/packages/runtime-store/src/schema.ts
+++ b/packages/runtime-store/src/schema.ts
@@ -73,7 +73,21 @@
 
 import type { SQLInputValue } from "node:sqlite";
 import { LEGACY_CHECKPOINT_FORMAT_TAG } from "@sidecar/brain";
-export const RUNTIME_SCHEMA_VERSION = 8;
+
+/**
+ * One flush marker per conversation: the generation and compaction count the
+ * last completed flush ran under. A row is consulted only for the generation
+ * it names, so a marker from an earlier lifetime never reads as this cycle's.
+ */
+const MEMORY_FLUSH_STATE_TABLE = `CREATE TABLE IF NOT EXISTS memory_flush_state (
+    session_key TEXT PRIMARY KEY,
+    generation_id TEXT NOT NULL,
+    compaction_count INTEGER NOT NULL,
+    outcome TEXT NOT NULL,
+    flushed_at INTEGER NOT NULL
+  )`;
+
+export const RUNTIME_SCHEMA_VERSION = 9;
 
 /**
  * How a database at an earlier version is brought to this one, in order. Each
@@ -133,6 +147,21 @@ export const RUNTIME_SCHEMA_MIGRATIONS: ReadonlyMap<number, readonly SchemaMigra
     [6, []],
     [7, []],
     [8, []],
+    [
+      9,
+      [
+        {
+          sql: "ALTER TABLE conversation_sessions ADD COLUMN compaction_count INTEGER NOT NULL DEFAULT 0",
+          params: [],
+        },
+        // The flush marker is keyed by the generation it was written under
+        // from this version on; rows from before it name no generation and
+        // were read by nothing, so the table starts over rather than
+        // carrying a marker no cycle can claim.
+        { sql: "DROP TABLE memory_flush_state", params: [] },
+        { sql: MEMORY_FLUSH_STATE_TABLE, params: [] },
+      ],
+    ],
   ]);
 
 export const RUNTIME_SCHEMA_STATEMENTS: readonly string[] = [
@@ -164,7 +193,8 @@ export const RUNTIME_SCHEMA_STATEMENTS: readonly string[] = [
     expires_at INTEGER NOT NULL,
     reset_cleared_at INTEGER,
     reset_generation_id TEXT,
-    checkpoint_format TEXT
+    checkpoint_format TEXT,
+    compaction_count INTEGER NOT NULL DEFAULT 0
   )`,
   `CREATE UNIQUE INDEX IF NOT EXISTS conversation_sessions_one_standing
     ON conversation_sessions(session_key)`,
@@ -403,10 +433,5 @@ export const RUNTIME_SCHEMA_STATEMENTS: readonly string[] = [
     candidate_keys TEXT NOT NULL,
     created_at INTEGER NOT NULL
   )`,
-  `CREATE TABLE IF NOT EXISTS memory_flush_state (
-    session_key TEXT PRIMARY KEY,
-    compaction_count INTEGER NOT NULL,
-    outcome TEXT NOT NULL,
-    flushed_at INTEGER NOT NULL
-  )`,
+  MEMORY_FLUSH_STATE_TABLE,
 ];

--- a/packages/runtime-store/src/worker-host.ts
+++ b/packages/runtime-store/src/worker-host.ts
@@ -179,7 +179,7 @@ const HANDLERS: RuntimeStoreHandlers = {
     publishMemoryRewrite(host.opened(), host.workspace(), params.ask, params.now),
   [RUNTIME_STORE_METHOD.MEMORY_REWRITES_LIST]: (host) => listMemoryRewrites(host.opened()),
   [RUNTIME_STORE_METHOD.MEMORY_FLUSH_STATE_GET]: (host, params) =>
-    flushState(host.opened(), params.sessionKey),
+    flushState(host.opened(), params.sessionKey, params.generationId),
   [RUNTIME_STORE_METHOD.MEMORY_FLUSH_STATE_PUT]: (host, params) => {
     recordFlush(host.opened(), params.sessionKey, params.state);
     return true;


### PR DESCRIPTION
Follow-up to PR 8 (#756, merged as 84db3b6). Rebased onto main at f7137075 (#760 squash, above #777 at 2b221d12, #766 at e6fdaa49, #763 at ed32085); only these four commits are the PR's own. #760 moved the brain, memory, and store wiring into `apps/desktop/src/main/host/runtime-host.ts`, so the `flushMarker` dependency is supplied there beside `beforeCompaction` and `beforeReset`; `desktop-app.ts` is untouched. Never merge, auto-merge, enqueue, or stack-merge this from an agent; the orchestrator owns the final CI merge.

## Part 1 (shipped here): durable flush cycle

The "once per compaction cycle" gate ran on two `BrainAgent` fields that reset at every relaunch, and the `memory_flush_state` row was written after every flush and read by nothing. This makes the guarantee restart-safe, with one owner for each half:

- **Compaction count on the generation envelope.** `BrainPersistedState.compactionCount` (fresh generation: 0; an envelope written before the field reads as 0) is carried on `Generation`, bumped where the context folds, and written with every checkpoint. Runtime store schema 9 adds `conversation_sessions.compaction_count` and the envelope delta carries it.
- **Flush marker in the maintenance table, keyed by generation.** `memory_flush_state` gains `generation_id`; `flushState(db, sessionKey, generationId)` answers only a row written under that generation, so a marker from an earlier lifetime is never read as this cycle's. The migration recreates the table (its previous rows were read by nothing). Clear, Start fresh, and Delete history replace the generation, so the new lifetime starts at cycle zero and consults no earlier marker. Reset capture still runs before the reset.
- **The agent reads and writes the marker** through the new `BrainAgentOptions.flushMarker` (`BrainFlushMarkerStore { read(generationId); write(generationId, compactionCount) }`): read once per generation before its first assessment (a read that fails defers the flush and reports), written after each completed flush with `MEMORY_FLUSH_DEFAULTS.MARKER_WRITE_ATTEMPTS` (3) bounded attempts; a write that still fails is reported and leaves the cycle unflushed, never silently marked done. The housekeeping turn is never rerun to retry a write. A hook answer other than completed writes no marker, as before.
  **Limitation:** the in-memory marker is set only after the write is confirmed. If the turn's signal fires while the write is in flight (stop, replacement), the write may still land on disk while the generation's cache stays unflushed, so the next assessment in the same process can flush that cycle a second time; the cache converges on re-read or relaunch. Assigned to a separate follow-up writer; not folded here.
- Tests: `packages/brain/src/agent-flush.test.ts` (restart in the same cycle, compaction then restart, Start fresh, failed marker write, failed turn writes no marker), `packages/runtime-store/src/memory-maintenance-table.test.ts` (generation scoping, schema 9 migration), `apps/desktop/src/main/memory-maintenance.test.ts` (marker store per conversation and generation).
- AGENTS.md's memory paragraph gains the ownership sentences. PRIVACY.md is unchanged: a count and a marker are not new kinds of content.

### Interface changes PR 9 (`conductor/openclaw-pr-09-gateway-client-and-node-protocol`) should propagate

- `MemoryMaintenance` gains `flushMarkerFor(sessionKey): BrainFlushMarkerStore | undefined`. `flushHookFor`, `captureBeforeReset`, `forget`, `runConsolidation`, `capturesOnReset` are unchanged.
- `BrainAgentOptions` gains optional `flushMarker`. `beforeCompaction`, `beforeReset`, `BrainFlushInput`, `BrainFlushCycle`, and `flushCycle()` keep their names; `flushCycle()` now reports the standing generation's count.
- Brain wiring dependencies gain optional `flushMarker: (sessionKey) => BrainFlushMarkerStore | undefined`.
- `BrainPersistedState.compactionCount: number` is required on the type (literal envelopes in tests need it).
- `FlushState` gains `generationId`; `RuntimeStoreClient.memoryFlushState(sessionKey, generationId)` takes the generation; `RUNTIME_SCHEMA_VERSION` is 9.
- The `@sidecar/memory` barrel is unchanged (`MEMORY_FLUSH_DEFAULTS` gains a key).

## Part 2 (deferred, tracked): cron dispatch registry

`desktop-app.ts` special-cases `job.id === CONSOLIDATION_DEFAULTS.JOB_ID` inside the shared cron `run` before the heartbeat dispatch. The clean shape is a map of managed-job handlers with the heartbeat as default. Deferred until PR 9's rewrite of that region and Gateway scheduling (PR 9/10) settle; done only if the orchestrator says so.

## Part 4 (shipped here): narrow hardening from PR 8's CodeQL review

- `comparableFact` collapsed and bounded the text before any pattern runs and strips comments by scanning, so a 100k-whitespace or 2,000-comment entry compares in linear time (timing regression in `maintenance.test.ts`). It is a comparison normalizer; nothing renders its answer.
- PEM redaction scans for the armor instead of matching lazily across the body; within the text unit it is given, an unterminated or cut block is redacted to the end of that unit. `noteSeeds` bounds a raw note line (4,000 chars) before scrubbing, and the rehydration read applies the same bound. **Limitation:** the protection is per text unit (one History line, one note line, one rehydrated slice), not per whole multiline dated note. A key whose `BEGIN` header sits on an earlier note line than its body is scrubbed only on the header's line; the body lines that follow carry no armor and pass the scan, and the generic PKCS8 header shape is only covered where it reads `... PRIVATE KEY-----`. Assigned to a separate follow-up writer; not folded here.
- A SKIPPED reset capture (ineligible conversation, or no brain standing) is the expected answer and is no longer reported as "did not complete"; only INTERRUPTED and FAILED are (`housekeepingFellShort`, test in `wiring-children.test.ts`). The `stripFences` fix landed on PR 8 and is adopted from main, not duplicated.

## Part 5 (shipped here): note seeds starved behind a full History budget

Notes took only what the conversations left of `LIGHT_LIMIT`, and a note line already held was charged again every sweep, so two full days of History let a completed note age out of the two-day lookback unstaged. Notes now take up to half the limit first, held lines cost nothing, the conversations take the rest, and either side's leftover goes to the other. Retention and the lookback are unchanged; forgetting and tombstones untouched. Test: 250 History lines plus a 20-line completed note across three sweeps.

## Part 3 (parked, not in this PR): structural cleanup

Steps 1 and 2 (one private-turn launcher `runPrivateTurn`/`completeToolFree`; `consolidation.ts` split into candidate, signals, deep-ranking, markers, plan, diary with the barrel unchanged) are committed and tested on `conductor/openclaw-pr-08-follow-up-memory-cleanup-wip`. Steps 3 to 5 (sweep into `packages/memory/src/sweep.ts` behind a port, `ingestion.ts`, `decideDeepRewrite`, one eligibility predicate, duplicates) are written on that branch as an unverified WIP commit. Held out of this PR so the correctness batch integrates cleanly with #763/#766.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34276995987/artifacts/10076243866) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34276995987)

- Commit: `63517d709a8a2215bc578005071bd3b9916dc270`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
