### PR TITLE
feat(desktop): caption every segment under the housing

### DIFF
--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -10,7 +10,7 @@ import { feedbackKindForLifecycleEvent } from "@sidecar/feedback";
 import { WingFace as LukeFace } from "@sidecar/panel";
 import { REALTIME_STATUS } from "@sidecar/realtime";
 import type { ObservedWorkspaceProject } from "@sidecar/session";
-import { FIXTURE_EPOCH_MS, FIXTURE_SPEAKING_CAPTION } from "@sidecar/session/fixtures";
+import { FIXTURE_EPOCH_MS, FIXTURE_SPEAKING_CAPTIONS } from "@sidecar/session/fixtures";
 import { APP_SETTING_SCHEMA, VOICE_HOTKEY_NONE, voiceHotkeyLabel } from "@sidecar/settings";
 import type { AppSettingsView, ObservedAccountCalendars } from "@sidecar/settings/wire";
 import { appSettingsView } from "@sidecar/settings/wire";
@@ -583,7 +583,7 @@ export function App(): React.JSX.Element {
   }, [brainRequests, cancelBrainAsk]);
   // A capture run always draws the fixture's words: the voice window that
   // otherwise decides the captions does not stand in one.
-  const lukeCaptions = fixtureSpeaking ? [FIXTURE_SPEAKING_CAPTION] : voiceView.lukeCaptions;
+  const lukeCaptions = fixtureSpeaking ? FIXTURE_SPEAKING_CAPTIONS : voiceView.lukeCaptions;
 
   // The hint rides the caption it explains, and only over a silence the
   // helper actually reported. "Got it" quiets it for this stretch of silence
@@ -1221,12 +1221,16 @@ export function App(): React.JSX.Element {
           jumping between two copies. Not in a wing — the wings clip at the
           capsule's height — and always mounted, like the count's caption, so
           both edges of its fade can run. The inner stack is what is measured —
-          two responses spoken back-to-back are two blocks in it, the settled
-          words above the ones still arriving — and its wrapped height is the
-          only honest answer to how much room the words need. The newest block
-          is always mounted like the stack itself; the settled one mounts only
-          while it has words, so a lone reply pays no gap for a block that is
-          not there. Hidden from readers while it captions speech — it
+          responses spoken back-to-back are one block each in it, oldest
+          first, the settled words above the ones still arriving — and its
+          wrapped height is the only honest answer to how much room the words
+          need; past the room the window reserved it rolls up rather than
+          growing, as `caption-layout.ts` says. The newest block is always
+          mounted like the stack itself; a settled one mounts only while it
+          has words, so a lone reply pays no gap for a block that is not
+          there, and the blocks keep their order as keys so a segment that
+          settles stays the element it streamed into. Hidden from readers
+          while it captions speech — it
           duplicates what is already audible — and announced as a status line
           when it carries a failure or a notice, which was never audible at
           all. */}
@@ -1237,10 +1241,15 @@ export function App(): React.JSX.Element {
         {...(caption.tone !== CAPTION_TONE.WORDS ? { role: "status" } : { "aria-hidden": true })}
       >
         <span className="voice-caption-stack" ref={caption.textRef}>
-          {caption.settled === undefined ? null : (
-            <MarkdownMessage className="voice-caption-text" words={caption.settled} />
-          )}
-          <MarkdownMessage className="voice-caption-text" words={caption.live ?? ""} />
+          {caption.settled.map((words, index) => (
+            // biome-ignore lint/suspicious/noArrayIndexKey: a segment's place in the reply is its identity — the strip never reorders or removes one while the reply stands — and the live slot below takes the next place, so the block a segment streamed into is the block it settles in.
+            <MarkdownMessage key={index} className="voice-caption-text" words={words} />
+          ))}
+          <MarkdownMessage
+            key={caption.settled.length}
+            className="voice-caption-text"
+            words={caption.live ?? ""}
+          />
         </span>
       </span>
 

--- a/apps/desktop/src/renderer/caption-layout.test.ts
+++ b/apps/desktop/src/renderer/caption-layout.test.ts
@@ -1,0 +1,58 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { VOICE_CAPTION_MAX_HEIGHT } from "@sidecar/surface";
+import { captionBlockSize, captionSegments, captionStackOverflow } from "./caption-layout";
+import { VOLUME_HINT_BAND_HEIGHT } from "./volume-hint";
+
+const PADDING = 12;
+
+test("the block grows to the words until it meets the room the window reserved", () => {
+  assert.equal(captionBlockSize(40, false, PADDING), 40 + PADDING);
+  assert.equal(
+    captionBlockSize(VOICE_CAPTION_MAX_HEIGHT, false, PADDING),
+    VOICE_CAPTION_MAX_HEIGHT,
+  );
+  assert.equal(captionBlockSize(1000, false, PADDING), VOICE_CAPTION_MAX_HEIGHT);
+});
+
+test("the volume hint's band comes off the block's maximum, never off the words", () => {
+  const room = VOICE_CAPTION_MAX_HEIGHT - VOLUME_HINT_BAND_HEIGHT;
+  assert.equal(captionBlockSize(40, true, PADDING), 40 + PADDING);
+  assert.equal(captionBlockSize(1000, true, PADDING), room);
+});
+
+test("a stack that fits rolls nowhere", () => {
+  assert.equal(captionStackOverflow(40, false, PADDING), 0);
+  // Exactly filling the room is still fitting: the bound is inclusive.
+  assert.equal(captionStackOverflow(VOICE_CAPTION_MAX_HEIGHT - PADDING, false, PADDING), 0);
+});
+
+test("a stack past the room rolls up by exactly what will not fit", () => {
+  // The padding above the words is spent before any line is, so the overflow
+  // is the words' excess alone: the newest line ends at the block's foot.
+  const words = VOICE_CAPTION_MAX_HEIGHT - PADDING + 28;
+  assert.equal(captionStackOverflow(words, false, PADDING), 28);
+  // Every line arriving past the bound rolls the stack one line further; the
+  // block itself has stopped growing.
+  assert.equal(captionStackOverflow(words + 14, false, PADDING), 42);
+  assert.equal(captionBlockSize(words + 14, false, PADDING), VOICE_CAPTION_MAX_HEIGHT);
+});
+
+test("the hint's band brings the roll forward by its own height", () => {
+  const words = VOICE_CAPTION_MAX_HEIGHT - PADDING + 28;
+  assert.equal(captionStackOverflow(words, true, PADDING), 28 + VOLUME_HINT_BAND_HEIGHT);
+});
+
+test("the newest segment is the live one whatever the count", () => {
+  assert.deepEqual(captionSegments(undefined), { settled: [], live: undefined });
+  assert.deepEqual(captionSegments([]), { settled: [], live: undefined });
+  assert.deepEqual(captionSegments(["Only one."]), { settled: [], live: "Only one." });
+  assert.deepEqual(captionSegments(["First.", "Second."]), {
+    settled: ["First."],
+    live: "Second.",
+  });
+  assert.deepEqual(captionSegments(["First.", "Second.", "Third.", "Fourth."]), {
+    settled: ["First.", "Second.", "Third."],
+    live: "Fourth.",
+  });
+});

--- a/apps/desktop/src/renderer/caption-layout.ts
+++ b/apps/desktop/src/renderer/caption-layout.ts
@@ -1,0 +1,66 @@
+import { VOICE_CAPTION_MAX_HEIGHT } from "@sidecar/surface";
+import { VOLUME_HINT_BAND_HEIGHT } from "./volume-hint";
+
+/**
+ * The geometry behind the caption block under the housing, kept pure so the
+ * bound it keeps can be tested without a browser.
+ *
+ * The block stacks every segment the voice reported — one per output item,
+ * oldest first, the newest still arriving — and is bounded by the room the
+ * window reserved under the housing, never by a count of segments. The
+ * window cannot resize for speech, so that room is physical, and once the
+ * stack outgrows it the block stops growing and the stack rolls up instead:
+ * the oldest lines travel up under the housing and out of the block's clip
+ * while the words still being spoken stay at its foot, where the eye already
+ * is. Rolling, rather than dropping whole segments, keeps a reply's shape
+ * continuous — a segment leaves a line at a time, the way it arrived — and
+ * rather than a scrollbar, because the strip is captioning speech nobody can
+ * scroll back through anyway.
+ */
+
+/**
+ * The caption block's visible height — the `--caption-size` the clip ends the
+ * element at. The strip's hover test reads it too: the element's own box runs
+ * to the reserved maximum, and only this much of it is words rather than
+ * desktop. The volume hint stands in a band of its own below the block, so
+ * while it is drawn the band comes off the block's maximum: the block and the
+ * band partition the reserved room instead of sharing it, and the stack never
+ * asks for more height than the window holds.
+ */
+export function captionBlockSize(textHeight: number, volumeHint: boolean, padding: number): number {
+  const hintBand = volumeHint ? VOLUME_HINT_BAND_HEIGHT : 0;
+  return Math.min(VOICE_CAPTION_MAX_HEIGHT - hintBand, textHeight + padding);
+}
+
+/**
+ * How far the stack rolls up to keep its newest lines inside the block: the
+ * height the wrapped words need past what the block can show, and zero while
+ * they fit. The block's own padding is above the words, so it is spent before
+ * any line is.
+ */
+export function captionStackOverflow(
+  textHeight: number,
+  volumeHint: boolean,
+  padding: number,
+): number {
+  return Math.max(0, textHeight + padding - captionBlockSize(textHeight, volumeHint, padding));
+}
+
+/** The stack's segments as the surface draws them. */
+export interface CaptionSegments {
+  /** Every settled segment, oldest first; each mounts only while it has words. */
+  settled: readonly string[];
+  /** The words still arriving, in the always-mounted slot a lone caption also uses. */
+  live: string | undefined;
+}
+
+/**
+ * Splits what the strip is showing into the blocks the stack draws. The
+ * newest segment is the live one whatever the count, and everything before it
+ * is settled, so one reply and a reply of several messages are the same
+ * shape at different lengths.
+ */
+export function captionSegments(texts: readonly string[] | undefined): CaptionSegments {
+  if (texts === undefined || texts.length === 0) return { settled: [], live: undefined };
+  return { settled: texts.slice(0, -1), live: texts.at(-1) };
+}

--- a/apps/desktop/src/renderer/strip-hold.test.ts
+++ b/apps/desktop/src/renderer/strip-hold.test.ts
@@ -43,6 +43,29 @@ test("an unchanged sentence keeps the hold's identity", () => {
   assert.equal(stripHoldNext({ hovered: true, drawn: rebuilt, held: WORDS }), WORDS);
 });
 
+test("a hold keeps every stacked segment, and a new segment arriving refreshes it whole", () => {
+  const three: SpokenStripContent = {
+    texts: ["Looking now.", "Two agents are waiting.", "Nothing else has moved."],
+    tone: CAPTION_TONE.WORDS,
+  };
+  // The snapshot is the whole stack, however many segments it holds...
+  assert.equal(stripHoldNext({ hovered: true, drawn: three, held: undefined }), three);
+  assert.equal(stripHoldNext({ hovered: true, drawn: undefined, held: three }), three);
+  // ...and the same three rebuilt keep the hold's identity, while a fourth
+  // segment arriving under the pointer is new content and replaces it.
+  const rebuilt: SpokenStripContent = { ...three, texts: [...three.texts] };
+  assert.equal(stripHoldNext({ hovered: true, drawn: rebuilt, held: three }), three);
+  const four: SpokenStripContent = { ...three, texts: [...three.texts, "Say the word."] };
+  assert.equal(stripHoldNext({ hovered: true, drawn: four, held: three }), four);
+  // A settled segment's transcript landing late changes one line of the
+  // stack, and that too is new content rather than the held frame.
+  const corrected: SpokenStripContent = {
+    ...three,
+    texts: ["Looking now, corrected.", ...three.texts.slice(1)],
+  };
+  assert.equal(stripHoldNext({ hovered: true, drawn: corrected, held: three }), corrected);
+});
+
 test("a tone change is a content change", () => {
   // The same words in a different tone are drawn differently, so a held
   // snapshot must not keep its identity across one.

--- a/apps/desktop/src/renderer/styles/base.css
+++ b/apps/desktop/src/renderer/styles/base.css
@@ -1323,8 +1323,11 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
    under it is what answers, so hovering the words holds the peek like
    hovering the shape does. */
 .voice-caption {
-  /* Named so the widen keyframe can hold it while animating the sides: an
-     animation owns the whole clip-path while it runs. */
+  /* Named so the widen keyframe can hold them while animating the sides: an
+     animation owns the whole clip-path while it runs. The top clip is the
+     block's own inset, so a stack rolled up past the words' edge is cut where
+     the inset begins rather than drawn in it. */
+  --voice-band-clip-top: var(--voice-band-inset);
   --voice-band-clip-bottom: calc(var(--caption-max) - var(--caption-size, 20px));
   position: absolute;
   z-index: 3;
@@ -1338,7 +1341,7 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
      the gap on that side, so the words are the same distance from the thing
      above them as from the thing below however the stack is composed. */
   padding: var(--voice-band-inset) 0 0;
-  clip-path: inset(0 0 var(--voice-band-clip-bottom));
+  clip-path: inset(var(--voice-band-clip-top) 0 var(--voice-band-clip-bottom));
   opacity: 0;
   pointer-events: none;
   transform: translate(-50%, calc(var(--caption-rest, 0px) + var(--voice-band-origin)));
@@ -1403,16 +1406,30 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
   );
 }
 
-/* The stack holds one block per response, so two responses spoken
-   back-to-back sit apart instead of running together. Nothing here moves:
-   the whole reply stays on screen — the block grows to the words, and the
-   window reserves room past what a spoken reply wraps to — so the clip on
-   the caption above is the only reveal. */
+/* The stack holds one block per response, oldest first, so responses spoken
+   back-to-back sit apart instead of running together. While the stack fits
+   the room the window reserved, nothing here moves: the block grows to the
+   words and the clip on the caption above is the only reveal. Past that room
+   the block stops growing and the stack rolls up by `--caption-overflow`,
+   the renderer's measure of what will not fit, so the newest words stay at
+   the block's foot and the oldest lines travel up under the housing and out
+   through the clip's top edge — a transform on the spring, like every
+   travel on the surface, never a scroll. The roll waits out
+   `--duration-exit` in the compact states like the caption's own transform,
+   so a stack leaving a state rolls with the shape rather than ahead of it;
+   the captioned rules below drop the delay while the words are up, the way
+   they do for the clip. */
 .voice-caption-stack {
   display: flex;
   flex-direction: column;
   gap: 14px;
   width: 100%;
+  transform: translateY(calc(-1 * var(--caption-overflow, 0px)));
+  transition: transform var(--duration-shape) var(--spring) var(--duration-exit);
+}
+
+.app-stage[data-caption="true"] .voice-caption-stack {
+  transition: transform var(--duration-shape) var(--spring);
 }
 
 .voice-caption-text {
@@ -1566,18 +1583,20 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
    animation fires only at the flip and never mid-panel, where the surface is
    already wide and the caption's arriving content needs its clip transition
    live rather than owned by a finished animation. One keyframe serves both
-   because each element's `--voice-band-clip-bottom` — 0 for the hint's bare
-   row — rides through both frames unchanged, so the animation ends exactly
-   on the clip the element's own rule draws. Leaving the panel needs no twin:
-   the compact width snaps back on the flip, already inside every edge the
-   collapse will pass. */
+   because each element's `--voice-band-clip-top` and `--voice-band-clip-bottom`
+   — 0 for the hint's bare row — ride through both frames unchanged, so the
+   animation ends exactly on the clip the element's own rule draws. Leaving
+   the panel needs no twin: the compact width snaps back on the flip, already
+   inside every edge the collapse will pass. */
 @keyframes voice-band-widen {
   from {
-    clip-path: inset(0 var(--voice-band-widen) var(--voice-band-clip-bottom, 0px));
+    clip-path: inset(
+      var(--voice-band-clip-top, 0px) var(--voice-band-widen) var(--voice-band-clip-bottom, 0px)
+    );
   }
 
   to {
-    clip-path: inset(0 0 var(--voice-band-clip-bottom, 0px));
+    clip-path: inset(var(--voice-band-clip-top, 0px) 0 var(--voice-band-clip-bottom, 0px));
   }
 }
 

--- a/apps/desktop/src/renderer/use-caption-presentation.ts
+++ b/apps/desktop/src/renderer/use-caption-presentation.ts
@@ -1,4 +1,3 @@
-import { VOICE_CAPTION_MAX_HEIGHT } from "@sidecar/surface";
 import { cssCustomProperties, SURFACE_PROPERTY } from "@sidecar/surface/react-css";
 import {
   type CSSProperties,
@@ -8,6 +7,7 @@ import {
   useRef,
   useState,
 } from "react";
+import { captionBlockSize, captionSegments, captionStackOverflow } from "./caption-layout";
 import { parsePixels } from "./session-motion";
 import {
   CAPTION_TONE,
@@ -18,34 +18,19 @@ import {
 } from "./strip-hold";
 import { useMeasuredHeight } from "./use-measured-height";
 import { voiceErrorToShow, voiceNoticeToShow } from "./use-voice-view";
-import { VOLUME_HINT_BAND_HEIGHT } from "./volume-hint";
 import type { WaveformVoice } from "./waveform";
-
-/**
- * The caption block's visible height — the `--caption-size` the clip ends the
- * element at. The strip's hover test reads it too: the element's own box runs
- * to the reserved maximum, and only this much of it is words rather than
- * desktop.
- */
-function captionBlockSize(textHeight: number, volumeHint: boolean, padding: number): number {
-  const hintBand = volumeHint ? VOLUME_HINT_BAND_HEIGHT : 0;
-  return Math.min(VOICE_CAPTION_MAX_HEIGHT - hintBand, textHeight + padding);
-}
 
 /**
  * Sizes the caption block to the words it currently holds. The text wraps, so
  * only a measurement can say how tall it is; the size drives the surface's
- * growth and the clip that reveals the text. The whole reply stays on screen —
- * the reserved maximum is sized past what a spoken reply wraps to, so the
- * clamp below is the window's physical bound rather than a working edge.
- * The volume hint stands in a band of its own below the block: while it is
- * drawn, the band comes off the block's maximum, so the block and the band
- * partition the reserved room instead of sharing it, and the stack never asks
- * for more height than the window holds.
- * Padding is the caption's own computed padding, not a restated number, so a
- * retune in the stylesheet grows the surface by exactly what the text is
- * inset — the one inset above the words, with whatever stands below the block
- * carrying the gap on that side.
+ * growth and the clip that reveals the text. The block grows to the stack
+ * until it meets the room the window reserved, and past that the stack rolls
+ * up by the overflow instead, so the newest words stay inside the clip while
+ * the oldest lines leave under the housing — `caption-layout.ts` says why the
+ * bound is spent that way. Padding is the caption's own computed padding, not
+ * a restated number, so a retune in the stylesheet grows the surface by
+ * exactly what the text is inset — the one inset above the words, with
+ * whatever stands below the block carrying the gap on that side.
  */
 function captionSizeStyle(
   textHeight: number | undefined,
@@ -55,6 +40,7 @@ function captionSizeStyle(
   if (!textHeight) return {};
   return cssCustomProperties({
     [SURFACE_PROPERTY.CAPTION_SIZE]: `${captionBlockSize(textHeight, volumeHint, padding)}px`,
+    [SURFACE_PROPERTY.CAPTION_OVERFLOW]: `${captionStackOverflow(textHeight, volumeHint, padding)}px`,
   });
 }
 
@@ -79,11 +65,11 @@ export interface CaptionPresentation {
   /** Everything the strip is showing, live words or a held snapshot. */
   texts: readonly string[] | undefined;
   tone: CaptionTone;
-  /** The reply above, drawn only when two are stacked. */
-  settled: string | undefined;
+  /** The segments already spoken, oldest first, each drawn only while it has words. */
+  settled: readonly string[];
   /** The words still arriving, in the always-mounted slot. */
   live: string | undefined;
-  /** The `--caption-size` the surface grows by. */
+  /** The `--caption-size` the surface grows by, and the `--caption-overflow` the stack rolls by. */
   style: CSSProperties;
 }
 
@@ -200,8 +186,9 @@ export function useCaptionPresentation(
    * The measured caption height the shape spends, held through a collapse
    * out of the panel. The compact width lands at the flip and re-wraps the
    * words while they are still riding down at the panel's foot, and a
-   * re-measure landing mid-ride would open the clip and retarget the surface
-   * past room nothing has made yet. The collapse travels on the panel's
+   * re-measure landing mid-ride would open the clip, retarget the surface
+   * past room nothing has made yet, and roll the stack against words still
+   * travelling. The collapse travels on the panel's
    * numbers; the compact re-measure lands when the shape has settled, and
    * grows it there the way words arriving at rest do.
    */
@@ -222,16 +209,17 @@ export function useCaptionPresentation(
       ? 0
       : captionBlockSize(textHeight, volumeHint, padding);
 
+  // Responses spoken back-to-back stack as captions in the order they were
+  // said: every settled one above, the one still arriving below, in the
+  // always-mounted slot the lone caption also uses.
+  const { settled, live } = captionSegments(texts);
   return {
     ref: element,
     textRef: textElement,
     texts,
     tone,
-    // Two responses spoken back-to-back stack as two captions: the settled one
-    // above, the one still arriving below, in the always-mounted slot the lone
-    // caption also uses.
-    settled: texts && texts.length > 1 ? texts.at(-2) : undefined,
-    live: texts?.at(-1),
+    settled,
+    live,
     style: captionSizeStyle(shownHeight, volumeHint, padding),
   };
 }

--- a/apps/desktop/src/renderer/voice/captions.test.ts
+++ b/apps/desktop/src/renderer/voice/captions.test.ts
@@ -82,8 +82,8 @@ test("every segment stays until the reply ends, and the whole reply is handed ov
   context.strip.mark(REPLY_KIND.BRIEFING);
   for (const index of [1, 2, 3, 4]) context.strip.append(`item-${index}`, `Sentence ${index}.`);
 
-  // How many the housing draws is the surface's own limit; the record is
-  // owed every message the reply said.
+  // No count retires a segment: how many fit under the housing is the
+  // surface's question, and the record is owed every message the reply said.
   assert.deepEqual(latest(context.drawn)?.texts, [
     "Sentence 1.",
     "Sentence 2.",

--- a/apps/desktop/src/renderer/voice/captions.ts
+++ b/apps/desktop/src/renderer/voice/captions.ts
@@ -37,9 +37,10 @@ export class CaptionStrip {
    * or the follow-up after a tool call — starts a new segment rather than
    * running its words onto the last one's, and an item's own final transcript
    * can still land on its own segment after the turn has moved on. Every
-   * segment stays until the reply ends, because the handover to Conversation
-   * is owed the whole reply; how many the housing draws is the surface's own
-   * limit, applied where the caption is drawn.
+   * segment stays until the reply ends: the handover to Conversation is owed
+   * the whole reply, and how many of them fit under the housing is the
+   * surface's question to answer from the room it has, not a count to keep
+   * here.
    */
   #segments: { itemId: string | undefined; text: string }[] = [];
   /**

--- a/apps/desktop/src/renderer/voice/conversation-call-captions.test.ts
+++ b/apps/desktop/src/renderer/voice/conversation-call-captions.test.ts
@@ -44,7 +44,7 @@ test("the caption grows with the deltas and the final text supersedes them", asy
 });
 
 // SAFETY: Fixture value matches the narrowed runtime shape this test exercises.
-test("back-to-back responses stack as two captions instead of running together", async () => {
+test("back-to-back responses stack as captions instead of running together", async () => {
   const context = harness();
   await context.session.connect();
   await holdTurn(context);
@@ -94,7 +94,8 @@ test("back-to-back responses stack as two captions instead of running together",
   ]);
 
   // A third response is kept with the rest: the call reports the whole reply,
-  // and how many of its segments the housing draws is the surface's own limit.
+  // and how many of its segments fit under the housing is the surface's own
+  // question, answered from the room it has rather than a count.
   context.emit({
     type: REALTIME_SERVER_EVENT.RESPONSE_OUTPUT_ITEM_ADDED,
     item: { id: "item-three" },

--- a/design/generate-surface-shared.mjs
+++ b/design/generate-surface-shared.mjs
@@ -65,12 +65,12 @@ const ROW_FAN_LIMIT = 5;
 // stays at the edge.
 const SURFACE_GEOMETRY_PX = {
   BUBBLE_LIFT: 4,
-  // The caption block shows a spoken reply whole — the block grows to the
-  // words and nothing scrolls — so the reservation must sit past what a
-  // reply wraps to at the peek's width: fourteen 14px lines plus the block's
-  // own padding, room enough for two long responses stacked. The window
-  // cannot resize for speech, so this bound is physical: a reply taller
-  // still clips at the block's edge rather than growing the window.
+  // The caption block grows to the words and nothing scrolls, so the
+  // reservation sits past what a reply wraps to at the peek's width: fourteen
+  // 14px lines plus the block's own padding, room enough for two long
+  // responses stacked. The window cannot resize for speech, so this bound is
+  // physical: a stack taller still rolls up inside the block, its oldest
+  // lines leaving under the housing, rather than growing the window.
   VOICE_CAPTION_MAX_HEIGHT: 210,
   // The one gap between anything the surface grows below the strip. The
   // words and the volume hint stack under the housing in the compact states
@@ -433,7 +433,8 @@ ${tsRecord(Object.entries(MOTION_DELAY_MS).map(([key, value]) => [key, value]))}
 export const BUBBLE_LIFT = ${SURFACE_GEOMETRY_PX.BUBBLE_LIFT};
 
 /** Tallest caption block the window holds — sized past a whole spoken reply,
- * because the block grows to the words and nothing scrolls. CSS: \`--caption-max\`. */
+ * because the block grows to the words and nothing scrolls; a taller stack
+ * rolls up inside it. CSS: \`--caption-max\`. */
 export const VOICE_CAPTION_MAX_HEIGHT = ${SURFACE_GEOMETRY_PX.VOICE_CAPTION_MAX_HEIGHT};
 
 /** The one gap between the strip, each band grown below it, and the shape's

--- a/packages/session/src/fixtures.ts
+++ b/packages/session/src/fixtures.ts
@@ -83,12 +83,17 @@ export interface FixtureSnapshot {
  * What the speaking evidence run captions the reply with. A capture run never
  * opens a call, so there are no words to draw unless the fixture supplies
  * them — and it must, or the caption strip ships unphotographed. Synthetic,
- * like every fixture, and long enough to wrap: a one-line fixture would leave
- * the wrapped form of the strip unphotographed too. It lives here, beside the
- * roster it talks about, so the sentence stays true to the rows it names.
+ * like every fixture, and shaped like a reply of several messages: the first
+ * long enough to wrap, and two more behind it, so the wrapped form of the
+ * strip and the stack of segments it draws are both in the frame. It lives
+ * here, beside the roster it talks about, so the sentences stay true to the
+ * rows they name.
  */
-export const FIXTURE_SPEAKING_CAPTION =
-  "Bootstrap the desktop shell and Review trust constraints are finished, lisbon-v2 is packaging the macOS build, and Follow a cloud agent and Watch a cloud session are waiting on you.";
+export const FIXTURE_SPEAKING_CAPTIONS: readonly string[] = [
+  "Bootstrap the desktop shell and Review trust constraints are finished, lisbon-v2 is packaging the macOS build, and Follow a cloud agent and Watch a cloud session are waiting on you.",
+  "Nothing else has moved since you last looked.",
+  "Say the word and I'll open either of the two that are waiting.",
+];
 
 /**
  * A fixed instant the fixture's observation times are measured back from. A

--- a/packages/surface/src/generated/motion-tokens.ts
+++ b/packages/surface/src/generated/motion-tokens.ts
@@ -25,7 +25,8 @@ export const MOTION_DELAY_MS = {
 export const BUBBLE_LIFT = 4;
 
 /** Tallest caption block the window holds — sized past a whole spoken reply,
- * because the block grows to the words and nothing scrolls. CSS: `--caption-max`. */
+ * because the block grows to the words and nothing scrolls; a taller stack
+ * rolls up inside it. CSS: `--caption-max`. */
 export const VOICE_CAPTION_MAX_HEIGHT = 210;
 
 /** The one gap between the strip, each band grown below it, and the shape's

--- a/packages/surface/src/react-css.ts
+++ b/packages/surface/src/react-css.ts
@@ -20,6 +20,7 @@ export const SURFACE_PROPERTY = {
   SLOT_HEIGHT: "--slot-height",
   FEEDBACK_HEIGHT: "--feedback-height",
   CAPTION_SIZE: "--caption-size",
+  CAPTION_OVERFLOW: "--caption-overflow",
 } as const;
 
 export type SurfaceProperty = (typeof SURFACE_PROPERTY)[keyof typeof SURFACE_PROPERTY];

--- a/packages/voice/src/orchestrator/index.ts
+++ b/packages/voice/src/orchestrator/index.ts
@@ -23,6 +23,6 @@ export {
   type VoiceState,
   type VoiceSurroundings,
 } from "./voice-orchestrator.js";
-export { activeVoiceStream, CAPTION_SEGMENT_LIMIT } from "./voice-policy.js";
+export { activeVoiceStream } from "./voice-policy.js";
 export { VOICE_READINESS_PART, type VoiceReadinessPart } from "./voice-readiness.js";
 export type { VoiceExchangeOpening, VoiceViewReport } from "./voice-view-reporter.js";

--- a/packages/voice/src/orchestrator/voice-policy.test.ts
+++ b/packages/voice/src/orchestrator/voice-policy.test.ts
@@ -133,8 +133,8 @@ test("Luke's captions are offered only on his turn, and only with a reason to re
       ...shown,
       captions: ["Sentence 1.", "Sentence 2.", "Sentence 3.", "Sentence 4."],
     }),
-    ["Sentence 3.", "Sentence 4."],
-    "the housing draws only the newest segments; the reply itself keeps them all",
+    ["Sentence 1.", "Sentence 2.", "Sentence 3.", "Sentence 4."],
+    "the gate decides whether captions draw, never how many: the surface bounds them by room",
   );
   assert.equal(lukeCaptionsToShow({ ...shown, captions: [] })?.length, 0);
   assert.equal(

--- a/packages/voice/src/orchestrator/voice-policy.ts
+++ b/packages/voice/src/orchestrator/voice-policy.ts
@@ -72,20 +72,10 @@ export function lukeCaptionsToShow(input: {
     (input.captionsEnabled || input.outputSilent) &&
     input.status === REALTIME_STATUS.RESPONDING
   ) {
-    return input.captions?.slice(-CAPTION_SEGMENT_LIMIT);
+    return input.captions;
   }
   return undefined;
 }
-
-/**
- * How many back-to-back responses the housing's caption keeps on screen at
- * once. Two is the shape the surface stacks — the words just settled and the
- * words now arriving — and a third response starting simply retires the
- * oldest from view, the way a long reply's oldest lines already roll up under
- * the shape. A limit on the drawing alone: the call keeps every segment of
- * the reply, so what Conversation records and streams is the whole of it.
- */
-export const CAPTION_SEGMENT_LIMIT = 2;
 
 /**
  * Whether a talk-key press has a call to open before the session is asked. A


### PR DESCRIPTION
## What this changes

While Luke speaks, the capsule under the housing captions his words. The realtime voice emits one transcript segment per output item, so a reply of several messages is several segments, and the capsule drew exactly two of them: the tracker in `voice/captions.ts` cut its list to the newest two (`CAPTION_SEGMENT_LIMIT`, from #237), and `use-caption-presentation.ts` read `texts.at(-2)` as settled and `texts.at(-1)` as live.

- **Every segment is kept and drawn.** `CaptionStrip` keeps every segment until the reply ends, so Conversation is handed the whole reply, and the stack under the housing draws them all, oldest first, the newest still arriving in the always-mounted slot. `CAPTION_SEGMENT_LIMIT` is removed rather than raised; no count constant remains.
- **The bound is vertical room, not a count.** The block grows to the stack until it meets the room the window reserved under the housing (`VOICE_CAPTION_MAX_HEIGHT`, less the volume hint's band while it is drawn). Past that, the block stops growing and the stack rolls up by exactly what will not fit: a `translateY` on the spring, driven by a new `--caption-overflow` property the renderer measures, so the oldest lines travel up under the housing and out through the clip's top edge while the words being spoken stay at the block's foot. The clip gains a top inset equal to the block's own padding so a rolled line is cut where the inset begins rather than drawn in it. Nothing grows without limit and there is no scrollbar. The reason for rolling rather than dropping segments or scrolling is written in `apps/desktop/src/renderer/caption-layout.ts`, where the geometry lives.
- **Generalized to N.** `captionSegments` splits the list into settled segments and the live one; `app.tsx` maps the settled ones with their place in the reply as key and gives the live slot the next place, so the block a segment streamed into is the block it settles in. `stripHoldNext` already snapshotted the whole list, so the pointer hold holds N segments unchanged; the tests now say so.
- **Fixture.** The speaking fixture becomes a reply of three segments (`FIXTURE_SPEAKING_CAPTIONS`) so the speaking and muted evidence frames photograph the stack.
- **Unchanged.** The caption's gate, `lukeCaptionsToShow` in `packages/voice/src/orchestrator/voice-policy.ts`, decides whether captions draw at all (preference on, or output muted, per #869) and is not touched.

One correction to the premise: the old limit's comment said a third response retired the oldest "the way a long reply's oldest lines already roll up", but nothing rolled before this change. A stack taller than the reserved room was clipped at the block's bottom edge, losing the newest lines. The roll here is new, and it is what makes the count bound unnecessary.

## Tests

- New `caption-layout.test.ts`: the block grows to the words until it meets the reserved room, the hint's band comes off the room, a stack that fits rolls nowhere, a stack past the room rolls by exactly its excess, and the newest segment is the live one for zero, one, two, and four segments.
- `strip-hold.test.ts`: a hold keeps three stacked segments whole and keeps its identity across an equal rebuild; a fourth segment or a late-settled first segment is new content.
- `captions.test.ts`: every segment stays up until the reply ends and is handed over whole.
- `conversation-call-captions.test.ts`: a third response stacks under the two before it.

`./scripts/check.sh` passes locally on Linux.

## Verification

`./scripts/verify.sh` needs macOS and this workspace is Linux, so the completion invariant rests on the "macOS app and evidence" CI job. I downloaded its evidence artifact (`app-visual-evidence-883`) and inspected the frames:

- **speaking**: the peek holds three caption blocks under the housing, oldest first: the long wrapped sentence on three lines, then "Nothing else has moved since you last looked.", then "Say the word and I'll open either of the two that are waiting." Each block is separated by the stack's gap, the surface's bottom edge closes one inset below the last block, and no words cross the shape's edge.
- **muted**: the same three blocks, with the orange "Unmute your Mac to hear Luke" hint and its Got it pill in their own band directly below the block, and the shape closed below the band. The captions are drawn with the preference off, as the mute gate requires.
- **compact, peek, expanded, slot**: unchanged from main.

The roll itself (a stack taller than the reserved room) is not in a fixture frame, since the fixture fits the room; it is covered by `caption-layout.test.ts`, and the motion it uses is the same `transform` on `--spring` the caption already travels on. **A physical-notch check was not performed and is left to Dean.**

## Overlap

#891 landed first from the related branch: it made `CaptionStrip` keep every segment for the Conversation record and moved the two-item cap into `lukeCaptionsToShow` as a `slice(-CAPTION_SEGMENT_LIMIT)`. This PR is rebased over it and resolves the overlap the way both intended: the tracker keeps every segment, the gate decides only whether captions draw, and `CAPTION_SEGMENT_LIMIT` is removed from `voice-policy.ts` and the orchestrator barrel, so no count constant remains anywhere. The surface bounds the caption by room, not by count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34420108202/artifacts/10130618774) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34420108202)

- Commit: `cf8e82f514fd4dc4c4747326690fede21c25f7b2`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
