### PR TITLE
fix(desktop): draw the listening meter while a press's call opens

### DIFF
--- a/apps/desktop/src/renderer/notch-wings.tsx
+++ b/apps/desktop/src/renderer/notch-wings.tsx
@@ -232,7 +232,6 @@ export function NotchWings({
                 speaking={fixtureSpeaking}
                 voice={meterVoice}
                 voiceActive={voiceActive}
-                connecting={voiceOpening && voice === undefined && !analyser}
                 onVoiceActivity={setMeasuredVoiceActive}
               />
             </span>

--- a/apps/desktop/src/renderer/styles/base.css
+++ b/apps/desktop/src/renderer/styles/base.css
@@ -1653,37 +1653,6 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
   --bar-height: 23px;
 }
 
-/* The press answered before the call is: while the handshake runs the bars
-   pulse on their own clock — they cannot yet hear anything and must not
-   pretend to — and the pulse hands over to the analyser the moment the turn
-   opens. Negative delays start every bar mid-cycle, so the meter arrives
-   already breathing instead of standing up bar by bar. */
-.waveform[data-connecting="true"] .waveform-bar {
-  animation: waveform-opening 1100ms ease-in-out infinite;
-  animation-play-state: var(--loop-motion);
-}
-
-.waveform[data-connecting="true"] .waveform-bar:nth-child(2),
-.waveform[data-connecting="true"] .waveform-bar:nth-child(4) {
-  animation-delay: -140ms;
-}
-
-.waveform[data-connecting="true"] .waveform-bar:nth-child(1),
-.waveform[data-connecting="true"] .waveform-bar:nth-child(5) {
-  animation-delay: -280ms;
-}
-
-@keyframes waveform-opening {
-  0%,
-  100% {
-    transform: scaleY(0.2);
-  }
-
-  50% {
-    transform: scaleY(0.55);
-  }
-}
-
 /* Expanded panel --------------------------------------------------------- */
 
 .expanded-stage {

--- a/apps/desktop/src/renderer/use-voice-view.ts
+++ b/apps/desktop/src/renderer/use-voice-view.ts
@@ -176,8 +176,10 @@ export function useVoiceView(): VoiceViewState {
     const timer = window.setTimeout(() => setVoiceActive(false), decided.remainingMs);
     return () => window.clearTimeout(timer);
   }, [levelReport]);
-  // A turn ending takes the voice with it, whatever the last level said.
-  const turnLive = waveformVoice(view.voiceStatus) !== undefined;
+  // A turn ending takes the voice with it, whatever the last level said. A
+  // press whose call is still opening is a live turn: its device is already
+  // heard, and the bars follow it as they will once the channel is up.
+  const turnLive = waveformVoice(view.voiceStatus) !== undefined || view.talkOpening;
   useEffect(() => {
     if (!turnLive) setVoiceActive(false);
   }, [turnLive]);

--- a/apps/desktop/src/renderer/waveform.tsx
+++ b/apps/desktop/src/renderer/waveform.tsx
@@ -38,7 +38,6 @@ export function Waveform({
   speaking = false,
   voice,
   voiceActive = false,
-  connecting = false,
   onVoiceActivity,
 }: {
   /** A stream to measure here, where the panel has none: the takeover's own. */
@@ -49,13 +48,6 @@ export function Waveform({
   /** Whose turn the bars are drawing, which is what colours them. */
   voice?: WaveformVoice;
   voiceActive?: boolean;
-  /**
-   * The press has landed but the call is still opening, so there is nothing to
-   * hear yet. The bars pulse on their own clock rather than sit at the floor —
-   * a press that changes nothing on screen reads as a press that did nothing —
-   * and stop pretending the moment a level takes over.
-   */
-  connecting?: boolean;
   /** The measured voice's edges, reported only where an analyser is measured. */
   onVoiceActivity?: (active: boolean) => void;
 }): React.JSX.Element {
@@ -128,16 +120,9 @@ export function Waveform({
     <span
       className="waveform"
       role="img"
-      aria-label={
-        connecting
-          ? "Voice is connecting"
-          : voice === WAVEFORM_VOICE.LUKE
-            ? "Luke is speaking"
-            : "Live speech activity"
-      }
-      aria-hidden={!isSpeaking && !connecting}
+      aria-label={voice === WAVEFORM_VOICE.LUKE ? "Luke is speaking" : "Live speech activity"}
+      aria-hidden={!isSpeaking}
       data-speaking={String(isSpeaking)}
-      data-connecting={String(connecting)}
       data-voice={voice}
     >
       {BAR_INDEXES.map((index) => (

--- a/packages/voice/src/orchestrator/voice-orchestrator.test.ts
+++ b/packages/voice/src/orchestrator/voice-orchestrator.test.ts
@@ -173,6 +173,9 @@ test("the meter is pointed at whoever holds the turn, and the element at Luke", 
   const conversation = calls.conversation;
   assert.ok(conversation);
   conversation.hooks.onLocalStream?.("mic");
+  // The press's device is metered while the call is still opening, so the
+  // bars draw the same listening before and after the channel comes up.
+  assert.equal(seen.at(-1)?.[0], "mic");
   conversation.hooks.onRemoteStream("luke");
   conversation.settle(REALTIME_STATUS.LISTENING);
   assert.deepEqual(seen.at(-1), ["mic", "luke"]);

--- a/packages/voice/src/orchestrator/voice-policy.test.ts
+++ b/packages/voice/src/orchestrator/voice-policy.test.ts
@@ -81,6 +81,21 @@ test("the meter listens to the stream of whoever holds the turn", () => {
   );
 });
 
+test("a connecting call meters the press's device, and nothing where no press opened one", () => {
+  assert.equal(
+    activeVoiceStream({ status: REALTIME_STATUS.CONNECTING, local: "mic", remote: undefined }),
+    "mic",
+  );
+  assert.equal(
+    activeVoiceStream({ status: REALTIME_STATUS.CONNECTING, local: undefined, remote: "luke" }),
+    undefined,
+  );
+  assert.equal(
+    activeVoiceStream({ status: REALTIME_STATUS.IDLE, local: "mic", remote: "luke" }),
+    undefined,
+  );
+});
+
 test("Luke's captions are offered only on his turn, and only with a reason to read them", () => {
   const shown = {
     captionsEnabled: true,

--- a/packages/voice/src/orchestrator/voice-policy.ts
+++ b/packages/voice/src/orchestrator/voice-policy.ts
@@ -36,7 +36,10 @@ export const VOICE_ERROR_NOTICE_MS = 12_000;
 
 /**
  * The stream the meter should listen to for this status, or none. Typed over
- * the stream itself so the rule can be tested without a MediaStream.
+ * the stream itself so the rule can be tested without a MediaStream. A
+ * connecting call meters the local stream too: only a press opens one, and
+ * its words are already being captured beside the handshake, so the meter
+ * draws the same listening it will draw once the channel is up.
  */
 export function activeVoiceStream<T>(input: {
   status: RealtimeStatus;
@@ -45,6 +48,7 @@ export function activeVoiceStream<T>(input: {
 }): T | undefined {
   if (input.status === REALTIME_STATUS.RESPONDING) return input.remote;
   if (input.status === REALTIME_STATUS.LISTENING) return input.local;
+  if (input.status === REALTIME_STATUS.CONNECTING) return input.local;
   return undefined;
 }
 


### PR DESCRIPTION
## Summary
- On a talk-key press against an idle call, Luke already captures the developer's words locally during the credential mint and WebRTC handshake and flushes them when the channel opens. The panel, though, drew a distinct pulsing meter labelled "Voice is connecting", so it read as not yet listening.
- The meter now reads the press's microphone stream while the call is CONNECTING (`activeVoiceStream`), `useVoiceView` treats an opening press as a live turn, and the separate connecting pulse, label, and CSS are removed. The ordinary listening meter draws from the press onward with no visible seam when the call comes up.
- Only a press opens a local stream, so a typed ask or briefing connect still meters nothing. Connect timing and capture are unchanged.

## Privacy
The drawing is the same meter the LISTENING state already recorded (bar heights from a scalar level). Nothing new is drawn or leaves the machine.

## Verification
- `./scripts/check.sh` passes (lint, typecheck, tests, build).
- New tests: `voice-policy.test.ts` (CONNECTING meters local only), `voice-orchestrator.test.ts` (mic metered before the channel opens).
- `./scripts/verify.sh` and visual evidence were not run: this change was made in a Linux sandbox. The connecting state has no fixture profile. Manual check owed on a Mac: press talk from idle, bars follow the voice immediately and stay steady as the call connects. No physical-notch check was performed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/7c93f220-5ec3-4d56-beac-49d4bad1d7f0)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34394217509/artifacts/10120929632) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34394217509)

- Commit: `c03c931c0dd3a848b540450685b813f0c4fb048a`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
