### PR TITLE
fix(ios): build the workspace sheet against the optional model default

### DIFF
--- a/apps/ios/Luke/WorkspaceCreatorSheet.swift
+++ b/apps/ios/Luke/WorkspaceCreatorSheet.swift
@@ -216,7 +216,7 @@ struct WorkspaceCreatorSheet: View {
             stored.effort == nil || option.efforts.contains(stored.effort ?? "")
         {
             agentKind = stored.agent
-            modelId = stored.model
+            modelId = stored.model ?? ""
             effort = stored.effort
         } else {
             agentKind = nil


### PR DESCRIPTION
Main's iOS app has not compiled since #775 landed: `WorkspaceAgentDefault.model` became `String?` in LukeKit, and `WorkspaceCreatorSheet.selectProvider` still assigns it to the sheet's `String` model id.

```
apps/ios/Luke/WorkspaceCreatorSheet.swift:219:30: error: value of optional type 'String?' must be unwrapped to a value of type 'String'
```

One line: an absent stored model reads as no selection, the same empty id the sheet starts an agent kind with (`modelId = ""` two branches down). Nothing else changes.

CI runs no Swift job, which is how this reached main; the iOS `Luke` scheme was built and its tests run on a Mac with Xcode 26.6 for this branch (results in the comment below once they finish).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34297090558/artifacts/10083583146) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34297090558)

- Commit: `285fc915820ddb4b6e86a361b9a9a34b230d15c7`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
