### PR TITLE
refactor: one home for each copy-pasted helper

### DIFF
--- a/apps/desktop/src/main/gateway/host-operator.ts
+++ b/apps/desktop/src/main/gateway/host-operator.ts
@@ -7,7 +7,7 @@ import type { AppGuideSnapshot } from "@sidecar/guide";
 import type { RealtimeConnection } from "@sidecar/hosted";
 import type { ConversationEntry, RealtimeDiagnostics } from "@sidecar/realtime";
 import type { GatewayCallResult, GatewayClient } from "@sidecar/runtime";
-import { GATEWAY_EVENT, GATEWAY_METHOD, type GatewayEventKind } from "@sidecar/runtime-contracts";
+import { GATEWAY_EVENT, GATEWAY_METHOD } from "@sidecar/runtime-contracts";
 import type {
   ObservedWorkspaceProject,
   Session,
@@ -31,14 +31,13 @@ import {
   isWireString,
   type UnparsedWireValue,
   type WireRecord,
-  type WireValue,
 } from "@sidecar/wire";
 import type { AppleCalendarAccess } from "#shared/apple-calendar";
 import type { AppSettings, SettingsUpdateResult } from "#shared/messages/settings";
 import type { SpeechOffer, SpeechOutcome } from "#shared/messages/speech";
 import { isSpeechOffer } from "#shared/messages/speech";
 import { RECEIVER_REPORT_KIND } from "../host/runtime-host";
-import { carried, onGatewayEvent } from "./wire";
+import { carried, gatewayEventReader } from "./wire";
 
 /**
  * The desktop's client over the host's own vocabulary: the settings, account,
@@ -240,11 +239,7 @@ export function createHostOperator(options: HostOperatorOptions): HostOperator {
     await result;
   };
 
-  const on = <Payload>(
-    kind: GatewayEventKind,
-    read: (payload: WireValue) => Payload | undefined,
-    listener: (payload: Payload) => void,
-  ) => onGatewayEvent(client, kind, read, listener);
+  const on = gatewayEventReader(client);
 
   const wireReporter = (reporter: string) => ({ reporter });
 

--- a/apps/desktop/src/main/gateway/host-operator.ts
+++ b/apps/desktop/src/main/gateway/host-operator.ts
@@ -38,6 +38,7 @@ import type { AppSettings, SettingsUpdateResult } from "#shared/messages/setting
 import type { SpeechOffer, SpeechOutcome } from "#shared/messages/speech";
 import { isSpeechOffer } from "#shared/messages/speech";
 import { RECEIVER_REPORT_KIND } from "../host/runtime-host";
+import { carried, onGatewayEvent } from "./wire";
 
 /**
  * The desktop's client over the host's own vocabulary: the settings, account,
@@ -204,13 +205,6 @@ function answeredList<Value>(value: UnparsedWireValue): readonly Value[] {
   return Array.isArray(value) ? value.flatMap((entry) => answered<Value>(entry) ?? []) : [];
 }
 
-/** One domain value of this client's, carried to the host as the JSON it already is. */
-function carried<Value>(value: Value): WireValue {
-  // SAFETY: the values carried here (settings values, guide snapshots, History entries, event properties) are the structured-clone payloads the bridge already guarded; each is JSON data.
-  // oxlint-disable-next-line anti-slop/no-chained-type-assertions -- The protocol carries JSON; the domain type is set aside at this one boundary.
-  return value as unknown as WireValue;
-}
-
 export function createHostOperator(options: HostOperatorOptions): HostOperator {
   const { client } = options;
 
@@ -250,11 +244,7 @@ export function createHostOperator(options: HostOperatorOptions): HostOperator {
     kind: GatewayEventKind,
     read: (payload: WireValue) => Payload | undefined,
     listener: (payload: Payload) => void,
-  ) =>
-    client.on(kind, (event) => {
-      const payload = read(event.payload);
-      if (payload !== undefined) listener(payload);
-    });
+  ) => onGatewayEvent(client, kind, read, listener);
 
   const wireReporter = (reporter: string) => ({ reporter });
 

--- a/apps/desktop/src/main/gateway/operator.ts
+++ b/apps/desktop/src/main/gateway/operator.ts
@@ -20,6 +20,7 @@ import {
 } from "#shared/messages/brain";
 import { CONVERSATION_DELETE_OUTCOME } from "../brain/conversation-deletion";
 import { REJECTED_SUBMISSION } from "../brain/ipc";
+import { onGatewayEvent } from "./wire";
 
 /**
  * The desktop's operator client: what the windows' IPC and the main
@@ -89,11 +90,7 @@ export function createGatewayOperator(options: GatewayOperatorOptions): GatewayO
     kind: GatewayEvent["kind"],
     read: (payload: WireValue) => Payload | undefined,
     listener: (payload: Payload) => void,
-  ) =>
-    client.on(kind, (event) => {
-      const payload = read(event.payload);
-      if (payload !== undefined) listener(payload);
-    });
+  ) => onGatewayEvent(client, kind, read, listener);
   return {
     client,
     submit: async (submission, sessionKey = MAIN_SESSION_KEY) =>

--- a/apps/desktop/src/main/gateway/operator.ts
+++ b/apps/desktop/src/main/gateway/operator.ts
@@ -3,7 +3,6 @@ import type { GatewayCallResult, GatewayClient } from "@sidecar/runtime";
 import {
   GATEWAY_EVENT,
   GATEWAY_METHOD,
-  type GatewayEvent,
   MAIN_SESSION_KEY,
   type SessionKey,
 } from "@sidecar/runtime-contracts";
@@ -20,7 +19,7 @@ import {
 } from "#shared/messages/brain";
 import { CONVERSATION_DELETE_OUTCOME } from "../brain/conversation-deletion";
 import { REJECTED_SUBMISSION } from "../brain/ipc";
-import { onGatewayEvent } from "./wire";
+import { gatewayEventReader } from "./wire";
 
 /**
  * The desktop's operator client: what the windows' IPC and the main
@@ -86,11 +85,7 @@ export interface GatewayOperatorOptions {
 
 export function createGatewayOperator(options: GatewayOperatorOptions): GatewayOperator {
   const { client } = options;
-  const on = <Payload>(
-    kind: GatewayEvent["kind"],
-    read: (payload: WireValue) => Payload | undefined,
-    listener: (payload: Payload) => void,
-  ) => onGatewayEvent(client, kind, read, listener);
+  const on = gatewayEventReader(client);
   return {
     client,
     submit: async (submission, sessionKey = MAIN_SESSION_KEY) =>

--- a/apps/desktop/src/main/gateway/service.ts
+++ b/apps/desktop/src/main/gateway/service.ts
@@ -59,6 +59,13 @@ import type {
 import { publishAsk } from "../brain/ipc";
 import type { SettableConfigurationPatch } from "../brain/wiring";
 import type { ConversationOperations } from "../conversation-operations";
+import { invalid } from "./wire";
+
+/** The two parameters a Gateway method refuses by name; protocol diagnostics, never words a person reads. */
+const REFUSAL = {
+  NO_RUN: "no run has that id",
+  NOT_LISTED: "the directory does not list that conversation",
+} as const;
 
 /**
  * The host side of the desktop's Gateway: every capability the protocol
@@ -144,15 +151,6 @@ export interface GatewayService {
   observationChanged: () => void;
   configurationChanged: () => void;
   childChanged: (childId: string) => void;
-}
-
-const REFUSAL = {
-  NO_RUN: "no run has that id",
-  NOT_LISTED: "the directory does not list that conversation",
-} as const;
-
-function invalid(message: string): GatewayMethodOutcome {
-  return gatewayError(GATEWAY_ERROR.INVALID_PARAMS, message);
 }
 
 /** A parameter that is not the shape its method takes; the reading handler answers it as an invalid-params refusal. */

--- a/apps/desktop/src/main/gateway/wire.ts
+++ b/apps/desktop/src/main/gateway/wire.ts
@@ -1,12 +1,12 @@
-import { type GatewayClient, gatewayError } from "@sidecar/runtime";
-import { GATEWAY_ERROR, type GatewayEventKind } from "@sidecar/runtime-contracts";
-import type { WireValue } from "@sidecar/wire";
-
 /**
  * The three things every side of the Gateway boundary does with the protocol:
  * hand a value the build already made to the wire, refuse a parameter that is
  * not the shape its method takes, and read one event kind under a guard.
  */
+
+import { type GatewayClient, gatewayError } from "@sidecar/runtime";
+import { GATEWAY_ERROR, type GatewayEventKind } from "@sidecar/runtime-contracts";
+import type { WireValue } from "@sidecar/wire";
 
 /** A value this build made, carried as the JSON it already is; every field of these shapes is a wire value. */
 export function carried<Value>(value: Value): WireValue {
@@ -20,15 +20,19 @@ export function invalid(message: string) {
   return gatewayError(GATEWAY_ERROR.INVALID_PARAMS, message);
 }
 
-/** Subscribes to one event kind, delivering only payloads its own reader accepted. */
-export function onGatewayEvent<Payload>(
-  client: GatewayClient,
-  kind: GatewayEventKind,
-  read: (payload: WireValue) => Payload | undefined,
-  listener: (payload: Payload) => void,
-) {
-  return client.on(kind, (event) => {
-    const payload = read(event.payload);
-    if (payload !== undefined) listener(payload);
-  });
+/**
+ * One client's event subscription, bound once: each kind is delivered only
+ * when its own reader accepted the payload, so no listener sees a shape the
+ * host never sent.
+ */
+export function gatewayEventReader(client: GatewayClient) {
+  return <Payload>(
+    kind: GatewayEventKind,
+    read: (payload: WireValue) => Payload | undefined,
+    listener: (payload: Payload) => void,
+  ) =>
+    client.on(kind, (event) => {
+      const payload = read(event.payload);
+      if (payload !== undefined) listener(payload);
+    });
 }

--- a/apps/desktop/src/main/gateway/wire.ts
+++ b/apps/desktop/src/main/gateway/wire.ts
@@ -1,0 +1,34 @@
+import { type GatewayClient, gatewayError } from "@sidecar/runtime";
+import { GATEWAY_ERROR, type GatewayEventKind } from "@sidecar/runtime-contracts";
+import type { WireValue } from "@sidecar/wire";
+
+/**
+ * The three things every side of the Gateway boundary does with the protocol:
+ * hand a value the build already made to the wire, refuse a parameter that is
+ * not the shape its method takes, and read one event kind under a guard.
+ */
+
+/** A value this build made, carried as the JSON it already is; every field of these shapes is a wire value. */
+export function carried<Value>(value: Value): WireValue {
+  // SAFETY: the values carried here (settings, snapshots, rosters, offers, History entries, event properties) are the structured-clone payloads the bridge already guarded; each is JSON data.
+  // oxlint-disable-next-line anti-slop/no-chained-type-assertions -- The protocol carries JSON; the domain type is set aside at this one boundary.
+  return value as unknown as WireValue;
+}
+
+/** A parameter that is not the shape its method takes, as the protocol's own refusal. */
+export function invalid(message: string) {
+  return gatewayError(GATEWAY_ERROR.INVALID_PARAMS, message);
+}
+
+/** Subscribes to one event kind, delivering only payloads its own reader accepted. */
+export function onGatewayEvent<Payload>(
+  client: GatewayClient,
+  kind: GatewayEventKind,
+  read: (payload: WireValue) => Payload | undefined,
+  listener: (payload: Payload) => void,
+) {
+  return client.on(kind, (event) => {
+    const payload = read(event.payload);
+    if (payload !== undefined) listener(payload);
+  });
+}

--- a/apps/desktop/src/main/host/runtime-host.ts
+++ b/apps/desktop/src/main/host/runtime-host.ts
@@ -88,7 +88,6 @@ import {
   DeliveryLedger,
   type GatewayMethodTable,
   type GatewayShutdownSteps,
-  gatewayError,
   gatewayOk,
   HEARTBEAT_DEFAULTS,
   heartbeatJob,
@@ -101,7 +100,6 @@ import {
   CONVERSATION_KIND,
   type ConversationRecord,
   type EmbeddingAdapter,
-  GATEWAY_ERROR,
   GATEWAY_EVENT,
   GATEWAY_METHOD,
   isIdentifier,
@@ -172,7 +170,7 @@ import {
   type WireRecord,
   type WireValue,
 } from "@sidecar/wire";
-import { APPLE_CALENDAR_ACCESS } from "#shared/apple-calendar";
+import { APPLE_CALENDAR_ACCESS, CALENDAR_PRIVACY_PANE_URL } from "#shared/apple-calendar";
 import { ACCOUNT_STATUS, type AccountSnapshot, isAccountProvider } from "#shared/messages/account";
 import type { BrainAppActRequest } from "#shared/messages/brain";
 import type { ObservedAccountCalendars, SettingsUpdateResult } from "#shared/messages/settings";
@@ -189,6 +187,7 @@ import { calendarOnboardingOwed } from "../calendar-onboarding-flow";
 import { conversationOperations, startHistoryMaintenance } from "../conversation-operations";
 import { NODE_CAPABILITY } from "../gateway/desktop-node";
 import { createGatewayService, type GatewayService, type GrantedWords } from "../gateway/service";
+import { carried, invalid } from "../gateway/wire";
 import { createSessionActPerformer, NodeAnswerLostError } from "../ipc/session-acts";
 import { wireMemoryMaintenance } from "../memory-maintenance";
 import { type OnboardingState, onboardingStateFile } from "../onboarding-state";
@@ -277,8 +276,6 @@ const HELD_NOTICE_RELEASE_INTERVAL_MS = 30_000;
  * the longest consent taken back keeps holding anything.
  */
 const APPLE_ACCESS_POLL_INTERVAL_MS = 10_000;
-const CALENDAR_PRIVACY_PANE_URL =
-  "x-apple.systempreferences:com.apple.preference.security?Privacy_Calendars";
 
 /** The agent's identity workspace and the skills beside it, under the agent's own directory. */
 const AGENT_WORKSPACE_DIRECTORY = "workspace";
@@ -289,10 +286,6 @@ const DIAGNOSTIC_COUNTED_AS = {
   [ADAPTER_DIAGNOSTIC_KIND.ACCIDENTAL_WAKE]: PRODUCT_DIAGNOSTIC_KIND.ACCIDENTAL_WAKE,
 } satisfies Record<AdapterDiagnosticKind, ProductDiagnosticKind>;
 
-function invalid(message: string) {
-  return gatewayError(GATEWAY_ERROR.INVALID_PARAMS, message);
-}
-
 function isSessionIdentity(value: UnparsedWireValue): value is SessionIdentity & WireRecord {
   return (
     isRecord(value) &&
@@ -300,13 +293,6 @@ function isSessionIdentity(value: UnparsedWireValue): value is SessionIdentity &
     isWireString(value.providerSessionId) &&
     value.providerSessionId.length > 0
   );
-}
-
-/** A record the build made, carried to the wire as it stands; every field of these shapes is already a wire value. */
-function wire<Value>(value: Value): WireValue {
-  // SAFETY: the shapes carried here (settings, snapshots, rosters, offers) are the structured-clone payloads the windows already receive; each is JSON data.
-  // oxlint-disable-next-line anti-slop/no-chained-type-assertions -- The protocol carries JSON; the domain type is set aside at this one boundary.
-  return value as unknown as WireValue;
 }
 
 /**
@@ -510,7 +496,7 @@ export function composeRuntimeHost(options: RuntimeHostOptions): RuntimeHost {
         writeOnboardingState({ calendarOnboardingRequiredAt: new Date(now()).toISOString() });
         void settleCalendarOnboardingIfConnected();
       }
-      emit(GATEWAY_EVENT.ACCOUNT_CHANGED, wire(account));
+      emit(GATEWAY_EVENT.ACCOUNT_CHANGED, carried(account));
       void emitSettings();
       void emitSessionReplay();
       if (signedIn && !wasSignedIn) productEvents.record(PRODUCT_EVENT.ACCOUNT_SIGN_IN, {});
@@ -855,7 +841,7 @@ export function composeRuntimeHost(options: RuntimeHostOptions): RuntimeHost {
     const generation = ++sessionReplayGeneration;
     const replay = await sessionReplayState();
     if (generation !== sessionReplayGeneration) return;
-    emit(GATEWAY_EVENT.SESSION_REPLAY_CHANGED, wire(replay));
+    emit(GATEWAY_EVENT.SESSION_REPLAY_CHANGED, carried(replay));
   }
 
   function emitSettingsSnapshot(
@@ -863,7 +849,7 @@ export function composeRuntimeHost(options: RuntimeHostOptions): RuntimeHost {
     reporter?: string,
   ): void {
     emit(GATEWAY_EVENT.SETTINGS_CHANGED, {
-      settings: wire(settings),
+      settings: carried(settings),
       ...(reporter !== undefined ? { reporter } : undefined),
     });
   }
@@ -946,7 +932,7 @@ export function composeRuntimeHost(options: RuntimeHostOptions): RuntimeHost {
     cli: supersetCli,
     openExternal: (url) => openExternalThroughNode(url),
     onChange: (state) => {
-      emit(GATEWAY_EVENT.SUPERSET_SIGN_IN_CHANGED, wire(state));
+      emit(GATEWAY_EVENT.SUPERSET_SIGN_IN_CHANGED, carried(state));
       if (state.stage !== SUPERSET_SIGN_IN_STAGE.CONNECTED) return;
       void sessionObservationLoop.refresh();
       recordProductEvent(PRODUCT_EVENT.SUPERSET_ACT, {
@@ -974,7 +960,7 @@ export function composeRuntimeHost(options: RuntimeHostOptions): RuntimeHost {
     const serialized = JSON.stringify(projects);
     if (serialized === lastWorkspaceProjects) return;
     lastWorkspaceProjects = serialized;
-    emit(GATEWAY_EVENT.WORKSPACE_PROJECTS_CHANGED, { projects: wire(projects) });
+    emit(GATEWAY_EVENT.WORKSPACE_PROJECTS_CHANGED, { projects: carried(projects) });
   }
 
   async function pruneWorkspaceProjectDefaults(
@@ -1112,7 +1098,7 @@ export function composeRuntimeHost(options: RuntimeHostOptions): RuntimeHost {
    * shape this build cannot read, is a refusal, and the act is left undone.
    */
   async function performBrainAppAct(action: BrainAppActRequest["action"]): Promise<WireRecord> {
-    const result = await nodes.invoke(NODE_CAPABILITY.PANEL_APP_ACT, { action: wire(action) });
+    const result = await nodes.invoke(NODE_CAPABILITY.PANEL_APP_ACT, { action: carried(action) });
     if (result.status === NODE_CAPABILITY_STATUS.OK && isRecord(result.value)) return result.value;
     if (result.status === NODE_CAPABILITY_STATUS.UNKNOWN) {
       return { status: UNKNOWN_ACT_STATUS, reason: result.reason };
@@ -1589,7 +1575,7 @@ export function composeRuntimeHost(options: RuntimeHostOptions): RuntimeHost {
   function offerNextSpeech(): void {
     if (!voiceReceiver.isReady() || !voiceCapabilities.realtimeCredentials) return;
     const offer = speechArbiter.next();
-    if (offer) emit(GATEWAY_EVENT.SPEECH_OFFERED, wire(offer));
+    if (offer) emit(GATEWAY_EVENT.SPEECH_OFFERED, carried(offer));
   }
 
   voiceReceiver.onReady(() => {
@@ -1621,7 +1607,7 @@ export function composeRuntimeHost(options: RuntimeHostOptions): RuntimeHost {
         ...(failure ? { failure } : undefined),
         ...(revoked ? { revoked } : undefined),
       }));
-      emit(GATEWAY_EVENT.CALENDARS_CHANGED, { calendars: wire(observedCalendars) });
+      emit(GATEWAY_EVENT.CALENDARS_CHANGED, { calendars: carried(observedCalendars) });
       for (const held of accounts) {
         if (held.failure) report(`Calendar observation failed: ${held.failure}`);
       }
@@ -1719,7 +1705,7 @@ export function composeRuntimeHost(options: RuntimeHostOptions): RuntimeHost {
 
   function broadcastSessions(sessions: readonly Session[]): void {
     rosterBroadcast = true;
-    emit(GATEWAY_EVENT.SESSIONS_CHANGED, { sessions: wire(sessions), settled: true });
+    emit(GATEWAY_EVENT.SESSIONS_CHANGED, { sessions: carried(sessions), settled: true });
   }
 
   function startSessionObservation(): void {
@@ -1898,13 +1884,13 @@ export function composeRuntimeHost(options: RuntimeHostOptions): RuntimeHost {
         sessionReplayState(),
       ]);
       return gatewayOk({
-        settings: wire(settings),
-        account: wire(account),
-        sessions: wire(rosterForClients()),
+        settings: carried(settings),
+        account: carried(account),
+        sessions: carried(rosterForClients()),
         sessionsSettled: !runMode.observesProviders || rosterBroadcast,
         announcementsHeld: quiet,
-        conversationHistory: wire(runtimeStoreWiring.thread().entries()),
-        workspaceProjects: wire(
+        conversationHistory: carried(runtimeStoreWiring.thread().entries()),
+        workspaceProjects: carried(
           accountCapabilitiesActive()
             ? normalizeObservedWorkspaceProjects(
                 offeredWorkspaceProjects(),
@@ -1912,18 +1898,18 @@ export function composeRuntimeHost(options: RuntimeHostOptions): RuntimeHost {
               )
             : [],
         ),
-        calendars: wire(accountCapabilitiesActive() ? observedCalendars : []),
+        calendars: carried(accountCapabilitiesActive() ? observedCalendars : []),
         calendarOnboardingOwed: calendarOnboardingGateOwed(),
         supersetInstalled,
         supersetConnected,
-        sessionReplay: wire(replay),
+        sessionReplay: carried(replay),
         receiverEpoch: voiceReceiver.epoch(),
         voiceAvailable: voiceCapabilities.realtimeCredentials !== undefined,
         agentTraceEnabled: agentTrace !== undefined,
       });
     },
     [GATEWAY_METHOD.SETTINGS_SNAPSHOT]: async () =>
-      gatewayOk({ settings: wire(await settingsStore.snapshot()) }),
+      gatewayOk({ settings: carried(await settingsStore.snapshot()) }),
     [GATEWAY_METHOD.SETTINGS_UPDATE]: async (params) => {
       const field = params.field;
       if (!isAppSettingField(field) || isKeyedAppSettingField(field)) {
@@ -1942,7 +1928,7 @@ export function composeRuntimeHost(options: RuntimeHostOptions): RuntimeHost {
         reporterOf(params),
       );
       if (!result.reason && isAccountPreferenceField(field)) pushAccountPreferences();
-      return gatewayOk(wire(result));
+      return gatewayOk(carried(result));
     },
     [GATEWAY_METHOD.SETTINGS_UPDATE_ENTRY]: async (params) => {
       const field = params.field;
@@ -1973,7 +1959,7 @@ export function composeRuntimeHost(options: RuntimeHostOptions): RuntimeHost {
         reporterOf(params),
       );
       if (!result.reason && isAccountPreferenceField(field)) pushAccountPreferences();
-      return gatewayOk(wire(result));
+      return gatewayOk(carried(result));
     },
     [GATEWAY_METHOD.SETTINGS_RESET]: async (params) => {
       const scope = params.scope;
@@ -1993,7 +1979,7 @@ export function composeRuntimeHost(options: RuntimeHostOptions): RuntimeHost {
         reporterOf(params),
       );
       if (!result.reason && resetTouchesAccountPreferences(scope)) pushAccountPreferences();
-      return gatewayOk(wire(result));
+      return gatewayOk(carried(result));
     },
     [GATEWAY_METHOD.CREDENTIAL_SET_API_KEY]: async (params) => {
       const providerId = params.providerId;
@@ -2027,9 +2013,9 @@ export function composeRuntimeHost(options: RuntimeHostOptions): RuntimeHost {
         "Could not save that API key on this system.",
         reporterOf(params),
       );
-      return gatewayOk(wire(result));
+      return gatewayOk(carried(result));
     },
-    [GATEWAY_METHOD.ACCOUNT_SNAPSHOT]: () => gatewayOk({ account: wire(account) }),
+    [GATEWAY_METHOD.ACCOUNT_SNAPSHOT]: () => gatewayOk({ account: carried(account) }),
     [GATEWAY_METHOD.ACCOUNT_BEGIN_SIGN_IN]: async (params) => {
       if (!isAccountProvider(params.provider))
         return invalid("provider is not one this build knows");
@@ -2037,7 +2023,7 @@ export function composeRuntimeHost(options: RuntimeHostOptions): RuntimeHost {
         account_act: PRODUCT_ACCOUNT_ACT.SIGN_IN_START,
       });
       const snapshot = await accountSession.beginSignIn(params.provider);
-      return gatewayOk({ account: wire(snapshot) });
+      return gatewayOk({ account: carried(snapshot) });
     },
     [GATEWAY_METHOD.ACCOUNT_CANCEL_SIGN_IN]: () => {
       recordProductEvent(PRODUCT_EVENT.ACCOUNT_ACT, {
@@ -2053,7 +2039,7 @@ export function composeRuntimeHost(options: RuntimeHostOptions): RuntimeHost {
       // next sign-in.
       await productEvents.flush();
       const snapshot = await accountSession.signOut({ revokeRemote: true });
-      return gatewayOk({ account: wire(snapshot) });
+      return gatewayOk({ account: carried(snapshot) });
     },
     [GATEWAY_METHOD.ACCOUNT_DELETE]: async () => {
       recordProductEvent(PRODUCT_EVENT.ACCOUNT_ACT, { account_act: PRODUCT_ACCOUNT_ACT.DELETE });
@@ -2062,7 +2048,7 @@ export function composeRuntimeHost(options: RuntimeHostOptions): RuntimeHost {
       // Only a deletion that landed stands recording down for the run.
       sessionReplayEndedByDeletion = true;
       void emitSessionReplay();
-      return gatewayOk({ account: wire(snapshot) });
+      return gatewayOk({ account: carried(snapshot) });
     },
     [GATEWAY_METHOD.CALENDAR_CONNECT_GOOGLE]: async (params) => {
       const result = await settingsWrite(
@@ -2091,7 +2077,7 @@ export function composeRuntimeHost(options: RuntimeHostOptions): RuntimeHost {
         "Could not connect Google Calendar on this system.",
         reporterOf(params),
       );
-      return gatewayOk(wire(result));
+      return gatewayOk(carried(result));
     },
     [GATEWAY_METHOD.CALENDAR_CANCEL_GOOGLE_SIGN_IN]: () => {
       googleCalendarSignIn.cancel();
@@ -2116,7 +2102,7 @@ export function composeRuntimeHost(options: RuntimeHostOptions): RuntimeHost {
         "Could not disconnect that account on this system.",
         reporterOf(params),
       );
-      return gatewayOk(wire(result));
+      return gatewayOk(carried(result));
     },
     [GATEWAY_METHOD.CALENDAR_CONNECT_APPLE]: async (params) => {
       const generation = ++appleConnectGeneration;
@@ -2154,7 +2140,7 @@ export function composeRuntimeHost(options: RuntimeHostOptions): RuntimeHost {
         "Could not connect Apple Calendar on this system.",
         reporterOf(params),
       );
-      return gatewayOk(wire(result));
+      return gatewayOk(carried(result));
     },
     [GATEWAY_METHOD.CALENDAR_DISCONNECT_APPLE]: async (params) => {
       const result = await settingsWrite(
@@ -2169,7 +2155,7 @@ export function composeRuntimeHost(options: RuntimeHostOptions): RuntimeHost {
         "Could not disconnect Apple Calendar on this system.",
         reporterOf(params),
       );
-      return gatewayOk(wire(result));
+      return gatewayOk(carried(result));
     },
     [GATEWAY_METHOD.CALENDAR_APPLE_ACCESS_STATUS]: async () => {
       try {
@@ -2199,7 +2185,7 @@ export function composeRuntimeHost(options: RuntimeHostOptions): RuntimeHost {
           ?.calendars.some((candidate) => candidate.id === calendarId)
       ) {
         return gatewayOk(
-          wire(
+          carried(
             await refusedSettings("That calendar is not one the account's latest list offered."),
           ),
         );
@@ -2217,7 +2203,7 @@ export function composeRuntimeHost(options: RuntimeHostOptions): RuntimeHost {
         "Could not save that calendar choice on this system.",
         reporterOf(params),
       );
-      return gatewayOk(wire(result));
+      return gatewayOk(carried(result));
     },
     [GATEWAY_METHOD.TRACKER_CONNECT]: async (params) => {
       const result = await settingsWrite(
@@ -2236,7 +2222,7 @@ export function composeRuntimeHost(options: RuntimeHostOptions): RuntimeHost {
         "Could not connect Linear on this system.",
         reporterOf(params),
       );
-      return gatewayOk(wire(result));
+      return gatewayOk(carried(result));
     },
     [GATEWAY_METHOD.TRACKER_CANCEL_SIGN_IN]: () => {
       linearSignIn.cancel();
@@ -2262,7 +2248,7 @@ export function composeRuntimeHost(options: RuntimeHostOptions): RuntimeHost {
         "Could not disconnect Linear on this system.",
         reporterOf(params),
       );
-      return gatewayOk(wire(result));
+      return gatewayOk(carried(result));
     },
     [GATEWAY_METHOD.SUPERSET_STATUS]: async () => {
       const [installed, connected] = await Promise.all([
@@ -2275,15 +2261,15 @@ export function composeRuntimeHost(options: RuntimeHostOptions): RuntimeHost {
       recordProductEvent(PRODUCT_EVENT.SUPERSET_ACT, {
         superset_act: PRODUCT_SUPERSET_ACT.SIGN_IN_START,
       });
-      return gatewayOk({ state: wire(await supersetSignIn.begin()) });
+      return gatewayOk({ state: carried(await supersetSignIn.begin()) });
     },
     [GATEWAY_METHOD.SUPERSET_SUBMIT_CODE]: async (params) => {
       if (!isWireString(params.code)) return invalid("code must be a string");
-      return gatewayOk({ state: wire(await supersetSignIn.submitCode(params.code)) });
+      return gatewayOk({ state: carried(await supersetSignIn.submitCode(params.code)) });
     },
     [GATEWAY_METHOD.SUPERSET_CHOOSE_ORGANIZATION]: async (params) => {
       if (!isWireString(params.slug)) return invalid("slug must be a string");
-      return gatewayOk({ state: wire(await supersetSignIn.chooseOrganization(params.slug)) });
+      return gatewayOk({ state: carried(await supersetSignIn.chooseOrganization(params.slug)) });
     },
     [GATEWAY_METHOD.SUPERSET_REOPEN_SIGN_IN]: () => {
       supersetSignIn.reopen();
@@ -2312,12 +2298,12 @@ export function composeRuntimeHost(options: RuntimeHostOptions): RuntimeHost {
     },
     [GATEWAY_METHOD.SESSION_ROSTER]: () =>
       gatewayOk({
-        sessions: wire(rosterForClients()),
+        sessions: carried(rosterForClients()),
         settled: !runMode.observesProviders || rosterBroadcast,
       }),
     [GATEWAY_METHOD.SESSION_OPEN]: async (params) => {
       if (!isSessionIdentity(params.identity)) return invalid("identity must name a session");
-      return gatewayOk(wire(await sessionActPerformer.openSession(params.identity)));
+      return gatewayOk(carried(await sessionActPerformer.openSession(params.identity)));
     },
     [GATEWAY_METHOD.SESSION_OPEN_APPLICATION]: async (params) => {
       if (!isSessionIdentity(params.identity)) return invalid("identity must name a session");
@@ -2325,18 +2311,18 @@ export function composeRuntimeHost(options: RuntimeHostOptions): RuntimeHost {
         return invalid("applicationId is not one this build knows");
       }
       return gatewayOk(
-        wire(
+        carried(
           await sessionActPerformer.openSessionApplication(params.identity, params.applicationId),
         ),
       );
     },
     [GATEWAY_METHOD.SESSION_OPEN_CHANGE]: async (params) => {
       if (!isSessionIdentity(params.identity)) return invalid("identity must name a session");
-      return gatewayOk(wire(await sessionActPerformer.openSessionChange(params.identity)));
+      return gatewayOk(carried(await sessionActPerformer.openSessionChange(params.identity)));
     },
     [GATEWAY_METHOD.WORKSPACE_PROJECTS]: async () =>
       gatewayOk({
-        projects: wire(
+        projects: carried(
           accountCapabilitiesActive()
             ? normalizeObservedWorkspaceProjects(
                 offeredWorkspaceProjects(),
@@ -2382,11 +2368,11 @@ export function composeRuntimeHost(options: RuntimeHostOptions): RuntimeHost {
           credential_source: VOICE_SOURCE_COUNTED_AS[voiceCapabilities.voiceSource],
         });
       }
-      return gatewayOk(credential ? { credential: wire(credential) } : {});
+      return gatewayOk(credential ? { credential: carried(credential) } : {});
     },
     [GATEWAY_METHOD.VOICE_DIAGNOSTICS]: () =>
       gatewayOk({
-        diagnostics: wire(
+        diagnostics: carried(
           voiceCapabilities.realtimeCredentials?.diagnostics() ??
             voiceCapabilities.unavailableDiagnostics,
         ),

--- a/apps/desktop/src/main/ipc/session-acts.test.ts
+++ b/apps/desktop/src/main/ipc/session-acts.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { ACT_KIND, type CarriedSessionAct } from "@sidecar/acts";
+import { ACT_KIND, ACT_REFUSAL, type CarriedSessionAct } from "@sidecar/acts";
 import {
   PROVIDER_ID,
   type ProviderSessionObservation,
@@ -145,7 +145,7 @@ test("a create whose turn ends while the stored defaults are read never reaches 
   settings.release();
   const result = await pending;
   assert.equal(result.status, ACT_RESULT_STATUS.REJECTED);
-  assert.ok(String(result.reason).includes("ended"));
+  assert.equal(result.reason, ACT_REFUSAL.TURN_OVER);
   assert.deepEqual(adapter.creates, []);
 });
 
@@ -162,7 +162,7 @@ test("a spawn whose turn ends while the stored defaults are read never reaches t
   settings.release();
   const result = await pending;
   assert.equal(result.status, ACT_RESULT_STATUS.REJECTED);
-  assert.ok(String(result.reason).includes("ended"));
+  assert.equal(result.reason, ACT_REFUSAL.TURN_OVER);
   assert.deepEqual(adapter.spawns, []);
 });
 

--- a/apps/desktop/src/main/ipc/session-acts.ts
+++ b/apps/desktop/src/main/ipc/session-acts.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import {
   ACT_KIND,
+  ACT_REFUSAL,
   type ActGuard,
   type CarriedIssueAct,
   type CarriedSessionAct,
@@ -137,16 +138,19 @@ export interface SessionActPerformer {
 }
 
 const REFUSAL = {
-  NO_SESSION: "No observed session matches that identity.",
-  NO_ISSUE: "No tracked issue matches that identity.",
+  // The sentences `admit` already says for these. The performer refuses the
+  // same three things at the last boundary before an effect, and a refusal
+  // worded twice is a refusal that drifts.
+  NO_SESSION: ACT_REFUSAL.NO_SESSION,
+  NO_ISSUE: ACT_REFUSAL.NO_ISSUE,
+  NO_ADDRESS: ACT_REFUSAL.NO_ADDRESS,
+  TURN_OVER: ACT_REFUSAL.TURN_OVER,
   PROVIDER_ABSENT: "That session's provider is not connected.",
-  NO_ADDRESS: "That session has no address to open.",
   NO_APP_ADDRESS: "That session has no address to open in that app.",
   NO_CHANGE: "That session reports no pull request.",
   OPEN_FAILED: "The system could not open that session.",
   OPEN_APP_FAILED: "The system could not open that session in the selected app.",
   OPEN_CHANGE_FAILED: "The system could not open that pull request.",
-  TURN_OVER: "Not run: the turn that asked for this act ended before it could start.",
 } as const;
 
 export function createSessionActPerformer(

--- a/apps/desktop/src/main/ipc/settings-rows.ts
+++ b/apps/desktop/src/main/ipc/settings-rows.ts
@@ -8,7 +8,7 @@ import {
 } from "@sidecar/settings";
 import { ACT_RESULT_STATUS, isWireString } from "@sidecar/wire";
 import type { IpcMain, IpcMainEvent, IpcMainInvokeEvent } from "electron";
-import { APPLE_CALENDAR_ACCESS } from "#shared/apple-calendar";
+import { APPLE_CALENDAR_ACCESS, CALENDAR_PRIVACY_PANE_URL } from "#shared/apple-calendar";
 import { BRIDGE, type BridgeArgumentsFor } from "#shared/bridge";
 import type { AppSettings } from "#shared/messages/settings";
 import type { HostOperator } from "../gateway/host-operator";
@@ -193,9 +193,6 @@ export function registerSettingsRowsIpc(dependencies: SettingsRowsIpcDependencie
 
   registerConnectionRows(dependencies);
 }
-
-const CALENDAR_PRIVACY_PANE_URL =
-  "x-apple.systempreferences:com.apple.preference.security?Privacy_Calendars";
 
 /**
  * The Linear and calendar rows, proxied to the host that owns each grant: the

--- a/apps/desktop/src/renderer/voice/speech-mouth.ts
+++ b/apps/desktop/src/renderer/voice/speech-mouth.ts
@@ -104,11 +104,11 @@ export class SpeechMouth {
   #ownReply = false;
   /** Until when the developer keeps the floor, as the injected clock reads it. */
   #holdUntil = 0;
-  #holdTimer: unknown;
-  #lingerTimer: unknown;
+  #holdTimer: ScheduledTimer | undefined;
+  #lingerTimer: ScheduledTimer | undefined;
   /** How many times the offer now in hand has tried to open Luke's own call. */
   #connectAttempts = 0;
-  #retryTimer: unknown;
+  #retryTimer: ScheduledTimer | undefined;
   /**
    * Whether the hold, as the panel last drew it, is standing. Read by nothing
    * that decides whether to speak: the main process is the authority on the
@@ -343,24 +343,23 @@ export class SpeechMouth {
     }, delayMs);
   }
 
-  #cancelHold(): void {
-    if (this.#holdTimer === undefined) return;
+  /** Stops one timer and answers the handle a stopped timer holds. */
+  #cancelTimer(handle: ScheduledTimer | undefined): undefined {
+    if (handle === undefined) return undefined;
     // SAFETY: The handle is whatever `schedule ?? setTimeout` returned, and the
     // fallbacks are paired — a handle from `setTimeout` can only reach
     // `clearTimeout`. The cast satisfies that signature; nothing reads it as a
     // number.
-    (this.#options.cancel ?? clearTimeout)(this.#holdTimer as number);
-    this.#holdTimer = undefined;
+    (this.#options.cancel ?? clearTimeout)(handle as number);
+    return undefined;
+  }
+
+  #cancelHold(): void {
+    this.#holdTimer = this.#cancelTimer(this.#holdTimer);
   }
 
   #cancelRetry(): void {
-    if (this.#retryTimer === undefined) return;
-    // SAFETY: The handle is whatever `schedule ?? setTimeout` returned, and the
-    // fallbacks are paired — a handle from `setTimeout` can only reach
-    // `clearTimeout`. The cast satisfies that signature; nothing reads it as a
-    // number.
-    (this.#options.cancel ?? clearTimeout)(this.#retryTimer as number);
-    this.#retryTimer = undefined;
+    this.#retryTimer = this.#cancelTimer(this.#retryTimer);
   }
 
   #armLinger(): void {
@@ -374,13 +373,7 @@ export class SpeechMouth {
   }
 
   #cancelLinger(): void {
-    if (this.#lingerTimer === undefined) return;
-    // SAFETY: The handle is whatever `schedule ?? setTimeout` returned, and the
-    // fallbacks are paired — a handle from `setTimeout` can only reach
-    // `clearTimeout`. The cast satisfies that signature; nothing reads it as a
-    // number.
-    (this.#options.cancel ?? clearTimeout)(this.#lingerTimer as number);
-    this.#lingerTimer = undefined;
+    this.#lingerTimer = this.#cancelTimer(this.#lingerTimer);
   }
 
   #closeOwnCall(): void {

--- a/apps/desktop/src/renderer/voice/use-voice-session.test.ts
+++ b/apps/desktop/src/renderer/voice/use-voice-session.test.ts
@@ -175,25 +175,13 @@ test("a typed ask, or an output that would swallow the reply, captions whatever 
 });
 
 test("a latched press is the release's to answer, and does not open a second call", () => {
-  assert.deepEqual(talkKeyPress({ latched: true, microphoneCall: false }), {
-    deferToRelease: true,
-    openCall: false,
-  });
-  assert.deepEqual(talkKeyPress({ latched: true, microphoneCall: true }), {
-    deferToRelease: true,
-    openCall: false,
-  });
+  assert.deepEqual(talkKeyPress({ latched: true, microphoneCall: false }), { openCall: false });
+  assert.deepEqual(talkKeyPress({ latched: true, microphoneCall: true }), { openCall: false });
 });
 
 test("a press against no microphone call has to open one, and the meter answers the press", () => {
-  assert.deepEqual(talkKeyPress({ latched: false, microphoneCall: false }), {
-    deferToRelease: false,
-    openCall: true,
-  });
-  assert.deepEqual(talkKeyPress({ latched: false, microphoneCall: true }), {
-    deferToRelease: false,
-    openCall: false,
-  });
+  assert.deepEqual(talkKeyPress({ latched: false, microphoneCall: false }), { openCall: true });
+  assert.deepEqual(talkKeyPress({ latched: false, microphoneCall: true }), { openCall: false });
 });
 
 test("the press-wait meter rides a handshake and a pending takeover, nothing else", () => {

--- a/apps/desktop/src/renderer/voice/use-voice-session.ts
+++ b/apps/desktop/src/renderer/voice/use-voice-session.ts
@@ -193,23 +193,14 @@ export function lukeCaptionsToShow(input: {
 }
 
 /**
- * What a talk-key press does before the session is asked. A latched turn is
- * already open — this press is someone saying they are done, which is the
- * release's to answer. Otherwise a press against no microphone call has
- * seconds of handshake ahead of it, and the meter has to answer the press,
- * not the handshake.
+ * Whether a talk-key press has a call to open before the session is asked. A
+ * latched turn is already open — that press is someone saying they are done,
+ * which is the release's to answer. Otherwise a press against no microphone
+ * call has seconds of handshake ahead of it, and the meter has to answer the
+ * press, not the handshake.
  */
 export function talkKeyPress(input: { latched: boolean; microphoneCall: boolean }) {
-  if (input.latched) {
-    return { deferToRelease: true, openCall: false } satisfies {
-      deferToRelease: boolean;
-      openCall: boolean;
-    };
-  }
-  return { deferToRelease: false, openCall: !input.microphoneCall } satisfies {
-    deferToRelease: boolean;
-    openCall: boolean;
-  };
+  return { openCall: !input.latched && !input.microphoneCall };
 }
 
 /**
@@ -243,6 +234,14 @@ export function liveSpeedApplies(
 }
 
 /**
+ * Whether a changed voice is still owed a restart, and what to do about it now.
+ */
+export interface VoiceRestartDecision {
+  due: boolean;
+  action: VoiceRestart;
+}
+
+/**
  * What a changed voice should do to a call already up. A call being opened
  * counts as one to reopen: its credential may already have been minted in the
  * old voice. A call that ended on its own owes nothing.
@@ -253,41 +252,20 @@ export function voiceRestartAction(input: {
   live: boolean;
   due: boolean;
   status: RealtimeStatus;
-}) {
-  if (input.next === undefined) {
-    return { due: input.due, action: VOICE_RESTART.NONE } satisfies {
-      due: boolean;
-      action: VoiceRestart;
-    };
-  }
+}): VoiceRestartDecision {
+  if (input.next === undefined) return { due: input.due, action: VOICE_RESTART.NONE };
   const due =
     input.due || (input.previous !== undefined && input.previous !== input.next && input.live);
-  if (!due) {
-    return { due: false, action: VOICE_RESTART.NONE } satisfies {
-      due: boolean;
-      action: VoiceRestart;
-    };
-  }
+  if (!due) return { due: false, action: VOICE_RESTART.NONE };
   if (
     input.status === REALTIME_STATUS.IDLE ||
     input.status === REALTIME_STATUS.FAILED ||
     input.status === REALTIME_STATUS.UNAVAILABLE
   ) {
-    return { due: false, action: VOICE_RESTART.DROP } satisfies {
-      due: boolean;
-      action: VoiceRestart;
-    };
+    return { due: false, action: VOICE_RESTART.DROP };
   }
-  if (input.status !== REALTIME_STATUS.READY) {
-    return { due: true, action: VOICE_RESTART.WAIT } satisfies {
-      due: boolean;
-      action: VoiceRestart;
-    };
-  }
-  return { due: false, action: VOICE_RESTART.RESTART } satisfies {
-    due: boolean;
-    action: VoiceRestart;
-  };
+  if (input.status !== REALTIME_STATUS.READY) return { due: true, action: VOICE_RESTART.WAIT };
+  return { due: false, action: VOICE_RESTART.RESTART };
 }
 
 /** A transcription belongs only to the same visible history generation as its turn. */

--- a/apps/desktop/src/shared/apple-calendar.ts
+++ b/apps/desktop/src/shared/apple-calendar.ts
@@ -14,3 +14,11 @@ export const APPLE_CALENDAR_ACCESS = {
 
 export type AppleCalendarAccess =
   (typeof APPLE_CALENDAR_ACCESS)[keyof typeof APPLE_CALENDAR_ACCESS];
+
+/**
+ * The System Settings pane where the Mac's own calendar grant is given or
+ * taken back. The grant is macOS's, never Luke's, so the only thing to offer
+ * is the way there.
+ */
+export const CALENDAR_PRIVACY_PANE_URL =
+  "x-apple.systempreferences:com.apple.preference.security?Privacy_Calendars";

--- a/apps/web/server/admin/http.ts
+++ b/apps/web/server/admin/http.ts
@@ -8,13 +8,12 @@
  * desktop tier has no notion of.
  */
 
+import { HTTP_STATUS } from "@sidecar/wire";
+
 export const ADMIN_HTTP_STATUS = {
+  ...HTTP_STATUS,
   OK: 200,
   BAD_REQUEST: 400,
-  UNAUTHORIZED: 401,
-  FORBIDDEN: 403,
-  NOT_FOUND: 404,
-  METHOD_NOT_ALLOWED: 405,
   SERVICE_UNAVAILABLE: 503,
 } as const;
 

--- a/apps/web/server/hosted/apns.ts
+++ b/apps/web/server/hosted/apns.ts
@@ -31,11 +31,6 @@ export interface ApnsCredentials {
   bundleId: string;
 }
 
-function trimmedText(value: string | undefined): string | undefined {
-  const trimmed = value?.trim();
-  return trimmed || undefined;
-}
-
 /**
  * Reads the credential, or nothing when any part is missing. A dashboard
  * often stores a multi-line key with its newlines escaped, so the two-character
@@ -44,10 +39,10 @@ function trimmedText(value: string | undefined): string | undefined {
 export function apnsCredentialsFromEnvironment(
   environment: Readonly<Record<string, string | undefined>>,
 ): ApnsCredentials | undefined {
-  const teamId = trimmedText(environment[APNS_ENVIRONMENT.TEAM_ID]);
-  const keyId = trimmedText(environment[APNS_ENVIRONMENT.KEY_ID]);
-  const privateKey = trimmedText(environment[APNS_ENVIRONMENT.PRIVATE_KEY])?.replace(/\\n/g, "\n");
-  const bundleId = trimmedText(environment[APNS_ENVIRONMENT.BUNDLE_ID]);
+  const teamId = text(environment[APNS_ENVIRONMENT.TEAM_ID]);
+  const keyId = text(environment[APNS_ENVIRONMENT.KEY_ID]);
+  const privateKey = text(environment[APNS_ENVIRONMENT.PRIVATE_KEY])?.replace(/\\n/g, "\n");
+  const bundleId = text(environment[APNS_ENVIRONMENT.BUNDLE_ID]);
   if (!teamId || !keyId || !privateKey || !bundleId) return undefined;
   return { teamId, keyId, privateKey, bundleId };
 }

--- a/apps/web/server/hosted/brain-v2.ts
+++ b/apps/web/server/hosted/brain-v2.ts
@@ -12,6 +12,7 @@ import {
   brainOutputReplayable,
   brainResponsesOutput,
   brainResponsesRequest,
+  type CloudFetch,
   embeddingsVectors,
   HOSTED_BRAIN_CONTRACT_VERSION,
   HOSTED_BRAIN_OPERATION,
@@ -44,7 +45,7 @@ import {
   jsonResponse,
   readBoundedBody,
 } from "./http.js";
-import { type FetchLike, postOpenAi } from "./openai.js";
+import { postOpenAi } from "./openai.js";
 import type { HostedSpend } from "./quota.js";
 
 /**
@@ -81,7 +82,7 @@ export interface BrainCapabilitiesOptions {
 
 export interface BrainV2Options extends BrainCapabilitiesOptions {
   spend: (userId: string) => Promise<HostedSpend>;
-  fetch?: FetchLike;
+  fetch?: CloudFetch;
   timeoutMs?: number;
 }
 

--- a/apps/web/server/hosted/events.ts
+++ b/apps/web/server/hosted/events.ts
@@ -35,13 +35,7 @@ import { createRateBrake } from "./rate-brake.js";
 /** Bigger than a full batch of allowlisted events can be, and refused before parsing. */
 const MAXIMUM_BODY_BYTES = 16_384;
 
-/**
- * A best-effort brake, keyed on the resolved account rather than the address:
- * the token already names who is asking, so an account cannot rotate past it
- * by changing networks. The counter lives in the function instance, which
- * makes it a per-instance brake rather than a guarantee — platform-level rules
- * are the real backstop — but it turns a looping desktop bug into a trickle.
- */
+/** What the shared brake holds this endpoint to; a batch spends its own event count. */
 const RATE_LIMIT = {
   WINDOW_MS: 60_000,
   MAX_EVENTS_PER_WINDOW: 120,

--- a/apps/web/server/hosted/events.ts
+++ b/apps/web/server/hosted/events.ts
@@ -1,4 +1,5 @@
 import {
+  type CloudFetch,
   PRODUCT_EVENT_CLIENT_HEADER,
   PRODUCT_EVENT_CLIENT_LIB,
   type ProductEventBatch,
@@ -9,13 +10,13 @@ import {
 } from "../core.js";
 import { errorResponse, HOSTED_API_ERROR, HOSTED_HTTP_STATUS, jsonResponse } from "./http.js";
 import {
-  type FetchLike,
   type PosthogBatch,
   type PosthogBatchItem,
   type PosthogPerson,
   type PosthogUpstreamOptions,
   postPosthogBatch,
 } from "./posthog.js";
+import { createRateBrake } from "./rate-brake.js";
 
 /**
  * Records what the signed-in desktop counted about its own use. The desktop
@@ -57,18 +58,11 @@ const RATE_LIMIT = {
  */
 const MAXIMUM_EVENT_AGE_MS = 7 * 24 * 60 * 60 * 1000;
 
-const recentUsers = new Map<string, { windowStart: number; count: number }>();
-
-function rateLimited(userId: string, events: number, now: number): boolean {
-  const held = recentUsers.get(userId);
-  if (!held || now - held.windowStart >= RATE_LIMIT.WINDOW_MS) {
-    if (recentUsers.size >= RATE_LIMIT.MAX_TRACKED_USERS) recentUsers.clear();
-    recentUsers.set(userId, { windowStart: now, count: events });
-    return events > RATE_LIMIT.MAX_EVENTS_PER_WINDOW;
-  }
-  held.count += events;
-  return held.count > RATE_LIMIT.MAX_EVENTS_PER_WINDOW;
-}
+const rateLimited = createRateBrake({
+  windowMs: RATE_LIMIT.WINDOW_MS,
+  maxRequestsPerWindow: RATE_LIMIT.MAX_EVENTS_PER_WINDOW,
+  maxTrackedUsers: RATE_LIMIT.MAX_TRACKED_USERS,
+});
 
 export interface EventsOptions {
   request: Request;
@@ -82,7 +76,7 @@ export interface EventsOptions {
    * deployment that would rather PostHog held neither; the counts still land.
    */
   readPerson?: (userId: string) => Promise<PosthogPerson | undefined>;
-  fetch?: FetchLike;
+  fetch?: CloudFetch;
   now?: () => number;
   timeoutMs?: number;
 }
@@ -173,7 +167,7 @@ export async function handleEvents(options: EventsOptions): Promise<Response> {
   }
 
   const now = (options.now ?? Date.now)();
-  if (rateLimited(userId, events.length, now)) {
+  if (rateLimited(userId, now, events.length)) {
     return errorResponse(HOSTED_HTTP_STATUS.TOO_MANY_REQUESTS, HOSTED_API_ERROR.QUOTA_EXHAUSTED);
   }
 

--- a/apps/web/server/hosted/http.ts
+++ b/apps/web/server/hosted/http.ts
@@ -1,3 +1,4 @@
+import { HTTP_STATUS } from "@sidecar/wire";
 import type { HostedApiError, HostedQuota } from "../core.js";
 
 /**
@@ -9,14 +10,13 @@ import type { HostedApiError, HostedQuota } from "../core.js";
 
 export { HOSTED_API_ERROR, type HostedApiError } from "../core.js";
 
+/** The wire boundary's statuses, plus the ones only a route answers with. */
 export const HOSTED_HTTP_STATUS = {
+  ...HTTP_STATUS,
   OK: 200,
   ACCEPTED: 202,
   BAD_REQUEST: 400,
-  UNAUTHORIZED: 401,
-  METHOD_NOT_ALLOWED: 405,
   PAYLOAD_TOO_LARGE: 413,
-  TOO_MANY_REQUESTS: 429,
   BAD_GATEWAY: 502,
   SERVICE_UNAVAILABLE: 503,
 } as const;

--- a/apps/web/server/hosted/introduction-mint.ts
+++ b/apps/web/server/hosted/introduction-mint.ts
@@ -1,10 +1,10 @@
 import {
+  type CloudFetch,
   introductionSessionConfig,
   type RealtimeSessionOptions,
   text as trimmedText,
 } from "../core.js";
 import { errorResponse, HOSTED_API_ERROR, HOSTED_HTTP_STATUS, jsonResponse } from "./http.js";
-import type { FetchLike } from "./openai.js";
 import type { IntroductionSpend } from "./quota.js";
 import {
   mintRealtimeConnection,
@@ -74,7 +74,7 @@ export interface IntroductionMintOptions {
   /** A deployment-configured model override; the shared default otherwise. */
   model?: string;
   spend: () => Promise<IntroductionSpend>;
-  fetch?: FetchLike;
+  fetch?: CloudFetch;
   now?: () => number;
   timeoutMs?: number;
 }

--- a/apps/web/server/hosted/openai.ts
+++ b/apps/web/server/hosted/openai.ts
@@ -5,6 +5,7 @@
  * off, the same kill switch the feedback endpoint uses.
  */
 
+import type { CloudFetch } from "@sidecar/wire";
 import type {
   BrainCompactRequest,
   BrainEmbeddingsRequest,
@@ -29,8 +30,6 @@ export const HOSTED_OPENAI_DEFAULTS = {
   REQUEST_TIMEOUT_MS: 15_000,
 } as const;
 
-export type FetchLike = (input: string, init: RequestInit) => Promise<Response>;
-
 /** Build-fixed documents the hosted tier POSTs to OpenAI. */
 export type OpenAiPostBody =
   | ReturnType<typeof realtimeClientSecretRequest>
@@ -43,7 +42,7 @@ export type OpenAiPostBody =
 
 export interface OpenAiUpstreamOptions {
   apiKey: string;
-  fetch?: FetchLike;
+  fetch?: CloudFetch;
   timeoutMs?: number;
   /** The caller's own cancellation, when the runtime carries one; the upstream call is dropped with it. */
   signal?: AbortSignal;

--- a/apps/web/server/hosted/posthog.ts
+++ b/apps/web/server/hosted/posthog.ts
@@ -13,6 +13,8 @@
  * retry, which this pipeline does not want — the desktop never retries either.
  */
 
+import { type CloudFetch, withoutTrailingSlash } from "@sidecar/wire";
+
 export const POSTHOG_ENVIRONMENT = {
   PROJECT_API_KEY: "POSTHOG_PROJECT_API_KEY",
   /** The ingestion host a batch is posted to. */
@@ -42,8 +44,6 @@ export const POSTHOG_DEFAULTS = {
 export function posthogProjectConsoleUrl(projectId: string, host?: string): string {
   return `${resolvePosthogApiHost(host)}/project/${encodeURIComponent(projectId)}`;
 }
-
-export type FetchLike = (input: string, init: RequestInit) => Promise<Response>;
 
 /**
  * Who the account behind a batch is, as the person record should read. The
@@ -75,12 +75,8 @@ export interface PosthogBatch {
 
 export interface PosthogUpstreamOptions {
   host?: string;
-  fetch?: FetchLike;
+  fetch?: CloudFetch;
   timeoutMs?: number;
-}
-
-function withoutTrailingSlash(value: string): string {
-  return value.endsWith("/") ? value.slice(0, -1) : value;
 }
 
 /** The deployment's private-API host override when it holds one, the default otherwise. */

--- a/apps/web/server/hosted/rate-brake.ts
+++ b/apps/web/server/hosted/rate-brake.ts
@@ -13,18 +13,25 @@ export interface RateBrakeConfig {
   maxTrackedUsers: number;
 }
 
-export function createRateBrake(config: RateBrakeConfig): (userId: string, now: number) => boolean {
+/**
+ * Whether this ask puts the caller over the window. `weight` is what the ask
+ * costs — one request by default, or the events a batch carries — so a single
+ * oversized batch is braked on arrival rather than on the one after it.
+ */
+export type RateBrake = (userId: string, now: number, weight?: number) => boolean;
+
+export function createRateBrake(config: RateBrakeConfig): RateBrake {
   const recentUsers = new Map<string, { windowStart: number; count: number }>();
-  return (userId, now) => {
+  return (userId, now, weight = 1) => {
     const held = recentUsers.get(userId);
     if (!held || now - held.windowStart >= config.windowMs) {
       if (recentUsers.size >= config.maxTrackedUsers) {
         recentUsers.clear();
       }
-      recentUsers.set(userId, { windowStart: now, count: 1 });
-      return false;
+      recentUsers.set(userId, { windowStart: now, count: weight });
+      return weight > config.maxRequestsPerWindow;
     }
-    held.count += 1;
+    held.count += weight;
     return held.count > config.maxRequestsPerWindow;
   };
 }

--- a/apps/web/server/hosted/remote-voice-mint.ts
+++ b/apps/web/server/hosted/remote-voice-mint.ts
@@ -1,6 +1,7 @@
 import {
   CLOUD_AGENT_PROVIDER_ID,
   type CloudAgentProviderId,
+  type CloudFetch,
   CONTEXT_ITEM_KIND,
   contextItemId,
   type ObservedSession,
@@ -10,7 +11,6 @@ import { cloudSessionAdapterFor } from "./cloud-adapters.js";
 import { decryptProviderKey } from "./encryption.js";
 import { errorResponse, HOSTED_API_ERROR, HOSTED_HTTP_STATUS, jsonResponse } from "./http.js";
 import { type VaultKeyRow, writeAdvertisedActs } from "./observe.js";
-import type { FetchLike } from "./openai.js";
 import type { HostedSpend } from "./quota.js";
 import { remoteSessionContextText } from "./remote-context.js";
 import { mintRealtimeConnection, voiceMintPreferences } from "./voice-mint.js";
@@ -35,7 +35,7 @@ export interface RemoteVoiceMintOptions {
   spend: (userId: string) => Promise<HostedSpend>;
   encryptionSecret: string | undefined;
   readVaultKeys: (userId: string) => Promise<VaultKeyRow[]>;
-  fetch?: FetchLike;
+  fetch?: CloudFetch;
   now?: () => number;
   timeoutMs?: number;
 }

--- a/apps/web/server/hosted/voice-mint.ts
+++ b/apps/web/server/hosted/voice-mint.ts
@@ -1,4 +1,5 @@
 import {
+  type CloudFetch,
   HOSTED_WS_BASE_URL,
   isRealtimeVoice,
   isRealtimeVoiceSpeed,
@@ -16,12 +17,7 @@ import {
   type UnparsedWireValue,
 } from "../core.js";
 import { errorResponse, HOSTED_API_ERROR, HOSTED_HTTP_STATUS, jsonResponse } from "./http.js";
-import {
-  type FetchLike,
-  HOSTED_OPENAI_DEFAULTS,
-  type OpenAiPostBody,
-  postOpenAi,
-} from "./openai.js";
+import { HOSTED_OPENAI_DEFAULTS, type OpenAiPostBody, postOpenAi } from "./openai.js";
 import type { HostedSpend } from "./quota.js";
 
 /**
@@ -83,7 +79,7 @@ export interface RealtimeConnectionMintOptions {
   preferences: VoiceMintPreferences;
   /** Builds the session document this endpoint mints with. */
   clientSecretRequest: (options: RealtimeSessionOptions) => OpenAiPostBody;
-  fetch?: FetchLike;
+  fetch?: CloudFetch;
   now?: () => number;
   timeoutMs?: number;
 }
@@ -159,7 +155,7 @@ export interface VoiceMintOptions {
   model?: string;
   resolveUserId: (request: Request) => Promise<string | undefined>;
   spend: (userId: string) => Promise<HostedSpend>;
-  fetch?: FetchLike;
+  fetch?: CloudFetch;
   now?: () => number;
   timeoutMs?: number;
 }

--- a/packages/account/src/preferences.ts
+++ b/packages/account/src/preferences.ts
@@ -7,6 +7,7 @@ import {
   text,
   type UnparsedWireValue,
   unparsedWire,
+  withoutTrailingSlash,
 } from "@sidecar/wire";
 import type { FetchLike } from "./client.js";
 
@@ -35,10 +36,6 @@ interface AccountPreferencesRequest {
   method: "GET" | "PUT";
   path: string;
   body?: Record<string, UnparsedWireValue>;
-}
-
-function withoutTrailingSlash(value: string): string {
-  return value.endsWith("/") ? value.slice(0, -1) : value;
 }
 
 function accountPreferencesAnswerFromWire(

--- a/packages/account/src/vault.ts
+++ b/packages/account/src/vault.ts
@@ -9,15 +9,20 @@ import {
   vaultKeysListAnswerFromWire,
 } from "@sidecar/hosted";
 import type { CloudAgentProviderId } from "@sidecar/session";
-import { positiveInteger, text, type UnparsedWireValue, unparsedWire } from "@sidecar/wire";
+import {
+  type CloudFetch,
+  positiveInteger,
+  text,
+  type UnparsedWireValue,
+  unparsedWire,
+  withoutTrailingSlash,
+} from "@sidecar/wire";
 
 const VAULT_DEFAULTS = {
   REQUEST_TIMEOUT_MS: 10_000,
 } as const;
 
 const UNAUTHORIZED_STATUS = 401;
-
-type FetchLike = (input: string, init: RequestInit) => Promise<Response>;
 
 export interface HostedVaultClientOptions {
   /** The hosted service origin, without a trailing slash. */
@@ -31,7 +36,7 @@ export interface HostedVaultClientOptions {
    * never as a fresh bearer to carry the old account's payload under.
    */
   readAccountKey?: () => Promise<string | undefined>;
-  fetch?: FetchLike;
+  fetch?: CloudFetch;
   requestTimeoutMs?: number;
 }
 
@@ -39,10 +44,6 @@ interface VaultRequest {
   method: "POST" | "GET" | "DELETE";
   path: string;
   body?: Record<string, string>;
-}
-
-function withoutTrailingSlash(value: string): string {
-  return value.endsWith("/") ? value.slice(0, -1) : value;
 }
 
 /**
@@ -59,7 +60,7 @@ export class HostedVaultClient {
   readonly #readAccessToken: () => Promise<string | undefined>;
   readonly #refreshAccount: () => Promise<void>;
   readonly #readAccountKey?: () => Promise<string | undefined>;
-  readonly #fetch: FetchLike;
+  readonly #fetch: CloudFetch;
   readonly #requestTimeoutMs: number;
 
   constructor(options: HostedVaultClientOptions) {

--- a/packages/analytics/src/sender.ts
+++ b/packages/analytics/src/sender.ts
@@ -9,7 +9,7 @@ import {
   productEventFromWire,
 } from "@sidecar/analytics";
 import { HOSTED_SERVICE_PATH } from "@sidecar/hosted";
-import { positiveInteger, text } from "@sidecar/wire";
+import { type CloudFetch, positiveInteger, text, withoutTrailingSlash } from "@sidecar/wire";
 
 const PRODUCT_EVENT_DEFAULTS = {
   REQUEST_TIMEOUT_MS: 10_000,
@@ -33,8 +33,6 @@ const UNAUTHORIZED_STATUS = 401;
 /** The one discriminator the day marker dedups on; the day itself is the key. */
 const DAY_ACTIVE_KEY = "day";
 
-type FetchLike = (input: string, init: RequestInit) => Promise<Response>;
-
 export interface ProductEventSenderOptions {
   /** The hosted service origin, without a trailing slash. */
   serviceBaseUrl: string;
@@ -44,15 +42,11 @@ export interface ProductEventSenderOptions {
   sends: boolean;
   readAccessToken: () => Promise<string | undefined>;
   refreshAccount: () => Promise<void>;
-  fetch?: FetchLike;
+  fetch?: CloudFetch;
   now?: () => number;
   requestTimeoutMs?: number;
   flushIntervalMs?: number;
   queueLimit?: number;
-}
-
-function withoutTrailingSlash(value: string): string {
-  return value.endsWith("/") ? value.slice(0, -1) : value;
 }
 
 /**
@@ -79,7 +73,7 @@ export class ProductEventSender {
   readonly #sends: boolean;
   readonly #readAccessToken: () => Promise<string | undefined>;
   readonly #refreshAccount: () => Promise<void>;
-  readonly #fetch: FetchLike;
+  readonly #fetch: CloudFetch;
   readonly #now: () => number;
   readonly #requestTimeoutMs: number;
   readonly #flushIntervalMs: number;

--- a/packages/brain/src/agent.test.ts
+++ b/packages/brain/src/agent.test.ts
@@ -23,6 +23,7 @@ import {
 } from "@sidecar/runtime-contracts";
 import {
   normalizeSession,
+  OMISSION_MARKER,
   type ProviderSessionObservation,
   type ProviderTranscriptResult,
   type ProviderTranscriptSinceResult,
@@ -70,7 +71,6 @@ import {
 } from "./state-store.js";
 import { BRAIN_TOOL, isBrainOnlyTool, TOOL_GROUP } from "./tools.js";
 import type { BrainTurnTraceRecord } from "./trace.js";
-import { OMISSION_MARKER } from "./transcript-reads.js";
 import { BRAIN_TURN_TRIGGER } from "./turn.js";
 import { BRAIN_WAKE_KIND, type BrainDelivery, type BrainWakeEvent } from "./wake-events.js";
 

--- a/packages/brain/src/agent.ts
+++ b/packages/brain/src/agent.ts
@@ -79,9 +79,11 @@ import {
   type RunEnd,
   SAVE_SCOPE,
 } from "./ledger.js";
+import { NestedMap } from "./nested-map.js";
 import {
   type BrainObservationEntry,
   entryFromEvent,
+  entryMark,
   eventFromEntry,
   sameObservation,
 } from "./observation-inbox.js";
@@ -205,10 +207,12 @@ export const BRAIN_DEFAULTS = {
   FULL_TRANSCRIPT_CHARS: 60_000,
   /**
    * The most wakes held for one turn; past it the oldest go, since the delta
-   * read covers what they said. The wake buffer is not the ask queue, whose
-   * capacity and overflow are the port's own.
+   * read covers what they said. It is the inbox's own bound, because a wake
+   * held past what one turn can open with is a wake no turn would read. The
+   * wake buffer is not the ask queue, whose capacity and overflow are the
+   * port's own.
    */
-  PENDING_WAKE_CAPACITY: 20,
+  PENDING_WAKE_CAPACITY: INBOX_CAPACITY,
 } as const;
 
 /**
@@ -503,7 +507,7 @@ export class BrainAgent {
    * launch is captured even with no transcript gained, because a status that
    * changed while Luke was closed is still a change worth one look.
    */
-  readonly #lastLook = new BySession<string>();
+  readonly #lastLook = new NestedMap<string>();
   /** Captures run one after another, so two reads of one session never race each other's cursor. */
   #capturing: Promise<unknown> = Promise.resolve();
   #capturesInFlight = 0;
@@ -1062,19 +1066,19 @@ export class BrainAgent {
       if (!generation || this.#stopped || generation.abort.signal.aborted) return 0;
       const fresh = events.filter(
         (event, index) =>
-          !generation.inbox.some((entry) => sameObservation(entry, event)) &&
-          !events.slice(0, index).some((earlier) => sameWake(earlier, event)),
+          !generation.inbox.some((entry) => sameObservation(entryMark(entry), event)) &&
+          !events.slice(0, index).some((earlier) => sameObservation(earlier, event)),
       );
       if (fresh.length === 0) return 0;
       const mark = generation.captureCursors.persisted();
-      const reads = new BySession<{
+      const reads = new NestedMap<{
         delta: BrainTranscriptDelta | undefined;
         cursor: string | undefined;
       }>();
       const entries: BrainObservationEntry[] = [];
       const now = this.#now();
       for (const event of fresh) {
-        let read = reads.get(event.identity);
+        let read = reads.get(event.identity.providerId, event.identity.providerSessionId);
         if (!read) {
           const delta = await readTranscriptDelta(event.identity, {
             cursors: generation.captureCursors,
@@ -1087,7 +1091,7 @@ export class BrainAgent {
             return 0;
           }
           read = { delta, cursor: generation.captureCursors.cursor(event.identity) };
-          reads.set(event.identity, read);
+          reads.set(event.identity.providerId, event.identity.providerSessionId, read);
         } else {
           // A second event for the same session in one batch carries no
           // second delta: the first read covers both.
@@ -1103,7 +1107,8 @@ export class BrainAgent {
         if (
           event.kind === BRAIN_WAKE_KIND.ROSTER &&
           !read.delta?.text &&
-          this.#lastLook.get(event.identity) === lookFingerprint(event)
+          this.#lastLook.get(event.identity.providerId, event.identity.providerSessionId) ===
+            lookFingerprint(event)
         ) {
           continue;
         }
@@ -1123,7 +1128,11 @@ export class BrainAgent {
       }
       for (const event of fresh) {
         if (event.kind === BRAIN_WAKE_KIND.ROSTER) {
-          this.#lastLook.set(event.identity, lookFingerprint(event));
+          this.#lastLook.set(
+            event.identity.providerId,
+            event.identity.providerSessionId,
+            lookFingerprint(event),
+          );
         }
       }
       return entries.length;
@@ -2750,37 +2759,6 @@ function uniqueIdentities(events: readonly BrainWakeEvent[]): readonly SessionId
     }
   }
   return seen;
-}
-
-function sameWake(first: BrainWakeEvent, second: BrainWakeEvent): boolean {
-  return (
-    first.kind === second.kind &&
-    first.hookEvent === second.hookEvent &&
-    first.atMs === second.atMs &&
-    sameIdentity(first.identity, second.identity)
-  );
-}
-
-/**
- * A value per observed session, keyed by provider and then by the provider's
- * own session id, the way the cursors are: two identifiers, never one string
- * composed of both.
- */
-class BySession<T> {
-  readonly #providers = new Map<string, Map<string, T>>();
-
-  get(identity: SessionIdentity): T | undefined {
-    return this.#providers.get(identity.providerId)?.get(identity.providerSessionId);
-  }
-
-  set(identity: SessionIdentity, value: T): void {
-    let sessions = this.#providers.get(identity.providerId);
-    if (!sessions) {
-      sessions = new Map();
-      this.#providers.set(identity.providerId, sessions);
-    }
-    sessions.set(identity.providerSessionId, value);
-  }
 }
 
 /** A session as the roster showed it at a look, in the fields a change would move; never a transcript. */

--- a/packages/brain/src/compaction.ts
+++ b/packages/brain/src/compaction.ts
@@ -1,3 +1,4 @@
+import { ESTIMATED_CHARS_PER_TOKEN } from "@sidecar/memory";
 import {
   COMPACTION_SOURCE,
   type CompactionOptions,
@@ -8,7 +9,6 @@ import {
   type RuntimeCompaction,
 } from "@sidecar/runtime-contracts";
 import type { WireRecord } from "@sidecar/wire";
-import { ESTIMATED_CHARS_PER_TOKEN } from "./context-engine.js";
 
 /**
  * The one component that decides when the context folds and how. The

--- a/packages/brain/src/context-engine.ts
+++ b/packages/brain/src/context-engine.ts
@@ -1,4 +1,5 @@
 import { RESPONSES_INPUT_ITEM_TYPE } from "@sidecar/hosted";
+import { ESTIMATED_CHARS_PER_TOKEN } from "@sidecar/memory";
 import {
   type CheckpointFormat,
   CONTEXT_INPUT_KIND,
@@ -20,9 +21,6 @@ import {
   type ResponsesInputItem,
   userMessageItem,
 } from "./responses-api.js";
-
-/** OpenClaw's own approximation where no count is at hand. */
-export const ESTIMATED_CHARS_PER_TOKEN = 4;
 
 /**
  * The context engine for the OpenAI Responses input array. It is the one

--- a/packages/brain/src/cursors.ts
+++ b/packages/brain/src/cursors.ts
@@ -1,4 +1,5 @@
 import type { SessionIdentity } from "@sidecar/session";
+import { NestedMap } from "./nested-map.js";
 import type { BrainTranscriptCursors } from "./state-store.js";
 
 /**
@@ -9,23 +10,18 @@ import type { BrainTranscriptCursors } from "./state-store.js";
  * again rather than skipped — but they are no part of any checkpoint format.
  */
 export class TranscriptCursors {
-  #cursors: Map<string, Map<string, string>>;
+  #cursors: NestedMap<string>;
 
   constructor(cursors: BrainTranscriptCursors = {}) {
     this.#cursors = cursorMap(cursors);
   }
 
   cursor(identity: SessionIdentity): string | undefined {
-    return this.#cursors.get(identity.providerId)?.get(identity.providerSessionId);
+    return this.#cursors.get(identity.providerId, identity.providerSessionId);
   }
 
   setCursor(identity: SessionIdentity, cursor: string): void {
-    let provider = this.#cursors.get(identity.providerId);
-    if (!provider) {
-      provider = new Map();
-      this.#cursors.set(identity.providerId, provider);
-    }
-    provider.set(identity.providerSessionId, cursor);
+    this.#cursors.set(identity.providerId, identity.providerSessionId, cursor);
   }
 
   /** Forgets the cursors of sessions the roster no longer holds, so the map cannot grow forever. */
@@ -39,12 +35,15 @@ export class TranscriptCursors {
       }
       provider.add(identity.providerSessionId);
     }
-    for (const [providerId, sessions] of this.#cursors) {
+    const dropped: [string, string][] = [];
+    for (const [providerId, sessions] of this.#cursors.groups()) {
       const keptSessions = kept.get(providerId);
       for (const providerSessionId of sessions.keys()) {
-        if (!keptSessions?.has(providerSessionId)) sessions.delete(providerSessionId);
+        if (!keptSessions?.has(providerSessionId)) dropped.push([providerId, providerSessionId]);
       }
-      if (sessions.size === 0) this.#cursors.delete(providerId);
+    }
+    for (const [providerId, providerSessionId] of dropped) {
+      this.#cursors.delete(providerId, providerSessionId);
     }
   }
 
@@ -54,7 +53,7 @@ export class TranscriptCursors {
 
   persisted(): BrainTranscriptCursors {
     const record: Record<string, Record<string, string>> = {};
-    for (const [providerId, sessions] of this.#cursors) {
+    for (const [providerId, sessions] of this.#cursors.groups()) {
       if (sessions.size === 0) continue;
       record[providerId] = Object.fromEntries(sessions);
     }
@@ -62,11 +61,12 @@ export class TranscriptCursors {
   }
 }
 
-function cursorMap(cursors: BrainTranscriptCursors): Map<string, Map<string, string>> {
-  return new Map(
-    Object.entries(cursors).map(([providerId, sessions]) => [
-      providerId,
-      new Map(Object.entries(sessions)),
-    ]),
-  );
+function cursorMap(cursors: BrainTranscriptCursors): NestedMap<string> {
+  const map = new NestedMap<string>();
+  for (const [providerId, sessions] of Object.entries(cursors)) {
+    for (const [providerSessionId, cursor] of Object.entries(sessions)) {
+      map.set(providerId, providerSessionId, cursor);
+    }
+  }
+  return map;
 }

--- a/packages/brain/src/cursors.ts
+++ b/packages/brain/src/cursors.ts
@@ -35,15 +35,13 @@ export class TranscriptCursors {
       }
       provider.add(identity.providerSessionId);
     }
-    const dropped: [string, string][] = [];
     for (const [providerId, sessions] of this.#cursors.groups()) {
       const keptSessions = kept.get(providerId);
       for (const providerSessionId of sessions.keys()) {
-        if (!keptSessions?.has(providerSessionId)) dropped.push([providerId, providerSessionId]);
+        if (!keptSessions?.has(providerSessionId)) {
+          this.#cursors.delete(providerId, providerSessionId);
+        }
       }
-    }
-    for (const [providerId, providerSessionId] of dropped) {
-      this.#cursors.delete(providerId, providerSessionId);
     }
   }
 

--- a/packages/brain/src/embedding-adapters.ts
+++ b/packages/brain/src/embedding-adapters.ts
@@ -13,14 +13,12 @@ import {
   MODEL_FAILURE,
   MODEL_RESPONSE_OUTCOME,
 } from "@sidecar/runtime-contracts";
-import { positiveInteger, text } from "@sidecar/wire";
+import { type CloudFetch, HTTP_STATUS, positiveInteger, text } from "@sidecar/wire";
 import {
   BRAIN_REQUEST_TIMEOUT_MS,
-  type FetchLike,
   failed,
   HostedServiceCalls,
   HTTP_METHOD,
-  HTTP_STATUS,
   notServed,
   payloadOf,
   RETRY_AFTER_HEADER,
@@ -55,7 +53,7 @@ export const EMBEDDING_BATCH_SIZE = HOSTED_BRAIN_EMBED_BOUNDS.MAXIMUM_TEXTS;
 
 export interface OpenAiEmbeddingAdapterOptions {
   apiKey: string;
-  fetch?: FetchLike;
+  fetch?: CloudFetch;
   now?: () => number;
   requestTimeoutMs?: number;
 }
@@ -63,7 +61,7 @@ export interface OpenAiEmbeddingAdapterOptions {
 /** The model and endpoint are fixed by the build: the index stores vectors under one model, and a key chooses none. */
 export class OpenAiEmbeddingAdapter implements EmbeddingAdapter {
   readonly #apiKey: string;
-  readonly #fetch: FetchLike;
+  readonly #fetch: CloudFetch;
   readonly #now: () => number;
   readonly #timeoutMs: number;
   #dimensions: number | undefined;
@@ -135,7 +133,7 @@ export interface HostedEmbeddingAdapterOptions {
   serviceBaseUrl: string;
   readAccessToken: () => Promise<string | undefined>;
   refreshAccount: () => Promise<void>;
-  fetch?: FetchLike;
+  fetch?: CloudFetch;
   now?: () => number;
   requestTimeoutMs?: number;
 }

--- a/packages/brain/src/hosted-model-adapter.ts
+++ b/packages/brain/src/hosted-model-adapter.ts
@@ -22,15 +22,20 @@ import {
   type ModelResponse,
   type ModelTokenCount,
 } from "@sidecar/runtime-contracts";
-import { type UnparsedWireValue, unparsedWire, type WireRecord, wireRecord } from "@sidecar/wire";
+import {
+  type CloudFetch,
+  HTTP_STATUS,
+  type UnparsedWireValue,
+  unparsedWire,
+  type WireRecord,
+  wireRecord,
+} from "@sidecar/wire";
 import { COMPACTION_POLICY } from "./compaction.js";
 import {
   type Failure,
-  type FetchLike,
   failed,
   HostedServiceCalls,
   HTTP_METHOD,
-  HTTP_STATUS,
   type Normalized,
   notServed,
   payloadOf,
@@ -55,7 +60,7 @@ export interface HostedModelAdapterOptions {
   serviceBaseUrl: string;
   readAccessToken: () => Promise<string | undefined>;
   refreshAccount: () => Promise<void>;
-  fetch?: FetchLike;
+  fetch?: CloudFetch;
   now?: () => number;
   requestTimeoutMs?: number;
   report?: (message: string) => void;

--- a/packages/brain/src/housekeeping.ts
+++ b/packages/brain/src/housekeeping.ts
@@ -18,6 +18,7 @@ import {
 } from "@sidecar/runtime-contracts";
 import { ACT_RESULT_STATUS, isWireString, type WireRecord, wireRecord } from "@sidecar/wire";
 import type { BrainWorkspaceAccess } from "./tool-executor.js";
+import { answer } from "./tool-results.js";
 import { BRAIN_TOOL, brainToolCatalog } from "./tools.js";
 import { REFUSAL_REASON } from "./turn.js";
 
@@ -136,13 +137,6 @@ export async function completeToolFree(
   return end.reason === RUN_END_REASON.COMPLETED && end.text.trim().length > 0
     ? end.text
     : undefined;
-}
-
-function answer(output: WireRecord): ToolResult {
-  return {
-    outputJson: JSON.stringify(output),
-    ...(isWireString(output.status) ? { status: output.status } : undefined),
-  };
 }
 
 function rejection(reason: string): ToolResult {

--- a/packages/brain/src/journal.ts
+++ b/packages/brain/src/journal.ts
@@ -5,6 +5,8 @@ import {
   UNKNOWN_ACT_STATUS,
   type UnparsedWireValue,
 } from "@sidecar/wire";
+import { NestedMap } from "./nested-map.js";
+import { outputStatus } from "./tool-results.js";
 
 /**
  * The action journal: one entry per act a developer ask dispatched, keyed by
@@ -101,43 +103,24 @@ export function journalActCounts(
   return counts;
 }
 
-function outputStatus(outputJson: string): string | undefined {
-  try {
-    // SAFETY: JSON.parse returns a wire value; the record and string guards are the validation.
-    const parsed = JSON.parse(outputJson) as UnparsedWireValue;
-    return isRecord(parsed) && isWireString(parsed.status) ? parsed.status : undefined;
-  } catch {
-    return undefined;
-  }
-}
-
 /**
  * Journal entries as one run reads them: by call id, with the two questions
  * the dispatch asks — has this call already been answered, and does a repeated
  * id carry the same arguments it did the first time.
  */
 export class BrainJournal {
-  readonly #entries = new Map<string, Map<string, BrainJournalEntry>>();
+  readonly #entries = new NestedMap<BrainJournalEntry>();
 
   constructor(entries: readonly BrainJournalEntry[] = []) {
-    for (const entry of entries) this.#run(entry.runId).set(entry.callId, { ...entry });
-  }
-
-  #run(runId: string): Map<string, BrainJournalEntry> {
-    let run = this.#entries.get(runId);
-    if (!run) {
-      run = new Map();
-      this.#entries.set(runId, run);
-    }
-    return run;
+    for (const entry of entries) this.#entries.set(entry.runId, entry.callId, { ...entry });
   }
 
   get(runId: string, callId: string): BrainJournalEntry | undefined {
-    return this.#entries.get(runId)?.get(callId);
+    return this.#entries.get(runId, callId);
   }
 
   start(entry: Omit<BrainJournalEntry, "outputJson" | "settledAt">): void {
-    this.#run(entry.runId).set(entry.callId, { ...entry });
+    this.#entries.set(entry.runId, entry.callId, { ...entry });
   }
 
   settle(runId: string, callId: string, outputJson: string, settledAt: number): void {
@@ -149,18 +132,18 @@ export class BrainJournal {
 
   /** Every entry, runs in insertion order and calls in dispatch order. */
   entries(): readonly BrainJournalEntry[] {
-    return [...this.#entries.values()].flatMap((run) => [...run.values()].map((e) => ({ ...e })));
+    return [...this.#entries.groups()].flatMap(([, run]) =>
+      [...run.values()].map((entry) => ({ ...entry })),
+    );
   }
 
   /** Drops one entry whose start could not be checkpointed, so it never reads as an act that ran. */
   forget(runId: string, callId: string): void {
-    const run = this.#entries.get(runId);
-    run?.delete(callId);
-    if (run?.size === 0) this.#entries.delete(runId);
+    this.#entries.delete(runId, callId);
   }
 
   /** Drops the journals of the runs named, for the host's retention to call. */
   dropRuns(runIds: Iterable<string>): void {
-    for (const runId of runIds) this.#entries.delete(runId);
+    for (const runId of runIds) this.#entries.deleteOuter(runId);
   }
 }

--- a/packages/brain/src/model-adapter-shared.ts
+++ b/packages/brain/src/model-adapter-shared.ts
@@ -10,7 +10,14 @@ import {
   MODEL_RESPONSE_OUTCOME,
   type ModelFailure,
 } from "@sidecar/runtime-contracts";
-import { positiveInteger, text, type UnparsedWireValue } from "@sidecar/wire";
+import {
+  type CloudFetch,
+  HTTP_STATUS,
+  positiveInteger,
+  text,
+  type UnparsedWireValue,
+  withoutTrailingSlash,
+} from "@sidecar/wire";
 
 /** The output budget one inference is asked for, the same on every transport: the hosted contract's ceiling. */
 export const BRAIN_MAXIMUM_OUTPUT_TOKENS = HOSTED_BRAIN_OPTION_BOUNDS.MAXIMUM_OUTPUT_TOKENS;
@@ -22,14 +29,6 @@ export const BRAIN_REQUEST_TIMEOUT_MS = 90_000;
  * What the two Responses adapters share: the statuses they read off a
  * transport, the cooldown a rate limit earns, and the shapes of a failure.
  */
-
-export const HTTP_STATUS = {
-  UNAUTHORIZED: 401,
-  FORBIDDEN: 403,
-  NOT_FOUND: 404,
-  METHOD_NOT_ALLOWED: 405,
-  TOO_MANY_REQUESTS: 429,
-} as const;
 
 export const HTTP_METHOD = {
   GET: "GET",
@@ -59,12 +58,6 @@ export function rateLimitWaitMs(retryAfter: string | null): number {
   const seconds = Number(retryAfter);
   if (!Number.isFinite(seconds) || seconds <= 0) return BRAIN_RATE_LIMIT_COOLDOWN_MS;
   return Math.min(Math.round(seconds * 1000), BRAIN_RATE_LIMIT_RETRY_AFTER_BOUND_MS);
-}
-
-export type FetchLike = (input: string, init: RequestInit) => Promise<Response>;
-
-export function withoutTrailingSlash(value: string): string {
-  return value.endsWith("/") ? value.slice(0, -1) : value;
 }
 
 /** The per-request timeout, joined with the run's own cancellation when the inference belongs to one. */
@@ -117,7 +110,7 @@ export interface HostedServiceCallOptions {
   serviceBaseUrl: string;
   readAccessToken: () => Promise<string | undefined>;
   refreshAccount: () => Promise<void>;
-  fetch?: FetchLike;
+  fetch?: CloudFetch;
   requestTimeoutMs?: number;
 }
 
@@ -133,7 +126,7 @@ export class HostedServiceCalls {
   readonly #baseUrl: string;
   readonly #readAccessToken: () => Promise<string | undefined>;
   readonly #refreshAccount: () => Promise<void>;
-  readonly #fetch: FetchLike;
+  readonly #fetch: CloudFetch;
   readonly #requestTimeoutMs: number;
 
   constructor(options: HostedServiceCallOptions) {

--- a/packages/brain/src/nested-map.ts
+++ b/packages/brain/src/nested-map.ts
@@ -33,8 +33,12 @@ export class NestedMap<Value> {
     this.#outer.delete(outer);
   }
 
-  /** Outer keys in insertion order, each with its own inner map. */
-  groups(): IterableIterator<[string, Map<string, Value>]> {
+  /**
+   * Outer keys in insertion order, each with its inner map to read. Deleting
+   * through {@link delete} while walking a group is safe: a Map's iteration
+   * order is defined under removal of the entry being visited.
+   */
+  groups(): IterableIterator<[string, ReadonlyMap<string, Value>]> {
     return this.#outer.entries();
   }
 }

--- a/packages/brain/src/nested-map.ts
+++ b/packages/brain/src/nested-map.ts
@@ -1,0 +1,40 @@
+/**
+ * A value under two identifiers, held as a map of maps. The two keys stay two
+ * keys: a provider id and the provider's own session id, or a run id and a
+ * call id, are never joined into one string, so an identifier carrying the
+ * separator cannot be read back as a different pair.
+ */
+export class NestedMap<Value> {
+  readonly #outer = new Map<string, Map<string, Value>>();
+
+  get(outer: string, inner: string): Value | undefined {
+    return this.#outer.get(outer)?.get(inner);
+  }
+
+  set(outer: string, inner: string, value: Value): void {
+    let held = this.#outer.get(outer);
+    if (!held) {
+      held = new Map();
+      this.#outer.set(outer, held);
+    }
+    held.set(inner, value);
+  }
+
+  /** Drops one value, and the outer key with it once nothing is left under it. */
+  delete(outer: string, inner: string): void {
+    const held = this.#outer.get(outer);
+    if (!held) return;
+    held.delete(inner);
+    if (held.size === 0) this.#outer.delete(outer);
+  }
+
+  /** Drops everything under one outer key. */
+  deleteOuter(outer: string): void {
+    this.#outer.delete(outer);
+  }
+
+  /** Outer keys in insertion order, each with its own inner map. */
+  groups(): IterableIterator<[string, Map<string, Value>]> {
+    return this.#outer.entries();
+  }
+}

--- a/packages/brain/src/observation-inbox.ts
+++ b/packages/brain/src/observation-inbox.ts
@@ -2,9 +2,9 @@ import type { Session, SessionIdentity } from "@sidecar/session";
 import {
   ACT_RESULT_STATUS,
   type ActResultStatus,
+  isInstant,
   isRecord,
   isWireBoolean,
-  isWireNumber,
   isWireString,
   type UnparsedWireValue,
   type WireRecord,
@@ -53,10 +53,6 @@ function isWakeKind(value: UnparsedWireValue): value is BrainWakeKind {
   return isWireString(value) && WAKE_KIND_LIST.includes(value as BrainWakeKind);
 }
 
-function instant(value: UnparsedWireValue): value is number {
-  return isWireNumber(value) && Number.isFinite(value) && value >= 0;
-}
-
 const ACT_RESULT_STATUS_LIST: readonly ActResultStatus[] = Object.values(ACT_RESULT_STATUS);
 
 function isActResultStatus(value: UnparsedWireValue): value is ActResultStatus {
@@ -78,7 +74,7 @@ export function brainObservationEntryFromWire(
   if (!isRecord(value)) return undefined;
   if (!isWireString(value.id) || value.id.length === 0 || !isWakeKind(value.kind)) return undefined;
   if (!isWireString(value.providerId) || !isWireString(value.providerSessionId)) return undefined;
-  if (!instant(value.atMs) || !instant(value.capturedAt)) return undefined;
+  if (!isInstant(value.atMs) || !isInstant(value.capturedAt)) return undefined;
   if (value.hookEvent !== undefined && !isWireString(value.hookEvent)) return undefined;
   if (value.session !== undefined && !isRecord(value.session)) return undefined;
   if (value.cursor !== undefined && !isWireString(value.cursor)) return undefined;
@@ -159,13 +155,31 @@ export function eventFromEntry(entry: BrainObservationEntry): BrainWakeEvent {
   };
 }
 
-/** Whether an entry already stands for the same observation: the same hook for the same session at the same instant. */
-export function sameObservation(entry: BrainObservationEntry, event: BrainWakeEvent): boolean {
+/** What makes two observations the same one: the same hook for the same session at the same instant. */
+export interface ObservationMark {
+  readonly kind: BrainWakeKind;
+  readonly hookEvent?: string;
+  readonly atMs: number;
+  readonly identity: SessionIdentity;
+}
+
+/** An inbox entry's mark; the entry keeps the session identity as two flat fields. */
+export function entryMark(entry: BrainObservationEntry): ObservationMark {
+  return {
+    kind: entry.kind,
+    hookEvent: entry.hookEvent,
+    atMs: entry.atMs,
+    identity: { providerId: entry.providerId, providerSessionId: entry.providerSessionId },
+  };
+}
+
+/** Whether two observations are the one observation, so a hook delivered twice is captured once. */
+export function sameObservation(first: ObservationMark, second: ObservationMark): boolean {
   return (
-    entry.kind === event.kind &&
-    entry.hookEvent === event.hookEvent &&
-    entry.atMs === event.atMs &&
-    entry.providerId === event.identity.providerId &&
-    entry.providerSessionId === event.identity.providerSessionId
+    first.kind === second.kind &&
+    first.hookEvent === second.hookEvent &&
+    first.atMs === second.atMs &&
+    first.identity.providerId === second.identity.providerId &&
+    first.identity.providerSessionId === second.identity.providerSessionId
   );
 }

--- a/packages/brain/src/openai-model-adapter.ts
+++ b/packages/brain/src/openai-model-adapter.ts
@@ -5,19 +5,23 @@ import {
   REASONING_EFFORT,
   type ReasoningEffort,
 } from "@sidecar/runtime-contracts";
-import { positiveInteger, text, type WireRecord } from "@sidecar/wire";
+import {
+  type CloudFetch,
+  HTTP_STATUS,
+  positiveInteger,
+  text,
+  type WireRecord,
+  withoutTrailingSlash,
+} from "@sidecar/wire";
 import { COMPACTION_POLICY } from "./compaction.js";
 import {
   BRAIN_MAXIMUM_OUTPUT_TOKENS,
   BRAIN_REQUEST_TIMEOUT_MS,
-  type FetchLike,
   failed,
-  HTTP_STATUS,
   RETRY_AFTER_HEADER,
   rateLimitWaitMs,
   requestFault,
   requestSignal,
-  withoutTrailingSlash,
 } from "./model-adapter-shared.js";
 import {
   BRAIN_RESPONSES_COMPACT_PATH,
@@ -72,7 +76,7 @@ export interface OpenAiModelAdapterOptions {
   model?: string;
   baseUrl?: string;
   reasoningEffort?: ReasoningEffort;
-  fetch?: FetchLike;
+  fetch?: CloudFetch;
   now?: () => number;
   requestTimeoutMs?: number;
   report?: (message: string) => void;
@@ -93,7 +97,7 @@ class OpenAiTransport implements ResponsesTransport<undefined> {
   readonly #apiKey: string;
   readonly #baseUrl: string;
   readonly #reasoningEffort: ReasoningEffort;
-  readonly #fetch: FetchLike;
+  readonly #fetch: CloudFetch;
   readonly #now: () => number;
   readonly #requestTimeoutMs: number;
 

--- a/packages/brain/src/responses-model-adapter.ts
+++ b/packages/brain/src/responses-model-adapter.ts
@@ -9,14 +9,8 @@ import {
   type ModelResponse,
   type ModelTokenCount,
 } from "@sidecar/runtime-contracts";
-import type { UnparsedWireValue, WireRecord } from "@sidecar/wire";
-import {
-  type Failure,
-  HTTP_STATUS,
-  type Normalized,
-  payloadOf,
-  throttled,
-} from "./model-adapter-shared.js";
+import { HTTP_STATUS, type UnparsedWireValue, type WireRecord } from "@sidecar/wire";
+import { type Failure, type Normalized, payloadOf, throttled } from "./model-adapter-shared.js";
 import { RESPONSES_ITEM_FORMAT } from "./responses-api.js";
 import { TOOL_LOOP_RUNTIME } from "./runtime.js";
 

--- a/packages/brain/src/runtime.ts
+++ b/packages/brain/src/runtime.ts
@@ -25,10 +25,11 @@ import {
   type ToolInvocation,
   type ToolResult,
 } from "@sidecar/runtime-contracts";
-import { ACT_RESULT_STATUS, isRecord, isWireString, type UnparsedWireValue } from "@sidecar/wire";
+import { ACT_RESULT_STATUS } from "@sidecar/wire";
 import { compactContext } from "./compaction.js";
 import { LOOP_GUARD_LEVEL, LoopGuard, type LoopGuardConfig } from "./loop-guard.js";
 import { settledUnlessAborted } from "./settled.js";
+import { outputStatus } from "./tool-results.js";
 
 /**
  * The loop between a model and its tools, and nothing outside it. A run
@@ -83,16 +84,6 @@ interface EndSignal {
 
 export function incompleteDetail(incomplete: ModelIncomplete): string {
   return `${incomplete.status ?? "incomplete"}: ${incomplete.reason}`;
-}
-
-function resultStatus(outputJson: string): string | undefined {
-  try {
-    // SAFETY: JSON.parse returns a wire value; the record and string checks are the validation.
-    const parsed = JSON.parse(outputJson) as UnparsedWireValue;
-    return isRecord(parsed) && isWireString(parsed.status) ? parsed.status : undefined;
-  } catch {
-    return undefined;
-  }
 }
 
 export class ToolLoopAgentRuntime implements AgentRuntime {
@@ -392,7 +383,7 @@ export class ToolLoopAgentRuntime implements AgentRuntime {
         status: TOOL_DID_NOT_ANSWER.status,
       };
     }
-    const status = result.status ?? resultStatus(result.outputJson);
+    const status = result.status ?? outputStatus(result.outputJson);
     return status !== undefined ? { outputJson: result.outputJson, status } : result;
   }
 }

--- a/packages/brain/src/state-store.ts
+++ b/packages/brain/src/state-store.ts
@@ -1,5 +1,11 @@
 import { checkpointFormatFromTag, type TranscriptEvent } from "@sidecar/runtime-contracts";
-import { isRecord, isWireNumber, isWireString, type UnparsedWireValue } from "@sidecar/wire";
+import {
+  isInstant,
+  isRecord,
+  isWireNumber,
+  isWireString,
+  type UnparsedWireValue,
+} from "@sidecar/wire";
 import { type BrainJournalEntry, brainJournalEntryFromWire } from "./journal.js";
 import { type BrainObservationEntry, brainObservationEntryFromWire } from "./observation-inbox.js";
 import {
@@ -117,7 +123,7 @@ export function brainPersistedStateFromWire(
 ): BrainPersistedState | undefined {
   if (!isRecord(value) || value.version !== BRAIN_STATE_VERSION) return undefined;
   if (!isWireString(value.generationId) || value.generationId.length === 0) return undefined;
-  if (!instant(value.createdAt) || !instant(value.expiresAt)) return undefined;
+  if (!isInstant(value.createdAt) || !isInstant(value.expiresAt)) return undefined;
   // The lifetime is the build's, not the file's: an envelope claiming any
   // other span was not written by this rule and is not given one now.
   if (value.expiresAt - value.createdAt !== BRAIN_GENERATION_LIFETIME_MS) return undefined;
@@ -213,14 +219,10 @@ function checkpointFormatTagFromWire(value: UnparsedWireValue): string | undefin
 /** The marker as stored, nothing when absent, and null when present but unreadable. */
 function resetMarkerFromWire(value: UnparsedWireValue): BrainResetMarker | undefined | null {
   if (value === undefined) return undefined;
-  if (!isRecord(value) || !instant(value.clearedAt)) return null;
+  if (!isRecord(value) || !isInstant(value.clearedAt)) return null;
   if (value.generationId === undefined) return { clearedAt: value.clearedAt };
   if (!isWireString(value.generationId) || value.generationId.length === 0) return null;
   return { clearedAt: value.clearedAt, generationId: value.generationId };
-}
-
-function instant(value: UnparsedWireValue): value is number {
-  return isWireNumber(value) && Number.isFinite(value) && value >= 0;
 }
 
 /** The record the state persists as. */

--- a/packages/brain/src/tool-executor.ts
+++ b/packages/brain/src/tool-executor.ts
@@ -26,7 +26,6 @@ import {
   type ToolExecutionContext,
   type ToolExecutor,
   type ToolInvocation,
-  type ToolResult,
 } from "@sidecar/runtime-contracts";
 import type { SessionIdentity } from "@sidecar/session";
 import {
@@ -46,6 +45,7 @@ import {
 } from "./input-items.js";
 import { UNCONFIRMED_ACT_RESULT, UNKNOWN_ACT_RESULT } from "./journal.js";
 import type { BrainActExecution, BrainActPerformer, BrainRoster } from "./performer.js";
+import { answer } from "./tool-results.js";
 import {
   BRAIN_TOOL,
   isBrainOnlyTool,
@@ -190,11 +190,6 @@ export function refusalForPolicy(
     return rejection(REFUSAL_REASON.ANNOUNCE_IN_ASK);
   }
   return rejection(REFUSAL_REASON.NOT_ALLOWED);
-}
-
-function answer(output: WireRecord): ToolResult {
-  const status = text(output.status);
-  return { outputJson: JSON.stringify(output), ...(status ? { status } : undefined) };
 }
 
 /**

--- a/packages/brain/src/tool-results.ts
+++ b/packages/brain/src/tool-results.ts
@@ -1,0 +1,29 @@
+import type { ToolResult } from "@sidecar/runtime-contracts";
+import {
+  isRecord,
+  isWireString,
+  text,
+  type UnparsedWireValue,
+  type WireRecord,
+} from "@sidecar/wire";
+
+/**
+ * A tool's output as the runtime carries it: the record serialized, with the
+ * status lifted beside it so the journal and the loop can read what became of
+ * an act without parsing the body again.
+ */
+export function answer(output: WireRecord): ToolResult {
+  const status = text(output.status);
+  return { outputJson: JSON.stringify(output), ...(status ? { status } : undefined) };
+}
+
+/** The status a serialized tool output carries, for a reader holding only the JSON. */
+export function outputStatus(outputJson: string): string | undefined {
+  try {
+    // SAFETY: JSON.parse returns a wire value; the record and string guards are the validation.
+    const parsed = JSON.parse(outputJson) as UnparsedWireValue;
+    return isRecord(parsed) && isWireString(parsed.status) ? parsed.status : undefined;
+  } catch {
+    return undefined;
+  }
+}

--- a/packages/brain/src/transcript-reads.ts
+++ b/packages/brain/src/transcript-reads.ts
@@ -1,16 +1,14 @@
-import type {
-  ProviderTranscriptResult,
-  ProviderTranscriptSinceResult,
-  SessionIdentity,
+import {
+  OMISSION_MARKER,
+  type ProviderTranscriptResult,
+  type ProviderTranscriptSinceResult,
+  type SessionIdentity,
 } from "@sidecar/session";
 import { ACT_RESULT_STATUS, type WireRecord } from "@sidecar/wire";
 import { rejection, sameIdentity } from "./generation.js";
 import { type Settled, settledUnlessAborted } from "./settled.js";
 import { REFUSAL_REASON } from "./turn.js";
 import type { BrainTranscriptDelta, BrainWakeEvent } from "./wake-events.js";
-
-/** Stands where the front of a transcript was cut, so the model knows it is reading a tail. */
-export const OMISSION_MARKER = "[… earlier transcript omitted …]";
 
 /** A transcript held to a bound from the front, and whether anything was cut. */
 export interface FrontCut {

--- a/packages/calendar/src/reader.ts
+++ b/packages/calendar/src/reader.ts
@@ -4,6 +4,7 @@ import {
   type MeetingInterval,
   meetingsFromBusyIntervals,
 } from "@sidecar/calendar";
+import { ACCESS_TOKEN_EXPIRY_SLACK_MS } from "@sidecar/credentials";
 import {
   isRecord,
   isWireNumber,
@@ -33,9 +34,6 @@ const GOOGLE_CALENDAR_LIST_URL = "https://www.googleapis.com/calendar/v3/users/m
 const GOOGLE_FREEBUSY_URL = "https://www.googleapis.com/calendar/v3/freeBusy";
 
 const REQUEST_TIMEOUT_MS = 10_000;
-
-/** Refreshed a minute early, so a pass never rides a token mid-expiry. */
-const ACCESS_TOKEN_EXPIRY_SLACK_MS = 60_000;
 
 // The list bounds, exported because the Apple reader keeps them too: the two
 // sources' calendars land on the same settings rows, which must not learn to

--- a/packages/credentials/src/expiry.ts
+++ b/packages/credentials/src/expiry.ts
@@ -1,0 +1,6 @@
+/**
+ * How early a stored grant counts as expired. A refresh a minute ahead of the
+ * stamp means no pass rides a token across its own expiry, which would spend a
+ * consumed refresh token to recover from a failure that never had to happen.
+ */
+export const ACCESS_TOKEN_EXPIRY_SLACK_MS = 60_000;

--- a/packages/credentials/src/index.ts
+++ b/packages/credentials/src/index.ts
@@ -12,6 +12,7 @@ export {
   VOICE_CREDENTIAL_PROVIDER,
   VOICE_CREDENTIAL_PROVIDER_ID,
 } from "./credential-providers.js";
+export { ACCESS_TOKEN_EXPIRY_SLACK_MS } from "./expiry.js";
 export {
   accountLoopbackPage,
   LOOPBACK_CONNECTION_SOURCE,

--- a/packages/feedback/src/delivery.ts
+++ b/packages/feedback/src/delivery.ts
@@ -1,3 +1,4 @@
+import { type CloudFetch, text } from "@sidecar/wire";
 import type { FeedbackResult, FeedbackSubmission } from "./submission.js";
 
 const FEEDBACK_ENVIRONMENT = {
@@ -23,17 +24,10 @@ const FEEDBACK_REFUSAL = {
   REFUSED: "The feedback service could not take this right now. Try again in a moment.",
 } as const;
 
-type FetchLike = (input: string, init: RequestInit) => Promise<Response>;
-
 export interface FeedbackDeliveryOptions {
   url?: string;
-  fetch?: FetchLike;
+  fetch?: CloudFetch;
   requestTimeoutMs?: number;
-}
-
-function trimmedText(value: string | undefined): string | undefined {
-  const normalized = value?.trim();
-  return normalized || undefined;
 }
 
 /**
@@ -45,11 +39,11 @@ function trimmedText(value: string | undefined): string | undefined {
  */
 export class FeedbackDelivery {
   readonly #url: string;
-  readonly #fetch: FetchLike;
+  readonly #fetch: CloudFetch;
   readonly #requestTimeoutMs: number;
 
   constructor(options: FeedbackDeliveryOptions = {}) {
-    this.#url = trimmedText(options.url) ?? FEEDBACK_DEFAULTS.URL;
+    this.#url = text(options.url) ?? FEEDBACK_DEFAULTS.URL;
     this.#fetch = options.fetch ?? ((input, init) => fetch(input, init));
     this.#requestTimeoutMs = options.requestTimeoutMs ?? FEEDBACK_DEFAULTS.REQUEST_TIMEOUT_MS;
   }
@@ -90,7 +84,7 @@ export class FeedbackDelivery {
 export function feedbackDeliveryFromEnvironment(
   options: FeedbackDeliveryOptions = {},
 ): FeedbackDelivery {
-  const url = trimmedText(options.url) ?? trimmedText(process.env[FEEDBACK_ENVIRONMENT.URL]);
+  const url = text(options.url) ?? text(process.env[FEEDBACK_ENVIRONMENT.URL]);
   const deliveryOptions = url ? { ...options, url } : options;
   return new FeedbackDelivery(deliveryOptions);
 }

--- a/packages/memory/src/defaults.ts
+++ b/packages/memory/src/defaults.ts
@@ -1,4 +1,11 @@
 /**
+ * How many characters stand for a token where no real count is at hand. The
+ * pinned OpenClaw uses it both to cut a chunk and to size a context, so one
+ * number answers for both rather than two that could drift apart.
+ */
+export const ESTIMATED_CHARS_PER_TOKEN = 4;
+
+/**
  * The retrieval defaults, pinned to OpenClaw `b7528507`
  * (`src/agents/memory-search.ts`). Changing one of these is a deliberate
  * change to the parity fixture, not a tuning an implementer makes alone.
@@ -18,7 +25,7 @@ export const MEMORY_SEARCH_DEFAULTS = {
   TEMPORAL_DECAY_HALF_LIFE_DAYS: 30,
   EMBEDDING_CACHE_MAXIMUM_ENTRIES: 50_000,
   /** The pinned source estimates four characters per token when it cuts a chunk. */
-  CHARS_PER_TOKEN_ESTIMATE: 4,
+  CHARS_PER_TOKEN_ESTIMATE: ESTIMATED_CHARS_PER_TOKEN,
 } as const;
 
 /**

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -29,6 +29,7 @@ export {
   type VectorHit,
 } from "./contracts.js";
 export {
+  ESTIMATED_CHARS_PER_TOKEN,
   MEMORY_QUERY_MAXIMUM_CHARS,
   MEMORY_SEARCH_DEFAULTS,
   RETRIEVAL_MODE,

--- a/packages/providers/src/claude-code/transcript.test.ts
+++ b/packages/providers/src/claude-code/transcript.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test, { type TestContext } from "node:test";
+import { OMISSION_MARKER } from "@sidecar/session";
 import type { ParsedJsonObject } from "@sidecar/wire/testing";
 import { ClaudeCodeSessionAdapter } from "./adapter.js";
 
@@ -101,8 +102,8 @@ test("keeps the newest turns when the rendering is cut, and says so", async (t) 
   });
 
   assert.ok(rendered);
-  assert.ok(rendered.startsWith("[earlier turns omitted]\n"));
-  assert.ok(rendered.length <= 400 + "[earlier turns omitted]\n".length);
+  assert.ok(rendered.startsWith(`${OMISSION_MARKER}\n`));
+  assert.ok(rendered.length <= 400 + OMISSION_MARKER.length + 1);
   assert.ok(rendered.includes("prompt number 39"), "the newest turn survives the cut");
   assert.ok(!rendered.includes("prompt number 0 "), "the oldest turn is what goes");
   // SAFETY: Fixture value matches the narrowed runtime shape this test exercises.
@@ -127,7 +128,7 @@ test("renders every line uncut when no rendered length is asked for", async (t) 
 
   assert.ok(rendered);
   assert.ok(rendered.length > 8_000, "the old whole-rendering cap no longer applies");
-  assert.ok(!rendered.includes("[earlier turns omitted]"));
+  assert.ok(!rendered.includes(OMISSION_MARKER));
   assert.equal(rendered.split("\n").length, 400);
   assert.ok(rendered.startsWith("Developer: prompt number 0 "));
   assert.ok(rendered.includes("prompt number 399"));

--- a/packages/providers/src/codex/cloud-adapter.test.ts
+++ b/packages/providers/src/codex/cloud-adapter.test.ts
@@ -6,6 +6,7 @@ import {
   CLI_CONNECTION,
   SESSION_LOCATION,
   SESSION_STATUS,
+  UNSUPPORTED_BY_OBSERVATION,
 } from "@sidecar/session";
 import type { JsonObject } from "@sidecar/wire/testing";
 import {
@@ -435,7 +436,7 @@ test("refuses a creation the latest pass did not offer or cannot honour", async 
   // An environment the pass never reported names nowhere a creation could go.
   assert.deepEqual(await adapter.createWorkspace({ providerProjectId: "env-9", task: "Fix it" }), {
     status: "unsupported",
-    reason: "That act is not supported by the latest observation.",
+    reason: UNSUPPORTED_BY_OBSERVATION,
   });
   // Codex names tasks itself, so a chosen name is refused rather than dropped.
   const named = await adapter.createWorkspace({

--- a/packages/providers/src/codex/cloud-adapter.ts
+++ b/packages/providers/src/codex/cloud-adapter.ts
@@ -7,6 +7,7 @@ import {
   type SessionDiffSummary,
   type SessionStatus,
   sessionMessageText,
+  UNSUPPORTED_BY_OBSERVATION,
   WORKSPACE_TASK_SUPPORT,
   type WorkspaceProject,
 } from "@sidecar/session";
@@ -231,7 +232,7 @@ export class CodexCloudSessionAdapter extends CliSessionAdapter {
     if (!project)
       return {
         status: ACT_RESULT_STATUS.UNSUPPORTED,
-        reason: "That act is not supported by the latest observation.",
+        reason: UNSUPPORTED_BY_OBSERVATION,
       };
 
     // Codex names tasks itself from the prompt; a name the user typed has

--- a/packages/providers/src/conductor/adapter.test.ts
+++ b/packages/providers/src/conductor/adapter.test.ts
@@ -6,6 +6,7 @@ import {
   advertisedActFor,
   advertisedControls,
   SESSION_STATUS,
+  UNSUPPORTED_BY_OBSERVATION,
 } from "@sidecar/session";
 import type { JsonObject, JsonValue } from "@sidecar/wire/testing";
 import { HTTP_STATUS, jsonResponse, recordingFetch } from "@sidecar/wire/testing";
@@ -1810,7 +1811,7 @@ test("refuses to archive a workspace no row advertised, before any request exist
 
   assert.deepEqual(result, {
     status: "unsupported",
-    reason: "That act is not supported by the latest observation.",
+    reason: UNSUPPORTED_BY_OBSERVATION,
   });
   assert.equal(api.requests.length, requestsBefore);
 });
@@ -1912,7 +1913,7 @@ test("refuses a chat rename for a session no pass observed, before any request e
 
   assert.deepEqual(result, {
     status: "unsupported",
-    reason: "That act is not supported by the latest observation.",
+    reason: UNSUPPORTED_BY_OBSERVATION,
   });
   assert.equal(api.requests.length, requestsBefore);
 });
@@ -1943,7 +1944,7 @@ test("refuses a rename for a session no pass observed, before any request exists
 
   assert.deepEqual(result, {
     status: "unsupported",
-    reason: "That act is not supported by the latest observation.",
+    reason: UNSUPPORTED_BY_OBSERVATION,
   });
   assert.equal(api.requests.length, requestsBefore);
 });
@@ -2131,7 +2132,7 @@ test("refuses a creation ask for a project the last pass did not list", async ()
   // No request exists for a project observation did not see.
   assert.deepEqual(unlisted, {
     status: "unsupported",
-    reason: "That act is not supported by the latest observation.",
+    reason: UNSUPPORTED_BY_OBSERVATION,
   });
   assert.equal(api.requests.length, requestsBefore);
 
@@ -2342,11 +2343,11 @@ test("refuses to start an agent the row never listed, before any request exists"
 
   assert.deepEqual(unlisted, {
     status: "unsupported",
-    reason: "That act is not supported by the latest observation.",
+    reason: UNSUPPORTED_BY_OBSERVATION,
   });
   assert.deepEqual(unobserved, {
     status: "unsupported",
-    reason: "That act is not supported by the latest observation.",
+    reason: UNSUPPORTED_BY_OBSERVATION,
   });
   assert.equal(api.requests.length, requestsBefore);
 });
@@ -2613,7 +2614,7 @@ test("refuses a conversation read for anything the latest pass did not stand beh
 
   assert.deepEqual(unobserved, {
     status: "unsupported",
-    reason: "That act is not supported by the latest observation.",
+    reason: UNSUPPORTED_BY_OBSERVATION,
   });
   assert.deepEqual(badCursor, {
     status: "rejected",

--- a/packages/providers/src/conductor/adapter.ts
+++ b/packages/providers/src/conductor/adapter.ts
@@ -21,6 +21,7 @@ import {
   SESSION_STATUS,
   type SessionProvider,
   type SessionStatus,
+  UNSUPPORTED_BY_OBSERVATION,
   WORKSPACE_TASK_SUPPORT,
   type WorkspaceAgentSelection,
   type WorkspaceProject,
@@ -940,7 +941,7 @@ export class ConductorSessionAdapter extends CloudSessionAdapter {
     if (!observation) {
       return {
         status: ACT_RESULT_STATUS.UNSUPPORTED,
-        reason: "That act is not supported by the latest observation.",
+        reason: UNSUPPORTED_BY_OBSERVATION,
       };
     }
     // Only ids that are actually UUIDs may enter the request path — the same

--- a/packages/providers/src/conductor/local-workspace-adapter.ts
+++ b/packages/providers/src/conductor/local-workspace-adapter.ts
@@ -6,6 +6,7 @@ import {
   type ProviderWorkspaceRequest,
   type ProviderWorkspaceResult,
   SessionProviderAdapterBase,
+  UNSUPPORTED_BY_OBSERVATION,
   WORKSPACE_TASK_SUPPORT,
   type WorkspaceProject,
 } from "@sidecar/session";
@@ -244,7 +245,7 @@ export class ConductorLocalWorkspaceAdapter extends SessionProviderAdapterBase {
     if (!rootPath)
       return {
         status: ACT_RESULT_STATUS.UNSUPPORTED,
-        reason: "That act is not supported by the latest observation.",
+        reason: UNSUPPORTED_BY_OBSERVATION,
       };
     const link = conductorCreateWorkspaceLink(rootPath, request.task);
     try {

--- a/packages/providers/src/omp/transcript.test.ts
+++ b/packages/providers/src/omp/transcript.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test, { type TestContext } from "node:test";
+import { OMISSION_MARKER } from "@sidecar/session";
 import type { ParsedJsonObject } from "@sidecar/wire/testing";
 import { OmpSessionAdapter } from "./adapter.js";
 import { OMP_SESSIONS_DIRECTORY } from "./records.js";
@@ -164,7 +165,7 @@ test("keeps the newest turns when the rendering outgrows its bound", async (t) =
     maximumRenderedLength: 80,
   });
 
-  assert.ok(rendered?.startsWith("[earlier turns omitted]"));
+  assert.ok(rendered?.startsWith(OMISSION_MARKER));
   assert.ok(rendered?.endsWith("OMP: Fixed; the test passes now."));
 });
 

--- a/packages/providers/src/shared/cloud-session-adapter.test.ts
+++ b/packages/providers/src/shared/cloud-session-adapter.test.ts
@@ -9,6 +9,7 @@ import {
   type ProviderSessionObservation,
   SESSION_LOCATION,
   SESSION_STATUS,
+  UNSUPPORTED_BY_OBSERVATION,
 } from "@sidecar/session";
 import { isWireString } from "@sidecar/wire";
 import { HTTP_STATUS, jsonResponse, recordingFetch } from "@sidecar/wire/testing";
@@ -159,7 +160,7 @@ test("answers unsupported explicitly when no observed route exists", async () =>
   for (const adapter of [stub, observer]) {
     assert.deepEqual(await adapter.sendMessage({ providerSessionId: "missing", text: "hello" }), {
       status: ACT_RESULT_STATUS.UNSUPPORTED,
-      reason: "That act is not supported by the latest observation.",
+      reason: UNSUPPORTED_BY_OBSERVATION,
     });
     assert.deepEqual(adapter.workspaceProjects(), []);
   }
@@ -530,11 +531,11 @@ test("refuses a message for any session that did not advertise taking one", asyn
   // been promised nothing, and no request should exist to find that out.
   assert.deepEqual(unadvertised, {
     status: "unsupported",
-    reason: "That act is not supported by the latest observation.",
+    reason: UNSUPPORTED_BY_OBSERVATION,
   });
   assert.deepEqual(unobserved, {
     status: "unsupported",
-    reason: "That act is not supported by the latest observation.",
+    reason: UNSUPPORTED_BY_OBSERVATION,
   });
   assert.equal(stub.requests.length, observationRequests);
 });
@@ -721,11 +722,11 @@ test("runs an advertised control through its documented route, sending no body",
   assert.equal(write?.body, undefined);
   assert.deepEqual(unadvertised, {
     status: "unsupported",
-    reason: "That act is not supported by the latest observation.",
+    reason: UNSUPPORTED_BY_OBSERVATION,
   });
   assert.deepEqual(unknown, {
     status: "unsupported",
-    reason: "That act is not supported by the latest observation.",
+    reason: UNSUPPORTED_BY_OBSERVATION,
   });
   assert.equal(stub.requests.length, observationRequests + 1);
 });

--- a/packages/providers/src/shared/cloud-session-adapter.ts
+++ b/packages/providers/src/shared/cloud-session-adapter.ts
@@ -20,6 +20,7 @@ import {
   SessionProviderAdapterBase,
   sessionMessageText,
   UNKNOWN_WORKSPACE_LABEL,
+  UNSUPPORTED_BY_OBSERVATION,
   WORKSPACE_TASK_SUPPORT,
   type WorkspaceAgentSelection,
   type WorkspaceProject,
@@ -389,7 +390,7 @@ export abstract class CloudSessionAdapter extends SessionProviderAdapterBase {
     if (!observation || !advertisedActFor(observation, ACT_KIND.MESSAGE)) {
       return {
         status: ACT_RESULT_STATUS.UNSUPPORTED,
-        reason: "That act is not supported by the latest observation.",
+        reason: UNSUPPORTED_BY_OBSERVATION,
       };
     }
 
@@ -413,7 +414,7 @@ export abstract class CloudSessionAdapter extends SessionProviderAdapterBase {
     if (!route)
       return {
         status: ACT_RESULT_STATUS.UNSUPPORTED,
-        reason: "That act is not supported by the latest observation.",
+        reason: UNSUPPORTED_BY_OBSERVATION,
       };
     return this.#postWrite(apiKey, route);
   }
@@ -443,7 +444,7 @@ export abstract class CloudSessionAdapter extends SessionProviderAdapterBase {
     if (!advertised)
       return {
         status: ACT_RESULT_STATUS.UNSUPPORTED,
-        reason: "That act is not supported by the latest observation.",
+        reason: UNSUPPORTED_BY_OBSERVATION,
       };
 
     const apiKey = await this.#readApiKey().catch(() => undefined);
@@ -453,7 +454,7 @@ export abstract class CloudSessionAdapter extends SessionProviderAdapterBase {
     if (!route)
       return {
         status: ACT_RESULT_STATUS.UNSUPPORTED,
-        reason: "That act is not supported by the latest observation.",
+        reason: UNSUPPORTED_BY_OBSERVATION,
       };
     return this.#postWrite(apiKey, route);
   }
@@ -474,7 +475,7 @@ export abstract class CloudSessionAdapter extends SessionProviderAdapterBase {
     if (!observation)
       return {
         status: ACT_RESULT_STATUS.UNSUPPORTED,
-        reason: "That act is not supported by the latest observation.",
+        reason: UNSUPPORTED_BY_OBSERVATION,
       };
     // The advertised list — not the caller's word — is what the route is
     // built from, so an agent kind is only ever one the last pass promised.
@@ -483,7 +484,7 @@ export abstract class CloudSessionAdapter extends SessionProviderAdapterBase {
     if (!agent)
       return {
         status: ACT_RESULT_STATUS.UNSUPPORTED,
-        reason: "That act is not supported by the latest observation.",
+        reason: UNSUPPORTED_BY_OBSERVATION,
       };
 
     const name = request.name === undefined ? undefined : workspaceNameText(request.name);
@@ -513,7 +514,7 @@ export abstract class CloudSessionAdapter extends SessionProviderAdapterBase {
     if (!route)
       return {
         status: ACT_RESULT_STATUS.UNSUPPORTED,
-        reason: "That act is not supported by the latest observation.",
+        reason: UNSUPPORTED_BY_OBSERVATION,
       };
 
     const apiKey = await this.#readApiKey().catch(() => undefined);
@@ -557,7 +558,7 @@ export abstract class CloudSessionAdapter extends SessionProviderAdapterBase {
     if (!renameWorkspace)
       return {
         status: ACT_RESULT_STATUS.UNSUPPORTED,
-        reason: "That act is not supported by the latest observation.",
+        reason: UNSUPPORTED_BY_OBSERVATION,
       };
 
     const name = workspaceNameText(request.name);
@@ -576,7 +577,7 @@ export abstract class CloudSessionAdapter extends SessionProviderAdapterBase {
     if (!route)
       return {
         status: ACT_RESULT_STATUS.UNSUPPORTED,
-        reason: "That act is not supported by the latest observation.",
+        reason: UNSUPPORTED_BY_OBSERVATION,
       };
 
     const apiKey = await this.#readApiKey().catch(() => undefined);
@@ -613,7 +614,7 @@ export abstract class CloudSessionAdapter extends SessionProviderAdapterBase {
     if (!observation || !advertisedActFor(observation, ACT_KIND.RENAME_SESSION))
       return {
         status: ACT_RESULT_STATUS.UNSUPPORTED,
-        reason: "That act is not supported by the latest observation.",
+        reason: UNSUPPORTED_BY_OBSERVATION,
       };
 
     const name = workspaceNameText(request.name);
@@ -628,7 +629,7 @@ export abstract class CloudSessionAdapter extends SessionProviderAdapterBase {
     if (!route)
       return {
         status: ACT_RESULT_STATUS.UNSUPPORTED,
-        reason: "That act is not supported by the latest observation.",
+        reason: UNSUPPORTED_BY_OBSERVATION,
       };
 
     const apiKey = await this.#readApiKey().catch(() => undefined);
@@ -668,7 +669,7 @@ export abstract class CloudSessionAdapter extends SessionProviderAdapterBase {
     if (!project)
       return {
         status: ACT_RESULT_STATUS.UNSUPPORTED,
-        reason: "That act is not supported by the latest observation.",
+        reason: UNSUPPORTED_BY_OBSERVATION,
       };
 
     const name = request.name === undefined ? undefined : workspaceNameText(request.name);
@@ -709,7 +710,7 @@ export abstract class CloudSessionAdapter extends SessionProviderAdapterBase {
     if (!route)
       return {
         status: ACT_RESULT_STATUS.UNSUPPORTED,
-        reason: "That act is not supported by the latest observation.",
+        reason: UNSUPPORTED_BY_OBSERVATION,
       };
     const created = await this.#postWriteDetailed(apiKey, route, WRITE_SUBJECT.PROJECT);
     if (created.outcome.status !== ACT_RESULT_STATUS.ACCEPTED) {

--- a/packages/providers/src/shared/local-session-adapter.ts
+++ b/packages/providers/src/shared/local-session-adapter.ts
@@ -16,6 +16,7 @@ import {
   type SessionStatus,
   sessionMessageText,
   UNKNOWN_WORKSPACE_LABEL,
+  UNSUPPORTED_BY_OBSERVATION,
 } from "@sidecar/session";
 import { recordFromJsonLine, resolveOptions, type WireRecord } from "@sidecar/wire";
 
@@ -228,7 +229,7 @@ export abstract class LocalSessionAdapter extends SessionProviderAdapterBase {
     if (!observation || !advertisedActFor(observation, ACT_KIND.MESSAGE)) {
       return {
         status: ACT_RESULT_STATUS.UNSUPPORTED,
-        reason: "That act is not supported by the latest observation.",
+        reason: UNSUPPORTED_BY_OBSERVATION,
       };
     }
     const text = sessionMessageText(message.text);

--- a/packages/providers/src/shared/local-transcript.ts
+++ b/packages/providers/src/shared/local-transcript.ts
@@ -9,7 +9,7 @@
  * a reader sees the whole rendering the tail it read produces.
  */
 
-import { transcriptReadTailBytes } from "@sidecar/session";
+import { OMISSION_MARKER, transcriptReadTailBytes } from "@sidecar/session";
 import { isRecord, isWireString, recordFromJsonLine, text, type WireRecord } from "@sidecar/wire";
 import { type FileWindow, fileStats, readRange, readTailWindow } from "./local-session-adapter.js";
 
@@ -29,8 +29,6 @@ export const TRANSCRIPT_BOUNDS = {
   /** A rendered tool call or its result: the gist, never the payload. */
   MAXIMUM_TOOL_LENGTH: 200,
 } as const;
-
-export const OMISSION_MARKER = "[earlier turns omitted]";
 
 export function transcriptContentBlocks(
   record: WireRecord,

--- a/packages/realtime/src/introduction.ts
+++ b/packages/realtime/src/introduction.ts
@@ -1,5 +1,5 @@
 import { LUKE_PERSONA } from "@sidecar/guide";
-import type { WireRecord } from "@sidecar/wire";
+import { text, type WireRecord } from "@sidecar/wire";
 import { type RealtimeSessionOptions, realtimeSessionConfig } from "./realtime-credentials.js";
 import { REALTIME_CLIENT_EVENT } from "./realtime-protocol.js";
 
@@ -86,11 +86,6 @@ export interface IntroductionLine {
  */
 const maximumIntroductionDataLength = 1_000;
 
-function trimmedText(value: string | undefined): string | undefined {
-  const normalized = value?.trim();
-  return normalized || undefined;
-}
-
 /**
  * Builds the events that speak one introduction beat.
  *
@@ -102,20 +97,20 @@ function trimmedText(value: string | undefined): string | undefined {
  * declares no tools, so a scripted beat can never become an act.
  */
 export function introductionSpeechEvents(line: IntroductionLine): readonly WireRecord[] {
-  const direction = trimmedText(line.direction);
+  const direction = text(line.direction);
   if (!direction) return [];
   const data = (line.data ?? [])
-    .map((value) => trimmedText(value.replace(/\s+/g, " ")))
+    .map((value) => text(value.replace(/\s+/g, " ")))
     .filter((value): value is string => value !== undefined)
     .join("\n")
     .slice(0, maximumIntroductionDataLength);
-  const text = data
+  const content = data
     ? `[introduction line]\n${direction}\n[data]\n${data}`
     : `[introduction line]\n${direction}`;
   return [
     {
       type: REALTIME_CLIENT_EVENT.CONVERSATION_ITEM_CREATE,
-      item: { type: "message", role: "user", content: [{ type: "input_text", text }] },
+      item: { type: "message", role: "user", content: [{ type: "input_text", text: content }] },
     },
     {
       type: REALTIME_CLIENT_EVENT.RESPONSE_CREATE,

--- a/packages/runtime-contracts/src/children.ts
+++ b/packages/runtime-contracts/src/children.ts
@@ -1,7 +1,7 @@
 import {
+  isInstant,
   isRecord,
   isWireBoolean,
-  isWireNumber,
   isWireString,
   type UnparsedWireValue,
 } from "@sidecar/wire";
@@ -133,12 +133,8 @@ export interface ChildRunRecord {
   readonly archivedAt?: number;
 }
 
-function instant(value: UnparsedWireValue): value is number {
-  return isWireNumber(value) && Number.isFinite(value) && value >= 0;
-}
-
 function optionalInstant(value: UnparsedWireValue): value is number | undefined {
-  return value === undefined || instant(value);
+  return value === undefined || isInstant(value);
 }
 
 function optionalString(value: UnparsedWireValue): value is string | undefined {
@@ -163,7 +159,7 @@ export function childRunRecordFromWire(value: UnparsedWireValue): ChildRunRecord
   }
   if (!isIdentifier(value.childRunId) || !isWireString(value.task)) return undefined;
   if (!optionalString(value.requesterRunId) || !optionalString(value.label)) return undefined;
-  if (!instant(value.depth) || !Number.isInteger(value.depth)) return undefined;
+  if (!isInstant(value.depth) || !Number.isInteger(value.depth)) return undefined;
   if (!optionalString(value.model) || !optionalString(value.contextNote)) return undefined;
   if (!isChildContextMode(value.requestedContext) || !isChildContextMode(value.context)) {
     return undefined;
@@ -172,10 +168,10 @@ export function childRunRecordFromWire(value: UnparsedWireValue): ChildRunRecord
   const allowed = stringList(value.policy.allowed);
   const denied = stringList(value.policy.denied);
   if (!allowed || !denied) return undefined;
-  if (!instant(value.timeoutMs) || !isChildCleanup(value.cleanup)) return undefined;
+  if (!isInstant(value.timeoutMs) || !isChildCleanup(value.cleanup)) return undefined;
   if (!isIdentifier(value.completionDestination)) return undefined;
   if (!isWireBoolean(value.expectsCompletion)) return undefined;
-  if (!isChildRunStatus(value.status) || !instant(value.acceptedAt)) return undefined;
+  if (!isChildRunStatus(value.status) || !isInstant(value.acceptedAt)) return undefined;
   if (!optionalInstant(value.startedAt) || !optionalInstant(value.settledAt)) return undefined;
   if (!optionalInstant(value.archivedAt)) return undefined;
   if (!optionalString(value.resultText) || !optionalString(value.failureDetail)) return undefined;
@@ -283,8 +279,8 @@ export function childCompletionRecordFromWire(
   if (!isIdentifier(value.completionId) || !isIdentifier(value.childId)) return undefined;
   if (!isIdentifier(value.destination) || !isChildRunStatus(value.status)) return undefined;
   if (!optionalString(value.resultText) || !optionalString(value.failureDetail)) return undefined;
-  if (!instant(value.createdAt) || !isCompletionDeliveryStatus(value.delivery)) return undefined;
-  if (!instant(value.attempts) || !Number.isInteger(value.attempts)) return undefined;
+  if (!isInstant(value.createdAt) || !isCompletionDeliveryStatus(value.delivery)) return undefined;
+  if (!isInstant(value.attempts) || !Number.isInteger(value.attempts)) return undefined;
   if (!optionalInstant(value.firstAttemptAt) || !optionalInstant(value.nextAttemptAt)) {
     return undefined;
   }

--- a/packages/runtime-contracts/src/storage.ts
+++ b/packages/runtime-contracts/src/storage.ts
@@ -1,6 +1,6 @@
 import {
+  isInstant,
   isRecord,
-  isWireNumber,
   isWireString,
   type UnparsedWireValue,
   type WireRecord,
@@ -124,20 +124,16 @@ export interface ConversationRecord {
   readonly temporary?: boolean;
 }
 
-function instant(value: UnparsedWireValue): value is number {
-  return isWireNumber(value) && Number.isFinite(value) && value >= 0;
-}
-
 export function conversationRecordFromWire(
   value: UnparsedWireValue,
 ): ConversationRecord | undefined {
   if (!isRecord(value)) return undefined;
   if (!isWireString(value.sessionKey) || value.sessionKey.length === 0) return undefined;
   if (!isConversationKind(value.kind) || !isWireString(value.name)) return undefined;
-  if (!instant(value.createdAt) || !instant(value.lastActivityAt)) return undefined;
-  if (value.archivedAt !== undefined && !instant(value.archivedAt)) return undefined;
+  if (!isInstant(value.createdAt) || !isInstant(value.lastActivityAt)) return undefined;
+  if (value.archivedAt !== undefined && !isInstant(value.archivedAt)) return undefined;
   if (value.archiveReason !== undefined && !isArchiveReason(value.archiveReason)) return undefined;
-  if (value.pinnedAt !== undefined && !instant(value.pinnedAt)) return undefined;
+  if (value.pinnedAt !== undefined && !isInstant(value.pinnedAt)) return undefined;
   if (value.sessionId !== undefined && !isWireString(value.sessionId)) return undefined;
   if (value.temporary !== undefined && value.temporary !== true) return undefined;
   // SAFETY: the session key is a non-empty string; the constructor's check is the one made above.
@@ -219,11 +215,11 @@ export function historyArchiveRecordFromWire(
   if (!isWireString(value.archiveId) || value.archiveId.length === 0) return undefined;
   if (!isWireString(value.sessionKey) || value.sessionKey.length === 0) return undefined;
   if (!isConversationKind(value.kind) || !isWireString(value.name)) return undefined;
-  if (!instant(value.createdAt) || !instant(value.deletedAt)) return undefined;
+  if (!isInstant(value.createdAt) || !isInstant(value.deletedAt)) return undefined;
   if (!isArchiveEncoding(value.encoding) || !isWireString(value.sha256)) return undefined;
-  if (!instant(value.byteLength) || !isWireString(value.fileName)) return undefined;
-  if (value.publishedAt !== undefined && !instant(value.publishedAt)) return undefined;
-  if (!instant(value.historyLines) || !instant(value.transcriptEvents)) return undefined;
+  if (!isInstant(value.byteLength) || !isWireString(value.fileName)) return undefined;
+  if (value.publishedAt !== undefined && !isInstant(value.publishedAt)) return undefined;
+  if (!isInstant(value.historyLines) || !isInstant(value.transcriptEvents)) return undefined;
   return {
     archiveId: value.archiveId,
     // SAFETY: a non-empty string, checked above, is what the session key constructor admits.

--- a/packages/session/src/bounds.ts
+++ b/packages/session/src/bounds.ts
@@ -2,6 +2,15 @@ import { text, type UnparsedWireValue } from "@sidecar/wire";
 import { isOpenableSessionLink, SESSION_LINK_SCHEME } from "./session-identity.js";
 import type { SessionDiffSummary } from "./session-shape.js";
 
+/**
+ * Stands where the front of a transcript was cut, so a reader — a model or a
+ * row — knows it is holding a tail rather than the whole conversation. One
+ * marker for every cut: the brain's bounded read and a provider adapter's own
+ * rendering both say the same thing, so nothing downstream has to recognize
+ * two spellings of the same fact.
+ */
+export const OMISSION_MARKER = "[… earlier transcript omitted …]";
+
 export const maximumSessionTitleLength = 160;
 /** An agent kind is a short identifier, never a sentence. */
 export const maximumSpawnableAgentLength = 40;

--- a/packages/session/src/index.ts
+++ b/packages/session/src/index.ts
@@ -1,4 +1,4 @@
-export { ACT_RESULT_STATUS } from "@sidecar/wire";
+export { ACT_RESULT_STATUS, UNSUPPORTED_BY_OBSERVATION } from "@sidecar/wire";
 export * from "./act-results.js";
 export * from "./advertised-acts.js";
 export * from "./agent-identities.js";

--- a/packages/settings/src/voice-hotkey.ts
+++ b/packages/settings/src/voice-hotkey.ts
@@ -28,6 +28,26 @@ export const DEFAULT_VOICE_HOTKEYS: readonly string[] = ["Alt+Space"];
 export const VOICE_HOTKEY_NONE = "none";
 
 /**
+ * The one rule all three Luke keys follow: a deleted key offers nothing, a
+ * chosen chord goes first because it is what the user asked for, the defaults
+ * stand behind a choice and never behind a removal, and a chord a
+ * higher-ranked key already holds is left out, because two Luke keys competing
+ * for one chord would silently cost one of them its whole feature with nothing
+ * on screen saying why.
+ */
+function hotkeyCandidates(
+  chosen: string | undefined,
+  defaults: readonly string[],
+  taken: readonly (string | undefined)[],
+): readonly string[] {
+  if (chosen === VOICE_HOTKEY_NONE) return [];
+  const candidates = chosen
+    ? [chosen, ...defaults.filter((candidate) => candidate !== chosen)]
+    : defaults;
+  return candidates.filter((candidate) => !taken.includes(candidate));
+}
+
+/**
  * The key that cuts off a reply being spoken, from whatever app is frontmost.
  *
  * Option-S because S is for stop, and Option-letter is the family the other
@@ -50,11 +70,7 @@ export function stopHotkeyCandidates(
   chosen: string | undefined,
   taken: readonly (string | undefined)[],
 ): readonly string[] {
-  if (chosen === VOICE_HOTKEY_NONE) return [];
-  const candidates = chosen
-    ? [chosen, ...DEFAULT_STOP_HOTKEYS.filter((candidate) => candidate !== chosen)]
-    : DEFAULT_STOP_HOTKEYS;
-  return candidates.filter((candidate) => !taken.includes(candidate));
+  return hotkeyCandidates(chosen, DEFAULT_STOP_HOTKEYS, taken);
 }
 
 /**
@@ -83,11 +99,7 @@ export function askHotkeyCandidates(
   chosen: string | undefined,
   taken: readonly (string | undefined)[],
 ): readonly string[] {
-  if (chosen === VOICE_HOTKEY_NONE) return [];
-  const candidates = chosen
-    ? [chosen, ...DEFAULT_ASK_HOTKEYS.filter((candidate) => candidate !== chosen)]
-    : DEFAULT_ASK_HOTKEYS;
-  return candidates.filter((candidate) => !taken.includes(candidate));
+  return hotkeyCandidates(chosen, DEFAULT_ASK_HOTKEYS, taken);
 }
 
 /**
@@ -194,9 +206,7 @@ export function parseVoiceHotkey(value: string): string | undefined {
  * back on its own.
  */
 export function voiceHotkeyCandidates(chosen: string | undefined): readonly string[] {
-  if (chosen === VOICE_HOTKEY_NONE) return [];
-  if (!chosen) return DEFAULT_VOICE_HOTKEYS;
-  return [chosen, ...DEFAULT_VOICE_HOTKEYS.filter((candidate) => candidate !== chosen)];
+  return hotkeyCandidates(chosen, DEFAULT_VOICE_HOTKEYS, []);
 }
 
 /** What became of one keystroke offered to the recording control. */

--- a/packages/superset/src/cli.test.ts
+++ b/packages/superset/src/cli.test.ts
@@ -3,7 +3,12 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test, { type TestContext } from "node:test";
-import { ACT_RESULT_STATUS, PROVIDER_ID, SESSION_STATUS } from "@sidecar/session";
+import {
+  ACT_RESULT_STATUS,
+  PROVIDER_ID,
+  SESSION_STATUS,
+  UNSUPPORTED_BY_OBSERVATION,
+} from "@sidecar/session";
 import { isRecord, text, type UnparsedWireValue } from "@sidecar/wire";
 import {
   isSupersetControlId,
@@ -114,7 +119,7 @@ test("a missing CLI login exposes no Superset actions", async (t) => {
   assert.equal(await cli.connected(), false);
   assert.deepEqual(await cli.sendMessage(CONTEXT, "hello"), {
     status: ACT_RESULT_STATUS.UNSUPPORTED,
-    reason: "That act is not supported by the latest observation.",
+    reason: UNSUPPORTED_BY_OBSERVATION,
   });
 });
 
@@ -259,7 +264,7 @@ test("a chatless workspace context takes the delete but never a message", async 
   // No terminal exists for a message to land in, so no invocation may run.
   assert.deepEqual(await cli.sendMessage(chatless, "hello"), {
     status: ACT_RESULT_STATUS.UNSUPPORTED,
-    reason: "That act is not supported by the latest observation.",
+    reason: UNSUPPORTED_BY_OBSERVATION,
   });
   assert.equal(
     (await cli.executeControl(chatless, SUPERSET_CONTROL_ID.DELETE_WORKSPACE)).status,

--- a/packages/superset/src/cli.ts
+++ b/packages/superset/src/cli.ts
@@ -12,6 +12,7 @@ import {
   type ProviderWorkspaceResult,
   SessionProviderAdapterBase,
   SUPERSET_WORKSPACE_PROVIDER_ID,
+  UNSUPPORTED_BY_OBSERVATION,
   WORKSPACE_TASK_SUPPORT,
   type WorkspaceProject,
 } from "@sidecar/session";
@@ -40,6 +41,8 @@ const SUPERSET_TARGET_LIMIT = 20;
 const SUPERSET_PROJECT_LIMIT = 50;
 const SUPERSET_FAILURE_REASON_LIMIT = 300;
 const SUPERSET_PROJECT_REFRESH_INTERVAL_MS = 60_000;
+/** How long any one CLI invocation may run before it is given up on. */
+const SUPERSET_INVOCATION_TIMEOUT_MS = 30_000;
 const LOCAL_TARGET_ID = "local";
 const ANSI_ESCAPE_PATTERN = new RegExp(`${String.fromCharCode(27)}\\[[0-?]*[ -/]*[@-~]`, "gu");
 
@@ -65,6 +68,25 @@ function supersetFailureReason(error: UnparsedWireValue, fallback: string): stri
   return reason || fallback;
 }
 
+/**
+ * The stderr a failed invocation attached to what it threw, whether the runner
+ * is the injected one or `execFile`. The parameter is the thrown cause itself,
+ * because that attachment is the only place the CLI's own words survive.
+ */
+function attachedStderr(cause: unknown): UnparsedWireValue {
+  if (!(cause instanceof Error) || !("stderr" in cause)) return undefined;
+  // SAFETY: a command runner's failure may attach stderr; the reason reader validates it as wire.
+  // oxlint-disable-next-line anti-slop/no-chained-type-assertions -- The attached value is untyped; the wire reader is the validation.
+  return (cause as Error & { stderr?: UnparsedWireValue }).stderr;
+}
+
+/** The values an envelope carries, whether the CLI answered a bare array or wrapped it in `data`. */
+function envelopeValues(parsed: UnparsedWireValue): readonly UnparsedWireValue[] {
+  if (Array.isArray(parsed)) return parsed;
+  const envelope = wireRecord(parsed);
+  return envelope && Array.isArray(envelope.data) ? envelope.data : [];
+}
+
 function failedSupersetInvocation(binary: string, stderr: string): InvocationError {
   return Object.assign(new InvocationError(INVOCATION_FAILURE.FAILED, binary), { stderr });
 }
@@ -87,7 +109,7 @@ async function defaultCommandRunner(
   const result = await boundedInvocation({
     binary: executable,
     arguments: arguments_,
-    timeoutMs: 30_000,
+    timeoutMs: SUPERSET_INVOCATION_TIMEOUT_MS,
     maximumOutputBytes: SUPERSET_QUERY_OUTPUT_LIMIT,
   });
   if (result.exitCode !== 0) {
@@ -196,7 +218,11 @@ export class SupersetCli {
     const choice = choices.find((organization) => organization.slug === slug);
     if (!choice) return false;
     try {
-      await this.#query(this.executable, ["organization", "switch", choice.slug, "--json"], 30_000);
+      await this.#query(
+        this.executable,
+        ["organization", "switch", choice.slug, "--json"],
+        SUPERSET_INVOCATION_TIMEOUT_MS,
+      );
       return this.connected();
     } catch {
       return false;
@@ -205,14 +231,12 @@ export class SupersetCli {
 
   async organizations(): Promise<readonly SupersetOrganizationChoice[]> {
     try {
-      const output = await this.#query(this.executable, ["organization", "list", "--json"], 30_000);
-      const parsed = unparsedWire(JSON.parse(output));
-      const envelope = wireRecord(parsed);
-      const values = Array.isArray(parsed)
-        ? parsed
-        : envelope && Array.isArray(envelope.data)
-          ? envelope.data
-          : [];
+      const output = await this.#query(
+        this.executable,
+        ["organization", "list", "--json"],
+        SUPERSET_INVOCATION_TIMEOUT_MS,
+      );
+      const values = envelopeValues(unparsedWire(JSON.parse(output)));
       return values.slice(0, SUPERSET_ORGANIZATION_LIMIT).flatMap((value) => {
         if (!isRecord(value)) return [];
         const id = text(value.id);
@@ -314,7 +338,7 @@ export class SupersetCli {
     if (!offered)
       return {
         status: ACT_RESULT_STATUS.UNSUPPORTED,
-        reason: "That act is not supported by the latest observation.",
+        reason: UNSUPPORTED_BY_OBSERVATION,
       };
     const branch = this.#branchName(request.name ?? request.task);
     const name = request.name ?? branch;
@@ -341,10 +365,10 @@ export class SupersetCli {
     if (!(await this.connected()))
       return {
         status: ACT_RESULT_STATUS.UNSUPPORTED,
-        reason: "That act is not supported by the latest observation.",
+        reason: UNSUPPORTED_BY_OBSERVATION,
       };
     try {
-      const output = await this.#query(this.executable, arguments_, 30_000);
+      const output = await this.#query(this.executable, arguments_, SUPERSET_INVOCATION_TIMEOUT_MS);
       const parsed = unparsedWire(JSON.parse(output));
       const envelope = wireRecord(parsed);
       // The CLI answers a creation with `{ workspace, alreadyExists }`, so the
@@ -371,15 +395,10 @@ export class SupersetCli {
         };
       }
     } catch (error) {
-      const stderr =
-        error instanceof Error && "stderr" in error
-          ? // SAFETY: injected command-runner failures may attach stderr.
-            (error as Error & { stderr?: UnparsedWireValue }).stderr
-          : undefined;
       return {
         status: ACT_RESULT_STATUS.REJECTED,
         reason: supersetFailureReason(
-          unparsedWire({ stderr }),
+          unparsedWire({ stderr: attachedStderr(error) }),
           "Superset could not create that workspace.",
         ),
       };
@@ -397,7 +416,7 @@ export class SupersetCli {
     if (!context.terminalId)
       return {
         status: ACT_RESULT_STATUS.UNSUPPORTED,
-        reason: "That act is not supported by the latest observation.",
+        reason: UNSUPPORTED_BY_OBSERVATION,
       };
     return this.#act(
       [
@@ -429,7 +448,7 @@ export class SupersetCli {
     }
     return {
       status: ACT_RESULT_STATUS.UNSUPPORTED,
-      reason: "That act is not supported by the latest observation.",
+      reason: UNSUPPORTED_BY_OBSERVATION,
     };
   }
 
@@ -450,7 +469,7 @@ export class SupersetCli {
     if (!(await this.connected()))
       return {
         status: ACT_RESULT_STATUS.UNSUPPORTED,
-        reason: "That act is not supported by the latest observation.",
+        reason: UNSUPPORTED_BY_OBSERVATION,
       };
     try {
       await this.#run(this.executable, [
@@ -462,15 +481,10 @@ export class SupersetCli {
       ]);
       return { status: ACT_RESULT_STATUS.ACCEPTED };
     } catch (error) {
-      const stderr =
-        error instanceof Error && "stderr" in error
-          ? // SAFETY: execFile failures attach stderr to the thrown Error object.
-            (error as Error & { stderr?: UnparsedWireValue }).stderr
-          : undefined;
       return {
         status: ACT_RESULT_STATUS.REJECTED,
         reason: supersetFailureReason(
-          unparsedWire({ stderr }),
+          unparsedWire({ stderr: attachedStderr(error) }),
           "Superset could not rename that workspace.",
         ),
       };
@@ -508,7 +522,7 @@ export class SupersetCli {
     if (!(await this.connected()))
       return {
         status: ACT_RESULT_STATUS.UNSUPPORTED,
-        reason: "That act is not supported by the latest observation.",
+        reason: UNSUPPORTED_BY_OBSERVATION,
       };
     try {
       await this.#run(this.executable, arguments_);
@@ -521,14 +535,9 @@ export class SupersetCli {
   async #records(arguments_: readonly string[]): Promise<readonly WireRecord[]> {
     try {
       const parsed = unparsedWire(
-        JSON.parse(await this.#query(this.executable, arguments_, 30_000)),
+        JSON.parse(await this.#query(this.executable, arguments_, SUPERSET_INVOCATION_TIMEOUT_MS)),
       );
-      const envelope = wireRecord(parsed);
-      const values = Array.isArray(parsed)
-        ? parsed
-        : envelope && Array.isArray(envelope.data)
-          ? envelope.data
-          : [];
+      const values = envelopeValues(parsed);
       return values.flatMap((value) => {
         const record = wireRecord(value);
         return record ? [record] : [];

--- a/packages/trackers/src/linear/credentials.ts
+++ b/packages/trackers/src/linear/credentials.ts
@@ -1,16 +1,13 @@
 // The same collapsing the account's refresh uses, and for the same reason:
 // Linear consumes a refresh token when it is spent, so two refreshes racing
 // would have the loser spend one Linear has already rotated away.
-import { singleFlight } from "@sidecar/credentials";
+import { ACCESS_TOKEN_EXPIRY_SLACK_MS, singleFlight } from "@sidecar/credentials";
 import {
   LINEAR_REFRESH_STATUS,
   type LinearGrant,
   refreshLinearGrant,
   revokeLinearGrant,
 } from "./oauth.js";
-
-/** Refreshed a minute early, so a pass never rides a token mid-expiry. */
-const ACCESS_TOKEN_EXPIRY_SLACK_MS = 60_000;
 
 export interface LinearCredentialsOptions {
   /**

--- a/packages/trackers/src/linear/tracker.test.ts
+++ b/packages/trackers/src/linear/tracker.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { ACT_RESULT_STATUS, ISSUE_ACTION_KIND } from "@sidecar/issues";
+import { UNSUPPORTED_BY_OBSERVATION } from "@sidecar/wire";
 import type { JsonValue, ParsedJsonObject } from "@sidecar/wire/testing";
 import {
   HTTP_STATUS,
@@ -87,7 +88,7 @@ test("no token means no request and a tracker that is not connected", async () =
     }),
     {
       status: ACT_RESULT_STATUS.UNSUPPORTED,
-      reason: "That act is not supported by the latest observation.",
+      reason: UNSUPPORTED_BY_OBSERVATION,
     },
   );
   assert.equal(requests.length, 0);

--- a/packages/trackers/src/linear/tracker.ts
+++ b/packages/trackers/src/linear/tracker.ts
@@ -14,6 +14,7 @@ import {
   isRecord,
   isWireNumber,
   text,
+  UNSUPPORTED_BY_OBSERVATION,
   type UnparsedWireValue,
   unparsedWire,
   type WireRecord,
@@ -191,7 +192,7 @@ export class LinearIssueTracker implements IssueTrackerAdapter {
     if (!accessToken)
       return {
         status: ACT_RESULT_STATUS.UNSUPPORTED,
-        reason: "That act is not supported by the latest observation.",
+        reason: UNSUPPORTED_BY_OBSERVATION,
       };
 
     const [document, variables, resultField] =

--- a/packages/voice/src/hosted-credentials.ts
+++ b/packages/voice/src/hosted-credentials.ts
@@ -6,8 +6,8 @@ import {
   type RealtimeConnection,
 } from "@sidecar/hosted";
 import { REALTIME_MINT_OUTCOME } from "@sidecar/realtime";
-import { isRecord, type UnparsedWireValue, unparsedWire } from "@sidecar/wire";
-import { type FetchLike, ServiceRealtimeCredentialMinter } from "./service-mint.js";
+import { type CloudFetch, isRecord, type UnparsedWireValue, unparsedWire } from "@sidecar/wire";
+import { ServiceRealtimeCredentialMinter } from "./service-mint.js";
 
 const UNAUTHORIZED_STATUS = 401;
 const QUOTA_STATUS = 429;
@@ -27,7 +27,7 @@ export interface HostedRealtimeCredentialOptions {
   refreshAccount: () => Promise<void>;
   voice?: string;
   speed?: number;
-  fetch?: FetchLike;
+  fetch?: CloudFetch;
   now?: () => number;
   requestTimeoutMs?: number;
 }

--- a/packages/voice/src/introduction-credentials.ts
+++ b/packages/voice/src/introduction-credentials.ts
@@ -1,7 +1,7 @@
 import { HOSTED_SERVICE_PATH, type RealtimeConnection } from "@sidecar/hosted";
 import { REALTIME_MINT_OUTCOME } from "@sidecar/realtime";
-import type { UnparsedWireValue } from "@sidecar/wire";
-import { type FetchLike, ServiceRealtimeCredentialMinter } from "./service-mint.js";
+import type { CloudFetch, UnparsedWireValue } from "@sidecar/wire";
+import { ServiceRealtimeCredentialMinter } from "./service-mint.js";
 
 const RATE_LIMITED_STATUS = 429;
 const UNAVAILABLE_STATUS = 503;
@@ -11,7 +11,7 @@ export interface IntroductionRealtimeCredentialOptions {
   serviceBaseUrl: string;
   voice?: string;
   speed?: number;
-  fetch?: FetchLike;
+  fetch?: CloudFetch;
   now?: () => number;
   requestTimeoutMs?: number;
 }

--- a/packages/voice/src/openai-credentials.ts
+++ b/packages/voice/src/openai-credentials.ts
@@ -16,7 +16,14 @@ import {
   realtimeClientSecretRequest,
   realtimeCredentialFromResponse,
 } from "@sidecar/realtime";
-import { positiveInteger, text, unparsedWire, type WireBoundaryInput } from "@sidecar/wire";
+import {
+  type CloudFetch,
+  positiveInteger,
+  text,
+  unparsedWire,
+  type WireBoundaryInput,
+  withoutTrailingSlash,
+} from "@sidecar/wire";
 
 export const OPENAI_ENVIRONMENT = {
   API_KEY: "OPENAI_API_KEY",
@@ -30,24 +37,18 @@ const OPENAI_DEFAULTS = {
   REQUEST_TIMEOUT_MS: 10_000,
 } as const;
 
-type FetchLike = (input: string, init: RequestInit) => Promise<Response>;
-
 export interface OpenAiRealtimeCredentialOptions {
   apiKey: string;
   model?: string;
   voice?: string;
   speed?: number;
   baseUrl?: string;
-  fetch?: FetchLike;
+  fetch?: CloudFetch;
   now?: () => number;
   requestTimeoutMs?: number;
 }
 
 export type OpenAiRealtimeMinterOptions = Omit<OpenAiRealtimeCredentialOptions, "apiKey">;
-
-function withoutTrailingSlash(value: string): string {
-  return value.endsWith("/") ? value.slice(0, -1) : value;
-}
 
 /**
  * The launch environment's voice, honoured only when it is one Luke offers.
@@ -94,7 +95,7 @@ export class OpenAiRealtimeCredentialMinter {
   readonly #configuredSpeed: number;
   #speed: number;
   readonly #baseUrl: string;
-  readonly #fetch: FetchLike;
+  readonly #fetch: CloudFetch;
   readonly #now: () => number;
   readonly #requestTimeoutMs: number;
   #lastOutcome: RealtimeMintOutcome = REALTIME_MINT_OUTCOME.NOT_ATTEMPTED;

--- a/packages/voice/src/service-mint.ts
+++ b/packages/voice/src/service-mint.ts
@@ -11,14 +11,19 @@ import {
   type RealtimeDiagnostics,
   type RealtimeMintOutcome,
 } from "@sidecar/realtime";
-import { positiveInteger, text, type UnparsedWireValue, unparsedWire } from "@sidecar/wire";
+import {
+  type CloudFetch,
+  positiveInteger,
+  text,
+  type UnparsedWireValue,
+  unparsedWire,
+  withoutTrailingSlash,
+} from "@sidecar/wire";
 import type { RealtimeCredentialMinter } from "./minter.js";
 
 const SERVICE_MINT_DEFAULTS = {
   REQUEST_TIMEOUT_MS: 10_000,
 } as const;
-
-export type FetchLike = (input: string, init: RequestInit) => Promise<Response>;
 
 export interface ServiceMintOptions {
   /** The hosted service origin, without a trailing slash. */
@@ -31,13 +36,9 @@ export interface ServiceMintOptions {
   malformedDetail: string;
   voice?: string;
   speed?: number;
-  fetch?: FetchLike;
+  fetch?: CloudFetch;
   now?: () => number;
   requestTimeoutMs?: number;
-}
-
-function withoutTrailingSlash(value: string): string {
-  return value.endsWith("/") ? value.slice(0, -1) : value;
 }
 
 /**
@@ -58,7 +59,7 @@ export abstract class ServiceRealtimeCredentialMinter implements RealtimeCredent
   #voice: string | undefined;
   readonly #configuredSpeed: number | undefined;
   #speed: number | undefined;
-  readonly #fetch: FetchLike;
+  readonly #fetch: CloudFetch;
   readonly #now: () => number;
   readonly #requestTimeoutMs: number;
   #lastModel: string | undefined;

--- a/packages/wire/src/act-result.ts
+++ b/packages/wire/src/act-result.ts
@@ -8,6 +8,15 @@ export const ACT_RESULT_STATUS = {
 
 export type ActResultStatus = (typeof ACT_RESULT_STATUS)[keyof typeof ACT_RESULT_STATUS];
 
+/**
+ * The one sentence an adapter answers an act its target's latest observation
+ * did not advertise. It is written once because it is one refusal: the latest
+ * read is what says which acts a provider documents for a session or an issue
+ * now, and an act that outran that read is refused the same way whoever was
+ * asked.
+ */
+export const UNSUPPORTED_BY_OBSERVATION = "That act is not supported by the latest observation.";
+
 const ACT_RESULT_STATUSES: ReadonlySet<string> = new Set(Object.values(ACT_RESULT_STATUS));
 
 /** Whether an untrusted value names one of the three statuses an act can end in. */

--- a/packages/wire/src/index.ts
+++ b/packages/wire/src/index.ts
@@ -5,11 +5,13 @@ export {
   isActResult,
   isActResultStatus,
   UNKNOWN_ACT_STATUS,
+  UNSUPPORTED_BY_OBSERVATION,
   type UnknownActResult,
 } from "./act-result.js";
 export {
   type CloudFetch,
   HTTP_STATUS,
+  isInstant,
   isOptionalWireString,
   isRecord,
   isUnitLevel,
@@ -32,6 +34,7 @@ export {
   type WireValue,
   wholeNumber,
   wireRecord,
+  withoutTrailingSlash,
 } from "./json.js";
 export {
   type ArrayOptions,

--- a/packages/wire/src/json.ts
+++ b/packages/wire/src/json.ts
@@ -104,6 +104,15 @@ export function text(value: UnparsedWireValue): string | undefined {
   return normalized || undefined;
 }
 
+/**
+ * An instant on the wire: epoch milliseconds, finite and never before the
+ * epoch, so a record claiming a negative or infinite time reads as no time at
+ * all rather than as an arithmetic hazard downstream.
+ */
+export function isInstant(value: UnparsedWireValue): value is number {
+  return isWireNumber(value) && Number.isFinite(value) && value >= 0;
+}
+
 export function wholeNumber(value: UnparsedWireValue): number | undefined {
   if (!isWireNumber(value) || !Number.isFinite(value)) return undefined;
   return value;
@@ -223,8 +232,18 @@ export const HTTP_STATUS = {
   UNAUTHORIZED: 401,
   FORBIDDEN: 403,
   NOT_FOUND: 404,
+  METHOD_NOT_ALLOWED: 405,
   CONFLICT: 409,
+  TOO_MANY_REQUESTS: 429,
 } as const;
 
 /** The fetch a caller is given, so a test can answer for the network. */
 export type CloudFetch = (url: string, init: RequestInit) => Promise<Response>;
+
+/**
+ * A base address with no trailing separator, so a path joined to it cannot
+ * produce a doubled slash the upstream reads as a different route.
+ */
+export function withoutTrailingSlash(value: string): string {
+  return value.endsWith("/") ? value.slice(0, -1) : value;
+}

--- a/packages/wire/src/testing/http-fake.ts
+++ b/packages/wire/src/testing/http-fake.ts
@@ -13,8 +13,6 @@ export const HTTP_STATUS = {
   // What a production route answers a request missing a header it demands,
   // reproduced by a provider fake so a forgotten header cannot pass.
   BAD_REQUEST: 400,
-  // Named by the OAuth tests, which treat it as transient alongside 408.
-  TOO_MANY_REQUESTS: 429,
   SERVER_ERROR: 500,
 } as const;
 


### PR DESCRIPTION
About twenty-five small helpers stood in two to six places each — strip a trailing slash, an HTTP status table, a "same observation?" check, a refusal sentence written forty times. Each now has one home, and every other site reads it from there. No behaviour changes except the two noted below.

### What moved where

**`@sidecar/wire`** — the boundary everything already depends on:
- `withoutTrailingSlash` (7 copies: `account/preferences`, `account/vault`, `analytics/sender`, `brain/model-adapter-shared`, `voice/openai-credentials`, `voice/service-mint`, `apps/web/.../posthog`).
- `isInstant` (4 copies of the same `isWireNumber && isFinite && >= 0` guard in `brain/observation-inbox`, `brain/state-store`, `runtime-contracts/children`, `runtime-contracts/storage`).
- `CloudFetch` already lived here; seven modules each declared an identical `FetchLike` beside it. They now name the one type. (`account/client.ts`'s wider `FetchLike` is a different signature and stays.)
- `HTTP_STATUS` gains `METHOD_NOT_ALLOWED` and `TOO_MANY_REQUESTS`, so `brain/model-adapter-shared.ts`'s own table goes, and `apps/web/server/hosted/http.ts`, `apps/web/server/admin/http.ts` and `wire/testing/http-fake.ts` spread the boundary's statuses instead of restating 401/403/404/405/429.
- `UNSUPPORTED_BY_OBSERVATION`, beside `ACT_RESULT_STATUS` in `act-result.ts` and re-exported by `@sidecar/session` the way `ACT_RESULT_STATUS` already is, replacing the sentence written at 40 call sites across five provider adapters, the Superset CLI, and the Linear tracker.

**`@sidecar/session`** — `OMISSION_MARKER`, which had two wordings (`brain/transcript-reads` and `providers/shared/local-transcript`). One marker now, so nothing downstream has to recognise two spellings.

**`@sidecar/credentials`** — `ACCESS_TOKEN_EXPIRY_SLACK_MS` (`calendar/reader`, `trackers/linear/credentials`).

**`@sidecar/memory`** — `ESTIMATED_CHARS_PER_TOKEN`; `MEMORY_SEARCH_DEFAULTS.CHARS_PER_TOKEN_ESTIMATE` and `brain/context-engine`'s own constant were the same pinned 4.

**`@sidecar/brain`** — two new modules:
- `tool-results.ts`: `answer(output)` (`tool-executor`, `housekeeping`) and the serialized-output status reader that was `outputStatus` in `journal.ts` and `resultStatus` in `runtime.ts`.
- `nested-map.ts`: `NestedMap<Value>`, the map-of-maps `BySession`, `TranscriptCursors` and `BrainJournal` each hand-rolled. It is what CLAUDE.md's "nested `Map` instances keyed by the original identifiers" rule asks for, written once.
- `sameWake` folds into `sameObservation`, which now compares two `ObservationMark`s; an inbox entry reaches one through `entryMark`.
- `BRAIN_DEFAULTS.PENDING_WAKE_CAPACITY` is `INBOX_CAPACITY` rather than a second literal 20: a wake held past what one turn can open with is a wake no turn would read.

**`apps/desktop/src/main/gateway/wire.ts`** — `carried` (`host-operator`'s `carried` and `runtime-host`'s identical `wire`), `invalid` (`gateway/service`, `runtime-host`), and `gatewayEventReader`, which replaces the `on` helper written twice in `host-operator` and `operator`. `CALENDAR_PRIVACY_PANE_URL` joins `#shared/apple-calendar`, which both call sites already import.

**Elsewhere** — Superset's CLI gets `envelopeValues`, `attachedStderr` and `SUPERSET_INVOCATION_TIMEOUT_MS` in place of three, two and five repetitions; `settings/voice-hotkey`'s three `*HotkeyCandidates` share one `hotkeyCandidates` rule; `speech-mouth`'s three identical cancel-and-clear blocks (with the same four-line SAFETY comment) become `#cancelTimer`, whose handles are now typed `ScheduledTimer` rather than `unknown`; `voiceRestartAction` carries one `VoiceRestartDecision` return type instead of five inline `satisfies`; `talkKeyPress` loses `deferToRelease`, which no caller read; and `apps/web/server/hosted/events.ts` uses the existing `createRateBrake`, which now takes what an ask weighs so a batch of events costs its own size.

### The `REFUSAL` tables, after the rebase

The plan asked for the three `REFUSAL` tables to become one. #812 landed first and did the right version of that: `ACT_REFUSAL` in `@sidecar/acts` is now the canonical home for the act vocabulary, and `act-performer` already reads `TURN_OVER` from it. So rather than add a fourth home, `ipc/session-acts`'s table now reads `NO_SESSION`, `NO_ISSUE`, `NO_ADDRESS` and `TURN_OVER` from `ACT_REFUSAL` — the four sentences it was restating — and keeps only the six that are the performer's own. `gateway/service`'s two entries are protocol diagnostics, not words anyone reads, and stay where they are with a comment saying so.

### One visible change, deliberate

The transcript omission marker a provider adapter renders changes from `[earlier turns omitted]` to `[… earlier transcript omitted …]`, the brain's wording, since one marker is the point. Tests read the constant rather than the literal now.

### Not done, and why

The plan also names `apps/web/api/feedback.mjs:60`'s brake as a `rate-brake.ts` caller. That file is deliberately plain ESM — its own docblock says so, because handing Vercel's builder JavaScript "leaves that builder nothing to resolve, transpile, or fail on" — and importing a `.ts` from it is exactly the class of break `packages/AGENTS.md` warns about: nothing local reports it and production reports it only as `FUNCTION_INVOCATION_FAILED`. Its brake stands where it is. `events.ts` is the one converted.

### Trust constraints

No trust boundary moves. Every constant, guard, and refusal keeps its value and its meaning; the omission marker above is the only string that changes, and it is not a rule. No CLAUDE.md or `PRIVACY.md` sentence describes a symbol this PR moved.

### Verification

`./scripts/check.sh` — green after rebasing onto `b7d4b36` (lint, oxlint, typecheck, every package's tests, build). Not a UI PR: no renderer-visible surface changes, so no `verify.sh` run or fixture PNG, and no physical-notch check.

- `git diff --shortstat origin/main...` → `81 files changed, 655 insertions(+), 632 deletions(-)`
- Running total: 254,563 tracked source lines (target ~125k). This PR is a consolidation, not a deletion: the insertions are the imports and the one-home modules that replace the copies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34304203257/artifacts/10086101409) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34304203257)

- Commit: `3fa5da7760b55750a0498406c78bc7f87cd2d366`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
