### PR TITLE
feat(ios): uncover conversation timestamps with a sideways pull

### DIFF
--- a/apps/ios/Luke/VoiceView.swift
+++ b/apps/ios/Luke/VoiceView.swift
@@ -808,31 +808,35 @@ struct VoiceView: View {
 /// trailing edge, which the pull brings in the way iMessage uncovers a
 /// message's time. The stamp is the row's, not the bubble's, so sent and
 /// received stand in one column. A sent bubble rides the pull, moving left
-/// to make the room the way a sent bubble does in iMessage; Luke's words
-/// stand still, because the room the column takes on their side is room the
-/// row already had spare, and nothing of his is ever pushed off the screen.
+/// to make the room the way a sent bubble does in iMessage, and stops where
+/// iMessage's does: with its trailing edge on the line the widest received
+/// bubble's trailing edge reaches, the two sides squared up and the stamps
+/// standing at the thread's edge beside them. Luke's words stand still,
+/// because the room the column takes on their side is room the row already
+/// had spare, and nothing of his is ever pushed off the screen.
 private struct StampedMessageRow: View {
     let message: VoiceConversationMessage
     let pull: CGFloat
 
-    /// Room for the widest stamp a twelve-hour clock draws, and the inset it
-    /// keeps from the screen's edge once uncovered.
-    static let timeColumn: CGFloat = 56
+    /// Room for the widest stamp a twelve-hour clock draws at this size, and
+    /// the inset it keeps from the thread's edge once uncovered.
+    private static let timeColumn: CGFloat = 48
     private static let stampInset: CGFloat = 4
     /// The thread's horizontal inset, which the column rests behind.
     private static let threadInset: CGFloat = 16
     /// The margin the shared bubbles keep on their far side.
     private static let bubbleMargin: CGFloat = 48
-    /// How far the column travels to stand fully in view: its own width and
-    /// the inset it rests behind.
-    static let reveal: CGFloat = timeColumn + threadInset
-    /// What a sent bubble leaves free beyond its own margin, so a long ask
-    /// riding the full pull stops at the screen's leading edge rather than
-    /// through it; only the resistance past the reveal carries it further.
+    /// What Luke's bubble leaves free beyond its own margin: the stop is set
+    /// so that a full pull squares a sent bubble's trailing edge with the
+    /// widest received bubble's, and this is what puts the received edge far
+    /// enough in that the uncovered column, its inset, and a gap fit beside it.
+    private static let receivedRoom: CGFloat = 20
+    /// How far the pull travels before it stops: the column and the inset it
+    /// rests behind, so the stamps arrive exactly as the edges square up.
+    static let reveal: CGFloat = bubbleMargin + receivedRoom
+    /// What a sent bubble leaves free beyond its own margin, so the full pull
+    /// stops it at the screen's leading edge rather than carrying it through.
     private static let sentRoom: CGFloat = reveal - bubbleMargin - threadInset
-    /// What Luke's bubble leaves free beyond its own margin, so a long reply
-    /// and the stamp uncovered beside it never share a pixel.
-    private static let receivedRoom: CGFloat = timeColumn + stampInset - bubbleMargin
 
     var body: some View {
         ZStack(alignment: .trailing) {

--- a/apps/ios/Luke/VoiceView.swift
+++ b/apps/ios/Luke/VoiceView.swift
@@ -815,20 +815,31 @@ private struct StampedMessageRow: View {
     let message: VoiceConversationMessage
     let pull: CGFloat
 
-    /// Room for the widest stamp a twelve-hour clock draws.
+    /// Room for the widest stamp a twelve-hour clock draws, and the inset it
+    /// keeps from the screen's edge once uncovered.
     static let timeColumn: CGFloat = 56
+    private static let stampInset: CGFloat = 4
+    /// The thread's horizontal inset, which the column rests behind.
+    private static let threadInset: CGFloat = 16
+    /// The margin the shared bubbles keep on their far side.
+    private static let bubbleMargin: CGFloat = 48
     /// How far the column travels to stand fully in view: its own width and
-    /// the thread's trailing inset it rests behind.
-    static let reveal: CGFloat = timeColumn + 16
+    /// the inset it rests behind.
+    static let reveal: CGFloat = timeColumn + threadInset
+    /// What a sent bubble leaves free beyond its own margin, so a long ask
+    /// riding the full pull stops at the screen's leading edge rather than
+    /// through it; only the resistance past the reveal carries it further.
+    private static let sentRoom: CGFloat = reveal - bubbleMargin - threadInset
     /// What Luke's bubble leaves free beyond its own margin, so a long reply
     /// and the stamp uncovered beside it never share a pixel.
-    private static let receivedRoom: CGFloat = 12
+    private static let receivedRoom: CGFloat = timeColumn + stampInset - bubbleMargin
 
     var body: some View {
         ZStack(alignment: .trailing) {
             switch message.speaker {
             case .developer:
                 DeveloperMessageBubble(words: message.words)
+                    .padding(.leading, Self.sentRoom)
                     .offset(x: -pull)
             case .luke:
                 AgentMessageBubble(words: message.words)
@@ -840,7 +851,7 @@ private struct StampedMessageRow: View {
                 .foregroundStyle(Color.inkTertiary)
                 .lineLimit(1)
                 .frame(width: Self.timeColumn, alignment: .trailing)
-                .padding(.trailing, 4)
+                .padding(.trailing, Self.stampInset)
                 .offset(x: Self.reveal - pull)
         }
     }

--- a/apps/ios/Luke/VoiceView.swift
+++ b/apps/ios/Luke/VoiceView.swift
@@ -273,6 +273,10 @@ struct VoiceView: View {
     // Guards the double-send window while an ask is reopening the call; the
     // send button alone cannot, because a disabled state lands a render late.
     @State private var typedAskInFlight = false
+    // The sideways pull that uncovers the thread's stamps, and whether the
+    // drag under way is the pull's or the scroll's, decided at its first move.
+    @State private var timePull: CGFloat = 0
+    @State private var pullClaimed: Bool?
     @FocusState private var composing: Bool
     // The keyboard button and composer are the two shapes of one control.
     @Namespace private var glassNamespace
@@ -429,15 +433,8 @@ struct VoiceView: View {
             ScrollView {
                 VStack(spacing: 14) {
                     ForEach(conversation.messages) { message in
-                        Group {
-                            switch message.speaker {
-                            case .developer:
-                                DeveloperMessageBubble(words: message.words)
-                            case .luke:
-                                AgentMessageBubble(words: message.words)
-                            }
-                        }
-                        .id(message.id)
+                        StampedMessageRow(message: message, pull: timePull)
+                            .id(message.id)
                     }
                 }
                 .frame(maxWidth: .infinity, alignment: .top)
@@ -449,6 +446,7 @@ struct VoiceView: View {
                 .padding(.bottom, 200)
             }
             .scrollDismissesKeyboard(.interactively)
+            .simultaneousGesture(timePullGesture)
             .onChange(of: conversation.messages) {
                 guard let last = conversation.messages.last else { return }
                 withAnimation { proxy.scrollTo(last.id, anchor: .bottom) }
@@ -472,6 +470,32 @@ struct VoiceView: View {
         }
         .frame(maxHeight: .infinity)
         .animation(.easeInOut(duration: 0.15), value: conversation.messages.isEmpty)
+    }
+
+    /// The pull rides beside the scroll rather than replacing it. A drag that
+    /// starts mostly sideways is the pull's for its whole length, and one that
+    /// starts mostly upright is the scroll's, decided once at the first
+    /// movement so a finger drifting mid-pull never hands the column back.
+    /// The lift is what puts the column away, on a spring, the way iMessage's
+    /// snaps back the moment the fingers leave.
+    private var timePullGesture: some Gesture {
+        DragGesture(minimumDistance: 8)
+            .onChanged { value in
+                let claimed =
+                    pullClaimed
+                    ?? ConversationTimePull.claimsDrag(
+                        width: value.translation.width, height: value.translation.height
+                    )
+                pullClaimed = claimed
+                guard claimed else { return }
+                timePull = ConversationTimePull.distance(
+                    dragged: value.translation.width, reveal: StampedMessageRow.reveal
+                )
+            }
+            .onEnded { _ in
+                pullClaimed = nil
+                withAnimation(.spring(duration: 0.35)) { timePull = 0 }
+            }
     }
 
     private var bottomControls: some View {
@@ -774,6 +798,50 @@ struct VoiceView: View {
         case .listening: return "Listening…"
         case .thinking: return "Thinking…"
         case .speaking: return "Speaking…"
+        }
+    }
+}
+
+// MARK: - Timestamps
+
+/// One line of the thread with its stamp in the column past the screen's
+/// trailing edge, which the pull brings in the way iMessage uncovers a
+/// message's time. The stamp is the row's, not the bubble's, so sent and
+/// received stand in one column. A sent bubble rides the pull, moving left
+/// to make the room the way a sent bubble does in iMessage; Luke's words
+/// stand still, because the room the column takes on their side is room the
+/// row already had spare, and nothing of his is ever pushed off the screen.
+private struct StampedMessageRow: View {
+    let message: VoiceConversationMessage
+    let pull: CGFloat
+
+    /// Room for the widest stamp a twelve-hour clock draws.
+    static let timeColumn: CGFloat = 56
+    /// How far the column travels to stand fully in view: its own width and
+    /// the thread's trailing inset it rests behind.
+    static let reveal: CGFloat = timeColumn + 16
+    /// What Luke's bubble leaves free beyond its own margin, so a long reply
+    /// and the stamp uncovered beside it never share a pixel.
+    private static let receivedRoom: CGFloat = 12
+
+    var body: some View {
+        ZStack(alignment: .trailing) {
+            switch message.speaker {
+            case .developer:
+                DeveloperMessageBubble(words: message.words)
+                    .offset(x: -pull)
+            case .luke:
+                AgentMessageBubble(words: message.words)
+                    .padding(.trailing, Self.receivedRoom)
+            }
+            Text(message.recordedAt, format: .dateTime.hour().minute())
+                .font(.caption2)
+                .monospacedDigit()
+                .foregroundStyle(Color.inkTertiary)
+                .lineLimit(1)
+                .frame(width: Self.timeColumn, alignment: .trailing)
+                .padding(.trailing, 4)
+                .offset(x: Self.reveal - pull)
         }
     }
 }

--- a/apps/ios/LukeKit/Sources/LukeKit/ConversationTimePull.swift
+++ b/apps/ios/LukeKit/Sources/LukeKit/ConversationTimePull.swift
@@ -3,15 +3,13 @@ import Foundation
 /// The sideways pull that uncovers the thread's timestamps, the way iMessage
 /// does: the stamps stand in a column past the screen's trailing edge, and a
 /// drag to the left brings the column in by exactly the distance dragged
-/// until the column stands fully in view, past which the drag meets
-/// resistance and gives only a little more, so the fingers feel where the
-/// column ends. A drag to the right pulls nothing. The arithmetic lives here,
-/// off the screen, so the phone and the watch pull the same way and a test
-/// can say so.
+/// until the column stands fully in view, where the pull stops. It stops
+/// rather than yielding, because the stop is where the sent bubbles' edges
+/// line up with the received ones' and the stamps stand at the thread's
+/// edge, a place worth holding still at. A drag to the right pulls nothing.
+/// The arithmetic lives here, off the screen, so the phone and the watch
+/// pull the same way and a test can say so.
 public enum ConversationTimePull {
-    /// How much of a drag past the column's full reveal still moves it.
-    public static let overshootFraction = 0.2
-
     /// Whether a drag is the pull's rather than the scroll's, read from its
     /// first movement: mostly sideways is a pull, mostly upright a scroll.
     public static func claimsDrag(width: Double, height: Double) -> Bool {
@@ -20,11 +18,8 @@ public enum ConversationTimePull {
 
     /// How far the column stands in for a drag whose horizontal translation
     /// is `translation` (negative to the left, as the system reports it),
-    /// given the distance `reveal` at which it stands fully in view.
+    /// given the distance `reveal` at which it stands fully in view and stops.
     public static func distance(dragged translation: Double, reveal: Double) -> Double {
-        let pulled = -translation
-        guard pulled > 0 else { return 0 }
-        guard pulled > reveal else { return pulled }
-        return reveal + (pulled - reveal) * overshootFraction
+        min(max(-translation, 0), reveal)
     }
 }

--- a/apps/ios/LukeKit/Sources/LukeKit/ConversationTimePull.swift
+++ b/apps/ios/LukeKit/Sources/LukeKit/ConversationTimePull.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+/// The sideways pull that uncovers the thread's timestamps, the way iMessage
+/// does: the stamps stand in a column past the screen's trailing edge, and a
+/// drag to the left brings the column in by exactly the distance dragged
+/// until the column stands fully in view, past which the drag meets
+/// resistance and gives only a little more, so the fingers feel where the
+/// column ends. A drag to the right pulls nothing. The arithmetic lives here,
+/// off the screen, so the phone and the watch pull the same way and a test
+/// can say so.
+public enum ConversationTimePull {
+    /// How much of a drag past the column's full reveal still moves it.
+    public static let overshootFraction = 0.2
+
+    /// Whether a drag is the pull's rather than the scroll's, read from its
+    /// first movement: mostly sideways is a pull, mostly upright a scroll.
+    public static func claimsDrag(width: Double, height: Double) -> Bool {
+        abs(width) > abs(height)
+    }
+
+    /// How far the column stands in for a drag whose horizontal translation
+    /// is `translation` (negative to the left, as the system reports it),
+    /// given the distance `reveal` at which it stands fully in view.
+    public static func distance(dragged translation: Double, reveal: Double) -> Double {
+        let pulled = -translation
+        guard pulled > 0 else { return 0 }
+        guard pulled > reveal else { return pulled }
+        return reveal + (pulled - reveal) * overshootFraction
+    }
+}

--- a/apps/ios/LukeKit/Sources/LukeKit/VoiceConversationThread.swift
+++ b/apps/ios/LukeKit/Sources/LukeKit/VoiceConversationThread.swift
@@ -20,13 +20,22 @@ public struct VoiceConversationMessage: Identifiable, Equatable, Sendable {
     /// the context re-feed can lead with the same distinction the desktop's
     /// history keeps.
     public let typed: Bool
+    /// The instant this line was first recorded, the desktop's own stamp
+    /// transcribed: a caption keeps the moment its first words arrived
+    /// however long it goes on streaming, and a late transcript stands at the
+    /// moment it landed, not the press it answers. The screen's clock alone,
+    /// never sent anywhere.
+    public let recordedAt: Date
 
-    public init(turnId: UUID, speaker: Speaker, words: String, typed: Bool = false) {
+    public init(
+        turnId: UUID, speaker: Speaker, words: String, typed: Bool = false, recordedAt: Date = Date()
+    ) {
         id = UUID()
         self.turnId = turnId
         self.speaker = speaker
         self.words = words
         self.typed = typed
+        self.recordedAt = recordedAt
     }
 }
 
@@ -53,8 +62,13 @@ public final class VoiceConversationThread {
 
     private var activeTurnId: UUID?
     private var activeResponseMessageId: UUID?
+    /// The clock every line is stamped from; injected so a test can say what
+    /// time it is.
+    private let now: () -> Date
 
-    public init() {}
+    public init(now: @escaping () -> Date = Date.init) {
+        self.now = now
+    }
 
     /// Marks a developer press: the ask and reply that follow belong to one
     /// turn, which is what lets a transcript arriving late find its place.
@@ -81,7 +95,9 @@ public final class VoiceConversationThread {
             if !messages[index].typed { messages[index].words = words }
             return
         }
-        let message = VoiceConversationMessage(turnId: turnId, speaker: .developer, words: words)
+        let message = VoiceConversationMessage(
+            turnId: turnId, speaker: .developer, words: words, recordedAt: now()
+        )
         if let responseIndex = messages.firstIndex(where: {
             $0.turnId == turnId && $0.speaker == .luke
         }) {
@@ -102,7 +118,8 @@ public final class VoiceConversationThread {
         beginTurn()
         messages.append(
             VoiceConversationMessage(
-                turnId: currentTurnId(), speaker: .developer, words: words, typed: true
+                turnId: currentTurnId(), speaker: .developer, words: words, typed: true,
+                recordedAt: now()
             )
         )
         retainRecentMessages()
@@ -124,7 +141,8 @@ public final class VoiceConversationThread {
         let message = VoiceConversationMessage(
             turnId: currentTurnId(),
             speaker: .luke,
-            words: text
+            words: text,
+            recordedAt: now()
         )
         messages.append(message)
         activeResponseMessageId = message.id

--- a/apps/ios/LukeKit/Tests/LukeKitTests/ConversationTimePullTests.swift
+++ b/apps/ios/LukeKit/Tests/LukeKitTests/ConversationTimePullTests.swift
@@ -13,8 +13,9 @@ final class ConversationTimePullTests: XCTestCase {
         XCTAssertEqual(ConversationTimePull.distance(dragged: 40, reveal: 72), 0)
     }
 
-    func testADragPastTheRevealMeetsResistance() {
-        XCTAssertEqual(ConversationTimePull.distance(dragged: -122, reveal: 72), 82)
+    func testADragPastTheRevealStopsAtIt() {
+        XCTAssertEqual(ConversationTimePull.distance(dragged: -122, reveal: 72), 72)
+        XCTAssertEqual(ConversationTimePull.distance(dragged: -400, reveal: 72), 72)
     }
 
     func testAMostlySidewaysDragIsThePulls() {

--- a/apps/ios/LukeKit/Tests/LukeKitTests/ConversationTimePullTests.swift
+++ b/apps/ios/LukeKit/Tests/LukeKitTests/ConversationTimePullTests.swift
@@ -1,0 +1,26 @@
+import XCTest
+
+@testable import LukeKit
+
+final class ConversationTimePullTests: XCTestCase {
+    func testADragToTheLeftPullsTheColumnInByItsOwnDistance() {
+        XCTAssertEqual(ConversationTimePull.distance(dragged: -30, reveal: 72), 30)
+        XCTAssertEqual(ConversationTimePull.distance(dragged: -72, reveal: 72), 72)
+    }
+
+    func testADragToTheRightPullsNothing() {
+        XCTAssertEqual(ConversationTimePull.distance(dragged: 0, reveal: 72), 0)
+        XCTAssertEqual(ConversationTimePull.distance(dragged: 40, reveal: 72), 0)
+    }
+
+    func testADragPastTheRevealMeetsResistance() {
+        XCTAssertEqual(ConversationTimePull.distance(dragged: -122, reveal: 72), 82)
+    }
+
+    func testAMostlySidewaysDragIsThePulls() {
+        XCTAssertTrue(ConversationTimePull.claimsDrag(width: -20, height: 5))
+        XCTAssertTrue(ConversationTimePull.claimsDrag(width: 20, height: -5))
+        XCTAssertFalse(ConversationTimePull.claimsDrag(width: -5, height: 20))
+        XCTAssertFalse(ConversationTimePull.claimsDrag(width: 10, height: 10))
+    }
+}

--- a/apps/ios/LukeKit/Tests/LukeKitTests/VoiceConversationThreadTests.swift
+++ b/apps/ios/LukeKit/Tests/LukeKitTests/VoiceConversationThreadTests.swift
@@ -109,6 +109,33 @@ final class VoiceConversationThreadTests: XCTestCase {
         XCTAssertEqual(thread.messages.map(\.words), ["After"])
     }
 
+    func testEveryLineIsStampedWhenFirstRecorded() {
+        var clock = Date(timeIntervalSince1970: 1_000)
+        let thread = VoiceConversationThread(now: { clock })
+        thread.beginTurn()
+        thread.recordCaption("Working")
+        clock = Date(timeIntervalSince1970: 1_005)
+        thread.recordCaption("Working on it")
+        clock = Date(timeIntervalSince1970: 1_010)
+        thread.recordSpokenAsk("How are the tests?")
+        clock = Date(timeIntervalSince1970: 1_020)
+        thread.recordTypedAsk("Open the Codex session")
+        XCTAssertEqual(
+            thread.messages.map(\.recordedAt.timeIntervalSince1970),
+            [1_010, 1_000, 1_020]
+        )
+    }
+
+    func testAFullerTranscriptionKeepsTheAsksFirstStamp() {
+        var clock = Date(timeIntervalSince1970: 1_000)
+        let thread = VoiceConversationThread(now: { clock })
+        thread.beginTurn()
+        thread.recordSpokenAsk("How are")
+        clock = Date(timeIntervalSince1970: 1_003)
+        thread.recordSpokenAsk("How are the tests?")
+        XCTAssertEqual(thread.messages.map(\.recordedAt.timeIntervalSince1970), [1_000])
+    }
+
     func testRetentionDropsTheOldestLines() {
         let thread = VoiceConversationThread()
         for index in 0 ..< (VoiceConversationThread.maximumRetainedMessages + 5) {


### PR DESCRIPTION
First of four PRs bringing the desktop's conversation timestamps to the phone and the watch; this one is the phone's per-message stamps. It sits on main directly and does not depend on #795.

## What changes

- **`VoiceConversationMessage.recordedAt`** (LukeKit): every line of the thread now carries the instant it was first recorded, the desktop's own `recordedAt` transcribed. A streaming caption keeps the moment its first words arrived; a fuller transcription of a spoken ask keeps the ask's first stamp; a late transcript stands at the moment it landed. `VoiceConversationThread` takes an injectable clock (`init(now:)`) so the tests can say what time it is. Nothing here is sent anywhere: the stamp is the screen's alone and never enters the conversation context re-fed to a call.
- **`ConversationTimePull`** (LukeKit): the pull arithmetic, shared with the watch PR that follows. A drag to the left brings the stamp column in by exactly the distance dragged until it stands fully in view, where the pull stops; a drag to the right pulls nothing; a drag is claimed as a pull or left to the scroll by whether its first movement was mostly sideways.
- **`VoiceView`**: each message is drawn as a `StampedMessageRow` with its time (`hour().minute()`, the reader's locale) in a 48pt column resting past the screen's trailing edge, behind the thread's 16pt inset. A `simultaneousGesture` on the scroll view drives the pull; the lift springs the column back the way iMessage's does. As on the desktop, the developer's bubbles ride the pull and move left to make the room, while Luke's bubbles stand still: the space to the right of a received bubble is room the row already had, and nothing of his is pushed off the screen.
- **The stop.** The pull travels 68pt and stops there, which is exactly where a sent bubble's trailing edge lands on the line the widest received bubble's trailing edge reaches, the way iMessage squares the two sides up. Luke's bubbles keep 20pt more trailing room than before to put that line far enough in that the uncovered column, its inset, and a 16pt gap fit beside it; the constants in `StampedMessageRow` are derived from one another so the arithmetic is on the page.

## Beside #795

Nothing here depends on the rename in #795. The two touch adjacent lines in `VoiceView.swift` and `WatchVoiceView.swift` (this stack adds state beside the `actClient` property #795 renames), so whichever lands second takes a one-line rebase.

## Verified

- `swift test` on the LukeKit package, on a Mac with Xcode 26.6: 292 tests, 0 failures.
- iOS `Luke` scheme built for the iOS simulator (`xcodebuild ... -destination generic/platform=iOS Simulator`): BUILD SUCCEEDED.
- CI runs no Swift job; the Electron checks are unaffected by these Swift-only changes.

## To test on a phone

Say or type a few things to Luke, then drag the thread to the left: your bubbles slide over and every line's time appears at the right edge; let go and it snaps back. A vertical scroll should feel unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34296203052/artifacts/10083290471) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34296203052)

- Commit: `f8e2f832f5988b6561a45a98ac380fba8510f8ca`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->