### PR TITLE
fix(actions): a target_id cannot hide a project listed without one

### DIFF
--- a/packages/actions/src/action-schemas.ts
+++ b/packages/actions/src/action-schemas.ts
@@ -199,7 +199,13 @@ export const CREATE_WORKSPACE_REQUEST = record({
   project_id: s
     .text({ description: "The project ID; omit it to create in that provider's default project." })
     .optional(),
-  target_id: s.text({ description: "The target ID." }).optional(),
+  target_id: s
+    .text({
+      description:
+        "The target ID of the host, exactly as the projects list gives it, and only for a " +
+        "project whose line carries a target_id; a project listed without one takes none.",
+    })
+    .optional(),
   agent: AGENT_KIND.optional(),
   name: WORKSPACE_NAME.describe(
     "The workspace's name: the developer's own when they chose one, otherwise a short, " +

--- a/packages/actions/src/admit.test.ts
+++ b/packages/actions/src/admit.test.ts
@@ -22,6 +22,7 @@ import {
 import { ACTION_RESULT_STATUS } from "@sidecar/wire";
 import {
   ACTION_FAMILY,
+  ACTION_REFUSAL,
   ACTIONS,
   REALTIME_TOOL,
   type RealtimeFunctionCall,
@@ -447,6 +448,104 @@ test("an implicit project resolves only when the latest roster has one match", a
   assert.equal(ambiguous.status, ACTION_RESULT_STATUS.REJECTED);
   // SAFETY: Refused session-tool actions carry a reason string this assertion inspects.
   assert.match((ambiguous as { reason?: string }).reason ?? "", /More than one listed project/);
+});
+
+test("a target names a host only where the listed project carries one", async () => {
+  const localTwin: ObservedWorkspaceProject = {
+    ...OFFERED_PROJECT,
+    providerId: "conductor-local",
+    providerName: "Conductor (local)",
+    providerProjectId: "repo-7",
+    providerTargetId: "/Users/me/conductor/repos/luke",
+  };
+  const hosted = (target: string): ObservedWorkspaceProject => ({
+    ...OFFERED_PROJECT,
+    providerId: "superset",
+    providerName: "Superset",
+    providerTargetId: target,
+    targetName: target,
+  });
+  const noModels = () => [];
+
+  // A cloud project lists no target, so a target the ask invents for it — the
+  // words the sibling lines' target_id invites — cannot hide the project it
+  // named by provider and id.
+  for (const invented of ["default", "luke", "cloud", "proj-1"]) {
+    assert.deepEqual(
+      await sessionToolAction(
+        messageCall(
+          `{"provider_id":"conductor","project_id":"proj-1","target_id":"${invented}"}`,
+          REALTIME_TOOL.CREATE_WORKSPACE,
+        ),
+        [],
+        [OFFERED_PROJECT, localTwin],
+        noModels,
+        "conductor",
+      ),
+      { kind: "create-workspace", providerId: "conductor", providerProjectId: "proj-1" },
+    );
+  }
+
+  // A target the list gives picks out the project that carries it, ahead of
+  // the default provider's target-less twin.
+  assert.deepEqual(
+    await sessionToolAction(
+      messageCall(`{"target_id":"${localTwin.providerTargetId}"}`, REALTIME_TOOL.CREATE_WORKSPACE),
+      [],
+      [OFFERED_PROJECT, localTwin],
+      noModels,
+      "conductor",
+    ),
+    {
+      kind: "create-workspace",
+      providerId: "conductor-local",
+      providerProjectId: "repo-7",
+      providerTargetId: localTwin.providerTargetId,
+    },
+  );
+
+  // One repository on two hosts under one project id: the target chooses the
+  // host, and a host the list never gave is refused by name rather than
+  // guessed at or sent on to the target-less default.
+  const hosts = [hosted("local"), hosted("studio")];
+  assert.deepEqual(
+    await sessionToolAction(
+      messageCall(
+        '{"provider_id":"superset","project_id":"proj-1","target_id":"studio"}',
+        REALTIME_TOOL.CREATE_WORKSPACE,
+      ),
+      [],
+      hosts,
+    ),
+    {
+      kind: "create-workspace",
+      providerId: "superset",
+      providerProjectId: "proj-1",
+      providerTargetId: "studio",
+    },
+  );
+  const unlisted = await sessionToolAction(
+    messageCall(
+      '{"provider_id":"superset","project_id":"proj-1","target_id":"host-old"}',
+      REALTIME_TOOL.CREATE_WORKSPACE,
+    ),
+    [],
+    hosts,
+  );
+  assert.equal(unlisted.status, ACTION_RESULT_STATUS.REJECTED);
+  // SAFETY: Refused session-tool actions carry a reason string this assertion inspects.
+  assert.equal((unlisted as { reason?: string }).reason, ACTION_REFUSAL.NO_TARGET);
+  const wrongHostOnly = await sessionToolAction(
+    messageCall(
+      '{"provider_id":"conductor-local","target_id":"/Users/me/elsewhere"}',
+      REALTIME_TOOL.CREATE_WORKSPACE,
+    ),
+    [],
+    [OFFERED_PROJECT, localTwin],
+  );
+  assert.equal(wrongHostOnly.status, ACTION_RESULT_STATUS.REJECTED);
+  // SAFETY: Refused session-tool actions carry a reason string this assertion inspects.
+  assert.equal((wrongHostOnly as { reason?: string }).reason, ACTION_REFUSAL.NO_TARGET);
 });
 
 test("the saved defaults settle what a creation ask leaves unnamed", async () => {

--- a/packages/actions/src/admit.ts
+++ b/packages/actions/src/admit.ts
@@ -171,6 +171,8 @@ export const ACTION_REFUSAL = {
   NO_APP_ADDRESS: "No app carries an exact address for that session.",
   NO_PROJECT: "No listed project matches that identity.",
   MANY_PROJECTS: "More than one listed project matches; name the project and host.",
+  NO_TARGET:
+    "No listed project carries that target; a target_id is named only as the projects list gives it, and a project listed without one takes none.",
   NO_PROJECT_AGENT: "That project lists no such agent to start.",
   NAME_A_PROJECT_AGENT: "Name one of the agents that project lists for a new workspace.",
   PROJECT_NAMES_ITSELF: "That project names its own workspaces.",
@@ -577,12 +579,30 @@ const admitCreateWorkspace: Admitter<typeof ACTION_KIND.CREATE_WORKSPACE> = asyn
   const providerId = textArgument(fields, "provider_id");
   const projectId = textArgument(fields, "project_id");
   const targetId = textArgument(fields, "target_id");
-  let matchingProjects = listed.filter(
+  const namedProjects = listed.filter(
     (candidate) =>
       (!providerId || candidate.providerId === providerId) &&
-      (!projectId || candidate.providerProjectId === projectId) &&
-      (!targetId || candidate.providerTargetId === targetId),
+      (!projectId || candidate.providerProjectId === projectId),
   );
+  // A target picks out a host among the projects the ask named — one
+  // repository a provider reports on several hosts under one project id — so
+  // it narrows only where a listed project carries one. A project listed
+  // without a target has no host to pick, and a target the ask invented for it
+  // cannot hide it: the action still carries the listed entry's own identity
+  // and never the ask's word. Where the named projects do carry targets and
+  // none is the one asked for, the refusal names the target, so the correction
+  // is said rather than guessed at or sent on to a target-less twin.
+  let matchingProjects = namedProjects;
+  if (targetId) {
+    const onTarget = namedProjects.filter((candidate) => candidate.providerTargetId === targetId);
+    matchingProjects =
+      onTarget.length > 0
+        ? onTarget
+        : namedProjects.filter((candidate) => candidate.providerTargetId === undefined);
+    if (matchingProjects.length === 0 && namedProjects.length > 0) {
+      return refuse(ACTION_REFUSAL.NO_TARGET);
+    }
+  }
   // The saved defaults settle only what the ask left unnamed: no provider
   // named sends a still-ambiguous ask to the default provider while it is
   // offering, and no project named sends it on to that provider's chosen

--- a/packages/actions/src/guarantees.test.ts
+++ b/packages/actions/src/guarantees.test.ts
@@ -334,6 +334,15 @@ test("lands only in a project its provider reported on the latest observation pa
   // Every identifier the action carries is the listed project's, never the ask's.
   assert.equal(admitted.providerId, LISTED_PROJECT.providerId);
   assert.equal(admitted.providerProjectId, LISTED_PROJECT.providerProjectId);
+  // A target the ask invents for a project listed without one names no host
+  // to pick, so it neither hides the project nor rides the action.
+  const targeted = await admit(
+    { kind: ACTION_KIND.CREATE_WORKSPACE, fields: { project_id: "luke", target_id: "default" } },
+    context(),
+  );
+  assert.ok(targeted.kind === ACTION_KIND.CREATE_WORKSPACE);
+  assert.equal(targeted.providerProjectId, LISTED_PROJECT.providerProjectId);
+  assert.equal(targeted.providerTargetId, undefined);
 });
 
 test("each project says whether it takes a task, needs one, or takes none", async () => {


### PR DESCRIPTION
## Summary

Conversational workspace creation in a Conductor cloud project was refused every time with "No listed project matches that identity." The action journal on the developer's Mac shows eleven rejected `create_workspace` calls today, each naming the cloud `luke` project correctly by `provider_id` and `project_id` and each also carrying a `target_id` the model invented (`default`, `luke`, `cloud`, the project's own UUID). The sibling project lines for Superset and Conductor (local) carry a `target_id` and the schema described the field only as "The target ID", so the model supplied one. `admit()` treated any `target_id` as a hard match against a project's `providerTargetId`; a cloud project carries none, so nothing matched, and the refusal never named the target as the problem, so the model retried blind.

## Root cause

- `packages/actions/src/admit.ts`: the creation filter `(!targetId || candidate.providerTargetId === targetId)` excluded every target-less project as soon as a `target_id` arrived. The filter was written for Superset hosts in #274, where every project carries a target.
- `packages/actions/src/action-schemas.ts`: #313 shortened the field's description from "The target_id of the host, exactly as the projects list gives it, when present." to "The target ID.", dropping the guidance that made the model omit it.
- The performer and the plugin dispatch (`session-action-performer.ts`, `provider-plugin.ts`) re-match on the admitted action's own `providerTargetId`, which comes from the listed project and not the ask, so they were never the fault. The iOS validator ignores `target_id` altogether and was unaffected.

## Fix

- A `target_id` now narrows only among the projects the ask named that carry one. A project listed without a target cannot be hidden by one, and the action still carries the listed entry's identity, never the ask's word.
- Where the named projects do carry targets and none is the one asked for (a Superset host the list never gave, or Conductor (local) with the wrong path), a new refusal `NO_TARGET` names the target, so the correction is said instead of guessed at or sent on to a target-less twin.
- The schema description says again what the original change said: exactly as the projects list gives it, and only for a project whose line carries one.

## Tests

- `admit.test.ts`: a new test covers each invented target on the cloud project landing on that project; a listed local path picking out Conductor (local) ahead of the default provider's target-less twin; a Superset target choosing the host among two under one project id; and an unlisted host, or a wrong local path, refused with `NO_TARGET`.
- `guarantees.test.ts`: an invented target on a target-less listed project neither hides it nor rides the action.
- `./scripts/check.sh` passes. Portable change only, no UI touched, so no macOS verification or physical-notch check applies.

The hosted tier builds its tool catalog from the same actions table, so the new description reaches hosted users at the service's next deploy; the admission fix is desktop-side and is the functional repair on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34409857704/artifacts/10126864263) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34409857704)

- Commit: `960af12ad92a5cf90483b4143b86c1f6edea7bac`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
