### PR TITLE
feat(watch): date the conversation after a long silence

### DIFF
--- a/apps/ios/LukeWatch/WatchVoiceView.swift
+++ b/apps/ios/LukeWatch/WatchVoiceView.swift
@@ -21,6 +21,11 @@ struct WatchVoiceView: View {
     // drag under way is the pull's or the scroll's, decided at its first move.
     @State private var timePull: CGFloat = 0
     @State private var pullClaimed: Bool?
+    // The instant the thread's dates are read against, so a line from earlier
+    // today says Today and one from last week says which day. It moves when a
+    // line lands, when the page appears, and at midnight, and at no other
+    // time, because nothing else can change what a date should say.
+    @State private var now = Date()
     private let actClient = ActClient(baseURL: AccountConstants.serviceURL)
 
     var body: some View {
@@ -117,7 +122,14 @@ struct WatchVoiceView: View {
                             .frame(maxWidth: .infinity, minHeight: 80, alignment: .center)
                             .opacity(model.status == .connecting ? 0.4 : 1)
                     } else {
-                        ForEach(conversation.messages) { message in
+                        ForEach(Array(conversation.messages.enumerated()), id: \.element.id) {
+                            index, message in
+                            if ConversationTimeBreak.opens(
+                                after: index == 0 ? nil : conversation.messages[index - 1].recordedAt,
+                                recordedAt: message.recordedAt
+                            ) {
+                                WatchTimeBreakLabel(recordedAt: message.recordedAt, now: now)
+                            }
                             WatchVoiceBubble(message: message, pull: timePull)
                                 .id(message.id)
                         }
@@ -132,13 +144,18 @@ struct WatchVoiceView: View {
             }
             .simultaneousGesture(timePullGesture)
             .onChange(of: conversation.messages) {
+                now = Date()
                 guard let last = conversation.messages.last else { return }
                 withAnimation { proxy.scrollTo(last.id, anchor: .bottom) }
             }
             .onAppear {
+                now = Date()
                 if let last = conversation.messages.last {
                     proxy.scrollTo(last.id, anchor: .bottom)
                 }
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .NSCalendarDayChanged)) { _ in
+                now = Date()
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -343,5 +360,29 @@ private struct WatchVoiceBubble: View {
                 .padding(.trailing, Self.stampInset)
                 .offset(x: Self.reveal - pull)
         }
+    }
+}
+
+// MARK: - Time break
+
+/// The moment a line was said, set over it the way iMessage dates a message
+/// that followed a long silence, worded by the rule the phone and the desktop
+/// share. It is the thread's line, not a message: centered, in the quiet
+/// voice of the status label, and standing still under the pull, so
+/// uncovering the stamp column never pushes a date off the screen.
+private struct WatchTimeBreakLabel: View {
+    let recordedAt: Date
+    let now: Date
+
+    var body: some View {
+        let label = ConversationTimeBreak.label(recordedAt: recordedAt, now: now)
+        return (Text(label.day).fontWeight(.semibold) + Text(" \(label.time)"))
+            .font(.system(size: 10))
+            .monospacedDigit()
+            .foregroundStyle(.secondary)
+            .multilineTextAlignment(.center)
+            .frame(maxWidth: .infinity)
+            .padding(.top, 4)
+            .accessibilityElement(children: .combine)
     }
 }


### PR DESCRIPTION
Stacked on #802 (→ #801 → #799 → main, independent of #795). Fourth of four: the watch's centered date labels over a long gap.

## What changes

- **`WatchVoiceView`**: a `WatchTimeBreakLabel` is drawn over the thread's first line and over any line that followed an hour or more of silence, deciding and wording it through the `ConversationTimeBreak` rule #802 added to LukeKit, so the watch, the phone, and the desktop date a conversation identically. Centered, 10pt, day in semibold with the time beside it, in the secondary color the status label uses. It stands still under the pull, so uncovering the stamp column never pushes a date off the screen. The `now` the dates are read against moves when a line lands, when the page appears, and at midnight (`NSCalendarDayChanged`), and at no other time.

No LukeKit change: the rule and its tests arrive with #802.

## Verified

- `LukeWatch` scheme built for the watchOS simulator on a Mac with Xcode 26.6 (`xcodebuild ... -destination generic/platform=watchOS Simulator`): BUILD SUCCEEDED.
- CI runs no Swift job; the Electron checks are unaffected.

## To test on a watch

Open the voice page with a conversation from earlier: a **Today** line stands over the first message, and another over any message that came an hour or more after the one before it. Drag left to reveal the times: the date labels stay put.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/c235ba9b-a02d-452a-aa66-34e101c622bf)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34299819935/artifacts/10084561384) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34299819935)

- Commit: `f1f954683eb990cb26bed82a214863c122259369`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->