### PR TITLE
feat(iOS): sync account preferences

### DIFF
--- a/apps/ios/Luke/LukeApp.swift
+++ b/apps/ios/Luke/LukeApp.swift
@@ -10,6 +10,8 @@ struct LukeApp: App {
     @Environment(\.scenePhase) private var scenePhase
     // Held for its lifetime — the WCSessionDelegate must not be deallocated.
     private let phoneRelay: PhoneSessionRelay
+    private let accountPreferences: AccountPreferencesSync
+    private let accountPreferencesEnabled: Bool
 
     init() {
         let session = AccountSession(
@@ -20,6 +22,10 @@ struct LukeApp: App {
         )
         _session = State(initialValue: session)
         phoneRelay = PhoneSessionRelay(accountSession: session)
+        accountPreferences = AccountPreferencesSync(
+            client: AccountPreferencesClient(baseURL: AccountConstants.serviceURL),
+            session: session
+        )
         _vault = State(initialValue: VaultStore(
             client: VaultClient(baseURL: AccountConstants.serviceURL),
             session: session
@@ -28,6 +34,7 @@ struct LukeApp: App {
         // counts and recording would be a test's, not a developer's — the
         // desktop's fixture and evidence gate, at this app's one seam.
         let testing = ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil
+        accountPreferencesEnabled = !testing
         let events = ProductEventSender(
             serviceURL: AccountConstants.serviceURL,
             appVersion: Self.appVersion,
@@ -40,7 +47,9 @@ struct LukeApp: App {
         events.record(.appLaunch)
         events.markDayActive()
         events.start()
-        if !testing {
+        if accountPreferencesEnabled {
+            accountPreferences.start()
+            accountPreferences.reconcile()
             SessionReplay.start()
             // A launch restored from the keychain is already the account's;
             // a signed-out launch records anonymously until the sign-in edge.
@@ -60,8 +69,12 @@ struct LukeApp: App {
                 .onChange(of: session.state) { previous, current in
                     accountEdge(from: previous, to: current)
                     switch current {
-                    case .signedIn: phoneRelay.push()
-                    case .signedOut: phoneRelay.pushSignOut()
+                    case .signedIn:
+                        if accountPreferencesEnabled { accountPreferences.reconcile() }
+                        phoneRelay.push()
+                    case .signedOut:
+                        if accountPreferencesEnabled { accountPreferences.clearAccountPreferences() }
+                        phoneRelay.pushSignOut()
                     }
                 }
         }
@@ -69,6 +82,7 @@ struct LukeApp: App {
             // iOS suspends rather than quits, so backgrounding is the moment
             // the desktop's timed flush cannot be counted on to arrive.
             if phase == .background { events.flush() }
+            if phase == .active && accountPreferencesEnabled { accountPreferences.reconcile() }
         }
     }
 

--- a/apps/ios/LukeKit/Sources/LukeKit/AccountPreferencesClient.swift
+++ b/apps/ios/LukeKit/Sources/LukeKit/AccountPreferencesClient.swift
@@ -1,0 +1,251 @@
+import Foundation
+
+public struct AccountPreferencesAnswer: Sendable, Equatable {
+    public let preferences: DeviceSettingsSnapshot
+    public let hasStoredSnapshot: Bool
+
+    public init(preferences: DeviceSettingsSnapshot, hasStoredSnapshot: Bool = false) {
+        self.preferences = preferences
+        self.hasStoredSnapshot = hasStoredSnapshot
+    }
+}
+
+public enum AccountPreferencesClientError: Error, Equatable {
+    case invalidResponse
+    case serverError(status: Int, apiError: HostedAPIError?)
+}
+
+private enum AccountPreferenceWireField {
+    static let voice = "voice"
+    static let voiceSpeed = "voiceSpeed"
+    static let defaultWorkspaceProvider = "defaultWorkspaceProvider"
+    static let workspaceProjectDefaults = "workspaceProjectDefaults"
+    static let workspaceAgentDefaults = "workspaceAgentDefaults"
+    static let agent = "agent"
+    static let model = "model"
+    static let effort = "effort"
+
+    static let topLevel: Set<String> = [
+        voice,
+        voiceSpeed,
+        defaultWorkspaceProvider,
+        workspaceProjectDefaults,
+        workspaceAgentDefaults,
+    ]
+}
+
+private let workspaceProviderIds: Set<String> = ["codex", "conductor", "superset"]
+private let supersetWorkspaceProviderId = "superset"
+private let maximumWorkspaceProjectIdLength = 500
+
+private func hostedVoiceSpeed(_ value: Any) -> RealtimeVoiceSpeed? {
+    if value is Bool { return nil }
+    if let number = value as? NSNumber {
+        return RealtimeVoiceSpeed(multiplier: number.doubleValue)
+    }
+    if let number = value as? Double {
+        return RealtimeVoiceSpeed(multiplier: number)
+    }
+    return nil
+}
+
+private func hostedMilliseconds(_ value: Any) -> Double? {
+    if value is Bool { return nil }
+    let milliseconds: Double
+    if let number = value as? NSNumber {
+        milliseconds = number.doubleValue
+    } else if let number = value as? Double {
+        milliseconds = number
+    } else {
+        return nil
+    }
+    return milliseconds >= 0 ? milliseconds : nil
+}
+
+private func isWorkspaceProviderId(_ value: String) -> Bool {
+    workspaceProviderIds.contains(value)
+}
+
+private func isSupersetAgentKind(_ value: String) -> Bool {
+    guard !value.isEmpty, value.count <= 80 else { return false }
+    return value.range(of: #"^[a-z0-9][a-z0-9-]*$"#, options: .regularExpression) != nil
+}
+
+/// Client for the account preferences endpoint. It sends only the cross-device
+/// preferences held by `DeviceSettingsSnapshot`; missing voice and speed values
+/// mean the shared defaults, so a reset clears the account choice rather than
+/// writing a copy of the default.
+public final class AccountPreferencesClient: Sendable {
+    private let baseURL: URL
+    private let http: HTTPClient
+
+    public init(baseURL: URL, http: HTTPClient = URLSession.shared) {
+        self.baseURL = baseURL
+        self.http = http
+    }
+
+    public func readPreferences(accessToken: String) async throws -> AccountPreferencesAnswer {
+        let json = try await send(
+            path: "api/account/preferences", method: "GET", body: nil, accessToken: accessToken
+        )
+        return try Self.answer(from: json)
+    }
+
+    public func writePreferences(_ snapshot: DeviceSettingsSnapshot, accessToken: String)
+        async throws -> AccountPreferencesAnswer
+    {
+        let json = try await send(
+            path: "api/account/preferences",
+            method: "PUT",
+            body: ["preferences": snapshot.accountPreferencesWire],
+            accessToken: accessToken
+        )
+        return try Self.answer(from: json)
+    }
+
+    private static func answer(from json: [String: Any]) throws -> AccountPreferencesAnswer {
+        guard let preferences = json["preferences"] as? [String: Any] else {
+            throw AccountPreferencesClientError.invalidResponse
+        }
+        let hasStoredSnapshot: Bool
+        if let stamp = json["updatedAt"] {
+            guard hostedMilliseconds(stamp) != nil else {
+                throw AccountPreferencesClientError.invalidResponse
+            }
+            hasStoredSnapshot = true
+        } else {
+            hasStoredSnapshot = false
+        }
+        guard let parsed = DeviceSettingsSnapshot(accountPreferencesWire: preferences) else {
+            throw AccountPreferencesClientError.invalidResponse
+        }
+        return AccountPreferencesAnswer(
+            preferences: parsed,
+            hasStoredSnapshot: hasStoredSnapshot
+        )
+    }
+
+    private func send(
+        path: String,
+        method: String,
+        body: [String: Any]?,
+        accessToken: String
+    ) async throws -> [String: Any] {
+        var request = URLRequest(url: baseURL.appendingPathComponent(path))
+        request.httpMethod = method
+        request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+        if let body {
+            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+            request.httpBody = try JSONSerialization.data(withJSONObject: body)
+        }
+        let (data, response) = try await http.data(for: request)
+        let status = (response as? HTTPURLResponse)?.statusCode ?? 0
+        let json = (try? JSONSerialization.jsonObject(with: data) as? [String: Any]) ?? [:]
+        guard (200 ..< 300).contains(status) else {
+            let reason = (json["error"] as? String).flatMap(HostedAPIError.init(rawValue:))
+            throw AccountPreferencesClientError.serverError(status: status, apiError: reason)
+        }
+        return json
+    }
+}
+
+extension DeviceSettingsSnapshot {
+    public var accountPreferencesWire: [String: Any] {
+        var wire: [String: Any] = [:]
+        if voice != .default { wire[AccountPreferenceWireField.voice] = voice.rawValue }
+        if speed != .default { wire[AccountPreferenceWireField.voiceSpeed] = speed.multiplier }
+        if let workspaceProviderId {
+            wire[AccountPreferenceWireField.defaultWorkspaceProvider] = workspaceProviderId
+        }
+        if !workspaceProjectIds.isEmpty {
+            wire[AccountPreferenceWireField.workspaceProjectDefaults] = workspaceProjectIds
+        }
+        if !workspaceAgentDefaults.isEmpty {
+            wire[AccountPreferenceWireField.workspaceAgentDefaults] = workspaceAgentDefaults.mapValues { selection in
+                var fields = [AccountPreferenceWireField.agent: selection.agent]
+                if let model = selection.model { fields[AccountPreferenceWireField.model] = model }
+                if let effort = selection.effort { fields[AccountPreferenceWireField.effort] = effort }
+                return fields
+            }
+        }
+        return wire
+    }
+
+    public init?(accountPreferencesWire wire: [String: Any]) {
+        for key in wire.keys where !AccountPreferenceWireField.topLevel.contains(key) {
+            return nil
+        }
+
+        var voice = RealtimeVoice.default
+        if let rawVoice = wire[AccountPreferenceWireField.voice] {
+            guard let name = rawVoice as? String, let parsed = RealtimeVoice(rawValue: name)
+            else { return nil }
+            voice = parsed
+        }
+
+        var speed = RealtimeVoiceSpeed.default
+        if let rawSpeed = wire[AccountPreferenceWireField.voiceSpeed] {
+            guard let parsed = hostedVoiceSpeed(rawSpeed) else { return nil }
+            speed = parsed
+        }
+
+        var workspaceProviderId: String?
+        if let rawProvider = wire[AccountPreferenceWireField.defaultWorkspaceProvider] {
+            guard let provider = rawProvider as? String, isWorkspaceProviderId(provider)
+            else { return nil }
+            workspaceProviderId = provider
+        }
+
+        var workspaceProjectIds: [String: String] = [:]
+        if let rawProjects = wire[AccountPreferenceWireField.workspaceProjectDefaults] {
+            guard let projects = rawProjects as? [String: Any] else { return nil }
+            for (provider, rawProjectId) in projects {
+                guard isWorkspaceProviderId(provider), let projectId = rawProjectId as? String else {
+                    return nil
+                }
+                let trimmed = projectId.trimmingCharacters(in: .whitespacesAndNewlines)
+                guard !trimmed.isEmpty, trimmed.count <= maximumWorkspaceProjectIdLength else {
+                    return nil
+                }
+                workspaceProjectIds[provider] = trimmed
+            }
+        }
+
+        var workspaceAgentDefaults: [String: WorkspaceAgentDefault] = [:]
+        if let rawAgents = wire[AccountPreferenceWireField.workspaceAgentDefaults] {
+            guard let agents = rawAgents as? [String: Any] else { return nil }
+            for (provider, rawFields) in agents {
+                guard isWorkspaceProviderId(provider), let fields = rawFields as? [String: Any],
+                      let agent = fields[AccountPreferenceWireField.agent] as? String
+                else { return nil }
+                if provider == supersetWorkspaceProviderId {
+                    guard fields[AccountPreferenceWireField.model] == nil,
+                          fields[AccountPreferenceWireField.effort] == nil,
+                          isSupersetAgentKind(agent)
+                    else { return nil }
+                    workspaceAgentDefaults[provider] = WorkspaceAgentDefault(agent: agent)
+                    continue
+                }
+                guard let model = fields[AccountPreferenceWireField.model] as? String,
+                      !agent.isEmpty, !model.isEmpty
+                else { return nil }
+                if let effort = fields[AccountPreferenceWireField.effort], !(effort is String) {
+                    return nil
+                }
+                workspaceAgentDefaults[provider] = WorkspaceAgentDefault(
+                    agent: agent,
+                    model: model,
+                    effort: fields[AccountPreferenceWireField.effort] as? String
+                )
+            }
+        }
+
+        self.init(
+            voice: voice,
+            speed: speed,
+            workspaceProviderId: workspaceProviderId,
+            workspaceProjectIds: workspaceProjectIds,
+            workspaceAgentDefaults: workspaceAgentDefaults
+        )
+    }
+}

--- a/apps/ios/LukeKit/Sources/LukeKit/AccountPreferencesSync.swift
+++ b/apps/ios/LukeKit/Sources/LukeKit/AccountPreferencesSync.swift
@@ -1,0 +1,235 @@
+import Foundation
+
+/// Mirrors the phone's cross-device preferences into the signed-in Luke account.
+/// The watch still gets the same choices through WatchConnectivity; only the
+/// phone talks to the hosted service, because it owns the account session.
+@MainActor
+public final class AccountPreferencesSync {
+    private enum Key {
+        static let baseline = "accountPreferences.syncBaseline"
+        static let accountEmail = "accountEmail"
+        static let preferences = "preferences"
+    }
+
+    private let store: UserDefaults
+    private let client: AccountPreferencesClient
+    private let session: any AccountTokenProviding
+    private var known: DeviceSettingsSnapshot
+    private var hydratedAccount: String?
+    private var applying = false
+    private var observer: (any NSObjectProtocol)?
+    private var task: Task<Void, Never>?
+
+    public init(
+        store: UserDefaults = .standard,
+        client: AccountPreferencesClient,
+        session: any AccountTokenProviding
+    ) {
+        self.store = store
+        self.client = client
+        self.session = session
+        known = DeviceSettingsSnapshot.read(from: store)
+    }
+
+    deinit {
+        if let observer { NotificationCenter.default.removeObserver(observer) }
+        task?.cancel()
+    }
+
+    public func start() {
+        observer = NotificationCenter.default.addObserver(
+            forName: UserDefaults.didChangeNotification, object: store, queue: nil
+        ) { [weak self] _ in
+            if Thread.isMainThread {
+                MainActor.assumeIsolated { self?.noteLocalChange() }
+            } else {
+                Task { @MainActor [weak self] in self?.noteLocalChange() }
+            }
+        }
+    }
+
+    @discardableResult
+    public func reconcile() -> Task<Void, Never> {
+        enqueue { _ = await self.reconcileNow() }
+    }
+
+    public func clearAccountPreferences() {
+        task?.cancel()
+        task = nil
+        hydratedAccount = nil
+        clearBaseline()
+        known = DeviceSettingsSnapshot()
+        applying = true
+        known.write(to: store)
+        applying = false
+    }
+
+    @discardableResult
+    private func reconcileNow() async -> Bool {
+        guard let account = session.accountEmail else { return false }
+        let baseline = hydrationBaseline(for: account)
+        let answer: AccountPreferencesAnswer
+        do {
+            answer = try await authorized { try await self.client.readPreferences(accessToken: $0) }
+        } catch {
+            return false
+        }
+        guard session.accountEmail == account else { return false }
+        let local = DeviceSettingsSnapshot.read(from: store)
+        if !answer.hasStoredSnapshot {
+            if local != DeviceSettingsSnapshot(),
+               !(await write(local, account: account))
+            {
+                return false
+            }
+            setBaseline(local, for: account)
+            hydratedAccount = account
+            return true
+        }
+        let merged = answer.preferences.mergingLocalChanges(current: local, expected: baseline)
+        apply(merged)
+        guard session.accountEmail == account else { return false }
+        hydratedAccount = account
+        guard merged != answer.preferences else {
+            setBaseline(merged, for: account)
+            return true
+        }
+        if await write(merged, account: account) {
+            setBaseline(merged, for: account)
+        }
+        return true
+    }
+
+    private func noteLocalChange() {
+        guard !applying else { return }
+        let current = DeviceSettingsSnapshot.read(from: store)
+        guard current != known else { return }
+        known = current
+        enqueue { await self.push() }
+    }
+
+    private func push() async {
+        guard let account = session.accountEmail else { return }
+        if hydratedAccount != account, !(await reconcileNow()) {
+            return
+        }
+        let snapshot = DeviceSettingsSnapshot.read(from: store)
+        guard session.accountEmail == account, hydratedAccount == account else { return }
+        if await write(snapshot, account: account) {
+            setBaseline(snapshot, for: account)
+        }
+    }
+
+    private func apply(_ snapshot: DeviceSettingsSnapshot) {
+        guard snapshot != known else { return }
+        known = snapshot
+        applying = true
+        snapshot.write(to: store)
+        applying = false
+    }
+
+    private func write(_ snapshot: DeviceSettingsSnapshot, account: String) async -> Bool {
+        do {
+            let answer = try await authorized {
+                try await self.client.writePreferences(snapshot, accessToken: $0)
+            }
+            guard session.accountEmail == account else { return false }
+            known = answer.preferences
+            return true
+        } catch {
+            return false
+        }
+    }
+
+    private func hydrationBaseline(for account: String) -> DeviceSettingsSnapshot {
+        if let baseline = storedBaseline(for: account) { return baseline }
+        let snapshot = DeviceSettingsSnapshot.read(from: store)
+        setBaseline(snapshot, for: account)
+        return snapshot
+    }
+
+    private func storedBaseline(for account: String) -> DeviceSettingsSnapshot? {
+        guard let record = store.dictionary(forKey: Key.baseline),
+              record[Key.accountEmail] as? String == account,
+              let preferences = record[Key.preferences] as? [String: Any]
+        else { return nil }
+        return DeviceSettingsSnapshot(accountPreferencesWire: preferences)
+    }
+
+    private func setBaseline(_ snapshot: DeviceSettingsSnapshot, for account: String) {
+        store.set(
+            [
+                Key.accountEmail: account,
+                Key.preferences: snapshot.accountPreferencesWire,
+            ],
+            forKey: Key.baseline
+        )
+    }
+
+    private func clearBaseline() {
+        store.removeObject(forKey: Key.baseline)
+    }
+
+    @discardableResult
+    private func enqueue(_ work: @escaping @MainActor () async -> Void) -> Task<Void, Never> {
+        let previous = task
+        let next = Task { @MainActor in
+            await previous?.value
+            if Task.isCancelled { return }
+            await work()
+        }
+        task = next
+        return next
+    }
+
+    private func authorized<T>(_ call: (String) async throws -> T) async throws -> T {
+        guard let account = session.accountEmail else { throw AccountSessionError.signedOut }
+        let token = try await session.validAccessToken()
+        guard session.accountEmail == account else { throw AccountSessionError.signedOut }
+        do {
+            return try await call(token)
+        } catch AccountPreferencesClientError.serverError(let status, _) where status == 401 {
+            guard session.accountEmail == account else { throw AccountSessionError.signedOut }
+            let refreshed = try await session.refreshAccessToken()
+            guard session.accountEmail == account else { throw AccountSessionError.signedOut }
+            return try await call(refreshed)
+        }
+    }
+}
+
+private extension DeviceSettingsSnapshot {
+    func mergingLocalChanges(
+        current: DeviceSettingsSnapshot,
+        expected: DeviceSettingsSnapshot
+    ) -> DeviceSettingsSnapshot {
+        DeviceSettingsSnapshot(
+            voice: current.voice == expected.voice ? voice : current.voice,
+            speed: current.speed == expected.speed ? speed : current.speed,
+            workspaceProviderId: current.workspaceProviderId == expected.workspaceProviderId
+                ? workspaceProviderId
+                : current.workspaceProviderId,
+            workspaceProjectIds: Self.merging(
+                remote: workspaceProjectIds,
+                current: current.workspaceProjectIds,
+                expected: expected.workspaceProjectIds
+            ),
+            workspaceAgentDefaults: Self.merging(
+                remote: workspaceAgentDefaults,
+                current: current.workspaceAgentDefaults,
+                expected: expected.workspaceAgentDefaults
+            )
+        )
+    }
+
+    private static func merging<Value: Equatable>(
+        remote: [String: Value],
+        current: [String: Value],
+        expected: [String: Value]
+    ) -> [String: Value] {
+        var merged = remote
+        for key in Set(current.keys).union(expected.keys) where current[key] != expected[key] {
+            merged[key] = current[key]
+        }
+        return merged
+    }
+}

--- a/apps/ios/LukeKit/Sources/LukeKit/ActClient.swift
+++ b/apps/ios/LukeKit/Sources/LukeKit/ActClient.swift
@@ -193,8 +193,8 @@ public final class ActClient: Sendable {
     ///
     /// `name` and `task` are optional; the server bounds them before passing
     /// them to the provider. `agent`, `model`, and `effort` name a choice from
-    /// the projects answer's own agent table — the server validates the
-    /// pairing against the same table and refuses anything it does not list.
+    /// the projects answer's own agent table, with `model` and `effort` sent
+    /// only for providers that document them.
     public func createWorkspace(
         accessToken: String,
         providerId: String,

--- a/apps/ios/LukeKit/Sources/LukeKit/DeviceSettingsSync.swift
+++ b/apps/ios/LukeKit/Sources/LukeKit/DeviceSettingsSync.swift
@@ -202,7 +202,8 @@ public final class DeviceSettingsSync {
             Field.speed: snapshot.speed.rawValue,
             Field.workspaceProjects: snapshot.workspaceProjectIds,
             Field.workspaceAgents: snapshot.workspaceAgentDefaults.mapValues { selection in
-                var fields = [Field.agent: selection.agent, Field.model: selection.model]
+                var fields = [Field.agent: selection.agent]
+                if let model = selection.model { fields[Field.model] = model }
                 if let effort = selection.effort { fields[Field.effort] = effort }
                 return fields
             },
@@ -221,10 +222,12 @@ public final class DeviceSettingsSync {
         else { return nil }
         let agents = (payload[Field.workspaceAgents] as? [String: [String: String]] ?? [:])
             .compactMapValues { fields -> WorkspaceAgentDefault? in
-                guard let agent = fields[Field.agent], let model = fields[Field.model] else {
-                    return nil
-                }
-                return WorkspaceAgentDefault(agent: agent, model: model, effort: fields[Field.effort])
+                guard let agent = fields[Field.agent] else { return nil }
+                return WorkspaceAgentDefault(
+                    agent: agent,
+                    model: fields[Field.model],
+                    effort: fields[Field.effort]
+                )
             }
         return DeviceSettingsSnapshot(
             voice: RealtimeVoice(rawValue: voice) ?? .default,

--- a/apps/ios/LukeKit/Sources/LukeKit/ProjectsClient.swift
+++ b/apps/ios/LukeKit/Sources/LukeKit/ProjectsClient.swift
@@ -103,7 +103,7 @@ public struct WorkspaceAgentOption: Identifiable, Equatable, Sendable {
             else { return nil }
             return WorkspaceAgentModelChoice(id: id, label: label)
         }
-        guard !models.isEmpty else { return nil }
+        guard modelsJSON.isEmpty || !models.isEmpty else { return nil }
         self.providerId = providerId
         self.agent = agent
         self.models = models

--- a/apps/ios/LukeKit/Sources/LukeKit/VoiceActDispatcher.swift
+++ b/apps/ios/LukeKit/Sources/LukeKit/VoiceActDispatcher.swift
@@ -165,10 +165,8 @@ public func dispatchVoiceToolCall(
                     ask.project.providerProjectId, for: ask.project.providerId
                 )
                 context.defaults.setAgentDefault(
-                    ask.agent.flatMap { agent in
-                        ask.model.map { model in
-                            WorkspaceAgentDefault(agent: agent, model: model, effort: ask.effort)
-                        }
+                    ask.agent.map { agent in
+                        WorkspaceAgentDefault(agent: agent, model: ask.model, effort: ask.effort)
                     },
                     for: ask.project.providerId
                 )

--- a/apps/ios/LukeKit/Sources/LukeKit/VoiceAsks.swift
+++ b/apps/ios/LukeKit/Sources/LukeKit/VoiceAsks.swift
@@ -398,13 +398,10 @@ public enum VoiceAsks {
             case .success(let resolved): selection = resolved
             case .failure(let refusal): return .failure(refusal)
             }
-        } else if let agent, let option = options.first(where: { $0.agent == agent }),
-            let first = option.models.first
-        {
-            // The creation endpoint takes an agent only beside a model, so an
-            // agent named alone runs the first model its table lists — the
-            // same one the New Workspace sheet preselects for it.
-            selection = AgentSelection(agent: agent, model: first.id, effort: nil)
+        } else if let agent, let option = options.first(where: { $0.agent == agent }) {
+            // Model-backed agents use the first model the New Workspace sheet
+            // preselects; kind-only agents carry only the provider's agent id.
+            selection = AgentSelection(agent: agent, model: option.models.first?.id, effort: nil)
         } else if agent == nil,
             let stored = WorkspaceProjectsContext.validAgentDefault(
                 defaultAgentDefaults[project.providerId], in: options
@@ -429,7 +426,7 @@ public enum VoiceAsks {
 
     struct AgentSelection: Equatable {
         let agent: String
-        let model: String
+        let model: String?
         let effort: String?
     }
 

--- a/apps/ios/LukeKit/Sources/LukeKit/WorkspaceCreationDefaults.swift
+++ b/apps/ios/LukeKit/Sources/LukeKit/WorkspaceCreationDefaults.swift
@@ -1,15 +1,14 @@
 import Foundation
 
-/// The agent kind, model, and optionally effort last chosen for new
-/// workspaces on one provider — one value on purpose, the way the desktop
-/// stores it: a model id or an effort level only means anything beside the
-/// agent that runs it.
+/// The agent kind, optional model, and optional effort last chosen for new
+/// workspaces on one provider. Most providers require a model beside the
+/// agent, while kind-only providers carry only the agent name.
 public struct WorkspaceAgentDefault: Equatable, Sendable {
     public let agent: String
-    public let model: String
+    public let model: String?
     public let effort: String?
 
-    public init(agent: String, model: String, effort: String? = nil) {
+    public init(agent: String, model: String? = nil, effort: String? = nil) {
         self.agent = agent
         self.model = model
         self.effort = effort
@@ -111,12 +110,13 @@ public final class WorkspaceCreationDefaults {
     }
 
     private static func agentDefault(fields: [String: String]) -> WorkspaceAgentDefault? {
-        guard let agent = fields["agent"], let model = fields["model"] else { return nil }
-        return WorkspaceAgentDefault(agent: agent, model: model, effort: fields["effort"])
+        guard let agent = fields["agent"] else { return nil }
+        return WorkspaceAgentDefault(agent: agent, model: fields["model"], effort: fields["effort"])
     }
 
     private static func fields(of selection: WorkspaceAgentDefault) -> [String: String] {
-        var fields = ["agent": selection.agent, "model": selection.model]
+        var fields = ["agent": selection.agent]
+        if let model = selection.model { fields["model"] = model }
         if let effort = selection.effort { fields["effort"] = effort }
         return fields
     }

--- a/apps/ios/LukeKit/Sources/LukeKit/WorkspaceProjectsContext.swift
+++ b/apps/ios/LukeKit/Sources/LukeKit/WorkspaceProjectsContext.swift
@@ -65,11 +65,13 @@ public enum WorkspaceProjectsContext {
             let options = answer.agentModels.filter { $0.providerId == providerId }
             guard !options.isEmpty else { continue }
             let agents = options.map { option in
-                let models = option.models.map { "\($0.label) (\($0.id))" }.joined(separator: ", ")
+                let models = option.models.isEmpty
+                    ? "no model choice"
+                    : "models \(option.models.map { "\($0.label) (\($0.id))" }.joined(separator: ", "))"
                 let efforts =
                     option.efforts.isEmpty
                     ? "" : "; efforts \(option.efforts.joined(separator: ", "))"
-                return "\(option.agent) — models \(models)\(efforts)"
+                return "\(option.agent) — \(models)\(efforts)"
             }
             let stored = validAgentDefault(defaultAgentDefaults[providerId], in: options).map {
                 defaultAgentText($0, in: options)
@@ -79,7 +81,7 @@ public enum WorkspaceProjectsContext {
                 ?? "Omitted, the provider's own default agent starts."
             lines.append(
                 "\(VaultProviderID.displayLabel(forWireId: providerId)) agents a new workspace can start, "
-                    + "each with the models it runs: \(agents.joined(separator: " | ")). \(omitted)"
+                    + "each with its model choices: \(agents.joined(separator: " | ")). \(omitted)"
             )
         }
         if let chosenDefault {
@@ -133,10 +135,14 @@ public enum WorkspaceProjectsContext {
         in options: [WorkspaceAgentOption]
     ) -> WorkspaceAgentDefault? {
         guard let stored,
-            let option = options.first(where: { $0.agent == stored.agent }),
-            option.models.contains(where: { $0.id == stored.model }),
-            stored.effort == nil || option.efforts.contains(stored.effort ?? "")
+            let option = options.first(where: { $0.agent == stored.agent })
         else { return nil }
+        if let model = stored.model {
+            guard option.models.contains(where: { $0.id == model }) else { return nil }
+        } else {
+            guard option.models.isEmpty, stored.effort == nil else { return nil }
+        }
+        if let effort = stored.effort, !option.efforts.contains(effort) { return nil }
         return stored
     }
 
@@ -144,9 +150,10 @@ public enum WorkspaceProjectsContext {
         _ stored: WorkspaceAgentDefault,
         in options: [WorkspaceAgentOption]
     ) -> String {
+        guard let storedModel = stored.model else { return stored.agent }
         let option = options.first { $0.agent == stored.agent }
-        let model = option?.models.first { $0.id == stored.model }
-        let modelText = model.map { "\($0.label) (\($0.id))" } ?? stored.model
+        let model = option?.models.first { $0.id == storedModel }
+        let modelText = model.map { "\($0.label) (\($0.id))" } ?? storedModel
         let effortText = stored.effort.map { ", effort \($0)" } ?? ""
         return "\(stored.agent) with \(modelText)\(effortText)"
     }

--- a/apps/ios/LukeKit/Tests/LukeKitTests/AccountPreferencesClientTests.swift
+++ b/apps/ios/LukeKit/Tests/LukeKitTests/AccountPreferencesClientTests.swift
@@ -1,0 +1,173 @@
+import Foundation
+import XCTest
+
+@testable import LukeKit
+
+private func preferencesResponse(url: URL, status: Int) -> HTTPURLResponse {
+    HTTPURLResponse(url: url, statusCode: status, httpVersion: nil, headerFields: nil)!
+}
+
+private func preferencesJSONData(_ dict: [String: Any]) -> Data {
+    try! JSONSerialization.data(withJSONObject: dict)
+}
+
+@MainActor
+final class AccountPreferencesClientTests: XCTestCase {
+    private let base = URL(string: "https://tryluke.dev")!
+
+    func testAccountPreferencesWireOmitsDefaultValuesAndIncludesWorkspaceDefaults() {
+        let snapshot = DeviceSettingsSnapshot(
+            voice: .marin,
+            speed: .default,
+            workspaceProviderId: "conductor",
+            workspaceProjectIds: ["conductor": "project-1"],
+            workspaceAgentDefaults: [
+                "conductor": WorkspaceAgentDefault(
+                    agent: "codex", model: "gpt-5.6-sol", effort: "high"
+                ),
+                "superset": WorkspaceAgentDefault(agent: "composer"),
+            ]
+        )
+
+        let wire = snapshot.accountPreferencesWire
+        XCTAssertEqual(wire["voice"] as? String, "marin")
+        XCTAssertNil(wire["voiceSpeed"])
+        XCTAssertEqual(wire["defaultWorkspaceProvider"] as? String, "conductor")
+        XCTAssertEqual(wire["workspaceProjectDefaults"] as? [String: String], [
+            "conductor": "project-1",
+        ])
+        XCTAssertEqual(
+            (wire["workspaceAgentDefaults"] as? [String: [String: String]])?["conductor"],
+            ["agent": "codex", "model": "gpt-5.6-sol", "effort": "high"]
+        )
+        XCTAssertEqual(
+            (wire["workspaceAgentDefaults"] as? [String: [String: String]])?["superset"],
+            ["agent": "composer"]
+        )
+    }
+
+    func testAccountPreferencesWireParsesHostedSnapshot() {
+        let snapshot = DeviceSettingsSnapshot(accountPreferencesWire: [
+            "voice": "coral",
+            "voiceSpeed": 1.5,
+            "defaultWorkspaceProvider": "conductor",
+            "workspaceProjectDefaults": ["conductor": "project-1"],
+            "workspaceAgentDefaults": [
+                "conductor": ["agent": "codex", "model": "gpt-5.6-sol"],
+                "superset": ["agent": "composer"],
+            ],
+        ])
+
+        XCTAssertEqual(snapshot?.voice, .coral)
+        XCTAssertEqual(snapshot?.speed, .fast)
+        XCTAssertEqual(snapshot?.workspaceProviderId, "conductor")
+        XCTAssertEqual(snapshot?.workspaceProjectIds, ["conductor": "project-1"])
+        XCTAssertEqual(snapshot?.workspaceAgentDefaults, [
+            "conductor": WorkspaceAgentDefault(agent: "codex", model: "gpt-5.6-sol"),
+            "superset": WorkspaceAgentDefault(agent: "composer"),
+        ])
+    }
+
+    func testAccountPreferencesWireRejectsUnknownAndInvalidHostedValues() {
+        XCTAssertNil(DeviceSettingsSnapshot(accountPreferencesWire: ["futureSetting": "ignored"]))
+        XCTAssertNil(DeviceSettingsSnapshot(accountPreferencesWire: ["voice": "baritone"]))
+        XCTAssertNil(DeviceSettingsSnapshot(accountPreferencesWire: ["voiceSpeed": true]))
+        XCTAssertNil(
+            DeviceSettingsSnapshot(accountPreferencesWire: [
+                "workspaceProjectDefaults": ["unknown": "project-1"],
+            ])
+        )
+        XCTAssertNil(
+            DeviceSettingsSnapshot(accountPreferencesWire: [
+                "workspaceAgentDefaults": ["superset": ["agent": "composer", "model": "gpt"]],
+            ])
+        )
+    }
+
+    func testReadAccountPreferencesParsesSnapshotAndStoredMarker() async throws {
+        let stub = StubHTTPClient { request in
+            XCTAssertEqual(request.httpMethod, "GET")
+            XCTAssertEqual(request.url?.path, "/api/account/preferences")
+            XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer at-1")
+            XCTAssertNil(request.httpBody)
+            return (
+                preferencesJSONData([
+                    "preferences": [
+                        "voice": "coral",
+                        "voiceSpeed": 1.25,
+                    ],
+                    "updatedAt": 1_800_000_000_000,
+                ]),
+                preferencesResponse(url: request.url!, status: 200)
+            )
+        }
+        let client = AccountPreferencesClient(baseURL: base, http: stub)
+        let answer = try await client.readPreferences(accessToken: "at-1")
+
+        XCTAssertEqual(answer.preferences.voice, .coral)
+        XCTAssertEqual(answer.preferences.speed, .quick)
+        XCTAssertTrue(answer.hasStoredSnapshot)
+    }
+
+    func testWriteAccountPreferencesSendsSnapshot() async throws {
+        let stub = StubHTTPClient { request in
+            XCTAssertEqual(request.httpMethod, "PUT")
+            XCTAssertEqual(request.url?.path, "/api/account/preferences")
+            XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer at-1")
+            XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "application/json")
+            let body = try! JSONSerialization.jsonObject(
+                with: request.httpBody ?? Data()
+            ) as! [String: Any]
+            let preferences = body["preferences"] as? [String: Any]
+            XCTAssertEqual(preferences?["voiceSpeed"] as? Double, 0.75)
+            XCTAssertNil(preferences?["voice"])
+            return (
+                preferencesJSONData([
+                    "preferences": ["voiceSpeed": 0.75],
+                    "updatedAt": 1_800_000_000_000,
+                ]),
+                preferencesResponse(url: request.url!, status: 200)
+            )
+        }
+        let client = AccountPreferencesClient(baseURL: base, http: stub)
+        let answer = try await client.writePreferences(
+            DeviceSettingsSnapshot(speed: .slow),
+            accessToken: "at-1"
+        )
+
+        XCTAssertEqual(answer.preferences.speed, .slow)
+    }
+
+    func testReadWithoutStoredRowParsesAsDefaults() async throws {
+        let stub = StubHTTPClient { request in
+            (
+                preferencesJSONData(["preferences": [:]]),
+                preferencesResponse(url: request.url!, status: 200)
+            )
+        }
+        let client = AccountPreferencesClient(baseURL: base, http: stub)
+        let answer = try await client.readPreferences(accessToken: "at-1")
+
+        XCTAssertEqual(answer.preferences, DeviceSettingsSnapshot())
+        XCTAssertFalse(answer.hasStoredSnapshot)
+    }
+
+    func testRefusalCarriesHostedReason() async {
+        let stub = StubHTTPClient { request in
+            (
+                preferencesJSONData(["error": "invalid-token"]),
+                preferencesResponse(url: request.url!, status: 401)
+            )
+        }
+        let client = AccountPreferencesClient(baseURL: base, http: stub)
+        do {
+            _ = try await client.readPreferences(accessToken: "expired")
+            XCTFail("Expected throw")
+        } catch AccountPreferencesClientError.serverError(let status, let apiError) {
+            XCTAssertEqual(status, 401)
+            XCTAssertEqual(apiError, .invalidToken)
+        } catch {
+            XCTFail("Unexpected: \(error)")
+        }
+    }
+}

--- a/apps/ios/LukeKit/Tests/LukeKitTests/AccountPreferencesSyncTests.swift
+++ b/apps/ios/LukeKit/Tests/LukeKitTests/AccountPreferencesSyncTests.swift
@@ -1,0 +1,309 @@
+import Foundation
+import XCTest
+
+@testable import LukeKit
+
+private func syncResponse(url: URL, status: Int) -> HTTPURLResponse {
+    HTTPURLResponse(url: url, statusCode: status, httpVersion: nil, headerFields: nil)!
+}
+
+private func syncJSONData(_ dict: [String: Any]) -> Data {
+    try! JSONSerialization.data(withJSONObject: dict)
+}
+
+@MainActor
+private final class AccountPreferencesTokenSource: AccountTokenProviding {
+    var accountEmail: String? = "user@example.com"
+    var token: String? = "at-1"
+    var refreshedToken: String? = "at-2"
+    var refreshes = 0
+
+    func validAccessToken() async throws -> String {
+        guard let token else { throw AccountSessionError.signedOut }
+        return token
+    }
+
+    func refreshAccessToken() async throws -> String {
+        refreshes += 1
+        guard let refreshedToken else { throw AccountSessionError.signedOut }
+        token = refreshedToken
+        return refreshedToken
+    }
+}
+
+@MainActor
+final class AccountPreferencesSyncTests: XCTestCase {
+    private var suites: [String] = []
+    private let base = URL(string: "https://tryluke.dev")!
+
+    override func tearDown() {
+        for suite in suites { UserDefaults(suiteName: suite)?.removePersistentDomain(forName: suite) }
+        super.tearDown()
+    }
+
+    private func makeStore() -> UserDefaults {
+        let suite = "account-preferences-sync-tests-\(UUID().uuidString)"
+        suites.append(suite)
+        return UserDefaults(suiteName: suite)!
+    }
+
+    func testReconcileRestoresAccountPreferencesIntoUserDefaults() async {
+        let store = makeStore()
+        let tokenSource = AccountPreferencesTokenSource()
+        let stub = StubHTTPClient { request in
+            XCTAssertEqual(request.httpMethod, "GET")
+            return (
+                syncJSONData([
+                    "preferences": [
+                        "voice": "marin",
+                        "voiceSpeed": 1.5,
+                        "defaultWorkspaceProvider": "conductor",
+                        "workspaceProjectDefaults": ["conductor": "project-1"],
+                        "workspaceAgentDefaults": [
+                            "conductor": [
+                                "agent": "codex",
+                                "model": "gpt-5.6-sol",
+                                "effort": "high",
+                            ],
+                        ],
+                    ],
+                    "updatedAt": 1_800_000_000_000,
+                ]),
+                syncResponse(url: request.url!, status: 200)
+            )
+        }
+        let sync = AccountPreferencesSync(
+            store: store,
+            client: AccountPreferencesClient(baseURL: base, http: stub),
+            session: tokenSource
+        )
+
+        await sync.reconcile().value
+
+        XCTAssertEqual(DeviceSettingsSnapshot.read(from: store), DeviceSettingsSnapshot(
+            voice: .marin,
+            speed: .fast,
+            workspaceProviderId: "conductor",
+            workspaceProjectIds: ["conductor": "project-1"],
+            workspaceAgentDefaults: [
+                "conductor": WorkspaceAgentDefault(
+                    agent: "codex", model: "gpt-5.6-sol", effort: "high"
+                ),
+            ]
+        ))
+    }
+
+    func testReconcilePublishesLocalPreferencesWhenTheAccountHasNoRow() async {
+        let store = makeStore()
+        DeviceSettingsSnapshot(
+            voice: .sage,
+            speed: .default,
+            workspaceProjectIds: ["conductor": "project-local"]
+        ).write(to: store)
+        let tokenSource = AccountPreferencesTokenSource()
+        var methods: [String] = []
+        var writtenPreferences: [String: Any]?
+        let stub = StubHTTPClient { request in
+            methods.append(request.httpMethod ?? "")
+            if request.httpMethod == "GET" {
+                return (syncJSONData(["preferences": [:]]), syncResponse(url: request.url!, status: 200))
+            }
+            let body = try! JSONSerialization.jsonObject(
+                with: request.httpBody ?? Data()
+            ) as! [String: Any]
+            writtenPreferences = body["preferences"] as? [String: Any]
+            return (
+                syncJSONData([
+                    "preferences": writtenPreferences ?? [:],
+                    "updatedAt": 1_800_000_000_000,
+                ]),
+                syncResponse(url: request.url!, status: 200)
+            )
+        }
+        let sync = AccountPreferencesSync(
+            store: store,
+            client: AccountPreferencesClient(baseURL: base, http: stub),
+            session: tokenSource
+        )
+
+        await sync.reconcile().value
+
+        XCTAssertEqual(methods, ["GET", "PUT"])
+        XCTAssertEqual(writtenPreferences?["voice"] as? String, "sage")
+        XCTAssertNil(writtenPreferences?["voiceSpeed"])
+        XCTAssertEqual(writtenPreferences?["workspaceProjectDefaults"] as? [String: String], [
+            "conductor": "project-local",
+        ])
+    }
+
+    func testReconcileDoesNotCreateARowForUntouchedDefaults() async {
+        let store = makeStore()
+        let tokenSource = AccountPreferencesTokenSource()
+        var methods: [String] = []
+        let stub = StubHTTPClient { request in
+            methods.append(request.httpMethod ?? "")
+            return (syncJSONData(["preferences": [:]]), syncResponse(url: request.url!, status: 200))
+        }
+        let sync = AccountPreferencesSync(
+            store: store,
+            client: AccountPreferencesClient(baseURL: base, http: stub),
+            session: tokenSource
+        )
+
+        await sync.reconcile().value
+
+        XCTAssertEqual(methods, ["GET"])
+    }
+
+    func testReconcileLeavesNewerLocalPreferenceWhenItChangesDuringTheRead() async {
+        let store = makeStore()
+        DeviceSettingsSnapshot(voice: .sage).write(to: store)
+        let tokenSource = AccountPreferencesTokenSource()
+        var methods: [String] = []
+        let stub = StubHTTPClient { request in
+            methods.append(request.httpMethod ?? "")
+            if request.httpMethod == "PUT" {
+                let body = try! JSONSerialization.jsonObject(
+                    with: request.httpBody ?? Data()
+                ) as! [String: Any]
+                return (
+                    syncJSONData([
+                        "preferences": body["preferences"] as? [String: Any] ?? [:],
+                        "updatedAt": 1_800_000_000_000,
+                    ]),
+                    syncResponse(url: request.url!, status: 200)
+                )
+            }
+            await MainActor.run { DeviceSettingsSnapshot(voice: .coral).write(to: store) }
+            return (
+                syncJSONData([
+                    "preferences": ["voice": "marin"],
+                    "updatedAt": 1_800_000_000_000,
+                ]),
+                syncResponse(url: request.url!, status: 200)
+            )
+        }
+        let sync = AccountPreferencesSync(
+            store: store,
+            client: AccountPreferencesClient(baseURL: base, http: stub),
+            session: tokenSource
+        )
+
+        await sync.reconcile().value
+
+        XCTAssertEqual(methods, ["GET", "PUT"])
+        XCTAssertEqual(DeviceSettingsSnapshot.read(from: store).voice, .coral)
+    }
+
+    func testReconcileKeepsLocalEditsAcrossFailedHostedWriteAndRestart() async {
+        let store = makeStore()
+        DeviceSettingsSnapshot(voice: .sage).write(to: store)
+        let tokenSource = AccountPreferencesTokenSource()
+        let firstStub = StubHTTPClient { request in
+            XCTAssertEqual(request.httpMethod, "GET")
+            return (
+                syncJSONData(["preferences": ["voice": "sage"], "updatedAt": 1_800_000_000_000]),
+                syncResponse(url: request.url!, status: 200)
+            )
+        }
+        let firstSync = AccountPreferencesSync(
+            store: store,
+            client: AccountPreferencesClient(baseURL: base, http: firstStub),
+            session: tokenSource
+        )
+        await firstSync.reconcile().value
+
+        DeviceSettingsSnapshot(voice: .coral).write(to: store)
+
+        var methods: [String] = []
+        var writtenPreferences: [String: Any]?
+        let restartStub = StubHTTPClient { request in
+            methods.append(request.httpMethod ?? "")
+            if request.httpMethod == "GET" {
+                return (
+                    syncJSONData([
+                        "preferences": ["voice": "sage", "voiceSpeed": 1.5],
+                        "updatedAt": 1_800_000_000_000,
+                    ]),
+                    syncResponse(url: request.url!, status: 200)
+                )
+            }
+            let body = try! JSONSerialization.jsonObject(
+                with: request.httpBody ?? Data()
+            ) as! [String: Any]
+            writtenPreferences = body["preferences"] as? [String: Any]
+            return (
+                syncJSONData([
+                    "preferences": writtenPreferences ?? [:],
+                    "updatedAt": 1_800_000_000_000,
+                ]),
+                syncResponse(url: request.url!, status: 200)
+            )
+        }
+        let restartedSync = AccountPreferencesSync(
+            store: store,
+            client: AccountPreferencesClient(baseURL: base, http: restartStub),
+            session: tokenSource
+        )
+
+        await restartedSync.reconcile().value
+
+        XCTAssertEqual(methods, ["GET", "PUT"])
+        XCTAssertEqual(DeviceSettingsSnapshot.read(from: store).voice, .coral)
+        XCTAssertEqual(DeviceSettingsSnapshot.read(from: store).speed, .fast)
+        XCTAssertEqual(writtenPreferences?["voice"] as? String, "coral")
+        XCTAssertEqual(writtenPreferences?["voiceSpeed"] as? Double, 1.5)
+    }
+
+    func testClearAccountPreferencesRemovesLocalPreferences() {
+        let store = makeStore()
+        DeviceSettingsSnapshot(
+            voice: .sage,
+            speed: .fast,
+            workspaceProviderId: "conductor",
+            workspaceProjectIds: ["conductor": "project-1"],
+            workspaceAgentDefaults: ["conductor": WorkspaceAgentDefault(agent: "codex", model: "gpt")]
+        ).write(to: store)
+        let sync = AccountPreferencesSync(
+            store: store,
+            client: AccountPreferencesClient(baseURL: base, http: StubHTTPClient { request in
+                (Data(), syncResponse(url: request.url!, status: 200))
+            }),
+            session: AccountPreferencesTokenSource()
+        )
+
+        sync.clearAccountPreferences()
+
+        XCTAssertEqual(DeviceSettingsSnapshot.read(from: store), DeviceSettingsSnapshot())
+    }
+
+    func testA401RefreshesAndRetriesOnce() async {
+        let store = makeStore()
+        let tokenSource = AccountPreferencesTokenSource()
+        var tokens: [String?] = []
+        let stub = StubHTTPClient { request in
+            tokens.append(request.value(forHTTPHeaderField: "Authorization"))
+            if tokens.count == 1 {
+                return (
+                    syncJSONData(["error": "invalid-token"]),
+                    syncResponse(url: request.url!, status: 401)
+                )
+            }
+            return (
+                syncJSONData(["preferences": ["voice": "ash"], "updatedAt": 1_800_000_000_000]),
+                syncResponse(url: request.url!, status: 200)
+            )
+        }
+        let sync = AccountPreferencesSync(
+            store: store,
+            client: AccountPreferencesClient(baseURL: base, http: stub),
+            session: tokenSource
+        )
+
+        await sync.reconcile().value
+
+        XCTAssertEqual(tokenSource.refreshes, 1)
+        XCTAssertEqual(tokens, ["Bearer at-1", "Bearer at-2"])
+        XCTAssertEqual(DeviceSettingsSnapshot.read(from: store).voice, .ash)
+    }
+}

--- a/apps/ios/LukeKit/Tests/LukeKitTests/DeviceSettingsSyncTests.swift
+++ b/apps/ios/LukeKit/Tests/LukeKitTests/DeviceSettingsSyncTests.swift
@@ -32,6 +32,7 @@ final class DeviceSettingsSyncTests: XCTestCase {
         workspaceAgentDefaults: [
             "conductor": WorkspaceAgentDefault(agent: "claude", model: "fable-5", effort: "high"),
             "codex": WorkspaceAgentDefault(agent: "codex", model: "gpt"),
+            "superset": WorkspaceAgentDefault(agent: "composer"),
         ]
     )
 

--- a/apps/ios/LukeKit/Tests/LukeKitTests/ProjectsClientTests.swift
+++ b/apps/ios/LukeKit/Tests/LukeKitTests/ProjectsClientTests.swift
@@ -93,12 +93,26 @@ final class WorkspaceAgentOptionTests: XCTestCase {
         XCTAssertEqual(option?.efforts, ["low", "high"])
     }
 
-    func testNoUsableModelsIsNoOption() {
+    func testExplicitlyEmptyModelsDecodeAsKindOnlyOption() {
+        let option = WorkspaceAgentOption(json: [
+            "providerId": "superset",
+            "agent": "composer",
+            "models": [],
+            "efforts": [],
+        ])
+
+        XCTAssertEqual(
+            option,
+            WorkspaceAgentOption(providerId: "superset", agent: "composer", models: [], efforts: [])
+        )
+    }
+
+    func testOnlyMalformedModelsIsNoOption() {
         XCTAssertNil(
             WorkspaceAgentOption(json: [
                 "providerId": "conductor",
                 "agent": "claude",
-                "models": [],
+                "models": [["id": "", "label": "nameless"]],
                 "efforts": [],
             ])
         )
@@ -141,6 +155,12 @@ final class ProjectsClientTests: XCTestCase {
                         "models": [["id": "fable-5-1", "label": "Fable 5.1"]],
                         "efforts": ["low"],
                     ],
+                    [
+                        "providerId": "superset",
+                        "agent": "composer",
+                        "models": [],
+                        "efforts": [],
+                    ],
                     ["providerId": "conductor"],  // malformed: skipped
                 ],
             ])
@@ -150,8 +170,10 @@ final class ProjectsClientTests: XCTestCase {
         XCTAssertEqual(answer.projects.count, 1)
         XCTAssertEqual(answer.projects.first?.providerProjectId, "proj-1")
         XCTAssertEqual(answer.projects.first?.taskSupport, .optional)
-        XCTAssertEqual(answer.agentModels.count, 1)
+        XCTAssertEqual(answer.agentModels.count, 2)
         XCTAssertEqual(answer.agentModels.first?.agent, "claude")
+        XCTAssertEqual(answer.agentModels.last?.agent, "composer")
+        XCTAssertEqual(answer.agentModels.last?.models, [])
     }
 
     func testServerErrorThrows() async {

--- a/apps/ios/LukeKit/Tests/LukeKitTests/VoiceActDispatcherTests.swift
+++ b/apps/ios/LukeKit/Tests/LukeKitTests/VoiceActDispatcherTests.swift
@@ -288,6 +288,53 @@ final class VoiceActDispatcherTests: XCTestCase {
             WorkspaceAgentDefault(agent: "claude", model: "fable-5", effort: "high")
         )
     }
+
+    func testAcceptedKindOnlyCreationPersistsTheChosenAgent() async {
+        let suite = "VoiceActDispatcherTests.\(UUID().uuidString)"
+        let store = UserDefaults(suiteName: suite)!
+        defer { store.removePersistentDomain(forName: suite) }
+        let defaults = WorkspaceCreationDefaults(store: store)
+        let projects = ProjectsAnswer(
+            projects: [
+                RosterProject(
+                    providerId: "superset",
+                    providerProjectId: "p1",
+                    repository: "owner/repo",
+                    taskSupport: .optional
+                )
+            ],
+            agentModels: [
+                WorkspaceAgentOption(providerId: "superset", agent: "composer", models: [], efforts: [])
+            ]
+        )
+        let http = StubHTTPClient { request in
+            XCTAssertEqual(request.url?.path, "/api/acts/workspace")
+            let body = try JSONSerialization.jsonObject(with: request.httpBody ?? Data()) as? [String: String]
+            XCTAssertEqual(
+                body,
+                [
+                    "providerId": "superset",
+                    "providerProjectId": "p1",
+                    "agent": "composer",
+                ]
+            )
+            return (
+                jsonData(["result": "accepted", "providerSessionId": "created-1"]),
+                makeResponse(url: request.url!, status: 200)
+            )
+        }
+
+        let output = await dispatchVoiceToolCall(
+            name: VoiceToolName.createWorkspace.rawValue,
+            arguments: ["project_id": "p1", "agent": "composer"],
+            context: context(mintedTools: everyTool, projects: projects, defaults: defaults, http: http)
+        )
+
+        XCTAssertEqual(output, #"{"result":"accepted"}"#)
+        XCTAssertEqual(defaults.lastProviderId, "superset")
+        XCTAssertEqual(defaults.lastProjectId(for: "superset"), "p1")
+        XCTAssertEqual(defaults.agentDefault(for: "superset"), WorkspaceAgentDefault(agent: "composer"))
+    }
 }
 
 private extension RosterSession {

--- a/apps/ios/LukeKit/Tests/LukeKitTests/VoiceAsksTests.swift
+++ b/apps/ios/LukeKit/Tests/LukeKitTests/VoiceAsksTests.swift
@@ -327,6 +327,40 @@ final class VoiceAsksWorkspaceCreationTests: XCTestCase {
         XCTAssertNil(staleEffort.effort)
     }
 
+    func testAnUnnamedAgentRestoresKindOnlyDeviceDefaultWhileItIsListed() throws {
+        let answer = ProjectsAnswer(
+            projects: [
+                RosterProject(
+                    providerId: "superset", providerProjectId: "p1", repository: "acme/web",
+                    taskSupport: .optional)
+            ],
+            agentModels: [
+                WorkspaceAgentOption(providerId: "superset", agent: "composer", models: [], efforts: [])
+            ]
+        )
+        let restored = try VoiceAsks.workspaceCreation(
+            ["project_id": "p1"],
+            projects: answer,
+            defaultProviderId: nil,
+            defaultProjectIds: [:],
+            defaultAgentDefaults: ["superset": WorkspaceAgentDefault(agent: "composer")]
+        ).get()
+        XCTAssertEqual(restored.agent, "composer")
+        XCTAssertNil(restored.model)
+        XCTAssertNil(restored.effort)
+
+        let stale = try VoiceAsks.workspaceCreation(
+            ["project_id": "p1"],
+            projects: answer,
+            defaultProviderId: nil,
+            defaultProjectIds: [:],
+            defaultAgentDefaults: ["superset": WorkspaceAgentDefault(agent: "claude")]
+        ).get()
+        XCTAssertNil(stale.agent)
+        XCTAssertNil(stale.model)
+        XCTAssertNil(stale.effort)
+    }
+
     func testAModelNamedAloneDecidesTheAgentThatRunsIt() throws {
         let ask = try creation(["project_id": "p1", "model": "gpt-5"]).get()
         XCTAssertEqual(ask.agent, "codex")

--- a/apps/ios/LukeKit/Tests/LukeKitTests/WorkspaceCreationDefaultsTests.swift
+++ b/apps/ios/LukeKit/Tests/LukeKitTests/WorkspaceCreationDefaultsTests.swift
@@ -53,6 +53,12 @@ final class WorkspaceCreationDefaultsTests: XCTestCase {
             defaults.agentDefault(for: "conductor"),
             WorkspaceAgentDefault(agent: "cursor", model: "auto", effort: nil)
         )
+
+        defaults.setAgentDefault(WorkspaceAgentDefault(agent: "composer"), for: "superset")
+        XCTAssertEqual(
+            defaults.agentDefault(for: "superset"),
+            WorkspaceAgentDefault(agent: "composer")
+        )
     }
 
     func testChoosingTheProviderDefaultForgetsTheStoredChoice() {

--- a/apps/ios/LukeKit/Tests/LukeKitTests/WorkspaceProjectsContextTests.swift
+++ b/apps/ios/LukeKit/Tests/LukeKitTests/WorkspaceProjectsContextTests.swift
@@ -121,6 +121,41 @@ final class WorkspaceProjectsContextTests: XCTestCase {
         )
     }
 
+    func testKindOnlyAgentSelectionIsSaidOnlyWhileItIsListed() {
+        let answer = ProjectsAnswer(
+            projects: [
+                RosterProject(
+                    providerId: "superset", providerProjectId: "p1", repository: "acme/web",
+                    taskSupport: .optional)
+            ],
+            agentModels: [
+                WorkspaceAgentOption(providerId: "superset", agent: "composer", models: [], efforts: [])
+            ]
+        )
+
+        let text = WorkspaceProjectsContext.text(
+            answer: answer,
+            defaultProviderId: "superset",
+            defaultProjectIds: [:],
+            defaultAgentDefaults: ["superset": WorkspaceAgentDefault(agent: "composer")]
+        )
+        XCTAssertTrue(text.contains("composer — no model choice"))
+        XCTAssertTrue(
+            text.contains("Omitted, the saved default agent selection starts: composer.")
+        )
+        XCTAssertFalse(
+            WorkspaceProjectsContext.text(
+                answer: answer,
+                defaultProviderId: "superset",
+                defaultProjectIds: [:],
+                defaultAgentDefaults: [
+                    "superset": WorkspaceAgentDefault(agent: "composer", model: "unexpected")
+                ]
+            )
+            .contains("saved default agent selection")
+        )
+    }
+
     func testTheCapKeepsTheDefaultProjectPastTheCut() {
         let projects = (0 ..< 12).map { project("p\($0)", repository: "repo-\($0)") }
         let listed = WorkspaceProjectsContext.listedProjects(projects, defaultProjectIds: ["conductor": "p11"])


### PR DESCRIPTION
## Summary
- add iOS account-preferences client and sync coordinator for the hosted full-snapshot endpoint
- keep `voice` and `voiceSpeed` hosted along with workspace defaults
- restore hosted defaults into `UserDefaults`, upload local defaults when the account has no hosted row, and support kind-only agent defaults with no model choice

## Stack
1. #772 Persist iOS workspace agent defaults
2. #773 Add hosted account preferences contract
3. #774 Sync account preferences on desktop
4. Sync account preferences on iOS (this PR)

## Verification
- `swiftc -frontend -parse apps/ios/Luke/LukeApp.swift apps/ios/LukeKit/Sources/LukeKit/AccountPreferencesClient.swift apps/ios/LukeKit/Sources/LukeKit/AccountPreferencesSync.swift apps/ios/LukeKit/Sources/LukeKit/ActClient.swift apps/ios/LukeKit/Sources/LukeKit/DeviceSettingsSync.swift apps/ios/LukeKit/Sources/LukeKit/ProjectsClient.swift apps/ios/LukeKit/Sources/LukeKit/VoiceActDispatcher.swift apps/ios/LukeKit/Sources/LukeKit/VoiceAsks.swift apps/ios/LukeKit/Sources/LukeKit/WorkspaceCreationDefaults.swift apps/ios/LukeKit/Sources/LukeKit/WorkspaceProjectsContext.swift apps/ios/LukeKit/Tests/LukeKitTests/AccountPreferencesClientTests.swift apps/ios/LukeKit/Tests/LukeKitTests/AccountPreferencesSyncTests.swift apps/ios/LukeKit/Tests/LukeKitTests/DeviceSettingsSyncTests.swift apps/ios/LukeKit/Tests/LukeKitTests/ProjectsClientTests.swift apps/ios/LukeKit/Tests/LukeKitTests/VoiceActDispatcherTests.swift apps/ios/LukeKit/Tests/LukeKitTests/VoiceAsksTests.swift apps/ios/LukeKit/Tests/LukeKitTests/WorkspaceCreationDefaultsTests.swift apps/ios/LukeKit/Tests/LukeKitTests/WorkspaceProjectsContextTests.swift`

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/fa3a346a-5bf2-4346-8a8d-35b123467a32)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34290304710/artifacts/10081146181) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34290304710)

- Commit: `6788f23808b8c6ca49ffced1ef7946ecffeb216e`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
