### PR TITLE
feat(providers): the brain reads a Conductor session's conversation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -207,20 +207,27 @@ Canonical commands:
   address hands the address to the operating system exactly once, as a row
   press would. Nothing a model decided can start that wait, and a created
   session that reports no address inside its window is left unopened like any
-  other row without one. Reading a local session's
+  other row without one. Reading a session's
   transcript at the developer's ask is the brain's own read, not an action: the
   brain's `read_transcript` tool, offered in every kind of turn, names a
   session by the identity the standing context lists, is refused in the
   agent for any identity the roster does not hold, is refused again in the
-  main process for a session whose location is not this machine or whose
-  provider is not connected, and reads the provider's own file through that
-  provider's own reader, bounded as the next rule says. The read performs
-  nothing, reaches no provider, and answers only for a local session whose
-  provider's transcript this build documents reading (Claude Code, Codex,
-  and OMP today); a cloud session's conversation lives with its provider and
-  is never fetched. The read renders only what the provider actually wrote
-  down, and a provider whose stored shape this build cannot render
-  faithfully keeps the honest refusal instead. What the read rendered enters
+  main process for a session whose provider is not connected, and reads
+  through that provider's own reader, bounded as the next rule says. The read
+  performs nothing and answers only where this build documents reading a
+  transcript: for a local session, the provider's own file (Claude Code,
+  Codex, and OMP today), reaching no provider; for a Conductor cloud session,
+  the same documented messages endpoint the iOS screen reads
+  (`GET /v0/sessions/{id}/messages`), under the developer's own Conductor
+  key on this Mac, only for a session the plugin's latest pass reported, only
+  as the product of the tool call itself and never of an observation pass,
+  answering the newest page of the developer's own sends and the agent's own
+  words — a tool call, tool output, or unattributed record is dropped whole —
+  rendered in the same line vocabulary the local readers use and held only in
+  the turn's working memory; any other cloud session's conversation lives
+  with its provider and is never fetched. The read renders only what the
+  provider actually wrote down, and a provider whose stored shape this build
+  cannot render faithfully keeps the honest refusal instead. What the read rendered enters
   the brain's working memory like every other tool answer, and lives and dies
   with its generation under the next rule; what reaches the developer is the
   reply the brain writes from it, which may quote or summarize the reading
@@ -260,8 +267,9 @@ Canonical commands:
   is one entry, and the inbox holds at most 20 entries. The conversation
   may also read one observed session's whole
   tail, cut from the front to 60,000 characters, through the same read tool
-  a developer's ask is offered; a cloud session, and a provider whose
-  transcript this build does not read, are read from roster fields alone.
+  a developer's ask is offered; a cloud session whose provider documents no
+  transcript read, and a local provider whose transcript this build does not
+  read, are read from roster fields alone.
   An observed conversation's `announce` reaches the voice directly; main
   neither approves nor rewords it. Any conversation may delegate: the brain's
   `sessions_spawn` tool records a child (`agent:main:subagent:<uuid>`, kind
@@ -1142,8 +1150,9 @@ Canonical commands:
 
 ### Reading a session's conversation
 
-- A session's conversation itself is read in exactly one place, and the place
-  is deliberate: in the open, at the developer's own press, never behind an
+- A cloud session's conversation itself is read in exactly two places, and
+  both are deliberate: in the open, at the developer's own press, and through
+  the brain's `read_transcript` tool under the rule above, never behind an
   observation pass, which reads no message of any chat. When the developer opens a
   Conductor session's own screen in the iOS app, that screen asks Luke's
   service for the conversation, and the service reads it through Conductor's

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -36,7 +36,13 @@ throttle, a failure, or a quit picks it up rather than rereading or losing
 it; an entry leaves the inbox when a turn has consumed it, and the inbox
 holds at most 20 entries. What he reads is sent to a model as described under
 "Who we send it to", and what he keeps of it lives under his working memory's
-own lifetime, described below, one memory per conversation. Nothing else reads message history, file
+own lifetime, described below, one memory per conversation. For a Conductor
+session, which keeps no transcript on your Mac, the same "read the recent
+tail" ask reads the newest page of that chat's conversation from Conductor
+instead — your own messages and the agent's replies, not its tool activity —
+using the Conductor key you gave the Mac app, only for a session Luke was just
+shown, and never on his periodic look; what he reads is held in that turn's
+working memory and stored nowhere else. Nothing else reads message history, file
 contents, or command output. If you run
 agents inside the Herdr terminal manager, Luke also asks Herdr's own
 command-line tool which of those sessions it holds, so their rows can say so;
@@ -380,7 +386,10 @@ and email you signed it with, and any screenshots you attached.
   agent's replies, not its tool activity — using the key you synced, and
   passes it to your phone while the screen is open. We store none of it: each
   refresh is a new read, and nothing about the conversation stays on our
-  servers after the response is sent.
+  servers after the response is sent. The Mac app reads the same conversation
+  directly from Conductor, with your own key and through no server of ours,
+  when Luke reads a Conductor session's recent tail as described under "What
+  we collect".
 - Google, if you connect Google Calendar. We request your calendar list and your
   availability. Google returns busy times only, so event titles and attendees
   are never available to Luke.

--- a/README.md
+++ b/README.md
@@ -58,7 +58,8 @@ him to forget it.
 Luke speaks up when an agent is waiting for you, hits an error, or finishes. For
 a local agent whose transcript he can read (Claude Code, Codex, and OMP today)
 he reads what the transcript gained since he last looked; for a cloud agent he
-goes by what its provider reports about it. Either way he judges whether it is
+goes by what its provider reports about it, and for a Conductor agent he can
+also read the conversation itself when the status is not enough. Either way he judges whether it is
 worth interrupting you for, and says everything worth saying in one breath
 rather than a sentence per event.
 

--- a/apps/web/server/hosted/remote-context.ts
+++ b/apps/web/server/hosted/remote-context.ts
@@ -67,10 +67,8 @@ function remoteCapabilityText(
   const capabilities = [
     `provider_id=${session.providerId} provider_session_id=${session.sessionId}`,
     `messages=${Boolean(session.canReceiveMessage)}`,
-    // The phone opens a session on its own screen; no cloud session has a
-    // transcript on the device to read.
+    // The phone opens a session on its own screen.
     "open=true",
-    "transcript=false",
     ...(mostRecent.get(session.providerId) === session.sessionId
       ? ["most_recent_for_provider=true", "most_recent_openable_for_provider=true"]
       : []),

--- a/apps/web/tests/hosted-remote-context.test.ts
+++ b/apps/web/tests/hosted-remote-context.test.ts
@@ -26,7 +26,6 @@ test("every phone row opens, and the newest per provider wears both recency labe
   );
   const [, newest, older] = text.split("\n");
   assert.ok(newest?.includes("open=true"));
-  assert.ok(newest?.includes("transcript=false"));
   assert.ok(newest?.includes("most_recent_for_provider=true"));
   assert.ok(newest?.includes("most_recent_openable_for_provider=true"));
   assert.ok(older?.includes("open=true"));

--- a/packages/brain/src/standing-context.test.ts
+++ b/packages/brain/src/standing-context.test.ts
@@ -364,8 +364,8 @@ test("the roster says what a session is doing and where, in the attention update
   assert.doesNotMatch(bareText, /error:/);
 });
 
-test("the roster says which sessions keep a readable transcript and a pull request, never an address", () => {
-  const local = normalizeSession(
+test("the roster says which sessions have a pull request, never an address", () => {
+  const plain = normalizeSession(
     { id: "codex", displayName: "Codex" },
     {
       providerSessionId: "thread-local",
@@ -374,8 +374,6 @@ test("the roster says which sessions keep a readable transcript and a pull reque
       lastActivityAt: OBSERVED_AT,
     },
   );
-  assert.match(sessionContextText([local]), /transcript=true/);
-
   const cloud = normalizeSession(
     { id: "conductor", displayName: "Conductor" },
     {
@@ -388,12 +386,11 @@ test("the roster says which sessions keep a readable transcript and a pull reque
     },
   );
   const cloudText = sessionContextText([cloud]);
-  assert.match(cloudText, /transcript=false/);
   // The pull request travels as a fact, like openability: the row is where it
   // opens from, and no address belongs in a conversation.
   assert.match(cloudText, /pull_request=true/);
   assert.doesNotMatch(cloudText, /github\.com/);
-  assert.doesNotMatch(sessionContextText([local]), /pull_request=true/);
+  assert.doesNotMatch(sessionContextText([plain]), /pull_request=true/);
 });
 
 test("session context stays bounded when many sessions are observed", () => {

--- a/packages/brain/src/standing-context.ts
+++ b/packages/brain/src/standing-context.ts
@@ -4,7 +4,6 @@ import {
   advertisedActionFor,
   advertisedControls,
   type ObservedWorkspaceProject,
-  SESSION_LOCATION,
   type Session,
   WORKSPACE_TASK_SUPPORT,
   type WorkspaceTaskSupport,
@@ -65,7 +64,6 @@ function sessionCapabilityText(session: Session, recency: SessionRecency): strin
             .join(", ")}`,
         ]
       : []),
-    `transcript=${session.location === SESSION_LOCATION.LOCAL}`,
     ...(recency.mostRecentForProvider ? ["most_recent_for_provider=true"] : []),
     ...(recency.mostRecentOpenableForProvider ? ["most_recent_openable_for_provider=true"] : []),
     ...(session.detail.change ? ["pull_request=true"] : []),

--- a/packages/brain/src/tools.ts
+++ b/packages/brain/src/tools.ts
@@ -108,9 +108,10 @@ const BRAIN_ONLY_TOOLS: readonly ActionToolDefinition[] = [
     name: BRAIN_TOOL.READ_TRANSCRIPT,
     description:
       "Read the recent transcript of one observed session in full, bounded to its tail. Use it " +
-      "when an event's transcript delta is not enough to judge what the agent is doing. Only a " +
-      "local session whose provider's transcript this build reads answers; a cloud session " +
-      "returns a refusal.",
+      "when an event's transcript delta is not enough to judge what the agent is doing. A local " +
+      "session answers when its provider's transcript this build reads; a Conductor cloud " +
+      "session answers with the developer's messages and the agent's replies, never its tool " +
+      "activity; any other cloud session returns a refusal.",
     parameters: {
       type: "object",
       properties: SESSION_IDENTITY_PROPERTIES,

--- a/packages/host/src/brain/wiring.ts
+++ b/packages/host/src/brain/wiring.ts
@@ -635,12 +635,9 @@ export function wireBrain(dependencies: BrainWiringDependencies): BrainWiring {
             reason: "No observed session matches that identity.",
           });
         }
-        if (session.location !== SESSION_LOCATION.LOCAL) {
-          return Promise.resolve({
-            status: ACTION_RESULT_STATUS.UNSUPPORTED,
-            reason: "A cloud session's conversation lives with its provider, not on this machine.",
-          });
-        }
+        // Whether a session's transcript can be read is the provider's own
+        // word: a local reader opens its file, Conductor reads its documented
+        // messages endpoint, and a provider naming no handler refuses.
         return dispatchRead(plugin, "transcript", identity.providerSessionId);
       },
       deliver: (delivery) => dependencies.deliver({ ...delivery, sessionKey }),

--- a/packages/providers/src/conductor/contract.test.ts
+++ b/packages/providers/src/conductor/contract.test.ts
@@ -32,6 +32,7 @@ describeProviderContract(
     ],
     unadvertised: [],
     targetedControlId: "archive-workspace",
+    transcript: { sessionId: CONDUCTOR_SESSION_ID.IDLE, throughMessagesEndpoint: true },
     conversation: { sessionId: CONDUCTOR_SESSION_ID.IDLE },
   },
 );

--- a/packages/providers/src/conductor/conversation.test.ts
+++ b/packages/providers/src/conductor/conversation.test.ts
@@ -467,3 +467,70 @@ test("a conversation read names what refused it without echoing the provider", a
     reason: "Conductor did not answer, so the conversation could not be read.",
   });
 });
+
+test("the brain's transcript read renders the attributed words one line each, in the shared vocabulary", async () => {
+  const api = conversationApi();
+  const plugin = pluginFor(api.fetch);
+  await plugin.observe();
+  const requestsBefore = api.requests.length;
+
+  const read = await dispatchRead(plugin, "transcript", IDLE_SESSION_UUID);
+
+  assert.equal(read.status, "accepted");
+  if (read.status !== "accepted") return;
+  assert.equal(
+    read.transcript,
+    [
+      "Developer: Fix the flaky roster test",
+      "Conductor: Looking at the test now. It races the clock.",
+      "Conductor: Fixed: the test now stubs the clock.",
+    ].join("\n"),
+  );
+  const reads = api.requests.slice(requestsBefore);
+  assert.ok(reads.length >= 1);
+  for (const request of reads) {
+    assert.equal(request.method, "GET");
+    assert.equal(request.pathname, `/v0/sessions/${IDLE_SESSION_UUID}/messages`);
+  }
+});
+
+test("a transcript read refuses a session the latest pass did not report and reaches nothing", async () => {
+  const api = conversationApi();
+  const plugin = pluginFor(api.fetch);
+  await plugin.observe();
+  const requestsBefore = api.requests.length;
+
+  const read = await dispatchRead(plugin, "transcript", "99999999-9999-4999-8999-999999999999");
+
+  assert.equal(read.status, "unsupported");
+  assert.equal(api.requests.length, requestsBefore);
+});
+
+test("a transcript read of a chat with no attributed words is not found rather than empty", async () => {
+  const api = conversationApi({
+    storedMessages: [
+      storedAgentEvent(STORED_MESSAGE_UUIDS[7], { type: "system", subtype: "init" }, TEST_TIME),
+    ],
+  });
+  const plugin = pluginFor(api.fetch);
+  await plugin.observe();
+
+  const read = await dispatchRead(plugin, "transcript", IDLE_SESSION_UUID);
+
+  assert.deepEqual(read, {
+    status: "rejected",
+    reason: "That session's transcript could not be found.",
+  });
+});
+
+test("a transcript read that Conductor refuses is rejected with the reason, never thrown", async () => {
+  const api = conversationApi({ messagesHttpStatus: HTTP_STATUS.UNAUTHORIZED });
+  const plugin = pluginFor(api.fetch);
+  await plugin.observe();
+
+  const read = await dispatchRead(plugin, "transcript", IDLE_SESSION_UUID);
+
+  assert.equal(read.status, "rejected");
+  if (read.status !== "rejected") return;
+  assert.match(read.reason, /Conductor/u);
+});

--- a/packages/providers/src/conductor/conversation.ts
+++ b/packages/providers/src/conductor/conversation.ts
@@ -1,13 +1,21 @@
 import {
   ACTION_RESULT_STATUS,
+  CONVERSATION_MESSAGE_AUTHOR,
   type ConversationPage,
+  OMISSION_MARKER,
   type ProviderConversationMessage,
   type ProviderConversationResult,
+  type ProviderTranscriptResult,
 } from "@sidecar/session";
-import type { WireRecord } from "@sidecar/wire";
+import { oneLine, type WireRecord } from "@sidecar/wire";
 import { ADAPTER_FAILURE, AdapterFailure } from "../shared/adapter-failure.js";
 import type { CloudPass } from "../shared/cloud-pass.js";
 import { isDefined, recordsFromPage, textFromRecord } from "../shared/cloud-wire.js";
+import {
+  boundedTranscript,
+  TRANSCRIPT_BOUNDS,
+  transcriptLine,
+} from "../shared/jsonl-transcript.js";
 import { CONDUCTOR_PROVIDER_NAME, UUID_PATTERN } from "./vocabulary.js";
 import {
   CONDUCTOR_CONVERSATION_BOUNDS,
@@ -20,15 +28,18 @@ import {
 
 /**
  * One observed chat's stored conversation, through the documented transcript
- * read `GET …/sessions/{id}/messages`, only at a developer's own ask — never
- * from an observation pass. It reads the way a chat screen does: opened plain
- * it answers the newest page, walking to the transcript's end because the
- * endpoint pages ascending; handed `beforeOffset` it answers the older
- * history just before what the screen holds; handed `afterMessageId` it
- * answers only what is newer, behind the endpoint's own polling cursor. Every
- * mode keeps only the messages the store itself attributes, and everything
- * else is dropped unread. The page is answered to the caller and nothing is
- * kept here: the conversation stays the provider's.
+ * read `GET …/sessions/{id}/messages`, never from an observation pass. Two
+ * callers ask for it. A conversation screen reads the way a chat screen does:
+ * opened plain it answers the newest page, walking to the transcript's end
+ * because the endpoint pages ascending; handed `beforeOffset` it answers the
+ * older history just before what the screen holds; handed `afterMessageId`
+ * it answers only what is newer, behind the endpoint's own polling cursor.
+ * The brain's transcript read takes the same newest page, rendered in the
+ * line vocabulary every local transcript reader speaks, so one shape
+ * describes an agent wherever it runs. Every mode keeps only the messages the
+ * store itself attributes, and everything else is dropped unread. The page is
+ * answered to the caller and nothing is kept here: the conversation stays the
+ * provider's.
  */
 
 /**
@@ -266,6 +277,78 @@ function rememberEnd(
   }
 }
 
+/**
+ * What an agent message is spoken as when the pass could not map the chat's
+ * agent kind: Conductor is the one that stored it, so Conductor's name stands
+ * rather than a guess at whose words they are.
+ */
+const CONDUCTOR_SPEAKER_NAME = CONDUCTOR_PROVIDER_NAME;
+
+/** A read Conductor refused, named without echoing the provider's own words. */
+function readRefusal(failure: AdapterFailure, subject: string) {
+  return {
+    status: ACTION_RESULT_STATUS.REJECTED,
+    reason:
+      failure.failure === ADAPTER_FAILURE.UNAUTHORIZED
+        ? `${CONDUCTOR_PROVIDER_NAME} rejected the configured API key.`
+        : `${CONDUCTOR_PROVIDER_NAME} did not answer, so the ${subject} could not be read.`,
+  };
+}
+
+/**
+ * The brain's whole-transcript read of one cloud chat: the newest page of its
+ * stored conversation, rendered one attributed message per line. It reaches
+ * the provider, so it answers only for a session the latest pass reported,
+ * the same guard the conversation read stands behind. A tail that history
+ * precedes opens with the omission marker, so the reader knows the chat did
+ * not begin there; a chat with no attributed message yet is not found rather
+ * than rendered empty.
+ */
+export async function readConductorTranscript(
+  pass: CloudPass,
+  ends: ConductorConversationEnds,
+  providerSessionId: string,
+): Promise<ProviderTranscriptResult> {
+  const observation = pass
+    .latest()
+    .find((candidate) => candidate.providerSessionId === providerSessionId);
+  if (!observation || !UUID_PATTERN.test(providerSessionId)) {
+    return {
+      status: ACTION_RESULT_STATUS.UNSUPPORTED,
+      reason: "That session is not one the latest observation pass reported.",
+    };
+  }
+  let tail: ProviderConversationResult;
+  try {
+    tail = await readTailPage(pass, ends, providerSessionId);
+  } catch (error) {
+    if (error instanceof AdapterFailure) return readRefusal(error, "transcript");
+    throw error;
+  }
+  if (tail.status !== ACTION_RESULT_STATUS.ACCEPTED) return tail;
+  const speaker = observation.agent?.displayName ?? CONDUCTOR_SPEAKER_NAME;
+  const lines = tail.messages.flatMap((message) => {
+    const words = oneLine(message.text, TRANSCRIPT_BOUNDS.MAXIMUM_MESSAGE_LENGTH);
+    if (!words) return [];
+    return [
+      message.author === CONVERSATION_MESSAGE_AUTHOR.USER
+        ? transcriptLine.developer(words)
+        : transcriptLine.agent(speaker, words),
+    ];
+  });
+  const rendered = boundedTranscript(lines);
+  if (rendered === undefined) {
+    return {
+      status: ACTION_RESULT_STATUS.REJECTED,
+      reason: "That session's transcript could not be found.",
+    };
+  }
+  return {
+    status: ACTION_RESULT_STATUS.ACCEPTED,
+    transcript: tail.hasOlder ? `${OMISSION_MARKER}\n${rendered}` : rendered,
+  };
+}
+
 export async function readConductorConversation(
   pass: CloudPass,
   ends: ConductorConversationEnds,
@@ -313,15 +396,7 @@ export async function readConductorConversation(
     }
     return await readTailPage(pass, ends, providerSessionId);
   } catch (error) {
-    if (error instanceof AdapterFailure) {
-      return {
-        status: ACTION_RESULT_STATUS.REJECTED,
-        reason:
-          error.failure === ADAPTER_FAILURE.UNAUTHORIZED
-            ? `${CONDUCTOR_PROVIDER_NAME} rejected the configured API key.`
-            : `${CONDUCTOR_PROVIDER_NAME} did not answer, so the conversation could not be read.`,
-      };
-    }
+    if (error instanceof AdapterFailure) return readRefusal(error, "conversation");
     throw error;
   }
 }

--- a/packages/providers/src/conductor/index.ts
+++ b/packages/providers/src/conductor/index.ts
@@ -4,7 +4,11 @@ import type { CloudFetch } from "@sidecar/wire";
 import type { AdapterDiagnosticCallback } from "../shared/adapter-diagnostics.js";
 import { cloudPass } from "../shared/cloud-pass.js";
 import { conductorActions } from "./actions.js";
-import { conductorConversationEnds, readConductorConversation } from "./conversation.js";
+import {
+  conductorConversationEnds,
+  readConductorConversation,
+  readConductorTranscript,
+} from "./conversation.js";
 import { type ConductorPassCache, conductorObservations } from "./observe.js";
 import {
   CONDUCTOR_DEFAULT_API_URL,
@@ -32,9 +36,13 @@ export interface ConductorPluginOptions {
  * thing a press opens and a write reaches, and a workspace holding two chats
  * in two states is two facts, not one.
  *
- * No observation pass reads a word of a conversation. The one read of it is
- * the `conversation` handler, reached only at a developer's own ask, and it
- * keeps nothing but where in each transcript it last got to.
+ * No observation pass reads a word of a conversation. Its two reads are the
+ * `conversation` handler, reached at a developer's own press on a chat's
+ * screen, and the `transcript` handler, reached by the brain's own read tool
+ * in a turn, and between them they keep nothing but where in each transcript
+ * the last read got to. Neither takes a cursor from a pass: the incremental
+ * `transcriptSince` read stays unanswered, so an observation pass judges a
+ * cloud chat from what Conductor reports about it.
  */
 export function conductorPlugin(options: ConductorPluginOptions): SessionProviderPlugin {
   /**
@@ -81,6 +89,7 @@ export function conductorPlugin(options: ConductorPluginOptions): SessionProvide
     actions: conductorActions(pass),
 
     reads: {
+      transcript: (providerSessionId) => readConductorTranscript(pass, ends, providerSessionId),
       conversation: ({ request, observation }) =>
         readConductorConversation(pass, ends, observation.providerSessionId, request),
     },

--- a/packages/providers/src/conductor/observe.test.ts
+++ b/packages/providers/src/conductor/observe.test.ts
@@ -42,9 +42,10 @@ test("names every action Conductor documents, and none it does not", () => {
     "renameWorkspace",
     "spawnAgent",
   ]);
-  // A cloud session's conversation lives with its provider: the developer's
-  // own conversation read is the one read here, and no transcript read at all.
-  assert.deepEqual(Object.keys(plugin.reads ?? {}), ["conversation"]);
+  // A cloud session's conversation lives with its provider, and both reads of
+  // it go there: the developer's own conversation read and the brain's
+  // transcript read, with no incremental read for an observation pass.
+  assert.deepEqual(Object.keys(plugin.reads ?? {}).sort(), ["conversation", "transcript"]);
 });
 test("observes cloud sessions the signed-in user created, under their own names", async () => {
   const api = fakeConductorApi({

--- a/packages/providers/src/conductor/wire.ts
+++ b/packages/providers/src/conductor/wire.ts
@@ -33,7 +33,8 @@ import {
  * a user asks for by opening a conversation screen:
  * `GET …/sessions/{id}/messages`, Conductor's documented read of one
  * session's stored transcript, paged with the `after` cursor its own answers
- * hand back and never issued by an observation pass. The writers
+ * hand back; the brain's own transcript read takes its newest page too, and
+ * it is never issued by an observation pass. The writers
  * are `POST …/sessions/{id}/messages`, which is
  * Conductor's documented way to hand a prompt to an existing session — queued
  * while it is idle, steered into the running turn while it works —
@@ -237,7 +238,8 @@ export const CONDUCTOR_SQL_FIELD = {
  * The columns ask for the agent kind and nothing else. The view also holds
  * each chat's transcript, and no column of it is named here: the
  * conversation is the documented messages endpoint's to read, at the
- * developer's own press, never an observation pass's.
+ * developer's own press or the brain's own read tool, never an observation
+ * pass's.
  */
 export const CONDUCTOR_READ_AGENT_KINDS_PREFIX =
   `SELECT ${CONDUCTOR_SQL_FIELD.SESSION_ID}, ${CONDUCTOR_SQL_FIELD.AGENT_TYPE} ` +

--- a/packages/providers/src/testing/provider-contract.ts
+++ b/packages/providers/src/testing/provider-contract.ts
@@ -110,6 +110,11 @@ export interface ProviderFixtures {
     readonly sessionId: string;
     /** An observed session whose stored shape this build renders nothing from. */
     readonly unrenderableSessionId?: string;
+    /**
+     * Set for a cloud provider whose transcript read is its documented
+     * messages endpoint: the read reaches the provider, and only that route.
+     */
+    readonly throughMessagesEndpoint?: boolean;
   };
   /** Set when this provider documents a conversation read. */
   readonly conversation?: { readonly sessionId: string };
@@ -697,10 +702,10 @@ export function describeProviderContract(
     });
   }
 
-  // "The read performs nothing, reaches no provider, and answers only for a
-  // local session whose provider's transcript this build documents reading …;
-  // a cloud session's conversation lives with its provider and is never
-  // fetched."
+  // "The read performs nothing and answers only for a session whose provider's
+  // transcript this build documents reading: a local provider's own file, or
+  // a cloud provider's documented messages endpoint (Conductor today), which
+  // the read reaches and nothing else does."
   test(named("reads a transcript only where this build documents reading one"), async (t) => {
     const { plugin, api, cli } = await contractCase(t);
     await plugin.observe();
@@ -721,7 +726,15 @@ export function describeProviderContract(
         "a session whose transcript this build does not read answered with one",
       );
     }
-    assert.equal(api.requests().length, requestsAfterPass);
+    if (fixtures.transcript?.throughMessagesEndpoint) {
+      const routes = recordedRoutes(api.requests().slice(requestsAfterPass));
+      assert.ok(routes.length > 0, "the transcript read reached no messages endpoint");
+      for (const route of routes) {
+        assert.ok(route.includes("/messages"), `a transcript read reached ${route}`);
+      }
+    } else {
+      assert.equal(api.requests().length, requestsAfterPass);
+    }
     assert.equal(cli.invocations().length, invocationsAfterPass);
   });
 

--- a/packages/session/fixtures/providers/conductor/golden/transcript.txt
+++ b/packages/session/fixtures/providers/conductor/golden/transcript.txt
@@ -1,0 +1,2 @@
+Developer: Please fix the flaky check.
+Conductor: Parting words.

--- a/packages/session/src/provider-plugin.test.ts
+++ b/packages/session/src/provider-plugin.test.ts
@@ -171,6 +171,37 @@ test("a transcript read stops at the observer that holds the session", async () 
   assert.deepEqual(asked, ["local"]);
 });
 
+test("a transcript read goes to the observer that reported the session, so a cloud session keeps its honest refusal", async () => {
+  const asked: string[] = [];
+  const local: SessionProviderPlugin = {
+    provider: { id: "merged", displayName: "merged" },
+    observe: async () => [OBSERVATION],
+    latest: () => [OBSERVATION],
+    reads: {
+      transcript: async () => {
+        asked.push("local");
+        return { status: ACTION_RESULT_STATUS.REJECTED, reason: "not found" };
+      },
+    },
+  };
+  const cloud: SessionProviderPlugin = {
+    provider: { id: "merged", displayName: "merged" },
+    observe: async () => [CLOUD_OBSERVATION],
+    latest: () => [CLOUD_OBSERVATION],
+  };
+  const merged = mergePlugins({ id: "merged", displayName: "Merged" }, [local, cloud]);
+
+  const read = await merged.reads?.transcript?.(CLOUD_OBSERVATION.providerSessionId);
+
+  assert.equal(read?.status, ACTION_RESULT_STATUS.UNSUPPORTED);
+  assert.deepEqual(asked, []);
+  assert.equal(
+    (await merged.reads?.transcript?.(OBSERVATION.providerSessionId))?.status,
+    ACTION_RESULT_STATUS.REJECTED,
+  );
+  assert.deepEqual(asked, ["local"]);
+});
+
 test("merging an observer of another provider is refused outright", () => {
   const other: SessionProviderPlugin = {
     provider: { id: "other", displayName: "Other" },

--- a/packages/session/src/provider-plugin.ts
+++ b/packages/session/src/provider-plugin.ts
@@ -493,6 +493,23 @@ export function mergePlugins(
     reason: "No provider observer supports that action.",
   } as const;
 
+  /**
+   * A transcript read belongs to the observer whose latest pass reported the
+   * session, and its answer — a rendering, a refusal in its own words, or no
+   * transcript at all — is the session's own: a local file reader asked
+   * about a cloud session would answer not found, when the honest answer is
+   * that the cloud keeps no transcript. A session no observer reported is
+   * asked of each in turn, the way a hook's session between passes is.
+   */
+  const readOf = <Result extends { status: string }>(
+    providerSessionId: string,
+    ask: (plugin: SessionProviderPlugin) => Promise<Result>,
+    unread: Result,
+  ): Promise<Result> => {
+    const holder = plugins.find((plugin) => observationFor(plugin, providerSessionId));
+    return holder ? ask(holder) : firstFirmAnswer(ask, unread);
+  };
+
   /** One action, asked of each observer in turn with the ask it was built from. */
   const askEach = <Kind extends PluginActionKind>(
     kind: Kind,
@@ -532,12 +549,14 @@ export function mergePlugins(
 
     reads: {
       transcript: (providerSessionId) =>
-        firstFirmAnswer<ProviderTranscriptResult>(
+        readOf<ProviderTranscriptResult>(
+          providerSessionId,
           (plugin) => dispatchRead(plugin, "transcript", providerSessionId),
           exhausted,
         ),
       transcriptSince: (providerSessionId, cursor) =>
-        firstFirmAnswer<ProviderTranscriptSinceResult>(
+        readOf<ProviderTranscriptSinceResult>(
+          providerSessionId,
           (plugin) => dispatchRead(plugin, "transcriptSince", providerSessionId, cursor),
           exhausted,
         ),


### PR DESCRIPTION
## Summary

- The brain's `read_transcript` tool now answers for Conductor cloud sessions. The Conductor plugin gains a `transcript` read that takes the newest page of the chat through the documented `GET /v0/sessions/{id}/messages` endpoint (the same read the iOS conversation screen uses), renders the developer's sends and the agent's replies in the shared `Developer:` / `<agent>:` line vocabulary, and drops tool activity and unattributed records whole. It answers only for a session the latest pass reported and is never issued by an observation pass; no `transcriptSince` handler is added, so pass-driven deltas stay local-only.
- The host stops refusing cloud sessions by location and lets each provider's own `transcript` handler decide. Codex cloud names none and keeps the honest refusal.
- The roster's per-session `transcript=` flag, derived from location, told the model a Conductor session could not be read even after the tool could. It is removed from the desktop standing context and the hosted phone context; the tool description alone says which sessions answer, and the tool refuses with a reason where none does.
- `AGENTS.md`, `PRIVACY.md`, and `README.md` say the widening in as many words. The provider contract suite gains a `throughMessagesEndpoint` fixture flag asserting the read touches only the messages route, with a synthetic golden `transcript.txt`.

## Test plan

- [x] `./scripts/check.sh` passes (lint, typecheck, tests, build).
- [x] New Conductor tests: rendering, refusal of an unreported session with no request made, an empty chat answering not found, and a provider refusal mapped to a rejection.
- [x] Manually on a Mac with a Conductor key: Luke reads a Conductor session's conversation when asked what it is doing.
- [ ] Portable-only change; no `verify.sh` or physical-notch check performed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34402304449/artifacts/10124029329) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34402304449)

- Commit: `f1081cbae4bb1f6b0fb617f28abbe05a592763c0`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
