### PR TITLE
test(desktop): shared fixtures

### DIFF
--- a/apps/desktop/src/main/brain/act-performer.test.ts
+++ b/apps/desktop/src/main/brain/act-performer.test.ts
@@ -21,6 +21,7 @@ import {
 } from "@sidecar/session";
 import { ACT_RESULT_STATUS } from "@sidecar/wire";
 import type { BrainAppActRequest } from "#shared/messages/brain";
+import { drainMicrotasks } from "#testing/drain";
 import { type BrainActPerformerDependencies, createBrainActPerformer } from "./act-performer";
 
 const NOW = 1_800_000_000_000;
@@ -235,7 +236,7 @@ test("two conversations remembering at once both land: each write is one whole r
       remember: async (ask) => {
         // The worker answers one request at a time; a beat's delay here shows
         // the performer never reads the list, computes, and writes it back.
-        await new Promise((resolve) => setImmediate(resolve));
+        await drainMicrotasks(1);
         facts = [...facts, { id: ask.id, words: ask.words }];
         return true;
       },
@@ -472,14 +473,14 @@ test("a cancel during the roster refresh or the defaults read settles the act, a
     void pending.then(() => {
       settled = true;
     });
-    await new Promise((resolve) => setImmediate(resolve));
+    await drainMicrotasks(1);
     assert.equal(settled, false);
     controller.abort();
     const outcome = await pending;
     assert.equal(outcome.status, ACT_RESULT_STATUS.REJECTED);
     assert.deepEqual(h.performed, []);
     release?.();
-    await new Promise((resolve) => setImmediate(resolve));
+    await drainMicrotasks(1);
     assert.deepEqual(h.performed, [], `${held}: the late read dispatched nothing`);
     assert.deepEqual(h.recorded, []);
   }

--- a/apps/desktop/src/main/brain/conversation-deletion.test.ts
+++ b/apps/desktop/src/main/brain/conversation-deletion.test.ts
@@ -1,9 +1,8 @@
 import assert from "node:assert/strict";
 import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
-import test from "node:test";
+import test, { type TestContext } from "node:test";
 import { MessageChannel } from "node:worker_threads";
 import zlib from "node:zlib";
 import {
@@ -40,6 +39,8 @@ import {
   serveRuntimeStore,
 } from "@sidecar/runtime-store";
 import { ACT_RESULT_STATUS, type WireRecord } from "@sidecar/wire";
+import { drainMicrotasks } from "#testing/drain";
+import { temporaryDirectory } from "#testing/temporary-directory";
 import { ConversationThread } from "../conversation-thread";
 import { operatorOverBrain } from "../gateway/testing";
 import {
@@ -97,10 +98,6 @@ function reply(text: string, ...before: WireRecord[]): ModelResponse {
   return answer;
 }
 
-async function settle(): Promise<void> {
-  for (let index = 0; index < 40; index += 1) await new Promise((resolve) => setImmediate(resolve));
-}
-
 /** The envelope repository as the store client builds it, with a switch that refuses writes. */
 function repository(client: RuntimeStoreClient) {
   const inner = client.brainStateRepository(MAIN_SESSION_KEY);
@@ -115,8 +112,8 @@ function repository(client: RuntimeStoreClient) {
   return repo;
 }
 
-function composed() {
-  const root = fs.mkdtempSync(path.join(os.tmpdir(), "luke-clear-"));
+function composed(t: TestContext) {
+  const root = temporaryDirectory(t, "luke-clear-");
   const channel = new MessageChannel();
   // SAFETY: a MessagePort posts and receives structured-clone values on the same events the port contract names.
   serveRuntimeStore(channel.port2 as unknown as RuntimeStorePort);
@@ -312,7 +309,6 @@ function composed() {
       await client.close();
       channel.port1.close();
       channel.port2.close();
-      fs.rmSync(root, { recursive: true, force: true });
     },
   };
 }
@@ -323,11 +319,11 @@ async function seeded(c: ReturnType<typeof composed>) {
   const client = heldClient();
   const agent = c.build(client);
   const first = await c.submit(agent, OLD_ASK);
-  await settle();
+  await drainMicrotasks(40);
   client.release(
     reply(OLD_REPLY, { type: "compaction", id: "cmp_1", encrypted_content: OLD_COMPACTION }),
   );
-  await settle();
+  await drainMicrotasks(40);
   assert.equal(agent.request(first)?.status, BRAIN_REQUEST_STATUS.SUCCEEDED);
   assert.ok(c.thread.entries().some((entry) => entry.words === OLD_REPLY));
   for (const word of [OLD_ASK, OLD_REPLY, OLD_COMPACTION]) assert.ok(c.rows().includes(word));
@@ -378,13 +374,13 @@ function assertNoneOf(words: readonly string[], surface: string): void {
 }
 
 test("a Clear under a held model answer fences the brain and the thread before any wait, keeps the line accepted after the press, archives what stood, and the next ask sees none of the old words", async (t) => {
-  const c = composed();
+  const c = composed(t);
   t.after(() => c.close());
   const { agent, client } = await seeded(c);
   // A second ask whose answer is still out when the press lands.
   c.tick();
   const late = await c.submit(agent, "second ask");
-  await settle();
+  await drainMicrotasks(40);
   const pressedAt = c.tick();
   const clearing = c.clear();
   // The fences are synchronous: the store already stands on the successor,
@@ -401,7 +397,7 @@ test("a Clear under a held model answer fences the brain and the thread before a
   );
   // The late answer lands on the fenced generation: recorded nowhere.
   client.release(reply(LATE_REPLY));
-  await settle();
+  await drainMicrotasks(40);
   assert.equal(await clearing, CONVERSATION_DELETE_OUTCOME.COMPLETE);
   // The late run went with its generation: revoked, and standing in no record.
   assert.equal(agent.request(late), undefined);
@@ -433,18 +429,18 @@ test("a Clear under a held model answer fences the brain and the thread before a
   assert.equal(content.includes(AFTER_WORDS), false);
   // The same agent works on from the successor: its next ask carries none of the old words.
   const next = await c.submit(agent, "what now");
-  await settle();
+  await drainMicrotasks(40);
   assertNoneOf(OLD_WORDS, client.inputs.at(-1) ?? "");
   assert.ok((client.inputs.at(-1) ?? "").includes(AFTER_WORDS));
   client.release(reply("fresh"));
-  await settle();
+  await drainMicrotasks(40);
   assert.equal(agent.request(next)?.status, BRAIN_REQUEST_STATUS.SUCCEEDED);
   assertNoneOf(OLD_WORDS, c.rows());
   await c.stop(agent);
 });
 
 test("a Clear whose rows the store will not remove answers refused, yet the old words reach no context, no window, and no later launch of the brain", async (t) => {
-  const c = composed();
+  const c = composed(t);
   t.after(() => c.close());
   const { agent, client } = await seeded(c);
   c.refuseErase(true);
@@ -463,23 +459,23 @@ test("a Clear whose rows the store will not remove answers refused, yet the old 
   // The same agent's next ask, and a rebuilt agent's — a credential change
   // landing now — both see none of the old words.
   await c.submit(agent, "again");
-  await settle();
+  await drainMicrotasks(40);
   assertNoneOf(OLD_WORDS, client.inputs.at(-1) ?? "");
   client.release(reply("ok"));
-  await settle();
+  await drainMicrotasks(40);
   await c.stop(agent);
   const rebuiltClient = heldClient();
   const rebuilt = c.build(rebuiltClient);
   await c.submit(rebuilt, "after a rebuild");
-  await settle();
+  await drainMicrotasks(40);
   assertNoneOf(OLD_WORDS, rebuiltClient.inputs.at(-1) ?? "");
   rebuiltClient.release(reply("ok"));
-  await settle();
+  await drainMicrotasks(40);
   await c.stop(rebuilt);
 });
 
 test("a Clear whose marker the disk refuses answers refused without touching the rows, and still fences every context; the next landed write replaces what the disk kept", async (t) => {
-  const c = composed();
+  const c = composed(t);
   t.after(() => c.close());
   const { agent, client } = await seeded(c);
   c.repo.refuse = true;
@@ -495,10 +491,10 @@ test("a Clear whose marker the disk refuses answers refused without touching the
   assert.deepEqual(c.thread.entries(), []);
   c.repo.refuse = false;
   const next = await c.submit(agent, "again");
-  await settle();
+  await drainMicrotasks(40);
   assertNoneOf(OLD_WORDS, client.inputs.at(-1) ?? "");
   client.release(reply("ok"));
-  await settle();
+  await drainMicrotasks(40);
   assert.equal(agent.request(next)?.status, BRAIN_REQUEST_STATUS.SUCCEEDED);
   // The acceptance's write replaced the old generation on disk with the marker successor.
   assert.equal(c.standing()?.reset_cleared_at, pressedAt);
@@ -507,7 +503,7 @@ test("a Clear whose marker the disk refuses answers refused without touching the
 });
 
 test("a credential rebuild landing while the deletion waits on the disk builds over the successor, never the old checkpoint, and a second Clear during the first is harmless", async (t) => {
-  const c = composed();
+  const c = composed(t);
   t.after(() => c.close());
   const { agent, client } = await seeded(c);
   await c.stop(agent);
@@ -519,10 +515,10 @@ test("a credential rebuild landing while the deletion waits on the disk builds o
   const rebuilt = c.build(rebuiltClient);
   await rebuilt.ready();
   await c.submit(rebuilt, "during the wait");
-  await settle();
+  await drainMicrotasks(40);
   assertNoneOf(OLD_WORDS, rebuiltClient.inputs.at(-1) ?? "");
   rebuiltClient.release(reply("ok"));
-  await settle();
+  await drainMicrotasks(40);
   // A second press while the first still waits: another fence, no harm.
   c.tick();
   const second = c.clear();
@@ -536,7 +532,7 @@ test("a credential rebuild landing while the deletion waits on the disk builds o
 });
 
 test("a Clear whose marker the disk refused, followed by a Clear that lands, archives the lines still on disk under the cutoff the disk held before the press, never the refused press's own fence", async (t) => {
-  const c = composed();
+  const c = composed(t);
   t.after(() => c.close());
   const { agent } = await seeded(c);
   await c.stop(agent);

--- a/apps/desktop/src/main/brain/host-lifecycle.test.ts
+++ b/apps/desktop/src/main/brain/host-lifecycle.test.ts
@@ -3,280 +3,33 @@ import test from "node:test";
 import {
   BRAIN_REQUEST_ORIGIN,
   BRAIN_REQUEST_STATUS,
-  BrainAgent,
-  type BrainAgentOptions,
   type BrainRequestRecord,
-  type BrainStateStorage,
-  BrainStateStore,
   brainStateFromStored,
-  responsesModelAnswer,
 } from "@sidecar/brain";
-import { brainReplyWords, isTerminalBrainRequestStatus } from "@sidecar/brain/requests";
+import { brainReplyWords } from "@sidecar/brain/requests";
+import { CONVERSATION_ENTRY_KIND } from "@sidecar/realtime";
+import { QUEUE_MODE } from "@sidecar/runtime";
 import {
-  type BareResponsesModel,
-  bareModelAdapter,
-  toolLoopRuntimeOver,
-} from "@sidecar/brain/testing";
-import {
-  appendConversationThreadEntry,
-  CONVERSATION_ENTRY_KIND,
-  type ConversationEntry,
-} from "@sidecar/realtime";
-import { DeliveryLedger, type DeliveryRecord, QUEUE_MODE } from "@sidecar/runtime";
-import { DELIVERY_STATE, type ModelResponse } from "@sidecar/runtime-contracts";
-import { ACT_RESULT_STATUS, type WireRecord } from "@sidecar/wire";
-import type {
-  BrainReplyClaimResult,
-  BrainReplyOffer,
-  BrainRequestSnapshot,
-} from "#shared/messages/brain";
-import { deliverable, type GrantedWords, ledgerContext } from "../gateway/service";
-import { operatorOverBrain } from "../gateway/testing";
-import { VoiceReceiver } from "../voice-receiver";
-import { BrainHost } from "./host";
-import { followBrainRequests } from "./ipc";
-
-/**
- * The real agent, store, host, follower, and submission path composed as the
- * main process composes them, with only the model and the disk synthetic.
- */
-
-const NOW = 1_800_000_000_000;
-
-class MemoryStorage implements BrainStateStorage {
-  file: string | undefined;
-  read() {
-    return this.file;
-  }
-  write(contents: string) {
-    this.file = contents;
-    return true;
-  }
-}
-
-/** A model that answers nothing until the test says so. */
-function heldClient(): BareResponsesModel & { release: (answer: ModelResponse) => void } {
-  const waiting: ((answer: ModelResponse) => void)[] = [];
-  return {
-    respond: () =>
-      new Promise((resolve) => {
-        waiting.push(resolve);
-      }),
-    quietUntil: () => undefined,
-    release: (answer) => {
-      for (const resolve of waiting.splice(0)) resolve(answer);
-    },
-  };
-}
-
-function settle(): Promise<void> {
-  return new Promise((resolve) => {
-    let ticks = 0;
-    const tick = () => {
-      ticks += 1;
-      if (ticks > 30) resolve();
-      else setImmediate(tick);
-    };
-    tick();
-  });
-}
-
-function composed() {
-  const storage = new MemoryStorage();
-  let ids = 0;
-  const store = new BrainStateStore({
-    storage,
-    createGenerationId: () => `gen-${++ids}`,
-    now: () => NOW,
-  });
-  let thread: readonly ConversationEntry[] = [];
-  let refuseWrites = false;
-  const broadcasts: (readonly BrainRequestSnapshot[])[] = [];
-  const record = (entry: ConversationEntry, at: number) => {
-    if (refuseWrites) return false;
-    thread = appendConversationThreadEntry(thread, entry, NOW + 1000, at);
-    return true;
-  };
-  // The delivery owner and the receiver, composed as desktop-app composes
-  // them: every report is observed before it is broadcast, every published
-  // end is offered to a ready receiver, and readiness flushes what waited.
-  const deliveries = new DeliveryLedger<GrantedWords>({
-    nextDeliveryId: () => `delivery-${++ids}`,
-  });
-  const receiver = new VoiceReceiver();
-  const offers: BrainReplyOffer[] = [];
-  const offerReplies = () => {
-    if (!receiver.isReady()) return;
-    const offer = deliveries.nextOffer(receiver.epoch());
-    if (offer) offers.push(offer);
-  };
-  receiver.onReady(offerReplies);
-  store.onReplaced(() => deliveries.reset());
-  const host = new BrainHost({
-    follow: (agent) =>
-      followBrainRequests(agent, {
-        recordConversationEntry: record,
-        broadcastRequests: (snapshots) => {
-          deliveries.observe(
-            snapshots.map((snapshot) => ({
-              runId: snapshot.runId,
-              ended: isTerminalBrainRequestStatus(snapshot.status),
-            })),
-          );
-          broadcasts.push(snapshots);
-        },
-        onEndPublished: (ended) => {
-          const generationId = store.generationId();
-          if (generationId !== undefined && deliverable(ended)) {
-            deliveries.published(ended.runId, generationId);
-          }
-          offerReplies();
-        },
-      }),
-    publishEmpty: () => broadcasts.push([]),
-  });
-  /** Submits as a window does, through the operator over the standing brain; the ask's own line is written here. */
-  const { submit } = operatorOverBrain({
-    current: () => host.current(),
-    recordConversationEntry: record,
-  });
-  const claimContext = () => ({
-    receiverCurrent: (epoch: number) => receiver.isReady() && receiver.epoch() === epoch,
-    generationStands: (generationId: string) => store.holdsGeneration(generationId),
-    liveRecord: (runId: string) => host.current()?.request(runId),
-  });
-  const claim = (offer: BrainReplyOffer): BrainReplyClaimResult => {
-    const granted = deliveries.claim(
-      offer.runId,
-      offer.deliveryId,
-      offer.epoch,
-      ledgerContext(claimContext()),
-    );
-    return granted.granted
-      ? { granted: true, words: granted.words.words, origin: granted.words.origin }
-      : { granted: false };
-  };
-  /** Queued or offered: everything owed that no receiver has taken in hand. */
-  const unclaimed = (): readonly DeliveryRecord[] =>
-    deliveries
-      .records()
-      .filter(
-        (delivery) =>
-          delivery.state === DELIVERY_STATE.QUEUED || delivery.state === DELIVERY_STATE.OFFERED,
-      );
-  const acknowledge = (offer: BrainReplyOffer) => {
-    const emptied = deliveries.acknowledge(offer.runId, offer.deliveryId, offer.epoch);
-    if (emptied) offerReplies();
-    return emptied;
-  };
-  /** The wait as main's IPC answers it: publication let finish, live record re-read, the call granted or not. */
-  const waitOnCall = async (runId: string, epoch: number, timeoutMs = 1) => {
-    const agent = host.current();
-    const waited = await agent?.waitAsk(runId, timeoutMs);
-    if (!waited || !isTerminalBrainRequestStatus(waited.status))
-      return { record: waited, speak: false };
-    await settle();
-    const live = agent?.request(runId) ?? waited;
-    if (live.historyRecordedAt === undefined) return { record: live, speak: false };
-    const generationId = store.generationId() ?? "";
-    const speak =
-      deliverable(live) &&
-      deliveries.grantOnCall(live.runId, generationId, epoch, ledgerContext(claimContext()));
-    if (speak) offerReplies();
-    return { record: live, speak };
-  };
-  const build = (client: BareResponsesModel, options: Partial<BrainAgentOptions> = {}) => {
-    const model = bareModelAdapter(client);
-    return new BrainAgent({
-      ...options,
-      runtime: toolLoopRuntimeOver(model),
-      prepareTurn: () => ({ prompt: "instructions", layers: {} }),
-      acts: { perform: async () => ({ status: ACT_RESULT_STATUS.ACCEPTED }) },
-      roster: () => ({ text: "", identities: [] }),
-      standingContext: () => "",
-      readTranscriptSince: async () => ({ status: ACT_RESULT_STATUS.REJECTED, reason: "no" }),
-      readTranscript: async () => ({ status: ACT_RESULT_STATUS.REJECTED, reason: "no" }),
-      deliver: () => undefined,
-      store,
-      createRunId: () => `run-${++ids}`,
-      report: () => {},
-      now: () => NOW,
-      // A run left in flight at a test's end must not hold the process open:
-      // its deadline timers are unreferenced, as the test's own would be.
-      schedule: (callback, delayMs) => {
-        const timer = setTimeout(callback, delayMs);
-        timer.unref();
-        return timer;
-      },
-      // SAFETY: the handle is what `schedule` above returned, which is always a `setTimeout` timer.
-      cancel: (timer) => clearTimeout(timer as ReturnType<typeof setTimeout>),
-    });
-  };
-  return {
-    storage,
-    store,
-    host,
-    build,
-    record,
-    submit,
-    thread: () => thread,
-    broadcasts,
-    deliveries,
-    unclaimed,
-    receiver,
-    offers,
-    claim,
-    acknowledge,
-    waitOnCall,
-    refuse: (value: boolean) => {
-      refuseWrites = value;
-    },
-  };
-}
-
-/** A raw Responses payload as the adapter would normalize it. */
-function answerOf(payload: WireRecord): ModelResponse {
-  const answer = responsesModelAnswer(payload);
-  assert.ok(answer);
-  return answer;
-}
-
-function answered(text: string): ModelResponse {
-  return answerOf({
-    output: [{ type: "message", role: "assistant", content: [{ type: "output_text", text }] }],
-  });
-}
-
-function replies(thread: readonly ConversationEntry[], runId: string) {
-  return thread.filter((e) => e.kind === CONVERSATION_ENTRY_KIND.REPLY && e.requestId === runId);
-}
-
-async function submitMany(submit: ReturnType<typeof composed>["submit"], count: number) {
-  const runIds: string[] = [];
-  for (let index = 0; index < count; index += 1) {
-    const result = await submit({
-      submissionId: `sub-${index}`,
-      question: `ask ${index}`,
-      origin: BRAIN_REQUEST_ORIGIN.TYPED,
-    });
-    assert.equal(result.outcome, "accepted");
-    if (result.outcome === "accepted") runIds.push(result.runId);
-  }
-  return runIds;
-}
+  answered,
+  answerOf,
+  brainHarness,
+  heldModel,
+  BRAIN_HARNESS_NOW as NOW,
+} from "#testing/brain-harness";
+import { drainMicrotasks } from "#testing/drain";
 
 test("removing the capability under five outstanding runs leaves every run interrupted, published, and marked", async () => {
-  const c = composed();
-  const client = heldClient();
+  const c = brainHarness();
+  const client = heldModel();
   await c.host.replace(() => c.build(client));
   const agent = c.host.current();
   assert.ok(agent);
-  const runIds = await submitMany(c.submit, 5);
-  await settle();
+  const runIds = await c.submitMany(5);
+  await drainMicrotasks();
   assert.equal(c.thread().filter((e) => e.kind === CONVERSATION_ENTRY_KIND.TYPED_ASK).length, 5);
 
   await c.host.replace(() => undefined);
-  await settle();
+  await drainMicrotasks();
   assert.equal(c.host.current(), undefined);
   const stored = brainStateFromStored(c.storage.file);
   assert.equal(stored?.requests.length, 5);
@@ -303,7 +56,7 @@ test("removing the capability under five outstanding runs leaves every run inter
       ],
     }),
   );
-  await settle();
+  await drainMicrotasks();
   assert.equal(c.thread().filter((e) => e.words === "late").length, 0);
   assert.equal(
     brainStateFromStored(c.storage.file)?.requests.every(
@@ -314,19 +67,19 @@ test("removing the capability under five outstanding runs leaves every run inter
 });
 
 test("a successor replacing the agent under outstanding runs inherits a thread with every end written, and owns the store alone", async () => {
-  const c = composed();
-  const first = heldClient();
+  const c = brainHarness();
+  const first = heldModel();
   await c.host.replace(() => c.build(first));
   const agent = c.host.current();
   assert.ok(agent);
-  const runIds = await submitMany(c.submit, 5);
+  const runIds = await c.submitMany(5);
   // An earlier publication is held: the thread refuses until the handoff.
   c.refuse(true);
-  await settle();
+  await drainMicrotasks();
   c.refuse(false);
-  const second = heldClient();
+  const second = heldModel();
   await c.host.replace(() => c.build(second));
-  await settle();
+  await drainMicrotasks();
   const successor = c.host.current();
   assert.ok(successor && successor !== agent);
   for (const runId of runIds) {
@@ -346,7 +99,7 @@ test("a successor replacing the agent under outstanding runs inherits a thread w
   assert.equal(result.outcome, "accepted");
   // The host reaches its first inference only after the run's own
   // bookkeeping; the answer is released once the model has been asked.
-  await settle();
+  await drainMicrotasks();
   second.release(
     answerOf({
       output: [
@@ -354,7 +107,7 @@ test("a successor replacing the agent under outstanding runs inherits a thread w
       ],
     }),
   );
-  await settle();
+  await drainMicrotasks();
   const fresh = brainStateFromStored(c.storage.file)?.requests.find(
     (r) => r.question === "new ask",
   );
@@ -377,15 +130,15 @@ test("a successor replacing the agent under outstanding runs inherits a thread w
 });
 
 test("a reset under outstanding runs discards them without publishing, and the successor starts clean", async () => {
-  const c = composed();
-  const client = heldClient();
+  const c = brainHarness();
+  const client = heldModel();
   await c.host.replace(() => c.build(client));
   const agent = c.host.current();
   assert.ok(agent);
-  await submitMany(c.submit, 3);
-  await settle();
+  await c.submitMany(3);
+  await drainMicrotasks();
   assert.equal(await c.store.clear(), true);
-  await settle();
+  await drainMicrotasks();
   assert.deepEqual(agent.requests(), []);
   assert.equal(c.thread().filter((e) => e.kind === CONVERSATION_ENTRY_KIND.REPLY).length, 0);
   // The file holds the empty successor and the marker of the erasure alone.
@@ -393,19 +146,19 @@ test("a reset under outstanding runs discards them without publishing, and the s
   assert.equal(stored?.requests.length, 0);
   assert.equal(stored?.reset?.generationId, "gen-1");
   await c.host.replace(() => undefined);
-  await settle();
+  await drainMicrotasks();
   assert.equal(c.thread().filter((e) => e.kind === CONVERSATION_ENTRY_KIND.REPLY).length, 0);
 });
 
 test("a run ending long after its wait is offered once, to a ready receiver, only after its line and mark landed", async () => {
-  const c = composed();
-  const client = heldClient();
+  const c = brainHarness();
+  const client = heldModel();
   await c.host.replace(() => c.build(client));
   const agent = c.host.current();
   assert.ok(agent);
   const epoch = c.receiver.begin();
   c.receiver.markReady(epoch);
-  const [runId] = await submitMany(c.submit, 1);
+  const [runId] = await c.submitMany(1);
   assert.ok(runId);
   // The wait comes back pending — the ask outlived its thirty seconds — and
   // the developer's call is released with no grant. Nothing is owed yet.
@@ -416,8 +169,8 @@ test("a run ending long after its wait is offered once, to a ready receiver, onl
   // marked, and the reply waits for a receiver rather than landing on none.
   c.receiver.reset();
   client.release(answered("Two agents are waiting."));
-  await settle();
-  assert.equal(replies(c.thread(), runId).length, 1);
+  await drainMicrotasks();
+  assert.equal(c.replies(runId).length, 1);
   assert.equal(c.unclaimed().length, 1);
   assert.equal(c.offers.length, 0);
   // Readiness flushes it, exactly once, under the epoch that reported.
@@ -432,18 +185,18 @@ test("a run ending long after its wait is offered once, to a ready receiver, onl
     words: "Two agents are waiting.",
     origin: BRAIN_REQUEST_ORIGIN.TYPED,
   });
-  assert.equal(replies(c.thread(), runId)[0]?.words, "Two agents are waiting.");
+  assert.equal(c.replies(runId)[0]?.words, "Two agents are waiting.");
   // A duplicate claim, a repeated readiness, and a later report add nothing.
   assert.deepEqual(c.claim(offer), { granted: false });
   c.receiver.markReady(next);
-  await settle();
+  await drainMicrotasks();
   assert.equal(c.offers.length, 1);
-  assert.equal(replies(c.thread(), runId).length, 1);
+  assert.equal(c.replies(runId).length, 1);
 });
 
 test("a refused History write keeps the reply unoffered and ungranted until the write recovers, then it is offered once", async () => {
-  const c = composed();
-  const client = heldClient();
+  const c = brainHarness();
+  const client = heldModel();
   await c.host.replace(() => c.build(client));
   const agent = c.host.current();
   assert.ok(agent);
@@ -456,10 +209,10 @@ test("a refused History write keeps the reply unoffered and ungranted until the 
   });
   assert.equal(spoken.outcome, "accepted");
   if (spoken.outcome !== "accepted") return;
-  await settle();
+  await drainMicrotasks();
   c.refuse(true);
   client.release(answered("Done."));
-  await settle();
+  await drainMicrotasks();
   // Ended, but the thread refused the line: unmarked, not offered, and the
   // asking call is not granted the words either — nothing is said before
   // History holds it.
@@ -472,11 +225,11 @@ test("a refused History write keeps the reply unoffered and ungranted until the 
   // until the records next change — another ask accepted — and that report
   // writes the line, marks the run, and only then offers it, once.
   c.refuse(false);
-  await settle();
+  await drainMicrotasks();
   assert.equal(c.offers.length, 0);
-  await submitMany(c.submit, 1);
-  await settle();
-  assert.equal(replies(c.thread(), spoken.runId).length, 1);
+  await c.submitMany(1);
+  await drainMicrotasks();
+  assert.equal(c.replies(spoken.runId).length, 1);
   assert.deepEqual(
     c.offers.map((offer) => offer.runId),
     [spoken.runId],
@@ -492,18 +245,18 @@ test("a refused History write keeps the reply unoffered and ungranted until the 
 });
 
 test("two completions flushed together are offered one at a time, the second only after the first is acknowledged", async () => {
-  const c = composed();
-  const client = heldClient();
+  const c = brainHarness();
+  const client = heldModel();
   // Follow-up mode: two asks are two runs with two completions, where steer would answer both in one.
   await c.host.replace(() => c.build(client, { queueMode: QUEUE_MODE.FOLLOWUP }));
   const agent = c.host.current();
   assert.ok(agent);
-  const [runA, runB] = await submitMany(c.submit, 2);
+  const [runA, runB] = await c.submitMany(2);
   assert.ok(runA && runB);
   client.release(answered("Answer."));
-  await settle();
+  await drainMicrotasks();
   client.release(answered("Answer."));
-  await settle();
+  await drainMicrotasks();
   // Both ended with no receiver; readiness offers the oldest alone.
   const epoch = c.receiver.begin();
   c.receiver.markReady(epoch);
@@ -527,19 +280,19 @@ test("two completions flushed together are offered one at a time, the second onl
 });
 
 test("an offer the renderer never claimed is offered again to the next epoch; a claimed one is not, and old-epoch claims are refused", async () => {
-  const c = composed();
-  const client = heldClient();
+  const c = brainHarness();
+  const client = heldModel();
   await c.host.replace(() => c.build(client, { queueMode: QUEUE_MODE.FOLLOWUP }));
   const agent = c.host.current();
   assert.ok(agent);
   const first = c.receiver.begin();
   c.receiver.markReady(first);
-  const [runA, runB] = await submitMany(c.submit, 2);
+  const [runA, runB] = await c.submitMany(2);
   assert.ok(runA && runB);
   client.release(answered("Answer."));
-  await settle();
+  await drainMicrotasks();
   client.release(answered("Answer."));
-  await settle();
+  await drainMicrotasks();
   // A is offered and claimed; its renderer dies before the reply ends.
   const offerA = c.offers[0];
   assert.ok(offerA && offerA.runId === runA);
@@ -560,23 +313,23 @@ test("an offer the renderer never claimed is offered again to the next epoch; a 
   // refused even though the delivery ids match; the current epoch's is granted.
   assert.deepEqual(c.claim(offerB), { granted: false });
   assert.equal(c.claim(again).granted, true);
-  assert.equal(replies(c.thread(), runA).length, 1);
-  assert.equal(replies(c.thread(), runB).length, 1);
+  assert.equal(c.replies(runA).length, 1);
+  assert.equal(c.replies(runB).length, 1);
 });
 
 test("a Clear invalidates every delivery: an unclaimed offer is refused, a late acknowledgement is ignored, nothing is offered again", async () => {
-  const c = composed();
-  const client = heldClient();
+  const c = brainHarness();
+  const client = heldModel();
   await c.host.replace(() => c.build(client));
   const agent = c.host.current();
   assert.ok(agent);
   const epoch = c.receiver.begin();
   c.receiver.markReady(epoch);
-  const [runId] = await submitMany(c.submit, 1);
+  const [runId] = await c.submitMany(1);
   assert.ok(runId);
-  await settle();
+  await drainMicrotasks();
   client.release(answered("Before the clear."));
-  await settle();
+  await drainMicrotasks();
   assert.equal(c.offers.length, 1);
   const offer = c.offers[0];
   assert.ok(offer);
@@ -585,7 +338,7 @@ test("a Clear invalidates every delivery: an unclaimed offer is refused, a late 
   assert.deepEqual(c.claim(offer), { granted: false });
   assert.deepEqual(c.unclaimed(), []);
   await cleared;
-  await settle();
+  await drainMicrotasks();
   assert.equal(c.acknowledge(offer), false);
   // A new renderer reporting ready is offered nothing of the erased generation.
   c.receiver.reset();
@@ -594,21 +347,21 @@ test("a Clear invalidates every delivery: an unclaimed offer is refused, a late 
 });
 
 test("a launch that finds ended runs restores their words and speaks none of them", async () => {
-  const c = composed();
-  const client = heldClient();
+  const c = brainHarness();
+  const client = heldModel();
   await c.host.replace(() => c.build(client));
   const agent = c.host.current();
   assert.ok(agent);
-  await submitMany(c.submit, 2);
+  await c.submitMany(2);
   await c.host.replace(() => undefined);
-  await settle();
+  await drainMicrotasks();
   assert.equal(c.thread().filter((e) => e.kind === CONVERSATION_ENTRY_KIND.REPLY).length, 2);
   // The next launch: a fresh delivery owner, a fresh receiver, the same file.
-  const next = composed();
+  const next = brainHarness();
   next.storage.file = c.storage.file;
   next.receiver.markReady(next.receiver.begin());
-  await next.host.replace(() => next.build(heldClient()));
-  await settle();
+  await next.host.replace(() => next.build(heldModel()));
+  await drainMicrotasks();
   assert.equal(next.host.current()?.requests().length, 2);
   assert.equal(next.offers.length, 0);
   assert.deepEqual(next.thread(), []);
@@ -622,8 +375,8 @@ test("a launch that finds ended runs restores their words and speaks none of the
 test("a spoken ask's end is authorized exactly once across the call that asked and the offer path, whichever comes first", async () => {
   // Publication before the wait: the run ended, was written, marked, and
   // offered before the asking call's wait ever reached main.
-  const c = composed();
-  const client = heldClient();
+  const c = brainHarness();
+  const client = heldModel();
   await c.host.replace(() => c.build(client));
   const agent = c.host.current();
   assert.ok(agent);
@@ -636,9 +389,9 @@ test("a spoken ask's end is authorized exactly once across the call that asked a
   });
   assert.equal(spoken.outcome, "accepted");
   if (spoken.outcome !== "accepted") return;
-  await settle();
+  await drainMicrotasks();
   client.release(answered("Both are waiting."));
-  await settle();
+  await drainMicrotasks();
   assert.equal(c.offers.length, 1);
   const offer = c.offers[0];
   assert.ok(offer);
@@ -648,7 +401,7 @@ test("a spoken ask's end is authorized exactly once across the call that asked a
   assert.equal(waited.speak, true);
   assert.deepEqual(c.claim(offer), { granted: false });
   assert.equal(c.unclaimed().length, 0);
-  assert.equal(replies(c.thread(), spoken.runId).length, 1);
+  assert.equal(c.replies(spoken.runId).length, 1);
 
   // The reverse order: the offer is claimed first, and the wait is refused.
   const second = await c.submit({
@@ -658,9 +411,9 @@ test("a spoken ask's end is authorized exactly once across the call that asked a
   });
   assert.equal(second.outcome, "accepted");
   if (second.outcome !== "accepted") return;
-  await settle();
+  await drainMicrotasks();
   client.release(answered("Still waiting."));
-  await settle();
+  await drainMicrotasks();
   const secondOffer = c.offers[1];
   assert.ok(secondOffer && secondOffer.runId === second.runId);
   assert.equal(c.claim(secondOffer).granted, true);
@@ -678,9 +431,9 @@ test("a spoken ask's end is authorized exactly once across the call that asked a
   assert.equal(third.outcome, "accepted");
   if (third.outcome !== "accepted") return;
   c.acknowledge(secondOffer);
-  await settle();
+  await drainMicrotasks();
   client.release(answered("Later."));
-  await settle();
+  await drainMicrotasks();
   const staleWait = await c.waitOnCall(third.runId, epoch - 1);
   assert.equal(staleWait.speak, false);
   const thirdOffer = c.offers[2];
@@ -691,8 +444,8 @@ test("a spoken ask's end is authorized exactly once across the call that asked a
 });
 
 test("an on-call grant that takes the offered run out of the receiver's hand offers the next owed reply at once", async () => {
-  const c = composed();
-  const client = heldClient();
+  const c = brainHarness();
+  const client = heldModel();
   await c.host.replace(() => c.build(client));
   const agent = c.host.current();
   assert.ok(agent);
@@ -708,14 +461,14 @@ test("an on-call grant that takes the offered run out of the receiver's hand off
   });
   assert.equal(spoken.outcome, "accepted");
   if (spoken.outcome !== "accepted") return;
-  await settle();
+  await drainMicrotasks();
   client.release(answered("A."));
-  await settle();
-  const [typed] = await submitMany(c.submit, 1);
+  await drainMicrotasks();
+  const [typed] = await c.submitMany(1);
   assert.ok(typed);
-  await settle();
+  await drainMicrotasks();
   client.release(answered("B."));
-  await settle();
+  await drainMicrotasks();
   assert.deepEqual(
     c.offers.map((offer) => offer.runId),
     [spoken.runId],

--- a/apps/desktop/src/main/brain/host-retention.test.ts
+++ b/apps/desktop/src/main/brain/host-retention.test.ts
@@ -3,12 +3,12 @@ import test from "node:test";
 import {
   BRAIN_GENERATION_LIFETIME_MS,
   BrainGenerationClock,
-  type BrainStateStorage,
   BrainStateStore,
   brainStateRecord,
   freshBrainState,
 } from "@sidecar/brain";
-import type { ScheduledTimer } from "@sidecar/realtime";
+import { MemoryBrainStorage, BRAIN_HARNESS_NOW as NOW } from "#testing/brain-harness";
+import { FakeClock } from "#testing/fake-clock";
 
 /**
  * Retention as the main process owns it: the store and its clock stand from
@@ -17,59 +17,9 @@ import type { ScheduledTimer } from "@sidecar/realtime";
  * past its stamped deadline, and the clock arms nothing.
  */
 
-const NOW = 1_800_000_000_000;
 const EXPIRED_SECRET = "EXPIRED_SECRET_MARKER";
 
-class MemoryStorage implements BrainStateStorage {
-  file: string | undefined;
-  read() {
-    return this.file;
-  }
-  write(contents: string) {
-    this.file = contents;
-    return true;
-  }
-}
-
-class FakeClock {
-  now = NOW;
-  readonly timers = new Map<ScheduledTimer, { callback: () => void; at: number }>();
-  schedule = (callback: () => void, delayMs: number): ScheduledTimer => {
-    const handle: ScheduledTimer = {};
-    this.timers.set(handle, { callback, at: this.now + delayMs });
-    return handle;
-  };
-  cancel = (timer: ScheduledTimer): void => {
-    this.timers.delete(timer);
-  };
-  async advance(untilMs: number): Promise<void> {
-    for (;;) {
-      const due = [...this.timers.entries()]
-        .filter(([, timer]) => timer.at <= untilMs)
-        .sort((a, b) => a[1].at - b[1].at)[0];
-      if (!due) break;
-      this.timers.delete(due[0]);
-      this.now = Math.max(this.now, due[1].at);
-      due[1].callback();
-      await settle();
-    }
-    this.now = Math.max(this.now, untilMs);
-  }
-}
-
-function settle(): Promise<void> {
-  return new Promise((resolve) => {
-    let ticks = 0;
-    const tick = () => {
-      ticks += 1;
-      if (ticks > 20) resolve();
-      else setImmediate(tick);
-    };
-    tick();
-  });
-}
-
-function launch(storage: MemoryStorage, clock: FakeClock) {
+function launch(storage: MemoryBrainStorage, clock: FakeClock) {
   const reports: string[] = [];
   let generations = 0;
   const store = new BrainStateStore({
@@ -89,7 +39,7 @@ function launch(storage: MemoryStorage, clock: FakeClock) {
 }
 
 test("a launch under the default policy keeps a checkpoint past its stamped deadline and arms no clock", async () => {
-  const storage = new MemoryStorage();
+  const storage = new MemoryBrainStorage();
   const stale = {
     ...freshBrainState("gen-old", NOW - BRAIN_GENERATION_LIFETIME_MS - 1),
     items: [{ type: "message", role: "user", content: EXPIRED_SECRET }],

--- a/apps/desktop/src/main/brain/host.test.ts
+++ b/apps/desktop/src/main/brain/host.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import type { BrainAgent } from "@sidecar/brain";
+import { drainMicrotasks } from "#testing/drain";
 import { BrainHost } from "./host";
 
 /** An agent whose stop the test releases, recording the order things happened in. */
@@ -67,7 +68,7 @@ test("overlapping transitions install only the latest agent, once every earlier 
     return c.agent;
   });
   assert.equal(brains.current(), undefined);
-  await new Promise((resolve) => setImmediate(resolve));
+  await drainMicrotasks(1);
   assert.ok(!log.includes("build b") && !log.includes("build c"));
   a.release();
   await Promise.all([second, third]);

--- a/apps/desktop/src/main/brain/ipc.test.ts
+++ b/apps/desktop/src/main/brain/ipc.test.ts
@@ -20,6 +20,7 @@ import { GATEWAY_CLIENT_ROLE, GATEWAY_EVENT, MAIN_SESSION_KEY } from "@sidecar/r
 import type { IpcMainEvent, IpcMainInvokeEvent, WebContents } from "electron";
 import { BRIDGE } from "#shared/bridge";
 import type { BrainAskWait, BrainReplyClaimResult } from "#shared/messages/brain";
+import { drainMicrotasks } from "#testing/drain";
 import type { ConversationOperations } from "../conversation-operations";
 import { createGatewayOperator } from "../gateway/operator";
 import { createGatewayService, type GrantedWords } from "../gateway/service";
@@ -223,7 +224,7 @@ test("a retired follower stops between two records, and the second waits for a l
   };
   let following = true;
   const publishing = publishRuns(agent, live, written.record, () => following);
-  await new Promise((resolve) => setImmediate(resolve));
+  await drainMicrotasks(1);
   assert.deepEqual(marked, ["run-1"]);
   following = false;
   holdMark?.();
@@ -369,15 +370,15 @@ test("following a brain relays every report, writes and marks the ended runs, an
     recordConversationEntry: written.record,
     broadcastRequests: (snapshots) => broadcasts.push(snapshots),
   });
-  await new Promise((resolve) => setImmediate(resolve));
-  await new Promise((resolve) => setImmediate(resolve));
+  await drainMicrotasks(1);
+  await drainMicrotasks(1);
   // The launch's interrupted run is written and relayed once it is read.
   assert.equal(broadcasts.length, 1);
   assert.equal(written.entries()[0]?.words, "That ask was interrupted before I could finish it.");
   assert.deepEqual(marked, ["run-1"]);
   listener?.([{ ...ready, historyRecordedAt: NOW + 2 }, record({ runId: "run-2" })]);
-  await new Promise((resolve) => setImmediate(resolve));
-  await new Promise((resolve) => setImmediate(resolve));
+  await drainMicrotasks(1);
+  await drainMicrotasks(1);
   assert.equal(broadcasts.length, 2);
   assert.equal(written.entries().length, 2);
   unfollow();
@@ -411,7 +412,7 @@ test("a retired follower relays nothing a late report carries", async () => {
   unfollow();
   releaseReady?.();
   listener?.([record()]);
-  await new Promise((resolve) => setImmediate(resolve));
+  await drainMicrotasks(1);
   assert.deepEqual(broadcasts, []);
   assert.deepEqual(written.recorded, []);
 });
@@ -602,7 +603,7 @@ function registered(live: () => BrainRequestRecord | undefined) {
     const before = deliveries.records().length;
     // SAFETY: the bridge reads only the sender off the event.
     sends.get(BRIDGE.ackBrainReply.channel)?.({ sender } as IpcMainEvent, runId, deliveryId, epoch);
-    await new Promise((resolve) => setImmediate(resolve));
+    await drainMicrotasks(1);
     if (deliveries.records().length < before) acknowledged.push(runId);
   };
   return {

--- a/apps/desktop/src/main/brain/wiring-children.test.ts
+++ b/apps/desktop/src/main/brain/wiring-children.test.ts
@@ -1,14 +1,10 @@
 import assert from "node:assert/strict";
-import fs from "node:fs";
-import os from "node:os";
-import path from "node:path";
-import test from "node:test";
+import test, { type TestContext } from "node:test";
 import {
   BRAIN_INPUT_MARKER,
   BRAIN_REQUEST_ORIGIN,
   BRAIN_SUBMISSION_OUTCOME,
   BRAIN_TOOL,
-  type BrainStateStorage,
   brainStateRepositoryFromStorage,
   type ResponsesInputItem,
   responsesModelAnswer,
@@ -17,7 +13,7 @@ import { type BareResponsesModel, bareModelAdapter } from "@sidecar/brain/testin
 import { RESPONSES_INPUT_ITEM_TYPE } from "@sidecar/hosted";
 import { MEMORY_HOUSEKEEPING_OUTCOME } from "@sidecar/memory";
 import type { ConversationEntry } from "@sidecar/realtime";
-import { type ChildStore, CREDENTIAL_REFERENCE_KIND, type ScheduledTimer } from "@sidecar/runtime";
+import { type ChildStore, CREDENTIAL_REFERENCE_KIND } from "@sidecar/runtime";
 import {
   CHILD_CONTEXT_MODE,
   CHILD_RUN_STATUS,
@@ -31,6 +27,10 @@ import {
   type SessionKey,
 } from "@sidecar/runtime-contracts";
 import { ACT_RESULT_STATUS, isRecord, isWireString, type WireRecord } from "@sidecar/wire";
+import { MemoryBrainStorage } from "#testing/brain-harness";
+import { drainMicrotasks } from "#testing/drain";
+import { FakeClock } from "#testing/fake-clock";
+import { temporaryDirectory } from "#testing/temporary-directory";
 import { type BrainWiring, wireBrain } from "./wiring";
 
 /**
@@ -65,29 +65,6 @@ async function waitFor(condition: () => boolean, timeoutMs = 10_000): Promise<vo
   while (!condition()) {
     if (Date.now() > deadline) throw new Error("the condition did not hold in time");
     await new Promise((resolve) => setTimeout(resolve, 5));
-  }
-}
-
-function settle(rounds = 3): Promise<void> {
-  return new Promise((resolve) => {
-    let ticks = 0;
-    const tick = () => {
-      ticks += 1;
-      if (ticks > 60 * rounds) resolve();
-      else setImmediate(tick);
-    };
-    tick();
-  });
-}
-
-class MemoryStorage implements BrainStateStorage {
-  file: string | undefined;
-  read() {
-    return this.file;
-  }
-  write(contents: string) {
-    this.file = contents;
-    return true;
   }
 }
 
@@ -147,11 +124,12 @@ interface Composed {
   ensured: { sessionKey: SessionKey; name: string }[];
   archived: SessionKey[];
   history: Map<SessionKey, ConversationEntry[]>;
-  /** The child service's timers, held rather than fired, so an archive delay never outlives the test. */
-  timers: Map<ScheduledTimer, { callback: () => void; delayMs: number }>;
+  /** The child service's clock, its timers held rather than fired, so an archive delay never outlives the test. */
+  clock: FakeClock;
 }
 
 function composed(
+  t: TestContext,
   script: Script,
   overrides: Partial<Parameters<typeof wireBrain>[0]> = {},
 ): Composed {
@@ -183,7 +161,7 @@ function composed(
     quietUntil: () => undefined,
   };
   const model = bareModelAdapter(client);
-  const storages = new Map<SessionKey, MemoryStorage>();
+  const storages = new Map<SessionKey, MemoryBrainStorage>();
   const children = new Map<string, ChildRunRecord>();
   const completions = new Map<string, ChildCompletionRecord>();
   const childStore: ChildStore = {
@@ -204,23 +182,14 @@ function composed(
   const archived: SessionKey[] = [];
   const history = new Map<SessionKey, ConversationEntry[]>();
   let ids = 0;
-  const timers = new Map<ScheduledTimer, { callback: () => void; delayMs: number }>();
-  const workspace = fs.mkdtempSync(path.join(os.tmpdir(), "luke-children-"));
+  const clock = new FakeClock();
+  const workspace = temporaryDirectory(t, "luke-children-");
   const wiring = wireBrain({
-    childTimers: {
-      schedule: (callback, delayMs) => {
-        const handle: ScheduledTimer = {};
-        timers.set(handle, { callback, delayMs });
-        return handle;
-      },
-      cancel: (timer) => {
-        timers.delete(timer);
-      },
-    },
+    childTimers: { schedule: clock.schedule, cancel: clock.cancel },
     repositoryFor: (sessionKey) => {
       let storage = storages.get(sessionKey);
       if (!storage) {
-        storage = new MemoryStorage();
+        storage = new MemoryBrainStorage();
         storages.set(sessionKey, storage);
       }
       return brainStateRepositoryFromStorage(storage);
@@ -297,7 +266,7 @@ function composed(
     ensured,
     archived,
     history,
-    timers,
+    clock,
   };
 }
 
@@ -329,8 +298,8 @@ async function ask(c: Composed, question: string, submissionId = "s-1"): Promise
   return accepted.outcome === BRAIN_SUBMISSION_OUTCOME.ACCEPTED ? accepted.runId : "";
 }
 
-test("a spawn from main runs the child in its own conversation at depth one and hands the completion back to main as its own turn", async () => {
-  const c = composed(delegatingScript());
+test("a spawn from main runs the child in its own conversation at depth one and hands the completion back to main as its own turn", async (t) => {
+  const c = composed(t, delegatingScript());
   await c.wiring.rebuild();
   const runId = await ask(c, "look into the last commit");
   await waitFor(() =>
@@ -381,20 +350,20 @@ test("a spawn from main runs the child in its own conversation at depth one and 
   assert.equal(completionTurns.length, 1);
   // The child's conversation stands for an hour after its end, then archives.
   const hour = 60 * 60 * 1000;
-  const archive = [...c.timers.values()].find(
+  const archive = [...c.clock.timers.values()].find(
     (timer) => timer.delayMs > hour - 10_000 && timer.delayMs <= hour,
   );
   assert.ok(archive, "the archive is armed for an hour after the end");
   assert.deepEqual(c.archived, []);
   archive.callback();
-  await settle();
+  await drainMicrotasks(180);
   assert.deepEqual(c.archived, [child.childSessionKey]);
   assert.equal(c.wiring.current(child.childSessionKey), undefined);
   c.wiring.retire();
   await c.wiring.rebuild();
 });
 
-test("a child spawning a child counts one deeper, and at the depth cap the delegation tools are gone", async () => {
+test("a child spawning a child counts one deeper, and at the depth cap the delegation tools are gone", async (t) => {
   // Every child spawns another until refused; the last child answers text.
   const script: Script = (seen) => {
     if (seen.texts.includes(BRAIN_INPUT_MARKER.DEVELOPER_ASK) && seen.outputs.length === 0) {
@@ -408,7 +377,7 @@ test("a child spawning a child counts one deeper, and at the depth cap the deleg
     }
     return textAnswer("ok");
   };
-  const c = composed(script);
+  const c = composed(t, script);
   await c.wiring.rebuild();
   await ask(c, "go deep");
   await waitFor(
@@ -435,7 +404,7 @@ test("a child spawning a child counts one deeper, and at the depth cap the deleg
   await c.wiring.rebuild();
 });
 
-test("a fork carries the requester's context into the child and an isolated child sees none of it", async () => {
+test("a fork carries the requester's context into the child and an isolated child sees none of it", async (t) => {
   const script: Script = (seen) => {
     if (seen.answeringTool) return textAnswer("ok");
     if (seen.lastInput.includes(BRAIN_INPUT_MARKER.CHILD_COMPLETION)) return textAnswer("reviewed");
@@ -451,11 +420,11 @@ test("a fork carries the requester's context into the child and an isolated chil
     }
     return textAnswer(MAIN_SECRET);
   };
-  const c = composed(script);
+  const c = composed(t, script);
   await c.wiring.rebuild();
   // Main first says something memorable, so its context holds a secret to fork.
   const first = await ask(c, "remember this", "s-0");
-  await settle();
+  await drainMicrotasks(180);
   await c.wiring.current()?.waitAsk(first, 1);
   await ask(c, "now fork a child", "s-fork");
   await waitFor(() =>
@@ -482,7 +451,7 @@ test("a fork carries the requester's context into the child and an isolated chil
   await c.wiring.rebuild();
 });
 
-test("Start fresh cancels a conversation's descendants first, and their cancellation is a completion owed to it", async () => {
+test("Start fresh cancels a conversation's descendants first, and their cancellation is a completion owed to it", async (t) => {
   let releaseChild: (() => void) | undefined;
   const script: Script = (seen) => {
     if (seen.texts.includes(BRAIN_INPUT_MARKER.DEVELOPER_ASK) && seen.outputs.length === 0) {
@@ -490,7 +459,7 @@ test("Start fresh cancels a conversation's descendants first, and their cancella
     }
     return textAnswer("ok");
   };
-  const c = composed((seen, calls) => {
+  const c = composed(t, (seen, calls) => {
     if (seen.texts.includes(BRAIN_INPUT_MARKER.SUBAGENT_TASK)) {
       // The child's model call never answers until released: the child stays running.
       return new Promise<ScriptedAnswer>((_resolve, reject) => {
@@ -520,14 +489,14 @@ test("Start fresh cancels a conversation's descendants first, and their cancella
   await c.wiring.rebuild();
 });
 
-test("a reset capture that was skipped reports nothing, while one that failed is said so; the reset proceeds either way", async () => {
+test("a reset capture that was skipped reports nothing, while one that failed is said so; the reset proceeds either way", async (t) => {
   for (const [outcome, reported] of [
     [MEMORY_HOUSEKEEPING_OUTCOME.SKIPPED, false],
     [MEMORY_HOUSEKEEPING_OUTCOME.FAILED, true],
   ] as const) {
     const reports: string[] = [];
     let captures = 0;
-    const c = composed(() => textAnswer("ok"), {
+    const c = composed(t, () => textAnswer("ok"), {
       report: (message) => {
         reports.push(message);
       },

--- a/apps/desktop/src/main/brain/wiring-routing.test.ts
+++ b/apps/desktop/src/main/brain/wiring-routing.test.ts
@@ -1,8 +1,5 @@
 import assert from "node:assert/strict";
-import fs from "node:fs";
-import os from "node:os";
-import path from "node:path";
-import test from "node:test";
+import test, { type TestContext } from "node:test";
 import {
   BRAIN_INPUT_MARKER,
   BRAIN_REQUEST_ORIGIN,
@@ -10,7 +7,6 @@ import {
   BRAIN_TURN_TRIGGER,
   BRAIN_WAKE_KIND,
   type BrainDelivery,
-  type BrainStateStorage,
   brainStateRepositoryFromStorage,
   type ResponsesInputItem,
   responsesModelAnswer,
@@ -34,6 +30,9 @@ import {
   type SessionProvider,
 } from "@sidecar/session";
 import { ACT_RESULT_STATUS, isRecord, isWireString, type WireRecord } from "@sidecar/wire";
+import { MemoryBrainStorage } from "#testing/brain-harness";
+import { drainMicrotasks } from "#testing/drain";
+import { temporaryDirectory } from "#testing/temporary-directory";
 import { type BrainWiring, wireBrain } from "./wiring";
 
 /**
@@ -55,17 +54,6 @@ function session(id: string): Session {
     status: SESSION_STATUS.WORKING,
     lastActivityAt: 1_800_000_000_000,
   });
-}
-
-class MemoryStorage implements BrainStateStorage {
-  file: string | undefined;
-  read() {
-    return this.file;
-  }
-  write(contents: string) {
-    this.file = contents;
-    return true;
-  }
 }
 
 function answer(text: string) {
@@ -106,18 +94,6 @@ function pause(ms: number): Promise<void> {
   return new Promise<void>((resolve) => setTimeout(resolve, ms));
 }
 
-function settle(): Promise<void> {
-  return new Promise((resolve) => {
-    let ticks = 0;
-    const tick = () => {
-      ticks += 1;
-      if (ticks > 60) resolve();
-      else setImmediate(tick);
-    };
-    tick();
-  });
-}
-
 interface Composed {
   wiring: BrainWiring;
   inputs: ResponsesInputItem[][];
@@ -140,7 +116,7 @@ interface Gate {
   release: () => void;
 }
 
-function composed(gate?: Gate): Composed {
+function composed(t: TestContext, gate?: Gate): Composed {
   const inputs: ResponsesInputItem[][] = [];
   const waiting: (() => void)[] = [];
   const client: BareResponsesModel = {
@@ -161,7 +137,7 @@ function composed(gate?: Gate): Composed {
     };
   }
   const model = bareModelAdapter(client);
-  const storages = new Map<SessionKey, MemoryStorage>();
+  const storages = new Map<SessionKey, MemoryBrainStorage>();
   const repositories = new Map<SessionKey, number>();
   const writes = new Map<SessionKey, number>();
   const ensured: Composed["ensured"] = [];
@@ -171,13 +147,13 @@ function composed(gate?: Gate): Composed {
   const roster: Session[] = [session("abc"), session("def")];
   let ids = 0;
   let builds = 0;
-  const workspace = fs.mkdtempSync(path.join(os.tmpdir(), "luke-wiring-"));
+  const workspace = temporaryDirectory(t, "luke-wiring-");
   const wiring = wireBrain({
     repositoryFor: (sessionKey) => {
       repositories.set(sessionKey, (repositories.get(sessionKey) ?? 0) + 1);
       let storage = storages.get(sessionKey);
       if (!storage) {
-        storage = new MemoryStorage();
+        storage = new MemoryBrainStorage();
         storages.set(sessionKey, storage);
       }
       const repository = brainStateRepositoryFromStorage(storage);
@@ -277,8 +253,8 @@ function composed(gate?: Gate): Composed {
   };
 }
 
-test("a roster look opens one conversation per observed session, each reading only its own transcript, and main reads notices instead", async () => {
-  const c = composed();
+test("a roster look opens one conversation per observed session, each reading only its own transcript, and main reads notices instead", async (t) => {
+  const c = composed(t);
   await c.wiring.rebuild();
   c.wiring.rosterLook();
   await until(() => c.inputs.length >= 2 && c.wiring.pendingNotices().length === 2);
@@ -322,7 +298,7 @@ test("a roster look opens one conversation per observed session, each reading on
   });
   assert.equal(accepted.outcome, BRAIN_SUBMISSION_OUTCOME.ACCEPTED);
   await until(() => c.inputs.length >= 3);
-  await settle();
+  await drainMicrotasks(60);
   const mainInput = c.inputs[2] ?? [];
   const mainTexts = itemTexts(mainInput).join("\n");
   assert.ok(mainTexts.includes(BRAIN_INPUT_MARKER.ACTIVITY_NOTICES));
@@ -343,8 +319,8 @@ test("a roster look opens one conversation per observed session, each reading on
   await c.wiring.rebuild();
 });
 
-test("hooks route to the session's own conversation, main is never woken by one, and a held briefing returns to its source", async () => {
-  const c = composed();
+test("hooks route to the session's own conversation, main is never woken by one, and a held briefing returns to its source", async (t) => {
+  const c = composed(t);
   await c.wiring.rebuild();
   const abcKey = observedSessionKey(ABC);
   c.wiring.wake([
@@ -372,7 +348,7 @@ test("hooks route to the session's own conversation, main is never woken by one,
       .map((input) => itemTexts(input).join("\n"))
       .filter((text) => text.includes(BRAIN_INPUT_MARKER.HOLD_RELEASED));
   await until(() => releasesSoFar().length >= 2);
-  await settle();
+  await drainMicrotasks(60);
   const releases = releasesSoFar();
   assert.equal(releases.length, 2);
   assert.ok(releases.some((text) => text.includes("abc finished") && !text.includes("old news")));
@@ -383,8 +359,8 @@ test("hooks route to the session's own conversation, main is never woken by one,
   await c.wiring.rebuild();
 });
 
-test("a held briefing whose source conversation has stood down goes back to that conversation, reopened for it, never to main", async () => {
-  const c = composed();
+test("a held briefing whose source conversation has stood down goes back to that conversation, reopened for it, never to main", async (t) => {
+  const c = composed(t);
   await c.wiring.rebuild();
   const goneKey = observedSessionKey({ providerId: claude.id, providerSessionId: "gone" });
   c.wiring.releaseHeld([
@@ -398,7 +374,7 @@ test("a held briefing whose source conversation has stood down goes back to that
   // The release's turn ends and leaves its notice before anything is judged.
   await until(() => !(c.wiring.current(goneKey)?.busy() ?? true));
   await until(() => c.wiring.pendingNotices().length >= 1);
-  await settle();
+  await drainMicrotasks(60);
   // The source conversation is opened again for the briefing it decided:
   // it, not main, re-decides it, and the briefing is neither dropped nor
   // sent to another session's conversation.
@@ -412,9 +388,9 @@ test("a held briefing whose source conversation has stood down goes back to that
   await c.wiring.rebuild();
 });
 
-test("a session that leaves the roster while its analysis is held keeps its conversation until the analysis ends", async () => {
+test("a session that leaves the roster while its analysis is held keeps its conversation until the analysis ends", async (t) => {
   const gate: Gate = { holds: (texts) => texts.includes(SECRET("abc")), release: () => undefined };
-  const c = composed(gate);
+  const c = composed(t, gate);
   await c.wiring.rebuild();
   const abcKey = observedSessionKey(ABC);
   c.wiring.rosterLook();
@@ -427,7 +403,7 @@ test("a session that leaves the roster while its analysis is held keeps its conv
     1,
   );
   c.wiring.rosterLook();
-  await settle();
+  await drainMicrotasks(60);
   await pause(20);
   // Still standing: an analysis in flight is never cut mid-thought.
   assert.ok(c.wiring.current(abcKey));
@@ -441,8 +417,8 @@ test("a session that leaves the roster while its analysis is held keeps its conv
   await c.wiring.rebuild();
 });
 
-test("a hook for a session whose conversation is standing down waits for the close and builds one store, never a second on the same envelope", async () => {
-  const c = composed();
+test("a hook for a session whose conversation is standing down waits for the close and builds one store, never a second on the same envelope", async (t) => {
+  const c = composed(t);
   await c.wiring.rebuild();
   const abcKey = observedSessionKey(ABC);
   c.wiring.rosterLook();
@@ -466,7 +442,7 @@ test("a hook for a session whose conversation is standing down waits for the clo
     },
   ]);
   await until(() => c.wiring.pendingNotices().length === 3);
-  await settle();
+  await drainMicrotasks(60);
   // One conversation stands for abc, on the second store built for it; the
   // first was let go of before the second was opened.
   assert.ok(c.wiring.current(abcKey));
@@ -475,8 +451,8 @@ test("a hook for a session whose conversation is standing down waits for the clo
   await c.wiring.rebuild();
 });
 
-test("a rebuild landing while a conversation stands down leaves the closing host to its close, and the reopen owns the sole store", async () => {
-  const c = composed();
+test("a rebuild landing while a conversation stands down leaves the closing host to its close, and the reopen owns the sole store", async (t) => {
+  const c = composed(t);
   await c.wiring.rebuild();
   const abcKey = observedSessionKey(ABC);
   c.wiring.rosterLook();
@@ -494,7 +470,7 @@ test("a rebuild landing while a conversation stands down leaves the closing host
   // The rebuild built main's brain and def's, and nothing onto the host the
   // close was about to discard, where no retire could ever reach it; the
   // first envelope took no write after its conversation stood down.
-  await settle();
+  await drainMicrotasks(60);
   assert.equal(c.builds() - buildsBefore, 2);
   assert.equal(c.writes.get(abcKey) ?? 0, writesBefore);
   // Reopened for a hook, the session's conversation stands on a second store
@@ -515,8 +491,8 @@ test("a rebuild landing while a conversation stands down leaves the closing host
   await c.wiring.rebuild();
 });
 
-test("a conversation reopened while it stands down waits for the close and stands on its own new store", async () => {
-  const c = composed();
+test("a conversation reopened while it stands down waits for the close and stands on its own new store", async (t) => {
+  const c = composed(t);
   await c.wiring.rebuild();
   const threadKey = threadSessionKey("t-1");
   await c.wiring.openConversation(threadKey);
@@ -534,8 +510,8 @@ test("a conversation reopened while it stands down waits for the close and stand
   await c.wiring.rebuild();
 });
 
-test("two opens of one key landing in the same tick, a hook and a held briefing, build one store and list the conversation once", async () => {
-  const c = composed();
+test("two opens of one key landing in the same tick, a hook and a held briefing, build one store and list the conversation once", async (t) => {
+  const c = composed(t);
   await c.wiring.rebuild();
   const abcKey = observedSessionKey(ABC);
   assert.equal(c.repositories.get(abcKey), undefined);
@@ -565,19 +541,19 @@ test("two opens of one key landing in the same tick, a hook and a held briefing,
   await c.wiring.rebuild();
 });
 
-test("a heartbeat settles only when its turn has, so a scheduler's tick is over when its work is", async () => {
+test("a heartbeat settles only when its turn has, so a scheduler's tick is over when its work is", async (t) => {
   const gate: Gate = {
     holds: (texts) => texts.includes(BRAIN_INPUT_MARKER.HEARTBEAT),
     release: () => undefined,
   };
-  const c = composed(gate);
+  const c = composed(t, gate);
   await c.wiring.rebuild();
   let settled = false;
   const tick = c.wiring.heartbeat().then(() => {
     settled = true;
   });
   await until(() => c.inputs.length >= 1);
-  await settle();
+  await drainMicrotasks(60);
   // The review is under way and the tick still open.
   assert.equal(settled, false);
   gate.release();
@@ -587,9 +563,9 @@ test("a heartbeat settles only when its turn has, so a scheduler's tick is over 
   await c.wiring.rebuild();
 });
 
-test("one observed conversation waiting on its model neither blocks another nor main", async () => {
+test("one observed conversation waiting on its model neither blocks another nor main", async (t) => {
   const gate: Gate = { holds: (texts) => texts.includes(SECRET("def")), release: () => undefined };
-  const c = composed(gate);
+  const c = composed(t, gate);
   await c.wiring.rebuild();
   c.wiring.rosterLook();
   await until(() => c.inputs.length >= 2 && c.wiring.pendingNotices().length === 1);

--- a/apps/desktop/src/main/brain/wiring.test.ts
+++ b/apps/desktop/src/main/brain/wiring.test.ts
@@ -4,6 +4,7 @@ import { BRAIN_WAKE_KIND, type BrainStateRepository } from "@sidecar/brain";
 import { CREDENTIAL_REFERENCE_KIND, memoryChildStore } from "@sidecar/runtime";
 import { MAIN_SESSION_KEY, threadSessionKey } from "@sidecar/runtime-contracts";
 import { normalizeSession, SESSION_STATUS, type Session } from "@sidecar/session";
+import { drainMicrotasks } from "#testing/drain";
 import { type BrainWiringDependencies, wakeEventsFromHooks, wireBrain } from "./wiring";
 
 /**
@@ -78,10 +79,10 @@ test("with no model to run on, a rebuild opens no conversation and loads no stor
   assert.deepEqual(brains.busyConversations(), []);
   // Asking for a store is what opens one, and only the one asked for.
   brains.store();
-  await new Promise((resolve) => setImmediate(resolve));
+  await drainMicrotasks(1);
   assert.deepEqual(loads, [MAIN_SESSION_KEY]);
   await brains.openConversation(threadSessionKey("t-1"));
-  await new Promise((resolve) => setImmediate(resolve));
+  await drainMicrotasks(1);
   assert.deepEqual(loads, [MAIN_SESSION_KEY, threadSessionKey("t-1")]);
   assert.equal(brains.current(threadSessionKey("t-1")), undefined);
   await brains.closeConversation(threadSessionKey("t-1"));

--- a/apps/desktop/src/main/host/lifecycle.test.ts
+++ b/apps/desktop/src/main/host/lifecycle.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { GATEWAY_SHUTDOWN_DEFAULTS, shutdownGateway } from "@sidecar/runtime";
+import { drainMicrotasks } from "#testing/drain";
 import { seedWorkspaceThenStartMemory, shutdownStepsFlushingEvents } from "./lifecycle";
 
 test("a workspace seed that fails is reported and the memory index still starts, after the seed and not before", async () => {
@@ -70,7 +71,7 @@ test("the flush begins as admissions close and is waited for before the unresolv
     });
   });
   const report = shutdownGateway(steps, { deadlineMs: GATEWAY_SHUTDOWN_DEFAULTS.DEADLINE_MS });
-  await new Promise((resolve) => setImmediate(resolve));
+  await drainMicrotasks(1);
   assert.deepEqual(order, ["close", "flush:start", "cancel", "settled"]);
   settleFlush?.();
   const outcome = await report;

--- a/apps/desktop/src/main/host/notebook-memory.test.ts
+++ b/apps/desktop/src/main/host/notebook-memory.test.ts
@@ -1,8 +1,7 @@
 import assert from "node:assert/strict";
 import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
-import test from "node:test";
+import test, { type TestContext } from "node:test";
 import { MEMORY_SOURCE, RETRIEVAL_MODE } from "@sidecar/memory";
 import { CONVERSATION_ENTRY_KIND, type ConversationEntry } from "@sidecar/realtime";
 import {
@@ -23,12 +22,13 @@ import {
   serveRuntimeStore,
 } from "@sidecar/runtime-store";
 import { isRecord, type WireRecord } from "@sidecar/wire";
+import { temporaryDirectory } from "#testing/temporary-directory";
 import { composeNotebookMemory, type NotebookMemoryDependencies } from "./runtime-host";
 
 const NOW = 1_800_000_000_000;
 
-function agentRoot() {
-  const root = fs.mkdtempSync(path.join(os.tmpdir(), "luke-notebook-memory-"));
+function agentRoot(t: TestContext) {
+  const root = temporaryDirectory(t, "luke-notebook-memory-");
   fs.mkdirSync(path.join(root, "workspace", "memory"), { recursive: true });
   fs.writeFileSync(
     path.join(root, "workspace", "MEMORY.md"),
@@ -81,8 +81,8 @@ function adapter(
   return built;
 }
 
-async function harness(overrides: Partial<NotebookMemoryDependencies> = {}) {
-  const root = agentRoot();
+async function harness(t: TestContext, overrides: Partial<NotebookMemoryDependencies> = {}) {
+  const root = agentRoot(t);
   const { store, close } = client();
   await store.open({
     agentRoot: root,
@@ -133,8 +133,8 @@ function resultsOf(answer: WireRecord): WireRecord[] {
   return Array.isArray(answer.results) ? answer.results.filter(isRecord) : [];
 }
 
-test("a sync indexes the notebook with vectors, a search runs hybrid, and a hand edit is picked up by the next sync", async () => {
-  const h = await harness();
+test("a sync indexes the notebook with vectors, a search runs hybrid, and a hand edit is picked up by the next sync", async (t) => {
+  const h = await harness(t);
   const first = await h.wiring.sync();
   assert.equal(first?.mode, RETRIEVAL_MODE.HYBRID);
   assert.ok(first && first.embeddedChunks > 0 && first.embeddedChunks === first.indexedChunks);
@@ -166,9 +166,9 @@ test("a sync indexes the notebook with vectors, a search runs hybrid, and a hand
   h.close();
 });
 
-test("an embedding outage degrades an automatic provider to keyword-only, and the search says so", async () => {
+test("an embedding outage degrades an automatic provider to keyword-only, and the search says so", async (t) => {
   const failing = adapter({ fail: true });
-  const h = await harness({ embeddingAdapter: () => failing });
+  const h = await harness(t, { embeddingAdapter: () => failing });
   const report = await h.wiring.sync();
   assert.equal(report?.mode, RETRIEVAL_MODE.KEYWORD_ONLY);
   assert.ok(report?.note?.includes("embeddings are down"));
@@ -187,8 +187,8 @@ test("an embedding outage degrades an automatic provider to keyword-only, and th
   h.close();
 });
 
-test("past-conversation results come from eligible conversations' History alone, never the asking one or a temporary thread", async () => {
-  const h = await harness();
+test("past-conversation results come from eligible conversations' History alone, never the asking one or a temporary thread", async (t) => {
+  const h = await harness(t);
   await h.wiring.sync();
   await h.store.appendHistory(
     MAIN_SESSION_KEY,
@@ -254,10 +254,10 @@ test("past-conversation results come from eligible conversations' History alone,
   h.close();
 });
 
-test("a launch before any credential indexes keyword-only, and the first credentialed sync backfills the vectors without an edit", async () => {
+test("a launch before any credential indexes keyword-only, and the first credentialed sync backfills the vectors without an edit", async (t) => {
   const embedding = adapter();
   let credential: EmbeddingAdapter | undefined;
-  const h = await harness({ embeddingAdapter: () => credential });
+  const h = await harness(t, { embeddingAdapter: () => credential });
   const first = await h.wiring.sync();
   assert.equal(first?.mode, RETRIEVAL_MODE.KEYWORD_ONLY);
   assert.equal(first?.embeddedChunks, 0);
@@ -276,9 +276,9 @@ test("a launch before any credential indexes keyword-only, and the first credent
   h.close();
 });
 
-test("a transient embedding failure leaves keyword rows searchable and the next sync retries the vectors", async () => {
+test("a transient embedding failure leaves keyword rows searchable and the next sync retries the vectors", async (t) => {
   const embedding = adapter({ fail: true });
-  const h = await harness({ embeddingAdapter: () => embedding });
+  const h = await harness(t, { embeddingAdapter: () => embedding });
   const failed = await h.wiring.sync();
   assert.equal(failed?.mode, RETRIEVAL_MODE.KEYWORD_ONLY);
   assert.equal((await h.store.memoryIndexStatus()).embeddedChunks, 0);

--- a/apps/desktop/src/main/host/voice-credential-transition.test.ts
+++ b/apps/desktop/src/main/host/voice-credential-transition.test.ts
@@ -18,6 +18,7 @@ import {
 import { REASONING_EFFORT } from "@sidecar/runtime-contracts";
 import { APP_SETTING_SCHEMA, VOICE_SOURCE, type VoiceSource } from "@sidecar/settings";
 import { VoiceCapabilityAssembler, type VoiceSettings } from "@sidecar/voice";
+import { drainMicrotasks } from "#testing/drain";
 import { BrainHost } from "../brain/host";
 import { transitionVoiceCredential } from "./runtime-host";
 
@@ -71,10 +72,6 @@ class HeldSettings implements VoiceSettings {
     assert.ok(gate, "no read is held");
     gate();
   }
-}
-
-async function settle(): Promise<void> {
-  for (let index = 0; index < 20; index += 1) await new Promise((resolve) => setImmediate(resolve));
 }
 
 /**
@@ -270,7 +267,7 @@ for (const held of Object.values(HELD_READ)) {
     const c = composition();
     c.settings.holdNext = held;
     const older = c.transition();
-    await settle();
+    await drainMicrotasks(20);
     c.settings.source = VOICE_SOURCE.ACCOUNT;
     assert.equal(await c.transition(), true);
     assertHostedSet(c);
@@ -288,7 +285,7 @@ for (const held of Object.values(HELD_READ)) {
     });
     assert.equal(accepted.outcome, BRAIN_SUBMISSION_OUTCOME.ACCEPTED);
     const runId = accepted.outcome === BRAIN_SUBMISSION_OUTCOME.ACCEPTED ? accepted.runId : "";
-    await settle();
+    await drainMicrotasks(20);
     assert.equal(hostedAgent.request(runId)?.status, BRAIN_REQUEST_STATUS.RUNNING);
 
     // The older read answers now, with the key source it was started under.
@@ -318,7 +315,7 @@ test("the reverse order holds too: a late account read never overrides a newer k
   c.settings.source = VOICE_SOURCE.ACCOUNT;
   c.settings.holdNext = HELD_READ.SOURCE;
   const older = c.transition();
-  await settle();
+  await drainMicrotasks(20);
   c.settings.source = VOICE_SOURCE.KEY;
   assert.equal(await c.transition(), true);
   assert.equal(c.assembler.voiceSource, VOICE_SOURCE.KEY);
@@ -341,7 +338,7 @@ test("a late read cannot resurrect a capability the newer transition removed", a
   assert.ok(c.host.current());
   c.settings.holdNext = HELD_READ.SOURCE;
   const older = c.transition();
-  await settle();
+  await drainMicrotasks(20);
   // The key is removed and the account signed out: nothing may stand.
   c.settings.key = undefined;
   c.gate.accountSignedIn = false;
@@ -364,7 +361,7 @@ test("a late read cannot resurrect a capability the newer transition removed", a
   // A closed gate is the same removal from the other side.
   c.settings.holdNext = HELD_READ.SOURCE;
   const heldAgain = c.transition();
-  await settle();
+  await drainMicrotasks(20);
   c.gate.credentialsUsable = false;
   assert.equal(await c.transition(), true);
   c.settings.release();

--- a/apps/desktop/src/main/ipc/session-acts.test.ts
+++ b/apps/desktop/src/main/ipc/session-acts.test.ts
@@ -15,6 +15,7 @@ import {
   type WorkspaceProject,
 } from "@sidecar/session";
 import { ACT_RESULT_STATUS } from "@sidecar/wire";
+import { drainMicrotasks } from "#testing/drain";
 import type { SettingsStore } from "../settings-store";
 import { createSessionActPerformer } from "./session-acts";
 
@@ -128,17 +129,13 @@ const SPAWN: CarriedSessionAct = {
   agent: "claude",
 };
 
-async function settleMicrotasks(): Promise<void> {
-  for (let index = 0; index < 10; index += 1) await new Promise((resolve) => setImmediate(resolve));
-}
-
 test("a create whose turn ends while the stored defaults are read never reaches the provider", async () => {
   const adapter = new FakeAdapter();
   const settings = heldSettings();
   const performer = deeperPerformer(adapter, settings.store);
   let revoked = false;
   const pending = performer.perform(CREATE, { isRevoked: () => revoked });
-  await settleMicrotasks();
+  await drainMicrotasks(10);
   assert.equal(settings.reads(), 1);
   assert.deepEqual(adapter.creates, []);
   revoked = true;
@@ -155,7 +152,7 @@ test("a spawn whose turn ends while the stored defaults are read never reaches t
   const performer = deeperPerformer(adapter, settings.store);
   let revoked = false;
   const pending = performer.perform(SPAWN, { isRevoked: () => revoked });
-  await settleMicrotasks();
+  await drainMicrotasks(10);
   assert.equal(settings.reads(), 1);
   assert.deepEqual(adapter.spawns, []);
   revoked = true;
@@ -175,18 +172,18 @@ test("a create whose turn is cancelled while the stored defaults are read settle
     isRevoked: () => controller.signal.aborted,
     signal: controller.signal,
   });
-  await settleMicrotasks();
+  await drainMicrotasks(10);
   assert.equal(settings.reads(), 1);
   controller.abort();
   // Settles without the read being released.
   const result = await pending;
   assert.equal(result.status, ACT_RESULT_STATUS.REJECTED);
   settings.release();
-  await settleMicrotasks();
+  await drainMicrotasks(10);
   assert.deepEqual(adapter.creates, []);
   // A row's own press carries no signal and waits the read out, as before.
   const direct = performer.perform(CREATE, { isRevoked: () => false });
-  await settleMicrotasks();
+  await drainMicrotasks(10);
   settings.release();
   assert.equal((await direct).status, ACT_RESULT_STATUS.ACCEPTED);
 });
@@ -198,14 +195,14 @@ test("a create and a spawn whose turn still stands after the read land on the pr
   const live = { isRevoked: () => false };
 
   const creating = performer.perform(CREATE, live);
-  await settleMicrotasks();
+  await drainMicrotasks(10);
   settings.release();
   assert.equal((await creating).status, ACT_RESULT_STATUS.ACCEPTED);
   assert.equal(adapter.creates.length, 1);
   assert.equal(adapter.creates[0]?.task, "add tests");
 
   const spawning = performer.perform(SPAWN, live);
-  await settleMicrotasks();
+  await drainMicrotasks(10);
   settings.release();
   assert.equal((await spawning).status, ACT_RESULT_STATUS.ACCEPTED);
   assert.equal(adapter.spawns.length, 1);
@@ -217,7 +214,7 @@ test("a row-shaped call with no guard still lands, because a press is its own tu
   const settings = heldSettings();
   const performer = deeperPerformer(adapter, settings.store);
   const creating = performer.perform(CREATE);
-  await settleMicrotasks();
+  await drainMicrotasks(10);
   settings.release();
   assert.equal((await creating).status, ACT_RESULT_STATUS.ACCEPTED);
   assert.equal(adapter.creates.length, 1);

--- a/apps/desktop/src/main/memory-maintenance.test.ts
+++ b/apps/desktop/src/main/memory-maintenance.test.ts
@@ -1,8 +1,7 @@
 import assert from "node:assert/strict";
 import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
-import test from "node:test";
+import test, { type TestContext } from "node:test";
 import { MEMORY_HOUSEKEEPING_OUTCOME } from "@sidecar/memory";
 import { recentDailyNotes } from "@sidecar/runtime";
 import {
@@ -19,6 +18,7 @@ import {
   type RuntimeStorePort,
   serveRuntimeStore,
 } from "@sidecar/runtime-store";
+import { temporaryDirectory } from "#testing/temporary-directory";
 import { type MemoryMaintenanceDependencies, wireMemoryMaintenance } from "./memory-maintenance";
 
 const DAY_MS = 24 * 60 * 60 * 1000;
@@ -76,10 +76,11 @@ function fakeRuntime(answer: (prompt: string, input: string) => string | undefin
 }
 
 async function harness(
+  t: TestContext,
   answer: (prompt: string, input: string) => string | undefined = () => "stored.",
   overrides: Partial<MemoryMaintenanceDependencies> = {},
 ) {
-  const root = fs.mkdtempSync(path.join(os.tmpdir(), "luke-memory-maintenance-"));
+  const root = temporaryDirectory(t, "luke-memory-maintenance-");
   const workspace = path.join(root, "workspace");
   fs.mkdirSync(path.join(workspace, "memory"), { recursive: true });
   fs.writeFileSync(
@@ -135,8 +136,8 @@ async function harness(
   };
 }
 
-test("the flush hook and the reset capture exist only for main and durable private threads, and a fresh conversation is primed with today's and yesterday's notes, slugged variants included", async () => {
-  const h = await harness();
+test("the flush hook and the reset capture exist only for main and durable private threads, and a fresh conversation is primed with today's and yesterday's notes, slugged variants included", async (t) => {
+  const h = await harness(t);
   assert.ok(h.maintenance.flushHookFor(MAIN_SESSION_KEY));
   assert.ok(h.maintenance.flushHookFor(h.thread));
   assert.equal(h.maintenance.flushHookFor(h.temporary), undefined);
@@ -147,7 +148,7 @@ test("the flush hook and the reset capture exist only for main and durable priva
   const empty = await h.maintenance.captureBeforeReset(MAIN_SESSION_KEY, []);
   assert.equal(empty.outcome, MEMORY_HOUSEKEEPING_OUTCOME.NOTHING_TO_STORE);
   // A capture whose model fails is reported as failed, never as done.
-  const failing = await harness(() => undefined);
+  const failing = await harness(t, () => undefined);
   const failed = await failing.maintenance.captureBeforeReset(MAIN_SESSION_KEY, [
     { type: "message" },
   ]);
@@ -164,8 +165,8 @@ test("the flush hook and the reset capture exist only for main and durable priva
   h.close();
 });
 
-test("the flush marker is kept per conversation under the generation the brain names, and a new generation reads none", async () => {
-  const h = await harness();
+test("the flush marker is kept per conversation under the generation the brain names, and a new generation reads none", async (t) => {
+  const h = await harness(t);
   const marker = h.maintenance.flushMarkerFor(MAIN_SESSION_KEY);
   assert.ok(marker);
   assert.equal(await marker.read("gen-1"), undefined);

--- a/apps/desktop/src/main/native/media-duck.test.ts
+++ b/apps/desktop/src/main/native/media-duck.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import { fakeNativeHelper } from "#testing/native-helper";
 import { MediaDuckController } from "./media-duck";
 import type { NativeHelperProcess } from "./native-helper";
 
@@ -9,46 +10,28 @@ const RELEASE_DELAY_MS = 40;
 interface Harness {
   controller: MediaDuckController;
   /** Every line written to every helper, in order, newlines stripped. */
-  commands: string[];
+  commands: () => readonly string[];
   spawns: () => number;
   stdinEnded: () => boolean;
   die: () => void;
 }
 
 function harness(options: { spawns?: (() => NativeHelperProcess | undefined)[] } = {}): Harness {
-  const commands: string[] = [];
   let spawned = 0;
-  let ended = false;
-  const exits: (() => void)[] = [];
+  const helper = fakeNativeHelper();
 
   const spawnHelper = (): NativeHelperProcess | undefined => {
     const scripted = options.spawns?.[spawned];
     spawned += 1;
-    if (scripted) return scripted();
-    return {
-      stdin: {
-        write: (chunk: string) => commands.push(chunk.trim()),
-        end: () => {
-          ended = true;
-        },
-      },
-      on: (event, listener) => {
-        if (event === "exit") exits.push(listener);
-      },
-      removeAllListeners: () => {
-        exits.length = 0;
-      },
-    };
+    return scripted ? scripted() : helper.process;
   };
 
   return {
     controller: new MediaDuckController({ spawnHelper, releaseDelayMs: RELEASE_DELAY_MS }),
-    commands,
+    commands: () => helper.written.map((chunk) => chunk.trim()),
     spawns: () => spawned,
-    stdinEnded: () => ended,
-    die: () => {
-      for (const exit of [...exits]) exit();
-    },
+    stdinEnded: helper.inputEnded,
+    die: helper.exit,
   };
 }
 
@@ -61,15 +44,15 @@ test("an exchange ducks at once and restores only after the hangover", async () 
   context.controller.setEnabled(true);
 
   context.controller.setExchangeActive(true);
-  assert.deepEqual(context.commands, ["duck"]);
+  assert.deepEqual(context.commands(), ["duck"]);
 
   context.controller.setExchangeActive(false);
   // The reply just ended; the players stay down through the pause a follow-up
   // question would arrive in.
-  assert.deepEqual(context.commands, ["duck"]);
+  assert.deepEqual(context.commands(), ["duck"]);
 
   await settle();
-  assert.deepEqual(context.commands, ["duck", "restore"]);
+  assert.deepEqual(context.commands(), ["duck", "restore"]);
 });
 
 test("a turn beginning inside the hangover keeps the duck held", async () => {
@@ -84,11 +67,11 @@ test("a turn beginning inside the hangover keeps the duck held", async () => {
   // Neither a restore — the conversation never stopped — nor a second duck,
   // SAFETY: Fixture value matches the narrowed runtime shape this test exercises.
   // which would read the ducked volume back as the one to restore to.
-  assert.deepEqual(context.commands, ["duck"]);
+  assert.deepEqual(context.commands(), ["duck"]);
 
   context.controller.setExchangeActive(false);
   await settle();
-  assert.deepEqual(context.commands, ["duck", "restore"]);
+  assert.deepEqual(context.commands(), ["duck", "restore"]);
 });
 
 test("disabled, an exchange never touches the helper at all", async () => {
@@ -100,7 +83,7 @@ test("disabled, an exchange never touches the helper at all", async () => {
   await settle();
 
   assert.equal(context.spawns(), 0);
-  assert.deepEqual(context.commands, []);
+  assert.deepEqual(context.commands(), []);
 });
 
 test("turning the setting off mid-duck restores at once, without the hangover", () => {
@@ -112,16 +95,16 @@ test("turning the setting off mid-duck restores at once, without the hangover", 
 
   // The hangover exists so a conversation does not pump; this is not a pause
   // in a conversation but the user asking for their volume back.
-  assert.deepEqual(context.commands, ["duck", "restore"]);
+  assert.deepEqual(context.commands(), ["duck", "restore"]);
 });
 
 test("enabling mid-exchange ducks the exchange already underway", () => {
   const context = harness();
   context.controller.setExchangeActive(true);
-  assert.deepEqual(context.commands, []);
+  assert.deepEqual(context.commands(), []);
 
   context.controller.setEnabled(true);
-  assert.deepEqual(context.commands, ["duck"]);
+  assert.deepEqual(context.commands(), ["duck"]);
 });
 
 test("a helper that dies is replaced for the next exchange", async () => {
@@ -134,11 +117,11 @@ test("a helper that dies is replaced for the next exchange", async () => {
   // restore, and the next exchange starts fresh.
   context.controller.setExchangeActive(false);
   await settle();
-  assert.deepEqual(context.commands, ["duck"]);
+  assert.deepEqual(context.commands(), ["duck"]);
 
   context.controller.setExchangeActive(true);
   assert.equal(context.spawns(), 2);
-  assert.deepEqual(context.commands, ["duck", "duck"]);
+  assert.deepEqual(context.commands(), ["duck", "duck"]);
 });
 
 test("enabling spawns the listening helper before any exchange", () => {
@@ -148,7 +131,7 @@ test("enabling spawns the listening helper before any exchange", () => {
   // The helper is up so it can hear the players' play-state broadcasts, but
   // nothing has asked for quiet, so nothing is written to it.
   assert.equal(context.spawns(), 1);
-  assert.deepEqual(context.commands, []);
+  assert.deepEqual(context.commands(), []);
 });
 
 test("a helper that cannot be spawned leaves the exchange unharmed", () => {
@@ -163,7 +146,7 @@ test("a helper that cannot be spawned leaves the exchange unharmed", () => {
   context.controller.setExchangeActive(false);
 
   assert.equal(context.spawns(), 2);
-  assert.deepEqual(context.commands, []);
+  assert.deepEqual(context.commands(), []);
 });
 
 test("a duck write that throws drops the helper, and the next exchange starts fresh", () => {
@@ -191,7 +174,7 @@ test("a duck write that throws drops the helper, and the next exchange starts fr
   context.controller.setExchangeActive(false);
   context.controller.setExchangeActive(true);
   assert.equal(context.spawns(), 2);
-  assert.deepEqual(context.commands, ["duck"]);
+  assert.deepEqual(context.commands(), ["duck"]);
 });
 
 test("a restore write that throws costs nothing but the dead helper", async () => {
@@ -223,7 +206,7 @@ test("a restore write that throws costs nothing but the dead helper", async () =
   // rather than the broken pipe.
   context.controller.setExchangeActive(true);
   assert.equal(context.spawns(), 2);
-  assert.deepEqual(context.commands, ["duck"]);
+  assert.deepEqual(context.commands(), ["duck"]);
 });
 
 test("stopping a controller whose pipe already broke does not throw", () => {
@@ -258,5 +241,5 @@ test("stopping closes stdin rather than writing, and writes nothing after", asyn
   // players back up on EOF — so a written restore would say it twice.
   assert.equal(context.stdinEnded(), true);
   await settle();
-  assert.deepEqual(context.commands, ["duck"]);
+  assert.deepEqual(context.commands(), ["duck"]);
 });

--- a/apps/desktop/src/main/native/microphone-route.test.ts
+++ b/apps/desktop/src/main/native/microphone-route.test.ts
@@ -1,13 +1,13 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { LID_STATE, MICROPHONE_TRANSPORT, type MicrophoneRoute } from "#shared/messages/audio";
+import { fakeNativeHelper } from "#testing/native-helper";
 import {
   MICROPHONE_ROUTE_PROBE,
   type MicrophoneRouteWatch,
   microphoneRouteWatcher,
   parseMicrophoneRouteLine,
 } from "./microphone-route";
-import type { NativeHelperProcess } from "./native-helper";
 
 test("a route line parses into its three facts", () => {
   assert.deepEqual(
@@ -45,41 +45,18 @@ interface Harness {
   watcher: MicrophoneRouteWatch;
   routes: MicrophoneRoute[];
   unavailable: () => number;
-  written: string[];
+  written: readonly string[];
   emit: (chunk: string) => void;
   die: () => void;
 }
 
 function harness(): Harness {
   const routes: MicrophoneRoute[] = [];
-  const written: string[] = [];
   let unavailable = 0;
-  let listener: ((chunk: string) => void) | undefined;
-  const exits: (() => void)[] = [];
-
-  const child: NativeHelperProcess = {
-    stdin: {
-      write: (chunk) => {
-        written.push(chunk);
-      },
-    },
-    stdout: {
-      setEncoding: () => undefined,
-      on: (_event, dataListener) => {
-        listener = dataListener;
-      },
-    },
-    on: (event, exitListener) => {
-      if (event === "exit") exits.push(exitListener);
-    },
-    removeAllListeners: () => {
-      exits.length = 0;
-    },
-    kill: () => undefined,
-  };
+  const helper = fakeNativeHelper();
 
   const watcher = microphoneRouteWatcher({
-    spawnHelper: () => child,
+    spawnHelper: () => helper.process,
     onRoute: (route) => {
       routes.push(route);
     },
@@ -92,11 +69,9 @@ function harness(): Harness {
     watcher,
     routes,
     unavailable: () => unavailable,
-    written,
-    emit: (chunk) => listener?.(chunk),
-    die: () => {
-      for (const exit of [...exits]) exit();
-    },
+    written: helper.written,
+    emit: helper.emit,
+    die: helper.exit,
   };
 }
 

--- a/apps/desktop/src/main/native/output-volume.test.ts
+++ b/apps/desktop/src/main/native/output-volume.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import type { OutputAudioState } from "#shared/messages/audio";
+import { fakeNativeHelper } from "#testing/native-helper";
 import { type OutputVolumeWatch, outputVolumeWatcher, parseOutputLine } from "./output-volume";
 
 interface Harness {
@@ -13,31 +14,10 @@ interface Harness {
 
 function harness(spawnFails = false): Harness {
   const events: string[] = [];
-  let killed = false;
-  let onData: ((chunk: string) => void) | undefined;
-  const exits: (() => void)[] = [];
+  const helper = fakeNativeHelper();
 
   const watcher = outputVolumeWatcher({
-    spawnHelper: () =>
-      spawnFails
-        ? undefined
-        : {
-            stdout: {
-              setEncoding: () => undefined,
-              on: (_event, listener) => {
-                onData = listener;
-              },
-            },
-            on: (event, listener) => {
-              if (event === "exit") exits.push(listener);
-            },
-            removeAllListeners: () => {
-              exits.length = 0;
-            },
-            kill: () => {
-              killed = true;
-            },
-          },
+    spawnHelper: () => (spawnFails ? undefined : helper.process),
     onState: (state: OutputAudioState) =>
       events.push(`state:${state.muted ? 1 : 0}:${state.volume}`),
     onUnavailable: () => events.push("unavailable"),
@@ -46,11 +26,9 @@ function harness(spawnFails = false): Harness {
   return {
     watcher,
     events,
-    killed: () => killed,
-    emit: (chunk) => onData?.(chunk),
-    die: () => {
-      for (const exit of [...exits]) exit();
-    },
+    killed: helper.killed,
+    emit: helper.emit,
+    die: helper.exit,
   };
 }
 

--- a/apps/desktop/src/main/native/talk-key.test.ts
+++ b/apps/desktop/src/main/native/talk-key.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import { fakeNativeHelper } from "#testing/native-helper";
 import { type TalkKeyWatch, talkKeyWatcher } from "./talk-key";
 
 interface Harness {
@@ -14,30 +15,12 @@ interface Harness {
 function harness(): Harness {
   const edges: string[] = [];
   const candidates: string[][] = [];
-  let killed = false;
-  let onData: ((chunk: string) => void) | undefined;
-  const exits: (() => void)[] = [];
+  const helper = fakeNativeHelper();
 
   const watcher = talkKeyWatcher({
     spawnHelper: (requested) => {
       candidates.push([...requested]);
-      return {
-        stdout: {
-          setEncoding: () => undefined,
-          on: (_event, listener) => {
-            onData = listener;
-          },
-        },
-        on: (event, listener) => {
-          if (event === "exit") exits.push(listener);
-        },
-        removeAllListeners: () => {
-          exits.length = 0;
-        },
-        kill: () => {
-          killed = true;
-        },
-      };
+      return helper.process;
     },
     onPress: () => edges.push("press"),
     onRelease: () => edges.push("release"),
@@ -49,11 +32,9 @@ function harness(): Harness {
     watcher,
     edges,
     candidates,
-    killed: () => killed,
-    emit: (chunk) => onData?.(chunk),
-    die: () => {
-      for (const exit of [...exits]) exit();
-    },
+    killed: helper.killed,
+    emit: helper.emit,
+    die: helper.exit,
   };
 }
 

--- a/apps/desktop/src/main/onboarding-state.test.ts
+++ b/apps/desktop/src/main/onboarding-state.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import test, { type TestContext } from "node:test";
+import { temporaryDirectory } from "#testing/temporary-directory";
 import { arrivalBeatOwed, countsFirstAnnouncement } from "./arrival-flow";
 import { calendarOnboardingOwed } from "./calendar-onboarding-flow";
 import { shouldRunIntroduction } from "./introduction-flow";
@@ -12,10 +13,7 @@ const SIGNED_IN_AT = "2026-08-24T00:00:00.000Z";
 const LATER = "2026-08-24T00:05:00.000Z";
 
 function fileIn(t: TestContext) {
-  const root = fs.mkdtempSync(path.join(os.tmpdir(), "luke-onboarding-"));
-  t.after(() => {
-    fs.rmSync(root, { recursive: true, force: true });
-  });
+  const root = temporaryDirectory(t, "luke-onboarding-");
   return { root, file: onboardingStateFile(() => root) };
 }
 

--- a/apps/desktop/src/main/runtime-store-wiring.test.ts
+++ b/apps/desktop/src/main/runtime-store-wiring.test.ts
@@ -1,6 +1,5 @@
 import assert from "node:assert/strict";
 import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 import { MessageChannel } from "node:worker_threads";
@@ -14,6 +13,7 @@ import {
   threadSessionKey,
 } from "@sidecar/runtime-contracts";
 import { type RuntimeStorePort, serveRuntimeStore } from "@sidecar/runtime-store";
+import { temporaryDirectory } from "#testing/temporary-directory";
 import { wireRuntimeStore } from "./runtime-store-wiring";
 
 /**
@@ -76,8 +76,7 @@ function wiring(root: string) {
 const LINE = { kind: CONVERSATION_ENTRY_KIND.TYPED_ASK, words: "kept for good" } as const;
 
 test("a listed conversation and its lines survive the next launch; archiving keeps the thread readable and main cannot be archived", async (t) => {
-  const root = fs.mkdtempSync(path.join(os.tmpdir(), "luke-wiring-"));
-  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const root = temporaryDirectory(t, "luke-wiring-");
   const first = wiring(root);
   t.after(() => first.close());
   await first.wired.open();
@@ -127,8 +126,7 @@ test("a listed conversation and its lines survive the next launch; archiving kee
 });
 
 test("an erasure takes what stood at the instant it was asked at; a line recorded after the press is the conversation's next line", async (t) => {
-  const root = fs.mkdtempSync(path.join(os.tmpdir(), "luke-wiring-"));
-  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const root = temporaryDirectory(t, "luke-wiring-");
   const c = wiring(root);
   t.after(() => c.close());
   await c.wired.open();

--- a/apps/desktop/src/main/settings-store.test.ts
+++ b/apps/desktop/src/main/settings-store.test.ts
@@ -1,8 +1,7 @@
 import assert from "node:assert/strict";
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
-import test, { type TestContext } from "node:test";
+import test from "node:test";
 import {
   CREDENTIAL_CONNECTION,
   CREDENTIAL_PROVIDER_ID,
@@ -29,6 +28,7 @@ import { PANEL_FORM_FACTOR } from "@sidecar/surface";
 import { type UnparsedWireValue, unparsedWire, type WireRecord } from "@sidecar/wire";
 import { ACCOUNT_STATUS, CREDENTIAL_SOURCE, SECRET_STORAGE } from "#shared/messages/account";
 import { appSettingsView, SETTINGS_RESET_SCOPE, VOICE_SOURCE } from "#shared/messages/settings";
+import { temporaryDirectory } from "#testing/temporary-directory";
 import {
   apiKeyRejection,
   type SecretCipher,
@@ -173,14 +173,6 @@ function expectedPersistedSettings(overrides: WireRecord = {}): UnparsedWireValu
   );
 }
 
-async function temporaryDirectory(t: TestContext): Promise<string> {
-  const directory = await fs.mkdtemp(path.join(os.tmpdir(), "luke-settings-"));
-  t.after(async () => {
-    await fs.rm(directory, { recursive: true, force: true });
-  });
-  return directory;
-}
-
 function storeIn(
   directory: string,
   options: {
@@ -205,7 +197,7 @@ function storeIn(
 }
 
 test("a failed first load is retried before a later write", async (t) => {
-  const directory = await temporaryDirectory(t);
+  const directory = temporaryDirectory(t, "luke-settings-");
   await fs.writeFile(
     path.join(directory, SETTINGS_FILE_NAME),
     JSON.stringify({
@@ -318,7 +310,7 @@ test("every setting starts at its default, survives a reopen, and can be cleared
   for (const field of APP_SETTING_FIELDS) {
     const fallback = APP_SETTING_SCHEMA[field].guard(undefined).value;
     const sample = SAMPLE_VALUE[field];
-    const directory = await temporaryDirectory(t);
+    const directory = temporaryDirectory(t, "luke-settings-");
     const store = storeIn(directory);
 
     assert.deepEqual(await store.get(field), fallback, `${field} did not start at its default`);
@@ -354,7 +346,7 @@ test("every setting starts at its default, survives a reopen, and can be cleared
 
 test("every setting reads as its default when the file holds a shape it cannot be", async (t) => {
   for (const field of APP_SETTING_FIELDS) {
-    const directory = await temporaryDirectory(t);
+    const directory = temporaryDirectory(t, "luke-settings-");
     await fs.writeFile(
       path.join(directory, SETTINGS_FILE_NAME),
       JSON.stringify({ version: 2, apiKeys: {}, [field]: CORRUPT_VALUE }),
@@ -371,7 +363,7 @@ test("every setting reads as its default when the file holds a shape it cannot b
 
 test("no setting's write reaches the cipher, and none disturbs a stored key", async (t) => {
   for (const field of APP_SETTING_FIELDS) {
-    const directory = await temporaryDirectory(t);
+    const directory = temporaryDirectory(t, "luke-settings-");
     const cipher = countingCipher();
     const store = storeIn(directory, { cipher });
     await store.setApiKey(CONDUCTOR, TEST_API_KEY);
@@ -391,7 +383,7 @@ test("no setting's write reaches the cipher, and none disturbs a stored key", as
 });
 
 test("stores an API key encrypted, private to the owner, and never in a snapshot", async (t) => {
-  const directory = await temporaryDirectory(t);
+  const directory = temporaryDirectory(t, "luke-settings-");
   const store = storeIn(directory);
 
   const { settings, reason } = await store.setApiKey(CONDUCTOR, TEST_API_KEY);
@@ -411,7 +403,7 @@ test("stores an API key encrypted, private to the owner, and never in a snapshot
 });
 
 test("round-trips an encrypted account without exposing either token in snapshots", async (t) => {
-  const directory = await temporaryDirectory(t);
+  const directory = temporaryDirectory(t, "luke-settings-");
   const store = storeIn(directory);
   const account = {
     accessToken: "access-token-secret",
@@ -444,7 +436,7 @@ test("round-trips an encrypted account without exposing either token in snapshot
 test("decrypts once and re-decrypts only after the key changes", async (t) => {
   // The observation timer reads the credential every few seconds, so decrypting
   // on each read would reach the OS keychain thousands of times a day.
-  const directory = await temporaryDirectory(t);
+  const directory = temporaryDirectory(t, "luke-settings-");
   let decryptions = 0;
   const cipher = testCipher();
   const store = storeIn(directory, {
@@ -470,7 +462,7 @@ test("decrypts once and re-decrypts only after the key changes", async (t) => {
 });
 
 test("reads a stored key back from a new store instance", async (t) => {
-  const directory = await temporaryDirectory(t);
+  const directory = temporaryDirectory(t, "luke-settings-");
   await storeIn(directory).setApiKey(CONDUCTOR, TEST_API_KEY);
 
   const reopened = storeIn(directory);
@@ -483,7 +475,7 @@ test("reads a stored key back from a new store instance", async (t) => {
 });
 
 test("clears a stored key", async (t) => {
-  const directory = await temporaryDirectory(t);
+  const directory = temporaryDirectory(t, "luke-settings-");
   const store = storeIn(directory);
   await store.setApiKey(CONDUCTOR, TEST_API_KEY);
 
@@ -496,7 +488,7 @@ test("clears a stored key", async (t) => {
 
 // SAFETY: Fixture value matches the narrowed runtime shape this test exercises.
 test("a stored selection keeps only the filters this build recognizes", async (t) => {
-  const directory = await temporaryDirectory(t);
+  const directory = temporaryDirectory(t, "luke-settings-");
   await fs.writeFile(
     path.join(directory, SETTINGS_FILE_NAME),
     JSON.stringify({
@@ -515,7 +507,7 @@ test("a stored selection keeps only the filters this build recognizes", async (t
 
 // SAFETY: Fixture value matches the narrowed runtime shape this test exercises.
 test("a stored query of nothing but whitespace reads as unset rather than narrowing", async (t) => {
-  const directory = await temporaryDirectory(t);
+  const directory = temporaryDirectory(t, "luke-settings-");
   await fs.writeFile(
     path.join(directory, SETTINGS_FILE_NAME),
     JSON.stringify({ version: 2, apiKeys: {}, sessionSearchQuery: "   " }),
@@ -526,7 +518,7 @@ test("a stored query of nothing but whitespace reads as unset rather than narrow
 });
 
 test("a stored connection answers presence without touching any grant", async (t) => {
-  const directory = await temporaryDirectory(t);
+  const directory = temporaryDirectory(t, "luke-settings-");
   const store = storeIn(directory);
 
   assert.equal(await store.calendarConnectionStored(), false);
@@ -539,7 +531,7 @@ test("a stored connection answers presence without touching any grant", async (t
 });
 
 test("a calendar account stores its grant encrypted and survives a reopen", async (t) => {
-  const directory = await temporaryDirectory(t);
+  const directory = temporaryDirectory(t, "luke-settings-");
   const store = storeIn(directory);
 
   assert.deepEqual(await store.readCalendarAccounts(), []);
@@ -566,7 +558,7 @@ test("a calendar account stores its grant encrypted and survives a reopen", asyn
 });
 
 test("accounts stand side by side, and reconnecting one keeps its choices", async (t) => {
-  const directory = await temporaryDirectory(t);
+  const directory = temporaryDirectory(t, "luke-settings-");
   const store = storeIn(directory);
 
   await store.addCalendarAccount("work@example.com", "1//work-grant", ["work@example.com"]);
@@ -591,7 +583,7 @@ test("accounts stand side by side, and reconnecting one keeps its choices", asyn
 });
 
 test("selection changes one calendar on one account, and removal takes the grant with it", async (t) => {
-  const directory = await temporaryDirectory(t);
+  const directory = temporaryDirectory(t, "luke-settings-");
   const store = storeIn(directory);
   await store.addCalendarAccount("dev@example.com", "1//grant", ["dev@example.com"]);
 
@@ -610,7 +602,7 @@ test("selection changes one calendar on one account, and removal takes the grant
 });
 
 test("the Apple Calendar connection stores only the choice and survives a reopen", async (t) => {
-  const directory = await temporaryDirectory(t);
+  const directory = temporaryDirectory(t, "luke-settings-");
   const store = storeIn(directory, { appleCalendarSupported: true });
 
   assert.equal(await store.readAppleCalendarConnection(), undefined);
@@ -635,7 +627,7 @@ test("the Apple Calendar connection stores only the choice and survives a reopen
 });
 
 test("connecting Apple Calendar again keeps the held choices, and selection edits them", async (t) => {
-  const directory = await temporaryDirectory(t);
+  const directory = temporaryDirectory(t, "luke-settings-");
   const store = storeIn(directory, { appleCalendarSupported: true });
   await store.connectAppleCalendar(["default-calendar"]);
   // Asking to connect while connected is not a fresh mind about the choices.
@@ -656,13 +648,13 @@ test("connecting Apple Calendar again keeps the held choices, and selection edit
 });
 
 test("Apple Calendar is not offered where there is no Mac calendar to read", async (t) => {
-  const directory = await temporaryDirectory(t);
+  const directory = temporaryDirectory(t, "luke-settings-");
   const snapshot = await storeIn(directory, { appleCalendarSupported: false }).snapshot();
   assert.equal(appSettingsView(snapshot).appleCalendarAvailable, false);
 });
 
 test("a calendar account never disturbs a stored key, nor a key an account", async (t) => {
-  const directory = await temporaryDirectory(t);
+  const directory = temporaryDirectory(t, "luke-settings-");
   const store = storeIn(directory);
 
   await store.setApiKey(CONDUCTOR, TEST_API_KEY);
@@ -675,7 +667,7 @@ test("a calendar account never disturbs a stored key, nor a key an account", asy
 });
 
 test("keeps each provider's key, environment fallback, and reported source separate", async (t) => {
-  const directory = await temporaryDirectory(t);
+  const directory = temporaryDirectory(t, "luke-settings-");
   const store = storeIn(directory, {
     providers: TEST_PROVIDERS,
     environment: { [TEST_ENVIRONMENT_VARIABLE.SECOND_CLOUD_API_KEY]: "second-cloud-environment" },
@@ -706,7 +698,7 @@ test("keeps each provider's key, environment fallback, and reported source separ
 test("keeps both keys when two providers are saved at once", async (t) => {
   // Each settings row carries its own busy flag, so a user with more than one
   // provider can start a second save before the first has landed.
-  const directory = await temporaryDirectory(t);
+  const directory = temporaryDirectory(t, "luke-settings-");
   const store = storeIn(directory, { providers: TEST_PROVIDERS });
 
   await Promise.all([
@@ -731,7 +723,7 @@ test("keeps both keys when two providers are saved at once", async (t) => {
 });
 
 test("reports nothing for a provider this store does not know", async (t) => {
-  const directory = await temporaryDirectory(t);
+  const directory = temporaryDirectory(t, "luke-settings-");
   const store = storeIn(directory, { providers: [FIRST_CLOUD_PROVIDER] });
 
   assert.equal(await store.readApiKey(SECOND_CLOUD), undefined);
@@ -739,7 +731,7 @@ test("reports nothing for a provider this store does not know", async (t) => {
 });
 
 test("falls back to an API key from the environment", async (t) => {
-  const directory = await temporaryDirectory(t);
+  const directory = temporaryDirectory(t, "luke-settings-");
   const store = storeIn(directory, {
     environment: { [TEST_ENVIRONMENT_VARIABLE.API_TOKEN]: `  ${TEST_API_KEY}  ` },
   });
@@ -751,7 +743,7 @@ test("falls back to an API key from the environment", async (t) => {
 });
 
 test("prefers a stored key over one from the environment", async (t) => {
-  const directory = await temporaryDirectory(t);
+  const directory = temporaryDirectory(t, "luke-settings-");
   const store = storeIn(directory, {
     environment: { [TEST_ENVIRONMENT_VARIABLE.API_KEY]: "conductor-environment-key" },
   });
@@ -761,7 +753,7 @@ test("prefers a stored key over one from the environment", async (t) => {
 });
 
 test("rejects a key that cannot be sent as an authorization header", async (t) => {
-  const directory = await temporaryDirectory(t);
+  const directory = temporaryDirectory(t, "luke-settings-");
   const store = storeIn(directory);
 
   for (const candidate of ["short", "key with spaces", "k".repeat(513)]) {
@@ -778,7 +770,7 @@ test("holds a key only in the form its provider says it issues", async (t) => {
   // A credential in a form the provider no longer accepts would be refused on
   // the first request, and a key Luke cannot use is worth saying so about
   // rather than storing and then going quiet.
-  const directory = await temporaryDirectory(t);
+  const directory = temporaryDirectory(t, "luke-settings-");
   const store = storeIn(directory, {
     providers: TEST_PROVIDERS,
     environment: { [TEST_ENVIRONMENT_VARIABLE.THIRD_CLOUD_API_KEY]: "legacy-third-cloud-key" },
@@ -805,7 +797,7 @@ test("holds a key only in the form its provider says it issues", async (t) => {
 test("stops honouring a stored key the moment its provider names a form it is not", async (t) => {
   // The rule arrived after the key did, so the key was stored under an older
   // build that had no format to hold it to.
-  const directory = await temporaryDirectory(t);
+  const directory = temporaryDirectory(t, "luke-settings-");
   await fs.writeFile(
     path.join(directory, SETTINGS_FILE_NAME),
     JSON.stringify({ version: 2, apiKeys: { [THIRD_CLOUD]: sealed("legacy-third-cloud-key") } }),
@@ -823,7 +815,7 @@ test("stops honouring a stored key the moment its provider names a form it is no
 });
 
 test("refuses to store a key when encrypted storage is unavailable", async (t) => {
-  const directory = await temporaryDirectory(t);
+  const directory = temporaryDirectory(t, "luke-settings-");
   const store = storeIn(directory, { cipher: testCipher(false) });
 
   const { settings, reason } = await store.setApiKey(CONDUCTOR, TEST_API_KEY);
@@ -835,7 +827,7 @@ test("refuses to store a key when encrypted storage is unavailable", async (t) =
 });
 
 test("asks the cipher nothing on a launch with no key to protect", async (t) => {
-  const directory = await temporaryDirectory(t);
+  const directory = temporaryDirectory(t, "luke-settings-");
   const cipher = countingCipher();
   const store = storeIn(directory, { cipher });
 
@@ -848,7 +840,7 @@ test("asks the cipher nothing on a launch with no key to protect", async (t) => 
 });
 
 test("asks the cipher nothing to clear a key", async (t) => {
-  const directory = await temporaryDirectory(t);
+  const directory = temporaryDirectory(t, "luke-settings-");
   const cipher = countingCipher();
   const store = storeIn(directory, { cipher });
 
@@ -860,7 +852,7 @@ test("asks the cipher nothing to clear a key", async (t) => {
 });
 
 test("asks once when a key is stored and reports that answer from then on", async (t) => {
-  const directory = await temporaryDirectory(t);
+  const directory = temporaryDirectory(t, "luke-settings-");
   const cipher = countingCipher();
   const store = storeIn(directory, { cipher });
 
@@ -875,7 +867,7 @@ test("asks once when a key is stored and reports that answer from then on", asyn
 });
 
 test("decrypts a stored key without asking whether storage is available", async (t) => {
-  const directory = await temporaryDirectory(t);
+  const directory = temporaryDirectory(t, "luke-settings-");
   await storeIn(directory).setApiKey(CONDUCTOR, TEST_API_KEY);
   const cipher = countingCipher();
   const store = storeIn(directory, { cipher });
@@ -888,7 +880,7 @@ test("decrypts a stored key without asking whether storage is available", async 
 });
 
 test("ignores a stored key that can no longer be decrypted", async (t) => {
-  const directory = await temporaryDirectory(t);
+  const directory = temporaryDirectory(t, "luke-settings-");
   await storeIn(directory).setApiKey(CONDUCTOR, TEST_API_KEY);
   await fs.writeFile(
     path.join(directory, SETTINGS_FILE_NAME),
@@ -909,7 +901,7 @@ test("ignores a stored key that can no longer be decrypted", async (t) => {
 
 test("carries a key belonging to a provider this build does not know", async (t) => {
   // A file written by a newer build must not lose credentials to an older one.
-  const directory = await temporaryDirectory(t);
+  const directory = temporaryDirectory(t, "luke-settings-");
   await fs.writeFile(
     path.join(directory, SETTINGS_FILE_NAME),
     JSON.stringify({ version: 2, apiKeys: { "later-cloud": sealed("later-cloud-key") } }),
@@ -930,7 +922,7 @@ test("decides the Dock icon from the file alone, never the keychain", async (t) 
   // The icon is drawn at launch from this answer, so a locked or slow
   // Keychain — which decrypting a stored key can wait on — must not be able to
   // delay it.
-  const directory = await temporaryDirectory(t);
+  const directory = temporaryDirectory(t, "luke-settings-");
   await fs.writeFile(
     path.join(directory, SETTINGS_FILE_NAME),
     JSON.stringify({
@@ -947,7 +939,7 @@ test("decides the Dock icon from the file alone, never the keychain", async (t) 
 });
 
 test("prefers the chosen voice over the environment, and the environment over the default", async (t) => {
-  const directory = await temporaryDirectory(t);
+  const directory = temporaryDirectory(t, "luke-settings-");
   const store = storeIn(directory, {
     environment: { LUKE_REALTIME_VOICE: REALTIME_VOICE.SAGE },
   });
@@ -966,7 +958,7 @@ test("prefers the chosen voice over the environment, and the environment over th
 });
 
 test("ignores a stored or environment voice this build does not offer", async (t) => {
-  const directory = await temporaryDirectory(t);
+  const directory = temporaryDirectory(t, "luke-settings-");
   await fs.writeFile(
     path.join(directory, SETTINGS_FILE_NAME),
     JSON.stringify({ version: 2, apiKeys: {}, voice: "baritone" }),
@@ -978,7 +970,7 @@ test("ignores a stored or environment voice this build does not offer", async (t
 });
 
 test("prefers the chosen pace over the environment, and the environment over the default", async (t) => {
-  const directory = await temporaryDirectory(t);
+  const directory = temporaryDirectory(t, "luke-settings-");
   const store = storeIn(directory, {
     environment: { LUKE_REALTIME_SPEED: String(REALTIME_VOICE_SPEED.SLOW) },
   });
@@ -994,7 +986,7 @@ test("prefers the chosen pace over the environment, and the environment over the
 });
 
 test("ignores a stored or environment pace this build does not offer", async (t) => {
-  const directory = await temporaryDirectory(t);
+  const directory = temporaryDirectory(t, "luke-settings-");
   await fs.writeFile(
     path.join(directory, SETTINGS_FILE_NAME),
     JSON.stringify({ version: 2, apiKeys: {}, voiceSpeed: 3 }),
@@ -1006,7 +998,7 @@ test("ignores a stored or environment pace this build does not offer", async (t)
 });
 
 test("account preferences extraction excludes resolved defaults and local-only preferences", async (t) => {
-  const directory = await temporaryDirectory(t);
+  const directory = temporaryDirectory(t, "luke-settings-");
   const store = storeIn(directory, {
     environment: {
       LUKE_REALTIME_VOICE: REALTIME_VOICE.SAGE,
@@ -1024,7 +1016,7 @@ test("account preferences extraction excludes resolved defaults and local-only p
 });
 
 test("applies account preferences to disk and restores them from a new store", async (t) => {
-  const directory = await temporaryDirectory(t);
+  const directory = temporaryDirectory(t, "luke-settings-");
   const store = storeIn(directory);
   await store.set(APP_SETTING_SCHEMA.showInDock.field, true);
   await store.set(APP_SETTING_SCHEMA.voiceHotkey.field, VOICE_HOTKEY_NONE);
@@ -1056,7 +1048,7 @@ test("applies account preferences to disk and restores them from a new store", a
 });
 
 test("merges hosted account preferences around concurrent local preference edits", async (t) => {
-  const directory = await temporaryDirectory(t);
+  const directory = temporaryDirectory(t, "luke-settings-");
   const store = storeIn(directory);
   const account = {
     accessToken: "access-token-secret",
@@ -1091,7 +1083,7 @@ test("merges hosted account preferences around concurrent local preference edits
 });
 
 test("keeps local account preference edits across a failed hosted write and restart", async (t) => {
-  const directory = await temporaryDirectory(t);
+  const directory = temporaryDirectory(t, "luke-settings-");
   const account = {
     accessToken: "access-token-secret",
     refreshToken: "refresh-token-secret",
@@ -1119,7 +1111,7 @@ test("keeps local account preference edits across a failed hosted write and rest
 });
 
 test("skips a guarded account preference apply after account sign-out", async (t) => {
-  const directory = await temporaryDirectory(t);
+  const directory = temporaryDirectory(t, "luke-settings-");
   const store = storeIn(directory);
   const account = {
     accessToken: "access-token-secret",
@@ -1148,7 +1140,7 @@ test("skips a guarded account preference apply after account sign-out", async (t
 });
 
 test("stores a deleted talk key as the none token and reads it back", async (t) => {
-  const directory = await temporaryDirectory(t);
+  const directory = temporaryDirectory(t, "luke-settings-");
   const store = storeIn(directory);
 
   const { settings, reason } = await store.set(
@@ -1172,7 +1164,7 @@ test("ignores a stored chord this build cannot register", async (t) => {
     APP_SETTING_SCHEMA.askHotkey.field,
     APP_SETTING_SCHEMA.stopHotkey.field,
   ]) {
-    const directory = await temporaryDirectory(t);
+    const directory = temporaryDirectory(t, "luke-settings-");
     await fs.writeFile(
       path.join(directory, SETTINGS_FILE_NAME),
       JSON.stringify({ version: 2, apiKeys: {}, [field]: "F13" }),
@@ -1187,7 +1179,7 @@ test("ignores a stored chord this build cannot register", async (t) => {
 });
 
 test("the three Luke keys survive each other's writes", async (t) => {
-  const directory = await temporaryDirectory(t);
+  const directory = temporaryDirectory(t, "luke-settings-");
   const store = storeIn(directory);
 
   await store.set(APP_SETTING_SCHEMA.voiceHotkey.field, "Control+Alt+Space");
@@ -1202,7 +1194,7 @@ test("the three Luke keys survive each other's writes", async (t) => {
 
 test("a stored key and a chosen preference survive each other's writes", async (t) => {
   for (const field of APP_SETTING_FIELDS) {
-    const directory = await temporaryDirectory(t);
+    const directory = temporaryDirectory(t, "luke-settings-");
     const store = storeIn(directory);
 
     await store.setApiKey(CONDUCTOR, TEST_API_KEY);
@@ -1216,7 +1208,7 @@ test("a stored key and a chosen preference survive each other's writes", async (
 });
 
 test("ignores a stored form this build does not draw", async (t) => {
-  const directory = await temporaryDirectory(t);
+  const directory = temporaryDirectory(t, "luke-settings-");
   await fs.writeFile(
     path.join(directory, SETTINGS_FILE_NAME),
     JSON.stringify({ version: 2, apiKeys: {}, formFactor: "hexagon" }),
@@ -1230,7 +1222,7 @@ test("ignores a stored form this build does not draw", async (t) => {
 });
 
 test("ignores a stored default provider this build does not know", async (t) => {
-  const directory = await temporaryDirectory(t);
+  const directory = temporaryDirectory(t, "luke-settings-");
   await fs.writeFile(
     path.join(directory, SETTINGS_FILE_NAME),
     JSON.stringify({ version: 2, apiKeys: {}, defaultWorkspaceProvider: "someone-else" }),
@@ -1247,7 +1239,7 @@ test("ignores a stored default provider this build does not know", async (t) => 
 });
 
 test("stores Superset workspace and agent defaults without touching credentials", async (t) => {
-  const directory = await temporaryDirectory(t);
+  const directory = temporaryDirectory(t, "luke-settings-");
   const store = storeIn(directory);
 
   await store.set(APP_SETTING_SCHEMA.defaultWorkspaceProvider.field, "superset");
@@ -1268,7 +1260,7 @@ test("stores Superset workspace and agent defaults without touching credentials"
 });
 
 test("lets the first creation choose each provider's project until one is chosen", async (t) => {
-  const directory = await temporaryDirectory(t);
+  const directory = temporaryDirectory(t, "luke-settings-");
   const store = storeIn(directory);
 
   // Unset on purpose, the provider default's own terms: the default is always
@@ -1302,7 +1294,7 @@ test("lets the first creation choose each provider's project until one is chosen
 });
 
 test("keeps one provider's default project apart from another's", async (t) => {
-  const directory = await temporaryDirectory(t);
+  const directory = temporaryDirectory(t, "luke-settings-");
   const store = storeIn(directory);
 
   await setWorkspaceProjectDefault(store, PROVIDER_ID.CONDUCTOR, "proj-1");
@@ -1320,7 +1312,7 @@ test("keeps one provider's default project apart from another's", async (t) => {
 });
 
 test("forgetting a default no provider offers survives the reload it was written for", async (t) => {
-  const directory = await temporaryDirectory(t);
+  const directory = temporaryDirectory(t, "luke-settings-");
   const cipher = countingCipher();
   const store = storeIn(directory, { cipher });
   await setWorkspaceProjectDefault(store, PROVIDER_ID.CONDUCTOR, "proj-gone");
@@ -1338,7 +1330,7 @@ test("forgetting a default no provider offers survives the reload it was written
 });
 
 test("a stale cleanup cannot clear a newer project default", async (t) => {
-  const store = storeIn(await temporaryDirectory(t));
+  const store = storeIn(temporaryDirectory(t, "luke-settings-"));
   await setWorkspaceProjectDefault(store, PROVIDER_ID.CONDUCTOR, "proj-old");
   await setWorkspaceProjectDefault(store, PROVIDER_ID.CONDUCTOR, "proj-new");
 
@@ -1421,7 +1413,7 @@ test("every map-valued setting is written one entry at a time", () => {
 });
 
 test("overlapping default projects each survive the other's write", async (t) => {
-  const directory = await temporaryDirectory(t);
+  const directory = temporaryDirectory(t, "luke-settings-");
   const store = storeIn(directory);
 
   // Both start before either lands, the way two provider rows saved in quick
@@ -1440,7 +1432,7 @@ test("overlapping default projects each survive the other's write", async (t) =>
 });
 
 test("an overlapping clear forgets its own entry and no other", async (t) => {
-  const directory = await temporaryDirectory(t);
+  const directory = temporaryDirectory(t, "luke-settings-");
   const store = storeIn(directory);
   await setWorkspaceProjectDefault(store, PROVIDER_ID.CONDUCTOR, "proj-1");
 
@@ -1457,7 +1449,7 @@ test("an overlapping clear forgets its own entry and no other", async (t) => {
 });
 
 test("ignores stored default projects this store cannot hold", async (t) => {
-  const directory = await temporaryDirectory(t);
+  const directory = temporaryDirectory(t, "luke-settings-");
   await fs.writeFile(
     path.join(directory, SETTINGS_FILE_NAME),
     JSON.stringify({
@@ -1481,7 +1473,7 @@ test("ignores stored default projects this store cannot hold", async (t) => {
 });
 
 test("ignores a stored pairing this build's table does not list", async (t) => {
-  const directory = await temporaryDirectory(t);
+  const directory = temporaryDirectory(t, "luke-settings-");
   await fs.writeFile(
     path.join(directory, SETTINGS_FILE_NAME),
     JSON.stringify({
@@ -1504,7 +1496,7 @@ test("ignores a stored pairing this build's table does not list", async (t) => {
 });
 
 test("recovers from a corrupt settings file", async (t) => {
-  const directory = await temporaryDirectory(t);
+  const directory = temporaryDirectory(t, "luke-settings-");
   await fs.writeFile(path.join(directory, SETTINGS_FILE_NAME), "{ not json");
   const store = storeIn(directory);
 
@@ -1518,7 +1510,7 @@ test("recovers from a corrupt settings file", async (t) => {
 });
 
 test("a voice reset forgets the voice, pace, captions, and duck in one act", async (t) => {
-  const directory = await temporaryDirectory(t);
+  const directory = temporaryDirectory(t, "luke-settings-");
   const store = storeIn(directory);
   await store.set(APP_SETTING_SCHEMA.voice.field, REALTIME_VOICE.MARIN);
   await store.set(APP_SETTING_SCHEMA.voiceSpeed.field, REALTIME_VOICE_SPEED.QUICK);
@@ -1539,7 +1531,7 @@ test("a voice reset forgets the voice, pace, captions, and duck in one act", asy
 });
 
 test("a voice reset returns to the environment's voice where one stands behind the choice", async (t) => {
-  const directory = await temporaryDirectory(t);
+  const directory = temporaryDirectory(t, "luke-settings-");
   const store = storeIn(directory, {
     environment: { LUKE_REALTIME_VOICE: REALTIME_VOICE.SAGE },
   });
@@ -1554,7 +1546,7 @@ test("a voice reset returns to the environment's voice where one stands behind t
 });
 
 test("an appearance reset returns Luke's stances without touching the voice page", async (t) => {
-  const directory = await temporaryDirectory(t);
+  const directory = temporaryDirectory(t, "luke-settings-");
   const store = storeIn(directory);
   await store.set(APP_SETTING_SCHEMA.showInDock.field, true);
   await store.set(APP_SETTING_SCHEMA.showOnAllDisplays.field, true);
@@ -1573,7 +1565,7 @@ test("an appearance reset returns Luke's stances without touching the voice page
 });
 
 test("a shortcuts reset forgets all three chords at once", async (t) => {
-  const directory = await temporaryDirectory(t);
+  const directory = temporaryDirectory(t, "luke-settings-");
   const store = storeIn(directory);
   await store.set(APP_SETTING_SCHEMA.voiceHotkey.field, "Shift+Command+L");
   await store.set(APP_SETTING_SCHEMA.askHotkey.field, "Control+Alt+K");
@@ -1591,7 +1583,7 @@ test("a shortcuts reset forgets all three chords at once", async (t) => {
 });
 
 test("a workspaces reset forgets the provider and project defaults but never the agent pairing", async (t) => {
-  const directory = await temporaryDirectory(t);
+  const directory = temporaryDirectory(t, "luke-settings-");
   const store = storeIn(directory);
   const pairing = { agent: "claude", model: "sonnet" };
   await store.set(APP_SETTING_SCHEMA.defaultWorkspaceProvider.field, PROVIDER_ID.CONDUCTOR);
@@ -1615,7 +1607,7 @@ test("a workspaces reset forgets the provider and project defaults but never the
 });
 
 test("a reset of settings already at their defaults writes nothing", async (t) => {
-  const directory = await temporaryDirectory(t);
+  const directory = temporaryDirectory(t, "luke-settings-");
   const store = storeIn(directory);
 
   const { settings, reason } = await store.resetSettings(SETTINGS_RESET_SCOPE.VOICE);
@@ -1628,7 +1620,7 @@ test("a reset of settings already at their defaults writes nothing", async (t) =
 });
 
 test("a reset never touches the cipher", async (t) => {
-  const directory = await temporaryDirectory(t);
+  const directory = temporaryDirectory(t, "luke-settings-");
   const cipher = countingCipher();
   const store = storeIn(directory, { cipher });
   await store.set(APP_SETTING_SCHEMA.voiceCaptions.field, true);
@@ -1641,7 +1633,7 @@ test("a reset never touches the cipher", async (t) => {
 });
 
 test("a reset leaves a stored key standing", async (t) => {
-  const directory = await temporaryDirectory(t);
+  const directory = temporaryDirectory(t, "luke-settings-");
   await fs.writeFile(
     path.join(directory, SETTINGS_FILE_NAME),
     JSON.stringify({
@@ -1679,7 +1671,7 @@ const TEST_ACCOUNT = {
 };
 
 test("with no key stored there is only one source to run on", async (t) => {
-  const store = storeIn(await temporaryDirectory(t));
+  const store = storeIn(temporaryDirectory(t, "luke-settings-"));
   await store.setAccount(TEST_ACCOUNT);
 
   assert.equal(await store.readVoiceSource(), VOICE_SOURCE.ACCOUNT);
@@ -1693,7 +1685,7 @@ test("with no key stored there is only one source to run on", async (t) => {
 });
 
 test("connecting the voice key chooses it, and the allowance can take it back", async (t) => {
-  const store = storeIn(await temporaryDirectory(t));
+  const store = storeIn(temporaryDirectory(t, "luke-settings-"));
   await store.setAccount(TEST_ACCOUNT);
   await store.setApiKey(CREDENTIAL_PROVIDER_ID.OPENAI, "sk-developers-own");
 
@@ -1716,7 +1708,7 @@ test("connecting the voice key chooses it, and the allowance can take it back", 
 });
 
 test("a choice that would start spending a key is never made by fallback", async (t) => {
-  const directory = await temporaryDirectory(t);
+  const directory = temporaryDirectory(t, "luke-settings-");
   const store = storeIn(directory);
   await store.setAccount(TEST_ACCOUNT);
   await store.setApiKey(CREDENTIAL_PROVIDER_ID.OPENAI, "sk-developers-own");
@@ -1737,7 +1729,7 @@ test("a choice that would start spending a key is never made by fallback", async
 
 // SAFETY: Fixture value matches the narrowed runtime shape this test exercises.
 test("the chosen source survives a reopen, and a corrupt one reads as no choice", async (t) => {
-  const directory = await temporaryDirectory(t);
+  const directory = temporaryDirectory(t, "luke-settings-");
   const store = storeIn(directory);
   await store.setAccount(TEST_ACCOUNT);
   await store.setApiKey(CREDENTIAL_PROVIDER_ID.OPENAI, "sk-developers-own");
@@ -1757,7 +1749,7 @@ test("the chosen source survives a reopen, and a corrupt one reads as no choice"
 });
 
 test("pasting a key back while parked on the allowance is still choosing it", async (t) => {
-  const store = storeIn(await temporaryDirectory(t));
+  const store = storeIn(temporaryDirectory(t, "luke-settings-"));
   await store.setAccount(TEST_ACCOUNT);
   await store.setApiKey(CREDENTIAL_PROVIDER_ID.OPENAI, "sk-developers-own");
   await store.set(APP_SETTING_SCHEMA.voiceSource.field, VOICE_SOURCE.ACCOUNT);
@@ -1772,7 +1764,7 @@ test("pasting a key back while parked on the allowance is still choosing it", as
 });
 
 test("a grant is stored encrypted, and read back only in the main process", async (t) => {
-  const directory = await temporaryDirectory(t);
+  const directory = temporaryDirectory(t, "luke-settings-");
   const store = storeIn(directory, { providers: TEST_PROVIDERS });
 
   const { settings } = await store.setGrant(CONSENT_SERVICE, {
@@ -1809,7 +1801,7 @@ test("a grant is stored encrypted, and read back only in the main process", asyn
 });
 
 test("clearing a grant leaves nothing behind, and keys alone", async (t) => {
-  const directory = await temporaryDirectory(t);
+  const directory = temporaryDirectory(t, "luke-settings-");
   const store = storeIn(directory, { providers: TEST_PROVIDERS });
   await store.setApiKey(FIRST_CLOUD, "first-cloud-key");
   await store.setGrant(CONSENT_SERVICE, { accessToken: "granted-access", expiresAt: 1 });
@@ -1826,7 +1818,7 @@ test("clearing a grant leaves nothing behind, and keys alone", async (t) => {
 });
 
 test("a key left by a build that asked for one is dropped, never carried", async (t) => {
-  const directory = await temporaryDirectory(t);
+  const directory = temporaryDirectory(t, "luke-settings-");
   // What an installation upgraded from a build that pasted this service's key
   // would hold: a credential this build can never send anywhere.
   await fs.writeFile(

--- a/apps/desktop/src/main/voice/speech-arbiter.test.ts
+++ b/apps/desktop/src/main/voice/speech-arbiter.test.ts
@@ -9,6 +9,7 @@ import {
   isBriefingSpeech,
 } from "@sidecar/realtime";
 import { SPEECH_OUTCOME } from "#shared/messages/speech";
+import { FakeClock } from "#testing/fake-clock";
 import {
   MAXIMUM_PENDING_BRIEFINGS,
   SPEECH_DECISION,
@@ -23,11 +24,11 @@ function delivery(briefing: string, decidedAt = 1_000): BrainDelivery {
 interface Harness {
   arbiter: SpeechArbiter;
   traces: SpeechTraceRecord[];
-  clock: { now: number };
+  clock: FakeClock;
 }
 
 function harness(now = 1_000): Harness {
-  const clock = { now };
+  const clock = new FakeClock(now);
   const traces: SpeechTraceRecord[] = [];
   let id = 0;
   const arbiter = new SpeechArbiter({

--- a/apps/desktop/src/main/window/dock-presence.test.ts
+++ b/apps/desktop/src/main/window/dock-presence.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import { drainMicrotasks } from "#testing/drain";
 import { DOCK_ICON_FILES, DockPresence, type DockTile } from "./dock-presence";
 
 function harness(options: { visible?: boolean; ignoreFirstHide?: boolean } = {}) {
@@ -70,8 +71,8 @@ function harness(options: { visible?: boolean; ignoreFirstHide?: boolean } = {})
 test("a hide macOS ignores is asked again until the Dock matches", async () => {
   const context = harness({ visible: true, ignoreFirstHide: true });
   context.presence.apply(false, 7);
-  await new Promise((resolve) => setImmediate(resolve));
-  await new Promise((resolve) => setImmediate(resolve));
+  await drainMicrotasks(1);
+  await drainMicrotasks(1);
 
   assert.equal(context.hideAttempts(), 2);
   assert.equal(context.isVisible(), false);
@@ -82,7 +83,7 @@ test("a hide macOS ignores is asked again until the Dock matches", async () => {
 test("a show puts Luke's face back on the tile the show forgot", async () => {
   const context = harness({ visible: false });
   context.presence.apply(true);
-  await new Promise((resolve) => setImmediate(resolve));
+  await drainMicrotasks(1);
 
   assert.equal(context.isVisible(), true);
   assert.deepEqual(context.icons(), [DOCK_ICON_FILES.LIGHT]);

--- a/apps/desktop/src/renderer/errand-queue.test.ts
+++ b/apps/desktop/src/renderer/errand-queue.test.ts
@@ -1,11 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { CREDENTIAL_PROVIDER_ID } from "@sidecar/credentials/vocabulary";
-import { REALTIME_VOICE, REALTIME_VOICE_SPEED } from "@sidecar/realtime";
-import { PANEL_FORM_FACTOR } from "@sidecar/surface";
-import { CREDENTIAL_SOURCE, SECRET_STORAGE } from "#shared/messages/account";
-import type { AppSettingsView } from "#shared/messages/settings";
-import { APP_SETTING_DEFAULTS, CLI_CONNECTION, VOICE_SOURCE } from "#shared/messages/settings";
+import { settingsView } from "#testing/settings-fixtures";
 import {
   armErrand,
   EMPTY_ERRAND_RUN,
@@ -29,35 +24,7 @@ import { PANEL_TAB } from "./panel-tabs";
 import { SESSION_FILTER, SESSION_SORT } from "./session-model";
 import { SETTINGS_VIEW } from "./settings-views";
 
-/** A settings snapshot, told apart from the next only by the switch that moved. */
-function settings(captions: boolean): AppSettingsView {
-  return {
-    ...APP_SETTING_DEFAULTS,
-    credentialSources: {
-      [CREDENTIAL_PROVIDER_ID.CONDUCTOR]: CREDENTIAL_SOURCE.NONE,
-      [CREDENTIAL_PROVIDER_ID.LINEAR]: CREDENTIAL_SOURCE.NONE,
-      [CREDENTIAL_PROVIDER_ID.OPENAI]: CREDENTIAL_SOURCE.NONE,
-    },
-    secretStorage: SECRET_STORAGE.UNKNOWN,
-    codexCloudConnection: CLI_CONNECTION.UNKNOWN,
-    showInDock: false,
-    voice: REALTIME_VOICE.CEDAR,
-    voiceSpeed: REALTIME_VOICE_SPEED.NORMAL,
-    voiceCaptions: captions,
-    duckOtherMedia: true,
-    quietDuringMeetings: true,
-    announceSessions: true,
-    calendarSignInAvailable: false,
-    linearSignInAvailable: false,
-    appleCalendarAvailable: false,
-    voiceAvailable: false,
-    voiceSource: VOICE_SOURCE.ACCOUNT,
-    preferBuiltInMicrophone: false,
-    calendarAccounts: [],
-    showOnAllDisplays: false,
-    formFactor: PANEL_FORM_FACTOR.BUBBLE,
-  };
-}
+const settings = (captions: boolean) => settingsView({ voiceCaptions: captions });
 
 // SAFETY: Fixture value matches the narrowed runtime shape this test exercises.
 /** A settings change, as the carrier arms one. */

--- a/apps/desktop/src/renderer/luke-errand.test.ts
+++ b/apps/desktop/src/renderer/luke-errand.test.ts
@@ -1,19 +1,15 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { SESSION_LIST_ALL } from "@sidecar/acts";
-import { CREDENTIAL_PROVIDER_ID } from "@sidecar/credentials/vocabulary";
 import {
   APP_PANEL_TAB,
   APP_SETTING_KIND,
   type AppGuideSetting,
   SESSION_LIST_SORT,
 } from "@sidecar/guide";
-import { REALTIME_VOICE, REALTIME_VOICE_SPEED } from "@sidecar/realtime";
-import { PANEL_FORM_FACTOR } from "@sidecar/surface";
-import { ACCOUNT_STATUS, CREDENTIAL_SOURCE, SECRET_STORAGE } from "#shared/messages/account";
-import type { AppSettingsView } from "#shared/messages/settings";
-import { APP_SETTING_DEFAULTS, CLI_CONNECTION, VOICE_SOURCE } from "#shared/messages/settings";
+import { ACCOUNT_STATUS } from "#shared/messages/account";
 import { UPDATE_STATUS } from "#shared/messages/update";
+import { settingsView } from "#testing/settings-fixtures";
 import {
   captionRoom,
   ERRAND_TARGET,
@@ -33,38 +29,9 @@ import {
 import { APP_SETTING_ID, buildLukeGuide, isAppSettingId, type LukeGuideInput } from "./luke-guide";
 import { SETTING_PAGE, SETTINGS_PAGE_LABEL } from "./settings-views";
 
-function settings(): AppSettingsView {
-  return {
-    ...APP_SETTING_DEFAULTS,
-    credentialSources: {
-      [CREDENTIAL_PROVIDER_ID.CONDUCTOR]: CREDENTIAL_SOURCE.NONE,
-      [CREDENTIAL_PROVIDER_ID.LINEAR]: CREDENTIAL_SOURCE.NONE,
-      [CREDENTIAL_PROVIDER_ID.OPENAI]: CREDENTIAL_SOURCE.NONE,
-    },
-    secretStorage: SECRET_STORAGE.UNKNOWN,
-    codexCloudConnection: CLI_CONNECTION.UNKNOWN,
-    showInDock: false,
-    voice: REALTIME_VOICE.CEDAR,
-    voiceSpeed: REALTIME_VOICE_SPEED.NORMAL,
-    voiceCaptions: false,
-    duckOtherMedia: true,
-    quietDuringMeetings: true,
-    announceSessions: true,
-    calendarSignInAvailable: false,
-    linearSignInAvailable: false,
-    appleCalendarAvailable: false,
-    voiceAvailable: false,
-    voiceSource: VOICE_SOURCE.ACCOUNT,
-    preferBuiltInMicrophone: false,
-    calendarAccounts: [],
-    showOnAllDisplays: false,
-    formFactor: PANEL_FORM_FACTOR.BUBBLE,
-  };
-}
-
 const guideInput: LukeGuideInput = {
   account: { status: ACCOUNT_STATUS.SIGNED_OUT },
-  settings: settings(),
+  settings: settingsView(),
   update: {
     status: UPDATE_STATUS.IDLE,
     currentVersion: "0.3.8",

--- a/apps/desktop/src/renderer/luke-guide.test.ts
+++ b/apps/desktop/src/renderer/luke-guide.test.ts
@@ -14,7 +14,6 @@ import {
   REALTIME_VOICE_SPEED,
 } from "@sidecar/realtime";
 import { PROVIDER_ID, type WorkspaceAgentSelection } from "@sidecar/session";
-import { VOICE_SOURCE } from "@sidecar/settings";
 import { PANEL_FORM_FACTOR } from "@sidecar/surface";
 import {
   ACCOUNT_PROVIDER,
@@ -23,9 +22,10 @@ import {
   SECRET_STORAGE,
 } from "#shared/messages/account";
 import type { AppSettingsView, SettingsUpdateResult } from "#shared/messages/settings";
-import { APP_SETTING_DEFAULTS, appSettingsView, CLI_CONNECTION } from "#shared/messages/settings";
+import { appSettingsView } from "#shared/messages/settings";
 import type { UpdateSnapshot } from "#shared/messages/update";
 import { UPDATE_STATUS } from "#shared/messages/update";
+import { settingsView } from "#testing/settings-fixtures";
 import { appSettingsWire, spokenSettingBridge } from "#testing/spoken-setting-bridge";
 import {
   APP_SETTING_ID,
@@ -35,37 +35,16 @@ import {
 } from "./luke-guide";
 
 function settings(overrides: Partial<AppSettingsView> = {}): AppSettingsView {
-  // Object.assign rather than a spread: spreading a Partial marks every key it
-  // could carry optional, and the result stops being an AppSettingsView.
-  return Object.assign<AppSettingsView, Partial<AppSettingsView>>(
-    {
-      ...APP_SETTING_DEFAULTS,
-      credentialSources: {
-        [CREDENTIAL_PROVIDER_ID.CONDUCTOR]: CREDENTIAL_SOURCE.ENCRYPTED_FILE,
-        [CREDENTIAL_PROVIDER_ID.LINEAR]: CREDENTIAL_SOURCE.NONE,
-        [CREDENTIAL_PROVIDER_ID.OPENAI]: CREDENTIAL_SOURCE.NONE,
-      },
-      secretStorage: SECRET_STORAGE.UNKNOWN,
-      codexCloudConnection: CLI_CONNECTION.UNKNOWN,
-      showInDock: false,
-      voice: REALTIME_VOICE.CEDAR,
-      voiceSpeed: REALTIME_VOICE_SPEED.NORMAL,
-      voiceCaptions: false,
-      duckOtherMedia: true,
-      quietDuringMeetings: true,
-      announceSessions: true,
-      calendarSignInAvailable: false,
-      appleCalendarAvailable: false,
-      linearSignInAvailable: false,
-      calendarAccounts: [],
-      showOnAllDisplays: false,
-      formFactor: PANEL_FORM_FACTOR.BUBBLE,
-      voiceAvailable: true,
-      voiceSource: VOICE_SOURCE.ACCOUNT,
-      preferBuiltInMicrophone: true,
+  return settingsView({
+    credentialSources: {
+      [CREDENTIAL_PROVIDER_ID.CONDUCTOR]: CREDENTIAL_SOURCE.ENCRYPTED_FILE,
+      [CREDENTIAL_PROVIDER_ID.LINEAR]: CREDENTIAL_SOURCE.NONE,
+      [CREDENTIAL_PROVIDER_ID.OPENAI]: CREDENTIAL_SOURCE.NONE,
     },
-    overrides,
-  );
+    voiceAvailable: true,
+    preferBuiltInMicrophone: true,
+    ...overrides,
+  });
 }
 
 function idleUpdate(upToDate = false): UpdateSnapshot {

--- a/apps/desktop/src/renderer/settings-search.test.ts
+++ b/apps/desktop/src/renderer/settings-search.test.ts
@@ -1,12 +1,11 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { CLOUD_AGENT_PROVIDER_LIST, CREDENTIAL_PROVIDER_ID } from "@sidecar/credentials/vocabulary";
-import { REALTIME_VOICE, REALTIME_VOICE_SPEED } from "@sidecar/realtime";
 import { APP_SETTING_SCHEMA, settingFieldForGuideId, settingGuideEntries } from "@sidecar/settings";
-import { PANEL_FORM_FACTOR } from "@sidecar/surface";
-import { CREDENTIAL_SOURCE, SECRET_STORAGE } from "#shared/messages/account";
+import { CREDENTIAL_SOURCE } from "#shared/messages/account";
 import type { AppSettingsView } from "#shared/messages/settings";
-import { APP_SETTING_DEFAULTS, CLI_CONNECTION, VOICE_SOURCE } from "#shared/messages/settings";
+import { VOICE_SOURCE } from "#shared/messages/settings";
+import { settingsView } from "#testing/settings-fixtures";
 import {
   type SettingsSearchEntry,
   type SettingsSearchInput,
@@ -17,35 +16,7 @@ import {
 import { SETTINGS_VIEW } from "./settings-views";
 
 function settings(overrides: Partial<AppSettingsView> = {}): AppSettingsView {
-  return Object.assign<AppSettingsView, Partial<AppSettingsView>>(
-    {
-      ...APP_SETTING_DEFAULTS,
-      credentialSources: {
-        [CREDENTIAL_PROVIDER_ID.CONDUCTOR]: CREDENTIAL_SOURCE.NONE,
-        [CREDENTIAL_PROVIDER_ID.LINEAR]: CREDENTIAL_SOURCE.NONE,
-        [CREDENTIAL_PROVIDER_ID.OPENAI]: CREDENTIAL_SOURCE.NONE,
-      },
-      secretStorage: SECRET_STORAGE.UNKNOWN,
-      codexCloudConnection: CLI_CONNECTION.UNKNOWN,
-      voiceAvailable: true,
-      voiceSource: VOICE_SOURCE.ACCOUNT,
-      showInDock: false,
-      voice: REALTIME_VOICE.CEDAR,
-      voiceSpeed: REALTIME_VOICE_SPEED.NORMAL,
-      voiceCaptions: false,
-      duckOtherMedia: true,
-      preferBuiltInMicrophone: true,
-      quietDuringMeetings: true,
-      announceSessions: true,
-      calendarSignInAvailable: false,
-      appleCalendarAvailable: false,
-      linearSignInAvailable: false,
-      calendarAccounts: [],
-      showOnAllDisplays: false,
-      formFactor: PANEL_FORM_FACTOR.BUBBLE,
-    },
-    overrides,
-  );
+  return settingsView({ voiceAvailable: true, preferBuiltInMicrophone: true, ...overrides });
 }
 
 function searchInput(overrides: Partial<SettingsSearchInput> = {}): SettingsSearchInput {

--- a/apps/desktop/src/renderer/voice/reply-delivery-player.test.ts
+++ b/apps/desktop/src/renderer/voice/reply-delivery-player.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 import { BRAIN_REQUEST_ORIGIN, type BrainRequestOrigin } from "@sidecar/brain/requests";
 import { REALTIME_STATUS, type RealtimeStatus } from "@sidecar/realtime";
 import type { BrainReplyClaimResult, BrainReplyOffer } from "#shared/messages/brain";
+import { drainMicrotasks } from "#testing/drain";
 import { ReplyDeliveryPlayer } from "./reply-delivery-player";
 
 interface Harness {
@@ -85,8 +86,6 @@ function harness(): Harness {
   };
 }
 
-const tick = () => new Promise((resolve) => setImmediate(resolve));
-
 function granted(
   words: string,
   origin: BrainRequestOrigin = BRAIN_REQUEST_ORIGIN.TYPED,
@@ -99,10 +98,10 @@ test("an offer is claimed, the call opened, the words spoken once, and acknowled
   h.player.offer(offer("run-1"));
   assert.deepEqual(h.log, ["claim run-1@1"]);
   h.grant(granted("Two agents are waiting."));
-  await tick();
+  await drainMicrotasks(1);
   assert.deepEqual(h.log.slice(1), ["connect"]);
   h.connected(true);
-  await tick();
+  await drainMicrotasks(1);
   assert.deepEqual(h.log.slice(2), ["speak run-1: Two agents are waiting.", "speaking typed"]);
   assert.equal(h.player.active?.runId, "run-1");
   // The same offer again is the same offer; another run's ending is not this one's.
@@ -121,7 +120,7 @@ test("a Clear while the claim is out leaves the granted words unspoken, unshown,
   h.generation.current += 1;
   h.player.withdraw();
   h.grant(granted("Old words."));
-  await tick();
+  await drainMicrotasks(1);
   assert.deepEqual(h.log, ["claim run-1@1"]);
   assert.equal(h.player.pending, undefined);
   assert.equal(h.player.active, undefined);
@@ -131,12 +130,12 @@ test("a withdrawn generation while the call is opening leaves the words unspoken
   const h = harness();
   h.player.offer(offer("run-1"));
   h.grant(granted("Old words."));
-  await tick();
+  await drainMicrotasks(1);
   assert.deepEqual(h.log, ["claim run-1@1", "connect"]);
   // The generation ends — expiry, or a Clear from a panel — mid-connect.
   h.player.withdraw();
   h.connected(true);
-  await tick();
+  await drainMicrotasks(1);
   assert.deepEqual(h.log, ["claim run-1@1", "connect"]);
   // A new offer, of the new generation, is claimed afresh.
   h.player.offer(offer("run-2", 1));
@@ -148,7 +147,7 @@ test("a newer offer arriving during a claim retires the older attempt without sp
   h.player.offer(offer("run-1"));
   h.player.offer(offer("run-2"));
   h.grant(granted("First."));
-  await tick();
+  await drainMicrotasks(1);
   // The first grant is not spoken; the pending offer is now the second, claimed next.
   assert.deepEqual(h.log, ["claim run-1@1", "claim run-2@1"]);
 });
@@ -157,7 +156,7 @@ test("a refused claim empties the hand with nothing said", async () => {
   const h = harness();
   h.player.offer(offer("run-1"));
   h.grant({ granted: false });
-  await tick();
+  await drainMicrotasks(1);
   assert.deepEqual(h.log, ["claim run-1@1"]);
   assert.equal(h.player.pending, undefined);
 });
@@ -167,9 +166,9 @@ test("words the voice cannot say are shown once and acknowledged at once", async
   h.session.speaks = false;
   h.player.offer(offer("run-1"));
   h.grant(granted("Two agents are waiting."));
-  await tick();
+  await drainMicrotasks(1);
   h.connected(true);
-  await tick();
+  await drainMicrotasks(1);
   assert.deepEqual(h.log.slice(2), [
     "speak run-1: Two agents are waiting.",
     "notice Two agents are waiting.",
@@ -193,7 +192,7 @@ test("an offer waits for a quiet moment: not while the developer talks or a repl
   h.player.onStatus(REALTIME_STATUS.READY);
   assert.deepEqual(h.log, ["claim run-1@1"]);
   h.grant(granted("Now."));
-  await tick();
+  await drainMicrotasks(1);
   assert.deepEqual(h.log.slice(1), ["speak run-1: Now.", "speaking typed"]);
 });
 
@@ -201,9 +200,9 @@ test("the call ending under a delivered reply acknowledges it, so the next may b
   const h = harness();
   h.player.offer(offer("run-1"));
   h.grant(granted("Words."));
-  await tick();
+  await drainMicrotasks(1);
   h.connected(true);
-  await tick();
+  await drainMicrotasks(1);
   assert.equal(h.player.active?.runId, "run-1");
   h.session.status = REALTIME_STATUS.FAILED;
   h.player.onStatus(REALTIME_STATUS.FAILED);
@@ -215,9 +214,9 @@ test("a withdrawal while a delivered reply plays acknowledges nothing: the main 
   const h = harness();
   h.player.offer(offer("run-1"));
   h.grant(granted("Words."));
-  await tick();
+  await drainMicrotasks(1);
   h.connected(true);
-  await tick();
+  await drainMicrotasks(1);
   h.player.withdraw();
   h.player.onReplyEnded("run-1");
   assert.equal(h.log.filter((line) => line.startsWith("ack")).length, 0);
@@ -227,9 +226,9 @@ test("a delivered reply carries the origin of the ask it answers, so only a type
   const h = harness();
   h.player.offer(offer("run-s"));
   h.grant(granted("Later.", BRAIN_REQUEST_ORIGIN.SPOKEN));
-  await tick();
+  await drainMicrotasks(1);
   h.connected(true);
-  await tick();
+  await drainMicrotasks(1);
   assert.deepEqual(h.log.slice(2), ["speak run-s: Later.", "speaking spoken"]);
 });
 
@@ -244,16 +243,16 @@ test("a grant landing after the developer took the turn is held, not spoken over
   h.session.status = REALTIME_STATUS.LISTENING;
   h.player.onStatus(REALTIME_STATUS.LISTENING);
   h.grant(granted("Held words."));
-  await tick();
+  await drainMicrotasks(1);
   assert.deepEqual(h.log, ["claim run-1@1"]);
   h.session.status = REALTIME_STATUS.RESPONDING;
   h.player.onStatus(REALTIME_STATUS.RESPONDING);
-  await tick();
+  await drainMicrotasks(1);
   assert.deepEqual(h.log, ["claim run-1@1"]);
   // Their reply ends: the held grant is spoken, with no second claim.
   h.session.status = REALTIME_STATUS.READY;
   h.player.onStatus(REALTIME_STATUS.READY);
-  await tick();
+  await drainMicrotasks(1);
   assert.deepEqual(h.log.slice(1), ["speak run-1: Held words.", "speaking typed"]);
   assert.equal(h.player.active?.runId, "run-1");
 });
@@ -262,17 +261,17 @@ test("a grant whose call opened into the developer's turn is held through the co
   const h = harness();
   h.player.offer(offer("run-1"));
   h.grant(granted("Held words."));
-  await tick();
+  await drainMicrotasks(1);
   assert.deepEqual(h.log, ["claim run-1@1", "connect"]);
   // The call opens, but the developer is already talking on it.
   h.connected(true);
   h.session.status = REALTIME_STATUS.LISTENING;
-  await tick();
+  await drainMicrotasks(1);
   assert.deepEqual(h.log, ["claim run-1@1", "connect"]);
   h.player.onStatus(REALTIME_STATUS.RESPONDING);
   h.session.status = REALTIME_STATUS.READY;
   h.player.onStatus(REALTIME_STATUS.READY);
-  await tick();
+  await drainMicrotasks(1);
   assert.deepEqual(h.log.slice(2), ["speak run-1: Held words.", "speaking typed"]);
   assert.equal(h.log.filter((line) => line.startsWith("claim")).length, 1);
 });
@@ -286,10 +285,10 @@ test("a held grant is voided by a withdrawal: the next quiet status speaks nothi
   h.session.status = REALTIME_STATUS.RESPONDING;
   h.player.onStatus(REALTIME_STATUS.RESPONDING);
   h.grant(granted("Held words."));
-  await tick();
+  await drainMicrotasks(1);
   h.player.withdraw();
   h.session.status = REALTIME_STATUS.READY;
   h.player.onStatus(REALTIME_STATUS.READY);
-  await tick();
+  await drainMicrotasks(1);
   assert.deepEqual(h.log, ["claim run-1@1"]);
 });

--- a/apps/desktop/src/renderer/voice/speech-mouth.test.ts
+++ b/apps/desktop/src/renderer/voice/speech-mouth.test.ts
@@ -1,11 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import type {
-  BriefingSpeech,
-  ProactiveSpeechTurn,
-  RealtimeStatus,
-  ScheduledTimer,
-} from "@sidecar/realtime";
+import type { BriefingSpeech, ProactiveSpeechTurn, RealtimeStatus } from "@sidecar/realtime";
 import {
   BRIEFING_SPEECH_KIND,
   CALENDAR_ONBOARDING_SPEECH_KIND,
@@ -13,6 +8,7 @@ import {
   REALTIME_STATUS,
 } from "@sidecar/realtime";
 import { SPEECH_OUTCOME, type SpeechOffer, type SpeechOutcome } from "#shared/messages/speech";
+import { FakeClock } from "#testing/fake-clock";
 import {
   ANNOUNCER_GRACE_MS,
   ANNOUNCER_LINGER_MS,
@@ -99,45 +95,12 @@ function fakeSession(): FakeSession {
   return session;
 }
 
-interface Timers {
-  schedule: (callback: () => void, delayMs: number) => ScheduledTimer;
-  cancel: (timer: ScheduledTimer) => void;
-  fire: () => void;
-  armed: () => number;
-  delays: number[];
-}
-
-function fakeTimers(): Timers {
-  const pending = new Map<ScheduledTimer, () => void>();
-  const delays: number[] = [];
-  let key = 0;
-  return {
-    schedule: (callback, delayMs) => {
-      delays.push(delayMs);
-      key += 1;
-      pending.set(key, callback);
-      return key;
-    },
-    cancel: (timer) => {
-      pending.delete(timer);
-    },
-    fire: () => {
-      for (const [id, callback] of [...pending]) {
-        pending.delete(id);
-        callback();
-      }
-    },
-    armed: () => pending.size,
-    delays,
-  };
-}
-
 interface Settlement {
   id: string;
   outcome: SpeechOutcome;
 }
 
-function mouth(session: FakeSession, timers: Timers, now = () => 1_000) {
+function mouth(session: FakeSession, timers: FakeClock, now = () => 1_000) {
   const settled: Settlement[] = [];
   const subject = new SpeechMouth({
     session: () => session,
@@ -151,7 +114,7 @@ function mouth(session: FakeSession, timers: Timers, now = () => 1_000) {
 
 test("an offer arriving into silence opens Luke's own call, is spoken, and settles SPOKEN", async () => {
   const session = fakeSession();
-  const timers = fakeTimers();
+  const timers = new FakeClock();
   const { subject, settled } = mouth(session, timers);
 
   subject.offer(offer("a"));
@@ -166,7 +129,7 @@ test("an offer arriving into silence opens Luke's own call, is spoken, and settl
 
 test("offers speak one per reply, in order, on one call", async () => {
   const session = fakeSession();
-  const timers = fakeTimers();
+  const timers = new FakeClock();
   const { subject, settled } = mouth(session, timers);
 
   subject.offer(offer("a"));
@@ -191,7 +154,7 @@ test("offers speak one per reply, in order, on one call", async () => {
 
 test("the same offer again is the same offer", async () => {
   const session = fakeSession();
-  const timers = fakeTimers();
+  const timers = new FakeClock();
   const { subject, settled } = mouth(session, timers);
 
   subject.offer(offer("a"));
@@ -206,7 +169,7 @@ test("an offer whose deadline passed settles STALE without speaking", () => {
   const session = fakeSession();
   session.setStatus(REALTIME_STATUS.RESPONDING);
   session.microphone = true;
-  const timers = fakeTimers();
+  const timers = new FakeClock();
   let now = 10_000;
   const { subject, settled } = mouth(session, timers, () => now);
 
@@ -223,14 +186,14 @@ test("an offer whose deadline passed settles STALE without speaking", () => {
   assert.deepEqual(spokenIds(session), []);
   assert.deepEqual(settled, [{ id: "a", outcome: SPEECH_OUTCOME.STALE }]);
   // The retry clock armed mid-reply fires into an empty hand and says nothing.
-  timers.fire();
+  timers.fireAll();
   assert.deepEqual(spokenIds(session), []);
   assert.equal(settled.length, 1);
 });
 
 test("withdraw drops an unspoken offer without a settle and leaves a begun reply alone", async () => {
   const session = fakeSession();
-  const timers = fakeTimers();
+  const timers = new FakeClock();
   const { subject, settled } = mouth(session, timers);
 
   subject.offer(offer("beat", { kind: CALENDAR_ONBOARDING_SPEECH_KIND, decidedAt: 1_000 }));
@@ -254,7 +217,7 @@ test("withdraw drops an unspoken offer without a settle and leaves a begun reply
 
 test("the call Luke opened lingers for stragglers, then closes itself", async () => {
   const session = fakeSession();
-  const timers = fakeTimers();
+  const timers = new FakeClock();
   const { subject } = mouth(session, timers);
 
   subject.offer(offer("a"));
@@ -274,7 +237,7 @@ test("the call Luke opened lingers for stragglers, then closes itself", async ()
 
   session.setStatus(REALTIME_STATUS.READY);
   subject.onStatus(REALTIME_STATUS.READY);
-  timers.fire();
+  timers.fireAll();
   assert.equal(session.closes, 1);
 });
 
@@ -282,7 +245,7 @@ test("an offer riding the developer's call never closes it", () => {
   const session = fakeSession();
   session.microphone = true;
   session.setStatus(REALTIME_STATUS.READY);
-  const timers = fakeTimers();
+  const timers = new FakeClock();
   const { subject } = mouth(session, timers);
 
   subject.offer(offer("a"));
@@ -293,14 +256,14 @@ test("an offer riding the developer's call never closes it", () => {
   subject.onStatus(REALTIME_STATUS.READY);
   // No linger is ever armed against the developer's own call.
   assert.equal(timers.armed(), 0);
-  timers.fire();
+  timers.fireAll();
   assert.equal(session.closes, 0);
 });
 
 test("a refused call keeps the offer and speaks it on the retry", async () => {
   const session = fakeSession();
   session.connectOpens = false;
-  const timers = fakeTimers();
+  const timers = new FakeClock();
   const { subject, settled } = mouth(session, timers);
 
   subject.offer(offer("a"));
@@ -315,7 +278,7 @@ test("a refused call keeps the offer and speaks it on the retry", async () => {
 
   // The rate limit lifted; the retry delivers the same offer.
   session.connectOpens = true;
-  timers.fire();
+  timers.fireAll();
   await Promise.resolve();
   assert.equal(session.connects, 2);
   assert.deepEqual(spokenIds(session), ["a"]);
@@ -325,14 +288,14 @@ test("a refused call keeps the offer and speaks it on the retry", async () => {
 test("an offer that outlives its attempts settles REFUSED, not retried into a loop", async () => {
   const session = fakeSession();
   session.connectOpens = false;
-  const timers = fakeTimers();
+  const timers = new FakeClock();
   const { subject, settled } = mouth(session, timers);
 
   subject.offer(offer("a"));
   await Promise.resolve();
   subject.onStatus(REALTIME_STATUS.UNAVAILABLE);
   for (let attempt = 1; attempt < MAXIMUM_CONNECT_ATTEMPTS; attempt += 1) {
-    timers.fire();
+    timers.fireAll();
     await Promise.resolve();
     subject.onStatus(REALTIME_STATUS.UNAVAILABLE);
   }
@@ -342,7 +305,7 @@ test("an offer that outlives its attempts settles REFUSED, not retried into a lo
   // and no clock is left ticking for it.
   assert.deepEqual(settled, [{ id: "a", outcome: SPEECH_OUTCOME.REFUSED }]);
   assert.equal(timers.armed(), 0);
-  timers.fire();
+  timers.fireAll();
   await Promise.resolve();
   assert.equal(session.connects, MAXIMUM_CONNECT_ATTEMPTS);
 
@@ -356,13 +319,13 @@ test("an offer that outlives its attempts settles REFUSED, not retried into a lo
 test("an offer arriving right after a refused one is kept, not refused with it", async () => {
   const session = fakeSession();
   session.connectOpens = false;
-  const timers = fakeTimers();
+  const timers = new FakeClock();
   const { subject, settled } = mouth(session, timers);
 
   subject.offer(offer("a"));
   await Promise.resolve();
   for (let attempt = 1; attempt < MAXIMUM_CONNECT_ATTEMPTS; attempt += 1) {
-    timers.fire();
+    timers.fireAll();
     await Promise.resolve();
   }
   assert.equal(session.connects, MAXIMUM_CONNECT_ATTEMPTS);
@@ -380,7 +343,7 @@ test("an offer stranded by a call that ended is picked up by the retry clock", a
   const session = fakeSession();
   session.microphone = true;
   session.setStatus(REALTIME_STATUS.RESPONDING);
-  const timers = fakeTimers();
+  const timers = new FakeClock();
   const { subject } = mouth(session, timers);
 
   // Arrives mid-reply on the developer's call and waits its turn.
@@ -393,7 +356,7 @@ test("an offer stranded by a call that ended is picked up by the retry clock", a
   subject.onStatus(REALTIME_STATUS.IDLE);
   assert.equal(timers.armed(), 1);
 
-  timers.fire();
+  timers.fireAll();
   await Promise.resolve();
   assert.equal(session.connects, 1);
   assert.deepEqual(spokenIds(session), ["a"]);
@@ -403,7 +366,7 @@ test("an offer refused mid-reply keeps a clock of its own beside the READY edge"
   const session = fakeSession();
   session.microphone = true;
   session.setStatus(REALTIME_STATUS.RESPONDING);
-  const timers = fakeTimers();
+  const timers = new FakeClock();
   const { subject } = mouth(session, timers);
 
   // Arrives mid-reply and is refused the turn. The READY edge is the
@@ -417,13 +380,13 @@ test("an offer refused mid-reply keeps a clock of its own beside the READY edge"
   // The edge never lands; the clock fires into a call that has since settled
   // and the offer is spoken rather than stranded.
   session.setStatus(REALTIME_STATUS.READY);
-  timers.fire();
+  timers.fireAll();
   assert.deepEqual(spokenIds(session), ["a"]);
 });
 
 test("quiet beginning cuts the reply mid-sentence, closes Luke's own call, and hands back the unspoken offer HELD", async () => {
   const session = fakeSession();
-  const timers = fakeTimers();
+  const timers = new FakeClock();
   const { subject, settled } = mouth(session, timers);
 
   // Mid-briefing on Luke's own call, with the next offer waiting behind it.
@@ -459,7 +422,7 @@ test("an offer arriving under a hold the panel still draws is spoken, not handed
   // The arbiter offers only once the quiet has ended; the panel's copy of
   // the hold lands a render later. The offer is the fresher word.
   const session = fakeSession();
-  const timers = fakeTimers();
+  const timers = new FakeClock();
   const { subject, settled } = mouth(session, timers);
 
   subject.setHeld(true);
@@ -473,7 +436,7 @@ test("an offer arriving under a hold the panel still draws is spoken, not handed
 
 test("a hold beginning over an unspoken offer settles it HELD and opens no call", async () => {
   const session = fakeSession();
-  const timers = fakeTimers();
+  const timers = new FakeClock();
   const { subject, settled } = mouth(session, timers);
 
   session.connectOpens = false;
@@ -491,7 +454,7 @@ test("quiet beginning never touches the developer's own call", () => {
   const session = fakeSession();
   session.microphone = true;
   session.setStatus(REALTIME_STATUS.RESPONDING);
-  const timers = fakeTimers();
+  const timers = new FakeClock();
   const { subject, settled } = mouth(session, timers);
 
   // Waiting out the developer's reply when the quiet lands.
@@ -513,7 +476,7 @@ test("quiet beginning never touches the developer's own call", () => {
 test("an offer waits out the developer's floor after Luke answers them", () => {
   const session = fakeSession();
   session.microphone = true;
-  const timers = fakeTimers();
+  const timers = new FakeClock();
   let now = 1_000;
   const { subject } = mouth(session, timers, () => now);
 
@@ -532,12 +495,12 @@ test("an offer waits out the developer's floor after Luke answers them", () => {
 
   // Half the window passes in silence; the offer still may not speak.
   now = 1_000 + ANNOUNCER_GRACE_MS / 2;
-  timers.fire();
+  timers.fireAll();
   assert.deepEqual(spokenIds(session), []);
 
   // The developer left the pause empty; the waiting offer takes it.
   now = 1_000 + ANNOUNCER_GRACE_MS;
-  timers.fire();
+  timers.fireAll();
   assert.deepEqual(spokenIds(session), ["a"]);
 
   // The next offer keeps its own readout after the first one ends.
@@ -550,7 +513,7 @@ test("an offer waits out the developer's floor after Luke answers them", () => {
 test("the developer speaking inside the window keeps the floor theirs", () => {
   const session = fakeSession();
   session.microphone = true;
-  const timers = fakeTimers();
+  const timers = new FakeClock();
   let now = 1_000;
   const { subject } = mouth(session, timers, () => now);
 
@@ -570,12 +533,12 @@ test("the developer speaking inside the window keeps the floor theirs", () => {
   subject.onStatus(REALTIME_STATUS.RESPONDING);
   session.setStatus(REALTIME_STATUS.READY);
   subject.onStatus(REALTIME_STATUS.READY);
-  timers.fire();
+  timers.fireAll();
   assert.deepEqual(spokenIds(session), []);
 
   // Only the pause after the second answer, left empty, is spoken into.
   now = 1_000 + ANNOUNCER_GRACE_MS / 2 + ANNOUNCER_GRACE_MS;
-  timers.fire();
+  timers.fireAll();
   assert.deepEqual(spokenIds(session), ["s"]);
 });
 
@@ -583,7 +546,7 @@ test("the retry clock respects the developer's floor", () => {
   const session = fakeSession();
   session.microphone = true;
   session.setStatus(REALTIME_STATUS.RESPONDING);
-  const timers = fakeTimers();
+  const timers = new FakeClock();
   let now = 1_000;
   const { subject } = mouth(session, timers, () => now);
 
@@ -594,17 +557,17 @@ test("the retry clock respects the developer's floor", () => {
 
   // Every armed clock firing inside the window still finds the floor held.
   now = 1_000 + ANNOUNCER_GRACE_MS - 1;
-  timers.fire();
+  timers.fireAll();
   assert.deepEqual(spokenIds(session), []);
 
   now = 1_000 + ANNOUNCER_GRACE_MS;
-  timers.fire();
+  timers.fireAll();
   assert.deepEqual(spokenIds(session), ["a"]);
 });
 
 test("an offer on Luke's own call speaks without the developer's window", async () => {
   const session = fakeSession();
-  const timers = fakeTimers();
+  const timers = new FakeClock();
   const { subject } = mouth(session, timers);
 
   // Nobody is conversing: the window guards the developer's next ask, and
@@ -618,7 +581,7 @@ test("an offer on Luke's own call speaks without the developer's window", async 
 test("the developer taking the turn stands the grace clock down", () => {
   const session = fakeSession();
   session.microphone = true;
-  const timers = fakeTimers();
+  const timers = new FakeClock();
   let now = 1_000;
   const { subject } = mouth(session, timers, () => now);
 
@@ -639,15 +602,15 @@ test("the developer taking the turn stands the grace clock down", () => {
   session.setStatus(REALTIME_STATUS.RESPONDING);
   subject.onStatus(REALTIME_STATUS.RESPONDING);
   now = 1_000 + ANNOUNCER_GRACE_MS * 2;
-  timers.fire();
+  timers.fireAll();
   assert.deepEqual(spokenIds(session), []);
 
   // The answer's own end opens the next window, on a clock of its own.
   session.setStatus(REALTIME_STATUS.READY);
   subject.onStatus(REALTIME_STATUS.READY);
-  timers.fire();
+  timers.fireAll();
   assert.deepEqual(spokenIds(session), []);
   now = 1_000 + ANNOUNCER_GRACE_MS * 3;
-  timers.fire();
+  timers.fireAll();
   assert.deepEqual(spokenIds(session), ["a"]);
 });

--- a/apps/desktop/src/testing/AGENTS.md
+++ b/apps/desktop/src/testing/AGENTS.md
@@ -1,0 +1,36 @@
+# Test fixtures
+
+Everything here is imported by tests alone, through the `#testing/*` alias, and
+never by anything that ships. A fixture earns its place by having more than one
+caller: a helper one test file needs stays in that file, where a reader can see
+it beside the assertions it serves.
+
+The six shared ones, and the rule each carries:
+
+- `temporary-directory.ts` — a directory of the test's own, removed by
+  `t.after`. A test that makes one by hand forgets the cleanup, and four of
+  them had.
+- `drain.ts` — `drainMicrotasks(ticks)`, which lets queued microtasks and
+  immediates run. The tick count is the length of the await chain being
+  waited out, stated rather than guessed; hand-rolled copies had settled on
+  four different numbers for the same wait.
+- `fake-clock.ts` — a clock the test drives, so a deadline is crossed without
+  waiting out a real one. `advance` runs what is due, `fireAll` runs
+  everything armed now and nothing a callback arms behind it.
+- `native-helper.ts` — a `NativeHelperProcess` that never was, for the
+  watchers over the macOS helpers: the test says what came back on stdout and
+  reads what was written to stdin.
+- `brain-harness.ts` — the agent, store, host, follower, delivery ledger,
+  receiver, and submission path composed as the main process composes them,
+  with only the model and the disk synthetic. Its pieces
+  (`MemoryBrainStorage`, `heldModel`, `answered`) are exported on their own
+  for the tests that compose the brain differently.
+- `settings-fixtures.ts` — an `AppSettingsView` with every member at a stated
+  value, so a test is told apart from the next only by what it moves.
+- `realtime-fixtures.ts` and `spoken-setting-bridge.ts` — the browser surfaces
+  the realtime session opens, and the bridge a spoken settings change crosses.
+
+A test file does not hand-roll a temporary directory, a microtask drain, a
+clock, or a native-helper process: `repository-checks.sh` fails the build on a
+`mkdtemp` or a `setImmediate` under `apps/desktop/src`, because those two are
+how the hand-rolled copies always begin.

--- a/apps/desktop/src/testing/CLAUDE.md
+++ b/apps/desktop/src/testing/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/apps/desktop/src/testing/brain-harness.ts
+++ b/apps/desktop/src/testing/brain-harness.ts
@@ -1,0 +1,252 @@
+import assert from "node:assert/strict";
+import {
+  BRAIN_REQUEST_ORIGIN,
+  BrainAgent,
+  type BrainAgentOptions,
+  type BrainStateStorage,
+  BrainStateStore,
+  responsesModelAnswer,
+} from "@sidecar/brain";
+import { isTerminalBrainRequestStatus } from "@sidecar/brain/requests";
+import {
+  type BareResponsesModel,
+  bareModelAdapter,
+  toolLoopRuntimeOver,
+} from "@sidecar/brain/testing";
+import {
+  appendConversationThreadEntry,
+  CONVERSATION_ENTRY_KIND,
+  type ConversationEntry,
+} from "@sidecar/realtime";
+import { DeliveryLedger, type DeliveryRecord } from "@sidecar/runtime";
+import { DELIVERY_STATE, type ModelResponse } from "@sidecar/runtime-contracts";
+import { ACT_RESULT_STATUS, type WireRecord } from "@sidecar/wire";
+import { BrainHost } from "#main/brain/host";
+import { followBrainRequests } from "#main/brain/ipc";
+import { deliverable, type GrantedWords, ledgerContext } from "#main/gateway/service";
+import { operatorOverBrain } from "#main/gateway/testing";
+import { VoiceReceiver } from "#main/voice-receiver";
+import type {
+  BrainReplyClaimResult,
+  BrainReplyOffer,
+  BrainRequestSnapshot,
+} from "#shared/messages/brain";
+import { drainMicrotasks } from "./drain";
+
+/** The instant every clock in a brain fixture reads. */
+export const BRAIN_HARNESS_NOW = 1_800_000_000_000;
+const NOW = BRAIN_HARNESS_NOW;
+
+/** The envelope on nothing but a string, so a test can read and plant the file. */
+export class MemoryBrainStorage implements BrainStateStorage {
+  file: string | undefined;
+  read() {
+    return this.file;
+  }
+  write(contents: string) {
+    this.file = contents;
+    return true;
+  }
+}
+
+/** A model that answers nothing until the test says so. */
+export function heldModel(): BareResponsesModel & { release: (answer: ModelResponse) => void } {
+  const waiting: ((answer: ModelResponse) => void)[] = [];
+  return {
+    respond: () =>
+      new Promise((resolve) => {
+        waiting.push(resolve);
+      }),
+    quietUntil: () => undefined,
+    release: (answer) => {
+      for (const resolve of waiting.splice(0)) resolve(answer);
+    },
+  };
+}
+
+/**
+ * The real agent, store, host, follower, delivery ledger, receiver, and
+ * submission path composed as the main process composes them, with only the
+ * model and the disk synthetic.
+ */
+export function brainHarness() {
+  const storage = new MemoryBrainStorage();
+  let ids = 0;
+  const store = new BrainStateStore({
+    storage,
+    createGenerationId: () => `gen-${++ids}`,
+    now: () => NOW,
+  });
+  let thread: readonly ConversationEntry[] = [];
+  let refuseWrites = false;
+  const broadcasts: (readonly BrainRequestSnapshot[])[] = [];
+  const record = (entry: ConversationEntry, at: number) => {
+    if (refuseWrites) return false;
+    thread = appendConversationThreadEntry(thread, entry, NOW + 1000, at);
+    return true;
+  };
+  // The delivery owner and the receiver, composed as desktop-app composes
+  // them: every report is observed before it is broadcast, every published
+  // end is offered to a ready receiver, and readiness flushes what waited.
+  const deliveries = new DeliveryLedger<GrantedWords>({
+    nextDeliveryId: () => `delivery-${++ids}`,
+  });
+  const receiver = new VoiceReceiver();
+  const offers: BrainReplyOffer[] = [];
+  const offerReplies = () => {
+    if (!receiver.isReady()) return;
+    const offer = deliveries.nextOffer(receiver.epoch());
+    if (offer) offers.push(offer);
+  };
+  receiver.onReady(offerReplies);
+  store.onReplaced(() => deliveries.reset());
+  const host = new BrainHost({
+    follow: (agent) =>
+      followBrainRequests(agent, {
+        recordConversationEntry: record,
+        broadcastRequests: (snapshots) => {
+          deliveries.observe(
+            snapshots.map((snapshot) => ({
+              runId: snapshot.runId,
+              ended: isTerminalBrainRequestStatus(snapshot.status),
+            })),
+          );
+          broadcasts.push(snapshots);
+        },
+        onEndPublished: (ended) => {
+          const generationId = store.generationId();
+          if (generationId !== undefined && deliverable(ended)) {
+            deliveries.published(ended.runId, generationId);
+          }
+          offerReplies();
+        },
+      }),
+    publishEmpty: () => broadcasts.push([]),
+  });
+  /** Submits as a window does, through the operator over the standing brain; the ask's own line is written here. */
+  const { submit } = operatorOverBrain({
+    current: () => host.current(),
+    recordConversationEntry: record,
+  });
+  const claimContext = () => ({
+    receiverCurrent: (epoch: number) => receiver.isReady() && receiver.epoch() === epoch,
+    generationStands: (generationId: string) => store.holdsGeneration(generationId),
+    liveRecord: (runId: string) => host.current()?.request(runId),
+  });
+  const claim = (offer: BrainReplyOffer): BrainReplyClaimResult => {
+    const granted = deliveries.claim(
+      offer.runId,
+      offer.deliveryId,
+      offer.epoch,
+      ledgerContext(claimContext()),
+    );
+    return granted.granted
+      ? { granted: true, words: granted.words.words, origin: granted.words.origin }
+      : { granted: false };
+  };
+  /** Queued or offered: everything owed that no receiver has taken in hand. */
+  const unclaimed = (): readonly DeliveryRecord[] =>
+    deliveries
+      .records()
+      .filter(
+        (delivery) =>
+          delivery.state === DELIVERY_STATE.QUEUED || delivery.state === DELIVERY_STATE.OFFERED,
+      );
+  const acknowledge = (offer: BrainReplyOffer) => {
+    const emptied = deliveries.acknowledge(offer.runId, offer.deliveryId, offer.epoch);
+    if (emptied) offerReplies();
+    return emptied;
+  };
+  /** The wait as main's IPC answers it: publication let finish, live record re-read, the call granted or not. */
+  const waitOnCall = async (runId: string, epoch: number, timeoutMs = 1) => {
+    const agent = host.current();
+    const waited = await agent?.waitAsk(runId, timeoutMs);
+    if (!waited || !isTerminalBrainRequestStatus(waited.status))
+      return { record: waited, speak: false };
+    await drainMicrotasks();
+    const live = agent?.request(runId) ?? waited;
+    if (live.historyRecordedAt === undefined) return { record: live, speak: false };
+    const generationId = store.generationId() ?? "";
+    const speak =
+      deliverable(live) &&
+      deliveries.grantOnCall(live.runId, generationId, epoch, ledgerContext(claimContext()));
+    if (speak) offerReplies();
+    return { record: live, speak };
+  };
+  const submitMany = async (count: number) => {
+    const runIds: string[] = [];
+    for (let index = 0; index < count; index += 1) {
+      const result = await submit({
+        submissionId: `sub-${index}`,
+        question: `ask ${index}`,
+        origin: BRAIN_REQUEST_ORIGIN.TYPED,
+      });
+      assert.equal(result.outcome, "accepted");
+      if (result.outcome === "accepted") runIds.push(result.runId);
+    }
+    return runIds;
+  };
+  const build = (client: BareResponsesModel, options: Partial<BrainAgentOptions> = {}) => {
+    const model = bareModelAdapter(client);
+    return new BrainAgent({
+      ...options,
+      runtime: toolLoopRuntimeOver(model),
+      prepareTurn: () => ({ prompt: "instructions", layers: {} }),
+      acts: { perform: async () => ({ status: ACT_RESULT_STATUS.ACCEPTED }) },
+      roster: () => ({ text: "", identities: [] }),
+      standingContext: () => "",
+      readTranscriptSince: async () => ({ status: ACT_RESULT_STATUS.REJECTED, reason: "no" }),
+      readTranscript: async () => ({ status: ACT_RESULT_STATUS.REJECTED, reason: "no" }),
+      deliver: () => undefined,
+      store,
+      createRunId: () => `run-${++ids}`,
+      report: () => {},
+      now: () => NOW,
+      // A run left in flight at a test's end must not hold the process open:
+      // its deadline timers are unreferenced, as the test's own would be.
+      schedule: (callback, delayMs) => {
+        const timer = setTimeout(callback, delayMs);
+        timer.unref();
+        return timer;
+      },
+      // SAFETY: the handle is what `schedule` above returned, which is always a `setTimeout` timer.
+      cancel: (timer) => clearTimeout(timer as ReturnType<typeof setTimeout>),
+    });
+  };
+  return {
+    storage,
+    store,
+    host,
+    build,
+    submit,
+    thread: () => thread,
+    replies: (runId: string) =>
+      thread.filter((e) => e.kind === CONVERSATION_ENTRY_KIND.REPLY && e.requestId === runId),
+    submitMany,
+    broadcasts,
+    deliveries,
+    unclaimed,
+    receiver,
+    offers,
+    claim,
+    acknowledge,
+    waitOnCall,
+    refuse: (value: boolean) => {
+      refuseWrites = value;
+    },
+  };
+}
+
+/** A raw Responses payload as the adapter would normalize it. */
+export function answerOf(payload: WireRecord): ModelResponse {
+  const answer = responsesModelAnswer(payload);
+  assert.ok(answer);
+  return answer;
+}
+
+/** The normalized answer for one assistant message. */
+export function answered(text: string): ModelResponse {
+  return answerOf({
+    output: [{ type: "message", role: "assistant", content: [{ type: "output_text", text }] }],
+  });
+}

--- a/apps/desktop/src/testing/drain.ts
+++ b/apps/desktop/src/testing/drain.ts
@@ -1,0 +1,12 @@
+import { setImmediate as immediate } from "node:timers/promises";
+
+/**
+ * Lets queued microtasks and immediates run. `ticks` is how many turns of the
+ * immediate queue to allow, and a chain of N awaits needs N: a caller states
+ * the length of the wait it is settling rather than guessing at a round
+ * number, which is how the hand-rolled copies ended up with four counts for
+ * one wait.
+ */
+export async function drainMicrotasks(ticks = 30): Promise<void> {
+  for (let turn = 0; turn < ticks; turn += 1) await immediate();
+}

--- a/apps/desktop/src/testing/fake-clock.ts
+++ b/apps/desktop/src/testing/fake-clock.ts
@@ -1,0 +1,66 @@
+import type { ScheduledTimer } from "@sidecar/realtime";
+import { drainMicrotasks } from "./drain";
+
+interface ArmedTimer {
+  callback: () => void;
+  /** The instant the timer is due, on this clock's own reading. */
+  at: number;
+  delayMs: number;
+}
+
+/**
+ * A clock a test drives by hand: nothing is due until the test advances or
+ * fires, so a deadline can be crossed without waiting out a real one.
+ */
+export class FakeClock {
+  now: number;
+  /** Every timer still armed, in the order it was scheduled. */
+  readonly timers = new Map<ScheduledTimer, ArmedTimer>();
+  /** Every delay ever asked for, in order, including timers since cancelled. */
+  readonly delays: number[] = [];
+
+  constructor(now = 1_800_000_000_000) {
+    this.now = now;
+  }
+
+  schedule = (callback: () => void, delayMs: number): ScheduledTimer => {
+    const handle: ScheduledTimer = {};
+    this.delays.push(delayMs);
+    this.timers.set(handle, { callback, at: this.now + delayMs, delayMs });
+    return handle;
+  };
+
+  cancel = (timer: ScheduledTimer): void => {
+    this.timers.delete(timer);
+  };
+
+  /** Runs every timer due at or before `untilMs`, in due order, draining between each. */
+  async advance(untilMs: number): Promise<void> {
+    for (;;) {
+      const due = [...this.timers.entries()]
+        .filter(([, timer]) => timer.at <= untilMs)
+        .sort((a, b) => a[1].at - b[1].at)[0];
+      if (!due) break;
+      this.timers.delete(due[0]);
+      this.now = Math.max(this.now, due[1].at);
+      due[1].callback();
+      await drainMicrotasks(20);
+    }
+    this.now = Math.max(this.now, untilMs);
+  }
+
+  /**
+   * Runs every timer armed now, whatever its deadline, and only those: a
+   * callback that arms another leaves it for the next fire.
+   */
+  fireAll(): void {
+    for (const [handle, timer] of [...this.timers]) {
+      this.timers.delete(handle);
+      timer.callback();
+    }
+  }
+
+  armed(): number {
+    return this.timers.size;
+  }
+}

--- a/apps/desktop/src/testing/native-helper.ts
+++ b/apps/desktop/src/testing/native-helper.ts
@@ -1,0 +1,67 @@
+import type { NativeHelperProcess } from "#main/native/native-helper";
+
+export interface FakeNativeHelper {
+  /** The process the watcher is handed in place of a spawned binary. */
+  readonly process: NativeHelperProcess;
+  /** Delivers stdout bytes exactly as written — split a line to exercise framing. */
+  emit(chunk: string): void;
+  /** The helper's `exit` event. */
+  exit(): void;
+  /** Every chunk written to the helper's stdin, in order, exactly as written. */
+  readonly written: string[];
+  killed(): boolean;
+  /** Whether stdin was closed without a kill — how the media helper is released. */
+  inputEnded(): boolean;
+}
+
+/**
+ * A helper process that never was: the watcher subscribes and writes to it
+ * exactly as it would to a spawned binary, and the test says what came back.
+ */
+export function fakeNativeHelper(): FakeNativeHelper {
+  const written: string[] = [];
+  const exits: (() => void)[] = [];
+  let onData: ((chunk: string) => void) | undefined;
+  let killed = false;
+  let inputEnded = false;
+
+  const process: NativeHelperProcess = {
+    stdin: {
+      write: (chunk) => {
+        written.push(chunk);
+      },
+      end: () => {
+        inputEnded = true;
+      },
+      on: () => undefined,
+    },
+    stdout: {
+      setEncoding: () => undefined,
+      on: (_event, listener) => {
+        onData = listener;
+      },
+    },
+    on: (event, listener) => {
+      if (event === "exit") exits.push(listener);
+    },
+    // Detaching before the kill is what keeps a line the dying helper got out
+    // from being acted on, so a fired exit after one must reach nothing.
+    removeAllListeners: () => {
+      exits.length = 0;
+    },
+    kill: () => {
+      killed = true;
+    },
+  };
+
+  return {
+    process,
+    written,
+    emit: (chunk) => onData?.(chunk),
+    exit: () => {
+      for (const listener of [...exits]) listener();
+    },
+    killed: () => killed,
+    inputEnded: () => inputEnded,
+  };
+}

--- a/apps/desktop/src/testing/settings-fixtures.ts
+++ b/apps/desktop/src/testing/settings-fixtures.ts
@@ -1,0 +1,48 @@
+import { CREDENTIAL_PROVIDER_ID } from "@sidecar/credentials/vocabulary";
+import { REALTIME_VOICE, REALTIME_VOICE_SPEED } from "@sidecar/realtime";
+import { PANEL_FORM_FACTOR } from "@sidecar/surface";
+import { CREDENTIAL_SOURCE, SECRET_STORAGE } from "#shared/messages/account";
+import {
+  APP_SETTING_DEFAULTS,
+  type AppSettingsView,
+  CLI_CONNECTION,
+  VOICE_SOURCE,
+} from "#shared/messages/settings";
+
+/**
+ * A settings snapshot with every member at a stated value, so a test is told
+ * apart from the next only by what it moves.
+ */
+export function settingsView(overrides: Partial<AppSettingsView> = {}): AppSettingsView {
+  // Object.assign rather than a spread: spreading a Partial marks every key it
+  // could carry optional, and the result stops being an AppSettingsView.
+  return Object.assign<AppSettingsView, Partial<AppSettingsView>>(
+    {
+      ...APP_SETTING_DEFAULTS,
+      credentialSources: {
+        [CREDENTIAL_PROVIDER_ID.CONDUCTOR]: CREDENTIAL_SOURCE.NONE,
+        [CREDENTIAL_PROVIDER_ID.LINEAR]: CREDENTIAL_SOURCE.NONE,
+        [CREDENTIAL_PROVIDER_ID.OPENAI]: CREDENTIAL_SOURCE.NONE,
+      },
+      secretStorage: SECRET_STORAGE.UNKNOWN,
+      codexCloudConnection: CLI_CONNECTION.UNKNOWN,
+      showInDock: false,
+      voice: REALTIME_VOICE.CEDAR,
+      voiceSpeed: REALTIME_VOICE_SPEED.NORMAL,
+      voiceCaptions: false,
+      duckOtherMedia: true,
+      quietDuringMeetings: true,
+      announceSessions: true,
+      calendarSignInAvailable: false,
+      linearSignInAvailable: false,
+      appleCalendarAvailable: false,
+      voiceAvailable: false,
+      voiceSource: VOICE_SOURCE.ACCOUNT,
+      preferBuiltInMicrophone: false,
+      calendarAccounts: [],
+      showOnAllDisplays: false,
+      formFactor: PANEL_FORM_FACTOR.BUBBLE,
+    },
+    overrides,
+  );
+}

--- a/apps/desktop/src/testing/temporary-directory.ts
+++ b/apps/desktop/src/testing/temporary-directory.ts
@@ -1,0 +1,16 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { TestContext } from "node:test";
+
+/**
+ * A directory of this test's own, removed when the test ends. Synchronous, so
+ * a fixture assembled outside an async helper can have one.
+ */
+export function temporaryDirectory(t: TestContext, prefix = "luke-"): string {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  t.after(() => {
+    fs.rmSync(directory, { recursive: true, force: true });
+  });
+  return directory;
+}

--- a/scripts/repository-checks.sh
+++ b/scripts/repository-checks.sh
@@ -313,6 +313,20 @@ if [[ -n "$drawn_hosted_quota" ]]; then
     exit 1
 fi
 
+# A temporary directory, a microtask drain, a fake clock, a native-helper
+# process and a brain composition were each hand-rolled in several test files,
+# and every copy drifted: three temporary directories were never cleaned up and
+# four drains had settled on four different tick counts for the same wait. The
+# fixtures under apps/desktop/src/testing are the one copy of each, and these
+# two calls are how a hand-rolled one always begins.
+hand_rolled_fixtures=$(grep -rnaE --include='*.test.ts' --include='*.test.tsx' \
+    'mkdtemp|setImmediate' "$SIDECAR_REPO_ROOT/apps/desktop/src" || true)
+if [[ -n "$hand_rolled_fixtures" ]]; then
+    printf 'error: test files import #testing/temporary-directory and #testing/drain rather than hand-rolling them:\n%s\n' \
+        "$hand_rolled_fixtures" >&2
+    exit 1
+fi
+
 # BRIDGE is the one renderer-to-main declaration, and registerBridge is the
 # one place that may attach it to Electron. A handler registered beside its
 # domain logic would bypass the manifest's sender and wire guards.


### PR DESCRIPTION
## What

Temporary directories, microtask drains, fake clocks, native-helper child processes, an in-memory brain envelope and an `AppSettingsView` literal were each hand-rolled in several desktop test files. Every copy had drifted: three temporary directories were never cleaned up at all, and four drains had settled on four different tick counts for the same wait.

One copy of each now lives under the existing `#testing/*` alias, beside `realtime-fixtures.ts` and `spoken-setting-bridge.ts`:

| Fixture | What it holds | Adopters |
| --- | --- | --- |
| `temporary-directory.ts` | `temporaryDirectory(t, prefix)` — `mkdtempSync` plus the `t.after` that removes it | 8 |
| `drain.ts` | `drainMicrotasks(ticks)` | 16 |
| `fake-clock.ts` | `FakeClock` — `now`, `schedule`, `cancel`, `seams`, `advance`, `fireAll`, `armed`, `delays` | 4 |
| `native-helper.ts` | `fakeNativeHelper()` — a `NativeHelperProcess` that never was | 4 |
| `brain-harness.ts` | `brainHarness()`, and `MemoryBrainStorage` / `heldModel` / `answered` / `answerOf` on their own | 1 whole, 5 partial |
| `settings-fixtures.ts` | `settingsView(overrides)` | 4 |

`apps/desktop/src/testing/AGENTS.md` (with its `CLAUDE.md` symlink) names each fixture and the rule it carries, and `scripts/repository-checks.sh` gains a check that fails the build on a `mkdtemp` or a `setImmediate` inside any `apps/desktop/src` test file — the two calls a hand-rolled copy always begins with.

## Proof it changed no behaviour

- **No test name is added or removed.** `git diff origin/main -- 'apps/desktop/src/**/*.test.ts' | grep '^[-+]test('` yields 22 removals and 22 additions, and stripping the callback signature makes them pair off exactly — every one is `async () =>` becoming `async (t) =>` so a helper can take a `TestContext` for its temporary directory.
- `grep -rnaE --include='*.test.ts' --include='*.test.tsx' 'mkdtemp|setImmediate' apps/desktop/src` → empty.
- `grep -rn 'class MemoryStorage\|function settle\b\|fakeTimers\|class FakeClock' apps/desktop/src` → hits only inside `apps/desktop/src/testing/`.
- `./scripts/repository-checks.sh` was demonstrated failing on a planted `setImmediate` in `main/brain/host.test.ts` and passing once removed.
- `ls /tmp | grep -c luke-` is unchanged across a full `pnpm test`, which the three uncleaned directories previously were not.

## Departures from the plan, and why

Three items in the G4 spec turned out to describe duplication that is not there. Each is left alone rather than manufactured:

1. **`errandWindow()` is not extracted.** `STAGE`, `SURFACE`, `TOKENS` and `homeward` have exactly one consumer (`luke-errand.test.ts`; `errand-queue.test.ts` names none of them), and the extraction would drag a `.tsx` import into `src/testing/`, which the `#renderer/*` alias does not resolve. Moving a single-consumer helper into a shared file is relocation, not deduplication. The file is therefore `settings-fixtures.ts`, holding only `settingsView`, which genuinely had four copies.
2. **`realtime-fixtures.ts` is not extended with `fakeSession`.** `speech-mouth.test.ts` is its only consumer; `reply-delivery-player.test.ts`'s session fake is a different shape (`speakReply`, no `connect`/`close`), and `use-voice-session.test.ts` has none.
3. **The four `composed()` helpers are not unified.** They are not one harness in three dresses: `host-lifecycle`'s composes `BrainHost` + follower + delivery ledger over an in-memory envelope; `wiring-routing`'s and `wiring-children`'s compose `wireBrain`; `conversation-deletion`'s composes a real SQLite store, a `ConversationThread` and the deletion flow. Only `host-lifecycle`'s became `brainHarness()`. The other three adopt the pieces they actually share — `MemoryBrainStorage`, `drainMicrotasks`, `FakeClock`, `temporaryDirectory` — and keep their own composition.

Consequently the spec's "`main/brain/*.test.ts` preamble under 20%" is met where the duplication was real and not where it was not:

| File | Preamble before | after |
| --- | --- | --- |
| `host-lifecycle.test.ts` | 34% (709 lines) | **4%** (491) |
| `host.test.ts` | 26% | **12%** |
| `ipc.test.ts` | 16% | **15%** |
| `wiring-routing.test.ts` | 45% | 42% |
| `wiring-children.test.ts` | 63% | 57% |
| `conversation-deletion.test.ts` | 66% | 67% |

Rebased onto `origin/main` after B11 (`#804`), B13 (`#810`), B14/E4 (`#812`) and the `#shared/wire` → `#shared/messages` move landed; the fixtures are re-derived from the current watcher factories, the current `DeliveryLedger<GrantedWords>` composition, and the current import paths, and `./scripts/check.sh` is green on that base.

The three that barely moved are bespoke composition of `wireBrain` and the deletion flow, not shared boilerplate; folding them into a fixture with per-caller parameters nobody else uses would be the abstraction-for-callers-who-never-arrived the plan is written against.

Two other adoptions in the spec are skipped for the same reason: `voice-level-meter.test.ts`'s `now` is a mutable local driven by a frame stepper, with no scheduling seam for `FakeClock` to fill, and `media-duck.test.ts`'s `settle()` is a real `setTimeout` wait on a real release delay, not a microtask drain.

## Diff

```
$ git diff --shortstat origin/main...
 38 files changed, 968 insertions(+), 1059 deletions(-)
```

Test files alone: **−557 lines of test**, against +460 of fixture, +45 of guide and +14 of repository check.

Repository line total after this PR: **~251,000** (tracked `.ts/.tsx/.mjs/.js/.swift/.md/.json/.css/.sh/.yml`, `pnpm-lock.yaml` excluded), against the plan's ~125k target.

## Verification

- `./scripts/check.sh` — green (exit 0), including `repository-checks.sh`, the design contract, typecheck, every package's tests, and both desktop builds.
- Not a UI PR: no renderer component, style, or drawn output changes, so no `verify.sh` fixture PNG and no physical-notch check. The renderer files touched are three `.test.ts` files, which never enter the bundle.
- No trust constraint is touched: nothing here ships, no CLAUDE.md sentence names a moved symbol, and `PRIVACY.md` is unchanged because no fixture observes, stores, or sends anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Self-review

Two passes were run on this PR after it opened, and everything real they surfaced is fixed in the two follow-up commits.

**Thermonuclear code-quality review** (Cursor's rubric — code judo, spaghetti growth, thin abstractions, the 1,000-line rule, boundary cleanliness):

- **Thin abstraction / pass-through helpers.** Seven exports had no caller at all: `emitLines`, `fail` and `detached` on the native-helper fake, `seams` and `ClockSeams` on the clock, the `BrainHarness` type alias, and the harness's `record`. A fixture built for a caller that never arrived is the disease this whole cleanup is against, so all seven are gone (`758f1be`).
- **The 1,000-line rule.** Two files in the diff are over it — `settings-store.test.ts` (2,435) and `luke-guide.test.ts` (1,032) — and both were over it before this PR. This PR shrinks both and adds nothing to either.
- **Documented invariants that were false.** The drain's docblock claimed its default covers every chain here; two callers pass 40 and 60. Reworded to say what the parameter is for.
- **Held, with the tension recorded rather than hidden.** `brainHarness()` itself has one caller. By the ponytail ladder that is a `yagni:` — inline it until a second arrives. It is kept because the plan names `apps/desktop/src/testing/brain-harness.ts` as the deliverable and names C0 as the PR that moves it to `packages/host/src/testing/`, so it is a declared seam rather than a speculative one; and because its pieces (`MemoryBrainStorage`, `heldModel`, `answered`, `answerOf`) do have five further callers, which is why they are exported separately.

**Ponytail review** (subtractive only — `delete` / `stdlib` / `native` / `yagni` / `shrink`, correctness out of scope):

- `testing/drain.ts:L1-16: stdlib: hand-rolled recursive setImmediate scheduler. node:timers/promises ships an awaitable setImmediate; the body is a for-loop over it.` Applied (`7262d76`).
- `testing/native-helper.ts: delete: seven exports with no caller.` Applied (`758f1be`).
- `net: −38 lines beyond the opening commit.`

**One correctness regression the reviews caught, fixed in `7262d76`.** The native-helper fake was `trim()`ing what the watcher wrote to stdin, which quietly cost `microphone-route.test.ts` its assertion that the probe carries the newline the helper frames by — a shared fixture must not buy its shape with an adopter's coverage. The fake now keeps the chunk exactly as written, and the media duck, whose helper takes whole words, trims at its own assertion.

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34303766577/artifacts/10085948321) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34303766577)

- Commit: `e76e25399c936225033ff57210f05a064c4c0278`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
