### PR TITLE
chore: delete compatibility branches for installs that never existed

### DIFF
--- a/apps/desktop/src/main/arrival-flow.test.ts
+++ b/apps/desktop/src/main/arrival-flow.test.ts
@@ -5,7 +5,6 @@ import {
   arrivalRecord,
   arrivalStateFromStored,
   countsFirstAnnouncement,
-  shouldBackfillArrivalSettled,
 } from "./arrival-flow";
 
 const SIGNED_IN_AT = "2026-08-24T00:00:00.000Z";
@@ -18,7 +17,7 @@ test("the beat is owed from an observed sign-in until its reply actually begins"
   assert.equal(arrivalBeatOwed({ signedInAt: SIGNED_IN_AT, firstAnnouncementAt: LATER }), true);
 });
 
-test("no record, and a backfilled record, owe no beat", () => {
+test("a record with no observed sign-in owes no beat", () => {
   assert.equal(arrivalBeatOwed(undefined), false);
   assert.equal(arrivalBeatOwed({ settledAt: LATER }), false);
 });
@@ -33,25 +32,6 @@ test("the first announcement counts once, and only against an observed sign-in",
   );
   assert.equal(countsFirstAnnouncement(undefined), false);
   assert.equal(countsFirstAnnouncement({ settledAt: LATER }), false);
-});
-
-test("a signed-in launch with no record backfills a settled one", () => {
-  assert.equal(
-    shouldBackfillArrivalSettled({ requiresAccount: true, signedIn: true, hasRecord: false }),
-    true,
-  );
-  assert.equal(
-    shouldBackfillArrivalSettled({ requiresAccount: true, signedIn: true, hasRecord: true }),
-    false,
-  );
-  assert.equal(
-    shouldBackfillArrivalSettled({ requiresAccount: true, signedIn: false, hasRecord: false }),
-    false,
-  );
-  assert.equal(
-    shouldBackfillArrivalSettled({ requiresAccount: false, signedIn: true, hasRecord: false }),
-    false,
-  );
 });
 
 test("the record round-trips, and anything unreadable reads as no record", () => {

--- a/apps/desktop/src/main/arrival-flow.ts
+++ b/apps/desktop/src/main/arrival-flow.ts
@@ -17,26 +17,13 @@ import { isRecord, text, type UnparsedWireValue } from "@sidecar/wire";
  * not the one moment this plays.
  */
 
-/**
- * The arrival record, beside `introduction.json` in the app's own state
- * directory. Unlike the introduction's, a missing file does not simply mean
- * "not yet": an install that was already signed in before this file existed
- * has been living with Luke for some time, so the launch backfills a settled
- * record rather than greeting a veteran as an arrival.
- */
+/** The arrival record, beside `introduction.json` in the app's own state directory. */
 export const ARRIVAL_STATE_FILE = "arrival.json";
 
 export interface ArrivalState {
-  /**
-   * When the account's first sign-in landed. Absent on a backfilled record,
-   * which is what keeps the first-announcement count honest: an install whose
-   * sign-in was never observed has no elapsed time worth reporting.
-   */
+  /** When the account's first sign-in landed, as this install observed it. */
   signedInAt?: string;
-  /**
-   * When the beat stopped being owed: its reply actually began, or — on a
-   * backfilled record — the install was recognized as predating it.
-   */
+  /** When the beat stopped being owed: its reply actually began. */
   settledAt?: string;
   /** When the first announcement after that sign-in was spoken. */
   firstAnnouncementAt?: string;
@@ -44,9 +31,8 @@ export interface ArrivalState {
 
 /**
  * Reads a stored record, or nothing for a file that is missing or does not
- * parse. "Nothing" means "no record", which the launch turns into a backfill —
- * the safe direction, since a backfill can only ever withhold the beat and the
- * count, never replay one already given.
+ * parse. "Nothing" means "no sign-in was ever observed", which owes no beat:
+ * the safe direction, since it can only withhold the beat, never replay one.
  */
 export function arrivalStateFromStored(stored: string | undefined): ArrivalState | undefined {
   if (stored === undefined) return undefined;
@@ -89,19 +75,4 @@ export function arrivalBeatOwed(state: ArrivalState | undefined): boolean {
  */
 export function countsFirstAnnouncement(state: ArrivalState | undefined): boolean {
   return state?.signedInAt !== undefined && state.firstAnnouncementAt === undefined;
-}
-
-/**
- * Whether this launch should write a settled record without speaking anything.
- * A signed-in launch with no record predates the arrival beat — its sign-in
- * was never observed — and without the record on file, a later sign-out and
- * sign-in would greet someone months in as an arrival. Only an interactive
- * launch may write it: a fixture or capture run observes no accounts at all.
- */
-export function shouldBackfillArrivalSettled(input: {
-  requiresAccount: boolean;
-  signedIn: boolean;
-  hasRecord: boolean;
-}): boolean {
-  return input.requiresAccount && input.signedIn && !input.hasRecord;
 }

--- a/apps/desktop/src/main/calendar-onboarding-flow.test.ts
+++ b/apps/desktop/src/main/calendar-onboarding-flow.test.ts
@@ -4,7 +4,6 @@ import {
   calendarOnboardingOwed,
   calendarOnboardingRecord,
   calendarOnboardingStateFromStored,
-  shouldBackfillCalendarOnboardingSettled,
 } from "./calendar-onboarding-flow";
 
 const REQUIRED_AT = "2026-08-24T00:00:00.000Z";
@@ -19,45 +18,10 @@ test("a decline on the gate stands it down for good, like a settle", () => {
   assert.equal(calendarOnboardingOwed({ requiredAt: REQUIRED_AT, skippedAt: LATER }), false);
 });
 
-test("no record, and a backfilled record, owe no gate", () => {
+test("a record with no observed sign-in owes no gate", () => {
   assert.equal(calendarOnboardingOwed(undefined), false);
   assert.equal(calendarOnboardingOwed({ settledAt: LATER }), false);
   assert.equal(calendarOnboardingOwed({}), false);
-});
-
-test("a signed-in launch with no record backfills a settled one", () => {
-  assert.equal(
-    shouldBackfillCalendarOnboardingSettled({
-      requiresAccount: true,
-      signedIn: true,
-      hasRecord: false,
-    }),
-    true,
-  );
-  assert.equal(
-    shouldBackfillCalendarOnboardingSettled({
-      requiresAccount: true,
-      signedIn: true,
-      hasRecord: true,
-    }),
-    false,
-  );
-  assert.equal(
-    shouldBackfillCalendarOnboardingSettled({
-      requiresAccount: true,
-      signedIn: false,
-      hasRecord: false,
-    }),
-    false,
-  );
-  assert.equal(
-    shouldBackfillCalendarOnboardingSettled({
-      requiresAccount: false,
-      signedIn: true,
-      hasRecord: false,
-    }),
-    false,
-  );
 });
 
 test("the record round-trips, and anything unreadable reads as no record", () => {

--- a/apps/desktop/src/main/calendar-onboarding-flow.ts
+++ b/apps/desktop/src/main/calendar-onboarding-flow.ts
@@ -18,25 +18,15 @@ import { isRecord, text, type UnparsedWireValue } from "@sidecar/wire";
  * rows run; the gate changes when the ask is made, never what it may do.
  */
 
-/**
- * The calendar onboarding record, beside `arrival.json` in the app's own
- * state directory. Like the arrival's, a missing file does not simply mean
- * "not yet": an install that was already signed in before this file existed
- * finished its onboarding under the old terms, so the launch backfills a
- * settled record rather than gating a veteran.
- */
+/** The calendar onboarding record, beside `arrival.json` in the app's own state directory. */
 export const CALENDAR_ONBOARDING_STATE_FILE = "calendar-onboarding.json";
 
 export interface CalendarOnboardingState {
-  /**
-   * When the install's first observed sign-in put the gate up. Absent on a
-   * backfilled record, whose sign-in predates the gate existing at all.
-   */
+  /** When the install's first observed sign-in put the gate up. */
   requiredAt?: string;
   /**
    * When the gate stopped standing: Done confirmed the connected calendars,
-   * a calendar already standing was recognized at a launch or a sign-in, or —
-   * on a backfilled record — the install was recognized as predating the step.
+   * or a calendar already standing was recognized at a launch or a sign-in.
    */
   settledAt?: string;
   /**
@@ -50,9 +40,9 @@ export interface CalendarOnboardingState {
 
 /**
  * Reads a stored record, or nothing for a file that is missing or does not
- * parse. "Nothing" means "no record", which the launch turns into a backfill —
- * the safe direction, since a backfill can only ever stand the gate down,
- * never raise it over someone who already passed it.
+ * parse. "Nothing" means "no sign-in was ever observed", which raises no
+ * gate: the safe direction, since it can only stand the gate down, never
+ * raise it over someone who already passed it.
  */
 export function calendarOnboardingStateFromStored(
   stored: string | undefined,
@@ -93,19 +83,4 @@ export function calendarOnboardingOwed(state: CalendarOnboardingState | undefine
     state.settledAt === undefined &&
     state.skippedAt === undefined
   );
-}
-
-/**
- * Whether this launch should write a settled record without gating anything.
- * A signed-in launch with no record predates the calendar step — its sign-in
- * was never observed by it — and without the record on file, an update would
- * raise an onboarding gate over someone months in. Only an interactive launch
- * may write it: a fixture or capture run observes no accounts at all.
- */
-export function shouldBackfillCalendarOnboardingSettled(input: {
-  requiresAccount: boolean;
-  signedIn: boolean;
-  hasRecord: boolean;
-}): boolean {
-  return input.requiresAccount && input.signedIn && !input.hasRecord;
 }

--- a/apps/desktop/src/main/desktop-app.ts
+++ b/apps/desktop/src/main/desktop-app.ts
@@ -77,7 +77,6 @@ import {
   INTRODUCTION_STATE_FILE,
   introductionCompleted,
   introductionRecord,
-  shouldBackfillIntroductionCompletion,
   shouldRunIntroduction,
 } from "./introduction-flow";
 import { registerAccountSessionIpc } from "./ipc/account-session";
@@ -1060,13 +1059,11 @@ export function startDesktopApp(): void {
         await localRuntime.start();
         await onAttached();
       }
-      const introductionInput = {
+      const giveIntroduction = shouldRunIntroduction({
         requiresAccount: runMode.requiresAccount,
         signedIn: account.status === ACCOUNT_STATUS.SIGNED_IN,
         completed: introductionCompletedOnDisk(),
-      };
-      const giveIntroduction = shouldRunIntroduction(introductionInput);
-      if (shouldBackfillIntroductionCompletion(introductionInput)) markIntroductionComplete();
+      });
       await panels.refreshGeometry();
       registerIpc();
       dock.applyIcon();

--- a/apps/desktop/src/main/host/runtime-host.ts
+++ b/apps/desktop/src/main/host/runtime-host.ts
@@ -184,7 +184,6 @@ import {
   arrivalRecord,
   arrivalStateFromStored,
   countsFirstAnnouncement,
-  shouldBackfillArrivalSettled,
 } from "../arrival-flow";
 import type { WorkspaceCreationDefaults } from "../brain/act-performer";
 import { wakeEventsFromHooks } from "../brain/flow";
@@ -196,7 +195,6 @@ import {
   calendarOnboardingOwed,
   calendarOnboardingRecord,
   calendarOnboardingStateFromStored,
-  shouldBackfillCalendarOnboardingSettled,
 } from "../calendar-onboarding-flow";
 import { conversationOperations, startHistoryMaintenance } from "../conversation-operations";
 import { NODE_CAPABILITY } from "../gateway/desktop-node";
@@ -2512,26 +2510,7 @@ export function composeRuntimeHost(options: RuntimeHostOptions): RuntimeHost {
       await cronScheduler.ensure(heartbeatJob(now()));
       await cronScheduler.ensure(consolidationJob(now()));
     }
-    const signedIn = account.status === ACCOUNT_STATUS.SIGNED_IN;
-    if (
-      shouldBackfillArrivalSettled({
-        requiresAccount: runMode.requiresAccount,
-        signedIn,
-        hasRecord: arrivalState !== undefined,
-      })
-    ) {
-      writeArrivalState({ settledAt: new Date(now()).toISOString() });
-    }
     calendarOnboardingState = calendarOnboardingStateFromDisk();
-    if (
-      shouldBackfillCalendarOnboardingSettled({
-        requiresAccount: runMode.requiresAccount,
-        signedIn,
-        hasRecord: calendarOnboardingState !== undefined,
-      })
-    ) {
-      writeCalendarOnboardingState({ settledAt: new Date(now()).toISOString() });
-    }
     void settleCalendarOnboardingIfConnected();
     void settingsStore.snapshot();
     productEvents.arm();

--- a/apps/desktop/src/main/introduction-flow.test.ts
+++ b/apps/desktop/src/main/introduction-flow.test.ts
@@ -3,7 +3,6 @@ import test from "node:test";
 import {
   introductionCompleted,
   introductionRecord,
-  shouldBackfillIntroductionCompletion,
   shouldRunIntroduction,
 } from "./introduction-flow";
 
@@ -31,44 +30,6 @@ test("a deterministic run never gives the introduction", () => {
 test("a completed introduction never replays", () => {
   assert.equal(
     shouldRunIntroduction({ requiresAccount: true, signedIn: false, completed: true }),
-    false,
-  );
-});
-
-test("a signed-in launch with no record backfills one, so a sign-out cannot replay", () => {
-  assert.equal(
-    shouldBackfillIntroductionCompletion({
-      requiresAccount: true,
-      signedIn: true,
-      completed: false,
-    }),
-    true,
-  );
-});
-
-test("a launch with the record on file, or none to prove a meeting, backfills nothing", () => {
-  assert.equal(
-    shouldBackfillIntroductionCompletion({
-      requiresAccount: true,
-      signedIn: true,
-      completed: true,
-    }),
-    false,
-  );
-  assert.equal(
-    shouldBackfillIntroductionCompletion({
-      requiresAccount: true,
-      signedIn: false,
-      completed: false,
-    }),
-    false,
-  );
-  assert.equal(
-    shouldBackfillIntroductionCompletion({
-      requiresAccount: false,
-      signedIn: true,
-      completed: false,
-    }),
     false,
   );
 });

--- a/apps/desktop/src/main/introduction-flow.ts
+++ b/apps/desktop/src/main/introduction-flow.ts
@@ -63,22 +63,6 @@ export function shouldRunIntroduction(input: {
   return input.requiresAccount && !input.signedIn && !input.completed;
 }
 
-/**
- * Whether this launch should write the completion record without playing
- * anything. A signed-in launch proves the user has already met Luke — an
- * install that predates the introduction upgrades into exactly this state —
- * and without the record on file, a later sign-out would replay a first
- * meeting to someone months in. Only an interactive launch may write it: a
- * fixture or capture run says nothing about who has met whom.
- */
-export function shouldBackfillIntroductionCompletion(input: {
-  requiresAccount: boolean;
-  signedIn: boolean;
-  completed: boolean;
-}): boolean {
-  return input.requiresAccount && input.signedIn && !input.completed;
-}
-
 /** Whether a stored record says the introduction finished. */
 export function introductionCompleted(stored: string | undefined): boolean {
   if (stored === undefined) return false;

--- a/apps/desktop/src/main/settings-store.test.ts
+++ b/apps/desktop/src/main/settings-store.test.ts
@@ -1076,34 +1076,6 @@ test("ignores a stored key that can no longer be decrypted", async (t) => {
   );
 });
 
-test("keeps a Conductor key stored by an earlier version working", async (t) => {
-  const directory = await temporaryDirectory(t);
-  await fs.writeFile(
-    path.join(directory, SETTINGS_FILE_NAME),
-    JSON.stringify({ version: 1, conductorApiKey: sealed(TEST_API_KEY) }),
-  );
-  const store = storeIn(directory);
-
-  assert.equal(await store.readApiKey(CONDUCTOR), TEST_API_KEY);
-  assert.equal(
-    appSettingsView(await store.snapshot()).credentialSources[CONDUCTOR],
-    CREDENTIAL_SOURCE.ENCRYPTED_FILE,
-  );
-
-  // The migrated key moves under its provider id the next time settings are
-  // written, and the version 1 field does not survive that write.
-  await store.setApiKey(CONDUCTOR, "conductor-replacement-key");
-  const persisted: unknown = JSON.parse(await readSettingsFile(directory));
-
-  assert.deepEqual(
-    persisted,
-    expectedPersistedSettings({
-      apiKeys: { [CONDUCTOR]: sealed("conductor-replacement-key") },
-    }),
-  );
-  assert.equal(await storeIn(directory).readApiKey(CONDUCTOR), "conductor-replacement-key");
-});
-
 test("carries a key belonging to a provider this build does not know", async (t) => {
   // A file written by a newer build must not lose credentials to an older one.
   const directory = await temporaryDirectory(t);
@@ -1121,21 +1093,6 @@ test("carries a key belonging to a provider this build does not know", async (t)
       apiKeys: { "later-cloud": sealed("later-cloud-key"), [CONDUCTOR]: sealed(TEST_API_KEY) },
     }),
   );
-});
-
-test("drops the retired menu bar preference on the next settings write", async (t) => {
-  const directory = await temporaryDirectory(t);
-  await fs.writeFile(
-    path.join(directory, SETTINGS_FILE_NAME),
-    JSON.stringify({ version: 2, apiKeys: {}, showInMenuBar: false }),
-  );
-  const store = storeIn(directory);
-
-  await store.set(APP_SETTING_SCHEMA.showInDock.field, true);
-
-  const persisted = JSON.parse(await readSettingsFile(directory));
-  assert.equal(persisted.showInMenuBar, undefined);
-  assert.equal(persisted.showInDock, true);
 });
 
 test("keeps Luke out of the Dock until asked, and remembers the answer", async (t) => {
@@ -1823,55 +1780,6 @@ test("stores Superset workspace and agent defaults without touching credentials"
   assert.deepEqual(
     appSettingsView(await storeIn(directory).snapshot()).workspaceAgentDefaults?.superset,
     { agent: "codex" },
-  );
-});
-
-test("folds a Superset agent default stored apart by an earlier build into the record", async (t) => {
-  const directory = await temporaryDirectory(t);
-  await fs.writeFile(
-    path.join(directory, SETTINGS_FILE_NAME),
-    JSON.stringify({ version: 2, apiKeys: {}, supersetAgentDefault: "codex" }),
-  );
-
-  const store = storeIn(directory);
-  assert.deepEqual(appSettingsView(await store.snapshot()).workspaceAgentDefaults?.superset, {
-    agent: "codex",
-  });
-
-  await store.set(APP_SETTING_SCHEMA.voiceCaptions.field, true);
-  const written = JSON.parse(await fs.readFile(path.join(directory, SETTINGS_FILE_NAME), "utf8"));
-  assert.equal(written.supersetAgentDefault, undefined);
-  assert.deepEqual(written.workspaceAgentDefaults, { superset: { agent: "codex" } });
-});
-
-test("a folded Superset entry outranks the legacy field it replaced", async (t) => {
-  const directory = await temporaryDirectory(t);
-  await fs.writeFile(
-    path.join(directory, SETTINGS_FILE_NAME),
-    JSON.stringify({
-      version: 2,
-      apiKeys: {},
-      supersetAgentDefault: "codex",
-      workspaceAgentDefaults: { superset: { agent: "claude-code" } },
-    }),
-  );
-
-  assert.deepEqual(
-    appSettingsView(await storeIn(directory).snapshot()).workspaceAgentDefaults?.superset,
-    { agent: "claude-code" },
-  );
-});
-
-test("ignores a legacy Superset agent default that is not an agent kind", async (t) => {
-  const directory = await temporaryDirectory(t);
-  await fs.writeFile(
-    path.join(directory, SETTINGS_FILE_NAME),
-    JSON.stringify({ version: 2, apiKeys: {}, supersetAgentDefault: "Not An Agent!" }),
-  );
-
-  assert.equal(
-    appSettingsView(await storeIn(directory).snapshot()).workspaceAgentDefaults,
-    undefined,
   );
 });
 

--- a/apps/desktop/src/main/settings-store.ts
+++ b/apps/desktop/src/main/settings-store.ts
@@ -2,7 +2,6 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import {
   CREDENTIAL_CONNECTION,
-  CREDENTIAL_PROVIDER_ID,
   CREDENTIAL_PROVIDER_LIST,
   type CredentialFormat,
   type CredentialProvider,
@@ -10,7 +9,6 @@ import {
   VOICE_CREDENTIAL_PROVIDER_ID,
 } from "@sidecar/credentials";
 import { REALTIME_DEFAULTS } from "@sidecar/realtime";
-import { parseWorkspaceAgentKindSelection, SUPERSET_WORKSPACE_PROVIDER_ID } from "@sidecar/session";
 import { DEFAULT_PANEL_FORM_FACTOR } from "@sidecar/surface";
 import {
   ACT_RESULT_STATUS,
@@ -77,7 +75,6 @@ import {
 
 const SETTINGS_FILE_NAME = "settings.json";
 const SETTINGS_TEMPORARY_FILE_NAME = "settings.json.tmp";
-/** Version 2 keys credentials by provider id; version 1 held one Conductor key. */
 const SETTINGS_FILE_VERSION = 2;
 const SETTINGS_FILE_MODE = 0o600;
 
@@ -87,8 +84,6 @@ const SETTINGS_FIELD = {
   APPLE_CALENDAR: "appleCalendar",
   CALENDAR_ACCOUNTS: "calendarAccounts",
   GRANTS: "grants",
-  LEGACY_CONDUCTOR_API_KEY: "conductorApiKey",
-  LEGACY_SUPERSET_AGENT_DEFAULT: "supersetAgentDefault",
   ACCOUNT_PREFERENCES_SYNC: "accountPreferencesSync",
   VAULT_SYNC_ACCOUNT: "vaultSyncAccount",
   VERSION: "version",
@@ -164,7 +159,7 @@ interface PersistedSettings extends StoredAppSettings {
   /** Account tokens encrypted together; only display identity stays plaintext. */
   account?: {
     tokenCipher: string;
-    /** Absent for an account stored before the id was kept; see `StoredAccount`. */
+    /** Absent where the sign-in's identity carried none; see `AccountIdentity`. */
     id?: string;
     email: string;
     name?: string;
@@ -196,10 +191,10 @@ interface PersistedSettings extends StoredAppSettings {
   appleCalendar?: { calendars: readonly string[] };
   /**
    * Which account this Mac's provider keys were last synced for — the
-   * account's opaque id, or its address for an account stored before ids
-   * were kept. It outlives a sign-out on purpose: it is what keeps an
-   * automatic sweep from handing one person's keys to whoever signs in
-   * next, so it must remember the person after they have gone.
+   * account's opaque id, or its address where the identity carried no id. It
+   * outlives a sign-out on purpose: it is what keeps an automatic sweep from
+   * handing one person's keys to whoever signs in next, so it must remember
+   * the person after they have gone.
    */
   vaultSyncAccount?: string;
 }
@@ -404,12 +399,6 @@ function storedApiKeys(record: WireRecord, providers: readonly CredentialProvide
       apiKeys[providerId] = ciphertext;
     }
   }
-  // An installation upgraded from version 1 keeps its Conductor key: the
-  // ciphertext is unchanged, so it decrypts exactly as it did before.
-  const legacy = record[SETTINGS_FIELD.LEGACY_CONDUCTOR_API_KEY];
-  if (isWireString(legacy) && legacy && !apiKeys[CREDENTIAL_PROVIDER_ID.CONDUCTOR]) {
-    apiKeys[CREDENTIAL_PROVIDER_ID.CONDUCTOR] = legacy;
-  }
   return apiKeys;
 }
 
@@ -427,24 +416,6 @@ function readStoredSettings(record: WireRecord): StoredAppSettings {
       APP_SETTING_SCHEMA[field].guard(record[field]).value,
     ]),
   ) as StoredAppSettings;
-}
-
-function withLegacySupersetAgentDefault(
-  settings: StoredAppSettings,
-  record: WireRecord,
-): StoredAppSettings {
-  if (settings.workspaceAgentDefaults?.[SUPERSET_WORKSPACE_PROVIDER_ID]) return settings;
-  const legacy = parseWorkspaceAgentKindSelection(
-    unparsedWire({ agent: record[SETTINGS_FIELD.LEGACY_SUPERSET_AGENT_DEFAULT] }),
-  );
-  if (!legacy) return settings;
-  return {
-    ...settings,
-    workspaceAgentDefaults: {
-      ...settings.workspaceAgentDefaults,
-      [SUPERSET_WORKSPACE_PROVIDER_ID]: legacy,
-    },
-  };
 }
 
 function storedSettingsFromPersisted(persisted: PersistedSettings): StoredAppSettings {
@@ -552,7 +523,7 @@ function parsePersistedSettings(
   const calendarAccounts = storedCalendarAccounts(record);
   const appleCalendar = storedAppleCalendar(record);
   const grants = storedGrants(record);
-  const settings = withLegacySupersetAgentDefault(readStoredSettings(record), record);
+  const settings = readStoredSettings(record);
   const vaultSyncAccount = record[SETTINGS_FIELD.VAULT_SYNC_ACCOUNT];
   const account = storedAccount(record);
   const accountPreferencesSync = storedAccountPreferencesSync(record);

--- a/packages/account/src/client.ts
+++ b/packages/account/src/client.ts
@@ -200,18 +200,8 @@ export class AccountClient {
   }
 }
 
-export interface StoredAccount {
+/** The signed-in identity with the tokens it was issued, as the store keeps it. */
+export interface StoredAccount extends AccountIdentity {
   accessToken: string;
   refreshToken: string;
-  /**
-   * The identity's opaque id; see `AccountIdentity`. Optional here alone,
-   * because an account signed in by a build that predates it was stored
-   * without one: dropping such an account would sign the user out on upgrade
-   * for a field nothing they do depends on. The next identity read fills it.
-   */
-  id?: string;
-  email: string;
-  name?: string;
-  pictureUrl?: string;
-  provider: AccountProvider;
 }

--- a/packages/brain/src/agent.test.ts
+++ b/packages/brain/src/agent.test.ts
@@ -9,6 +9,7 @@ import {
   type ChildCompletionRecord,
   type ChildRunRecord,
   COMPLETION_DELIVERY_STATUS,
+  checkpointFormatTag,
   childSessionKey,
   DEFAULT_AGENT_ID,
   MAIN_SESSION_KEY,
@@ -853,6 +854,7 @@ test("restored memory opens the next turn, and held briefings are re-decided fro
   const storage = new FakeStorage(
     JSON.stringify({
       ...freshBrainState("gen-prior", NOW - 1),
+      checkpointFormat: checkpointFormatTag(CHECKPOINT),
       items: prior,
       cursors: { "claude-code": { abc: "old" } },
     }),

--- a/packages/brain/src/index.ts
+++ b/packages/brain/src/index.ts
@@ -109,8 +109,6 @@ export {
   brainStateRecord,
   brainStateRepositoryFromStorage,
   freshBrainState,
-  LEGACY_CHECKPOINT_FORMAT_TAG,
-  legacyStampOf,
 } from "./state-store.js";
 export type {
   BrainChildAccess,

--- a/packages/brain/src/state-store.test.ts
+++ b/packages/brain/src/state-store.test.ts
@@ -14,7 +14,6 @@ import {
   brainStateFromStored,
   brainStateRecord,
   freshBrainState,
-  LEGACY_CHECKPOINT_FORMAT_TAG,
   retainedBrainState,
 } from "./state-store.js";
 
@@ -29,7 +28,8 @@ function raw(value: BrainPersistedState | BrainPersistedState["requests"][number
 function complete(): BrainPersistedState {
   return {
     ...freshBrainState("gen-1", NOW),
-    checkpointFormat: LEGACY_CHECKPOINT_FORMAT_TAG,
+    // A well-formed stamp, as `checkpointFormatTag` writes this build's own.
+    checkpointFormat: "tool-loop@1:openai-responses-input/1",
     items: [{ type: "message", role: "user", content: [] }],
     cursors: { "claude-code": { abc: "7" } },
     requests: [
@@ -91,10 +91,11 @@ test("the envelope round-trips, and anything from another shape reads as nothing
   assert.equal(read({ ...raw(state), journal: [{ runId: "x" }] }), undefined);
 });
 
-test("the checkpoint stamp is kept as written, defaulted for unstamped items, and absent for an empty unstamped generation", () => {
+test("the checkpoint stamp is kept as written, and absent wherever none was written", () => {
   const read = (value: WireBoundaryInput) => brainPersistedStateFromWire(unparsedWire(value));
   const { checkpointFormat: _stamp, ...unstamped } = raw(complete());
-  assert.equal(read(unstamped)?.checkpointFormat, LEGACY_CHECKPOINT_FORMAT_TAG);
+  const held = read(unstamped);
+  assert.ok(held && !("checkpointFormat" in held));
   const empty = read({ ...unstamped, items: [] });
   assert.ok(empty && !("checkpointFormat" in empty));
   // An empty checkpoint of another runtime keeps saying whose it is.

--- a/packages/brain/src/state-store.ts
+++ b/packages/brain/src/state-store.ts
@@ -1,8 +1,4 @@
-import {
-  checkpointFormatFromTag,
-  checkpointFormatTag,
-  type TranscriptEvent,
-} from "@sidecar/runtime-contracts";
+import { checkpointFormatFromTag, type TranscriptEvent } from "@sidecar/runtime-contracts";
 import { isRecord, isWireNumber, isWireString, type UnparsedWireValue } from "@sidecar/wire";
 import { type BrainJournalEntry, brainJournalEntryFromWire } from "./journal.js";
 import { type BrainObservationEntry, brainObservationEntryFromWire } from "./observation-inbox.js";
@@ -11,8 +7,7 @@ import {
   brainRequestRecordFromWire,
   isTerminalBrainRequestStatus,
 } from "./requests.js";
-import { RESPONSES_ITEM_FORMAT, type ResponsesInputItem } from "./responses-api.js";
-import { TOOL_LOOP_RUNTIME } from "./runtime.js";
+import type { ResponsesInputItem } from "./responses-api.js";
 
 /**
  * Everything the brain keeps across launches, in one envelope with one
@@ -60,24 +55,6 @@ export interface BrainResetMarker {
 }
 
 export type BrainTranscriptCursors = Readonly<Record<string, Readonly<Record<string, string>>>>;
-
-/**
- * The stamp a checkpoint written before stamps existed carries: every such
- * checkpoint was the tool-loop runtime's first version over the Responses
- * input array, because nothing else ever wrote one. The versions are pinned
- * history, not the current ones, and stay `1` when either moves on.
- */
-export const LEGACY_CHECKPOINT_FORMAT_TAG = checkpointFormatTag({
-  runtime: TOOL_LOOP_RUNTIME.ID,
-  runtimeVersion: 1,
-  format: RESPONSES_ITEM_FORMAT.FORMAT,
-  formatVersion: 1,
-});
-
-/** The stamp an unstamped envelope carries: the legacy stamp when it holds items, nothing when it holds none. */
-export function legacyStampOf(items: readonly unknown[]): string | undefined {
-  return items.length > 0 ? LEGACY_CHECKPOINT_FORMAT_TAG : undefined;
-}
 
 export interface BrainPersistedState {
   version: typeof BRAIN_STATE_VERSION;
@@ -146,7 +123,7 @@ export function brainPersistedStateFromWire(
   if (value.expiresAt - value.createdAt !== BRAIN_GENERATION_LIFETIME_MS) return undefined;
   if (!Array.isArray(value.items) || !isRecord(value.cursors)) return undefined;
   if (!Array.isArray(value.requests) || !Array.isArray(value.journal)) return undefined;
-  const checkpointFormat = checkpointFormatTagFromWire(value.checkpointFormat, value.items);
+  const checkpointFormat = checkpointFormatTagFromWire(value.checkpointFormat);
   if (checkpointFormat === null) return undefined;
   const reset = resetMarkerFromWire(value.reset);
   if (reset === null || (reset && reset.clearedAt > value.createdAt)) return undefined;
@@ -224,15 +201,11 @@ function cursorsFromWire(
 }
 
 /**
- * The stamp as stored: nothing for a generation never checkpointed, the
- * legacy stamp for items written before stamps existed, the tag itself when
- * it reads as one, and null for a tag not written by the rule.
+ * The stamp as stored: nothing for a generation never checkpointed, the tag
+ * itself when it reads as one, and null for a tag not written by the rule.
  */
-function checkpointFormatTagFromWire(
-  value: UnparsedWireValue,
-  items: readonly unknown[],
-): string | undefined | null {
-  if (value === undefined) return legacyStampOf(items);
+function checkpointFormatTagFromWire(value: UnparsedWireValue): string | undefined | null {
+  if (value === undefined) return undefined;
   if (!isWireString(value) || !checkpointFormatFromTag(value)) return null;
   return value;
 }

--- a/packages/hosted/src/hosted-service.test.ts
+++ b/packages/hosted/src/hosted-service.test.ts
@@ -75,7 +75,7 @@ test("a mint answer round-trips through the wire reader, with or without a quota
   assert.deepEqual(metered?.quota, quota);
 });
 
-test("a mint answer without wsUrl (old server) still parses for new readers", () => {
+test("a mint answer with no wsUrl at all is discarded", () => {
   const wire = {
     connection: {
       value: "eph-secret",
@@ -84,9 +84,7 @@ test("a mint answer without wsUrl (old server) still parses for new readers", ()
       callsUrl: HOSTED_CALLS_URL,
     },
   };
-  const answer = hostedMintAnswerFromWire(wire, NOW);
-  assert.ok(answer);
-  assert.equal(answer.connection.wsUrl, undefined);
+  assert.equal(hostedMintAnswerFromWire(wire, NOW), undefined);
 });
 
 test("a credential aimed anywhere but the canonical calls endpoint is discarded", () => {

--- a/packages/hosted/src/hosted-service.ts
+++ b/packages/hosted/src/hosted-service.ts
@@ -316,17 +316,15 @@ export function hostedMintAnswerFromWire(
   if (!secret || !model) return undefined;
   if (expiresAt === undefined) return undefined;
   if (connection.callsUrl !== HOSTED_CALLS_URL) return undefined;
-  const wsUrlFromWire = text(connection.wsUrl);
-  if (wsUrlFromWire !== undefined && wsUrlFromWire !== `${HOSTED_WS_BASE_URL}?model=${model}`) {
-    return undefined;
-  }
+  const wsUrl = text(connection.wsUrl);
+  if (wsUrl !== `${HOSTED_WS_BASE_URL}?model=${model}`) return undefined;
   const credential: RealtimeConnection = {
     value: secret,
     expiresAt,
     model,
     callsUrl: HOSTED_CALLS_URL,
+    wsUrl,
   };
-  if (wsUrlFromWire !== undefined) credential.wsUrl = wsUrlFromWire;
   if (!realtimeCredentialIsUsable(credential, now)) return undefined;
   const quota = hostedQuotaFromWire(value.quota);
   const answer: HostedMintAnswer = { connection: credential };

--- a/packages/hosted/src/realtime-contract.ts
+++ b/packages/hosted/src/realtime-contract.ts
@@ -11,7 +11,13 @@ export interface RealtimeCredential {
 /** Everything a renderer needs to open a call, and nothing more. */
 export interface RealtimeConnection extends RealtimeCredential {
   callsUrl: string;
-  /** WebSocket realtime endpoint, including ?model=. Absent on servers that predate this field. */
+  /**
+   * WebSocket realtime endpoint, including ?model=, for a client that opens
+   * the call over WebSocket rather than WebRTC. The hosted mint always
+   * carries it; a connection minted straight against OpenAI on the
+   * developer's own key does not, because that mint answers a calls URL
+   * alone and composing one here would invent an endpoint.
+   */
   wsUrl?: string;
 }
 

--- a/packages/runtime-store/src/brain-envelope.ts
+++ b/packages/runtime-store/src/brain-envelope.ts
@@ -6,7 +6,6 @@ import {
   type BrainRequestRecord,
   type BrainTranscriptCursors,
   brainPersistedStateFromWire,
-  legacyStampOf,
 } from "@sidecar/brain";
 import type { SessionKey } from "@sidecar/runtime-contracts";
 import { isWireNumber, isWireString, type WireRecord, type WireValue } from "@sidecar/wire";
@@ -90,9 +89,6 @@ export function loadBrainEnvelope(database: RuntimeDatabase, sessionKey: Session
   const items = database
     .prepare("SELECT item FROM runtime_checkpoints WHERE session_id = ? ORDER BY sequence")
     .all(session.sessionId) as { item: string }[];
-  // The stamp lives on the generation row alone, so an empty checkpoint keeps
-  // it and an item row says nothing about whose shape it is.
-  const stamp = session.checkpointFormat ?? legacyStampOf(items);
   // SAFETY: the three text columns selected are the ones the row type names.
   const cursorRows = database
     .prepare(
@@ -142,7 +138,11 @@ export function loadBrainEnvelope(database: RuntimeDatabase, sessionKey: Session
     generationId: session.sessionId,
     createdAt: session.createdAt,
     expiresAt: session.expiresAt,
-    ...(stamp !== undefined ? { checkpointFormat: stamp } : undefined),
+    // The stamp lives on the generation row alone, so an empty checkpoint
+    // keeps it and an item row says nothing about whose shape it is.
+    ...(session.checkpointFormat !== undefined
+      ? { checkpointFormat: session.checkpointFormat }
+      : undefined),
     items: parsedItems,
     compactionCount: session.compactionCount,
     cursors,
@@ -260,7 +260,7 @@ function replaceGeneration(
       state.expiresAt,
       nullable(state.reset?.clearedAt),
       nullable(state.reset?.generationId),
-      nullable(stampOf(state)),
+      nullable(state.checkpointFormat),
       state.compactionCount,
     );
   if (state.reset) raiseHistoryCutoff(database, sessionKey, state.reset.clearedAt);
@@ -274,10 +274,6 @@ function replaceGeneration(
   state.journal.forEach((entry, ordinal) => {
     upsertJournal(database, state.generationId, ordinal, entry);
   });
-}
-
-function stampOf(state: BrainPersistedState): string | undefined {
-  return state.checkpointFormat ?? legacyStampOf(state.items);
 }
 
 function insertItems(

--- a/packages/runtime-store/src/schema.ts
+++ b/packages/runtime-store/src/schema.ts
@@ -35,23 +35,23 @@
  * transaction that removed the rows and cleared only once the file it names
  * is published and verified.
  *
- * Version 4 adds the scheduler's jobs: one row per job, its payload the job
- * as the scheduler wrote it, so a launch finds what was scheduled and when it
- * last ran without a second store beside the database.
+ * The scheduler's jobs are one row per job, its payload the job as the
+ * scheduler wrote it, so a launch finds what was scheduled and when it last
+ * ran without a second store beside the database.
  *
- * Version 5 adds the durable observation inbox: the observations captured
- * for a conversation and not yet consumed by a turn, and the capture cursors
- * that say how far each transcript has been written down — kept apart from
- * the consumed cursors, which say how far a model has read.
+ * The durable observation inbox holds the observations captured for a
+ * conversation and not yet consumed by a turn, and the capture cursors that
+ * say how far each transcript has been written down — kept apart from the
+ * consumed cursors, which say how far a model has read.
  *
- * Version 6 adds delegation: one row per child run and one per completion,
- * each its record as the child service wrote it. A completion is written
- * before its delivery is tried and stands apart from the child's row, so a
- * child's result survives a delivery that could not land, and a launch finds
- * both what was still running and what was still owed.
+ * Delegation is one row per child run and one per completion, each its
+ * record as the child service wrote it. A completion is written before its
+ * delivery is tried and stands apart from the child's row, so a child's
+ * result survives a delivery that could not land, and a launch finds both
+ * what was still running and what was still owed.
  *
- * Version 7 makes the notebook's Markdown files the source of truth for what
- * Luke remembers and keeps only derived and provenance rows here: the search
+ * The notebook's Markdown files are the source of truth for what Luke
+ * remembers, so only derived and provenance rows stand here: the search
  * index over the notebook (sources, chunks, their FTS5 shadow, the embedding
  * cache), and the notebook entries' provenance (each USER.md line's id and
  * origin, and the file hash last reconciled). The `personal_facts` table is
@@ -59,20 +59,29 @@
  * into USER.md under the same id and empties the table; nothing writes it
  * any more.
  *
- * Version 8 adds memory maintenance: the short-term candidates consolidation
- * ranks, one row per candidate holding the record as the sweep wrote it; the
- * ingestion cursors and seen-message hashes that keep a History line from
- * being learned twice; the tombstones of forgotten sources, which a scan
- * refuses to relearn; the preimage of every MEMORY.md rewrite, so a
- * consolidation is reversible; and each conversation's last flush, so a
- * flush runs once per compaction cycle.
+ * Memory maintenance keeps the short-term candidates consolidation ranks, one
+ * row per candidate holding the record as the sweep wrote it; the ingestion
+ * cursors and seen-message hashes that keep a History line from being learned
+ * twice; the tombstones of forgotten sources, which a scan refuses to
+ * relearn; the preimage of every MEMORY.md rewrite, so a consolidation is
+ * reversible; and each conversation's last flush, so a flush runs once per
+ * compaction cycle.
  *
  * The schema is versioned by the `schema_version` table. A database at a
  * version this build does not know is refused rather than migrated by guess.
  */
 
 import type { SQLInputValue } from "node:sqlite";
-import { LEGACY_CHECKPOINT_FORMAT_TAG } from "@sidecar/brain";
+
+/**
+ * The stamp version 2 writes onto a checkpoint stored before stamps existed:
+ * every such checkpoint was the tool-loop runtime's first version over the
+ * Responses input array, because nothing else ever wrote one. Pinned history,
+ * so it is a literal rather than composed from this build's own ids — a
+ * runtime or item format renamed later must not change what a decade-old row
+ * is said to be.
+ */
+const LEGACY_CHECKPOINT_FORMAT_TAG = "tool-loop@1:openai-responses-input/1";
 
 /**
  * One flush marker per conversation: the generation and compaction count the
@@ -142,6 +151,10 @@ export const RUNTIME_SCHEMA_MIGRATIONS: ReadonlyMap<number, readonly SchemaMigra
         },
       ],
     ],
+    // Versions 4 through 8 alter no table that already stands: each adds one
+    // the current statements create where none is. The entries are still
+    // needed, because a version with none is refused rather than assumed
+    // empty.
     [4, []],
     [5, []],
     [6, []],

--- a/packages/runtime-store/src/testing.ts
+++ b/packages/runtime-store/src/testing.ts
@@ -5,7 +5,6 @@ import {
   type BrainPersistedState,
   type BrainRequestRecord,
   freshBrainState,
-  LEGACY_CHECKPOINT_FORMAT_TAG,
 } from "@sidecar/brain";
 import { CONVERSATION_ENTRY_KIND, type ConversationEntry } from "@sidecar/realtime";
 import type { SessionKey } from "@sidecar/runtime-contracts";
@@ -68,7 +67,8 @@ export function receipt(
 export function populatedState(generationId: string, createdAt = NOW): BrainPersistedState {
   return {
     ...freshBrainState(generationId, createdAt),
-    checkpointFormat: LEGACY_CHECKPOINT_FORMAT_TAG,
+    // A well-formed stamp, as `checkpointFormatTag` writes this build's own.
+    checkpointFormat: "tool-loop@1:openai-responses-input/1",
     items: [
       { type: "message", role: "user", content: "first" },
       { type: "function_call", call_id: "call-1", name: "send_message", arguments: "{}" },

--- a/packages/voice/src/hosted-credentials.test.ts
+++ b/packages/voice/src/hosted-credentials.test.ts
@@ -1,11 +1,13 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { HOSTED_CALLS_URL } from "@sidecar/hosted";
+import { HOSTED_CALLS_URL, HOSTED_WS_BASE_URL } from "@sidecar/hosted";
 import { REALTIME_MINT_OUTCOME, REALTIME_VOICE, REALTIME_VOICE_SPEED } from "@sidecar/realtime";
 import type { ParsedJsonObject } from "@sidecar/wire/testing";
 import { HostedRealtimeCredentialMinter } from "./hosted-credentials.js";
 
 const NOW = 1_800_000_000_000;
+const MODEL = "gpt-realtime-2.1";
+const WS_URL = `${HOSTED_WS_BASE_URL}?model=${MODEL}`;
 const SERVICE = "https://tryluke.dev";
 const QUOTA = { used: 3, limit: 50, remaining: 47, resetsAt: NOW + 3_600_000 };
 
@@ -14,8 +16,9 @@ function mintedBody(overrides: ParsedJsonObject = {}) {
     connection: {
       value: "eph-secret",
       expiresAt: NOW + 60_000,
-      model: "gpt-realtime-2.1",
+      model: MODEL,
       callsUrl: HOSTED_CALLS_URL,
+      wsUrl: WS_URL,
       ...overrides,
     },
     quota: QUOTA,
@@ -64,8 +67,9 @@ test("mints through the hosted service on the account's bearer token", async () 
   assert.deepEqual(connection, {
     value: "eph-secret",
     expiresAt: NOW + 60_000,
-    model: "gpt-realtime-2.1",
+    model: MODEL,
     callsUrl: HOSTED_CALLS_URL,
+    wsUrl: WS_URL,
   });
 
   const [request] = requests;

--- a/packages/voice/src/introduction-credentials.test.ts
+++ b/packages/voice/src/introduction-credentials.test.ts
@@ -1,11 +1,13 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { HOSTED_CALLS_URL } from "@sidecar/hosted";
+import { HOSTED_CALLS_URL, HOSTED_WS_BASE_URL } from "@sidecar/hosted";
 import { REALTIME_MINT_OUTCOME, REALTIME_VOICE, REALTIME_VOICE_SPEED } from "@sidecar/realtime";
 import type { ParsedJsonObject } from "@sidecar/wire/testing";
 import { IntroductionRealtimeCredentialMinter } from "./introduction-credentials.js";
 
 const NOW = 1_800_000_000_000;
+const MODEL = "gpt-realtime-2.1";
+const WS_URL = `${HOSTED_WS_BASE_URL}?model=${MODEL}`;
 const SERVICE = "https://tryluke.dev";
 
 function mintedBody(overrides: ParsedJsonObject = {}) {
@@ -13,8 +15,9 @@ function mintedBody(overrides: ParsedJsonObject = {}) {
     connection: {
       value: "eph-secret",
       expiresAt: NOW + 60_000,
-      model: "gpt-realtime-2.1",
+      model: MODEL,
       callsUrl: HOSTED_CALLS_URL,
+      wsUrl: WS_URL,
       ...overrides,
     },
   };
@@ -62,8 +65,9 @@ test("mints through the introduction endpoint with no authorization at all", asy
   assert.deepEqual(connection, {
     value: "eph-secret",
     expiresAt: NOW + 60_000,
-    model: "gpt-realtime-2.1",
+    model: MODEL,
     callsUrl: HOSTED_CALLS_URL,
+    wsUrl: WS_URL,
   });
 
   const [request] = requests;


### PR DESCRIPTION
## What this is

**PR B2** of the repo-wide cleanup plan: delete the code that migrates settings, credentials, onboarding records, and brain checkpoints from older app versions, plus the five empty database migrations. There are no installs to migrate.

```
git diff --shortstat origin/main...
 23 files changed, 106 insertions(+), 433 deletions(-)
```

Net **−327 lines**. Tracked source after this PR: 211,269 TS/TSX/MJS + 20,765 Swift + 29,066 docs/config/shell/CSS.

## What went

- **`settings-store.ts`** — the version-1 credential comment; `LEGACY_CONDUCTOR_API_KEY` and the branch that lifted a version-1 `conductorApiKey` under its provider id; `LEGACY_SUPERSET_AGENT_DEFAULT` and `withLegacySupersetAgentDefault`, which folded a Superset agent default an earlier build stored apart into `workspaceAgentDefaults`. Nothing else read either field, so the now-unused `CREDENTIAL_PROVIDER_ID`, `parseWorkspaceAgentKindSelection`, and `SUPERSET_WORKSPACE_PROVIDER_ID` imports go with them.
- **`shouldBackfillArrivalSettled`, `shouldBackfillCalendarOnboardingSettled`, `shouldBackfillIntroductionCompletion`** and their callers in `runtime-host.ts` and `desktop-app.ts`. Each wrote a settled record on a launch that was already signed in when the record's own file did not exist — an install that predated the feature. On a fresh install the sign-in that puts the record up is always observed in-process, and where no record stands `arrivalBeatOwed`/`calendarOnboardingOwed` already answer `false`, so the beat and the gate behave exactly as before. The prose in the three flow files that justified the backfill is rewritten to describe the record as it now stands.
- **The retired menu-bar preference** had no branch to delete: `readStoredSettings` keeps only the fields the build's own table lists, so a stored `showInMenuBar` was already dropped by construction. Only the test that pinned the migration goes.
- **`legacyStampOf`** and both `?? legacyStampOf(...)` fallbacks in `brain-envelope.ts`. Schema migration 2 backfills `checkpoint_format` for every generation that holds checkpoints, and `ledger.ts` stamps every save that carries one, so the fallback was unreachable. `LEGACY_CHECKPOINT_FORMAT_TAG` now lives inside that migration and nowhere else: it moves out of `packages/brain` into `runtime-store/schema.ts` as the historical literal `"tool-loop@1:openai-responses-input/1"`. It had been composed from `TOOL_LOOP_RUNTIME.ID` and `RESPONSES_ITEM_FORMAT.FORMAT` under a comment insisting it was pinned history — so renaming either id would silently have changed what a pre-stamp row is said to be. Pinning it as a literal is what the comment always claimed. `database.test.ts` already asserts that exact string end to end through a version-1 open. The two fixtures that borrowed the constant as "a well-formed stamp" now name one inline, the way the neighbouring foreign-stamp cases already do.
- **`runtime-store/schema.ts`** — the five empty migrations 4–8 keep their entries (the migrator refuses a version with none rather than assuming it needs nothing) and collapse to the one comment that says why they are empty, which is the only thing about them that was ever noise. The header's five "Version N adds…" paragraphs are rewritten in the present tense: they described edits, not the schema as it stands, and each still documents its tables.
- **Seven tests**: the version-1 Conductor key, the retired menu-bar preference, and the three legacy Superset agent-default tests in `settings-store.test.ts`; the backfill tables in the three onboarding-flow tests; the "old server" `wsUrl` case in `hosted-service.test.ts`; and the legacy-stamp default in `state-store.test.ts`.

## Three named items resolved differently, and why

Each of these turned out to rest on a live runtime branch rather than on an install that never existed. Saying so rather than forcing the change:

1. **`StoredAccount.id` stays optional.** The plan reads its comment as a compatibility branch, and half of it is. But `AccountIdentity.id` is optional because `userInfo` may get an answer with no `sub` (`client.ts:184`), and the code records that refusing such a sign-in "would trade an account for a feature". Requiring `id` on `StoredAccount` would either break `mergedIdentity`, which spreads an identity into a stored account, or force that refusal — a product decision about the account gate, not a cleanup. What did go: the compatibility justification, and the duplicated field list. `StoredAccount` now `extends AccountIdentity`, so the optionality has one home and one reason. `ProviderKeyVaultSync`'s `tenantName` and `accountAnswersTo` stand for the same live reason (its own comment: "an identity refresh may fill the id in later"); the settings-store comments that attributed the absence to an old install now name the real cause.

2. **`last-run-version.json` stays.** The plan deletes it *if* its only reader is the update row's just-updated first-check delay. It is not: `UpdateService.start` also moves the row to `UPDATE_STATUS.UPDATED` with the previous version, which `renderer/update-row.ts:83` draws. Deleting the file would delete a live confirmation the user sees after every update.

3. **`RealtimeConnection.wsUrl` stays optional on the interface, and is now required by the hosted reader.** The compatibility branch was in `hostedMintAnswerFromWire`, which tolerated a service that predates the field; it now discards an answer without one, and `apps/web` has always sent it. The field itself cannot be required outright: `openai-credentials.ts` mints straight against OpenAI on the developer's own key, and that mint answers a calls URL alone — composing a WebSocket URL there would invent an endpoint. The comment now says that instead of naming old servers. iOS already required `wsUrl` in its own guard, so the hosted path is consistent end to end.

## Trust constraints

No `CLAUDE.md` sentence changes, and none is weakened. The three that touch this diff still hold:

- *"a generation whose rows this build cannot read is replaced by the store that observed it"* — unchanged. A stamp that is not one this build reads is still `null` from `checkpointFormatTagFromWire` and still makes the generation unreadable; only the absent-stamp default is gone.
- *"the ephemeral realtime credential the host minted"* — unchanged. The hosted reader got stricter, never looser: a mint answer whose `wsUrl` is absent or aimed anywhere but the canonical base is now discarded outright.
- *"It plays on the first interactive launch, before any account exists, at most once to the end: a completion on file never replays"* — unchanged. Removing the introduction backfill means a launch that is signed in with no completion record no longer writes one; the introduction still runs only when signed out and uncompleted, which is exactly "at most once to the end".

## Verification

`./scripts/check.sh` — green (lint, typecheck, test, build). No UI change, so no `verify.sh` run and no notch check: this PR touches no renderer file and draws nothing new.

`git grep` for every removed symbol (`shouldBackfill*`, `legacyStampOf`, `withLegacySupersetAgentDefault`, `LEGACY_CONDUCTOR_API_KEY`, `conductorApiKey`, `supersetAgentDefault`) returns only unrelated live locals in `runtime-host.ts` and `app.tsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34290333935/artifacts/10081174422) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34290333935)

- Commit: `b875eca65ae87e494530eb3646b7a8a3b17aa4de`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
