### PR TITLE
feat(wire): IDisposable, DisposableStore, and the Emitter/Event pair

### DIFF
--- a/packages/AGENTS.md
+++ b/packages/AGENTS.md
@@ -28,6 +28,12 @@ which both parses the untrusted value and emits the JSON Schema a model is
 shown for it. A hand-written parser beside a hand-written schema is two
 statements of the same rule that can drift.
 
+`@sidecar/wire` is also the base every layer's lifecycle is written in —
+`IDisposable`, `DisposableStore`, `toDisposable`, `Event`, and `Emitter` — so a
+listener's unsubscribe, a watcher's teardown, and the store that ends both are
+one shape wherever they are held, and adopting it adds no edge: every package
+but `packages/panel` already depends on wire.
+
 ## The graph is acyclic, and stays that way
 
 Every package declares exactly the packages its own sources reach, and the

--- a/packages/wire/src/event.test.ts
+++ b/packages/wire/src/event.test.ts
@@ -1,0 +1,146 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { Emitter } from "./event.js";
+import { DisposableStore, type IDisposable } from "./lifecycle.js";
+
+test("every listener standing when a round opens hears the value", () => {
+  const emitter = new Emitter<number>();
+  const heard: string[] = [];
+  emitter.event((value) => heard.push(`first:${value}`));
+  emitter.event((value) => heard.push(`second:${value}`));
+
+  emitter.fire(7);
+
+  assert.deepEqual(heard, ["first:7", "second:7"]);
+});
+
+test("the event is the same function however often it is read", () => {
+  const emitter = new Emitter<void>();
+
+  assert.equal(emitter.event, emitter.event);
+});
+
+test("a listener subscribing from inside a round hears the next value, not that one", () => {
+  const emitter = new Emitter<number>();
+  const heard: string[] = [];
+  emitter.event((value) => {
+    heard.push(`opener:${value}`);
+    if (value === 1) emitter.event((later) => heard.push(`joiner:${later}`));
+  });
+
+  emitter.fire(1);
+  emitter.fire(2);
+
+  assert.deepEqual(heard, ["opener:1", "opener:2", "joiner:2"]);
+});
+
+test("a listener unsubscribed by an earlier one in the same round is not called", () => {
+  const emitter = new Emitter<number>();
+  const heard: string[] = [];
+  let second: IDisposable | undefined;
+  emitter.event(() => {
+    heard.push("first");
+    second?.dispose();
+  });
+  second = emitter.event(() => heard.push("second"));
+  emitter.event(() => heard.push("third"));
+
+  emitter.fire(1);
+
+  assert.deepEqual(heard, ["first", "third"]);
+});
+
+test("a listener unsubscribing itself mid-round hears nothing further", () => {
+  const emitter = new Emitter<number>();
+  const heard: number[] = [];
+  const subscription = emitter.event((value) => {
+    heard.push(value);
+    subscription.dispose();
+  });
+
+  emitter.fire(1);
+  emitter.fire(2);
+
+  assert.deepEqual(heard, [1]);
+});
+
+test("the same function subscribed twice is two subscriptions, ended separately", () => {
+  const emitter = new Emitter<number>();
+  const heard: number[] = [];
+  const listener = (value: number) => heard.push(value);
+  const first = emitter.event(listener);
+  emitter.event(listener);
+
+  emitter.fire(1);
+  first.dispose();
+  emitter.fire(2);
+
+  assert.deepEqual(heard, [1, 1, 2]);
+});
+
+test("unsubscribing twice ends only that one subscription", () => {
+  const emitter = new Emitter<number>();
+  const heard: string[] = [];
+  const first = emitter.event(() => heard.push("first"));
+  emitter.event(() => heard.push("second"));
+
+  first.dispose();
+  first.dispose();
+  emitter.fire(1);
+
+  assert.deepEqual(heard, ["second"]);
+});
+
+test("a throwing listener stops none of the rest, and the failures are reported together", () => {
+  const emitter = new Emitter<number>();
+  const heard: string[] = [];
+  const failure = new Error("the first listener");
+  emitter.event(() => {
+    heard.push("first");
+    throw failure;
+  });
+  emitter.event(() => heard.push("second"));
+
+  assert.throws(() => emitter.fire(1), {
+    name: "AggregateError",
+    message: "1 of 2 listeners failed",
+    errors: [failure],
+  });
+
+  assert.deepEqual(heard, ["first", "second"]);
+});
+
+test("a disposed emitter drops its listeners and fires nothing", () => {
+  const emitter = new Emitter<number>();
+  const heard: number[] = [];
+  emitter.event((value) => heard.push(value));
+
+  emitter.dispose();
+  emitter.dispose();
+  emitter.fire(1);
+
+  assert.deepEqual(heard, []);
+});
+
+test("subscribing to a disposed emitter answers an unsubscribe that is safe to dispose", () => {
+  const emitter = new Emitter<number>();
+  emitter.dispose();
+
+  const subscription = emitter.event(() => assert.fail("a disposed emitter fires nothing"));
+  subscription.dispose();
+
+  emitter.fire(1);
+});
+
+test("a store ends the subscriptions it holds", () => {
+  const emitter = new Emitter<number>();
+  const store = new DisposableStore();
+  const heard: number[] = [];
+  store.add(emitter.event((value) => heard.push(value)));
+
+  emitter.fire(1);
+  store.dispose();
+  emitter.fire(2);
+
+  assert.deepEqual(heard, [1]);
+});

--- a/packages/wire/src/event.ts
+++ b/packages/wire/src/event.ts
@@ -1,0 +1,79 @@
+import { type IDisposable, toDisposable } from "./lifecycle.js";
+
+/**
+ * Subscribing is calling the event itself, and what comes back is the
+ * unsubscribe. A listener therefore reaches nothing of the emitter, so an
+ * owner can only end its own subscription and never the round, the emitter, or
+ * anyone else's.
+ */
+export type Event<T> = (listener: (value: T) => void) => IDisposable;
+
+/**
+ * One subscription, identified by this object rather than by the function it
+ * holds, so the same function subscribed twice is two subscriptions and one
+ * owner's unsubscribe cannot end the other's.
+ */
+interface Subscription<T> {
+  readonly listener: (value: T) => void;
+}
+
+const INERT: IDisposable = { dispose: () => {} };
+
+/**
+ * The one side that may fire. A composition keeps the emitter and publishes
+ * only its `event`, which is what makes a subscriber unable to speak in the
+ * emitter's name.
+ */
+export class Emitter<T> implements IDisposable {
+  readonly #subscriptions = new Set<Subscription<T>>();
+  #disposed = false;
+
+  readonly event: Event<T> = (listener) => {
+    if (this.#disposed) return INERT;
+    const subscription: Subscription<T> = { listener };
+    this.#subscriptions.add(subscription);
+    return toDisposable(() => {
+      this.#subscriptions.delete(subscription);
+    });
+  };
+
+  /**
+   * Delivers to the subscriptions standing when the round opened, and to no
+   * other: a listener subscribing from inside a round hears the next value
+   * rather than this one, and one unsubscribed by an earlier listener in the
+   * same round is not called at all, which is what makes disposing an owner
+   * from inside a handler safe. A thrower stops none of the rest, for the same
+   * reason a failed disposal does not, and the failures are reported together
+   * once the round is complete; wire has no error reporter to hand them to,
+   * and swallowing them here would lose them entirely.
+   */
+  fire(value: T): void {
+    if (this.#disposed) return;
+    const failures: unknown[] = [];
+    let delivered = 0;
+    for (const subscription of [...this.#subscriptions]) {
+      if (!this.#subscriptions.has(subscription)) continue;
+      delivered += 1;
+      try {
+        subscription.listener(value);
+      } catch (failure) {
+        failures.push(failure);
+      }
+    }
+    if (failures.length > 0) {
+      throw new AggregateError(failures, `${failures.length} of ${delivered} listeners failed`);
+    }
+  }
+
+  /**
+   * Drops every subscription and fires nothing further. The listeners are the
+   * emitter's own bookkeeping rather than things it created, so nothing of
+   * theirs is disposed here: an owner ends its own subscription, and a store
+   * ends what a composition built.
+   */
+  dispose(): void {
+    if (this.#disposed) return;
+    this.#disposed = true;
+    this.#subscriptions.clear();
+  }
+}

--- a/packages/wire/src/index.ts
+++ b/packages/wire/src/index.ts
@@ -9,6 +9,7 @@ export {
   type UnknownActionResult,
 } from "./action-result.js";
 export { type Admitted, reshapeAdmitted } from "./admitted.js";
+export { Emitter, type Event } from "./event.js";
 export {
   type CloudFetch,
   HTTP_STATUS,
@@ -38,6 +39,12 @@ export {
   withoutTrailingSlash,
 } from "./json.js";
 export { type LateRef, lateRef } from "./late-ref.js";
+export {
+  DisposableStore,
+  disposeAll,
+  type IDisposable,
+  toDisposable,
+} from "./lifecycle.js";
 export {
   type ArrayOptions,
   type BoundedTextOptions,

--- a/packages/wire/src/lifecycle.test.ts
+++ b/packages/wire/src/lifecycle.test.ts
@@ -1,0 +1,159 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { DisposableStore, disposeAll, toDisposable } from "./lifecycle.js";
+
+test("a wrapped teardown runs at most once however often it is disposed", () => {
+  let runs = 0;
+  const disposable = toDisposable(() => {
+    runs += 1;
+  });
+
+  disposable.dispose();
+  disposable.dispose();
+  disposable.dispose();
+
+  assert.equal(runs, 1);
+});
+
+test("disposeAll disposes in iteration order", () => {
+  const order: string[] = [];
+  disposeAll([
+    toDisposable(() => order.push("first")),
+    toDisposable(() => order.push("second")),
+    toDisposable(() => order.push("third")),
+  ]);
+
+  assert.deepEqual(order, ["first", "second", "third"]);
+});
+
+test("disposeAll continues past a thrower and reports every failure together", () => {
+  const order: string[] = [];
+  const firstFailure = new Error("first owner");
+  const secondFailure = new Error("second owner");
+
+  assert.throws(
+    () =>
+      disposeAll([
+        toDisposable(() => {
+          order.push("first");
+          throw firstFailure;
+        }),
+        toDisposable(() => order.push("second")),
+        toDisposable(() => {
+          order.push("third");
+          throw secondFailure;
+        }),
+        toDisposable(() => order.push("fourth")),
+      ]),
+    {
+      name: "AggregateError",
+      message: "2 of 4 disposals failed",
+      errors: [firstFailure, secondFailure],
+    },
+  );
+
+  assert.deepEqual(order, ["first", "second", "third", "fourth"]);
+});
+
+test("a single failure is still reported as an aggregate, so a caller catches one shape", () => {
+  const failure = new Error("the only owner");
+
+  assert.throws(
+    () =>
+      disposeAll([
+        toDisposable(() => {
+          throw failure;
+        }),
+      ]),
+    { name: "AggregateError", message: "1 of 1 disposals failed", errors: [failure] },
+  );
+});
+
+test("a store disposes what it holds in the reverse of the order it was added", () => {
+  const order: string[] = [];
+  const store = new DisposableStore();
+  store.add(toDisposable(() => order.push("first")));
+  store.add(toDisposable(() => order.push("second")));
+  store.add(toDisposable(() => order.push("third")));
+
+  store.dispose();
+
+  assert.deepEqual(order, ["third", "second", "first"]);
+});
+
+test("a store answers the entry it was handed", () => {
+  const store = new DisposableStore();
+  const disposable = toDisposable(() => {});
+
+  assert.equal(store.add(disposable), disposable);
+});
+
+test("disposing a store twice ends what it held exactly once", () => {
+  let runs = 0;
+  const store = new DisposableStore();
+  store.add(
+    toDisposable(() => {
+      runs += 1;
+    }),
+  );
+
+  store.dispose();
+  store.dispose();
+
+  assert.equal(runs, 1);
+});
+
+test("a store disposes an entry added after its own life ended", () => {
+  const store = new DisposableStore();
+  store.dispose();
+
+  let disposed = false;
+  store.add(
+    toDisposable(() => {
+      disposed = true;
+    }),
+  );
+
+  assert.equal(disposed, true);
+});
+
+test("a store's disposal continues past a thrower and reports the failures", () => {
+  const order: string[] = [];
+  const failure = new Error("the middle owner");
+  const store = new DisposableStore();
+  store.add(toDisposable(() => order.push("first")));
+  store.add(
+    toDisposable(() => {
+      order.push("second");
+      throw failure;
+    }),
+  );
+  store.add(toDisposable(() => order.push("third")));
+
+  assert.throws(() => store.dispose(), {
+    name: "AggregateError",
+    message: "1 of 3 disposals failed",
+    errors: [failure],
+  });
+
+  assert.deepEqual(order, ["third", "second", "first"]);
+});
+
+test("a store that threw while disposing is still disposed", () => {
+  const store = new DisposableStore();
+  store.add(
+    toDisposable(() => {
+      throw new Error("the only owner");
+    }),
+  );
+  assert.throws(() => store.dispose());
+
+  let disposedOnAdd = false;
+  store.add(
+    toDisposable(() => {
+      disposedOnAdd = true;
+    }),
+  );
+
+  assert.equal(disposedOnAdd, true);
+});

--- a/packages/wire/src/lifecycle.ts
+++ b/packages/wire/src/lifecycle.ts
@@ -1,0 +1,86 @@
+/**
+ * One word for the end of a thing's life. A listener's unsubscribe, a watcher's
+ * teardown, a timer's cancellation, and a store of all three are the same
+ * shape, so a composition can hold what it created without knowing what any of
+ * it was.
+ */
+export interface IDisposable {
+  dispose(): void;
+}
+
+/**
+ * Wraps a teardown callback, which runs at most once however many times
+ * `dispose()` is called. A callback that ran again on the second call would
+ * make every double-dispose a bug the caller has to prevent, and the whole
+ * point of handing an unsubscribe to a `DisposableStore` is that the caller
+ * stops tracking whether it already ran. The callback is dropped rather than
+ * flagged spent, so whatever it captured is collectable once it has run even
+ * where the disposable itself is held on.
+ */
+export function toDisposable(run: () => void): IDisposable {
+  let pending: (() => void) | undefined = run;
+  return {
+    dispose: () => {
+      const held = pending;
+      pending = undefined;
+      held?.();
+    },
+  };
+}
+
+/**
+ * Disposes every entry in iteration order, and lets a thrower stop none of the
+ * rest: one owner's failed teardown must not leave its siblings alive. The
+ * failures are reported together once the round is complete, as a single
+ * `AggregateError` whatever their number, so a caller catches one shape rather
+ * than deciding at run time whether it holds the failure or a bag of them.
+ */
+export function disposeAll(disposables: Iterable<IDisposable>): void {
+  const failures: unknown[] = [];
+  let attempted = 0;
+  for (const disposable of disposables) {
+    attempted += 1;
+    try {
+      disposable.dispose();
+    } catch (failure) {
+      failures.push(failure);
+    }
+  }
+  if (failures.length > 0) {
+    throw new AggregateError(failures, `${failures.length} of ${attempted} disposals failed`);
+  }
+}
+
+/**
+ * Holds what a composition created so one `dispose()` ends all of it, in the
+ * reverse of the order it was added: the later entry is the one that may still
+ * be reading the earlier, so unwinding a construction backwards is what keeps
+ * a teardown from reaching through something already gone.
+ */
+export class DisposableStore implements IDisposable {
+  #held: IDisposable[] = [];
+  #disposed = false;
+
+  /**
+   * Answers the entry itself so a composition can hold and use a thing in one
+   * expression. An entry added after the store was disposed is disposed at
+   * once rather than kept: a store whose life is over must never become the
+   * only reference to something alive.
+   */
+  add<T extends IDisposable>(disposable: T): T {
+    if (this.#disposed) {
+      disposable.dispose();
+      return disposable;
+    }
+    this.#held.push(disposable);
+    return disposable;
+  }
+
+  dispose(): void {
+    if (this.#disposed) return;
+    this.#disposed = true;
+    const held = this.#held;
+    this.#held = [];
+    disposeAll(held.reverse());
+  }
+}


### PR DESCRIPTION
The base lifecycle primitives the rest of this cleanup stack is written in. Home is `@sidecar/wire`, and both reasons for that were re-verified before starting:

- **Zero new edges.** Every package but `packages/panel` (the React one) already declares `@sidecar/wire`; 19 of the 20 packages above it, plus wire itself.
- **The barrel is Node-free.** No `node:` import anywhere in wire's barrel graph — the only `node:` matches in `packages/wire/src` are the `JsonSchemaNode` identifiers in `schema.ts` and the test files' own imports.

## What landed

`packages/wire/src/lifecycle.ts` (+86)

```ts
interface IDisposable { dispose(): void }
function toDisposable(run: () => void): IDisposable            // runs at most once, drops the callback
function disposeAll(disposables: Iterable<IDisposable>): void  // iteration order, collects failures
class DisposableStore { add<T extends IDisposable>(d: T): T; dispose(): void }  // reverse order, idempotent
```

`packages/wire/src/event.ts` (+79)

```ts
type Event<T> = (listener: (value: T) => void) => IDisposable
class Emitter<T> { readonly event: Event<T>; fire(value: T): void; dispose(): void }  // copy-on-fire
```

Both on the barrel. `IDisposable` keeps VS Code's spelling; nothing else in the repo takes an `I` prefix.

Semantics worth stating, since they are what later PRs will lean on:

- **Copy-on-fire, with the live set still consulted.** A round iterates a snapshot, so a listener subscribing from inside one hears the *next* value rather than that one; and each subscription is re-checked against the live set before delivery, so one unsubscribed by an earlier listener in the same round is not called at all. That second half is what makes disposing an owner from inside its own handler safe.
- **One failure stops neither a round nor a teardown.** `disposeAll` and `fire` both run every entry and report the failures together, always as a single `AggregateError` however many there were, so a caller catches one shape instead of deciding at run time whether it holds the failure or a bag of them.
- **Each subscription is its own identity**, not the function it holds, so the same function subscribed twice is two subscriptions and one owner's unsubscribe cannot end the other's. (A `Set<listener>` would have silently deduped them.)
- **`toDisposable` drops its callback** rather than flagging it spent, so whatever it captured is collectable once it has run even where the disposable itself is held on.

## What was deleted

Nothing — this PR is purely additive. **Zero call sites change**, because PRs 2, 7 and 8 are what adopt it. Confirmed none of `IDisposable`, `DisposableStore`, `disposeAll`, `toDisposable`, `Event`, or `Emitter` was already declared or re-exported anywhere in the tree, so `apps/web/server/core.ts`'s `export *` door for wire cannot drop a name two doors both carry.

24 tests: copy-on-fire, mid-round subscribe, mid-round unsubscribe by another listener and by itself, duplicate subscriptions ended separately, idempotent unsubscribe, idempotent store dispose, reverse-order disposal, an entry added after the store's life ended, failure collection continuing past a thrower in both `disposeAll` and `fire`, a single failure still arriving as an aggregate, a disposed emitter, and a store ending the subscriptions it holds.

## Doc sentence changed

`packages/AGENTS.md` gained one paragraph after the `Schema` paragraph, naming wire as the lifecycle base:

> `@sidecar/wire` is also the base every layer's lifecycle is written in — `IDisposable`, `DisposableStore`, `toDisposable`, `Event`, and `Emitter` — so a listener's unsubscribe, a watcher's teardown, and the store that ends both are one shape wherever they are held, and adopting it adds no edge: every package but `packages/panel` already depends on wire.

No sentence in `CLAUDE.md`, `PRIVACY.md`, or any `README.md` was made false: this PR changes no trust constraint, no observation, no write path, and nothing that leaves the machine. `packages/CLAUDE.md` is a symlink to `packages/AGENTS.md`, so it moved with it.

## `./scripts/check.sh`

```
$ ./scripts/check.sh
Repository contract checks passed.
...
Found 23 warnings          (all pre-existing unicorn(no-useless-spread) / eslint warnings, none in this diff)
ℹ tests 3026
ℹ pass  3026
ℹ fail  0
packages/wire test: ℹ tests 66
packages/wire test: ℹ pass  66
packages/wire test: ℹ fail  0
apps/desktop build: Done
check.sh EXIT=0
```

Zero `: error ` lines. Also run individually:

```
$ pnpm --filter @sidecar/wire typecheck
> tsc --project tsconfig.json          (clean)

$ pnpm --filter @sidecar/wire test
ℹ tests 66  ℹ pass 66  ℹ fail 0
```

`./scripts/verify.sh` needs a Mac and is not available in this cloud workspace — **but this change is not macOS- or UI-bearing**: it adds two files to a Node-free package, draws nothing, and changes no renderer, panel, or Electron code. No visual evidence applies.

Re-run after rebasing onto `origin/main` at `cf7b692` — same result, 3026 tests passing, exit 0. (The count moved by one because two unrelated commits landed on main while CI ran; neither touches `packages/wire`.)

An earlier run of `check.sh` did fail, on two of the repo's own `anti-slop` oxlint rules in this diff, both now fixed (see below). Worth flagging for the rest of the stack: piping `check.sh` through `tail` masks its exit code, so the failure only showed as `ELIFECYCLE` lines in the body of the output.

## Review passes

### Cursor's thermo-nuclear code quality review

Applied as published (cursor/plugins `cursor-team-kit/skills/thermo-nuclear-code-quality-review`): code-judo restructurings, file-size boundaries, spaghetti prevention, direct-over-magical, canonical layer ownership, atomic orchestration, and its "aggressive flags" list.

Found and fixed:

1. **A thin wrapper adding indirection without value** — `Emitter` had a `readonly #subscribe: Event<T>` field behind a `get event()` that only returned it: two members where one does the job. Collapsed to a single `readonly event: Event<T>` field. Structurally identical to every consumer (same stable function identity, still not reassignable in TypeScript), one member fewer.
2. **A denominator that could overstate what happened** — `fire`'s aggregate message used `round.length`, the size of the snapshot, but a subscription unsubscribed mid-round is skipped rather than called. It now counts deliveries, so "1 of 2 listeners failed" always names calls that were actually made.
3. **An unjustified type assertion** — the `(disposable as IDisposable) === this` self-add guard tripped `anti-slop(require-safety-comment-for-type-assertion)`. Deleted rather than annotated; see the ponytail finding below.
4. **A `SAFETY:`-less cast and four unparsed parameters** — `anti-slop(no-unknown-parameters)` on the `(thrown: unknown) => {...}` validators passed to `assert.throws`. Replaced with the repo's own idiom, `assert.throws(fn, { name, message, errors })`, which is both shorter and what `packages/session/src/normalize.test.ts` already does.

Considered and deliberately not done, with the reasoning recorded because a later reviewer will see the same thing:

- **`fire` and `disposeAll` both run-collect-and-aggregate.** The obvious judo move is one shared helper. Rejected: sharing needs a per-entry closure allocation on what is the hot path of every later PR's event plumbing, and the two loops guard differently (`fire` re-checks the live set, `disposeAll` does not). Rule 5's own caution against "generic mechanisms hiding simple assumptions" and "thin abstractions adding indirection" applies more strongly than the twelve duplicated lines.
- File sizes are 86 and 79 lines; nothing near the 1k boundary. No new conditionals bolted onto unrelated paths, no `any`, no optional parameters, no cross-layer leak: wire is the bottom of the graph and `event.ts` → `lifecycle.ts` is the only new internal edge. Atomicity holds — `DisposableStore.dispose` sets `#disposed` and detaches `#held` *before* disposing anything, so a re-entrant `add` or `dispose` during teardown meets a settled store.

### Ponytail review

Applied as published (DietrichGebert/ponytail `skills/ponytail-review`): `delete:` / `stdlib:` / `native:` / `yagni:` / `shrink:`, one line per finding, closing net-lines metric.

```
lifecycle.ts L69  delete: the store's self-add guard, its cast, its error, and its test. Nothing.
event.ts     L40  shrink: get event() over readonly #subscribe. One readonly event field.
*.test.ts    x4   shrink: (thrown: unknown) => {...} validators. assert.throws(fn, {name, message, errors}).
net: -22 lines possible.
```

All three taken; the diff is 22 lines smaller than the first draft.

On the self-add guard specifically, since deleting a guard deserves the argument: `store.add(store)` cannot recurse, because `dispose()` sets `#disposed` before disposing what it held, so the nested `store.dispose()` returns immediately. The guard converted a harmless no-op into a throw, and cost a type assertion, a `SAFETY:` comment, and a test to do it. That is `yagni:` by the letter.

Considered and kept:

- **`native:` `Symbol.dispose` / `using`.** The platform now has a disposal protocol, and `IDisposable` could carry `[Symbol.dispose]()`. Not adopted: the repo's `tsconfig.base.json` has `lib: ["ES2023", ...]` with no `esnext.disposable`, and the stack's own idiom names `dispose()`. Widening to the native protocol is its own decision, not a detail to slip into PR 1.
- **`yagni:` exporting `disposeAll`.** One internal caller today (`DisposableStore.dispose`). Kept because it is the named deliverable and the only way to dispose a collection you do not own a store for.
- **`yagni:` the `Subscription<T>` wrapper.** Three lines, and the alternative (a `Set` of the functions themselves) silently deduplicates two independent owners into one subscription that either can kill. There is a test pinning that.
- Per the skill's own scope note, minimal test assertions stay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/f302f190-5b7b-4bbe-aee4-7bc83b747a38)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34405728385/artifacts/10125329978) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34405728385)

- Commit: `03de644ebb6e7d93a5b2fa9658dd3b9f95f1e3ca`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

