### PR TITLE
docs: one agent guide per directory, and stale statements

### DIFF
--- a/.github/RELEASE.md
+++ b/.github/RELEASE.md
@@ -196,8 +196,8 @@ silently missing. They are the same values the Actions secrets hold.
 
 Electron-builder writes the distribution artifacts under `artifacts/release-builder/`, and
 the publish script is what knows the asset set: it refuses to publish unless all six are
-present, refuses a tag that does not exist, and creates a published, non-draft release. Re-running it is safe: assets
-are replaced with `--clobber`.
+present, refuses a tag that does not exist, and creates a published, non-draft
+release. Re-running it is safe: assets are replaced with `--clobber`.
 
 Then run the checks under "Verify after a release" above, and afterwards find out why
 Actions could not cut the release — a hand-cut release is a workflow bug left standing.

--- a/.github/RELEASE.md
+++ b/.github/RELEASE.md
@@ -196,8 +196,7 @@ silently missing. They are the same values the Actions secrets hold.
 
 Electron-builder writes the distribution artifacts under `artifacts/release-builder/`, and
 the publish script is what knows the asset set: it refuses to publish unless all six are
-present, refuses a tag that does not match `apps/desktop/package.json`, refuses a tag that
-does not exist, and creates a published, non-draft release. Re-running it is safe: assets
+present, refuses a tag that does not exist, and creates a published, non-draft release. Re-running it is safe: assets
 are replaced with `--clobber`.
 
 Then run the checks under "Verify after a release" above, and afterwards find out why

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -755,9 +755,7 @@ Trust constraints:
   machine in a recording. That view retains every line the retention policy
   holds, its words whole, including session actions and the lines that outlived
   the last launch, until the developer clears it — the same thread on every
-  display's panel, relayed between windows through the main process — while
-  the 20 most recent lines enter model context, each cut there to its own
-  length bound, beside the brain's own working memory of its turns. There
+  display's panel, relayed between windows through the main process. There
   is no general masking module to consult and nothing that makes any other new
   component silent by construction, so what a recording may see is decided by
   what the panel draws or explicitly blocks — which makes drawing something
@@ -816,15 +814,14 @@ Trust constraints:
   Luke's own application data, never a provider's file, under a real retention
   policy replacing the old "dies with the app": every admitted line stands
   in the brain's store's own table until Delete conversation or the conversation
-  maintenance below removes it, and what the panel draws and the model is
-  handed is a projection over that record, the 200 most recent lines and
-  nothing older than a fortnight. Each line
+  maintenance below removes it, and what the panel draws is a projection over
+  that record, the 200 most recent lines and nothing older than a fortnight.
+  Each line
   carries an id its writer minted, and the store's append is idempotent on
   it: a window reports only the lines it added, never the whole thread, so a
   report can add to the thread and never replace it, a line delivered twice
-  is one line, and two deliberate identical utterances are two. What the
-  thread hands a model is the same bounded recent slice, riding beside the
-  brain's own working memory, and the Conversation tab's Delete conversation reaches the
+  is one line, and two deliberate identical utterances are two. The
+  Conversation tab's Delete conversation reaches the
   stored lines as well as the screen, behind the recovery archive the rule
   above describes, because a deletion that emptied only the view would leave
   the words on the machine with nothing left to draw them. The narrower thing is a durable
@@ -1021,7 +1018,8 @@ Trust constraints:
   feed address fixed by the build, an unauthenticated fetch carrying
   nothing about the user, their sessions, or their keys, on a timer of its
   own and at the press of the Updates row's button; never in a fixture or
-  capture run, and never in an unpackaged build. A newer build found by any
+  evidence run, behind the same run-mode gate, and never in an unpackaged
+  build. A newer build found by any
   check downloads at once, so the row can offer a restart instead of a wait,
   but what is fetched is only ever what this repository's own release
   pipeline published: the manifest carries the archive's sha512, the archive
@@ -1050,7 +1048,8 @@ Trust constraints:
 - The spoken introduction is the one moment Luke runs before the account gate,
   and it is bounded on every side. It plays on the first interactive launch,
   before any account exists, at most once to the end: a completion on file
-  never replays, and it never runs in a fixture or capture run. Its voice is
+  never replays, and the same run-mode gate keeps it from running in a fixture
+  or evidence run. Its voice is
   the introduction mint, an accountless endpoint on Luke's own service that
   issues one short-lived credential per call, keeps nothing about the caller
   but a hashed network address for its own daily caps (per caller and global
@@ -1240,13 +1239,6 @@ works in that subtree:
 | `packages/host/AGENTS.md` | The host's seams, why it draws nothing, and the one drain |
 | `packages/analytics/AGENTS.md` | The product-event allowlist and its `PRIVACY.md` obligation |
 | `packages/hosted/AGENTS.md` | The hosted wire boundary and its dependency direction |
-
-## Repository shape
-
-`apps/` holds only what is specific to a deployable: the Electron processes, the
-React surfaces, and the Vite site. Everything else is a package under
-`packages/`, named for the concern it holds, so `ls packages/` answers "what is
-this codebase made of" and an import specifier names what it depends on.
 
 ## Git workflow
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -755,8 +755,8 @@ Trust constraints:
   machine in a recording. That view retains every line the retention policy
   holds, its words whole, including session actions and the lines that outlived
   the last launch, until the developer clears it — the same thread on every
-  display's panel, relayed between windows through the main process. There
-  is no general masking module to consult and nothing that makes any other new
+  display's panel, relayed between windows through the main process. There is
+  no general masking module to consult and nothing that makes any other new
   component silent by construction, so what a recording may see is decided by
   what the panel draws or explicitly blocks — which makes drawing something
   new on the panel a decision about what leaves the machine. It is still Luke's
@@ -816,12 +816,11 @@ Trust constraints:
   in the brain's store's own table until Delete conversation or the conversation
   maintenance below removes it, and what the panel draws is a projection over
   that record, the 200 most recent lines and nothing older than a fortnight.
-  Each line
-  carries an id its writer minted, and the store's append is idempotent on
-  it: a window reports only the lines it added, never the whole thread, so a
-  report can add to the thread and never replace it, a line delivered twice
-  is one line, and two deliberate identical utterances are two. The
-  Conversation tab's Delete conversation reaches the
+  Each line carries an id its writer minted, and the store's append is
+  idempotent on it: a window reports only the lines it added, never the whole
+  thread, so a report can add to the thread and never replace it, a line
+  delivered twice is one line, and two deliberate identical utterances are
+  two. The Conversation tab's Delete conversation reaches the
   stored lines as well as the screen, behind the recovery archive the rule
   above describes, because a deletion that emptied only the view would leave
   the words on the machine with nothing left to draw them. The narrower thing is a durable
@@ -1018,8 +1017,7 @@ Trust constraints:
   feed address fixed by the build, an unauthenticated fetch carrying
   nothing about the user, their sessions, or their keys, on a timer of its
   own and at the press of the Updates row's button; never in a fixture or
-  evidence run, behind the same run-mode gate, and never in an unpackaged
-  build. A newer build found by any
+  evidence run, and never in an unpackaged build. A newer build found by any
   check downloads at once, so the row can offer a restart instead of a wait,
   but what is fetched is only ever what this repository's own release
   pipeline published: the manifest carries the archive's sha512, the archive
@@ -1048,8 +1046,7 @@ Trust constraints:
 - The spoken introduction is the one moment Luke runs before the account gate,
   and it is bounded on every side. It plays on the first interactive launch,
   before any account exists, at most once to the end: a completion on file
-  never replays, and the same run-mode gate keeps it from running in a fixture
-  or evidence run. Its voice is
+  never replays, and it never runs in a fixture or evidence run. Its voice is
   the introduction mint, an accountless endpoint on Luke's own service that
   issues one short-lived credential per call, keeps nothing about the caller
   but a hashed network address for its own daily caps (per caller and global

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,7 @@
 # Contributing to Luke
 
 Luke is a macOS-first Electron sidecar that observes coding-agent sessions.
-This page covers setup, the checks a change has to pass, and the commit and pull
-request conventions.
+This page covers setup and points at the documents that own the rest.
 
 ## Before you write code
 
@@ -15,8 +14,9 @@ request.
 
 ## Set up
 
-Requires an Apple Silicon Mac on macOS 14 or newer, Node.js 24 or newer,
-pnpm 9.15.0, and the Xcode Command Line Tools.
+Requires an Apple Silicon Mac on macOS 14 or newer, Node.js 24 or newer, the
+pnpm version `packageManager` in the root `package.json` pins, and the Xcode
+Command Line Tools.
 
 ```sh
 ./scripts/bootstrap.sh   # install pinned workspace dependencies
@@ -26,10 +26,8 @@ pnpm 9.15.0, and the Xcode Command Line Tools.
 
 ## Make the change
 
-[docs/WORKFLOW.md](docs/WORKFLOW.md) is the step-by-step. In short: start from a
-scoped issue, make the smallest change that satisfies it, use fixtures rather
-than personal data or live provider state, and put regression coverage at the
-cheapest layer that would have caught the bug.
+[docs/WORKFLOW.md](docs/WORKFLOW.md) is the step-by-step, from the scoped issue
+through the evidence in the pull request.
 
 Deployable products live in `apps/`, reusable logic lives in `packages/`. Keep
 Electron main and preload code thin, keep the renderer sandboxed, and put
@@ -37,26 +35,14 @@ platform-independent behavior in a package.
 
 ## Check your work
 
-```sh
-./scripts/check.sh    # portable repository, type, test, and build checks
-./scripts/verify.sh   # required for any macOS or UI change
-```
-
-`./scripts/verify.sh` is required for anything that touches the macOS app, an
-Electron window, a native adapter, the microphone, or the desktop UI. For a UI
-change, inspect the evidence it generates rather than trusting the exit code.
-Biome is the executable style policy; `pnpm lint:fix` applies it.
+The canonical commands and when each one is required are the command table and
+the handoff invariant in [AGENTS.md](AGENTS.md).
 
 ## Open the pull request
 
-- Commit messages follow [Conventional Commits 1.0.0](https://www.conventionalcommits.org/en/v1.0.0/).
-- PR titles read `type(scope): description`, as in `fix(voice): stop the capture on a shut lid`.
-- Fill in the template's Evidence section with the commands you ran and their
-  results. UI changes need a screenshot, attached through GitHub's PR editor
-  rather than committed.
-- When your branch falls behind, `git rebase origin/main` and force-push with
-  `--force-with-lease`. Do not merge main into the branch; main squash-merges
-  through a merge queue, and a conflicting branch silently stops CI.
+The commit, PR title, and rebase conventions are the "Git workflow" section of
+[AGENTS.md](AGENTS.md); what the description has to carry is step 5 of
+[docs/WORKFLOW.md](docs/WORKFLOW.md).
 
 ## Reporting problems
 

--- a/apps/web/server/README.md
+++ b/apps/web/server/README.md
@@ -1,4 +1,6 @@
-# Database and auth workflow
+# Luke web server
+
+## Database and auth workflow
 
 Neon is provisioned through the Vercel integration. It supplies the pooled
 `DATABASE_URL` for application traffic and `DATABASE_URL_UNPOOLED` for
@@ -67,7 +69,7 @@ Google's callback is `${BETTER_AUTH_URL}/api/auth/callback/google`; GitHub's is
 `api/feedback.mjs` deliberately remains plain ESM so Vercel's builder has nothing
 to transpile.
 
-# Signing in on a Preview deployment
+## Signing in on a Preview deployment
 
 A Preview deployment answers on hostnames minted for the branch, so
 `server/auth-deployment.ts` reads the deployment's own address rather than
@@ -118,7 +120,7 @@ from production lands on the protected preview like any other request, so the
 browser needs that deployment's access cookie already; without it the dashboard
 reports the intercepted API call rather than the metrics.
 
-# Hosted voice
+## Hosted voice
 
 `api/voice/mint.ts` runs Luke's voice on the deployment's own OpenAI key for a
 signed-in desktop. It is an exact-path file, so Vercel's zero-config `api/`
@@ -183,7 +185,7 @@ one atomic upsert before each upstream call, checked against the ceilings in
 long they run; a spend limit on the OpenAI project behind the key is the
 backstop and should be configured with it.
 
-# Hosted brain inference
+## Hosted brain inference
 
 `api/brain/capabilities.ts` and the four routes under `api/brain/v2/` run
 Luke's brain on the deployment's own OpenAI key for a signed-in client that
@@ -224,7 +226,7 @@ nothing in a request can name one. Without `OPENAI_API_KEY` the routes answer
 503 like the rest of the hosted tier. The existing mint and device routes are
 untouched by these routes and keep their contracts for released clients.
 
-# Provider key vault
+## Provider key vault
 
 `api/vault/key.ts` and `api/vault/keys.ts` store, list, and delete the provider
 API keys a signed-in user syncs for server-side observation. Keys are encrypted
@@ -244,7 +246,7 @@ secret simply has no working vault, and no plaintext key can be stored
 accidentally. Set this variable in the Vercel project environment (production
 and any Preview that needs a working vault) alongside `DATABASE_URL`.
 
-# Hosted conversation store
+## Hosted conversation store
 
 The tables under `server/db/conversation-schema.ts`, `workspace-schema.ts`,
 `roster-schema.ts`, and `briefing-schema.ts` hold the hosted brain's
@@ -287,7 +289,7 @@ DATABASE_URL_UNPOOLED=postgresql://... pnpm --filter @luke/web db:migrate
 LUKE_STORE_TEST_DATABASE_URL=postgresql://... pnpm --filter @luke/web test:store
 ```
 
-# Phone push tokens
+## Phone push tokens
 
 `api/devices/token.ts` registers (POST) and forgets (DELETE) the push token of
 a phone signed into Luke. A token names one app installation and nothing else:

--- a/design/brand/README.md
+++ b/design/brand/README.md
@@ -102,9 +102,6 @@ supported (browsers, most macOS contexts) and survive copy/paste. Motion is alwa
 whole-head or eyes-only; the mouth never morphs (chosen deliberately, because mouth
 morphing read as unnatural).
 
-Where each one is used in the app is in the README at the repository root; the
-three the app has no moment for are noted there too.
-
 | State file | Product moment |
 |---|---|
 | `talking` | speaking / narrating (head bob) |
@@ -117,12 +114,18 @@ three the app has no moment for are noted there too.
 | `notification` | attention caught by something new (brow flash) |
 | `wink` | confirmation / easter egg |
 | `sleeping` | nothing to watch (lids down, zzz) |
+| `hushed` | voice spent for the day (awake, grayed out) |
 | `refresh` | relaunch (one pirouette) |
 | `boop` | tap feedback (puff) |
 | `monitoring` | humming along (slow sway) |
 | `appear` | attaching (peek-slide in) |
+| `wake` | first waking (introduction: eyes blink open) |
 | `attention` | attention caught (perk up) |
 | `floating` | hovering idle |
 | `hiding` | minimized (peekaboo duck) |
+| `flyoff` | hover flourish (fly off and swoop back) |
 | `tease` | playful (brow waggle) |
 | `waiting` | needs approval (fidget) |
+| `shimmy` | shaking it off (happy wiggle) |
+| `dizzy` | woozy after a flight (decaying wobble) |
+| `glance` | checking both ways (look around) |

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -2,11 +2,11 @@
 
 This is the contract every animated element in the panel obeys, and the bar
 every word drawn on it has to clear. The "Panel motion" section of
-`apps/desktop/src/renderer/AGENTS.md` says what the window and the surface are; this file says how anything drawn on
-them is allowed to move, how much it is allowed to say, and which of the
-machine's keys Luke may take. A change that adds or alters motion or copy is
-reviewed against these rules, and the fastest way to pass that review is to
-build from them.
+`apps/desktop/src/renderer/AGENTS.md` says what the window and the surface are;
+this file says how anything drawn on them is allowed to move, how much it is
+allowed to say, and which of the machine's keys Luke may take. A change that
+adds or alters motion or copy is reviewed against these rules, and the fastest
+way to pass that review is to build from them.
 
 ## The vocabulary
 

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -1,8 +1,8 @@
 # Design: how the surface moves and reads
 
 This is the contract every animated element in the panel obeys, and the bar
-every word drawn on it has to clear. The "Panel motion" section of AGENTS.md
-says what the window and the surface are; this file says how anything drawn on
+every word drawn on it has to clear. The "Panel motion" section of
+`apps/desktop/src/renderer/AGENTS.md` says what the window and the surface are; this file says how anything drawn on
 them is allowed to move, how much it is allowed to say, and which of the
 machine's keys Luke may take. A change that adds or alters motion or copy is
 reviewed against these rules, and the fastest way to pass that review is to

--- a/packages/CLAUDE.md
+++ b/packages/CLAUDE.md
@@ -1,1 +1,1 @@
-See [AGENTS.md](./AGENTS.md).
+AGENTS.md


### PR DESCRIPTION
## Summary

Documentation-only cleanup (PR B16). Seven files; no source, no behavior.

- **`packages/CLAUDE.md` → symlink.** It was the one guide file of eight that was a regular file holding `See [AGENTS.md](./AGENTS.md).`; it is now the same `AGENTS.md` symlink the other seven are, so the two names cannot drift.
- **`CONTRIBUTING.md`.** The pnpm version is read off `packageManager` in the root `package.json` (which pins 10.34.5) instead of naming 9.15.0. The three sections that restated other documents — the workflow summary (`:29`), the check commands (`:38-48`), and the PR conventions (`:50-59`) — link the document that owns each rule instead.
- **`docs/DESIGN.md:4`.** "The 'Panel motion' section of AGENTS.md" now names `apps/desktop/src/renderer/AGENTS.md`, which is where that section lives.
- **`design/brand/README.md`.** Deleted the pointer to a root-README table of product moments that does not exist ("Where each one is used in the app is in the README at the repository root; the three the app has no moment for are noted there too"). The motion table gained the six states `design/generate-brand-assets.mjs` emits but it never listed — `hushed`, `wake`, `flyoff`, `shimmy`, `dizzy`, `glance` — each with the generator's own `moment`, in the generator's order; the table and the generator's 25 entries now match name-for-name and moment-for-moment.
- **`.github/RELEASE.md:199`.** Deleted "refuses a tag that does not match `apps/desktop/package.json`": `scripts/release/publish-github.sh` *derives* `TAG` from that file (`VERSION=$(node -p ...)`, `TAG="v$VERSION"`), so there is nothing it could refuse a mismatch against. The two refusals it does make (all six assets present, the tag exists) stay.
- **`apps/web/server/README.md`.** It was the only Markdown file in the tree with more than one H1 (six). One H1 title, its six sections beneath it as H2.

## AGENTS.md

- **`:1224-1229` ("## Repository shape") deleted.** It restated the guide's own opening paragraph (`apps/` deployable, `packages/` reusable) and, at more length, the opening of `packages/AGENTS.md`, which the table immediately above it already points at.
- **`:478-481` was already deleted on main** by #855's rewrite of the Gateway bullet; "Widening the method vocabulary…" now appears exactly once. Nothing to do.
- **One canonical sentence per repeated statement.** No constraint is weakened; each rule is stated once and referred to elsewhere:
  - *"20 most recent lines" into model context.* Canonical home is the standing-context rule ("the brain whose standing context carries the recent exchange — the 20 most recent Conversation lines, each cut to its own length bound"). The restatement inside the **replay-stream** bullet is gone; that bullet is about what a recording may see, and it keeps its own claim whole (Conversation is the one blocked subtree; the view retains every line the retention policy holds).
  - *"200 records / fortnight."* Canonical home is the conversation-retention bullet. Its own second statement ("What the thread hands a model is the same bounded recent slice") is gone — and it was also wrong: `maximumStoredConversationEntries = 200` with `storedConversationMaximumAgeMs = 14 days` is what survives a quit and what the panel reads, while `maximumConversationEntries = 20` (× `maximumConversationEntryLength = 400`) is what reaches the model. `packages/brain/src/store/database.test.ts:231` states the split in its name, and `PRIVACY.md:55` and `:62` already stated the two bounds separately. The canonical sentence now says the projection is the panel's, and the model's slice stands where it always did.
  - *"a fixture run stays silent."* One name for one gate. `runModeFor` in `packages/host/src/run-mode.ts` computes one `sendsNetwork` flag from `--capture-evidence` or `--fixture`, so "capture run" and "evidence run" were two names for the same set. The analytics/replay bullet keeps the full statement of the rule ("there is no switch, and the run mode is the whole of the gate"); Sentry and the development trace already referred to it ("the same run-mode network gate", "the same gate that keeps it off the network"); the updater and the introduction now refer to it too, in the same words, instead of restating it with the other name.

## Trust constraints

None widened, none narrowed. Every deleted sentence is a second statement of a rule the file still makes once, except the three that describe things that do not exist (the root-README motion table, the publish script's tag check) or that contradict the code (the model receiving the 200-line projection). `PRIVACY.md` needed no change: it already stated the 200/20 split correctly and the fixture-run gate in its own words.

## Evidence

```
$ ./scripts/check.sh
exit=0
```

`./scripts/verify.sh` was not run and no physical-notch check was performed: no source, style, asset, or renderer file is touched, so there is nothing for a capture to show. `git diff --stat` is seven Markdown files and one symlink.

```
$ git diff --shortstat origin/main...
 7 files changed, 46 insertions(+), 67 deletions(-)
```

Running total against the ~125k-line target: **-21 lines**.

Rebased onto `origin/main` after #851 landed. That PR added a "Hosted conversation store" section to `apps/web/server/README.md` as another H1; the rebase resolution demotes it with the rest. Worth recording for whoever hits this next: the conflict was silently stopping every `pull_request` CI run, exactly as AGENTS.md's git-workflow rule warns — the rollup showed only CodeQL, Cursor, and Vercel, and `all()` over that partial set answers `true`. Waiting on the rollup alone is not enough; the wait has to require that "TypeScript checks" and "macOS app and evidence" are in it.

## Reviews

A thermonuclear code-quality review and a ponytail (over-engineering) review ran over the diff. Neither skill is installed here, so both were run from their published methodology. Findings fixed in the second commit:

- **Legibility.** The deletions left AGENTS.md lines a third the width of their neighbours, and `.github/RELEASE.md` and `docs/DESIGN.md` each ended up with one line far past the width the rest of the file keeps. The affected paragraphs are reflowed.
- **Over-claiming.** The first commit had the updater and the introduction bullets say "behind the same run-mode gate". They do each read `runModeFor`'s output, but different flags of it — `apps/desktop/src/main/services/compose-desktop.ts:75` and `update-service-host.ts:111` gate the updater on `runMode.sendsNetwork`; `shouldRunIntroduction` gates on `requiresAccount` — so naming "the same" gate beside three bullets that name a *network* gate claims more than either does. Both now take only the one name for the run that sends nothing, and which flag stands is left to the canonical bullet, which is the point of the dedupe.

Nothing else survived. The remaining ponytail candidate, CONTRIBUTING's `apps/`/`packages/` paragraph, is itself a restatement of AGENTS.md's opening, but it is not one of the three sections this PR was scoped to and cutting it would widen the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/bc18b39a-28cf-4cb0-9a1f-6a46e29d3a65)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34397668458/artifacts/10122244455) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34397668458)

- Commit: `c7a1cbd945698ec218df455413585996ab9f487c`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

