### PR TITLE
fix(brain): migrate a pre-rename store forward instead of refusing it

### DIFF
--- a/packages/brain/src/store/database.test.ts
+++ b/packages/brain/src/store/database.test.ts
@@ -616,21 +616,211 @@ test("the checkpoint stamp lives on the generation: an empty foreign checkpoint 
   );
 });
 
-test("a database from before the rename is refused at the door, and a newer one is never guessed at", () => {
+test("a database from before the rename opens with its lines, archives, and requests carried under the new names, and a newer one is never guessed at", () => {
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), "luke-runtime-store-"));
   const location = path.join(directory, "agent.sqlite");
-  StoreDatabase.open(location).close();
-  const earlier = new DatabaseSync(location);
-  earlier.exec("UPDATE schema_version SET version = 10");
-  earlier.close();
-  assert.throws(
-    () => StoreDatabase.open(location),
-    new RegExp(`schema version 10, not ${STORE_SCHEMA_VERSION}`, "u"),
+  const seeded = StoreDatabase.open(location);
+  createConversation(seeded, {
+    agentId: DEFAULT_AGENT_ID,
+    sessionKey: MAIN_SESSION_KEY,
+    name: "main",
+    now: NOW,
+  });
+  saveBrainEnvelope(seeded, MAIN_SESSION_KEY, {
+    kind: SAVE_KIND.REPLACE,
+    state: populatedState("gen-kept"),
+  });
+  appendConversation(seeded, MAIN_SESSION_KEY, [line("kept", NOW, { eventId: "k" })], NOW);
+  raiseConversationCutoff(seeded, MAIN_SESSION_KEY, NOW - 1);
+  seeded.close();
+
+  // The shape version 10 wrote: the same rows under the old table and column names.
+  const older = new DatabaseSync(location);
+  older.exec(
+    "ALTER TABLE conversations RENAME COLUMN next_conversation_sequence TO next_history_sequence",
   );
+  older.exec(
+    "ALTER TABLE conversations RENAME COLUMN conversation_cleared_at TO history_cleared_at",
+  );
+  older.exec("ALTER TABLE requests RENAME COLUMN performed_actions TO performed_acts");
+  older.exec("ALTER TABLE requests RENAME COLUMN unknown_actions TO unknown_acts");
+  older.exec("ALTER TABLE requests RENAME COLUMN conversation_recorded_at TO history_recorded_at");
+  older.exec("ALTER TABLE conversation_events RENAME TO history_events");
+  older.exec("ALTER TABLE conversation_archives RENAME TO history_archives");
+  older.exec("ALTER TABLE history_archives RENAME COLUMN conversation_lines TO history_lines");
+  older.exec("UPDATE schema_version SET version = 10");
+  older.close();
+
+  const database = StoreDatabase.open(location);
+  // SAFETY: the schema_version table has one integer column.
+  const version = database.prepare("SELECT version FROM schema_version").get() as {
+    version: number;
+  };
+  assert.equal(version.version, STORE_SCHEMA_VERSION);
+  // SAFETY: sqlite_master's name column is text.
+  const names = new Set(
+    (database.prepare("SELECT name FROM sqlite_master").all() as { name: string }[]).map(
+      (row) => row.name,
+    ),
+  );
+  for (const gone of ["history_events", "history_archives", "history_events_by_key"]) {
+    assert.equal(names.has(gone), false, gone);
+  }
+  for (const stands of [
+    "conversation_events",
+    "conversation_archives",
+    "conversation_events_by_key",
+    "conversation_events_by_time",
+    "conversation_events_once_published",
+  ]) {
+    assert.equal(names.has(stands), true, stands);
+  }
+  assert.equal(loadBrainEnvelope(database, MAIN_SESSION_KEY).state?.generationId, "gen-kept");
+  assert.deepEqual(
+    listConversation(database, MAIN_SESSION_KEY, NOW).map((entry) => entry.words),
+    ["kept"],
+  );
+  assert.equal(conversationClearedAt(database, MAIN_SESSION_KEY), NOW - 1);
+  // The renamed table keeps its constraints: a second publication of the same line is one line.
+  assert.equal(
+    appendConversation(database, MAIN_SESSION_KEY, [line("kept", NOW, { eventId: "k" })], NOW)
+      .changed,
+    false,
+  );
+  database.close();
+  // Reopening at the current version is a no-op, and a newer database is refused.
+  StoreDatabase.open(location).close();
   const newer = new DatabaseSync(location);
   newer.exec("UPDATE schema_version SET version = 99");
   newer.close();
   assert.throws(() => StoreDatabase.open(location), /schema version 99/u);
+  fs.rmSync(directory, { recursive: true, force: true });
+});
+
+test("a version-1 database is walked forward: its item-tagged generation gains the legacy stamp and its row the later columns", () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "luke-store-"));
+  const location = path.join(directory, "agent.sqlite");
+  const raw = new DatabaseSync(location);
+  raw.exec(`CREATE TABLE schema_version (version INTEGER NOT NULL)`);
+  raw.exec(`INSERT INTO schema_version (version) VALUES (1)`);
+  raw.exec(`CREATE TABLE agents (agent_id TEXT PRIMARY KEY, created_at INTEGER NOT NULL)`);
+  raw.exec(`CREATE TABLE conversations (
+    session_key TEXT PRIMARY KEY, agent_id TEXT NOT NULL REFERENCES agents(agent_id),
+    name TEXT NOT NULL, created_at INTEGER NOT NULL,
+    next_history_sequence INTEGER NOT NULL DEFAULT 1, history_cleared_at INTEGER)`);
+  raw.exec(`CREATE TABLE conversation_sessions (
+    session_id TEXT PRIMARY KEY, session_key TEXT NOT NULL REFERENCES conversations(session_key),
+    created_at INTEGER NOT NULL, expires_at INTEGER NOT NULL,
+    reset_cleared_at INTEGER, reset_generation_id TEXT)`);
+  raw.exec(`CREATE TABLE runtime_checkpoints (
+    session_id TEXT NOT NULL REFERENCES conversation_sessions(session_id) ON DELETE CASCADE,
+    sequence INTEGER NOT NULL, format TEXT NOT NULL, item TEXT NOT NULL,
+    PRIMARY KEY (session_id, sequence))`);
+  raw.prepare("INSERT INTO agents VALUES (?, ?)").run("main", NOW);
+  raw
+    .prepare(
+      "INSERT INTO conversations (session_key, agent_id, name, created_at) VALUES (?, ?, ?, ?)",
+    )
+    .run(MAIN_SESSION_KEY, "main", "main", NOW);
+  const lifetime = 14 * 24 * 60 * 60 * 1000;
+  raw
+    .prepare(
+      "INSERT INTO conversation_sessions (session_id, session_key, created_at, expires_at) VALUES (?, ?, ?, ?)",
+    )
+    .run("gen-old", MAIN_SESSION_KEY, NOW, NOW + lifetime);
+  raw
+    .prepare("INSERT INTO runtime_checkpoints VALUES (?, ?, ?, ?)")
+    .run(
+      "gen-old",
+      0,
+      "openai-responses-input/1",
+      JSON.stringify({ type: "message", role: "user", content: "x" }),
+    );
+  raw.close();
+
+  const database = StoreDatabase.open(location);
+  const loaded = loadBrainEnvelope(database, MAIN_SESSION_KEY);
+  assert.equal(loaded.state?.checkpointFormat, "tool-loop@1:openai-responses-input/1");
+  assert.equal(loaded.state?.items.length, 1);
+  // SAFETY: the schema_version table has one integer column.
+  const version = database.prepare("SELECT version FROM schema_version").get() as {
+    version: number;
+  };
+  assert.equal(version.version, STORE_SCHEMA_VERSION);
+  // SAFETY: the columns version 3 and 11 gave the conversation row.
+  const migrated = database
+    .prepare(
+      "SELECT kind, last_activity_at, next_conversation_sequence FROM conversations WHERE session_key = ?",
+    )
+    .get(MAIN_SESSION_KEY) as {
+    kind: string;
+    last_activity_at: number;
+    next_conversation_sequence: number;
+  };
+  assert.equal(migrated.kind, "main");
+  assert.equal(migrated.last_activity_at, NOW);
+  assert.equal(migrated.next_conversation_sequence, 1);
+  assert.deepEqual(
+    appendConversation(
+      database,
+      MAIN_SESSION_KEY,
+      [line("first", NOW, { eventId: "f" })],
+      NOW,
+    ).entries.map((entry) => entry.words),
+    ["first"],
+  );
+  database.close();
+  StoreDatabase.open(location).close();
+  fs.rmSync(directory, { recursive: true, force: true });
+});
+
+test("a database still carrying the retired memory tables opens with them dropped and everything else intact", () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "luke-store-"));
+  const location = path.join(directory, "agent.sqlite");
+  const seeded = StoreDatabase.open(location);
+  createConversation(seeded, {
+    agentId: DEFAULT_AGENT_ID,
+    sessionKey: MAIN_SESSION_KEY,
+    name: "main",
+    now: NOW,
+  });
+  saveBrainEnvelope(seeded, MAIN_SESSION_KEY, {
+    kind: SAVE_KIND.REPLACE,
+    state: populatedState("gen-kept"),
+  });
+  appendConversation(seeded, MAIN_SESSION_KEY, [line("kept", NOW, { eventId: "k" })], NOW);
+  seeded.close();
+
+  // The shape a build before the memory tables went: their rows stand under
+  // the pre-rename table names, and the version is the one before the
+  // migration that drops them.
+  const older = new DatabaseSync(location);
+  older.exec("CREATE TABLE memory_candidates (candidate_id TEXT PRIMARY KEY, words TEXT NOT NULL)");
+  older.prepare("INSERT INTO memory_candidates VALUES (?, ?)").run("c-1", "CANDIDATE_SECRET");
+  older.exec("ALTER TABLE conversation_events RENAME TO history_events");
+  older.exec("UPDATE schema_version SET version = 9");
+  older.close();
+
+  const database = StoreDatabase.open(location);
+  // SAFETY: the query selects the one column its row type names.
+  const tables = database
+    .prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name LIKE 'memory_%'")
+    .all() as { name: string }[];
+  const names = new Set(tables.map((row) => row.name));
+  assert.equal(names.has("memory_candidates"), false);
+  assert.equal(names.has("memory_index_chunks"), true);
+  assert.equal(names.has("memory_flush_state"), true);
+  // SAFETY: as above.
+  const version = database.prepare("SELECT version FROM schema_version").get() as {
+    version: number;
+  };
+  assert.equal(version.version, STORE_SCHEMA_VERSION);
+  assert.equal(loadBrainEnvelope(database, MAIN_SESSION_KEY).state?.generationId, "gen-kept");
+  assert.deepEqual(
+    listConversation(database, MAIN_SESSION_KEY, NOW).map((entry) => entry.words),
+    ["kept"],
+  );
+  database.close();
   fs.rmSync(directory, { recursive: true, force: true });
 });
 

--- a/packages/brain/src/store/database.ts
+++ b/packages/brain/src/store/database.ts
@@ -105,7 +105,10 @@ export class StoreDatabase {
         // does not know at all, raised above.
         for (let version = row.version + 1; version <= STORE_SCHEMA_VERSION; version += 1) {
           const steps = STORE_SCHEMA_MIGRATIONS.get(version) ?? [];
-          for (const step of steps) this.#db.prepare(step.sql).run(...step.params);
+          for (const step of steps) {
+            if (step.onlyIf && !this.#stands(step.onlyIf)) continue;
+            this.#db.prepare(step.sql).run(...step.params);
+          }
         }
       }
       if (!row) {
@@ -116,6 +119,19 @@ export class StoreDatabase {
         this.#db.prepare("UPDATE schema_version SET version = ?").run(STORE_SCHEMA_VERSION);
       }
     });
+  }
+
+  #stands(target: { table: string; column?: string }): boolean {
+    const table = this.#db
+      .prepare("SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?")
+      .get(target.table);
+    if (!table) return false;
+    if (target.column === undefined) return true;
+    return (
+      this.#db
+        .prepare("SELECT 1 FROM pragma_table_info(?) WHERE name = ?")
+        .get(target.table, target.column) !== undefined
+    );
   }
 
   prepare(sql: string): StatementSync {

--- a/packages/brain/src/store/schema.ts
+++ b/packages/brain/src/store/schema.ts
@@ -68,23 +68,24 @@
  * `conversation_events` for its lines and `conversation_archives` for the
  * recovery payloads of deleted conversations, with the conversation row's
  * sequence, cutoff, and the request's recorded-at column named to match.
- * Version 11 carries nothing across that rename: a database from before it
- * is refused at the door rather than opened onto tables whose columns it
- * lacks, and no step exists to carry it over.
- *
- * The conversation's own tables are named for what they hold:
- * `conversation_events` for its lines and `conversation_archives` for the
- * recovery payloads of deleted conversations, with the conversation row's
- * sequence, cutoff, and the request's recorded-at column named to match.
- * Version 11 carries nothing across that rename: a database from before it
- * is refused at the door rather than opened onto tables whose columns it
- * lacks, and no step exists to carry it over.
+ * Version 11 renames them in place: a database from before it keeps every
+ * line, archive, and request it held, under the new names.
  *
  * The schema is versioned by the `schema_version` table. A database at a
  * version this build does not know is refused rather than migrated by guess.
  */
 
 import type { SQLInputValue } from "node:sqlite";
+
+/**
+ * The stamp version 2 writes onto a checkpoint stored before stamps existed:
+ * every such checkpoint was the tool-loop runtime's first version over the
+ * Responses input array, because nothing else ever wrote one. Pinned history,
+ * so it is a literal rather than composed from this build's own ids — a
+ * runtime or item format renamed later must not change what a decade-old row
+ * is said to be.
+ */
+const LEGACY_CHECKPOINT_FORMAT_TAG = "tool-loop@1:openai-responses-input/1";
 
 /**
  * One flush marker per conversation: the generation and compaction count the
@@ -102,13 +103,11 @@ const MEMORY_FLUSH_STATE_TABLE = `CREATE TABLE IF NOT EXISTS memory_flush_state 
 export const STORE_SCHEMA_VERSION = 11;
 
 /**
- * The earliest version this build opens. The rename at 11 carried nothing
- * across: a database from before it still holds the old table and column
- * names, and `CREATE TABLE IF NOT EXISTS` cannot rename a column on a table
- * that already stands, so opening one would fail at its first write. It is
- * refused at the door instead, and there is no step that carries it over.
+ * The earliest version this build opens. Every version since the first has a
+ * step below or changed nothing a step must carry, so no database a released
+ * build wrote is refused for its age.
  */
-export const STORE_SCHEMA_FLOOR = 11;
+export const STORE_SCHEMA_FLOOR = 1;
 
 /**
  * How a database at an earlier version is brought to this one, in order. Each
@@ -121,10 +120,164 @@ export const STORE_SCHEMA_FLOOR = 11;
 export interface SchemaMigrationStep {
   sql: string;
   params: readonly SQLInputValue[];
+  /**
+   * Runs the step only where the named table, or the named column of it,
+   * stands. A rename must be skipped on a database that never had the old
+   * name — one created at a version whose current statements already made the
+   * table under the new one — and SQLite's DDL carries no condition of its own.
+   */
+  onlyIf?: { table: string; column?: string };
 }
 
-export const STORE_SCHEMA_MIGRATIONS: ReadonlyMap<number, readonly SchemaMigrationStep[]> =
-  new Map();
+const CONVERSATION_EVENTS_INDEXES: readonly string[] = [
+  `CREATE UNIQUE INDEX IF NOT EXISTS conversation_events_by_key
+    ON conversation_events(session_key, event_key)`,
+  `CREATE INDEX IF NOT EXISTS conversation_events_by_time
+    ON conversation_events(session_key, recorded_at, sequence)`,
+  `CREATE UNIQUE INDEX IF NOT EXISTS conversation_events_once_published
+    ON conversation_events(session_key, request_id, kind) WHERE request_id IS NOT NULL`,
+];
+
+/**
+ * The rename at 11. The current statements have already created the new
+ * tables empty where none stood, so a table under the old name is carried
+ * over by dropping that empty stand-in and renaming the old one into its
+ * place; a column is renamed on the table that already stands. Each step is
+ * guarded on the old name, so a database whose tables were created under the
+ * new names has nothing to do here.
+ */
+const RENAME_TO_CONVERSATION_STEPS: readonly SchemaMigrationStep[] = [
+  {
+    sql: "ALTER TABLE conversations RENAME COLUMN next_history_sequence TO next_conversation_sequence",
+    params: [],
+    onlyIf: { table: "conversations", column: "next_history_sequence" },
+  },
+  {
+    sql: "ALTER TABLE conversations RENAME COLUMN history_cleared_at TO conversation_cleared_at",
+    params: [],
+    onlyIf: { table: "conversations", column: "history_cleared_at" },
+  },
+  {
+    sql: "ALTER TABLE requests RENAME COLUMN performed_acts TO performed_actions",
+    params: [],
+    onlyIf: { table: "requests", column: "performed_acts" },
+  },
+  {
+    sql: "ALTER TABLE requests RENAME COLUMN unknown_acts TO unknown_actions",
+    params: [],
+    onlyIf: { table: "requests", column: "unknown_acts" },
+  },
+  {
+    sql: "ALTER TABLE requests RENAME COLUMN history_recorded_at TO conversation_recorded_at",
+    params: [],
+    onlyIf: { table: "requests", column: "history_recorded_at" },
+  },
+  { sql: "DROP TABLE conversation_events", params: [], onlyIf: { table: "history_events" } },
+  {
+    sql: "ALTER TABLE history_events RENAME TO conversation_events",
+    params: [],
+    onlyIf: { table: "history_events" },
+  },
+  { sql: "DROP INDEX IF EXISTS history_events_by_key", params: [] },
+  { sql: "DROP INDEX IF EXISTS history_events_by_time", params: [] },
+  { sql: "DROP INDEX IF EXISTS history_events_once_published", params: [] },
+  ...CONVERSATION_EVENTS_INDEXES.map((sql) => ({ sql, params: [] })),
+  { sql: "DROP TABLE conversation_archives", params: [], onlyIf: { table: "history_archives" } },
+  {
+    sql: "ALTER TABLE history_archives RENAME TO conversation_archives",
+    params: [],
+    onlyIf: { table: "history_archives" },
+  },
+  {
+    sql: "ALTER TABLE conversation_archives RENAME COLUMN history_lines TO conversation_lines",
+    params: [],
+    onlyIf: { table: "conversation_archives", column: "history_lines" },
+  },
+];
+
+export const STORE_SCHEMA_MIGRATIONS: ReadonlyMap<number, readonly SchemaMigrationStep[]> = new Map(
+  [
+    [
+      2,
+      [
+        { sql: "ALTER TABLE conversation_sessions ADD COLUMN checkpoint_format TEXT", params: [] },
+        {
+          sql: `UPDATE conversation_sessions SET checkpoint_format = ?
+       WHERE checkpoint_format IS NULL
+         AND EXISTS (SELECT 1 FROM runtime_checkpoints WHERE runtime_checkpoints.session_id = conversation_sessions.session_id)`,
+          params: [LEGACY_CHECKPOINT_FORMAT_TAG],
+        },
+      ],
+    ],
+    [
+      3,
+      [
+        { sql: "ALTER TABLE runtime_checkpoints DROP COLUMN format", params: [] },
+        {
+          sql: "ALTER TABLE conversations ADD COLUMN kind TEXT NOT NULL DEFAULT 'main'",
+          params: [],
+        },
+        { sql: "ALTER TABLE conversations ADD COLUMN archived_at INTEGER", params: [] },
+        { sql: "ALTER TABLE conversations ADD COLUMN archive_reason TEXT", params: [] },
+        { sql: "ALTER TABLE conversations ADD COLUMN pinned_at INTEGER", params: [] },
+        {
+          sql: "ALTER TABLE conversations ADD COLUMN last_activity_at INTEGER NOT NULL DEFAULT 0",
+          params: [],
+        },
+        {
+          sql: "ALTER TABLE conversations ADD COLUMN next_transcript_sequence INTEGER NOT NULL DEFAULT 1",
+          params: [],
+        },
+        // The lines stand under the current statements' table on a database
+        // that never had the pre-11 name, and under that name on one that did;
+        // the second statement recomputes over the old table where it stands.
+        {
+          sql: `UPDATE conversations SET last_activity_at = MAX(
+         created_at,
+         COALESCE((SELECT MAX(recorded_at) FROM conversation_events WHERE conversation_events.session_key = conversations.session_key), 0),
+         COALESCE((SELECT MAX(created_at) FROM conversation_sessions WHERE conversation_sessions.session_key = conversations.session_key), 0)
+       )`,
+          params: [],
+        },
+        {
+          sql: `UPDATE conversations SET last_activity_at = MAX(
+         created_at,
+         COALESCE((SELECT MAX(recorded_at) FROM history_events WHERE history_events.session_key = conversations.session_key), 0),
+         COALESCE((SELECT MAX(created_at) FROM conversation_sessions WHERE conversation_sessions.session_key = conversations.session_key), 0)
+       )`,
+          params: [],
+          onlyIf: { table: "history_events" },
+        },
+      ],
+    ],
+    [
+      9,
+      [
+        {
+          sql: "ALTER TABLE conversation_sessions ADD COLUMN compaction_count INTEGER NOT NULL DEFAULT 0",
+          params: [],
+        },
+        // The flush marker is keyed by the generation it was written under
+        // from this version on; rows from before it name no generation and
+        // were read by nothing, so the table starts over rather than
+        // carrying a marker no cycle can claim.
+        { sql: "DROP TABLE memory_flush_state", params: [] },
+        { sql: MEMORY_FLUSH_STATE_TABLE, params: [] },
+      ],
+    ],
+    [
+      10,
+      [
+        { sql: "DROP TABLE IF EXISTS memory_candidates", params: [] },
+        { sql: "DROP TABLE IF EXISTS memory_ingestion_cursors", params: [] },
+        { sql: "DROP TABLE IF EXISTS memory_ingested_messages", params: [] },
+        { sql: "DROP TABLE IF EXISTS memory_forgotten_sources", params: [] },
+        { sql: "DROP TABLE IF EXISTS memory_rewrites", params: [] },
+      ],
+    ],
+    [11, RENAME_TO_CONVERSATION_STEPS],
+  ],
+);
 
 export const STORE_SCHEMA_STATEMENTS: readonly string[] = [
   `CREATE TABLE IF NOT EXISTS schema_version (
@@ -234,12 +387,7 @@ export const STORE_SCHEMA_STATEMENTS: readonly string[] = [
     payload TEXT NOT NULL,
     PRIMARY KEY (session_key, sequence)
   )`,
-  `CREATE UNIQUE INDEX IF NOT EXISTS conversation_events_by_key
-    ON conversation_events(session_key, event_key)`,
-  `CREATE INDEX IF NOT EXISTS conversation_events_by_time
-    ON conversation_events(session_key, recorded_at, sequence)`,
-  `CREATE UNIQUE INDEX IF NOT EXISTS conversation_events_once_published
-    ON conversation_events(session_key, request_id, kind) WHERE request_id IS NOT NULL`,
+  ...CONVERSATION_EVENTS_INDEXES,
   `CREATE TABLE IF NOT EXISTS transcript_events (
     session_key TEXT NOT NULL REFERENCES conversations(session_key),
     sequence INTEGER NOT NULL,


### PR DESCRIPTION
## Summary

Launching the current build over any store written before #795 failed with:

```
the runtime could not stand up: the brain's store is at schema version 9, not 11
```

The rename to Conversation at schema version 11 shipped with no step from an earlier version and deleted the migration ladder, so every existing install refused its own database.

- Version 11 now renames in place: `history_events` → `conversation_events`, `history_archives` → `conversation_archives`, and the renamed columns on `conversations`, `requests`, and the archives table. Lines, archives, requests, and the standing generation all survive.
- The ladder for versions 2, 3, 9, and 10 is restored and `STORE_SCHEMA_FLOOR` is back to 1, so a store from any released build opens.
- A migration step may carry an `onlyIf` guard on a table or column. The current `CREATE TABLE IF NOT EXISTS` statements run first and create the new tables empty, so the rename step drops that empty stand-in and renames the old table into its place, and skips itself on a database that never had the old name.

## Test plan

- [x] New test: a version-10 store (the reported shape) opens with its lines, cutoff, archives, and generation intact under the new names, and its unique index still refuses a duplicate line.
- [x] Restored test: a version-1 store is walked forward through every step.
- [x] Restored test: a version-9 store with the retired memory tables opens with them dropped.
- [x] `./scripts/check.sh` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34390094657/artifacts/10119402943) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34390094657)

- Commit: `494a7978767c52ca29ea3a7ef5ecb8af61d5392e`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
