### PR TITLE
chore(desktop): delete dead files and test-only production code

### DIFF
--- a/apps/desktop/src/main/brain/reply-delivery.ts
+++ b/apps/desktop/src/main/brain/reply-delivery.ts
@@ -4,7 +4,7 @@ import {
   isTerminalBrainRequestStatus,
 } from "@sidecar/brain/requests";
 import { DeliveryLedger, type DeliveryOffer, type DeliveryRecord } from "@sidecar/runtime";
-import { DELIVERY_STATE, type DeliveryState } from "@sidecar/runtime-contracts";
+import { DELIVERY_STATE } from "@sidecar/runtime-contracts";
 import { type BrainReplyClaimResult, brainReplyWords } from "#shared/wire/brain";
 
 export interface BrainReplyDeliveriesOptions {
@@ -90,10 +90,6 @@ export class BrainReplyDeliveries {
   /** Every delivery the ledger holds, with its state, for inspection through the protocol. */
   records(): readonly DeliveryRecord[] {
     return this.#ledger.records();
-  }
-
-  state(runId: string): DeliveryState | undefined {
-    return this.#ledger.state(runId);
   }
 
   /** The one offer the receiver epoch given may hold now, or nothing. */

--- a/apps/desktop/src/main/gateway/service.test.ts
+++ b/apps/desktop/src/main/gateway/service.test.ts
@@ -7,6 +7,7 @@ import type { ChildRunService, ResolvedConfiguration } from "@sidecar/runtime";
 import { GatewayClient, InProcessTransport, LoopbackTransport } from "@sidecar/runtime";
 import {
   DELIVERY_STATE,
+  type DeliveryState,
   GATEWAY_CLIENT_ROLE,
   GATEWAY_EVENT,
   GATEWAY_METHOD,
@@ -28,6 +29,11 @@ const NOW = 1_800_000_000_000;
 function recordOf(value: WireValue | undefined): WireRecord {
   assert.ok(isRecord(value));
   return value;
+}
+
+/** The state the ledger holds for one run, or nothing once the run's delivery is gone. */
+function deliveryState(deliveries: BrainReplyDeliveries, runId: string): DeliveryState | undefined {
+  return deliveries.records().find((delivery) => delivery.runId === runId)?.state;
 }
 
 function record(overrides: Partial<BrainRequestRecord> = {}): BrainRequestRecord {
@@ -212,7 +218,7 @@ for (const kind of ["in-process", "loopback"] as const) {
     f.service.receiverReady();
     f.end("run-1");
     assert.equal(f.offers().length, 1);
-    assert.equal(f.deliveries.state("run-1"), DELIVERY_STATE.OFFERED);
+    assert.equal(deliveryState(f.deliveries, "run-1"), DELIVERY_STATE.OFFERED);
     // The renderer reloads before claiming: a new epoch, the offer re-issued to it.
     f.receiver.reset();
     const second = f.receiver.begin();
@@ -230,7 +236,7 @@ for (const kind of ["in-process", "loopback"] as const) {
     assert.deepEqual(await f.operator.claim("run-1", String(offer.deliveryId), second), {
       granted: false,
     });
-    assert.equal(f.deliveries.state("run-1"), DELIVERY_STATE.CLAIMED);
+    assert.equal(deliveryState(f.deliveries, "run-1"), DELIVERY_STATE.CLAIMED);
   });
 
   test(`[${kind}] a claimed reply is never re-offered to a competing receiver, and a delayed acknowledgement under the old epoch changes nothing`, async () => {
@@ -261,21 +267,21 @@ for (const kind of ["in-process", "loopback"] as const) {
     const next = recordOf(f.offers()[1]?.payload);
     // run-1 may already have been heard: only run-2 is offered to the newcomer.
     assert.equal(next.runId, "run-2");
-    assert.equal(f.deliveries.state("run-1"), DELIVERY_STATE.CLAIMED);
+    assert.equal(deliveryState(f.deliveries, "run-1"), DELIVERY_STATE.CLAIMED);
     // The first receiver's acknowledgement lands late, under the epoch its
     // grant went to: it closes run-1 — the words were its to finish — and
     // re-offers nothing, since the newcomer already holds run-2. A stranger's
     // acknowledgement under the wrong epoch or delivery changes nothing.
     assert.equal(await f.operator.acknowledge("run-2", String(next.deliveryId), first), false);
     assert.equal(await f.operator.acknowledge("run-1", "delivery-none", first), false);
-    assert.equal(f.deliveries.state("run-1"), DELIVERY_STATE.CLAIMED);
+    assert.equal(deliveryState(f.deliveries, "run-1"), DELIVERY_STATE.CLAIMED);
     assert.equal(await f.operator.acknowledge("run-1", String(offer.deliveryId), first), true);
-    assert.equal(f.deliveries.state("run-1"), undefined);
+    assert.equal(deliveryState(f.deliveries, "run-1"), undefined);
     assert.equal(f.offers().length, 2);
     // The second receiver claims and acknowledges run-2, which ends it.
     assert.equal((await f.operator.claim("run-2", String(next.deliveryId), second)).granted, true);
     assert.equal(await f.operator.acknowledge("run-2", String(next.deliveryId), second), true);
-    assert.equal(f.deliveries.state("run-2"), undefined);
+    assert.equal(deliveryState(f.deliveries, "run-2"), undefined);
   });
 
   test(`[${kind}] an account change withdraws every owed reply and the receiver is told under its epoch`, async () => {
@@ -291,13 +297,13 @@ for (const kind of ["in-process", "loopback"] as const) {
     const epoch = f.receiver.begin();
     f.receiver.markReady(epoch);
     f.end("run-1");
-    assert.equal(f.deliveries.state("run-1"), DELIVERY_STATE.OFFERED);
+    assert.equal(deliveryState(f.deliveries, "run-1"), DELIVERY_STATE.OFFERED);
     // The credential changes: the generation is replaced and the brain retired.
     f.generation.id = "gen-2";
     f.retireBrain();
     f.service.generationReplaced(MAIN_SESSION_KEY);
     assert.deepEqual(withdrawn, [epoch]);
-    assert.equal(f.deliveries.state("run-1"), undefined);
+    assert.equal(deliveryState(f.deliveries, "run-1"), undefined);
     const offer = recordOf(f.offers()[0]?.payload);
     assert.deepEqual(await f.operator.claim("run-1", String(offer.deliveryId), epoch), {
       granted: false,

--- a/apps/desktop/src/main/ipc/settings-rows.ts
+++ b/apps/desktop/src/main/ipc/settings-rows.ts
@@ -6,7 +6,7 @@ import {
   type AppSettingField,
   SETTING_SIDE_EFFECT,
 } from "@sidecar/settings";
-import { ACT_RESULT_STATUS, isWireString, type UnparsedWireValue } from "@sidecar/wire";
+import { ACT_RESULT_STATUS, isWireString } from "@sidecar/wire";
 import { BRIDGE, type BridgeArgumentsFor } from "#shared/bridge";
 import type { AppSettings } from "#shared/contracts";
 import type { HostOperator } from "../gateway/host-operator";
@@ -185,5 +185,3 @@ export function registerSettingsRowsIpc(dependencies: SettingsRowsIpcDependencie
     refusal: "Could not reset those settings on this system.",
   });
 }
-
-export type { UnparsedWireValue };

--- a/apps/desktop/src/main/voice/speech-arbiter.test.ts
+++ b/apps/desktop/src/main/voice/speech-arbiter.test.ts
@@ -286,7 +286,6 @@ test("settle HELD while no quiet stands returns the request to the head unheld",
   arbiter.request({ kind: ARRIVAL_SPEECH_KIND });
   const offer = arbiter.next();
   assert.ok(offer);
-  assert.equal(arbiter.quiet, false);
   assert.equal(arbiter.settle(offer.id, SPEECH_OUTCOME.HELD)?.outcome, SPEECH_OUTCOME.HELD);
   assert.equal(traces.at(-1)?.decision, SPEECH_OUTCOME.HELD);
 

--- a/apps/desktop/src/main/voice/speech-arbiter.ts
+++ b/apps/desktop/src/main/voice/speech-arbiter.ts
@@ -115,10 +115,6 @@ export class SpeechArbiter {
     this.#options = options;
   }
 
-  get quiet(): boolean {
-    return this.#quiet;
-  }
-
   get pendingCount(): number {
     return this.#pending.length;
   }

--- a/apps/desktop/src/renderer/luke-errand.test.ts
+++ b/apps/desktop/src/renderer/luke-errand.test.ts
@@ -10,7 +10,7 @@ import {
 } from "@sidecar/guide";
 import { REALTIME_VOICE, REALTIME_VOICE_SPEED } from "@sidecar/realtime";
 import { PANEL_FORM_FACTOR } from "@sidecar/surface";
-import { CREDENTIAL_SOURCE, SECRET_STORAGE } from "#shared/wire/account";
+import { ACCOUNT_STATUS, CREDENTIAL_SOURCE, SECRET_STORAGE } from "#shared/wire/account";
 import type { AppSettingsView } from "#shared/wire/settings";
 import { APP_SETTING_DEFAULTS, CLI_CONNECTION, VOICE_SOURCE } from "#shared/wire/settings";
 import { UPDATE_STATUS } from "#shared/wire/update";
@@ -63,6 +63,7 @@ function settings(): AppSettingsView {
 }
 
 const guideInput: LukeGuideInput = {
+  account: { status: ACCOUNT_STATUS.SIGNED_OUT },
   settings: settings(),
   update: {
     status: UPDATE_STATUS.IDLE,

--- a/apps/desktop/src/renderer/luke-guide.test.ts
+++ b/apps/desktop/src/renderer/luke-guide.test.ts
@@ -74,6 +74,7 @@ function idleUpdate(upToDate = false): UpdateSnapshot {
 
 function guideInput(overrides: Partial<LukeGuideInput> = {}): LukeGuideInput {
   return {
+    account: { status: ACCOUNT_STATUS.SIGNED_OUT },
     settings: settings(),
     update: idleUpdate(),
     voiceAvailable: true,

--- a/apps/desktop/src/renderer/luke-guide.ts
+++ b/apps/desktop/src/renderer/luke-guide.ts
@@ -86,8 +86,7 @@ const CONDUCTOR_DEFAULT_CHOICE = "Conductor's default";
 
 /** What the guide needs from the app to describe the current state of it. */
 export interface LukeGuideInput {
-  /** Optional only for pure callers that predate accounts; the app always supplies it. */
-  account?: AccountSnapshot;
+  account: AccountSnapshot;
   settings: AppSettingsView;
   /** Where the build stands, for the guide's Updates entry. */
   update: UpdateSnapshot;
@@ -349,7 +348,7 @@ function updateGuideEntry(update: UpdateSnapshot): AppGuideUpdate {
  * conversation always describes the app as it is, not as it launched.
  */
 export function buildLukeGuide(input: LukeGuideInput): AppGuideSnapshot {
-  const account = input.account ?? { status: ACCOUNT_STATUS.SIGNED_OUT };
+  const { account } = input;
   const facts: AppGuideFact[] = [
     {
       label: "What Luke is",

--- a/apps/desktop/src/renderer/notch-wings.test.ts
+++ b/apps/desktop/src/renderer/notch-wings.test.ts
@@ -1,13 +1,8 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import { wingMarkCapacity, wingPileOffset } from "@sidecar/panel";
 import { CAPSULE_SIDE_WIDTH, PANEL_WIDTH, PEEK_MIN_WIDTH } from "@sidecar/surface";
-import {
-  peekSideWidth,
-  signInLabelFit,
-  wingMarkCapacity,
-  wingPileOffset,
-  wingSlots,
-} from "./notch-wings";
+import { peekSideWidth, signInLabelFit, wingSlots } from "./notch-wings";
 import type { ProviderTally } from "./session-model";
 
 const panelSideWidth = (housingWidth: number) => (PANEL_WIDTH - housingWidth) / 2;

--- a/apps/desktop/src/renderer/notch-wings.tsx
+++ b/apps/desktop/src/renderer/notch-wings.tsx
@@ -69,14 +69,6 @@ interface NotchWingsProps {
 }
 
 /**
- * How many marks fit beside the face in a wing of this width. The peek's side
- * is 124px beside the housing it was measured against, which is where its
- * limit of four comes from; the panel's side is what is left of
- * `--panel-width` after the housing, so it holds roughly twice as many.
- */
-export { wingMarkCapacity, wingPileOffset } from "@sidecar/panel";
-
-/**
  * The peek's side beside this housing: what is left of the floored peek after
  * the housing splits it. Beside the 14-inch housing and anything wider this is
  * the 124px the wing was drawn at; a narrower housing — or the bubble's none —

--- a/apps/desktop/src/renderer/session-parts.tsx
+++ b/apps/desktop/src/renderer/session-parts.tsx
@@ -17,13 +17,6 @@ import {
 import { CloseIcon, CloudIcon, LaptopIcon, VoiceIcon } from "./settings-icons";
 
 /**
- * Rides beside a branch name to say which kind of identifier it is: a branch
- * name alone reads as any string of slashes. Ours rather than a brand, so it is
- * drawn in whatever text colour the line already has.
- */
-export { BranchGlyph } from "@sidecar/panel";
-
-/**
  * Rides beside a workspace's name to say what kind of thing the tray is. The
  * shape is the tray itself in miniature — one box with its name line across
  * the top — drawn in whatever text colour the line already has, like the
@@ -39,9 +32,6 @@ export function WorkspaceGlyph(): React.JSX.Element {
     </svg>
   );
 }
-
-/** Leads a finished session's sentence, the way a spinner leads a working one. */
-export { CheckGlyph } from "@sidecar/panel";
 
 export function EmptyState(): React.JSX.Element {
   return (

--- a/apps/desktop/src/renderer/styles/settings.css
+++ b/apps/desktop/src/renderer/styles/settings.css
@@ -157,24 +157,6 @@
   margin-left: auto;
 }
 
-/* A group heading that carries the group's reset: the words keep their line
-   and the control keeps the right edge the page head's reset keeps. The
-   button is pulled toward the heading's own height with negative margins so
-   the heading keeps the section's rhythm rather than growing a row of its
-   own around one control. */
-.settings-heading {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-}
-
-.settings-heading .settings-reset {
-  width: 22px;
-  height: 22px;
-  margin-top: -5px;
-  margin-bottom: -5px;
-}
-
 /* A reset's refusal takes the wrap's next line whole. */
 .settings-reset-refusal {
   flex-basis: 100%;

--- a/apps/desktop/src/renderer/voice/realtime-session.test.ts
+++ b/apps/desktop/src/renderer/voice/realtime-session.test.ts
@@ -792,7 +792,7 @@ test("a press during the handshake opens the turn it was asking for", async () =
   // it starts. The press opens the device beside the mint and is captured
   // from the moment it answers, so the turn opens on those words — as
   // appends, with the track joining the sender only when the turn is over.
-  context.session.toggleTurn();
+  context.session.beginTurn();
   await context.session.connect();
 
   assert.equal(context.session.status, REALTIME_STATUS.LISTENING);
@@ -801,25 +801,6 @@ test("a press during the handshake opens the turn it was asking for", async () =
   // the sender stays empty, so nothing rides the network before the commit.
   assert.equal(context.microphoneEnabled(), true);
   assert.deepEqual(context.replacedTracks(), []);
-});
-
-test("pressing twice during the handshake leaves no turn open", async () => {
-  const context = harness({ connectionDelayMs: 5 });
-
-  context.session.toggleTurn();
-  const opening = context.session.connect();
-  // Pressing again before the call is up cannot send anything — the microphone
-  // has not opened yet — so it takes back the press rather than queueing a turn
-  // that would commit an empty buffer.
-  context.session.toggleTurn();
-  await opening;
-
-  assert.equal(context.session.status, REALTIME_STATUS.READY);
-  assert.equal(context.microphoneEnabled(), false);
-  assert.deepEqual(
-    context.sent.filter((event) => event.type === REALTIME_CLIENT_EVENT.INPUT_AUDIO_BUFFER_COMMIT),
-    [],
-  );
 });
 
 test("words spoken into the handshake are carried into the turn it opens", async () => {
@@ -946,15 +927,17 @@ test("the words a failed attempt captured die with it", async () => {
   );
 });
 
-test("pressing twice during the handshake takes the words back with the press", async () => {
+test("a press let go over captured words before the call is up, discarding, takes them back", async () => {
   const context = harness({ connectionDelayMs: 5 });
 
-  context.session.toggleTurn();
+  context.session.beginTurn();
   const opening = context.session.connect();
   await deviceArrives();
   context.pressCaptures[0]?.feed([1]);
-  context.session.toggleTurn();
-  // The cancelled turn takes its words and its device with it.
+  // A discard while the handshake is still out has no channel to seal the
+  // words toward, so the turn takes them and its device with it rather than
+  // owing a delivery to the call that is about to come up.
+  context.session.endTurn(false);
   assert.equal(context.pressCaptures[0]?.stopped, true);
   assert.equal(context.microphoneStopped(), true);
   await opening;
@@ -1139,7 +1122,7 @@ test("a speak-only call captures nothing, however long a press waits", async () 
 test("a press does not outlive the call it failed to open", async () => {
   const context = harness({ connection: undefined });
 
-  context.session.toggleTurn();
+  context.session.beginTurn();
   assert.equal(await context.session.connect(), false);
   assert.equal(context.session.status, REALTIME_STATUS.UNAVAILABLE);
 
@@ -1154,9 +1137,8 @@ test("a press does not outlive the call it failed to open", async () => {
 test("a reply that runs out before the model says so still ends", async () => {
   const context = harness();
   await context.session.connect();
-  context.session.toggleTurn();
-  await deviceArrives();
-  context.session.toggleTurn();
+  await holdTurn(context);
+  context.session.endTurn(true);
   assert.equal(context.session.status, REALTIME_STATUS.RESPONDING);
 
   // Playback finishing and generation finishing have no fixed order. The meter
@@ -1440,9 +1422,8 @@ test("a call that never reports an ending still ends its replies", async () => {
 test("a pause mid-reply is not the reply running out", async () => {
   const context = harness();
   await context.session.connect();
-  context.session.toggleTurn();
-  await deviceArrives();
-  context.session.toggleTurn();
+  await holdTurn(context);
+  context.session.endTurn(true);
 
   // Long enough between two sentences for the meter to call it quiet, and then
   // he carries on. Ending here would take the meter and the face down with Luke
@@ -1507,9 +1488,8 @@ test("the quiet before Luke starts is not Luke going quiet", () => {
 test("a reply is not over when the model stops producing it", async () => {
   const context = harness();
   await context.session.connect();
-  context.session.toggleTurn();
-  await deviceArrives();
-  context.session.toggleTurn();
+  await holdTurn(context);
+  context.session.endTurn(true);
   assert.equal(context.session.status, REALTIME_STATUS.RESPONDING);
 
   // `response.done` says generation finished. The audio it produced is still
@@ -1524,9 +1504,8 @@ test("a reply is not over when the model stops producing it", async () => {
 test("quiet before the model has finished is a pause, not the end", async () => {
   const context = harness();
   await context.session.connect();
-  context.session.toggleTurn();
-  await deviceArrives();
-  context.session.toggleTurn();
+  await holdTurn(context);
+  context.session.endTurn(true);
 
   // Luke draws breath mid-sentence; the reply is still coming.
   context.session.reportRemoteAudioIdle();
@@ -1537,9 +1516,8 @@ test("quiet before the model has finished is a pause, not the end", async () => 
 test("a finished response returns the session to ready", async () => {
   const context = harness();
   await context.session.connect();
-  context.session.toggleTurn();
-  await deviceArrives();
-  context.session.toggleTurn();
+  await holdTurn(context);
+  context.session.endTurn(true);
 
   context.emit({ type: REALTIME_SERVER_EVENT.RESPONSE_DONE });
   context.session.reportRemoteAudioIdle();
@@ -1716,9 +1694,8 @@ test("an unexpected channel close releases the microphone", async () => {
 test("an error instead of response.done still frees the turn", async () => {
   const context = harness();
   await context.session.connect();
-  context.session.toggleTurn();
-  await deviceArrives();
-  context.session.toggleTurn();
+  await holdTurn(context);
+  context.session.endTurn(true);
   assert.equal(context.session.status, REALTIME_STATUS.RESPONDING);
 
   // An empty push-to-talk commit reports an error with no matching done.
@@ -2130,8 +2107,8 @@ test("a turn opens from an empty buffer and the key ends it", async () => {
   await context.session.connect();
   const sentAfterConnect = context.sent.length;
 
-  // One key: press to open a turn, press again to send it.
-  context.session.toggleTurn();
+  // One key: held to open a turn, released to send it.
+  context.session.beginTurn();
   await deviceArrives();
   assert.equal(context.session.status, REALTIME_STATUS.LISTENING);
   assert.equal(context.microphoneEnabled(), true);
@@ -2141,7 +2118,7 @@ test("a turn opens from an empty buffer and the key ends it", async () => {
     [REALTIME_CLIENT_EVENT.INPUT_AUDIO_BUFFER_CLEAR],
   );
 
-  context.session.toggleTurn();
+  context.session.endTurn(true);
   assert.equal(context.microphoneEnabled(), false);
   assert.deepEqual(
     context.sent.slice(sentAfterConnect).map((event) => event.type),
@@ -2315,16 +2292,15 @@ test("taking the turn silences Luke rather than only stopping generation", async
   const context = harness();
   await context.session.connect();
   context.deliverRemoteTrack();
-  context.session.toggleTurn();
-  await deviceArrives();
-  context.session.toggleTurn();
+  await holdTurn(context);
+  context.session.endTurn(true);
   assert.equal(context.session.status, REALTIME_STATUS.RESPONDING);
   // Audible once the server says the reply is under way, rather than when it
   // was asked for: until then anything arriving belongs to whatever came before.
   context.emit({ type: REALTIME_SERVER_EVENT.RESPONSE_CREATED });
   assert.equal(context.lukeAudible(), true);
 
-  context.session.toggleTurn();
+  context.session.beginTurn();
 
   // Cancelling stops the model producing more; it does not stop what is already
   // on its way down the connection. Only this end can — and at the press, not
@@ -2334,7 +2310,7 @@ test("taking the turn silences Luke rather than only stopping generation", async
   assert.equal(context.session.status, REALTIME_STATUS.LISTENING);
 
   // The next reply has to be audible again.
-  context.session.toggleTurn();
+  context.session.endTurn(true);
   context.emit({ type: REALTIME_SERVER_EVENT.RESPONSE_CREATED });
   assert.equal(context.lukeAudible(), true);
 });
@@ -2342,14 +2318,12 @@ test("taking the turn silences Luke rather than only stopping generation", async
 test("taking the turn cuts Luke off mid-reply", async () => {
   const context = harness();
   await context.session.connect();
-  context.session.toggleTurn();
-  await deviceArrives();
-  context.session.toggleTurn();
+  await holdTurn(context);
+  context.session.endTurn(true);
   assert.equal(context.session.status, REALTIME_STATUS.RESPONDING);
   context.sent.length = 0;
 
-  context.session.toggleTurn();
-  await deviceArrives();
+  await holdTurn(context);
 
   // The developer's turn always wins: the reply is stopped, not queued behind.
   assert.deepEqual(

--- a/apps/desktop/src/renderer/voice/realtime-session.ts
+++ b/apps/desktop/src/renderer/voice/realtime-session.ts
@@ -841,37 +841,6 @@ export class RealtimeVoiceSession {
     this.stopListening(commit);
   }
 
-  toggleTurn(): void {
-    // Until the device this press opens is live — and, before the call is up,
-    // the call too — there is no turn to take yet: the press is remembered
-    // and applied the moment there is. A second press cancels the first
-    // rather than queueing another, because two presses have always meant a
-    // turn opened and closed, and one that held nothing is one with nothing
-    // to send. A connected speak-only call is the waiting case too: Luke's
-    // own call cannot take a turn, so the press waits for the one that can.
-    if (!this.isConnected || !this.#microphone) {
-      this.#pendingTurn = !this.#pendingTurn;
-      if (this.#pendingTurn) {
-        // The same early cut a held press makes: the reply stops at the
-        // press, and the turn opens when the device arrives.
-        this.stopSpeaking();
-        this.#acquireMicrophone();
-      } else {
-        // The second press takes back the first: the words captured toward
-        // the cancelled turn go with it, and so does the device they were
-        // being read from.
-        this.#retirePressCapture();
-        if (this.#status !== REALTIME_STATUS.LISTENING) this.#releaseMicrophone();
-      }
-      return;
-    }
-    if (this.#status === REALTIME_STATUS.LISTENING) {
-      this.stopListening(true);
-      return;
-    }
-    this.startListening();
-  }
-
   /** Whether a call is being opened, so a press has something to wait for. */
   get isConnecting(): boolean {
     return this.#connecting !== undefined;
@@ -1123,28 +1092,23 @@ export class RealtimeVoiceSession {
       this.#acquireMicrophone();
       return;
     }
-    this.#flushHeldAudio(capture, "opened live");
+    this.#flushHeldAudio(capture);
     this.#listeningOnAppends = true;
     this.#turnEpoch += 1;
     this.#setStatus(REALTIME_STATUS.LISTENING);
   }
 
   /**
-   * Sends one captured turn's opening: the format the appends must be read
-   * as, a clean buffer, then everything the capture has held — and one line
-   * of diagnostics, because whether the held words actually left this machine
-   * is exactly what a report of Luke not hearing them needs answered. How
-   * much audio and nothing else: the words themselves stay out of the log.
+   * Sends one captured turn's opening, in the one order the service accepts
+   * it: the format the appends are to be read as, then a clear, then the
+   * held audio. Appends ahead of either are read against whatever the last
+   * turn left behind.
    */
-  #flushHeldAudio(capture: PressCaptureState, _how: string): void {
-    const _heldMs = Math.round(capture.buffer.bufferedMs);
-    const _droppedMs = Math.round(capture.buffer.droppedMs);
+  #flushHeldAudio(capture: PressCaptureState): void {
     this.#send(inputAudioFormatUpdateEvents());
     this.#send(clearInputAudioEvents());
-    let _appends = 0;
     for (const chunk of capture.buffer.drain()) {
       this.#send(inputAudioAppendEvents(chunk));
-      _appends += 1;
     }
   }
 
@@ -1164,7 +1128,7 @@ export class RealtimeVoiceSession {
       return;
     }
     this.#pressCommitPending = false;
-    this.#flushHeldAudio(capture, "delivered sealed");
+    this.#flushHeldAudio(capture);
     this.#retirePressCapture();
     // A turn exactly as a live commit is: the developer opened it by holding
     // the key and spoke into it; only the delivery waited.
@@ -2063,8 +2027,6 @@ export class RealtimeVoiceSession {
         this.#armSettleTimer();
         return;
       }
-      case REALTIME_SERVER_EVENT.CONVERSATION_ITEM_DELETED:
-        return;
       case REALTIME_SERVER_EVENT.ERROR:
         // Only Luke's own trim can draw a past-the-end refusal, the service
         // clamps and truncates anyway, and it names no event this could match

--- a/apps/desktop/src/shared/bridge.typecheck.ts
+++ b/apps/desktop/src/shared/bridge.typecheck.ts
@@ -1,8 +1,0 @@
-import { channels } from "./bridge";
-
-const bootstrapChannel: typeof channels.getBootstrap = channels.getBootstrap;
-void bootstrapChannel;
-
-// @ts-expect-error A method cannot be paired with another method's channel.
-const mismatchedChannel: typeof channels.getBootstrap = channels.beginSignIn;
-void mismatchedChannel;

--- a/apps/desktop/src/testing/ipc-fixtures.ts
+++ b/apps/desktop/src/testing/ipc-fixtures.ts
@@ -1,7 +1,0 @@
-import type { IpcMainInvokeEvent } from "electron";
-
-/** Fixture invoke event carrying only sender.id for trust validation. */
-export function invokeEvent(senderId: number): IpcMainInvokeEvent {
-  // SAFETY: Fixture invoke event carries only sender.id for trust validation.
-  return { sender: { id: senderId } } as IpcMainInvokeEvent;
-}

--- a/packages/realtime/src/realtime-protocol.ts
+++ b/packages/realtime/src/realtime-protocol.ts
@@ -74,8 +74,6 @@ export const REALTIME_CLIENT_EVENT = {
 
 export const REALTIME_SERVER_EVENT = {
   RESPONSE_CREATED: "response.created",
-  /** The server confirming a superseded context item is gone. */
-  CONVERSATION_ITEM_DELETED: "conversation.item.deleted",
   /** The server confirming it dropped the audio it had queued for us. */
   OUTPUT_AUDIO_BUFFER_CLEARED: "output_audio_buffer.cleared",
   /** Names the message a reply is being spoken into, which is what a truncate cuts. */
@@ -757,7 +755,6 @@ export type ParsedRealtimeServerEvent =
        */
       hasAudio?: boolean;
     }
-  | { type: typeof REALTIME_SERVER_EVENT.CONVERSATION_ITEM_DELETED; itemId?: string }
   /**
    * `eventId` names the client event the service is complaining about, when it
    * says. It is what lets a caller tell an error meant for the developer from
@@ -950,14 +947,6 @@ export function parseRealtimeServerEvent(
       };
       if (responseId) parsed.responseId = responseId;
       if (hasAudio !== undefined) parsed.hasAudio = hasAudio;
-      return parsed;
-    }
-    case REALTIME_SERVER_EVENT.CONVERSATION_ITEM_DELETED: {
-      const itemId = optionalString(event.item_id);
-      const parsed: ParsedRealtimeServerEvent = {
-        type: REALTIME_SERVER_EVENT.CONVERSATION_ITEM_DELETED,
-      };
-      if (itemId) parsed.itemId = itemId;
       return parsed;
     }
     case REALTIME_SERVER_EVENT.ERROR: {

--- a/packages/realtime/src/realtime.test.ts
+++ b/packages/realtime/src/realtime.test.ts
@@ -170,13 +170,6 @@ test("a refused delete is read back with the event it names", () => {
   assert.equal(parsed?.errorType, "invalid_request_error");
   assert.equal(parsed?.errorCode, "item_not_found");
   assert.match(parsed?.message ?? "", /not found/);
-
-  const deleted = parseRealtimeServerEvent({
-    type: REALTIME_SERVER_EVENT.CONVERSATION_ITEM_DELETED,
-    item_id: "luke_ctx_sessions_1",
-  });
-  assert.equal(deleted?.type, REALTIME_SERVER_EVENT.CONVERSATION_ITEM_DELETED);
-  assert.equal(deleted?.itemId, "luke_ctx_sessions_1");
 });
 
 test("a mint response yields a credential with a millisecond expiry", () => {

--- a/packages/runtime/src/gateway/delivery.ts
+++ b/packages/runtime/src/gateway/delivery.ts
@@ -103,10 +103,6 @@ export class DeliveryLedger<Words> {
     return delivery;
   }
 
-  state(runId: string): DeliveryState | undefined {
-    return this.#deliveries.get(runId)?.state;
-  }
-
   records(): readonly DeliveryRecord[] {
     return [...this.#deliveries.values()].map((delivery) => ({ ...delivery }));
   }


### PR DESCRIPTION
PR **B3** of the repo-wide cleanup plan. Pure deletion: files nothing imports, a keyboard toggle production replaced but never removed, diagnostics that log nothing, and accessors only tests read.

## What went

| Item | Why it was dead |
| --- | --- |
| `apps/desktop/src/testing/ipc-fixtures.ts` | No importer anywhere |
| `apps/desktop/src/shared/bridge.typecheck.ts` | No importer anywhere |
| `.settings-heading` / `.settings-heading .settings-reset` (`settings.css`) | Matched no element the panel draws |
| `RealtimeSession.toggleTurn()` + 28 test refs | The one-key latch `beginTurn`/`endTurn` replaced; no production caller |
| `#flushHeldAudio`'s `_how`/`_heldMs`/`_droppedMs`/`_appends` and its docblock | Four values computed for a log line that was never written |
| `conversation.item.deleted` (session case, `REALTIME_SERVER_EVENT` entry, union member, parse case) | The session's case returned; nothing read the parsed event |
| `BrainReplyDeliveries.state()` and `DeliveryLedger.state()` | Read only by `service.test.ts`; the wrapper was the ledger method's only caller |
| `SpeechArbiter.quiet` | Read by one assertion of a freshly built arbiter's default |
| `LukeGuideInput.account?` → required, and the signed-out default it carried | Optional "for pure callers that predate accounts"; both callers supply it |
| `export type { UnparsedWireValue }` (`main/ipc/settings-rows.ts`) | Re-export with no importer |
| `BranchGlyph`, `CheckGlyph` re-exports (`session-parts.tsx`) | Re-exports with no importer; `@sidecar/panel` holds their rationale |
| `wingMarkCapacity`, `wingPileOffset` re-exports (`notch-wings.tsx`) | Read only by the colocated test, which now imports `@sidecar/panel` directly |

`toggleTurn`'s paired test call sites become the hold and release the talk key actually produces (`holdTurn`/`endTurn(true)`), and the two tests written for the latch's own second-press cancel go with it — production has no such press.

One of those two, though, was the only test reaching `endTurn`'s discard-before-the-channel-opens branch with words already captured. That is a live branch of a surviving API, so it is converted rather than lost: **"a press let go over captured words before the call is up, discarding, takes them back."** Verified by mutation — deleting `#retirePressCapture()` from that branch fails this test and no other. The no-words half of the deleted pair is already covered by `endTurn(true)`'s empty-capture drop.

`#flushHeldAudio`'s docblock now carries the constraint the code cannot — appends must follow the format update and the clear — instead of promising a diagnostic log.

## Four items in the assignment I did not delete

Each is exported or public solely for a test, but in each case the test is a cross-file reconciliation the export exists to make possible, so deleting the symbol deletes a guarantee rather than dead weight. Flagging rather than removing:

- **`BrainHost.settled()`** — the only observation of the transition queue's quiescence. Twelve assertions in `host.test.ts` and `credential-transition.test.ts` (the newer-transition-wins guarantees) synchronize on it; `#chain` is private, and `replace()`'s own step does not cover a transition started inside an `atNextReport` hook.
- **`SpeechArbiter.pendingCount` / `.offeredId`** — the only observation of the backlog and the held offer, and the plan's own "Not changed, and why" list keeps `speech-arbiter.ts` as the single home of a `CLAUDE.md` guarantee. ~35 assertions read them; there is no other seam, and the trace only reports at a decision.
- **`SETTINGS_PAGE_LABEL`** — the table `luke-errand.test.ts` reconciles against `SETTING_PAGE`, for the invariant a `Record` cannot enforce: "the page each setting lives on is stated twice … and the two have to be the same answer."
- **`POSTHOG_ASSETS_HOST`** — what `session-replay.test.ts` reconciles `index.html`'s `connect-src` against. Deleting the export leaves the CSP checked against a literal in the test rather than against the host the recorder documents deriving.

`BrainReplyDeliveries.unclaimed()` is a fifth near-miss that I deleted and then restored during my own review: replacing it duplicated its one filter into two sibling test files and grew the repository. `state()` went because its replacement is a single `find` in a single test file, which also let `DeliveryLedger.state()` go.

## Verification

- `./scripts/check.sh`: green (lint, typecheck, test, build). `fail 0` across every package.
- `git grep` finds no reference to any removed symbol or file.
- Not a UI PR under the plan, and `verify.sh` needs a Mac this cloud workspace does not have; CI's **macOS app and evidence** job passed and covers the packaged validation. The one surface file touched is `settings.css`, and the two rules removed from it selected a class no TSX emits (`git grep settings-heading` returned only those two CSS lines before, and returns nothing now), so nothing drawn changes. **No physical-notch check was performed.**
- I downloaded and inspected this run's `app-visual-evidence-791` fixture PNGs. The expanded panel still draws a branch glyph on every row and the check glyph on the complete session, and the peek still spreads three provider marks flat beside the housing — the three symbols whose dead renderer re-exports this PR removes, rendering unchanged from `@sidecar/panel` internally. No settings page is in the fixture set, so the `.settings-heading` claim rests on the grep rather than on a capture.
- `git diff --shortstat origin/main...`: `19 files changed, 60 insertions(+), 206 deletions(-)`
- Running total (TS/TSX/MJS), rebased onto `origin/main` at `640017b`: 206,223 → **206,095** (−128), against the plan's ~125k target.

## Trust constraints

None touched. The reply-grant ledger keeps every state and every guarantee test; the speech arbiter's holding behaviour is untouched; `conversation.item.deleted` was a confirmation the session already discarded, so nothing observed, spoken, or written changes; and no provider file, transcript, or credential path is in the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34292918026/artifacts/10082111202) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34292918026)

- Commit: `72aa820bce534cdfa1dca206a4adac7ad220b58d`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->


