### PR TITLE
chore(repo): trim declared dependencies that no import reaches

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -50,7 +50,6 @@
     "@sidecar/guide": "workspace:*",
     "@sidecar/host": "workspace:*",
     "@sidecar/hosted": "workspace:*",
-    "@sidecar/memory": "workspace:*",
     "@sidecar/panel": "workspace:*",
     "@sidecar/providers": "workspace:*",
     "@sidecar/realtime": "workspace:*",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -28,7 +28,6 @@
     "@fontsource-variable/jetbrains-mono": "5.3.0",
     "@paper-design/shaders": "0.0.80",
     "@sidecar/brain": "workspace:*",
-    "@sidecar/credentials": "workspace:*",
     "@sidecar/hosted": "workspace:*",
     "@sidecar/panel": "workspace:*",
     "@sidecar/realtime": "workspace:*",

--- a/apps/web/server/core.ts
+++ b/apps/web/server/core.ts
@@ -20,6 +20,11 @@
  * the ones reached only through another package, so a package pulled in for
  * compilation alone cannot silently collide with a name a door above it
  * already exports.
+ *
+ * A door here reaches its package for the compiler, not the resolver: it
+ * satisfies Vercel's relative import graph, never a bare specifier `apps/web`
+ * code imports, so `apps/web`'s `package.json` need not declare a dependency
+ * on a package reached only through this file.
  */
 import "../../../packages/credentials/src/credential-providers.js";
 import "../../../packages/guide/src/index.js";

--- a/packages/AGENTS.md
+++ b/packages/AGENTS.md
@@ -30,9 +30,12 @@ statements of the same rule that can drift.
 
 ## The graph is acyclic, and stays that way
 
-Every package declares exactly the packages its own sources reach, and the
-graph has no cycles, checked by `pnpm --recursive run typecheck` from a clean
-`node_modules`, which resolves workspace links strictly.
+Every package declares exactly the packages its own sources reach by bare
+specifier — not one reached only through `apps/web/server/core.ts`'s relative
+doors, which pull a package into the compiler's graph without asking the
+resolver for it — and the graph has no cycles, checked by
+`pnpm --recursive run typecheck` from a clean `node_modules`, which resolves
+workspace links strictly.
 
 Adding a package means adding a `package.json` and a `tsconfig.json` copied
 from any sibling, a barrel at `src/index.ts`, and the dependencies its imports

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,9 +75,6 @@ importers:
       '@sidecar/hosted':
         specifier: workspace:*
         version: link:../../packages/hosted
-      '@sidecar/memory':
-        specifier: workspace:*
-        version: link:../../packages/memory
       '@sidecar/panel':
         specifier: workspace:*
         version: link:../../packages/panel
@@ -171,9 +168,6 @@ importers:
       '@sidecar/brain':
         specifier: workspace:*
         version: link:../../packages/brain
-      '@sidecar/credentials':
-        specifier: workspace:*
-        version: link:../../packages/credentials
       '@sidecar/hosted':
         specifier: workspace:*
         version: link:../../packages/hosted


### PR DESCRIPTION
## Summary
- Removed two declared workspace edges that no bare import ever reaches:
  - `apps/desktop` → `@sidecar/memory`
  - `apps/web` → `@sidecar/credentials`
- Left `apps/web` → `@sidecar/brain` declared: verified empirically that removing it breaks typecheck, because `apps/web/tests/hosted-store.test.ts` genuinely imports `@sidecar/brain` by bare specifier. The task brief listed this as a third edge to drop, but a repo-wide check found a real importer, so it stays. (Reported to the requesting orchestrator alongside this PR.)
- Updated docs to say why `apps/web/server/core.ts`'s relative imports of `packages/credentials` and `packages/memory` don't require a declared dependency: `core.ts` imports each package's compiled path directly so Vercel's bundler pulls it into the deployed function, but that path never goes through the package's name (`@sidecar/credentials`, `@sidecar/memory`) the way normal application code does — so it's not a dependency the resolver, or `apps/web`'s `package.json`, ever needs to know about.
  - `apps/web/server/core.ts`'s header comment gained a paragraph saying so.
  - `packages/AGENTS.md`'s "Every package declares exactly the packages its own sources reach" sentence gained the same clause: declared dependencies are meant to match the packages actually imported by name, not every package whose compiled file ends up bundled some other way.

## Verification
Confirmed empirically for each of the three candidate edges (temporarily removed, ran typecheck, restored as needed):
- `apps/desktop` → `@sidecar/memory`: zero bare importers anywhere in `apps/desktop`; typecheck passes with it removed.
- `apps/web` → `@sidecar/credentials`: zero bare importers anywhere in `apps/web`; typecheck passes with it removed.
- `apps/web` → `@sidecar/brain`: **not removed** — `tests/hosted-store.test.ts` imports it directly, and removing the edge breaks `pnpm --filter @luke/web typecheck` with `TS2307: Cannot find module '@sidecar/brain'`.

`pnpm --recursive run typecheck`: all 25 projects pass.

`./scripts/check.sh`: exits 0 (lint, typecheck, test, build all green). `./scripts/verify.sh` needs a physical Mac and was not run here; this change is non-UI (dependency graph + comments only), so no visual evidence is expected.

## Review passes
- **Thermonuclear code review** (via the `code-review` skill at high effort): no findings. Confirmed the diff is minimal, both affected apps typecheck, no remaining bare-specifier usages of the removed packages, and the added comments meet the repo's comment bar (explain a non-obvious constraint rather than narrate).
- **Ponytail review** (YAGNI/over-engineering lens, applied manually per its published philosophy — a delete-list check that protects trust-boundary validation, error handling, security, and accessibility): nothing to flag. The diff is two one-line dependency deletions plus two short comments the task explicitly required; no trust-boundary, validation, error-handling, security, or accessibility code was touched.

## Doc sentences changed
- `packages/AGENTS.md`: "Every package declares exactly the packages its own sources reach" → now qualified "...by bare specifier — not one reached only through `apps/web/server/core.ts`'s relative imports, which pull a package into the compiled bundle without the resolver ever seeing its name."
- `apps/web/server/core.ts`: header comment gained a paragraph stating that these imports satisfy the bundler, not the module resolver, so no declared dependency is required for them.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/6b2baae8-a0c6-4477-b69e-e1674124198c)
