### PR TITLE
feat(desktop): draw Luke's turn in the thread and make the composer disc its stop

### DIFF
--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -3,6 +3,7 @@ import {
   PRODUCT_SEARCH_SURFACE,
   PRODUCT_SURFACE_EVENT,
 } from "@sidecar/analytics";
+import { brainRequestPending } from "@sidecar/brain/requests-wire";
 import { ACCOUNT_STATUS } from "@sidecar/credentials/snapshot";
 import { CREDENTIAL_PROVIDER_LIST, CREDENTIAL_SOURCE } from "@sidecar/credentials/vocabulary";
 import { feedbackKindForLifecycleEvent } from "@sidecar/feedback";
@@ -573,6 +574,13 @@ export function App(): React.JSX.Element {
     clearConversationLines,
   } = useVoiceView();
   const { voiceError, voiceNotice, talkOpening, liveConversationEntries } = voiceView;
+  // The composer's stop takes every run still going: a second ask joined the
+  // turn under way, so stopping the turn is stopping them all.
+  const stopThinking = useCallback(() => {
+    for (const run of brainRequests) {
+      if (brainRequestPending(run)) cancelBrainAsk(run.runId);
+    }
+  }, [brainRequests, cancelBrainAsk]);
   // A capture run always draws the fixture's words: the voice window that
   // otherwise decides the captions does not stand in one.
   const lukeCaptions = fixtureSpeaking ? [FIXTURE_SPEAKING_CAPTION] : voiceView.lukeCaptions;
@@ -1045,7 +1053,7 @@ export function App(): React.JSX.Element {
             liveConversationEntries={liveConversationEntries}
             onClearConversationConversation={clearConversationLines}
             brainRequests={brainRequests}
-            onCancelBrainRequest={cancelBrainAsk}
+            onStopThinking={stopThinking}
             ask={askLuke}
             onAskEngaged={changeAskEngagement}
             {...(shownAskHotkey ? { askShortcut: shownAskHotkey } : undefined)}

--- a/apps/desktop/src/renderer/ask-luke.test.ts
+++ b/apps/desktop/src/renderer/ask-luke.test.ts
@@ -5,7 +5,7 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { AskLuke, STOP_LABEL } from "./ask-luke";
 
 /** The label as static markup carries it: the apostrophe escaped, as React writes attributes. */
-const STOP_LABEL_MARKUP = STOP_LABEL.replace("'", "&#x27;");
+const STOP_LABEL_MARKUP = STOP_LABEL.replaceAll("'", "&#x27;");
 
 const props = {
   ask: async () => undefined,

--- a/apps/desktop/src/renderer/ask-luke.test.ts
+++ b/apps/desktop/src/renderer/ask-luke.test.ts
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { AskLuke, STOP_LABEL } from "./ask-luke";
+
+/** The label as static markup carries it: the apostrophe escaped, as React writes attributes. */
+const STOP_LABEL_MARKUP = STOP_LABEL.replace("'", "&#x27;");
+
+const props = {
+  ask: async () => undefined,
+  onEngagedChange: () => undefined,
+  rowIndex: 1,
+};
+
+test("the disc sends until a run of Luke's is going, and is its stop while one is", () => {
+  const idle = renderToStaticMarkup(createElement(AskLuke, props));
+  assert.match(idle, /data-turn="you"/);
+  assert.match(
+    idle,
+    /type="submit" class="ask-luke-send" aria-label="Ask Luke" title="Ask Luke" disabled=""/,
+  );
+  assert.doesNotMatch(idle, new RegExp(STOP_LABEL_MARKUP));
+
+  const thinking = renderToStaticMarkup(
+    createElement(AskLuke, { ...props, thinking: true, onStop: () => undefined }),
+  );
+  // The same button in its other state: lit whatever the field holds, named
+  // for what it does, and a button rather than the form's submit.
+  assert.match(thinking, /data-turn="luke"/);
+  assert.match(
+    thinking,
+    new RegExp(
+      `type="button" class="ask-luke-send" aria-label="${STOP_LABEL_MARKUP}" title="${STOP_LABEL_MARKUP}"`,
+    ),
+  );
+  assert.doesNotMatch(thinking, /disabled/);
+});
+
+test("a run going with nothing to stop it through leaves the disc the send it was", () => {
+  const markup = renderToStaticMarkup(createElement(AskLuke, { ...props, thinking: true }));
+  assert.match(markup, /data-turn="you"/);
+  assert.match(markup, /aria-label="Ask Luke"/);
+});

--- a/apps/desktop/src/renderer/ask-luke.tsx
+++ b/apps/desktop/src/renderer/ask-luke.tsx
@@ -72,8 +72,8 @@ export type AskHandler = (text: string) => Promise<string | undefined>;
  * sends; Shift-Enter breaks the line.
  *
  * While a run of Luke's is still going, the disc is its stop: the same control
- * in the same place, changing colour and glyph rather than anything arriving
- * beside the field, and Escape in the field presses it. The disc is the one
+ * in the same place, lit in the primary ink with a stop glyph rather than
+ * anything arriving beside the field, and Escape in the field presses it. The disc is the one
  * element both tabs share, so a run opened from either tab or the ask key can
  * be stopped from wherever the hand already is. An ask typed meanwhile still
  * sends, and joins the turn under way as the brain's queue has it.

--- a/apps/desktop/src/renderer/ask-luke.tsx
+++ b/apps/desktop/src/renderer/ask-luke.tsx
@@ -1,5 +1,5 @@
 import { PRODUCT_ASK_OUTCOME, PRODUCT_SURFACE_EVENT } from "@sidecar/analytics";
-import { SendIcon } from "@sidecar/panel";
+import { SendIcon, StopIcon } from "@sidecar/panel";
 import { cssCustomProperties } from "@sidecar/surface/react-css";
 import { useCallback, useRef, useState } from "react";
 import { ACT_KIND } from "#shared/messages/acts";
@@ -13,6 +13,10 @@ import { Keycaps } from "./keycaps";
  * loud with its words landing right below the field.
  */
 const ASK_PLACEHOLDER = "Ask Luke…";
+
+/** The disc's two names: the field's own ask, and the stop of a run of Luke's still going. */
+const SEND_LABEL = "Ask Luke";
+export const STOP_LABEL = "Stop Luke's reply";
 
 /**
  * How the ask field is found from outside the component, the way the options
@@ -66,12 +70,21 @@ export type AskHandler = (text: string) => Promise<string | undefined>;
  * instant layout change the surface answers with one spring — up to the
  * stylesheet's cap, where the field starts scrolling instead. Enter still
  * sends; Shift-Enter breaks the line.
+ *
+ * While a run of Luke's is still going, the disc is its stop: the same control
+ * in the same place, changing colour and glyph rather than anything arriving
+ * beside the field, and Escape in the field presses it. The disc is the one
+ * element both tabs share, so a run opened from either tab or the ask key can
+ * be stopped from wherever the hand already is. An ask typed meanwhile still
+ * sends, and joins the turn under way as the brain's queue has it.
  */
 export function AskLuke({
   ask,
   onEngagedChange,
   rowIndex,
   shortcut,
+  thinking = false,
+  onStop,
 }: {
   ask: AskHandler;
   /**
@@ -89,7 +102,12 @@ export function AskLuke({
    * key that answers — a hint for a chord another app owns would be a lie.
    */
   shortcut?: string;
+  /** Whether a run of Luke's is still going, which makes the disc its stop. */
+  thinking?: boolean;
+  /** Stops every run still going, at the disc's press or Escape in the field. */
+  onStop?: () => void;
 }): React.JSX.Element {
+  const stopping = thinking && onStop !== undefined;
   const [draft, setDraft] = useState("");
   const [asking, setAsking] = useState(false);
   const field = useRef<HTMLTextAreaElement | null>(null);
@@ -134,6 +152,7 @@ export function AskLuke({
         className="ask-luke"
         data-asking={String(asking)}
         data-draft={String(draft.length > 0)}
+        data-turn={stopping ? "luke" : "you"}
         onSubmit={(event) => {
           event.preventDefault();
           void submit();
@@ -164,8 +183,14 @@ export function AskLuke({
           onKeyDown={(event) => {
             // Escape lets go of the field rather than closing the panel
             // behind it. The draft survives: the field is not going anywhere.
+            // While Luke is still working it stops him first, and the caret
+            // stays: quiet is what was asked for, not leaving.
             if (event.key === "Escape") {
               event.stopPropagation();
+              if (stopping) {
+                onStop();
+                return;
+              }
               event.currentTarget.blur();
               return;
             }
@@ -188,14 +213,17 @@ export function AskLuke({
             Left readable: a reader announcing the caps agrees with
             aria-keyshortcuts. */}
         {shortcut ? <Keycaps className="ask-luke-hint" accelerator={shortcut} /> : null}
+        {/* One button in both of its states, so the disc neither remounts nor
+            loses focus when the turn changes hands. */}
         <button
-          type="submit"
+          type={stopping ? "button" : "submit"}
           className="ask-luke-send"
-          aria-label="Ask Luke"
-          title="Ask Luke"
-          disabled={asking || !draft.trim()}
+          aria-label={stopping ? STOP_LABEL : SEND_LABEL}
+          title={stopping ? STOP_LABEL : SEND_LABEL}
+          disabled={!stopping && (asking || !draft.trim())}
+          {...(stopping ? { onClick: onStop } : undefined)}
         >
-          <SendIcon />
+          {stopping ? <StopIcon /> : <SendIcon />}
         </button>
       </form>
     </div>

--- a/apps/desktop/src/renderer/conversation-panel.test.ts
+++ b/apps/desktop/src/renderer/conversation-panel.test.ts
@@ -5,10 +5,11 @@ import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import {
   CONVERSATION_ENTRY_SPEAKER,
-  CONVERSATION_PENDING_LABEL,
+  CONVERSATION_THINKING_LABEL,
   ConversationClearButton,
   ConversationPanel,
   conversationEntryPresentation,
+  thinkingElapsedLabel,
 } from "./conversation-panel";
 
 const NOW = Date.parse("2026-09-08T17:30:00.000Z");
@@ -250,53 +251,66 @@ test("the composer stands at the foot of the thread, empty or not", () => {
   assert.match(threaded, /aria-keyshortcuts="Alt\+Space"/);
 });
 
-test("an ask whose run is still going waits beside its words and offers a cancel", () => {
-  const cancelled: string[] = [];
+test("a run still going draws Luke's turn at the tail, with no control of its own", () => {
   const run = {
     runId: "run-1",
     submissionId: "sub-1",
     origin: "typed",
     question: "ship it",
     revision: 1,
-    acceptedAt: 1,
+    acceptedAt: NOW,
     performedActions: 0,
     unknownActions: 0,
   } as const;
-  const render = (status: "running" | "succeeded") =>
+  const render = (status: "running" | "succeeded", now = NOW) =>
     renderToStaticMarkup(
       createElement(ConversationPanel, {
         entries: [
           { kind: CONVERSATION_ENTRY_KIND.TYPED_ASK, words: "ship it", requestId: "run-1" },
         ],
         requests: [{ ...run, status }],
-        onCancelRequest: (runId) => cancelled.push(runId),
-        now: NOW,
+        now,
         ask: async () => undefined,
         onAskEngaged: () => undefined,
+        onStop: () => undefined,
       }),
     );
   const pending = render("running");
-  assert.match(pending, new RegExp(CONVERSATION_PENDING_LABEL));
-  assert.match(pending, /class="conversation-cancel"/);
-  // The wait stands beneath the words, inside the bubble, after the question's
-  // own paragraph: the bubble stacks, so the status never shares the row.
-  assert.match(pending, /<\/p><\/div><span class="conversation-pending" role="status">/);
+  // Luke's side, after the ask, wearing the success hop on repeat, with the
+  // reader's line as the live region and nothing to press.
+  assert.match(pending, /data-speaker="luke" data-thinking="true"/);
+  assert.match(pending, /<\/li><li class="conversation-entry" data-speaker="luke" data-thinking/);
+  assert.match(pending, /class="conversation-thinking"/);
+  assert.match(pending, /data-motion="success" data-repeat="true"/);
+  assert.match(pending, new RegExp(`role="status">${CONVERSATION_THINKING_LABEL}`));
+  assert.doesNotMatch(pending, /conversation-cancel|conversation-pending|Cancel/);
+  // Under ten seconds the wait says nothing of its age; past it, how long.
+  assert.doesNotMatch(pending, /Still thinking/);
+  assert.match(render("running", NOW + 71_000), /Still thinking · 1:11/);
   // Still inside the blocked subtree: a wait is drawn beside words a recording never sees.
   assert.match(pending, /ph-no-capture/);
+  // The composer's disc is the stop, in both of its states.
+  assert.match(pending, /data-turn="luke"/);
+  assert.match(pending, /aria-label="Stop Luke&#x27;s reply"/);
   const settled = render("succeeded");
-  assert.doesNotMatch(settled, /conversation-cancel|conversation-pending/);
+  assert.doesNotMatch(settled, /conversation-thinking|data-thinking/);
   // A spoken ask is the same lifecycle: its transcript, tied to its run, waits too.
   const spoken = renderToStaticMarkup(
     createElement(ConversationPanel, {
       entries: [{ kind: CONVERSATION_ENTRY_KIND.SPOKEN_ASK, words: "ship it", requestId: "run-1" }],
       requests: [{ ...run, origin: "spoken", status: "running" }],
-      onCancelRequest: (runId) => cancelled.push(runId),
       now: NOW,
       ask: async () => undefined,
       onAskEngaged: () => undefined,
     }),
   );
-  assert.match(spoken, /class="conversation-cancel"/);
+  assert.match(spoken, /class="conversation-thinking"/);
+});
+
+test("the wait's age is worded once it is worth a word", () => {
+  assert.equal(thinkingElapsedLabel(NOW, NOW + 9_999), undefined);
+  assert.equal(thinkingElapsedLabel(NOW, NOW + 10_000), "Still thinking · 0:10");
+  assert.equal(thinkingElapsedLabel(NOW, NOW + 605_000), "Still thinking · 10:05");
 });
 
 test("a line that followed a long silence is dated over it, in the quiet event voice", () => {

--- a/apps/desktop/src/renderer/conversation-panel.tsx
+++ b/apps/desktop/src/renderer/conversation-panel.tsx
@@ -1,11 +1,12 @@
 import { type BrainRequestSnapshot, brainRequestPending } from "@sidecar/brain/requests-wire";
-import { CheckIcon, CopyIcon } from "@sidecar/panel";
+import { CheckIcon, CopyIcon, WingFace } from "@sidecar/panel";
 import {
   CONVERSATION_ENTRY_KIND,
   type ConversationEntry,
   type ConversationEntryKind,
   conversationEntryKey,
 } from "@sidecar/session";
+import { FACE_MOTION } from "@sidecar/surface";
 import { useEffect, useRef, useState } from "react";
 import { ACT_KIND } from "#shared/messages/acts";
 import { tell } from "./act";
@@ -56,20 +57,86 @@ const ENTRY_TIME = new Intl.DateTimeFormat(undefined, { hour: "numeric", minute:
 
 const timeBreakLabel = createConversationTimeBreakFormatter();
 
-/** What Conversation says under an ask whose run has not ended yet. */
-export const CONVERSATION_PENDING_LABEL = "Luke is working on this…";
+/** What a reader is told of a run still going; the sighted read the face and the dots. */
+export const CONVERSATION_THINKING_LABEL = "Luke is thinking";
+
+/** How long a run goes before the wait says how long it has been. */
+const THINKING_ELAPSED_AFTER_MS = 10_000;
+
+/** How often the wait's own clock moves once it is saying its age. */
+const THINKING_CLOCK_MS = 1_000;
+
+/**
+ * What the wait says once a run has gone on long enough to be worth a word,
+ * and nothing before that: a quick reply earns no sentence, and a run that has
+ * stood for minutes must not read like one that started a second ago.
+ */
+export function thinkingElapsedLabel(since: number, now: number): string | undefined {
+  const elapsed = now - since;
+  if (elapsed < THINKING_ELAPSED_AFTER_MS) return undefined;
+  const seconds = Math.floor(elapsed / 1000);
+  return `Still thinking · ${Math.floor(seconds / 60)}:${String(seconds % 60).padStart(2, "0")}`;
+}
+
+/**
+ * Luke's turn, drawn on his side of the thread in the bubble his reply will
+ * fill, so the thread holds one object per turn and the reply replaces the wait
+ * in place. His face plays the success hop on repeat — a run still going is
+ * continuously true, which is what a repeating motion is for — and three dots
+ * rise in its wake. Nothing here is a control: the stop is the composer's disc,
+ * which both tabs share. The reader's line is the live region, and the age
+ * beside it is not, so a ticking count is never read out second by second.
+ */
+function ConversationThinkingRow({
+  since,
+  now,
+}: {
+  since: number;
+  now: number;
+}): React.JSX.Element {
+  // The wait keeps a clock of its own past the app's, which moves only when
+  // the app renders: a count of how long a run has been going has to move on
+  // its own. Never behind the app's clock, so a fixed clock is never
+  // contradicted by this one.
+  const [clock, setClock] = useState(now);
+  useEffect(() => {
+    const timer = window.setInterval(() => setClock(Date.now()), THINKING_CLOCK_MS);
+    return () => window.clearInterval(timer);
+  }, []);
+  const elapsed = thinkingElapsedLabel(since, Math.max(clock, now));
+  return (
+    <li
+      className="conversation-entry"
+      data-speaker={CONVERSATION_ENTRY_SPEAKER.LUKE}
+      data-thinking="true"
+    >
+      <small className="visually-hidden">Luke</small>
+      <div className="conversation-message">
+        <span className="conversation-bubble">
+          <span className="conversation-thinking">
+            <WingFace motion={FACE_MOTION.SUCCESS} repeat />
+            <span className="conversation-thinking-dots" aria-hidden="true">
+              <i />
+              <i />
+              <i />
+            </span>
+            {elapsed ? <span className="conversation-thinking-elapsed">{elapsed}</span> : null}
+            <span className="visually-hidden" role="status">
+              {CONVERSATION_THINKING_LABEL}
+            </span>
+          </span>
+        </span>
+      </div>
+    </li>
+  );
+}
 
 function ConversationEntryRow({
   entry,
   streaming,
-  pending,
-  onCancel,
 }: {
   entry: ConversationEntry;
   streaming?: boolean;
-  /** Whether the run this ask opened is still going, which draws the wait and the cancel. */
-  pending?: boolean;
-  onCancel?: () => void;
 }): React.JSX.Element {
   const presentation = conversationEntryPresentation(entry.kind);
   const words = entry.words;
@@ -93,16 +160,6 @@ function ConversationEntryRow({
       <div className="conversation-message">
         <span className="conversation-bubble">
           <MarkdownMessage words={words} className="conversation-words" />
-          {pending ? (
-            <span className="conversation-pending" role="status">
-              <span className="conversation-pending-label">{CONVERSATION_PENDING_LABEL}</span>
-              {onCancel ? (
-                <button type="button" className="conversation-cancel" onClick={onCancel}>
-                  Cancel
-                </button>
-              ) : null}
-            </span>
-          ) : null}
           {/* Copying words still arriving would copy half a sentence; the control
             appears with the settled line the same words become. */}
           {presentation.speaker === CONVERSATION_ENTRY_SPEAKER.EVENT || streaming ? null : (
@@ -228,10 +285,10 @@ export function ConversationPanel({
   live = [],
   requests = [],
   now,
-  onCancelRequest,
   ask,
   onAskEngaged,
   askShortcut,
+  onStop,
 }: {
   entries: readonly ConversationEntry[];
   /**
@@ -241,12 +298,11 @@ export function ConversationPanel({
    */
   now: number;
   /**
-   * The brain's runs, so an ask whose run is still going is drawn waiting,
-   * with the cancel the developer holds. Read here from the records alone;
-   * the reply's own line arrives when the run ends.
+   * The brain's runs, so a run still going draws Luke's turn at the thread's
+   * tail. Read here from the records alone; the reply's own line arrives when
+   * the run ends, and the stop is the composer's.
    */
   requests?: readonly BrainRequestSnapshot[];
-  onCancelRequest?: (runId: string) => void;
   /**
    * The lines still being said, drawn under the settled thread as the same
    * bubbles they will settle into — words growing, no timestamp, no copy.
@@ -256,21 +312,26 @@ export function ConversationPanel({
   ask: AskHandler;
   onAskEngaged: (engaged: boolean) => void;
   askShortcut?: string;
+  /** Stops every run still going, for the composer's disc while one is. */
+  onStop?: () => void;
 }): React.JSX.Element {
   const list = useRef<HTMLDivElement | null>(null);
   const entryCount = entries.length;
   const liveLength = live.reduce((total, entry) => total + entry.words.length, 0);
-  const pendingRuns = new Set(
-    requests.filter(brainRequestPending).map((snapshot) => snapshot.runId),
-  );
+  // One wait however many runs are going: a second ask joins the turn under
+  // way, and two waits for one turn would say otherwise. Its age is the
+  // oldest run's.
+  const pending = requests.filter(brainRequestPending);
+  const thinkingSince =
+    pending.length > 0 ? Math.min(...pending.map((snapshot) => snapshot.acceptedAt)) : undefined;
 
   useEffect(() => {
-    // Reading the count binds the scroll to an append or clear, not to an
-    // unrelated render of the same conversation.
-    if (entryCount === 0) return;
+    // Reading the count binds the scroll to an append, a clear, or the wait
+    // arriving, not to an unrelated render of the same conversation.
+    if (entryCount === 0 && thinkingSince === undefined) return;
     const element = list.current;
     if (element) element.scrollTop = element.scrollHeight;
-  }, [entryCount]);
+  }, [entryCount, thinkingSince]);
 
   useEffect(() => {
     // A streaming line only carries the reader along; unlike an append, it
@@ -282,7 +343,7 @@ export function ConversationPanel({
     if (fromTail <= STREAM_FOLLOW_SLACK_PX) element.scrollTop = element.scrollHeight;
   }, [liveLength]);
 
-  const thread = entries.length > 0 || live.length > 0;
+  const thread = entries.length > 0 || live.length > 0 || thinkingSince !== undefined;
 
   return (
     <section
@@ -302,22 +363,7 @@ export function ConversationPanel({
           <div className="conversation-pull">
             <ol className="conversation-list">
               {keyedConversationEntries(entries).flatMap(({ entry, key, opensBreak }) => {
-                const runId = entry.requestId;
-                const pending =
-                  runId !== undefined &&
-                  (entry.kind === CONVERSATION_ENTRY_KIND.TYPED_ASK ||
-                    entry.kind === CONVERSATION_ENTRY_KIND.SPOKEN_ASK) &&
-                  pendingRuns.has(runId);
-                const row = (
-                  <ConversationEntryRow
-                    key={key}
-                    entry={entry}
-                    pending={pending}
-                    {...(pending && runId !== undefined && onCancelRequest
-                      ? { onCancel: () => onCancelRequest(runId) }
-                      : undefined)}
-                  />
-                );
+                const row = <ConversationEntryRow key={key} entry={entry} />;
                 return opensBreak && entry.recordedAt !== undefined
                   ? [
                       <ConversationTimeBreak
@@ -337,6 +383,11 @@ export function ConversationPanel({
                   streaming
                 />
               ))}
+              {/* After the lines still being said: a spoken ask's own words
+                  stream in above the wait for their answer. */}
+              {thinkingSince !== undefined ? (
+                <ConversationThinkingRow since={thinkingSince} now={now} />
+              ) : null}
             </ol>
           </div>
         </div>
@@ -354,6 +405,8 @@ export function ConversationPanel({
         ask={ask}
         onEngagedChange={onAskEngaged}
         rowIndex={CONVERSATION_COMPOSER_ROW_INDEX}
+        thinking={thinkingSince !== undefined}
+        {...(onStop ? { onStop } : undefined)}
         {...(askShortcut ? { shortcut: askShortcut } : undefined)}
       />
     </section>

--- a/apps/desktop/src/renderer/panel-body.tsx
+++ b/apps/desktop/src/renderer/panel-body.tsx
@@ -1,4 +1,4 @@
-import type { BrainRequestSnapshot } from "@sidecar/brain/requests-wire";
+import { type BrainRequestSnapshot, brainRequestPending } from "@sidecar/brain/requests-wire";
 import {
   ACCOUNT_STATUS,
   type AccountProvider,
@@ -184,10 +184,10 @@ export interface PanelBodyProps {
   liveConversationEntries: readonly ConversationEntry[];
   /** Clears that same thread from the view, Luke's next context, and the stored file. */
   onClearConversationConversation: () => void;
-  /** The brain's runs, so Conversation draws an ask still being worked on beside its words. */
+  /** The brain's runs, so Conversation draws Luke's turn while one is going and the composer offers its stop. */
   brainRequests: readonly BrainRequestSnapshot[];
-  /** Cancels one of those runs at the developer's press. */
-  onCancelBrainRequest: (runId: string) => void;
+  /** Stops every run still going, at the composer's press. */
+  onStopThinking: () => void;
   /** Carries a typed ask to Luke's own conversation, answering why it could not go. */
   ask: AskHandler;
   /** Reports someone being part-way through an ask, so the panel holds for them. */
@@ -241,7 +241,7 @@ export function PanelBody({
   liveConversationEntries,
   onClearConversationConversation,
   brainRequests,
-  onCancelBrainRequest,
+  onStopThinking,
   ask,
   onAskEngaged,
   askShortcut,
@@ -258,6 +258,9 @@ export function PanelBody({
   onTabChange,
   settings,
 }: PanelBodyProps): React.JSX.Element {
+  // Whether a run of Luke's is still going, read from the same records
+  // Conversation draws the wait from, so the disc and the wait cannot disagree.
+  const thinking = brainRequests.some(brainRequestPending);
   const sessionListRef = useSessionReorderMotion();
   const rows = useRoster(list.sessions, sessionListRef);
   // The sheet floats over the list, so its height never reaches the panel's
@@ -362,9 +365,9 @@ export function PanelBody({
           live={liveConversationEntries}
           requests={brainRequests}
           now={now}
-          onCancelRequest={onCancelBrainRequest}
           ask={ask}
           onAskEngaged={onAskEngaged}
+          onStop={onStopThinking}
           {...(askShortcut ? { askShortcut } : undefined)}
         />
       ) : (
@@ -459,6 +462,8 @@ export function PanelBody({
             ask={ask}
             onEngagedChange={onAskEngaged}
             rowIndex={rows.length + 1}
+            thinking={thinking}
+            onStop={onStopThinking}
             {...(askShortcut ? { shortcut: askShortcut } : undefined)}
           />
         </SessionsPanel>

--- a/apps/desktop/src/renderer/styles/conversation.css
+++ b/apps/desktop/src/renderer/styles/conversation.css
@@ -205,29 +205,129 @@
   color: var(--text-primary);
 }
 
-/* The wait under an ask still running, and the one control it offers: quiet,
-   in the bubble's own column, gone the moment the reply's line arrives. */
-.conversation-pending {
-  display: flex;
+/* Luke's turn, in the bubble his reply will fill: his face, three dots, and
+   past ten seconds how long it has been. It is a received bubble in every
+   measure but its words, so the reply lands exactly where the wait stood.
+   Nothing here is a control; the stop is the composer's disc. */
+.conversation-thinking {
+  display: inline-flex;
+  min-height: 32px;
   align-items: center;
-  flex-wrap: wrap;
-  gap: 4px 8px;
-  padding: 4px 6px 2px;
-  color: var(--text-secondary);
-  font-size: 11.5px;
+  gap: 9px;
+  padding: 6px 12px 6px 10px;
+  border-radius: 15px 15px 15px 5px;
+  background: var(--raised-strong);
 }
 
-.conversation-cancel {
-  padding: 1px 8px;
-  border-radius: 999px;
-  background: var(--raised);
-  color: var(--text-primary);
-  font-size: 11px;
+/* A step below the wing's face: the bubble is a line of text, not a housing. */
+.conversation-thinking .luke-face {
+  width: 16px;
+  height: 16px;
 }
 
-.conversation-cancel:hover {
+.conversation-thinking-dots {
+  display: inline-flex;
+  height: 12px;
+  align-items: center;
+  gap: 4px;
+}
+
+/* The dots follow the generated `success` cycle the face beside them is
+   playing on repeat — luke-success-2, 2s, the head off the ground from 25% to
+   65% and highest at 45% — each rising as the head comes down, one after
+   another, a ripple off the hop. The stagger is cut into the keyframes rather
+   than carried as a delay, so a paused loop holds every dot at rest, the pose
+   the face itself holds paused; and being timed to a face gesture, they answer
+   --face-motion rather than --loop-motion, so the two can never stop apart. */
+.conversation-thinking-dots i {
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
   background: var(--text-secondary);
-  color: var(--surface);
+  opacity: 0.35;
+  animation-duration: 2s;
+  animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
+  animation-iteration-count: infinite;
+  animation-play-state: var(--face-motion);
+}
+
+.conversation-thinking-dots i:nth-child(1) {
+  animation-name: conversation-thinking-dot-1;
+}
+
+.conversation-thinking-dots i:nth-child(2) {
+  animation-name: conversation-thinking-dot-2;
+}
+
+.conversation-thinking-dots i:nth-child(3) {
+  animation-name: conversation-thinking-dot-3;
+}
+
+@keyframes conversation-thinking-dot-1 {
+  0%,
+  45% {
+    opacity: 0.35;
+    transform: translateY(0);
+  }
+
+  55% {
+    opacity: 1;
+    transform: translateY(-3px);
+  }
+
+  65%,
+  100% {
+    opacity: 0.35;
+    transform: translateY(0);
+  }
+}
+
+@keyframes conversation-thinking-dot-2 {
+  0%,
+  53% {
+    opacity: 0.35;
+    transform: translateY(0);
+  }
+
+  63% {
+    opacity: 1;
+    transform: translateY(-3px);
+  }
+
+  73%,
+  100% {
+    opacity: 0.35;
+    transform: translateY(0);
+  }
+}
+
+@keyframes conversation-thinking-dot-3 {
+  0%,
+  61% {
+    opacity: 0.35;
+    transform: translateY(0);
+  }
+
+  71% {
+    opacity: 1;
+    transform: translateY(-3px);
+  }
+
+  81%,
+  100% {
+    opacity: 0.35;
+    transform: translateY(0);
+  }
+}
+
+/* How long the run has been going, said only once it is worth saying. Plain
+   text beside the reader's status line rather than inside it, so a count that
+   moves every second is never read out every second. */
+.conversation-thinking-elapsed {
+  color: var(--text-tertiary);
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
 }
 
 /* The bubble's words, drawn as the Markdown they were written in; the block

--- a/apps/desktop/src/renderer/styles/sessions.css
+++ b/apps/desktop/src/renderer/styles/sessions.css
@@ -1312,13 +1312,17 @@ html[data-keyboard="true"] .row-application-button:focus-visible {
   height: 12px;
 }
 
-/* Luke's turn: while a run of his is still going the disc is its stop, in his
-   blue — the colour the surface gives something of his in progress — and lit
-   whatever the field holds. The disc alone carries the state: it neither grows
-   nor moves, nothing arrives around it, and a quick reply flickers nothing in
-   and out because no element ever arrives or leaves. */
+/* Luke's turn: while a run of his is still going the disc is its stop, lit in
+   the primary ink whatever the field holds — the way every desktop chat surface
+   draws a stop — and in no colour at all. Green is your turn and Luke's blue is
+   his voice, and a stop is neither; a blue here would also stand a few pixels
+   from the sent bubbles' own, different blue and read as a mismatch rather than
+   a meaning. The thread's wait already says whose turn it is. The disc alone
+   carries the state: it neither grows nor moves, nothing arrives around it, and
+   a quick reply flickers nothing in and out because no element ever arrives or
+   leaves. */
 .ask-luke[data-turn="luke"] .ask-luke-send {
-  background: var(--voice-luke);
+  background: var(--text-primary);
   color: rgba(0, 0, 0, 0.82);
 }
 

--- a/apps/desktop/src/renderer/styles/sessions.css
+++ b/apps/desktop/src/renderer/styles/sessions.css
@@ -1312,6 +1312,16 @@ html[data-keyboard="true"] .row-application-button:focus-visible {
   height: 12px;
 }
 
+/* Luke's turn: while a run of his is still going the disc is its stop, in his
+   blue — the colour the surface gives something of his in progress — and lit
+   whatever the field holds. The disc alone carries the state: it neither grows
+   nor moves, nothing arrives around it, and a quick reply flickers nothing in
+   and out because no element ever arrives or leaves. */
+.ask-luke[data-turn="luke"] .ask-luke-send {
+  background: var(--voice-luke);
+  color: rgba(0, 0, 0, 0.82);
+}
+
 /* An ask on its way to a call that may still be opening: the disc breathes
    instead of a spinner arriving, because nothing in the pill may change size.
    It holds still under the same token as every other loop — a capture must

--- a/packages/brain/src/requests.test.ts
+++ b/packages/brain/src/requests.test.ts
@@ -5,8 +5,11 @@ import {
   BRAIN_REQUEST_ORIGIN,
   BRAIN_REQUEST_STATUS,
   type BrainRequestRecord,
+  brainReplyWords,
   brainRequestRecordFromWire,
   brainRequestRecordToWire,
+  STOPPED_ASK_NARRATION,
+  stoppedAskNarration,
 } from "./requests.js";
 
 const NOW = 1_800_000_000_000;
@@ -45,4 +48,34 @@ test("a request record survives the wire whole, with every optional field presen
     assert.deepEqual(brainRequestRecordFromWire(wire), record);
     assert.deepEqual(Object.keys(wire).sort(), Object.keys(record).sort());
   }
+});
+
+test("a plain stop has no reply words and leaves the quiet line; one that had acted keeps its account", () => {
+  const stopped: BrainRequestRecord = {
+    runId: "run-3",
+    submissionId: "sub-3",
+    origin: BRAIN_REQUEST_ORIGIN.TYPED,
+    question: "what needs me?",
+    status: BRAIN_REQUEST_STATUS.CANCELLED,
+    revision: 2,
+    acceptedAt: NOW,
+    settledAt: NOW + 3,
+    performedActions: 0,
+    unknownActions: 0,
+  };
+  assert.equal(brainReplyWords(stopped), undefined);
+  assert.equal(stoppedAskNarration(stopped), STOPPED_ASK_NARRATION);
+  // An action already carried is news the stop must not swallow, so it is a reply after all.
+  const acted = { ...stopped, performedActions: 1 };
+  assert.match(brainReplyWords(acted) ?? "", /^Cancelled, though /);
+  assert.equal(stoppedAskNarration(acted), undefined);
+  // Any other end is worded as itself and is never the quiet line.
+  assert.equal(
+    stoppedAskNarration({ ...stopped, status: BRAIN_REQUEST_STATUS.TIMED_OUT }),
+    undefined,
+  );
+  assert.equal(
+    stoppedAskNarration({ ...stopped, status: BRAIN_REQUEST_STATUS.RUNNING }),
+    undefined,
+  );
 });

--- a/packages/brain/src/requests.ts
+++ b/packages/brain/src/requests.ts
@@ -291,6 +291,9 @@ export const BRAIN_ASK_REFUSAL = {
 /** What the voice says while a run is still going when its wait ran out. */
 export const BRAIN_ASK_PENDING_NOTE = "I'm still working on that. I'll tell you when it's done.";
 
+/** What the voice says of a spoken ask the developer stopped before its reply formed. */
+export const BRAIN_ASK_STOPPED_NOTE = "That ask was stopped before I finished it.";
+
 function actionsPhrase(count: number): string {
   return count === 1 ? "one thing you asked" : `${count} things you asked`;
 }
@@ -349,7 +352,11 @@ export function brainReplyWords(snapshot: BrainRequestRecord): string | undefine
         ? `${account}, but I couldn't put the reply into words.`
         : "I couldn't work that one out. Ask me again in a moment.";
     case BRAIN_REQUEST_STATUS.CANCELLED:
-      return acted ? `Cancelled, though ${account}.` : "Cancelled.";
+      // A plain stop is the developer's own press, not a reply: it reaches the
+      // thread as the quiet line `stoppedAskNarration` words and is never
+      // offered to the ear. What was done before the stop is still news, so
+      // that account is said.
+      return acted ? `Cancelled, though ${account}.` : undefined;
     case BRAIN_REQUEST_STATUS.TIMED_OUT:
       return acted ? `That ask ran out of time, though ${account}.` : "That ask ran out of time.";
     case BRAIN_REQUEST_STATUS.INTERRUPTED:
@@ -357,6 +364,20 @@ export function brainReplyWords(snapshot: BrainRequestRecord): string | undefine
         ? `That ask was interrupted, though ${account}.`
         : "That ask was interrupted before I could finish it.";
   }
+}
+
+/** What a stopped ask leaves in the thread, in the voice of the actions carried at the developer's ask. */
+export const STOPPED_ASK_NARRATION = "stopped working on that ask";
+
+/**
+ * The quiet line a run the developer stopped leaves behind, worded as what
+ * Luke did at their ask rather than as something he said, so it is drawn in the
+ * thread's event voice and never spoken. A cancel that had already acted is
+ * not quiet: its account travels as the reply `brainReplyWords` builds.
+ */
+export function stoppedAskNarration(snapshot: BrainRequestRecord): string | undefined {
+  if (snapshot.status !== BRAIN_REQUEST_STATUS.CANCELLED) return undefined;
+  return actionsAccount(snapshot).length > 0 ? undefined : STOPPED_ASK_NARRATION;
 }
 
 /** Some fields of one record, as a save applies them over what is committed. */

--- a/packages/host/src/brain/publication.test.ts
+++ b/packages/host/src/brain/publication.test.ts
@@ -188,8 +188,11 @@ test("a run's end reaches the thread once, at the moment it settled, decided aga
   ];
   await publishRuns(agent, live, written.record);
   assert.equal(written.recorded.length, 2);
+  // A plain stop leaves the quiet line, in the event voice, never a reply.
   const [, secondWrite] = written.recorded;
-  assert.equal(secondWrite?.entry.words, "Cancelled.");
+  assert.equal(secondWrite?.entry.kind, CONVERSATION_ENTRY_KIND.ACTION);
+  assert.equal(secondWrite?.entry.words, "stopped working on that ask");
+  assert.equal(secondWrite?.entry.requestId, "run-2");
   assert.deepEqual(marked, ["run-1", "run-2"]);
   // A run the live agent no longer knows — the generation was reset — is not written.
   live = [];

--- a/packages/host/src/brain/publication.ts
+++ b/packages/host/src/brain/publication.ts
@@ -5,12 +5,14 @@ import {
   BRAIN_SUBMISSION_REJECTION,
   brainReplyWords,
   isTerminalBrainRequestStatus,
+  stoppedAskNarration,
 } from "@sidecar/brain/requests";
 import type { BrainAskSubmissionResult, BrainRequestSnapshot } from "@sidecar/brain/requests-wire";
 import { MAIN_SESSION_KEY, type SessionKey } from "@sidecar/runtime/vocabulary";
 import {
   type ConversationEntry,
   replyConversationEntry,
+  stoppedAskConversationEntry,
   typedAskConversationEntry,
 } from "@sidecar/session";
 
@@ -96,12 +98,19 @@ async function publishEnd(
   const current = agent.request(runId);
   if (!current || !isTerminalBrainRequestStatus(current.status)) return undefined;
   if (current.conversationRecordedAt !== undefined) return current;
+  // An end with words is Luke's reply; a plain stop has none and leaves the
+  // quiet line instead, so every ended run reaches the thread and is marked.
   const words = brainReplyWords(current);
-  if (!words) return undefined;
+  const narration = words === undefined ? stoppedAskNarration(current) : undefined;
+  const entry =
+    words !== undefined
+      ? replyConversationEntry(words, current.runId)
+      : narration !== undefined
+        ? stoppedAskConversationEntry(narration, current.runId)
+        : undefined;
+  if (!entry) return undefined;
   const at = current.settledAt ?? current.acceptedAt;
-  if (!(await record(replyConversationEntry(words, current.runId), at, sessionKey))) {
-    return undefined;
-  }
+  if (!(await record(entry, at, sessionKey))) return undefined;
   if (!(await agent.markConversationRecorded(runId, at))) return undefined;
   // Re-read rather than patched: the mark landed on the live record, and a
   // Clear or a replacement in the meantime has taken the record with it.

--- a/packages/panel/src/glyphs.tsx
+++ b/packages/panel/src/glyphs.tsx
@@ -407,6 +407,15 @@ export function SendIcon(): React.JSX.Element {
   );
 }
 
+/** Stops the reply under way, drawn the way every chat surface draws it: a square. */
+export function StopIcon(): React.JSX.Element {
+  return (
+    <Glyph className="control-icon">
+      <rect x="6.5" y="6.5" width="11" height="11" rx="2.2" fill="currentColor" stroke="none" />
+    </Glyph>
+  );
+}
+
 export function OptionsIcon(): React.JSX.Element {
   return (
     <svg

--- a/packages/panel/src/glyphs.tsx
+++ b/packages/panel/src/glyphs.tsx
@@ -411,7 +411,7 @@ export function SendIcon(): React.JSX.Element {
 export function StopIcon(): React.JSX.Element {
   return (
     <Glyph className="control-icon">
-      <rect x="6.5" y="6.5" width="11" height="11" rx="2.2" fill="currentColor" stroke="none" />
+      <rect x="5.2" y="5.2" width="13.6" height="13.6" rx="2.8" fill="currentColor" stroke="none" />
     </Glyph>
   );
 }

--- a/packages/session/src/conversation/conversation.ts
+++ b/packages/session/src/conversation/conversation.ts
@@ -389,6 +389,15 @@ export function replyConversationEntry(words: string, requestId?: string): Conve
   };
 }
 
+/**
+ * The quiet line a run the developer stopped leaves behind, tied to its run
+ * the way the reply it stands in for would be, so it is recorded exactly once
+ * however many windows hear of the run's end.
+ */
+export function stoppedAskConversationEntry(words: string, requestId: string): ConversationEntry {
+  return { kind: CONVERSATION_ENTRY_KIND.ACTION, words, requestId };
+}
+
 /** The history line a typed ask the brain accepted leaves behind, tied to its run. */
 export function typedAskConversationEntry(words: string, requestId: string): ConversationEntry {
   return { kind: CONVERSATION_ENTRY_KIND.TYPED_ASK, words, requestId };

--- a/packages/voice/src/orchestrator/brain-ask.ts
+++ b/packages/voice/src/orchestrator/brain-ask.ts
@@ -1,6 +1,7 @@
 import {
   BRAIN_ASK_PENDING_NOTE,
   BRAIN_ASK_REFUSAL,
+  BRAIN_ASK_STOPPED_NOTE,
   BRAIN_REQUEST_ORIGIN,
   BRAIN_SUBMISSION_OUTCOME,
   brainReplyWords,
@@ -62,6 +63,11 @@ export async function askBrain(
     return { status: ACTION_RESULT_STATUS.REJECTED, reason: BRAIN_ASK_REFUSAL.absent };
   }
   const moved = generation !== context.thread.generation || withdrawals !== context.withdrawals();
+  // A run the developer stopped ended with no reply to grant: the thread holds
+  // its quiet line already, and the voice says so rather than "still working".
+  if (!brainRequestPending(waited.record) && brainReplyWords(waited.record) === undefined) {
+    return { status: ACTION_RESULT_STATUS.REJECTED, reason: BRAIN_ASK_STOPPED_NOTE };
+  }
   if (brainRequestPending(waited.record) || !waited.speak || moved) {
     return { status: BRAIN_ASK_PENDING_STATUS, note: BRAIN_ASK_PENDING_NOTE };
   }


### PR DESCRIPTION
## Summary

- Draws Luke's turn on his side of the Conversation thread while a run is going: his face playing the `success` hop on repeat beside three dots that rise in its wake, in the bubble the reply will fill, so the reply replaces the wait in place. After ten seconds the wait reports its age (`Still thinking · 0:12`), so a run that has stood for minutes no longer reads like one that started a second ago.
- Makes the composer's send disc the stop while Luke has the turn: the same button, lit in the primary ink with a stop glyph (no colour: green is your turn, Luke's blue is his voice, and the sent bubbles' own blue sits beside it), named "Stop Luke's reply", lit whatever the field holds, and pressed by Escape in the field. The disc is the one control both tabs share, so a run opened from the Sessions tab or the ask key can be stopped without switching tabs. Nothing arrives or leaves, so a quick reply flickers no control in and out.
- Removes the "Luke is working on this… Cancel" line that stood under the developer's own bubble, and the two Cancels a steered second ask grew for one run.
- A plain stop lands in the thread as a quiet event line (`stopped working on that ask`, in the voice of the actions carried at the developer's ask) and is never offered to speech; before this, Luke wrote "Cancelled." as his own bubble and said it aloud. A cancel that had already carried an action keeps its account as a reply, since that is news. A spoken ask stopped from the composer now tells the voice "That ask was stopped before I finished it." instead of "I'm still working on that."
- The dots are timed to the generated `success` cycle with the stagger cut into the keyframes, and answer `--face-motion`, so a capture run and reduced motion hold face and dots at rest together, per `docs/DESIGN.md`.
- The face in the strip is deliberately left as it was: a second looping Luke beside the housing would run out of phase with the one in the thread.

Product exploration behind this: a standalone prototype comparing today's experience with two alternatives; this ships the composer-anchored one, with the ring around the disc dropped and the placeholder face changed to the hop at review.

## Evidence

- Platform-independent checks: `./scripts/check.sh` — `passed` (lint, typecheck, tests, build; exit 0)
- macOS Electron verification (`./scripts/verify.sh`): `not run`
- CI's deterministic macOS evidence (six `smoke` captures, run 34405882292) downloaded and inspected: the Sessions tab, peek, slot, muted, compact, and speaking states draw as before, with the composer disc in its idle state; the fixture holds no pending brain run, so the thinking state itself is not in a capture — no macOS machine in this workspace; the fixture and evidence runs draw no pending brain run, so the new state is exercised by the renderer's unit tests (`conversation-panel.test.ts`, `ask-luke.test.ts`) and the design-contract check.

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34409191342/artifacts/10126634598) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34409191342)

- Commit: `3d91794c664e50cd577310531a528f7de6f77b05`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

### Physical-device evidence

- Screenshot or screen recording: `not attached`
- Physical-notch check: `not performed`
- Device/display configuration: `not recorded`

## Notes

- Blockers or follow-up verification: a live run on a Mac to watch the hop and dots share the beat, and to press the disc and Escape against a real run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

