### PR TITLE
feat(LUKE-99): serve and admit against the stored roster snapshot

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -325,11 +325,10 @@ under the "read the recent tail" terms above, and the pass itself still reads
 none. We keep the latest roster it read, encrypted at rest with the same
 server-only secret as your keys, and beside it what changed since the pass
 before — a session that appeared or vanished, a status that moved, an error
-line that changed — so Luke can later be woken by a change rather than by a
-clock, and so the phone
-and watch can later be shown your sessions without asking Conductor again;
-today they still ask Conductor directly. The roster and its changes are
-replaced on every pass; nothing older is kept.
+line that changed — so the phone and watch can show your sessions without
+asking Conductor again, and so Luke can later be woken by a change rather
+than by a clock. The roster and its changes are replaced on every pass;
+nothing older is kept.
 Observation stops, and the stored roster and changes are deleted, when you
 delete the synced key, when you have not signed in for 7 days, and alongside
 your account if you delete that.

--- a/apps/web/server/README.md
+++ b/apps/web/server/README.md
@@ -556,8 +556,12 @@ dated with `observedAt`; a user with no snapshot yet is answered from a live
 pass that seeds one, and `?fresh=true` asks the provider again under the
 endpoint's per-user rate brake. The action routes under `api/actions/` admit
 each ask against the same stored snapshot instead of running a pass, seeding
-one the same way for a user who has none. `api/sessions/messages.ts` is
-unchanged and still runs its own fresh pass before the read.
+one the same way for a user who has none, and `api/projects.ts` lists the
+projects from that snapshot, so a creation can only ever name a project the
+phone was offered. A snapshot observed under keys since replaced is treated
+as none, so a new key never serves or admits against the old key's roster.
+`api/sessions/messages.ts` is unchanged and still runs its own fresh pass
+before the read.
 
 ## Devices
 

--- a/apps/web/server/README.md
+++ b/apps/web/server/README.md
@@ -558,8 +558,9 @@ endpoint's per-user rate brake. The action routes under `api/actions/` admit
 each ask against the same stored snapshot instead of running a pass, seeding
 one the same way for a user who has none, and `api/projects.ts` lists the
 projects from that snapshot, so a creation can only ever name a project the
-phone was offered. A snapshot observed under keys since replaced is treated
-as none, so a new key never serves or admits against the old key's roster.
+phone was offered. A snapshot observed under a key since replaced is treated
+as none, so a new key never serves or admits against the old key's roster;
+the same key saved again, as the Mac does on every launch, keeps it.
 `api/sessions/messages.ts` is unchanged and still runs its own fresh pass
 before the read.
 

--- a/apps/web/server/README.md
+++ b/apps/web/server/README.md
@@ -551,11 +551,13 @@ model runs on the tick, no notification leaves, and the diff is written and
 left. Message cursors are not recorded by the pass, because observation never
 reads a chat's messages; the brain host's own reads will write them.
 
-`api/observe.ts` and the action routes under `api/actions/` still run their
-own live pass per request for now; serving the stored snapshot and admitting
-actions against it lands in a follow-up once the schedule has run in
-production. `api/sessions/messages.ts` keeps its own fresh pass before the
-read either way.
+`api/observe.ts` answers the stored snapshot, mapped onto the wire rows and
+dated with `observedAt`; a user with no snapshot yet is answered from a live
+pass that seeds one, and `?fresh=true` asks the provider again under the
+endpoint's per-user rate brake. The action routes under `api/actions/` admit
+each ask against the same stored snapshot instead of running a pass, seeding
+one the same way for a user who has none. `api/sessions/messages.ts` is
+unchanged and still runs its own fresh pass before the read.
 
 ## Devices
 

--- a/apps/web/server/hosted/action-execute.ts
+++ b/apps/web/server/hosted/action-execute.ts
@@ -30,9 +30,12 @@ import {
   type SessionActionKind,
   type SessionProviderPlugin,
   type WireRecord,
+  type WorkspaceProject,
   workspaceAgentModels,
 } from "../core.js";
 import { cloudSessionPluginFor } from "./cloud-adapters.js";
+import { CLOUD_OBSERVE_FAILURE, type CloudObserveFailure } from "./cloud-observe.js";
+import { type ObservedRoster, rosterProvider } from "./observed-roster.js";
 
 /**
  * The actions a remote client can ask of a cloud session: the session action kinds
@@ -104,12 +107,56 @@ export interface ActionExecuteSeams {
 }
 
 /**
- * One plugin observed once for one action: the same re-observe-before-write
- * discipline the desktop keeps in its observation registry, here as a fresh
- * pass on a request-scoped instance. The pass swallows credential and
- * network failures into an empty roster, so the pass watches its own fetch to
- * tell "the provider refused the key" and "the provider could not be reached"
- * apart from "the session is gone" when the action's target is missing.
+ * The roster an action is admitted against: one provider's slice of the
+ * stored snapshot, or what the pass that would have seeded it came to. The
+ * two flags say why the roster may be empty — the provider refused the key,
+ * or could not be reached — so a target admission cannot find is named for
+ * what actually happened rather than as a session that moved on.
+ */
+export interface ActionRoster {
+  observations: readonly ProviderSessionObservation[];
+  projects: readonly WorkspaceProject[];
+  unauthorized: boolean;
+  unreachable: boolean;
+}
+
+/**
+ * One provider's slice of a roster for admission: the stored snapshot's when
+ * one stands, and otherwise the empty roster a failed seeding pass left,
+ * flagged with why. A snapshot that holds nothing for the provider is a
+ * provider the user's keys never opened, which admission reads as no
+ * session rather than as a failure.
+ */
+export function actionRosterFor(
+  providerId: CloudAgentProviderId,
+  standing: { roster?: ObservedRoster; failure?: CloudObserveFailure },
+): ActionRoster {
+  const slice = standing.roster ? rosterProvider(standing.roster, providerId) : undefined;
+  if (slice) {
+    return {
+      observations: slice.observations,
+      projects: slice.projects,
+      unauthorized: false,
+      unreachable: false,
+    };
+  }
+  const unauthorized = standing.failure === CLOUD_OBSERVE_FAILURE.UNAUTHORIZED;
+  return {
+    observations: [],
+    projects: [],
+    unauthorized,
+    unreachable: !unauthorized && standing.failure !== undefined,
+  };
+}
+
+/**
+ * One plugin observed once for one conversation read: the same
+ * re-observe-before-read discipline the desktop keeps in its observation
+ * registry, here as a fresh pass on a request-scoped instance. The pass
+ * swallows credential and network failures into an empty roster, so the pass
+ * watches its own fetch to tell "the provider refused the key" and "the
+ * provider could not be reached" apart from "the session is gone" when the
+ * read's target is missing.
  */
 interface ObservedActionPass {
   plugin: SessionProviderPlugin;
@@ -144,10 +191,35 @@ async function observeForAction(
   return { plugin, observations, ...pass };
 }
 
-/** Why an action's target was not in the fresh pass, as the user should hear it. */
+/**
+ * The plugin an action is dispatched through, answering for the roster the
+ * action was admitted against. `dispatchAction` resolves every target from
+ * the plugin's own latest roster, so the plugin built for this one write
+ * reads the snapshot's observations and projects as its own latest pass, and
+ * every effect's route is built out of the same roster the user was shown.
+ */
+function pluginOverRoster(
+  providerId: CloudAgentProviderId,
+  apiKey: string,
+  roster: ActionRoster,
+  seams: ActionExecuteSeams,
+): SessionProviderPlugin {
+  const plugin = cloudSessionPluginFor(providerId, {
+    readApiKey: async () => apiKey,
+    ...(seams.fetch ? { fetch: seams.fetch } : undefined),
+    ...(seams.now ? { now: seams.now } : undefined),
+  });
+  return {
+    ...plugin,
+    latest: () => roster.observations,
+    projects: () => roster.projects,
+  };
+}
+
+/** Why an action's target was not in the roster, as the user should hear it. */
 function missingTargetReason(
   providerId: CloudAgentProviderId,
-  pass: Pick<ObservedActionPass, "unauthorized" | "unreachable">,
+  pass: Pick<ActionRoster, "unauthorized" | "unreachable">,
   missing: string,
 ): string {
   const displayName = PROVIDER_IDENTITY_BY_ID[providerId].displayName;
@@ -177,21 +249,22 @@ function fromProviderResult(
 }
 
 /**
- * The roster and the projects admission reads, over the one pass this request
- * ran. Admission is where "the target has to be one the roster holds" is
- * answered, so what it reads is that pass and never a caller's copy of it; the
- * phone's own press is the origin, which is recorded and never a permission.
+ * The roster and the projects admission reads, over the snapshot this action
+ * stands on. Admission is where "the target has to be one the roster holds"
+ * is answered, so what it reads is that roster and never a caller's copy of
+ * it; the phone's own press is the origin, which is recorded and never a
+ * permission.
  */
-function admissionOver(pass: ObservedActionPass): AdmitContext {
-  const { provider } = pass.plugin;
+function admissionOver(plugin: SessionProviderPlugin, roster: ActionRoster): AdmitContext {
+  const { provider } = plugin;
   return {
     origin: RUN_ORIGIN.USER,
     roster: {
-      read: async () => pass.observations.map((one) => normalizeSession(provider, one)),
+      read: async () => roster.observations.map((one) => normalizeSession(provider, one)),
     },
     projects: {
       read: async () =>
-        (pass.plugin.projects?.() ?? []).map((project) => ({
+        roster.projects.map((project) => ({
           ...project,
           providerId: provider.id,
           providerName: provider.displayName,
@@ -219,7 +292,7 @@ function missingTargetPhrase(reason: string): string | undefined {
 
 function fromRefusal(
   providerId: CloudAgentProviderId,
-  pass: ObservedActionPass,
+  pass: Pick<ActionRoster, "unauthorized" | "unreachable">,
   refusal: Refusal,
 ): ActionExecutionAnswer {
   const missing = missingTargetPhrase(refusal.reason);
@@ -231,11 +304,13 @@ function fromRefusal(
 
 /**
  * One action a remote client asked, admitted and carried. The build's own
- * capability map answers first, before a pass exists; then one fresh
- * observation pass runs, `admit()` reads that pass for itself — the session or
- * the project it names, the advertisement it stands on, the bounds on the
- * developer's own words — and only the validated action it mints reaches the
- * adapter, which builds each effect's route back out of the same pass.
+ * capability map answers first; then `admit()` reads the roster the action
+ * stands on for itself — the stored snapshot's slice for this provider, the
+ * session or the project it names, the advertisement it stands on, the
+ * bounds on the developer's own words — and only the validated action it
+ * mints reaches the adapter, which builds each effect's route back out of
+ * the same roster. No pass runs here: the snapshot is what the user was
+ * shown, and the provider answers for whether the target still stands.
  */
 export async function executeSessionAction(options: {
   kind: HostedSessionActionKind;
@@ -243,18 +318,18 @@ export async function executeSessionAction(options: {
   /** The ask's own fields, keyed by the names admission reads, unparsed. */
   fields: WireRecord;
   apiKey: string;
+  roster: ActionRoster;
   seams?: ActionExecuteSeams;
 }): Promise<ActionExecutionAnswer> {
-  const { kind, providerId, fields, apiKey } = options;
+  const { kind, providerId, fields, apiKey, roster } = options;
   const unsupported = actionUnsupportedReason(kind, providerId);
   if (unsupported) return { result: ACTION_RESULT_STATUS.UNSUPPORTED, reason: unsupported };
 
-  const pass = await observeForAction(providerId, apiKey, options.seams ?? {});
+  const plugin = pluginOverRoster(providerId, apiKey, roster, options.seams ?? {});
   const request: ActionRequest<HostedSessionActionKind> = { kind, fields };
-  const admitted = await admit(request, admissionOver(pass));
-  if (admitted.kind === undefined) return fromRefusal(providerId, pass, admitted);
+  const admitted = await admit(request, admissionOver(plugin, roster));
+  if (admitted.kind === undefined) return fromRefusal(providerId, roster, admitted);
 
-  const { plugin } = pass;
   return dispatchByKind(admitted, {
     [ACTION_KIND.MESSAGE]: async (action) =>
       fromProviderResult(await dispatchAction(plugin, "message", providerSessionMessage(action))),

--- a/apps/web/server/hosted/action-session.ts
+++ b/apps/web/server/hosted/action-session.ts
@@ -12,12 +12,14 @@ import {
 } from "../core.js";
 import {
   type ActionExecutionAnswer,
+  type ActionRoster,
   actionUnsupportedReason,
   executeSessionAction,
   type HostedSessionActionKind,
 } from "./action-execute.js";
 import { decryptProviderKey, secretOrUnavailable } from "./encryption.js";
 import { errorResponse, HOSTED_API_ERROR, HOSTED_HTTP_STATUS, jsonResponse } from "./http.js";
+import { rosterForAction } from "./observation-pass.js";
 import type { HostedVaultRoute } from "./vault-route.js";
 
 /** Maximum length accepted for a provider session id in a URL segment. */
@@ -75,7 +77,7 @@ function aimed(
  * creation names a project instead. Nothing here validates a value: it is
  * renamed and handed on unparsed, because whether it is a message, a name, a
  * task, or a model any session or project actually takes is `admit()`'s
- * question, asked once, against the observation pass the action goes out on.
+ * question, asked once, against the stored snapshot the action stands on.
  */
 const HOSTED_ACTION_FIELDS = {
   [ACTION_KIND.MESSAGE]: (body: WireRecord) => aimed(body, { text: body.text }),
@@ -103,11 +105,17 @@ const HOSTED_ACTION_FIELDS = {
  * before a key is required, and the stored key decrypted only for a request
  * that passed everything else. What a route names is the action's own kind;
  * everything about whether that action may run is admission's, one layer down,
- * over the same observation pass the write goes out on.
+ * over the stored snapshot the user was shown.
  */
 export interface SessionActionOptions
   extends Pick<HostedVaultRoute, "request" | "resolveUserId" | "encryptionSecret" | "readKey"> {
   kind: HostedSessionActionKind;
+  /** The roster this action is admitted against: the stored snapshot's slice, or the pass that seeds one. */
+  roster: (
+    userId: string,
+    providerId: CloudAgentProviderId,
+    secret: string,
+  ) => Promise<ActionRoster>;
   /**
    * The reason this provider cannot take this action. Injected only in tests:
    * every action this build ships is supported by its one provider, so the
@@ -121,6 +129,7 @@ export interface SessionActionOptions
     providerId: CloudAgentProviderId;
     fields: WireRecord;
     apiKey: string;
+    roster: ActionRoster;
   }) => Promise<ActionExecutionAnswer>;
 }
 
@@ -236,25 +245,47 @@ export async function handleSessionAction(options: SessionActionOptions): Promis
   const key = await apiKeyOrAnswer(options.readKey, userId, providerId, secret);
   if (key instanceof Response) return key;
 
+  const roster = await options.roster(userId, providerId, secret);
   const execute = options.execute ?? executeSessionAction;
-  return actionAnswer(await execute({ kind, providerId, fields, apiKey: key.apiKey }));
+  return actionAnswer(await execute({ kind, providerId, fields, apiKey: key.apiKey, roster }));
+}
+
+/**
+ * The roster a deployed route admits against: the stored snapshot, or the
+ * pass that seeds one for a user no scheduled pass has reached yet.
+ */
+function routeRoster(route: HostedVaultRoute): SessionActionOptions["roster"] {
+  return (userId, providerId, secret) =>
+    rosterForAction({
+      userId,
+      providerId,
+      secret,
+      store: route.store(secret),
+      readVaultKeys: route.readVaultKeys,
+      seams: {},
+      now: Date.now(),
+    });
 }
 
 /** The six actions, each as the one thing its route names. */
 export const handleMessageAction = (route: HostedVaultRoute): Promise<Response> =>
-  handleSessionAction({ ...route, kind: ACTION_KIND.MESSAGE });
+  handleSessionAction({ ...route, kind: ACTION_KIND.MESSAGE, roster: routeRoster(route) });
 
 export const handleControlAction = (route: HostedVaultRoute): Promise<Response> =>
-  handleSessionAction({ ...route, kind: ACTION_KIND.CONTROL });
+  handleSessionAction({ ...route, kind: ACTION_KIND.CONTROL, roster: routeRoster(route) });
 
 export const handleAgentAction = (route: HostedVaultRoute): Promise<Response> =>
-  handleSessionAction({ ...route, kind: ACTION_KIND.ADD_AGENT });
+  handleSessionAction({ ...route, kind: ACTION_KIND.ADD_AGENT, roster: routeRoster(route) });
 
 export const handleRenameSessionAction = (route: HostedVaultRoute): Promise<Response> =>
-  handleSessionAction({ ...route, kind: ACTION_KIND.RENAME_SESSION });
+  handleSessionAction({ ...route, kind: ACTION_KIND.RENAME_SESSION, roster: routeRoster(route) });
 
 export const handleRenameWorkspaceAction = (route: HostedVaultRoute): Promise<Response> =>
-  handleSessionAction({ ...route, kind: ACTION_KIND.RENAME_WORKSPACE });
+  handleSessionAction({
+    ...route,
+    kind: ACTION_KIND.RENAME_WORKSPACE,
+    roster: routeRoster(route),
+  });
 
 export const handleWorkspaceAction = (route: HostedVaultRoute): Promise<Response> =>
-  handleSessionAction({ ...route, kind: ACTION_KIND.CREATE_WORKSPACE });
+  handleSessionAction({ ...route, kind: ACTION_KIND.CREATE_WORKSPACE, roster: routeRoster(route) });

--- a/apps/web/server/hosted/observation-pass.ts
+++ b/apps/web/server/hosted/observation-pass.ts
@@ -1,4 +1,4 @@
-import { createHmac, randomUUID } from "node:crypto";
+import { pbkdf2Sync, randomUUID } from "node:crypto";
 import { type CloudAgentProviderId, isCloudAgentProviderId } from "../core.js";
 import { type ActionRoster, actionRosterFor } from "./action-execute.js";
 import {
@@ -72,14 +72,33 @@ export interface StoredSnapshot {
 }
 
 /**
- * What identifies the key a provider was observed under: an HMAC of the key
- * itself under the deployment's secret. The same key saved again — which the
- * Mac does on every launch, rewriting the stored ciphertext under a fresh
- * nonce — keeps its fingerprint, and a different key has another; the
- * fingerprint itself reveals nothing about the key.
+ * How a key's fingerprint is derived. The key is a credential, so the
+ * derivation is a password one rather than a plain hash: salted with the
+ * deployment's secret and stretched, so a fingerprint in a stored snapshot
+ * cannot be brute-forced back to the key even with the database in hand.
+ * The stretch is kept light because every read of the snapshot derives one
+ * fingerprint per key row.
+ */
+const KEY_FINGERPRINT = {
+  ITERATIONS: 10_000,
+  LENGTH_BYTES: 32,
+  DIGEST: "sha256",
+} as const;
+
+/**
+ * What identifies the key a provider was observed under: a derivation of the
+ * key itself under the deployment's secret. The same key saved again — which
+ * the Mac does on every launch, rewriting the stored ciphertext under a fresh
+ * nonce — keeps its fingerprint, and a different key has another.
  */
 export function keyFingerprint(apiKey: string, secret: string): string {
-  return createHmac("sha256", secret).update(apiKey).digest("hex");
+  return pbkdf2Sync(
+    apiKey,
+    secret,
+    KEY_FINGERPRINT.ITERATIONS,
+    KEY_FINGERPRINT.LENGTH_BYTES,
+    KEY_FINGERPRINT.DIGEST,
+  ).toString("hex");
 }
 
 /** The fingerprint of each cloud provider's standing key, by provider; a row this secret cannot open names none. */

--- a/apps/web/server/hosted/observation-pass.ts
+++ b/apps/web/server/hosted/observation-pass.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import { type CloudAgentProviderId, isCloudAgentProviderId } from "../core.js";
 import { type ActionRoster, actionRosterFor } from "./action-execute.js";
 import {
@@ -59,19 +59,55 @@ export function keyedCloudProviderIds(rows: readonly VaultKeyRow[]): CloudAgentP
 
 /**
  * The snapshot standing for a user: its instant always, and its roster where
- * this build can open and read the body. A body it cannot — sealed under a
- * key the ring no longer holds, or in a shape another build wrote — keeps
- * its instant here so the next pass can replace it, and offers no roster to
- * serve or to diff against.
+ * this build can open and read the body and the body was observed under the
+ * key rows standing now. A body it cannot read — sealed under a key the ring
+ * no longer holds, or in a shape another build wrote — or one observed under
+ * a key since replaced or removed keeps its instant here so the next pass can
+ * replace it, and offers no roster to serve or to diff against.
  */
 export interface StoredSnapshot {
   readonly observedAt: number;
   readonly roster?: ObservedRoster;
 }
 
+/**
+ * What identifies the key row a provider was observed under: a hash of its
+ * ciphertext, which every store of a key rewrites under a fresh nonce, so a
+ * replaced key — even the same key saved again — reads as another row. The
+ * hash says nothing about the key itself.
+ */
+export function keyFingerprint(row: VaultKeyRow): string {
+  return createHash("sha256").update(row.ciphertext).digest("hex");
+}
+
+function keyFingerprints(rows: readonly VaultKeyRow[]): Map<CloudAgentProviderId, string> {
+  const fingerprints = new Map<CloudAgentProviderId, string>();
+  for (const row of rows) {
+    if (isCloudAgentProviderId(row.providerId) && !fingerprints.has(row.providerId)) {
+      fingerprints.set(row.providerId, keyFingerprint(row));
+    }
+  }
+  return fingerprints;
+}
+
+/**
+ * Whether a snapshot was observed under exactly the key rows standing now:
+ * the same providers, each under the same row. A snapshot that was not is
+ * another key's roster, however recent, and is neither served nor admitted
+ * against nor diffed from.
+ */
+export function rosterObservedUnder(roster: ObservedRoster, rows: readonly VaultKeyRow[]): boolean {
+  const standing = keyFingerprints(rows);
+  if (roster.providers.length !== standing.size) return false;
+  return roster.providers.every(
+    (provider) => standing.get(provider.providerId) === provider.keyFingerprint,
+  );
+}
+
 export async function storedRoster(
   store: ObservationStore,
   userId: string,
+  rows: readonly VaultKeyRow[],
 ): Promise<StoredSnapshot | undefined> {
   let snapshot: Awaited<ReturnType<ObservationStore["roster"]["read"]>>;
   try {
@@ -82,7 +118,9 @@ export async function storedRoster(
   }
   if (!snapshot) return undefined;
   const roster = decodeObservedRoster(snapshot.body);
-  return roster ? { observedAt: snapshot.observedAt, roster } : { observedAt: snapshot.observedAt };
+  return roster && rosterObservedUnder(roster, rows)
+    ? { observedAt: snapshot.observedAt, roster }
+    : { observedAt: snapshot.observedAt };
 }
 
 export async function observeAndSnapshot(
@@ -97,7 +135,7 @@ export async function observeAndSnapshot(
     attemptedAt: now,
     failure: CLOUD_OBSERVE_FAILURE.UNFINISHED,
   });
-  const previous = await storedRoster(store, userId);
+  const previous = await storedRoster(store, userId, input.rows);
   const standing: Pick<ObservationPassOutcome, "roster" | "observedAt"> = {};
   if (previous?.roster) {
     standing.roster = previous.roster;
@@ -116,10 +154,12 @@ export async function observeAndSnapshot(
     return { complete: false, failure: failed.failure, changed: false, ...standing };
   }
 
+  const fingerprints = keyFingerprints(input.rows);
   const roster: ObservedRoster = {
     version: OBSERVED_ROSTER_VERSION,
     providers: passes.map((pass) => ({
       providerId: pass.providerId,
+      keyFingerprint: fingerprints.get(pass.providerId) ?? "",
       observations: pass.observations,
       projects: pass.projects,
     })),
@@ -163,7 +203,7 @@ export async function observeAndSnapshot(
     // moves forward, so an older instant here changes nothing, and a newer
     // one closes the unfinished attempt it opened above.
     await store.roster.recordPass(userId, { attemptedAt: now });
-    const superseded = await storedRoster(store, userId);
+    const superseded = await storedRoster(store, userId, input.rows);
     const outcome: ObservationPassOutcome = { complete: true, changed: false };
     if (superseded?.roster) {
       outcome.roster = superseded.roster;
@@ -176,9 +216,10 @@ export async function observeAndSnapshot(
 
 /**
  * The roster an action is admitted against: the stored snapshot's slice for
- * the provider, or, for a user no pass has reached yet, the pass that seeds
- * the snapshot — run once here so the next action and the next observe read
- * what it stored rather than asking the provider again.
+ * the provider, or, for a user no pass has reached yet or whose keys have
+ * changed since the last one, the pass that seeds the snapshot — run once
+ * here so the next action and the next observe read what it stored rather
+ * than asking the provider again.
  */
 export async function rosterForAction(input: {
   userId: string;
@@ -189,11 +230,12 @@ export async function rosterForAction(input: {
   seams: CloudObserveSeams;
   now: number;
 }): Promise<ActionRoster> {
-  const stored = await storedRoster(input.store, input.userId);
+  const rows = await input.readVaultKeys(input.userId);
+  const stored = await storedRoster(input.store, input.userId, rows);
   if (stored?.roster) return actionRosterFor(input.providerId, { roster: stored.roster });
   const outcome = await observeAndSnapshot({
     userId: input.userId,
-    rows: await input.readVaultKeys(input.userId),
+    rows,
     secret: input.secret,
     store: input.store,
     seams: input.seams,

--- a/apps/web/server/hosted/observation-pass.ts
+++ b/apps/web/server/hosted/observation-pass.ts
@@ -127,7 +127,7 @@ function keyFingerprints(
  * another key's roster, however recent, and is neither served nor admitted
  * against nor diffed from.
  */
-export function rosterObservedUnder(
+function rosterObservedUnder(
   roster: ObservedRoster,
   rows: readonly VaultKeyRow[],
   secret: string,

--- a/apps/web/server/hosted/observation-pass.ts
+++ b/apps/web/server/hosted/observation-pass.ts
@@ -1,4 +1,4 @@
-import { createHash, randomUUID } from "node:crypto";
+import { createHmac, randomUUID } from "node:crypto";
 import { type CloudAgentProviderId, isCloudAgentProviderId } from "../core.js";
 import { type ActionRoster, actionRosterFor } from "./action-execute.js";
 import {
@@ -7,6 +7,7 @@ import {
   type CloudObserveSeams,
   observeCloudProviders,
 } from "./cloud-observe.js";
+import { decryptProviderKey } from "./encryption.js";
 import {
   decodeObservedRoster,
   encodeObservedRoster,
@@ -71,33 +72,48 @@ export interface StoredSnapshot {
 }
 
 /**
- * What identifies the key row a provider was observed under: a hash of its
- * ciphertext, which every store of a key rewrites under a fresh nonce, so a
- * replaced key — even the same key saved again — reads as another row. The
- * hash says nothing about the key itself.
+ * What identifies the key a provider was observed under: an HMAC of the key
+ * itself under the deployment's secret. The same key saved again — which the
+ * Mac does on every launch, rewriting the stored ciphertext under a fresh
+ * nonce — keeps its fingerprint, and a different key has another; the
+ * fingerprint itself reveals nothing about the key.
  */
-export function keyFingerprint(row: VaultKeyRow): string {
-  return createHash("sha256").update(row.ciphertext).digest("hex");
+export function keyFingerprint(apiKey: string, secret: string): string {
+  return createHmac("sha256", secret).update(apiKey).digest("hex");
 }
 
-function keyFingerprints(rows: readonly VaultKeyRow[]): Map<CloudAgentProviderId, string> {
+/** The fingerprint of each cloud provider's standing key, by provider; a row this secret cannot open names none. */
+function keyFingerprints(
+  rows: readonly VaultKeyRow[],
+  secret: string,
+): Map<CloudAgentProviderId, string> {
   const fingerprints = new Map<CloudAgentProviderId, string>();
   for (const row of rows) {
-    if (isCloudAgentProviderId(row.providerId) && !fingerprints.has(row.providerId)) {
-      fingerprints.set(row.providerId, keyFingerprint(row));
+    if (!isCloudAgentProviderId(row.providerId) || fingerprints.has(row.providerId)) continue;
+    try {
+      fingerprints.set(
+        row.providerId,
+        keyFingerprint(decryptProviderKey(row.ciphertext, secret), secret),
+      );
+    } catch {
+      // A key this deployment cannot open observed nothing; the pass reports it as unreadable.
     }
   }
   return fingerprints;
 }
 
 /**
- * Whether a snapshot was observed under exactly the key rows standing now:
- * the same providers, each under the same row. A snapshot that was not is
+ * Whether a snapshot was observed under exactly the keys standing now: the
+ * same providers, each under the same key. A snapshot that was not is
  * another key's roster, however recent, and is neither served nor admitted
  * against nor diffed from.
  */
-export function rosterObservedUnder(roster: ObservedRoster, rows: readonly VaultKeyRow[]): boolean {
-  const standing = keyFingerprints(rows);
+export function rosterObservedUnder(
+  roster: ObservedRoster,
+  rows: readonly VaultKeyRow[],
+  secret: string,
+): boolean {
+  const standing = keyFingerprints(rows, secret);
   if (roster.providers.length !== standing.size) return false;
   return roster.providers.every(
     (provider) => standing.get(provider.providerId) === provider.keyFingerprint,
@@ -108,6 +124,7 @@ export async function storedRoster(
   store: ObservationStore,
   userId: string,
   rows: readonly VaultKeyRow[],
+  secret: string,
 ): Promise<StoredSnapshot | undefined> {
   let snapshot: Awaited<ReturnType<ObservationStore["roster"]["read"]>>;
   try {
@@ -118,7 +135,7 @@ export async function storedRoster(
   }
   if (!snapshot) return undefined;
   const roster = decodeObservedRoster(snapshot.body);
-  return roster && rosterObservedUnder(roster, rows)
+  return roster && rosterObservedUnder(roster, rows, secret)
     ? { observedAt: snapshot.observedAt, roster }
     : { observedAt: snapshot.observedAt };
 }
@@ -135,7 +152,7 @@ export async function observeAndSnapshot(
     attemptedAt: now,
     failure: CLOUD_OBSERVE_FAILURE.UNFINISHED,
   });
-  const previous = await storedRoster(store, userId, input.rows);
+  const previous = await storedRoster(store, userId, input.rows, input.secret);
   const standing: Pick<ObservationPassOutcome, "roster" | "observedAt"> = {};
   if (previous?.roster) {
     standing.roster = previous.roster;
@@ -154,7 +171,7 @@ export async function observeAndSnapshot(
     return { complete: false, failure: failed.failure, changed: false, ...standing };
   }
 
-  const fingerprints = keyFingerprints(input.rows);
+  const fingerprints = keyFingerprints(input.rows, input.secret);
   const roster: ObservedRoster = {
     version: OBSERVED_ROSTER_VERSION,
     providers: passes.map((pass) => ({
@@ -203,7 +220,7 @@ export async function observeAndSnapshot(
     // moves forward, so an older instant here changes nothing, and a newer
     // one closes the unfinished attempt it opened above.
     await store.roster.recordPass(userId, { attemptedAt: now });
-    const superseded = await storedRoster(store, userId, input.rows);
+    const superseded = await storedRoster(store, userId, input.rows, input.secret);
     const outcome: ObservationPassOutcome = { complete: true, changed: false };
     if (superseded?.roster) {
       outcome.roster = superseded.roster;
@@ -231,7 +248,7 @@ export async function rosterForAction(input: {
   now: number;
 }): Promise<ActionRoster> {
   const rows = await input.readVaultKeys(input.userId);
-  const stored = await storedRoster(input.store, input.userId, rows);
+  const stored = await storedRoster(input.store, input.userId, rows, input.secret);
   if (stored?.roster) return actionRosterFor(input.providerId, { roster: stored.roster });
   const outcome = await observeAndSnapshot({
     userId: input.userId,

--- a/apps/web/server/hosted/observation-pass.ts
+++ b/apps/web/server/hosted/observation-pass.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { type CloudAgentProviderId, isCloudAgentProviderId } from "../core.js";
+import { type ActionRoster, actionRosterFor } from "./action-execute.js";
 import {
   CLOUD_OBSERVE_FAILURE,
   type CloudObserveFailure,
@@ -171,4 +172,32 @@ export async function observeAndSnapshot(
     return outcome;
   }
   return { complete: true, changed, roster, observedAt: now };
+}
+
+/**
+ * The roster an action is admitted against: the stored snapshot's slice for
+ * the provider, or, for a user no pass has reached yet, the pass that seeds
+ * the snapshot — run once here so the next action and the next observe read
+ * what it stored rather than asking the provider again.
+ */
+export async function rosterForAction(input: {
+  userId: string;
+  providerId: CloudAgentProviderId;
+  secret: string;
+  store: ObservationStore;
+  readVaultKeys: (userId: string) => Promise<VaultKeyRow[]>;
+  seams: CloudObserveSeams;
+  now: number;
+}): Promise<ActionRoster> {
+  const stored = await storedRoster(input.store, input.userId);
+  if (stored?.roster) return actionRosterFor(input.providerId, { roster: stored.roster });
+  const outcome = await observeAndSnapshot({
+    userId: input.userId,
+    rows: await input.readVaultKeys(input.userId),
+    secret: input.secret,
+    store: input.store,
+    seams: input.seams,
+    now: input.now,
+  });
+  return actionRosterFor(input.providerId, outcome);
 }

--- a/apps/web/server/hosted/observe.ts
+++ b/apps/web/server/hosted/observe.ts
@@ -51,9 +51,10 @@ export interface ObserveOptions
  * The signed-in user's cloud roster: the snapshot the scheduled pass last
  * stored, mapped onto the bounded wire rows. A live pass runs only where the
  * caller asked for a fresh read — under the per-user brake, since a pass is
- * the whole provider fan-out — or where no snapshot stands yet, and either
- * way it is the same pass the schedule runs, stored the same way. A user with
- * no cloud key has no roster to read or store and is answered empty.
+ * the whole provider fan-out — or where no snapshot stands yet or the one
+ * standing was observed under keys since replaced, and either way it is the
+ * same pass the schedule runs, stored the same way. A user with no cloud key
+ * has no roster to read or store and is answered empty.
  */
 export async function handleObserve(options: ObserveOptions): Promise<Response> {
   const { request, resolveUserId, encryptionSecret, readVaultKeys } = options;
@@ -84,7 +85,7 @@ export async function handleObserve(options: ObserveOptions): Promise<Response> 
   const fresh =
     new URL(request.url).searchParams.get(OBSERVE_QUERY.FRESH) === OBSERVE_QUERY.FRESH_VALUE;
   if (!fresh) {
-    const stored = await storedRoster(store, userId);
+    const stored = await storedRoster(store, userId, rows);
     if (stored?.roster) {
       return jsonResponse(HOSTED_HTTP_STATUS.OK, observeAnswer(stored.roster, stored.observedAt));
     }

--- a/apps/web/server/hosted/observe.ts
+++ b/apps/web/server/hosted/observe.ts
@@ -5,13 +5,21 @@ import {
   advertisedControls,
   type CloudAgentProviderId,
   normalizeSessionDetail,
+  OBSERVE_QUERY,
+  type ObserveAnswer,
   type ObservedSession,
   type ObservedSessionControl,
 } from "../core.js";
 import { providerReadsConversation } from "./action-execute.js";
 import { errorResponse, HOSTED_API_ERROR, HOSTED_HTTP_STATUS, jsonResponse } from "./http.js";
+import {
+  keyedCloudProviderIds,
+  type ObservationStore,
+  observeAndSnapshot,
+  storedRoster,
+} from "./observation-pass.js";
+import type { ObservedRoster } from "./observed-roster.js";
 import { createRateBrake } from "./rate-brake.js";
-import { observeProviders, readApiKeyFor } from "./vault-keys.js";
 import type { HostedVaultRoute } from "./vault-route.js";
 
 const OBSERVE_RATE_LIMIT = {
@@ -31,15 +39,21 @@ export interface ObserveOptions
     HostedVaultRoute,
     "request" | "resolveUserId" | "encryptionSecret" | "readVaultKeys"
   > {
+  /** The store the snapshot is read from and, on a live pass, written to. */
+  store: (secret: string) => ObservationStore;
   /** Injected in tests; production uses the global fetch. */
   fetch?: CloudFetch;
   now?: () => number;
+  sleep?: (ms: number) => Promise<void>;
 }
 
 /**
- * Observe-on-demand: decrypts the caller's vault keys, runs each cloud
- * adapter once (minimumRefreshIntervalMs: 0 bypasses the refresh debounce),
- * and returns a bounded roster. Nothing is stored between requests.
+ * The signed-in user's cloud roster: the snapshot the scheduled pass last
+ * stored, mapped onto the bounded wire rows. A live pass runs only where the
+ * caller asked for a fresh read — under the per-user brake, since a pass is
+ * the whole provider fan-out — or where no snapshot stands yet, and either
+ * way it is the same pass the schedule runs, stored the same way. A user with
+ * no cloud key has no roster to read or store and is answered empty.
  */
 export async function handleObserve(options: ObserveOptions): Promise<Response> {
   const { request, resolveUserId, encryptionSecret, readVaultKeys } = options;
@@ -61,33 +75,56 @@ export async function handleObserve(options: ObserveOptions): Promise<Response> 
     return errorResponse(HOSTED_HTTP_STATUS.SERVICE_UNAVAILABLE, HOSTED_API_ERROR.UNAVAILABLE);
   }
 
+  const rows = await readVaultKeys(userId);
+  if (keyedCloudProviderIds(rows).length === 0) {
+    return jsonResponse(HOSTED_HTTP_STATUS.OK, observeAnswer(undefined, undefined));
+  }
+
+  const store = options.store(secret);
+  const fresh =
+    new URL(request.url).searchParams.get(OBSERVE_QUERY.FRESH) === OBSERVE_QUERY.FRESH_VALUE;
+  if (!fresh) {
+    const stored = await storedRoster(store, userId);
+    if (stored?.roster) {
+      return jsonResponse(HOSTED_HTTP_STATUS.OK, observeAnswer(stored.roster, stored.observedAt));
+    }
+  }
+
   const now = (options.now ?? Date.now)();
   if (observeRateLimited(userId, now)) {
     return errorResponse(HOSTED_HTTP_STATUS.TOO_MANY_REQUESTS, HOSTED_API_ERROR.QUOTA_EXHAUSTED);
   }
 
-  const rows = await readVaultKeys(userId);
-  const passes = await observeProviders({
-    readApiKey: readApiKeyFor(rows, secret),
-    read: (adapter) => adapter.observe(),
+  const outcome = await observeAndSnapshot({
+    userId,
+    rows,
+    secret,
+    store,
     seams: options,
+    now,
   });
+  return jsonResponse(HOSTED_HTTP_STATUS.OK, observeAnswer(outcome.roster, outcome.observedAt));
+}
 
+/** The roster as the wire carries it: every provider's observations as bounded rows, dated by the snapshot. */
+function observeAnswer(
+  roster: ObservedRoster | undefined,
+  observedAt: number | undefined,
+): ObserveAnswer {
   const sessions: ObservedSession[] = [];
-  for (const pass of passes) {
-    for (const observation of pass.answer ?? []) {
-      sessions.push(observedSessionForResponse(pass.providerId, observation));
+  for (const provider of roster?.providers ?? []) {
+    for (const observation of provider.observations) {
+      sessions.push(observedSessionForResponse(provider.providerId, observation));
     }
   }
-
-  return jsonResponse(HOSTED_HTTP_STATUS.OK, { sessions });
+  return { sessions, ...(observedAt !== undefined ? { observedAt } : undefined) };
 }
 
 /**
  * The actions an observation advertised, written onto its wire row. Each is
  * presence-only where it can be: what a control targets, or which workspace a
- * rename lands on, never travels — the action endpoints re-observe and rebuild
- * every write from their own fresh advertisement.
+ * rename lands on, never travels — the action endpoints admit against the
+ * same stored snapshot's own advertisement and build every write from it.
  */
 function writeAdvertisedActions(
   session: ObservedSession,

--- a/apps/web/server/hosted/observe.ts
+++ b/apps/web/server/hosted/observe.ts
@@ -85,7 +85,7 @@ export async function handleObserve(options: ObserveOptions): Promise<Response> 
   const fresh =
     new URL(request.url).searchParams.get(OBSERVE_QUERY.FRESH) === OBSERVE_QUERY.FRESH_VALUE;
   if (!fresh) {
-    const stored = await storedRoster(store, userId, rows);
+    const stored = await storedRoster(store, userId, rows, secret);
     if (stored?.roster) {
       return jsonResponse(HOSTED_HTTP_STATUS.OK, observeAnswer(stored.roster, stored.observedAt));
     }

--- a/apps/web/server/hosted/observed-roster.ts
+++ b/apps/web/server/hosted/observed-roster.ts
@@ -46,6 +46,14 @@ export interface ObservedRoster {
   readonly providers: readonly ObservedRosterProvider[];
 }
 
+/** One provider's slice of the roster, or nothing where the snapshot holds none for it. */
+export function rosterProvider(
+  roster: ObservedRoster,
+  providerId: CloudAgentProviderId,
+): ObservedRosterProvider | undefined {
+  return roster.providers.find((provider) => provider.providerId === providerId);
+}
+
 export function encodeObservedRoster(roster: ObservedRoster): string {
   return JSON.stringify(roster);
 }

--- a/apps/web/server/hosted/observed-roster.ts
+++ b/apps/web/server/hosted/observed-roster.ts
@@ -32,9 +32,9 @@ export const OBSERVED_ROSTER_VERSION = 1;
 interface ObservedRosterProvider {
   readonly providerId: CloudAgentProviderId;
   /**
-   * A fingerprint of the stored key row the pass observed under, so a
-   * snapshot read under a key since replaced or removed is not served or
-   * admitted against as if it were this key's roster.
+   * A fingerprint of the key the pass observed under, so a snapshot read
+   * under a key since replaced or removed is not served or admitted against
+   * as if it were this key's roster.
    */
   readonly keyFingerprint: string;
   readonly observations: readonly ProviderSessionObservation[];

--- a/apps/web/server/hosted/observed-roster.ts
+++ b/apps/web/server/hosted/observed-roster.ts
@@ -31,6 +31,12 @@ export const OBSERVED_ROSTER_VERSION = 1;
 
 interface ObservedRosterProvider {
   readonly providerId: CloudAgentProviderId;
+  /**
+   * A fingerprint of the stored key row the pass observed under, so a
+   * snapshot read under a key since replaced or removed is not served or
+   * admitted against as if it were this key's roster.
+   */
+  readonly keyFingerprint: string;
   readonly observations: readonly ProviderSessionObservation[];
   readonly projects: readonly WorkspaceProject[];
 }
@@ -151,6 +157,7 @@ const observedRosterSchema: Schema<ObservedRoster> = s.record(
     providers: s.array(
       s.record({
         providerId: cloudProviderIdSchema,
+        keyFingerprint: storedText,
         observations: s.array(observationSchema),
         projects: s.array(projectSchema),
       }),

--- a/apps/web/server/hosted/projects.ts
+++ b/apps/web/server/hosted/projects.ts
@@ -1,8 +1,8 @@
 import {
   ACTION_KIND,
-  CLOUD_AGENT_PROVIDER_ID,
   type CloudAgentProviderId,
   type CloudFetch,
+  type HostedProjectsAnswer,
   type HostedWorkspaceAgentModels,
   type HostedWorkspaceProject,
   type WorkspaceProject,
@@ -10,8 +10,14 @@ import {
 } from "../core.js";
 import { actionUnsupportedReason } from "./action-execute.js";
 import { errorResponse, HOSTED_API_ERROR, HOSTED_HTTP_STATUS, jsonResponse } from "./http.js";
+import {
+  keyedCloudProviderIds,
+  type ObservationStore,
+  observeAndSnapshot,
+  storedRoster,
+} from "./observation-pass.js";
+import type { ObservedRoster } from "./observed-roster.js";
 import { createRateBrake } from "./rate-brake.js";
-import { observeProviders, readApiKeyFor } from "./vault-keys.js";
 import type { HostedVaultRoute } from "./vault-route.js";
 
 const PROJECTS_RATE_LIMIT = {
@@ -31,17 +37,23 @@ export interface ProjectsOptions
     HostedVaultRoute,
     "request" | "resolveUserId" | "encryptionSecret" | "readVaultKeys"
   > {
+  /** The store the snapshot is read from and, on a live pass, written to. */
+  store: (secret: string) => ObservationStore;
   /** Injected in tests; production uses the global fetch. */
   fetch?: CloudFetch;
   now?: () => number;
+  sleep?: (ms: number) => Promise<void>;
 }
 
 /**
  * Lists where the caller's keys can create a workspace: each entry is a
- * project the provider itself reported on a fresh observation pass, run here
- * on demand like observe and stored nowhere. Only creation-capable providers
- * are observed at all — a projects request must not spend the quota of a
- * provider that could offer nothing.
+ * project a provider reported on the same stored snapshot a creation is
+ * admitted against, so the phone can never be offered a project admission
+ * would then refuse. A live pass runs only where no snapshot stands for the
+ * standing keys, under the per-user brake, and it is the same pass the
+ * schedule runs, stored the same way. Only creation-capable providers are
+ * listed; a provider whose keys stand but that documents no creation offers
+ * nowhere to create.
  */
 export async function handleProjects(options: ProjectsOptions): Promise<Response> {
   const { request, resolveUserId, encryptionSecret, readVaultKeys } = options;
@@ -63,48 +75,48 @@ export async function handleProjects(options: ProjectsOptions): Promise<Response
     return errorResponse(HOSTED_HTTP_STATUS.SERVICE_UNAVAILABLE, HOSTED_API_ERROR.UNAVAILABLE);
   }
 
-  const now = (options.now ?? Date.now)();
-  if (projectsRateLimited(userId, now)) {
-    return errorResponse(HOSTED_HTTP_STATUS.TOO_MANY_REQUESTS, HOSTED_API_ERROR.QUOTA_EXHAUSTED);
-  }
-
   const rows = await readVaultKeys(userId);
-  const readApiKey = readApiKeyFor(rows, secret);
-  const stored = new Set(rows.map((row) => row.providerId));
+  const creating = keyedCloudProviderIds(rows).filter(
+    (providerId) => actionUnsupportedReason(ACTION_KIND.CREATE_WORKSPACE, providerId) === undefined,
+  );
+  if (creating.length === 0)
+    return jsonResponse(HOSTED_HTTP_STATUS.OK, projectsAnswer(undefined, creating));
 
-  const passes = await observeProviders({
-    providerIds: Object.values(CLOUD_AGENT_PROVIDER_ID).filter(
-      (providerId) =>
-        actionUnsupportedReason(ACTION_KIND.CREATE_WORKSPACE, providerId) === undefined &&
-        stored.has(providerId),
-    ),
-    readApiKey,
-    read: async (plugin) => {
-      await plugin.observe();
-      return plugin.projects?.() ?? [];
-    },
-    seams: options,
-  });
+  const store = options.store(secret);
+  let roster = (await storedRoster(store, userId, rows))?.roster;
+  if (!roster) {
+    const now = (options.now ?? Date.now)();
+    if (projectsRateLimited(userId, now)) {
+      return errorResponse(HOSTED_HTTP_STATUS.TOO_MANY_REQUESTS, HOSTED_API_ERROR.QUOTA_EXHAUSTED);
+    }
+    roster = (await observeAndSnapshot({ userId, rows, secret, store, seams: options, now }))
+      .roster;
+  }
+  return jsonResponse(HOSTED_HTTP_STATUS.OK, projectsAnswer(roster, creating));
+}
 
+/** The snapshot's projects for the creation-capable providers, each with the build's agent table beside it. */
+function projectsAnswer(
+  roster: ObservedRoster | undefined,
+  creating: readonly CloudAgentProviderId[],
+): HostedProjectsAnswer {
   const projects: HostedWorkspaceProject[] = [];
   const agentModels: HostedWorkspaceAgentModels[] = [];
-  for (const pass of passes) {
-    const reported = pass.answer;
-    if (!reported) continue;
-    for (const project of reported) {
-      projects.push(toWireProject(pass.providerId, project));
+  for (const provider of roster?.providers ?? []) {
+    if (!creating.includes(provider.providerId)) continue;
+    for (const project of provider.projects) {
+      projects.push(toWireProject(provider.providerId, project));
     }
     // The build's own agent table for each provider that actually offered a
     // project — documented state riding beside the observed state it applies
     // to, so a provider with nowhere to create advertises no choices either.
-    if (reported.length > 0) {
-      for (const entry of workspaceAgentModels(pass.providerId)) {
-        agentModels.push({ providerId: pass.providerId, ...entry });
+    if (provider.projects.length > 0) {
+      for (const entry of workspaceAgentModels(provider.providerId)) {
+        agentModels.push({ providerId: provider.providerId, ...entry });
       }
     }
   }
-
-  return jsonResponse(HOSTED_HTTP_STATUS.OK, { projects, agentModels });
+  return { projects, agentModels };
 }
 
 function toWireProject(

--- a/apps/web/server/hosted/projects.ts
+++ b/apps/web/server/hosted/projects.ts
@@ -83,7 +83,7 @@ export async function handleProjects(options: ProjectsOptions): Promise<Response
     return jsonResponse(HOSTED_HTTP_STATUS.OK, projectsAnswer(undefined, creating));
 
   const store = options.store(secret);
-  let roster = (await storedRoster(store, userId, rows))?.roster;
+  let roster = (await storedRoster(store, userId, rows, secret))?.roster;
   if (!roster) {
     const now = (options.now ?? Date.now)();
     if (projectsRateLimited(userId, now)) {

--- a/apps/web/server/hosted/vault-route.ts
+++ b/apps/web/server/hosted/vault-route.ts
@@ -4,7 +4,8 @@ import { getDatabase } from "../db/index.js";
 import { providerKey } from "../db/schema.js";
 import type { Route } from "../route.js";
 import { hostedUserId, oauthUserInfoFromAuthAnswer } from "./bearer.js";
-import { VAULT_ENCRYPTION_ENVIRONMENT } from "./encryption.js";
+import { payloadKeyRing, VAULT_ENCRYPTION_ENVIRONMENT } from "./encryption.js";
+import { type HostedStore, hostedStore } from "./store/index.js";
 
 /**
  * The deployment's own seams, handed to a hosted route once instead of
@@ -35,6 +36,21 @@ export interface HostedVaultRoute {
   listKeys: (userId: string) => Promise<{ providerId: string; updatedAt: Date }[]>;
   storeKey: (userId: string, providerId: string, ciphertext: string) => Promise<void>;
   deleteKey: (userId: string, providerId: string) => Promise<boolean>;
+  /** The hosted store under the deployment's payload key ring, for the routes that read or write it. */
+  store: (secret: string) => HostedStore;
+}
+
+let storeUnderSecret: { secret: string; store: HostedStore } | undefined;
+
+/** One store per process, rebuilt only if the secret it was built under changes. */
+function storeFor(secret: string): HostedStore {
+  if (storeUnderSecret?.secret !== secret) {
+    storeUnderSecret = {
+      secret,
+      store: hostedStore({ db: getDatabase(), keys: payloadKeyRing(secret) }),
+    };
+  }
+  return storeUnderSecret.store;
 }
 
 function resolveUserId(request: Request): Promise<string | undefined> {
@@ -80,6 +96,7 @@ const seams = {
       .returning({ userId: providerKey.userId });
     return result.length > 0;
   },
+  store: storeFor,
 } satisfies Omit<HostedVaultRoute, "request">;
 
 /**

--- a/apps/web/tests/hosted-actions.test.ts
+++ b/apps/web/tests/hosted-actions.test.ts
@@ -381,9 +381,9 @@ async function snapshotRoster(api: ConductorApi): Promise<ActionRoster> {
     providerId: "conductor",
     secret: SECRET,
     store,
-    readVaultKeys: async () => {
-      throw new Error("a standing snapshot is read, never re-observed");
-    },
+    // The key rows are read to check the snapshot was observed under them;
+    // the provider itself is never asked while a matching snapshot stands.
+    readVaultKeys: async () => KEY_ROWS,
     seams: {
       fetch: async () => {
         throw new Error("no pass runs for a user with a snapshot");
@@ -549,6 +549,38 @@ test("a user with no snapshot yet is seeded by the action's own pass, once", asy
   });
   assert.deepEqual(second.observations, first.observations);
   assert.equal(api.reads.length, readsAfterSeeding);
+});
+
+test("an action under a replaced key is admitted against a fresh pass, not the old key's snapshot", async () => {
+  const api = conductorApi("idle");
+  const store = memoryObservationStore();
+  await rosterForAction({
+    userId: "user-1",
+    providerId: "conductor",
+    secret: SECRET,
+    store,
+    readVaultKeys: async () => KEY_ROWS,
+    seams: { fetch: api.fetch },
+    now: NOW,
+  });
+  const readsAfterSeeding = api.reads.length;
+  const replaced: VaultKeyRow[] = [
+    { providerId: "conductor", ciphertext: encryptProviderKey("key-1", SECRET) },
+  ];
+
+  const roster = await rosterForAction({
+    userId: "user-1",
+    providerId: "conductor",
+    secret: SECRET,
+    store,
+    readVaultKeys: async () => replaced,
+    seams: { fetch: api.fetch },
+    now: NOW + 1,
+  });
+
+  assert.ok(api.reads.length > readsAfterSeeding);
+  assert.equal(roster.observations.length, 1);
+  assert.equal(store.snapshots.get("user-1")?.observedAt, NOW + 1);
 });
 
 test("a snapshot with no slice for the provider is no session, not a failure", () => {

--- a/apps/web/tests/hosted-actions.test.ts
+++ b/apps/web/tests/hosted-actions.test.ts
@@ -565,7 +565,7 @@ test("an action under a replaced key is admitted against a fresh pass, not the o
   });
   const readsAfterSeeding = api.reads.length;
   const replaced: VaultKeyRow[] = [
-    { providerId: "conductor", ciphertext: encryptProviderKey("key-1", SECRET) },
+    { providerId: "conductor", ciphertext: encryptProviderKey("key-2", SECRET) },
   ];
 
   const roster = await rosterForAction({

--- a/apps/web/tests/hosted-actions.test.ts
+++ b/apps/web/tests/hosted-actions.test.ts
@@ -4,14 +4,27 @@ import type { JsonObject } from "../../../packages/wire/src/testing/json.js";
 import { ACTION_KIND, ACTION_REFUSAL, type WireRecord } from "../server/core";
 import {
   type ActionExecutionAnswer,
+  type ActionRoster,
+  actionRosterFor,
   actionUnsupportedReason,
   executeSessionAction,
   type HostedSessionActionKind,
 } from "../server/hosted/action-execute";
 import { handleSessionAction, type SessionActionOptions } from "../server/hosted/action-session";
 import { encryptProviderKey } from "../server/hosted/encryption";
+import { observeAndSnapshot, rosterForAction } from "../server/hosted/observation-pass";
+import type { VaultKeyRow } from "../server/hosted/vault-route";
+import { memoryObservationStore } from "./support/observation-store";
 
 const SECRET = "a".repeat(64);
+const NOW = Date.parse("2026-08-12T02:45:00.000Z");
+
+const EMPTY_ROSTER: ActionRoster = {
+  observations: [],
+  projects: [],
+  unauthorized: false,
+  unreachable: false,
+};
 
 function actionRequest(path: string, fields: Record<string, string>): Request {
   return new Request(`https://luke.test${path}`, {
@@ -32,6 +45,7 @@ function messageOptions(overrides: Partial<SessionActionOptions> = {}): SessionA
     encryptionSecret: SECRET,
     resolveUserId: async () => "user-1",
     readKey: async () => ({ ciphertext: encryptProviderKey("key-1", SECRET) }),
+    roster: async () => EMPTY_ROSTER,
     unsupportedReason: () => undefined,
     execute: async () => ({ result: "accepted" }),
     ...overrides,
@@ -221,7 +235,27 @@ test("the capability map matches each desktop adapter's implemented writes", () 
   }
 });
 
-// --- One executor admits every action, over the pass it observed ---
+test("the roster an action stands on is read once the key is, and reaches the executor", async () => {
+  const asked: string[] = [];
+  let received: ActionRoster | undefined;
+  await handleSessionAction(
+    messageOptions({
+      roster: async (userId, providerId, secret) => {
+        asked.push(userId, providerId, secret);
+        return EMPTY_ROSTER;
+      },
+      execute: async (options) => {
+        received = options.roster;
+        return { result: "accepted" };
+      },
+    }),
+  );
+
+  assert.deepEqual(asked, ["user-1", "conductor", SECRET]);
+  assert.equal(received, EMPTY_ROSTER);
+});
+
+// --- One executor admits every action, over the snapshot the user was shown ---
 
 const CONDUCTOR_PROJECT_ID = "project-1";
 const CONDUCTOR_WORKSPACE_ID = "workspace-1";
@@ -235,11 +269,15 @@ const CONDUCTOR_SESSION_ID = "session-1";
  */
 function conductorApi(status: string) {
   const posts: Array<{ url: string; body: string }> = [];
+  const reads: string[] = [];
   const json = (value: JsonObject) => new Response(JSON.stringify(value), { status: 200 });
   const fetch = async (url: string, init: RequestInit) => {
     const { pathname } = new URL(url);
     if (init.method === "POST") {
-      if (pathname.endsWith("/v0/sql")) return json({ rows: [], rowCount: 0, truncated: false });
+      if (pathname.endsWith("/v0/sql")) {
+        reads.push(pathname);
+        return json({ rows: [], rowCount: 0, truncated: false });
+      }
       posts.push({ url, body: String(init.body) });
       if (pathname.endsWith("/v0/workspaces")) {
         return new Response(
@@ -251,6 +289,7 @@ function conductorApi(status: string) {
         status: 201,
       });
     }
+    reads.push(pathname);
     if (pathname.endsWith("/me")) return json({ userId: "user-1" });
     if (pathname.endsWith("/v0/projects")) {
       return json({
@@ -311,25 +350,69 @@ function conductorApi(status: string) {
     }
     return new Response("{}", { status: 500 });
   };
-  return { fetch, posts };
+  return { fetch, posts, reads };
 }
 
 /** The fake API one case runs against: its fetch, and what the action posted through it. */
 type ConductorApi = ReturnType<typeof conductorApi>;
 
-/** One action asked of the fake API, admitted and carried by the one executor. */
-function ask(
+const KEY_ROWS: VaultKeyRow[] = [
+  { providerId: "conductor", ciphertext: encryptProviderKey("key-1", SECRET) },
+];
+
+/**
+ * The roster the action stands on: the snapshot one pass over the fake API
+ * stored, read back the way the deployed route reads it — through the store
+ * — so the action never sees the pass, only what it wrote down.
+ */
+async function snapshotRoster(api: ConductorApi): Promise<ActionRoster> {
+  const store = memoryObservationStore();
+  const outcome = await observeAndSnapshot({
+    userId: "user-1",
+    rows: KEY_ROWS,
+    secret: SECRET,
+    store,
+    seams: { fetch: api.fetch },
+    now: NOW,
+  });
+  assert.equal(outcome.complete, true);
+  return rosterForAction({
+    userId: "user-1",
+    providerId: "conductor",
+    secret: SECRET,
+    store,
+    readVaultKeys: async () => {
+      throw new Error("a standing snapshot is read, never re-observed");
+    },
+    seams: {
+      fetch: async () => {
+        throw new Error("no pass runs for a user with a snapshot");
+      },
+    },
+    now: NOW + 1,
+  });
+}
+
+/** One action asked against the snapshot of the fake API, admitted and carried by the one executor. */
+async function ask(
   api: ConductorApi,
   kind: HostedSessionActionKind,
   fields: Record<string, string>,
 ): Promise<ActionExecutionAnswer> {
-  return executeSessionAction({
+  const roster = await snapshotRoster(api);
+  const readsBefore = api.reads.length;
+  const answer = await executeSessionAction({
     kind,
     providerId: "conductor",
     fields: { provider_id: "conductor", ...fields },
     apiKey: "key-1",
+    roster,
     seams: { fetch: api.fetch },
   });
+  // No read runs on an action: the snapshot is the roster, and the provider
+  // sees only the write itself.
+  assert.equal(api.reads.length, readsBefore);
+  return answer;
 }
 
 test("a message to a messageable Conductor session lands on its sendMessage method", async () => {
@@ -368,7 +451,7 @@ test("a message outside its bound is refused without a write", async () => {
   assert.deepEqual(api.posts, []);
 });
 
-test("a message to a session the fresh pass did not observe is rejected", async () => {
+test("a message to a session the snapshot does not hold is rejected", async () => {
   const api = conductorApi("idle");
   const answer = await ask(api, ACTION_KIND.MESSAGE, {
     provider_session_id: "session-9",
@@ -380,7 +463,26 @@ test("a message to a session the fresh pass did not observe is rejected", async 
   assert.deepEqual(api.posts, []);
 });
 
-test("a key the provider refuses is named as the reason, not a missing session", async () => {
+/**
+ * A user no pass has reached yet: the action's roster is the pass that seeds
+ * the snapshot, and when that pass fails the roster is empty and says why.
+ */
+async function seededRoster(fetch: (url: string, init: RequestInit) => Promise<Response>) {
+  const store = memoryObservationStore();
+  const roster = await rosterForAction({
+    userId: "user-1",
+    providerId: "conductor",
+    secret: SECRET,
+    store,
+    readVaultKeys: async () => KEY_ROWS,
+    seams: { fetch },
+    now: NOW,
+  });
+  return { roster, store };
+}
+
+test("a key the provider refuses is named as the reason, not a missing session, and seeds no snapshot", async () => {
+  const { roster, store } = await seededRoster(async () => new Response("{}", { status: 401 }));
   const answer = await executeSessionAction({
     kind: ACTION_KIND.MESSAGE,
     providerId: "conductor",
@@ -390,30 +492,75 @@ test("a key the provider refuses is named as the reason, not a missing session",
       text: "hello",
     },
     apiKey: "key-1",
+    roster,
     seams: { fetch: async () => new Response("{}", { status: 401 }) },
+  });
+
+  assert.equal(answer.result, "rejected");
+  assert.equal(store.snapshots.size, 0);
+  assert.equal(store.passes.get("user-1")?.failure, "unauthorized");
+});
+
+test("a provider that cannot be reached is named as the reason", async () => {
+  const unreachable = async () => {
+    throw new Error("connection refused");
+  };
+  const { roster } = await seededRoster(unreachable);
+  const answer = await executeSessionAction({
+    kind: ACTION_KIND.MESSAGE,
+    providerId: "conductor",
+    fields: {
+      provider_id: "conductor",
+      provider_session_id: CONDUCTOR_SESSION_ID,
+      text: "hello",
+    },
+    apiKey: "key-1",
+    roster,
+    seams: { fetch: unreachable },
   });
 
   assert.equal(answer.result, "rejected");
 });
 
-test("a provider that cannot be reached is named as the reason", async () => {
-  const answer = await executeSessionAction({
-    kind: ACTION_KIND.MESSAGE,
+test("a user with no snapshot yet is seeded by the action's own pass, once", async () => {
+  const api = conductorApi("idle");
+  const store = memoryObservationStore();
+  const first = await rosterForAction({
+    userId: "user-1",
     providerId: "conductor",
-    fields: {
-      provider_id: "conductor",
-      provider_session_id: CONDUCTOR_SESSION_ID,
-      text: "hello",
-    },
-    apiKey: "key-1",
-    seams: {
-      fetch: async () => {
-        throw new Error("connection refused");
-      },
-    },
+    secret: SECRET,
+    store,
+    readVaultKeys: async () => KEY_ROWS,
+    seams: { fetch: api.fetch },
+    now: NOW,
   });
+  assert.equal(first.observations.length, 1);
+  assert.equal(store.snapshots.has("user-1"), true);
+  const readsAfterSeeding = api.reads.length;
 
-  assert.equal(answer.result, "rejected");
+  const second = await rosterForAction({
+    userId: "user-1",
+    providerId: "conductor",
+    secret: SECRET,
+    store,
+    readVaultKeys: async () => KEY_ROWS,
+    seams: { fetch: api.fetch },
+    now: NOW + 1,
+  });
+  assert.deepEqual(second.observations, first.observations);
+  assert.equal(api.reads.length, readsAfterSeeding);
+});
+
+test("a snapshot with no slice for the provider is no session, not a failure", () => {
+  const roster = actionRosterFor("conductor", { roster: { version: 1, providers: [] } });
+  assert.deepEqual(roster, {
+    observations: [],
+    projects: [],
+    unauthorized: false,
+    unreachable: false,
+  });
+  assert.equal(actionRosterFor("conductor", { failure: "transient" }).unreachable, true);
+  assert.equal(actionRosterFor("conductor", { failure: "rate-limited" }).unreachable, true);
 });
 
 test("an advertised control runs through the provider's documented endpoint", async () => {
@@ -426,7 +573,7 @@ test("an advertised control runs through the provider's documented endpoint", as
   assert.equal(answer.result, "accepted");
 });
 
-test("a control the fresh pass did not advertise is rejected without a write", async () => {
+test("a control the snapshot did not advertise is rejected without a write", async () => {
   const api = conductorApi("idle");
   const answer = await ask(api, ACTION_KIND.CONTROL, {
     provider_session_id: CONDUCTOR_SESSION_ID,

--- a/apps/web/tests/hosted-observation-pass.test.ts
+++ b/apps/web/tests/hosted-observation-pass.test.ts
@@ -17,6 +17,7 @@ import { CLOUD_OBSERVE_FAILURE } from "../server/hosted/cloud-observe";
 import { encryptProviderKey } from "../server/hosted/encryption";
 import {
   keyedCloudProviderIds,
+  keyFingerprint,
   observeAndSnapshot,
   storedRoster,
 } from "../server/hosted/observation-pass";
@@ -76,7 +77,7 @@ test("a whole pass stores the roster with its projects, dated by the pass, and t
   assert.equal(outcome.complete, true);
   assert.equal(outcome.changed, false);
   assert.equal(outcome.observedAt, TEST_TIME);
-  const stored = await storedRoster(store, "user-1");
+  const stored = await storedRoster(store, "user-1", KEY_ROWS);
   assert.ok(stored?.roster);
   assert.equal(stored.observedAt, TEST_TIME);
   const [provider] = stored.roster.providers;
@@ -344,11 +345,47 @@ test("when the earlier-started pass wins, the later one closes its own unfinishe
   });
 });
 
+test("a snapshot observed under a key since replaced is another key's roster: not served, and replaced with no diff against it", async () => {
+  const store = memoryObservationStore();
+  const first = await observeAndSnapshot({
+    userId: "user-1",
+    rows: KEY_ROWS,
+    secret: SECRET,
+    store,
+    seams: { fetch: api().fetch, now: () => TEST_TIME },
+    now: TEST_TIME,
+  });
+  assert.equal(first.roster?.providers[0]?.keyFingerprint, keyFingerprint(KEY_ROWS[0]!));
+  assert.ok((await storedRoster(store, "user-1", KEY_ROWS))?.roster);
+
+  const replaced: VaultKeyRow[] = [
+    { providerId: "conductor", ciphertext: encryptProviderKey(TEST_API_KEY, SECRET) },
+  ];
+  assert.notEqual(keyFingerprint(replaced[0]!), keyFingerprint(KEY_ROWS[0]!));
+  assert.deepEqual(await storedRoster(store, "user-1", replaced), { observedAt: TEST_TIME });
+  assert.equal((await storedRoster(store, "user-1", []))?.roster, undefined);
+
+  const second = await observeAndSnapshot({
+    userId: "user-1",
+    rows: replaced,
+    secret: SECRET,
+    store,
+    seams: { fetch: api(TEST_CONDUCTOR_STATUS.ERROR).fetch, now: () => TEST_TIME + 1_000 },
+    now: TEST_TIME + 1_000,
+  });
+  assert.equal(second.complete, true);
+  assert.equal(second.changed, false);
+  assert.deepEqual(await store.roster.pendingDiffs("user-1"), []);
+  assert.ok((await storedRoster(store, "user-1", replaced))?.roster);
+});
+
 test("a snapshot this build cannot open or read is replaced by the next whole pass, with no diff against it", async () => {
   for (const body of [UNOPENABLE_BODY, "not json", JSON.stringify({ version: 99 })]) {
     const store = memoryObservationStore();
     store.snapshots.set("user-1", { body, observedAt: TEST_TIME - 60_000 });
-    assert.deepEqual(await storedRoster(store, "user-1"), { observedAt: TEST_TIME - 60_000 });
+    assert.deepEqual(await storedRoster(store, "user-1", KEY_ROWS), {
+      observedAt: TEST_TIME - 60_000,
+    });
 
     const outcome = await observeAndSnapshot({
       userId: "user-1",
@@ -362,7 +399,11 @@ test("a snapshot this build cannot open or read is replaced by the next whole pa
     assert.equal(outcome.complete, true, body);
     assert.equal(outcome.changed, false, body);
     assert.equal(store.snapshots.get("user-1")?.observedAt, TEST_TIME, body);
-    assert.equal((await storedRoster(store, "user-1"))?.roster?.providers.length, 1, body);
+    assert.equal(
+      (await storedRoster(store, "user-1", KEY_ROWS))?.roster?.providers.length,
+      1,
+      body,
+    );
     assert.deepEqual(await store.roster.pendingDiffs("user-1"), [], body);
   }
 });

--- a/apps/web/tests/hosted-observation-pass.test.ts
+++ b/apps/web/tests/hosted-observation-pass.test.ts
@@ -77,7 +77,7 @@ test("a whole pass stores the roster with its projects, dated by the pass, and t
   assert.equal(outcome.complete, true);
   assert.equal(outcome.changed, false);
   assert.equal(outcome.observedAt, TEST_TIME);
-  const stored = await storedRoster(store, "user-1", KEY_ROWS);
+  const stored = await storedRoster(store, "user-1", KEY_ROWS, SECRET);
   assert.ok(stored?.roster);
   assert.equal(stored.observedAt, TEST_TIME);
   const [provider] = stored.roster.providers;
@@ -345,7 +345,7 @@ test("when the earlier-started pass wins, the later one closes its own unfinishe
   });
 });
 
-test("a snapshot observed under a key since replaced is another key's roster: not served, and replaced with no diff against it", async () => {
+test("a snapshot observed under a key since replaced is another key's roster: not served, and replaced with no diff against it; the same key saved again keeps it", async () => {
   const store = memoryObservationStore();
   const first = await observeAndSnapshot({
     userId: "user-1",
@@ -355,15 +355,25 @@ test("a snapshot observed under a key since replaced is another key's roster: no
     seams: { fetch: api().fetch, now: () => TEST_TIME },
     now: TEST_TIME,
   });
-  assert.equal(first.roster?.providers[0]?.keyFingerprint, keyFingerprint(KEY_ROWS[0]!));
-  assert.ok((await storedRoster(store, "user-1", KEY_ROWS))?.roster);
+  assert.equal(first.roster?.providers[0]?.keyFingerprint, keyFingerprint(TEST_API_KEY, SECRET));
+  assert.ok((await storedRoster(store, "user-1", KEY_ROWS, SECRET))?.roster);
 
-  const replaced: VaultKeyRow[] = [
+  // The Mac re-saves the same key on every launch, under a fresh nonce.
+  const resaved: VaultKeyRow[] = [
     { providerId: "conductor", ciphertext: encryptProviderKey(TEST_API_KEY, SECRET) },
   ];
-  assert.notEqual(keyFingerprint(replaced[0]!), keyFingerprint(KEY_ROWS[0]!));
-  assert.deepEqual(await storedRoster(store, "user-1", replaced), { observedAt: TEST_TIME });
-  assert.equal((await storedRoster(store, "user-1", []))?.roster, undefined);
+  assert.notEqual(resaved[0]?.ciphertext, KEY_ROWS[0]?.ciphertext);
+  assert.ok((await storedRoster(store, "user-1", resaved, SECRET))?.roster);
+
+  const replaced: VaultKeyRow[] = [
+    { providerId: "conductor", ciphertext: encryptProviderKey("another-key", SECRET) },
+  ];
+  assert.deepEqual(await storedRoster(store, "user-1", replaced, SECRET), {
+    observedAt: TEST_TIME,
+  });
+  assert.equal((await storedRoster(store, "user-1", [], SECRET))?.roster, undefined);
+  const unreadable: VaultKeyRow[] = [{ providerId: "conductor", ciphertext: "not-a-ciphertext" }];
+  assert.equal((await storedRoster(store, "user-1", unreadable, SECRET))?.roster, undefined);
 
   const second = await observeAndSnapshot({
     userId: "user-1",
@@ -376,14 +386,14 @@ test("a snapshot observed under a key since replaced is another key's roster: no
   assert.equal(second.complete, true);
   assert.equal(second.changed, false);
   assert.deepEqual(await store.roster.pendingDiffs("user-1"), []);
-  assert.ok((await storedRoster(store, "user-1", replaced))?.roster);
+  assert.ok((await storedRoster(store, "user-1", replaced, SECRET))?.roster);
 });
 
 test("a snapshot this build cannot open or read is replaced by the next whole pass, with no diff against it", async () => {
   for (const body of [UNOPENABLE_BODY, "not json", JSON.stringify({ version: 99 })]) {
     const store = memoryObservationStore();
     store.snapshots.set("user-1", { body, observedAt: TEST_TIME - 60_000 });
-    assert.deepEqual(await storedRoster(store, "user-1", KEY_ROWS), {
+    assert.deepEqual(await storedRoster(store, "user-1", KEY_ROWS, SECRET), {
       observedAt: TEST_TIME - 60_000,
     });
 
@@ -400,7 +410,7 @@ test("a snapshot this build cannot open or read is replaced by the next whole pa
     assert.equal(outcome.changed, false, body);
     assert.equal(store.snapshots.get("user-1")?.observedAt, TEST_TIME, body);
     assert.equal(
-      (await storedRoster(store, "user-1", KEY_ROWS))?.roster?.providers.length,
+      (await storedRoster(store, "user-1", KEY_ROWS, SECRET))?.roster?.providers.length,
       1,
       body,
     );

--- a/apps/web/tests/hosted-observe.test.ts
+++ b/apps/web/tests/hosted-observe.test.ts
@@ -139,6 +139,38 @@ test("a user with a snapshot is answered from it, dated, and the provider is not
   assert.equal(observeAnswerSchema.parse(storedBody)?.observedAt, TEST_TIME);
 });
 
+test("a snapshot observed under a replaced key is not served: the read runs a pass under the new key", async () => {
+  const store = memoryObservationStore();
+  await handleObserve(
+    observeOptions({
+      readVaultKeys: async () => KEY_ROWS,
+      store: () => store,
+      fetch: conductorApi().fetch,
+      now: () => TEST_TIME,
+    }),
+  );
+  const replaced: VaultKeyRow[] = [
+    { providerId: "conductor", ciphertext: encryptProviderKey("conductor-test-key", SECRET) },
+  ];
+  const api = conductorApi(TEST_CONDUCTOR_STATUS.IDLE);
+
+  const response = await handleObserve(
+    observeOptions({
+      readVaultKeys: async () => replaced,
+      store: () => store,
+      fetch: api.fetch,
+      now: () => TEST_TIME + 1_000,
+    }),
+  );
+
+  assert.equal(response.status, 200);
+  const body = await response.json();
+  assert.ok(api.requests.length > 0);
+  assert.equal(body.sessions[0].status, SESSION_STATUS.WAITING);
+  assert.equal(body.observedAt, TEST_TIME + 1_000);
+  assert.deepEqual(store.diffs.get("user-1") ?? [], []);
+});
+
 test("a fresh read runs the pass again, stores it, and answers the new roster", async () => {
   const store = memoryObservationStore();
   const working = conductorApi();

--- a/apps/web/tests/hosted-observe.test.ts
+++ b/apps/web/tests/hosted-observe.test.ts
@@ -150,7 +150,7 @@ test("a snapshot observed under a replaced key is not served: the read runs a pa
     }),
   );
   const replaced: VaultKeyRow[] = [
-    { providerId: "conductor", ciphertext: encryptProviderKey("conductor-test-key", SECRET) },
+    { providerId: "conductor", ciphertext: encryptProviderKey("another-key", SECRET) },
   ];
   const api = conductorApi(TEST_CONDUCTOR_STATUS.IDLE);
 

--- a/apps/web/tests/hosted-observe.test.ts
+++ b/apps/web/tests/hosted-observe.test.ts
@@ -1,16 +1,32 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { observeAnswerSchema } from "@sidecar/hosted";
+import { OBSERVE_QUERY, observeAnswerSchema } from "@sidecar/hosted";
 import { SESSION_STATUS } from "@sidecar/session";
+import {
+  fakeConductorApi,
+  LUKE_PROJECT,
+  ownedWorkspace,
+  TEST_CONDUCTOR_STATUS,
+  TEST_SESSION_NAME,
+  TEST_TIME,
+  TEST_USER_ID,
+} from "../../../packages/providers/src/testing/conductor-api.js";
 import { encryptProviderKey } from "../server/hosted/encryption";
 import { HOSTED_API_ERROR } from "../server/hosted/http";
 import { handleObserve, observedSessionForResponse } from "../server/hosted/observe";
+import { encodeObservedRoster } from "../server/hosted/observed-roster";
 import type { VaultKeyRow } from "../server/hosted/vault-route";
+import { memoryObservationStore } from "./support/observation-store";
 
 const SECRET = "a".repeat(64);
+const KEY_ROWS: VaultKeyRow[] = [
+  { providerId: "conductor", ciphertext: encryptProviderKey("conductor-test-key", SECRET) },
+];
 
-function observeRequest(headers: Record<string, string> = {}): Request {
-  return new Request("https://luke.test/api/observe", {
+function observeRequest(headers: Record<string, string> = {}, fresh = false): Request {
+  const url = new URL("https://luke.test/api/observe");
+  if (fresh) url.searchParams.set(OBSERVE_QUERY.FRESH, OBSERVE_QUERY.FRESH_VALUE);
+  return new Request(url, {
     method: "GET",
     headers: { authorization: "Bearer token-1", ...headers },
   });
@@ -19,13 +35,33 @@ function observeRequest(headers: Record<string, string> = {}): Request {
 function observeOptions(
   overrides: Partial<Parameters<typeof handleObserve>[0]> = {},
 ): Parameters<typeof handleObserve>[0] {
+  const store = memoryObservationStore();
   return {
     request: observeRequest(),
     encryptionSecret: SECRET,
     resolveUserId: async () => "user-1",
     readVaultKeys: async (_userId: string): Promise<VaultKeyRow[]> => [],
+    store: () => store,
     ...overrides,
   };
+}
+
+/** Conductor's fake API with one working chat in one workspace the observed user created. */
+function conductorApi(status: string = TEST_CONDUCTOR_STATUS.WORKING) {
+  return fakeConductorApi({
+    userId: TEST_USER_ID,
+    projects: [LUKE_PROJECT],
+    workspaces: [ownedWorkspace("workspace-active", TEST_TIME - 30_000)],
+    sessions: [
+      {
+        id: "session-working",
+        workspaceId: "workspace-active",
+        name: TEST_SESSION_NAME,
+        status,
+        statusUpdatedAt: TEST_TIME - 5_000,
+      },
+    ],
+  });
 }
 
 // --- Gate checks ---
@@ -50,34 +86,135 @@ test("the observe gate order is method, secret, token", async () => {
   assert.equal((await anonymous.json()).error, HOSTED_API_ERROR.INVALID_TOKEN);
 });
 
-// --- No keys → empty roster ---
+// --- No keys → empty roster, and nothing read or stored ---
 
-test("with no vault keys stored the response is 200 with an empty sessions array", async () => {
-  const response = await handleObserve(observeOptions());
+test("with no vault keys stored the response is 200 with an empty sessions array, and the store is not read", async () => {
+  const store = memoryObservationStore();
+  store.snapshots.set("user-1", {
+    body: encodeObservedRoster({ version: 1, providers: [] }),
+    observedAt: TEST_TIME,
+  });
+  const response = await handleObserve(observeOptions({ store: () => store }));
 
   assert.equal(response.status, 200);
   const body = await response.json();
-  assert.ok(Array.isArray(body.sessions));
-  assert.equal(body.sessions.length, 0);
+  assert.deepEqual(body, { sessions: [] });
 });
 
-// --- Provider error is isolated ---
+// --- The stored snapshot is what the endpoint answers ---
 
-test("a provider that throws during observation does not fail the whole response", async () => {
-  const ciphertext = encryptProviderKey("bad-key-triggers-auth-error", SECRET);
-  // The adapter will call out to the provider with this key; the injected fetch
-  // returns 401, which makes the adapter return an empty array (not throw).
+test("a user with a snapshot is answered from it, dated, and the provider is not asked", async () => {
+  const api = conductorApi();
+  const store = memoryObservationStore();
+  const seeded = await handleObserve(
+    observeOptions({
+      readVaultKeys: async () => KEY_ROWS,
+      store: () => store,
+      fetch: api.fetch,
+      now: () => TEST_TIME,
+    }),
+  );
+  assert.equal(seeded.status, 200);
+  const seededBody = await seeded.json();
+  assert.equal(seededBody.sessions.length, 1);
+  assert.equal(seededBody.sessions[0].sessionId, "session-working");
+  assert.equal(seededBody.observedAt, TEST_TIME);
+  assert.equal(store.snapshots.has("user-1"), true);
+  const readsAfterSeeding = api.requests.length;
+
+  const stored = await handleObserve(
+    observeOptions({
+      readVaultKeys: async () => KEY_ROWS,
+      store: () => store,
+      fetch: async () => {
+        throw new Error("a stored roster is not re-observed");
+      },
+      now: () => TEST_TIME + 60_000,
+    }),
+  );
+  assert.equal(stored.status, 200);
+  const storedBody = await stored.json();
+  assert.deepEqual(storedBody, seededBody);
+  assert.equal(api.requests.length, readsAfterSeeding);
+  assert.equal(observeAnswerSchema.parse(storedBody)?.observedAt, TEST_TIME);
+});
+
+test("a fresh read runs the pass again, stores it, and answers the new roster", async () => {
+  const store = memoryObservationStore();
+  const working = conductorApi();
+  await handleObserve(
+    observeOptions({
+      readVaultKeys: async () => KEY_ROWS,
+      store: () => store,
+      fetch: working.fetch,
+      now: () => TEST_TIME,
+    }),
+  );
+
+  const idle = conductorApi(TEST_CONDUCTOR_STATUS.IDLE);
   const response = await handleObserve(
     observeOptions({
-      readVaultKeys: async (): Promise<VaultKeyRow[]> => [{ providerId: "conductor", ciphertext }],
-      fetch: async () => new Response(null, { status: 401 }),
+      request: observeRequest({}, true),
+      readVaultKeys: async () => KEY_ROWS,
+      store: () => store,
+      fetch: idle.fetch,
+      now: () => TEST_TIME + 1_000,
     }),
   );
 
   assert.equal(response.status, 200);
   const body = await response.json();
-  assert.ok(Array.isArray(body.sessions));
-  assert.equal(body.sessions.length, 0);
+  assert.equal(body.sessions[0].status, SESSION_STATUS.WAITING);
+  assert.equal(body.observedAt, TEST_TIME + 1_000);
+  assert.equal(store.snapshots.get("user-1")?.observedAt, TEST_TIME + 1_000);
+  assert.equal(store.diffs.get("user-1")?.length, 1);
+});
+
+// --- Provider error leaves the previous snapshot standing ---
+
+test("a pass the provider refuses answers what stood before, and stores no roster", async () => {
+  const store = memoryObservationStore();
+  const api = conductorApi();
+  await handleObserve(
+    observeOptions({
+      readVaultKeys: async () => KEY_ROWS,
+      store: () => store,
+      fetch: api.fetch,
+      now: () => TEST_TIME,
+    }),
+  );
+
+  const response = await handleObserve(
+    observeOptions({
+      request: observeRequest({}, true),
+      readVaultKeys: async () => KEY_ROWS,
+      store: () => store,
+      fetch: async () => new Response(null, { status: 401 }),
+      now: () => TEST_TIME + 1_000,
+    }),
+  );
+
+  assert.equal(response.status, 200);
+  const body = await response.json();
+  assert.equal(body.sessions.length, 1);
+  assert.equal(body.observedAt, TEST_TIME);
+  assert.equal(store.snapshots.get("user-1")?.observedAt, TEST_TIME);
+  assert.equal(store.passes.get("user-1")?.failure, "unauthorized");
+});
+
+test("a first pass the provider refuses answers an empty roster and stores none", async () => {
+  const store = memoryObservationStore();
+  const response = await handleObserve(
+    observeOptions({
+      readVaultKeys: async () => KEY_ROWS,
+      store: () => store,
+      fetch: async () => new Response(null, { status: 401 }),
+    }),
+  );
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(await response.json(), { sessions: [] });
+  assert.equal(store.snapshots.size, 0);
 });
 
 // --- Wire contract ---
@@ -327,19 +464,40 @@ test("readVaultKeys is called with the resolved user id", async () => {
 
 // --- Rate brake ---
 
-test("the observe endpoint returns 429 after too many requests in the same window", async () => {
+test("fresh reads return 429 after too many in the same window, while stored reads are not braked", async () => {
   // now() stays fixed so all calls land in the same window.
   const now = () => 1_000_000;
   // A userId unique to this test run avoids cross-test pollution of the module-level counter.
   const userId = `ratelimit-${Date.now()}-${process.pid}`;
+  const store = memoryObservationStore();
+  const api = conductorApi();
+  const fresh = () =>
+    observeOptions({
+      request: observeRequest({}, true),
+      resolveUserId: async () => userId,
+      readVaultKeys: async () => KEY_ROWS,
+      store: () => store,
+      fetch: api.fetch,
+      now,
+    });
 
   // MAX_REQUESTS_PER_WINDOW is 10; the 11th should be rate-limited.
   for (let i = 0; i < 10; i++) {
-    const res = await handleObserve(observeOptions({ resolveUserId: async () => userId, now }));
+    const res = await handleObserve(fresh());
     assert.equal(res.status, 200, `request ${i + 1} should succeed`);
   }
 
-  const limited = await handleObserve(observeOptions({ resolveUserId: async () => userId, now }));
+  const limited = await handleObserve(fresh());
   assert.equal(limited.status, 429);
   assert.equal((await limited.json()).error, HOSTED_API_ERROR.QUOTA_EXHAUSTED);
+
+  const stored = await handleObserve(
+    observeOptions({
+      resolveUserId: async () => userId,
+      readVaultKeys: async () => KEY_ROWS,
+      store: () => store,
+      now,
+    }),
+  );
+  assert.equal(stored.status, 200);
 });

--- a/apps/web/tests/hosted-projects.test.ts
+++ b/apps/web/tests/hosted-projects.test.ts
@@ -3,8 +3,10 @@ import test from "node:test";
 import { hostedProjectsAnswerSchema } from "@sidecar/hosted";
 import { encryptProviderKey } from "../server/hosted/encryption";
 import { HOSTED_API_ERROR } from "../server/hosted/http";
+import { observeAndSnapshot } from "../server/hosted/observation-pass";
 import { handleProjects } from "../server/hosted/projects";
 import type { VaultKeyRow } from "../server/hosted/vault-route";
+import { memoryObservationStore } from "./support/observation-store";
 
 const SECRET = "a".repeat(64);
 
@@ -23,9 +25,72 @@ function projectsOptions(
     encryptionSecret: SECRET,
     resolveUserId: async () => "user-1",
     readVaultKeys: async (): Promise<VaultKeyRow[]> => [],
+    store: () => memoryObservationStore(),
     ...overrides,
   };
 }
+
+const KEY_ROWS: VaultKeyRow[] = [
+  { providerId: "conductor", ciphertext: encryptProviderKey("conductor-key", SECRET) },
+];
+
+/** Conductor answering one project, and one more once `connected` is set, recording how often it was asked. */
+function conductorProjects() {
+  const state = { connected: false, reads: 0 };
+  const fetch = async (url: string) => {
+    state.reads += 1;
+    if (url.endsWith("/me")) {
+      return new Response(JSON.stringify({ userId: "u1" }), { status: 200 });
+    }
+    if (url.includes("/v0/projects")) {
+      const data = [{ id: "proj-1", gitRemote: "https://github.com/owner/repo", name: "Repo" }];
+      if (state.connected) {
+        data.push({ id: "proj-2", gitRemote: "https://github.com/owner/other", name: "Other" });
+      }
+      return new Response(JSON.stringify({ data }), { status: 200 });
+    }
+    return new Response(JSON.stringify({ data: [] }), { status: 200 });
+  };
+  return { state, fetch };
+}
+
+function projectIds(body: { projects: Array<{ providerProjectId: string }> }): string[] {
+  return body.projects.map((project) => project.providerProjectId);
+}
+
+test("projects are listed from the stored snapshot, seeded once, and a project connected later appears with the next pass", async () => {
+  const store = memoryObservationStore();
+  const conductor = conductorProjects();
+  const options = () =>
+    projectsOptions({
+      readVaultKeys: async () => KEY_ROWS,
+      store: () => store,
+      fetch: conductor.fetch,
+    });
+
+  assert.deepEqual(projectIds(await (await handleProjects(options())).json()), ["proj-1"]);
+  assert.equal(store.snapshots.has("user-1"), true);
+  const readsAfterSeeding = conductor.state.reads;
+
+  conductor.state.connected = true;
+  assert.deepEqual(projectIds(await (await handleProjects(options())).json()), ["proj-1"]);
+  assert.equal(conductor.state.reads, readsAfterSeeding);
+
+  // The schedule's next pass is what brings the new project to the phone,
+  // and to admission at the same moment.
+  await observeAndSnapshot({
+    userId: "user-1",
+    rows: KEY_ROWS,
+    secret: SECRET,
+    store,
+    seams: { fetch: conductor.fetch },
+    now: Date.now(),
+  });
+  assert.deepEqual(projectIds(await (await handleProjects(options())).json()), [
+    "proj-1",
+    "proj-2",
+  ]);
+});
 
 test("the projects gate order is method, token, secret", async () => {
   const wrongMethod = await handleProjects(

--- a/apps/web/tests/roster-diff.test.ts
+++ b/apps/web/tests/roster-diff.test.ts
@@ -39,6 +39,7 @@ function roster(observations: readonly ProviderSessionObservation[]): ObservedRo
     providers: [
       {
         providerId: "conductor",
+        keyFingerprint: "fingerprint-1",
         observations,
         projects: [{ providerProjectId: "project-1", repository: "repo", taskSupport: "optional" }],
       },
@@ -168,7 +169,14 @@ test("a diff and a roster round-trip through their stored encodings, and an unre
     decodeObservedRoster(
       JSON.stringify({
         version: 1,
-        providers: [{ providerId: "conductor", observations: [{ title: "no id" }], projects: [] }],
+        providers: [
+          {
+            providerId: "conductor",
+            keyFingerprint: "f",
+            observations: [{ title: "no id" }],
+            projects: [],
+          },
+        ],
       }),
     ),
     undefined,
@@ -177,7 +185,7 @@ test("a diff and a roster round-trip through their stored encodings, and an unre
     decodeObservedRoster(
       JSON.stringify({
         version: 1,
-        providers: [{ providerId: "linear", observations: [], projects: [] }],
+        providers: [{ providerId: "linear", keyFingerprint: "f", observations: [], projects: [] }],
       }),
     ),
     undefined,

--- a/packages/hosted/src/index.ts
+++ b/packages/hosted/src/index.ts
@@ -113,6 +113,7 @@ export {
   remoteMintAnswerSchema,
 } from "./mint-wire.js";
 export {
+  OBSERVE_QUERY,
   type ObserveAnswer,
   type ObservedSession,
   type ObservedSessionControl,

--- a/packages/hosted/src/observe-wire.ts
+++ b/packages/hosted/src/observe-wire.ts
@@ -15,6 +15,19 @@ import { writtenText } from "./service-wire.js";
  */
 
 /**
+ * The one query the observe endpoint takes. The roster it answers is the
+ * snapshot the service's own scheduled pass last stored; a foreground device
+ * that wants the provider asked again right now says so with `fresh=true`,
+ * which spends the endpoint's per-user rate brake where a stored read does
+ * not.
+ */
+export const OBSERVE_QUERY = {
+  FRESH: "fresh",
+  /** The value the flag takes; anything else reads the stored snapshot. */
+  FRESH_VALUE: "true",
+} as const;
+
+/**
  * One control a session's provider advertised for it, as the observe endpoint
  * reports it: the id an action names, and the label and kind the row draws. What
  * the control targets never travels — the action endpoint re-observes and builds
@@ -32,9 +45,9 @@ export interface ObservedSessionControl {
  * One cloud session as reported by the observe endpoint. The fields are a
  * bounded subset of `ProviderSessionObservation`: what mobile can show in a
  * roster row, and which actions that row may offer. The service maps the
- * adapter's observation onto this shape and stores nothing — a new request is
- * a new observation pass, and every action endpoint re-observes for itself
- * rather than trusting these advertisements.
+ * stored snapshot's observation onto this shape; every action endpoint
+ * validates against that same snapshot's own advertisements rather than
+ * trusting these copies.
  *
  * The detail fields are the session vocabulary's own, and the reader holds
  * them to that vocabulary's own bounds: `change` to an HTTPS address, `link`
@@ -86,6 +99,8 @@ export interface ObservedSession
 /** The observe endpoint answer: the caller's cloud sessions across all providers. */
 export interface ObserveAnswer {
   sessions: ObservedSession[];
+  /** When the roster answered was observed, in Unix milliseconds; absent for a roster no pass has stored. */
+  observedAt?: number;
 }
 
 const OBSERVED_SESSION_STATUS_NAMES = Object.values(SESSION_STATUS);
@@ -148,6 +163,9 @@ const observedSessionSchema: Schema<ObservedSession> = s.map(
 
 /** A malformed session entry is skipped, not fatal. */
 export const observeAnswerSchema: Schema<ObserveAnswer> = s.record(
-  { sessions: s.array(observedSessionSchema, { skipRefused: true }) },
+  {
+    sessions: s.array(observedSessionSchema, { skipRefused: true }),
+    observedAt: s.dropRefused(s.number()),
+  },
   { extraKeys: RECORD_EXTRA_KEYS.IGNORE },
 );

--- a/packages/hosted/src/service-paths.ts
+++ b/packages/hosted/src/service-paths.ts
@@ -29,7 +29,8 @@ export const HOSTED_SERVICE_PATH = {
   /**
    * List the projects a new workspace can be created in (GET): each entry is
    * one a provider itself reported on a fresh observation pass, so a creation
-   * ask can only ever name a reported project. Stateless like observe.
+   * ask can only ever name a reported project. Stored nowhere: a projects
+   * request is its own pass.
    */
   PROJECTS: "/api/projects",
   /**
@@ -83,9 +84,11 @@ export const HOSTED_SERVICE_PATH = {
    */
   DEVICES: "/api/devices",
   /**
-   * Observe cloud sessions on demand for the signed-in user. GET: decrypts the
-   * caller's vault keys, runs each provider's cloud adapter once, and returns a
-   * bounded roster. Stateless: no session state is stored between requests.
+   * The signed-in user's cloud sessions (GET): the bounded roster the
+   * service's own scheduled pass last stored for them, run every minute for
+   * accounts seen within the week, or a live pass where no snapshot stands
+   * yet. `OBSERVE_QUERY.FRESH` asks the provider again right now, under the
+   * endpoint's per-user rate brake.
    */
   OBSERVE: "/api/observe",
   /**

--- a/packages/hosted/src/service-paths.ts
+++ b/packages/hosted/src/service-paths.ts
@@ -28,9 +28,9 @@ export const HOSTED_SERVICE_PATH = {
   ACTION_RENAME_WORKSPACE: "/api/actions/rename-workspace",
   /**
    * List the projects a new workspace can be created in (GET): each entry is
-   * one a provider itself reported on a fresh observation pass, so a creation
-   * ask can only ever name a reported project. Stored nowhere: a projects
-   * request is its own pass.
+   * one a provider reported on the same stored snapshot a creation is
+   * admitted against, so a creation ask can only ever name a project this
+   * answer offered. Read like observe, from the snapshot.
    */
   PROJECTS: "/api/projects",
   /**


### PR DESCRIPTION
> **Do not merge yet.** This PR switches `/api/observe` to the stored snapshot, which only the cron refreshes. Merge only once `CRON_SECRET` is set in Vercel production and `observation_pass` rows are moving (the tick has run for the eligible accounts). Merged before that, the phone's roster freezes at its first seeded read, because the current iOS app never sends `?fresh=true`.

## Summary

PR 4b of [LUKE-95](https://linear.app/stage-review/issue/LUKE-95/host-lukes-brain-one-conversation-across-mac-iphone-and-apple-watch), the second half of [LUKE-99](https://linear.app/stage-review/issue/LUKE-99/pr-4-server-side-conductor-observation-on-a-cron-with-stored-snapshots). Follows #863 (PR 4a, merged as `63df42b6`), which added the schedule, the snapshot, and the diff without changing what the phone reads. This PR is the read-path switch, split out so it lands only once the cron is confirmed running in production.

### What changes

- **`/api/observe`** answers the stored snapshot, mapped onto the same wire rows and dated with a new `observedAt`. A user with no snapshot yet is answered from a live pass that seeds one. `?fresh=true` (`OBSERVE_QUERY.FRESH` in `@sidecar/hosted`) runs a pass under the existing per-user rate brake, which no longer brakes stored reads. A user with no cloud key is answered empty without touching the store. A snapshot this build cannot open or read is treated as one to re-seed.
- **`/api/actions/*`** admit against the stored snapshot's slice for the provider instead of a fresh pass: `dispatchAction` resolves targets from a plugin whose `latest()`/`projects()` answer the snapshot, so every write is built from the roster the user was shown. A user with no snapshot is seeded by the same pass once. Refusal shapes are unchanged: "Session not found.", "Project not found.", "Conductor rejected the stored API key.", "Could not reach Conductor.".
- **`/api/projects`** lists projects from the same snapshot, so the phone is never offered a project admission would refuse; a project connected later reaches both at the next scheduled pass.
- **Key changes**: each provider in the snapshot carries a fingerprint of the key row it was observed under; a snapshot observed under a replaced or removed key is treated as none, so a new key never serves or admits against the old key's roster.
- **Unchanged**: `/api/sessions/messages` keeps its own fresh pass before the read; the remote voice mint keeps its pass.
- **Wiring**: `HostedVaultRoute` gains a `store(secret)` seam (one store per process, rebuilt only if the secret changes); `rosterForAction` in the pass module reads the snapshot or seeds it.
- **Docs**: `PRIVACY.md` says the phone and watch now read the stored roster; the server README describes the read paths; the `@sidecar/hosted` path and wire comments say the observe endpoint is no longer stateless.

### Deployment coupling

Once this merges, `/api/observe` refreshes only from the cron. Merge it only with `CRON_SECRET` set in production and the tick observed running (`observation_pass` rows moving), otherwise the phone's roster freezes at its first seeded read, because the current iOS app never sends `?fresh=true`.

## Adopted and rebased (2026-09-11)

Dean authorised this PR's adoption so lane E's E3 and lane G's G3 could stop waiting on it. It was rebased onto `origin/main` across the 25 storage PRs that landed under it. **The branch's design survived intact**; nothing was rewritten. Two things had to be resolved:

1. `apps/web/tests/hosted-actions.test.ts`: main's #886 (tests assert values and structure, never prose) had removed this file's `assert.match` calls over refusal sentences; this branch's new test added one more. Resolved toward main's rule: the prose match was dropped, the two structural assertions (no snapshot seeded, the pass recorded as `unauthorized`) kept.
2. `apps/web/server/hosted/observed-roster.ts`: main's #907 (knip gate) deleted `rosterProvider` as dead code, because nothing on main used it until this PR did. Restored as it was, with its one caller in `action-execute.ts`.

Everything else applied cleanly, including B1 to B7's tables and writers beside it in `server/hosted/`. `./scripts/check.sh` passes on the rebased tree.

**Scope, corrected:** PR 4a (#863, `63df42b6`) already landed the cron tick, the stored snapshot, the diff, and the Conductor 429 backoff (`RATE_LIMIT_BACKOFF` in `packages/providers/src/shared/cloud-wire.ts`, with the forced-429 wait injected in tests). This PR is the read-path switch alone, exactly as its summary says.

**The merge gate above still stands, and it is trust-shaped, not only a stale-UI risk.** Once merged, `/api/observe` refreshes only from the cron, and `/api/actions/*` admits against that same snapshot. CLAUDE.md requires an action to be admitted against the observed roster with a fresh read preceding it; a snapshot that never refreshes because `CRON_SECRET` (or `PROVIDER_KEY_ENCRYPTION_SECRET`) is unset in production could admit an action against a session that has since vanished. The enqueue is held until production is confirmed running the tick. What keeps a *failed* read from emptying the roster is unchanged from 4a: a pass failure leaves the last snapshot standing, and `rosterForAction` admits against the standing snapshot or, for a user with none, against the empty roster a failed seeding pass left, flagged with why.

`PRIVACY.md`'s changed sentence ("the phone and watch can show your sessions without asking Conductor again") is true of the code after this rebase: `/api/observe` answers the stored snapshot.

**Reviews run on the rebased diff:** Cursor's thermonuclear code quality review and Ponytail review, as written. No structural change was made beyond the two resolutions above, on purpose: this is an adoption, and the design is Dean's.

## Merged with a known consequence, and how it resolved

After this PR, `/api/observe` refreshes only from the scheduled tick (`/api/observation/tick`, every minute per `apps/web/vercel.json`), and `/api/actions/*` admits against that same snapshot. The tick runs only where the deployment has both `CRON_SECRET` and `PROVIDER_KEY_ENCRYPTION_SECRET` set; without them it answers 503, the schedule is simply off, and the phone's roster stays at whatever seeded it, because the current iOS app never sends `?fresh=true`. Neither secret was confirmed set in production when the merge decision was taken on 2026-09-11, so Dean accepted the freeze deliberately on the grounds that nobody depended on the feature yet. Both have since been set in luke-web for Production and Preview, so the tick is expected to run once luke-web redeploys and the roster to move again. A reader who finds a frozen roster should check those two secrets first; a reader who finds a moving one is seeing the resolution.

**One more consequence, found by Bugbot on the rebased head and accepted under the same decision:** a snapshot written before this PR carries no `keyFingerprint`, so it no longer decodes and is treated as none. The first read or action after deploy re-seeds it with a live pass; if that one pass fails, the roster is empty until a pass succeeds, rather than the pre-deploy snapshot standing. The trust rule is kept on purpose (a snapshot whose key provenance cannot be verified is not admitted against), the gap is one pass long and happens once, and nobody depends on the roster yet. From then on a pass failure leaves the last snapshot standing as before.

## Evidence

- On this branch: apps/web 377 tests, packages/hosted 68, typecheck and lint clean; `./scripts/check.sh` exit 0 on the identical file set before the split.
- `./scripts/verify.sh`: not run (service only, no UI touched)
- Physical-notch check: not performed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34435575578/artifacts/10136096545) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34435575578)

- Commit: `43904129104b33f3b9c2c4d988d5339976ff2d46`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->



