### PR TITLE
refactor(host): the composers share one ComposerContext

### DIFF
--- a/packages/host/src/compose-account.ts
+++ b/packages/host/src/compose-account.ts
@@ -23,9 +23,7 @@ import {
 import { VOICE_SOURCE_COUNTED_AS } from "@sidecar/settings";
 import { VoiceCapabilityAssembler } from "@sidecar/voice";
 import { lateRef } from "@sidecar/wire";
-import type { SettingsComposer } from "./compose-settings.js";
-import type { Composer } from "./composer.js";
-import type { HostKernel } from "./host-kernel.js";
+import type { Composer, ComposerContext } from "./composer.js";
 import { transitionVoiceCredential } from "./voice-credential-transition.js";
 
 const ACCOUNT_CLIENT_ID = "luke-desktop";
@@ -61,10 +59,7 @@ export interface AccountComposer extends Composer {
   link: (links: AccountLinks) => void;
 }
 
-export interface AccountDependencies {
-  kernel: HostKernel;
-  settings: SettingsComposer;
-}
+export type AccountDependencies = ComposerContext;
 
 export function composeAccount(dependencies: AccountDependencies): AccountComposer {
   const { kernel, settings } = dependencies;

--- a/packages/host/src/compose-brain.ts
+++ b/packages/host/src/compose-brain.ts
@@ -43,11 +43,9 @@ import { wireBrain } from "./brain/wiring.js";
 import type { AccountComposer } from "./compose-account.js";
 import type { IssuesComposer } from "./compose-issues.js";
 import type { ObservationComposer } from "./compose-observation.js";
-import type { SettingsComposer } from "./compose-settings.js";
 import type { SpeechComposer } from "./compose-speech.js";
-import type { Composer } from "./composer.js";
+import type { Composer, ComposerContext } from "./composer.js";
 import { conversationOperations, startConversationMaintenance } from "./conversation-operations.js";
-import type { HostKernel } from "./host-kernel.js";
 import { seedWorkspaceThenStartMemory } from "./lifecycle.js";
 import { wireMemoryMaintenance } from "./memory-maintenance.js";
 import { HOST_NODE_CAPABILITY } from "./node-capabilities.js";
@@ -72,9 +70,7 @@ export interface BrainComposer extends Composer {
   syncMemory: () => void;
 }
 
-export interface BrainDependencies {
-  kernel: HostKernel;
-  settings: SettingsComposer;
+export interface BrainDependencies extends ComposerContext {
   account: AccountComposer;
   issues: IssuesComposer;
   observation: ObservationComposer;

--- a/packages/host/src/compose-calendars.ts
+++ b/packages/host/src/compose-calendars.ts
@@ -31,9 +31,7 @@ import {
   AppleCalendarReader,
 } from "./apple-calendar.js";
 import { calendarOnboardingOwed } from "./calendar-onboarding-flow.js";
-import type { SettingsComposer } from "./compose-settings.js";
-import type { Composer } from "./composer.js";
-import type { HostKernel } from "./host-kernel.js";
+import type { Composer, ComposerContext } from "./composer.js";
 import { HOST_NODE_CAPABILITY } from "./node-capabilities.js";
 import { type OnboardingState, onboardingStateFile } from "./onboarding-state.js";
 import type { OnboardingBeatKind } from "./voice/speech-arbiter.js";
@@ -86,9 +84,7 @@ export interface CalendarsComposer extends Composer {
   link: (links: CalendarsLinks) => void;
 }
 
-export interface CalendarsDependencies {
-  kernel: HostKernel;
-  settings: SettingsComposer;
+export interface CalendarsDependencies extends ComposerContext {
   observationGate: () => boolean;
 }
 

--- a/packages/host/src/compose-issues.ts
+++ b/packages/host/src/compose-issues.ts
@@ -9,9 +9,7 @@ import { carried, GATEWAY_METHOD, type GatewayMethodTable, gatewayOk } from "@si
 import { ObservationLoop } from "@sidecar/runtime";
 import { ISSUE_TRACKER_ID, normalizeTrackedIssue, type TrackedIssue } from "@sidecar/session";
 import { ACTION_RESULT_STATUS } from "@sidecar/wire";
-import type { SettingsComposer } from "./compose-settings.js";
-import type { Composer } from "./composer.js";
-import type { HostKernel } from "./host-kernel.js";
+import type { Composer, ComposerContext } from "./composer.js";
 import { reporterOf } from "./wire-helpers.js";
 
 /** A board changes at the pace of hands, not of models; a minute is current. */
@@ -27,9 +25,7 @@ export interface IssuesComposer extends Composer {
   stopObservation: () => void;
 }
 
-export interface IssuesDependencies {
-  kernel: HostKernel;
-  settings: SettingsComposer;
+export interface IssuesDependencies extends ComposerContext {
   observationGate: () => boolean;
 }
 

--- a/packages/host/src/compose-speech.ts
+++ b/packages/host/src/compose-speech.ts
@@ -21,9 +21,7 @@ import { arrivalBeatOwed, countsFirstAnnouncement } from "./arrival-flow.js";
 import type { AccountComposer } from "./compose-account.js";
 import type { CalendarsComposer } from "./compose-calendars.js";
 import type { ObservationComposer } from "./compose-observation.js";
-import type { SettingsComposer } from "./compose-settings.js";
-import type { Composer } from "./composer.js";
-import type { HostKernel } from "./host-kernel.js";
+import type { Composer, ComposerContext } from "./composer.js";
 import { type OnboardingBeatKind, SpeechArbiter } from "./voice/speech-arbiter.js";
 import { VoiceReceiver } from "./voice-receiver.js";
 
@@ -47,9 +45,7 @@ export interface SpeechComposer extends Composer {
   link: (links: SpeechLinks) => void;
 }
 
-export interface SpeechDependencies {
-  kernel: HostKernel;
-  settings: SettingsComposer;
+export interface SpeechDependencies extends ComposerContext {
   account: AccountComposer;
   calendars: CalendarsComposer;
   observation: ObservationComposer;

--- a/packages/host/src/composer.ts
+++ b/packages/host/src/composer.ts
@@ -1,4 +1,12 @@
 import type { GatewayMethod, GatewayMethodTable } from "@sidecar/gateway";
+import type { SettingsComposer } from "./compose-settings.js";
+import type { HostKernel } from "./host-kernel.js";
+
+/** What every composer built over the settings composer is handed. */
+export interface ComposerContext {
+  kernel: HostKernel;
+  settings: SettingsComposer;
+}
 
 /** One concern of the host: the Gateway methods it answers, and its own lifecycle. */
 export interface Composer {


### PR DESCRIPTION
## What changed

Five of the six composer files under `packages/host/src/` each began by
destructuring the same pair — `kernel: HostKernel` and `settings:
SettingsComposer` — out of their own `*Dependencies` interface. Named that
pair once, `ComposerContext`, in `composer.ts` beside `Composer` and
`mergeMethods` where the concept already lives, and had
`AccountDependencies`, `BrainDependencies`, `CalendarsDependencies`,
`IssuesDependencies`, and `SpeechDependencies` extend it instead of
redeclaring the two fields.

`compose-settings.ts` is deliberately untouched: its `SettingsDependencies`
only ever took `kernel` (it builds the settings composer itself, so it never
had `settings` to destructure), so it doesn't have the pair the other five
share. The task description named it among the six files with the identical
pair, but that isn't what the code in this repo actually does — leaving it
alone rather than forcing an unused `settings` field onto it or an empty
`Pick<ComposerContext, "kernel">`.

No composer body was restructured; `start`/`stop` naming is untouched. Net
−13 lines.

## check.sh

Green, exit 0. Full log tail:

```
> luke@0.5.0 typecheck /home/vercel-sandbox/luke
> pnpm --recursive --if-present run typecheck
...
packages/host typecheck: Done
> luke@0.5.0 test /home/vercel-sandbox/luke
...
apps/desktop test: ℹ tests 655
apps/desktop test: ℹ pass 655
apps/desktop test: ℹ fail 0
...
apps/desktop build: Done
```

`@sidecar/host`'s own suite: 276/276 pass. Two pre-existing oxlint warnings
(`speech-mouth.ts` unused private member, a control-regex warning in
`providers/superset/vocabulary.ts`) are unrelated to this diff and were
present before it.

`./scripts/verify.sh` needs a Mac and was not run; this change is
TypeScript-only, touches no renderer or native code, and is not
macOS/UI-bearing.

## Docs

No sentence in `CLAUDE.md`, `PRIVACY.md`, a `README.md`, or an `AGENTS.md`
was made false by this change — it's an internal type refactor with no
behavioral or architectural change to what those files describe.

## Review passes

**Thermonuclear code review** — applied to the diff. Two findings:
- A type-only circular import between `composer.ts` (now imports `type
  SettingsComposer` from `compose-settings.js`) and `compose-settings.ts`
  (already imports `type Composer` from `composer.js`). Confirmed this is
  erased at compile time under `isolatedModules`, causes no runtime cycle,
  and biome raises nothing on it — kept as is rather than adding an
  indirection to avoid a type-only back-edge.
- `AccountDependencies` is a type alias (`= ComposerContext`) while the other
  four are `interface X extends ComposerContext { ... }`. Verified this is
  intentional, not sloppiness: the other four add their own fields, so
  `interface extends` is the natural shape; `AccountDependencies` has
  nothing to add, and `interface AccountDependencies extends ComposerContext
  {}` would be a pointless empty interface. Kept the alias.

**Ponytail review** — applied to the diff. No findings: the refactor deletes
five duplicated three-line shapes for one shared interface, introduces no
new wrapper or indirection beyond that interface, and is net negative lines.
It flagged the same alias-vs-interface point as pass one from the opposite
direction (preferring aliases everywhere); noted above as a deliberate,
lint-driven choice rather than an oversight.

## Test plan

- [x] `pnpm --filter @sidecar/host typecheck`
- [x] `pnpm --filter @sidecar/host test` (276/276)
- [x] `./scripts/check.sh` (exit 0)
- [ ] `./scripts/verify.sh` — not run (no Mac available in this environment); change is not macOS/UI-bearing

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/d16ff50e-e2eb-48fa-a9d2-789e8ebf0ad4)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34404155222/artifacts/10124754401) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34404155222)

- Commit: `a82cfcb59182da77db7239956636b9dfd379aa31`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
