### PR TITLE
feat(ios): date the conversation after a long silence

### DIFF
--- a/apps/ios/Luke/VoiceView.swift
+++ b/apps/ios/Luke/VoiceView.swift
@@ -277,6 +277,11 @@ struct VoiceView: View {
     // drag under way is the pull's or the scroll's, decided at its first move.
     @State private var timePull: CGFloat = 0
     @State private var pullClaimed: Bool?
+    // The instant the thread's dates are read against, so a line from earlier
+    // today says Today and one from last week says which day. It moves when a
+    // line lands, when the screen appears, and at midnight, and at no other
+    // time, because nothing else can change what a date should say.
+    @State private var now = Date()
     @FocusState private var composing: Bool
     // The keyboard button and composer are the two shapes of one control.
     @Namespace private var glassNamespace
@@ -432,7 +437,14 @@ struct VoiceView: View {
         ScrollViewReader { proxy in
             ScrollView {
                 VStack(spacing: 14) {
-                    ForEach(conversation.messages) { message in
+                    ForEach(Array(conversation.messages.enumerated()), id: \.element.id) {
+                        index, message in
+                        if ConversationTimeBreak.opens(
+                            after: index == 0 ? nil : conversation.messages[index - 1].recordedAt,
+                            recordedAt: message.recordedAt
+                        ) {
+                            ConversationTimeBreakLabel(recordedAt: message.recordedAt, now: now)
+                        }
                         StampedMessageRow(message: message, pull: timePull)
                             .id(message.id)
                     }
@@ -448,13 +460,18 @@ struct VoiceView: View {
             .scrollDismissesKeyboard(.interactively)
             .simultaneousGesture(timePullGesture)
             .onChange(of: conversation.messages) {
+                now = Date()
                 guard let last = conversation.messages.last else { return }
                 withAnimation { proxy.scrollTo(last.id, anchor: .bottom) }
             }
             .onAppear {
+                now = Date()
                 if let last = conversation.messages.last {
                     proxy.scrollTo(last.id, anchor: .bottom)
                 }
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .NSCalendarDayChanged)) { _ in
+                now = Date()
             }
         }
         .overlay {
@@ -858,5 +875,27 @@ private struct StampedMessageRow: View {
                 .padding(.trailing, Self.stampInset)
                 .offset(x: Self.reveal - pull)
         }
+    }
+}
+
+/// The moment a line was said, set over it the way iMessage dates a message
+/// that followed a long silence. It is the thread's line, not a message: it
+/// reads in the quiet voice of a caption, centered, and it stands still under
+/// the pull as Luke's rows do, so uncovering the stamp column never pushes a
+/// date off the screen.
+private struct ConversationTimeBreakLabel: View {
+    let recordedAt: Date
+    let now: Date
+
+    var body: some View {
+        let label = ConversationTimeBreak.label(recordedAt: recordedAt, now: now)
+        return (Text(label.day).fontWeight(.semibold) + Text(" \(label.time)"))
+            .font(.caption2)
+            .monospacedDigit()
+            .foregroundStyle(Color.inkTertiary)
+            .multilineTextAlignment(.center)
+            .frame(maxWidth: .infinity)
+            .padding(.top, 4)
+            .accessibilityElement(children: .combine)
     }
 }

--- a/apps/ios/LukeKit/Sources/LukeKit/ConversationTimeBreak.swift
+++ b/apps/ios/LukeKit/Sources/LukeKit/ConversationTimeBreak.swift
@@ -1,0 +1,62 @@
+import Foundation
+
+/// The date set over a line that followed a long silence, the way iMessage
+/// dates a message that followed a long break. The desktop's rule
+/// transcribed, so the three screens agree on when a break opens and how it
+/// is worded.
+public enum ConversationTimeBreak {
+    /// How long a silence between two recorded lines has to be before the
+    /// thread names the moment the next one was said. An hour is iMessage's
+    /// own threshold: closer than that, a message answers the one before it,
+    /// and the row's own stamp in the pull column is enough.
+    public static let silence: TimeInterval = 60 * 60
+
+    /// The past week's weekdays are unambiguous by name; a week on they are not.
+    private static let weekdayNameDays = 7
+
+    /// Whether the line recorded at `recordedAt` opens a break: the thread's
+    /// first line always does, since the date of what the reader is looking
+    /// at is the whole question, and a later one does when the silence before
+    /// it reached the threshold.
+    public static func opens(after previousRecordedAt: Date?, recordedAt: Date) -> Bool {
+        guard let previousRecordedAt else { return true }
+        return recordedAt.timeIntervalSince(previousRecordedAt) >= silence
+    }
+
+    public struct Label: Equatable, Sendable {
+        /// The day, as a reader would name it: Today, Yesterday, a weekday, or a date.
+        public let day: String
+        /// The clock time on that day.
+        public let time: String
+    }
+
+    /// Names the moment a break's line was said, read against `now`. The day
+    /// is relative only while relative is exact — Today, Yesterday, then the
+    /// weekday for the rest of the past week — and a date after that, with
+    /// the year once the year is not this one, because the thread exists to
+    /// say what date an old line is from and a bare weekday a fortnight on
+    /// says nothing. The calendar decides the day the way the reader's clock
+    /// does, so an evening line is dated by the reader's evening, not UTC's.
+    public static func label(
+        recordedAt: Date, now: Date, calendar: Calendar = .current, locale: Locale = .current
+    ) -> Label {
+        let style = Date.FormatStyle(locale: locale, calendar: calendar, timeZone: calendar.timeZone)
+        let daysAgo =
+            calendar.dateComponents(
+                [.day], from: calendar.startOfDay(for: recordedAt), to: calendar.startOfDay(for: now)
+            ).day ?? 0
+        let day: String
+        if daysAgo == 0 {
+            day = "Today"
+        } else if daysAgo == 1 {
+            day = "Yesterday"
+        } else if daysAgo > 1, daysAgo < weekdayNameDays {
+            day = recordedAt.formatted(style.weekday(.wide))
+        } else if calendar.component(.year, from: recordedAt) == calendar.component(.year, from: now) {
+            day = recordedAt.formatted(style.weekday(.abbreviated).month(.abbreviated).day())
+        } else {
+            day = recordedAt.formatted(style.month(.abbreviated).day().year())
+        }
+        return Label(day: day, time: recordedAt.formatted(style.hour().minute()))
+    }
+}

--- a/apps/ios/LukeKit/Tests/LukeKitTests/ConversationTimeBreakTests.swift
+++ b/apps/ios/LukeKit/Tests/LukeKitTests/ConversationTimeBreakTests.swift
@@ -1,0 +1,66 @@
+import Foundation
+import XCTest
+
+@testable import LukeKit
+
+final class ConversationTimeBreakTests: XCTestCase {
+    private let now = Date(timeIntervalSince1970: 1_788_888_600) // 2026-09-08T17:30:00Z
+    private let minute: TimeInterval = 60
+    private let day: TimeInterval = 24 * 60 * 60
+
+    private var calendar: Calendar {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(identifier: "America/Los_Angeles")!
+        calendar.locale = Locale(identifier: "en_US")
+        return calendar
+    }
+
+    private func label(_ recordedAt: Date) -> ConversationTimeBreak.Label {
+        let label = ConversationTimeBreak.label(
+            recordedAt: recordedAt, now: now, calendar: calendar, locale: Locale(identifier: "en_US")
+        )
+        // Foundation sets a narrow no-break space before the period on some
+        // systems; the words are what the test is about.
+        return .init(day: label.day, time: label.time.replacingOccurrences(of: "\u{202F}", with: " "))
+    }
+
+    func testTheFirstLineOpensABreakAndASilenceOfAnHourOpensTheNext() {
+        XCTAssertTrue(ConversationTimeBreak.opens(after: nil, recordedAt: now))
+        XCTAssertFalse(ConversationTimeBreak.opens(after: now, recordedAt: now + 59 * minute))
+        XCTAssertTrue(
+            ConversationTimeBreak.opens(after: now, recordedAt: now + ConversationTimeBreak.silence)
+        )
+        XCTAssertTrue(ConversationTimeBreak.opens(after: now, recordedAt: now + day))
+    }
+
+    func testALineFromTodayIsNamedByItsTimeAloneUnderToday() {
+        XCTAssertEqual(label(now - 3 * 60 * minute), .init(day: "Today", time: "7:30 AM"))
+    }
+
+    func testTheCalendarDayIsReadInTheReadersZoneNotUTC() {
+        // 03:00 UTC on the 8th is still the evening of the 7th in Los Angeles.
+        XCTAssertEqual(
+            label(Date(timeIntervalSince1970: 1_788_836_400)),
+            .init(day: "Yesterday", time: "8:00 PM")
+        )
+    }
+
+    func testThePastWeeksDaysAreNamedByWeekdayAndAWeekOnByDate() {
+        XCTAssertEqual(label(now - 2 * day).day, "Sunday")
+        XCTAssertEqual(label(now - 6 * day).day, "Wednesday")
+        XCTAssertEqual(label(now - 7 * day).day, "Tue, Sep 1")
+        XCTAssertEqual(label(now - 14 * day).day, "Tue, Aug 25")
+    }
+
+    func testALineFromAnotherYearCarriesTheYear() {
+        // 2025-12-31T20:15:00Z
+        XCTAssertEqual(
+            label(Date(timeIntervalSince1970: 1_767_212_100)),
+            .init(day: "Dec 31, 2025", time: "12:15 PM")
+        )
+    }
+
+    func testAStampAheadOfTheClockIsDatedRatherThanCalledToday() {
+        XCTAssertEqual(label(now + 2 * day).day, "Thu, Sep 10")
+    }
+}


### PR DESCRIPTION
Stacked on #801 (→ #799 → main, independent of #795). Third of four: the phone's centered date labels over a long gap.

## What changes

- **`ConversationTimeBreak`** (LukeKit): the desktop's `conversation-time-break.ts` transcribed, shared with the watch PR that follows. A break opens over the thread's first line and over any line that followed an hour or more of silence (iMessage's own threshold). Its label names the day the way a reader would: Today, Yesterday, the weekday for the rest of the past week, then `Tue, Sep 1` within the year and `Dec 31, 2025` outside it, with the clock time beside it; the calendar day is read in the reader's zone, not UTC, and a stamp ahead of the clock is dated rather than called Today. The tests are the desktop's tests, case for case.
- **`VoiceView`**: a `ConversationTimeBreakLabel` is drawn over each line that opens a break, centered, day in semibold and time beside it, in the caption voice. It stands still under the pull, as Luke's rows do, so uncovering the stamp column never pushes a date off the screen. The `now` the dates are read against moves when a line lands, when the screen appears, and at midnight (`NSCalendarDayChanged`), and at no other time.

## Verified

- `swift test` on the LukeKit package, on a Mac with Xcode 26.6: 298 tests, 0 failures (six of them the new `ConversationTimeBreakTests`).
- iOS `Luke` scheme built for the iOS simulator (`xcodebuild ... -destination generic/platform=iOS Simulator`): BUILD SUCCEEDED.
- CI runs no Swift job; the Electron checks are unaffected.

## To test on a phone

Open the voice screen with a conversation from earlier: a **Today** line stands over the first message, and another over any message that came an hour or more after the one before it. A conversation from yesterday reads **Yesterday**. Drag left to reveal the times: the date labels stay put.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/c235ba9b-a02d-452a-aa66-34e101c622bf)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34299032738/artifacts/10084269389) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34299032738)

- Commit: `857a11a460d74fb725a57cc3ebbe1da4ad01d809`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->