### PR TITLE
Persist iOS workspace agent defaults

### DIFF
--- a/apps/ios/Luke/VoiceView.swift
+++ b/apps/ios/Luke/VoiceView.swift
@@ -121,7 +121,8 @@ private final class VoiceSessionModel {
                         WorkspaceProjectsContext.item(
                             answer: projects,
                             defaultProviderId: self.defaults.lastProviderId,
-                            defaultProjectIds: self.defaults.lastProjectIds
+                            defaultProjectIds: self.defaults.lastProjectIds,
+                            defaultAgentDefaults: self.defaults.agentDefaults
                         )
                     )
                 }

--- a/apps/ios/LukeKit/Sources/LukeKit/VoiceActDispatcher.swift
+++ b/apps/ios/LukeKit/Sources/LukeKit/VoiceActDispatcher.swift
@@ -143,7 +143,8 @@ public func dispatchVoiceToolCall(
             arguments,
             projects: projects,
             defaultProviderId: context.defaults.lastProviderId,
-            defaultProjectIds: context.defaults.lastProjectIds
+            defaultProjectIds: context.defaults.lastProjectIds,
+            defaultAgentDefaults: context.defaults.agentDefaults
         )
         return await carry(ask, context, .workspaceCreate) { ask, token in
             let answer = try await context.actClient.createWorkspace(
@@ -157,11 +158,19 @@ public func dispatchVoiceToolCall(
                 effort: ask.effort
             )
             if answer.result == .accepted {
-                // The first creation saves its provider as the default, the
-                // same tie-break the New Workspace sheet remembers.
+                // A successful creation saves the same choices the New
+                // Workspace sheet remembers.
                 context.defaults.lastProviderId = ask.project.providerId
                 context.defaults.setLastProjectId(
                     ask.project.providerProjectId, for: ask.project.providerId
+                )
+                context.defaults.setAgentDefault(
+                    ask.agent.flatMap { agent in
+                        ask.model.map { model in
+                            WorkspaceAgentDefault(agent: agent, model: model, effort: ask.effort)
+                        }
+                    },
+                    for: ask.project.providerId
                 )
             }
             return answer

--- a/apps/ios/LukeKit/Sources/LukeKit/VoiceAsks.swift
+++ b/apps/ios/LukeKit/Sources/LukeKit/VoiceAsks.swift
@@ -311,13 +311,16 @@ public enum VoiceAsks {
     /// Validates a creation ask against the projects the conversation was
     /// shown, settling only what the ask left unnamed from this device's own
     /// defaults: no provider named sends a still-ambiguous ask to the default
-    /// provider while it is offering, and no project named sends it on to
-    /// that provider's chosen project. Neither step can leave the listed set.
+    /// provider while it is offering, no project named sends it on to that
+    /// provider's chosen project, and no agent/model named uses that
+    /// provider's saved agent selection while it is still listed. No default
+    /// can leave the listed set.
     public static func workspaceCreation(
         _ arguments: [String: Any],
         projects answer: ProjectsAnswer,
         defaultProviderId: String?,
-        defaultProjectIds: [String: String]
+        defaultProjectIds: [String: String],
+        defaultAgentDefaults: [String: WorkspaceAgentDefault] = [:]
     ) -> Result<WorkspaceCreationAsk, VoiceAskRefusal> {
         let providerId = text(arguments, "provider_id")
         let projectId = text(arguments, "project_id")
@@ -402,6 +405,12 @@ public enum VoiceAsks {
             // agent named alone runs the first model its table lists — the
             // same one the New Workspace sheet preselects for it.
             selection = AgentSelection(agent: agent, model: first.id, effort: nil)
+        } else if agent == nil,
+            let stored = WorkspaceProjectsContext.validAgentDefault(
+                defaultAgentDefaults[project.providerId], in: options
+            )
+        {
+            selection = AgentSelection(agent: stored.agent, model: stored.model, effort: stored.effort)
         }
 
         return .success(

--- a/apps/ios/LukeKit/Sources/LukeKit/WorkspaceProjectsContext.swift
+++ b/apps/ios/LukeKit/Sources/LukeKit/WorkspaceProjectsContext.swift
@@ -24,21 +24,24 @@ public enum WorkspaceProjectsContext {
     public static func item(
         answer: ProjectsAnswer,
         defaultProviderId: String?,
-        defaultProjectIds: [String: String]
+        defaultProjectIds: [String: String],
+        defaultAgentDefaults: [String: WorkspaceAgentDefault] = [:]
     ) -> VoiceContextItem {
         VoiceContextItem(
             itemId: contextItemId,
             text: "[\(contextLabel)]\n"
                 + text(
                     answer: answer, defaultProviderId: defaultProviderId,
-                    defaultProjectIds: defaultProjectIds)
+                    defaultProjectIds: defaultProjectIds,
+                    defaultAgentDefaults: defaultAgentDefaults)
         )
     }
 
     public static func text(
         answer: ProjectsAnswer,
         defaultProviderId: String?,
-        defaultProjectIds: [String: String]
+        defaultProjectIds: [String: String],
+        defaultAgentDefaults: [String: WorkspaceAgentDefault] = [:]
     ) -> String {
         let projects = answer.projects
         if projects.isEmpty { return "No provider currently offers workspace creation." }
@@ -68,10 +71,15 @@ public enum WorkspaceProjectsContext {
                     ? "" : "; efforts \(option.efforts.joined(separator: ", "))"
                 return "\(option.agent) — models \(models)\(efforts)"
             }
+            let stored = validAgentDefault(defaultAgentDefaults[providerId], in: options).map {
+                defaultAgentText($0, in: options)
+            }
+            let omitted =
+                stored.map { "Omitted, the saved default agent selection starts: \($0)." }
+                ?? "Omitted, the provider's own default agent starts."
             lines.append(
                 "\(VaultProviderID.displayLabel(forWireId: providerId)) agents a new workspace can start, "
-                    + "each with the models it runs: \(agents.joined(separator: " | ")). Omitted, the "
-                    + "provider's own default agent starts."
+                    + "each with the models it runs: \(agents.joined(separator: " | ")). \(omitted)"
             )
         }
         if let chosenDefault {
@@ -118,5 +126,28 @@ public enum WorkspaceProjectsContext {
         case .optional: "takes an opening task"
         case .required: "needs an opening task"
         }
+    }
+
+    static func validAgentDefault(
+        _ stored: WorkspaceAgentDefault?,
+        in options: [WorkspaceAgentOption]
+    ) -> WorkspaceAgentDefault? {
+        guard let stored,
+            let option = options.first(where: { $0.agent == stored.agent }),
+            option.models.contains(where: { $0.id == stored.model }),
+            stored.effort == nil || option.efforts.contains(stored.effort ?? "")
+        else { return nil }
+        return stored
+    }
+
+    private static func defaultAgentText(
+        _ stored: WorkspaceAgentDefault,
+        in options: [WorkspaceAgentOption]
+    ) -> String {
+        let option = options.first { $0.agent == stored.agent }
+        let model = option?.models.first { $0.id == stored.model }
+        let modelText = model.map { "\($0.label) (\($0.id))" } ?? stored.model
+        let effortText = stored.effort.map { ", effort \($0)" } ?? ""
+        return "\(stored.agent) with \(modelText)\(effortText)"
     }
 }

--- a/apps/ios/LukeKit/Tests/LukeKitTests/VoiceActDispatcherTests.swift
+++ b/apps/ios/LukeKit/Tests/LukeKitTests/VoiceActDispatcherTests.swift
@@ -26,6 +26,7 @@ final class VoiceActDispatcherTests: XCTestCase {
         mintedTools: [String]?,
         sessions: [RosterSession] = [],
         projects: ProjectsAnswer? = nil,
+        defaults: WorkspaceCreationDefaults? = nil,
         http: StubHTTPClient = StubHTTPClient { _ in throw URLError(.notConnectedToInternet) },
         accessToken: @escaping () async throws -> String = { "token" },
         count: @escaping (ProductSessionAct, String) -> Void = { _, _ in },
@@ -37,9 +38,10 @@ final class VoiceActDispatcherTests: XCTestCase {
             mintedTools: mintedTools,
             sessions: sessions,
             projects: projects,
-            defaults: WorkspaceCreationDefaults(
-                store: UserDefaults(suiteName: "VoiceActDispatcherTests.\(UUID().uuidString)")!
-            ),
+            defaults: defaults
+                ?? WorkspaceCreationDefaults(
+                    store: UserDefaults(suiteName: "VoiceActDispatcherTests.\(UUID().uuidString)")!
+                ),
             actClient: ActClient(baseURL: base, http: http),
             accessToken: accessToken,
             count: count,
@@ -227,6 +229,63 @@ final class VoiceActDispatcherTests: XCTestCase {
         XCTAssertEqual(
             output,
             #"{"reason":"The projects a workspace can be created in have not loaded yet.","result":"rejected"}"#
+        )
+    }
+
+    func testAcceptedCreationPersistsTheChosenAgentModelAndEffort() async {
+        let suite = "VoiceActDispatcherTests.\(UUID().uuidString)"
+        let store = UserDefaults(suiteName: suite)!
+        defer { store.removePersistentDomain(forName: suite) }
+        let defaults = WorkspaceCreationDefaults(store: store)
+        let projects = ProjectsAnswer(
+            projects: [
+                RosterProject(
+                    providerId: "conductor",
+                    providerProjectId: "p1",
+                    repository: "owner/repo",
+                    taskSupport: .optional
+                )
+            ],
+            agentModels: [
+                WorkspaceAgentOption(
+                    providerId: "conductor",
+                    agent: "claude",
+                    models: [WorkspaceAgentModelChoice(id: "fable-5", label: "Fable 5")],
+                    efforts: ["low", "high"]
+                )
+            ]
+        )
+        let http = StubHTTPClient { request in
+            XCTAssertEqual(request.url?.path, "/api/acts/workspace")
+            let body = try JSONSerialization.jsonObject(with: request.httpBody ?? Data()) as? [String: String]
+            XCTAssertEqual(
+                body,
+                [
+                    "providerId": "conductor",
+                    "providerProjectId": "p1",
+                    "agent": "claude",
+                    "model": "fable-5",
+                    "effort": "high",
+                ]
+            )
+            return (
+                jsonData(["result": "accepted", "providerSessionId": "created-1"]),
+                makeResponse(url: request.url!, status: 200)
+            )
+        }
+
+        let output = await dispatchVoiceToolCall(
+            name: VoiceToolName.createWorkspace.rawValue,
+            arguments: ["project_id": "p1", "agent": "claude", "model": "fable-5", "effort": "high"],
+            context: context(mintedTools: everyTool, projects: projects, defaults: defaults, http: http)
+        )
+
+        XCTAssertEqual(output, #"{"result":"accepted"}"#)
+        XCTAssertEqual(defaults.lastProviderId, "conductor")
+        XCTAssertEqual(defaults.lastProjectId(for: "conductor"), "p1")
+        XCTAssertEqual(
+            defaults.agentDefault(for: "conductor"),
+            WorkspaceAgentDefault(agent: "claude", model: "fable-5", effort: "high")
         )
     }
 }

--- a/apps/ios/LukeKit/Tests/LukeKitTests/VoiceAsksTests.swift
+++ b/apps/ios/LukeKit/Tests/LukeKitTests/VoiceAsksTests.swift
@@ -239,11 +239,12 @@ final class VoiceAsksWorkspaceCreationTests: XCTestCase {
     private func creation(
         _ arguments: [String: Any],
         defaultProviderId: String? = nil,
-        defaultProjectIds: [String: String] = [:]
+        defaultProjectIds: [String: String] = [:],
+        defaultAgentDefaults: [String: WorkspaceAgentDefault] = [:]
     ) -> Result<VoiceAsks.WorkspaceCreationAsk, VoiceAskRefusal> {
         VoiceAsks.workspaceCreation(
             arguments, projects: answer, defaultProviderId: defaultProviderId,
-            defaultProjectIds: defaultProjectIds)
+            defaultProjectIds: defaultProjectIds, defaultAgentDefaults: defaultAgentDefaults)
     }
 
     func testAnAskNamesAListedProjectOrIsSettledByTheDeviceDefaults() throws {
@@ -292,6 +293,38 @@ final class VoiceAsksWorkspaceCreationTests: XCTestCase {
             reason(creation(["project_id": "p1", "agent": "gemini"])),
             "That project lists no such agent to start."
         )
+    }
+
+    func testAnUnnamedAgentRestoresTheDeviceDefaultWhileItIsListed() throws {
+        let restored = try creation(
+            ["project_id": "p1"],
+            defaultAgentDefaults: [
+                "conductor": WorkspaceAgentDefault(agent: "claude", model: "sonnet-4", effort: "high")
+            ]
+        ).get()
+        XCTAssertEqual(restored.agent, "claude")
+        XCTAssertEqual(restored.model, "sonnet-4")
+        XCTAssertEqual(restored.effort, "high")
+
+        let staleModel = try creation(
+            ["project_id": "p1"],
+            defaultAgentDefaults: [
+                "conductor": WorkspaceAgentDefault(agent: "claude", model: "missing", effort: "high")
+            ]
+        ).get()
+        XCTAssertNil(staleModel.agent)
+        XCTAssertNil(staleModel.model)
+        XCTAssertNil(staleModel.effort)
+
+        let staleEffort = try creation(
+            ["project_id": "p1"],
+            defaultAgentDefaults: [
+                "conductor": WorkspaceAgentDefault(agent: "claude", model: "sonnet-4", effort: "max")
+            ]
+        ).get()
+        XCTAssertNil(staleEffort.agent)
+        XCTAssertNil(staleEffort.model)
+        XCTAssertNil(staleEffort.effort)
     }
 
     func testAModelNamedAloneDecidesTheAgentThatRunsIt() throws {

--- a/apps/ios/LukeKit/Tests/LukeKitTests/WorkspaceProjectsContextTests.swift
+++ b/apps/ios/LukeKit/Tests/LukeKitTests/WorkspaceProjectsContextTests.swift
@@ -90,6 +90,37 @@ final class WorkspaceProjectsContextTests: XCTestCase {
         XCTAssertTrue(text.contains("codex — models GPT-6 Astra (gpt-6-astra); efforts ultra"))
     }
 
+    func testTheSavedAgentSelectionIsSaidOnlyWhileItIsListed() {
+        let answer = ProjectsAnswer(
+            projects: [project("p1", repository: "acme/web")],
+            agentModels: [
+                WorkspaceAgentOption(
+                    providerId: "conductor", agent: "claude",
+                    models: [WorkspaceAgentModelChoice(id: "opus-4", label: "Opus 4")],
+                    efforts: ["low", "high"]
+                )
+            ]
+        )
+        XCTAssertTrue(
+            WorkspaceProjectsContext.text(
+                answer: answer, defaultProviderId: "conductor", defaultProjectIds: [:],
+                defaultAgentDefaults: [
+                    "conductor": WorkspaceAgentDefault(agent: "claude", model: "opus-4", effort: "high")
+                ])
+                .contains(
+                    "Omitted, the saved default agent selection starts: claude with Opus 4 (opus-4), effort high."
+                )
+        )
+        XCTAssertFalse(
+            WorkspaceProjectsContext.text(
+                answer: answer, defaultProviderId: "conductor", defaultProjectIds: [:],
+                defaultAgentDefaults: [
+                    "conductor": WorkspaceAgentDefault(agent: "claude", model: "missing", effort: "high")
+                ])
+                .contains("saved default agent selection")
+        )
+    }
+
     func testTheCapKeepsTheDefaultProjectPastTheCut() {
         let projects = (0 ..< 12).map { project("p\($0)", repository: "repo-\($0)") }
         let listed = WorkspaceProjectsContext.listedProjects(projects, defaultProjectIds: ["conductor": "p11"])

--- a/apps/ios/LukeWatch/WatchVoiceSessionModel.swift
+++ b/apps/ios/LukeWatch/WatchVoiceSessionModel.swift
@@ -167,7 +167,8 @@ final class WatchVoiceSessionModel {
                         WorkspaceProjectsContext.item(
                             answer: projects,
                             defaultProviderId: self.defaults.lastProviderId,
-                            defaultProjectIds: self.defaults.lastProjectIds
+                            defaultProjectIds: self.defaults.lastProjectIds,
+                            defaultAgentDefaults: self.defaults.agentDefaults
                         )
                     )
                 }


### PR DESCRIPTION
## Summary
- persist selected workspace agent defaults in iOS `UserDefaults`
- include agent/model/effort defaults when creating workspaces from voice and watch flows
- add focused iOS parsing/dispatch tests for saving and restoring those defaults

## Stack
1. Persist iOS workspace agent defaults (this PR)
2. Add hosted account preferences contract
3. Sync account preferences on desktop
4. Sync account preferences on iOS

## Verification
- `swiftc -frontend -parse apps/ios/Luke/VoiceView.swift apps/ios/LukeKit/Sources/LukeKit/VoiceActDispatcher.swift apps/ios/LukeKit/Sources/LukeKit/VoiceAsks.swift apps/ios/LukeKit/Sources/LukeKit/WorkspaceProjectsContext.swift apps/ios/LukeKit/Tests/LukeKitTests/VoiceActDispatcherTests.swift apps/ios/LukeKit/Tests/LukeKitTests/VoiceAsksTests.swift apps/ios/LukeKit/Tests/LukeKitTests/WorkspaceProjectsContextTests.swift apps/ios/LukeWatch/WatchVoiceSessionModel.swift`

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/fa3a346a-5bf2-4346-8a8d-35b123467a32)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34271779605/artifacts/10074257614) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34271779605)

- Commit: `b2088eff21419bd870bed29ecd55442f891ebd39`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
