### PR TITLE
fix(memory): let a recall run settle only its own in-flight registration

### DIFF
--- a/packages/memory/src/memory.test.ts
+++ b/packages/memory/src/memory.test.ts
@@ -426,6 +426,51 @@ test("recall: trusted hit answers without a subrun, intent escalates, cache hold
   assert.equal(recovered.status, RECALL_STATUS.OK);
 });
 
+test("recall: a run outlived by an invalidation settles only its own registration, so its successor stays shared", async () => {
+  const pending: Array<{ started: Promise<void>; finish: (reply: string) => void }> = [];
+  const recall = new ConversationRecall({
+    trustedMemory: async () => ({ strongHit: false }),
+    subrun: () =>
+      new Promise<string | undefined>((resolve) => {
+        pending.push({ started: Promise.resolve(), finish: resolve });
+      }),
+  });
+  const ask = {
+    sessionKey: MAIN_SESSION_KEY,
+    agentId: "main",
+    query: "what did we decide about deploys?",
+    recentTurns: [],
+  };
+  // Every step between a recall's entry and its subrun call is a microtask,
+  // so a few macrotask turns settle whatever a recall was going to start.
+  const settle = async () => {
+    for (let i = 0; i < 4; i += 1) await new Promise<void>((resolve) => setImmediate(resolve));
+  };
+  const subrunStarted = async (count: number) => {
+    await settle();
+    assert.equal(pending.length, count);
+  };
+
+  const a = recall.recall(ask);
+  await subrunStarted(1);
+  recall.invalidate();
+  const b = recall.recall(ask);
+  await subrunStarted(2);
+  pending[0]?.finish("A's answer.");
+  assert.equal((await a).summary, "A's answer.");
+
+  const c = recall.recall(ask);
+  await settle();
+  assert.equal(pending.length, 2, "C shares B's run rather than opening a third");
+  pending[1]?.finish("B's answer.");
+  assert.equal((await b).summary, "B's answer.");
+  assert.equal((await c).summary, "B's answer.");
+  const cached = await recall.recall(ask);
+  assert.equal(cached.cached, true, "B ran under the current epoch, so its answer is cached");
+  assert.equal(cached.summary, "B's answer.");
+  assert.equal(pending.length, 2);
+});
+
 test("a subrun that returns nothing because the timeout cut it counts as a timeout, not as nothing found", async () => {
   let lookups = 0;
   const recall = new ConversationRecall({

--- a/packages/memory/src/recall.ts
+++ b/packages/memory/src/recall.ts
@@ -283,7 +283,12 @@ export class ConversationRecall {
     }
     const running = this.#inFlight.get(key);
     if (running) return running;
-    const started = this.#run({ ...ask, query }, key).finally(() => this.#inFlight.delete(key));
+    // A run settles its own registration only: an invalidation may have cleared
+    // it and a later run may hold the key by now, and that run's callers still
+    // share it until it finishes.
+    const started: Promise<RecallResult> = this.#run({ ...ask, query }, key).finally(() => {
+      if (this.#inFlight.get(key) === started) this.#inFlight.delete(key);
+    });
     this.#inFlight.set(key, started);
     return started;
   }


### PR DESCRIPTION
Follow-up to #769, now over its squash 25d43478 on main.

`invalidate()` clears the shared in-flight map, and a run started after it takes the same key. The earlier run's `finally` then deleted whichever promise held the key, so a third caller opened a duplicate subrun instead of sharing the successor. The epoch fence already kept the stale answer out of the cache, so the only consequence was duplicate work.

The cleanup now deletes the registration only while the map still holds that run's own promise. Epoch fence, cache TTL, abort, deadline, and breaker semantics are unchanged; no signature or schema changes.

Regression test (deterministic, no sleeps): A pending, invalidate, B pending, A finishes, C starts and shares B (subrun count stays 2), B's answer is cached under the current epoch. The test fails on the parent with `actual: 3, expected: 2` and passes here.

Verification: `packages/memory` tests pass; `./scripts/check.sh` exits 0 on this patch over the identical parent tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34278078601/artifacts/10076654959) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34278078601)

- Commit: `8162a608c2d8bb528e01413f7c042b1672172bd3`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
