### PR TITLE
fix(desktop): draw a refused typed ask on the caption strip again

### DIFF
--- a/apps/desktop/src/renderer/ask-luke.test.ts
+++ b/apps/desktop/src/renderer/ask-luke.test.ts
@@ -1,8 +1,11 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import { PRODUCT_ASK_OUTCOME } from "@sidecar/analytics";
+import { BRAIN_ASK_REFUSAL } from "@sidecar/brain/requests";
 import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
-import { AskLuke, STOP_LABEL } from "./ask-luke";
+import { AskLuke, composerAfterAsk, STOP_LABEL } from "./ask-luke";
+import { ASK_UNSENT_REASON } from "./use-voice-view";
 
 /** The label as static markup carries it: the apostrophe escaped, as React writes attributes. */
 const STOP_LABEL_MARKUP = STOP_LABEL.replaceAll("'", "&#x27;");
@@ -41,4 +44,21 @@ test("a run going with nothing to stop it through leaves the disc the send it wa
   const markup = renderToStaticMarkup(createElement(AskLuke, { ...props, thinking: true }));
   assert.match(markup, /data-turn="you"/);
   assert.match(markup, /aria-label="Ask Luke"/);
+});
+
+test("a refused ask keeps the draft and is counted as refused", () => {
+  for (const reason of [...Object.values(BRAIN_ASK_REFUSAL), ASK_UNSENT_REASON]) {
+    assert.deepEqual(
+      composerAfterAsk(reason),
+      { outcome: PRODUCT_ASK_OUTCOME.REFUSED, keepDraft: true },
+      `${reason}: a refused ask is still the developer's words`,
+    );
+  }
+});
+
+test("an accepted ask empties the field and is counted as sent", () => {
+  assert.deepEqual(composerAfterAsk(undefined), {
+    outcome: PRODUCT_ASK_OUTCOME.SENT,
+    keepDraft: false,
+  });
 });

--- a/apps/desktop/src/renderer/ask-luke.tsx
+++ b/apps/desktop/src/renderer/ask-luke.tsx
@@ -1,4 +1,8 @@
-import { PRODUCT_ASK_OUTCOME, PRODUCT_SURFACE_EVENT } from "@sidecar/analytics";
+import {
+  PRODUCT_ASK_OUTCOME,
+  PRODUCT_SURFACE_EVENT,
+  type ProductAskOutcome,
+} from "@sidecar/analytics";
 import { SendIcon, StopIcon } from "@sidecar/panel";
 import { cssCustomProperties } from "@sidecar/surface/react-css";
 import { useCallback, useRef, useState } from "react";
@@ -42,12 +46,27 @@ export function focusAskField(): () => void {
 
 /**
  * Carries one typed ask to the conversation. Answers with why it could not be
- * sent, or with nothing when it was. The reason has already been drawn by the
- * conversation itself — on the caption strip, where the reply would have
- * landed — so the composer reads the answer only to decide whether the draft
- * stays.
+ * sent, or with nothing when it was. The handler has already landed the reason
+ * on the caption strip, where the reply would have — so the composer reads the
+ * answer only to decide whether the draft stays and what to count.
  */
 export type AskHandler = (text: string) => Promise<string | undefined>;
+
+/**
+ * What one answered ask does to the composer. A refusal keeps the draft — a
+ * refused ask is still the developer's words — and counts as refused; an
+ * accepted ask is the conversation's now, so the field empties for the next
+ * one and it counts as sent. Neither draws a word here: the handler that
+ * answered has already put a refusal's sentence on the strip below.
+ */
+export function composerAfterAsk(reason: string | undefined): {
+  outcome: ProductAskOutcome;
+  keepDraft: boolean;
+} {
+  return reason === undefined
+    ? { outcome: PRODUCT_ASK_OUTCOME.SENT, keepDraft: false }
+    : { outcome: PRODUCT_ASK_OUTCOME.REFUSED, keepDraft: true };
+}
 
 /**
  * The panel's own composer: one pill at the foot of the sessions list and of
@@ -60,7 +79,7 @@ export type AskHandler = (text: string) => Promise<string | undefined>;
  * Sending is deliberately quiet. A sent ask clears the field and nothing else:
  * the reply beginning is the confirmation, and a line saying "sent" would sit
  * between the question and its answer. Only a refusal earns a sentence, and
- * that sentence is not the pill's to draw: the conversation lands it on the
+ * that sentence is not the pill's to draw: the ask handler lands it on the
  * caption strip directly below, in the notice tone — the reply's own place,
  * so a refusal reads like every other answer. The draft stays through one,
  * because a refused ask is still the developer's words.
@@ -124,21 +143,15 @@ export function AskLuke({
     askInFlight.current = true;
     setAsking(true);
     try {
-      // A refusal keeps the draft — a refused ask is still the developer's
-      // words — and needs nothing drawn here: the conversation has already
-      // landed the sentence on the caption strip below.
-      const reason = await ask(text);
+      const settled = composerAfterAsk(await ask(text));
       // What the ask carried never travels; whether it reached a conversation
       // at all does, because a field people type into and are refused by is
       // indistinguishable from one nobody uses without it.
       window.sidecar.recordSurfaceEvent(PRODUCT_SURFACE_EVENT.ASK_SUBMIT, {
-        ask_outcome: reason ? PRODUCT_ASK_OUTCOME.REFUSED : PRODUCT_ASK_OUTCOME.SENT,
+        ask_outcome: settled.outcome,
       });
-      if (!reason) {
-        // The ask has become the conversation's; the field empties for the
-        // next one, and the caret stays for it.
-        setDraft("");
-      }
+      // The caret stays either way: for the retry, or for the next ask.
+      if (!settled.keepDraft) setDraft("");
     } finally {
       askInFlight.current = false;
       setAsking(false);

--- a/apps/desktop/src/renderer/use-voice-view.test.ts
+++ b/apps/desktop/src/renderer/use-voice-view.test.ts
@@ -1,11 +1,21 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { BRAIN_ASK_REFUSAL } from "@sidecar/brain/requests";
+import {
+  BRAIN_ASK_REFUSAL,
+  BRAIN_SUBMISSION_OUTCOME,
+  BRAIN_SUBMISSION_REJECTION,
+  type BrainSubmissionRejection,
+} from "@sidecar/brain/requests";
+import type { BrainAskSubmissionResult } from "@sidecar/brain/requests-wire";
 import { REALTIME_STATUS } from "@sidecar/realtime";
+import { NoticeStrip, VOICE_ERROR_NOTICE_MS } from "@sidecar/voice/orchestrator";
 import { IDLE_VOICE_VIEW } from "#shared/messages/voice-view";
 import {
   ASK_UNSENT_REASON,
   askDraftReason,
+  CLEAR_FAILED_REASON,
+  panelVoiceView,
+  submitTypedAsk,
   voiceActiveFor,
   voiceErrorToShow,
   voiceNoticeToShow,
@@ -91,6 +101,106 @@ test("a refused or unanswered typed ask keeps its draft; an accepted one clears 
     ASK_UNSENT_REASON,
     "an ask nobody answered is the developer's words to retry, not to lose",
   );
+});
+
+/**
+ * A strip whose clock is held by the test: what it was asked to draw, and
+ * when each line would have left on its own.
+ */
+function panelStrip() {
+  const expiries: { at: number; fire: () => void }[] = [];
+  const strip = new NoticeStrip({
+    onChanged: () => undefined,
+    schedule: (fire, at) => {
+      expiries.push({ at, fire });
+      return expiries.length;
+    },
+    cancel: () => undefined,
+  });
+  const handed = () =>
+    panelVoiceView(IDLE_VOICE_VIEW, { error: strip.error, notice: strip.notice });
+  return { strip, expiries, handed };
+}
+
+function rejected(reason: BrainSubmissionRejection): BrainAskSubmissionResult {
+  return { outcome: BRAIN_SUBMISSION_OUTCOME.REJECTED, reason };
+}
+
+test("a refused typed ask lands its reason on the strip the panel is handed, as a notice and never a caption", async () => {
+  for (const rejection of Object.values(BRAIN_SUBMISSION_REJECTION)) {
+    const { strip, handed } = panelStrip();
+    const reason = await submitTypedAsk({ strip, submit: async () => rejected(rejection) });
+    assert.equal(reason, BRAIN_ASK_REFUSAL[rejection]);
+    const view = handed();
+    assert.equal(
+      view.voiceNotice,
+      BRAIN_ASK_REFUSAL[rejection],
+      `${rejection}: the sentence is drawn where the reply would have landed`,
+    );
+    assert.equal(view.voiceError, undefined, "a refusal is the notice tone, not a fault");
+    assert.equal(
+      view.lukeCaptions,
+      undefined,
+      "nothing was said, so nothing is captioned: the captions preference does not decide a refusal",
+    );
+  }
+});
+
+test("an ask nobody answered is reported on the strip too, and leaves on the failure's own clock", async () => {
+  const { strip, expiries, handed } = panelStrip();
+  assert.equal(
+    await submitTypedAsk({
+      strip,
+      submit: () => Promise.reject(new Error("the bridge is gone")),
+    }),
+    ASK_UNSENT_REASON,
+  );
+  assert.equal(handed().voiceNotice, ASK_UNSENT_REASON);
+  assert.equal(expiries.at(-1)?.at, VOICE_ERROR_NOTICE_MS);
+  expiries.at(-1)?.fire();
+  assert.equal(handed().voiceNotice, undefined, "the strip takes no pointer, so time dismisses it");
+});
+
+test("an accepted ask clears the refusal the strip was still reading and answers the composer nothing", async () => {
+  const { strip, handed } = panelStrip();
+  await submitTypedAsk({ strip, submit: async () => rejected(BRAIN_SUBMISSION_REJECTION.ABSENT) });
+  assert.equal(handed().voiceNotice, BRAIN_ASK_REFUSAL.absent);
+  const reason = await submitTypedAsk({
+    strip,
+    submit: async () => ({
+      outcome: BRAIN_SUBMISSION_OUTCOME.ACCEPTED,
+      runId: "run-1",
+      acceptedAt: 1,
+    }),
+  });
+  assert.equal(reason, undefined);
+  assert.equal(handed().voiceNotice, undefined, "a sent ask outdates the refusal before it");
+});
+
+test("the panel's own strip lines stand over the voice window's while they last, and otherwise the report is handed on whole", () => {
+  const reported = {
+    ...IDLE_VOICE_VIEW,
+    voiceError: "The voice service refused the call (status 401).",
+    voiceNotice: "Listening on the built-in microphone.",
+  };
+  assert.equal(
+    panelVoiceView(reported, { error: undefined, notice: undefined }),
+    reported,
+    "nothing of the panel's own leaves the report untouched",
+  );
+  const both = panelVoiceView(reported, {
+    error: CLEAR_FAILED_REASON,
+    notice: BRAIN_ASK_REFUSAL.full,
+  });
+  assert.equal(both.voiceError, CLEAR_FAILED_REASON);
+  assert.equal(both.voiceNotice, BRAIN_ASK_REFUSAL.full);
+  assert.equal(both.voiceStatus, reported.voiceStatus);
+  const noticeOnly = panelVoiceView(reported, {
+    error: undefined,
+    notice: BRAIN_ASK_REFUSAL.conflict,
+  });
+  assert.equal(noticeOnly.voiceError, reported.voiceError, "a refusal displaces no fault");
+  assert.equal(noticeOnly.voiceNotice, BRAIN_ASK_REFUSAL.conflict);
 });
 
 test("a quiet level lets the hangover run out from the last loud one, never past it", () => {

--- a/apps/desktop/src/renderer/use-voice-view.ts
+++ b/apps/desktop/src/renderer/use-voice-view.ts
@@ -5,7 +5,7 @@ import {
 } from "@sidecar/brain/requests";
 import type { BrainAskSubmissionResult, BrainRequestSnapshot } from "@sidecar/brain/requests-wire";
 import { REALTIME_STATUS, type RealtimeStatus } from "@sidecar/realtime";
-import { VOICE_ERROR_NOTICE_MS } from "@sidecar/voice/orchestrator";
+import { NoticeStrip } from "@sidecar/voice/orchestrator";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { ACT_KIND } from "#shared/messages/acts";
 import {
@@ -39,9 +39,56 @@ export function askDraftReason(result: BrainAskSubmissionResult | undefined): st
     : BRAIN_ASK_REFUSAL[result.reason];
 }
 
+/**
+ * Carries one typed ask to the brain and answers the composer with the reason
+ * it was refused, or nothing when it was accepted. A refusal is the one
+ * outcome nobody hears: the reply that would have said it never starts, so
+ * the sentence is landed where the reply would have — on the caption strip,
+ * in the notice tone, on the strip's own clock — and a fixed sentence it is,
+ * never composed with the ask. An accepted ask outdates whatever refusal the
+ * strip was still reading, since the reply beginning is now the answer.
+ */
+export async function submitTypedAsk(input: {
+  submit: () => Promise<BrainAskSubmissionResult>;
+  strip: NoticeStrip;
+}): Promise<string | undefined> {
+  const reason = askDraftReason(
+    await input.submit().catch((): BrainAskSubmissionResult | undefined => undefined),
+  );
+  input.strip.showNotice(reason);
+  return reason;
+}
+
 /** What the strip says when the stored thread could not be deleted. */
 export const CLEAR_FAILED_REASON =
   "Conversation was cleared from view, but its file could not be fully erased. Try again.";
+
+/**
+ * The two lines the panel puts on the strip itself: a fault and a notice the
+ * main process answered to this panel's own press, which the voice window
+ * never saw and so never reports.
+ */
+export interface PanelStripLines {
+  error: string | undefined;
+  notice: string | undefined;
+}
+
+const NO_PANEL_STRIP_LINES: PanelStripLines = { error: undefined, notice: undefined };
+
+/**
+ * The view the panel draws: the voice window's report, with the panel's own
+ * strip lines standing over the report's for as long as they last. Each line
+ * displaces only its own slot, so a refusal never hides a fault, and a report
+ * the panel adds nothing to is handed on as the same object.
+ */
+export function panelVoiceView(reported: VoiceView, strip: PanelStripLines): VoiceView {
+  if (strip.error === undefined && strip.notice === undefined) return reported;
+  return {
+    ...reported,
+    voiceError: strip.error ?? reported.voiceError,
+    voiceNotice: strip.notice ?? reported.voiceNotice,
+  };
+}
 
 /**
  * How long a voice has been active, read off the relayed levels with the
@@ -121,8 +168,9 @@ export interface VoiceViewState {
   /**
    * A typed ask to Luke, submitted to the brain in the main process and
    * answered with whether it was accepted into a run: nothing when it was, a
-   * reason when it was not, so the composer keeps a refused draft. The reply
-   * arrives later, in the thread and in the voice.
+   * reason when it was not, so the composer keeps a refused draft. The reason
+   * is already on the strip in `view` by the time it is answered; the reply
+   * to an accepted ask arrives later, in the thread and in the voice.
    */
   askLuke: (text: string) => Promise<string | undefined>;
   /** Every run the brain holds, for Conversation to draw a pending ask beside its words. */
@@ -184,20 +232,34 @@ export function useVoiceView(): VoiceViewState {
     if (!turnLive) setVoiceActive(false);
   }, [turnLive]);
 
+  // The panel's own strip lines, on the same clock the voice window's strip
+  // keeps, because they share the box the developer reads them in. The strip
+  // reports each change into React state, so the view below re-composes on a
+  // line arriving or expiring.
+  const [stripLines, setStripLines] = useState(NO_PANEL_STRIP_LINES);
+  const [strip] = useState(() => {
+    const created: NoticeStrip = new NoticeStrip({
+      onChanged: () => setStripLines({ error: created.error, notice: created.notice }),
+    });
+    return created;
+  });
+  useEffect(() => () => strip.stop(), [strip]);
   // One submission id per press of Send: the id is what makes a retry of
   // this very ask the same run and a second deliberate ask a new one.
   const askLuke = useCallback(
-    async (text: string): Promise<string | undefined> =>
-      askDraftReason(
-        await act(ACT_KIND.BRAIN_SUBMIT_ASK, {
-          submission: {
-            submissionId: crypto.randomUUID(),
-            question: text,
-            origin: BRAIN_REQUEST_ORIGIN.TYPED,
-          },
-        }).catch((): BrainAskSubmissionResult | undefined => undefined),
-      ),
-    [],
+    (text: string): Promise<string | undefined> =>
+      submitTypedAsk({
+        strip,
+        submit: () =>
+          act(ACT_KIND.BRAIN_SUBMIT_ASK, {
+            submission: {
+              submissionId: crypto.randomUUID(),
+              question: text,
+              origin: BRAIN_REQUEST_ORIGIN.TYPED,
+            },
+          }),
+      }),
+    [strip],
   );
   // Every version of the document carries the whole list the standing brain
   // holds: a run absent from it is one no current brain can find, so its row
@@ -215,25 +277,19 @@ export function useVoiceView(): VoiceViewState {
   const requestMicrophoneAccess = useCallback(() => {
     tell(ACT_KIND.VOICE_COMMAND, { command: VOICE_COMMAND.REQUEST_MICROPHONE_ACCESS });
   }, []);
-  // The one failure the panel reports itself: the stored thread refusing to
-  // go is the main process's answer to this press, not anything the voice
-  // window saw, so it borrows the strip here on the strip's own clock.
-  const [localError, setLocalError] = useState<string>();
-  useEffect(() => {
-    if (localError === undefined) return;
-    const timer = window.setTimeout(() => setLocalError(undefined), VOICE_ERROR_NOTICE_MS);
-    return () => window.clearTimeout(timer);
-  }, [localError]);
+  // The stored thread refusing to go is the main process's answer to this
+  // press, not anything the voice window saw, so it is the panel's own fault
+  // to report.
   const clearConversationLines = useCallback(() => {
     act(ACT_KIND.VOICE_COMMAND, { command: VOICE_COMMAND.CLEAR_CONVERSATION })
       .catch((): VoiceCommandOutcome => VOICE_COMMAND_OUTCOME.REFUSED)
       .then((outcome) => {
-        if (outcome === VOICE_COMMAND_OUTCOME.REFUSED) setLocalError(CLEAR_FAILED_REASON);
+        if (outcome === VOICE_COMMAND_OUTCOME.REFUSED) strip.showError(CLEAR_FAILED_REASON);
       });
-  }, []);
+  }, [strip]);
 
   return {
-    view: localError === undefined ? view : { ...view, voiceError: localError },
+    view: panelVoiceView(view, stripLines),
     speaking: view.voiceStatus === REALTIME_STATUS.RESPONDING,
     voiceTurn: waveformVoice(view.voiceStatus),
     level,

--- a/packages/analytics/src/index.ts
+++ b/packages/analytics/src/index.ts
@@ -23,6 +23,7 @@ export {
   PRODUCT_SURFACE_EVENT,
   PRODUCT_UPDATE_ACTION,
   type ProductAccountAction,
+  type ProductAskOutcome,
   type ProductCredentialSource,
   type ProductDiagnosticKind,
   type ProductEvent,


### PR DESCRIPTION
## What

A typed ask the brain refused reported nothing anywhere: `use-voice-view.ts`'s `askLuke` computed the reason, `ask-luke.tsx` used it only to keep the draft and fill the `ask_outcome` analytics property, and nothing drew it. Before #738 the same refusal landed on the caption strip in the notice tone, where the reply would have; #739 then deleted the orphaned `askRefusal`.

- The panel's voice view now keeps its own two strip lines on the voice package's `NoticeStrip`, so the refusal and the existing Clear failure (`CLEAR_FAILED_REASON`) share the strip's `VOICE_ERROR_NOTICE_MS` clock. A refused ask reaches the panel as `voiceNotice`, drawn through the existing `voiceNoticeToShow` rule (yields to Luke's turn alone), never as a caption: nothing was said, so the captions preference decides nothing about it and #869 stands.
- Every `BRAIN_SUBMISSION_REJECTION` (`absent`, `empty`, `persistence`, `conflict`, `full`, `incompatible`) and the unanswered case (`ASK_UNSENT_REASON`) land the same way. An accepted ask takes a standing refusal off the strip.
- `submitTypedAsk` and `panelVoiceView` are pure so the flow is testable without a DOM; `composerAfterAsk` in `ask-luke.tsx` is the composer's post-ask decision, and the stale comments there now describe what the code does.
- `ProductAskOutcome` is exported from `@sidecar/analytics` beside its sibling value-set types.

## Reproduction

With no OpenAI key connected the act router answers `BRAIN_SUBMISSION_REJECTION.ABSENT`; the composer kept the draft and the strip stayed empty. The new tests fail on `origin/main` (`submitTypedAsk`/`panelVoiceView` absent; no path landed the reason on the view) and pass with the fix. A live repro needs the Electron app on a Mac and could not run in this Linux sandbox.

## Tests

- `use-voice-view.test.ts`: a refused ask's reason appears as `voiceNotice` in the view handed to the panel for every rejection and the unanswered case, is a notice and not a caption or a fault, leaves on `VOICE_ERROR_NOTICE_MS`, and is cleared by an accepted ask; the panel's lines stand over the voice window's per slot and an untouched report is handed on as the same object.
- `ask-luke.test.ts`: every refusal keeps the draft and reports `refused`; an accepted ask empties the field and reports `sent`. No DOM test library exists in the workspace, so the component's `submit` is tested through the pure decision it calls rather than by pressing Send.

## Checks

`./scripts/check.sh` passes: repository and design contract checks, Biome, oxlint, typecheck, every package's tests (apps/desktop 660/660, packages/voice 118/118, all others 0 failures), and the desktop build. `./scripts/verify.sh` needs a physical Mac and could not run here; this change draws an existing strip slot with existing tones and timing, so no new visual evidence was captured.

Found by the PR #738 unintended-changes audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/6fdf715b-299d-450b-9640-914ad54b8413)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34411254774/artifacts/10127405889) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34411254774)

- Commit: `b31eb95336b4a3b5cb627ce1e47fc8bf21bde707`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
