### PR TITLE
fix(brain): let the hold, the live exchange, and a closed chat reach the brain

### DIFF
--- a/packages/brain/src/observation-inbox.test.ts
+++ b/packages/brain/src/observation-inbox.test.ts
@@ -366,9 +366,9 @@ test("a conversation that looks at one session reads only it, and a repeated unc
   assert.equal(h.client.inputs.length, 2);
 });
 
-test("a session the developer is speaking with wakes nothing until the exchange ends, and stays on the roster throughout", async () => {
+test("a session the developer is speaking with wakes nothing, and the exchange over is read past rather than replayed", async () => {
   let live = true;
-  let text = `${TRANSCRIPT_SECRET} said aloud`;
+  let transcript = `${TRANSCRIPT_SECRET} said aloud`;
   const h = harness({
     observes: { kind: LOOK_SUBJECT.SESSION, identity: ABC },
     roster: () => ({
@@ -381,15 +381,18 @@ test("a session the developer is speaking with wakes nothing until the exchange 
         }),
       ],
     }),
-    readTranscriptSince: async () => ({
+    // The cursor is a position in the transcript, so each read starts where the
+    // last one stopped, the way a provider's own reader does.
+    readTranscriptSince: async (_identity, cursor) => ({
       status: ACTION_RESULT_STATUS.ACCEPTED,
-      text,
-      cursor: `abc-${text.length}`,
+      text: transcript.slice(Number(cursor ?? 0)),
+      cursor: String(transcript.length),
       truncated: false,
     }),
   });
   // Neither the look nor the provider's own hook opens an inference over an
-  // exchange being heard first-hand, and nothing is captured to open one later.
+  // exchange being heard first-hand, and nothing is written down to open one
+  // later — but the capture cursor moves past what was said.
   h.agent.rosterLook();
   await settle();
   await h.agent.wake([
@@ -401,15 +404,25 @@ test("a session the developer is speaking with wakes nothing until the exchange 
   await settle();
   assert.equal(h.client.inputs.length, 0);
   assert.equal(h.repository.state?.inbox.length ?? 0, 0);
+  assert.equal(h.repository.state?.captureCursors["claude-code"]?.abc, String(transcript.length));
 
-  // The exchange over, the next look reads the session again.
+  // The exchange ending is not news: with nothing gained since, the look
+  // opens nothing and replays none of what the developer heard themselves.
   live = false;
-  text = "assistant: back to typing";
+  h.agent.rosterLook();
+  await settle();
+  assert.equal(h.client.inputs.length, 0);
+
+  // A fresh turn after it is read from where the exchange left off.
+  transcript += "\nassistant: back to typing";
   h.client.answers.push(answered([message("")]));
   h.agent.rosterLook();
   await settle();
   assert.equal(h.client.inputs.length, 1);
-  assert.ok(itemText((h.client.inputs[0] ?? [])[0]).includes("back to typing"));
+  const opening = itemText((h.client.inputs[0] ?? [])[0]);
+  assert.ok(opening.includes("back to typing"));
+  assert.ok(!opening.includes(TRANSCRIPT_SECRET));
+  assert.equal(h.repository.state?.captureCursors["claude-code"]?.abc, String(transcript.length));
   await h.agent.stop();
 });
 

--- a/packages/brain/src/observation-inbox.test.ts
+++ b/packages/brain/src/observation-inbox.test.ts
@@ -4,6 +4,7 @@ import { RESPONSES_INPUT_ITEM_TYPE } from "@sidecar/hosted";
 import {
   normalizeSession,
   type ProviderTranscriptSinceResult,
+  SESSION_COMPLETION_CAUSE,
   SESSION_STATUS,
   type SessionIdentity,
 } from "@sidecar/session";
@@ -363,6 +364,86 @@ test("a conversation that looks at one session reads only it, and a repeated unc
   h.agent.rosterLook();
   await settle();
   assert.equal(h.client.inputs.length, 2);
+});
+
+test("a session the developer is speaking with wakes nothing until the exchange ends, and stays on the roster throughout", async () => {
+  let live = true;
+  let text = `${TRANSCRIPT_SECRET} said aloud`;
+  const h = harness({
+    observes: { kind: LOOK_SUBJECT.SESSION, identity: ABC },
+    roster: () => ({
+      text: "roster",
+      identities: [ABC],
+      sessions: [
+        session("abc", {
+          status: SESSION_STATUS.WORKING,
+          ...(live ? { realtimeVoiceLive: true } : undefined),
+        }),
+      ],
+    }),
+    readTranscriptSince: async () => ({
+      status: ACTION_RESULT_STATUS.ACCEPTED,
+      text,
+      cursor: `abc-${text.length}`,
+      truncated: false,
+    }),
+  });
+  // Neither the look nor the provider's own hook opens an inference over an
+  // exchange being heard first-hand, and nothing is captured to open one later.
+  h.agent.rosterLook();
+  await settle();
+  await h.agent.wake([
+    {
+      ...edge(ABC),
+      session: session("abc", { status: SESSION_STATUS.WORKING, realtimeVoiceLive: true }),
+    },
+  ]);
+  await settle();
+  assert.equal(h.client.inputs.length, 0);
+  assert.equal(h.repository.state?.inbox.length ?? 0, 0);
+
+  // The exchange over, the next look reads the session again.
+  live = false;
+  text = "assistant: back to typing";
+  h.client.answers.push(answered([message("")]));
+  h.agent.rosterLook();
+  await settle();
+  assert.equal(h.client.inputs.length, 1);
+  assert.ok(itemText((h.client.inputs[0] ?? [])[0]).includes("back to typing"));
+  await h.agent.stop();
+});
+
+test("a wake's session summary carries the hold and the completion cause beside the status", async () => {
+  const h = harness();
+  await h.agent.wake([
+    {
+      ...edge(ABC),
+      hookEvent: "PermissionRequest",
+      session: session("abc", { holdingForDeveloper: true }),
+    },
+    {
+      ...edge(DEF),
+      session: session("def", {
+        status: SESSION_STATUS.COMPLETE,
+        completionCause: SESSION_COMPLETION_CAUSE.SESSION_CLOSED,
+      }),
+    },
+  ]);
+  await h.clock.advance(NOW + 3_000);
+  await settle();
+  const opening = itemText(
+    itemsOfType(h.client.inputs[0] ?? [], RESPONSES_INPUT_ITEM_TYPE.MESSAGE)[0],
+  );
+  const body = wireRecord(unparsedWire(JSON.parse(opening.slice(opening.indexOf("\n") + 1))));
+  assert.ok(Array.isArray(body?.events));
+  const [holding, closed] = body.events.map((event) =>
+    wireRecord(unparsedWire(wireRecord(unparsedWire(event))?.session)),
+  );
+  assert.equal(holding?.status, SESSION_STATUS.WAITING);
+  assert.equal(holding?.holding_for_developer, true);
+  assert.equal(closed?.status, SESSION_STATUS.COMPLETE);
+  assert.equal(closed?.completion_cause, SESSION_COMPLETION_CAUSE.SESSION_CLOSED);
+  await h.agent.stop();
 });
 
 test("a relaunch does not run an ask that was only queued, and runs a captured observation without rereading it", async () => {

--- a/packages/brain/src/observation-inbox.ts
+++ b/packages/brain/src/observation-inbox.ts
@@ -119,6 +119,8 @@ export function sessionSummary(session: Session): WireRecord {
     provider_name: session.provider.displayName,
     title: session.title,
     status: session.status,
+    ...(session.holdingForDeveloper === true ? { holding_for_developer: true } : undefined),
+    ...(session.completionCause ? { completion_cause: session.completionCause } : undefined),
     ...(session.workspace?.name ? { workspace: session.workspace.name } : undefined),
     ...(session.detail.error ? { error: session.detail.error } : undefined),
     ...(session.detail.activity ? { activity: session.detail.activity } : undefined),

--- a/packages/brain/src/standing-context.test.ts
+++ b/packages/brain/src/standing-context.test.ts
@@ -6,6 +6,7 @@ import {
   type ObservedWorkspaceProject,
   SESSION_APPLICATION_ID,
   SESSION_APPLICATION_SCOPE,
+  SESSION_COMPLETION_CAUSE,
   SESSION_LOCATION,
   SESSION_STATUS,
   WORKSPACE_TASK_SUPPORT,
@@ -362,6 +363,77 @@ test("the roster says what a session is doing and where, in the attention update
   assert.match(bareText, /in repository luke/);
   assert.doesNotMatch(bareText, /running/);
   assert.doesNotMatch(bareText, /error:/);
+});
+
+test("the roster tells a wait holding for the developer from an idle one, and a closed chat from a finished turn, in fixed words", () => {
+  const holding = normalizeSession(
+    { id: "claude-code", displayName: "Claude Code" },
+    {
+      providerSessionId: "session-holding",
+      title: "checkout-service",
+      status: SESSION_STATUS.WAITING,
+      lastActivityAt: OBSERVED_AT,
+      holdingForDeveloper: true,
+      detail: { activity: "Bash: rm -rf build" },
+    },
+  );
+  const idle = normalizeSession(
+    { id: "claude-code", displayName: "Claude Code" },
+    {
+      providerSessionId: "session-idle",
+      title: "checkout-service",
+      status: SESSION_STATUS.WAITING,
+      lastActivityAt: OBSERVED_AT,
+    },
+  );
+  const holdingText = sessionContextText([holding]);
+  const idleText = sessionContextText([idle]);
+  // The hold is a fixed phrase beside the provider's own bounded activity,
+  // never the provider's wording of the permission itself.
+  assert.match(holdingText, /waiting — updated just now — holding for your permission or answer/);
+  assert.match(holdingText, /running Bash: rm -rf build/);
+  assert.match(idleText, /waiting/);
+  assert.doesNotMatch(idleText, /holding/);
+
+  const closed = normalizeSession(
+    { id: "codex", displayName: "Codex" },
+    {
+      providerSessionId: "session-closed",
+      title: "checkout-service",
+      status: SESSION_STATUS.COMPLETE,
+      completionCause: SESSION_COMPLETION_CAUSE.SESSION_CLOSED,
+      lastActivityAt: OBSERVED_AT,
+    },
+  );
+  const finished = normalizeSession(
+    { id: "codex", displayName: "Codex" },
+    {
+      providerSessionId: "session-finished",
+      title: "checkout-service",
+      status: SESSION_STATUS.COMPLETE,
+      completionCause: SESSION_COMPLETION_CAUSE.WORK_FINISHED,
+      lastActivityAt: OBSERVED_AT,
+    },
+  );
+  const untold = normalizeSession(
+    { id: "codex", displayName: "Codex" },
+    {
+      providerSessionId: "session-untold",
+      title: "checkout-service",
+      status: SESSION_STATUS.COMPLETE,
+      lastActivityAt: OBSERVED_AT,
+    },
+  );
+  const closedText = sessionContextText([closed]);
+  const finishedText = sessionContextText([finished]);
+  const untoldText = sessionContextText([untold]);
+  assert.match(closedText, /complete — updated just now — the chat was closed/);
+  assert.doesNotMatch(closedText, /finished its work/);
+  assert.match(finishedText, /complete — updated just now — finished its work/);
+  assert.doesNotMatch(finishedText, /closed/);
+  // A provider that could not say why leaves the line at its status alone.
+  assert.match(untoldText, /complete/);
+  assert.doesNotMatch(untoldText, /closed|finished/);
 });
 
 test("the roster says which sessions have a pull request, never an address", () => {

--- a/packages/brain/src/standing-context.ts
+++ b/packages/brain/src/standing-context.ts
@@ -4,7 +4,9 @@ import {
   advertisedActionFor,
   advertisedControls,
   type ObservedWorkspaceProject,
+  SESSION_COMPLETION_CAUSE,
   type Session,
+  type SessionCompletionCause,
   WORKSPACE_TASK_SUPPORT,
   type WorkspaceTaskSupport,
   workspaceProjectSelectionId,
@@ -143,13 +145,35 @@ function sessionAgeText(lastActivityAt: number, now: number): SessionAgeText {
 }
 
 /**
- * The checkout, current tool, and reported failure a session's line carries —
- * the same bounded about-fields the panel draws, worded as short labelled
- * phrases so Luke can say what a session is doing or stuck on rather than
- * only that it works or waits.
+ * How a waiting session that cannot continue without the developer reads: one
+ * fixed phrase, never the provider's own words for the permission, approval,
+ * or question it reported. A waiting session whose adapter could not tell
+ * carries no phrase and reads as waiting alone, so an idle turn end and a
+ * tool call holding for permission are told apart on the line itself.
+ */
+const HOLDING_FOR_DEVELOPER_TEXT = "holding for your permission or answer";
+
+/**
+ * Why a complete session became complete, where its provider could say. A
+ * chat the developer closed is not a turn that finished, and the two are news
+ * of different kinds: one is work to report, the other the developer's own
+ * hand. A provider that could not tell reports no cause and says nothing here.
+ */
+const COMPLETION_CAUSE_TEXT = {
+  [SESSION_COMPLETION_CAUSE.WORK_FINISHED]: "finished its work",
+  [SESSION_COMPLETION_CAUSE.SESSION_CLOSED]: "the chat was closed",
+} as const satisfies Record<SessionCompletionCause, string>;
+
+/**
+ * The checkout, current tool, reported failure, hold, and completion cause a
+ * session's line carries — the same bounded about-fields the panel draws,
+ * worded as short labelled phrases so Luke can say what a session is doing or
+ * stuck on rather than only that it works or waits.
  */
 function sessionAboutText(session: Session): readonly string[] {
   return [
+    ...(session.holdingForDeveloper === true ? [HOLDING_FOR_DEVELOPER_TEXT] : []),
+    ...(session.completionCause ? [COMPLETION_CAUSE_TEXT[session.completionCause]] : []),
     ...(session.detail.branch
       ? [`on branch ${session.detail.branch}`]
       : session.detail.repository
@@ -175,7 +199,8 @@ function sessionSpokenName(session: Session): string {
  * Renders the session roster the conversation is allowed to know about.
  *
  * These are the same bounded, redacted fields the panel already draws —
- * provider, title, status, when last seen, repository or branch,
+ * provider, title, status, when last seen, whether a wait holds for the
+ * developer, why a complete chat ended, repository or branch,
  * current tool, and reported error — plus the
  * workspace a chat belongs to when its provider groups them, the apps that
  * independently associate themselves with it, what each session can be asked to do, and the

--- a/packages/brain/src/wakes.ts
+++ b/packages/brain/src/wakes.ts
@@ -133,10 +133,8 @@ export class WakeCapture {
    * Settles once the capture has landed or been refused.
    */
   wake(events: readonly BrainWakeEvent[]): Promise<void> {
-    if (this.#seam.stopped()) return Promise.resolve();
-    const heard = events.filter((event) => !event.session || !developerSpeakingWith(event.session));
-    if (heard.length === 0) return Promise.resolve();
-    return this.#capture(heard).then((captured) => {
+    if (this.#seam.stopped() || events.length === 0) return Promise.resolve();
+    return this.#capture(events).then((captured) => {
       if (this.#seam.stopped()) return;
       const generation = this.#seam.generation();
       if (!generation) return;
@@ -207,10 +205,11 @@ export class WakeCapture {
    * batch is read once from its capture cursor; an event that names a hook
    * the inbox already holds — the same hook, session, and instant delivered
    * twice — is not captured again; a roster edge that gained nothing over a
-   * session standing exactly as it last stood is not captured at all. What
-   * remains is written with the advanced capture cursors in one save, and a
-   * save the store refuses moves no cursor in memory either. Answers how many
-   * entries were captured.
+   * session standing exactly as it last stood is not captured at all; and an
+   * event on a session the developer is speaking with moves its cursor past
+   * what was read and leaves no entry. What remains is written with the
+   * advanced capture cursors in one save, and a save the store refuses moves
+   * no cursor in memory either. Answers how many entries were captured.
    */
   #capture(events: readonly BrainWakeEvent[]): Promise<number> {
     const work = async (): Promise<number> => {
@@ -229,6 +228,7 @@ export class WakeCapture {
         cursor: string | undefined;
       }>();
       const entries: BrainObservationEntry[] = [];
+      let heardFirstHand = false;
       const now = this.#seam.now();
       for (const event of fresh) {
         let read = reads.get(event.identity.providerId, event.identity.providerSessionId);
@@ -257,6 +257,10 @@ export class WakeCapture {
             cursor: read.cursor,
           };
         }
+        if (event.session && developerSpeakingWith(event.session)) {
+          heardFirstHand = true;
+          continue;
+        }
         if (
           event.kind === BRAIN_WAKE_KIND.ROSTER &&
           !read.delta?.text &&
@@ -269,7 +273,7 @@ export class WakeCapture {
           entryFromEvent(event, this.#options.createRunId(), now, read.delta, read.cursor),
         );
       }
-      if (entries.length === 0) {
+      if (entries.length === 0 && !heardFirstHand) {
         generation.captureCursors.rollback(mark);
         return 0;
       }
@@ -320,7 +324,6 @@ export class WakeCapture {
       if (subject.kind === LOOK_SUBJECT.SESSION && !sameIdentity(subject.identity, identity)) {
         return [];
       }
-      if (developerSpeakingWith(session)) return [];
       const readBefore = cursors.cursor(identity) !== undefined;
       const live =
         session.status === SESSION_STATUS.WORKING || session.status === SESSION_STATUS.WAITING;
@@ -369,10 +372,12 @@ export class WakeCapture {
 /**
  * A session the developer is speaking with first-hand wakes nothing: its turn
  * boundaries are the rhythm of a conversation being heard as it happens, and a
- * briefing read over them would talk over the very exchange it reports. The
- * hook and the look are dropped rather than held, so the exchange ending never
- * replays what happened inside it; the session stays on the roster and in the
- * standing context throughout, because the developer may still ask about it.
+ * briefing read over them would talk over the very exchange it reports. Its
+ * hooks and looks still read what the transcript gained, so the capture cursor
+ * moves past the exchange, but they write no entry and open no turn — the text
+ * is read past rather than read out, and the exchange ending never replays
+ * what happened inside it. The session stays on the roster and in the standing
+ * context throughout, because the developer may still ask about it.
  */
 function developerSpeakingWith(session: Session): boolean {
   return session.realtimeVoiceLive === true;

--- a/packages/brain/src/wakes.ts
+++ b/packages/brain/src/wakes.ts
@@ -2,6 +2,7 @@ import {
   type ProviderTranscriptSinceResult,
   SESSION_LOCATION,
   SESSION_STATUS,
+  type Session,
   type SessionIdentity,
 } from "@sidecar/session";
 import { ACTION_RESULT_STATUS } from "@sidecar/wire";
@@ -132,8 +133,10 @@ export class WakeCapture {
    * Settles once the capture has landed or been refused.
    */
   wake(events: readonly BrainWakeEvent[]): Promise<void> {
-    if (this.#seam.stopped() || events.length === 0) return Promise.resolve();
-    return this.#capture(events).then((captured) => {
+    if (this.#seam.stopped()) return Promise.resolve();
+    const heard = events.filter((event) => !event.session || !developerSpeakingWith(event.session));
+    if (heard.length === 0) return Promise.resolve();
+    return this.#capture(heard).then((captured) => {
       if (this.#seam.stopped()) return;
       const generation = this.#seam.generation();
       if (!generation) return;
@@ -317,6 +320,7 @@ export class WakeCapture {
       if (subject.kind === LOOK_SUBJECT.SESSION && !sameIdentity(subject.identity, identity)) {
         return [];
       }
+      if (developerSpeakingWith(session)) return [];
       const readBefore = cursors.cursor(identity) !== undefined;
       const live =
         session.status === SESSION_STATUS.WORKING || session.status === SESSION_STATUS.WAITING;
@@ -362,6 +366,18 @@ export class WakeCapture {
   }
 }
 
+/**
+ * A session the developer is speaking with first-hand wakes nothing: its turn
+ * boundaries are the rhythm of a conversation being heard as it happens, and a
+ * briefing read over them would talk over the very exchange it reports. The
+ * hook and the look are dropped rather than held, so the exchange ending never
+ * replays what happened inside it; the session stays on the roster and in the
+ * standing context throughout, because the developer may still ask about it.
+ */
+function developerSpeakingWith(session: Session): boolean {
+  return session.realtimeVoiceLive === true;
+}
+
 /** A session as the roster showed it at a look, in the fields a change would move; never a transcript. */
 function lookFingerprint(event: BrainWakeEvent): string {
   const session = event.session;
@@ -369,6 +385,8 @@ function lookFingerprint(event: BrainWakeEvent): string {
     session
       ? [
           session.status,
+          session.holdingForDeveloper === true,
+          session.completionCause ?? null,
           session.lastActivityAt,
           session.detail.activity ?? null,
           session.detail.error ?? null,


### PR DESCRIPTION
## Summary

PR #738 removed the deterministic notice tracker and attention evaluator, which was intended, but three facts the providers still observe stopped reaching anything on main: a waiting session's hold for the developer, a live realtime voice exchange over a session, and a chat closed rather than finished. This PR makes each reach the brain again, in the narrowest place that consumes it.

- **Standing context** (`packages/brain/src/standing-context.ts`): a waiting session whose provider reported a real permission, approval, or question now carries one fixed phrase, `holding for your permission or answer`, so it reads apart from an idle turn end. A complete session carries its completion cause where the provider could say: `finished its work` or `the chat was closed`. Both are fixed words from `as const` tables, never provider text, and a session whose adapter could not tell carries neither.
- **Wake events** (`packages/brain/src/observation-inbox.ts`, `wakes.ts`): the session summary an observed-events turn opens with carries the same two facts as fixed fields (`holding_for_developer`, `completion_cause`), and the unchanged-look fingerprint moves on them, so a wait that becomes a hold is a change worth one look.
- **Live exchange** (`packages/brain/src/wakes.ts`): a session with `realtimeVoiceLive` wakes nothing. Its roster look and its hooks still read what the transcript gained, so the capture cursor moves past the exchange, but they write no inbox entry and open no turn: the text is read past rather than read out, and the exchange ending never replays what the developer heard first-hand. The session stays on the roster and in the standing context throughout, matching how the voice roster stood before #738, where only the announcement layer skipped it.

## What was left alone, and why

- **The panel row.** The row's state is the urgency word from the generated surface vocabulary (`Working`, `Needs you`, `Complete`, `Idle`) under the sentence the provider reported. A hold already reads as `Needs you` over the activity awaiting permission, and a closed chat as `Complete`. Adding a fifth word means changing the generated cross-surface table in `design/generate-surface-shared.mjs`, which is a surface decision rather than this fix, so the row is unchanged.
- **`PRIVACY.md`.** The roster already discloses title, status, repository, branch, model, current tool, and errors. The two new phrases are refinements of the status, carry no observed value, and do not change what travels in character.

## Tests

Each new test fails on main and passes here.

- `standing-context.test.ts`: the hold renders as a fixed phrase and an idle wait does not; a closed chat, a finished turn, and an untold completion render distinctly.
- `observation-inbox.test.ts`: a live-voice session's roster look and hook open no inference and write no entry while moving the capture cursor, the look after the exchange ends replays nothing, and a later turn is read from where the exchange left off; a wake's session summary carries the hold and the completion cause.

`./scripts/check.sh`: exit 0 (lint, typecheck, every package test, and build all passed).

This change touches no macOS or UI code; `./scripts/verify.sh` needs a physical Mac and was not run here.

Found by the PR #738 unintended-changes audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34410978742/artifacts/10127299557) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34410978742)

- Commit: `2bffae2d219118f2b5625c0fc017f14e353d7241`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
