### PR TITLE
feat(desktop): draw carried actions as rows

### DIFF
--- a/apps/desktop/src/renderer/conversation-panel.test.ts
+++ b/apps/desktop/src/renderer/conversation-panel.test.ts
@@ -1,6 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { appendConversationThreadEntry, CONVERSATION_ENTRY_KIND } from "@sidecar/session";
+import {
+  ACTION_KIND,
+  appendConversationThreadEntry,
+  CONVERSATION_ENTRY_KIND,
+} from "@sidecar/session";
 import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import {
@@ -39,17 +43,110 @@ test("Luke replies and announcements use the received-message side", () => {
 });
 
 test("session actions remain quiet events between messages", () => {
-  assert.equal(
-    conversationEntryPresentation(CONVERSATION_ENTRY_KIND.ACTION).speaker,
-    CONVERSATION_ENTRY_SPEAKER.EVENT,
-  );
+  assert.deepEqual(conversationEntryPresentation(CONVERSATION_ENTRY_KIND.ACTION), {
+    speaker: CONVERSATION_ENTRY_SPEAKER.EVENT,
+    label: "At your request",
+  });
 });
 
-test("an action Luke took on his own judgment is drawn as his own line, never as the developer's request", () => {
+test("an action Luke took on his own judgment is the same quiet row under his own name, never the developer's request", () => {
   assert.deepEqual(conversationEntryPresentation(CONVERSATION_ENTRY_KIND.OWN_ACTION), {
-    speaker: CONVERSATION_ENTRY_SPEAKER.LUKE,
-    label: "Luke",
+    speaker: CONVERSATION_ENTRY_SPEAKER.EVENT,
+    label: "Luke, on his own judgment",
   });
+});
+
+test("an action draws as a row led by the mark of its kind, with no bubble and no copy", () => {
+  const markup = renderToStaticMarkup(
+    createElement(ConversationPanel, {
+      entries: [
+        {
+          kind: CONVERSATION_ENTRY_KIND.ACTION,
+          words: 'sent a message to "checkout-service": "please add tests"',
+          recordedAt: NOW,
+          action: { kind: ACTION_KIND.MESSAGE },
+        },
+      ],
+      now: NOW,
+      ask: async () => undefined,
+      onAskEngaged: () => undefined,
+    }),
+  );
+  assert.match(markup, /class="conversation-entry" data-speaker="event" data-origin="ask"/);
+  assert.match(markup, /<small class="visually-hidden">At your request<\/small>/);
+  // The mark leads the words inside the row, and the stamp stands outside it.
+  assert.match(
+    markup,
+    /<span class="conversation-action"><span class="conversation-action-mark" aria-hidden="true"><svg class="icon-button-glyph"/,
+  );
+  assert.match(markup, /<\/div><time class="conversation-time"/);
+  assert.doesNotMatch(markup, /conversation-bubble|conversation-copy|conversation-turn/);
+  // No identity and no provider on the action: the words end with no mark.
+  assert.doesNotMatch(markup, /conversation-action-provider/);
+  // A line an earlier build recorded without its kind keeps the mark's room and fills it with nothing.
+  const unmarked = renderToStaticMarkup(
+    createElement(ConversationPanel, {
+      entries: [{ kind: CONVERSATION_ENTRY_KIND.ACTION, words: 'opened "checkout-service"' }],
+      now: NOW,
+      ask: async () => undefined,
+      onAskEngaged: () => undefined,
+    }),
+  );
+  assert.match(unmarked, /<span class="conversation-action-mark" aria-hidden="true"><\/span>/);
+});
+
+test("an action row ends on the mark of the provider it reached", () => {
+  const render = (entry: Parameters<typeof ConversationPanel>[0]["entries"][number]) =>
+    renderToStaticMarkup(
+      createElement(ConversationPanel, {
+        entries: [entry],
+        now: NOW,
+        ask: async () => undefined,
+        onAskEngaged: () => undefined,
+      }),
+    );
+  // An action on a session wears the session's own provider.
+  const onSession = render({
+    kind: CONVERSATION_ENTRY_KIND.ACTION,
+    words: 'sent a message to "checkout-service": "please add tests"',
+    identity: { providerId: "claude-code", providerSessionId: "session-a" },
+    action: { kind: ACTION_KIND.MESSAGE },
+  });
+  assert.match(
+    onSession,
+    /<\/div><span class="conversation-action-provider" aria-hidden="true"><svg class="provider-mark" data-mark="claude-code"/,
+  );
+  // A creation has no session, so its line names the provider it asked.
+  const creation = render({
+    kind: CONVERSATION_ENTRY_KIND.ACTION,
+    words: 'asked conductor to create a workspace named "Notch panel clipping"',
+    action: { kind: ACTION_KIND.CREATE_WORKSPACE, providerId: "conductor" },
+  });
+  assert.match(creation, /class="provider-mark" data-mark="conductor"/);
+});
+
+test("an action Luke took on his own is signed with his face and never wears a reply's bubble", () => {
+  const markup = renderToStaticMarkup(
+    createElement(ConversationPanel, {
+      entries: [
+        {
+          kind: CONVERSATION_ENTRY_KIND.OWN_ACTION,
+          words: 'ran "Retry" on "checkout-service"',
+          action: { kind: ACTION_KIND.CONTROL },
+        },
+      ],
+      now: NOW,
+      ask: async () => undefined,
+      onAskEngaged: () => undefined,
+    }),
+  );
+  assert.match(markup, /data-speaker="event" data-origin="own"/);
+  assert.match(markup, /<small class="visually-hidden">Luke, on his own judgment<\/small>/);
+  assert.match(
+    markup,
+    /class="conversation-action-mark" aria-hidden="true"><svg class="luke-face"/,
+  );
+  assert.doesNotMatch(markup, /data-speaker="luke"|conversation-copy/);
 });
 
 test("an announcement shows its spoken transcript", () => {

--- a/apps/desktop/src/renderer/conversation-panel.tsx
+++ b/apps/desktop/src/renderer/conversation-panel.tsx
@@ -1,6 +1,18 @@
 import { type BrainRequestSnapshot, brainRequestPending } from "@sidecar/brain/requests-wire";
-import { CheckIcon, CopyIcon, WingFace } from "@sidecar/panel";
 import {
+  CheckIcon,
+  ControlIcon,
+  CopyIcon,
+  ExternalIcon,
+  MessageIcon,
+  PencilIcon,
+  PlusIcon,
+  ProviderMark,
+  WingFace,
+} from "@sidecar/panel";
+import {
+  ACTION_KIND,
+  type ActionKind,
   CONVERSATION_ENTRY_KIND,
   type ConversationEntry,
   type ConversationEntryKind,
@@ -27,6 +39,12 @@ export const CONVERSATION_ENTRY_SPEAKER = {
 type ConversationEntrySpeaker =
   (typeof CONVERSATION_ENTRY_SPEAKER)[keyof typeof CONVERSATION_ENTRY_SPEAKER];
 
+/** Whose judgment an action row records: the developer's ask, or Luke's own. */
+export const CONVERSATION_ACTION_ORIGIN = {
+  ASK: "ask",
+  OWN: "own",
+} as const;
+
 export interface ConversationEntryPresentation {
   speaker: ConversationEntrySpeaker;
   label: string;
@@ -42,14 +60,32 @@ export function conversationEntryPresentation(
       return { speaker: CONVERSATION_ENTRY_SPEAKER.YOU, label: "You" };
     case CONVERSATION_ENTRY_KIND.REPLY:
     case CONVERSATION_ENTRY_KIND.ANNOUNCEMENT:
-    // An action Luke took on his own judgment is drawn as his own line, never as
-    // the developer's request; the attribution lives in the stored kind.
-    case CONVERSATION_ENTRY_KIND.OWN_ACTION:
       return { speaker: CONVERSATION_ENTRY_SPEAKER.LUKE, label: "Luke" };
     case CONVERSATION_ENTRY_KIND.ACTION:
       return { speaker: CONVERSATION_ENTRY_SPEAKER.EVENT, label: "At your request" };
+    // An action Luke took on his own judgment is the same quiet row, never a
+    // reply bubble and never the developer's request; the label names whose
+    // judgment it was, and the row signs it with his face.
+    case CONVERSATION_ENTRY_KIND.OWN_ACTION:
+      return { speaker: CONVERSATION_ENTRY_SPEAKER.EVENT, label: "Luke, on his own judgment" };
   }
 }
+
+/**
+ * The mark an action row leads with, one per kind of thing that can be done to
+ * a session, total over the vocabulary so a new kind does not compile until it
+ * has one. Two renames share the pencil and two creations the plus: the mark
+ * says what sort of thing happened, and the words say to what.
+ */
+const ACTION_GLYPH = {
+  [ACTION_KIND.MESSAGE]: MessageIcon,
+  [ACTION_KIND.CONTROL]: ControlIcon,
+  [ACTION_KIND.OPEN]: ExternalIcon,
+  [ACTION_KIND.CREATE_WORKSPACE]: PlusIcon,
+  [ACTION_KIND.ADD_AGENT]: PlusIcon,
+  [ACTION_KIND.RENAME_WORKSPACE]: PencilIcon,
+  [ACTION_KIND.RENAME_SESSION]: PencilIcon,
+} as const satisfies Record<ActionKind, () => React.JSX.Element>;
 
 const COPY_CONFIRMATION_MS = 1500;
 
@@ -131,7 +167,22 @@ function ConversationThinkingRow({
   );
 }
 
-function ConversationEntryRow({
+/**
+ * The stamp is the row's, not the bubble's: it stands in one column past the
+ * thread's visible edge, sent, received, and acted alike, which the thread's
+ * own sideways scroll brings into view.
+ */
+function ConversationStamp({ recordedAt }: { recordedAt: number | undefined }) {
+  if (recordedAt === undefined) return null;
+  const at = new Date(recordedAt);
+  return (
+    <time className="conversation-time" dateTime={at.toISOString()}>
+      {ENTRY_TIME.format(at)}
+    </time>
+  );
+}
+
+function ConversationMessageRow({
   entry,
   streaming,
 }: {
@@ -148,8 +199,6 @@ function ConversationEntryRow({
     return () => clearTimeout(timer);
   }, [copied]);
 
-  const recordedAt = entry.recordedAt === undefined ? undefined : new Date(entry.recordedAt);
-
   return (
     <li
       className="conversation-entry"
@@ -162,7 +211,7 @@ function ConversationEntryRow({
           <MarkdownMessage words={words} className="conversation-words" />
           {/* Copying words still arriving would copy half a sentence; the control
             appears with the settled line the same words become. */}
-          {presentation.speaker === CONVERSATION_ENTRY_SPEAKER.EVENT || streaming ? null : (
+          {streaming ? null : (
             <button
               type="button"
               className="conversation-copy"
@@ -181,15 +230,63 @@ function ConversationEntryRow({
           )}
         </span>
       </div>
-      {/* The stamp is the row's, not the bubble's: it stands in one column
-          past the thread's visible edge, sent and received alike, which the
-          thread's own sideways scroll brings into view. */}
-      {recordedAt ? (
-        <time className="conversation-time" dateTime={recordedAt.toISOString()}>
-          {ENTRY_TIME.format(recordedAt)}
-        </time>
-      ) : null}
+      <ConversationStamp recordedAt={entry.recordedAt} />
     </li>
+  );
+}
+
+/**
+ * An action Luke carried is a row rather than a bubble: what was done, in the
+ * quiet voice the dates use, led by a mark for the kind of thing it was. A row
+ * from a turn nobody opened leads with Luke's face instead — he signs his own
+ * work here as the errand has him do on a control — so whose judgment an
+ * action was is read at a glance and never wears a reply's bubble. The words
+ * end on the mark of the provider the action reached — the session's own for
+ * an action on a session, the one a creation asked for a new workspace — so
+ * a row is placed the way a session row is, by its mark. A line an earlier
+ * build recorded without its kind draws with the mark's room left empty
+ * rather than guessing one. No copy control: the words are a record of an
+ * act, not something said.
+ */
+function ConversationActionRow({ entry }: { entry: ConversationEntry }): React.JSX.Element {
+  const presentation = conversationEntryPresentation(entry.kind);
+  const own = entry.kind === CONVERSATION_ENTRY_KIND.OWN_ACTION;
+  const Glyph = entry.action ? ACTION_GLYPH[entry.action.kind] : undefined;
+  const providerId = entry.identity?.providerId ?? entry.action?.providerId;
+  return (
+    <li
+      className="conversation-entry"
+      data-speaker={presentation.speaker}
+      data-origin={own ? CONVERSATION_ACTION_ORIGIN.OWN : CONVERSATION_ACTION_ORIGIN.ASK}
+    >
+      <small className="visually-hidden">{presentation.label}</small>
+      <div className="conversation-message">
+        <span className="conversation-action">
+          <span className="conversation-action-mark" aria-hidden="true">
+            {own ? <WingFace /> : Glyph ? <Glyph /> : null}
+          </span>
+          <MarkdownMessage words={entry.words} className="conversation-words" />
+          {providerId === undefined ? null : (
+            <span className="conversation-action-provider" aria-hidden="true">
+              <ProviderMark providerId={providerId} />
+            </span>
+          )}
+        </span>
+      </div>
+      <ConversationStamp recordedAt={entry.recordedAt} />
+    </li>
+  );
+}
+
+function ConversationEntryRow(props: {
+  entry: ConversationEntry;
+  streaming?: boolean;
+}): React.JSX.Element {
+  return conversationEntryPresentation(props.entry.kind).speaker ===
+    CONVERSATION_ENTRY_SPEAKER.EVENT ? (
+    <ConversationActionRow entry={props.entry} />
+  ) : (
+    <ConversationMessageRow {...props} />
   );
 }
 
@@ -212,8 +309,16 @@ function ConversationTimeBreak({ recordedAt, now }: { recordedAt: number; now: n
   );
 }
 
+interface KeyedConversationEntry {
+  entry: ConversationEntry;
+  key: string;
+  opensBreak: boolean;
+}
+
 /** Stable enough for repeated identical lines without pretending the record has durable ids. */
-function keyedConversationEntries(entries: readonly ConversationEntry[]) {
+function keyedConversationEntries(
+  entries: readonly ConversationEntry[],
+): readonly KeyedConversationEntry[] {
   const occurrences = new Map<string, number>();
   let previousRecordedAt: number | undefined;
   return entries.map((entry) => {
@@ -345,6 +450,18 @@ export function ConversationPanel({
 
   const thread = entries.length > 0 || live.length > 0 || thinkingSince !== undefined;
 
+  const dated = (lead: KeyedConversationEntry, row: React.JSX.Element) =>
+    lead.opensBreak && lead.entry.recordedAt !== undefined
+      ? [
+          <ConversationTimeBreak
+            key={`${lead.key}:break`}
+            recordedAt={lead.entry.recordedAt}
+            now={now}
+          />,
+          row,
+        ]
+      : [row];
+
   return (
     <section
       // PostHog blocks this fixed class and its whole subtree. Conversation
@@ -362,19 +479,9 @@ export function ConversationPanel({
               moment the fingers lift, which only the browser can see. */}
           <div className="conversation-pull">
             <ol className="conversation-list">
-              {keyedConversationEntries(entries).flatMap(({ entry, key, opensBreak }) => {
-                const row = <ConversationEntryRow key={key} entry={entry} />;
-                return opensBreak && entry.recordedAt !== undefined
-                  ? [
-                      <ConversationTimeBreak
-                        key={`${key}:break`}
-                        recordedAt={entry.recordedAt}
-                        now={now}
-                      />,
-                      row,
-                    ]
-                  : [row];
-              })}
+              {keyedConversationEntries(entries).flatMap((keyed) =>
+                dated(keyed, <ConversationEntryRow key={keyed.key} entry={keyed.entry} />),
+              )}
               {live.map((entry, index) => (
                 <ConversationEntryRow
                   // biome-ignore lint/suspicious/noArrayIndexKey: A line still being said has no durable id, and its words change on every delta — a key made of either would remount the bubble mid-sentence, while its position holds still for exactly as long as the line does.

--- a/apps/desktop/src/renderer/styles/conversation.css
+++ b/apps/desktop/src/renderer/styles/conversation.css
@@ -1,5 +1,5 @@
 /* A compact chat thread: sent and received messages use the familiar two-sided
-   bubble grammar, while the developer's requested actions sit between them. */
+   bubble grammar, while the actions Luke carried sit between them as rows. */
 .conversation-view {
   display: flex;
   min-height: 0;
@@ -376,22 +376,72 @@
   background: var(--raised-strong);
 }
 
-.conversation-entry[data-speaker="event"] .conversation-message {
-  justify-content: center;
-  padding: 8px 12px;
-  text-align: center;
+/* An action Luke carried is a row, not a bubble: what was done, in the quiet
+   voice the dates use, led by a mark for the kind of thing it was and ended
+   on the mark of the provider it reached. It reads from Luke's side of the
+   thread, because it is his doing — its leading mark sits on the edge his
+   bubbles start from — and it stands still under the pull as his words do. */
+.conversation-action {
+  display: flex;
+  min-width: 0;
+  max-width: min(88%, 64ch);
+  align-items: flex-start;
+  gap: 7px;
+  padding: 3px 0;
 }
 
-.conversation-entry[data-speaker="event"] .conversation-bubble {
-  max-width: 84%;
+/* The provider's mark, at the size the row's own marks take, trailing the
+   words the way a session row's application marks trail its title. */
+.conversation-action-provider {
+  display: inline-flex;
+  height: 16px;
+  flex: 0 0 auto;
   align-items: center;
+}
+
+.conversation-action-provider .provider-mark {
+  width: 12px;
+  height: 12px;
+}
+
+.conversation-action-provider .provider-mark[data-mark="superset"] {
+  width: 21px;
+}
+
+/* The mark's room is reserved whether or not a mark fills it, so rows with
+   and without one keep their words on one line. Luke's face in it wears the
+   text colour like the strip's does, only smaller. */
+.conversation-action-mark {
+  display: inline-flex;
+  width: 12px;
+  height: 12px;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: center;
+  margin-top: 2px;
+  color: var(--text-tertiary);
+}
+
+.conversation-action-mark svg {
+  width: 12px;
+  height: 12px;
+}
+
+.conversation-action-mark .luke-face {
+  color: var(--text-secondary);
 }
 
 .conversation-entry[data-speaker="event"] .conversation-words {
   padding: 0;
   color: var(--text-secondary);
-  font-size: 10.5px;
+  font-size: 11.5px;
   line-height: 1.4;
+}
+
+/* The narration is written in the model's lower case; the row reads as a
+   sentence of its own. */
+.conversation-entry[data-speaker="event"] .conversation-words > p:first-child::first-letter {
+  text-transform: uppercase;
 }
 
 /* The date over a line that followed a long silence, in the quiet voice the

--- a/packages/actions/src/action-narration.ts
+++ b/packages/actions/src/action-narration.ts
@@ -7,6 +7,7 @@
 import type {
   CONVERSATION_ENTRY_KIND,
   ConversationEntry,
+  ConversationEntryAction,
   Session,
   SessionApplicationId,
   SessionIdentity,
@@ -92,9 +93,10 @@ export function actionNarration(action: CarriedAction, sessions: readonly Sessio
 /**
  * The history line one carried action leaves behind: the ask, in the words of
  * what was asked — never the outcome, which the reply voicing it records as
- * its own line. A transcript reading is deliberately only the fact that one
- * was read: the rendering travels in the turn that asked for it and nowhere
- * else, so the record keeps the action and not a word of what it rendered.
+ * its own line — beside the kind it was, which is what the panel draws the
+ * line by. A transcript reading is deliberately only the fact that one was read: the
+ * rendering travels in the turn that asked for it and nowhere else, so the
+ * record keeps the action and not a word of what it rendered.
  *
  * It is here rather than beside the rest of the conversation model because it
  * is the one line whose words are an action's narration, and the action vocabulary
@@ -106,7 +108,9 @@ export function sessionActionConversationEntry(
   kind: typeof CONVERSATION_ENTRY_KIND.ACTION | typeof CONVERSATION_ENTRY_KIND.OWN_ACTION,
 ): ConversationEntry {
   const words = actionNarration(action, sessions);
-  const entry: ConversationEntry = { kind, words };
+  const carried: ConversationEntryAction = { kind: action.kind };
+  if (action.kind === ACTION_KIND.CREATE_WORKSPACE) carried.providerId = action.providerId;
+  const entry: ConversationEntry = { kind, words, action: carried };
   if ("identity" in action) entry.identity = action.identity;
   return entry;
 }

--- a/packages/actions/src/actions.test.ts
+++ b/packages/actions/src/actions.test.ts
@@ -230,6 +230,8 @@ test("an action's line records the ask in words, with the identity it named", ()
   assert.equal(message.kind, CONVERSATION_ENTRY_KIND.ACTION);
   assert.equal(message.words, 'sent a message to "checkout-service": "please add tests"');
   assert.deepEqual(message.identity, identity);
+  // The kind rides beside the words, for the panel to draw the row by.
+  assert.deepEqual(message.action, { kind: ACTION_KIND.MESSAGE });
 
   const control: AdvertisedControl = { kind: ACTION_KIND.CONTROL, id: "retry", label: "Retry" };
   assert.equal(
@@ -292,6 +294,11 @@ test("an action's line records the ask in words, with the identity it named", ()
   );
   assert.equal(created.words, "asked conductor to create a workspace");
   assert.equal(created.identity, undefined);
+  // With no identity to name it, the creation's line names the provider it asked.
+  assert.deepEqual(created.action, {
+    kind: ACTION_KIND.CREATE_WORKSPACE,
+    providerId: "conductor",
+  });
   const createdNamed = sessionActionConversationEntry(
     {
       kind: ACTION_KIND.CREATE_WORKSPACE,

--- a/packages/host/src/brain/action-performer.test.ts
+++ b/packages/host/src/brain/action-performer.test.ts
@@ -172,9 +172,11 @@ test("a session action reaches the performer only for a session the roster holds
   assert.equal(landed.status, ACTION_RESULT_STATUS.ACCEPTED);
   assert.equal(performed.length, 1);
   assert.equal(performed[0]?.kind, "message");
-  // The ask is recorded as the developer's, before the outcome is known.
+  // The ask is recorded as the developer's, before the outcome is known, with
+  // the kind of thing it was, so the panel can draw the row by it.
   assert.equal(recorded.length, 1);
   assert.equal(recorded[0]?.kind, "action");
+  assert.deepEqual(recorded[0]?.action, { kind: "message" });
 
   const stranger = await actions.perform(
     {
@@ -314,6 +316,7 @@ test("an action in a turn Luke opened himself runs under the same validators and
   assert.equal(performed.length, 1);
   assert.equal(recorded.length, 1);
   assert.equal(recorded[0]?.kind, "own-action");
+  assert.deepEqual(recorded[0]?.action, { kind: "message" });
 });
 
 test("an action with no turn standing is refused in main before any validator or effect", async () => {

--- a/packages/panel/src/glyphs.tsx
+++ b/packages/panel/src/glyphs.tsx
@@ -67,6 +67,34 @@ export function CopyIcon(): React.JSX.Element {
   );
 }
 
+/** A speech bubble: words sent to a session. */
+export function MessageIcon(): React.JSX.Element {
+  return (
+    <Glyph className="icon-button-glyph">
+      <path d="M20.4 6.2a1.8 1.8 0 0 0-1.8-1.8H5.4a1.8 1.8 0 0 0-1.8 1.8v7.4a1.8 1.8 0 0 0 1.8 1.8h3.4v3.8l4.4-3.8h5.4a1.8 1.8 0 0 0 1.8-1.8z" />
+    </Glyph>
+  );
+}
+
+/** A bolt: a control a session advertised, pressed. */
+export function ControlIcon(): React.JSX.Element {
+  return (
+    <Glyph className="icon-button-glyph">
+      <path d="M13.2 2.8 5.6 13.6h5.6l-1 7.6 7.6-10.8h-5.6z" />
+    </Glyph>
+  );
+}
+
+/** A plus: a workspace or an agent that did not exist before the action. */
+export function PlusIcon(): React.JSX.Element {
+  return (
+    <Glyph className="icon-button-glyph">
+      <path d="M12 5.4v13.2" />
+      <path d="M5.4 12h13.2" />
+    </Glyph>
+  );
+}
+
 export function PencilIcon(): React.JSX.Element {
   return (
     <Glyph className="icon-button-glyph">

--- a/packages/session/src/conversation/conversation.test.ts
+++ b/packages/session/src/conversation/conversation.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import { ACTION_KIND } from "../advertised-actions.js";
 import { normalizeSession } from "../normalize.js";
 import { SESSION_STATUS } from "../session-status.js";
 import {
@@ -407,6 +408,37 @@ test("a stored line reads back, and retention cuts by age and by count", () => {
     line,
   );
 
+  // An action line keeps the kind it was, over the wire and back from disk; a
+  // kind this build does not know refuses the line the way a malformed
+  // identity does.
+  const acted = {
+    kind: CONVERSATION_ENTRY_KIND.ACTION,
+    words: 'sent a message to "checkout-service": "go ahead"',
+    recordedAt: now,
+    identity: { providerId: "claude-code", providerSessionId: "a" },
+    action: { kind: ACTION_KIND.MESSAGE },
+  };
+  assert.deepEqual(storedConversationEntry(conversationEntryToWire(acted)), acted);
+  assert.deepEqual(storedConversationEntry(JSON.parse(JSON.stringify(acted))), acted);
+  assert.equal(storedConversationEntry({ ...acted, action: { kind: "invented" } }), undefined);
+  assert.equal(storedConversationEntry({ ...acted, action: {} }), undefined);
+  // A creation names the provider it asked on the action itself, having no identity to name it.
+  const created = {
+    kind: CONVERSATION_ENTRY_KIND.ACTION,
+    words: 'asked conductor to create a workspace named "Notch panel clipping"',
+    recordedAt: now,
+    action: { kind: ACTION_KIND.CREATE_WORKSPACE, providerId: "conductor" },
+  };
+  assert.deepEqual(storedConversationEntry(conversationEntryToWire(created)), created);
+  assert.equal(
+    storedConversationEntry({ ...created, action: { ...created.action, providerId: "" } }),
+    undefined,
+  );
+  assert.equal(
+    storedConversationEntry({ ...created, action: { ...created.action, providerId: 7 } }),
+    undefined,
+  );
+
   const stale = { ...line, recordedAt: now - storedConversationMaximumAgeMs - 1 };
   assert.deepEqual(retainedConversationEntries([stale, line], now), [line]);
 
@@ -436,6 +468,16 @@ test("the unstrict read takes what the strict one refuses, and nothing wider", (
 
   const blankIdentity = { ...unclocked, identity: { providerId: "", providerSessionId: "" } };
   assert.deepEqual(storedConversationEntry(blankIdentity, { strict: false }), blankIdentity);
+
+  const blankProvider = {
+    ...unclocked,
+    action: { kind: ACTION_KIND.CREATE_WORKSPACE, providerId: "" },
+  };
+  assert.deepEqual(storedConversationEntry(blankProvider, { strict: false }), blankProvider);
+  assert.equal(
+    storedConversationEntry({ ...blankProvider, recordedAt: line.recordedAt }),
+    undefined,
+  );
   assert.equal(
     storedConversationEntry({ ...blankIdentity, recordedAt: line.recordedAt }),
     undefined,

--- a/packages/session/src/conversation/conversation.ts
+++ b/packages/session/src/conversation/conversation.ts
@@ -22,6 +22,7 @@ import {
   type UnparsedWireValue,
   type WireRecord,
 } from "@sidecar/wire";
+import { ACTION_KIND, type ActionKind } from "../advertised-actions.js";
 import type { SessionIdentity } from "../session-identity.js";
 import type { Session } from "../session-shape.js";
 
@@ -55,6 +56,13 @@ export type ConversationEntryKind =
   (typeof CONVERSATION_ENTRY_KIND)[keyof typeof CONVERSATION_ENTRY_KIND];
 
 const CONVERSATION_ENTRY_KIND_LIST = Object.values(CONVERSATION_ENTRY_KIND);
+const ACTION_KIND_LIST = Object.values(ACTION_KIND);
+
+function isConversationEntryActionKind(value: UnparsedWireValue): value is ActionKind {
+  if (!isWireString(value)) return false;
+  // SAFETY: value is a string; list membership is the action vocabulary contract check.
+  return ACTION_KIND_LIST.includes(value as ActionKind);
+}
 
 export function isConversationEntryKind(value: UnparsedWireValue): value is ConversationEntryKind {
   if (!isWireString(value)) return false;
@@ -132,6 +140,23 @@ export interface ConversationEntry {
    * into model context.
    */
   requestId?: string;
+  /**
+   * The action an action line records, for the panel to draw the line by:
+   * which kind of thing was done. Never rendered into model context, whose
+   * lead already says whose judgment the action was and whose words say what
+   * it did.
+   */
+  action?: ConversationEntryAction;
+}
+
+export interface ConversationEntryAction {
+  kind: ActionKind;
+  /**
+   * The provider a workspace creation asked, the one action aimed at no
+   * session and so the one whose line carries no identity to read a provider
+   * from. Every other action's provider is its identity's.
+   */
+  providerId?: string;
 }
 
 /** The line as the Gateway protocol carries it; the unstrict read below takes it back whole. */
@@ -150,6 +175,7 @@ export function conversationEntryToWire(entry: ConversationEntry): WireRecord {
       : undefined),
     ...(entry.recordedAt !== undefined ? { recordedAt: entry.recordedAt } : undefined),
     ...(entry.requestId !== undefined ? { requestId: entry.requestId } : undefined),
+    ...(entry.action ? { action: { ...entry.action } } : undefined),
   };
 }
 
@@ -179,6 +205,7 @@ export function appendConversationThreadEntry(
   if (entry.eventId !== undefined) appended.eventId = entry.eventId;
   if (entry.identity) appended.identity = entry.identity;
   if (entry.requestId !== undefined) appended.requestId = entry.requestId;
+  if (entry.action) appended.action = entry.action;
   // A line stamped earlier than the tail goes where it happened: after the
   // last line that happened no later than it.
   let at = entries.length;
@@ -522,6 +549,9 @@ export function storedConversationEntry(
   ) {
     return undefined;
   }
+  const action =
+    value.action === undefined ? undefined : storedConversationEntryAction(value.action, strict);
+  if (value.action !== undefined && action === undefined) return undefined;
   return {
     kind: value.kind,
     words: value.words,
@@ -531,6 +561,30 @@ export function storedConversationEntry(
       : undefined),
     ...(isWireString(value.requestId) ? { requestId: value.requestId } : undefined),
     ...(isWireString(value.eventId) ? { eventId: value.eventId } : undefined),
+    ...(action ? { action } : undefined),
+  };
+}
+
+/**
+ * The action field as one line carries it, held to the same strictness as
+ * the line's other optional fields: a kind this build does not know refuses
+ * the line either way, and only the strict read refuses a provider left blank.
+ */
+function storedConversationEntryAction(
+  value: UnparsedWireValue,
+  strict: boolean,
+): ConversationEntryAction | undefined {
+  if (!isRecord(value) || !isConversationEntryActionKind(value.kind)) return undefined;
+  const providerId = value.providerId;
+  if (
+    providerId !== undefined &&
+    !(isWireString(providerId) && (!strict || providerId.length > 0))
+  ) {
+    return undefined;
+  }
+  return {
+    kind: value.kind,
+    ...(isWireString(providerId) ? { providerId } : undefined),
   };
 }
 


### PR DESCRIPTION
## What

The Conversation tab drew an action Luke carried as one centered 10.5px lowercase line with no mark and no relation to the thread around it, and drew an action he took on his own judgment as a grey reply bubble. This PR replaces both with one row anatomy:

- **Action rows.** Each carried action is a left-aligned 11.5px row, flush with Luke's bubbles, led by a 12px mark for the kind of thing it was (message, control, open, plus for a created workspace or added agent, pencil for a rename) and ended on the mark of the provider it reached. The words are the same narration the record already holds, read as a sentence. No check marks: the row settles by staying exactly as it was.
- **Own judgment.** An action from a turn nobody opened leads with Luke's face instead of the kind mark, with the hidden label "Luke, on his own judgment", so it never wears a reply's bubble and is never read as the developer's request.

Folding a turn's actions is the next PR in the stack.

## How

- `ConversationEntry` gains an optional `action: { kind, providerId? }`: the kind of thing done, and, for a workspace creation only (the one action with no identity to read a provider from), the provider it asked. It travels on the wire, round-trips through the stored payload under the same strictness as the other optional fields, and is never rendered into model context.
- `sessionActionConversationEntry` mints the field; three glyphs join `@sidecar/panel` (message, control, plus); open and rename reuse existing ones.
- Lines an earlier build recorded without a kind draw with the mark's room left empty.

## Scope

Desktop only. The iPhone and Watch threads have no action record to draw from yet (their voice call runs the older shape, and the hosted conversation sync is pending), and Swift can't be built from this sandbox; they are a follow-up once actions reach their thread.

## Verification

- Typecheck clean across the workspace; session 89, actions 60, host 285, and desktop renderer 280 tests pass, including tests for the row anatomy, the own-judgment signature, the provider mark, and the empty mark on an older line.
- The panel was server-rendered against the real stylesheets and screenshotted headless (Chromium). `./scripts/verify.sh` and a physical-notch check were **not** run: this sandbox has no macOS. Please run `./scripts/verify.sh` locally before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34421502036/artifacts/10131137389) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34421502036)

- Commit: `bed63cbaf126613d174ae5bc600e9cc6177371bc`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
