### PR TITLE
refactor(host): one settings-store write path

### DIFF
--- a/apps/desktop/src/main/host/runtime-host.ts
+++ b/apps/desktop/src/main/host/runtime-host.ts
@@ -135,6 +135,7 @@ import {
   isSettingEntryKey,
   isSettingsResetScope,
   SETTING_SIDE_EFFECT,
+  type SettingEntryValue,
   settingAnalytics,
   settingEntryGuard,
   VOICE_SOURCE,
@@ -1865,7 +1866,7 @@ export function composeRuntimeHost(options: RuntimeHostOptions): RuntimeHost {
       }
       const result = await settingsWrite(
         // SAFETY: settingEntryGuard validated the entry before it reaches the store.
-        () => settingsStore.setEntry(field, key, parsed.value as UnparsedWireValue),
+        () => settingsStore.setEntry(field, key, parsed.value as SettingEntryValue<typeof field>),
         async (saved) => {
           if (saved.reason) return;
           recordSettingUpdate(field, saved.settings);

--- a/apps/desktop/src/main/settings-store.test.ts
+++ b/apps/desktop/src/main/settings-store.test.ts
@@ -19,6 +19,8 @@ import {
 import {
   APP_SETTING_FIELDS,
   APP_SETTING_SCHEMA,
+  type AppSettingField,
+  type AppSettingValue,
   isKeyedAppSettingField,
   settingEntryGuard,
   VOICE_HOTKEY_NONE,
@@ -27,7 +29,12 @@ import { PANEL_FORM_FACTOR } from "@sidecar/surface";
 import { type UnparsedWireValue, unparsedWire, type WireRecord } from "@sidecar/wire";
 import { ACCOUNT_STATUS, CREDENTIAL_SOURCE, SECRET_STORAGE } from "#shared/messages/account";
 import { appSettingsView, SETTINGS_RESET_SCOPE, VOICE_SOURCE } from "#shared/messages/settings";
-import { type SecretCipher, SettingsStore, type SettingsStoreOptions } from "./settings-store";
+import {
+  apiKeyRejection,
+  type SecretCipher,
+  SettingsStore,
+  type SettingsStoreOptions,
+} from "./settings-store";
 
 const TEST_API_KEY = "conductor-live-key";
 const SETTINGS_FILE_NAME = "settings.json";
@@ -261,6 +268,128 @@ async function readSettingsFile(directory: string): Promise<string> {
   return fs.readFile(path.join(directory, SETTINGS_FILE_NAME), "utf8");
 }
 
+/**
+ * A value each setting can hold that is not the value it falls back to, so a
+ * write can be told from the state it replaced. The table is total over
+ * `APP_SETTING_FIELDS`, so a setting added without one fails to compile rather
+ * than going quietly untested.
+ */
+const SAMPLE_VALUE = {
+  openAtLogin: false,
+  showInDock: true,
+  voice: REALTIME_VOICE.MARIN,
+  voiceSpeed: REALTIME_VOICE_SPEED.QUICK,
+  voiceCaptions: true,
+  voiceHotkey: "Shift+Command+L",
+  askHotkey: "Control+Alt+K",
+  stopHotkey: "Control+Alt+P",
+  duckOtherMedia: false,
+  voiceSource: VOICE_SOURCE.ACCOUNT,
+  preferBuiltInMicrophone: false,
+  announceSessions: false,
+  quietDuringMeetings: false,
+  syncProviderKeys: false,
+  showOnAllDisplays: true,
+  formFactor: PANEL_FORM_FACTOR.NOTCH,
+  sessionFilters: [SESSION_FILTER.LOCAL, PROVIDER_ID.CODEX],
+  sessionSearchQuery: "review",
+  defaultWorkspaceProvider: PROVIDER_ID.CONDUCTOR,
+  workspaceAgentDefaults: { [PROVIDER_ID.CONDUCTOR]: { agent: "claude", model: "sonnet" } },
+  workspaceProjectDefaults: { [PROVIDER_ID.CONDUCTOR]: "project-one" },
+} satisfies { [Field in AppSettingField]: NonNullable<AppSettingValue<Field>> };
+
+/**
+ * The settings a snapshot resolves rather than reports: what the panel draws
+ * for them comes from the environment, or from what this run could actually
+ * do, so only their own tests below can state it. What the file holds for them
+ * is still the table's business.
+ */
+const RESOLVED_FIELDS = new Set<AppSettingField>([
+  APP_SETTING_SCHEMA.voice.field,
+  APP_SETTING_SCHEMA.voiceSpeed.field,
+  APP_SETTING_SCHEMA.voiceSource.field,
+  APP_SETTING_SCHEMA.formFactor.field,
+]);
+
+/** A number is no setting's shape, so one file corrupts every field at once. */
+const CORRUPT_VALUE = 7;
+
+test("every setting starts at its default, survives a reopen, and can be cleared", async (t) => {
+  for (const field of APP_SETTING_FIELDS) {
+    const fallback = APP_SETTING_SCHEMA[field].guard(undefined).value;
+    const sample = SAMPLE_VALUE[field];
+    const directory = await temporaryDirectory(t);
+    const store = storeIn(directory);
+
+    assert.deepEqual(await store.get(field), fallback, `${field} did not start at its default`);
+
+    const written = await store.set(field, sample);
+    assert.equal(written.reason, undefined, field);
+    assert.deepEqual(await store.get(field), sample, field);
+    assert.deepEqual(
+      await storeIn(directory).get(field),
+      sample,
+      `${field} did not survive a reopen`,
+    );
+    if (!RESOLVED_FIELDS.has(field)) {
+      assert.deepEqual(
+        appSettingsView(written.settings)[field],
+        sample,
+        `${field} was not drawn as it was stored`,
+      );
+    }
+
+    // Clearing is the absence of a choice, not a stored empty value, so a
+    // setting that can be unset reads as unset again from a reopened file.
+    if (APP_SETTING_SCHEMA[field].guard(undefined).valid) {
+      await store.set(field, undefined);
+      assert.deepEqual(
+        await storeIn(directory).get(field),
+        fallback,
+        `${field} did not clear back to its default`,
+      );
+    }
+  }
+});
+
+test("every setting reads as its default when the file holds a shape it cannot be", async (t) => {
+  for (const field of APP_SETTING_FIELDS) {
+    const directory = await temporaryDirectory(t);
+    await fs.writeFile(
+      path.join(directory, SETTINGS_FILE_NAME),
+      JSON.stringify({ version: 2, apiKeys: {}, [field]: CORRUPT_VALUE }),
+      "utf8",
+    );
+
+    assert.deepEqual(
+      await storeIn(directory).get(field),
+      APP_SETTING_SCHEMA[field].guard(undefined).value,
+      `${field} honoured a value it cannot hold`,
+    );
+  }
+});
+
+test("no setting's write reaches the cipher, and none disturbs a stored key", async (t) => {
+  for (const field of APP_SETTING_FIELDS) {
+    const directory = await temporaryDirectory(t);
+    const cipher = countingCipher();
+    const store = storeIn(directory, { cipher });
+    await store.setApiKey(CONDUCTOR, TEST_API_KEY);
+    const protectingTheKey = { ...cipher.calls };
+
+    await store.set(field, SAMPLE_VALUE[field]);
+
+    // A preference is not a credential, so choosing one must reach the
+    // Keychain not at all — and never raise its permission dialog.
+    assert.deepEqual(cipher.calls, protectingTheKey, `${field} reached the cipher`);
+    assert.equal(
+      await storeIn(directory).readApiKey(CONDUCTOR),
+      TEST_API_KEY,
+      `${field} disturbed a stored key`,
+    );
+  }
+});
+
 test("stores an API key encrypted, private to the owner, and never in a snapshot", async (t) => {
   const directory = await temporaryDirectory(t);
   const store = storeIn(directory);
@@ -365,149 +494,6 @@ test("clears a stored key", async (t) => {
   assert.equal((await readSettingsFile(directory)).includes(CONDUCTOR), false);
 });
 
-test("captions are off until switched on, and the choice survives a reopen", async (t) => {
-  const directory = await temporaryDirectory(t);
-  // A preference is not a credential, so choosing it must reach the Keychain
-  // not at all.
-  const cipher = countingCipher();
-  const store = storeIn(directory, { cipher });
-
-  assert.equal(appSettingsView(await store.snapshot()).voiceCaptions, false);
-  const enabled = await store.set(APP_SETTING_SCHEMA.voiceCaptions.field, true);
-
-  assert.equal(appSettingsView(enabled.settings).voiceCaptions, true);
-  assert.equal(appSettingsView(await storeIn(directory).snapshot()).voiceCaptions, true);
-  assert.equal(cipher.calls.isAvailable, 0);
-  assert.equal(cipher.calls.encrypt, 0);
-});
-
-test("switching captions never disturbs a stored key", async (t) => {
-  const directory = await temporaryDirectory(t);
-  const store = storeIn(directory);
-  await store.setApiKey(CONDUCTOR, TEST_API_KEY);
-
-  await store.set(APP_SETTING_SCHEMA.voiceCaptions.field, true);
-  const off = await store.set(APP_SETTING_SCHEMA.voiceCaptions.field, false);
-
-  assert.equal(appSettingsView(off.settings).voiceCaptions, false);
-  assert.equal(await storeIn(directory).readApiKey(CONDUCTOR), TEST_API_KEY);
-});
-
-// SAFETY: Fixture value matches the narrowed runtime shape this test exercises.
-test("a corrupt captions value reads as off rather than switching them on", async (t) => {
-  const directory = await temporaryDirectory(t);
-  await fs.writeFile(
-    path.join(directory, SETTINGS_FILE_NAME),
-    JSON.stringify({ version: 2, apiKeys: {}, voiceCaptions: "yes" }),
-    "utf8",
-  );
-
-  assert.equal(appSettingsView(await storeIn(directory).snapshot()).voiceCaptions, false);
-});
-
-test("other media is quieted until asked otherwise, and the choice survives a reopen", async (t) => {
-  const directory = await temporaryDirectory(t);
-  // A preference is not a credential, so choosing it must reach the Keychain
-  // not at all.
-  const cipher = countingCipher();
-  const store = storeIn(directory, { cipher });
-
-  assert.equal(appSettingsView(await store.snapshot()).duckOtherMedia, true);
-  const disabled = await store.set(APP_SETTING_SCHEMA.duckOtherMedia.field, false);
-
-  assert.equal(appSettingsView(disabled.settings).duckOtherMedia, false);
-  assert.equal(appSettingsView(await storeIn(directory).snapshot()).duckOtherMedia, false);
-  assert.equal(cipher.calls.isAvailable, 0);
-  assert.equal(cipher.calls.encrypt, 0);
-});
-
-test("switching the media duck never disturbs a stored key", async (t) => {
-  const directory = await temporaryDirectory(t);
-  const store = storeIn(directory);
-  await store.setApiKey(CONDUCTOR, TEST_API_KEY);
-
-  await store.set(APP_SETTING_SCHEMA.duckOtherMedia.field, false);
-  const on = await store.set(APP_SETTING_SCHEMA.duckOtherMedia.field, true);
-
-  assert.equal(appSettingsView(on.settings).duckOtherMedia, true);
-  assert.equal(await storeIn(directory).readApiKey(CONDUCTOR), TEST_API_KEY);
-});
-
-// SAFETY: Fixture value matches the narrowed runtime shape this test exercises.
-test("a corrupt media duck value reads as the default rather than as off", async (t) => {
-  const directory = await temporaryDirectory(t);
-  // The mirror of the captions rule: each lands on its own default, and this
-  // one's default is on.
-  await fs.writeFile(
-    path.join(directory, SETTINGS_FILE_NAME),
-    JSON.stringify({ version: 2, apiKeys: {}, duckOtherMedia: "no" }),
-    "utf8",
-  );
-
-  assert.equal(appSettingsView(await storeIn(directory).snapshot()).duckOtherMedia, true);
-});
-
-test("the microphone preference persists, defaults on, and shrugs off corruption", async (t) => {
-  const directory = await temporaryDirectory(t);
-  const store = storeIn(directory);
-
-  assert.equal(appSettingsView(await store.snapshot()).preferBuiltInMicrophone, true);
-  const disabled = await store.set(APP_SETTING_SCHEMA.preferBuiltInMicrophone.field, false);
-
-  assert.equal(appSettingsView(disabled.settings).preferBuiltInMicrophone, false);
-  assert.equal(appSettingsView(await storeIn(directory).snapshot()).preferBuiltInMicrophone, false);
-});
-
-// SAFETY: Fixture value matches the narrowed runtime shape this test exercises.
-test("a corrupt microphone preference reads as the default rather than as off", async (t) => {
-  const directory = await temporaryDirectory(t);
-  await fs.writeFile(
-    path.join(directory, SETTINGS_FILE_NAME),
-    JSON.stringify({ version: 2, apiKeys: {}, preferBuiltInMicrophone: "no" }),
-    "utf8",
-  );
-
-  assert.equal(appSettingsView(await storeIn(directory).snapshot()).preferBuiltInMicrophone, true);
-});
-
-test("the session filter selection starts unset and survives a reopen", async (t) => {
-  const directory = await temporaryDirectory(t);
-  // A view preference is not a credential, so storing it must reach the
-  // Keychain not at all.
-  const cipher = countingCipher();
-  const store = storeIn(directory, { cipher });
-
-  assert.equal(appSettingsView(await store.snapshot()).sessionFilters, undefined);
-  const chosen = [SESSION_FILTER.LOCAL, PROVIDER_ID.CODEX];
-  const narrowed = await store.set(APP_SETTING_SCHEMA.sessionFilters.field, chosen);
-
-  assert.deepEqual(appSettingsView(narrowed.settings).sessionFilters, chosen);
-  assert.deepEqual(appSettingsView(await storeIn(directory).snapshot()).sessionFilters, chosen);
-  assert.equal(cipher.calls.isAvailable, 0);
-  assert.equal(cipher.calls.encrypt, 0);
-});
-
-test("clearing the session filter selection reads as unset after a reopen", async (t) => {
-  const directory = await temporaryDirectory(t);
-  const store = storeIn(directory);
-  await store.set(APP_SETTING_SCHEMA.sessionFilters.field, [SESSION_FILTER.CLOUD]);
-
-  const cleared = await store.set(APP_SETTING_SCHEMA.sessionFilters.field, undefined);
-
-  assert.equal(appSettingsView(cleared.settings).sessionFilters, undefined);
-  assert.equal(appSettingsView(await storeIn(directory).snapshot()).sessionFilters, undefined);
-});
-
-test("storing the session filter selection never disturbs a stored key", async (t) => {
-  const directory = await temporaryDirectory(t);
-  const store = storeIn(directory);
-  await store.setApiKey(CONDUCTOR, TEST_API_KEY);
-
-  await store.set(APP_SETTING_SCHEMA.sessionFilters.field, [SESSION_FILTER.VOICE]);
-
-  assert.equal(await storeIn(directory).readApiKey(CONDUCTOR), TEST_API_KEY);
-});
-
 // SAFETY: Fixture value matches the narrowed runtime shape this test exercises.
 test("a stored selection keeps only the filters this build recognizes", async (t) => {
   const directory = await temporaryDirectory(t);
@@ -528,75 +514,11 @@ test("a stored selection keeps only the filters this build recognizes", async (t
 });
 
 // SAFETY: Fixture value matches the narrowed runtime shape this test exercises.
-test("a corrupt session filter value reads as unset rather than narrowing the list", async (t) => {
-  const directory = await temporaryDirectory(t);
-  await fs.writeFile(
-    path.join(directory, SETTINGS_FILE_NAME),
-    JSON.stringify({ version: 2, apiKeys: {}, sessionFilters: "local" }),
-    "utf8",
-  );
-
-  assert.equal(appSettingsView(await storeIn(directory).snapshot()).sessionFilters, undefined);
-});
-
-test("the session search query starts unset and survives a reopen as typed", async (t) => {
-  const directory = await temporaryDirectory(t);
-  // A view preference is not a credential, so storing it must reach the
-  // Keychain not at all.
-  const cipher = countingCipher();
-  const store = storeIn(directory, { cipher });
-
-  assert.equal(appSettingsView(await store.snapshot()).sessionSearchQuery, undefined);
-  const held = await store.set(APP_SETTING_SCHEMA.sessionSearchQuery.field, "Fix CI  on main");
-
-  assert.equal(appSettingsView(held.settings).sessionSearchQuery, "Fix CI  on main");
-  assert.equal(
-    appSettingsView(await storeIn(directory).snapshot()).sessionSearchQuery,
-    "Fix CI  on main",
-  );
-  assert.equal(cipher.calls.isAvailable, 0);
-  assert.equal(cipher.calls.encrypt, 0);
-});
-
-test("clearing the session search query reads as unset after a reopen", async (t) => {
-  const directory = await temporaryDirectory(t);
-  const store = storeIn(directory);
-  await store.set(APP_SETTING_SCHEMA.sessionSearchQuery.field, "conductor");
-
-  const cleared = await store.set(APP_SETTING_SCHEMA.sessionSearchQuery.field, undefined);
-
-  assert.equal(appSettingsView(cleared.settings).sessionSearchQuery, undefined);
-  assert.equal(appSettingsView(await storeIn(directory).snapshot()).sessionSearchQuery, undefined);
-});
-
-test("storing the session search query never disturbs a stored key", async (t) => {
-  const directory = await temporaryDirectory(t);
-  const store = storeIn(directory);
-  await store.setApiKey(CONDUCTOR, TEST_API_KEY);
-
-  await store.set(APP_SETTING_SCHEMA.sessionSearchQuery.field, "review");
-
-  assert.equal(await storeIn(directory).readApiKey(CONDUCTOR), TEST_API_KEY);
-});
-
-// SAFETY: Fixture value matches the narrowed runtime shape this test exercises.
 test("a stored query of nothing but whitespace reads as unset rather than narrowing", async (t) => {
   const directory = await temporaryDirectory(t);
   await fs.writeFile(
     path.join(directory, SETTINGS_FILE_NAME),
     JSON.stringify({ version: 2, apiKeys: {}, sessionSearchQuery: "   " }),
-    "utf8",
-  );
-
-  assert.equal(appSettingsView(await storeIn(directory).snapshot()).sessionSearchQuery, undefined);
-});
-
-// SAFETY: Fixture value matches the narrowed runtime shape this test exercises.
-test("a corrupt session search query reads as unset rather than refilling the field", async (t) => {
-  const directory = await temporaryDirectory(t);
-  await fs.writeFile(
-    path.join(directory, SETTINGS_FILE_NAME),
-    JSON.stringify({ version: 2, apiKeys: {}, sessionSearchQuery: 7 }),
     "utf8",
   );
 
@@ -752,93 +674,6 @@ test("a calendar account never disturbs a stored key, nor a key an account", asy
   assert.equal((await reopened.readCalendarAccounts()).length, 1);
 });
 
-test("announcements wait out meetings until asked otherwise, and the choice survives a reopen", async (t) => {
-  const directory = await temporaryDirectory(t);
-  // A preference is not a credential, so choosing it must reach the Keychain
-  // not at all — and the shallow reader main asks on every announcement pass
-  // must answer from the file alone.
-  const cipher = countingCipher();
-  const store = storeIn(directory, { cipher });
-
-  assert.equal(appSettingsView(await store.snapshot()).quietDuringMeetings, true);
-  assert.equal(await store.get(APP_SETTING_SCHEMA.quietDuringMeetings.field), true);
-  const disabled = await store.set(APP_SETTING_SCHEMA.quietDuringMeetings.field, false);
-
-  assert.equal(appSettingsView(disabled.settings).quietDuringMeetings, false);
-  assert.equal(await storeIn(directory).get(APP_SETTING_SCHEMA.quietDuringMeetings.field), false);
-  assert.equal(appSettingsView(await storeIn(directory).snapshot()).quietDuringMeetings, false);
-  assert.equal(cipher.calls.isAvailable, 0);
-  assert.equal(cipher.calls.encrypt, 0);
-});
-
-test("switching the meeting quiet never disturbs a stored key", async (t) => {
-  const directory = await temporaryDirectory(t);
-  const store = storeIn(directory);
-  await store.setApiKey(CONDUCTOR, TEST_API_KEY);
-
-  await store.set(APP_SETTING_SCHEMA.quietDuringMeetings.field, false);
-  const on = await store.set(APP_SETTING_SCHEMA.quietDuringMeetings.field, true);
-
-  assert.equal(appSettingsView(on.settings).quietDuringMeetings, true);
-  assert.equal(await storeIn(directory).readApiKey(CONDUCTOR), TEST_API_KEY);
-});
-
-// SAFETY: Fixture value matches the narrowed runtime shape this test exercises.
-test("a corrupt meeting quiet value reads as the default rather than as off", async (t) => {
-  const directory = await temporaryDirectory(t);
-  // The media duck's rule: this one's default is on, so nonsense lands on on.
-  await fs.writeFile(
-    path.join(directory, SETTINGS_FILE_NAME),
-    JSON.stringify({ version: 2, apiKeys: {}, quietDuringMeetings: "no" }),
-    "utf8",
-  );
-
-  assert.equal(appSettingsView(await storeIn(directory).snapshot()).quietDuringMeetings, true);
-});
-
-test("announcements speak until switched off by hand, and the quiet survives a reopen", async (t) => {
-  const directory = await temporaryDirectory(t);
-  // The switch is read on every announcement pass, so like the meeting quiet
-  // it must answer from the file alone and never reach the Keychain.
-  const cipher = countingCipher();
-  const store = storeIn(directory, { cipher });
-
-  assert.equal(appSettingsView(await store.snapshot()).announceSessions, true);
-  assert.equal(await store.get(APP_SETTING_SCHEMA.announceSessions.field), true);
-  const quiet = await store.set(APP_SETTING_SCHEMA.announceSessions.field, false);
-
-  assert.equal(appSettingsView(quiet.settings).announceSessions, false);
-  assert.equal(await storeIn(directory).get(APP_SETTING_SCHEMA.announceSessions.field), false);
-  assert.equal(appSettingsView(await storeIn(directory).snapshot()).announceSessions, false);
-  assert.equal(cipher.calls.isAvailable, 0);
-  assert.equal(cipher.calls.encrypt, 0);
-});
-
-test("switching announcements never disturbs a stored key", async (t) => {
-  const directory = await temporaryDirectory(t);
-  const store = storeIn(directory);
-  await store.setApiKey(CONDUCTOR, TEST_API_KEY);
-
-  await store.set(APP_SETTING_SCHEMA.announceSessions.field, false);
-  const on = await store.set(APP_SETTING_SCHEMA.announceSessions.field, true);
-
-  assert.equal(appSettingsView(on.settings).announceSessions, true);
-  assert.equal(await storeIn(directory).readApiKey(CONDUCTOR), TEST_API_KEY);
-});
-
-// SAFETY: Fixture value matches the narrowed runtime shape this test exercises.
-test("a corrupt announce value reads as the default rather than as silence", async (t) => {
-  const directory = await temporaryDirectory(t);
-  // This one's default is on: nonsense must not silence Luke.
-  await fs.writeFile(
-    path.join(directory, SETTINGS_FILE_NAME),
-    JSON.stringify({ version: 2, apiKeys: {}, announceSessions: "yes" }),
-    "utf8",
-  );
-
-  assert.equal(appSettingsView(await storeIn(directory).snapshot()).announceSessions, true);
-});
-
 test("keeps each provider's key, environment fallback, and reported source separate", async (t) => {
   const directory = await temporaryDirectory(t);
   const store = storeIn(directory, {
@@ -925,14 +760,16 @@ test("prefers a stored key over one from the environment", async (t) => {
   assert.equal(await store.readApiKey(CONDUCTOR), TEST_API_KEY);
 });
 
-// SAFETY: Fixture value matches the narrowed runtime shape this test exercises.
 test("rejects a key that cannot be sent as an authorization header", async (t) => {
   const directory = await temporaryDirectory(t);
   const store = storeIn(directory);
 
-  assert.match((await store.setApiKey(CONDUCTOR, "short")).reason ?? "", /too short/);
-  assert.match((await store.setApiKey(CONDUCTOR, "key with spaces")).reason ?? "", /unsupported/);
-  assert.match((await store.setApiKey(CONDUCTOR, "k".repeat(513))).reason ?? "", /too long/);
+  for (const candidate of ["short", "key with spaces", "k".repeat(513)]) {
+    // The store answers with the rule's own reason rather than one of its
+    // own, and a refused key leaves the file it would have been written to
+    // uncreated.
+    assert.equal((await store.setApiKey(CONDUCTOR, candidate)).reason, apiKeyRejection(candidate));
+  }
   assert.equal(await store.readApiKey(CONDUCTOR), undefined);
   await assert.rejects(() => readSettingsFile(directory), /ENOENT/);
 });
@@ -1089,40 +926,6 @@ test("carries a key belonging to a provider this build does not know", async (t)
   );
 });
 
-test("keeps Luke out of the Dock until asked, and remembers the answer", async (t) => {
-  const directory = await temporaryDirectory(t);
-  const store = storeIn(directory);
-
-  assert.equal(appSettingsView(await store.snapshot()).showInDock, false);
-
-  const { settings, reason } = await store.set(APP_SETTING_SCHEMA.showInDock.field, true);
-
-  assert.equal(reason, undefined);
-  assert.equal(appSettingsView(settings).showInDock, true);
-  assert.deepEqual(
-    JSON.parse(await readSettingsFile(directory)),
-    expectedPersistedSettings({
-      showInDock: true,
-    }),
-  );
-  // The choice outlives the run that heard it.
-  assert.equal(appSettingsView(await storeIn(directory).snapshot()).showInDock, true);
-});
-
-test("changes the Dock preference without touching the cipher", async (t) => {
-  // A preference is not a credential, so storing one must never be the reason
-  // the Keychain dialog appears.
-  const directory = await temporaryDirectory(t);
-  const cipher = countingCipher();
-  const store = storeIn(directory, { cipher });
-
-  const { settings } = await store.set(APP_SETTING_SCHEMA.showInDock.field, true);
-
-  assert.equal(appSettingsView(settings).showInDock, true);
-  assert.deepEqual(cipher.calls, { isAvailable: 0, encrypt: 0, decrypt: 0 });
-  assert.equal(appSettingsView(settings).secretStorage, SECRET_STORAGE.UNKNOWN);
-});
-
 test("decides the Dock icon from the file alone, never the keychain", async (t) => {
   // The icon is drawn at launch from this answer, so a locked or slow
   // Keychain — which decrypting a stored key can wait on — must not be able to
@@ -1141,42 +944,6 @@ test("decides the Dock icon from the file alone, never the keychain", async (t) 
 
   assert.equal(await store.get(APP_SETTING_SCHEMA.showInDock.field), true);
   assert.deepEqual(cipher.calls, { isAvailable: 0, encrypt: 0, decrypt: 0 });
-});
-
-test("keeps Luke out of the Dock when the file says something a boolean is not", async (t) => {
-  const directory = await temporaryDirectory(t);
-  await fs.writeFile(
-    path.join(directory, SETTINGS_FILE_NAME),
-    JSON.stringify({ version: 2, apiKeys: {}, showInDock: "always" }),
-  );
-
-  assert.equal(appSettingsView(await storeIn(directory).snapshot()).showInDock, false);
-});
-
-test("reports the default voice until one is chosen", async (t) => {
-  const directory = await temporaryDirectory(t);
-  const store = storeIn(directory);
-
-  assert.equal(appSettingsView(await store.snapshot()).voice, REALTIME_DEFAULTS.VOICE);
-  assert.equal(await store.get(APP_SETTING_SCHEMA.voice.field), undefined);
-});
-
-test("stores the chosen voice plainly and reads it back from a new store instance", async (t) => {
-  const directory = await temporaryDirectory(t);
-  const cipher = countingCipher();
-  const store = storeIn(directory, { cipher });
-
-  const { settings, reason } = await store.set(
-    APP_SETTING_SCHEMA.voice.field,
-    REALTIME_VOICE.MARIN,
-  );
-
-  assert.equal(reason, undefined);
-  assert.equal(appSettingsView(settings).voice, REALTIME_VOICE.MARIN);
-  // A preference is not a credential, so choosing one never reaches the
-  // Keychain — and never raises its permission dialog.
-  assert.deepEqual(cipher.calls, { isAvailable: 0, encrypt: 0, decrypt: 0 });
-  assert.equal(await storeIn(directory).get(APP_SETTING_SCHEMA.voice.field), REALTIME_VOICE.MARIN);
 });
 
 test("prefers the chosen voice over the environment, and the environment over the default", async (t) => {
@@ -1208,35 +975,6 @@ test("ignores a stored or environment voice this build does not offer", async (t
 
   assert.equal(await store.get(APP_SETTING_SCHEMA.voice.field), undefined);
   assert.equal(appSettingsView(await store.snapshot()).voice, REALTIME_DEFAULTS.VOICE);
-});
-
-test("reports the natural pace until one is chosen", async (t) => {
-  const directory = await temporaryDirectory(t);
-  const store = storeIn(directory);
-
-  assert.equal(appSettingsView(await store.snapshot()).voiceSpeed, REALTIME_DEFAULTS.SPEED);
-  assert.equal(await store.get(APP_SETTING_SCHEMA.voiceSpeed.field), undefined);
-});
-
-test("stores the chosen pace plainly and reads it back from a new store instance", async (t) => {
-  const directory = await temporaryDirectory(t);
-  const cipher = countingCipher();
-  const store = storeIn(directory, { cipher });
-
-  const { settings, reason } = await store.set(
-    APP_SETTING_SCHEMA.voiceSpeed.field,
-    REALTIME_VOICE_SPEED.QUICK,
-  );
-
-  assert.equal(reason, undefined);
-  assert.equal(appSettingsView(settings).voiceSpeed, REALTIME_VOICE_SPEED.QUICK);
-  // A preference is not a credential, so choosing one never reaches the
-  // Keychain — and never raises its permission dialog.
-  assert.deepEqual(cipher.calls, { isAvailable: 0, encrypt: 0, decrypt: 0 });
-  assert.equal(
-    await storeIn(directory).get(APP_SETTING_SCHEMA.voiceSpeed.field),
-    REALTIME_VOICE_SPEED.QUICK,
-  );
 });
 
 test("prefers the chosen pace over the environment, and the environment over the default", async (t) => {
@@ -1409,49 +1147,6 @@ test("skips a guarded account preference apply after account sign-out", async (t
   assert.equal(await store.accountPreferencesSyncBaseline(account.email), undefined);
 });
 
-test("reports no talk-key chord until one is chosen", async (t) => {
-  const directory = await temporaryDirectory(t);
-  const store = storeIn(directory);
-
-  assert.equal(await store.get(APP_SETTING_SCHEMA.voiceHotkey.field), undefined);
-  assert.equal(appSettingsView(await store.snapshot()).voiceHotkey, undefined);
-});
-
-test("stores the chosen talk-key chord plainly and reads it back from a new store instance", async (t) => {
-  const directory = await temporaryDirectory(t);
-  const cipher = countingCipher();
-  const store = storeIn(directory, { cipher });
-
-  const { settings, reason } = await store.set(
-    APP_SETTING_SCHEMA.voiceHotkey.field,
-    "Shift+Command+L",
-  );
-
-  assert.equal(reason, undefined);
-  assert.equal(appSettingsView(settings).voiceHotkey, "Shift+Command+L");
-  // A preference is not a credential, so choosing one never reaches the
-  // Keychain — and never raises its permission dialog.
-  assert.deepEqual(cipher.calls, { isAvailable: 0, encrypt: 0, decrypt: 0 });
-  assert.equal(
-    await storeIn(directory).get(APP_SETTING_SCHEMA.voiceHotkey.field),
-    "Shift+Command+L",
-  );
-});
-
-test("clearing the talk-key chord returns to no choice at all", async (t) => {
-  const directory = await temporaryDirectory(t);
-  const store = storeIn(directory);
-
-  await store.set(APP_SETTING_SCHEMA.voiceHotkey.field, "Shift+Command+L");
-  const { settings } = await store.set(APP_SETTING_SCHEMA.voiceHotkey.field, undefined);
-
-  assert.equal(appSettingsView(settings).voiceHotkey, undefined);
-  // SAFETY: Fixture value matches the narrowed runtime shape this test exercises.
-  // Absent from the file rather than stored as an empty value: reset is the
-  // absence of a choice, and a reopened store must read it the same way.
-  assert.equal(await storeIn(directory).get(APP_SETTING_SCHEMA.voiceHotkey.field), undefined);
-});
-
 test("stores a deleted talk key as the none token and reads it back", async (t) => {
   const directory = await temporaryDirectory(t);
   const store = storeIn(directory);
@@ -1471,113 +1166,24 @@ test("stores a deleted talk key as the none token and reads it back", async (t) 
   );
 });
 
-test("ignores a stored talk-key chord this build cannot register", async (t) => {
-  const directory = await temporaryDirectory(t);
-  await fs.writeFile(
-    path.join(directory, SETTINGS_FILE_NAME),
-    JSON.stringify({ version: 2, apiKeys: {}, voiceHotkey: "F13" }),
-  );
-  const store = storeIn(directory);
-
-  // A hand-edited chord the registrars would refuse is dropped rather than
-  // carried: honouring it would claim a key nothing was ever told about.
-  assert.equal(await store.get(APP_SETTING_SCHEMA.voiceHotkey.field), undefined);
-  assert.equal(appSettingsView(await store.snapshot()).voiceHotkey, undefined);
-});
-
-test("stores the chosen ask-key chord on the talk key's terms and reads it back", async (t) => {
-  const directory = await temporaryDirectory(t);
-  const cipher = countingCipher();
-  const store = storeIn(directory, { cipher });
-
-  assert.equal(await store.get(APP_SETTING_SCHEMA.askHotkey.field), undefined);
-  assert.equal(appSettingsView(await store.snapshot()).askHotkey, undefined);
-
-  const { settings, reason } = await store.set(APP_SETTING_SCHEMA.askHotkey.field, "Control+Alt+K");
-
-  assert.equal(reason, undefined);
-  assert.equal(appSettingsView(settings).askHotkey, "Control+Alt+K");
-  // A preference is not a credential, so choosing one never reaches the
-  // Keychain — and never raises its permission dialog.
-  assert.deepEqual(cipher.calls, { isAvailable: 0, encrypt: 0, decrypt: 0 });
-  assert.equal(await storeIn(directory).get(APP_SETTING_SCHEMA.askHotkey.field), "Control+Alt+K");
-});
-
-test("clearing the ask-key chord returns to no choice at all", async (t) => {
-  const directory = await temporaryDirectory(t);
-  const store = storeIn(directory);
-
-  await store.set(APP_SETTING_SCHEMA.askHotkey.field, "Control+Alt+K");
-  const { settings } = await store.set(APP_SETTING_SCHEMA.askHotkey.field, undefined);
-
-  assert.equal(appSettingsView(settings).askHotkey, undefined);
-  // SAFETY: Fixture value matches the narrowed runtime shape this test exercises.
-  // Absent from the file rather than stored as an empty value: reset is the
-  // absence of a choice, and a reopened store must read it the same way.
-  assert.equal(await storeIn(directory).get(APP_SETTING_SCHEMA.askHotkey.field), undefined);
-});
-
-test("ignores a stored ask-key chord this build cannot register", async (t) => {
-  const directory = await temporaryDirectory(t);
-  await fs.writeFile(
-    path.join(directory, SETTINGS_FILE_NAME),
-    JSON.stringify({ version: 2, apiKeys: {}, askHotkey: "F13" }),
-  );
-  const store = storeIn(directory);
-
-  // A hand-edited chord the registrar would refuse is dropped rather than
-  // carried: honouring it would claim a key nothing was ever told about.
-  assert.equal(await store.get(APP_SETTING_SCHEMA.askHotkey.field), undefined);
-  assert.equal(appSettingsView(await store.snapshot()).askHotkey, undefined);
-});
-
-test("stores the chosen stop-key chord on the other keys' terms and reads it back", async (t) => {
-  const directory = await temporaryDirectory(t);
-  const cipher = countingCipher();
-  const store = storeIn(directory, { cipher });
-
-  assert.equal(await store.get(APP_SETTING_SCHEMA.stopHotkey.field), undefined);
-  assert.equal(appSettingsView(await store.snapshot()).stopHotkey, undefined);
-
-  const { settings, reason } = await store.set(
+test("ignores a stored chord this build cannot register", async (t) => {
+  for (const field of [
+    APP_SETTING_SCHEMA.voiceHotkey.field,
+    APP_SETTING_SCHEMA.askHotkey.field,
     APP_SETTING_SCHEMA.stopHotkey.field,
-    "Control+Alt+X",
-  );
+  ]) {
+    const directory = await temporaryDirectory(t);
+    await fs.writeFile(
+      path.join(directory, SETTINGS_FILE_NAME),
+      JSON.stringify({ version: 2, apiKeys: {}, [field]: "F13" }),
+    );
+    const store = storeIn(directory);
 
-  assert.equal(reason, undefined);
-  assert.equal(appSettingsView(settings).stopHotkey, "Control+Alt+X");
-  // A preference is not a credential, so choosing one never reaches the
-  // Keychain — and never raises its permission dialog.
-  assert.deepEqual(cipher.calls, { isAvailable: 0, encrypt: 0, decrypt: 0 });
-  assert.equal(await storeIn(directory).get(APP_SETTING_SCHEMA.stopHotkey.field), "Control+Alt+X");
-});
-
-test("clearing the stop-key chord returns to no choice at all", async (t) => {
-  const directory = await temporaryDirectory(t);
-  const store = storeIn(directory);
-
-  await store.set(APP_SETTING_SCHEMA.stopHotkey.field, "Control+Alt+X");
-  const { settings } = await store.set(APP_SETTING_SCHEMA.stopHotkey.field, undefined);
-
-  assert.equal(appSettingsView(settings).stopHotkey, undefined);
-  // SAFETY: Fixture value matches the narrowed runtime shape this test exercises.
-  // Absent from the file rather than stored as an empty value: reset is the
-  // absence of a choice, and a reopened store must read it the same way.
-  assert.equal(await storeIn(directory).get(APP_SETTING_SCHEMA.stopHotkey.field), undefined);
-});
-
-test("ignores a stored stop-key chord this build cannot register", async (t) => {
-  const directory = await temporaryDirectory(t);
-  await fs.writeFile(
-    path.join(directory, SETTINGS_FILE_NAME),
-    JSON.stringify({ version: 2, apiKeys: {}, stopHotkey: "F13" }),
-  );
-  const store = storeIn(directory);
-
-  // A hand-edited chord the registrar would refuse is dropped rather than
-  // carried: honouring it would claim a key nothing was ever told about.
-  assert.equal(await store.get(APP_SETTING_SCHEMA.stopHotkey.field), undefined);
-  assert.equal(appSettingsView(await store.snapshot()).stopHotkey, undefined);
+    // A hand-edited chord the registrars would refuse is dropped rather than
+    // carried: honouring it would claim a key nothing was ever told about.
+    assert.equal(await store.get(field), undefined, field);
+    assert.equal(appSettingsView(await store.snapshot())[field], undefined, field);
+  }
 });
 
 test("the three Luke keys survive each other's writes", async (t) => {
@@ -1594,90 +1200,19 @@ test("the three Luke keys survive each other's writes", async (t) => {
   assert.equal(await reopened.get(APP_SETTING_SCHEMA.stopHotkey.field), "Control+Alt+X");
 });
 
-test("the talk-key chord and a stored key survive each other's writes", async (t) => {
-  const directory = await temporaryDirectory(t);
-  const store = storeIn(directory);
+test("a stored key and a chosen preference survive each other's writes", async (t) => {
+  for (const field of APP_SETTING_FIELDS) {
+    const directory = await temporaryDirectory(t);
+    const store = storeIn(directory);
 
-  await store.setApiKey(CONDUCTOR, TEST_API_KEY);
-  await store.set(APP_SETTING_SCHEMA.voiceHotkey.field, "Control+Alt+Space");
-  await store.setApiKey(CONDUCTOR, "conductor-replacement-key");
+    await store.setApiKey(CONDUCTOR, TEST_API_KEY);
+    await store.set(field, SAMPLE_VALUE[field]);
+    await store.setApiKey(CONDUCTOR, "conductor-replacement-key");
 
-  const reopened = storeIn(directory);
-  assert.equal(await reopened.readApiKey(CONDUCTOR), "conductor-replacement-key");
-  assert.equal(await reopened.get(APP_SETTING_SCHEMA.voiceHotkey.field), "Control+Alt+Space");
-});
-
-test("keeps Luke to the main display until asked, and remembers the answer", async (t) => {
-  const directory = await temporaryDirectory(t);
-  const store = storeIn(directory);
-
-  assert.equal(appSettingsView(await store.snapshot()).showOnAllDisplays, false);
-  assert.equal(await store.get(APP_SETTING_SCHEMA.showOnAllDisplays.field), false);
-
-  const { settings, reason } = await store.set(APP_SETTING_SCHEMA.showOnAllDisplays.field, true);
-
-  assert.equal(reason, undefined);
-  assert.equal(appSettingsView(settings).showOnAllDisplays, true);
-  // The choice outlives the run that heard it.
-  assert.equal(await storeIn(directory).get(APP_SETTING_SCHEMA.showOnAllDisplays.field), true);
-});
-
-test("changes the displays preference without touching the cipher", async (t) => {
-  // A preference is not a credential, so storing one must never be the reason
-  // the Keychain dialog appears.
-  const directory = await temporaryDirectory(t);
-  const cipher = countingCipher();
-  const store = storeIn(directory, { cipher });
-
-  const { settings } = await store.set(APP_SETTING_SCHEMA.showOnAllDisplays.field, true);
-
-  assert.equal(appSettingsView(settings).showOnAllDisplays, true);
-  assert.deepEqual(cipher.calls, { isAvailable: 0, encrypt: 0, decrypt: 0 });
-});
-
-test("keeps Luke to the main display when the file says something a boolean is not", async (t) => {
-  const directory = await temporaryDirectory(t);
-  await fs.writeFile(
-    path.join(directory, SETTINGS_FILE_NAME),
-    JSON.stringify({ version: 2, apiKeys: {}, showOnAllDisplays: "every one of them" }),
-  );
-
-  assert.equal(await storeIn(directory).get(APP_SETTING_SCHEMA.showOnAllDisplays.field), false);
-});
-
-test("draws the bubble until a form is chosen, and remembers the choice", async (t) => {
-  const directory = await temporaryDirectory(t);
-  const store = storeIn(directory);
-
-  assert.equal(appSettingsView(await store.snapshot()).formFactor, PANEL_FORM_FACTOR.BUBBLE);
-  assert.equal(await store.get(APP_SETTING_SCHEMA.formFactor.field), undefined);
-
-  const { settings, reason } = await store.set(
-    APP_SETTING_SCHEMA.formFactor.field,
-    PANEL_FORM_FACTOR.NOTCH,
-  );
-
-  assert.equal(reason, undefined);
-  assert.equal(appSettingsView(settings).formFactor, PANEL_FORM_FACTOR.NOTCH);
-  // The choice outlives the run that heard it.
-  assert.equal(
-    await storeIn(directory).get(APP_SETTING_SCHEMA.formFactor.field),
-    PANEL_FORM_FACTOR.NOTCH,
-  );
-});
-
-test("changes the form without touching the cipher", async (t) => {
-  const directory = await temporaryDirectory(t);
-  const cipher = countingCipher();
-  const store = storeIn(directory, { cipher });
-
-  const { settings } = await store.set(
-    APP_SETTING_SCHEMA.formFactor.field,
-    PANEL_FORM_FACTOR.NOTCH,
-  );
-
-  assert.equal(appSettingsView(settings).formFactor, PANEL_FORM_FACTOR.NOTCH);
-  assert.deepEqual(cipher.calls, { isAvailable: 0, encrypt: 0, decrypt: 0 });
+    const reopened = storeIn(directory);
+    assert.equal(await reopened.readApiKey(CONDUCTOR), "conductor-replacement-key");
+    assert.deepEqual(await reopened.get(field), SAMPLE_VALUE[field], `${field} did not survive`);
+  }
 });
 
 test("ignores a stored form this build does not draw", async (t) => {
@@ -1692,51 +1227,6 @@ test("ignores a stored form this build does not draw", async (t) => {
     appSettingsView(await storeIn(directory).snapshot()).formFactor,
     PANEL_FORM_FACTOR.BUBBLE,
   );
-});
-
-test("asks each time until a default workspace provider is chosen, and remembers the choice", async (t) => {
-  const directory = await temporaryDirectory(t);
-  const store = storeIn(directory);
-
-  // Unset on purpose: the default is always a choice the user made — by hand
-  // or by their first creation — never one made for them.
-  assert.equal(appSettingsView(await store.snapshot()).defaultWorkspaceProvider, undefined);
-  assert.equal(await store.get(APP_SETTING_SCHEMA.defaultWorkspaceProvider.field), undefined);
-
-  const { settings, reason } = await store.set(
-    APP_SETTING_SCHEMA.defaultWorkspaceProvider.field,
-    PROVIDER_ID.CONDUCTOR,
-  );
-
-  assert.equal(reason, undefined);
-  assert.equal(appSettingsView(settings).defaultWorkspaceProvider, PROVIDER_ID.CONDUCTOR);
-  // The choice outlives the run that heard it.
-  assert.equal(
-    await storeIn(directory).get(APP_SETTING_SCHEMA.defaultWorkspaceProvider.field),
-    PROVIDER_ID.CONDUCTOR,
-  );
-
-  // Clearing is returning to asking each time, not storing an answer.
-  const cleared = await store.set(APP_SETTING_SCHEMA.defaultWorkspaceProvider.field, undefined);
-  assert.equal(appSettingsView(cleared.settings).defaultWorkspaceProvider, undefined);
-  assert.equal(
-    await storeIn(directory).get(APP_SETTING_SCHEMA.defaultWorkspaceProvider.field),
-    undefined,
-  );
-});
-
-test("changes the default workspace provider without touching the cipher", async (t) => {
-  const directory = await temporaryDirectory(t);
-  const cipher = countingCipher();
-  const store = storeIn(directory, { cipher });
-
-  const { settings } = await store.set(
-    APP_SETTING_SCHEMA.defaultWorkspaceProvider.field,
-    PROVIDER_ID.CODEX,
-  );
-
-  assert.equal(appSettingsView(settings).defaultWorkspaceProvider, PROVIDER_ID.CODEX);
-  assert.deepEqual(cipher.calls, { isAvailable: 0, encrypt: 0, decrypt: 0 });
 });
 
 test("ignores a stored default provider this build does not know", async (t) => {
@@ -1777,52 +1267,6 @@ test("stores Superset workspace and agent defaults without touching credentials"
   );
 });
 
-test("starts new workspaces on the provider's defaults until a pairing is chosen", async (t) => {
-  const directory = await temporaryDirectory(t);
-  const store = storeIn(directory);
-
-  assert.equal(appSettingsView(await store.snapshot()).workspaceAgentDefaults, undefined);
-  assert.equal(await readWorkspaceAgentDefault(store, PROVIDER_ID.CONDUCTOR), undefined);
-
-  const chosen = { agent: "claude", model: "sonnet", effort: "max" };
-  const { settings, reason } = await setWorkspaceAgentDefault(store, PROVIDER_ID.CONDUCTOR, chosen);
-
-  assert.equal(reason, undefined);
-  assert.deepEqual(appSettingsView(settings).workspaceAgentDefaults, {
-    [PROVIDER_ID.CONDUCTOR]: chosen,
-  });
-  // The choice outlives the run that heard it.
-  assert.deepEqual(
-    await readWorkspaceAgentDefault(storeIn(directory), PROVIDER_ID.CONDUCTOR),
-    chosen,
-  );
-
-  // Clearing returns that one provider to its own defaults.
-  const cleared = await setWorkspaceAgentDefault(store, PROVIDER_ID.CONDUCTOR, undefined);
-  assert.equal(appSettingsView(cleared.settings).workspaceAgentDefaults, undefined);
-  assert.equal(
-    await readWorkspaceAgentDefault(storeIn(directory), PROVIDER_ID.CONDUCTOR),
-    undefined,
-  );
-});
-
-test("changes a workspace agent pairing without touching the cipher", async (t) => {
-  const directory = await temporaryDirectory(t);
-  const cipher = countingCipher();
-  const store = storeIn(directory, { cipher });
-
-  const { settings } = await setWorkspaceAgentDefault(store, PROVIDER_ID.CONDUCTOR, {
-    agent: "codex",
-    model: "gpt-5.6-sol",
-  });
-
-  assert.deepEqual(appSettingsView(settings).workspaceAgentDefaults?.[PROVIDER_ID.CONDUCTOR], {
-    agent: "codex",
-    model: "gpt-5.6-sol",
-  });
-  assert.deepEqual(cipher.calls, { isAvailable: 0, encrypt: 0, decrypt: 0 });
-});
-
 test("lets the first creation choose each provider's project until one is chosen", async (t) => {
   const directory = await temporaryDirectory(t);
   const store = storeIn(directory);
@@ -1855,19 +1299,6 @@ test("lets the first creation choose each provider's project until one is chosen
     await readWorkspaceProjectDefault(storeIn(directory), PROVIDER_ID.CONDUCTOR),
     undefined,
   );
-});
-
-test("changes a default project without touching the cipher", async (t) => {
-  const directory = await temporaryDirectory(t);
-  const cipher = countingCipher();
-  const store = storeIn(directory, { cipher });
-
-  const { settings } = await setWorkspaceProjectDefault(store, PROVIDER_ID.CODEX, "proj-2");
-
-  assert.deepEqual(appSettingsView(settings).workspaceProjectDefaults, {
-    [PROVIDER_ID.CODEX]: "proj-2",
-  });
-  assert.deepEqual(cipher.calls, { isAvailable: 0, encrypt: 0, decrypt: 0 });
 });
 
 test("keeps one provider's default project apart from another's", async (t) => {
@@ -2070,19 +1501,6 @@ test("ignores a stored pairing this build's table does not list", async (t) => {
   const store = storeIn(directory);
   assert.equal(await readWorkspaceAgentDefault(store, PROVIDER_ID.CONDUCTOR), undefined);
   assert.equal(appSettingsView(await store.snapshot()).workspaceAgentDefaults, undefined);
-});
-
-test("the voice and a stored key survive each other's writes", async (t) => {
-  const directory = await temporaryDirectory(t);
-  const store = storeIn(directory);
-
-  await store.setApiKey(CONDUCTOR, TEST_API_KEY);
-  await store.set(APP_SETTING_SCHEMA.voice.field, REALTIME_VOICE.MARIN);
-  await store.setApiKey(CONDUCTOR, "conductor-replacement-key");
-
-  const reopened = storeIn(directory);
-  assert.equal(await reopened.readApiKey(CONDUCTOR), "conductor-replacement-key");
-  assert.equal(await reopened.get(APP_SETTING_SCHEMA.voice.field), REALTIME_VOICE.MARIN);
 });
 
 test("recovers from a corrupt settings file", async (t) => {

--- a/apps/desktop/src/main/settings-store.ts
+++ b/apps/desktop/src/main/settings-store.ts
@@ -1194,12 +1194,10 @@ export class SettingsStore {
         reason: "That is not a calendar id.",
       };
     let missing: string | undefined;
-    // Only a Google account's list is decrypted, so only its edit costs the
-    // cache; this Mac's connection carries no grant to have cached.
-    let editedAccount = false;
+    const apple = accountId === APPLE_CALENDAR_ID;
     await this.#mutate(
       (persisted) => {
-        if (accountId === APPLE_CALENDAR_ID) {
+        if (apple) {
           const held = persisted.appleCalendar;
           if (!held) {
             missing = "Apple Calendar is not connected.";
@@ -1216,7 +1214,6 @@ export class SettingsStore {
         }
         const calendars = toggledCalendarSelection(held.calendars, id, selected);
         if (!calendars) return undefined;
-        editedAccount = true;
         return withCalendarAccounts(
           persisted,
           existing.map((account) =>
@@ -1224,9 +1221,9 @@ export class SettingsStore {
           ),
         );
       },
-      () => {
-        if (editedAccount) this.#forgetCalendarAccounts();
-      },
+      // Only a Google account's grant is decrypted, so only its edit costs the
+      // cache; this Mac's connection carries no grant to have cached.
+      apple ? undefined : () => this.#forgetCalendarAccounts(),
     );
     const settings = await this.snapshot();
     return missing
@@ -1334,9 +1331,13 @@ export class SettingsStore {
   /**
    * The one settings write: serialize, load, mutate, stamp, write, cache, and
    * invalidate. A mutator answering nothing means the stored value is already
-   * the one asked for, so nothing is written and no cache is dropped —
-   * `invalidate` runs only after a write actually landed, so a no-op change
-   * can never cost a Keychain read. Answers whether a write landed.
+   * the one asked for, so nothing is written. It runs exactly once per call,
+   * so it may record what it decided for its caller to read afterwards.
+   *
+   * `invalidate` drops the caches the write made stale, and runs only after
+   * one actually landed: dropping a decrypted value a no-op change did not
+   * disturb would cost a Keychain read for nothing. Answers whether a write
+   * landed.
    */
   async #mutate(
     mutate: (persisted: PersistedSettings) => PersistedSettings | undefined,

--- a/apps/desktop/src/main/settings-store.ts
+++ b/apps/desktop/src/main/settings-store.ts
@@ -48,8 +48,6 @@ import type { AppleCalendarConnection } from "./apple-calendar";
 export type { StoredAccount } from "@sidecar/account";
 
 import type { StoredAccount } from "@sidecar/account";
-// The reader owns the shape it is fed: what this store resolves a stored
-// account into is exactly what `readAccounts` promises it.
 import type { CalendarAccountCredential } from "@sidecar/calendar";
 import { googleCalendarSignInConfig } from "@sidecar/calendar";
 import {
@@ -66,8 +64,6 @@ import {
   type StoredAppSettings,
   sameSettingEntry,
 } from "@sidecar/settings";
-// The same ownership the calendar reader has over its credential shape: what
-// this store resolves a stored grant into is what the sign-in produced.
 import { type LinearGrant, linearSignInConfig } from "@sidecar/trackers";
 import {
   environmentRealtimeSpeed,
@@ -317,6 +313,32 @@ function storedAppleCalendar(record: WireRecord): PersistedSettings["appleCalend
 interface PersistedGrant {
   tokenCipher: string;
   expiresAt: number;
+}
+
+/**
+ * The settings with this account list, kept the way an emptied map is kept: an
+ * empty list is a deleted field, so a disconnection reads as no calendars
+ * rather than as a connection with none.
+ */
+function withCalendarAccounts(
+  persisted: PersistedSettings,
+  calendarAccounts: readonly PersistedCalendarAccount[],
+): PersistedSettings {
+  const next: PersistedSettings = { ...persisted };
+  if (calendarAccounts.length > 0) next.calendarAccounts = calendarAccounts;
+  else delete next.calendarAccounts;
+  return next;
+}
+
+/** The settings with this Mac's connection, on the same terms. */
+function withAppleCalendar(
+  persisted: PersistedSettings,
+  appleCalendar: PersistedSettings["appleCalendar"],
+): PersistedSettings {
+  const next: PersistedSettings = { ...persisted };
+  if (appleCalendar) next.appleCalendar = appleCalendar;
+  else delete next.appleCalendar;
+  return next;
 }
 
 /** Reads the stored grants, keeping only well-formed entries. */
@@ -572,22 +594,15 @@ export class SettingsStore {
   async set<Field extends AppSettingField>(
     field: Field,
     value: AppSettingValue<Field>,
-  ): Promise<SettingsUpdateResult>;
-  async set(
-    field: AppSettingField,
-    value: StoredAppSettings[AppSettingField],
-  ): Promise<SettingsUpdateResult>;
-  async set(
-    field: AppSettingField,
-    value: StoredAppSettings[AppSettingField],
   ): Promise<SettingsUpdateResult> {
-    return this.#setField((persisted) => {
-      if (persisted[field] === value) return;
+    await this.#mutate((persisted) => {
+      if (persisted[field] === value) return undefined;
       const next: PersistedSettings = { ...persisted };
       if (value === undefined) delete next[field];
       else Object.assign(next, { [field]: value });
       return next;
     });
+    return { status: ACT_RESULT_STATUS.ACCEPTED, settings: await this.snapshot() };
   }
 
   /**
@@ -602,29 +617,22 @@ export class SettingsStore {
     field: Field,
     key: string,
     value: SettingEntryValue<Field> | undefined,
-  ): Promise<SettingsUpdateResult>;
-  async setEntry(
-    field: KeyedAppSettingField,
-    key: string,
-    value: UnparsedWireValue,
-  ): Promise<SettingsUpdateResult>;
-  async setEntry(
-    field: KeyedAppSettingField,
-    key: string,
-    value: UnparsedWireValue,
   ): Promise<SettingsUpdateResult> {
-    return this.#setField((persisted) => {
+    // SAFETY: a setting entry's own value is one of the wire values it was parsed from.
+    const entry = value as UnparsedWireValue;
+    await this.#mutate((persisted) => {
       // SAFETY: KeyedAppSettingField identifies fields whose stored value is a wire record.
       const current = persisted[field] as WireRecord | undefined;
-      if (sameSettingEntry(field, current?.[key], value)) return;
+      if (sameSettingEntry(field, current?.[key], entry)) return undefined;
       const entries = { ...current };
-      if (value === undefined) delete entries[key];
-      else entries[key] = value;
+      if (entry === undefined) delete entries[key];
+      else entries[key] = entry;
       const next: PersistedSettings = { ...persisted };
       if (Object.keys(entries).length > 0) Object.assign(next, { [field]: entries });
       else delete next[field];
       return next;
     });
+    return { status: ACT_RESULT_STATUS.ACCEPTED, settings: await this.snapshot() };
   }
 
   async accountPreferences(): Promise<AccountPreferences> {
@@ -636,9 +644,8 @@ export class SettingsStore {
     expected?: { accountEmail: string; preferences: AccountPreferences },
   ): Promise<SettingsUpdateResult & { changed: readonly AccountPreferenceField[] }> {
     const changed: AccountPreferenceField[] = [];
-    await this.#serialize(async () => {
-      const persisted = await this.#load();
-      if (expected && persisted.account?.email !== expected.accountEmail) return;
+    await this.#mutate((persisted) => {
+      if (expected && persisted.account?.email !== expected.accountEmail) return undefined;
       const nextSettings = expected
         ? accountPreferencesWithLocalChanges(
             settings,
@@ -646,7 +653,7 @@ export class SettingsStore {
             expected.preferences,
           )
         : settings;
-      const next: PersistedSettings = { ...persisted, version: SETTINGS_FILE_VERSION };
+      const next: PersistedSettings = { ...persisted };
       for (const field of ACCOUNT_PREFERENCE_FIELDS) {
         // SAFETY: AccountPreferences is the parsed subset of JSON-compatible stored app settings.
         const value = nextSettings[field] as UnparsedWireValue;
@@ -657,9 +664,7 @@ export class SettingsStore {
         if (value === undefined) delete next[field];
         else Object.assign(next, { [field]: value });
       }
-      if (changed.length === 0) return;
-      await this.#write(next);
-      this.#loading = Promise.resolve(next);
+      return changed.length > 0 ? next : undefined;
     });
     return {
       status: ACT_RESULT_STATUS.ACCEPTED,
@@ -680,24 +685,16 @@ export class SettingsStore {
     preferences: AccountPreferences,
   ): Promise<boolean> {
     let saved = false;
-    await this.#serialize(async () => {
-      const persisted = await this.#load();
-      if (persisted.account?.email !== accountEmail) return;
+    await this.#mutate((persisted) => {
+      if (persisted.account?.email !== accountEmail) return undefined;
+      saved = true;
       if (
         persisted.accountPreferencesSync?.accountEmail === accountEmail &&
         JSON.stringify(persisted.accountPreferencesSync.preferences) === JSON.stringify(preferences)
       ) {
-        saved = true;
-        return;
+        return undefined;
       }
-      const next: PersistedSettings = {
-        ...persisted,
-        version: SETTINGS_FILE_VERSION,
-        accountPreferencesSync: { accountEmail, preferences },
-      };
-      await this.#write(next);
-      this.#loading = Promise.resolve(next);
-      saved = true;
+      return { ...persisted, accountPreferencesSync: { accountEmail, preferences } };
     });
     return saved;
   }
@@ -708,20 +705,18 @@ export class SettingsStore {
     key: string,
     expected: SettingEntryValue<Field>,
   ): Promise<SettingsUpdateResult & { cleared: boolean }> {
-    let cleared = false;
-    await this.#serialize(async () => {
-      const persisted = await this.#load();
+    // SAFETY: a setting entry's own value is one of the wire values it was parsed from.
+    const held = expected as UnparsedWireValue;
+    const cleared = await this.#mutate((persisted) => {
       // SAFETY: KeyedAppSettingField identifies fields whose stored value is a wire record.
       const current = persisted[field] as WireRecord | undefined;
-      if (!sameSettingEntry(field, current?.[key], expected)) return;
+      if (!sameSettingEntry(field, current?.[key], held)) return undefined;
       const entries = { ...current };
       delete entries[key];
-      const next: PersistedSettings = { ...persisted, version: SETTINGS_FILE_VERSION };
+      const next: PersistedSettings = { ...persisted };
       if (Object.keys(entries).length > 0) Object.assign(next, { [field]: entries });
       else delete next[field];
-      await this.#write(next);
-      this.#loading = Promise.resolve(next);
-      cleared = true;
+      return next;
     });
     return { status: ACT_RESULT_STATUS.ACCEPTED, settings: await this.snapshot(), cleared };
   }
@@ -739,14 +734,7 @@ export class SettingsStore {
 
   async snapshot(): Promise<AppSettings> {
     const persisted = await this.#load();
-    const voiceCapability = resolveVoiceCapability({
-      credentialsUsable: this.#credentialsUsable,
-      keyConfigured:
-        this.#credentialsUsable &&
-        (await this.readApiKey(VOICE_CREDENTIAL_PROVIDER_ID)) !== undefined,
-      accountSignedIn: this.#credentialsUsable && (await this.readAccount()) !== undefined,
-      chosenSource: persisted.voiceSource,
-    });
+    const voiceCapability = await this.#voiceCapability(persisted);
     const sources = await Promise.all(
       this.#providers.map(
         async (provider) => [provider.id, (await this.#resolveApiKey(provider)).source] as const,
@@ -825,9 +813,7 @@ export class SettingsStore {
   async readAccount(): Promise<StoredAccount | undefined> {
     const account = (await this.#load()).account;
     if (!account) return undefined;
-    try {
-      const tokens = JSON.parse(this.#cipher.decrypt(Buffer.from(account.tokenCipher, "base64")));
-      if (!isRecord(tokens)) return undefined;
+    return this.#decryptRecord(account.tokenCipher, (tokens) => {
       const { accessToken, refreshToken } = tokens;
       if (!isWireString(accessToken) || !isWireString(refreshToken)) return undefined;
       return {
@@ -839,9 +825,7 @@ export class SettingsStore {
         ...(account.pictureUrl ? { pictureUrl: account.pictureUrl } : undefined),
         provider: account.provider,
       };
-    } catch {
-      return undefined;
-    }
+    });
   }
 
   async accountSnapshot(): Promise<AccountSnapshot> {
@@ -862,8 +846,7 @@ export class SettingsStore {
     if (!this.#secretStorageUsable()) {
       throw new Error("Encrypted credential storage is unavailable on this system.");
     }
-    await this.#serialize(async () => {
-      const persisted = await this.#load();
+    await this.#mutate((persisted) => {
       const tokenCipher = this.#cipher
         .encrypt(
           JSON.stringify({
@@ -874,7 +857,6 @@ export class SettingsStore {
         .toString("base64");
       const next: PersistedSettings = {
         ...persisted,
-        version: SETTINGS_FILE_VERSION,
         account: {
           tokenCipher,
           ...(account.id ? { id: account.id } : undefined),
@@ -890,31 +872,36 @@ export class SettingsStore {
         }
         delete next.accountPreferencesSync;
       }
-      await this.#write(next);
-      this.#loading = Promise.resolve(next);
+      return next;
     });
     return this.accountSnapshot();
   }
 
   async clearAccount(): Promise<AccountSnapshot> {
-    await this.#serialize(async () => {
-      const persisted = await this.#load();
-      if (!persisted.account) return;
+    await this.#mutate((persisted) => {
+      if (!persisted.account) return undefined;
       const { account: _account, ...withoutAccount } = persisted;
-      const next: PersistedSettings = { ...withoutAccount, version: SETTINGS_FILE_VERSION };
+      const next: PersistedSettings = { ...withoutAccount };
       for (const field of ACCOUNT_PREFERENCE_FIELDS) {
         delete next[field];
       }
       delete next.accountPreferencesSync;
-      await this.#write(next);
-      this.#loading = Promise.resolve(next);
+      return next;
     });
     return { status: ACCOUNT_STATUS.SIGNED_OUT };
   }
 
   /** Main-process only: the source the minter and the reviewer are built for. */
   async readVoiceSource(): Promise<VoiceSource> {
-    const persisted = await this.#load();
+    return (await this.#voiceCapability(await this.#load())).source;
+  }
+
+  /**
+   * What a spoken turn would actually run on: the stored choice read against
+   * what this run holds. One resolution, so the panel's snapshot and the
+   * minter's own read can never answer the question differently.
+   */
+  async #voiceCapability(persisted: PersistedSettings) {
     return resolveVoiceCapability({
       credentialsUsable: this.#credentialsUsable,
       keyConfigured:
@@ -922,7 +909,7 @@ export class SettingsStore {
         (await this.readApiKey(VOICE_CREDENTIAL_PROVIDER_ID)) !== undefined,
       accountSignedIn: this.#credentialsUsable && (await this.readAccount()) !== undefined,
       chosenSource: persisted.voiceSource,
-    }).source;
+    });
   }
 
   /**
@@ -955,17 +942,11 @@ export class SettingsStore {
   }
 
   async setVaultSyncAccount(accountKey: string): Promise<void> {
-    await this.#serialize(async () => {
-      const persisted = await this.#load();
-      if (persisted.vaultSyncAccount === accountKey) return;
-      const next: PersistedSettings = {
-        ...persisted,
-        version: SETTINGS_FILE_VERSION,
-        vaultSyncAccount: accountKey,
-      };
-      await this.#write(next);
-      this.#loading = Promise.resolve(next);
-    });
+    await this.#mutate((persisted) =>
+      persisted.vaultSyncAccount === accountKey
+        ? undefined
+        : { ...persisted, vaultSyncAccount: accountKey },
+    );
   }
 
   /**
@@ -993,39 +974,35 @@ export class SettingsStore {
         reason: rejection,
       };
 
-    await this.#serialize(async () => {
-      const persisted = await this.#load();
-      const ciphertext = normalized
-        ? this.#cipher.encrypt(normalized).toString("base64")
-        : undefined;
-      // Connecting the key voice runs on is choosing it: someone who parked on
-      // the free allowance and later pastes a key means to use that key, and a
-      // stored preference quietly ignoring it would look like the key failed
-      // to save. Deleting one leaves the choice alone — there is nothing left
-      // for it to hold back, and it says where to land if another key arrives.
-      const chooses =
-        providerId === VOICE_CREDENTIAL_PROVIDER_ID &&
-        ciphertext !== undefined &&
-        persisted.voiceSource !== VOICE_SOURCE.KEY;
-      // A key that is already stored is not a write — unless it is also the
-      // act of choosing it, which pasting the same key back while parked on
-      // the allowance is.
-      if (persisted.apiKeys[providerId] === ciphertext && !chooses) return;
-      // Every other provider's ciphertext is carried over, so saving one key
-      // never disturbs another.
-      const apiKeys = { ...persisted.apiKeys };
-      if (ciphertext) apiKeys[providerId] = ciphertext;
-      else delete apiKeys[providerId];
-      const next: PersistedSettings = {
-        ...persisted,
-        version: SETTINGS_FILE_VERSION,
-        apiKeys,
-      };
-      if (chooses) next.voiceSource = VOICE_SOURCE.KEY;
-      await this.#write(next);
-      this.#loading = Promise.resolve(next);
-      this.#resolved.delete(providerId);
-    });
+    await this.#mutate(
+      (persisted) => {
+        const ciphertext = normalized
+          ? this.#cipher.encrypt(normalized).toString("base64")
+          : undefined;
+        // Connecting the key voice runs on is choosing it: someone who parked on
+        // the free allowance and later pastes a key means to use that key, and a
+        // stored preference quietly ignoring it would look like the key failed
+        // to save. Deleting one leaves the choice alone — there is nothing left
+        // for it to hold back, and it says where to land if another key arrives.
+        const chooses =
+          providerId === VOICE_CREDENTIAL_PROVIDER_ID &&
+          ciphertext !== undefined &&
+          persisted.voiceSource !== VOICE_SOURCE.KEY;
+        // A key that is already stored is not a write — unless it is also the
+        // act of choosing it, which pasting the same key back while parked on
+        // the allowance is.
+        if (persisted.apiKeys[providerId] === ciphertext && !chooses) return undefined;
+        // Every other provider's ciphertext is carried over, so saving one key
+        // never disturbs another.
+        const apiKeys = { ...persisted.apiKeys };
+        if (ciphertext) apiKeys[providerId] = ciphertext;
+        else delete apiKeys[providerId];
+        const next: PersistedSettings = { ...persisted, apiKeys };
+        if (chooses) next.voiceSource = VOICE_SOURCE.KEY;
+        return next;
+      },
+      () => this.#resolved.delete(providerId),
+    );
     return { status: ACT_RESULT_STATUS.ACCEPTED, settings: await this.snapshot() };
   }
 
@@ -1066,51 +1043,46 @@ export class SettingsStore {
         reason: rejection,
       };
 
-    await this.#serialize(async () => {
-      const persisted = await this.#load();
-      const tokenCipher = this.#cipher
-        .encrypt(
-          JSON.stringify({
-            accessToken,
-            ...(grant.refreshToken ? { refreshToken: grant.refreshToken } : undefined),
-          }),
-        )
-        .toString("base64");
-      // Every other provider's grant is carried over, so connecting one never
-      // disturbs another.
-      const grants = { ...(persisted.grants ?? {}) };
-      grants[providerId] = { tokenCipher, expiresAt: grant.expiresAt };
-      await this.#writeGrants(persisted, grants, providerId);
-    });
+    await this.#mutate(
+      (persisted) => {
+        const tokenCipher = this.#cipher
+          .encrypt(
+            JSON.stringify({
+              accessToken,
+              ...(grant.refreshToken ? { refreshToken: grant.refreshToken } : undefined),
+            }),
+          )
+          .toString("base64");
+        // Every other provider's grant is carried over, so connecting one never
+        // disturbs another.
+        const grants = { ...(persisted.grants ?? {}) };
+        grants[providerId] = { tokenCipher, expiresAt: grant.expiresAt };
+        return { ...persisted, grants };
+      },
+      () => this.#forgetGrant(providerId),
+    );
     return { status: ACT_RESULT_STATUS.ACCEPTED, settings: await this.snapshot() };
   }
 
   /** Disconnects one provider, deleting its stored grant with it. */
   async clearGrant(providerId: CredentialProviderId): Promise<SettingsUpdateResult> {
-    await this.#serialize(async () => {
-      const persisted = await this.#load();
-      if (!persisted.grants?.[providerId]) return;
-      const grants = { ...persisted.grants };
-      delete grants[providerId];
-      await this.#writeGrants(persisted, grants, providerId);
-    });
+    await this.#mutate(
+      (persisted) => {
+        if (!persisted.grants?.[providerId]) return undefined;
+        const grants = { ...persisted.grants };
+        delete grants[providerId];
+        const next: PersistedSettings = { ...persisted };
+        if (Object.keys(grants).length > 0) next.grants = grants;
+        else delete next.grants;
+        return next;
+      },
+      () => this.#forgetGrant(providerId),
+    );
     return { status: ACT_RESULT_STATUS.ACCEPTED, settings: await this.snapshot() };
   }
 
-  /** One place writes the grants, so neither cache can outlive the file. */
-  async #writeGrants(
-    persisted: PersistedSettings,
-    grants: Readonly<Record<string, PersistedGrant>>,
-    providerId: CredentialProviderId,
-  ): Promise<void> {
-    const next: PersistedSettings = {
-      ...persisted,
-      version: SETTINGS_FILE_VERSION,
-    };
-    if (Object.keys(grants).length > 0) next.grants = grants;
-    else delete next.grants;
-    await this.#write(next);
-    this.#loading = Promise.resolve(next);
+  /** Both caches a written grant makes stale: the grant itself and the row's source. */
+  #forgetGrant(providerId: CredentialProviderId): void {
     this.#resolvedGrants.delete(providerId);
     // The row's own source is resolved from the same file, so it is stale now
     // for exactly the same reason.
@@ -1119,9 +1091,7 @@ export class SettingsStore {
 
   /** Recovers one stored grant's tokens, or nothing if they cannot be read. */
   #decryptGrant(held: PersistedGrant): LinearGrant | undefined {
-    try {
-      const tokens = JSON.parse(this.#cipher.decrypt(Buffer.from(held.tokenCipher, "base64")));
-      if (!isRecord(tokens)) return undefined;
+    return this.#decryptRecord(held.tokenCipher, (tokens) => {
       const { accessToken, refreshToken } = tokens;
       if (!isWireString(accessToken) || !accessToken) return undefined;
       return {
@@ -1129,10 +1099,7 @@ export class SettingsStore {
         ...(isWireString(refreshToken) && refreshToken ? { refreshToken } : undefined),
         expiresAt: held.expiresAt,
       };
-    } catch {
-      // Unrecoverable; the user connects that provider again.
-      return undefined;
-    }
+    });
   }
 
   /**
@@ -1164,36 +1131,45 @@ export class SettingsStore {
       };
     }
 
-    await this.#serialize(async () => {
-      const persisted = await this.#load();
-      const token = this.#cipher.encrypt(normalized).toString("base64");
-      const existing = persisted.calendarAccounts ?? [];
-      const held = existing.find((account) => account.id === id);
-      if (!held && existing.length >= MAXIMUM_CALENDAR_ACCOUNTS) {
-        throw new Error("More calendar accounts than the store keeps");
-      }
-      const account: PersistedCalendarAccount = {
-        id,
-        token,
-        calendars: held ? held.calendars : sanitizedCalendarIds(unparsedWire(selectedCalendarIds)),
-      };
-      const calendarAccounts = held
-        ? existing.map((candidate) => (candidate.id === id ? account : candidate))
-        : [...existing, account];
-      await this.#writeCalendarAccounts(persisted, calendarAccounts);
-    });
+    await this.#mutate(
+      (persisted) => {
+        const token = this.#cipher.encrypt(normalized).toString("base64");
+        const existing = persisted.calendarAccounts ?? [];
+        const held = existing.find((account) => account.id === id);
+        if (!held && existing.length >= MAXIMUM_CALENDAR_ACCOUNTS) {
+          throw new Error("More calendar accounts than the store keeps");
+        }
+        const account: PersistedCalendarAccount = {
+          id,
+          token,
+          calendars: held
+            ? held.calendars
+            : sanitizedCalendarIds(unparsedWire(selectedCalendarIds)),
+        };
+        return withCalendarAccounts(
+          persisted,
+          held
+            ? existing.map((candidate) => (candidate.id === id ? account : candidate))
+            : [...existing, account],
+        );
+      },
+      () => this.#forgetCalendarAccounts(),
+    );
     return { status: ACT_RESULT_STATUS.ACCEPTED, settings: await this.snapshot() };
   }
 
   /** Disconnects one account, deleting its stored grant with it. */
   async removeCalendarAccount(accountId: string): Promise<SettingsUpdateResult> {
-    await this.#serialize(async () => {
-      const persisted = await this.#load();
-      const existing = persisted.calendarAccounts ?? [];
-      const calendarAccounts = existing.filter((account) => account.id !== accountId);
-      if (calendarAccounts.length === existing.length) return;
-      await this.#writeCalendarAccounts(persisted, calendarAccounts);
-    });
+    await this.#mutate(
+      (persisted) => {
+        const existing = persisted.calendarAccounts ?? [];
+        const calendarAccounts = existing.filter((account) => account.id !== accountId);
+        return calendarAccounts.length === existing.length
+          ? undefined
+          : withCalendarAccounts(persisted, calendarAccounts);
+      },
+      () => this.#forgetCalendarAccounts(),
+    );
     return { status: ACT_RESULT_STATUS.ACCEPTED, settings: await this.snapshot() };
   }
 
@@ -1218,31 +1194,40 @@ export class SettingsStore {
         reason: "That is not a calendar id.",
       };
     let missing: string | undefined;
-    await this.#serialize(async () => {
-      const persisted = await this.#load();
-      if (accountId === APPLE_CALENDAR_ID) {
-        const held = persisted.appleCalendar;
+    // Only a Google account's list is decrypted, so only its edit costs the
+    // cache; this Mac's connection carries no grant to have cached.
+    let editedAccount = false;
+    await this.#mutate(
+      (persisted) => {
+        if (accountId === APPLE_CALENDAR_ID) {
+          const held = persisted.appleCalendar;
+          if (!held) {
+            missing = "Apple Calendar is not connected.";
+            return undefined;
+          }
+          const calendars = toggledCalendarSelection(held.calendars, id, selected);
+          return calendars ? withAppleCalendar(persisted, { calendars }) : undefined;
+        }
+        const existing = persisted.calendarAccounts ?? [];
+        const held = existing.find((account) => account.id === accountId);
         if (!held) {
-          missing = "Apple Calendar is not connected.";
-          return;
+          missing = "That calendar account is not connected.";
+          return undefined;
         }
         const calendars = toggledCalendarSelection(held.calendars, id, selected);
-        if (calendars) await this.#writeAppleCalendar(persisted, { calendars });
-        return;
-      }
-      const existing = persisted.calendarAccounts ?? [];
-      const held = existing.find((account) => account.id === accountId);
-      if (!held) {
-        missing = "That calendar account is not connected.";
-        return;
-      }
-      const calendars = toggledCalendarSelection(held.calendars, id, selected);
-      if (!calendars) return;
-      const calendarAccounts = existing.map((account) =>
-        account.id === accountId ? { ...account, calendars } : account,
-      );
-      await this.#writeCalendarAccounts(persisted, calendarAccounts);
-    });
+        if (!calendars) return undefined;
+        editedAccount = true;
+        return withCalendarAccounts(
+          persisted,
+          existing.map((account) =>
+            account.id === accountId ? { ...account, calendars } : account,
+          ),
+        );
+      },
+      () => {
+        if (editedAccount) this.#forgetCalendarAccounts();
+      },
+    );
     const settings = await this.snapshot();
     return missing
       ? { status: ACT_RESULT_STATUS.REJECTED, settings, reason: missing }
@@ -1260,13 +1245,9 @@ export class SettingsStore {
     const persisted = await this.#load();
     const accounts: CalendarAccountCredential[] = [];
     for (const account of persisted.calendarAccounts ?? []) {
-      try {
-        const refreshToken = this.#cipher.decrypt(Buffer.from(account.token, "base64")).trim();
-        if (!refreshToken || apiKeyRejection(refreshToken)) continue;
-        accounts.push({ id: account.id, refreshToken, selectedCalendarIds: account.calendars });
-      } catch {
-        // Unrecoverable; the user signs into that account again.
-      }
+      const refreshToken = this.#decryptSecret(account.token);
+      if (!refreshToken) continue;
+      accounts.push({ id: account.id, refreshToken, selectedCalendarIds: account.calendars });
     }
     this.#resolvedCalendarAccounts = accounts;
     return accounts;
@@ -1282,13 +1263,13 @@ export class SettingsStore {
   async connectAppleCalendar(
     selectedCalendarIds: readonly string[],
   ): Promise<SettingsUpdateResult> {
-    await this.#serialize(async () => {
-      const persisted = await this.#load();
-      if (persisted.appleCalendar) return;
-      await this.#writeAppleCalendar(persisted, {
-        calendars: sanitizedCalendarIds(unparsedWire(selectedCalendarIds)),
-      });
-    });
+    await this.#mutate((persisted) =>
+      persisted.appleCalendar
+        ? undefined
+        : withAppleCalendar(persisted, {
+            calendars: sanitizedCalendarIds(unparsedWire(selectedCalendarIds)),
+          }),
+    );
     return { status: ACT_RESULT_STATUS.ACCEPTED, settings: await this.snapshot() };
   }
 
@@ -1297,12 +1278,15 @@ export class SettingsStore {
    * the system grant stays macOS's, withdrawable in System Settings.
    */
   async disconnectAppleCalendar(): Promise<SettingsUpdateResult> {
-    await this.#serialize(async () => {
-      const persisted = await this.#load();
-      if (!persisted.appleCalendar) return;
-      await this.#writeAppleCalendar(persisted, undefined);
-    });
+    await this.#mutate((persisted) =>
+      persisted.appleCalendar ? withAppleCalendar(persisted, undefined) : undefined,
+    );
     return { status: ACT_RESULT_STATUS.ACCEPTED, settings: await this.snapshot() };
+  }
+
+  /** The decrypted account list a written one makes stale. */
+  #forgetCalendarAccounts(): void {
+    this.#resolvedCalendarAccounts = undefined;
   }
 
   /**
@@ -1321,34 +1305,6 @@ export class SettingsStore {
     return held ? { selectedCalendarIds: held.calendars } : undefined;
   }
 
-  /** One place writes the connection, like the account list beside it. */
-  async #writeAppleCalendar(
-    persisted: PersistedSettings,
-    appleCalendar: PersistedSettings["appleCalendar"],
-  ): Promise<void> {
-    const next: PersistedSettings = { ...persisted, version: SETTINGS_FILE_VERSION };
-    if (appleCalendar) next.appleCalendar = appleCalendar;
-    else delete next.appleCalendar;
-    await this.#write(next);
-    this.#loading = Promise.resolve(next);
-  }
-
-  /** One place writes the account list, so the cache can never outlive it. */
-  async #writeCalendarAccounts(
-    persisted: PersistedSettings,
-    calendarAccounts: readonly PersistedCalendarAccount[],
-  ): Promise<void> {
-    const next: PersistedSettings = {
-      ...persisted,
-      version: SETTINGS_FILE_VERSION,
-    };
-    if (calendarAccounts.length > 0) next.calendarAccounts = calendarAccounts;
-    else delete next.calendarAccounts;
-    await this.#write(next);
-    this.#loading = Promise.resolve(next);
-    this.#resolvedCalendarAccounts = undefined;
-  }
-
   /**
    * Returns one group of preferences to its defaults in a single write, by
    * forgetting the choices rather than storing copies of the defaults: an
@@ -1361,7 +1317,7 @@ export class SettingsStore {
    * asked for the value it holds.
    */
   async resetSettings(scope: SettingsResetScope): Promise<SettingsUpdateResult> {
-    return this.#setField((persisted) => {
+    await this.#mutate((persisted) => {
       const next: PersistedSettings = { ...persisted };
       for (const field of APP_SETTING_FIELDS) {
         const definition = APP_SETTING_SCHEMA[field];
@@ -1372,29 +1328,32 @@ export class SettingsStore {
       const changed = APP_SETTING_FIELDS.some((field) => next[field] !== persisted[field]);
       return changed ? next : undefined;
     });
+    return { status: ACT_RESULT_STATUS.ACCEPTED, settings: await this.snapshot() };
   }
 
   /**
-   * One preference write: serialize, load, mutate, write, cache. Returning
-   * undefined means the stored value is already the one asked for, so nothing
-   * is written. Credentials stay on their own path — a preference must never
-   * be the reason the Keychain is asked.
+   * The one settings write: serialize, load, mutate, stamp, write, cache, and
+   * invalidate. A mutator answering nothing means the stored value is already
+   * the one asked for, so nothing is written and no cache is dropped —
+   * `invalidate` runs only after a write actually landed, so a no-op change
+   * can never cost a Keychain read. Answers whether a write landed.
    */
-  async #setField(
+  async #mutate(
     mutate: (persisted: PersistedSettings) => PersistedSettings | undefined,
-  ): Promise<SettingsUpdateResult> {
+    invalidate?: () => void,
+  ): Promise<boolean> {
+    let wrote = false;
     await this.#serialize(async () => {
       const persisted = await this.#load();
       const mutated = mutate(persisted);
       if (!mutated) return;
-      const next: PersistedSettings = {
-        ...mutated,
-        version: SETTINGS_FILE_VERSION,
-      };
+      const next: PersistedSettings = { ...mutated, version: SETTINGS_FILE_VERSION };
       await this.#write(next);
       this.#loading = Promise.resolve(next);
+      invalidate?.();
+      wrote = true;
     });
-    return { status: ACT_RESULT_STATUS.ACCEPTED, settings: await this.snapshot() };
+    return wrote;
   }
 
   /**
@@ -1467,15 +1426,38 @@ export class SettingsStore {
 
   async #storedApiKey(provider: CredentialProvider): Promise<string | undefined> {
     const ciphertext = (await this.#load()).apiKeys[provider.id];
-    if (!ciphertext) return undefined;
+    return ciphertext ? this.#decryptSecret(ciphertext, provider.keyFormat) : undefined;
+  }
+
+  /**
+   * One stored ciphertext's JSON object, read by the caller's own reader, or
+   * nothing. Unrecoverable is an answer: a value encrypted under a different OS
+   * account, or against a rotated Keychain entry, cannot be read back, and the
+   * row it draws is what says to connect again.
+   */
+  #decryptRecord<Value>(
+    cipherText: string,
+    read: (record: WireRecord) => Value | undefined,
+  ): Value | undefined {
     try {
-      const apiKey = this.#cipher.decrypt(Buffer.from(ciphertext, "base64")).trim();
-      // A key stored before this build learned which kind the provider issues
-      // is held to the same rule, so a rule added later takes effect at once.
-      return apiKey && !apiKeyRejection(apiKey, provider.keyFormat) ? apiKey : undefined;
+      const parsed = JSON.parse(this.#cipher.decrypt(Buffer.from(cipherText, "base64")));
+      return isRecord(parsed) ? read(parsed) : undefined;
     } catch {
-      // A key encrypted under a different account, or against a rotated
-      // Keychain entry, cannot be recovered; the user re-enters it instead.
+      return undefined;
+    }
+  }
+
+  /**
+   * One stored ciphertext's plain secret, held to the same sendability rule a
+   * pasted key answers to — so a secret stored before this build learned which
+   * kind its provider issues is held to the rule added later. Unrecoverable
+   * reads as absent, exactly as a record's does.
+   */
+  #decryptSecret(cipherText: string, format?: CredentialFormat): string | undefined {
+    try {
+      const secret = this.#cipher.decrypt(Buffer.from(cipherText, "base64")).trim();
+      return secret && !apiKeyRejection(secret, format) ? secret : undefined;
+    } catch {
       return undefined;
     }
   }


### PR DESCRIPTION
## What this is

PR **B14** of the cleanup plan: one settings-store write path.

`SettingsStore` performed the same load-modify-stamp-write-cache dance **eleven** times — `#setField`, `#writeGrants`, `#writeAppleCalendar`, `#writeCalendarAccounts`, and inline copies in `setAccount`, `clearAccount`, `setVaultSyncAccount`, `clearEntryIfUnchanged`, `setApiKey`, `applyAccountPreferences`, and `setAccountPreferencesSyncBaseline`. Each copy independently remembered to stamp `version: SETTINGS_FILE_VERSION`, to reassign `#loading`, and to drop the caches its write made stale.

- **`#mutate(mutate, invalidate?)`** is that dance once. It answers whether a write landed — which is exactly what `clearEntryIfUnchanged` needs — and its `invalidate` runs only *after* a write landed, so a no-op change can never cost a Keychain read.
- **`#decryptRecord`** and **`#decryptSecret`** replace the four decrypt-and-parse copies (`readAccount`, `#decryptGrant`, `#storedApiKey`, `readCalendarAccounts`). Two, not one: two callers read a JSON record, two hold a bare secret, and forcing the latter through a record reader would mean encoding a string as one.
- **`#voiceCapability`** replaces the duplicated eight-line resolution in `snapshot` and `readVoiceSource`, so the panel's snapshot and the minter's own read cannot answer that question differently.
- `withCalendarAccounts` / `withAppleCalendar` state the set-or-delete-when-empty shape once, as pure functions with no write in them.
- `set` and `setEntry` lose their overloads for one generic signature apiece; `runtime-host.ts`'s `setEntry` cast is retargeted from `UnparsedWireValue` to `SettingEntryValue<typeof field>` and its SAFETY comment kept, and `set` needs no cast at all.

### Tests

`settings-store.test.ts` 2,437 → 1,299 lines, 124 → 78 tests. **Commit 1 left the test file byte-identical and green** — that is the proof the eleven dances were the same dance.

Forty-six per-field tests said the same five things about twenty-one fields (and said nothing about the fields nobody had written a copy for). Three loops over `APP_SETTING_FIELDS` now say them for every field: the default it starts at, the value that survives a reopen, the clear that returns it, the shape it refuses, the cipher it never reaches, and the stored key it never disturbs. Two more identical-modulo-the-field pairs folded the same way (`a stored key and a chosen preference survive each other's writes`, `ignores a stored chord this build cannot register`). The `SAMPLE_VALUE` table is total over `AppSettingField` under `satisfies`, so a setting added without one fails to compile rather than going quietly untested.

Everything the loops cannot state stays its own case, verbatim: values resolved from the environment, vocabularies this build does not know, and every credential, cipher-count, calendar, grant, account-preference, reset, voice-source, and write-path test.

**Deviation from the spec, recorded:** the spec deletes `rejects a key that cannot be sent as an authorization header` outright. `apiKeyRejection` has no other test in the repo, and the case also asserts that a refused key leaves the settings file uncreated — a store behaviour no guard test can state. It is kept, rewritten as a loop that asserts the store answers with `apiKeyRejection`'s own reason rather than one of its own.

## CLAUDE.md sentences touched

Two sentences describe what this file does; both are unchanged and both rules stay where they were.

- *"the settings store and its `safeStorage` cipher (so the credentials are decrypted in the Gateway, under the same app name and Keychain entry, with no desktop-side owner to fall back to)"* — no decryption moved across the boundary. `#decryptRecord` and `#decryptSecret` run exactly where the four copies ran, in the same process, behind the same `SecretCipher`.
- *"The files an earlier build kept beside `settings.json` are left in place and never read"* — untouched; no read or write path changed address.

The cipher's ask-at-most-once rule still lives in `#secretStorageUsable`, and its docblock is kept verbatim. The "no accessor returns a credential to a renderer" rule still lives in the `SettingsStore` class docblock, also verbatim. `PRIVACY.md` is unchanged: nothing new is stored, nothing new leaves the machine, and the file's `0o600` mode and atomic-rename write are untouched.

## Verification

- `./scripts/check.sh` — green (run after each commit; commit 1 with the test file byte-identical to `origin/main`).
- `git grep -n "#setField\|#writeGrants\|#writeAppleCalendar\|#writeCalendarAccounts"` → empty.
- `git grep -n "cipher.decrypt" apps/desktop/src/main/settings-store.ts` → exactly two hits, one in `#decryptRecord` and one in `#decryptSecret`.
- `git grep -n "SETTINGS_FILE_VERSION" apps/desktop/src/main/settings-store.ts` → the declaration, `defaultPersistedSettings`, `parsePersistedSettings`, and exactly one write-path hit, inside `#mutate`.
- Not a UI PR: no renderer file changes, so no `verify.sh` fixture PNG and no physical-notch check.

## Size

```
git diff --shortstat origin/main...
 3 files changed, 432 insertions(+), 1031 deletions(-)
```

Running repository total after this PR: **~250,700** tracked lines (`ts,tsx,mjs,js,swift,md,json,css,sh`), against the plan's ~125k target.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/329a6962-659a-4060-904e-557d7a84bd2f)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34302523761/artifacts/10085497381) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34302523761)

- Commit: `50bdbfbe84047a6732b2d5be8cfc5a9ae514e84c`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
