### PR TITLE
fix(gateway): restore memory start, trace forwarding, and quit event flush after the process split

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -471,8 +471,11 @@ Trust constraints:
   `settings`, `credential`, `account`, `calendar`, `tracker`, `superset`,
   `session`, `workspace`, `speech`, `receiver`, `voice`, `guide`,
   `analytics`, `conversation.append`, and `onboarding` methods, and the
-  change events beside them); no credential or account secret travels in any
-  answer or event, and the one secret that reaches the voice client is the
+  change events beside them; `voice.recordTrace` carries the renderer's
+  tapped realtime events to the development trace writer the Gateway owns,
+  under the same gate, so an untraced run drops them at the host); no
+  credential or account secret travels in any answer or event, and the one
+  secret that reaches the voice client is the
   ephemeral realtime credential the host minted. Widening the method
   vocabulary, the event set, or what a node may be asked is a product
   decision, not an implementation detail. The same protocol suite runs over the in-process transport, the
@@ -897,7 +900,7 @@ Trust constraints:
   JSONL under the developer's chosen directory and
   sent nowhere; `pnpm trace:export` turns one file into a document a local
   viewer opens. The tap only observes: nothing reads its result, and the
-  main process drops the renderer's tapped events whenever no writer stands.
+  Gateway drops the renderer's tapped events whenever no writer stands.
   A trace carries real titles, branches, and spoken words, so trace files are
   never committed, for the same reason fixtures stay synthetic. Widening what
   a trace records is a product decision, not an implementation detail.

--- a/apps/desktop/src/main/desktop-app.ts
+++ b/apps/desktop/src/main/desktop-app.ts
@@ -820,9 +820,9 @@ function registerIpc(): void {
       return (await gateway.host.realtimeDiagnostics()) ?? introductionMinter.diagnostics();
     },
     recordProductEvent,
-    // The development trace is the host's; the renderer's tapped wire events
-    // travel nowhere from this process.
-    recordAgentTrace: () => undefined,
+    // The development trace is the host's: a tapped wire event crosses to its
+    // writer, which alone knows whether this run records anything.
+    recordAgentTrace: (trace) => gateway.host.recordAgentTrace(trace),
   });
 
   registerSessionActsIpc({

--- a/apps/desktop/src/main/gateway/host-operator.ts
+++ b/apps/desktop/src/main/gateway/host-operator.ts
@@ -2,6 +2,7 @@ import type { AccountProvider, AccountSnapshot } from "@sidecar/account/snapshot
 import type { ProductEventName, ProductEventPropertiesFor } from "@sidecar/analytics";
 import type { ObservedAccountCalendars } from "@sidecar/calendar/observation";
 import type { CredentialProviderId } from "@sidecar/credentials";
+import type { AgentWireTrace } from "@sidecar/devtrace/vocabulary";
 import type { AppGuideSnapshot } from "@sidecar/guide";
 import type { ConversationEntry, RealtimeConnection, RealtimeDiagnostics } from "@sidecar/realtime";
 import type { GatewayCallResult, GatewayClient } from "@sidecar/runtime";
@@ -142,6 +143,8 @@ export interface HostOperator {
   resetReceiver(): Promise<void>;
   mintRealtimeCredential(): Promise<RealtimeConnection | undefined>;
   realtimeDiagnostics(): Promise<RealtimeDiagnostics | undefined>;
+  /** One tapped wire event for the host's development trace; the host drops it where no writer stands. */
+  recordAgentTrace(trace: AgentWireTrace): void;
   reportGuide(guide: AppGuideSnapshot): Promise<void>;
   recordEvent<Name extends ProductEventName>(
     name: Name,
@@ -399,6 +402,9 @@ export function createHostOperator(options: HostOperatorOptions): HostOperator {
       answered<RealtimeDiagnostics>(
         record(await client.call(GATEWAY_METHOD.VOICE_DIAGNOSTICS))?.diagnostics,
       ),
+    recordAgentTrace: (trace) => {
+      void client.call(GATEWAY_METHOD.VOICE_RECORD_TRACE, { trace: carried(trace) });
+    },
     reportGuide: (guide) =>
       fire(client.call(GATEWAY_METHOD.GUIDE_REPORT, { guide: carried(guide) })),
     recordEvent: (name, properties) => {

--- a/apps/desktop/src/main/host/lifecycle.test.ts
+++ b/apps/desktop/src/main/host/lifecycle.test.ts
@@ -1,0 +1,115 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { GATEWAY_SHUTDOWN_DEFAULTS, shutdownGateway } from "@sidecar/runtime";
+import { seedWorkspaceThenStartMemory, shutdownStepsFlushingEvents } from "./lifecycle";
+
+test("a workspace seed that fails is reported and the memory index still starts, after the seed and not before", async () => {
+  const order: string[] = [];
+  const reports: string[] = [];
+  await seedWorkspaceThenStartMemory({
+    seedWorkspace: async () => {
+      order.push("seed");
+      throw new Error("read-only volume");
+    },
+    startMemory: async () => {
+      order.push("memory");
+    },
+    report: (message) => reports.push(message),
+  });
+  assert.deepEqual(order, ["seed", "memory"]);
+  assert.deepEqual(reports, ["Brain workspace could not be seeded: read-only volume"]);
+});
+
+test("a seed that succeeds reports nothing, and the start does not wait on the index settling", async () => {
+  const reports: string[] = [];
+  let settleMemory: (() => void) | undefined;
+  let started = false;
+  await seedWorkspaceThenStartMemory({
+    seedWorkspace: async () => undefined,
+    startMemory: () =>
+      new Promise<void>((resolve) => {
+        started = true;
+        settleMemory = resolve;
+      }),
+    report: (message) => reports.push(message),
+  });
+  assert.equal(started, true);
+  assert.deepEqual(reports, []);
+  settleMemory?.();
+});
+
+function baseSteps(order: string[]) {
+  return {
+    closeAdmissions: () => {
+      order.push("close");
+    },
+    cancelActive: async () => {
+      order.push("cancel");
+      return ["run-1"];
+    },
+    awaitSettled: async () => {
+      order.push("settled");
+    },
+    persistUnresolved: async () => {
+      order.push("persist");
+      return 0;
+    },
+  };
+}
+
+test("the flush begins as admissions close and is waited for before the unresolved count, so the install's count leaves with the drain", async () => {
+  const order: string[] = [];
+  let settleFlush: (() => void) | undefined;
+  const steps = shutdownStepsFlushingEvents(baseSteps(order), () => {
+    order.push("flush:start");
+    return new Promise<void>((resolve) => {
+      settleFlush = () => {
+        order.push("flush:end");
+        resolve();
+      };
+    });
+  });
+  const report = shutdownGateway(steps, { deadlineMs: GATEWAY_SHUTDOWN_DEFAULTS.DEADLINE_MS });
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.deepEqual(order, ["close", "flush:start", "cancel", "settled"]);
+  settleFlush?.();
+  const outcome = await report;
+  assert.deepEqual(order, ["close", "flush:start", "cancel", "settled", "flush:end", "persist"]);
+  assert.equal(outcome.settled, true);
+  assert.deepEqual(outcome.cancelled, ["run-1"]);
+});
+
+test("a flush that never answers ends the shutdown at the deadline with the runs' own outcome intact", async () => {
+  const order: string[] = [];
+  const steps = shutdownStepsFlushingEvents(
+    baseSteps(order),
+    () => new Promise<void>(() => undefined),
+  );
+  const outcome = await shutdownGateway(steps, { deadlineMs: 20 });
+  assert.equal(outcome.settled, false);
+  assert.deepEqual(outcome.cancelled, ["run-1"]);
+  assert.equal(outcome.unresolved, 0);
+  assert.ok(order.includes("persist"));
+});
+
+test("a flush that rejects is a count nobody has, not a failed quit", async () => {
+  const order: string[] = [];
+  const steps = shutdownStepsFlushingEvents(baseSteps(order), () =>
+    Promise.reject(new Error("offline")),
+  );
+  const outcome = await shutdownGateway(steps, {
+    deadlineMs: GATEWAY_SHUTDOWN_DEFAULTS.DEADLINE_MS,
+  });
+  assert.equal(outcome.settled, true);
+  assert.deepEqual(order, ["close", "cancel", "settled", "persist"]);
+});
+
+test("closing admissions twice flushes once", () => {
+  let flushes = 0;
+  const steps = shutdownStepsFlushingEvents(baseSteps([]), async () => {
+    flushes += 1;
+  });
+  steps.closeAdmissions();
+  steps.closeAdmissions();
+  assert.equal(flushes, 1);
+});

--- a/apps/desktop/src/main/host/lifecycle.ts
+++ b/apps/desktop/src/main/host/lifecycle.ts
@@ -1,0 +1,61 @@
+import type { GatewayShutdownSteps } from "@sidecar/runtime";
+
+/**
+ * Two moments of the runtime host's life where one concern must not decide
+ * another's fate: the workspace seed and the memory index at start, and the
+ * counted events and the run drain at the explicit quit.
+ */
+
+export interface StartupStoreOptions {
+  /** Seeds the workspace's missing files; a failure is reported and stops nothing else. */
+  seedWorkspace: () => Promise<void>;
+  /** Starts the notebook index; its own settling is nobody's to wait on. */
+  startMemory: () => Promise<void>;
+  report: (message: string) => void;
+}
+
+/**
+ * The workspace's missing files are seeded at every live launch and never
+ * rewritten. A seed that failed leaves the files that already stand, which
+ * are still worth indexing, so the index starts whatever became of the seed
+ * and the start does not wait on the index.
+ */
+export async function seedWorkspaceThenStartMemory(options: StartupStoreOptions): Promise<void> {
+  try {
+    await options.seedWorkspace();
+  } catch (error) {
+    options.report(
+      `Brain workspace could not be seeded: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+  void options.startMemory();
+}
+
+/**
+ * The explicit quit's steps with the counted events' last flush folded in.
+ * The flush begins the moment the door closes, so a count the client made
+ * just before its quit (the update install it asked for) leaves alongside the
+ * drain rather than after the process has gone; it is waited for only inside
+ * the coordinator's one deadline, beside the runs settling, so a network that
+ * stalls delays the quit by nothing more than the drain already allows, and
+ * what did not settle is still counted from the persisted records without it.
+ * The sender's own flush never rejects; the guard here is for the shape, not
+ * a case it has.
+ */
+export function shutdownStepsFlushingEvents(
+  steps: GatewayShutdownSteps,
+  flushEvents: () => Promise<void>,
+): GatewayShutdownSteps {
+  let flushing: Promise<void> | undefined;
+  return {
+    closeAdmissions: () => {
+      steps.closeAdmissions();
+      flushing ??= flushEvents().catch(() => undefined);
+    },
+    cancelActive: steps.cancelActive,
+    awaitSettled: async (signal) => {
+      await Promise.all([steps.awaitSettled(signal), flushing ?? Promise.resolve()]);
+    },
+    persistUnresolved: steps.persistUnresolved,
+  };
+}

--- a/apps/desktop/src/main/host/runtime-host.ts
+++ b/apps/desktop/src/main/host/runtime-host.ts
@@ -38,6 +38,7 @@ import {
   VOICE_CREDENTIAL_PROVIDER_ID,
 } from "@sidecar/credentials";
 import { AgentTraceWriter, tracedModelAdapter } from "@sidecar/devtrace";
+import { isAgentWireTrace } from "@sidecar/devtrace/vocabulary";
 import {
   APP_SETTING_ID,
   type AppGuideSnapshot,
@@ -207,6 +208,7 @@ import { type SecretCipher, SettingsStore } from "../settings-store";
 import { transitionVoiceCredential } from "../voice/credential-transition";
 import { type OnboardingBeatKind, SpeechArbiter } from "../voice/speech-arbiter";
 import { VoiceReceiver } from "../voice-receiver";
+import { seedWorkspaceThenStartMemory, shutdownStepsFlushingEvents } from "./lifecycle";
 
 /**
  * Luke's runtime as one host: everything that executes, persists, schedules,
@@ -2175,6 +2177,15 @@ export function composeRuntimeHost(options: RuntimeHostOptions): RuntimeHost {
             voiceCapabilities.unavailableDiagnostics,
         ),
       }),
+    // One realtime event the renderer's tap saw cross the data channel, into
+    // the development trace. Read again here for the shape the tap sends; on
+    // a run without a writer — packaged, fixture, or simply untraced — it
+    // lands here and stops.
+    [GATEWAY_METHOD.VOICE_RECORD_TRACE]: (params) => {
+      if (!isAgentWireTrace(params.trace)) return invalid("trace is not one tapped wire event");
+      agentTrace?.recordWire(params.trace);
+      return gatewayOk({});
+    },
     [GATEWAY_METHOD.GUIDE_REPORT]: (params) => {
       if (!isAppGuideSnapshot(params.guide))
         return invalid("guide is not the shape a panel reports");
@@ -2305,14 +2316,13 @@ export function composeRuntimeHost(options: RuntimeHostOptions): RuntimeHost {
     arrivalState = arrivalStateFromDisk();
     if (runMode.observesProviders) {
       await runtimeStoreWiring.open();
-      try {
-        await brainWiring.seedWorkspace();
-        void memoryWiring.start();
-      } catch (error) {
-        report(
-          `Brain workspace could not be seeded: ${error instanceof Error ? error.message : String(error)}`,
-        );
-      }
+      await seedWorkspaceThenStartMemory({
+        seedWorkspace: async () => {
+          await brainWiring.seedWorkspace();
+        },
+        startMemory: () => memoryWiring.start(),
+        report,
+      });
       await brainWiring.store().load();
       await runtimeStoreWiring.restore();
       stopHistoryMaintenance = startHistoryMaintenance({
@@ -2370,57 +2380,60 @@ export function composeRuntimeHost(options: RuntimeHostOptions): RuntimeHost {
    * counted rather than finished: the store's load at the next start marks
    * an unsettled run interrupted and replays nothing.
    */
-  const shutdownSteps: GatewayShutdownSteps = {
-    closeAdmissions: () => service.server.closeAdmissions(),
-    cancelActive: async () => {
-      observationSupervisor.setEnabled(false);
-      cronScheduler.stop();
-      const cancelled: string[] = [];
-      for (const record of brainWiring.allRequests()) {
-        if (
-          record.status !== BRAIN_REQUEST_STATUS.QUEUED &&
-          record.status !== BRAIN_REQUEST_STATUS.RUNNING
-        ) {
-          continue;
+  const shutdownSteps: GatewayShutdownSteps = shutdownStepsFlushingEvents(
+    {
+      closeAdmissions: () => service.server.closeAdmissions(),
+      cancelActive: async () => {
+        observationSupervisor.setEnabled(false);
+        cronScheduler.stop();
+        const cancelled: string[] = [];
+        for (const record of brainWiring.allRequests()) {
+          if (
+            record.status !== BRAIN_REQUEST_STATUS.QUEUED &&
+            record.status !== BRAIN_REQUEST_STATUS.RUNNING
+          ) {
+            continue;
+          }
+          const agent = brainWiring.agentForRun(record.runId);
+          if (!agent) continue;
+          cancelled.push(record.runId);
+          await agent.cancelAsk(record.runId).catch(() => undefined);
         }
-        const agent = brainWiring.agentForRun(record.runId);
-        if (!agent) continue;
-        cancelled.push(record.runId);
-        await agent.cancelAsk(record.runId).catch(() => undefined);
-      }
-      for (const child of brainWiring.children.children()) {
-        if (isTerminalChildRunStatus(child.status)) continue;
-        await brainWiring.children.cancel(child.childId).catch(() => undefined);
-      }
-      return cancelled;
+        for (const child of brainWiring.children.children()) {
+          if (isTerminalChildRunStatus(child.status)) continue;
+          await brainWiring.children.cancel(child.childId).catch(() => undefined);
+        }
+        return cancelled;
+      },
+      awaitSettled: async (signal) => {
+        if (signal.aborted) return;
+        await brainWiring.publicationSettled();
+      },
+      persistUnresolved: async () => {
+        // What the next launch will find: the records as the stores last
+        // persisted them, read from the envelopes rather than from memory. A
+        // cancellation whose write did not land leaves its run queued or
+        // running on disk, and that is what the load marks interrupted and
+        // never replays, so it is counted here as unresolved.
+        const keys = new Set<SessionKey>([
+          MAIN_SESSION_KEY,
+          ...runtimeStoreWiring.directory().entries.map((entry) => entry.sessionKey),
+        ]);
+        let unresolved = 0;
+        for (const key of keys) {
+          const persisted = brainWiring.store(key).current();
+          if (!persisted) continue;
+          unresolved += persisted.requests.filter(
+            (record) =>
+              record.status === BRAIN_REQUEST_STATUS.QUEUED ||
+              record.status === BRAIN_REQUEST_STATUS.RUNNING,
+          ).length;
+        }
+        return unresolved;
+      },
     },
-    awaitSettled: async (signal) => {
-      if (signal.aborted) return;
-      await brainWiring.publicationSettled();
-    },
-    persistUnresolved: async () => {
-      // What the next launch will find: the records as the stores last
-      // persisted them, read from the envelopes rather than from memory. A
-      // cancellation whose write did not land leaves its run queued or
-      // running on disk, and that is what the load marks interrupted and
-      // never replays, so it is counted here as unresolved.
-      const keys = new Set<SessionKey>([
-        MAIN_SESSION_KEY,
-        ...runtimeStoreWiring.directory().entries.map((entry) => entry.sessionKey),
-      ]);
-      let unresolved = 0;
-      for (const key of keys) {
-        const persisted = brainWiring.store(key).current();
-        if (!persisted) continue;
-        unresolved += persisted.requests.filter(
-          (record) =>
-            record.status === BRAIN_REQUEST_STATUS.QUEUED ||
-            record.status === BRAIN_REQUEST_STATUS.RUNNING,
-        ).length;
-      }
-      return unresolved;
-    },
-  };
+    () => productEvents.flush(),
+  );
 
   const close = async (): Promise<void> => {
     observationSupervisor.setEnabled(false);

--- a/packages/runtime-contracts/src/protocol.ts
+++ b/packages/runtime-contracts/src/protocol.ts
@@ -98,6 +98,8 @@ export const GATEWAY_METHOD = {
   RECEIVER_REPORT: "receiver.report",
   VOICE_MINT_REALTIME_CREDENTIAL: "voice.mintRealtimeCredential",
   VOICE_DIAGNOSTICS: "voice.diagnostics",
+  /** One tapped realtime event for the host's development trace; a no-op where no writer stands. */
+  VOICE_RECORD_TRACE: "voice.recordTrace",
   GUIDE_REPORT: "guide.report",
   ANALYTICS_RECORD: "analytics.record",
   CONVERSATION_APPEND: "conversation.append",
@@ -174,6 +176,7 @@ export const MUTATING_GATEWAY_METHODS: ReadonlySet<GatewayMethod> = new Set<Gate
   GATEWAY_METHOD.SPEECH_SETTLE,
   GATEWAY_METHOD.RECEIVER_REPORT,
   GATEWAY_METHOD.VOICE_MINT_REALTIME_CREDENTIAL,
+  GATEWAY_METHOD.VOICE_RECORD_TRACE,
   GATEWAY_METHOD.GUIDE_REPORT,
   GATEWAY_METHOD.ANALYTICS_RECORD,
   GATEWAY_METHOD.CONVERSATION_APPEND,


### PR DESCRIPTION
Bounded follow-up to #760 restoring three behaviors main had before the Gateway split. No UI changes.

## What changed

1. **Memory start survives a failed seed.** `runtime-host.start` ran `memoryWiring.start()` inside the seed's `try`, so a seed that threw skipped the index. `seedWorkspaceThenStartMemory` (new `apps/desktop/src/main/host/lifecycle.ts`) reports the seed failure and starts memory regardless, keeping the order seed → memory → store load.
2. **Renderer trace events reach the host's writer.** `desktop-app.ts` passed a no-op `recordAgentTrace`. The operator now forwards each tapped event over one additive method, `voice.recordTrace`, which the host validates with `isAgentWireTrace` and hands to the same `AgentTraceWriter` (same gates: unpackaged live run with `LUKE_TRACE_DIR`; fixture and evidence runs construct no writer, so the event is dropped). No renderer or preload edits, no new recorded content. `AGENTS.md` names the method.
3. **Queued product events flush at quit/install.** `shutdownStepsFlushingEvents` wraps the host's shutdown steps: `productEvents.flush()` starts as admissions close and is awaited beside `awaitSettled`, inside the coordinator's existing 10 s deadline, so a stalled or failed flush never holds Quit or `quitAndInstall`. `persistUnresolved` does not wait on it.

## Interface deltas

- `GATEWAY_METHOD.VOICE_RECORD_TRACE = "voice.recordTrace"` (mutating; params `{ trace: AgentWireTrace }`; answers `{}`; `INVALID` on a malformed trace).
- `HostOperator.recordAgentTrace(trace): void`.

## Tests

`apps/desktop/src/main/host/lifecycle.test.ts`: failed seed still starts memory in order; success reports nothing and does not wait on the index; flush starts at close and completes before the unresolved count; a hanging flush ends at the deadline with the runs' outcome intact; a rejecting flush does not fail the quit; double close flushes once.

`./scripts/bootstrap.sh` then `./scripts/check.sh` exit 0 on the pushed head. No macOS packaging or physical Mac verification was possible in this sandbox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/7c461a53-6c31-4057-87cd-11edb4dfc79d)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34278223664/artifacts/10076700858) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34278223664)

- Commit: `187d2eb907e201d675c81d03423d3b3e205e6a69`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
