### PR TITLE
refactor(hosted): one AccountCall behind every call to Luke's service

### DIFF
--- a/packages/analytics/src/sender.test.ts
+++ b/packages/analytics/src/sender.test.ts
@@ -101,44 +101,35 @@ test("a sender that was never armed sends nothing", async () => {
   assert.deepEqual(requests, []);
 });
 
-test("a 401 refreshes and retries once, and the same token twice does not", async () => {
+test("a batch queued under one account is never posted under another's bearer", async () => {
+  let account = "ada@luke.test";
   let token = "stale";
-  const { fetch, requests } = recordingFetch((request) =>
-    request.authorization === "Bearer fresh"
-      ? new Response("{}")
-      : new Response("{}", { status: HTTP_STATUS.UNAUTHORIZED }),
+  const { fetch, requests } = recordingFetch(
+    () => new Response("{}", { status: HTTP_STATUS.UNAUTHORIZED }),
   );
-  let refreshes = 0;
-  const sender = new ProductEventSender({
-    serviceBaseUrl: BASE_URL,
-    appVersion: APP_VERSION,
-    sends: true,
+  const { sender } = sharingSender({
+    fetch,
     readAccessToken: async () => token,
+    readAccountKey: async () => account,
+    // The sign-out and sign-in the refusal was the first sign of: the token
+    // the retry would carry answers for somebody else.
     refreshAccount: async () => {
-      refreshes += 1;
+      account = "grace@luke.test";
       token = "fresh";
     },
-    fetch,
-    now: () => NOON,
   });
-  sender.arm();
   sender.record(PRODUCT_EVENT.APP_LAUNCH, { app_version: APP_VERSION });
   await sender.flush();
 
-  assert.equal(refreshes, 1);
   assert.deepEqual(
     requests.map((request) => request.authorization),
-    ["Bearer stale", "Bearer fresh"],
+    ["Bearer stale"],
   );
 
-  const stuck = senderWith(
-    { readAccessToken: async () => "same" },
-    () => new Response("{}", { status: HTTP_STATUS.UNAUTHORIZED }),
-  );
-  stuck.sender.arm();
-  stuck.sender.record(PRODUCT_EVENT.APP_LAUNCH, { app_version: APP_VERSION });
-  await stuck.sender.flush();
-  assert.equal(stuck.requests.length, 1);
+  // Spent, not requeued: these counts belong to an account this sender can no
+  // longer name.
+  await sender.flush();
+  assert.equal(requests.length, 1);
 });
 
 test("a failed send drops its batch rather than retrying it behind the next one", async () => {

--- a/packages/analytics/src/sender.test.ts
+++ b/packages/analytics/src/sender.test.ts
@@ -181,6 +181,23 @@ test("signed out the queue waits rather than being spent", async () => {
   assert.equal(sentEvents(recordedRequest(requests)).length, 1);
 });
 
+test("a token the settings file could not answer leaves the batch queued", async () => {
+  let readable = false;
+  const { sender, requests } = sharingSender({
+    readAccessToken: async () => {
+      if (!readable) throw new Error("the settings file could not be read");
+      return "token-1";
+    },
+  });
+  sender.record(PRODUCT_EVENT.APP_LAUNCH, { app_version: APP_VERSION });
+  await sender.flush();
+  assert.deepEqual(requests, []);
+
+  readable = true;
+  await sender.flush();
+  assert.equal(sentEvents(recordedRequest(requests)).length, 1);
+});
+
 test("past the queue limit the oldest go and the newest stay", async () => {
   const { sender, requests } = sharingSender({ queueLimit: 3 });
   for (const providerId of ["claude-code", "codex", "conductor", "omp"] as const) {

--- a/packages/analytics/src/sender.ts
+++ b/packages/analytics/src/sender.ts
@@ -1,5 +1,13 @@
-import { type AccountToken, HOSTED_SERVICE_PATH } from "@sidecar/hosted";
-import { type CloudFetch, positiveInteger, text, withoutTrailingSlash } from "@sidecar/wire";
+import {
+  type AccountCall,
+  type AccountToken,
+  accountBearer,
+  CALL_FAULT,
+  callAnswered,
+  createAccountCall,
+  HOSTED_SERVICE_PATH,
+} from "@sidecar/hosted";
+import { type CloudFetch, HTTP_METHOD, positiveInteger } from "@sidecar/wire";
 import {
   PRODUCT_EVENT,
   PRODUCT_EVENT_BATCH_LIMIT,
@@ -12,7 +20,6 @@ import {
 } from "./product-events.js";
 
 const PRODUCT_EVENT_DEFAULTS = {
-  REQUEST_TIMEOUT_MS: 10_000,
   /**
    * A minute between flushes. Long enough that a launch, a sign-in, and a
    * first observation ride one request rather than three; short enough that a
@@ -27,8 +34,6 @@ const PRODUCT_EVENT_DEFAULTS = {
    */
   QUEUE_LIMIT: 200,
 } as const;
-
-const UNAUTHORIZED_STATUS = 401;
 
 /** The one discriminator the day marker dedups on; the day itself is the key. */
 const DAY_ACTIVE_KEY = "day";
@@ -66,14 +71,10 @@ export interface ProductEventSenderOptions extends AccountToken {
  * so there is nothing here to name a person with.
  */
 export class ProductEventSender {
-  readonly #endpoint: string;
+  readonly #call: AccountCall;
   readonly #appVersion: string;
   readonly #sends: boolean;
-  readonly #readAccessToken: () => Promise<string | undefined>;
-  readonly #refreshAccount: () => Promise<void>;
-  readonly #fetch: CloudFetch;
   readonly #now: () => number;
-  readonly #requestTimeoutMs: number;
   readonly #flushIntervalMs: number;
   readonly #queueLimit: number;
   readonly #queue: ProductEvent[] = [];
@@ -84,19 +85,15 @@ export class ProductEventSender {
   #inFlight: Promise<void> | undefined;
 
   constructor(options: ProductEventSenderOptions) {
-    const baseUrl = text(options.serviceBaseUrl);
-    if (!baseUrl) throw new Error("Hosted service base URL must not be empty");
-    this.#endpoint = `${withoutTrailingSlash(baseUrl)}${HOSTED_SERVICE_PATH.EVENTS}`;
+    this.#call = createAccountCall({
+      baseUrl: options.serviceBaseUrl,
+      credential: accountBearer(options),
+      fetch: options.fetch,
+      requestTimeoutMs: options.requestTimeoutMs,
+    });
     this.#appVersion = options.appVersion;
     this.#sends = options.sends;
-    this.#readAccessToken = options.readAccessToken;
-    this.#refreshAccount = options.refreshAccount;
-    this.#fetch = options.fetch ?? ((input, init) => fetch(input, init));
     this.#now = options.now ?? Date.now;
-    this.#requestTimeoutMs = positiveInteger(
-      options.requestTimeoutMs,
-      PRODUCT_EVENT_DEFAULTS.REQUEST_TIMEOUT_MS,
-    );
     this.#flushIntervalMs = positiveInteger(
       options.flushIntervalMs,
       PRODUCT_EVENT_DEFAULTS.FLUSH_INTERVAL_MS,
@@ -121,9 +118,7 @@ export class ProductEventSender {
     const event = productEventFromWire({ name, at: this.#now(), properties });
     if (!event) return;
     this.#queue.push(event);
-    if (this.#queue.length > this.#queueLimit) {
-      this.#queue.splice(0, this.#queue.length - this.#queueLimit);
-    }
+    this.#trimQueue();
   }
 
   /**
@@ -213,39 +208,32 @@ export class ProductEventSender {
 
   async #send(): Promise<void> {
     if (this.#queue.length === 0) return;
-    const token = await this.#readAccessToken();
-    // Signed out is temporary and nobody's fault, so the queue waits rather
-    // than being spent against a request that cannot authenticate.
-    if (!token) return;
-    // Taken only once a request will actually be made, and gone whatever
-    // becomes of it.
+    // Gone whatever becomes of the request, save for the one end that never
+    // authenticated at all.
     const events = this.#queue.splice(0, PRODUCT_EVENT_BATCH_LIMIT);
-    let response = await this.#post(token, events);
-    if (response?.status === UNAUTHORIZED_STATUS) {
-      await this.#refreshAccount().catch(() => undefined);
-      const refreshed = await this.#readAccessToken();
-      if (refreshed && refreshed !== token) {
-        response = await this.#post(refreshed, events);
-      }
+    const answer = await this.#call.send({
+      method: HTTP_METHOD.POST,
+      path: HOSTED_SERVICE_PATH.EVENTS,
+      headers: {
+        // This sender is the desktop's; the iOS app runs its own Swift
+        // sender and names itself the same way.
+        [PRODUCT_EVENT_CLIENT_HEADER]: PRODUCT_EVENT_CLIENT.DESKTOP,
+      },
+      body: JSON.stringify({ events }),
+    });
+    // Signed out is temporary and nobody's fault, and nothing was asked of the
+    // service, so the batch waits rather than being spent. An account that
+    // changed under a refreshed token is not that case: those counts were
+    // queued by an account this request can no longer name, and they go.
+    if (!callAnswered(answer) && answer.fault === CALL_FAULT.NO_CREDENTIAL) {
+      this.#queue.unshift(...events);
+      this.#trimQueue();
     }
   }
 
-  async #post(token: string, events: readonly ProductEvent[]): Promise<Response | undefined> {
-    try {
-      return await this.#fetch(this.#endpoint, {
-        method: "POST",
-        headers: {
-          authorization: `Bearer ${token}`,
-          "content-type": "application/json",
-          // This sender is the desktop's; the iOS app runs its own Swift
-          // sender and names itself the same way.
-          [PRODUCT_EVENT_CLIENT_HEADER]: PRODUCT_EVENT_CLIENT.DESKTOP,
-        },
-        body: JSON.stringify({ events }),
-        signal: AbortSignal.timeout(this.#requestTimeoutMs),
-      });
-    } catch {
-      return undefined;
+  #trimQueue(): void {
+    if (this.#queue.length > this.#queueLimit) {
+      this.#queue.splice(0, this.#queue.length - this.#queueLimit);
     }
   }
 }

--- a/packages/brain/src/client.test.ts
+++ b/packages/brain/src/client.test.ts
@@ -2,11 +2,12 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { HOSTED_BRAIN_CONTRACT_VERSION, HOSTED_SERVICE_PATH } from "@sidecar/hosted";
 import { MODEL_FAILURE, MODEL_RESPONSE_OUTCOME } from "@sidecar/runtime/vocabulary";
-import { HostedBrainTransport, KeyedBrainTransport } from "./client.js";
+import { HTTP_METHOD } from "@sidecar/wire";
+import { hostedBrainTransport, keyedBrainTransport } from "./client.js";
 import {
   BRAIN_RATE_LIMIT_COOLDOWN_MS,
   BRAIN_RATE_LIMIT_RETRY_AFTER_BOUND_MS,
-  HTTP_METHOD,
+  BRAIN_REQUEST_TIMEOUT_MS,
 } from "./model-adapter-shared.js";
 
 const NOW = 1_800_000_000_000;
@@ -45,7 +46,7 @@ function keyed(answers: readonly (() => Response)[], baseUrl = `${BASE}/v1/`) {
   const { fetch, calls } = recorder(answers);
   return {
     calls,
-    transport: new KeyedBrainTransport({ baseUrl, apiKey: "sk-test", fetch, now: () => NOW }),
+    transport: keyedBrainTransport({ baseUrl, apiKey: "sk-test", fetch, now: () => NOW }),
   };
 }
 
@@ -57,7 +58,7 @@ function hosted(
   const queue = [...tokens];
   let current = queue.shift();
   const refreshes: number[] = [];
-  const transport = new HostedBrainTransport({
+  const transport = hostedBrainTransport({
     baseUrl: BASE,
     readAccessToken: () => Promise.resolve(current),
     refreshAccount: () => {
@@ -98,7 +99,7 @@ test("the run's own cancellation is joined with the per-request timeout, and nei
 });
 
 test("a fetch that throws is a network failure named by the error's kind alone, never by its words", async () => {
-  const transport = new KeyedBrainTransport({
+  const transport = keyedBrainTransport({
     baseUrl: BASE,
     apiKey: "sk-secret-key",
     fetch: () => Promise.reject(new TypeError("sk-secret-key was refused by dns")),
@@ -124,23 +125,24 @@ test("the keyed transport sends one attempt and never refreshes; no account toke
   assert.deepEqual(signedOut.calls, []);
 });
 
-test("a hosted attempt refused once is refreshed and retried once; a refresh that changes nothing lets the refusal stand", async () => {
-  const retried = hosted(
-    [() => new Response("", { status: 401 }), () => Response.json({ ok: true })],
-    ["stale", "fresh"],
-  );
-  const answer = await retried.transport.send("/responses", HTTP_METHOD.POST, "{}");
-  assert.ok(answer instanceof Response && answer.ok);
-  assert.deepEqual(
-    retried.calls.map((call) => call.authorization),
-    ["Bearer stale", "Bearer fresh"],
-  );
-
+test("a refusal that outlived a renewed token is the caller's to read, not a failure of its own", async () => {
   const unchanged = hosted([() => new Response("", { status: 401 })], ["only"]);
   const refusal = await unchanged.transport.send("/responses", HTTP_METHOD.POST, "{}");
   assert.ok(refusal instanceof Response && refusal.status === 401);
-  assert.equal(unchanged.calls.length, 1);
   assert.equal(unchanged.refreshes.length, 1);
+});
+
+test("the brain asks for its own deadline, and an explicit one replaces it", () => {
+  assert.equal(BRAIN_REQUEST_TIMEOUT_MS, 90_000);
+  assert.equal(keyed([]).transport.requestTimeoutMs, BRAIN_REQUEST_TIMEOUT_MS);
+  assert.equal(hosted([]).transport.requestTimeoutMs, BRAIN_REQUEST_TIMEOUT_MS);
+  const tighter = keyedBrainTransport({
+    baseUrl: BASE,
+    apiKey: "sk-test",
+    requestTimeoutMs: 5_000,
+    now: () => NOW,
+  });
+  assert.equal(tighter.requestTimeoutMs, 5_000);
 });
 
 test("a 429 earns the bounded Retry-After or the fixed cooldown on either transport, and a spent allowance waits for its reset", () => {

--- a/packages/brain/src/client.test.ts
+++ b/packages/brain/src/client.test.ts
@@ -12,6 +12,7 @@ import {
 
 const NOW = 1_800_000_000_000;
 const BASE = "https://luke.test";
+const TRANSCRIPT = '{"input":"what the session said"}';
 
 interface Call {
   url: string;
@@ -53,10 +54,13 @@ function keyed(answers: readonly (() => Response)[], baseUrl = `${BASE}/v1/`) {
 function hosted(
   answers: readonly (() => Response)[],
   tokens: (string | undefined)[] = ["token-1"],
+  accounts?: string[],
 ) {
   const { fetch, calls } = recorder(answers);
   const queue = [...tokens];
+  const holders = accounts ? [...accounts] : undefined;
   let current = queue.shift();
+  let holder = holders?.shift();
   const refreshes: number[] = [];
   const transport = hostedBrainTransport({
     baseUrl: BASE,
@@ -64,8 +68,10 @@ function hosted(
     refreshAccount: () => {
       refreshes.push(1);
       current = queue.shift() ?? current;
+      holder = holders?.shift() ?? holder;
       return Promise.resolve();
     },
+    ...(holders ? { readAccountKey: () => Promise.resolve(holder) } : undefined),
     fetch,
     now: () => NOW,
   });
@@ -130,6 +136,18 @@ test("a refusal that outlived a renewed token is the caller's to read, not a fai
   const refusal = await unchanged.transport.send("/responses", HTTP_METHOD.POST, "{}");
   assert.ok(refusal instanceof Response && refusal.status === 401);
   assert.equal(unchanged.refreshes.length, 1);
+});
+
+test("a token refreshed for another account never carries this turn's input", async () => {
+  const crossed = hosted(
+    [() => new Response("", { status: 401 })],
+    ["stale", "fresh"],
+    ["ada@luke.test", "grace@luke.test"],
+  );
+  const failure = await crossed.transport.send("/responses", HTTP_METHOD.POST, TRANSCRIPT);
+  assert.ok(!(failure instanceof Response) && failure.failure === MODEL_FAILURE.CREDENTIAL);
+  assert.equal(crossed.calls.length, 1);
+  assert.equal(crossed.calls[0]?.authorization, "Bearer stale");
 });
 
 test("the brain asks for its own deadline, and an explicit one replaces it", () => {

--- a/packages/brain/src/client.ts
+++ b/packages/brain/src/client.ts
@@ -1,5 +1,12 @@
 import {
+  type AccountCall,
   type AccountToken,
+  accountBearer,
+  CALL_FAULT,
+  type CallCredential,
+  callAnswered,
+  createAccountCall,
+  fixedBearer,
   HOSTED_API_ERROR,
   HOSTED_BRAIN_CONTRACT_VERSION,
   HOSTED_SERVICE_PATH,
@@ -10,20 +17,18 @@ import {
 import { MODEL_FAILURE } from "@sidecar/runtime/vocabulary";
 import {
   type CloudFetch,
+  HTTP_METHOD,
   HTTP_STATUS,
-  positiveInteger,
+  type HttpMethod,
   text,
   type UnparsedWireValue,
   unparsedWire,
   wireRecord,
-  withoutTrailingSlash,
 } from "@sidecar/wire";
 import {
   BRAIN_REQUEST_TIMEOUT_MS,
   type Failure,
   failed,
-  HTTP_METHOD,
-  type HttpMethod,
   notServed,
   payloadOf,
   RETRY_AFTER_HEADER,
@@ -42,47 +47,47 @@ export interface BrainTransportOptions {
 }
 
 /**
- * One call out of the brain, whatever authorizes it: the base URL trimmed
- * once, the bearer header written once, the per-request timeout joined with
- * the caller's own cancellation once, a fetch that throws read as a network
- * failure by the error's kind alone and never by its words, which could carry
- * a key, and one reading of what a 429 means. What a subclass supplies is the
- * credential — a key the developer typed, or the signed-in account's token,
- * which is refreshed once when the first attempt is refused.
+ * One call out of the brain, whatever authorizes it: the account call's own
+ * bearer header, renewal, and single retry, with the two readings that are
+ * the brain's alone — a fault named as the failure kind the host reads, and
+ * what a 429 means. What a factory below supplies is the credential — a key
+ * the developer typed, or the signed-in account's token — and the words a
+ * quiet is reported with.
  */
-abstract class BrainTransport {
-  readonly #baseUrl: string;
+export class BrainTransport {
+  readonly #call: AccountCall;
+  readonly #label: string;
   readonly #now: () => number;
-  readonly #fetch: CloudFetch;
-  readonly #requestTimeoutMs: number;
 
-  protected constructor(options: BrainTransportOptions) {
-    const baseUrl = text(options.baseUrl);
-    if (!baseUrl) throw new Error("Brain transport base URL must not be empty");
-    this.#baseUrl = withoutTrailingSlash(baseUrl);
-    this.#fetch = options.fetch ?? ((input, init) => fetch(input, init));
+  constructor(
+    options: BrainTransportOptions & {
+      credential: CallCredential;
+      /** The words a quiet is reported with, which name the transport the developer is on. */
+      label: string;
+    },
+  ) {
+    this.#call = createAccountCall({
+      baseUrl: options.baseUrl,
+      credential: options.credential,
+      fetch: options.fetch,
+      // A turn may read a transcript, reason over it, and act, so the brain
+      // asks for its own deadline rather than the ten seconds a settings row
+      // would wait.
+      requestTimeoutMs: options.requestTimeoutMs ?? BRAIN_REQUEST_TIMEOUT_MS,
+    });
+    this.#label = options.label;
     this.#now = options.now ?? Date.now;
-    this.#requestTimeoutMs = positiveInteger(options.requestTimeoutMs, BRAIN_REQUEST_TIMEOUT_MS);
   }
 
-  /** The words a quiet is reported with, which name the transport the developer is on. */
-  protected abstract readonly label: string;
-
-  /** The authorization header for one attempt, or nothing when there is no credential to send. */
-  protected abstract authorization(): Promise<string | undefined>;
-
-  /** Asks whoever owns the credential to renew it; a transport with nothing to renew does nothing. */
-  protected renewCredential(): Promise<void> {
-    return Promise.resolve();
+  /** The deadline every request of this transport is under. */
+  get requestTimeoutMs(): number {
+    return this.#call.requestTimeoutMs;
   }
 
   /**
-   * One authorized request. No credential at all and a fetch that did not
-   * complete are already ends, named by kind; every status is the caller's to
-   * read, including the refusal that outlived a renewed credential.
-   *
-   * A refusal is retried exactly once, and only on a credential that actually
-   * changed: retrying the same one would only repeat the no.
+   * One authorized request. A call that never reached the service is already
+   * an end, named by kind; every status is the caller's to read, including
+   * the refusal that outlived a renewed credential.
    */
   async send(
     path: string,
@@ -90,17 +95,16 @@ abstract class BrainTransport {
     body?: string,
     signal?: AbortSignal,
   ): Promise<Response | Failure> {
-    const authorization = await this.authorization();
-    if (!authorization) return failed(MODEL_FAILURE.CREDENTIAL, "no account token");
-    const response = await this.#attempt(path, method, authorization, body, signal);
-    if (!(response instanceof Response) || response.status !== HTTP_STATUS.UNAUTHORIZED) {
-      return response;
+    const answer = await this.#call.send({ path, method, body, signal });
+    if (callAnswered(answer)) return answer.response;
+    switch (answer.fault) {
+      case CALL_FAULT.NO_CREDENTIAL:
+        return failed(MODEL_FAILURE.CREDENTIAL, "no account token");
+      case CALL_FAULT.HOLDER_CHANGED:
+        return failed(MODEL_FAILURE.CREDENTIAL, "the account changed mid-call");
+      case CALL_FAULT.NETWORK:
+        return requestFault(answer.errorName);
     }
-    await this.renewCredential();
-    const renewed = await this.authorization();
-    return renewed === undefined || renewed === authorization
-      ? response
-      : this.#attempt(path, method, renewed, body, signal);
   }
 
   /**
@@ -119,70 +123,14 @@ abstract class BrainTransport {
     if (resetsAt !== undefined && resetsAt > this.#now()) {
       return {
         until: resetsAt,
-        message: `${this.label} are out of today's allowance; pausing for ${Math.round((resetsAt - this.#now()) / 1000)}s`,
+        message: `${this.#label} are out of today's allowance; pausing for ${Math.round((resetsAt - this.#now()) / 1000)}s`,
       };
     }
     const waitMs = rateLimitWaitMs(response.headers.get(RETRY_AFTER_HEADER));
     return {
       until: this.#now() + waitMs,
-      message: `${this.label} are rate limited; pausing for ${Math.round(waitMs / 1000)}s`,
+      message: `${this.#label} are rate limited; pausing for ${Math.round(waitMs / 1000)}s`,
     };
-  }
-
-  async #attempt(
-    path: string,
-    method: HttpMethod,
-    authorization: string,
-    body: string | undefined,
-    signal: AbortSignal | undefined,
-  ): Promise<Response | Failure> {
-    try {
-      return await this.#fetch(`${this.#baseUrl}${path}`, {
-        method,
-        headers: {
-          authorization,
-          ...(body !== undefined ? { "content-type": "application/json" } : undefined),
-        },
-        ...(body !== undefined ? { body } : undefined),
-        signal: requestSignal(this.#requestTimeoutMs, signal),
-      });
-    } catch (error) {
-      return requestFault(error instanceof Error ? error : undefined);
-    }
-  }
-}
-
-/** The developer's own key straight to the provider: one header, one attempt, nothing to refresh. */
-export class KeyedBrainTransport extends BrainTransport {
-  protected readonly label = "OpenAI brain turns";
-  readonly #authorization: string;
-
-  constructor(options: BrainTransportOptions & { apiKey: string }) {
-    super(options);
-    const apiKey = text(options.apiKey);
-    if (!apiKey) throw new Error("OpenAI API key must not be empty");
-    this.#authorization = bearer(apiKey);
-  }
-
-  protected authorization(): Promise<string | undefined> {
-    return Promise.resolve(this.#authorization);
-  }
-}
-
-/**
- * Luke's hosted service on the signed-in account, shared by every adapter
- * that speaks to it: the token read fresh per attempt and refreshed once when
- * the first is refused, and the capabilities read that admits an operation.
- */
-export class HostedBrainTransport extends BrainTransport {
-  protected readonly label = "Hosted brain turns";
-  readonly #readAccessToken: () => Promise<string | undefined>;
-  readonly #refreshAccount: () => Promise<void>;
-
-  constructor(options: BrainTransportOptions & AccountToken) {
-    super(options);
-    this.#readAccessToken = options.readAccessToken;
-    this.#refreshAccount = options.refreshAccount;
   }
 
   /** Reads the service's capabilities; a service that has none, or names another contract, is incompatible. */
@@ -210,24 +158,35 @@ export class HostedBrainTransport extends BrainTransport {
     }
     return capabilities;
   }
-
-  /** Routine expiry of an hour-lived token inside a day-lived app; a refresh that itself fails leaves the refusal standing. */
-  protected override renewCredential(): Promise<void> {
-    return this.#refreshAccount().catch(() => undefined);
-  }
-
-  protected async authorization(): Promise<string | undefined> {
-    const token = await this.#readAccessToken();
-    return token ? bearer(token) : undefined;
-  }
 }
 
-function bearer(credential: string): string {
-  return `Bearer ${credential}`;
+/** The developer's own key straight to the provider: one header, one attempt, nothing to renew. */
+export function keyedBrainTransport(
+  options: BrainTransportOptions & { apiKey: string },
+): BrainTransport {
+  // Destructured rather than spread: the key travels no further than the one
+  // credential that holds it.
+  const { apiKey, ...addressed } = options;
+  const key = text(apiKey);
+  if (!key) throw new Error("OpenAI API key must not be empty");
+  return new BrainTransport({
+    ...addressed,
+    credential: fixedBearer(key),
+    label: "OpenAI brain turns",
+  });
 }
 
-/** The per-request timeout, joined with the run's own cancellation when the call belongs to one. */
-function requestSignal(timeoutMs: number, cancellation: AbortSignal | undefined): AbortSignal {
-  const timeout = AbortSignal.timeout(timeoutMs);
-  return cancellation ? AbortSignal.any([timeout, cancellation]) : timeout;
+/**
+ * Luke's hosted service on the signed-in account, shared by every adapter
+ * that speaks to it: the token read fresh per attempt and refreshed once when
+ * the first is refused, and the capabilities read that admits an operation.
+ */
+export function hostedBrainTransport(
+  options: BrainTransportOptions & AccountToken,
+): BrainTransport {
+  return new BrainTransport({
+    ...options,
+    credential: accountBearer(options),
+    label: "Hosted brain turns",
+  });
 }

--- a/packages/brain/src/embedding-adapters.ts
+++ b/packages/brain/src/embedding-adapters.ts
@@ -17,6 +17,7 @@ import {
 } from "@sidecar/runtime/vocabulary";
 import {
   type CloudFetch,
+  HTTP_METHOD,
   HTTP_STATUS,
   isRecord,
   isWireNumber,
@@ -24,8 +25,8 @@ import {
   numberVectors,
   type UnparsedWireValue,
 } from "@sidecar/wire";
-import { HostedBrainTransport, KeyedBrainTransport } from "./client.js";
-import { failed, HTTP_METHOD, notServed, payloadOf, throttled } from "./model-adapter-shared.js";
+import { type BrainTransport, hostedBrainTransport, keyedBrainTransport } from "./client.js";
+import { failed, notServed, payloadOf, throttled } from "./model-adapter-shared.js";
 import { BRAIN_OPENAI_DEFAULTS } from "./openai-model-adapter.js";
 
 /**
@@ -84,11 +85,11 @@ export interface OpenAiEmbeddingAdapterOptions {
 
 /** The model and endpoint are fixed by the build: the index stores vectors under one model, and a key chooses none. */
 export class OpenAiEmbeddingAdapter implements EmbeddingAdapter {
-  readonly #client: KeyedBrainTransport;
+  readonly #client: BrainTransport;
   #dimensions: number | undefined;
 
   constructor(options: OpenAiEmbeddingAdapterOptions) {
-    this.#client = new KeyedBrainTransport({
+    this.#client = keyedBrainTransport({
       ...options,
       baseUrl: BRAIN_OPENAI_DEFAULTS.BASE_URL,
     });
@@ -146,13 +147,13 @@ export interface HostedEmbeddingAdapterOptions extends AccountToken {
 }
 
 export class HostedEmbeddingAdapter implements EmbeddingAdapter {
-  readonly #client: HostedBrainTransport;
+  readonly #client: BrainTransport;
   #model: string | undefined;
   #dimensions: number | undefined;
   #offered: boolean | undefined;
 
   constructor(options: HostedEmbeddingAdapterOptions) {
-    this.#client = new HostedBrainTransport({ ...options, baseUrl: options.serviceBaseUrl });
+    this.#client = hostedBrainTransport({ ...options, baseUrl: options.serviceBaseUrl });
   }
 
   identity(): Promise<EmbeddingIdentity> {

--- a/packages/brain/src/guarantees.test.ts
+++ b/packages/brain/src/guarantees.test.ts
@@ -3,9 +3,15 @@ import test from "node:test";
 import { RESPONSES_INPUT_ITEM_TYPE } from "@sidecar/hosted";
 import { RUN_ORIGIN } from "@sidecar/runtime/vocabulary";
 import { OMISSION_MARKER } from "@sidecar/session";
-import { ACTION_RESULT_STATUS, isWireString, unparsedWire, wireRecord } from "@sidecar/wire";
+import {
+  ACTION_RESULT_STATUS,
+  HTTP_METHOD,
+  isWireString,
+  unparsedWire,
+  wireRecord,
+} from "@sidecar/wire";
 import { LOOK_SUBJECT } from "./agent.js";
-import { HostedBrainTransport, KeyedBrainTransport } from "./client.js";
+import { hostedBrainTransport, keyedBrainTransport } from "./client.js";
 import {
   BRAIN_GENERATION_LIFETIME_MS,
   BRAIN_STATE_VERSION,
@@ -42,7 +48,6 @@ import {
   TRANSCRIPT_SECRET,
   UNKNOWN,
 } from "./harness.js";
-import { HTTP_METHOD } from "./model-adapter-shared.js";
 import { INBOX_CAPACITY } from "./observation-inbox.js";
 import {
   BRAIN_REQUEST_STATUS,
@@ -487,13 +492,13 @@ test("a brain call is addressed to the developer's own key or to Luke's own serv
     addressed.push(url);
     return Promise.resolve(Response.json({}));
   };
-  const keyed = new KeyedBrainTransport({
+  const keyed = keyedBrainTransport({
     baseUrl: "https://api.openai.test/v1",
     apiKey: "sk-secret",
     fetch,
     now: () => NOW,
   });
-  const service = new HostedBrainTransport({
+  const service = hostedBrainTransport({
     baseUrl: "https://luke.test",
     readAccessToken: () => Promise.resolve("account-secret"),
     refreshAccount: () => Promise.resolve(),

--- a/packages/brain/src/hosted-model-adapter.ts
+++ b/packages/brain/src/hosted-model-adapter.ts
@@ -24,16 +24,16 @@ import {
 } from "@sidecar/runtime/vocabulary";
 import {
   type CloudFetch,
+  HTTP_METHOD,
   HTTP_STATUS,
   type UnparsedWireValue,
   type WireRecord,
 } from "@sidecar/wire";
-import { HostedBrainTransport } from "./client.js";
+import { type BrainTransport, hostedBrainTransport } from "./client.js";
 import { COMPACTION_POLICY } from "./compaction.js";
 import {
   type Failure,
   failed,
-  HTTP_METHOD,
   type Normalized,
   notServed,
   payloadOf,
@@ -74,11 +74,11 @@ const HOSTED_PATH = {
  */
 class HostedTransport implements ResponsesTransport<HostedBrainCapabilities> {
   readonly adapter = BUILTIN_MODEL_ADAPTER.HOSTED;
-  readonly #client: HostedBrainTransport;
+  readonly #client: BrainTransport;
   #capabilities: HostedBrainCapabilities | undefined;
 
   constructor(options: HostedModelAdapterOptions) {
-    this.#client = new HostedBrainTransport({ ...options, baseUrl: options.serviceBaseUrl });
+    this.#client = hostedBrainTransport({ ...options, baseUrl: options.serviceBaseUrl });
   }
 
   /** The service's model, once capabilities have been read; the service's to know until then. */

--- a/packages/brain/src/model-adapter-shared.ts
+++ b/packages/brain/src/model-adapter-shared.ts
@@ -17,13 +17,6 @@ export const BRAIN_REQUEST_TIMEOUT_MS = 90_000;
  * transport, the cooldown a rate limit earns, and the shapes of a failure.
  */
 
-export const HTTP_METHOD = {
-  GET: "GET",
-  POST: "POST",
-} as const;
-
-export type HttpMethod = (typeof HTTP_METHOD)[keyof typeof HTTP_METHOD];
-
 export const RETRY_AFTER_HEADER = "retry-after";
 
 /**
@@ -70,11 +63,8 @@ export type Failure = ReturnType<typeof failed>;
 export type Normalized = Failure | ReturnType<typeof throttled>;
 
 /** A network fault or a timeout, named by the error's kind alone, never its words, which could carry a key. */
-export function requestFault(error: Error | undefined) {
-  return failed(
-    MODEL_FAILURE.NETWORK,
-    `request did not complete: ${error?.name ?? "unknown error"}`,
-  );
+export function requestFault(errorName: string | undefined) {
+  return failed(MODEL_FAILURE.NETWORK, `request did not complete: ${errorName ?? "unknown error"}`);
 }
 
 /** Whether the service answered that it does not serve the path at all, as distinct from refusing the call. */

--- a/packages/brain/src/openai-model-adapter.ts
+++ b/packages/brain/src/openai-model-adapter.ts
@@ -6,14 +6,13 @@ import {
   REASONING_EFFORT,
   type ReasoningEffort,
 } from "@sidecar/runtime/vocabulary";
-import { type CloudFetch, HTTP_STATUS, text, type WireRecord } from "@sidecar/wire";
-import { KeyedBrainTransport } from "./client.js";
+import { type CloudFetch, HTTP_METHOD, HTTP_STATUS, text, type WireRecord } from "@sidecar/wire";
+import { type BrainTransport, keyedBrainTransport } from "./client.js";
 import { COMPACTION_POLICY } from "./compaction.js";
 import {
   BRAIN_MAXIMUM_OUTPUT_TOKENS,
   BRAIN_REQUEST_TIMEOUT_MS,
   failed,
-  HTTP_METHOD,
 } from "./model-adapter-shared.js";
 import {
   BRAIN_RESPONSES_COMPACT_PATH,
@@ -85,12 +84,12 @@ class OpenAiTransport implements ResponsesTransport<undefined> {
   readonly adapter = BUILTIN_MODEL_ADAPTER.OPENAI;
   readonly #model: string;
   readonly #reasoningEffort: ReasoningEffort;
-  readonly #client: KeyedBrainTransport;
+  readonly #client: BrainTransport;
 
   constructor(options: OpenAiModelAdapterOptions) {
     this.#model = text(options.model) ?? BRAIN_OPENAI_DEFAULTS.MODEL;
     this.#reasoningEffort = options.reasoningEffort ?? BRAIN_OPENAI_DEFAULTS.REASONING_EFFORT;
-    this.#client = new KeyedBrainTransport({
+    this.#client = keyedBrainTransport({
       ...options,
       baseUrl: text(options.baseUrl) ?? BRAIN_OPENAI_DEFAULTS.BASE_URL,
     });

--- a/packages/host/src/account-preferences-client.test.ts
+++ b/packages/host/src/account-preferences-client.test.ts
@@ -98,40 +98,7 @@ test("a malformed account preferences payload never travels", async () => {
   assert.equal(requests.length, 0);
 });
 
-test("a 401 refreshes the account and retries once on the new token", async () => {
-  const tokens = ["token-1", "token-2"];
-  let refreshes = 0;
-  const { requests, fetchLike } = service([
-    () => new Response(JSON.stringify({ error: "invalid-token" }), { status: 401 }),
-    () => new Response(JSON.stringify(PREFERENCES_ANSWER), { status: 200 }),
-  ]);
-
-  const answer = await client({
-    fetch: fetchLike,
-    readAccessToken: async () => tokens.shift(),
-    refreshAccount: async () => {
-      refreshes += 1;
-    },
-  }).readPreferences();
-
-  assert.deepEqual(answer, {
-    preferences: PREFERENCES_ANSWER.preferences,
-    hasStoredSnapshot: true,
-  });
-  assert.equal(refreshes, 1);
-  assert.equal(requests.length, 2);
-  assert.equal(new Headers(requests[1]?.init?.headers).get("authorization"), "Bearer token-2");
-});
-
-test("failures, malformed answers, and a missing account read as no answer", async () => {
-  const failing = client({
-    fetch: async () => {
-      throw new Error("offline");
-    },
-  });
-  assert.equal(await failing.readPreferences(), undefined);
-  assert.equal(await failing.writePreferences({ voice: "sage" }), undefined);
-
+test("a refusal and a snapshot the settings vocabulary does not admit read as no answer", async () => {
   const refused = client({
     fetch: async () => new Response(JSON.stringify({ error: "unavailable" }), { status: 503 }),
   });
@@ -141,6 +108,7 @@ test("failures, malformed answers, and a missing account read as no answer", asy
     fetch: async () => new Response(JSON.stringify({ preferences: "none" }), { status: 200 }),
   });
   assert.equal(await malformed.readPreferences(), undefined);
+
   const unknownField = client({
     fetch: async () =>
       new Response(JSON.stringify({ preferences: { voiceHotkey: "Command+Space" } }), {
@@ -148,15 +116,4 @@ test("failures, malformed answers, and a missing account read as no answer", asy
       }),
   });
   assert.equal(await unknownField.readPreferences(), undefined);
-
-  const requests: RecordedRequest[] = [];
-  const signedOut = client({
-    fetch: async (url, init) => {
-      requests.push({ url, init });
-      return new Response(JSON.stringify(PREFERENCES_ANSWER), { status: 200 });
-    },
-    readAccessToken: async () => undefined,
-  });
-  assert.equal(await signedOut.readPreferences(), undefined);
-  assert.equal(requests.length, 0);
 });

--- a/packages/host/src/account-preferences-client.ts
+++ b/packages/host/src/account-preferences-client.ts
@@ -1,41 +1,29 @@
-import type { FetchLike } from "@sidecar/credentials";
-import { HOSTED_SERVICE_PATH } from "@sidecar/hosted";
+import {
+  type AccountCall,
+  type AccountToken,
+  accountBearer,
+  createAccountCall,
+  HOSTED_SERVICE_PATH,
+} from "@sidecar/hosted";
 import { type AccountPreferences, accountPreferencesFromWire } from "@sidecar/settings";
 import {
+  type CloudFetch,
+  HTTP_METHOD,
   isRecord,
   isWireNumber,
-  positiveInteger,
-  text,
   type UnparsedWireValue,
-  unparsedWire,
-  withoutTrailingSlash,
 } from "@sidecar/wire";
-
-const PREFERENCES_DEFAULTS = {
-  REQUEST_TIMEOUT_MS: 10_000,
-} as const;
-
-const UNAUTHORIZED_STATUS = 401;
 
 export interface AccountPreferencesAnswer {
   preferences: AccountPreferences;
   hasStoredSnapshot: boolean;
 }
 
-export interface AccountPreferencesClientOptions {
+export interface AccountPreferencesClientOptions extends AccountToken {
   /** The hosted service origin, without a trailing slash. */
   serviceBaseUrl: string;
-  readAccessToken: () => Promise<string | undefined>;
-  refreshAccount: () => Promise<void>;
-  readAccountKey?: () => Promise<string | undefined>;
-  fetch?: FetchLike;
+  fetch?: CloudFetch;
   requestTimeoutMs?: number;
-}
-
-interface AccountPreferencesRequest {
-  method: "GET" | "PUT";
-  path: string;
-  body?: Record<string, UnparsedWireValue>;
 }
 
 function accountPreferencesAnswerFromWire(
@@ -54,82 +42,39 @@ function accountPreferencesAnswerFromWire(
 /**
  * Reads and writes the account preference snapshot. The local store decides
  * which settings are eligible to travel; this client validates the service's
- * answer and refreshes the bearer once on expiry, matching the hosted vault.
+ * answer, and the account call behind it is the same one every hosted client
+ * makes its requests through.
  */
 export class AccountPreferencesClient {
-  readonly #baseUrl: string;
-  readonly #readAccessToken: () => Promise<string | undefined>;
-  readonly #refreshAccount: () => Promise<void>;
-  readonly #readAccountKey?: () => Promise<string | undefined>;
-  readonly #fetch: FetchLike;
-  readonly #requestTimeoutMs: number;
+  readonly #call: AccountCall;
 
   constructor(options: AccountPreferencesClientOptions) {
-    const baseUrl = text(options.serviceBaseUrl);
-    if (!baseUrl) throw new Error("Hosted service base URL must not be empty");
-    this.#baseUrl = withoutTrailingSlash(baseUrl);
-    this.#readAccessToken = options.readAccessToken;
-    this.#refreshAccount = options.refreshAccount;
-    if (options.readAccountKey) this.#readAccountKey = options.readAccountKey;
-    this.#fetch = options.fetch ?? ((input, init) => fetch(input, init));
-    this.#requestTimeoutMs = positiveInteger(
-      options.requestTimeoutMs,
-      PREFERENCES_DEFAULTS.REQUEST_TIMEOUT_MS,
-    );
+    this.#call = createAccountCall({
+      baseUrl: options.serviceBaseUrl,
+      credential: accountBearer(options),
+      fetch: options.fetch,
+      requestTimeoutMs: options.requestTimeoutMs,
+    });
   }
 
   readPreferences(): Promise<AccountPreferencesAnswer | undefined> {
-    return this.#ask({ method: "GET", path: HOSTED_SERVICE_PATH.ACCOUNT_PREFERENCES });
+    return this.#call.ask(
+      { method: HTTP_METHOD.GET, path: HOSTED_SERVICE_PATH.ACCOUNT_PREFERENCES },
+      accountPreferencesAnswerFromWire,
+    );
   }
 
   writePreferences(preferences: AccountPreferences): Promise<AccountPreferencesAnswer | undefined> {
     // SAFETY: AccountPreferences is JSON-compatible; the strict parser protects this runtime boundary.
     const parsed = accountPreferencesFromWire(preferences as UnparsedWireValue);
     if (parsed === undefined) return Promise.resolve(undefined);
-    return this.#ask({
-      method: "PUT",
-      path: HOSTED_SERVICE_PATH.ACCOUNT_PREFERENCES,
-      // SAFETY: The strict parser accepted this as a wire-shaped account preference object.
-      body: { preferences: parsed as UnparsedWireValue },
-    });
-  }
-
-  async #ask(request: AccountPreferencesRequest): Promise<AccountPreferencesAnswer | undefined> {
-    const account = await this.#readAccountKey?.();
-    const token = await this.#readAccessToken();
-    if (!token) return undefined;
-
-    let response = await this.#request(request, token);
-    if (response?.status === UNAUTHORIZED_STATUS) {
-      await this.#refreshAccount().catch(() => undefined);
-      const refreshed = await this.#readAccessToken();
-      const sameAccount =
-        this.#readAccountKey === undefined || (await this.#readAccountKey()) === account;
-      if (refreshed && refreshed !== token && sameAccount) {
-        response = await this.#request(request, refreshed);
-      }
-    }
-    if (!response?.ok) return undefined;
-
-    const payload = await response.json().catch(() => undefined);
-    return payload === undefined
-      ? undefined
-      : accountPreferencesAnswerFromWire(unparsedWire(payload));
-  }
-
-  async #request(request: AccountPreferencesRequest, token: string): Promise<Response | undefined> {
-    try {
-      return await this.#fetch(`${this.#baseUrl}${request.path}`, {
-        method: request.method,
-        headers: {
-          authorization: `Bearer ${token}`,
-          ...(request.body ? { "content-type": "application/json" } : undefined),
-        },
-        ...(request.body ? { body: JSON.stringify(request.body) } : undefined),
-        signal: AbortSignal.timeout(this.#requestTimeoutMs),
-      });
-    } catch {
-      return undefined;
-    }
+    return this.#call.ask(
+      {
+        method: HTTP_METHOD.PUT,
+        path: HOSTED_SERVICE_PATH.ACCOUNT_PREFERENCES,
+        body: JSON.stringify({ preferences: parsed }),
+      },
+      accountPreferencesAnswerFromWire,
+    );
   }
 }

--- a/packages/host/src/compose-settings.ts
+++ b/packages/host/src/compose-settings.ts
@@ -116,6 +116,7 @@ export function composeSettings(dependencies: SettingsDependencies): SettingsCom
     sends: runMode.sendsNetwork,
     readAccessToken: async () => (await store.readAccount())?.accessToken,
     refreshAccount: () => links.get().refreshAccount(),
+    readAccountKey: async () => (await store.readAccount())?.email,
   });
   const hostedVault = new HostedVaultClient({
     serviceBaseUrl: kernel.hostedServiceBaseUrl,

--- a/packages/hosted/AGENTS.md
+++ b/packages/hosted/AGENTS.md
@@ -24,7 +24,9 @@ trimmed once, the bearer header written once, the deadline joined with the
 caller's own cancellation, a fetch that threw read as a fault by the error's
 kind alone, and the one reading of a 401 — renew the credential, retry
 exactly once, only on a credential that changed, and only while it still
-answers for the same holder. It holds no credential itself: a
+answers for the same holder. It answers rather than throws, including when
+the credential itself could not be read: a caller that took work off a queue
+to send it has to be able to put it back. It holds no credential itself: a
 `CallCredential` is handed in (`accountBearer` for the signed-in account,
 `fixedBearer` for a key, `NO_CREDENTIAL` for an endpoint that takes no
 identity at all), so who may renew a credential and who may say which account

--- a/packages/hosted/AGENTS.md
+++ b/packages/hosted/AGENTS.md
@@ -15,6 +15,24 @@ account preference client in `@sidecar/host` because the snapshot it carries is
 settings vocabulary, and realtime credential lifecycle depends on this package
 rather than being imported by it.
 
+## One call stands behind all of them
+
+`account-call.ts` is the request every caller to Luke's own service makes,
+here rather than beside any one of them because this is the lowest package
+they all reach. It owns what each of them used to restate: the base address
+trimmed once, the bearer header written once, the deadline joined with the
+caller's own cancellation, a fetch that threw read as a fault by the error's
+kind alone, and the one reading of a 401 — renew the credential, retry
+exactly once, only on a credential that changed, and only while it still
+answers for the same holder. It holds no credential itself: a
+`CallCredential` is handed in (`accountBearer` for the signed-in account,
+`fixedBearer` for a key, `NO_CREDENTIAL` for an endpoint that takes no
+identity at all), so who may renew a credential and who may say which account
+it answers for stay their owners' to know. What a caller keeps is its own
+vocabulary and its own reading of a status: `ask` for a caller that wants a
+validated body or nothing, `send` for one that reads the status itself.
+`device-client.ts` still carries its own copy of that dance.
+
 A renamed wire field keeps its old name on the wire for one iOS release. The
 desktop and the service ship together, but an installed phone reads whatever
 the service sends until its owner updates it, so the service writes both names

--- a/packages/hosted/src/account-call.test.ts
+++ b/packages/hosted/src/account-call.test.ts
@@ -138,6 +138,21 @@ test("a credential that reads nothing asks the service nothing at all", async ()
   assert.deepEqual(requests, []);
 });
 
+test("a credential the store could not read is a call that was never made, not a throw", async () => {
+  const { call, requests } = callOn(
+    {
+      authorization: () => Promise.reject(new Error("the settings file could not be read")),
+      renew: () => Promise.resolve(),
+    },
+    () => jsonResponse({}),
+  );
+
+  const answer = await call.send({ method: HTTP_METHOD.POST, path: PATH, body: "{}" });
+
+  assert.ok(!callAnswered(answer) && answer.fault === CALL_FAULT.NO_CREDENTIAL);
+  assert.deepEqual(requests, []);
+});
+
 test("an endpoint that takes no identity is asked without a header, and its own 401 is no fault of a credential", async () => {
   const { call, requests } = callOn(NO_CREDENTIAL, () => refusal());
 

--- a/packages/hosted/src/account-call.test.ts
+++ b/packages/hosted/src/account-call.test.ts
@@ -1,0 +1,249 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { HTTP_METHOD, type UnparsedWireValue } from "@sidecar/wire";
+import {
+  HTTP_STATUS,
+  jsonResponse,
+  type RecordedRequest,
+  recordedRequest,
+  recordingFetch,
+} from "@sidecar/wire/testing";
+import {
+  accountBearer,
+  CALL_FAULT,
+  type CallCredential,
+  callAnswered,
+  createAccountCall,
+  fixedBearer,
+  NO_CREDENTIAL,
+} from "./account-call.js";
+
+const BASE_URL = "https://luke.test";
+const PATH = "/api/account/preferences";
+
+function refusal(): Response {
+  return jsonResponse({ error: "invalid-token" }, HTTP_STATUS.UNAUTHORIZED);
+}
+
+/** An account whose token the test moves, and whose holder it can move too. */
+function account(tokens: (string | undefined)[], holders?: (string | undefined)[]) {
+  const renewals: string[] = [];
+  let token = tokens.shift();
+  let holder = holders?.shift();
+  return {
+    renewals,
+    credential: accountBearer({
+      readAccessToken: () => Promise.resolve(token),
+      refreshAccount: () => {
+        renewals.push("renewed");
+        token = tokens.shift() ?? token;
+        holder = holders === undefined ? holder : (holders.shift() ?? holder);
+        return Promise.resolve();
+      },
+      ...(holders ? { readAccountKey: () => Promise.resolve(holder) } : undefined),
+    }),
+  };
+}
+
+function callOn(
+  credential: CallCredential,
+  respond: (request: RecordedRequest) => Response | Promise<Response>,
+  requestTimeoutMs?: number,
+) {
+  const { fetch, requests } = recordingFetch(respond);
+  return {
+    requests,
+    call: createAccountCall({ baseUrl: `${BASE_URL}/`, credential, fetch, requestTimeoutMs }),
+  };
+}
+
+test("the base address is trimmed once and a body is what names a content type", async () => {
+  const { call, requests } = callOn(fixedBearer("sk-test"), () => jsonResponse({}));
+
+  await call.send({ method: HTTP_METHOD.PUT, path: PATH, body: '{"a":1}' });
+  await call.send({ method: HTTP_METHOD.GET, path: PATH });
+
+  assert.equal(recordedRequest(requests).url, `${BASE_URL}${PATH}`);
+  assert.equal(recordedRequest(requests).method, HTTP_METHOD.PUT);
+  assert.equal(recordedRequest(requests).authorization, "Bearer sk-test");
+  assert.equal(recordedRequest(requests).contentType, "application/json");
+  assert.equal(recordedRequest(requests).body, '{"a":1}');
+  assert.equal(recordedRequest(requests, 1).contentType, undefined);
+  assert.equal(recordedRequest(requests, 1).body, undefined);
+  assert.equal(call.address(PATH), `${BASE_URL}${PATH}`);
+});
+
+test("a header the build fixes travels, and cannot displace the authorization", async () => {
+  const { call, requests } = callOn(fixedBearer("sk-test"), () => jsonResponse({}));
+
+  await call.send({
+    method: HTTP_METHOD.POST,
+    path: PATH,
+    body: "{}",
+    headers: { "x-luke-client": "desktop", authorization: "Bearer forged" },
+  });
+
+  assert.equal(recordedRequest(requests).headers.get("x-luke-client"), "desktop");
+  assert.equal(recordedRequest(requests).authorization, "Bearer sk-test");
+});
+
+test("a 401 renews the credential and retries once, on the credential that changed", async () => {
+  const { credential, renewals } = account(["stale", "fresh"]);
+  const { call, requests } = callOn(credential, (request) =>
+    request.authorization === "Bearer fresh" ? jsonResponse({ ok: true }) : refusal(),
+  );
+
+  const answer = await call.send({ method: HTTP_METHOD.GET, path: PATH });
+
+  assert.ok(callAnswered(answer) && answer.response.ok);
+  assert.deepEqual(
+    requests.map((request) => request.authorization),
+    ["Bearer stale", "Bearer fresh"],
+  );
+  assert.equal(renewals.length, 1);
+});
+
+test("a renewal that produced the same credential, or none at all, leaves the refusal standing", async () => {
+  const unchanged = account(["only"]);
+  const stuck = callOn(unchanged.credential, () => refusal());
+  const standing = await stuck.call.send({ method: HTTP_METHOD.GET, path: PATH });
+  assert.ok(callAnswered(standing) && standing.response.status === HTTP_STATUS.UNAUTHORIZED);
+  assert.equal(stuck.requests.length, 1);
+  assert.equal(unchanged.renewals.length, 1);
+
+  const signedOut = account(["held", undefined]);
+  const gone = callOn(signedOut.credential, () => refusal());
+  const answer = await gone.call.send({ method: HTTP_METHOD.GET, path: PATH });
+  assert.ok(callAnswered(answer) && answer.response.status === HTTP_STATUS.UNAUTHORIZED);
+  assert.equal(gone.requests.length, 1);
+
+  const failing = createAccountCall({
+    baseUrl: BASE_URL,
+    credential: {
+      authorization: () => Promise.resolve("Bearer held"),
+      renew: () => Promise.reject(new Error("the network is down")),
+    },
+    fetch: () => Promise.resolve(refusal()),
+  });
+  const refused = await failing.send({ method: HTTP_METHOD.GET, path: PATH });
+  assert.ok(callAnswered(refused) && refused.response.status === HTTP_STATUS.UNAUTHORIZED);
+});
+
+test("a credential that reads nothing asks the service nothing at all", async () => {
+  const { call, requests } = callOn(account([undefined]).credential, () => jsonResponse({}));
+
+  const answer = await call.send({ method: HTTP_METHOD.GET, path: PATH });
+
+  assert.ok(!callAnswered(answer) && answer.fault === CALL_FAULT.NO_CREDENTIAL);
+  assert.deepEqual(requests, []);
+});
+
+test("an endpoint that takes no identity is asked without a header, and its own 401 is no fault of a credential", async () => {
+  const { call, requests } = callOn(NO_CREDENTIAL, () => refusal());
+
+  const answer = await call.send({ method: HTTP_METHOD.POST, path: PATH, body: "{}" });
+
+  assert.ok(callAnswered(answer) && answer.response.status === HTTP_STATUS.UNAUTHORIZED);
+  assert.equal(requests.length, 1);
+  assert.equal(recordedRequest(requests).authorization, undefined);
+});
+
+test("a holder that changed between the attempt and its retry refuses the retry", async () => {
+  const { credential, renewals } = account(
+    ["stale", "fresh"],
+    ["ada@luke.test", "grace@luke.test"],
+  );
+  const { call, requests } = callOn(credential, () => refusal());
+
+  const answer = await call.send({ method: HTTP_METHOD.POST, path: PATH, body: "{}" });
+
+  assert.ok(!callAnswered(answer) && answer.fault === CALL_FAULT.HOLDER_CHANGED);
+  assert.equal(renewals.length, 1);
+  assert.deepEqual(
+    requests.map((request) => request.authorization),
+    ["Bearer stale"],
+  );
+});
+
+test("a holder that stands is retried under the credential that changed", async () => {
+  const { credential } = account(["stale", "fresh"], ["ada@luke.test"]);
+  const { call, requests } = callOn(credential, (request) =>
+    request.authorization === "Bearer fresh" ? jsonResponse({ ok: true }) : refusal(),
+  );
+
+  const answer = await call.send({ method: HTTP_METHOD.GET, path: PATH });
+
+  assert.ok(callAnswered(answer) && answer.response.ok);
+  assert.equal(requests.length, 2);
+});
+
+test("a fetch that throws is a network fault named by the error's kind alone, never its words", async () => {
+  const { call } = callOn(fixedBearer("sk-secret-key"), () => {
+    throw new TypeError("sk-secret-key was refused by dns");
+  });
+
+  const answer = await call.send({ method: HTTP_METHOD.GET, path: PATH });
+
+  assert.ok(!callAnswered(answer) && answer.fault === CALL_FAULT.NETWORK);
+  assert.equal(answer.errorName, "TypeError");
+});
+
+test("an ask reads a validated body, and a fault, a refusal, or a body that is not JSON is no answer", async () => {
+  const read = (payload: UnparsedWireValue) => (payload === undefined ? undefined : { payload });
+
+  const answered = callOn(fixedBearer("sk-test"), () => jsonResponse({ voice: "marin" }));
+  assert.deepEqual(await answered.call.ask({ method: HTTP_METHOD.GET, path: PATH }, read), {
+    payload: { voice: "marin" },
+  });
+
+  const refused = callOn(fixedBearer("sk-test"), () => refusal());
+  assert.equal(await refused.call.ask({ method: HTTP_METHOD.GET, path: PATH }, read), undefined);
+
+  const unreadable = callOn(fixedBearer("sk-test"), () => new Response("not json"));
+  assert.equal(await unreadable.call.ask({ method: HTTP_METHOD.GET, path: PATH }, read), undefined);
+
+  const offline = callOn(fixedBearer("sk-test"), () => {
+    throw new Error("offline");
+  });
+  assert.equal(await offline.call.ask({ method: HTTP_METHOD.GET, path: PATH }, read), undefined);
+
+  const refusedByReader = callOn(fixedBearer("sk-test"), () => jsonResponse({}));
+  assert.equal(
+    await refusedByReader.call.ask({ method: HTTP_METHOD.GET, path: PATH }, () => undefined),
+    undefined,
+  );
+});
+
+test("the deadline is the one the call was built with, and it ends a request that outlives it", async () => {
+  const asked = callOn(fixedBearer("sk-test"), () => jsonResponse({}));
+  assert.equal(asked.call.requestTimeoutMs, 10_000);
+  assert.equal(
+    callOn(fixedBearer("sk-test"), () => jsonResponse({}), 90_000).call.requestTimeoutMs,
+    90_000,
+  );
+
+  const held = createAccountCall({
+    baseUrl: BASE_URL,
+    credential: fixedBearer("sk-test"),
+    requestTimeoutMs: 1,
+    fetch: (_url, init) =>
+      new Promise((_settle, reject) => {
+        init.signal?.addEventListener("abort", () => reject(init.signal?.reason));
+      }),
+  });
+  const answer = await held.send({ method: HTTP_METHOD.GET, path: PATH });
+  assert.ok(!callAnswered(answer) && answer.fault === CALL_FAULT.NETWORK);
+  assert.equal(answer.errorName, "TimeoutError");
+});
+
+test("the caller's own cancellation is joined with the deadline, and neither alone ends the other", async () => {
+  const cancellation = new AbortController();
+  const { call, requests } = callOn(fixedBearer("sk-test"), () => jsonResponse({}));
+
+  await call.send({ method: HTTP_METHOD.GET, path: PATH, signal: cancellation.signal });
+
+  const signal = recordedRequest(requests).init.signal;
+  assert.ok(signal && !signal.aborted);
+  cancellation.abort();
+  assert.equal(signal.aborted, true);
+});

--- a/packages/hosted/src/account-call.ts
+++ b/packages/hosted/src/account-call.ts
@@ -120,6 +120,11 @@ export interface AccountCall {
   ): Promise<Answer | undefined>;
 }
 
+interface Identity {
+  holder: string | undefined;
+  authorization: string | undefined;
+}
+
 export function createAccountCall(options: AccountCallOptions): AccountCall {
   const baseUrl = text(options.baseUrl);
   if (!baseUrl) throw new Error("A call's base URL must not be empty");
@@ -155,14 +160,29 @@ export function createAccountCall(options: AccountCallOptions): AccountCall {
     }
   }
 
-  async function send(request: CallRequest): Promise<CallAnswer> {
-    const holder = await credential.holder?.();
-    const authorization = await credential.authorization?.();
-    if (credential.authorization && authorization === undefined) {
-      return { fault: CALL_FAULT.NO_CREDENTIAL };
+  /**
+   * Who the credential answers for and what one attempt carries, read
+   * together. A credential that cannot be read at all — a store that failed,
+   * not an account that is absent — reads as nothing rather than throwing,
+   * because a caller that took work off a queue to send it has to be able to
+   * put it back.
+   */
+  async function identify(): Promise<Identity | undefined> {
+    try {
+      const holder = await credential.holder?.();
+      const authorization = await credential.authorization?.();
+      if (credential.authorization && authorization === undefined) return undefined;
+      return { holder, authorization };
+    } catch {
+      return undefined;
     }
+  }
 
-    const answer = await attempt(request, authorization);
+  async function send(request: CallRequest): Promise<CallAnswer> {
+    const identity = await identify();
+    if (!identity) return { fault: CALL_FAULT.NO_CREDENTIAL };
+
+    const answer = await attempt(request, identity.authorization);
     if (!callAnswered(answer) || answer.response.status !== HTTP_STATUS.UNAUTHORIZED) {
       return answer;
     }
@@ -171,12 +191,10 @@ export function createAccountCall(options: AccountCallOptions): AccountCall {
     // that itself fails, or that produced the same credential, leaves the
     // refusal standing: retrying it would only repeat the no.
     await credential.renew?.().catch(() => undefined);
-    const renewed = await credential.authorization?.();
-    if (renewed === undefined || renewed === authorization) return answer;
-    if (credential.holder && (await credential.holder()) !== holder) {
-      return { fault: CALL_FAULT.HOLDER_CHANGED };
-    }
-    return attempt(request, renewed);
+    const renewal = await identify();
+    if (!renewal || renewal.authorization === identity.authorization) return answer;
+    if (renewal.holder !== identity.holder) return { fault: CALL_FAULT.HOLDER_CHANGED };
+    return attempt(request, renewal.authorization);
   }
 
   return {

--- a/packages/hosted/src/account-call.ts
+++ b/packages/hosted/src/account-call.ts
@@ -1,0 +1,223 @@
+import {
+  type CloudFetch,
+  HTTP_STATUS,
+  type HttpMethod,
+  positiveInteger,
+  text,
+  type UnparsedWireValue,
+  unparsedWire,
+  withoutTrailingSlash,
+} from "@sidecar/wire";
+import type { AccountToken } from "./account-token.js";
+
+const ACCOUNT_CALL_DEFAULTS = {
+  REQUEST_TIMEOUT_MS: 10_000,
+} as const;
+
+/**
+ * What authorizes one call, and what may be done about a refusal. Three
+ * members rather than a token, because the three questions a refused call
+ * asks — what header to send, who can renew it, and who it answers for — are
+ * answered by three different owners.
+ */
+export interface CallCredential {
+  /**
+   * The header one attempt carries. A credential with no `authorization` at
+   * all is an endpoint that takes no identity, so an attempt without a header
+   * is its own answer; a credential that has one and reads nothing is a call
+   * that cannot be made.
+   */
+  authorization?: () => Promise<string | undefined>;
+  /** Asks whoever owns the credential to renew it; one with nothing to renew omits this. */
+  renew?: () => Promise<void>;
+  /**
+   * Who the credential answers for, as an opaque identity. Read before an
+   * attempt and again before its one retry, because the retry re-reads the
+   * credential: a sign-out and sign-in between the two must read as the
+   * caller's account gone, never as a fresh bearer to carry the old account's
+   * payload under.
+   */
+  holder?: () => Promise<string | undefined>;
+}
+
+/** The ends a call reaches before any status is read. */
+export const CALL_FAULT = {
+  NO_CREDENTIAL: "no-credential",
+  HOLDER_CHANGED: "holder-changed",
+  NETWORK: "network",
+} as const;
+
+export type CallFault = (typeof CALL_FAULT)[keyof typeof CALL_FAULT];
+
+/** The service answered; every status, including a refusal, is the caller's to read. */
+export interface CallResponse {
+  response: Response;
+}
+
+export interface CallFailure {
+  fault: CallFault;
+  /**
+   * The kind of error a network fault ended with, never its words, which
+   * could carry a credential.
+   */
+  errorName?: string;
+}
+
+export type CallAnswer = CallResponse | CallFailure;
+
+/** Whether the service answered at all, as distinct from the call never reaching it. */
+export function callAnswered(answer: CallAnswer): answer is CallResponse {
+  return "response" in answer;
+}
+
+/** One request, as the build fixes it: nothing here is composed from what a service answered. */
+export interface CallRequest {
+  method: HttpMethod;
+  /** The path under the call's own base address. */
+  path: string;
+  /** The serialized body, which is also what names the request's content type. */
+  body?: string;
+  /** Extra headers the build fixes; the authorization and content type are the call's own. */
+  headers?: Record<string, string>;
+  /** The caller's own cancellation, joined with the call's deadline. */
+  signal?: AbortSignal;
+}
+
+export interface AccountCallOptions {
+  /** The service origin; any trailing separator is trimmed once. */
+  baseUrl: string;
+  credential: CallCredential;
+  fetch?: CloudFetch;
+  requestTimeoutMs?: number;
+}
+
+/**
+ * One call to Luke's own service, however it is authorized: the base address
+ * trimmed once, the credential read fresh for every attempt, the header
+ * written once, the deadline joined with the caller's own cancellation once, a
+ * fetch that throws read as a network fault by the error's kind alone, and one
+ * reading of a 401 — renew the credential and retry exactly once, only on a
+ * credential that actually changed and only while it still answers for the
+ * same holder.
+ */
+export interface AccountCall {
+  /**
+   * The deadline in force. An `AbortSignal.timeout` cannot be read back, so
+   * the value the call was built with is what says which deadline a request
+   * is under.
+   */
+  readonly requestTimeoutMs: number;
+  /** The address a path is asked at, for a caller that reports its endpoint. */
+  address(path: string): string;
+  send(request: CallRequest): Promise<CallAnswer>;
+  /**
+   * The whole of an answer a caller only wants read: anything but a validated
+   * body — a fault, a refusal, a body that is not JSON — is no answer.
+   */
+  ask<Answer>(
+    request: CallRequest,
+    read: (payload: UnparsedWireValue) => Answer | undefined,
+  ): Promise<Answer | undefined>;
+}
+
+export function createAccountCall(options: AccountCallOptions): AccountCall {
+  const baseUrl = text(options.baseUrl);
+  if (!baseUrl) throw new Error("A call's base URL must not be empty");
+  const address = withoutTrailingSlash(baseUrl);
+  const credential = options.credential;
+  const cloudFetch = options.fetch ?? ((input, init) => fetch(input, init));
+  const requestTimeoutMs = positiveInteger(
+    options.requestTimeoutMs,
+    ACCOUNT_CALL_DEFAULTS.REQUEST_TIMEOUT_MS,
+  );
+
+  async function attempt(
+    request: CallRequest,
+    authorization: string | undefined,
+  ): Promise<CallAnswer> {
+    try {
+      const response = await cloudFetch(`${address}${request.path}`, {
+        method: request.method,
+        headers: {
+          ...request.headers,
+          ...(authorization === undefined ? undefined : { authorization }),
+          ...(request.body === undefined ? undefined : { "content-type": "application/json" }),
+        },
+        ...(request.body === undefined ? undefined : { body: request.body }),
+        signal: deadline(requestTimeoutMs, request.signal),
+      });
+      return { response };
+    } catch (error) {
+      return {
+        fault: CALL_FAULT.NETWORK,
+        ...(error instanceof Error ? { errorName: error.name } : undefined),
+      };
+    }
+  }
+
+  async function send(request: CallRequest): Promise<CallAnswer> {
+    const holder = await credential.holder?.();
+    const authorization = await credential.authorization?.();
+    if (credential.authorization && authorization === undefined) {
+      return { fault: CALL_FAULT.NO_CREDENTIAL };
+    }
+
+    const answer = await attempt(request, authorization);
+    if (!callAnswered(answer) || answer.response.status !== HTTP_STATUS.UNAUTHORIZED) {
+      return answer;
+    }
+
+    // Routine expiry of an hour-lived token inside a day-lived app. A renewal
+    // that itself fails, or that produced the same credential, leaves the
+    // refusal standing: retrying it would only repeat the no.
+    await credential.renew?.().catch(() => undefined);
+    const renewed = await credential.authorization?.();
+    if (renewed === undefined || renewed === authorization) return answer;
+    if (credential.holder && (await credential.holder()) !== holder) {
+      return { fault: CALL_FAULT.HOLDER_CHANGED };
+    }
+    return attempt(request, renewed);
+  }
+
+  return {
+    requestTimeoutMs,
+    address: (path) => `${address}${path}`,
+    send,
+    async ask(request, read) {
+      const answer = await send(request);
+      if (!callAnswered(answer) || !answer.response.ok) return undefined;
+      const payload = await answer.response.json().catch(() => undefined);
+      return payload === undefined ? undefined : read(unparsedWire(payload));
+    },
+  };
+}
+
+/** The signed-in account's bearer, read fresh for every attempt and renewed by the account lifecycle. */
+export function accountBearer(token: AccountToken): CallCredential {
+  return {
+    authorization: async () => {
+      const accessToken = await token.readAccessToken();
+      return accessToken ? bearer(accessToken) : undefined;
+    },
+    renew: token.refreshAccount,
+    holder: token.readAccountKey,
+  };
+}
+
+/** A credential the build or the developer fixed: one header, one attempt, nothing to renew. */
+export function fixedBearer(credential: string): CallCredential {
+  const authorization = bearer(credential);
+  return { authorization: () => Promise.resolve(authorization) };
+}
+
+/** An endpoint that takes no identity: nothing to send, nothing to renew, nobody to answer for. */
+export const NO_CREDENTIAL: CallCredential = {};
+
+function bearer(credential: string): string {
+  return `Bearer ${credential}`;
+}
+
+function deadline(timeoutMs: number, cancellation: AbortSignal | undefined): AbortSignal {
+  const timeout = AbortSignal.timeout(timeoutMs);
+  return cancellation ? AbortSignal.any([timeout, cancellation]) : timeout;
+}

--- a/packages/hosted/src/account-token.ts
+++ b/packages/hosted/src/account-token.ts
@@ -1,8 +1,8 @@
 /**
  * Who a call to Luke's own service is on behalf of. Every client that speaks
  * to the service on the signed-in account — the brain's transports, the voice
- * mint, the key vault, the event sender — is handed the same pair rather than
- * the account itself: the token is read fresh for every attempt, so a client
+ * mint, the key vault, the event sender — is handed these rather than the
+ * account itself: the token is read fresh for every attempt, so a client
  * holds none, and the account lifecycle stays the one thing that knows how a
  * session is kept.
  */
@@ -16,4 +16,13 @@ export interface AccountToken {
    * second refusal is reported.
    */
   refreshAccount: () => Promise<void>;
+  /**
+   * Who the token answers for, as an opaque identity, for the one comparison
+   * a refreshed token needs: a sign-out and sign-in between an attempt and
+   * its retry must read as the caller's account gone rather than as a fresh
+   * bearer to carry the old account's payload under. An account lifecycle
+   * with no identity to name omits it, and then the comparison does not
+   * exist.
+   */
+  readAccountKey?: () => Promise<string | undefined>;
 }

--- a/packages/hosted/src/index.ts
+++ b/packages/hosted/src/index.ts
@@ -1,3 +1,14 @@
+export {
+  type AccountCall,
+  accountBearer,
+  CALL_FAULT,
+  type CallCredential,
+  type CallFailure,
+  callAnswered,
+  createAccountCall,
+  fixedBearer,
+  NO_CREDENTIAL,
+} from "./account-call.js";
 export type { AccountToken } from "./account-token.js";
 export {
   type HostedActionAnswer,

--- a/packages/hosted/src/vault-client.test.ts
+++ b/packages/hosted/src/vault-client.test.ts
@@ -101,47 +101,7 @@ test("deletes one provider's key and reads whether one was removed", async () =>
   });
 });
 
-test("a 401 refreshes the account and retries once on the new token", async () => {
-  const tokens = ["token-1", "token-2"];
-  let refreshes = 0;
-  const { requests, fetchLike } = service([
-    () => new Response(JSON.stringify({ error: "invalid-token" }), { status: 401 }),
-    () => new Response(JSON.stringify(LIST_ANSWER), { status: 200 }),
-  ]);
-
-  const keys = await client({
-    fetch: fetchLike,
-    readAccessToken: async () => tokens.shift(),
-    refreshAccount: async () => {
-      refreshes += 1;
-    },
-  }).listKeys();
-
-  assert.deepEqual(keys, LIST_ANSWER.keys);
-  assert.equal(refreshes, 1);
-  assert.equal(requests.length, 2);
-  assert.equal(new Headers(requests[1]?.init.headers).get("authorization"), "Bearer token-2");
-});
-
-test("a 401 whose refresh yields the same token is not retried", async () => {
-  const { requests, fetchLike } = service([
-    () => new Response(JSON.stringify({ error: "invalid-token" }), { status: 401 }),
-  ]);
-
-  const answer = await client({ fetch: fetchLike }).deleteKey(CLOUD_AGENT_PROVIDER_ID.CONDUCTOR);
-  assert.equal(answer, undefined);
-  assert.equal(requests.length, 1);
-});
-
-test("failures, malformed answers, and a missing account all read as no answer", async () => {
-  const failing = client({
-    fetch: async () => {
-      throw new Error("offline");
-    },
-  });
-  assert.equal(await failing.listKeys(), undefined);
-  assert.equal(await failing.storeKey(CLOUD_AGENT_PROVIDER_ID.CONDUCTOR, "key_1234"), undefined);
-
+test("a refusal and an answer the vault contract does not admit both read as no answer", async () => {
   const refused = client({
     fetch: async () => new Response(JSON.stringify({ error: "unavailable" }), { status: 503 }),
   });
@@ -154,15 +114,4 @@ test("failures, malformed answers, and a missing account all read as no answer",
       }),
   });
   assert.equal(await malformed.listKeys(), undefined);
-
-  const requests: RecordedRequest[] = [];
-  const signedOut = client({
-    fetch: async (url, init) => {
-      requests.push({ url, init });
-      return new Response(JSON.stringify(LIST_ANSWER), { status: 200 });
-    },
-    readAccessToken: async () => undefined,
-  });
-  assert.equal(await signedOut.listKeys(), undefined);
-  assert.equal(requests.length, 0);
 });

--- a/packages/hosted/src/vault-client.ts
+++ b/packages/hosted/src/vault-client.ts
@@ -1,12 +1,6 @@
 import type { CloudAgentProviderId } from "@sidecar/session";
-import {
-  type CloudFetch,
-  positiveInteger,
-  text,
-  type UnparsedWireValue,
-  unparsedWire,
-  withoutTrailingSlash,
-} from "@sidecar/wire";
+import { type CloudFetch, HTTP_METHOD } from "@sidecar/wire";
+import { type AccountCall, accountBearer, createAccountCall } from "./account-call.js";
 import type { AccountToken } from "./account-token.js";
 import { HOSTED_SERVICE_PATH } from "./service-paths.js";
 import {
@@ -19,132 +13,70 @@ import {
   vaultKeysListAnswerSchema,
 } from "./vault-wire.js";
 
-const VAULT_DEFAULTS = {
-  REQUEST_TIMEOUT_MS: 10_000,
-} as const;
-
-const UNAUTHORIZED_STATUS = 401;
-
 export interface HostedVaultClientOptions extends AccountToken {
   /** The hosted service origin, without a trailing slash. */
   serviceBaseUrl: string;
-  /**
-   * Who the bearer answers for, as an opaque identity. Read before an ask and
-   * again before its one 401 retry, because the retry re-reads the token: a
-   * sign-out and sign-in between the two must read as the action's account gone,
-   * never as a fresh bearer to carry the old account's payload under.
-   */
-  readAccountKey?: () => Promise<string | undefined>;
   fetch?: CloudFetch;
   requestTimeoutMs?: number;
-}
-
-interface VaultRequest {
-  method: "POST" | "GET" | "DELETE";
-  path: string;
-  body?: Record<string, string>;
 }
 
 /**
  * The desktop's side of the provider-key vault: store a key, list what is
  * stored (ids and timestamps — the service holds no endpoint that reads a
- * key back, and stores no fragment for display), and delete one. The shape follows the hosted usage reader —
- * token read fresh per ask, a 401 refreshed and retried once, every answer
- * validated by the shared wire contract — and a failure resolves to nothing,
+ * key back, and stores no fragment for display), and delete one. Every ask
+ * goes out on the one account call, and a failure resolves to nothing,
  * leaving the wording to the settings row that asked. Every call here is the
  * direct product of a press on that row; nothing reads the vault on a timer.
  */
 export class HostedVaultClient {
-  readonly #baseUrl: string;
-  readonly #readAccessToken: () => Promise<string | undefined>;
-  readonly #refreshAccount: () => Promise<void>;
-  readonly #readAccountKey?: () => Promise<string | undefined>;
-  readonly #fetch: CloudFetch;
-  readonly #requestTimeoutMs: number;
+  readonly #call: AccountCall;
 
   constructor(options: HostedVaultClientOptions) {
-    const baseUrl = text(options.serviceBaseUrl);
-    if (!baseUrl) throw new Error("Hosted service base URL must not be empty");
-    this.#baseUrl = withoutTrailingSlash(baseUrl);
-    this.#readAccessToken = options.readAccessToken;
-    this.#refreshAccount = options.refreshAccount;
-    if (options.readAccountKey) this.#readAccountKey = options.readAccountKey;
-    this.#fetch = options.fetch ?? ((input, init) => fetch(input, init));
-    this.#requestTimeoutMs = positiveInteger(
-      options.requestTimeoutMs,
-      VAULT_DEFAULTS.REQUEST_TIMEOUT_MS,
-    );
+    this.#call = createAccountCall({
+      baseUrl: options.serviceBaseUrl,
+      credential: accountBearer(options),
+      fetch: options.fetch,
+      requestTimeoutMs: options.requestTimeoutMs,
+    });
   }
 
   /**
    * Stores or replaces one provider's key. A key the service would refuse by
    * shape is refused here without traveling at all.
    */
-  async storeKey(
+  storeKey(
     providerId: CloudAgentProviderId,
     key: string,
   ): Promise<VaultKeyStoreAnswer | undefined> {
-    if (!vaultKeyIsStorable(key)) return undefined;
-    return this.#ask(
-      { method: "POST", path: HOSTED_SERVICE_PATH.VAULT_KEY, body: { providerId, key } },
+    if (!vaultKeyIsStorable(key)) return Promise.resolve(undefined);
+    return this.#call.ask(
+      {
+        method: HTTP_METHOD.POST,
+        path: HOSTED_SERVICE_PATH.VAULT_KEY,
+        body: JSON.stringify({ providerId, key }),
+      },
       (payload) => vaultKeyStoreAnswerSchema.parse(payload),
     );
   }
 
   /** Lists what is stored — provider ids and timestamps, never keys. */
   async listKeys(): Promise<readonly VaultKeyListEntry[] | undefined> {
-    const answer = await this.#ask(
-      { method: "GET", path: HOSTED_SERVICE_PATH.VAULT_KEYS },
+    const answer = await this.#call.ask(
+      { method: HTTP_METHOD.GET, path: HOSTED_SERVICE_PATH.VAULT_KEYS },
       (payload) => vaultKeysListAnswerSchema.parse(payload),
     );
     return answer?.keys;
   }
 
   /** Deletes one provider's key; `deleted: false` means none was stored. */
-  async deleteKey(providerId: CloudAgentProviderId): Promise<VaultKeyDeleteAnswer | undefined> {
-    return this.#ask(
-      { method: "DELETE", path: HOSTED_SERVICE_PATH.VAULT_KEY, body: { providerId } },
+  deleteKey(providerId: CloudAgentProviderId): Promise<VaultKeyDeleteAnswer | undefined> {
+    return this.#call.ask(
+      {
+        method: HTTP_METHOD.DELETE,
+        path: HOSTED_SERVICE_PATH.VAULT_KEY,
+        body: JSON.stringify({ providerId }),
+      },
       (payload) => vaultKeyDeleteAnswerSchema.parse(payload),
     );
-  }
-
-  async #ask<Answer>(
-    request: VaultRequest,
-    read: (payload: UnparsedWireValue) => Answer | undefined,
-  ): Promise<Answer | undefined> {
-    const account = await this.#readAccountKey?.();
-    const token = await this.#readAccessToken();
-    if (!token) return undefined;
-
-    let response = await this.#request(request, token);
-    if (response?.status === UNAUTHORIZED_STATUS) {
-      await this.#refreshAccount().catch(() => undefined);
-      const refreshed = await this.#readAccessToken();
-      const sameAccount =
-        this.#readAccountKey === undefined || (await this.#readAccountKey()) === account;
-      if (refreshed && refreshed !== token && sameAccount) {
-        response = await this.#request(request, refreshed);
-      }
-    }
-    if (!response?.ok) return undefined;
-
-    const payload = await response.json().catch(() => undefined);
-    return payload === undefined ? undefined : read(unparsedWire(payload));
-  }
-
-  async #request(request: VaultRequest, token: string): Promise<Response | undefined> {
-    try {
-      return await this.#fetch(`${this.#baseUrl}${request.path}`, {
-        method: request.method,
-        headers: {
-          authorization: `Bearer ${token}`,
-          ...(request.body ? { "content-type": "application/json" } : undefined),
-        },
-        ...(request.body ? { body: JSON.stringify(request.body) } : undefined),
-        signal: AbortSignal.timeout(this.#requestTimeoutMs),
-      });
-    } catch {
-      return undefined;
-    }
   }
 }

--- a/packages/voice/src/capability-assembler.ts
+++ b/packages/voice/src/capability-assembler.ts
@@ -52,7 +52,13 @@ export interface VoiceSettings {
   readVoiceSource(): Promise<VoiceSource>;
   readApiKey(providerId: typeof VOICE_CREDENTIAL_PROVIDER_ID): Promise<string | undefined>;
   get<Field extends AppSettingField>(field: Field): Promise<AppSettingValue<Field>>;
-  readAccount(): Promise<{ accessToken: string } | undefined>;
+  /**
+   * The signed-in account, as the hosted callers need it: the token every
+   * attempt is authorized with, and the identity that token answers for, so a
+   * refreshed one is never carried on behalf of an account that signed in
+   * behind it.
+   */
+  readAccount(): Promise<{ accessToken: string; email?: string } | undefined>;
 }
 
 export interface VoiceCapabilityAssemblerOptions {
@@ -184,6 +190,7 @@ export class VoiceCapabilityAssembler {
       serviceBaseUrl: this.#options.hostedServiceBaseUrl,
       readAccessToken: async () => (await this.#options.settings.readAccount())?.accessToken,
       refreshAccount: this.#options.refreshAccount,
+      readAccountKey: async () => (await this.#options.settings.readAccount())?.email,
       ...(this.#options.fetch ? { fetch: this.#options.fetch } : undefined),
     };
     const [voice, speed] = await Promise.all([

--- a/packages/voice/src/service-mint.test.ts
+++ b/packages/voice/src/service-mint.test.ts
@@ -151,27 +151,6 @@ test("no access token asks the service nothing and says why voice is off", async
   assert.equal(minter.diagnostics().lastOutcome, REALTIME_MINT_OUTCOME.NOT_SIGNED_IN);
 });
 
-test("a 401 refreshes the account and retries once with the new token", async () => {
-  const tokens = ["stale-token", "fresh-token"];
-  let refreshes = 0;
-  const { requests, fetchLike } = service([
-    refused(401, { error: "invalid-token" }),
-    minted(mintedBody()),
-  ]);
-  const minter = hosted({
-    fetch: fetchLike,
-    readAccessToken: async () => tokens[Math.min(refreshes, tokens.length - 1)],
-    refreshAccount: async () => {
-      refreshes += 1;
-    },
-  });
-
-  assert.ok(await minter.mint());
-  assert.equal(refreshes, 1);
-  assert.equal(requests.length, 2);
-  assert.equal(new Headers(requests[1]?.init.headers).get("authorization"), "Bearer fresh-token");
-});
-
 test("a refresh that changes nothing is not retried and reads as signed out", async () => {
   let refreshes = 0;
   const { requests, fetchLike } = service([refused(401, { error: "invalid-token" })]);

--- a/packages/voice/src/service-mint.ts
+++ b/packages/voice/src/service-mint.ts
@@ -1,9 +1,16 @@
 import {
+  type AccountCall,
   type AccountToken,
+  accountBearer,
+  CALL_FAULT,
+  type CallFailure,
+  callAnswered,
+  createAccountCall,
   HOSTED_SERVICE_PATH,
   type HostedQuota,
   hostedMintAnswerAt,
   hostedQuotaSchema,
+  NO_CREDENTIAL,
   type RealtimeConnection,
 } from "@sidecar/hosted";
 import {
@@ -16,20 +23,14 @@ import {
 } from "@sidecar/realtime";
 import {
   type CloudFetch,
+  HTTP_METHOD,
+  HTTP_STATUS,
   isRecord,
-  positiveInteger,
   text,
   type UnparsedWireValue,
   unparsedWire,
-  withoutTrailingSlash,
 } from "@sidecar/wire";
 
-const SERVICE_MINT_DEFAULTS = {
-  REQUEST_TIMEOUT_MS: 10_000,
-} as const;
-
-const UNAUTHORIZED_STATUS = 401;
-const QUOTA_STATUS = 429;
 const UNAVAILABLE_STATUS = 503;
 
 /**
@@ -75,18 +76,18 @@ interface ServiceMintOptions {
  * refusal a spent quota answers with is diagnosed from.
  */
 class ServiceRealtimeCredentialMinter implements RealtimeCredentialMinter {
-  readonly #endpoint: string;
+  readonly #call: AccountCall;
+  readonly #path: string;
+  /** Whether an attempt carried an identity at all, which is what makes a 401 a signed-out answer. */
+  readonly #identified: boolean;
   readonly #logLabel: string;
   readonly #malformedDetail: string;
-  readonly #authorization: AccountToken | undefined;
   /** The voice from construction, which a cleared setting falls back to. */
   readonly #configuredVoice: string | undefined;
   #voice: string | undefined;
   readonly #configuredSpeed: number | undefined;
   #speed: number | undefined;
-  readonly #fetch: CloudFetch;
   readonly #now: () => number;
-  readonly #requestTimeoutMs: number;
   #lastModel: string | undefined;
   #lastOutcome: RealtimeMintOutcome = REALTIME_MINT_OUTCOME.NOT_ATTEMPTED;
   #lastDetail: string | undefined;
@@ -94,22 +95,21 @@ class ServiceRealtimeCredentialMinter implements RealtimeCredentialMinter {
   #quota: HostedQuota | undefined;
 
   constructor(options: ServiceMintOptions) {
-    const baseUrl = text(options.serviceBaseUrl);
-    if (!baseUrl) throw new Error("Hosted service base URL must not be empty");
-    this.#endpoint = `${withoutTrailingSlash(baseUrl)}${options.servicePath}`;
+    this.#call = createAccountCall({
+      baseUrl: options.serviceBaseUrl,
+      credential: options.authorization ? accountBearer(options.authorization) : NO_CREDENTIAL,
+      fetch: options.fetch,
+      requestTimeoutMs: options.requestTimeoutMs,
+    });
+    this.#path = options.servicePath;
+    this.#identified = options.authorization !== undefined;
     this.#logLabel = options.logLabel;
     this.#malformedDetail = options.malformedDetail;
-    this.#authorization = options.authorization;
     this.#configuredVoice = text(options.voice);
     this.#voice = this.#configuredVoice;
     this.#configuredSpeed = options.speed;
     this.#speed = this.#configuredSpeed;
-    this.#fetch = options.fetch ?? ((input, init) => fetch(input, init));
     this.#now = options.now ?? Date.now;
-    this.#requestTimeoutMs = positiveInteger(
-      options.requestTimeoutMs,
-      SERVICE_MINT_DEFAULTS.REQUEST_TIMEOUT_MS,
-    );
   }
 
   /**
@@ -121,9 +121,18 @@ class ServiceRealtimeCredentialMinter implements RealtimeCredentialMinter {
    */
   async mint(): Promise<RealtimeConnection | undefined> {
     this.#lastAttemptAt = this.#now();
-    const response = await this.#authorizedMint();
-    if (!response) return undefined;
-    return this.#settleMint(response);
+    const answer = await this.#call.send({
+      method: HTTP_METHOD.POST,
+      path: this.#path,
+      // Only values inside the build's own sets travel; anything else lets
+      // the service mint its default rather than sending a refusable field.
+      body: JSON.stringify({
+        ...(isRealtimeVoice(this.#voice) ? { voice: this.#voice } : undefined),
+        ...(isRealtimeVoiceSpeed(this.#speed) ? { speed: this.#speed } : undefined),
+      }),
+    });
+    if (!callAnswered(answer)) return this.#refuseCall(answer);
+    return this.#settleMint(answer.response);
   }
 
   /**
@@ -146,7 +155,7 @@ class ServiceRealtimeCredentialMinter implements RealtimeCredentialMinter {
       model: this.#lastModel ?? REALTIME_DEFAULTS.MODEL,
       voice: this.#voice ?? REALTIME_DEFAULTS.VOICE,
       speed: this.#speed ?? REALTIME_DEFAULTS.SPEED,
-      endpoint: this.#endpoint,
+      endpoint: this.#call.address(this.#path),
       lastOutcome: this.#lastOutcome,
       ...(this.#lastDetail ? { lastDetail: this.#lastDetail } : undefined),
       ...(this.#lastAttemptAt === undefined ? undefined : { lastAttemptAt: this.#lastAttemptAt }),
@@ -154,48 +163,21 @@ class ServiceRealtimeCredentialMinter implements RealtimeCredentialMinter {
     };
   }
 
-  async #authorizedMint(): Promise<Response | undefined> {
-    if (!this.#authorization) return this.#requestMint({});
-
-    const token = await this.#authorization.readAccessToken();
-    if (!token) {
-      this.#recordOutcome(REALTIME_MINT_OUTCOME.NOT_SIGNED_IN, "no access token");
-      return undefined;
-    }
-
-    const response = await this.#requestMint({ authorization: `Bearer ${token}` });
-    if (response?.status !== UNAUTHORIZED_STATUS) return response;
-
-    // Routine expiry of an hour-lived token inside a day-lived app: refresh
-    // and retry once. A retry on the same token would only repeat the no.
-    await this.#authorization.refreshAccount().catch(() => undefined);
-    const refreshed = await this.#authorization.readAccessToken();
-    if (!refreshed || refreshed === token) return response;
-    return this.#requestMint({ authorization: `Bearer ${refreshed}` });
-  }
-
-  async #requestMint(headers: Record<string, string>): Promise<Response | undefined> {
-    try {
-      return await this.#fetch(this.#endpoint, {
-        method: "POST",
-        headers: {
-          ...headers,
-          "content-type": "application/json",
-        },
-        // Only values inside the build's own sets travel; anything else lets
-        // the service mint its default rather than sending a refusable field.
-        body: JSON.stringify({
-          ...(isRealtimeVoice(this.#voice) ? { voice: this.#voice } : undefined),
-          ...(isRealtimeVoiceSpeed(this.#speed) ? { speed: this.#speed } : undefined),
-        }),
-        signal: AbortSignal.timeout(this.#requestTimeoutMs),
-      });
-    } catch (error) {
-      this.#recordOutcome(
-        REALTIME_MINT_OUTCOME.NETWORK_ERROR,
-        error instanceof Error ? error.name : "unknown error",
-      );
-      return undefined;
+  /** A mint that never reached the service, named by the fault the call ended at. */
+  #refuseCall(failure: CallFailure): undefined {
+    switch (failure.fault) {
+      case CALL_FAULT.NO_CREDENTIAL:
+        this.#recordOutcome(REALTIME_MINT_OUTCOME.NOT_SIGNED_IN, "no access token");
+        return undefined;
+      case CALL_FAULT.HOLDER_CHANGED:
+        this.#recordOutcome(REALTIME_MINT_OUTCOME.NOT_SIGNED_IN, "the account changed");
+        return undefined;
+      case CALL_FAULT.NETWORK:
+        this.#recordOutcome(
+          REALTIME_MINT_OUTCOME.NETWORK_ERROR,
+          failure.errorName ?? "unknown error",
+        );
+        return undefined;
     }
   }
 
@@ -228,7 +210,7 @@ class ServiceRealtimeCredentialMinter implements RealtimeCredentialMinter {
    * where an identity was sent at all.
    */
   #refuseMint(status: number, payload: UnparsedWireValue): void {
-    if (status === QUOTA_STATUS) {
+    if (status === HTTP_STATUS.TOO_MANY_REQUESTS) {
       this.#quota = isRecord(payload)
         ? hostedQuotaSchema.parse(unparsedWire(payload.quota))
         : undefined;
@@ -239,7 +221,7 @@ class ServiceRealtimeCredentialMinter implements RealtimeCredentialMinter {
       this.#recordOutcome(REALTIME_MINT_OUTCOME.HOSTED_UNAVAILABLE);
       return;
     }
-    if (status === UNAUTHORIZED_STATUS && this.#authorization) {
+    if (status === HTTP_STATUS.UNAUTHORIZED && this.#identified) {
       this.#recordOutcome(REALTIME_MINT_OUTCOME.NOT_SIGNED_IN, `status ${status}`);
       return;
     }
@@ -272,13 +254,13 @@ export type HostedRealtimeCredentialOptions = RealtimeCredentialOptions & Accoun
 export function hostedRealtimeCredentialMinter(
   options: HostedRealtimeCredentialOptions,
 ): RealtimeCredentialMinter {
-  const { readAccessToken, refreshAccount, ...rest } = options;
+  const { readAccessToken, refreshAccount, readAccountKey, ...rest } = options;
   return new ServiceRealtimeCredentialMinter({
     ...rest,
     servicePath: HOSTED_SERVICE_PATH.VOICE_MINT,
     logLabel: "Hosted realtime mint",
     malformedDetail: "no usable hosted credential",
-    authorization: { readAccessToken, refreshAccount },
+    authorization: { readAccessToken, refreshAccount, readAccountKey },
   });
 }
 

--- a/packages/wire/src/index.ts
+++ b/packages/wire/src/index.ts
@@ -12,7 +12,9 @@ export { type Admitted, reshapeAdmitted } from "./admitted.js";
 export { Emitter, type Event } from "./event.js";
 export {
   type CloudFetch,
+  HTTP_METHOD,
   HTTP_STATUS,
+  type HttpMethod,
   isInstant,
   isOptionalWireString,
   isRecord,

--- a/packages/wire/src/json.ts
+++ b/packages/wire/src/json.ts
@@ -227,6 +227,16 @@ export function wireRecord(value: UnparsedWireValue): WireRecord | undefined {
   return isRecord(value) ? value : undefined;
 }
 
+/** The methods this build's own requests are made with. */
+export const HTTP_METHOD = {
+  GET: "GET",
+  POST: "POST",
+  PUT: "PUT",
+  DELETE: "DELETE",
+} as const;
+
+export type HttpMethod = (typeof HTTP_METHOD)[keyof typeof HTTP_METHOD];
+
 /** The statuses this build branches on at the HTTP boundary. */
 export const HTTP_STATUS = {
   UNAUTHORIZED: 401,


### PR DESCRIPTION
Five places called Luke's own service and each re-implemented the same
bearer/renew/retry dance. They now go out on one call object.

## What was deleted

`packages/hosted/src/account-call.ts` is the one request every caller makes:
the base address trimmed once, the bearer header written once, the deadline
joined with the caller's own cancellation, a fetch that threw read as a fault
by the error's kind alone, and one reading of a 401 — renew, retry exactly
once, only on a credential that changed, and only while it still answers for
the same holder. It holds no credential itself: a `CallCredential` is handed
in (`accountBearer`, `fixedBearer`, `NO_CREDENTIAL`).

Deleted from the five callers: five copies of the 401 retry, five
`REQUEST_TIMEOUT_MS: 10_000` constants, four hand-written `UNAUTHORIZED_STATUS
= 401`, five `withoutTrailingSlash`/empty-base-URL checks, five `try/catch`
fetch wrappers, five bearer-header literals, two copies of the holder
comparison, and the brain's own `requestSignal` (now the call's `deadline`).
Net at the sites is −281 lines against +230 in the new module.

- `packages/hosted/src/vault-client.ts`
- `packages/host/src/account-preferences-client.ts` (byte-identical to the
  vault's dance before this)
- `packages/voice/src/service-mint.ts` — the introduction mint is
  `NO_CREDENTIAL`, which is why `CallCredential.authorization` is optional: an
  endpoint that takes no identity is a credential with no header to read, and
  is not the same as a credential that read nothing.
- `packages/analytics/src/sender.ts`
- `packages/brain/src/client.ts` — the abstract `BrainTransport` and its
  `KeyedBrainTransport`/`HostedBrainTransport` subclasses become one class
  plus `keyedBrainTransport()`/`hostedBrainTransport()`. What stays brain-only
  is the mapping of a fault to a `MODEL_FAILURE` and the reading of a 429.

`HTTP_METHOD` moved from `packages/brain/src/model-adapter-shared.ts` to
`packages/wire/src/json.ts`, beside the `HTTP_STATUS` already there, and
gained `PUT`/`DELETE` for the callers that use them. `requestFault` now takes
the error's name rather than the error, because the call hands back a kind and
never an object that could carry a key.

The brain's 90-second deadline is explicit: the transport passes it to the
call rather than relying on a fallback, `AccountCall.requestTimeoutMs` reports
the deadline in force (an `AbortSignal.timeout` cannot be read back), and
`client.test.ts` asserts both it and an explicit override.

`packages/hosted/src/device-client.ts` still carries its own copy,
deliberately: this PR converts the five callers it was scoped to, and that one
is left for the PR that follows.

## The correctness fix

**The holder check becomes uniform at all five sites.** Today it exists only
in the vault and account preference clients, so the analytics sender could
post one account's queued events under another account's bearer: a batch is
taken off the queue, the first attempt is refused with a 401, the refresh
lands a token for whoever signed in meanwhile, and the retry posts the first
account's counts under the second account's identity. The check now lives in
`AccountCall.send` for every caller whose credential names a holder, and
`compose-settings.ts` hands the sender the holder to compare (the same
`readAccountKey` the vault client already got). `sender.test.ts` covers it —
"a batch queued under one account is never posted under another's bearer" —
and that test fails on the code as it stood before this change.

A batch refused that way is spent rather than requeued: those counts belong to
an account this sender can no longer name. A batch that never authenticated at
all (`CALL_FAULT.NO_CREDENTIAL`) still goes back on the queue, which is the
signed-out behaviour from before.

The second commit finishes the same fix at the three callers the first left
half-wired (see the review passes below): the hosted brain adapter, the hosted
embedding adapter, and the hosted voice mint are all built from the voice
capability assembler's one `seams` object, which supplied only a token and a
refresh. `VoiceSettings.readAccount` already answered from the settings store,
which holds the account's address; its type now says so, and the seams pass it
as the holder. Every hosted caller in this build compares. `client.test.ts`
covers the brain's own mapping of that refusal — "a token refreshed for
another account never carries this turn's input".

## Tests

The four copies of "a 401 refreshes the credential and retries once / the same
token is not retried / a malformed body reads as no answer" are now one, in
`packages/hosted/src/account-call.test.ts` (15 tests, including the holder
crossover, the anonymous endpoint, the renewal that itself fails, the
credential read that throws, the joined cancellation, and the deadline
actually ending a request that outlives it).
Each converted site keeps only the tests about its own vocabulary and its own
reading of a status.

## Doc sentence changed

`packages/hosted/AGENTS.md` said this package holds the wire vocabulary and
"the two clients here", with everything above the boundary belonging above it.
That is now incomplete: four of the five callers live above the boundary and
reach down for this call. A new section, "One call stands behind all of them",
says what `account-call.ts` owns, why it is the lowest package they all reach,
that it holds no credential of its own, and that `device-client.ts` still
carries its own copy. No sentence in `CLAUDE.md`, `PRIVACY.md`, or a
`README.md` was made false: nothing there describes the retry, the deadline,
or these clients' internals, and no CLAUDE.md-bound name was renamed.

## `./scripts/check.sh`

Green.

Run after each commit, and again after each rebase onto `origin/main` — most
recently over #871, #872, #867, #873, #876, #877, #878, #879, and #880. Green
every time. The run below is the last one, on the rebased branch.

```
> luke@0.5.0 check /home/vercel-sandbox/luke
> pnpm lint && pnpm typecheck && pnpm test && pnpm build

72 generated files are up to date
4 generated files are up to date
Design contract checks passed.
Repository contract checks passed.

Checked 1246 files in 866ms. No fixes applied.

packages/wire test:      ℹ tests 66  / fail 0
packages/hosted test:    ℹ tests 79  / fail 0
packages/analytics test: ℹ tests 30  / fail 0
packages/voice test:     ℹ tests 117 / fail 0
packages/brain test:     ℹ tests 337 / fail 0
packages/host test:      ℹ tests 284 / fail 0
packages/providers test: ℹ tests 468 / fail 0
apps/web test:           ℹ tests 346 / fail 0
apps/desktop test:       ℹ tests 677 / fail 0
... every package: fail 0
apps/desktop build: Done

CHECK_EXIT=0
```

The 23 warnings are the pre-existing `unicorn(no-useless-spread)` and
`no-control-regex` ones on untouched files. Per-package runs before that:
`pnpm --filter @sidecar/{wire,hosted,host,voice,analytics,brain} typecheck`
and `test` all clean, and `pnpm --recursive typecheck` reports nothing.

`./scripts/verify.sh` needs a Mac and is not available in this cloud
workspace. This change is not macOS- or UI-bearing: it touches no `apps/`
code, draws nothing, and the two desktop native tests that flaked once under
the full parallel `pnpm check` (`output-volume`, `screen-geometry` — they
spawn real helper processes) pass on their own and on a re-run.

## CI

All ten checks pass on `e349aef`, the Vercel deployment included: TypeScript
checks, macOS app and evidence, Postgres migrations and store, CodeQL, both
Analyze jobs, Vercel, Vercel Preview Comments, Cursor Bugbot, and the Cursor
Security Reviewer. `mergeStateStatus` is `CLEAN`.

The two bot comments still shown on the diff are against earlier commits — the
security one against `b75f8675` and Bugbot's against `44f1391a` — and both
bots re-ran on the final head with nothing further to say.

## Review passes

Neither skill is installed here, so both were looked up and applied as
published.

**Thermo-nuclear code quality review** ([cursor/plugins](https://github.com/cursor/plugins/blob/main/cursor-team-kit/skills/thermo-nuclear-code-quality-review/SKILL.md)) — structural
ambition, spaghetti prevention, type and boundary clarity, canonical layer
discipline, orchestration efficiency, the 1,000-line bound.

- *Duplicated helper left in place*: `device-client.ts` is a sixth copy of the
  dance. Not fixed here — named above and in the AGENTS.md section, left to
  the next PR rather than colliding with it. It is the one caller with no
  holder to compare and no transcript to carry (a device id and a platform),
  which is why leaving it is a scope decision rather than the security finding
  above repeated. Nothing else duplicates.
- *Boundary clarity*: the account preference client took a `FetchLike` from
  `@sidecar/credentials` for a hosted call; it now takes `CloudFetch` like its
  four siblings, and the `as UnparsedWireValue` cast on its request body is
  gone, because the body is a string the call sends rather than a record it
  re-serializes.
- *Unnecessary optionality*: challenged `CallCredential.authorization?` and
  kept it — it is what lets `NO_CREDENTIAL` be `{}` rather than a sentinel
  string or a second boolean saying the same thing. Documented on the member.
- *Canonical layer*: `HTTP_METHOD` was in a brain module and read by callers
  in four packages; it belongs in the wire vocabulary, and that is the move
  the PR opens with.
- *Missed judo, fixed*: the mint held both an `#endpoint` and its path; it now
  holds the path and asks the call for the address when diagnostics want it.
- *Orchestration efficiency*: considered reading the holder and the credential
  in parallel in `send` and rejected it. Both are cheap local reads, and in
  the one function that guards account crossover the sequence — holder, then
  credential, then attempt — is worth more as documentation than a microtask
  is worth as speed.
- No file crosses 1,000 lines; the largest touched file drops from 199 to 192.

**Cursor Security Reviewer** (CI, not one of the two asked for, but it read
this diff before the review passes were written up and its finding is the
substantive one) — MEDIUM: the holder check is skipped whenever a credential
names no holder, and the hosted brain, embeddings, and mint are built from
assembler seams that supplied none, so those three kept the fail-open retry
this PR otherwise closed; a brain POST carries transcript input, so the replay
would attribute one account's transcript to another. Correct, and it is the
same defect the PR set out to fix, one level up in the wiring. Fixed in
`506c52c` — the finding was that three sites were not wired, not that the
mechanism was wrong, so the fix is two lines of wiring and a widened seam
type, plus the test above. My own note in the first draft said this was
deferred; on the evidence that a transcript rides those calls, deferring was
the wrong call.

**Cursor Bugbot** (CI) — LOW, on the second commit: the event sender now takes
its batch off the queue before the call reads the token, and the credential
reads sat outside the fetch's `try`, so a settings read that threw would lose
a batch that used to stay queued. Correct, and a regression this PR
introduced. Fixed in `e349aef`: the two credential reads move into
`identify()`, which answers nothing on a failed read the way it already
answers nothing on a signed-out account, so `AccountCall.send` answers rather
than rejects for every caller — an `ask` reads as no answer, a brain turn as a
credential failure, and the sender's batch goes back on the queue.
`sender.test.ts` and `account-call.test.ts` both cover it, and the sender's
test fails on the code as it stood in the second commit.

**Ponytail review** ([dietrichgebert/ponytail](https://github.com/dietrichgebert/ponytail)) — over-engineering only:
what to delete.

- `yagni`: the barrel exported `AccountCallOptions`, `CallAnswer`,
  `CallFault`, `CallRequest`, and `CallResponse`, which nothing imports. Cut;
  the barrel now names the nine symbols that are actually reached.
- `yagni`: also cut the `HostedVaultClientOptions` export I had briefly added
  to the barrel for symmetry — nothing imports it either.
- `shrink`: the analytics queue trim was written twice (once in `record`, once
  where a refused batch goes back); it is one `#trimQueue`.
- `yagni` (considered, rejected): a `hostedServiceCall()` wrapper would have
  collapsed the three-line `createAccountCall({...})` block that three callers
  share. It only renames `serviceBaseUrl` to `baseUrl`, so it would be a layer
  earning nothing.
- `yagni` (considered, rejected): `AccountCall.address()` has one caller, the
  mint's diagnostics. Kept, because the alternative is a second copy of the
  base-address trim in the one place that must report the endpoint it asks at.
- `net: −51 lines` beyond the five conversions, from the cuts above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34415683468/artifacts/10129018011) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34415683468)

- Commit: `9e8918a5d0192df51f27214239e196a82ca44cf2`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/5d182cf1-b6a0-45d6-86c7-7da707cf498c)
