### PR TITLE
refactor(brain): one transport base

### DIFF
--- a/packages/analytics/src/sender.ts
+++ b/packages/analytics/src/sender.ts
@@ -8,7 +8,7 @@ import {
   type ProductEventPropertiesFor,
   productEventFromWire,
 } from "@sidecar/analytics";
-import { HOSTED_SERVICE_PATH } from "@sidecar/hosted";
+import { type AccountToken, HOSTED_SERVICE_PATH } from "@sidecar/hosted";
 import { type CloudFetch, positiveInteger, text, withoutTrailingSlash } from "@sidecar/wire";
 
 const PRODUCT_EVENT_DEFAULTS = {
@@ -33,15 +33,13 @@ const UNAUTHORIZED_STATUS = 401;
 /** The one discriminator the day marker dedups on; the day itself is the key. */
 const DAY_ACTIVE_KEY = "day";
 
-export interface ProductEventSenderOptions {
+export interface ProductEventSenderOptions extends AccountToken {
   /** The hosted service origin, without a trailing slash. */
   serviceBaseUrl: string;
   /** The running build's version, as the packaged app reports it. */
   appVersion: string;
   /** `runMode.sendsNetwork`. False makes every record a no-op. */
   sends: boolean;
-  readAccessToken: () => Promise<string | undefined>;
-  refreshAccount: () => Promise<void>;
   fetch?: CloudFetch;
   now?: () => number;
   requestTimeoutMs?: number;

--- a/packages/brain/src/client.test.ts
+++ b/packages/brain/src/client.test.ts
@@ -1,0 +1,211 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { HOSTED_BRAIN_CONTRACT_VERSION, HOSTED_SERVICE_PATH } from "@sidecar/hosted";
+import { MODEL_FAILURE, MODEL_RESPONSE_OUTCOME } from "@sidecar/runtime/vocabulary";
+import { HostedBrainTransport, KeyedBrainTransport } from "./client.js";
+import {
+  BRAIN_RATE_LIMIT_COOLDOWN_MS,
+  BRAIN_RATE_LIMIT_RETRY_AFTER_BOUND_MS,
+  HTTP_METHOD,
+} from "./model-adapter-shared.js";
+
+const NOW = 1_800_000_000_000;
+const BASE = "https://luke.test";
+
+interface Call {
+  url: string;
+  method: string | undefined;
+  authorization: string | null;
+  contentType: string | null;
+  body: string | undefined;
+  signal: AbortSignal | undefined;
+}
+
+function recorder(answers: readonly (() => Response)[]) {
+  const calls: Call[] = [];
+  const queue = [...answers];
+  const fetch = (url: string, init: RequestInit): Promise<Response> => {
+    const headers = new Headers(init.headers);
+    calls.push({
+      url,
+      method: init.method,
+      authorization: headers.get("authorization"),
+      contentType: headers.get("content-type"),
+      body: init.body === undefined ? undefined : String(init.body),
+      signal: init.signal ?? undefined,
+    });
+    const answer = queue.shift();
+    assert.ok(answer, `unexpected call to ${url}`);
+    return Promise.resolve(answer());
+  };
+  return { fetch, calls };
+}
+
+function keyed(answers: readonly (() => Response)[], baseUrl = `${BASE}/v1/`) {
+  const { fetch, calls } = recorder(answers);
+  return {
+    calls,
+    transport: new KeyedBrainTransport({ baseUrl, apiKey: "sk-test", fetch, now: () => NOW }),
+  };
+}
+
+function hosted(
+  answers: readonly (() => Response)[],
+  tokens: (string | undefined)[] = ["token-1"],
+) {
+  const { fetch, calls } = recorder(answers);
+  const queue = [...tokens];
+  let current = queue.shift();
+  const refreshes: number[] = [];
+  const transport = new HostedBrainTransport({
+    baseUrl: BASE,
+    readAccessToken: () => Promise.resolve(current),
+    refreshAccount: () => {
+      refreshes.push(1);
+      current = queue.shift() ?? current;
+      return Promise.resolve();
+    },
+    fetch,
+    now: () => NOW,
+  });
+  return { calls, refreshes, transport };
+}
+
+test("a base URL is trimmed once, the credential is one bearer header, and a body names its own type", async () => {
+  const { calls, transport } = keyed([() => Response.json({ ok: true })]);
+  const response = await transport.send("/responses", HTTP_METHOD.POST, '{"a":1}');
+  assert.ok(response instanceof Response);
+  assert.equal(calls[0]?.url, `${BASE}/v1/responses`);
+  assert.equal(calls[0]?.method, HTTP_METHOD.POST);
+  assert.equal(calls[0]?.authorization, "Bearer sk-test");
+  assert.equal(calls[0]?.contentType, "application/json");
+  assert.equal(calls[0]?.body, '{"a":1}');
+
+  const read = keyed([() => Response.json({ ok: true })]);
+  await read.transport.send("/capabilities", HTTP_METHOD.GET);
+  assert.equal(read.calls[0]?.body, undefined);
+  assert.equal(read.calls[0]?.contentType, null);
+});
+
+test("the run's own cancellation is joined with the per-request timeout, and neither alone ends the other", async () => {
+  const cancellation = new AbortController();
+  const { calls, transport } = keyed([() => Response.json({})]);
+  await transport.send("/responses", HTTP_METHOD.POST, "{}", cancellation.signal);
+  const signal = calls[0]?.signal;
+  assert.ok(signal && !signal.aborted);
+  cancellation.abort();
+  assert.equal(signal.aborted, true);
+});
+
+test("a fetch that throws is a network failure named by the error's kind alone, never by its words", async () => {
+  const transport = new KeyedBrainTransport({
+    baseUrl: BASE,
+    apiKey: "sk-secret-key",
+    fetch: () => Promise.reject(new TypeError("sk-secret-key was refused by dns")),
+    now: () => NOW,
+  });
+  const failure = await transport.send("/responses", HTTP_METHOD.POST, "{}");
+  assert.ok(!(failure instanceof Response));
+  assert.equal(failure.outcome, MODEL_RESPONSE_OUTCOME.FAILED);
+  assert.equal(failure.failure, MODEL_FAILURE.NETWORK);
+  assert.equal(failure.reason, "request did not complete: TypeError");
+  assert.ok(!failure.reason.includes("sk-secret"));
+});
+
+test("the keyed transport sends one attempt and never refreshes; no account token at all is a credential failure", async () => {
+  const { calls, transport } = keyed([() => new Response("", { status: 401 })]);
+  const refused = await transport.send("/responses", HTTP_METHOD.POST, "{}");
+  assert.ok(refused instanceof Response && refused.status === 401);
+  assert.equal(calls.length, 1);
+
+  const signedOut = hosted([], [undefined]);
+  const failure = await signedOut.transport.send("/responses", HTTP_METHOD.POST, "{}");
+  assert.ok(!(failure instanceof Response) && failure.failure === MODEL_FAILURE.CREDENTIAL);
+  assert.deepEqual(signedOut.calls, []);
+});
+
+test("a hosted attempt refused once is refreshed and retried once; a refresh that changes nothing lets the refusal stand", async () => {
+  const retried = hosted(
+    [() => new Response("", { status: 401 }), () => Response.json({ ok: true })],
+    ["stale", "fresh"],
+  );
+  const answer = await retried.transport.send("/responses", HTTP_METHOD.POST, "{}");
+  assert.ok(answer instanceof Response && answer.ok);
+  assert.deepEqual(
+    retried.calls.map((call) => call.authorization),
+    ["Bearer stale", "Bearer fresh"],
+  );
+
+  const unchanged = hosted([() => new Response("", { status: 401 })], ["only"]);
+  const refusal = await unchanged.transport.send("/responses", HTTP_METHOD.POST, "{}");
+  assert.ok(refusal instanceof Response && refusal.status === 401);
+  assert.equal(unchanged.calls.length, 1);
+  assert.equal(unchanged.refreshes.length, 1);
+});
+
+test("a 429 earns the bounded Retry-After or the fixed cooldown on either transport, and a spent allowance waits for its reset", () => {
+  const { transport } = keyed([]);
+  const header = transport.quietUntil(
+    new Response("", { status: 429, headers: { "retry-after": "7" } }),
+  );
+  assert.deepEqual(header, {
+    until: NOW + 7_000,
+    message: "OpenAI brain turns are rate limited; pausing for 7s",
+  });
+  assert.equal(
+    transport.quietUntil(new Response("", { status: 429 })).until,
+    NOW + BRAIN_RATE_LIMIT_COOLDOWN_MS,
+  );
+  assert.equal(
+    transport.quietUntil(new Response("", { status: 429, headers: { "retry-after": "86400" } }))
+      .until,
+    NOW + BRAIN_RATE_LIMIT_RETRY_AFTER_BOUND_MS,
+  );
+
+  const service = hosted([]);
+  const throttle = new Response("", { status: 429, headers: { "retry-after": "7" } });
+  assert.deepEqual(service.transport.quietUntil(throttle), {
+    until: NOW + 7_000,
+    message: "Hosted brain turns are rate limited; pausing for 7s",
+  });
+  const resetsAt = NOW + 3_600_000;
+  assert.deepEqual(
+    service.transport.quietUntil(throttle, {
+      error: "quota-exhausted",
+      quota: { used: 5000, limit: 5000, resetsAt },
+    }),
+    {
+      until: resetsAt,
+      message: "Hosted brain turns are out of today's allowance; pausing for 3600s",
+    },
+  );
+  const spent = { error: "quota-exhausted", quota: { used: 1, limit: 1, resetsAt: NOW - 1 } };
+  assert.equal(service.transport.quietUntil(throttle, spent).until, NOW + 7_000);
+});
+
+test("the capabilities read names a service with none, another contract, a refused token, and an outage by kind", async () => {
+  const capabilities = {
+    contract: HOSTED_BRAIN_CONTRACT_VERSION,
+    model: "gpt-hosted",
+    operations: ["respond"],
+    tools: [],
+    bounds: { promptChars: 1, requestBytes: 1, maximumOutputTokens: 1, inputItems: 1 },
+    reasoningEfforts: ["medium"],
+  };
+  const served = hosted([() => Response.json(capabilities)]);
+  const read = await served.transport.capabilities();
+  assert.ok(!("outcome" in read) && read.model === "gpt-hosted");
+  assert.equal(served.calls[0]?.url, `${BASE}${HOSTED_SERVICE_PATH.BRAIN_CAPABILITIES}`);
+  assert.equal(served.calls[0]?.method, HTTP_METHOD.GET);
+
+  for (const [answer, failure] of [
+    [() => new Response("", { status: 404 }), MODEL_FAILURE.COMPATIBILITY],
+    [() => new Response("", { status: 405 }), MODEL_FAILURE.COMPATIBILITY],
+    [() => Response.json({ ...capabilities, contract: 1 }), MODEL_FAILURE.COMPATIBILITY],
+    [() => new Response("", { status: 401 }), MODEL_FAILURE.CREDENTIAL],
+    [() => new Response("", { status: 503 }), MODEL_FAILURE.UPSTREAM],
+  ] as const) {
+    const refused = await hosted([answer]).transport.capabilities();
+    assert.ok("outcome" in refused && refused.failure === failure);
+  }
+});

--- a/packages/brain/src/client.ts
+++ b/packages/brain/src/client.ts
@@ -50,18 +50,18 @@ export interface BrainTransportOptions {
  * credential — a key the developer typed, or the signed-in account's token,
  * which is refreshed once when the first attempt is refused.
  */
-export abstract class BrainTransport {
-  protected readonly baseUrl: string;
-  protected readonly now: () => number;
+abstract class BrainTransport {
+  readonly #baseUrl: string;
+  readonly #now: () => number;
   readonly #fetch: CloudFetch;
   readonly #requestTimeoutMs: number;
 
   protected constructor(options: BrainTransportOptions) {
     const baseUrl = text(options.baseUrl);
     if (!baseUrl) throw new Error("Brain transport base URL must not be empty");
-    this.baseUrl = withoutTrailingSlash(baseUrl);
+    this.#baseUrl = withoutTrailingSlash(baseUrl);
     this.#fetch = options.fetch ?? ((input, init) => fetch(input, init));
-    this.now = options.now ?? Date.now;
+    this.#now = options.now ?? Date.now;
     this.#requestTimeoutMs = positiveInteger(options.requestTimeoutMs, BRAIN_REQUEST_TIMEOUT_MS);
   }
 
@@ -71,15 +71,18 @@ export abstract class BrainTransport {
   /** The authorization header for one attempt, or nothing when there is no credential to send. */
   protected abstract authorization(): Promise<string | undefined>;
 
-  /** A fresh authorization for one retry of a refused attempt, or nothing to let the refusal stand. */
-  protected retryUnauthorized(_used: string): Promise<string | undefined> {
-    return Promise.resolve(undefined);
+  /** Asks whoever owns the credential to renew it; a transport with nothing to renew does nothing. */
+  protected renewCredential(): Promise<void> {
+    return Promise.resolve();
   }
 
   /**
    * One authorized request. No credential at all and a fetch that did not
    * complete are already ends, named by kind; every status is the caller's to
-   * read, including the refusal that outlived a refreshed credential.
+   * read, including the refusal that outlived a renewed credential.
+   *
+   * A refusal is retried exactly once, and only on a credential that actually
+   * changed: retrying the same one would only repeat the no.
    */
   async send(
     path: string,
@@ -93,10 +96,11 @@ export abstract class BrainTransport {
     if (!(response instanceof Response) || response.status !== HTTP_STATUS.UNAUTHORIZED) {
       return response;
     }
-    const refreshed = await this.retryUnauthorized(authorization);
-    return refreshed === undefined
+    await this.renewCredential();
+    const renewed = await this.authorization();
+    return renewed === undefined || renewed === authorization
       ? response
-      : this.#attempt(path, method, refreshed, body, signal);
+      : this.#attempt(path, method, renewed, body, signal);
   }
 
   /**
@@ -112,15 +116,15 @@ export abstract class BrainTransport {
         ? hostedQuotaSchema.parse(unparsedWire(record.quota))
         : undefined;
     const resetsAt = quota?.resetsAt;
-    if (resetsAt !== undefined && resetsAt > this.now()) {
+    if (resetsAt !== undefined && resetsAt > this.#now()) {
       return {
         until: resetsAt,
-        message: `${this.label} are out of today's allowance; pausing for ${Math.round((resetsAt - this.now()) / 1000)}s`,
+        message: `${this.label} are out of today's allowance; pausing for ${Math.round((resetsAt - this.#now()) / 1000)}s`,
       };
     }
     const waitMs = rateLimitWaitMs(response.headers.get(RETRY_AFTER_HEADER));
     return {
-      until: this.now() + waitMs,
+      until: this.#now() + waitMs,
       message: `${this.label} are rate limited; pausing for ${Math.round(waitMs / 1000)}s`,
     };
   }
@@ -133,7 +137,7 @@ export abstract class BrainTransport {
     signal: AbortSignal | undefined,
   ): Promise<Response | Failure> {
     try {
-      return await this.#fetch(`${this.baseUrl}${path}`, {
+      return await this.#fetch(`${this.#baseUrl}${path}`, {
         method,
         headers: {
           authorization,
@@ -207,14 +211,9 @@ export class HostedBrainTransport extends BrainTransport {
     return capabilities;
   }
 
-  protected override async retryUnauthorized(used: string): Promise<string | undefined> {
-    // Routine expiry of an hour-lived token inside a day-lived app: refresh and
-    // retry once. A retry on the same token would only repeat the no.
-    await this.#refreshAccount().catch(() => undefined);
-    const refreshed = await this.#readAccessToken();
-    if (!refreshed) return undefined;
-    const authorization = bearer(refreshed);
-    return authorization === used ? undefined : authorization;
+  /** Routine expiry of an hour-lived token inside a day-lived app; a refresh that itself fails leaves the refusal standing. */
+  protected override renewCredential(): Promise<void> {
+    return this.#refreshAccount().catch(() => undefined);
   }
 
   protected async authorization(): Promise<string | undefined> {

--- a/packages/brain/src/client.ts
+++ b/packages/brain/src/client.ts
@@ -1,0 +1,234 @@
+import {
+  type AccountToken,
+  HOSTED_API_ERROR,
+  HOSTED_BRAIN_CONTRACT_VERSION,
+  HOSTED_SERVICE_PATH,
+  type HostedBrainCapabilities,
+  hostedBrainCapabilitiesFromWire,
+  hostedQuotaSchema,
+} from "@sidecar/hosted";
+import { MODEL_FAILURE } from "@sidecar/runtime/vocabulary";
+import {
+  type CloudFetch,
+  HTTP_STATUS,
+  positiveInteger,
+  text,
+  type UnparsedWireValue,
+  unparsedWire,
+  wireRecord,
+  withoutTrailingSlash,
+} from "@sidecar/wire";
+import {
+  BRAIN_REQUEST_TIMEOUT_MS,
+  type Failure,
+  failed,
+  HTTP_METHOD,
+  type HttpMethod,
+  notServed,
+  payloadOf,
+  RETRY_AFTER_HEADER,
+  rateLimitWaitMs,
+  requestFault,
+} from "./model-adapter-shared.js";
+import type { Quiet } from "./responses-model-adapter.js";
+
+/** What every call out of the brain is addressed and bounded by, whatever authorizes it. */
+export interface BrainTransportOptions {
+  /** The origin the calls are addressed to; any trailing separator is trimmed. */
+  baseUrl: string;
+  fetch?: CloudFetch;
+  now?: () => number;
+  requestTimeoutMs?: number;
+}
+
+/**
+ * One call out of the brain, whatever authorizes it: the base URL trimmed
+ * once, the bearer header written once, the per-request timeout joined with
+ * the caller's own cancellation once, a fetch that throws read as a network
+ * failure by the error's kind alone and never by its words, which could carry
+ * a key, and one reading of what a 429 means. What a subclass supplies is the
+ * credential — a key the developer typed, or the signed-in account's token,
+ * which is refreshed once when the first attempt is refused.
+ */
+export abstract class BrainTransport {
+  protected readonly baseUrl: string;
+  protected readonly now: () => number;
+  readonly #fetch: CloudFetch;
+  readonly #requestTimeoutMs: number;
+
+  protected constructor(options: BrainTransportOptions) {
+    const baseUrl = text(options.baseUrl);
+    if (!baseUrl) throw new Error("Brain transport base URL must not be empty");
+    this.baseUrl = withoutTrailingSlash(baseUrl);
+    this.#fetch = options.fetch ?? ((input, init) => fetch(input, init));
+    this.now = options.now ?? Date.now;
+    this.#requestTimeoutMs = positiveInteger(options.requestTimeoutMs, BRAIN_REQUEST_TIMEOUT_MS);
+  }
+
+  /** The words a quiet is reported with, which name the transport the developer is on. */
+  protected abstract readonly label: string;
+
+  /** The authorization header for one attempt, or nothing when there is no credential to send. */
+  protected abstract authorization(): Promise<string | undefined>;
+
+  /** A fresh authorization for one retry of a refused attempt, or nothing to let the refusal stand. */
+  protected retryUnauthorized(_used: string): Promise<string | undefined> {
+    return Promise.resolve(undefined);
+  }
+
+  /**
+   * One authorized request. No credential at all and a fetch that did not
+   * complete are already ends, named by kind; every status is the caller's to
+   * read, including the refusal that outlived a refreshed credential.
+   */
+  async send(
+    path: string,
+    method: HttpMethod,
+    body?: string,
+    signal?: AbortSignal,
+  ): Promise<Response | Failure> {
+    const authorization = await this.authorization();
+    if (!authorization) return failed(MODEL_FAILURE.CREDENTIAL, "no account token");
+    const response = await this.#attempt(path, method, authorization, body, signal);
+    if (!(response instanceof Response) || response.status !== HTTP_STATUS.UNAUTHORIZED) {
+      return response;
+    }
+    const refreshed = await this.retryUnauthorized(authorization);
+    return refreshed === undefined
+      ? response
+      : this.#attempt(path, method, refreshed, body, signal);
+  }
+
+  /**
+   * What a 429 means. The bounded `Retry-After` wait is the floor every
+   * transport takes, so a hosted developer and a keyed one wait the same way
+   * for the same provider limit; a body naming a later reset — a spent daily
+   * allowance — stands the transport down until then instead.
+   */
+  quietUntil(response: Response, body?: UnparsedWireValue): Quiet {
+    const record = wireRecord(unparsedWire(body));
+    const quota =
+      record?.error === HOSTED_API_ERROR.QUOTA_EXHAUSTED
+        ? hostedQuotaSchema.parse(unparsedWire(record.quota))
+        : undefined;
+    const resetsAt = quota?.resetsAt;
+    if (resetsAt !== undefined && resetsAt > this.now()) {
+      return {
+        until: resetsAt,
+        message: `${this.label} are out of today's allowance; pausing for ${Math.round((resetsAt - this.now()) / 1000)}s`,
+      };
+    }
+    const waitMs = rateLimitWaitMs(response.headers.get(RETRY_AFTER_HEADER));
+    return {
+      until: this.now() + waitMs,
+      message: `${this.label} are rate limited; pausing for ${Math.round(waitMs / 1000)}s`,
+    };
+  }
+
+  async #attempt(
+    path: string,
+    method: HttpMethod,
+    authorization: string,
+    body: string | undefined,
+    signal: AbortSignal | undefined,
+  ): Promise<Response | Failure> {
+    try {
+      return await this.#fetch(`${this.baseUrl}${path}`, {
+        method,
+        headers: {
+          authorization,
+          ...(body !== undefined ? { "content-type": "application/json" } : undefined),
+        },
+        ...(body !== undefined ? { body } : undefined),
+        signal: requestSignal(this.#requestTimeoutMs, signal),
+      });
+    } catch (error) {
+      return requestFault(error instanceof Error ? error : undefined);
+    }
+  }
+}
+
+/** The developer's own key straight to the provider: one header, one attempt, nothing to refresh. */
+export class KeyedBrainTransport extends BrainTransport {
+  protected readonly label = "OpenAI brain turns";
+  readonly #authorization: string;
+
+  constructor(options: BrainTransportOptions & { apiKey: string }) {
+    super(options);
+    const apiKey = text(options.apiKey);
+    if (!apiKey) throw new Error("OpenAI API key must not be empty");
+    this.#authorization = bearer(apiKey);
+  }
+
+  protected authorization(): Promise<string | undefined> {
+    return Promise.resolve(this.#authorization);
+  }
+}
+
+/**
+ * Luke's hosted service on the signed-in account, shared by every adapter
+ * that speaks to it: the token read fresh per attempt and refreshed once when
+ * the first is refused, and the capabilities read that admits an operation.
+ */
+export class HostedBrainTransport extends BrainTransport {
+  protected readonly label = "Hosted brain turns";
+  readonly #readAccessToken: () => Promise<string | undefined>;
+  readonly #refreshAccount: () => Promise<void>;
+
+  constructor(options: BrainTransportOptions & AccountToken) {
+    super(options);
+    this.#readAccessToken = options.readAccessToken;
+    this.#refreshAccount = options.refreshAccount;
+  }
+
+  /** Reads the service's capabilities; a service that has none, or names another contract, is incompatible. */
+  async capabilities(): Promise<HostedBrainCapabilities | Failure> {
+    const response = await this.send(HOSTED_SERVICE_PATH.BRAIN_CAPABILITIES, HTTP_METHOD.GET);
+    if (!(response instanceof Response)) return response;
+    if (notServed(response)) {
+      return failed(
+        MODEL_FAILURE.COMPATIBILITY,
+        `the hosted service does not offer brain contract ${HOSTED_BRAIN_CONTRACT_VERSION}`,
+      );
+    }
+    if (response.status === HTTP_STATUS.UNAUTHORIZED) {
+      return failed(MODEL_FAILURE.CREDENTIAL, "the account token was refused");
+    }
+    if (!response.ok) {
+      return failed(MODEL_FAILURE.UPSTREAM, `capabilities failed with status ${response.status}`);
+    }
+    const capabilities = hostedBrainCapabilitiesFromWire(await payloadOf(response));
+    if (!capabilities) {
+      return failed(
+        MODEL_FAILURE.COMPATIBILITY,
+        `the hosted service's capabilities are not brain contract ${HOSTED_BRAIN_CONTRACT_VERSION}`,
+      );
+    }
+    return capabilities;
+  }
+
+  protected override async retryUnauthorized(used: string): Promise<string | undefined> {
+    // Routine expiry of an hour-lived token inside a day-lived app: refresh and
+    // retry once. A retry on the same token would only repeat the no.
+    await this.#refreshAccount().catch(() => undefined);
+    const refreshed = await this.#readAccessToken();
+    if (!refreshed) return undefined;
+    const authorization = bearer(refreshed);
+    return authorization === used ? undefined : authorization;
+  }
+
+  protected async authorization(): Promise<string | undefined> {
+    const token = await this.#readAccessToken();
+    return token ? bearer(token) : undefined;
+  }
+}
+
+function bearer(credential: string): string {
+  return `Bearer ${credential}`;
+}
+
+/** The per-request timeout, joined with the run's own cancellation when the call belongs to one. */
+function requestSignal(timeoutMs: number, cancellation: AbortSignal | undefined): AbortSignal {
+  const timeout = AbortSignal.timeout(timeoutMs);
+  return cancellation ? AbortSignal.any([timeout, cancellation]) : timeout;
+}

--- a/packages/brain/src/embedding-adapters.ts
+++ b/packages/brain/src/embedding-adapters.ts
@@ -1,4 +1,5 @@
 import {
+  type AccountToken,
   HOSTED_BRAIN_CONTRACT_VERSION,
   HOSTED_BRAIN_EMBED_BOUNDS,
   HOSTED_BRAIN_OPERATION,
@@ -21,22 +22,10 @@ import {
   isWireNumber,
   isWireString,
   numberVectors,
-  positiveInteger,
-  text,
   type UnparsedWireValue,
 } from "@sidecar/wire";
-import {
-  BRAIN_REQUEST_TIMEOUT_MS,
-  failed,
-  HostedServiceCalls,
-  HTTP_METHOD,
-  notServed,
-  payloadOf,
-  RETRY_AFTER_HEADER,
-  rateLimitWaitMs,
-  requestSignal,
-  throttled,
-} from "./model-adapter-shared.js";
+import { HostedBrainTransport, KeyedBrainTransport } from "./client.js";
+import { failed, HTTP_METHOD, notServed, payloadOf, throttled } from "./model-adapter-shared.js";
 import { BRAIN_OPENAI_DEFAULTS } from "./openai-model-adapter.js";
 
 /**
@@ -95,19 +84,14 @@ export interface OpenAiEmbeddingAdapterOptions {
 
 /** The model and endpoint are fixed by the build: the index stores vectors under one model, and a key chooses none. */
 export class OpenAiEmbeddingAdapter implements EmbeddingAdapter {
-  readonly #apiKey: string;
-  readonly #fetch: CloudFetch;
-  readonly #now: () => number;
-  readonly #timeoutMs: number;
+  readonly #client: KeyedBrainTransport;
   #dimensions: number | undefined;
 
   constructor(options: OpenAiEmbeddingAdapterOptions) {
-    const apiKey = text(options.apiKey);
-    if (!apiKey) throw new Error("OpenAI API key must not be empty");
-    this.#apiKey = apiKey;
-    this.#fetch = options.fetch ?? ((input, init) => fetch(input, init));
-    this.#now = options.now ?? Date.now;
-    this.#timeoutMs = positiveInteger(options.requestTimeoutMs, BRAIN_REQUEST_TIMEOUT_MS);
+    this.#client = new KeyedBrainTransport({
+      ...options,
+      baseUrl: BRAIN_OPENAI_DEFAULTS.BASE_URL,
+    });
   }
 
   identity(): Promise<EmbeddingIdentity> {
@@ -129,25 +113,15 @@ export class OpenAiEmbeddingAdapter implements EmbeddingAdapter {
         `an embedding batch carries at most ${EMBEDDING_BATCH_SIZE} texts`,
       );
     }
-    let response: Response;
-    try {
-      response = await this.#fetch(`${BRAIN_OPENAI_DEFAULTS.BASE_URL}${BRAIN_EMBEDDINGS_PATH}`, {
-        method: HTTP_METHOD.POST,
-        headers: {
-          authorization: `Bearer ${this.#apiKey}`,
-          "content-type": "application/json",
-        },
-        body: JSON.stringify(brainEmbeddingsRequest(texts, { model: BRAIN_EMBEDDING_MODEL })),
-        signal: requestSignal(this.#timeoutMs, options?.signal),
-      });
-    } catch (error) {
-      return failed(
-        MODEL_FAILURE.NETWORK,
-        `embeddings request did not complete: ${error instanceof Error ? error.name : "unknown error"}`,
-      );
-    }
+    const response = await this.#client.send(
+      BRAIN_EMBEDDINGS_PATH,
+      HTTP_METHOD.POST,
+      JSON.stringify(brainEmbeddingsRequest(texts, { model: BRAIN_EMBEDDING_MODEL })),
+      options?.signal,
+    );
+    if (!(response instanceof Response)) return response;
     if (response.status === HTTP_STATUS.TOO_MANY_REQUESTS) {
-      return throttled(this.#now() + rateLimitWaitMs(response.headers.get(RETRY_AFTER_HEADER)));
+      return throttled(this.#client.quietUntil(response).until);
     }
     if (response.status === HTTP_STATUS.UNAUTHORIZED) {
       return failed(MODEL_FAILURE.CREDENTIAL, "the OpenAI key was refused");
@@ -164,25 +138,21 @@ export class OpenAiEmbeddingAdapter implements EmbeddingAdapter {
   }
 }
 
-export interface HostedEmbeddingAdapterOptions {
+export interface HostedEmbeddingAdapterOptions extends AccountToken {
   serviceBaseUrl: string;
-  readAccessToken: () => Promise<string | undefined>;
-  refreshAccount: () => Promise<void>;
   fetch?: CloudFetch;
   now?: () => number;
   requestTimeoutMs?: number;
 }
 
 export class HostedEmbeddingAdapter implements EmbeddingAdapter {
-  readonly #calls: HostedServiceCalls;
-  readonly #now: () => number;
+  readonly #client: HostedBrainTransport;
   #model: string | undefined;
   #dimensions: number | undefined;
   #offered: boolean | undefined;
 
   constructor(options: HostedEmbeddingAdapterOptions) {
-    this.#calls = new HostedServiceCalls(options);
-    this.#now = options.now ?? Date.now;
+    this.#client = new HostedBrainTransport({ ...options, baseUrl: options.serviceBaseUrl });
   }
 
   identity(): Promise<EmbeddingIdentity> {
@@ -196,7 +166,7 @@ export class HostedEmbeddingAdapter implements EmbeddingAdapter {
   /** Reads the capabilities once: a service that does not list the embed operation offers no embeddings. */
   async #offers(): Promise<EmbeddingBatch | undefined> {
     if (this.#offered === true) return undefined;
-    const capabilities = await this.#calls.capabilities();
+    const capabilities = await this.#client.capabilities();
     if ("outcome" in capabilities) return capabilities;
     if (!capabilities.operations.includes(HOSTED_BRAIN_OPERATION.EMBED)) {
       this.#offered = false;
@@ -221,17 +191,15 @@ export class HostedEmbeddingAdapter implements EmbeddingAdapter {
       texts,
     });
     if (!read.ok) return failed(MODEL_FAILURE.BOUNDS, `embed request refused: ${read.refusal}`);
-    const response = await this.#calls.request(
+    const response = await this.#client.send(
       HOSTED_SERVICE_PATH.BRAIN_EMBED,
       HTTP_METHOD.POST,
       JSON.stringify(read.request),
       options?.signal,
     );
-    if (!(response instanceof Response)) {
-      return response ?? failed(MODEL_FAILURE.NETWORK, "embed request did not complete");
-    }
+    if (!(response instanceof Response)) return response;
     if (response.status === HTTP_STATUS.TOO_MANY_REQUESTS) {
-      return throttled(this.#now() + rateLimitWaitMs(response.headers.get(RETRY_AFTER_HEADER)));
+      return throttled(this.#client.quietUntil(response).until);
     }
     if (response.status === HTTP_STATUS.UNAUTHORIZED) {
       return failed(MODEL_FAILURE.CREDENTIAL, "the account token was refused");

--- a/packages/brain/src/guarantees.test.ts
+++ b/packages/brain/src/guarantees.test.ts
@@ -483,10 +483,9 @@ test("an ask's reply is its final text, and announce is refused inside one", asy
  */
 test("a brain call is addressed to the developer's own key or to Luke's own service, and reports neither", async () => {
   const addressed: string[] = [];
-  const answer = () => Promise.resolve(Response.json({}));
   const fetch = (url: string) => {
     addressed.push(url);
-    return answer();
+    return Promise.resolve(Response.json({}));
   };
   const keyed = new KeyedBrainTransport({
     baseUrl: "https://api.openai.test/v1",

--- a/packages/brain/src/guarantees.test.ts
+++ b/packages/brain/src/guarantees.test.ts
@@ -5,6 +5,7 @@ import { RUN_ORIGIN } from "@sidecar/runtime/vocabulary";
 import { OMISSION_MARKER } from "@sidecar/session";
 import { ACT_RESULT_STATUS, isWireString, unparsedWire, wireRecord } from "@sidecar/wire";
 import { LOOK_SUBJECT } from "./agent.js";
+import { HostedBrainTransport, KeyedBrainTransport } from "./client.js";
 import {
   BRAIN_GENERATION_LIFETIME_MS,
   BRAIN_STATE_VERSION,
@@ -41,6 +42,7 @@ import {
   TRANSCRIPT_SECRET,
   UNKNOWN,
 } from "./harness.js";
+import { HTTP_METHOD } from "./model-adapter-shared.js";
 import { INBOX_CAPACITY } from "./observation-inbox.js";
 import {
   BRAIN_REQUEST_STATUS,
@@ -471,4 +473,48 @@ test("an ask's reply is its final text, and announce is refused inside one", asy
     h.traces.every((trace) => !trace.tools.includes(BRAIN_TOOL.ANNOUNCE)),
     "and it was never offered",
   );
+});
+
+/**
+ * "The brain's own turns are the first … on the developer's own key or
+ * through Luke's own service." — `client.ts`: a call is addressed to the one
+ * origin its transport was built with, and what a quiet reports names the
+ * transport and the wait alone.
+ */
+test("a brain call is addressed to the developer's own key or to Luke's own service, and reports neither", async () => {
+  const addressed: string[] = [];
+  const answer = () => Promise.resolve(Response.json({}));
+  const fetch = (url: string) => {
+    addressed.push(url);
+    return answer();
+  };
+  const keyed = new KeyedBrainTransport({
+    baseUrl: "https://api.openai.test/v1",
+    apiKey: "sk-secret",
+    fetch,
+    now: () => NOW,
+  });
+  const service = new HostedBrainTransport({
+    baseUrl: "https://luke.test",
+    readAccessToken: () => Promise.resolve("account-secret"),
+    refreshAccount: () => Promise.resolve(),
+    fetch,
+    now: () => NOW,
+  });
+  await keyed.send("/responses", HTTP_METHOD.POST, TRANSCRIPT_SECRET);
+  await service.send("/api/brain/v2/respond", HTTP_METHOD.POST, TRANSCRIPT_SECRET);
+  assert.deepEqual(addressed, [
+    "https://api.openai.test/v1/responses",
+    "https://luke.test/api/brain/v2/respond",
+  ]);
+
+  const throttle = new Response("", { status: 429 });
+  for (const reported of [
+    keyed.quietUntil(throttle).message,
+    service.quietUntil(throttle).message,
+  ]) {
+    assert.ok(!reported.includes("sk-secret"));
+    assert.ok(!reported.includes("account-secret"));
+    assert.ok(!reported.includes(TRANSCRIPT_SECRET));
+  }
 });

--- a/packages/brain/src/hosted-model-adapter.ts
+++ b/packages/brain/src/hosted-model-adapter.ts
@@ -1,6 +1,6 @@
 import {
+  type AccountToken,
   brainOutputReplayable,
-  HOSTED_API_ERROR,
   HOSTED_BRAIN_CONTRACT_VERSION,
   HOSTED_BRAIN_REQUEST_REFUSAL,
   HOSTED_SERVICE_PATH,
@@ -10,7 +10,6 @@ import {
   hostedBrainCountTokensAnswerFromWire,
   hostedBrainCountTokensRequestFromWire,
   hostedBrainRespondRequestFromWire,
-  hostedQuotaSchema,
   maximumHostedBrainRequestBytes,
   serializedRequestBytes,
 } from "@sidecar/hosted";
@@ -27,21 +26,17 @@ import {
   type CloudFetch,
   HTTP_STATUS,
   type UnparsedWireValue,
-  unparsedWire,
   type WireRecord,
-  wireRecord,
 } from "@sidecar/wire";
+import { HostedBrainTransport } from "./client.js";
 import { COMPACTION_POLICY } from "./compaction.js";
 import {
   type Failure,
   failed,
-  HostedServiceCalls,
   HTTP_METHOD,
   type Normalized,
   notServed,
   payloadOf,
-  RETRY_AFTER_HEADER,
-  rateLimitWaitMs,
 } from "./model-adapter-shared.js";
 import { responsesCompactedWindow, responsesModelAnswer } from "./responses-api.js";
 import {
@@ -54,11 +49,9 @@ import {
   type ResponsesTransport,
 } from "./responses-model-adapter.js";
 
-export interface HostedModelAdapterOptions {
+export interface HostedModelAdapterOptions extends AccountToken {
   /** The hosted service origin, without a trailing slash. */
   serviceBaseUrl: string;
-  readAccessToken: () => Promise<string | undefined>;
-  refreshAccount: () => Promise<void>;
   fetch?: CloudFetch;
   now?: () => number;
   requestTimeoutMs?: number;
@@ -81,13 +74,11 @@ const HOSTED_PATH = {
  */
 class HostedTransport implements ResponsesTransport<HostedBrainCapabilities> {
   readonly adapter = BUILTIN_MODEL_ADAPTER.HOSTED;
-  readonly #calls: HostedServiceCalls;
-  readonly #now: () => number;
+  readonly #client: HostedBrainTransport;
   #capabilities: HostedBrainCapabilities | undefined;
 
   constructor(options: HostedModelAdapterOptions) {
-    this.#calls = new HostedServiceCalls(options);
-    this.#now = options.now ?? Date.now;
+    this.#client = new HostedBrainTransport({ ...options, baseUrl: options.serviceBaseUrl });
   }
 
   /** The service's model, once capabilities have been read; the service's to know until then. */
@@ -192,46 +183,21 @@ class HostedTransport implements ResponsesTransport<HostedBrainCapabilities> {
     );
   }
 
-  async request(
+  request(
     operation: ResponsesOperation,
     body: string,
     signal: AbortSignal | undefined,
   ): Promise<Response | Normalized> {
-    const response = await this.#calls.request(
-      HOSTED_PATH[operation],
-      HTTP_METHOD.POST,
-      body,
-      signal,
-    );
-    if (!response) return failed(MODEL_FAILURE.NETWORK, "request did not complete");
-    return response;
+    return this.#client.send(HOSTED_PATH[operation], HTTP_METHOD.POST, body, signal);
   }
 
   /**
-   * Two quiets wear the same status. A spent allowance names the day's reset
-   * in its quota and stands the adapter down until then; the provider rate
-   * limiting behind the service names a bounded wait in `Retry-After`, or
-   * earns the same fixed cooldown the keyed adapter takes, so a hosted
-   * developer and a keyed one wait the same way for the same limit.
+   * Two quiets wear the same status, so the answer's own body is what tells
+   * a spent daily allowance from the provider rate limiting behind the
+   * service. Reading it is the transport's.
    */
   async quiet(response: Response): Promise<Quiet> {
-    const record = wireRecord(unparsedWire(await payloadOf(response)));
-    const quota =
-      record?.error === HOSTED_API_ERROR.QUOTA_EXHAUSTED
-        ? hostedQuotaSchema.parse(unparsedWire(record.quota))
-        : undefined;
-    const resetsAt = quota?.resetsAt;
-    if (resetsAt !== undefined && resetsAt > this.#now()) {
-      return {
-        until: resetsAt,
-        message: `Hosted brain turns are out of today's allowance; pausing for ${Math.round((resetsAt - this.#now()) / 1000)}s`,
-      };
-    }
-    const waitMs = rateLimitWaitMs(response.headers.get(RETRY_AFTER_HEADER));
-    return {
-      until: this.#now() + waitMs,
-      message: `Hosted brain turns are rate limited; pausing for ${Math.round(waitMs / 1000)}s`,
-    };
+    return this.#client.quietUntil(response, await payloadOf(response));
   }
 
   failureFor(response: Response, operation: ResponsesOperation): Failure {
@@ -252,7 +218,7 @@ class HostedTransport implements ResponsesTransport<HostedBrainCapabilities> {
 
   /** Reads the capabilities once per adapter; a service that has none, or names another contract, is incompatible. */
   async #discover(): Promise<HostedBrainCapabilities | Failure> {
-    const capabilities = await this.#calls.capabilities();
+    const capabilities = await this.#client.capabilities();
     if (!("outcome" in capabilities)) this.#capabilities = capabilities;
     return capabilities;
   }

--- a/packages/brain/src/model-adapter-shared.ts
+++ b/packages/brain/src/model-adapter-shared.ts
@@ -1,23 +1,10 @@
-import {
-  HOSTED_BRAIN_CONTRACT_VERSION,
-  HOSTED_BRAIN_OPTION_BOUNDS,
-  HOSTED_SERVICE_PATH,
-  type HostedBrainCapabilities,
-  hostedBrainCapabilitiesFromWire,
-} from "@sidecar/hosted";
+import { HOSTED_BRAIN_OPTION_BOUNDS } from "@sidecar/hosted";
 import {
   MODEL_FAILURE,
   MODEL_RESPONSE_OUTCOME,
   type ModelFailure,
 } from "@sidecar/runtime/vocabulary";
-import {
-  type CloudFetch,
-  HTTP_STATUS,
-  positiveInteger,
-  text,
-  type UnparsedWireValue,
-  withoutTrailingSlash,
-} from "@sidecar/wire";
+import { HTTP_STATUS, type UnparsedWireValue } from "@sidecar/wire";
 
 /** The output budget one inference is asked for, the same on every transport: the hosted contract's ceiling. */
 export const BRAIN_MAXIMUM_OUTPUT_TOKENS = HOSTED_BRAIN_OPTION_BOUNDS.MAXIMUM_OUTPUT_TOKENS;
@@ -60,15 +47,6 @@ export function rateLimitWaitMs(retryAfter: string | null): number {
   return Math.min(Math.round(seconds * 1000), BRAIN_RATE_LIMIT_RETRY_AFTER_BOUND_MS);
 }
 
-/** The per-request timeout, joined with the run's own cancellation when the inference belongs to one. */
-export function requestSignal(
-  timeoutMs: number,
-  cancellation: AbortSignal | undefined,
-): AbortSignal {
-  const timeout = AbortSignal.timeout(timeoutMs);
-  return cancellation ? AbortSignal.any([timeout, cancellation]) : timeout;
-}
-
 /** The body as JSON, or nothing when it is not; every reader validates what comes back as wire. */
 export async function payloadOf(response: Response): Promise<UnparsedWireValue | undefined> {
   try {
@@ -104,111 +82,4 @@ export function notServed(response: Response): boolean {
   return (
     response.status === HTTP_STATUS.NOT_FOUND || response.status === HTTP_STATUS.METHOD_NOT_ALLOWED
   );
-}
-
-export interface HostedServiceCallOptions {
-  serviceBaseUrl: string;
-  readAccessToken: () => Promise<string | undefined>;
-  refreshAccount: () => Promise<void>;
-  fetch?: CloudFetch;
-  requestTimeoutMs?: number;
-}
-
-/**
- * One call to Luke's hosted service under the account's token, shared by
- * every adapter that speaks to it: the request itself, the token refreshed
- * once when the first is refused — the routine expiry of an hour-lived token
- * inside a day-lived app, handled like the hosted mint handles it — and the
- * capabilities read that admits an operation. No token at all is a
- * credential failure before anything is sent.
- */
-export class HostedServiceCalls {
-  readonly #baseUrl: string;
-  readonly #readAccessToken: () => Promise<string | undefined>;
-  readonly #refreshAccount: () => Promise<void>;
-  readonly #fetch: CloudFetch;
-  readonly #requestTimeoutMs: number;
-
-  constructor(options: HostedServiceCallOptions) {
-    const baseUrl = text(options.serviceBaseUrl);
-    if (!baseUrl) throw new Error("Hosted service base URL must not be empty");
-    this.#baseUrl = withoutTrailingSlash(baseUrl);
-    this.#readAccessToken = options.readAccessToken;
-    this.#refreshAccount = options.refreshAccount;
-    this.#fetch = options.fetch ?? ((input, init) => fetch(input, init));
-    this.#requestTimeoutMs = positiveInteger(options.requestTimeoutMs, BRAIN_REQUEST_TIMEOUT_MS);
-  }
-
-  async send(
-    path: string,
-    method: HttpMethod,
-    token: string,
-    body?: string,
-    signal?: AbortSignal,
-  ): Promise<Response | undefined> {
-    try {
-      return await this.#fetch(`${this.#baseUrl}${path}`, {
-        method,
-        headers: {
-          authorization: `Bearer ${token}`,
-          ...(body !== undefined ? { "content-type": "application/json" } : undefined),
-        },
-        ...(body !== undefined ? { body } : undefined),
-        signal: requestSignal(this.#requestTimeoutMs, signal),
-      });
-    } catch {
-      return undefined;
-    }
-  }
-
-  async authorized(
-    call: (token: string) => Promise<Response | undefined>,
-  ): Promise<Response | Failure | undefined> {
-    const token = await this.#readAccessToken();
-    if (!token) return failed(MODEL_FAILURE.CREDENTIAL, "no account token");
-    const response = await call(token);
-    if (response?.status !== HTTP_STATUS.UNAUTHORIZED) return response;
-    await this.#refreshAccount().catch(() => undefined);
-    const refreshed = await this.#readAccessToken();
-    if (refreshed && refreshed !== token) return call(refreshed);
-    return response;
-  }
-
-  /** One authorized call to `path`, or the failure the transport earned; an unauthorized answer after the refresh stands as a response. */
-  request(
-    path: string,
-    method: HttpMethod,
-    body?: string,
-    signal?: AbortSignal,
-  ): Promise<Response | Failure | undefined> {
-    return this.authorized((token) => this.send(path, method, token, body, signal));
-  }
-
-  /** Reads the service's capabilities; a service that has none, or names another contract, is incompatible. */
-  async capabilities(): Promise<HostedBrainCapabilities | Failure> {
-    const response = await this.request(HOSTED_SERVICE_PATH.BRAIN_CAPABILITIES, HTTP_METHOD.GET);
-    if (!(response instanceof Response)) {
-      return response ?? failed(MODEL_FAILURE.NETWORK, "capabilities request did not complete");
-    }
-    if (notServed(response)) {
-      return failed(
-        MODEL_FAILURE.COMPATIBILITY,
-        `the hosted service does not offer brain contract ${HOSTED_BRAIN_CONTRACT_VERSION}`,
-      );
-    }
-    if (response.status === HTTP_STATUS.UNAUTHORIZED) {
-      return failed(MODEL_FAILURE.CREDENTIAL, "the account token was refused");
-    }
-    if (!response.ok) {
-      return failed(MODEL_FAILURE.UPSTREAM, `capabilities failed with status ${response.status}`);
-    }
-    const capabilities = hostedBrainCapabilitiesFromWire(await payloadOf(response));
-    if (!capabilities) {
-      return failed(
-        MODEL_FAILURE.COMPATIBILITY,
-        `the hosted service's capabilities are not brain contract ${HOSTED_BRAIN_CONTRACT_VERSION}`,
-      );
-    }
-    return capabilities;
-  }
 }

--- a/packages/brain/src/openai-model-adapter.ts
+++ b/packages/brain/src/openai-model-adapter.ts
@@ -6,23 +6,14 @@ import {
   REASONING_EFFORT,
   type ReasoningEffort,
 } from "@sidecar/runtime/vocabulary";
-import {
-  type CloudFetch,
-  HTTP_STATUS,
-  positiveInteger,
-  text,
-  type WireRecord,
-  withoutTrailingSlash,
-} from "@sidecar/wire";
+import { type CloudFetch, HTTP_STATUS, text, type WireRecord } from "@sidecar/wire";
+import { KeyedBrainTransport } from "./client.js";
 import { COMPACTION_POLICY } from "./compaction.js";
 import {
   BRAIN_MAXIMUM_OUTPUT_TOKENS,
   BRAIN_REQUEST_TIMEOUT_MS,
   failed,
-  RETRY_AFTER_HEADER,
-  rateLimitWaitMs,
-  requestFault,
-  requestSignal,
+  HTTP_METHOD,
 } from "./model-adapter-shared.js";
 import {
   BRAIN_RESPONSES_COMPACT_PATH,
@@ -93,26 +84,16 @@ const ADMITTED: Admission<undefined> = { admitted: undefined };
 class OpenAiTransport implements ResponsesTransport<undefined> {
   readonly adapter = BUILTIN_MODEL_ADAPTER.OPENAI;
   readonly #model: string;
-  readonly #apiKey: string;
-  readonly #baseUrl: string;
   readonly #reasoningEffort: ReasoningEffort;
-  readonly #fetch: CloudFetch;
-  readonly #now: () => number;
-  readonly #requestTimeoutMs: number;
+  readonly #client: KeyedBrainTransport;
 
   constructor(options: OpenAiModelAdapterOptions) {
-    const apiKey = text(options.apiKey);
-    if (!apiKey) throw new Error("OpenAI API key must not be empty");
-    this.#apiKey = apiKey;
     this.#model = text(options.model) ?? BRAIN_OPENAI_DEFAULTS.MODEL;
-    this.#baseUrl = withoutTrailingSlash(text(options.baseUrl) ?? BRAIN_OPENAI_DEFAULTS.BASE_URL);
     this.#reasoningEffort = options.reasoningEffort ?? BRAIN_OPENAI_DEFAULTS.REASONING_EFFORT;
-    this.#fetch = options.fetch ?? ((input, init) => fetch(input, init));
-    this.#now = options.now ?? Date.now;
-    this.#requestTimeoutMs = positiveInteger(
-      options.requestTimeoutMs,
-      BRAIN_OPENAI_DEFAULTS.REQUEST_TIMEOUT_MS,
-    );
+    this.#client = new KeyedBrainTransport({
+      ...options,
+      baseUrl: text(options.baseUrl) ?? BRAIN_OPENAI_DEFAULTS.BASE_URL,
+    });
   }
 
   model(): string {
@@ -184,28 +165,13 @@ class OpenAiTransport implements ResponsesTransport<undefined> {
     );
   }
 
-  async request(operation: ResponsesOperation, body: string, signal: AbortSignal | undefined) {
-    try {
-      return await this.#fetch(`${this.#baseUrl}${OPENAI_PATH[operation]}`, {
-        method: "POST",
-        headers: {
-          authorization: `Bearer ${this.#apiKey}`,
-          "content-type": "application/json",
-        },
-        body,
-        signal: requestSignal(this.#requestTimeoutMs, signal),
-      });
-    } catch (error) {
-      return requestFault(error instanceof Error ? error : undefined);
-    }
+  request(operation: ResponsesOperation, body: string, signal: AbortSignal | undefined) {
+    return this.#client.send(OPENAI_PATH[operation], HTTP_METHOD.POST, body, signal);
   }
 
+  /** Nothing stands between the key and the provider, so a 429 is the provider's own bounded wait. */
   quiet(response: Response): Promise<Quiet> {
-    const waitMs = rateLimitWaitMs(response.headers.get(RETRY_AFTER_HEADER));
-    return Promise.resolve({
-      until: this.#now() + waitMs,
-      message: `OpenAI brain turns are rate limited; pausing for ${Math.round(waitMs / 1000)}s`,
-    });
+    return Promise.resolve(this.#client.quietUntil(response));
   }
 
   /** Status alone diagnoses credentials or an outage, without writing the request, the key, or any session material to the log. */

--- a/packages/hosted/src/account-token.ts
+++ b/packages/hosted/src/account-token.ts
@@ -1,0 +1,19 @@
+/**
+ * Who a call to Luke's own service is on behalf of. Every client that speaks
+ * to the service on the signed-in account — the brain's transports, the voice
+ * mint, the key vault, the event sender — is handed the same pair rather than
+ * the account itself: the token is read fresh for every attempt, so a client
+ * holds none, and the account lifecycle stays the one thing that knows how a
+ * session is kept.
+ */
+export interface AccountToken {
+  /** The signed-in account's current access token, read fresh for every attempt. */
+  readAccessToken: () => Promise<string | undefined>;
+  /**
+   * Asks the account lifecycle to refresh its tokens. Access tokens outlive a
+   * call by an hour at most while the app runs for days, so a 401 is routine:
+   * the call retries once with whatever the refresh produced, and only a
+   * second refusal is reported.
+   */
+  refreshAccount: () => Promise<void>;
+}

--- a/packages/hosted/src/index.ts
+++ b/packages/hosted/src/index.ts
@@ -1,3 +1,4 @@
+export type { AccountToken } from "./account-token.js";
 export {
   type HostedActAnswer,
   type HostedActWorkspaceAnswer,

--- a/packages/hosted/src/vault-client.ts
+++ b/packages/hosted/src/vault-client.ts
@@ -7,6 +7,7 @@ import {
   unparsedWire,
   withoutTrailingSlash,
 } from "@sidecar/wire";
+import type { AccountToken } from "./account-token.js";
 import { HOSTED_SERVICE_PATH } from "./service-paths.js";
 import {
   type VaultKeyDeleteAnswer,
@@ -24,11 +25,9 @@ const VAULT_DEFAULTS = {
 
 const UNAUTHORIZED_STATUS = 401;
 
-export interface HostedVaultClientOptions {
+export interface HostedVaultClientOptions extends AccountToken {
   /** The hosted service origin, without a trailing slash. */
   serviceBaseUrl: string;
-  readAccessToken: () => Promise<string | undefined>;
-  refreshAccount: () => Promise<void>;
   /**
    * Who the bearer answers for, as an opaque identity. Read before an ask and
    * again before its one 401 retry, because the retry re-reads the token: a

--- a/packages/voice/src/index.ts
+++ b/packages/voice/src/index.ts
@@ -23,5 +23,4 @@ export {
   type IntroductionRealtimeCredentialOptions,
   introductionRealtimeCredentialMinter,
   type RealtimeCredentialMinter,
-  type ServiceMintAuthorization,
 } from "./service-mint.js";

--- a/packages/voice/src/service-mint.ts
+++ b/packages/voice/src/service-mint.ts
@@ -1,4 +1,5 @@
 import {
+  type AccountToken,
   HOSTED_SERVICE_PATH,
   type HostedQuota,
   hostedMintAnswerAt,
@@ -44,18 +45,6 @@ export interface RealtimeCredentialMinter {
   diagnostics(): RealtimeDiagnostics;
 }
 
-export interface ServiceMintAuthorization {
-  /** The signed-in account's current access token, read fresh for every attempt. */
-  readAccessToken: () => Promise<string | undefined>;
-  /**
-   * Asks the account lifecycle to refresh its tokens. Access tokens outlive a
-   * mint by an hour at most while the app runs for days, so a 401 here is
-   * routine — the mint retries once with whatever the refresh produced, and
-   * only a second refusal is reported.
-   */
-  refreshAccount: () => Promise<void>;
-}
-
 interface ServiceMintOptions {
   /** The hosted service origin, without a trailing slash. */
   serviceBaseUrl: string;
@@ -69,7 +58,7 @@ interface ServiceMintOptions {
    * The identity an attempt carries. An endpoint that takes none omits this,
    * and then neither the header nor the refresh-and-retry exists.
    */
-  authorization?: ServiceMintAuthorization;
+  authorization?: AccountToken;
   voice?: string;
   speed?: number;
   fetch?: CloudFetch;
@@ -89,7 +78,7 @@ class ServiceRealtimeCredentialMinter implements RealtimeCredentialMinter {
   readonly #endpoint: string;
   readonly #logLabel: string;
   readonly #malformedDetail: string;
-  readonly #authorization: ServiceMintAuthorization | undefined;
+  readonly #authorization: AccountToken | undefined;
   /** The voice from construction, which a cleared setting falls back to. */
   readonly #configuredVoice: string | undefined;
   #voice: string | undefined;
@@ -274,7 +263,7 @@ type RealtimeCredentialOptions = Omit<
   "servicePath" | "logLabel" | "malformedDetail" | "authorization"
 >;
 
-export type HostedRealtimeCredentialOptions = RealtimeCredentialOptions & ServiceMintAuthorization;
+export type HostedRealtimeCredentialOptions = RealtimeCredentialOptions & AccountToken;
 
 /**
  * The signed-in account's voice mint, for a developer who has not connected


### PR DESCRIPTION
## What

Two model clients over the same `ResponsesTransport` seam duplicated the HTTP half of a call out of the brain: base-URL trimming, the bearer header, the per-request timeout joined with the run's own cancellation, a fetch that throws read as a failure by kind, 401/404/405 classification, and the `Retry-After` reading. `HostedServiceCalls` was a third copy of that half and `OpenAiEmbeddingAdapter`'s inline fetch a hand-rolled fourth.

`packages/brain/src/client.ts` is now the one place:

- **`BrainTransport`** (abstract, ~130 lines) owns the request, the trimmed base URL, the joined signal, the network fault named by the error's kind alone, the one 401 retry, and the **one `quietUntil`** — the bounded `Retry-After` wait every transport takes, or the later reset a spent daily allowance names, worded over one `label`.
- **`KeyedBrainTransport`** supplies the developer's own key: one header, one attempt, nothing to refresh.
- **`HostedBrainTransport`** supplies the signed-in account's token, read fresh per attempt and refreshed once when the first is refused, plus the capabilities read that admits an operation.

Both model transports (`HostedTransport`, `OpenAiTransport`) and both embedding adapters compose it. `HostedServiceCalls`, `HostedServiceCallOptions`, and `requestSignal` are gone from `model-adapter-shared.ts`, which is now 85 lines of shared vocabulary and nothing else.

`{readAccessToken, refreshAccount}`, written out verbatim in six option interfaces, is one named type: **`AccountToken`** in `@sidecar/hosted` (`account-token.ts`, exported from the barrel), adopted by the brain's hosted model and embedding adapters, `HostedVaultClientOptions`, `ProductEventSenderOptions`, and voice's mint (`ServiceMintAuthorization` deleted, including its barrel line — nothing imported it). It lives in `hosted` because `brain`, `voice`, and `analytics` already depend on that package and none depends on `account`; `credentials`' Linear tracker holds only `readAccessToken` and is untouched.

No behaviour changes. Every rendered string is byte-identical (`"Hosted brain turns are rate limited; pausing for 60s"`, `"OpenAI brain turns are rate limited; pausing for 60s"`) except that a fetch that threw now names the error's kind on the hosted path too (`request did not complete: TypeError`), the same shape the keyed path already reported and the same `MODEL_FAILURE.NETWORK` kind either way.

## Trust constraints

No `CLAUDE.md` sentence changes; this is not a ⚠ PR. The one rule the new file is the enforcer of gains a guarantee case:

> "The brain's own turns are the first … on the developer's own key or through Luke's own service."

`guarantees.test.ts` now asserts a brain call is addressed to the one origin its transport was built with and nothing else, and that neither transport writes a key, a token, or a transcript's text into anything it reports. Its home is `client.ts`.

`PRIVACY.md` is untouched: neither what leaves nor where it goes changed.

## Tests

- `client.test.ts` (~190 lines, 7 tests) covers the base directly: the trimmed origin and the one bearer header, a read that sends no body and no content type, the cancellation joined with the timeout, a fetch that throws naming no words of its own, the keyed transport's single attempt, no account token at all as a credential failure, the hosted refresh-and-retry (and a refresh that changed nothing letting the refusal stand), `quietUntil` across quota / `Retry-After` / bound / cooldown on both transports, and the capabilities read's four refusals by kind.
- `guarantees.test.ts` +1 case (15 → 16).
- The adapter suites are unchanged and still pass, so the composition is covered end to end as well as the base in isolation. The spec's move of two `acceptance.test.ts` cases into `client.test.ts` is not done here: those two are whole-host acceptance tests over the agent harness, and the other three of that same set (F1 commit 5) have not moved either, so `acceptance.test.ts` still carries the scaffolding they share. Moving them belongs with that set, not inside a transport unit test.

## Verification

`./scripts/check.sh` — green (exit 0, `fail 0` across every package). Not a UI PR: no `verify.sh`, no fixture PNG, no notch check.

Greps: `git grep -n "HostedServiceCalls\|ServiceMintAuthorization"` empty; `requestSignal` only in `client.ts`.

## Size

`git diff --shortstat origin/main...` → `13 files changed, 568 insertions(+), 301 deletions(-)`

Running total: ~200k baseline → the repo's non-test line count is unchanged in net terms here (−216 production lines, +267 test lines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/136e9a64-78dd-40d6-8b5d-4035362270b2)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34345176589/artifacts/10101476286) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34345176589)

- Commit: `480e9ee0fa78eaa450d8fe6684118c4b8eb02d97`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
