### PR TITLE
feat(watch): uncover conversation timestamps with a sideways pull

### DIFF
--- a/apps/ios/LukeWatch/LukeWatchView.swift
+++ b/apps/ios/LukeWatch/LukeWatchView.swift
@@ -27,15 +27,19 @@ struct LukeWatchView: View {
 
     private var signedInPages: some View {
         @Bindable var navigation = navigation
+        // The list stands to the left of Luke, and Luke is still the page the
+        // watch opens on: a swipe to the right reaches the sessions, and a
+        // swipe to the left over the thread is the pull that uncovers its
+        // times, which the two pages would otherwise contest.
         return TabView(selection: $navigation.page) {
-            NavigationStack {
-                WatchVoiceView()
-            }
-            .tag(WatchPage.voice)
             NavigationStack(path: $navigation.path) {
                 WatchRosterView()
             }
             .tag(WatchPage.sessions)
+            NavigationStack {
+                WatchVoiceView()
+            }
+            .tag(WatchPage.voice)
         }
         .tabViewStyle(.page)
         // The pages and the stack above the list are the signed-in

--- a/apps/ios/LukeWatch/WatchVoiceView.swift
+++ b/apps/ios/LukeWatch/WatchVoiceView.swift
@@ -17,6 +17,10 @@ struct WatchVoiceView: View {
     @State private var model = WatchVoiceSessionModel()
     @State private var isPressing = false
     @State private var settingsShown = false
+    // The sideways pull that uncovers the thread's stamps, and whether the
+    // drag under way is the pull's or the scroll's, decided at its first move.
+    @State private var timePull: CGFloat = 0
+    @State private var pullClaimed: Bool?
     private let actClient = ActClient(baseURL: AccountConstants.serviceURL)
 
     var body: some View {
@@ -114,7 +118,7 @@ struct WatchVoiceView: View {
                             .opacity(model.status == .connecting ? 0.4 : 1)
                     } else {
                         ForEach(conversation.messages) { message in
-                            WatchVoiceBubble(message: message)
+                            WatchVoiceBubble(message: message, pull: timePull)
                                 .id(message.id)
                         }
                     }
@@ -126,6 +130,7 @@ struct WatchVoiceView: View {
                 .padding(.bottom, 88)
                 .frame(maxWidth: .infinity)
             }
+            .simultaneousGesture(timePullGesture)
             .onChange(of: conversation.messages) {
                 guard let last = conversation.messages.last else { return }
                 withAnimation { proxy.scrollTo(last.id, anchor: .bottom) }
@@ -137,6 +142,30 @@ struct WatchVoiceView: View {
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    /// The pull rides beside the scroll rather than replacing it, as on the
+    /// phone: a drag that starts mostly sideways is the pull's for its whole
+    /// length, one that starts mostly upright is the scroll's, and the lift
+    /// springs the column back. The crown still scrolls throughout.
+    private var timePullGesture: some Gesture {
+        DragGesture(minimumDistance: 8)
+            .onChanged { value in
+                let claimed =
+                    pullClaimed
+                    ?? ConversationTimePull.claimsDrag(
+                        width: value.translation.width, height: value.translation.height
+                    )
+                pullClaimed = claimed
+                guard claimed else { return }
+                timePull = ConversationTimePull.distance(
+                    dragged: value.translation.width, reveal: WatchVoiceBubble.reveal
+                )
+            }
+            .onEnded { _ in
+                pullClaimed = nil
+                withAnimation(.spring(duration: 0.35)) { timePull = 0 }
+            }
     }
 
     // MARK: - Floating controls
@@ -266,22 +295,47 @@ struct WatchVoiceView: View {
 
 // MARK: - Message bubble
 
+/// One line of the thread with its stamp in the column past the screen's
+/// trailing edge, which the pull brings in the way iMessage uncovers a
+/// message's time. The watch's screen is too narrow for a received bubble to
+/// keep room spare beside it, so here both sides ride the pull and move left
+/// together, Luke's words running off the leading edge for as long as the
+/// fingers hold; the phone, with room to the right of his bubbles, leaves
+/// them standing.
 private struct WatchVoiceBubble: View {
     let message: VoiceConversationMessage
+    let pull: CGFloat
+
+    /// Room for the widest stamp a twelve-hour clock draws at this size.
+    static let timeColumn: CGFloat = 48
+    /// How far the column travels to stand fully in view: its own width and
+    /// the thread's trailing inset it rests behind.
+    static let reveal: CGFloat = timeColumn + 4
 
     private var isDeveloper: Bool { message.speaker == .developer }
 
     var body: some View {
-        Text(message.words)
-            .font(.system(size: 13))
-            .foregroundStyle(isDeveloper ? Color.white : Color.primary)
-            .multilineTextAlignment(.leading)
-            .padding(.horizontal, 9)
-            .padding(.vertical, 7)
-            .background {
-                RoundedRectangle(cornerRadius: 12)
-                    .fill(isDeveloper ? Color.accentColor : Color.secondary.opacity(0.18))
-            }
-            .frame(maxWidth: .infinity, alignment: isDeveloper ? .trailing : .leading)
+        ZStack(alignment: .trailing) {
+            Text(message.words)
+                .font(.system(size: 13))
+                .foregroundStyle(isDeveloper ? Color.white : Color.primary)
+                .multilineTextAlignment(.leading)
+                .padding(.horizontal, 9)
+                .padding(.vertical, 7)
+                .background {
+                    RoundedRectangle(cornerRadius: 12)
+                        .fill(isDeveloper ? Color.accentColor : Color.secondary.opacity(0.18))
+                }
+                .frame(maxWidth: .infinity, alignment: isDeveloper ? .trailing : .leading)
+                .offset(x: -pull)
+            Text(message.recordedAt, format: .dateTime.hour().minute())
+                .font(.system(size: 10))
+                .monospacedDigit()
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+                .frame(width: Self.timeColumn, alignment: .trailing)
+                .padding(.trailing, 2)
+                .offset(x: Self.reveal - pull)
+        }
     }
 }

--- a/apps/ios/LukeWatch/WatchVoiceView.swift
+++ b/apps/ios/LukeWatch/WatchVoiceView.swift
@@ -301,16 +301,22 @@ struct WatchVoiceView: View {
 /// keep room spare beside it, so here both sides ride the pull and move left
 /// together, Luke's words running off the leading edge for as long as the
 /// fingers hold; the phone, with room to the right of his bubbles, leaves
-/// them standing.
+/// them standing. The pull stops the moment the column stands fully in, the
+/// least travel that shows every stamp whole, because every point further is
+/// more of the words off the screen for nothing.
 private struct WatchVoiceBubble: View {
     let message: VoiceConversationMessage
     let pull: CGFloat
 
-    /// Room for the widest stamp a twelve-hour clock draws at this size.
-    static let timeColumn: CGFloat = 48
-    /// How far the column travels to stand fully in view: its own width and
-    /// the thread's trailing inset it rests behind.
-    static let reveal: CGFloat = timeColumn + 4
+    /// Room for the widest stamp a twelve-hour clock draws at this size, and
+    /// the inset it keeps from the thread's edge once uncovered.
+    private static let timeColumn: CGFloat = 44
+    private static let stampInset: CGFloat = 2
+    /// The thread's horizontal inset, which the column rests behind.
+    private static let threadInset: CGFloat = 4
+    /// How far the pull travels before it stops: the column and the inset it
+    /// rests behind, which is exactly what stands it fully in view.
+    static let reveal: CGFloat = timeColumn + stampInset + threadInset
 
     private var isDeveloper: Bool { message.speaker == .developer }
 
@@ -334,7 +340,7 @@ private struct WatchVoiceBubble: View {
                 .foregroundStyle(.secondary)
                 .lineLimit(1)
                 .frame(width: Self.timeColumn, alignment: .trailing)
-                .padding(.trailing, 2)
+                .padding(.trailing, Self.stampInset)
                 .offset(x: Self.reveal - pull)
         }
     }


### PR DESCRIPTION
Stacked on #799 (which is on main, independent of #795). Second of four: the watch's per-message stamps.

## What changes

- **`WatchVoiceView`**: each message is drawn as a `WatchVoiceBubble` with its time (`hour().minute()`, the reader's locale, 10pt) in a 44pt column resting past the screen's trailing edge, behind the thread's 4pt inset. A `simultaneousGesture` on the scroll view drives the pull through the same `ConversationTimePull` arithmetic #799 added to LukeKit; the lift springs the column back. The crown scrolls throughout. The pull stops at 50pt, the moment the column stands fully in view: the least travel that shows every stamp whole, since on the watch every point further is more of the words off the screen for nothing.
- **`LukeWatchView`**: the sessions page moves to the left of the voice page, and the watch still opens on Luke (`WatchNavigation.page` defaults to `.voice`). A swipe to the right reaches the list and a swipe to the left over the thread is the pull alone; with the list on the right, the two contested the same gesture and the list could not be reached.
- **Both sides move.** The watch's screen is too narrow for a received bubble to keep room spare beside it, so unlike the phone, Luke's bubbles ride the pull too and run off the leading edge for as long as the fingers hold. This is the deliberate difference from #799.

No LukeKit change: the stamp and the pull arithmetic arrive with #799.

## Verified

- `LukeWatch` scheme built for the watchOS simulator on a Mac with Xcode 26.6 (`xcodebuild ... -destination generic/platform=watchOS Simulator`): BUILD SUCCEEDED.
- CI runs no Swift job; the Electron checks are unaffected.

## To test on a watch

Talk to Luke a couple of times, then drag the thread to the left: every bubble slides over and each line's time appears at the right edge; let go and it snaps back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/c235ba9b-a02d-452a-aa66-34e101c622bf)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34296885814/artifacts/10083512029) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34296885814)

- Commit: `131dbaaadb925efbcdb22d90da10fc1eb46ee1b0`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->