### PR TITLE
feat(acts): admit() mints the only ValidatedAct

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,9 +120,12 @@ Trust constraints:
   it, or the same two acts asked of Luke, out loud or typed into his own
   composer, in a conversation the user is holding, each through the
   provider's own documented endpoint under the same user-supplied credential,
-  and each validated against the observed roster, and against that session's
-  own advertisement of the acts its provider documents for it now, before an
-  adapter sees it.
+  and each admitted against the observed roster, and against that session's
+  own advertisement of the acts its provider documents for it now, by
+  `@sidecar/acts`'s `admit()` — the one function that mints the validated act,
+  reading the roster for itself rather than taking a caller's copy of it — and
+  by the layers beneath it that still hold the same rule until they are
+  deleted, before an adapter sees it.
   Observation passes stay read-only by construction; where a provider's
   documented read answers only a POSTed query (Conductor's transcripts view,
   like Linear's GraphQL), observation sends a read document fixed by the
@@ -890,9 +893,9 @@ Trust constraints:
   here. The two acts a tracker takes, moving an issue to a state its latest
   observation listed and adding a comment, happen only as the direct product of
   a turn the developer opened themselves, through the tracker's own documented
-  endpoint under the same grant, validated against the observed issue roster
-  in the renderer and again in the main process before the tracker client sees
-  anything. Observation sends only the read document; the write documents are
+  endpoint under the same grant, admitted against the observed issue roster by
+  the same `admit()` every session act runs, and validated again in the main
+  process before the tracker client sees anything. Observation sends only the read document; the write documents are
   fixed by the build and issued only for a validated act.
 - The calendar is the same rule with no write path at all. Luke reads when
   the user's meetings start and end, under accounts the user signed in, and

--- a/apps/desktop/src/main/brain/act-performer.test.ts
+++ b/apps/desktop/src/main/brain/act-performer.test.ts
@@ -407,6 +407,41 @@ test("an act is validated against the roster as refreshed inside the turn, not a
   assert.deepEqual(performed, []);
 });
 
+test("a creation is admitted against the projects the same pass reported, and the pass runs once", async () => {
+  let projects: readonly ObservedWorkspaceProject[] = [];
+  let passes = 0;
+  const { acts, performed } = performer({
+    workspaceProjects: () => projects,
+    refreshSessions: async () => {
+      passes += 1;
+      // The project is only offered once an observation pass has run.
+      projects = [LISTED_PROJECT];
+    },
+  });
+  const created = await acts.perform(CREATE_CALL, LIVE);
+  assert.equal(created.status, ACT_RESULT_STATUS.ACCEPTED);
+  assert.equal(passes, 1);
+  assert.deepEqual(
+    performed.map((act) => act.kind),
+    [ACT_KIND.CREATE_WORKSPACE],
+  );
+});
+
+test("an issue act observes nothing: no pass runs for an act the roster cannot answer for", async () => {
+  let passes = 0;
+  const { acts } = performer({
+    refreshSessions: async () => {
+      passes += 1;
+    },
+  });
+  const refused = await acts.perform(
+    { name: REALTIME_TOOL.COMMENT_ON_ISSUE, argumentsJson: "{}" },
+    LIVE,
+  );
+  assert.equal(refused.status, ACT_RESULT_STATUS.REJECTED);
+  assert.equal(passes, 0);
+});
+
 test("a cancel during the roster refresh or the defaults read settles the act, and the late read dispatches nothing", async () => {
   for (const held of ["refreshSessions", "workspaceDefaults"] as const) {
     let release: (() => void) | undefined;

--- a/apps/desktop/src/main/brain/act-performer.test.ts
+++ b/apps/desktop/src/main/brain/act-performer.test.ts
@@ -1,8 +1,9 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import {
-  type CarriedIssueAction,
-  type CarriedSessionAction,
+  ACT_REFUSAL,
+  type CarriedIssueAct,
+  type CarriedSessionAct,
   REALTIME_TOOL,
   type RememberedFact,
 } from "@sidecar/acts";
@@ -10,7 +11,14 @@ import type { BrainActExecution } from "@sidecar/brain";
 import { APP_SETTING_KIND, EMPTY_APP_GUIDE } from "@sidecar/guide";
 import type { ConversationEntry } from "@sidecar/realtime";
 import { RUN_ORIGIN } from "@sidecar/runtime-contracts";
-import { ACT_KIND, normalizeSession, SESSION_STATUS, type Session } from "@sidecar/session";
+import {
+  ACT_KIND,
+  normalizeSession,
+  type ObservedWorkspaceProject,
+  SESSION_STATUS,
+  type Session,
+  WORKSPACE_TASK_SUPPORT,
+} from "@sidecar/session";
 import { ACT_RESULT_STATUS } from "@sidecar/wire";
 import type { BrainAppActRequest } from "#shared/messages/brain";
 import { type BrainActPerformerDependencies, createBrainActPerformer } from "./act-performer";
@@ -66,6 +74,18 @@ const SETTING_CALL = {
   name: REALTIME_TOOL.CHANGE_APP_SETTING,
   argumentsJson: '{"setting_id":"voice_captions","value":"on"}',
 };
+/** The one act whose admission reads the saved creation defaults as well as the roster. */
+const CREATE_CALL = {
+  name: REALTIME_TOOL.CREATE_WORKSPACE,
+  argumentsJson: '{"provider_id":"conductor","project_id":"luke"}',
+};
+const LISTED_PROJECT: ObservedWorkspaceProject = {
+  providerId: "conductor",
+  providerName: "Conductor",
+  providerProjectId: "luke",
+  repository: "luke",
+  taskSupport: WORKSPACE_TASK_SUPPORT.OPTIONAL,
+};
 
 const observed = normalizeSession(
   { id: "claude-code", displayName: "Claude Code" },
@@ -79,7 +99,7 @@ const observed = normalizeSession(
 );
 
 function performer(overrides: Partial<BrainActPerformerDependencies> = {}) {
-  const performed: (CarriedSessionAction | CarriedIssueAction)[] = [];
+  const performed: (CarriedSessionAct | CarriedIssueAct)[] = [];
   const recorded: ConversationEntry[] = [];
   const appActs: BrainAppActRequest["action"][] = [];
   let facts: readonly RememberedFact[] = [];
@@ -339,7 +359,7 @@ test("a turn revoked while the roster refreshed is refused before the effect, an
     developerTurn(() => revoked),
   );
   assert.equal(refused.status, ACT_RESULT_STATUS.REJECTED);
-  assert.ok(String(refused.reason).includes("over"));
+  assert.equal(refused.reason, ACT_REFUSAL.TURN_OVER);
   assert.deepEqual(performed, []);
   assert.deepEqual(recorded, []);
 });
@@ -347,13 +367,14 @@ test("a turn revoked while the roster refreshed is refused before the effect, an
 test("a turn revoked while the creation defaults were read is refused before the effect", async () => {
   let revoked = false;
   const { acts, performed, recorded } = performer({
+    workspaceProjects: () => [LISTED_PROJECT],
     workspaceDefaults: async () => {
       revoked = true;
       return {};
     },
   });
   const refused = await acts.perform(
-    MESSAGE_CALL,
+    CREATE_CALL,
     developerTurn(() => revoked),
   );
   assert.equal(refused.status, ACT_RESULT_STATUS.REJECTED);
@@ -393,6 +414,7 @@ test("a cancel during the roster refresh or the defaults read settles the act, a
       release = resolve;
     });
     const h = performer({
+      workspaceProjects: () => [LISTED_PROJECT],
       [held]: async () => {
         await gate;
         return {};
@@ -405,7 +427,12 @@ test("a cancel during the roster refresh or the defaults read settles the act, a
       isRevoked: () => controller.signal.aborted,
       signal: controller.signal,
     };
-    const pending = h.acts.perform(MESSAGE_CALL, execution);
+    // Only a creation reads the defaults, so each held read is exercised by the
+    // act that actually waits on it.
+    const pending = h.acts.perform(
+      held === "refreshSessions" ? MESSAGE_CALL : CREATE_CALL,
+      execution,
+    );
     let settled = false;
     void pending.then(() => {
       settled = true;

--- a/apps/desktop/src/main/brain/act-performer.ts
+++ b/apps/desktop/src/main/brain/act-performer.ts
@@ -1,22 +1,16 @@
 import { randomUUID } from "node:crypto";
 import {
-  APP_TOOL_KIND,
-  appToolAction,
-  type CarriedAppAction,
+  ACT_KIND,
+  ACT_REFUSAL,
+  type AdmitContext,
   dispatchByKind,
-  issueToolAction,
-  REALTIME_TOOL_FAMILY,
   type RealtimeFunctionCall,
-  type RealtimeToolFamily,
   type RememberedFact,
-  realtimeToolFamily,
-  sessionToolAction,
+  type SessionActKind,
+  toolAction,
+  type ValidatedAct,
 } from "@sidecar/acts";
-import {
-  type BrainActExecution,
-  type BrainActPerformer,
-  settledUnlessAborted,
-} from "@sidecar/brain";
+import type { BrainActExecution, BrainActPerformer } from "@sidecar/brain";
 import type { AppGuideSnapshot } from "@sidecar/guide";
 import type { TrackedIssue } from "@sidecar/issues";
 import {
@@ -76,10 +70,11 @@ export interface BrainActPerformerDependencies {
 }
 
 const REFUSAL = {
-  NO_SUCH_TOOL: "No such tool exists.",
   NO_EXECUTION: "Not run: an act needs the standing of a turn.",
-  TURN_OVER: "Not run: the turn that asked for this act is over.",
-  NO_TRACKER: "No issue tracker is connected.",
+  // One sentence for a turn that ended, wherever it is noticed: here before
+  // admission runs, inside admission after each read of its own, and in the
+  // performer at the last boundary before an effect.
+  TURN_OVER: ACT_REFUSAL.TURN_OVER,
   MEMORY_NOT_SAVED: "That memory could not be saved.",
   MEMORY_NOT_REMOVED: "That memory could not be removed.",
 } as const;
@@ -90,58 +85,63 @@ function rejection(reason: string): WireRecord {
 
 /**
  * The gauntlet every act the brain asks for runs, in the main process: the
- * call is validated against the roster, the issue board, the offered
- * projects, the guide, or the remembered facts — the same validators the
- * voice's own tool calls once ran in the renderer — and only a validated act
- * reaches the performer that carries it. The brain is another way to ask,
- * never a wider one: a call that names a session Luke was not shown, a
- * project no adapter offers, or a setting the guide does not list is refused
- * with a reason the brain can read.
+ * call is admitted by `admit`, against the roster it reads for itself, the
+ * issue board, the offered projects, the guide, or the remembered facts, and
+ * only the validated act it mints reaches the performer that carries it. The
+ * brain is another way to ask, never a wider one: a call that names a session
+ * Luke was not shown, a project no adapter offers, or a setting the guide does
+ * not list is refused with a reason the brain can read.
  *
  * Before any of that, the act has to arrive with a turn's standing: an
- * execution context the brain built for the turn that emitted the call,
- * naming the run and who opened it. Whether the act may run at all was the
- * tool policy's decision before the call left the brain; here the context is
- * what says the turn still stands, and it is asked again after every step
- * awaited and once more just before the effect, so an act whose turn ended
- * while the roster was refreshing is refused rather than dispatched. A call
- * with no context or a malformed one is refused before a validator runs. The
- * origin decides only how History records the act: at the developer's ask,
- * or as Luke's own judgment in a turn nobody asked him anything in.
+ * execution context the brain built for the turn that emitted the call, naming
+ * the run and who opened it. Whether the act may run at all was the tool
+ * policy's decision before the call left the brain; here the context is what
+ * says the turn still stands, and admission asks it again after every read of
+ * its own, so an act whose turn ended while the roster was refreshing is
+ * refused rather than dispatched. A call with no context or a malformed one is
+ * refused before admission runs. The origin decides only how History records
+ * the act: at the developer's ask, or as Luke's own judgment in a turn nobody
+ * asked him anything in.
  */
 export function createBrainActPerformer(
   dependencies: BrainActPerformerDependencies,
 ): BrainActPerformer {
-  const performSession = async (
-    call: RealtimeFunctionCall,
+  const admissionContext = (execution: BrainActExecution): AdmitContext => {
+    const issues = dependencies.trackedIssues();
+    return {
+      origin: execution.origin,
+      guard: execution,
+      // The reads before an effect wait only as long as the standing does: a
+      // cancel landing mid-refresh settles the act inside admission, and the
+      // refresh's late answer dispatches nothing.
+      roster: {
+        read: async () => {
+          await dependencies.refreshSessions();
+          return dependencies.sessions();
+        },
+      },
+      projects: {
+        read: async () => dependencies.workspaceProjects(),
+        defaults: () => dependencies.workspaceDefaults(),
+        agentModels: workspaceAgentModels,
+      },
+      guide: dependencies.appGuide(),
+      ...(issues ? { issues } : undefined),
+      rememberedFacts: dependencies.rememberedFacts(),
+    };
+  };
+
+  const carrySessionAct = (
+    act: ValidatedAct<SessionActKind>,
     execution: BrainActExecution,
   ): Promise<WireRecord> => {
-    // The reads before the effect wait only as long as the standing does: a
-    // cancel landing mid-refresh settles the act here, and the refresh's late
-    // answer dispatches nothing.
-    const refreshed = await settledUnlessAborted(dependencies.refreshSessions(), execution.signal);
-    if (refreshed.aborted || execution.isRevoked()) return rejection(REFUSAL.TURN_OVER);
-    const sessions = dependencies.sessions();
-    const read = await settledUnlessAborted(dependencies.workspaceDefaults(), execution.signal);
-    if (read.aborted || execution.isRevoked()) return rejection(REFUSAL.TURN_OVER);
-    const defaults = read.value;
-    const action = sessionToolAction(
-      call,
-      sessions,
-      dependencies.workspaceProjects(),
-      workspaceAgentModels,
-      defaults.defaultProviderId,
-      defaults.defaultProjectIds,
-    );
-    if (action.status === ACT_RESULT_STATUS.REJECTED) return rejection(action.reason);
     // The ask is recorded before the outcome is known: a refusal still leaves
     // the developer having asked it, and the reply voicing the outcome is
     // recorded as what Luke said.
-    if (execution.isRevoked()) return rejection(REFUSAL.TURN_OVER);
     dependencies.recordConversationEntry(
       sessionActConversationEntry(
-        action,
-        sessions,
+        act,
+        dependencies.sessions(),
         execution.origin === RUN_ORIGIN.USER
           ? CONVERSATION_ENTRY_KIND.ACT
           : CONVERSATION_ENTRY_KIND.OWN_ACT,
@@ -149,74 +149,47 @@ export function createBrainActPerformer(
     );
     // The performer awaits once more of its own before a create or a spawn,
     // so the execution rides along to be asked again there.
-    return dependencies.sessionActs.perform(action, execution);
+    return dependencies.sessionActs.perform(act, execution);
   };
-
-  const performIssue = async (
-    call: RealtimeFunctionCall,
-    execution: BrainActExecution,
-  ): Promise<WireRecord> => {
-    const issues = dependencies.trackedIssues();
-    if (!issues) return rejection(REFUSAL.NO_TRACKER);
-    const action = issueToolAction(call, issues);
-    if (action.status === ACT_RESULT_STATUS.REJECTED) return rejection(action.reason);
-    if (execution.isRevoked()) return rejection(REFUSAL.TURN_OVER);
-    return dependencies.sessionActs.perform(action, execution);
-  };
-
-  const performApp = async (
-    call: RealtimeFunctionCall,
-    execution: BrainActExecution,
-  ): Promise<WireRecord> => {
-    const action = appToolAction(
-      call,
-      dependencies.appGuide(),
-      dependencies.sessions(),
-      dependencies.rememberedFacts(),
-    );
-    if (action.status === ACT_RESULT_STATUS.REJECTED) return rejection(action.reason);
-    if (execution.isRevoked()) return rejection(REFUSAL.TURN_OVER);
-    return carryAppAction(action);
-  };
-
-  const carryAppAction = (action: CarriedAppAction): Promise<WireRecord> =>
-    dispatchByKind(action, {
-      // The two memory writes are the notebook's own: the store's worker
-      // writes the line and its provenance, and its answer is the whole report.
-      [APP_TOOL_KIND.REMEMBER]: async (act) =>
-        (await dependencies.notebook.remember({
-          id: randomUUID(),
-          words: act.words,
-          ...(act.replaces !== undefined ? { replaces: act.replaces } : undefined),
-        }))
-          ? { status: ACT_RESULT_STATUS.ACCEPTED }
-          : rejection(REFUSAL.MEMORY_NOT_SAVED),
-      [APP_TOOL_KIND.FORGET]: async (act) =>
-        (await dependencies.notebook.forget(act.id))
-          ? { status: ACT_RESULT_STATUS.ACCEPTED }
-          : rejection(REFUSAL.MEMORY_NOT_REMOVED),
-      [APP_TOOL_KIND.SETTING]: (act) => dependencies.performAppAct(act),
-      [APP_TOOL_KIND.PANEL]: (act) => dependencies.performAppAct(act),
-      [APP_TOOL_KIND.FEEDBACK]: (act) => dependencies.performAppAct(act),
-      [APP_TOOL_KIND.UPDATE]: (act) => dependencies.performAppAct(act),
-    });
-
-  const performers = {
-    [REALTIME_TOOL_FAMILY.SESSION]: performSession,
-    [REALTIME_TOOL_FAMILY.ISSUE]: performIssue,
-    [REALTIME_TOOL_FAMILY.APP]: performApp,
-  } as const satisfies Record<
-    RealtimeToolFamily,
-    (call: RealtimeFunctionCall, execution: BrainActExecution) => Promise<WireRecord>
-  >;
 
   return {
     async perform(call: RealtimeFunctionCall, execution: BrainActExecution) {
       if (!isExecution(execution)) return rejection(REFUSAL.NO_EXECUTION);
       if (execution.isRevoked()) return rejection(REFUSAL.TURN_OVER);
-      const family = realtimeToolFamily(call.name);
-      if (family === undefined) return rejection(REFUSAL.NO_SUCH_TOOL);
-      return performers[family](call, execution);
+      const admitted = await toolAction(call, admissionContext(execution));
+      if (admitted.kind === undefined) return rejection(admitted.reason);
+      if (execution.isRevoked()) return rejection(REFUSAL.TURN_OVER);
+      // Where each admitted act goes, named kind by kind: the two notebook
+      // writes are carried here, an app act is the renderer's to perform, an
+      // issue act reaches its tracker without a History line, and a session
+      // act is recorded as it is carried.
+      return dispatchByKind(admitted, {
+        [ACT_KIND.REMEMBER]: async (act) =>
+          (await dependencies.notebook.remember({
+            id: randomUUID(),
+            words: act.words,
+            ...(act.replaces !== undefined ? { replaces: act.replaces } : undefined),
+          }))
+            ? { status: ACT_RESULT_STATUS.ACCEPTED }
+            : rejection(REFUSAL.MEMORY_NOT_SAVED),
+        [ACT_KIND.FORGET]: async (act) =>
+          (await dependencies.notebook.forget(act.id))
+            ? { status: ACT_RESULT_STATUS.ACCEPTED }
+            : rejection(REFUSAL.MEMORY_NOT_REMOVED),
+        [ACT_KIND.SETTING]: (act) => dependencies.performAppAct(act),
+        [ACT_KIND.PANEL]: (act) => dependencies.performAppAct(act),
+        [ACT_KIND.FEEDBACK]: (act) => dependencies.performAppAct(act),
+        [ACT_KIND.UPDATE]: (act) => dependencies.performAppAct(act),
+        [ACT_KIND.ISSUE_STATE]: (act) => dependencies.sessionActs.perform(act, execution),
+        [ACT_KIND.ISSUE_COMMENT]: (act) => dependencies.sessionActs.perform(act, execution),
+        [ACT_KIND.MESSAGE]: (act) => carrySessionAct(act, execution),
+        [ACT_KIND.CONTROL]: (act) => carrySessionAct(act, execution),
+        [ACT_KIND.OPEN]: (act) => carrySessionAct(act, execution),
+        [ACT_KIND.CREATE_WORKSPACE]: (act) => carrySessionAct(act, execution),
+        [ACT_KIND.ADD_AGENT]: (act) => carrySessionAct(act, execution),
+        [ACT_KIND.RENAME_WORKSPACE]: (act) => carrySessionAct(act, execution),
+        [ACT_KIND.RENAME_SESSION]: (act) => carrySessionAct(act, execution),
+      });
     },
   };
 }

--- a/apps/desktop/src/main/brain/act-performer.ts
+++ b/apps/desktop/src/main/brain/act-performer.ts
@@ -108,6 +108,12 @@ export function createBrainActPerformer(
 ): BrainActPerformer {
   const admissionContext = (execution: BrainActExecution): AdmitContext => {
     const issues = dependencies.trackedIssues();
+    // The roster and the projects an act is admitted against are two readings
+    // of one observation pass, so the pass runs once per act however many of
+    // them admission asks for. An act that asks for neither — an issue act, a
+    // setting — observes nothing at all.
+    let pass: Promise<void> | undefined;
+    const observed = () => (pass ??= dependencies.refreshSessions());
     return {
       origin: execution.origin,
       guard: execution,
@@ -116,12 +122,15 @@ export function createBrainActPerformer(
       // refresh's late answer dispatches nothing.
       roster: {
         read: async () => {
-          await dependencies.refreshSessions();
+          await observed();
           return dependencies.sessions();
         },
       },
       projects: {
-        read: async () => dependencies.workspaceProjects(),
+        read: async () => {
+          await observed();
+          return dependencies.workspaceProjects();
+        },
         defaults: () => dependencies.workspaceDefaults(),
         agentModels: workspaceAgentModels,
       },

--- a/apps/desktop/src/main/gateway/wiring.ts
+++ b/apps/desktop/src/main/gateway/wiring.ts
@@ -1,4 +1,4 @@
-import { APP_TOOL_KIND } from "@sidecar/acts";
+import { ACT_KIND } from "@sidecar/acts";
 import { brainRequestRecordFromWire } from "@sidecar/brain/requests";
 import { type ConversationEntry, conversationEntryFromWire } from "@sidecar/realtime";
 import { GatewayClient, type GatewayTransport } from "@sidecar/runtime";
@@ -84,8 +84,8 @@ function isCarriedAppAction(
   return (
     isRecord(value) &&
     isWireString(value.kind) &&
-    value.kind !== APP_TOOL_KIND.REMEMBER &&
-    value.kind !== APP_TOOL_KIND.FORGET
+    value.kind !== ACT_KIND.REMEMBER &&
+    value.kind !== ACT_KIND.FORGET
   );
 }
 

--- a/apps/desktop/src/main/ipc/session-acts.test.ts
+++ b/apps/desktop/src/main/ipc/session-acts.test.ts
@@ -1,8 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { type CarriedSessionAction, SESSION_TOOL_KIND } from "@sidecar/acts";
+import { ACT_KIND, type CarriedSessionAct } from "@sidecar/acts";
 import {
-  ACT_KIND,
   PROVIDER_ID,
   type ProviderSessionObservation,
   type ProviderWorkspaceAgentRequest,
@@ -117,14 +116,14 @@ const WORKSPACE_OBSERVATION: ProviderSessionObservation = {
   lastActivityAt: NOW_DEEP,
   advertises: [{ kind: ACT_KIND.ADD_AGENT, agents: ["claude"] }],
 };
-const CREATE: CarriedSessionAction = {
-  kind: SESSION_TOOL_KIND.CREATE_WORKSPACE,
+const CREATE: CarriedSessionAct = {
+  kind: ACT_KIND.CREATE_WORKSPACE,
   providerId: PROVIDER_ID.CONDUCTOR,
   providerProjectId: "project-1",
   task: "add tests",
 };
-const SPAWN: CarriedSessionAction = {
-  kind: SESSION_TOOL_KIND.ADD_AGENT,
+const SPAWN: CarriedSessionAct = {
+  kind: ACT_KIND.ADD_AGENT,
   identity: { providerId: PROVIDER_ID.CONDUCTOR, providerSessionId: "workspace-1" },
   agent: "claude",
 };

--- a/apps/desktop/src/main/ipc/session-acts.ts
+++ b/apps/desktop/src/main/ipc/session-acts.ts
@@ -101,17 +101,6 @@ export interface SessionActPerformerDependencies {
   recordProductEvent: RecordProductEvent;
 }
 
-/**
- * Whether the turn an act belongs to still stands, asked once more at the last
- * boundary before a provider effect. A brain-origin act arrives with one; a row
- * press, which is not a write and opens its turn and its effect in the same
- * breath, carries none. The performer asks it only after an await of its own
- * that stands between admission and the effect — the stored agent defaults read
- * before a create or a spawn — because an act whose turn ended during that read
- * must refuse rather than start the write.
- */
-export type ActExecutionGuard = ActGuard;
-
 export interface SessionActsIpcDependencies {
   ipcMain: Pick<IpcMain, "handle" | "on">;
   trustedSender: (event: IpcMainEvent | IpcMainInvokeEvent) => boolean;
@@ -130,10 +119,14 @@ export interface SessionActsIpcDependencies {
  * not a write and reaches them without the brain.
  */
 export interface SessionActPerformer {
-  perform(
-    action: CarriedSessionAct | CarriedIssueAct,
-    guard?: ActExecutionGuard,
-  ): Promise<WireRecord>;
+  /**
+   * The guard is asked once more at the last boundary before a provider
+   * effect. A brain-origin act arrives with one; a row press, which is not a
+   * write and opens its turn and its effect in the same breath, carries none.
+   * Only a create and a spawn ask it, because only they await a read of their
+   * own — the stored agent defaults — between admission and the write.
+   */
+  perform(action: CarriedSessionAct | CarriedIssueAct, guard?: ActGuard): Promise<WireRecord>;
   openSession(identity: SessionIdentity): Promise<SessionOpenResult>;
   openSessionApplication(
     identity: SessionIdentity,
@@ -391,7 +384,7 @@ export function createSessionActPerformer(
     name: string | undefined,
     task: string | undefined,
     namedSelection: WorkspaceAgentSelection | undefined,
-    guard: ActExecutionGuard | undefined,
+    guard: ActGuard | undefined,
   ): Promise<ProviderWorkspaceResult> => {
     if (!sendsNetwork) {
       return {
@@ -528,7 +521,7 @@ export function createSessionActPerformer(
     task: string | undefined,
     namedModel: string | undefined,
     namedEffort: string | undefined,
-    guard: ActExecutionGuard | undefined,
+    guard: ActGuard | undefined,
   ): Promise<WireRecord> => {
     const session = sessionRegistry.get(identity);
     if (!session) return { status: ACT_RESULT_STATUS.UNSUPPORTED, reason: REFUSAL.NO_SESSION };
@@ -734,7 +727,7 @@ export function createSessionActPerformer(
   // guard; the rest reach their adapter or the CLI with nothing awaited between.
   const performSessionAction = (
     action: CarriedSessionAct,
-    guard: ActExecutionGuard | undefined,
+    guard: ActGuard | undefined,
   ): Promise<WireRecord> =>
     dispatchByKind(action, {
       [ACT_KIND.MESSAGE]: (act) => sendMessage(act.identity, act.text),

--- a/apps/desktop/src/main/ipc/session-acts.ts
+++ b/apps/desktop/src/main/ipc/session-acts.ts
@@ -1,10 +1,11 @@
 import { randomUUID } from "node:crypto";
 import {
-  type CarriedIssueAction,
-  type CarriedSessionAction,
+  ACT_KIND,
+  type ActGuard,
+  type CarriedIssueAct,
+  type CarriedSessionAct,
   dispatchByKind,
-  ISSUE_TOOL_KIND,
-  SESSION_TOOL_KIND,
+  guardedRead,
 } from "@sidecar/acts";
 import {
   PRODUCT_EVENT,
@@ -13,7 +14,6 @@ import {
   type ProductSessionAct,
   type RecordProductEvent,
 } from "@sidecar/analytics";
-import { settledUnlessAborted } from "@sidecar/brain";
 import {
   ISSUE_ACTION_KIND,
   isIssueTrackerId,
@@ -22,7 +22,6 @@ import {
   type TrackerActionResult,
 } from "@sidecar/issues";
 import {
-  ACT_KIND,
   advertisedActFor,
   advertisedControl,
   advertisedControls,
@@ -103,34 +102,15 @@ export interface SessionActPerformerDependencies {
 }
 
 /**
- * Whether the turn an act belongs to still stands, asked once more at the
- * last boundary before a provider effect. A brain-origin act arrives with
- * one; a row press, which is not a write and opens its turn and its effect
- * in the same breath, carries none. The performer asks it only after an
- * await of its own that stands between validation and the effect — the
- * stored agent defaults read before a create or a spawn — because an act
- * whose turn ended during that read must refuse rather than start the write.
+ * Whether the turn an act belongs to still stands, asked once more at the last
+ * boundary before a provider effect. A brain-origin act arrives with one; a row
+ * press, which is not a write and opens its turn and its effect in the same
+ * breath, carries none. The performer asks it only after an await of its own
+ * that stands between admission and the effect — the stored agent defaults read
+ * before a create or a spawn — because an act whose turn ended during that read
+ * must refuse rather than start the write.
  */
-/**
- * A read awaited before an effect, held only as long as the guard's standing:
- * once the signal fires the wait answers nothing, and the `isRevoked` check
- * that follows every such read refuses the act before anything is dispatched.
- * A guard with no signal — a row's own press — waits the read out.
- */
-async function guardedRead<T>(
-  read: Promise<T>,
-  guard: ActExecutionGuard | undefined,
-): Promise<T | undefined> {
-  if (!guard?.signal) return read;
-  const settled = await settledUnlessAborted(read, guard.signal);
-  return settled.aborted ? undefined : settled.value;
-}
-
-export interface ActExecutionGuard {
-  isRevoked(): boolean;
-  /** Fires on revocation, so a read awaited before the effect settles at once rather than finishing first. */
-  readonly signal?: AbortSignal;
-}
+export type ActExecutionGuard = ActGuard;
 
 export interface SessionActsIpcDependencies {
   ipcMain: Pick<IpcMain, "handle" | "on">;
@@ -151,7 +131,7 @@ export interface SessionActsIpcDependencies {
  */
 export interface SessionActPerformer {
   perform(
-    action: CarriedSessionAction | CarriedIssueAction,
+    action: CarriedSessionAct | CarriedIssueAct,
     guard?: ActExecutionGuard,
   ): Promise<WireRecord>;
   openSession(identity: SessionIdentity): Promise<SessionOpenResult>;
@@ -687,7 +667,7 @@ export function createSessionActPerformer(
   // tracker itself listed — so what reaches a tracker client is built from
   // observed state, never from what a model composed. A fixture run observes
   // no tracker, so it refuses every act.
-  const performIssueAct = async (action: CarriedIssueAction): Promise<TrackerActionResult> => {
+  const performIssueAct = async (action: CarriedIssueAct): Promise<TrackerActionResult> => {
     const issue = trackedIssues()?.find(
       (candidate) =>
         candidate.trackerId === action.identity.trackerId &&
@@ -703,7 +683,7 @@ export function createSessionActPerformer(
     }
 
     let result: TrackerActionResult;
-    if (action.kind === ISSUE_TOOL_KIND.ISSUE_STATE) {
+    if (action.kind === ACT_KIND.ISSUE_STATE) {
       const transition = issue.transitions.find(
         (candidate) => candidate.id === action.transition.id,
       );
@@ -740,7 +720,7 @@ export function createSessionActPerformer(
         recordProductEvent(PRODUCT_EVENT.ISSUE_ACT_SEND, {
           tracker_id: issue.trackerId,
           issue_act:
-            action.kind === ISSUE_TOOL_KIND.ISSUE_STATE
+            action.kind === ACT_KIND.ISSUE_STATE
               ? PRODUCT_ISSUE_ACT.STATE_MOVE
               : PRODUCT_ISSUE_ACT.COMMENT_ADD,
         });
@@ -753,17 +733,17 @@ export function createSessionActPerformer(
   // own between validation and the provider effect, so only they take the
   // guard; the rest reach their adapter or the CLI with nothing awaited between.
   const performSessionAction = (
-    action: CarriedSessionAction,
+    action: CarriedSessionAct,
     guard: ActExecutionGuard | undefined,
   ): Promise<WireRecord> =>
     dispatchByKind(action, {
-      [SESSION_TOOL_KIND.MESSAGE]: (act) => sendMessage(act.identity, act.text),
-      [SESSION_TOOL_KIND.CONTROL]: (act) => executeControl(act.identity, act.control.id),
-      [SESSION_TOOL_KIND.OPEN]: async (act): Promise<WireRecord> =>
+      [ACT_KIND.MESSAGE]: (act) => sendMessage(act.identity, act.text),
+      [ACT_KIND.CONTROL]: (act) => executeControl(act.identity, act.control.id),
+      [ACT_KIND.OPEN]: async (act): Promise<WireRecord> =>
         act.applicationId
           ? openSessionApplication(act.identity, act.applicationId)
           : openSession(act.identity),
-      [SESSION_TOOL_KIND.CREATE_WORKSPACE]: async (act): Promise<WireRecord> =>
+      [ACT_KIND.CREATE_WORKSPACE]: async (act): Promise<WireRecord> =>
         createWorkspace(
           act.providerId,
           act.providerProjectId,
@@ -774,7 +754,7 @@ export function createSessionActPerformer(
           act.agentSelection,
           guard,
         ),
-      [SESSION_TOOL_KIND.ADD_AGENT]: (act) =>
+      [ACT_KIND.ADD_AGENT]: (act) =>
         addWorkspaceAgent(
           act.identity,
           act.agent,
@@ -784,16 +764,13 @@ export function createSessionActPerformer(
           act.effort,
           guard,
         ),
-      [SESSION_TOOL_KIND.RENAME_WORKSPACE]: (act) => renameWorkspace(act.identity, act.name),
-      [SESSION_TOOL_KIND.RENAME_SESSION]: (act) => renameSession(act.identity, act.name),
+      [ACT_KIND.RENAME_WORKSPACE]: (act) => renameWorkspace(act.identity, act.name),
+      [ACT_KIND.RENAME_SESSION]: (act) => renameSession(act.identity, act.name),
     });
 
   return {
     async perform(action, guard) {
-      if (
-        action.kind === ISSUE_TOOL_KIND.ISSUE_STATE ||
-        action.kind === ISSUE_TOOL_KIND.ISSUE_COMMENT
-      ) {
+      if (action.kind === ACT_KIND.ISSUE_STATE || action.kind === ACT_KIND.ISSUE_COMMENT) {
         return performIssueAct(action);
       }
       return performSessionAction(action, guard);

--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -1,4 +1,4 @@
-import { APP_TOOL_KIND, dispatchByKind } from "@sidecar/acts";
+import { ACT_KIND, dispatchByKind } from "@sidecar/acts";
 import {
   PRODUCT_PANEL_SOURCE,
   PRODUCT_SEARCH_SURFACE,
@@ -1713,7 +1713,7 @@ export function App(): React.JSX.Element {
   const carryAppAction = useCallback<AppActionCarrier>(
     async (action) =>
       dispatchByKind(action, {
-        [APP_TOOL_KIND.SETTING]: async (action): Promise<WireRecord> => {
+        [ACT_KIND.SETTING]: async (action): Promise<WireRecord> => {
           // The store's answer is caught rather than drawn: the switch is what
           // Luke is on his way to move, so it waits for him to reach it. It is
           // caught in a local and handed to this act alone, because one reply
@@ -1781,7 +1781,7 @@ export function App(): React.JSX.Element {
           }
           return outcome;
         },
-        [APP_TOOL_KIND.FEEDBACK]: async (action) => {
+        [ACT_KIND.FEEDBACK]: async (action) => {
           // The main process expands the window and sends the composer's
           // lifecycle event down the same ordered channel as the mode event,
           // so the composer's shape can never lose a race to the panel apply
@@ -1825,7 +1825,7 @@ export function App(): React.JSX.Element {
                   }),
           };
         },
-        [APP_TOOL_KIND.PANEL]: async (action) => {
+        [ACT_KIND.PANEL]: async (action) => {
           // Whether this ask is what opens the panel, read before it does: an
           // errand into a shape still growing has to trail the whole opening,
           // and one into a panel already up does not.
@@ -1894,7 +1894,7 @@ export function App(): React.JSX.Element {
             ...(notes.length > 0 ? { note: notes.join(" ") } : undefined),
           };
         },
-        [APP_TOOL_KIND.UPDATE]: async (action): Promise<WireRecord> => {
+        [ACT_KIND.UPDATE]: async (action): Promise<WireRecord> => {
           // The Updates row's own three presses, behind the same bridge calls
           // its button uses; the main process holds its own guards — a check
           // never interrupts a download, an install runs only on a build in

--- a/apps/desktop/src/renderer/luke-errand.tsx
+++ b/apps/desktop/src/renderer/luke-errand.tsx
@@ -1,4 +1,4 @@
-import { type AppToolAction, SESSION_LIST_ALL } from "@sidecar/acts";
+import { type CarriedAppAct, type Refusal, SESSION_LIST_ALL } from "@sidecar/acts";
 import { APP_PANEL_TAB, type AppPanelTab } from "@sidecar/guide";
 import { WingFace as LukeFace } from "@sidecar/panel";
 import { useEffect, useRef } from "react";
@@ -125,7 +125,7 @@ export function errandOriginProps() {
  * something to choose between, so the tab stands behind it. The flight takes
  * the first candidate actually drawn, and an act with none flies nowhere.
  */
-export function errandTargets(action: AppToolAction): readonly ErrandTarget[] {
+export function errandTargets(action: CarriedAppAct | Refusal): readonly ErrandTarget[] {
   if (action.kind === "setting") {
     // The guide's ids travel as plain text, so one that names no setting of
     // Luke's is no landing place either.

--- a/apps/desktop/src/shared/bridge.ts
+++ b/apps/desktop/src/shared/bridge.ts
@@ -1,5 +1,5 @@
 import type { AccountProvider, AccountSnapshot } from "@sidecar/account/snapshot";
-import { APP_TOOL_KIND } from "@sidecar/acts";
+import { ACT_KIND } from "@sidecar/acts";
 import {
   isProductExchangeKind,
   isProductSurfaceEventName,
@@ -1028,8 +1028,8 @@ export const BRIDGE = {
         isWireString(v.requestId) &&
         isRecord(v.action) &&
         isWireString(v.action.kind) &&
-        v.action.kind !== APP_TOOL_KIND.REMEMBER &&
-        v.action.kind !== APP_TOOL_KIND.FORGET,
+        v.action.kind !== ACT_KIND.REMEMBER &&
+        v.action.kind !== ACT_KIND.FORGET,
     ),
   }),
   onConversationHistoryChanged: entry({

--- a/apps/desktop/src/shared/messages/brain.ts
+++ b/apps/desktop/src/shared/messages/brain.ts
@@ -1,4 +1,4 @@
-import type { CarriedAppAction } from "@sidecar/acts";
+import type { CarriedAppAct } from "@sidecar/acts";
 import {
   type BRAIN_REQUEST_ORIGIN,
   BRAIN_REQUEST_STATUS,
@@ -171,7 +171,7 @@ export function isBrainReplyClaimResult(value: UnparsedWireValue): boolean {
  */
 export interface BrainAppActRequest {
   requestId: string;
-  action: Exclude<CarriedAppAction, { kind: "remember" | "forget" }>;
+  action: Exclude<CarriedAppAct, { kind: "remember" | "forget" }>;
 }
 
 /** The renderer's answer to one app act: what became of it, as the brain reads outcomes. */

--- a/apps/web/server/core.ts
+++ b/apps/web/server/core.ts
@@ -28,6 +28,11 @@ import "../../../packages/memory/src/index.js";
 import "../../../packages/runtime/src/index.js";
 
 export * from "../../../packages/acts/src/index.js";
+// The act table and the session package both name the act vocabulary: the
+// table's is the whole of it and the session package's is the advertised
+// subset of the same strings, proven identical where the table declares it. A
+// star export from two doors carries neither, so the whole one is named here.
+export { ACT_KIND, type ActKind } from "../../../packages/acts/src/index.js";
 export * from "../../../packages/analytics/src/index.js";
 export * from "../../../packages/brain/src/index.js";
 export * from "../../../packages/hosted/src/index.js";

--- a/apps/web/tests/hosted-acts.test.ts
+++ b/apps/web/tests/hosted-acts.test.ts
@@ -1,7 +1,16 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import type { JsonObject } from "../../../packages/wire/src/testing/json.js";
-import { text, type WorkspaceAgentSelection } from "../server/core";
+import {
+  ACT_KIND,
+  admit,
+  normalizeSession,
+  PROVIDER_IDENTITY_BY_ID,
+  RUN_ORIGIN,
+  type Session,
+  text,
+  type WorkspaceAgentSelection,
+} from "../server/core";
 import {
   actUnsupportedReason,
   executeControlAct,
@@ -11,6 +20,7 @@ import {
 } from "../server/hosted/act-execute";
 import { handleSessionAct, type SessionActOptions } from "../server/hosted/act-session";
 import { handleActWorkspace } from "../server/hosted/act-workspace";
+import { cloudSessionAdapterFor } from "../server/hosted/cloud-adapters";
 import { encryptProviderKey } from "../server/hosted/encryption";
 
 const SECRET = "a".repeat(64);
@@ -287,6 +297,9 @@ function conductorApi(status: string) {
   return { fetch, posts };
 }
 
+/** The fake API one case runs against: its fetch, and what the act posted through it. */
+type ConductorApi = ReturnType<typeof conductorApi>;
+
 test("a message to a messageable Conductor session lands on its sendMessage method", async () => {
   const api = conductorApi("idle");
   const answer = await executeMessageAct({
@@ -495,4 +508,86 @@ test("no selection fields is no selection, never a guess", async () => {
 
   assert.equal(ran, true);
   assert.equal(received, undefined);
+});
+
+/**
+ * The hosted executors answer "may this act run?" with checks of their own,
+ * against the observations of their own fresh pass. `admit` answers the same
+ * question against the same observations, and this is what says the two agree
+ * before the executors' copies are deleted: every case below is run through
+ * both, and a disagreement on whether the act may run fails here.
+ */
+async function observedSessions(fetch: ConductorApi["fetch"]): Promise<readonly Session[]> {
+  const adapter = cloudSessionAdapterFor("conductor", { readApiKey: async () => "key-1", fetch });
+  const observations = await adapter.observe();
+  return observations.map((observation) =>
+    normalizeSession(PROVIDER_IDENTITY_BY_ID.conductor, observation),
+  );
+}
+
+async function admits(
+  fetch: ConductorApi["fetch"],
+  kind: typeof ACT_KIND.MESSAGE | typeof ACT_KIND.CONTROL,
+  fields: Record<string, string>,
+): Promise<boolean> {
+  const sessions = await observedSessions(fetch);
+  const admitted = await admit(
+    { kind, fields },
+    { origin: RUN_ORIGIN.USER, roster: { read: async () => sessions } },
+  );
+  return admitted.kind !== undefined;
+}
+
+test("admission answers each hosted act exactly as the executor's own checks do", async () => {
+  const messages = [
+    { status: "idle", providerSessionId: CONDUCTOR_SESSION_ID },
+    { status: "error", providerSessionId: CONDUCTOR_SESSION_ID },
+    { status: "idle", providerSessionId: "session-9" },
+  ] as const;
+  for (const { status, providerSessionId } of messages) {
+    const executor = conductorApi(status);
+    const admission = conductorApi(status);
+    const executed = await executeMessageAct({
+      providerId: "conductor",
+      providerSessionId,
+      text: "please continue",
+      apiKey: "key-1",
+      seams: { fetch: executor.fetch },
+    });
+    assert.equal(
+      await admits(admission.fetch, ACT_KIND.MESSAGE, {
+        provider_id: "conductor",
+        provider_session_id: providerSessionId,
+        text: "please continue",
+      }),
+      executed.result === "accepted",
+      `message on a ${status} ${providerSessionId}`,
+    );
+  }
+
+  const controls = [
+    { status: "working", controlId: "cancel-turn" },
+    { status: "idle", controlId: "cancel-turn" },
+    { status: "working", controlId: "terminate" },
+  ] as const;
+  for (const { status, controlId } of controls) {
+    const executor = conductorApi(status);
+    const admission = conductorApi(status);
+    const executed = await executeControlAct({
+      providerId: "conductor",
+      providerSessionId: CONDUCTOR_SESSION_ID,
+      controlId,
+      apiKey: "key-1",
+      seams: { fetch: executor.fetch },
+    });
+    assert.equal(
+      await admits(admission.fetch, ACT_KIND.CONTROL, {
+        provider_id: "conductor",
+        provider_session_id: CONDUCTOR_SESSION_ID,
+        control_id: controlId,
+      }),
+      executed.result === "accepted",
+      `${controlId} on a ${status} session`,
+    );
+  }
 });

--- a/packages/AGENTS.md
+++ b/packages/AGENTS.md
@@ -8,6 +8,14 @@ components. Each app owns the styling that presents those components. Other
 modules belong in an app when they import `electron`, `react`, or a DOM API.
 Everything else is logic and can be tested with `node --test` and no harness.
 
+Whether an act may run is decided once, by `admit()` in `@sidecar/acts`, which
+mints the only `ValidatedAct` there is: its brand is a module-private symbol, so
+nothing outside that module can write one down, and a signature that takes one
+says the gauntlet ran. The direction stays acts → session → wire, and
+`@sidecar/session` keeps the narrower act vocabulary an observation advertises
+with; the two are proven to be the same strings where `@sidecar/acts` declares
+the whole of it.
+
 A wire value's rules are declared once, as a `Schema` in `@sidecar/wire`,
 which both parses the untrusted value and emits the JSON Schema a model is
 shown for it. A hand-written parser beside a hand-written schema is two
@@ -53,7 +61,10 @@ is one whose sources compilation never visits. Packages the server names get
 `export *`; packages reached only through another get a bare side-effect
 import, which pulls the file into the compile graph without widening the
 export namespace, where `export *` can silently drop a name two doors both
-export.
+export. Where two doors genuinely both have to carry a name — `ACT_KIND`, which
+the act table names in full and the session package names its advertised subset
+of — the door that carries the whole of it re-exports the name explicitly,
+which takes precedence over both stars.
 
 Every package's `exports` names `./src/index.js`, never `./src/index.ts`. It is
 the same rule as the one above, one level up: post-compile the `.js` target is

--- a/packages/acts/package.json
+++ b/packages/acts/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@sidecar/guide": "workspace:*",
     "@sidecar/issues": "workspace:*",
+    "@sidecar/runtime-contracts": "workspace:*",
     "@sidecar/session": "workspace:*",
     "@sidecar/wire": "workspace:*"
   },

--- a/packages/acts/src/act-kinds.ts
+++ b/packages/acts/src/act-kinds.ts
@@ -1,0 +1,189 @@
+/**
+ * The one vocabulary every act intake speaks: which family an act belongs to,
+ * which kind it is, and what a carried act of that kind holds. It is declared
+ * here rather than beside any one intake because a renderer press, a model's
+ * tool call, and a hosted route all name the same acts, and a kind spelled one
+ * way where an act is offered and another where it is admitted is the drift
+ * this file exists to close.
+ */
+
+import type {
+  AppGuideSetting,
+  AppPanelTab,
+  AppUpdateAct,
+  FeedbackComposerKind,
+  SessionListSort,
+} from "@sidecar/guide";
+import type { IssueIdentity, IssueTransition } from "@sidecar/issues";
+import type {
+  ACT_KIND as ADVERTISED_ACT_KIND,
+  AdvertisedControl,
+  SessionApplicationId,
+  SessionIdentity,
+  WorkspaceAgentSelection,
+} from "@sidecar/session";
+import type { WireRecord } from "@sidecar/wire";
+
+/**
+ * One tool call as admission is handed it: the act's own name and its
+ * arguments as the model wrote them. No call id — the id an answer travels
+ * back under belongs to the transport, which extends this with one.
+ */
+export interface RealtimeFunctionCall {
+  name: string;
+  argumentsJson: string;
+}
+
+/** Which process an act is about: a session, an issue, or Luke himself. */
+export const ACT_FAMILY = {
+  SESSION: "session",
+  ISSUE: "issue",
+  APP: "app",
+} as const;
+
+export type ActFamily = (typeof ACT_FAMILY)[keyof typeof ACT_FAMILY];
+
+/**
+ * Every act, in one table. The session kinds are the same strings the session
+ * package's advertisement vocabulary holds — the `satisfies` below is what
+ * keeps them so — because an act admitted against an advertisement has to be
+ * named identically on both sides of that check.
+ */
+export const ACT_KIND = {
+  MESSAGE: "message",
+  CONTROL: "control",
+  OPEN: "open",
+  CREATE_WORKSPACE: "create-workspace",
+  ADD_AGENT: "add-agent",
+  RENAME_WORKSPACE: "rename-workspace",
+  RENAME_SESSION: "rename-session",
+  ISSUE_STATE: "issue-state",
+  ISSUE_COMMENT: "issue-comment",
+  SETTING: "setting",
+  PANEL: "panel",
+  FEEDBACK: "feedback",
+  UPDATE: "update",
+  REMEMBER: "remember",
+  FORGET: "forget",
+} as const satisfies typeof ADVERTISED_ACT_KIND & Record<string, string>;
+
+export type ActKind = (typeof ACT_KIND)[keyof typeof ACT_KIND];
+
+/** The two whole-list scopes of a spoken panel ask beyond the locations. */
+export const SESSION_LIST_ALL = "all";
+export const SESSION_LIST_VOICE = "voice";
+
+/**
+ * An act payload that can never be mistaken for a refusal: the two shapes are
+ * disjoint, so `kind === undefined` is the whole of the test either way.
+ */
+export type Carried<T> = T & { status?: never; reason?: never };
+
+/**
+ * What each kind of act carries once admitted. Every field here is either the
+ * developer's own bounded text or a value read back out of what the roster,
+ * the projects list, the guide, or the notebook advertised — never a caller's
+ * copy of one.
+ */
+export interface ActPayloads {
+  [ACT_KIND.MESSAGE]: { identity: SessionIdentity; text: string };
+  [ACT_KIND.CONTROL]: { identity: SessionIdentity; control: AdvertisedControl };
+  [ACT_KIND.OPEN]: {
+    identity: SessionIdentity;
+    /** The one app the developer named to open it in, resolved to its id. */
+    applicationId?: SessionApplicationId;
+  };
+  [ACT_KIND.CREATE_WORKSPACE]: {
+    providerId: string;
+    providerProjectId: string;
+    providerTargetId?: string;
+    agent?: string;
+    name?: string;
+    task?: string;
+    /** The model the developer named for this one creation, resolved to ids. */
+    agentSelection?: WorkspaceAgentSelection;
+  };
+  [ACT_KIND.ADD_AGENT]: {
+    identity: SessionIdentity;
+    agent: string;
+    name?: string;
+    task?: string;
+    /** The model the developer named for this one agent, as its wire id. */
+    model?: string;
+    /** The effort riding that model, when the developer named both. */
+    effort?: string;
+  };
+  /** The workspace's new name, exactly as the developer chose it. */
+  [ACT_KIND.RENAME_WORKSPACE]: { identity: SessionIdentity; name: string };
+  /** The chat's new name, exactly as the developer chose it. */
+  [ACT_KIND.RENAME_SESSION]: { identity: SessionIdentity; name: string };
+  [ACT_KIND.ISSUE_STATE]: { identity: IssueIdentity; transition: IssueTransition };
+  [ACT_KIND.ISSUE_COMMENT]: { identity: IssueIdentity; body: string };
+  [ACT_KIND.SETTING]: {
+    setting: AppGuideSetting;
+    value: string;
+    /** The effort riding the new value, when the developer named both. */
+    effort?: string;
+  };
+  [ACT_KIND.PANEL]: {
+    tab: AppPanelTab;
+    /** The validated narrowing, combined like the chips: OR within an axis, AND across. */
+    filters?: readonly string[];
+    sort?: SessionListSort;
+    /** Words to search the list for, exactly as the developer asked them. */
+    query?: string;
+  };
+  /**
+   * Opens the composer and nothing else: `draft` is at most the developer's
+   * own words, placed only into an empty note, and what the composer holds
+   * leaves only by its own Send button — no act here sends.
+   */
+  [ACT_KIND.FEEDBACK]: { composer: FeedbackComposerKind; draft?: string };
+  [ACT_KIND.UPDATE]: { act: AppUpdateAct };
+  [ACT_KIND.REMEMBER]: {
+    /** One concise durable fact selected from the developer-opened turn. */
+    words: string;
+    /** The id of the fact this one stands in for, when it changes one. */
+    replaces?: string;
+  };
+  [ACT_KIND.FORGET]: { id: string };
+}
+
+/** One act ready for the performer that carries it, for one kind or any of them. */
+export type CarriedAct<Kind extends ActKind = ActKind> = {
+  [K in Kind]: Carried<{ kind: K } & ActPayloads[K]>;
+}[Kind];
+
+export type SessionActKind =
+  | typeof ACT_KIND.MESSAGE
+  | typeof ACT_KIND.CONTROL
+  | typeof ACT_KIND.OPEN
+  | typeof ACT_KIND.CREATE_WORKSPACE
+  | typeof ACT_KIND.ADD_AGENT
+  | typeof ACT_KIND.RENAME_WORKSPACE
+  | typeof ACT_KIND.RENAME_SESSION;
+
+export type IssueActKind = typeof ACT_KIND.ISSUE_STATE | typeof ACT_KIND.ISSUE_COMMENT;
+
+export type AppActKind =
+  | typeof ACT_KIND.SETTING
+  | typeof ACT_KIND.PANEL
+  | typeof ACT_KIND.FEEDBACK
+  | typeof ACT_KIND.UPDATE
+  | typeof ACT_KIND.REMEMBER
+  | typeof ACT_KIND.FORGET;
+
+export type CarriedSessionAct = CarriedAct<SessionActKind>;
+export type CarriedIssueAct = CarriedAct<IssueActKind>;
+export type CarriedAppAct = CarriedAct<AppActKind>;
+
+/**
+ * One ask at an intake, before anything about it has been read: the kind names
+ * which admitter runs, and the fields are untrusted wire values keyed by the
+ * act's own schema names — the same names the tool schema publishes and the
+ * model emits, so admission learns one dialect rather than one per intake.
+ */
+export interface ActRequest<Kind extends ActKind = ActKind> {
+  readonly kind: Kind;
+  readonly fields: WireRecord;
+}

--- a/packages/acts/src/act-narration.ts
+++ b/packages/acts/src/act-narration.ts
@@ -1,0 +1,76 @@
+/**
+ * The History sentence each act is recorded under. One entry per kind, total
+ * over the vocabulary, so a new act does not compile until its sentence is
+ * written and no act can be recorded as "an act" with nothing said about it.
+ */
+
+import type { Session, SessionApplicationId, SessionIdentity } from "@sidecar/session";
+import { ACT_KIND, type ActKind, type CarriedAct } from "./act-kinds.js";
+
+function observedSessionName(identity: SessionIdentity, sessions: readonly Session[]): string {
+  const session = sessions.find(
+    (candidate) =>
+      candidate.providerId === identity.providerId &&
+      candidate.providerSessionId === identity.providerSessionId,
+  );
+  return session ? `"${session.title}"` : "a session";
+}
+
+function observedApplicationName(
+  identity: SessionIdentity,
+  applicationId: SessionApplicationId,
+  sessions: readonly Session[],
+): string {
+  const session = sessions.find(
+    (candidate) =>
+      candidate.providerId === identity.providerId &&
+      candidate.providerSessionId === identity.providerSessionId,
+  );
+  return (
+    session?.applications.find((application) => application.id === applicationId)?.displayName ??
+    applicationId
+  );
+}
+
+const ACT_NARRATION = {
+  [ACT_KIND.MESSAGE]: (act, sessions) =>
+    `sent a message to ${observedSessionName(act.identity, sessions)}: "${act.text}"`,
+  [ACT_KIND.CONTROL]: (act, sessions) =>
+    `ran "${act.control.label}" on ${observedSessionName(act.identity, sessions)}`,
+  [ACT_KIND.OPEN]: (act, sessions) => {
+    const name = observedSessionName(act.identity, sessions);
+    return act.applicationId
+      ? `opened ${name} in ${observedApplicationName(act.identity, act.applicationId, sessions)}`
+      : `opened ${name}`;
+  },
+  [ACT_KIND.CREATE_WORKSPACE]: (act) =>
+    `asked ${act.providerId} to create a workspace${act.name ? ` named "${act.name}"` : ""}`,
+  [ACT_KIND.ADD_AGENT]: (act, sessions) =>
+    `added a ${act.agent} agent to ${observedSessionName(act.identity, sessions)}`,
+  [ACT_KIND.RENAME_WORKSPACE]: (act, sessions) =>
+    `renamed the workspace of ${observedSessionName(act.identity, sessions)} to "${act.name}"`,
+  [ACT_KIND.RENAME_SESSION]: (act, sessions) =>
+    `renamed ${observedSessionName(act.identity, sessions)} to "${act.name}"`,
+  [ACT_KIND.ISSUE_STATE]: (act) =>
+    `moved issue ${act.identity.identifier} to "${act.transition.name}"`,
+  [ACT_KIND.ISSUE_COMMENT]: (act) => `commented on issue ${act.identity.identifier}`,
+  [ACT_KIND.SETTING]: (act) => `changed ${act.setting.label} to ${act.value}`,
+  [ACT_KIND.PANEL]: (act) => `showed the ${act.tab} panel`,
+  [ACT_KIND.FEEDBACK]: (act) => `opened the ${act.composer} composer`,
+  [ACT_KIND.UPDATE]: (act) => `ran the Updates row's ${act.act}`,
+  [ACT_KIND.REMEMBER]: (act) =>
+    act.replaces
+      ? `remembered "${act.words}" in place of something remembered before`
+      : `remembered "${act.words}"`,
+  [ACT_KIND.FORGET]: () => "forgot something remembered before",
+} as const satisfies {
+  [K in ActKind]: (act: CarriedAct<K>, sessions: readonly Session[]) => string;
+};
+
+/** The History sentence declared by the same vocabulary that declared the act. */
+export function actNarration(act: CarriedAct, sessions: readonly Session[]): string {
+  const narrate = ACT_NARRATION[act.kind];
+  // SAFETY: the record is keyed by the same union `act.kind` ranges over, so the
+  // entry selected is the one written for this act's own shape.
+  return (narrate as (act: CarriedAct, sessions: readonly Session[]) => string)(act, sessions);
+}

--- a/packages/acts/src/act-schemas.ts
+++ b/packages/acts/src/act-schemas.ts
@@ -69,7 +69,7 @@ const SESSION_LIST_FILTER_DESCRIPTION =
  * from those two axes and the whole-list scope. Which values narrow to
  * anything is the observed roster's question, answered on the phone.
  */
-export const REMOTE_SESSION_LIST_FILTER_VALUES: readonly string[] = [
+const REMOTE_SESSION_LIST_FILTER_VALUES: readonly string[] = [
   ...new Set<string>([SESSION_LIST_ALL, ...PROVIDER_ID_LIST, ...Object.values(SESSION_STATUS)]),
 ];
 
@@ -85,7 +85,7 @@ const SESSION_LIST_SORT_DESCRIPTION =
   `developer first, ${SESSION_LIST_SORT.RECENCY} puts what moved last first.`;
 
 const identifier = (description: string): Schema<string> =>
-  s.text({ max: maximumIdentifierLength, oneLine: true, description });
+  s.text({ max: maximumIdentifierLength, description });
 
 /** The identity fields every session act names its target by. */
 export const SESSION_IDENTITY_FIELDS = {
@@ -250,7 +250,7 @@ export const PANEL_FILTERS = filterValues(
   SESSION_LIST_FILTER_DESCRIPTION,
 ).optional();
 
-export const REMOTE_PANEL_FILTERS = filterValues(
+const REMOTE_PANEL_FILTERS = filterValues(
   REMOTE_SESSION_LIST_FILTER_VALUES,
   REMOTE_SESSION_LIST_FILTER_DESCRIPTION,
 ).optional();

--- a/packages/acts/src/act-schemas.ts
+++ b/packages/acts/src/act-schemas.ts
@@ -1,0 +1,291 @@
+/**
+ * Every act's own field vocabulary, declared once: what the model is shown for
+ * it and what admission reads out of what arrived. A hand-written JSON literal
+ * beside a hand-written parser is two statements of one rule that drift a
+ * field at a time; a `Schema` is one statement, so a field no admitter reads
+ * is a field no model is offered.
+ */
+
+import {
+  APP_PANEL_TAB,
+  APP_UPDATE_ACT,
+  FEEDBACK_COMPOSER_KIND,
+  SESSION_LIST_SORT,
+} from "@sidecar/guide";
+import { maximumIssueCommentLength } from "@sidecar/issues";
+import {
+  maximumSessionMessageLength,
+  maximumWorkspaceNameLength,
+  PROVIDER_ID_LIST,
+  SESSION_APPLICATION_ID,
+  SESSION_LOCATION,
+  SESSION_STATUS,
+} from "@sidecar/session";
+import {
+  isWireString,
+  type JsonSchemaNode,
+  RECORD_EXTRA_KEYS,
+  SCHEMA_REFUSAL,
+  type Schema,
+  type SchemaFields,
+  s,
+  type UnparsedWireValue,
+} from "@sidecar/wire";
+import { SESSION_LIST_ALL, SESSION_LIST_VOICE } from "./act-kinds.js";
+
+/** An identifier travels in a URL segment or a request field, never as prose. */
+const maximumIdentifierLength = 200;
+
+/**
+ * Every value a spoken narrowing may name, fixed by the build: the whole-list
+ * scopes, every agent this build knows, and every app that associates with
+ * sessions. The chips can hold no other value — a `SessionFilter` is drawn
+ * from these same sets — so this enum is the whole vocabulary rather than a
+ * convenience, and the model picks a token from it instead of echoing the
+ * developer's words for a matcher to guess at. Which of these values narrow
+ * to anything right now is the roster's question, answered by admission.
+ */
+export const SESSION_LIST_FILTER_VALUES: readonly string[] = [
+  ...new Set<string>([
+    SESSION_LIST_ALL,
+    SESSION_LOCATION.LOCAL,
+    SESSION_LOCATION.CLOUD,
+    SESSION_LIST_VOICE,
+    ...PROVIDER_ID_LIST,
+    ...Object.values(SESSION_APPLICATION_ID),
+  ]),
+];
+
+const SESSION_LIST_FILTER_DESCRIPTION =
+  `The values to narrow the session list to: ${SESSION_LIST_ALL} for every session, ` +
+  `${SESSION_LOCATION.LOCAL} or ${SESSION_LOCATION.CLOUD} for where work runs, ` +
+  `${SESSION_LIST_VOICE} for voice chats, an agent's provider_id, or an associated app's id. ` +
+  `Values combine — ${SESSION_LOCATION.LOCAL} with an agent keeps that agent's local ` +
+  `sessions — and ${SESSION_LIST_ALL} stands alone.`;
+
+/**
+ * The narrowing vocabulary the phone's list holds: its chips read a row's
+ * provider and status and nothing else, so a spoken narrowing there picks
+ * from those two axes and the whole-list scope. Which values narrow to
+ * anything is the observed roster's question, answered on the phone.
+ */
+export const REMOTE_SESSION_LIST_FILTER_VALUES: readonly string[] = [
+  ...new Set<string>([SESSION_LIST_ALL, ...PROVIDER_ID_LIST, ...Object.values(SESSION_STATUS)]),
+];
+
+const REMOTE_SESSION_LIST_FILTER_DESCRIPTION =
+  `The values to narrow the session list to: ${SESSION_LIST_ALL} for every session, a ` +
+  `provider_id for one provider's sessions, or a status (${Object.values(SESSION_STATUS).join(
+    ", ",
+  )}). Values combine — a provider with a status keeps that provider's sessions in that ` +
+  `status — and ${SESSION_LIST_ALL} stands alone.`;
+
+const SESSION_LIST_SORT_DESCRIPTION =
+  `Reorders the session list: ${SESSION_LIST_SORT.URGENCY} puts what needs the ` +
+  `developer first, ${SESSION_LIST_SORT.RECENCY} puts what moved last first.`;
+
+const identifier = (description: string): Schema<string> =>
+  s.text({ max: maximumIdentifierLength, oneLine: true, description });
+
+/** The identity fields every session act names its target by. */
+export const SESSION_IDENTITY_FIELDS = {
+  provider_id: identifier("The session provider ID."),
+  provider_session_id: identifier("The session ID."),
+} as const;
+
+/** The identity fields every issue act names its target by. */
+export const ISSUE_IDENTITY_FIELDS = {
+  tracker_id: identifier("The tracker ID."),
+  issue_id: identifier("The issue ID."),
+} as const;
+
+/** The message, task, and comment bounds: refused rather than cut, one declaration each. */
+export const MESSAGE_TEXT = s.text({
+  max: maximumSessionMessageLength,
+  description: "The message to send.",
+});
+export const OPENING_TASK = s.text({
+  max: maximumSessionMessageLength,
+  description: "An optional opening task.",
+});
+export const COMMENT_BODY = s.text({
+  max: maximumIssueCommentLength,
+  description: "The comment to add.",
+});
+export const WORKSPACE_NAME = s.text({ max: maximumWorkspaceNameLength });
+
+/**
+ * A spoken narrowing as it arrives: several values, or a lone string for a
+ * narrowing of one. Blank entries are dropped rather than refused, and an
+ * emptied list is no narrowing at all. Its node is the enum the model is
+ * shown; which of those values narrow to anything now is admission's question.
+ */
+function filterValues(
+  values: readonly string[],
+  description: string,
+): Schema<readonly string[] | undefined> {
+  const node: JsonSchemaNode = {
+    type: "array",
+    items: { type: "string", enum: values },
+    description,
+  };
+  return s.reader<readonly string[] | undefined>({
+    read: (value: UnparsedWireValue) => {
+      const entries = isWireString(value) ? [value] : value;
+      if (!Array.isArray(entries) || !entries.every((entry) => isWireString(entry))) {
+        return { ok: false, refusal: SCHEMA_REFUSAL.MALFORMED, path: [] };
+      }
+      const cleaned = entries.map((entry) => entry.trim()).filter((entry) => entry.length > 0);
+      return { ok: true, value: cleaned.length > 0 ? cleaned : undefined };
+    },
+    jsonSchema: () => node,
+  });
+}
+
+const PANEL_QUERY = s.text({
+  description: "Optional words to search the session list for; only rows saying every word stay.",
+});
+
+export const PANEL_SORT = s.enumOf(Object.values(SESSION_LIST_SORT), {
+  description: SESSION_LIST_SORT_DESCRIPTION,
+});
+
+/** The tab, sort, and act enums, so the model reads the same value sets admission holds. */
+export const PANEL_TAB = s.enumOf(Object.values(APP_PANEL_TAB), {
+  description: "The tab to show. Defaults to sessions.",
+});
+export const FEEDBACK_KIND = s.enumOf(Object.values(FEEDBACK_COMPOSER_KIND), {
+  description: "The feedback type.",
+});
+export const UPDATE_ACT = s.enumOf(Object.values(APP_UPDATE_ACT), {
+  description: "The act to run, as the guide's Updates line offers it.",
+});
+const AGENT_KIND = s.text({ description: "The agent kind." });
+const OPTIONAL_MODEL = s.text({ description: "An optional model." }).optional();
+const OPTIONAL_EFFORT = s.text({ description: "An optional effort level." }).optional();
+
+/**
+ * A request's field table. Extra keys are ignored rather than refused: a model
+ * that adds a field admission does not read has not asked for something wider,
+ * and the emitted node still declines to invite one.
+ */
+const record = <Fields extends SchemaFields>(fields: Fields) =>
+  s.record(fields, { extraKeys: RECORD_EXTRA_KEYS.IGNORE });
+
+export const MESSAGE_REQUEST = record({ ...SESSION_IDENTITY_FIELDS, text: MESSAGE_TEXT });
+
+export const CONTROL_REQUEST = record({
+  ...SESSION_IDENTITY_FIELDS,
+  control_id: s.text({ description: "The control ID." }),
+});
+
+export const OPEN_REQUEST = record({
+  ...SESSION_IDENTITY_FIELDS,
+  application: s
+    .text({
+      description:
+        "The app to open the session in, as its roster line's opens_in lists it — only " +
+        "when the developer named one. Omitted, the session opens at its own address.",
+    })
+    .optional(),
+});
+
+export const REMOTE_OPEN_REQUEST = record({ ...SESSION_IDENTITY_FIELDS });
+
+export const CREATE_WORKSPACE_REQUEST = record({
+  provider_id: s
+    .text({ description: "The provider ID; omit it to create in the default provider." })
+    .optional(),
+  project_id: s
+    .text({ description: "The project ID; omit it to create in that provider's default project." })
+    .optional(),
+  target_id: s.text({ description: "The target ID." }).optional(),
+  agent: AGENT_KIND.optional(),
+  name: WORKSPACE_NAME.describe(
+    "The workspace's name: the developer's own when they chose one, otherwise a short, " +
+      "specific name composed from what the workspace is for, in a few words with no " +
+      "punctuation. Always supply one, except in a project listed as naming its own " +
+      "workspaces, which takes none.",
+  ).optional(),
+  task: OPENING_TASK.optional(),
+  model: OPTIONAL_MODEL,
+  effort: OPTIONAL_EFFORT,
+});
+
+export const ADD_AGENT_REQUEST = record({
+  ...SESSION_IDENTITY_FIELDS,
+  agent: AGENT_KIND,
+  name: WORKSPACE_NAME.describe("An optional agent name.").optional(),
+  task: OPENING_TASK.optional(),
+  model: OPTIONAL_MODEL,
+  effort: OPTIONAL_EFFORT,
+});
+
+export const RENAME_WORKSPACE_REQUEST = record({
+  ...SESSION_IDENTITY_FIELDS,
+  name: WORKSPACE_NAME.describe("The workspace's new name, exactly as the developer chose it."),
+});
+
+export const RENAME_SESSION_REQUEST = record({
+  ...SESSION_IDENTITY_FIELDS,
+  name: WORKSPACE_NAME.describe("The chat's new name, exactly as the developer chose it."),
+});
+
+export const ISSUE_STATE_REQUEST = record({
+  ...ISSUE_IDENTITY_FIELDS,
+  state: s.text({ description: "The target state." }),
+});
+
+export const ISSUE_COMMENT_REQUEST = record({ ...ISSUE_IDENTITY_FIELDS, body: COMMENT_BODY });
+
+export const SETTING_REQUEST = record({
+  setting_id: s.text({ description: "The setting ID." }),
+  value: s.text({ description: "The new value." }),
+  effort: OPTIONAL_EFFORT,
+});
+
+/** The narrowing as it arrives on each surface; absent is no narrowing at all. */
+export const PANEL_FILTERS = filterValues(
+  SESSION_LIST_FILTER_VALUES,
+  SESSION_LIST_FILTER_DESCRIPTION,
+).optional();
+
+export const REMOTE_PANEL_FILTERS = filterValues(
+  REMOTE_SESSION_LIST_FILTER_VALUES,
+  REMOTE_SESSION_LIST_FILTER_DESCRIPTION,
+).optional();
+
+export const PANEL_REQUEST = record({
+  tab: PANEL_TAB.optional(),
+  filters: PANEL_FILTERS,
+  sort: PANEL_SORT.optional(),
+  query: PANEL_QUERY.optional(),
+});
+
+export const REMOTE_PANEL_REQUEST = record({
+  filters: REMOTE_PANEL_FILTERS,
+  sort: PANEL_SORT.optional(),
+  query: PANEL_QUERY.optional(),
+});
+
+export const FEEDBACK_REQUEST = record({
+  kind: FEEDBACK_KIND,
+  draft: s.text({ description: "An optional draft." }).optional(),
+});
+
+export const UPDATE_REQUEST = record({ action: UPDATE_ACT });
+
+export const REMEMBER_REQUEST = record({
+  // The words are flattened and cut to their bound rather than refused past
+  // it, which no text combinator says, so the bound stays `rememberedFactText`'s.
+  words: s.text({ description: "A concise durable fact about the developer." }),
+  replaces: s
+    .text({
+      description: "The id of the remembered entry this one stands in for, when it changes one.",
+    })
+    .optional(),
+});
+
+export const FORGET_REQUEST = record({
+  id: s.text({ description: "The remembered entry's id." }),
+});

--- a/packages/acts/src/acts.test.ts
+++ b/packages/acts/src/acts.test.ts
@@ -1,22 +1,39 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { EMPTY_APP_GUIDE } from "@sidecar/guide";
+import { RUN_ORIGIN } from "@sidecar/runtime-contracts";
 import { ACT_RESULT_STATUS } from "@sidecar/wire";
+import { ACT_KIND } from "./act-kinds.js";
+import { actNarration } from "./act-narration.js";
 import {
-  APP_TOOL_KIND,
-  actNarration,
-  appToolAction,
   REALTIME_TOOL,
   realtimeToolDefinitions,
   remoteRealtimeToolDefinitions,
+  toolAction,
 } from "./acts.js";
-import { maximumRememberedFacts } from "./memory.js";
+import { maximumRememberedFacts, type RememberedFact } from "./memory.js";
+import { withoutAdmission } from "./testing/admitted.js";
+import { itemEnum, objectProperties } from "./testing/json-schema.js";
 
-test("a setting act narrates the setting label and accepted value", () => {
+/** One app act, admitted the way the brain's own intake admits it. */
+const appToolAction = (
+  call: { name: string; argumentsJson: string },
+  guide: typeof EMPTY_APP_GUIDE,
+  sessions: readonly never[],
+  rememberedFacts: readonly RememberedFact[],
+) =>
+  toolAction(call, {
+    origin: RUN_ORIGIN.USER,
+    roster: { read: async () => sessions },
+    guide,
+    rememberedFacts,
+  });
+
+test("a setting act narrates the setting label and accepted value", async () => {
   assert.equal(
     actNarration(
       {
-        kind: APP_TOOL_KIND.SETTING,
+        kind: ACT_KIND.SETTING,
         setting: {
           id: "voice_captions",
           label: "Captions",
@@ -42,8 +59,8 @@ const memoryCall = (name: string, args: Record<string, string>) => ({
 
 const HELD = [{ id: "fact-one", words: "prefers CI updates" }];
 
-test("an automatic memory update may only replace an entry in context", () => {
-  const replacing = appToolAction(
+test("an automatic memory update may only replace an entry in context", async () => {
+  const replacing = await appToolAction(
     memoryCall(REALTIME_TOOL.REMEMBER_FACT, {
       words: "  stop telling me\n about CI ",
       replaces: "fact-one",
@@ -52,13 +69,13 @@ test("an automatic memory update may only replace an entry in context", () => {
     [],
     HELD,
   );
-  assert.deepEqual(replacing, {
-    kind: APP_TOOL_KIND.REMEMBER,
+  assert.deepEqual(withoutAdmission(replacing), {
+    kind: ACT_KIND.REMEMBER,
     words: "stop telling me about CI",
     replaces: "fact-one",
   });
 
-  const invented = appToolAction(
+  const invented = await appToolAction(
     memoryCall(REALTIME_TOOL.REMEMBER_FACT, { words: "anything", replaces: "fact-invented" }),
     EMPTY_APP_GUIDE,
     [],
@@ -67,8 +84,8 @@ test("an automatic memory update may only replace an entry in context", () => {
   assert.equal(invented.status, ACT_RESULT_STATUS.REJECTED);
 });
 
-test("words that bound away to nothing are remembered as nothing", () => {
-  const empty = appToolAction(
+test("words that bound away to nothing are remembered as nothing", async () => {
+  const empty = await appToolAction(
     memoryCall(REALTIME_TOOL.REMEMBER_FACT, { words: "   " }),
     EMPTY_APP_GUIDE,
     [],
@@ -77,12 +94,12 @@ test("words that bound away to nothing are remembered as nothing", () => {
   assert.equal(empty.status, ACT_RESULT_STATUS.REJECTED);
 });
 
-test("the cap refuses a new fact rather than evicting an old one", () => {
+test("the cap refuses a new fact rather than evicting an old one", async () => {
   const full = Array.from({ length: maximumRememberedFacts }, (_, index) => ({
     id: `fact-${index}`,
     words: `something ${index}`,
   }));
-  const refused = appToolAction(
+  const refused = await appToolAction(
     memoryCall(REALTIME_TOOL.REMEMBER_FACT, { words: "one more" }),
     EMPTY_APP_GUIDE,
     [],
@@ -91,37 +108,41 @@ test("the cap refuses a new fact rather than evicting an old one", () => {
   assert.equal(refused.status, ACT_RESULT_STATUS.REJECTED);
 
   // A replacement retires one as it lands, so a full list still takes it.
-  const replacing = appToolAction(
+  const replacing = await appToolAction(
     memoryCall(REALTIME_TOOL.REMEMBER_FACT, { words: "one more", replaces: "fact-0" }),
     EMPTY_APP_GUIDE,
     [],
     full,
   );
-  assert.equal(replacing.kind, APP_TOOL_KIND.REMEMBER);
+  assert.equal(replacing.kind, ACT_KIND.REMEMBER);
 });
 
-test("forgetting can only name an entry that stands", () => {
+test("forgetting can only name an entry that stands", async () => {
   assert.deepEqual(
-    appToolAction(
-      memoryCall(REALTIME_TOOL.FORGET_FACT, { id: "fact-one" }),
-      EMPTY_APP_GUIDE,
-      [],
-      HELD,
+    withoutAdmission(
+      await appToolAction(
+        memoryCall(REALTIME_TOOL.FORGET_FACT, { id: "fact-one" }),
+        EMPTY_APP_GUIDE,
+        [],
+        HELD,
+      ),
     ),
-    { kind: APP_TOOL_KIND.FORGET, id: "fact-one" },
+    { kind: ACT_KIND.FORGET, id: "fact-one" },
   );
   assert.equal(
-    appToolAction(
-      memoryCall(REALTIME_TOOL.FORGET_FACT, { id: "fact-two" }),
-      EMPTY_APP_GUIDE,
-      [],
-      HELD,
+    (
+      await appToolAction(
+        memoryCall(REALTIME_TOOL.FORGET_FACT, { id: "fact-two" }),
+        EMPTY_APP_GUIDE,
+        [],
+        HELD,
+      )
     ).status,
     ACT_RESULT_STATUS.REJECTED,
   );
 });
 
-test("the phone is handed the acts it carries, in the shape its own surface gives them", () => {
+test("the phone is handed the acts it carries, in the shape its own surface gives them", async () => {
   const remote = remoteRealtimeToolDefinitions();
   const names: readonly string[] = remote.map((tool) => tool.name);
   // Spread so the equality narrows a copy, leaving `names` a plain string list.
@@ -154,16 +175,17 @@ test("the phone is handed the acts it carries, in the shape its own surface give
   // An open on the phone lands on the app's own screen, so no app to open in is offered.
   const open = remote.find((tool) => tool.name === REALTIME_TOOL.OPEN_SESSION);
   assert.ok(open);
-  assert.deepEqual(Object.keys(open.parameters.properties), ["provider_id", "provider_session_id"]);
+  assert.deepEqual(Object.keys(objectProperties(open.parameters)), [
+    "provider_id",
+    "provider_session_id",
+  ]);
   assert.match(open.description, /own screen in this app/);
 
   // The phone's list narrows on provider and status, and has no tabs to show.
   const panel = remote.find((tool) => tool.name === REALTIME_TOOL.SHOW_PANEL);
   assert.ok(panel);
-  assert.deepEqual(Object.keys(panel.parameters.properties), ["filters", "sort", "query"]);
-  const filters = panel.parameters.properties.filters;
-  assert.ok(filters && filters.type === "array");
-  const values = filters.items.enum ?? [];
+  assert.deepEqual(Object.keys(objectProperties(panel.parameters)), ["filters", "sort", "query"]);
+  const values = itemEnum(objectProperties(panel.parameters).filters);
   assert.ok(values.includes("all"));
   assert.ok(values.includes("waiting"));
   assert.ok(values.includes("conductor"));

--- a/packages/acts/src/acts.ts
+++ b/packages/acts/src/acts.ts
@@ -3,1788 +3,223 @@
  * table. Family membership, the spoken tool count, and the schema list are
  * derived from it; adding a tool is adding a row.
  *
- * The session trio are the same acts the panel's rows offer — the two writes,
- * and the press that opens a session where its provider keeps it — and the
- * issue pair are the two acts a connected tracker takes. Creating a workspace
- * is the session act with no row yet to mirror. The last four are the same
- * presses turned toward the app itself: a settings
- * change, showing the panel, opening the feedback composer, and the Updates
- * row's button.
+ * The session acts are the ones the panel's rows offer — the writes, and the
+ * press that opens a session where its provider keeps it — and the issue pair
+ * are the two acts a connected tracker takes. Creating a workspace is the
+ * session act with no row yet to mirror. The last six are the same presses
+ * turned toward the app itself: a settings change, showing the panel, opening
+ * the feedback composer, the Updates row's button, and the notebook's two writes.
  *
- * All run the same gauntlet: a call is validated against the observed roster
- * (or the guide) before anything leaves the renderer, and the main process
- * validates it again against what it observed before anything happens. The
- * `validate` on each row is the renderer's half of that, never a substitute
- * for the main process's. Luke is another way to ask, never a wider one.
+ * Whether a call may run is not this file's question: `admit` answers it once,
+ * and a row declares only its name, its family, its kind, its prose, and its
+ * schema. Luke is another way to ask, never a wider one.
  */
 
-import {
-  APP_PANEL_TAB,
-  APP_SETTING_KIND,
-  APP_UPDATE_ACT,
-  APP_UPDATE_WAIT,
-  type AppGuideSetting,
-  type AppGuideSnapshot,
-  type AppGuideUpdate,
-  type AppPanelTab,
-  type AppUpdateAct,
-  appGuideSetting,
-  appToggleValue,
-  FEEDBACK_COMPOSER_KIND,
-  type FeedbackComposerKind,
-  isAppPanelTab,
-  isAppUpdateAct,
-  isFeedbackComposerKind,
-  isSessionListSort,
-  SESSION_LIST_SORT,
-  type SessionListSort,
-} from "@sidecar/guide";
 import {
   ACT_RESULT_STATUS,
-  type IssueIdentity,
-  type IssueTransition,
-  issueCommentText,
-  type TrackedIssue,
-} from "@sidecar/issues";
-import {
-  ACT_KIND,
-  type AdvertisedControl,
-  advertisedActFor,
-  advertisedControl,
-  isSessionApplicationId,
-  matchesFilterSelection,
-  maximumSessionMessageLength,
-  maximumWorkspaceNameLength,
-  type ObservedWorkspaceProject,
-  PROVIDER_ID_LIST,
-  SESSION_APPLICATION_ID,
-  SESSION_LOCATION,
-  SESSION_STATUS,
-  type Session,
-  type SessionApplicationId,
-  type SessionIdentity,
-  sessionMessageText,
-  WORKSPACE_TASK_SUPPORT,
-  type WorkspaceAgentModels,
-  type WorkspaceAgentSelection,
-  workspaceNameText,
-  workspaceProjectSelectionId,
-} from "@sidecar/session";
-import {
   isRecord,
-  isWireString,
+  type JsonSchemaNode,
+  type Schema,
   type UnparsedWireValue,
-  type WireRecord,
-  text as wireText,
 } from "@sidecar/wire";
 import {
-  holdsRememberedFact,
-  maximumRememberedFactLength,
-  maximumRememberedFacts,
-  type RememberedFact,
-  rememberedFactText,
-} from "./memory.js";
+  ACT_FAMILY,
+  ACT_KIND,
+  type ActFamily,
+  type ActKind,
+  type RealtimeFunctionCall,
+} from "./act-kinds.js";
+import {
+  ADD_AGENT_REQUEST,
+  CONTROL_REQUEST,
+  CREATE_WORKSPACE_REQUEST,
+  FEEDBACK_REQUEST,
+  FORGET_REQUEST,
+  ISSUE_COMMENT_REQUEST,
+  ISSUE_STATE_REQUEST,
+  MESSAGE_REQUEST,
+  OPEN_REQUEST,
+  PANEL_REQUEST,
+  REMEMBER_REQUEST,
+  REMOTE_OPEN_REQUEST,
+  REMOTE_PANEL_REQUEST,
+  RENAME_SESSION_REQUEST,
+  RENAME_WORKSPACE_REQUEST,
+  SETTING_REQUEST,
+  UPDATE_REQUEST,
+} from "./act-schemas.js";
+import { ACT_REFUSAL, type AdmitContext, admit, type Refusal, type ValidatedAct } from "./admit.js";
 
-/**
- * One tool call as a validator is handed it: the act's own name and its
- * arguments as the model wrote them. No call id — the id an answer travels
- * back under belongs to the transport, which extends this with one.
- */
-export interface RealtimeFunctionCall {
-  name: string;
-  argumentsJson: string;
-}
-
-/** Which process a tool call is about: a session, an issue, or Luke himself. */
-export const REALTIME_TOOL_FAMILY = {
-  SESSION: "session",
-  ISSUE: "issue",
-  APP: "app",
-} as const;
-
-export type RealtimeToolFamily = (typeof REALTIME_TOOL_FAMILY)[keyof typeof REALTIME_TOOL_FAMILY];
-
-/** What a validated session tool call asks for, as the bridge names it. */
-export const SESSION_TOOL_KIND = {
-  MESSAGE: "message",
-  CONTROL: "control",
-  OPEN: "open",
-  CREATE_WORKSPACE: "create-workspace",
-  ADD_AGENT: "add-agent",
-  RENAME_WORKSPACE: "rename-workspace",
-  RENAME_SESSION: "rename-session",
-} as const;
-
-/** What a validated issue tool call asks for, as the bridge names it. */
-export const ISSUE_TOOL_KIND = {
-  ISSUE_STATE: "issue-state",
-  ISSUE_COMMENT: "issue-comment",
-} as const;
-
-/** What a validated app tool call asks for, as the app performs it. */
-export const APP_TOOL_KIND = {
-  SETTING: "setting",
-  PANEL: "panel",
-  FEEDBACK: "feedback",
-  UPDATE: "update",
-  REMEMBER: "remember",
-  FORGET: "forget",
-} as const;
-
-/** The two whole-list scopes of a spoken panel ask beyond the locations. */
-export const SESSION_LIST_ALL = "all";
-export const SESSION_LIST_VOICE = "voice";
-
-/**
- * Every value a spoken narrowing may name, fixed by the build: the whole-list
- * scopes, every agent this build knows, and every app that associates with
- * sessions. The chips can hold no other value — a `SessionFilter` is drawn
- * from these same sets — so this enum is the whole vocabulary rather than a
- * convenience, and the model picks a token from it instead of echoing the
- * developer's words for a matcher to guess at. Which of these values narrow
- * to anything right now is the roster's question, answered by the validator.
- */
-const SESSION_LIST_FILTER_VALUES: readonly string[] = [
-  ...new Set<string>([
-    SESSION_LIST_ALL,
-    SESSION_LOCATION.LOCAL,
-    SESSION_LOCATION.CLOUD,
-    SESSION_LIST_VOICE,
-    ...PROVIDER_ID_LIST,
-    ...Object.values(SESSION_APPLICATION_ID),
-  ]),
-];
-
-const SESSION_LIST_FILTER_DESCRIPTION =
-  `The values to narrow the session list to: ${SESSION_LIST_ALL} for every session, ` +
-  `${SESSION_LOCATION.LOCAL} or ${SESSION_LOCATION.CLOUD} for where work runs, ` +
-  `${SESSION_LIST_VOICE} for voice chats, an agent's provider_id, or an associated app's id. ` +
-  `Values combine — ${SESSION_LOCATION.LOCAL} with an agent keeps that agent's local ` +
-  `sessions — and ${SESSION_LIST_ALL} stands alone.`;
-
-/**
- * The narrowing vocabulary the phone's list holds: its chips read a row's
- * provider and status and nothing else, so a spoken narrowing there picks
- * from those two axes and the whole-list scope. Which values narrow to
- * anything is the observed roster's question, answered on the phone.
- */
-const REMOTE_SESSION_LIST_FILTER_VALUES: readonly string[] = [
-  ...new Set<string>([SESSION_LIST_ALL, ...PROVIDER_ID_LIST, ...Object.values(SESSION_STATUS)]),
-];
-
-const REMOTE_SESSION_LIST_FILTER_DESCRIPTION =
-  `The values to narrow the session list to: ${SESSION_LIST_ALL} for every session, a ` +
-  `provider_id for one provider's sessions, or a status (${Object.values(SESSION_STATUS).join(
-    ", ",
-  )}). Values combine — a provider with a status keeps that provider's sessions in that ` +
-  `status — and ${SESSION_LIST_ALL} stands alone.`;
-
-/** What one validated tool call asks for, ready for the bridge that carries it. */
-type CarriedSessionActionFields =
-  | { kind: typeof SESSION_TOOL_KIND.MESSAGE; identity: SessionIdentity; text: string }
-  | {
-      kind: typeof SESSION_TOOL_KIND.CONTROL;
-      identity: SessionIdentity;
-      control: AdvertisedControl;
-    }
-  | {
-      kind: typeof SESSION_TOOL_KIND.OPEN;
-      identity: SessionIdentity;
-      /** The one app the developer named to open it in, resolved to its id. */
-      applicationId?: SessionApplicationId;
-    }
-  | {
-      kind: typeof SESSION_TOOL_KIND.CREATE_WORKSPACE;
-      providerId: string;
-      providerProjectId: string;
-      providerTargetId?: string;
-      agent?: string;
-      name?: string;
-      task?: string;
-      /** The model the developer named for this one creation, resolved to ids. */
-      agentSelection?: WorkspaceAgentSelection;
-    }
-  | {
-      kind: typeof SESSION_TOOL_KIND.ADD_AGENT;
-      identity: SessionIdentity;
-      agent: string;
-      name?: string;
-      task?: string;
-      /** The model the developer named for this one agent, as its wire id. */
-      model?: string;
-      /** The effort riding that model, when the developer named both. */
-      effort?: string;
-    }
-  | {
-      kind: typeof SESSION_TOOL_KIND.RENAME_WORKSPACE;
-      identity: SessionIdentity;
-      /** The workspace's new name, exactly as the developer chose it. */
-      name: string;
-    }
-  | {
-      kind: typeof SESSION_TOOL_KIND.RENAME_SESSION;
-      identity: SessionIdentity;
-      /** The chat's new name, exactly as the developer chose it. */
-      name: string;
-    };
-
-export type CarriedSessionAction = CarriedSessionActionFields & {
-  status?: never;
-  reason?: never;
-};
-
-type ActRejection = {
-  status: typeof ACT_RESULT_STATUS.REJECTED;
-  reason: string;
-  kind?: never;
-};
-export type SessionToolAction = CarriedSessionAction | ActRejection;
-
-/** What one validated issue tool call asks for, ready for the bridge that carries it. */
-type CarriedIssueActionFields =
-  | {
-      kind: typeof ISSUE_TOOL_KIND.ISSUE_STATE;
-      identity: IssueIdentity;
-      transition: IssueTransition;
-    }
-  | { kind: typeof ISSUE_TOOL_KIND.ISSUE_COMMENT; identity: IssueIdentity; body: string };
-
-export type CarriedIssueAction = CarriedIssueActionFields & {
-  status?: never;
-  reason?: never;
-};
-export type IssueToolAction = CarriedIssueAction | ActRejection;
-
-/**
- * What one validated app tool call asks for, ready for the app to perform.
- * The feedback action opens the composer and nothing else: `draft` is at most
- * the developer's own words, placed only into an empty note, and what the
- * composer holds leaves only by its own Send button — no action here sends.
- */
-type CarriedAppActionFields =
-  | {
-      kind: typeof APP_TOOL_KIND.SETTING;
-      setting: AppGuideSetting;
-      value: string;
-      /** The effort riding the new value, when the developer named both. */
-      effort?: string;
-    }
-  | {
-      kind: typeof APP_TOOL_KIND.PANEL;
-      tab: AppPanelTab;
-      /** The validated narrowing, combined like the chips: OR within an axis, AND across. */
-      filters?: readonly string[];
-      sort?: SessionListSort;
-      /** Words to search the list for, exactly as the developer asked them. */
-      query?: string;
-    }
-  | { kind: typeof APP_TOOL_KIND.FEEDBACK; composer: FeedbackComposerKind; draft?: string }
-  | { kind: typeof APP_TOOL_KIND.UPDATE; act: AppUpdateAct }
-  | {
-      kind: typeof APP_TOOL_KIND.REMEMBER;
-      /** One concise durable fact selected from the developer-opened turn. */
-      words: string;
-      /** The id of the fact this one stands in for, when it changes one. */
-      replaces?: string;
-    }
-  | { kind: typeof APP_TOOL_KIND.FORGET; id: string };
-
-export type CarriedAppAction = CarriedAppActionFields & {
-  status?: never;
-  reason?: never;
-};
-export type AppToolAction = CarriedAppAction | ActRejection;
-
-export type CarriedAct = CarriedSessionAction | CarriedIssueAction | CarriedAppAction;
-
-export interface SessionToolContext {
-  sessions: readonly Session[];
-  workspaceProjects: readonly ObservedWorkspaceProject[];
-  agentModels: (providerId: string) => readonly WorkspaceAgentModels[];
-  /**
-   * The developer's saved tie-breaks for a creation ask, the same ones the
-   * projects context narrates: the provider a nameless ask goes to, and each
-   * provider's chosen project. Both only ever narrow within the listed
-   * projects — a default can settle an ambiguous ask, never widen where one
-   * can land or override a provider or project the ask actually named.
-   */
-  defaultProviderId?: string;
-  defaultProjectIds?: Readonly<Partial<Record<string, string>>>;
-}
-
-export interface IssueToolContext {
-  issues: readonly TrackedIssue[];
-}
-
-export interface AppToolContext {
-  guide: AppGuideSnapshot;
-  sessions: readonly Session[];
-  /**
-   * The facts standing right now, which a replacement or a removal is
-   * validated against — the same discipline a session act keeps against the
-   * roster. An id the conversation was never shown names nothing.
-   */
-  rememberedFacts: readonly RememberedFact[];
-}
-
-type JsonSchemaStringProperty = {
-  type: "string";
-  description?: string;
-  enum?: readonly string[];
-};
-
-type JsonSchemaObjectProperty = {
-  type: "object";
-  description?: string;
-  properties?: JsonSchemaPropertyMap;
-  required?: readonly string[];
-  additionalProperties?: boolean;
-};
-
-type JsonSchemaArrayProperty = {
-  type: "array";
-  description?: string;
-  items: JsonSchemaStringProperty;
-};
-
-type JsonSchemaScalarProperty = {
-  type: "integer" | "boolean";
-  description?: string;
-};
-
-type JsonSchemaProperty =
-  | JsonSchemaStringProperty
-  | JsonSchemaObjectProperty
-  | JsonSchemaArrayProperty
-  | JsonSchemaScalarProperty;
-
-type JsonSchemaPropertyMap = {
-  readonly [key: string]: JsonSchemaProperty;
-};
-
-interface RealtimeToolParameters {
-  type: "object";
-  properties: JsonSchemaPropertyMap;
-  required: readonly string[];
-}
-
-export interface RealtimeToolWireDefinition {
-  type: "function";
-  name: string;
-  description: string;
-  parameters: RealtimeToolParameters;
-}
-
-type SessionToolValidate = (parsed: WireRecord, context: SessionToolContext) => SessionToolAction;
-
-type IssueToolValidate = (parsed: WireRecord, context: IssueToolContext) => IssueToolAction;
-
-type AppToolValidate = (parsed: WireRecord, context: AppToolContext) => AppToolAction;
-
-type ActActionKind = CarriedAct["kind"];
-type ActNarration = (action: CarriedAct, sessions: readonly Session[]) => string;
-
-interface RealtimeToolSchema {
-  description: string;
-  parameters: RealtimeToolParameters;
-}
-
-type SessionToolSpec = {
-  name: string;
-  family: typeof REALTIME_TOOL_FAMILY.SESSION;
-  actionKind: ActActionKind;
-  narration: ActNarration;
-  schema: RealtimeToolSchema;
+/** What a row declares: what it is called, what it is, what it says, and what it takes. */
+export interface ToolSpec<Family extends ActFamily, Kind extends ActKind> {
+  readonly name: string;
+  readonly family: Family;
+  readonly kind: Kind;
+  readonly description: string;
+  /** The act's own field vocabulary: what admission reads and what the model is shown. */
+  readonly request: Schema<unknown>;
   /**
    * The same act as the phone offers it, where the phone's surface gives the
    * act a different shape: an open lands on the app's own screen rather than
    * a provider's address, and the list narrows on the axes its chips hold.
-   * Absent, the phone is handed the desktop's schema unchanged.
+   * Absent, the phone is handed the desktop's.
    */
-  remoteSchema?: RealtimeToolSchema;
-  validate: SessionToolValidate;
-};
-
-type IssueToolSpec = {
-  name: string;
-  family: typeof REALTIME_TOOL_FAMILY.ISSUE;
-  actionKind: ActActionKind;
-  narration: ActNarration;
-  schema: RealtimeToolSchema;
-  remoteSchema?: RealtimeToolSchema;
-  validate: IssueToolValidate;
-};
-
-type AppToolSpec = {
-  name: string;
-  family: typeof REALTIME_TOOL_FAMILY.APP;
-  actionKind: ActActionKind;
-  narration: ActNarration;
-  schema: RealtimeToolSchema;
-  remoteSchema?: RealtimeToolSchema;
-  validate: AppToolValidate;
-};
-
-type RealtimeToolSpec = SessionToolSpec | IssueToolSpec | AppToolSpec;
-
-const SESSION_IDENTITY_PARAMETERS = {
-  provider_id: {
-    type: "string",
-    description: "The session provider ID.",
-  },
-  provider_session_id: {
-    type: "string",
-    description: "The session ID.",
-  },
-} as const;
-
-const ISSUE_IDENTITY_PARAMETERS = {
-  tracker_id: {
-    type: "string",
-    description: "The tracker ID.",
-  },
-  issue_id: {
-    type: "string",
-    description: "The issue ID.",
-  },
-} as const;
-
-function textArgument(record: WireRecord, key: string): string | undefined {
-  return wireText(record[key]);
-}
-
-function parseToolArguments(
-  call: RealtimeFunctionCall,
-): { ok: true; value: WireRecord } | { ok: false; reason: string } {
-  let parsed: UnparsedWireValue;
-  try {
-    // SAFETY: JSON.parse returns a runtime value; isRecord validates the object contract.
-    parsed = JSON.parse(call.argumentsJson) as UnparsedWireValue;
-  } catch {
-    return { ok: false, reason: "The tool call's arguments were not readable." };
-  }
-  if (!isRecord(parsed)) {
-    return { ok: false, reason: "The tool call's arguments were not readable." };
-  }
-  return { ok: true, value: parsed };
-}
-
-function sessionFromArguments(
-  parsed: WireRecord,
-  sessions: readonly Session[],
-): { session: Session; identity: SessionIdentity } | ActRejection {
-  const providerId = textArgument(parsed, "provider_id");
-  const providerSessionId = textArgument(parsed, "provider_session_id");
-  const session = sessions.find(
-    (candidate) =>
-      candidate.providerId === providerId && candidate.providerSessionId === providerSessionId,
-  );
-  if (!session) {
-    return {
-      status: ACT_RESULT_STATUS.REJECTED,
-      reason: "No observed session matches that identity.",
-    };
-  }
-  return {
-    session,
-    identity: {
-      providerId: session.providerId,
-      providerSessionId: session.providerSessionId,
-    },
-  };
-}
-
-function issueFromArguments(
-  parsed: WireRecord,
-  issues: readonly TrackedIssue[],
-): { issue: TrackedIssue; identity: IssueIdentity } | ActRejection {
-  const trackerId = textArgument(parsed, "tracker_id");
-  const issueId = textArgument(parsed, "issue_id");
-  const issue = issues.find(
-    (candidate) => candidate.trackerId === trackerId && candidate.identifier === issueId,
-  );
-  if (!issue) {
-    return {
-      status: ACT_RESULT_STATUS.REJECTED,
-      reason: "No tracked issue matches that identity.",
-    };
-  }
-  return {
-    issue,
-    identity: {
-      trackerId: issue.trackerId,
-      identifier: issue.identifier,
-    },
-  };
-}
-
-/**
- * Resolves a model the developer named — by the label the guide lists it
- * under, or its id — to the wire pairing an endpoint takes, held to the
- * build's documented entries for the provider. The effort, when named, must
- * be one the resolved model's own agent documents: the pairing is validated
- * as the whole it will be sent as.
- */
-function resolveWorkspaceAgentModel(
-  entries: readonly WorkspaceAgentModels[],
-  modelWord: string,
-  effortWord: string | undefined,
-): { selection: WorkspaceAgentSelection } | { refusal: string } {
-  const normalizedModel = modelWord.trim().toLowerCase();
-  const named = entries
-    .flatMap((entry) => entry.models.map((model) => ({ entry, model })))
-    .find(
-      ({ model }) =>
-        model.label.toLowerCase() === normalizedModel || model.id.toLowerCase() === normalizedModel,
-    );
-  if (!named) return { refusal: "No documented model goes by that name here." };
-  let effort: string | undefined;
-  if (effortWord !== undefined) {
-    const normalizedEffort = effortWord.trim().toLowerCase();
-    effort = named.entry.efforts.find((candidate) => candidate.toLowerCase() === normalizedEffort);
-    if (!effort) {
-      return {
-        refusal:
-          named.entry.efforts.length > 0
-            ? `That model's effort is one of ${named.entry.efforts.join(", ")}.`
-            : "That model takes no effort level.",
-      };
-    }
-  }
-  const selection: WorkspaceAgentSelection = {
-    agent: named.entry.agent,
-    model: named.model.id,
-  };
-  if (effort) selection.effort = effort;
-  return { selection };
-}
-
-function validateSendSessionMessage(
-  parsed: WireRecord,
-  context: SessionToolContext,
-): SessionToolAction {
-  const found = sessionFromArguments(parsed, context.sessions);
-  if ("status" in found) return found;
-  const { session, identity } = found;
-  if (!advertisedActFor(session, ACT_KIND.MESSAGE)) {
-    return {
-      status: ACT_RESULT_STATUS.REJECTED,
-      reason: "That session does not take messages right now.",
-    };
-  }
-  const messageText = sessionMessageText(parsed.text);
-  if (!messageText) {
-    return {
-      status: ACT_RESULT_STATUS.REJECTED,
-      reason: "That message is empty or too long.",
-    };
-  }
-  return { kind: SESSION_TOOL_KIND.MESSAGE, identity, text: messageText };
-}
-
-function validateRunSessionControl(
-  parsed: WireRecord,
-  context: SessionToolContext,
-): SessionToolAction {
-  const found = sessionFromArguments(parsed, context.sessions);
-  if ("status" in found) return found;
-  const { session, identity } = found;
-  const controlId = textArgument(parsed, "control_id");
-  const control = controlId ? advertisedControl(session, controlId) : undefined;
-  if (!control) {
-    return {
-      status: ACT_RESULT_STATUS.REJECTED,
-      reason: "That session advertises no such control.",
-    };
-  }
-  return { kind: SESSION_TOOL_KIND.CONTROL, identity, control };
-}
-
-function validateOpenSession(parsed: WireRecord, context: SessionToolContext): SessionToolAction {
-  const found = sessionFromArguments(parsed, context.sessions);
-  if ("status" in found) return found;
-  const { session, identity } = found;
-  // The action carries the identity — and, when the developer named an app,
-  // that app's id — never the address: the main process reads the link back
-  // out of its own registry, the same as a pressed row or a pressed app mark.
-  const applicationWord = textArgument(parsed, "application");
-  if (applicationWord !== undefined) {
-    const normalized = applicationWord.trim().toLowerCase();
-    const application = session.applications.find(
-      (candidate) =>
-        candidate.displayName.toLowerCase() === normalized || candidate.id === normalized,
-    );
-    // An association without an exact address identifies the app but opens
-    // nothing, so it refuses like an app the roster never listed — and the
-    // refusal names the apps that can open, which the roster already carries.
-    // The id must be one the build fixed: the bridge takes no other, and the
-    // main process would refuse it again.
-    const applicationId = application?.link ? application.id : undefined;
-    if (applicationId === undefined || !isSessionApplicationId(applicationId)) {
-      const openable = session.applications.filter((candidate) => candidate.link);
-      return {
-        status: ACT_RESULT_STATUS.REJECTED,
-        reason:
-          openable.length > 0
-            ? `That session opens in ${openable
-                .map((candidate) => candidate.displayName)
-                .join(" or ")}, not there.`
-            : "No app carries an exact address for that session.",
-      };
-    }
-    return { kind: SESSION_TOOL_KIND.OPEN, identity, applicationId };
-  }
-  if (!session.detail.link) {
-    return { status: ACT_RESULT_STATUS.REJECTED, reason: "That session has no address to open." };
-  }
-  return { kind: SESSION_TOOL_KIND.OPEN, identity };
-}
-
-function validateCreateWorkspace(
-  parsed: WireRecord,
-  context: SessionToolContext,
-): SessionToolAction {
-  // A creation ask names a project rather than a session, so it is validated
-  // against the projects the conversation was shown — the same discipline,
-  // against the list that actually offered it.
-  const providerId = textArgument(parsed, "provider_id");
-  const projectId = textArgument(parsed, "project_id");
-  const targetId = textArgument(parsed, "target_id");
-  let matchingProjects = context.workspaceProjects.filter(
-    (candidate) =>
-      (!providerId || candidate.providerId === providerId) &&
-      (!projectId || candidate.providerProjectId === projectId) &&
-      (!targetId || candidate.providerTargetId === targetId),
-  );
-  // The saved defaults settle only what the ask left unnamed: no provider
-  // named sends a still-ambiguous ask to the default provider while it is
-  // offering, and no project named sends it on to that provider's chosen
-  // project. Neither step can leave the listed set, and an ask that named
-  // its own provider or project is never overridden.
-  if (!providerId && context.defaultProviderId && matchingProjects.length > 1) {
-    const offeredByDefault = matchingProjects.filter(
-      (candidate) => candidate.providerId === context.defaultProviderId,
-    );
-    if (offeredByDefault.length > 0) matchingProjects = offeredByDefault;
-  }
-  // A provider's chosen project settles which project, never which provider:
-  // while candidates still span providers, one provider's saved project must
-  // not quietly decide an ask the developer left open between them.
-  const [firstMatch] = matchingProjects;
-  const oneProviderMatches =
-    firstMatch !== undefined &&
-    matchingProjects.every((candidate) => candidate.providerId === firstMatch.providerId);
-  if (!projectId && oneProviderMatches && matchingProjects.length > 1) {
-    const chosenProjects = matchingProjects.filter(
-      (candidate) =>
-        context.defaultProjectIds?.[candidate.providerId] ===
-        workspaceProjectSelectionId(candidate),
-    );
-    if (chosenProjects.length === 1) matchingProjects = chosenProjects;
-  }
-  if (matchingProjects.length !== 1) {
-    return {
-      status: ACT_RESULT_STATUS.REJECTED,
-      reason:
-        matchingProjects.length === 0
-          ? "No listed project matches that identity."
-          : "More than one listed project matches; name the project and host.",
-    };
-  }
-  const project = matchingProjects[0];
-  if (!project)
-    return {
-      status: ACT_RESULT_STATUS.REJECTED,
-      reason: "No listed project matches that identity.",
-    };
-  const requestedAgent = textArgument(parsed, "agent");
-  const matchingAgents = requestedAgent
-    ? project.spawnableAgents?.filter(
-        (candidate) => candidate.toLocaleLowerCase() === requestedAgent.toLocaleLowerCase(),
-      )
-    : undefined;
-  const agent =
-    (requestedAgent && project.spawnableAgents?.includes(requestedAgent)
-      ? requestedAgent
-      : matchingAgents?.length === 1
-        ? matchingAgents[0]
-        : undefined) ?? project.defaultAgent;
-  if (project.spawnableAgents && (!agent || !project.spawnableAgents.includes(agent))) {
-    return {
-      status: ACT_RESULT_STATUS.REJECTED,
-      reason: agent
-        ? "That project lists no such agent to start."
-        : "Name one of the agents that project lists for a new workspace.",
-    };
-  }
-  let name: string | undefined;
-  if (parsed.name !== undefined) {
-    if (project.namesItself) {
-      return {
-        status: ACT_RESULT_STATUS.REJECTED,
-        reason: "That project names its own workspaces.",
-      };
-    }
-    name = workspaceNameText(parsed.name);
-    if (!name) {
-      return {
-        status: ACT_RESULT_STATUS.REJECTED,
-        reason: `A workspace name has to be under ${maximumWorkspaceNameLength} characters and longer than nothing.`,
-      };
-    }
-  }
-  // The task is held to the project's own word for it: a project that takes
-  // none cannot be handed one, a project that needs one cannot be created
-  // without it, and the text itself is bounded like the message it is.
-  let task: string | undefined;
-  if (parsed.task !== undefined) {
-    if (project.taskSupport === WORKSPACE_TASK_SUPPORT.NONE) {
-      return { status: ACT_RESULT_STATUS.REJECTED, reason: "That project takes no opening task." };
-    }
-    task = sessionMessageText(parsed.task);
-    if (!task) {
-      return {
-        status: ACT_RESULT_STATUS.REJECTED,
-        reason: "That task is empty or too long.",
-      };
-    }
-  } else if (project.taskSupport === WORKSPACE_TASK_SUPPORT.REQUIRED) {
-    return {
-      status: ACT_RESULT_STATUS.REJECTED,
-      reason: "That project needs an opening task to create a workspace.",
-    };
-  }
-  // A model named for this one creation resolves against the provider's own
-  // documented table, and the effort only ever rides a model: alone it has
-  // nothing documented to attach to.
-  const spokenModel = textArgument(parsed, "model");
-  const spokenEffort = textArgument(parsed, "effort");
-  if (spokenEffort !== undefined && spokenModel === undefined) {
-    return {
-      status: ACT_RESULT_STATUS.REJECTED,
-      reason: "An effort rides a model; name the model too.",
-    };
-  }
-  let agentSelection: WorkspaceAgentSelection | undefined;
-  if (spokenModel !== undefined) {
-    const resolved = resolveWorkspaceAgentModel(
-      context.agentModels(project.providerId),
-      spokenModel,
-      spokenEffort,
-    );
-    if ("refusal" in resolved)
-      return { status: ACT_RESULT_STATUS.REJECTED, reason: resolved.refusal };
-    agentSelection = resolved.selection;
-  }
-  const action: CarriedSessionAction = {
-    kind: SESSION_TOOL_KIND.CREATE_WORKSPACE,
-    providerId: project.providerId,
-    providerProjectId: project.providerProjectId,
-  };
-  if (project.providerTargetId) action.providerTargetId = project.providerTargetId;
-  if (agent) action.agent = agent;
-  if (name) action.name = name;
-  if (task) action.task = task;
-  if (agentSelection) action.agentSelection = agentSelection;
-  return action;
-}
-
-function validateAddWorkspaceAgent(
-  parsed: WireRecord,
-  context: SessionToolContext,
-): SessionToolAction {
-  const found = sessionFromArguments(parsed, context.sessions);
-  if ("status" in found) return found;
-  const { session, identity } = found;
-  // The agent must be one this session's own roster entry listed: the list
-  // is the provider's word for what its endpoint takes, so an ask outside it
-  // is refused rather than forwarded to be refused.
-  const agent = textArgument(parsed, "agent");
-  if (!agent || !advertisedActFor(session, ACT_KIND.ADD_AGENT)?.agents.includes(agent)) {
-    return {
-      status: ACT_RESULT_STATUS.REJECTED,
-      reason: "That session lists no such agent to add.",
-    };
-  }
-  let name: string | undefined;
-  if (parsed.name !== undefined) {
-    name = workspaceNameText(parsed.name);
-    if (!name) {
-      return {
-        status: ACT_RESULT_STATUS.REJECTED,
-        reason: `A session name has to be under ${maximumWorkspaceNameLength} characters and longer than nothing.`,
-      };
-    }
-  }
-  let task: string | undefined;
-  if (parsed.task !== undefined) {
-    task = sessionMessageText(parsed.task);
-    if (!task) {
-      return {
-        status: ACT_RESULT_STATUS.REJECTED,
-        reason: "That task is empty or too long.",
-      };
-    }
-  }
-  // A model named for this one agent resolves within the asked-for kind
-  // alone: the developer's chosen agent is never re-decided by the model
-  // they named beside it, so a mismatch is a refusal rather than a swap.
-  const spokenModel = textArgument(parsed, "model");
-  const spokenEffort = textArgument(parsed, "effort");
-  if (spokenEffort !== undefined && spokenModel === undefined) {
-    return {
-      status: ACT_RESULT_STATUS.REJECTED,
-      reason: "An effort rides a model; name the model too.",
-    };
-  }
-  let selection: WorkspaceAgentSelection | undefined;
-  if (spokenModel !== undefined) {
-    const entries = context
-      .agentModels(session.providerId)
-      .filter((candidate) => candidate.agent === agent);
-    const resolved = resolveWorkspaceAgentModel(entries, spokenModel, spokenEffort);
-    if ("refusal" in resolved) {
-      return {
-        status: ACT_RESULT_STATUS.REJECTED,
-        reason: resolved.refusal.startsWith("No documented model")
-          ? `A ${agent} agent runs no model by that name.`
-          : resolved.refusal,
-      };
-    }
-    selection = resolved.selection;
-  }
-  const action: CarriedSessionAction = {
-    kind: SESSION_TOOL_KIND.ADD_AGENT,
-    identity,
-    agent,
-  };
-  if (name) action.name = name;
-  if (task) action.task = task;
-  if (selection) action.model = selection.model;
-  if (selection?.effort) action.effort = selection.effort;
-  return action;
-}
-
-function validateRenameWorkspace(
-  parsed: WireRecord,
-  context: SessionToolContext,
-): SessionToolAction {
-  const found = sessionFromArguments(parsed, context.sessions);
-  if ("status" in found) return found;
-  const { session, identity } = found;
-  // Only a session whose roster entry advertised renaming has a workspace a
-  // rename can land on. The action carries the identity and the name, never
-  // the target: the main process resolves the workspace from its own
-  // registry, the same way an open never carries an address.
-  if (!advertisedActFor(session, ACT_KIND.RENAME_WORKSPACE)) {
-    return {
-      status: ACT_RESULT_STATUS.REJECTED,
-      reason: "That session's workspace cannot be renamed.",
-    };
-  }
-  const name = workspaceNameText(parsed.name);
-  if (!name) {
-    return {
-      status: ACT_RESULT_STATUS.REJECTED,
-      reason: `A workspace name has to be under ${maximumWorkspaceNameLength} characters and longer than nothing.`,
-    };
-  }
-  return { kind: SESSION_TOOL_KIND.RENAME_WORKSPACE, identity, name };
-}
-
-function validateRenameSession(parsed: WireRecord, context: SessionToolContext): SessionToolAction {
-  const found = sessionFromArguments(parsed, context.sessions);
-  if ("status" in found) return found;
-  const { session, identity } = found;
-  if (!advertisedActFor(session, ACT_KIND.RENAME_SESSION)) {
-    return { status: ACT_RESULT_STATUS.REJECTED, reason: "That chat cannot be renamed." };
-  }
-  const name = workspaceNameText(parsed.name);
-  if (!name) {
-    return {
-      status: ACT_RESULT_STATUS.REJECTED,
-      reason: `A chat name has to be under ${maximumWorkspaceNameLength} characters and longer than nothing.`,
-    };
-  }
-  return { kind: SESSION_TOOL_KIND.RENAME_SESSION, identity, name };
-}
-
-function validateUpdateIssueState(parsed: WireRecord, context: IssueToolContext): IssueToolAction {
-  const found = issueFromArguments(parsed, context.issues);
-  if ("status" in found) return found;
-  const { issue, identity } = found;
-  const state = textArgument(parsed, "state");
-  // Spoken names arrive with their case retold rather than copied, so the
-  // match forgives case alone — never spelling — and only while it stays
-  // unambiguous. Two advertised states apart only in case are not a guess
-  // Luke gets to make.
-  const named = state
-    ? issue.transitions.filter((candidate) => candidate.name.toLowerCase() === state.toLowerCase())
-    : [];
-  const transition =
-    named.find((candidate) => candidate.name === state) ??
-    (named.length === 1 ? named[0] : undefined);
-  if (!transition) {
-    return { status: ACT_RESULT_STATUS.REJECTED, reason: "That issue lists no such state." };
-  }
-  return { kind: ISSUE_TOOL_KIND.ISSUE_STATE, identity, transition };
-}
-
-function validateCommentOnIssue(parsed: WireRecord, context: IssueToolContext): IssueToolAction {
-  const found = issueFromArguments(parsed, context.issues);
-  if ("status" in found) return found;
-  const { issue, identity } = found;
-  if (!issue.canComment) {
-    return { status: ACT_RESULT_STATUS.REJECTED, reason: "That issue does not take comments." };
-  }
-  const body = issueCommentText(parsed.body);
-  if (!body) {
-    return {
-      status: ACT_RESULT_STATUS.REJECTED,
-      reason: "That comment is empty or too long.",
-    };
-  }
-  return { kind: ISSUE_TOOL_KIND.ISSUE_COMMENT, identity, body };
-}
-
-/**
- * Validates the value a spoken change carries against the setting it names.
- * A toggle takes the guide's own two words (and their unambiguous synonyms);
- * a choice takes exactly one of the values the guide listed. Anything else is
- * refused with the accepted set, so the refusal is also the correction.
- */
-function appSettingValue(setting: AppGuideSetting, value: UnparsedWireValue): string | undefined {
-  if (setting.kind === APP_SETTING_KIND.TOGGLE) return appToggleValue(value);
-  if (!isWireString(value)) return undefined;
-  const normalized = value.trim().toLowerCase();
-  return setting.choices?.find((choice) => choice.toLowerCase() === normalized);
-}
-
-/**
- * Whether one observed session answers one spoken filter value. Every
- * identity a row carries is a filter on the same terms as its provider id —
- * the agent behind a hosted chat, an app associated with it, and a workspace
- * manager's scope id — so a spoken ask reaches exactly the rows the matching
- * chip would keep.
- */
-function sessionAnswersFilter(session: Session, filter: string): boolean {
-  if (filter === SESSION_LOCATION.LOCAL || filter === SESSION_LOCATION.CLOUD) {
-    return session.location === filter;
-  }
-  if (filter === SESSION_LIST_VOICE) return session.realtimeVoice === true;
-  return (
-    session.providerId === filter ||
-    session.agent?.id === filter ||
-    session.workspace?.scopeId === filter ||
-    session.applications.some((application) => application.id === filter)
-  );
-}
-
-/**
- * Validates a spoken session-list narrowing against the sessions actually
- * being observed. A narrowing that would show nothing is refused rather than
- * applied: the panel would quietly fall back to showing everything, and Luke
- * would have reported a narrowing that never happened. Each value is checked
- * on its own first, so the refusal can name the value that is wrong rather
- * than only the combination — and then the combination is checked whole, on
- * the same axis terms the chips combine on, because two values a roster
- * answers separately can still name an intersection nothing occupies.
- */
-function panelFiltersAction(
-  filters: readonly string[],
-  sessions: readonly Session[],
-): { filters: readonly string[] } | { reason: string } {
-  // The enum on the tool's own schema already binds a compliant model to
-  // these tokens; this is the backstop for a call composed past it.
-  for (const filter of filters) {
-    if (!SESSION_LIST_FILTER_VALUES.includes(filter)) {
-      return { reason: `"${filter}" is not one of the filter values the tool lists.` };
-    }
-  }
-  const chosen = [...new Set(filters)];
-  if (chosen.includes(SESSION_LIST_ALL)) {
-    if (chosen.length > 1) {
-      return { reason: `${SESSION_LIST_ALL} is the whole list, so it combines with nothing.` };
-    }
-    return { filters: chosen };
-  }
-  for (const filter of chosen) {
-    if (sessions.some((session) => sessionAnswersFilter(session, filter))) continue;
-    if (filter === SESSION_LOCATION.LOCAL || filter === SESSION_LOCATION.CLOUD) {
-      return { reason: `No ${filter} sessions are observed right now.` };
-    }
-    if (filter === SESSION_LIST_VOICE) {
-      return { reason: "No voice sessions are observed right now." };
-    }
-    return {
-      reason: `No observed session belongs to an agent, app, or workspace manager "${filter}".`,
-    };
-  }
-  if (
-    chosen.length > 1 &&
-    !sessions.some((session) =>
-      matchesFilterSelection(chosen, (filter) => sessionAnswersFilter(session, filter)),
-    )
-  ) {
-    return { reason: "No observed session matches that combination of filters." };
-  }
-  return { filters: chosen };
-}
-
-function validateChangeAppSetting(parsed: WireRecord, context: AppToolContext): AppToolAction {
-  const setting = appGuideSetting(context.guide, textArgument(parsed, "setting_id"));
-  if (!setting) {
-    return { status: ACT_RESULT_STATUS.REJECTED, reason: "The app guide lists no such setting." };
-  }
-  if (!setting.adjustable) {
-    return {
-      status: ACT_RESULT_STATUS.REJECTED,
-      reason: `${setting.label} can only be changed by hand: ${setting.manual}`,
-    };
-  }
-  const value = appSettingValue(setting, parsed.value);
-  if (value === undefined) {
-    const accepted =
-      setting.kind === APP_SETTING_KIND.TOGGLE ? "on or off" : (setting.choices ?? []).join(", ");
-    return { status: ACT_RESULT_STATUS.REJECTED, reason: `${setting.label} takes ${accepted}.` };
-  }
-  // An effort may ride only a value the guide lists levels for, so both
-  // halves of one stored pairing can be asked for in one change — matched
-  // like the value: case retold rather than copied, answered in the guide's
-  // own casing.
-  const effortWord = textArgument(parsed, "effort");
-  if (effortWord === undefined) return { kind: APP_TOOL_KIND.SETTING, setting, value };
-  const levels = setting.efforts?.[value] ?? [];
-  if (levels.length === 0) {
-    return {
-      status: ACT_RESULT_STATUS.REJECTED,
-      reason:
-        setting.efforts === undefined
-          ? `${setting.label} takes no effort level.`
-          : `${value} takes no effort level.`,
-    };
-  }
-  const normalizedEffort = effortWord.trim().toLowerCase();
-  const effort = levels.find((candidate) => candidate.toLowerCase() === normalizedEffort);
-  if (effort === undefined) {
-    return {
-      status: ACT_RESULT_STATUS.REJECTED,
-      reason: `${value}'s effort is one of ${levels.join(", ")}.`,
-    };
-  }
-  return { kind: APP_TOOL_KIND.SETTING, setting, value, effort };
-}
-
-/**
- * Reads the narrowing a panel ask carries: several values, or a lone string
- * for a narrowing of one. Blank entries are dropped rather than validated,
- * and an emptied list is no narrowing at all.
- */
-function spokenFilterValues(
-  value: UnparsedWireValue,
-): { values: readonly string[] | undefined } | { reason: string } {
-  if (value === undefined) return { values: undefined };
-  const entries = isWireString(value) ? [value] : value;
-  if (!Array.isArray(entries) || !entries.every((entry) => isWireString(entry))) {
-    return { reason: "filters takes a list of filter values." };
-  }
-  const cleaned = entries.map((entry) => entry.trim()).filter((entry) => entry.length > 0);
-  return { values: cleaned.length > 0 ? cleaned : undefined };
-}
-
-function validateShowPanel(parsed: WireRecord, context: AppToolContext): AppToolAction {
-  const tab = parsed.tab ?? APP_PANEL_TAB.SESSIONS;
-  if (!isAppPanelTab(tab)) {
-    return { status: ACT_RESULT_STATUS.REJECTED, reason: "The panel has no such tab." };
-  }
-  const sort = textArgument(parsed, "sort");
-  if (sort !== undefined && !isSessionListSort(sort)) {
-    return {
-      status: ACT_RESULT_STATUS.REJECTED,
-      reason: "The list orders by urgency or by recency.",
-    };
-  }
-  // A search is bounded by the hand's own control: the magnifier is only
-  // offered beside a list with more than one session, and a spoken ask
-  // reaches no further than it. The words themselves are not validated
-  // against the rows the way a filter is — a query is read against the lines
-  // as the surface words them, which only the renderer knows, and a search
-  // matching nothing is the list's own honest answer rather than a stale
-  // narrowing to refuse.
-  const query = textArgument(parsed, "query");
-  if (query !== undefined && context.sessions.length < 2) {
-    return {
-      status: ACT_RESULT_STATUS.REJECTED,
-      reason: "The list offers a search only when more than one session is observed.",
-    };
-  }
-  const asked = spokenFilterValues(parsed.filters);
-  if ("reason" in asked) return { status: ACT_RESULT_STATUS.REJECTED, reason: asked.reason };
-  if (asked.values === undefined) {
-    const action: CarriedAppAction = { kind: APP_TOOL_KIND.PANEL, tab };
-    if (sort !== undefined) action.sort = sort;
-    if (query !== undefined) action.query = query;
-    return action;
-  }
-  const outcome = panelFiltersAction(asked.values, context.sessions);
-  if ("reason" in outcome) return { status: ACT_RESULT_STATUS.REJECTED, reason: outcome.reason };
-  const action: CarriedAppAction = {
-    kind: APP_TOOL_KIND.PANEL,
-    tab,
-    filters: outcome.filters,
-  };
-  if (sort !== undefined) action.sort = sort;
-  if (query !== undefined) action.query = query;
-  return action;
-}
-
-function validateOpenFeedbackComposer(parsed: WireRecord, _context: AppToolContext): AppToolAction {
-  const composer = parsed.kind;
-  if (!isFeedbackComposerKind(composer)) {
-    return {
-      status: ACT_RESULT_STATUS.REJECTED,
-      reason: "The composer writes feedback or a prompt, nothing else.",
-    };
-  }
-  // The draft is the developer's ask restated in their words, not a document,
-  // so it is bounded like a typed one; a blank draft is no draft, and the
-  // composer simply opens empty.
-  const draft = textArgument(parsed, "draft")?.slice(0, maximumSessionMessageLength);
-  const action: CarriedAppAction = { kind: APP_TOOL_KIND.FEEDBACK, composer };
-  if (draft) action.draft = draft;
-  return action;
-}
-
-/**
- * What stands where the asked-for act would be, so a refusal can say why the
- * row is not offering it — the row's own detail says where the build stands,
- * and this names the one press that stands instead.
- */
-const UPDATE_BUTTON_STANDING = {
-  [APP_UPDATE_ACT.CHECK]: "Its button offers a check right now.",
-  [APP_UPDATE_ACT.DOWNLOAD]: "Its button offers the releases page in the browser right now.",
-  [APP_UPDATE_ACT.RESTART]: "Its button offers Restart to update right now.",
-  [APP_UPDATE_WAIT.CHECKING]: "Nothing is pressable while the check is out.",
-  [APP_UPDATE_WAIT.DOWNLOADING]: "Nothing is pressable while the download runs.",
-} as const satisfies Record<AppGuideUpdate["button"], string>;
-
-function validateRunUpdateAction(parsed: WireRecord, context: AppToolContext): AppToolAction {
-  // The guide's update entry is the roster here: a run that reported nothing
-  // about updates — a fixture, a pure caller — advertises no act to run.
-  const update = context.guide.update;
-  if (!update) {
-    return {
-      status: ACT_RESULT_STATUS.REJECTED,
-      reason: "This run does not report where updates stand.",
-    };
-  }
-  const act = parsed.action;
-  if (!isAppUpdateAct(act)) {
-    return {
-      status: ACT_RESULT_STATUS.REJECTED,
-      reason: "The Updates button checks, downloads, or restarts.",
-    };
-  }
-  // One button, one act: only the press the row is actually drawing runs, so
-  // the refusal is the row's own words plus what stands in the act's place.
-  if (act !== update.button) {
-    return {
-      status: ACT_RESULT_STATUS.REJECTED,
-      reason: `${update.detail} ${UPDATE_BUTTON_STANDING[update.button]}`,
-    };
-  }
-  return { kind: APP_TOOL_KIND.UPDATE, act };
-}
-
-/** Validates one automatic memory update against the bounded list in context. */
-function validateRememberFact(parsed: WireRecord, context: AppToolContext): AppToolAction {
-  const words = rememberedFactText(parsed.words);
-  if (!words) {
-    return {
-      status: ACT_RESULT_STATUS.REJECTED,
-      reason: `A memory has to be under ${maximumRememberedFactLength} characters and longer than nothing.`,
-    };
-  }
-  const replaces = textArgument(parsed, "replaces");
-  if (replaces !== undefined && !holdsRememberedFact(context.rememberedFacts, replaces)) {
-    return {
-      status: ACT_RESULT_STATUS.REJECTED,
-      reason: "Nothing remembered goes by that id.",
-    };
-  }
-  // A replacement retires one as it lands; a new fact never evicts silently.
-  if (replaces === undefined && context.rememberedFacts.length >= maximumRememberedFacts) {
-    return {
-      status: ACT_RESULT_STATUS.REJECTED,
-      reason: `Luke already remembers ${maximumRememberedFacts} things; replace or forget one first.`,
-    };
-  }
-  return { kind: APP_TOOL_KIND.REMEMBER, words, ...(replaces ? { replaces } : undefined) };
-}
-
-function validateForgetFact(parsed: WireRecord, context: AppToolContext): AppToolAction {
-  const id = textArgument(parsed, "id");
-  if (!id || !holdsRememberedFact(context.rememberedFacts, id)) {
-    return { status: ACT_RESULT_STATUS.REJECTED, reason: "Nothing remembered goes by that id." };
-  }
-  return { kind: APP_TOOL_KIND.FORGET, id };
-}
-
-function observedSessionName(identity: SessionIdentity, sessions: readonly Session[]): string {
-  const session = sessions.find(
-    (candidate) =>
-      candidate.providerId === identity.providerId &&
-      candidate.providerSessionId === identity.providerSessionId,
-  );
-  return session ? `"${session.title}"` : "a session";
-}
-
-function observedApplicationName(
-  identity: SessionIdentity,
-  applicationId: SessionApplicationId,
-  sessions: readonly Session[],
-): string {
-  const session = sessions.find(
-    (candidate) =>
-      candidate.providerId === identity.providerId &&
-      candidate.providerSessionId === identity.providerSessionId,
-  );
-  return (
-    session?.applications.find((application) => application.id === applicationId)?.displayName ??
-    applicationId
-  );
-}
-
-function narrate<K extends ActActionKind>(
-  kind: K,
-  render: (action: Extract<CarriedAct, { kind: K }>, sessions: readonly Session[]) => string,
-): ActNarration {
-  return (action, sessions) => {
-    if (action.kind !== kind) return "carried an act";
-    // SAFETY: the equality above narrows the discriminated union to the kind
-    // captured beside this renderer; TypeScript cannot correlate generic K.
-    return render(action as Extract<CarriedAct, { kind: K }>, sessions);
-  };
+  readonly remote?: { readonly description: string; readonly request: Schema<unknown> };
 }
 
 /**
  * The acts Luke can carry, keyed the way a value set is: adding a tool is
  * adding a key, and the family sets, the spoken count, and the schema list
- * follow. Each row's `validate` is the renderer's half of the gauntlet — the
- * main process still validates the same act against what it observed.
+ * follow.
  */
 export const ACTS = {
   SEND_SESSION_MESSAGE: {
     name: "send_session_message",
-    family: REALTIME_TOOL_FAMILY.SESSION,
-    actionKind: SESSION_TOOL_KIND.MESSAGE,
-    narration: narrate(
-      SESSION_TOOL_KIND.MESSAGE,
-      (action, sessions) =>
-        `sent a message to ${observedSessionName(action.identity, sessions)}: "${action.text}"`,
-    ),
-    schema: {
-      description: "Send a message to an observed session.",
-      parameters: {
-        type: "object",
-        properties: {
-          ...SESSION_IDENTITY_PARAMETERS,
-          text: {
-            type: "string",
-            description: "The message to send.",
-          },
-        },
-        required: ["provider_id", "provider_session_id", "text"],
-      },
-    },
-    validate: validateSendSessionMessage,
+    family: ACT_FAMILY.SESSION,
+    kind: ACT_KIND.MESSAGE,
+    description: "Send a message to an observed session.",
+    request: MESSAGE_REQUEST,
   },
   RUN_SESSION_CONTROL: {
     name: "run_session_control",
-    family: REALTIME_TOOL_FAMILY.SESSION,
-    actionKind: SESSION_TOOL_KIND.CONTROL,
-    narration: narrate(
-      SESSION_TOOL_KIND.CONTROL,
-      (action, sessions) =>
-        `ran "${action.control.label}" on ${observedSessionName(action.identity, sessions)}`,
-    ),
-    schema: {
-      description: "Run a control advertised by an observed session.",
-      parameters: {
-        type: "object",
-        properties: {
-          ...SESSION_IDENTITY_PARAMETERS,
-          control_id: {
-            type: "string",
-            description: "The control ID.",
-          },
-        },
-        required: ["provider_id", "provider_session_id", "control_id"],
-      },
-    },
-    validate: validateRunSessionControl,
+    family: ACT_FAMILY.SESSION,
+    kind: ACT_KIND.CONTROL,
+    description: "Run a control advertised by an observed session.",
+    request: CONTROL_REQUEST,
   },
   OPEN_SESSION: {
     name: "open_session",
-    family: REALTIME_TOOL_FAMILY.SESSION,
-    actionKind: SESSION_TOOL_KIND.OPEN,
-    narration: narrate(SESSION_TOOL_KIND.OPEN, (action, sessions) => {
-      const name = observedSessionName(action.identity, sessions);
-      return action.applicationId
-        ? `opened ${name} in ${observedApplicationName(action.identity, action.applicationId, sessions)}`
-        : `opened ${name}`;
-    }),
-    schema: {
-      description:
-        "Open one observed session where its provider keeps it — only when the developer asks " +
-        "to open, go to, or jump into that specific session. An ask to show, see, or list " +
-        'sessions or agents — "show me the cloud agents" — filters the panel through ' +
-        "show_panel instead, never this. An ask to open one session per provider uses this tool " +
-        "once per matching provider in the same response, without filtering the panel first.",
-      parameters: {
-        type: "object",
-        properties: {
-          ...SESSION_IDENTITY_PARAMETERS,
-          application: {
-            type: "string",
-            description:
-              "The app to open the session in, as its roster line's opens_in lists it — only " +
-              "when the developer named one. Omitted, the session opens at its own address.",
-          },
-        },
-        required: ["provider_id", "provider_session_id"],
-      },
-    },
-    remoteSchema: {
+    family: ACT_FAMILY.SESSION,
+    kind: ACT_KIND.OPEN,
+    description:
+      "Open one observed session where its provider keeps it — only when the developer asks " +
+      "to open, go to, or jump into that specific session. An ask to show, see, or list " +
+      'sessions or agents — "show me the cloud agents" — filters the panel through ' +
+      "show_panel instead, never this. An ask to open one session per provider uses this tool " +
+      "once per matching provider in the same response, without filtering the panel first.",
+    request: OPEN_REQUEST,
+    remote: {
       description:
         "Open one observed session's own screen in this app, leaving this conversation — only " +
         "when the developer asks to open, go to, or jump into that specific session. An ask to " +
         'show, see, or list sessions or agents — "show me the waiting sessions" — narrows the ' +
         "list through show_panel instead, never this. The phone shows one screen, so open one " +
         "session per response; asked for several, ask which.",
-      parameters: {
-        type: "object",
-        properties: { ...SESSION_IDENTITY_PARAMETERS },
-        required: ["provider_id", "provider_session_id"],
-      },
+      request: REMOTE_OPEN_REQUEST,
     },
-    validate: validateOpenSession,
   },
   CREATE_WORKSPACE: {
     name: "create_workspace",
-    family: REALTIME_TOOL_FAMILY.SESSION,
-    actionKind: SESSION_TOOL_KIND.CREATE_WORKSPACE,
-    narration: narrate(
-      SESSION_TOOL_KIND.CREATE_WORKSPACE,
-      (action) =>
-        `asked ${action.providerId} to create a workspace${action.name ? ` named "${action.name}"` : ""}`,
-    ),
-    schema: {
-      description: "Create a workspace for a new agent.",
-      parameters: {
-        type: "object",
-        properties: {
-          provider_id: {
-            type: "string",
-            description: "The provider ID; omit it to create in the default provider.",
-          },
-          project_id: {
-            type: "string",
-            description: "The project ID; omit it to create in that provider's default project.",
-          },
-          target_id: {
-            type: "string",
-            description: "The target ID.",
-          },
-          agent: {
-            type: "string",
-            description: "The agent kind.",
-          },
-          name: {
-            type: "string",
-            description:
-              "The workspace's name: the developer's own when they chose one, otherwise a short, " +
-              "specific name composed from what the workspace is for, in a few words with no " +
-              "punctuation. Always supply one, except in a project listed as naming its own " +
-              "workspaces, which takes none.",
-          },
-          task: {
-            type: "string",
-            description: "An optional opening task.",
-          },
-          model: {
-            type: "string",
-            description: "An optional model.",
-          },
-          effort: {
-            type: "string",
-            description: "An optional effort level.",
-          },
-        },
-        required: [],
-      },
-    },
-    validate: validateCreateWorkspace,
+    family: ACT_FAMILY.SESSION,
+    kind: ACT_KIND.CREATE_WORKSPACE,
+    description: "Create a workspace for a new agent.",
+    request: CREATE_WORKSPACE_REQUEST,
   },
   ADD_WORKSPACE_AGENT: {
     name: "add_workspace_agent",
-    family: REALTIME_TOOL_FAMILY.SESSION,
-    actionKind: SESSION_TOOL_KIND.ADD_AGENT,
-    narration: narrate(
-      SESSION_TOOL_KIND.ADD_AGENT,
-      (action, sessions) =>
-        `added a ${action.agent} agent to ${observedSessionName(action.identity, sessions)}`,
-    ),
-    schema: {
-      description: "Add an agent to an observed workspace.",
-      parameters: {
-        type: "object",
-        properties: {
-          ...SESSION_IDENTITY_PARAMETERS,
-          agent: {
-            type: "string",
-            description: "The agent kind.",
-          },
-          name: {
-            type: "string",
-            description: "An optional agent name.",
-          },
-          task: {
-            type: "string",
-            description: "An optional opening task.",
-          },
-          model: {
-            type: "string",
-            description: "An optional model.",
-          },
-          effort: {
-            type: "string",
-            description: "An optional effort level.",
-          },
-        },
-        required: ["provider_id", "provider_session_id", "agent"],
-      },
-    },
-    validate: validateAddWorkspaceAgent,
+    family: ACT_FAMILY.SESSION,
+    kind: ACT_KIND.ADD_AGENT,
+    description: "Add an agent to an observed workspace.",
+    request: ADD_AGENT_REQUEST,
   },
   RENAME_WORKSPACE: {
     name: "rename_workspace",
-    family: REALTIME_TOOL_FAMILY.SESSION,
-    actionKind: SESSION_TOOL_KIND.RENAME_WORKSPACE,
-    narration: narrate(
-      SESSION_TOOL_KIND.RENAME_WORKSPACE,
-      (action, sessions) =>
-        `renamed the workspace of ${observedSessionName(action.identity, sessions)} to "${action.name}"`,
-    ),
-    schema: {
-      description:
-        "Rename the workspace one observed session runs in, to a name the developer just " +
-        "chose — their own words, never a name composed for them. Only sessions whose roster " +
-        "entry says the workspace can be renamed take one.",
-      parameters: {
-        type: "object",
-        properties: {
-          ...SESSION_IDENTITY_PARAMETERS,
-          name: {
-            type: "string",
-            description: "The workspace's new name, exactly as the developer chose it.",
-          },
-        },
-        required: ["provider_id", "provider_session_id", "name"],
-      },
-    },
-    validate: validateRenameWorkspace,
+    family: ACT_FAMILY.SESSION,
+    kind: ACT_KIND.RENAME_WORKSPACE,
+    description:
+      "Rename the workspace one observed session runs in, to a name the developer just " +
+      "chose — their own words, never a name composed for them. Only sessions whose roster " +
+      "entry says the workspace can be renamed take one.",
+    request: RENAME_WORKSPACE_REQUEST,
   },
   RENAME_SESSION: {
     name: "rename_session",
-    family: REALTIME_TOOL_FAMILY.SESSION,
-    actionKind: SESSION_TOOL_KIND.RENAME_SESSION,
-    narration: narrate(
-      SESSION_TOOL_KIND.RENAME_SESSION,
-      (action, sessions) =>
-        `renamed ${observedSessionName(action.identity, sessions)} to "${action.name}"`,
-    ),
-    schema: {
-      description:
-        "Rename one observed chat itself — not the workspace around it — to a name the " +
-        "developer just chose, in their own words. Only chats whose roster entry says they can " +
-        "be renamed take one; an ask that names the workspace renames the workspace instead.",
-      parameters: {
-        type: "object",
-        properties: {
-          ...SESSION_IDENTITY_PARAMETERS,
-          name: {
-            type: "string",
-            description: "The chat's new name, exactly as the developer chose it.",
-          },
-        },
-        required: ["provider_id", "provider_session_id", "name"],
-      },
-    },
-    validate: validateRenameSession,
+    family: ACT_FAMILY.SESSION,
+    kind: ACT_KIND.RENAME_SESSION,
+    description:
+      "Rename one observed chat itself — not the workspace around it — to a name the " +
+      "developer just chose, in their own words. Only chats whose roster entry says they can " +
+      "be renamed take one; an ask that names the workspace renames the workspace instead.",
+    request: RENAME_SESSION_REQUEST,
   },
   UPDATE_ISSUE_STATE: {
     name: "update_issue_state",
-    family: REALTIME_TOOL_FAMILY.ISSUE,
-    actionKind: ISSUE_TOOL_KIND.ISSUE_STATE,
-    narration: narrate(
-      ISSUE_TOOL_KIND.ISSUE_STATE,
-      (action) => `moved issue ${action.identity.identifier} to "${action.transition.name}"`,
-    ),
-    schema: {
-      description: "Update a tracked issue's state.",
-      parameters: {
-        type: "object",
-        properties: {
-          ...ISSUE_IDENTITY_PARAMETERS,
-          state: {
-            type: "string",
-            description: "The target state.",
-          },
-        },
-        required: ["tracker_id", "issue_id", "state"],
-      },
-    },
-    validate: validateUpdateIssueState,
+    family: ACT_FAMILY.ISSUE,
+    kind: ACT_KIND.ISSUE_STATE,
+    description: "Update a tracked issue's state.",
+    request: ISSUE_STATE_REQUEST,
   },
   COMMENT_ON_ISSUE: {
     name: "comment_on_issue",
-    family: REALTIME_TOOL_FAMILY.ISSUE,
-    actionKind: ISSUE_TOOL_KIND.ISSUE_COMMENT,
-    narration: narrate(
-      ISSUE_TOOL_KIND.ISSUE_COMMENT,
-      (action) => `commented on issue ${action.identity.identifier}`,
-    ),
-    schema: {
-      description: "Add a comment to a tracked issue.",
-      parameters: {
-        type: "object",
-        properties: {
-          ...ISSUE_IDENTITY_PARAMETERS,
-          body: {
-            type: "string",
-            description: "The comment to add.",
-          },
-        },
-        required: ["tracker_id", "issue_id", "body"],
-      },
-    },
-    validate: validateCommentOnIssue,
+    family: ACT_FAMILY.ISSUE,
+    kind: ACT_KIND.ISSUE_COMMENT,
+    description: "Add a comment to a tracked issue.",
+    request: ISSUE_COMMENT_REQUEST,
   },
   CHANGE_APP_SETTING: {
     name: "change_app_setting",
-    family: REALTIME_TOOL_FAMILY.APP,
-    actionKind: APP_TOOL_KIND.SETTING,
-    narration: narrate(
-      APP_TOOL_KIND.SETTING,
-      (action) => `changed ${action.setting.label} to ${action.value}`,
-    ),
-    schema: {
-      description: "Change a Luke setting.",
-      parameters: {
-        type: "object",
-        properties: {
-          setting_id: {
-            type: "string",
-            description: "The setting ID.",
-          },
-          value: {
-            type: "string",
-            description: "The new value.",
-          },
-          effort: {
-            type: "string",
-            description: "An optional effort level.",
-          },
-        },
-        required: ["setting_id", "value"],
-      },
-    },
-    validate: validateChangeAppSetting,
+    family: ACT_FAMILY.APP,
+    kind: ACT_KIND.SETTING,
+    description: "Change a Luke setting.",
+    request: SETTING_REQUEST,
   },
   SHOW_PANEL: {
     name: "show_panel",
-    family: REALTIME_TOOL_FAMILY.APP,
-    actionKind: APP_TOOL_KIND.PANEL,
-    narration: narrate(APP_TOOL_KIND.PANEL, (action) => `showed the ${action.tab} panel`),
-    schema: {
-      description:
-        "Show Luke's panel on a tab — and, on the sessions tab, narrow or reorder the list. " +
-        'An ask to show, see, or list sessions or agents of some kind — "show me the Codex ' +
-        'agents", "show me my local sessions" — is this tool with a filter, not open_session.',
-      parameters: {
-        type: "object",
-        properties: {
-          tab: {
-            type: "string",
-            enum: Object.values(APP_PANEL_TAB),
-            description: "The tab to show. Defaults to sessions.",
-          },
-          filters: {
-            type: "array",
-            items: { type: "string", enum: SESSION_LIST_FILTER_VALUES },
-            description: SESSION_LIST_FILTER_DESCRIPTION,
-          },
-          sort: {
-            type: "string",
-            enum: Object.values(SESSION_LIST_SORT),
-            description:
-              `Reorders the session list: ${SESSION_LIST_SORT.URGENCY} puts what needs the ` +
-              `developer first, ${SESSION_LIST_SORT.RECENCY} puts what moved last first.`,
-          },
-          query: {
-            type: "string",
-            description:
-              "Optional words to search the session list for; only rows saying every word stay.",
-          },
-        },
-        required: [],
-      },
-    },
-    remoteSchema: {
+    family: ACT_FAMILY.APP,
+    kind: ACT_KIND.PANEL,
+    description:
+      "Show Luke's panel on a tab — and, on the sessions tab, narrow or reorder the list. " +
+      'An ask to show, see, or list sessions or agents of some kind — "show me the Codex ' +
+      'agents", "show me my local sessions" — is this tool with a filter, not open_session.',
+    request: PANEL_REQUEST,
+    remote: {
       description:
         "Show the session list — and narrow, search, or reorder it. An ask to show, see, or " +
         'list sessions of some kind — "show me the waiting sessions", "show me the Conductor ' +
         'agents" — is this tool with a filter, not open_session.',
-      parameters: {
-        type: "object",
-        properties: {
-          filters: {
-            type: "array",
-            items: { type: "string", enum: REMOTE_SESSION_LIST_FILTER_VALUES },
-            description: REMOTE_SESSION_LIST_FILTER_DESCRIPTION,
-          },
-          sort: {
-            type: "string",
-            enum: Object.values(SESSION_LIST_SORT),
-            description:
-              `Reorders the session list: ${SESSION_LIST_SORT.URGENCY} puts what needs the ` +
-              `developer first, ${SESSION_LIST_SORT.RECENCY} puts what moved last first.`,
-          },
-          query: {
-            type: "string",
-            description:
-              "Optional words to search the session list for; only rows saying every word stay.",
-          },
-        },
-        required: [],
-      },
+      request: REMOTE_PANEL_REQUEST,
     },
-    validate: validateShowPanel,
   },
   OPEN_FEEDBACK_COMPOSER: {
     name: "open_feedback_composer",
-    family: REALTIME_TOOL_FAMILY.APP,
-    actionKind: APP_TOOL_KIND.FEEDBACK,
-    narration: narrate(
-      APP_TOOL_KIND.FEEDBACK,
-      (action) => `opened the ${action.composer} composer`,
-    ),
-    schema: {
-      description: "Open the feedback composer.",
-      parameters: {
-        type: "object",
-        properties: {
-          kind: {
-            type: "string",
-            enum: Object.values(FEEDBACK_COMPOSER_KIND),
-            description: "The feedback type.",
-          },
-          draft: {
-            type: "string",
-            description: "An optional draft.",
-          },
-        },
-        required: ["kind"],
-      },
-    },
-    validate: validateOpenFeedbackComposer,
+    family: ACT_FAMILY.APP,
+    kind: ACT_KIND.FEEDBACK,
+    description: "Open the feedback composer.",
+    request: FEEDBACK_REQUEST,
   },
   RUN_UPDATE_ACTION: {
     name: "run_update_action",
-    family: REALTIME_TOOL_FAMILY.APP,
-    actionKind: APP_TOOL_KIND.UPDATE,
-    narration: narrate(APP_TOOL_KIND.UPDATE, (action) => `ran the Updates row's ${action.act}`),
-    schema: {
-      description:
-        "Press the Updates row's button for the developer: check for updates, open the latest " +
-        "release's page in the browser to download by hand, or restart into an update already " +
-        "downloaded. Only the act the button currently offers runs — the app guide's Updates " +
-        "line names it.",
-      parameters: {
-        type: "object",
-        properties: {
-          action: {
-            type: "string",
-            enum: Object.values(APP_UPDATE_ACT),
-            description: "The act to run, as the guide's Updates line offers it.",
-          },
-        },
-        required: ["action"],
-      },
-    },
-    validate: validateRunUpdateAction,
+    family: ACT_FAMILY.APP,
+    kind: ACT_KIND.UPDATE,
+    description:
+      "Press the Updates row's button for the developer: check for updates, open the latest " +
+      "release's page in the browser to download by hand, or restart into an update already " +
+      "downloaded. Only the act the button currently offers runs — the app guide's Updates " +
+      "line names it.",
+    request: UPDATE_REQUEST,
   },
   REMEMBER_FACT: {
     name: "remember_fact",
-    family: REALTIME_TOOL_FAMILY.APP,
-    actionKind: APP_TOOL_KIND.REMEMBER,
-    narration: narrate(APP_TOOL_KIND.REMEMBER, (action) =>
-      action.replaces
-        ? `remembered "${action.words}" in place of something remembered before`
-        : `remembered "${action.words}"`,
-    ),
-    schema: {
-      description:
-        "Silently save a concise stable preference, personal fact, goal, or recurring constraint " +
-        "from this developer-opened turn. Skip transient details and uncertain inferences. Never " +
-        "save credentials; save sensitive facts only when explicitly asked. Do not mention routine " +
-        "memory changes. Skip duplicates, and pass an existing id as replaces when updating a " +
-        "contradiction.",
-      parameters: {
-        type: "object",
-        properties: {
-          words: {
-            type: "string",
-            description: "A concise durable fact about the developer.",
-          },
-          replaces: {
-            type: "string",
-            description:
-              "The id of the remembered entry this one stands in for, when it changes one.",
-          },
-        },
-        required: ["words"],
-      },
-    },
-    validate: validateRememberFact,
+    family: ACT_FAMILY.APP,
+    kind: ACT_KIND.REMEMBER,
+    description:
+      "Silently save a concise stable preference, personal fact, goal, or recurring constraint " +
+      "from this developer-opened turn. Skip transient details and uncertain inferences. Never " +
+      "save credentials; save sensitive facts only when explicitly asked. Do not mention routine " +
+      "memory changes. Skip duplicates, and pass an existing id as replaces when updating a " +
+      "contradiction.",
+    request: REMEMBER_REQUEST,
   },
   FORGET_FACT: {
     name: "forget_fact",
-    family: REALTIME_TOOL_FAMILY.APP,
-    actionKind: APP_TOOL_KIND.FORGET,
-    narration: narrate(APP_TOOL_KIND.FORGET, () => "forgot something remembered before"),
-    schema: {
-      description:
-        "Silently forget an outdated or explicitly unwanted memory. Only an id from the remembered " +
-        "list can be named. Do not mention routine memory changes.",
-      parameters: {
-        type: "object",
-        properties: {
-          id: { type: "string", description: "The remembered entry's id." },
-        },
-        required: ["id"],
-      },
-    },
-    validate: validateForgetFact,
+    family: ACT_FAMILY.APP,
+    kind: ACT_KIND.FORGET,
+    description:
+      "Silently forget an outdated or explicitly unwanted memory. Only an id from the remembered " +
+      "list can be named. Do not mention routine memory changes.",
+    request: FORGET_REQUEST,
   },
-} as const satisfies Record<string, RealtimeToolSpec>;
-
-/** The history sentence declared by the same row that declared the act. */
-export function actNarration(action: CarriedAct, sessions: readonly Session[]): string {
-  const row = Object.values(ACTS).find((candidate) => candidate.actionKind === action.kind);
-  return row?.narration(action, sessions) ?? "carried an act";
-}
+} as const satisfies Record<string, ToolSpec<ActFamily, ActKind>>;
 
 function namesFromToolTable<T extends Record<string, { readonly name: string }>>(table: T) {
   // SAFETY: keys are drawn from the same table object; each entry's name field is the tool id.
@@ -1799,25 +234,38 @@ function namesFromToolTable<T extends Record<string, { readonly name: string }>>
 
 export const REALTIME_TOOL = namesFromToolTable(ACTS);
 
-const REALTIME_TOOL_LIST: readonly RealtimeToolSpec[] = Object.values(ACTS);
+const ACT_LIST: readonly ToolSpec<ActFamily, ActKind>[] = Object.values(ACTS);
 
-const ACTS_BY_NAME = new Map<string, RealtimeToolSpec>(
-  REALTIME_TOOL_LIST.map((tool) => [tool.name, tool]),
+const ACTS_BY_NAME = new Map<string, ToolSpec<ActFamily, ActKind>>(
+  ACT_LIST.map((tool) => [tool.name, tool]),
 );
 
 /** The family a named tool belongs to, or nothing when no such tool exists. */
-export function realtimeToolFamily(name: string): RealtimeToolFamily | undefined {
+export function realtimeToolFamily(name: string): ActFamily | undefined {
   return ACTS_BY_NAME.get(name)?.family;
 }
 
-/** The tool schemas a Realtime session is configured with. */
-export function realtimeToolDefinitions(): readonly RealtimeToolWireDefinition[] {
-  return REALTIME_TOOL_LIST.map((tool) => ({
+/** One function tool as a Responses or Realtime request carries it. */
+export interface ActToolDefinition {
+  type: "function";
+  name: string;
+  description: string;
+  parameters: JsonSchemaNode;
+}
+
+function definitionOf(spec: ToolSpec<ActFamily, ActKind>, remote: boolean): ActToolDefinition {
+  const shape = (remote ? spec.remote : undefined) ?? spec;
+  return {
     type: "function",
-    name: tool.name,
-    description: tool.schema.description,
-    parameters: tool.schema.parameters,
-  }));
+    name: spec.name,
+    description: shape.description,
+    parameters: shape.request.jsonSchema(),
+  };
+}
+
+/** The tool schemas a Realtime session is configured with. */
+export function realtimeToolDefinitions(): readonly ActToolDefinition[] {
+  return ACT_LIST.map((tool) => definitionOf(tool, false));
 }
 
 /**
@@ -1825,119 +273,60 @@ export function realtimeToolDefinitions(): readonly RealtimeToolWireDefinition[]
  * The session writes are the ones the hosted act endpoints serve — MESSAGE,
  * CONTROL, CREATE_WORKSPACE, ADD_AGENT, RENAME_WORKSPACE, RENAME_SESSION —
  * and the phone validates each against the roster and projects it was shown
- * before an endpoint sees it, the renderer's half of the gauntlet. OPEN lands
- * on the session's own screen in the app and PANEL on the app's own list, so
- * each is performed on the phone and reaches no endpoint at all.
+ * before an endpoint sees it. OPEN lands on the session's own screen in the
+ * app and PANEL on the app's own list, so each is performed on the phone and
+ * reaches no endpoint at all.
  *
- * The issue acts are absent because no tracker is connected on the phone; a setting
- * change, the feedback composer, and the Updates row are surfaces the phone
- * does not draw. REMEMBER and FORGET are absent because the phone keeps no
- * memory: Luke's durable facts live on the Mac alone.
+ * The issue acts are absent because no tracker is connected on the phone; a
+ * setting change, the feedback composer, and the Updates row are surfaces the
+ * phone does not draw. REMEMBER and FORGET are absent because the phone keeps
+ * no memory: Luke's durable facts live on the Mac alone.
  */
-const REMOTE_ACTION_KINDS: ReadonlySet<string> = new Set([
-  SESSION_TOOL_KIND.MESSAGE,
-  SESSION_TOOL_KIND.CONTROL,
-  SESSION_TOOL_KIND.OPEN,
-  SESSION_TOOL_KIND.CREATE_WORKSPACE,
-  SESSION_TOOL_KIND.ADD_AGENT,
-  SESSION_TOOL_KIND.RENAME_WORKSPACE,
-  SESSION_TOOL_KIND.RENAME_SESSION,
-  APP_TOOL_KIND.PANEL,
+const REMOTE_ACT_KINDS: ReadonlySet<string> = new Set<ActKind>([
+  ACT_KIND.MESSAGE,
+  ACT_KIND.CONTROL,
+  ACT_KIND.OPEN,
+  ACT_KIND.CREATE_WORKSPACE,
+  ACT_KIND.ADD_AGENT,
+  ACT_KIND.RENAME_WORKSPACE,
+  ACT_KIND.RENAME_SESSION,
+  ACT_KIND.PANEL,
 ]);
 
-export function remoteRealtimeToolDefinitions(): readonly RealtimeToolWireDefinition[] {
-  return REALTIME_TOOL_LIST.filter((tool) => REMOTE_ACTION_KINDS.has(tool.actionKind)).map(
-    (tool) => {
-      const schema = tool.remoteSchema ?? tool.schema;
-      return {
-        type: "function",
-        name: tool.name,
-        description: schema.description,
-        parameters: schema.parameters,
-      };
-    },
+export function remoteRealtimeToolDefinitions(): readonly ActToolDefinition[] {
+  return ACT_LIST.filter((tool) => REMOTE_ACT_KINDS.has(tool.kind)).map((tool) =>
+    definitionOf(tool, true),
   );
 }
 
-/**
- * Validates one tool call against the sessions actually being observed. This
- * is the renderer's half of the gauntlet — the main process re-validates
- * against its registry — and it exists so a call the model composed can only
- * name a session Luke was shown, doing something that session advertised.
- * Everything else is refused with a reason Luke can say aloud.
- */
-export function sessionToolAction(
-  call: RealtimeFunctionCall,
-  sessions: readonly Session[],
-  workspaceProjects: readonly ObservedWorkspaceProject[] = [],
-  // The models a creation ask may name, per provider — the app's own
-  // build-documented tables, handed in so this stays brand-neutral. The
-  // default offers none, so an ask that names a model is refused rather than
-  // forwarded unchecked.
-  agentModels: (providerId: string) => readonly WorkspaceAgentModels[] = () => [],
-  // The developer's saved creation tie-breaks, riding in beside the projects
-  // they narrow — see {@link SessionToolContext}.
-  defaultProviderId?: string,
-  defaultProjectIds?: Readonly<Partial<Record<string, string>>>,
-): SessionToolAction {
-  const parsed = parseToolArguments(call);
-  if (!parsed.ok) return { status: ACT_RESULT_STATUS.REJECTED, reason: parsed.reason };
-  const tool = ACTS_BY_NAME.get(call.name);
-  if (!tool || tool.family !== REALTIME_TOOL_FAMILY.SESSION) {
-    return { status: ACT_RESULT_STATUS.REJECTED, reason: "No such tool exists." };
+function refuse(reason: string): Refusal {
+  return { status: ACT_RESULT_STATUS.REJECTED, reason };
+}
+
+function parseToolArguments(call: RealtimeFunctionCall): UnparsedWireValue | undefined {
+  try {
+    // SAFETY: JSON.parse returns a runtime value; isRecord validates the object contract.
+    return JSON.parse(call.argumentsJson) as UnparsedWireValue;
+  } catch {
+    return undefined;
   }
-  return tool.validate(parsed.value, {
-    sessions,
-    workspaceProjects,
-    agentModels,
-    defaultProviderId,
-    defaultProjectIds,
-  });
 }
 
 /**
- * Validates one issue tool call against the issues actually observed. The
- * renderer's half of the same gauntlet the session tools run — the main
- * process re-validates against what it observed — so a call the model
- * composed can only name an issue Luke was shown, going somewhere its
- * tracker advertised. Everything else is refused with a reason Luke can say
- * aloud.
+ * One model-emitted tool call, admitted. The name selects the act; the
+ * arguments are read as that act's own fields and handed to `admit`, which is
+ * the whole of validation. A name no row declares, or arguments that are not a
+ * record, refuse before an admitter runs.
  */
-export function issueToolAction(
+export async function toolAction(
   call: RealtimeFunctionCall,
-  issues: readonly TrackedIssue[],
-): IssueToolAction {
+  context: AdmitContext,
+): Promise<ValidatedAct | Refusal> {
   const parsed = parseToolArguments(call);
-  if (!parsed.ok) return { status: ACT_RESULT_STATUS.REJECTED, reason: parsed.reason };
+  if (!isRecord(parsed)) return refuse(ACT_REFUSAL.UNREADABLE);
   const tool = ACTS_BY_NAME.get(call.name);
-  if (!tool || tool.family !== REALTIME_TOOL_FAMILY.ISSUE) {
-    return { status: ACT_RESULT_STATUS.REJECTED, reason: "No such tool exists." };
-  }
-  return tool.validate(parsed.value, { issues });
-}
-
-/**
- * Validates one app tool call against the guide the app actually provided and
- * the sessions actually observed. The same posture as {@link sessionToolAction}:
- * a call the model composed can only name a setting the guide lists, changing
- * it to a value the guide accepts, a panel view the roster can fill, or the
- * composer on one of its own two kinds — and a setting the guide marks as
- * by-hand-only is refused with the path to it, so the refusal Luke voices is
- * itself the guidance.
- */
-export function appToolAction(
-  call: RealtimeFunctionCall,
-  guide: AppGuideSnapshot,
-  sessions: readonly Session[],
-  rememberedFacts: readonly RememberedFact[] = [],
-): AppToolAction {
-  const parsed = parseToolArguments(call);
-  if (!parsed.ok) return { status: ACT_RESULT_STATUS.REJECTED, reason: parsed.reason };
-  const tool = ACTS_BY_NAME.get(call.name);
-  if (!tool || tool.family !== REALTIME_TOOL_FAMILY.APP) {
-    return { status: ACT_RESULT_STATUS.REJECTED, reason: "No such tool exists." };
-  }
-  return tool.validate(parsed.value, { guide, sessions, rememberedFacts });
+  if (!tool) return refuse(ACT_REFUSAL.NO_TOOL);
+  return admit({ kind: tool.kind, fields: parsed }, context);
 }
 
 /**

--- a/packages/acts/src/admit.test.ts
+++ b/packages/acts/src/admit.test.ts
@@ -1,6 +1,8 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { ISSUE_TRACKER_ID, normalizeTrackedIssue } from "@sidecar/issues";
+import { RUN_ORIGIN } from "@sidecar/runtime-contracts";
+import type { ObservedWorkspaceProject as ListedProject, Session } from "@sidecar/session";
 import {
   ACT_KIND,
   maximumWorkspaceNameLength,
@@ -17,15 +19,82 @@ import {
 } from "@sidecar/session";
 import { ACT_RESULT_STATUS } from "@sidecar/wire";
 import {
+  ACT_FAMILY,
   ACTS,
-  issueToolAction,
   REALTIME_TOOL,
-  REALTIME_TOOL_FAMILY,
+  type RealtimeFunctionCall,
   realtimeToolFamily,
   SESSION_LIST_ALL,
   SESSION_LIST_VOICE,
-  sessionToolAction,
-} from "./acts.js";
+  toolAction,
+} from "./index.js";
+import {
+  issueToolAction as legacyIssueToolAction,
+  sessionToolAction as legacySessionToolAction,
+} from "./legacy-validation.js";
+import { withoutAdmission } from "./testing/admitted.js";
+import { itemEnum, objectProperties } from "./testing/json-schema.js";
+
+/**
+ * Every case below runs the validator the intakes used before `admit` existed
+ * and `admit` itself, on the same input, and refuses to pass unless the two
+ * answer identically. It is the whole of what makes this a refactor rather
+ * than a rewrite of the gauntlet, and it goes when the old validators do.
+ */
+async function agreed<Legacy extends { kind?: string }>(
+  call: RealtimeFunctionCall,
+  legacy: Legacy,
+  context: Parameters<typeof toolAction>[1],
+): Promise<Legacy> {
+  // Which family a name belongs to was the caller's question before admission
+  // and is the caller's question still; only what a named act admits to is
+  // compared here.
+  if (realtimeToolFamily(call.name) !== undefined) {
+    assert.deepEqual(withoutAdmission(await toolAction(call, context)), legacy);
+  }
+  return legacy;
+}
+
+async function sessionToolAction(
+  call: RealtimeFunctionCall,
+  sessions: readonly Session[],
+  workspaceProjects: readonly ListedProject[] = [],
+  agentModels: Parameters<typeof legacySessionToolAction>[3] = () => [],
+  defaultProviderId?: string,
+  defaultProjectIds?: Readonly<Partial<Record<string, string>>>,
+) {
+  return agreed(
+    call,
+    legacySessionToolAction(
+      call,
+      sessions,
+      workspaceProjects,
+      agentModels,
+      defaultProviderId,
+      defaultProjectIds,
+    ),
+    {
+      origin: RUN_ORIGIN.USER,
+      roster: { read: async () => sessions },
+      projects: {
+        read: async () => workspaceProjects,
+        defaults: async () => ({ defaultProviderId, defaultProjectIds }),
+        agentModels,
+      },
+    },
+  );
+}
+
+async function issueToolAction(
+  call: RealtimeFunctionCall,
+  issues: Parameters<typeof legacyIssueToolAction>[1],
+) {
+  return agreed(call, legacyIssueToolAction(call, issues), {
+    origin: RUN_ORIGIN.USER,
+    roster: { read: async () => [] },
+    issues,
+  });
+}
 
 const DECIDED_AT = 1_800_000_000_000;
 
@@ -55,17 +124,20 @@ function messageCall(argumentsJson: string, name: string = REALTIME_TOOL.SEND_SE
   return { name, argumentsJson };
 }
 
-test("a tool call can act only on a session Luke was shown, doing what it advertised", () => {
+test("a tool call can act only on a session Luke was shown, doing what it advertised", async () => {
   const roster = [actionableSession()];
   const identity = '"provider_id":"conductor","provider_session_id":"conductor-1"';
 
-  assert.deepEqual(sessionToolAction(messageCall(`{${identity},"text":"add tests too"}`), roster), {
-    kind: "message",
-    identity: { providerId: "conductor", providerSessionId: "conductor-1" },
-    text: "add tests too",
-  });
   assert.deepEqual(
-    sessionToolAction(
+    await sessionToolAction(messageCall(`{${identity},"text":"add tests too"}`), roster),
+    {
+      kind: "message",
+      identity: { providerId: "conductor", providerSessionId: "conductor-1" },
+      text: "add tests too",
+    },
+  );
+  assert.deepEqual(
+    await sessionToolAction(
       messageCall(`{${identity},"control_id":"cancel-run"}`, REALTIME_TOOL.RUN_SESSION_CONTROL),
       roster,
     ),
@@ -83,7 +155,7 @@ test("a tool call can act only on a session Luke was shown, doing what it advert
   // The open action carries the identity and nothing else: the address stays
   // in the main process's registry, where the press reads it back.
   assert.deepEqual(
-    sessionToolAction(messageCall(`{${identity}}`, REALTIME_TOOL.OPEN_SESSION), roster),
+    await sessionToolAction(messageCall(`{${identity}}`, REALTIME_TOOL.OPEN_SESSION), roster),
     {
       kind: "open",
       identity: { providerId: "conductor", providerSessionId: "conductor-1" },
@@ -93,18 +165,18 @@ test("a tool call can act only on a session Luke was shown, doing what it advert
   // Every way a call can point somewhere Luke was not shown is a refusal with
   // a reason he can say aloud, never a request that reaches a bridge.
   const refusals = [
-    sessionToolAction(messageCall("not json"), roster),
-    sessionToolAction(
+    await sessionToolAction(messageCall("not json"), roster),
+    await sessionToolAction(
       messageCall('{"provider_id":"conductor","provider_session_id":"other"}'),
       roster,
     ),
-    sessionToolAction(messageCall(`{${identity},"text":""}`), roster),
-    sessionToolAction(messageCall(`{${identity},"text":"${"a".repeat(4_100)}"}`), roster),
-    sessionToolAction(
+    await sessionToolAction(messageCall(`{${identity},"text":""}`), roster),
+    await sessionToolAction(messageCall(`{${identity},"text":"${"a".repeat(4_100)}"}`), roster),
+    await sessionToolAction(
       messageCall(`{${identity},"control_id":"terminate"}`, REALTIME_TOOL.RUN_SESSION_CONTROL),
       roster,
     ),
-    sessionToolAction(messageCall(`{${identity},"text":"hi"}`, "delete_everything"), roster),
+    await sessionToolAction(messageCall(`{${identity},"text":"hi"}`, "delete_everything"), roster),
   ];
   for (const refusal of refusals) assert.equal(refusal.status, ACT_RESULT_STATUS.REJECTED);
 
@@ -118,13 +190,13 @@ test("a tool call can act only on a session Luke was shown, doing what it advert
       lastActivityAt: DECIDED_AT,
     },
   );
-  const silentRefusal = sessionToolAction(
+  const silentRefusal = await sessionToolAction(
     messageCall('{"provider_id":"codex","provider_session_id":"thread-1","text":"hi"}'),
     [quiet],
   );
   assert.equal(silentRefusal.status, ACT_RESULT_STATUS.REJECTED);
   // No address means nowhere to open, however real the identity is.
-  const nowhereToOpen = sessionToolAction(
+  const nowhereToOpen = await sessionToolAction(
     messageCall(
       '{"provider_id":"codex","provider_session_id":"thread-1"}',
       REALTIME_TOOL.OPEN_SESSION,
@@ -135,14 +207,14 @@ test("a tool call can act only on a session Luke was shown, doing what it advert
 
   // The retired spoken transcript reading is no act at all: a call naming it
   // is refused as unknown rather than routed anywhere.
-  const retired = sessionToolAction(
+  const retired = await sessionToolAction(
     messageCall(`{${identity}}`, "read_session_transcript"),
     roster,
   );
   assert.equal(retired.status, ACT_RESULT_STATUS.REJECTED);
 });
 
-test("an open ask can pick the app, held to the roster's own associations", () => {
+test("an open ask can pick the app, held to the roster's own associations", async () => {
   const held = normalizeSession(
     { id: "codex", displayName: "Codex" },
     {
@@ -172,7 +244,7 @@ test("an open ask can pick the app, held to the roster's own associations", () =
   // name in any case, or by the id itself — and the action carries that id,
   // never the address behind it.
   assert.deepEqual(
-    sessionToolAction(
+    await sessionToolAction(
       messageCall(`{${identity},"application":"superset"}`, REALTIME_TOOL.OPEN_SESSION),
       [held],
     ),
@@ -185,14 +257,14 @@ test("an open ask can pick the app, held to the roster's own associations", () =
 
   // An ask that names no app keeps the row's own destination.
   assert.deepEqual(
-    sessionToolAction(messageCall(`{${identity}}`, REALTIME_TOOL.OPEN_SESSION), [held]),
+    await sessionToolAction(messageCall(`{${identity}}`, REALTIME_TOOL.OPEN_SESSION), [held]),
     { kind: "open", identity: { providerId: "codex", providerSessionId: "thread-2" } },
   );
 
   // An association without an address opens nothing, and an app the roster
   // never listed opens nothing; each refusal says where the session does open.
   for (const application of ["Conductor", "TextEdit"]) {
-    const refusal = sessionToolAction(
+    const refusal = await sessionToolAction(
       messageCall(`{${identity},"application":"${application}"}`, REALTIME_TOOL.OPEN_SESSION),
       [held],
     );
@@ -222,13 +294,13 @@ function conductorAgentModels(providerId: string): readonly WorkspaceAgentModels
   return providerId === "conductor" ? AGENT_TABLE : [];
 }
 
-test("a creation ask may name a model, by the name the guide lists it under", () => {
+test("a creation ask may name a model, by the name the guide lists it under", async () => {
   const projects = [OFFERED_PROJECT];
   const identity = '"provider_id":"conductor","project_id":"proj-1"';
 
   // Named by label, carried as the wire pairing, effort beside it.
   assert.deepEqual(
-    sessionToolAction(
+    await sessionToolAction(
       messageCall(`{${identity},"model":"Fable 5","effort":"max"}`, REALTIME_TOOL.CREATE_WORKSPACE),
       [],
       projects,
@@ -247,13 +319,13 @@ test("a creation ask may name a model, by the name the guide lists it under", ()
   // does not document, an effort with no model beside it, and a provider the
   // build documents no models for at all.
   const refusals = [
-    sessionToolAction(
+    await sessionToolAction(
       messageCall(`{${identity},"model":"GPT-9"}`, REALTIME_TOOL.CREATE_WORKSPACE),
       [],
       projects,
       conductorAgentModels,
     ),
-    sessionToolAction(
+    await sessionToolAction(
       messageCall(
         `{${identity},"model":"Cursor Auto","effort":"max"}`,
         REALTIME_TOOL.CREATE_WORKSPACE,
@@ -262,13 +334,13 @@ test("a creation ask may name a model, by the name the guide lists it under", ()
       projects,
       conductorAgentModels,
     ),
-    sessionToolAction(
+    await sessionToolAction(
       messageCall(`{${identity},"effort":"max"}`, REALTIME_TOOL.CREATE_WORKSPACE),
       [],
       projects,
       conductorAgentModels,
     ),
-    sessionToolAction(
+    await sessionToolAction(
       messageCall(`{${identity},"model":"Fable 5"}`, REALTIME_TOOL.CREATE_WORKSPACE),
       [],
       projects,
@@ -277,7 +349,7 @@ test("a creation ask may name a model, by the name the guide lists it under", ()
   for (const refusal of refusals) assert.equal(refusal.status, ACT_RESULT_STATUS.REJECTED);
 });
 
-test("an added agent may carry a model, only of the asked-for kind", () => {
+test("an added agent may carry a model, only of the asked-for kind", async () => {
   const spawning = normalizeSession(
     { id: "conductor", displayName: "Conductor" },
     {
@@ -291,7 +363,7 @@ test("an added agent may carry a model, only of the asked-for kind", () => {
   const identity = '"provider_id":"conductor","provider_session_id":"chat-1"';
 
   assert.deepEqual(
-    sessionToolAction(
+    await sessionToolAction(
       messageCall(
         `{${identity},"agent":"claude","model":"Fable 5","effort":"max"}`,
         REALTIME_TOOL.ADD_WORKSPACE_AGENT,
@@ -311,7 +383,7 @@ test("an added agent may carry a model, only of the asked-for kind", () => {
 
   // The asked-for kind is never re-decided by the model named beside it: a
   // claude model on a cursor agent is a refusal, not a swap.
-  const mismatched = sessionToolAction(
+  const mismatched = await sessionToolAction(
     messageCall(
       `{${identity},"agent":"cursor","model":"Fable 5"}`,
       REALTIME_TOOL.ADD_WORKSPACE_AGENT,
@@ -326,16 +398,20 @@ test("an added agent may carry a model, only of the asked-for kind", () => {
   }
 });
 
-test("a creation ask can only name a project Luke was shown", () => {
+test("a creation ask can only name a project Luke was shown", async () => {
   const projects = [OFFERED_PROJECT];
   const identity = '"provider_id":"conductor","project_id":"proj-1"';
 
   assert.deepEqual(
-    sessionToolAction(messageCall(`{${identity}}`, REALTIME_TOOL.CREATE_WORKSPACE), [], projects),
+    await sessionToolAction(
+      messageCall(`{${identity}}`, REALTIME_TOOL.CREATE_WORKSPACE),
+      [],
+      projects,
+    ),
     { kind: "create-workspace", providerId: "conductor", providerProjectId: "proj-1" },
   );
   assert.deepEqual(
-    sessionToolAction(
+    await sessionToolAction(
       messageCall(`{${identity},"name":"fix the panel"}`, REALTIME_TOOL.CREATE_WORKSPACE),
       [],
       projects,
@@ -351,7 +427,7 @@ test("a creation ask can only name a project Luke was shown", () => {
   // Every way a call can point somewhere Luke was not shown — or carry a name
   // outside its bound — is a refusal with a reason he can say aloud.
   const refusals = [
-    sessionToolAction(
+    await sessionToolAction(
       messageCall(
         '{"provider_id":"conductor","project_id":"other"}',
         REALTIME_TOOL.CREATE_WORKSPACE,
@@ -359,12 +435,12 @@ test("a creation ask can only name a project Luke was shown", () => {
       [],
       projects,
     ),
-    sessionToolAction(
+    await sessionToolAction(
       messageCall('{"provider_id":"codex","project_id":"proj-1"}', REALTIME_TOOL.CREATE_WORKSPACE),
       [],
       projects,
     ),
-    sessionToolAction(
+    await sessionToolAction(
       messageCall(
         `{${identity},"name":"${"a".repeat(maximumWorkspaceNameLength + 1)}"}`,
         REALTIME_TOOL.CREATE_WORKSPACE,
@@ -373,16 +449,16 @@ test("a creation ask can only name a project Luke was shown", () => {
       projects,
     ),
     // No list, no ask: a roster of sessions is not a list of projects.
-    sessionToolAction(messageCall(`{${identity}}`, REALTIME_TOOL.CREATE_WORKSPACE), [
+    await sessionToolAction(messageCall(`{${identity}}`, REALTIME_TOOL.CREATE_WORKSPACE), [
       actionableSession(),
     ]),
   ];
   for (const refusal of refusals) assert.equal(refusal.status, ACT_RESULT_STATUS.REJECTED);
 });
 
-test("an implicit project resolves only when the latest roster has one match", () => {
+test("an implicit project resolves only when the latest roster has one match", async () => {
   assert.deepEqual(
-    sessionToolAction(
+    await sessionToolAction(
       messageCall('{"provider_id":"conductor"}', REALTIME_TOOL.CREATE_WORKSPACE),
       [],
       [OFFERED_PROJECT],
@@ -390,7 +466,7 @@ test("an implicit project resolves only when the latest roster has one match", (
     { kind: "create-workspace", providerId: "conductor", providerProjectId: "proj-1" },
   );
 
-  const ambiguous = sessionToolAction(
+  const ambiguous = await sessionToolAction(
     messageCall('{"provider_id":"conductor"}', REALTIME_TOOL.CREATE_WORKSPACE),
     [],
     [OFFERED_PROJECT, { ...OFFERED_PROJECT, providerProjectId: "proj-2" }],
@@ -400,7 +476,7 @@ test("an implicit project resolves only when the latest roster has one match", (
   assert.match((ambiguous as { reason?: string }).reason ?? "", /More than one listed project/);
 });
 
-test("the saved defaults settle what a creation ask leaves unnamed", () => {
+test("the saved defaults settle what a creation ask leaves unnamed", async () => {
   const localTwin: ObservedWorkspaceProject = {
     ...OFFERED_PROJECT,
     providerId: "conductor-local",
@@ -411,7 +487,7 @@ test("the saved defaults settle what a creation ask leaves unnamed", () => {
 
   // A nameless ask between the two Conductors goes to the default provider.
   assert.deepEqual(
-    sessionToolAction(
+    await sessionToolAction(
       messageCall("{}", REALTIME_TOOL.CREATE_WORKSPACE),
       [],
       [OFFERED_PROJECT, localTwin],
@@ -423,7 +499,7 @@ test("the saved defaults settle what a creation ask leaves unnamed", () => {
 
   // An ask that names its own provider is never overridden by the default.
   assert.deepEqual(
-    sessionToolAction(
+    await sessionToolAction(
       messageCall('{"provider_id":"conductor-local"}', REALTIME_TOOL.CREATE_WORKSPACE),
       [],
       [OFFERED_PROJECT, localTwin],
@@ -435,7 +511,7 @@ test("the saved defaults settle what a creation ask leaves unnamed", () => {
 
   // The provider's chosen project settles an ask that names no project.
   assert.deepEqual(
-    sessionToolAction(
+    await sessionToolAction(
       messageCall('{"provider_id":"conductor"}', REALTIME_TOOL.CREATE_WORKSPACE),
       [],
       [OFFERED_PROJECT, { ...OFFERED_PROJECT, providerProjectId: "proj-2" }],
@@ -448,7 +524,7 @@ test("the saved defaults settle what a creation ask leaves unnamed", () => {
 
   // A default provider offering nothing settles nothing: the ask stays
   // ambiguous between the projects actually listed.
-  const unsettled = sessionToolAction(
+  const unsettled = await sessionToolAction(
     messageCall("{}", REALTIME_TOOL.CREATE_WORKSPACE),
     [],
     [OFFERED_PROJECT, localTwin],
@@ -461,7 +537,7 @@ test("the saved defaults settle what a creation ask leaves unnamed", () => {
   // default provider is chosen, an ask still spanning providers stays a
   // question even when exactly one candidate is some provider's chosen
   // project.
-  const crossProvider = sessionToolAction(
+  const crossProvider = await sessionToolAction(
     messageCall("{}", REALTIME_TOOL.CREATE_WORKSPACE),
     [],
     [OFFERED_PROJECT, { ...OFFERED_PROJECT, providerProjectId: "proj-2" }, localTwin],
@@ -472,7 +548,7 @@ test("the saved defaults settle what a creation ask leaves unnamed", () => {
   assert.equal(crossProvider.status, ACT_RESULT_STATUS.REJECTED);
 });
 
-test("another agent can only be added as a kind the session's own entry lists", () => {
+test("another agent can only be added as a kind the session's own entry lists", async () => {
   const spawning = normalizeSession(
     { id: "conductor", displayName: "Conductor" },
     {
@@ -487,7 +563,7 @@ test("another agent can only be added as a kind the session's own entry lists", 
   const identity = '"provider_id":"conductor","provider_session_id":"chat-1"';
 
   assert.deepEqual(
-    sessionToolAction(
+    await sessionToolAction(
       messageCall(
         `{${identity},"agent":"codex","name":"xyz feature","task":"Build the XYZ feature"}`,
         REALTIME_TOOL.ADD_WORKSPACE_AGENT,
@@ -504,7 +580,7 @@ test("another agent can only be added as a kind the session's own entry lists", 
   );
   // Bare is fine too: the agent is the only thing the endpoint cannot default.
   assert.deepEqual(
-    sessionToolAction(
+    await sessionToolAction(
       messageCall(`{${identity},"agent":"claude"}`, REALTIME_TOOL.ADD_WORKSPACE_AGENT),
       roster,
     ),
@@ -517,12 +593,12 @@ test("another agent can only be added as a kind the session's own entry lists", 
 
   const refusals = [
     // An agent kind the entry does not list is refused, not forwarded.
-    sessionToolAction(
+    await sessionToolAction(
       messageCall(`{${identity},"agent":"unlisted-agent"}`, REALTIME_TOOL.ADD_WORKSPACE_AGENT),
       roster,
     ),
     // A session that lists no new agents takes no such ask at all.
-    sessionToolAction(
+    await sessionToolAction(
       messageCall(
         '{"provider_id":"conductor","provider_session_id":"conductor-1","agent":"claude"}',
         REALTIME_TOOL.ADD_WORKSPACE_AGENT,
@@ -530,14 +606,14 @@ test("another agent can only be added as a kind the session's own entry lists", 
       roster,
     ),
     // The name and the task keep their bounds.
-    sessionToolAction(
+    await sessionToolAction(
       messageCall(
         `{${identity},"agent":"claude","name":"${"a".repeat(maximumWorkspaceNameLength + 1)}"}`,
         REALTIME_TOOL.ADD_WORKSPACE_AGENT,
       ),
       roster,
     ),
-    sessionToolAction(
+    await sessionToolAction(
       messageCall(
         `{${identity},"agent":"claude","task":"${"a".repeat(4_100)}"}`,
         REALTIME_TOOL.ADD_WORKSPACE_AGENT,
@@ -548,7 +624,7 @@ test("another agent can only be added as a kind the session's own entry lists", 
   for (const refusal of refusals) assert.equal(refusal.status, ACT_RESULT_STATUS.REJECTED);
 });
 
-test("an opening task is held to the project's own word for it", () => {
+test("an opening task is held to the project's own word for it", async () => {
   const requiresTask: ObservedWorkspaceProject = {
     ...OFFERED_PROJECT,
     providerId: "cursor",
@@ -565,7 +641,7 @@ test("an opening task is held to the project's own word for it", () => {
 
   // A task rides through where the project takes one, in the developer's words.
   assert.deepEqual(
-    sessionToolAction(
+    await sessionToolAction(
       messageCall(
         '{"provider_id":"cursor","project_id":"proj-1","task":"Add the XYZ feature"}',
         REALTIME_TOOL.CREATE_WORKSPACE,
@@ -581,7 +657,7 @@ test("an opening task is held to the project's own word for it", () => {
     },
   );
   // A project with an optional task is happy either way.
-  const bare = sessionToolAction(
+  const bare = await sessionToolAction(
     messageCall(
       '{"provider_id":"conductor","project_id":"proj-1"}',
       REALTIME_TOOL.CREATE_WORKSPACE,
@@ -593,13 +669,13 @@ test("an opening task is held to the project's own word for it", () => {
 
   const refusals = [
     // A project that needs a task cannot be created without one.
-    sessionToolAction(
+    await sessionToolAction(
       messageCall('{"provider_id":"cursor","project_id":"proj-1"}', REALTIME_TOOL.CREATE_WORKSPACE),
       [],
       projects,
     ),
     // A project that takes none is handed none.
-    sessionToolAction(
+    await sessionToolAction(
       messageCall(
         '{"provider_id":"codex","project_id":"proj-1","task":"Add the XYZ feature"}',
         REALTIME_TOOL.CREATE_WORKSPACE,
@@ -608,7 +684,7 @@ test("an opening task is held to the project's own word for it", () => {
       projects,
     ),
     // A task is bounded like the message it is.
-    sessionToolAction(
+    await sessionToolAction(
       messageCall(
         `{"provider_id":"cursor","project_id":"proj-1","task":"${"a".repeat(4_100)}"}`,
         REALTIME_TOOL.CREATE_WORKSPACE,
@@ -644,23 +720,23 @@ function issueCall(argumentsJson: string, name: string = REALTIME_TOOL.UPDATE_IS
   return { name, argumentsJson };
 }
 
-test("an issue tool call can act only on an issue Luke was shown, going where its tracker allows", () => {
+test("an issue tool call can act only on an issue Luke was shown, going where its tracker allows", async () => {
   const roster = [actionableIssue()];
   const identity = '"tracker_id":"linear","issue_id":"LUKE-123"';
 
-  assert.deepEqual(issueToolAction(issueCall(`{${identity},"state":"Done"}`), roster), {
+  assert.deepEqual(await issueToolAction(issueCall(`{${identity},"state":"Done"}`), roster), {
     kind: "issue-state",
     identity: { trackerId: "linear", identifier: "LUKE-123" },
     transition: { id: "state-done", name: "Done" },
   });
   // A spoken state arrives with its case retold rather than copied.
-  assert.deepEqual(issueToolAction(issueCall(`{${identity},"state":"done"}`), roster), {
+  assert.deepEqual(await issueToolAction(issueCall(`{${identity},"state":"done"}`), roster), {
     kind: "issue-state",
     identity: { trackerId: "linear", identifier: "LUKE-123" },
     transition: { id: "state-done", name: "Done" },
   });
   assert.deepEqual(
-    issueToolAction(
+    await issueToolAction(
       issueCall(`{${identity},"body":"deferred to next release"}`, REALTIME_TOOL.COMMENT_ON_ISSUE),
       roster,
     ),
@@ -674,20 +750,23 @@ test("an issue tool call can act only on an issue Luke was shown, going where it
   // Every way a call can point somewhere Luke was not shown is a refusal with
   // a reason he can say aloud, never a request that reaches a bridge.
   const refusals = [
-    issueToolAction(issueCall("not json"), roster),
-    issueToolAction(
+    await issueToolAction(issueCall("not json"), roster),
+    await issueToolAction(
       issueCall('{"tracker_id":"linear","issue_id":"LUKE-999","state":"Done"}'),
       roster,
     ),
     // The issue's own state is not a transition its tracker advertised.
-    issueToolAction(issueCall(`{${identity},"state":"In Progress"}`), roster),
-    issueToolAction(issueCall(`{${identity},"state":""}`), roster),
-    issueToolAction(issueCall(`{${identity},"body":""}`, REALTIME_TOOL.COMMENT_ON_ISSUE), roster),
-    issueToolAction(
+    await issueToolAction(issueCall(`{${identity},"state":"In Progress"}`), roster),
+    await issueToolAction(issueCall(`{${identity},"state":""}`), roster),
+    await issueToolAction(
+      issueCall(`{${identity},"body":""}`, REALTIME_TOOL.COMMENT_ON_ISSUE),
+      roster,
+    ),
+    await issueToolAction(
       issueCall(`{${identity},"body":"${"a".repeat(4_100)}"}`, REALTIME_TOOL.COMMENT_ON_ISSUE),
       roster,
     ),
-    issueToolAction(issueCall(`{${identity},"state":"Done"}`, "delete_everything"), roster),
+    await issueToolAction(issueCall(`{${identity},"state":"Done"}`, "delete_everything"), roster),
   ];
   for (const refusal of refusals) assert.equal(refusal.status, ACT_RESULT_STATUS.REJECTED);
 
@@ -705,33 +784,32 @@ test("an issue tool call can act only on an issue Luke was shown, going where it
   assert.ok(still);
   const quietIdentity = '"tracker_id":"linear","issue_id":"LUKE-124"';
   assert.equal(
-    issueToolAction(issueCall(`{${quietIdentity},"state":"Done"}`), [still]).status,
+    (await issueToolAction(issueCall(`{${quietIdentity},"state":"Done"}`), [still])).status,
     ACT_RESULT_STATUS.REJECTED,
   );
   assert.equal(
-    issueToolAction(issueCall(`{${quietIdentity},"body":"hi"}`, REALTIME_TOOL.COMMENT_ON_ISSUE), [
-      still,
-    ]).status,
+    (
+      await issueToolAction(
+        issueCall(`{${quietIdentity},"body":"hi"}`, REALTIME_TOOL.COMMENT_ON_ISSUE),
+        [still],
+      )
+    ).status,
     ACT_RESULT_STATUS.REJECTED,
   );
 });
 
-test("each act belongs to one family", () => {
-  assert.equal(
-    realtimeToolFamily(REALTIME_TOOL.SEND_SESSION_MESSAGE),
-    REALTIME_TOOL_FAMILY.SESSION,
-  );
-  assert.equal(realtimeToolFamily(REALTIME_TOOL.UPDATE_ISSUE_STATE), REALTIME_TOOL_FAMILY.ISSUE);
-  assert.equal(realtimeToolFamily(REALTIME_TOOL.COMMENT_ON_ISSUE), REALTIME_TOOL_FAMILY.ISSUE);
+test("each act belongs to one family", async () => {
+  assert.equal(realtimeToolFamily(REALTIME_TOOL.SEND_SESSION_MESSAGE), ACT_FAMILY.SESSION);
+  assert.equal(realtimeToolFamily(REALTIME_TOOL.UPDATE_ISSUE_STATE), ACT_FAMILY.ISSUE);
+  assert.equal(realtimeToolFamily(REALTIME_TOOL.COMMENT_ON_ISSUE), ACT_FAMILY.ISSUE);
   assert.equal(realtimeToolFamily("delete_everything"), undefined);
-  assert.equal(ACTS.CHANGE_APP_SETTING.family, REALTIME_TOOL_FAMILY.APP);
-  assert.equal(ACTS.SEND_SESSION_MESSAGE.family, REALTIME_TOOL_FAMILY.SESSION);
-  assert.equal(ACTS.UPDATE_ISSUE_STATE.family, REALTIME_TOOL_FAMILY.ISSUE);
+  assert.equal(ACTS.CHANGE_APP_SETTING.family, ACT_FAMILY.APP);
+  assert.equal(ACTS.SEND_SESSION_MESSAGE.family, ACT_FAMILY.SESSION);
+  assert.equal(ACTS.UPDATE_ISSUE_STATE.family, ACT_FAMILY.ISSUE);
 });
 
-test("show_panel's filter enum carries the whole vocabulary its validator accepts", () => {
-  const filters = ACTS.SHOW_PANEL.schema.parameters.properties.filters;
-  const values = filters.items.enum;
+test("show_panel's filter enum carries the whole vocabulary its validator accepts", async () => {
+  const values = itemEnum(objectProperties(ACTS.SHOW_PANEL.request.jsonSchema()).filters);
 
   // The enum is what binds the model to real tokens instead of the
   // developer's own words for them — a value the validator accepts but the

--- a/packages/acts/src/admit.ts
+++ b/packages/acts/src/admit.ts
@@ -84,17 +84,19 @@ import {
 } from "./memory.js";
 
 /**
- * Not exported, and this module holds no factory but {@link admit}: a value
- * carrying this key cannot be written down anywhere else, so a performer that
- * takes one is unreachable without admission having run. Deleting this privacy
- * is the only way to reintroduce the bug the whole file exists to prevent.
+ * Not exported, and this module holds no factory but {@link admit}: nothing
+ * elsewhere can spell this key, so no object literal is an admitted act and a
+ * payload never reaches a performer's parameter on its own. Exporting it would
+ * be the one way to reintroduce the bug the whole file exists to prevent.
  */
 const ADMITTED: unique symbol = Symbol("admitted act");
 
 /**
  * An act that ran the gauntlet, carrying the turn's origin for History to
- * record. The brand is a module-private symbol, so no literal, no cast, and no
- * other module can spell one.
+ * record. What the brand buys is that admission cannot be skipped by accident;
+ * a deliberate `as ValidatedAct` would still compile, since the admitted act is
+ * a subtype of its own payload, and that assertion appears nowhere in this
+ * repository — `validated-act.type-test.ts` says both in as many words.
  */
 export type ValidatedAct<Kind extends ActKind = ActKind> = CarriedAct<Kind> & {
   readonly [ADMITTED]: true;
@@ -219,11 +221,6 @@ export interface Refusal {
 
 function refuse(reason: string): Refusal {
   return { status: ACT_RESULT_STATUS.REJECTED, reason };
-}
-
-/** A refusal that also names what the roster the caller already read does offer. */
-function withDetail(reason: string, detail: string): Refusal {
-  return refuse(`${reason} ${detail}`);
 }
 
 /**
@@ -362,8 +359,6 @@ function namedOnce<Entry>(
     (named.length === 1 ? named[0] : undefined)
   );
 }
-
-const itself = (name: string): string => name;
 
 /**
  * Resolves a model the developer named — by the label the guide lists it
@@ -625,8 +620,12 @@ const admitCreateWorkspace: Admitter<typeof ACT_KIND.CREATE_WORKSPACE> = async (
   const agent =
     (spawnable === undefined || requestedAgent === undefined
       ? undefined
-      : namedOnce(spawnable, requestedAgent, itself, (name) => name.toLocaleLowerCase())) ??
-    project.defaultAgent;
+      : namedOnce(
+          spawnable,
+          requestedAgent,
+          (agentKind) => agentKind,
+          (name) => name.toLocaleLowerCase(),
+        )) ?? project.defaultAgent;
   if (spawnable && (!agent || !spawnable.includes(agent))) {
     return refuse(agent ? ACT_REFUSAL.NO_PROJECT_AGENT : ACT_REFUSAL.NAME_A_PROJECT_AGENT);
   }
@@ -895,7 +894,7 @@ const admitUpdate: Admitter<typeof ACT_KIND.UPDATE> = (fields, context) => {
   // One button, one act: only the press the row is actually drawing runs, so
   // the refusal is the row's own words plus what stands in the act's place.
   if (act !== update.button) {
-    return withDetail(update.detail, UPDATE_BUTTON_STANDING[update.button]);
+    return refuse(`${update.detail} ${UPDATE_BUTTON_STANDING[update.button]}`);
   }
   return { kind: ACT_KIND.UPDATE, act };
 };

--- a/packages/acts/src/admit.ts
+++ b/packages/acts/src/admit.ts
@@ -1,0 +1,965 @@
+/**
+ * The one gauntlet an act runs, and the only place a {@link ValidatedAct}
+ * comes from. In order: the guard (the turn that asked still stands), the
+ * roster (a fresh read of its own, and the target has to be one it holds), the
+ * advertisement (the advertised entry itself becomes what the act carries — a
+ * control, an agent kind, a rename target, a listed project — so nothing a
+ * caller sent can redirect the effect), then the bounds (the developer's own
+ * text, refused rather than cut). The guard is asked again after every await,
+ * so an act whose turn ended while the roster was refreshing refuses rather
+ * than dispatching.
+ *
+ * Admission decides only whether an act may run. Which acts a conversation may
+ * ask for at all was the effective tool policy's decision before a call left
+ * the model, and who opened the turn is recorded on what admission mints and
+ * consulted as a permission by nothing.
+ */
+
+import {
+  APP_PANEL_TAB,
+  APP_SETTING_KIND,
+  APP_UPDATE_ACT,
+  APP_UPDATE_WAIT,
+  type AppGuideSetting,
+  type AppGuideSnapshot,
+  type AppGuideUpdate,
+  appGuideSetting,
+  appToggleValue,
+  EMPTY_APP_GUIDE,
+} from "@sidecar/guide";
+import type { IssueIdentity, TrackedIssue } from "@sidecar/issues";
+import type { RunOrigin } from "@sidecar/runtime-contracts";
+import {
+  advertisedActFor,
+  advertisedControl,
+  isSessionApplicationId,
+  matchesFilterSelection,
+  maximumSessionMessageLength,
+  maximumWorkspaceNameLength,
+  type ObservedWorkspaceProject,
+  SESSION_LOCATION,
+  type Session,
+  type SessionIdentity,
+  WORKSPACE_TASK_SUPPORT,
+  type WorkspaceAgentModels,
+  type WorkspaceAgentSelection,
+  workspaceProjectSelectionId,
+} from "@sidecar/session";
+import {
+  ACT_RESULT_STATUS,
+  isWireString,
+  type UnparsedWireValue,
+  type WireRecord,
+  text as wireText,
+} from "@sidecar/wire";
+import {
+  ACT_KIND,
+  type ActKind,
+  type ActPayloads,
+  type ActRequest,
+  type CarriedAct,
+  SESSION_LIST_ALL,
+  SESSION_LIST_VOICE,
+} from "./act-kinds.js";
+import {
+  COMMENT_BODY,
+  FEEDBACK_KIND,
+  ISSUE_IDENTITY_FIELDS,
+  MESSAGE_TEXT,
+  OPENING_TASK,
+  PANEL_FILTERS,
+  PANEL_SORT,
+  PANEL_TAB,
+  SESSION_IDENTITY_FIELDS,
+  SESSION_LIST_FILTER_VALUES,
+  UPDATE_ACT,
+  WORKSPACE_NAME,
+} from "./act-schemas.js";
+import {
+  holdsRememberedFact,
+  maximumRememberedFactLength,
+  maximumRememberedFacts,
+  type RememberedFact,
+  rememberedFactText,
+} from "./memory.js";
+
+/**
+ * Not exported, and this module holds no factory but {@link admit}: a value
+ * carrying this key cannot be written down anywhere else, so a performer that
+ * takes one is unreachable without admission having run. Deleting this privacy
+ * is the only way to reintroduce the bug the whole file exists to prevent.
+ */
+const ADMITTED: unique symbol = Symbol("admitted act");
+
+/**
+ * An act that ran the gauntlet, carrying the turn's origin for History to
+ * record. The brand is a module-private symbol, so no literal, no cast, and no
+ * other module can spell one.
+ */
+export type ValidatedAct<Kind extends ActKind = ActKind> = CarriedAct<Kind> & {
+  readonly [ADMITTED]: true;
+  /** Who opened the turn; recorded, never a permission. */
+  readonly origin: RunOrigin;
+};
+
+/** Whether the turn an act belongs to still stands, asked again after every await. */
+export interface ActGuard {
+  isRevoked(): boolean;
+  /** Fires on revocation, so a read awaited before the effect settles at once rather than finishing first. */
+  readonly signal?: AbortSignal;
+}
+
+/**
+ * The roster as admission reads it, and never as a caller hands it: `read`
+ * answers what the latest observation saw, so the fresh-roster step is
+ * admission's own rather than each intake's promise.
+ */
+export interface ActRoster {
+  read(): Promise<readonly Session[]>;
+}
+
+/** The projects a creation ask may land in, read the same way and from the same pass. */
+export interface ActProjects {
+  read(): Promise<readonly ObservedWorkspaceProject[]>;
+  /**
+   * The developer's saved tie-breaks, which only ever narrow within what
+   * `read` returned: a default can settle an ambiguous ask, never widen where
+   * one can land or override a provider or project the ask actually named.
+   */
+  defaults(): Promise<{
+    defaultProviderId?: string;
+    defaultProjectIds?: Readonly<Partial<Record<string, string>>>;
+  }>;
+  /** The models a creation or a spawn may name, per provider, as the build documents them. */
+  agentModels(providerId: string): readonly WorkspaceAgentModels[];
+}
+
+export interface AdmitContext {
+  /**
+   * Who opened the turn this act belongs to. Recorded on what admission mints
+   * and never consulted as a permission: a developer's ask and a heartbeat's
+   * turn run exactly the same admission.
+   */
+  readonly origin: RunOrigin;
+  /** Absent for a row's own press, which opens its turn and its effect in the same breath. */
+  readonly guard?: ActGuard;
+  readonly roster: ActRoster;
+  /** Absent in a run that offers none, which then admits no creation. */
+  readonly projects?: ActProjects;
+  /** The app's own word about itself; absent in a run that reports none, which then admits no app act. */
+  readonly guide?: AppGuideSnapshot;
+  /** Absent when no tracker is connected, which then admits no issue act. */
+  readonly issues?: readonly TrackedIssue[];
+  /** The facts standing right now; an id the conversation never saw names nothing. */
+  readonly rememberedFacts?: readonly RememberedFact[];
+}
+
+/**
+ * Why an act was not admitted, in words Luke can say aloud. What rides beside
+ * a reason is only ever what the roster the caller already read already told
+ * them — the controls a session does advertise, the efforts a model does
+ * take — so a refusal is also the correction and never a disclosure.
+ */
+export const ACT_REFUSAL = {
+  UNREADABLE: "The tool call's arguments were not readable.",
+  NO_TOOL: "No such tool exists.",
+  TURN_OVER: "Not run: the turn that asked for this act ended before it could start.",
+  NO_SESSION: "No observed session matches that identity.",
+  NO_MESSAGES: "That session does not take messages right now.",
+  MESSAGE_BOUND: "That message is empty or too long.",
+  NO_CONTROL: "That session advertises no such control.",
+  NO_ADDRESS: "That session has no address to open.",
+  NO_APP_ADDRESS: "No app carries an exact address for that session.",
+  NO_PROJECT: "No listed project matches that identity.",
+  MANY_PROJECTS: "More than one listed project matches; name the project and host.",
+  NO_PROJECT_AGENT: "That project lists no such agent to start.",
+  NAME_A_PROJECT_AGENT: "Name one of the agents that project lists for a new workspace.",
+  PROJECT_NAMES_ITSELF: "That project names its own workspaces.",
+  NO_SESSION_AGENT: "That session lists no such agent to add.",
+  WORKSPACE_NAME_BOUND: `A workspace name has to be under ${maximumWorkspaceNameLength} characters and longer than nothing.`,
+  SESSION_NAME_BOUND: `A session name has to be under ${maximumWorkspaceNameLength} characters and longer than nothing.`,
+  CHAT_NAME_BOUND: `A chat name has to be under ${maximumWorkspaceNameLength} characters and longer than nothing.`,
+  NO_WORKSPACE_RENAME: "That session's workspace cannot be renamed.",
+  NO_SESSION_RENAME: "That chat cannot be renamed.",
+  TASK_BOUND: "That task is empty or too long.",
+  NO_TASK_TAKEN: "That project takes no opening task.",
+  TASK_REQUIRED: "That project needs an opening task to create a workspace.",
+  NO_MODEL: "No documented model goes by that name here.",
+  NO_EFFORT_LEVEL: "That model takes no effort level.",
+  EFFORT_NEEDS_MODEL: "An effort rides a model; name the model too.",
+  NO_ISSUE: "No tracked issue matches that identity.",
+  NO_ISSUE_STATE: "That issue lists no such state.",
+  NO_COMMENTS: "That issue does not take comments.",
+  COMMENT_BOUND: "That comment is empty or too long.",
+  NO_SETTING: "The app guide lists no such setting.",
+  NO_TAB: "The panel has no such tab.",
+  NO_SORT: "The list orders by urgency or by recency.",
+  NO_SEARCH: "The list offers a search only when more than one session is observed.",
+  FILTERS_SHAPE: "filters takes a list of filter values.",
+  ALL_STANDS_ALONE: `${SESSION_LIST_ALL} is the whole list, so it combines with nothing.`,
+  NO_FILTER_MATCH: "No observed session matches that combination of filters.",
+  NO_VOICE_SESSIONS: "No voice sessions are observed right now.",
+  NO_COMPOSER: "The composer writes feedback or a prompt, nothing else.",
+  NO_UPDATE_REPORT: "This run does not report where updates stand.",
+  NO_UPDATE_ACT: "The Updates button checks, downloads, or restarts.",
+  NO_SUCH_FACT: "Nothing remembered goes by that id.",
+  MEMORY_BOUND: `A memory has to be under ${maximumRememberedFactLength} characters and longer than nothing.`,
+  MEMORY_FULL: `Luke already remembers ${maximumRememberedFacts} things; replace or forget one first.`,
+  NO_TRACKER: "No issue tracker is connected.",
+} as const;
+
+export type ActRefusalReason = (typeof ACT_REFUSAL)[keyof typeof ACT_REFUSAL];
+
+/** Why an act was not admitted. Disjoint from every carried act, by `kind`. */
+export interface Refusal {
+  readonly status: typeof ACT_RESULT_STATUS.REJECTED;
+  readonly reason: string;
+  readonly kind?: never;
+}
+
+function refuse(reason: string): Refusal {
+  return { status: ACT_RESULT_STATUS.REJECTED, reason };
+}
+
+/** A refusal that also names what the roster the caller already read does offer. */
+function withDetail(reason: string, detail: string): Refusal {
+  return refuse(`${reason} ${detail}`);
+}
+
+/**
+ * A read awaited before an effect, held only as long as the guard's standing:
+ * once the signal fires the wait answers nothing, and the `isRevoked` check
+ * that follows every such read refuses the act before anything is dispatched.
+ * A guard with no signal — a row's own press — waits the read out.
+ */
+export function guardedRead<T>(
+  read: Promise<T>,
+  guard: ActGuard | undefined,
+): Promise<T | undefined> {
+  const signal = guard?.signal;
+  if (!signal) return read;
+  return new Promise<T | undefined>((resolve, reject) => {
+    let decided = false;
+    const settle = () => {
+      if (decided) return false;
+      decided = true;
+      signal.removeEventListener("abort", onAbort);
+      return true;
+    };
+    function onAbort() {
+      if (settle()) resolve(undefined);
+    }
+    if (signal.aborted) {
+      onAbort();
+      // The read still runs; its value and any failure are nobody's once the
+      // abort has answered, so neither is left to surface unhandled.
+      void read.catch(() => undefined);
+      return;
+    }
+    signal.addEventListener("abort", onAbort, { once: true });
+    void (async () => {
+      try {
+        const value = await read;
+        if (settle()) resolve(value);
+      } catch (failure) {
+        // A failure after the abort answered belongs to nobody, and is dropped
+        // rather than surfacing as an unhandled rejection.
+        if (settle()) reject(failure instanceof Error ? failure : new Error(String(failure)));
+      }
+    })();
+  });
+}
+
+/**
+ * The reads one admission makes, each made at most once and each held only as
+ * long as the guard's standing. `undefined` means the turn ended mid-read, and
+ * the admitter that asked refuses rather than deciding on a half-read picture.
+ */
+interface AdmittedReads {
+  sessions(): Promise<readonly Session[] | undefined>;
+  projects(): Promise<readonly ObservedWorkspaceProject[] | undefined>;
+  defaults(): Promise<
+    | { defaultProviderId?: string; defaultProjectIds?: Readonly<Partial<Record<string, string>>> }
+    | undefined
+  >;
+}
+
+function admittedReads(context: AdmitContext): AdmittedReads {
+  const once = <T>(read: () => Promise<T>): (() => Promise<T | undefined>) => {
+    let pending: Promise<T | undefined> | undefined;
+    return () => {
+      pending ??= (async () => {
+        if (context.guard?.isRevoked()) return undefined;
+        const value = await guardedRead(read(), context.guard);
+        return context.guard?.isRevoked() ? undefined : value;
+      })();
+      return pending;
+    };
+  };
+  const projects = context.projects;
+  return {
+    sessions: once(() => context.roster.read()),
+    projects: once(async () => (projects ? projects.read() : [])),
+    defaults: once(async () => (projects ? projects.defaults() : {})),
+  };
+}
+
+function textArgument(fields: WireRecord, key: string): string | undefined {
+  return wireText(fields[key]);
+}
+
+function sessionFrom(
+  fields: WireRecord,
+  sessions: readonly Session[],
+): { session: Session; identity: SessionIdentity } | Refusal {
+  const providerId = SESSION_IDENTITY_FIELDS.provider_id.parse(fields.provider_id);
+  const providerSessionId = SESSION_IDENTITY_FIELDS.provider_session_id.parse(
+    fields.provider_session_id,
+  );
+  const session = sessions.find(
+    (candidate) =>
+      candidate.providerId === providerId && candidate.providerSessionId === providerSessionId,
+  );
+  if (!session) return refuse(ACT_REFUSAL.NO_SESSION);
+  return {
+    session,
+    identity: {
+      providerId: session.providerId,
+      providerSessionId: session.providerSessionId,
+    },
+  };
+}
+
+function issueFrom(
+  fields: WireRecord,
+  issues: readonly TrackedIssue[],
+): { issue: TrackedIssue; identity: IssueIdentity } | Refusal {
+  const trackerId = ISSUE_IDENTITY_FIELDS.tracker_id.parse(fields.tracker_id);
+  const issueId = ISSUE_IDENTITY_FIELDS.issue_id.parse(fields.issue_id);
+  const issue = issues.find(
+    (candidate) => candidate.trackerId === trackerId && candidate.identifier === issueId,
+  );
+  if (!issue) return refuse(ACT_REFUSAL.NO_ISSUE);
+  return { issue, identity: { trackerId: issue.trackerId, identifier: issue.identifier } };
+}
+
+/**
+ * The one entry a spoken name picks out. Spoken names arrive with their case
+ * retold rather than copied, so the match forgives case alone — never
+ * spelling — and only while it stays unambiguous: two advertised entries apart
+ * only in case are not a guess Luke gets to make.
+ */
+function namedOnce<Entry>(
+  entries: readonly Entry[],
+  word: string,
+  nameOf: (entry: Entry) => string,
+  fold: (name: string) => string,
+): Entry | undefined {
+  const folded = fold(word);
+  const named = entries.filter((candidate) => fold(nameOf(candidate)) === folded);
+  return (
+    named.find((candidate) => nameOf(candidate) === word) ??
+    (named.length === 1 ? named[0] : undefined)
+  );
+}
+
+const itself = (name: string): string => name;
+
+/**
+ * Resolves a model the developer named — by the label the guide lists it
+ * under, or its id — to the wire pairing an endpoint takes, held to the
+ * build's documented entries for the provider. The effort, when named, must be
+ * one the resolved model's own agent documents: the pairing is validated as
+ * the whole it will be sent as.
+ */
+function resolveWorkspaceAgentModel(
+  entries: readonly WorkspaceAgentModels[],
+  modelWord: string,
+  effortWord: string | undefined,
+): { selection: WorkspaceAgentSelection } | { refusal: Refusal; unnamedModel: boolean } {
+  const normalizedModel = modelWord.trim().toLowerCase();
+  const named = entries
+    .flatMap((entry) => entry.models.map((model) => ({ entry, model })))
+    .find(
+      ({ model }) =>
+        model.label.toLowerCase() === normalizedModel || model.id.toLowerCase() === normalizedModel,
+    );
+  if (!named) return { refusal: refuse(ACT_REFUSAL.NO_MODEL), unnamedModel: true };
+  let effort: string | undefined;
+  if (effortWord !== undefined) {
+    const normalizedEffort = effortWord.trim().toLowerCase();
+    effort = named.entry.efforts.find((candidate) => candidate.toLowerCase() === normalizedEffort);
+    if (!effort) {
+      return {
+        unnamedModel: false,
+        refusal:
+          named.entry.efforts.length > 0
+            ? refuse(`That model's effort is one of ${named.entry.efforts.join(", ")}.`)
+            : refuse(ACT_REFUSAL.NO_EFFORT_LEVEL),
+      };
+    }
+  }
+  const selection: WorkspaceAgentSelection = { agent: named.entry.agent, model: named.model.id };
+  if (effort) selection.effort = effort;
+  return { selection };
+}
+
+/**
+ * Validates the value a spoken change carries against the setting it names.
+ * A toggle takes the guide's own two words (and their unambiguous synonyms);
+ * a choice takes exactly one of the values the guide listed. Anything else is
+ * refused with the accepted set, so the refusal is also the correction.
+ */
+function appSettingValue(setting: AppGuideSetting, value: UnparsedWireValue): string | undefined {
+  if (setting.kind === APP_SETTING_KIND.TOGGLE) return appToggleValue(value);
+  if (!isWireString(value)) return undefined;
+  const normalized = value.trim().toLowerCase();
+  return setting.choices?.find((choice) => choice.toLowerCase() === normalized);
+}
+
+/**
+ * Whether one observed session answers one spoken filter value. Every identity
+ * a row carries is a filter on the same terms as its provider id — the agent
+ * behind a hosted chat, an app associated with it, and a workspace manager's
+ * scope id — so a spoken ask reaches exactly the rows the matching chip would
+ * keep.
+ */
+function sessionAnswersFilter(session: Session, filter: string): boolean {
+  if (filter === SESSION_LOCATION.LOCAL || filter === SESSION_LOCATION.CLOUD) {
+    return session.location === filter;
+  }
+  if (filter === SESSION_LIST_VOICE) return session.realtimeVoice === true;
+  return (
+    session.providerId === filter ||
+    session.agent?.id === filter ||
+    session.workspace?.scopeId === filter ||
+    session.applications.some((application) => application.id === filter)
+  );
+}
+
+/**
+ * Admits a spoken session-list narrowing against the sessions actually being
+ * observed. A narrowing that would show nothing is refused rather than
+ * applied: the panel would quietly fall back to showing everything, and Luke
+ * would have reported a narrowing that never happened. Each value is checked
+ * on its own first, so the refusal can name the value that is wrong rather
+ * than only the combination — and then the combination is checked whole, on
+ * the same axis terms the chips combine on, because two values a roster
+ * answers separately can still name an intersection nothing occupies.
+ */
+function admittedFilters(
+  filters: readonly string[],
+  sessions: readonly Session[],
+): { filters: readonly string[] } | Refusal {
+  // The enum on the tool's own schema already binds a compliant model to these
+  // tokens; this is the backstop for a call composed past it.
+  for (const filter of filters) {
+    if (!SESSION_LIST_FILTER_VALUES.includes(filter)) {
+      return refuse(`"${filter}" is not one of the filter values the tool lists.`);
+    }
+  }
+  const chosen = [...new Set(filters)];
+  if (chosen.includes(SESSION_LIST_ALL)) {
+    if (chosen.length > 1) return refuse(ACT_REFUSAL.ALL_STANDS_ALONE);
+    return { filters: chosen };
+  }
+  for (const filter of chosen) {
+    if (sessions.some((session) => sessionAnswersFilter(session, filter))) continue;
+    if (filter === SESSION_LOCATION.LOCAL || filter === SESSION_LOCATION.CLOUD) {
+      return refuse(`No ${filter} sessions are observed right now.`);
+    }
+    if (filter === SESSION_LIST_VOICE) return refuse(ACT_REFUSAL.NO_VOICE_SESSIONS);
+    return refuse(
+      `No observed session belongs to an agent, app, or workspace manager "${filter}".`,
+    );
+  }
+  if (
+    chosen.length > 1 &&
+    !sessions.some((session) =>
+      matchesFilterSelection(chosen, (filter) => sessionAnswersFilter(session, filter)),
+    )
+  ) {
+    return refuse(ACT_REFUSAL.NO_FILTER_MATCH);
+  }
+  return { filters: chosen };
+}
+
+/**
+ * What stands where the asked-for act would be, so a refusal can say why the
+ * row is not offering it — the row's own detail says where the build stands,
+ * and this names the one press that stands instead.
+ */
+const UPDATE_BUTTON_STANDING = {
+  [APP_UPDATE_ACT.CHECK]: "Its button offers a check right now.",
+  [APP_UPDATE_ACT.DOWNLOAD]: "Its button offers the releases page in the browser right now.",
+  [APP_UPDATE_ACT.RESTART]: "Its button offers Restart to update right now.",
+  [APP_UPDATE_WAIT.CHECKING]: "Nothing is pressable while the check is out.",
+  [APP_UPDATE_WAIT.DOWNLOADING]: "Nothing is pressable while the download runs.",
+} as const satisfies Record<AppGuideUpdate["button"], string>;
+
+type Admitted<Kind extends ActKind> = ({ kind: Kind } & ActPayloads[Kind]) | Refusal;
+
+type Admitter<Kind extends ActKind> = (
+  fields: WireRecord,
+  context: AdmitContext,
+  reads: AdmittedReads,
+) => Promise<Admitted<Kind>> | Admitted<Kind>;
+
+async function admittedSession(
+  fields: WireRecord,
+  reads: AdmittedReads,
+): Promise<{ session: Session; identity: SessionIdentity } | Refusal> {
+  const sessions = await reads.sessions();
+  if (!sessions) return refuse(ACT_REFUSAL.TURN_OVER);
+  return sessionFrom(fields, sessions);
+}
+
+const admitMessage: Admitter<typeof ACT_KIND.MESSAGE> = async (fields, _context, reads) => {
+  const found = await admittedSession(fields, reads);
+  if ("status" in found) return found;
+  if (!advertisedActFor(found.session, ACT_KIND.MESSAGE)) {
+    return refuse(ACT_REFUSAL.NO_MESSAGES);
+  }
+  const text = MESSAGE_TEXT.parse(fields.text);
+  if (!text) return refuse(ACT_REFUSAL.MESSAGE_BOUND);
+  return { kind: ACT_KIND.MESSAGE, identity: found.identity, text };
+};
+
+const admitControl: Admitter<typeof ACT_KIND.CONTROL> = async (fields, _context, reads) => {
+  const found = await admittedSession(fields, reads);
+  if ("status" in found) return found;
+  const controlId = textArgument(fields, "control_id");
+  // The advertised control itself is what the act carries: the caller's copy
+  // names which one, and never what the effect is built from.
+  const control = controlId ? advertisedControl(found.session, controlId) : undefined;
+  if (!control) return refuse(ACT_REFUSAL.NO_CONTROL);
+  return { kind: ACT_KIND.CONTROL, identity: found.identity, control };
+};
+
+const admitOpen: Admitter<typeof ACT_KIND.OPEN> = async (fields, _context, reads) => {
+  const found = await admittedSession(fields, reads);
+  if ("status" in found) return found;
+  const { session, identity } = found;
+  // The act carries the identity — and, when the developer named an app, that
+  // app's id — never the address: the address is read back out of the roster
+  // by whoever performs the open, the same as a pressed row or a pressed app mark.
+  const applicationWord = textArgument(fields, "application");
+  if (applicationWord !== undefined) {
+    const normalized = applicationWord.trim().toLowerCase();
+    const application = session.applications.find(
+      (candidate) =>
+        candidate.displayName.toLowerCase() === normalized || candidate.id === normalized,
+    );
+    // An association without an exact address identifies the app but opens
+    // nothing, so it refuses like an app the roster never listed — and the
+    // refusal names the apps that can open, which the roster already carries.
+    // The id must be one the build fixed: the bridge takes no other.
+    const applicationId = application?.link ? application.id : undefined;
+    if (applicationId === undefined || !isSessionApplicationId(applicationId)) {
+      const openable = session.applications.filter((candidate) => candidate.link);
+      return openable.length > 0
+        ? refuse(
+            `That session opens in ${openable
+              .map((candidate) => candidate.displayName)
+              .join(" or ")}, not there.`,
+          )
+        : refuse(ACT_REFUSAL.NO_APP_ADDRESS);
+    }
+    return { kind: ACT_KIND.OPEN, identity, applicationId };
+  }
+  if (!session.detail.link) return refuse(ACT_REFUSAL.NO_ADDRESS);
+  return { kind: ACT_KIND.OPEN, identity };
+};
+
+const admitCreateWorkspace: Admitter<typeof ACT_KIND.CREATE_WORKSPACE> = async (
+  fields,
+  context,
+  reads,
+) => {
+  // A creation ask names a project rather than a session, so it is admitted
+  // against the projects the conversation was shown — the same discipline,
+  // against the list that actually offered it.
+  const listed = await reads.projects();
+  const saved = await reads.defaults();
+  if (!listed || !saved) return refuse(ACT_REFUSAL.TURN_OVER);
+  const providerId = textArgument(fields, "provider_id");
+  const projectId = textArgument(fields, "project_id");
+  const targetId = textArgument(fields, "target_id");
+  let matchingProjects = listed.filter(
+    (candidate) =>
+      (!providerId || candidate.providerId === providerId) &&
+      (!projectId || candidate.providerProjectId === projectId) &&
+      (!targetId || candidate.providerTargetId === targetId),
+  );
+  // The saved defaults settle only what the ask left unnamed: no provider
+  // named sends a still-ambiguous ask to the default provider while it is
+  // offering, and no project named sends it on to that provider's chosen
+  // project. Neither step can leave the listed set, and an ask that named its
+  // own provider or project is never overridden.
+  if (!providerId && saved.defaultProviderId && matchingProjects.length > 1) {
+    const offeredByDefault = matchingProjects.filter(
+      (candidate) => candidate.providerId === saved.defaultProviderId,
+    );
+    if (offeredByDefault.length > 0) matchingProjects = offeredByDefault;
+  }
+  // A provider's chosen project settles which project, never which provider:
+  // while candidates still span providers, one provider's saved project must
+  // not quietly decide an ask the developer left open between them.
+  const [firstMatch] = matchingProjects;
+  const oneProviderMatches =
+    firstMatch !== undefined &&
+    matchingProjects.every((candidate) => candidate.providerId === firstMatch.providerId);
+  if (!projectId && oneProviderMatches && matchingProjects.length > 1) {
+    const chosenProjects = matchingProjects.filter(
+      (candidate) =>
+        saved.defaultProjectIds?.[candidate.providerId] === workspaceProjectSelectionId(candidate),
+    );
+    if (chosenProjects.length === 1) matchingProjects = chosenProjects;
+  }
+  const [project] = matchingProjects;
+  if (matchingProjects.length !== 1 || project === undefined) {
+    return refuse(matchingProjects.length > 1 ? ACT_REFUSAL.MANY_PROJECTS : ACT_REFUSAL.NO_PROJECT);
+  }
+  const requestedAgent = textArgument(fields, "agent");
+  const spawnable = project.spawnableAgents;
+  const agent =
+    (spawnable === undefined || requestedAgent === undefined
+      ? undefined
+      : namedOnce(spawnable, requestedAgent, itself, (name) => name.toLocaleLowerCase())) ??
+    project.defaultAgent;
+  if (spawnable && (!agent || !spawnable.includes(agent))) {
+    return refuse(agent ? ACT_REFUSAL.NO_PROJECT_AGENT : ACT_REFUSAL.NAME_A_PROJECT_AGENT);
+  }
+  let name: string | undefined;
+  if (fields.name !== undefined) {
+    if (project.namesItself) return refuse(ACT_REFUSAL.PROJECT_NAMES_ITSELF);
+    name = WORKSPACE_NAME.parse(fields.name);
+    if (!name) return refuse(ACT_REFUSAL.WORKSPACE_NAME_BOUND);
+  }
+  // The task is held to the project's own word for it: a project that takes
+  // none cannot be handed one, a project that needs one cannot be created
+  // without it, and the text itself is bounded like the message it is.
+  let task: string | undefined;
+  if (fields.task !== undefined) {
+    if (project.taskSupport === WORKSPACE_TASK_SUPPORT.NONE) {
+      return refuse(ACT_REFUSAL.NO_TASK_TAKEN);
+    }
+    task = OPENING_TASK.parse(fields.task);
+    if (!task) return refuse(ACT_REFUSAL.TASK_BOUND);
+  } else if (project.taskSupport === WORKSPACE_TASK_SUPPORT.REQUIRED) {
+    return refuse(ACT_REFUSAL.TASK_REQUIRED);
+  }
+  // A model named for this one creation resolves against the provider's own
+  // documented table, and the effort only ever rides a model: alone it has
+  // nothing documented to attach to.
+  const spokenModel = textArgument(fields, "model");
+  const spokenEffort = textArgument(fields, "effort");
+  if (spokenEffort !== undefined && spokenModel === undefined) {
+    return refuse(ACT_REFUSAL.EFFORT_NEEDS_MODEL);
+  }
+  let agentSelection: WorkspaceAgentSelection | undefined;
+  if (spokenModel !== undefined) {
+    const resolved = resolveWorkspaceAgentModel(
+      context.projects?.agentModels(project.providerId) ?? [],
+      spokenModel,
+      spokenEffort,
+    );
+    if ("refusal" in resolved) return resolved.refusal;
+    agentSelection = resolved.selection;
+  }
+  const act: {
+    kind: typeof ACT_KIND.CREATE_WORKSPACE;
+  } & ActPayloads[typeof ACT_KIND.CREATE_WORKSPACE] = {
+    kind: ACT_KIND.CREATE_WORKSPACE,
+    providerId: project.providerId,
+    providerProjectId: project.providerProjectId,
+  };
+  if (project.providerTargetId) act.providerTargetId = project.providerTargetId;
+  if (agent) act.agent = agent;
+  if (name) act.name = name;
+  if (task) act.task = task;
+  if (agentSelection) act.agentSelection = agentSelection;
+  return act;
+};
+
+const admitAddAgent: Admitter<typeof ACT_KIND.ADD_AGENT> = async (fields, context, reads) => {
+  const found = await admittedSession(fields, reads);
+  if ("status" in found) return found;
+  const { session, identity } = found;
+  // The agent must be one this session's own roster entry listed: the list is
+  // the provider's word for what its endpoint takes, so an ask outside it is
+  // refused rather than forwarded to be refused.
+  const asked = textArgument(fields, "agent");
+  const advertised = advertisedActFor(session, ACT_KIND.ADD_AGENT)?.agents ?? [];
+  const agent = asked === undefined ? undefined : advertised.find((entry) => entry === asked);
+  if (agent === undefined) return refuse(ACT_REFUSAL.NO_SESSION_AGENT);
+  let name: string | undefined;
+  if (fields.name !== undefined) {
+    name = WORKSPACE_NAME.parse(fields.name);
+    if (!name) return refuse(ACT_REFUSAL.SESSION_NAME_BOUND);
+  }
+  let task: string | undefined;
+  if (fields.task !== undefined) {
+    task = OPENING_TASK.parse(fields.task);
+    if (!task) return refuse(ACT_REFUSAL.TASK_BOUND);
+  }
+  // A model named for this one agent resolves within the asked-for kind alone:
+  // the developer's chosen agent is never re-decided by the model they named
+  // beside it, so a mismatch is a refusal rather than a swap.
+  const spokenModel = textArgument(fields, "model");
+  const spokenEffort = textArgument(fields, "effort");
+  if (spokenEffort !== undefined && spokenModel === undefined) {
+    return refuse(ACT_REFUSAL.EFFORT_NEEDS_MODEL);
+  }
+  let selection: WorkspaceAgentSelection | undefined;
+  if (spokenModel !== undefined) {
+    const entries = (context.projects?.agentModels(session.providerId) ?? []).filter(
+      (candidate) => candidate.agent === agent,
+    );
+    const resolved = resolveWorkspaceAgentModel(entries, spokenModel, spokenEffort);
+    if ("refusal" in resolved) {
+      return resolved.unnamedModel
+        ? refuse(`A ${agent} agent runs no model by that name.`)
+        : resolved.refusal;
+    }
+    selection = resolved.selection;
+  }
+  const act: { kind: typeof ACT_KIND.ADD_AGENT } & ActPayloads[typeof ACT_KIND.ADD_AGENT] = {
+    kind: ACT_KIND.ADD_AGENT,
+    identity,
+    agent,
+  };
+  if (name) act.name = name;
+  if (task) act.task = task;
+  if (selection) act.model = selection.model;
+  if (selection?.effort) act.effort = selection.effort;
+  return act;
+};
+
+const admitRenameWorkspace: Admitter<typeof ACT_KIND.RENAME_WORKSPACE> = async (
+  fields,
+  _context,
+  reads,
+) => {
+  const found = await admittedSession(fields, reads);
+  if ("status" in found) return found;
+  // Only a session whose roster entry advertised renaming has a workspace a
+  // rename can land on. The act carries the identity and the name, never the
+  // target: the workspace is resolved from the observed entry, the same way an
+  // open never carries an address.
+  if (!advertisedActFor(found.session, ACT_KIND.RENAME_WORKSPACE)) {
+    return refuse(ACT_REFUSAL.NO_WORKSPACE_RENAME);
+  }
+  const name = WORKSPACE_NAME.parse(fields.name);
+  if (!name) return refuse(ACT_REFUSAL.WORKSPACE_NAME_BOUND);
+  return { kind: ACT_KIND.RENAME_WORKSPACE, identity: found.identity, name };
+};
+
+const admitRenameSession: Admitter<typeof ACT_KIND.RENAME_SESSION> = async (
+  fields,
+  _context,
+  reads,
+) => {
+  const found = await admittedSession(fields, reads);
+  if ("status" in found) return found;
+  if (!advertisedActFor(found.session, ACT_KIND.RENAME_SESSION)) {
+    return refuse(ACT_REFUSAL.NO_SESSION_RENAME);
+  }
+  const name = WORKSPACE_NAME.parse(fields.name);
+  if (!name) return refuse(ACT_REFUSAL.CHAT_NAME_BOUND);
+  return { kind: ACT_KIND.RENAME_SESSION, identity: found.identity, name };
+};
+
+function admittedIssue(
+  fields: WireRecord,
+  context: AdmitContext,
+): { issue: TrackedIssue; identity: IssueIdentity } | Refusal {
+  if (!context.issues) return refuse(ACT_REFUSAL.NO_TRACKER);
+  return issueFrom(fields, context.issues);
+}
+
+const admitIssueState: Admitter<typeof ACT_KIND.ISSUE_STATE> = (fields, context) => {
+  const found = admittedIssue(fields, context);
+  if ("status" in found) return found;
+  const state = textArgument(fields, "state");
+  const transition =
+    state === undefined
+      ? undefined
+      : namedOnce(
+          found.issue.transitions,
+          state,
+          (candidate) => candidate.name,
+          (name) => name.toLowerCase(),
+        );
+  if (!transition) return refuse(ACT_REFUSAL.NO_ISSUE_STATE);
+  return { kind: ACT_KIND.ISSUE_STATE, identity: found.identity, transition };
+};
+
+const admitIssueComment: Admitter<typeof ACT_KIND.ISSUE_COMMENT> = (fields, context) => {
+  const found = admittedIssue(fields, context);
+  if ("status" in found) return found;
+  if (!found.issue.canComment) return refuse(ACT_REFUSAL.NO_COMMENTS);
+  const body = COMMENT_BODY.parse(fields.body);
+  if (!body) return refuse(ACT_REFUSAL.COMMENT_BOUND);
+  return { kind: ACT_KIND.ISSUE_COMMENT, identity: found.identity, body };
+};
+
+const admitSetting: Admitter<typeof ACT_KIND.SETTING> = (fields, context) => {
+  const guide = context.guide ?? EMPTY_APP_GUIDE;
+  const setting = appGuideSetting(guide, textArgument(fields, "setting_id"));
+  if (!setting) return refuse(ACT_REFUSAL.NO_SETTING);
+  if (!setting.adjustable) {
+    return refuse(`${setting.label} can only be changed by hand: ${setting.manual}`);
+  }
+  const value = appSettingValue(setting, fields.value);
+  if (value === undefined) {
+    const accepted =
+      setting.kind === APP_SETTING_KIND.TOGGLE ? "on or off" : (setting.choices ?? []).join(", ");
+    return refuse(`${setting.label} takes ${accepted}.`);
+  }
+  // An effort may ride only a value the guide lists levels for, so both halves
+  // of one stored pairing can be asked for in one change — matched like the
+  // value: case retold rather than copied, answered in the guide's own casing.
+  const effortWord = textArgument(fields, "effort");
+  if (effortWord === undefined) return { kind: ACT_KIND.SETTING, setting, value };
+  const levels = setting.efforts?.[value] ?? [];
+  if (levels.length === 0) {
+    return refuse(
+      setting.efforts === undefined
+        ? `${setting.label} takes no effort level.`
+        : `${value} takes no effort level.`,
+    );
+  }
+  const normalizedEffort = effortWord.trim().toLowerCase();
+  const effort = levels.find((candidate) => candidate.toLowerCase() === normalizedEffort);
+  if (effort === undefined) return refuse(`${value}'s effort is one of ${levels.join(", ")}.`);
+  return { kind: ACT_KIND.SETTING, setting, value, effort };
+};
+
+const admitPanel: Admitter<typeof ACT_KIND.PANEL> = async (fields, _context, reads) => {
+  const sessions = await reads.sessions();
+  if (!sessions) return refuse(ACT_REFUSAL.TURN_OVER);
+  const askedTab = fields.tab ?? undefined;
+  const tab = askedTab === undefined ? APP_PANEL_TAB.SESSIONS : PANEL_TAB.parse(askedTab);
+  if (tab === undefined) return refuse(ACT_REFUSAL.NO_TAB);
+  const sortWord = textArgument(fields, "sort");
+  const sort = sortWord === undefined ? undefined : PANEL_SORT.parse(sortWord);
+  if (sortWord !== undefined && sort === undefined) return refuse(ACT_REFUSAL.NO_SORT);
+  // A search is bounded by the hand's own control: the magnifier is only
+  // offered beside a list with more than one session, and a spoken ask reaches
+  // no further than it. The words themselves are not validated against the
+  // rows the way a filter is — a query is read against the lines as the
+  // surface words them, which only the renderer knows, and a search matching
+  // nothing is the list's own honest answer rather than a stale narrowing to
+  // refuse.
+  const query = textArgument(fields, "query");
+  if (query !== undefined && sessions.length < 2) return refuse(ACT_REFUSAL.NO_SEARCH);
+  const asked = PANEL_FILTERS.read(fields.filters);
+  if (!asked.ok) return refuse(ACT_REFUSAL.FILTERS_SHAPE);
+  const act: { kind: typeof ACT_KIND.PANEL } & ActPayloads[typeof ACT_KIND.PANEL] = {
+    kind: ACT_KIND.PANEL,
+    tab,
+  };
+  if (asked.value !== undefined) {
+    const outcome = admittedFilters(asked.value, sessions);
+    if ("status" in outcome) return outcome;
+    act.filters = outcome.filters;
+  }
+  if (sort !== undefined) act.sort = sort;
+  if (query !== undefined) act.query = query;
+  return act;
+};
+
+const admitFeedback: Admitter<typeof ACT_KIND.FEEDBACK> = (fields) => {
+  const composer = FEEDBACK_KIND.parse(fields.kind);
+  if (composer === undefined) return refuse(ACT_REFUSAL.NO_COMPOSER);
+  // The draft is the developer's ask restated in their words, not a document,
+  // so it is bounded like a typed one; a blank draft is no draft, and the
+  // composer simply opens empty.
+  const draft = textArgument(fields, "draft")?.slice(0, maximumSessionMessageLength);
+  const act: { kind: typeof ACT_KIND.FEEDBACK } & ActPayloads[typeof ACT_KIND.FEEDBACK] = {
+    kind: ACT_KIND.FEEDBACK,
+    composer,
+  };
+  if (draft) act.draft = draft;
+  return act;
+};
+
+const admitUpdate: Admitter<typeof ACT_KIND.UPDATE> = (fields, context) => {
+  // The guide's update entry is the roster here: a run that reported nothing
+  // about updates — a fixture, a pure caller — advertises no act to run.
+  const update = (context.guide ?? EMPTY_APP_GUIDE).update;
+  if (!update) return refuse(ACT_REFUSAL.NO_UPDATE_REPORT);
+  const act = UPDATE_ACT.parse(fields.action);
+  if (act === undefined) return refuse(ACT_REFUSAL.NO_UPDATE_ACT);
+  // One button, one act: only the press the row is actually drawing runs, so
+  // the refusal is the row's own words plus what stands in the act's place.
+  if (act !== update.button) {
+    return withDetail(update.detail, UPDATE_BUTTON_STANDING[update.button]);
+  }
+  return { kind: ACT_KIND.UPDATE, act };
+};
+
+const admitRemember: Admitter<typeof ACT_KIND.REMEMBER> = (fields, context) => {
+  const facts = context.rememberedFacts ?? [];
+  const words = rememberedFactText(fields.words);
+  if (!words) return refuse(ACT_REFUSAL.MEMORY_BOUND);
+  const replaces = textArgument(fields, "replaces");
+  if (replaces !== undefined && !holdsRememberedFact(facts, replaces)) {
+    return refuse(ACT_REFUSAL.NO_SUCH_FACT);
+  }
+  // A replacement retires one as it lands; a new fact never evicts silently.
+  if (replaces === undefined && facts.length >= maximumRememberedFacts) {
+    return refuse(ACT_REFUSAL.MEMORY_FULL);
+  }
+  return { kind: ACT_KIND.REMEMBER, words, ...(replaces ? { replaces } : undefined) };
+};
+
+const admitForget: Admitter<typeof ACT_KIND.FORGET> = (fields, context) => {
+  const id = textArgument(fields, "id");
+  if (!id || !holdsRememberedFact(context.rememberedFacts ?? [], id)) {
+    return refuse(ACT_REFUSAL.NO_SUCH_FACT);
+  }
+  return { kind: ACT_KIND.FORGET, id };
+};
+
+const ADMITTERS = {
+  [ACT_KIND.MESSAGE]: admitMessage,
+  [ACT_KIND.CONTROL]: admitControl,
+  [ACT_KIND.OPEN]: admitOpen,
+  [ACT_KIND.CREATE_WORKSPACE]: admitCreateWorkspace,
+  [ACT_KIND.ADD_AGENT]: admitAddAgent,
+  [ACT_KIND.RENAME_WORKSPACE]: admitRenameWorkspace,
+  [ACT_KIND.RENAME_SESSION]: admitRenameSession,
+  [ACT_KIND.ISSUE_STATE]: admitIssueState,
+  [ACT_KIND.ISSUE_COMMENT]: admitIssueComment,
+  [ACT_KIND.SETTING]: admitSetting,
+  [ACT_KIND.PANEL]: admitPanel,
+  [ACT_KIND.FEEDBACK]: admitFeedback,
+  [ACT_KIND.UPDATE]: admitUpdate,
+  [ACT_KIND.REMEMBER]: admitRemember,
+  [ACT_KIND.FORGET]: admitForget,
+} as const satisfies { [K in ActKind]: Admitter<K> };
+
+/**
+ * The one function that mints a {@link ValidatedAct}. Everything a performer
+ * or an adapter needs to have been checked is checked here, once, and the type
+ * it answers with is how every path is held to having run it.
+ */
+export async function admit<Kind extends ActKind>(
+  request: ActRequest<Kind>,
+  context: AdmitContext,
+): Promise<ValidatedAct<Kind> | Refusal> {
+  if (context.guard?.isRevoked()) return refuse(ACT_REFUSAL.TURN_OVER);
+  // SAFETY: the table is keyed by the same union `request.kind` ranges over, so
+  // the entry selected is the admitter written for this request's own kind.
+  const admitter = ADMITTERS[request.kind] as Admitter<Kind>;
+  const admitted = await admitter(request.fields, context, admittedReads(context));
+  if ("status" in admitted) return admitted;
+  // Asked once more after every await admission made, so an act whose turn
+  // ended while the roster was refreshing refuses rather than being minted.
+  if (context.guard?.isRevoked()) return refuse(ACT_REFUSAL.TURN_OVER);
+  // SAFETY: the brand is nominal and this is its one producer; the payload
+  // stands exactly as the admitter built it.
+  return { ...admitted, origin: context.origin, [ADMITTED]: true } as ValidatedAct<Kind>;
+}

--- a/packages/acts/src/guarantees.test.ts
+++ b/packages/acts/src/guarantees.test.ts
@@ -479,36 +479,62 @@ test("opening a session is not a write: the act carries an identity, never an ad
   assert.deepEqual(Object.keys(admitted).sort(), ["identity", "kind", "origin"]);
 });
 
-test("admitting performs nothing: no seam beyond the roster and the projects is reached", async () => {
-  let reads = 0;
-  const counted: AdmitContext = {
-    origin: RUN_ORIGIN.USER,
-    roster: {
-      read: async () => {
-        reads += 1;
-        return [offering()];
+/**
+ * Which observed state each act is admitted against, and nothing wider. Only
+ * an act whose target the roster holds reads the roster, and only a creation
+ * reads the offered projects — an intake that observes lazily has to be held
+ * to observing for the acts that need it, since a read that quietly stops
+ * happening is an act admitted against a stale picture.
+ */
+const READS = {
+  [ACT_KIND.MESSAGE]: ["roster"],
+  [ACT_KIND.CONTROL]: ["roster"],
+  [ACT_KIND.OPEN]: ["roster"],
+  [ACT_KIND.CREATE_WORKSPACE]: ["projects", "defaults"],
+  [ACT_KIND.ADD_AGENT]: ["roster"],
+  [ACT_KIND.RENAME_WORKSPACE]: ["roster"],
+  [ACT_KIND.RENAME_SESSION]: ["roster"],
+  [ACT_KIND.ISSUE_STATE]: [],
+  [ACT_KIND.ISSUE_COMMENT]: [],
+  [ACT_KIND.SETTING]: [],
+  [ACT_KIND.PANEL]: ["roster"],
+  [ACT_KIND.FEEDBACK]: [],
+  [ACT_KIND.UPDATE]: [],
+  [ACT_KIND.REMEMBER]: [],
+  [ACT_KIND.FORGET]: [],
+} satisfies Record<ActKind, readonly ("roster" | "projects" | "defaults")[]>;
+
+test("each act is admitted against the observed state it names, and against nothing wider", async () => {
+  for (const kind of EVERY_KIND) {
+    const reached: string[] = [];
+    await admit(
+      { kind, fields: FIELDS[kind] },
+      {
+        origin: RUN_ORIGIN.USER,
+        roster: {
+          read: async () => {
+            reached.push("roster");
+            return [offering()];
+          },
+        },
+        projects: {
+          read: async () => {
+            reached.push("projects");
+            return [LISTED_PROJECT];
+          },
+          defaults: async () => {
+            reached.push("defaults");
+            return {};
+          },
+          agentModels: () => [],
+        },
+        ...(ISSUE ? { issues: [ISSUE] } : undefined),
+        guide: EMPTY_APP_GUIDE,
+        rememberedFacts: [{ id: "fact-one", words: "prefers concise answers" }],
       },
-    },
-    projects: {
-      read: async () => {
-        reads += 1;
-        return [LISTED_PROJECT];
-      },
-      defaults: async () => {
-        reads += 1;
-        return {};
-      },
-      agentModels: () => {
-        reads += 1;
-        return [];
-      },
-    },
-    issues: ISSUE ? [ISSUE] : [],
-    guide: EMPTY_APP_GUIDE,
-    rememberedFacts: [{ id: "fact-one", words: "prefers concise answers" }],
-  };
-  for (const kind of EVERY_KIND) await admit({ kind, fields: FIELDS[kind] }, counted);
-  // Nothing else exists to reach: an act's effect is the performer's, and
-  // admission holds no adapter, no CLI, and no tracker client to call.
-  assert.ok(reads > 0);
+    );
+    // Sorted, because which of a creation's two reads runs first is admission's
+    // own business; that both run, once each, is not.
+    assert.deepEqual([...reached].sort(), [...READS[kind]].sort(), kind);
+  }
 });

--- a/packages/acts/src/guarantees.test.ts
+++ b/packages/acts/src/guarantees.test.ts
@@ -1,0 +1,514 @@
+/**
+ * One case per trust constraint the act pipeline holds, each named by the
+ * sentence it keeps. A failure here is not a refactoring nit: it is a
+ * guarantee `CLAUDE.md` states in as many words having stopped being true.
+ */
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import { EMPTY_APP_GUIDE } from "@sidecar/guide";
+import { normalizeTrackedIssue } from "@sidecar/issues";
+import { RUN_ORIGIN } from "@sidecar/runtime-contracts";
+import {
+  maximumSessionMessageLength,
+  maximumWorkspaceNameLength,
+  normalizeSession,
+  type ObservedWorkspaceProject,
+  SESSION_CONTROL_KIND,
+  SESSION_LOCATION,
+  SESSION_STATUS,
+  type Session,
+  WORKSPACE_TASK_SUPPORT,
+} from "@sidecar/session";
+import { ACT_RESULT_STATUS, type WireRecord } from "@sidecar/wire";
+import { ACT_KIND, type ActKind } from "./act-kinds.js";
+import { ACT_REFUSAL, type AdmitContext, admit, type Refusal, type ValidatedAct } from "./admit.js";
+import { maximumRememberedFacts } from "./memory.js";
+
+const NOW = 1_800_000_000_000;
+
+const IDENTITY = { provider_id: "conductor", provider_session_id: "chat-1" };
+
+/** One session advertising every act its provider could document for it. */
+function offering(): Session {
+  return normalizeSession(
+    { id: "conductor", displayName: "Conductor" },
+    {
+      providerSessionId: "chat-1",
+      title: "Conductor: luke",
+      status: SESSION_STATUS.WAITING,
+      lastActivityAt: NOW,
+      location: SESSION_LOCATION.CLOUD,
+      detail: { link: "https://app.conductor.build/sessions/chat-1" },
+      advertises: [
+        { kind: ACT_KIND.MESSAGE },
+        {
+          kind: ACT_KIND.CONTROL,
+          id: "cancel-run",
+          label: "Stop this run",
+          controlKind: SESSION_CONTROL_KIND.STOP,
+        },
+        { kind: ACT_KIND.ADD_AGENT, agents: ["codex"] },
+        { kind: ACT_KIND.RENAME_SESSION },
+        { kind: ACT_KIND.RENAME_WORKSPACE, target: "workspace-1" },
+      ],
+    },
+  );
+}
+
+/** The same session with nothing advertised: a local chat its provider documents no way into. */
+function silent(): Session {
+  return normalizeSession(
+    { id: "claude-code", displayName: "Claude Code" },
+    {
+      providerSessionId: "chat-1",
+      title: "Claude Code: luke",
+      status: SESSION_STATUS.WORKING,
+      lastActivityAt: NOW,
+      location: SESSION_LOCATION.LOCAL,
+    },
+  );
+}
+
+const LISTED_PROJECT: ObservedWorkspaceProject = {
+  providerId: "conductor",
+  providerName: "Conductor",
+  providerProjectId: "luke",
+  repository: "luke",
+  taskSupport: WORKSPACE_TASK_SUPPORT.OPTIONAL,
+};
+
+const ISSUE = normalizeTrackedIssue(
+  { id: "linear", displayName: "Linear" },
+  {
+    trackerIssueId: "issue-uuid",
+    identifier: "LUKE-1",
+    title: "Ship admission",
+    stateName: "Todo",
+    observedAt: NOW,
+    canComment: true,
+    transitions: [{ id: "state-done", name: "Done" }],
+  },
+);
+
+/**
+ * A context whose seams count what admission actually reached, so a test can
+ * say not only what was answered but what was read to answer it.
+ */
+function context(
+  overrides: Partial<AdmitContext> & { sessions?: readonly Session[] } = {},
+): AdmitContext & { rosterReads: () => number; effects: () => number } {
+  let rosterReads = 0;
+  const sessions = overrides.sessions ?? [offering()];
+  const built: AdmitContext = {
+    origin: RUN_ORIGIN.USER,
+    roster: {
+      read: async () => {
+        rosterReads += 1;
+        return sessions;
+      },
+    },
+    projects: {
+      read: async () => [LISTED_PROJECT],
+      defaults: async () => ({}),
+      agentModels: () => [],
+    },
+    ...overrides,
+  };
+  return { ...built, rosterReads: () => rosterReads, effects: () => 0 };
+}
+
+const FIELDS = {
+  [ACT_KIND.MESSAGE]: { ...IDENTITY, text: "go ahead" },
+  [ACT_KIND.CONTROL]: { ...IDENTITY, control_id: "cancel-run" },
+  [ACT_KIND.OPEN]: { ...IDENTITY },
+  [ACT_KIND.CREATE_WORKSPACE]: { provider_id: "conductor", project_id: "luke" },
+  [ACT_KIND.ADD_AGENT]: { ...IDENTITY, agent: "codex" },
+  [ACT_KIND.RENAME_WORKSPACE]: { ...IDENTITY, name: "new name" },
+  [ACT_KIND.RENAME_SESSION]: { ...IDENTITY, name: "new name" },
+  [ACT_KIND.ISSUE_STATE]: { tracker_id: "linear", issue_id: "LUKE-1", state: "Done" },
+  [ACT_KIND.ISSUE_COMMENT]: { tracker_id: "linear", issue_id: "LUKE-1", body: "looking" },
+  [ACT_KIND.SETTING]: { setting_id: "voice_captions", value: "on" },
+  [ACT_KIND.PANEL]: { tab: "sessions" },
+  [ACT_KIND.FEEDBACK]: { kind: "feedback" },
+  [ACT_KIND.UPDATE]: { action: "check" },
+  [ACT_KIND.REMEMBER]: { words: "prefers concise answers" },
+  [ACT_KIND.FORGET]: { id: "fact-one" },
+} satisfies Record<ActKind, WireRecord>;
+
+const SESSION_KINDS = [
+  ACT_KIND.MESSAGE,
+  ACT_KIND.CONTROL,
+  ACT_KIND.OPEN,
+  ACT_KIND.ADD_AGENT,
+  ACT_KIND.RENAME_WORKSPACE,
+  ACT_KIND.RENAME_SESSION,
+] as const;
+
+// SAFETY: the table above is keyed by every act kind and by nothing else.
+const EVERY_KIND = Object.keys(FIELDS) as readonly ActKind[];
+
+function refused(result: ValidatedAct | Refusal): string {
+  assert.equal(result.kind, undefined, "expected a refusal");
+  assert.ok(result.kind === undefined);
+  assert.equal(result.status, ACT_RESULT_STATUS.REJECTED);
+  return result.reason;
+}
+
+test("each validated against the observed roster before an adapter sees it", async () => {
+  const elsewhere = context({ sessions: [] });
+  for (const kind of SESSION_KINDS) {
+    const answer = await admit({ kind, fields: FIELDS[kind] }, elsewhere);
+    assert.equal(refused(answer), ACT_REFUSAL.NO_SESSION, kind);
+  }
+  assert.equal(elsewhere.rosterReads(), SESSION_KINDS.length);
+});
+
+test("a fresh roster read precedes it, and admission reads it once per act", async () => {
+  for (const kind of SESSION_KINDS) {
+    const standing = context();
+    assert.notEqual((await admit({ kind, fields: FIELDS[kind] }, standing)).kind, undefined, kind);
+    assert.equal(standing.rosterReads(), 1, kind);
+  }
+});
+
+test("its target has to be one the roster holds", async () => {
+  // The same session id under another provider is another session, and names nothing.
+  const answer = await admit(
+    { kind: ACT_KIND.MESSAGE, fields: { ...FIELDS[ACT_KIND.MESSAGE], provider_id: "codex" } },
+    context(),
+  );
+  assert.equal(refused(answer), ACT_REFUSAL.NO_SESSION);
+});
+
+test("a cancellation or a revoked run refuses it", async () => {
+  for (const kind of EVERY_KIND) {
+    const revoked = context({ guard: { isRevoked: () => true } });
+    assert.equal(
+      refused(await admit({ kind, fields: FIELDS[kind] }, revoked)),
+      ACT_REFUSAL.TURN_OVER,
+      kind,
+    );
+    assert.equal(revoked.rosterReads(), 0, kind);
+  }
+});
+
+test("a turn that ends while the roster is read refuses rather than dispatching", async () => {
+  let over = false;
+  const controller = new AbortController();
+  const answer = await admit(
+    { kind: ACT_KIND.MESSAGE, fields: FIELDS[ACT_KIND.MESSAGE] },
+    {
+      origin: RUN_ORIGIN.USER,
+      guard: { isRevoked: () => over, signal: controller.signal },
+      roster: {
+        read: async () => {
+          over = true;
+          return [offering()];
+        },
+      },
+    },
+  );
+  assert.equal(refused(answer), ACT_REFUSAL.TURN_OVER);
+});
+
+test("a read still out when the signal fires answers nothing, and the act refuses", async () => {
+  const controller = new AbortController();
+  let release: (() => void) | undefined;
+  const held = new Promise<readonly Session[]>((resolve) => {
+    release = () => resolve([offering()]);
+  });
+  const pending = admit(
+    { kind: ACT_KIND.MESSAGE, fields: FIELDS[ACT_KIND.MESSAGE] },
+    {
+      origin: RUN_ORIGIN.USER,
+      guard: { isRevoked: () => controller.signal.aborted, signal: controller.signal },
+      roster: { read: () => held },
+    },
+  );
+  controller.abort();
+  assert.equal(refused(await pending), ACT_REFUSAL.TURN_OVER);
+  release?.();
+});
+
+test("a control its provider advertised for it, and never the caller's copy", async () => {
+  const roster = [offering()];
+  const admitted = await admit(
+    { kind: ACT_KIND.CONTROL, fields: FIELDS[ACT_KIND.CONTROL] },
+    context({ sessions: roster }),
+  );
+  assert.equal(admitted.kind, ACT_KIND.CONTROL);
+  assert.ok(admitted.kind === ACT_KIND.CONTROL);
+  const advertised = roster[0]?.advertises.find((act) => act.kind === ACT_KIND.CONTROL);
+  assert.deepEqual(admitted.control, advertised);
+  assert.equal(
+    refused(
+      await admit(
+        { kind: ACT_KIND.CONTROL, fields: { ...IDENTITY, control_id: "terminate" } },
+        context(),
+      ),
+    ),
+    ACT_REFUSAL.NO_CONTROL,
+  );
+});
+
+test("a session whose current state is documented for none advertises nothing and is offered nothing", async () => {
+  const local = silent();
+  const quiet = context({ sessions: [local] });
+  const named = { provider_id: local.providerId, provider_session_id: local.providerSessionId };
+  for (const kind of SESSION_KINDS) {
+    if (kind === ACT_KIND.OPEN) continue;
+    assert.notEqual(
+      refused(await admit({ kind, fields: { ...FIELDS[kind], ...named } }, quiet)),
+      "",
+      kind,
+    );
+  }
+});
+
+test("local sessions have no such endpoint and stay entirely read-only", async () => {
+  const local = silent();
+  const observed = context({ sessions: [local] });
+  const named = { provider_id: local.providerId, provider_session_id: local.providerSessionId };
+  for (const kind of SESSION_KINDS) {
+    if (kind === ACT_KIND.OPEN) continue;
+    assert.equal(
+      (await admit({ kind, fields: { ...FIELDS[kind], ...named } }, observed)).kind,
+      undefined,
+      kind,
+    );
+  }
+  // An open is not a write, and a session reporting no address is offered nowhere to open.
+  assert.equal(
+    refused(await admit({ kind: ACT_KIND.OPEN, fields: named }, observed)),
+    ACT_REFUSAL.NO_ADDRESS,
+  );
+});
+
+test("the developer's own text, bounded and refused rather than cut", async () => {
+  const atBound = "a".repeat(maximumSessionMessageLength);
+  const admitted = await admit(
+    { kind: ACT_KIND.MESSAGE, fields: { ...IDENTITY, text: atBound } },
+    context(),
+  );
+  assert.ok(admitted.kind === ACT_KIND.MESSAGE);
+  assert.equal(admitted.text, atBound);
+  assert.equal(
+    refused(
+      await admit(
+        { kind: ACT_KIND.MESSAGE, fields: { ...IDENTITY, text: `${atBound}a` } },
+        context(),
+      ),
+    ),
+    ACT_REFUSAL.MESSAGE_BOUND,
+  );
+  const name = "n".repeat(maximumWorkspaceNameLength + 1);
+  for (const kind of [ACT_KIND.RENAME_WORKSPACE, ACT_KIND.RENAME_SESSION] as const) {
+    assert.equal((await admit({ kind, fields: { ...IDENTITY, name } }, context())).kind, undefined);
+  }
+});
+
+test("lands only in a project its provider reported on the latest observation pass", async () => {
+  assert.equal(
+    refused(
+      await admit(
+        { kind: ACT_KIND.CREATE_WORKSPACE, fields: { project_id: "/Users/me/other" } },
+        context(),
+      ),
+    ),
+    ACT_REFUSAL.NO_PROJECT,
+  );
+  const admitted = await admit(
+    { kind: ACT_KIND.CREATE_WORKSPACE, fields: { project_id: "luke" } },
+    context(),
+  );
+  assert.ok(admitted.kind === ACT_KIND.CREATE_WORKSPACE);
+  // Every identifier the act carries is the listed project's, never the ask's.
+  assert.equal(admitted.providerId, LISTED_PROJECT.providerId);
+  assert.equal(admitted.providerProjectId, LISTED_PROJECT.providerProjectId);
+});
+
+test("each project says whether it takes a task, needs one, or takes none", async () => {
+  const withSupport = (taskSupport: ObservedWorkspaceProject["taskSupport"]) =>
+    context({
+      projects: {
+        read: async () => [{ ...LISTED_PROJECT, taskSupport }],
+        defaults: async () => ({}),
+        agentModels: () => [],
+      },
+    });
+  assert.equal(
+    refused(
+      await admit(
+        { kind: ACT_KIND.CREATE_WORKSPACE, fields: { project_id: "luke", task: "start" } },
+        withSupport(WORKSPACE_TASK_SUPPORT.NONE),
+      ),
+    ),
+    ACT_REFUSAL.NO_TASK_TAKEN,
+  );
+  assert.equal(
+    refused(
+      await admit(
+        { kind: ACT_KIND.CREATE_WORKSPACE, fields: { project_id: "luke" } },
+        withSupport(WORKSPACE_TASK_SUPPORT.REQUIRED),
+      ),
+    ),
+    ACT_REFUSAL.TASK_REQUIRED,
+  );
+});
+
+test("as one of the agent kinds that row's latest observation listed", async () => {
+  assert.equal(
+    refused(
+      await admit(
+        { kind: ACT_KIND.ADD_AGENT, fields: { ...IDENTITY, agent: "opencode" } },
+        context(),
+      ),
+    ),
+    ACT_REFUSAL.NO_SESSION_AGENT,
+  );
+  const admitted = await admit(
+    { kind: ACT_KIND.ADD_AGENT, fields: FIELDS[ACT_KIND.ADD_AGENT] },
+    context(),
+  );
+  assert.ok(admitted.kind === ACT_KIND.ADD_AGENT);
+  assert.equal(admitted.agent, "codex");
+});
+
+test("who opened a turn is recorded on the act and is never by itself a permission", async () => {
+  const answers = await Promise.all(
+    Object.values(RUN_ORIGIN).map(async (origin) => {
+      const admitted = await admit(
+        { kind: ACT_KIND.MESSAGE, fields: FIELDS[ACT_KIND.MESSAGE] },
+        { ...context(), origin },
+      );
+      assert.ok(admitted.kind === ACT_KIND.MESSAGE);
+      assert.equal(admitted.origin, origin);
+      const { origin: _origin, ...payload } = admitted;
+      return payload;
+    }),
+  );
+  for (const answer of answers) assert.deepEqual(answer, answers[0]);
+});
+
+test("validated against the observed issue roster before the tracker client sees anything", async () => {
+  const noTracker = context();
+  for (const kind of [ACT_KIND.ISSUE_STATE, ACT_KIND.ISSUE_COMMENT] as const) {
+    assert.equal(
+      refused(await admit({ kind, fields: FIELDS[kind] }, noTracker)),
+      ACT_REFUSAL.NO_TRACKER,
+    );
+  }
+  assert.ok(ISSUE);
+  const board = context({ issues: [ISSUE] });
+  assert.equal(
+    refused(
+      await admit(
+        {
+          kind: ACT_KIND.ISSUE_STATE,
+          fields: { ...FIELDS[ACT_KIND.ISSUE_STATE], state: "Shipped" },
+        },
+        board,
+      ),
+    ),
+    ACT_REFUSAL.NO_ISSUE_STATE,
+  );
+  const admitted = await admit(
+    { kind: ACT_KIND.ISSUE_STATE, fields: FIELDS[ACT_KIND.ISSUE_STATE] },
+    board,
+  );
+  assert.ok(admitted.kind === ACT_KIND.ISSUE_STATE);
+  assert.deepEqual(admitted.transition, ISSUE.transitions[0]);
+});
+
+test("a setting the guide does not carry is one the conversation cannot change", async () => {
+  assert.equal(
+    refused(
+      await admit(
+        { kind: ACT_KIND.SETTING, fields: FIELDS[ACT_KIND.SETTING] },
+        { ...context(), guide: EMPTY_APP_GUIDE },
+      ),
+    ),
+    ACT_REFUSAL.NO_SETTING,
+  );
+  // A run that reports nothing about itself changes nothing about itself.
+  assert.equal(
+    refused(await admit({ kind: ACT_KIND.SETTING, fields: FIELDS[ACT_KIND.SETTING] }, context())),
+    ACT_REFUSAL.NO_SETTING,
+  );
+  assert.equal(
+    refused(await admit({ kind: ACT_KIND.UPDATE, fields: FIELDS[ACT_KIND.UPDATE] }, context())),
+    ACT_REFUSAL.NO_UPDATE_REPORT,
+  );
+});
+
+test("only an id from the remembered list can be named, and the cap refuses rather than evicts", async () => {
+  const held = [{ id: "fact-one", words: "prefers concise answers" }];
+  const notebook = context({ rememberedFacts: held });
+  assert.equal(
+    refused(await admit({ kind: ACT_KIND.FORGET, fields: { id: "fact-two" } }, notebook)),
+    ACT_REFUSAL.NO_SUCH_FACT,
+  );
+  assert.equal(
+    refused(
+      await admit(
+        { kind: ACT_KIND.REMEMBER, fields: { words: "x", replaces: "fact-two" } },
+        notebook,
+      ),
+    ),
+    ACT_REFUSAL.NO_SUCH_FACT,
+  );
+  const full = Array.from({ length: maximumRememberedFacts }, (_, index) => ({
+    id: `fact-${index}`,
+    words: `something ${index}`,
+  }));
+  assert.equal(
+    refused(
+      await admit(
+        { kind: ACT_KIND.REMEMBER, fields: FIELDS[ACT_KIND.REMEMBER] },
+        context({ rememberedFacts: full }),
+      ),
+    ),
+    ACT_REFUSAL.MEMORY_FULL,
+  );
+});
+
+test("opening a session is not a write: the act carries an identity, never an address", async () => {
+  const admitted = await admit({ kind: ACT_KIND.OPEN, fields: FIELDS[ACT_KIND.OPEN] }, context());
+  assert.ok(admitted.kind === ACT_KIND.OPEN);
+  assert.deepEqual(Object.keys(admitted).sort(), ["identity", "kind", "origin"]);
+});
+
+test("admitting performs nothing: no seam beyond the roster and the projects is reached", async () => {
+  let reads = 0;
+  const counted: AdmitContext = {
+    origin: RUN_ORIGIN.USER,
+    roster: {
+      read: async () => {
+        reads += 1;
+        return [offering()];
+      },
+    },
+    projects: {
+      read: async () => {
+        reads += 1;
+        return [LISTED_PROJECT];
+      },
+      defaults: async () => {
+        reads += 1;
+        return {};
+      },
+      agentModels: () => {
+        reads += 1;
+        return [];
+      },
+    },
+    issues: ISSUE ? [ISSUE] : [],
+    guide: EMPTY_APP_GUIDE,
+    rememberedFacts: [{ id: "fact-one", words: "prefers concise answers" }],
+  };
+  for (const kind of EVERY_KIND) await admit({ kind, fields: FIELDS[kind] }, counted);
+  // Nothing else exists to reach: an act's effect is the performer's, and
+  // admission holds no adapter, no CLI, and no tracker client to call.
+  assert.ok(reads > 0);
+});

--- a/packages/acts/src/guide.test.ts
+++ b/packages/acts/src/guide.test.ts
@@ -14,6 +14,8 @@ import {
   FEEDBACK_COMPOSER_KIND,
   SESSION_LIST_SORT,
 } from "@sidecar/guide";
+import { RUN_ORIGIN } from "@sidecar/runtime-contracts";
+import type { Session } from "@sidecar/session";
 import {
   maximumSessionMessageLength,
   normalizeSession,
@@ -22,13 +24,43 @@ import {
 } from "@sidecar/session";
 import { ACT_RESULT_STATUS } from "@sidecar/wire";
 import {
-  appToolAction,
+  ACT_FAMILY,
   REALTIME_TOOL,
-  REALTIME_TOOL_FAMILY,
   type RealtimeFunctionCall,
   realtimeToolFamily,
   SESSION_LIST_VOICE,
-} from "./acts.js";
+  toolAction,
+} from "./index.js";
+import { appToolAction as legacyAppToolAction } from "./legacy-validation.js";
+import { withoutAdmission } from "./testing/admitted.js";
+
+/**
+ * Every app act below is admitted twice — once by the validator the intakes
+ * ran before `admit` existed, once by `admit` — and the case passes only if
+ * the two answer identically. The pair goes when the old validator does.
+ */
+async function appToolAction(
+  functionCall: RealtimeFunctionCall,
+  guide: AppGuideSnapshot,
+  sessions: readonly Session[],
+) {
+  const legacy = legacyAppToolAction(functionCall, guide, sessions);
+  // Which family a name belongs to is the caller's question, before admission
+  // and after it; only what a named act admits to is compared here.
+  if (realtimeToolFamily(functionCall.name) !== undefined) {
+    assert.deepEqual(
+      withoutAdmission(
+        await toolAction(functionCall, {
+          origin: RUN_ORIGIN.USER,
+          roster: { read: async () => sessions },
+          guide,
+        }),
+      ),
+      legacy,
+    );
+  }
+  return legacy;
+}
 
 const GUIDE: AppGuideSnapshot = {
   facts: [
@@ -101,7 +133,7 @@ function observedConductorSession(realtimeVoice = false) {
   );
 }
 
-test("the guide's text carries app facts and compact setting data", () => {
+test("the guide's text carries app facts and compact setting data", async () => {
   const text = appGuideContextText(GUIDE);
 
   assert.match(text, /What Luke is: A macOS sidecar/);
@@ -119,11 +151,11 @@ test("the guide's text carries app facts and compact setting data", () => {
   assert.doesNotMatch(text, /Cursor Auto:/);
 });
 
-test("an empty guide says so rather than describing an app it was never told about", () => {
+test("an empty guide says so rather than describing an app it was never told about", async () => {
   assert.match(appGuideContextText(EMPTY_APP_GUIDE), /has not been provided/);
 });
 
-test("a spoken toggle accepts the unambiguous words and nothing else", () => {
+test("a spoken toggle accepts the unambiguous words and nothing else", async () => {
   assert.equal(appToggleValue("on"), "on");
   assert.equal(appToggleValue(" Enabled "), "on");
   assert.equal(appToggleValue("true"), "on");
@@ -135,59 +167,60 @@ test("a spoken toggle accepts the unambiguous words and nothing else", () => {
   assert.equal(appToggleText(false), "off");
 });
 
-test("only the app's own tools are routed to the guide", () => {
-  assert.equal(realtimeToolFamily(REALTIME_TOOL.CHANGE_APP_SETTING), REALTIME_TOOL_FAMILY.APP);
-  assert.equal(realtimeToolFamily(REALTIME_TOOL.SHOW_PANEL), REALTIME_TOOL_FAMILY.APP);
-  assert.equal(realtimeToolFamily(REALTIME_TOOL.OPEN_FEEDBACK_COMPOSER), REALTIME_TOOL_FAMILY.APP);
-  assert.equal(realtimeToolFamily(REALTIME_TOOL.RUN_UPDATE_ACTION), REALTIME_TOOL_FAMILY.APP);
-  assert.equal(
-    realtimeToolFamily(REALTIME_TOOL.SEND_SESSION_MESSAGE),
-    REALTIME_TOOL_FAMILY.SESSION,
-  );
+test("only the app's own tools are routed to the guide", async () => {
+  assert.equal(realtimeToolFamily(REALTIME_TOOL.CHANGE_APP_SETTING), ACT_FAMILY.APP);
+  assert.equal(realtimeToolFamily(REALTIME_TOOL.SHOW_PANEL), ACT_FAMILY.APP);
+  assert.equal(realtimeToolFamily(REALTIME_TOOL.OPEN_FEEDBACK_COMPOSER), ACT_FAMILY.APP);
+  assert.equal(realtimeToolFamily(REALTIME_TOOL.RUN_UPDATE_ACTION), ACT_FAMILY.APP);
+  assert.equal(realtimeToolFamily(REALTIME_TOOL.SEND_SESSION_MESSAGE), ACT_FAMILY.SESSION);
 });
 
-test("a spoken change can name only a setting the guide lists, to a value it accepts", () => {
-  const change = (argumentsJson: string) =>
-    appToolAction(call(REALTIME_TOOL.CHANGE_APP_SETTING, argumentsJson), GUIDE, []);
+test("a spoken change can name only a setting the guide lists, to a value it accepts", async () => {
+  const change = async (argumentsJson: string) =>
+    await appToolAction(call(REALTIME_TOOL.CHANGE_APP_SETTING, argumentsJson), GUIDE, []);
 
-  assert.deepEqual(change('{"setting_id":"voice_captions","value":"on"}'), {
+  assert.deepEqual(await change('{"setting_id":"voice_captions","value":"on"}'), {
     kind: "setting",
     setting: GUIDE.settings[0],
     value: "on",
   });
   // A choice is matched case-insensitively but answered in the guide's own case.
-  assert.deepEqual(change('{"setting_id":"voice","value":"Marin"}'), {
+  assert.deepEqual(await change('{"setting_id":"voice","value":"Marin"}'), {
     kind: "setting",
     setting: GUIDE.settings[1],
     value: "marin",
   });
 
-  const unknown = change('{"setting_id":"telemetry","value":"on"}');
+  const unknown = await change('{"setting_id":"telemetry","value":"on"}');
   assert.equal(unknown.status, ACT_RESULT_STATUS.REJECTED);
 
-  const unreadable = appToolAction(call(REALTIME_TOOL.CHANGE_APP_SETTING, "not json"), GUIDE, []);
+  const unreadable = await appToolAction(
+    call(REALTIME_TOOL.CHANGE_APP_SETTING, "not json"),
+    GUIDE,
+    [],
+  );
   assert.equal(unreadable.status, ACT_RESULT_STATUS.REJECTED);
 
-  const badToggle = change('{"setting_id":"voice_captions","value":"sideways"}');
+  const badToggle = await change('{"setting_id":"voice_captions","value":"sideways"}');
   assert.equal(badToggle.status, ACT_RESULT_STATUS.REJECTED);
   if (badToggle.status === ACT_RESULT_STATUS.REJECTED) {
     assert.match(badToggle.reason, /on or off/);
   }
 
-  const badChoice = change('{"setting_id":"voice","value":"basso"}');
+  const badChoice = await change('{"setting_id":"voice","value":"basso"}');
   assert.equal(badChoice.status, ACT_RESULT_STATUS.REJECTED);
   if (badChoice.status === ACT_RESULT_STATUS.REJECTED) {
     assert.match(badChoice.reason, /cedar, marin/);
   }
 });
 
-test("a value and its effort named in one change are validated as the pair they are", () => {
-  const change = (argumentsJson: string) =>
-    appToolAction(call(REALTIME_TOOL.CHANGE_APP_SETTING, argumentsJson), GUIDE, []);
+test("a value and its effort named in one change are validated as the pair they are", async () => {
+  const change = async (argumentsJson: string) =>
+    await appToolAction(call(REALTIME_TOOL.CHANGE_APP_SETTING, argumentsJson), GUIDE, []);
 
   // The pair rides one action, the effort matched like the value: case
   // retold rather than copied, answered in the guide's own casing.
-  assert.deepEqual(change('{"setting_id":"agent_model","value":"Fable 5","effort":"High"}'), {
+  assert.deepEqual(await change('{"setting_id":"agent_model","value":"Fable 5","effort":"High"}'), {
     kind: "setting",
     setting: GUIDE.settings[3],
     value: "Fable 5",
@@ -195,36 +228,40 @@ test("a value and its effort named in one change are validated as the pair they 
   });
 
   // Unnamed, nothing rides: the action carries no effort at all.
-  assert.deepEqual(change('{"setting_id":"agent_model","value":"Fable 5"}'), {
+  assert.deepEqual(await change('{"setting_id":"agent_model","value":"Fable 5"}'), {
     kind: "setting",
     setting: GUIDE.settings[3],
     value: "Fable 5",
   });
 
   // A level the choice's own list does not carry is refused with that list.
-  const wrongLevel = change('{"setting_id":"agent_model","value":"Fable 5","effort":"ultra"}');
+  const wrongLevel = await change(
+    '{"setting_id":"agent_model","value":"Fable 5","effort":"ultra"}',
+  );
   assert.equal(wrongLevel.status, ACT_RESULT_STATUS.REJECTED);
   if (wrongLevel.status === ACT_RESULT_STATUS.REJECTED) {
     assert.match(wrongLevel.reason, /low, high, max/);
   }
 
   // A choice the guide lists no levels for takes none.
-  const levelless = change('{"setting_id":"agent_model","value":"Cursor Auto","effort":"high"}');
+  const levelless = await change(
+    '{"setting_id":"agent_model","value":"Cursor Auto","effort":"high"}',
+  );
   assert.equal(levelless.status, ACT_RESULT_STATUS.REJECTED);
   if (levelless.status === ACT_RESULT_STATUS.REJECTED) {
     assert.match(levelless.reason, /Cursor Auto takes no effort level/);
   }
 
   // And a setting with no levels anywhere refuses by its own name.
-  const toggled = change('{"setting_id":"voice_captions","value":"on","effort":"high"}');
+  const toggled = await change('{"setting_id":"voice_captions","value":"on","effort":"high"}');
   assert.equal(toggled.status, ACT_RESULT_STATUS.REJECTED);
   if (toggled.status === ACT_RESULT_STATUS.REJECTED) {
     assert.match(toggled.reason, /Captions takes no effort level/);
   }
 });
 
-test("a by-hand-only setting is refused with the path to it, so the refusal is the guidance", () => {
-  const action = appToolAction(
+test("a by-hand-only setting is refused with the path to it, so the refusal is the guidance", async () => {
+  const action = await appToolAction(
     call(REALTIME_TOOL.CHANGE_APP_SETTING, '{"setting_id":"microphone","value":"on"}'),
     GUIDE,
     [],
@@ -236,65 +273,68 @@ test("a by-hand-only setting is refused with the path to it, so the refusal is t
   }
 });
 
-test("a spoken panel ask opens a real tab and narrows only to what is observed", () => {
+test("a spoken panel ask opens a real tab and narrows only to what is observed", async () => {
   const sessions = [observedConductorSession()];
-  const show = (argumentsJson: string) =>
-    appToolAction(call(REALTIME_TOOL.SHOW_PANEL, argumentsJson), GUIDE, sessions);
+  const show = async (argumentsJson: string) =>
+    await appToolAction(call(REALTIME_TOOL.SHOW_PANEL, argumentsJson), GUIDE, sessions);
 
-  assert.deepEqual(show("{}"), { kind: "panel", tab: APP_PANEL_TAB.SESSIONS });
-  assert.deepEqual(show('{"tab":"settings"}'), { kind: "panel", tab: APP_PANEL_TAB.SETTINGS });
-  assert.deepEqual(show('{"filters":["all"]}'), {
+  assert.deepEqual(await show("{}"), { kind: "panel", tab: APP_PANEL_TAB.SESSIONS });
+  assert.deepEqual(await show('{"tab":"settings"}'), {
+    kind: "panel",
+    tab: APP_PANEL_TAB.SETTINGS,
+  });
+  assert.deepEqual(await show('{"filters":["all"]}'), {
     kind: "panel",
     tab: APP_PANEL_TAB.SESSIONS,
     filters: ["all"],
   });
-  assert.deepEqual(show('{"filters":["conductor"]}'), {
+  assert.deepEqual(await show('{"filters":["conductor"]}'), {
     kind: "panel",
     tab: APP_PANEL_TAB.SESSIONS,
     filters: ["conductor"],
   });
   // A narrowing of one may arrive as a lone string, read as a list of one.
-  assert.deepEqual(show('{"filters":"cloud"}'), {
+  assert.deepEqual(await show('{"filters":"cloud"}'), {
     kind: "panel",
     tab: APP_PANEL_TAB.SESSIONS,
     filters: ["cloud"],
   });
 
-  assert.deepEqual(show('{"filters":["voice"]}'), {
+  assert.deepEqual(await show('{"filters":["voice"]}'), {
     status: ACT_RESULT_STATUS.REJECTED,
     reason: "No voice sessions are observed right now.",
   });
 
-  assert.equal(show('{"tab":"about"}').status, ACT_RESULT_STATUS.REJECTED);
+  assert.equal((await show('{"tab":"about"}')).status, ACT_RESULT_STATUS.REJECTED);
   // A narrowing that would show nothing is refused rather than applied: the
   // panel would fall back to everything, and the sentence would be wrong.
-  assert.equal(show('{"filters":["local"]}').status, ACT_RESULT_STATUS.REJECTED);
-  assert.equal(show('{"filters":["codex"]}').status, ACT_RESULT_STATUS.REJECTED);
+  assert.equal((await show('{"filters":["local"]}')).status, ACT_RESULT_STATUS.REJECTED);
+  assert.equal((await show('{"filters":["codex"]}')).status, ACT_RESULT_STATUS.REJECTED);
 
-  const voiceShow = (argumentsJson: string) =>
-    appToolAction(call(REALTIME_TOOL.SHOW_PANEL, argumentsJson), GUIDE, [
+  const voiceShow = async (argumentsJson: string) =>
+    await appToolAction(call(REALTIME_TOOL.SHOW_PANEL, argumentsJson), GUIDE, [
       observedConductorSession(true),
     ]);
-  assert.deepEqual(voiceShow('{"filters":["voice"]}'), {
+  assert.deepEqual(await voiceShow('{"filters":["voice"]}'), {
     kind: "panel",
     tab: APP_PANEL_TAB.SESSIONS,
     filters: [SESSION_LIST_VOICE],
   });
 });
 
-test("a spoken panel ask can combine filters, on the axes the chips combine on", () => {
+test("a spoken panel ask can combine filters, on the axes the chips combine on", async () => {
   const sessions = [observedConductorSession(), observedConductorSession(true)];
-  const show = (argumentsJson: string) =>
-    appToolAction(call(REALTIME_TOOL.SHOW_PANEL, argumentsJson), GUIDE, sessions);
+  const show = async (argumentsJson: string) =>
+    await appToolAction(call(REALTIME_TOOL.SHOW_PANEL, argumentsJson), GUIDE, sessions);
 
   // Values on different axes narrow: a cloud Conductor voice chat is observed.
-  assert.deepEqual(show('{"filters":["cloud","conductor","voice"]}'), {
+  assert.deepEqual(await show('{"filters":["cloud","conductor","voice"]}'), {
     kind: "panel",
     tab: APP_PANEL_TAB.SESSIONS,
     filters: ["cloud", "conductor", "voice"],
   });
   // A repeated value is one value, not a tighter ask.
-  assert.deepEqual(show('{"filters":["cloud","cloud"]}'), {
+  assert.deepEqual(await show('{"filters":["cloud","cloud"]}'), {
     kind: "panel",
     tab: APP_PANEL_TAB.SESSIONS,
     filters: ["cloud"],
@@ -304,12 +344,12 @@ test("a spoken panel ask can combine filters, on the axes the chips combine on",
   // nothing occupies: every observed session is cloud, so local matches
   // nothing — and with a local session beside them, local Conductor exists
   // but no local voice chat does.
-  assert.deepEqual(show('{"filters":["local","conductor"]}'), {
+  assert.deepEqual(await show('{"filters":["local","conductor"]}'), {
     status: ACT_RESULT_STATUS.REJECTED,
     reason: "No local sessions are observed right now.",
   });
-  const mixed = (argumentsJson: string) =>
-    appToolAction(call(REALTIME_TOOL.SHOW_PANEL, argumentsJson), GUIDE, [
+  const mixed = async (argumentsJson: string) =>
+    await appToolAction(call(REALTIME_TOOL.SHOW_PANEL, argumentsJson), GUIDE, [
       ...sessions,
       normalizeSession(
         { id: "conductor", displayName: "Conductor" },
@@ -322,36 +362,36 @@ test("a spoken panel ask can combine filters, on the axes the chips combine on",
         },
       ),
     ]);
-  assert.deepEqual(mixed('{"filters":["local","conductor"]}'), {
+  assert.deepEqual(await mixed('{"filters":["local","conductor"]}'), {
     kind: "panel",
     tab: APP_PANEL_TAB.SESSIONS,
     filters: ["local", "conductor"],
   });
-  assert.deepEqual(mixed('{"filters":["local","voice"]}'), {
+  assert.deepEqual(await mixed('{"filters":["local","voice"]}'), {
     status: ACT_RESULT_STATUS.REJECTED,
     reason: "No observed session matches that combination of filters.",
   });
 
   // The whole list is not a value to narrow by.
-  assert.deepEqual(show('{"filters":["all","cloud"]}'), {
+  assert.deepEqual(await show('{"filters":["all","cloud"]}'), {
     status: ACT_RESULT_STATUS.REJECTED,
     reason: "all is the whole list, so it combines with nothing.",
   });
   // A narrowing has to be a list of words; anything else is unreadable.
-  assert.equal(show('{"filters":[3]}').status, ACT_RESULT_STATUS.REJECTED);
-  assert.equal(show('{"filters":{"value":"cloud"}}').status, ACT_RESULT_STATUS.REJECTED);
+  assert.equal((await show('{"filters":[3]}')).status, ACT_RESULT_STATUS.REJECTED);
+  assert.equal((await show('{"filters":{"value":"cloud"}}')).status, ACT_RESULT_STATUS.REJECTED);
   // A list of nothing is no narrowing at all.
-  assert.deepEqual(show('{"filters":[]}'), { kind: "panel", tab: APP_PANEL_TAB.SESSIONS });
+  assert.deepEqual(await show('{"filters":[]}'), { kind: "panel", tab: APP_PANEL_TAB.SESSIONS });
 
   // The enum on the schema binds the model to real tokens — a developer's
   // phrase arriving untranslated is refused by the backstop, never guessed at.
-  assert.deepEqual(show('{"filters":["Claude Code"]}'), {
+  assert.deepEqual(await show('{"filters":["Claude Code"]}'), {
     status: ACT_RESULT_STATUS.REJECTED,
     reason: '"Claude Code" is not one of the filter values the tool lists.',
   });
 });
 
-test("a spoken panel ask can search, only where the list offers a search at all", () => {
+test("a spoken panel ask can search, only where the list offers a search at all", async () => {
   const pair = [
     observedConductorSession(),
     normalizeSession(
@@ -364,10 +404,10 @@ test("a spoken panel ask can search, only where the list offers a search at all"
       },
     ),
   ];
-  const show = (argumentsJson: string, sessions = pair) =>
-    appToolAction(call(REALTIME_TOOL.SHOW_PANEL, argumentsJson), GUIDE, sessions);
+  const show = async (argumentsJson: string, sessions = pair) =>
+    await appToolAction(call(REALTIME_TOOL.SHOW_PANEL, argumentsJson), GUIDE, sessions);
 
-  assert.deepEqual(show('{"query":" parser build "}'), {
+  assert.deepEqual(await show('{"query":" parser build "}'), {
     kind: "panel",
     tab: APP_PANEL_TAB.SESSIONS,
     query: "parser build",
@@ -375,7 +415,7 @@ test("a spoken panel ask can search, only where the list offers a search at all"
   // A search rides the same ask as a narrowing and an ordering, and the words
   // are not judged here: a query matching nothing is the list's own honest
   // answer, where a filter showing nothing would be a stale choice.
-  assert.deepEqual(show('{"filters":["conductor"],"sort":"recency","query":"zanzibar"}'), {
+  assert.deepEqual(await show('{"filters":["conductor"],"sort":"recency","query":"zanzibar"}'), {
     kind: "panel",
     tab: APP_PANEL_TAB.SESSIONS,
     filters: ["conductor"],
@@ -383,65 +423,65 @@ test("a spoken panel ask can search, only where the list offers a search at all"
     query: "zanzibar",
   });
   // A blank query is no search, the way a blank draft is no draft.
-  assert.deepEqual(show('{"query":"   "}'), { kind: "panel", tab: APP_PANEL_TAB.SESSIONS });
+  assert.deepEqual(await show('{"query":"   "}'), { kind: "panel", tab: APP_PANEL_TAB.SESSIONS });
 
   // The magnifier is only offered beside a list with more than one session,
   // and a spoken search reaches no further than the hand's own control.
-  assert.deepEqual(show('{"query":"parser"}', [observedConductorSession()]), {
+  assert.deepEqual(await show('{"query":"parser"}', [observedConductorSession()]), {
     status: ACT_RESULT_STATUS.REJECTED,
     reason: "The list offers a search only when more than one session is observed.",
   });
-  assert.equal(show('{"query":"parser"}', []).status, ACT_RESULT_STATUS.REJECTED);
+  assert.equal((await show('{"query":"parser"}', [])).status, ACT_RESULT_STATUS.REJECTED);
 });
 
-test("a spoken panel ask can reorder the list in the panel's own two words", () => {
+test("a spoken panel ask can reorder the list in the panel's own two words", async () => {
   const sessions = [observedConductorSession()];
-  const show = (argumentsJson: string) =>
-    appToolAction(call(REALTIME_TOOL.SHOW_PANEL, argumentsJson), GUIDE, sessions);
+  const show = async (argumentsJson: string) =>
+    await appToolAction(call(REALTIME_TOOL.SHOW_PANEL, argumentsJson), GUIDE, sessions);
 
-  assert.deepEqual(show('{"sort":"recency"}'), {
+  assert.deepEqual(await show('{"sort":"recency"}'), {
     kind: "panel",
     tab: APP_PANEL_TAB.SESSIONS,
     sort: SESSION_LIST_SORT.RECENCY,
   });
-  assert.deepEqual(show('{"filters":["conductor"],"sort":"urgency"}'), {
+  assert.deepEqual(await show('{"filters":["conductor"],"sort":"urgency"}'), {
     kind: "panel",
     tab: APP_PANEL_TAB.SESSIONS,
     filters: ["conductor"],
     sort: SESSION_LIST_SORT.URGENCY,
   });
-  assert.equal(show('{"sort":"alphabetical"}').status, ACT_RESULT_STATUS.REJECTED);
+  assert.equal((await show('{"sort":"alphabetical"}')).status, ACT_RESULT_STATUS.REJECTED);
 });
 
-test("a spoken composer open takes only the two kinds, drafting only the developer's words", () => {
-  const open = (argumentsJson: string) =>
-    appToolAction(call(REALTIME_TOOL.OPEN_FEEDBACK_COMPOSER, argumentsJson), GUIDE, []);
+test("a spoken composer open takes only the two kinds, drafting only the developer's words", async () => {
+  const open = async (argumentsJson: string) =>
+    await appToolAction(call(REALTIME_TOOL.OPEN_FEEDBACK_COMPOSER, argumentsJson), GUIDE, []);
 
-  assert.deepEqual(open('{"kind":"prompt","draft":"  let Luke restart a stuck run  "}'), {
+  assert.deepEqual(await open('{"kind":"prompt","draft":"  let Luke restart a stuck run  "}'), {
     kind: "feedback",
     composer: FEEDBACK_COMPOSER_KIND.PROMPT,
     draft: "let Luke restart a stuck run",
   });
   // No draft is a valid open: the composer simply comes up empty.
-  assert.deepEqual(open('{"kind":"feedback"}'), {
+  assert.deepEqual(await open('{"kind":"feedback"}'), {
     kind: "feedback",
     composer: FEEDBACK_COMPOSER_KIND.FEEDBACK,
   });
   // A blank draft is no draft either.
-  assert.deepEqual(open('{"kind":"prompt","draft":"   "}'), {
+  assert.deepEqual(await open('{"kind":"prompt","draft":"   "}'), {
     kind: "feedback",
     composer: FEEDBACK_COMPOSER_KIND.PROMPT,
   });
 
   // The vocabulary is fixed: a kind outside it names no composer the app has.
-  assert.equal(open('{"kind":"complaint"}').status, ACT_RESULT_STATUS.REJECTED);
-  assert.equal(open('{"kind":""}').status, ACT_RESULT_STATUS.REJECTED);
-  assert.equal(open("{}").status, ACT_RESULT_STATUS.REJECTED);
-  assert.equal(open("not json").status, ACT_RESULT_STATUS.REJECTED);
+  assert.equal((await open('{"kind":"complaint"}')).status, ACT_RESULT_STATUS.REJECTED);
+  assert.equal((await open('{"kind":""}')).status, ACT_RESULT_STATUS.REJECTED);
+  assert.equal((await open("{}")).status, ACT_RESULT_STATUS.REJECTED);
+  assert.equal((await open("not json")).status, ACT_RESULT_STATUS.REJECTED);
 });
 
-test("a spoken draft is bounded like a typed ask", () => {
-  const action = appToolAction(
+test("a spoken draft is bounded like a typed ask", async () => {
+  const action = await appToolAction(
     call(
       REALTIME_TOOL.OPEN_FEEDBACK_COMPOSER,
       `{"kind":"prompt","draft":"${"a".repeat(maximumSessionMessageLength + 100)}"}`,
@@ -457,8 +497,8 @@ test("a spoken draft is bounded like a typed ask", () => {
   }
 });
 
-test("an app tool call the build does not know is refused", () => {
-  const action = appToolAction(call("rename_the_app", "{}"), GUIDE, []);
+test("an app tool call the build does not know is refused", async () => {
+  const action = await appToolAction(call("rename_the_app", "{}"), GUIDE, []);
   assert.equal(action.status, ACT_RESULT_STATUS.REJECTED);
 });
 
@@ -466,20 +506,20 @@ function guideWithUpdate(button: AppUpdateButton, detail: string): AppGuideSnaps
   return { ...GUIDE, update: { version: "0.3.8", detail, button } };
 }
 
-test("a spoken update ask runs only the act the row's button offers", () => {
-  const ask = (argumentsJson: string, guide: AppGuideSnapshot) =>
-    appToolAction(call(REALTIME_TOOL.RUN_UPDATE_ACTION, argumentsJson), guide, []);
+test("a spoken update ask runs only the act the row's button offers", async () => {
+  const ask = async (argumentsJson: string, guide: AppGuideSnapshot) =>
+    await appToolAction(call(REALTIME_TOOL.RUN_UPDATE_ACTION, argumentsJson), guide, []);
 
   const offersCheck = guideWithUpdate(
     APP_UPDATE_ACT.CHECK,
     "The latest release has not been checked for yet.",
   );
-  assert.deepEqual(ask('{"action":"check"}', offersCheck), {
+  assert.deepEqual(await ask('{"action":"check"}', offersCheck), {
     kind: "update",
     act: APP_UPDATE_ACT.CHECK,
   });
   // One button, one act: what the row is not drawing, no ask can press.
-  const restartWhileCheckable = ask('{"action":"restart"}', offersCheck);
+  const restartWhileCheckable = await ask('{"action":"restart"}', offersCheck);
   assert.equal(restartWhileCheckable.status, ACT_RESULT_STATUS.REJECTED);
   if (restartWhileCheckable.status === ACT_RESULT_STATUS.REJECTED) {
     assert.match(restartWhileCheckable.reason, /not been checked for yet/);
@@ -487,7 +527,7 @@ test("a spoken update ask runs only the act the row's button offers", () => {
   }
 
   const offersRestart = guideWithUpdate(APP_UPDATE_ACT.RESTART, "Version 0.3.9 is downloaded.");
-  assert.deepEqual(ask('{"action":"restart"}', offersRestart), {
+  assert.deepEqual(await ask('{"action":"restart"}', offersRestart), {
     kind: "update",
     act: APP_UPDATE_ACT.RESTART,
   });
@@ -496,18 +536,18 @@ test("a spoken update ask runs only the act the row's button offers", () => {
     APP_UPDATE_ACT.DOWNLOAD,
     "This build updates by hand: the releases page has the latest.",
   );
-  assert.deepEqual(ask('{"action":"download"}', offersBrowser), {
+  assert.deepEqual(await ask('{"action":"download"}', offersBrowser), {
     kind: "update",
     act: APP_UPDATE_ACT.DOWNLOAD,
   });
-  assert.equal(ask('{"action":"check"}', offersBrowser).status, ACT_RESULT_STATUS.REJECTED);
+  assert.equal((await ask('{"action":"check"}', offersBrowser)).status, ACT_RESULT_STATUS.REJECTED);
 });
 
-test("a spoken update ask waits out a check or download already running", () => {
-  const ask = (argumentsJson: string, guide: AppGuideSnapshot) =>
-    appToolAction(call(REALTIME_TOOL.RUN_UPDATE_ACTION, argumentsJson), guide, []);
+test("a spoken update ask waits out a check or download already running", async () => {
+  const ask = async (argumentsJson: string, guide: AppGuideSnapshot) =>
+    await appToolAction(call(REALTIME_TOOL.RUN_UPDATE_ACTION, argumentsJson), guide, []);
 
-  const checking = ask(
+  const checking = await ask(
     '{"action":"check"}',
     guideWithUpdate(APP_UPDATE_WAIT.CHECKING, "Checking the latest release…"),
   );
@@ -515,7 +555,7 @@ test("a spoken update ask waits out a check or download already running", () => 
   if (checking.status === ACT_RESULT_STATUS.REJECTED)
     assert.match(checking.reason, /while the check is out/);
 
-  const downloading = ask(
+  const downloading = await ask(
     '{"action":"restart"}',
     guideWithUpdate(APP_UPDATE_WAIT.DOWNLOADING, "Downloading version 0.3.9…"),
   );
@@ -524,21 +564,26 @@ test("a spoken update ask waits out a check or download already running", () => 
     assert.match(downloading.reason, /while the download runs/);
 });
 
-test("a spoken update ask outside the vocabulary, or with no row to press, is refused", () => {
+test("a spoken update ask outside the vocabulary, or with no row to press, is refused", async () => {
   const offersCheck = guideWithUpdate(APP_UPDATE_ACT.CHECK, "This is the latest release.");
 
   assert.equal(
-    appToolAction(call(REALTIME_TOOL.RUN_UPDATE_ACTION, '{"action":"install"}'), offersCheck, [])
-      .status,
+    (
+      await appToolAction(
+        call(REALTIME_TOOL.RUN_UPDATE_ACTION, '{"action":"install"}'),
+        offersCheck,
+        [],
+      )
+    ).status,
     ACT_RESULT_STATUS.REJECTED,
   );
   assert.equal(
-    appToolAction(call(REALTIME_TOOL.RUN_UPDATE_ACTION, "{}"), offersCheck, []).status,
+    (await appToolAction(call(REALTIME_TOOL.RUN_UPDATE_ACTION, "{}"), offersCheck, [])).status,
     ACT_RESULT_STATUS.REJECTED,
   );
   // A guide with no update entry — a run that reports nothing about updates —
   // advertises no act at all.
-  const unreported = appToolAction(
+  const unreported = await appToolAction(
     call(REALTIME_TOOL.RUN_UPDATE_ACTION, '{"action":"check"}'),
     GUIDE,
     [],
@@ -546,7 +591,7 @@ test("a spoken update ask outside the vocabulary, or with no row to press, is re
   assert.equal(unreported.status, ACT_RESULT_STATUS.REJECTED);
 });
 
-test("the guide's text names the update button beside the state it stands in", () => {
+test("the guide's text names the update button beside the state it stands in", async () => {
   const text = appGuideContextText(
     guideWithUpdate(APP_UPDATE_ACT.CHECK, "This is the latest release."),
   );

--- a/packages/acts/src/index.ts
+++ b/packages/acts/src/index.ts
@@ -1,6 +1,5 @@
 export * from "./act-kinds.js";
 export * from "./act-narration.js";
-export * from "./act-schemas.js";
 export * from "./acts.js";
 export * from "./admit.js";
 export * from "./memory.js";

--- a/packages/acts/src/index.ts
+++ b/packages/acts/src/index.ts
@@ -1,2 +1,6 @@
+export * from "./act-kinds.js";
+export * from "./act-narration.js";
+export * from "./act-schemas.js";
 export * from "./acts.js";
+export * from "./admit.js";
 export * from "./memory.js";

--- a/packages/acts/src/legacy-validation.ts
+++ b/packages/acts/src/legacy-validation.ts
@@ -1,0 +1,1093 @@
+/**
+ * The validators every intake ran before `admit` existed, kept for exactly as
+ * long as it takes to prove `admit` answers what they answered. Nothing in the
+ * product calls them: each is exercised only by `admit.test.ts`, which runs the
+ * pair on the same input and asserts the two agree. The PR that deletes this
+ * file is the one that deletes the redundant layers beneath it.
+ */
+
+import {
+  APP_PANEL_TAB,
+  APP_SETTING_KIND,
+  APP_UPDATE_ACT,
+  APP_UPDATE_WAIT,
+  type AppGuideSetting,
+  type AppGuideSnapshot,
+  type AppGuideUpdate,
+  type AppPanelTab,
+  type AppUpdateAct,
+  appGuideSetting,
+  appToggleValue,
+  type FeedbackComposerKind,
+  isAppPanelTab,
+  isAppUpdateAct,
+  isFeedbackComposerKind,
+  isSessionListSort,
+  type SessionListSort,
+} from "@sidecar/guide";
+import {
+  ACT_RESULT_STATUS,
+  type IssueIdentity,
+  type IssueTransition,
+  issueCommentText,
+  type TrackedIssue,
+} from "@sidecar/issues";
+import {
+  ACT_KIND,
+  type AdvertisedControl,
+  advertisedActFor,
+  advertisedControl,
+  isSessionApplicationId,
+  matchesFilterSelection,
+  maximumSessionMessageLength,
+  maximumWorkspaceNameLength,
+  type ObservedWorkspaceProject,
+  SESSION_LOCATION,
+  type Session,
+  type SessionApplicationId,
+  type SessionIdentity,
+  sessionMessageText,
+  WORKSPACE_TASK_SUPPORT,
+  type WorkspaceAgentModels,
+  type WorkspaceAgentSelection,
+  workspaceNameText,
+  workspaceProjectSelectionId,
+} from "@sidecar/session";
+import {
+  isRecord,
+  isWireString,
+  type UnparsedWireValue,
+  type WireRecord,
+  text as wireText,
+} from "@sidecar/wire";
+import { type RealtimeFunctionCall, SESSION_LIST_ALL, SESSION_LIST_VOICE } from "./act-kinds.js";
+import { SESSION_LIST_FILTER_VALUES } from "./act-schemas.js";
+import {
+  holdsRememberedFact,
+  maximumRememberedFactLength,
+  maximumRememberedFacts,
+  type RememberedFact,
+  rememberedFactText,
+} from "./memory.js";
+
+const SESSION_TOOL_KIND = ACT_KIND;
+const ISSUE_TOOL_KIND = { ISSUE_STATE: "issue-state", ISSUE_COMMENT: "issue-comment" } as const;
+const APP_TOOL_KIND = {
+  SETTING: "setting",
+  PANEL: "panel",
+  FEEDBACK: "feedback",
+  UPDATE: "update",
+  REMEMBER: "remember",
+  FORGET: "forget",
+} as const;
+
+type CarriedSessionActionFields =
+  | { kind: typeof SESSION_TOOL_KIND.MESSAGE; identity: SessionIdentity; text: string }
+  | {
+      kind: typeof SESSION_TOOL_KIND.CONTROL;
+      identity: SessionIdentity;
+      control: AdvertisedControl;
+    }
+  | {
+      kind: typeof SESSION_TOOL_KIND.OPEN;
+      identity: SessionIdentity;
+      /** The one app the developer named to open it in, resolved to its id. */
+      applicationId?: SessionApplicationId;
+    }
+  | {
+      kind: typeof SESSION_TOOL_KIND.CREATE_WORKSPACE;
+      providerId: string;
+      providerProjectId: string;
+      providerTargetId?: string;
+      agent?: string;
+      name?: string;
+      task?: string;
+      /** The model the developer named for this one creation, resolved to ids. */
+      agentSelection?: WorkspaceAgentSelection;
+    }
+  | {
+      kind: typeof SESSION_TOOL_KIND.ADD_AGENT;
+      identity: SessionIdentity;
+      agent: string;
+      name?: string;
+      task?: string;
+      /** The model the developer named for this one agent, as its wire id. */
+      model?: string;
+      /** The effort riding that model, when the developer named both. */
+      effort?: string;
+    }
+  | {
+      kind: typeof SESSION_TOOL_KIND.RENAME_WORKSPACE;
+      identity: SessionIdentity;
+      /** The workspace's new name, exactly as the developer chose it. */
+      name: string;
+    }
+  | {
+      kind: typeof SESSION_TOOL_KIND.RENAME_SESSION;
+      identity: SessionIdentity;
+      /** The chat's new name, exactly as the developer chose it. */
+      name: string;
+    };
+
+export type CarriedSessionAction = CarriedSessionActionFields & {
+  status?: never;
+  reason?: never;
+};
+
+type ActRejection = {
+  status: typeof ACT_RESULT_STATUS.REJECTED;
+  reason: string;
+  kind?: never;
+};
+export type SessionToolAction = CarriedSessionAction | ActRejection;
+
+/** What one validated issue tool call asks for, ready for the bridge that carries it. */
+type CarriedIssueActionFields =
+  | {
+      kind: typeof ISSUE_TOOL_KIND.ISSUE_STATE;
+      identity: IssueIdentity;
+      transition: IssueTransition;
+    }
+  | { kind: typeof ISSUE_TOOL_KIND.ISSUE_COMMENT; identity: IssueIdentity; body: string };
+
+export type CarriedIssueAction = CarriedIssueActionFields & {
+  status?: never;
+  reason?: never;
+};
+export type IssueToolAction = CarriedIssueAction | ActRejection;
+
+/**
+ * What one validated app tool call asks for, ready for the app to perform.
+ * The feedback action opens the composer and nothing else: `draft` is at most
+ * the developer's own words, placed only into an empty note, and what the
+ * composer holds leaves only by its own Send button — no action here sends.
+ */
+type CarriedAppActionFields =
+  | {
+      kind: typeof APP_TOOL_KIND.SETTING;
+      setting: AppGuideSetting;
+      value: string;
+      /** The effort riding the new value, when the developer named both. */
+      effort?: string;
+    }
+  | {
+      kind: typeof APP_TOOL_KIND.PANEL;
+      tab: AppPanelTab;
+      /** The validated narrowing, combined like the chips: OR within an axis, AND across. */
+      filters?: readonly string[];
+      sort?: SessionListSort;
+      /** Words to search the list for, exactly as the developer asked them. */
+      query?: string;
+    }
+  | { kind: typeof APP_TOOL_KIND.FEEDBACK; composer: FeedbackComposerKind; draft?: string }
+  | { kind: typeof APP_TOOL_KIND.UPDATE; act: AppUpdateAct }
+  | {
+      kind: typeof APP_TOOL_KIND.REMEMBER;
+      /** One concise durable fact selected from the developer-opened turn. */
+      words: string;
+      /** The id of the fact this one stands in for, when it changes one. */
+      replaces?: string;
+    }
+  | { kind: typeof APP_TOOL_KIND.FORGET; id: string };
+
+export type CarriedAppAction = CarriedAppActionFields & {
+  status?: never;
+  reason?: never;
+};
+export type AppToolAction = CarriedAppAction | ActRejection;
+
+export type CarriedAct = CarriedSessionAction | CarriedIssueAction | CarriedAppAction;
+
+export interface SessionToolContext {
+  sessions: readonly Session[];
+  workspaceProjects: readonly ObservedWorkspaceProject[];
+  agentModels: (providerId: string) => readonly WorkspaceAgentModels[];
+  /**
+   * The developer's saved tie-breaks for a creation ask, the same ones the
+   * projects context narrates: the provider a nameless ask goes to, and each
+   * provider's chosen project. Both only ever narrow within the listed
+   * projects — a default can settle an ambiguous ask, never widen where one
+   * can land or override a provider or project the ask actually named.
+   */
+  defaultProviderId?: string;
+  defaultProjectIds?: Readonly<Partial<Record<string, string>>>;
+}
+
+export interface IssueToolContext {
+  issues: readonly TrackedIssue[];
+}
+
+export interface AppToolContext {
+  guide: AppGuideSnapshot;
+  sessions: readonly Session[];
+  /**
+   * The facts standing right now, which a replacement or a removal is
+   * validated against — the same discipline a session act keeps against the
+   * roster. An id the conversation was never shown names nothing.
+   */
+  rememberedFacts: readonly RememberedFact[];
+}
+type SessionToolValidate = (parsed: WireRecord, context: SessionToolContext) => SessionToolAction;
+
+type IssueToolValidate = (parsed: WireRecord, context: IssueToolContext) => IssueToolAction;
+
+type AppToolValidate = (parsed: WireRecord, context: AppToolContext) => AppToolAction;
+
+function textArgument(record: WireRecord, key: string): string | undefined {
+  return wireText(record[key]);
+}
+
+function parseToolArguments(
+  call: RealtimeFunctionCall,
+): { ok: true; value: WireRecord } | { ok: false; reason: string } {
+  let parsed: UnparsedWireValue;
+  try {
+    // SAFETY: JSON.parse returns a runtime value; isRecord validates the object contract.
+    parsed = JSON.parse(call.argumentsJson) as UnparsedWireValue;
+  } catch {
+    return { ok: false, reason: "The tool call's arguments were not readable." };
+  }
+  if (!isRecord(parsed)) {
+    return { ok: false, reason: "The tool call's arguments were not readable." };
+  }
+  return { ok: true, value: parsed };
+}
+
+function sessionFromArguments(
+  parsed: WireRecord,
+  sessions: readonly Session[],
+): { session: Session; identity: SessionIdentity } | ActRejection {
+  const providerId = textArgument(parsed, "provider_id");
+  const providerSessionId = textArgument(parsed, "provider_session_id");
+  const session = sessions.find(
+    (candidate) =>
+      candidate.providerId === providerId && candidate.providerSessionId === providerSessionId,
+  );
+  if (!session) {
+    return {
+      status: ACT_RESULT_STATUS.REJECTED,
+      reason: "No observed session matches that identity.",
+    };
+  }
+  return {
+    session,
+    identity: {
+      providerId: session.providerId,
+      providerSessionId: session.providerSessionId,
+    },
+  };
+}
+
+function issueFromArguments(
+  parsed: WireRecord,
+  issues: readonly TrackedIssue[],
+): { issue: TrackedIssue; identity: IssueIdentity } | ActRejection {
+  const trackerId = textArgument(parsed, "tracker_id");
+  const issueId = textArgument(parsed, "issue_id");
+  const issue = issues.find(
+    (candidate) => candidate.trackerId === trackerId && candidate.identifier === issueId,
+  );
+  if (!issue) {
+    return {
+      status: ACT_RESULT_STATUS.REJECTED,
+      reason: "No tracked issue matches that identity.",
+    };
+  }
+  return {
+    issue,
+    identity: {
+      trackerId: issue.trackerId,
+      identifier: issue.identifier,
+    },
+  };
+}
+
+/**
+ * Resolves a model the developer named — by the label the guide lists it
+ * under, or its id — to the wire pairing an endpoint takes, held to the
+ * build's documented entries for the provider. The effort, when named, must
+ * be one the resolved model's own agent documents: the pairing is validated
+ * as the whole it will be sent as.
+ */
+function resolveWorkspaceAgentModel(
+  entries: readonly WorkspaceAgentModels[],
+  modelWord: string,
+  effortWord: string | undefined,
+): { selection: WorkspaceAgentSelection } | { refusal: string } {
+  const normalizedModel = modelWord.trim().toLowerCase();
+  const named = entries
+    .flatMap((entry) => entry.models.map((model) => ({ entry, model })))
+    .find(
+      ({ model }) =>
+        model.label.toLowerCase() === normalizedModel || model.id.toLowerCase() === normalizedModel,
+    );
+  if (!named) return { refusal: "No documented model goes by that name here." };
+  let effort: string | undefined;
+  if (effortWord !== undefined) {
+    const normalizedEffort = effortWord.trim().toLowerCase();
+    effort = named.entry.efforts.find((candidate) => candidate.toLowerCase() === normalizedEffort);
+    if (!effort) {
+      return {
+        refusal:
+          named.entry.efforts.length > 0
+            ? `That model's effort is one of ${named.entry.efforts.join(", ")}.`
+            : "That model takes no effort level.",
+      };
+    }
+  }
+  const selection: WorkspaceAgentSelection = {
+    agent: named.entry.agent,
+    model: named.model.id,
+  };
+  if (effort) selection.effort = effort;
+  return { selection };
+}
+
+function validateSendSessionMessage(
+  parsed: WireRecord,
+  context: SessionToolContext,
+): SessionToolAction {
+  const found = sessionFromArguments(parsed, context.sessions);
+  if ("status" in found) return found;
+  const { session, identity } = found;
+  if (!advertisedActFor(session, ACT_KIND.MESSAGE)) {
+    return {
+      status: ACT_RESULT_STATUS.REJECTED,
+      reason: "That session does not take messages right now.",
+    };
+  }
+  const messageText = sessionMessageText(parsed.text);
+  if (!messageText) {
+    return {
+      status: ACT_RESULT_STATUS.REJECTED,
+      reason: "That message is empty or too long.",
+    };
+  }
+  return { kind: SESSION_TOOL_KIND.MESSAGE, identity, text: messageText };
+}
+
+function validateRunSessionControl(
+  parsed: WireRecord,
+  context: SessionToolContext,
+): SessionToolAction {
+  const found = sessionFromArguments(parsed, context.sessions);
+  if ("status" in found) return found;
+  const { session, identity } = found;
+  const controlId = textArgument(parsed, "control_id");
+  const control = controlId ? advertisedControl(session, controlId) : undefined;
+  if (!control) {
+    return {
+      status: ACT_RESULT_STATUS.REJECTED,
+      reason: "That session advertises no such control.",
+    };
+  }
+  return { kind: SESSION_TOOL_KIND.CONTROL, identity, control };
+}
+
+function validateOpenSession(parsed: WireRecord, context: SessionToolContext): SessionToolAction {
+  const found = sessionFromArguments(parsed, context.sessions);
+  if ("status" in found) return found;
+  const { session, identity } = found;
+  // The action carries the identity — and, when the developer named an app,
+  // that app's id — never the address: the main process reads the link back
+  // out of its own registry, the same as a pressed row or a pressed app mark.
+  const applicationWord = textArgument(parsed, "application");
+  if (applicationWord !== undefined) {
+    const normalized = applicationWord.trim().toLowerCase();
+    const application = session.applications.find(
+      (candidate) =>
+        candidate.displayName.toLowerCase() === normalized || candidate.id === normalized,
+    );
+    // An association without an exact address identifies the app but opens
+    // nothing, so it refuses like an app the roster never listed — and the
+    // refusal names the apps that can open, which the roster already carries.
+    // The id must be one the build fixed: the bridge takes no other, and the
+    // main process would refuse it again.
+    const applicationId = application?.link ? application.id : undefined;
+    if (applicationId === undefined || !isSessionApplicationId(applicationId)) {
+      const openable = session.applications.filter((candidate) => candidate.link);
+      return {
+        status: ACT_RESULT_STATUS.REJECTED,
+        reason:
+          openable.length > 0
+            ? `That session opens in ${openable
+                .map((candidate) => candidate.displayName)
+                .join(" or ")}, not there.`
+            : "No app carries an exact address for that session.",
+      };
+    }
+    return { kind: SESSION_TOOL_KIND.OPEN, identity, applicationId };
+  }
+  if (!session.detail.link) {
+    return { status: ACT_RESULT_STATUS.REJECTED, reason: "That session has no address to open." };
+  }
+  return { kind: SESSION_TOOL_KIND.OPEN, identity };
+}
+
+function validateCreateWorkspace(
+  parsed: WireRecord,
+  context: SessionToolContext,
+): SessionToolAction {
+  // A creation ask names a project rather than a session, so it is validated
+  // against the projects the conversation was shown — the same discipline,
+  // against the list that actually offered it.
+  const providerId = textArgument(parsed, "provider_id");
+  const projectId = textArgument(parsed, "project_id");
+  const targetId = textArgument(parsed, "target_id");
+  let matchingProjects = context.workspaceProjects.filter(
+    (candidate) =>
+      (!providerId || candidate.providerId === providerId) &&
+      (!projectId || candidate.providerProjectId === projectId) &&
+      (!targetId || candidate.providerTargetId === targetId),
+  );
+  // The saved defaults settle only what the ask left unnamed: no provider
+  // named sends a still-ambiguous ask to the default provider while it is
+  // offering, and no project named sends it on to that provider's chosen
+  // project. Neither step can leave the listed set, and an ask that named
+  // its own provider or project is never overridden.
+  if (!providerId && context.defaultProviderId && matchingProjects.length > 1) {
+    const offeredByDefault = matchingProjects.filter(
+      (candidate) => candidate.providerId === context.defaultProviderId,
+    );
+    if (offeredByDefault.length > 0) matchingProjects = offeredByDefault;
+  }
+  // A provider's chosen project settles which project, never which provider:
+  // while candidates still span providers, one provider's saved project must
+  // not quietly decide an ask the developer left open between them.
+  const [firstMatch] = matchingProjects;
+  const oneProviderMatches =
+    firstMatch !== undefined &&
+    matchingProjects.every((candidate) => candidate.providerId === firstMatch.providerId);
+  if (!projectId && oneProviderMatches && matchingProjects.length > 1) {
+    const chosenProjects = matchingProjects.filter(
+      (candidate) =>
+        context.defaultProjectIds?.[candidate.providerId] ===
+        workspaceProjectSelectionId(candidate),
+    );
+    if (chosenProjects.length === 1) matchingProjects = chosenProjects;
+  }
+  if (matchingProjects.length !== 1) {
+    return {
+      status: ACT_RESULT_STATUS.REJECTED,
+      reason:
+        matchingProjects.length === 0
+          ? "No listed project matches that identity."
+          : "More than one listed project matches; name the project and host.",
+    };
+  }
+  const project = matchingProjects[0];
+  if (!project)
+    return {
+      status: ACT_RESULT_STATUS.REJECTED,
+      reason: "No listed project matches that identity.",
+    };
+  const requestedAgent = textArgument(parsed, "agent");
+  const matchingAgents = requestedAgent
+    ? project.spawnableAgents?.filter(
+        (candidate) => candidate.toLocaleLowerCase() === requestedAgent.toLocaleLowerCase(),
+      )
+    : undefined;
+  const agent =
+    (requestedAgent && project.spawnableAgents?.includes(requestedAgent)
+      ? requestedAgent
+      : matchingAgents?.length === 1
+        ? matchingAgents[0]
+        : undefined) ?? project.defaultAgent;
+  if (project.spawnableAgents && (!agent || !project.spawnableAgents.includes(agent))) {
+    return {
+      status: ACT_RESULT_STATUS.REJECTED,
+      reason: agent
+        ? "That project lists no such agent to start."
+        : "Name one of the agents that project lists for a new workspace.",
+    };
+  }
+  let name: string | undefined;
+  if (parsed.name !== undefined) {
+    if (project.namesItself) {
+      return {
+        status: ACT_RESULT_STATUS.REJECTED,
+        reason: "That project names its own workspaces.",
+      };
+    }
+    name = workspaceNameText(parsed.name);
+    if (!name) {
+      return {
+        status: ACT_RESULT_STATUS.REJECTED,
+        reason: `A workspace name has to be under ${maximumWorkspaceNameLength} characters and longer than nothing.`,
+      };
+    }
+  }
+  // The task is held to the project's own word for it: a project that takes
+  // none cannot be handed one, a project that needs one cannot be created
+  // without it, and the text itself is bounded like the message it is.
+  let task: string | undefined;
+  if (parsed.task !== undefined) {
+    if (project.taskSupport === WORKSPACE_TASK_SUPPORT.NONE) {
+      return { status: ACT_RESULT_STATUS.REJECTED, reason: "That project takes no opening task." };
+    }
+    task = sessionMessageText(parsed.task);
+    if (!task) {
+      return {
+        status: ACT_RESULT_STATUS.REJECTED,
+        reason: "That task is empty or too long.",
+      };
+    }
+  } else if (project.taskSupport === WORKSPACE_TASK_SUPPORT.REQUIRED) {
+    return {
+      status: ACT_RESULT_STATUS.REJECTED,
+      reason: "That project needs an opening task to create a workspace.",
+    };
+  }
+  // A model named for this one creation resolves against the provider's own
+  // documented table, and the effort only ever rides a model: alone it has
+  // nothing documented to attach to.
+  const spokenModel = textArgument(parsed, "model");
+  const spokenEffort = textArgument(parsed, "effort");
+  if (spokenEffort !== undefined && spokenModel === undefined) {
+    return {
+      status: ACT_RESULT_STATUS.REJECTED,
+      reason: "An effort rides a model; name the model too.",
+    };
+  }
+  let agentSelection: WorkspaceAgentSelection | undefined;
+  if (spokenModel !== undefined) {
+    const resolved = resolveWorkspaceAgentModel(
+      context.agentModels(project.providerId),
+      spokenModel,
+      spokenEffort,
+    );
+    if ("refusal" in resolved)
+      return { status: ACT_RESULT_STATUS.REJECTED, reason: resolved.refusal };
+    agentSelection = resolved.selection;
+  }
+  const action: CarriedSessionAction = {
+    kind: SESSION_TOOL_KIND.CREATE_WORKSPACE,
+    providerId: project.providerId,
+    providerProjectId: project.providerProjectId,
+  };
+  if (project.providerTargetId) action.providerTargetId = project.providerTargetId;
+  if (agent) action.agent = agent;
+  if (name) action.name = name;
+  if (task) action.task = task;
+  if (agentSelection) action.agentSelection = agentSelection;
+  return action;
+}
+
+function validateAddWorkspaceAgent(
+  parsed: WireRecord,
+  context: SessionToolContext,
+): SessionToolAction {
+  const found = sessionFromArguments(parsed, context.sessions);
+  if ("status" in found) return found;
+  const { session, identity } = found;
+  // The agent must be one this session's own roster entry listed: the list
+  // is the provider's word for what its endpoint takes, so an ask outside it
+  // is refused rather than forwarded to be refused.
+  const agent = textArgument(parsed, "agent");
+  if (!agent || !advertisedActFor(session, ACT_KIND.ADD_AGENT)?.agents.includes(agent)) {
+    return {
+      status: ACT_RESULT_STATUS.REJECTED,
+      reason: "That session lists no such agent to add.",
+    };
+  }
+  let name: string | undefined;
+  if (parsed.name !== undefined) {
+    name = workspaceNameText(parsed.name);
+    if (!name) {
+      return {
+        status: ACT_RESULT_STATUS.REJECTED,
+        reason: `A session name has to be under ${maximumWorkspaceNameLength} characters and longer than nothing.`,
+      };
+    }
+  }
+  let task: string | undefined;
+  if (parsed.task !== undefined) {
+    task = sessionMessageText(parsed.task);
+    if (!task) {
+      return {
+        status: ACT_RESULT_STATUS.REJECTED,
+        reason: "That task is empty or too long.",
+      };
+    }
+  }
+  // A model named for this one agent resolves within the asked-for kind
+  // alone: the developer's chosen agent is never re-decided by the model
+  // they named beside it, so a mismatch is a refusal rather than a swap.
+  const spokenModel = textArgument(parsed, "model");
+  const spokenEffort = textArgument(parsed, "effort");
+  if (spokenEffort !== undefined && spokenModel === undefined) {
+    return {
+      status: ACT_RESULT_STATUS.REJECTED,
+      reason: "An effort rides a model; name the model too.",
+    };
+  }
+  let selection: WorkspaceAgentSelection | undefined;
+  if (spokenModel !== undefined) {
+    const entries = context
+      .agentModels(session.providerId)
+      .filter((candidate) => candidate.agent === agent);
+    const resolved = resolveWorkspaceAgentModel(entries, spokenModel, spokenEffort);
+    if ("refusal" in resolved) {
+      return {
+        status: ACT_RESULT_STATUS.REJECTED,
+        reason: resolved.refusal.startsWith("No documented model")
+          ? `A ${agent} agent runs no model by that name.`
+          : resolved.refusal,
+      };
+    }
+    selection = resolved.selection;
+  }
+  const action: CarriedSessionAction = {
+    kind: SESSION_TOOL_KIND.ADD_AGENT,
+    identity,
+    agent,
+  };
+  if (name) action.name = name;
+  if (task) action.task = task;
+  if (selection) action.model = selection.model;
+  if (selection?.effort) action.effort = selection.effort;
+  return action;
+}
+
+function validateRenameWorkspace(
+  parsed: WireRecord,
+  context: SessionToolContext,
+): SessionToolAction {
+  const found = sessionFromArguments(parsed, context.sessions);
+  if ("status" in found) return found;
+  const { session, identity } = found;
+  // Only a session whose roster entry advertised renaming has a workspace a
+  // rename can land on. The action carries the identity and the name, never
+  // the target: the main process resolves the workspace from its own
+  // registry, the same way an open never carries an address.
+  if (!advertisedActFor(session, ACT_KIND.RENAME_WORKSPACE)) {
+    return {
+      status: ACT_RESULT_STATUS.REJECTED,
+      reason: "That session's workspace cannot be renamed.",
+    };
+  }
+  const name = workspaceNameText(parsed.name);
+  if (!name) {
+    return {
+      status: ACT_RESULT_STATUS.REJECTED,
+      reason: `A workspace name has to be under ${maximumWorkspaceNameLength} characters and longer than nothing.`,
+    };
+  }
+  return { kind: SESSION_TOOL_KIND.RENAME_WORKSPACE, identity, name };
+}
+
+function validateRenameSession(parsed: WireRecord, context: SessionToolContext): SessionToolAction {
+  const found = sessionFromArguments(parsed, context.sessions);
+  if ("status" in found) return found;
+  const { session, identity } = found;
+  if (!advertisedActFor(session, ACT_KIND.RENAME_SESSION)) {
+    return { status: ACT_RESULT_STATUS.REJECTED, reason: "That chat cannot be renamed." };
+  }
+  const name = workspaceNameText(parsed.name);
+  if (!name) {
+    return {
+      status: ACT_RESULT_STATUS.REJECTED,
+      reason: `A chat name has to be under ${maximumWorkspaceNameLength} characters and longer than nothing.`,
+    };
+  }
+  return { kind: SESSION_TOOL_KIND.RENAME_SESSION, identity, name };
+}
+
+function validateUpdateIssueState(parsed: WireRecord, context: IssueToolContext): IssueToolAction {
+  const found = issueFromArguments(parsed, context.issues);
+  if ("status" in found) return found;
+  const { issue, identity } = found;
+  const state = textArgument(parsed, "state");
+  // Spoken names arrive with their case retold rather than copied, so the
+  // match forgives case alone — never spelling — and only while it stays
+  // unambiguous. Two advertised states apart only in case are not a guess
+  // Luke gets to make.
+  const named = state
+    ? issue.transitions.filter((candidate) => candidate.name.toLowerCase() === state.toLowerCase())
+    : [];
+  const transition =
+    named.find((candidate) => candidate.name === state) ??
+    (named.length === 1 ? named[0] : undefined);
+  if (!transition) {
+    return { status: ACT_RESULT_STATUS.REJECTED, reason: "That issue lists no such state." };
+  }
+  return { kind: ISSUE_TOOL_KIND.ISSUE_STATE, identity, transition };
+}
+
+function validateCommentOnIssue(parsed: WireRecord, context: IssueToolContext): IssueToolAction {
+  const found = issueFromArguments(parsed, context.issues);
+  if ("status" in found) return found;
+  const { issue, identity } = found;
+  if (!issue.canComment) {
+    return { status: ACT_RESULT_STATUS.REJECTED, reason: "That issue does not take comments." };
+  }
+  const body = issueCommentText(parsed.body);
+  if (!body) {
+    return {
+      status: ACT_RESULT_STATUS.REJECTED,
+      reason: "That comment is empty or too long.",
+    };
+  }
+  return { kind: ISSUE_TOOL_KIND.ISSUE_COMMENT, identity, body };
+}
+
+/**
+ * Validates the value a spoken change carries against the setting it names.
+ * A toggle takes the guide's own two words (and their unambiguous synonyms);
+ * a choice takes exactly one of the values the guide listed. Anything else is
+ * refused with the accepted set, so the refusal is also the correction.
+ */
+function appSettingValue(setting: AppGuideSetting, value: UnparsedWireValue): string | undefined {
+  if (setting.kind === APP_SETTING_KIND.TOGGLE) return appToggleValue(value);
+  if (!isWireString(value)) return undefined;
+  const normalized = value.trim().toLowerCase();
+  return setting.choices?.find((choice) => choice.toLowerCase() === normalized);
+}
+
+/**
+ * Whether one observed session answers one spoken filter value. Every
+ * identity a row carries is a filter on the same terms as its provider id —
+ * the agent behind a hosted chat, an app associated with it, and a workspace
+ * manager's scope id — so a spoken ask reaches exactly the rows the matching
+ * chip would keep.
+ */
+function sessionAnswersFilter(session: Session, filter: string): boolean {
+  if (filter === SESSION_LOCATION.LOCAL || filter === SESSION_LOCATION.CLOUD) {
+    return session.location === filter;
+  }
+  if (filter === SESSION_LIST_VOICE) return session.realtimeVoice === true;
+  return (
+    session.providerId === filter ||
+    session.agent?.id === filter ||
+    session.workspace?.scopeId === filter ||
+    session.applications.some((application) => application.id === filter)
+  );
+}
+
+/**
+ * Validates a spoken session-list narrowing against the sessions actually
+ * being observed. A narrowing that would show nothing is refused rather than
+ * applied: the panel would quietly fall back to showing everything, and Luke
+ * would have reported a narrowing that never happened. Each value is checked
+ * on its own first, so the refusal can name the value that is wrong rather
+ * than only the combination — and then the combination is checked whole, on
+ * the same axis terms the chips combine on, because two values a roster
+ * answers separately can still name an intersection nothing occupies.
+ */
+function panelFiltersAction(
+  filters: readonly string[],
+  sessions: readonly Session[],
+): { filters: readonly string[] } | { reason: string } {
+  // The enum on the tool's own schema already binds a compliant model to
+  // these tokens; this is the backstop for a call composed past it.
+  for (const filter of filters) {
+    if (!SESSION_LIST_FILTER_VALUES.includes(filter)) {
+      return { reason: `"${filter}" is not one of the filter values the tool lists.` };
+    }
+  }
+  const chosen = [...new Set(filters)];
+  if (chosen.includes(SESSION_LIST_ALL)) {
+    if (chosen.length > 1) {
+      return { reason: `${SESSION_LIST_ALL} is the whole list, so it combines with nothing.` };
+    }
+    return { filters: chosen };
+  }
+  for (const filter of chosen) {
+    if (sessions.some((session) => sessionAnswersFilter(session, filter))) continue;
+    if (filter === SESSION_LOCATION.LOCAL || filter === SESSION_LOCATION.CLOUD) {
+      return { reason: `No ${filter} sessions are observed right now.` };
+    }
+    if (filter === SESSION_LIST_VOICE) {
+      return { reason: "No voice sessions are observed right now." };
+    }
+    return {
+      reason: `No observed session belongs to an agent, app, or workspace manager "${filter}".`,
+    };
+  }
+  if (
+    chosen.length > 1 &&
+    !sessions.some((session) =>
+      matchesFilterSelection(chosen, (filter) => sessionAnswersFilter(session, filter)),
+    )
+  ) {
+    return { reason: "No observed session matches that combination of filters." };
+  }
+  return { filters: chosen };
+}
+
+function validateChangeAppSetting(parsed: WireRecord, context: AppToolContext): AppToolAction {
+  const setting = appGuideSetting(context.guide, textArgument(parsed, "setting_id"));
+  if (!setting) {
+    return { status: ACT_RESULT_STATUS.REJECTED, reason: "The app guide lists no such setting." };
+  }
+  if (!setting.adjustable) {
+    return {
+      status: ACT_RESULT_STATUS.REJECTED,
+      reason: `${setting.label} can only be changed by hand: ${setting.manual}`,
+    };
+  }
+  const value = appSettingValue(setting, parsed.value);
+  if (value === undefined) {
+    const accepted =
+      setting.kind === APP_SETTING_KIND.TOGGLE ? "on or off" : (setting.choices ?? []).join(", ");
+    return { status: ACT_RESULT_STATUS.REJECTED, reason: `${setting.label} takes ${accepted}.` };
+  }
+  // An effort may ride only a value the guide lists levels for, so both
+  // halves of one stored pairing can be asked for in one change — matched
+  // like the value: case retold rather than copied, answered in the guide's
+  // own casing.
+  const effortWord = textArgument(parsed, "effort");
+  if (effortWord === undefined) return { kind: APP_TOOL_KIND.SETTING, setting, value };
+  const levels = setting.efforts?.[value] ?? [];
+  if (levels.length === 0) {
+    return {
+      status: ACT_RESULT_STATUS.REJECTED,
+      reason:
+        setting.efforts === undefined
+          ? `${setting.label} takes no effort level.`
+          : `${value} takes no effort level.`,
+    };
+  }
+  const normalizedEffort = effortWord.trim().toLowerCase();
+  const effort = levels.find((candidate) => candidate.toLowerCase() === normalizedEffort);
+  if (effort === undefined) {
+    return {
+      status: ACT_RESULT_STATUS.REJECTED,
+      reason: `${value}'s effort is one of ${levels.join(", ")}.`,
+    };
+  }
+  return { kind: APP_TOOL_KIND.SETTING, setting, value, effort };
+}
+
+/**
+ * Reads the narrowing a panel ask carries: several values, or a lone string
+ * for a narrowing of one. Blank entries are dropped rather than validated,
+ * and an emptied list is no narrowing at all.
+ */
+function spokenFilterValues(
+  value: UnparsedWireValue,
+): { values: readonly string[] | undefined } | { reason: string } {
+  if (value === undefined) return { values: undefined };
+  const entries = isWireString(value) ? [value] : value;
+  if (!Array.isArray(entries) || !entries.every((entry) => isWireString(entry))) {
+    return { reason: "filters takes a list of filter values." };
+  }
+  const cleaned = entries.map((entry) => entry.trim()).filter((entry) => entry.length > 0);
+  return { values: cleaned.length > 0 ? cleaned : undefined };
+}
+
+function validateShowPanel(parsed: WireRecord, context: AppToolContext): AppToolAction {
+  const tab = parsed.tab ?? APP_PANEL_TAB.SESSIONS;
+  if (!isAppPanelTab(tab)) {
+    return { status: ACT_RESULT_STATUS.REJECTED, reason: "The panel has no such tab." };
+  }
+  const sort = textArgument(parsed, "sort");
+  if (sort !== undefined && !isSessionListSort(sort)) {
+    return {
+      status: ACT_RESULT_STATUS.REJECTED,
+      reason: "The list orders by urgency or by recency.",
+    };
+  }
+  // A search is bounded by the hand's own control: the magnifier is only
+  // offered beside a list with more than one session, and a spoken ask
+  // reaches no further than it. The words themselves are not validated
+  // against the rows the way a filter is — a query is read against the lines
+  // as the surface words them, which only the renderer knows, and a search
+  // matching nothing is the list's own honest answer rather than a stale
+  // narrowing to refuse.
+  const query = textArgument(parsed, "query");
+  if (query !== undefined && context.sessions.length < 2) {
+    return {
+      status: ACT_RESULT_STATUS.REJECTED,
+      reason: "The list offers a search only when more than one session is observed.",
+    };
+  }
+  const asked = spokenFilterValues(parsed.filters);
+  if ("reason" in asked) return { status: ACT_RESULT_STATUS.REJECTED, reason: asked.reason };
+  if (asked.values === undefined) {
+    const action: CarriedAppAction = { kind: APP_TOOL_KIND.PANEL, tab };
+    if (sort !== undefined) action.sort = sort;
+    if (query !== undefined) action.query = query;
+    return action;
+  }
+  const outcome = panelFiltersAction(asked.values, context.sessions);
+  if ("reason" in outcome) return { status: ACT_RESULT_STATUS.REJECTED, reason: outcome.reason };
+  const action: CarriedAppAction = {
+    kind: APP_TOOL_KIND.PANEL,
+    tab,
+    filters: outcome.filters,
+  };
+  if (sort !== undefined) action.sort = sort;
+  if (query !== undefined) action.query = query;
+  return action;
+}
+
+function validateOpenFeedbackComposer(parsed: WireRecord, _context: AppToolContext): AppToolAction {
+  const composer = parsed.kind;
+  if (!isFeedbackComposerKind(composer)) {
+    return {
+      status: ACT_RESULT_STATUS.REJECTED,
+      reason: "The composer writes feedback or a prompt, nothing else.",
+    };
+  }
+  // The draft is the developer's ask restated in their words, not a document,
+  // so it is bounded like a typed one; a blank draft is no draft, and the
+  // composer simply opens empty.
+  const draft = textArgument(parsed, "draft")?.slice(0, maximumSessionMessageLength);
+  const action: CarriedAppAction = { kind: APP_TOOL_KIND.FEEDBACK, composer };
+  if (draft) action.draft = draft;
+  return action;
+}
+
+/**
+ * What stands where the asked-for act would be, so a refusal can say why the
+ * row is not offering it — the row's own detail says where the build stands,
+ * and this names the one press that stands instead.
+ */
+const UPDATE_BUTTON_STANDING = {
+  [APP_UPDATE_ACT.CHECK]: "Its button offers a check right now.",
+  [APP_UPDATE_ACT.DOWNLOAD]: "Its button offers the releases page in the browser right now.",
+  [APP_UPDATE_ACT.RESTART]: "Its button offers Restart to update right now.",
+  [APP_UPDATE_WAIT.CHECKING]: "Nothing is pressable while the check is out.",
+  [APP_UPDATE_WAIT.DOWNLOADING]: "Nothing is pressable while the download runs.",
+} as const satisfies Record<AppGuideUpdate["button"], string>;
+
+function validateRunUpdateAction(parsed: WireRecord, context: AppToolContext): AppToolAction {
+  // The guide's update entry is the roster here: a run that reported nothing
+  // about updates — a fixture, a pure caller — advertises no act to run.
+  const update = context.guide.update;
+  if (!update) {
+    return {
+      status: ACT_RESULT_STATUS.REJECTED,
+      reason: "This run does not report where updates stand.",
+    };
+  }
+  const act = parsed.action;
+  if (!isAppUpdateAct(act)) {
+    return {
+      status: ACT_RESULT_STATUS.REJECTED,
+      reason: "The Updates button checks, downloads, or restarts.",
+    };
+  }
+  // One button, one act: only the press the row is actually drawing runs, so
+  // the refusal is the row's own words plus what stands in the act's place.
+  if (act !== update.button) {
+    return {
+      status: ACT_RESULT_STATUS.REJECTED,
+      reason: `${update.detail} ${UPDATE_BUTTON_STANDING[update.button]}`,
+    };
+  }
+  return { kind: APP_TOOL_KIND.UPDATE, act };
+}
+
+/** Validates one automatic memory update against the bounded list in context. */
+function validateRememberFact(parsed: WireRecord, context: AppToolContext): AppToolAction {
+  const words = rememberedFactText(parsed.words);
+  if (!words) {
+    return {
+      status: ACT_RESULT_STATUS.REJECTED,
+      reason: `A memory has to be under ${maximumRememberedFactLength} characters and longer than nothing.`,
+    };
+  }
+  const replaces = textArgument(parsed, "replaces");
+  if (replaces !== undefined && !holdsRememberedFact(context.rememberedFacts, replaces)) {
+    return {
+      status: ACT_RESULT_STATUS.REJECTED,
+      reason: "Nothing remembered goes by that id.",
+    };
+  }
+  // A replacement retires one as it lands; a new fact never evicts silently.
+  if (replaces === undefined && context.rememberedFacts.length >= maximumRememberedFacts) {
+    return {
+      status: ACT_RESULT_STATUS.REJECTED,
+      reason: `Luke already remembers ${maximumRememberedFacts} things; replace or forget one first.`,
+    };
+  }
+  return { kind: APP_TOOL_KIND.REMEMBER, words, ...(replaces ? { replaces } : undefined) };
+}
+
+function validateForgetFact(parsed: WireRecord, context: AppToolContext): AppToolAction {
+  const id = textArgument(parsed, "id");
+  if (!id || !holdsRememberedFact(context.rememberedFacts, id)) {
+    return { status: ACT_RESULT_STATUS.REJECTED, reason: "Nothing remembered goes by that id." };
+  }
+  return { kind: APP_TOOL_KIND.FORGET, id };
+}
+
+const LEGACY_VALIDATE = {
+  send_session_message: validateSendSessionMessage,
+  run_session_control: validateRunSessionControl,
+  open_session: validateOpenSession,
+  create_workspace: validateCreateWorkspace,
+  add_workspace_agent: validateAddWorkspaceAgent,
+  rename_workspace: validateRenameWorkspace,
+  rename_session: validateRenameSession,
+} as const satisfies Record<string, SessionToolValidate>;
+
+const LEGACY_ISSUE_VALIDATE = {
+  update_issue_state: validateUpdateIssueState,
+  comment_on_issue: validateCommentOnIssue,
+} as const satisfies Record<string, IssueToolValidate>;
+
+const LEGACY_APP_VALIDATE = {
+  change_app_setting: validateChangeAppSetting,
+  show_panel: validateShowPanel,
+  open_feedback_composer: validateOpenFeedbackComposer,
+  run_update_action: validateRunUpdateAction,
+  remember_fact: validateRememberFact,
+  forget_fact: validateForgetFact,
+} as const satisfies Record<string, AppToolValidate>;
+
+export function sessionToolAction(
+  call: RealtimeFunctionCall,
+  sessions: readonly Session[],
+  workspaceProjects: readonly ObservedWorkspaceProject[] = [],
+  agentModels: (providerId: string) => readonly WorkspaceAgentModels[] = () => [],
+  defaultProviderId?: string,
+  defaultProjectIds?: Readonly<Partial<Record<string, string>>>,
+): SessionToolAction {
+  const parsed = parseToolArguments(call);
+  if (!parsed.ok) return { status: ACT_RESULT_STATUS.REJECTED, reason: parsed.reason };
+  // SAFETY: `Object.hasOwn` just answered that the table holds this name.
+  const validate = Object.hasOwn(LEGACY_VALIDATE, call.name)
+    ? LEGACY_VALIDATE[call.name as keyof typeof LEGACY_VALIDATE]
+    : undefined;
+  if (!validate) return { status: ACT_RESULT_STATUS.REJECTED, reason: "No such tool exists." };
+  return validate(parsed.value, {
+    sessions,
+    workspaceProjects,
+    agentModels,
+    defaultProviderId,
+    defaultProjectIds,
+  });
+}
+
+export function issueToolAction(
+  call: RealtimeFunctionCall,
+  issues: readonly TrackedIssue[],
+): IssueToolAction {
+  const parsed = parseToolArguments(call);
+  if (!parsed.ok) return { status: ACT_RESULT_STATUS.REJECTED, reason: parsed.reason };
+  // SAFETY: `Object.hasOwn` just answered that the table holds this name.
+  const validate = Object.hasOwn(LEGACY_ISSUE_VALIDATE, call.name)
+    ? LEGACY_ISSUE_VALIDATE[call.name as keyof typeof LEGACY_ISSUE_VALIDATE]
+    : undefined;
+  if (!validate) return { status: ACT_RESULT_STATUS.REJECTED, reason: "No such tool exists." };
+  return validate(parsed.value, { issues });
+}
+
+export function appToolAction(
+  call: RealtimeFunctionCall,
+  guide: AppGuideSnapshot,
+  sessions: readonly Session[],
+  rememberedFacts: readonly RememberedFact[] = [],
+): AppToolAction {
+  const parsed = parseToolArguments(call);
+  if (!parsed.ok) return { status: ACT_RESULT_STATUS.REJECTED, reason: parsed.reason };
+  // SAFETY: `Object.hasOwn` just answered that the table holds this name.
+  const validate = Object.hasOwn(LEGACY_APP_VALIDATE, call.name)
+    ? LEGACY_APP_VALIDATE[call.name as keyof typeof LEGACY_APP_VALIDATE]
+    : undefined;
+  if (!validate) return { status: ACT_RESULT_STATUS.REJECTED, reason: "No such tool exists." };
+  return validate(parsed.value, { guide, sessions, rememberedFacts });
+}

--- a/packages/acts/src/testing/admitted.ts
+++ b/packages/acts/src/testing/admitted.ts
@@ -1,0 +1,18 @@
+import type { CarriedAct } from "../act-kinds.js";
+import type { Refusal, ValidatedAct } from "../admit.js";
+
+/**
+ * An admitted act as the plain payload it carries: the brand a deep equality
+ * would report and the origin admission stamped are both dropped, so a case
+ * can compare what was admitted against what a validator that knew neither
+ * answered.
+ */
+export function withoutAdmission(result: ValidatedAct | Refusal): CarriedAct | Refusal {
+  if (result.kind === undefined) return result;
+  const { origin, ...payload } = result;
+  void origin;
+  for (const key of Object.getOwnPropertySymbols(payload)) {
+    Reflect.deleteProperty(payload, key);
+  }
+  return payload;
+}

--- a/packages/acts/src/testing/json-schema.ts
+++ b/packages/acts/src/testing/json-schema.ts
@@ -1,0 +1,13 @@
+import type { JsonSchemaNode } from "@sidecar/wire";
+
+/** The property table of an emitted object node, for a test that reads one. */
+export function objectProperties(node: JsonSchemaNode): { readonly [key: string]: JsonSchemaNode } {
+  return "properties" in node ? node.properties : {};
+}
+
+/** The enum an emitted array-of-strings node offers, or nothing. */
+export function itemEnum(node: JsonSchemaNode | undefined): readonly string[] {
+  if (!node || !("items" in node)) return [];
+  const items = node.items;
+  return "type" in items && items.type === "string" ? (items.enum ?? []) : [];
+}

--- a/packages/acts/src/validated-act.type-test.ts
+++ b/packages/acts/src/validated-act.type-test.ts
@@ -1,0 +1,45 @@
+/**
+ * The claim `admit` exists to make, checked by the compiler rather than by a
+ * run: a `ValidatedAct` cannot be written down anywhere but inside `admit`.
+ * Its brand is a module-private `unique symbol`, so nothing outside that module
+ * can spell the key an object literal would need, and no payload flows into a
+ * performer's parameter on its own.
+ *
+ * What the type cannot stop is a deliberate `as ValidatedAct` assertion, since
+ * the brand makes the admitted act a subtype of the payload and TypeScript
+ * permits an assertion between the two. That one is caught by reading the diff
+ * and by `git grep "as ValidatedAct"` answering nothing, which is why the
+ * assertion appears nowhere in this repository.
+ *
+ * This file exports nothing and runs nowhere. It fails by an `@ts-expect-error`
+ * that stops erroring, which `tsc` reports as an error of its own.
+ */
+
+import type { ACT_KIND, CarriedAct } from "./act-kinds.js";
+import { admit, type ValidatedAct } from "./admit.js";
+
+declare const carried: CarriedAct<typeof ACT_KIND.MESSAGE>;
+declare const admittedMessage: ValidatedAct<typeof ACT_KIND.MESSAGE>;
+declare function takesAdmitted(act: ValidatedAct<typeof ACT_KIND.MESSAGE>): void;
+
+// @ts-expect-error a plain payload is not admitted: the brand is a module-private symbol.
+takesAdmitted(carried);
+
+// @ts-expect-error nothing outside admit.ts can spell the brand, so no literal satisfies it.
+takesAdmitted({ ...carried, origin: "user" });
+
+declare const words: string;
+// @ts-expect-error a value of another shape is not an act, admitted or otherwise.
+takesAdmitted(words);
+
+// @ts-expect-error one kind's admission is not another's.
+const wrongKind: ValidatedAct<typeof ACT_KIND.CONTROL> = admittedMessage;
+void wrongKind;
+
+// The one producer typechecks, and what it mints is what a performer takes.
+declare const request: Parameters<typeof admit<typeof ACT_KIND.MESSAGE>>[0];
+declare const context: Parameters<typeof admit<typeof ACT_KIND.MESSAGE>>[1];
+void (async () => {
+  const result = await admit(request, context);
+  if (result.kind !== undefined) takesAdmitted(result);
+});

--- a/packages/brain/src/index.ts
+++ b/packages/brain/src/index.ts
@@ -86,6 +86,7 @@ export {
   embeddingsVectors,
   type ResponsesFunctionTool,
   type ResponsesInputItem,
+  type ResponsesToolDefinition,
   responsesCompactedWindow,
   responsesInputTokens,
   responsesModelAnswer,

--- a/packages/brain/src/responses-api.ts
+++ b/packages/brain/src/responses-api.ts
@@ -1,4 +1,4 @@
-import type { RealtimeToolWireDefinition } from "@sidecar/acts";
+import type { ActToolDefinition } from "@sidecar/acts";
 import {
   RESPONSES_CONTENT_PART_TYPE,
   RESPONSES_INPUT_ITEM_TYPE,
@@ -61,10 +61,16 @@ export const BRAIN_REASONING_EFFORT = {
 export type BrainReasoningEffort =
   (typeof BRAIN_REASONING_EFFORT)[keyof typeof BRAIN_REASONING_EFFORT];
 
+/** A function tool built from a contract schema, whose parameters travel as they were declared. */
+export interface ResponsesToolDefinition {
+  type: "function";
+  name: string;
+  description: string;
+  parameters: WireRecord;
+}
+
 /** A function tool as the Responses request carries it: the acts table's own row, or a contract schema wrapped. */
-export type ResponsesFunctionTool =
-  | RealtimeToolWireDefinition
-  | { type: "function"; name: string; description: string; parameters: WireRecord };
+export type ResponsesFunctionTool = ActToolDefinition | ResponsesToolDefinition;
 
 export interface BrainResponsesOptions {
   model: string;
@@ -224,7 +230,7 @@ export const BRAIN_RESPONSES_COMPACT_PATH = "/responses/compact";
 export const BRAIN_RESPONSES_INPUT_TOKENS_PATH = "/responses/input_tokens";
 
 /** A tool as the brain's contracts carry it, as the Responses API takes it: a function tool. */
-export function responsesToolDefinition(schema: ToolSchema): ResponsesFunctionTool {
+export function responsesToolDefinition(schema: ToolSchema): ResponsesToolDefinition {
   return {
     type: "function",
     name: schema.name,
@@ -234,7 +240,7 @@ export function responsesToolDefinition(schema: ToolSchema): ResponsesFunctionTo
 }
 
 /** A tool as the acts table or the brain defines it, in the brain's contract shape. */
-export function toolSchemaFromDefinition(definition: RealtimeToolWireDefinition): ToolSchema {
+export function toolSchemaFromDefinition(definition: ActToolDefinition): ToolSchema {
   // SAFETY: the parameters are a JSON-schema object built from literals; a JSON round trip is its wire form.
   const parameters = wireRecord(
     JSON.parse(JSON.stringify(definition.parameters)) as UnparsedWireValue,

--- a/packages/brain/src/tools.ts
+++ b/packages/brain/src/tools.ts
@@ -1,8 +1,4 @@
-import {
-  type RealtimeToolWireDefinition,
-  realtimeToolDefinitions,
-  realtimeToolFamily,
-} from "@sidecar/acts";
+import { type ActToolDefinition, realtimeToolDefinitions, realtimeToolFamily } from "@sidecar/acts";
 import { MEMORY_QUERY_MAXIMUM_CHARS } from "@sidecar/memory";
 import {
   type ChildPolicyContext,
@@ -16,7 +12,7 @@ import {
 } from "@sidecar/runtime";
 import type { ToolSchema } from "@sidecar/runtime-contracts";
 import {
-  type ResponsesFunctionTool,
+  type ResponsesToolDefinition,
   responsesToolDefinition,
   toolSchemaFromDefinition,
 } from "./responses-api.js";
@@ -92,7 +88,7 @@ export const maximumChildTaskLength = 8_000;
 /** The most history lines one `sessions_history` read answers with. */
 export const maximumSessionsHistoryLines = 50;
 
-const BRAIN_ONLY_TOOLS: readonly RealtimeToolWireDefinition[] = [
+const BRAIN_ONLY_TOOLS: readonly ActToolDefinition[] = [
   {
     type: BRAIN_TOOL_TYPE,
     name: BRAIN_TOOL.LIST_SESSIONS,
@@ -100,7 +96,7 @@ const BRAIN_ONLY_TOOLS: readonly RealtimeToolWireDefinition[] = [
       "Read the full roster of observed sessions as it stands right now, with each session's " +
       "identity, status, and capabilities. The standing context already carries it; call this " +
       "only when you need it fresher than the turn's opening.",
-    parameters: { type: "object", properties: {}, required: [] },
+    parameters: { type: "object", properties: {}, required: [], additionalProperties: false },
   },
   {
     type: BRAIN_TOOL_TYPE,
@@ -114,6 +110,7 @@ const BRAIN_ONLY_TOOLS: readonly RealtimeToolWireDefinition[] = [
       type: "object",
       properties: SESSION_IDENTITY_PROPERTIES,
       required: SESSION_IDENTITY_REQUIRED,
+      additionalProperties: false,
     },
   },
   {
@@ -133,6 +130,7 @@ const BRAIN_ONLY_TOOLS: readonly RealtimeToolWireDefinition[] = [
         },
       },
       required: ["briefing"],
+      additionalProperties: false,
     },
   },
   {
@@ -148,6 +146,7 @@ const BRAIN_ONLY_TOOLS: readonly RealtimeToolWireDefinition[] = [
         name: { type: "string", description: "The file's name relative to the workspace." },
       },
       required: ["name"],
+      additionalProperties: false,
     },
   },
   {
@@ -164,6 +163,7 @@ const BRAIN_ONLY_TOOLS: readonly RealtimeToolWireDefinition[] = [
         content: { type: "string", description: "The file's whole new content." },
       },
       required: ["name", "content"],
+      additionalProperties: false,
     },
   },
   {
@@ -178,6 +178,7 @@ const BRAIN_ONLY_TOOLS: readonly RealtimeToolWireDefinition[] = [
         location: { type: "string", description: "The SKILL.md location exactly as listed." },
       },
       required: ["location"],
+      additionalProperties: false,
     },
   },
   {
@@ -221,6 +222,7 @@ const BRAIN_ONLY_TOOLS: readonly RealtimeToolWireDefinition[] = [
         },
       },
       required: ["task"],
+      additionalProperties: false,
     },
   },
   {
@@ -241,6 +243,7 @@ const BRAIN_ONLY_TOOLS: readonly RealtimeToolWireDefinition[] = [
         child_id: { type: "string", description: "The child to cancel, as the list gave it." },
       },
       required: [],
+      additionalProperties: false,
     },
   },
   {
@@ -250,7 +253,7 @@ const BRAIN_ONLY_TOOLS: readonly RealtimeToolWireDefinition[] = [
       "List Luke's own conversations — main, the developer's threads, the observed sessions' " +
       "conversations, and child conversations — by key, kind, name, and last activity. These " +
       "are your own conversations, not the coding agents the roster lists.",
-    parameters: { type: "object", properties: {}, required: [] },
+    parameters: { type: "object", properties: {}, required: [], additionalProperties: false },
   },
   {
     type: BRAIN_TOOL_TYPE,
@@ -265,6 +268,7 @@ const BRAIN_ONLY_TOOLS: readonly RealtimeToolWireDefinition[] = [
         limit: { type: "integer", description: "How many lines at most." },
       },
       required: ["child_id"],
+      additionalProperties: false,
     },
   },
   {
@@ -289,6 +293,7 @@ const BRAIN_ONLY_TOOLS: readonly RealtimeToolWireDefinition[] = [
         },
       },
       required: ["query"],
+      additionalProperties: false,
     },
   },
   {
@@ -309,6 +314,7 @@ const BRAIN_ONLY_TOOLS: readonly RealtimeToolWireDefinition[] = [
         lines: { type: "integer", description: "How many lines to read." },
       },
       required: ["path"],
+      additionalProperties: false,
     },
   },
 ];
@@ -383,7 +389,7 @@ const BRAIN_ONLY_DESCRIPTORS = {
   },
 } as const satisfies Record<BrainToolName, Pick<ToolDescriptor, "execution" | "effect" | "groups">>;
 
-function actDescriptor(definition: RealtimeToolWireDefinition): ToolDescriptor {
+function actDescriptor(definition: ActToolDefinition): ToolDescriptor {
   const family = realtimeToolFamily(definition.name);
   if (family === undefined) throw new TypeError(`${definition.name} is not an act`);
   return {
@@ -395,7 +401,7 @@ function actDescriptor(definition: RealtimeToolWireDefinition): ToolDescriptor {
   };
 }
 
-function brainOnlyDescriptor(definition: RealtimeToolWireDefinition): ToolDescriptor {
+function brainOnlyDescriptor(definition: ActToolDefinition): ToolDescriptor {
   const name = definition.name;
   if (!isBrainOnlyTool(name)) throw new TypeError(`${name} is not a brain tool`);
   return {
@@ -456,6 +462,6 @@ export function brainToolSchemas(policy: EffectiveToolPolicy): readonly ToolSche
  * a desktop checks the names it means to send against the catalog the
  * service advertised; the trace viewer renders a turn's tools from it.
  */
-export function hostedBrainToolCatalog(): ReadonlyMap<string, ResponsesFunctionTool> {
+export function hostedBrainToolCatalog(): ReadonlyMap<string, ResponsesToolDefinition> {
   return new Map(brainToolCatalog().map((tool) => [tool.id, responsesToolDefinition(tool.schema)]));
 }

--- a/packages/issues/src/index.ts
+++ b/packages/issues/src/index.ts
@@ -9,6 +9,7 @@ export {
   type IssueTransition,
   isIssueTrackerId,
   issueCommentText,
+  maximumIssueCommentLength,
   maximumIssueTransitions,
   normalizeTrackedIssue,
   type TrackedIssue,

--- a/packages/realtime/src/conversation-history.test.ts
+++ b/packages/realtime/src/conversation-history.test.ts
@@ -1,8 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { SESSION_TOOL_KIND } from "@sidecar/acts";
+import { ACT_KIND } from "@sidecar/acts";
 import {
-  ACT_KIND,
   type AdvertisedControl,
   normalizeSession,
   SESSION_APPLICATION_ID,
@@ -180,7 +179,7 @@ test("an act's line records the ask in words, with the identity it named", () =>
   const identity = { providerId: "claude-code", providerSessionId: "session-a" };
 
   const message = sessionActConversationEntry(
-    { kind: SESSION_TOOL_KIND.MESSAGE, identity, text: "please add tests" },
+    { kind: ACT_KIND.MESSAGE, identity, text: "please add tests" },
     sessions,
     CONVERSATION_ENTRY_KIND.ACT,
   );
@@ -191,7 +190,7 @@ test("an act's line records the ask in words, with the identity it named", () =>
   const control: AdvertisedControl = { kind: ACT_KIND.CONTROL, id: "retry", label: "Retry" };
   assert.equal(
     sessionActConversationEntry(
-      { kind: SESSION_TOOL_KIND.CONTROL, identity, control },
+      { kind: ACT_KIND.CONTROL, identity, control },
       sessions,
       CONVERSATION_ENTRY_KIND.ACT,
     ).words,
@@ -200,11 +199,8 @@ test("an act's line records the ask in words, with the identity it named", () =>
 
   // A session the roster no longer shows is still named honestly.
   assert.equal(
-    sessionActConversationEntry(
-      { kind: SESSION_TOOL_KIND.OPEN, identity },
-      [],
-      CONVERSATION_ENTRY_KIND.ACT,
-    ).words,
+    sessionActConversationEntry({ kind: ACT_KIND.OPEN, identity }, [], CONVERSATION_ENTRY_KIND.ACT)
+      .words,
     "opened a session",
   );
 
@@ -228,7 +224,7 @@ test("an act's line records the ask in words, with the identity it named", () =>
     },
   );
   const openedInApp = {
-    kind: SESSION_TOOL_KIND.OPEN,
+    kind: ACT_KIND.OPEN,
     identity,
     applicationId: SESSION_APPLICATION_ID.SUPERSET,
   } as const;
@@ -243,7 +239,7 @@ test("an act's line records the ask in words, with the identity it named", () =>
 
   // A workspace creation aims at no session, so its line carries no identity.
   const created = sessionActConversationEntry(
-    { kind: SESSION_TOOL_KIND.CREATE_WORKSPACE, providerId: "conductor", providerProjectId: "p1" },
+    { kind: ACT_KIND.CREATE_WORKSPACE, providerId: "conductor", providerProjectId: "p1" },
     sessions,
     CONVERSATION_ENTRY_KIND.ACT,
   );
@@ -251,7 +247,7 @@ test("an act's line records the ask in words, with the identity it named", () =>
   assert.equal(created.identity, undefined);
   const createdNamed = sessionActConversationEntry(
     {
-      kind: SESSION_TOOL_KIND.CREATE_WORKSPACE,
+      kind: ACT_KIND.CREATE_WORKSPACE,
       providerId: "conductor",
       providerProjectId: "p1",
       name: "Notch panel clipping",

--- a/packages/realtime/src/conversation-history.ts
+++ b/packages/realtime/src/conversation-history.ts
@@ -30,7 +30,7 @@
  * app" was itself a policy and persisting means replacing it with a real one.
  */
 
-import { actNarration, type CarriedSessionAction } from "@sidecar/acts";
+import { actNarration, type CarriedSessionAct } from "@sidecar/acts";
 import type { Session, SessionIdentity } from "@sidecar/session";
 import {
   isRecord,
@@ -421,7 +421,7 @@ export function withConversationEntryRequest(
  * else, so the record keeps the act and not a word of what it rendered.
  */
 export function sessionActConversationEntry(
-  action: CarriedSessionAction,
+  action: CarriedSessionAct,
   sessions: readonly Session[],
   kind: typeof CONVERSATION_ENTRY_KIND.ACT | typeof CONVERSATION_ENTRY_KIND.OWN_ACT,
 ): ConversationEntry {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -308,6 +308,9 @@ importers:
       '@sidecar/issues':
         specifier: workspace:*
         version: link:../issues
+      '@sidecar/runtime-contracts':
+        specifier: workspace:*
+        version: link:../runtime-contracts
       '@sidecar/session':
         specifier: workspace:*
         version: link:../session


### PR DESCRIPTION
## What this is

PR **E4** of the repo-wide cleanup. Today the question *"may this act reach this session right now?"* is answered in up to seven places — the renderer/brain validators in `packages/acts/src/acts.ts`, the main-process performer, the hosted route handlers, the hosted executors, and again inside each adapter. Each re-implements the same four steps in its own words, and each is enforced by convention: a new caller can skip any of them and nothing fails to compile.

`admit()` in `packages/acts/src/admit.ts` is now the one gauntlet and the **only** code that can produce a `ValidatedAct<K>`.

- **guard → roster → advertisement → bounds.** Admission reads the roster itself rather than taking a caller's copy, so "a fresh roster read precedes it" belongs to the function that guarantees it; the advertised entry (the control, the agent kind, the listed project) is what the act carries, so nothing a caller sent can redirect the effect; the developer's own text is refused rather than cut; and the guard is asked again after every read admission made.
- **The brand is a module-private `unique symbol`.** No literal outside `admit.ts` can spell it. `validated-act.type-test.ts` holds the compiler to that with `@ts-expect-error`, and says plainly the one thing the type *cannot* stop — a deliberate `as ValidatedAct` assertion, which is what the grep below is for.
- **Reads are lazy and memoised**, so an issue act reaches no roster, a `show_panel` reads it once, and only a creation reads the saved defaults.

## The split

`acts.ts` becomes the registry it always described itself as (1,951 → 328 lines):

| File | What it holds |
|---|---|
| `act-kinds.ts` | `ACT_FAMILY`, `ACT_KIND`, `Carried<T>`, the `ActPayloads` table, `CarriedAct<K>`, `ActRequest<K>` |
| `act-schemas.ts` | Each act's fields declared once — the JSON Schema a model reads and the bounds admission enforces are one statement |
| `admit.ts` | `admit`, `ValidatedAct`, `AdmitContext`, `ActGuard`/`ActRoster`/`ActProjects`, `Refusal`, `ACT_REFUSAL`, `guardedRead` |
| `act-narration.ts` | The History sentences as a total `Record` — the `"carried an act"` fallback is gone because the record cannot miss a kind |
| `acts.ts` | `ToolSpec<Family, Kind>`, `ACTS`, one `toolAction`, `dispatchByKind` |

`SESSION_TOOL_KIND` / `ISSUE_TOOL_KIND` / `APP_TOOL_KIND` / `REALTIME_TOOL_FAMILY`, the three `Carried*Action` wrappers, the three `*ToolContext`s, `JsonSchemaProperty` and its siblings, and `narrate` are all gone. `validateCreateWorkspace`'s two dead branches go with them (the unreachable `!project` arm, and the three-way agent conditional whose middle arm could only differ by case, now one `namedOnce` shared with the issue-transition match).

## ⚠ Trust boundary: the parallel run

Nothing is deleted from a trust boundary here. The old validators stand in `legacy-validation.ts`, called by nothing in the product, and **every** case in `admit.test.ts` (the former `acts-validation.test.ts`, unchanged in substance) and `guide.test.ts` runs the old validator and `admit` on the same input and fails unless the two answer identically — 58 tests, ~60 dual-run call sites. `apps/web/tests/hosted-acts.test.ts` gains the same proof one remove out: admission and each hosted executor's own checks are run against the same Conductor observation pass and must agree on whether the act may run. E5 deletes the old layers and the file.

### CLAUDE.md sentences touched, and where the rule now lives

| Sentence | New home |
|---|---|
| `AGENTS.md:123` — "each validated against the observed roster, and against that session's own advertisement of the acts its provider documents for it now, before an adapter sees it" | Reworded: admitted by `@sidecar/acts`'s `admit()`, the one function that mints the validated act, reading the roster for itself — **and by the layers beneath it that still hold the same rule until they are deleted**. |
| `AGENTS.md:895` — "validated against the observed issue roster in the renderer and again in the main process" | Reworded: admitted against the observed issue roster by the same `admit()` every session act runs, and validated again in the main process. |
| `AGENTS.md:146-149` — "Every act still runs the same validation whoever opened the turn: a cancellation or a revoked run refuses it, a fresh roster read precedes it, its target has to be one the roster holds" | Unchanged text, now stated once in `admit.ts` and held by `guarantees.test.ts`. |
| `AGENTS.md:812` — the notebook write's gauntlet | Unchanged: the renderer half (`bridge.ts`) still stands, and the main-process half is now `admit()`. |

`packages/AGENTS.md` gains the admission rule and a note on the one name two doors both carry. No `PRIVACY.md` paragraph moves: nothing about what leaves the machine changes.

## `guarantees.test.ts`

19 cases, each named by the sentence it keeps: the roster read happening once and never being handed in; a revoked guard refusing every kind before any read; a read still out when the signal fires answering nothing; the admitted control being the roster's object and not the caller's copy; a local session with nothing advertised taking no write of any kind; a message at its bound admitted and one character past it refused, never truncated; a creation landing only in a listed project and carrying the *project's* identifiers; task support in all three shapes; the origin recorded on the act and changing nothing else about it; an issue act refusing with no tracker; the guide's settings; the notebook cap refusing rather than evicting; and an admitted open carrying an identity and never an address.

## Deliberate behaviour changes

These are the whole of what a user could notice, and each follows from the derivation rather than from a decision taken here:

1. **Act tool JSON schemas are derived from their `Schema`.** They gain `additionalProperties: false` (the strict form a function tool's parameters take), `minLength: 1` where the parser already refused an empty string, and `maxLength` where a bound already existed — a bound the parser holds and the node omits is drift in the direction that misleads a model. Property sets, required arrays, and every description string are byte-identical.
2. **The brain's own tool literals gain `additionalProperties: false`** for the same reason, since they share the emitted node's type. Every one has a closed property set.
3. **`show_panel` now runs a fresh observation pass** before its narrowing is validated, because admission owns the roster read. No other app or issue act reads the roster at all, and no act but a creation reads the saved workspace defaults (they never used them).
4. **One sentence for a turn that ended.** The brain's `"…is over."` and the performer's `"…ended before it could start."` were two wordings of one thing; `ACT_REFUSAL.TURN_OVER` is now the only one.
5. `REFUSAL_REASON` is exported as **`ACT_REFUSAL`**: `@sidecar/brain` already exports a `REFUSAL_REASON`, and `apps/web/server/core.ts` stars both doors, where a shared name is silently dropped. `ACT_KIND` genuinely has to live in both `@sidecar/acts` (all fifteen) and `@sidecar/session` (the five an observation advertises); the two are held to the same strings by a `satisfies` where the table declares them, and `core.ts` names the whole one explicitly so the star exports cannot drop it.

## Verification

```
./scripts/check.sh   # green (typecheck, lint, format, repository checks, tests, build)
```

- `git grep -n 'ADMITTED' -- 'packages/**/*.ts'` → only `admit.ts`.
- `git grep -n 'as ValidatedAct'` → nothing.
- `git grep -nE 'sessionToolAction|issueToolAction|appToolAction|JsonSchemaProperty|REALTIME_TOOL_FAMILY|SESSION_TOOL_KIND|ISSUE_TOOL_KIND|APP_TOOL_KIND'` → only `legacy-validation.ts` and the two dual-run test files.
- `pnpm install && ./scripts/check.sh` from a clean `node_modules` proves `acts → runtime-contracts` left the graph acyclic.

Not a UI PR: no `verify.sh`, no fixture PNG, no notch check.

## Scope left to E5

The press intake in `registerSessionActsIpc` and the hosted `handleSessionAct` are **not** rewired to call `admit` in production here. Both would need a roster seam threaded from a composition root, and the hosted one would run a second observation pass per act until the six executors collapse into one — which is E5's own first commits. Their equivalence is proved by test in this PR instead, which is what the ⚠ convention asks for and what Decision 9 of the spec says: a production branch running two validators would be a third place the guarantee lives.

## Diff

```
git diff --shortstat origin/main...
 35 files changed, 4128 insertions(+), 2291 deletions(-)
```

Net **+1,837** lines against the ~125k target — `legacy-validation.ts` (1,093) and the dual-run scaffolding in the three test files are the whole of the overshoot and are deleted by E5, which also removes ~1,650 more source lines from the layers this PR makes redundant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34302585784/artifacts/10085499897) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34302585784)

- Commit: `38e31b7c73a89fdd82226aba22581fa46651ac9f`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
