### PR TITLE
fix(memory): generic private-key header, whole-block note exclusion, and a settled flush-marker write

### DIFF
--- a/apps/desktop/src/main/memory-maintenance.test.ts
+++ b/apps/desktop/src/main/memory-maintenance.test.ts
@@ -576,3 +576,89 @@ test("a completed dated note is staged beside a full History budget rather than 
   assert.equal(fromMain(await h.store.listMemoryCandidates()), 250);
   h.close();
 });
+
+test("a multiline private-key block in a dated note stages no line, generic or labelled, while the bullets around it keep their exact line numbers, and a body line staged by an earlier build is refused at the re-read", async () => {
+  const h = await harness();
+  const rsaBody = "SYNTHETICRSABODYLINE00000000000000000000000000000000";
+  const pkcs8Body = "SYNTHETICPKCS8BODYLINE1111111111111111111111111111111";
+  const ecBody = "SYNTHETICECBODYLINE22222222222222222222222222222222";
+  const note = [
+    `# ${YESTERDAY}`,
+    "",
+    "- The release train leaves on Thursday mornings for every service",
+    "-----BEGIN RSA PRIVATE KEY-----",
+    rsaBody,
+    rsaBody.toLowerCase(),
+    "-----END RSA PRIVATE KEY-----",
+    "- The staging cluster is reached through the shared bastion host",
+    "-----BEGIN PRIVATE KEY-----\r",
+    `${pkcs8Body}\r`,
+    "-----END PRIVATE KEY-----\r",
+    "- Deploy notes belong in the runbook rather than the chat thread",
+    "-----BEGIN EC PRIVATE KEY-----",
+    ecBody,
+    "-----END EC PRIVATE",
+    "- This bullet follows a truncated closing armor and is dropped conservatively",
+  ];
+  const notePath = `memory/${YESTERDAY}.md`;
+  fs.writeFileSync(path.join(h.workspace, notePath), `${note.join("\n")}\n`);
+  // A candidate an earlier build staged from a body line, recurring enough to rank at deep.
+  for (const [day, at] of [
+    [TWO_DAYS_AGO, NOW - 2 * DAY_MS],
+    [YESTERDAY, NOW - DAY_MS],
+    [TODAY, NOW],
+  ] as const) {
+    await h.store.stageMemoryCandidates(
+      [
+        {
+          text: rsaBody,
+          path: notePath,
+          startLine: 5,
+          endLine: 5,
+          origin: CANDIDATE_ORIGIN.USER,
+          sessionKind: CANDIDATE_SESSION_KIND.INTERACTIVE,
+          query: `ingest:${day}`,
+          score: 0.8,
+          day,
+        },
+      ],
+      at,
+    );
+  }
+  const report = await h.maintenance.runConsolidation();
+  assert.ok(report);
+  const candidates = await h.store.listMemoryCandidates();
+  const fromNote = candidates.filter((candidate) => candidate.path === notePath);
+  assert.deepEqual(
+    fromNote
+      .filter((candidate) => candidate.text !== rsaBody)
+      .map((candidate) => [candidate.startLine, candidate.endLine, candidate.text])
+      .sort((a, b) => Number(a[0]) - Number(b[0])),
+    [
+      [3, 3, note[2]?.slice(2)],
+      [8, 8, note[7]?.slice(2)],
+      [12, 12, note[11]?.slice(2)],
+    ],
+    "the safe bullets stand at their original line numbers and nothing from a block or after a truncated armor",
+  );
+  const leaked = (text: string) =>
+    [rsaBody, rsaBody.toLowerCase(), pkcs8Body, ecBody, "PRIVATE KEY"].some((marker) =>
+      text.includes(marker),
+    );
+  assert.equal(
+    candidates.filter((candidate) => candidate.text !== rsaBody).some((c) => leaked(c.text)),
+    false,
+    "no body line or armor is staged",
+  );
+  assert.equal(
+    h.prompts.some((prompt) => leaked(prompt)),
+    false,
+    "nothing of the block reaches a model prompt",
+  );
+  assert.ok(
+    report.notes.some((line) => /its source is gone or changed/u.test(line)),
+    "the body line staged earlier is refused at the re-read",
+  );
+  assert.equal(h.memory().includes(rsaBody), false);
+  h.close();
+});

--- a/apps/desktop/src/main/memory-maintenance.ts
+++ b/apps/desktop/src/main/memory-maintenance.ts
@@ -33,6 +33,7 @@ import {
   memoryFlushPrompt,
   parseConsolidationPlan,
   prepareForIngestion,
+  privateKeyLines,
   type RankedCandidate,
   remReflections,
   resetCapturePrompt,
@@ -456,7 +457,12 @@ export function wireMemoryMaintenance(
       } catch {
         continue;
       }
-      content.split("\n").forEach((line, index) => {
+      const lines = content.split("\n");
+      // A key block is excluded whole before any line becomes a candidate:
+      // split first, a body line carries no armor for the redaction to see.
+      const insideKey = privateKeyLines(lines);
+      lines.forEach((line, index) => {
+        if (insideKey[index]) return;
         const trimmed = line.trim();
         if (trimmed.length === 0 || trimmed.startsWith("#") || trimmed.startsWith("<!--")) return;
         const prepared = prepareForIngestion(
@@ -494,9 +500,13 @@ export function wireMemoryMaintenance(
     const read = await readWorkspaceFile(dependencies.workspaceDirectory(), candidate.path);
     if (!read.ok) return false;
     const lines = read.content.split("\n");
-    const slice = lines
-      .slice(Math.max(0, candidate.startLine - 1), Math.max(candidate.startLine, candidate.endLine))
-      .join(" ");
+    const insideKey = privateKeyLines(lines);
+    const from = Math.max(0, candidate.startLine - 1);
+    const to = Math.max(candidate.startLine, candidate.endLine);
+    // The re-read excludes what the staging read excludes, so a candidate an
+    // earlier build staged from inside a key block is never confirmed present.
+    if (insideKey.slice(from, to).some(Boolean)) return false;
+    const slice = lines.slice(from, to).join(" ");
     const prepared = prepareForIngestion(
       slice.replace(/^[-*+]\s+/u, "").slice(0, NOTE_LINE_MAX_CHARS),
     );

--- a/packages/brain/src/agent-flush.test.ts
+++ b/packages/brain/src/agent-flush.test.ts
@@ -370,3 +370,50 @@ test("failed persistence: a marker write that fails is reported and leaves the c
   assert.equal(failing.markers.size, 0);
   await f.agent.stop();
 });
+
+test("a marker write still out when the turn is revoked is waited for at the next assessment: a write that lands late marks the cycle and the hook is not rerun", async () => {
+  const marker = new FakeMarkerStore();
+  let release: (() => void) | undefined;
+  const gate = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  const write = marker.write.bind(marker);
+  marker.write = async (generationId, compactionCount) => {
+    await gate;
+    return write(generationId, compactionCount);
+  };
+  let calls = 0;
+  const h = agentWith(
+    async () => {
+      calls += 1;
+      return { outcome: MEMORY_HOUSEKEEPING_OUTCOME.COMPLETED, writes: 1 };
+    },
+    { marker },
+  );
+  await ask(h.agent, OVER_FLUSH_THRESHOLD);
+  assert.equal(calls, 1, "the flush ran in maintenance");
+  assert.equal(marker.markers.size, 0, "its marker write is still out");
+  // A new ask revokes the maintenance holding the write; the write lands only afterwards.
+  const accepted = await h.agent.submitAsk({
+    submissionId: "after-revoke",
+    question: "still over the threshold",
+    origin: BRAIN_REQUEST_ORIGIN.TYPED,
+  });
+  assert.equal(accepted.outcome, BRAIN_SUBMISSION_OUTCOME.ACCEPTED);
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.ok(release);
+  release();
+  const runId = accepted.outcome === BRAIN_SUBMISSION_OUTCOME.ACCEPTED ? accepted.runId : "";
+  const record = await h.agent.waitAsk(runId, 60_000);
+  assert.equal(record?.status, BRAIN_REQUEST_STATUS.SUCCEEDED);
+  await settle();
+  const generation = h.store.generationId();
+  assert.ok(generation);
+  assert.equal(marker.markers.get(generation), 0, "the late write landed under the generation");
+  assert.equal(marker.writes, 1, "the write was issued once and never retried");
+  assert.equal(calls, 1, "the flushed cycle is not run again");
+  assert.deepEqual(h.agent.flushCycle(), { compactionCount: 0, lastFlushCompactionCount: 0 });
+  await ask(h.agent, "another");
+  assert.equal(calls, 1);
+  await h.agent.stop();
+});

--- a/packages/brain/src/agent.ts
+++ b/packages/brain/src/agent.ts
@@ -100,7 +100,7 @@ import {
   isTerminalBrainRequestStatus,
 } from "./requests.js";
 import { incompleteDetail, TOOL_RESULT_STATUS } from "./runtime.js";
-import { type Settled, settledUnlessAborted } from "./settled.js";
+import { claimedUnlessAborted, type Settled, settledUnlessAborted } from "./settled.js";
 import {
   type BrainPersistedState,
   type BrainStateStore,
@@ -1768,6 +1768,14 @@ export class BrainAgent {
     turnContext: Pick<TurnContext, "generation" | "signal">,
   ): Promise<boolean> {
     const { generation, signal } = turnContext;
+    if (generation.flush.settling) {
+      // A write an earlier turn stopped waiting for may still be in flight;
+      // the gate is read only once it has landed or failed, so the store is
+      // never consulted ahead of a write already issued to it.
+      const settled = await settledUnlessAborted(generation.flush.settling, signal);
+      if (settled.aborted || this.#revoked(turnContext)) return false;
+      delete generation.flush.settling;
+    }
     if (generation.flush.read) return true;
     const store = this.#options.flushMarker;
     if (!store) {
@@ -1792,19 +1800,27 @@ export class BrainAgent {
     return true;
   }
 
-  /** Offers the completed flush's marker to the store, a bounded number of times; the turn itself is never rerun to retry. */
+  /**
+   * Offers the completed flush's marker to the store, a bounded number of
+   * times; the turn itself is never rerun to retry. A turn revoked while a
+   * write is out settles at once, but the write is not forgotten: the
+   * attempt still in flight is what the generation's flush state waits for
+   * before its gate is next read, and a write that lands late marks the
+   * cycle as a timely one would, so the housekeeping turn is not run twice.
+   */
   async #writeFlushMarker(
     turnContext: Pick<TurnContext, "generation" | "signal">,
     cycle: number,
   ): Promise<Settled<{ ok: true } | { ok: false; reason: string }>> {
     const store = this.#options.flushMarker;
     if (!store) return { aborted: false, value: { ok: true } };
+    const { generation, signal } = turnContext;
     const attempts = async (): Promise<{ ok: true } | { ok: false; reason: string }> => {
       let reason = "";
       for (let attempt = 0; attempt < MEMORY_FLUSH_DEFAULTS.MARKER_WRITE_ATTEMPTS; attempt += 1) {
-        if (turnContext.signal.aborted) return { ok: false, reason: "the turn was revoked" };
+        if (signal.aborted) return { ok: false, reason: "the turn was revoked" };
         try {
-          await store.write(turnContext.generation.id, cycle);
+          await store.write(generation.id, cycle);
           return { ok: true };
         } catch (error) {
           reason = error instanceof Error ? error.message : String(error);
@@ -1812,7 +1828,14 @@ export class BrainAgent {
       }
       return { ok: false, reason };
     };
-    return settledUnlessAborted(attempts(), turnContext.signal);
+    const outcome = attempts();
+    const settled = await claimedUnlessAborted(outcome, signal, (late) => {
+      if (late.ok) generation.flush.lastCompactionCount = cycle;
+    });
+    if (settled.aborted) {
+      generation.flush.settling = outcome.then(() => undefined);
+    }
+    return settled;
   }
 
   /** Where the standing generation is in its compaction cycles, and the cycle the last completed flush ran under, as read so far. */

--- a/packages/brain/src/generation.ts
+++ b/packages/brain/src/generation.ts
@@ -54,9 +54,12 @@ export interface Generation {
    * The flush marker as this generation has read it: whether the store has
    * been consulted, and the compaction count the last completed flush ran
    * under. Filled from the marker store at the first assessment and kept in
-   * step with every marker that lands after.
+   * step with every marker that lands after. A marker write the turn stopped
+   * waiting for is still `settling`: the next assessment waits for it before
+   * reading the gate, so a write that lands late is counted and never
+   * repeated.
    */
-  flush: { read: boolean; lastCompactionCount?: number };
+  flush: { read: boolean; lastCompactionCount?: number; settling?: Promise<void> };
   journal: BrainJournal;
   requests: Map<string, BrainRequestRecord>;
   /** Runs accepted in memory but not yet checkpointed; not yet acknowledged to anyone. */

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -183,6 +183,7 @@ export {
 } from "./recall.js";
 export {
   prepareForIngestion,
+  privateKeyLines,
   RECALLED_CONTEXT_MARKER,
   REDACTED_TOKEN,
   type RedactionResult,

--- a/packages/memory/src/maintenance.test.ts
+++ b/packages/memory/src/maintenance.test.ts
@@ -43,6 +43,7 @@ import {
 } from "./flush.js";
 import {
   prepareForIngestion,
+  privateKeyLines,
   RECALLED_CONTEXT_MARKER,
   REDACTED_TOKEN,
   redactSensitiveText,
@@ -177,6 +178,69 @@ test("private-key armor is redacted by scanning: a terminated block whole, an un
     REDACTED_TOKEN,
   );
   assert.ok(performance.now() - startedAt < 500, "the scan is linear in the text");
+});
+
+test("a generic PKCS#8 header with no label is a private key too, whole, cut, and line by line", () => {
+  const body =
+    "MIIBSYNTHETICBODYLINE0000000000000000000000000000\nSYNTHETICBODYLINE1111111111111111111111111111111";
+  const pkcs8 = `-----BEGIN PRIVATE KEY-----\n${body}\n-----END PRIVATE KEY-----`;
+  const whole = redactSensitiveText(`before ${pkcs8} after`);
+  assert.equal(whole.text, `before ${REDACTED_TOKEN} after`);
+  assert.equal(whole.redactions, 1);
+  const cut = redactSensitiveText(pkcs8.slice(0, 60));
+  assert.equal(cut.text, REDACTED_TOKEN);
+  assert.equal(prepareForIngestion("-----BEGIN PRIVATE KEY-----"), undefined);
+  const encrypted = redactSensitiveText(
+    "-----BEGIN ENCRYPTED PRIVATE KEY-----\nabc\n-----END ENCRYPTED PRIVATE KEY-----",
+  );
+  assert.equal(encrypted.text, REDACTED_TOKEN);
+  // A label past the bound is not an armor: the scan moves on rather than matching across it.
+  const long = redactSensitiveText(`-----BEGIN ${"A".repeat(65)} PRIVATE KEY-----\nabc`);
+  assert.equal(long.redactions, 0);
+});
+
+test("privateKeyLines marks every line of a key block by index, through the END line, to the end when unterminated, across CRLF and repeated blocks, and nothing outside", () => {
+  const lines = [
+    "- safe before",
+    "-----BEGIN RSA PRIVATE KEY-----",
+    "SYNTHETICRSABODY",
+    "-----END RSA PRIVATE KEY-----",
+    "- safe between",
+    "-----BEGIN PRIVATE KEY-----\r",
+    "SYNTHETICPKCS8BODY\r",
+    "-----END PRIVATE KEY-----\r",
+    "- safe after",
+    "note -----BEGIN EC PRIVATE KEY-----",
+    "SYNTHETICECBODY",
+    "-----END EC PRIVATE",
+    "still inside: the closing armor was truncated",
+  ];
+  assert.deepEqual(privateKeyLines(lines), [
+    false,
+    true,
+    true,
+    true,
+    false,
+    true,
+    true,
+    true,
+    false,
+    true,
+    true,
+    true,
+    true,
+  ]);
+  assert.deepEqual(privateKeyLines(["- a", "-----BEGIN CERTIFICATE-----", "x", "- b"]), [
+    false,
+    false,
+    false,
+    false,
+  ]);
+  assert.deepEqual(privateKeyLines([]), []);
+  const startedAt = performance.now();
+  const many = new Array(50_000).fill("-----BEGIN RSA PRIVATE KEY-----");
+  assert.equal(privateKeyLines(many).every(Boolean), true);
+  assert.ok(performance.now() - startedAt < 500, "the line scan is linear");
 });
 
 test("only an interrupted or failed housekeeping turn fell short; a skipped one is the expected answer and reports nothing", () => {

--- a/packages/memory/src/redaction.ts
+++ b/packages/memory/src/redaction.ts
@@ -53,7 +53,39 @@ const SENSITIVE_PATTERNS: readonly RegExp[] = [
 
 const PEM_BEGIN = "-----BEGIN ";
 const PEM_END = "-----END ";
-const PEM_HEADER_REST = /^[A-Z ]{1,64}PRIVATE KEY-----/u;
+/**
+ * What follows `-----BEGIN ` or `-----END ` in a private-key armor: an
+ * optional bounded label (`RSA `, `EC `, `ENCRYPTED `) or nothing at all,
+ * since a generic PKCS#8 header reads `-----BEGIN PRIVATE KEY-----`.
+ */
+const PEM_HEADER_REST = /^[A-Z ]{0,64}PRIVATE KEY-----/u;
+
+function isPrivateKeyArmor(line: string, armor: string): boolean {
+  const at = line.indexOf(armor);
+  return at !== -1 && PEM_HEADER_REST.test(line.slice(at + armor.length, at + armor.length + 128));
+}
+
+/**
+ * Which lines of a text stand inside a private-key block, so a reader that
+ * stages or re-reads a file line by line drops every line of a block rather
+ * than only the one carrying `BEGIN`. The scan is stateful and linear: a
+ * line holding a `BEGIN ... PRIVATE KEY` header opens a block, every line
+ * through the matching `END` header is inside it, and a block never closed
+ * runs to the end of the text, the same conservative answer the single-text
+ * redaction gives. Indices are the caller's own, so the lines outside a
+ * block keep their original coordinates.
+ */
+export function privateKeyLines(lines: readonly string[]): readonly boolean[] {
+  const inside: boolean[] = new Array(lines.length).fill(false);
+  let open = false;
+  lines.forEach((line, index) => {
+    if (!open && isPrivateKeyArmor(line, PEM_BEGIN)) open = true;
+    if (!open) return;
+    inside[index] = true;
+    if (isPrivateKeyArmor(line, PEM_END)) open = false;
+  });
+  return inside;
+}
 
 /**
  * Redacts private-key blocks by scanning for their armor rather than


### PR DESCRIPTION
Follow-up to #767, now merged to main as dff490b9. One own commit (a313cd4) replayed from the verified #767 boundary onto that squash; the diff is identical to the version reviewed over #767 (range-diff equal at every replay: a7f64e8 → a1ea558 → a313cd4). It closes the three limitations #767's body names as tracked follow-ups, without widening what the flush may write, what consolidation ingests, or what a forget reaches.

## Generic private-key header

`redactPrivateKeys` required a label before `PRIVATE KEY-----`, so a PKCS#8 block (`-----BEGIN PRIVATE KEY-----`) passed every redaction whole, in a History line, a note line, and a rehydrated slice alike. The label is now optional and still bounded at 64 characters, so the scan stays linear and a header past the bound is not an armor. RSA, EC, and ENCRYPTED headers redact as before.

## A key block in a dated note, excluded whole

The light phase split a dated note by line before scrubbing, so a multiline key's body lines carried no armor and were staged verbatim while only the `BEGIN` line was redacted. `privateKeyLines` (in `@sidecar/memory`) marks every line of a block by index: from a `BEGIN … PRIVATE KEY` line through the matching `END` line, to the end of the file when the block is unterminated or its closing armor is cut, across CRLF and repeated blocks. `noteSeeds` skips those lines before any candidate is made, and the bullets around a block keep their original `startLine`/`endLine`. The deep re-read applies the same exclusion, so a body-line candidate an earlier build staged is refused as gone at rehydration rather than confirmed and offered to the consolidation model. No schema, FTS, or search-index change; the exclusion is a linear pass over the lines the reader already split.

## An aborted flush-marker write, settled before the gate is read again

A marker write the revoked turn stopped waiting for could land on disk while the generation's cache still read the cycle unflushed, so the same cycle flushed again in-process. The write still in flight is now kept on the generation as `flush.settling`: a write that lands late marks the cycle in memory, and the next `#readFlushMarker` waits for the outstanding attempts (under its own signal) before reading the gate, so the store is never consulted ahead of a write already issued to it, and the housekeeping turn is never rerun to retry a marker write. A cancelled caller still settles at the abort; the attempt loop issues no further write after it; and a write that failed leaves the cached marker as it was, exactly as a timely failure does. Generation fences are unchanged: the write is keyed by the generation's id, and a replaced generation's late write marks nothing standing.

This is the case Bugbot flagged on #767 (review thread PRRT_kwDOT0q88c6gYS5L), which #767 resolved as a tracked follow-up rather than as fixed.

## Tests

- `packages/memory/src/maintenance.test.ts`: the PKCS#8 header whole, cut, and per line; the ENCRYPTED variant; a label past the bound; `privateKeyLines` over a mixed file with RSA, CRLF PKCS#8, and a truncated EC closing armor, plus a linear-time run of 50,000 headers.
- `apps/desktop/src/main/memory-maintenance.test.ts`: through the real `wireMemoryMaintenance` and store worker, a dated note holding three synthetic blocks between safe bullets stages only the bullets, at their exact original line numbers; no body marker or armor reaches the candidate store or any model prompt; and a body-line candidate staged by an earlier build is refused at the re-read. Fails at the parent's head, passes here.
- `packages/brain/src/agent-flush.test.ts`: the hook completes, the marker write is gated, a new ask revokes the maintenance holding it, the write then lands, and the next assessment reads the durable marker and does not rerun the hook (one write, one hook call). Fails at the parent's head with a second hook call, passes here.

All synthetic fixtures; no real key material.

## Checks

`./scripts/check.sh` passed at a7f64e8 (exit 0) over #767 head 9c53b35. Later replays changed only the parent, with the own diff identical, so the affected suites were rerun at each head (memory, brain agent-flush, desktop memory-maintenance, all passing at a313cd4) and PR CI on main is the final check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34278136503/artifacts/10076697955) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34278136503)

- Commit: `a313cd4b9dfa17174f6b4fa5ed75e63dd22260f7`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
