### PR TITLE
refactor(host): split composeHost into composers

### DIFF
--- a/apps/desktop/src/main/gateway/host-operator.ts
+++ b/apps/desktop/src/main/gateway/host-operator.ts
@@ -5,9 +5,14 @@ import type { CredentialProviderId } from "@sidecar/credentials";
 import type { AccountProvider, AccountSnapshot } from "@sidecar/credentials/snapshot";
 import type { AgentWireTrace } from "@sidecar/devtrace/vocabulary";
 import type { GatewayCallResult, GatewayClient } from "@sidecar/gateway";
-import { carried, GATEWAY_EVENT, GATEWAY_METHOD, gatewayEventReader } from "@sidecar/gateway";
+import {
+  carried,
+  GATEWAY_EVENT,
+  GATEWAY_METHOD,
+  gatewayEventReader,
+  RECEIVER_REPORT_KIND,
+} from "@sidecar/gateway";
 import type { AppGuideSnapshot } from "@sidecar/guide";
-import { RECEIVER_REPORT_KIND } from "@sidecar/host";
 import type { RealtimeConnection } from "@sidecar/hosted";
 import type { SupersetSignInSnapshot } from "@sidecar/providers/superset/sign-in-stage";
 import type { ConversationEntry, RealtimeDiagnostics } from "@sidecar/realtime";

--- a/packages/gateway/AGENTS.md
+++ b/packages/gateway/AGENTS.md
@@ -9,7 +9,10 @@ cannot be forgotten in a set beside it: `isMutatingGatewayMethod` reads the
 same entry the name came from, and the server demands an idempotency key from
 exactly the methods that flag says change something. Widening the method
 vocabulary or the event set is a product decision, not an implementation
-detail.
+detail. What a method's own parameters may say belongs here too, beside the
+entry that names it: `RECEIVER_REPORT_KIND` is the vocabulary of
+`receiver.report`, so the host that answers it and the client that sends it
+read the same three words from the contract rather than from each other.
 
 ## Three doors, because one of them reaches `ws`
 

--- a/packages/gateway/src/protocol.ts
+++ b/packages/gateway/src/protocol.ts
@@ -109,6 +109,15 @@ export const GATEWAY_METHOD =
 
 export type GatewayMethod = (typeof GATEWAY_METHOD)[keyof typeof GATEWAY_METHOD];
 
+/** How a `receiver.report` names the moment it reports. */
+export const RECEIVER_REPORT_KIND = {
+  BEGIN: "begin",
+  READY: "ready",
+  RESET: "reset",
+} as const;
+
+export type ReceiverReportKind = (typeof RECEIVER_REPORT_KIND)[keyof typeof RECEIVER_REPORT_KIND];
+
 const GATEWAY_METHODS_BY_NAME: ReadonlyMap<string, GatewayMethodEntry> = new Map(
   Object.values(GATEWAY_METHODS).map((entry) => [entry.name, entry]),
 );

--- a/packages/host/AGENTS.md
+++ b/packages/host/AGENTS.md
@@ -20,6 +20,25 @@ that line: the ipcMain registrations stayed in `apps/desktop/src/main/ipc/`,
 and resolving this Mac's EventKit helper bundle stayed in
 `apps/desktop/src/main/native/`.
 
+## One composition, seven concerns
+
+`composeHost` constructs, links, merges, and starts; it holds no state of a
+concern's own. Each concern is a composer — settings, account, issues,
+observation, calendars, speech, brain — that owns its own mutable state, its
+own timers, and the Gateway methods of its domain, and answers `start()` and
+`stop()` for exactly what it began. The merge folds their method tables into
+one and refuses a method two of them claim, so which concern answers a method
+is checked at construction rather than left to the fold's order.
+`client.bootstrap` is the one method no composer owns: it reads six of them,
+and giving it to any would hand that composer references to the other five.
+
+The concerns depend on each other in both directions in five places — the
+account's capability gate starts the loops whose owners read that gate, the
+calendars hold the speech that reconciles against them — so those edges are
+`link()`'s, listed once in the merge and held in a `LateRef` that throws by
+name when read before `link()` has run. Everything else is a constructor
+argument, in the order the composers are built.
+
 ## One drain, in one place
 
 `Host.stop()` is the whole quit, in the coordinator's fixed order:

--- a/packages/host/src/compose-account.ts
+++ b/packages/host/src/compose-account.ts
@@ -1,0 +1,261 @@
+import { PRODUCT_ACCOUNT_ACT, PRODUCT_EVENT } from "@sidecar/analytics";
+import { AccountClient, AccountSessionManager, accountGateOpen } from "@sidecar/credentials";
+import {
+  ACCOUNT_STATUS,
+  type AccountSnapshot,
+  isAccountProvider,
+} from "@sidecar/credentials/snapshot";
+import { AgentTraceWriter, tracedModelAdapter } from "@sidecar/devtrace";
+import { isAgentWireTrace } from "@sidecar/devtrace/vocabulary";
+import {
+  carried,
+  GATEWAY_EVENT,
+  GATEWAY_METHOD,
+  type GatewayMethodTable,
+  gatewayOk,
+  invalid,
+} from "@sidecar/gateway";
+import { VOICE_SOURCE_COUNTED_AS } from "@sidecar/settings";
+import { VoiceCapabilityAssembler } from "@sidecar/voice";
+import type { SettingsComposer } from "./compose-settings.js";
+import type { Composer } from "./composer.js";
+import type { HostKernel } from "./host-kernel.js";
+import { lateRef } from "./late-ref.js";
+import { transitionVoiceCredential } from "./voice-credential-transition.js";
+
+const ACCOUNT_CLIENT_ID = "luke-desktop";
+
+/**
+ * What the account reaches in the other concerns. The capability gate is the
+ * genuine cycle: signing in starts the loops, and the loops read the gate, so
+ * neither side can be the other's constructor argument.
+ */
+export interface AccountLinks {
+  startCapabilities: () => Promise<void>;
+  stopCapabilities: () => Promise<void>;
+  /** The calendar step of onboarding, raised before the account event so the gate already stands when the renderer learns of the sign-in. */
+  onFirstSignIn: () => void;
+  /** The arrival beat's own moment, recorded after the account event. */
+  onFirstSignInArrival: () => void;
+  retireBrain: () => void;
+  rebuildBrain: () => Promise<void>;
+  syncMemory: () => void;
+}
+
+export interface AccountComposer extends Composer {
+  readonly session: AccountSessionManager;
+  readonly voiceCapabilities: VoiceCapabilityAssembler;
+  readonly agentTrace: AgentTraceWriter | undefined;
+  snapshot: () => AccountSnapshot;
+  signedIn: () => boolean;
+  capabilitiesActive: () => boolean;
+  applyVoiceCredential: () => Promise<void>;
+  sessionReplayState: () => Promise<{ permitted: boolean; accountId?: string }>;
+  link: (links: AccountLinks) => void;
+}
+
+export interface AccountDependencies {
+  kernel: HostKernel;
+  settings: SettingsComposer;
+}
+
+export function composeAccount(dependencies: AccountDependencies): AccountComposer {
+  const { kernel, settings } = dependencies;
+  const { runMode, report, options } = kernel;
+  const links = lateRef<AccountLinks>("the account composer's links");
+
+  const client = new AccountClient({
+    baseUrl: kernel.accountBaseUrl,
+    clientId: ACCOUNT_CLIENT_ID,
+  });
+  let account: AccountSnapshot = { status: ACCOUNT_STATUS.SIGNED_OUT };
+
+  const session = new AccountSessionManager({
+    client,
+    store: settings.store,
+    hostedServiceBaseUrl: kernel.hostedServiceBaseUrl,
+    requiresAccount: runMode.requiresAccount,
+    openExternal: (url) => kernel.openExternalThroughNode(url),
+    startCapabilities: () => links.get().startCapabilities(),
+    stopCapabilities: () => links.get().stopCapabilities(),
+    onChange: (next) => {
+      const signedIn = next.status === ACCOUNT_STATUS.SIGNED_IN;
+      const wasSignedIn = account.status === ACCOUNT_STATUS.SIGNED_IN;
+      const previousAccountKey =
+        account.status === ACCOUNT_STATUS.SIGNED_IN ? account.email : undefined;
+      const nextAccountKey = signedIn ? next.email : undefined;
+      account = next;
+      if (previousAccountKey !== nextAccountKey) settings.forgetAccountPreferenceHydration();
+      if (signedIn && !wasSignedIn) links.get().onFirstSignIn();
+      kernel.emit(GATEWAY_EVENT.ACCOUNT_CHANGED, carried(account));
+      void settings.emitSettings();
+      void emitSessionReplay();
+      if (signedIn && !wasSignedIn) {
+        settings.recordProductEvent(PRODUCT_EVENT.ACCOUNT_SIGN_IN, {});
+        links.get().onFirstSignInArrival();
+      }
+    },
+  });
+
+  /**
+   * The development trace, gated so it cannot exist for a user: a packaged
+   * build never reads the variable, a fixture or evidence run has no traffic to
+   * tap and constructs no writer.
+   */
+  const agentTraceDirectory =
+    options.packaged || !runMode.sendsNetwork ? undefined : options.environment.LUKE_TRACE_DIR;
+  const agentTrace = agentTraceDirectory
+    ? new AgentTraceWriter({ directory: agentTraceDirectory })
+    : undefined;
+  if (agentTrace) report(`Agent trace: ${agentTrace.file}`);
+
+  function capabilitiesActive(): boolean {
+    return accountGateOpen(runMode, account.status === ACCOUNT_STATUS.SIGNED_IN);
+  }
+
+  const voiceCapabilities = new VoiceCapabilityAssembler({
+    settings: settings.store,
+    credentialsUsable: () => runMode.sendsNetwork && capabilitiesActive(),
+    fixtureRun: () => !runMode.sendsNetwork,
+    accountSignedIn: () => account.status === ACCOUNT_STATUS.SIGNED_IN,
+    hostedServiceBaseUrl: kernel.hostedServiceBaseUrl,
+    refreshAccount: session.refreshOnce,
+    ...(agentTrace
+      ? {
+          wrapBrainModel: (model) =>
+            tracedModelAdapter(model, (record) => agentTrace.recordBrainRequest(record)),
+        }
+      : undefined),
+  });
+
+  /**
+   * Whether an account was deleted in this run, which stands recording down
+   * for the rest of it; the client relays the answer to its renderers.
+   */
+  let sessionReplayEndedByDeletion = false;
+
+  async function sessionReplayState(): Promise<{ permitted: boolean; accountId?: string }> {
+    const signedIn = account.status === ACCOUNT_STATUS.SIGNED_IN;
+    const accountId = signedIn ? (await settings.store.readAccount())?.id : undefined;
+    return {
+      permitted: runMode.sendsNetwork && !sessionReplayEndedByDeletion,
+      ...(accountId ? { accountId } : undefined),
+    };
+  }
+
+  let sessionReplayGeneration = 0;
+  async function emitSessionReplay(): Promise<void> {
+    // The account is read asynchronously, and a sign-out reports the transition
+    // before it clears the stored account, so a late answer must not restart
+    // recording under the person who just left.
+    const generation = ++sessionReplayGeneration;
+    const replay = await sessionReplayState();
+    if (generation !== sessionReplayGeneration) return;
+    kernel.emit(GATEWAY_EVENT.SESSION_REPLAY_CHANGED, carried(replay));
+  }
+
+  async function applyVoiceCredential(): Promise<void> {
+    await transitionVoiceCredential({
+      retire: () => links.get().retireBrain(),
+      apply: () => voiceCapabilities.apply(),
+      rebuild: async () => {
+        await links.get().rebuildBrain();
+        links.get().syncMemory();
+      },
+    });
+  }
+
+  const methods: GatewayMethodTable = {
+    [GATEWAY_METHOD.ACCOUNT_SNAPSHOT]: () => gatewayOk({ account: carried(account) }),
+    [GATEWAY_METHOD.ACCOUNT_BEGIN_SIGN_IN]: async (params) => {
+      if (!isAccountProvider(params.provider))
+        return invalid("provider is not one this build knows");
+      settings.recordProductEvent(PRODUCT_EVENT.ACCOUNT_ACT, {
+        account_act: PRODUCT_ACCOUNT_ACT.SIGN_IN_START,
+      });
+      const snapshot = await session.beginSignIn(params.provider);
+      return gatewayOk({ account: carried(snapshot) });
+    },
+    [GATEWAY_METHOD.ACCOUNT_CANCEL_SIGN_IN]: () => {
+      settings.recordProductEvent(PRODUCT_EVENT.ACCOUNT_ACT, {
+        account_act: PRODUCT_ACCOUNT_ACT.SIGN_IN_CANCEL,
+      });
+      session.cancelSignIn();
+      return gatewayOk({});
+    },
+    [GATEWAY_METHOD.ACCOUNT_SIGN_OUT]: async () => {
+      settings.recordProductEvent(PRODUCT_EVENT.ACCOUNT_ACT, {
+        account_act: PRODUCT_ACCOUNT_ACT.SIGN_OUT,
+      });
+      // The count of the act leaves before the act ends the account it is
+      // authenticated with; queued behind the sign-out it would wait for the
+      // next sign-in.
+      await settings.flushProductEvents();
+      const snapshot = await session.signOut({ revokeRemote: true });
+      return gatewayOk({ account: carried(snapshot) });
+    },
+    [GATEWAY_METHOD.ACCOUNT_DELETE]: async () => {
+      settings.recordProductEvent(PRODUCT_EVENT.ACCOUNT_ACT, {
+        account_act: PRODUCT_ACCOUNT_ACT.DELETE,
+      });
+      await settings.flushProductEvents();
+      const snapshot = await session.deleteEverywhere();
+      // Only a deletion that landed stands recording down for the run.
+      sessionReplayEndedByDeletion = true;
+      void emitSessionReplay();
+      return gatewayOk({ account: carried(snapshot) });
+    },
+    // The one credential that crosses to the voice client: the short-lived
+    // realtime secret the account minter issues, never the key or the token
+    // behind it. Counted here, under the source it actually came from.
+    [GATEWAY_METHOD.VOICE_MINT_REALTIME_CREDENTIAL]: async () => {
+      const minter = voiceCapabilities.realtimeCredentials;
+      if (!minter) return gatewayOk({});
+      const credential = await minter.mint();
+      if (credential) {
+        settings.recordProductEvent(PRODUCT_EVENT.VOICE_CALL_START, {
+          credential_source: VOICE_SOURCE_COUNTED_AS[voiceCapabilities.voiceSource],
+        });
+      }
+      return gatewayOk(credential ? { credential: carried(credential) } : {});
+    },
+    [GATEWAY_METHOD.VOICE_DIAGNOSTICS]: () =>
+      gatewayOk({
+        diagnostics: carried(
+          voiceCapabilities.realtimeCredentials?.diagnostics() ??
+            voiceCapabilities.unavailableDiagnostics,
+        ),
+      }),
+    // One realtime event the renderer's tap saw cross the data channel, into
+    // the development trace. Read again here for the shape the tap sends; on
+    // a run without a writer — packaged, fixture, or simply untraced — it
+    // lands here and stops.
+    [GATEWAY_METHOD.VOICE_RECORD_TRACE]: (params) => {
+      if (!isAgentWireTrace(params.trace)) return invalid("trace is not one tapped wire event");
+      agentTrace?.recordWire(params.trace);
+      return gatewayOk({});
+    },
+  };
+
+  return {
+    methods,
+    session,
+    voiceCapabilities,
+    agentTrace,
+    snapshot: () => account,
+    signedIn: () => account.status === ACCOUNT_STATUS.SIGNED_IN,
+    capabilitiesActive,
+    applyVoiceCredential,
+    sessionReplayState,
+    link: (next) => links.set(next),
+    start: async () => {
+      account = runMode.requiresAccount
+        ? await settings.store.accountSnapshot()
+        : { status: ACCOUNT_STATUS.SIGNED_OUT };
+      session.initialize(account);
+    },
+    // The session manager holds no timer this host started: what a sign-in
+    // began is stopped by the capabilities it started, not here.
+    stop: async () => undefined,
+  };
+}

--- a/packages/host/src/compose-brain.ts
+++ b/packages/host/src/compose-brain.ts
@@ -1,0 +1,332 @@
+import fs from "node:fs";
+import { rememberedFactsText } from "@sidecar/acts";
+import { DeliveryLedger } from "@sidecar/brain";
+import type { BrainAppActRequest } from "@sidecar/brain/requests-wire";
+import { CREDENTIAL_PROVIDER_ID } from "@sidecar/credentials";
+import {
+  carried,
+  GATEWAY_METHOD,
+  type GatewayMethodTable,
+  gatewayOk,
+  invalid,
+  NODE_CAPABILITY_STATUS,
+} from "@sidecar/gateway";
+import {
+  type AppGuideSnapshot,
+  appGuideContextText,
+  EMPTY_APP_GUIDE,
+  isAppGuideSnapshot,
+} from "@sidecar/guide";
+import {
+  type ConversationEntry,
+  conversationHistoryText,
+  recentConversationEntries,
+  storedConversationEntry,
+  workspaceProjectContextText,
+} from "@sidecar/realtime";
+import {
+  CREDENTIAL_REFERENCE_KIND,
+  CronScheduler,
+  HEARTBEAT_DEFAULTS,
+  heartbeatJob,
+  LANE,
+} from "@sidecar/runtime";
+import {
+  CONVERSATION_KIND,
+  isIdentifier,
+  MAIN_SESSION_KEY,
+  sessionKey as toSessionKey,
+} from "@sidecar/runtime-contracts";
+import { VOICE_SOURCE } from "@sidecar/settings";
+import { ACT_RESULT_STATUS, isRecord, UNKNOWN_ACT_STATUS, type WireRecord } from "@sidecar/wire";
+import { wireBrain } from "./brain/wiring.js";
+import type { AccountComposer } from "./compose-account.js";
+import type { IssuesComposer } from "./compose-issues.js";
+import type { ObservationComposer } from "./compose-observation.js";
+import type { SettingsComposer } from "./compose-settings.js";
+import type { SpeechComposer } from "./compose-speech.js";
+import type { Composer } from "./composer.js";
+import { conversationOperations, startHistoryMaintenance } from "./conversation-operations.js";
+import type { HostKernel } from "./host-kernel.js";
+import { seedWorkspaceThenStartMemory } from "./lifecycle.js";
+import { wireMemoryMaintenance } from "./memory-maintenance.js";
+import { HOST_NODE_CAPABILITY } from "./node-capabilities.js";
+import {
+  composeNotebookMemory,
+  INERT_MEMORY_WIRING,
+  type MemoryWiring,
+} from "./notebook-memory.js";
+import type { GrantedWords } from "./service.js";
+import { agentRootPath } from "./store-path.js";
+import { wireRuntimeStore } from "./store-wiring.js";
+import { reporterOf } from "./wire-helpers.js";
+
+export type BrainWiring = ReturnType<typeof wireBrain>;
+export type RuntimeStoreWiring = ReturnType<typeof wireRuntimeStore>;
+
+export interface BrainComposer extends Composer {
+  readonly wiring: BrainWiring;
+  readonly store: RuntimeStoreWiring;
+  readonly conversations: ReturnType<typeof conversationOperations>;
+  readonly deliveries: DeliveryLedger<GrantedWords>;
+  readonly cron: CronScheduler;
+  memoryMode: () => ReturnType<MemoryWiring["mode"]>;
+  syncMemory: () => void;
+}
+
+export interface BrainDependencies {
+  kernel: HostKernel;
+  settings: SettingsComposer;
+  account: AccountComposer;
+  issues: IssuesComposer;
+  observation: ObservationComposer;
+  speech: SpeechComposer;
+}
+
+export function composeBrain(dependencies: BrainDependencies): BrainComposer {
+  const { kernel, account, issues, observation, speech } = dependencies;
+  const { runMode, report, now, createId } = kernel;
+
+  /**
+   * The runtime store and the conversation it holds: one retained thread
+   * shared by every panel window and persisted for the next launch. A window's
+   * report is appended under an opaque reporter the client minted, so the
+   * history event can skip echoing it to the window that reported it, and the
+   * reporter names nothing about the window to anyone else.
+   */
+  const store = wireRuntimeStore({
+    persistent: runMode.observesProviders,
+    createWorker: kernel.options.createWorker,
+    agentRoot: () => agentRootPath(kernel.stateRoot),
+    workspaceDirectory: kernel.agentWorkspacePath,
+    ensureDirectory: (directory) => fs.mkdirSync(directory, { recursive: true, mode: 0o700 }),
+    now,
+    createEventId: createId,
+    onHistoryChanged: (sessionKey, entries, except) =>
+      kernel.service().historyChanged(sessionKey, entries, except),
+    onDirectoryChanged: () => undefined,
+    report,
+  });
+  const deliveries = new DeliveryLedger<GrantedWords>({ nextDeliveryId: createId });
+  let appGuide: AppGuideSnapshot = EMPTY_APP_GUIDE;
+  let stopHistoryMaintenance: (() => void) | undefined;
+
+  const memory: MemoryWiring = runMode.observesProviders
+    ? composeNotebookMemory({
+        client: store.client,
+        embeddingAdapter: () => account.voiceCapabilities.embeddingAdapter,
+        workspaceDirectory: kernel.agentWorkspacePath,
+        conversationDirectory: () => store.directory(),
+        isTemporary: store.isTemporary,
+        now,
+        report,
+        onSynced: () => {
+          void store.refreshNotebook();
+        },
+      })
+    : INERT_MEMORY_WIRING;
+  const memoryMaintenance = wireMemoryMaintenance({
+    persistent: runMode.observesProviders,
+    client: store.client,
+    createRuntime: () => wiring.createRuntime(),
+    workspaceDirectory: kernel.agentWorkspacePath,
+    isTemporary: store.isTemporary,
+    now,
+    createId,
+    report,
+    onNotebookChanged: () => {
+      void memory.sync();
+    },
+  });
+
+  function standingContext(): string {
+    const sessions = observation.actableSessions();
+    const projects = observation.workspaceProjects();
+    const defaults = observation.heldWorkspaceDefaults();
+    return [
+      workspaceProjectContextText(projects, defaults.defaultProviderId, defaults.defaultProjectIds),
+      rememberedFactsText(store.rememberedFacts()),
+      conversationHistoryText(recentConversationEntries(store.thread().entries()), sessions),
+      appGuideContextText(appGuide),
+    ]
+      .filter((part): part is string => part !== undefined && part.trim().length > 0)
+      .join("\n\n");
+  }
+
+  /**
+   * Carries an app act only a renderer can perform to the native node, as the
+   * validated act itself, serialized: the node hands it to the panel and
+   * answers what became of it. No node connected, or one that answers in a
+   * shape this build cannot read, is a refusal, and the act is left undone.
+   */
+  async function performAppAct(action: BrainAppActRequest["action"]): Promise<WireRecord> {
+    const result = await kernel.nodes.invoke(HOST_NODE_CAPABILITY.PANEL_APP_ACT, {
+      action: carried(action),
+    });
+    if (result.status === NODE_CAPABILITY_STATUS.OK && isRecord(result.value)) return result.value;
+    if (result.status === NODE_CAPABILITY_STATUS.UNKNOWN) {
+      return { status: UNKNOWN_ACT_STATUS, reason: result.reason };
+    }
+    return {
+      status: ACT_RESULT_STATUS.REJECTED,
+      reason:
+        result.status === NODE_CAPABILITY_STATUS.OK
+          ? "The panel answered in a shape this build cannot read."
+          : result.reason,
+    };
+  }
+
+  const wiring = wireBrain({
+    repositoryFor: (sessionKey) => store.brainStateRepository(sessionKey),
+    ensureObservedConversation: async (sessionKey, name) => {
+      await store.ensureConversation(sessionKey, CONVERSATION_KIND.OBSERVED, name);
+    },
+    ensureChildConversation: async (sessionKey, name) => {
+      await store.ensureConversation(sessionKey, CONVERSATION_KIND.CHILD, name);
+    },
+    archiveConversation: (sessionKey) => store.archive(sessionKey),
+    conversationDirectory: () => store.directory(),
+    historyLines: (sessionKey) => store.thread(sessionKey).entries(),
+    childStore: () => store.childStore(),
+    createId,
+    report,
+    ...(account.agentTrace
+      ? { traceTurn: (record) => account.agentTrace?.recordBrainTurn(record) }
+      : undefined),
+    recordConversationEntry: (entry, recordedAt, sessionKey) =>
+      store.recordConversationEntry(entry, recordedAt, sessionKey),
+    broadcastRequests: (snapshots) => kernel.service().runsReported(snapshots),
+    onEndPublished: (record, sessionKey) => kernel.service().endPublished(record, sessionKey),
+    onGenerationReplaced: (sessionKey) => {
+      if (sessionKey === MAIN_SESSION_KEY) speech.withdrawBriefings();
+      kernel.service().generationReplaced(sessionKey);
+    },
+    acts: {
+      sessionActs: observation.sessionActs,
+      sessions: observation.actableSessions,
+      refreshSessions: () => observation.loop.refresh(),
+      workspaceProjects: observation.workspaceProjects,
+      workspaceDefaults: observation.workspaceDefaults,
+      trackedIssues: () => issues.issues(),
+      appGuide: () => appGuide,
+      rememberedFacts: store.rememberedFacts,
+      notebook: {
+        remember: store.rememberNotebookEntry,
+        forget: store.forgetNotebookEntry,
+      },
+      performAppAct: (action) => performAppAct(action),
+      recordConversationEntry: store.recordConversationEntry,
+    },
+    roster: observation.roster,
+    standingContext,
+    pluginFor: observation.pluginFor,
+    session: observation.session,
+    deliver: speech.deliverBriefing,
+    model: () => account.voiceCapabilities.brainModel,
+    credential: () =>
+      account.voiceCapabilities.voiceSource === VOICE_SOURCE.KEY
+        ? {
+            kind: CREDENTIAL_REFERENCE_KIND.PROVIDER_KEY,
+            providerId: CREDENTIAL_PROVIDER_ID.OPENAI,
+          }
+        : { kind: CREDENTIAL_REFERENCE_KIND.HOSTED_ACCOUNT },
+    workspaceDirectory: kernel.agentWorkspacePath,
+    skillRoots: () => [kernel.agentSkillsPath()],
+    runnable: () =>
+      runMode.observesProviders && runMode.sendsNetwork && account.capabilitiesActive(),
+    dropBriefings: speech.dropBriefings,
+    memory: (sessionKey) => memory.accessFor(sessionKey),
+    beforeCompaction: (sessionKey) => memoryMaintenance.flushHookFor(sessionKey),
+    flushMarker: (sessionKey) => memoryMaintenance.flushMarkerFor(sessionKey),
+    beforeReset: (sessionKey, items) => memoryMaintenance.captureBeforeReset(sessionKey, items),
+  });
+
+  const conversations = conversationOperations({
+    store,
+    brain: wiring,
+    now,
+    report,
+  });
+
+  const cron = new CronScheduler({
+    store: store.scheduledJobStore(),
+    coordinate: (work) => wiring.lanes.run(LANE.CRON, work),
+    // The heartbeat is the only job this build schedules. A row of any other
+    // id is one a build before this one left behind — the nightly memory
+    // consolidation, until now — and running it as a heartbeat would be a
+    // turn nothing asked for, so it is removed instead.
+    run: async (job) => {
+      if (job.id !== HEARTBEAT_DEFAULTS.JOB_ID) {
+        report(`A scheduled job this build does not run was removed: ${job.id}`);
+        await cron.remove(job.id);
+        return;
+      }
+      await wiring.heartbeat(job.sessionKey);
+    },
+    report,
+  });
+
+  const methods: GatewayMethodTable = {
+    [GATEWAY_METHOD.GUIDE_REPORT]: (params) => {
+      if (!isAppGuideSnapshot(params.guide))
+        return invalid("guide is not the shape a panel reports");
+      appGuide = params.guide;
+      return gatewayOk({});
+    },
+    [GATEWAY_METHOD.CONVERSATION_APPEND]: async (params) => {
+      const sessionKey =
+        params.sessionKey === undefined
+          ? MAIN_SESSION_KEY
+          : isIdentifier(params.sessionKey)
+            ? toSessionKey(params.sessionKey)
+            : undefined;
+      if (!sessionKey) return invalid("sessionKey must be a non-empty string");
+      if (!Array.isArray(params.entries)) return invalid("entries must be a list");
+      const entries: ConversationEntry[] = [];
+      for (const entry of params.entries) {
+        const stored = storedConversationEntry(entry);
+        if (!stored) return invalid("an entry is not the shape History keeps");
+        entries.push(stored);
+      }
+      const accepted = await store.thread(sessionKey).append(entries, reporterOf(params));
+      return gatewayOk({ accepted });
+    },
+  };
+
+  return {
+    methods,
+    wiring,
+    store,
+    conversations,
+    deliveries,
+    cron,
+    memoryMode: () => memory.mode(),
+    syncMemory: () => {
+      void memory.sync();
+    },
+    start: async () => {
+      if (!runMode.observesProviders) return;
+      await store.open();
+      await seedWorkspaceThenStartMemory({
+        seedWorkspace: async () => {
+          await wiring.seedWorkspace();
+        },
+        startMemory: () => memory.start(),
+        report,
+      });
+      await wiring.store().load();
+      await store.restore();
+      stopHistoryMaintenance = startHistoryMaintenance({ store, brain: wiring });
+      await cron.start();
+      await cron.ensure(heartbeatJob(now()));
+    },
+    stop: async () => {
+      stopHistoryMaintenance?.();
+      stopHistoryMaintenance = undefined;
+      cron.stop();
+      wiring.retire();
+      memory.stop();
+      await store.close();
+    },
+  };
+}

--- a/packages/host/src/compose-calendars.ts
+++ b/packages/host/src/compose-calendars.ts
@@ -1,0 +1,518 @@
+import { PRODUCT_CALENDAR_SOURCE, PRODUCT_EVENT, PRODUCT_SETTING_VALUE } from "@sidecar/analytics";
+import {
+  activeMeetingEnd,
+  GoogleCalendarReader,
+  GoogleCalendarSignIn,
+  type MeetingInterval,
+  nextMeetingBoundary,
+} from "@sidecar/calendar";
+import {
+  APPLE_CALENDAR_ACCESS,
+  APPLE_CALENDAR_ID,
+  CALENDAR_PRIVACY_PANE_URL,
+} from "@sidecar/calendar/vocabulary";
+import {
+  carried,
+  GATEWAY_EVENT,
+  GATEWAY_METHOD,
+  type GatewayMethodTable,
+  gatewayOk,
+  invalid,
+  NODE_CAPABILITY_STATUS,
+} from "@sidecar/gateway";
+import { ARRIVAL_SPEECH_KIND, CALENDAR_ONBOARDING_SPEECH_KIND } from "@sidecar/realtime";
+import { ObservationLoop } from "@sidecar/runtime";
+import { APP_SETTING_ID, APP_SETTING_SCHEMA } from "@sidecar/settings";
+import type { ObservedAccountCalendars } from "@sidecar/settings/wire";
+import { ACT_RESULT_STATUS, isWireBoolean, isWireString } from "@sidecar/wire";
+import {
+  APPLE_CALENDAR_ACCESS_REFUSAL,
+  type AppleCalendarHelperRun,
+  AppleCalendarReader,
+} from "./apple-calendar.js";
+import { calendarOnboardingOwed } from "./calendar-onboarding-flow.js";
+import type { SettingsComposer } from "./compose-settings.js";
+import type { Composer } from "./composer.js";
+import type { HostKernel } from "./host-kernel.js";
+import { lateRef } from "./late-ref.js";
+import { HOST_NODE_CAPABILITY } from "./node-capabilities.js";
+import { type OnboardingState, onboardingStateFile } from "./onboarding-state.js";
+import type { OnboardingBeatKind } from "./voice/speech-arbiter.js";
+import { reporterOf } from "./wire-helpers.js";
+
+/** A diary changes at the pace of hands too; five minutes is current. */
+const CALENDAR_REFRESH_INTERVAL_MS = 5 * 60_000;
+/**
+ * How often held notices ask whether the meeting holding them has ended. The
+ * question is answered from meetings already in memory, so asking often costs
+ * nothing. The boundary timer is what answers on time — this tick is the net
+ * behind it, for the clocks a timer cannot promise to keep: a laptop asleep
+ * through the boundary, or a system clock moved by hand.
+ */
+const HELD_NOTICE_RELEASE_INTERVAL_MS = 30_000;
+/**
+ * How often the System Settings switch is asked about between passes. Each
+ * probe is a fresh helper process on purpose: EventKit answers a running
+ * process's authorization from state it read at launch, so only a fresh
+ * process can be trusted about where the switch stands now. Ten seconds is
+ * the longest consent taken back keeps holding anything.
+ */
+const APPLE_ACCESS_POLL_INTERVAL_MS = 10_000;
+
+/** What the calendars reach in the speech the meetings hold. */
+export interface CalendarsLinks {
+  reconcileSpeech: () => void;
+  withdrawBeat: (kind: OnboardingBeatKind) => void;
+  /** The arbiter's held briefings go with the meetings that were holding them. */
+  dropBriefings: () => void;
+  /** The gate settling is where the beat that was waiting for it may speak. */
+  requestOnboardingBeat: () => void;
+}
+
+export interface CalendarsComposer extends Composer {
+  /** The loop the merge's supervisor enables; the composer never enables it itself. */
+  readonly loop: ObservationLoop;
+  observedCalendars: () => readonly ObservedAccountCalendars[];
+  announcementsQuietNow: (at: number) => Promise<boolean>;
+  /** Whether the calendar step of onboarding still stands over the panel. */
+  gateOwed: () => boolean;
+  gateOfferable: () => Promise<boolean>;
+  /** The onboarding record as it stands, for the beats that read their own moments out of it. */
+  onboarding: () => OnboardingState | undefined;
+  writeOnboarding: (moment: OnboardingState) => void;
+  /** The calendar step goes up at the first sign-in ever observed, before the account event. */
+  recordFirstSignIn: () => void;
+  startObservation: () => void;
+  stopObservation: () => void;
+  link: (links: CalendarsLinks) => void;
+}
+
+export interface CalendarsDependencies {
+  kernel: HostKernel;
+  settings: SettingsComposer;
+  observationGate: () => boolean;
+}
+
+export function composeCalendars(dependencies: CalendarsDependencies): CalendarsComposer {
+  const { kernel, settings, observationGate } = dependencies;
+  const { runMode, report, now } = kernel;
+  const settingsStore = settings.store;
+  const links = lateRef<CalendarsLinks>("the calendars composer's links");
+
+  const googleCalendar = new GoogleCalendarReader({
+    readAccounts: () => settingsStore.readCalendarAccounts(),
+  });
+  const googleCalendarSignIn = new GoogleCalendarSignIn({
+    openExternal: (url) => void kernel.openExternalThroughNode(url).catch(kernel.reportOpenFailure),
+  });
+  /**
+   * The EventKit helper runs on the desktop, where the device is: each
+   * invocation the reader composes — a command fixed by the build, the
+   * window's instants, the chosen calendar ids — crosses to the native node
+   * and its stdout comes back. No node connected is a failed read, which
+   * the reader answers by standing what it last showed, never by emptying
+   * a calendar on the strength of an absent desktop.
+   */
+  const runAppleCalendarHelper: AppleCalendarHelperRun = async (helperArguments, timeoutMs) => {
+    const result = await kernel.nodes.invoke(HOST_NODE_CAPABILITY.APPLE_CALENDAR_HELPER, {
+      arguments: [...helperArguments],
+      timeoutMs,
+    });
+    if (result.status !== NODE_CAPABILITY_STATUS.OK) throw new Error(result.reason);
+    if (!isWireString(result.value)) throw new Error("the helper answered no text");
+    return result.value;
+  };
+  const appleCalendar = new AppleCalendarReader({
+    readConnection: () => settingsStore.readAppleCalendarConnection(),
+    runHelper: runAppleCalendarHelper,
+    now,
+  });
+
+  let calendarMeetings: readonly MeetingInterval[] | undefined;
+  let quietBoundaryTimer: NodeJS.Timeout | undefined;
+  let observedCalendars: readonly ObservedAccountCalendars[] = [];
+  let heldNoticeReleaseTimer: NodeJS.Timeout | undefined;
+  let appleAccessPollTimer: NodeJS.Timeout | undefined;
+  let appleAccessProbeFailing = false;
+  let announcementsHeld = false;
+  let appleConnectGeneration = 0;
+
+  const onboarding = onboardingStateFile(() => kernel.stateRoot, report);
+  let onboardingState: OnboardingState | undefined;
+  let announcedCalendarGateOwed: boolean | undefined;
+
+  function calendarOnboardingGateOwed(): boolean {
+    return runMode.requiresAccount && calendarOnboardingOwed(onboardingState);
+  }
+
+  /**
+   * The one onboarding write, taking the moment it records and merging it over
+   * the record as it stands on disk — the client writes the
+   * introduction's own moment into the same file. Every moment lives in one
+   * record, so each write reconciles both beats; the gate event stays fenced
+   * on a changed answer, so writing an arrival moment cannot tell the renderer
+   * about a gate that did not move.
+   */
+  function writeOnboardingState(moment: OnboardingState): void {
+    onboardingState = onboarding.update((current) => ({ ...current, ...moment }));
+    if (moment.arrivalSpokenAt !== undefined) links.get().withdrawBeat(ARRIVAL_SPEECH_KIND);
+    const owed = calendarOnboardingGateOwed();
+    if (!owed) links.get().withdrawBeat(CALENDAR_ONBOARDING_SPEECH_KIND);
+    if (owed === announcedCalendarGateOwed) return;
+    announcedCalendarGateOwed = owed;
+    kernel.emit(GATEWAY_EVENT.CALENDAR_ONBOARDING_CHANGED, { owed });
+  }
+
+  async function settleCalendarOnboardingIfConnected(): Promise<void> {
+    if (!calendarOnboardingOwed(onboardingState)) return;
+    const connected = await settingsStore.calendarConnectionStored();
+    if (!connected || !calendarOnboardingOwed(onboardingState)) return;
+    writeOnboardingState({ calendarOnboardingSettledAt: new Date(now()).toISOString() });
+  }
+
+  async function calendarGateOfferable(): Promise<boolean> {
+    if (!calendarOnboardingGateOwed()) return false;
+    const snapshot = await settingsStore.snapshot();
+    if (!calendarOnboardingGateOwed()) return false;
+    return snapshot.status.appleCalendarAvailable || snapshot.status.calendarSignInAvailable;
+  }
+
+  async function announcementsQuietNow(at: number): Promise<boolean> {
+    const paused = !(await settingsStore.get(APP_SETTING_SCHEMA.announceSessions.field));
+    const inMeeting =
+      !paused &&
+      calendarMeetings !== undefined &&
+      activeMeetingEnd(calendarMeetings, at) !== undefined;
+    const holding =
+      paused ||
+      (inMeeting && (await settingsStore.get(APP_SETTING_SCHEMA.quietDuringMeetings.field)));
+    if (holding !== announcementsHeld) {
+      announcementsHeld = holding;
+      kernel.emit(GATEWAY_EVENT.ANNOUNCEMENTS_HELD_CHANGED, { held: holding });
+    }
+    return holding;
+  }
+
+  async function refreshAnnouncementHold(): Promise<void> {
+    await announcementsQuietNow(now());
+  }
+
+  function armQuietBoundaryTimer(): void {
+    if (quietBoundaryTimer) clearTimeout(quietBoundaryTimer);
+    quietBoundaryTimer = undefined;
+    if (!calendarMeetings) return;
+    const at = now();
+    const boundary = nextMeetingBoundary(calendarMeetings, at);
+    if (boundary === undefined) return;
+    quietBoundaryTimer = setTimeout(
+      () => {
+        quietBoundaryTimer = undefined;
+        links.get().reconcileSpeech();
+        armQuietBoundaryTimer();
+      },
+      boundary - at + 1,
+    );
+    quietBoundaryTimer.unref();
+  }
+
+  async function refreshCalendarMeetings(generation: number): Promise<void> {
+    try {
+      const [observations, appleObservation] = await Promise.all([
+        googleCalendar.observe(),
+        appleCalendar.observe(),
+      ]);
+      if (!loop.isCurrent(generation)) return;
+      const accounts = [...(observations ?? []), ...(appleObservation ? [appleObservation] : [])];
+      calendarMeetings =
+        observations === undefined && appleObservation === undefined
+          ? undefined
+          : accounts.flatMap((held) => [...held.meetings]);
+      observedCalendars = accounts.map(({ accountId, calendars, failure, revoked }) => ({
+        accountId,
+        calendars,
+        ...(failure ? { failure } : undefined),
+        ...(revoked ? { revoked } : undefined),
+      }));
+      kernel.emit(GATEWAY_EVENT.CALENDARS_CHANGED, { calendars: carried(observedCalendars) });
+      for (const held of accounts) {
+        if (held.failure) report(`Calendar observation failed: ${held.failure}`);
+      }
+    } catch (error) {
+      report(
+        `Calendar observation failed: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+    if (!loop.isCurrent(generation)) return;
+    links.get().reconcileSpeech();
+    armQuietBoundaryTimer();
+  }
+
+  const loop = new ObservationLoop({
+    gate: observationGate,
+    intervalMs: CALENDAR_REFRESH_INTERVAL_MS,
+    run: refreshCalendarMeetings,
+  });
+
+  async function pollAppleCalendarAccess(): Promise<void> {
+    if (!(await settingsStore.readAppleCalendarConnection())) return;
+    let access: string | undefined;
+    try {
+      access = await appleCalendar.status();
+    } catch (error) {
+      if (!appleAccessProbeFailing) {
+        report(
+          `Calendar access probe failed: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
+    }
+    appleAccessProbeFailing = access === undefined;
+    if (access === undefined) return;
+    const drawnRevoked =
+      observedCalendars.find((held) => held.accountId === APPLE_CALENDAR_ID)?.revoked === true;
+    const probeRevoked = access !== APPLE_CALENDAR_ACCESS.FULL;
+    if (probeRevoked !== drawnRevoked) {
+      report(`Calendar access now reads ${access}; running a pass.`);
+      void loop.refresh();
+    }
+  }
+
+  function startObservation(): void {
+    if (heldNoticeReleaseTimer) return;
+    heldNoticeReleaseTimer = setInterval(() => {
+      links.get().reconcileSpeech();
+    }, HELD_NOTICE_RELEASE_INTERVAL_MS);
+    heldNoticeReleaseTimer.unref();
+    if (process.platform === "darwin" && runMode.observesProviders) {
+      appleAccessPollTimer = setInterval(() => {
+        void pollAppleCalendarAccess();
+      }, APPLE_ACCESS_POLL_INTERVAL_MS);
+      appleAccessPollTimer.unref();
+    }
+  }
+
+  function stopObservation(): void {
+    if (heldNoticeReleaseTimer) clearInterval(heldNoticeReleaseTimer);
+    heldNoticeReleaseTimer = undefined;
+    if (appleAccessPollTimer) clearInterval(appleAccessPollTimer);
+    appleAccessPollTimer = undefined;
+    appleAccessProbeFailing = false;
+    if (quietBoundaryTimer) clearTimeout(quietBoundaryTimer);
+    quietBoundaryTimer = undefined;
+    calendarMeetings = undefined;
+    observedCalendars = [];
+    googleCalendar.forget();
+    appleCalendar.forget();
+    links.get().dropBriefings();
+    kernel.emit(GATEWAY_EVENT.CALENDARS_CHANGED, { calendars: [] });
+    void refreshAnnouncementHold();
+  }
+
+  const methods: GatewayMethodTable = {
+    [GATEWAY_METHOD.CALENDAR_CONNECT_GOOGLE]: async (params) => {
+      const result = await settings.settingsWrite(
+        async () => {
+          const outcome = await googleCalendarSignIn.signIn();
+          if ("reason" in outcome) return settings.refusedSettings(outcome.reason);
+          let primaryId: string | undefined;
+          try {
+            const calendars = await googleCalendar.listCalendars(outcome.accessToken);
+            primaryId = (calendars.find((candidate) => candidate.primary) ?? calendars[0])?.id;
+          } catch {
+            primaryId = undefined;
+          }
+          if (!primaryId) {
+            return settings.refusedSettings("Google did not answer with the account's calendars.");
+          }
+          return settingsStore.addCalendarAccount(primaryId, outcome.refreshToken, [primaryId]);
+        },
+        (saved) => {
+          if (saved.reason) return;
+          void loop.refresh();
+          settings.recordProductEvent(PRODUCT_EVENT.CALENDAR_CONNECT, {
+            calendar_source: PRODUCT_CALENDAR_SOURCE.GOOGLE,
+          });
+        },
+        "Could not connect Google Calendar on this system.",
+        reporterOf(params),
+      );
+      return gatewayOk(carried(result));
+    },
+    [GATEWAY_METHOD.CALENDAR_CANCEL_GOOGLE_SIGN_IN]: () => {
+      googleCalendarSignIn.cancel();
+      return gatewayOk({});
+    },
+    [GATEWAY_METHOD.CALENDAR_REOPEN_GOOGLE_SIGN_IN]: () => {
+      googleCalendarSignIn.reopen();
+      return gatewayOk({});
+    },
+    [GATEWAY_METHOD.CALENDAR_REMOVE_ACCOUNT]: async (params) => {
+      if (!isWireString(params.accountId)) return invalid("accountId must be a string");
+      const accountId = params.accountId;
+      const result = await settings.settingsWrite(
+        () => settingsStore.removeCalendarAccount(accountId),
+        (saved) => {
+          if (saved.reason) return;
+          void loop.refresh();
+          settings.recordProductEvent(PRODUCT_EVENT.CALENDAR_DISCONNECT, {
+            calendar_source: PRODUCT_CALENDAR_SOURCE.GOOGLE,
+          });
+        },
+        "Could not disconnect that account on this system.",
+        reporterOf(params),
+      );
+      return gatewayOk(carried(result));
+    },
+    [GATEWAY_METHOD.CALENDAR_CONNECT_APPLE]: async (params) => {
+      const generation = ++appleConnectGeneration;
+      let stored = false;
+      const result = await settings.settingsWrite(
+        async () => {
+          // The system's own consent is the whole connect flow, raised by the
+          // helper on the desktop at this press and nowhere else.
+          const outcome = await appleCalendar.obtainAccess({
+            openSystemSettings: () =>
+              void kernel
+                .openExternalThroughNode(CALENDAR_PRIVACY_PANE_URL)
+                .catch(kernel.reportOpenFailure),
+            superseded: () => appleConnectGeneration !== generation,
+          });
+          if (appleConnectGeneration !== generation) {
+            return { status: ACT_RESULT_STATUS.ACCEPTED, settings: await settingsStore.snapshot() };
+          }
+          if (outcome.access !== APPLE_CALENDAR_ACCESS.FULL) {
+            return settings.refusedSettings(
+              outcome.failure ?? APPLE_CALENDAR_ACCESS_REFUSAL[outcome.access],
+            );
+          }
+          const seed = outcome.defaultCalendarId ?? outcome.calendars[0]?.id;
+          stored = true;
+          return settingsStore.connectAppleCalendar(seed ? [seed] : []);
+        },
+        (saved) => {
+          if (saved.reason) return;
+          void loop.refresh();
+          if (stored) {
+            settings.recordProductEvent(PRODUCT_EVENT.CALENDAR_CONNECT, {
+              calendar_source: PRODUCT_CALENDAR_SOURCE.APPLE,
+            });
+          }
+        },
+        "Could not connect Apple Calendar on this system.",
+        reporterOf(params),
+      );
+      return gatewayOk(carried(result));
+    },
+    [GATEWAY_METHOD.CALENDAR_DISCONNECT_APPLE]: async (params) => {
+      const result = await settings.settingsWrite(
+        () => settingsStore.disconnectAppleCalendar(),
+        (saved) => {
+          if (saved.reason) return;
+          void loop.refresh();
+          settings.recordProductEvent(PRODUCT_EVENT.CALENDAR_DISCONNECT, {
+            calendar_source: PRODUCT_CALENDAR_SOURCE.APPLE,
+          });
+        },
+        "Could not disconnect Apple Calendar on this system.",
+        reporterOf(params),
+      );
+      return gatewayOk(carried(result));
+    },
+    [GATEWAY_METHOD.CALENDAR_APPLE_ACCESS_STATUS]: async () => {
+      try {
+        return gatewayOk({ access: await appleCalendar.status() });
+      } catch {
+        return gatewayOk({ access: APPLE_CALENDAR_ACCESS.NOT_DETERMINED });
+      }
+    },
+    [GATEWAY_METHOD.CALENDAR_CANCEL_APPLE_CONNECT]: () => {
+      appleConnectGeneration += 1;
+      return gatewayOk({});
+    },
+    [GATEWAY_METHOD.CALENDAR_REFRESH]: async () => {
+      await loop.refresh();
+      return gatewayOk({});
+    },
+    [GATEWAY_METHOD.CALENDAR_SET_SELECTED]: async (params) => {
+      if (!isWireString(params.accountId) || !isWireString(params.calendarId)) {
+        return invalid("accountId and calendarId must be strings");
+      }
+      if (!isWireBoolean(params.selected)) return invalid("selected must be a boolean");
+      const { accountId, calendarId, selected } = params;
+      if (
+        selected &&
+        !observedCalendars
+          .find((held) => held.accountId === accountId)
+          ?.calendars.some((candidate) => candidate.id === calendarId)
+      ) {
+        return gatewayOk(
+          carried(
+            await settings.refusedSettings(
+              "That calendar is not one the account's latest list offered.",
+            ),
+          ),
+        );
+      }
+      const result = await settings.settingsWrite(
+        () => settingsStore.setCalendarSelected(accountId, calendarId, selected),
+        (saved) => {
+          if (saved.reason) return;
+          void loop.refresh();
+          settings.recordProductEvent(PRODUCT_EVENT.SETTING_UPDATE, {
+            setting_id: APP_SETTING_ID.CALENDAR_SELECTED,
+            setting_value: selected ? PRODUCT_SETTING_VALUE.ON : PRODUCT_SETTING_VALUE.OFF,
+          });
+        },
+        "Could not save that calendar choice on this system.",
+        reporterOf(params),
+      );
+      return gatewayOk(carried(result));
+    },
+    [GATEWAY_METHOD.ONBOARDING_STATE]: () =>
+      gatewayOk({ calendarOnboardingOwed: calendarOnboardingGateOwed() }),
+    [GATEWAY_METHOD.ONBOARDING_SKIP_CALENDAR]: () => {
+      if (calendarOnboardingOwed(onboardingState)) {
+        writeOnboardingState({ calendarOnboardingSkippedAt: new Date(now()).toISOString() });
+        links.get().requestOnboardingBeat();
+      }
+      return gatewayOk({});
+    },
+    [GATEWAY_METHOD.ONBOARDING_COMPLETE_CALENDAR]: () => {
+      if (calendarOnboardingOwed(onboardingState)) {
+        writeOnboardingState({ calendarOnboardingSettledAt: new Date(now()).toISOString() });
+        links.get().requestOnboardingBeat();
+      }
+      return gatewayOk({});
+    },
+  };
+
+  return {
+    methods,
+    loop,
+    observedCalendars: () => observedCalendars,
+    announcementsQuietNow,
+    gateOwed: calendarOnboardingGateOwed,
+    gateOfferable: calendarGateOfferable,
+    onboarding: () => onboardingState,
+    writeOnboarding: writeOnboardingState,
+    recordFirstSignIn: () => {
+      // The first sign-in ever observed is also where the calendar step of
+      // onboarding goes up: recorded on disk rather than derived, so quitting
+      // at the gate and relaunching finds it standing.
+      if (onboardingState?.calendarOnboardingRequiredAt !== undefined) return;
+      writeOnboardingState({ calendarOnboardingRequiredAt: new Date(now()).toISOString() });
+      void settleCalendarOnboardingIfConnected();
+    },
+    startObservation,
+    stopObservation,
+    link: (next) => {
+      links.set(next);
+    },
+    start: async () => {
+      onboardingState = onboarding.read();
+      void settleCalendarOnboardingIfConnected();
+    },
+    stop: async () => {
+      stopObservation();
+    },
+  };
+}

--- a/packages/host/src/compose-host.test.ts
+++ b/packages/host/src/compose-host.test.ts
@@ -1,0 +1,119 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { temporaryDirectory } from "@sidecar/fixtures/testing";
+import {
+  GATEWAY_CLIENT_ROLE,
+  GATEWAY_METHOD,
+  GATEWAY_PROTOCOL_VERSION,
+  type GatewayMethod,
+  gatewayOk,
+} from "@sidecar/gateway";
+import { isRecord } from "@sidecar/wire";
+import { composeHost } from "./compose-host.js";
+import { type Composer, mergeMethods } from "./composer.js";
+import { createHostKernel } from "./host-kernel.js";
+import { lateRef } from "./late-ref.js";
+import { runModeFor } from "./run-mode.js";
+import type { SecretCipher } from "./settings-store.js";
+
+const CIPHER: SecretCipher = {
+  isAvailable: () => false,
+  encrypt: (plainText) => Buffer.from(plainText, "utf8"),
+  decrypt: (cipherText) => cipherText.toString("utf8"),
+};
+
+function stubComposer(methods: readonly GatewayMethod[]): Composer {
+  return {
+    methods: Object.fromEntries(methods.map((method) => [method, () => gatewayOk({})])),
+    start: async () => undefined,
+    stop: async () => undefined,
+  };
+}
+
+function fixtureHost(stateRoot: string) {
+  return composeHost({
+    stateRoot,
+    runMode: runModeFor({ capture: false, fixture: true }),
+    appVersion: "0.0.0-test",
+    packaged: false,
+    homeDirectory: stateRoot,
+    environment: {},
+    cipher: CIPHER,
+    createWorker: () => {
+      throw new Error("a fixture run keeps nothing on disk");
+    },
+    registerProviderHooks: false,
+    now: () => 0,
+    createId: () => "id",
+    report: () => undefined,
+  });
+}
+
+test("a method two composers claim is a construction failure, not a last writer", () => {
+  assert.throws(
+    () =>
+      mergeMethods([
+        stubComposer([GATEWAY_METHOD.SETTINGS_SNAPSHOT]),
+        stubComposer([GATEWAY_METHOD.SETTINGS_SNAPSHOT]),
+      ]),
+    /two composers answer settings\.snapshot/,
+  );
+  assert.deepEqual(
+    Object.keys(
+      mergeMethods([
+        stubComposer([GATEWAY_METHOD.SETTINGS_SNAPSHOT]),
+        stubComposer([GATEWAY_METHOD.ACCOUNT_SNAPSHOT]),
+      ]),
+    ).sort(),
+    [GATEWAY_METHOD.ACCOUNT_SNAPSHOT, GATEWAY_METHOD.SETTINGS_SNAPSHOT].sort(),
+  );
+});
+
+test("a late reference read before link() has run says so rather than answering nothing", () => {
+  const held = lateRef<{ value: number }>("the test's links");
+  assert.throws(() => held.get(), /the test's links is read before link\(\) has run/);
+  held.set({ value: 1 });
+  assert.equal(held.get().value, 1);
+});
+
+test("the kernel's service is a named failure before the merge composed it", () => {
+  const kernel = createHostKernel({
+    stateRoot: "/nowhere",
+    runMode: runModeFor({ capture: false, fixture: true }),
+    appVersion: "0.0.0-test",
+    packaged: false,
+    homeDirectory: "/nowhere",
+    environment: {},
+    cipher: CIPHER,
+    createWorker: () => {
+      throw new Error("unused");
+    },
+    now: () => 0,
+    createId: () => "id",
+    report: () => undefined,
+  });
+  assert.throws(() => kernel.service(), /before the merge composed it/);
+});
+
+test("the merge answers the bootstrap every concern contributes to, and starts and stops", async (t) => {
+  const host = fixtureHost(temporaryDirectory(t));
+  await host.start();
+  // The one method no composer owns: it reads six of them, so an answer
+  // proves the merge stood every concern up and linked their back-edges.
+  const response = await host.server.handle(
+    {
+      protocolVersion: GATEWAY_PROTOCOL_VERSION,
+      id: "bootstrap-1",
+      method: GATEWAY_METHOD.CLIENT_BOOTSTRAP,
+      params: {},
+    },
+    { clientId: "test", role: GATEWAY_CLIENT_ROLE.OPERATOR },
+  );
+  assert.ok(response.ok);
+  assert.ok(isRecord(response.result));
+  assert.equal(response.result.calendarOnboardingOwed, false);
+  assert.equal(response.result.voiceAvailable, false);
+  await host.stop({ deadlineMs: 0 });
+  // A second stop is the quit arriving twice; it must not throw.
+  await host.stop({ deadlineMs: 0 });
+});

--- a/packages/host/src/compose-host.ts
+++ b/packages/host/src/compose-host.ts
@@ -1,261 +1,42 @@
-import fs from "node:fs";
-import path from "node:path";
-import { rememberedFactsText } from "@sidecar/acts";
-import {
-  PRODUCT_ACCOUNT_ACT,
-  PRODUCT_CALENDAR_SOURCE,
-  PRODUCT_DIAGNOSTIC_KIND,
-  PRODUCT_EVENT,
-  PRODUCT_SETTING_VALUE,
-  PRODUCT_SUPERSET_ACT,
-  type ProductDiagnosticKind,
-  type ProductEventPropertiesFor,
-  ProductEventSender,
-  productEventFromWire,
-  productSessionCountBucket,
-  productSignInAge,
-  type RecordProductEvent,
-} from "@sidecar/analytics";
-import {
-  type BrainDelivery,
-  type BrainMemoryAccess,
-  DeliveryLedger,
-  EMBEDDING_BATCH_SIZE,
-} from "@sidecar/brain";
 import { BRAIN_REQUEST_STATUS } from "@sidecar/brain/requests";
-import type { BrainAppActRequest } from "@sidecar/brain/requests-wire";
-import {
-  activeMeetingEnd,
-  GoogleCalendarReader,
-  GoogleCalendarSignIn,
-  type MeetingInterval,
-  nextMeetingBoundary,
-} from "@sidecar/calendar";
-import {
-  APPLE_CALENDAR_ACCESS,
-  APPLE_CALENDAR_ID,
-  CALENDAR_PRIVACY_PANE_URL,
-} from "@sidecar/calendar/vocabulary";
-import {
-  AccountClient,
-  AccountSessionManager,
-  accountGateOpen,
-  CREDENTIAL_PROVIDER_ID,
-  type CredentialProviderId,
-  isCredentialProviderId,
-  LinearCredentials,
-  LinearIssueTracker,
-  LinearSignIn,
-  VOICE_CREDENTIAL_PROVIDER_ID,
-} from "@sidecar/credentials";
-import {
-  ACCOUNT_STATUS,
-  type AccountSnapshot,
-  isAccountProvider,
-} from "@sidecar/credentials/snapshot";
-import { AgentTraceWriter, tracedModelAdapter } from "@sidecar/devtrace";
-import { isAgentWireTrace } from "@sidecar/devtrace/vocabulary";
 import {
   carried,
-  GATEWAY_EVENT,
   GATEWAY_METHOD,
   type GatewayMethodTable,
   type GatewayServer,
   type GatewayShutdownOptions,
   type GatewayShutdownSteps,
   gatewayOk,
-  invalid,
-  NODE_CAPABILITY_STATUS,
-  NodeRegistry,
   shutdownGateway,
 } from "@sidecar/gateway";
+import { ARRIVAL_SPEECH_KIND, CALENDAR_ONBOARDING_SPEECH_KIND } from "@sidecar/realtime";
+import { ObservationSupervisor } from "@sidecar/runtime";
 import {
-  APP_SETTING_ID,
-  type AppGuideSnapshot,
-  appGuideContextText,
-  EMPTY_APP_GUIDE,
-  isAppGuideSnapshot,
-} from "@sidecar/guide";
-import { HostedVaultClient } from "@sidecar/hosted";
-import { ISSUE_TRACKER_ID, normalizeTrackedIssue, type TrackedIssue } from "@sidecar/issues";
-import {
-  type MemorySyncReport,
-  NotebookMemory,
-  RETRIEVAL_MODE,
-  type RetrievalMode,
-} from "@sidecar/memory";
-import {
-  ADAPTER_DIAGNOSTIC_KIND,
-  type AdapterDiagnosticKind,
-  claudeDesktopApplications,
-  codexCloudPlugin,
-  conductorApplications,
-  conductorLocalWorkspacePlugin,
-  ObservationHookRegistry,
-  type ObservationSpoolWatcher,
-  type ProviderRegistration,
-  providerRegistrations,
-  SUPERSET_SIGN_IN_STAGE,
-  SupersetSignIn,
-  supersetPlugin,
-  supersetPressedLink,
-  type WorkspaceHostEnrichment,
-  type WorkspaceHostRegistration,
-  watchObservationSpool,
-  workspaceHostRegistrations,
-} from "@sidecar/providers";
-import {
-  ARRIVAL_SPEECH_KIND,
-  BRIEFING_SPEECH_KIND,
-  CALENDAR_ONBOARDING_SPEECH_KIND,
-  type ConversationEntry,
-  conversationHistoryText,
-  recentConversationEntries,
-  sessionContextText,
-  storedConversationEntry,
-  workspaceProjectContextText,
-} from "@sidecar/realtime";
-import { isSpeechOutcome, SPEECH_OUTCOME, type SpeechOutcome } from "@sidecar/realtime/speech";
-import {
-  CREDENTIAL_REFERENCE_KIND,
-  CronScheduler,
-  HEARTBEAT_DEFAULTS,
-  heartbeatJob,
-  LANE,
-  ObservationLoop,
-  ObservationSupervisor,
-} from "@sidecar/runtime";
-import {
-  CONVERSATION_KIND,
-  type ConversationRecord,
-  type EmbeddingAdapter,
-  isIdentifier,
   isTerminalChildRunStatus,
   MAIN_SESSION_KEY,
   type SessionKey,
-  sessionKey as toSessionKey,
 } from "@sidecar/runtime-contracts";
-import type { RuntimeStoreClient, RuntimeStorePort } from "@sidecar/runtime-store";
-import {
-  CONDUCTOR_LOCAL_WORKSPACE_PROVIDER_ID,
-  CreatedWorkspaceOpenTracker,
-  isProviderId,
-  isSessionApplicationId,
-  isWorkspaceProviderId,
-  normalizeObservedWorkspaceProjects,
-  type ObservedWorkspaceProject,
-  PROVIDER_ID,
-  PROVIDER_ID_LIST,
-  type ProviderId,
-  type Session,
-  type SessionIdentity,
-  type SessionProviderPlugin,
-  SessionRoster,
-  SUPERSET_WORKSPACE_PROVIDER_ID,
-  staleWorkspaceProjectDefaults,
-  type WorkspaceAgentSelection,
-  workspaceProjectSelectionId,
-} from "@sidecar/session";
-import {
-  ACCOUNT_PREFERENCE_FIELDS,
-  type AccountPreferenceField,
-  type AccountPreferences,
-  APP_SETTING_FIELDS,
-  APP_SETTING_SCHEMA,
-  type AppSettingField,
-  isAppSettingField,
-  isKeyedAppSettingField,
-  isSettingEntryKey,
-  isSettingsResetScope,
-  SETTING_SIDE_EFFECT,
-  type SettingEntryValue,
-  settingAnalytics,
-  settingEntryGuard,
-  VOICE_SOURCE,
-  VOICE_SOURCE_COUNTED_AS,
-} from "@sidecar/settings";
-import type { ObservedAccountCalendars, SettingsUpdateResult } from "@sidecar/settings/wire";
-import { type VoiceCapabilityApplication, VoiceCapabilityAssembler } from "@sidecar/voice";
-import {
-  ACT_RESULT_STATUS,
-  isRecord,
-  isWireBoolean,
-  isWireNumber,
-  isWireString,
-  UNKNOWN_ACT_STATUS,
-  type UnparsedWireValue,
-  type WireRecord,
-  type WireValue,
-} from "@sidecar/wire";
-import { AccountPreferencesClient } from "./account-preferences-client.js";
-import {
-  APPLE_CALENDAR_ACCESS_REFUSAL,
-  type AppleCalendarHelperRun,
-  AppleCalendarReader,
-} from "./apple-calendar.js";
-import { arrivalBeatOwed, countsFirstAnnouncement } from "./arrival-flow.js";
-import type { WorkspaceCreationDefaults } from "./brain/act-performer.js";
-import { wakeEventsFromHooks, wireBrain } from "./brain/wiring.js";
-import { calendarOnboardingOwed } from "./calendar-onboarding-flow.js";
-import { conversationOperations, startHistoryMaintenance } from "./conversation-operations.js";
-import { seedWorkspaceThenStartMemory, shutdownStepsFlushingEvents } from "./lifecycle.js";
-import { wireMemoryMaintenance } from "./memory-maintenance.js";
-import { HOST_NODE_CAPABILITY } from "./node-capabilities.js";
-import { type OnboardingState, onboardingStateFile } from "./onboarding-state.js";
-import { ProviderKeyVaultSync, type VaultSyncAccount } from "./provider-key-vault-sync.js";
-import type { RunMode } from "./run-mode.js";
-import { createGatewayService, type GatewayService, type GrantedWords } from "./service.js";
-import { createSessionActPerformer, NodeAnswerLostError } from "./session-act-performer.js";
-import { type SecretCipher, SettingsStore } from "./settings-store.js";
-import { agentRootPath } from "./store-path.js";
-import { wireRuntimeStore } from "./store-wiring.js";
-import { type OnboardingBeatKind, SpeechArbiter } from "./voice/speech-arbiter.js";
-import { VoiceReceiver } from "./voice-receiver.js";
+import { normalizeObservedWorkspaceProjects } from "@sidecar/session";
+import { APP_SETTING_SCHEMA } from "@sidecar/settings";
+import { composeAccount } from "./compose-account.js";
+import { composeBrain } from "./compose-brain.js";
+import { composeCalendars } from "./compose-calendars.js";
+import { composeIssues } from "./compose-issues.js";
+import { composeObservation } from "./compose-observation.js";
+import { composeSettings } from "./compose-settings.js";
+import { composeSpeech } from "./compose-speech.js";
+import { type Composer, mergeMethods } from "./composer.js";
+import { createHostKernel, type HostSeams } from "./host-kernel.js";
+import { shutdownStepsFlushingEvents } from "./lifecycle.js";
+import { createGatewayService } from "./service.js";
 
 /**
- * Luke's runtime as one host: everything that executes, persists, schedules,
- * observes, or holds an account, composed once over an explicit state root
- * and reached only through the Gateway server it answers with. It draws
- * nothing and touches no window: what a window must learn leaves as a host
- * event, and what only the machine a client runs on can do — open an
- * address, carry an act to a panel, run the EventKit helper — is asked of
- * the native node by name and answers a typed unavailable when no node is
- * connected. The desktop composes this in its own process and reaches it
- * over the in-process transport, keeping nothing on disk and sending nothing
- * for a fixture or capture run; a process on the other side of a socket is
- * the same composition over another transport, and the client code path is
- * one either way.
+ * How long the quit waits for the store to close after the drain has
+ * settled. A close that hangs on a disk must not hold the process open past
+ * its quit: what it could not write is what the next launch marks
+ * interrupted, which is the same answer an unsettled drain leaves.
  */
-export interface HostSeams {
-  /** Luke's own application-state root, given explicitly: never derived from the hosting process's profile. */
-  stateRoot: string;
-  runMode: RunMode;
-  appVersion: string;
-  packaged: boolean;
-  /** The user's home, for the Superset CLI's own directory. */
-  homeDirectory: string;
-  /** The environment the host reads its development overrides from. */
-  environment: NodeJS.ProcessEnv;
-  cipher: SecretCipher;
-  createWorker: () => RuntimeStorePort;
-  /**
-   * Whether the observation hooks are registered with the providers' own
-   * user-level configurations at start. A validation run on a temporary
-   * state root says no, so nothing of the developer's real provider
-   * configuration moves; the transcripts are observed either way.
-   */
-  registerProviderHooks?: boolean;
-  now: () => number;
-  createId: () => string;
-  report: (message: string) => void;
-  /**
-   * Hears the protocol's shutdown method: the client's explicit Quit, or a
-   * newer build draining this one. The process hosting the runtime leaves in
-   * the coordinator's order; a host with no process to leave (a fixture run)
-   * hears nothing.
-   */
-  onShutdownRequested?: () => void;
-}
+const HOST_CLOSE_WAIT_MS = 5_000;
 
 export interface Host {
   /** The one boundary a client reaches this host through. */
@@ -274,2254 +55,205 @@ export interface Host {
   stop: (options?: GatewayShutdownOptions) => Promise<void>;
 }
 
-const ACCOUNT_CLIENT_ID = "luke-desktop";
-const SESSION_REFRESH_INTERVAL_MS = 60_000;
-/** A board changes at the pace of hands, not of models; a minute is current. */
-const ISSUE_REFRESH_INTERVAL_MS = 60_000;
-/** A diary changes at the pace of hands too; five minutes is current. */
-const CALENDAR_REFRESH_INTERVAL_MS = 5 * 60_000;
-/**
- * How often held notices ask whether the meeting holding them has ended. The
- * question is answered from meetings already in memory, so asking often costs
- * nothing. The boundary timer is what answers on time — this tick is the net
- * behind it, for the clocks a timer cannot promise to keep: a laptop asleep
- * through the boundary, or a system clock moved by hand.
- */
-const HELD_NOTICE_RELEASE_INTERVAL_MS = 30_000;
-/**
- * How often the System Settings switch is asked about between passes. Each
- * probe is a fresh helper process on purpose: EventKit answers a running
- * process's authorization from state it read at launch, so only a fresh
- * process can be trusted about where the switch stands now. Ten seconds is
- * the longest consent taken back keeps holding anything.
- */
-const APPLE_ACCESS_POLL_INTERVAL_MS = 10_000;
-
-/** The agent's identity workspace and the skills beside it, under the agent's own directory. */
-const AGENT_WORKSPACE_DIRECTORY = "workspace";
-
-/**
- * How long the quit waits for the store to close after the drain has
- * settled. A close that hangs on a disk must not hold the process open past
- * its quit: what it could not write is what the next launch marks
- * interrupted, which is the same answer an unsettled drain leaves.
- */
-const HOST_CLOSE_WAIT_MS = 5_000;
-const AGENT_SKILLS_DIRECTORY = "skills";
-
-const DIAGNOSTIC_COUNTED_AS = {
-  [ADAPTER_DIAGNOSTIC_KIND.PASS_FAILURE]: PRODUCT_DIAGNOSTIC_KIND.PASS_FAILURE,
-  [ADAPTER_DIAGNOSTIC_KIND.ACCIDENTAL_WAKE]: PRODUCT_DIAGNOSTIC_KIND.ACCIDENTAL_WAKE,
-} satisfies Record<AdapterDiagnosticKind, ProductDiagnosticKind>;
-
-function isSessionIdentity(value: UnparsedWireValue): value is SessionIdentity & WireRecord {
-  return (
-    isRecord(value) &&
-    isWireString(value.providerId) &&
-    isWireString(value.providerSessionId) &&
-    value.providerSessionId.length > 0
-  );
-}
-
-/**
- * One credential transition, from the seams this host owns: the brain
- * wiring's synchronous retire, the assembler's application, and the rebuild
- * that installs what the applied capability allows. The retire is immediate,
- * so no run keeps the old source's authority past the transition's first
- * await. The rebuild belongs to the current application alone, asked at the
- * moment of use rather than read off the answer: a newer transition can begin
- * between the assembler's publication and this continuation, and it has
- * already retired the wiring, so a rebuild on the older one's behalf would be
- * the newest thing the host was asked for and would install the retired
- * source over the selection still being read. An overtaken transition builds
- * nothing and leaves the host empty for the newer one to fill. Answers
- * whether this transition was the one that installed.
- */
-interface VoiceCredentialTransitionSeams {
-  retire: () => void;
-  apply: () => Promise<VoiceCapabilityApplication>;
-  rebuild: () => Promise<void>;
-}
-
-export async function transitionVoiceCredential(
-  seams: VoiceCredentialTransitionSeams,
-): Promise<boolean> {
-  seams.retire();
-  const applied = await seams.apply();
-  if (!applied.latest || !applied.isCurrent()) return false;
-  await seams.rebuild();
-  return true;
-}
-
-/** The notebook's index as the host holds it, and what a run without one still answers. */
-interface MemoryWiring {
-  /** Syncs once and starts watching; a run with nothing on disk does neither. */
-  start: () => Promise<void>;
-  stop: () => void;
-  /** One reconcile of the index against the files; a call during a pass earns one follow-on pass under the adapter standing then. */
-  sync: () => Promise<MemorySyncReport | undefined>;
-  /** The brain's memory tools for one conversation. */
-  accessFor: (sessionKey: SessionKey) => BrainMemoryAccess | undefined;
-  /** The retrieval mode the last sync settled on. */
-  mode: () => RetrievalMode;
-}
-
-/** A run without a notebook: nothing on disk to index, so nothing to search. */
-const INERT_MEMORY_WIRING: MemoryWiring = {
-  start: async () => undefined,
-  stop: () => undefined,
-  sync: async () => undefined,
-  accessFor: () => undefined,
-  mode: () => RETRIEVAL_MODE.KEYWORD_ONLY,
-};
-
-export interface NotebookMemoryDependencies {
-  client: () => RuntimeStoreClient;
-  /** The embedding adapter the credential policy built, or nothing when no credential stands. */
-  embeddingAdapter: () => EmbeddingAdapter | undefined;
-  /** Hears every credential change that may have replaced the adapter; the index is synced again so keyword-only chunks gain their vectors. */
-  onEmbeddingAdapterChanged?: (listener: () => void) => void;
-  /** The agent's identity workspace, watched for the notebook's files. */
-  workspaceDirectory: () => string;
-  conversationDirectory: () => readonly ConversationRecord[];
-  isTemporary: (sessionKey: SessionKey) => boolean;
-  now: () => number;
-  report: (message: string) => void;
-  /** Hears every completed sync, so the notebook's cached entries can be read again after a hand edit. */
-  onSynced?: () => void;
-}
-
-/**
- * The notebook's index as the host wires it: the memory package's host over
- * the store's worker and the embedding adapter the credential policy built.
- * This composes only; the sync and the search live in `NotebookMemory`.
- */
-export function composeNotebookMemory(dependencies: NotebookMemoryDependencies): NotebookMemory {
-  const memory = new NotebookMemory({
-    store: dependencies.client,
-    embeddingAdapter: dependencies.embeddingAdapter,
-    embeddingBatchSize: EMBEDDING_BATCH_SIZE,
-    workspaceDirectory: dependencies.workspaceDirectory,
-    conversationDirectory: dependencies.conversationDirectory,
-    isTemporary: dependencies.isTemporary,
-    now: dependencies.now,
-    report: dependencies.report,
-    ...(dependencies.onSynced ? { onSynced: dependencies.onSynced } : undefined),
-  });
-  dependencies.onEmbeddingAdapterChanged?.(() => {
-    void memory.sync();
-  });
-  return memory;
-}
-
 export function composeHost(options: HostSeams): Host {
-  const { stateRoot, runMode, report, now, createId } = options;
-  const userData = () => stateRoot;
+  const kernel = createHostKernel(options);
+  const { runMode, report, now } = kernel;
 
-  // A development build may be pointed at a local account service; a packaged one
-  // may not. The override redirects the whole sign-in — including the identity
-  // request that carries the access token — so it stops at the packaging boundary
-  // rather than shipping inside a signed binary.
-  const ACCOUNT_BASE_URL =
-    (options.packaged ? undefined : options.environment.LUKE_ACCOUNT_BASE_URL) ??
-    "https://tryluke.dev/api/auth";
-  // The hosted voice endpoints live on the same origin as the account service,
-  // so the one development override redirects both together.
-  const HOSTED_SERVICE_BASE_URL = ACCOUNT_BASE_URL.replace(/\/api\/auth\/?$/, "");
+  const settings = composeSettings({ kernel });
+  const account = composeAccount({ kernel, settings });
+  const observationGate = () => runMode.observesProviders && account.capabilitiesActive();
+  const issues = composeIssues({ kernel, settings, observationGate });
+  const observation = composeObservation({ kernel, settings, account, issues, observationGate });
+  const calendars = composeCalendars({ kernel, settings, observationGate });
+  const speech = composeSpeech({ kernel, settings, account, calendars, observation });
+  const brain = composeBrain({ kernel, settings, account, issues, observation, speech });
 
-  const nodes = new NodeRegistry();
-  let service: GatewayService;
-
-  /** One host event, numbered into the log every client follows. */
-  const emit = (kind: (typeof GATEWAY_EVENT)[keyof typeof GATEWAY_EVENT], payload: WireValue) => {
-    service.server.emit(kind, payload);
-  };
-
-  /**
-   * An address a host-owned flow needs opened: the native node's. No node
-   * connected is a refusal the act reports as not done; a node that took the
-   * ask and vanished before answering is the lost-answer error, which every
-   * caller that journals an act records as unknown rather than failed.
-   */
-  const openExternalThroughNode = async (url: string): Promise<void> => {
-    const result = await nodes.invoke(HOST_NODE_CAPABILITY.OPEN_EXTERNAL, { url });
-    if (result.status === NODE_CAPABILITY_STATUS.OK) return;
-    if (result.status === NODE_CAPABILITY_STATUS.UNKNOWN) {
-      throw new NodeAnswerLostError(result.reason);
-    }
-    throw new Error(result.reason);
-  };
-
-  const sessionRegistry = new SessionRoster();
-  const codexCloud = codexCloudPlugin({
-    onDiagnostic: (kind, error) => reportAdapterDiagnostic(PROVIDER_ID.CODEX, kind, error),
+  // Every edge a composer could not take as a constructor argument, in one
+  // list: each is a cycle the concerns genuinely have, and reading one before
+  // this has run throws by name rather than answering nothing.
+  settings.link({
+    codexCloudConnection: observation.codexCloudConnection,
+    refreshAccount: async () => {
+      await account.session.refreshOnce();
+    },
+    applyVoiceCredential: account.applyVoiceCredential,
+    setVoice: (voice) => account.voiceCapabilities.realtimeCredentials?.setVoice(voice),
+    setVoiceSpeed: (speed) => account.voiceCapabilities.realtimeCredentials?.setSpeed(speed),
+    reconcileSpeech: () => void speech.reconcileSpeech(),
+    refreshSupersetWorkspaceHost: async () => {
+      await observation.readSupersetWorkspaceHost();
+    },
+    broadcastWorkspaceProjects: observation.broadcastWorkspaceProjects,
+    refreshCredentialAdapter: observation.refreshCredentialAdapter,
+    refreshIssues: issues.refresh,
+    workspaceProjectOffered: observation.workspaceProjectOffered,
   });
-  const conductorSessionApplications = conductorApplications();
-  const claudeDesktopSessionApplications = claudeDesktopApplications();
-  // The local counterpart of the cloud Conductor adapter's creation path: it
-  // reads the repositories Conductor holds and creates a workspace in one by
-  // handing Conductor's own creation deep link to the operating system, through
-  // the native node.
-  const conductorLocalWorkspaces = conductorLocalWorkspacePlugin({
-    openExternal: (url: string) => openExternalThroughNode(url),
-  });
-  const supersetHomeDirectory =
-    options.environment.SUPERSET_HOME_DIR ?? path.join(options.homeDirectory, ".superset");
-  const superset = supersetPlugin({ homeDirectory: supersetHomeDirectory });
-  const supersetCli = superset.cli;
-  const supersetWorkspaceHost: WorkspaceHostRegistration = {
-    observationFailureLabel: "Superset observation",
-    read: readSupersetWorkspaceHost,
-    emptyEnrichment: (_providerId, observations) => observations,
-  };
-  const workspaceHosts = workspaceHostRegistrations({
-    superset: supersetWorkspaceHost,
-    conductorApplications: conductorSessionApplications,
-    claudeDesktopApplications: claudeDesktopSessionApplications,
-  });
-  const settingsStore = new SettingsStore({
-    directory: userData,
-    // A fixture or evidence run refuses the credentials it resolves, so nothing is
-    // reported as available that would not actually happen.
-    credentialsUsable: runMode.observesProviders,
-    cipher: options.cipher,
-    environment: options.environment,
-    codexCloudConnection: () => codexCloud.connection(),
-  });
-  const accountClient = new AccountClient({
-    baseUrl: ACCOUNT_BASE_URL,
-    clientId: ACCOUNT_CLIENT_ID,
-  });
-  let account: AccountSnapshot = { status: ACCOUNT_STATUS.SIGNED_OUT };
-  let accountPreferencesHydratedAccount: string | undefined;
-  const accountSession = new AccountSessionManager({
-    client: accountClient,
-    store: settingsStore,
-    hostedServiceBaseUrl: HOSTED_SERVICE_BASE_URL,
-    requiresAccount: runMode.requiresAccount,
-    openExternal: (url) => openExternalThroughNode(url),
-    startCapabilities: () => startAccountCapabilities(),
+  account.link({
+    startCapabilities: startAccountCapabilities,
     stopCapabilities: stopAccountCapabilities,
-    onChange: (next) => {
-      const signedIn = next.status === ACCOUNT_STATUS.SIGNED_IN;
-      const wasSignedIn = account.status === ACCOUNT_STATUS.SIGNED_IN;
-      const previousAccountKey =
-        account.status === ACCOUNT_STATUS.SIGNED_IN ? account.email : undefined;
-      const nextAccountKey = signedIn ? next.email : undefined;
-      account = next;
-      if (previousAccountKey !== nextAccountKey) {
-        accountPreferencesHydratedAccount = undefined;
-      }
-      // The first sign-in ever observed is also where the calendar step of
-      // onboarding goes up: recorded on disk rather than derived, so quitting
-      // at the gate and relaunching finds it standing. Written before the
-      // account event below, so the gate is already standing when the
-      // renderer learns it is signed in.
-      if (signedIn && !wasSignedIn && onboardingState?.calendarOnboardingRequiredAt === undefined) {
-        writeOnboardingState({ calendarOnboardingRequiredAt: new Date(now()).toISOString() });
-        void settleCalendarOnboardingIfConnected();
-      }
-      emit(GATEWAY_EVENT.ACCOUNT_CHANGED, carried(account));
-      void emitSettings();
-      void emitSessionReplay();
-      if (signedIn && !wasSignedIn) productEvents.record(PRODUCT_EVENT.ACCOUNT_SIGN_IN, {});
-      if (signedIn && !wasSignedIn && onboardingState?.arrivalSignedInAt === undefined) {
-        writeOnboardingState({ arrivalSignedInAt: new Date(now()).toISOString() });
-      }
-    },
+    onFirstSignIn: calendars.recordFirstSignIn,
+    onFirstSignInArrival: speech.seedArrivalOnFirstSignIn,
+    retireBrain: () => brain.wiring.retire(),
+    rebuildBrain: () => brain.wiring.rebuild(),
+    syncMemory: brain.syncMemory,
   });
-  // The hook spool and every provider script live under the explicit state
-  // root, the same directory Luke always kept them in.
-  const observationHooks = new ObservationHookRegistry(userData);
-  const providerRegistry = providerRegistrations({
-    readApiKey: (providerId) => settingsStore.readApiKey(providerId),
-    observationHookInstallation: (providerId) => observationHooks.installation(providerId),
-    codexCloud,
-    onDiagnostic: reportAdapterDiagnostic,
+  observation.link({
+    wake: (events) => brain.wiring.wake(events),
+    rosterLook: () => brain.wiring.rosterLook(),
   });
-  const orderedRegistrations: readonly ProviderRegistration[] = PROVIDER_ID_LIST.map(
-    (providerId) => providerRegistry[providerId],
-  );
-  const linearCredentials = new LinearCredentials({
-    readGrant: () => settingsStore.readGrant(CREDENTIAL_PROVIDER_ID.LINEAR),
-    writeGrant: async (grant) => {
-      await settingsStore.setGrant(CREDENTIAL_PROVIDER_ID.LINEAR, grant);
-    },
-    forgetGrant: async () => {
-      const cleared = await settingsStore.clearGrant(CREDENTIAL_PROVIDER_ID.LINEAR);
-      // Nobody pressed anything to end this connection — Linear refused the
-      // renewal — so no settings reply is on its way to say so.
-      emitSettingsSnapshot(cleared.settings);
-    },
+  calendars.link({
+    reconcileSpeech: () => void speech.reconcileSpeech(),
+    withdrawBeat: speech.withdrawBeat,
+    dropBriefings: speech.dropBriefings,
+    requestOnboardingBeat: () => void speech.requestOnboardingBeat(),
   });
-  const linearTracker = new LinearIssueTracker({
-    readAccessToken: () => linearCredentials.accessToken(),
-  });
-  const linearSignIn = new LinearSignIn({
-    openExternal: (url) => void openExternalThroughNode(url).catch(reportOpenFailure),
-  });
-  const issueTrackers = [linearTracker] as const;
-  let trackedIssues: readonly TrackedIssue[] | undefined;
-  const googleCalendar = new GoogleCalendarReader({
-    readAccounts: () => settingsStore.readCalendarAccounts(),
-  });
-  const googleCalendarSignIn = new GoogleCalendarSignIn({
-    openExternal: (url) => void openExternalThroughNode(url).catch(reportOpenFailure),
-  });
-  /**
-   * The EventKit helper runs on the desktop, where the device is: each
-   * invocation the reader composes — a command fixed by the build, the
-   * window's instants, the chosen calendar ids — crosses to the native node
-   * and its stdout comes back. No node connected is a failed read, which
-   * the reader answers by standing what it last showed, never by emptying
-   * a calendar on the strength of an absent desktop.
-   */
-  const runAppleCalendarHelper: AppleCalendarHelperRun = async (helperArguments, timeoutMs) => {
-    const result = await nodes.invoke(HOST_NODE_CAPABILITY.APPLE_CALENDAR_HELPER, {
-      arguments: [...helperArguments],
-      timeoutMs,
-    });
-    if (result.status !== NODE_CAPABILITY_STATUS.OK) throw new Error(result.reason);
-    if (!isWireString(result.value)) throw new Error("the helper answered no text");
-    return result.value;
-  };
-  const appleCalendar = new AppleCalendarReader({
-    readConnection: () => settingsStore.readAppleCalendarConnection(),
-    runHelper: runAppleCalendarHelper,
-    now,
-  });
-  let calendarMeetings: readonly MeetingInterval[] | undefined;
-  let quietBoundaryTimer: NodeJS.Timeout | undefined;
-  let observedCalendars: readonly ObservedAccountCalendars[] = [];
-  let heldNoticeReleaseTimer: NodeJS.Timeout | undefined;
-  let appleAccessPollTimer: NodeJS.Timeout | undefined;
-  let appleAccessProbeFailing = false;
-  let announcementsHeld = false;
-
-  /**
-   * The runtime store and the conversation it holds: one retained thread
-   * shared by every panel window and persisted for the next launch. A window's
-   * report is appended under an opaque reporter the client minted, so the
-   * history event can skip echoing it to the window that reported it, and the
-   * reporter names nothing about the window to anyone else.
-   */
-  const runtimeStoreWiring = wireRuntimeStore({
-    persistent: runMode.observesProviders,
-    createWorker: options.createWorker,
-    agentRoot: () => agentRootPath(stateRoot),
-    workspaceDirectory: () => agentWorkspacePath(),
-    ensureDirectory: (directory) => fs.mkdirSync(directory, { recursive: true, mode: 0o700 }),
-    now,
-    createEventId: createId,
-    onHistoryChanged: (sessionKey, entries, except) =>
-      service.historyChanged(sessionKey, entries, except),
-    onDirectoryChanged: () => undefined,
-    report,
-  });
-  const brainReplyDeliveries = new DeliveryLedger<GrantedWords>({ nextDeliveryId: createId });
-  /**
-   * The one voice receiver, as the client that owns the voice window reports
-   * it: the host mints the epochs, so a claim names an epoch this host issued,
-   * and a client's connection closing ends the epoch as its renderer going
-   * away would.
-   */
-  const voiceReceiver = new VoiceReceiver();
-  let spoolWatchers: readonly ObservationSpoolWatcher[] = [];
-  let appGuide: AppGuideSnapshot = EMPTY_APP_GUIDE;
-  const createdWorkspaceOpens = new CreatedWorkspaceOpenTracker();
-  /**
-   * The development trace, gated so it cannot exist for a user: a packaged
-   * build never reads the variable, a fixture or evidence run has no traffic to
-   * tap and constructs no writer.
-   */
-  const agentTraceDirectory =
-    options.packaged || !runMode.sendsNetwork ? undefined : options.environment.LUKE_TRACE_DIR;
-  const agentTrace = agentTraceDirectory
-    ? new AgentTraceWriter({ directory: agentTraceDirectory })
-    : undefined;
-  if (agentTrace) report(`Agent trace: ${agentTrace.file}`);
-  const speechArbiter = new SpeechArbiter({
-    now,
-    nextId: createId,
-    ...(agentTrace ? { trace: (record) => agentTrace.recordSpeechDecision(record) } : undefined),
-  });
-  const voiceCapabilities = new VoiceCapabilityAssembler({
-    settings: settingsStore,
-    credentialsUsable: () => runMode.sendsNetwork && accountCapabilitiesActive(),
-    fixtureRun: () => !runMode.sendsNetwork,
-    accountSignedIn: () => account.status === ACCOUNT_STATUS.SIGNED_IN,
-    hostedServiceBaseUrl: HOSTED_SERVICE_BASE_URL,
-    refreshAccount: accountSession.refreshOnce,
-    ...(agentTrace
-      ? {
-          wrapBrainModel: (model) =>
-            tracedModelAdapter(model, (record) => agentTrace.recordBrainRequest(record)),
-        }
-      : undefined),
-  });
-  const productEvents = new ProductEventSender({
-    serviceBaseUrl: HOSTED_SERVICE_BASE_URL,
-    appVersion: options.appVersion,
-    sends: runMode.sendsNetwork,
-    readAccessToken: async () => (await settingsStore.readAccount())?.accessToken,
-    refreshAccount: accountSession.refreshOnce,
-  });
-  const hostedVault = new HostedVaultClient({
-    serviceBaseUrl: HOSTED_SERVICE_BASE_URL,
-    readAccessToken: async () =>
-      runMode.sendsNetwork ? (await settingsStore.readAccount())?.accessToken : undefined,
-    refreshAccount: accountSession.refreshOnce,
-    readAccountKey: async () => (await settingsStore.readAccount())?.email,
-  });
-  const accountPreferencesClient = new AccountPreferencesClient({
-    serviceBaseUrl: HOSTED_SERVICE_BASE_URL,
-    readAccessToken: async () =>
-      runMode.sendsNetwork ? (await settingsStore.readAccount())?.accessToken : undefined,
-    refreshAccount: accountSession.refreshOnce,
-    readAccountKey: readAccountPreferenceAccountKey,
-  });
-  const providerKeyVaultSync = new ProviderKeyVaultSync({
-    vault: hostedVault,
-    readStoredApiKey: (providerId) => settingsStore.readStoredApiKey(providerId),
-    account: async () => {
-      const held = await settingsStore.readAccount();
-      if (!held) return undefined;
-      const vaultAccount: VaultSyncAccount = { email: held.email };
-      if (held.id) vaultAccount.id = held.id;
-      return vaultAccount;
-    },
-    tenant: {
-      read: () => settingsStore.readVaultSyncAccount(),
-      write: (accountKey) => settingsStore.setVaultSyncAccount(accountKey),
-    },
-  });
-  let accountPreferencesSync: Promise<void> = Promise.resolve();
-  function reconcileProviderKeyVault(): void {
-    void settingsStore
-      .snapshot()
-      .then((settings) =>
-        settings.stored.syncProviderKeys
-          ? providerKeyVaultSync.apply(true, { claim: false })
-          : undefined,
-      );
-  }
-
-  async function readAccountPreferenceAccountKey(): Promise<string | undefined> {
-    return (await settingsStore.readAccount())?.email;
-  }
-
-  function queueAccountPreferencesSync(label: string, work: () => Promise<void>): Promise<void> {
-    const queued = accountPreferencesSync.then(work, work).catch((error) => {
-      report(
-        `Account preferences ${label} failed: ${error instanceof Error ? error.message : String(error)}`,
-      );
-    });
-    accountPreferencesSync = queued.then(
-      () => undefined,
-      () => undefined,
-    );
-    return queued;
-  }
-
-  function accountPreferencesEmpty(preferences: AccountPreferences): boolean {
-    return Object.keys(preferences).length === 0;
-  }
-
-  function accountPreferencesSame(left: AccountPreferences, right: AccountPreferences): boolean {
-    return JSON.stringify(left) === JSON.stringify(right);
-  }
-
-  async function accountPreferenceHydrationBaseline(
-    accountEmail: string,
-  ): Promise<AccountPreferences> {
-    const baseline = await settingsStore.accountPreferencesSyncBaseline(accountEmail);
-    if (baseline !== undefined) return baseline;
-    const preferences = await settingsStore.accountPreferences();
-    await settingsStore.setAccountPreferencesSyncBaseline(accountEmail, preferences);
-    return preferences;
-  }
-
-  function isAccountPreferenceField(field: AppSettingField): field is AccountPreferenceField {
-    return ACCOUNT_PREFERENCE_FIELDS.some((candidate) => candidate === field);
-  }
-
-  function resetTouchesAccountPreferences(scope: UnparsedWireValue): boolean {
-    return ACCOUNT_PREFERENCE_FIELDS.some((field) => {
-      const definition = APP_SETTING_SCHEMA[field];
-      return "resetScope" in definition && definition.resetScope === scope;
-    });
-  }
-
-  async function reconcileAccountPreferences(): Promise<void> {
-    return queueAccountPreferencesSync("reconcile", async () => {
-      const accountKey = await readAccountPreferenceAccountKey();
-      if (!accountKey) return;
-      await hydrateAccountPreferences(accountKey);
-    });
-  }
-
-  async function hydrateAccountPreferences(accountKey: string): Promise<boolean> {
-    const baseline = await accountPreferenceHydrationBaseline(accountKey);
-    if ((await readAccountPreferenceAccountKey()) !== accountKey) return false;
-    const remote = await accountPreferencesClient.readPreferences();
-    if (!remote || (await readAccountPreferenceAccountKey()) !== accountKey) return false;
-
-    if (!remote.hasStoredSnapshot) {
-      const preferences = await settingsStore.accountPreferences();
-      if ((await readAccountPreferenceAccountKey()) !== accountKey) return false;
-      if (!accountPreferencesEmpty(preferences)) {
-        const written = await accountPreferencesClient.writePreferences(preferences);
-        if (!written || (await readAccountPreferenceAccountKey()) !== accountKey) return false;
-      }
-      if (!(await settingsStore.setAccountPreferencesSyncBaseline(accountKey, preferences))) {
-        return false;
-      }
-      accountPreferencesHydratedAccount = accountKey;
-      return true;
-    }
-
-    const saved = await settingsStore.applyAccountPreferences(remote.preferences, {
-      accountEmail: accountKey,
-      preferences: baseline,
-    });
-    if ((await readAccountPreferenceAccountKey()) !== accountKey) return false;
-    accountPreferencesHydratedAccount = accountKey;
-    const preferences = await settingsStore.accountPreferences();
-    if ((await readAccountPreferenceAccountKey()) !== accountKey) return false;
-    if (saved.changed.length > 0) {
-      await applyAccountPreferenceSideEffects(saved, saved.changed);
-    }
-    if (!accountPreferencesSame(preferences, remote.preferences)) {
-      const written = await accountPreferencesClient.writePreferences(preferences);
-      if (!written || (await readAccountPreferenceAccountKey()) !== accountKey) return true;
-    }
-    await settingsStore.setAccountPreferencesSyncBaseline(accountKey, preferences);
-    return true;
-  }
-
-  function pushAccountPreferences(): void {
-    void queueAccountPreferencesSync("write", async () => {
-      const accountKey = await readAccountPreferenceAccountKey();
-      if (!accountKey) return;
-      if (
-        accountPreferencesHydratedAccount !== accountKey &&
-        !(await hydrateAccountPreferences(accountKey))
-      ) {
-        return;
-      }
-      const preferences = await settingsStore.accountPreferences();
-      if (
-        (await readAccountPreferenceAccountKey()) !== accountKey ||
-        accountPreferencesHydratedAccount !== accountKey
-      ) {
-        return;
-      }
-      const written = await accountPreferencesClient.writePreferences(preferences);
-      if (!written || (await readAccountPreferenceAccountKey()) !== accountKey) return;
-      await settingsStore.setAccountPreferencesSyncBaseline(accountKey, preferences);
-    });
-  }
-
-  const recordProductEvent: RecordProductEvent = (name, properties) =>
-    productEvents.record(name, properties);
-
-  function reportOpenFailure(error: Error): void {
-    report(`An address could not be opened: ${error.message}`);
-  }
-
-  function reportAdapterDiagnostic(
-    providerId: ProviderId,
-    kind: AdapterDiagnosticKind,
-    error: Error,
-  ): void {
-    report(`Observation diagnostic (${providerId}, ${kind}): ${error.message}`);
-    const counted = DIAGNOSTIC_COUNTED_AS[kind];
-    if (!counted) return;
-    productEvents.record(PRODUCT_EVENT.SESSION_DIAGNOSTIC, {
-      provider_id: providerId,
-      diagnostic_kind: counted,
-    });
-  }
-
-  /**
-   * Whether an account was deleted in this run, which stands recording down
-   * for the rest of it; the client relays the answer to its renderers.
-   */
-  let sessionReplayEndedByDeletion = false;
-
-  async function sessionReplayState(): Promise<{ permitted: boolean; accountId?: string }> {
-    const signedIn = account.status === ACCOUNT_STATUS.SIGNED_IN;
-    const accountId = signedIn ? (await settingsStore.readAccount())?.id : undefined;
-    return {
-      permitted: runMode.sendsNetwork && !sessionReplayEndedByDeletion,
-      ...(accountId ? { accountId } : undefined),
-    };
-  }
-
-  let sessionReplayGeneration = 0;
-  async function emitSessionReplay(): Promise<void> {
-    // The account is read asynchronously, and a sign-out reports the transition
-    // before it clears the stored account, so a late answer must not restart
-    // recording under the person who just left.
-    const generation = ++sessionReplayGeneration;
-    const replay = await sessionReplayState();
-    if (generation !== sessionReplayGeneration) return;
-    emit(GATEWAY_EVENT.SESSION_REPLAY_CHANGED, carried(replay));
-  }
-
-  function emitSettingsSnapshot(
-    settings: SettingsUpdateResult["settings"],
-    reporter?: string,
-  ): void {
-    emit(GATEWAY_EVENT.SETTINGS_CHANGED, {
-      settings: carried(settings),
-      ...(reporter !== undefined ? { reporter } : undefined),
-    });
-  }
-
-  async function emitSettings(): Promise<void> {
-    emitSettingsSnapshot(await settingsStore.snapshot());
-  }
-
-  let announcedCodexCloudConnection = codexCloud.connection();
-  async function emitCodexCloudConnection(): Promise<void> {
-    const connection = codexCloud.connection();
-    if (connection === announcedCodexCloudConnection) return;
-    announcedCodexCloudConnection = connection;
-    await emitSettings();
-  }
-
-  const onboarding = onboardingStateFile(() => stateRoot, report);
-  let onboardingState: OnboardingState | undefined;
-  let announcedCalendarGateOwed: boolean | undefined;
-  function calendarOnboardingGateOwed(): boolean {
-    return runMode.requiresAccount && calendarOnboardingOwed(onboardingState);
-  }
-  /**
-   * The one onboarding write, taking the moment it records and merging it over
-   * the record as it stands on disk — the client writes the
-   * introduction's own moment into the same file. Every moment lives in one
-   * record, so each write reconciles both beats; the gate event stays fenced
-   * on a changed answer, so writing an arrival moment cannot tell the renderer
-   * about a gate that did not move.
-   */
-  function writeOnboardingState(moment: OnboardingState): void {
-    onboardingState = onboarding.update((current) => ({ ...current, ...moment }));
-    if (moment.arrivalSpokenAt !== undefined) withdrawBeat(ARRIVAL_SPEECH_KIND);
-    const owed = calendarOnboardingGateOwed();
-    if (!owed) withdrawBeat(CALENDAR_ONBOARDING_SPEECH_KIND);
-    if (owed === announcedCalendarGateOwed) return;
-    announcedCalendarGateOwed = owed;
-    emit(GATEWAY_EVENT.CALENDAR_ONBOARDING_CHANGED, { owed });
-  }
-  async function settleCalendarOnboardingIfConnected(): Promise<void> {
-    if (!calendarOnboardingOwed(onboardingState)) return;
-    const connected = await settingsStore.calendarConnectionStored();
-    if (!connected || !calendarOnboardingOwed(onboardingState)) return;
-    writeOnboardingState({ calendarOnboardingSettledAt: new Date(now()).toISOString() });
-  }
-  async function calendarGateOfferable(): Promise<boolean> {
-    if (!calendarOnboardingGateOwed()) return false;
-    const settings = await settingsStore.snapshot();
-    if (!calendarOnboardingGateOwed()) return false;
-    return settings.status.appleCalendarAvailable || settings.status.calendarSignInAvailable;
-  }
-  async function requestOnboardingBeat(): Promise<void> {
-    if (!runMode.requiresAccount || account.status !== ACCOUNT_STATUS.SIGNED_IN) return;
-    if (!voiceCapabilities.realtimeCredentials) return;
-    if (await calendarGateOfferable()) {
-      speechArbiter.request({ kind: CALENDAR_ONBOARDING_SPEECH_KIND });
-      void reconcileSpeech();
-      return;
-    }
-    if (!arrivalBeatOwed(onboardingState)) return;
-    await sessionObservationLoop.refresh().catch(() => undefined);
-    if (account.status !== ACCOUNT_STATUS.SIGNED_IN || !arrivalBeatOwed(onboardingState)) return;
-    speechArbiter.request({ kind: ARRIVAL_SPEECH_KIND });
-    void reconcileSpeech();
-  }
-  function markFirstAnnouncementSpoken(): void {
-    if (!countsFirstAnnouncement(onboardingState)) return;
-    const signedInAt = onboardingState?.arrivalSignedInAt;
-    const at = now();
-    const signedInAtMs = signedInAt !== undefined ? Date.parse(signedInAt) : Number.NaN;
-    if (Number.isFinite(signedInAtMs)) {
-      productEvents.record(PRODUCT_EVENT.VOICE_FIRST_ANNOUNCEMENT, {
-        sign_in_age: productSignInAge(at - signedInAtMs),
-      });
-    }
-    writeOnboardingState({ arrivalFirstAnnouncementAt: new Date(at).toISOString() });
-  }
-
-  const supersetSignIn = new SupersetSignIn({
-    cli: supersetCli,
-    openExternal: (url) => openExternalThroughNode(url),
-    onChange: (state) => {
-      emit(GATEWAY_EVENT.SUPERSET_SIGN_IN_CHANGED, carried(state));
-      if (state.stage !== SUPERSET_SIGN_IN_STAGE.CONNECTED) return;
-      void sessionObservationLoop.refresh();
-      recordProductEvent(PRODUCT_EVENT.SUPERSET_ACT, {
-        superset_act: PRODUCT_SUPERSET_ACT.SIGN_IN_COMPLETE,
-      });
-    },
+  speech.link({
+    brainCurrent: () => brain.wiring.current() !== undefined,
+    releaseHeld: (briefings) => brain.wiring.releaseHeld(briefings),
   });
 
-  let unsubscribeSessions: (() => void) | undefined;
-  let lastWorkspaceProjects: string | undefined;
-  let workspaceProjectsBroadcastGeneration = 0;
-
-  async function broadcastWorkspaceProjects(): Promise<void> {
-    const generation = ++workspaceProjectsBroadcastGeneration;
-    const offeredProjects = offeredWorkspaceProjects();
-    const defaults = (await readWorkspaceDefaults()).defaultProjectIds;
-    if (generation !== workspaceProjectsBroadcastGeneration) return;
-    await pruneWorkspaceProjectDefaults(
-      offeredProjects,
-      defaults,
-      () => generation === workspaceProjectsBroadcastGeneration,
-    );
-    if (generation !== workspaceProjectsBroadcastGeneration) return;
-    const projects = normalizeObservedWorkspaceProjects(offeredProjects, defaults);
-    const serialized = JSON.stringify(projects);
-    if (serialized === lastWorkspaceProjects) return;
-    lastWorkspaceProjects = serialized;
-    emit(GATEWAY_EVENT.WORKSPACE_PROJECTS_CHANGED, { projects: carried(projects) });
-  }
-
-  async function pruneWorkspaceProjectDefaults(
-    projects: readonly ObservedWorkspaceProject[],
-    defaults: Readonly<Partial<Record<string, string>>> | undefined,
-    isCurrent: () => boolean,
-  ): Promise<void> {
-    if (account.status === ACCOUNT_STATUS.SIGNED_IN) return;
-    try {
-      for (const providerId of staleWorkspaceProjectDefaults(projects, defaults)) {
-        if (!isCurrent()) return;
-        const expected = defaults?.[providerId];
-        if (expected === undefined) continue;
-        const saved = await settingsStore.clearEntryIfUnchanged(
-          APP_SETTING_SCHEMA.workspaceProjectDefaults.field,
-          providerId,
-          expected,
-        );
-        if (!saved.cleared) continue;
-        if (!isCurrent()) return;
-        emitSettingsSnapshot(saved.settings);
-      }
-    } catch {
-      return;
-    }
-  }
-
-  function accountCapabilitiesActive(): boolean {
-    return accountGateOpen(runMode, account.status === ACCOUNT_STATUS.SIGNED_IN);
-  }
+  const composers: readonly Composer[] = [
+    settings,
+    account,
+    issues,
+    observation,
+    calendars,
+    speech,
+    brain,
+  ];
+  const supervisor = new ObservationSupervisor([observation.loop, issues.loop, calendars.loop]);
 
   async function startAccountCapabilities(): Promise<void> {
-    if (!accountCapabilitiesActive()) return;
-    void reconcileAccountPreferences();
-    await applyVoiceCredential();
-    await emitSettings();
-    if (!accountCapabilitiesActive()) return;
-    startSessionObservation();
-    startCalendarObservation();
-    observationSupervisor.setEnabled(true);
-    void requestOnboardingBeat();
-    reconcileProviderKeyVault();
+    if (!account.capabilitiesActive()) return;
+    void settings.reconcileAccountPreferences();
+    await account.applyVoiceCredential();
+    await settings.emitSettings();
+    if (!account.capabilitiesActive()) return;
+    observation.startObservation();
+    calendars.startObservation();
+    supervisor.setEnabled(true);
+    void speech.requestOnboardingBeat();
+    settings.reconcileProviderKeyVault();
   }
 
   async function stopAccountCapabilities(): Promise<void> {
-    observationSupervisor.setEnabled(false);
-    stopSessionObservation();
-    stopIssueObservation();
-    stopCalendarObservation();
-    withdrawBeat(ARRIVAL_SPEECH_KIND);
-    withdrawBeat(CALENDAR_ONBOARDING_SPEECH_KIND);
-    await applyVoiceCredential();
-    await emitSettings();
-  }
-
-  async function applyVoiceCredential(): Promise<void> {
-    await transitionVoiceCredential({
-      retire: () => brainWiring.retire(),
-      apply: () => voiceCapabilities.apply(),
-      rebuild: async () => {
-        await brainWiring.rebuild();
-        void memoryWiring.sync();
-      },
-    });
-  }
-
-  function withdrawBriefings(): void {
-    const offered = speechArbiter.withdrawBriefings();
-    if (offered) emit(GATEWAY_EVENT.SPEECH_WITHDRAWN, { id: offered });
-    offerNextSpeech();
-  }
-
-  function brainRoster() {
-    const at = now();
-    const sessions = sessionRegistry.list().filter((session) => session.realtimeVoice !== true);
-    return {
-      text: sessionContextText(sessions, at),
-      identities: sessions.map((session) => ({
-        providerId: session.providerId,
-        providerSessionId: session.providerSessionId,
-      })),
-      sessions,
-    };
-  }
-
-  function brainActableSessions(): readonly Session[] {
-    return sessionRegistry.list().filter((session) => session.realtimeVoice !== true);
-  }
-
-  let brainWorkspaceDefaults: WorkspaceCreationDefaults = {};
-
-  async function readWorkspaceDefaults(): Promise<WorkspaceCreationDefaults> {
-    const [defaultProviderId, defaultProjectIds] = await Promise.all([
-      settingsStore.get(APP_SETTING_SCHEMA.defaultWorkspaceProvider.field),
-      settingsStore.get(APP_SETTING_SCHEMA.workspaceProjectDefaults.field),
-    ]);
-    const defaults: WorkspaceCreationDefaults = {};
-    if (defaultProviderId) defaults.defaultProviderId = defaultProviderId;
-    if (defaultProjectIds) defaults.defaultProjectIds = defaultProjectIds;
-    brainWorkspaceDefaults = defaults;
-    return defaults;
-  }
-
-  function brainWorkspaceProjects(): readonly ObservedWorkspaceProject[] {
-    return normalizeObservedWorkspaceProjects(
-      offeredWorkspaceProjects(),
-      brainWorkspaceDefaults.defaultProjectIds,
-    );
-  }
-
-  function brainStandingContext(): string {
-    const sessions = brainActableSessions();
-    const projects = brainWorkspaceProjects();
-    return [
-      workspaceProjectContextText(
-        projects,
-        brainWorkspaceDefaults.defaultProviderId,
-        brainWorkspaceDefaults.defaultProjectIds,
-      ),
-      rememberedFactsText(runtimeStoreWiring.rememberedFacts()),
-      conversationHistoryText(
-        recentConversationEntries(runtimeStoreWiring.thread().entries()),
-        sessions,
-      ),
-      appGuideContextText(appGuide),
-    ]
-      .filter((part): part is string => part !== undefined && part.trim().length > 0)
-      .join("\n\n");
+    supervisor.setEnabled(false);
+    observation.stopObservation();
+    issues.stopObservation();
+    calendars.stopObservation();
+    speech.withdrawBeat(ARRIVAL_SPEECH_KIND);
+    speech.withdrawBeat(CALENDAR_ONBOARDING_SPEECH_KIND);
+    await account.applyVoiceCredential();
+    await settings.emitSettings();
   }
 
   /**
-   * Carries an app act only a renderer can perform to the native node, as the
-   * validated act itself, serialized: the node hands it to the panel and
-   * answers what became of it. No node connected, or one that answers in a
-   * shape this build cannot read, is a refusal, and the act is left undone.
+   * The one method no composer can own: it reads six of them at once, so
+   * giving it to any would hand that composer references to the other five,
+   * which is the coupling the split exists to remove.
    */
-  async function performBrainAppAct(action: BrainAppActRequest["action"]): Promise<WireRecord> {
-    const result = await nodes.invoke(HOST_NODE_CAPABILITY.PANEL_APP_ACT, {
-      action: carried(action),
-    });
-    if (result.status === NODE_CAPABILITY_STATUS.OK && isRecord(result.value)) return result.value;
-    if (result.status === NODE_CAPABILITY_STATUS.UNKNOWN) {
-      return { status: UNKNOWN_ACT_STATUS, reason: result.reason };
-    }
-    return {
-      status: ACT_RESULT_STATUS.REJECTED,
-      reason:
-        result.status === NODE_CAPABILITY_STATUS.OK
-          ? "The panel answered in a shape this build cannot read."
-          : result.reason,
-    };
-  }
-
-  async function deliverBriefing(delivery: BrainDelivery): Promise<void> {
-    if (!voiceCapabilities.realtimeCredentials) return;
-    speechArbiter.request({ kind: BRIEFING_SPEECH_KIND, delivery });
-    await reconcileSpeech();
-  }
-
-  const sessionActPerformer = createSessionActPerformer({
-    sessionRegistry,
-    openExternal: (url) => openExternalThroughNode(url),
-    pluginFor,
-    sendsNetwork: runMode.sendsNetwork,
-    settingsStore,
-    rememberWorkspaceDefaults,
-    expectCreatedWorkspace: (identity, at) => createdWorkspaceOpens.expect(identity, at),
-    openCreatedWorkspaces: () => openCreatedWorkspaces(sessionRegistry.list()),
-    trackedIssues: () => trackedIssues,
-    issueTrackers,
-    refreshIssues: () => void issueObservationLoop.refresh(),
-    supersetContext: (identity) =>
-      superset.actableContext(identity.providerId, identity.providerSessionId),
-    supersetCli,
-    recordProductEvent,
-  });
-
-  const agentWorkspacePath = () => path.join(agentRootPath(stateRoot), AGENT_WORKSPACE_DIRECTORY);
-
-  const memoryWiring: MemoryWiring = runMode.observesProviders
-    ? composeNotebookMemory({
-        client: runtimeStoreWiring.client,
-        embeddingAdapter: () => voiceCapabilities.embeddingAdapter,
-        workspaceDirectory: agentWorkspacePath,
-        conversationDirectory: () => runtimeStoreWiring.directory(),
-        isTemporary: runtimeStoreWiring.isTemporary,
-        now,
-        report,
-        onSynced: () => {
-          void runtimeStoreWiring.refreshNotebook();
-        },
-      })
-    : INERT_MEMORY_WIRING;
-  const memoryMaintenance = wireMemoryMaintenance({
-    persistent: runMode.observesProviders,
-    client: runtimeStoreWiring.client,
-    createRuntime: () => brainWiring.createRuntime(),
-    workspaceDirectory: agentWorkspacePath,
-    isTemporary: runtimeStoreWiring.isTemporary,
-    now,
-    createId,
-    report,
-    onNotebookChanged: () => {
-      void memoryWiring.sync();
-    },
-  });
-  const brainWiring = wireBrain({
-    repositoryFor: (sessionKey) => runtimeStoreWiring.brainStateRepository(sessionKey),
-    ensureObservedConversation: async (sessionKey, name) => {
-      await runtimeStoreWiring.ensureConversation(sessionKey, CONVERSATION_KIND.OBSERVED, name);
-    },
-    ensureChildConversation: async (sessionKey, name) => {
-      await runtimeStoreWiring.ensureConversation(sessionKey, CONVERSATION_KIND.CHILD, name);
-    },
-    archiveConversation: (sessionKey) => runtimeStoreWiring.archive(sessionKey),
-    conversationDirectory: () => runtimeStoreWiring.directory(),
-    historyLines: (sessionKey) => runtimeStoreWiring.thread(sessionKey).entries(),
-    childStore: () => runtimeStoreWiring.childStore(),
-    createId,
-    report,
-    ...(agentTrace ? { traceTurn: (record) => agentTrace.recordBrainTurn(record) } : undefined),
-    recordConversationEntry: (entry, recordedAt, sessionKey) =>
-      runtimeStoreWiring.recordConversationEntry(entry, recordedAt, sessionKey),
-    broadcastRequests: (snapshots) => service.runsReported(snapshots),
-    onEndPublished: (record, sessionKey) => service.endPublished(record, sessionKey),
-    onGenerationReplaced: (sessionKey) => {
-      if (sessionKey === MAIN_SESSION_KEY) withdrawBriefings();
-      service.generationReplaced(sessionKey);
-    },
-    acts: {
-      sessionActs: sessionActPerformer,
-      sessions: brainActableSessions,
-      refreshSessions: () => sessionObservationLoop.refresh(),
-      workspaceProjects: brainWorkspaceProjects,
-      workspaceDefaults: readWorkspaceDefaults,
-      trackedIssues: () => trackedIssues,
-      appGuide: () => appGuide,
-      rememberedFacts: runtimeStoreWiring.rememberedFacts,
-      notebook: {
-        remember: runtimeStoreWiring.rememberNotebookEntry,
-        forget: runtimeStoreWiring.forgetNotebookEntry,
-      },
-      performAppAct: (action) => performBrainAppAct(action),
-      recordConversationEntry: runtimeStoreWiring.recordConversationEntry,
-    },
-    roster: brainRoster,
-    standingContext: brainStandingContext,
-    pluginFor,
-    session: (identity) => sessionRegistry.get(identity),
-    deliver: deliverBriefing,
-    model: () => voiceCapabilities.brainModel,
-    credential: () =>
-      voiceCapabilities.voiceSource === VOICE_SOURCE.KEY
-        ? {
-            kind: CREDENTIAL_REFERENCE_KIND.PROVIDER_KEY,
-            providerId: CREDENTIAL_PROVIDER_ID.OPENAI,
-          }
-        : { kind: CREDENTIAL_REFERENCE_KIND.HOSTED_ACCOUNT },
-    workspaceDirectory: agentWorkspacePath,
-    skillRoots: () => [path.join(agentWorkspacePath(), AGENT_SKILLS_DIRECTORY)],
-    runnable: () =>
-      runMode.observesProviders && runMode.sendsNetwork && accountCapabilitiesActive(),
-    dropBriefings: () => speechArbiter.dropBriefings(),
-    memory: (sessionKey) => memoryWiring.accessFor(sessionKey),
-    beforeCompaction: (sessionKey) => memoryMaintenance.flushHookFor(sessionKey),
-    flushMarker: (sessionKey) => memoryMaintenance.flushMarkerFor(sessionKey),
-    beforeReset: (sessionKey, items) => memoryMaintenance.captureBeforeReset(sessionKey, items),
-  });
-
-  const conversationControls = conversationOperations({
-    store: runtimeStoreWiring,
-    brain: brainWiring,
-    now,
-    report,
-  });
-  let stopHistoryMaintenance: (() => void) | undefined;
-
-  const cronScheduler = new CronScheduler({
-    store: runtimeStoreWiring.scheduledJobStore(),
-    coordinate: (work) => brainWiring.lanes.run(LANE.CRON, work),
-    // The heartbeat is the only job this build schedules. A row of any other
-    // id is one a build before this one left behind — the nightly memory
-    // consolidation, until now — and running it as a heartbeat would be a
-    // turn nothing asked for, so it is removed instead.
-    run: async (job) => {
-      if (job.id !== HEARTBEAT_DEFAULTS.JOB_ID) {
-        report(`A scheduled job this build does not run was removed: ${job.id}`);
-        await cronScheduler.remove(job.id);
-        return;
-      }
-      await brainWiring.heartbeat(job.sessionKey);
-    },
-    report,
-  });
-
-  function pluginFor(providerId: string) {
-    if (providerId === SUPERSET_WORKSPACE_PROVIDER_ID) return superset;
-    if (providerId === CONDUCTOR_LOCAL_WORKSPACE_PROVIDER_ID) return conductorLocalWorkspaces;
-    return isProviderId(providerId) ? providerRegistry[providerId].plugin : undefined;
-  }
-
-  function pluginForCredential(providerId: CredentialProviderId) {
-    return orderedRegistrations.find((entry) => entry.credential?.id === providerId)?.plugin;
-  }
-
-  function workspaceProjectOffered(providerId: string, providerProjectId: string): boolean {
-    const projects = pluginFor(providerId)?.projects?.() ?? [];
-    return projects.some((project) => workspaceProjectSelectionId(project) === providerProjectId);
-  }
-
-  async function rememberWorkspaceDefaults(
-    plugin: SessionProviderPlugin,
-    providerProjectId: string,
-    providerTargetId: string | undefined,
-    namedSelection: WorkspaceAgentSelection | undefined,
-    agent: string | undefined,
-  ): Promise<void> {
-    const providerId = plugin.provider.id;
-    if (!isWorkspaceProviderId(providerId)) return;
-    try {
-      let accountPreferencesTouched = false;
-      if (
-        (await settingsStore.get(APP_SETTING_SCHEMA.defaultWorkspaceProvider.field)) === undefined
-      ) {
-        const saved = await settingsStore.set(
-          APP_SETTING_SCHEMA.defaultWorkspaceProvider.field,
-          providerId,
-        );
-        emitSettingsSnapshot(saved.settings);
-        accountPreferencesTouched = true;
-      }
-      if (
-        providerId === SUPERSET_WORKSPACE_PROVIDER_ID &&
-        agent !== undefined &&
-        (await settingsStore.get(APP_SETTING_SCHEMA.workspaceAgentDefaults.field))?.[
-          SUPERSET_WORKSPACE_PROVIDER_ID
-        ] === undefined
-      ) {
-        const saved = await settingsStore.setEntry(
-          APP_SETTING_SCHEMA.workspaceAgentDefaults.field,
-          SUPERSET_WORKSPACE_PROVIDER_ID,
-          { agent },
-        );
-        emitSettingsSnapshot(saved.settings);
-        accountPreferencesTouched = true;
-      }
-      if (
-        (await settingsStore.get(APP_SETTING_SCHEMA.workspaceProjectDefaults.field))?.[
-          providerId
-        ] === undefined
-      ) {
-        const saved = await settingsStore.setEntry(
-          APP_SETTING_SCHEMA.workspaceProjectDefaults.field,
-          providerId,
-          workspaceProjectSelectionId(
-            providerTargetId ? { providerProjectId, providerTargetId } : { providerProjectId },
-          ),
-        );
-        emitSettingsSnapshot(saved.settings);
-        accountPreferencesTouched = true;
-      }
-      if (
-        isProviderId(providerId) &&
-        namedSelection !== undefined &&
-        (await settingsStore.get(APP_SETTING_SCHEMA.workspaceAgentDefaults.field))?.[providerId] ===
-          undefined
-      ) {
-        const saved = await settingsStore.setEntry(
-          APP_SETTING_SCHEMA.workspaceAgentDefaults.field,
-          providerId,
-          namedSelection,
-        );
-        emitSettingsSnapshot(saved.settings);
-        accountPreferencesTouched = true;
-      }
-      if (accountPreferencesTouched) pushAccountPreferences();
-    } catch {
-      // The reply is the creation's; a failed remember has no line in it.
-    }
-  }
-
-  function offeredWorkspaceProjects(): readonly ObservedWorkspaceProject[] {
-    if (!runMode.observesProviders) return [];
-    return [
-      ...orderedRegistrations.map(({ plugin }) => plugin),
-      superset,
-      conductorLocalWorkspaces,
-    ].flatMap((plugin) =>
-      (plugin.projects?.() ?? []).map((project) => ({
-        ...project,
-        providerId: plugin.provider.id,
-        providerName: plugin.provider.displayName,
-      })),
-    );
-  }
-
-  async function applyLocalSessionHooks(): Promise<void> {
-    if (!runMode.observesProviders || options.registerProviderHooks === false) return;
-    await Promise.all(
-      orderedRegistrations.map(async ({ plugin, registerObservationHook }) => {
-        if (!registerObservationHook) return;
-        try {
-          await registerObservationHook();
-        } catch (error) {
-          const message = error instanceof Error ? error.message : String(error);
-          report(`${plugin.provider.displayName} hook registration failed: ${message}`);
-        }
-      }),
-    );
-    watchObservationSpools();
-  }
-
-  function watchObservationSpools(): void {
-    if (spoolWatchers.length > 0) return;
-    spoolWatchers = orderedRegistrations.flatMap(({ plugin, observationSpool }) => {
-      if (!observationSpool) return [];
-      const providerId = plugin.provider.id;
-      return [
-        watchObservationSpool({
-          spoolDirectory: observationSpool.directory(),
-          events: observationSpool.events,
-          onEvents: (events) => {
-            void (async () => {
-              await sessionObservationLoop.refresh().catch(() => undefined);
-              brainWiring.wake(wakeEventsFromHooks(providerId, events, sessionRegistry, now()));
-            })();
-          },
-        }),
-      ];
-    });
-  }
-
-  async function readSupersetWorkspaceHost(): Promise<WorkspaceHostEnrichment> {
-    try {
-      const agentDefault = (
-        await settingsStore.get(APP_SETTING_SCHEMA.workspaceAgentDefaults.field)
-      )?.[SUPERSET_WORKSPACE_PROVIDER_ID]?.agent;
-      return await superset.refresh(agentDefault);
-    } catch (error) {
-      report(
-        `Superset observation failed: ${error instanceof Error ? error.message : String(error)}`,
-      );
-      return superset.emptyEnrichment;
-    }
-  }
-
-  async function refreshProviderSessions(generation: number): Promise<void> {
-    const actionsWereEnabled = superset.activeOrganization() !== undefined;
-    const conductorRepositoriesPromise = conductorLocalWorkspaces.refresh().catch((error) => {
-      report(
-        `Conductor repository observation failed: ${error instanceof Error ? error.message : String(error)}`,
-      );
-    });
-    const hostEnrichments = await Promise.all(
-      workspaceHosts.map((host) =>
-        host.read().catch((error) => {
-          report(
-            `${host.observationFailureLabel} failed: ${error instanceof Error ? error.message : String(error)}`,
-          );
-          return host.emptyEnrichment;
-        }),
-      ),
-    );
-    await conductorRepositoriesPromise;
-    const supersetActionsEnabled = superset.activeOrganization() !== undefined;
-    if (actionsWereEnabled !== supersetActionsEnabled) {
-      if (supersetActionsEnabled) {
-        emit(GATEWAY_EVENT.SUPERSET_SIGN_IN_CHANGED, {
-          stage: SUPERSET_SIGN_IN_STAGE.CONNECTED,
-          organizations: [],
-        });
-      } else {
-        supersetSignIn.cancel();
-      }
-    }
-    await Promise.all([
-      ...orderedRegistrations.map(async ({ plugin }) => {
-        try {
-          await sessionRegistry.refresh(plugin, (providerId, observations) =>
-            hostEnrichments.reduce(
-              (enriched, enrichment) => enrichment(providerId, enriched),
-              observations,
-            ),
-          );
-        } catch (error) {
-          report(
-            `Session observation failed (${plugin.provider.id}): ${error instanceof Error ? error.message : String(error)}`,
-          );
-        }
-      }),
-      (async () => {
-        try {
-          await sessionRegistry.refresh(superset);
-        } catch (error) {
-          report(
-            `Session observation failed (${superset.provider.id}): ${error instanceof Error ? error.message : String(error)}`,
-          );
-        }
-      })(),
-    ]);
-    if (!sessionObservationLoop.isCurrent(generation)) return;
-    void broadcastWorkspaceProjects();
-  }
-
-  function openCreatedWorkspaces(sessions: readonly Session[]): void {
-    for (const created of createdWorkspaceOpens.claim(sessions, now())) {
-      const link = created.detail.link;
-      if (!link) continue;
-      openExternalThroughNode(supersetPressedLink(link, createId())).catch((error: Error) => {
-        report(`Created workspace could not be opened: ${error.message}`);
-      });
-    }
-  }
-
-  async function announcementsQuietNow(at: number): Promise<boolean> {
-    const paused = !(await settingsStore.get(APP_SETTING_SCHEMA.announceSessions.field));
-    const inMeeting =
-      !paused &&
-      calendarMeetings !== undefined &&
-      activeMeetingEnd(calendarMeetings, at) !== undefined;
-    const holding =
-      paused ||
-      (inMeeting && (await settingsStore.get(APP_SETTING_SCHEMA.quietDuringMeetings.field)));
-    if (holding !== announcementsHeld) {
-      announcementsHeld = holding;
-      emit(GATEWAY_EVENT.ANNOUNCEMENTS_HELD_CHANGED, { held: holding });
-    }
-    return holding;
-  }
-
-  async function refreshAnnouncementHold(): Promise<void> {
-    await announcementsQuietNow(now());
-  }
-
-  function armQuietBoundaryTimer(): void {
-    if (quietBoundaryTimer) clearTimeout(quietBoundaryTimer);
-    quietBoundaryTimer = undefined;
-    if (!calendarMeetings) return;
-    const at = now();
-    const boundary = nextMeetingBoundary(calendarMeetings, at);
-    if (boundary === undefined) return;
-    quietBoundaryTimer = setTimeout(
-      () => {
-        quietBoundaryTimer = undefined;
-        void reconcileSpeech();
-        armQuietBoundaryTimer();
-      },
-      boundary - at + 1,
-    );
-    quietBoundaryTimer.unref();
-  }
-
-  async function reconcileSpeech(): Promise<void> {
-    const quiet = await announcementsQuietNow(now());
-    speechArbiter.setQuiet(quiet);
-    if (!quiet && speechArbiter.heldBriefingCount > 0) {
-      if (brainWiring.current() && voiceCapabilities.realtimeCredentials) {
-        brainWiring.releaseHeld(speechArbiter.takeHeldBriefings());
-      } else if (!voiceCapabilities.realtimeCredentials) {
-        speechArbiter.dropBriefings();
-      }
-    }
-    offerNextSpeech();
-  }
-
-  function settleSpeech(id: string, outcome: SpeechOutcome): void {
-    const settled = speechArbiter.settle(id, outcome);
-    if (!settled) return;
-    if (settled.outcome === SPEECH_OUTCOME.SPOKEN) {
-      if (settled.kind === BRIEFING_SPEECH_KIND) {
-        productEvents.record(PRODUCT_EVENT.VOICE_ANNOUNCEMENT_SPEAK, {});
-        markFirstAnnouncementSpoken();
-      }
-      if (settled.kind === ARRIVAL_SPEECH_KIND && arrivalBeatOwed(onboardingState)) {
-        writeOnboardingState({ arrivalSpokenAt: new Date(now()).toISOString() });
-      }
-    }
-    void reconcileSpeech();
-  }
-
-  /**
-   * Hands the mouth the arbiter's head request, if one may be offered now:
-   * a ready receiver stands, and a voice to say it with. Synchronous past the
-   * quiet's await, so two reconciles landing together cannot each offer.
-   */
-  function offerNextSpeech(): void {
-    if (!voiceReceiver.isReady() || !voiceCapabilities.realtimeCredentials) return;
-    const offer = speechArbiter.next();
-    if (offer) emit(GATEWAY_EVENT.SPEECH_OFFERED, carried(offer));
-  }
-
-  voiceReceiver.onReady(() => {
-    offerNextSpeech();
-    service.receiverReady();
-  });
-  voiceReceiver.onReset(() => speechArbiter.reclaimOffer());
-
-  function withdrawBeat(kind: OnboardingBeatKind): void {
-    const id = speechArbiter.retract(kind);
-    if (id) emit(GATEWAY_EVENT.SPEECH_WITHDRAWN, { id });
-  }
-
-  async function refreshCalendarMeetings(generation: number): Promise<void> {
-    try {
-      const [observations, appleObservation] = await Promise.all([
-        googleCalendar.observe(),
-        appleCalendar.observe(),
-      ]);
-      if (!calendarObservationLoop.isCurrent(generation)) return;
-      const accounts = [...(observations ?? []), ...(appleObservation ? [appleObservation] : [])];
-      calendarMeetings =
-        observations === undefined && appleObservation === undefined
-          ? undefined
-          : accounts.flatMap((held) => [...held.meetings]);
-      observedCalendars = accounts.map(({ accountId, calendars, failure, revoked }) => ({
-        accountId,
-        calendars,
-        ...(failure ? { failure } : undefined),
-        ...(revoked ? { revoked } : undefined),
-      }));
-      emit(GATEWAY_EVENT.CALENDARS_CHANGED, { calendars: carried(observedCalendars) });
-      for (const held of accounts) {
-        if (held.failure) report(`Calendar observation failed: ${held.failure}`);
-      }
-    } catch (error) {
-      report(
-        `Calendar observation failed: ${error instanceof Error ? error.message : String(error)}`,
-      );
-    }
-    if (!calendarObservationLoop.isCurrent(generation)) return;
-    void reconcileSpeech();
-    armQuietBoundaryTimer();
-  }
-
-  const observationGate = () => runMode.observesProviders && accountCapabilitiesActive();
-  const sessionObservationLoop = new ObservationLoop({
-    gate: observationGate,
-    intervalMs: SESSION_REFRESH_INTERVAL_MS,
-    run: refreshProviderSessions,
-    afterRun: () => {
-      void emitCodexCloudConnection();
-      brainWiring.rosterLook();
-    },
-  });
-  const issueObservationLoop = new ObservationLoop({
-    gate: observationGate,
-    intervalMs: ISSUE_REFRESH_INTERVAL_MS,
-    run: refreshTrackedIssues,
-  });
-  const calendarObservationLoop = new ObservationLoop({
-    gate: observationGate,
-    intervalMs: CALENDAR_REFRESH_INTERVAL_MS,
-    run: refreshCalendarMeetings,
-  });
-  const observationSupervisor = new ObservationSupervisor([
-    sessionObservationLoop,
-    issueObservationLoop,
-    calendarObservationLoop,
-  ]);
-
-  async function pollAppleCalendarAccess(): Promise<void> {
-    if (!(await settingsStore.readAppleCalendarConnection())) return;
-    let access: string | undefined;
-    try {
-      access = await appleCalendar.status();
-    } catch (error) {
-      if (!appleAccessProbeFailing) {
-        report(
-          `Calendar access probe failed: ${error instanceof Error ? error.message : String(error)}`,
-        );
-      }
-    }
-    appleAccessProbeFailing = access === undefined;
-    if (access === undefined) return;
-    const drawnRevoked =
-      observedCalendars.find((held) => held.accountId === APPLE_CALENDAR_ID)?.revoked === true;
-    const probeRevoked = access !== APPLE_CALENDAR_ACCESS.FULL;
-    if (probeRevoked !== drawnRevoked) {
-      report(`Calendar access now reads ${access}; running a pass.`);
-      void calendarObservationLoop.refresh();
-    }
-  }
-
-  function startCalendarObservation(): void {
-    if (heldNoticeReleaseTimer) return;
-    heldNoticeReleaseTimer = setInterval(() => {
-      void reconcileSpeech();
-    }, HELD_NOTICE_RELEASE_INTERVAL_MS);
-    heldNoticeReleaseTimer.unref();
-    if (process.platform === "darwin" && runMode.observesProviders) {
-      appleAccessPollTimer = setInterval(() => {
-        void pollAppleCalendarAccess();
-      }, APPLE_ACCESS_POLL_INTERVAL_MS);
-      appleAccessPollTimer.unref();
-    }
-  }
-
-  function stopCalendarObservation(): void {
-    if (heldNoticeReleaseTimer) clearInterval(heldNoticeReleaseTimer);
-    heldNoticeReleaseTimer = undefined;
-    if (appleAccessPollTimer) clearInterval(appleAccessPollTimer);
-    appleAccessPollTimer = undefined;
-    appleAccessProbeFailing = false;
-    if (quietBoundaryTimer) clearTimeout(quietBoundaryTimer);
-    quietBoundaryTimer = undefined;
-    calendarMeetings = undefined;
-    observedCalendars = [];
-    googleCalendar.forget();
-    appleCalendar.forget();
-    speechArbiter.dropBriefings();
-    emit(GATEWAY_EVENT.CALENDARS_CHANGED, { calendars: [] });
-    void refreshAnnouncementHold();
-  }
-
-  let rosterBroadcast = false;
-
-  function broadcastSessions(sessions: readonly Session[]): void {
-    rosterBroadcast = true;
-    emit(GATEWAY_EVENT.SESSIONS_CHANGED, { sessions: carried(sessions), settled: true });
-  }
-
-  function startSessionObservation(): void {
-    if (!runMode.observesProviders || !accountCapabilitiesActive() || unsubscribeSessions) return;
-    unsubscribeSessions = sessionRegistry.subscribe((sessions) => {
-      broadcastSessions(sessions);
-      openCreatedWorkspaces(sessions);
-      void broadcastWorkspaceProjects();
-      countObservedSessions(sessions);
-    });
-  }
-
-  function countObservedSessions(sessions: readonly Session[]): void {
-    const counts = new Map<string, number>();
-    for (const session of sessions) {
-      counts.set(session.providerId, (counts.get(session.providerId) ?? 0) + 1);
-    }
-    for (const [providerId, count] of counts) {
-      if (!isProviderId(providerId)) continue;
-      productEvents.recordOncePerDay(PRODUCT_EVENT.SESSION_OBSERVE, providerId, {
-        provider_id: providerId,
-        session_count: productSessionCountBucket(count),
-      });
-    }
-  }
-
-  function stopSessionObservation(): void {
-    workspaceProjectsBroadcastGeneration += 1;
-    unsubscribeSessions?.();
-    unsubscribeSessions = undefined;
-    for (const { plugin } of orderedRegistrations) {
-      sessionRegistry.replaceProvider(plugin.provider, []);
-    }
-    emit(GATEWAY_EVENT.SESSIONS_CHANGED, { sessions: [], settled: true });
-    emit(GATEWAY_EVENT.WORKSPACE_PROJECTS_CHANGED, { projects: [] });
-    lastWorkspaceProjects = undefined;
-  }
-
-  async function refreshTrackedIssues(generation: number): Promise<void> {
-    try {
-      const collected: TrackedIssue[] = [];
-      let connected = false;
-      for (const tracker of issueTrackers) {
-        const observations = await tracker.observe();
-        if (!observations) continue;
-        connected = true;
-        for (const observation of observations) {
-          const issue = normalizeTrackedIssue(tracker.tracker, observation);
-          if (issue) collected.push(issue);
-        }
-      }
-      if (issueObservationLoop.isCurrent(generation)) {
-        trackedIssues = connected ? collected : undefined;
-      }
-    } catch (error) {
-      report(`Issue observation failed: ${error instanceof Error ? error.message : String(error)}`);
-    }
-  }
-
-  function stopIssueObservation(): void {
-    trackedIssues = undefined;
-  }
-
-  /** The roster a client draws: the same relevance gate every broadcast passes. */
-  function rosterForClients(): readonly Session[] {
-    return runMode.observesProviders && accountCapabilitiesActive() ? sessionRegistry.list() : [];
-  }
-
-  // ---- The settings writes, with the host's own side effects -------------
-
-  function recordSettingUpdate(field: AppSettingField, settings: SettingsUpdateResult["settings"]) {
-    const analytics = settingAnalytics(field, settings.stored);
-    if (!analytics) return;
-    recordProductEvent(PRODUCT_EVENT.SETTING_UPDATE, {
-      setting_id: analytics.id,
-      setting_value: analytics.value,
-    });
-  }
-
-  /**
-   * The side effects a setting has in the host. The client applies its own —
-   * the login item, the Dock, the displays, the form factor, the keys, the
-   * duck — from the same answered snapshot; nothing here reaches a window.
-   */
-  async function applyHostSettingSideEffect(
-    field: AppSettingField,
-    settings: SettingsUpdateResult["settings"],
-  ): Promise<void> {
-    switch (APP_SETTING_SCHEMA[field].mainProcessSideEffect) {
-      case SETTING_SIDE_EFFECT.VOICE:
-        voiceCapabilities.realtimeCredentials?.setVoice(settings.stored.voice);
-        break;
-      case SETTING_SIDE_EFFECT.VOICE_SPEED:
-        voiceCapabilities.realtimeCredentials?.setSpeed(settings.stored.voiceSpeed);
-        break;
-      case SETTING_SIDE_EFFECT.VOICE_SOURCE:
-        await applyVoiceCredential();
-        await emitSettings();
-        break;
-      case SETTING_SIDE_EFFECT.ANNOUNCEMENT_HOLD:
-        void reconcileSpeech();
-        break;
-      case SETTING_SIDE_EFFECT.VAULT_SYNC:
-        void providerKeyVaultSync.apply(settings.stored.syncProviderKeys, { claim: true });
-        break;
-      default:
-        break;
-    }
-  }
-
-  async function applyAccountPreferenceSideEffects(
-    result: SettingsUpdateResult,
-    changed: readonly AccountPreferenceField[],
-  ): Promise<void> {
-    for (const field of changed) {
-      await applyHostSettingSideEffect(field, result.settings);
-    }
-    const workspaceAgentDefaultsChanged = changed.includes(
-      APP_SETTING_SCHEMA.workspaceAgentDefaults.field,
-    );
-    if (workspaceAgentDefaultsChanged) {
-      await readSupersetWorkspaceHost();
-    }
-    if (
-      workspaceAgentDefaultsChanged ||
-      changed.includes(APP_SETTING_SCHEMA.defaultWorkspaceProvider.field) ||
-      changed.includes(APP_SETTING_SCHEMA.workspaceProjectDefaults.field)
-    ) {
-      await broadcastWorkspaceProjects();
-    }
-    emitSettingsSnapshot(result.settings);
-  }
-
-  const refusedSettings = async (reason: string): Promise<SettingsUpdateResult> => ({
-    status: ACT_RESULT_STATUS.REJECTED,
-    settings: await settingsStore.snapshot(),
-    reason,
-  });
-
-  /** Runs one settings write and, when it landed, its host side effects and the change event. */
-  async function settingsWrite(
-    save: () => Promise<SettingsUpdateResult>,
-    apply: (result: SettingsUpdateResult) => Promise<void> | void,
-    refusal: string,
-    reporter: string | undefined,
-  ): Promise<SettingsUpdateResult> {
-    let saved: SettingsUpdateResult;
-    try {
-      saved = await save();
-      await apply(saved);
-    } catch {
-      return refusedSettings(refusal);
-    }
-    emitSettingsSnapshot(saved.settings, reporter);
-    return saved;
-  }
-
-  const reporterOf = (params: WireRecord): string | undefined =>
-    isWireString(params.reporter) ? params.reporter : undefined;
-
-  // ---- The Apple connect's generation, as the client's cancel moves it ----
-  let appleConnectGeneration = 0;
-
-  /** The methods the client reaches this host's ownership through, beside the protocol's own. */
-  const hostMethods: GatewayMethodTable = {
+  const bootstrapMethods: GatewayMethodTable = {
     [GATEWAY_METHOD.SHUTDOWN]: () => {
       options.onShutdownRequested?.();
       return gatewayOk({ accepted: true });
     },
     [GATEWAY_METHOD.CLIENT_BOOTSTRAP]: async () => {
-      const [settings, supersetInstalled, supersetConnected, quiet, replay] = await Promise.all([
-        settingsStore.snapshot(),
-        supersetCli.installed(),
-        supersetCli.connected(),
-        accountCapabilitiesActive() ? announcementsQuietNow(now()) : Promise.resolve(false),
-        sessionReplayState(),
+      const [snapshot, supersetInstalled, supersetConnected, quiet, replay] = await Promise.all([
+        settings.store.snapshot(),
+        observation.supersetCli.installed(),
+        observation.supersetCli.connected(),
+        account.capabilitiesActive()
+          ? calendars.announcementsQuietNow(now())
+          : Promise.resolve(false),
+        account.sessionReplayState(),
       ]);
       return gatewayOk({
-        settings: carried(settings),
-        account: carried(account),
-        sessions: carried(rosterForClients()),
-        sessionsSettled: !runMode.observesProviders || rosterBroadcast,
+        settings: carried(snapshot),
+        account: carried(account.snapshot()),
+        sessions: carried(observation.rosterForClients()),
+        sessionsSettled: observation.rosterSettled(),
         announcementsHeld: quiet,
-        conversationHistory: carried(runtimeStoreWiring.thread().entries()),
+        conversationHistory: carried(brain.store.thread().entries()),
         workspaceProjects: carried(
-          accountCapabilitiesActive()
+          account.capabilitiesActive()
             ? normalizeObservedWorkspaceProjects(
-                offeredWorkspaceProjects(),
-                await settingsStore.get(APP_SETTING_SCHEMA.workspaceProjectDefaults.field),
+                observation.offeredWorkspaceProjects(),
+                await settings.store.get(APP_SETTING_SCHEMA.workspaceProjectDefaults.field),
               )
             : [],
         ),
-        calendars: carried(accountCapabilitiesActive() ? observedCalendars : []),
-        calendarOnboardingOwed: calendarOnboardingGateOwed(),
+        calendars: carried(account.capabilitiesActive() ? calendars.observedCalendars() : []),
+        calendarOnboardingOwed: calendars.gateOwed(),
         supersetInstalled,
         supersetConnected,
         sessionReplay: carried(replay),
-        receiverEpoch: voiceReceiver.epoch(),
-        voiceAvailable: voiceCapabilities.realtimeCredentials !== undefined,
-        agentTraceEnabled: agentTrace !== undefined,
+        receiverEpoch: speech.receiver.epoch(),
+        voiceAvailable: account.voiceCapabilities.realtimeCredentials !== undefined,
+        agentTraceEnabled: account.agentTrace !== undefined,
       });
-    },
-    [GATEWAY_METHOD.SETTINGS_SNAPSHOT]: async () =>
-      gatewayOk({ settings: carried(await settingsStore.snapshot()) }),
-    [GATEWAY_METHOD.SETTINGS_UPDATE]: async (params) => {
-      const field = params.field;
-      if (!isAppSettingField(field) || isKeyedAppSettingField(field)) {
-        return invalid("field must name a plain setting");
-      }
-      const parsed = APP_SETTING_SCHEMA[field].guard(params.value);
-      if (!parsed.valid) return invalid("value is not the shape that setting takes");
-      const result = await settingsWrite(
-        () => settingsStore.set(field, parsed.value),
-        async (saved) => {
-          if (saved.reason) return;
-          recordSettingUpdate(field, saved.settings);
-          await applyHostSettingSideEffect(field, saved.settings);
-        },
-        "Could not save that setting on this system.",
-        reporterOf(params),
-      );
-      if (!result.reason && isAccountPreferenceField(field)) pushAccountPreferences();
-      return gatewayOk(carried(result));
-    },
-    [GATEWAY_METHOD.SETTINGS_UPDATE_ENTRY]: async (params) => {
-      const field = params.field;
-      if (!isKeyedAppSettingField(field)) return invalid("field must name a keyed setting");
-      const key = params.key;
-      if (!isSettingEntryKey(field, key)) return invalid("key is not one that setting takes");
-      // SAFETY: the guard is the parser; a wire value is one it reads.
-      const parsed = settingEntryGuard(field, key, params.value as UnparsedWireValue);
-      if (!parsed.valid) return invalid("value is not the shape that entry takes");
-      // SAFETY: settingEntryGuard validated workspace project defaults as a wire string.
-      const projectWire = parsed.value as UnparsedWireValue;
-      if (
-        field === APP_SETTING_SCHEMA.workspaceProjectDefaults.field &&
-        isWireString(projectWire) &&
-        !workspaceProjectOffered(key, projectWire)
-      ) {
-        return invalid("that project is not one a provider offers");
-      }
-      const result = await settingsWrite(
-        // SAFETY: settingEntryGuard validated the entry before it reaches the store.
-        () => settingsStore.setEntry(field, key, parsed.value as SettingEntryValue<typeof field>),
-        async (saved) => {
-          if (saved.reason) return;
-          recordSettingUpdate(field, saved.settings);
-          await applyHostSettingSideEffect(field, saved.settings);
-        },
-        "Could not save that setting on this system.",
-        reporterOf(params),
-      );
-      if (!result.reason && isAccountPreferenceField(field)) pushAccountPreferences();
-      return gatewayOk(carried(result));
-    },
-    [GATEWAY_METHOD.SETTINGS_RESET]: async (params) => {
-      const scope = params.scope;
-      if (!isSettingsResetScope(scope)) return invalid("scope is not one this build knows");
-      const result = await settingsWrite(
-        () => settingsStore.resetSettings(scope),
-        async (saved) => {
-          if (saved.reason) return;
-          recordProductEvent(PRODUCT_EVENT.SETTINGS_RESET, {});
-          for (const field of APP_SETTING_FIELDS) {
-            const definition = APP_SETTING_SCHEMA[field];
-            if (!("resetScope" in definition) || definition.resetScope !== scope) continue;
-            await applyHostSettingSideEffect(field, saved.settings);
-          }
-        },
-        "Could not reset those settings on this system.",
-        reporterOf(params),
-      );
-      if (!result.reason && resetTouchesAccountPreferences(scope)) pushAccountPreferences();
-      return gatewayOk(carried(result));
-    },
-    [GATEWAY_METHOD.CREDENTIAL_SET_API_KEY]: async (params) => {
-      const providerId = params.providerId;
-      if (!isCredentialProviderId(providerId))
-        return invalid("providerId is not one this build knows");
-      if (params.apiKey !== undefined && !isWireString(params.apiKey)) {
-        return invalid("apiKey must be a string");
-      }
-      const apiKey = params.apiKey;
-      const result = await settingsWrite(
-        () => settingsStore.setApiKey(providerId, apiKey),
-        async (saved) => {
-          if (saved.reason) return;
-          const plugin = pluginForCredential(providerId);
-          if (plugin) void sessionRegistry.refresh(plugin);
-          if (providerId === CREDENTIAL_PROVIDER_ID.LINEAR) void issueObservationLoop.refresh();
-          if (providerId === VOICE_CREDENTIAL_PROVIDER_ID) {
-            await applyVoiceCredential();
-            await emitSettings();
-          }
-          void providerKeyVaultSync.keySaved(
-            providerId,
-            apiKey,
-            saved.settings.stored.syncProviderKeys,
-          );
-          recordProductEvent(
-            apiKey?.trim() ? PRODUCT_EVENT.PROVIDER_CONNECT : PRODUCT_EVENT.PROVIDER_DISCONNECT,
-            { connection_id: providerId },
-          );
-        },
-        "Could not save that API key on this system.",
-        reporterOf(params),
-      );
-      return gatewayOk(carried(result));
-    },
-    [GATEWAY_METHOD.ACCOUNT_SNAPSHOT]: () => gatewayOk({ account: carried(account) }),
-    [GATEWAY_METHOD.ACCOUNT_BEGIN_SIGN_IN]: async (params) => {
-      if (!isAccountProvider(params.provider))
-        return invalid("provider is not one this build knows");
-      recordProductEvent(PRODUCT_EVENT.ACCOUNT_ACT, {
-        account_act: PRODUCT_ACCOUNT_ACT.SIGN_IN_START,
-      });
-      const snapshot = await accountSession.beginSignIn(params.provider);
-      return gatewayOk({ account: carried(snapshot) });
-    },
-    [GATEWAY_METHOD.ACCOUNT_CANCEL_SIGN_IN]: () => {
-      recordProductEvent(PRODUCT_EVENT.ACCOUNT_ACT, {
-        account_act: PRODUCT_ACCOUNT_ACT.SIGN_IN_CANCEL,
-      });
-      accountSession.cancelSignIn();
-      return gatewayOk({});
-    },
-    [GATEWAY_METHOD.ACCOUNT_SIGN_OUT]: async () => {
-      recordProductEvent(PRODUCT_EVENT.ACCOUNT_ACT, { account_act: PRODUCT_ACCOUNT_ACT.SIGN_OUT });
-      // The count of the act leaves before the act ends the account it is
-      // authenticated with; queued behind the sign-out it would wait for the
-      // next sign-in.
-      await productEvents.flush();
-      const snapshot = await accountSession.signOut({ revokeRemote: true });
-      return gatewayOk({ account: carried(snapshot) });
-    },
-    [GATEWAY_METHOD.ACCOUNT_DELETE]: async () => {
-      recordProductEvent(PRODUCT_EVENT.ACCOUNT_ACT, { account_act: PRODUCT_ACCOUNT_ACT.DELETE });
-      await productEvents.flush();
-      const snapshot = await accountSession.deleteEverywhere();
-      // Only a deletion that landed stands recording down for the run.
-      sessionReplayEndedByDeletion = true;
-      void emitSessionReplay();
-      return gatewayOk({ account: carried(snapshot) });
-    },
-    [GATEWAY_METHOD.CALENDAR_CONNECT_GOOGLE]: async (params) => {
-      const result = await settingsWrite(
-        async () => {
-          const outcome = await googleCalendarSignIn.signIn();
-          if ("reason" in outcome) return refusedSettings(outcome.reason);
-          let primaryId: string | undefined;
-          try {
-            const calendars = await googleCalendar.listCalendars(outcome.accessToken);
-            primaryId = (calendars.find((candidate) => candidate.primary) ?? calendars[0])?.id;
-          } catch {
-            primaryId = undefined;
-          }
-          if (!primaryId) {
-            return refusedSettings("Google did not answer with the account's calendars.");
-          }
-          return settingsStore.addCalendarAccount(primaryId, outcome.refreshToken, [primaryId]);
-        },
-        (saved) => {
-          if (saved.reason) return;
-          void calendarObservationLoop.refresh();
-          recordProductEvent(PRODUCT_EVENT.CALENDAR_CONNECT, {
-            calendar_source: PRODUCT_CALENDAR_SOURCE.GOOGLE,
-          });
-        },
-        "Could not connect Google Calendar on this system.",
-        reporterOf(params),
-      );
-      return gatewayOk(carried(result));
-    },
-    [GATEWAY_METHOD.CALENDAR_CANCEL_GOOGLE_SIGN_IN]: () => {
-      googleCalendarSignIn.cancel();
-      return gatewayOk({});
-    },
-    [GATEWAY_METHOD.CALENDAR_REOPEN_GOOGLE_SIGN_IN]: () => {
-      googleCalendarSignIn.reopen();
-      return gatewayOk({});
-    },
-    [GATEWAY_METHOD.CALENDAR_REMOVE_ACCOUNT]: async (params) => {
-      if (!isWireString(params.accountId)) return invalid("accountId must be a string");
-      const accountId = params.accountId;
-      const result = await settingsWrite(
-        () => settingsStore.removeCalendarAccount(accountId),
-        (saved) => {
-          if (saved.reason) return;
-          void calendarObservationLoop.refresh();
-          recordProductEvent(PRODUCT_EVENT.CALENDAR_DISCONNECT, {
-            calendar_source: PRODUCT_CALENDAR_SOURCE.GOOGLE,
-          });
-        },
-        "Could not disconnect that account on this system.",
-        reporterOf(params),
-      );
-      return gatewayOk(carried(result));
-    },
-    [GATEWAY_METHOD.CALENDAR_CONNECT_APPLE]: async (params) => {
-      const generation = ++appleConnectGeneration;
-      let stored = false;
-      const result = await settingsWrite(
-        async () => {
-          // The system's own consent is the whole connect flow, raised by the
-          // helper on the desktop at this press and nowhere else.
-          const outcome = await appleCalendar.obtainAccess({
-            openSystemSettings: () =>
-              void openExternalThroughNode(CALENDAR_PRIVACY_PANE_URL).catch(reportOpenFailure),
-            superseded: () => appleConnectGeneration !== generation,
-          });
-          if (appleConnectGeneration !== generation) {
-            return { status: ACT_RESULT_STATUS.ACCEPTED, settings: await settingsStore.snapshot() };
-          }
-          if (outcome.access !== APPLE_CALENDAR_ACCESS.FULL) {
-            return refusedSettings(
-              outcome.failure ?? APPLE_CALENDAR_ACCESS_REFUSAL[outcome.access],
-            );
-          }
-          const seed = outcome.defaultCalendarId ?? outcome.calendars[0]?.id;
-          stored = true;
-          return settingsStore.connectAppleCalendar(seed ? [seed] : []);
-        },
-        (saved) => {
-          if (saved.reason) return;
-          void calendarObservationLoop.refresh();
-          if (stored) {
-            recordProductEvent(PRODUCT_EVENT.CALENDAR_CONNECT, {
-              calendar_source: PRODUCT_CALENDAR_SOURCE.APPLE,
-            });
-          }
-        },
-        "Could not connect Apple Calendar on this system.",
-        reporterOf(params),
-      );
-      return gatewayOk(carried(result));
-    },
-    [GATEWAY_METHOD.CALENDAR_DISCONNECT_APPLE]: async (params) => {
-      const result = await settingsWrite(
-        () => settingsStore.disconnectAppleCalendar(),
-        (saved) => {
-          if (saved.reason) return;
-          void calendarObservationLoop.refresh();
-          recordProductEvent(PRODUCT_EVENT.CALENDAR_DISCONNECT, {
-            calendar_source: PRODUCT_CALENDAR_SOURCE.APPLE,
-          });
-        },
-        "Could not disconnect Apple Calendar on this system.",
-        reporterOf(params),
-      );
-      return gatewayOk(carried(result));
-    },
-    [GATEWAY_METHOD.CALENDAR_APPLE_ACCESS_STATUS]: async () => {
-      try {
-        return gatewayOk({ access: await appleCalendar.status() });
-      } catch {
-        return gatewayOk({ access: APPLE_CALENDAR_ACCESS.NOT_DETERMINED });
-      }
-    },
-    [GATEWAY_METHOD.CALENDAR_CANCEL_APPLE_CONNECT]: () => {
-      appleConnectGeneration += 1;
-      return gatewayOk({});
-    },
-    [GATEWAY_METHOD.CALENDAR_REFRESH]: async () => {
-      await calendarObservationLoop.refresh();
-      return gatewayOk({});
-    },
-    [GATEWAY_METHOD.CALENDAR_SET_SELECTED]: async (params) => {
-      if (!isWireString(params.accountId) || !isWireString(params.calendarId)) {
-        return invalid("accountId and calendarId must be strings");
-      }
-      if (!isWireBoolean(params.selected)) return invalid("selected must be a boolean");
-      const { accountId, calendarId, selected } = params;
-      if (
-        selected &&
-        !observedCalendars
-          .find((held) => held.accountId === accountId)
-          ?.calendars.some((candidate) => candidate.id === calendarId)
-      ) {
-        return gatewayOk(
-          carried(
-            await refusedSettings("That calendar is not one the account's latest list offered."),
-          ),
-        );
-      }
-      const result = await settingsWrite(
-        () => settingsStore.setCalendarSelected(accountId, calendarId, selected),
-        (saved) => {
-          if (saved.reason) return;
-          void calendarObservationLoop.refresh();
-          recordProductEvent(PRODUCT_EVENT.SETTING_UPDATE, {
-            setting_id: APP_SETTING_ID.CALENDAR_SELECTED,
-            setting_value: selected ? PRODUCT_SETTING_VALUE.ON : PRODUCT_SETTING_VALUE.OFF,
-          });
-        },
-        "Could not save that calendar choice on this system.",
-        reporterOf(params),
-      );
-      return gatewayOk(carried(result));
-    },
-    [GATEWAY_METHOD.TRACKER_CONNECT]: async (params) => {
-      const result = await settingsWrite(
-        async () => {
-          const outcome = await linearSignIn.signIn();
-          if ("reason" in outcome) return refusedSettings(outcome.reason);
-          return settingsStore.setGrant(CREDENTIAL_PROVIDER_ID.LINEAR, outcome);
-        },
-        (saved) => {
-          if (saved.reason) return;
-          void issueObservationLoop.refresh();
-          recordProductEvent(PRODUCT_EVENT.TRACKER_CONNECT, {
-            tracker_id: ISSUE_TRACKER_ID.LINEAR,
-          });
-        },
-        "Could not connect Linear on this system.",
-        reporterOf(params),
-      );
-      return gatewayOk(carried(result));
-    },
-    [GATEWAY_METHOD.TRACKER_CANCEL_SIGN_IN]: () => {
-      linearSignIn.cancel();
-      return gatewayOk({});
-    },
-    [GATEWAY_METHOD.TRACKER_REOPEN_SIGN_IN]: () => {
-      linearSignIn.reopen();
-      return gatewayOk({});
-    },
-    [GATEWAY_METHOD.TRACKER_DISCONNECT]: async (params) => {
-      const result = await settingsWrite(
-        async () => {
-          await linearCredentials.disconnect();
-          return { status: ACT_RESULT_STATUS.ACCEPTED, settings: await settingsStore.snapshot() };
-        },
-        (saved) => {
-          if (saved.reason) return;
-          void issueObservationLoop.refresh();
-          recordProductEvent(PRODUCT_EVENT.TRACKER_DISCONNECT, {
-            tracker_id: ISSUE_TRACKER_ID.LINEAR,
-          });
-        },
-        "Could not disconnect Linear on this system.",
-        reporterOf(params),
-      );
-      return gatewayOk(carried(result));
-    },
-    [GATEWAY_METHOD.SUPERSET_STATUS]: async () => {
-      const [installed, connected] = await Promise.all([
-        supersetCli.installed(),
-        supersetCli.connected(),
-      ]);
-      return gatewayOk({ installed, connected });
-    },
-    [GATEWAY_METHOD.SUPERSET_BEGIN_SIGN_IN]: async () => {
-      recordProductEvent(PRODUCT_EVENT.SUPERSET_ACT, {
-        superset_act: PRODUCT_SUPERSET_ACT.SIGN_IN_START,
-      });
-      return gatewayOk({ state: carried(await supersetSignIn.begin()) });
-    },
-    [GATEWAY_METHOD.SUPERSET_SUBMIT_CODE]: async (params) => {
-      if (!isWireString(params.code)) return invalid("code must be a string");
-      return gatewayOk({ state: carried(await supersetSignIn.submitCode(params.code)) });
-    },
-    [GATEWAY_METHOD.SUPERSET_CHOOSE_ORGANIZATION]: async (params) => {
-      if (!isWireString(params.slug)) return invalid("slug must be a string");
-      return gatewayOk({ state: carried(await supersetSignIn.chooseOrganization(params.slug)) });
-    },
-    [GATEWAY_METHOD.SUPERSET_REOPEN_SIGN_IN]: () => {
-      supersetSignIn.reopen();
-      return gatewayOk({});
-    },
-    [GATEWAY_METHOD.SUPERSET_CANCEL_SIGN_IN]: () => {
-      supersetSignIn.cancel();
-      recordProductEvent(PRODUCT_EVENT.SUPERSET_ACT, {
-        superset_act: PRODUCT_SUPERSET_ACT.SIGN_IN_CANCEL,
-      });
-      return gatewayOk({});
-    },
-    [GATEWAY_METHOD.SUPERSET_DISCONNECT]: async () => {
-      if (!(await supersetCli.signOut())) {
-        return gatewayOk({
-          status: ACT_RESULT_STATUS.REJECTED,
-          reason: "Superset could not sign out.",
-        });
-      }
-      supersetSignIn.cancel();
-      void sessionObservationLoop.refresh();
-      recordProductEvent(PRODUCT_EVENT.SUPERSET_ACT, {
-        superset_act: PRODUCT_SUPERSET_ACT.DISCONNECT,
-      });
-      return gatewayOk({ status: ACT_RESULT_STATUS.ACCEPTED });
-    },
-    [GATEWAY_METHOD.SESSION_ROSTER]: () =>
-      gatewayOk({
-        sessions: carried(rosterForClients()),
-        settled: !runMode.observesProviders || rosterBroadcast,
-      }),
-    [GATEWAY_METHOD.SESSION_OPEN]: async (params) => {
-      if (!isSessionIdentity(params.identity)) return invalid("identity must name a session");
-      return gatewayOk(carried(await sessionActPerformer.openSession(params.identity)));
-    },
-    [GATEWAY_METHOD.SESSION_OPEN_APPLICATION]: async (params) => {
-      if (!isSessionIdentity(params.identity)) return invalid("identity must name a session");
-      if (!isWireString(params.applicationId) || !isSessionApplicationId(params.applicationId)) {
-        return invalid("applicationId is not one this build knows");
-      }
-      return gatewayOk(
-        carried(
-          await sessionActPerformer.openSessionApplication(params.identity, params.applicationId),
-        ),
-      );
-    },
-    [GATEWAY_METHOD.SESSION_OPEN_CHANGE]: async (params) => {
-      if (!isSessionIdentity(params.identity)) return invalid("identity must name a session");
-      return gatewayOk(carried(await sessionActPerformer.openSessionChange(params.identity)));
-    },
-    [GATEWAY_METHOD.WORKSPACE_PROJECTS]: async () =>
-      gatewayOk({
-        projects: carried(
-          accountCapabilitiesActive()
-            ? normalizeObservedWorkspaceProjects(
-                offeredWorkspaceProjects(),
-                await settingsStore.get(APP_SETTING_SCHEMA.workspaceProjectDefaults.field),
-              )
-            : [],
-        ),
-      }),
-    [GATEWAY_METHOD.SPEECH_SETTLE]: (params) => {
-      if (!isIdentifier(params.id)) return invalid("id must be a non-empty string");
-      if (!isSpeechOutcome(params.outcome)) return invalid("outcome is not one this build knows");
-      settleSpeech(params.id, params.outcome);
-      return gatewayOk({});
-    },
-    // The one voice receiver's lifecycle, as the client that owns its window
-    // reports it. Begin mints an epoch here and answers it; ready counts only
-    // for the epoch it names; reset ends the epoch. The client's connection
-    // closing ends it too, below, so nothing is offered to a renderer nobody
-    // can reach.
-    [GATEWAY_METHOD.RECEIVER_REPORT]: (params) => {
-      switch (params.kind) {
-        case RECEIVER_REPORT_KIND.BEGIN:
-          return gatewayOk({ epoch: voiceReceiver.begin() });
-        case RECEIVER_REPORT_KIND.READY:
-          if (!isWireNumber(params.epoch)) return invalid("epoch must be a number");
-          return gatewayOk({ ready: voiceReceiver.markReady(params.epoch) });
-        case RECEIVER_REPORT_KIND.RESET:
-          voiceReceiver.reset();
-          return gatewayOk({ epoch: voiceReceiver.epoch() });
-        default:
-          return invalid("kind is not one this build knows");
-      }
-    },
-    // The one credential that crosses to the voice client: the short-lived
-    // realtime secret the account minter issues, never the key or the token
-    // behind it. Counted here, under the source it actually came from.
-    [GATEWAY_METHOD.VOICE_MINT_REALTIME_CREDENTIAL]: async () => {
-      const minter = voiceCapabilities.realtimeCredentials;
-      if (!minter) return gatewayOk({});
-      const credential = await minter.mint();
-      if (credential) {
-        recordProductEvent(PRODUCT_EVENT.VOICE_CALL_START, {
-          credential_source: VOICE_SOURCE_COUNTED_AS[voiceCapabilities.voiceSource],
-        });
-      }
-      return gatewayOk(credential ? { credential: carried(credential) } : {});
-    },
-    [GATEWAY_METHOD.VOICE_DIAGNOSTICS]: () =>
-      gatewayOk({
-        diagnostics: carried(
-          voiceCapabilities.realtimeCredentials?.diagnostics() ??
-            voiceCapabilities.unavailableDiagnostics,
-        ),
-      }),
-    // One realtime event the renderer's tap saw cross the data channel, into
-    // the development trace. Read again here for the shape the tap sends; on
-    // a run without a writer — packaged, fixture, or simply untraced — it
-    // lands here and stops.
-    [GATEWAY_METHOD.VOICE_RECORD_TRACE]: (params) => {
-      if (!isAgentWireTrace(params.trace)) return invalid("trace is not one tapped wire event");
-      agentTrace?.recordWire(params.trace);
-      return gatewayOk({});
-    },
-    [GATEWAY_METHOD.GUIDE_REPORT]: (params) => {
-      if (!isAppGuideSnapshot(params.guide))
-        return invalid("guide is not the shape a panel reports");
-      appGuide = params.guide;
-      return gatewayOk({});
-    },
-    // A count the client's own surfaces made: read against the allowlist
-    // again here, and queued only when it reads. Nothing observed can travel
-    // in one, because the reader builds the event from the allowlist rather
-    // than from what arrived.
-    [GATEWAY_METHOD.ANALYTICS_RECORD]: (params) => {
-      const event = productEventFromWire(params.event);
-      if (!event) return invalid("event is not one the allowlist names");
-      // SAFETY: the reader built these properties from the allowlist for this very name.
-      productEvents.record(
-        event.name,
-        event.properties as ProductEventPropertiesFor<typeof event.name>,
-      );
-      return gatewayOk({});
-    },
-    [GATEWAY_METHOD.CONVERSATION_APPEND]: async (params) => {
-      const sessionKey =
-        params.sessionKey === undefined
-          ? MAIN_SESSION_KEY
-          : isIdentifier(params.sessionKey)
-            ? toSessionKey(params.sessionKey)
-            : undefined;
-      if (!sessionKey) return invalid("sessionKey must be a non-empty string");
-      if (!Array.isArray(params.entries)) return invalid("entries must be a list");
-      const entries: ConversationEntry[] = [];
-      for (const entry of params.entries) {
-        const stored = storedConversationEntry(entry);
-        if (!stored) return invalid("an entry is not the shape History keeps");
-        entries.push(stored);
-      }
-      const accepted = await runtimeStoreWiring
-        .thread(sessionKey)
-        .append(entries, reporterOf(params));
-      return gatewayOk({ accepted });
-    },
-    [GATEWAY_METHOD.ONBOARDING_STATE]: () =>
-      gatewayOk({ calendarOnboardingOwed: calendarOnboardingGateOwed() }),
-    [GATEWAY_METHOD.ONBOARDING_SKIP_CALENDAR]: () => {
-      if (calendarOnboardingOwed(onboardingState)) {
-        writeOnboardingState({ calendarOnboardingSkippedAt: new Date(now()).toISOString() });
-        void requestOnboardingBeat();
-      }
-      return gatewayOk({});
-    },
-    [GATEWAY_METHOD.ONBOARDING_COMPLETE_CALENDAR]: () => {
-      if (calendarOnboardingOwed(onboardingState)) {
-        writeOnboardingState({ calendarOnboardingSettledAt: new Date(now()).toISOString() });
-        void requestOnboardingBeat();
-      }
-      return gatewayOk({});
     },
   };
 
-  service = createGatewayService({
+  const service = createGatewayService({
     brain: {
-      current: (sessionKey) => brainWiring.current(sessionKey),
-      agentForRun: (runId) => brainWiring.agentForRun(runId),
-      conversationForRun: (runId) => brainWiring.conversationForRun(runId),
-      allRequests: () => brainWiring.allRequests(),
-      generationId: (sessionKey) => brainWiring.store(sessionKey).generationId(),
-      holdsGeneration: (generationId) => brainWiring.holdsGeneration(generationId),
-      publicationSettled: () => brainWiring.publicationSettled(),
-      children: brainWiring.children,
-      configuration: () => brainWiring.configuration(),
-      updateConfiguration: (patch) => brainWiring.updateConfiguration(patch),
+      current: (sessionKey) => brain.wiring.current(sessionKey),
+      agentForRun: (runId) => brain.wiring.agentForRun(runId),
+      conversationForRun: (runId) => brain.wiring.conversationForRun(runId),
+      allRequests: () => brain.wiring.allRequests(),
+      generationId: (sessionKey) => brain.wiring.store(sessionKey).generationId(),
+      holdsGeneration: (generationId) => brain.wiring.holdsGeneration(generationId),
+      publicationSettled: () => brain.wiring.publicationSettled(),
+      children: brain.wiring.children,
+      configuration: () => brain.wiring.configuration(),
+      updateConfiguration: (patch) => brain.wiring.updateConfiguration(patch),
     },
-    conversations: conversationControls,
+    conversations: brain.conversations,
     memory: {
       status: () => ({
-        mode: memoryWiring.mode(),
-        entries: runtimeStoreWiring.rememberedFacts().length,
+        mode: brain.memoryMode(),
+        entries: brain.store.rememberedFacts().length,
       }),
     },
-    observedSessionCount: () =>
-      sessionRegistry.list().filter((session) => session.realtimeVoice !== true).length,
-    deliveries: brainReplyDeliveries,
-    receiver: voiceReceiver,
-    nodes,
+    observedSessionCount: observation.observedSessionCount,
+    deliveries: brain.deliveries,
+    receiver: speech.receiver,
+    nodes: kernel.nodes,
     recordConversationEntry: (entry, recordedAt, sessionKey) =>
-      runtimeStoreWiring.recordConversationEntry(entry, recordedAt, sessionKey),
+      brain.store.recordConversationEntry(entry, recordedAt, sessionKey),
     now,
-    createId,
-    methods: hostMethods,
+    createId: kernel.createId,
+    methods: { ...mergeMethods(composers), ...bootstrapMethods },
     // A client whose connection closed can reach no renderer: its receiver
     // epoch ends here as its window going away would, so replies and
     // briefings wait for the next epoch rather than being offered into a gap.
-    onOperatorDisconnected: () => voiceReceiver.reset(),
+    onOperatorDisconnected: () => speech.receiver.reset(),
   });
+  kernel.setService(service);
+
+  // The order the launch has to keep: the account is read before anything
+  // gated on it, the store is open before the brain's credential transition
+  // installs a runtime over it, and the loops are armed only once every
+  // owner of one has started.
+  const startOrder: readonly Composer[] = [
+    settings,
+    account,
+    brain,
+    calendars,
+    observation,
+    speech,
+    issues,
+  ];
 
   const start = async (): Promise<void> => {
-    account = runMode.requiresAccount
-      ? await settingsStore.accountSnapshot()
-      : { status: ACCOUNT_STATUS.SIGNED_OUT };
-    accountSession.initialize(account);
-    onboardingState = onboarding.read();
-    if (runMode.observesProviders) {
-      await runtimeStoreWiring.open();
-      await seedWorkspaceThenStartMemory({
-        seedWorkspace: async () => {
-          await brainWiring.seedWorkspace();
-        },
-        startMemory: () => memoryWiring.start(),
-        report,
-      });
-      await brainWiring.store().load();
-      await runtimeStoreWiring.restore();
-      stopHistoryMaintenance = startHistoryMaintenance({
-        store: runtimeStoreWiring,
-        brain: brainWiring,
-      });
-      await cronScheduler.start();
-      await cronScheduler.ensure(heartbeatJob(now()));
-    }
-    void settleCalendarOnboardingIfConnected();
-    void settingsStore.snapshot();
-    productEvents.arm();
-    productEvents.record(PRODUCT_EVENT.APP_LAUNCH, { app_version: options.appVersion });
-    productEvents.markDayActive();
-    if (runMode.sendsNetwork) productEvents.start();
-    void applyLocalSessionHooks().catch((error) => {
-      report(
-        `Local session hook registration failed: ${error instanceof Error ? error.message : String(error)}`,
-      );
-    });
-    if (account.status === ACCOUNT_STATUS.SIGNED_IN) void reconcileAccountPreferences();
-    await applyVoiceCredential();
-    startSessionObservation();
-    startCalendarObservation();
-    observationSupervisor.setEnabled(true);
-    if (account.status === ACCOUNT_STATUS.SIGNED_IN) reconcileProviderKeyVault();
-    void requestOnboardingBeat();
-    void accountSession.refreshOnce();
+    for (const composer of startOrder) await composer.start();
+    if (account.signedIn()) void settings.reconcileAccountPreferences();
+    await account.applyVoiceCredential();
+    observation.startObservation();
+    calendars.startObservation();
+    supervisor.setEnabled(true);
+    if (account.signedIn()) settings.reconcileProviderKeyVault();
+    void speech.requestOnboardingBeat();
+    void account.session.refreshOnce();
   };
 
   /**
@@ -2535,30 +267,30 @@ export function composeHost(options: HostSeams): Host {
     {
       closeAdmissions: () => service.server.closeAdmissions(),
       cancelActive: async () => {
-        observationSupervisor.setEnabled(false);
-        cronScheduler.stop();
+        supervisor.setEnabled(false);
+        brain.cron.stop();
         const cancelled: string[] = [];
-        for (const record of brainWiring.allRequests()) {
+        for (const record of brain.wiring.allRequests()) {
           if (
             record.status !== BRAIN_REQUEST_STATUS.QUEUED &&
             record.status !== BRAIN_REQUEST_STATUS.RUNNING
           ) {
             continue;
           }
-          const agent = brainWiring.agentForRun(record.runId);
+          const agent = brain.wiring.agentForRun(record.runId);
           if (!agent) continue;
           cancelled.push(record.runId);
           await agent.cancelAsk(record.runId).catch(() => undefined);
         }
-        for (const child of brainWiring.children.children()) {
+        for (const child of brain.wiring.children.children()) {
           if (isTerminalChildRunStatus(child.status)) continue;
-          await brainWiring.children.cancel(child.childId).catch(() => undefined);
+          await brain.wiring.children.cancel(child.childId).catch(() => undefined);
         }
         return cancelled;
       },
       awaitSettled: async (signal) => {
         if (signal.aborted) return;
-        await brainWiring.publicationSettled();
+        await brain.wiring.publicationSettled();
       },
       persistUnresolved: async () => {
         // What the next launch will find: the records as the stores last
@@ -2568,11 +300,11 @@ export function composeHost(options: HostSeams): Host {
         // never replays, so it is counted here as unresolved.
         const keys = new Set<SessionKey>([
           MAIN_SESSION_KEY,
-          ...runtimeStoreWiring.directory().map((entry) => entry.sessionKey),
+          ...brain.store.directory().map((entry) => entry.sessionKey),
         ]);
         let unresolved = 0;
         for (const key of keys) {
-          const persisted = brainWiring.store(key).current();
+          const persisted = brain.wiring.store(key).current();
           if (!persisted) continue;
           unresolved += persisted.requests.filter(
             (record) =>
@@ -2583,21 +315,18 @@ export function composeHost(options: HostSeams): Host {
         return unresolved;
       },
     },
-    () => productEvents.flush(),
+    () => settings.flushProductEvents(),
   );
 
   const close = async (): Promise<void> => {
-    observationSupervisor.setEnabled(false);
-    stopCalendarObservation();
-    for (const watcher of spoolWatchers) watcher.close();
-    spoolWatchers = [];
-    stopHistoryMaintenance?.();
-    cronScheduler.stop();
-    brainWiring.retire();
-    memoryWiring.stop();
-    supersetSignIn.shutdown();
-    productEvents.stop();
-    await runtimeStoreWiring.close();
+    supervisor.setEnabled(false);
+    // Every concern gives back what it began, in the reverse of the order it
+    // began in; one that cannot must not strand the store's close.
+    for (const composer of [...startOrder].reverse()) {
+      await composer.stop().catch((error: Error) => {
+        report(`a composer did not stop cleanly: ${error.message}`);
+      });
+    }
   };
 
   const stop = async (shutdown: GatewayShutdownOptions = {}): Promise<void> => {
@@ -2626,10 +355,3 @@ export function composeHost(options: HostSeams): Host {
 
   return { server: service.server, start, stop };
 }
-
-/** How a receiver report names the moment it reports. */
-export const RECEIVER_REPORT_KIND = {
-  BEGIN: "begin",
-  READY: "ready",
-  RESET: "reset",
-} as const;

--- a/packages/host/src/compose-issues.ts
+++ b/packages/host/src/compose-issues.ts
@@ -1,0 +1,154 @@
+import { PRODUCT_EVENT } from "@sidecar/analytics";
+import {
+  CREDENTIAL_PROVIDER_ID,
+  LinearCredentials,
+  LinearIssueTracker,
+  LinearSignIn,
+} from "@sidecar/credentials";
+import { carried, GATEWAY_METHOD, type GatewayMethodTable, gatewayOk } from "@sidecar/gateway";
+import { ISSUE_TRACKER_ID, normalizeTrackedIssue, type TrackedIssue } from "@sidecar/issues";
+import { ObservationLoop } from "@sidecar/runtime";
+import { ACT_RESULT_STATUS } from "@sidecar/wire";
+import type { SettingsComposer } from "./compose-settings.js";
+import type { Composer } from "./composer.js";
+import type { HostKernel } from "./host-kernel.js";
+import { reporterOf } from "./wire-helpers.js";
+
+/** A board changes at the pace of hands, not of models; a minute is current. */
+const ISSUE_REFRESH_INTERVAL_MS = 60_000;
+
+export interface IssuesComposer extends Composer {
+  /** The loop the merge's supervisor enables; the composer never enables it itself. */
+  readonly loop: ObservationLoop;
+  readonly trackers: readonly LinearIssueTracker[];
+  issues: () => readonly TrackedIssue[] | undefined;
+  refresh: () => void;
+  /** What the account's capability gate takes back: the board a signed-out Luke may not draw. */
+  stopObservation: () => void;
+}
+
+export interface IssuesDependencies {
+  kernel: HostKernel;
+  settings: SettingsComposer;
+  observationGate: () => boolean;
+}
+
+export function composeIssues(dependencies: IssuesDependencies): IssuesComposer {
+  const { kernel, settings, observationGate } = dependencies;
+  const { report } = kernel;
+  const settingsStore = settings.store;
+
+  const linearCredentials = new LinearCredentials({
+    readGrant: () => settingsStore.readGrant(CREDENTIAL_PROVIDER_ID.LINEAR),
+    writeGrant: async (grant) => {
+      await settingsStore.setGrant(CREDENTIAL_PROVIDER_ID.LINEAR, grant);
+    },
+    forgetGrant: async () => {
+      const cleared = await settingsStore.clearGrant(CREDENTIAL_PROVIDER_ID.LINEAR);
+      // Nobody pressed anything to end this connection — Linear refused the
+      // renewal — so no settings reply is on its way to say so.
+      settings.emitSettingsSnapshot(cleared.settings);
+    },
+  });
+  const linearTracker = new LinearIssueTracker({
+    readAccessToken: () => linearCredentials.accessToken(),
+  });
+  const linearSignIn = new LinearSignIn({
+    openExternal: (url) => void kernel.openExternalThroughNode(url).catch(kernel.reportOpenFailure),
+  });
+  const issueTrackers = [linearTracker] as const;
+  let trackedIssues: readonly TrackedIssue[] | undefined;
+
+  async function refreshTrackedIssues(generation: number): Promise<void> {
+    try {
+      const collected: TrackedIssue[] = [];
+      let connected = false;
+      for (const tracker of issueTrackers) {
+        const observations = await tracker.observe();
+        if (!observations) continue;
+        connected = true;
+        for (const observation of observations) {
+          const issue = normalizeTrackedIssue(tracker.tracker, observation);
+          if (issue) collected.push(issue);
+        }
+      }
+      if (loop.isCurrent(generation)) {
+        trackedIssues = connected ? collected : undefined;
+      }
+    } catch (error) {
+      report(`Issue observation failed: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+
+  function stopObservation(): void {
+    trackedIssues = undefined;
+  }
+
+  const loop = new ObservationLoop({
+    gate: observationGate,
+    intervalMs: ISSUE_REFRESH_INTERVAL_MS,
+    run: refreshTrackedIssues,
+  });
+
+  const methods: GatewayMethodTable = {
+    [GATEWAY_METHOD.TRACKER_CONNECT]: async (params) => {
+      const result = await settings.settingsWrite(
+        async () => {
+          const outcome = await linearSignIn.signIn();
+          if ("reason" in outcome) return settings.refusedSettings(outcome.reason);
+          return settingsStore.setGrant(CREDENTIAL_PROVIDER_ID.LINEAR, outcome);
+        },
+        (saved) => {
+          if (saved.reason) return;
+          void loop.refresh();
+          settings.recordProductEvent(PRODUCT_EVENT.TRACKER_CONNECT, {
+            tracker_id: ISSUE_TRACKER_ID.LINEAR,
+          });
+        },
+        "Could not connect Linear on this system.",
+        reporterOf(params),
+      );
+      return gatewayOk(carried(result));
+    },
+    [GATEWAY_METHOD.TRACKER_CANCEL_SIGN_IN]: () => {
+      linearSignIn.cancel();
+      return gatewayOk({});
+    },
+    [GATEWAY_METHOD.TRACKER_REOPEN_SIGN_IN]: () => {
+      linearSignIn.reopen();
+      return gatewayOk({});
+    },
+    [GATEWAY_METHOD.TRACKER_DISCONNECT]: async (params) => {
+      const result = await settings.settingsWrite(
+        async () => {
+          await linearCredentials.disconnect();
+          return { status: ACT_RESULT_STATUS.ACCEPTED, settings: await settingsStore.snapshot() };
+        },
+        (saved) => {
+          if (saved.reason) return;
+          void loop.refresh();
+          settings.recordProductEvent(PRODUCT_EVENT.TRACKER_DISCONNECT, {
+            tracker_id: ISSUE_TRACKER_ID.LINEAR,
+          });
+        },
+        "Could not disconnect Linear on this system.",
+        reporterOf(params),
+      );
+      return gatewayOk(carried(result));
+    },
+  };
+
+  return {
+    methods,
+    loop,
+    trackers: issueTrackers,
+    issues: () => trackedIssues,
+    refresh: () => void loop.refresh(),
+    stopObservation,
+    // The loop is armed by the merge's supervisor, so there is nothing of its own to begin.
+    start: async () => undefined,
+    stop: async () => {
+      stopObservation();
+    },
+  };
+}

--- a/packages/host/src/compose-observation.ts
+++ b/packages/host/src/compose-observation.ts
@@ -1,0 +1,714 @@
+import path from "node:path";
+import {
+  PRODUCT_DIAGNOSTIC_KIND,
+  PRODUCT_EVENT,
+  PRODUCT_SUPERSET_ACT,
+  type ProductDiagnosticKind,
+  productSessionCountBucket,
+} from "@sidecar/analytics";
+import type { BrainRoster, BrainWakeEvent } from "@sidecar/brain";
+import type { CredentialProviderId } from "@sidecar/credentials";
+import {
+  carried,
+  GATEWAY_EVENT,
+  GATEWAY_METHOD,
+  type GatewayMethodTable,
+  gatewayOk,
+  invalid,
+} from "@sidecar/gateway";
+import {
+  ADAPTER_DIAGNOSTIC_KIND,
+  type AdapterDiagnosticKind,
+  claudeDesktopApplications,
+  codexCloudPlugin,
+  conductorApplications,
+  conductorLocalWorkspacePlugin,
+  ObservationHookRegistry,
+  type ObservationSpoolWatcher,
+  type ProviderRegistration,
+  providerRegistrations,
+  SUPERSET_SIGN_IN_STAGE,
+  SupersetSignIn,
+  supersetPlugin,
+  supersetPressedLink,
+  type WorkspaceHostEnrichment,
+  type WorkspaceHostRegistration,
+  watchObservationSpool,
+  workspaceHostRegistrations,
+} from "@sidecar/providers";
+import { sessionContextText } from "@sidecar/realtime";
+import { ObservationLoop } from "@sidecar/runtime";
+import {
+  CONDUCTOR_LOCAL_WORKSPACE_PROVIDER_ID,
+  CreatedWorkspaceOpenTracker,
+  isProviderId,
+  isSessionApplicationId,
+  isWorkspaceProviderId,
+  normalizeObservedWorkspaceProjects,
+  type ObservedWorkspaceProject,
+  PROVIDER_ID,
+  PROVIDER_ID_LIST,
+  type ProviderId,
+  type Session,
+  type SessionIdentity,
+  type SessionProviderPlugin,
+  SessionRoster,
+  SUPERSET_WORKSPACE_PROVIDER_ID,
+  staleWorkspaceProjectDefaults,
+  type WorkspaceAgentSelection,
+  workspaceProjectSelectionId,
+} from "@sidecar/session";
+import { APP_SETTING_SCHEMA } from "@sidecar/settings";
+import type { CliConnection } from "@sidecar/settings/wire";
+import {
+  ACT_RESULT_STATUS,
+  isRecord,
+  isWireString,
+  type UnparsedWireValue,
+  type WireRecord,
+} from "@sidecar/wire";
+import type { WorkspaceCreationDefaults } from "./brain/act-performer.js";
+import { wakeEventsFromHooks } from "./brain/wiring.js";
+import type { AccountComposer } from "./compose-account.js";
+import type { IssuesComposer } from "./compose-issues.js";
+import type { SettingsComposer } from "./compose-settings.js";
+import type { Composer } from "./composer.js";
+import type { HostKernel } from "./host-kernel.js";
+import { lateRef } from "./late-ref.js";
+import { createSessionActPerformer, type SessionActPerformer } from "./session-act-performer.js";
+
+const SESSION_REFRESH_INTERVAL_MS = 60_000;
+
+const DIAGNOSTIC_COUNTED_AS = {
+  [ADAPTER_DIAGNOSTIC_KIND.PASS_FAILURE]: PRODUCT_DIAGNOSTIC_KIND.PASS_FAILURE,
+  [ADAPTER_DIAGNOSTIC_KIND.ACCIDENTAL_WAKE]: PRODUCT_DIAGNOSTIC_KIND.ACCIDENTAL_WAKE,
+} satisfies Record<AdapterDiagnosticKind, ProductDiagnosticKind>;
+
+function isSessionIdentity(value: UnparsedWireValue): value is SessionIdentity & WireRecord {
+  return (
+    isRecord(value) &&
+    isWireString(value.providerId) &&
+    isWireString(value.providerSessionId) &&
+    value.providerSessionId.length > 0
+  );
+}
+
+/** What observation reaches in the brain: a hook's wake, and the look the pass ends with. */
+export interface ObservationLinks {
+  wake: (events: readonly BrainWakeEvent[]) => void;
+  rosterLook: () => void;
+}
+
+export interface ObservationComposer extends Composer {
+  /** The loop the merge's supervisor enables; the composer never enables it itself. */
+  readonly loop: ObservationLoop;
+  readonly sessionActs: SessionActPerformer;
+  readonly supersetCli: ReturnType<typeof supersetPlugin>["cli"];
+  codexCloudConnection: () => CliConnection;
+  pluginFor: (providerId: string) => SessionProviderPlugin | undefined;
+  session: (identity: SessionIdentity) => Session | undefined;
+  observedSessionCount: () => number;
+  /** The roster a client draws: the same relevance gate every broadcast passes. */
+  rosterForClients: () => readonly Session[];
+  rosterSettled: () => boolean;
+  offeredWorkspaceProjects: () => readonly ObservedWorkspaceProject[];
+  workspaceProjectOffered: (providerId: string, providerProjectId: string) => boolean;
+  broadcastWorkspaceProjects: () => Promise<void>;
+  readSupersetWorkspaceHost: () => Promise<WorkspaceHostEnrichment>;
+  refreshCredentialAdapter: (providerId: CredentialProviderId) => void;
+  /** The sessions an act may name: the roster less the voice's own. */
+  actableSessions: () => readonly Session[];
+  roster: () => BrainRoster;
+  workspaceProjects: () => readonly ObservedWorkspaceProject[];
+  workspaceDefaults: () => Promise<WorkspaceCreationDefaults>;
+  heldWorkspaceDefaults: () => WorkspaceCreationDefaults;
+  startObservation: () => void;
+  stopObservation: () => void;
+  link: (links: ObservationLinks) => void;
+}
+
+export interface ObservationDependencies {
+  kernel: HostKernel;
+  settings: SettingsComposer;
+  account: AccountComposer;
+  issues: IssuesComposer;
+  observationGate: () => boolean;
+}
+
+export function composeObservation(dependencies: ObservationDependencies): ObservationComposer {
+  const { kernel, settings, account, issues, observationGate } = dependencies;
+  const { runMode, report, now, options } = kernel;
+  const settingsStore = settings.store;
+  const links = lateRef<ObservationLinks>("the observation composer's links");
+
+  function reportAdapterDiagnostic(
+    providerId: ProviderId,
+    kind: AdapterDiagnosticKind,
+    error: Error,
+  ): void {
+    report(`Observation diagnostic (${providerId}, ${kind}): ${error.message}`);
+    const counted = DIAGNOSTIC_COUNTED_AS[kind];
+    if (!counted) return;
+    settings.recordProductEvent(PRODUCT_EVENT.SESSION_DIAGNOSTIC, {
+      provider_id: providerId,
+      diagnostic_kind: counted,
+    });
+  }
+
+  const sessionRegistry = new SessionRoster();
+  const codexCloud = codexCloudPlugin({
+    onDiagnostic: (kind, error) => reportAdapterDiagnostic(PROVIDER_ID.CODEX, kind, error),
+  });
+  const conductorSessionApplications = conductorApplications();
+  const claudeDesktopSessionApplications = claudeDesktopApplications();
+  // The local counterpart of the cloud Conductor adapter's creation path: it
+  // reads the repositories Conductor holds and creates a workspace in one by
+  // handing Conductor's own creation deep link to the operating system, through
+  // the native node.
+  const conductorLocalWorkspaces = conductorLocalWorkspacePlugin({
+    openExternal: (url: string) => kernel.openExternalThroughNode(url),
+  });
+  const supersetHomeDirectory =
+    options.environment.SUPERSET_HOME_DIR ?? path.join(options.homeDirectory, ".superset");
+  const superset = supersetPlugin({ homeDirectory: supersetHomeDirectory });
+  const supersetCli = superset.cli;
+  const supersetWorkspaceHost: WorkspaceHostRegistration = {
+    observationFailureLabel: "Superset observation",
+    read: () => readSupersetWorkspaceHost(),
+    emptyEnrichment: (_providerId, observations) => observations,
+  };
+  const workspaceHosts = workspaceHostRegistrations({
+    superset: supersetWorkspaceHost,
+    conductorApplications: conductorSessionApplications,
+    claudeDesktopApplications: claudeDesktopSessionApplications,
+  });
+  // The hook spool and every provider script live under the explicit state
+  // root, the same directory Luke always kept them in.
+  const observationHooks = new ObservationHookRegistry(() => kernel.stateRoot);
+  const providerRegistry = providerRegistrations({
+    readApiKey: (providerId) => settingsStore.readApiKey(providerId),
+    observationHookInstallation: (providerId) => observationHooks.installation(providerId),
+    codexCloud,
+    onDiagnostic: reportAdapterDiagnostic,
+  });
+  const orderedRegistrations: readonly ProviderRegistration[] = PROVIDER_ID_LIST.map(
+    (providerId) => providerRegistry[providerId],
+  );
+
+  let spoolWatchers: readonly ObservationSpoolWatcher[] = [];
+  const createdWorkspaceOpens = new CreatedWorkspaceOpenTracker();
+  let unsubscribeSessions: (() => void) | undefined;
+  let lastWorkspaceProjects: string | undefined;
+  let workspaceProjectsBroadcastGeneration = 0;
+  let rosterBroadcast = false;
+  let brainWorkspaceDefaults: WorkspaceCreationDefaults = {};
+
+  const supersetSignIn = new SupersetSignIn({
+    cli: supersetCli,
+    openExternal: (url) => kernel.openExternalThroughNode(url),
+    onChange: (state) => {
+      kernel.emit(GATEWAY_EVENT.SUPERSET_SIGN_IN_CHANGED, carried(state));
+      if (state.stage !== SUPERSET_SIGN_IN_STAGE.CONNECTED) return;
+      void loop.refresh();
+      settings.recordProductEvent(PRODUCT_EVENT.SUPERSET_ACT, {
+        superset_act: PRODUCT_SUPERSET_ACT.SIGN_IN_COMPLETE,
+      });
+    },
+  });
+
+  function pluginFor(providerId: string) {
+    if (providerId === SUPERSET_WORKSPACE_PROVIDER_ID) return superset;
+    if (providerId === CONDUCTOR_LOCAL_WORKSPACE_PROVIDER_ID) return conductorLocalWorkspaces;
+    return isProviderId(providerId) ? providerRegistry[providerId].plugin : undefined;
+  }
+
+  function pluginForCredential(providerId: CredentialProviderId) {
+    return orderedRegistrations.find((entry) => entry.credential?.id === providerId)?.plugin;
+  }
+
+  function workspaceProjectOffered(providerId: string, providerProjectId: string): boolean {
+    const projects = pluginFor(providerId)?.projects?.() ?? [];
+    return projects.some((project) => workspaceProjectSelectionId(project) === providerProjectId);
+  }
+
+  function offeredWorkspaceProjects(): readonly ObservedWorkspaceProject[] {
+    if (!runMode.observesProviders) return [];
+    return [
+      ...orderedRegistrations.map(({ plugin }) => plugin),
+      superset,
+      conductorLocalWorkspaces,
+    ].flatMap((plugin) =>
+      (plugin.projects?.() ?? []).map((project) => ({
+        ...project,
+        providerId: plugin.provider.id,
+        providerName: plugin.provider.displayName,
+      })),
+    );
+  }
+
+  async function readWorkspaceDefaults(): Promise<WorkspaceCreationDefaults> {
+    const [defaultProviderId, defaultProjectIds] = await Promise.all([
+      settingsStore.get(APP_SETTING_SCHEMA.defaultWorkspaceProvider.field),
+      settingsStore.get(APP_SETTING_SCHEMA.workspaceProjectDefaults.field),
+    ]);
+    const defaults: WorkspaceCreationDefaults = {};
+    if (defaultProviderId) defaults.defaultProviderId = defaultProviderId;
+    if (defaultProjectIds) defaults.defaultProjectIds = defaultProjectIds;
+    brainWorkspaceDefaults = defaults;
+    return defaults;
+  }
+
+  function brainWorkspaceProjects(): readonly ObservedWorkspaceProject[] {
+    return normalizeObservedWorkspaceProjects(
+      offeredWorkspaceProjects(),
+      brainWorkspaceDefaults.defaultProjectIds,
+    );
+  }
+
+  async function pruneWorkspaceProjectDefaults(
+    projects: readonly ObservedWorkspaceProject[],
+    defaults: Readonly<Partial<Record<string, string>>> | undefined,
+    isCurrent: () => boolean,
+  ): Promise<void> {
+    if (account.signedIn()) return;
+    try {
+      for (const providerId of staleWorkspaceProjectDefaults(projects, defaults)) {
+        if (!isCurrent()) return;
+        const expected = defaults?.[providerId];
+        if (expected === undefined) continue;
+        const saved = await settingsStore.clearEntryIfUnchanged(
+          APP_SETTING_SCHEMA.workspaceProjectDefaults.field,
+          providerId,
+          expected,
+        );
+        if (!saved.cleared) continue;
+        if (!isCurrent()) return;
+        settings.emitSettingsSnapshot(saved.settings);
+      }
+    } catch {
+      return;
+    }
+  }
+
+  async function broadcastWorkspaceProjects(): Promise<void> {
+    const generation = ++workspaceProjectsBroadcastGeneration;
+    const offeredProjects = offeredWorkspaceProjects();
+    const defaults = (await readWorkspaceDefaults()).defaultProjectIds;
+    if (generation !== workspaceProjectsBroadcastGeneration) return;
+    await pruneWorkspaceProjectDefaults(
+      offeredProjects,
+      defaults,
+      () => generation === workspaceProjectsBroadcastGeneration,
+    );
+    if (generation !== workspaceProjectsBroadcastGeneration) return;
+    const projects = normalizeObservedWorkspaceProjects(offeredProjects, defaults);
+    const serialized = JSON.stringify(projects);
+    if (serialized === lastWorkspaceProjects) return;
+    lastWorkspaceProjects = serialized;
+    kernel.emit(GATEWAY_EVENT.WORKSPACE_PROJECTS_CHANGED, { projects: carried(projects) });
+  }
+
+  async function rememberWorkspaceDefaults(
+    plugin: SessionProviderPlugin,
+    providerProjectId: string,
+    providerTargetId: string | undefined,
+    namedSelection: WorkspaceAgentSelection | undefined,
+    agent: string | undefined,
+  ): Promise<void> {
+    const providerId = plugin.provider.id;
+    if (!isWorkspaceProviderId(providerId)) return;
+    try {
+      let accountPreferencesTouched = false;
+      if (
+        (await settingsStore.get(APP_SETTING_SCHEMA.defaultWorkspaceProvider.field)) === undefined
+      ) {
+        const saved = await settingsStore.set(
+          APP_SETTING_SCHEMA.defaultWorkspaceProvider.field,
+          providerId,
+        );
+        settings.emitSettingsSnapshot(saved.settings);
+        accountPreferencesTouched = true;
+      }
+      if (
+        providerId === SUPERSET_WORKSPACE_PROVIDER_ID &&
+        agent !== undefined &&
+        (await settingsStore.get(APP_SETTING_SCHEMA.workspaceAgentDefaults.field))?.[
+          SUPERSET_WORKSPACE_PROVIDER_ID
+        ] === undefined
+      ) {
+        const saved = await settingsStore.setEntry(
+          APP_SETTING_SCHEMA.workspaceAgentDefaults.field,
+          SUPERSET_WORKSPACE_PROVIDER_ID,
+          { agent },
+        );
+        settings.emitSettingsSnapshot(saved.settings);
+        accountPreferencesTouched = true;
+      }
+      if (
+        (await settingsStore.get(APP_SETTING_SCHEMA.workspaceProjectDefaults.field))?.[
+          providerId
+        ] === undefined
+      ) {
+        const saved = await settingsStore.setEntry(
+          APP_SETTING_SCHEMA.workspaceProjectDefaults.field,
+          providerId,
+          workspaceProjectSelectionId(
+            providerTargetId ? { providerProjectId, providerTargetId } : { providerProjectId },
+          ),
+        );
+        settings.emitSettingsSnapshot(saved.settings);
+        accountPreferencesTouched = true;
+      }
+      if (
+        isProviderId(providerId) &&
+        namedSelection !== undefined &&
+        (await settingsStore.get(APP_SETTING_SCHEMA.workspaceAgentDefaults.field))?.[providerId] ===
+          undefined
+      ) {
+        const saved = await settingsStore.setEntry(
+          APP_SETTING_SCHEMA.workspaceAgentDefaults.field,
+          providerId,
+          namedSelection,
+        );
+        settings.emitSettingsSnapshot(saved.settings);
+        accountPreferencesTouched = true;
+      }
+      if (accountPreferencesTouched) settings.pushAccountPreferences();
+    } catch {
+      // The reply is the creation's; a failed remember has no line in it.
+    }
+  }
+
+  function openCreatedWorkspaces(sessions: readonly Session[]): void {
+    for (const created of createdWorkspaceOpens.claim(sessions, now())) {
+      const link = created.detail.link;
+      if (!link) continue;
+      kernel
+        .openExternalThroughNode(supersetPressedLink(link, kernel.createId()))
+        .catch((error: Error) => {
+          report(`Created workspace could not be opened: ${error.message}`);
+        });
+    }
+  }
+
+  const sessionActs = createSessionActPerformer({
+    sessionRegistry,
+    openExternal: (url) => kernel.openExternalThroughNode(url),
+    pluginFor,
+    sendsNetwork: runMode.sendsNetwork,
+    settingsStore,
+    rememberWorkspaceDefaults,
+    expectCreatedWorkspace: (identity, at) => createdWorkspaceOpens.expect(identity, at),
+    openCreatedWorkspaces: () => openCreatedWorkspaces(sessionRegistry.list()),
+    trackedIssues: () => issues.issues(),
+    issueTrackers: issues.trackers,
+    refreshIssues: () => issues.refresh(),
+    supersetContext: (identity) =>
+      superset.actableContext(identity.providerId, identity.providerSessionId),
+    supersetCli,
+    recordProductEvent: settings.recordProductEvent,
+  });
+
+  async function applyLocalSessionHooks(): Promise<void> {
+    if (!runMode.observesProviders || options.registerProviderHooks === false) return;
+    await Promise.all(
+      orderedRegistrations.map(async ({ plugin, registerObservationHook }) => {
+        if (!registerObservationHook) return;
+        try {
+          await registerObservationHook();
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          report(`${plugin.provider.displayName} hook registration failed: ${message}`);
+        }
+      }),
+    );
+    watchObservationSpools();
+  }
+
+  function watchObservationSpools(): void {
+    if (spoolWatchers.length > 0) return;
+    spoolWatchers = orderedRegistrations.flatMap(({ plugin, observationSpool }) => {
+      if (!observationSpool) return [];
+      const providerId = plugin.provider.id;
+      return [
+        watchObservationSpool({
+          spoolDirectory: observationSpool.directory(),
+          events: observationSpool.events,
+          onEvents: (events) => {
+            void (async () => {
+              await loop.refresh().catch(() => undefined);
+              links.get().wake(wakeEventsFromHooks(providerId, events, sessionRegistry, now()));
+            })();
+          },
+        }),
+      ];
+    });
+  }
+
+  async function readSupersetWorkspaceHost(): Promise<WorkspaceHostEnrichment> {
+    try {
+      const agentDefault = (
+        await settingsStore.get(APP_SETTING_SCHEMA.workspaceAgentDefaults.field)
+      )?.[SUPERSET_WORKSPACE_PROVIDER_ID]?.agent;
+      return await superset.refresh(agentDefault);
+    } catch (error) {
+      report(
+        `Superset observation failed: ${error instanceof Error ? error.message : String(error)}`,
+      );
+      return superset.emptyEnrichment;
+    }
+  }
+
+  async function refreshProviderSessions(generation: number): Promise<void> {
+    const actionsWereEnabled = superset.activeOrganization() !== undefined;
+    const conductorRepositoriesPromise = conductorLocalWorkspaces.refresh().catch((error) => {
+      report(
+        `Conductor repository observation failed: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    });
+    const hostEnrichments = await Promise.all(
+      workspaceHosts.map((host) =>
+        host.read().catch((error) => {
+          report(
+            `${host.observationFailureLabel} failed: ${error instanceof Error ? error.message : String(error)}`,
+          );
+          return host.emptyEnrichment;
+        }),
+      ),
+    );
+    await conductorRepositoriesPromise;
+    const supersetActionsEnabled = superset.activeOrganization() !== undefined;
+    if (actionsWereEnabled !== supersetActionsEnabled) {
+      if (supersetActionsEnabled) {
+        kernel.emit(GATEWAY_EVENT.SUPERSET_SIGN_IN_CHANGED, {
+          stage: SUPERSET_SIGN_IN_STAGE.CONNECTED,
+          organizations: [],
+        });
+      } else {
+        supersetSignIn.cancel();
+      }
+    }
+    await Promise.all([
+      ...orderedRegistrations.map(async ({ plugin }) => {
+        try {
+          await sessionRegistry.refresh(plugin, (providerId, observations) =>
+            hostEnrichments.reduce(
+              (enriched, enrichment) => enrichment(providerId, enriched),
+              observations,
+            ),
+          );
+        } catch (error) {
+          report(
+            `Session observation failed (${plugin.provider.id}): ${error instanceof Error ? error.message : String(error)}`,
+          );
+        }
+      }),
+      (async () => {
+        try {
+          await sessionRegistry.refresh(superset);
+        } catch (error) {
+          report(
+            `Session observation failed (${superset.provider.id}): ${error instanceof Error ? error.message : String(error)}`,
+          );
+        }
+      })(),
+    ]);
+    if (!loop.isCurrent(generation)) return;
+    void broadcastWorkspaceProjects();
+  }
+
+  const loop = new ObservationLoop({
+    gate: observationGate,
+    intervalMs: SESSION_REFRESH_INTERVAL_MS,
+    run: refreshProviderSessions,
+    afterRun: () => {
+      void settings.emitCodexCloudConnection();
+      links.get().rosterLook();
+    },
+  });
+
+  function broadcastSessions(sessions: readonly Session[]): void {
+    rosterBroadcast = true;
+    kernel.emit(GATEWAY_EVENT.SESSIONS_CHANGED, { sessions: carried(sessions), settled: true });
+  }
+
+  function countObservedSessions(sessions: readonly Session[]): void {
+    const counts = new Map<string, number>();
+    for (const session of sessions) {
+      counts.set(session.providerId, (counts.get(session.providerId) ?? 0) + 1);
+    }
+    for (const [providerId, count] of counts) {
+      if (!isProviderId(providerId)) continue;
+      settings.recordProductEventOncePerDay(PRODUCT_EVENT.SESSION_OBSERVE, providerId, {
+        provider_id: providerId,
+        session_count: productSessionCountBucket(count),
+      });
+    }
+  }
+
+  function startObservation(): void {
+    if (!runMode.observesProviders || !account.capabilitiesActive() || unsubscribeSessions) return;
+    unsubscribeSessions = sessionRegistry.subscribe((sessions) => {
+      broadcastSessions(sessions);
+      openCreatedWorkspaces(sessions);
+      void broadcastWorkspaceProjects();
+      countObservedSessions(sessions);
+    });
+  }
+
+  function stopObservation(): void {
+    workspaceProjectsBroadcastGeneration += 1;
+    unsubscribeSessions?.();
+    unsubscribeSessions = undefined;
+    for (const { plugin } of orderedRegistrations) {
+      sessionRegistry.replaceProvider(plugin.provider, []);
+    }
+    kernel.emit(GATEWAY_EVENT.SESSIONS_CHANGED, { sessions: [], settled: true });
+    kernel.emit(GATEWAY_EVENT.WORKSPACE_PROJECTS_CHANGED, { projects: [] });
+    lastWorkspaceProjects = undefined;
+  }
+
+  function actableSessions(): readonly Session[] {
+    return sessionRegistry.list().filter((session) => session.realtimeVoice !== true);
+  }
+
+  function rosterForClients(): readonly Session[] {
+    return runMode.observesProviders && account.capabilitiesActive() ? sessionRegistry.list() : [];
+  }
+
+  const methods: GatewayMethodTable = {
+    [GATEWAY_METHOD.SESSION_ROSTER]: () =>
+      gatewayOk({
+        sessions: carried(rosterForClients()),
+        settled: !runMode.observesProviders || rosterBroadcast,
+      }),
+    [GATEWAY_METHOD.SESSION_OPEN]: async (params) => {
+      if (!isSessionIdentity(params.identity)) return invalid("identity must name a session");
+      return gatewayOk(carried(await sessionActs.openSession(params.identity)));
+    },
+    [GATEWAY_METHOD.SESSION_OPEN_APPLICATION]: async (params) => {
+      if (!isSessionIdentity(params.identity)) return invalid("identity must name a session");
+      if (!isWireString(params.applicationId) || !isSessionApplicationId(params.applicationId)) {
+        return invalid("applicationId is not one this build knows");
+      }
+      return gatewayOk(
+        carried(await sessionActs.openSessionApplication(params.identity, params.applicationId)),
+      );
+    },
+    [GATEWAY_METHOD.SESSION_OPEN_CHANGE]: async (params) => {
+      if (!isSessionIdentity(params.identity)) return invalid("identity must name a session");
+      return gatewayOk(carried(await sessionActs.openSessionChange(params.identity)));
+    },
+    [GATEWAY_METHOD.WORKSPACE_PROJECTS]: async () =>
+      gatewayOk({
+        projects: carried(
+          account.capabilitiesActive()
+            ? normalizeObservedWorkspaceProjects(
+                offeredWorkspaceProjects(),
+                await settingsStore.get(APP_SETTING_SCHEMA.workspaceProjectDefaults.field),
+              )
+            : [],
+        ),
+      }),
+    [GATEWAY_METHOD.SUPERSET_STATUS]: async () => {
+      const [installed, connected] = await Promise.all([
+        supersetCli.installed(),
+        supersetCli.connected(),
+      ]);
+      return gatewayOk({ installed, connected });
+    },
+    [GATEWAY_METHOD.SUPERSET_BEGIN_SIGN_IN]: async () => {
+      settings.recordProductEvent(PRODUCT_EVENT.SUPERSET_ACT, {
+        superset_act: PRODUCT_SUPERSET_ACT.SIGN_IN_START,
+      });
+      return gatewayOk({ state: carried(await supersetSignIn.begin()) });
+    },
+    [GATEWAY_METHOD.SUPERSET_SUBMIT_CODE]: async (params) => {
+      if (!isWireString(params.code)) return invalid("code must be a string");
+      return gatewayOk({ state: carried(await supersetSignIn.submitCode(params.code)) });
+    },
+    [GATEWAY_METHOD.SUPERSET_CHOOSE_ORGANIZATION]: async (params) => {
+      if (!isWireString(params.slug)) return invalid("slug must be a string");
+      return gatewayOk({ state: carried(await supersetSignIn.chooseOrganization(params.slug)) });
+    },
+    [GATEWAY_METHOD.SUPERSET_REOPEN_SIGN_IN]: () => {
+      supersetSignIn.reopen();
+      return gatewayOk({});
+    },
+    [GATEWAY_METHOD.SUPERSET_CANCEL_SIGN_IN]: () => {
+      supersetSignIn.cancel();
+      settings.recordProductEvent(PRODUCT_EVENT.SUPERSET_ACT, {
+        superset_act: PRODUCT_SUPERSET_ACT.SIGN_IN_CANCEL,
+      });
+      return gatewayOk({});
+    },
+    [GATEWAY_METHOD.SUPERSET_DISCONNECT]: async () => {
+      if (!(await supersetCli.signOut())) {
+        return gatewayOk({
+          status: ACT_RESULT_STATUS.REJECTED,
+          reason: "Superset could not sign out.",
+        });
+      }
+      supersetSignIn.cancel();
+      void loop.refresh();
+      settings.recordProductEvent(PRODUCT_EVENT.SUPERSET_ACT, {
+        superset_act: PRODUCT_SUPERSET_ACT.DISCONNECT,
+      });
+      return gatewayOk({ status: ACT_RESULT_STATUS.ACCEPTED });
+    },
+  };
+
+  return {
+    methods,
+    loop,
+    sessionActs,
+    supersetCli,
+    codexCloudConnection: () => codexCloud.connection(),
+    pluginFor,
+    session: (identity) => sessionRegistry.get(identity),
+    observedSessionCount: () => actableSessions().length,
+    rosterForClients,
+    rosterSettled: () => !runMode.observesProviders || rosterBroadcast,
+    offeredWorkspaceProjects,
+    workspaceProjectOffered,
+    broadcastWorkspaceProjects,
+    readSupersetWorkspaceHost,
+    refreshCredentialAdapter: (providerId) => {
+      const plugin = pluginForCredential(providerId);
+      if (plugin) void sessionRegistry.refresh(plugin);
+    },
+    actableSessions,
+    roster: () => {
+      const at = now();
+      const sessions = actableSessions();
+      return {
+        text: sessionContextText(sessions, at),
+        identities: sessions.map((session) => ({
+          providerId: session.providerId,
+          providerSessionId: session.providerSessionId,
+        })),
+        sessions,
+      };
+    },
+    workspaceProjects: brainWorkspaceProjects,
+    workspaceDefaults: readWorkspaceDefaults,
+    heldWorkspaceDefaults: () => brainWorkspaceDefaults,
+    startObservation,
+    stopObservation,
+    link: (next) => links.set(next),
+    start: async () => {
+      void applyLocalSessionHooks().catch((error) => {
+        report(
+          `Local session hook registration failed: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      });
+    },
+    stop: async () => {
+      unsubscribeSessions?.();
+      unsubscribeSessions = undefined;
+      for (const watcher of spoolWatchers) watcher.close();
+      spoolWatchers = [];
+      supersetSignIn.shutdown();
+    },
+  };
+}

--- a/packages/host/src/compose-settings.ts
+++ b/packages/host/src/compose-settings.ts
@@ -1,0 +1,545 @@
+import {
+  PRODUCT_EVENT,
+  type ProductEventPropertiesFor,
+  ProductEventSender,
+  productEventFromWire,
+  type RecordProductEvent,
+} from "@sidecar/analytics";
+import {
+  CREDENTIAL_PROVIDER_ID,
+  type CredentialProviderId,
+  isCredentialProviderId,
+  VOICE_CREDENTIAL_PROVIDER_ID,
+} from "@sidecar/credentials";
+import {
+  carried,
+  GATEWAY_EVENT,
+  GATEWAY_METHOD,
+  type GatewayMethodTable,
+  gatewayOk,
+  invalid,
+} from "@sidecar/gateway";
+import { HostedVaultClient } from "@sidecar/hosted";
+import {
+  ACCOUNT_PREFERENCE_FIELDS,
+  type AccountPreferenceField,
+  type AccountPreferences,
+  APP_SETTING_FIELDS,
+  APP_SETTING_SCHEMA,
+  type AppSettingField,
+  isAppSettingField,
+  isKeyedAppSettingField,
+  isSettingEntryKey,
+  isSettingsResetScope,
+  SETTING_SIDE_EFFECT,
+  type SettingEntryValue,
+  settingAnalytics,
+  settingEntryGuard,
+} from "@sidecar/settings";
+import type { CliConnection, SettingsUpdateResult } from "@sidecar/settings/wire";
+import { ACT_RESULT_STATUS, isWireString, type UnparsedWireValue } from "@sidecar/wire";
+import { AccountPreferencesClient } from "./account-preferences-client.js";
+import type { Composer } from "./composer.js";
+import type { HostKernel } from "./host-kernel.js";
+import { lateRef } from "./late-ref.js";
+import { ProviderKeyVaultSync, type VaultSyncAccount } from "./provider-key-vault-sync.js";
+import { SettingsStore } from "./settings-store.js";
+import { reporterOf } from "./wire-helpers.js";
+
+type StoredSettings = SettingsUpdateResult["settings"]["stored"];
+
+/**
+ * What the settings write path reaches in the other concerns. Every one of
+ * them is a genuine back-edge: a setting is where the developer changes what
+ * a loop, a credential, or a voice does, so the write cannot be the leaf of
+ * the graph however much simpler that would be.
+ */
+export interface SettingsLinks {
+  codexCloudConnection: () => CliConnection;
+  refreshAccount: () => Promise<void>;
+  applyVoiceCredential: () => Promise<void>;
+  setVoice: (voice: StoredSettings["voice"]) => void;
+  setVoiceSpeed: (speed: StoredSettings["voiceSpeed"]) => void;
+  reconcileSpeech: () => void;
+  refreshSupersetWorkspaceHost: () => Promise<void>;
+  broadcastWorkspaceProjects: () => Promise<void>;
+  /** One provider's sessions read again after its key changed. */
+  refreshCredentialAdapter: (providerId: CredentialProviderId) => void;
+  refreshIssues: () => void;
+  workspaceProjectOffered: (providerId: string, providerProjectId: string) => boolean;
+}
+
+export interface SettingsComposer extends Composer {
+  readonly store: SettingsStore;
+  readonly recordProductEvent: RecordProductEvent;
+  /** One count per provider per day, as the observation pass makes it. */
+  recordProductEventOncePerDay: ProductEventSender["recordOncePerDay"];
+  emitSettingsSnapshot: (settings: SettingsUpdateResult["settings"], reporter?: string) => void;
+  emitSettings: () => Promise<void>;
+  emitCodexCloudConnection: () => Promise<void>;
+  refusedSettings: (reason: string) => Promise<SettingsUpdateResult>;
+  settingsWrite: (
+    save: () => Promise<SettingsUpdateResult>,
+    apply: (result: SettingsUpdateResult) => Promise<void> | void,
+    refusal: string,
+    reporter: string | undefined,
+  ) => Promise<SettingsUpdateResult>;
+  reconcileProviderKeyVault: () => void;
+  reconcileAccountPreferences: () => Promise<void>;
+  /** The developer's own preference write, on its way to the account behind it. */
+  pushAccountPreferences: () => void;
+  /** The account behind the hydrated preferences changed; the next push hydrates again. */
+  forgetAccountPreferenceHydration: () => void;
+  /** The count the account acts flush before they end the account they are authenticated with. */
+  flushProductEvents: () => Promise<void>;
+  link: (links: SettingsLinks) => void;
+}
+
+export interface SettingsDependencies {
+  kernel: HostKernel;
+}
+
+export function composeSettings(dependencies: SettingsDependencies): SettingsComposer {
+  const { kernel } = dependencies;
+  const { runMode, report, options } = kernel;
+  const links = lateRef<SettingsLinks>("the settings composer's links");
+
+  const store = new SettingsStore({
+    directory: () => kernel.stateRoot,
+    // A fixture or evidence run refuses the credentials it resolves, so nothing is
+    // reported as available that would not actually happen.
+    credentialsUsable: runMode.observesProviders,
+    cipher: options.cipher,
+    environment: options.environment,
+    codexCloudConnection: () => links.get().codexCloudConnection(),
+  });
+
+  const productEvents = new ProductEventSender({
+    serviceBaseUrl: kernel.hostedServiceBaseUrl,
+    appVersion: options.appVersion,
+    sends: runMode.sendsNetwork,
+    readAccessToken: async () => (await store.readAccount())?.accessToken,
+    refreshAccount: () => links.get().refreshAccount(),
+  });
+  const hostedVault = new HostedVaultClient({
+    serviceBaseUrl: kernel.hostedServiceBaseUrl,
+    readAccessToken: async () =>
+      runMode.sendsNetwork ? (await store.readAccount())?.accessToken : undefined,
+    refreshAccount: () => links.get().refreshAccount(),
+    readAccountKey: async () => (await store.readAccount())?.email,
+  });
+  const accountPreferencesClient = new AccountPreferencesClient({
+    serviceBaseUrl: kernel.hostedServiceBaseUrl,
+    readAccessToken: async () =>
+      runMode.sendsNetwork ? (await store.readAccount())?.accessToken : undefined,
+    refreshAccount: () => links.get().refreshAccount(),
+    readAccountKey: readAccountPreferenceAccountKey,
+  });
+  const vaultSync = new ProviderKeyVaultSync({
+    vault: hostedVault,
+    readStoredApiKey: (providerId) => store.readStoredApiKey(providerId),
+    account: async () => {
+      const held = await store.readAccount();
+      if (!held) return undefined;
+      const vaultAccount: VaultSyncAccount = { email: held.email };
+      if (held.id) vaultAccount.id = held.id;
+      return vaultAccount;
+    },
+    tenant: {
+      read: () => store.readVaultSyncAccount(),
+      write: (accountKey) => store.setVaultSyncAccount(accountKey),
+    },
+  });
+
+  let accountPreferencesHydratedAccount: string | undefined;
+  let accountPreferencesSync: Promise<void> = Promise.resolve();
+
+  function reconcileProviderKeyVault(): void {
+    void store
+      .snapshot()
+      .then((settings) =>
+        settings.stored.syncProviderKeys ? vaultSync.apply(true, { claim: false }) : undefined,
+      );
+  }
+
+  async function readAccountPreferenceAccountKey(): Promise<string | undefined> {
+    return (await store.readAccount())?.email;
+  }
+
+  function queueAccountPreferencesSync(label: string, work: () => Promise<void>): Promise<void> {
+    const queued = accountPreferencesSync.then(work, work).catch((error) => {
+      report(
+        `Account preferences ${label} failed: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    });
+    accountPreferencesSync = queued.then(
+      () => undefined,
+      () => undefined,
+    );
+    return queued;
+  }
+
+  function accountPreferencesEmpty(preferences: AccountPreferences): boolean {
+    return Object.keys(preferences).length === 0;
+  }
+
+  function accountPreferencesSame(left: AccountPreferences, right: AccountPreferences): boolean {
+    return JSON.stringify(left) === JSON.stringify(right);
+  }
+
+  async function accountPreferenceHydrationBaseline(
+    accountEmail: string,
+  ): Promise<AccountPreferences> {
+    const baseline = await store.accountPreferencesSyncBaseline(accountEmail);
+    if (baseline !== undefined) return baseline;
+    const preferences = await store.accountPreferences();
+    await store.setAccountPreferencesSyncBaseline(accountEmail, preferences);
+    return preferences;
+  }
+
+  function isAccountPreferenceField(field: AppSettingField): field is AccountPreferenceField {
+    return ACCOUNT_PREFERENCE_FIELDS.some((candidate) => candidate === field);
+  }
+
+  function resetTouchesAccountPreferences(scope: UnparsedWireValue): boolean {
+    return ACCOUNT_PREFERENCE_FIELDS.some((field) => {
+      const definition = APP_SETTING_SCHEMA[field];
+      return "resetScope" in definition && definition.resetScope === scope;
+    });
+  }
+
+  async function reconcileAccountPreferences(): Promise<void> {
+    return queueAccountPreferencesSync("reconcile", async () => {
+      const accountKey = await readAccountPreferenceAccountKey();
+      if (!accountKey) return;
+      await hydrateAccountPreferences(accountKey);
+    });
+  }
+
+  async function hydrateAccountPreferences(accountKey: string): Promise<boolean> {
+    const baseline = await accountPreferenceHydrationBaseline(accountKey);
+    if ((await readAccountPreferenceAccountKey()) !== accountKey) return false;
+    const remote = await accountPreferencesClient.readPreferences();
+    if (!remote || (await readAccountPreferenceAccountKey()) !== accountKey) return false;
+
+    if (!remote.hasStoredSnapshot) {
+      const preferences = await store.accountPreferences();
+      if ((await readAccountPreferenceAccountKey()) !== accountKey) return false;
+      if (!accountPreferencesEmpty(preferences)) {
+        const written = await accountPreferencesClient.writePreferences(preferences);
+        if (!written || (await readAccountPreferenceAccountKey()) !== accountKey) return false;
+      }
+      if (!(await store.setAccountPreferencesSyncBaseline(accountKey, preferences))) {
+        return false;
+      }
+      accountPreferencesHydratedAccount = accountKey;
+      return true;
+    }
+
+    const saved = await store.applyAccountPreferences(remote.preferences, {
+      accountEmail: accountKey,
+      preferences: baseline,
+    });
+    if ((await readAccountPreferenceAccountKey()) !== accountKey) return false;
+    accountPreferencesHydratedAccount = accountKey;
+    const preferences = await store.accountPreferences();
+    if ((await readAccountPreferenceAccountKey()) !== accountKey) return false;
+    if (saved.changed.length > 0) {
+      await applyAccountPreferenceSideEffects(saved, saved.changed);
+    }
+    if (!accountPreferencesSame(preferences, remote.preferences)) {
+      const written = await accountPreferencesClient.writePreferences(preferences);
+      if (!written || (await readAccountPreferenceAccountKey()) !== accountKey) return true;
+    }
+    await store.setAccountPreferencesSyncBaseline(accountKey, preferences);
+    return true;
+  }
+
+  function pushAccountPreferences(): void {
+    void queueAccountPreferencesSync("write", async () => {
+      const accountKey = await readAccountPreferenceAccountKey();
+      if (!accountKey) return;
+      if (
+        accountPreferencesHydratedAccount !== accountKey &&
+        !(await hydrateAccountPreferences(accountKey))
+      ) {
+        return;
+      }
+      const preferences = await store.accountPreferences();
+      if (
+        (await readAccountPreferenceAccountKey()) !== accountKey ||
+        accountPreferencesHydratedAccount !== accountKey
+      ) {
+        return;
+      }
+      const written = await accountPreferencesClient.writePreferences(preferences);
+      if (!written || (await readAccountPreferenceAccountKey()) !== accountKey) return;
+      await store.setAccountPreferencesSyncBaseline(accountKey, preferences);
+    });
+  }
+
+  const recordProductEvent: RecordProductEvent = (name, properties) =>
+    productEvents.record(name, properties);
+
+  function emitSettingsSnapshot(
+    settings: SettingsUpdateResult["settings"],
+    reporter?: string,
+  ): void {
+    kernel.emit(GATEWAY_EVENT.SETTINGS_CHANGED, {
+      settings: carried(settings),
+      ...(reporter !== undefined ? { reporter } : undefined),
+    });
+  }
+
+  async function emitSettings(): Promise<void> {
+    emitSettingsSnapshot(await store.snapshot());
+  }
+
+  let announcedCodexCloudConnection: CliConnection | undefined;
+  async function emitCodexCloudConnection(): Promise<void> {
+    const connection = links.get().codexCloudConnection();
+    if (connection === announcedCodexCloudConnection) return;
+    announcedCodexCloudConnection = connection;
+    await emitSettings();
+  }
+
+  function recordSettingUpdate(field: AppSettingField, settings: SettingsUpdateResult["settings"]) {
+    const analytics = settingAnalytics(field, settings.stored);
+    if (!analytics) return;
+    recordProductEvent(PRODUCT_EVENT.SETTING_UPDATE, {
+      setting_id: analytics.id,
+      setting_value: analytics.value,
+    });
+  }
+
+  /**
+   * The side effects a setting has in the host. The client applies its own —
+   * the login item, the Dock, the displays, the form factor, the keys, the
+   * duck — from the same answered snapshot; nothing here reaches a window.
+   */
+  async function applyHostSettingSideEffect(
+    field: AppSettingField,
+    settings: SettingsUpdateResult["settings"],
+  ): Promise<void> {
+    switch (APP_SETTING_SCHEMA[field].mainProcessSideEffect) {
+      case SETTING_SIDE_EFFECT.VOICE:
+        links.get().setVoice(settings.stored.voice);
+        break;
+      case SETTING_SIDE_EFFECT.VOICE_SPEED:
+        links.get().setVoiceSpeed(settings.stored.voiceSpeed);
+        break;
+      case SETTING_SIDE_EFFECT.VOICE_SOURCE:
+        await links.get().applyVoiceCredential();
+        await emitSettings();
+        break;
+      case SETTING_SIDE_EFFECT.ANNOUNCEMENT_HOLD:
+        links.get().reconcileSpeech();
+        break;
+      case SETTING_SIDE_EFFECT.VAULT_SYNC:
+        void vaultSync.apply(settings.stored.syncProviderKeys, { claim: true });
+        break;
+      default:
+        break;
+    }
+  }
+
+  async function applyAccountPreferenceSideEffects(
+    result: SettingsUpdateResult,
+    changed: readonly AccountPreferenceField[],
+  ): Promise<void> {
+    for (const field of changed) {
+      await applyHostSettingSideEffect(field, result.settings);
+    }
+    const workspaceAgentDefaultsChanged = changed.includes(
+      APP_SETTING_SCHEMA.workspaceAgentDefaults.field,
+    );
+    if (workspaceAgentDefaultsChanged) {
+      await links.get().refreshSupersetWorkspaceHost();
+    }
+    if (
+      workspaceAgentDefaultsChanged ||
+      changed.includes(APP_SETTING_SCHEMA.defaultWorkspaceProvider.field) ||
+      changed.includes(APP_SETTING_SCHEMA.workspaceProjectDefaults.field)
+    ) {
+      await links.get().broadcastWorkspaceProjects();
+    }
+    emitSettingsSnapshot(result.settings);
+  }
+
+  const refusedSettings = async (reason: string): Promise<SettingsUpdateResult> => ({
+    status: ACT_RESULT_STATUS.REJECTED,
+    settings: await store.snapshot(),
+    reason,
+  });
+
+  /** Runs one settings write and, when it landed, its host side effects and the change event. */
+  async function settingsWrite(
+    save: () => Promise<SettingsUpdateResult>,
+    apply: (result: SettingsUpdateResult) => Promise<void> | void,
+    refusal: string,
+    reporter: string | undefined,
+  ): Promise<SettingsUpdateResult> {
+    let saved: SettingsUpdateResult;
+    try {
+      saved = await save();
+      await apply(saved);
+    } catch {
+      return refusedSettings(refusal);
+    }
+    emitSettingsSnapshot(saved.settings, reporter);
+    return saved;
+  }
+
+  const methods: GatewayMethodTable = {
+    [GATEWAY_METHOD.SETTINGS_SNAPSHOT]: async () =>
+      gatewayOk({ settings: carried(await store.snapshot()) }),
+    [GATEWAY_METHOD.SETTINGS_UPDATE]: async (params) => {
+      const field = params.field;
+      if (!isAppSettingField(field) || isKeyedAppSettingField(field)) {
+        return invalid("field must name a plain setting");
+      }
+      const parsed = APP_SETTING_SCHEMA[field].guard(params.value);
+      if (!parsed.valid) return invalid("value is not the shape that setting takes");
+      const result = await settingsWrite(
+        () => store.set(field, parsed.value),
+        async (saved) => {
+          if (saved.reason) return;
+          recordSettingUpdate(field, saved.settings);
+          await applyHostSettingSideEffect(field, saved.settings);
+        },
+        "Could not save that setting on this system.",
+        reporterOf(params),
+      );
+      if (!result.reason && isAccountPreferenceField(field)) pushAccountPreferences();
+      return gatewayOk(carried(result));
+    },
+    [GATEWAY_METHOD.SETTINGS_UPDATE_ENTRY]: async (params) => {
+      const field = params.field;
+      if (!isKeyedAppSettingField(field)) return invalid("field must name a keyed setting");
+      const key = params.key;
+      if (!isSettingEntryKey(field, key)) return invalid("key is not one that setting takes");
+      // SAFETY: the guard is the parser; a wire value is one it reads.
+      const parsed = settingEntryGuard(field, key, params.value as UnparsedWireValue);
+      if (!parsed.valid) return invalid("value is not the shape that entry takes");
+      // SAFETY: settingEntryGuard validated workspace project defaults as a wire string.
+      const projectWire = parsed.value as UnparsedWireValue;
+      if (
+        field === APP_SETTING_SCHEMA.workspaceProjectDefaults.field &&
+        isWireString(projectWire) &&
+        !links.get().workspaceProjectOffered(key, projectWire)
+      ) {
+        return invalid("that project is not one a provider offers");
+      }
+      const result = await settingsWrite(
+        // SAFETY: settingEntryGuard validated the entry before it reaches the store.
+        () => store.setEntry(field, key, parsed.value as SettingEntryValue<typeof field>),
+        async (saved) => {
+          if (saved.reason) return;
+          recordSettingUpdate(field, saved.settings);
+          await applyHostSettingSideEffect(field, saved.settings);
+        },
+        "Could not save that setting on this system.",
+        reporterOf(params),
+      );
+      if (!result.reason && isAccountPreferenceField(field)) pushAccountPreferences();
+      return gatewayOk(carried(result));
+    },
+    [GATEWAY_METHOD.SETTINGS_RESET]: async (params) => {
+      const scope = params.scope;
+      if (!isSettingsResetScope(scope)) return invalid("scope is not one this build knows");
+      const result = await settingsWrite(
+        () => store.resetSettings(scope),
+        async (saved) => {
+          if (saved.reason) return;
+          recordProductEvent(PRODUCT_EVENT.SETTINGS_RESET, {});
+          for (const field of APP_SETTING_FIELDS) {
+            const definition = APP_SETTING_SCHEMA[field];
+            if (!("resetScope" in definition) || definition.resetScope !== scope) continue;
+            await applyHostSettingSideEffect(field, saved.settings);
+          }
+        },
+        "Could not reset those settings on this system.",
+        reporterOf(params),
+      );
+      if (!result.reason && resetTouchesAccountPreferences(scope)) pushAccountPreferences();
+      return gatewayOk(carried(result));
+    },
+    [GATEWAY_METHOD.CREDENTIAL_SET_API_KEY]: async (params) => {
+      const providerId = params.providerId;
+      if (!isCredentialProviderId(providerId))
+        return invalid("providerId is not one this build knows");
+      if (params.apiKey !== undefined && !isWireString(params.apiKey)) {
+        return invalid("apiKey must be a string");
+      }
+      const apiKey = params.apiKey;
+      const result = await settingsWrite(
+        () => store.setApiKey(providerId, apiKey),
+        async (saved) => {
+          if (saved.reason) return;
+          links.get().refreshCredentialAdapter(providerId);
+          if (providerId === CREDENTIAL_PROVIDER_ID.LINEAR) links.get().refreshIssues();
+          if (providerId === VOICE_CREDENTIAL_PROVIDER_ID) {
+            await links.get().applyVoiceCredential();
+            await emitSettings();
+          }
+          void vaultSync.keySaved(providerId, apiKey, saved.settings.stored.syncProviderKeys);
+          recordProductEvent(
+            apiKey?.trim() ? PRODUCT_EVENT.PROVIDER_CONNECT : PRODUCT_EVENT.PROVIDER_DISCONNECT,
+            { connection_id: providerId },
+          );
+        },
+        "Could not save that API key on this system.",
+        reporterOf(params),
+      );
+      return gatewayOk(carried(result));
+    },
+    // A count the client's own surfaces made: read against the allowlist
+    // again here, and queued only when it reads. Nothing observed can travel
+    // in one, because the reader builds the event from the allowlist rather
+    // than from what arrived.
+    [GATEWAY_METHOD.ANALYTICS_RECORD]: (params) => {
+      const event = productEventFromWire(params.event);
+      if (!event) return invalid("event is not one the allowlist names");
+      // SAFETY: the reader built these properties from the allowlist for this very name.
+      productEvents.record(
+        event.name,
+        event.properties as ProductEventPropertiesFor<typeof event.name>,
+      );
+      return gatewayOk({});
+    },
+  };
+
+  return {
+    methods,
+    store,
+    recordProductEvent,
+    recordProductEventOncePerDay: (name, key, properties) =>
+      productEvents.recordOncePerDay(name, key, properties),
+    emitSettingsSnapshot,
+    emitSettings,
+    emitCodexCloudConnection,
+    refusedSettings,
+    settingsWrite,
+    reconcileProviderKeyVault,
+    reconcileAccountPreferences,
+    pushAccountPreferences,
+    forgetAccountPreferenceHydration: () => {
+      accountPreferencesHydratedAccount = undefined;
+    },
+    flushProductEvents: () => productEvents.flush(),
+    link: (next) => {
+      links.set(next);
+      announcedCodexCloudConnection = next.codexCloudConnection();
+    },
+    start: async () => {
+      void store.snapshot();
+      productEvents.arm();
+      productEvents.record(PRODUCT_EVENT.APP_LAUNCH, { app_version: options.appVersion });
+      productEvents.markDayActive();
+      if (runMode.sendsNetwork) productEvents.start();
+    },
+    stop: async () => {
+      productEvents.stop();
+    },
+  };
+}

--- a/packages/host/src/compose-speech.ts
+++ b/packages/host/src/compose-speech.ts
@@ -1,0 +1,217 @@
+import { PRODUCT_EVENT, productSignInAge } from "@sidecar/analytics";
+import type { BrainDelivery } from "@sidecar/brain";
+import {
+  carried,
+  GATEWAY_EVENT,
+  GATEWAY_METHOD,
+  type GatewayMethodTable,
+  gatewayOk,
+  invalid,
+  RECEIVER_REPORT_KIND,
+} from "@sidecar/gateway";
+import {
+  ARRIVAL_SPEECH_KIND,
+  BRIEFING_SPEECH_KIND,
+  CALENDAR_ONBOARDING_SPEECH_KIND,
+} from "@sidecar/realtime";
+import { isSpeechOutcome, SPEECH_OUTCOME, type SpeechOutcome } from "@sidecar/realtime/speech";
+import { isIdentifier } from "@sidecar/runtime-contracts";
+import { isWireNumber } from "@sidecar/wire";
+import { arrivalBeatOwed, countsFirstAnnouncement } from "./arrival-flow.js";
+import type { AccountComposer } from "./compose-account.js";
+import type { CalendarsComposer } from "./compose-calendars.js";
+import type { ObservationComposer } from "./compose-observation.js";
+import type { SettingsComposer } from "./compose-settings.js";
+import type { Composer } from "./composer.js";
+import type { HostKernel } from "./host-kernel.js";
+import { lateRef } from "./late-ref.js";
+import { type OnboardingBeatKind, SpeechArbiter } from "./voice/speech-arbiter.js";
+import { VoiceReceiver } from "./voice-receiver.js";
+
+/** What speech reaches in the brain whose words it says. */
+export interface SpeechLinks {
+  /** Whether a conversation stands that a held briefing can be given back to. */
+  brainCurrent: () => boolean;
+  releaseHeld: (briefings: ReturnType<SpeechArbiter["takeHeldBriefings"]>) => void;
+}
+
+export interface SpeechComposer extends Composer {
+  readonly receiver: VoiceReceiver;
+  reconcileSpeech: () => Promise<void>;
+  withdrawBeat: (kind: OnboardingBeatKind) => void;
+  withdrawBriefings: () => void;
+  dropBriefings: () => void;
+  deliverBriefing: (delivery: BrainDelivery) => Promise<void>;
+  requestOnboardingBeat: () => Promise<void>;
+  /** The arrival beat's own moment, recorded at the first sign-in ever observed. */
+  seedArrivalOnFirstSignIn: () => void;
+  link: (links: SpeechLinks) => void;
+}
+
+export interface SpeechDependencies {
+  kernel: HostKernel;
+  settings: SettingsComposer;
+  account: AccountComposer;
+  calendars: CalendarsComposer;
+  observation: ObservationComposer;
+}
+
+export function composeSpeech(dependencies: SpeechDependencies): SpeechComposer {
+  const { kernel, settings, account, calendars, observation } = dependencies;
+  const { runMode, now } = kernel;
+  const links = lateRef<SpeechLinks>("the speech composer's links");
+
+  /**
+   * The one voice receiver, as the client that owns the voice window reports
+   * it: the host mints the epochs, so a claim names an epoch this host issued,
+   * and a client's connection closing ends the epoch as its renderer going
+   * away would.
+   */
+  const receiver = new VoiceReceiver();
+  const arbiter = new SpeechArbiter({
+    now,
+    nextId: kernel.createId,
+    ...(account.agentTrace
+      ? { trace: (record) => account.agentTrace?.recordSpeechDecision(record) }
+      : undefined),
+  });
+
+  function withdrawBeat(kind: OnboardingBeatKind): void {
+    const id = arbiter.retract(kind);
+    if (id) kernel.emit(GATEWAY_EVENT.SPEECH_WITHDRAWN, { id });
+  }
+
+  function withdrawBriefings(): void {
+    const offered = arbiter.withdrawBriefings();
+    if (offered) kernel.emit(GATEWAY_EVENT.SPEECH_WITHDRAWN, { id: offered });
+    offerNextSpeech();
+  }
+
+  /**
+   * Hands the mouth the arbiter's head request, if one may be offered now:
+   * a ready receiver stands, and a voice to say it with. Synchronous past the
+   * quiet's await, so two reconciles landing together cannot each offer.
+   */
+  function offerNextSpeech(): void {
+    if (!receiver.isReady() || !account.voiceCapabilities.realtimeCredentials) return;
+    const offer = arbiter.next();
+    if (offer) kernel.emit(GATEWAY_EVENT.SPEECH_OFFERED, carried(offer));
+  }
+
+  async function reconcileSpeech(): Promise<void> {
+    const quiet = await calendars.announcementsQuietNow(now());
+    arbiter.setQuiet(quiet);
+    if (!quiet && arbiter.heldBriefingCount > 0) {
+      if (links.get().brainCurrent() && account.voiceCapabilities.realtimeCredentials) {
+        links.get().releaseHeld(arbiter.takeHeldBriefings());
+      } else if (!account.voiceCapabilities.realtimeCredentials) {
+        arbiter.dropBriefings();
+      }
+    }
+    offerNextSpeech();
+  }
+
+  function markFirstAnnouncementSpoken(): void {
+    const onboardingState = calendars.onboarding();
+    if (!countsFirstAnnouncement(onboardingState)) return;
+    const signedInAt = onboardingState?.arrivalSignedInAt;
+    const at = now();
+    const signedInAtMs = signedInAt !== undefined ? Date.parse(signedInAt) : Number.NaN;
+    if (Number.isFinite(signedInAtMs)) {
+      settings.recordProductEvent(PRODUCT_EVENT.VOICE_FIRST_ANNOUNCEMENT, {
+        sign_in_age: productSignInAge(at - signedInAtMs),
+      });
+    }
+    calendars.writeOnboarding({ arrivalFirstAnnouncementAt: new Date(at).toISOString() });
+  }
+
+  function settleSpeech(id: string, outcome: SpeechOutcome): void {
+    const settled = arbiter.settle(id, outcome);
+    if (!settled) return;
+    if (settled.outcome === SPEECH_OUTCOME.SPOKEN) {
+      if (settled.kind === BRIEFING_SPEECH_KIND) {
+        settings.recordProductEvent(PRODUCT_EVENT.VOICE_ANNOUNCEMENT_SPEAK, {});
+        markFirstAnnouncementSpoken();
+      }
+      if (settled.kind === ARRIVAL_SPEECH_KIND && arrivalBeatOwed(calendars.onboarding())) {
+        calendars.writeOnboarding({ arrivalSpokenAt: new Date(now()).toISOString() });
+      }
+    }
+    void reconcileSpeech();
+  }
+
+  async function requestOnboardingBeat(): Promise<void> {
+    if (!runMode.requiresAccount || !account.signedIn()) return;
+    if (!account.voiceCapabilities.realtimeCredentials) return;
+    if (await calendars.gateOfferable()) {
+      arbiter.request({ kind: CALENDAR_ONBOARDING_SPEECH_KIND });
+      void reconcileSpeech();
+      return;
+    }
+    if (!arrivalBeatOwed(calendars.onboarding())) return;
+    await observation.loop.refresh().catch(() => undefined);
+    if (!account.signedIn() || !arrivalBeatOwed(calendars.onboarding())) return;
+    arbiter.request({ kind: ARRIVAL_SPEECH_KIND });
+    void reconcileSpeech();
+  }
+
+  async function deliverBriefing(delivery: BrainDelivery): Promise<void> {
+    if (!account.voiceCapabilities.realtimeCredentials) return;
+    arbiter.request({ kind: BRIEFING_SPEECH_KIND, delivery });
+    await reconcileSpeech();
+  }
+
+  receiver.onReady(() => {
+    offerNextSpeech();
+    kernel.service().receiverReady();
+  });
+  receiver.onReset(() => arbiter.reclaimOffer());
+
+  const methods: GatewayMethodTable = {
+    [GATEWAY_METHOD.SPEECH_SETTLE]: (params) => {
+      if (!isIdentifier(params.id)) return invalid("id must be a non-empty string");
+      if (!isSpeechOutcome(params.outcome)) return invalid("outcome is not one this build knows");
+      settleSpeech(params.id, params.outcome);
+      return gatewayOk({});
+    },
+    // The one voice receiver's lifecycle, as the client that owns its window
+    // reports it. Begin mints an epoch here and answers it; ready counts only
+    // for the epoch it names; reset ends the epoch. The client's connection
+    // closing ends it too, so nothing is offered to a renderer nobody can
+    // reach.
+    [GATEWAY_METHOD.RECEIVER_REPORT]: (params) => {
+      switch (params.kind) {
+        case RECEIVER_REPORT_KIND.BEGIN:
+          return gatewayOk({ epoch: receiver.begin() });
+        case RECEIVER_REPORT_KIND.READY:
+          if (!isWireNumber(params.epoch)) return invalid("epoch must be a number");
+          return gatewayOk({ ready: receiver.markReady(params.epoch) });
+        case RECEIVER_REPORT_KIND.RESET:
+          receiver.reset();
+          return gatewayOk({ epoch: receiver.epoch() });
+        default:
+          return invalid("kind is not one this build knows");
+      }
+    },
+  };
+
+  return {
+    methods,
+    receiver,
+    reconcileSpeech,
+    withdrawBeat,
+    withdrawBriefings,
+    dropBriefings: () => arbiter.dropBriefings(),
+    deliverBriefing,
+    requestOnboardingBeat,
+    seedArrivalOnFirstSignIn: () => {
+      if (calendars.onboarding()?.arrivalSignedInAt !== undefined) return;
+      calendars.writeOnboarding({ arrivalSignedInAt: new Date(now()).toISOString() });
+    },
+    link: (next) => links.set(next),
+    start: async () => undefined,
+    // The arbiter's briefings are dropped where the meetings holding them are:
+    // the calendars composer's own stop, which is where they were held.
+    stop: async () => undefined,
+  };
+}

--- a/packages/host/src/composer.ts
+++ b/packages/host/src/composer.ts
@@ -1,0 +1,29 @@
+import type { GatewayMethod, GatewayMethodTable } from "@sidecar/gateway";
+
+/** One concern of the host: the Gateway methods it answers, and its own lifecycle. */
+export interface Composer {
+  /** The methods this concern answers. Disjoint from every other composer's. */
+  readonly methods: GatewayMethodTable;
+  /** What this concern begins: timers, subscriptions, loops, stores. */
+  start: () => Promise<void>;
+  /** Stops exactly what `start` began; safe to call when `start` never ran, and safe to call twice. */
+  stop: () => Promise<void>;
+}
+
+/**
+ * The one method table, folded from the composers' own. A method two
+ * composers claim is a construction failure rather than a silent
+ * last-writer-wins: which concern answers a method is a fact about the split,
+ * never about the order the merge happened to fold it in.
+ */
+export function mergeMethods(composers: readonly Composer[]): GatewayMethodTable {
+  const merged: GatewayMethodTable = {};
+  for (const composer of composers) {
+    // SAFETY: a method table's keys are the method names it was built from.
+    for (const method of Object.keys(composer.methods) as GatewayMethod[]) {
+      if (merged[method]) throw new Error(`two composers answer ${method}`);
+      merged[method] = composer.methods[method];
+    }
+  }
+  return merged;
+}

--- a/packages/host/src/host-kernel.ts
+++ b/packages/host/src/host-kernel.ts
@@ -1,0 +1,133 @@
+import path from "node:path";
+import { type GatewayEventKind, NODE_CAPABILITY_STATUS, NodeRegistry } from "@sidecar/gateway";
+import type { RuntimeStorePort } from "@sidecar/runtime-store";
+import type { WireValue } from "@sidecar/wire";
+import { HOST_NODE_CAPABILITY } from "./node-capabilities.js";
+import type { RunMode } from "./run-mode.js";
+import type { GatewayService } from "./service.js";
+import { NodeAnswerLostError } from "./session-act-performer.js";
+import type { SecretCipher } from "./settings-store.js";
+import { agentRootPath } from "./store-path.js";
+
+export interface HostSeams {
+  /** Luke's own application-state root, given explicitly: never derived from the hosting process's profile. */
+  stateRoot: string;
+  runMode: RunMode;
+  appVersion: string;
+  packaged: boolean;
+  /** The user's home, for the Superset CLI's own directory. */
+  homeDirectory: string;
+  /** The environment the host reads its development overrides from. */
+  environment: NodeJS.ProcessEnv;
+  cipher: SecretCipher;
+  createWorker: () => RuntimeStorePort;
+  /**
+   * Whether the observation hooks are registered with the providers' own
+   * user-level configurations at start. A validation run on a temporary
+   * state root says no, so nothing of the developer's real provider
+   * configuration moves; the transcripts are observed either way.
+   */
+  registerProviderHooks?: boolean;
+  now: () => number;
+  createId: () => string;
+  report: (message: string) => void;
+  /**
+   * Hears the protocol's shutdown method: the client's explicit Quit, or a
+   * newer build draining this one. The process hosting the runtime leaves in
+   * the coordinator's order; a host with no process to leave (a fixture run)
+   * hears nothing.
+   */
+  onShutdownRequested?: () => void;
+}
+
+/** The agent's identity workspace and the skills beside it, under the agent's own directory. */
+const AGENT_WORKSPACE_DIRECTORY = "workspace";
+const AGENT_SKILLS_DIRECTORY = "skills";
+
+/**
+ * What every composer of the host is handed: the seams the host was given,
+ * the two derived base URLs, the node registry, the one event door, and the
+ * paths under the agent's own directory. It holds no concern of its own, so
+ * nothing a composer owns can be reached through it by another.
+ */
+export interface HostKernel {
+  readonly options: HostSeams;
+  readonly runMode: RunMode;
+  readonly stateRoot: string;
+  readonly now: () => number;
+  readonly createId: () => string;
+  readonly report: (message: string) => void;
+  readonly accountBaseUrl: string;
+  readonly hostedServiceBaseUrl: string;
+  readonly nodes: NodeRegistry;
+  /** One host event, numbered into the log every client follows. */
+  emit: (kind: GatewayEventKind, payload: WireValue) => void;
+  /** The service the merge composed; reading it before the merge has is a named failure, never a silent undefined. */
+  service: () => GatewayService;
+  setService: (service: GatewayService) => void;
+  /**
+   * An address a host-owned flow needs opened: the native node's. No node
+   * connected is a refusal the act reports as not done; a node that took the
+   * ask and vanished before answering is the lost-answer error, which every
+   * caller that journals an act records as unknown rather than failed.
+   */
+  openExternalThroughNode: (url: string) => Promise<void>;
+  reportOpenFailure: (error: Error) => void;
+  agentWorkspacePath: () => string;
+  agentSkillsPath: () => string;
+}
+
+export function createHostKernel(options: HostSeams): HostKernel {
+  const { stateRoot, runMode, report, now, createId } = options;
+
+  // A development build may be pointed at a local account service; a packaged one
+  // may not. The override redirects the whole sign-in — including the identity
+  // request that carries the access token — so it stops at the packaging boundary
+  // rather than shipping inside a signed binary.
+  const accountBaseUrl =
+    (options.packaged ? undefined : options.environment.LUKE_ACCOUNT_BASE_URL) ??
+    "https://tryluke.dev/api/auth";
+  // The hosted voice endpoints live on the same origin as the account service,
+  // so the one development override redirects both together.
+  const hostedServiceBaseUrl = accountBaseUrl.replace(/\/api\/auth\/?$/, "");
+
+  const nodes = new NodeRegistry();
+  let service: GatewayService | undefined;
+  const agentWorkspacePath = () => path.join(agentRootPath(stateRoot), AGENT_WORKSPACE_DIRECTORY);
+
+  return {
+    options,
+    runMode,
+    stateRoot,
+    now,
+    createId,
+    report,
+    accountBaseUrl,
+    hostedServiceBaseUrl,
+    nodes,
+    emit: (kind, payload) => {
+      if (!service) throw new Error("the host's service is read before the merge composed it");
+      service.server.emit(kind, payload);
+    },
+    service: () => {
+      if (!service) throw new Error("the host's service is read before the merge composed it");
+      return service;
+    },
+    setService: (next) => {
+      service = next;
+    },
+    openExternalThroughNode: async (url) => {
+      const result = await nodes.invoke(HOST_NODE_CAPABILITY.OPEN_EXTERNAL, { url });
+      if (result.status === NODE_CAPABILITY_STATUS.OK) return;
+      if (result.status === NODE_CAPABILITY_STATUS.UNKNOWN) {
+        throw new NodeAnswerLostError(result.reason);
+      }
+      throw new Error(result.reason);
+    },
+    reportOpenFailure: (error) => {
+      report(`An address could not be opened: ${error.message}`);
+    },
+    agentWorkspacePath,
+    agentSkillsPath: () => path.join(agentWorkspacePath(), AGENT_SKILLS_DIRECTORY),
+  };
+}

--- a/packages/host/src/index.ts
+++ b/packages/host/src/index.ts
@@ -14,8 +14,9 @@
  * client does not reach yet is added when one arrives.
  */
 export { REJECTED_SUBMISSION } from "./brain/publication.js";
-export { composeHost, type Host, type HostSeams, RECEIVER_REPORT_KIND } from "./compose-host.js";
+export { composeHost, type Host } from "./compose-host.js";
 export type { ConversationOperations } from "./conversation-operations.js";
+export type { HostSeams } from "./host-kernel.js";
 export {
   INTRODUCTION_FADE_MS,
   INTRODUCTION_HANDOFF_READY_MS,

--- a/packages/host/src/late-ref.ts
+++ b/packages/host/src/late-ref.ts
@@ -1,0 +1,25 @@
+/**
+ * A reference filled after construction. Some of the host's concerns depend
+ * on each other in both directions — the account's capability gate starts the
+ * loops whose owners read that gate — so those edges cannot be constructor
+ * arguments. A read before `link()` has filled it throws by name, so a cycle
+ * closed in the wrong order is a named failure rather than an `undefined` a
+ * caller carries somewhere else.
+ */
+export interface LateRef<T> {
+  set: (value: T) => void;
+  get: () => T;
+}
+
+export function lateRef<T>(name: string): LateRef<T> {
+  let held: T | undefined;
+  return {
+    set: (value) => {
+      held = value;
+    },
+    get: () => {
+      if (held === undefined) throw new Error(`${name} is read before link() has run`);
+      return held;
+    },
+  };
+}

--- a/packages/host/src/notebook-memory.test.ts
+++ b/packages/host/src/notebook-memory.test.ts
@@ -23,7 +23,7 @@ import {
   serveRuntimeStore,
 } from "@sidecar/runtime-store";
 import { isRecord, type WireRecord } from "@sidecar/wire";
-import { composeNotebookMemory, type NotebookMemoryDependencies } from "./compose-host.js";
+import { composeNotebookMemory, type NotebookMemoryDependencies } from "./notebook-memory.js";
 
 const NOW = 1_800_000_000_000;
 

--- a/packages/host/src/notebook-memory.ts
+++ b/packages/host/src/notebook-memory.ts
@@ -1,0 +1,71 @@
+import type { BrainMemoryAccess } from "@sidecar/brain";
+import { EMBEDDING_BATCH_SIZE } from "@sidecar/brain";
+import {
+  type MemorySyncReport,
+  NotebookMemory,
+  RETRIEVAL_MODE,
+  type RetrievalMode,
+} from "@sidecar/memory";
+import type { ConversationRecord, EmbeddingAdapter, SessionKey } from "@sidecar/runtime-contracts";
+import type { RuntimeStoreClient } from "@sidecar/runtime-store";
+
+/** The notebook's index as the host holds it, and what a run without one still answers. */
+export interface MemoryWiring {
+  /** Syncs once and starts watching; a run with nothing on disk does neither. */
+  start: () => Promise<void>;
+  stop: () => void;
+  /** One reconcile of the index against the files; a call during a pass earns one follow-on pass under the adapter standing then. */
+  sync: () => Promise<MemorySyncReport | undefined>;
+  /** The brain's memory tools for one conversation. */
+  accessFor: (sessionKey: SessionKey) => BrainMemoryAccess | undefined;
+  /** The retrieval mode the last sync settled on. */
+  mode: () => RetrievalMode;
+}
+
+/** A run without a notebook: nothing on disk to index, so nothing to search. */
+export const INERT_MEMORY_WIRING: MemoryWiring = {
+  start: async () => undefined,
+  stop: () => undefined,
+  sync: async () => undefined,
+  accessFor: () => undefined,
+  mode: () => RETRIEVAL_MODE.KEYWORD_ONLY,
+};
+
+export interface NotebookMemoryDependencies {
+  client: () => RuntimeStoreClient;
+  /** The embedding adapter the credential policy built, or nothing when no credential stands. */
+  embeddingAdapter: () => EmbeddingAdapter | undefined;
+  /** Hears every credential change that may have replaced the adapter; the index is synced again so keyword-only chunks gain their vectors. */
+  onEmbeddingAdapterChanged?: (listener: () => void) => void;
+  /** The agent's identity workspace, watched for the notebook's files. */
+  workspaceDirectory: () => string;
+  conversationDirectory: () => readonly ConversationRecord[];
+  isTemporary: (sessionKey: SessionKey) => boolean;
+  now: () => number;
+  report: (message: string) => void;
+  /** Hears every completed sync, so the notebook's cached entries can be read again after a hand edit. */
+  onSynced?: () => void;
+}
+
+/**
+ * The notebook's index as the host wires it: the memory package's host over
+ * the store's worker and the embedding adapter the credential policy built.
+ * This composes only; the sync and the search live in `NotebookMemory`.
+ */
+export function composeNotebookMemory(dependencies: NotebookMemoryDependencies): NotebookMemory {
+  const memory = new NotebookMemory({
+    store: dependencies.client,
+    embeddingAdapter: dependencies.embeddingAdapter,
+    embeddingBatchSize: EMBEDDING_BATCH_SIZE,
+    workspaceDirectory: dependencies.workspaceDirectory,
+    conversationDirectory: dependencies.conversationDirectory,
+    isTemporary: dependencies.isTemporary,
+    now: dependencies.now,
+    report: dependencies.report,
+    ...(dependencies.onSynced ? { onSynced: dependencies.onSynced } : undefined),
+  });
+  dependencies.onEmbeddingAdapterChanged?.(() => {
+    void memory.sync();
+  });
+  return memory;
+}

--- a/packages/host/src/voice-credential-transition.test.ts
+++ b/packages/host/src/voice-credential-transition.test.ts
@@ -20,7 +20,7 @@ import { REASONING_EFFORT } from "@sidecar/runtime-contracts";
 import { APP_SETTING_SCHEMA, VOICE_SOURCE, type VoiceSource } from "@sidecar/settings";
 import { VoiceCapabilityAssembler, type VoiceSettings } from "@sidecar/voice";
 import { BrainHost } from "./brain/host.js";
-import { transitionVoiceCredential } from "./compose-host.js";
+import { transitionVoiceCredential } from "./voice-credential-transition.js";
 
 const HELD_READ = {
   SOURCE: "source",

--- a/packages/host/src/voice-credential-transition.ts
+++ b/packages/host/src/voice-credential-transition.ts
@@ -1,0 +1,31 @@
+import type { VoiceCapabilityApplication } from "@sidecar/voice";
+
+/**
+ * One credential transition, from the seams the host owns: the brain
+ * wiring's synchronous retire, the assembler's application, and the rebuild
+ * that installs what the applied capability allows. The retire is immediate,
+ * so no run keeps the old source's authority past the transition's first
+ * await. The rebuild belongs to the current application alone, asked at the
+ * moment of use rather than read off the answer: a newer transition can begin
+ * between the assembler's publication and this continuation, and it has
+ * already retired the wiring, so a rebuild on the older one's behalf would be
+ * the newest thing the host was asked for and would install the retired
+ * source over the selection still being read. An overtaken transition builds
+ * nothing and leaves the host empty for the newer one to fill. Answers
+ * whether this transition was the one that installed.
+ */
+export interface VoiceCredentialTransitionSeams {
+  retire: () => void;
+  apply: () => Promise<VoiceCapabilityApplication>;
+  rebuild: () => Promise<void>;
+}
+
+export async function transitionVoiceCredential(
+  seams: VoiceCredentialTransitionSeams,
+): Promise<boolean> {
+  seams.retire();
+  const applied = await seams.apply();
+  if (!applied.latest || !applied.isCurrent()) return false;
+  await seams.rebuild();
+  return true;
+}

--- a/packages/host/src/wire-helpers.ts
+++ b/packages/host/src/wire-helpers.ts
@@ -1,0 +1,10 @@
+import { isWireString, type WireRecord } from "@sidecar/wire";
+
+/**
+ * The opaque reporter a client minted for the window that asked. It rides on
+ * the change event so that window can skip echoing its own write back to
+ * itself, and names nothing about the window to anyone else.
+ */
+export function reporterOf(params: WireRecord): string | undefined {
+  return isWireString(params.reporter) ? params.reporter : undefined;
+}


### PR DESCRIPTION
## What

`composeHost` was one 2,600-line function holding every concern of the runtime in a single scope: 24 mutable `let`s that nothing could keep private, a 570-line method table covering seven unrelated domains, and a dependency graph that existed only as closure capture.

It is now seven composers, each owning its own mutable state, its own timers, and the Gateway methods of its domain, each answering `start()` and `stop()` for exactly what it began:

| file | concern | methods |
|---|---|---|
| `compose-settings.ts` | the store, the one write path and its host side effects, analytics, the vault and account-preference syncs | 6 |
| `compose-account.ts` | the account and its session, the capability gate, the voice assembler, the dev trace, session-replay permission | 7 |
| `compose-issues.ts` | Linear: credentials, tracker, sign-in, the tracked-issue list | 4 |
| `compose-observation.ts` | providers, the roster and its loop, Superset, workspace projects, hooks and spool watchers, the session-act performer | 12 |
| `compose-calendars.ts` | Google and Apple calendars, meetings and the quiet boundary, the onboarding record and its gate | 13 |
| `compose-speech.ts` | the arbiter, the one receiver, the beats, offering and settling | 2 |
| `compose-brain.ts` | the store, the notebook and its maintenance, the brain, conversations, cron | 2 |

`compose-host.ts` (357 lines) constructs them, links the back-edges, merges their method tables, and keeps the drain. `client.bootstrap` and `shutdown` are the two methods no composer owns — the first reads six of them, so giving it to any would hand that composer references to the other five.

Three new seams carry the split:

- `composer.ts` — the `Composer` interface and `mergeMethods`, which **throws at construction** on a method two composers claim. Disjointness is an invariant, not a convention.
- `host-kernel.ts` — what every composer is handed: the seams, the two derived base URLs, the node registry, the one event door, the paths. Reading the service before the merge composed it is a named failure rather than the old unguarded `let service`.
- `late-ref.ts` — the five genuine cycles (the account's capability gate starts the loops whose owners read that gate; the calendars hold the speech that reconciles against them) are listed once in `link()` and held in a reference that throws by name when read early.

`RECEIVER_REPORT_KIND` moves to `packages/gateway`'s `protocol.ts`, beside the `receiver.report` entry it is the vocabulary of. `composeNotebookMemory` and `transitionVoiceCredential` move to the files their tests were already named for.

The import-narrating header, the two section banners, and the two aphorism sentences are deleted. Every comment that records a constraint or a reason moved onto the code it explains.

## Behaviour

Mechanical relocation. No method's semantics, no event's payload, and no ordering the launch or the quit depends on has changed:

- the method vocabulary is byte-identical — 49 `GATEWAY_METHOD` entries, verified by diffing the set against `origin/main`;
- every non-comment line of the old function is accounted for in the new files (checked mechanically both ways; the only differences are renames — `settingsStore` → `store`, `brainWiring` → `wiring`, `emit` → `kernel.emit`);
- `start()` keeps the sequence that carries guarantees: the account is read and initialised before anything gated on it, the store is open before the credential transition installs a runtime over it, hooks are registered before the voice credential, and the supervisor is armed last;
- `close()` stops each concern in the reverse of the order it started in, each failure reported rather than stranding the store's close.

`service.test.ts` is unchanged, as are `host-lifecycle.test.ts`, `host-retention.test.ts`, `conversation-clear.test.ts`, and every `brain/*.test.ts`.

## Tests

New `compose-host.test.ts`:

- a method two composers claim throws at construction;
- a late reference read before `link()` says so;
- the kernel's service before the merge says so;
- the composed host answers `client.bootstrap` — the one method that reads six composers, so an answer proves the merge stood every concern up and linked its back-edges — and starts, stops, and stops again.

It runs without `--test-force-exit` and the process exits on its own, so a composer's `stop()` leaving a timer would hang the run.

## Review passes

A thermonuclear pass (structural regressions, missed simplification, file sprawl, spaghetti branching) and a ponytail pass (over-engineering, dead flexibility) ran over the diff. The ponytail pass found nine composer-interface members with no caller — `applyHostSettingSideEffect`, `vaultSync`, `emitSessionReplay`, `arbiter`, `meetings`, `refreshAnnouncementHold`, `armQuietBoundaryTimer`, `memoryAccessFor`, `guide` — each exposed by reflex rather than by a reader. They are gone; the functions behind them stay local to the composers that use them. No file crosses 1,000 lines (largest: `compose-observation.ts` at ~715), and no new conditional was introduced.

## Verification

`./scripts/check.sh` green, and CI's TypeScript, macOS app and evidence, CodeQL, Bugbot, and security checks were all green on the previous head before this rebase onto #829 and #830 (which renamed the provider adapter seam to `plugin`; the rename is carried through `compose-observation.ts` and `compose-brain.ts` here). Not a UI change: no renderer, panel, or style file is touched, so no `verify.sh` fixture capture or physical-notch check applies.

`git diff --shortstat origin/main...`: **22 files changed, 3387 insertions(+), 2474 deletions(-)**

Running total (tracked `.ts`/`.tsx`/`.mjs`): 197,528 → 198,419, **+891**. A decomposition of one scope into seven costs the seven interface declarations and `link()`, and that is the point of the PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34325015689/artifacts/10093485540) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34325015689)

- Commit: `82beda77e44afc486dfc816b09c779e4e245186c`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
