### PR TITLE
refactor(providers): a provider is a plugin value

### DIFF
--- a/apps/web/server/hosted/cloud-adapters.ts
+++ b/apps/web/server/hosted/cloud-adapters.ts
@@ -1,6 +1,5 @@
 import { ConductorSessionAdapter } from "../../../../packages/providers/src/conductor/adapter.js";
-import type { CloudFetch } from "../../../../packages/providers/src/shared/cloud-session-adapter.js";
-import type { CloudAgentProviderId, SessionProviderAdapter } from "../core.js";
+import type { CloudAgentProviderId, CloudFetch, SessionProviderAdapter } from "../core.js";
 import { CLOUD_AGENT_PROVIDER_ID } from "../core.js";
 
 /**

--- a/apps/web/server/hosted/observe.ts
+++ b/apps/web/server/hosted/observe.ts
@@ -1,5 +1,4 @@
-import type { CloudFetch } from "../../../../packages/providers/src/shared/cloud-session-adapter.js";
-import type { ProviderSessionObservation } from "../core.js";
+import type { CloudFetch, ProviderSessionObservation } from "../core.js";
 import {
   ACT_KIND,
   advertisedActFor,

--- a/apps/web/server/hosted/projects.ts
+++ b/apps/web/server/hosted/projects.ts
@@ -1,7 +1,7 @@
-import type { CloudFetch } from "../../../../packages/providers/src/shared/cloud-session-adapter.js";
 import {
   CLOUD_AGENT_PROVIDER_ID,
   type CloudAgentProviderId,
+  type CloudFetch,
   type HostedWorkspaceAgentModels,
   type HostedWorkspaceProject,
   type WorkspaceProject,

--- a/packages/providers/AGENTS.md
+++ b/packages/providers/AGENTS.md
@@ -14,11 +14,24 @@ Copilot, Gemini CLI, Grok Build — are hosted-agent identities in
 `@sidecar/session` alone: a mark and a display name, with no adapter, files,
 hook, or credential behind them.
 
-The adapter seam remains the authority for acts. Every adapter implements the
-total `SessionProviderAdapter` interface through its base class, whose answer is
-unsupported. A provider gains an act only by overriding the matching protected
-route or delivery seam and preserving every trust constraint in root
-`CLAUDE.md`. Transcript reading belongs inside the adapter.
+The plugin seam remains the authority for acts. A provider is a
+`SessionProviderPlugin`: one `observe`, the roster that pass published, and a
+partial map of the acts and reads it actually implements. An absent handler is
+the unsupported answer, so a provider gains an act only by naming its key and
+taking on that act's constraint in root `CLAUDE.md` along with it. `dispatchAct`
+is the only code that reaches a handler, and it re-resolves every target from
+the plugin's own latest roster. Transcript reading belongs inside the plugin,
+through `jsonlTranscriptReader` for a provider whose records are JSONL.
+
+The base classes still standing — `SessionProviderAdapter` and the local,
+cloud and CLI bases — are the class-shaped reading of the same thing while the
+providers convert one at a time; `adapterAsPlugin` and `pluginAsAdapter` are
+the two directions, and both go with the interface. The shared mechanics are
+functions with one home each: `observationPass` for a file-backed pass,
+`cloudPass` and `cliPass` for the credential and login halves, `hostClaims`
+for a workspace manager's claims, `mergePlugins` for one provider observed in
+more than one place, and `AdapterFailure` with `clearsObservedState` for
+whether a failed read clears what was observed.
 
 Every provider passes one contract suite. `describeProviderContract` in
 `@sidecar/providers/testing` states the trust constraints as tests over
@@ -33,7 +46,7 @@ which `repository-checks.sh` enforces and Biome is kept away from;
 
 Capabilities stay with their owning package in explicit, exhaustive maps:
 credentials in `@sidecar/credentials`, analytics connections in
-`@sidecar/analytics` and the desktop bridge, hooks and adapter registration in
+`@sidecar/analytics` and the desktop bridge, hooks and plugin registration in
 this package, fixture coverage in `@sidecar/fixtures` and the recorded
 provider fixtures beside `@sidecar/session`, workspace presentation in the
 surface that offers it, and Superset agent kinds in `@sidecar/superset`.

--- a/packages/providers/src/claude-code/adapter.ts
+++ b/packages/providers/src/claude-code/adapter.ts
@@ -21,12 +21,14 @@ import {
   wholeNumber,
 } from "@sidecar/wire";
 import {
-  discoverSessionFiles,
   type HookStatusRefinement,
   hookRefinedStatus,
-  LOCAL_ADAPTER_DEFAULTS,
-  LocalFileSessionAdapter,
   localSessionStatus,
+} from "../shared/hook-status.js";
+import { type JsonlTranscriptReader, jsonlTranscriptReader } from "../shared/jsonl-transcript.js";
+import {
+  discoverSessionFiles,
+  LOCAL_ADAPTER_DEFAULTS,
   readDirectory,
   readHead,
   readTail,
@@ -35,8 +37,8 @@ import {
   statDirectoryEntry,
   tailRecords,
   workspaceLabel,
-} from "../shared/local-session-adapter.js";
-import { type JsonlTranscriptReader, jsonlTranscriptReader } from "../shared/jsonl-transcript.js";
+} from "../shared/local-files.js";
+import { LocalFileSessionAdapter } from "../shared/local-session-adapter.js";
 import {
   CLAUDE_HOOK_EVENT,
   type ClaudeHookEvent,
@@ -93,7 +95,6 @@ const CLAUDE_CONTENT_TYPE = {
   TOOL_USE: "tool_use",
 } as const;
 
-/** Tool inputs whose value names the work, in the order they read best. */
 const CLAUDE_ADAPTER_DEFAULTS = {
   MAXIMUM_PROJECT_DIRECTORIES: 200,
   /**

--- a/packages/providers/src/claude-code/adapter.ts
+++ b/packages/providers/src/claude-code/adapter.ts
@@ -6,8 +6,6 @@ import {
   type ProviderSessionObservation,
   type ProviderTranscriptResult,
   type ProviderTranscriptSinceResult,
-  providerTranscriptResult,
-  providerTranscriptSinceResult,
   SESSION_COMPLETION_CAUSE,
   SESSION_STATUS,
   type SessionDetail,
@@ -23,13 +21,12 @@ import {
   wholeNumber,
 } from "@sidecar/wire";
 import {
+  discoverSessionFiles,
   type HookStatusRefinement,
   hookRefinedStatus,
-  localSessionStatus,
-} from "../shared/hook-status.js";
-import {
-  discoverSessionFiles,
   LOCAL_ADAPTER_DEFAULTS,
+  LocalFileSessionAdapter,
+  localSessionStatus,
   readDirectory,
   readHead,
   readTail,
@@ -38,9 +35,8 @@ import {
   statDirectoryEntry,
   tailRecords,
   workspaceLabel,
-} from "../shared/local-files.js";
-import { LocalFileSessionAdapter } from "../shared/local-session-adapter.js";
-import { TranscriptPathCache } from "../shared/local-transcript.js";
+} from "../shared/local-session-adapter.js";
+import { type JsonlTranscriptReader, jsonlTranscriptReader } from "../shared/jsonl-transcript.js";
 import {
   CLAUDE_HOOK_EVENT,
   type ClaudeHookEvent,
@@ -48,7 +44,8 @@ import {
   type ObservedClaudeHookEvent,
   readClaudeHookEvent,
 } from "./hooks.js";
-import { readClaudeSessionTranscript, readClaudeSessionTranscriptSince } from "./transcript.js";
+import { CLAUDE_TOOL_INPUT_KEYS } from "./records.js";
+import { claudeTranscriptFilePath, linesFromClaudeRecord } from "./transcript.js";
 
 const CLAUDE_CODE_PROVIDER_ID = PROVIDER_ID.CLAUDE_CODE;
 const CLAUDE_CODE_PROVIDER_NAME = "Claude Code";
@@ -97,8 +94,6 @@ const CLAUDE_CONTENT_TYPE = {
 } as const;
 
 /** Tool inputs whose value names the work, in the order they read best. */
-const CLAUDE_TOOL_INPUT_KEY = ["description", "file_path", "pattern", "command", "prompt"] as const;
-
 const CLAUDE_ADAPTER_DEFAULTS = {
   MAXIMUM_PROJECT_DIRECTORIES: 200,
   /**
@@ -227,7 +222,7 @@ function activityFromAssistant(record: WireRecord): string | undefined {
     const name = text(block.name);
     if (!name) continue;
     const input = isRecord(block.input) ? block.input : {};
-    for (const key of CLAUDE_TOOL_INPUT_KEY) {
+    for (const key of CLAUDE_TOOL_INPUT_KEYS) {
       const detail = oneLine(text(input[key]), CLAUDE_ADAPTER_DEFAULTS.MAXIMUM_ACTIVITY_LENGTH);
       if (detail) return `${name}: ${detail}`;
     }
@@ -529,13 +524,17 @@ export class ClaudeCodeSessionAdapter extends LocalFileSessionAdapter<
   readonly provider = CLAUDE_CODE_PROVIDER;
 
   readonly #claudeHome: string;
-  readonly #transcriptPaths = new TranscriptPathCache();
+  readonly #transcripts: JsonlTranscriptReader;
   readonly #hookEventsDirectory: (() => string | undefined) | undefined;
 
   constructor(options: ClaudeCodeAdapterOptions = {}) {
     super(options);
     this.#claudeHome = options.claudeHome ?? defaultClaudeHome();
     this.#hookEventsDirectory = options.hookEventsDirectory;
+    this.#transcripts = jsonlTranscriptReader({
+      locate: (providerSessionId) => claudeTranscriptFilePath(this.#claudeHome, providerSessionId),
+      lines: linesFromClaudeRecord,
+    });
   }
 
   protected async parse(candidate: SessionFileCandidate): Promise<ParsedClaudeSessionTail> {
@@ -589,25 +588,13 @@ export class ClaudeCodeSessionAdapter extends LocalFileSessionAdapter<
   }
 
   override readTranscript(providerSessionId: string): Promise<ProviderTranscriptResult> {
-    return providerTranscriptResult(
-      readClaudeSessionTranscript({
-        claudeHome: this.#claudeHome,
-        providerSessionId,
-      }),
-    );
+    return this.#transcripts.read(providerSessionId);
   }
 
   override readTranscriptSince(
     providerSessionId: string,
     cursor?: string,
   ): Promise<ProviderTranscriptSinceResult> {
-    return providerTranscriptSinceResult(
-      readClaudeSessionTranscriptSince({
-        claudeHome: this.#claudeHome,
-        providerSessionId,
-        cursor,
-        pathCache: this.#transcriptPaths,
-      }),
-    );
+    return this.#transcripts.readSince(providerSessionId, cursor);
   }
 }

--- a/packages/providers/src/claude-code/adapter.ts
+++ b/packages/providers/src/claude-code/adapter.ts
@@ -23,12 +23,13 @@ import {
   wholeNumber,
 } from "@sidecar/wire";
 import {
-  discoverSessionFiles,
   type HookStatusRefinement,
   hookRefinedStatus,
-  LOCAL_ADAPTER_DEFAULTS,
-  LocalFileSessionAdapter,
   localSessionStatus,
+} from "../shared/hook-status.js";
+import {
+  discoverSessionFiles,
+  LOCAL_ADAPTER_DEFAULTS,
   readDirectory,
   readHead,
   readTail,
@@ -37,7 +38,8 @@ import {
   statDirectoryEntry,
   tailRecords,
   workspaceLabel,
-} from "../shared/local-session-adapter.js";
+} from "../shared/local-files.js";
+import { LocalFileSessionAdapter } from "../shared/local-session-adapter.js";
 import { TranscriptPathCache } from "../shared/local-transcript.js";
 import {
   CLAUDE_HOOK_EVENT,

--- a/packages/providers/src/claude-code/desktop-applications.ts
+++ b/packages/providers/src/claude-code/desktop-applications.ts
@@ -9,11 +9,7 @@ import {
   type SessionApplication,
 } from "@sidecar/session";
 import { text, unparsedWire, type WireRecord, wireRecord } from "@sidecar/wire";
-import {
-  readDirectory,
-  readTextFile,
-  statDirectoryEntry,
-} from "../shared/local-session-adapter.js";
+import { readDirectory, readTextFile, statDirectoryEntry } from "../shared/local-files.js";
 import { WorkspaceHostSnapshot } from "../shared/workspace-host-snapshot.js";
 
 const CLAUDE_DESKTOP_APPLICATION_SUPPORT_DIRECTORY = "Claude";

--- a/packages/providers/src/claude-code/records.ts
+++ b/packages/providers/src/claude-code/records.ts
@@ -1,0 +1,19 @@
+/**
+ * The vocabulary Claude Code's own records are read with. It is one table per
+ * fact the provider writes down, seeded here with the one thing the
+ * observation pass and the transcript read both need to say.
+ */
+
+/**
+ * Tool inputs whose value names the work, in the order they read best. The
+ * observation pass and the transcript read look at the same tool blocks, so a
+ * second copy of this order would let a tool's activity be named one way on a
+ * row and another in a rendering.
+ */
+export const CLAUDE_TOOL_INPUT_KEYS = [
+  "description",
+  "file_path",
+  "pattern",
+  "command",
+  "prompt",
+] as const;

--- a/packages/providers/src/claude-code/transcript.test.ts
+++ b/packages/providers/src/claude-code/transcript.test.ts
@@ -5,8 +5,46 @@ import path from "node:path";
 import test, { type TestContext } from "node:test";
 import { OMISSION_MARKER } from "@sidecar/session";
 import type { ParsedJsonObject } from "@sidecar/wire/testing";
+import {
+  boundedTranscript,
+  jsonlTranscriptReader,
+  TRANSCRIPT_BOUNDS,
+} from "../shared/jsonl-transcript.js";
+import { readTail, tailRecords } from "../shared/local-files.js";
 import { ClaudeCodeSessionAdapter } from "./adapter.js";
-import { readClaudeSessionTranscript } from "./transcript.js";
+import { claudeTranscriptFilePath, linesFromClaudeRecord } from "./transcript.js";
+
+/**
+ * The reader the adapter builds, built here too: what is under test is where
+ * a session's records live and what one of them renders as, which is all a
+ * provider supplies.
+ */
+function claudeTranscripts(claudeHome: string) {
+  return jsonlTranscriptReader({
+    locate: (providerSessionId) => claudeTranscriptFilePath(claudeHome, providerSessionId),
+    lines: linesFromClaudeRecord,
+  });
+}
+
+async function readClaudeSessionTranscript(request: {
+  claudeHome: string;
+  providerSessionId: string;
+}): Promise<string | undefined> {
+  const result = await claudeTranscripts(request.claudeHome).read(request.providerSessionId);
+  return result.status === "accepted" ? result.transcript : undefined;
+}
+
+/** The rendered lines a session's records yield, for a test of the cut itself. */
+async function claudeTranscriptLines(
+  claudeHome: string,
+  providerSessionId: string,
+): Promise<readonly string[]> {
+  const filePath = await claudeTranscriptFilePath(claudeHome, providerSessionId);
+  assert.ok(filePath);
+  return tailRecords(await readTail(filePath, TRANSCRIPT_BOUNDS.READ_TAIL_BYTES)).flatMap(
+    linesFromClaudeRecord,
+  );
+}
 
 const TEST_SESSION_ID = "3f9a1b2c-4d5e-6789-abcd-ef0123456789";
 const CLAUDE_PROJECTS_DIRECTORY = "projects";
@@ -82,11 +120,9 @@ test("keeps the newest turns when the rendering is cut, and says so", async (t) 
   }));
   await writeTranscript(claudeHome, TEST_SESSION_ID, records);
 
-  const rendered = await readClaudeSessionTranscript({
-    claudeHome,
-    providerSessionId: TEST_SESSION_ID,
-    maximumRenderedLength: 400,
-  });
+  // The cut is `boundedTranscript`'s, so it is asked for where it lives: a
+  // read the build performs never cuts a rendering at all.
+  const rendered = boundedTranscript(await claudeTranscriptLines(claudeHome, TEST_SESSION_ID), 400);
 
   assert.ok(rendered);
   assert.ok(rendered.startsWith(`${OMISSION_MARKER}\n`));

--- a/packages/providers/src/claude-code/transcript.ts
+++ b/packages/providers/src/claude-code/transcript.ts
@@ -14,6 +14,7 @@ import {
   transcriptMessageText,
 } from "../shared/jsonl-transcript.js";
 import { readDirectory, statDirectoryEntry } from "../shared/local-files.js";
+import { CLAUDE_TOOL_INPUT_KEYS } from "./records.js";
 
 /**
  * On-demand reading of one Claude Code session's transcript, for a question
@@ -32,14 +33,11 @@ const CLAUDE_SESSION_FILE_EXTENSION = ".jsonl";
 /** The same shape the observation hook accepts: the ids Claude Code mints. */
 const CLAUDE_SESSION_ID_PATTERN = /^[0-9a-fA-F-]{8,64}$/;
 
-/** Tool inputs whose value names the work, in the order they read best. */
-const TOOL_INPUT_KEYS = ["description", "file_path", "pattern", "command", "prompt"] as const;
-
 function toolLine(block: WireRecord): string | undefined {
   const name = text(block.name);
   if (!name) return undefined;
   const input = isRecord(block.input) ? block.input : {};
-  for (const key of TOOL_INPUT_KEYS) {
+  for (const key of CLAUDE_TOOL_INPUT_KEYS) {
     const detail = oneLine(text(input[key]), TRANSCRIPT_BOUNDS.MAXIMUM_TOOL_LENGTH);
     if (detail) return transcriptLine.toolCall(name, detail);
   }

--- a/packages/providers/src/claude-code/transcript.ts
+++ b/packages/providers/src/claude-code/transcript.ts
@@ -1,5 +1,4 @@
 import path from "node:path";
-import type { ProviderTranscriptSinceReading } from "@sidecar/session";
 import {
   isRecord,
   isWireString,
@@ -8,16 +7,13 @@ import {
   type UnparsedWireValue,
   type WireRecord,
 } from "@sidecar/wire";
-import { readDirectory, readTail, statDirectoryEntry, tailRecords } from "../shared/local-files.js";
 import {
-  boundedTranscript,
-  readRecordsSince,
   TRANSCRIPT_BOUNDS,
-  type TranscriptPathCache,
   transcriptContentBlocks,
   transcriptLine,
   transcriptMessageText,
-} from "../shared/local-transcript.js";
+} from "../shared/jsonl-transcript.js";
+import { readDirectory, statDirectoryEntry } from "../shared/local-files.js";
 
 /**
  * On-demand reading of one Claude Code session's transcript, for a question
@@ -38,18 +34,6 @@ const CLAUDE_SESSION_ID_PATTERN = /^[0-9a-fA-F-]{8,64}$/;
 
 /** Tool inputs whose value names the work, in the order they read best. */
 const TOOL_INPUT_KEYS = ["description", "file_path", "pattern", "command", "prompt"] as const;
-
-export interface ClaudeTranscriptRequest {
-  claudeHome: string;
-  providerSessionId: string;
-  readTailBytes?: number;
-  maximumRenderedLength?: number;
-}
-
-export interface ClaudeTranscriptSinceRequest extends ClaudeTranscriptRequest {
-  cursor?: string;
-  pathCache: TranscriptPathCache;
-}
 
 function toolLine(block: WireRecord): string | undefined {
   const name = text(block.name);
@@ -105,7 +89,7 @@ function isToolResult(record: WireRecord): boolean {
 }
 
 /** Renders one record into the lines a conversation can carry, oldest first. */
-function linesFromRecord(record: WireRecord): string[] {
+export function linesFromClaudeRecord(record: WireRecord): string[] {
   if (record.type === "user") {
     if (isToolResult(record)) {
       const answer = oneLine(toolResultText(record), TRANSCRIPT_BOUNDS.MAXIMUM_TOOL_LENGTH);
@@ -151,7 +135,7 @@ function linesFromRecord(record: WireRecord): string[] {
  * without trusting the id as a path: an id outside the shape Claude Code
  * mints names nothing.
  */
-async function transcriptFilePath(
+export async function claudeTranscriptFilePath(
   claudeHome: string,
   providerSessionId: string,
 ): Promise<string | undefined> {
@@ -165,45 +149,4 @@ async function transcriptFilePath(
     if (candidate?.stats.isFile()) return candidate.directoryPath;
   }
   return undefined;
-}
-
-/**
- * Reads one session's recent transcript into a bounded rendering, or nothing
- * when no transcript file exists for that id.
- */
-export async function readClaudeSessionTranscript(
-  request: ClaudeTranscriptRequest,
-): Promise<string | undefined> {
-  const filePath = await transcriptFilePath(request.claudeHome, request.providerSessionId);
-  if (!filePath) return undefined;
-
-  const tail = await readTail(filePath, request.readTailBytes ?? TRANSCRIPT_BOUNDS.READ_TAIL_BYTES);
-  const lines = tailRecords(tail).flatMap(linesFromRecord);
-  return boundedTranscript(lines, request.maximumRenderedLength);
-}
-
-/**
- * Renders what the session's transcript has gained since `cursor`, or nothing
- * when no transcript file exists for that id. The rendering is unbounded in
- * total, like a tail read with no maximum: the window the read loads and the
- * per-line cuts are the bounds.
- */
-export async function readClaudeSessionTranscriptSince(
-  request: ClaudeTranscriptSinceRequest,
-): Promise<ProviderTranscriptSinceReading | undefined> {
-  const filePath = await request.pathCache.resolve(request.providerSessionId, () =>
-    transcriptFilePath(request.claudeHome, request.providerSessionId),
-  );
-  if (!filePath) return undefined;
-
-  const since = await readRecordsSince(
-    filePath,
-    request.cursor,
-    request.readTailBytes ?? TRANSCRIPT_BOUNDS.READ_TAIL_BYTES,
-  );
-  return {
-    text: boundedTranscript(since.records.flatMap(linesFromRecord)) ?? "",
-    cursor: since.cursor,
-    truncated: since.truncated,
-  };
 }

--- a/packages/providers/src/claude-code/transcript.ts
+++ b/packages/providers/src/claude-code/transcript.ts
@@ -8,12 +8,7 @@ import {
   type UnparsedWireValue,
   type WireRecord,
 } from "@sidecar/wire";
-import {
-  readDirectory,
-  readTail,
-  statDirectoryEntry,
-  tailRecords,
-} from "../shared/local-session-adapter.js";
+import { readDirectory, readTail, statDirectoryEntry, tailRecords } from "../shared/local-files.js";
 import {
   boundedTranscript,
   readRecordsSince,

--- a/packages/providers/src/codex/adapter.ts
+++ b/packages/providers/src/codex/adapter.ts
@@ -27,6 +27,7 @@ import {
   type WireRecord,
 } from "@sidecar/wire";
 import { type HookStatusRefinement, hookRefinedStatus } from "../shared/hook-status.js";
+import { TranscriptPathCache } from "../shared/jsonl-transcript.js";
 import { readTail, readTextFile, uniquePaths, workspaceLabel } from "../shared/local-files.js";
 import { LocalSessionAdapter } from "../shared/local-session-adapter.js";
 import {
@@ -37,7 +38,6 @@ import {
   type SqliteModuleLoader,
   textFromRow,
 } from "../shared/local-sqlite.js";
-import { TranscriptPathCache } from "../shared/local-transcript.js";
 import {
   CODEX_HOOK_EVENT,
   type CodexHookEvent,

--- a/packages/providers/src/codex/adapter.ts
+++ b/packages/providers/src/codex/adapter.ts
@@ -26,15 +26,9 @@ import {
   type UnparsedWireValue,
   type WireRecord,
 } from "@sidecar/wire";
-import {
-  type HookStatusRefinement,
-  hookRefinedStatus,
-  LocalSessionAdapter,
-  readTail,
-  readTextFile,
-  uniquePaths,
-  workspaceLabel,
-} from "../shared/local-session-adapter.js";
+import { type HookStatusRefinement, hookRefinedStatus } from "../shared/hook-status.js";
+import { readTail, readTextFile, uniquePaths, workspaceLabel } from "../shared/local-files.js";
+import { LocalSessionAdapter } from "../shared/local-session-adapter.js";
 import {
   canIgnoreSqliteError,
   defaultSqliteModule,

--- a/packages/providers/src/codex/cloud-adapter.test.ts
+++ b/packages/providers/src/codex/cloud-adapter.test.ts
@@ -14,7 +14,7 @@ import {
   type AdapterDiagnosticCallback,
 } from "../shared/adapter-diagnostics.js";
 import { ADAPTER_FAILURE, AdapterFailure } from "../shared/adapter-failure.js";
-import { CLI_ADAPTER_DEFAULTS, type CliRun } from "../shared/cli-session-adapter.js";
+import { CLI_ADAPTER_DEFAULTS, type CliRun } from "../shared/cli-pass.js";
 import { CodexCloudSessionAdapter } from "./cloud-adapter.js";
 
 const TEST_TIME = Date.parse("2026-08-18T02:45:00.000Z");

--- a/packages/providers/src/codex/cloud-adapter.test.ts
+++ b/packages/providers/src/codex/cloud-adapter.test.ts
@@ -13,12 +13,8 @@ import {
   ADAPTER_DIAGNOSTIC_KIND,
   type AdapterDiagnosticCallback,
 } from "../shared/adapter-diagnostics.js";
-import {
-  CLI_ADAPTER_DEFAULTS,
-  CLI_FAILURE,
-  CliCommandError,
-  type CliRun,
-} from "../shared/cli-session-adapter.js";
+import { ADAPTER_FAILURE, AdapterFailure } from "../shared/adapter-failure.js";
+import { CLI_ADAPTER_DEFAULTS, type CliRun } from "../shared/cli-session-adapter.js";
 import { CodexCloudSessionAdapter } from "./cloud-adapter.js";
 
 const TEST_TIME = Date.parse("2026-08-18T02:45:00.000Z");
@@ -93,7 +89,7 @@ function fakeCodexCli(behavior: FakeCliBehavior) {
   const run: CliRun = async (binary, argv) => {
     invocations.push({ binary, argv });
     if (behavior.binaryMissing) {
-      throw new CliCommandError(CLI_FAILURE.UNAVAILABLE, "codex could not be run");
+      throw new AdapterFailure(ADAPTER_FAILURE.UNAVAILABLE, "codex could not be run");
     }
     if (argv.join(" ") === LOGIN_PROBE_ARGV.join(" ")) {
       return { exitCode: (behavior.loggedIn ?? true) ? 0 : 1, stdout: "" };

--- a/packages/providers/src/codex/cloud-adapter.ts
+++ b/packages/providers/src/codex/cloud-adapter.ts
@@ -12,11 +12,8 @@ import {
   type WorkspaceProject,
 } from "@sidecar/session";
 import { isRecord, isWireNumber, type UnparsedWireValue, type WireRecord } from "@sidecar/wire";
-import {
-  type CliAdapterOptions,
-  type CliReadRequest,
-  CliSessionAdapter,
-} from "../shared/cli-session-adapter.js";
+import type { CliReadRequest } from "../shared/cli-pass.js";
+import { type CliAdapterOptions, CliSessionAdapter } from "../shared/cli-session-adapter.js";
 import {
   isDefined,
   knownValue,
@@ -24,7 +21,7 @@ import {
   repositoryLabel,
   textFromRecord,
   timestampFromRecord,
-} from "../shared/cloud-session-adapter.js";
+} from "../shared/cloud-wire.js";
 import { CODEX_PROVIDER } from "./adapter.js";
 
 /**

--- a/packages/providers/src/codex/transcript.ts
+++ b/packages/providers/src/codex/transcript.ts
@@ -8,7 +8,7 @@ import {
   type UnparsedWireValue,
   type WireRecord,
 } from "@sidecar/wire";
-import { readTail, tailRecords } from "../shared/local-session-adapter.js";
+import { readTail, tailRecords } from "../shared/local-files.js";
 import {
   canIgnoreSqliteError,
   defaultSqliteModule,

--- a/packages/providers/src/codex/transcript.ts
+++ b/packages/providers/src/codex/transcript.ts
@@ -8,6 +8,13 @@ import {
   type UnparsedWireValue,
   type WireRecord,
 } from "@sidecar/wire";
+import {
+  boundedTranscript,
+  readRecordsSince,
+  TRANSCRIPT_BOUNDS,
+  type TranscriptPathCache,
+  transcriptLine,
+} from "../shared/jsonl-transcript.js";
 import { readTail, tailRecords } from "../shared/local-files.js";
 import {
   canIgnoreSqliteError,
@@ -15,13 +22,6 @@ import {
   openReadOnlyDatabase,
   type SqliteModuleLoader,
 } from "../shared/local-sqlite.js";
-import {
-  boundedTranscript,
-  readRecordsSince,
-  TRANSCRIPT_BOUNDS,
-  type TranscriptPathCache,
-  transcriptLine,
-} from "../shared/local-transcript.js";
 import {
   argumentPhrase,
   CODEX_CALL_ARGUMENT_KEY,

--- a/packages/providers/src/conductor/adapter.test.ts
+++ b/packages/providers/src/conductor/adapter.test.ts
@@ -8,9 +8,10 @@ import {
   SESSION_STATUS,
   UNSUPPORTED_BY_OBSERVATION,
 } from "@sidecar/session";
+import type { CloudFetch } from "@sidecar/wire";
 import type { JsonObject, JsonValue } from "@sidecar/wire/testing";
 import { HTTP_STATUS, jsonResponse, recordingFetch } from "@sidecar/wire/testing";
-import { CLOUD_ADAPTER_DEFAULTS, type CloudFetch } from "../shared/cloud-session-adapter.js";
+import { CLOUD_ADAPTER_DEFAULTS } from "../shared/cloud-wire.js";
 import { CONDUCTOR_PROVIDER, ConductorSessionAdapter } from "./adapter.js";
 
 const TEST_TIME = Date.parse("2026-08-12T02:45:00.000Z");

--- a/packages/providers/src/conductor/adapter.ts
+++ b/packages/providers/src/conductor/adapter.ts
@@ -29,11 +29,10 @@ import {
 } from "@sidecar/session";
 import { isRecord, text, type UnparsedWireValue, type WireRecord } from "@sidecar/wire";
 import { ADAPTER_FAILURE, AdapterFailure } from "../shared/adapter-failure.js";
+import { type CloudAdapterOptions, CloudSessionAdapter } from "../shared/cloud-session-adapter.js";
 import {
   CLOUD_ADAPTER_DEFAULTS,
-  type CloudAdapterOptions,
   type CloudRequest,
-  CloudSessionAdapter,
   type CloudWriteRoute,
   isDefined,
   knownValue,
@@ -41,7 +40,7 @@ import {
   repositoryLabel,
   textFromRecord,
   timestampFromRecord,
-} from "../shared/cloud-session-adapter.js";
+} from "../shared/cloud-wire.js";
 import { CONDUCTOR_AGENT_BY_TYPE } from "./session-applications.js";
 
 // Shared with the credential registry so the key the user saves and the

--- a/packages/providers/src/conductor/adapter.ts
+++ b/packages/providers/src/conductor/adapter.ts
@@ -28,12 +28,11 @@ import {
   workspaceAgentModels,
 } from "@sidecar/session";
 import { isRecord, text, type UnparsedWireValue, type WireRecord } from "@sidecar/wire";
+import { ADAPTER_FAILURE, AdapterFailure } from "../shared/adapter-failure.js";
 import {
   CLOUD_ADAPTER_DEFAULTS,
-  CLOUD_FAILURE,
   type CloudAdapterOptions,
   type CloudRequest,
-  CloudRequestError,
   CloudSessionAdapter,
   type CloudWriteRoute,
   isDefined,
@@ -988,11 +987,11 @@ export class ConductorSessionAdapter extends CloudSessionAdapter {
         request.beforeOffset === undefined,
       );
     } catch (error) {
-      if (error instanceof CloudRequestError) {
+      if (error instanceof AdapterFailure) {
         return {
           status: ACT_RESULT_STATUS.REJECTED,
           reason:
-            error.failure === CLOUD_FAILURE.UNAUTHORIZED
+            error.failure === ADAPTER_FAILURE.UNAUTHORIZED
               ? `${CONDUCTOR_PROVIDER_NAME} rejected the configured API key.`
               : `${CONDUCTOR_PROVIDER_NAME} did not answer, so the conversation could not be read.`,
         };

--- a/packages/providers/src/conductor/local-workspace-adapter.ts
+++ b/packages/providers/src/conductor/local-workspace-adapter.ts
@@ -11,7 +11,7 @@ import {
   type WorkspaceProject,
 } from "@sidecar/session";
 import { text, UNKNOWN_ACT_STATUS, wireRecord } from "@sidecar/wire";
-import { repositoryLabel } from "../shared/cloud-session-adapter.js";
+import { repositoryLabel } from "../shared/cloud-wire.js";
 import {
   canIgnoreSqliteError,
   defaultSqliteModule,

--- a/packages/providers/src/conductor/session-applications.ts
+++ b/packages/providers/src/conductor/session-applications.ts
@@ -10,6 +10,7 @@ import {
   type SessionProvider,
 } from "@sidecar/session";
 import { text, type UnparsedWireValue, wholeNumber, wireRecord } from "@sidecar/wire";
+import { unclaimedWorkspace } from "../shared/host-claims.js";
 import {
   canIgnoreSqliteError,
   defaultSqliteModule,
@@ -17,7 +18,7 @@ import {
   type SqliteDatabase,
   type SqliteModuleLoader,
 } from "../shared/local-sqlite.js";
-import { unclaimedWorkspace, WorkspaceHostSnapshot } from "../shared/workspace-host-snapshot.js";
+import { WorkspaceHostSnapshot } from "../shared/workspace-host-snapshot.js";
 
 const CONDUCTOR_APPLICATION_SUPPORT_DIRECTORY = "com.conductor.app";
 const CONDUCTOR_DATABASE_FILE = "conductor.db";

--- a/packages/providers/src/index.ts
+++ b/packages/providers/src/index.ts
@@ -17,7 +17,7 @@ export {
   type AdapterDiagnosticCallback,
   type AdapterDiagnosticKind,
 } from "./shared/adapter-diagnostics.js";
-export { canIgnoreFilesystemError, readDirectory } from "./shared/local-session-adapter.js";
+export { canIgnoreFilesystemError, readDirectory } from "./shared/local-files.js";
 export {
   canIgnoreSqliteError,
   defaultSqliteModule,

--- a/packages/providers/src/omp/adapter.ts
+++ b/packages/providers/src/omp/adapter.ts
@@ -12,11 +12,11 @@ import {
   type SessionStatus,
 } from "@sidecar/session";
 import { isRecord, isWireString, oneLine, text, type WireRecord } from "@sidecar/wire";
+import { localSessionStatus } from "../shared/hook-status.js";
+import { type JsonlTranscriptReader, jsonlTranscriptReader } from "../shared/jsonl-transcript.js";
 import {
   discoverSessionFiles,
   LOCAL_ADAPTER_DEFAULTS,
-  LocalFileSessionAdapter,
-  localSessionStatus,
   readDirectory,
   readHead,
   readTail,
@@ -24,8 +24,8 @@ import {
   statDirectoryEntry,
   tailRecords,
   workspaceLabel,
-} from "../shared/local-session-adapter.js";
-import { type JsonlTranscriptReader, jsonlTranscriptReader } from "../shared/jsonl-transcript.js";
+} from "../shared/local-files.js";
+import { LocalFileSessionAdapter } from "../shared/local-session-adapter.js";
 import {
   defaultOmpHome,
   OMP_CONTENT_TYPE,

--- a/packages/providers/src/omp/adapter.ts
+++ b/packages/providers/src/omp/adapter.ts
@@ -14,11 +14,10 @@ import {
   type SessionStatus,
 } from "@sidecar/session";
 import { isRecord, isWireString, oneLine, text, type WireRecord } from "@sidecar/wire";
+import { localSessionStatus } from "../shared/hook-status.js";
 import {
   discoverSessionFiles,
   LOCAL_ADAPTER_DEFAULTS,
-  LocalFileSessionAdapter,
-  localSessionStatus,
   readDirectory,
   readHead,
   readTail,
@@ -26,7 +25,8 @@ import {
   statDirectoryEntry,
   tailRecords,
   workspaceLabel,
-} from "../shared/local-session-adapter.js";
+} from "../shared/local-files.js";
+import { LocalFileSessionAdapter } from "../shared/local-session-adapter.js";
 import { TranscriptPathCache } from "../shared/local-transcript.js";
 import {
   defaultOmpHome,

--- a/packages/providers/src/omp/adapter.ts
+++ b/packages/providers/src/omp/adapter.ts
@@ -5,8 +5,6 @@ import {
   type ProviderSessionObservation,
   type ProviderTranscriptResult,
   type ProviderTranscriptSinceResult,
-  providerTranscriptResult,
-  providerTranscriptSinceResult,
   SESSION_COMPLETION_CAUSE,
   SESSION_STATUS,
   type SessionDetail,
@@ -14,10 +12,11 @@ import {
   type SessionStatus,
 } from "@sidecar/session";
 import { isRecord, isWireString, oneLine, text, type WireRecord } from "@sidecar/wire";
-import { localSessionStatus } from "../shared/hook-status.js";
 import {
   discoverSessionFiles,
   LOCAL_ADAPTER_DEFAULTS,
+  LocalFileSessionAdapter,
+  localSessionStatus,
   readDirectory,
   readHead,
   readTail,
@@ -25,9 +24,8 @@ import {
   statDirectoryEntry,
   tailRecords,
   workspaceLabel,
-} from "../shared/local-files.js";
-import { LocalFileSessionAdapter } from "../shared/local-session-adapter.js";
-import { TranscriptPathCache } from "../shared/local-transcript.js";
+} from "../shared/local-session-adapter.js";
+import { type JsonlTranscriptReader, jsonlTranscriptReader } from "../shared/jsonl-transcript.js";
 import {
   defaultOmpHome,
   OMP_CONTENT_TYPE,
@@ -42,7 +40,7 @@ import {
   ompMessageText,
   sessionIdFromOmpFileName,
 } from "./records.js";
-import { readOmpSessionTranscript, readOmpSessionTranscriptSince } from "./transcript.js";
+import { linesFromOmpRecord, ompTranscriptFilePath } from "./transcript.js";
 
 const OMP_PROVIDER_ID = PROVIDER_ID.OMP;
 const OMP_PROVIDER_NAME = "OMP";
@@ -306,11 +304,15 @@ export class OmpSessionAdapter extends LocalFileSessionAdapter<
   readonly provider = OMP_PROVIDER;
 
   readonly #ompHome: string;
-  readonly #transcriptPaths = new TranscriptPathCache();
+  readonly #transcripts: JsonlTranscriptReader;
 
   constructor(options: OmpAdapterOptions = {}) {
     super(options);
     this.#ompHome = options.ompHome ?? defaultOmpHome();
+    this.#transcripts = jsonlTranscriptReader({
+      locate: (providerSessionId) => ompTranscriptFilePath(this.#ompHome, providerSessionId),
+      lines: linesFromOmpRecord,
+    });
   }
 
   protected discover(): Promise<OmpSessionFileCandidate[]> {
@@ -351,25 +353,13 @@ export class OmpSessionAdapter extends LocalFileSessionAdapter<
   }
 
   override readTranscript(providerSessionId: string): Promise<ProviderTranscriptResult> {
-    return providerTranscriptResult(
-      readOmpSessionTranscript({
-        ompHome: this.#ompHome,
-        providerSessionId,
-      }),
-    );
+    return this.#transcripts.read(providerSessionId);
   }
 
   override readTranscriptSince(
     providerSessionId: string,
     cursor?: string,
   ): Promise<ProviderTranscriptSinceResult> {
-    return providerTranscriptSinceResult(
-      readOmpSessionTranscriptSince({
-        ompHome: this.#ompHome,
-        providerSessionId,
-        cursor,
-        pathCache: this.#transcriptPaths,
-      }),
-    );
+    return this.#transcripts.readSince(providerSessionId, cursor);
   }
 }

--- a/packages/providers/src/omp/transcript.test.ts
+++ b/packages/providers/src/omp/transcript.test.ts
@@ -5,8 +5,11 @@ import path from "node:path";
 import test, { type TestContext } from "node:test";
 import { OMISSION_MARKER } from "@sidecar/session";
 import type { ParsedJsonObject } from "@sidecar/wire/testing";
+import { boundedTranscript, TRANSCRIPT_BOUNDS } from "../shared/jsonl-transcript.js";
+import { readTail, tailRecords } from "../shared/local-files.js";
 import { OmpSessionAdapter } from "./adapter.js";
 import { OMP_SESSIONS_DIRECTORY } from "./records.js";
+import { linesFromOmpRecord, ompTranscriptFilePath } from "./transcript.js";
 
 const SESSION_ID = "01a0540a-c238-7264-80d8-546b0c7be0d8";
 
@@ -14,12 +17,10 @@ const SESSION_ID = "01a0540a-c238-7264-80d8-546b0c7be0d8";
 async function readOmpSessionTranscript(request: {
   ompHome: string;
   providerSessionId: string;
-  maximumRenderedLength?: number;
 }): Promise<string | undefined> {
-  const result = await new OmpSessionAdapter({
-    ompHome: request.ompHome,
-    transcriptMaximumRenderedLength: request.maximumRenderedLength,
-  }).readTranscript(request.providerSessionId);
+  const result = await new OmpSessionAdapter({ ompHome: request.ompHome }).readTranscript(
+    request.providerSessionId,
+  );
   return result.status === "accepted" ? result.transcript : undefined;
 }
 const SESSION_FILE_NAME = `2026-08-20T11-58-00-000Z_${SESSION_ID}.jsonl`;
@@ -171,11 +172,16 @@ test("keeps the newest turns when the rendering outgrows its bound", async (t) =
   const ompHome = await temporaryOmpHome(t);
   await writeSessionFile(ompHome, CONVERSATION);
 
-  const rendered = await readOmpSessionTranscript({
-    ompHome,
-    providerSessionId: SESSION_ID,
-    maximumRenderedLength: 80,
-  });
+  // The cut is `boundedTranscript`'s, so it is asked for where it lives: a
+  // read the build performs never cuts a rendering at all.
+  const filePath = await ompTranscriptFilePath(ompHome, SESSION_ID);
+  assert.ok(filePath);
+  const rendered = boundedTranscript(
+    tailRecords(await readTail(filePath, TRANSCRIPT_BOUNDS.READ_TAIL_BYTES)).flatMap(
+      linesFromOmpRecord,
+    ),
+    80,
+  );
 
   assert.ok(rendered?.startsWith(OMISSION_MARKER));
   assert.ok(rendered?.endsWith("OMP: Fixed; the test passes now."));

--- a/packages/providers/src/omp/transcript.test.ts
+++ b/packages/providers/src/omp/transcript.test.ts
@@ -7,9 +7,21 @@ import { OMISSION_MARKER } from "@sidecar/session";
 import type { ParsedJsonObject } from "@sidecar/wire/testing";
 import { OmpSessionAdapter } from "./adapter.js";
 import { OMP_SESSIONS_DIRECTORY } from "./records.js";
-import { readOmpSessionTranscript } from "./transcript.js";
 
 const SESSION_ID = "01a0540a-c238-7264-80d8-546b0c7be0d8";
+
+/** Reads through the adapter, which is the only caller a rendering has. */
+async function readOmpSessionTranscript(request: {
+  ompHome: string;
+  providerSessionId: string;
+  maximumRenderedLength?: number;
+}): Promise<string | undefined> {
+  const result = await new OmpSessionAdapter({
+    ompHome: request.ompHome,
+    transcriptMaximumRenderedLength: request.maximumRenderedLength,
+  }).readTranscript(request.providerSessionId);
+  return result.status === "accepted" ? result.transcript : undefined;
+}
 const SESSION_FILE_NAME = `2026-08-20T11-58-00-000Z_${SESSION_ID}.jsonl`;
 
 async function temporaryOmpHome(t: TestContext): Promise<string> {

--- a/packages/providers/src/omp/transcript.ts
+++ b/packages/providers/src/omp/transcript.ts
@@ -1,14 +1,7 @@
 import path from "node:path";
-import type { ProviderTranscriptSinceReading } from "@sidecar/session";
 import { isRecord, oneLine, text, type WireRecord } from "@sidecar/wire";
-import { readDirectory, readTail, statDirectoryEntry, tailRecords } from "../shared/local-files.js";
-import {
-  boundedTranscript,
-  readRecordsSince,
-  TRANSCRIPT_BOUNDS,
-  type TranscriptPathCache,
-  transcriptLine,
-} from "../shared/local-transcript.js";
+import { TRANSCRIPT_BOUNDS, transcriptLine } from "../shared/jsonl-transcript.js";
+import { readDirectory, statDirectoryEntry } from "../shared/local-files.js";
 import {
   OMP_CONTENT_TYPE,
   OMP_MESSAGE_ROLE,
@@ -30,18 +23,6 @@ import {
 const OMP_SPEAKER_NAME = "OMP";
 const OMP_TOOL_INPUT_KEY = ["command", "path", "file_path", "pattern", "prompt"] as const;
 
-export interface OmpTranscriptRequest {
-  ompHome: string;
-  providerSessionId: string;
-  readTailBytes?: number;
-  maximumRenderedLength?: number;
-}
-
-export interface OmpTranscriptSinceRequest extends OmpTranscriptRequest {
-  cursor?: string;
-  pathCache: TranscriptPathCache;
-}
-
 function toolCallLine(block: WireRecord): string | undefined {
   const name = text(block.name);
   if (!name) return undefined;
@@ -55,7 +36,7 @@ function toolCallLine(block: WireRecord): string | undefined {
   return transcriptLine.toolCall(name);
 }
 
-function linesFromRecord(record: WireRecord): string[] {
+export function linesFromOmpRecord(record: WireRecord): string[] {
   const message = ompMessageFrom(record);
   if (!message) return [];
   const role = text(message.role);
@@ -94,7 +75,7 @@ function linesFromRecord(record: WireRecord): string[] {
  * ends in `_<id>.jsonl` inside one encoded-cwd directory, without trusting
  * the id as a path.
  */
-async function transcriptFilePath(
+export async function ompTranscriptFilePath(
   ompHome: string,
   providerSessionId: string,
 ): Promise<string | undefined> {
@@ -110,45 +91,4 @@ async function transcriptFilePath(
     }
   }
   return undefined;
-}
-
-/**
- * Reads one session's recent transcript into a bounded rendering, or nothing
- * when no recording exists for that id.
- */
-export async function readOmpSessionTranscript(
-  request: OmpTranscriptRequest,
-): Promise<string | undefined> {
-  const filePath = await transcriptFilePath(request.ompHome, request.providerSessionId);
-  if (!filePath) return undefined;
-
-  const tail = await readTail(filePath, request.readTailBytes ?? TRANSCRIPT_BOUNDS.READ_TAIL_BYTES);
-  return boundedTranscript(
-    tailRecords(tail).flatMap(linesFromRecord),
-    request.maximumRenderedLength,
-  );
-}
-
-/**
- * Renders what the session's recording has gained since `cursor`, or nothing
- * when no recording exists for that id.
- */
-export async function readOmpSessionTranscriptSince(
-  request: OmpTranscriptSinceRequest,
-): Promise<ProviderTranscriptSinceReading | undefined> {
-  const filePath = await request.pathCache.resolve(request.providerSessionId, () =>
-    transcriptFilePath(request.ompHome, request.providerSessionId),
-  );
-  if (!filePath) return undefined;
-
-  const since = await readRecordsSince(
-    filePath,
-    request.cursor,
-    request.readTailBytes ?? TRANSCRIPT_BOUNDS.READ_TAIL_BYTES,
-  );
-  return {
-    text: boundedTranscript(since.records.flatMap(linesFromRecord)) ?? "",
-    cursor: since.cursor,
-    truncated: since.truncated,
-  };
 }

--- a/packages/providers/src/omp/transcript.ts
+++ b/packages/providers/src/omp/transcript.ts
@@ -1,12 +1,7 @@
 import path from "node:path";
 import type { ProviderTranscriptSinceReading } from "@sidecar/session";
 import { isRecord, oneLine, text, type WireRecord } from "@sidecar/wire";
-import {
-  readDirectory,
-  readTail,
-  statDirectoryEntry,
-  tailRecords,
-} from "../shared/local-session-adapter.js";
+import { readDirectory, readTail, statDirectoryEntry, tailRecords } from "../shared/local-files.js";
 import {
   boundedTranscript,
   readRecordsSince,

--- a/packages/providers/src/shared/adapter-failure.test.ts
+++ b/packages/providers/src/shared/adapter-failure.test.ts
@@ -1,0 +1,26 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { ADAPTER_FAILURE, AdapterFailure, clearsObservedState } from "./adapter-failure.js";
+
+test("a rejected credential and nothing to observe with both clear observed state", () => {
+  assert.equal(clearsObservedState(ADAPTER_FAILURE.UNAUTHORIZED), true);
+  assert.equal(clearsObservedState(ADAPTER_FAILURE.UNAVAILABLE), true);
+});
+
+test("a failure that says nothing about the credential leaves the snapshot standing", () => {
+  assert.equal(clearsObservedState(ADAPTER_FAILURE.TRANSIENT), false);
+});
+
+test("every failure kind has an answer, so a new one cannot arrive undecided", () => {
+  for (const failure of Object.values(ADAPTER_FAILURE)) {
+    assert.equal(typeof clearsObservedState(failure), "boolean");
+  }
+});
+
+test("a failure carries its kind and stays an error", () => {
+  const failure = new AdapterFailure(ADAPTER_FAILURE.TRANSIENT, "the provider did not answer");
+  assert.ok(failure instanceof Error);
+  assert.equal(failure.name, "AdapterFailure");
+  assert.equal(failure.failure, ADAPTER_FAILURE.TRANSIENT);
+  assert.equal(failure.message, "the provider did not answer");
+});

--- a/packages/providers/src/shared/adapter-failure.test.ts
+++ b/packages/providers/src/shared/adapter-failure.test.ts
@@ -12,9 +12,15 @@ test("a failure that says nothing about the credential leaves the snapshot stand
 });
 
 test("every failure kind has an answer, so a new one cannot arrive undecided", () => {
-  for (const failure of Object.values(ADAPTER_FAILURE)) {
-    assert.equal(typeof clearsObservedState(failure), "boolean");
-  }
+  const answers = Object.values(ADAPTER_FAILURE).map((failure) => [
+    failure,
+    clearsObservedState(failure),
+  ]);
+  assert.deepEqual(answers, [
+    [ADAPTER_FAILURE.UNAUTHORIZED, true],
+    [ADAPTER_FAILURE.UNAVAILABLE, true],
+    [ADAPTER_FAILURE.TRANSIENT, false],
+  ]);
 });
 
 test("a failure carries its kind and stays an error", () => {

--- a/packages/providers/src/shared/adapter-failure.ts
+++ b/packages/providers/src/shared/adapter-failure.ts
@@ -36,3 +36,19 @@ export class AdapterFailure extends Error {
 export function clearsObservedState(failure: AdapterFailureKind): boolean {
   return failure !== ADAPTER_FAILURE.TRANSIENT;
 }
+
+/**
+ * Keeps one failed resource from discarding an otherwise complete pass. A
+ * failure that clears observed state is not one resource's problem, so it
+ * still ends the pass.
+ */
+export async function tolerateItemFailure<Result>(
+  operation: () => Promise<Result>,
+): Promise<Result | undefined> {
+  try {
+    return await operation();
+  } catch (error) {
+    if (error instanceof AdapterFailure && clearsObservedState(error.failure)) throw error;
+    return undefined;
+  }
+}

--- a/packages/providers/src/shared/adapter-failure.ts
+++ b/packages/providers/src/shared/adapter-failure.ts
@@ -1,0 +1,38 @@
+/**
+ * How an observation fails, in one vocabulary for every way a provider is
+ * observed. A cloud provider spoke of a rejected credential and a network
+ * blip, a CLI provider of an absent binary and a command that failed, and the
+ * two rules were already the same rule under different names: some failures
+ * mean the observed state was read under something that no longer stands, and
+ * the rest mean the read simply did not happen this time.
+ */
+export const ADAPTER_FAILURE = {
+  /** The credential or login was rejected: observed state clears. */
+  UNAUTHORIZED: "unauthorized",
+  /** There is nothing to observe with — no binary, no key, signed out: observed state clears. */
+  UNAVAILABLE: "unavailable",
+  /** It ran and failed: the previous snapshot stands until the next attempt. */
+  TRANSIENT: "transient",
+} as const;
+
+export type AdapterFailureKind = (typeof ADAPTER_FAILURE)[keyof typeof ADAPTER_FAILURE];
+
+export class AdapterFailure extends Error {
+  readonly failure: AdapterFailureKind;
+
+  constructor(failure: AdapterFailureKind, message: string) {
+    super(message);
+    this.name = "AdapterFailure";
+    this.failure = failure;
+  }
+}
+
+/**
+ * Whether this failure clears what the last pass observed. Nothing read under
+ * a credential or login that has since been rejected or withdrawn may keep
+ * being served; a failure that says nothing about either leaves the previous
+ * snapshot standing, because a network blip is not news about a session.
+ */
+export function clearsObservedState(failure: AdapterFailureKind): boolean {
+  return failure !== ADAPTER_FAILURE.TRANSIENT;
+}

--- a/packages/providers/src/shared/cli-pass.test.ts
+++ b/packages/providers/src/shared/cli-pass.test.ts
@@ -1,0 +1,246 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  ACT_RESULT_STATUS,
+  CLI_CONNECTION,
+  type ProviderSessionObservation,
+  SESSION_LOCATION,
+  SESSION_STATUS,
+  type SessionProvider,
+} from "@sidecar/session";
+import { ADAPTER_DIAGNOSTIC_KIND } from "./adapter-diagnostics.js";
+import { ADAPTER_FAILURE, AdapterFailure } from "./adapter-failure.js";
+import { type CliPassInput, type CliRun, cliPass } from "./cli-pass.js";
+
+const TEST_TIME = Date.parse("2026-09-01T12:00:00.000Z");
+const BINARY = "stub";
+const LOGIN_PROBE_ARGV = ["login", "status"];
+const LIST_ARGV = ["cloud", "list", "--json"];
+
+const STUB_PROVIDER: SessionProvider = { id: "stub", displayName: "Stub" };
+
+function observation(providerSessionId: string): ProviderSessionObservation {
+  return {
+    providerSessionId,
+    title: providerSessionId,
+    status: SESSION_STATUS.WORKING,
+    lastActivityAt: TEST_TIME,
+  };
+}
+
+interface CliBehavior {
+  signedOut?: boolean;
+  binaryMissing?: boolean;
+  listFails?: boolean;
+  listStdout?: string;
+}
+
+function fakeCli(behavior: CliBehavior = {}) {
+  const invocations: (readonly string[])[] = [];
+  const run: CliRun = async (_binary, argv) => {
+    invocations.push(argv);
+    if (behavior.binaryMissing) {
+      throw new AdapterFailure(ADAPTER_FAILURE.UNAVAILABLE, "no binary");
+    }
+    if (argv.join(" ") === LOGIN_PROBE_ARGV.join(" ")) {
+      return { exitCode: behavior.signedOut ? 1 : 0, stdout: "" };
+    }
+    if (behavior.listFails) return { exitCode: 1, stdout: "" };
+    return { exitCode: 0, stdout: behavior.listStdout ?? JSON.stringify({ items: [] }) };
+  };
+  return { run, invocations, behavior };
+}
+
+function harness(
+  behavior: CliBehavior = {},
+  overrides: Partial<CliPassInput> = {},
+): {
+  pass: ReturnType<typeof cliPass>;
+  invocations: (readonly string[])[];
+  behavior: CliBehavior;
+  forgotten: () => number;
+  collected: () => number;
+} {
+  const cli = fakeCli(behavior);
+  let forgotten = 0;
+  let collected = 0;
+  const pass = cliPass({
+    provider: STUB_PROVIDER,
+    binary: BINARY,
+    loginProbeArgv: LOGIN_PROBE_ARGV,
+    run: cli.run,
+    now: () => TEST_TIME,
+    minimumRefreshIntervalMs: 0,
+    forget: () => {
+      forgotten += 1;
+    },
+    collect: async (request) => {
+      collected += 1;
+      await request(LIST_ARGV);
+      return [observation("one")];
+    },
+    ...overrides,
+  });
+  return {
+    pass,
+    invocations: cli.invocations,
+    behavior: cli.behavior,
+    forgotten: () => forgotten,
+    collected: () => collected,
+  };
+}
+
+test("a signed-in pass reports its sessions as living in the cloud", async () => {
+  const { pass, invocations } = harness();
+  const observations = await pass.run();
+  assert.deepEqual(
+    observations.map((entry) => entry.location),
+    [SESSION_LOCATION.CLOUD],
+  );
+  assert.equal(pass.connection(), CLI_CONNECTION.CONNECTED);
+  assert.deepEqual(invocations, [LOGIN_PROBE_ARGV, LIST_ARGV]);
+});
+
+test("a signed-out CLI is observed as having nothing, and the list is never run", async () => {
+  const { pass, invocations, collected } = harness({ signedOut: true });
+  assert.deepEqual(await pass.run(), []);
+  assert.equal(pass.connection(), CLI_CONNECTION.SIGNED_OUT);
+  assert.equal(collected(), 0);
+  assert.deepEqual(invocations, [LOGIN_PROBE_ARGV]);
+});
+
+test("an absent binary is observed as having nothing", async () => {
+  const { pass } = harness({ binaryMissing: true });
+  assert.deepEqual(await pass.run(), []);
+  assert.equal(pass.connection(), CLI_CONNECTION.CLI_MISSING);
+});
+
+test("signing out clears what an earlier pass observed", async () => {
+  const { pass, behavior, forgotten } = harness();
+  assert.equal((await pass.run()).length, 1);
+  behavior.signedOut = true;
+  assert.deepEqual(await pass.run(), []);
+  assert.deepEqual(pass.latest(), []);
+  assert.equal(forgotten(), 1);
+});
+
+test("a command that ran and failed keeps the previous snapshot", async () => {
+  const { pass, behavior, forgotten } = harness();
+  const first = await pass.run();
+  behavior.listFails = true;
+  assert.deepEqual(await pass.run(), first);
+  assert.equal(forgotten(), 0);
+});
+
+test("inside the refresh interval a second pass runs nothing at all", async () => {
+  const { pass, invocations } = harness({}, { minimumRefreshIntervalMs: 60_000 });
+  const first = await pass.run();
+  const before = invocations.length;
+  assert.deepEqual(await pass.run(), first);
+  assert.equal(invocations.length, before);
+});
+
+test("a write that landed makes the next pass actually ask", async () => {
+  const { pass, invocations } = harness({}, { minimumRefreshIntervalMs: 60_000 });
+  await pass.run();
+  const written = await pass.write(["cloud", "create"]);
+  assert.equal(written.outcome.status, ACT_RESULT_STATUS.ACCEPTED);
+  const before = invocations.length;
+  await pass.run();
+  assert.ok(invocations.length > before);
+});
+
+test("a write refuses without running when the CLI has signed out since the pass", async () => {
+  const { pass, behavior, invocations } = harness();
+  await pass.run();
+  behavior.signedOut = true;
+  const before = invocations.length;
+  const written = await pass.write(["cloud", "create"]);
+  assert.deepEqual(written, {
+    outcome: {
+      status: ACT_RESULT_STATUS.REJECTED,
+      reason: "Stub's CLI is signed out, so nothing was sent.",
+    },
+  });
+  // The probe ran; the write itself did not.
+  assert.deepEqual(invocations.slice(before), [LOGIN_PROBE_ARGV]);
+  assert.deepEqual(pass.latest(), []);
+});
+
+test("a write refuses without running when the binary has gone", async () => {
+  const { pass, behavior } = harness();
+  await pass.run();
+  behavior.binaryMissing = true;
+  const written = await pass.write(["cloud", "create"]);
+  assert.deepEqual(written.outcome, {
+    status: ACT_RESULT_STATUS.REJECTED,
+    reason: "Stub's CLI is not installed, so nothing was sent.",
+  });
+});
+
+test("a write the CLI refused names no CLI output", async () => {
+  const { pass } = harness({ listFails: true });
+  const written = await pass.write(["cloud", "create"]);
+  assert.deepEqual(written.outcome, {
+    status: ACT_RESULT_STATUS.REJECTED,
+    reason: "Stub's CLI refused the request.",
+  });
+});
+
+test("unreadable CLI output is transient, not a diagnostic", async () => {
+  const diagnostics: string[] = [];
+  const { pass } = harness(
+    { listStdout: "not json" },
+    {
+      onDiagnostic: (kind) => {
+        diagnostics.push(kind);
+      },
+    },
+  );
+  assert.deepEqual(await pass.run(), []);
+  assert.deepEqual(diagnostics, []);
+});
+
+test("a bug in the adapter's own parsing is reported and rethrown", async () => {
+  const diagnostics: string[] = [];
+  const { pass } = harness(
+    {},
+    {
+      collect: async () => {
+        throw new TypeError("the adapter misread a row");
+      },
+      onDiagnostic: (kind) => {
+        diagnostics.push(kind);
+      },
+    },
+  );
+  await assert.rejects(pass.run(), TypeError);
+  assert.deepEqual(diagnostics, [ADAPTER_DIAGNOSTIC_KIND.PASS_FAILURE]);
+});
+
+test("a superseded pass never lands its answer over the newer one", async () => {
+  let release: (() => void) | undefined;
+  const held = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  let passes = 0;
+  const { pass } = harness(
+    {},
+    {
+      collect: async (request) => {
+        passes += 1;
+        if (passes === 1) await held;
+        await request(LIST_ARGV);
+        return [observation(`pass-${passes}`)];
+      },
+    },
+  );
+  const first = pass.run();
+  const second = await pass.run();
+  release?.();
+  assert.deepEqual(await first, second);
+  assert.deepEqual(
+    pass.latest().map((entry) => entry.providerSessionId),
+    ["pass-2"],
+  );
+});

--- a/packages/providers/src/shared/cli-pass.test.ts
+++ b/packages/providers/src/shared/cli-pass.test.ts
@@ -10,7 +10,7 @@ import {
 } from "@sidecar/session";
 import { ADAPTER_DIAGNOSTIC_KIND } from "./adapter-diagnostics.js";
 import { ADAPTER_FAILURE, AdapterFailure } from "./adapter-failure.js";
-import { type CliPassInput, type CliRun, cliPass } from "./cli-pass.js";
+import { type CliPass, type CliPassInput, type CliRun, cliPass } from "./cli-pass.js";
 
 const TEST_TIME = Date.parse("2026-09-01T12:00:00.000Z");
 const BINARY = "stub";
@@ -51,16 +51,15 @@ function fakeCli(behavior: CliBehavior = {}) {
   return { run, invocations, behavior };
 }
 
-function harness(
-  behavior: CliBehavior = {},
-  overrides: Partial<CliPassInput> = {},
-): {
-  pass: ReturnType<typeof cliPass>;
+interface PassHarness {
+  pass: CliPass;
   invocations: (readonly string[])[];
   behavior: CliBehavior;
   forgotten: () => number;
   collected: () => number;
-} {
+}
+
+function harness(behavior: CliBehavior = {}, overrides: Partial<CliPassInput> = {}): PassHarness {
   const cli = fakeCli(behavior);
   let forgotten = 0;
   let collected = 0;

--- a/packages/providers/src/shared/cli-pass.ts
+++ b/packages/providers/src/shared/cli-pass.ts
@@ -1,0 +1,369 @@
+import {
+  boundedInvocation,
+  DEFAULT_CLI_PATH_DIRECTORIES,
+  INVOCATION_FAILURE,
+  InvocationError,
+} from "@sidecar/process";
+import {
+  ACT_RESULT_STATUS,
+  CLI_CONNECTION,
+  type CliConnection,
+  type ProviderActResult,
+  type ProviderSessionObservation,
+  SESSION_LOCATION,
+  type SessionProvider,
+} from "@sidecar/session";
+import {
+  resolveOptions,
+  unparsedWire,
+  type WireBoundaryInput,
+  type WireRecord,
+  wireRecord,
+} from "@sidecar/wire";
+import { ADAPTER_DIAGNOSTIC_KIND, type AdapterDiagnosticCallback } from "./adapter-diagnostics.js";
+import { ADAPTER_FAILURE, AdapterFailure, clearsObservedState } from "./adapter-failure.js";
+
+export const CLI_ADAPTER_DEFAULTS = {
+  MINIMUM_REFRESH_INTERVAL_MS: 15 * 1000,
+  COMMAND_TIMEOUT_MS: 8 * 1000,
+  /**
+   * A write command does more than a read answers for — Codex's creation
+   * resolves the environment and stands the task up before it prints — so it
+   * gets a wider deadline than the read's, and still a hard one.
+   */
+  WRITE_TIMEOUT_MS: 20 * 1000,
+  /** A read that answers with more than this is not the bounded list it claims to be. */
+  MAXIMUM_OUTPUT_BYTES: 4 * 1024 * 1024,
+} as const;
+
+/**
+ * Where provider CLIs actually land on a Mac. An app launched from the Finder
+ * inherits a PATH without the package-manager directories a terminal adds, so
+ * these are appended after the inherited PATH — never ahead of it, so a binary
+ * the user's own shell would resolve still wins.
+ */
+export interface CliRunResult {
+  exitCode: number;
+  stdout: string;
+}
+
+export type CliRun = (
+  binary: string,
+  argv: readonly string[],
+  options: Readonly<{ timeoutMs: number; maximumOutputBytes: number }>,
+) => Promise<CliRunResult>;
+
+/**
+ * Runs the binary directly — no shell, so nothing in an argument can become a
+ * second command — and answers with the exit code rather than throwing on it:
+ * a probe's no is an answer, not a failure. Only a binary that cannot run at
+ * all is unavailable; a command that ran out of time or output is transient.
+ */
+export const defaultCliRun: CliRun = async (binary, argv, options) => {
+  try {
+    const result = await boundedInvocation({
+      binary,
+      arguments: argv,
+      timeoutMs: options.timeoutMs,
+      maximumOutputBytes: options.maximumOutputBytes,
+      pathDirectories: DEFAULT_CLI_PATH_DIRECTORIES,
+    });
+    return { exitCode: result.exitCode, stdout: result.stdout };
+  } catch (error) {
+    throw new AdapterFailure(
+      error instanceof InvocationError && error.failure === INVOCATION_FAILURE.UNAVAILABLE
+        ? ADAPTER_FAILURE.UNAVAILABLE
+        : ADAPTER_FAILURE.TRANSIENT,
+      `${binary} could not be run`,
+    );
+  }
+};
+
+/**
+ * The only way an adapter reaches its provider while observing: one invocation
+ * of the pass's binary, bounded in time and output, parsed as JSON, and
+ * discarded past what the adapter reports. The argv an adapter passes must be
+ * fixed by the build — the same rule that fixes a POSTed read document — with
+ * nothing interpolated beyond bounded values the provider itself reported.
+ */
+export type CliReadRequest = (argv: readonly string[]) => Promise<WireRecord>;
+
+export interface CliPassInput {
+  provider: SessionProvider;
+  /** The provider's own CLI, resolved the way the user's shell would resolve it. */
+  binary: string;
+  /**
+   * The read that answers whether the CLI holds a login, by exit code alone.
+   * Its stdout is never parsed: what the account is called is the CLI's
+   * business, and whether it exists is the only fact observation needs.
+   */
+  loginProbeArgv: readonly string[];
+  run?: CliRun;
+  now?: () => number;
+  minimumRefreshIntervalMs?: number;
+  /**
+   * Called when an observation pass fails for a reason other than the CLI
+   * being unavailable or a command failing — a TypeError in an adapter's
+   * parsing, for example. Unavailable and transient failures never reach it.
+   */
+  onDiagnostic?: AdapterDiagnosticCallback;
+  /**
+   * Clears anything the adapter cached across passes — projects offered for
+   * creation, above all. It runs whenever the login goes away, so nothing
+   * observed under one login can be offered or acted on under another.
+   */
+  forget?(): void;
+  /** Runs one login-gated pass. Duplicate session ids are dropped here. */
+  collect(request: CliReadRequest, now: number): Promise<readonly ProviderSessionObservation[]>;
+}
+
+/**
+ * The shared half of every CLI-observed provider: the login gate, its own
+ * refresh cadence, the failure rules that decide whether a snapshot survives,
+ * bounded read-only invocations of the provider's own CLI, and the one write.
+ *
+ * The credential never passes through Luke. The CLI holds the login the user
+ * gave it for its own sake, and observation runs under it exactly as the
+ * user's own terminal would — Luke reads no token, stores none, and passes
+ * none. A machine whose CLI is absent or signed out is observed as having
+ * nothing, the same answer a cloud provider gives with no key, so observation
+ * begins and ends with the user's own login and nothing else. Nothing here
+ * raises `unauthorized` for that reason: an absent binary or a probe's no is
+ * the only way a login stops standing.
+ */
+export interface CliPass {
+  run(): Promise<readonly ProviderSessionObservation[]>;
+  latest(): readonly ProviderSessionObservation[];
+  /**
+   * What the latest pass learned about the login behind this provider, for a
+   * settings row to report — never the login itself, which stays the CLI's.
+   */
+  connection(): CliConnection;
+  /** One authenticated write; answers what became of it, never throws. */
+  write(argv: readonly string[]): Promise<{ outcome: ProviderActResult; stdout?: string }>;
+}
+
+/**
+ * Drops a session an adapter reported twice, and stamps the location the pass
+ * already knows: nothing reaches this point except through the provider's own
+ * cloud CLI, so an adapter cannot forget to say its sessions run elsewhere.
+ */
+function cliObservations(
+  observations: readonly ProviderSessionObservation[],
+): readonly ProviderSessionObservation[] {
+  const unique = new Map<string, ProviderSessionObservation>();
+  for (const observation of observations) {
+    if (!unique.has(observation.providerSessionId)) {
+      unique.set(observation.providerSessionId, {
+        ...observation,
+        location: SESSION_LOCATION.CLOUD,
+      });
+    }
+  }
+  return [...unique.values()];
+}
+
+export function cliPass(input: CliPassInput): CliPass {
+  const provider = input.provider;
+  const binary = input.binary;
+  const run = input.run ?? defaultCliRun;
+  const now = input.now ?? Date.now;
+  const { minimumRefreshIntervalMs } = resolveOptions(
+    input,
+    { minimumRefreshIntervalMs: CLI_ADAPTER_DEFAULTS.MINIMUM_REFRESH_INTERVAL_MS },
+    { nonNegative: ["minimumRefreshIntervalMs"] },
+  );
+
+  let observations: readonly ProviderSessionObservation[] = [];
+  let lastAttemptAt = Number.NEGATIVE_INFINITY;
+  let collectPass = 0;
+  let connection: CliConnection = CLI_CONNECTION.UNKNOWN;
+
+  /**
+   * Clears observed state and supersedes any pass still in flight, so nothing
+   * read under a login that no longer stands can land back over the clear.
+   */
+  const forgetLogin = (): void => {
+    collectPass += 1;
+    input.forget?.();
+    observations = [];
+  };
+
+  const probeLogin = async (): Promise<CliConnection> => {
+    try {
+      const probe = await run(binary, input.loginProbeArgv, {
+        timeoutMs: CLI_ADAPTER_DEFAULTS.COMMAND_TIMEOUT_MS,
+        maximumOutputBytes: CLI_ADAPTER_DEFAULTS.MAXIMUM_OUTPUT_BYTES,
+      });
+      return probe.exitCode === 0 ? CLI_CONNECTION.CONNECTED : CLI_CONNECTION.SIGNED_OUT;
+    } catch (error) {
+      // A probe that cannot run at all is a machine with nothing to observe;
+      // a probe that ran out of time says nothing about the login either way,
+      // so the pass keeps its snapshot and asks again next time.
+      if (error instanceof AdapterFailure && clearsObservedState(error.failure)) {
+        return CLI_CONNECTION.CLI_MISSING;
+      }
+      throw error;
+    }
+  };
+
+  const assertPassCurrent = (pass: number): void => {
+    if (pass !== collectPass) {
+      throw new AdapterFailure(
+        ADAPTER_FAILURE.TRANSIENT,
+        `${provider.displayName} pass was superseded`,
+      );
+    }
+  };
+
+  /**
+   * Binds one pass's invocations to its own currency, so a slow command from
+   * a pass that has been superseded fails instead of landing its answer over
+   * state that belongs to the newer pass.
+   */
+  const requestForPass = (pass: number): CliReadRequest => {
+    return async (argv) => {
+      assertPassCurrent(pass);
+      const result = await run(binary, argv, {
+        timeoutMs: CLI_ADAPTER_DEFAULTS.COMMAND_TIMEOUT_MS,
+        maximumOutputBytes: CLI_ADAPTER_DEFAULTS.MAXIMUM_OUTPUT_BYTES,
+      });
+      assertPassCurrent(pass);
+      const name = provider.displayName;
+      if (result.exitCode !== 0) {
+        throw new AdapterFailure(ADAPTER_FAILURE.TRANSIENT, `${name} CLI answered with a failure`);
+      }
+      let body: WireBoundaryInput;
+      try {
+        body = JSON.parse(result.stdout);
+      } catch {
+        throw new AdapterFailure(ADAPTER_FAILURE.TRANSIENT, `${name} CLI answered unreadably`);
+      }
+      const bodyRecord = wireRecord(unparsedWire(body));
+      if (!bodyRecord) {
+        throw new AdapterFailure(ADAPTER_FAILURE.TRANSIENT, `${name} CLI answered unexpectedly`);
+      }
+      return bodyRecord;
+    };
+  };
+
+  return {
+    async run() {
+      const attemptedAt = now();
+      // A CLI is spawned per read, so the cadence guard leads everything: the
+      // shared refresh timer ticks faster than a process-per-pass should run.
+      if (attemptedAt - lastAttemptAt < minimumRefreshIntervalMs) return observations;
+      lastAttemptAt = attemptedAt;
+
+      const pass = ++collectPass;
+      try {
+        // The login is probed every pass rather than cached, so signing the
+        // CLI out is honoured on the next pass the way removing a key is:
+        // state read under a login that no longer stands must not keep being
+        // served.
+        const probed = await probeLogin();
+        connection = probed;
+        if (probed !== CLI_CONNECTION.CONNECTED) {
+          if (pass === collectPass) forgetLogin();
+          return observations;
+        }
+        const collected = await input.collect(requestForPass(pass), attemptedAt);
+        if (pass === collectPass) observations = cliObservations(collected);
+      } catch (error) {
+        // A superseded pass says nothing about the login that now stands.
+        if (pass !== collectPass) return observations;
+        if (error instanceof AdapterFailure) {
+          // A binary gone mid-pass clears observed state; a command that ran
+          // and failed keeps the previous snapshot until the next attempt.
+          if (clearsObservedState(error.failure)) {
+            connection = CLI_CONNECTION.CLI_MISSING;
+            forgetLogin();
+          }
+          return observations;
+        }
+        // Anything else is a bug in this pass — a TypeError thrown by an
+        // adapter's parsing is not a flaky command, and must not keep serving
+        // the stale snapshot with no log, counter, or hook.
+        input.onDiagnostic?.(
+          ADAPTER_DIAGNOSTIC_KIND.PASS_FAILURE,
+          error instanceof Error ? error : new Error(String(error)),
+        );
+        throw error;
+      }
+      return observations;
+    },
+
+    latest: () => observations,
+
+    connection: () => connection,
+
+    /**
+     * The one authenticated write: a single invocation of the provider's own
+     * CLI, for something the user just asked for against what the latest pass
+     * observed — an adapter validates before it builds the argv, exactly as
+     * the cloud pass's callers do. The login is probed at act time rather than
+     * held from the observation pass, so a CLI signed out since then refuses
+     * before anything runs, and the refusal wording is fixed here rather than
+     * echoing whatever the CLI printed. What the command wrote to stdout rides
+     * an acceptance for the adapter that needs the id a creation named — it
+     * travels no further than that adapter.
+     */
+    async write(argv) {
+      const name = provider.displayName;
+      let probed: CliConnection;
+      try {
+        probed = await probeLogin();
+      } catch {
+        return {
+          outcome: {
+            status: ACT_RESULT_STATUS.REJECTED,
+            reason: `${name}'s CLI could not answer, so nothing was sent.`,
+          },
+        };
+      }
+      connection = probed;
+      if (probed !== CLI_CONNECTION.CONNECTED) {
+        // The act just learned what the next pass would have: the login is
+        // gone. Observed state clears now rather than a tick later, and a pass
+        // still in flight is superseded so its answer cannot land what was
+        // read under the login that no longer stands.
+        forgetLogin();
+        return {
+          outcome: {
+            status: ACT_RESULT_STATUS.REJECTED,
+            reason:
+              probed === CLI_CONNECTION.CLI_MISSING
+                ? `${name}'s CLI is not installed, so nothing was sent.`
+                : `${name}'s CLI is signed out, so nothing was sent.`,
+          },
+        };
+      }
+      let result: CliRunResult;
+      try {
+        result = await run(binary, argv, {
+          timeoutMs: CLI_ADAPTER_DEFAULTS.WRITE_TIMEOUT_MS,
+          maximumOutputBytes: CLI_ADAPTER_DEFAULTS.MAXIMUM_OUTPUT_BYTES,
+        });
+      } catch {
+        return {
+          outcome: {
+            status: ACT_RESULT_STATUS.REJECTED,
+            reason: `${name}'s CLI could not answer, so the request may not have landed.`,
+          },
+        };
+      }
+      if (result.exitCode !== 0) {
+        return {
+          outcome: {
+            status: ACT_RESULT_STATUS.REJECTED,
+            reason: `${name}'s CLI refused the request.`,
+          },
+        };
+      }
+      // A write that landed changes what the provider holds, so the refresh
+      // that follows must actually ask rather than serve the cached snapshot.
+      lastAttemptAt = Number.NEGATIVE_INFINITY;
+      return { outcome: { status: ACT_RESULT_STATUS.ACCEPTED }, stdout: result.stdout };
+    },
+  };
+}

--- a/packages/providers/src/shared/cli-session-adapter.ts
+++ b/packages/providers/src/shared/cli-session-adapter.ts
@@ -1,84 +1,12 @@
 import {
-  boundedInvocation,
-  DEFAULT_CLI_PATH_DIRECTORIES,
-  INVOCATION_FAILURE,
-  InvocationError,
-} from "@sidecar/process";
-import {
-  ACT_RESULT_STATUS,
-  CLI_CONNECTION,
   type CliConnection,
   type ProviderActResult,
   type ProviderSessionObservation,
-  SESSION_LOCATION,
   type SessionProvider,
   SessionProviderAdapterBase,
 } from "@sidecar/session";
-import {
-  resolveOptions,
-  unparsedWire,
-  type WireBoundaryInput,
-  type WireRecord,
-  wireRecord,
-} from "@sidecar/wire";
-import { ADAPTER_DIAGNOSTIC_KIND, type AdapterDiagnosticCallback } from "./adapter-diagnostics.js";
-import { ADAPTER_FAILURE, AdapterFailure, clearsObservedState } from "./adapter-failure.js";
-
-export const CLI_ADAPTER_DEFAULTS = {
-  MINIMUM_REFRESH_INTERVAL_MS: 15 * 1000,
-  COMMAND_TIMEOUT_MS: 8 * 1000,
-  /**
-   * A write command does more than a read answers for — Codex's creation
-   * resolves the environment and stands the task up before it prints — so it
-   * gets a wider deadline than the read's, and still a hard one.
-   */
-  WRITE_TIMEOUT_MS: 20 * 1000,
-  /** A read that answers with more than this is not the bounded list it claims to be. */
-  MAXIMUM_OUTPUT_BYTES: 4 * 1024 * 1024,
-} as const;
-
-/**
- * Where provider CLIs actually land on a Mac. An app launched from the Finder
- * inherits a PATH without the package-manager directories a terminal adds, so
- * these are appended after the inherited PATH — never ahead of it, so a binary
- * the user's own shell would resolve still wins.
- */
-export interface CliRunResult {
-  exitCode: number;
-  stdout: string;
-}
-
-export type CliRun = (
-  binary: string,
-  argv: readonly string[],
-  options: Readonly<{ timeoutMs: number; maximumOutputBytes: number }>,
-) => Promise<CliRunResult>;
-
-/**
- * Runs the binary directly — no shell, so nothing in an argument can become a
- * second command — and answers with the exit code rather than throwing on it:
- * a probe's no is an answer, not a failure. Only a binary that cannot run at
- * all is unavailable; a command that ran out of time or output is transient.
- */
-export const defaultCliRun: CliRun = async (binary, argv, options) => {
-  try {
-    const result = await boundedInvocation({
-      binary,
-      arguments: argv,
-      timeoutMs: options.timeoutMs,
-      maximumOutputBytes: options.maximumOutputBytes,
-      pathDirectories: DEFAULT_CLI_PATH_DIRECTORIES,
-    });
-    return { exitCode: result.exitCode, stdout: result.stdout };
-  } catch (error) {
-    throw new AdapterFailure(
-      error instanceof InvocationError && error.failure === INVOCATION_FAILURE.UNAVAILABLE
-        ? ADAPTER_FAILURE.UNAVAILABLE
-        : ADAPTER_FAILURE.TRANSIENT,
-      `${binary} could not be run`,
-    );
-  }
-};
+import type { AdapterDiagnosticCallback } from "./adapter-diagnostics.js";
+import { type CliPass, type CliReadRequest, type CliRun, cliPass } from "./cli-pass.js";
 
 export interface CliAdapterOptions {
   run?: CliRun;
@@ -106,104 +34,31 @@ export interface CliAdapterProfile {
 }
 
 /**
- * The only way a subclass reaches its provider while observing: one invocation
- * of the profile's binary, bounded in time and output, parsed as JSON, and
- * discarded past what the subclass reports. The argv a subclass passes must be
- * fixed by the build — the same rule that fixes a POSTed read document — with
- * nothing interpolated beyond bounded values the provider itself reported.
- */
-export type CliReadRequest = (argv: readonly string[]) => Promise<WireRecord>;
-
-/**
- * The shared half of every CLI-observed provider adapter: the login gate, its
- * own refresh cadence, the failure rules that decide whether a snapshot
- * survives, and bounded read-only invocations of the provider's own CLI.
- *
- * The credential never passes through Luke. The CLI holds the login the user
- * gave it for its own sake, and observation runs under it exactly as the
- * user's own terminal would — Luke reads no token, stores none, and passes
- * none. A machine whose CLI is absent or signed out is observed as having
- * nothing, the same answer a cloud provider gives with no key, so observation
- * begins and ends with the user's own login and nothing else.
+ * The adapter-shaped half of a CLI-observed provider. `cliPass` holds the
+ * login gate, the refresh cadence, the failure rules and the one write; what
+ * is left here is the seams a subclass supplies.
  */
 export abstract class CliSessionAdapter extends SessionProviderAdapterBase {
   readonly provider: SessionProvider;
 
-  readonly #binary: string;
-  readonly #loginProbeArgv: readonly string[];
-  readonly #run: CliRun;
-  readonly #now: () => number;
-  readonly #minimumRefreshIntervalMs: number;
-  readonly #onDiagnostic: AdapterDiagnosticCallback | undefined;
-
-  #observations: readonly ProviderSessionObservation[] = [];
-  #lastAttemptAt = Number.NEGATIVE_INFINITY;
-  #collectPass = 0;
-  #connection: CliConnection = CLI_CONNECTION.UNKNOWN;
+  readonly #pass: CliPass;
 
   constructor(profile: CliAdapterProfile, options: CliAdapterOptions = {}) {
     super();
     this.provider = profile.provider;
-    this.#binary = profile.binary;
-    this.#loginProbeArgv = profile.loginProbeArgv;
-    this.#run = options.run ?? defaultCliRun;
-    this.#now = options.now ?? Date.now;
-    const { minimumRefreshIntervalMs } = resolveOptions(
-      options,
-      { minimumRefreshIntervalMs: CLI_ADAPTER_DEFAULTS.MINIMUM_REFRESH_INTERVAL_MS },
-      { nonNegative: ["minimumRefreshIntervalMs"] },
-    );
-    this.#minimumRefreshIntervalMs = minimumRefreshIntervalMs;
-    this.#onDiagnostic = options.onDiagnostic;
+    this.#pass = cliPass({
+      ...profile,
+      ...options,
+      collect: (request, now) => this.collect(request, now),
+      forget: () => this.forgetCachedIdentity(),
+    });
   }
 
-  async observe(): Promise<readonly ProviderSessionObservation[]> {
-    const now = this.#now();
-    // A CLI is spawned per read, so the cadence guard leads everything: the
-    // shared refresh timer ticks faster than a process-per-pass should run.
-    if (now - this.#lastAttemptAt < this.#minimumRefreshIntervalMs) return this.#observations;
-    this.#lastAttemptAt = now;
-
-    const pass = ++this.#collectPass;
-    try {
-      // The login is probed every pass rather than cached, so signing the CLI
-      // out is honoured on the next pass the way removing a key is: state read
-      // under a login that no longer stands must not keep being served.
-      const connection = await this.#probeLogin();
-      this.#connection = connection;
-      if (connection !== CLI_CONNECTION.CONNECTED) {
-        this.#forgetObservedState(pass);
-        return this.#observations;
-      }
-      const collected = await this.collect(this.#requestForPass(pass), now);
-      if (pass === this.#collectPass) this.#observations = cliObservations(collected);
-    } catch (error) {
-      // A superseded pass says nothing about the login that now stands.
-      if (pass !== this.#collectPass) return this.#observations;
-      if (error instanceof AdapterFailure) {
-        // A binary gone mid-pass clears observed state; a command that ran and
-        // failed keeps the previous snapshot until the next attempt. Nothing
-        // here raises `unauthorized`: the credential never passes through
-        // Luke, so an absent binary is the only way a login stops standing.
-        if (clearsObservedState(error.failure)) {
-          this.#connection = CLI_CONNECTION.CLI_MISSING;
-          this.#forgetObservedState(pass);
-        }
-        return this.#observations;
-      }
-      // Anything else is a bug in this pass — a TypeError thrown by a
-      // subclass's parsing is not a flaky command, and must not keep serving
-      // the stale snapshot with no log, counter, or hook.
-      this.#onDiagnostic?.(
-        ADAPTER_DIAGNOSTIC_KIND.PASS_FAILURE,
-        error instanceof Error ? error : new Error(String(error)),
-      );
-      throw error;
-    }
-    return this.#observations;
+  observe(): Promise<readonly ProviderSessionObservation[]> {
+    return this.#pass.run();
   }
 
-  /** Runs one login-gated pass. Duplicate session ids are dropped by the base. */
+  /** Runs one login-gated pass. Duplicate session ids are dropped by the pass. */
   protected abstract collect(
     request: CliReadRequest,
     now: number,
@@ -214,7 +69,12 @@ export abstract class CliSessionAdapter extends SessionProviderAdapterBase {
    * settings row to report — never the login itself, which stays the CLI's.
    */
   connection(): CliConnection {
-    return this.#connection;
+    return this.#pass.connection();
+  }
+
+  /** What the latest pass observed, for a subclass answering an act of its own. */
+  protected latest(): readonly ProviderSessionObservation[] {
+    return this.#pass.latest();
   }
 
   /**
@@ -228,163 +88,11 @@ export abstract class CliSessionAdapter extends SessionProviderAdapterBase {
    * The one authenticated write: a single invocation of the provider's own
    * CLI, for something the user just asked for against what the latest pass
    * observed — a subclass validates before it builds the argv, exactly as the
-   * cloud base does. The login is probed at act time rather than held from
-   * the observation pass, so a CLI signed out since then refuses before
-   * anything runs, and the refusal wording is fixed here rather than echoing
-   * whatever the CLI printed. What the command wrote to stdout rides an
-   * acceptance for the subclass that needs the id a creation named — it
-   * travels no further than that subclass.
+   * cloud base does.
    */
-  protected async performWrite(
+  protected performWrite(
     argv: readonly string[],
   ): Promise<{ outcome: ProviderActResult; stdout?: string }> {
-    const name = this.provider.displayName;
-    let connection: CliConnection;
-    try {
-      connection = await this.#probeLogin();
-    } catch {
-      return {
-        outcome: {
-          status: ACT_RESULT_STATUS.REJECTED,
-          reason: `${name}'s CLI could not answer, so nothing was sent.`,
-        },
-      };
-    }
-    this.#connection = connection;
-    if (connection !== CLI_CONNECTION.CONNECTED) {
-      // The act just learned what the next pass would have: the login is
-      // gone. Observed state clears now rather than a tick later, and a pass
-      // still in flight is superseded so its answer cannot land what was read
-      // under the login that no longer stands.
-      this.#forgetLogin();
-      return {
-        outcome: {
-          status: ACT_RESULT_STATUS.REJECTED,
-          reason:
-            connection === CLI_CONNECTION.CLI_MISSING
-              ? `${name}'s CLI is not installed, so nothing was sent.`
-              : `${name}'s CLI is signed out, so nothing was sent.`,
-        },
-      };
-    }
-    let result: CliRunResult;
-    try {
-      result = await this.#run(this.#binary, argv, {
-        timeoutMs: CLI_ADAPTER_DEFAULTS.WRITE_TIMEOUT_MS,
-        maximumOutputBytes: CLI_ADAPTER_DEFAULTS.MAXIMUM_OUTPUT_BYTES,
-      });
-    } catch {
-      return {
-        outcome: {
-          status: ACT_RESULT_STATUS.REJECTED,
-          reason: `${name}'s CLI could not answer, so the request may not have landed.`,
-        },
-      };
-    }
-    if (result.exitCode !== 0) {
-      return {
-        outcome: {
-          status: ACT_RESULT_STATUS.REJECTED,
-          reason: `${name}'s CLI refused the request.`,
-        },
-      };
-    }
-    // A write that landed changes what the provider holds, so the refresh
-    // that follows must actually ask rather than serve the cached snapshot.
-    this.#lastAttemptAt = Number.NEGATIVE_INFINITY;
-    return { outcome: { status: ACT_RESULT_STATUS.ACCEPTED }, stdout: result.stdout };
+    return this.#pass.write(argv);
   }
-
-  async #probeLogin(): Promise<CliConnection> {
-    try {
-      const probe = await this.#run(this.#binary, this.#loginProbeArgv, {
-        timeoutMs: CLI_ADAPTER_DEFAULTS.COMMAND_TIMEOUT_MS,
-        maximumOutputBytes: CLI_ADAPTER_DEFAULTS.MAXIMUM_OUTPUT_BYTES,
-      });
-      return probe.exitCode === 0 ? CLI_CONNECTION.CONNECTED : CLI_CONNECTION.SIGNED_OUT;
-    } catch (error) {
-      // A probe that cannot run at all is a machine with nothing to observe;
-      // a probe that ran out of time says nothing about the login either way,
-      // so the pass keeps its snapshot and asks again next time.
-      if (error instanceof AdapterFailure && clearsObservedState(error.failure)) {
-        return CLI_CONNECTION.CLI_MISSING;
-      }
-      throw error;
-    }
-  }
-
-  /**
-   * Binds one pass's invocations to its own currency, so a slow command from
-   * a pass that has been superseded fails instead of landing its answer over
-   * state that belongs to the newer pass.
-   */
-  #requestForPass(pass: number): CliReadRequest {
-    return async (argv) => {
-      this.#assertPassCurrent(pass);
-      const result = await this.#run(this.#binary, argv, {
-        timeoutMs: CLI_ADAPTER_DEFAULTS.COMMAND_TIMEOUT_MS,
-        maximumOutputBytes: CLI_ADAPTER_DEFAULTS.MAXIMUM_OUTPUT_BYTES,
-      });
-      this.#assertPassCurrent(pass);
-      const name = this.provider.displayName;
-      if (result.exitCode !== 0) {
-        throw new AdapterFailure(ADAPTER_FAILURE.TRANSIENT, `${name} CLI answered with a failure`);
-      }
-      let body: WireBoundaryInput;
-      try {
-        body = JSON.parse(result.stdout);
-      } catch {
-        throw new AdapterFailure(ADAPTER_FAILURE.TRANSIENT, `${name} CLI answered unreadably`);
-      }
-      const bodyRecord = wireRecord(unparsedWire(body));
-      if (!bodyRecord) {
-        throw new AdapterFailure(ADAPTER_FAILURE.TRANSIENT, `${name} CLI answered unexpectedly`);
-      }
-      return bodyRecord;
-    };
-  }
-
-  #assertPassCurrent(pass: number): void {
-    if (pass !== this.#collectPass) {
-      throw new AdapterFailure(
-        ADAPTER_FAILURE.TRANSIENT,
-        `${this.provider.displayName} pass was superseded`,
-      );
-    }
-  }
-
-  #forgetObservedState(pass: number): void {
-    if (pass !== this.#collectPass) return;
-    this.#forgetLogin();
-  }
-
-  /**
-   * Clears observed state and supersedes any pass still in flight, so nothing
-   * read under a login that no longer stands can land back over the clear.
-   */
-  #forgetLogin(): void {
-    this.#collectPass += 1;
-    this.forgetCachedIdentity();
-    this.#observations = [];
-  }
-}
-
-/**
- * Drops a session a subclass reported twice, and stamps the location the base
- * already knows: nothing reaches this point except through the provider's own
- * cloud CLI, so a subclass cannot forget to say its sessions run elsewhere.
- */
-function cliObservations(
-  observations: readonly ProviderSessionObservation[],
-): readonly ProviderSessionObservation[] {
-  const unique = new Map<string, ProviderSessionObservation>();
-  for (const observation of observations) {
-    if (!unique.has(observation.providerSessionId)) {
-      unique.set(observation.providerSessionId, {
-        ...observation,
-        location: SESSION_LOCATION.CLOUD,
-      });
-    }
-  }
-  return [...unique.values()];
 }

--- a/packages/providers/src/shared/cli-session-adapter.ts
+++ b/packages/providers/src/shared/cli-session-adapter.ts
@@ -22,30 +22,7 @@ import {
   wireRecord,
 } from "@sidecar/wire";
 import { ADAPTER_DIAGNOSTIC_KIND, type AdapterDiagnosticCallback } from "./adapter-diagnostics.js";
-
-/**
- * How a CLI-observed provider fails. Unavailable means there is nothing to
- * observe with — the binary is not installed, or its login probe answered no —
- * which is the CLI analogue of a missing API key and clears observed state the
- * same way. Transient covers a command that ran and failed, which keeps the
- * last snapshot until the next attempt the way a network blip does.
- */
-export const CLI_FAILURE = {
-  UNAVAILABLE: "unavailable",
-  TRANSIENT: "transient",
-} as const;
-
-export type CliFailure = (typeof CLI_FAILURE)[keyof typeof CLI_FAILURE];
-
-export class CliCommandError extends Error {
-  readonly failure: CliFailure;
-
-  constructor(failure: CliFailure, message: string) {
-    super(message);
-    this.name = "CliCommandError";
-    this.failure = failure;
-  }
-}
+import { ADAPTER_FAILURE, AdapterFailure, clearsObservedState } from "./adapter-failure.js";
 
 export const CLI_ADAPTER_DEFAULTS = {
   MINIMUM_REFRESH_INTERVAL_MS: 15 * 1000,
@@ -94,10 +71,10 @@ export const defaultCliRun: CliRun = async (binary, argv, options) => {
     });
     return { exitCode: result.exitCode, stdout: result.stdout };
   } catch (error) {
-    throw new CliCommandError(
+    throw new AdapterFailure(
       error instanceof InvocationError && error.failure === INVOCATION_FAILURE.UNAVAILABLE
-        ? CLI_FAILURE.UNAVAILABLE
-        : CLI_FAILURE.TRANSIENT,
+        ? ADAPTER_FAILURE.UNAVAILABLE
+        : ADAPTER_FAILURE.TRANSIENT,
       `${binary} could not be run`,
     );
   }
@@ -203,10 +180,12 @@ export abstract class CliSessionAdapter extends SessionProviderAdapterBase {
     } catch (error) {
       // A superseded pass says nothing about the login that now stands.
       if (pass !== this.#collectPass) return this.#observations;
-      if (error instanceof CliCommandError) {
+      if (error instanceof AdapterFailure) {
         // A binary gone mid-pass clears observed state; a command that ran and
-        // failed keeps the previous snapshot until the next attempt.
-        if (error.failure === CLI_FAILURE.UNAVAILABLE) {
+        // failed keeps the previous snapshot until the next attempt. Nothing
+        // here raises `unauthorized`: the credential never passes through
+        // Luke, so an absent binary is the only way a login stops standing.
+        if (clearsObservedState(error.failure)) {
           this.#connection = CLI_CONNECTION.CLI_MISSING;
           this.#forgetObservedState(pass);
         }
@@ -327,7 +306,7 @@ export abstract class CliSessionAdapter extends SessionProviderAdapterBase {
       // A probe that cannot run at all is a machine with nothing to observe;
       // a probe that ran out of time says nothing about the login either way,
       // so the pass keeps its snapshot and asks again next time.
-      if (error instanceof CliCommandError && error.failure === CLI_FAILURE.UNAVAILABLE) {
+      if (error instanceof AdapterFailure && clearsObservedState(error.failure)) {
         return CLI_CONNECTION.CLI_MISSING;
       }
       throw error;
@@ -349,17 +328,17 @@ export abstract class CliSessionAdapter extends SessionProviderAdapterBase {
       this.#assertPassCurrent(pass);
       const name = this.provider.displayName;
       if (result.exitCode !== 0) {
-        throw new CliCommandError(CLI_FAILURE.TRANSIENT, `${name} CLI answered with a failure`);
+        throw new AdapterFailure(ADAPTER_FAILURE.TRANSIENT, `${name} CLI answered with a failure`);
       }
       let body: WireBoundaryInput;
       try {
         body = JSON.parse(result.stdout);
       } catch {
-        throw new CliCommandError(CLI_FAILURE.TRANSIENT, `${name} CLI answered unreadably`);
+        throw new AdapterFailure(ADAPTER_FAILURE.TRANSIENT, `${name} CLI answered unreadably`);
       }
       const bodyRecord = wireRecord(unparsedWire(body));
       if (!bodyRecord) {
-        throw new CliCommandError(CLI_FAILURE.TRANSIENT, `${name} CLI answered unexpectedly`);
+        throw new AdapterFailure(ADAPTER_FAILURE.TRANSIENT, `${name} CLI answered unexpectedly`);
       }
       return bodyRecord;
     };
@@ -367,8 +346,8 @@ export abstract class CliSessionAdapter extends SessionProviderAdapterBase {
 
   #assertPassCurrent(pass: number): void {
     if (pass !== this.#collectPass) {
-      throw new CliCommandError(
-        CLI_FAILURE.TRANSIENT,
+      throw new AdapterFailure(
+        ADAPTER_FAILURE.TRANSIENT,
         `${this.provider.displayName} pass was superseded`,
       );
     }

--- a/packages/providers/src/shared/cli-session-adapter.ts
+++ b/packages/providers/src/shared/cli-session-adapter.ts
@@ -72,11 +72,6 @@ export abstract class CliSessionAdapter extends SessionProviderAdapterBase {
     return this.#pass.connection();
   }
 
-  /** What the latest pass observed, for a subclass answering an act of its own. */
-  protected latest(): readonly ProviderSessionObservation[] {
-    return this.#pass.latest();
-  }
-
   /**
    * Clears anything a subclass cached across passes — projects offered for
    * creation, above all. It runs whenever the login goes away, so nothing

--- a/packages/providers/src/shared/cloud-pass.ts
+++ b/packages/providers/src/shared/cloud-pass.ts
@@ -1,0 +1,490 @@
+import {
+  ACT_RESULT_STATUS,
+  type ProviderActResult,
+  type ProviderSessionObservation,
+  SESSION_LOCATION,
+  type SessionProvider,
+} from "@sidecar/session";
+import {
+  type CloudFetch,
+  HTTP_STATUS,
+  isRecord,
+  resolveOptions,
+  unparsedWire,
+  type WireBoundaryInput,
+  type WireRecord,
+  wireRecord,
+} from "@sidecar/wire";
+import {
+  ADAPTER_DIAGNOSTIC_KIND,
+  type AdapterDiagnosticCallback,
+  type AdapterDiagnosticKind,
+} from "./adapter-diagnostics.js";
+import { ADAPTER_FAILURE, AdapterFailure, clearsObservedState } from "./adapter-failure.js";
+import {
+  CLOUD_ADAPTER_DEFAULTS,
+  type CloudRequest,
+  type CloudWriteRoute,
+  requestDeadlineMs,
+} from "./cloud-wire.js";
+
+const HTTP_METHOD = {
+  GET: "GET",
+  POST: "POST",
+} as const;
+
+/**
+ * How every provider observed here presents its credential. A provider that
+ * authenticates some other way is not supported rather than approximated.
+ */
+function authorizationHeaders(apiKey: string) {
+  return { Authorization: `Bearer ${apiKey}` };
+}
+
+const DEFAULT_REQUEST_HEADERS = {
+  Accept: "application/json",
+};
+
+/**
+ * The one body key a POSTed read document rides under. Linear's GraphQL and
+ * Conductor's transcripts view both name it `query`, and a provider that names
+ * it something else is asking for its own client rather than an option here.
+ */
+const READ_DOCUMENT_FIELD = "query";
+
+/** What a write acts on, as a refusal should name it. */
+export const WRITE_SUBJECT = {
+  SESSION: "session",
+  PROJECT: "project",
+  WORKSPACE: "workspace",
+} as const;
+
+export type WriteSubject = (typeof WRITE_SUBJECT)[keyof typeof WRITE_SUBJECT];
+
+/** What one authenticated write became, and whatever the provider answered with. */
+export interface CloudWriteOutcome {
+  outcome: ProviderActResult;
+  body?: WireRecord;
+}
+
+/**
+ * One read bound to the credential rather than to one pass, for an offer that
+ * rides beside the passes and may outlive several. Only a credential change
+ * discards it. What the caller does with the answer is handed in rather than
+ * returned, so the check and the write share one synchronous step and a
+ * credential cleared in the gap between them has no gap to land in.
+ */
+export type CredentialBoundRead = (
+  segments: readonly string[],
+  query: Readonly<Record<string, string>> | undefined,
+  options: Readonly<{ timeoutMs?: number; document?: string }> | undefined,
+  apply: (body: WireRecord) => void,
+) => Promise<void>;
+
+export interface CloudPassInput {
+  provider: SessionProvider;
+  defaultBaseUrl: string;
+  baseUrlEnvironmentVariable?: string;
+  /** Resolves the credential at observation time so a settings change applies immediately. */
+  readApiKey: () => Promise<string | undefined>;
+  baseUrl?: string;
+  fetch?: CloudFetch;
+  now?: () => number;
+  minimumRefreshIntervalMs?: number;
+  /**
+   * The headers every request carries besides the credential, for a provider
+   * that asks for its own media type or a version pin. The authorization
+   * header is layered on after these, so nothing here can replace the
+   * credential.
+   */
+  requestHeaders?: Readonly<Record<string, string>>;
+  /**
+   * Called when an observation pass fails for a reason other than a network
+   * or credential fault — a TypeError in an adapter's parsing, for example —
+   * or when an adapter reports a problem of its own, named by the kind.
+   * Transient and unauthorized {@link AdapterFailure} never reach it.
+   */
+  onDiagnostic?: AdapterDiagnosticCallback;
+  /**
+   * Clears anything the adapter cached across passes. It runs whenever the
+   * credential changes or is rejected, so nothing read as one user can be
+   * reported as another.
+   */
+  forget?(): void;
+  /** Runs one authenticated pass. Duplicate session ids are dropped here. */
+  collect(request: CloudRequest, now: number): Promise<readonly ProviderSessionObservation[]>;
+}
+
+/**
+ * The shared half of every cloud provider: credential handling, its own
+ * refresh cadence, the failure rules that decide whether a snapshot survives,
+ * bounded read-only requests, and the one authenticated write. An adapter
+ * supplies the provider's routes and how its reported state maps onto Luke's,
+ * and reaches its provider through nothing but these.
+ */
+export interface CloudPass {
+  run(): Promise<readonly ProviderSessionObservation[]>;
+  latest(): readonly ProviderSessionObservation[];
+  /** One authenticated write; answers what became of it, never throws. */
+  write(apiKey: string, route: CloudWriteRoute, subject?: WriteSubject): Promise<CloudWriteOutcome>;
+  credentialBoundRead: CredentialBoundRead;
+  /** The credential as the caller's own act should present it, read afresh. */
+  readApiKey(): Promise<string | undefined>;
+  reportDiagnostic(kind: AdapterDiagnosticKind, error: Error): void;
+}
+
+const defaultFetch: CloudFetch = (url, init) => fetch(url, init);
+
+function resolveBaseUrl(input: CloudPassInput): string {
+  const fromEnvironment = input.baseUrlEnvironmentVariable
+    ? process.env[input.baseUrlEnvironmentVariable]?.trim()
+    : undefined;
+  return input.baseUrl?.trim() || fromEnvironment || input.defaultBaseUrl;
+}
+
+/**
+ * Drops a session an adapter reported twice, and stamps the location the pass
+ * already knows: nothing reaches this point except over the network, so an
+ * adapter cannot forget to say its sessions run somewhere else.
+ */
+function cloudObservations(
+  observations: readonly ProviderSessionObservation[],
+): readonly ProviderSessionObservation[] {
+  const unique = new Map<string, ProviderSessionObservation>();
+  for (const observation of observations) {
+    if (!unique.has(observation.providerSessionId)) {
+      unique.set(observation.providerSessionId, {
+        ...observation,
+        location: SESSION_LOCATION.CLOUD,
+      });
+    }
+  }
+  return [...unique.values()];
+}
+
+export function cloudPass(input: CloudPassInput): CloudPass {
+  const provider = input.provider;
+  const baseUrl = resolveBaseUrl(input);
+  const performFetch = input.fetch ?? defaultFetch;
+  const now = input.now ?? Date.now;
+  const { minimumRefreshIntervalMs } = resolveOptions(
+    input,
+    { minimumRefreshIntervalMs: CLOUD_ADAPTER_DEFAULTS.MINIMUM_REFRESH_INTERVAL_MS },
+    { nonNegative: ["minimumRefreshIntervalMs"] },
+  );
+  const requestHeaders = input.requestHeaders ?? DEFAULT_REQUEST_HEADERS;
+
+  let credential: string | undefined;
+  /**
+   * Bumped only when the credential changes or is rejected — unlike the pass
+   * counter, which moves on every observation. It is what a slow read that
+   * outlives its pass is bound to: several passes may come and go while it
+   * runs, and only a different credential makes its answer wrong.
+   */
+  let credentialEpoch = 0;
+  let observations: readonly ProviderSessionObservation[] = [];
+  let lastAttemptAt = Number.NEGATIVE_INFINITY;
+  let collectPass = 0;
+
+  const forgetObservedState = (): void => {
+    // A pass still in flight was started under a credential that no longer
+    // stands, so its result must not land — and neither may a slow read's.
+    collectPass += 1;
+    credentialEpoch += 1;
+    input.forget?.();
+    observations = [];
+  };
+
+  const url = (
+    segments: readonly string[],
+    query: Readonly<Record<string, string>>,
+    action?: string,
+  ): string => {
+    const composed = new URL(baseUrl);
+    // The action rides after the segments unencoded: `:sendMessage` is part of
+    // the route, and encoding its colon would name a different route.
+    composed.pathname = `/${segments.map((segment) => encodeURIComponent(segment)).join("/")}${
+      action ? `:${action}` : ""
+    }`;
+    for (const [name, value] of Object.entries(query)) composed.searchParams.set(name, value);
+    return composed.href;
+  };
+
+  const requestJson = async (
+    apiKey: string,
+    segments: readonly string[],
+    query: Readonly<Record<string, string>> = {},
+    options: Readonly<{ timeoutMs?: number; document?: string }> = {},
+  ): Promise<WireRecord> => {
+    const name = provider.displayName;
+    const timeoutMs = requestDeadlineMs(options.timeoutMs);
+    // A read document rides as a POST because that is how its endpoint is
+    // documented, not because it writes: the body carries the document and
+    // nothing else, so the request can still express nothing but a read.
+    const document = options.document;
+    let response: Response;
+    try {
+      response = await performFetch(url(segments, query), {
+        method: document === undefined ? HTTP_METHOD.GET : HTTP_METHOD.POST,
+        headers: {
+          ...requestHeaders,
+          ...authorizationHeaders(apiKey),
+          ...(document === undefined ? undefined : { "Content-Type": "application/json" }),
+        },
+        ...(document === undefined
+          ? undefined
+          : { body: JSON.stringify({ [READ_DOCUMENT_FIELD]: document }) }),
+        signal: AbortSignal.timeout(timeoutMs),
+      });
+    } catch {
+      throw new AdapterFailure(ADAPTER_FAILURE.TRANSIENT, `${name} request failed`);
+    }
+
+    if (response.status === HTTP_STATUS.UNAUTHORIZED || response.status === HTTP_STATUS.FORBIDDEN) {
+      throw new AdapterFailure(
+        ADAPTER_FAILURE.UNAUTHORIZED,
+        `${name} rejected the configured API key`,
+      );
+    }
+    if (!response.ok) {
+      throw new AdapterFailure(
+        ADAPTER_FAILURE.TRANSIENT,
+        `${name} responded with status ${response.status}`,
+      );
+    }
+
+    let body: WireBoundaryInput;
+    try {
+      body = await response.json();
+    } catch {
+      throw new AdapterFailure(
+        ADAPTER_FAILURE.TRANSIENT,
+        `${name} returned an unreadable response`,
+      );
+    }
+    const bodyRecord = wireRecord(unparsedWire(body));
+    if (!bodyRecord) {
+      throw new AdapterFailure(
+        ADAPTER_FAILURE.TRANSIENT,
+        `${name} returned an unexpected response`,
+      );
+    }
+    return bodyRecord;
+  };
+
+  const assertPassCurrent = (pass: number): void => {
+    if (pass !== collectPass) {
+      throw new AdapterFailure(
+        ADAPTER_FAILURE.TRANSIENT,
+        `${provider.displayName} pass was superseded`,
+      );
+    }
+  };
+
+  /**
+   * Binds one pass's requests to the credential it started with. A superseded
+   * pass fails instead of issuing another request with a replaced key, and
+   * whatever a request already read is discarded before an adapter can cache
+   * it over state that belongs to the new credential.
+   */
+  const requestForPass = (pass: number, apiKey: string): CloudRequest => {
+    return async (segments, query, options) => {
+      assertPassCurrent(pass);
+      const body = await requestJson(apiKey, segments, query, options);
+      assertPassCurrent(pass);
+      return body;
+    };
+  };
+
+  return {
+    async run() {
+      // One observer must never abort the shared refresh pass, so a settings
+      // read that fails is treated the same as having no credential at all.
+      const apiKey = await input.readApiKey().catch(() => undefined);
+      if (!apiKey) {
+        credential = undefined;
+        forgetObservedState();
+        return observations;
+      }
+
+      const attemptedAt = now();
+      if (apiKey === credential) {
+        // A network provider refreshes on its own cadence instead of on every
+        // tick of the shared observation timer.
+        if (attemptedAt - lastAttemptAt < minimumRefreshIntervalMs) return observations;
+      } else {
+        credential = apiKey;
+        forgetObservedState();
+      }
+      lastAttemptAt = attemptedAt;
+
+      // Observers can overlap: a settings save refreshes this adapter while a
+      // timer-driven pass is still in flight with the key it replaced. Only
+      // the newest pass may write, or sessions read as one credential would be
+      // served as another's until the next refresh.
+      const pass = ++collectPass;
+      try {
+        const collected = await input.collect(requestForPass(pass, apiKey), attemptedAt);
+        if (pass === collectPass) observations = cloudObservations(collected);
+      } catch (error) {
+        // A rejected credential clears observed state; a transient network or
+        // server failure keeps the previous snapshot until the next attempt. A
+        // superseded pass reports on a credential that no longer stands, so
+        // its rejection says nothing about the current one.
+        if (pass !== collectPass) return observations;
+        if (error instanceof AdapterFailure) {
+          if (clearsObservedState(error.failure)) forgetObservedState();
+          return observations;
+        }
+        // Anything else is a bug in this pass — a TypeError thrown by an
+        // adapter's parsing is not a network blip, and must not keep serving
+        // the stale snapshot with no log, counter, or hook.
+        input.onDiagnostic?.(
+          ADAPTER_DIAGNOSTIC_KIND.PASS_FAILURE,
+          error instanceof Error ? error : new Error(String(error)),
+        );
+        throw error;
+      }
+      return observations;
+    },
+
+    latest: () => observations,
+
+    readApiKey: () => input.readApiKey().catch(() => undefined),
+
+    reportDiagnostic(kind, error) {
+      input.onDiagnostic?.(kind, error);
+    },
+
+    /**
+     * The one authenticated write. It shares the read path's timeout and its
+     * refusal to echo anything the provider said into an error a user sees,
+     * and it answers with what became of the request rather than throwing: a
+     * write is a user's own act, so every outcome has to land back on the row
+     * it left. The subject is what the route acts on, so a refusal names the
+     * thing that actually went missing. What the provider answered with rides
+     * along for the adapter that needs it — a creation response names the
+     * thing it created — and travels no further.
+     */
+    async write(apiKey, route, subject = WRITE_SUBJECT.SESSION) {
+      const name = provider.displayName;
+      let response: Response;
+      try {
+        response = await performFetch(url(route.segments, {}, route.action), {
+          method: HTTP_METHOD.POST,
+          // The same layering as a read: the provider's own headers first, the
+          // credential after them so no override can replace it.
+          headers: {
+            ...requestHeaders,
+            ...authorizationHeaders(apiKey),
+            // An endpoint that documents an empty request gets exactly that,
+            // not an empty JSON object it never asked for.
+            ...(route.body === undefined ? undefined : { "Content-Type": "application/json" }),
+          },
+          ...(route.body === undefined ? undefined : { body: JSON.stringify(route.body) }),
+          signal: AbortSignal.timeout(requestDeadlineMs(route.timeoutMs)),
+        });
+      } catch {
+        // A thrown fetch cannot say which side of the wire failed: a
+        // connection that never opened sent nothing, but a timeout or a reset
+        // while the answer was coming back leaves a request the provider may
+        // have already acted on. So the refusal hedges rather than claims, and
+        // the refresh that follows must actually ask, so a write that did land
+        // is reconciled against the provider instead of the cache still
+        // advertising it.
+        lastAttemptAt = Number.NEGATIVE_INFINITY;
+        return {
+          outcome: {
+            status: ACT_RESULT_STATUS.REJECTED,
+            reason: `${name} did not answer, so the request may not have landed.`,
+          },
+        };
+      }
+
+      if (response.ok) {
+        // A write that landed changes what the session is doing, so the
+        // refresh that follows must actually ask: served from the cache inside
+        // the minimum interval, the row would keep offering what the provider
+        // has already taken.
+        lastAttemptAt = Number.NEGATIVE_INFINITY;
+        // An unreadable body is not a failed write: the provider already said
+        // yes, so only a follow-up that needed the body has anything to miss.
+        const body = await response.json().catch(() => undefined);
+        return {
+          outcome: { status: ACT_RESULT_STATUS.ACCEPTED },
+          ...(isRecord(body) ? { body } : undefined),
+        };
+      }
+      if (
+        response.status === HTTP_STATUS.UNAUTHORIZED ||
+        response.status === HTTP_STATUS.FORBIDDEN
+      ) {
+        return {
+          outcome: {
+            status: ACT_RESULT_STATUS.REJECTED,
+            reason: `${name} rejected the configured API key.`,
+          },
+        };
+      }
+      if (response.status === HTTP_STATUS.NOT_FOUND) {
+        return {
+          outcome: {
+            status: ACT_RESULT_STATUS.REJECTED,
+            reason: `${name} no longer has this ${subject}.`,
+          },
+        };
+      }
+      if (response.status === HTTP_STATUS.CONFLICT) {
+        return {
+          outcome: {
+            status: ACT_RESULT_STATUS.REJECTED,
+            reason: `${name} says this ${subject} has moved on since Luke last looked.`,
+          },
+        };
+      }
+      // Any other status is an answer that says nothing certain about the act
+      // — a gateway that gave up may stand in front of a write that finished —
+      // so this hedges the way a thrown fetch does, and the refresh that
+      // follows must actually ask rather than keep advertising what the
+      // provider may have already taken.
+      lastAttemptAt = Number.NEGATIVE_INFINITY;
+      return {
+        outcome: {
+          status: ACT_RESULT_STATUS.REJECTED,
+          reason: `${name} answered with status ${response.status}, so the request may not have landed.`,
+        },
+      };
+    },
+
+    async credentialBoundRead(segments, query, options, apply) {
+      const epoch = credentialEpoch;
+      const apiKey = credential;
+      if (!apiKey) {
+        throw new AdapterFailure(
+          ADAPTER_FAILURE.TRANSIENT,
+          `${provider.displayName} has no credential to read with`,
+        );
+      }
+      const body = await requestJson(apiKey, segments, query, options);
+      if (epoch !== credentialEpoch) {
+        throw new AdapterFailure(
+          ADAPTER_FAILURE.TRANSIENT,
+          `${provider.displayName} read outlived its credential`,
+        );
+      }
+      apply(body);
+    },
+  };
+}
+
+/** Keeps one failed resource from discarding an otherwise complete pass. */
+export async function tolerateItemFailure<Result>(
+  operation: () => Promise<Result>,
+): Promise<Result | undefined> {
+  try {
+    return await operation();
+  } catch (error) {
+    if (error instanceof AdapterFailure && clearsObservedState(error.failure)) throw error;
+    return undefined;
+  }
+}

--- a/packages/providers/src/shared/cloud-pass.ts
+++ b/packages/providers/src/shared/cloud-pass.ts
@@ -186,6 +186,13 @@ export function cloudPass(input: CloudPassInput): CloudPass {
   let lastAttemptAt = Number.NEGATIVE_INFINITY;
   let collectPass = 0;
 
+  /**
+   * One observer must never abort the shared refresh pass, so a settings read
+   * that fails is treated the same as having no credential at all — here, and
+   * for the act that reads the credential again at its own moment.
+   */
+  const readApiKey = (): Promise<string | undefined> => input.readApiKey().catch(() => undefined);
+
   const forgetObservedState = (): void => {
     // A pass still in flight was started under a credential that no longer
     // stands, so its result must not land — and neither may a slow read's.
@@ -298,9 +305,7 @@ export function cloudPass(input: CloudPassInput): CloudPass {
 
   return {
     async run() {
-      // One observer must never abort the shared refresh pass, so a settings
-      // read that fails is treated the same as having no credential at all.
-      const apiKey = await input.readApiKey().catch(() => undefined);
+      const apiKey = await readApiKey();
       if (!apiKey) {
         credential = undefined;
         forgetObservedState();
@@ -350,7 +355,7 @@ export function cloudPass(input: CloudPassInput): CloudPass {
 
     latest: () => observations,
 
-    readApiKey: () => input.readApiKey().catch(() => undefined),
+    readApiKey,
 
     reportDiagnostic(kind, error) {
       input.onDiagnostic?.(kind, error);
@@ -475,16 +480,4 @@ export function cloudPass(input: CloudPassInput): CloudPass {
       apply(body);
     },
   };
-}
-
-/** Keeps one failed resource from discarding an otherwise complete pass. */
-export async function tolerateItemFailure<Result>(
-  operation: () => Promise<Result>,
-): Promise<Result | undefined> {
-  try {
-    return await operation();
-  } catch (error) {
-    if (error instanceof AdapterFailure && clearsObservedState(error.failure)) throw error;
-    return undefined;
-  }
 }

--- a/packages/providers/src/shared/cloud-session-adapter.test.ts
+++ b/packages/providers/src/shared/cloud-session-adapter.test.ts
@@ -11,19 +11,17 @@ import {
   SESSION_STATUS,
   UNSUPPORTED_BY_OBSERVATION,
 } from "@sidecar/session";
-import { isWireString } from "@sidecar/wire";
+import { type CloudFetch, isWireString } from "@sidecar/wire";
 import { HTTP_STATUS, jsonResponse, recordingFetch } from "@sidecar/wire/testing";
 import { ADAPTER_DIAGNOSTIC_KIND, type AdapterDiagnosticCallback } from "./adapter-diagnostics.js";
+import { type CloudAdapterOptions, CloudSessionAdapter } from "./cloud-session-adapter.js";
 import {
   CLOUD_ADAPTER_DEFAULTS,
-  type CloudAdapterOptions,
-  type CloudFetch,
   type CloudRequest,
-  CloudSessionAdapter,
   isDefined,
   knownValue,
   requestDeadlineMs,
-} from "./cloud-session-adapter.js";
+} from "./cloud-wire.js";
 
 const TEST_TIME = Date.parse("2026-08-12T02:45:00.000Z");
 const TEST_BASE_URL = "https://api.provider.test";
@@ -70,8 +68,11 @@ class StubCloudAdapter extends CloudSessionAdapter {
   collected: readonly ProviderSessionObservation[] = [];
   collectError: Error | undefined;
 
-  constructor(options: CloudAdapterOptions) {
-    super({ provider: STUB_PROVIDER, defaultBaseUrl: TEST_BASE_URL }, options);
+  constructor({
+    requestHeaders,
+    ...options
+  }: CloudAdapterOptions & { requestHeaders?: Readonly<Record<string, string>> }) {
+    super({ provider: STUB_PROVIDER, defaultBaseUrl: TEST_BASE_URL, requestHeaders }, options);
   }
 
   protected override forgetCachedIdentity(): void {
@@ -142,8 +143,11 @@ function adapterFor(
 
 /** A cloud adapter that observes and routes nothing. */
 class ObservationOnlyAdapter extends CloudSessionAdapter {
-  constructor(options: CloudAdapterOptions) {
-    super({ provider: STUB_PROVIDER, defaultBaseUrl: TEST_BASE_URL }, options);
+  constructor({
+    requestHeaders,
+    ...options
+  }: CloudAdapterOptions & { requestHeaders?: Readonly<Record<string, string>> }) {
+    super({ provider: STUB_PROVIDER, defaultBaseUrl: TEST_BASE_URL, requestHeaders }, options);
   }
 
   protected async collect(): Promise<readonly ProviderSessionObservation[]> {
@@ -196,16 +200,10 @@ test("authenticates a bounded read and encodes the route a subclass asked for", 
   assert.equal(request.body, undefined);
 });
 
-/** Stands in for a provider that asks for its own media type and version pin. */
-class PinnedHeaderAdapter extends StubCloudAdapter {
-  protected override requestHeaders() {
-    return { Accept: "application/vnd.stub+json", "X-Stub-Api-Version": "2026-03-10" };
-  }
-}
-
-test("lets a subclass pin its own request headers without touching the credential", async () => {
+test("lets a provider pin its own request headers without touching the credential", async () => {
   const { fetch, requests } = recordingFetch(() => jsonResponse({}));
-  const adapter = new PinnedHeaderAdapter({
+  const adapter = new StubCloudAdapter({
+    requestHeaders: { Accept: "application/vnd.stub+json", "X-Stub-Api-Version": "2026-03-10" },
     readApiKey: async () => TEST_API_KEY,
     baseUrl: TEST_BASE_URL,
     fetch,
@@ -325,8 +323,11 @@ function deferred() {
  * by the account that answers, not by anything cached on the adapter.
  */
 class AccountBoundAdapter extends CloudSessionAdapter {
-  constructor(options: CloudAdapterOptions) {
-    super({ provider: STUB_PROVIDER, defaultBaseUrl: TEST_BASE_URL }, options);
+  constructor({
+    requestHeaders,
+    ...options
+  }: CloudAdapterOptions & { requestHeaders?: Readonly<Record<string, string>> }) {
+    super({ provider: STUB_PROVIDER, defaultBaseUrl: TEST_BASE_URL, requestHeaders }, options);
   }
 
   protected async collect(request: CloudRequest): Promise<readonly ProviderSessionObservation[]> {

--- a/packages/providers/src/shared/cloud-session-adapter.ts
+++ b/packages/providers/src/shared/cloud-session-adapter.ts
@@ -26,7 +26,8 @@ import {
 } from "@sidecar/session";
 import type { CloudFetch, WireRecord } from "@sidecar/wire";
 import type { AdapterDiagnosticCallback, AdapterDiagnosticKind } from "./adapter-diagnostics.js";
-import { type CloudPass, cloudPass, tolerateItemFailure, WRITE_SUBJECT } from "./cloud-pass.js";
+import { tolerateItemFailure } from "./adapter-failure.js";
+import { type CloudPass, cloudPass, WRITE_SUBJECT } from "./cloud-pass.js";
 import type { CloudRequest, CloudWriteRoute } from "./cloud-wire.js";
 
 export interface CloudAdapterOptions {

--- a/packages/providers/src/shared/cloud-session-adapter.ts
+++ b/packages/providers/src/shared/cloud-session-adapter.ts
@@ -15,88 +15,19 @@ import {
   type ProviderWorkspaceRenameRequest,
   type ProviderWorkspaceRequest,
   type ProviderWorkspaceResult,
-  SESSION_LOCATION,
   type SessionProvider,
   SessionProviderAdapterBase,
   sessionMessageText,
-  UNKNOWN_WORKSPACE_LABEL,
-  UNSUPPORTED_BY_OBSERVATION,
   WORKSPACE_TASK_SUPPORT,
   type WorkspaceAgentSelection,
   type WorkspaceProject,
+  UNSUPPORTED_BY_OBSERVATION,
   workspaceNameText,
 } from "@sidecar/session";
-import {
-  type CloudFetch,
-  HTTP_STATUS,
-  isRecord,
-  positiveInteger,
-  resolveOptions,
-  text,
-  unparsedWire,
-  type WireBoundaryInput,
-  type WireRecord,
-  wireRecord,
-} from "@sidecar/wire";
-import {
-  ADAPTER_DIAGNOSTIC_KIND,
-  type AdapterDiagnosticCallback,
-  type AdapterDiagnosticKind,
-} from "./adapter-diagnostics.js";
-import { ADAPTER_FAILURE, AdapterFailure, clearsObservedState } from "./adapter-failure.js";
-
-const GIT_SUFFIX = ".git";
-
-const HTTP_METHOD = {
-  GET: "GET",
-  POST: "POST",
-} as const;
-
-/**
- * How every provider observed here presents its credential. A provider that
- * authenticates some other way is not supported rather than approximated.
- */
-function authorizationHeaders(apiKey: string) {
-  return { Authorization: `Bearer ${apiKey}` };
-}
-
-const DEFAULT_REQUEST_HEADERS = {
-  Accept: "application/json",
-};
-
-/**
- * The one body key a POSTed read document rides under. Linear's GraphQL and
- * Conductor's transcripts view both name it `query`, and a provider that names
- * it something else is asking for its own client rather than an option here.
- */
-const READ_DOCUMENT_FIELD = "query";
-
-/** What a write acts on, as a refusal should name it. */
-const WRITE_SUBJECT = {
-  SESSION: "session",
-  PROJECT: "project",
-  WORKSPACE: "workspace",
-} as const;
-
-type WriteSubject = (typeof WRITE_SUBJECT)[keyof typeof WRITE_SUBJECT];
-
-/**
- * Cloud-only request bounds. The freshness bound in `OBSERVATION_WINDOW` is
- * shared with every local provider.
- */
-export const CLOUD_ADAPTER_DEFAULTS = {
-  MINIMUM_REFRESH_INTERVAL_MS: 15 * 1000,
-  REQUEST_TIMEOUT_MS: 8 * 1000,
-  /**
-   * For the rare read a provider documents as slow — Cursor's repository list
-   * can take tens of seconds for a large organisation. A read on this deadline
-   * must never hold the observation pass; it is for work that rides beside
-   * one.
-   */
-  SLOW_REQUEST_TIMEOUT_MS: 45 * 1000,
-} as const;
-
-export type { CloudFetch } from "@sidecar/wire";
+import type { CloudFetch, WireRecord } from "@sidecar/wire";
+import type { AdapterDiagnosticCallback, AdapterDiagnosticKind } from "./adapter-diagnostics.js";
+import { type CloudPass, cloudPass, tolerateItemFailure, WRITE_SUBJECT } from "./cloud-pass.js";
+import type { CloudRequest, CloudWriteRoute } from "./cloud-wire.js";
 
 export interface CloudAdapterOptions {
   /** Resolves the credential at observation time so a settings change applies immediately. */
@@ -109,7 +40,7 @@ export interface CloudAdapterOptions {
    * Called when an observation pass fails for a reason other than a network
    * or credential fault — a TypeError in a subclass's parsing, for example —
    * or when a subclass reports a problem of its own, named by the kind.
-   * Transient and unauthorized {@link AdapterFailure} never reach it.
+   * Transient and unauthorized adapter failures never reach it.
    */
   onDiagnostic?: AdapterDiagnosticCallback;
 }
@@ -119,224 +50,45 @@ export interface CloudAdapterProfile {
   provider: SessionProvider;
   defaultBaseUrl: string;
   baseUrlEnvironmentVariable?: string;
-}
-
-/**
- * The only way a subclass reaches its provider while observing. It
- * authenticates, bounds, and parses the request, and it can express nothing
- * but a read, so no observation pass built on it can change provider state.
- * The deadline can be widened only to the slow bound, and only for a read the
- * provider itself documents as slow.
- *
- * A read the provider answers only at a POSTed query endpoint — Conductor's
- * transcripts view — names its document here, and the separation a GET gives
- * for free is held the way the Linear tracker holds it: the document's text is
- * fixed by the build, observation only ever sends a read, and an adapter
- * interpolates nothing into it beyond identifiers the same pass reported, each
- * validated against the shape its provider documents.
- */
-export type CloudRequest = (
-  segments: readonly string[],
-  query?: Readonly<Record<string, string>>,
-  options?: Readonly<{ timeoutMs?: number; document?: string }>,
-) => Promise<WireRecord>;
-
-/**
- * One documented write a provider takes for one of its sessions: the route and
- * the exact body its endpoint asks for. A subclass describes the request; the
- * base is the only thing that issues one.
- */
-export interface CloudWriteRoute {
-  segments: readonly string[];
   /**
-   * A Google-style custom method, appended to the path as `:action` rather
-   * than as a segment: it names what the request does to the resource the
-   * segments already name.
+   * The headers every request carries besides the credential, for a provider
+   * that asks for its own media type or a version pin. The authorization
+   * header is layered on after these, so nothing declared here can replace
+   * the credential.
    */
-  action?: string;
-  /** Left off entirely for an endpoint that documents an empty request. */
-  body?: Readonly<WireRecord>;
-  /**
-   * For the rare write the provider answers only once the act itself is done
-   * — Conductor's archive stands the whole workspace down before it says so,
-   * well past the shared request bound. A deadline shorter than the act turns
-   * a write that landed into "may not have landed", so such a route asks for
-   * the slow bound, the same ceiling a slow read gets and the widest this one
-   * can reach.
-   */
-  timeoutMs?: number;
+  requestHeaders?: Readonly<Record<string, string>>;
 }
 
 /**
- * A request's deadline never widens past the slow bound: the option exists for
- * a read or write the provider is known to answer slowly, not for one that
- * never ends.
- */
-export function requestDeadlineMs(requested: number | undefined): number {
-  return Math.min(
-    positiveInteger(requested, CLOUD_ADAPTER_DEFAULTS.REQUEST_TIMEOUT_MS),
-    CLOUD_ADAPTER_DEFAULTS.SLOW_REQUEST_TIMEOUT_MS,
-  );
-}
-
-export function isDefined<Value>(value: Value | undefined): value is Value {
-  return value !== undefined;
-}
-
-export function textFromRecord(record: WireRecord, key: string): string | undefined {
-  return text(record[key]);
-}
-
-export function timestampFromRecord(record: WireRecord, key: string): number | undefined {
-  const value = textFromRecord(record, key);
-  if (!value) return undefined;
-  const timestampMs = Date.parse(value);
-  return Number.isFinite(timestampMs) ? timestampMs : undefined;
-}
-
-/**
- * Reads a value a provider reported only when this build knows it, so a state
- * added after this build shipped is left undefined rather than guessed at.
- */
-export function knownValue<Value extends string>(
-  values: Readonly<Record<string, Value>>,
-  reported: string | undefined,
-): Value | undefined {
-  return Object.values(values).find((candidate) => candidate === reported);
-}
-
-/** Reads a list page without assuming which key a given provider wraps it in. */
-export function recordsFromPage(body: WireRecord, key: string): WireRecord[] {
-  const data = body[key];
-  return Array.isArray(data) ? data.filter(isRecord) : [];
-}
-
-/**
- * Luke labels a session by its repository, never by a workspace, agent, or
- * session name. Cloud providers derive those names from the opening prompt, so
- * they are transcript content that no adapter may surface.
- */
-export function repositoryLabel(
-  gitRemote: string | undefined,
-  fallbackName: string | undefined,
-): string {
-  const remote = gitRemote?.trim().replace(/\/+$/, "");
-  const lastSegment = remote?.split(/[/:]/).pop()?.trim();
-  const repository = lastSegment?.endsWith(GIT_SUFFIX)
-    ? lastSegment.slice(0, -GIT_SUFFIX.length)
-    : lastSegment;
-  return repository || fallbackName?.trim() || UNKNOWN_WORKSPACE_LABEL;
-}
-
-const defaultFetch: CloudFetch = (url, init) => fetch(url, init);
-
-function resolveBaseUrl(profile: CloudAdapterProfile, configured: string | undefined): string {
-  const fromEnvironment = profile.baseUrlEnvironmentVariable
-    ? process.env[profile.baseUrlEnvironmentVariable]?.trim()
-    : undefined;
-  return configured?.trim() || fromEnvironment || profile.defaultBaseUrl;
-}
-
-/**
- * The shared half of every cloud provider adapter: credential handling, its own
- * refresh cadence, the failure rules that decide whether a snapshot survives,
- * and bounded read-only requests. A subclass supplies the provider's routes
- * and how its reported state maps onto Luke's.
+ * The adapter-shaped half of a cloud provider. `cloudPass` holds the
+ * credential, the refresh cadence, the failure rules that decide whether a
+ * snapshot survives, the bounded read-only requests and the one authenticated
+ * write; what is left here is the act guards — each acting on nothing but
+ * what a user asked for against something the last pass observed — and the
+ * route seams a subclass supplies.
  *
  * Every operation is explicit on the adapter interface. The base answers
- * unsupported unless a subclass supplies the matching route, and each routed
- * operation acts on nothing but what a user asked for against something the
- * last pass observed. Observation itself stays read-only.
+ * unsupported unless a subclass supplies the matching route. Observation
+ * itself stays read-only.
  */
 export abstract class CloudSessionAdapter extends SessionProviderAdapterBase {
   readonly provider: SessionProvider;
 
-  readonly #readApiKey: () => Promise<string | undefined>;
-  readonly #baseUrl: string;
-  readonly #fetch: CloudFetch;
-  readonly #now: () => number;
-  readonly #minimumRefreshIntervalMs: number;
-  readonly #onDiagnostic: AdapterDiagnosticCallback | undefined;
-
-  #credential: string | undefined;
-  /**
-   * Bumped only when the credential changes or is rejected — unlike the pass
-   * counter, which moves on every observation. It is what a slow read that
-   * outlives its pass is bound to: several passes may come and go while it
-   * runs, and only a different credential makes its answer wrong.
-   */
-  #credentialEpoch = 0;
-  #observations: readonly ProviderSessionObservation[] = [];
-  #lastAttemptAt = Number.NEGATIVE_INFINITY;
-  #collectPass = 0;
+  readonly #pass: CloudPass;
 
   constructor(profile: CloudAdapterProfile, options: CloudAdapterOptions) {
     super();
     this.provider = profile.provider;
-    this.#readApiKey = options.readApiKey;
-    this.#baseUrl = resolveBaseUrl(profile, options.baseUrl);
-    this.#fetch = options.fetch ?? defaultFetch;
-    this.#now = options.now ?? Date.now;
-    const { minimumRefreshIntervalMs } = resolveOptions(
-      options,
-      { minimumRefreshIntervalMs: CLOUD_ADAPTER_DEFAULTS.MINIMUM_REFRESH_INTERVAL_MS },
-      { nonNegative: ["minimumRefreshIntervalMs"] },
-    );
-    this.#minimumRefreshIntervalMs = minimumRefreshIntervalMs;
-    this.#onDiagnostic = options.onDiagnostic;
+    this.#pass = cloudPass({
+      ...profile,
+      ...options,
+      collect: (request, now) => this.collect(request, now),
+      forget: () => this.forgetCachedIdentity(),
+    });
   }
 
-  async observe(): Promise<readonly ProviderSessionObservation[]> {
-    // One observer must never abort the shared refresh pass, so a settings read
-    // that fails is treated the same as having no credential at all.
-    const apiKey = await this.#readApiKey().catch(() => undefined);
-    if (!apiKey) {
-      this.#credential = undefined;
-      this.#forgetObservedState();
-      return this.#observations;
-    }
-
-    const now = this.#now();
-    if (apiKey === this.#credential) {
-      // A network provider refreshes on its own cadence instead of on every
-      // tick of the shared observation timer.
-      if (now - this.#lastAttemptAt < this.#minimumRefreshIntervalMs) return this.#observations;
-    } else {
-      this.#credential = apiKey;
-      this.#forgetObservedState();
-    }
-    this.#lastAttemptAt = now;
-
-    // Observers can overlap: a settings save refreshes this adapter while a
-    // timer-driven pass is still in flight with the key it replaced. Only the
-    // newest pass may write, or sessions read as one credential would be
-    // served as another's until the next refresh.
-    const pass = ++this.#collectPass;
-    try {
-      const collected = await this.collect(this.#requestForPass(pass, apiKey), now);
-      if (pass === this.#collectPass) this.#observations = cloudObservations(collected);
-    } catch (error) {
-      // A rejected credential clears observed state; a transient network or
-      // server failure keeps the previous snapshot until the next attempt. A
-      // superseded pass reports on a credential that no longer stands, so its
-      // rejection says nothing about the current one.
-      if (pass !== this.#collectPass) {
-        return this.#observations;
-      }
-      if (error instanceof AdapterFailure) {
-        if (clearsObservedState(error.failure)) this.#forgetObservedState();
-        return this.#observations;
-      }
-      // Anything else is a bug in this pass — a TypeError thrown by a
-      // subclass's parsing is not a network blip, and must not keep serving
-      // the stale snapshot with no log, counter, or hook.
-      this.reportDiagnostic(
-        ADAPTER_DIAGNOSTIC_KIND.PASS_FAILURE,
-        error instanceof Error ? error : new Error(String(error)),
-      );
-      throw error;
-    }
-    return this.#observations;
+  observe(): Promise<readonly ProviderSessionObservation[]> {
+    return this.#pass.run();
   }
 
   /**
@@ -344,7 +96,7 @@ export abstract class CloudSessionAdapter extends SessionProviderAdapterBase {
    * surfacing from a pass that otherwise succeeded.
    */
   protected reportDiagnostic(kind: AdapterDiagnosticKind, error: Error): void {
-    this.#onDiagnostic?.(kind, error);
+    this.#pass.reportDiagnostic(kind, error);
   }
 
   /**
@@ -354,9 +106,9 @@ export abstract class CloudSessionAdapter extends SessionProviderAdapterBase {
    * exists only for a session the last pass actually saw.
    */
   protected latestObservation(providerSessionId: string): ProviderSessionObservation | undefined {
-    return this.#observations.find(
-      (candidate) => candidate.providerSessionId === providerSessionId,
-    );
+    return this.#pass
+      .latest()
+      .find((candidate) => candidate.providerSessionId === providerSessionId);
   }
 
   /**
@@ -368,9 +120,7 @@ export abstract class CloudSessionAdapter extends SessionProviderAdapterBase {
    * without touching the network.
    */
   override async sendMessage(message: ProviderSessionMessage): Promise<ProviderMessageResult> {
-    const observation = this.#observations.find(
-      (candidate) => candidate.providerSessionId === message.providerSessionId,
-    );
+    const observation = this.latestObservation(message.providerSessionId);
     if (!observation || !advertisedActFor(observation, ACT_KIND.MESSAGE)) {
       return {
         status: ACT_RESULT_STATUS.UNSUPPORTED,
@@ -391,7 +141,7 @@ export abstract class CloudSessionAdapter extends SessionProviderAdapterBase {
     // absence is a rejection with the actual reason, not the unsupported answer: the
     // session advertised taking messages while a key stood behind it, and a
     // key that has since gone is a different fact than a session that moved on.
-    const apiKey = await this.#readApiKey().catch(() => undefined);
+    const apiKey = await this.#pass.readApiKey();
     if (!apiKey) return this.#missingKeyRejection();
 
     const route = this.messageRoute(message.providerSessionId, text);
@@ -400,7 +150,7 @@ export abstract class CloudSessionAdapter extends SessionProviderAdapterBase {
         status: ACT_RESULT_STATUS.UNSUPPORTED,
         reason: UNSUPPORTED_BY_OBSERVATION,
       };
-    return this.#postWrite(apiKey, route);
+    return (await this.#pass.write(apiKey, route)).outcome;
   }
 
   #missingKeyRejection(): ProviderActResult {
@@ -418,9 +168,7 @@ export abstract class CloudSessionAdapter extends SessionProviderAdapterBase {
    * credential.
    */
   override async executeControl(request: ProviderControlRequest): Promise<ProviderControlResult> {
-    const observation = this.#observations.find(
-      (candidate) => candidate.providerSessionId === request.providerSessionId,
-    );
+    const observation = this.latestObservation(request.providerSessionId);
     // The advertised control — not the caller's copy of it — is what the route
     // is built from, so whatever it targets is the thing the last pass actually
     // saw, and nothing a caller sends can redirect it.
@@ -431,7 +179,7 @@ export abstract class CloudSessionAdapter extends SessionProviderAdapterBase {
         reason: UNSUPPORTED_BY_OBSERVATION,
       };
 
-    const apiKey = await this.#readApiKey().catch(() => undefined);
+    const apiKey = await this.#pass.readApiKey();
     if (!apiKey) return this.#missingKeyRejection();
 
     const route = this.controlRoute(request.providerSessionId, advertised);
@@ -440,7 +188,7 @@ export abstract class CloudSessionAdapter extends SessionProviderAdapterBase {
         status: ACT_RESULT_STATUS.UNSUPPORTED,
         reason: UNSUPPORTED_BY_OBSERVATION,
       };
-    return this.#postWrite(apiKey, route);
+    return (await this.#pass.write(apiKey, route)).outcome;
   }
 
   /**
@@ -453,9 +201,7 @@ export abstract class CloudSessionAdapter extends SessionProviderAdapterBase {
   override async spawnWorkspaceAgent(
     request: ProviderWorkspaceAgentRequest,
   ): Promise<ProviderWorkspaceResult> {
-    const observation = this.#observations.find(
-      (candidate) => candidate.providerSessionId === request.providerSessionId,
-    );
+    const observation = this.latestObservation(request.providerSessionId);
     if (!observation)
       return {
         status: ACT_RESULT_STATUS.UNSUPPORTED,
@@ -501,9 +247,9 @@ export abstract class CloudSessionAdapter extends SessionProviderAdapterBase {
         reason: UNSUPPORTED_BY_OBSERVATION,
       };
 
-    const apiKey = await this.#readApiKey().catch(() => undefined);
+    const apiKey = await this.#pass.readApiKey();
     if (!apiKey) return this.#missingKeyRejection();
-    return this.#postWrite(apiKey, route);
+    return (await this.#pass.write(apiKey, route)).outcome;
   }
 
   /**
@@ -532,9 +278,7 @@ export abstract class CloudSessionAdapter extends SessionProviderAdapterBase {
   override async renameWorkspace(
     request: ProviderWorkspaceRenameRequest,
   ): Promise<ProviderActResult> {
-    const observation = this.#observations.find(
-      (candidate) => candidate.providerSessionId === request.providerSessionId,
-    );
+    const observation = this.latestObservation(request.providerSessionId);
     // The advertised target — not the caller's word — is what the route is
     // built from, so a rename only ever lands on the workspace the last pass
     // promised.
@@ -564,9 +308,9 @@ export abstract class CloudSessionAdapter extends SessionProviderAdapterBase {
         reason: UNSUPPORTED_BY_OBSERVATION,
       };
 
-    const apiKey = await this.#readApiKey().catch(() => undefined);
+    const apiKey = await this.#pass.readApiKey();
     if (!apiKey) return this.#missingKeyRejection();
-    return this.#postWrite(apiKey, route, WRITE_SUBJECT.WORKSPACE);
+    return (await this.#pass.write(apiKey, route, WRITE_SUBJECT.WORKSPACE)).outcome;
   }
 
   /**
@@ -592,9 +336,7 @@ export abstract class CloudSessionAdapter extends SessionProviderAdapterBase {
    * the network.
    */
   override async renameSession(request: ProviderSessionRenameRequest): Promise<ProviderActResult> {
-    const observation = this.#observations.find(
-      (candidate) => candidate.providerSessionId === request.providerSessionId,
-    );
+    const observation = this.latestObservation(request.providerSessionId);
     if (!observation || !advertisedActFor(observation, ACT_KIND.RENAME_SESSION))
       return {
         status: ACT_RESULT_STATUS.UNSUPPORTED,
@@ -616,9 +358,9 @@ export abstract class CloudSessionAdapter extends SessionProviderAdapterBase {
         reason: UNSUPPORTED_BY_OBSERVATION,
       };
 
-    const apiKey = await this.#readApiKey().catch(() => undefined);
+    const apiKey = await this.#pass.readApiKey();
     if (!apiKey) return this.#missingKeyRejection();
-    return this.#postWrite(apiKey, route);
+    return (await this.#pass.write(apiKey, route)).outcome;
   }
 
   /**
@@ -687,7 +429,7 @@ export abstract class CloudSessionAdapter extends SessionProviderAdapterBase {
       };
     }
 
-    const apiKey = await this.#readApiKey().catch(() => undefined);
+    const apiKey = await this.#pass.readApiKey();
     if (!apiKey) return this.#missingKeyRejection();
 
     const route = this.workspaceCreationRoute(project, name, task, request.agentSelection);
@@ -696,7 +438,7 @@ export abstract class CloudSessionAdapter extends SessionProviderAdapterBase {
         status: ACT_RESULT_STATUS.UNSUPPORTED,
         reason: UNSUPPORTED_BY_OBSERVATION,
       };
-    const created = await this.#postWriteDetailed(apiKey, route, WRITE_SUBJECT.PROJECT);
+    const created = await this.#pass.write(apiKey, route, WRITE_SUBJECT.PROJECT);
     if (created.outcome.status !== ACT_RESULT_STATUS.ACCEPTED) {
       return created.outcome;
     }
@@ -723,7 +465,7 @@ export abstract class CloudSessionAdapter extends SessionProviderAdapterBase {
         reason: `The workspace was created, but its opening task was not delivered: ${followUp.undeliverable}`,
       };
     }
-    const delivered = await this.#postWriteDetailed(apiKey, followUp, WRITE_SUBJECT.SESSION);
+    const delivered = await this.#pass.write(apiKey, followUp, WRITE_SUBJECT.SESSION);
     if (delivered.outcome.status === ACT_RESULT_STATUS.ACCEPTED) {
       return landed;
     }
@@ -807,7 +549,7 @@ export abstract class CloudSessionAdapter extends SessionProviderAdapterBase {
     return undefined;
   }
 
-  /** Runs one authenticated pass. Duplicate session ids are dropped by the base. */
+  /** Runs one authenticated pass. Duplicate session ids are dropped by the pass. */
   protected abstract collect(
     request: CloudRequest,
     now: number,
@@ -820,302 +562,24 @@ export abstract class CloudSessionAdapter extends SessionProviderAdapterBase {
    */
   protected forgetCachedIdentity(): void {}
 
-  /**
-   * The headers every request carries besides the credential. A subclass
-   * overrides this only when its provider asks for its own media type or a
-   * version pin; the authorization header is layered on after these, so no
-   * override can replace the credential.
-   */
-  protected requestHeaders() {
-    return DEFAULT_REQUEST_HEADERS satisfies Readonly<Record<string, string>>;
-  }
-
   /** Keeps one failed resource from discarding an otherwise complete pass. */
-  protected async tolerateItemFailure<Result>(
+  protected tolerateItemFailure<Result>(
     operation: () => Promise<Result>,
   ): Promise<Result | undefined> {
-    try {
-      return await operation();
-    } catch (error) {
-      if (error instanceof AdapterFailure && error.failure === ADAPTER_FAILURE.UNAUTHORIZED) {
-        throw error;
-      }
-      return undefined;
-    }
-  }
-
-  #forgetObservedState(): void {
-    // A pass still in flight was started under a credential that no longer
-    // stands, so its result must not land — and neither may a slow read's.
-    this.#collectPass += 1;
-    this.#credentialEpoch += 1;
-    this.forgetCachedIdentity();
-    this.#observations = [];
+    return tolerateItemFailure(operation);
   }
 
   /**
    * One read bound to the credential rather than to one pass, for an offer
    * that rides beside the passes and may outlive several — the pass-scoped
    * request would discard exactly the slow answer such a read exists for.
-   * Only a credential change discards it: the read refuses to land across
-   * one, so nothing read as one user is ever kept as another's. What the
-   * caller does with the answer is handed in rather than returned, so the
-   * check and the write share one synchronous step and a credential cleared
-   * in the gap between them has no gap to land in.
    */
-  protected async credentialBoundRead(
+  protected credentialBoundRead(
     segments: readonly string[],
     query: Readonly<Record<string, string>> | undefined,
     options: Readonly<{ timeoutMs?: number }> | undefined,
     apply: (body: WireRecord) => void,
   ): Promise<void> {
-    const epoch = this.#credentialEpoch;
-    const apiKey = this.#credential;
-    if (!apiKey) {
-      throw new AdapterFailure(
-        ADAPTER_FAILURE.TRANSIENT,
-        `${this.provider.displayName} has no credential to read with`,
-      );
-    }
-    const body = await this.#requestJson(apiKey, segments, query, options);
-    if (epoch !== this.#credentialEpoch) {
-      throw new AdapterFailure(
-        ADAPTER_FAILURE.TRANSIENT,
-        `${this.provider.displayName} read outlived its credential`,
-      );
-    }
-    apply(body);
+    return this.#pass.credentialBoundRead(segments, query, options, apply);
   }
-
-  /**
-   * Binds one pass's requests to the credential it started with. A superseded
-   * pass fails instead of issuing another request with a replaced key, and
-   * whatever a request already read is discarded before a subclass can cache
-   * it over state that belongs to the new credential.
-   */
-  #requestForPass(pass: number, apiKey: string): CloudRequest {
-    return async (segments, query, options) => {
-      this.#assertPassCurrent(pass);
-      const body = await this.#requestJson(apiKey, segments, query, options);
-      this.#assertPassCurrent(pass);
-      return body;
-    };
-  }
-
-  #assertPassCurrent(pass: number): void {
-    if (pass !== this.#collectPass) {
-      throw new AdapterFailure(
-        ADAPTER_FAILURE.TRANSIENT,
-        `${this.provider.displayName} pass was superseded`,
-      );
-    }
-  }
-
-  #url(
-    segments: readonly string[],
-    query: Readonly<Record<string, string>>,
-    action?: string,
-  ): string {
-    const url = new URL(this.#baseUrl);
-    // The action rides after the segments unencoded: `:sendMessage` is part of
-    // the route, and encoding its colon would name a different route.
-    url.pathname = `/${segments.map((segment) => encodeURIComponent(segment)).join("/")}${
-      action ? `:${action}` : ""
-    }`;
-    for (const [name, value] of Object.entries(query)) url.searchParams.set(name, value);
-    return url.href;
-  }
-
-  /**
-   * The one authenticated write. It shares the read path's timeout and its
-   * refusal to echo anything the provider said into an error a user sees, and
-   * it answers with what became of the request rather than throwing: a write
-   * is a user's own act, so every outcome has to land back on the row it left.
-   * The subject is what the route acts on, so a refusal names the thing that
-   * actually went missing.
-   */
-  async #postWrite(
-    apiKey: string,
-    route: CloudWriteRoute,
-    subject: WriteSubject = WRITE_SUBJECT.SESSION,
-  ): Promise<ProviderActResult> {
-    return (await this.#postWriteDetailed(apiKey, route, subject)).outcome;
-  }
-
-  /**
-   * The same write, keeping what the provider answered with: a creation
-   * response names the thing it created, and a follow-up write is built from
-   * that. The body never travels further than the adapter that asked for it.
-   */
-  async #postWriteDetailed(
-    apiKey: string,
-    route: CloudWriteRoute,
-    subject: WriteSubject,
-  ): Promise<{ outcome: ProviderActResult; body?: WireRecord }> {
-    const name = this.provider.displayName;
-    let response: Response;
-    try {
-      response = await this.#fetch(this.#url(route.segments, {}, route.action), {
-        method: HTTP_METHOD.POST,
-        // The same layering as a read: the provider's own headers first, the
-        // credential after them so no override can replace it.
-        headers: {
-          ...this.requestHeaders(),
-          ...authorizationHeaders(apiKey),
-          // An endpoint that documents an empty request gets exactly that,
-          // not an empty JSON object it never asked for.
-          ...(route.body === undefined ? undefined : { "Content-Type": "application/json" }),
-        },
-        ...(route.body === undefined ? undefined : { body: JSON.stringify(route.body) }),
-        signal: AbortSignal.timeout(requestDeadlineMs(route.timeoutMs)),
-      });
-    } catch {
-      // A thrown fetch cannot say which side of the wire failed: a connection
-      // that never opened sent nothing, but a timeout or a reset while the
-      // answer was coming back leaves a request the provider may have already
-      // acted on. So the refusal hedges rather than claims, and the refresh
-      // that follows must actually ask, so a write that did land is reconciled
-      // against the provider instead of the cache still advertising it.
-      this.#lastAttemptAt = Number.NEGATIVE_INFINITY;
-      return {
-        outcome: {
-          status: ACT_RESULT_STATUS.REJECTED,
-          reason: `${name} did not answer, so the request may not have landed.`,
-        },
-      };
-    }
-
-    if (response.ok) {
-      // A write that landed changes what the session is doing, so the refresh
-      // that follows must actually ask: served from the cache inside the
-      // minimum interval, the row would keep offering what the provider has
-      // already taken.
-      this.#lastAttemptAt = Number.NEGATIVE_INFINITY;
-      // An unreadable body is not a failed write: the provider already said
-      // yes, so only a follow-up that needed the body has anything to miss.
-      const body = await response.json().catch(() => undefined);
-      return {
-        outcome: { status: ACT_RESULT_STATUS.ACCEPTED },
-        ...(isRecord(body) ? { body } : undefined),
-      };
-    }
-    if (response.status === HTTP_STATUS.UNAUTHORIZED || response.status === HTTP_STATUS.FORBIDDEN) {
-      return {
-        outcome: {
-          status: ACT_RESULT_STATUS.REJECTED,
-          reason: `${name} rejected the configured API key.`,
-        },
-      };
-    }
-    if (response.status === HTTP_STATUS.NOT_FOUND) {
-      return {
-        outcome: {
-          status: ACT_RESULT_STATUS.REJECTED,
-          reason: `${name} no longer has this ${subject}.`,
-        },
-      };
-    }
-    if (response.status === HTTP_STATUS.CONFLICT) {
-      return {
-        outcome: {
-          status: ACT_RESULT_STATUS.REJECTED,
-          reason: `${name} says this ${subject} has moved on since Luke last looked.`,
-        },
-      };
-    }
-    // Any other status is an answer that says nothing certain about the act —
-    // a gateway that gave up may stand in front of a write that finished — so
-    // this hedges the way a thrown fetch does, and the refresh that follows
-    // must actually ask rather than keep advertising what the provider may
-    // have already taken.
-    this.#lastAttemptAt = Number.NEGATIVE_INFINITY;
-    return {
-      outcome: {
-        status: ACT_RESULT_STATUS.REJECTED,
-        reason: `${name} answered with status ${response.status}, so the request may not have landed.`,
-      },
-    };
-  }
-
-  async #requestJson(
-    apiKey: string,
-    segments: readonly string[],
-    query = {},
-    options: Readonly<{ timeoutMs?: number; document?: string }> = {},
-  ): Promise<WireRecord> {
-    const name = this.provider.displayName;
-    const timeoutMs = requestDeadlineMs(options.timeoutMs);
-    // A read document rides as a POST because that is how its endpoint is
-    // documented, not because it writes: the body carries the document and
-    // nothing else, so the request can still express nothing but a read.
-    const document = options.document;
-    let response: Response;
-    try {
-      response = await this.#fetch(this.#url(segments, query), {
-        method: document === undefined ? HTTP_METHOD.GET : HTTP_METHOD.POST,
-        headers: {
-          ...this.requestHeaders(),
-          ...authorizationHeaders(apiKey),
-          ...(document === undefined ? undefined : { "Content-Type": "application/json" }),
-        },
-        ...(document === undefined
-          ? undefined
-          : { body: JSON.stringify({ [READ_DOCUMENT_FIELD]: document }) }),
-        signal: AbortSignal.timeout(timeoutMs),
-      });
-    } catch {
-      throw new AdapterFailure(ADAPTER_FAILURE.TRANSIENT, `${name} request failed`);
-    }
-
-    if (response.status === HTTP_STATUS.UNAUTHORIZED || response.status === HTTP_STATUS.FORBIDDEN) {
-      throw new AdapterFailure(
-        ADAPTER_FAILURE.UNAUTHORIZED,
-        `${name} rejected the configured API key`,
-      );
-    }
-    if (!response.ok) {
-      throw new AdapterFailure(
-        ADAPTER_FAILURE.TRANSIENT,
-        `${name} responded with status ${response.status}`,
-      );
-    }
-
-    let body: WireBoundaryInput;
-    try {
-      body = await response.json();
-    } catch {
-      throw new AdapterFailure(
-        ADAPTER_FAILURE.TRANSIENT,
-        `${name} returned an unreadable response`,
-      );
-    }
-    const bodyRecord = wireRecord(unparsedWire(body));
-    if (!bodyRecord) {
-      throw new AdapterFailure(
-        ADAPTER_FAILURE.TRANSIENT,
-        `${name} returned an unexpected response`,
-      );
-    }
-    return bodyRecord;
-  }
-}
-
-/**
- * Drops a session a subclass reported twice, and stamps the location the base
- * already knows: nothing reaches this point except over the network, so a
- * subclass cannot forget to say its sessions run somewhere else.
- */
-function cloudObservations(
-  observations: readonly ProviderSessionObservation[],
-): readonly ProviderSessionObservation[] {
-  const unique = new Map<string, ProviderSessionObservation>();
-  for (const observation of observations) {
-    if (!unique.has(observation.providerSessionId)) {
-      unique.set(observation.providerSessionId, {
-        ...observation,
-        location: SESSION_LOCATION.CLOUD,
-      });
-    }
-  }
-  return [...unique.values()];
 }

--- a/packages/providers/src/shared/cloud-session-adapter.ts
+++ b/packages/providers/src/shared/cloud-session-adapter.ts
@@ -43,6 +43,7 @@ import {
   type AdapterDiagnosticCallback,
   type AdapterDiagnosticKind,
 } from "./adapter-diagnostics.js";
+import { ADAPTER_FAILURE, AdapterFailure, clearsObservedState } from "./adapter-failure.js";
 
 const GIT_SUFFIX = ".git";
 
@@ -70,11 +71,6 @@ const DEFAULT_REQUEST_HEADERS = {
  */
 const READ_DOCUMENT_FIELD = "query";
 
-export const CLOUD_FAILURE = {
-  UNAUTHORIZED: "unauthorized",
-  TRANSIENT: "transient",
-} as const;
-
 /** What a write acts on, as a refusal should name it. */
 const WRITE_SUBJECT = {
   SESSION: "session",
@@ -83,8 +79,6 @@ const WRITE_SUBJECT = {
 } as const;
 
 type WriteSubject = (typeof WRITE_SUBJECT)[keyof typeof WRITE_SUBJECT];
-
-export type CloudFailure = (typeof CLOUD_FAILURE)[keyof typeof CLOUD_FAILURE];
 
 /**
  * Cloud-only request bounds. The freshness bound in `OBSERVATION_WINDOW` is
@@ -104,16 +98,6 @@ export const CLOUD_ADAPTER_DEFAULTS = {
 
 export type { CloudFetch } from "@sidecar/wire";
 
-export class CloudRequestError extends Error {
-  readonly failure: CloudFailure;
-
-  constructor(failure: CloudFailure, message: string) {
-    super(message);
-    this.name = "CloudRequestError";
-    this.failure = failure;
-  }
-}
-
 export interface CloudAdapterOptions {
   /** Resolves the credential at observation time so a settings change applies immediately. */
   readApiKey: () => Promise<string | undefined>;
@@ -125,7 +109,7 @@ export interface CloudAdapterOptions {
    * Called when an observation pass fails for a reason other than a network
    * or credential fault — a TypeError in a subclass's parsing, for example —
    * or when a subclass reports a problem of its own, named by the kind.
-   * Transient and unauthorized {@link CloudRequestError} never reach it.
+   * Transient and unauthorized {@link AdapterFailure} never reach it.
    */
   onDiagnostic?: AdapterDiagnosticCallback;
 }
@@ -339,8 +323,8 @@ export abstract class CloudSessionAdapter extends SessionProviderAdapterBase {
       if (pass !== this.#collectPass) {
         return this.#observations;
       }
-      if (error instanceof CloudRequestError) {
-        if (error.failure === CLOUD_FAILURE.UNAUTHORIZED) this.#forgetObservedState();
+      if (error instanceof AdapterFailure) {
+        if (clearsObservedState(error.failure)) this.#forgetObservedState();
         return this.#observations;
       }
       // Anything else is a bug in this pass — a TypeError thrown by a
@@ -853,7 +837,7 @@ export abstract class CloudSessionAdapter extends SessionProviderAdapterBase {
     try {
       return await operation();
     } catch (error) {
-      if (error instanceof CloudRequestError && error.failure === CLOUD_FAILURE.UNAUTHORIZED) {
+      if (error instanceof AdapterFailure && error.failure === ADAPTER_FAILURE.UNAUTHORIZED) {
         throw error;
       }
       return undefined;
@@ -888,15 +872,15 @@ export abstract class CloudSessionAdapter extends SessionProviderAdapterBase {
     const epoch = this.#credentialEpoch;
     const apiKey = this.#credential;
     if (!apiKey) {
-      throw new CloudRequestError(
-        CLOUD_FAILURE.TRANSIENT,
+      throw new AdapterFailure(
+        ADAPTER_FAILURE.TRANSIENT,
         `${this.provider.displayName} has no credential to read with`,
       );
     }
     const body = await this.#requestJson(apiKey, segments, query, options);
     if (epoch !== this.#credentialEpoch) {
-      throw new CloudRequestError(
-        CLOUD_FAILURE.TRANSIENT,
+      throw new AdapterFailure(
+        ADAPTER_FAILURE.TRANSIENT,
         `${this.provider.displayName} read outlived its credential`,
       );
     }
@@ -920,8 +904,8 @@ export abstract class CloudSessionAdapter extends SessionProviderAdapterBase {
 
   #assertPassCurrent(pass: number): void {
     if (pass !== this.#collectPass) {
-      throw new CloudRequestError(
-        CLOUD_FAILURE.TRANSIENT,
+      throw new AdapterFailure(
+        ADAPTER_FAILURE.TRANSIENT,
         `${this.provider.displayName} pass was superseded`,
       );
     }
@@ -1080,18 +1064,18 @@ export abstract class CloudSessionAdapter extends SessionProviderAdapterBase {
         signal: AbortSignal.timeout(timeoutMs),
       });
     } catch {
-      throw new CloudRequestError(CLOUD_FAILURE.TRANSIENT, `${name} request failed`);
+      throw new AdapterFailure(ADAPTER_FAILURE.TRANSIENT, `${name} request failed`);
     }
 
     if (response.status === HTTP_STATUS.UNAUTHORIZED || response.status === HTTP_STATUS.FORBIDDEN) {
-      throw new CloudRequestError(
-        CLOUD_FAILURE.UNAUTHORIZED,
+      throw new AdapterFailure(
+        ADAPTER_FAILURE.UNAUTHORIZED,
         `${name} rejected the configured API key`,
       );
     }
     if (!response.ok) {
-      throw new CloudRequestError(
-        CLOUD_FAILURE.TRANSIENT,
+      throw new AdapterFailure(
+        ADAPTER_FAILURE.TRANSIENT,
         `${name} responded with status ${response.status}`,
       );
     }
@@ -1100,15 +1084,15 @@ export abstract class CloudSessionAdapter extends SessionProviderAdapterBase {
     try {
       body = await response.json();
     } catch {
-      throw new CloudRequestError(
-        CLOUD_FAILURE.TRANSIENT,
+      throw new AdapterFailure(
+        ADAPTER_FAILURE.TRANSIENT,
         `${name} returned an unreadable response`,
       );
     }
     const bodyRecord = wireRecord(unparsedWire(body));
     if (!bodyRecord) {
-      throw new CloudRequestError(
-        CLOUD_FAILURE.TRANSIENT,
+      throw new AdapterFailure(
+        ADAPTER_FAILURE.TRANSIENT,
         `${name} returned an unexpected response`,
       );
     }

--- a/packages/providers/src/shared/cloud-session-adapter.ts
+++ b/packages/providers/src/shared/cloud-session-adapter.ts
@@ -18,10 +18,10 @@ import {
   type SessionProvider,
   SessionProviderAdapterBase,
   sessionMessageText,
+  UNSUPPORTED_BY_OBSERVATION,
   WORKSPACE_TASK_SUPPORT,
   type WorkspaceAgentSelection,
   type WorkspaceProject,
-  UNSUPPORTED_BY_OBSERVATION,
   workspaceNameText,
 } from "@sidecar/session";
 import type { CloudFetch, WireRecord } from "@sidecar/wire";

--- a/packages/providers/src/shared/cloud-wire.ts
+++ b/packages/providers/src/shared/cloud-wire.ts
@@ -1,0 +1,134 @@
+/**
+ * What a cloud provider's answers are read with, and what a request to one is
+ * described by: the shared bounds, the route and request shapes, and the small
+ * readers every adapter's parsing is built out of. Nothing here reaches a
+ * network; issuing a request is `cloudPass`'s alone.
+ */
+
+import { UNKNOWN_WORKSPACE_LABEL } from "@sidecar/session";
+import { isRecord, positiveInteger, text, type WireRecord } from "@sidecar/wire";
+
+const GIT_SUFFIX = ".git";
+
+/**
+ * Cloud-only request bounds. The freshness bound in `OBSERVATION_WINDOW` is
+ * shared with every local provider.
+ */
+export const CLOUD_ADAPTER_DEFAULTS = {
+  MINIMUM_REFRESH_INTERVAL_MS: 15 * 1000,
+  REQUEST_TIMEOUT_MS: 8 * 1000,
+  /**
+   * For the rare read a provider documents as slow — Cursor's repository list
+   * can take tens of seconds for a large organisation. A read on this deadline
+   * must never hold the observation pass; it is for work that rides beside
+   * one.
+   */
+  SLOW_REQUEST_TIMEOUT_MS: 45 * 1000,
+} as const;
+
+/**
+ * The only way an adapter reaches its provider while observing. It
+ * authenticates, bounds, and parses the request, and it can express nothing
+ * but a read, so no observation pass built on it can change provider state.
+ * The deadline can be widened only to the slow bound, and only for a read the
+ * provider itself documents as slow.
+ *
+ * A read the provider answers only at a POSTed query endpoint — Conductor's
+ * transcripts view — names its document here, and the separation a GET gives
+ * for free is held the way the Linear tracker holds it: the document's text is
+ * fixed by the build, observation only ever sends a read, and an adapter
+ * interpolates nothing into it beyond identifiers the same pass reported, each
+ * validated against the shape its provider documents.
+ */
+export type CloudRequest = (
+  segments: readonly string[],
+  query?: Readonly<Record<string, string>>,
+  options?: Readonly<{ timeoutMs?: number; document?: string }>,
+) => Promise<WireRecord>;
+
+/**
+ * One documented write a provider takes for one of its sessions: the route and
+ * the exact body its endpoint asks for. An adapter describes the request;
+ * `cloudPass` is the only thing that issues one.
+ */
+export interface CloudWriteRoute {
+  segments: readonly string[];
+  /**
+   * A Google-style custom method, appended to the path as `:action` rather
+   * than as a segment: it names what the request does to the resource the
+   * segments already name.
+   */
+  action?: string;
+  /** Left off entirely for an endpoint that documents an empty request. */
+  body?: Readonly<WireRecord>;
+  /**
+   * For the rare write the provider answers only once the act itself is done
+   * — Conductor's archive stands the whole workspace down before it says so,
+   * well past the shared request bound. A deadline shorter than the act turns
+   * a write that landed into "may not have landed", so such a route asks for
+   * the slow bound, the same ceiling a slow read gets and the widest this one
+   * can reach.
+   */
+  timeoutMs?: number;
+}
+
+/**
+ * A request's deadline never widens past the slow bound: the option exists for
+ * a read or write the provider is known to answer slowly, not for one that
+ * never ends.
+ */
+export function requestDeadlineMs(requested: number | undefined): number {
+  return Math.min(
+    positiveInteger(requested, CLOUD_ADAPTER_DEFAULTS.REQUEST_TIMEOUT_MS),
+    CLOUD_ADAPTER_DEFAULTS.SLOW_REQUEST_TIMEOUT_MS,
+  );
+}
+
+export function isDefined<Value>(value: Value | undefined): value is Value {
+  return value !== undefined;
+}
+
+export function textFromRecord(record: WireRecord, key: string): string | undefined {
+  return text(record[key]);
+}
+
+export function timestampFromRecord(record: WireRecord, key: string): number | undefined {
+  const value = textFromRecord(record, key);
+  if (!value) return undefined;
+  const timestampMs = Date.parse(value);
+  return Number.isFinite(timestampMs) ? timestampMs : undefined;
+}
+
+/**
+ * Reads a value a provider reported only when this build knows it, so a state
+ * added after this build shipped is left undefined rather than guessed at.
+ */
+export function knownValue<Value extends string>(
+  values: Readonly<Record<string, Value>>,
+  reported: string | undefined,
+): Value | undefined {
+  return Object.values(values).find((candidate) => candidate === reported);
+}
+
+/** Reads a list page without assuming which key a given provider wraps it in. */
+export function recordsFromPage(body: WireRecord, key: string): WireRecord[] {
+  const data = body[key];
+  return Array.isArray(data) ? data.filter(isRecord) : [];
+}
+
+/**
+ * Luke labels a session by its repository, never by a workspace, agent, or
+ * session name. Cloud providers derive those names from the opening prompt, so
+ * they are transcript content that no adapter may surface.
+ */
+export function repositoryLabel(
+  gitRemote: string | undefined,
+  fallbackName: string | undefined,
+): string {
+  const remote = gitRemote?.trim().replace(/\/+$/, "");
+  const lastSegment = remote?.split(/[/:]/).pop()?.trim();
+  const repository = lastSegment?.endsWith(GIT_SUFFIX)
+    ? lastSegment.slice(0, -GIT_SUFFIX.length)
+    : lastSegment;
+  return repository || fallbackName?.trim() || UNKNOWN_WORKSPACE_LABEL;
+}

--- a/packages/providers/src/shared/dispatch-act.test.ts
+++ b/packages/providers/src/shared/dispatch-act.test.ts
@@ -1,0 +1,435 @@
+/**
+ * The parallel run that lets `dispatchAct` replace the guards the adapter
+ * base classes hold. Every act is asked twice — once through the surviving
+ * base-class method, once through `dispatchAct` over the same adapter read as
+ * a plugin — and the two answers, and the requests each issued, must be
+ * identical, across every refusal the constraints in root `CLAUDE.md` name: a
+ * session the pass did not report, an act the observation did not advertise,
+ * a target the caller rewrote, and an ask outside its bound.
+ */
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  ACT_KIND,
+  ACT_RESULT_STATUS,
+  type AdvertisedControl,
+  adapterAsPlugin,
+  dispatchAct,
+  dispatchConversation,
+  dispatchRead,
+  maximumSessionMessageLength,
+  maximumWorkspaceNameLength,
+  type PluginActKind,
+  type PluginActRequests,
+  type ProviderSessionObservation,
+  SESSION_CONTROL_KIND,
+  SESSION_STATUS,
+  type SessionProviderAdapter,
+  type SessionProviderPlugin,
+  WORKSPACE_TASK_SUPPORT,
+  type WorkspaceProject,
+} from "@sidecar/session";
+import { jsonResponse, type RecordedRequest, recordingFetch } from "@sidecar/wire/testing";
+import { type CloudAdapterOptions, CloudSessionAdapter } from "./cloud-session-adapter.js";
+import type { CloudRequest } from "./cloud-wire.js";
+
+const TEST_TIME = Date.parse("2026-09-01T12:00:00.000Z");
+const TEST_BASE_URL = "https://api.stub.test";
+const TEST_API_KEY = "stub-key";
+const STUB_PROVIDER = { id: "stub", displayName: "Stub" };
+const SESSION_ID = "session-1";
+const BARE_SESSION_ID = "session-bare";
+const ABSENT_SESSION_ID = "session-absent";
+const SPAWN_TARGET = "workspace-1";
+const RENAME_TARGET = "workspace-2";
+
+const CANCEL_CONTROL: AdvertisedControl = {
+  kind: ACT_KIND.CONTROL,
+  id: "cancel-turn",
+  label: "Stop this turn",
+  controlKind: SESSION_CONTROL_KIND.STOP,
+  target: "run-1",
+};
+
+const PROJECT: WorkspaceProject = {
+  providerProjectId: "project-1",
+  repository: "luke",
+  taskSupport: WORKSPACE_TASK_SUPPORT.OPTIONAL,
+};
+
+const REQUIRED_TASK_PROJECT: WorkspaceProject = {
+  ...PROJECT,
+  providerProjectId: "project-required",
+  taskSupport: WORKSPACE_TASK_SUPPORT.REQUIRED,
+};
+
+const NO_TASK_PROJECT: WorkspaceProject = {
+  ...PROJECT,
+  providerProjectId: "project-none",
+  taskSupport: WORKSPACE_TASK_SUPPORT.NONE,
+};
+
+const OBSERVATION: ProviderSessionObservation = {
+  providerSessionId: SESSION_ID,
+  title: "luke",
+  status: SESSION_STATUS.WORKING,
+  lastActivityAt: TEST_TIME,
+  advertises: [
+    { kind: ACT_KIND.MESSAGE },
+    CANCEL_CONTROL,
+    { kind: ACT_KIND.ADD_AGENT, agents: ["claude"], target: SPAWN_TARGET },
+    { kind: ACT_KIND.RENAME_WORKSPACE, target: RENAME_TARGET },
+    { kind: ACT_KIND.RENAME_SESSION },
+  ],
+};
+
+/** A session the pass reported that advertises nothing at all. */
+const BARE_OBSERVATION: ProviderSessionObservation = {
+  providerSessionId: BARE_SESSION_ID,
+  title: "bare",
+  status: SESSION_STATUS.WORKING,
+  lastActivityAt: TEST_TIME,
+};
+
+/** Routes every act, so a refusal can only ever have come from a guard. */
+class StubAdapter extends CloudSessionAdapter {
+  constructor(options: CloudAdapterOptions) {
+    super({ provider: STUB_PROVIDER, defaultBaseUrl: TEST_BASE_URL }, options);
+  }
+
+  protected async collect(_request: CloudRequest): Promise<readonly ProviderSessionObservation[]> {
+    return [OBSERVATION, BARE_OBSERVATION];
+  }
+
+  override workspaceProjects(): readonly WorkspaceProject[] {
+    return [PROJECT, REQUIRED_TASK_PROJECT, NO_TASK_PROJECT];
+  }
+
+  protected override messageRoute(providerSessionId: string, text: string) {
+    return { segments: ["v0", "sessions", providerSessionId, "messages"], body: { text } };
+  }
+
+  protected override controlRoute(providerSessionId: string, control: AdvertisedControl) {
+    return { segments: ["v0", "runs", control.target ?? providerSessionId, "cancel"] };
+  }
+
+  protected override workspaceCreationRoute(project: WorkspaceProject, name?: string) {
+    return {
+      segments: ["v0", "projects", project.providerProjectId, "workspaces"],
+      body: { ...(name === undefined ? undefined : { name }) },
+    };
+  }
+
+  protected override workspaceAgentRoute(spawnTarget: string) {
+    return { segments: ["v0", "workspaces", spawnTarget, "agents"] };
+  }
+
+  protected override workspaceRenameRoute(renameTarget: string, name: string) {
+    return { segments: ["v0", "workspaces", renameTarget], body: { name } };
+  }
+
+  protected override sessionRenameRoute(providerSessionId: string, name: string) {
+    return { segments: ["v0", "sessions", providerSessionId], body: { name } };
+  }
+}
+
+const BASE_METHOD_BY_ACT: {
+  [Kind in PluginActKind]: (
+    adapter: SessionProviderAdapter,
+    request: PluginActRequests[Kind],
+  ) => Promise<unknown>;
+} = {
+  message: (adapter, request) => adapter.sendMessage(request),
+  control: (adapter, request) => adapter.executeControl(request),
+  createWorkspace: (adapter, request) => adapter.createWorkspace(request),
+  spawnAgent: (adapter, request) => adapter.spawnWorkspaceAgent(request),
+  renameWorkspace: (adapter, request) => adapter.renameWorkspace(request),
+  renameSession: (adapter, request) => adapter.renameSession(request),
+};
+
+interface Harness {
+  adapter: StubAdapter;
+  requests: readonly RecordedRequest[];
+}
+
+function harness(): Harness {
+  const { fetch, requests } = recordingFetch(() => jsonResponse({}));
+  const adapter = new StubAdapter({
+    readApiKey: async () => TEST_API_KEY,
+    baseUrl: TEST_BASE_URL,
+    fetch,
+    now: () => TEST_TIME,
+    minimumRefreshIntervalMs: 0,
+  });
+  return { adapter, requests };
+}
+
+async function observedPlugin(): Promise<{
+  plugin: SessionProviderPlugin;
+  requests: readonly RecordedRequest[];
+}> {
+  const { adapter, requests } = harness();
+  const plugin = adapterAsPlugin(adapter);
+  await plugin.observe();
+  return { plugin, requests };
+}
+
+/** What one write asked of the provider, as an answer can be compared by. */
+function writes(requests: readonly RecordedRequest[], from: number) {
+  return requests.slice(from).map((request) => ({
+    method: request.method,
+    url: request.url,
+    body: request.body,
+  }));
+}
+
+/**
+ * Asks one act both ways over two adapters standing in the same state, and
+ * asserts the answers and the requests each issued are identical.
+ */
+async function bothWays<Kind extends PluginActKind>(
+  kind: Kind,
+  request: PluginActRequests[Kind],
+): Promise<void> {
+  const base = harness();
+  await base.adapter.observe();
+  const baseWritesFrom = base.requests.length;
+  const fromBase = await BASE_METHOD_BY_ACT[kind](base.adapter, request);
+
+  const dispatched = await observedPlugin();
+  const dispatchWritesFrom = dispatched.requests.length;
+  const fromDispatch = await dispatchAct(dispatched.plugin, kind, request);
+
+  const where = `${kind} ${JSON.stringify(request)}`;
+  assert.deepEqual(fromDispatch, fromBase, `answered differently: ${where}`);
+  assert.deepEqual(
+    writes(dispatched.requests, dispatchWritesFrom),
+    writes(base.requests, baseWritesFrom),
+    `issued different requests: ${where}`,
+  );
+}
+
+const OVER_LONG_MESSAGE = "m".repeat(maximumSessionMessageLength + 1);
+const OVER_LONG_NAME = "n".repeat(maximumWorkspaceNameLength + 1);
+
+test("a message answers identically through the base method and through dispatchAct", async () => {
+  for (const request of [
+    { providerSessionId: SESSION_ID, text: "ship it" },
+    { providerSessionId: ABSENT_SESSION_ID, text: "ship it" },
+    { providerSessionId: BARE_SESSION_ID, text: "ship it" },
+    { providerSessionId: SESSION_ID, text: "   " },
+    { providerSessionId: SESSION_ID, text: OVER_LONG_MESSAGE },
+  ]) {
+    await bothWays("message", request);
+  }
+});
+
+test("a control answers identically, on the advertised target either way", async () => {
+  for (const request of [
+    { providerSessionId: SESSION_ID, control: CANCEL_CONTROL },
+    { providerSessionId: ABSENT_SESSION_ID, control: CANCEL_CONTROL },
+    { providerSessionId: BARE_SESSION_ID, control: CANCEL_CONTROL },
+    { providerSessionId: SESSION_ID, control: { ...CANCEL_CONTROL, id: "invented" } },
+    // A caller that rewrote the target must still act on the advertised one.
+    { providerSessionId: SESSION_ID, control: { ...CANCEL_CONTROL, target: "somewhere-else" } },
+  ]) {
+    await bothWays("control", request);
+  }
+});
+
+test("a creation answers identically, including every task-support refusal", async () => {
+  for (const request of [
+    { providerProjectId: PROJECT.providerProjectId },
+    { providerProjectId: PROJECT.providerProjectId, name: "notch", task: "start here" },
+    { providerProjectId: "project-unreported" },
+    { providerProjectId: PROJECT.providerProjectId, name: OVER_LONG_NAME },
+    { providerProjectId: PROJECT.providerProjectId, task: "  " },
+    { providerProjectId: NO_TASK_PROJECT.providerProjectId, task: "start here" },
+    { providerProjectId: REQUIRED_TASK_PROJECT.providerProjectId },
+  ]) {
+    await bothWays("createWorkspace", request);
+  }
+});
+
+test("a spawn answers identically, on the advertised workspace either way", async () => {
+  for (const request of [
+    { providerSessionId: SESSION_ID, agent: "claude" },
+    { providerSessionId: SESSION_ID, agent: "claude", name: "notch", task: "start here" },
+    { providerSessionId: ABSENT_SESSION_ID, agent: "claude" },
+    { providerSessionId: BARE_SESSION_ID, agent: "claude" },
+    { providerSessionId: SESSION_ID, agent: "invented" },
+    { providerSessionId: SESSION_ID, agent: "claude", name: OVER_LONG_NAME },
+    { providerSessionId: SESSION_ID, agent: "claude", task: OVER_LONG_MESSAGE },
+  ]) {
+    await bothWays("spawnAgent", request);
+  }
+});
+
+test("both renames answer identically, on the advertised target either way", async () => {
+  for (const request of [
+    { providerSessionId: SESSION_ID, name: "notch" },
+    { providerSessionId: ABSENT_SESSION_ID, name: "notch" },
+    { providerSessionId: BARE_SESSION_ID, name: "notch" },
+    { providerSessionId: SESSION_ID, name: "  " },
+    { providerSessionId: SESSION_ID, name: OVER_LONG_NAME },
+  ]) {
+    await bothWays("renameWorkspace", request);
+    await bothWays("renameSession", request);
+  }
+});
+
+test("a control acts on the target the observation advertised", async () => {
+  const { plugin, requests } = await observedPlugin();
+  const from = requests.length;
+
+  const result = await dispatchAct(plugin, "control", {
+    providerSessionId: SESSION_ID,
+    control: { ...CANCEL_CONTROL, target: "somewhere-else" },
+  });
+
+  assert.equal(result.status, ACT_RESULT_STATUS.ACCEPTED);
+  assert.deepEqual(
+    requests.slice(from).map((request) => request.url),
+    [`${TEST_BASE_URL}/v0/runs/run-1/cancel`],
+  );
+});
+
+test("a spawn acts on the advertised workspace, not the session it was asked with", async () => {
+  const { plugin, requests } = await observedPlugin();
+  const from = requests.length;
+
+  await dispatchAct(plugin, "spawnAgent", { providerSessionId: SESSION_ID, agent: "claude" });
+
+  assert.deepEqual(
+    requests.slice(from).map((request) => request.url),
+    [`${TEST_BASE_URL}/v0/workspaces/${SPAWN_TARGET}/agents`],
+  );
+});
+
+test("a rename acts on the advertised workspace, not the session it was asked with", async () => {
+  const { plugin, requests } = await observedPlugin();
+  const from = requests.length;
+
+  await dispatchAct(plugin, "renameWorkspace", { providerSessionId: SESSION_ID, name: "notch" });
+
+  assert.deepEqual(
+    requests.slice(from).map((request) => request.url),
+    [`${TEST_BASE_URL}/v0/workspaces/${RENAME_TARGET}`],
+  );
+});
+
+test("an act the plugin does not name answers unsupported and issues no request", async () => {
+  const { plugin, requests } = await observedPlugin();
+  const { acts: _acts, ...withoutActs } = plugin;
+  const from = requests.length;
+
+  const expected = {
+    status: ACT_RESULT_STATUS.UNSUPPORTED,
+    reason: "That act is not supported by the latest observation.",
+  };
+  assert.deepEqual(
+    await dispatchAct(withoutActs, "message", { providerSessionId: SESSION_ID, text: "ship it" }),
+    expected,
+  );
+  assert.deepEqual(
+    await dispatchAct(withoutActs, "control", {
+      providerSessionId: SESSION_ID,
+      control: CANCEL_CONTROL,
+    }),
+    expected,
+  );
+  assert.deepEqual(
+    await dispatchAct(withoutActs, "spawnAgent", {
+      providerSessionId: SESSION_ID,
+      agent: "claude",
+    }),
+    expected,
+  );
+  assert.deepEqual(
+    await dispatchAct(withoutActs, "renameWorkspace", {
+      providerSessionId: SESSION_ID,
+      name: "notch",
+    }),
+    expected,
+  );
+  assert.deepEqual(
+    await dispatchAct(withoutActs, "renameSession", {
+      providerSessionId: SESSION_ID,
+      name: "notch",
+    }),
+    expected,
+  );
+  assert.deepEqual(
+    await dispatchAct(withoutActs, "createWorkspace", {
+      providerProjectId: PROJECT.providerProjectId,
+    }),
+    expected,
+  );
+  assert.equal(requests.length, from);
+});
+
+test("a plugin that reports no projects is offered nowhere to create", async () => {
+  const { plugin } = await observedPlugin();
+  const { projects: _projects, ...withoutProjects } = plugin;
+
+  assert.deepEqual(
+    await dispatchAct(withoutProjects, "createWorkspace", {
+      providerProjectId: PROJECT.providerProjectId,
+    }),
+    {
+      status: ACT_RESULT_STATUS.UNSUPPORTED,
+      reason: "That act is not supported by the latest observation.",
+    },
+  );
+});
+
+test("both transcript reads answer identically through the base method and dispatchRead", async () => {
+  const base = harness();
+  await base.adapter.observe();
+  const { plugin } = await observedPlugin();
+
+  assert.deepEqual(
+    await dispatchRead(plugin, "transcript", SESSION_ID),
+    await base.adapter.readTranscript(SESSION_ID),
+  );
+  assert.deepEqual(
+    await dispatchRead(plugin, "transcriptSince", SESSION_ID, "12"),
+    await base.adapter.readTranscriptSince(SESSION_ID, "12"),
+  );
+});
+
+test("a plugin naming no transcript read says so rather than guessing", async () => {
+  const { plugin } = await observedPlugin();
+  const { reads: _reads, ...withoutReads } = plugin;
+
+  const expected = {
+    status: ACT_RESULT_STATUS.UNSUPPORTED,
+    reason: "This provider keeps no transcript this build can read.",
+  };
+  assert.deepEqual(await dispatchRead(withoutReads, "transcript", SESSION_ID), expected);
+  assert.deepEqual(await dispatchRead(withoutReads, "transcriptSince", SESSION_ID), expected);
+});
+
+test("a conversation read is refused for a session the pass did not report", async () => {
+  const { plugin, requests } = await observedPlugin();
+  const from = requests.length;
+
+  assert.deepEqual(await dispatchConversation(plugin, { providerSessionId: ABSENT_SESSION_ID }), {
+    status: ACT_RESULT_STATUS.UNSUPPORTED,
+    reason: "That act is not supported by the latest observation.",
+  });
+  assert.equal(requests.length, from);
+});
+
+test("a plugin naming no conversation read answers identically to the base", async () => {
+  const base = harness();
+  await base.adapter.observe();
+  const { plugin } = await observedPlugin();
+  const { reads: _reads, ...withoutReads } = plugin;
+
+  assert.deepEqual(
+    await dispatchConversation(withoutReads, { providerSessionId: SESSION_ID }),
+    await base.adapter.readConversation({ providerSessionId: SESSION_ID }),
+  );
+});

--- a/packages/providers/src/shared/dispatch-act.test.ts
+++ b/packages/providers/src/shared/dispatch-act.test.ts
@@ -12,6 +12,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
   ACT_KIND,
+  ACT_REQUEST_FROM,
   ACT_RESULT_STATUS,
   type AdvertisedControl,
   adapterAsPlugin,
@@ -30,6 +31,7 @@ import {
   type SessionProviderPlugin,
   UNSUPPORTED_BY_OBSERVATION,
   WORKSPACE_TASK_SUPPORT,
+  type WorkspaceCreationInput,
   type WorkspaceProject,
 } from "@sidecar/session";
 import { jsonResponse, type RecordedRequest, recordingFetch } from "@sidecar/wire/testing";
@@ -72,6 +74,22 @@ const NO_TASK_PROJECT: WorkspaceProject = {
   taskSupport: WORKSPACE_TASK_SUPPORT.NONE,
 };
 
+/**
+ * The same repository offered on two hosts under one project id, which is how
+ * Superset and Conductor's local creator both report a repository they can
+ * reach in more than one place.
+ */
+const HOSTED_PROJECT: WorkspaceProject = {
+  ...PROJECT,
+  providerProjectId: "project-hosted",
+  providerTargetId: "host-a",
+};
+
+const OTHER_HOST_PROJECT: WorkspaceProject = {
+  ...HOSTED_PROJECT,
+  providerTargetId: "host-b",
+};
+
 const OBSERVATION: ProviderSessionObservation = {
   providerSessionId: SESSION_ID,
   title: "luke",
@@ -105,7 +123,7 @@ class StubAdapter extends CloudSessionAdapter {
   }
 
   override workspaceProjects(): readonly WorkspaceProject[] {
-    return [PROJECT, REQUIRED_TASK_PROJECT, NO_TASK_PROJECT];
+    return [PROJECT, REQUIRED_TASK_PROJECT, NO_TASK_PROJECT, HOSTED_PROJECT, OTHER_HOST_PROJECT];
   }
 
   protected override messageRoute(providerSessionId: string, text: string) {
@@ -435,5 +453,106 @@ test("a plugin naming no conversation read answers identically to the base", asy
   assert.deepEqual(
     await dispatchConversation(withoutReads, { providerSessionId: SESSION_ID }),
     await base.adapter.readConversation({ providerSessionId: SESSION_ID }),
+  );
+});
+
+/**
+ * Both providers that report a project per host — Superset, and Conductor's
+ * local workspace creator — resolve a creation against the project id *and*
+ * the target the ask named, and the target the create fires against is read
+ * back off the offered project rather than trusted from the ask. `dispatchAct`
+ * resolves the same way, so what a handler is handed is the offered project
+ * itself; a creation aimed at one host can never land on whichever project
+ * happened to share the id. The surviving cloud base still matches on the id
+ * alone, which is why these read the resolution rather than the request it
+ * would issue.
+ */
+async function recordedCreations(): Promise<{
+  plugin: SessionProviderPlugin;
+  created: WorkspaceCreationInput[];
+}> {
+  const { plugin } = await observedPlugin();
+  const created: WorkspaceCreationInput[] = [];
+  return {
+    plugin: {
+      ...plugin,
+      acts: {
+        ...plugin.acts,
+        createWorkspace: async (input) => {
+          created.push(input);
+          return { status: ACT_RESULT_STATUS.ACCEPTED };
+        },
+      },
+    },
+    created,
+  };
+}
+
+test("a creation resolves the project by the target the ask named", async () => {
+  const { plugin, created } = await recordedCreations();
+
+  const result = await dispatchAct(plugin, "createWorkspace", {
+    providerProjectId: HOSTED_PROJECT.providerProjectId,
+    providerTargetId: "host-b",
+  });
+
+  assert.equal(result.status, ACT_RESULT_STATUS.ACCEPTED);
+  assert.deepEqual(
+    created.map((input) => input.project),
+    [OTHER_HOST_PROJECT],
+  );
+});
+
+test("a creation naming a target no project reported is offered nowhere to create", async () => {
+  const { plugin, created } = await recordedCreations();
+
+  assert.deepEqual(
+    await dispatchAct(plugin, "createWorkspace", {
+      providerProjectId: HOSTED_PROJECT.providerProjectId,
+      providerTargetId: "host-never-reported",
+    }),
+    { status: ACT_RESULT_STATUS.UNSUPPORTED, reason: UNSUPPORTED_BY_OBSERVATION },
+  );
+  assert.deepEqual(created, []);
+});
+
+test("a creation naming no target still reaches the project that shares its id", async () => {
+  const { plugin, created } = await recordedCreations();
+
+  await dispatchAct(plugin, "createWorkspace", {
+    providerProjectId: HOSTED_PROJECT.providerProjectId,
+  });
+
+  assert.deepEqual(
+    created.map((input) => input.project),
+    [HOSTED_PROJECT],
+  );
+});
+
+test("the agent kind an ask carried reaches the handler that documents taking one", async () => {
+  const { plugin, created } = await recordedCreations();
+
+  await dispatchAct(plugin, "createWorkspace", {
+    providerProjectId: HOSTED_PROJECT.providerProjectId,
+    agent: "claude",
+    task: "start here",
+  });
+
+  assert.deepEqual(created, [{ project: HOSTED_PROJECT, agent: "claude", task: "start here" }]);
+});
+
+test("the ask a creation input was built from carries the offered target and the agent kind", () => {
+  assert.deepEqual(
+    ACT_REQUEST_FROM.createWorkspace({
+      project: HOSTED_PROJECT,
+      agent: "claude",
+      task: "start here",
+    }),
+    {
+      providerProjectId: HOSTED_PROJECT.providerProjectId,
+      providerTargetId: "host-a",
+      agent: "claude",
+      task: "start here",
+    },
   );
 });

--- a/packages/providers/src/shared/dispatch-act.test.ts
+++ b/packages/providers/src/shared/dispatch-act.test.ts
@@ -28,6 +28,7 @@ import {
   SESSION_STATUS,
   type SessionProviderAdapter,
   type SessionProviderPlugin,
+  UNSUPPORTED_BY_OBSERVATION,
   WORKSPACE_TASK_SUPPORT,
   type WorkspaceProject,
 } from "@sidecar/session";
@@ -329,7 +330,7 @@ test("an act the plugin does not name answers unsupported and issues no request"
 
   const expected = {
     status: ACT_RESULT_STATUS.UNSUPPORTED,
-    reason: "That act is not supported by the latest observation.",
+    reason: UNSUPPORTED_BY_OBSERVATION,
   };
   assert.deepEqual(
     await dispatchAct(withoutActs, "message", { providerSessionId: SESSION_ID, text: "ship it" }),
@@ -382,7 +383,7 @@ test("a plugin that reports no projects is offered nowhere to create", async () 
     }),
     {
       status: ACT_RESULT_STATUS.UNSUPPORTED,
-      reason: "That act is not supported by the latest observation.",
+      reason: UNSUPPORTED_BY_OBSERVATION,
     },
   );
 });
@@ -420,7 +421,7 @@ test("a conversation read is refused for a session the pass did not report", asy
 
   assert.deepEqual(await dispatchConversation(plugin, { providerSessionId: ABSENT_SESSION_ID }), {
     status: ACT_RESULT_STATUS.UNSUPPORTED,
-    reason: "That act is not supported by the latest observation.",
+    reason: UNSUPPORTED_BY_OBSERVATION,
   });
   assert.equal(requests.length, from);
 });

--- a/packages/providers/src/shared/dispatch-act.test.ts
+++ b/packages/providers/src/shared/dispatch-act.test.ts
@@ -22,6 +22,7 @@ import {
   maximumWorkspaceNameLength,
   type PluginActKind,
   type PluginActRequests,
+  type PluginActResults,
   type ProviderSessionObservation,
   SESSION_CONTROL_KIND,
   SESSION_STATUS,
@@ -134,12 +135,14 @@ class StubAdapter extends CloudSessionAdapter {
   }
 }
 
-const BASE_METHOD_BY_ACT: {
+type BaseMethods = {
   [Kind in PluginActKind]: (
     adapter: SessionProviderAdapter,
     request: PluginActRequests[Kind],
-  ) => Promise<unknown>;
-} = {
+  ) => Promise<PluginActResults[Kind]>;
+};
+
+const BASE_METHOD_BY_ACT: BaseMethods = {
   message: (adapter, request) => adapter.sendMessage(request),
   control: (adapter, request) => adapter.executeControl(request),
   createWorkspace: (adapter, request) => adapter.createWorkspace(request),

--- a/packages/providers/src/shared/hook-merge.ts
+++ b/packages/providers/src/shared/hook-merge.ts
@@ -10,7 +10,7 @@ import {
   type WireRecord,
   type WireValue,
 } from "@sidecar/wire";
-import { canIgnoreFilesystemError } from "./local-session-adapter.js";
+import { canIgnoreFilesystemError } from "./local-files.js";
 
 /**
  * Hook-fed observation for the local providers that register hooks at all,

--- a/packages/providers/src/shared/hook-status.ts
+++ b/packages/providers/src/shared/hook-status.ts
@@ -1,0 +1,136 @@
+/**
+ * What one local session's own state says it is doing, and how what the
+ * observation hook last said sharpens it. A provider's files are the whole
+ * story wherever the hook is absent; the hook only ever refines a verdict
+ * these functions would reach without it.
+ */
+
+import { agedStatus, SESSION_STATUS, type SessionStatus } from "@sidecar/session";
+
+export function localSessionStatus(
+  status: SessionStatus,
+  lastActivityAt: number,
+  now: number,
+  freshnessMs: number,
+): SessionStatus {
+  if (status === SESSION_STATUS.WORKING && now - lastActivityAt > freshnessMs) {
+    return SESSION_STATUS.UNKNOWN;
+  }
+  return agedStatus(status, lastActivityAt, now, freshnessMs);
+}
+
+export interface HookEventStatus<Event extends string> {
+  event: Event;
+  fresh: SessionStatus;
+  stale?: SessionStatus;
+}
+
+export interface HookStatusRefinement<Event extends string> {
+  definitive: readonly HookEventStatus<Event>[];
+  fresh: readonly HookEventStatus<Event>[];
+  /**
+   * The token meaning the session is holding on a question only the developer
+   * can answer. It is the one event granted no tolerance against the
+   * provider's clock — holding writes nothing, so provider state at or past
+   * the event is itself the news that the hold ended — and the one that marks
+   * the observation as holding for the developer while it stands. A provider
+   * whose hooks carry no such moment omits it, and the honest absence stands.
+   */
+  notificationEvent?: Event;
+  /**
+   * The token meaning the provider closed the session for good, which is what
+   * lets the observation report the closure as the completion's cause. A
+   * provider that fires no closing hook omits it.
+   */
+  sessionEndEvent?: Event;
+}
+
+function refineStatusWithHookEvent<Event extends string>(
+  status: SessionStatus,
+  event: Event,
+  isFresh: boolean,
+  refinement: HookStatusRefinement<Event>,
+): SessionStatus {
+  const definitive = refinement.definitive.find((candidate) => candidate.event === event);
+  if (definitive) return definitive.fresh;
+  if (status === SESSION_STATUS.COMPLETE || status === SESSION_STATUS.ERROR) return status;
+  const candidate = refinement.fresh.find((entry) => entry.event === event);
+  if (!candidate) return status;
+  return isFresh ? candidate.fresh : (candidate.stale ?? status);
+}
+
+/**
+ * How much older than the provider's clock a hook event may run and still
+ * describe the same moment. The hook fires as a turn boundary happens and the
+ * provider's own closing records land moments later under their own
+ * timestamps, so a boundary's event usually trails the record it belongs with
+ * by a breath — never by more than this. An event further behind describes a
+ * turn the provider has already moved past, and refines nothing.
+ */
+export const HOOK_EVENT_TOLERANCE_MS = 5_000;
+
+/** What the hook settled for one observation, beyond the status itself. */
+export interface HookRefinedStatus {
+  status: SessionStatus;
+  /**
+   * The clock the freshness decay runs on: the provider's own, or the
+   * event's when it stands past it.
+   */
+  lastActivityAt: number;
+  /** The provider closed the session, on the hook's word. */
+  sessionClosed: boolean;
+  /** The session is holding on a question only the developer can answer. */
+  holdingForDeveloper: boolean;
+}
+
+/**
+ * Sharpens a provider's own verdict with what the observation hook last said,
+ * in the order the meanings bind: a definitive event outranks the provider,
+ * a provider that already settled on complete or error is never talked out
+ * of it by a softer event, and the rest refine only a fresh session — the
+ * decay to unknown exists because a hook can go silent (a killed process
+ * fires no session end), so an old event must age the same way old provider
+ * state does. A hook event trailing the provider's clock by more than the
+ * tolerance describes a turn the session already moved past, so it is
+ * ignored whole. One that stands is proof the session moved — only Luke's
+ * own script writes the spool, so its date cannot suffer the bulk-touch
+ * problem a provider's files can — and dates the session for the freshness
+ * decay as well. A notification alone gets no tolerance: a granted
+ * permission must not read as waiting for even one more pass.
+ */
+export function hookRefinedStatus<Event extends string>(options: {
+  refinement: HookStatusRefinement<Event>;
+  /** The spool's last word about the session, if the hook said anything. */
+  hookEvent: { event: Event; atMs: number } | undefined;
+  /** When the provider's own state last said the session moved. */
+  providerAtMs: number;
+  /** The provider's own verdict, given the clock the refinement settles on. */
+  statusAt: (lastActivityAt: number) => SessionStatus;
+  now: number;
+  activeSessionFreshnessMs: number;
+}): HookRefinedStatus {
+  const { refinement, hookEvent, providerAtMs } = options;
+  const toleranceMs =
+    refinement.notificationEvent !== undefined && hookEvent?.event === refinement.notificationEvent
+      ? 0
+      : HOOK_EVENT_TOLERANCE_MS;
+  const eventStands = hookEvent !== undefined && hookEvent.atMs + toleranceMs >= providerAtMs;
+  const lastActivityAt = eventStands ? Math.max(providerAtMs, hookEvent.atMs) : providerAtMs;
+  let status = options.statusAt(lastActivityAt);
+  if (eventStands) {
+    const isFresh = options.now - lastActivityAt <= options.activeSessionFreshnessMs;
+    status = refineStatusWithHookEvent(status, hookEvent.event, isFresh, refinement);
+  }
+  return {
+    status,
+    lastActivityAt,
+    sessionClosed:
+      status === SESSION_STATUS.COMPLETE &&
+      eventStands &&
+      hookEvent.event === refinement.sessionEndEvent,
+    holdingForDeveloper:
+      status === SESSION_STATUS.WAITING &&
+      eventStands &&
+      hookEvent.event === refinement.notificationEvent,
+  };
+}

--- a/packages/providers/src/shared/host-claims.test.ts
+++ b/packages/providers/src/shared/host-claims.test.ts
@@ -1,0 +1,150 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  type ProviderSessionObservation,
+  SESSION_APPLICATION_ID,
+  SESSION_APPLICATION_SCOPE,
+  SESSION_LOCATION,
+  SESSION_STATUS,
+} from "@sidecar/session";
+import { hostClaims, unclaimedWorkspace, type WorkspaceHostContexts } from "./host-claims.js";
+
+const OBSERVED_AT = Date.parse("2026-09-01T09:00:00.000Z");
+const PROVIDER_ID = "claude-code";
+
+interface StubContext {
+  workspaceName: string;
+  archived?: boolean;
+}
+
+function observation(
+  providerSessionId: string,
+  overrides: Partial<ProviderSessionObservation> = {},
+): ProviderSessionObservation {
+  return {
+    providerSessionId,
+    title: providerSessionId,
+    status: SESSION_STATUS.WORKING,
+    lastActivityAt: OBSERVED_AT,
+    ...overrides,
+  };
+}
+
+function contexts(
+  entries: Readonly<Record<string, StubContext>>,
+): WorkspaceHostContexts<StubContext> {
+  return new Map([[PROVIDER_ID, new Map(Object.entries(entries))]]);
+}
+
+function claims(
+  entries: Readonly<Record<string, StubContext>>,
+  overrides: { retains?: (context: StubContext) => boolean } = {},
+) {
+  return hostClaims<StubContext>({
+    applicationId: SESSION_APPLICATION_ID.CLAUDE,
+    contexts: contexts(entries),
+    ...(overrides.retains === undefined ? undefined : { retains: overrides.retains }),
+    annotate: ({ observation: row, context }) => ({
+      ...row,
+      applications: [
+        ...(row.applications ?? []),
+        {
+          id: SESSION_APPLICATION_ID.CLAUDE,
+          displayName: context.workspaceName,
+          scope: SESSION_APPLICATION_SCOPE.SESSION,
+        },
+      ],
+    }),
+  });
+}
+
+test("a manager with nothing to say about a provider changes nothing", () => {
+  const rows = [observation("one")];
+  assert.equal(claims({}).enrich("codex", rows), rows);
+});
+
+test("a matched row is annotated and an unmatched one is left alone", () => {
+  const enriched = claims({ one: { workspaceName: "luke" } }).enrich(PROVIDER_ID, [
+    observation("one"),
+    observation("two"),
+  ]);
+
+  assert.deepEqual(
+    enriched.map((row) => row.applications?.map((application) => application.displayName)),
+    [["luke"], undefined],
+  );
+});
+
+test("a row already carrying this manager's association stands exactly as it is", () => {
+  const already = observation("one", {
+    applications: [
+      {
+        id: SESSION_APPLICATION_ID.CLAUDE,
+        displayName: "already",
+        scope: SESSION_APPLICATION_SCOPE.SESSION,
+      },
+    ],
+  });
+
+  const enriched = claims({ one: { workspaceName: "luke" } }).enrich(PROVIDER_ID, [already]);
+
+  assert.equal(enriched[0], already);
+});
+
+test("a cloud row with a coincidentally equal id is never annotated", () => {
+  const enriched = claims({ one: { workspaceName: "luke" } }).enrich(PROVIDER_ID, [
+    observation("one", { location: SESSION_LOCATION.CLOUD }),
+  ]);
+
+  assert.equal(enriched[0]?.applications, undefined);
+});
+
+test("a sub-agent inherits its nearest indexed ancestor's context", () => {
+  const enriched = claims({ parent: { workspaceName: "luke" } }).enrich(PROVIDER_ID, [
+    observation("parent"),
+    observation("child", { parentProviderSessionId: "parent" }),
+    observation("grandchild", { parentProviderSessionId: "child" }),
+  ]);
+
+  assert.deepEqual(
+    enriched.map((row) => row.applications?.[0]?.displayName),
+    ["luke", "luke", "luke"],
+  );
+});
+
+test("an ancestor chain that loops back on itself ends rather than spinning", () => {
+  const enriched = claims({}).enrich(PROVIDER_ID, [
+    observation("one", { parentProviderSessionId: "two" }),
+    observation("two", { parentProviderSessionId: "one" }),
+  ]);
+
+  assert.deepEqual(
+    enriched.map((row) => row.applications),
+    [undefined, undefined],
+  );
+});
+
+test("a manager that drops a filed-away row leaves no row at all", () => {
+  const enriched = claims(
+    { one: { workspaceName: "luke", archived: true }, two: { workspaceName: "luke" } },
+    { retains: (context) => context.archived !== true },
+  ).enrich(PROVIDER_ID, [observation("one"), observation("two")]);
+
+  assert.deepEqual(
+    enriched.map((row) => row.providerSessionId),
+    ["two"],
+  );
+});
+
+test("has answers for the sessions this manager's own index named", () => {
+  const claimed = claims({ one: { workspaceName: "luke" } });
+  assert.equal(claimed.has(PROVIDER_ID, "one"), true);
+  assert.equal(claimed.has(PROVIDER_ID, "two"), false);
+  assert.equal(claimed.has("codex", "one"), false);
+});
+
+test("a claim lands only where no earlier manager already grouped the chat", () => {
+  const claim = { providerWorkspaceId: "workspace-1", name: "luke" };
+  assert.deepEqual(unclaimedWorkspace(observation("one"), claim), claim);
+  assert.equal(unclaimedWorkspace(observation("one", { workspace: claim }), claim), undefined);
+});

--- a/packages/providers/src/shared/host-claims.ts
+++ b/packages/providers/src/shared/host-claims.ts
@@ -5,7 +5,12 @@ import {
   type SessionWorkspace,
 } from "@sidecar/session";
 import { text } from "@sidecar/wire";
-import type { WorkspaceHostEnrichment } from "./workspace-hosts.js";
+
+/** One manager's annotation of one provider's already-observed sessions. */
+export type WorkspaceHostEnrichment = (
+  providerId: string,
+  observations: readonly ProviderSessionObservation[],
+) => readonly ProviderSessionObservation[];
 
 /**
  * What one workspace manager's own records say about the sessions it holds,

--- a/packages/providers/src/shared/host-claims.ts
+++ b/packages/providers/src/shared/host-claims.ts
@@ -1,0 +1,106 @@
+import {
+  type ProviderSessionObservation,
+  SESSION_LOCATION,
+  type SessionApplicationId,
+  type SessionWorkspace,
+} from "@sidecar/session";
+import { text } from "@sidecar/wire";
+import type { WorkspaceHostEnrichment } from "./workspace-hosts.js";
+
+/**
+ * What one workspace manager's own records say about the sessions it holds,
+ * keyed by the agent provider Luke already observes each session under and
+ * then by the provider's own session id.
+ */
+export type WorkspaceHostContexts<Context> = ReadonlyMap<string, ReadonlyMap<string, Context>>;
+
+/**
+ * One chat is grouped by exactly one manager however many of them hold it, so
+ * a claim lands only where no manager earlier in the enrichment order already
+ * grouped the chat.
+ */
+export function unclaimedWorkspace(
+  observation: ProviderSessionObservation,
+  claim: SessionWorkspace,
+): SessionWorkspace | undefined {
+  return observation.workspace ? undefined : claim;
+}
+
+/** What one manager's own index decides about the rows it holds. */
+export interface HostClaimsInput<Context> {
+  /** The association whose presence on a row means it is already annotated. */
+  readonly applicationId: SessionApplicationId;
+  readonly contexts: WorkspaceHostContexts<Context>;
+  /**
+   * Whether a matched row should stand at all. Conductor drops a chat its
+   * records say the user filed away; every other manager keeps every match.
+   */
+  retains?(context: Context): boolean;
+  /** One matched row's annotation, everything a manager decorates for itself. */
+  annotate(input: {
+    readonly observation: ProviderSessionObservation;
+    readonly context: Context;
+    readonly hostSessions: ReadonlyMap<string, Context>;
+  }): ProviderSessionObservation;
+}
+
+export interface HostClaims {
+  has(providerId: string, providerSessionId: string): boolean;
+  readonly enrich: WorkspaceHostEnrichment;
+}
+
+/**
+ * One local workspace manager's observed index of the agent sessions it
+ * holds, annotating already-observed rows without ever making a provider's
+ * own observation disappear: an absent app or an unreadable index is an empty
+ * claim, and an empty claim changes nothing. Only local observations can match
+ * a local manager's index — a cloud row with a coincidentally equal provider
+ * id is never annotated — and a sub-agent inherits its nearest indexed
+ * ancestor's context: the child is the manager's work even though only the
+ * parent reached the manager's records. A row already carrying this manager's
+ * association is left exactly as it stands.
+ */
+export function hostClaims<Context>(input: HostClaimsInput<Context>): HostClaims {
+  const retains = input.retains ?? (() => true);
+  return {
+    has(providerId, providerSessionId) {
+      return input.contexts.get(providerId)?.has(providerSessionId) === true;
+    },
+
+    enrich(providerId, observations) {
+      const hostSessions = input.contexts.get(providerId);
+      if (!hostSessions) return observations;
+
+      const localObservationsById = new Map(
+        observations
+          .filter((observation) => observation.location !== SESSION_LOCATION.CLOUD)
+          .map((observation) => [observation.providerSessionId, observation] as const),
+      );
+
+      const contextFor = (observation: ProviderSessionObservation): Context | undefined => {
+        if (observation.location === SESSION_LOCATION.CLOUD) return undefined;
+        let sessionId: string | undefined = observation.providerSessionId;
+        const visited = new Set<string>();
+        while (sessionId && !visited.has(sessionId)) {
+          const context = hostSessions.get(sessionId);
+          if (context) return context;
+          visited.add(sessionId);
+          sessionId = text(localObservationsById.get(sessionId)?.parentProviderSessionId);
+        }
+        return undefined;
+      };
+
+      return observations.flatMap((observation) => {
+        const context = contextFor(observation);
+        if (context && !retains(context)) return [];
+        if (
+          !context ||
+          observation.applications?.some((application) => application.id === input.applicationId)
+        ) {
+          return [observation];
+        }
+        return [input.annotate({ observation, context, hostSessions })];
+      });
+    },
+  };
+}

--- a/packages/providers/src/shared/jsonl-transcript.test.ts
+++ b/packages/providers/src/shared/jsonl-transcript.test.ts
@@ -4,7 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import test, { type TestContext } from "node:test";
 import type { WireRecord } from "@sidecar/wire";
-import { readRecordsSince, TranscriptPathCache } from "./local-transcript.js";
+import { readRecordsSince, TranscriptPathCache } from "./jsonl-transcript.js";
 
 const WINDOW_BYTES = 256;
 

--- a/packages/providers/src/shared/jsonl-transcript.ts
+++ b/packages/providers/src/shared/jsonl-transcript.ts
@@ -9,9 +9,22 @@
  * a reader sees the whole rendering the tail it read produces.
  */
 
-import { OMISSION_MARKER, transcriptReadTailBytes } from "@sidecar/session";
+import {
+  ACT_RESULT_STATUS,
+  OMISSION_MARKER,
+  type ProviderTranscriptResult,
+  type ProviderTranscriptSinceResult,
+  transcriptReadTailBytes,
+} from "@sidecar/session";
 import { isRecord, isWireString, recordFromJsonLine, text, type WireRecord } from "@sidecar/wire";
-import { type FileWindow, fileStats, readRange, readTailWindow } from "./local-files.js";
+import {
+  type FileWindow,
+  fileStats,
+  readRange,
+  readTail,
+  readTailWindow,
+  tailRecords,
+} from "./local-files.js";
 
 export const transcriptLine = {
   developer: (words: string) => `Developer: ${words}`,
@@ -189,4 +202,76 @@ export class TranscriptPathCache {
     }
     return located;
   }
+}
+
+/**
+ * The transcript-not-found refusal. It is the same answer for a session this
+ * provider never wrote a record file for and for one whose file has since
+ * gone: what a reader learns is that there is nothing to render, and nothing
+ * about the provider's own directory.
+ */
+const TRANSCRIPT_NOT_FOUND = {
+  status: ACT_RESULT_STATUS.REJECTED,
+  reason: "That session's transcript could not be found.",
+} as const;
+
+/** How one provider's stored records become transcript lines. */
+export interface JsonlTranscriptInput {
+  /** Where this session's record file is, or nothing when there is none. */
+  locate(providerSessionId: string): Promise<string | undefined>;
+  /** The attributed lines one stored record yields, or none. */
+  lines(record: WireRecord): readonly string[];
+  readTailBytes?: number;
+  maximumRenderedLength?: number;
+}
+
+export interface JsonlTranscriptReader {
+  read(providerSessionId: string): Promise<ProviderTranscriptResult>;
+  readSince(providerSessionId: string, cursor?: string): Promise<ProviderTranscriptSinceResult>;
+}
+
+/**
+ * Every on-demand read of a JSONL-backed transcript: the bounded tail read,
+ * the cursor arithmetic, the path cache an incremental read walks by, and the
+ * bounds every rendering is held to. A provider supplies only where its
+ * records live and what one of them says; nothing here opens a file for
+ * writing, and the rendering is kept nowhere.
+ */
+export function jsonlTranscriptReader(input: JsonlTranscriptInput): JsonlTranscriptReader {
+  const readTailBytes = input.readTailBytes ?? TRANSCRIPT_BOUNDS.READ_TAIL_BYTES;
+  const paths = new TranscriptPathCache();
+  return {
+    async read(providerSessionId) {
+      // A whole-tail read walks the provider's directory itself: it happens
+      // once at a developer's ask, where the incremental read repeats on
+      // every wake and is what the path cache exists for.
+      const filePath = await input.locate(providerSessionId);
+      if (filePath === undefined) return TRANSCRIPT_NOT_FOUND;
+      const tail = await readTail(filePath, readTailBytes);
+      const transcript = boundedTranscript(
+        tailRecords(tail).flatMap((record) => input.lines(record)),
+        input.maximumRenderedLength,
+      );
+      return transcript === undefined
+        ? TRANSCRIPT_NOT_FOUND
+        : { status: ACT_RESULT_STATUS.ACCEPTED, transcript };
+    },
+
+    async readSince(providerSessionId, cursor) {
+      const filePath = await paths.resolve(providerSessionId, () =>
+        input.locate(providerSessionId),
+      );
+      if (filePath === undefined) return TRANSCRIPT_NOT_FOUND;
+      const since = await readRecordsSince(filePath, cursor, readTailBytes);
+      return {
+        status: ACT_RESULT_STATUS.ACCEPTED,
+        // The rendering is unbounded in total, like a tail read with no
+        // maximum: the window the read loaded and the per-line cuts are the
+        // bounds.
+        text: boundedTranscript(since.records.flatMap((record) => input.lines(record))) ?? "",
+        cursor: since.cursor,
+        truncated: since.truncated,
+      };
+    },
+  };
 }

--- a/packages/providers/src/shared/jsonl-transcript.ts
+++ b/packages/providers/src/shared/jsonl-transcript.ts
@@ -221,8 +221,6 @@ export interface JsonlTranscriptInput {
   locate(providerSessionId: string): Promise<string | undefined>;
   /** The attributed lines one stored record yields, or none. */
   lines(record: WireRecord): readonly string[];
-  readTailBytes?: number;
-  maximumRenderedLength?: number;
 }
 
 export interface JsonlTranscriptReader {
@@ -233,12 +231,13 @@ export interface JsonlTranscriptReader {
 /**
  * Every on-demand read of a JSONL-backed transcript: the bounded tail read,
  * the cursor arithmetic, the path cache an incremental read walks by, and the
- * bounds every rendering is held to. A provider supplies only where its
+ * bounds every rendering is held to — the tail the build fixes, and the
+ * per-line cuts, with no bound on the total, so a reader sees the whole
+ * rendering the tail it read produces. A provider supplies only where its
  * records live and what one of them says; nothing here opens a file for
  * writing, and the rendering is kept nowhere.
  */
 export function jsonlTranscriptReader(input: JsonlTranscriptInput): JsonlTranscriptReader {
-  const readTailBytes = input.readTailBytes ?? TRANSCRIPT_BOUNDS.READ_TAIL_BYTES;
   const paths = new TranscriptPathCache();
   return {
     async read(providerSessionId) {
@@ -247,10 +246,9 @@ export function jsonlTranscriptReader(input: JsonlTranscriptInput): JsonlTranscr
       // every wake and is what the path cache exists for.
       const filePath = await input.locate(providerSessionId);
       if (filePath === undefined) return TRANSCRIPT_NOT_FOUND;
-      const tail = await readTail(filePath, readTailBytes);
+      const tail = await readTail(filePath, TRANSCRIPT_BOUNDS.READ_TAIL_BYTES);
       const transcript = boundedTranscript(
         tailRecords(tail).flatMap((record) => input.lines(record)),
-        input.maximumRenderedLength,
       );
       return transcript === undefined
         ? TRANSCRIPT_NOT_FOUND
@@ -262,12 +260,9 @@ export function jsonlTranscriptReader(input: JsonlTranscriptInput): JsonlTranscr
         input.locate(providerSessionId),
       );
       if (filePath === undefined) return TRANSCRIPT_NOT_FOUND;
-      const since = await readRecordsSince(filePath, cursor, readTailBytes);
+      const since = await readRecordsSince(filePath, cursor, TRANSCRIPT_BOUNDS.READ_TAIL_BYTES);
       return {
         status: ACT_RESULT_STATUS.ACCEPTED,
-        // The rendering is unbounded in total, like a tail read with no
-        // maximum: the window the read loaded and the per-line cuts are the
-        // bounds.
         text: boundedTranscript(since.records.flatMap((record) => input.lines(record))) ?? "",
         cursor: since.cursor,
         truncated: since.truncated,

--- a/packages/providers/src/shared/local-files.ts
+++ b/packages/providers/src/shared/local-files.ts
@@ -1,0 +1,284 @@
+/**
+ * The shared half of every adapter that observes sessions on this machine:
+ * bounded, failure-tolerant reads of the files a provider already writes for
+ * itself. Nothing here opens a file for writing, and no caller may.
+ */
+
+import type { Dirent, Stats } from "node:fs";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { UNKNOWN_WORKSPACE_LABEL } from "@sidecar/session";
+import { recordFromJsonLine, type WireRecord } from "@sidecar/wire";
+
+/** How much of a transcript one local observation pass may read. */
+export const LOCAL_ADAPTER_DEFAULTS = {
+  READ_TAIL_BYTES: 64 * 1024,
+} as const;
+
+export interface DirectoryEntry {
+  directoryPath: string;
+  name: string;
+  stats: Stats;
+}
+
+/** The least an adapter has to know about a session file to place it in time. */
+export interface SessionFileCandidate {
+  filePath: string;
+  providerSessionId: string;
+  mtimeMs: number;
+}
+
+export function sessionIdFromFileName(fileName: string, extension: string): string | undefined {
+  if (!fileName.endsWith(extension)) return undefined;
+  const providerSessionId = fileName.slice(0, -extension.length).trim();
+  return providerSessionId || undefined;
+}
+
+/** How one provider's directory layout turns into session files. */
+export interface SessionFileDiscovery<Candidate extends SessionFileCandidate> {
+  projectsDirectory: string;
+  /**
+   * The directory inside a project that its sessions land in, for a provider
+   * that keeps them somewhere other than the project directory itself.
+   */
+  sessionsDirectoryName?: string;
+  maximumProjectDirectories: number;
+  sessionFilesIn: (sessionsDirectory: string, project: DirectoryEntry) => Promise<Candidate[]>;
+}
+
+/** Where one project keeps its sessions, and when it last started one. */
+interface ProjectSessionsDirectory {
+  project: DirectoryEntry;
+  sessionsDirectory: string;
+  mtimeMs: number;
+}
+
+function isNodeError(error: Error): error is NodeJS.ErrnoException {
+  return error instanceof Error && "code" in error;
+}
+
+/**
+ * A provider directory that is absent, or that this user cannot read, means
+ * Luke observes nothing there — never that the observation pass failed.
+ */
+export function canIgnoreFilesystemError(error: Error): boolean {
+  return (
+    isNodeError(error) &&
+    (error.code === "ENOENT" ||
+      error.code === "ENOTDIR" ||
+      error.code === "EACCES" ||
+      error.code === "EPERM")
+  );
+}
+
+export async function readDirectory(directoryPath: string): Promise<Dirent[]> {
+  try {
+    return await fs.readdir(directoryPath, { withFileTypes: true });
+  } catch (error) {
+    if (!(error instanceof Error) || !canIgnoreFilesystemError(error)) throw error;
+    return [];
+  }
+}
+
+export async function fileStats(filePath: string): Promise<Stats | undefined> {
+  try {
+    return await fs.stat(filePath);
+  } catch (error) {
+    if (!(error instanceof Error) || !canIgnoreFilesystemError(error)) throw error;
+    return undefined;
+  }
+}
+
+/** `lstat`, so a link out of a provider directory is never followed. */
+export async function statDirectoryEntry(
+  directoryPath: string,
+  name: string,
+): Promise<DirectoryEntry | undefined> {
+  const entryPath = path.join(directoryPath, name);
+  try {
+    const stats = await fs.lstat(entryPath);
+    return { directoryPath: entryPath, name, stats };
+  } catch (error) {
+    if (!(error instanceof Error) || !canIgnoreFilesystemError(error)) throw error;
+    return undefined;
+  }
+}
+
+export async function readTextFile(filePath: string): Promise<string | undefined> {
+  try {
+    return await fs.readFile(filePath, "utf8");
+  } catch (error) {
+    if (!(error instanceof Error) || !canIgnoreFilesystemError(error)) throw error;
+    return undefined;
+  }
+}
+
+/**
+ * One bounded window of a session file's bytes, with where it began and how
+ * large the file was when it was read, so a reader that walks a file by
+ * offset can tell a window that reached the end from one that fell short.
+ */
+export interface FileWindow {
+  bytes: Buffer;
+  offset: number;
+  fileSize: number;
+}
+
+const EMPTY_WINDOW: FileWindow = { bytes: Buffer.alloc(0), offset: 0, fileSize: 0 };
+
+/**
+ * Reads a bounded region of a session file. A transcript grows without bound,
+ * so no adapter may read one whole, and the file is opened for reading alone.
+ */
+async function readRegion(
+  filePath: string,
+  window: (size: number) => { offset: number; length: number },
+): Promise<FileWindow> {
+  let handle: fs.FileHandle | undefined;
+  try {
+    handle = await fs.open(filePath, "r");
+    const stats = await handle.stat();
+    if (!stats.isFile() || stats.size <= 0) return EMPTY_WINDOW;
+    const { offset, length } = window(stats.size);
+    if (length <= 0) return { bytes: Buffer.alloc(0), offset, fileSize: stats.size };
+    const buffer = Buffer.alloc(length);
+    await handle.read(buffer, 0, length, offset);
+    return { bytes: buffer, offset, fileSize: stats.size };
+  } catch (error) {
+    if (!(error instanceof Error) || !canIgnoreFilesystemError(error)) throw error;
+    return EMPTY_WINDOW;
+  } finally {
+    await handle?.close();
+  }
+}
+
+/** The end of a session file, where its newest records say what it is doing. */
+export async function readTail(filePath: string, maximumBytes: number): Promise<string> {
+  return (await readTailWindow(filePath, maximumBytes)).bytes.toString("utf8");
+}
+
+/** The tail as bytes, for a reader that has to account for where it began. */
+export function readTailWindow(filePath: string, maximumBytes: number): Promise<FileWindow> {
+  return readRegion(filePath, (size) => {
+    const length = Math.min(size, maximumBytes);
+    return { offset: size - length, length };
+  });
+}
+
+/** The start of a session file, for the records a provider writes only once. */
+export async function readHead(filePath: string, maximumBytes: number): Promise<string> {
+  const window = await readRegion(filePath, (size) => ({
+    offset: 0,
+    length: Math.min(size, maximumBytes),
+  }));
+  return window.bytes.toString("utf8");
+}
+
+/**
+ * The bytes from `offset` forward, at most `maximumBytes` of them. An offset
+ * at or past the end reads nothing and reports the size it was measured
+ * against, which is how a caller learns its offset no longer fits the file.
+ */
+export function readRange(
+  filePath: string,
+  offset: number,
+  maximumBytes: number,
+): Promise<FileWindow> {
+  return readRegion(filePath, (size) => ({
+    offset,
+    length: Math.min(Math.max(0, size - offset), maximumBytes),
+  }));
+}
+
+function tailLines(tail: string): string[] {
+  const lines = tail.split(/\r?\n/).filter((line) => line.trim().length > 0);
+  // A bounded read lands mid-record, and a provider appending right now can
+  // leave the last one unfinished; neither half-record is a record.
+  if (!tail.startsWith("{")) lines.shift();
+  return lines;
+}
+
+/** The whole records a tail holds, oldest first. */
+export function tailRecords(tail: string): WireRecord[] {
+  return tailLines(tail)
+    .map(recordFromJsonLine)
+    .filter((record): record is WireRecord => record !== undefined);
+}
+
+/** Sessions are labelled by the folder they run in, never by a provider's own name for them. */
+export function workspaceLabel(directoryPath: string | undefined): string {
+  if (!directoryPath) return UNKNOWN_WORKSPACE_LABEL;
+  const label = path.basename(directoryPath.trim());
+  return label || UNKNOWN_WORKSPACE_LABEL;
+}
+
+/** Drops duplicate paths while keeping first-seen order. */
+export function uniquePaths(paths: readonly string[]): string[] {
+  return [...new Set(paths)];
+}
+
+/**
+ * Places a project in time by the directory its sessions land in, which is the
+ * one a new session moves. A project directory's own mtime stops moving the
+ * moment a provider nests its transcripts inside it — nothing done to a session
+ * afterwards reaches it — so ranking by it would rank a folder used every day
+ * by the day the provider first wrote there. A project with no sessions
+ * directory has no sessions, and takes none of the bound below.
+ */
+async function projectSessionsDirectory(
+  project: DirectoryEntry,
+  sessionsDirectoryName: string | undefined,
+): Promise<ProjectSessionsDirectory | undefined> {
+  if (sessionsDirectoryName === undefined) {
+    return {
+      project,
+      sessionsDirectory: project.directoryPath,
+      mtimeMs: project.stats.mtimeMs,
+    };
+  }
+  const sessionsDirectory = path.join(project.directoryPath, sessionsDirectoryName);
+  const stats = await fileStats(sessionsDirectory);
+  if (!stats?.isDirectory()) return undefined;
+  return { project, sessionsDirectory, mtimeMs: stats.mtimeMs };
+}
+
+/**
+ * Finds the newest session files across a provider's project directories. Both
+ * levels are bounded and ordered by recency, so a machine with years of
+ * projects costs the same pass as a machine with one. A directory's mtime does
+ * not move when a file inside it is appended to, so the project bound keeps the
+ * projects that most recently *started* a session; the session bound that
+ * follows it is ordered by each transcript's own last write.
+ */
+export async function discoverSessionFiles<Candidate extends SessionFileCandidate>(
+  discovery: SessionFileDiscovery<Candidate>,
+): Promise<Candidate[]> {
+  const entries = await readDirectory(discovery.projectsDirectory);
+  const projects = (
+    await Promise.all(
+      entries.map((entry) => statDirectoryEntry(discovery.projectsDirectory, entry.name)),
+    )
+  ).filter((entry): entry is DirectoryEntry => entry?.stats.isDirectory() === true);
+
+  const sessionsDirectories = (
+    await Promise.all(
+      projects.map((project) => projectSessionsDirectory(project, discovery.sessionsDirectoryName)),
+    )
+  )
+    .filter((entry): entry is ProjectSessionsDirectory => entry !== undefined)
+    .sort((first, second) => second.mtimeMs - first.mtimeMs)
+    .slice(0, discovery.maximumProjectDirectories);
+
+  const files = (
+    await Promise.all(
+      sessionsDirectories.map((entry) =>
+        discovery.sessionFilesIn(entry.sessionsDirectory, entry.project),
+      ),
+    )
+  ).flat();
+  // Newest first, so a duplicate session id resolves to its latest file.
+  // There is deliberately no cap: a conversation is never dropped for being
+  // old, and what keeps a pass cheap is each adapter re-reading only the
+  // files that changed since the last one.
+  return files.sort((first, second) => second.mtimeMs - first.mtimeMs);
+}

--- a/packages/providers/src/shared/local-session-adapter.ts
+++ b/packages/providers/src/shared/local-session-adapter.ts
@@ -1,195 +1,34 @@
-import type { Dirent, Stats } from "node:fs";
-import fs from "node:fs/promises";
-import path from "node:path";
 import {
   ACT_KIND,
   ACT_RESULT_STATUS,
   advertisedActFor,
-  agedStatus,
-  OBSERVATION_WINDOW,
   type ProviderMessageResult,
   type ProviderSessionMessage,
   type ProviderSessionObservation,
-  SESSION_STATUS,
   type SessionProvider,
   SessionProviderAdapterBase,
-  type SessionStatus,
   sessionMessageText,
-  UNKNOWN_WORKSPACE_LABEL,
   UNSUPPORTED_BY_OBSERVATION,
 } from "@sidecar/session";
-import { recordFromJsonLine, type WireRecord } from "@sidecar/wire";
-
-export function localSessionStatus(
-  status: SessionStatus,
-  lastActivityAt: number,
-  now: number,
-  freshnessMs: number,
-): SessionStatus {
-  if (status === SESSION_STATUS.WORKING && now - lastActivityAt > freshnessMs) {
-    return SESSION_STATUS.UNKNOWN;
-  }
-  return agedStatus(status, lastActivityAt, now, freshnessMs);
-}
-
-export interface HookEventStatus<Event extends string> {
-  event: Event;
-  fresh: SessionStatus;
-  stale?: SessionStatus;
-}
-
-export interface HookStatusRefinement<Event extends string> {
-  definitive: readonly HookEventStatus<Event>[];
-  fresh: readonly HookEventStatus<Event>[];
-  /**
-   * The token meaning the session is holding on a question only the developer
-   * can answer. It is the one event granted no tolerance against the
-   * provider's clock — holding writes nothing, so provider state at or past
-   * the event is itself the news that the hold ended — and the one that marks
-   * the observation as holding for the developer while it stands. A provider
-   * whose hooks carry no such moment omits it, and the honest absence stands.
-   */
-  notificationEvent?: Event;
-  /**
-   * The token meaning the provider closed the session for good, which is what
-   * lets the observation report the closure as the completion's cause. A
-   * provider that fires no closing hook omits it.
-   */
-  sessionEndEvent?: Event;
-}
-
-function refineStatusWithHookEvent<Event extends string>(
-  status: SessionStatus,
-  event: Event,
-  isFresh: boolean,
-  refinement: HookStatusRefinement<Event>,
-): SessionStatus {
-  const definitive = refinement.definitive.find((candidate) => candidate.event === event);
-  if (definitive) return definitive.fresh;
-  if (status === SESSION_STATUS.COMPLETE || status === SESSION_STATUS.ERROR) return status;
-  const candidate = refinement.fresh.find((entry) => entry.event === event);
-  if (!candidate) return status;
-  return isFresh ? candidate.fresh : (candidate.stale ?? status);
-}
-
-/**
- * How much older than the provider's clock a hook event may run and still
- * describe the same moment. The hook fires as a turn boundary happens and the
- * provider's own closing records land moments later under their own
- * timestamps, so a boundary's event usually trails the record it belongs with
- * by a breath — never by more than this. An event further behind describes a
- * turn the provider has already moved past, and refines nothing.
- */
-export const HOOK_EVENT_TOLERANCE_MS = 5_000;
-
-/** What the hook settled for one observation, beyond the status itself. */
-export interface HookRefinedStatus {
-  status: SessionStatus;
-  /**
-   * The clock the freshness decay runs on: the provider's own, or the
-   * event's when it stands past it.
-   */
-  lastActivityAt: number;
-  /** The provider closed the session, on the hook's word. */
-  sessionClosed: boolean;
-  /** The session is holding on a question only the developer can answer. */
-  holdingForDeveloper: boolean;
-}
-
-/**
- * Sharpens a provider's own verdict with what the observation hook last said,
- * in the order the meanings bind: a definitive event outranks the provider,
- * a provider that already settled on complete or error is never talked out
- * of it by a softer event, and the rest refine only a fresh session — the
- * decay to unknown exists because a hook can go silent (a killed process
- * fires no session end), so an old event must age the same way old provider
- * state does. A hook event trailing the provider's clock by more than the
- * tolerance describes a turn the session already moved past, so it is
- * ignored whole. One that stands is proof the session moved — only Luke's
- * own script writes the spool, so its date cannot suffer the bulk-touch
- * problem a provider's files can — and dates the session for the freshness
- * decay as well. A notification alone gets no tolerance: a granted
- * permission must not read as waiting for even one more pass.
- */
-export function hookRefinedStatus<Event extends string>(options: {
-  refinement: HookStatusRefinement<Event>;
-  /** The spool's last word about the session, if the hook said anything. */
-  hookEvent: { event: Event; atMs: number } | undefined;
-  /** When the provider's own state last said the session moved. */
-  providerAtMs: number;
-  /** The provider's own verdict, given the clock the refinement settles on. */
-  statusAt: (lastActivityAt: number) => SessionStatus;
-  now: number;
-  activeSessionFreshnessMs: number;
-}): HookRefinedStatus {
-  const { refinement, hookEvent, providerAtMs } = options;
-  const toleranceMs =
-    refinement.notificationEvent !== undefined && hookEvent?.event === refinement.notificationEvent
-      ? 0
-      : HOOK_EVENT_TOLERANCE_MS;
-  const eventStands = hookEvent !== undefined && hookEvent.atMs + toleranceMs >= providerAtMs;
-  const lastActivityAt = eventStands ? Math.max(providerAtMs, hookEvent.atMs) : providerAtMs;
-  let status = options.statusAt(lastActivityAt);
-  if (eventStands) {
-    const isFresh = options.now - lastActivityAt <= options.activeSessionFreshnessMs;
-    status = refineStatusWithHookEvent(status, hookEvent.event, isFresh, refinement);
-  }
-  return {
-    status,
-    lastActivityAt,
-    sessionClosed:
-      status === SESSION_STATUS.COMPLETE &&
-      eventStands &&
-      hookEvent.event === refinement.sessionEndEvent,
-    holdingForDeveloper:
-      status === SESSION_STATUS.WAITING &&
-      eventStands &&
-      hookEvent.event === refinement.notificationEvent,
-  };
-}
-
-/**
- * The shared half of every adapter that observes sessions on this machine:
- * bounded, failure-tolerant reads of the files a provider already writes for
- * itself. Nothing here opens a file for writing, and no caller may.
- */
-
-/** How much of a transcript one local observation pass may read. */
-export const LOCAL_ADAPTER_DEFAULTS = {
-  READ_TAIL_BYTES: 64 * 1024,
-} as const;
-
-export interface DirectoryEntry {
-  directoryPath: string;
-  name: string;
-  stats: Stats;
-}
-
-/** The least an adapter has to know about a session file to place it in time. */
-export interface SessionFileCandidate {
-  filePath: string;
-  providerSessionId: string;
-  mtimeMs: number;
-}
-
-export function sessionIdFromFileName(fileName: string, extension: string): string | undefined {
-  if (!fileName.endsWith(extension)) return undefined;
-  const providerSessionId = fileName.slice(0, -extension.length).trim();
-  return providerSessionId || undefined;
-}
+import type { SessionFileCandidate } from "./local-files.js";
+import {
+  type ObservationPass,
+  observationPass,
+  type RosterHolder,
+  rosterHolder,
+} from "./observation-pass.js";
 
 export interface LocalSessionAdapterOptions {
   now?: () => number;
 }
 
 /**
- * The shared observation lifecycle for transcript-backed local providers:
- * discover, prepare provider-specific lookup state, parse only changed files,
- * assemble one observation per session, and prune parses for vanished files.
+ * The adapter-shaped half of a local provider: the roster a local write
+ * re-checks against, and the guard that does the re-checking.
  */
 export abstract class LocalSessionAdapter extends SessionProviderAdapterBase {
   readonly #now: () => number;
-  #observations: readonly ProviderSessionObservation[] = [];
+  readonly #roster: RosterHolder = rosterHolder();
 
   protected constructor(options: LocalSessionAdapterOptions = {}) {
     super();
@@ -204,8 +43,7 @@ export abstract class LocalSessionAdapter extends SessionProviderAdapterBase {
   protected observed(
     observations: readonly ProviderSessionObservation[],
   ): readonly ProviderSessionObservation[] {
-    this.#observations = observations;
-    return observations;
+    return this.#roster.publish(observations);
   }
 
   /**
@@ -215,9 +53,9 @@ export abstract class LocalSessionAdapter extends SessionProviderAdapterBase {
    * already-bounded developer text.
    */
   override async sendMessage(message: ProviderSessionMessage): Promise<ProviderMessageResult> {
-    const observation = this.#observations.find(
-      (candidate) => candidate.providerSessionId === message.providerSessionId,
-    );
+    const observation = this.#roster
+      .latest()
+      .find((candidate) => candidate.providerSessionId === message.providerSessionId);
     if (!observation || !advertisedActFor(observation, ACT_KIND.MESSAGE)) {
       return {
         status: ACT_RESULT_STATUS.UNSUPPORTED,
@@ -251,10 +89,18 @@ export abstract class LocalFileSessionAdapter<
 > extends LocalSessionAdapter {
   abstract override readonly provider: SessionProvider;
 
-  readonly #parsed = new Map<string, { mtimeMs: number; value: Parsed }>();
+  readonly #pass: ObservationPass;
 
   protected constructor(options: LocalSessionAdapterOptions = {}) {
     super(options);
+    this.#pass = observationPass<Candidate, Parsed>({
+      now: () => this.observationTime(),
+      discover: () => this.discover(),
+      prepare: (candidates) => this.prepare(candidates),
+      parse: (candidate) => this.parse(candidate),
+      observation: ({ candidate, parsed, now, activeSessionFreshnessMs }) =>
+        this.observation(candidate, parsed, now, activeSessionFreshnessMs),
+    });
   }
 
   protected abstract discover(): Promise<readonly Candidate[]>;
@@ -269,284 +115,6 @@ export abstract class LocalFileSessionAdapter<
   protected prepare(_candidates: readonly Candidate[]): Promise<void> | void {}
 
   async observe(): Promise<readonly ProviderSessionObservation[]> {
-    const now = this.observationTime();
-    const candidates = await this.discover();
-    await this.prepare(candidates);
-    const observations = new Map<string, ProviderSessionObservation>();
-    for (const candidate of candidates) {
-      if (observations.has(candidate.providerSessionId)) continue;
-      const cached = this.#parsed.get(candidate.filePath);
-      const parsed =
-        cached?.mtimeMs === candidate.mtimeMs ? cached.value : await this.parseAndCache(candidate);
-      observations.set(
-        candidate.providerSessionId,
-        await this.observation(
-          candidate,
-          parsed,
-          now,
-          OBSERVATION_WINDOW.ACTIVE_SESSION_FRESHNESS_MS,
-        ),
-      );
-    }
-    const discovered = new Set(candidates.map((candidate) => candidate.filePath));
-    for (const filePath of this.#parsed.keys()) {
-      if (!discovered.has(filePath)) this.#parsed.delete(filePath);
-    }
-    return this.observed([...observations.values()]);
+    return this.observed(await this.#pass.run());
   }
-
-  private async parseAndCache(candidate: Candidate): Promise<Parsed> {
-    const value = await this.parse(candidate);
-    this.#parsed.set(candidate.filePath, { mtimeMs: candidate.mtimeMs, value });
-    return value;
-  }
-}
-
-/** How one provider's directory layout turns into session files. */
-export interface SessionFileDiscovery<Candidate extends SessionFileCandidate> {
-  projectsDirectory: string;
-  /**
-   * The directory inside a project that its sessions land in, for a provider
-   * that keeps them somewhere other than the project directory itself.
-   */
-  sessionsDirectoryName?: string;
-  maximumProjectDirectories: number;
-  sessionFilesIn: (sessionsDirectory: string, project: DirectoryEntry) => Promise<Candidate[]>;
-}
-
-/** Where one project keeps its sessions, and when it last started one. */
-interface ProjectSessionsDirectory {
-  project: DirectoryEntry;
-  sessionsDirectory: string;
-  mtimeMs: number;
-}
-
-function isNodeError(error: Error): error is NodeJS.ErrnoException {
-  return error instanceof Error && "code" in error;
-}
-
-/**
- * A provider directory that is absent, or that this user cannot read, means
- * Luke observes nothing there — never that the observation pass failed.
- */
-export function canIgnoreFilesystemError(error: Error): boolean {
-  return (
-    isNodeError(error) &&
-    (error.code === "ENOENT" ||
-      error.code === "ENOTDIR" ||
-      error.code === "EACCES" ||
-      error.code === "EPERM")
-  );
-}
-
-export async function readDirectory(directoryPath: string): Promise<Dirent[]> {
-  try {
-    return await fs.readdir(directoryPath, { withFileTypes: true });
-  } catch (error) {
-    if (!(error instanceof Error) || !canIgnoreFilesystemError(error)) throw error;
-    return [];
-  }
-}
-
-export async function fileStats(filePath: string): Promise<Stats | undefined> {
-  try {
-    return await fs.stat(filePath);
-  } catch (error) {
-    if (!(error instanceof Error) || !canIgnoreFilesystemError(error)) throw error;
-    return undefined;
-  }
-}
-
-/** `lstat`, so a link out of a provider directory is never followed. */
-export async function statDirectoryEntry(
-  directoryPath: string,
-  name: string,
-): Promise<DirectoryEntry | undefined> {
-  const entryPath = path.join(directoryPath, name);
-  try {
-    const stats = await fs.lstat(entryPath);
-    return { directoryPath: entryPath, name, stats };
-  } catch (error) {
-    if (!(error instanceof Error) || !canIgnoreFilesystemError(error)) throw error;
-    return undefined;
-  }
-}
-
-export async function readTextFile(filePath: string): Promise<string | undefined> {
-  try {
-    return await fs.readFile(filePath, "utf8");
-  } catch (error) {
-    if (!(error instanceof Error) || !canIgnoreFilesystemError(error)) throw error;
-    return undefined;
-  }
-}
-
-/**
- * One bounded window of a session file's bytes, with where it began and how
- * large the file was when it was read, so a reader that walks a file by
- * offset can tell a window that reached the end from one that fell short.
- */
-export interface FileWindow {
-  bytes: Buffer;
-  offset: number;
-  fileSize: number;
-}
-
-const EMPTY_WINDOW: FileWindow = { bytes: Buffer.alloc(0), offset: 0, fileSize: 0 };
-
-/**
- * Reads a bounded region of a session file. A transcript grows without bound,
- * so no adapter may read one whole, and the file is opened for reading alone.
- */
-async function readRegion(
-  filePath: string,
-  window: (size: number) => { offset: number; length: number },
-): Promise<FileWindow> {
-  let handle: fs.FileHandle | undefined;
-  try {
-    handle = await fs.open(filePath, "r");
-    const stats = await handle.stat();
-    if (!stats.isFile() || stats.size <= 0) return EMPTY_WINDOW;
-    const { offset, length } = window(stats.size);
-    if (length <= 0) return { bytes: Buffer.alloc(0), offset, fileSize: stats.size };
-    const buffer = Buffer.alloc(length);
-    await handle.read(buffer, 0, length, offset);
-    return { bytes: buffer, offset, fileSize: stats.size };
-  } catch (error) {
-    if (!(error instanceof Error) || !canIgnoreFilesystemError(error)) throw error;
-    return EMPTY_WINDOW;
-  } finally {
-    await handle?.close();
-  }
-}
-
-/** The end of a session file, where its newest records say what it is doing. */
-export async function readTail(filePath: string, maximumBytes: number): Promise<string> {
-  return (await readTailWindow(filePath, maximumBytes)).bytes.toString("utf8");
-}
-
-/** The tail as bytes, for a reader that has to account for where it began. */
-export function readTailWindow(filePath: string, maximumBytes: number): Promise<FileWindow> {
-  return readRegion(filePath, (size) => {
-    const length = Math.min(size, maximumBytes);
-    return { offset: size - length, length };
-  });
-}
-
-/** The start of a session file, for the records a provider writes only once. */
-export async function readHead(filePath: string, maximumBytes: number): Promise<string> {
-  const window = await readRegion(filePath, (size) => ({
-    offset: 0,
-    length: Math.min(size, maximumBytes),
-  }));
-  return window.bytes.toString("utf8");
-}
-
-/**
- * The bytes from `offset` forward, at most `maximumBytes` of them. An offset
- * at or past the end reads nothing and reports the size it was measured
- * against, which is how a caller learns its offset no longer fits the file.
- */
-export function readRange(
-  filePath: string,
-  offset: number,
-  maximumBytes: number,
-): Promise<FileWindow> {
-  return readRegion(filePath, (size) => ({
-    offset,
-    length: Math.min(Math.max(0, size - offset), maximumBytes),
-  }));
-}
-
-function tailLines(tail: string): string[] {
-  const lines = tail.split(/\r?\n/).filter((line) => line.trim().length > 0);
-  // A bounded read lands mid-record, and a provider appending right now can
-  // leave the last one unfinished; neither half-record is a record.
-  if (!tail.startsWith("{")) lines.shift();
-  return lines;
-}
-
-/** The whole records a tail holds, oldest first. */
-export function tailRecords(tail: string): WireRecord[] {
-  return tailLines(tail)
-    .map(recordFromJsonLine)
-    .filter((record): record is WireRecord => record !== undefined);
-}
-
-/** Sessions are labelled by the folder they run in, never by a provider's own name for them. */
-export function workspaceLabel(directoryPath: string | undefined): string {
-  if (!directoryPath) return UNKNOWN_WORKSPACE_LABEL;
-  const label = path.basename(directoryPath.trim());
-  return label || UNKNOWN_WORKSPACE_LABEL;
-}
-
-/** Drops duplicate paths while keeping first-seen order. */
-export function uniquePaths(paths: readonly string[]): string[] {
-  return [...new Set(paths)];
-}
-
-/**
- * Places a project in time by the directory its sessions land in, which is the
- * one a new session moves. A project directory's own mtime stops moving the
- * moment a provider nests its transcripts inside it — nothing done to a session
- * afterwards reaches it — so ranking by it would rank a folder used every day
- * by the day the provider first wrote there. A project with no sessions
- * directory has no sessions, and takes none of the bound below.
- */
-async function projectSessionsDirectory(
-  project: DirectoryEntry,
-  sessionsDirectoryName: string | undefined,
-): Promise<ProjectSessionsDirectory | undefined> {
-  if (sessionsDirectoryName === undefined) {
-    return {
-      project,
-      sessionsDirectory: project.directoryPath,
-      mtimeMs: project.stats.mtimeMs,
-    };
-  }
-  const sessionsDirectory = path.join(project.directoryPath, sessionsDirectoryName);
-  const stats = await fileStats(sessionsDirectory);
-  if (!stats?.isDirectory()) return undefined;
-  return { project, sessionsDirectory, mtimeMs: stats.mtimeMs };
-}
-
-/**
- * Finds the newest session files across a provider's project directories. Both
- * levels are bounded and ordered by recency, so a machine with years of
- * projects costs the same pass as a machine with one. A directory's mtime does
- * not move when a file inside it is appended to, so the project bound keeps the
- * projects that most recently *started* a session; the session bound that
- * follows it is ordered by each transcript's own last write.
- */
-export async function discoverSessionFiles<Candidate extends SessionFileCandidate>(
-  discovery: SessionFileDiscovery<Candidate>,
-): Promise<Candidate[]> {
-  const entries = await readDirectory(discovery.projectsDirectory);
-  const projects = (
-    await Promise.all(
-      entries.map((entry) => statDirectoryEntry(discovery.projectsDirectory, entry.name)),
-    )
-  ).filter((entry): entry is DirectoryEntry => entry?.stats.isDirectory() === true);
-
-  const sessionsDirectories = (
-    await Promise.all(
-      projects.map((project) => projectSessionsDirectory(project, discovery.sessionsDirectoryName)),
-    )
-  )
-    .filter((entry): entry is ProjectSessionsDirectory => entry !== undefined)
-    .sort((first, second) => second.mtimeMs - first.mtimeMs)
-    .slice(0, discovery.maximumProjectDirectories);
-
-  const files = (
-    await Promise.all(
-      sessionsDirectories.map((entry) =>
-        discovery.sessionFilesIn(entry.sessionsDirectory, entry.project),
-      ),
-    )
-  ).flat();
-  // Newest first, so a duplicate session id resolves to its latest file.
-  // There is deliberately no cap: a conversation is never dropped for being
-  // old, and what keeps a pass cheap is each adapter re-reading only the
-  // files that changed since the last one.
-  return files.sort((first, second) => second.mtimeMs - first.mtimeMs);
 }

--- a/packages/providers/src/shared/local-sqlite.ts
+++ b/packages/providers/src/shared/local-sqlite.ts
@@ -1,5 +1,5 @@
 import { text, type UnparsedWireValue, type WireRecord, wholeNumber } from "@sidecar/wire";
-import { canIgnoreFilesystemError, fileStats } from "./local-session-adapter.js";
+import { canIgnoreFilesystemError, fileStats } from "./local-files.js";
 
 export function numberFromRow(row: WireRecord, key: string): number | undefined {
   return wholeNumber(row[key]);

--- a/packages/providers/src/shared/local-transcript.ts
+++ b/packages/providers/src/shared/local-transcript.ts
@@ -11,7 +11,7 @@
 
 import { OMISSION_MARKER, transcriptReadTailBytes } from "@sidecar/session";
 import { isRecord, isWireString, recordFromJsonLine, text, type WireRecord } from "@sidecar/wire";
-import { type FileWindow, fileStats, readRange, readTailWindow } from "./local-session-adapter.js";
+import { type FileWindow, fileStats, readRange, readTailWindow } from "./local-files.js";
 
 export const transcriptLine = {
   developer: (words: string) => `Developer: ${words}`,

--- a/packages/providers/src/shared/observation-pass.test.ts
+++ b/packages/providers/src/shared/observation-pass.test.ts
@@ -137,17 +137,7 @@ test("latest answers exactly what the last run published", async () => {
   assert.deepEqual(pass.latest(), observations);
 });
 
-test("forget drops the roster and every cached parse", async () => {
-  const { candidates, parses, pass } = harness();
-  candidates.push(candidate("one", 10));
-  await pass.run();
-  pass.forget();
-  assert.deepEqual(pass.latest(), []);
-  await pass.run();
-  assert.deepEqual(parses, ["/sessions/one.jsonl", "/sessions/one.jsonl"]);
-});
-
-test("a roster holder answers what it last published, and nothing after a forget", () => {
+test("a roster holder answers exactly what it last published", () => {
   const roster = rosterHolder();
   const published = roster.publish([
     {
@@ -158,6 +148,4 @@ test("a roster holder answers what it last published, and nothing after a forget
     },
   ]);
   assert.deepEqual(roster.latest(), published);
-  roster.forget();
-  assert.deepEqual(roster.latest(), []);
 });

--- a/packages/providers/src/shared/observation-pass.test.ts
+++ b/packages/providers/src/shared/observation-pass.test.ts
@@ -1,0 +1,163 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { type ProviderSessionObservation, SESSION_STATUS } from "@sidecar/session";
+import type { SessionFileCandidate } from "./local-files.js";
+import { observationPass, rosterHolder } from "./observation-pass.js";
+
+const NOW = Date.parse("2026-09-01T12:00:00.000Z");
+
+function candidate(
+  providerSessionId: string,
+  mtimeMs: number,
+  filePath = `/sessions/${providerSessionId}.jsonl`,
+): SessionFileCandidate {
+  return { filePath, providerSessionId, mtimeMs };
+}
+
+interface PassHarness {
+  candidates: SessionFileCandidate[];
+  parses: string[];
+  pass: ReturnType<typeof observationPass<SessionFileCandidate, string>>;
+}
+
+function harness(
+  observation?: (
+    input: Readonly<{ candidate: SessionFileCandidate; parsed: string }>,
+  ) => ProviderSessionObservation | undefined,
+): PassHarness {
+  const candidates: SessionFileCandidate[] = [];
+  const parses: string[] = [];
+  const pass = observationPass<SessionFileCandidate, string>({
+    now: () => NOW,
+    discover: async () => candidates,
+    parse: async (entry) => {
+      parses.push(entry.filePath);
+      return `${entry.filePath}@${entry.mtimeMs}`;
+    },
+    observation:
+      observation ??
+      (({ candidate: entry, parsed }) => ({
+        providerSessionId: entry.providerSessionId,
+        title: parsed,
+        status: SESSION_STATUS.WORKING,
+        lastActivityAt: entry.mtimeMs,
+      })),
+  });
+  return { candidates, parses, pass };
+}
+
+test("a file whose mtime has not moved is not parsed again", async () => {
+  const { candidates, parses, pass } = harness();
+  candidates.push(candidate("one", 10));
+  await pass.run();
+  await pass.run();
+  assert.deepEqual(parses, ["/sessions/one.jsonl"]);
+});
+
+test("a file whose mtime moved is parsed again", async () => {
+  const { candidates, parses, pass } = harness();
+  candidates.push(candidate("one", 10));
+  await pass.run();
+  candidates[0] = candidate("one", 11);
+  const observations = await pass.run();
+  assert.deepEqual(parses, ["/sessions/one.jsonl", "/sessions/one.jsonl"]);
+  assert.equal(observations[0]?.title, "/sessions/one.jsonl@11");
+});
+
+test("a vanished file's parse is pruned, so its return is a fresh read", async () => {
+  const { candidates, parses, pass } = harness();
+  candidates.push(candidate("one", 10));
+  await pass.run();
+  candidates.length = 0;
+  await pass.run();
+  candidates.push(candidate("one", 10));
+  await pass.run();
+  assert.deepEqual(parses, ["/sessions/one.jsonl", "/sessions/one.jsonl"]);
+});
+
+test("a session id two files claim resolves to the first the discovery ordered", async () => {
+  const { candidates, parses, pass } = harness();
+  candidates.push(
+    candidate("one", 20, "/sessions/newest.jsonl"),
+    candidate("one", 10, "/sessions/oldest.jsonl"),
+  );
+  const observations = await pass.run();
+  assert.equal(observations.length, 1);
+  assert.equal(observations[0]?.title, "/sessions/newest.jsonl@20");
+  assert.deepEqual(parses, ["/sessions/newest.jsonl"]);
+});
+
+test("a candidate the provider declines to observe leaves no row", async () => {
+  const { candidates, pass } = harness(({ candidate: entry }) =>
+    entry.providerSessionId === "hidden"
+      ? undefined
+      : {
+          providerSessionId: entry.providerSessionId,
+          title: entry.providerSessionId,
+          status: SESSION_STATUS.WORKING,
+          lastActivityAt: entry.mtimeMs,
+        },
+  );
+  candidates.push(candidate("hidden", 10), candidate("shown", 11));
+  const observations = await pass.run();
+  assert.deepEqual(
+    observations.map((observation) => observation.providerSessionId),
+    ["shown"],
+  );
+});
+
+test("prepare runs once per pass, before any parse", async () => {
+  const order: string[] = [];
+  const pass = observationPass<SessionFileCandidate, string>({
+    now: () => NOW,
+    discover: async () => [candidate("one", 10), candidate("two", 11)],
+    prepare: () => {
+      order.push("prepare");
+    },
+    parse: async (entry) => {
+      order.push(`parse:${entry.providerSessionId}`);
+      return entry.providerSessionId;
+    },
+    observation: ({ candidate: entry }) => ({
+      providerSessionId: entry.providerSessionId,
+      title: entry.providerSessionId,
+      status: SESSION_STATUS.WORKING,
+      lastActivityAt: entry.mtimeMs,
+    }),
+  });
+  await pass.run();
+  assert.deepEqual(order, ["prepare", "parse:one", "parse:two"]);
+});
+
+test("latest answers exactly what the last run published", async () => {
+  const { candidates, pass } = harness();
+  assert.deepEqual(pass.latest(), []);
+  candidates.push(candidate("one", 10));
+  const observations = await pass.run();
+  assert.deepEqual(pass.latest(), observations);
+});
+
+test("forget drops the roster and every cached parse", async () => {
+  const { candidates, parses, pass } = harness();
+  candidates.push(candidate("one", 10));
+  await pass.run();
+  pass.forget();
+  assert.deepEqual(pass.latest(), []);
+  await pass.run();
+  assert.deepEqual(parses, ["/sessions/one.jsonl", "/sessions/one.jsonl"]);
+});
+
+test("a roster holder answers what it last published, and nothing after a forget", () => {
+  const roster = rosterHolder();
+  const published = roster.publish([
+    {
+      providerSessionId: "one",
+      title: "one",
+      status: SESSION_STATUS.WORKING,
+      lastActivityAt: NOW,
+    },
+  ]);
+  assert.deepEqual(roster.latest(), published);
+  roster.forget();
+  assert.deepEqual(roster.latest(), []);
+});

--- a/packages/providers/src/shared/observation-pass.ts
+++ b/packages/providers/src/shared/observation-pass.ts
@@ -1,0 +1,108 @@
+import { OBSERVATION_WINDOW, type ProviderSessionObservation } from "@sidecar/session";
+import type { SessionFileCandidate } from "./local-files.js";
+
+/**
+ * The roster the latest pass published, and nothing else. Every act is
+ * re-validated against exactly this, so the one thing a provider has to get
+ * right is publishing it — which is why holding it is a function rather than
+ * a protected field a subclass could forget to write.
+ */
+export interface RosterHolder {
+  publish(
+    observations: readonly ProviderSessionObservation[],
+  ): readonly ProviderSessionObservation[];
+  latest(): readonly ProviderSessionObservation[];
+  forget(): void;
+}
+
+export function rosterHolder(): RosterHolder {
+  let observations: readonly ProviderSessionObservation[] = [];
+  return {
+    publish(published) {
+      observations = published;
+      return observations;
+    },
+    latest: () => observations,
+    forget() {
+      observations = [];
+    },
+  };
+}
+
+/** Everything one file-backed provider decides about its own pass. */
+export interface ObservationPassInput<Candidate extends SessionFileCandidate, Parsed> {
+  now?: () => number;
+  discover(): Promise<readonly Candidate[]>;
+  /** Provider lookup state built once per pass, before any parse. */
+  prepare?(candidates: readonly Candidate[]): Promise<void> | void;
+  /** Called only for a candidate whose mtime moved since the last pass. */
+  parse(candidate: Candidate): Promise<Parsed>;
+  observation(input: {
+    readonly candidate: Candidate;
+    readonly parsed: Parsed;
+    readonly now: number;
+    readonly activeSessionFreshnessMs: number;
+  }): Promise<ProviderSessionObservation | undefined> | ProviderSessionObservation | undefined;
+}
+
+export interface ObservationPass {
+  /** Discover, prepare, parse only what changed, assemble, prune vanished parses. */
+  run(): Promise<readonly ProviderSessionObservation[]>;
+  /** The roster the last `run` published — what every act is re-validated against. */
+  latest(): readonly ProviderSessionObservation[];
+  /** Drops the roster and every cached parse. */
+  forget(): void;
+}
+
+/**
+ * The shared observation lifecycle for transcript-backed local providers:
+ * discover, prepare provider-specific lookup state, parse only changed files,
+ * assemble one observation per session, and prune parses for vanished files.
+ * A candidate list arrives newest-first, so a session id two files claim
+ * resolves to its latest file and the older one is skipped.
+ */
+export function observationPass<Candidate extends SessionFileCandidate, Parsed>(
+  input: ObservationPassInput<Candidate, Parsed>,
+): ObservationPass {
+  const now = input.now ?? Date.now;
+  const parsed = new Map<string, { mtimeMs: number; value: Parsed }>();
+  const roster = rosterHolder();
+
+  const parseAndCache = async (candidate: Candidate): Promise<Parsed> => {
+    const value = await input.parse(candidate);
+    parsed.set(candidate.filePath, { mtimeMs: candidate.mtimeMs, value });
+    return value;
+  };
+
+  return {
+    async run() {
+      const observedAt = now();
+      const candidates = await input.discover();
+      await input.prepare?.(candidates);
+      const observations = new Map<string, ProviderSessionObservation>();
+      for (const candidate of candidates) {
+        if (observations.has(candidate.providerSessionId)) continue;
+        const cached = parsed.get(candidate.filePath);
+        const value =
+          cached?.mtimeMs === candidate.mtimeMs ? cached.value : await parseAndCache(candidate);
+        const observation = await input.observation({
+          candidate,
+          parsed: value,
+          now: observedAt,
+          activeSessionFreshnessMs: OBSERVATION_WINDOW.ACTIVE_SESSION_FRESHNESS_MS,
+        });
+        if (observation) observations.set(candidate.providerSessionId, observation);
+      }
+      const discovered = new Set(candidates.map((candidate) => candidate.filePath));
+      for (const filePath of parsed.keys()) {
+        if (!discovered.has(filePath)) parsed.delete(filePath);
+      }
+      return roster.publish([...observations.values()]);
+    },
+    latest: () => roster.latest(),
+    forget() {
+      parsed.clear();
+      roster.forget();
+    },
+  };
+}

--- a/packages/providers/src/shared/observation-pass.ts
+++ b/packages/providers/src/shared/observation-pass.ts
@@ -12,7 +12,6 @@ export interface RosterHolder {
     observations: readonly ProviderSessionObservation[],
   ): readonly ProviderSessionObservation[];
   latest(): readonly ProviderSessionObservation[];
-  forget(): void;
 }
 
 export function rosterHolder(): RosterHolder {
@@ -23,9 +22,6 @@ export function rosterHolder(): RosterHolder {
       return observations;
     },
     latest: () => observations,
-    forget() {
-      observations = [];
-    },
   };
 }
 
@@ -50,8 +46,6 @@ export interface ObservationPass {
   run(): Promise<readonly ProviderSessionObservation[]>;
   /** The roster the last `run` published — what every act is re-validated against. */
   latest(): readonly ProviderSessionObservation[];
-  /** Drops the roster and every cached parse. */
-  forget(): void;
 }
 
 /**
@@ -100,9 +94,5 @@ export function observationPass<Candidate extends SessionFileCandidate, Parsed>(
       return roster.publish([...observations.values()]);
     },
     latest: () => roster.latest(),
-    forget() {
-      parsed.clear();
-      roster.forget();
-    },
   };
 }

--- a/packages/providers/src/shared/observation-pass.ts
+++ b/packages/providers/src/shared/observation-pass.ts
@@ -37,6 +37,11 @@ export interface ObservationPassInput<Candidate extends SessionFileCandidate, Pa
     readonly candidate: Candidate;
     readonly parsed: Parsed;
     readonly now: number;
+    /**
+     * The window the build fixes, handed over rather than imported so a
+     * provider's own status lattice reads it from the pass that dated the
+     * observation and cannot decay against a different clock.
+     */
     readonly activeSessionFreshnessMs: number;
   }): Promise<ProviderSessionObservation | undefined> | ProviderSessionObservation | undefined;
 }

--- a/packages/providers/src/shared/workspace-host-snapshot.ts
+++ b/packages/providers/src/shared/workspace-host-snapshot.ts
@@ -1,54 +1,22 @@
-import {
-  type ProviderSessionObservation,
-  SESSION_LOCATION,
-  type SessionApplicationId,
-  type SessionWorkspace,
-} from "@sidecar/session";
-import { text } from "@sidecar/wire";
+import type { ProviderSessionObservation, SessionApplicationId } from "@sidecar/session";
+import { type HostClaims, hostClaims, type WorkspaceHostContexts } from "./host-claims.js";
 
 /**
- * What one workspace manager's own records say about the sessions it holds,
- * keyed by the agent provider Luke already observes each session under and
- * then by the provider's own session id.
- */
-export type WorkspaceHostContexts<Context> = ReadonlyMap<string, ReadonlyMap<string, Context>>;
-
-/**
- * One chat is grouped by exactly one manager however many of them hold it, so
- * a claim lands only where no manager earlier in the enrichment order already
- * grouped the chat.
- */
-export function unclaimedWorkspace(
-  observation: ProviderSessionObservation,
-  claim: SessionWorkspace,
-): SessionWorkspace | undefined {
-  return observation.workspace ? undefined : claim;
-}
-
-/**
- * One local workspace manager's observed index of the agent sessions it
- * holds, annotating already-observed rows without ever making a provider's
- * own observation disappear: an absent app or an unreadable index is an empty
- * snapshot, and an empty snapshot changes nothing. Only local observations
- * can match a local manager's index — a cloud row with a coincidentally equal
- * provider id is never annotated — and a sub-agent inherits its nearest
- * indexed ancestor's context: the child is the manager's work even though
- * only the parent reached the manager's records. A row already carrying this
- * manager's association is left exactly as it stands.
+ * The class-shaped reading of {@link hostClaims}, for the managers whose
+ * readers are still classes. Everything a claim decides lives in that
+ * function; what a subclass supplies is the association, whether a matched
+ * row stands, and the annotation itself.
  */
 export abstract class WorkspaceHostSnapshot<Context> {
-  readonly #sessionsByProvider: WorkspaceHostContexts<Context>;
+  readonly #contexts: WorkspaceHostContexts<Context>;
+  #claims: HostClaims | undefined;
 
   constructor(sessionsByProvider: WorkspaceHostContexts<Context> = new Map()) {
-    this.#sessionsByProvider = sessionsByProvider;
+    this.#contexts = sessionsByProvider;
   }
 
   /** The association whose presence on a row means it is already annotated. */
   protected abstract readonly applicationId: SessionApplicationId;
-
-  has(providerId: string, providerSessionId: string): boolean {
-    return this.#sessionsByProvider.get(providerId)?.has(providerSessionId) === true;
-  }
 
   /**
    * Whether a matched row should stand at all. Conductor drops a chat its
@@ -65,42 +33,29 @@ export abstract class WorkspaceHostSnapshot<Context> {
     hostSessions: ReadonlyMap<string, Context>,
   ): ProviderSessionObservation;
 
+  /**
+   * A subclass's own fields are not assigned while the base constructor runs
+   * and `applicationId` is one of them, so the claims are built on first use.
+   */
+  #resolved(): HostClaims {
+    this.#claims ??= hostClaims<Context>({
+      applicationId: this.applicationId,
+      contexts: this.#contexts,
+      retains: (context) => this.retains(context),
+      annotate: ({ observation, context, hostSessions }) =>
+        this.annotate(observation, context, hostSessions),
+    });
+    return this.#claims;
+  }
+
+  has(providerId: string, providerSessionId: string): boolean {
+    return this.#resolved().has(providerId, providerSessionId);
+  }
+
   enrich(
     providerId: string,
     observations: readonly ProviderSessionObservation[],
   ): readonly ProviderSessionObservation[] {
-    const hostSessions = this.#sessionsByProvider.get(providerId);
-    if (!hostSessions) return observations;
-
-    const localObservationsById = new Map(
-      observations
-        .filter((observation) => observation.location !== SESSION_LOCATION.CLOUD)
-        .map((observation) => [observation.providerSessionId, observation] as const),
-    );
-
-    const contextFor = (observation: ProviderSessionObservation): Context | undefined => {
-      if (observation.location === SESSION_LOCATION.CLOUD) return undefined;
-      let sessionId: string | undefined = observation.providerSessionId;
-      const visited = new Set<string>();
-      while (sessionId && !visited.has(sessionId)) {
-        const context = hostSessions.get(sessionId);
-        if (context) return context;
-        visited.add(sessionId);
-        sessionId = text(localObservationsById.get(sessionId)?.parentProviderSessionId);
-      }
-      return undefined;
-    };
-
-    return observations.flatMap((observation) => {
-      const context = contextFor(observation);
-      if (context && !this.retains(context)) return [];
-      if (
-        !context ||
-        observation.applications?.some((application) => application.id === this.applicationId)
-      ) {
-        return [observation];
-      }
-      return [this.annotate(observation, context, hostSessions)];
-    });
+    return this.#resolved().enrich(providerId, observations);
   }
 }

--- a/packages/providers/src/shared/workspace-host-snapshot.ts
+++ b/packages/providers/src/shared/workspace-host-snapshot.ts
@@ -9,7 +9,6 @@ import { type HostClaims, hostClaims, type WorkspaceHostContexts } from "./host-
  */
 export abstract class WorkspaceHostSnapshot<Context> {
   readonly #contexts: WorkspaceHostContexts<Context>;
-  #claims: HostClaims | undefined;
 
   constructor(sessionsByProvider: WorkspaceHostContexts<Context> = new Map()) {
     this.#contexts = sessionsByProvider;
@@ -34,28 +33,28 @@ export abstract class WorkspaceHostSnapshot<Context> {
   ): ProviderSessionObservation;
 
   /**
-   * A subclass's own fields are not assigned while the base constructor runs
-   * and `applicationId` is one of them, so the claims are built on first use.
+   * The claims hold no state of their own, and `applicationId` is a subclass
+   * field that is not assigned while the base constructor runs, so they are
+   * built where they are asked for rather than held.
    */
-  #resolved(): HostClaims {
-    this.#claims ??= hostClaims<Context>({
+  #claims(): HostClaims {
+    return hostClaims<Context>({
       applicationId: this.applicationId,
       contexts: this.#contexts,
       retains: (context) => this.retains(context),
       annotate: ({ observation, context, hostSessions }) =>
         this.annotate(observation, context, hostSessions),
     });
-    return this.#claims;
   }
 
   has(providerId: string, providerSessionId: string): boolean {
-    return this.#resolved().has(providerId, providerSessionId);
+    return this.#claims().has(providerId, providerSessionId);
   }
 
   enrich(
     providerId: string,
     observations: readonly ProviderSessionObservation[],
   ): readonly ProviderSessionObservation[] {
-    return this.#resolved().enrich(providerId, observations);
+    return this.#claims().enrich(providerId, observations);
   }
 }

--- a/packages/providers/src/shared/workspace-hosts.ts
+++ b/packages/providers/src/shared/workspace-hosts.ts
@@ -1,4 +1,7 @@
 import type { ProviderSessionObservation } from "@sidecar/session";
+
+export type { WorkspaceHostEnrichment } from "./host-claims.js";
+
 import {
   type ClaudeDesktopSessionApplicationReader,
   ClaudeDesktopSessionApplicationSnapshot,
@@ -7,12 +10,7 @@ import {
   type ConductorSessionApplicationReader,
   ConductorSessionApplicationSnapshot,
 } from "../conductor/session-applications.js";
-
-/** One manager's annotation of one provider's already-observed sessions. */
-export type WorkspaceHostEnrichment = (
-  providerId: string,
-  observations: readonly ProviderSessionObservation[],
-) => readonly ProviderSessionObservation[];
+import type { WorkspaceHostEnrichment } from "./host-claims.js";
 
 /**
  * One workspace manager in the observation pass: how its own records become

--- a/packages/providers/src/testing/fixture-recording.ts
+++ b/packages/providers/src/testing/fixture-recording.ts
@@ -13,7 +13,7 @@ import {
   type JsonValue,
 } from "@sidecar/wire/testing";
 import { ADAPTER_FAILURE, AdapterFailure } from "../shared/adapter-failure.js";
-import type { CliRun } from "../shared/cli-session-adapter.js";
+import type { CliRun } from "../shared/cli-pass.js";
 
 /**
  * What a recorded provider fixture is, and how one is read back: the home a

--- a/packages/providers/src/testing/fixture-recording.ts
+++ b/packages/providers/src/testing/fixture-recording.ts
@@ -12,7 +12,8 @@ import {
   type JsonObject,
   type JsonValue,
 } from "@sidecar/wire/testing";
-import { CLI_FAILURE, CliCommandError, type CliRun } from "../shared/cli-session-adapter.js";
+import { ADAPTER_FAILURE, AdapterFailure } from "../shared/adapter-failure.js";
+import type { CliRun } from "../shared/cli-session-adapter.js";
 
 /**
  * What a recorded provider fixture is, and how one is read back: the home a
@@ -249,7 +250,7 @@ export async function recordedCli(
   return {
     run: async (_binary, argv) => {
       invocations.push(argv);
-      if (uninstalled) throw new CliCommandError(CLI_FAILURE.UNAVAILABLE, "no binary");
+      if (uninstalled) throw new AdapterFailure(ADAPTER_FAILURE.UNAVAILABLE, "no binary");
       const slug = invocationSlug(argv);
       if (slug === loginProbeSlug) return { exitCode: signedOut ? 1 : 0, stdout: "" };
       if (failing) return { exitCode: 1, stdout: "" };

--- a/packages/providers/src/testing/provider-contract.ts
+++ b/packages/providers/src/testing/provider-contract.ts
@@ -29,7 +29,7 @@ import {
   recordedRoutes,
   temporaryDirectory,
 } from "@sidecar/wire/testing";
-import type { CliRun } from "../shared/cli-session-adapter.js";
+import type { CliRun } from "../shared/cli-pass.js";
 import {
   assertGoldenJson,
   assertGoldenText,

--- a/packages/providers/src/testing/provider-contract.ts
+++ b/packages/providers/src/testing/provider-contract.ts
@@ -190,16 +190,29 @@ async function askAct(
       };
       return (await plugin.acts?.control?.(input({ control }))) ?? UNSUPPORTED;
     }
-    case ACT_KIND.ADD_AGENT:
+    case ACT_KIND.ADD_AGENT: {
+      // The dispatcher resolves the target from the advertisement, so the
+      // suite hands over exactly what the advertisement named.
+      const advertised = observation && advertisedActFor(observation, ACT_KIND.ADD_AGENT);
       return (
         (await plugin.acts?.spawnAgent?.(
-          input({ agent: overrides.agent ?? "contract-unadvertised-agent" }),
+          input({
+            spawnTarget: advertised?.target ?? providerSessionId,
+            agent: overrides.agent ?? "contract-unadvertised-agent",
+          }),
         )) ?? UNSUPPORTED
       );
+    }
     case ACT_KIND.RENAME_SESSION:
       return (await plugin.acts?.renameSession?.(input({ name: "contract" }))) ?? UNSUPPORTED;
-    case ACT_KIND.RENAME_WORKSPACE:
-      return (await plugin.acts?.renameWorkspace?.(input({ name: "contract" }))) ?? UNSUPPORTED;
+    case ACT_KIND.RENAME_WORKSPACE: {
+      const advertised = observation && advertisedActFor(observation, ACT_KIND.RENAME_WORKSPACE);
+      return (
+        (await plugin.acts?.renameWorkspace?.(
+          input({ renameTarget: advertised?.target ?? providerSessionId, name: "contract" }),
+        )) ?? UNSUPPORTED
+      );
+    }
   }
 }
 

--- a/packages/session/src/provider-plugin.test.ts
+++ b/packages/session/src/provider-plugin.test.ts
@@ -12,7 +12,13 @@ import {
   type ProviderWorkspaceRequest,
   SessionProviderAdapterBase,
 } from "./provider-contract.js";
-import { adapterAsPlugin } from "./provider-plugin.js";
+import {
+  adapterAsPlugin,
+  mergePlugins,
+  pluginAsAdapter,
+  type SessionProviderPlugin,
+  UNSUPPORTED_BY_OBSERVATION,
+} from "./provider-plugin.js";
 import type { ProviderSessionObservation } from "./session-shape.js";
 import { SESSION_STATUS } from "./session-status.js";
 import { WORKSPACE_TASK_SUPPORT, type WorkspaceProject } from "./workspace-projects.js";
@@ -118,8 +124,14 @@ test("carries every act and read to the adapter, naming the observation's own se
   await plugin.acts?.message?.({ request: { text: "ship it" }, observation: OBSERVATION });
   await plugin.acts?.control?.({ request: { control }, observation: OBSERVATION });
   await plugin.acts?.createWorkspace?.({ project: PROJECT, task: "start here" });
-  await plugin.acts?.spawnAgent?.({ request: { agent: "claude" }, observation: OBSERVATION });
-  await plugin.acts?.renameWorkspace?.({ request: { name: "notch" }, observation: OBSERVATION });
+  await plugin.acts?.spawnAgent?.({
+    request: { spawnTarget: "workspace-1", agent: "claude" },
+    observation: OBSERVATION,
+  });
+  await plugin.acts?.renameWorkspace?.({
+    request: { renameTarget: "workspace-1", name: "notch" },
+    observation: OBSERVATION,
+  });
   await plugin.acts?.renameSession?.({ request: { name: "notch" }, observation: OBSERVATION });
   await plugin.reads?.transcript?.("session-1");
   await plugin.reads?.transcriptSince?.("session-1", "cursor-1");
@@ -146,4 +158,156 @@ test("leaves an act the caller did not choose out of the request entirely", asyn
   await plugin.acts?.createWorkspace?.({ project: PROJECT });
 
   assert.deepEqual(adapter.asked, [{ providerProjectId: "project-1" }]);
+});
+
+/** A plugin observing one named session and answering every act firmly. */
+function stubPlugin(
+  providerId: string,
+  observations: readonly ProviderSessionObservation[],
+  answer: () => Promise<{ status: typeof ACT_RESULT_STATUS.ACCEPTED }>,
+  asked: string[],
+): SessionProviderPlugin {
+  return {
+    provider: { id: providerId, displayName: providerId },
+    observe: async () => observations,
+    latest: () => observations,
+    projects: () => [{ ...PROJECT, providerProjectId: `${providerId}-project` }],
+    acts: {
+      message: async () => {
+        asked.push(providerId);
+        return answer();
+      },
+    },
+  };
+}
+
+const ADVERTISING_OBSERVATION: ProviderSessionObservation = {
+  ...OBSERVATION,
+  advertises: [{ kind: ACT_KIND.MESSAGE }],
+};
+
+const CLOUD_OBSERVATION: ProviderSessionObservation = {
+  ...ADVERTISING_OBSERVATION,
+  providerSessionId: "session-cloud",
+};
+
+test("merged plugins answer one roster, with a repeated session named once", async () => {
+  const asked: string[] = [];
+  const accepted = async () => ({ status: ACT_RESULT_STATUS.ACCEPTED }) as const;
+  const local = stubPlugin("merged", [ADVERTISING_OBSERVATION], accepted, asked);
+  const cloud = stubPlugin("merged", [ADVERTISING_OBSERVATION, CLOUD_OBSERVATION], accepted, asked);
+  const merged = mergePlugins({ id: "merged", displayName: "Merged" }, [local, cloud]);
+
+  assert.deepEqual(
+    (await merged.observe()).map((entry) => entry.providerSessionId),
+    ["session-1", "session-cloud"],
+  );
+  assert.deepEqual(
+    merged.projects?.().map((project) => project.providerProjectId),
+    ["merged-project", "merged-project"],
+  );
+});
+
+test("a merged pass fails whole rather than retiring the observer that answered", async () => {
+  const asked: string[] = [];
+  const accepted = async () => ({ status: ACT_RESULT_STATUS.ACCEPTED }) as const;
+  const working = stubPlugin("merged", [ADVERTISING_OBSERVATION], accepted, asked);
+  const failing: SessionProviderPlugin = {
+    provider: { id: "merged", displayName: "merged" },
+    observe: async () => {
+      throw new Error("the second observer failed");
+    },
+    latest: () => [],
+  };
+  const merged = mergePlugins({ id: "merged", displayName: "Merged" }, [working, failing]);
+
+  await assert.rejects(merged.observe(), /the second observer failed/);
+});
+
+test("an act moves past an observer that never saw the session and stops at a firm answer", async () => {
+  const asked: string[] = [];
+  const unaware: SessionProviderPlugin = {
+    provider: { id: "merged", displayName: "merged" },
+    observe: async () => [],
+    latest: () => [],
+    acts: {
+      message: async () => {
+        asked.push("unaware");
+        return { status: ACT_RESULT_STATUS.ACCEPTED };
+      },
+    },
+  };
+  const holder = stubPlugin(
+    "merged",
+    [ADVERTISING_OBSERVATION],
+    async () => ({ status: ACT_RESULT_STATUS.ACCEPTED }) as const,
+    asked,
+  );
+  const merged = mergePlugins({ id: "merged", displayName: "Merged" }, [unaware, holder]);
+  await merged.observe();
+
+  const result = await merged.acts?.message?.({
+    request: { text: "ship it" },
+    observation: ADVERTISING_OBSERVATION,
+  });
+
+  assert.deepEqual(result, { status: ACT_RESULT_STATUS.ACCEPTED });
+  // The unaware observer's own handler is never reached: its roster refused
+  // the session before the handler could be asked.
+  assert.deepEqual(asked, ["merged"]);
+});
+
+test("an act no observer holds answers unsupported once", async () => {
+  const unaware: SessionProviderPlugin = {
+    provider: { id: "merged", displayName: "merged" },
+    observe: async () => [],
+    latest: () => [],
+  };
+  const merged = mergePlugins({ id: "merged", displayName: "Merged" }, [unaware, unaware]);
+
+  assert.deepEqual(
+    await merged.acts?.message?.({
+      request: { text: "ship it" },
+      observation: ADVERTISING_OBSERVATION,
+    }),
+    { status: ACT_RESULT_STATUS.UNSUPPORTED, reason: "No provider observer supports that act." },
+  );
+});
+
+test("merging an observer of another provider is refused outright", () => {
+  const other: SessionProviderPlugin = {
+    provider: { id: "other", displayName: "Other" },
+    observe: async () => [],
+    latest: () => [],
+  };
+  assert.throws(
+    () => mergePlugins({ id: "merged", displayName: "Merged" }, [other]),
+    /Merged plugin for merged cannot observe other/,
+  );
+});
+
+test("an adapter read as a plugin and back answers every act the same way", async () => {
+  const adapter = new RecordingAdapter();
+  adapter.observations = [ADVERTISING_OBSERVATION];
+  const roundTripped = pluginAsAdapter(adapterAsPlugin(adapter));
+  await roundTripped.observe();
+
+  assert.deepEqual(await roundTripped.sendMessage({ providerSessionId: "session-1", text: "go" }), {
+    status: ACT_RESULT_STATUS.ACCEPTED,
+  });
+  assert.deepEqual(adapter.asked, [{ providerSessionId: "session-1", text: "go" }]);
+  assert.deepEqual(roundTripped.workspaceProjects(), [PROJECT]);
+});
+
+test("a round-tripped adapter still refuses a session the pass did not report", async () => {
+  const adapter = new RecordingAdapter();
+  adapter.observations = [ADVERTISING_OBSERVATION];
+  const roundTripped = pluginAsAdapter(adapterAsPlugin(adapter));
+  await roundTripped.observe();
+
+  assert.deepEqual(
+    await roundTripped.sendMessage({ providerSessionId: "session-absent", text: "go" }),
+    { status: ACT_RESULT_STATUS.UNSUPPORTED, reason: UNSUPPORTED_BY_OBSERVATION },
+  );
+  assert.deepEqual(adapter.asked, []);
 });

--- a/packages/session/src/provider-plugin.test.ts
+++ b/packages/session/src/provider-plugin.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { ACT_RESULT_STATUS } from "@sidecar/wire";
+import { ACT_RESULT_STATUS, UNSUPPORTED_BY_OBSERVATION } from "@sidecar/wire";
 import { ACT_KIND, SESSION_CONTROL_KIND } from "./advertised-acts.js";
 import {
   type ProviderControlRequest,
@@ -17,7 +17,6 @@ import {
   mergePlugins,
   pluginAsAdapter,
   type SessionProviderPlugin,
-  UNSUPPORTED_BY_OBSERVATION,
 } from "./provider-plugin.js";
 import type { ProviderSessionObservation } from "./session-shape.js";
 import { SESSION_STATUS } from "./session-status.js";

--- a/packages/session/src/provider-plugin.ts
+++ b/packages/session/src/provider-plugin.ts
@@ -1,3 +1,4 @@
+import { ACT_RESULT_STATUS } from "@sidecar/wire";
 import type {
   ProviderActResult,
   ProviderConversationResult,
@@ -5,13 +6,28 @@ import type {
   ProviderTranscriptSinceResult,
   ProviderWorkspaceResult,
 } from "./act-results.js";
-import type { AdvertisedControl } from "./advertised-acts.js";
-import type { ProviderConversationRequest, SessionProviderAdapter } from "./provider-contract.js";
+import {
+  ACT_KIND,
+  type AdvertisedControl,
+  advertisedActFor,
+  advertisedControl,
+} from "./advertised-acts.js";
+import { sessionMessageText, workspaceNameText } from "./bounds.js";
+import type {
+  ProviderControlRequest,
+  ProviderConversationRequest,
+  ProviderSessionMessage,
+  ProviderSessionRenameRequest,
+  ProviderWorkspaceAgentRequest,
+  ProviderWorkspaceRenameRequest,
+  ProviderWorkspaceRequest,
+  SessionProviderAdapter,
+} from "./provider-contract.js";
 import type { CliConnection } from "./provider-identity.js";
 import type { SessionProvider } from "./session-identity.js";
 import type { ProviderSessionObservation } from "./session-shape.js";
 import type { WorkspaceAgentSelection } from "./workspace-agents.js";
-import type { WorkspaceProject } from "./workspace-projects.js";
+import { WORKSPACE_TASK_SUPPORT, type WorkspaceProject } from "./workspace-projects.js";
 
 /**
  * A provider is a value: what it observes, the roster that pass published, and
@@ -61,6 +77,8 @@ export interface ActHandlers {
   createWorkspace(input: WorkspaceCreationInput): Promise<ProviderWorkspaceResult>;
   spawnAgent(
     input: ActInput<{
+      /** The workspace the observation's own `add-agent` advertisement named. */
+      readonly spawnTarget: string;
       readonly agent: string;
       readonly name?: string;
       readonly task?: string;
@@ -68,7 +86,13 @@ export interface ActHandlers {
       readonly effort?: string;
     }>,
   ): Promise<ProviderWorkspaceResult>;
-  renameWorkspace(input: ActInput<{ readonly name: string }>): Promise<ProviderActResult>;
+  renameWorkspace(
+    input: ActInput<{
+      /** The workspace the observation's own `rename-workspace` advertisement named. */
+      readonly renameTarget: string;
+      readonly name: string;
+    }>,
+  ): Promise<ProviderActResult>;
   renameSession(input: ActInput<{ readonly name: string }>): Promise<ProviderActResult>;
 }
 
@@ -147,6 +171,468 @@ export function adapterAsPlugin(adapter: SessionProviderAdapter): SessionProvide
           providerSessionId: observation.providerSessionId,
           ...request,
         }),
+    },
+  };
+}
+
+/**
+ * The one refusal an absent handler or an unobserved target answers with. It
+ * is deliberately the same wording for both: a caller learns that the latest
+ * observation does not support the act, and nothing about which of the two
+ * reasons it was.
+ */
+export const UNSUPPORTED_BY_OBSERVATION = "That act is not supported by the latest observation.";
+
+const unsupportedByObservation = {
+  status: ACT_RESULT_STATUS.UNSUPPORTED,
+  reason: UNSUPPORTED_BY_OBSERVATION,
+} as const;
+
+const NO_TRANSCRIPT = {
+  status: ACT_RESULT_STATUS.UNSUPPORTED,
+  reason: "This provider keeps no transcript this build can read.",
+} as const;
+
+const NO_CONVERSATION_READ = {
+  status: ACT_RESULT_STATUS.UNSUPPORTED,
+  reason: "This provider documents no conversation read this build carries.",
+} as const;
+
+/** What each act is asked with, before `dispatchAct` resolves its target. */
+export interface PluginActRequests {
+  message: ProviderSessionMessage;
+  control: ProviderControlRequest;
+  createWorkspace: ProviderWorkspaceRequest;
+  spawnAgent: ProviderWorkspaceAgentRequest;
+  renameWorkspace: ProviderWorkspaceRenameRequest;
+  renameSession: ProviderSessionRenameRequest;
+}
+
+/** What each act answers with. */
+export interface PluginActResults {
+  message: ProviderActResult;
+  control: ProviderActResult;
+  createWorkspace: ProviderWorkspaceResult;
+  spawnAgent: ProviderWorkspaceResult;
+  renameWorkspace: ProviderActResult;
+  renameSession: ProviderActResult;
+}
+
+export type PluginActKind = keyof PluginActRequests;
+
+type ActDispatchers = {
+  [Kind in PluginActKind]: (
+    plugin: SessionProviderPlugin,
+    request: PluginActRequests[Kind],
+  ) => Promise<PluginActResults[Kind]>;
+};
+
+function observationFor(
+  plugin: SessionProviderPlugin,
+  providerSessionId: string,
+): ProviderSessionObservation | undefined {
+  return plugin.latest().find((candidate) => candidate.providerSessionId === providerSessionId);
+}
+
+const ACT_DISPATCHERS: ActDispatchers = {
+  async message(plugin, request) {
+    const observation = observationFor(plugin, request.providerSessionId);
+    if (!observation || !advertisedActFor(observation, ACT_KIND.MESSAGE)) {
+      return unsupportedByObservation;
+    }
+    const text = sessionMessageText(request.text);
+    if (!text) {
+      return { status: ACT_RESULT_STATUS.REJECTED, reason: "That message is empty or too long." };
+    }
+    const handler = plugin.acts?.message;
+    if (!handler) return unsupportedByObservation;
+    return handler({ request: { text }, observation });
+  },
+
+  async control(plugin, request) {
+    const observation = observationFor(plugin, request.providerSessionId);
+    // The advertised control — not the caller's copy of it — is what the
+    // handler is given, so whatever it targets is the thing the last pass
+    // actually saw, and nothing a caller sends can redirect it.
+    const advertised = observation && advertisedControl(observation, request.control.id);
+    if (!observation || !advertised) return unsupportedByObservation;
+    const handler = plugin.acts?.control;
+    if (!handler) return unsupportedByObservation;
+    return handler({ request: { control: advertised }, observation });
+  },
+
+  async createWorkspace(plugin, request) {
+    const project = plugin
+      .projects?.()
+      .find((candidate) => candidate.providerProjectId === request.providerProjectId);
+    if (!project) return unsupportedByObservation;
+
+    const name = request.name === undefined ? undefined : workspaceNameText(request.name);
+    if (request.name !== undefined && !name) {
+      return {
+        status: ACT_RESULT_STATUS.REJECTED,
+        reason: "That workspace name is empty or too long.",
+      };
+    }
+    // The task is held to the project's own word for it, again here: the
+    // renderer already refused what it could, but a provider answers for its
+    // own writes.
+    const task = request.task === undefined ? undefined : sessionMessageText(request.task);
+    if (request.task !== undefined && !task) {
+      return { status: ACT_RESULT_STATUS.REJECTED, reason: "That task is empty or too long." };
+    }
+    if (task && project.taskSupport === WORKSPACE_TASK_SUPPORT.NONE) {
+      return { status: ACT_RESULT_STATUS.REJECTED, reason: "This project takes no opening task." };
+    }
+    if (!task && project.taskSupport === WORKSPACE_TASK_SUPPORT.REQUIRED) {
+      return {
+        status: ACT_RESULT_STATUS.REJECTED,
+        reason: "This project needs an opening task to create a workspace.",
+      };
+    }
+
+    const handler = plugin.acts?.createWorkspace;
+    if (!handler) return unsupportedByObservation;
+    return handler({
+      project,
+      ...(name === undefined ? undefined : { name }),
+      ...(task === undefined ? undefined : { task }),
+      ...(request.agentSelection === undefined
+        ? undefined
+        : { agentSelection: request.agentSelection }),
+    });
+  },
+
+  async spawnAgent(plugin, request) {
+    const observation = observationFor(plugin, request.providerSessionId);
+    if (!observation) return unsupportedByObservation;
+    // The advertised list — not the caller's word — is what the handler is
+    // given, so an agent kind is only ever one the last pass promised.
+    const addAgent = advertisedActFor(observation, ACT_KIND.ADD_AGENT);
+    const agent = addAgent?.agents.find((candidate) => candidate === request.agent);
+    if (!addAgent || !agent) return unsupportedByObservation;
+
+    const name = request.name === undefined ? undefined : workspaceNameText(request.name);
+    if (request.name !== undefined && !name) {
+      return {
+        status: ACT_RESULT_STATUS.REJECTED,
+        reason: "That session name is empty or too long.",
+      };
+    }
+    const task = request.task === undefined ? undefined : sessionMessageText(request.task);
+    if (request.task !== undefined && !task) {
+      return { status: ACT_RESULT_STATUS.REJECTED, reason: "That task is empty or too long." };
+    }
+
+    const handler = plugin.acts?.spawnAgent;
+    if (!handler) return unsupportedByObservation;
+    return handler({
+      request: {
+        spawnTarget: addAgent.target ?? request.providerSessionId,
+        agent,
+        ...(name === undefined ? undefined : { name }),
+        ...(task === undefined ? undefined : { task }),
+        ...(request.model === undefined ? undefined : { model: request.model }),
+        ...(request.effort === undefined ? undefined : { effort: request.effort }),
+      },
+      observation,
+    });
+  },
+
+  async renameWorkspace(plugin, request) {
+    const observation = observationFor(plugin, request.providerSessionId);
+    // The advertised target — not the caller's word — is what the handler is
+    // given, so a rename only ever lands on the workspace the last pass
+    // promised.
+    const advertised = observation && advertisedActFor(observation, ACT_KIND.RENAME_WORKSPACE);
+    if (!observation || !advertised) return unsupportedByObservation;
+
+    const name = workspaceNameText(request.name);
+    if (!name) {
+      return {
+        status: ACT_RESULT_STATUS.REJECTED,
+        reason: "That workspace name is empty or too long.",
+      };
+    }
+
+    const handler = plugin.acts?.renameWorkspace;
+    if (!handler) return unsupportedByObservation;
+    return handler({ request: { renameTarget: advertised.target, name }, observation });
+  },
+
+  async renameSession(plugin, request) {
+    const observation = observationFor(plugin, request.providerSessionId);
+    if (!observation || !advertisedActFor(observation, ACT_KIND.RENAME_SESSION)) {
+      return unsupportedByObservation;
+    }
+
+    const name = workspaceNameText(request.name);
+    if (!name) {
+      return {
+        status: ACT_RESULT_STATUS.REJECTED,
+        reason: "That session name is empty or too long.",
+      };
+    }
+
+    const handler = plugin.acts?.renameSession;
+    if (!handler) return unsupportedByObservation;
+    return handler({ request: { name }, observation });
+  },
+};
+
+/**
+ * The only route to an act handler. It resolves every target from the
+ * plugin's own latest roster — the advertised control, the `add-agent` and
+ * `rename-workspace` targets, and the target's own observation — so an act
+ * acts on what the pass saw and never on what a caller sent, holds the ask to
+ * its bound, and answers unsupported for a session the pass did not report or
+ * an act the plugin does not name.
+ */
+export function dispatchAct<Kind extends PluginActKind>(
+  plugin: SessionProviderPlugin,
+  kind: Kind,
+  request: PluginActRequests[Kind],
+): Promise<PluginActResults[Kind]> {
+  // SAFETY: the table is keyed by the same act kind the request and result
+  // types are, so the entry this key selects takes and answers exactly these.
+  const dispatch = ACT_DISPATCHERS[kind] as (
+    plugin: SessionProviderPlugin,
+    request: PluginActRequests[Kind],
+  ) => Promise<PluginActResults[Kind]>;
+  return dispatch(plugin, request);
+}
+
+/**
+ * The same dispatch for the two transcript reads. They are guarded by nothing
+ * but the plugin naming a handler: a transcript read reaches no provider and
+ * performs nothing, and the roster check that decides whether a session may
+ * be read at all is the host's, made before the ask arrives here.
+ */
+export function dispatchRead(
+  plugin: SessionProviderPlugin,
+  kind: "transcript",
+  providerSessionId: string,
+): Promise<ProviderTranscriptResult>;
+export function dispatchRead(
+  plugin: SessionProviderPlugin,
+  kind: "transcriptSince",
+  providerSessionId: string,
+  cursor?: string,
+): Promise<ProviderTranscriptSinceResult>;
+export async function dispatchRead(
+  plugin: SessionProviderPlugin,
+  kind: "transcript" | "transcriptSince",
+  providerSessionId: string,
+  cursor?: string,
+): Promise<ProviderTranscriptResult | ProviderTranscriptSinceResult> {
+  if (kind === "transcript") {
+    const handler = plugin.reads?.transcript;
+    return handler ? handler(providerSessionId) : NO_TRANSCRIPT;
+  }
+  const handler = plugin.reads?.transcriptSince;
+  return handler ? handler(providerSessionId, cursor) : NO_TRANSCRIPT;
+}
+
+/**
+ * The conversation read, dispatched like an act rather than like a transcript
+ * read: it reaches the provider, so it exists only for a session the latest
+ * pass reported, and the session it names is the observation's own.
+ */
+export async function dispatchConversation(
+  plugin: SessionProviderPlugin,
+  request: ProviderConversationRequest,
+): Promise<ProviderConversationResult> {
+  const observation = observationFor(plugin, request.providerSessionId);
+  if (!observation) return unsupportedByObservation;
+  const handler = plugin.reads?.conversation;
+  if (!handler) return NO_CONVERSATION_READ;
+  const { providerSessionId: _named, ...page } = request;
+  return handler({ request: page, observation });
+}
+
+/**
+ * Reads a plugin as the class-shaped adapter the host's seams still take, so
+ * a provider can become a plugin one at a time. It is the inverse of
+ * {@link adapterAsPlugin} and lives exactly as long as
+ * `SessionProviderAdapter` does.
+ */
+export function pluginAsAdapter(plugin: SessionProviderPlugin): SessionProviderAdapter {
+  return {
+    provider: plugin.provider,
+    observe: () => plugin.observe(),
+    workspaceProjects: () => plugin.projects?.() ?? [],
+    sendMessage: (message) => dispatchAct(plugin, "message", message),
+    executeControl: (request) => dispatchAct(plugin, "control", request),
+    createWorkspace: (request) => dispatchAct(plugin, "createWorkspace", request),
+    spawnWorkspaceAgent: (request) => dispatchAct(plugin, "spawnAgent", request),
+    renameWorkspace: (request) => dispatchAct(plugin, "renameWorkspace", request),
+    renameSession: (request) => dispatchAct(plugin, "renameSession", request),
+    readTranscript: (providerSessionId) => dispatchRead(plugin, "transcript", providerSessionId),
+    readTranscriptSince: (providerSessionId, cursor) =>
+      dispatchRead(plugin, "transcriptSince", providerSessionId, cursor),
+    readConversation: (request) => dispatchConversation(plugin, request),
+  };
+}
+
+/**
+ * One provider observed in more than one place — sessions on this machine and
+ * the same provider's sessions in its cloud. The registry replaces a
+ * provider's sessions in a single commit, so observers that share a provider
+ * id have to arrive as one plugin: registered separately, each pass would
+ * retire the other's sessions.
+ */
+export function mergePlugins(
+  provider: SessionProvider,
+  plugins: readonly SessionProviderPlugin[],
+): SessionProviderPlugin {
+  for (const plugin of plugins) {
+    // Observing one provider's sessions under another's identity is a wiring
+    // mistake rather than something a user can correct.
+    if (plugin.provider.id !== provider.id) {
+      throw new Error(`Merged plugin for ${provider.id} cannot observe ${plugin.provider.id}`);
+    }
+  }
+
+  /**
+   * Asks each observer in turn. Unsupported means this observer has never
+   * seen the subject, so the question moves on; any firm answer is the
+   * subject's own and ends the search.
+   */
+  const firstFirmAnswer = async <Result extends { status: string }>(
+    ask: (plugin: SessionProviderPlugin) => Promise<Result>,
+    exhausted: Result,
+  ): Promise<Result> => {
+    for (const plugin of plugins) {
+      const result = await ask(plugin);
+      if (result.status !== ACT_RESULT_STATUS.UNSUPPORTED) return result;
+    }
+    return exhausted;
+  };
+
+  const merged = (
+    collected: readonly (readonly ProviderSessionObservation[])[],
+  ): readonly ProviderSessionObservation[] => {
+    const observations = new Map<string, ProviderSessionObservation>();
+    // A session two observers both reached is still one session, and the
+    // registry rejects a snapshot that names one twice.
+    for (const observation of collected.flat()) {
+      if (!observations.has(observation.providerSessionId)) {
+        observations.set(observation.providerSessionId, observation);
+      }
+    }
+    return [...observations.values()];
+  };
+
+  const exhausted = {
+    status: ACT_RESULT_STATUS.UNSUPPORTED,
+    reason: "No provider observer supports that act.",
+  } as const;
+
+  return {
+    provider,
+
+    /**
+     * A pass fails whole. The registry commits a provider snapshot entire, so
+     * reporting the observers that answered would retire every session
+     * belonging to the one that did not, and the panel would lose them until
+     * it recovers.
+     */
+    async observe() {
+      return merged(await Promise.all(plugins.map((plugin) => plugin.observe())));
+    },
+
+    latest: () => merged(plugins.map((plugin) => plugin.latest())),
+
+    /** Every project any observer offered, in the order the observers stand in. */
+    projects: () => plugins.flatMap((plugin) => plugin.projects?.() ?? []),
+
+    acts: {
+      message: (input) =>
+        firstFirmAnswer(
+          (plugin) =>
+            dispatchAct(plugin, "message", {
+              providerSessionId: input.observation.providerSessionId,
+              text: input.request.text,
+            }),
+          exhausted,
+        ),
+      control: (input) =>
+        firstFirmAnswer(
+          (plugin) =>
+            dispatchAct(plugin, "control", {
+              providerSessionId: input.observation.providerSessionId,
+              control: input.request.control,
+            }),
+          exhausted,
+        ),
+      createWorkspace: (input) =>
+        firstFirmAnswer<ProviderWorkspaceResult>(
+          (plugin) =>
+            dispatchAct(plugin, "createWorkspace", {
+              providerProjectId: input.project.providerProjectId,
+              ...(input.name === undefined ? undefined : { name: input.name }),
+              ...(input.task === undefined ? undefined : { task: input.task }),
+              ...(input.agentSelection === undefined
+                ? undefined
+                : { agentSelection: input.agentSelection }),
+            }),
+          exhausted,
+        ),
+      spawnAgent: (input) =>
+        firstFirmAnswer<ProviderWorkspaceResult>(
+          (plugin) =>
+            dispatchAct(plugin, "spawnAgent", {
+              providerSessionId: input.observation.providerSessionId,
+              agent: input.request.agent,
+              ...(input.request.name === undefined ? undefined : { name: input.request.name }),
+              ...(input.request.task === undefined ? undefined : { task: input.request.task }),
+              ...(input.request.model === undefined ? undefined : { model: input.request.model }),
+              ...(input.request.effort === undefined
+                ? undefined
+                : { effort: input.request.effort }),
+            }),
+          exhausted,
+        ),
+      renameWorkspace: (input) =>
+        firstFirmAnswer(
+          (plugin) =>
+            dispatchAct(plugin, "renameWorkspace", {
+              providerSessionId: input.observation.providerSessionId,
+              name: input.request.name,
+            }),
+          exhausted,
+        ),
+      renameSession: (input) =>
+        firstFirmAnswer(
+          (plugin) =>
+            dispatchAct(plugin, "renameSession", {
+              providerSessionId: input.observation.providerSessionId,
+              name: input.request.name,
+            }),
+          exhausted,
+        ),
+    },
+
+    reads: {
+      transcript: (providerSessionId) =>
+        firstFirmAnswer<ProviderTranscriptResult>(
+          (plugin) => dispatchRead(plugin, "transcript", providerSessionId),
+          exhausted,
+        ),
+      transcriptSince: (providerSessionId, cursor) =>
+        firstFirmAnswer<ProviderTranscriptSinceResult>(
+          (plugin) => dispatchRead(plugin, "transcriptSince", providerSessionId, cursor),
+          exhausted,
+        ),
+      conversation: (input) =>
+        firstFirmAnswer<ProviderConversationResult>(
+          (plugin) =>
+            dispatchConversation(plugin, {
+              providerSessionId: input.observation.providerSessionId,
+              ...input.request,
+            }),
+          exhausted,
+        ),
     },
   };
 }

--- a/packages/session/src/provider-plugin.ts
+++ b/packages/session/src/provider-plugin.ts
@@ -1,4 +1,4 @@
-import { ACT_RESULT_STATUS } from "@sidecar/wire";
+import { ACT_RESULT_STATUS, UNSUPPORTED_BY_OBSERVATION } from "@sidecar/wire";
 import type {
   ProviderActResult,
   ProviderConversationResult,
@@ -144,13 +144,11 @@ export function adapterAsPlugin(adapter: SessionProviderAdapter): SessionProvide
 }
 
 /**
- * The one refusal an absent handler or an unobserved target answers with. It
- * is deliberately the same wording for both: a caller learns that the latest
+ * The one answer an absent handler and an unobserved target both give. The
+ * wording is deliberately the same for both: a caller learns that the latest
  * observation does not support the act, and nothing about which of the two
  * reasons it was.
  */
-export const UNSUPPORTED_BY_OBSERVATION = "That act is not supported by the latest observation.";
-
 const unsupportedByObservation = {
   status: ACT_RESULT_STATUS.UNSUPPORTED,
   reason: UNSUPPORTED_BY_OBSERVATION,

--- a/packages/session/src/provider-plugin.ts
+++ b/packages/session/src/provider-plugin.ts
@@ -123,44 +123,12 @@ export function adapterAsPlugin(adapter: SessionProviderAdapter): SessionProvide
     latest: () => observed,
     projects: () => adapter.workspaceProjects(),
     acts: {
-      message: ({ request, observation }) =>
-        adapter.sendMessage({
-          providerSessionId: observation.providerSessionId,
-          text: request.text,
-        }),
-      control: ({ request, observation }) =>
-        adapter.executeControl({
-          providerSessionId: observation.providerSessionId,
-          control: request.control,
-        }),
-      createWorkspace: (input) =>
-        adapter.createWorkspace({
-          providerProjectId: input.project.providerProjectId,
-          ...(input.name === undefined ? undefined : { name: input.name }),
-          ...(input.task === undefined ? undefined : { task: input.task }),
-          ...(input.agentSelection === undefined
-            ? undefined
-            : { agentSelection: input.agentSelection }),
-        }),
-      spawnAgent: ({ request, observation }) =>
-        adapter.spawnWorkspaceAgent({
-          providerSessionId: observation.providerSessionId,
-          agent: request.agent,
-          ...(request.name === undefined ? undefined : { name: request.name }),
-          ...(request.task === undefined ? undefined : { task: request.task }),
-          ...(request.model === undefined ? undefined : { model: request.model }),
-          ...(request.effort === undefined ? undefined : { effort: request.effort }),
-        }),
-      renameWorkspace: ({ request, observation }) =>
-        adapter.renameWorkspace({
-          providerSessionId: observation.providerSessionId,
-          name: request.name,
-        }),
-      renameSession: ({ request, observation }) =>
-        adapter.renameSession({
-          providerSessionId: observation.providerSessionId,
-          name: request.name,
-        }),
+      message: (input) => adapter.sendMessage(ACT_REQUEST_FROM.message(input)),
+      control: (input) => adapter.executeControl(ACT_REQUEST_FROM.control(input)),
+      createWorkspace: (input) => adapter.createWorkspace(ACT_REQUEST_FROM.createWorkspace(input)),
+      spawnAgent: (input) => adapter.spawnWorkspaceAgent(ACT_REQUEST_FROM.spawnAgent(input)),
+      renameWorkspace: (input) => adapter.renameWorkspace(ACT_REQUEST_FROM.renameWorkspace(input)),
+      renameSession: (input) => adapter.renameSession(ACT_REQUEST_FROM.renameSession(input)),
     },
     reads: {
       transcript: (providerSessionId) => adapter.readTranscript(providerSessionId),
@@ -381,6 +349,49 @@ const ACT_DISPATCHERS: ActDispatchers = {
 };
 
 /**
+ * The ask each act's handler input was built from. `dispatchAct` resolves an
+ * ask into a handler input; a caller holding the input and needing the ask
+ * again — an adapter behind a plugin, or one of several observers being asked
+ * in turn — reads it back through here, so the two directions cannot drift.
+ */
+export type ActRequestFrom = {
+  [Kind in PluginActKind]: (input: Parameters<ActHandlers[Kind]>[0]) => PluginActRequests[Kind];
+};
+
+export const ACT_REQUEST_FROM: ActRequestFrom = {
+  message: ({ request, observation }) => ({
+    providerSessionId: observation.providerSessionId,
+    text: request.text,
+  }),
+  control: ({ request, observation }) => ({
+    providerSessionId: observation.providerSessionId,
+    control: request.control,
+  }),
+  createWorkspace: (input) => ({
+    providerProjectId: input.project.providerProjectId,
+    ...(input.name === undefined ? undefined : { name: input.name }),
+    ...(input.task === undefined ? undefined : { task: input.task }),
+    ...(input.agentSelection === undefined ? undefined : { agentSelection: input.agentSelection }),
+  }),
+  spawnAgent: ({ request, observation }) => ({
+    providerSessionId: observation.providerSessionId,
+    agent: request.agent,
+    ...(request.name === undefined ? undefined : { name: request.name }),
+    ...(request.task === undefined ? undefined : { task: request.task }),
+    ...(request.model === undefined ? undefined : { model: request.model }),
+    ...(request.effort === undefined ? undefined : { effort: request.effort }),
+  }),
+  renameWorkspace: ({ request, observation }) => ({
+    providerSessionId: observation.providerSessionId,
+    name: request.name,
+  }),
+  renameSession: ({ request, observation }) => ({
+    providerSessionId: observation.providerSessionId,
+    name: request.name,
+  }),
+};
+
+/**
  * The only route to an act handler. It resolves every target from the
  * plugin's own latest roster — the advertised control, the `add-agent` and
  * `rename-workspace` targets, and the target's own observation — so an act
@@ -528,6 +539,16 @@ export function mergePlugins(
     reason: "No provider observer supports that act.",
   } as const;
 
+  /** One act, asked of each observer in turn with the ask it was built from. */
+  const askEach = <Kind extends PluginActKind>(
+    kind: Kind,
+    input: Parameters<ActHandlers[Kind]>[0],
+  ): Promise<PluginActResults[Kind]> =>
+    firstFirmAnswer<PluginActResults[Kind]>(
+      (plugin) => dispatchAct(plugin, kind, ACT_REQUEST_FROM[kind](input)),
+      exhausted,
+    );
+
   return {
     provider,
 
@@ -547,70 +568,12 @@ export function mergePlugins(
     projects: () => plugins.flatMap((plugin) => plugin.projects?.() ?? []),
 
     acts: {
-      message: (input) =>
-        firstFirmAnswer(
-          (plugin) =>
-            dispatchAct(plugin, "message", {
-              providerSessionId: input.observation.providerSessionId,
-              text: input.request.text,
-            }),
-          exhausted,
-        ),
-      control: (input) =>
-        firstFirmAnswer(
-          (plugin) =>
-            dispatchAct(plugin, "control", {
-              providerSessionId: input.observation.providerSessionId,
-              control: input.request.control,
-            }),
-          exhausted,
-        ),
-      createWorkspace: (input) =>
-        firstFirmAnswer<ProviderWorkspaceResult>(
-          (plugin) =>
-            dispatchAct(plugin, "createWorkspace", {
-              providerProjectId: input.project.providerProjectId,
-              ...(input.name === undefined ? undefined : { name: input.name }),
-              ...(input.task === undefined ? undefined : { task: input.task }),
-              ...(input.agentSelection === undefined
-                ? undefined
-                : { agentSelection: input.agentSelection }),
-            }),
-          exhausted,
-        ),
-      spawnAgent: (input) =>
-        firstFirmAnswer<ProviderWorkspaceResult>(
-          (plugin) =>
-            dispatchAct(plugin, "spawnAgent", {
-              providerSessionId: input.observation.providerSessionId,
-              agent: input.request.agent,
-              ...(input.request.name === undefined ? undefined : { name: input.request.name }),
-              ...(input.request.task === undefined ? undefined : { task: input.request.task }),
-              ...(input.request.model === undefined ? undefined : { model: input.request.model }),
-              ...(input.request.effort === undefined
-                ? undefined
-                : { effort: input.request.effort }),
-            }),
-          exhausted,
-        ),
-      renameWorkspace: (input) =>
-        firstFirmAnswer(
-          (plugin) =>
-            dispatchAct(plugin, "renameWorkspace", {
-              providerSessionId: input.observation.providerSessionId,
-              name: input.request.name,
-            }),
-          exhausted,
-        ),
-      renameSession: (input) =>
-        firstFirmAnswer(
-          (plugin) =>
-            dispatchAct(plugin, "renameSession", {
-              providerSessionId: input.observation.providerSessionId,
-              name: input.request.name,
-            }),
-          exhausted,
-        ),
+      message: (input) => askEach("message", input),
+      control: (input) => askEach("control", input),
+      createWorkspace: (input) => askEach("createWorkspace", input),
+      spawnAgent: (input) => askEach("spawnAgent", input),
+      renameWorkspace: (input) => askEach("renameWorkspace", input),
+      renameSession: (input) => askEach("renameSession", input),
     },
 
     reads: {

--- a/packages/session/src/provider-plugin.ts
+++ b/packages/session/src/provider-plugin.ts
@@ -59,9 +59,18 @@ export interface ActInput<Request> {
   readonly observation: ProviderSessionObservation;
 }
 
-/** A user-asked creation, in a project the latest pass reported. */
+/**
+ * A user-asked creation, in a project the latest pass reported. `project` is
+ * the offered project itself, resolved by both the ask's project id and the
+ * target it named, because a provider may offer one repository on several
+ * hosts and the target is what tells those apart. The agent kind the ask
+ * carried rides along for a provider whose creation takes one; whether it is
+ * a kind that project permits is the handler's own check, since only the
+ * provider knows what its endpoint accepts.
+ */
 export interface WorkspaceCreationInput {
   readonly project: WorkspaceProject;
+  readonly agent?: string;
   readonly name?: string;
   readonly task?: string;
   readonly agentSelection?: WorkspaceAgentSelection;
@@ -228,9 +237,17 @@ const ACT_DISPATCHERS: ActDispatchers = {
   },
 
   async createWorkspace(plugin, request) {
+    // The target is part of resolving *which* project, not a field to pass
+    // along: a provider may report one repository on several hosts under one
+    // project id, and a creation that named a host must land on that host's.
     const project = plugin
       .projects?.()
-      .find((candidate) => candidate.providerProjectId === request.providerProjectId);
+      .find(
+        (candidate) =>
+          candidate.providerProjectId === request.providerProjectId &&
+          (request.providerTargetId === undefined ||
+            candidate.providerTargetId === request.providerTargetId),
+      );
     if (!project) return unsupportedByObservation;
 
     const name = request.name === undefined ? undefined : workspaceNameText(request.name);
@@ -261,6 +278,7 @@ const ACT_DISPATCHERS: ActDispatchers = {
     if (!handler) return unsupportedByObservation;
     return handler({
       project,
+      ...(request.agent === undefined ? undefined : { agent: request.agent }),
       ...(name === undefined ? undefined : { name }),
       ...(task === undefined ? undefined : { task }),
       ...(request.agentSelection === undefined
@@ -367,6 +385,12 @@ export const ACT_REQUEST_FROM: ActRequestFrom = {
   }),
   createWorkspace: (input) => ({
     providerProjectId: input.project.providerProjectId,
+    // Read back off the offered project, never the ask: a re-dispatch acts on
+    // the target the pass reported.
+    ...(input.project.providerTargetId === undefined
+      ? undefined
+      : { providerTargetId: input.project.providerTargetId }),
+    ...(input.agent === undefined ? undefined : { agent: input.agent }),
     ...(input.name === undefined ? undefined : { name: input.name }),
     ...(input.task === undefined ? undefined : { task: input.task }),
     ...(input.agentSelection === undefined ? undefined : { agentSelection: input.agentSelection }),


### PR DESCRIPTION
## What this is

PR **E7** of the repo-wide cleanup plan. Six base classes served eight
adapters, four of them with exactly one subclass. The inheritance encoded
guarantees as "override this protected seam and you take on its constraint",
which the compiler cannot check, and it forced every shared mechanic — roster
publication, message bounds, credential epochs, pass supersession, transcript
rendering, host claims — to be a `protected` member reachable only by
subclassing.

E7 lands the interface and the functions. It converts no provider: every
adapter still implements `SessionProviderAdapter`, and each base class is now
a thin shell over the function that holds its mechanics. E8–E13 convert the
providers one at a time and delete the shells.

| New home | What it holds |
| --- | --- |
| `session/provider-plugin.ts` | `dispatchAct` / `dispatchRead` / `dispatchConversation`, `UNSUPPORTED_BY_OBSERVATION`, `mergePlugins`, `pluginAsAdapter` |
| `providers/shared/adapter-failure.ts` | one `AdapterFailure` and `clearsObservedState` |
| `providers/shared/observation-pass.ts` | `observationPass`, `rosterHolder` |
| `providers/shared/cloud-pass.ts` | `cloudPass`, `credentialBoundRead`, the one authenticated write, `tolerateItemFailure` |
| `providers/shared/cli-pass.ts` | `cliPass`, `CliRun`, `defaultCliRun` |
| `providers/shared/cloud-wire.ts` | route and request shapes, the response readers, the bounds |
| `providers/shared/local-files.ts` | the bounded read-only filesystem half |
| `providers/shared/hook-status.ts` | `localSessionStatus`, `hookRefinedStatus` |
| `providers/shared/jsonl-transcript.ts` | `jsonlTranscriptReader` (was `local-transcript.ts`) |
| `providers/shared/host-claims.ts` | `hostClaims`, `unclaimedWorkspace`, `WorkspaceHostEnrichment` |
| `providers/claude-code/records.ts` | one `CLAUDE_TOOL_INPUT_KEYS` |

Six commits, in the plan's order:

1. `refactor(providers): one adapter failure`
2. `refactor(providers): split the local adapter file`
3. `refactor(providers): a cloud pass and a CLI pass are functions`
4. `feat(session): dispatchAct is the only route to a provider handler`
5. `refactor(providers): one transcript reader and one host-claims value`
6. `refactor(providers): one CLAUDE_TOOL_INPUT_KEY`

## ⚠ Trust boundary

`dispatchAct` is the new home of guards the adapter bases hold today, so the
old and new paths **run side by side** and are asserted equal until E8–E13
delete the old one. `shared/dispatch-act.test.ts` asks every act and read
twice — once through the surviving base-class method, once through
`dispatchAct` over the same adapter read as a plugin — and asserts both the
answers and the requests each issued are identical, across the unobserved,
unadvertised, rewritten-target, empty-text and over-long-text cases.

CLAUDE.md sentences touched, and where the rule now lives:

| Sentence | New home |
| --- | --- |
| "The one thing Luke may change about a session is what the user just asked to send it… each validated against the observed roster, and against that session's own advertisement of the acts its provider documents for it now, before an adapter sees it." | `dispatchAct` in `packages/session/src/provider-plugin.ts` — it resolves the target's observation, the advertised control, and the `add-agent` / `rename-workspace` targets from the plugin's own `latest()`, and answers `UNSUPPORTED_BY_OBSERVATION` for a session the pass did not report or an act the plugin does not name. The cloud and local bases keep the identical guards until their adapters convert. |
| "a rejection carries a reason the user can act on, never the message itself" | `dispatchAct`'s bound checks, over `sessionMessageText` / `workspaceNameText`, and the same checks still in `CloudSessionAdapter` / `LocalSessionAdapter`. |
| "A provider whose sessions exist only in a cloud service may read a user-supplied API key, but it must observe nothing until the user supplies one…" | `cloudPass` in `providers/shared/cloud-pass.ts` — the credential is read per pass, a missing or throwing read clears observed state, and the credential epoch bounds a slow read. |
| "a machine whose CLI is absent or signed out is observed as having nothing… signing the CLI out withdraws it on the next pass." | `cliPass` in `providers/shared/cli-pass.ts` — the login is probed every pass and again at every write, and never cached. |
| "Observation passes stay read-only by construction; where a provider's documented read answers only a POSTed query… observation sends a read document fixed by the build." | `cloudPass`'s `requestJson`: a `document` rides as a POST body under the one `query` key and nothing else; `write` is the only other request it can make. |
| "The read performs nothing, reaches no provider, and answers only for a local session whose provider's transcript this build documents reading." | `jsonlTranscriptReader` in `providers/shared/jsonl-transcript.ts` — bounded tail read, cursor arithmetic and per-line cuts in one place; it opens no file for writing and keeps nothing. |
| "Never write provider transcripts or session-state files." | Unchanged and still structural: `local-files.ts` is the only module that opens a provider file, and it opens for reading alone. |
| "A pass fails whole" (the registry commits a provider snapshot entire) | `mergePlugins` in `provider-plugin.ts`, with the comment recording why kept verbatim. |

The E6 contract suite, which states these constraints as tests over recorded
fixtures, was green before commit 1 and after every commit.

## Notes

- **`dispatchAct` does not take a `ValidatedAct`, and cannot.** E4 has landed
  (#812), but `ValidatedAct` lives in `@sidecar/acts`, which depends on
  `@sidecar/session` — so `provider-plugin.ts` cannot name it without
  inverting the package graph. `dispatchAct` takes the existing per-act
  request types (`PluginActRequests`) instead, and it is E5's job to decide
  where the brand is unwrapped on the way in. Nothing else about the spec's
  `dispatchAct` changes: it still re-resolves every target from the plugin's
  own roster and re-runs the bound checks, which is what the base classes it
  replaces do today.
- **B15 and C3 are not in this PR.** The E7 spec's commit sequence lists them
  as commits 6 and 7, but Part I assigns them their own PRs, so the
  speculative auth scheme, the hook-spec generality, and the `process` /
  `superset` package fold are left to them.
- **Codex's transcript module is untouched.** Its `.zst` refusal carries its
  own wording that `jsonlTranscriptReader` deliberately knows nothing about;
  the plan assigns that decision to E10, and wiring it here would have changed
  an answer.
- `apps/web`'s three `CloudFetch` imports now follow the type back to the wire
  package it was always re-exported from, since `cloud-session-adapter.ts` no
  longer re-exports it.

## Self-review

A thermonuclear-style structural pass and a ponytail-style over-engineering
pass over this diff, both applied in the last commit:

- **One behaviour defect, in the new seam itself.** Both providers that
  report a project per host — Superset, and Conductor's own local workspace
  creator — resolve a creation against the project id *and* the target the ask
  named, and fire against the target read back off the offered project.
  `dispatchAct` resolved by the id alone and dropped the target and the agent
  kind from the handler input, so a creation aimed at one host would have
  landed on whichever project shared the id, and a Superset plugin could never
  have seen the agent kind its own endpoint requires. Fixed, with four cases
  pinning it. Worth a reviewer's eye: the surviving `CloudSessionAdapter`
  still matches on the id alone, so this is the one place `dispatchAct` is
  deliberately *stricter* than the base it replaces rather than equal to it —
  the new cases read the resolution rather than the request it would issue,
  and the parallel run asserts equality only over asks that name no target.
- **The same translation stood in two places.** `adapterAsPlugin` and
  `mergePlugins` each rebuilt the same six requests out of the same handler
  inputs. `ACT_REQUEST_FROM` is that translation once, and `mergePlugins`'s six
  handlers collapse onto one `askEach` — 102 lines out, 65 in.
- **Logic in the wrong layer.** `tolerateItemFailure` is about failure
  semantics, not the cloud pass, so it moved to `adapter-failure.ts` beside
  `clearsObservedState`, which it is expressed in terms of.
- **A rule with two homes.** `cloudPass` read the credential inline in `run`
  and again in its `readApiKey` accessor, each applying "a settings read that
  fails is the same as no credential". One helper now.
- **Two lazy-init dances.** `LocalFileSessionAdapter` built its pass on first
  `observe` and `WorkspaceHostSnapshot` cached its claims on first use, both
  to dodge subclass field-initialisation order. The pass is now built in the
  constructor (every seam it reads is a prototype method or a base field
  already assigned) and the claims, which hold no state, are built where they
  are asked for.
- **A module cycle.** `host-claims.ts` imported `WorkspaceHostEnrichment` from
  `workspace-hosts.ts`, which imports the two application readers, which
  import `host-claims.ts`. The type now lives in `host-claims.ts` and
  `workspace-hosts.ts` re-exports it.
- **Dead generality I had added.** `CliSessionAdapter`'s `latest()` accessor
  had no caller and is gone; a `requestHeaders()` override seam nothing
  overrode became a declared value on the cloud profile. `CloudPass.report​Diagnostic`
  is kept: `registrations.test.ts` reaches the seam it backs.

- **Dead flexibility I had written.** `ObservationPass.forget()` and
  `RosterHolder.forget()` had one caller each, and both were their own tests:
  a file-backed provider has no credential to change, so nothing local ever
  drops its roster or its parse cache. Both are gone, and are three lines to
  add back beside a caller that wants them.

### Rebased on `b9838b3d`

Nine commits landed on `main` mid-review. Rebased three times with `git rebase
origin/main` (no merge commit), and two of them needed reconciling rather
than just resolving:

- **#817** gave the unsupported-by-observation sentence one home in
  `@sidecar/wire`. Every site this branch added or moved now reads it from
  there, so the branch does not reintroduce the copy-paste #817 removed.
  `git grep "That act is not supported by the latest observation"` → one
  definition.
- **#818** deleted the test-only transcript bounds and
  `activeSessionFreshnessMs` from the adapter options this branch was
  threading into `observationPass` and `jsonlTranscriptReader`. Both now take
  neither: the pass reads the freshness window the build fixes, and the reader
  reads the tail the build fixes and cuts no rendering at all — which is what
  production always did. The two tests those knobs existed for read the cut
  where the cut lives, the `boundedTranscript` call itself, which is #818's
  own cure; and Claude Code's transcript test builds the same reader the
  adapter builds, since what it tests is where a session's records live and
  what one renders as.

## Verification

- `./scripts/check.sh` — green (lint, typecheck, 4 test suites, build).
- `pnpm --filter @sidecar/providers test` — 447 pass, 0 fail.
- `pnpm --filter @sidecar/session test` — 75 pass, 0 fail.
- `git grep -n "CloudRequestError\|CLOUD_FAILURE\|CliCommandError\|CLI_FAILURE\|local-transcript"` → empty.
- `git grep -n "TOOL_INPUT_KEYS"` → one definition (`claude-code/records.ts`) and its two readers.
- No UI change, so no `verify.sh` run and no notch check: the diff touches
  `packages/providers`, `packages/session`, and three `apps/web` import lines.

## Size

`git diff --shortstat origin/main...`:

```
48 files changed, 3924 insertions(+), 1816 deletions(-)
```

Running total: **225,569** lines of TS/TSX/MJS/Swift, rebased on `b9838b3d` (from 223,461).

E7 is net **+2,108**, and deliberately so: it is the PR that lands the new
seam beside the old one. Roughly +1,030 of it is the new tests (`dispatch-act`
438, `cli-pass` 245, `observation-pass` 163, `host-claims` 150,
`adapter-failure` 32), and the rest is `dispatchAct` + `mergePlugins` +
`pluginAsAdapter` standing next to the six base classes and the composite
adapter they replace. E8–E13 delete those, and the plan's arithmetic for the
group has `providers` + `superset` src falling from 9,625 to ~7,400 and tests
from 13,036 to ~6,360.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/d7680db1-c029-46fb-a13c-81e67f14a0f0)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34308371770/artifacts/10087528950) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34308371770)

- Commit: `c0b46beb217ae1dbba95714868f4c757bd14b733`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->










