### PR TITLE
fix(desktop): admit a voice view whose live lines are still streaming

### DIFF
--- a/apps/desktop/src/shared/messages/voice-view.test.ts
+++ b/apps/desktop/src/shared/messages/voice-view.test.ts
@@ -1,7 +1,16 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { REALTIME_STATUS } from "@sidecar/realtime";
-import { isRealtimeStatus, isVoiceCommand, VOICE_COMMAND } from "./voice-view";
+import { CONVERSATION_ENTRY_KIND, streamingConversationEntry } from "@sidecar/session";
+import type { UnparsedWireValue } from "@sidecar/wire";
+import {
+  IDLE_VOICE_VIEW,
+  isRealtimeStatus,
+  isVoiceCommand,
+  isVoiceView,
+  VOICE_COMMAND,
+  type VoiceView,
+} from "./voice-view";
 
 test("every realtime status is recognized and nothing else is", () => {
   for (const status of Object.values(REALTIME_STATUS)) {
@@ -17,4 +26,48 @@ test("the four voice commands are the whole set; a typed ask is a brain submissi
   assert.equal(isVoiceCommand("ask-text"), false);
   for (const command of commands) assert.equal(isVoiceCommand(command), true);
   assert.equal(isVoiceCommand("stop-microphone"), false);
+});
+
+/** The view as IPC hands it to the guard: a structured clone, its types erased. */
+function overWire(view: VoiceView): UnparsedWireValue {
+  // SAFETY: JSON.parse returns the erased value the guard under test exists to parse.
+  return JSON.parse(JSON.stringify(view)) as UnparsedWireValue;
+}
+
+test("a view carrying a caption and its streaming line is a voice view", () => {
+  const line = streamingConversationEntry(CONVERSATION_ENTRY_KIND.REPLY, "On my way.");
+  assert.ok(line);
+  assert.equal(
+    isVoiceView(
+      overWire({
+        ...IDLE_VOICE_VIEW,
+        voiceStatus: REALTIME_STATUS.RESPONDING,
+        lukeCaptions: ["On my way."],
+        liveConversationEntries: [line],
+      }),
+    ),
+    true,
+  );
+});
+
+test("a streaming line refuses empty words or an unknown kind", () => {
+  assert.equal(
+    isVoiceView(
+      overWire({
+        ...IDLE_VOICE_VIEW,
+        liveConversationEntries: [{ kind: CONVERSATION_ENTRY_KIND.REPLY, words: "" }],
+      }),
+    ),
+    false,
+  );
+  assert.equal(
+    isVoiceView(
+      overWire({
+        ...IDLE_VOICE_VIEW,
+        // SAFETY: the test hands the guard a kind it must refuse, which the view type cannot spell.
+        liveConversationEntries: [{ kind: "not-a-kind" as "reply", words: "words" }],
+      }),
+    ),
+    false,
+  );
 });

--- a/apps/desktop/src/shared/messages/voice-view.ts
+++ b/apps/desktop/src/shared/messages/voice-view.ts
@@ -22,6 +22,13 @@ export interface VoiceView {
   voiceNotice: string | undefined;
   talkOpening: boolean;
   lukeCaptions: readonly string[] | undefined;
+  /**
+   * The lines still being said, as `streamingConversationEntry` builds them:
+   * a kind and words, and no timestamp, because a line still growing has not
+   * happened yet. Read under the unstrict parse for that reason — the strict
+   * one refuses every unstamped line, which would drop the whole report at
+   * exactly the edges that carry a caption.
+   */
   liveConversationEntries: readonly ConversationEntry[];
 }
 
@@ -98,7 +105,11 @@ export function isVoiceView(value: UnparsedWireValue): value is VoiceView & Wire
   }
   const entries = value.liveConversationEntries;
   return (
-    Array.isArray(entries) && entries.every((entry) => storedConversationEntry(entry) !== undefined)
+    Array.isArray(entries) &&
+    entries.every((entry) => {
+      const streaming = storedConversationEntry(entry, { strict: false });
+      return streaming !== undefined && streaming.words.length > 0;
+    })
   );
 }
 


### PR DESCRIPTION
## Why

Captions stopped drawing under the housing, and the Conversation tab stopped showing the streaming reply line.

## Cause

`isVoiceView` validated `liveConversationEntries` with `storedConversationEntry(entry)`, whose default is strict and requires a `recordedAt`. The live lines come from `streamingConversationEntry`, which carries no timestamp ("a line still growing has not happened yet"). So whenever a caption or spoken-ask preview existed, the whole `app:report-voice-view` send failed the guard and `bridge-host.ts` dropped it silently. The panel kept the last accepted view, with captions `undefined`; once the reply ended the lines emptied and reports resumed, so status and meter looked fine. This surfaced with #848, which moved reporting into `VoiceViewReporter` and sends this exact shape through the guard.

## Change

- `voice-view.ts`: parse live lines with `storedConversationEntry(entry, { strict: false })`, the same unstrict read `main/gateway/wiring.ts` uses, and require non-empty words. Doc comment says why.
- `voice-view.test.ts`: a view carrying a caption and its streaming line is admitted; empty words or an unknown kind is refused.

## Verification

- `./scripts/check.sh` passes end to end.
- `./scripts/verify.sh` not run: this was fixed from a Linux sandbox, so no visual evidence and no physical-notch check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/12dbbf8e-35f3-4e1e-8812-978cf98dba99)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34393674661/artifacts/10120723867) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34393674661)

- Commit: `e07c1effdb6a59d97c984f364fe5bc676b7714c4`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
