### PR TITLE
docs: delete orphaned and narrating comments in packages

### DIFF
--- a/apps/desktop/src/main/window/voice-window.ts
+++ b/apps/desktop/src/main/window/voice-window.ts
@@ -4,12 +4,6 @@ import { hardenedWebPreferences, refuseForeignNavigation } from "./hardened-wind
 
 export interface VoiceWindowOptions {
   runMode: RunMode;
-  /**
-   * Whether the renderer inside can receive anything yet, owned by the main
-   * process: every load begins an epoch unready here, and every reload,
-   * crash, replacement, or close ends it, so nothing is sent to a renderer on
-   * the strength of its window existing.
-   */
   /** Where the renderer's epochs begin and end: the host's receiver, reached through the client. */
   receiver: { begin: () => void; reset: () => void };
   preloadPath: string;

--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -503,12 +503,6 @@ export function App(): React.JSX.Element {
    */
   const answeredSettings = useRef<AppSettingsView | undefined>(undefined);
   /**
-   * The one way settings are drawn. Every path travels it — a row's own press,
-   * a key stored or removed, another window's push, and an errand's hold
-   * coming down — so the snapshot the next spoken change composes against is
-   * never older than the panel it is drawn on.
-   */
-  /**
    * What this run was told about recording, kept so a settings change can
    * re-decide without asking for another bootstrap. Absent until bootstrap
    * answers, which is also the whole window in which nothing can record.
@@ -534,6 +528,12 @@ export function App(): React.JSX.Element {
     },
   );
 
+  /**
+   * The one way settings are drawn. Every path travels it — a row's own press,
+   * a key stored or removed, another window's push, and an errand's hold
+   * coming down — so the snapshot the next spoken change composes against is
+   * never older than the panel it is drawn on.
+   */
   const applySettingsView = useCallback(
     (next: AppSettingsView) => {
       answeredSettings.current = next;

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -154,9 +154,8 @@ vocabulary is missing a name.
 
 ## The keys Luke takes from the machine
 
-Luke's three keys are registered with the system rather than with a window, so
-each one takes its chord away from every other app on the Mac. That is the
-whole reason the chords are argued about here instead of chosen in
+A key Luke registers takes its chord away from every other app on the Mac, so
+which chord is a product decision and is argued about here rather than in
 `voice-hotkey.ts`.
 
 - **Option-Space talks.** It is where a macOS user already reaches for a voice
@@ -171,10 +170,8 @@ whole reason the chords are argued about here instead of chosen in
   most editors, and which a global registration would swallow machine-wide.
   Option-L costs the system only the ¬ character.
 
-Two keys must never be able to land on one chord: whichever registered first
-would silently cost the other its whole feature, with nothing on screen saying
-why. `hotkeyCandidates` is where that is enforced, and it is why the talk key
-carries no fallback chord of its own.
+No two of them may be able to land on one chord. `hotkeyCandidates` is where
+that is enforced, and says why.
 
 ## Copy: delete what describes, keep what instructs
 

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -3,9 +3,10 @@
 This is the contract every animated element in the panel obeys, and the bar
 every word drawn on it has to clear. The "Panel motion" section of AGENTS.md
 says what the window and the surface are; this file says how anything drawn on
-them is allowed to move, and how much it is allowed to say. A change that adds
-or alters motion or copy is reviewed against these rules, and the fastest way
-to pass that review is to build from them.
+them is allowed to move, how much it is allowed to say, and which of the
+machine's keys Luke may take. A change that adds or alters motion or copy is
+reviewed against these rules, and the fastest way to pass that review is to
+build from them.
 
 ## The vocabulary
 
@@ -150,6 +151,30 @@ Compact geometry uses local optical spacing where one-off alignment demands
 it. Repeated structural widths, heights, gaps, radii, colors, and motion belong
 to semantic or generated tokens; a repeated literal is evidence that the
 vocabulary is missing a name.
+
+## The keys Luke takes from the machine
+
+Luke's three keys are registered with the system rather than with a window, so
+each one takes its chord away from every other app on the Mac. That is the
+whole reason the chords are argued about here instead of chosen in
+`voice-hotkey.ts`.
+
+- **Option-Space talks.** It is where a macOS user already reaches for a voice
+  assistant: Superwhisper, the ChatGPT desktop app, and Alfred all sit there.
+- **Option-S stops.** S is for stop, and Option-letter is the family the other
+  two keys live in. It is a sibling of Escape rather than of the talk key: it
+  asks for quiet and nothing in its place, where the talk key over a reply
+  interrupts by taking the turn.
+- **Option-L asks.** Hold Option-Space to speak to Luke, tap Option-L to type
+  to him — one modifier for both halves of the same conversation. Deliberately
+  not Command-L, which is the address bar in every browser and a taken chord in
+  most editors, and which a global registration would swallow machine-wide.
+  Option-L costs the system only the ¬ character.
+
+Two keys must never be able to land on one chord: whichever registered first
+would silently cost the other its whole feature, with nothing on screen saying
+why. `hotkeyCandidates` is where that is enforced, and it is why the talk key
+carries no fallback chord of its own.
 
 ## Copy: delete what describes, keep what instructs
 

--- a/packages/analytics/src/product-events.ts
+++ b/packages/analytics/src/product-events.ts
@@ -389,7 +389,6 @@ export function productSessionCountBucket(count: number): ProductSessionCountBuc
   );
 }
 
-/** What each property's value is, once it has been read. */
 interface ProductEventPropertyValue {
   [PRODUCT_EVENT_PROPERTY.APP_VERSION]: string;
   [PRODUCT_EVENT_PROPERTY.CONNECTION_ID]: CredentialProviderId;

--- a/packages/brain/src/requests-wire.ts
+++ b/packages/brain/src/requests-wire.ts
@@ -146,7 +146,6 @@ export function isBrainAskWait(value: UnparsedWireValue): boolean {
   );
 }
 
-/** The main process's answer to a claim: the words to say, once, or nothing. */
 /**
  * The main process's answer to a claim: the words to say, once, with the
  * origin of the ask they answer — a typed ask's reply holds the composer's

--- a/packages/brain/src/standing-context.ts
+++ b/packages/brain/src/standing-context.ts
@@ -29,13 +29,6 @@ import {
  */
 export const maximumVoiceContextSessions = 25;
 
-/**
- * What one session can be asked to do, said in the roster so Luke offers only
- * what its provider promised: the identity a tool call must name, whether it
- * takes a message, each advertised control with the id a call names it by,
- * and each app whose exact address an open ask may pick — by name alone,
- * because the address behind it stays on the machine.
- */
 interface SessionRecency {
   readonly mostRecentForProvider: boolean;
   readonly mostRecentOpenableForProvider: boolean;

--- a/packages/brain/src/standing-context.ts
+++ b/packages/brain/src/standing-context.ts
@@ -41,6 +41,13 @@ function sessionCanOpen(session: Session): boolean {
   );
 }
 
+/**
+ * What one session can be asked to do, so Luke offers only what its provider
+ * promised: the identity a tool call must name, whether it takes a message,
+ * each advertised control with the id a call names it by, and each app an
+ * open ask may pick — by name alone, because the address behind it stays on
+ * the machine.
+ */
 function sessionCapabilityText(session: Session, recency: SessionRecency): string {
   const openableApplications = session.applications.filter(
     (application) => application.link !== undefined,

--- a/packages/brain/src/store/transcript-table.ts
+++ b/packages/brain/src/store/transcript-table.ts
@@ -102,7 +102,6 @@ function transcriptPayload(
 }
 
 export interface TranscriptListOptions {
-  /** Only events after this sequence. */
   afterSequence?: number;
   limit?: number;
 }

--- a/packages/brain/src/trace.ts
+++ b/packages/brain/src/trace.ts
@@ -22,7 +22,6 @@ export interface BrainTurnTraceRecord {
   runtime: string;
   /** The tools the effective policy offered, by name. */
   tools: readonly string[];
-  /** How long the prepared prompt was, in characters. */
   promptChars: number;
   inputTokens?: number;
   transcriptBytes: number;

--- a/packages/credentials/src/credential-providers.ts
+++ b/packages/credentials/src/credential-providers.ts
@@ -151,19 +151,9 @@ export const CREDENTIAL_PROVIDERS: CredentialProviderRegistry = {
   [CREDENTIAL_PROVIDER_ID.OPENAI]: {
     id: CREDENTIAL_PROVIDER_ID.OPENAI,
     connection: CREDENTIAL_CONNECTION.KEY,
-    // The service, plainly. The row stands inside the section that already
-    // says what it is for — the other way voice can run — so the name has no
-    // acronym to carry: "BYOK" named the choice for anyone who already knew
-    // the word, and named nothing for everyone else.
     displayName: "OpenAI",
-    // No description, alone among the providers, because its section says
-    // everything one could: the toggle above the row names both sources and
-    // what each costs, and the disclosure below it says what the key is spent
-    // on and who bills for it. A sentence between them could only repeat one
-    // of the two.
-    // Realtime is what a spoken turn runs on, and an account that cannot reach
-    // it fails at the first word rather than at the paste — so the line says so
-    // before the key is entered rather than after.
+    // No description, alone among the providers: the toggle above the row and
+    // the disclosure below it already say everything a sentence could.
     hint: {
       lead: "Create a key on the OpenAI platform under",
       destination: "API keys",
@@ -192,15 +182,13 @@ export const CREDENTIAL_PROVIDER_LIST: readonly CredentialProvider[] =
 const INTEGRATION_IDS: ReadonlySet<CredentialProviderId> = new Set([CREDENTIAL_PROVIDER_ID.LINEAR]);
 
 /**
- * The one key Luke speaks through, and asks about a session with. Named here so
- * the main process reads it by what it is for rather than by an id spelled out
- * at each of the places that build something from it. Its row lives on the
- * Voice page rather than under Connections, because the key is what turns
- * voice on and the page that goes quiet without one is where that is learned.
+ * The one key Luke speaks through, and asks about a session with. Its row
+ * lives on the Voice page rather than under Connections, because the key is
+ * what turns voice on and the page that goes quiet without one is where that
+ * is learned.
  */
 export const VOICE_CREDENTIAL_PROVIDER_ID = CREDENTIAL_PROVIDER_ID.OPENAI;
 
-/** The one provider the Voice page holds a key for. */
 export const VOICE_CREDENTIAL_PROVIDER: CredentialProvider =
   CREDENTIAL_PROVIDERS[VOICE_CREDENTIAL_PROVIDER_ID];
 

--- a/packages/host/src/brain/conversation-deletion.ts
+++ b/packages/host/src/brain/conversation-deletion.ts
@@ -1,31 +1,5 @@
 import type { HistoryErasure } from "../store-wiring.js";
 
-/**
- * Delete history, in the order that makes a late arrival harmless and the
- * erasure recoverable. The fences come first and are synchronous: the relayed
- * thread is emptied and every window told, and the brain's generation is
- * fenced in the same breath — the store forgets it and announces the empty
- * successor before waiting on anything, so every run and every turn of the
- * old lifetime loses its execution at once and a late model answer, act
- * result, or checkpoint of it lands nowhere. The successor's marker is then
- * written over the old content, and only once it is durable does the store
- * remove what stood at or before the press: the lines and transcript of that
- * instant and earlier, in one transaction with the compressed recovery
- * archive and the raised cutoff, while a line accepted after the press stays
- * and the successor lifetime stands. Nothing is retired or reopened: the same
- * brain works on from the empty successor, and a credential rebuild landing
- * meanwhile builds over the same store, whose standing generation is that
- * successor.
- *
- * The answer is honest about each seam: complete only when the archive file
- * is published and verified; incomplete when the rows are gone and the
- * archive committed but not yet on disk, which the next launch retries; and
- * refused when the marker could not be written or the store did not take the
- * deletion — the fences stand either way, the old content is out of every
- * context and every window, and the next write that lands replaces what the
- * disk kept, so the developer sees an emptied History and is told the
- * erasure did not finish, never that it did.
- */
 /** The durable cutoff as read, which may itself be absent when no deletion ever raised one. */
 export interface CutoffBefore {
   value: number | undefined;
@@ -81,6 +55,23 @@ export const CONVERSATION_DELETION_INCOMPLETE = {
   ARCHIVE: "the recovery archive is committed but not yet published; the next launch retries",
 } as const;
 
+/**
+ * Delete history, in the order that makes a late arrival harmless and the
+ * erasure recoverable. The fences come first and are synchronous: the relayed
+ * thread is emptied and every window told, and the brain's generation is
+ * fenced in the same breath — the store forgets it and announces the empty
+ * successor before waiting on anything, so every run and every turn of the
+ * old lifetime loses its execution at once and a late model answer, act
+ * result, or checkpoint of it lands nowhere. The successor's marker is then
+ * written over the old content, and only once it is durable does the store
+ * remove what stood at or before the press: the lines and transcript of that
+ * instant and earlier, in one transaction with the compressed recovery
+ * archive and the raised cutoff, while a line accepted after the press stays
+ * and the successor lifetime stands. Nothing is retired or reopened: the same
+ * brain works on from the empty successor, and a credential rebuild landing
+ * meanwhile builds over the same store, whose standing generation is that
+ * successor.
+ */
 export async function deleteConversationHistoryFlow(
   dependencies: ConversationDeletionDependencies,
 ): Promise<ConversationDeleteOutcome> {

--- a/packages/host/src/store-wiring.ts
+++ b/packages/host/src/store-wiring.ts
@@ -83,7 +83,6 @@ export interface StoreWiring {
   thread: (sessionKey?: SessionKey) => ConversationThread;
   /** A conversation's envelope, for the brain wiring to build its writer on: the store's, or memory alone where nothing is kept on disk. */
   brainStateRepository: (sessionKey?: SessionKey) => BrainStateRepository;
-  /** Opens the database for this launch. */
   open: () => Promise<void>;
   /** Restores every stored conversation's thread, its cutoff, and the notebook's entries, once opened. */
   restore: () => Promise<void>;

--- a/packages/memory/src/contracts.ts
+++ b/packages/memory/src/contracts.ts
@@ -62,7 +62,6 @@ export interface MemorySearchAnswer {
   readonly note?: string;
 }
 
-/** A source file as the index recorded it last. */
 export interface IndexedSourceRecord {
   readonly path: string;
   readonly source: MemorySource;
@@ -117,13 +116,11 @@ export interface VectorHit {
   readonly provenance: MemoryProvenance;
 }
 
-/** One chunk's vector as a sync hands it to the store. */
 export interface EmbeddingWrite {
   readonly hash: string;
   readonly vector: readonly number[];
 }
 
-/** What the store plans for one sync: the files to write, the paths to drop, and the chunk texts still without a vector. */
 export interface MemoryScanPlan {
   readonly changed: readonly IndexedFileWrite[];
   readonly removed: readonly string[];
@@ -163,13 +160,11 @@ export interface MemorySearchOutcome {
   readonly vectorHits: number;
 }
 
-/** A retained History line that carries a search's words, with the conversation it was said in. */
 export interface ConversationLineHit {
   readonly sessionKey: SessionKey;
   readonly entry: ConversationEntry;
 }
 
-/** What a read of one file's lines answers with. */
 export interface MemoryReadResult {
   readonly path: string;
   readonly text: string;

--- a/packages/panel/src/provider-marks.tsx
+++ b/packages/panel/src/provider-marks.tsx
@@ -1,3 +1,44 @@
+/**
+ * The provider marks, and the one badge that rides them. Path data is
+ * generated into `@sidecar/surface` from `design/generate-surface-shared.mjs`
+ * so the marketing mock cannot ship a different geometry; the React that
+ * traces it stays here, because the desktop ships marks the mock does not.
+ * Marks are inlined as path data rather than bundled image files, so the
+ * renderer stays asset-free and they scale with the surface.
+ *
+ * Each is the provider's own mark, reproduced rather than redrawn — Claude Code
+ * via Simple Icons (CC0-1.0, sourced from code.claude.com), the Claude app's
+ * own mark via Simple Icons (CC0-1.0, sourced from claude.ai), Codex via
+ * @lobehub/icons (MIT), Conductor's letter mark verbatim from the published
+ * brand kit at https://www.conductor.build/brandkit, Copilot via Simple Icons
+ * (MIT, sourced from https://primer.style/foundations/icons/copilot-24),
+ * Cursor via Simple Icons (CC0-1.0, sourced from https://cursor.com/brand),
+ * Gemini's aurora sparkle verbatim from the vector the
+ * Gemini web app inlines at gemini.google.com (trademark of Google LLC),
+ * keeping the masked, blurred colour field it is published with,
+ * Google Calendar via Simple Icons (CC0-1.0, sourced from
+ * https://developers.google.com/calendar), Grok Build's comet mark verbatim
+ * from the favicon https://grok.com serves (a trademark of xAI),
+ * OpenAI via Simple Icons (CC0-1.0), Linear via Simple Icons (CC0-1.0, sourced from
+ * https://linear.app), OpenCode's two-tone terminal mark verbatim from
+ * the favicon https://opencode.ai serves, OMP's pi verbatim from the favicon
+ * https://omp.sh serves, and Superset's bracket mark traced
+ * from the pixel grid of the favicon https://superset.sh serves — the one
+ * square mark Superset publishes — keeping the vertical metallic gradient the
+ * favicon draws it with. Each keeps its own brand colour
+ * (see the `--mark-*` custom properties), so a mark says which provider a
+ * session belongs to while the chips and row tints say what state it is in.
+ * Copilot, Cursor, and Grok Build each publish one
+ * silhouette rather than a colour, so all three are drawn in the light form
+ * their brand uses on a dark surface. They are trademarks of their respective owners. Do not restyle the
+ * geometry or recolour them; swap the path in the generator if a provider
+ * publishes an updated mark. Apple Calendar is the one exception to
+ * "reproduced rather than redrawn": Apple distributes the Calendar icon only
+ * as raster app artwork, so its flat anatomy — tile, red weekday line, and
+ * the marketing icon's 17 — is drawn in the generator instead (a trademark
+ * of Apple Inc.).
+ */
+
 import { APPLE_CALENDAR_ID, GOOGLE_CALENDAR_ID } from "@sidecar/calendar/vocabulary";
 import { CREDENTIAL_PROVIDER_ID } from "@sidecar/credentials/vocabulary";
 import {
@@ -38,49 +79,6 @@ import React, { useId } from "react";
 // `tsx` executes imported workspace-package JSX with the classic runtime.
 void React;
 
-/**
- * The provider marks, and the one badge that rides them.
- *
- * Path data is generated into `@sidecar/surface` from
- * `design/generate-surface-shared.mjs` so the marketing mock cannot ship a
- * different geometry. The React that traces it stays here: the desktop ships
- * marks the mock does not.
- *
- * Provider marks are inlined as path data rather than bundled image files, so
- * the renderer stays asset-free and the marks scale with the surface.
- *
- * Each is the provider's own mark, reproduced rather than redrawn — Claude Code
- * via Simple Icons (CC0-1.0, sourced from code.claude.com), the Claude app's
- * own mark via Simple Icons (CC0-1.0, sourced from claude.ai), Codex via
- * @lobehub/icons (MIT), Conductor's letter mark verbatim from the published
- * brand kit at https://www.conductor.build/brandkit, Copilot via Simple Icons
- * (MIT, sourced from https://primer.style/foundations/icons/copilot-24),
- * Cursor via Simple Icons (CC0-1.0, sourced from https://cursor.com/brand),
- * Gemini's aurora sparkle verbatim from the vector the
- * Gemini web app inlines at gemini.google.com (trademark of Google LLC),
- * keeping the masked, blurred colour field it is published with,
- * Google Calendar via Simple Icons (CC0-1.0, sourced from
- * https://developers.google.com/calendar), Grok Build's comet mark verbatim
- * from the favicon https://grok.com serves (a trademark of xAI),
- * OpenAI via Simple Icons (CC0-1.0), Linear via Simple Icons (CC0-1.0, sourced from
- * https://linear.app), OpenCode's two-tone terminal mark verbatim from
- * the favicon https://opencode.ai serves, OMP's pi verbatim from the favicon
- * https://omp.sh serves, and Superset's bracket mark traced
- * from the pixel grid of the favicon https://superset.sh serves — the one
- * square mark Superset publishes — keeping the vertical metallic gradient the
- * favicon draws it with. Each keeps its own brand colour
- * (see the `--mark-*` custom properties), so a mark says which provider a
- * session belongs to while the chips and row tints say what state it is in.
- * Copilot, Cursor, and Grok Build each publish one
- * silhouette rather than a colour, so all three are drawn in the light form
- * their brand uses on a dark surface. They are trademarks of their respective owners. Do not restyle the
- * geometry or recolour them; swap the path in the generator if a provider
- * publishes an updated mark. Apple Calendar is the one exception to
- * "reproduced rather than redrawn": Apple distributes the Calendar icon only
- * as raster app artwork, so its flat anatomy — tile, red weekday line, and
- * the marketing icon's 17 — is drawn in the generator instead (a trademark
- * of Apple Inc.).
- */
 interface MarkProps {
   className?: string;
 }

--- a/packages/providers/src/codex/observe.ts
+++ b/packages/providers/src/codex/observe.ts
@@ -274,6 +274,12 @@ async function readCodexSessionTitles(codexHome: string): Promise<Map<string, st
   return titles;
 }
 
+/**
+ * Codex keeps the initial user message in the thread row even after it gives
+ * the chat a user-facing name. That makes it a more durable signal than the
+ * provisional title, while the title fallback covers older rows that do not
+ * carry the column's value.
+ */
 function isCodexRealtimeDelegationThread(row: CodexThreadRow): boolean {
   return (
     isCodexRealtimeDelegationText(textFromRow(row, CODEX_THREAD_COLUMN.FIRST_USER_MESSAGE)) ||

--- a/packages/providers/src/codex/records.ts
+++ b/packages/providers/src/codex/records.ts
@@ -109,12 +109,6 @@ export function argumentPhrase(value: UnparsedWireValue): string | undefined {
   return tokens.every((token) => token !== undefined) ? text(tokens.join(" ")) : undefined;
 }
 
-/**
- * Codex keeps the initial user message in the thread row even after it gives
- * the chat a user-facing name. That makes it a more durable signal than the
- * provisional title, while the title fallback covers older rows that do not
- * carry the column's value.
- */
 export function isCodexRealtimeDelegationText(value: string | undefined): boolean {
   return text(value)?.trimStart().startsWith(CODEX_REALTIME_DELEGATION_MARKER) === true;
 }

--- a/packages/providers/src/local-peek.ts
+++ b/packages/providers/src/local-peek.ts
@@ -1,23 +1,14 @@
 import { normalizeSession, type Session, type SessionProviderPlugin } from "@sidecar/session";
 import { type LocalSessionAdapterHomes, localSessionAdapters } from "./local-adapters.js";
 
-/**
- * Where each local observer reads, overridable so a test can pin every
- * location to synthetic fixtures. Only read locations can be injected —
- * nothing hook-bearing, credential-bearing, or otherwise able to write —
- * so the peek stays read-only no matter what a caller hands it.
- */
 export type LocalPeekOptions = LocalSessionAdapterHomes;
 
-/** What the peek asks of an observer, whatever shape that observer has. */
 type LocalPeekObserver = Pick<SessionProviderPlugin, "provider" | "observe">;
 
 /**
  * The on-disk observers from the same table `providerRegistrations` builds
  * from, minus everything account-shaped: no hook spool to read or register,
- * no key, and no cloud half beside a local one. Each absent
- * `hookEventsDirectory` makes its observer read the provider's own recordings
- * alone, which is what they did before hooks existed.
+ * no key, and no cloud half beside a local one.
  */
 function localPeekObservers(options: LocalPeekOptions): readonly LocalPeekObserver[] {
   return Object.values(localSessionAdapters(options));

--- a/packages/providers/src/shared/cli-pass.ts
+++ b/packages/providers/src/shared/cli-pass.ts
@@ -36,12 +36,6 @@ export const CLI_ADAPTER_DEFAULTS = {
   MAXIMUM_OUTPUT_BYTES: 4 * 1024 * 1024,
 } as const;
 
-/**
- * Where provider CLIs actually land on a Mac. An app launched from the Finder
- * inherits a PATH without the package-manager directories a terminal adds, so
- * these are appended after the inherited PATH — never ahead of it, so a binary
- * the user's own shell would resolve still wins.
- */
 export interface CliRunResult {
   exitCode: number;
   stdout: string;

--- a/packages/providers/src/shared/hook-merge.ts
+++ b/packages/providers/src/shared/hook-merge.ts
@@ -238,15 +238,6 @@ function withoutLukeHooks(entry: WireRecord, scriptName: string): WireRecord | u
   return { ...entry, hooks: kept };
 }
 
-/**
- * Strips Luke's entries from every event in place — including events this
- * build no longer registers, so an entry from an older build is cleaned up by
- * the newer one rather than left behind. Anything that is not the nested
- * shape the provider documents is preserved verbatim: a malformed entry is
- * the user's problem to notice, never ours to discard. Answers whether
- * anything of Luke's was actually there, so removal can decline to rewrite a
- * file it only ever read — a formatting difference must not read as a change.
- */
 /** A JSON object this module may rewrite while merging hook entries. */
 type MutableWireRecord = { [key: string]: WireValue };
 
@@ -259,6 +250,15 @@ function mutableHooks(root: MutableWireRecord): MutableWireRecord {
   return hooks ? { ...hooks } : createMutableWireRecord();
 }
 
+/**
+ * Strips Luke's entries from every event in place — including events this
+ * build no longer registers, so an entry from an older build is cleaned up by
+ * the newer one rather than left behind. Anything that is not the nested
+ * shape the provider documents is preserved verbatim: a malformed entry is
+ * the user's problem to notice, never ours to discard. Answers whether
+ * anything of Luke's was actually there, so removal can decline to rewrite a
+ * file it only ever read — a formatting difference must not read as a change.
+ */
 function stripLukeEntries(events: MutableWireRecord, scriptName: string): boolean {
   let stripped = false;
   for (const [eventName, entries] of Object.entries(events)) {

--- a/packages/realtime/src/realtime-credentials.ts
+++ b/packages/realtime/src/realtime-credentials.ts
@@ -152,7 +152,6 @@ export function realtimeCredentialFromResponse(
   };
 }
 
-/** Reports whether a credential is still usable at a given moment. */
 /**
  * Why the last attempt to mint a Realtime credential ended the way it did.
  *

--- a/packages/runtime/src/children.ts
+++ b/packages/runtime/src/children.ts
@@ -285,7 +285,6 @@ export class ChildRunService {
     return this.#children.get(childId);
   }
 
-  /** The children one conversation asked for. */
   childrenOf(requesterSessionKey: SessionKey): readonly ChildRunRecord[] {
     return this.children().filter((record) => record.requesterSessionKey === requesterSessionKey);
   }

--- a/packages/runtime/src/execution.ts
+++ b/packages/runtime/src/execution.ts
@@ -553,12 +553,6 @@ export interface RuntimeIdentity {
   readonly model?: string;
 }
 
-/**
- * Turns a request into normalized events over a model adapter, a context
- * engine, and a tool executor. It owns the loop between the model and the
- * tools and nothing outside it: no scheduling, no persistence, no policy
- * about what a tool may do.
- */
 /** That a compaction happened, by which way and folding how much, or why it did not. */
 export type RuntimeCompaction =
   | { readonly compacted: true; readonly source: CompactionSource; readonly dropped: number }
@@ -570,6 +564,12 @@ export interface CompactionOptions {
   readonly signal: AbortSignal;
 }
 
+/**
+ * Turns a request into normalized events over a model adapter, a context
+ * engine, and a tool executor. It owns the loop between the model and the
+ * tools and nothing outside it: no scheduling, no persistence, no policy
+ * about what a tool may do.
+ */
 export interface AgentRuntime {
   readonly descriptor: RuntimeIdentity;
   /** The moment held-back inferences may resume, for a host to ask before opening a turn. */

--- a/packages/runtime/src/identifiers.ts
+++ b/packages/runtime/src/identifiers.ts
@@ -116,7 +116,6 @@ export function childIdOf(key: SessionKey | string): string | undefined {
   return parsed?.rest.length === 2 && segment === SUBAGENT_SEGMENT ? childId : undefined;
 }
 
-/** The agent a child key belongs to. */
 export function childAgentOf(key: SessionKey | string): AgentId | undefined {
   const parsed = parsedSessionKey(key);
   return parsed && parsed.rest[0] === SUBAGENT_SEGMENT ? agentId(parsed.agent) : undefined;

--- a/packages/runtime/src/lanes.ts
+++ b/packages/runtime/src/lanes.ts
@@ -14,7 +14,6 @@ import { availableParallelism } from "node:os";
 export const LANE = {
   /** Ordinary conversation turns: asks, observation looks, heartbeats' own turns. */
   AGENT: "agent",
-  /** Child agent runs. */
   CHILD: "child",
   /** The cron coordinator: deciding which jobs are due and dispatching them. */
   CRON: "cron",

--- a/packages/session/src/conversation/conversation-history.ts
+++ b/packages/session/src/conversation/conversation-history.ts
@@ -3,31 +3,16 @@
  * of the wire. A Realtime call is a transport that comes and goes — the
  * announcer's speak-only call is torn down by the very talk-key press that
  * asks about it, and the developer's call retires when idle — so the thread
- * itself is kept here, as a record of what was already said and done during
- * this app launch. A bounded recent slice is re-fed to whichever call the
- * developer opens next; the retained thread remains available to the
- * developer in the panel until they clear it.
- *
- * Every panel window draws the same thread. The window that appends a line
- * reports the whole thread to its own main process, which holds the launch's
- * copy for a panel that opens late and mirrors each report to every other
- * display's panel — the relay never leaves the machine.
+ * itself is kept here, and a bounded recent slice is re-fed to whichever call
+ * the developer opens next.
  *
  * Every line already traveled to the voice service once, on the call that
  * said it: the developer's own asks — typed, or spoken and handed back as
  * text by the service that heard them — the words Luke spoke or announced,
  * and the acts he carried at the developer's ask. Nothing else may enter —
  * not a roster, not a transcript rendering, not an outcome a provider
- * answered with.
- *
- * The thread outlives the app. What is stored is exactly what that rule
- * already admits — words that were said, each of which reached the voice
- * service once on the call that said it — and never a claim Luke formed
- * about the developer, which is a different kind of thing kept somewhere
- * else. So the justification above holds across a launch unchanged: quitting
- * and coming back is the same continuity a retired call already has, one
- * boundary further out. Only the retention changes, because "dies with the
- * app" was itself a policy and persisting means replacing it with a real one.
+ * answered with — and never a claim Luke formed about the developer, which is
+ * a different kind of thing kept somewhere else.
  */
 
 import {
@@ -99,13 +84,6 @@ export const maximumConversationEntryLength = 400;
  * of its own: every word already traveled to the voice service once on the
  * call that said it, so keeping it whole changes what the panel can show back,
  * not what leaves the machine.
- *
- * At this size continuity needs no retrieval: quitting and returning to the
- * last twenty lines is the whole of it, and the panel simply draws the rest.
- * Retrieval starts to matter only if the model's slice stops being the recent
- * slice — if a turn should be able to reach back to something said last month
- * rather than last night. That is a different feature with a different budget,
- * and nothing here anticipates it.
  */
 export const maximumStoredConversationEntries = 200;
 export const storedConversationMaximumAgeMs = 14 * 24 * 60 * 60 * 1000;
@@ -441,14 +419,12 @@ const CONVERSATION_ENTRY_LEAD = {
  * opening says what was talked about at a fraction of the cost the whole
  * would spend — while the thread behind it keeps the full words, newlines
  * and all, for the panel.
- * Each line carries its identity only while the roster
- * still observes that session: the words are history and stay, but an
- * identity the roster no longer reports is one no tool call may name, and a
- * line still offering it would steer "that chat" toward a guaranteed refusal.
- * The departure is said rather than left blank — a line that merely fell
- * silent reads like one that never named a session, and an ask pointed at it
- * would be resolved by guessing among the sessions still observed. The fixed
- * note is what the standing instructions teach: gone, so say so or ask.
+ *
+ * A line carries its identity only while the roster still observes that
+ * session, and says so in place of the ids once it does not: a line that
+ * merely fell silent reads like one that never named a session, and an ask
+ * pointed at it would be resolved by guessing among the sessions still
+ * observed.
  */
 export function conversationHistoryText(
   entries: readonly ConversationEntry[],

--- a/packages/session/src/issues/issues.ts
+++ b/packages/session/src/issues/issues.ts
@@ -1,17 +1,12 @@
 /**
- * The issue-tracker model: the work items a tracker lists for the developer,
- * and the two acts a tracker may be asked to carry for one of them. It mirrors
- * the session model deliberately — bounded observations normalized once, acts
- * validated against what the latest observation advertised — so an issue and a
- * session are offered to the rest of the app under the same discipline.
+ * The issue-tracker model. It mirrors the session model deliberately —
+ * bounded observations normalized once, acts validated against what the
+ * latest observation advertised — so an issue and a session are offered to
+ * the rest of the app under the same discipline.
  */
 
 import { type ActResult, text, type UnparsedWireValue } from "@sidecar/wire";
 
-/**
- * Stable tracker identifiers shared by the tracker client, the settings that
- * hold its credential, and the UI that draws its mark.
- */
 export const ISSUE_TRACKER_ID = {
   LINEAR: "linear",
 } as const;
@@ -20,12 +15,10 @@ export type IssueTrackerId = (typeof ISSUE_TRACKER_ID)[keyof typeof ISSUE_TRACKE
 
 const ISSUE_TRACKER_IDS: ReadonlySet<string> = new Set(Object.values(ISSUE_TRACKER_ID));
 
-/** Whether this build knows the tracker an observation or an act names. */
 export function isIssueTrackerId(value: string): value is IssueTrackerId {
   return ISSUE_TRACKER_IDS.has(value);
 }
 
-/** A stable tracker identity and the label that can be shown or spoken. */
 export interface IssueTracker {
   id: string;
   displayName: string;
@@ -60,7 +53,6 @@ export interface TrackerIssueObservation {
   trackerIssueId: string;
   identifier: string;
   title: string;
-  /** The name of the state the issue is in now. */
   stateName: string;
   observedAt: number;
   url?: string;
@@ -73,7 +65,6 @@ export interface TrackerIssueObservation {
   canComment?: boolean;
 }
 
-/** The normalized issue shared by the main process, the bridge, and the voice roster. */
 export interface TrackedIssue extends IssueIdentity {
   tracker: IssueTracker;
   trackerIssueId: string;
@@ -238,11 +229,9 @@ export type TrackerIssueAction =
     };
 
 /**
- * A tracker client has no dependency on Electron, a renderer, or live UI
- * state. Observing must issue only reads; `execute` is the one place a client
- * may change tracker state, and only ever with an act the developer asked for,
+ * Observing must issue only reads; `execute` is the one place a client may
+ * change tracker state, and only ever with an act the developer asked for,
  * against an issue and a transition the latest observation advertised.
- * Nothing that decides on the developer's behalf may reach it.
  */
 export interface IssueTrackerAdapter {
   readonly tracker: IssueTracker;

--- a/packages/session/src/provider-identity.ts
+++ b/packages/session/src/provider-identity.ts
@@ -147,7 +147,6 @@ export function isHostedAgentId(value: string): value is HostedAgentId {
 
 const PROVIDER_IDS: ReadonlySet<string> = new Set(PROVIDER_ID_LIST);
 
-/** Whether this build knows the provider an observation names. */
 export function isProviderId(value: string): value is ProviderId {
   return PROVIDER_IDS.has(value);
 }

--- a/packages/session/src/session-shape.ts
+++ b/packages/session/src/session-shape.ts
@@ -180,10 +180,6 @@ export interface ProviderSessionObservation extends SessionFields {
   directory?: string;
 }
 
-/**
- * The normalized model shared by observers, the UI, and any future
- * capability-gated controls.
- */
 export type Session = SessionIdentity &
   Omit<SessionFields, NormalizedSessionField> &
   Required<Pick<SessionFields, NormalizedSessionField>> & { provider: SessionProvider };

--- a/packages/settings/src/schema.ts
+++ b/packages/settings/src/schema.ts
@@ -465,9 +465,8 @@ export const APP_SETTING_SCHEMA = {
     guard: hotkey,
     settingsPage: SETTINGS_PAGE.SHORTCUTS,
     resetScope: SETTINGS_RESET_SCOPE.SHORTCUTS,
-    // The talk-key fact reports the registered chord and its manual path, so
-    // the guide builds no setting for it; the id is listed all the same, so
-    // the chord's page is named and a change to it can be counted.
+    // The talk-key fact reports the chord and its manual path, so the guide
+    // builds no setting; the id is listed to name the page and count a change.
     guideEntry: settingGuideEntry("voiceHotkey", [APP_SETTING_ID.TALK_HOTKEY], () => undefined),
     mainProcessSideEffect: SETTING_SIDE_EFFECT.TALK_HOTKEY,
     analytics: { id: APP_SETTING_ID.TALK_HOTKEY, value: hotkeyAnalytics },
@@ -478,9 +477,8 @@ export const APP_SETTING_SCHEMA = {
     guard: hotkey,
     settingsPage: SETTINGS_PAGE.SHORTCUTS,
     resetScope: SETTINGS_RESET_SCOPE.SHORTCUTS,
-    // The ask-key fact reports the registered chord and its manual path, so
-    // the guide builds no setting for it; the id is listed all the same, so
-    // the chord's page is named and a change to it can be counted.
+    // The ask-key fact reports the chord and its manual path, so the guide
+    // builds no setting; the id is listed to name the page and count a change.
     guideEntry: settingGuideEntry("askHotkey", [APP_SETTING_ID.ASK_HOTKEY], () => undefined),
     mainProcessSideEffect: SETTING_SIDE_EFFECT.ASK_HOTKEY,
     analytics: { id: APP_SETTING_ID.ASK_HOTKEY, value: hotkeyAnalytics },
@@ -491,9 +489,8 @@ export const APP_SETTING_SCHEMA = {
     guard: hotkey,
     settingsPage: SETTINGS_PAGE.SHORTCUTS,
     resetScope: SETTINGS_RESET_SCOPE.SHORTCUTS,
-    // The stop-key fact reports the registered chord and its manual path, so
-    // the guide builds no setting for it; the id is listed all the same, so
-    // the chord's page is named and a change to it can be counted.
+    // The stop-key fact reports the chord and its manual path, so the guide
+    // builds no setting; the id is listed to name the page and count a change.
     guideEntry: settingGuideEntry("stopHotkey", [APP_SETTING_ID.STOP_HOTKEY], () => undefined),
     mainProcessSideEffect: SETTING_SIDE_EFFECT.STOP_HOTKEY,
     analytics: { id: APP_SETTING_ID.STOP_HOTKEY, value: hotkeyAnalytics },

--- a/packages/settings/src/voice-hotkey.ts
+++ b/packages/settings/src/voice-hotkey.ts
@@ -7,13 +7,10 @@
  */
 
 /**
- * Tried in order when the user has not chosen one.
- *
- * Option-Space is where a macOS user reaches for a voice assistant —
- * Superwhisper, the ChatGPT desktop app and Alfred all sit there. It stands
- * alone, with no fallback chord: S is for stop, and a talk key that sometimes
- * lands on the stop key's chord would make which key does what depend on what
- * else is installed.
+ * Tried in order when the user has not chosen one. It stands alone, with no
+ * fallback chord: a talk key that sometimes landed on another Luke key's
+ * chord would make which key does what depend on what else is installed.
+ * Why these chords: `docs/DESIGN.md`.
  */
 export const DEFAULT_VOICE_HOTKEYS: readonly string[] = ["Alt+Space"];
 
@@ -47,25 +44,9 @@ function hotkeyCandidates(
   return candidates.filter((candidate) => !taken.includes(candidate));
 }
 
-/**
- * The key that cuts off a reply being spoken, from whatever app is frontmost.
- *
- * Option-S because S is for stop, and Option-letter is the family the other
- * Luke keys already live in. A sibling of Escape rather than of the talk key:
- * it asks for quiet and nothing in its place, where the talk key over a reply
- * interrupts by taking the turn.
- */
+/** The key that cuts off a reply being spoken, from whatever app is frontmost. */
 export const DEFAULT_STOP_HOTKEYS: readonly string[] = ["Alt+S"];
 
-/**
- * The stop chords worth asking the system for, in order, on the ask key's
- * exact terms: a chosen chord goes first — it is what the user asked for —
- * with the default kept behind it, and any chord the other Luke keys could
- * sit on is left out, because the keys must never compete for one chord —
- * whichever registered first would silently cost the other its whole
- * feature, with nothing on screen saying why. A deleted key offers nothing,
- * on the talk key's terms.
- */
 export function stopHotkeyCandidates(
   chosen: string | undefined,
   taken: readonly (string | undefined)[],
@@ -73,28 +54,9 @@ export function stopHotkeyCandidates(
   return hotkeyCandidates(chosen, DEFAULT_STOP_HOTKEYS, taken);
 }
 
-/**
- * The key that summons the ask field from whatever app is frontmost, tried in
- * order like the talk key's candidates.
- *
- * A sibling of the talk key on purpose: hold Option-Space to speak to Luke,
- * tap Option-L to type to him — one modifier for both halves of the same
- * conversation. It is deliberately not Command-L, which is the address bar in
- * every browser and a taken chord in most editors; a global registration
- * would swallow it machine-wide. Option-L costs the system only the ¬
- * character, and Option-letter is the family launcher apps already claim.
- */
+/** The key that summons the ask field from whatever app is frontmost. */
 export const DEFAULT_ASK_HOTKEYS: readonly string[] = ["Alt+L", "Alt+Shift+L"];
 
-/**
- * The ask chords worth asking the system for, in order. A chosen chord goes
- * first — it is what the user asked for — with the defaults kept behind it,
- * exactly as the talk key's candidates work. Any chord the talk key holds is
- * left out, the chosen one included: the two Luke keys must never compete for
- * one chord — whichever registered first would silently cost the other its
- * whole feature, with nothing on screen saying why. A deleted key offers
- * nothing, on the talk key's terms.
- */
 export function askHotkeyCandidates(
   chosen: string | undefined,
   taken: readonly (string | undefined)[],
@@ -197,13 +159,8 @@ export function parseVoiceHotkey(value: string): string | undefined {
 }
 
 /**
- * The chords to try, in order. A chosen key goes first — it is what the user
- * asked for — and the defaults stay behind it, so a chord another app claims
- * while Luke is closed costs the user a different talk key rather than none.
- * The panel shows whichever one actually registered. A deleted key offers
- * nothing at all: the defaults stand behind a choice, never behind a removal,
- * because a fallback the user asked to have no key would be the key coming
- * back on its own.
+ * The talk chords to try, in order. Nothing is taken: the talk key ranks
+ * highest, so the other two are what give way.
  */
 export function voiceHotkeyCandidates(chosen: string | undefined): readonly string[] {
   return hotkeyCandidates(chosen, DEFAULT_VOICE_HOTKEYS, []);

--- a/packages/settings/src/voice-hotkey.ts
+++ b/packages/settings/src/voice-hotkey.ts
@@ -1,16 +1,14 @@
 /**
- * The key that starts, sends, and interrupts a spoken turn.
- *
- * It is registered with the system rather than with a window, so it answers
- * from whatever app is frontmost. That is also why it is chosen carefully: a
- * global shortcut takes its key away from every other app on the machine.
+ * The three keys Luke registers with the system rather than with a window, so
+ * each answers from whatever app is frontmost — which is also why a chord is
+ * chosen carefully: a global shortcut takes its key away from every other app
+ * on the machine. Which chords, and why those: `docs/DESIGN.md`.
  */
 
 /**
- * Tried in order when the user has not chosen one. It stands alone, with no
- * fallback chord: a talk key that sometimes landed on another Luke key's
- * chord would make which key does what depend on what else is installed.
- * Why these chords: `docs/DESIGN.md`.
+ * Tried in order when the user has not chosen one. The talk key stands alone,
+ * with no fallback chord: one that sometimes landed on another Luke key's
+ * would make which key does what depend on what else is installed.
  */
 export const DEFAULT_VOICE_HOTKEYS: readonly string[] = ["Alt+Space"];
 


### PR DESCRIPTION
## What this is

PR **G1** of the repo-wide cleanup plan: comment density, not code.

Two things came out.

**Thirteen orphaned docblocks.** Each sat above a declaration it did not
describe — either the declaration it belonged to had moved to another module,
or an earlier wording was left standing beside the replacement that superseded
it. Where the rule the orphan carried is already stated at the declaration
itself, the orphan is deleted; where it was the only statement of that rule, it
moved to the declaration it describes:

| Orphan | Now |
| --- | --- |
| `providers/shared/hook-merge.ts` | moved to `stripLukeEntries` |
| `runtime/src/execution.ts` | moved to `AgentRuntime` |
| `desktop/renderer/app.tsx` | moved to `applySettingsView` |
| `host/brain/conversation-deletion.ts` | moved to `deleteConversationHistoryFlow`; its second paragraph restated `CONVERSATION_DELETE_OUTCOME`'s own docblock below it |
| `providers/codex/records.ts` | moved to `isCodexRealtimeDelegationThread` in `codex/observe.ts`, the reader that actually consults both columns |
| `panel/provider-marks.tsx` | the module doc bound to `interface MarkProps`; it is now a file header above the imports, attribution intact |
| `brain/requests-wire.ts`, `realtime/realtime-credentials.ts`, `desktop/main/window/voice-window.ts`, `brain/standing-context.ts`, `providers/shared/cli-pass.ts` | deleted — superseded wording, or a rule stated at its real home (`invocation.ts`'s `pathDirectories` carries the PATH-order constraint) |

**Narration.** Comments that only restated the line below, paraphrased a trust
constraint `AGENTS.md` already binds, narrated the edit that produced the code,
or speculated about a feature nothing here anticipates. Notably:

- `conversation-history.ts` — the paragraph about the window relay (which the
  host owns now), and the one explaining that persisting replaced the old
  "dies with the app" policy: a story about a change, which `AGENTS.md`
  forbids in a comment. Its one substantive clause is folded into the header.
  Also the paragraph about when retrieval would start to matter.
- `settings/src/schema.ts` — the same three-line comment over `voiceHotkey`,
  `askHotkey`, and `stopHotkey`. Compressed to one line each; it is not
  deleted, because `AGENTS.md` requires a `SETTING_GUIDE` entry returning
  `undefined` to say how the guide covers the setting instead.
- `credential-providers.ts` — copy rationale that `docs/DESIGN.md`'s "Copy"
  section already carries, including the sentence it cites verbatim as its
  own canonical *Instructs* example. The two comments that record rejected
  alternatives (no `OPENAI_API_KEY` fallback, no `sk-` prefix check) stay.
- `issues.ts`, `memory/contracts.ts`, `local-peek.ts`, `session-shape.ts` and
  seven single-line docblocks elsewhere that expanded an identifier into a
  sentence and stopped.

**`voice-hotkey.ts` → `docs/DESIGN.md`.** Why Option-Space, why Option-S, why
Option-L rather than Command-L, and why two Luke keys may never be able to land
on one chord were four essays in a parser module. They are one product
decision, so they are now one `## The keys Luke takes from the machine` section
in `docs/DESIGN.md`, and the intro sentence says the file covers it. The code
keeps the invariant `hotkeyCandidates` actually enforces.

## What deliberately stayed

`analytics/src/product-events.ts`. The audit listed its "exclusion paragraphs",
but each one records why a set is repeated rather than imported (the edge would
close a dependency cycle) or why a value is absent (a value nothing can emit
would read on a dashboard as an unused way in rather than a nonexistent one).
Deleting those would let someone reintroduce exactly the bug they name, which
is the test `AGENTS.md` sets, so only one truly vacuous line went. Same for the
provider-mark attributions, which are license and trademark provenance, and for
`brain/loop-guard.ts`, which `AGENTS.md` pins to OpenClaw `b7528507` verbatim.

No behaviour changes. No symbol, export, or type is touched; every removal is
inside a comment or a Markdown file.

## Verification

```
$ ./scripts/check.sh
exit=0
```

`git diff --shortstat origin/main...`:

```
29 files changed, 157 insertions(+), 281 deletions(-)
```

Running total: **201,819** lines of TS/TSX/MJS (−119 on this PR). The plan's
~160k TS baseline was measured at `f713707`; the tree has grown since, so the
number above is the honest current count rather than a delta against that.

**Not a UI PR, and `verify.sh` was not run.** Two touched files are renderer
code — `apps/desktop/src/renderer/app.tsx` and `packages/panel/src/provider-marks.tsx`
— but every change in both is inside a comment: nothing rendered, styled, laid
out, or animated differs, so there is no visual evidence to inspect and no
physical-notch check was performed. This workspace is a Linux cloud sandbox with
no access to the developer's Mac, which is where `verify.sh` runs.

## Self-review

A thermonuclear pass and a ponytail pass over this PR's own diff found two
real problems, fixed in the second commit.

- The chord rules ended up stated three times — the new `DESIGN.md` section,
  `hotkeyCandidates`, and `DEFAULT_VOICE_HOTKEYS` each carried the
  never-compete consequence — which is the defect this PR exists to remove.
  The rule now sits only on the function that enforces it, `DESIGN.md` points
  there, and the pointer to `DESIGN.md` moved to the module header, which is
  what actually covers all three chords.
- Deleting the `standing-context.ts` orphan outright lost a constraint that
  lived nowhere else: a roster line carries an openable app's *name* and never
  its address. `sessionCapabilityText` builds that line, so it carries the
  rule now.

Every other deletion was checked against the same test — does the fact live
anywhere else? — and it does: the PATH-order rule on `invocation.ts`'s
`pathDirectories`, the receiver-epoch lifecycle in `compose-speech.ts`, the
window relay in `conversation-thread.ts` and `store-wiring.ts`, the injectable
read locations on `LocalSessionAdapterHomes`, and the copy principle in
`docs/DESIGN.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/4d1f6585-e93c-4f3b-9663-1730ea694119)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34347901642/artifacts/10102564674) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34347901642)

- Commit: `98853ee43b17993caad26b7939efd3ec762b8226`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->


