### PR TITLE
fix(memory): sync follow-on, exact-token History admission, trusted recall signals, live recall cache invalidation

### DIFF
--- a/apps/desktop/src/main/memory-wiring.ts
+++ b/apps/desktop/src/main/memory-wiring.ts
@@ -57,7 +57,7 @@ export interface MemoryWiring {
   /** Syncs once and starts watching; a run with nothing on disk does neither. */
   start: () => Promise<void>;
   stop: () => void;
-  /** One reconcile of the index against the files; concurrent calls share one pass. */
+  /** One reconcile of the index against the files; a call during a pass earns one follow-on pass under the adapter standing then. */
   sync: () => Promise<MemorySyncReport | undefined>;
   /** The brain's memory tools for one conversation. */
   accessFor: (sessionKey: SessionKey) => BrainMemoryAccess | undefined;

--- a/packages/memory/src/notebook-memory.test.ts
+++ b/packages/memory/src/notebook-memory.test.ts
@@ -557,3 +557,101 @@ test("a launch before any credential indexes keyword-only, and the first credent
   const third = await h.memory.sync();
   assert.equal(third?.indexedFiles, 0, "once every chunk has a vector the files are left alone");
 });
+
+test("a sync asked for during a pass runs one follow-on pass under the adapter that stands then, and every request during the pass shares it", async () => {
+  let credential: EmbeddingAdapter | undefined;
+  let synced = 0;
+  const h = harness({
+    embeddingAdapter: () => credential,
+    onSynced: () => {
+      synced += 1;
+    },
+  });
+  const plan = h.store.planMemorySync.bind(h.store);
+  let release: (() => void) | undefined;
+  const gate = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  let plans = 0;
+  h.store.planMemorySync = async (identity: EmbeddingModelIdentity | undefined) => {
+    plans += 1;
+    if (plans === 1) await gate;
+    return plan(identity);
+  };
+  const launch = h.memory.sync();
+  credential = h.embedding;
+  const requested = h.memory.sync();
+  const again = h.memory.sync();
+  assert.equal(requested, again, "requests during one pass share the follow-on");
+  assert.notEqual(requested, launch);
+  release?.();
+  const first = await launch;
+  assert.equal(
+    first?.mode,
+    RETRIEVAL_MODE.KEYWORD_ONLY,
+    "the pass under way kept its adapter read",
+  );
+  const second = await requested;
+  assert.equal(second?.mode, RETRIEVAL_MODE.HYBRID);
+  assert.ok(second && second.embeddedChunks > 0);
+  assert.equal(h.store.status().embeddedChunks, h.store.status().chunks);
+  assert.equal(plans, 2, "exactly one follow-on pass ran");
+  assert.equal(synced, 2);
+  const idle = await h.memory.sync();
+  assert.equal(idle?.indexedFiles, 0);
+  assert.equal(plans, 3, "no pass runs that was not asked for");
+});
+
+test("recall signals: an ask with no intent records nothing, and an intent-bearing trusted lookup records the notebook results it retrieved exactly once", async () => {
+  const recorded: { query: string; paths: string[] }[] = [];
+  const h = harness({
+    onNotebookResults: async (query, results) => {
+      recorded.push({ query, paths: results.map((result) => result.path) });
+    },
+  });
+  await h.memory.sync();
+  const recall = h.memory.recallFor(MAIN_SESSION_KEY);
+  assert.ok(recall);
+  await recall({ query: "open the frankfurt cluster", signal: signal() });
+  assert.deepEqual(recorded, [], "no lookup, no signal");
+  await recall({ query: "remind me where we put the frankfurt cluster", signal: signal() });
+  assert.equal(h.subruns.length, 0);
+  assert.deepEqual(recorded, [
+    { query: "remind me where we put the frankfurt cluster", paths: [MEMORY_FILE] },
+  ]);
+});
+
+test("clearing the recall caches reaches a recall already bound, and a recall that began before the clear caches nothing when it lands", async () => {
+  let held: Promise<void> = Promise.resolve();
+  let subruns = 0;
+  const h = harness({
+    runSubrun: async (ask) => {
+      subruns += 1;
+      await held;
+      return recallingSubrun(ask);
+    },
+  });
+  await h.memory.sync();
+  const recall = h.memory.recallFor(MAIN_SESSION_KEY);
+  assert.ok(recall);
+  const query = "what did we decide about espresso?";
+  const first = await recall({ query, signal: signal() });
+  assert.ok(first);
+  await recall({ query, signal: signal() });
+  assert.equal(subruns, 1, "the second ask inside the window is served from the cache");
+  h.memory.clearRecallCaches();
+  await recall({ query, signal: signal() });
+  assert.equal(subruns, 2, "the same bound recall runs again after the clear");
+  let release: (() => void) | undefined;
+  held = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  h.memory.clearRecallCaches();
+  const pending = recall({ query, signal: signal() });
+  while (subruns < 3) await new Promise((resolve) => setTimeout(resolve, 1));
+  h.memory.clearRecallCaches();
+  release?.();
+  assert.equal(await pending, first, "the run under way still answers its own caller");
+  await recall({ query, signal: signal() });
+  assert.equal(subruns, 4, "a run that began before the clear left no cached answer behind");
+});

--- a/packages/memory/src/notebook-memory.ts
+++ b/packages/memory/src/notebook-memory.ts
@@ -261,6 +261,7 @@ export class NotebookMemory {
   #standing: RetrievalStanding = { mode: RETRIEVAL_MODE.KEYWORD_ONLY };
   #watcher: MemoryWatcher | undefined;
   #syncing: Promise<MemorySyncReport | undefined> | undefined;
+  #followOn: Promise<MemorySyncReport | undefined> | undefined;
 
   constructor(options: NotebookMemoryOptions) {
     this.#options = options;
@@ -290,10 +291,33 @@ export class NotebookMemory {
     this.#watcher = undefined;
   }
 
-  /** One reconcile of the index against the files; concurrent calls share one pass. */
+  /**
+   * One reconcile of the index against the files. A call while no pass runs
+   * starts one and answers its report. A call during a pass answers the one
+   * follow-on pass that starts when the running one ends, because the running
+   * pass read the adapter once when it began and a credential published
+   * meanwhile is what the caller is asking to be seen; every call during the
+   * same pass shares that follow-on, and a call during the follow-on
+   * schedules one more, so requests coalesce and a pass runs only when one
+   * was asked for. A pass that fails reports and answers nothing without
+   * cancelling the follow-on it owes; stop() closes the watcher and leaves a
+   * pass already promised to finish.
+   */
   sync(): Promise<MemorySyncReport | undefined> {
-    if (this.#syncing) return this.#syncing;
-    this.#syncing = this.#syncOnce()
+    if (!this.#syncing) {
+      this.#syncing = this.#runPass();
+      return this.#syncing;
+    }
+    this.#followOn ??= this.#syncing.then(() => {
+      this.#followOn = undefined;
+      this.#syncing ??= this.#runPass();
+      return this.#syncing;
+    });
+    return this.#followOn;
+  }
+
+  #runPass(): Promise<MemorySyncReport | undefined> {
+    return this.#syncOnce()
       .then((report) => {
         this.#options.onSynced?.();
         return report;
@@ -307,7 +331,6 @@ export class NotebookMemory {
       .finally(() => {
         this.#syncing = undefined;
       });
-    return this.#syncing;
   }
 
   /** The brain's memory tools for one conversation. */
@@ -345,9 +368,15 @@ export class NotebookMemory {
     };
   }
 
-  /** Forgets every cached recall, after a forget or a durable rewrite changed what a recall would say. */
+  /**
+   * Forgets every cached recall, after a forget or a durable rewrite changed
+   * what a recall would say. The recalls stay where the conversations that
+   * bound them can reach them; each drops its cached answers and refuses to
+   * cache a run that began before the clear, so a recall still in flight
+   * settles for its own callers and leaves nothing stale behind.
+   */
   clearRecallCaches(): void {
-    this.#recalls.clear();
+    for (const recall of this.#recalls.values()) recall.invalidate();
   }
 
   /** The recall an eligible conversation's asks run, or nothing for one that does not recall. */
@@ -444,6 +473,10 @@ export class NotebookMemory {
       embedding,
       MEMORY_SEARCH_DEFAULTS.MAXIMUM_RESULTS,
     );
+    // The lookup is a real retrieval from the notebook, so what it surfaced is
+    // a recall signal like any search's; the conversation fallback never runs
+    // here, so no line of History can be mistaken for one.
+    void this.#options.onNotebookResults?.(query, notebook.results);
     return {
       strongHit: notebook.results.some(
         (result) => result.score >= MEMORY_SEARCH_DEFAULTS.MINIMUM_SCORE,

--- a/packages/memory/src/recall.ts
+++ b/packages/memory/src/recall.ts
@@ -216,6 +216,7 @@ export class ConversationRecall {
   readonly #inFlight = new Map<string, Promise<RecallResult>>();
   #consecutiveTimeouts = 0;
   #lastTimeoutAt = 0;
+  #cacheEpoch = 0;
 
   constructor(options: ConversationRecallOptions) {
     this.#options = options;
@@ -241,6 +242,18 @@ export class ConversationRecall {
       return false;
     }
     return true;
+  }
+
+  /**
+   * Drops every cached answer and every run still shared, and fences the
+   * runs under way: one that finishes after this call answers its own callers
+   * and caches nothing, because what it read may no longer stand. The
+   * breaker's count is untouched; a forget says nothing about timeouts.
+   */
+  invalidate(): void {
+    this.#cacheEpoch += 1;
+    this.#cache.clear();
+    this.#inFlight.clear();
   }
 
   /** For inspection: how many timeouts in a row the breaker has counted. */
@@ -277,6 +290,7 @@ export class ConversationRecall {
 
   async #run(ask: RecallAsk, key: string): Promise<RecallResult> {
     const startedAt = this.#now();
+    const epoch = this.#cacheEpoch;
     const elapsed = () => this.#now() - startedAt;
     const decision = await decideRecall(ask.query, () =>
       this.#options.trustedMemory(ask.query, ask.signal),
@@ -356,7 +370,7 @@ export class ConversationRecall {
     } finally {
       clearTimeout(timer);
     }
-    if (result.status === RECALL_STATUS.OK) {
+    if (result.status === RECALL_STATUS.OK && epoch === this.#cacheEpoch) {
       const ttl = this.#options.cacheTtlMs ?? RECALL_DEFAULTS.CACHE_TTL_MS;
       this.#cache.set(key, { expiresAt: this.#now() + ttl, result });
       while (this.#cache.size > RECALL_DEFAULTS.MAXIMUM_CACHE_ENTRIES) {

--- a/packages/runtime-store/src/database.test.ts
+++ b/packages/runtime-store/src/database.test.ts
@@ -22,7 +22,13 @@ import { loadBrainEnvelope, saveBrainEnvelope } from "./brain-envelope.js";
 import { createConversation, raiseHistoryCutoff } from "./conversations-table.js";
 import { RuntimeDatabase } from "./database.js";
 import { EnvelopeTracker, SAVE_KIND } from "./envelope.js";
-import { appendHistory, historyClearedAt, listHistory, searchHistory } from "./history-table.js";
+import {
+  appendHistory,
+  HISTORY_SEARCH_MAXIMUM_SCANNED_ROWS,
+  historyClearedAt,
+  listHistory,
+  searchHistory,
+} from "./history-table.js";
 import { RUNTIME_SCHEMA_VERSION } from "./schema.js";
 import { inspectHistory, line, NOW, openTestDatabase, populatedState, request } from "./testing.js";
 
@@ -319,6 +325,78 @@ test("history search reads only the conversations named, under each one's cutoff
   assert.equal(
     searchHistory(database, [MAIN_SESSION_KEY, thread], "tuesday", 10, NOW + 3).length,
     1,
+  );
+});
+
+test("history search admits lines by exact token before the limit is spent, so recent substring-only lines cannot crowd an older match out", () => {
+  const database = openTestDatabase();
+  // SAFETY: a thread key of the documented shape, built by hand for the test.
+  const thread =
+    "agent:main:thread:11111111-1111-1111-1111-111111111111" as typeof MAIN_SESSION_KEY;
+  createConversation(database, {
+    agentId: DEFAULT_AGENT_ID,
+    sessionKey: thread,
+    name: "Thread",
+    now: NOW,
+  });
+  appendHistory(
+    database,
+    MAIN_SESSION_KEY,
+    [line("Deploy? Tuesday, we said.", NOW, { eventId: "exact" })],
+    NOW,
+  );
+  const crowd = Array.from({ length: 60 }, (_, index) =>
+    line(`deployment tuesday note ${index}`, NOW + 1 + index, { eventId: `crowd-${index}` }),
+  );
+  appendHistory(database, thread, crowd, NOW + 100);
+  appendHistory(
+    database,
+    thread,
+    [line("we redeploy TUESDAYS only", NOW + 200, { eventId: "substring" })],
+    NOW + 200,
+  );
+  const hits = searchHistory(database, [MAIN_SESSION_KEY, thread], "tuesday deploy", 6, NOW + 300);
+  assert.deepEqual(
+    hits.map((hit) => [hit.sessionKey, hit.entry.words]),
+    [[MAIN_SESSION_KEY, "Deploy? Tuesday, we said."]],
+    "only the line carrying every token as a word is a hit, in any order, case, or punctuation",
+  );
+  assert.equal(
+    searchHistory(database, [MAIN_SESSION_KEY, thread], "deployment", 6, NOW + 300).length,
+    6,
+    "the limit still bounds the whole answer across the conversations named",
+  );
+  raiseHistoryCutoff(database, MAIN_SESSION_KEY, NOW);
+  assert.equal(
+    searchHistory(database, [MAIN_SESSION_KEY, thread], "tuesday deploy", 6, NOW + 300).length,
+    0,
+    "a cleared conversation's lines are not reached by any page of the scan",
+  );
+  const many = Array.from({ length: HISTORY_SEARCH_MAXIMUM_SCANNED_ROWS }, (_, index) =>
+    line(`deployments ${index}`, NOW + 1000 + index, { eventId: `many-${index}` }),
+  );
+  appendHistory(database, thread, many, NOW + 5000);
+  appendHistory(
+    database,
+    thread,
+    [line("deploy now", NOW + 500, { eventId: "behind" })],
+    NOW + 5000,
+  );
+  assert.equal(
+    searchHistory(database, [thread], "deploy", 6, NOW + 6000).length,
+    0,
+    "a match behind more substring-only lines than the scan bound is not found: the bound is the documented limit",
+  );
+  assert.equal(
+    searchHistory(
+      database,
+      [thread],
+      "deploy",
+      6,
+      NOW + 1000 + HISTORY_SEARCH_MAXIMUM_SCANNED_ROWS - 2,
+    ).length,
+    1,
+    "and the same match is found once fewer lines stand in front of it",
   );
 });
 

--- a/packages/runtime-store/src/history-table.ts
+++ b/packages/runtime-store/src/history-table.ts
@@ -215,15 +215,27 @@ function listRetained(
 
 export type HistorySearchHit = ConversationLineHit;
 
+/** How many rows past the limit one page asks for, since the substring prefilter admits rows the token match will drop. */
+const HISTORY_SEARCH_PAGE_MULTIPLIER = 4;
+/** The most prefiltered rows one search reads before it answers what it has. */
+export const HISTORY_SEARCH_MAXIMUM_SCANNED_ROWS = 2_000;
+
 /**
  * The retained lines of the conversations named that carry every token of
  * the query, most recent first and bounded by `limit`, in one query over
  * every conversation named. Matching is by token, as the score the caller
  * gives a hit is, so a multi-word or punctuated query keeps a line that
- * shares its words in another order. Each line stands only above its own
- * conversation's cutoff — the durable one on the conversation row and the
- * standing generation's marker both — so a Clear hides its lines here as it
- * does everywhere.
+ * shares its words in another order. SQL narrows the scan by substring,
+ * which admits a line holding a longer word ("deployment" for "deploy"); the
+ * token check decides admission, and it runs before the limit is spent, over
+ * pages of the prefiltered rows, so recent lines that only share a substring
+ * never crowd an older exact match out of the answer. The scan itself is
+ * bounded: past `HISTORY_SEARCH_MAXIMUM_SCANNED_ROWS` prefiltered rows the
+ * search answers what it admitted, so a match behind more substring-only
+ * lines than that is not found rather than searched for without bound. Each
+ * line stands only above its own conversation's cutoff — the durable one on
+ * the conversation row and the standing generation's marker both — so a
+ * Clear hides its lines here as it does everywhere.
  */
 export function searchHistory(
   database: RuntimeDatabase,
@@ -236,10 +248,8 @@ export function searchHistory(
   if (tokens.length === 0 || sessionKeys.length === 0 || limit <= 0) return [];
   const keyMarks = sessionKeys.map(() => "?").join(", ");
   const tokenMarks = tokens.map(() => "instr(lower(words), ?) > 0").join(" AND ");
-  // SAFETY: the query selects the two columns the row type names.
-  const rows = database
-    .prepare(
-      `SELECT session_key, payload FROM history_events h
+  const page = database.prepare(
+    `SELECT session_key, payload FROM history_events h
        WHERE session_key IN (${keyMarks})
          AND recorded_at <= ? AND recorded_at >= ?
          AND recorded_at > COALESCE(
@@ -247,19 +257,37 @@ export function searchHistory(
          AND recorded_at > COALESCE(
            (SELECT reset_cleared_at FROM conversation_sessions s WHERE s.session_key = h.session_key), -1)
          AND ${tokenMarks}
-       ORDER BY recorded_at DESC, sequence DESC LIMIT ?`,
-    )
-    .all(...sessionKeys, now, now - storedConversationMaximumAgeMs, ...tokens, limit) as {
-    session_key: string;
-    payload: string;
-  }[];
+       ORDER BY recorded_at DESC, sequence DESC LIMIT ? OFFSET ?`,
+  );
+  const pageSize = Math.min(
+    limit * HISTORY_SEARCH_PAGE_MULTIPLIER,
+    HISTORY_SEARCH_MAXIMUM_SCANNED_ROWS,
+  );
   const hits: HistorySearchHit[] = [];
-  for (const row of rows) {
-    const entry = historyEntryFromPayload(row.payload);
-    if (!entry) continue;
-    // SAFETY: the column holds one of the session keys the IN clause was given.
-    const sessionKey = row.session_key as SessionKey;
-    hits.push({ sessionKey, entry });
+  let scanned = 0;
+  while (hits.length < limit && scanned < HISTORY_SEARCH_MAXIMUM_SCANNED_ROWS) {
+    const asked = Math.min(pageSize, HISTORY_SEARCH_MAXIMUM_SCANNED_ROWS - scanned);
+    // SAFETY: the query selects the two columns the row type names.
+    const rows = page.all(
+      ...sessionKeys,
+      now,
+      now - storedConversationMaximumAgeMs,
+      ...tokens,
+      asked,
+      scanned,
+    ) as { session_key: string; payload: string }[];
+    scanned += rows.length;
+    for (const row of rows) {
+      if (hits.length >= limit) break;
+      const entry = historyEntryFromPayload(row.payload);
+      if (!entry) continue;
+      const held = tokenize(entry.words);
+      if (!tokens.every((token) => held.has(token))) continue;
+      // SAFETY: the column holds one of the session keys the IN clause was given.
+      const sessionKey = row.session_key as SessionKey;
+      hits.push({ sessionKey, entry });
+    }
+    if (rows.length < asked) break;
   }
   return hits;
 }


### PR DESCRIPTION
Follow-up to #766 (merged as e6fdaa49); this PR is one commit over main at f7137075, the #760 merge. Four small correctness fixes named in that PR's known limitations, each with a regression test. Portable only: no UI, no schema or FTS change, no migration.

## Changes

**1. Sync follow-on after a credential change** (`packages/memory/src/notebook-memory.ts`)
- Before: `sync()` during a pass returned the running promise. The launch pass starts before `VoiceCapabilityAssembler.apply` publishes the embedding adapter, so the adapter-changed `sync()` merely joined the adapter-less pass and the vectors stayed missing until another file write or relaunch.
- After: a call during a pass answers one follow-on pass that starts when the running one ends and reads the adapter as it stands then. Every request during the same pass shares that follow-on; a request during the follow-on schedules one more. No pass runs that was not asked for, so there is no busy loop, and `onSynced` fires once per completed pass as before. A failed pass reports and answers `undefined` without cancelling the follow-on it owes; `stop()` closes the watcher and lets a pass already promised finish.
- Test: gated `planMemorySync`, launch pass with no adapter, adapter published mid-pass, two `sync()` calls share one follow-on, the follow-on runs hybrid and embeds every chunk, exactly two plans run, and an idle third `sync()` re-indexes nothing.

**2. Exact-token admission in History search** (`packages/runtime-store/src/history-table.ts`)
- Before: the SQL `instr(lower(words), token)` substring prefilter consumed the `LIMIT` before the caller's exact-token scoring, so recent lines holding "deployment" could exhaust the budget and hide an older true "deploy" hit, which then scored 0 and was filtered.
- After: the same prefiltered query is read in pages (`limit × 4` rows, `OFFSET`), each row admitted only when `tokenize(words)` holds every query token, until `limit` hits are admitted or `HISTORY_SEARCH_MAXIMUM_SCANNED_ROWS` (2,000) prefiltered rows have been read. Order, per-conversation `history_cleared_at`/`reset_cleared_at` cutoffs, one whole-answer limit across the named conversations, and the keyword-only 0.3 conversation ranking are unchanged. `searchHistory` is synchronous on the store worker, so the pages see one consistent table.
- Tradeoff, stated rather than hidden: a true match standing behind more than 2,000 substring-only newer lines is not found. The bound is documented in code and asserted by test; widening it or moving to an FTS token index is a separate decision.
- Test: 60 recent substring-only lines plus a punctuated substring line ahead of one older exact hit in mixed case and order; the limit still bounds the whole answer; cleared history leaks through no page; the scan bound is exercised in both directions.

**3. Trusted lookup contributes recall signals** (`packages/memory/src/notebook-memory.ts`)
- Before: `#trustedMemory` searched the notebook directly and fired no `onNotebookResults`, so intent-bearing asks answered by trusted memory staged no consolidation recall signal.
- After: the trusted lookup reports the notebook results it actually retrieved, once. The no-intent path is unchanged (no lookup, no embedding, no History read, no signal). The conversation fallback never runs in the trusted lookup, so no History line becomes a signal. `hasRecallIntent` still gates before any network.
- Test: no-intent ask records nothing; an intent-bearing ask answered by a strong trusted hit records exactly one signal with the notebook path and runs no subrun.

**4. Live recall cache invalidation** (`packages/memory/src/recall.ts`, `notebook-memory.ts`)
- Before: `clearRecallCaches` cleared the map, but a `BrainAgent` holds the recall bound at construction, so its `ConversationRecall` kept serving a cached summary for the remaining 15 s after a forget or rewrite.
- After: `ConversationRecall.invalidate()` bumps a cache epoch, drops cached answers and shared in-flight promises; a run that began before the clear still answers its own callers but caches nothing. `clearRecallCaches` invalidates every live instance and keeps them where the bound closures reach them. Abort and timeout handling and the breaker count are untouched.
- Test: a bound recall runs the subrun again after a clear; a recall pending across a clear returns to its caller and leaves no cached answer, so the next ask runs again.

## Known limitation, assigned separately

`ConversationRecall.recall()` deletes its in-flight key unconditionally in `finally`. After `invalidate()` clears the in-flight map and a new same-key run is registered, the older run finishing removes the newer run's entry, so a third ask starts its own subrun instead of joining the pending one. The epoch fence still keeps the older run from caching, so the cost is one extra subrun, never a stale answer. The conditional-ownership guard (delete only when the map still holds this exact started promise) and its gated regression are the separate follow-up in session 5658502b, based on this PR's commit (now fb1f3128 over f7137075); this PR's code is held stable.

## Validation

`./scripts/check.sh` exit 0 on the exact head fb1f3128 over f7137075 after a fresh bootstrap, and earlier on 281822b over b13ecf62; every rebase between was an own-commit-only `--onto` replay with an identical range-diff. Focused: `packages/memory` 37/37, `packages/runtime-store` 64/64. No macOS or UI change; no `verify.sh` run and no physical-notch check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/d4a70328-1ad6-49ac-bc78-e4b12bb0b7a9)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34276995399/artifacts/10076228864) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34276995399)

- Commit: `fb1f312836cf151e8e06d90fc385e57c35dfdeff`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->


