### PR TITLE
fix(host): age settled sessions off the roster again

### DIFF
--- a/packages/host/src/compose-observation.ts
+++ b/packages/host/src/compose-observation.ts
@@ -49,6 +49,7 @@ import {
   PROVIDER_ID,
   PROVIDER_ID_LIST,
   type ProviderId,
+  rosterRelevantSessions,
   type Session,
   type SessionIdentity,
   type SessionProviderPlugin,
@@ -111,7 +112,7 @@ export interface ObservationComposer extends Composer {
   pluginFor: (providerId: string) => SessionProviderPlugin | undefined;
   session: (identity: SessionIdentity) => Session | undefined;
   observedSessionCount: () => number;
-  /** The roster a client draws: the same relevance gate every broadcast passes. */
+  /** The roster a client draws: the sessions still worth a row, the same gate every broadcast passes. */
   rosterForClients: () => readonly Session[];
   rosterSettled: () => boolean;
   offeredWorkspaceProjects: () => readonly ObservedWorkspaceProject[];
@@ -119,7 +120,7 @@ export interface ObservationComposer extends Composer {
   broadcastWorkspaceProjects: () => Promise<void>;
   readSupersetWorkspaceHost: () => Promise<WorkspaceHostEnrichment>;
   refreshCredentialAdapter: (providerId: CredentialProviderId) => void;
-  /** The sessions an action may name: the roster less the voice's own. */
+  /** The sessions an action may name: the drawn roster less the voice's own. */
   actableSessions: () => readonly Session[];
   roster: () => BrainRoster;
   workspaceProjects: () => readonly ObservedWorkspaceProject[];
@@ -530,9 +531,25 @@ export function composeObservation(dependencies: ObservationDependencies): Obser
     },
   });
 
+  /**
+   * The roster keeps every observation whole, and the adapters age out and cap
+   * nothing, so this one gate is where a session that settled long ago stops
+   * being a row. Every client-facing read passes through it: the broadcast,
+   * the bootstrap and roster method, and the sessions an action may name, so
+   * the panel, the voice, and admission see one roster. The pass announces
+   * every run whether or not anything moved, so a session that crosses its
+   * horizon between observations leaves on the next broadcast.
+   */
+  function relevantSessions(sessions: readonly Session[]): readonly Session[] {
+    return rosterRelevantSessions(sessions, now());
+  }
+
   function broadcastSessions(sessions: readonly Session[]): void {
     rosterBroadcast = true;
-    kernel.emit(GATEWAY_EVENT.SESSIONS_CHANGED, { sessions: carried(sessions), settled: true });
+    kernel.emit(GATEWAY_EVENT.SESSIONS_CHANGED, {
+      sessions: carried(relevantSessions(sessions)),
+      settled: true,
+    });
   }
 
   function countObservedSessions(sessions: readonly Session[]): void {
@@ -572,11 +589,15 @@ export function composeObservation(dependencies: ObservationDependencies): Obser
   }
 
   function actableSessions(): readonly Session[] {
-    return sessionRegistry.list().filter((session) => session.realtimeVoice !== true);
+    return relevantSessions(sessionRegistry.list()).filter(
+      (session) => session.realtimeVoice !== true,
+    );
   }
 
   function rosterForClients(): readonly Session[] {
-    return runMode.observesProviders && account.capabilitiesActive() ? sessionRegistry.list() : [];
+    return runMode.observesProviders && account.capabilitiesActive()
+      ? relevantSessions(sessionRegistry.list())
+      : [];
   }
 
   const methods: GatewayMethodTable = {

--- a/packages/session/src/index.ts
+++ b/packages/session/src/index.ts
@@ -9,6 +9,7 @@ export * from "./normalize.js";
 export * from "./provider-contract.js";
 export * from "./provider-identity.js";
 export * from "./provider-plugin.js";
+export * from "./roster-relevance.js";
 export * from "./session-filter.js";
 export * from "./session-identity.js";
 export * from "./session-registry.js";

--- a/packages/session/src/roster-relevance.test.ts
+++ b/packages/session/src/roster-relevance.test.ts
@@ -1,0 +1,89 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  isRosterRelevant,
+  normalizeSession,
+  rosterRelevantSessions,
+  SESSION_STATUS,
+  type Session,
+  type SessionStatus,
+  sessionRosterRetentionMs,
+} from "@sidecar/session";
+
+const TEST_NOW = Date.parse("2026-09-09T12:00:00.000Z");
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function session(
+  providerSessionId: string,
+  status: SessionStatus,
+  lastActivityAt: number,
+): Session {
+  return normalizeSession(
+    { id: "codex", displayName: "Codex" },
+    { providerSessionId, title: "Implement the shared session core", status, lastActivityAt },
+  );
+}
+
+test("a session that is live or asking stays on the roster at any age", () => {
+  for (const status of [SESSION_STATUS.WORKING, SESSION_STATUS.WAITING]) {
+    assert.equal(
+      isRosterRelevant(session("run:1", status, TEST_NOW - 100 * DAY_MS), TEST_NOW),
+      true,
+    );
+  }
+});
+
+test("a failure stays through its rescue window and then leaves", () => {
+  const retention = sessionRosterRetentionMs(SESSION_STATUS.ERROR);
+  const atHorizon = session("run:1", SESSION_STATUS.ERROR, TEST_NOW - retention);
+  const pastHorizon = session("run:2", SESSION_STATUS.ERROR, TEST_NOW - retention - 1);
+  assert.equal(isRosterRelevant(atHorizon, TEST_NOW), true);
+  assert.equal(isRosterRelevant(pastHorizon, TEST_NOW), false);
+});
+
+test("a settled or quiet session stays while its ending is news and then leaves", () => {
+  for (const status of [SESSION_STATUS.COMPLETE, SESSION_STATUS.UNKNOWN]) {
+    const retention = sessionRosterRetentionMs(status);
+    assert.equal(isRosterRelevant(session("run:1", status, TEST_NOW - retention), TEST_NOW), true);
+    assert.equal(
+      isRosterRelevant(session("run:2", status, TEST_NOW - retention - 1), TEST_NOW),
+      false,
+    );
+  }
+});
+
+test("a standing row never ages out, however old its own timestamp", () => {
+  const standing = normalizeSession(
+    { id: "superset", displayName: "Superset" },
+    {
+      providerSessionId: "workspace-1",
+      title: "power-vacation",
+      status: SESSION_STATUS.COMPLETE,
+      lastActivityAt: TEST_NOW - 100 * DAY_MS,
+      standing: true,
+    },
+  );
+  // Its provider re-reports it while it exists and drops it when it is gone,
+  // so retention has nothing to age out — unlike the settled chat beside it.
+  assert.equal(standing.standing, true);
+  assert.equal(isRosterRelevant(standing, TEST_NOW), true);
+  assert.equal(
+    isRosterRelevant(session("run:1", SESSION_STATUS.COMPLETE, TEST_NOW - 100 * DAY_MS), TEST_NOW),
+    false,
+  );
+});
+
+test("filters a roster to the sessions still worth a row, keeping their order", () => {
+  const workedForever = session("run:working", SESSION_STATUS.WORKING, TEST_NOW - 100 * DAY_MS);
+  const finishedToday = session("run:finished-today", SESSION_STATUS.COMPLETE, TEST_NOW - 1_000);
+  const finishedLongAgo = session(
+    "run:finished-long-ago",
+    SESSION_STATUS.COMPLETE,
+    TEST_NOW - 100 * DAY_MS,
+  );
+
+  assert.deepEqual(
+    rosterRelevantSessions([workedForever, finishedLongAgo, finishedToday], TEST_NOW),
+    [workedForever, finishedToday],
+  );
+});

--- a/packages/session/src/roster-relevance.ts
+++ b/packages/session/src/roster-relevance.ts
@@ -1,0 +1,48 @@
+import type { Session } from "./session-shape.js";
+import { SESSION_STATUS, type SessionStatus } from "./session-status.js";
+
+/**
+ * How long a status keeps its session on the roster, measured from the
+ * provider's last activity. This is the one bound on the roster — no adapter
+ * ages out or caps its sessions: relevance follows what the status asks of the
+ * user, never a blanket clock over every conversation. A failure does not heal
+ * by going stale, but a rescue nobody made for days is a session the user has
+ * left behind; a settled or unreadable session says only where work ended,
+ * which is news while the user might still come back for it and history after.
+ */
+export const SESSION_ROSTER_RETENTION_MS = {
+  RESCUE_MS: 3 * 24 * 60 * 60 * 1000,
+  SETTLED_MS: 2 * 24 * 60 * 60 * 1000,
+} as const;
+
+/** The retention one status earns. */
+export function sessionRosterRetentionMs(status: SessionStatus): number {
+  if (status === SESSION_STATUS.ERROR) return SESSION_ROSTER_RETENTION_MS.RESCUE_MS;
+  if (status === SESSION_STATUS.COMPLETE || status === SESSION_STATUS.UNKNOWN) {
+    return SESSION_ROSTER_RETENTION_MS.SETTLED_MS;
+  }
+  // Working and waiting are live right now, so neither expires: the age of
+  // the ask is not the age of its relevance.
+  return Number.POSITIVE_INFINITY;
+}
+
+/** Whether a session's status still earns it a place on the roster. */
+export function isRosterRelevant(
+  session: Pick<Session, "status" | "lastActivityAt" | "standing">,
+  now: number,
+): boolean {
+  // Retention ages out history — settled chats whose files linger after the
+  // work ended. A standing session is not history: its provider re-reports it
+  // while the thing it names still exists and stops the moment it is gone, so
+  // there is nothing here to age out, however old its own timestamp grows.
+  if (session.standing) return true;
+  return now - session.lastActivityAt <= sessionRosterRetentionMs(session.status);
+}
+
+/** The sessions still worth a row, in the order they arrived. */
+export function rosterRelevantSessions(
+  sessions: readonly Session[],
+  now: number,
+): readonly Session[] {
+  return sessions.filter((session) => isRosterRelevant(session, now));
+}


### PR DESCRIPTION
## Why

Luke started showing local chats from months ago. PR #738 (`ef8ec55a`) replaced the session registry with `SessionRoster` and, as an unmentioned side effect, deleted the roster relevance gate that #144 added: working or waiting sessions never age out, a failure holds its row for three days, and a settled or unreadable session leaves after two days. Since #137 and #144 removed every age window and count cap from the adapters on purpose, that gate was the only thing bounding the roster. Without it every unarchived local transcript on the machine is a row, and the interface comment at `rosterForClients` still promised "the same relevance gate every broadcast passes" with no gate behind it.

## What changes

- `packages/session/src/roster-relevance.ts` restores `SESSION_ROSTER_RETENTION_MS`, `sessionRosterRetentionMs`, `isRosterRelevant`, and `rosterRelevantSessions` as they stood before #738, standing rows included. The five tests deleted in #738 return beside it.
- `packages/host/src/compose-observation.ts` applies the gate at the client-facing seams: the `SESSIONS_CHANGED` broadcast, `rosterForClients` (bootstrap and the roster method), and `actableSessions` (admission and the brain's roster). `SessionRoster` itself stays unfiltered for hook routing and observation internals, as #144 designed it. The pass notifies on every run, so a session that crosses its horizon between observations leaves on the next broadcast.

## Checks

- `./scripts/check.sh` passed (lint, recursive typecheck, tests, build).
- Portable-only change: no renderer or macOS surface moved, so `verify.sh` and visual evidence do not apply. No physical-notch check was performed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/6e8bedd6-c810-43f6-b7c5-a982826a2034)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34403666618/artifacts/10124557286) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34403666618)

- Commit: `b13217b99b0dfeb87b4567a6d7cb62983b1758b2`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
