### PR TITLE
docs: delete orphaned and narrating comments in apps

### DIFF
--- a/apps/desktop/src/main/ipc/brain.test.ts
+++ b/apps/desktop/src/main/ipc/brain.test.ts
@@ -58,7 +58,7 @@ function record(overrides: Partial<BrainRequestRecord> = {}): BrainRequestRecord
 function registered(live: () => BrainRequestRecord | undefined) {
   // SAFETY: the rows read senders by identity alone; two distinct inert objects are two windows.
   const voiceSender = {} as WebContents;
-  // SAFETY: as above, the panel.
+  // SAFETY: an inert object distinct from the one above, so the rows read it as a second window.
   const panelSender = {} as WebContents;
   let ids = 0;
   const deliveries = new DeliveryLedger<GrantedWords>({

--- a/apps/desktop/src/main/ipc/brain.test.ts
+++ b/apps/desktop/src/main/ipc/brain.test.ts
@@ -58,7 +58,7 @@ function record(overrides: Partial<BrainRequestRecord> = {}): BrainRequestRecord
 function registered(live: () => BrainRequestRecord | undefined) {
   // SAFETY: the rows read senders by identity alone; two distinct inert objects are two windows.
   const voiceSender = {} as WebContents;
-  // SAFETY: an inert object distinct from the one above, so the rows read it as a second window.
+  // SAFETY: a second inert object, so the rows read two distinct windows.
   const panelSender = {} as WebContents;
   let ids = 0;
   const deliveries = new DeliveryLedger<GrantedWords>({

--- a/apps/desktop/src/main/ipc/voice-runtime.test.ts
+++ b/apps/desktop/src/main/ipc/voice-runtime.test.ts
@@ -38,7 +38,7 @@ function fixture(clearConversation: () => Promise<boolean>) {
   const sentToVoice: { channel: string; payload: WireRecord }[] = [];
   // SAFETY: the row reads senders by identity alone; two distinct inert objects are two windows.
   const panelSender = {} as WebContents;
-  // SAFETY: as above, the second window.
+  // SAFETY: an inert object distinct from the one above, so the row reads it as a second window.
   const voiceSender = {} as WebContents;
   // SAFETY: the Clear path reads only `owns` and `current().webContents.send` off the voice window surface.
   const voiceWindow = {

--- a/apps/desktop/src/main/ipc/voice-runtime.test.ts
+++ b/apps/desktop/src/main/ipc/voice-runtime.test.ts
@@ -38,7 +38,7 @@ function fixture(clearConversation: () => Promise<boolean>) {
   const sentToVoice: { channel: string; payload: WireRecord }[] = [];
   // SAFETY: the row reads senders by identity alone; two distinct inert objects are two windows.
   const panelSender = {} as WebContents;
-  // SAFETY: an inert object distinct from the one above, so the row reads it as a second window.
+  // SAFETY: a second inert object, so the row reads two distinct windows.
   const voiceSender = {} as WebContents;
   // SAFETY: the Clear path reads only `owns` and `current().webContents.send` off the voice window surface.
   const voiceWindow = {

--- a/apps/desktop/src/main/ipc/window-surface.ts
+++ b/apps/desktop/src/main/ipc/window-surface.ts
@@ -106,11 +106,6 @@ export function windowSurfaceActRows(
   };
 }
 
-/**
- * What one window reports about its own surface. The pointer interception is
- * the window's own hit-testing, and the counting channel below is the one
- * thing the renderer counts for itself.
- */
 export function windowSurfaceReports(
   dependencies: Pick<WindowSurfaceDependencies, "recordProductEvent">,
 ): Pick<ReportHandlers, "setPointerInterception" | "recordSurfaceEvent"> {
@@ -121,9 +116,9 @@ export function windowSurfaceReports(
       });
     },
     /**
-     * The one counting channel the renderer has, and the narrowest thing in
-     * this file. Every other event is emitted where its act happens, in this
-     * process; these are surface motion no main-process handler can see.
+     * The one counting channel the renderer has. Every other event is emitted
+     * where its act happens, in this process; these are surface motion no
+     * main-process handler can see.
      *
      * Two gates rather than one. `isProductSurfaceEventName` is the narrowing
      * that matters: it refuses every name outside the surface set, so a

--- a/apps/desktop/src/main/services/operator-client.ts
+++ b/apps/desktop/src/main/services/operator-client.ts
@@ -95,9 +95,8 @@ export function createOperatorClient(dependencies: OperatorClientDependencies): 
     state.update(bootstrapPatch(state.snapshot(), boot));
   }
 
-  // What the host tells its clients, written to the document the windows are
-  // told from. The two offers a receiver alone may take are not state and
-  // reach the voice window directly.
+  // The two offers a receiver alone may take are not state and reach the voice
+  // window directly; everything else is written to the document.
   unsubscribers.push(
     gateway.host.onSettingsChanged((change) => {
       const stoodVoice = voiceAvailable;

--- a/apps/desktop/src/renderer/app-action-carrier.ts
+++ b/apps/desktop/src/renderer/app-action-carrier.ts
@@ -95,15 +95,10 @@ export function useAppActionCarrier(options: UseAppActionCarrierOptions): void {
   );
 
   /**
-   * The spoken asks about Luke himself. A settings change goes through the
-   * same bridge calls the settings rows use, and the snapshot that comes back
-   * redraws the panel's switches; showing the panel is the capsule's press
-   * with a tab — or, already open, that tab's own press — and optionally a
-   * narrowing, chosen out loud; opening the composer follows the spoken-ask
-   * path. All were validated against their fixed
+   * The spoken asks about Luke himself. All were validated against their fixed
    * vocabularies before they arrive here, so this only performs and reports.
    *
-   * A settings change and a change of view are also the two actions nobody
+   * A settings change and a change of view are the two actions nobody
    * watched anyone make, so both end by showing the control that moved and
    * sending Luke to it. A settings change stands the panel up on the Settings
    * tab to do it: the switch is the whole report, and a switch flipped behind

--- a/apps/desktop/src/renderer/errand-queue.ts
+++ b/apps/desktop/src/renderer/errand-queue.ts
@@ -8,24 +8,17 @@ import type { SettingsView } from "./settings-views";
  * The order Luke signs his own work in, when one reply asked for more than one
  * act.
  *
- * A reply may carry several tool calls, and they are answered one after
- * another with nothing between them but a couple of IPC round trips — far
- * inside the beat an errand waits before it sets off. So the actions arrive as a
- * burst and the flights cannot: there is only ever one Luke on screen, one
- * panel, and one settings page drawn at a time, and each of those is something
- * a second action would take out from under the first. Handed straight to the
- * flight, the second action ends the first mid-air: the mark never leaves the
- * strip, both controls flip at once, and only the last action is seen being done
- * — which is the whole of what an errand is for.
- *
- * So the actions queue and the flights run in turn. Each action carries what it is
- * holding back — the settings snapshot the store answered with, or the
- * narrowing a spoken ask chose — so a hold belongs to the action that caught it
- * rather than to whichever flight happens to be out, and each is drawn on its
- * own tap. Each also carries where it has to be seen, so the panel is turned
- * to a page when the action that needs it comes up rather than when it was asked
- * for: a page turned at the ask would take the first action's control off screen
- * before Luke ever reached it.
+ * A reply's actions arrive as a burst and the flights cannot: there is only
+ * ever one Luke on screen, one panel, and one settings page drawn at a time,
+ * and each of those is something a second action would take out from under the
+ * first. So the actions queue and the flights run in turn. Each action carries
+ * what it is holding back — the settings snapshot the store answered with, or
+ * the narrowing a spoken ask chose — so a hold belongs to the action that
+ * caught it rather than to whichever flight happens to be out. Each also
+ * carries where it has to be seen, so the panel is turned to a page when the
+ * action that needs it comes up rather than when it was asked for: a page
+ * turned at the ask would take the first action's control off screen before
+ * Luke ever reached it.
  *
  * Two flights in sequence cost more than one, and that is the deliberate
  * choice. A chained flight waits only a beat, and the panel stays up across

--- a/apps/desktop/src/renderer/luke-errand.tsx
+++ b/apps/desktop/src/renderer/luke-errand.tsx
@@ -9,18 +9,9 @@ import { HIT_REGION, HIT_REGION_ATTRIBUTE, PANEL_PRESENTATION } from "./panel-st
 import { parseMilliseconds, parsePixels, STILL_MS } from "./session-motion";
 
 /**
- * Luke signing his own work.
- *
- * A setting or a view changes two ways: a hand on the control, or Luke acting
- * on something asked of him. The control answers identically either way — and
- * a switch that flips with nobody near it reads as a glitch rather than as an
- * answer. So Luke goes and does it in the open: he leaves the strip under the
- * housing, dives to the very control that changed, taps it, and floats back.
- *
- * The dive and the tap are the whole of the emphasis. The way home is the
- * quietest motion that still reads as something moving under its own power,
- * because by then the point has been made and all that is left is to get out
- * of the way of the control he was pointing at.
+ * Luke signing his own work: a control that changed because he was asked to
+ * change it is tapped in the open, because a switch that flips with nobody
+ * near it reads as a glitch rather than as an answer.
  *
  * **There is only ever one Luke on screen.** The strip's own face is held
  * invisible for exactly as long as the flight lasts, so what crosses the panel

--- a/apps/desktop/src/renderer/luke-errand.tsx
+++ b/apps/desktop/src/renderer/luke-errand.tsx
@@ -9,9 +9,9 @@ import { HIT_REGION, HIT_REGION_ATTRIBUTE, PANEL_PRESENTATION } from "./panel-st
 import { parseMilliseconds, parsePixels, STILL_MS } from "./session-motion";
 
 /**
- * Luke signing his own work: a control that changed because he was asked to
- * change it is tapped in the open, because a switch that flips with nobody
- * near it reads as a glitch rather than as an answer.
+ * Luke signing his own work: a switch that flips with nobody near it reads as
+ * a glitch rather than as an answer, so a control Luke was asked to change is
+ * tapped in the open.
  *
  * **There is only ever one Luke on screen.** The strip's own face is held
  * invisible for exactly as long as the flight lasts, so what crosses the panel

--- a/apps/desktop/src/renderer/luke-face-mood.ts
+++ b/apps/desktop/src/renderer/luke-face-mood.ts
@@ -160,16 +160,13 @@ export interface WeightedAside {
 }
 
 /**
- * Gestures Luke makes for no reason at all, and how often each is worth making.
- * They are what keeps a permanent fixture from reading as a dead one — a face
- * that never moves is a screenshot — and between them the face is simply still.
- *
- * Weights rather than a rotation, because these are not equals. Half the pool is
- * the blink, which is the smallest thing the face can do and the only one whose
- * job is just to be alive; the loud ones sit at the bottom, rare enough to stay
- * surprises — the duck behind the housing turns up about once every ten minutes.
- * Nothing here means anything: what does is chosen by `restingMotion` or fired
- * by `noticedMotion` at something that just changed.
+ * Gestures Luke makes for no reason at all, weighted rather than rotated
+ * because these are not equals: the blink is half the pool and the loud ones
+ * sit at the bottom, rare enough to stay surprises. They are what keeps a
+ * permanent fixture from reading as a dead one — a face that never moves is a
+ * screenshot — and between them the face is simply still. Nothing here means
+ * anything: what does is chosen by `restingMotion` or fired by `noticedMotion`
+ * at something that just changed.
  *
  * The same gesture twice running is allowed, and has to be. Two blinks a
  * half-minute apart is what a calm face does, and forbidding a repeat would

--- a/apps/desktop/src/renderer/notch-wings.tsx
+++ b/apps/desktop/src/renderer/notch-wings.tsx
@@ -43,7 +43,6 @@ interface NotchWingsProps {
   voiceActive?: boolean;
   fixtureSpeaking: boolean;
   hasAudioSignal: boolean;
-  /** A pressed talk key still waiting for the call it asked to open. */
   voiceOpening: boolean;
   /** Whether announcements are held, by the announce switch off or a meeting — the face sleeps on it. */
   announcementsHeld: boolean;

--- a/apps/desktop/src/renderer/settings/settings-panel.tsx
+++ b/apps/desktop/src/renderer/settings/settings-panel.tsx
@@ -257,9 +257,10 @@ export function SettingsPanel({
       ) : null}
 
       {view === SETTINGS_VIEW.ROOT && !search ? (
-        /* A newer release waiting is marked on the tab rather than moved
-           here: a section that changed places as its own check found news
-           would rearrange the page under the hand that pressed it. */
+        /* A newer release waiting is marked on the tab rather than given a
+           section of its own here: a section that changed places as its own
+           check found news would rearrange the page under the hand that
+           pressed it. */
         <section
           className="settings-section settings-index"
           style={cssCustomProperties({ "--row-index": 1 })}

--- a/apps/desktop/src/renderer/settings/settings-panel.tsx
+++ b/apps/desktop/src/renderer/settings/settings-panel.tsx
@@ -238,10 +238,6 @@ export function SettingsPanel({
       ) : null}
 
       {settings && searchOpen ? (
-        /* The field opens at the head of whichever page is showing — under
-           the page's own pinned header, above the front page's sections —
-           and a typed query swaps the page below it for the rows it kept,
-           read across every page wherever the field was opened from. */
         <SettingsSearch
           query={searchQuery}
           search={search}
@@ -261,12 +257,9 @@ export function SettingsPanel({
       ) : null}
 
       {view === SETTINGS_VIEW.ROOT && !search ? (
-        /* The front page: one row per page, then the sections that answer at a glance —
-           what Luke is allowed, what he counts about his own use, the way to
-           the founders, whose account this is, and the way out. A newer
-           release waiting is marked on the tab rather than moved here: a
-           section that changed places as its own check found news would
-           rearrange the page under the hand that pressed it. */
+        /* A newer release waiting is marked on the tab rather than moved
+           here: a section that changed places as its own check found news
+           would rearrange the page under the hand that pressed it. */
         <section
           className="settings-section settings-index"
           style={cssCustomProperties({ "--row-index": 1 })}
@@ -308,8 +301,6 @@ export function SettingsPanel({
 
       {view === SETTINGS_VIEW.CONNECTIONS && connections && panelView && !search ? (
         <>
-          {/* The one choice spanning every provider leads the page; the
-              providers it chooses between follow. */}
           <WorkspacesSection view={panelView} writes={SETTINGS_WRITES} />
           <KeySyncSection view={panelView} writes={SETTINGS_WRITES} />
           <CredentialsSection input={connections} />
@@ -331,8 +322,6 @@ export function SettingsPanel({
 
           <FeedbackSection control={feedback} />
 
-          {/* The account and the two ways out of it, last of the sections:
-              signing out and deleting are rare and cannot be taken back. */}
           {account.status === ACCOUNT_STATUS.SIGNED_IN ? (
             <AccountSection
               account={account}

--- a/apps/ios/LukeKit/Sources/LukeKit/AccountSession.swift
+++ b/apps/ios/LukeKit/Sources/LukeKit/AccountSession.swift
@@ -73,12 +73,6 @@ public final class AccountSession {
         state = .signedIn(identity)
     }
 
-    /// Returns the stored access token when signed in, or nil when signed out.
-    public func currentAccessToken() -> String? {
-        guard case .signedIn = state else { return nil }
-        return KeychainStore.phone.get(.accessToken)
-    }
-
     /// Returns a credential payload suitable for WatchConnectivity transfer.
     /// Nil when signed out or any required field is absent.
     public func tokenPayload() -> [String: Any]? {

--- a/apps/web/src/about.tsx
+++ b/apps/web/src/about.tsx
@@ -3,8 +3,6 @@ import { startSiteAnalytics } from "./analytics";
 import { mountPrerenderedPage } from "./mount-page";
 import "./styles.css";
 
-// Every page the site builds, not only the landing one: a funnel that saw
-// the landing page alone would undercount everyone who arrived by a link.
 startSiteAnalytics();
 
 mountPrerenderedPage(<AboutPage />);

--- a/apps/web/src/analytics.ts
+++ b/apps/web/src/analytics.ts
@@ -46,6 +46,10 @@ let client: Promise<PostHog | undefined> | undefined;
  * inert rather than broken — the same kill switch the recording endpoint has,
  * so a preview deployment or a local run measures nothing without being
  * configured to.
+ *
+ * Called from every page the site builds, not only the landing one: a funnel
+ * that saw the landing page alone would undercount everyone who arrived by a
+ * link.
  */
 export function startSiteAnalytics(): void {
   const projectApiKey = PROJECT_API_KEY;

--- a/apps/web/src/changelog.tsx
+++ b/apps/web/src/changelog.tsx
@@ -3,8 +3,6 @@ import { ChangelogPage } from "./ChangelogPage";
 import { mountPrerenderedPage } from "./mount-page";
 import "./styles.css";
 
-// Every page the site builds, not only the landing one: a funnel that saw
-// the landing page alone would undercount everyone who arrived by a link.
 startSiteAnalytics();
 
 mountPrerenderedPage(<ChangelogPage />);

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -3,8 +3,6 @@ import { startSiteAnalytics } from "./analytics";
 import { mountPrerenderedPage } from "./mount-page";
 import "./styles.css";
 
-// Every page the site builds, not only the landing one: a funnel that saw
-// the landing page alone would undercount everyone who arrived by a link.
 startSiteAnalytics();
 
 mountPrerenderedPage(<App />);

--- a/apps/web/src/privacy.tsx
+++ b/apps/web/src/privacy.tsx
@@ -3,8 +3,6 @@ import { mountPrerenderedPage } from "./mount-page";
 import { PrivacyPage } from "./PrivacyPage";
 import "./styles.css";
 
-// Every page the site builds, not only the landing one: a funnel that saw
-// the landing page alone would undercount everyone who arrived by a link.
 startSiteAnalytics();
 
 mountPrerenderedPage(<PrivacyPage />);

--- a/packages/host/src/service.ts
+++ b/packages/host/src/service.ts
@@ -510,9 +510,6 @@ export function createGatewayService(dependencies: GatewayServiceDependencies): 
       }
       return gatewayOk(configurationToWire(brain.configuration()));
     }),
-    // A registration over the protocol names capabilities the host may ask
-    // for; each is invoked back through the registering client's own
-    // channel, which the in-process build wires directly.
     // A registration names the capabilities the host may ask the registering
     // connection for. Each ask travels back on that connection alone, bound
     // to it by the invocation id its ledger holds; the connection closing

--- a/packages/host/src/settings-store.ts
+++ b/packages/host/src/settings-store.ts
@@ -481,13 +481,11 @@ function accountPreferencesWithLocalChanges(
 ): AccountPreferences {
   const settings: Record<string, WireValue> = {};
   for (const field of ACCOUNT_PREFERENCE_FIELDS) {
+    // SAFETY: AccountPreferenceField selects JSON-compatible account preference values.
     const value = accountPreferenceWithLocalChanges(
       field,
-      // SAFETY: AccountPreferenceField selects JSON-compatible account preference values.
       remote[field] as UnparsedWireValue,
-      // SAFETY: AccountPreferenceField selects JSON-compatible account preference values.
       current[field] as UnparsedWireValue,
-      // SAFETY: AccountPreferenceField selects JSON-compatible account preference values.
       expected[field] as UnparsedWireValue,
     );
     if (value !== undefined) settings[field] = value;

--- a/packages/host/src/store-wiring.ts
+++ b/packages/host/src/store-wiring.ts
@@ -72,14 +72,12 @@ export type ConversationReporter = string;
 export type ConversationErasure = Pick<DeletionOutcome, "published">;
 
 export interface StoreWiring {
-  /** The client, started on first use; the worker's answers stand behind every method below. */
   client: () => StoreClient;
   /** One conversation's thread, relayed between windows through this process; created on first use. */
   thread: (sessionKey?: SessionKey) => ConversationThread;
   /** A conversation's envelope, for the brain wiring to build its writer on: the store's, or memory alone where nothing is kept on disk. */
   brainStateRepository: (sessionKey?: SessionKey) => BrainStateRepository;
   open: () => Promise<void>;
-  /** Restores every stored conversation's thread, its cutoff, and the notebook's entries, once opened. */
   restore: () => Promise<void>;
   /**
    * The notebook's entries as last read from the worker — the facts Luke
@@ -88,7 +86,6 @@ export interface StoreWiring {
    * whenever the notebook's files are reconciled.
    */
   rememberedFacts: () => readonly RememberedFact[];
-  /** Reads the notebook again, reconciling a hand edit, and answers its entries. */
   refreshNotebook: () => Promise<readonly NotebookEntry[]>;
   /**
    * The notebook's two writes. Each is one request to the worker, which
@@ -112,9 +109,7 @@ export interface StoreWiring {
     recordedAt?: number,
     sessionKey?: SessionKey,
   ) => Promise<boolean>;
-  /** The directory as this process holds it: stored conversations and the memory-held ones of this run. */
   directory: () => readonly ConversationRecord[];
-  /** Whether the key names a conversation the directory lists right now. */
   holds: (sessionKey: SessionKey) => boolean;
   /** Whether the key names a conversation held in memory alone for this run, which is never a recall source. */
   isTemporary: (sessionKey: SessionKey) => boolean;
@@ -155,9 +150,7 @@ export interface StoreWiring {
     keepSessionId: string | undefined,
     cutoffBefore: number | undefined,
   ) => Promise<ConversationErasure | undefined>;
-  /** One maintenance pass, with the conversations that must be kept whatever their age. */
   runMaintenance: (preserve: readonly SessionKey[]) => Promise<MaintenanceReport | undefined>;
-  /** Refreshes the directory from the store and tells every window. */
   refreshDirectory: () => Promise<void>;
 }
 

--- a/packages/host/src/testing/operator-over-brain.ts
+++ b/packages/host/src/testing/operator-over-brain.ts
@@ -34,7 +34,7 @@ export function operatorOverBrain(options: {
       publicationSettled: () => Promise.resolve(),
       // SAFETY: the submit path reaches no child; the stand-in is never read.
       children: {} as ChildRunService,
-      // SAFETY: only the revision is read here; the stand-in is never read further.
+      // SAFETY: only the revision is ever read off this stand-in.
       configuration: () => ({ revision: 1 }) as ResolvedConfiguration,
       updateConfiguration: () => [],
     },


### PR DESCRIPTION
The comment rule from `CLAUDE.md`, applied to the desktop, web, and iOS code: a comment survives only if deleting it would let someone reintroduce a bug. What goes is the rest — comments that restate the adjacent code or a symbol's name, headers that list what the JSX below already draws, one comment stated twice in the same file, one repeated verbatim across four page entries, and one doc comment on a function nothing calls.

`git diff --shortstat origin/main...`: **20 files changed, 40 insertions(+), 103 deletions(-)** — 63 lines net.
Running total (tracked `.ts`/`.tsx`/`.mjs`/`.swift`, generated outputs excluded): **226,729** lines, against the plan's ~125k target.

## What went

**Desktop**
- `services/operator-client.ts` — the header half of the ex-`desktop-app.ts:496-497` comment; the clause about the two receiver-only offers stays, since it is the one thing the block does not say for itself.
- `settings-store.ts` — the same `SAFETY:` line stated three times over three arguments of one call, now stated once above the statement.
- `store-wiring.ts` — seven `StoreWiring` docblocks that restated the member's own name (`client`, `restore`, `refreshNotebook`, `directory`, `holds`, `runMaintenance`, `refreshDirectory`). The ones carrying a constraint stay.
- `service.ts` — the `NODE_REGISTER` comment written twice, the second time more completely; the weaker copy goes.
- `luke-errand.tsx` — the flight choreography narrated at length. The reason the module exists stays, as do all five constraints: one Luke on screen, the colour keyed off `data-voice`, the errand deciding nothing, one flight at a time, and `transform`/`opacity` only.
- `errand-queue.ts` — the burst-and-flight failure retold twice over; the rejected-design paragraph and the hold-release invariant are kept whole, as the plan asks.
- `app-action-carrier.ts` — the first paragraph of the `carryAppAction` docblock, which walked through what the dispatch table below it does. The validation boundary sentence and the whole second paragraph stay.
- `settings/settings-panel.tsx` — three JSX headers that named the sections drawn underneath them; the release-marking rule and the "no heading of its own" rule stay.
- `notch-wings.tsx` — the docblock over `voiceOpening`.
- `luke-face-mood.ts` — the `IDLE_ASIDES` docblock's restatement of its own table, including a derived "once every ten minutes" figure that nothing keeps true. Both invariants stay: nothing in the pool means anything, and a repeat is allowed.
- `ipc/window-surface.ts` — the `windowSurfaceReports` docblock, which previewed the docblock immediately below it.

**Web**
- The same two-line comment on `startSiteAnalytics()` in `about.tsx`, `changelog.tsx`, `privacy.tsx`, and `main.tsx`, moved to the declaration it is about.

**iOS**
- `AccountSession.currentAccessToken()` and its doc comment: nothing in the app, the kit, the watch, or the tests calls it.

## What was named and deliberately left

- **`SAFETY: as above`** — kept, not deleted. `anti-slop(require-safety-comment-for-type-assertion)` fails the build without a justification at each assertion, and `CLAUDE.md` says a comment the toolchain demands must still explain. The two in `ipc/brain.test.ts` and `ipc/voice-runtime.test.ts` and the two in `host/testing/operator-over-brain.ts` now state their own invariant instead of pointing at the line above.
- **`speech-arbiter.ts:11-27`** — both docblocks state why the constant is the number it is, and the first states that the same window doubles as the offer's deadline. Deleting them is exactly the case the survival rule protects against.
- **`ipc/window-surface.ts:78-92`** (`recordSurfaceEvent`) — a statement of the analytics trust boundary `CLAUDE.md` requires, and not orphaned: a later PR already corrected it to name the bridge guard. Only the "narrowest thing in this file" clause went, the file having been split since.
- Already resolved on `main` since the plan's `f713707` anchor, so nothing to do: `realtime-session.ts` (D11 split it), `use-voice-session.ts:1622-1628` (gone with the same split), `wire/session.ts:161-168` (the hotkey PR rewrote the fields into `settings/controls.ts`), and `api/acts/{agent,control}.ts` (both routes are now one line behind `hostedVaultRoute`).
- **AdminDashboard copy justifications** — the plan assigns these to F3.
- **iOS LRU comments over `Set.first`** — there are none, at `f713707` or on `main`. The eviction defect itself is on the plan's separate-pass list.

## Trust constraints

No trust boundary moves and no `CLAUDE.md` sentence is touched. Every comment that states one is kept: the analytics allowlist gate, the receiver-only offers, the notebook's single-writer serialization, the errand deciding nothing, and the action-validation boundary in `carryAppAction`.

## Verification

`./scripts/check.sh` — green. Not a **UI** PR: nothing but comments and one unreferenced Swift method changed, so no drawn output can move; no fixture capture or notch check was performed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/efe2ab77-f34d-419d-8bd9-c5050d14f6da)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34394391688/artifacts/10121055228) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34394391688)

- Commit: `9644f2d9461b7df9243d48f091f254d76f905be5`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
