### PR TITLE
fix(desktop): retire the developer's idle call and end an expired one quietly

### DIFF
--- a/apps/desktop/src/renderer/voice/agents-realtime-transport.test.ts
+++ b/apps/desktop/src/renderer/voice/agents-realtime-transport.test.ts
@@ -183,6 +183,46 @@ test("SDK errors are rendered without serializing unknown values", () => {
   );
 });
 
+test("an RTCErrorEvent is rendered by the error it carries, never as its tag", () => {
+  class RTCErrorEvent {
+    get [Symbol.toStringTag]() {
+      return "RTCErrorEvent";
+    }
+    constructor(readonly error: Error | { message: string } | undefined) {}
+  }
+
+  assert.equal(
+    agentsRealtimeErrorMessage(
+      new RTCErrorEvent({ message: "User-Initiated Abort, reason=Close called" }),
+    ),
+    "User-Initiated Abort, reason=Close called",
+  );
+  assert.equal(
+    agentsRealtimeErrorMessage(new RTCErrorEvent(new Error("Transport channel closed"))),
+    "Transport channel closed",
+  );
+  assert.equal(
+    agentsRealtimeErrorMessage(new RTCErrorEvent(undefined)),
+    "The voice connection closed.",
+  );
+});
+
+test("an error on a call already put away is not reported", async () => {
+  const closedFirst = sdkHarness(realtimeSessionConfig());
+  await connect(closedFirst);
+  const close = closedFirst.transport.expectCall("close");
+  closedFirst.session.close();
+  await close;
+  closedFirst.transport.emit("error", { type: "error", error: new Error("channel aborted") });
+  assert.deepEqual(closedFirst.errors, []);
+
+  const disconnectedFirst = sdkHarness(realtimeSessionConfig());
+  await connect(disconnectedFirst);
+  disconnectedFirst.transport.disconnect();
+  disconnectedFirst.transport.emit("error", { type: "error", error: new Error("channel aborted") });
+  assert.deepEqual(disconnectedFirst.errors, []);
+});
+
 test("a server error is left to the session's own filter, not reported twice", async () => {
   const context = sdkHarness(realtimeSessionConfig());
   await connect(context);

--- a/apps/desktop/src/renderer/voice/agents-realtime-transport.ts
+++ b/apps/desktop/src/renderer/voice/agents-realtime-transport.ts
@@ -69,9 +69,29 @@ function sdkErrorText(value: TransportError["error"]): string | undefined {
   return normalized || undefined;
 }
 
+const RTC_ERROR_EVENT_TAG = "[object RTCErrorEvent]";
+const RTC_ERROR_EVENT_MESSAGE = "The voice connection closed.";
+
+/**
+ * The browser's own `RTCErrorEvent`, which a data channel abort raises. It is
+ * no plain object, so it is read here by its tag for the `RTCError` it
+ * carries — `String()` would print only the tag.
+ */
+function rtcErrorEventMessage(value: TransportError["error"]): string | undefined {
+  if (Object.prototype.toString.call(value) !== RTC_ERROR_EVENT_TAG) return undefined;
+  // SAFETY: The runtime tag above establishes an event whose fields remain untrusted below.
+  const event = value as { error?: unknown; message?: unknown };
+  const error = event.error;
+  // An `RTCError` is a `DOMException`, so an `Error`; a scripted stand-in is a record.
+  const nested = error instanceof Error ? error.message : sdkErrorRecord(error)?.message;
+  return sdkErrorText(nested) ?? sdkErrorText(event.message) ?? RTC_ERROR_EVENT_MESSAGE;
+}
+
 export function agentsRealtimeErrorMessage(error: TransportError["error"]): string {
   try {
     if (error instanceof Error) return error.message;
+    const rtc = rtcErrorEventMessage(error);
+    if (rtc !== undefined) return rtc;
     const record = sdkErrorRecord(error);
     if (record) {
       const nested = sdkErrorRecord(record.error);
@@ -143,12 +163,21 @@ export function createAgentsRealtimeTransport(
   options: SdkTransportFactoryOptions,
   injectedTransport?: RealtimeTransportLayer,
 ): SdkRealtimeTransport {
-  const report = (error: TransportError["error"]): void => {
+  let closed = false;
+  let live: RealtimeTransportLayer | undefined;
+  const surface = (error: TransportError["error"]): void => {
     try {
       options.onError(agentsRealtimeErrorMessage(error));
     } catch {
       // Closing a call must not be defeated by an error reporter.
     }
+  };
+  // An error on a call already being put away is not news to the developer:
+  // the channel abort that follows a close, or a provider-ended session, lands
+  // here after the session stopped listening.
+  const report = (error: TransportError["error"]): void => {
+    if (closed || live?.status === "disconnected" || live?.status === "disconnecting") return;
+    surface(error);
   };
 
   let releaseOwnedResources: (() => void) | undefined;
@@ -199,6 +228,7 @@ export function createAgentsRealtimeTransport(
         options.onToolOutputSent,
       );
     })();
+  live = transport;
 
   const tools = options.sessionConfig.tools.map((definition) =>
     tool({
@@ -241,7 +271,6 @@ export function createAgentsRealtimeTransport(
   });
   transport.on("connection_change", options.onConnectionChange);
 
-  let closed = false;
   return {
     get status() {
       return transport.status;
@@ -258,7 +287,7 @@ export function createAgentsRealtimeTransport(
       try {
         session.close();
       } catch (error) {
-        report(error);
+        surface(error);
       } finally {
         releaseOwnedResources?.();
       }

--- a/apps/desktop/src/renderer/voice/conversation-call-device.test.ts
+++ b/apps/desktop/src/renderer/voice/conversation-call-device.test.ts
@@ -7,6 +7,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { REALTIME_SERVER_EVENT, REALTIME_STATUS } from "@sidecar/realtime";
+import { drainMicrotasks } from "@sidecar/runtime/testing";
 import { REPLY_KIND } from "@sidecar/voice/orchestrator";
 import {
   armDeveloperTurn,
@@ -18,15 +19,46 @@ import {
   reportedErrors,
   settleReply,
 } from "#testing/conversation-call-harness";
+import { IDLE_CALL_RETIRE_MS } from "./conversation-call";
 
-test("an idle call stays open until the provider closes it", async (t) => {
+test("an idle developer call retires itself after five minutes", async (t) => {
+  t.mock.timers.enable({ apis: ["setTimeout"] });
+  const context = harness();
+  await context.session.connect();
+
+  t.mock.timers.tick(IDLE_CALL_RETIRE_MS - 1);
+  assert.equal(context.session.isConnected, true);
+
+  t.mock.timers.tick(1);
+
+  // An ordinary end: no fault drawn, and the next press opens a fresh call.
+  // The conversation itself is the brain's History, not the call's.
+  assert.equal(context.session.status, REALTIME_STATUS.IDLE);
+  assert.equal(context.session.isConnected, false);
+  assert.deepEqual(reportedErrors(context), []);
+  assert.equal(await context.session.connect(), true);
+  assert.equal(context.session.status, REALTIME_STATUS.READY);
+});
+
+test("a press during the idle countdown keeps the call", async (t) => {
   t.mock.timers.enable({ apis: ["setTimeout"] });
   const context = harness();
   await context.session.connect();
 
   t.mock.timers.tick(4 * 60_000);
-
+  context.session.beginTurn();
+  // The device's arrival is a promise, not a timer, so it lands under the mock.
+  await drainMicrotasks();
+  assert.equal(context.session.status, REALTIME_STATUS.LISTENING);
+  context.session.stopListening(true);
+  settleReply(context);
+  // The countdown starts over at the exchange's end, not from the connect.
+  t.mock.timers.tick(4 * 60_000);
   assert.equal(context.session.isConnected, true);
+
+  t.mock.timers.tick(60_000);
+  assert.equal(context.session.status, REALTIME_STATUS.IDLE);
+  assert.equal(context.session.isConnected, false);
 });
 
 test("the device closes with the exchange and the conversation stays", async () => {

--- a/apps/desktop/src/renderer/voice/conversation-call-device.test.ts
+++ b/apps/desktop/src/renderer/voice/conversation-call-device.test.ts
@@ -40,6 +40,38 @@ test("an idle developer call retires itself after five minutes", async (t) => {
   assert.equal(context.session.status, REALTIME_STATUS.READY);
 });
 
+test("a press let go of before its device arrived still lets the call retire", async (t) => {
+  t.mock.timers.enable({ apis: ["setTimeout"] });
+  const context = harness();
+  await context.session.connect();
+
+  t.mock.timers.tick(60_000);
+  context.session.beginTurn();
+  context.session.endTurn(false);
+  assert.equal(context.session.status, REALTIME_STATUS.READY);
+  assert.equal(context.session.turnPending, false);
+
+  t.mock.timers.tick(IDLE_CALL_RETIRE_MS - 60_000);
+  assert.equal(context.session.status, REALTIME_STATUS.IDLE);
+  assert.equal(context.session.isConnected, false);
+});
+
+test("a press still opening its device at the fire starts the countdown over", async (t) => {
+  t.mock.timers.enable({ apis: ["setTimeout"] });
+  const context = harness();
+  await context.session.connect();
+
+  t.mock.timers.tick(IDLE_CALL_RETIRE_MS - 1);
+  context.gateMicrophone();
+  context.session.beginTurn();
+  t.mock.timers.tick(1);
+  assert.equal(context.session.isConnected, true);
+
+  context.session.endTurn(false);
+  t.mock.timers.tick(IDLE_CALL_RETIRE_MS);
+  assert.equal(context.session.status, REALTIME_STATUS.IDLE);
+});
+
 test("a press during the idle countdown keeps the call", async (t) => {
   t.mock.timers.enable({ apis: ["setTimeout"] });
   const context = harness();

--- a/apps/desktop/src/renderer/voice/conversation-call-endings.test.ts
+++ b/apps/desktop/src/renderer/voice/conversation-call-endings.test.ts
@@ -412,9 +412,35 @@ test("a service error is surfaced rather than swallowed", async () => {
   const context = harness();
   await context.session.connect();
 
-  context.emit({ type: REALTIME_SERVER_EVENT.ERROR, error: { message: "Session expired" } });
+  context.emit({ type: REALTIME_SERVER_EVENT.ERROR, error: { message: "Rate limit reached" } });
 
-  assert.ok(context.errors.includes("Session expired"));
+  assert.ok(context.errors.includes("Rate limit reached"));
+});
+
+test("a session_expired error ends the call quietly", async () => {
+  const context = harness();
+  await context.session.connect();
+
+  context.emit({
+    type: REALTIME_SERVER_EVENT.ERROR,
+    error: {
+      type: "invalid_request_error",
+      code: "session_expired",
+      message: "Your session hit the maximum duration of 60 minutes.",
+    },
+  });
+
+  assert.equal(context.session.status, REALTIME_STATUS.IDLE);
+  assert.equal(context.session.isConnected, false);
+  assert.deepEqual(reportedErrors(context), []);
+
+  // The channel abort that follows lands on a call already put away.
+  context.closeChannel();
+  assert.equal(context.session.status, REALTIME_STATUS.IDLE);
+  assert.deepEqual(reportedErrors(context), []);
+
+  assert.equal(await context.session.connect(), true);
+  assert.equal(context.session.status, REALTIME_STATUS.READY);
 });
 
 test("malformed server data never breaks the session", async () => {

--- a/apps/desktop/src/renderer/voice/conversation-call.ts
+++ b/apps/desktop/src/renderer/voice/conversation-call.ts
@@ -221,7 +221,6 @@ export class ConversationCall extends SpeakOnlyCall<ConversationCallOptions> {
       // under way is cut off now, exactly as the stop key cuts one, and the
       // turn itself opens when the device arrives.
       this.stopSpeaking();
-      this.#clearIdleTimer();
       this.#pendingTurn = true;
       this.#acquireMicrophone();
       return;
@@ -429,17 +428,18 @@ export class ConversationCall extends SpeakOnlyCall<ConversationCallOptions> {
     }
   }
 
+  /**
+   * The countdown is not cleared by a press, only re-read at the fire: a
+   * press let go of before its device arrived leaves the status at READY and
+   * would otherwise stand the call up until the provider's cap. A press or
+   * reply still under way at the fire starts the countdown over instead.
+   */
   #armIdleTimer(): void {
     this.#idleTimer ??= setTimeout(() => {
       this.#idleTimer = undefined;
-      // Re-read at the fire: a press or a reply since the arm makes the
-      // countdown moot.
-      if (
-        !this.isConnected ||
-        this.status !== REALTIME_STATUS.READY ||
-        this.#pendingTurn ||
-        this.replying
-      ) {
+      if (!this.isConnected || this.status !== REALTIME_STATUS.READY) return;
+      if (this.#pendingTurn || this.replying) {
+        this.#armIdleTimer();
         return;
       }
       this.endCall();

--- a/apps/desktop/src/renderer/voice/conversation-call.ts
+++ b/apps/desktop/src/renderer/voice/conversation-call.ts
@@ -50,6 +50,16 @@ import { ToolFollowUp } from "./tool-follow-up";
  */
 export type AppActionCarrier = (action: BrainAppActionRequest["action"]) => Promise<WireRecord>;
 
+/**
+ * How long the developer's call stands with nothing happening on it before
+ * it is put away. The provider caps a session at sixty minutes and ends it
+ * with a fault, a follow-up after minutes of silence has no use for the
+ * server-side context the call kept (the conversation itself is the brain's
+ * History), and a new call opens in under a second. Luke's own speak-only
+ * call is not covered: the mouth already owns that lifetime.
+ */
+export const IDLE_CALL_RETIRE_MS = 5 * 60_000;
+
 export interface ConversationCallOptions extends SpeakOnlyCallOptions {
   /**
    * Answers the voice's one tool: the developer's words go to the brain under
@@ -160,6 +170,7 @@ export class ConversationCall extends SpeakOnlyCall<ConversationCallOptions> {
    * an intention rather than a turn.
    */
   #pendingTurn = false;
+  #idleTimer: ReturnType<typeof setTimeout> | undefined;
   /**
    * The calls an armed reply asked for, and whether the follow-up voicing
    * their outcomes is still owed. The turn holds through the writes — a READY
@@ -210,6 +221,7 @@ export class ConversationCall extends SpeakOnlyCall<ConversationCallOptions> {
       // under way is cut off now, exactly as the stop key cuts one, and the
       // turn itself opens when the device arrives.
       this.stopSpeaking();
+      this.#clearIdleTimer();
       this.#pendingTurn = true;
       this.#acquireMicrophone();
       return;
@@ -409,7 +421,35 @@ export class ConversationCall extends SpeakOnlyCall<ConversationCallOptions> {
     // the commit Luke is just starting to answer. Here the reply is over and
     // the blip lands in the quiet. A press already waiting keeps the device:
     // its turn is about to reuse it.
-    if (status === REALTIME_STATUS.READY && !this.#pendingTurn) this.#releaseMicrophone();
+    if (status === REALTIME_STATUS.READY && !this.#pendingTurn) {
+      this.#releaseMicrophone();
+      this.#armIdleTimer();
+    } else {
+      this.#clearIdleTimer();
+    }
+  }
+
+  #armIdleTimer(): void {
+    this.#idleTimer ??= setTimeout(() => {
+      this.#idleTimer = undefined;
+      // Re-read at the fire: a press or a reply since the arm makes the
+      // countdown moot.
+      if (
+        !this.isConnected ||
+        this.status !== REALTIME_STATUS.READY ||
+        this.#pendingTurn ||
+        this.replying
+      ) {
+        return;
+      }
+      this.endCall();
+    }, IDLE_CALL_RETIRE_MS);
+  }
+
+  #clearIdleTimer(): void {
+    if (this.#idleTimer === undefined) return;
+    clearTimeout(this.#idleTimer);
+    this.#idleTimer = undefined;
   }
 
   protected override onPeerConnection(
@@ -441,6 +481,7 @@ export class ConversationCall extends SpeakOnlyCall<ConversationCallOptions> {
     for (const track of tracks) step(() => track.stop());
     super.onTeardown(step);
     this.#pendingTurn = false;
+    this.#clearIdleTimer();
     step(() => this.options.onLocalStream(undefined));
   }
 

--- a/apps/desktop/src/renderer/voice/realtime-call.ts
+++ b/apps/desktop/src/renderer/voice/realtime-call.ts
@@ -306,6 +306,15 @@ export abstract class RealtimeCall<Options extends RealtimeCallOptions = Realtim
     ) {
       return;
     }
+    this.endCall();
+  }
+
+  /**
+   * The ordinary end of a call: the channel closed under it, the provider
+   * ended it at its cap, or it stood idle long enough. Nothing is reported,
+   * `#closed` stays as it was, and the next `connect()` opens a fresh call.
+   */
+  protected endCall(): void {
     this.onCallLost();
     this.teardown();
     this.setStatus(REALTIME_STATUS.IDLE);

--- a/apps/desktop/src/renderer/voice/speak-only-call.ts
+++ b/apps/desktop/src/renderer/voice/speak-only-call.ts
@@ -57,6 +57,9 @@ export const BRAIN_ASK_SETTLE_TIMEOUT_MS = 60_000;
  */
 export const REMOTE_QUIET_MS = 2_500;
 
+/** The provider's own code for a call it ended at its maximum duration. */
+const SESSION_EXPIRED_ERROR_CODE = "session_expired";
+
 /**
  * What a call Luke opens for himself declares at the API. The empty tool list
  * and the choice that can pick nothing from it are the whole of `CLAUDE.md`'s
@@ -559,6 +562,14 @@ export class SpeakOnlyCall<
         // sentence and never shown.
         if (Interruption.pastAudioEnd(event.message)) return;
         if (this.#interruption.error(event)) return;
+        // The provider ending a call at its maximum duration is an ordinary
+        // end, not a fault: nothing is drawn, and the next press opens a
+        // fresh call. The channel abort that follows lands on a transport
+        // the teardown has already let go of.
+        if (event.errorCode === SESSION_EXPIRED_ERROR_CODE) {
+          this.endCall();
+          return;
+        }
         this.options.onError(event.message);
         // An error can arrive *instead of* `response.done` — an empty push-to-talk
         // commit is the common case — which would otherwise leave the call
@@ -825,6 +836,11 @@ export class SpeakOnlyCall<
   }
 
   /** Starts the backstop for a reply whose proper ending never arrives. */
+  /** Whether the server has confirmed a reply it has not yet finished. */
+  protected get replying(): boolean {
+    return this.#activeResponseId !== undefined;
+  }
+
   protected armSettleTimer(delayMs: number = REALTIME_SETTLE_TIMEOUT_MS): void {
     this.#settleTimer ??= setTimeout(() => {
       this.#settleTimer = undefined;

--- a/apps/desktop/src/testing/conversation-call-harness.ts
+++ b/apps/desktop/src/testing/conversation-call-harness.ts
@@ -4,6 +4,7 @@
  * connecting, endings, interruption, the brain, the caption, the device — and
  * one harness is what keeps those files describing the same call.
  */
+import { after } from "node:test";
 import { BRAIN_ASK_PENDING_NOTE } from "@sidecar/brain/requests";
 import { BRAIN_ASK_PENDING_STATUS, type BrainAskResult } from "@sidecar/brain/requests-wire";
 import type { TraceDirection } from "@sidecar/devtrace/vocabulary";
@@ -118,6 +119,16 @@ export function brainAnswer(briefing: string, runId = "run-1"): BrainAskResult {
 export function brainPending(): BrainAskResult {
   return { status: BRAIN_ASK_PENDING_STATUS, note: BRAIN_ASK_PENDING_NOTE };
 }
+
+/**
+ * A developer's call left standing arms its idle retirement, a real timer of
+ * minutes; closing every call at the end lets the test process exit rather
+ * than wait one out.
+ */
+const openSessions: ConversationCall[] = [];
+after(async () => {
+  for (const session of openSessions) await session.close();
+});
 
 export function harness(
   options: {
@@ -380,6 +391,7 @@ export function harness(
     };
   }
   const session = new ConversationCall(sessionOptions);
+  openSessions.push(session);
 
   return {
     session,


### PR DESCRIPTION
## Summary

A trace from 2026-09-08 showed the developer's realtime call opened, used for one ask, then left idle until OpenAI closed it at 8:05 PM with `session_expired` ("Your session hit the maximum duration of 60 minutes"). The channel abort that followed reached the renderer as an `RTCErrorEvent`, which the error renderer could not print, so the panel drew a red `[object RTCErrorEvent]` caption.

- **Idle retirement.** The developer's call now retires itself after five minutes with nothing happening on it (`IDLE_CALL_RETIRE_MS` in `conversation-call.ts`). The timer is armed when the call settles to READY, cleared on any status change, a press, or teardown, and re-checks its conditions at fire time. Luke's own speak-only call is excluded: the mouth already owns that lifetime. The conversation lives in the brain's History, so nothing durable is lost when a call ends.
- **A provider-ended call is an ordinary end.** An `ERROR` with code `session_expired` ends the call quietly (status `idle`, no caption, next press opens a fresh call) instead of surfacing a fault.
- **Late errors on a closed transport are dropped.** Once `close()` has run or the transport is disconnected/disconnecting, the SDK's error reports are not surfaced. A close failure itself still surfaces.
- **`RTCErrorEvent` renders legibly** by the message of the `RTCError` it carries, with a fixed fallback sentence rather than `String(value)`.

## Tests

- `conversation-call-device.test.ts` and `conversation-call-endings.test.ts`: the idle call retires after five minutes and reconnects cleanly; a press during the countdown keeps the call and restarts it; Luke's own call is not retired; `session_expired` ends the call quietly and the following channel close reports nothing. The generic error test now uses a non-expiry message. A suite-level `after` in the shared conversation-call harness closes every call so the real idle timer cannot keep the test process alive.
- `agents-realtime-transport.test.ts`: `RTCErrorEvent` rendering; errors after close or disconnect are not reported.

## Verification

- `./scripts/check.sh` passes.
- No drawn surface changed, so `verify.sh` was not run and no physical-notch check was performed. The manual idle-for-five-minutes check on a Mac has not been done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/baef7ef2-5b38-44e4-af31-fa6c9424e66a)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34380832899/artifacts/10115865785) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34380832899)

- Commit: `36847328048bdc0e6a0f2a71c1b7662213e3bfae`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
