### PR TITLE
feat(LUKE-97): Postgres schema and store for the hosted conversation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,36 @@ jobs:
       - uses: ./.github/actions/setup
       - run: ./scripts/check.sh
 
+  # The store tests run on PGlite inside the portable job above; this job is
+  # the one place the generated migrations and the same tests meet a real
+  # Postgres, so a statement PGlite accepts and Postgres refuses is caught
+  # before a deployment's `db:migrate` finds it.
+  postgres:
+    name: Postgres migrations and store
+    runs-on: ubuntu-24.04
+    services:
+      postgres:
+        image: postgres:17
+        env:
+          POSTGRES_USER: luke
+          POSTGRES_PASSWORD: luke
+          POSTGRES_DB: luke
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U luke"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 12
+    env:
+      DATABASE_URL_UNPOOLED: postgresql://luke:luke@localhost:5432/luke
+      LUKE_STORE_TEST_DATABASE_URL: postgresql://luke:luke@localhost:5432/luke
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      - uses: ./.github/actions/setup
+      - run: pnpm --filter @luke/web db:migrate
+      - run: pnpm --filter @luke/web test:store
+
   # Packages the app and captures the fixture frames. The portable job above is
   # the one place the full check runs: repeating it on a macOS runner costs
   # minutes and reports nothing the Linux run did not.

--- a/apps/web/drizzle/0010_narrow_mac_gargan.sql
+++ b/apps/web/drizzle/0010_narrow_mac_gargan.sql
@@ -1,0 +1,205 @@
+CREATE TABLE "briefing" (
+	"id" text PRIMARY KEY NOT NULL,
+	"user_id" text NOT NULL,
+	"session_key" text NOT NULL,
+	"run_id" text,
+	"sealed_words" text NOT NULL,
+	"decided_at" bigint NOT NULL,
+	"expires_at" bigint NOT NULL,
+	"state" text NOT NULL,
+	"claimed_by_device_id" text,
+	"claimed_at" bigint,
+	"settled_at" bigint
+);
+--> statement-breakpoint
+CREATE TABLE "action_receipt" (
+	"user_id" text NOT NULL,
+	"run_id" text NOT NULL,
+	"call_id" text NOT NULL,
+	"session_id" text NOT NULL,
+	"ordinal" integer NOT NULL,
+	"name" text NOT NULL,
+	"sealed_arguments" text NOT NULL,
+	"started_at" bigint NOT NULL,
+	"sealed_output" text,
+	"settled_at" bigint,
+	CONSTRAINT "action_receipt_user_id_run_id_call_id_pk" PRIMARY KEY("user_id","run_id","call_id")
+);
+--> statement-breakpoint
+CREATE TABLE "compaction_boundary" (
+	"user_id" text NOT NULL,
+	"session_key" text NOT NULL,
+	"transcript_sequence" bigint NOT NULL,
+	"session_id" text,
+	"source" text NOT NULL,
+	"dropped" integer NOT NULL,
+	"checkpoint_format" text,
+	"created_at" bigint NOT NULL,
+	CONSTRAINT "compaction_boundary_user_id_session_key_transcript_sequence_pk" PRIMARY KEY("user_id","session_key","transcript_sequence")
+);
+--> statement-breakpoint
+CREATE TABLE "conversation" (
+	"user_id" text NOT NULL,
+	"session_key" text NOT NULL,
+	"kind" text NOT NULL,
+	"name" text NOT NULL,
+	"created_at" bigint NOT NULL,
+	"last_activity_at" bigint NOT NULL,
+	"next_line_sequence" bigint DEFAULT 1 NOT NULL,
+	"next_transcript_sequence" bigint DEFAULT 1 NOT NULL,
+	"cleared_at" bigint,
+	CONSTRAINT "conversation_user_id_session_key_pk" PRIMARY KEY("user_id","session_key")
+);
+--> statement-breakpoint
+CREATE TABLE "conversation_line" (
+	"user_id" text NOT NULL,
+	"session_key" text NOT NULL,
+	"sequence" bigint NOT NULL,
+	"session_id" text,
+	"event_key" text NOT NULL,
+	"kind" text NOT NULL,
+	"recorded_at" bigint NOT NULL,
+	"request_id" text,
+	"provider_id" text,
+	"provider_session_id" text,
+	"sealed_payload" text NOT NULL,
+	CONSTRAINT "conversation_line_user_id_session_key_sequence_pk" PRIMARY KEY("user_id","session_key","sequence")
+);
+--> statement-breakpoint
+CREATE TABLE "conversation_run" (
+	"user_id" text NOT NULL,
+	"run_id" text NOT NULL,
+	"session_id" text NOT NULL,
+	"ordinal" integer NOT NULL,
+	"submission_id" text NOT NULL,
+	"origin" text NOT NULL,
+	"sealed_question" text NOT NULL,
+	"status" text NOT NULL,
+	"revision" integer NOT NULL,
+	"accepted_at" bigint NOT NULL,
+	"started_at" bigint,
+	"settled_at" bigint,
+	"sealed_text" text,
+	"failure" text,
+	"performed_actions" integer NOT NULL,
+	"unknown_actions" integer NOT NULL,
+	"ask_recorded_at" bigint,
+	"conversation_recorded_at" bigint,
+	"trigger" text,
+	"run_origin" text,
+	"ending" text,
+	"input_tokens" integer,
+	"output_tokens" integer,
+	"input_item_kinds" text[],
+	"transcript_bytes" integer,
+	"elapsed_ms" integer,
+	"tool_names" text[],
+	"compacted" boolean,
+	CONSTRAINT "conversation_run_user_id_run_id_pk" PRIMARY KEY("user_id","run_id")
+);
+--> statement-breakpoint
+CREATE TABLE "conversation_session" (
+	"user_id" text NOT NULL,
+	"session_id" text NOT NULL,
+	"session_key" text NOT NULL,
+	"created_at" bigint NOT NULL,
+	"expires_at" bigint NOT NULL,
+	"reset_cleared_at" bigint,
+	"reset_generation_id" text,
+	"checkpoint_format" text,
+	"compaction_count" integer DEFAULT 0 NOT NULL,
+	CONSTRAINT "conversation_session_user_id_session_id_pk" PRIMARY KEY("user_id","session_id")
+);
+--> statement-breakpoint
+CREATE TABLE "observation_capture_cursor" (
+	"user_id" text NOT NULL,
+	"session_id" text NOT NULL,
+	"provider_id" text NOT NULL,
+	"provider_session_id" text NOT NULL,
+	"cursor" text NOT NULL,
+	CONSTRAINT "observation_capture_cursor_user_id_session_id_provider_id_provider_session_id_pk" PRIMARY KEY("user_id","session_id","provider_id","provider_session_id")
+);
+--> statement-breakpoint
+CREATE TABLE "observation_cursor" (
+	"user_id" text NOT NULL,
+	"session_id" text NOT NULL,
+	"provider_id" text NOT NULL,
+	"provider_session_id" text NOT NULL,
+	"cursor" text NOT NULL,
+	CONSTRAINT "observation_cursor_user_id_session_id_provider_id_provider_session_id_pk" PRIMARY KEY("user_id","session_id","provider_id","provider_session_id")
+);
+--> statement-breakpoint
+CREATE TABLE "observation_inbox_entry" (
+	"user_id" text NOT NULL,
+	"session_id" text NOT NULL,
+	"ordinal" integer NOT NULL,
+	"entry_id" text NOT NULL,
+	"sealed_payload" text NOT NULL,
+	CONSTRAINT "observation_inbox_entry_user_id_session_id_ordinal_pk" PRIMARY KEY("user_id","session_id","ordinal")
+);
+--> statement-breakpoint
+CREATE TABLE "runtime_checkpoint" (
+	"user_id" text NOT NULL,
+	"session_id" text NOT NULL,
+	"sequence" integer NOT NULL,
+	"sealed_item" text NOT NULL,
+	CONSTRAINT "runtime_checkpoint_user_id_session_id_sequence_pk" PRIMARY KEY("user_id","session_id","sequence")
+);
+--> statement-breakpoint
+CREATE TABLE "transcript_event" (
+	"user_id" text NOT NULL,
+	"session_key" text NOT NULL,
+	"sequence" bigint NOT NULL,
+	"session_id" text,
+	"kind" text NOT NULL,
+	"recorded_at" bigint NOT NULL,
+	"sealed_payload" text NOT NULL,
+	CONSTRAINT "transcript_event_user_id_session_key_sequence_pk" PRIMARY KEY("user_id","session_key","sequence")
+);
+--> statement-breakpoint
+CREATE TABLE "roster_snapshot" (
+	"user_id" text PRIMARY KEY NOT NULL,
+	"sealed_body" text NOT NULL,
+	"observed_at" bigint NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "personal_fact" (
+	"user_id" text NOT NULL,
+	"id" text NOT NULL,
+	"ordinal" integer NOT NULL,
+	"sealed_words" text NOT NULL,
+	"created_at" bigint NOT NULL,
+	CONSTRAINT "personal_fact_user_id_id_pk" PRIMARY KEY("user_id","id")
+);
+--> statement-breakpoint
+CREATE TABLE "workspace_file" (
+	"user_id" text NOT NULL,
+	"path" text NOT NULL,
+	"sealed_content" text NOT NULL,
+	"created_at" bigint NOT NULL,
+	"updated_at" bigint NOT NULL,
+	CONSTRAINT "workspace_file_user_id_path_pk" PRIMARY KEY("user_id","path")
+);
+--> statement-breakpoint
+ALTER TABLE "briefing" ADD CONSTRAINT "briefing_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "action_receipt" ADD CONSTRAINT "action_receipt_session_fk" FOREIGN KEY ("user_id","session_id") REFERENCES "public"."conversation_session"("user_id","session_id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "compaction_boundary" ADD CONSTRAINT "compaction_boundary_conversation_fk" FOREIGN KEY ("user_id","session_key") REFERENCES "public"."conversation"("user_id","session_key") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "conversation" ADD CONSTRAINT "conversation_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "conversation_line" ADD CONSTRAINT "conversation_line_conversation_fk" FOREIGN KEY ("user_id","session_key") REFERENCES "public"."conversation"("user_id","session_key") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "conversation_run" ADD CONSTRAINT "conversation_run_session_fk" FOREIGN KEY ("user_id","session_id") REFERENCES "public"."conversation_session"("user_id","session_id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "conversation_session" ADD CONSTRAINT "conversation_session_conversation_fk" FOREIGN KEY ("user_id","session_key") REFERENCES "public"."conversation"("user_id","session_key") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "observation_capture_cursor" ADD CONSTRAINT "observation_capture_cursor_session_fk" FOREIGN KEY ("user_id","session_id") REFERENCES "public"."conversation_session"("user_id","session_id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "observation_cursor" ADD CONSTRAINT "observation_cursor_session_fk" FOREIGN KEY ("user_id","session_id") REFERENCES "public"."conversation_session"("user_id","session_id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "observation_inbox_entry" ADD CONSTRAINT "observation_inbox_entry_session_fk" FOREIGN KEY ("user_id","session_id") REFERENCES "public"."conversation_session"("user_id","session_id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "runtime_checkpoint" ADD CONSTRAINT "runtime_checkpoint_session_fk" FOREIGN KEY ("user_id","session_id") REFERENCES "public"."conversation_session"("user_id","session_id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "transcript_event" ADD CONSTRAINT "transcript_event_conversation_fk" FOREIGN KEY ("user_id","session_key") REFERENCES "public"."conversation"("user_id","session_key") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "roster_snapshot" ADD CONSTRAINT "roster_snapshot_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "personal_fact" ADD CONSTRAINT "personal_fact_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "workspace_file" ADD CONSTRAINT "workspace_file_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "briefing_by_user_state" ON "briefing" USING btree ("user_id","state","decided_at");--> statement-breakpoint
+CREATE INDEX "action_receipt_by_session" ON "action_receipt" USING btree ("user_id","session_id","ordinal");--> statement-breakpoint
+CREATE UNIQUE INDEX "conversation_line_by_key" ON "conversation_line" USING btree ("user_id","session_key","event_key");--> statement-breakpoint
+CREATE INDEX "conversation_line_by_time" ON "conversation_line" USING btree ("user_id","session_key","recorded_at","sequence");--> statement-breakpoint
+CREATE UNIQUE INDEX "conversation_line_once_published" ON "conversation_line" USING btree ("user_id","session_key","request_id","kind") WHERE "conversation_line"."request_id" is not null;--> statement-breakpoint
+CREATE INDEX "conversation_run_by_session" ON "conversation_run" USING btree ("user_id","session_id","ordinal");--> statement-breakpoint
+CREATE UNIQUE INDEX "conversation_session_one_standing" ON "conversation_session" USING btree ("user_id","session_key");

--- a/apps/web/drizzle/0010_same_scarecrow.sql
+++ b/apps/web/drizzle/0010_same_scarecrow.sql
@@ -1,6 +1,6 @@
 CREATE TABLE "briefing" (
-	"id" text PRIMARY KEY NOT NULL,
 	"user_id" text NOT NULL,
+	"id" text NOT NULL,
 	"session_key" text NOT NULL,
 	"run_id" text,
 	"sealed_words" text NOT NULL,
@@ -9,7 +9,8 @@ CREATE TABLE "briefing" (
 	"state" text NOT NULL,
 	"claimed_by_device_id" text,
 	"claimed_at" bigint,
-	"settled_at" bigint
+	"settled_at" bigint,
+	CONSTRAINT "briefing_user_id_id_pk" PRIMARY KEY("user_id","id")
 );
 --> statement-breakpoint
 CREATE TABLE "action_receipt" (

--- a/apps/web/drizzle/meta/0010_snapshot.json
+++ b/apps/web/drizzle/meta/0010_snapshot.json
@@ -1,5 +1,5 @@
 {
-  "id": "96483389-b94a-47ca-a994-de16afd4a36d",
+  "id": "157bb098-45e3-4142-a5a7-705799ee4b1c",
   "prevId": "e71bcd47-fe5c-4fd8-b09e-f497fc091fc1",
   "version": "7",
   "dialect": "postgresql",
@@ -1074,14 +1074,14 @@
       "name": "briefing",
       "schema": "",
       "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
         "user_id": {
           "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
           "type": "text",
           "primaryKey": false,
           "notNull": true
@@ -1181,7 +1181,12 @@
           "onUpdate": "no action"
         }
       },
-      "compositePrimaryKeys": {},
+      "compositePrimaryKeys": {
+        "briefing_user_id_id_pk": {
+          "name": "briefing_user_id_id_pk",
+          "columns": ["user_id", "id"]
+        }
+      },
       "uniqueConstraints": {},
       "policies": {},
       "checkConstraints": {},

--- a/apps/web/drizzle/meta/0010_snapshot.json
+++ b/apps/web/drizzle/meta/0010_snapshot.json
@@ -1,0 +1,2842 @@
+{
+  "id": "96483389-b94a-47ca-a994-de16afd4a36d",
+  "prevId": "e71bcd47-fe5c-4fd8-b09e-f497fc091fc1",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.jwks": {
+      "name": "jwks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_key": {
+          "name": "private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_access_token": {
+      "name": "oauth_access_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_id": {
+          "name": "refresh_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "oauthAccessToken_clientId_idx": {
+          "name": "oauthAccessToken_clientId_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthAccessToken_sessionId_idx": {
+          "name": "oauthAccessToken_sessionId_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthAccessToken_userId_idx": {
+          "name": "oauthAccessToken_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthAccessToken_refreshId_idx": {
+          "name": "oauthAccessToken_refreshId_idx",
+          "columns": [
+            {
+              "expression": "refresh_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_access_token_client_id_oauth_client_client_id_fk": {
+          "name": "oauth_access_token_client_id_oauth_client_client_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "oauth_client",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["client_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_session_id_session_id_fk": {
+          "name": "oauth_access_token_session_id_session_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "session",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_user_id_user_id_fk": {
+          "name": "oauth_access_token_user_id_user_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_refresh_id_oauth_refresh_token_id_fk": {
+          "name": "oauth_access_token_refresh_id_oauth_refresh_token_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "oauth_refresh_token",
+          "columnsFrom": ["refresh_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_access_token_token_unique": {
+          "name": "oauth_access_token_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_client": {
+      "name": "oauth_client",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "skip_consent": {
+          "name": "skip_consent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enable_end_session": {
+          "name": "enable_end_session",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject_type": {
+          "name": "subject_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contacts": {
+          "name": "contacts",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tos": {
+          "name": "tos",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "policy": {
+          "name": "policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_id": {
+          "name": "software_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_version": {
+          "name": "software_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_statement": {
+          "name": "software_statement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_logout_redirect_uris": {
+          "name": "post_logout_redirect_uris",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_endpoint_auth_method": {
+          "name": "token_endpoint_auth_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grant_types": {
+          "name": "grant_types",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_types": {
+          "name": "response_types",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public": {
+          "name": "public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "require_pkce": {
+          "name": "require_pkce",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "oauthClient_userId_idx": {
+          "name": "oauthClient_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_client_user_id_user_id_fk": {
+          "name": "oauth_client_user_id_user_id_fk",
+          "tableFrom": "oauth_client",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_client_client_id_unique": {
+          "name": "oauth_client_client_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["client_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_consent": {
+      "name": "oauth_consent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "oauthConsent_clientId_idx": {
+          "name": "oauthConsent_clientId_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthConsent_userId_idx": {
+          "name": "oauthConsent_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_consent_client_id_oauth_client_client_id_fk": {
+          "name": "oauth_consent_client_id_oauth_client_client_id_fk",
+          "tableFrom": "oauth_consent",
+          "tableTo": "oauth_client",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["client_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_consent_user_id_user_id_fk": {
+          "name": "oauth_consent_user_id_user_id_fk",
+          "tableFrom": "oauth_consent",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_refresh_token": {
+      "name": "oauth_refresh_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked": {
+          "name": "revoked",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_time": {
+          "name": "auth_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "oauthRefreshToken_clientId_idx": {
+          "name": "oauthRefreshToken_clientId_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthRefreshToken_sessionId_idx": {
+          "name": "oauthRefreshToken_sessionId_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthRefreshToken_userId_idx": {
+          "name": "oauthRefreshToken_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_refresh_token_client_id_oauth_client_client_id_fk": {
+          "name": "oauth_refresh_token_client_id_oauth_client_client_id_fk",
+          "tableFrom": "oauth_refresh_token",
+          "tableTo": "oauth_client",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["client_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_refresh_token_session_id_session_id_fk": {
+          "name": "oauth_refresh_token_session_id_session_id_fk",
+          "tableFrom": "oauth_refresh_token",
+          "tableTo": "session",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "oauth_refresh_token_user_id_user_id_fk": {
+          "name": "oauth_refresh_token_user_id_user_id_fk",
+          "tableFrom": "oauth_refresh_token",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_refresh_token_token_unique": {
+          "name": "oauth_refresh_token_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_login_method": {
+          "name": "last_login_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'user'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.briefing": {
+      "name": "briefing",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_key": {
+          "name": "session_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sealed_words": {
+          "name": "sealed_words",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claimed_by_device_id": {
+          "name": "claimed_by_device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settled_at": {
+          "name": "settled_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "briefing_by_user_state": {
+          "name": "briefing_by_user_state",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "decided_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "briefing_user_id_user_id_fk": {
+          "name": "briefing_user_id_user_id_fk",
+          "tableFrom": "briefing",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.action_receipt": {
+      "name": "action_receipt",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "call_id": {
+          "name": "call_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ordinal": {
+          "name": "ordinal",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sealed_arguments": {
+          "name": "sealed_arguments",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sealed_output": {
+          "name": "sealed_output",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settled_at": {
+          "name": "settled_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "action_receipt_by_session": {
+          "name": "action_receipt_by_session",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ordinal",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "action_receipt_session_fk": {
+          "name": "action_receipt_session_fk",
+          "tableFrom": "action_receipt",
+          "tableTo": "conversation_session",
+          "columnsFrom": ["user_id", "session_id"],
+          "columnsTo": ["user_id", "session_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "action_receipt_user_id_run_id_call_id_pk": {
+          "name": "action_receipt_user_id_run_id_call_id_pk",
+          "columns": ["user_id", "run_id", "call_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.compaction_boundary": {
+      "name": "compaction_boundary",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_key": {
+          "name": "session_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transcript_sequence": {
+          "name": "transcript_sequence",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dropped": {
+          "name": "dropped",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "checkpoint_format": {
+          "name": "checkpoint_format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "compaction_boundary_conversation_fk": {
+          "name": "compaction_boundary_conversation_fk",
+          "tableFrom": "compaction_boundary",
+          "tableTo": "conversation",
+          "columnsFrom": ["user_id", "session_key"],
+          "columnsTo": ["user_id", "session_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "compaction_boundary_user_id_session_key_transcript_sequence_pk": {
+          "name": "compaction_boundary_user_id_session_key_transcript_sequence_pk",
+          "columns": ["user_id", "session_key", "transcript_sequence"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation": {
+      "name": "conversation",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_key": {
+          "name": "session_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "next_line_sequence": {
+          "name": "next_line_sequence",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "next_transcript_sequence": {
+          "name": "next_transcript_sequence",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "cleared_at": {
+          "name": "cleared_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "conversation_user_id_user_id_fk": {
+          "name": "conversation_user_id_user_id_fk",
+          "tableFrom": "conversation",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "conversation_user_id_session_key_pk": {
+          "name": "conversation_user_id_session_key_pk",
+          "columns": ["user_id", "session_key"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation_line": {
+      "name": "conversation_line",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_key": {
+          "name": "session_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_key": {
+          "name": "event_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recorded_at": {
+          "name": "recorded_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_session_id": {
+          "name": "provider_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sealed_payload": {
+          "name": "sealed_payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "conversation_line_by_key": {
+          "name": "conversation_line_by_key",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_line_by_time": {
+          "name": "conversation_line_by_time",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recorded_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sequence",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_line_once_published": {
+          "name": "conversation_line_once_published",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"conversation_line\".\"request_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_line_conversation_fk": {
+          "name": "conversation_line_conversation_fk",
+          "tableFrom": "conversation_line",
+          "tableTo": "conversation",
+          "columnsFrom": ["user_id", "session_key"],
+          "columnsTo": ["user_id", "session_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "conversation_line_user_id_session_key_sequence_pk": {
+          "name": "conversation_line_user_id_session_key_sequence_pk",
+          "columns": ["user_id", "session_key", "sequence"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation_run": {
+      "name": "conversation_run",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ordinal": {
+          "name": "ordinal",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submission_id": {
+          "name": "submission_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "origin": {
+          "name": "origin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sealed_question": {
+          "name": "sealed_question",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revision": {
+          "name": "revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settled_at": {
+          "name": "settled_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sealed_text": {
+          "name": "sealed_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure": {
+          "name": "failure",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "performed_actions": {
+          "name": "performed_actions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unknown_actions": {
+          "name": "unknown_actions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ask_recorded_at": {
+          "name": "ask_recorded_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conversation_recorded_at": {
+          "name": "conversation_recorded_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_origin": {
+          "name": "run_origin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ending": {
+          "name": "ending",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_item_kinds": {
+          "name": "input_item_kinds",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transcript_bytes": {
+          "name": "transcript_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "elapsed_ms": {
+          "name": "elapsed_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_names": {
+          "name": "tool_names",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "compacted": {
+          "name": "compacted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "conversation_run_by_session": {
+          "name": "conversation_run_by_session",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ordinal",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_run_session_fk": {
+          "name": "conversation_run_session_fk",
+          "tableFrom": "conversation_run",
+          "tableTo": "conversation_session",
+          "columnsFrom": ["user_id", "session_id"],
+          "columnsTo": ["user_id", "session_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "conversation_run_user_id_run_id_pk": {
+          "name": "conversation_run_user_id_run_id_pk",
+          "columns": ["user_id", "run_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation_session": {
+      "name": "conversation_session",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_key": {
+          "name": "session_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reset_cleared_at": {
+          "name": "reset_cleared_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reset_generation_id": {
+          "name": "reset_generation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checkpoint_format": {
+          "name": "checkpoint_format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "compaction_count": {
+          "name": "compaction_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "conversation_session_one_standing": {
+          "name": "conversation_session_one_standing",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_session_conversation_fk": {
+          "name": "conversation_session_conversation_fk",
+          "tableFrom": "conversation_session",
+          "tableTo": "conversation",
+          "columnsFrom": ["user_id", "session_key"],
+          "columnsTo": ["user_id", "session_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "conversation_session_user_id_session_id_pk": {
+          "name": "conversation_session_user_id_session_id_pk",
+          "columns": ["user_id", "session_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.observation_capture_cursor": {
+      "name": "observation_capture_cursor",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_session_id": {
+          "name": "provider_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cursor": {
+          "name": "cursor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "observation_capture_cursor_session_fk": {
+          "name": "observation_capture_cursor_session_fk",
+          "tableFrom": "observation_capture_cursor",
+          "tableTo": "conversation_session",
+          "columnsFrom": ["user_id", "session_id"],
+          "columnsTo": ["user_id", "session_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "observation_capture_cursor_user_id_session_id_provider_id_provider_session_id_pk": {
+          "name": "observation_capture_cursor_user_id_session_id_provider_id_provider_session_id_pk",
+          "columns": ["user_id", "session_id", "provider_id", "provider_session_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.observation_cursor": {
+      "name": "observation_cursor",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_session_id": {
+          "name": "provider_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cursor": {
+          "name": "cursor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "observation_cursor_session_fk": {
+          "name": "observation_cursor_session_fk",
+          "tableFrom": "observation_cursor",
+          "tableTo": "conversation_session",
+          "columnsFrom": ["user_id", "session_id"],
+          "columnsTo": ["user_id", "session_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "observation_cursor_user_id_session_id_provider_id_provider_session_id_pk": {
+          "name": "observation_cursor_user_id_session_id_provider_id_provider_session_id_pk",
+          "columns": ["user_id", "session_id", "provider_id", "provider_session_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.observation_inbox_entry": {
+      "name": "observation_inbox_entry",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ordinal": {
+          "name": "ordinal",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entry_id": {
+          "name": "entry_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sealed_payload": {
+          "name": "sealed_payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "observation_inbox_entry_session_fk": {
+          "name": "observation_inbox_entry_session_fk",
+          "tableFrom": "observation_inbox_entry",
+          "tableTo": "conversation_session",
+          "columnsFrom": ["user_id", "session_id"],
+          "columnsTo": ["user_id", "session_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "observation_inbox_entry_user_id_session_id_ordinal_pk": {
+          "name": "observation_inbox_entry_user_id_session_id_ordinal_pk",
+          "columns": ["user_id", "session_id", "ordinal"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.runtime_checkpoint": {
+      "name": "runtime_checkpoint",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sealed_item": {
+          "name": "sealed_item",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "runtime_checkpoint_session_fk": {
+          "name": "runtime_checkpoint_session_fk",
+          "tableFrom": "runtime_checkpoint",
+          "tableTo": "conversation_session",
+          "columnsFrom": ["user_id", "session_id"],
+          "columnsTo": ["user_id", "session_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "runtime_checkpoint_user_id_session_id_sequence_pk": {
+          "name": "runtime_checkpoint_user_id_session_id_sequence_pk",
+          "columns": ["user_id", "session_id", "sequence"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transcript_event": {
+      "name": "transcript_event",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_key": {
+          "name": "session_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recorded_at": {
+          "name": "recorded_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sealed_payload": {
+          "name": "sealed_payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "transcript_event_conversation_fk": {
+          "name": "transcript_event_conversation_fk",
+          "tableFrom": "transcript_event",
+          "tableTo": "conversation",
+          "columnsFrom": ["user_id", "session_key"],
+          "columnsTo": ["user_id", "session_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "transcript_event_user_id_session_key_sequence_pk": {
+          "name": "transcript_event_user_id_session_key_sequence_pk",
+          "columns": ["user_id", "session_key", "sequence"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.device_token": {
+      "name": "device_token",
+      "schema": "",
+      "columns": {
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "environment": {
+          "name": "environment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "device_token_user_id_user_id_fk": {
+          "name": "device_token_user_id_user_id_fk",
+          "tableFrom": "device_token",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.admin_favorite": {
+      "name": "admin_favorite",
+      "schema": "",
+      "columns": {
+        "admin_id": {
+          "name": "admin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "admin_favorite_admin_id_user_id_fk": {
+          "name": "admin_favorite_admin_id_user_id_fk",
+          "tableFrom": "admin_favorite",
+          "tableTo": "user",
+          "columnsFrom": ["admin_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "admin_favorite_user_id_user_id_fk": {
+          "name": "admin_favorite_user_id_user_id_fk",
+          "tableFrom": "admin_favorite",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "admin_favorite_admin_id_user_id_pk": {
+          "name": "admin_favorite_admin_id_user_id_pk",
+          "columns": ["admin_id", "user_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.account_preference": {
+      "name": "account_preference",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "voice": {
+          "name": "voice",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "voice_speed": {
+          "name": "voice_speed",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_workspace_provider": {
+          "name": "default_workspace_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_preference_user_id_user_id_fk": {
+          "name": "account_preference_user_id_user_id_fk",
+          "tableFrom": "account_preference",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.account_workspace_preference": {
+      "name": "account_workspace_preference",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_project_id": {
+          "name": "default_project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent": {
+          "name": "agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "effort": {
+          "name": "effort",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_workspace_preference_user_id_user_id_fk": {
+          "name": "account_workspace_preference_user_id_user_id_fk",
+          "tableFrom": "account_workspace_preference",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "account_workspace_preference_user_id_provider_id_pk": {
+          "name": "account_workspace_preference_user_id_provider_id_pk",
+          "columns": ["user_id", "provider_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.roster_snapshot": {
+      "name": "roster_snapshot",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "sealed_body": {
+          "name": "sealed_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "roster_snapshot_user_id_user_id_fk": {
+          "name": "roster_snapshot_user_id_user_id_fk",
+          "tableFrom": "roster_snapshot",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.hosted_usage": {
+      "name": "hosted_usage",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "day": {
+          "name": "day",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "calls": {
+          "name": "calls",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "hosted_usage_user_id_user_id_fk": {
+          "name": "hosted_usage_user_id_user_id_fk",
+          "tableFrom": "hosted_usage",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "hosted_usage_user_id_day_pk": {
+          "name": "hosted_usage_user_id_day_pk",
+          "columns": ["user_id", "day"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.introduction_usage": {
+      "name": "introduction_usage",
+      "schema": "",
+      "columns": {
+        "caller": {
+          "name": "caller",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "day": {
+          "name": "day",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mints": {
+          "name": "mints",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "introduction_usage_caller_day_pk": {
+          "name": "introduction_usage_caller_day_pk",
+          "columns": ["caller", "day"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provider_key": {
+      "name": "provider_key",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ciphertext": {
+          "name": "ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "provider_key_user_id_user_id_fk": {
+          "name": "provider_key_user_id_user_id_fk",
+          "tableFrom": "provider_key",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "provider_key_user_id_provider_id_pk": {
+          "name": "provider_key_user_id_provider_id_pk",
+          "columns": ["user_id", "provider_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.personal_fact": {
+      "name": "personal_fact",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ordinal": {
+          "name": "ordinal",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sealed_words": {
+          "name": "sealed_words",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "personal_fact_user_id_user_id_fk": {
+          "name": "personal_fact_user_id_user_id_fk",
+          "tableFrom": "personal_fact",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "personal_fact_user_id_id_pk": {
+          "name": "personal_fact_user_id_id_pk",
+          "columns": ["user_id", "id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspace_file": {
+      "name": "workspace_file",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sealed_content": {
+          "name": "sealed_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workspace_file_user_id_user_id_fk": {
+          "name": "workspace_file_user_id_user_id_fk",
+          "tableFrom": "workspace_file",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "workspace_file_user_id_path_pk": {
+          "name": "workspace_file_user_id_path_pk",
+          "columns": ["user_id", "path"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/web/drizzle/meta/_journal.json
+++ b/apps/web/drizzle/meta/_journal.json
@@ -75,8 +75,8 @@
     {
       "idx": 10,
       "version": "7",
-      "when": 1788965332963,
-      "tag": "0010_narrow_mac_gargan",
+      "when": 1788967420794,
+      "tag": "0010_same_scarecrow",
       "breakpoints": true
     }
   ]

--- a/apps/web/drizzle/meta/_journal.json
+++ b/apps/web/drizzle/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1788916794040,
       "tag": "0009_pretty_wendell_rand",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "7",
+      "when": 1788965332963,
+      "tag": "0010_narrow_mac_gargan",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -17,6 +17,7 @@
     "dev": "vite",
     "preview": "vite preview",
     "test": "tsx --test 'tests/**/*.test.ts'",
+    "test:store": "tsx --test tests/hosted-store.test.ts tests/hosted-payload-envelope.test.ts",
     "typecheck": "tsc --project tsconfig.json"
   },
   "dependencies": {
@@ -47,6 +48,7 @@
     "tailwindcss": "4.3.3"
   },
   "devDependencies": {
+    "@electric-sql/pglite": "0.5.8",
     "@types/node": "22.20.1",
     "@types/pg": "8.21.0",
     "@types/react": "19.2.18",

--- a/apps/web/server/README.md
+++ b/apps/web/server/README.md
@@ -244,6 +244,49 @@ secret simply has no working vault, and no plaintext key can be stored
 accidentally. Set this variable in the Vercel project environment (production
 and any Preview that needs a working vault) alongside `DATABASE_URL`.
 
+# Hosted conversation store
+
+The tables under `server/db/conversation-schema.ts`, `workspace-schema.ts`,
+`roster-schema.ts`, and `briefing-schema.ts` hold the hosted brain's
+conversation per account: the conversation directory, the standing generation
+with its checkpoint items, cursors, inbox, runs, and action receipts, the
+conversation lines, the retained transcript and its compaction boundaries, the
+identity workspace and daily notes, the remembered facts, the latest roster
+snapshot, and the briefings. Every row is keyed by `user_id` and cascades with
+the user row, so `api/account/delete.ts` erases them with the account. No route
+reads or writes them yet; `server/hosted/store/` is the store the brain host
+will compose against, implementing the storage contracts the desktop's SQLite
+store implements under `packages/brain/src/store`.
+
+Every user-derived column is a `sealed_*` column: the payload envelope in
+`server/hosted/encryption.ts`, AES-256-GCM under the vault's
+`PROVIDER_KEY_ENCRYPTION_SECRET`, written as `<keyId>:base64(nonce || ciphertext
+|| tag)` and bound to the row's user id as authenticated data. The key id is
+what makes a rotation possible: the ring names the current key and every key
+an envelope on record may still name, and the vault's own key format is left
+exactly as it was. Ids, keys, sequences, instants, states, and fixed vocabulary
+words stand clear so they can be indexed; a line's idempotency key is the
+SHA-256 of its identity, since a value-keyed line's identity is its words.
+
+The store keeps the SQLite store's invariants: a save is a compare-and-set on
+the standing generation and a stale handle is refused whole; the transcript is
+written in the same transaction as the checkpoint and never cascades with a
+generation; conversation lines carry their own retention and cutoff; a
+generation whose rows cannot be opened or read is reported unreadable and is
+repaired by the store that observed it. Clear is a hard delete of the
+conversation's lines, transcript, and boundaries at or before its instant,
+with no recovery archive and no maintenance ladder.
+
+The store tests run the generated migrations on PGlite in process, so
+`check.sh` needs no service; the `postgres` CI job runs the same migrations
+and tests against a Postgres service container. To run them against a
+Postgres of your own:
+
+```sh
+DATABASE_URL_UNPOOLED=postgresql://... pnpm --filter @luke/web db:migrate
+LUKE_STORE_TEST_DATABASE_URL=postgresql://... pnpm --filter @luke/web test:store
+```
+
 # Phone push tokens
 
 `api/devices/token.ts` registers (POST) and forgets (DELETE) the push token of

--- a/apps/web/server/core.ts
+++ b/apps/web/server/core.ts
@@ -34,6 +34,7 @@ export * from "../../../packages/actions/src/index.js";
 export { ACTION_KIND, type ActionKind } from "../../../packages/actions/src/index.js";
 export * from "../../../packages/analytics/src/index.js";
 export * from "../../../packages/brain/src/index.js";
+export * from "../../../packages/brain/src/store/shapes.js";
 export * from "../../../packages/hosted/src/index.js";
 export * from "../../../packages/realtime/src/index.js";
 export * from "../../../packages/runtime/src/vocabulary.js";

--- a/apps/web/server/db/briefing-schema.ts
+++ b/apps/web/server/db/briefing-schema.ts
@@ -1,4 +1,4 @@
-import { bigint, index, pgTable, text } from "drizzle-orm/pg-core";
+import { bigint, index, pgTable, primaryKey, text } from "drizzle-orm/pg-core";
 import { user } from "./auth-schema.js";
 
 /**
@@ -14,10 +14,11 @@ import { user } from "./auth-schema.js";
 export const briefing = pgTable(
   "briefing",
   {
-    id: text("id").notNull().primaryKey(),
     userId: text("user_id")
       .notNull()
       .references(() => user.id, { onDelete: "cascade" }),
+    /** The briefing's id as the brain minted it; one user's ids never stand in another's way. */
+    id: text("id").notNull(),
     sessionKey: text("session_key").notNull(),
     runId: text("run_id"),
     /** The briefing's words, as the brain chose to say them. Sealed. */
@@ -29,5 +30,8 @@ export const briefing = pgTable(
     claimedAt: bigint("claimed_at", { mode: "number" }),
     settledAt: bigint("settled_at", { mode: "number" }),
   },
-  (table) => [index("briefing_by_user_state").on(table.userId, table.state, table.decidedAt)],
+  (table) => [
+    primaryKey({ columns: [table.userId, table.id] }),
+    index("briefing_by_user_state").on(table.userId, table.state, table.decidedAt),
+  ],
 );

--- a/apps/web/server/db/briefing-schema.ts
+++ b/apps/web/server/db/briefing-schema.ts
@@ -1,0 +1,33 @@
+import { bigint, index, pgTable, text } from "drizzle-orm/pg-core";
+import { user } from "./auth-schema.js";
+
+/**
+ * A briefing the brain decided to give, waiting to be said on whichever
+ * device is active. Its life is the state column: offered, then claimed by
+ * one device in one atomic update, then spoken by that device, pushed to a
+ * phone when none was active, or expired unspoken. The words are sealed; the
+ * conversation and run it came from, the instants, and the state stand clear
+ * because they are what a feed reads and a transition checks. The claiming
+ * device is a plain column for now: the devices table lands beside this one
+ * in its own change, and this column takes its reference then.
+ */
+export const briefing = pgTable(
+  "briefing",
+  {
+    id: text("id").notNull().primaryKey(),
+    userId: text("user_id")
+      .notNull()
+      .references(() => user.id, { onDelete: "cascade" }),
+    sessionKey: text("session_key").notNull(),
+    runId: text("run_id"),
+    /** The briefing's words, as the brain chose to say them. Sealed. */
+    sealedWords: text("sealed_words").notNull(),
+    decidedAt: bigint("decided_at", { mode: "number" }).notNull(),
+    expiresAt: bigint("expires_at", { mode: "number" }).notNull(),
+    state: text("state").notNull(),
+    claimedByDeviceId: text("claimed_by_device_id"),
+    claimedAt: bigint("claimed_at", { mode: "number" }),
+    settledAt: bigint("settled_at", { mode: "number" }),
+  },
+  (table) => [index("briefing_by_user_state").on(table.userId, table.state, table.decidedAt)],
+);

--- a/apps/web/server/db/conversation-schema.ts
+++ b/apps/web/server/db/conversation-schema.ts
@@ -1,0 +1,350 @@
+import { sql } from "drizzle-orm";
+import {
+  bigint,
+  boolean,
+  foreignKey,
+  index,
+  integer,
+  pgTable,
+  primaryKey,
+  text,
+  uniqueIndex,
+} from "drizzle-orm/pg-core";
+import { user } from "./auth-schema.js";
+
+/**
+ * The hosted conversation, one directory per account, mirroring the tables
+ * the desktop's SQLite store keeps under Luke's application data. Every row
+ * is keyed by the user it belongs to and cascades away with the user row, so
+ * deleting an account is still one statement.
+ *
+ * Two lifetimes are kept apart here as they are there. A conversation
+ * session — the brain's generation — is replaced by Start fresh or Clear, and
+ * its checkpoints, cursors, inbox, runs, and receipts cascade with it. The
+ * conversation's lines and its retained transcript answer to the
+ * conversation instead: each names the session that stood when it was
+ * written, for attribution alone, and the column is not a foreign key, so
+ * replacing a generation erases no line. Clear is the one thing that reaches
+ * both, and on the hosted tier it is a hard delete: the lines, the
+ * transcript, and the boundaries go, with no recovery archive behind them.
+ *
+ * Indexable columns — ids, keys, sequences, instants, states, fixed
+ * vocabulary words — stand clear. Everything user-derived (checkpoint items,
+ * inbox entries, a run's question and reply, an action's arguments and
+ * output, a line's payload, a transcript event's payload) is a `sealed_*`
+ * column holding the payload envelope of `server/hosted/encryption.ts`, and
+ * nothing reads it back but the store that sealed it.
+ *
+ * Instants are epoch milliseconds in `bigint` columns rather than
+ * `timestamp`, because the storage contracts carry numbers and a round trip
+ * through a timestamp type would be a second clock to keep in step.
+ */
+
+export const conversation = pgTable(
+  "conversation",
+  {
+    userId: text("user_id")
+      .notNull()
+      .references(() => user.id, { onDelete: "cascade" }),
+    /** The conversation's stable address (`agent:<agentId>:main`, a thread, an observed session). */
+    sessionKey: text("session_key").notNull(),
+    kind: text("kind").notNull(),
+    name: text("name").notNull(),
+    createdAt: bigint("created_at", { mode: "number" }).notNull(),
+    lastActivityAt: bigint("last_activity_at", { mode: "number" }).notNull(),
+    /** The next line sequence to hand out; counted up and never reused, however many lines a Clear let go of. */
+    nextLineSequence: bigint("next_line_sequence", { mode: "number" }).notNull().default(1),
+    nextTranscriptSequence: bigint("next_transcript_sequence", { mode: "number" })
+      .notNull()
+      .default(1),
+    /** The Clear cutoff before which no line may stand; only ever raised, and outliving the generation that raised it. */
+    clearedAt: bigint("cleared_at", { mode: "number" }),
+  },
+  (table) => [primaryKey({ columns: [table.userId, table.sessionKey] })],
+);
+
+export const conversationSession = pgTable(
+  "conversation_session",
+  {
+    userId: text("user_id").notNull(),
+    /** The generation's id, minted by the brain at its birth. */
+    sessionId: text("session_id").notNull(),
+    sessionKey: text("session_key").notNull(),
+    createdAt: bigint("created_at", { mode: "number" }).notNull(),
+    expiresAt: bigint("expires_at", { mode: "number" }).notNull(),
+    resetClearedAt: bigint("reset_cleared_at", { mode: "number" }),
+    resetGenerationId: text("reset_generation_id"),
+    /** Whose shape the checkpoint items are; absent on a generation never checkpointed into. */
+    checkpointFormat: text("checkpoint_format"),
+    compactionCount: integer("compaction_count").notNull().default(0),
+  },
+  (table) => [
+    primaryKey({ columns: [table.userId, table.sessionId] }),
+    uniqueIndex("conversation_session_one_standing").on(table.userId, table.sessionKey),
+    foreignKey({
+      columns: [table.userId, table.sessionKey],
+      foreignColumns: [conversation.userId, conversation.sessionKey],
+      name: "conversation_session_conversation_fk",
+    }).onDelete("cascade"),
+  ],
+);
+
+export const runtimeCheckpoint = pgTable(
+  "runtime_checkpoint",
+  {
+    userId: text("user_id").notNull(),
+    sessionId: text("session_id").notNull(),
+    sequence: integer("sequence").notNull(),
+    /** One Responses input item. Sealed. */
+    sealedItem: text("sealed_item").notNull(),
+  },
+  (table) => [
+    primaryKey({ columns: [table.userId, table.sessionId, table.sequence] }),
+    foreignKey({
+      columns: [table.userId, table.sessionId],
+      foreignColumns: [conversationSession.userId, conversationSession.sessionId],
+      name: "runtime_checkpoint_session_fk",
+    }).onDelete("cascade"),
+  ],
+);
+
+/** Where a model has read each observed transcript to, keyed by provider and provider session. */
+export const observationCursor = pgTable(
+  "observation_cursor",
+  {
+    userId: text("user_id").notNull(),
+    sessionId: text("session_id").notNull(),
+    providerId: text("provider_id").notNull(),
+    providerSessionId: text("provider_session_id").notNull(),
+    cursor: text("cursor").notNull(),
+  },
+  (table) => [
+    primaryKey({
+      columns: [table.userId, table.sessionId, table.providerId, table.providerSessionId],
+    }),
+    foreignKey({
+      columns: [table.userId, table.sessionId],
+      foreignColumns: [conversationSession.userId, conversationSession.sessionId],
+      name: "observation_cursor_session_fk",
+    }).onDelete("cascade"),
+  ],
+);
+
+/** Where the inbox has captured each transcript to; ahead of the consumed cursor while entries wait. */
+export const observationCaptureCursor = pgTable(
+  "observation_capture_cursor",
+  {
+    userId: text("user_id").notNull(),
+    sessionId: text("session_id").notNull(),
+    providerId: text("provider_id").notNull(),
+    providerSessionId: text("provider_session_id").notNull(),
+    cursor: text("cursor").notNull(),
+  },
+  (table) => [
+    primaryKey({
+      columns: [table.userId, table.sessionId, table.providerId, table.providerSessionId],
+    }),
+    foreignKey({
+      columns: [table.userId, table.sessionId],
+      foreignColumns: [conversationSession.userId, conversationSession.sessionId],
+      name: "observation_capture_cursor_session_fk",
+    }).onDelete("cascade"),
+  ],
+);
+
+export const observationInboxEntry = pgTable(
+  "observation_inbox_entry",
+  {
+    userId: text("user_id").notNull(),
+    sessionId: text("session_id").notNull(),
+    ordinal: integer("ordinal").notNull(),
+    entryId: text("entry_id").notNull(),
+    /** The observation entry whole, transcript delta included. Sealed. */
+    sealedPayload: text("sealed_payload").notNull(),
+  },
+  (table) => [
+    primaryKey({ columns: [table.userId, table.sessionId, table.ordinal] }),
+    foreignKey({
+      columns: [table.userId, table.sessionId],
+      foreignColumns: [conversationSession.userId, conversationSession.sessionId],
+      name: "observation_inbox_entry_session_fk",
+    }).onDelete("cascade"),
+  ],
+);
+
+/**
+ * One run of the brain: the developer's ask as the brain owns it from
+ * acceptance to its end, and beside the record the turn's about-fields —
+ * what woke it, how it ended, what it counted — which the trace records on
+ * the desktop and the run row carries here. The about-fields describe the
+ * turn and never quote it: item kinds and tool names are fixed vocabulary,
+ * and every count is a number.
+ */
+export const conversationRun = pgTable(
+  "conversation_run",
+  {
+    userId: text("user_id").notNull(),
+    runId: text("run_id").notNull(),
+    sessionId: text("session_id").notNull(),
+    ordinal: integer("ordinal").notNull(),
+    submissionId: text("submission_id").notNull(),
+    origin: text("origin").notNull(),
+    /** The ask as the brain was handed it. Sealed. */
+    sealedQuestion: text("sealed_question").notNull(),
+    status: text("status").notNull(),
+    revision: integer("revision").notNull(),
+    acceptedAt: bigint("accepted_at", { mode: "number" }).notNull(),
+    startedAt: bigint("started_at", { mode: "number" }),
+    settledAt: bigint("settled_at", { mode: "number" }),
+    /** The reply, when the run reached one. Sealed. */
+    sealedText: text("sealed_text"),
+    failure: text("failure"),
+    performedActions: integer("performed_actions").notNull(),
+    unknownActions: integer("unknown_actions").notNull(),
+    askRecordedAt: bigint("ask_recorded_at", { mode: "number" }),
+    conversationRecordedAt: bigint("conversation_recorded_at", { mode: "number" }),
+    trigger: text("trigger"),
+    runOrigin: text("run_origin"),
+    ending: text("ending"),
+    inputTokens: integer("input_tokens"),
+    outputTokens: integer("output_tokens"),
+    inputItemKinds: text("input_item_kinds").array(),
+    transcriptBytes: integer("transcript_bytes"),
+    elapsedMs: integer("elapsed_ms"),
+    toolNames: text("tool_names").array(),
+    compacted: boolean("compacted"),
+  },
+  (table) => [
+    primaryKey({ columns: [table.userId, table.runId] }),
+    foreignKey({
+      columns: [table.userId, table.sessionId],
+      foreignColumns: [conversationSession.userId, conversationSession.sessionId],
+      name: "conversation_run_session_fk",
+    }).onDelete("cascade"),
+    index("conversation_run_by_session").on(table.userId, table.sessionId, table.ordinal),
+  ],
+);
+
+export const actionReceipt = pgTable(
+  "action_receipt",
+  {
+    userId: text("user_id").notNull(),
+    runId: text("run_id").notNull(),
+    callId: text("call_id").notNull(),
+    sessionId: text("session_id").notNull(),
+    ordinal: integer("ordinal").notNull(),
+    name: text("name").notNull(),
+    /** The action's arguments as the model wrote them. Sealed. */
+    sealedArguments: text("sealed_arguments").notNull(),
+    startedAt: bigint("started_at", { mode: "number" }).notNull(),
+    /** The action's outcome, once the performer answered. Sealed. */
+    sealedOutput: text("sealed_output"),
+    settledAt: bigint("settled_at", { mode: "number" }),
+  },
+  (table) => [
+    primaryKey({ columns: [table.userId, table.runId, table.callId] }),
+    foreignKey({
+      columns: [table.userId, table.sessionId],
+      foreignColumns: [conversationSession.userId, conversationSession.sessionId],
+      name: "action_receipt_session_fk",
+    }).onDelete("cascade"),
+    index("action_receipt_by_session").on(table.userId, table.sessionId, table.ordinal),
+  ],
+);
+
+/**
+ * The conversation's lines as the panel draws them. An append is idempotent
+ * on `event_key`, the hash of the line's own identity — its writer's id, or
+ * its value for a line that reached the store without one — so the identity
+ * of a value-keyed line, which is its words, never stands clear in an index.
+ * A run's ask and its end are each published once however many clients
+ * report them, and the partial unique index over the run and kind is what
+ * carries that rule.
+ */
+export const conversationLine = pgTable(
+  "conversation_line",
+  {
+    userId: text("user_id").notNull(),
+    sessionKey: text("session_key").notNull(),
+    sequence: bigint("sequence", { mode: "number" }).notNull(),
+    /** The generation standing at the write, for attribution alone; not a foreign key. */
+    sessionId: text("session_id"),
+    eventKey: text("event_key").notNull(),
+    kind: text("kind").notNull(),
+    recordedAt: bigint("recorded_at", { mode: "number" }).notNull(),
+    requestId: text("request_id"),
+    providerId: text("provider_id"),
+    providerSessionId: text("provider_session_id"),
+    /** The line whole, exactly the entry, so the projection is the record read back. Sealed. */
+    sealedPayload: text("sealed_payload").notNull(),
+  },
+  (table) => [
+    primaryKey({ columns: [table.userId, table.sessionKey, table.sequence] }),
+    foreignKey({
+      columns: [table.userId, table.sessionKey],
+      foreignColumns: [conversation.userId, conversation.sessionKey],
+      name: "conversation_line_conversation_fk",
+    }).onDelete("cascade"),
+    uniqueIndex("conversation_line_by_key").on(table.userId, table.sessionKey, table.eventKey),
+    index("conversation_line_by_time").on(
+      table.userId,
+      table.sessionKey,
+      table.recordedAt,
+      table.sequence,
+    ),
+    uniqueIndex("conversation_line_once_published")
+      .on(table.userId, table.sessionKey, table.requestId, table.kind)
+      .where(sql`${table.requestId} is not null`),
+  ],
+);
+
+/**
+ * The retained transcript: every input the context engine ingested and every
+ * point the projection folded, per conversation. A compaction changes the
+ * projection and erases nothing here, which is what makes the transcript the
+ * record and the checkpoint the projection.
+ */
+export const transcriptEvent = pgTable(
+  "transcript_event",
+  {
+    userId: text("user_id").notNull(),
+    sessionKey: text("session_key").notNull(),
+    sequence: bigint("sequence", { mode: "number" }).notNull(),
+    /** The generation the event was written under, for attribution alone; not a foreign key. */
+    sessionId: text("session_id"),
+    kind: text("kind").notNull(),
+    recordedAt: bigint("recorded_at", { mode: "number" }).notNull(),
+    /** The event less its kind and clock: the context input, or the boundary. Sealed. */
+    sealedPayload: text("sealed_payload").notNull(),
+  },
+  (table) => [
+    primaryKey({ columns: [table.userId, table.sessionKey, table.sequence] }),
+    foreignKey({
+      columns: [table.userId, table.sessionKey],
+      foreignColumns: [conversation.userId, conversation.sessionKey],
+      name: "transcript_event_conversation_fk",
+    }).onDelete("cascade"),
+  ],
+);
+
+export const compactionBoundary = pgTable(
+  "compaction_boundary",
+  {
+    userId: text("user_id").notNull(),
+    sessionKey: text("session_key").notNull(),
+    transcriptSequence: bigint("transcript_sequence", { mode: "number" }).notNull(),
+    sessionId: text("session_id"),
+    source: text("source").notNull(),
+    dropped: integer("dropped").notNull(),
+    checkpointFormat: text("checkpoint_format"),
+    createdAt: bigint("created_at", { mode: "number" }).notNull(),
+  },
+  (table) => [
+    primaryKey({ columns: [table.userId, table.sessionKey, table.transcriptSequence] }),
+    foreignKey({
+      columns: [table.userId, table.sessionKey],
+      foreignColumns: [conversation.userId, conversation.sessionKey],
+      name: "compaction_boundary_conversation_fk",
+    }).onDelete("cascade"),
+  ],
+);

--- a/apps/web/server/db/roster-schema.ts
+++ b/apps/web/server/db/roster-schema.ts
@@ -1,0 +1,18 @@
+import { bigint, pgTable, text } from "drizzle-orm/pg-core";
+import { user } from "./auth-schema.js";
+
+/**
+ * The latest roster one observation pass reported for a user: one row,
+ * replaced whole on every pass, so the next pass can tell a session that
+ * changed from one that merely still stands. The body carries titles,
+ * branches, and error lines, so it is sealed; the instant it was observed
+ * stands clear, because it is what decides whether the snapshot is current.
+ */
+export const rosterSnapshot = pgTable("roster_snapshot", {
+  userId: text("user_id")
+    .primaryKey()
+    .references(() => user.id, { onDelete: "cascade" }),
+  /** The roster as the pass reported it. Sealed. */
+  sealedBody: text("sealed_body").notNull(),
+  observedAt: bigint("observed_at", { mode: "number" }).notNull(),
+});

--- a/apps/web/server/db/schema.ts
+++ b/apps/web/server/db/schema.ts
@@ -1,8 +1,12 @@
 // Better Auth owns its generated schema; Luke-owned tables can join this
 // aggregate from their own schema modules without being overwritten by it.
 export * from "./auth-schema.js";
+export * from "./briefing-schema.js";
+export * from "./conversation-schema.js";
 export * from "./device-schema.js";
 export * from "./favorite-schema.js";
 export * from "./preferences-schema.js";
+export * from "./roster-schema.js";
 export * from "./usage-schema.js";
 export * from "./vault-schema.js";
+export * from "./workspace-schema.js";

--- a/apps/web/server/db/workspace-schema.ts
+++ b/apps/web/server/db/workspace-schema.ts
@@ -1,0 +1,46 @@
+import { bigint, integer, pgTable, primaryKey, text } from "drizzle-orm/pg-core";
+import { user } from "./auth-schema.js";
+
+/**
+ * The hosted brain's identity workspace and notebook, one row per user per
+ * file: the operating instructions, persona, and curated memory the desktop
+ * keeps under `agents/main/workspace`, and the dated notes under `memory/`,
+ * seeded once and edited only by the brain's own workspace tools. The path
+ * is the workspace-relative file name and stands clear; the contents are
+ * sealed, because every word of them is the developer's or the brain's.
+ */
+export const workspaceFile = pgTable(
+  "workspace_file",
+  {
+    userId: text("user_id")
+      .notNull()
+      .references(() => user.id, { onDelete: "cascade" }),
+    path: text("path").notNull(),
+    /** The file's whole contents. Sealed. */
+    sealedContent: text("sealed_content").notNull(),
+    createdAt: bigint("created_at", { mode: "number" }).notNull(),
+    updatedAt: bigint("updated_at", { mode: "number" }).notNull(),
+  },
+  (table) => [primaryKey({ columns: [table.userId, table.path] })],
+);
+
+/**
+ * The durable facts Luke keeps about the developer, in the order they were
+ * remembered. The list is replaced whole, as the desktop's fact store was, so
+ * a changed fact takes the place of the one it corrects rather than standing
+ * beside it. The words are sealed; the id is what a request to forget names.
+ */
+export const personalFact = pgTable(
+  "personal_fact",
+  {
+    userId: text("user_id")
+      .notNull()
+      .references(() => user.id, { onDelete: "cascade" }),
+    id: text("id").notNull(),
+    ordinal: integer("ordinal").notNull(),
+    /** The fact's words. Sealed. */
+    sealedWords: text("sealed_words").notNull(),
+    createdAt: bigint("created_at", { mode: "number" }).notNull(),
+  },
+  (table) => [primaryKey({ columns: [table.userId, table.id] })],
+);

--- a/apps/web/server/hosted/encryption.ts
+++ b/apps/web/server/hosted/encryption.ts
@@ -62,3 +62,73 @@ export function secretOrUnavailable(secret: string | undefined): { secret: strin
   }
   return { secret: trimmed };
 }
+
+/**
+ * A key the payload envelope may be sealed under or opened with, named by a
+ * small positive integer so a rotation can add the next key beside the last
+ * and every stored envelope still says which one opens it.
+ */
+export type PayloadKeyId = number;
+
+export const CURRENT_PAYLOAD_KEY_ID: PayloadKeyId = 1;
+
+export interface PayloadKeyRing {
+  /** The key new envelopes are sealed under. */
+  readonly current: PayloadKeyId;
+  /** Every key an envelope on record may name, the current one included; each a 64-character hex secret. */
+  readonly keys: ReadonlyMap<PayloadKeyId, string>;
+}
+
+/** The ring this build runs on: the vault's secret as key 1, and nothing older. */
+export function payloadKeyRing(secret: string): PayloadKeyRing {
+  return { current: CURRENT_PAYLOAD_KEY_ID, keys: new Map([[CURRENT_PAYLOAD_KEY_ID, secret]]) };
+}
+
+const PAYLOAD_ENVELOPE_SEPARATOR = ":";
+
+/**
+ * Seals a stored payload: `<keyId>:base64(nonce || ciphertext || authTag)`
+ * under AES-256-GCM, the key id in the clear so a later rotation can open
+ * what an earlier key sealed. `boundTo` is authenticated but not stored — the
+ * row's own user id — so an envelope lifted onto another user's row does not
+ * open there. The vault's key format is left exactly as it was: this is the
+ * variant beside it, for the conversation tables.
+ */
+export function sealPayload(plaintext: string, ring: PayloadKeyRing, boundTo: string): string {
+  const secret = ring.keys.get(ring.current);
+  if (secret === undefined) {
+    throw new Error(`the payload key ring names no key ${ring.current} to seal under`);
+  }
+  const key = secretBuffer(secret);
+  const nonce = randomBytes(NONCE_BYTES);
+  const cipher = createCipheriv(ALGORITHM, key, nonce);
+  cipher.setAAD(Buffer.from(boundTo, "utf8"));
+  const body = Buffer.concat([cipher.update(plaintext, "utf8"), cipher.final()]);
+  const tag = cipher.getAuthTag();
+  return `${ring.current}${PAYLOAD_ENVELOPE_SEPARATOR}${Buffer.concat([nonce, body, tag]).toString("base64")}`;
+}
+
+/**
+ * Opens an envelope `sealPayload` produced. Throws for a key id the ring does
+ * not hold, an envelope that is not one, and a tag that does not verify —
+ * tampering, another key, or another `boundTo` — so a caller never reads a
+ * payload the ring cannot vouch for.
+ */
+export function openPayload(sealed: string, ring: PayloadKeyRing, boundTo: string): string {
+  const separator = sealed.indexOf(PAYLOAD_ENVELOPE_SEPARATOR);
+  if (separator <= 0) throw new Error("the sealed payload names no key");
+  const keyId = Number(sealed.slice(0, separator));
+  if (!Number.isInteger(keyId) || keyId <= 0) throw new Error("the sealed payload names no key");
+  const secret = ring.keys.get(keyId);
+  if (secret === undefined) throw new Error(`the payload key ring holds no key ${keyId}`);
+  const key = secretBuffer(secret);
+  const buf = Buffer.from(sealed.slice(separator + 1), "base64");
+  if (buf.length < NONCE_BYTES + TAG_BYTES) throw new Error("the sealed payload is too short");
+  const nonce = buf.subarray(0, NONCE_BYTES);
+  const tag = buf.subarray(buf.length - TAG_BYTES);
+  const body = buf.subarray(NONCE_BYTES, buf.length - TAG_BYTES);
+  const decipher = createDecipheriv(ALGORITHM, key, nonce);
+  decipher.setAAD(Buffer.from(boundTo, "utf8"));
+  decipher.setAuthTag(tag);
+  return Buffer.concat([decipher.update(body), decipher.final()]).toString("utf8");
+}

--- a/apps/web/server/hosted/store/brain-envelope.ts
+++ b/apps/web/server/hosted/store/brain-envelope.ts
@@ -1,0 +1,504 @@
+import { and, asc, eq, gte, inArray } from "drizzle-orm";
+import type { PgColumn } from "drizzle-orm/pg-core";
+import {
+  type BrainJournalEntry,
+  type BrainObservationEntry,
+  type BrainPersistedState,
+  type BrainRequestRecord,
+  type BrainStateSave,
+  type BrainTranscriptCursors,
+  brainPersistedStateFromWire,
+  SAVE_KIND,
+  type SessionKey,
+  type WireRecord,
+  type WireValue,
+} from "../../core.js";
+import {
+  actionReceipt,
+  conversationRun,
+  conversationSession,
+  observationCaptureCursor,
+  observationCursor,
+  observationInboxEntry,
+  runtimeCheckpoint,
+} from "../../db/schema.js";
+import { clearConversationRows, touchConversation } from "./conversations.js";
+import { type HostedStoreDatabase, nullable, optionalField, type UserSeal } from "./database.js";
+import { appendTranscript } from "./transcript.js";
+
+/**
+ * The brain's envelope across the hosted tables: the standing generation
+ * and, under it, the model's checkpoint items, the transcript cursors, the
+ * inbox, the runs, and the action receipts. One generation stands per
+ * conversation per user, and replacing it cascades every row it owned away.
+ * The rows and the saves are the SQLite store's, keyed by user; what differs
+ * is that every user-derived column passes through the payload envelope on
+ * the way in and out.
+ */
+
+/** What a load answers: the standing generation's id, readable or not, and its envelope when it could be read. */
+export interface EnvelopeRead {
+  generation?: string;
+  state?: BrainPersistedState;
+  unreadable?: boolean;
+}
+
+export interface StandingGeneration {
+  sessionId: string;
+  checkpointFormat: string | undefined;
+  createdAt: number;
+  expiresAt: number;
+  resetClearedAt: number | undefined;
+  resetGenerationId: string | undefined;
+  compactionCount: number;
+}
+
+export async function standingGeneration(
+  db: HostedStoreDatabase,
+  userId: string,
+  sessionKey: SessionKey,
+): Promise<StandingGeneration | undefined> {
+  const [row] = await db
+    .select()
+    .from(conversationSession)
+    .where(
+      and(eq(conversationSession.userId, userId), eq(conversationSession.sessionKey, sessionKey)),
+    );
+  if (!row) return undefined;
+  return {
+    sessionId: row.sessionId,
+    checkpointFormat: row.checkpointFormat ?? undefined,
+    createdAt: row.createdAt,
+    expiresAt: row.expiresAt,
+    resetClearedAt: row.resetClearedAt ?? undefined,
+    resetGenerationId: row.resetGenerationId ?? undefined,
+    compactionCount: row.compactionCount,
+  };
+}
+
+/**
+ * The envelope as the tables hold it, opened and rebuilt into the envelope's
+ * wire shape and admitted by the brain's own reader, so a row this build
+ * cannot open or vouch for makes the whole generation unreadable. The
+ * standing generation's id travels beside the answer either way: it is the
+ * token a writer names to replace it, so an unreadable generation can be
+ * repaired by the store that loaded it and by nothing that did not.
+ */
+export async function loadBrainEnvelope(
+  db: HostedStoreDatabase,
+  seal: UserSeal,
+  userId: string,
+  sessionKey: SessionKey,
+): Promise<EnvelopeRead> {
+  const session = await standingGeneration(db, userId, sessionKey);
+  if (!session) return {};
+  const generation = session.sessionId;
+  const bySession = (table: { userId: PgColumn; sessionId: PgColumn }) =>
+    and(eq(table.userId, userId), eq(table.sessionId, generation));
+  const items = await db
+    .select({ sealedItem: runtimeCheckpoint.sealedItem })
+    .from(runtimeCheckpoint)
+    .where(bySession(runtimeCheckpoint))
+    .orderBy(asc(runtimeCheckpoint.sequence));
+  const cursorRows = await db.select().from(observationCursor).where(bySession(observationCursor));
+  const captureRows = await db
+    .select()
+    .from(observationCaptureCursor)
+    .where(bySession(observationCaptureCursor));
+  const inboxRows = await db
+    .select({ sealedPayload: observationInboxEntry.sealedPayload })
+    .from(observationInboxEntry)
+    .where(bySession(observationInboxEntry))
+    .orderBy(asc(observationInboxEntry.ordinal));
+  const requestRows = await db
+    .select()
+    .from(conversationRun)
+    .where(bySession(conversationRun))
+    .orderBy(asc(conversationRun.ordinal));
+  const journalRows = await db
+    .select()
+    .from(actionReceipt)
+    .where(bySession(actionReceipt))
+    .orderBy(asc(actionReceipt.ordinal));
+  let parsedItems: WireValue[];
+  let inbox: WireValue[];
+  let requests: WireRecord[];
+  let journal: WireRecord[];
+  try {
+    // SAFETY: JSON.parse returns a wire value; the envelope reader below is the validation.
+    parsedItems = items.map((row) => JSON.parse(seal.open(row.sealedItem)) as WireValue);
+    // SAFETY: as above, for the inbox entries.
+    inbox = inboxRows.map((row) => JSON.parse(seal.open(row.sealedPayload)) as WireValue);
+    requests = requestRows.map((row) => requestWire(seal, row));
+    journal = journalRows.map((row) => journalWire(seal, row));
+  } catch {
+    return { unreadable: true, generation };
+  }
+  const wire = {
+    version: 2,
+    generationId: session.sessionId,
+    createdAt: session.createdAt,
+    expiresAt: session.expiresAt,
+    ...(session.checkpointFormat !== undefined
+      ? { checkpointFormat: session.checkpointFormat }
+      : undefined),
+    items: parsedItems,
+    compactionCount: session.compactionCount,
+    cursors: cursorsFromRows(cursorRows),
+    captureCursors: cursorsFromRows(captureRows),
+    inbox,
+    requests,
+    journal,
+    ...(session.resetClearedAt !== undefined
+      ? {
+          reset: {
+            clearedAt: session.resetClearedAt,
+            ...(session.resetGenerationId !== undefined
+              ? { generationId: session.resetGenerationId }
+              : undefined),
+          },
+        }
+      : undefined),
+  } satisfies WireRecord;
+  const state = brainPersistedStateFromWire(wire);
+  return state ? { state, generation } : { unreadable: true, generation };
+}
+
+/**
+ * Makes the envelope given the one that stands, if the save's generation is
+ * the one standing: the compare-and-set every save runs. A replacement
+ * replaces the generation it expected, its rows cascading away with it; an
+ * amendment changes the generation it names. A writer naming some other
+ * generation — or none, when one stands — is stale, and is refused without
+ * anything of what it carried touching the tables. The transcript the save
+ * carries lands in the same transaction, so a checkpoint and its record of
+ * what entered the context are one write or none; and a replacement carrying
+ * the Clear's marker runs the Clear's hard delete of the conversation's rows
+ * at or before the marker's instant in that same transaction.
+ */
+export function saveBrainEnvelope(
+  db: HostedStoreDatabase,
+  seal: UserSeal,
+  userId: string,
+  sessionKey: SessionKey,
+  save: BrainStateSave,
+): Promise<boolean> {
+  return db.transaction(async (tx) => {
+    const standing = await standingGeneration(tx, userId, sessionKey);
+    if (save.kind === SAVE_KIND.REPLACE) {
+      if (standing?.sessionId !== save.expectGeneration) return false;
+      await replaceGeneration(tx, seal, userId, sessionKey, save.state);
+      await appendTranscript(
+        tx,
+        seal,
+        userId,
+        sessionKey,
+        save.state.generationId,
+        save.transcript ?? [],
+      );
+      await touchConversation(tx, userId, sessionKey, save.state.createdAt);
+      return true;
+    }
+    if (standing?.sessionId !== save.generationId) return false;
+    const { delta } = save;
+    const sessionId = save.generationId;
+    const owned = and(
+      eq(conversationSession.userId, userId),
+      eq(conversationSession.sessionId, sessionId),
+    );
+    await appendTranscript(tx, seal, userId, sessionKey, sessionId, save.transcript ?? []);
+    if (delta.checkpointFormat) {
+      await tx
+        .update(conversationSession)
+        .set({ checkpointFormat: nullable(delta.checkpointFormat.stamp) })
+        .where(owned);
+    }
+    if (delta.compactionCount !== undefined) {
+      await tx
+        .update(conversationSession)
+        .set({ compactionCount: delta.compactionCount })
+        .where(owned);
+    }
+    if (delta.items) {
+      await tx
+        .delete(runtimeCheckpoint)
+        .where(
+          and(
+            eq(runtimeCheckpoint.userId, userId),
+            eq(runtimeCheckpoint.sessionId, sessionId),
+            gte(runtimeCheckpoint.sequence, delta.items.keepPrefix),
+          ),
+        );
+      await insertItems(tx, seal, userId, sessionId, delta.items.append, delta.items.keepPrefix);
+    }
+    if (delta.cursors) {
+      await tx
+        .delete(observationCursor)
+        .where(
+          and(eq(observationCursor.userId, userId), eq(observationCursor.sessionId, sessionId)),
+        );
+      await insertCursors(tx, observationCursor, userId, sessionId, delta.cursors);
+    }
+    if (delta.captureCursors) {
+      await tx
+        .delete(observationCaptureCursor)
+        .where(
+          and(
+            eq(observationCaptureCursor.userId, userId),
+            eq(observationCaptureCursor.sessionId, sessionId),
+          ),
+        );
+      await insertCursors(tx, observationCaptureCursor, userId, sessionId, delta.captureCursors);
+    }
+    if (delta.inbox) {
+      await tx
+        .delete(observationInboxEntry)
+        .where(
+          and(
+            eq(observationInboxEntry.userId, userId),
+            eq(observationInboxEntry.sessionId, sessionId),
+          ),
+        );
+      await insertInbox(tx, seal, userId, sessionId, delta.inbox);
+    }
+    if (delta.requests) {
+      if (delta.requests.remove.length > 0) {
+        await tx
+          .delete(conversationRun)
+          .where(
+            and(
+              eq(conversationRun.userId, userId),
+              inArray(conversationRun.runId, [...delta.requests.remove]),
+            ),
+          );
+      }
+      for (const { ordinal, record } of delta.requests.upsert) {
+        await upsertRequest(tx, seal, userId, sessionId, ordinal, record);
+      }
+    }
+    if (delta.journal) {
+      for (const { runId, callId } of delta.journal.remove) {
+        await tx
+          .delete(actionReceipt)
+          .where(
+            and(
+              eq(actionReceipt.userId, userId),
+              eq(actionReceipt.runId, runId),
+              eq(actionReceipt.callId, callId),
+            ),
+          );
+      }
+      for (const { ordinal, entry } of delta.journal.upsert) {
+        await upsertJournal(tx, seal, userId, sessionId, ordinal, entry);
+      }
+    }
+    return true;
+  });
+}
+
+async function replaceGeneration(
+  db: HostedStoreDatabase,
+  seal: UserSeal,
+  userId: string,
+  sessionKey: SessionKey,
+  state: BrainPersistedState,
+): Promise<void> {
+  await db
+    .delete(conversationSession)
+    .where(
+      and(eq(conversationSession.userId, userId), eq(conversationSession.sessionKey, sessionKey)),
+    );
+  await db.insert(conversationSession).values({
+    userId,
+    sessionId: state.generationId,
+    sessionKey,
+    createdAt: state.createdAt,
+    expiresAt: state.expiresAt,
+    resetClearedAt: nullable(state.reset?.clearedAt),
+    resetGenerationId: nullable(state.reset?.generationId),
+    checkpointFormat: nullable(state.checkpointFormat),
+    compactionCount: state.compactionCount,
+  });
+  if (state.reset) await clearConversationRows(db, userId, sessionKey, state.reset.clearedAt);
+  await insertItems(db, seal, userId, state.generationId, state.items, 0);
+  await insertCursors(db, observationCursor, userId, state.generationId, state.cursors);
+  await insertCursors(
+    db,
+    observationCaptureCursor,
+    userId,
+    state.generationId,
+    state.captureCursors,
+  );
+  await insertInbox(db, seal, userId, state.generationId, state.inbox);
+  for (const [ordinal, record] of state.requests.entries()) {
+    await upsertRequest(db, seal, userId, state.generationId, ordinal, record);
+  }
+  for (const [ordinal, entry] of state.journal.entries()) {
+    await upsertJournal(db, seal, userId, state.generationId, ordinal, entry);
+  }
+}
+
+async function insertItems(
+  db: HostedStoreDatabase,
+  seal: UserSeal,
+  userId: string,
+  sessionId: string,
+  items: readonly unknown[],
+  from: number,
+): Promise<void> {
+  if (items.length === 0) return;
+  await db.insert(runtimeCheckpoint).values(
+    items.map((item, offset) => ({
+      userId,
+      sessionId,
+      sequence: from + offset,
+      sealedItem: seal.seal(JSON.stringify(item)),
+    })),
+  );
+}
+
+async function insertCursors(
+  db: HostedStoreDatabase,
+  table: typeof observationCursor | typeof observationCaptureCursor,
+  userId: string,
+  sessionId: string,
+  cursors: BrainTranscriptCursors,
+): Promise<void> {
+  const rows = Object.entries(cursors).flatMap(([providerId, sessions]) =>
+    Object.entries(sessions).map(([providerSessionId, cursor]) => ({
+      userId,
+      sessionId,
+      providerId,
+      providerSessionId,
+      cursor,
+    })),
+  );
+  if (rows.length === 0) return;
+  await db.insert(table).values(rows);
+}
+
+async function insertInbox(
+  db: HostedStoreDatabase,
+  seal: UserSeal,
+  userId: string,
+  sessionId: string,
+  inbox: readonly BrainObservationEntry[],
+): Promise<void> {
+  if (inbox.length === 0) return;
+  await db.insert(observationInboxEntry).values(
+    inbox.map((entry, ordinal) => ({
+      userId,
+      sessionId,
+      ordinal,
+      entryId: entry.id,
+      sealedPayload: seal.seal(JSON.stringify(entry)),
+    })),
+  );
+}
+
+function cursorsFromRows(
+  rows: readonly { providerId: string; providerSessionId: string; cursor: string }[],
+): BrainTranscriptCursors {
+  const cursors: Record<string, Record<string, string>> = {};
+  for (const row of rows) {
+    cursors[row.providerId] ??= {};
+    const provider = cursors[row.providerId];
+    if (provider) provider[row.providerSessionId] = row.cursor;
+  }
+  return cursors;
+}
+
+/**
+ * The record's own columns, and only those: the about-fields beside them on
+ * the run row are written by `recordRunAbout` and a record upsert leaves them
+ * as they are.
+ */
+async function upsertRequest(
+  db: HostedStoreDatabase,
+  seal: UserSeal,
+  userId: string,
+  sessionId: string,
+  ordinal: number,
+  record: BrainRequestRecord,
+): Promise<void> {
+  const columns = {
+    sessionId,
+    ordinal,
+    submissionId: record.submissionId,
+    origin: record.origin,
+    sealedQuestion: seal.seal(record.question),
+    status: record.status,
+    revision: record.revision,
+    acceptedAt: record.acceptedAt,
+    startedAt: nullable(record.startedAt),
+    settledAt: nullable(record.settledAt),
+    sealedText: record.text === undefined ? null : seal.seal(record.text),
+    failure: nullable(record.failure),
+    performedActions: record.performedActions,
+    unknownActions: record.unknownActions,
+    askRecordedAt: nullable(record.askRecordedAt),
+    conversationRecordedAt: nullable(record.conversationRecordedAt),
+  };
+  await db
+    .insert(conversationRun)
+    .values({ userId, runId: record.runId, ...columns })
+    .onConflictDoUpdate({ target: [conversationRun.userId, conversationRun.runId], set: columns });
+}
+
+async function upsertJournal(
+  db: HostedStoreDatabase,
+  seal: UserSeal,
+  userId: string,
+  sessionId: string,
+  ordinal: number,
+  entry: BrainJournalEntry,
+): Promise<void> {
+  const columns = {
+    sessionId,
+    ordinal,
+    name: entry.name,
+    sealedArguments: seal.seal(entry.argumentsJson),
+    startedAt: entry.startedAt,
+    sealedOutput: entry.outputJson === undefined ? null : seal.seal(entry.outputJson),
+    settledAt: nullable(entry.settledAt),
+  };
+  await db
+    .insert(actionReceipt)
+    .values({ userId, runId: entry.runId, callId: entry.callId, ...columns })
+    .onConflictDoUpdate({
+      target: [actionReceipt.userId, actionReceipt.runId, actionReceipt.callId],
+      set: columns,
+    });
+}
+
+function requestWire(seal: UserSeal, row: typeof conversationRun.$inferSelect): WireRecord {
+  return {
+    runId: row.runId,
+    submissionId: row.submissionId,
+    origin: row.origin,
+    question: seal.open(row.sealedQuestion),
+    status: row.status,
+    revision: row.revision,
+    acceptedAt: row.acceptedAt,
+    performedActions: row.performedActions,
+    unknownActions: row.unknownActions,
+    ...optionalField("startedAt", row.startedAt),
+    ...optionalField("settledAt", row.settledAt),
+    ...optionalField("text", row.sealedText === null ? null : seal.open(row.sealedText)),
+    ...optionalField("failure", row.failure),
+    ...optionalField("askRecordedAt", row.askRecordedAt),
+    ...optionalField("conversationRecordedAt", row.conversationRecordedAt),
+  };
+}
+
+function journalWire(seal: UserSeal, row: typeof actionReceipt.$inferSelect): WireRecord {
+  return {
+    runId: row.runId,
+    callId: row.callId,
+    name: row.name,
+    argumentsJson: seal.open(row.sealedArguments),
+    startedAt: row.startedAt,
+    ...optionalField("outputJson", row.sealedOutput === null ? null : seal.open(row.sealedOutput)),
+    ...optionalField("settledAt", row.settledAt),
+  };
+}

--- a/apps/web/server/hosted/store/brain-envelope.ts
+++ b/apps/web/server/hosted/store/brain-envelope.ts
@@ -84,7 +84,25 @@ export async function standingGeneration(
  * token a writer names to replace it, so an unreadable generation can be
  * repaired by the store that loaded it and by nothing that did not.
  */
-export async function loadBrainEnvelope(
+/**
+ * Reads the envelope in one transaction under the conversation's row lock,
+ * so a save landing meanwhile is seen whole or not at all: a handle never
+ * observes one generation's items beside another's requests, and the delta
+ * its next save carries is composed against rows that all stood together.
+ */
+export function loadBrainEnvelope(
+  db: HostedStoreDatabase,
+  seal: UserSeal,
+  userId: string,
+  sessionKey: SessionKey,
+): Promise<EnvelopeRead> {
+  return db.transaction(async (tx) => {
+    if (!(await lockConversation(tx, userId, sessionKey))) return {};
+    return readBrainEnvelope(tx, seal, userId, sessionKey);
+  });
+}
+
+async function readBrainEnvelope(
   db: HostedStoreDatabase,
   seal: UserSeal,
   userId: string,

--- a/apps/web/server/hosted/store/brain-envelope.ts
+++ b/apps/web/server/hosted/store/brain-envelope.ts
@@ -22,7 +22,7 @@ import {
   observationInboxEntry,
   runtimeCheckpoint,
 } from "../../db/schema.js";
-import { clearConversationRows, touchConversation } from "./conversations.js";
+import { clearConversationRows, lockConversation, touchConversation } from "./conversations.js";
 import { type HostedStoreDatabase, nullable, optionalField, type UserSeal } from "./database.js";
 import { appendTranscript } from "./transcript.js";
 
@@ -166,7 +166,10 @@ export async function loadBrainEnvelope(
 
 /**
  * Makes the envelope given the one that stands, if the save's generation is
- * the one standing: the compare-and-set every save runs. A replacement
+ * the one standing: the compare-and-set every save runs, under the
+ * conversation's row lock so the check and the write are one step and two
+ * writers that observed the same generation land one after the other, the
+ * second refused. A replacement
  * replaces the generation it expected, its rows cascading away with it; an
  * amendment changes the generation it names. A writer naming some other
  * generation — or none, when one stands — is stale, and is refused without
@@ -184,10 +187,11 @@ export function saveBrainEnvelope(
   save: BrainStateSave,
 ): Promise<boolean> {
   return db.transaction(async (tx) => {
+    if (!(await lockConversation(tx, userId, sessionKey))) return false;
     const standing = await standingGeneration(tx, userId, sessionKey);
     if (save.kind === SAVE_KIND.REPLACE) {
       if (standing?.sessionId !== save.expectGeneration) return false;
-      await replaceGeneration(tx, seal, userId, sessionKey, save.state);
+      await replaceGeneration(tx, seal, userId, sessionKey, standing?.sessionId, save.state);
       await appendTranscript(
         tx,
         seal,
@@ -296,18 +300,22 @@ export function saveBrainEnvelope(
   });
 }
 
+/** Replaces exactly the generation the save observed standing, under the conversation's row lock. */
 async function replaceGeneration(
   db: HostedStoreDatabase,
   seal: UserSeal,
   userId: string,
   sessionKey: SessionKey,
+  replaced: string | undefined,
   state: BrainPersistedState,
 ): Promise<void> {
-  await db
-    .delete(conversationSession)
-    .where(
-      and(eq(conversationSession.userId, userId), eq(conversationSession.sessionKey, sessionKey)),
-    );
+  if (replaced !== undefined) {
+    await db
+      .delete(conversationSession)
+      .where(
+        and(eq(conversationSession.userId, userId), eq(conversationSession.sessionId, replaced)),
+      );
+  }
   await db.insert(conversationSession).values({
     userId,
     sessionId: state.generationId,

--- a/apps/web/server/hosted/store/briefings.ts
+++ b/apps/web/server/hosted/store/briefings.ts
@@ -54,13 +54,23 @@ export interface BriefingRecord {
   readonly settledAt?: number;
 }
 
-function recordFromRow(seal: UserSeal, row: typeof briefing.$inferSelect): BriefingRecord {
+/** A row read back, or nothing for one whose words this ring cannot open; a bad row drops the row, not the list. */
+function recordFromRow(
+  seal: UserSeal,
+  row: typeof briefing.$inferSelect,
+): BriefingRecord | undefined {
+  let words: string;
+  try {
+    words = seal.open(row.sealedWords);
+  } catch {
+    return undefined;
+  }
   return {
     id: row.id,
     // SAFETY: the column holds the key the conversation row lock admitted when the briefing was recorded.
     sessionKey: row.sessionKey as SessionKey,
     ...(row.runId !== null ? { runId: row.runId } : undefined),
-    words: seal.open(row.sealedWords),
+    words,
     decidedAt: row.decidedAt,
     expiresAt: row.expiresAt,
     state: isBriefingState(row.state) ? row.state : BRIEFING_STATE.EXPIRED,
@@ -199,5 +209,5 @@ export async function listBriefings(
       and(eq(briefing.userId, userId), state !== undefined ? eq(briefing.state, state) : undefined),
     )
     .orderBy(asc(briefing.decidedAt), asc(briefing.id));
-  return rows.map((row) => recordFromRow(seal, row));
+  return rows.flatMap((row) => recordFromRow(seal, row) ?? []);
 }

--- a/apps/web/server/hosted/store/briefings.ts
+++ b/apps/web/server/hosted/store/briefings.ts
@@ -1,6 +1,7 @@
 import { and, asc, eq, gt, inArray, lte } from "drizzle-orm";
-import { isWireString, type UnparsedWireValue } from "../../core.js";
+import { isWireString, type SessionKey, type UnparsedWireValue } from "../../core.js";
 import { briefing } from "../../db/schema.js";
+import { lockConversation } from "./conversations.js";
 import type { HostedStoreDatabase, UserSeal } from "./database.js";
 
 /**
@@ -33,7 +34,7 @@ const OPEN_STATES: readonly BriefingState[] = [BRIEFING_STATE.OFFERED, BRIEFING_
 
 export interface BriefingInsert {
   readonly id: string;
-  readonly sessionKey: string;
+  readonly sessionKey: SessionKey;
   readonly runId?: string;
   readonly words: string;
   readonly decidedAt: number;
@@ -42,7 +43,7 @@ export interface BriefingInsert {
 
 export interface BriefingRecord {
   readonly id: string;
-  readonly sessionKey: string;
+  readonly sessionKey: SessionKey;
   readonly runId?: string;
   readonly words: string;
   readonly decidedAt: number;
@@ -56,7 +57,8 @@ export interface BriefingRecord {
 function recordFromRow(seal: UserSeal, row: typeof briefing.$inferSelect): BriefingRecord {
   return {
     id: row.id,
-    sessionKey: row.sessionKey,
+    // SAFETY: the column holds the key the conversation row lock admitted when the briefing was recorded.
+    sessionKey: row.sessionKey as SessionKey,
     ...(row.runId !== null ? { runId: row.runId } : undefined),
     words: seal.open(row.sealedWords),
     decidedAt: row.decidedAt,
@@ -68,28 +70,37 @@ function recordFromRow(seal: UserSeal, row: typeof briefing.$inferSelect): Brief
   };
 }
 
-/** Records a briefing the brain decided, offered from the moment it lands; an id already recorded is one briefing. */
-export async function insertBriefing(
+/**
+ * Records a briefing the brain decided, offered from the moment it lands; an
+ * id already recorded is one briefing. It runs under the conversation's row
+ * lock, the same lock the conversation's delete takes, so a briefing is
+ * recorded only for a conversation that still stands and a delete under way
+ * either takes it or was never raced.
+ */
+export function insertBriefing(
   db: HostedStoreDatabase,
   seal: UserSeal,
   userId: string,
   insert: BriefingInsert,
 ): Promise<boolean> {
-  const inserted = await db
-    .insert(briefing)
-    .values({
-      id: insert.id,
-      userId,
-      sessionKey: insert.sessionKey,
-      runId: insert.runId ?? null,
-      sealedWords: seal.seal(insert.words),
-      decidedAt: insert.decidedAt,
-      expiresAt: insert.expiresAt,
-      state: BRIEFING_STATE.OFFERED,
-    })
-    .onConflictDoNothing()
-    .returning({ id: briefing.id });
-  return inserted.length > 0;
+  return db.transaction(async (tx) => {
+    if (!(await lockConversation(tx, userId, insert.sessionKey))) return false;
+    const inserted = await tx
+      .insert(briefing)
+      .values({
+        id: insert.id,
+        userId,
+        sessionKey: insert.sessionKey,
+        runId: insert.runId ?? null,
+        sealedWords: seal.seal(insert.words),
+        decidedAt: insert.decidedAt,
+        expiresAt: insert.expiresAt,
+        state: BRIEFING_STATE.OFFERED,
+      })
+      .onConflictDoNothing()
+      .returning({ id: briefing.id });
+    return inserted.length > 0;
+  });
 }
 
 /** One device takes the briefing: only while it is offered and not yet due to expire, and only once. */

--- a/apps/web/server/hosted/store/briefings.ts
+++ b/apps/web/server/hosted/store/briefings.ts
@@ -1,0 +1,192 @@
+import { and, asc, eq, gt, inArray, lte } from "drizzle-orm";
+import { isWireString, type UnparsedWireValue } from "../../core.js";
+import { briefing } from "../../db/schema.js";
+import type { HostedStoreDatabase, UserSeal } from "./database.js";
+
+/**
+ * A briefing's life: offered to whichever device is active, claimed by one of
+ * them in one atomic update, then spoken by that device, pushed to a phone
+ * when none was active, or expired unspoken. Every transition is a
+ * conditional update on the state it leaves, so two devices racing for one
+ * briefing cannot both claim it and a late report cannot move a briefing
+ * backwards.
+ */
+export const BRIEFING_STATE = {
+  OFFERED: "offered",
+  CLAIMED: "claimed",
+  SPOKEN: "spoken",
+  PUSHED: "pushed",
+  EXPIRED: "expired",
+} as const;
+
+export type BriefingState = (typeof BRIEFING_STATE)[keyof typeof BRIEFING_STATE];
+
+const BRIEFING_STATE_LIST: readonly BriefingState[] = Object.values(BRIEFING_STATE);
+
+export function isBriefingState(value: UnparsedWireValue): value is BriefingState {
+  // SAFETY: value is a string; list membership is the vocabulary check.
+  return isWireString(value) && BRIEFING_STATE_LIST.includes(value as BriefingState);
+}
+
+/** The states a briefing may still leave: the two before anything was said of it. */
+const OPEN_STATES: readonly BriefingState[] = [BRIEFING_STATE.OFFERED, BRIEFING_STATE.CLAIMED];
+
+export interface BriefingInsert {
+  readonly id: string;
+  readonly sessionKey: string;
+  readonly runId?: string;
+  readonly words: string;
+  readonly decidedAt: number;
+  readonly expiresAt: number;
+}
+
+export interface BriefingRecord {
+  readonly id: string;
+  readonly sessionKey: string;
+  readonly runId?: string;
+  readonly words: string;
+  readonly decidedAt: number;
+  readonly expiresAt: number;
+  readonly state: BriefingState;
+  readonly claimedByDeviceId?: string;
+  readonly claimedAt?: number;
+  readonly settledAt?: number;
+}
+
+function recordFromRow(seal: UserSeal, row: typeof briefing.$inferSelect): BriefingRecord {
+  return {
+    id: row.id,
+    sessionKey: row.sessionKey,
+    ...(row.runId !== null ? { runId: row.runId } : undefined),
+    words: seal.open(row.sealedWords),
+    decidedAt: row.decidedAt,
+    expiresAt: row.expiresAt,
+    state: isBriefingState(row.state) ? row.state : BRIEFING_STATE.EXPIRED,
+    ...(row.claimedByDeviceId !== null ? { claimedByDeviceId: row.claimedByDeviceId } : undefined),
+    ...(row.claimedAt !== null ? { claimedAt: row.claimedAt } : undefined),
+    ...(row.settledAt !== null ? { settledAt: row.settledAt } : undefined),
+  };
+}
+
+/** Records a briefing the brain decided, offered from the moment it lands; an id already recorded is one briefing. */
+export async function insertBriefing(
+  db: HostedStoreDatabase,
+  seal: UserSeal,
+  userId: string,
+  insert: BriefingInsert,
+): Promise<boolean> {
+  const inserted = await db
+    .insert(briefing)
+    .values({
+      id: insert.id,
+      userId,
+      sessionKey: insert.sessionKey,
+      runId: insert.runId ?? null,
+      sealedWords: seal.seal(insert.words),
+      decidedAt: insert.decidedAt,
+      expiresAt: insert.expiresAt,
+      state: BRIEFING_STATE.OFFERED,
+    })
+    .onConflictDoNothing()
+    .returning({ id: briefing.id });
+  return inserted.length > 0;
+}
+
+/** One device takes the briefing: only while it is offered and not yet due to expire, and only once. */
+export async function claimBriefing(
+  db: HostedStoreDatabase,
+  userId: string,
+  id: string,
+  deviceId: string,
+  now: number,
+): Promise<boolean> {
+  const claimed = await db
+    .update(briefing)
+    .set({ state: BRIEFING_STATE.CLAIMED, claimedByDeviceId: deviceId, claimedAt: now })
+    .where(
+      and(
+        eq(briefing.userId, userId),
+        eq(briefing.id, id),
+        eq(briefing.state, BRIEFING_STATE.OFFERED),
+        gt(briefing.expiresAt, now),
+      ),
+    )
+    .returning({ id: briefing.id });
+  return claimed.length > 0;
+}
+
+/** The device that claimed the briefing reports it said; no other device can. */
+export async function markBriefingSpoken(
+  db: HostedStoreDatabase,
+  userId: string,
+  id: string,
+  deviceId: string,
+  now: number,
+): Promise<boolean> {
+  const spoken = await db
+    .update(briefing)
+    .set({ state: BRIEFING_STATE.SPOKEN, settledAt: now })
+    .where(
+      and(
+        eq(briefing.userId, userId),
+        eq(briefing.id, id),
+        eq(briefing.state, BRIEFING_STATE.CLAIMED),
+        eq(briefing.claimedByDeviceId, deviceId),
+      ),
+    )
+    .returning({ id: briefing.id });
+  return spoken.length > 0;
+}
+
+/** The server pushed the briefing instead: from offered, or from a claim that never became speech. */
+export async function markBriefingPushed(
+  db: HostedStoreDatabase,
+  userId: string,
+  id: string,
+  now: number,
+): Promise<boolean> {
+  const pushed = await db
+    .update(briefing)
+    .set({ state: BRIEFING_STATE.PUSHED, settledAt: now })
+    .where(
+      and(eq(briefing.userId, userId), eq(briefing.id, id), inArray(briefing.state, OPEN_STATES)),
+    )
+    .returning({ id: briefing.id });
+  return pushed.length > 0;
+}
+
+/** Expires every open briefing whose time has come, answering the ids so each can be recorded as unspoken. */
+export async function expireBriefings(
+  db: HostedStoreDatabase,
+  userId: string,
+  now: number,
+): Promise<readonly string[]> {
+  const expired = await db
+    .update(briefing)
+    .set({ state: BRIEFING_STATE.EXPIRED, settledAt: now })
+    .where(
+      and(
+        eq(briefing.userId, userId),
+        inArray(briefing.state, OPEN_STATES),
+        lte(briefing.expiresAt, now),
+      ),
+    )
+    .returning({ id: briefing.id });
+  return expired.map((row) => row.id);
+}
+
+export async function listBriefings(
+  db: HostedStoreDatabase,
+  seal: UserSeal,
+  userId: string,
+  state?: BriefingState,
+): Promise<readonly BriefingRecord[]> {
+  const rows = await db
+    .select()
+    .from(briefing)
+    .where(
+      and(eq(briefing.userId, userId), state !== undefined ? eq(briefing.state, state) : undefined),
+    )
+    .orderBy(asc(briefing.decidedAt), asc(briefing.id));
+  return rows.map((row) => recordFromRow(seal, row));
+}

--- a/apps/web/server/hosted/store/conversation-lines.ts
+++ b/apps/web/server/hosted/store/conversation-lines.ts
@@ -1,0 +1,255 @@
+import { createHash } from "node:crypto";
+import { and, desc, eq, gt, gte, lte, sql } from "drizzle-orm";
+import {
+  type ConversationAppendOutcome,
+  type ConversationEntry,
+  conversationEntryIdentity,
+  maximumStoredConversationEntries,
+  recordedAfterClear,
+  type SessionKey,
+  storedConversationEntry,
+  storedConversationMaximumAgeMs,
+  type UnparsedWireValue,
+} from "../../core.js";
+import { conversation, conversationLine } from "../../db/schema.js";
+import { standingGeneration } from "./brain-envelope.js";
+import { conversationCutoff } from "./conversations.js";
+import type { HostedStoreDatabase, UserSeal } from "./database.js";
+
+/**
+ * The conversation's lines as the panel draws them, kept apart from the
+ * brain's generation: a line names the generation that stood when it was
+ * written, for attribution alone, and answers to the thread's own retention
+ * and to the Clear rather than to the generation's replacement.
+ */
+
+/**
+ * The Clear cutoff before which no line may stand: the later of the standing
+ * generation's marker and the conversation's own durable cutoff, which
+ * outlives the generation.
+ */
+export async function conversationClearedAt(
+  db: HostedStoreDatabase,
+  userId: string,
+  sessionKey: SessionKey,
+): Promise<number | undefined> {
+  const durable = await conversationCutoff(db, userId, sessionKey);
+  const marker = (await standingGeneration(db, userId, sessionKey))?.resetClearedAt;
+  if (durable === undefined) return marker;
+  return marker === undefined ? durable : Math.max(durable, marker);
+}
+
+/**
+ * Appends lines to the conversation, idempotently. A line the thread already
+ * holds by identity is not written again — though it may now learn the run
+ * it opened — and a run's ask or end already published is not published
+ * twice however many clients report it. Each admitted line is stamped with
+ * the generation standing at the write. Nothing is removed here: stored lines
+ * answer to the Clear, and the bound is the projection's alone.
+ */
+export function appendConversationLines(
+  db: HostedStoreDatabase,
+  seal: UserSeal,
+  userId: string,
+  sessionKey: SessionKey,
+  entries: readonly ConversationEntry[],
+  now: number,
+): Promise<ConversationAppendOutcome<ConversationEntry>> {
+  return db.transaction(async (tx) => {
+    const standing = await standingGeneration(tx, userId, sessionKey);
+    const clearedAt = await conversationClearedAt(tx, userId, sessionKey);
+    let changed = false;
+    for (const entry of entries) {
+      if (!conversationEntryAdmitted(entry, now, clearedAt)) continue;
+      if (await appendOne(tx, seal, userId, sessionKey, standing?.sessionId, entry)) changed = true;
+    }
+    return { changed, entries: await listRetained(tx, seal, userId, sessionKey, now, clearedAt) };
+  });
+}
+
+async function appendOne(
+  db: HostedStoreDatabase,
+  seal: UserSeal,
+  userId: string,
+  sessionKey: SessionKey,
+  sessionId: string | undefined,
+  entry: ConversationEntry & { recordedAt: number },
+): Promise<boolean> {
+  const eventKey = conversationEventKey(entry);
+  const [held] = await db
+    .select({ sequence: conversationLine.sequence, requestId: conversationLine.requestId })
+    .from(conversationLine)
+    .where(
+      and(
+        eq(conversationLine.userId, userId),
+        eq(conversationLine.sessionKey, sessionKey),
+        eq(conversationLine.eventKey, eventKey),
+      ),
+    );
+  // A run's line of this kind already standing elsewhere refuses the update
+  // and the insert alike; asked before either, so the once-published index
+  // is the backstop rather than the path.
+  const alreadyPublished =
+    entry.requestId !== undefined &&
+    (await published(db, userId, sessionKey, entry.requestId, entry.kind));
+  if (held) {
+    if (held.requestId !== null || entry.requestId === undefined || alreadyPublished) return false;
+    await db
+      .update(conversationLine)
+      .set({ requestId: entry.requestId, sealedPayload: seal.seal(conversationPayload(entry)) })
+      .where(
+        and(
+          eq(conversationLine.userId, userId),
+          eq(conversationLine.sessionKey, sessionKey),
+          eq(conversationLine.sequence, held.sequence),
+        ),
+      );
+    return true;
+  }
+  if (alreadyPublished) return false;
+  const sequence = await nextLineSequence(db, userId, sessionKey);
+  await db.insert(conversationLine).values({
+    userId,
+    sessionKey,
+    sequence,
+    sessionId: sessionId ?? null,
+    eventKey,
+    kind: entry.kind,
+    recordedAt: entry.recordedAt,
+    requestId: entry.requestId ?? null,
+    providerId: entry.identity?.providerId ?? null,
+    providerSessionId: entry.identity?.providerSessionId ?? null,
+    sealedPayload: seal.seal(conversationPayload(entry)),
+  });
+  return true;
+}
+
+/** The conversation's next sequence, taken from its counter so a number is never handed out twice. */
+async function nextLineSequence(
+  db: HostedStoreDatabase,
+  userId: string,
+  sessionKey: SessionKey,
+): Promise<number> {
+  const [row] = await db
+    .update(conversation)
+    .set({ nextLineSequence: sql`${conversation.nextLineSequence} + 1` })
+    .where(and(eq(conversation.userId, userId), eq(conversation.sessionKey, sessionKey)))
+    .returning({ next: conversation.nextLineSequence });
+  if (!row) throw new Error(`no conversation stands at ${sessionKey}`);
+  return row.next - 1;
+}
+
+async function published(
+  db: HostedStoreDatabase,
+  userId: string,
+  sessionKey: SessionKey,
+  requestId: string,
+  kind: string,
+): Promise<boolean> {
+  const [row] = await db
+    .select({ sequence: conversationLine.sequence })
+    .from(conversationLine)
+    .where(
+      and(
+        eq(conversationLine.userId, userId),
+        eq(conversationLine.sessionKey, sessionKey),
+        eq(conversationLine.requestId, requestId),
+        eq(conversationLine.kind, kind),
+      ),
+    );
+  return row !== undefined;
+}
+
+/** The thread as the panel draws it: retained lines in the order they happened, oldest first. */
+export async function listConversationLines(
+  db: HostedStoreDatabase,
+  seal: UserSeal,
+  userId: string,
+  sessionKey: SessionKey,
+  now: number,
+): Promise<readonly ConversationEntry[]> {
+  return listRetained(
+    db,
+    seal,
+    userId,
+    sessionKey,
+    now,
+    await conversationClearedAt(db, userId, sessionKey),
+  );
+}
+
+async function listRetained(
+  db: HostedStoreDatabase,
+  seal: UserSeal,
+  userId: string,
+  sessionKey: SessionKey,
+  now: number,
+  clearedAt: number | undefined,
+): Promise<readonly ConversationEntry[]> {
+  const rows = await db
+    .select({ sealedPayload: conversationLine.sealedPayload })
+    .from(conversationLine)
+    .where(
+      and(
+        eq(conversationLine.userId, userId),
+        eq(conversationLine.sessionKey, sessionKey),
+        lte(conversationLine.recordedAt, now),
+        gte(conversationLine.recordedAt, now - storedConversationMaximumAgeMs),
+        gt(conversationLine.recordedAt, clearedAt ?? -1),
+      ),
+    )
+    .orderBy(desc(conversationLine.recordedAt), desc(conversationLine.sequence))
+    .limit(maximumStoredConversationEntries);
+  const entries: ConversationEntry[] = [];
+  for (const row of rows.reverse()) {
+    const entry = conversationEntryFromSealed(seal, row.sealedPayload);
+    if (entry) entries.push(entry);
+  }
+  return entries;
+}
+
+/** Whether a canonical line may stand now: recorded no later than now and after any Clear. */
+function conversationEntryAdmitted(
+  entry: ConversationEntry,
+  now: number,
+  clearedAt: number | undefined,
+): entry is ConversationEntry & { recordedAt: number } {
+  if (!recordedAfterClear(entry, clearedAt)) return false;
+  return entry.recordedAt <= now;
+}
+
+const EXPLICIT_EVENT_KEY_PREFIX = "event:";
+const VALUE_EVENT_KEY_PREFIX = "value:";
+
+/**
+ * What an append is idempotent on: the line's identity, prefixed by which
+ * kind it is so an id can never collide with a value key, and hashed, because
+ * a value-keyed line's identity is its words and the key column is indexed
+ * in the clear.
+ */
+function conversationEventKey(entry: ConversationEntry): string {
+  const identity = conversationEntryIdentity(entry);
+  const prefixed =
+    entry.eventId !== undefined
+      ? `${EXPLICIT_EVENT_KEY_PREFIX}${identity}`
+      : `${VALUE_EVENT_KEY_PREFIX}${identity}`;
+  return createHash("sha256").update(prefixed, "utf8").digest("hex");
+}
+
+/** The payload a line is kept as, exactly the entry, so the projection is the record read back. */
+function conversationPayload(entry: ConversationEntry): string {
+  return JSON.stringify(entry);
+}
+
+/** A payload read back, or nothing for one this build cannot open or vouch for. */
+function conversationEntryFromSealed(
+  seal: UserSeal,
+  sealedPayload: string,
+): ConversationEntry | undefined {
+  try {
+    // SAFETY: JSON.parse returns a wire value; the stored-entry reader is the validation.
+    return storedConversationEntry(JSON.parse(seal.open(sealedPayload)) as UnparsedWireValue);
+  } catch {
+    return undefined;
+  }
+}

--- a/apps/web/server/hosted/store/conversation-lines.ts
+++ b/apps/web/server/hosted/store/conversation-lines.ts
@@ -13,7 +13,7 @@ import {
 } from "../../core.js";
 import { conversation, conversationLine } from "../../db/schema.js";
 import { standingGeneration } from "./brain-envelope.js";
-import { conversationCutoff } from "./conversations.js";
+import { conversationCutoff, lockConversation } from "./conversations.js";
 import type { HostedStoreDatabase, UserSeal } from "./database.js";
 
 /**
@@ -56,6 +56,9 @@ export function appendConversationLines(
   now: number,
 ): Promise<ConversationAppendOutcome<ConversationEntry>> {
   return db.transaction(async (tx) => {
+    if (!(await lockConversation(tx, userId, sessionKey))) {
+      throw new Error(`no conversation stands at ${sessionKey}`);
+    }
     const standing = await standingGeneration(tx, userId, sessionKey);
     const clearedAt = await conversationClearedAt(tx, userId, sessionKey);
     let changed = false;
@@ -87,8 +90,10 @@ async function appendOne(
       ),
     );
   // A run's line of this kind already standing elsewhere refuses the update
-  // and the insert alike; asked before either, so the once-published index
-  // is the backstop rather than the path.
+  // and the insert alike. Asked before either, under the conversation's row
+  // lock, so the once-published index is the backstop rather than the path;
+  // an insert it still refuses reads as already stored, never as a batch
+  // rolled back.
   const alreadyPublished =
     entry.requestId !== undefined &&
     (await published(db, userId, sessionKey, entry.requestId, entry.kind));
@@ -108,20 +113,24 @@ async function appendOne(
   }
   if (alreadyPublished) return false;
   const sequence = await nextLineSequence(db, userId, sessionKey);
-  await db.insert(conversationLine).values({
-    userId,
-    sessionKey,
-    sequence,
-    sessionId: sessionId ?? null,
-    eventKey,
-    kind: entry.kind,
-    recordedAt: entry.recordedAt,
-    requestId: entry.requestId ?? null,
-    providerId: entry.identity?.providerId ?? null,
-    providerSessionId: entry.identity?.providerSessionId ?? null,
-    sealedPayload: seal.seal(conversationPayload(entry)),
-  });
-  return true;
+  const inserted = await db
+    .insert(conversationLine)
+    .values({
+      userId,
+      sessionKey,
+      sequence,
+      sessionId: sessionId ?? null,
+      eventKey,
+      kind: entry.kind,
+      recordedAt: entry.recordedAt,
+      requestId: entry.requestId ?? null,
+      providerId: entry.identity?.providerId ?? null,
+      providerSessionId: entry.identity?.providerSessionId ?? null,
+      sealedPayload: seal.seal(conversationPayload(entry)),
+    })
+    .onConflictDoNothing()
+    .returning({ sequence: conversationLine.sequence });
+  return inserted.length > 0;
 }
 
 /** The conversation's next sequence, taken from its counter so a number is never handed out twice. */

--- a/apps/web/server/hosted/store/conversations.ts
+++ b/apps/web/server/hosted/store/conversations.ts
@@ -120,6 +120,28 @@ export async function createConversation(
   return created;
 }
 
+/**
+ * Takes the conversation's row lock for the rest of the transaction, so every
+ * writer of the conversation — a checkpoint save, a Clear, a line append —
+ * runs one at a time and the standing generation it reads afterwards is the
+ * one it writes against. Postgres reads uncommitted-by-others nothing but
+ * also locks nothing on a plain read, so without this two saves that both
+ * observed one generation could both proceed. Answers whether the
+ * conversation stands.
+ */
+export async function lockConversation(
+  db: HostedStoreDatabase,
+  userId: string,
+  sessionKey: SessionKey,
+): Promise<boolean> {
+  const rows = await db
+    .select({ sessionKey: conversation.sessionKey })
+    .from(conversation)
+    .where(and(eq(conversation.userId, userId), eq(conversation.sessionKey, sessionKey)))
+    .for("update");
+  return rows.length > 0;
+}
+
 /** The conversation's durable Clear cutoff, which outlives the generation whose marker raised it. */
 export async function conversationCutoff(
   db: HostedStoreDatabase,

--- a/apps/web/server/hosted/store/conversations.ts
+++ b/apps/web/server/hosted/store/conversations.ts
@@ -7,6 +7,7 @@ import {
   type SessionKey,
 } from "../../core.js";
 import {
+  briefing,
   compactionBoundary,
   conversation,
   conversationLine,
@@ -227,15 +228,25 @@ export async function clearConversationRows(
   await raiseConversationCutoff(db, userId, sessionKey, instant);
 }
 
-/** Removes the conversation and everything under it: lines, transcript, boundaries, and the standing generation with its rows. */
-export async function deleteConversation(
+/**
+ * Removes the conversation and everything under it: lines, transcript,
+ * boundaries, the standing generation with its rows, and the briefings it
+ * decided, which hang from the user rather than the conversation row and so
+ * go here rather than by cascade.
+ */
+export function deleteConversation(
   db: HostedStoreDatabase,
   userId: string,
   sessionKey: SessionKey,
 ): Promise<boolean> {
-  const removed = await db
-    .delete(conversation)
-    .where(and(eq(conversation.userId, userId), eq(conversation.sessionKey, sessionKey)))
-    .returning({ sessionKey: conversation.sessionKey });
-  return removed.length > 0;
+  return db.transaction(async (tx) => {
+    await tx
+      .delete(briefing)
+      .where(and(eq(briefing.userId, userId), eq(briefing.sessionKey, sessionKey)));
+    const removed = await tx
+      .delete(conversation)
+      .where(and(eq(conversation.userId, userId), eq(conversation.sessionKey, sessionKey)))
+      .returning({ sessionKey: conversation.sessionKey });
+    return removed.length > 0;
+  });
 }

--- a/apps/web/server/hosted/store/conversations.ts
+++ b/apps/web/server/hosted/store/conversations.ts
@@ -232,7 +232,9 @@ export async function clearConversationRows(
  * Removes the conversation and everything under it: lines, transcript,
  * boundaries, the standing generation with its rows, and the briefings it
  * decided, which hang from the user rather than the conversation row and so
- * go here rather than by cascade.
+ * go here rather than by cascade. The conversation's row lock is taken first,
+ * so a briefing being recorded meanwhile lands before the delete and goes
+ * with it, or after and is refused.
  */
 export function deleteConversation(
   db: HostedStoreDatabase,
@@ -240,6 +242,7 @@ export function deleteConversation(
   sessionKey: SessionKey,
 ): Promise<boolean> {
   return db.transaction(async (tx) => {
+    if (!(await lockConversation(tx, userId, sessionKey))) return false;
     await tx
       .delete(briefing)
       .where(and(eq(briefing.userId, userId), eq(briefing.sessionKey, sessionKey)));

--- a/apps/web/server/hosted/store/conversations.ts
+++ b/apps/web/server/hosted/store/conversations.ts
@@ -1,0 +1,219 @@
+import { and, asc, eq, lte, sql } from "drizzle-orm";
+import {
+  type ConversationKind,
+  type ConversationRecord,
+  conversationKindOf,
+  isConversationKind,
+  type SessionKey,
+} from "../../core.js";
+import {
+  compactionBoundary,
+  conversation,
+  conversationLine,
+  conversationSession,
+  transcriptEvent,
+} from "../../db/schema.js";
+import type { HostedStoreDatabase } from "./database.js";
+
+/**
+ * The conversation directory, one per user: every logical conversation the
+ * account holds, with its kind and where it stands. A row outlives every
+ * generation that runs under it — Start fresh replaces the session and keeps
+ * the row and its lines — and is removed only by the hard delete below, which
+ * takes everything under it with it and keeps no archive.
+ */
+
+export interface ConversationCreation {
+  sessionKey: SessionKey;
+  name: string;
+  now: number;
+  /** The kind the key says it is unless the caller names one. */
+  kind?: ConversationKind;
+}
+
+type ConversationRow = {
+  sessionKey: string;
+  kind: string;
+  name: string;
+  createdAt: number;
+  lastActivityAt: number;
+  sessionId: string | null;
+};
+
+function recordFromRow(row: ConversationRow): ConversationRecord {
+  const kind: ConversationKind = isConversationKind(row.kind)
+    ? row.kind
+    : conversationKindOf(row.sessionKey);
+  return {
+    // SAFETY: the column holds the key the constructor admitted when the row was written.
+    sessionKey: row.sessionKey as SessionKey,
+    kind,
+    name: row.name,
+    createdAt: row.createdAt,
+    lastActivityAt: Math.max(row.lastActivityAt, row.createdAt),
+    ...(row.sessionId !== null ? { sessionId: row.sessionId } : undefined),
+  };
+}
+
+const CONVERSATION_COLUMNS = {
+  sessionKey: conversation.sessionKey,
+  kind: conversation.kind,
+  name: conversation.name,
+  createdAt: conversation.createdAt,
+  lastActivityAt: conversation.lastActivityAt,
+  sessionId: conversationSession.sessionId,
+};
+
+function conversationsQuery(db: HostedStoreDatabase) {
+  return db
+    .select(CONVERSATION_COLUMNS)
+    .from(conversation)
+    .leftJoin(
+      conversationSession,
+      and(
+        eq(conversationSession.userId, conversation.userId),
+        eq(conversationSession.sessionKey, conversation.sessionKey),
+      ),
+    );
+}
+
+export async function listConversations(
+  db: HostedStoreDatabase,
+  userId: string,
+): Promise<readonly ConversationRecord[]> {
+  const rows = await conversationsQuery(db)
+    .where(eq(conversation.userId, userId))
+    .orderBy(asc(conversation.createdAt), asc(conversation.sessionKey));
+  return rows.map(recordFromRow);
+}
+
+export async function conversationRecord(
+  db: HostedStoreDatabase,
+  userId: string,
+  sessionKey: SessionKey,
+): Promise<ConversationRecord | undefined> {
+  const [row] = await conversationsQuery(db).where(
+    and(eq(conversation.userId, userId), eq(conversation.sessionKey, sessionKey)),
+  );
+  return row ? recordFromRow(row) : undefined;
+}
+
+/** Creates the conversation, or answers the one already standing at the key; idempotent. */
+export async function createConversation(
+  db: HostedStoreDatabase,
+  userId: string,
+  creation: ConversationCreation,
+): Promise<ConversationRecord> {
+  await db
+    .insert(conversation)
+    .values({
+      userId,
+      sessionKey: creation.sessionKey,
+      kind: creation.kind ?? conversationKindOf(creation.sessionKey),
+      name: creation.name,
+      createdAt: creation.now,
+      lastActivityAt: creation.now,
+    })
+    .onConflictDoNothing();
+  const created = await conversationRecord(db, userId, creation.sessionKey);
+  if (!created) throw new Error(`conversation ${creation.sessionKey} was not created`);
+  return created;
+}
+
+/** The conversation's durable Clear cutoff, which outlives the generation whose marker raised it. */
+export async function conversationCutoff(
+  db: HostedStoreDatabase,
+  userId: string,
+  sessionKey: SessionKey,
+): Promise<number | undefined> {
+  const [row] = await db
+    .select({ clearedAt: conversation.clearedAt })
+    .from(conversation)
+    .where(and(eq(conversation.userId, userId), eq(conversation.sessionKey, sessionKey)));
+  return row?.clearedAt ?? undefined;
+}
+
+/** Raises the conversation's durable cutoff to `clearedAt`; never lowers it. */
+export async function raiseConversationCutoff(
+  db: HostedStoreDatabase,
+  userId: string,
+  sessionKey: SessionKey,
+  clearedAt: number,
+): Promise<void> {
+  await db
+    .update(conversation)
+    .set({
+      clearedAt: sql`greatest(coalesce(${conversation.clearedAt}, ${clearedAt}), ${clearedAt})`,
+    })
+    .where(and(eq(conversation.userId, userId), eq(conversation.sessionKey, sessionKey)));
+}
+
+/** Moves the conversation's latest activity forward to `now`; never back. */
+export async function touchConversation(
+  db: HostedStoreDatabase,
+  userId: string,
+  sessionKey: SessionKey,
+  now: number,
+): Promise<void> {
+  await db
+    .update(conversation)
+    .set({ lastActivityAt: sql`greatest(${conversation.lastActivityAt}, ${now})` })
+    .where(and(eq(conversation.userId, userId), eq(conversation.sessionKey, sessionKey)));
+}
+
+/**
+ * The Clear's erasure, and the one place the hosted store deletes a line: the
+ * lines and transcript recorded at or before the instant, and the boundaries
+ * folded by then, are removed outright, with no archive behind them, and the
+ * cutoff is raised so a late line from before the instant is refused whatever
+ * a client still holds. A line accepted after the instant is not the Clear's
+ * to take. The generation is the caller's to replace, in the same transaction.
+ */
+export async function clearConversationRows(
+  db: HostedStoreDatabase,
+  userId: string,
+  sessionKey: SessionKey,
+  instant: number,
+): Promise<void> {
+  await db
+    .delete(conversationLine)
+    .where(
+      and(
+        eq(conversationLine.userId, userId),
+        eq(conversationLine.sessionKey, sessionKey),
+        lte(conversationLine.recordedAt, instant),
+      ),
+    );
+  await db
+    .delete(compactionBoundary)
+    .where(
+      and(
+        eq(compactionBoundary.userId, userId),
+        eq(compactionBoundary.sessionKey, sessionKey),
+        lte(compactionBoundary.createdAt, instant),
+      ),
+    );
+  await db
+    .delete(transcriptEvent)
+    .where(
+      and(
+        eq(transcriptEvent.userId, userId),
+        eq(transcriptEvent.sessionKey, sessionKey),
+        lte(transcriptEvent.recordedAt, instant),
+      ),
+    );
+  await raiseConversationCutoff(db, userId, sessionKey, instant);
+}
+
+/** Removes the conversation and everything under it: lines, transcript, boundaries, and the standing generation with its rows. */
+export async function deleteConversation(
+  db: HostedStoreDatabase,
+  userId: string,
+  sessionKey: SessionKey,
+): Promise<boolean> {
+  const removed = await db
+    .delete(conversation)
+    .where(and(eq(conversation.userId, userId), eq(conversation.sessionKey, sessionKey)))
+    .returning({ sessionKey: conversation.sessionKey });
+  return removed.length > 0;
+}

--- a/apps/web/server/hosted/store/database.ts
+++ b/apps/web/server/hosted/store/database.ts
@@ -1,0 +1,45 @@
+import type { PgDatabase, PgQueryResultHKT } from "drizzle-orm/pg-core";
+import type * as schema from "../../db/schema.js";
+import { openPayload, type PayloadKeyRing, sealPayload } from "../encryption.js";
+
+/**
+ * What every table module here runs over: a Drizzle database on the hosted
+ * schema, whichever driver stands behind it — `pg` on Neon in a function,
+ * PGlite in a test — or a transaction on one, since a transaction is a
+ * database with the same query surface. The modules never name a driver,
+ * so the one store runs against both.
+ */
+export type HostedSchema = typeof schema;
+
+export type HostedStoreDatabase = PgDatabase<PgQueryResultHKT, HostedSchema>;
+
+export interface HostedStoreContext {
+  readonly db: HostedStoreDatabase;
+  readonly keys: PayloadKeyRing;
+}
+
+/**
+ * The seal and open for one user's rows, each envelope bound to that user's
+ * id, so a sealed column copied under another user does not open there.
+ */
+export interface UserSeal {
+  readonly seal: (plaintext: string) => string;
+  readonly open: (sealed: string) => string;
+}
+
+export function userSeal(keys: PayloadKeyRing, userId: string): UserSeal {
+  return {
+    seal: (plaintext) => sealPayload(plaintext, keys, userId),
+    open: (sealed) => openPayload(sealed, keys, userId),
+  };
+}
+
+/** An optional field as its nullable column takes it. */
+export function nullable<Value>(value: Value | undefined): Value | null {
+  return value === undefined ? null : value;
+}
+
+/** A nullable column as an optional field: present with its value, or absent. */
+export function optionalField<Value>(name: string, value: Value | null): Record<string, Value> {
+  return value === null ? {} : { [name]: value };
+}

--- a/apps/web/server/hosted/store/facts.ts
+++ b/apps/web/server/hosted/store/facts.ts
@@ -1,5 +1,5 @@
 import { asc, eq } from "drizzle-orm";
-import { personalFact } from "../../db/schema.js";
+import { personalFact, user } from "../../db/schema.js";
 import type { HostedStoreDatabase, UserSeal } from "./database.js";
 
 /**
@@ -42,7 +42,11 @@ export async function listFacts(
   return facts;
 }
 
-/** Replaces the list whole; a fact keeping its id keeps the instant it was first remembered. */
+/**
+ * Replaces the list whole under the user's row lock, so two replacements
+ * land one after the other rather than each deleting what it saw and both
+ * inserting; a fact keeping its id keeps the instant it was first remembered.
+ */
 export function replaceFacts(
   db: HostedStoreDatabase,
   seal: UserSeal,
@@ -51,6 +55,7 @@ export function replaceFacts(
   now: number,
 ): Promise<readonly StoredFact[]> {
   return db.transaction(async (tx) => {
+    await tx.select({ id: user.id }).from(user).where(eq(user.id, userId)).for("update");
     const held = await tx
       .select({ id: personalFact.id, createdAt: personalFact.createdAt })
       .from(personalFact)

--- a/apps/web/server/hosted/store/facts.ts
+++ b/apps/web/server/hosted/store/facts.ts
@@ -1,0 +1,73 @@
+import { asc, eq } from "drizzle-orm";
+import { personalFact } from "../../db/schema.js";
+import type { HostedStoreDatabase, UserSeal } from "./database.js";
+
+/**
+ * The durable facts Luke keeps about the developer, listed in the order they
+ * were remembered and replaced whole, so a changed fact takes the place of
+ * the one it corrects and a forgotten one is simply absent from the next
+ * list. The words are sealed; the id is what a request to forget names.
+ */
+export interface StoredFact {
+  readonly id: string;
+  readonly words: string;
+  readonly createdAt: number;
+}
+
+export interface FactWrite {
+  readonly id: string;
+  readonly words: string;
+}
+
+export async function listFacts(
+  db: HostedStoreDatabase,
+  seal: UserSeal,
+  userId: string,
+): Promise<readonly StoredFact[]> {
+  const rows = await db
+    .select()
+    .from(personalFact)
+    .where(eq(personalFact.userId, userId))
+    .orderBy(asc(personalFact.ordinal));
+  const facts: StoredFact[] = [];
+  for (const row of rows) {
+    let words: string;
+    try {
+      words = seal.open(row.sealedWords);
+    } catch {
+      continue;
+    }
+    facts.push({ id: row.id, words, createdAt: row.createdAt });
+  }
+  return facts;
+}
+
+/** Replaces the list whole; a fact keeping its id keeps the instant it was first remembered. */
+export function replaceFacts(
+  db: HostedStoreDatabase,
+  seal: UserSeal,
+  userId: string,
+  facts: readonly FactWrite[],
+  now: number,
+): Promise<readonly StoredFact[]> {
+  return db.transaction(async (tx) => {
+    const held = await tx
+      .select({ id: personalFact.id, createdAt: personalFact.createdAt })
+      .from(personalFact)
+      .where(eq(personalFact.userId, userId));
+    const remembered = new Map(held.map((row) => [row.id, row.createdAt]));
+    await tx.delete(personalFact).where(eq(personalFact.userId, userId));
+    if (facts.length > 0) {
+      await tx.insert(personalFact).values(
+        facts.map((fact, ordinal) => ({
+          userId,
+          id: fact.id,
+          ordinal,
+          sealedWords: seal.seal(fact.words),
+          createdAt: remembered.get(fact.id) ?? now,
+        })),
+      );
+    }
+    return listFacts(tx, seal, userId);
+  });
+}

--- a/apps/web/server/hosted/store/index.ts
+++ b/apps/web/server/hosted/store/index.ts
@@ -1,0 +1,234 @@
+import {
+  type BrainPersistedState,
+  type BrainStateLoad,
+  type BrainStateRepository,
+  type ConversationAppendOutcome,
+  type ConversationEntry,
+  type ConversationRecord,
+  EnvelopeTracker,
+  type SessionKey,
+  type StoredTranscriptEvent,
+  type TranscriptEvent,
+} from "../../core.js";
+import { loadBrainEnvelope, saveBrainEnvelope } from "./brain-envelope.js";
+import {
+  type BriefingInsert,
+  type BriefingRecord,
+  type BriefingState,
+  claimBriefing,
+  expireBriefings,
+  insertBriefing,
+  listBriefings,
+  markBriefingPushed,
+  markBriefingSpoken,
+} from "./briefings.js";
+import {
+  appendConversationLines,
+  conversationClearedAt,
+  listConversationLines,
+} from "./conversation-lines.js";
+import {
+  type ConversationCreation,
+  createConversation,
+  deleteConversation,
+  listConversations,
+} from "./conversations.js";
+import { type HostedStoreContext, userSeal } from "./database.js";
+import { type FactWrite, listFacts, replaceFacts, type StoredFact } from "./facts.js";
+import {
+  type RosterSnapshotRecord,
+  readRosterSnapshot,
+  writeRosterSnapshot,
+} from "./roster-snapshot.js";
+import { type RunAboutFields, recordRunAbout, runAbout } from "./run-about.js";
+import {
+  listCompactionBoundaries,
+  listTranscript,
+  type StoredCompactionBoundary,
+  type TranscriptListOptions,
+} from "./transcript.js";
+import {
+  deleteWorkspaceFile,
+  listWorkspaceFiles,
+  readWorkspaceFile,
+  seedWorkspaceFile,
+  type WorkspaceFileListing,
+  type WorkspaceFileRecord,
+  writeWorkspaceFile,
+} from "./workspace-files.js";
+
+/**
+ * The hosted conversation store: the storage contracts the desktop's SQLite
+ * store implements, over Postgres and keyed by user, so a brain host composes
+ * against it the way the desktop composes against its worker. Every method
+ * names the user whose rows it reaches, and nothing here resolves a user: the
+ * bearer seam above decides who is asking, and the store takes the answer.
+ * Each user-derived value crosses the payload envelope on its way to a row
+ * and back, bound to the user's id.
+ */
+export interface HostedStore {
+  /**
+   * The brain's envelope as a repository. Each save is a compare-and-set
+   * against the generation this handle last observed standing — loaded,
+   * readable or not, or saved — and carries only what changed, or the whole
+   * envelope when the generation itself changes. A generation whose rows
+   * could not be read is still observed by its id, so the store's repair of
+   * it lands; a save from a handle whose picture is stale answers false and
+   * changes nothing.
+   */
+  brainStateRepository(userId: string, sessionKey: SessionKey): BrainStateRepository;
+  conversations: {
+    list(userId: string): Promise<readonly ConversationRecord[]>;
+    create(userId: string, creation: ConversationCreation): Promise<ConversationRecord>;
+    /** The hard delete: the conversation and every row under it, with no archive behind them. */
+    delete(userId: string, sessionKey: SessionKey): Promise<boolean>;
+  };
+  lines: {
+    append(
+      userId: string,
+      sessionKey: SessionKey,
+      entries: readonly ConversationEntry[],
+      now: number,
+    ): Promise<ConversationAppendOutcome<ConversationEntry>>;
+    list(
+      userId: string,
+      sessionKey: SessionKey,
+      now: number,
+    ): Promise<readonly ConversationEntry[]>;
+    cutoff(userId: string, sessionKey: SessionKey): Promise<number | undefined>;
+  };
+  transcript: {
+    list(
+      userId: string,
+      sessionKey: SessionKey,
+      options?: TranscriptListOptions,
+    ): Promise<readonly StoredTranscriptEvent[]>;
+    boundaries(
+      userId: string,
+      sessionKey: SessionKey,
+    ): Promise<readonly StoredCompactionBoundary[]>;
+  };
+  runs: {
+    recordAbout(userId: string, runId: string, about: RunAboutFields): Promise<boolean>;
+    about(userId: string, runId: string): Promise<RunAboutFields | undefined>;
+  };
+  facts: {
+    list(userId: string): Promise<readonly StoredFact[]>;
+    replace(
+      userId: string,
+      facts: readonly FactWrite[],
+      now: number,
+    ): Promise<readonly StoredFact[]>;
+  };
+  workspace: {
+    read(userId: string, path: string): Promise<WorkspaceFileRecord | undefined>;
+    write(userId: string, path: string, content: string, now: number): Promise<void>;
+    seed(userId: string, path: string, content: string, now: number): Promise<boolean>;
+    delete(userId: string, path: string): Promise<boolean>;
+    list(userId: string): Promise<readonly WorkspaceFileListing[]>;
+  };
+  roster: {
+    read(userId: string): Promise<RosterSnapshotRecord | undefined>;
+    write(userId: string, snapshot: RosterSnapshotRecord): Promise<void>;
+  };
+  briefings: {
+    insert(userId: string, insert: BriefingInsert): Promise<boolean>;
+    claim(userId: string, id: string, deviceId: string, now: number): Promise<boolean>;
+    markSpoken(userId: string, id: string, deviceId: string, now: number): Promise<boolean>;
+    markPushed(userId: string, id: string, now: number): Promise<boolean>;
+    expire(userId: string, now: number): Promise<readonly string[]>;
+    list(userId: string, state?: BriefingState): Promise<readonly BriefingRecord[]>;
+  };
+}
+
+export function hostedStore({ db, keys }: HostedStoreContext): HostedStore {
+  const sealFor = (userId: string) => userSeal(keys, userId);
+  return {
+    brainStateRepository(userId, sessionKey) {
+      const seal = sealFor(userId);
+      const tracker = new EnvelopeTracker();
+      return {
+        load: async (): Promise<BrainStateLoad> => {
+          const loaded = await loadBrainEnvelope(db, seal, userId, sessionKey);
+          tracker.observe(loaded);
+          return loaded.state
+            ? { state: loaded.state }
+            : { unreadable: loaded.unreadable === true };
+        },
+        save: async (
+          state: BrainPersistedState,
+          transcript?: readonly TranscriptEvent[],
+        ): Promise<boolean> => {
+          const save = tracker.saveFor(state, transcript);
+          const landed = await saveBrainEnvelope(db, seal, userId, sessionKey, save);
+          if (landed) tracker.landed(state);
+          return landed;
+        },
+      };
+    },
+    conversations: {
+      list: (userId) => listConversations(db, userId),
+      create: (userId, creation) => createConversation(db, userId, creation),
+      delete: (userId, sessionKey) => deleteConversation(db, userId, sessionKey),
+    },
+    lines: {
+      append: (userId, sessionKey, entries, now) =>
+        appendConversationLines(db, sealFor(userId), userId, sessionKey, entries, now),
+      list: (userId, sessionKey, now) =>
+        listConversationLines(db, sealFor(userId), userId, sessionKey, now),
+      cutoff: (userId, sessionKey) => conversationClearedAt(db, userId, sessionKey),
+    },
+    transcript: {
+      list: (userId, sessionKey, options) =>
+        listTranscript(db, sealFor(userId), userId, sessionKey, options),
+      boundaries: (userId, sessionKey) => listCompactionBoundaries(db, userId, sessionKey),
+    },
+    runs: {
+      recordAbout: (userId, runId, about) => recordRunAbout(db, userId, runId, about),
+      about: (userId, runId) => runAbout(db, userId, runId),
+    },
+    facts: {
+      list: (userId) => listFacts(db, sealFor(userId), userId),
+      replace: (userId, facts, now) => replaceFacts(db, sealFor(userId), userId, facts, now),
+    },
+    workspace: {
+      read: (userId, path) => readWorkspaceFile(db, sealFor(userId), userId, path),
+      write: (userId, path, content, now) =>
+        writeWorkspaceFile(db, sealFor(userId), userId, path, content, now),
+      seed: (userId, path, content, now) =>
+        seedWorkspaceFile(db, sealFor(userId), userId, path, content, now),
+      delete: (userId, path) => deleteWorkspaceFile(db, userId, path),
+      list: (userId) => listWorkspaceFiles(db, userId),
+    },
+    roster: {
+      read: (userId) => readRosterSnapshot(db, sealFor(userId), userId),
+      write: (userId, snapshot) => writeRosterSnapshot(db, sealFor(userId), userId, snapshot),
+    },
+    briefings: {
+      insert: (userId, insert) => insertBriefing(db, sealFor(userId), userId, insert),
+      claim: (userId, id, deviceId, now) => claimBriefing(db, userId, id, deviceId, now),
+      markSpoken: (userId, id, deviceId, now) => markBriefingSpoken(db, userId, id, deviceId, now),
+      markPushed: (userId, id, now) => markBriefingPushed(db, userId, id, now),
+      expire: (userId, now) => expireBriefings(db, userId, now),
+      list: (userId, state) => listBriefings(db, sealFor(userId), userId, state),
+    },
+  };
+}
+
+export {
+  BRIEFING_STATE,
+  type BriefingInsert,
+  type BriefingRecord,
+  type BriefingState,
+} from "./briefings.js";
+export type { ConversationCreation } from "./conversations.js";
+export type { HostedStoreContext, HostedStoreDatabase } from "./database.js";
+export type { FactWrite, StoredFact } from "./facts.js";
+export type { RosterSnapshotRecord } from "./roster-snapshot.js";
+export type { RunAboutFields } from "./run-about.js";
+export type { StoredCompactionBoundary, TranscriptListOptions } from "./transcript.js";
+export {
+  isWorkspacePath,
+  type WorkspaceFileListing,
+  type WorkspaceFileRecord,
+} from "./workspace-files.js";

--- a/apps/web/server/hosted/store/roster-snapshot.ts
+++ b/apps/web/server/hosted/store/roster-snapshot.ts
@@ -1,0 +1,40 @@
+import { eq } from "drizzle-orm";
+import { rosterSnapshot } from "../../db/schema.js";
+import type { HostedStoreDatabase, UserSeal } from "./database.js";
+
+/**
+ * The latest roster an observation pass reported for a user, one row
+ * replaced whole on every pass. The body is whatever the pass serialized —
+ * titles, branches, error lines — and is sealed; the instant it was observed
+ * stands clear, because it is what decides whether the snapshot is current.
+ */
+export interface RosterSnapshotRecord {
+  readonly body: string;
+  readonly observedAt: number;
+}
+
+export async function readRosterSnapshot(
+  db: HostedStoreDatabase,
+  seal: UserSeal,
+  userId: string,
+): Promise<RosterSnapshotRecord | undefined> {
+  const [row] = await db.select().from(rosterSnapshot).where(eq(rosterSnapshot.userId, userId));
+  if (!row) return undefined;
+  return { body: seal.open(row.sealedBody), observedAt: row.observedAt };
+}
+
+export async function writeRosterSnapshot(
+  db: HostedStoreDatabase,
+  seal: UserSeal,
+  userId: string,
+  snapshot: RosterSnapshotRecord,
+): Promise<void> {
+  const sealedBody = seal.seal(snapshot.body);
+  await db
+    .insert(rosterSnapshot)
+    .values({ userId, sealedBody, observedAt: snapshot.observedAt })
+    .onConflictDoUpdate({
+      target: rosterSnapshot.userId,
+      set: { sealedBody, observedAt: snapshot.observedAt },
+    });
+}

--- a/apps/web/server/hosted/store/run-about.ts
+++ b/apps/web/server/hosted/store/run-about.ts
@@ -1,0 +1,115 @@
+import { and, eq } from "drizzle-orm";
+import {
+  BRAIN_TURN_TRIGGER,
+  type BrainTurnTrigger,
+  isRunOrigin,
+  isWireString,
+  RUN_END_REASON,
+  type RunEndReason,
+  type RunOrigin,
+  type UnparsedWireValue,
+} from "../../core.js";
+import { conversationRun } from "../../db/schema.js";
+import type { HostedStoreDatabase } from "./database.js";
+
+/**
+ * A turn's about-fields on its run row: what woke it, who opened it, how it
+ * ended, and what it counted. These are the fields the development trace
+ * records on the desktop, kept here on the run instead of in a log, and every
+ * one describes the turn without quoting it — the kinds and names are fixed
+ * vocabulary, the rest are numbers. They land after the run's record, which
+ * the envelope save owns, and a later save of that record leaves them as
+ * they are.
+ */
+export interface RunAboutFields {
+  trigger?: BrainTurnTrigger;
+  origin?: RunOrigin;
+  ending?: RunEndReason;
+  inputTokens?: number;
+  outputTokens?: number;
+  /** The kinds of item the turn appended, by their fixed names. */
+  inputItemKinds?: readonly string[];
+  transcriptBytes?: number;
+  elapsedMs?: number;
+  toolNames?: readonly string[];
+  compacted?: boolean;
+}
+
+const TRIGGER_LIST: readonly BrainTurnTrigger[] = Object.values(BRAIN_TURN_TRIGGER);
+const ENDING_LIST: readonly RunEndReason[] = Object.values(RUN_END_REASON);
+
+function isBrainTurnTrigger(value: UnparsedWireValue): value is BrainTurnTrigger {
+  // SAFETY: value is a string; list membership is the vocabulary check.
+  return isWireString(value) && TRIGGER_LIST.includes(value as BrainTurnTrigger);
+}
+
+function isRunEndReason(value: UnparsedWireValue): value is RunEndReason {
+  // SAFETY: value is a string; list membership is the vocabulary check.
+  return isWireString(value) && ENDING_LIST.includes(value as RunEndReason);
+}
+
+/** Writes the about-fields onto the run named; answers false for a run the tables do not hold. */
+export async function recordRunAbout(
+  db: HostedStoreDatabase,
+  userId: string,
+  runId: string,
+  about: RunAboutFields,
+): Promise<boolean> {
+  const updated = await db
+    .update(conversationRun)
+    .set({
+      ...(about.trigger !== undefined ? { trigger: about.trigger } : undefined),
+      ...(about.origin !== undefined ? { runOrigin: about.origin } : undefined),
+      ...(about.ending !== undefined ? { ending: about.ending } : undefined),
+      ...(about.inputTokens !== undefined ? { inputTokens: about.inputTokens } : undefined),
+      ...(about.outputTokens !== undefined ? { outputTokens: about.outputTokens } : undefined),
+      ...(about.inputItemKinds !== undefined
+        ? { inputItemKinds: [...about.inputItemKinds] }
+        : undefined),
+      ...(about.transcriptBytes !== undefined
+        ? { transcriptBytes: about.transcriptBytes }
+        : undefined),
+      ...(about.elapsedMs !== undefined ? { elapsedMs: about.elapsedMs } : undefined),
+      ...(about.toolNames !== undefined ? { toolNames: [...about.toolNames] } : undefined),
+      ...(about.compacted !== undefined ? { compacted: about.compacted } : undefined),
+    })
+    .where(and(eq(conversationRun.userId, userId), eq(conversationRun.runId, runId)))
+    .returning({ runId: conversationRun.runId });
+  return updated.length > 0;
+}
+
+/** The about-fields as the run row holds them, or nothing for a run the tables do not hold. */
+export async function runAbout(
+  db: HostedStoreDatabase,
+  userId: string,
+  runId: string,
+): Promise<RunAboutFields | undefined> {
+  const [row] = await db
+    .select({
+      trigger: conversationRun.trigger,
+      runOrigin: conversationRun.runOrigin,
+      ending: conversationRun.ending,
+      inputTokens: conversationRun.inputTokens,
+      outputTokens: conversationRun.outputTokens,
+      inputItemKinds: conversationRun.inputItemKinds,
+      transcriptBytes: conversationRun.transcriptBytes,
+      elapsedMs: conversationRun.elapsedMs,
+      toolNames: conversationRun.toolNames,
+      compacted: conversationRun.compacted,
+    })
+    .from(conversationRun)
+    .where(and(eq(conversationRun.userId, userId), eq(conversationRun.runId, runId)));
+  if (!row) return undefined;
+  return {
+    ...(isBrainTurnTrigger(row.trigger) ? { trigger: row.trigger } : undefined),
+    ...(isRunOrigin(row.runOrigin) ? { origin: row.runOrigin } : undefined),
+    ...(isRunEndReason(row.ending) ? { ending: row.ending } : undefined),
+    ...(row.inputTokens !== null ? { inputTokens: row.inputTokens } : undefined),
+    ...(row.outputTokens !== null ? { outputTokens: row.outputTokens } : undefined),
+    ...(row.inputItemKinds !== null ? { inputItemKinds: row.inputItemKinds } : undefined),
+    ...(row.transcriptBytes !== null ? { transcriptBytes: row.transcriptBytes } : undefined),
+    ...(row.elapsedMs !== null ? { elapsedMs: row.elapsedMs } : undefined),
+    ...(row.toolNames !== null ? { toolNames: row.toolNames } : undefined),
+    ...(row.compacted !== null ? { compacted: row.compacted } : undefined),
+  };
+}

--- a/apps/web/server/hosted/store/transcript.ts
+++ b/apps/web/server/hosted/store/transcript.ts
@@ -1,0 +1,170 @@
+import { and, asc, eq, gt, sql } from "drizzle-orm";
+import {
+  type SessionKey,
+  type StoredTranscriptEvent,
+  TRANSCRIPT_EVENT_KIND,
+  type TranscriptEvent,
+  transcriptEventFromPayload,
+  transcriptPayload,
+  type UnparsedWireValue,
+} from "../../core.js";
+import { compactionBoundary, conversation, transcriptEvent } from "../../db/schema.js";
+import { touchConversation } from "./conversations.js";
+import type { HostedStoreDatabase, UserSeal } from "./database.js";
+
+/**
+ * The retained transcript: every input the context engine ingested, in
+ * order, and every point the projection folded, per conversation. The rows
+ * name the generation they were written under for attribution and never
+ * cascade with it, so a Start fresh or a compaction erases nothing here; only
+ * the Clear's hard delete removes them. Nothing here reads inside a
+ * provider's item: a model's output is sealed as the opaque records it
+ * arrived as.
+ */
+
+/** Appends events under the generation named, taking the next sequences from the conversation's counter. Runs in the caller's transaction. */
+export async function appendTranscript(
+  db: HostedStoreDatabase,
+  seal: UserSeal,
+  userId: string,
+  sessionKey: SessionKey,
+  sessionId: string | undefined,
+  events: readonly TranscriptEvent[],
+): Promise<number> {
+  if (events.length === 0) return 0;
+  let latest = 0;
+  for (const event of events) {
+    const sequence = await nextTranscriptSequence(db, userId, sessionKey);
+    await db.insert(transcriptEvent).values({
+      userId,
+      sessionKey,
+      sequence,
+      sessionId: sessionId ?? null,
+      kind: event.kind,
+      recordedAt: event.recordedAt,
+      sealedPayload: seal.seal(JSON.stringify(transcriptPayload(event))),
+    });
+    if (event.kind === TRANSCRIPT_EVENT_KIND.COMPACTION) {
+      await db.insert(compactionBoundary).values({
+        userId,
+        sessionKey,
+        transcriptSequence: sequence,
+        sessionId: sessionId ?? null,
+        source: event.boundary.source,
+        dropped: event.boundary.dropped,
+        checkpointFormat: event.boundary.checkpointFormat ?? null,
+        createdAt: event.recordedAt,
+      });
+    }
+    latest = Math.max(latest, event.recordedAt);
+  }
+  await touchConversation(db, userId, sessionKey, latest);
+  return events.length;
+}
+
+async function nextTranscriptSequence(
+  db: HostedStoreDatabase,
+  userId: string,
+  sessionKey: SessionKey,
+): Promise<number> {
+  const [row] = await db
+    .update(conversation)
+    .set({ nextTranscriptSequence: sql`${conversation.nextTranscriptSequence} + 1` })
+    .where(and(eq(conversation.userId, userId), eq(conversation.sessionKey, sessionKey)))
+    .returning({ next: conversation.nextTranscriptSequence });
+  if (!row) throw new Error(`no conversation stands at ${sessionKey}`);
+  return row.next - 1;
+}
+
+export interface TranscriptListOptions {
+  afterSequence?: number;
+  limit?: number;
+}
+
+const DEFAULT_TRANSCRIPT_LIMIT = 10_000;
+
+export async function listTranscript(
+  db: HostedStoreDatabase,
+  seal: UserSeal,
+  userId: string,
+  sessionKey: SessionKey,
+  options: TranscriptListOptions = {},
+): Promise<readonly StoredTranscriptEvent[]> {
+  const rows = await db
+    .select({
+      sequence: transcriptEvent.sequence,
+      sessionId: transcriptEvent.sessionId,
+      kind: transcriptEvent.kind,
+      recordedAt: transcriptEvent.recordedAt,
+      sealedPayload: transcriptEvent.sealedPayload,
+    })
+    .from(transcriptEvent)
+    .where(
+      and(
+        eq(transcriptEvent.userId, userId),
+        eq(transcriptEvent.sessionKey, sessionKey),
+        gt(transcriptEvent.sequence, options.afterSequence ?? -1),
+      ),
+    )
+    .orderBy(asc(transcriptEvent.sequence))
+    .limit(options.limit ?? DEFAULT_TRANSCRIPT_LIMIT);
+  const events: StoredTranscriptEvent[] = [];
+  for (const row of rows) {
+    const event = transcriptEventFromSealed(seal, row.kind, row.recordedAt, row.sealedPayload);
+    if (!event) continue;
+    events.push({
+      sequence: row.sequence,
+      ...(row.sessionId !== null ? { sessionId: row.sessionId } : undefined),
+      event,
+    });
+  }
+  return events;
+}
+
+/** A row read back as an event, or nothing for one this build cannot open or vouch for; a bad row drops the row, not the transcript. */
+function transcriptEventFromSealed(
+  seal: UserSeal,
+  kind: string,
+  recordedAt: number,
+  sealedPayload: string,
+): TranscriptEvent | undefined {
+  let parsed: UnparsedWireValue;
+  try {
+    // SAFETY: JSON.parse returns a wire value; the payload reader is the validation.
+    parsed = JSON.parse(seal.open(sealedPayload)) as UnparsedWireValue;
+  } catch {
+    return undefined;
+  }
+  return transcriptEventFromPayload(kind, recordedAt, parsed);
+}
+
+export interface StoredCompactionBoundary {
+  transcriptSequence: number;
+  sessionId?: string;
+  source: string;
+  dropped: number;
+  checkpointFormat?: string;
+  createdAt: number;
+}
+
+export async function listCompactionBoundaries(
+  db: HostedStoreDatabase,
+  userId: string,
+  sessionKey: SessionKey,
+): Promise<readonly StoredCompactionBoundary[]> {
+  const rows = await db
+    .select()
+    .from(compactionBoundary)
+    .where(
+      and(eq(compactionBoundary.userId, userId), eq(compactionBoundary.sessionKey, sessionKey)),
+    )
+    .orderBy(asc(compactionBoundary.transcriptSequence));
+  return rows.map((row) => ({
+    transcriptSequence: row.transcriptSequence,
+    ...(row.sessionId !== null ? { sessionId: row.sessionId } : undefined),
+    source: row.source,
+    dropped: row.dropped,
+    ...(row.checkpointFormat !== null ? { checkpointFormat: row.checkpointFormat } : undefined),
+    createdAt: row.createdAt,
+  }));
+}

--- a/apps/web/server/hosted/store/workspace-files.ts
+++ b/apps/web/server/hosted/store/workspace-files.ts
@@ -1,0 +1,118 @@
+import { and, asc, eq } from "drizzle-orm";
+import { workspaceFile } from "../../db/schema.js";
+import type { HostedStoreDatabase, UserSeal } from "./database.js";
+
+/**
+ * The identity workspace and the notebook, one row per user per file. A path
+ * is workspace-relative and plain — no leading slash, no empty or `..`
+ * segment — so a row can never name a file outside the workspace; the
+ * contents are sealed whole and rewritten whole, the way the desktop's
+ * workspace files land through a rename.
+ */
+
+export interface WorkspaceFileRecord {
+  readonly path: string;
+  readonly content: string;
+  readonly createdAt: number;
+  readonly updatedAt: number;
+}
+
+export interface WorkspaceFileListing {
+  readonly path: string;
+  readonly updatedAt: number;
+}
+
+const PATH_SEPARATOR = "/";
+
+export function isWorkspacePath(path: string): boolean {
+  if (path.length === 0 || path.startsWith(PATH_SEPARATOR) || path.includes("\\")) return false;
+  return path
+    .split(PATH_SEPARATOR)
+    .every((segment) => segment.length > 0 && segment !== "." && segment !== "..");
+}
+
+function assertWorkspacePath(path: string): void {
+  if (!isWorkspacePath(path)) throw new Error("a workspace path is relative and names no parent");
+}
+
+export async function readWorkspaceFile(
+  db: HostedStoreDatabase,
+  seal: UserSeal,
+  userId: string,
+  path: string,
+): Promise<WorkspaceFileRecord | undefined> {
+  assertWorkspacePath(path);
+  const [row] = await db
+    .select()
+    .from(workspaceFile)
+    .where(and(eq(workspaceFile.userId, userId), eq(workspaceFile.path, path)));
+  if (!row) return undefined;
+  return {
+    path: row.path,
+    content: seal.open(row.sealedContent),
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}
+
+/** Writes the file whole, creating it or replacing it. */
+export async function writeWorkspaceFile(
+  db: HostedStoreDatabase,
+  seal: UserSeal,
+  userId: string,
+  path: string,
+  content: string,
+  now: number,
+): Promise<void> {
+  assertWorkspacePath(path);
+  const sealedContent = seal.seal(content);
+  await db
+    .insert(workspaceFile)
+    .values({ userId, path, sealedContent, createdAt: now, updatedAt: now })
+    .onConflictDoUpdate({
+      target: [workspaceFile.userId, workspaceFile.path],
+      set: { sealedContent, updatedAt: now },
+    });
+}
+
+/** Writes the file only where none stands: the seeding a launch does once, and an edit never undone by an upgrade. */
+export async function seedWorkspaceFile(
+  db: HostedStoreDatabase,
+  seal: UserSeal,
+  userId: string,
+  path: string,
+  content: string,
+  now: number,
+): Promise<boolean> {
+  assertWorkspacePath(path);
+  const inserted = await db
+    .insert(workspaceFile)
+    .values({ userId, path, sealedContent: seal.seal(content), createdAt: now, updatedAt: now })
+    .onConflictDoNothing()
+    .returning({ path: workspaceFile.path });
+  return inserted.length > 0;
+}
+
+export async function deleteWorkspaceFile(
+  db: HostedStoreDatabase,
+  userId: string,
+  path: string,
+): Promise<boolean> {
+  assertWorkspacePath(path);
+  const removed = await db
+    .delete(workspaceFile)
+    .where(and(eq(workspaceFile.userId, userId), eq(workspaceFile.path, path)))
+    .returning({ path: workspaceFile.path });
+  return removed.length > 0;
+}
+
+export async function listWorkspaceFiles(
+  db: HostedStoreDatabase,
+  userId: string,
+): Promise<readonly WorkspaceFileListing[]> {
+  return db
+    .select({ path: workspaceFile.path, updatedAt: workspaceFile.updatedAt })
+    .from(workspaceFile)
+    .where(eq(workspaceFile.userId, userId))
+    .orderBy(asc(workspaceFile.path));
+}

--- a/apps/web/tests/hosted-payload-envelope.test.ts
+++ b/apps/web/tests/hosted-payload-envelope.test.ts
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  CURRENT_PAYLOAD_KEY_ID,
+  decryptProviderKey,
+  encryptProviderKey,
+  openPayload,
+  type PayloadKeyRing,
+  payloadKeyRing,
+  sealPayload,
+} from "../server/hosted/encryption";
+
+const SECRET = "a".repeat(64);
+const NEXT_SECRET = "b".repeat(64);
+const USER = "user-1";
+
+test("a sealed payload names its key, opens under the same ring and binding, and reads as nothing without them", () => {
+  const ring = payloadKeyRing(SECRET);
+  const sealed = sealPayload("the words", ring, USER);
+
+  assert.ok(sealed.startsWith(`${CURRENT_PAYLOAD_KEY_ID}:`));
+  assert.doesNotMatch(sealed, /the words/);
+  assert.equal(openPayload(sealed, ring, USER), "the words");
+  assert.notEqual(sealPayload("the words", ring, USER), sealed);
+
+  assert.throws(() => openPayload(sealed, ring, "user-2"));
+  assert.throws(() => openPayload(sealed, payloadKeyRing(NEXT_SECRET), USER));
+  const tampered = `${sealed.slice(0, -4)}AAAA`;
+  assert.throws(() => openPayload(tampered, ring, USER));
+  assert.throws(() => openPayload(sealed.slice(2), ring, USER));
+  assert.throws(() => openPayload("", ring, USER));
+});
+
+test("a rotated ring opens what the earlier key sealed and seals under the current one", () => {
+  const first = payloadKeyRing(SECRET);
+  const sealedUnderFirst = sealPayload("kept", first, USER);
+  const rotated: PayloadKeyRing = {
+    current: 2,
+    keys: new Map([
+      [1, SECRET],
+      [2, NEXT_SECRET],
+    ]),
+  };
+
+  assert.equal(openPayload(sealedUnderFirst, rotated, USER), "kept");
+  const sealedUnderSecond = sealPayload("kept", rotated, USER);
+  assert.ok(sealedUnderSecond.startsWith("2:"));
+  assert.throws(() => openPayload(sealedUnderSecond, first, USER), /holds no key 2/);
+});
+
+test("the vault's own format is untouched: no key id, and the two envelopes do not open each other", () => {
+  const ring = payloadKeyRing(SECRET);
+  const vault = encryptProviderKey("sk-test", SECRET);
+
+  assert.doesNotMatch(vault, /^\d+:/);
+  assert.equal(decryptProviderKey(vault, SECRET), "sk-test");
+  assert.throws(() => openPayload(vault, ring, USER));
+  assert.throws(() => decryptProviderKey(sealPayload("sk-test", ring, USER), SECRET));
+});

--- a/apps/web/tests/hosted-store.test.ts
+++ b/apps/web/tests/hosted-store.test.ts
@@ -720,6 +720,14 @@ test("a briefing is offered once, claimed by one device once, settled only by it
   assert.equal((await briefings.list(userId, BRIEFING_STATE.OFFERED))[0]?.id, "briefing-4");
   const rows = await database.db.select().from(briefing).where(eq(briefing.userId, userId));
   for (const row of rows) assert.doesNotMatch(row.sealedWords, /needs you/);
+  await database.db
+    .update(briefing)
+    .set({ sealedWords: "1:not-an-envelope" })
+    .where(and(eq(briefing.userId, userId), eq(briefing.id, "briefing-2")));
+  assert.deepEqual(
+    (await briefings.list(userId)).map((record) => record.id),
+    ["briefing-1", "briefing-3", "briefing-4"],
+  );
 });
 
 test("deleting the user row cascades through every conversation table and leaves another user's rows standing", async () => {

--- a/apps/web/tests/hosted-store.test.ts
+++ b/apps/web/tests/hosted-store.test.ts
@@ -1,0 +1,780 @@
+import assert from "node:assert/strict";
+import test, { after } from "node:test";
+import {
+  BRAIN_REQUEST_ORIGIN,
+  BRAIN_REQUEST_STATUS,
+  BRAIN_TURN_TRIGGER,
+  type BrainJournalEntry,
+  type BrainPersistedState,
+  type BrainRequestRecord,
+  BrainStateStore,
+  freshBrainState,
+} from "@sidecar/brain";
+import {
+  CONVERSATION_ENTRY_KIND,
+  type ConversationEntry,
+  maximumStoredConversationEntries,
+  storedConversationMaximumAgeMs,
+} from "@sidecar/session";
+import { and, eq, getTableName, sql } from "drizzle-orm";
+import {
+  COMPACTION_SOURCE,
+  CONTEXT_INPUT_KIND,
+  MAIN_CONVERSATION_NAME,
+  MAIN_SESSION_KEY,
+  RUN_END_REASON,
+  RUN_ORIGIN,
+  SAVE_KIND,
+  type SessionKey,
+  TRANSCRIPT_EVENT_KIND,
+  type TranscriptEvent,
+  threadSessionKey,
+} from "../server/core";
+import {
+  actionReceipt,
+  briefing,
+  compactionBoundary,
+  conversation,
+  conversationLine,
+  conversationRun,
+  conversationSession,
+  observationCaptureCursor,
+  observationCursor,
+  observationInboxEntry,
+  personalFact,
+  rosterSnapshot,
+  runtimeCheckpoint,
+  transcriptEvent,
+  user,
+  workspaceFile,
+} from "../server/db/schema";
+import { payloadKeyRing } from "../server/hosted/encryption";
+import { BRIEFING_STATE } from "../server/hosted/store";
+import { loadBrainEnvelope, saveBrainEnvelope } from "../server/hosted/store/brain-envelope";
+import { userSeal } from "../server/hosted/store/database";
+import {
+  type HostedStoreTestDatabase,
+  openHostedStoreTestDatabase,
+  TEST_PAYLOAD_SECRET,
+} from "./support/hosted-store-database";
+
+/** Synthetic fixtures: no real title, branch, or transcript anywhere. */
+
+const NOW = 1_800_000_000_000;
+const THREAD_KEY = threadSessionKey("11111111-1111-4111-8111-111111111111");
+
+const opening = openHostedStoreTestDatabase();
+after(async () => {
+  await (await opening).close();
+});
+
+async function conversationFor(
+  sessionKey: SessionKey = MAIN_SESSION_KEY,
+): Promise<{ database: HostedStoreTestDatabase; userId: string }> {
+  const database = await opening;
+  const userId = await database.createUser();
+  await database.store.conversations.create(userId, {
+    sessionKey,
+    name: MAIN_CONVERSATION_NAME,
+    now: NOW,
+  });
+  return { database, userId };
+}
+
+function request(runId: string, overrides: Partial<BrainRequestRecord> = {}): BrainRequestRecord {
+  return {
+    runId,
+    submissionId: `submission-${runId}`,
+    origin: BRAIN_REQUEST_ORIGIN.TYPED,
+    question: `question for ${runId}`,
+    status: BRAIN_REQUEST_STATUS.QUEUED,
+    revision: 0,
+    acceptedAt: NOW,
+    performedActions: 0,
+    unknownActions: 0,
+    ...overrides,
+  };
+}
+
+function receipt(
+  runId: string,
+  callId: string,
+  overrides: Partial<BrainJournalEntry> = {},
+): BrainJournalEntry {
+  return {
+    runId,
+    callId,
+    name: "send_message",
+    argumentsJson: JSON.stringify({ text: "hello" }),
+    startedAt: NOW,
+    ...overrides,
+  };
+}
+
+function populatedState(generationId: string): BrainPersistedState {
+  return {
+    ...freshBrainState(generationId, NOW),
+    checkpointFormat: "tool-loop@1:openai-responses-input/1",
+    items: [
+      { type: "message", role: "user", content: "one" },
+      { type: "message", role: "assistant", content: "two" },
+    ],
+    compactionCount: 1,
+    cursors: { conductor: { "session-a": "cursor-a" } },
+    captureCursors: { conductor: { "session-a": "cursor-b" } },
+    inbox: [
+      {
+        id: "entry-1",
+        kind: "hook",
+        providerId: "conductor",
+        providerSessionId: "session-a",
+        atMs: NOW,
+        capturedAt: NOW,
+        delta: { text: "delta text", truncated: false, status: "accepted" },
+        cursor: "cursor-b",
+      },
+    ],
+    requests: [
+      request("run-1", {
+        status: BRAIN_REQUEST_STATUS.SUCCEEDED,
+        text: "reply one",
+        settledAt: NOW,
+      }),
+      request("run-2"),
+    ],
+    journal: [
+      receipt("run-1", "call-1", {
+        outputJson: JSON.stringify({ status: "accepted" }),
+        settledAt: NOW,
+      }),
+      receipt("run-2", "call-2"),
+    ],
+  };
+}
+
+function line(
+  words: string,
+  overrides: Partial<ConversationEntry> = {},
+): ConversationEntry & { recordedAt: number } {
+  return { kind: CONVERSATION_ENTRY_KIND.REPLY, words, recordedAt: NOW, ...overrides };
+}
+
+const CHECKPOINT_INPUT: TranscriptEvent = {
+  kind: TRANSCRIPT_EVENT_KIND.CONTEXT_INPUT,
+  recordedAt: NOW,
+  input: { kind: CONTEXT_INPUT_KIND.USER_TEXT, text: "an ask" },
+};
+
+const COMPACTION: TranscriptEvent = {
+  kind: TRANSCRIPT_EVENT_KIND.COMPACTION,
+  recordedAt: NOW + 1,
+  boundary: { source: COMPACTION_SOURCE.PROVIDER_EXPLICIT, dropped: 3 },
+};
+
+test("the envelope round-trips through the tables, requests and receipts in their order, every user-derived column sealed", async () => {
+  const { database, userId } = await conversationFor();
+  const repository = database.store.brainStateRepository(userId, MAIN_SESSION_KEY);
+  assert.deepEqual(await repository.load(), { unreadable: false });
+
+  const state = populatedState("gen-1");
+  assert.equal(await repository.save(state), true);
+  assert.deepEqual(await database.store.brainStateRepository(userId, MAIN_SESSION_KEY).load(), {
+    state,
+  });
+
+  const [runRow] = await database.db
+    .select()
+    .from(conversationRun)
+    .where(and(eq(conversationRun.userId, userId), eq(conversationRun.runId, "run-1")));
+  assert.ok(runRow);
+  assert.doesNotMatch(runRow.sealedQuestion, /question for/);
+  assert.doesNotMatch(runRow.sealedText ?? "", /reply one/);
+  const [itemRow] = await database.db
+    .select()
+    .from(runtimeCheckpoint)
+    .where(eq(runtimeCheckpoint.userId, userId));
+  assert.ok(itemRow);
+  assert.doesNotMatch(itemRow.sealedItem, /assistant|one/);
+  const [inboxRow] = await database.db
+    .select()
+    .from(observationInboxEntry)
+    .where(eq(observationInboxEntry.userId, userId));
+  assert.ok(inboxRow);
+  assert.doesNotMatch(inboxRow.sealedPayload, /delta text/);
+  assert.equal(inboxRow.entryId, "entry-1");
+});
+
+test("deltas leave the tables holding exactly the envelope given, checkpoint by checkpoint", async () => {
+  const { database, userId } = await conversationFor();
+  const repository = database.store.brainStateRepository(userId, MAIN_SESSION_KEY);
+  await repository.load();
+  const first = populatedState("gen-1");
+  assert.equal(await repository.save(first), true);
+
+  const second: BrainPersistedState = {
+    ...first,
+    items: [first.items[0] ?? {}, { type: "message", role: "assistant", content: "changed" }],
+    compactionCount: 2,
+    cursors: { conductor: { "session-a": "cursor-c", "session-b": "cursor-d" } },
+    inbox: [],
+    requests: [
+      {
+        ...request("run-1", { status: BRAIN_REQUEST_STATUS.SUCCEEDED, text: "reply one" }),
+        revision: 1,
+      },
+      request("run-3"),
+    ],
+    journal: [receipt("run-3", "call-3")],
+  };
+  assert.equal(await repository.save(second), true);
+  const fresh = database.store.brainStateRepository(userId, MAIN_SESSION_KEY);
+  assert.deepEqual(await fresh.load(), { state: second });
+
+  const runs = await database.db
+    .select({ runId: conversationRun.runId })
+    .from(conversationRun)
+    .where(eq(conversationRun.userId, userId));
+  assert.deepEqual(runs.map((row) => row.runId).sort(), ["run-1", "run-3"]);
+});
+
+test("a stale handle cannot save over a newer generation, whole or by delta, and stays refused until it loads again", async () => {
+  const { database, userId } = await conversationFor();
+  const first = database.store.brainStateRepository(userId, MAIN_SESSION_KEY);
+  const second = database.store.brainStateRepository(userId, MAIN_SESSION_KEY);
+  await first.load();
+  await second.load();
+  assert.equal(await first.save(populatedState("gen-1")), true);
+
+  assert.equal(await second.save(populatedState("gen-2")), false);
+  assert.equal(await second.save({ ...populatedState("gen-1"), compactionCount: 9 }), false);
+  assert.equal((await first.load()).state?.generationId, "gen-1");
+
+  await second.load();
+  assert.equal(await second.save(populatedState("gen-2")), true);
+  assert.equal(await first.save({ ...populatedState("gen-1"), compactionCount: 9 }), false);
+  assert.equal((await second.load()).state?.generationId, "gen-2");
+});
+
+test("a generation whose rows cannot be opened is unreadable and is repaired by the store that observed it, by no stale writer", async () => {
+  const { database, userId } = await conversationFor();
+  const stale = database.store.brainStateRepository(userId, MAIN_SESSION_KEY);
+  await stale.load();
+  const writer = database.store.brainStateRepository(userId, MAIN_SESSION_KEY);
+  await writer.load();
+  assert.equal(await writer.save(populatedState("gen-1")), true);
+
+  await database.db
+    .update(runtimeCheckpoint)
+    .set({ sealedItem: "1:not-an-envelope" })
+    .where(eq(runtimeCheckpoint.userId, userId));
+
+  const observer = database.store.brainStateRepository(userId, MAIN_SESSION_KEY);
+  assert.deepEqual(await observer.load(), { unreadable: true });
+  assert.equal(await stale.save(populatedState("gen-stale")), false);
+  assert.equal(await observer.save(populatedState("gen-2")), true);
+  assert.deepEqual(await database.store.brainStateRepository(userId, MAIN_SESSION_KEY).load(), {
+    state: populatedState("gen-2"),
+  });
+});
+
+test("the BrainStateStore keeps its fence and Clear guarantees over the hosted repository, and the Clear hard-deletes the lines at or before it", async () => {
+  const { database, userId } = await conversationFor();
+  const store = new BrainStateStore({
+    repository: database.store.brainStateRepository(userId, MAIN_SESSION_KEY),
+    createGenerationId: () => "gen-fresh",
+    now: () => NOW + 10,
+  });
+  const loaded = await store.load();
+  assert.equal(loaded.generationId, "gen-fresh");
+  await store.flush();
+
+  const before = await database.store.lines.append(
+    userId,
+    MAIN_SESSION_KEY,
+    [line("before the clear", { eventId: "line-1" })],
+    NOW + 10,
+  );
+  assert.equal(before.entries.length, 1);
+
+  assert.equal(await store.clear(NOW + 20), true);
+  assert.deepEqual(store.resetMarker(), { clearedAt: NOW + 20, generationId: "gen-fresh" });
+  assert.equal(await database.store.lines.cutoff(userId, MAIN_SESSION_KEY), NOW + 20);
+  const rows = await database.db
+    .select()
+    .from(conversationLine)
+    .where(eq(conversationLine.userId, userId));
+  assert.equal(rows.length, 0);
+
+  const late = await database.store.lines.append(
+    userId,
+    MAIN_SESSION_KEY,
+    [
+      line("from before, arriving late", { eventId: "line-2", recordedAt: NOW + 15 }),
+      line("after the clear", { eventId: "line-3", recordedAt: NOW + 25 }),
+    ],
+    NOW + 30,
+  );
+  assert.deepEqual(
+    late.entries.map((entry) => entry.words),
+    ["after the clear"],
+  );
+
+  assert.equal(await store.reset(NOW + 40), true);
+  assert.equal(store.resetMarker(), undefined);
+  assert.deepEqual(
+    (await database.store.lines.list(userId, MAIN_SESSION_KEY, NOW + 50)).map((e) => e.words),
+    ["after the clear"],
+  );
+  assert.equal(await database.store.lines.cutoff(userId, MAIN_SESSION_KEY), NOW + 20);
+});
+
+test("line appends are idempotent on the line's own id, a line learns its run, and a run's line of a kind is published once", async () => {
+  const { database, userId } = await conversationFor();
+  const lines = database.store.lines;
+
+  const first = await lines.append(
+    userId,
+    MAIN_SESSION_KEY,
+    [line("said once", { eventId: "line-1" }), line("said once", { eventId: "line-2" })],
+    NOW,
+  );
+  assert.equal(first.changed, true);
+  assert.equal(first.entries.length, 2);
+  const again = await lines.append(
+    userId,
+    MAIN_SESSION_KEY,
+    [line("said once", { eventId: "line-1" })],
+    NOW,
+  );
+  assert.equal(again.changed, false);
+  assert.equal(again.entries.length, 2);
+
+  const valued = await lines.append(userId, MAIN_SESSION_KEY, [line("no id"), line("no id")], NOW);
+  assert.equal(valued.entries.filter((entry) => entry.words === "no id").length, 1);
+
+  const learned = await lines.append(
+    userId,
+    MAIN_SESSION_KEY,
+    [line("said once", { eventId: "line-1", requestId: "run-1" })],
+    NOW,
+  );
+  assert.equal(learned.changed, true);
+  assert.equal(learned.entries.find((entry) => entry.eventId === "line-1")?.requestId, "run-1");
+
+  const republished = await lines.append(
+    userId,
+    MAIN_SESSION_KEY,
+    [line("a second reply for the run", { eventId: "line-9", requestId: "run-1" })],
+    NOW,
+  );
+  assert.equal(republished.changed, false);
+  assert.equal(
+    republished.entries.some((entry) => entry.eventId === "line-9"),
+    false,
+  );
+
+  const keyRows = await database.db
+    .select({ eventKey: conversationLine.eventKey, sealedPayload: conversationLine.sealedPayload })
+    .from(conversationLine)
+    .where(eq(conversationLine.userId, userId));
+  for (const row of keyRows) {
+    assert.match(row.eventKey, /^[0-9a-f]{64}$/);
+    assert.doesNotMatch(row.sealedPayload, /said once|no id/);
+  }
+});
+
+test("the sequence counts up and is never reused, and the projection keeps 200 recent lines under the age bound", async () => {
+  const { database, userId } = await conversationFor();
+  const entries = Array.from({ length: maximumStoredConversationEntries + 5 }, (_, index) =>
+    line(`line ${index}`, { eventId: `line-${index}`, recordedAt: NOW + index }),
+  );
+  entries.push(
+    line("too old", { eventId: "old", recordedAt: NOW - storedConversationMaximumAgeMs }),
+  );
+  const outcome = await database.store.lines.append(userId, MAIN_SESSION_KEY, entries, NOW + 1000);
+  assert.equal(outcome.entries.length, maximumStoredConversationEntries);
+  assert.equal(outcome.entries[0]?.words, "line 5");
+  assert.equal(outcome.entries.at(-1)?.words, `line ${maximumStoredConversationEntries + 4}`);
+
+  const [row] = await database.db
+    .select({ next: conversation.nextLineSequence })
+    .from(conversation)
+    .where(and(eq(conversation.userId, userId), eq(conversation.sessionKey, MAIN_SESSION_KEY)));
+  assert.equal(row?.next, entries.length + 1);
+  const stored = await database.db
+    .select({ count: sql<number>`count(*)::int` })
+    .from(conversationLine)
+    .where(eq(conversationLine.userId, userId));
+  assert.equal(stored[0]?.count, entries.length);
+});
+
+test("a checkpoint's transcript lands in the same transaction as the envelope, a compaction keeps the record and the boundary, and Start fresh keeps both", async () => {
+  const { database, userId } = await conversationFor();
+  const repository = database.store.brainStateRepository(userId, MAIN_SESSION_KEY);
+  await repository.load();
+  const state = populatedState("gen-1");
+  assert.equal(await repository.save(state, [CHECKPOINT_INPUT, COMPACTION]), true);
+
+  const transcript = await database.store.transcript.list(userId, MAIN_SESSION_KEY);
+  assert.deepEqual(
+    transcript.map((stored) => ({
+      sequence: stored.sequence,
+      sessionId: stored.sessionId,
+      kind: stored.event.kind,
+    })),
+    [
+      { sequence: 1, sessionId: "gen-1", kind: TRANSCRIPT_EVENT_KIND.CONTEXT_INPUT },
+      { sequence: 2, sessionId: "gen-1", kind: TRANSCRIPT_EVENT_KIND.COMPACTION },
+    ],
+  );
+  assert.deepEqual(transcript[0]?.event, CHECKPOINT_INPUT);
+  assert.deepEqual(await database.store.transcript.boundaries(userId, MAIN_SESSION_KEY), [
+    {
+      transcriptSequence: 2,
+      sessionId: "gen-1",
+      source: COMPACTION_SOURCE.PROVIDER_EXPLICIT,
+      dropped: 3,
+      createdAt: NOW + 1,
+    },
+  ]);
+  const [eventRow] = await database.db
+    .select()
+    .from(transcriptEvent)
+    .where(eq(transcriptEvent.userId, userId));
+  assert.doesNotMatch(eventRow?.sealedPayload ?? "", /an ask/);
+
+  const refused = database.store.brainStateRepository(userId, MAIN_SESSION_KEY);
+  assert.equal(await refused.save(populatedState("gen-x"), [CHECKPOINT_INPUT]), false);
+  assert.equal((await database.store.transcript.list(userId, MAIN_SESSION_KEY)).length, 2);
+
+  assert.equal(await repository.save(freshBrainState("gen-2", NOW + 5)), true);
+  assert.equal((await database.store.transcript.list(userId, MAIN_SESSION_KEY)).length, 2);
+  assert.equal(
+    (await database.store.transcript.list(userId, MAIN_SESSION_KEY, { afterSequence: 1 })).length,
+    1,
+  );
+  const rows = await database.db
+    .select({ count: sql<number>`count(*)::int` })
+    .from(runtimeCheckpoint)
+    .where(eq(runtimeCheckpoint.userId, userId));
+  assert.equal(rows[0]?.count, 0);
+});
+
+test("the conversation directory lists what the user holds, creation is idempotent, and the hard delete takes every row under it", async () => {
+  const { database, userId } = await conversationFor();
+  const other = await database.createUser();
+  await database.store.conversations.create(other, {
+    sessionKey: MAIN_SESSION_KEY,
+    name: MAIN_CONVERSATION_NAME,
+    now: NOW,
+  });
+  const created = await database.store.conversations.create(userId, {
+    sessionKey: THREAD_KEY,
+    name: "a thread",
+    now: NOW + 1,
+  });
+  const again = await database.store.conversations.create(userId, {
+    sessionKey: THREAD_KEY,
+    name: "renamed by a retry",
+    now: NOW + 2,
+  });
+  assert.deepEqual(again, created);
+  assert.deepEqual(
+    (await database.store.conversations.list(userId)).map((record) => [
+      record.sessionKey,
+      record.kind,
+      record.name,
+    ]),
+    [
+      [MAIN_SESSION_KEY, "main", MAIN_CONVERSATION_NAME],
+      [THREAD_KEY, "thread", "a thread"],
+    ],
+  );
+
+  const repository = database.store.brainStateRepository(userId, THREAD_KEY);
+  await repository.load();
+  await repository.save(populatedState("gen-thread"), [CHECKPOINT_INPUT, COMPACTION]);
+  await database.store.lines.append(
+    userId,
+    THREAD_KEY,
+    [line("in the thread", { eventId: "t-1" })],
+    NOW,
+  );
+  assert.equal((await database.store.conversations.list(userId))[1]?.sessionId, "gen-thread");
+
+  assert.equal(await database.store.conversations.delete(userId, THREAD_KEY), true);
+  assert.equal(await database.store.conversations.delete(userId, THREAD_KEY), false);
+  assert.equal((await database.store.conversations.list(userId)).length, 1);
+  for (const table of [conversationLine, transcriptEvent, compactionBoundary]) {
+    const rows = await database.db
+      .select({ count: sql<number>`count(*)::int` })
+      .from(table)
+      .where(and(eq(table.userId, userId), eq(table.sessionKey, THREAD_KEY)));
+    assert.equal(rows[0]?.count, 0);
+  }
+  const sessions = await database.db
+    .select()
+    .from(conversationSession)
+    .where(eq(conversationSession.userId, userId));
+  assert.equal(sessions.length, 0);
+  assert.equal((await database.store.conversations.list(other)).length, 1);
+});
+
+test("a run's about-fields land on its row, survive a record upsert, and answer nothing for a run the tables do not hold", async () => {
+  const { database, userId } = await conversationFor();
+  const repository = database.store.brainStateRepository(userId, MAIN_SESSION_KEY);
+  await repository.load();
+  const state = populatedState("gen-1");
+  await repository.save(state);
+
+  assert.deepEqual(await database.store.runs.about(userId, "run-1"), {});
+  assert.equal(await database.store.runs.about(userId, "run-missing"), undefined);
+  const about = {
+    trigger: BRAIN_TURN_TRIGGER.ASK,
+    origin: RUN_ORIGIN.USER,
+    ending: RUN_END_REASON.COMPLETED,
+    inputTokens: 1200,
+    outputTokens: 80,
+    inputItemKinds: ["message", "function_call"],
+    transcriptBytes: 4096,
+    elapsedMs: 2500,
+    toolNames: ["send_message", "read_transcript"],
+    compacted: false,
+  };
+  assert.equal(await database.store.runs.recordAbout(userId, "run-1", about), true);
+  assert.deepEqual(await database.store.runs.about(userId, "run-1"), about);
+  assert.equal(await database.store.runs.recordAbout(userId, "run-missing", about), false);
+
+  await repository.save({
+    ...state,
+    requests: state.requests.map((record) =>
+      record.runId === "run-1" ? { ...record, revision: 2, text: "amended" } : record,
+    ),
+  });
+  assert.deepEqual(await database.store.runs.about(userId, "run-1"), about);
+  assert.equal(
+    (await repository.load()).state?.requests.find((record) => record.runId === "run-1")?.text,
+    "amended",
+  );
+});
+
+test("facts are listed in order and replaced whole, a kept id keeping its first instant, and sealed at rest", async () => {
+  const { database, userId } = await conversationFor();
+  assert.deepEqual(await database.store.facts.list(userId), []);
+  const first = await database.store.facts.replace(
+    userId,
+    [
+      { id: "fact-1", words: "prefers short replies" },
+      { id: "fact-2", words: "works in the mornings" },
+    ],
+    NOW,
+  );
+  assert.deepEqual(first, [
+    { id: "fact-1", words: "prefers short replies", createdAt: NOW },
+    { id: "fact-2", words: "works in the mornings", createdAt: NOW },
+  ]);
+  const second = await database.store.facts.replace(
+    userId,
+    [
+      { id: "fact-3", words: "uses a standing desk" },
+      { id: "fact-1", words: "prefers short replies" },
+    ],
+    NOW + 5,
+  );
+  assert.deepEqual(second, [
+    { id: "fact-3", words: "uses a standing desk", createdAt: NOW + 5 },
+    { id: "fact-1", words: "prefers short replies", createdAt: NOW },
+  ]);
+  const rows = await database.db.select().from(personalFact).where(eq(personalFact.userId, userId));
+  for (const row of rows) assert.doesNotMatch(row.sealedWords, /prefers|standing/);
+});
+
+test("workspace files are read and written whole per user and path, seeded once, and refuse a path outside the workspace", async () => {
+  const { database, userId } = await conversationFor();
+  const workspace = database.store.workspace;
+  assert.equal(await workspace.read(userId, "AGENTS.md"), undefined);
+  assert.equal(await workspace.seed(userId, "AGENTS.md", "# seed", NOW), true);
+  assert.equal(await workspace.seed(userId, "AGENTS.md", "# a later seed", NOW + 1), false);
+  await workspace.write(userId, "memory/2026-09-09.md", "- a note", NOW + 2);
+  await workspace.write(userId, "AGENTS.md", "# edited", NOW + 3);
+  assert.deepEqual(await workspace.read(userId, "AGENTS.md"), {
+    path: "AGENTS.md",
+    content: "# edited",
+    createdAt: NOW,
+    updatedAt: NOW + 3,
+  });
+  assert.deepEqual(await workspace.list(userId), [
+    { path: "AGENTS.md", updatedAt: NOW + 3 },
+    { path: "memory/2026-09-09.md", updatedAt: NOW + 2 },
+  ]);
+  for (const path of ["/etc/passwd", "../SOUL.md", "memory/../../x", "", "a//b", "a\\b"]) {
+    await assert.rejects(workspace.write(userId, path, "x", NOW), /workspace path/);
+    await assert.rejects(workspace.read(userId, path), /workspace path/);
+  }
+  assert.equal(await workspace.delete(userId, "memory/2026-09-09.md"), true);
+  assert.equal(await workspace.delete(userId, "memory/2026-09-09.md"), false);
+  const rows = await database.db
+    .select()
+    .from(workspaceFile)
+    .where(eq(workspaceFile.userId, userId));
+  assert.equal(rows.length, 1);
+  assert.doesNotMatch(rows[0]?.sealedContent ?? "", /edited/);
+
+  const other = await database.createUser();
+  assert.equal(await workspace.read(other, "AGENTS.md"), undefined);
+});
+
+test("the roster snapshot is one sealed row per user, replaced whole", async () => {
+  const { database, userId } = await conversationFor();
+  assert.equal(await database.store.roster.read(userId), undefined);
+  await database.store.roster.write(userId, {
+    body: JSON.stringify({ sessions: ["a"] }),
+    observedAt: NOW,
+  });
+  await database.store.roster.write(userId, {
+    body: JSON.stringify({ sessions: ["b"] }),
+    observedAt: NOW + 1,
+  });
+  assert.deepEqual(await database.store.roster.read(userId), {
+    body: JSON.stringify({ sessions: ["b"] }),
+    observedAt: NOW + 1,
+  });
+  const rows = await database.db
+    .select()
+    .from(rosterSnapshot)
+    .where(eq(rosterSnapshot.userId, userId));
+  assert.equal(rows.length, 1);
+  assert.doesNotMatch(rows[0]?.sealedBody ?? "", /sessions/);
+});
+
+test("a briefing is offered once, claimed by one device once, settled only by its claimer or the push, and expired when its time comes", async () => {
+  const { database, userId } = await conversationFor();
+  const briefings = database.store.briefings;
+  const offered = {
+    id: "briefing-1",
+    sessionKey: MAIN_SESSION_KEY,
+    runId: "run-1",
+    words: "a session needs you",
+    decidedAt: NOW,
+    expiresAt: NOW + 60_000,
+  };
+  assert.equal(await briefings.insert(userId, offered), true);
+  assert.equal(await briefings.insert(userId, offered), false);
+  assert.deepEqual(await briefings.list(userId, BRIEFING_STATE.OFFERED), [
+    { ...offered, state: BRIEFING_STATE.OFFERED },
+  ]);
+
+  assert.equal(await briefings.markSpoken(userId, "briefing-1", "mac", NOW + 1), false);
+  assert.equal(await briefings.claim(userId, "briefing-1", "mac", NOW + 1), true);
+  assert.equal(await briefings.claim(userId, "briefing-1", "phone", NOW + 2), false);
+  assert.equal(await briefings.markSpoken(userId, "briefing-1", "phone", NOW + 3), false);
+  assert.equal(await briefings.markSpoken(userId, "briefing-1", "mac", NOW + 3), true);
+  assert.equal(await briefings.markPushed(userId, "briefing-1", NOW + 4), false);
+  assert.deepEqual(await briefings.list(userId), [
+    {
+      ...offered,
+      state: BRIEFING_STATE.SPOKEN,
+      claimedByDeviceId: "mac",
+      claimedAt: NOW + 1,
+      settledAt: NOW + 3,
+    },
+  ]);
+
+  await briefings.insert(userId, { ...offered, id: "briefing-2", decidedAt: NOW + 10 });
+  assert.equal(await briefings.markPushed(userId, "briefing-2", NOW + 11), true);
+  await briefings.insert(userId, { ...offered, id: "briefing-3", decidedAt: NOW + 20 });
+  await briefings.insert(userId, {
+    ...offered,
+    id: "briefing-4",
+    decidedAt: NOW + 30,
+    expiresAt: NOW + 99_000,
+  });
+  assert.equal(await briefings.claim(userId, "briefing-3", "mac", NOW + 60_000), false);
+  assert.deepEqual(await briefings.expire(userId, NOW + 60_000), ["briefing-3"]);
+  assert.equal((await briefings.list(userId, BRIEFING_STATE.EXPIRED))[0]?.id, "briefing-3");
+  assert.equal((await briefings.list(userId, BRIEFING_STATE.OFFERED))[0]?.id, "briefing-4");
+  const rows = await database.db.select().from(briefing).where(eq(briefing.userId, userId));
+  for (const row of rows) assert.doesNotMatch(row.sealedWords, /needs you/);
+});
+
+test("deleting the user row cascades through every conversation table and leaves another user's rows standing", async () => {
+  const { database, userId } = await conversationFor();
+  const { userId: other } = await conversationFor();
+  for (const id of [userId, other]) {
+    const repository = database.store.brainStateRepository(id, MAIN_SESSION_KEY);
+    await repository.load();
+    await repository.save(populatedState(`gen-${id}`), [CHECKPOINT_INPUT, COMPACTION]);
+    await database.store.lines.append(
+      id,
+      MAIN_SESSION_KEY,
+      [line("hello", { eventId: "l-1" })],
+      NOW,
+    );
+    await database.store.facts.replace(id, [{ id: "f-1", words: "a fact" }], NOW);
+    await database.store.workspace.write(id, "USER.md", "# user", NOW);
+    await database.store.roster.write(id, { body: "{}", observedAt: NOW });
+    await database.store.briefings.insert(id, {
+      id: `b-${id}`,
+      sessionKey: MAIN_SESSION_KEY,
+      words: "words",
+      decidedAt: NOW,
+      expiresAt: NOW + 1,
+    });
+  }
+
+  await database.db.delete(user).where(eq(user.id, userId));
+
+  const tables = [
+    conversation,
+    conversationSession,
+    runtimeCheckpoint,
+    observationCursor,
+    observationCaptureCursor,
+    observationInboxEntry,
+    conversationRun,
+    actionReceipt,
+    conversationLine,
+    transcriptEvent,
+    compactionBoundary,
+    personalFact,
+    workspaceFile,
+    rosterSnapshot,
+    briefing,
+  ];
+  for (const table of tables) {
+    const gone = await database.db
+      .select({ count: sql<number>`count(*)::int` })
+      .from(table)
+      .where(eq(table.userId, userId));
+    assert.equal(gone[0]?.count, 0, `${getTableName(table)} still holds rows for the deleted user`);
+    const kept = await database.db
+      .select({ count: sql<number>`count(*)::int` })
+      .from(table)
+      .where(eq(table.userId, other));
+    assert.ok((kept[0]?.count ?? 0) > 0, `${getTableName(table)} lost the other user's rows`);
+  }
+});
+
+test("a sealed row under one user does not open as another, and the raw table functions refuse a payload the ring cannot vouch for", async () => {
+  const { database, userId } = await conversationFor();
+  const other = await database.createUser();
+  const keys = payloadKeyRing(TEST_PAYLOAD_SECRET);
+  await saveBrainEnvelope(database.db, userSeal(keys, userId), userId, MAIN_SESSION_KEY, {
+    kind: SAVE_KIND.REPLACE,
+    state: populatedState("gen-1"),
+  });
+  const read = await loadBrainEnvelope(
+    database.db,
+    userSeal(keys, other),
+    userId,
+    MAIN_SESSION_KEY,
+  );
+  assert.deepEqual(read, { unreadable: true, generation: "gen-1" });
+  const own = await loadBrainEnvelope(
+    database.db,
+    userSeal(keys, userId),
+    userId,
+    MAIN_SESSION_KEY,
+  );
+  assert.deepEqual(own, { state: populatedState("gen-1"), generation: "gen-1" });
+});

--- a/apps/web/tests/hosted-store.test.ts
+++ b/apps/web/tests/hosted-store.test.ts
@@ -501,8 +501,21 @@ test("the conversation directory lists what the user holds, creation is idempote
     NOW,
   );
   assert.equal((await database.store.conversations.list(userId))[1]?.sessionId, "gen-thread");
+  for (const sessionKey of [THREAD_KEY, MAIN_SESSION_KEY]) {
+    await database.store.briefings.insert(userId, {
+      id: `briefing-${sessionKey}`,
+      sessionKey,
+      words: "words",
+      decidedAt: NOW,
+      expiresAt: NOW + 1,
+    });
+  }
 
   assert.equal(await database.store.conversations.delete(userId, THREAD_KEY), true);
+  assert.deepEqual(
+    (await database.store.briefings.list(userId)).map((record) => record.sessionKey),
+    [MAIN_SESSION_KEY],
+  );
   assert.equal(await database.store.conversations.delete(userId, THREAD_KEY), false);
   assert.equal((await database.store.conversations.list(userId)).length, 1);
   for (const table of [conversationLine, transcriptEvent, compactionBoundary]) {

--- a/apps/web/tests/hosted-store.test.ts
+++ b/apps/web/tests/hosted-store.test.ts
@@ -673,7 +673,16 @@ test("a briefing is offered once, claimed by one device once, settled only by it
   };
   assert.equal(await briefings.insert(userId, offered), true);
   assert.equal(await briefings.insert(userId, offered), false);
+  assert.equal(
+    await briefings.insert(userId, { ...offered, id: "briefing-orphan", sessionKey: THREAD_KEY }),
+    false,
+  );
   const other = await database.createUser();
+  await database.store.conversations.create(other, {
+    sessionKey: MAIN_SESSION_KEY,
+    name: MAIN_CONVERSATION_NAME,
+    now: NOW,
+  });
   assert.equal(await briefings.insert(other, offered), true);
   assert.equal((await briefings.list(other)).length, 1);
   assert.deepEqual(await briefings.list(userId, BRIEFING_STATE.OFFERED), [

--- a/apps/web/tests/hosted-store.test.ts
+++ b/apps/web/tests/hosted-store.test.ts
@@ -660,6 +660,9 @@ test("a briefing is offered once, claimed by one device once, settled only by it
   };
   assert.equal(await briefings.insert(userId, offered), true);
   assert.equal(await briefings.insert(userId, offered), false);
+  const other = await database.createUser();
+  assert.equal(await briefings.insert(other, offered), true);
+  assert.equal((await briefings.list(other)).length, 1);
   assert.deepEqual(await briefings.list(userId, BRIEFING_STATE.OFFERED), [
     { ...offered, state: BRIEFING_STATE.OFFERED },
   ]);
@@ -714,7 +717,7 @@ test("deleting the user row cascades through every conversation table and leaves
     await database.store.workspace.write(id, "USER.md", "# user", NOW);
     await database.store.roster.write(id, { body: "{}", observedAt: NOW });
     await database.store.briefings.insert(id, {
-      id: `b-${id}`,
+      id: "briefing-shared-id",
       sessionKey: MAIN_SESSION_KEY,
       words: "words",
       decidedAt: NOW,

--- a/apps/web/tests/support/hosted-store-database.ts
+++ b/apps/web/tests/support/hosted-store-database.ts
@@ -1,0 +1,76 @@
+import { randomUUID } from "node:crypto";
+import { fileURLToPath } from "node:url";
+import { PGlite } from "@electric-sql/pglite";
+import { drizzle as drizzleNodePostgres } from "drizzle-orm/node-postgres";
+import { migrate as migrateNodePostgres } from "drizzle-orm/node-postgres/migrator";
+import { drizzle as drizzlePglite } from "drizzle-orm/pglite";
+import { migrate as migratePglite } from "drizzle-orm/pglite/migrator";
+import { Pool } from "pg";
+import * as schema from "../../server/db/schema";
+import { payloadKeyRing } from "../../server/hosted/encryption";
+import { type HostedStore, type HostedStoreDatabase, hostedStore } from "../../server/hosted/store";
+
+/**
+ * The store's tests run against the real generated migrations on a real
+ * Postgres dialect: PGlite in process by default, so `check.sh` needs no
+ * service, or the Postgres named by `LUKE_STORE_TEST_DATABASE_URL`, which the
+ * CI job points at its service container after `db:migrate` has run there.
+ * Either way `migrate` is applied here too, which is idempotent, so the test
+ * never depends on who migrated first.
+ */
+
+/** The env var naming a Postgres the store tests should run against instead of PGlite. */
+export const STORE_TEST_DATABASE_ENVIRONMENT = {
+  URL: "LUKE_STORE_TEST_DATABASE_URL",
+} as const;
+
+export const TEST_PAYLOAD_SECRET = "c".repeat(64);
+
+const MIGRATIONS_FOLDER = fileURLToPath(new URL("../../drizzle", import.meta.url));
+
+export interface HostedStoreTestDatabase {
+  readonly db: HostedStoreDatabase;
+  readonly store: HostedStore;
+  /** Inserts a user row for one test, answering the id every other row hangs from. */
+  createUser(): Promise<string>;
+  close(): Promise<void>;
+}
+
+export async function openHostedStoreTestDatabase(): Promise<HostedStoreTestDatabase> {
+  const connectionString = process.env[STORE_TEST_DATABASE_ENVIRONMENT.URL];
+  const opened = connectionString ? await openNodePostgres(connectionString) : await openPglite();
+  const keys = payloadKeyRing(TEST_PAYLOAD_SECRET);
+  return {
+    db: opened.db,
+    store: hostedStore({ db: opened.db, keys }),
+    async createUser() {
+      const id = `user-${randomUUID()}`;
+      await opened.db.insert(schema.user).values({
+        id,
+        name: "Test User",
+        email: `${id}@luke.test`,
+      });
+      return id;
+    },
+    close: opened.close,
+  };
+}
+
+interface OpenedDatabase {
+  readonly db: HostedStoreDatabase;
+  close(): Promise<void>;
+}
+
+async function openPglite(): Promise<OpenedDatabase> {
+  const client = new PGlite();
+  const db = drizzlePglite(client, { schema });
+  await migratePglite(db, { migrationsFolder: MIGRATIONS_FOLDER });
+  return { db, close: () => client.close() };
+}
+
+async function openNodePostgres(connectionString: string): Promise<OpenedDatabase> {
+  const pool = new Pool({ connectionString, max: 1 });
+  const db = drizzleNodePostgres(pool, { schema });
+  await migrateNodePostgres(db, { migrationsFolder: MIGRATIONS_FOLDER });
+  return { db, close: () => pool.end() };
+}

--- a/packages/AGENTS.md
+++ b/packages/AGENTS.md
@@ -116,7 +116,11 @@ the barrel exports neither. `@sidecar/brain/envelope` is the third: the
 envelope's shape and its readings are what everything under `brain/src/store/`
 needs, and reaching them through the barrel — or through `state-store.ts`,
 which is the store class over them — would pull the whole brain into the module
-that only has to read a row back.
+that only has to read a row back. `@sidecar/brain/store-shapes` is the fourth,
+in the other direction: the stored shapes and their readings (the envelope
+delta a save carries, the transcript payload a row keeps), Node-free, so the
+hosted tier's Postgres store under `apps/web/server/hosted/store/` writes and
+reads the same rows the SQLite store does without resolving `node:sqlite`.
 
 `@sidecar/runtime/vocabulary` is the same rule at the bottom of the graph: the
 identities, the storage contracts, and the execution seams are Node-free, and

--- a/packages/brain/package.json
+++ b/packages/brain/package.json
@@ -9,6 +9,7 @@
     "./requests": "./src/requests.js",
     "./requests-wire": "./src/requests-wire.js",
     "./store": "./src/store/index.js",
+    "./store-shapes": "./src/store/shapes.js",
     "./store-worker": "./src/store/worker-entry.js",
     "./testing": "./src/testing.js"
   },

--- a/packages/brain/src/store/shapes.ts
+++ b/packages/brain/src/store/shapes.ts
@@ -1,0 +1,23 @@
+/**
+ * The stored shapes and their readings, Node-free: how one envelope becomes
+ * the next as a delta the tables can apply, and how a transcript event is
+ * kept and read back. A store over another database — the hosted tier's
+ * Postgres — writes and reads the same rows through these, so the two stores
+ * cannot drift in what a checkpoint or a transcript payload means.
+ */
+export {
+  type BrainItemsDelta,
+  type BrainJournalDelta,
+  type BrainRequestsDelta,
+  type BrainStateDelta,
+  type BrainStateSave,
+  brainStateSave,
+  EnvelopeTracker,
+  SAVE_KIND,
+  type SaveKind,
+} from "./envelope.js";
+export {
+  contextInputFromWire,
+  transcriptEventFromPayload,
+  transcriptPayload,
+} from "./transcript-payload.js";

--- a/packages/brain/src/store/transcript-payload.ts
+++ b/packages/brain/src/store/transcript-payload.ts
@@ -1,0 +1,82 @@
+import {
+  COMPACTION_SOURCE,
+  CONTEXT_INPUT_KIND,
+  type CompactionBoundary,
+  type ContextInput,
+  isCompactionSource,
+  TRANSCRIPT_EVENT_KIND,
+  type TranscriptEvent,
+} from "@sidecar/runtime/vocabulary";
+import { isRecord, isWireNumber, isWireString, type UnparsedWireValue } from "@sidecar/wire";
+
+/**
+ * The shape a transcript event is stored in, and the reading that takes it
+ * back. A row keeps the event's kind and clock in columns of their own and
+ * the rest as this payload, so the writer and the reader are one pair
+ * wherever the rows live, and a payload this build cannot vouch for drops the
+ * row rather than the transcript.
+ */
+
+/** The payload a row keeps: the event less its kind and clock, which have columns of their own. */
+export function transcriptPayload(
+  event: TranscriptEvent,
+): { input: ContextInput } | { boundary: CompactionBoundary } {
+  return event.kind === TRANSCRIPT_EVENT_KIND.CONTEXT_INPUT
+    ? { input: event.input }
+    : { boundary: event.boundary };
+}
+
+/** The event a parsed payload describes: the row's `{ input }` or `{ boundary }`, or an archive line carrying the same fields. */
+export function transcriptEventFromPayload(
+  kind: string,
+  recordedAt: number,
+  parsed: UnparsedWireValue,
+): TranscriptEvent | undefined {
+  if (!isRecord(parsed)) return undefined;
+  if (kind === TRANSCRIPT_EVENT_KIND.CONTEXT_INPUT) {
+    const input = contextInputFromWire(parsed.input);
+    return input ? { kind, recordedAt, input } : undefined;
+  }
+  if (kind === TRANSCRIPT_EVENT_KIND.COMPACTION) {
+    const boundary = parsed.boundary;
+    if (!isRecord(boundary) || !isWireNumber(boundary.dropped)) return undefined;
+    const source = isCompactionSource(boundary.source)
+      ? boundary.source
+      : COMPACTION_SOURCE.PROVIDER_INLINE;
+    return {
+      kind,
+      recordedAt,
+      boundary: {
+        source,
+        dropped: boundary.dropped,
+        ...(isWireString(boundary.checkpointFormat)
+          ? { checkpointFormat: boundary.checkpointFormat }
+          : undefined),
+      },
+    };
+  }
+  return undefined;
+}
+
+export function contextInputFromWire(value: UnparsedWireValue): ContextInput | undefined {
+  if (!isRecord(value)) return undefined;
+  switch (value.kind) {
+    case CONTEXT_INPUT_KIND.USER_TEXT:
+      return isWireString(value.text) ? { kind: value.kind, text: value.text } : undefined;
+    case CONTEXT_INPUT_KIND.MODEL_OUTPUT: {
+      if (!Array.isArray(value.items)) return undefined;
+      const items = [];
+      for (const item of value.items) {
+        if (!isRecord(item)) return undefined;
+        items.push(item);
+      }
+      return { kind: value.kind, items };
+    }
+    case CONTEXT_INPUT_KIND.TOOL_RESULT:
+      return isWireString(value.callId) && isWireString(value.outputJson)
+        ? { kind: value.kind, callId: value.callId, outputJson: value.outputJson }
+        : undefined;
+    default:
+      return undefined;
+  }
+}

--- a/packages/brain/src/store/transcript-table.ts
+++ b/packages/brain/src/store/transcript-table.ts
@@ -1,17 +1,13 @@
 import {
-  COMPACTION_SOURCE,
-  CONTEXT_INPUT_KIND,
-  type CompactionBoundary,
-  type ContextInput,
-  isCompactionSource,
   type SessionKey,
   type StoredTranscriptEvent,
   TRANSCRIPT_EVENT_KIND,
   type TranscriptEvent,
 } from "@sidecar/runtime/vocabulary";
-import { isRecord, isWireNumber, isWireString, type UnparsedWireValue } from "@sidecar/wire";
+import type { UnparsedWireValue } from "@sidecar/wire";
 import { touchConversation } from "./conversations-table.js";
 import { nullable, type StoreDatabase } from "./database.js";
+import { transcriptEventFromPayload, transcriptPayload } from "./transcript-payload.js";
 
 /**
  * The retained transcript: every input the context engine ingested, in
@@ -90,15 +86,6 @@ function nextTranscriptSequence(database: StoreDatabase, sessionKey: SessionKey)
     .get(sessionKey) as { sequence: number } | undefined;
   if (!row) throw new Error(`no conversation stands at ${sessionKey}`);
   return row.sequence;
-}
-
-/** The payload a row keeps: the event less its kind and clock, which have columns of their own. */
-function transcriptPayload(
-  event: TranscriptEvent,
-): { input: ContextInput } | { boundary: CompactionBoundary } {
-  return event.kind === TRANSCRIPT_EVENT_KIND.CONTEXT_INPUT
-    ? { input: event.input }
-    : { boundary: event.boundary };
 }
 
 export interface TranscriptListOptions {
@@ -216,59 +203,4 @@ export function transcriptEventFromRow(
     return undefined;
   }
   return transcriptEventFromPayload(kind, recordedAt, parsed);
-}
-
-/** The event a parsed payload describes: the row's `{ input }` or `{ boundary }`, or an archive line carrying the same fields. */
-export function transcriptEventFromPayload(
-  kind: string,
-  recordedAt: number,
-  parsed: UnparsedWireValue,
-): TranscriptEvent | undefined {
-  if (!isRecord(parsed)) return undefined;
-  if (kind === TRANSCRIPT_EVENT_KIND.CONTEXT_INPUT) {
-    const input = contextInputFromWire(parsed.input);
-    return input ? { kind, recordedAt, input } : undefined;
-  }
-  if (kind === TRANSCRIPT_EVENT_KIND.COMPACTION) {
-    const boundary = parsed.boundary;
-    if (!isRecord(boundary) || !isWireNumber(boundary.dropped)) return undefined;
-    const source = isCompactionSource(boundary.source)
-      ? boundary.source
-      : COMPACTION_SOURCE.PROVIDER_INLINE;
-    return {
-      kind,
-      recordedAt,
-      boundary: {
-        source,
-        dropped: boundary.dropped,
-        ...(isWireString(boundary.checkpointFormat)
-          ? { checkpointFormat: boundary.checkpointFormat }
-          : undefined),
-      },
-    };
-  }
-  return undefined;
-}
-
-export function contextInputFromWire(value: UnparsedWireValue): ContextInput | undefined {
-  if (!isRecord(value)) return undefined;
-  switch (value.kind) {
-    case CONTEXT_INPUT_KIND.USER_TEXT:
-      return isWireString(value.text) ? { kind: value.kind, text: value.text } : undefined;
-    case CONTEXT_INPUT_KIND.MODEL_OUTPUT: {
-      if (!Array.isArray(value.items)) return undefined;
-      const items = [];
-      for (const item of value.items) {
-        if (!isRecord(item)) return undefined;
-        items.push(item);
-      }
-      return { kind: value.kind, items };
-    }
-    case CONTEXT_INPUT_KIND.TOOL_RESULT:
-      return isWireString(value.callId) && isWireString(value.outputJson)
-        ? { kind: value.kind, callId: value.callId, outputJson: value.outputJson }
-        : undefined;
-    default:
-      return undefined;
-  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -152,10 +152,10 @@ importers:
     dependencies:
       '@better-auth/drizzle-adapter':
         specifier: 1.6.29
-        version: 1.6.29(@better-auth/core@1.6.29(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.5.0))(@better-auth/utils@0.4.2)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.21.0)(kysely@0.29.5)(pg@8.23.0))
+        version: 1.6.29(@better-auth/core@1.6.29(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.5.0))(@better-auth/utils@0.4.2)(drizzle-orm@0.45.2(@electric-sql/pglite@0.5.8)(@opentelemetry/api@1.9.1)(@types/pg@8.21.0)(kysely@0.29.5)(pg@8.23.0))
       '@better-auth/oauth-provider':
         specifier: 1.6.29
-        version: 1.6.29(@better-auth/core@1.6.29(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.5.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-auth@1.6.29(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.21.0)(kysely@0.29.5)(pg@8.23.0))(next@16.3.1(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@types/node@22.20.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(pg@8.23.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(better-call@1.4.0(zod@4.4.3))
+        version: 1.6.29(@better-auth/core@1.6.29(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.5.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-auth@1.6.29(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.5.8)(@opentelemetry/api@1.9.1)(@types/pg@8.21.0)(kysely@0.29.5)(pg@8.23.0))(next@16.3.1(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@types/node@22.20.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(pg@8.23.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(better-call@1.4.0(zod@4.4.3))
       '@fontsource-variable/bricolage-grotesque':
         specifier: 5.3.0
         version: 5.3.0
@@ -200,10 +200,10 @@ importers:
         version: 4.3.3(vite@7.3.1(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.12)(yaml@2.9.0))
       better-auth:
         specifier: 1.6.29
-        version: 1.6.29(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.21.0)(kysely@0.29.5)(pg@8.23.0))(next@16.3.1(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@types/node@22.20.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(pg@8.23.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        version: 1.6.29(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.5.8)(@opentelemetry/api@1.9.1)(@types/pg@8.21.0)(kysely@0.29.5)(pg@8.23.0))(next@16.3.1(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@types/node@22.20.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(pg@8.23.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       drizzle-orm:
         specifier: 0.45.2
-        version: 0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.21.0)(kysely@0.29.5)(pg@8.23.0)
+        version: 0.45.2(@electric-sql/pglite@0.5.8)(@opentelemetry/api@1.9.1)(@types/pg@8.21.0)(kysely@0.29.5)(pg@8.23.0)
       marked:
         specifier: 18.0.9
         version: 18.0.9
@@ -226,6 +226,9 @@ importers:
         specifier: 4.3.3
         version: 4.3.3
     devDependencies:
+      '@electric-sql/pglite':
+        specifier: 0.5.8
+        version: 0.5.8
       '@types/node':
         specifier: 22.20.1
         version: 22.20.1
@@ -1115,6 +1118,9 @@ packages:
 
   '@drizzle-team/brocli@0.10.2':
     resolution: {integrity: sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==}
+
+  '@electric-sql/pglite@0.5.8':
+    resolution: {integrity: sha512-n9tsbUOhwx2epK1V0ZG9Ar4SHWUju04dhmzZXiSBXwBoleOvIfals33NAaWgagQVAL4Rbvx/Ptsu3P+pA09f6Q==}
 
   '@electron-internal/extract-zip@1.0.5':
     resolution: {integrity: sha512-+bqFCP98pLI0Tt0XQo1TmlXtwjWchISndDOxCkEcIuUgXWpBnLyRI+2DU+mesvnMMX6L1XDqYNA0lXNDHd/yiA==}
@@ -5110,12 +5116,12 @@ snapshots:
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
 
-  '@better-auth/drizzle-adapter@1.6.29(@better-auth/core@1.6.29(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.5.0))(@better-auth/utils@0.4.2)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.21.0)(kysely@0.29.5)(pg@8.23.0))':
+  '@better-auth/drizzle-adapter@1.6.29(@better-auth/core@1.6.29(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.5.0))(@better-auth/utils@0.4.2)(drizzle-orm@0.45.2(@electric-sql/pglite@0.5.8)(@opentelemetry/api@1.9.1)(@types/pg@8.21.0)(kysely@0.29.5)(pg@8.23.0))':
     dependencies:
       '@better-auth/core': 1.6.29(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.5.0)
       '@better-auth/utils': 0.4.2
     optionalDependencies:
-      drizzle-orm: 0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.21.0)(kysely@0.29.5)(pg@8.23.0)
+      drizzle-orm: 0.45.2(@electric-sql/pglite@0.5.8)(@opentelemetry/api@1.9.1)(@types/pg@8.21.0)(kysely@0.29.5)(pg@8.23.0)
 
   '@better-auth/kysely-adapter@1.6.29(@better-auth/core@1.6.29(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.5.0))(@better-auth/utils@0.4.2)(kysely@0.29.5)':
     dependencies:
@@ -5134,12 +5140,12 @@ snapshots:
       '@better-auth/core': 1.6.29(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.5.0)
       '@better-auth/utils': 0.4.2
 
-  '@better-auth/oauth-provider@1.6.29(@better-auth/core@1.6.29(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.5.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-auth@1.6.29(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.21.0)(kysely@0.29.5)(pg@8.23.0))(next@16.3.1(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@types/node@22.20.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(pg@8.23.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(better-call@1.4.0(zod@4.4.3))':
+  '@better-auth/oauth-provider@1.6.29(@better-auth/core@1.6.29(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.5.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-auth@1.6.29(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.5.8)(@opentelemetry/api@1.9.1)(@types/pg@8.21.0)(kysely@0.29.5)(pg@8.23.0))(next@16.3.1(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@types/node@22.20.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(pg@8.23.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(better-call@1.4.0(zod@4.4.3))':
     dependencies:
       '@better-auth/core': 1.6.29(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.5.0)
       '@better-auth/utils': 0.4.2
       '@better-fetch/fetch': 1.3.1
-      better-auth: 1.6.29(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.21.0)(kysely@0.29.5)(pg@8.23.0))(next@16.3.1(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@types/node@22.20.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(pg@8.23.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      better-auth: 1.6.29(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.5.8)(@opentelemetry/api@1.9.1)(@types/pg@8.21.0)(kysely@0.29.5)(pg@8.23.0))(next@16.3.1(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@types/node@22.20.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(pg@8.23.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       better-call: 1.4.0(zod@4.4.3)
       jose: 6.2.9
       zod: 4.4.3
@@ -5206,6 +5212,8 @@ snapshots:
       ajv-keywords: 3.5.2(ajv@6.15.0)
 
   '@drizzle-team/brocli@0.10.2': {}
+
+  '@electric-sql/pglite@0.5.8': {}
 
   '@electron-internal/extract-zip@1.0.5': {}
 
@@ -6598,10 +6606,10 @@ snapshots:
 
   baseline-browser-mapping@2.11.13: {}
 
-  better-auth@1.6.29(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.21.0)(kysely@0.29.5)(pg@8.23.0))(next@16.3.1(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@types/node@22.20.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(pg@8.23.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
+  better-auth@1.6.29(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.5.8)(@opentelemetry/api@1.9.1)(@types/pg@8.21.0)(kysely@0.29.5)(pg@8.23.0))(next@16.3.1(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@types/node@22.20.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(pg@8.23.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:
       '@better-auth/core': 1.6.29(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.5.0)
-      '@better-auth/drizzle-adapter': 1.6.29(@better-auth/core@1.6.29(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.5.0))(@better-auth/utils@0.4.2)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.21.0)(kysely@0.29.5)(pg@8.23.0))
+      '@better-auth/drizzle-adapter': 1.6.29(@better-auth/core@1.6.29(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.5.0))(@better-auth/utils@0.4.2)(drizzle-orm@0.45.2(@electric-sql/pglite@0.5.8)(@opentelemetry/api@1.9.1)(@types/pg@8.21.0)(kysely@0.29.5)(pg@8.23.0))
       '@better-auth/kysely-adapter': 1.6.29(@better-auth/core@1.6.29(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.5.0))(@better-auth/utils@0.4.2)(kysely@0.29.5)
       '@better-auth/memory-adapter': 1.6.29(@better-auth/core@1.6.29(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.5.0))(@better-auth/utils@0.4.2)
       '@better-auth/mongo-adapter': 1.6.29(@better-auth/core@1.6.29(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.5.0))(@better-auth/utils@0.4.2)
@@ -6619,7 +6627,7 @@ snapshots:
       zod: 4.4.3
     optionalDependencies:
       drizzle-kit: 0.31.10
-      drizzle-orm: 0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.21.0)(kysely@0.29.5)(pg@8.23.0)
+      drizzle-orm: 0.45.2(@electric-sql/pglite@0.5.8)(@opentelemetry/api@1.9.1)(@types/pg@8.21.0)(kysely@0.29.5)(pg@8.23.0)
       next: 16.3.1(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@types/node@22.20.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       pg: 8.23.0
       react: 19.2.8
@@ -6945,8 +6953,9 @@ snapshots:
       esbuild: 0.25.12
       tsx: 4.23.12
 
-  drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.21.0)(kysely@0.29.5)(pg@8.23.0):
+  drizzle-orm@0.45.2(@electric-sql/pglite@0.5.8)(@opentelemetry/api@1.9.1)(@types/pg@8.21.0)(kysely@0.29.5)(pg@8.23.0):
     optionalDependencies:
+      '@electric-sql/pglite': 0.5.8
       '@opentelemetry/api': 1.9.1
       '@types/pg': 8.21.0
       kysely: 0.29.5


### PR DESCRIPTION
## Summary

Second of the twelve PRs under LUKE-95 (Host Luke's brain). Adds the hosted conversation's Postgres schema and a store over it that implements the same storage contracts the desktop's SQLite store implements, so PR 5's brain host composes against it unchanged. No routes, no desktop or client changes.

Linear: [LUKE-97](https://linear.app/stage-review/issue/LUKE-97) · parent [LUKE-95](https://linear.app/stage-review/issue/LUKE-95)

### Tables (`apps/web/server/db`, migration `0010_narrow_mac_gargan.sql`)

All keyed by `user_id` → `user.id` with `ON DELETE CASCADE`, so `api/account/delete.ts` erases them with the account (covered by a PGlite test that deletes the user row and checks every table).

| Table | Holds |
| --- | --- |
| `conversation` | The directory: key, kind, name, activity, the line and transcript sequence counters, the Clear cutoff |
| `conversation_session` | The standing generation, one per conversation (`conversation_session_one_standing`), with its reset marker, checkpoint format, and compaction count |
| `runtime_checkpoint` | The Responses input items, sealed, cascading with the generation |
| `observation_cursor`, `observation_capture_cursor` | Consumed and capture cursors per provider session |
| `observation_inbox_entry` | Captured observations waiting for a turn, sealed |
| `conversation_run` | The request record (question and reply sealed) plus the turn about-fields: `trigger`, `run_origin`, `ending`, `input_tokens`, `output_tokens`, `input_item_kinds`, `transcript_bytes`, `elapsed_ms`, `tool_names`, `compacted` |
| `action_receipt` | The action journal (arguments and output sealed) |
| `conversation_line` | The Conversation's lines, sealed; idempotency key is the SHA-256 of the line's identity; partial unique index publishes a run's line of a kind once |
| `transcript_event`, `compaction_boundary` | The retained transcript and its folds; attributed to a generation, never cascading with one |
| `personal_fact` | The remembered facts, sealed, replaced whole |
| `workspace_file` | Identity workspace and daily notes, one row per user per path, sealed |
| `roster_snapshot` | One latest sealed roster per user with its observed instant |
| `briefing` | id, user, conversation, run, sealed words, decided/expires instants, state, `claimed_by_device_id` as a plain nullable text column for now |

Instants are epoch-ms `bigint` columns because the contracts carry numbers.

### Envelope

`sealPayload` / `openPayload` in `server/hosted/encryption.ts`, beside the vault's cipher and leaving its format untouched: `<keyId>:base64(nonce ‖ ciphertext ‖ tag)`, AES-256-GCM under `PROVIDER_KEY_ENCRYPTION_SECRET` as key id 1, with the row's user id as authenticated data so a sealed column moved under another user does not open. `PayloadKeyRing` names the current key and every key an envelope on record may name, which is what a later rotation adds to.

### Store (`apps/web/server/hosted/store`)

`hostedStore({ db, keys })` exposes `brainStateRepository(userId, sessionKey)` (a `BrainStateRepository` with the SQLite client's `EnvelopeTracker` delta saves), conversations list/create/delete, lines append/list/cutoff, transcript list/boundaries, run about-fields, facts list/replace, workspace read/write/seed/delete/list, roster read/write, and briefing insert/claim/markSpoken/markPushed/expire/list. It runs over any Drizzle Postgres driver, so the same code runs on `pg` in a function and PGlite in a test.

Invariants preserved from the SQLite store: compare-and-set on the standing generation (a stale handle is refused whole and by delta until it loads again); the transcript lands in the same transaction as the checkpoint and never cascades with a generation; lines carry their own retention and the Clear cutoff, which outlives the generation that raised it; a generation whose rows cannot be opened or read is reported unreadable and repaired by the store that observed it, by no stale writer. Clear is a hard delete of the lines, transcript, and boundaries at or before its instant, with no recovery archive and no maintenance ladder.

The envelope delta and the transcript payload readers the two stores share move behind `@sidecar/brain/store-shapes` (Node-free), reached by the web server through `core.ts`.

### Tests and CI

- `tests/hosted-store.test.ts` and `tests/hosted-payload-envelope.test.ts` run the real generated migrations on PGlite (`@electric-sql/pglite` 0.5.8, dev) inside `check.sh`.
- New `postgres` CI job: a `postgres:17` service container, `db:migrate` through the advisory-lock runner, then the same store tests against it via `LUKE_STORE_TEST_DATABASE_URL`.
- Existing offline construction tests unchanged and passing.

### Deliberately left out

- **PR 3 (LUKE-98):** the `devices` table and its migration; `briefing.claimed_by_device_id` stays a plain column until then. Whichever of the two merges second rebases and regenerates its migration so the drizzle journal stays linear.
- **PR 5:** the brain host over this store, routes, leases, and the wiring of `recordAbout`; nothing here is reached by a route yet, so `PRIVACY.md` is unchanged until it is.
- Archive/pin columns and conversation maintenance: not carried over, per the parent's decisions.

## Evidence

- Platform-independent checks: `./scripts/check.sh` passed (exit 0; 2,947 tests, 0 failures across 25 packages; lint, typecheck, and build clean). `pnpm --filter @luke/web db:check` reports the journal and snapshots consistent.
- macOS Electron verification (`./scripts/verify.sh`): `not run` (no macOS or UI change).

### Physical-device evidence

- Screenshot or screen recording: `not attached` (no UI change)
- Physical-notch check: `not performed`
- Device/display configuration: `not recorded`

## Notes

- Blockers or follow-up verification: the `postgres` CI job is new in this PR and runs for the first time here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34394778854/artifacts/10121196969) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34394778854)

- Commit: `41640ad5ff601df73b7820b8dd5e3142f41c70e4`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
