### PR TITLE
refactor(desktop): seat History's Clear beside the tab bar

### DIFF
--- a/apps/desktop/src/renderer/conversation-history-panel.test.ts
+++ b/apps/desktop/src/renderer/conversation-history-panel.test.ts
@@ -7,6 +7,7 @@ import {
   ConversationHistoryPanel,
   HISTORY_ENTRY_SPEAKER,
   HISTORY_PENDING_LABEL,
+  HistoryClearButton,
   historyEntryPresentation,
 } from "./conversation-history-panel";
 
@@ -60,7 +61,6 @@ test("an announcement shows its spoken transcript", () => {
         },
       ],
       now: NOW,
-      onClear: () => undefined,
       ask: async () => undefined,
       onAskEngaged: () => undefined,
     }),
@@ -80,7 +80,6 @@ test("a reply keeps its lines through the thread and draws as the Markdown it wa
     createElement(ConversationHistoryPanel, {
       entries,
       now: NOW,
-      onClear: () => undefined,
       ask: async () => undefined,
       onAskEngaged: () => undefined,
     }),
@@ -103,7 +102,6 @@ test("a recorded entry keeps its local time at the row's edge, outside the bubbl
         },
       ],
       now: NOW,
-      onClear: () => undefined,
       ask: async () => undefined,
       onAskEngaged: () => undefined,
     }),
@@ -127,7 +125,6 @@ test("conversation history is blocked from optional panel recordings", () => {
     createElement(ConversationHistoryPanel, {
       entries: [{ kind: CONVERSATION_ENTRY_KIND.TYPED_ASK, words: "private words" }],
       now: NOW,
-      onClear: () => undefined,
       ask: async () => undefined,
       onAskEngaged: () => undefined,
     }),
@@ -147,7 +144,6 @@ test("messages offer a copy control while quiet events offer none", () => {
         { kind: CONVERSATION_ENTRY_KIND.ACT, words: "Sent to Codex." },
       ],
       now: NOW,
-      onClear: () => undefined,
       ask: async () => undefined,
       onAskEngaged: () => undefined,
     }),
@@ -170,7 +166,6 @@ test("a line still being said draws as the bubble it will settle into", () => {
       ],
       live: [{ kind: CONVERSATION_ENTRY_KIND.ANNOUNCEMENT, words: "Checkout is" }],
       now: NOW,
-      onClear: () => undefined,
       ask: async () => undefined,
       onAskEngaged: () => undefined,
     }),
@@ -190,7 +185,6 @@ test("words still arriving stand the thread up without a settled line", () => {
       entries: [],
       live: [{ kind: CONVERSATION_ENTRY_KIND.REPLY, words: "Looking now." }],
       now: NOW,
-      onClear: () => undefined,
       ask: async () => undefined,
       onAskEngaged: () => undefined,
     }),
@@ -198,8 +192,8 @@ test("words still arriving stand the thread up without a settled line", () => {
 
   assert.match(markup, />Looking now\.</);
   assert.doesNotMatch(markup, />No messages yet</);
-  // Clear retires recorded lines, and nothing here is recorded yet.
-  assert.doesNotMatch(markup, /history-header/);
+  // The clear rides the tab bar beside the panel, never a row of the thread's own.
+  assert.doesNotMatch(markup, /history-clear/);
 });
 
 test("the empty history reports only its state", () => {
@@ -207,14 +201,25 @@ test("the empty history reports only its state", () => {
     createElement(ConversationHistoryPanel, {
       entries: [],
       now: NOW,
-      onClear: () => undefined,
       ask: async () => undefined,
       onAskEngaged: () => undefined,
     }),
   );
 
   assert.match(markup, />No messages yet</);
-  assert.doesNotMatch(markup, /history-header|next typed|stays in memory/);
+  assert.doesNotMatch(markup, /history-clear|next typed|stays in memory/);
+});
+
+test("the clear control opens as one quiet button, its confirmation not yet asked", () => {
+  const markup = renderToStaticMarkup(
+    createElement(HistoryClearButton, { onClear: () => undefined }),
+  );
+
+  assert.match(markup, /<span class="history-clear-controls">/);
+  assert.match(markup, /class="history-clear"[^>]*>Clear</);
+  // The second press's words, and the way to stand down, arrive only with the
+  // first press.
+  assert.doesNotMatch(markup, /history-clear-cancel|Clear history/);
 });
 
 test("the composer stands at the foot of the thread, empty or not", () => {
@@ -222,7 +227,6 @@ test("the composer stands at the foot of the thread, empty or not", () => {
     createElement(ConversationHistoryPanel, {
       entries: [],
       now: NOW,
-      onClear: () => undefined,
       ask: async () => undefined,
       onAskEngaged: () => undefined,
     }),
@@ -235,7 +239,6 @@ test("the composer stands at the foot of the thread, empty or not", () => {
     createElement(ConversationHistoryPanel, {
       entries: [{ kind: CONVERSATION_ENTRY_KIND.TYPED_ASK, words: "ship it" }],
       now: NOW,
-      onClear: () => undefined,
       ask: async () => undefined,
       onAskEngaged: () => undefined,
       askShortcut: "Alt+Space",
@@ -268,7 +271,6 @@ test("an ask whose run is still going waits beside its words and offers a cancel
         requests: [{ ...run, status }],
         onCancelRequest: (runId) => cancelled.push(runId),
         now: NOW,
-        onClear: () => undefined,
         ask: async () => undefined,
         onAskEngaged: () => undefined,
       }),
@@ -290,7 +292,6 @@ test("an ask whose run is still going waits beside its words and offers a cancel
       requests: [{ ...run, origin: "spoken", status: "running" }],
       onCancelRequest: (runId) => cancelled.push(runId),
       now: NOW,
-      onClear: () => undefined,
       ask: async () => undefined,
       onAskEngaged: () => undefined,
     }),
@@ -317,7 +318,6 @@ test("a line that followed a long silence is dated over it, in the quiet event v
         { kind: CONVERSATION_ENTRY_KIND.REPLY, words: "Quiet.", recordedAt: NOW - HOUR_MS / 4 },
       ],
       now: NOW,
-      onClear: () => undefined,
       ask: async () => undefined,
       onAskEngaged: () => undefined,
     }),
@@ -363,7 +363,6 @@ test("lines with no stamp draw no date over them", () => {
       ],
       live: [{ kind: CONVERSATION_ENTRY_KIND.REPLY, words: "Still" }],
       now: NOW,
-      onClear: () => undefined,
       ask: async () => undefined,
       onAskEngaged: () => undefined,
     }),

--- a/apps/desktop/src/renderer/conversation-history-panel.tsx
+++ b/apps/desktop/src/renderer/conversation-history-panel.tsx
@@ -176,13 +176,47 @@ const STREAM_FOLLOW_SLACK_PX = 48;
  */
 const HISTORY_COMPOSER_ROW_INDEX = 1;
 
+/**
+ * The thread's one control, seated beside the tab bar the way each tab's
+ * search is, so every tab's control is opened from the same place. Clearing
+ * is the recoverable deletion, but it still asks twice: the second press
+ * names what the first one meant, with a way to stand down beside it. The
+ * confirmation needs no reset of its own — the button is drawn only over a
+ * thread with recorded lines, so the clear that empties them unmounts it,
+ * exactly as leaving the tab does.
+ */
+export function HistoryClearButton({ onClear }: { onClear: () => void }): React.JSX.Element {
+  const [confirming, setConfirming] = useState(false);
+  return (
+    <span className="history-clear-controls">
+      {confirming ? (
+        <button type="button" className="history-clear-cancel" onClick={() => setConfirming(false)}>
+          Cancel
+        </button>
+      ) : null}
+      <button
+        type="button"
+        className="history-clear"
+        onClick={() => {
+          if (!confirming) {
+            setConfirming(true);
+            return;
+          }
+          onClear();
+        }}
+      >
+        {confirming ? "Clear history" : "Clear"}
+      </button>
+    </span>
+  );
+}
+
 export function ConversationHistoryPanel({
   entries,
   live = [],
   requests = [],
   now,
   onCancelRequest,
-  onClear,
   ask,
   onAskEngaged,
   askShortcut,
@@ -206,13 +240,11 @@ export function ConversationHistoryPanel({
    * bubbles they will settle into — words growing, no timestamp, no copy.
    */
   live?: readonly ConversationEntry[];
-  onClear: () => void;
   /** The same ask the sessions tab's composer carries: one conversation, reached from either tab. */
   ask: AskHandler;
   onAskEngaged: (engaged: boolean) => void;
   askShortcut?: string;
 }): React.JSX.Element {
-  const [confirmingClear, setConfirmingClear] = useState(false);
   const list = useRef<HTMLDivElement | null>(null);
   const entryCount = entries.length;
   const liveLength = live.reduce((total, entry) => total + entry.words.length, 0);
@@ -238,10 +270,6 @@ export function ConversationHistoryPanel({
     if (fromTail <= STREAM_FOLLOW_SLACK_PX) element.scrollTop = element.scrollHeight;
   }, [liveLength]);
 
-  useEffect(() => {
-    if (entries.length === 0) setConfirmingClear(false);
-  }, [entries.length]);
-
   const thread = entries.length > 0 || live.length > 0;
 
   return (
@@ -253,34 +281,6 @@ export function ConversationHistoryPanel({
       id={panelPanelId(PANEL_TAB.HISTORY)}
       aria-labelledby={panelTabId(PANEL_TAB.HISTORY)}
     >
-      {entries.length > 0 ? (
-        <header className="history-header">
-          <span className="history-clear-controls">
-            {confirmingClear ? (
-              <button
-                type="button"
-                className="history-clear-cancel"
-                onClick={() => setConfirmingClear(false)}
-              >
-                Cancel
-              </button>
-            ) : null}
-            <button
-              type="button"
-              className="history-clear"
-              onClick={() => {
-                if (!confirmingClear) {
-                  setConfirmingClear(true);
-                  return;
-                }
-                onClear();
-              }}
-            >
-              {confirmingClear ? "Clear history" : "Clear"}
-            </button>
-          </span>
-        </header>
-      ) : null}
       {thread ? (
         <div className="history-scroll" ref={list}>
           {/* The pull is the thread's own sideways scroll, on a scroller of its

--- a/apps/desktop/src/renderer/panel-body.tsx
+++ b/apps/desktop/src/renderer/panel-body.tsx
@@ -15,7 +15,7 @@ import type { BrainRequestSnapshot } from "#shared/wire/brain";
 import type { SessionOpenResult } from "#shared/wire/session";
 import { type AskHandler, AskLuke } from "./ask-luke";
 import { CalendarGate, type CalendarGateControl } from "./calendar-gate";
-import { ConversationHistoryPanel } from "./conversation-history-panel";
+import { ConversationHistoryPanel, HistoryClearButton } from "./conversation-history-panel";
 import { PANEL_TAB, type PanelTab, TabBar } from "./panel-tabs";
 import {
   type ArrangedSessions,
@@ -659,6 +659,8 @@ export function PanelBody({
   const settingsNote = updateAvailable(settings.updates.update)
     ? updateRow(settings.updates.update).detail
     : undefined;
+  // Clear retires recorded lines, so only a thread holding some offers it.
+  const offerHistoryClear = tab === PANEL_TAB.HISTORY && conversationHistory.length > 0;
   return (
     <div className="body">
       {/* The tab bar says what you are looking at; the buttons beside it say
@@ -670,7 +672,7 @@ export function PanelBody({
           onTabChange={onTabChange}
           {...(settingsNote ? { settingsNote } : undefined)}
         />
-        {offerSearch || offerOptions || tab === PANEL_TAB.SETTINGS ? (
+        {offerSearch || offerOptions || tab === PANEL_TAB.SETTINGS || offerHistoryClear ? (
           <span className="header-controls">
             {offerSearch ? (
               <SessionSearchButton open={searchOpen} onToggle={onSearchToggle} />
@@ -681,6 +683,10 @@ export function PanelBody({
             {tab === PANEL_TAB.SETTINGS ? (
               <SettingsSearchButton open={settingsSearchOpen} onToggle={onSettingsSearchToggle} />
             ) : null}
+            {/* History's clear, in the same spot again: its words are the
+                build's own, so it may stand outside the blocked subtree the
+                thread's words never leave. */}
+            {offerHistoryClear ? <HistoryClearButton onClear={onClearConversationHistory} /> : null}
             {offerOptions ? (
               <SessionOptionsButton
                 list={list}
@@ -701,7 +707,6 @@ export function PanelBody({
           requests={brainRequests}
           now={now}
           onCancelRequest={onCancelBrainRequest}
-          onClear={onClearConversationHistory}
           ask={ask}
           onAskEngaged={onAskEngaged}
           {...(askShortcut ? { askShortcut } : undefined)}

--- a/apps/desktop/src/renderer/styles/history.css
+++ b/apps/desktop/src/renderer/styles/history.css
@@ -14,14 +14,8 @@
   margin-top: 0;
 }
 
-.history-header {
-  display: flex;
-  flex: 0 0 auto;
-  align-items: center;
-  justify-content: flex-end;
-  padding: 0 2px;
-}
-
+/* The clear rides the tab bar's line beside the other header controls, the
+   way each tab's search does, rather than taking a row of the thread's own. */
 .history-clear-controls {
   display: inline-flex;
   flex: 0 0 auto;


### PR DESCRIPTION
## What

On the History tab, the Clear button moves up out of the thread's own header row and into the panel header, beside the tab bar — the same seat the Settings tab's search button takes, so every tab's control is opened from the same place.

## How

- The clear control (with its unchanged two-press confirmation) is extracted into `HistoryClearButton`, exported from `conversation-history-panel.tsx`, and rendered by `panel-body.tsx` inside the existing `header-controls` span, gated the way the other header controls are: only while the History tab is showing and the thread holds recorded lines.
- The confirmation's reset needs no effect any more: clearing empties the entries, which unmounts the button, exactly as switching tabs always did.
- `ConversationHistoryPanel` loses its `onClear` prop and header row; the retired `.history-header` rule goes with it. The `.history-clear*` styles are unchanged.
- Privacy posture: the button now stands outside History's `ph-no-capture` subtree, which is fine because its words ("Clear", "Clear history", "Cancel") are the build's own — no conversation words leave the blocked subtree, and Delete history's behavior is untouched.

## Verification

- `./scripts/check.sh` passes (exit 0), including the updated `conversation-history-panel.test.ts` and the new test that the control opens unconfirmed.
- This is a UI change developed in a Linux cloud workspace, so `./scripts/verify.sh` (macOS) and the visual-evidence inspection could not be run here; no physical-notch check was performed. Please run `./scripts/verify.sh` on a Mac before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/fb29db94-cd80-428d-9135-3dff594da2c6)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34275722035/artifacts/10075751376) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34275722035)

- Commit: `69fcc70b6b3f53bc6fdfa880c3151cb301083f9b`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
