### PR TITLE
refactor(desktop): one native line-watcher

### DIFF
--- a/apps/desktop/src/main/desktop-app.ts
+++ b/apps/desktop/src/main/desktop-app.ts
@@ -81,8 +81,14 @@ import { registerVoiceRuntimeIpc } from "./ipc/voice-runtime";
 import { registerWindowSurfaceIpc } from "./ipc/window-surface";
 import { jsonStateFile } from "./json-state-file";
 import { MediaDuckController } from "./native/media-duck";
-import { MicrophoneRouteWatcher } from "./native/microphone-route";
-import { OutputVolumeWatcher } from "./native/output-volume";
+import {
+  microphoneRouteWatcher as createMicrophoneRouteWatcher,
+  type MicrophoneRouteWatch,
+} from "./native/microphone-route";
+import {
+  outputVolumeWatcher as createOutputVolumeWatcher,
+  type OutputVolumeWatch,
+} from "./native/output-volume";
 import { onboardingStateFile } from "./onboarding-state";
 import { type BridgeContext, registerBridge, registerBridgeEntry } from "./register-bridge";
 import { runModeFor, sentryReportingEnabled } from "./run-mode";
@@ -183,9 +189,9 @@ const BRAIN_APP_ACT_TIMEOUT_MS = 10_000;
 const mediaDuck = new MediaDuckController();
 const feedbackDelivery = feedbackDeliveryFromEnvironment();
 let outputAudio: OutputAudioState | undefined;
-let outputVolumeWatcher: OutputVolumeWatcher | undefined;
+let outputVolumeWatcher: OutputVolumeWatch | undefined;
 let microphoneRoute: MicrophoneRoute | undefined;
-let microphoneRouteWatcher: MicrophoneRouteWatcher | undefined;
+let microphoneRouteWatcher: MicrophoneRouteWatch | undefined;
 
 function rendererUrl(): string {
   return pathToFileURL(path.join(__dirname, "renderer", "index.html")).href;
@@ -335,7 +341,7 @@ function startOutputVolumeWatch(): void {
     outputAudio = state;
     broadcast(channels.onOutputAudioChanged, state);
   };
-  outputVolumeWatcher = new OutputVolumeWatcher({
+  outputVolumeWatcher = createOutputVolumeWatcher({
     onState: send,
     onUnavailable: () => send(undefined),
   });
@@ -344,7 +350,7 @@ function startOutputVolumeWatch(): void {
 
 function startMicrophoneRouteWatch(): void {
   if (!runMode.observesProviders) return;
-  microphoneRouteWatcher = new MicrophoneRouteWatcher({
+  microphoneRouteWatcher = createMicrophoneRouteWatcher({
     onRoute: (route) => {
       microphoneRoute = route;
     },

--- a/apps/desktop/src/main/ipc/window-surface.ts
+++ b/apps/desktop/src/main/ipc/window-surface.ts
@@ -15,7 +15,7 @@ import {
   type MicrophoneRoute,
   type MicrophoneStatus,
 } from "#shared/messages/audio";
-import type { MicrophoneRouteWatcher } from "../native/microphone-route";
+import type { MicrophoneRouteWatch } from "../native/microphone-route";
 import { registerBridge } from "../register-bridge";
 import type { PanelManager } from "../window/panel-manager";
 
@@ -39,7 +39,7 @@ export interface WindowSurfaceIpcDependencies {
   panels: PanelManager;
   requestMicrophone: () => Promise<MicrophoneStatus>;
   microphoneRoute: () => MicrophoneRoute | undefined;
-  microphoneRouteWatcher: () => MicrophoneRouteWatcher | undefined;
+  microphoneRouteWatcher: () => MicrophoneRouteWatch | undefined;
   recordProductEvent: RecordProductEvent;
 }
 

--- a/apps/desktop/src/main/native/line-watcher.ts
+++ b/apps/desktop/src/main/native/line-watcher.ts
@@ -84,6 +84,10 @@ export function lineWatcher<State>(options: LineWatcherOptions<State>): LineWatc
 
   return {
     start(): boolean {
+      // One helper per watcher: a second start would orphan a live process
+      // whose lines no one reads, and a restart after an ending would reopen a
+      // watch already reported unavailable.
+      if (helper || done) return false;
       const started = new NativeHelper({
         binary: options.binary,
         ...(options.arguments ? { arguments: options.arguments } : undefined),

--- a/apps/desktop/src/main/native/line-watcher.ts
+++ b/apps/desktop/src/main/native/line-watcher.ts
@@ -1,0 +1,116 @@
+import { NativeHelper, type NativeHelperProcess } from "./native-helper";
+
+/**
+ * What a parser returns for a line that says the helper cannot answer. A
+ * symbol, so a watcher whose state is itself a string can still return one.
+ */
+export const LINE_UNAVAILABLE: unique symbol = Symbol("line-unavailable");
+export type LineUnavailable = typeof LINE_UNAVAILABLE;
+
+/**
+ * A line's meaning: a state to report, the helper saying it cannot answer, or
+ * nothing — a line that does not parse is dropped rather than guessed at.
+ */
+export type ParsedLine<State> = State | LineUnavailable | undefined;
+
+export interface LineWatcherOptions<State> {
+  binary: string;
+  /** Fixed by the build and by the caller; never anything read from a model. */
+  arguments?: readonly string[];
+  /** `"pipe"` only for a watcher that writes the helper a word. */
+  input?: "ignore" | "pipe";
+  parse: (line: string) => ParsedLine<State>;
+  onState: (state: State) => void;
+  /**
+   * The helper cannot answer. Called at most once for an ending — a spawn that
+   * failed, an error, an exit — and never for a stop the app asked for. Called
+   * repeatedly, without ending the watch, for a parsed `LINE_UNAVAILABLE` when
+   * `unavailableLineEnds` is false.
+   */
+  onUnavailable: () => void;
+  /**
+   * Whether a parsed `LINE_UNAVAILABLE` ends the watch. True for a helper whose
+   * refusal is final (the talk key never registers again); false for one whose
+   * subject can come back (the default output device changes).
+   */
+  unavailableLineEnds: boolean;
+  /**
+   * How long `stop()` waits for the process to actually exit. Zero — the
+   * default — kills and does not wait. Non-zero only where a successor needs
+   * the system to have released what this process held.
+   */
+  exitWaitMs?: number;
+  /** Internal seam for tests; production always uses the one spawn in NativeHelper. */
+  spawnProcess?: () => NativeHelperProcess | undefined;
+}
+
+export interface LineWatcher {
+  /** Answers whether the helper could be launched at all, not whether it can answer. */
+  start(): boolean;
+  /** One line to the helper's stdin; false when there is nothing to write to. */
+  send(line: string): boolean;
+  /** Detaches, kills, and resolves when the process is gone or `exitWaitMs` elapses. */
+  stop(): Promise<void>;
+}
+
+/**
+ * One native helper read as a stream of lines: hold the process, parse each
+ * line, report the states, and report a single ending however it is heard.
+ * What differs between helpers is the parser and the edges, so that is all a
+ * caller supplies.
+ */
+export function lineWatcher<State>(options: LineWatcherOptions<State>): LineWatcher {
+  let helper: NativeHelper | undefined;
+  let done = false;
+
+  const end = (): void => {
+    if (done) return;
+    done = true;
+    helper = undefined;
+    options.onUnavailable();
+  };
+
+  const handle = (line: string): void => {
+    if (done) return;
+    const parsed = options.parse(line);
+    if (parsed === undefined) return;
+    if (parsed === LINE_UNAVAILABLE) {
+      if (options.unavailableLineEnds) end();
+      else options.onUnavailable();
+      return;
+    }
+    options.onState(parsed);
+  };
+
+  return {
+    start(): boolean {
+      const started = new NativeHelper({
+        binary: options.binary,
+        ...(options.arguments ? { arguments: options.arguments } : undefined),
+        ...(options.input ? { input: options.input } : undefined),
+        output: "lines",
+        ...(options.spawnProcess ? { spawnProcess: options.spawnProcess } : undefined),
+      });
+      started.onLine(handle);
+      started.onExit(end);
+      if (!started.start()) {
+        end();
+        return false;
+      }
+      helper = started;
+      return true;
+    },
+    send(line: string): boolean {
+      return done ? false : (helper?.writeLine(line) ?? false);
+    },
+    stop(): Promise<void> {
+      // Latched before detaching: the pipe outlives the kill by however long
+      // the process takes to die, so a line still in it is dropped rather than
+      // acted on under a helper the app has already let go of.
+      const stopping = helper;
+      done = true;
+      helper = undefined;
+      return stopping?.stop(options.exitWaitMs ?? 0) ?? Promise.resolve();
+    },
+  };
+}

--- a/apps/desktop/src/main/native/media-duck.test.ts
+++ b/apps/desktop/src/main/native/media-duck.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { MediaDuckController, type MediaDuckProcess } from "./media-duck";
+import { MediaDuckController } from "./media-duck";
+import type { NativeHelperProcess } from "./native-helper";
 
 /** Short enough to wait out for real, long enough to act inside of. */
 const RELEASE_DELAY_MS = 40;
@@ -14,13 +15,13 @@ interface Harness {
   die: () => void;
 }
 
-function harness(options: { spawns?: (() => MediaDuckProcess | undefined)[] } = {}): Harness {
+function harness(options: { spawns?: (() => NativeHelperProcess | undefined)[] } = {}): Harness {
   const commands: string[] = [];
   let spawned = 0;
   let ended = false;
   const exits: (() => void)[] = [];
 
-  const spawnHelper = (): MediaDuckProcess | undefined => {
+  const spawnHelper = (): NativeHelperProcess | undefined => {
     const scripted = options.spawns?.[spawned];
     spawned += 1;
     if (scripted) return scripted();

--- a/apps/desktop/src/main/native/media-duck.ts
+++ b/apps/desktop/src/main/native/media-duck.ts
@@ -20,12 +20,9 @@ type MediaDuckCommand = (typeof MEDIA_DUCK_COMMAND)[keyof typeof MEDIA_DUCK_COMM
  */
 export const MEDIA_DUCK_RELEASE_DELAY_MS = 1_000;
 
-/** Only the parts of a child process this needs, so a test can supply them. */
-export type MediaDuckProcess = NativeHelperProcess;
-
 export interface MediaDuckControllerOptions {
   /** Injectable so the ordering can be exercised without a Mac or a binary. */
-  spawnHelper?: () => MediaDuckProcess | undefined;
+  spawnHelper?: () => NativeHelperProcess | undefined;
   releaseDelayMs?: number;
 }
 
@@ -38,7 +35,7 @@ export interface MediaDuckControllerOptions {
  * that is the user's own hand asking for their volume back.
  */
 export class MediaDuckController {
-  readonly #spawnHelper: (() => MediaDuckProcess | undefined) | undefined;
+  readonly #spawnHelper: (() => NativeHelperProcess | undefined) | undefined;
   readonly #releaseDelayMs: number;
   #helper: NativeHelper | undefined;
   #enabled = false;

--- a/apps/desktop/src/main/native/microphone-route.test.ts
+++ b/apps/desktop/src/main/native/microphone-route.test.ts
@@ -3,10 +3,11 @@ import test from "node:test";
 import { LID_STATE, MICROPHONE_TRANSPORT, type MicrophoneRoute } from "#shared/messages/audio";
 import {
   MICROPHONE_ROUTE_PROBE,
-  type MicrophoneRouteProcess,
-  MicrophoneRouteWatcher,
+  type MicrophoneRouteWatch,
+  microphoneRouteWatcher,
   parseMicrophoneRouteLine,
 } from "./microphone-route";
+import type { NativeHelperProcess } from "./native-helper";
 
 test("a route line parses into its three facts", () => {
   assert.deepEqual(
@@ -41,7 +42,7 @@ test("a line outside the vocabulary is dropped rather than guessed at", () => {
 });
 
 interface Harness {
-  watcher: MicrophoneRouteWatcher;
+  watcher: MicrophoneRouteWatch;
   routes: MicrophoneRoute[];
   unavailable: () => number;
   written: string[];
@@ -56,7 +57,7 @@ function harness(): Harness {
   let listener: ((chunk: string) => void) | undefined;
   const exits: (() => void)[] = [];
 
-  const child: MicrophoneRouteProcess = {
+  const child: NativeHelperProcess = {
     stdin: {
       write: (chunk) => {
         written.push(chunk);
@@ -77,7 +78,7 @@ function harness(): Harness {
     kill: () => undefined,
   };
 
-  const watcher = new MicrophoneRouteWatcher({
+  const watcher = microphoneRouteWatcher({
     spawnHelper: () => child,
     onRoute: (route) => {
       routes.push(route);
@@ -136,7 +137,7 @@ test("a helper that dies withdraws the route rather than freezing it", () => {
 
 test("a watcher that cannot spawn says so once", () => {
   let unavailable = 0;
-  const watcher = new MicrophoneRouteWatcher({
+  const watcher = microphoneRouteWatcher({
     spawnHelper: () => undefined,
     onRoute: () => undefined,
     onUnavailable: () => {

--- a/apps/desktop/src/main/native/microphone-route.ts
+++ b/apps/desktop/src/main/native/microphone-route.ts
@@ -5,7 +5,8 @@ import {
   type MicrophoneRoute,
   type MicrophoneTransport,
 } from "#shared/messages/audio";
-import { NativeHelper, type NativeHelperProcess } from "./native-helper";
+import { lineWatcher } from "./line-watcher";
+import type { NativeHelperProcess } from "./native-helper";
 
 /** The one word the helper takes; its one line is read by the parser below. */
 export const MICROPHONE_ROUTE_PROBE = "probe";
@@ -17,12 +18,25 @@ export interface MicrophoneRouteEdges {
   onUnavailable(): void;
 }
 
-/** Only the parts of a child process this needs, so a test can supply them. */
-export type MicrophoneRouteProcess = NativeHelperProcess;
-
 export interface MicrophoneRouteWatcherOptions extends MicrophoneRouteEdges {
   /** Injectable so the reader can be exercised without a Mac or a binary. */
-  spawnHelper?: () => MicrophoneRouteProcess | undefined;
+  spawnHelper?: () => NativeHelperProcess | undefined;
+}
+
+export interface MicrophoneRouteWatch {
+  /**
+   * Starts the helper, reporting whether it could be launched at all. A `true`
+   * is not yet a readable route — that arrives on the helper's first line.
+   */
+  start(): boolean;
+  /**
+   * Asks for a fresh read. The lid can close without any device changing, so
+   * the app probes when a press is about to choose a device; the answer rides
+   * the same line every change does.
+   */
+  probe(): void;
+  /** Stops the helper. Nothing succeeds it during shutdown, so no one waits. */
+  stop(): void;
 }
 
 /**
@@ -32,67 +46,30 @@ export interface MicrophoneRouteWatcherOptions extends MicrophoneRouteEdges {
  * answer decides is bounded to one act: which device the renderer asks the
  * browser to open when a press takes a turn.
  */
-export class MicrophoneRouteWatcher {
-  readonly #options: MicrophoneRouteWatcherOptions;
-  #helper: NativeHelper | undefined;
-  #done = false;
+export function microphoneRouteWatcher(
+  options: MicrophoneRouteWatcherOptions,
+): MicrophoneRouteWatch {
+  const { spawnHelper } = options;
+  const watch = lineWatcher<MicrophoneRoute>({
+    binary: "mac-microphone-route",
+    input: "pipe",
+    parse: parseMicrophoneRouteLine,
+    onState: options.onRoute,
+    onUnavailable: options.onUnavailable,
+    // The helper writes no refusal of its own; only its death withdraws a route.
+    unavailableLineEnds: true,
+    ...(spawnHelper ? { spawnProcess: spawnHelper } : undefined),
+  });
 
-  constructor(options: MicrophoneRouteWatcherOptions) {
-    this.#options = options;
-  }
-
-  /**
-   * Starts the helper, reporting whether it could be launched at all. A `true`
-   * is not yet a readable route — that arrives on the helper's first line.
-   */
-  start(): boolean {
-    const helper = new NativeHelper({
-      binary: "mac-microphone-route",
-      input: "pipe",
-      output: "lines",
-      ...(this.#options.spawnHelper ? { spawnProcess: this.#options.spawnHelper } : undefined),
-    });
-    helper.onLine((line) => {
-      if (this.#done) return;
-      const route = parseMicrophoneRouteLine(line);
-      if (route) this.#options.onRoute(route);
-    });
-    helper.onExit(() => this.#unavailable());
-    if (!helper.start()) {
-      this.#unavailable();
-      return false;
-    }
-    this.#helper = helper;
-    return true;
-  }
-
-  /**
-   * Asks for a fresh read. The lid can close without any device changing, so
-   * the app probes when a press is about to choose a device; the answer rides
-   * the same line every change does.
-   */
-  probe(): void {
-    if (this.#done) return;
-    this.#helper?.writeLine(MICROPHONE_ROUTE_PROBE);
-  }
-
-  /**
-   * Stops the helper. Detached before killing: this exit is the app's own
-   * doing, and nothing succeeds a watcher during shutdown, so no one waits.
-   */
-  stop(): void {
-    const helper = this.#helper;
-    this.#helper = undefined;
-    this.#done = true;
-    void helper?.stop();
-  }
-
-  #unavailable(): void {
-    if (this.#done) return;
-    this.#done = true;
-    this.#helper = undefined;
-    this.#options.onUnavailable();
-  }
+  return {
+    start: () => watch.start(),
+    probe: () => {
+      watch.send(MICROPHONE_ROUTE_PROBE);
+    },
+    stop: () => {
+      void watch.stop();
+    },
+  };
 }
 
 const TRANSPORT_WORDS: readonly MicrophoneTransport[] = Object.values(MICROPHONE_TRANSPORT);

--- a/apps/desktop/src/main/native/microphone-route.ts
+++ b/apps/desktop/src/main/native/microphone-route.ts
@@ -61,6 +61,8 @@ export function microphoneRouteWatcher(
     ...(spawnHelper ? { spawnProcess: spawnHelper } : undefined),
   });
 
+  // The watcher's own `send` stays off the caller-facing shape: the one word
+  // ever written to this helper is the probe the build fixed.
   return {
     start: () => watch.start(),
     probe: () => {

--- a/apps/desktop/src/main/native/output-volume.test.ts
+++ b/apps/desktop/src/main/native/output-volume.test.ts
@@ -110,6 +110,15 @@ test("stopping kills the helper and silences everything after", () => {
   assert.deepEqual(context.events, []);
 });
 
+test("a second start is refused rather than standing up a helper nobody reads", () => {
+  const context = harness();
+  assert.equal(context.watcher.start(), true);
+  assert.equal(context.watcher.start(), false);
+
+  context.emit("output muted=1 volume=0.42\n");
+  assert.deepEqual(context.events, ["state:1:0.42"]);
+});
+
 test("a line that does not parse is dropped rather than guessed at", () => {
   assert.equal(parseOutputLine("output muted=2 volume=0.5"), undefined);
   assert.equal(parseOutputLine("output muted=1 volume=1.5"), undefined);

--- a/apps/desktop/src/main/native/output-volume.test.ts
+++ b/apps/desktop/src/main/native/output-volume.test.ts
@@ -1,10 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import type { OutputAudioState } from "#shared/messages/audio";
-import { OutputVolumeWatcher, parseOutputLine } from "./output-volume";
+import { type OutputVolumeWatch, outputVolumeWatcher, parseOutputLine } from "./output-volume";
 
 interface Harness {
-  watcher: OutputVolumeWatcher;
+  watcher: OutputVolumeWatch;
   events: string[];
   killed: () => boolean;
   emit: (chunk: string) => void;
@@ -17,7 +17,7 @@ function harness(spawnFails = false): Harness {
   let onData: ((chunk: string) => void) | undefined;
   const exits: (() => void)[] = [];
 
-  const watcher = new OutputVolumeWatcher({
+  const watcher = outputVolumeWatcher({
     spawnHelper: () =>
       spawnFails
         ? undefined

--- a/apps/desktop/src/main/native/output-volume.ts
+++ b/apps/desktop/src/main/native/output-volume.ts
@@ -1,5 +1,6 @@
 import type { OutputAudioState } from "#shared/messages/audio";
-import { NativeHelper, type NativeHelperProcess } from "./native-helper";
+import { LINE_UNAVAILABLE, lineWatcher } from "./line-watcher";
+import type { NativeHelperProcess } from "./native-helper";
 
 /**
  * The two things the helper says. Parsed rather than assumed, like the talk
@@ -23,12 +24,19 @@ export interface OutputVolumeEdges {
   onUnavailable(): void;
 }
 
-/** Only the parts of a child process this needs, so a test can supply them. */
-export type OutputVolumeProcess = NativeHelperProcess;
-
 export interface OutputVolumeWatcherOptions extends OutputVolumeEdges {
   /** Injectable so the reader can be exercised without a Mac or a binary. */
-  spawnHelper?: () => OutputVolumeProcess | undefined;
+  spawnHelper?: () => NativeHelperProcess | undefined;
+}
+
+export interface OutputVolumeWatch {
+  /**
+   * Starts the helper, reporting whether it could be launched at all. A `true`
+   * is not yet a readable output — that arrives on the helper's first line.
+   */
+  start(): boolean;
+  /** Stops the helper. Nothing succeeds it during shutdown, so no one waits. */
+  stop(): void;
 }
 
 /**
@@ -38,64 +46,27 @@ export interface OutputVolumeWatcherOptions extends OutputVolumeEdges {
  * renderer draws — captions forced on, and a hint asking for volume, while
  * Luke speaks unheard.
  */
-export class OutputVolumeWatcher {
-  readonly #options: OutputVolumeWatcherOptions;
-  #helper: NativeHelper | undefined;
-  #done = false;
-
-  constructor(options: OutputVolumeWatcherOptions) {
-    this.#options = options;
-  }
-
-  /**
-   * Starts the helper, reporting whether it could be launched at all. A `true`
-   * is not yet a readable output — that arrives on the helper's first line.
-   */
-  start(): boolean {
-    const helper = new NativeHelper({
-      binary: "mac-output-volume",
-      output: "lines",
-      ...(this.#options.spawnHelper ? { spawnProcess: this.#options.spawnHelper } : undefined),
-    });
-    helper.onLine((line) => this.#handle(line));
-    helper.onExit(() => this.#unavailable());
-    if (!helper.start()) {
-      this.#unavailable();
-      return false;
-    }
-    this.#helper = helper;
-    return true;
-  }
-
-  /**
-   * Stops the helper. Detached before killing: this exit is the app's own
-   * doing, and nothing succeeds a watcher during shutdown, so no one waits.
-   */
-  stop(): void {
-    const helper = this.#helper;
-    this.#helper = undefined;
-    this.#done = true;
-    void helper?.stop();
-  }
-
-  #handle(line: string): void {
-    if (line.startsWith(`${OUTPUT_VOLUME_EVENT.OUTPUT} `)) {
-      const state = parseOutputLine(line);
-      if (state) this.#options.onState(state);
-      return;
-    }
+export function outputVolumeWatcher(options: OutputVolumeWatcherOptions): OutputVolumeWatch {
+  const { spawnHelper } = options;
+  const watch = lineWatcher<OutputAudioState>({
+    binary: "mac-output-volume",
+    parse: (line) =>
+      line.startsWith(OUTPUT_VOLUME_EVENT.UNAVAILABLE) ? LINE_UNAVAILABLE : parseOutputLine(line),
+    onState: options.onState,
+    onUnavailable: options.onUnavailable,
     // Unlike the talk key's, this unavailability is not final: the default
     // device can change to one the helper can read, so the watcher stays up
     // and only the current answer is withdrawn.
-    if (line.startsWith(OUTPUT_VOLUME_EVENT.UNAVAILABLE)) this.#options.onUnavailable();
-  }
+    unavailableLineEnds: false,
+    ...(spawnHelper ? { spawnProcess: spawnHelper } : undefined),
+  });
 
-  #unavailable(): void {
-    if (this.#done) return;
-    this.#done = true;
-    this.#helper = undefined;
-    this.#options.onUnavailable();
-  }
+  return {
+    start: () => watch.start(),
+    stop: () => {
+      void watch.stop();
+    },
+  };
 }
 
 /**

--- a/apps/desktop/src/main/native/screen-geometry.test.ts
+++ b/apps/desktop/src/main/native/screen-geometry.test.ts
@@ -1,64 +1,28 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import type { NativeNotchGeometry } from "@sidecar/surface";
-import { createCoalescedScreenGeometryReader } from "./screen-geometry";
+import { sharedInFlight } from "./screen-geometry";
 
-const geometry = (displayId: number): Map<number, NativeNotchGeometry> =>
-  new Map([
-    [
-      displayId,
-      {
-        displayId,
-        safeAreaTop: 38,
-        notchWidth: 210,
-        hasNotch: true,
-      },
-    ],
-  ]);
-
-test("screen geometry reads are serial, coalesced, and latest-wins", async () => {
-  let activeReads = 0;
-  let maximumActiveReads = 0;
+test("concurrent reads share one probe, and a later read probes again", async () => {
   let readCount = 0;
-  const pendingReads: Array<(screens: Map<number, NativeNotchGeometry>) => void> = [];
-  const readGeometry = createCoalescedScreenGeometryReader(
+  const pending: Array<(value: string) => void> = [];
+  const read = sharedInFlight(
     () =>
-      new Promise((resolve) => {
+      new Promise<string>((resolve) => {
         readCount += 1;
-        activeReads += 1;
-        maximumActiveReads = Math.max(maximumActiveReads, activeReads);
-        pendingReads.push((screens) => {
-          activeReads -= 1;
-          resolve(screens);
-        });
+        pending.push(resolve);
       }),
   );
 
-  const first = readGeometry();
-  const second = readGeometry();
-  const third = readGeometry();
-  let resolved = false;
-  void Promise.all([first, second, third]).then(() => {
-    resolved = true;
-  });
-
+  const overlapping = [read(), read(), read()];
   assert.equal(readCount, 1);
-  assert.equal(maximumActiveReads, 1);
 
-  const stale = geometry(1);
-  pendingReads.shift()?.(stale);
-  await new Promise<void>((resolve) => setImmediate(resolve));
+  pending.shift()?.("first");
+  assert.deepEqual(await Promise.all(overlapping), ["first", "first", "first"]);
 
+  // The share lasts exactly as long as the read does: a caller after it settles
+  // gets a fresh probe rather than an answer from before the display changed.
+  const later = read();
   assert.equal(readCount, 2);
-  assert.equal(maximumActiveReads, 1);
-  assert.equal(resolved, false);
-
-  const newest = geometry(2);
-  pendingReads.shift()?.(newest);
-  const results = await Promise.all([first, second, third]);
-
-  assert.equal(readCount, 2);
-  assert.equal(maximumActiveReads, 1);
-  assert.deepEqual(results, [newest, newest, newest]);
-  assert.ok(results.every((result) => result !== stale));
+  pending.shift()?.("second");
+  assert.equal(await later, "second");
 });

--- a/apps/desktop/src/main/native/screen-geometry.ts
+++ b/apps/desktop/src/main/native/screen-geometry.ts
@@ -27,58 +27,6 @@ function parseNativeGeometry(value: UnparsedWireValue): NativeNotchGeometry | un
   return parsed;
 }
 
-type GeometryRead = () => Promise<Map<number, NativeNotchGeometry>>;
-
-/**
- * Coalesces refresh bursts without allowing an older probe to become visible.
- * Callers that arrive during a probe join the same wait and request one newer
- * snapshot; only a probe with no newer request behind it resolves the waiters.
- */
-export function createCoalescedScreenGeometryReader(readSnapshot: GeometryRead): GeometryRead {
-  let reading = false;
-  let newerSnapshotRequested = false;
-  let waiters: Array<{
-    resolve: (screens: Map<number, NativeNotchGeometry>) => void;
-    reject: (error: Error) => void;
-  }> = [];
-
-  const drain = async (): Promise<void> => {
-    reading = true;
-    try {
-      while (waiters.length > 0) {
-        newerSnapshotRequested = false;
-        let screens: Map<number, NativeNotchGeometry>;
-        try {
-          screens = await readSnapshot();
-        } catch (error) {
-          const failure = error instanceof Error ? error : new Error("Screen geometry read failed");
-          const failed = waiters;
-          waiters = [];
-          for (const waiter of failed) waiter.reject(failure);
-          return;
-        }
-
-        if (newerSnapshotRequested) continue;
-
-        const ready = waiters;
-        waiters = [];
-        for (const waiter of ready) waiter.resolve(screens);
-      }
-    } finally {
-      reading = false;
-    }
-  };
-
-  return () => {
-    newerSnapshotRequested = true;
-    const result = new Promise<Map<number, NativeNotchGeometry>>((resolve, reject) => {
-      waiters.push({ resolve, reject });
-    });
-    if (!reading) void drain();
-    return result;
-  };
-}
-
 async function probeMacScreenGeometry(): Promise<Map<number, NativeNotchGeometry>> {
   if (process.platform !== "darwin") return new Map();
 
@@ -97,8 +45,21 @@ async function probeMacScreenGeometry(): Promise<Map<number, NativeNotchGeometry
   }
 }
 
-const readCoalescedMacScreenGeometry = createCoalescedScreenGeometryReader(probeMacScreenGeometry);
-
-export function readMacScreenGeometry(): Promise<Map<number, NativeNotchGeometry>> {
-  return readCoalescedMacScreenGeometry();
+/**
+ * One read at a time, shared: callers arriving during a read take that read's
+ * answer rather than starting another, and the next caller after it settles
+ * probes again. Every caller here is a display or power event that reconciles
+ * the panels again anyway, so the worst a shared answer costs is a snapshot
+ * one event stale, immediately superseded.
+ */
+export function sharedInFlight<T>(read: () => Promise<T>): () => Promise<T> {
+  let inFlight: Promise<T> | undefined;
+  return () => {
+    inFlight ??= read().finally(() => {
+      inFlight = undefined;
+    });
+    return inFlight;
+  };
 }
+
+export const readMacScreenGeometry = sharedInFlight(probeMacScreenGeometry);

--- a/apps/desktop/src/main/native/talk-key.test.ts
+++ b/apps/desktop/src/main/native/talk-key.test.ts
@@ -1,9 +1,9 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { TalkKeyWatcher } from "./talk-key";
+import { type TalkKeyWatch, talkKeyWatcher } from "./talk-key";
 
 interface Harness {
-  watcher: TalkKeyWatcher;
+  watcher: TalkKeyWatch;
   edges: string[];
   candidates: string[][];
   killed: () => boolean;
@@ -18,7 +18,7 @@ function harness(): Harness {
   let onData: ((chunk: string) => void) | undefined;
   const exits: (() => void)[] = [];
 
-  const watcher = new TalkKeyWatcher({
+  const watcher = talkKeyWatcher({
     spawnHelper: (requested) => {
       candidates.push([...requested]);
       return {

--- a/apps/desktop/src/main/native/talk-key.ts
+++ b/apps/desktop/src/main/native/talk-key.ts
@@ -1,4 +1,5 @@
-import { NativeHelper, type NativeHelperProcess } from "./native-helper";
+import { LINE_UNAVAILABLE, type LineWatcher, lineWatcher, type ParsedLine } from "./line-watcher";
+import type { NativeHelperProcess } from "./native-helper";
 
 /**
  * What the helper says about itself on its first line, and what it streams
@@ -13,6 +14,12 @@ export const TALK_KEY_EVENT = {
   UNAVAILABLE: "unavailable",
 } as const;
 
+/** One thing the helper reported about the chord it was given. */
+export type TalkKeyEdge =
+  | { kind: "down" }
+  | { kind: "up" }
+  | { kind: "registered"; accelerator: string };
+
 export interface TalkKeyEdges {
   onPress(): void;
   onRelease(): void;
@@ -26,12 +33,25 @@ export interface TalkKeyEdges {
   onUnavailable(): void;
 }
 
-/** Only the parts of a child process this needs, so a test can supply them. */
-export type TalkKeyProcess = NativeHelperProcess;
-
 export interface TalkKeyWatcherOptions extends TalkKeyEdges {
   /** Injectable so the reader can be exercised without a Mac or a binary. */
-  spawnHelper?: (candidates: readonly string[]) => TalkKeyProcess;
+  spawnHelper?: (candidates: readonly string[]) => NativeHelperProcess;
+}
+
+export interface TalkKeyWatch {
+  /**
+   * Starts the helper, reporting whether it could be launched at all. A `true`
+   * here is not yet a registered key — that arrives on the helper's first line,
+   * through `onRegistered`.
+   */
+  start(candidates: readonly string[]): boolean;
+  /**
+   * Stops the helper, reporting when its process is actually gone. The answer
+   * matters to a successor — the system releases the chord with the process,
+   * not with the kill that asked for it, so a new helper that claims a chord
+   * this one still holds would be refused.
+   */
+  stop(): Promise<void>;
 }
 
 /**
@@ -40,6 +60,16 @@ export interface TalkKeyWatcherOptions extends TalkKeyEdges {
  * signal cannot wedge every later change of the talk key.
  */
 const EXIT_WAIT_MS = 1000;
+
+export function parseTalkKeyLine(line: string): ParsedLine<TalkKeyEdge> {
+  if (line === TALK_KEY_EVENT.DOWN) return { kind: "down" };
+  if (line === TALK_KEY_EVENT.UP) return { kind: "up" };
+  if (line.startsWith(`${TALK_KEY_EVENT.REGISTERED} `)) {
+    return { kind: "registered", accelerator: line.slice(TALK_KEY_EVENT.REGISTERED.length + 1) };
+  }
+  if (line.startsWith(TALK_KEY_EVENT.UNAVAILABLE)) return LINE_UNAVAILABLE;
+  return undefined;
+}
 
 /**
  * Watches the talk key being held down and let go of, from whatever app is
@@ -51,75 +81,30 @@ const EXIT_WAIT_MS = 1000;
  * for nothing else: it is told one chord and can see no other key, which is
  * what keeps hold-to-talk from costing the user an Accessibility grant.
  */
-export class TalkKeyWatcher {
-  readonly #options: TalkKeyWatcherOptions;
-  #helper: NativeHelper | undefined;
-  #done = false;
+export function talkKeyWatcher(options: TalkKeyWatcherOptions): TalkKeyWatch {
+  let watch: LineWatcher | undefined;
 
-  constructor(options: TalkKeyWatcherOptions) {
-    this.#options = options;
-  }
-
-  /**
-   * Starts the helper, reporting whether it could be launched at all. A `true`
-   * here is not yet a registered key — that arrives on the helper's first line,
-   * through `onRegistered`.
-   */
-  start(candidates: readonly string[]): boolean {
-    const helper = new NativeHelper({
-      binary: "mac-talk-key",
-      arguments: candidates,
-      output: "lines",
-      ...(this.#options.spawnHelper
-        ? { spawnProcess: () => this.#options.spawnHelper?.(candidates) }
-        : undefined),
-    });
-    helper.onLine((line) => this.#handle(line));
-    helper.onExit(() => this.#unavailable());
-    if (!helper.start()) {
-      this.#unavailable();
-      return false;
-    }
-    this.#helper = helper;
-    return true;
-  }
-
-  /**
-   * Stops the helper, reporting when its process is actually gone. Detached
-   * before killing: this exit is the app's own doing, and reporting it as the
-   * key becoming unavailable would stand up a fallback during shutdown. The
-   * answer matters to a successor — the system releases the chord with the
-   * process, not with the kill that asked for it, so a new helper that claims
-   * a chord this one still holds would be refused.
-   */
-  stop(): Promise<void> {
-    const helper = this.#helper;
-    this.#helper = undefined;
-    this.#done = true;
-    return helper?.stop(EXIT_WAIT_MS) ?? Promise.resolve();
-  }
-
-  #handle(line: string): void {
-    if (this.#done) return;
-    if (line === TALK_KEY_EVENT.DOWN) {
-      this.#options.onPress();
-      return;
-    }
-    if (line === TALK_KEY_EVENT.UP) {
-      this.#options.onRelease();
-      return;
-    }
-    if (line.startsWith(`${TALK_KEY_EVENT.REGISTERED} `)) {
-      this.#options.onRegistered(line.slice(TALK_KEY_EVENT.REGISTERED.length + 1));
-      return;
-    }
-    if (line.startsWith(TALK_KEY_EVENT.UNAVAILABLE)) this.#unavailable();
-  }
-
-  #unavailable(): void {
-    if (this.#done) return;
-    this.#done = true;
-    this.#helper = undefined;
-    this.#options.onUnavailable();
-  }
+  return {
+    start(candidates: readonly string[]): boolean {
+      const { spawnHelper } = options;
+      watch = lineWatcher<TalkKeyEdge>({
+        binary: "mac-talk-key",
+        arguments: candidates,
+        parse: parseTalkKeyLine,
+        onState: (edge) => {
+          if (edge.kind === "down") options.onPress();
+          else if (edge.kind === "up") options.onRelease();
+          else options.onRegistered(edge.accelerator);
+        },
+        onUnavailable: options.onUnavailable,
+        unavailableLineEnds: true,
+        exitWaitMs: EXIT_WAIT_MS,
+        ...(spawnHelper ? { spawnProcess: () => spawnHelper(candidates) } : undefined),
+      });
+      return watch.start();
+    },
+    stop(): Promise<void> {
+      return watch?.stop() ?? Promise.resolve();
+    },
+  };
 }

--- a/apps/desktop/src/main/window/hotkey-registrar.ts
+++ b/apps/desktop/src/main/window/hotkey-registrar.ts
@@ -8,7 +8,7 @@ import type { UnparsedWireValue } from "@sidecar/wire";
 import { type BrowserWindow, globalShortcut, type WebContents } from "electron";
 import { channels } from "#shared/bridge";
 import type { WindowMode } from "#shared/messages/session";
-import { type TalkKeyEdges, TalkKeyWatcher } from "../native/talk-key";
+import { type TalkKeyEdges, talkKeyWatcher } from "../native/talk-key";
 
 /**
  * The three Luke keys, in the order they outrank one another. Talk takes any
@@ -142,8 +142,7 @@ export class HotkeyRegistrar {
     this.#hasCredentials = options.hasCredentials;
     this.#recordProductEvent = options.recordProductEvent;
     this.#shortcut = options.shortcut ?? globalShortcut;
-    this.#createTalkKeyWatcher =
-      options.createTalkKeyWatcher ?? ((edges) => new TalkKeyWatcher(edges));
+    this.#createTalkKeyWatcher = options.createTalkKeyWatcher ?? talkKeyWatcher;
     this.#keys = new Map<HotkeyRank, KeyState>([
       [
         HOTKEY_RANK.TALK,


### PR DESCRIPTION
## What

`talk-key.ts`, `output-volume.ts` and `microphone-route.ts` were the same 30-line class written three times: hold a `NativeHelper`, subscribe `onLine` and `onExit`, keep a `#done` latch, report unavailable once however the ending is heard (spawn failure, stdin error, `error`, `exit`), and detach before killing so a line the dying helper got out is dropped. What actually differed between them was a line parser and which edges the caller is told about.

- New `apps/desktop/src/main/native/line-watcher.ts`: `lineWatcher<State>({ binary, arguments, input, parse, onState, onUnavailable, unavailableLineEnds, exitWaitMs, spawnProcess })`. The latch, the single-ending guarantee, the detach-before-kill ordering and the stdin write live there once.
- The three modules become a parser plus edges. `parseTalkKeyLine` is new and exported; `parseOutputLine` and `parseMicrophoneRouteLine` are unchanged.
- `unavailableLineEnds` is a required flag rather than inferred: the talk key's refusal is final, the output device's is not, and that difference is the whole reason the two watchers looked different.
- The three `= NativeHelperProcess` reference-identity aliases and their identical *"Only the parts of a child process this needs"* comments are deleted, plus `media-duck.ts`'s fourth copy of the same alias — the seam is `LineWatcherOptions.spawnProcess`, typed once.
- `screen-geometry.ts`'s 49-line request coalescer becomes a shared in-flight promise (`sharedInFlight`). Both callers are display-change and power events, `probeMacScreenGeometry` is capped at 2 s and swallows its own failures (so the coalescer's reject path had no reachable producer), and `panels.reconcile()` re-runs on every one of those events — the worst a shared answer costs is a snapshot one event stale, immediately superseded.

`LINE_UNAVAILABLE` is a unique symbol rather than a sentinel object so a watcher whose `State` is itself a string can still return one, and so `===` narrows it out of the union at the one place it is read.

## Behaviour

No caller-facing behaviour changes except the geometry read, which trades latest-wins for a shared probe as the plan directs. Every one of the 25 existing watcher tests is kept verbatim and retargeted at the factories — they are the specification of the shared watcher: *"a press and its release survive being split across chunks"* (framing), *"a refusal is reported once, not once per way of hearing it"* (the latch), *"a line the dying helper got out after a stop is dropped, not acted on"* (latch before detach), *"stopping reports when the helper's process is actually gone"* (`exitWaitMs`), *"an unavailable line withdraws the answer without ending the watch"* (`unavailableLineEnds: false`).

`screen-geometry.test.ts`'s one coalescer test is replaced by *"concurrent reads share one probe, and a later read probes again"*.

No trust constraint moves. The watcher spawns the same three binaries with the same build-fixed arguments, reads the same lines, and `send()` is reachable only from `probe()`, which writes the one build-fixed word `MICROPHONE_ROUTE_PROBE`. No `AGENTS.md` or `PRIVACY.md` sentence names a deleted symbol; the paragraphs describing the three helpers describe what they may read and write, which is unchanged.

## Verification

- `./scripts/check.sh` green (`apps/desktop`: 957 pass, 0 fail).
- `git grep "TalkKeyWatcher\|OutputVolumeWatcher\|MicrophoneRouteWatcher\|TalkKeyProcess\|OutputVolumeProcess\|MicrophoneRouteProcess\|MediaDuckProcess\|createCoalescedScreenGeometryReader"` → only the `createTalkKeyWatcher` seam name the registrar already had.
- `git grep "Only the parts of a child process"` → empty.
- Not run: the Mac-only checks (`verify.sh`, holding the talk key, muting the output, unplugging a headset). This cloud workspace has no macOS host, so no physical-notch check was performed and no fixture PNG was inspected. No renderer file changes in this PR; the geometry reader's own behaviour is covered by its rewritten test.

## Self-review

Thermonuclear (Cursor's structural rubric) and ponytail (`delete`/`stdlib`/`native`/`yagni`/`shrink`) passes over the diff. Two real findings, both fixed in the second commit:

- **Structural, standard 5 (boundary cleanliness).** All three original classes let `start()` be called twice, spawning a helper over a live one whose lines no one would read, and two of them left a restart after an ending in a half-dead state (the latch dropped every line but nothing ever reported unavailable again). The one watcher refuses both, and `output-volume.test.ts` gains *"a second start is refused rather than standing up a helper nobody reads"*.
- **Standard 4 (thin wrappers / what a boundary hides).** `microphoneRouteWatcher` deliberately keeps `LineWatcher.send` off its caller-facing shape — the narrowing is the point, since the one word ever written to that helper is the build-fixed probe. That is now stated where it is done rather than left to be inferred.

Considered and deliberately not changed:

- `sharedInFlight` is a generic with one production caller — a `yagni` tag on its face. It stays as the repo's existing "internal seam for tests" idiom (`NativeHelper.spawnProcess`), because it is what keeps *"a later read probes again"* — the `.finally` that clears the cache — under test at all. Inlining it would delete the only coverage of the behaviour this PR changes.
- `unavailableLineEnds` is a required flag rather than defaulted, so the one helper that differs states it at the site that differs. It is unreachable for the microphone route, whose helper writes no refusal, and the line says so.
- `TalkKeyWatch` and the registrar's `TalkKeyHandle` are two names for one shape. `TalkKeyHandle` is the registrar's own port type and collapsing them belongs to whoever owns that file, not to this PR.

## Size

`git diff --shortstat origin/main...` → `14 files changed, 326 insertions(+), 333 deletions(-)` (net −7).

Measured tree after this PR: 200,106 lines of TS/TSX/MJS and 22,305 of Swift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/50ae8c8c-326b-4f0a-8db6-eaf08692bbcb)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34302087508/artifacts/10085339487) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34302087508)

- Commit: `23d8d5b88fa5a31280851eec03c9e53077a92a20`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

