### PR TITLE
Sync account preferences on desktop

### DIFF
--- a/apps/desktop/src/main/host/runtime-host.ts
+++ b/apps/desktop/src/main/host/runtime-host.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import {
   AccountClient,
+  AccountPreferencesClient,
   AccountSessionManager,
   accountGateOpen,
   HostedVaultClient,
@@ -122,6 +123,9 @@ import {
   workspaceProjectSelectionId,
 } from "@sidecar/session";
 import {
+  ACCOUNT_PREFERENCE_FIELDS,
+  type AccountPreferenceField,
+  type AccountPreferences,
   APP_SETTING_FIELDS,
   APP_SETTING_SCHEMA,
   type AppSettingField,
@@ -404,6 +408,7 @@ export function composeRuntimeHost(options: RuntimeHostOptions): RuntimeHost {
     clientId: ACCOUNT_CLIENT_ID,
   });
   let account: AccountSnapshot = { status: ACCOUNT_STATUS.SIGNED_OUT };
+  let accountPreferencesHydratedAccount: string | undefined;
   const accountSession = new AccountSessionManager({
     client: accountClient,
     store: settingsStore,
@@ -415,7 +420,13 @@ export function composeRuntimeHost(options: RuntimeHostOptions): RuntimeHost {
     onChange: (next) => {
       const signedIn = next.status === ACCOUNT_STATUS.SIGNED_IN;
       const wasSignedIn = account.status === ACCOUNT_STATUS.SIGNED_IN;
+      const previousAccountKey =
+        account.status === ACCOUNT_STATUS.SIGNED_IN ? account.email : undefined;
+      const nextAccountKey = signedIn ? next.email : undefined;
       account = next;
+      if (previousAccountKey !== nextAccountKey) {
+        accountPreferencesHydratedAccount = undefined;
+      }
       // The first sign-in ever observed is also where the calendar step of
       // onboarding goes up: recorded on disk rather than derived, so quitting
       // at the gate and relaunching finds it standing. Written before the
@@ -577,6 +588,13 @@ export function composeRuntimeHost(options: RuntimeHostOptions): RuntimeHost {
     refreshAccount: accountSession.refreshOnce,
     readAccountKey: async () => (await settingsStore.readAccount())?.email,
   });
+  const accountPreferencesClient = new AccountPreferencesClient({
+    serviceBaseUrl: HOSTED_SERVICE_BASE_URL,
+    readAccessToken: async () =>
+      runMode.sendsNetwork ? (await settingsStore.readAccount())?.accessToken : undefined,
+    refreshAccount: accountSession.refreshOnce,
+    readAccountKey: readAccountPreferenceAccountKey,
+  });
   const providerKeyVaultSync = new ProviderKeyVaultSync({
     vault: hostedVault,
     readStoredApiKey: (providerId) => settingsStore.readStoredApiKey(providerId),
@@ -592,6 +610,7 @@ export function composeRuntimeHost(options: RuntimeHostOptions): RuntimeHost {
       write: (accountKey) => settingsStore.setVaultSyncAccount(accountKey),
     },
   });
+  let accountPreferencesSync: Promise<void> = Promise.resolve();
   function reconcileProviderKeyVault(): void {
     void settingsStore
       .snapshot()
@@ -601,6 +620,123 @@ export function composeRuntimeHost(options: RuntimeHostOptions): RuntimeHost {
           : undefined,
       );
   }
+
+  async function readAccountPreferenceAccountKey(): Promise<string | undefined> {
+    return (await settingsStore.readAccount())?.email;
+  }
+
+  function queueAccountPreferencesSync(label: string, work: () => Promise<void>): Promise<void> {
+    const queued = accountPreferencesSync.then(work, work).catch((error) => {
+      report(
+        `Account preferences ${label} failed: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    });
+    accountPreferencesSync = queued.then(
+      () => undefined,
+      () => undefined,
+    );
+    return queued;
+  }
+
+  function accountPreferencesEmpty(preferences: AccountPreferences): boolean {
+    return Object.keys(preferences).length === 0;
+  }
+
+  function accountPreferencesSame(left: AccountPreferences, right: AccountPreferences): boolean {
+    return JSON.stringify(left) === JSON.stringify(right);
+  }
+
+  async function accountPreferenceHydrationBaseline(
+    accountEmail: string,
+  ): Promise<AccountPreferences> {
+    const baseline = await settingsStore.accountPreferencesSyncBaseline(accountEmail);
+    if (baseline !== undefined) return baseline;
+    const preferences = await settingsStore.accountPreferences();
+    await settingsStore.setAccountPreferencesSyncBaseline(accountEmail, preferences);
+    return preferences;
+  }
+
+  function isAccountPreferenceField(field: AppSettingField): field is AccountPreferenceField {
+    return ACCOUNT_PREFERENCE_FIELDS.some((candidate) => candidate === field);
+  }
+
+  function resetTouchesAccountPreferences(scope: UnparsedWireValue): boolean {
+    return ACCOUNT_PREFERENCE_FIELDS.some((field) => {
+      const definition = APP_SETTING_SCHEMA[field];
+      return "resetScope" in definition && definition.resetScope === scope;
+    });
+  }
+
+  async function reconcileAccountPreferences(): Promise<void> {
+    return queueAccountPreferencesSync("reconcile", async () => {
+      const accountKey = await readAccountPreferenceAccountKey();
+      if (!accountKey) return;
+      await hydrateAccountPreferences(accountKey);
+    });
+  }
+
+  async function hydrateAccountPreferences(accountKey: string): Promise<boolean> {
+    const baseline = await accountPreferenceHydrationBaseline(accountKey);
+    if ((await readAccountPreferenceAccountKey()) !== accountKey) return false;
+    const remote = await accountPreferencesClient.readPreferences();
+    if (!remote || (await readAccountPreferenceAccountKey()) !== accountKey) return false;
+
+    if (!remote.hasStoredSnapshot) {
+      const preferences = await settingsStore.accountPreferences();
+      if ((await readAccountPreferenceAccountKey()) !== accountKey) return false;
+      if (!accountPreferencesEmpty(preferences)) {
+        const written = await accountPreferencesClient.writePreferences(preferences);
+        if (!written || (await readAccountPreferenceAccountKey()) !== accountKey) return false;
+      }
+      if (!(await settingsStore.setAccountPreferencesSyncBaseline(accountKey, preferences))) {
+        return false;
+      }
+      accountPreferencesHydratedAccount = accountKey;
+      return true;
+    }
+
+    const saved = await settingsStore.applyAccountPreferences(remote.preferences, {
+      accountEmail: accountKey,
+      preferences: baseline,
+    });
+    if ((await readAccountPreferenceAccountKey()) !== accountKey) return false;
+    accountPreferencesHydratedAccount = accountKey;
+    const preferences = await settingsStore.accountPreferences();
+    if ((await readAccountPreferenceAccountKey()) !== accountKey) return false;
+    if (saved.changed.length > 0) {
+      await applyAccountPreferenceSideEffects(saved, saved.changed);
+    }
+    if (!accountPreferencesSame(preferences, remote.preferences)) {
+      const written = await accountPreferencesClient.writePreferences(preferences);
+      if (!written || (await readAccountPreferenceAccountKey()) !== accountKey) return true;
+    }
+    await settingsStore.setAccountPreferencesSyncBaseline(accountKey, preferences);
+    return true;
+  }
+
+  function pushAccountPreferences(): void {
+    void queueAccountPreferencesSync("write", async () => {
+      const accountKey = await readAccountPreferenceAccountKey();
+      if (!accountKey) return;
+      if (
+        accountPreferencesHydratedAccount !== accountKey &&
+        !(await hydrateAccountPreferences(accountKey))
+      ) {
+        return;
+      }
+      const preferences = await settingsStore.accountPreferences();
+      if (
+        (await readAccountPreferenceAccountKey()) !== accountKey ||
+        accountPreferencesHydratedAccount !== accountKey
+      ) {
+        return;
+      }
+      const written = await accountPreferencesClient.writePreferences(preferences);
+      if (!written || (await readAccountPreferenceAccountKey()) !== accountKey) return;
+      await settingsStore.setAccountPreferencesSyncBaseline(accountKey, preferences);
+    });
+  }
+
   const recordProductEvent: RecordProductEvent = (name, properties) =>
     productEvents.record(name, properties);
 
@@ -800,6 +936,7 @@ export function composeRuntimeHost(options: RuntimeHostOptions): RuntimeHost {
     defaults: Readonly<Partial<Record<string, string>>> | undefined,
     isCurrent: () => boolean,
   ): Promise<void> {
+    if (account.status === ACCOUNT_STATUS.SIGNED_IN) return;
     try {
       for (const providerId of staleWorkspaceProjectDefaults(projects, defaults)) {
         if (!isCurrent()) return;
@@ -825,6 +962,7 @@ export function composeRuntimeHost(options: RuntimeHostOptions): RuntimeHost {
 
   async function startAccountCapabilities(): Promise<void> {
     if (!accountCapabilitiesActive()) return;
+    void reconcileAccountPreferences();
     await applyVoiceCredential();
     await emitSettings();
     if (!accountCapabilitiesActive()) return;
@@ -1127,6 +1265,7 @@ export function composeRuntimeHost(options: RuntimeHostOptions): RuntimeHost {
     const providerId = adapter.provider.id;
     if (!isWorkspaceProviderId(providerId)) return;
     try {
+      let accountPreferencesTouched = false;
       if (
         (await settingsStore.get(APP_SETTING_SCHEMA.defaultWorkspaceProvider.field)) === undefined
       ) {
@@ -1135,6 +1274,7 @@ export function composeRuntimeHost(options: RuntimeHostOptions): RuntimeHost {
           providerId,
         );
         emitSettingsSnapshot(saved.settings);
+        accountPreferencesTouched = true;
       }
       if (
         providerId === SUPERSET_WORKSPACE_PROVIDER_ID &&
@@ -1149,6 +1289,7 @@ export function composeRuntimeHost(options: RuntimeHostOptions): RuntimeHost {
           { agent },
         );
         emitSettingsSnapshot(saved.settings);
+        accountPreferencesTouched = true;
       }
       if (
         (await settingsStore.get(APP_SETTING_SCHEMA.workspaceProjectDefaults.field))?.[
@@ -1163,6 +1304,7 @@ export function composeRuntimeHost(options: RuntimeHostOptions): RuntimeHost {
           ),
         );
         emitSettingsSnapshot(saved.settings);
+        accountPreferencesTouched = true;
       }
       if (
         isProviderId(providerId) &&
@@ -1176,7 +1318,9 @@ export function composeRuntimeHost(options: RuntimeHostOptions): RuntimeHost {
           namedSelection,
         );
         emitSettingsSnapshot(saved.settings);
+        accountPreferencesTouched = true;
       }
+      if (accountPreferencesTouched) pushAccountPreferences();
     } catch {
       // The reply is the creation's; a failed remember has no line in it.
     }
@@ -1651,6 +1795,29 @@ export function composeRuntimeHost(options: RuntimeHostOptions): RuntimeHost {
     }
   }
 
+  async function applyAccountPreferenceSideEffects(
+    result: SettingsUpdateResult,
+    changed: readonly AccountPreferenceField[],
+  ): Promise<void> {
+    for (const field of changed) {
+      await applyHostSettingSideEffect(field, result.settings);
+    }
+    const workspaceAgentDefaultsChanged = changed.includes(
+      APP_SETTING_SCHEMA.workspaceAgentDefaults.field,
+    );
+    if (workspaceAgentDefaultsChanged) {
+      await readSupersetWorkspaceHost();
+    }
+    if (
+      workspaceAgentDefaultsChanged ||
+      changed.includes(APP_SETTING_SCHEMA.defaultWorkspaceProvider.field) ||
+      changed.includes(APP_SETTING_SCHEMA.workspaceProjectDefaults.field)
+    ) {
+      await broadcastWorkspaceProjects();
+    }
+    emitSettingsSnapshot(result.settings);
+  }
+
   const refusedSettings = async (reason: string): Promise<SettingsUpdateResult> => ({
     status: ACT_RESULT_STATUS.REJECTED,
     settings: await settingsStore.snapshot(),
@@ -1739,6 +1906,7 @@ export function composeRuntimeHost(options: RuntimeHostOptions): RuntimeHost {
         "Could not save that setting on this system.",
         reporterOf(params),
       );
+      if (!result.reason && isAccountPreferenceField(field)) pushAccountPreferences();
       return gatewayOk(wire(result));
     },
     [GATEWAY_METHOD.SETTINGS_UPDATE_ENTRY]: async (params) => {
@@ -1769,6 +1937,7 @@ export function composeRuntimeHost(options: RuntimeHostOptions): RuntimeHost {
         "Could not save that setting on this system.",
         reporterOf(params),
       );
+      if (!result.reason && isAccountPreferenceField(field)) pushAccountPreferences();
       return gatewayOk(wire(result));
     },
     [GATEWAY_METHOD.SETTINGS_RESET]: async (params) => {
@@ -1788,6 +1957,7 @@ export function composeRuntimeHost(options: RuntimeHostOptions): RuntimeHost {
         "Could not reset those settings on this system.",
         reporterOf(params),
       );
+      if (!result.reason && resetTouchesAccountPreferences(scope)) pushAccountPreferences();
       return gatewayOk(wire(result));
     },
     [GATEWAY_METHOD.CREDENTIAL_SET_API_KEY]: async (params) => {
@@ -2373,6 +2543,7 @@ export function composeRuntimeHost(options: RuntimeHostOptions): RuntimeHost {
         `Local session hook registration failed: ${error instanceof Error ? error.message : String(error)}`,
       );
     });
+    if (account.status === ACCOUNT_STATUS.SIGNED_IN) void reconcileAccountPreferences();
     await applyVoiceCredential();
     startSessionObservation();
     startCalendarObservation();

--- a/apps/desktop/src/main/settings-store.test.ts
+++ b/apps/desktop/src/main/settings-store.test.ts
@@ -1316,6 +1316,148 @@ test("ignores a stored or environment pace this build does not offer", async (t)
   assert.equal(appSettingsView(await store.snapshot()).voiceSpeed, REALTIME_DEFAULTS.SPEED);
 });
 
+test("account preferences extraction excludes resolved defaults and local-only preferences", async (t) => {
+  const directory = await temporaryDirectory(t);
+  const store = storeIn(directory, {
+    environment: {
+      LUKE_REALTIME_VOICE: REALTIME_VOICE.SAGE,
+      LUKE_REALTIME_SPEED: String(REALTIME_VOICE_SPEED.SLOW),
+    },
+  });
+
+  await store.set(APP_SETTING_SCHEMA.showInDock.field, true);
+  await store.set(APP_SETTING_SCHEMA.voiceHotkey.field, VOICE_HOTKEY_NONE);
+  await store.set(APP_SETTING_SCHEMA.voiceSpeed.field, REALTIME_VOICE_SPEED.FAST);
+
+  assert.deepEqual(await store.accountPreferences(), {
+    voiceSpeed: REALTIME_VOICE_SPEED.FAST,
+  });
+});
+
+test("applies account preferences to disk and restores them from a new store", async (t) => {
+  const directory = await temporaryDirectory(t);
+  const store = storeIn(directory);
+  await store.set(APP_SETTING_SCHEMA.showInDock.field, true);
+  await store.set(APP_SETTING_SCHEMA.voiceHotkey.field, VOICE_HOTKEY_NONE);
+  await store.set(APP_SETTING_SCHEMA.voice.field, REALTIME_VOICE.SAGE);
+  await store.set(APP_SETTING_SCHEMA.voiceSpeed.field, REALTIME_VOICE_SPEED.FAST);
+  await setWorkspaceProjectDefault(store, PROVIDER_ID.CONDUCTOR, "project-local");
+
+  const result = await store.applyAccountPreferences({
+    voice: REALTIME_VOICE.MARIN,
+    workspaceAgentDefaults: { conductor: { agent: "codex", model: "gpt-5.6-sol" } },
+  });
+
+  assert.deepEqual(result.changed, [
+    APP_SETTING_SCHEMA.voice.field,
+    APP_SETTING_SCHEMA.voiceSpeed.field,
+    APP_SETTING_SCHEMA.workspaceProjectDefaults.field,
+    APP_SETTING_SCHEMA.workspaceAgentDefaults.field,
+  ]);
+  const reopened = storeIn(directory);
+  assert.equal(await reopened.get(APP_SETTING_SCHEMA.showInDock.field), true);
+  assert.equal(await reopened.get(APP_SETTING_SCHEMA.voiceHotkey.field), VOICE_HOTKEY_NONE);
+  assert.equal(await reopened.get(APP_SETTING_SCHEMA.voice.field), REALTIME_VOICE.MARIN);
+  assert.equal(await reopened.get(APP_SETTING_SCHEMA.voiceSpeed.field), undefined);
+  assert.equal(await readWorkspaceProjectDefault(reopened, PROVIDER_ID.CONDUCTOR), undefined);
+  assert.deepEqual(await readWorkspaceAgentDefault(reopened, PROVIDER_ID.CONDUCTOR), {
+    agent: "codex",
+    model: "gpt-5.6-sol",
+  });
+});
+
+test("merges hosted account preferences around concurrent local preference edits", async (t) => {
+  const directory = await temporaryDirectory(t);
+  const store = storeIn(directory);
+  const account = {
+    accessToken: "access-token-secret",
+    refreshToken: "refresh-token-secret",
+    email: "developer@example.com",
+    name: "Developer",
+    provider: "github" as const,
+  };
+  await store.setAccount(account);
+  await store.set(APP_SETTING_SCHEMA.voice.field, REALTIME_VOICE.SAGE);
+  const expected = await store.accountPreferences();
+
+  await store.set(APP_SETTING_SCHEMA.voice.field, REALTIME_VOICE.ECHO);
+  await setWorkspaceProjectDefault(store, PROVIDER_ID.CONDUCTOR, "local-project");
+  const result = await store.applyAccountPreferences(
+    {
+      voice: REALTIME_VOICE.MARIN,
+      voiceSpeed: REALTIME_VOICE_SPEED.FAST,
+      workspaceProjectDefaults: { [PROVIDER_ID.CODEX]: "remote-project" },
+    },
+    { accountEmail: account.email, preferences: expected },
+  );
+
+  assert.deepEqual(result.changed, [
+    APP_SETTING_SCHEMA.voiceSpeed.field,
+    APP_SETTING_SCHEMA.workspaceProjectDefaults.field,
+  ]);
+  assert.equal(await store.get(APP_SETTING_SCHEMA.voice.field), REALTIME_VOICE.ECHO);
+  assert.equal(await store.get(APP_SETTING_SCHEMA.voiceSpeed.field), REALTIME_VOICE_SPEED.FAST);
+  assert.equal(await readWorkspaceProjectDefault(store, PROVIDER_ID.CONDUCTOR), "local-project");
+  assert.equal(await readWorkspaceProjectDefault(store, PROVIDER_ID.CODEX), "remote-project");
+});
+
+test("keeps local account preference edits across a failed hosted write and restart", async (t) => {
+  const directory = await temporaryDirectory(t);
+  const account = {
+    accessToken: "access-token-secret",
+    refreshToken: "refresh-token-secret",
+    email: "developer@example.com",
+    name: "Developer",
+    provider: "github" as const,
+  };
+  const store = storeIn(directory);
+  await store.setAccount(account);
+  await store.set(APP_SETTING_SCHEMA.voice.field, REALTIME_VOICE.SAGE);
+  await store.setAccountPreferencesSyncBaseline(account.email, await store.accountPreferences());
+
+  await store.set(APP_SETTING_SCHEMA.voice.field, REALTIME_VOICE.ECHO);
+  const reopened = storeIn(directory);
+  const baseline = await reopened.accountPreferencesSyncBaseline(account.email);
+  assert.deepEqual(baseline, { voice: REALTIME_VOICE.SAGE });
+  const result = await reopened.applyAccountPreferences(
+    { voice: REALTIME_VOICE.SAGE, voiceSpeed: REALTIME_VOICE_SPEED.FAST },
+    { accountEmail: account.email, preferences: baseline ?? {} },
+  );
+
+  assert.deepEqual(result.changed, [APP_SETTING_SCHEMA.voiceSpeed.field]);
+  assert.equal(await reopened.get(APP_SETTING_SCHEMA.voice.field), REALTIME_VOICE.ECHO);
+  assert.equal(await reopened.get(APP_SETTING_SCHEMA.voiceSpeed.field), REALTIME_VOICE_SPEED.FAST);
+});
+
+test("skips a guarded account preference apply after account sign-out", async (t) => {
+  const directory = await temporaryDirectory(t);
+  const store = storeIn(directory);
+  const account = {
+    accessToken: "access-token-secret",
+    refreshToken: "refresh-token-secret",
+    email: "developer@example.com",
+    name: "Developer",
+    provider: "github" as const,
+  };
+  await store.setAccount(account);
+  await store.set(APP_SETTING_SCHEMA.voice.field, REALTIME_VOICE.SAGE);
+  await store.set(APP_SETTING_SCHEMA.voiceSpeed.field, REALTIME_VOICE_SPEED.FAST);
+  await setWorkspaceProjectDefault(store, PROVIDER_ID.CONDUCTOR, "local-project");
+  const expected = await store.accountPreferences();
+
+  await store.clearAccount();
+  const result = await store.applyAccountPreferences(
+    { voice: REALTIME_VOICE.MARIN },
+    { accountEmail: account.email, preferences: expected },
+  );
+
+  assert.deepEqual(result.changed, []);
+  assert.equal(await store.get(APP_SETTING_SCHEMA.voice.field), undefined);
+  assert.equal(await store.get(APP_SETTING_SCHEMA.voiceSpeed.field), undefined);
+  assert.equal(await readWorkspaceProjectDefault(store, PROVIDER_ID.CONDUCTOR), undefined);
+  assert.equal(await store.accountPreferencesSyncBaseline(account.email), undefined);
+});
+
 test("reports no talk-key chord until one is chosen", async (t) => {
   const directory = await temporaryDirectory(t);
   const store = storeIn(directory);

--- a/apps/desktop/src/main/settings-store.ts
+++ b/apps/desktop/src/main/settings-store.ts
@@ -21,6 +21,7 @@ import {
   type UnparsedWireValue,
   unparsedWire,
   type WireRecord,
+  type WireValue,
 } from "@sidecar/wire";
 import { APPLE_CALENDAR_ID } from "#shared/apple-calendar";
 import {
@@ -52,10 +53,14 @@ import type { StoredAccount } from "@sidecar/account";
 import type { CalendarAccountCredential } from "@sidecar/calendar";
 import { googleCalendarSignInConfig } from "@sidecar/calendar";
 import {
+  ACCOUNT_PREFERENCE_FIELDS,
+  type AccountPreferenceField,
+  type AccountPreferences,
   APP_SETTING_FIELDS,
   APP_SETTING_SCHEMA,
   type AppSettingField,
   type AppSettingValue,
+  accountPreferencesFromStored,
   type KeyedAppSettingField,
   type SettingEntryValue,
   type StoredAppSettings,
@@ -84,6 +89,7 @@ const SETTINGS_FIELD = {
   GRANTS: "grants",
   LEGACY_CONDUCTOR_API_KEY: "conductorApiKey",
   LEGACY_SUPERSET_AGENT_DEFAULT: "supersetAgentDefault",
+  ACCOUNT_PREFERENCES_SYNC: "accountPreferencesSync",
   VAULT_SYNC_ACCOUNT: "vaultSyncAccount",
   VERSION: "version",
 } as const;
@@ -171,6 +177,17 @@ interface PersistedSettings extends StoredAppSettings {
    * Absent from the file while none are connected.
    */
   calendarAccounts?: readonly PersistedCalendarAccount[];
+  /**
+   * Last account-preference baseline used for hosted sync. It is local
+   * bookkeeping only: when the hosted write fails and the app restarts, this
+   * is what lets the next hosted read keep local edits made since the last
+   * successful baseline instead of treating the current local file as already
+   * synced.
+   */
+  accountPreferencesSync?: {
+    accountEmail: string;
+    preferences: AccountPreferences;
+  };
   /**
    * The Apple Calendar connection: present exactly while connected, holding
    * only the calendar ids the user chose to count. No credential rides with
@@ -436,6 +453,84 @@ function storedSettingsFromPersisted(persisted: PersistedSettings): StoredAppSet
   return entries as StoredAppSettings;
 }
 
+function sameAccountPreferenceValue(current: UnparsedWireValue, next: UnparsedWireValue): boolean {
+  return JSON.stringify(current) === JSON.stringify(next);
+}
+
+function accountPreferenceRecord(value: UnparsedWireValue): WireRecord {
+  return isRecord(value) ? value : {};
+}
+
+function accountPreferenceWithLocalChanges(
+  field: AccountPreferenceField,
+  remote: UnparsedWireValue,
+  current: UnparsedWireValue,
+  expected: UnparsedWireValue,
+): UnparsedWireValue {
+  if (
+    field === APP_SETTING_SCHEMA.workspaceAgentDefaults.field ||
+    field === APP_SETTING_SCHEMA.workspaceProjectDefaults.field
+  ) {
+    const entries = { ...accountPreferenceRecord(remote) };
+    const currentEntries = accountPreferenceRecord(current);
+    const expectedEntries = accountPreferenceRecord(expected);
+    const keys = new Set<string>();
+    for (const key of Object.keys(currentEntries)) keys.add(key);
+    for (const key of Object.keys(expectedEntries)) keys.add(key);
+    for (const key of keys) {
+      const currentEntry = currentEntries[key];
+      if (sameAccountPreferenceValue(currentEntry, expectedEntries[key])) continue;
+      if (currentEntry === undefined) delete entries[key];
+      else entries[key] = currentEntry;
+    }
+    return Object.keys(entries).length > 0 ? entries : undefined;
+  }
+  return sameAccountPreferenceValue(current, expected) ? remote : current;
+}
+
+function accountPreferencesWithLocalChanges(
+  remote: AccountPreferences,
+  current: AccountPreferences,
+  expected: AccountPreferences,
+): AccountPreferences {
+  const settings: Record<string, WireValue> = {};
+  for (const field of ACCOUNT_PREFERENCE_FIELDS) {
+    const value = accountPreferenceWithLocalChanges(
+      field,
+      // SAFETY: AccountPreferenceField selects JSON-compatible account preference values.
+      remote[field] as UnparsedWireValue,
+      // SAFETY: AccountPreferenceField selects JSON-compatible account preference values.
+      current[field] as UnparsedWireValue,
+      // SAFETY: AccountPreferenceField selects JSON-compatible account preference values.
+      expected[field] as UnparsedWireValue,
+    );
+    if (value !== undefined) settings[field] = value;
+  }
+  return accountPreferencesFromStored(settings) ?? {};
+}
+
+function accountPreferencesFromPersisted(persisted: PersistedSettings): AccountPreferences {
+  const settings: Record<string, WireValue> = {};
+  for (const field of ACCOUNT_PREFERENCE_FIELDS) {
+    // SAFETY: AccountPreferenceField selects JSON-compatible stored app settings.
+    const value = persisted[field] as UnparsedWireValue;
+    if (value !== undefined) settings[field] = value;
+  }
+  return accountPreferencesFromStored(settings) ?? {};
+}
+
+function storedAccountPreferencesSync(
+  record: WireRecord,
+): PersistedSettings["accountPreferencesSync"] {
+  const held = readWireRecord(record[SETTINGS_FIELD.ACCOUNT_PREFERENCES_SYNC]);
+  if (!held || !isWireString(held.accountEmail) || !held.accountEmail) return undefined;
+  const storedPreferences = readWireRecord(held.preferences);
+  if (!storedPreferences) return undefined;
+  const preferences = accountPreferencesFromStored(storedPreferences);
+  if (preferences === undefined) return undefined;
+  return { accountEmail: held.accountEmail, preferences };
+}
+
 function defaultPersistedSettings(): PersistedSettings {
   return {
     version: SETTINGS_FILE_VERSION,
@@ -459,12 +554,17 @@ function parsePersistedSettings(
   const grants = storedGrants(record);
   const settings = withLegacySupersetAgentDefault(readStoredSettings(record), record);
   const vaultSyncAccount = record[SETTINGS_FIELD.VAULT_SYNC_ACCOUNT];
+  const account = storedAccount(record);
+  const accountPreferencesSync = storedAccountPreferencesSync(record);
   const persisted = {
     ...settings,
     version: isWireNumber(version) ? version : SETTINGS_FILE_VERSION,
     apiKeys: storedApiKeys(record, providers),
     ...(Object.keys(grants).length > 0 ? { grants } : undefined),
-    ...(storedAccount(record) ? { account: storedAccount(record) } : undefined),
+    ...(account ? { account } : undefined),
+    ...(account && accountPreferencesSync?.accountEmail === account.email
+      ? { accountPreferencesSync }
+      : undefined),
     ...(calendarAccounts.length > 0 ? { calendarAccounts } : undefined),
     ...(appleCalendar ? { appleCalendar } : undefined),
     ...(isWireString(vaultSyncAccount) && vaultSyncAccount ? { vaultSyncAccount } : undefined),
@@ -556,6 +656,81 @@ export class SettingsStore {
       else delete next[field];
       return next;
     });
+  }
+
+  async accountPreferences(): Promise<AccountPreferences> {
+    return accountPreferencesFromPersisted(await this.#load());
+  }
+
+  async applyAccountPreferences(
+    settings: AccountPreferences,
+    expected?: { accountEmail: string; preferences: AccountPreferences },
+  ): Promise<SettingsUpdateResult & { changed: readonly AccountPreferenceField[] }> {
+    const changed: AccountPreferenceField[] = [];
+    await this.#serialize(async () => {
+      const persisted = await this.#load();
+      if (expected && persisted.account?.email !== expected.accountEmail) return;
+      const nextSettings = expected
+        ? accountPreferencesWithLocalChanges(
+            settings,
+            accountPreferencesFromPersisted(persisted),
+            expected.preferences,
+          )
+        : settings;
+      const next: PersistedSettings = { ...persisted, version: SETTINGS_FILE_VERSION };
+      for (const field of ACCOUNT_PREFERENCE_FIELDS) {
+        // SAFETY: AccountPreferences is the parsed subset of JSON-compatible stored app settings.
+        const value = nextSettings[field] as UnparsedWireValue;
+        // SAFETY: AccountPreferenceField selects the same persisted JSON-compatible setting value.
+        if (!sameAccountPreferenceValue(persisted[field] as UnparsedWireValue, value)) {
+          changed.push(field);
+        }
+        if (value === undefined) delete next[field];
+        else Object.assign(next, { [field]: value });
+      }
+      if (changed.length === 0) return;
+      await this.#write(next);
+      this.#loading = Promise.resolve(next);
+    });
+    return {
+      status: ACT_RESULT_STATUS.ACCEPTED,
+      settings: await this.snapshot(),
+      changed,
+    };
+  }
+
+  async accountPreferencesSyncBaseline(
+    accountEmail: string,
+  ): Promise<AccountPreferences | undefined> {
+    const sync = (await this.#load()).accountPreferencesSync;
+    return sync?.accountEmail === accountEmail ? sync.preferences : undefined;
+  }
+
+  async setAccountPreferencesSyncBaseline(
+    accountEmail: string,
+    preferences: AccountPreferences,
+  ): Promise<boolean> {
+    let saved = false;
+    await this.#serialize(async () => {
+      const persisted = await this.#load();
+      if (persisted.account?.email !== accountEmail) return;
+      if (
+        persisted.accountPreferencesSync?.accountEmail === accountEmail &&
+        JSON.stringify(persisted.accountPreferencesSync.preferences) === JSON.stringify(preferences)
+      ) {
+        saved = true;
+        return;
+      }
+      const next: PersistedSettings = {
+        ...persisted,
+        version: SETTINGS_FILE_VERSION,
+        accountPreferencesSync: { accountEmail, preferences },
+      };
+      await this.#write(next);
+      this.#loading = Promise.resolve(next);
+      saved = true;
+    });
+    return saved;
   }
 
   /** Clears one map entry only if it still holds the value the caller read. */
@@ -740,6 +915,12 @@ export class SettingsStore {
           provider: account.provider,
         },
       };
+      if (persisted.account?.email && persisted.account.email !== account.email) {
+        for (const field of ACCOUNT_PREFERENCE_FIELDS) {
+          delete next[field];
+        }
+        delete next.accountPreferencesSync;
+      }
       await this.#write(next);
       this.#loading = Promise.resolve(next);
     });
@@ -752,6 +933,10 @@ export class SettingsStore {
       if (!persisted.account) return;
       const { account: _account, ...withoutAccount } = persisted;
       const next: PersistedSettings = { ...withoutAccount, version: SETTINGS_FILE_VERSION };
+      for (const field of ACCOUNT_PREFERENCE_FIELDS) {
+        delete next[field];
+      }
+      delete next.accountPreferencesSync;
       await this.#write(next);
       this.#loading = Promise.resolve(next);
     });

--- a/packages/account/package.json
+++ b/packages/account/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "@sidecar/credentials": "workspace:*",
     "@sidecar/hosted": "workspace:*",
+    "@sidecar/settings": "workspace:*",
     "@sidecar/wire": "workspace:*"
   }
 }

--- a/packages/account/src/index.ts
+++ b/packages/account/src/index.ts
@@ -26,6 +26,11 @@ export {
   startAccountLoopback,
 } from "./loopback.js";
 export {
+  type AccountPreferencesAnswer,
+  AccountPreferencesClient,
+  type AccountPreferencesClientOptions,
+} from "./preferences.js";
+export {
   AccountSessionManager,
   type AccountSessionManagerOptions,
   type AccountSessionStore,

--- a/packages/account/src/preferences.test.ts
+++ b/packages/account/src/preferences.test.ts
@@ -1,0 +1,162 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { AccountPreferences } from "@sidecar/settings";
+import { AccountPreferencesClient } from "./preferences.js";
+
+const PREFERENCES_ANSWER = {
+  preferences: { voice: "marin", voiceSpeed: 1.5 },
+  updatedAt: 1_800_000_000_000,
+};
+
+interface RecordedRequest {
+  url: string | URL | Request;
+  init?: RequestInit;
+}
+
+function service(answers: Array<() => Response>) {
+  const requests: RecordedRequest[] = [];
+  let call = 0;
+  const fetchLike = async (url: string | URL | Request, init?: RequestInit): Promise<Response> => {
+    requests.push({ url, init });
+    const answer = answers[Math.min(call, answers.length - 1)];
+    call += 1;
+    if (!answer) throw new Error("no scripted answer");
+    return answer();
+  };
+  return { requests, fetchLike };
+}
+
+function client(options: Partial<ConstructorParameters<typeof AccountPreferencesClient>[0]> = {}) {
+  return new AccountPreferencesClient({
+    serviceBaseUrl: "https://tryluke.dev",
+    readAccessToken: async () => "token-1",
+    refreshAccount: async () => undefined,
+    ...options,
+  });
+}
+
+test("reads account preferences as a bearer-authenticated GET", async () => {
+  const { requests, fetchLike } = service([
+    () => new Response(JSON.stringify(PREFERENCES_ANSWER), { status: 200 }),
+  ]);
+
+  const answer = await client({ fetch: fetchLike }).readPreferences();
+  assert.deepEqual(answer, {
+    preferences: PREFERENCES_ANSWER.preferences,
+    hasStoredSnapshot: true,
+  });
+
+  const [request] = requests;
+  assert.equal(request?.url, "https://tryluke.dev/api/account/preferences");
+  assert.equal(request?.init?.method, "GET");
+  assert.equal(request?.init?.body, undefined);
+  assert.equal(new Headers(request?.init?.headers).get("authorization"), "Bearer token-1");
+  assert.equal(new Headers(request?.init?.headers).get("content-type"), null);
+});
+
+test("reads a missing hosted row as an empty snapshot without a stored marker", async () => {
+  const { fetchLike } = service([
+    () => new Response(JSON.stringify({ preferences: {} }), { status: 200 }),
+  ]);
+
+  assert.deepEqual(await client({ fetch: fetchLike }).readPreferences(), {
+    preferences: {},
+    hasStoredSnapshot: false,
+  });
+});
+
+test("writes account preferences as a full snapshot", async () => {
+  const { requests, fetchLike } = service([
+    () => new Response(JSON.stringify(PREFERENCES_ANSWER), { status: 200 }),
+  ]);
+
+  const answer = await client({ fetch: fetchLike }).writePreferences({
+    voice: "marin",
+    voiceSpeed: 1.5,
+  });
+  assert.deepEqual(answer, {
+    preferences: PREFERENCES_ANSWER.preferences,
+    hasStoredSnapshot: true,
+  });
+
+  const [request] = requests;
+  assert.equal(request?.url, "https://tryluke.dev/api/account/preferences");
+  assert.equal(request?.init?.method, "PUT");
+  assert.equal(new Headers(request?.init?.headers).get("content-type"), "application/json");
+  assert.deepEqual(JSON.parse(String(request?.init?.body)), {
+    preferences: { voice: "marin", voiceSpeed: 1.5 },
+  });
+});
+
+test("a malformed account preferences payload never travels", async () => {
+  const { requests, fetchLike } = service([]);
+
+  // SAFETY: This deliberately bypasses the public AccountPreferences type to verify the runtime guard.
+  const malformed = { voiceHotkey: "Command+Space" } as AccountPreferences;
+
+  assert.equal(await client({ fetch: fetchLike }).writePreferences(malformed), undefined);
+  assert.equal(requests.length, 0);
+});
+
+test("a 401 refreshes the account and retries once on the new token", async () => {
+  const tokens = ["token-1", "token-2"];
+  let refreshes = 0;
+  const { requests, fetchLike } = service([
+    () => new Response(JSON.stringify({ error: "invalid-token" }), { status: 401 }),
+    () => new Response(JSON.stringify(PREFERENCES_ANSWER), { status: 200 }),
+  ]);
+
+  const answer = await client({
+    fetch: fetchLike,
+    readAccessToken: async () => tokens.shift(),
+    refreshAccount: async () => {
+      refreshes += 1;
+    },
+  }).readPreferences();
+
+  assert.deepEqual(answer, {
+    preferences: PREFERENCES_ANSWER.preferences,
+    hasStoredSnapshot: true,
+  });
+  assert.equal(refreshes, 1);
+  assert.equal(requests.length, 2);
+  assert.equal(new Headers(requests[1]?.init?.headers).get("authorization"), "Bearer token-2");
+});
+
+test("failures, malformed answers, and a missing account read as no answer", async () => {
+  const failing = client({
+    fetch: async () => {
+      throw new Error("offline");
+    },
+  });
+  assert.equal(await failing.readPreferences(), undefined);
+  assert.equal(await failing.writePreferences({ voice: "sage" }), undefined);
+
+  const refused = client({
+    fetch: async () => new Response(JSON.stringify({ error: "unavailable" }), { status: 503 }),
+  });
+  assert.equal(await refused.writePreferences({ voice: "sage" }), undefined);
+
+  const malformed = client({
+    fetch: async () => new Response(JSON.stringify({ preferences: "none" }), { status: 200 }),
+  });
+  assert.equal(await malformed.readPreferences(), undefined);
+  const unknownField = client({
+    fetch: async () =>
+      new Response(JSON.stringify({ preferences: { voiceHotkey: "Command+Space" } }), {
+        status: 200,
+      }),
+  });
+  assert.equal(await unknownField.readPreferences(), undefined);
+
+  const requests: RecordedRequest[] = [];
+  const signedOut = client({
+    fetch: async (url, init) => {
+      requests.push({ url, init });
+      return new Response(JSON.stringify(PREFERENCES_ANSWER), { status: 200 });
+    },
+    readAccessToken: async () => undefined,
+  });
+  assert.equal(await signedOut.readPreferences(), undefined);
+  assert.equal(requests.length, 0);
+});

--- a/packages/account/src/preferences.ts
+++ b/packages/account/src/preferences.ts
@@ -1,0 +1,138 @@
+import { HOSTED_SERVICE_PATH } from "@sidecar/hosted";
+import { type AccountPreferences, accountPreferencesFromWire } from "@sidecar/settings";
+import {
+  isRecord,
+  isWireNumber,
+  positiveInteger,
+  text,
+  type UnparsedWireValue,
+  unparsedWire,
+} from "@sidecar/wire";
+import type { FetchLike } from "./client.js";
+
+const PREFERENCES_DEFAULTS = {
+  REQUEST_TIMEOUT_MS: 10_000,
+} as const;
+
+const UNAUTHORIZED_STATUS = 401;
+
+export interface AccountPreferencesAnswer {
+  preferences: AccountPreferences;
+  hasStoredSnapshot: boolean;
+}
+
+export interface AccountPreferencesClientOptions {
+  /** The hosted service origin, without a trailing slash. */
+  serviceBaseUrl: string;
+  readAccessToken: () => Promise<string | undefined>;
+  refreshAccount: () => Promise<void>;
+  readAccountKey?: () => Promise<string | undefined>;
+  fetch?: FetchLike;
+  requestTimeoutMs?: number;
+}
+
+interface AccountPreferencesRequest {
+  method: "GET" | "PUT";
+  path: string;
+  body?: Record<string, UnparsedWireValue>;
+}
+
+function withoutTrailingSlash(value: string): string {
+  return value.endsWith("/") ? value.slice(0, -1) : value;
+}
+
+function accountPreferencesAnswerFromWire(
+  value: UnparsedWireValue,
+): AccountPreferencesAnswer | undefined {
+  if (!isRecord(value)) return undefined;
+  const preferences = accountPreferencesFromWire(value.preferences);
+  if (preferences === undefined) return undefined;
+  if (value.updatedAt !== undefined && !isWireNumber(value.updatedAt)) return undefined;
+  return {
+    preferences,
+    hasStoredSnapshot: value.updatedAt !== undefined,
+  };
+}
+
+/**
+ * Reads and writes the account preference snapshot. The local store decides
+ * which settings are eligible to travel; this client validates the service's
+ * answer and refreshes the bearer once on expiry, matching the hosted vault.
+ */
+export class AccountPreferencesClient {
+  readonly #baseUrl: string;
+  readonly #readAccessToken: () => Promise<string | undefined>;
+  readonly #refreshAccount: () => Promise<void>;
+  readonly #readAccountKey?: () => Promise<string | undefined>;
+  readonly #fetch: FetchLike;
+  readonly #requestTimeoutMs: number;
+
+  constructor(options: AccountPreferencesClientOptions) {
+    const baseUrl = text(options.serviceBaseUrl);
+    if (!baseUrl) throw new Error("Hosted service base URL must not be empty");
+    this.#baseUrl = withoutTrailingSlash(baseUrl);
+    this.#readAccessToken = options.readAccessToken;
+    this.#refreshAccount = options.refreshAccount;
+    if (options.readAccountKey) this.#readAccountKey = options.readAccountKey;
+    this.#fetch = options.fetch ?? ((input, init) => fetch(input, init));
+    this.#requestTimeoutMs = positiveInteger(
+      options.requestTimeoutMs,
+      PREFERENCES_DEFAULTS.REQUEST_TIMEOUT_MS,
+    );
+  }
+
+  readPreferences(): Promise<AccountPreferencesAnswer | undefined> {
+    return this.#ask({ method: "GET", path: HOSTED_SERVICE_PATH.ACCOUNT_PREFERENCES });
+  }
+
+  writePreferences(preferences: AccountPreferences): Promise<AccountPreferencesAnswer | undefined> {
+    // SAFETY: AccountPreferences is JSON-compatible; the strict parser protects this runtime boundary.
+    const parsed = accountPreferencesFromWire(preferences as UnparsedWireValue);
+    if (parsed === undefined) return Promise.resolve(undefined);
+    return this.#ask({
+      method: "PUT",
+      path: HOSTED_SERVICE_PATH.ACCOUNT_PREFERENCES,
+      // SAFETY: The strict parser accepted this as a wire-shaped account preference object.
+      body: { preferences: parsed as UnparsedWireValue },
+    });
+  }
+
+  async #ask(request: AccountPreferencesRequest): Promise<AccountPreferencesAnswer | undefined> {
+    const account = await this.#readAccountKey?.();
+    const token = await this.#readAccessToken();
+    if (!token) return undefined;
+
+    let response = await this.#request(request, token);
+    if (response?.status === UNAUTHORIZED_STATUS) {
+      await this.#refreshAccount().catch(() => undefined);
+      const refreshed = await this.#readAccessToken();
+      const sameAccount =
+        this.#readAccountKey === undefined || (await this.#readAccountKey()) === account;
+      if (refreshed && refreshed !== token && sameAccount) {
+        response = await this.#request(request, refreshed);
+      }
+    }
+    if (!response?.ok) return undefined;
+
+    const payload = await response.json().catch(() => undefined);
+    return payload === undefined
+      ? undefined
+      : accountPreferencesAnswerFromWire(unparsedWire(payload));
+  }
+
+  async #request(request: AccountPreferencesRequest, token: string): Promise<Response | undefined> {
+    try {
+      return await this.#fetch(`${this.#baseUrl}${request.path}`, {
+        method: request.method,
+        headers: {
+          authorization: `Bearer ${token}`,
+          ...(request.body ? { "content-type": "application/json" } : undefined),
+        },
+        ...(request.body ? { body: JSON.stringify(request.body) } : undefined),
+        signal: AbortSignal.timeout(this.#requestTimeoutMs),
+      });
+    } catch {
+      return undefined;
+    }
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -283,6 +283,9 @@ importers:
       '@sidecar/hosted':
         specifier: workspace:*
         version: link:../hosted
+      '@sidecar/settings':
+        specifier: workspace:*
+        version: link:../settings
       '@sidecar/wire':
         specifier: workspace:*
         version: link:../wire


### PR DESCRIPTION
## Summary
- add desktop account-preferences sync against the hosted full-snapshot endpoint
- reconcile hosted values on sign-in/account capability startup and push local changes after settings updates
- apply remote voice and workspace-default changes to the live main-process state

## Stack
1. #772 Persist iOS workspace agent defaults
2. #773 Add hosted account preferences contract
3. Sync account preferences on desktop (this PR)
4. Sync account preferences on iOS

## Verification
- `pnpm exec biome check apps/desktop/src/main/account-preferences-sync.ts apps/desktop/src/main/account-preferences-sync.test.ts apps/desktop/src/main/desktop-app.ts apps/desktop/src/main/ipc/settings-rows.ts apps/desktop/src/main/settings-store.ts apps/desktop/src/main/settings-store.test.ts`
- `pnpm exec oxlint apps/desktop/src/main/account-preferences-sync.ts apps/desktop/src/main/account-preferences-sync.test.ts apps/desktop/src/main/desktop-app.ts apps/desktop/src/main/ipc/settings-rows.ts apps/desktop/src/main/settings-store.ts apps/desktop/src/main/settings-store.test.ts` (passes with existing `desktop-app.ts` warnings)
- `pnpm --filter @luke/desktop test -- src/main/account-preferences-sync.test.ts src/main/settings-store.test.ts`

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/fa3a346a-5bf2-4346-8a8d-35b123467a32)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34288501429/artifacts/10080526935) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34288501429)

- Commit: `1051e7cc2cb0787d5832ad43011211e0da0cf201`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
