### PR TITLE
fix(desktop): an open asked of Luke stands the panel down again

### DIFF
--- a/apps/desktop/src/main/gateway/wiring.ts
+++ b/apps/desktop/src/main/gateway/wiring.ts
@@ -15,6 +15,8 @@ import {
   HOST_NATIVE_NODE_ID,
   HOST_NODE_CAPABILITY,
   HOST_NODE_CAPABILITY_LIST,
+  type HostNodeOpenKind,
+  isHostNodeOpenKind,
 } from "@sidecar/host";
 import { MAIN_SESSION_KEY } from "@sidecar/runtime/vocabulary";
 import { type ConversationEntry, storedConversationEntry } from "@sidecar/session";
@@ -46,7 +48,7 @@ export interface GatewayWiringDependencies {
   state: AppStateStore;
   /** This machine's native capabilities, performed here at the host's ask. */
   node: {
-    openExternal: (url: string) => Promise<void>;
+    openExternal: (url: string, kind: HostNodeOpenKind) => Promise<void>;
     performAppAction: (action: BrainAppActionRequest["action"]) => Promise<WireRecord>;
     runAppleCalendarHelper: (
       helperArguments: readonly string[],
@@ -130,8 +132,9 @@ export function wireGateway(dependencies: GatewayWiringDependencies): GatewayWir
 
   /**
    * The capabilities this process performs at the host's ask. Each is
-   * validated here before anything native runs — the address a string, the
-   * act the shape the panel takes, the helper command one the build knows —
+   * validated here before anything native runs — the address a string and
+   * its kind one the build names, the act the shape the panel takes, the
+   * helper command one the build knows —
    * and each answers the host's own result vocabulary, so a refusal is typed
    * and never a throw that the wire would have to guess at.
    */
@@ -143,8 +146,12 @@ export function wireGateway(dependencies: GatewayWiringDependencies): GatewayWir
     });
     switch (invocation.capability) {
       case HOST_NODE_CAPABILITY.OPEN_EXTERNAL: {
-        if (!isWireString(invocation.params.url)) return failed("open needs a url");
-        await dependencies.node.openExternal(invocation.params.url);
+        const { url, kind } = invocation.params;
+        if (!isWireString(url)) return failed("open needs a url");
+        if (!isWireString(kind) || !isHostNodeOpenKind(kind)) {
+          return failed("open needs a kind this build names");
+        }
+        await dependencies.node.openExternal(url, kind);
         return { status: NODE_CAPABILITY_STATUS.OK, value: undefined };
       }
       case HOST_NODE_CAPABILITY.PANEL_APP_ACTION: {

--- a/apps/desktop/src/main/services/compose-desktop.ts
+++ b/apps/desktop/src/main/services/compose-desktop.ts
@@ -113,6 +113,7 @@ export function composeDesktop(config: DesktopConfig): DesktopServices {
   host.link({ attach: () => operator.start() });
   native.link({
     sendToPrimaryPanel: (channel, payload) => windows.sendToPrimaryPanel(channel, payload),
+    standPanelsDown: () => windows.panels.standDown(),
   });
   operator.link({
     sendToVoice: (channel, payload) => windows.sendToVoice(channel, payload),

--- a/apps/desktop/src/main/services/native-node.ts
+++ b/apps/desktop/src/main/services/native-node.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import type { BrainAppActionRequest } from "@sidecar/brain/requests-wire";
+import type { HostNodeOpenKind } from "@sidecar/host";
 import { ACTION_RESULT_STATUS, type LateRef, lateRef, type WireRecord } from "@sidecar/wire";
 import { systemPreferences } from "electron";
 import { channels } from "#shared/bridge";
@@ -21,6 +22,7 @@ import {
   type OutputVolumeWatch,
 } from "../native/output-volume";
 import type { DesktopConfig } from "./desktop-config";
+import { createNodeOpen } from "./node-open";
 import type { DesktopService } from "./service";
 
 /**
@@ -34,11 +36,17 @@ const BRAIN_APP_ACTION_TIMEOUT_MS = 10_000;
 export interface NativeNodeLinks {
   /** The one window an app act is carried to; none open is a refusal, not a wait. */
   sendToPrimaryPanel: (channel: string, payload: BrainAppActionRequest) => boolean;
+  /**
+   * Every expanded panel back to its capsule, owed by a session opened at an
+   * ask of Luke: the press its row would have taken stood no panel down, and
+   * Luke floats above the very chat he was asked to bring forward.
+   */
+  standPanelsDown: () => void;
 }
 
 /** The capabilities this node offers the host by name; a capability no node offers is a typed refusal there. */
 export interface NativeNodeCapabilities {
-  openExternal: (url: string) => Promise<void>;
+  openExternal: (url: string, kind: HostNodeOpenKind) => Promise<void>;
   performAppAction: (action: BrainAppActionRequest["action"]) => Promise<WireRecord>;
   runAppleCalendarHelper: (
     helperArguments: readonly string[],
@@ -144,7 +152,11 @@ export function createNativeNode(dependencies: NativeNodeDependencies): NativeNo
     name: "native",
     link: (next) => links.set(next),
     capabilities: {
-      openExternal: config.openExternal,
+      openExternal: createNodeOpen({
+        openExternal: config.openExternal,
+        fixtureMode: config.launch.fixtureMode,
+        standPanelsDown: () => links.get().standPanelsDown(),
+      }),
       performAppAction,
       runAppleCalendarHelper,
     },

--- a/apps/desktop/src/main/services/node-open.test.ts
+++ b/apps/desktop/src/main/services/node-open.test.ts
@@ -1,0 +1,53 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { HOST_NODE_OPEN_KIND } from "@sidecar/host";
+import { createNodeOpen } from "./node-open";
+
+const CHAT_URL = "https://example.invalid/chat/1";
+
+function harness(options: { fixtureMode?: boolean; opens?: (url: string) => Promise<void> } = {}) {
+  const opened: string[] = [];
+  let standDowns = 0;
+  const open = createNodeOpen({
+    openExternal: async (url) => {
+      opened.push(url);
+      await options.opens?.(url);
+    },
+    fixtureMode: options.fixtureMode ?? false,
+    standPanelsDown: () => {
+      standDowns += 1;
+    },
+  });
+  return { open, opened, standDowns: () => standDowns };
+}
+
+test("a session opened at an ask of Luke stands the panels down once it has opened", async () => {
+  const { open, opened, standDowns } = harness();
+  await open(CHAT_URL, HOST_NODE_OPEN_KIND.ASKED_SESSION);
+  assert.deepEqual(opened, [CHAT_URL]);
+  assert.equal(standDowns(), 1);
+});
+
+test("an address with a press already behind it leaves the panels where they are", async () => {
+  const { open, opened, standDowns } = harness();
+  await open(CHAT_URL, HOST_NODE_OPEN_KIND.ADDRESS);
+  assert.deepEqual(opened, [CHAT_URL]);
+  assert.equal(standDowns(), 0);
+});
+
+test("an open that did not land moves no panel", async () => {
+  const { open, standDowns } = harness({
+    opens: async () => {
+      throw new Error("no application claims that address");
+    },
+  });
+  await assert.rejects(open(CHAT_URL, HOST_NODE_OPEN_KIND.ASKED_SESSION), /claims/);
+  assert.equal(standDowns(), 0);
+});
+
+test("a fixture run opens the address and leaves its panel to the capture that drives it", async () => {
+  const { open, opened, standDowns } = harness({ fixtureMode: true });
+  await open(CHAT_URL, HOST_NODE_OPEN_KIND.ASKED_SESSION);
+  assert.deepEqual(opened, [CHAT_URL]);
+  assert.equal(standDowns(), 0);
+});

--- a/apps/desktop/src/main/services/node-open.ts
+++ b/apps/desktop/src/main/services/node-open.ts
@@ -1,0 +1,30 @@
+import { HOST_NODE_OPEN_KIND, type HostNodeOpenKind } from "@sidecar/host";
+
+export interface NodeOpenDependencies {
+  /** Hands the address to the operating system; a throw is an open that did not land. */
+  openExternal: (url: string) => Promise<void>;
+  /** A fixture run drives the panel itself, so nothing here moves it. */
+  fixtureMode: boolean;
+  /** Every expanded panel back to its capsule, the way a row press stands its own down. */
+  standPanelsDown: () => void;
+}
+
+/**
+ * The node's open capability: the address to the operating system, then what
+ * this client's own windows owe the open. A session opened at an ask of Luke
+ * had no row press to stand a panel down, so the panel is still up over the
+ * very chat coming forward, and the client stands it down here — only once
+ * the open has landed, because a panel dismissed for an address that never
+ * opened would read as though something had. Every other address leaves the
+ * windows where they are: the desktop's own opens never cross this node, and
+ * a row's press has already stood its panel down.
+ */
+export function createNodeOpen(
+  dependencies: NodeOpenDependencies,
+): (url: string, kind: HostNodeOpenKind) => Promise<void> {
+  return async (url, kind) => {
+    await dependencies.openExternal(url);
+    if (kind !== HOST_NODE_OPEN_KIND.ASKED_SESSION || dependencies.fixtureMode) return;
+    dependencies.standPanelsDown();
+  };
+}

--- a/apps/desktop/src/main/window/panel-manager.ts
+++ b/apps/desktop/src/main/window/panel-manager.ts
@@ -209,6 +209,20 @@ export class PanelManager {
   }
 
   /**
+   * Every expanded panel back to its capsule, the way a row press stands its
+   * own down: a chat is coming forward, and Luke floats above every window on
+   * every display it might land on. Through `setMode`, so a takeover keeps
+   * its display and each renderer is told the mode main decided; a panel
+   * already at its capsule is left alone, since its collapse is done or on
+   * its own clock.
+   */
+  standDown(): void {
+    for (const displayId of this.#windows.keys()) {
+      if (this.modeFor(displayId) === "expanded") this.setMode(displayId, "compact", false);
+    }
+  }
+
+  /**
    * Hands a payload to every living window, optionally skipping the one that
    * already holds the answer in its reply and must redraw from that rather
    * than race a broadcast.

--- a/packages/host/src/compose-observation.ts
+++ b/packages/host/src/compose-observation.ts
@@ -389,7 +389,7 @@ export function composeObservation(dependencies: ObservationDependencies): Obser
 
   const sessionActions = createSessionActionPerformer({
     sessionRegistry,
-    openExternal: (url) => kernel.openExternalThroughNode(url),
+    openExternal: (url, kind) => kernel.openExternalThroughNode(url, kind),
     pluginFor,
     sendsNetwork: runMode.sendsNetwork,
     settingsStore,

--- a/packages/host/src/host-kernel.ts
+++ b/packages/host/src/host-kernel.ts
@@ -2,7 +2,11 @@ import path from "node:path";
 import type { StorePort } from "@sidecar/brain/store";
 import { type GatewayEventKind, NODE_CAPABILITY_STATUS, NodeRegistry } from "@sidecar/gateway";
 import type { WireValue } from "@sidecar/wire";
-import { HOST_NODE_CAPABILITY } from "./node-capabilities.js";
+import {
+  HOST_NODE_CAPABILITY,
+  HOST_NODE_OPEN_KIND,
+  type HostNodeOpenKind,
+} from "./node-capabilities.js";
 import type { RunMode } from "./run-mode.js";
 import type { GatewayService } from "./service.js";
 import { NodeAnswerLostError } from "./session-action-performer.js";
@@ -70,8 +74,10 @@ export interface HostKernel {
    * connected is a refusal the action reports as not done; a node that took the
    * ask and vanished before answering is the lost-answer error, which every
    * caller that journals an action records as unknown rather than failed.
+   * The kind is what the address is, an address unless a caller says
+   * otherwise; the node decides from it what its own windows owe the open.
    */
-  openExternalThroughNode: (url: string) => Promise<void>;
+  openExternalThroughNode: (url: string, kind?: HostNodeOpenKind) => Promise<void>;
   reportOpenFailure: (error: Error) => void;
   agentWorkspacePath: () => string;
   agentSkillsPath: () => string;
@@ -116,8 +122,8 @@ export function createHostKernel(options: HostSeams): HostKernel {
     setService: (next) => {
       service = next;
     },
-    openExternalThroughNode: async (url) => {
-      const result = await nodes.invoke(HOST_NODE_CAPABILITY.OPEN_EXTERNAL, { url });
+    openExternalThroughNode: async (url, kind = HOST_NODE_OPEN_KIND.ADDRESS) => {
+      const result = await nodes.invoke(HOST_NODE_CAPABILITY.OPEN_EXTERNAL, { url, kind });
       if (result.status === NODE_CAPABILITY_STATUS.OK) return;
       if (result.status === NODE_CAPABILITY_STATUS.UNKNOWN) {
         throw new NodeAnswerLostError(result.reason);

--- a/packages/host/src/index.ts
+++ b/packages/host/src/index.ts
@@ -27,7 +27,10 @@ export {
   HOST_NATIVE_NODE_ID,
   HOST_NODE_CAPABILITY,
   HOST_NODE_CAPABILITY_LIST,
+  HOST_NODE_OPEN_KIND,
   HOST_OPERATOR_CLIENT_ID,
+  type HostNodeOpenKind,
+  isHostNodeOpenKind,
 } from "./node-capabilities.js";
 export { onboardingStateFile } from "./onboarding-state.js";
 export { createGatewayOperator, type GatewayOperator } from "./operator.js";

--- a/packages/host/src/node-capabilities.ts
+++ b/packages/host/src/node-capabilities.ts
@@ -13,7 +13,10 @@ export const HOST_OPERATOR_CLIENT_ID = "operator";
 export const HOST_NATIVE_NODE_ID = "native";
 
 export const HOST_NODE_CAPABILITY = {
-  /** Hands an address to the operating system, as a row press does. */
+  /**
+   * Hands an address to the operating system, as a row press does. The
+   * invocation says what the address is, in `HOST_NODE_OPEN_KIND`'s words.
+   */
   OPEN_EXTERNAL: "os.openExternal",
   /** Carries an app action only the panel can perform and answers what became of it. */
   PANEL_APP_ACTION: "panel.performAppAction",
@@ -31,3 +34,31 @@ export type HostNodeCapability = (typeof HOST_NODE_CAPABILITY)[keyof typeof HOST
 
 export const HOST_NODE_CAPABILITY_LIST: readonly HostNodeCapability[] =
   Object.values(HOST_NODE_CAPABILITY);
+
+/**
+ * What the address handed to `OPEN_EXTERNAL` is. The host says only that; the
+ * windows are the client's, so what the client does with its own behind the
+ * open is decided where the windows are.
+ */
+export const HOST_NODE_OPEN_KIND = {
+  /**
+   * An address with nothing owed behind it: a row's own press, whose panel
+   * stood itself down at the press; a consent page; a manager's link.
+   */
+  ADDRESS: "address",
+  /**
+   * A session's address, or one of its app routes, opened at an ask of Luke
+   * in conversation. No row was pressed, so no panel stood itself down, and
+   * Luke floats above the very chat he was asked to bring forward until the
+   * client stands its panels down behind the open.
+   */
+  ASKED_SESSION: "askedSession",
+} as const;
+
+export type HostNodeOpenKind = (typeof HOST_NODE_OPEN_KIND)[keyof typeof HOST_NODE_OPEN_KIND];
+
+const HOST_NODE_OPEN_KIND_SET: ReadonlySet<string> = new Set(Object.values(HOST_NODE_OPEN_KIND));
+
+export function isHostNodeOpenKind(value: string): value is HostNodeOpenKind {
+  return HOST_NODE_OPEN_KIND_SET.has(value);
+}

--- a/packages/host/src/session-action-performer.test.ts
+++ b/packages/host/src/session-action-performer.test.ts
@@ -20,6 +20,7 @@ import {
 } from "@sidecar/session";
 import { ACTION_RESULT_STATUS } from "@sidecar/wire";
 import { admittedForTest } from "@sidecar/wire/testing";
+import { HOST_NODE_OPEN_KIND, type HostNodeOpenKind } from "./node-capabilities.js";
 import { createSessionActionPerformer } from "./session-action-performer.js";
 import type { SettingsStore } from "./settings-store.js";
 
@@ -89,7 +90,11 @@ function heldSettings() {
   return { store, release: () => release?.(), reads: () => reads };
 }
 
-function deeperPerformer(plugin: FakePlugin, settingsStore: Pick<SettingsStore, "get">) {
+function deeperPerformer(
+  plugin: FakePlugin,
+  settingsStore: Pick<SettingsStore, "get">,
+  openExternal: (url: string, kind: HostNodeOpenKind) => Promise<void> = async () => {},
+) {
   const registry = new SessionRoster();
   registry.replaceProvider(plugin.provider, [WORKSPACE_OBSERVATION]);
   const unreachable = async () => {
@@ -97,7 +102,7 @@ function deeperPerformer(plugin: FakePlugin, settingsStore: Pick<SettingsStore, 
   };
   return createSessionActionPerformer({
     sessionRegistry: registry,
-    openExternal: async () => {},
+    openExternal,
     pluginFor: (providerId) => (providerId === plugin.provider.id ? plugin : undefined),
     sendsNetwork: true,
     settingsStore,
@@ -119,13 +124,36 @@ function deeperPerformer(plugin: FakePlugin, settingsStore: Pick<SettingsStore, 
 }
 
 const NOW_DEEP = 1_800_000_000_000;
+const WORKSPACE_LINK = "https://conductor.invalid/workspaces/workspace-1";
+const WORKSPACE_IDENTITY = {
+  providerId: PROVIDER_ID.CONDUCTOR,
+  providerSessionId: "workspace-1",
+} as const;
 const WORKSPACE_OBSERVATION: ProviderSessionObservation = {
   providerSessionId: "workspace-1",
   title: "Fix the flaky test",
   status: SESSION_STATUS.WAITING,
   lastActivityAt: NOW_DEEP,
+  detail: { link: WORKSPACE_LINK },
   advertises: [{ kind: ACTION_KIND.ADD_AGENT, agents: ["claude"] }],
 };
+/** The open the brain carries at an ask of Luke, as admission would have minted it. */
+const OPEN: ValidatedAction<SessionActionKind> = admittedForTest({
+  kind: ACTION_KIND.OPEN,
+  identity: WORKSPACE_IDENTITY,
+  origin: RUN_ORIGIN.USER,
+});
+
+/** The node's open, written down with what the host said each address was. */
+function recordingOpens() {
+  const opens: { url: string; kind: HostNodeOpenKind }[] = [];
+  return {
+    opens,
+    openExternal: async (url: string, kind: HostNodeOpenKind) => {
+      opens.push({ url, kind });
+    },
+  };
+}
 /** What admission would have minted, since only an admitted act reaches a performer. */
 const CREATE: ValidatedAction<SessionActionKind> = admittedForTest({
   kind: ACTION_KIND.CREATE_WORKSPACE,
@@ -230,4 +258,36 @@ test("a row-shaped call with no guard still lands, because a press is its own tu
   settings.release();
   assert.equal((await creating).status, ACTION_RESULT_STATUS.ACCEPTED);
   assert.equal(plugin.creates.length, 1);
+});
+
+test("an open the brain carries tells the node it was asked of Luke, and a row press hands it an address", async () => {
+  const node = recordingOpens();
+  const performer = deeperPerformer(fakePlugin(), heldSettings().store, node.openExternal);
+  assert.equal((await performer.perform(OPEN)).status, ACTION_RESULT_STATUS.ACCEPTED);
+  assert.equal(
+    (await performer.openSession(WORKSPACE_IDENTITY)).status,
+    ACTION_RESULT_STATUS.ACCEPTED,
+  );
+  assert.deepEqual(
+    node.opens.map((open) => open.kind),
+    [HOST_NODE_OPEN_KIND.ASKED_SESSION, HOST_NODE_OPEN_KIND.ADDRESS],
+  );
+  assert.ok(node.opens.every((open) => open.url === WORKSPACE_LINK));
+});
+
+test("an open refused before the node, or lost at it, is answered without the node opening anything of its own", async () => {
+  const node = recordingOpens();
+  const performer = deeperPerformer(fakePlugin(), heldSettings().store, node.openExternal);
+  const absent = admittedForTest({
+    kind: ACTION_KIND.OPEN,
+    identity: { providerId: PROVIDER_ID.CONDUCTOR, providerSessionId: "workspace-gone" },
+    origin: RUN_ORIGIN.USER,
+  });
+  assert.equal((await performer.perform(absent)).status, ACTION_RESULT_STATUS.UNSUPPORTED);
+  assert.equal(node.opens.length, 0);
+
+  const failing = deeperPerformer(fakePlugin(), heldSettings().store, async () => {
+    throw new Error("no application claims that address");
+  });
+  assert.equal((await failing.perform(OPEN)).status, ACTION_RESULT_STATUS.REJECTED);
 });

--- a/packages/host/src/session-action-performer.ts
+++ b/packages/host/src/session-action-performer.ts
@@ -53,6 +53,7 @@ import {
   type UnknownActionResult,
   type WireRecord,
 } from "@sidecar/wire";
+import { HOST_NODE_OPEN_KIND, type HostNodeOpenKind } from "./node-capabilities.js";
 import type { SettingsStore } from "./settings-store.js";
 
 /**
@@ -75,7 +76,13 @@ function unknownOpen(error: ExternalOpenAnswerLostError): SessionOpenResult {
  */
 export interface SessionActionPerformerDependencies {
   sessionRegistry: SessionRoster;
-  openExternal: (url: string) => Promise<void>;
+  /**
+   * Hands an address to the operating system through the native node, told
+   * what the address is: a row's press has already stood its panel down, and
+   * an open asked of Luke has no press behind it, so the client's windows
+   * owe the two different things.
+   */
+  openExternal: (url: string, kind: HostNodeOpenKind) => Promise<void>;
   pluginFor: (providerId: string) => SessionProviderPlugin | undefined;
   sendsNetwork: boolean;
   settingsStore: Pick<SettingsStore, "get">;
@@ -244,6 +251,7 @@ export function createSessionActionPerformer(
     // go are different answers, and only the second says what to try instead.
     absentAddressReason: string,
     failureReason: string,
+    kind: HostNodeOpenKind,
   ): Promise<SessionOpenResult> => {
     const observed = sessionRegistry.get(identity) !== undefined;
     const url = observed ? address(identity) : undefined;
@@ -254,7 +262,7 @@ export function createSessionActionPerformer(
       };
     }
     try {
-      await openExternal(url);
+      await openExternal(url, kind);
     } catch (error) {
       if (error instanceof ExternalOpenAnswerLostError) return unknownOpen(error);
       return { status: ACTION_RESULT_STATUS.REJECTED, reason: failureReason };
@@ -263,17 +271,19 @@ export function createSessionActionPerformer(
     return { status: ACTION_RESULT_STATUS.ACCEPTED };
   };
 
-  const openSession = (identity: SessionIdentity) =>
+  const openSession = (identity: SessionIdentity, kind: HostNodeOpenKind) =>
     openAddress(
       identity,
       (target) => pressedLink(sessionRegistry.get(target)?.detail.link),
       REFUSAL.NO_ADDRESS,
       REFUSAL.OPEN_FAILED,
+      kind,
     );
 
   const openSessionApplication = async (
     identity: SessionIdentity,
     applicationId: SessionApplicationId,
+    kind: HostNodeOpenKind,
   ): Promise<SessionOpenResult> => {
     const session = sessionRegistry.get(identity);
     if (!session) return { status: ACTION_RESULT_STATUS.UNSUPPORTED, reason: REFUSAL.NO_SESSION };
@@ -292,7 +302,7 @@ export function createSessionActionPerformer(
     const url = pressedLink(application.link);
     if (!url) return { status: ACTION_RESULT_STATUS.UNSUPPORTED, reason: REFUSAL.NO_APP_ADDRESS };
     try {
-      await openExternal(url);
+      await openExternal(url, kind);
     } catch (error) {
       if (error instanceof ExternalOpenAnswerLostError) return unknownOpen(error);
       return { status: ACTION_RESULT_STATUS.REJECTED, reason: REFUSAL.OPEN_APP_FAILED };
@@ -301,12 +311,15 @@ export function createSessionActionPerformer(
     return { status: ACTION_RESULT_STATUS.ACCEPTED };
   };
 
+  // The change is a web page beside the chat, not the chat itself: its row
+  // press leaves the panel up, and so does the same open asked of Luke.
   const openSessionChange = (identity: SessionIdentity) =>
     openAddress(
       identity,
       (target) => sessionRegistry.get(target)?.detail.change,
       REFUSAL.NO_CHANGE,
       REFUSAL.OPEN_CHANGE_FAILED,
+      HOST_NODE_OPEN_KIND.ADDRESS,
     );
 
   // A message is handed to the session's own provider, through the adapter
@@ -581,10 +594,16 @@ export function createSessionActionPerformer(
     dispatchByKind(action, {
       [ACTION_KIND.MESSAGE]: sendMessage,
       [ACTION_KIND.CONTROL]: executeControl,
+      // An open the brain carries was asked of Luke, never pressed on a row,
+      // so the node is told a panel still stands over the chat coming forward.
       [ACTION_KIND.OPEN]: async (open): Promise<WireRecord> =>
         open.applicationId
-          ? openSessionApplication(open.identity, open.applicationId)
-          : openSession(open.identity),
+          ? openSessionApplication(
+              open.identity,
+              open.applicationId,
+              HOST_NODE_OPEN_KIND.ASKED_SESSION,
+            )
+          : openSession(open.identity, HOST_NODE_OPEN_KIND.ASKED_SESSION),
       [ACTION_KIND.CREATE_WORKSPACE]: async (creation): Promise<WireRecord> =>
         createWorkspace(creation, guard),
       [ACTION_KIND.ADD_AGENT]: (spawn) => addWorkspaceAgent(spawn, guard),
@@ -599,8 +618,11 @@ export function createSessionActionPerformer(
       }
       return performSessionAction(action, guard);
     },
-    openSession,
-    openSessionApplication,
+    // The two a row press reaches: the pressing panel has stood itself down
+    // already, so the node is handed an address and nothing more.
+    openSession: (identity) => openSession(identity, HOST_NODE_OPEN_KIND.ADDRESS),
+    openSessionApplication: (identity, applicationId) =>
+      openSessionApplication(identity, applicationId, HOST_NODE_OPEN_KIND.ADDRESS),
     openSessionChange,
   };
 }


### PR DESCRIPTION
## What

Before #738, `openSessionAloud` in the renderer dismissed the panel after an accepted open asked of Luke in conversation, with the rationale that Luke floats above the very chat he was asked to bring forward. That PR moved the open into the host (`session-action-performer.ts` → the native node's open capability) and nothing dismissed the panel any more; only a row's own press did, in `use-session-list.ts`.

With the panel up, typing "open the <session> chat" into the Conversation composer brought the chat forward under a panel that stayed open.

## How

The seam is the desktop's, since window control is the client's:

- **Host says what the address is.** `HOST_NODE_OPEN_KIND` in `packages/host/src/node-capabilities.ts` names two kinds the `os.openExternal` invocation now carries beside its url: `address` (a row's press, whose panel stood itself down at the press; a consent page; a manager's link) and `askedSession` (a session's address or app route opened by the brain's `OPEN` action). The performer's brain-facing dispatch hands `askedSession`; the two opens a row press reaches over the Gateway, and the change-page open, hand `address`. Every other caller of `openExternalThroughNode` defaults to `address`.
- **Desktop decides what its windows owe.** The node's open capability (`apps/desktop/src/main/services/node-open.ts`) opens the address and, only for an asked session whose open landed and never in a fixture run, asks the panel manager to stand down. `PanelManager.standDown()` puts every expanded panel back to its capsule through `setMode`, so the introduction takeover keeps its display and each renderer is told the mode main decided on the existing lifecycle channel. No new IPC channel, no second act channel, and the renderer performs no open.
- **Wiring validates the kind** before anything native runs, refusing a kind the build does not name.

A refused open (session gone, no address), an open whose answer was lost at the node, and an open that threw all leave the panel where it is.

## Tests

- `packages/host/src/session-action-performer.test.ts`: the brain's `OPEN` action reaches the node as `askedSession` and the row press's `openSession` as `address`; a refused open never reaches the node and a failed one is rejected. The first fails before the fix, since the node was handed no kind at all.
- `apps/desktop/src/main/services/node-open.test.ts`: an asked session stands the panels down once opened; a plain address, a failed open, and a fixture run do not.

## Checks

`./scripts/check.sh` passes (lint, typecheck, every package's tests, build). `./scripts/verify.sh` needs a physical Mac and could not run in this cloud workspace; no physical-notch check was performed. The change draws nothing new on the panel, so no visual evidence changes.

Found by the PR #738 unintended-changes audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/85b57314-bb1f-48e4-98e6-92af56a41205)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34410483822/artifacts/10127095258) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34410483822)

- Commit: `5d8ca3edf01ab13c8f7e176eef007ed1618baed2`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
