### PR TITLE
fix(voice): captions follow the preference and the mute alone

### DIFF
--- a/packages/voice/src/orchestrator/voice-orchestrator.ts
+++ b/packages/voice/src/orchestrator/voice-orchestrator.ts
@@ -39,7 +39,6 @@ import {
   spokenAskPreviewSurvives,
   talkKeyPress,
   talkOpeningHolds,
-  typedAskHolds,
   VOICE_RESTART,
   voiceRestartAction,
 } from "./voice-policy.js";
@@ -184,12 +183,6 @@ export class VoiceOrchestrator<Stream> {
    * that did nothing.
    */
   #talkOpening = false;
-  /**
-   * Whether the reply under way answers an ask the developer typed. A typed
-   * ask is read, not only heard, so its reply draws the caption whatever the
-   * captions preference says.
-   */
-  #typedAsk = false;
   #localStream: Stream | undefined;
   #remoteStream: Stream | undefined;
   #caption: VoiceCaption = { texts: undefined, kind: undefined };
@@ -199,9 +192,9 @@ export class VoiceOrchestrator<Stream> {
   /** Whether a tap has left a turn open for a later press to end. */
   #talkLatched = false;
   /**
-   * Whether the exchange about to open was opened by the composer. The typed
-   * caption cannot answer for it: that is set once the words are away, which
-   * is after the call has already reached the edge the count is taken on.
+   * Whether the exchange about to open was opened by the composer, for the
+   * count alone: set once the words are away, which is after the call has
+   * already reached the edge the count is taken on, and read once there.
    */
   #typedExchange = false;
 
@@ -704,14 +697,12 @@ export class VoiceOrchestrator<Stream> {
       acknowledge: (offer) =>
         this.#bridge.ackBrainReply(offer.runId, offer.deliveryId, offer.epoch),
       showNotice: (words) => this.#strip.showNotice(words),
-      // Only a typed ask's reply is the composer's exchange: it counts as one
-      // and holds the caption the composer asked for. A spoken ask answered
-      // late is the spoken exchange it always was.
+      // Only a typed ask's reply is the composer's exchange, and counts as
+      // one. A spoken ask answered late is the spoken exchange it always was.
       onSpeaking: (origin) => {
         this.#strip.showNotice(undefined);
         if (origin !== BRAIN_REQUEST_ORIGIN.TYPED) return;
         this.#typedExchange = true;
-        this.#typedAsk = true;
         this.#report();
       },
       conversationGeneration: () => this.#thread.generation,
@@ -751,9 +742,6 @@ export class VoiceOrchestrator<Stream> {
     // in hand may be claimed, and a call ending settles the grant on it.
     this.#replyPlayer?.onStatus(status);
     this.#considerRestart();
-    // The reply that answered the typed ask is over, so the caption goes back
-    // to being the preference's to grant.
-    if (!typedAskHolds(status)) this.#typedAsk = false;
     // The call gone takes its half-transcribed turns with it: no completed
     // transcript can arrive to settle a preview, so none may keep streaming.
     if (!spokenAskPreviewSurvives(status)) this.#thread.clearPreviews();
@@ -883,7 +871,6 @@ export class VoiceOrchestrator<Stream> {
       talkOpening: this.#talkOpening,
       lukeCaptions: lukeCaptionsToShow({
         captionsEnabled: this.#surroundings.captionsEnabled,
-        typedAsk: this.#typedAsk,
         outputSilent: this.#surroundings.outputSilent,
         status: this.#status,
         captions: this.#caption.texts,

--- a/packages/voice/src/orchestrator/voice-policy.test.ts
+++ b/packages/voice/src/orchestrator/voice-policy.test.ts
@@ -11,7 +11,6 @@ import {
   spokenAskPreviewSurvives,
   talkKeyPress,
   talkOpeningHolds,
-  typedAskHolds,
   VOICE_RESTART,
   voiceRestartAction,
 } from "./voice-policy.js";
@@ -99,7 +98,6 @@ test("a connecting call meters the press's device, and nothing where no press op
 test("Luke's captions are offered only on his turn, and only with a reason to read them", () => {
   const shown = {
     captionsEnabled: true,
-    typedAsk: false,
     outputSilent: false,
     status: REALTIME_STATUS.RESPONDING,
     captions: ["two sessions are waiting on you.", "and the build just finished."],
@@ -120,15 +118,14 @@ test("Luke's captions are offered only on his turn, and only with a reason to re
   );
 });
 
-test("a typed ask, or an output that would swallow the reply, captions whatever the preference says", () => {
+test("an output that would swallow the reply captions whatever the preference says, and nothing else does", () => {
   const hidden = {
     captionsEnabled: false,
-    typedAsk: false,
     outputSilent: false,
     status: REALTIME_STATUS.RESPONDING,
     captions: ["the words"],
   };
-  assert.deepEqual(lukeCaptionsToShow({ ...hidden, typedAsk: true }), ["the words"]);
+  assert.equal(lukeCaptionsToShow(hidden), undefined);
   assert.deepEqual(lukeCaptionsToShow({ ...hidden, outputSilent: true }), ["the words"]);
 });
 
@@ -148,12 +145,6 @@ test("the press-wait meter rides a handshake and a pending takeover, nothing els
   assert.equal(talkOpeningHolds({ status: REALTIME_STATUS.LISTENING, turnPending: false }), false);
   assert.equal(talkOpeningHolds({ status: REALTIME_STATUS.READY, turnPending: false }), false);
   assert.equal(talkOpeningHolds({ status: REALTIME_STATUS.FAILED, turnPending: false }), false);
-});
-
-test("a typed ask's caption holds only for the reply it opened", () => {
-  assert.equal(typedAskHolds(REALTIME_STATUS.RESPONDING), true);
-  assert.equal(typedAskHolds(REALTIME_STATUS.READY), false);
-  assert.equal(typedAskHolds(REALTIME_STATUS.LISTENING), false);
 });
 
 test("the first stored pace is not a change, and a later one is", () => {

--- a/packages/voice/src/orchestrator/voice-policy.ts
+++ b/packages/voice/src/orchestrator/voice-policy.ts
@@ -56,18 +56,19 @@ export function activeVoiceStream<T>(input: {
  * The words the panels draw under the shape, one entry per response so
  * back-to-back responses stack apart instead of running together. Luke's
  * captions are offered only when there is a reason to read them and the reply
- * they belong to is his turn: the captions preference, a reply answering an
- * ask the developer typed, or an output that would swallow the speech.
+ * they belong to is his turn: the captions preference, or an output that
+ * would swallow the speech. A reply to an ask the developer typed earns no
+ * caption of its own: the words land in Conversation as a line, so the
+ * preference alone says whether they are also read under the housing.
  */
 export function lukeCaptionsToShow(input: {
   captionsEnabled: boolean;
-  typedAsk: boolean;
   outputSilent: boolean;
   status: RealtimeStatus;
   captions: readonly string[] | undefined;
 }): readonly string[] | undefined {
   if (
-    (input.captionsEnabled || input.typedAsk || input.outputSilent) &&
+    (input.captionsEnabled || input.outputSilent) &&
     input.status === REALTIME_STATUS.RESPONDING
   ) {
     return input.captions;
@@ -93,15 +94,6 @@ export function talkKeyPress(input: { latched: boolean; microphoneCall: boolean 
  */
 export function talkOpeningHolds(input: { status: RealtimeStatus; turnPending: boolean }): boolean {
   return input.status === REALTIME_STATUS.CONNECTING || input.turnPending;
-}
-
-/**
- * Whether a typed ask's reply is still the one being spoken. The caption of a
- * typed conversation stays readable whatever the preference says, and clears
- * the moment the turn moves on.
- */
-export function typedAskHolds(status: RealtimeStatus): boolean {
-  return status === REALTIME_STATUS.RESPONDING;
 }
 
 /**


### PR DESCRIPTION
## Summary

- A reply to a typed ask drew captions under the housing regardless of the captions preference (introduced in #738). With the preference off, the composer still produced captions.
- `lukeCaptionsToShow` now draws captions for exactly two reasons: the preference is on, or the Mac's output is muted or at zero volume, where the caption stands in for speech that cannot be heard.
- The typed-ask hold (`typedAskHolds`, the orchestrator's `#typedAsk`) is removed. The composer's exchange is still counted as typed for analytics, which was that flag's other job.

## Test plan

- [x] `./scripts/check.sh` passes
- [x] Policy tests updated: a typed reply with the preference off draws no caption; a silent output still does

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34404285331/artifacts/10124760908) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34404285331)

- Commit: `e29c9527bfd769c3d54bb826a0e054bd0a5d698a`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
