### PR TITLE
refactor(runtime): one Clock seam, one FakeClock

### DIFF
--- a/packages/AGENTS.md
+++ b/packages/AGENTS.md
@@ -116,7 +116,7 @@ session type. `@sidecar/runtime/testing` is the scaffolding every test in this
 repository shares — a self-cleaning temporary directory, a stated microtask
 drain, and a clock the test drives — behind its own door because it reaches
 `node:fs` and `node:os`, and in this package because the clock stands in for
-the runtime's own `ScheduledTimer`.
+the runtime's own `Clock`.
 
 `@sidecar/brain` is the reason the rule exists twice in one package: the barrel
 is a door the web functions and the renderer open, and the store beneath it

--- a/packages/brain/src/acceptance.test.ts
+++ b/packages/brain/src/acceptance.test.ts
@@ -25,7 +25,7 @@ import {
   seedWorkspace,
   TOOL_LOOP_RUNTIME,
 } from "@sidecar/runtime";
-import type { ScheduledTimer } from "@sidecar/runtime/vocabulary";
+import { FakeClock } from "@sidecar/runtime/testing";
 import {
   type AgentRuntime,
   type CheckpointFormat,
@@ -124,19 +124,6 @@ function actionCall(callId: string): WireRecord {
 
 function payload(output: readonly WireRecord[]): Response {
   return Response.json({ id: "resp", status: "completed", output, usage: { input_tokens: 9 } });
-}
-
-class FakeClock {
-  now = NOW;
-  readonly timers = new Map<ScheduledTimer, { callback: () => void; at: number }>();
-  schedule = (callback: () => void, delayMs: number): ScheduledTimer => {
-    const handle: ScheduledTimer = {};
-    this.timers.set(handle, { callback, at: this.now + delayMs });
-    return handle;
-  };
-  cancel = (timer: ScheduledTimer): void => {
-    this.timers.delete(timer);
-  };
 }
 
 interface UpstreamCall {
@@ -267,7 +254,7 @@ function host(
   const store = new BrainStateStore({
     repository,
     createGenerationId: () => `gen-${++ids}`,
-    now: () => clock.now,
+    now: () => clock.instant,
   });
   const performed: string[] = [];
   const session = normalizeSession(claude, {
@@ -298,9 +285,7 @@ function host(
     store,
     createRunId: () => `run-${++ids}`,
     report: () => undefined,
-    now: () => clock.now,
-    schedule: clock.schedule,
-    cancel: clock.cancel,
+    clock,
     ...overrides,
   });
   return {
@@ -631,7 +616,7 @@ test("a runtime that is not Responses drives the same host: actions journaled th
   await o.agent.ready();
   o.agent.wake([{ kind: BRAIN_WAKE_KIND.HOOK, identity: ABC, hookEvent: "Stop", atMs: NOW }]);
   await settle();
-  o.clock.now += 3_000;
+  o.clock.instant += 3_000;
   for (const timer of [...o.clock.timers.values()]) timer.callback();
   await settle();
   assert.deepEqual(o.performed, [REALTIME_TOOL.SEND_SESSION_MESSAGE]);
@@ -671,7 +656,7 @@ test("the Responses runtime refuses a valid checkpoint of the scripted runtime: 
   });
   responses.agent.wake([{ kind: BRAIN_WAKE_KIND.HOOK, identity: ABC, atMs: NOW }]);
   await settle();
-  responses.clock.now += 3_000;
+  responses.clock.instant += 3_000;
   for (const timer of [...responses.clock.timers.values()]) timer.callback();
   await settle();
   assert.equal(upstream.calls.length, 0);

--- a/packages/brain/src/agent-flush.test.ts
+++ b/packages/brain/src/agent-flush.test.ts
@@ -13,6 +13,7 @@ import {
   type ModelAdapter,
   type ModelRequestOptions,
   type ModelResponse,
+  systemClock,
 } from "@sidecar/runtime/vocabulary";
 import { ACTION_RESULT_STATUS, type WireRecord } from "@sidecar/wire";
 import { BrainAgent, type BrainFlushInput, type BrainFlushMarkerStore } from "./agent.js";
@@ -165,7 +166,7 @@ function agentWith(
     report: (line) => {
       reports.push(line);
     },
-    now: () => NOW,
+    clock: { ...systemClock, now: () => NOW },
     beforeCompaction: hook,
     ...(launch.marker ? { flushMarker: launch.marker } : undefined),
   });

--- a/packages/brain/src/agent.test.ts
+++ b/packages/brain/src/agent.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 import { REALTIME_TOOL, type RealtimeFunctionCall } from "@sidecar/actions";
 import { RESPONSES_INPUT_ITEM_TYPE } from "@sidecar/hosted";
 import { TOOL_LOOP_RUNTIME } from "@sidecar/runtime";
+import { drainMicrotasks } from "@sidecar/runtime/testing";
 import { checkpointFormatTag, RUN_ORIGIN } from "@sidecar/runtime/vocabulary";
 import {
   type ProviderTranscriptResult,
@@ -51,7 +52,6 @@ import {
   reasoning,
   reviewing,
   session,
-  settle,
   submit,
   TRANSCRIPT_SECRET,
 } from "./harness.js";
@@ -183,22 +183,22 @@ test("a wait that runs out answers the run still pending, and the same run finis
   const h = harness({ client: slow });
   const accepted = await submit(h, "anything?", "sub-1");
   const runId = acceptedRunId(accepted);
-  await settle();
+  await drainMicrotasks(20);
   // The transport retries the same submission: the same run, no second turn.
   assert.deepEqual(await submit(h, "anything?", "sub-1"), accepted);
   const firstWait = h.agent.waitAsk(runId, 30_000);
-  await settle();
+  await drainMicrotasks(20);
   await h.clock.advance(NOW + 30_000);
   const pending = await firstWait;
   assert.equal(pending?.status, BRAIN_REQUEST_STATUS.RUNNING);
   assert.equal(pending?.runId, runId);
   // A second wait, well past the old 45-second deadline: still the one run.
   const secondWait = h.agent.waitAsk(runId, 30_000);
-  await settle();
+  await drainMicrotasks(20);
   await h.clock.advance(NOW + 60_000);
   assert.equal((await secondWait)?.status, BRAIN_REQUEST_STATUS.RUNNING);
   release?.();
-  await settle();
+  await drainMicrotasks(20);
   const done = await h.agent.waitAsk(runId, 1);
   assert.equal(done?.status, BRAIN_REQUEST_STATUS.SUCCEEDED);
   assert.equal(done?.text, "Done at last.");
@@ -310,7 +310,7 @@ test("restored memory opens the next turn, and held briefings are re-decided fro
     answered([message("")]),
   );
   h.agent.releaseHeld([{ briefing: "Checkout wants a decision.", decidedAt: NOW - 1 }]);
-  await settle();
+  await drainMicrotasks(20);
   const input = h.client.inputs[0] ?? [];
   assert.deepEqual(input.slice(0, 2), prior);
   assert.ok(itemText(input[2]).startsWith(`${BRAIN_INPUT_MARKER.HOLD_RELEASED} `));
@@ -369,16 +369,16 @@ test("an observation turn whose model never answers ends at the execution deadli
   const h = harness({ client: hung, executionDeadlineMs: 60_000 });
   await h.agent.wake([edge(ABC)]);
   await h.clock.advance(NOW + 3_000);
-  await settle();
+  await drainMicrotasks(20);
   assert.equal(h.traces.length, 0, "the turn is still holding the model");
   await h.clock.advance(NOW + 3_000 + 60_000);
-  await settle();
+  await drainMicrotasks(20);
   assert.equal(h.traces.length, 1);
   assert.equal(h.traces[0]?.trigger, BRAIN_TURN_TRIGGER.WAKE);
   assert.equal(h.traces[0]?.error, "execution deadline passed");
   // The next turn is not stuck behind the dead one.
   h.agent.rosterLook();
-  await settle();
+  await drainMicrotasks(20);
   assert.equal(h.traces.length, 2);
   await h.agent.stop();
 });
@@ -445,7 +445,7 @@ test("a roster look under a policy denying actions runs none", async () => {
   });
   h.client.answers.push(answered(OBSERVATION_ACTIONS), answered([message("")]));
   h.agent.rosterLook();
-  await settle();
+  await drainMicrotasks(20);
   assertNoActionReached(h);
   assert.equal(h.traces[0]?.trigger, BRAIN_TURN_TRIGGER.ROSTER);
 });
@@ -454,7 +454,7 @@ test("a hold release under a policy denying actions runs none", async () => {
   const h = harness({ prepareTurn: NO_ACTS_POLICY });
   h.client.answers.push(answered(OBSERVATION_ACTIONS), answered([message("")]));
   h.agent.releaseHeld([{ briefing: INSTRUCTION_IN_DATA, decidedAt: NOW - 1 }]);
-  await settle();
+  await drainMicrotasks(20);
   assertNoActionReached(h);
   assert.equal(h.traces[0]?.trigger, BRAIN_TURN_TRIGGER.HOLD_RELEASED);
 });
@@ -480,7 +480,7 @@ test("a developer ask carries every action with a live execution, revoked once t
   assert.ok(messageAction);
   h.client.answers.push(answered([messageAction]), answered([message("Done.")]));
   const asked = ask(h, "send it");
-  await settle();
+  await drainMicrotasks(20);
   assert.equal(performedLate.length, 1);
   const [late] = performedLate;
   assert.ok(late);
@@ -520,11 +520,11 @@ test("a queued ask cancelled before its turn never starts, and its record says c
   });
   const first = acceptedRunId(await submit(h, "first?"));
   const second = acceptedRunId(await submit(h, "second?"));
-  await settle();
+  await drainMicrotasks(20);
   const cancelled = await h.agent.cancelAsk(second);
   assert.equal(cancelled?.status, BRAIN_REQUEST_STATUS.CANCELLED);
   release?.();
-  await settle();
+  await drainMicrotasks(20);
   assert.equal((await h.agent.waitAsk(first, 1))?.status, BRAIN_REQUEST_STATUS.SUCCEEDED);
   assert.equal(inner.inputs.length, 1);
   assert.equal(h.repository.state?.requests[1]?.status, BRAIN_REQUEST_STATUS.CANCELLED);
@@ -549,12 +549,12 @@ test("a cancel while the model is thinking aborts the request and settles the ru
     },
   });
   const runId = acceptedRunId(await submit(h, "slow?"));
-  await settle();
+  await drainMicrotasks(20);
   assert.equal(signals[0]?.aborted, false);
   const cancelled = await h.agent.cancelAsk(runId);
   assert.equal(signals[0]?.aborted, true);
   assert.equal(cancelled?.status, BRAIN_REQUEST_STATUS.RUNNING);
-  await settle();
+  await drainMicrotasks(20);
   assert.equal(h.agent.request(runId)?.status, BRAIN_REQUEST_STATUS.CANCELLED);
   assert.equal(h.repository.state?.requests[0]?.status, BRAIN_REQUEST_STATUS.CANCELLED);
   assert.equal(h.repository.state?.items.length, 0);
@@ -570,10 +570,10 @@ test("a cancel between two actions keeps the first's result and refuses the seco
     answered([message("Both sent.")]),
   );
   const runId = acceptedRunId(await submit(h, "send both"));
-  await settle();
+  await drainMicrotasks(20);
   assert.equal(performed.length, 1);
   held.releases[0]?.();
-  await settle();
+  await drainMicrotasks(20);
   // The first action's result is journaled and checkpointed before the second starts.
   const journaled = h.repository.state?.journal ?? [];
   assert.equal(journaled.length, 2);
@@ -581,7 +581,7 @@ test("a cancel between two actions keeps the first's result and refuses the seco
   assert.equal(journaled[1]?.outputJson, undefined);
   await h.agent.cancelAsk(runId);
   held.releases[1]?.();
-  await settle();
+  await drainMicrotasks(20);
   const record = h.agent.request(runId);
   assert.equal(record?.status, BRAIN_REQUEST_STATUS.CANCELLED);
   assert.equal(record?.performedActions, 1);
@@ -657,13 +657,13 @@ test("actions run one at a time in the order the model emitted them", async () =
     answered([message("Three sent.")]),
   );
   const asked = ask(h, "send three");
-  await settle();
+  await drainMicrotasks(20);
   assert.deepEqual(order, ["start a"]);
   held.releases[0]?.();
-  await settle();
+  await drainMicrotasks(20);
   assert.deepEqual(order, ["start a", "end a", "start b"]);
   held.releases[1]?.();
-  await settle();
+  await drainMicrotasks(20);
   held.releases[2]?.();
   const record = await asked;
   assert.deepEqual(order, ["start a", "end a", "start b", "end b", "start c", "end c"]);
@@ -675,10 +675,10 @@ test("a run past its execution deadline is timed out and its action refused", as
   const h = harness({ actions: held.actions, executionDeadlineMs: 60_000 });
   h.client.answers.push(answered([messageAction("call_1")]), answered([message("Sent.")]));
   const runId = acceptedRunId(await submit(h, "send"));
-  await settle();
+  await drainMicrotasks(20);
   await h.clock.advance(NOW + 60_000);
   held.releases[0]?.();
-  await settle();
+  await drainMicrotasks(20);
   const record = h.agent.request(runId);
   assert.equal(record?.status, BRAIN_REQUEST_STATUS.TIMED_OUT);
   assert.equal(record?.failure, BRAIN_REQUEST_FAILURE.DEADLINE);
@@ -692,14 +692,14 @@ test("the store's generation changing under a run revokes it and fences its late
   // Only the action is answered: a revoked run asks the model for no follow-up.
   h.client.answers.push(answered([messageAction("call_1")]));
   const runId = acceptedRunId(await submit(h, "send"));
-  await settle();
+  await drainMicrotasks(20);
   const execution = held.executions[0];
   assert.equal(execution?.isRevoked(), false);
   assert.equal(await h.store.clear(), true);
   assert.equal(execution?.isRevoked(), true);
   assert.equal(h.agent.requests().length, 0);
   held.releases[0]?.();
-  await settle();
+  await drainMicrotasks(20);
   // Nothing of the old generation reached the new envelope.
   const fresh = h.store.current();
   assert.equal(fresh?.requests.length, 0);
@@ -757,10 +757,10 @@ test("a reset while the model is thinking cannot roll old memory into the new ge
     });
   };
   const held = acceptedRunId(await submit(h, "and now?"));
-  await settle();
+  await drainMicrotasks(20);
   assert.equal(await h.store.clear(), true);
   release?.(answered([message(`late answer about ${OLD_SECRET}`)]));
-  await settle();
+  await drainMicrotasks(20);
   assert.equal(h.agent.request(held), undefined);
 
   // The new generation's first ask sees nothing of the old one anywhere.
@@ -785,7 +785,7 @@ test("a reset during a transcript read or an action's result cannot write into t
   });
   h.client.answers.push(answered([message("seen")]));
   const capture = h.agent.wake([edge(ABC)]);
-  await settle();
+  await drainMicrotasks(20);
   assert.ok(releaseRead);
   assert.equal(await h.store.clear(), true);
   releaseRead({
@@ -809,10 +809,10 @@ test("a reset during a transcript read or an action's result cannot write into t
   const acting = harness({ actions: held.actions });
   acting.client.answers.push(answered([messageAction("call_1", OLD_SECRET)]));
   const runId = acceptedRunId(await submit(acting, `send ${OLD_SECRET}`));
-  await settle();
+  await drainMicrotasks(20);
   assert.equal(await acting.store.clear(), true);
   held.releases[0]?.();
-  await settle();
+  await drainMicrotasks(20);
   acting.client.answers.push(answered([message("fresh")]));
   assert.equal((await ask(acting, "NEW_ASK"))?.text, "fresh");
   const surface = generationSurface(acting, acting.client);
@@ -846,10 +846,10 @@ test("a cancel, a deadline, or a stop settles a held read at once, and the next 
     ]),
   );
   const first = acceptedRunId(await submit(h, "read it"));
-  await settle();
+  await drainMicrotasks(20);
   assert.equal(reads.length, 1);
   await h.agent.cancelAsk(first);
-  await settle();
+  await drainMicrotasks(20);
   assert.equal(h.agent.request(first)?.status, BRAIN_REQUEST_STATUS.CANCELLED);
   assert.equal(h.client.inputs.length, 1);
 
@@ -859,7 +859,7 @@ test("a cancel, a deadline, or a stop settles a held read at once, and the next 
   h.client.answers.push(answered([message("proceeding")]));
   const second = acceptedRunId(await submit(h, "and this?"));
   assert.equal(deltas.length, 1);
-  await settle();
+  await drainMicrotasks(20);
   assert.equal((await h.agent.waitAsk(second, 1))?.text, "proceeding");
   assert.equal(h.client.inputs.length, 2);
   // The late read lands as a capture — an inbox entry and a capture cursor,
@@ -883,7 +883,7 @@ test("a cancel, a deadline, or a stop settles a held read at once, and the next 
 
   // A stop settles a held capture read too: nothing is captured, and the queue drains behind it.
   const held = h.agent.wake([edge(ABC)]);
-  await settle();
+  await drainMicrotasks(20);
   assert.equal(deltas.length, 2);
   await h.agent.stop();
   await held;
@@ -924,7 +924,7 @@ test("work queued behind a held act opens nothing once the generation it was que
   const h = harness({ actions: held.actions });
   h.client.answers.push(answered([messageAction("call_1")]));
   await submit(h, "send");
-  await settle();
+  await drainMicrotasks(20);
   // Every observation kind queues behind the held act: a hold release with an
   // old briefing, a roster look, a coalesced wake, and a quiet retry's wakes.
   h.agent.releaseHeld([{ briefing: "OLD_SECRET_QUEUED_BRIEFING", decidedAt: NOW }]);
@@ -934,7 +934,7 @@ test("work queued behind a held act opens nothing once the generation it was que
   assert.equal(await h.store.clear(), true);
   assert.equal(h.agent.pendingWakes(), 0);
   held.releases[0]?.();
-  await settle();
+  await drainMicrotasks(20);
   await h.clock.advance(NOW + 10_000);
   // The only inference was the held ask's own, in the old generation.
   assert.equal(h.client.inputs.length, 1);
@@ -965,7 +965,7 @@ test("a briefing is not delivered after a stop or reset that lands during the tu
   const stopping = h.agent.stop();
   releasing(true);
   await stopping;
-  await settle();
+  await drainMicrotasks(20);
   assert.deepEqual(h.deliveries, []);
 
   // A reset between two deliveries withdraws the second.
@@ -995,9 +995,7 @@ test("a generation dies exactly one lifetime after its birth, on the host's cloc
   const h = harness({ client: inner });
   const generationClock = new BrainGenerationClock({
     store: h.store,
-    now: () => h.clock.now,
-    schedule: h.clock.schedule,
-    cancel: h.clock.cancel,
+    clock: h.clock,
   });
   await generationClock.start();
   inner.answers.push(answered([message(`noted ${OLD_SECRET}`)]));
@@ -1017,7 +1015,7 @@ test("a generation dies exactly one lifetime after its birth, on the host's cloc
   };
   await h.clock.advance(born.expiresAt - 1);
   const held = acceptedRunId(await submit(h, "and now?"));
-  await settle();
+  await drainMicrotasks(20);
   assert.equal(h.store.generationId(), born.generationId);
   assert.ok(release, "the model holds the turn open");
 
@@ -1027,7 +1025,7 @@ test("a generation dies exactly one lifetime after its birth, on the host's cloc
   assert.equal(h.store.current()?.createdAt, born.expiresAt);
   assert.equal(h.agent.request(held), undefined);
   release?.(answered([message(`late ${OLD_SECRET}`)]));
-  await settle();
+  await drainMicrotasks(20);
 
   inner.respond = FakeClient.prototype.respond;
   inner.answers.push(answered([message("fresh")]));
@@ -1059,7 +1057,7 @@ test("an expiry is enforced at the door of a turn and a submission even when no 
   // The cursor died with the generation: the next look reads from the start.
   h.client.answers.push(answered([message("")]));
   await h.agent.wake([edge(ABC)]);
-  await h.clock.advance(h.clock.now + 3_000);
+  await h.clock.advance(h.clock.instant + 3_000);
   assert.equal(h.sinceReads.at(-1)?.cursor, undefined);
 
   // A generation that reaches its end while the app sits idle, with the
@@ -1070,10 +1068,10 @@ test("an expiry is enforced at the door of a turn and a submission even when no 
   const born = idle.store.current();
   assert.ok(born);
   for (const timer of idle.clock.timers.keys()) idle.clock.timers.delete(timer);
-  idle.clock.now = born.expiresAt;
+  idle.clock.instant = born.expiresAt;
   idle.client.answers.push(answered([message("")]));
   await idle.agent.wake([edge(ABC)]);
-  await idle.clock.advance(idle.clock.now + 3_000);
+  await idle.clock.advance(idle.clock.instant + 3_000);
   assert.notEqual(idle.store.generationId(), born.generationId);
   assert.equal(idle.store.current()?.requests.length, 0);
 });
@@ -1082,9 +1080,7 @@ test("a compaction and a fortnight of writes never extend a generation's life", 
   const h = harness();
   const generationClock = new BrainGenerationClock({
     store: h.store,
-    now: () => h.clock.now,
-    schedule: h.clock.schedule,
-    cancel: h.clock.cancel,
+    clock: h.clock,
   });
   await generationClock.start();
   h.client.answers.push(answered([message("one")]));
@@ -1124,9 +1120,7 @@ test("a Clear or expiry asked for while a write is out on disk revokes a held ac
     const h = harness({ actions });
     const generationClock = new BrainGenerationClock({
       store: h.store,
-      now: () => h.clock.now,
-      schedule: h.clock.schedule,
-      cancel: h.clock.cancel,
+      clock: h.clock,
     });
     await generationClock.start();
     h.client.answers.push(answered([message("first")]));
@@ -1136,16 +1130,16 @@ test("a Clear or expiry asked for while a write is out on disk revokes a held ac
     // The action's start is durable; its preparation is held.
     h.client.answers.push(answered([messageAction("call_1")]));
     const runId = acceptedRunId(await submit(h, "send"));
-    await settle();
+    await drainMicrotasks(20);
     assert.ok(releasePreparation, "the performer holds the action");
     assert.equal(h.repository.state?.journal.length, 1);
     // A metadata write of another run is out on disk when the end is asked for.
     const release = h.repository.hold();
     const marking = h.agent.markConversationRecorded(runId, NOW);
-    await settle();
+    await drainMicrotasks(20);
     assert.ok(h.repository.holding, "a write is on disk");
     if (ending === "clear") {
-      void h.store.clear(h.clock.now + 1);
+      void h.store.clear(h.clock.instant + 1);
     } else {
       await h.clock.advance(born.expiresAt);
     }
@@ -1153,10 +1147,10 @@ test("a Clear or expiry asked for while a write is out on disk revokes a held ac
     assert.equal(h.store.holdsGeneration(born.generationId), false);
     assert.equal(h.agent.request(runId), undefined);
     releasePreparation();
-    await settle();
+    await drainMicrotasks(20);
     release(true);
     await marking;
-    await settle();
+    await drainMicrotasks(20);
     await h.store.flush();
     assert.equal(effects, 0, `${ending}: an effect dispatched after the fence`);
     assert.equal(h.store.current()?.journal.length, 0);
@@ -1176,7 +1170,7 @@ test("a Clear pressed while a starting agent's load is still reading the file le
   const releaseRead = repository.holdRead();
   const h = harness({}, repository);
   const readying = h.agent.ready();
-  await settle();
+  await drainMicrotasks(20);
   assert.ok(repository.holding, "the load is reading the file");
   const clearing = h.store.clear(NOW);
   const fresh = h.store.generationId();
@@ -1201,7 +1195,7 @@ test("an ask during a client quiet ends as an honest failure with no effects, an
   h.client.answers.push(quietAnswer(NOW + 60_000));
   const first = await submit(h, "hello", "sub-quiet");
   const runId = acceptedRunId(first);
-  await settle();
+  await drainMicrotasks(20);
   // The run is not held for the quiet to end: it settles as a failed call,
   // with nothing performed and nothing delivered.
   const record = h.agent.request(runId);
@@ -1270,12 +1264,12 @@ test("a stop during a held initial bootstrap settles at once; the open finishing
       question: "hello",
       origin: BRAIN_REQUEST_ORIGIN.TYPED,
     });
-    await settle();
+    await drainMicrotasks(20);
     let stopped = false;
     const stopping = agent.stop().then(() => {
       stopped = true;
     });
-    await settle();
+    await drainMicrotasks(20);
     assert.equal(stopped, true, "stop settled while the bootstrap was still held");
     await stopping;
     await ready;
@@ -1285,11 +1279,11 @@ test("a stop during a held initial bootstrap settles at once; the open finishing
     // The open finishes after everything settled: the context is let go of,
     // once, and never installed.
     held.release();
-    await settle();
+    await drainMicrotasks(20);
     assert.equal(held.disposed(), 1);
     // Still not installed: the generation stays as the stop left it.
     assert.match((await agent.incompatibility()) ?? "", /replaced while its context was opening/u);
-    await settle();
+    await drainMicrotasks(20);
     assert.equal(held.disposed(), 1);
   }
 });
@@ -1354,12 +1348,12 @@ test("a reopen claimed just before a stop installs nothing: the stop's signal is
   h.client.answers.push(failedAnswer("boom"));
   const accepted = await submit(h, "fail");
   assert.ok(accepted.outcome === BRAIN_SUBMISSION_OUTCOME.ACCEPTED);
-  await settle();
+  await drainMicrotasks(20);
   assert.ok(releaseReopen, "the failed turn is reopening its context");
   const stopping = h.agent.stop();
   releaseReopen?.();
   await stopping;
-  await settle();
+  await drainMicrotasks(20);
   assert.equal(disposed, 1);
 });
 
@@ -1369,13 +1363,13 @@ test("an ask arriving while the model is thinking is steered into that run and a
   const h = harness({ client: gated.client });
   inner.answers.push(answered([message("First alone.")]), answered([message("Both answered.")]));
   const first = acceptedRunId(await submit(h, "first?"));
-  await settle();
+  await drainMicrotasks(20);
   const second = acceptedRunId(await submit(h, "second?"));
-  await settle();
+  await drainMicrotasks(20);
   // The second ask is running inside the first's execution, not queued behind it.
   assert.equal(h.agent.request(second)?.status, BRAIN_REQUEST_STATUS.RUNNING);
   gated.open();
-  await settle();
+  await drainMicrotasks(20);
   // Words steered in after the model had already answered are not lost: the
   // run asks once more with them, and the run's reply is everything it said,
   // the answer it had already given and the one that took both in.
@@ -1396,13 +1390,13 @@ test("steering lands between tool calls: every emitted call is answered before t
   const h = harness({ actions: held.actions });
   h.client.answers.push(answered([messageAction("call_1")]), answered([message("Done both.")]));
   const first = acceptedRunId(await submit(h, "send"));
-  await settle();
+  await drainMicrotasks(20);
   assert.equal(held.performed.length, 1);
   const second = acceptedRunId(await submit(h, "and this?"));
-  await settle();
+  await drainMicrotasks(20);
   assert.equal(h.agent.request(second)?.status, BRAIN_REQUEST_STATUS.RUNNING);
   held.releases[0]?.();
-  await settle();
+  await drainMicrotasks(20);
   assert.equal((await h.agent.waitAsk(first, 1))?.status, BRAIN_REQUEST_STATUS.SUCCEEDED);
   assert.equal((await h.agent.waitAsk(second, 1))?.text, "Done both.");
   const secondInput = h.client.inputs[1] ?? [];
@@ -1429,12 +1423,12 @@ test("a steered ask cancelled before the run ends is settled cancelled and takes
   // record's claim on the reply.
   inner.answers.push(answered([message("First.")]), answered([message("Reply.")]));
   const first = acceptedRunId(await submit(h, "first?"));
-  await settle();
+  await drainMicrotasks(20);
   const second = acceptedRunId(await submit(h, "second?"));
-  await settle();
+  await drainMicrotasks(20);
   assert.equal((await h.agent.cancelAsk(second))?.status, BRAIN_REQUEST_STATUS.CANCELLED);
   gated.open();
-  await settle();
+  await drainMicrotasks(20);
   assert.equal((await h.agent.waitAsk(first, 1))?.text, "First.\n\nReply.");
   assert.equal(h.agent.request(second)?.status, BRAIN_REQUEST_STATUS.CANCELLED);
   assert.equal(h.agent.request(second)?.text, undefined);
@@ -1445,15 +1439,15 @@ test("cancelling the run under way pairs its pending call, and the ask behind it
   const h = harness({ actions: held.actions });
   h.client.answers.push(answered([messageAction("call_1")]), answered([message("Second reply.")]));
   const first = acceptedRunId(await submit(h, "send"));
-  await settle();
+  await drainMicrotasks(20);
   assert.equal(held.performed.length, 1);
   // The run is still at its held act, so the record settles cancelled only
   // once that action returns; what the cancel does now is revoke the run.
   await h.agent.cancelAsk(first);
   const second = acceptedRunId(await submit(h, "stop, do this instead"));
-  await settle();
+  await drainMicrotasks(20);
   held.releases[0]?.();
-  await settle();
+  await drainMicrotasks(20);
   assert.equal((await h.agent.waitAsk(first, 1))?.status, BRAIN_REQUEST_STATUS.CANCELLED);
   assert.equal((await h.agent.waitAsk(second, 1))?.text, "Second reply.");
   // The interrupted run's call left no dangling function_call in what the next turn read or kept.
@@ -1474,7 +1468,7 @@ test("asks that arrive while a review runs open one turn together, each settled 
   const { h, inner, release } = await reviewing(answered([message("One reply for both.")]));
   const first = acceptedRunId(await submit(h, "first?"));
   const second = acceptedRunId(await submit(h, "second?"));
-  await settle();
+  await drainMicrotasks(20);
   assert.equal(inner.inputs.length, 0);
   await release();
   assert.equal(inner.inputs.length, 2);
@@ -1540,14 +1534,14 @@ test("a steered companion shares the run's persistence failure: a final write th
   // The steered words make the run ask once more; the second answer is the run's reply.
   inner.answers.push(answered([message("First alone.")]), answered([message("Reply for both.")]));
   const first = acceptedRunId(await submit(h, "first?"));
-  await settle();
+  await drainMicrotasks(20);
   const second = acceptedRunId(await submit(h, "second?"));
-  await settle();
+  await drainMicrotasks(20);
   assert.equal(h.agent.request(second)?.status, BRAIN_REQUEST_STATUS.RUNNING);
   // The disk refuses from here: the run's final checkpoint cannot land.
   h.repository.refuse();
   gated.open();
-  await settle();
+  await drainMicrotasks(20);
   const primary = h.agent.request(first);
   const companion = h.agent.request(second);
   assert.equal(primary?.status, BRAIN_REQUEST_STATUS.FAILED);
@@ -1575,12 +1569,12 @@ test("a rider settles when the shared turn dies to a thrown hook after its check
   });
   inner.answers.push(answered([message("First alone.")]), answered([message("Both.")]));
   const first = acceptedRunId(await submit(h, "first?"));
-  await settle();
+  await drainMicrotasks(20);
   const second = acceptedRunId(await submit(h, "second?"));
-  await settle();
+  await drainMicrotasks(20);
   assert.equal(h.agent.request(second)?.status, BRAIN_REQUEST_STATUS.RUNNING);
   gated.open();
-  await settle();
+  await drainMicrotasks(20);
   assert.equal(h.agent.request(first)?.status, BRAIN_REQUEST_STATUS.FAILED);
   assert.equal(h.agent.request(second)?.status, BRAIN_REQUEST_STATUS.FAILED);
   assert.ok(h.agent.requests().every((record) => record.status !== BRAIN_REQUEST_STATUS.RUNNING));
@@ -1591,7 +1585,7 @@ test("riders committed running before a turn refused at its door are settled wit
   const { h, inner, release } = await reviewing();
   const first = acceptedRunId(await submit(h, "first?"));
   const second = acceptedRunId(await submit(h, "second?"));
-  await settle();
+  await drainMicrotasks(20);
   // The generation is replaced the instant the primary is marked running, so
   // the drained turn reaches its door over a memory that no longer stands.
   let reset = false;
@@ -1618,7 +1612,7 @@ test("asks queued behind a primary that is cancelled or whose start the store re
   const { h, inner, release } = await reviewing(answered([message("second answered")]));
   const first = acceptedRunId(await submit(h, "first?"));
   const second = acceptedRunId(await submit(h, "second?"));
-  await settle();
+  await drainMicrotasks(20);
   // The primary is cancelled while the queue still holds them both.
   assert.equal((await h.agent.cancelAsk(first))?.status, BRAIN_REQUEST_STATUS.CANCELLED);
   await release();
@@ -1630,7 +1624,7 @@ test("asks queued behind a primary that is cancelled or whose start the store re
   const refusing = refused.h;
   const third = acceptedRunId(await submit(refusing, "third?"));
   const fourth = acceptedRunId(await submit(refusing, "fourth?"));
-  await settle();
+  await drainMicrotasks(20);
   refusing.repository.refuse();
   await refused.release();
   assert.equal(refusing.agent.request(third)?.status, BRAIN_REQUEST_STATUS.FAILED);
@@ -1676,7 +1670,7 @@ test("an idle ask pays no debounce, and one that arrives during a turn opens the
 
   const { h, inner, release } = await reviewing(answered([message("answered")]));
   const queued = acceptedRunId(await submit(h, "queued?"));
-  await settle();
+  await drainMicrotasks(20);
   assert.equal(h.agent.request(queued)?.status, BRAIN_REQUEST_STATUS.QUEUED);
   await release();
   // Nothing advanced the clock: the run ending is what drained the queue.
@@ -1781,7 +1775,7 @@ test("an ask already drained but waiting behind another turn takes its words wit
   const keptRun = acceptedRunId(await submit(h, "kept-behind-1e9b"));
   const cancelledRun = acceptedRunId(await submit(h, "cancelled-behind-5c7d"));
   await h.clock.advance(NOW + 500);
-  await settle();
+  await drainMicrotasks(20);
   assert.equal(h.agent.request(cancelledRun)?.status, BRAIN_REQUEST_STATUS.QUEUED);
   assert.equal((await h.agent.cancelAsk(cancelledRun))?.status, BRAIN_REQUEST_STATUS.CANCELLED);
   await release();
@@ -1802,7 +1796,7 @@ test("folded asks left alone by cancelling every ordinary one still open their t
   for (let index = 0; index < QUEUE_DEFAULTS.CAPACITY; index += 1) {
     ordinary.push(acceptedRunId(await submit(h, `ordinary ${index} marker-0d4c`)));
   }
-  await settle();
+  await drainMicrotasks(20);
   for (const runId of ordinary) {
     assert.equal((await h.agent.cancelAsk(runId))?.status, BRAIN_REQUEST_STATUS.CANCELLED);
   }
@@ -1837,7 +1831,7 @@ test("cancelling every waiting ask, folded ones included, leaves nothing queued,
   assert.equal(h.clock.timers.size, 0);
   // Stale summary metadata does not hold the conversation: the next ask opens its own turn at once.
   const next = acceptedRunId(await submit(h, "after all of them"));
-  await settle();
+  await drainMicrotasks(20);
   assert.equal((await h.agent.waitAsk(next, 1))?.text, "fresh");
   const opening = (inner.inputs[1] ?? []).map(itemText).join("\n");
   assert.ok(!opening.includes("summarized because the queue was full"));
@@ -1847,7 +1841,7 @@ test("a refused final checkpoint fails a drained batch's primary and its riders 
   const { h, release } = await reviewing(answered([message("reply for both")]));
   const first = acceptedRunId(await submit(h, "first?"));
   const second = acceptedRunId(await submit(h, "second?"));
-  await settle();
+  await drainMicrotasks(20);
   // The disk refuses from the moment the drained turn starts, so what cannot
   // land is its final checkpoint rather than its opening record.
   h.agent.subscribe((records) => {
@@ -1871,7 +1865,7 @@ test("a refused final checkpoint fails a drained batch's primary and its riders 
 test("a Clear with an ask still queued opens nothing for it and leaves no timer standing", async () => {
   const { h, inner, release } = await reviewing();
   const queued = acceptedRunId(await submit(h, "queued?"));
-  await settle();
+  await drainMicrotasks(20);
   assert.equal(await h.store.clear(), true);
   await release();
   // The queued ask belonged to the memory the Clear replaced: no turn opens
@@ -1884,11 +1878,11 @@ test("a Clear with an ask still queued opens nothing for it and leaves no timer 
 test("a stop with an ask still queued records it interrupted and opens nothing", async () => {
   const { h, inner, release } = await reviewing();
   const queued = acceptedRunId(await submit(h, "queued?"));
-  await settle();
+  await drainMicrotasks(20);
   const stopping = h.agent.stop();
   await release();
   await stopping;
-  await settle();
+  await drainMicrotasks(20);
   assert.equal(inner.inputs.length, 1);
   assert.equal(h.agent.request(queued)?.status, BRAIN_REQUEST_STATUS.INTERRUPTED);
 });

--- a/packages/brain/src/agent.ts
+++ b/packages/brain/src/agent.ts
@@ -1,11 +1,12 @@
 import type { MemoryHousekeepingResult } from "@sidecar/memory";
 import type { ChildEnd, ChildPolicyContext } from "@sidecar/runtime";
-import type {
-  AgentRuntime,
-  ChildCompletionRecord,
-  ChildRunRecord,
-  ReasoningEffort,
-  ScheduledTimer,
+import {
+  type AgentRuntime,
+  type ChildCompletionRecord,
+  type ChildRunRecord,
+  type Clock,
+  type ReasoningEffort,
+  systemClock,
 } from "@sidecar/runtime/vocabulary";
 import type {
   ProviderTranscriptResult,
@@ -145,9 +146,7 @@ export interface BrainAgentOptions {
   createRunId: () => string;
   trace?: (record: BrainTurnTraceRecord) => void;
   report?: (message: string) => void;
-  now?: () => number;
-  schedule?: (callback: () => void, delayMs: number) => ScheduledTimer;
-  cancel?: (timer: ScheduledTimer) => void;
+  clock?: Clock;
   maximumOutputTokens?: number;
   reasoningEffort?: ReasoningEffort;
   /**
@@ -202,9 +201,7 @@ export interface BrainAgentOptions {
  */
 export class BrainAgent {
   readonly #options: BrainAgentOptions;
-  readonly #now: () => number;
-  readonly #schedule: (callback: () => void, delayMs: number) => ScheduledTimer;
-  readonly #cancel: (timer: ScheduledTimer) => void;
+  readonly #clock: Clock;
   readonly #report: (message: string) => void;
   #generation: Generation | undefined;
   readonly #lease: BrainStoreLease;
@@ -223,28 +220,18 @@ export class BrainAgent {
 
   constructor(options: BrainAgentOptions) {
     this.#options = options;
-    this.#now = options.now ?? Date.now;
-    this.#schedule =
-      options.schedule ?? ((callback, delayMs) => globalThis.setTimeout(callback, delayMs));
-    this.#cancel =
-      options.cancel ??
-      ((timer) => {
-        // SAFETY: a timer this agent scheduled itself came from setTimeout above.
-        globalThis.clearTimeout(timer as ReturnType<typeof setTimeout>);
-      });
+    this.#clock = options.clock ?? systemClock;
     this.#report = options.report ?? ((message) => process.stderr.write(`${message}\n`));
     this.#lease = options.store.lease();
     this.#ledger = new BrainRequestLedger({
       store: options.store,
       lease: this.#lease,
-      now: this.#now,
+      now: () => this.#clock.now(),
       report: this.#report,
       notify: () => this.#asks.notify(),
     });
     const seam: AgentSeam = {
-      now: this.#now,
-      schedule: this.#schedule,
-      cancel: this.#cancel,
+      clock: this.#clock,
       report: this.#report,
       ledger: this.#ledger,
       generation: () => this.#generation,
@@ -603,11 +590,8 @@ export class BrainAgent {
   }
 
   #generationFrom(state: BrainPersistedState): Generation {
-    return generationFrom(
-      state,
-      this.#options.runtime,
-      JSON.stringify(UNKNOWN_ACTION_RESULT),
-      this.#now,
+    return generationFrom(state, this.#options.runtime, JSON.stringify(UNKNOWN_ACTION_RESULT), () =>
+      this.#clock.now(),
     );
   }
 
@@ -636,7 +620,7 @@ export class BrainAgent {
     if (opened.kind === CONTEXT_OPENING.INCOMPATIBLE) {
       this.#reportIncompatible(generation, opened.reason);
     }
-    const interrupted = interruptedUnfinishedRequests(state.requests, this.#now());
+    const interrupted = interruptedUnfinishedRequests(state.requests, this.#clock.now());
     // An action found started with no result may have happened: the runtime's
     // context paired it as unknown at load, and the interrupted run says so
     // in its count; neither is ever a call to make again.
@@ -720,8 +704,9 @@ export class BrainAgent {
    */
   #expireIfDue(): void {
     const generation = this.#generation;
-    if (this.#stopped || !generation || !brainGenerationExpired(generation, this.#now())) return;
-    this.#options.store.expireIfDue(this.#now());
+    const now = this.#clock.now();
+    if (this.#stopped || !generation || !brainGenerationExpired(generation, now)) return;
+    this.#options.store.expireIfDue(now);
   }
 
   #runRevoked(run: RunControl): boolean {

--- a/packages/brain/src/asks.ts
+++ b/packages/brain/src/asks.ts
@@ -4,8 +4,8 @@ import {
   type QueuedInput,
   queueSummaryLine,
 } from "@sidecar/runtime";
-import type { ScheduledTimer } from "@sidecar/runtime/vocabulary";
 import { CONTEXT_INPUT_KIND } from "@sidecar/runtime/vocabulary";
+import type { IDisposable } from "@sidecar/wire";
 import { CONTEXT_OPENING, type Generation } from "./generation.js";
 import { askInputText } from "./input-items.js";
 import {
@@ -74,8 +74,7 @@ export class AskLedger {
       steer: (input) => this.#steer(input),
       interrupt: () => this.#interrupt(),
       flush: (batches) => this.#openBatches(batches),
-      schedule: this.#seam.schedule,
-      cancel: this.#seam.cancel,
+      clock: this.#seam.clock,
     });
   }
 
@@ -243,7 +242,7 @@ export class AskLedger {
     generation: Generation,
     submission: BrainSubmission,
   ): Promise<BrainSubmissionResult> {
-    const acceptedAt = this.#seam.now();
+    const acceptedAt = this.#seam.clock.now();
     const record: BrainRequestRecord = {
       runId: this.#options.createRunId(),
       submissionId: submission.submissionId,
@@ -304,7 +303,11 @@ export class AskLedger {
       return;
     }
     const held = this.#queue.state.entries;
-    const admitted = this.#queue.push({ id: run.runId, text: question, atMs: this.#seam.now() });
+    const admitted = this.#queue.push({
+      id: run.runId,
+      text: question,
+      atMs: this.#seam.clock.now(),
+    });
     this.#foldEvicted(held);
     if (!admitted && !held.some((entry) => entry.id === run.runId)) {
       // The overflow refused these words outright: no turn will carry them,
@@ -344,7 +347,7 @@ export class AskLedger {
     // formed inside it would be that turn's, not the developer's answer. The
     // ask waits in the queue instead and opens its own turn when this one ends.
     if (active.plan.trigger !== BRAIN_TURN_TRIGGER.ASK) return false;
-    const text = askInputText(input.text, [], this.#seam.now());
+    const text = askInputText(input.text, [], this.#seam.clock.now());
     if (!active.started.steer({ kind: CONTEXT_INPUT_KIND.USER_TEXT, text })) return false;
     active.riders.push(run);
     // The one place a rider is committed running: its words are in the model's
@@ -352,7 +355,7 @@ export class AskLedger {
     void this.#seam.ledger
       .commit(run.generation, run.runId, {
         status: BRAIN_REQUEST_STATUS.RUNNING,
-        startedAt: this.#seam.now(),
+        startedAt: this.#seam.clock.now(),
       })
       .then(() => this.notify());
     return true;
@@ -435,17 +438,17 @@ export class AskLedger {
     if (!record) return undefined;
     if (isTerminalBrainRequestStatus(record.status)) return record;
     return new Promise((resolve) => {
-      let timer: ScheduledTimer | undefined;
+      let timer: IDisposable | undefined;
       const finish = () => {
         unsubscribe();
-        if (timer !== undefined) this.#seam.cancel(timer);
+        timer?.dispose();
         resolve(this.record(runId));
       };
       const unsubscribe = this.subscribe(() => {
         const current = this.record(runId);
         if (!current || isTerminalBrainRequestStatus(current.status)) finish();
       });
-      timer = this.#seam.schedule(finish, timeoutMs);
+      timer = this.#seam.clock.schedule(timeoutMs, finish);
     });
   }
 

--- a/packages/brain/src/children.test.ts
+++ b/packages/brain/src/children.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { RESPONSES_INPUT_ITEM_TYPE } from "@sidecar/hosted";
+import { drainMicrotasks } from "@sidecar/runtime/testing";
 import { CHILD_RUN_STATUS } from "@sidecar/runtime/vocabulary";
 import {
   acceptedRunId,
@@ -17,7 +18,6 @@ import {
   itemText,
   message,
   messageAction,
-  settle,
   submit,
 } from "./harness.js";
 import { BRAIN_INPUT_MARKER } from "./input-items.js";
@@ -36,7 +36,7 @@ test("a child's completion steers into the requester's run under way, is taken o
   const { client, open } = gatedClient(inner);
   const h = harness({ client });
   const runId = acceptedRunId(await submit(h, "keep going"));
-  await settle();
+  await drainMicrotasks(20);
   const completion = childCompletion({
     completionId: "completion:child-1",
     childId: "child-1",
@@ -45,12 +45,12 @@ test("a child's completion steers into the requester's run under way, is taken o
   // The run is waiting on its first inference: the completion is steered in,
   // and a retry that arrives while it is still being decided joins it.
   const steered = h.agent.deliverChildCompletion(...completion);
-  await settle();
+  await drainMicrotasks(20);
   const again = h.agent.deliverChildCompletion(...completion);
   open();
   assert.deepEqual(await steered, { delivered: true });
   assert.deepEqual(await again, { delivered: true });
-  await settle();
+  await drainMicrotasks(20);
   assert.equal((await h.agent.waitAsk(runId, 1))?.status, BRAIN_REQUEST_STATUS.SUCCEEDED);
   // Two inferences: the action's, then the one that read the steered completion
   // beside the action's result, and never a third for the duplicate.
@@ -91,7 +91,7 @@ test("a child task's end is decided in the brain: a run its generation forgot be
   const h = harness({ client });
   const run = await h.agent.runChildTask("look into it", "child-run-1");
   assert.ok(run);
-  await settle();
+  await drainMicrotasks(20);
   // The generation is replaced while the child's inference is still out: the
   // run's record goes with it, and the requester's service is still owed an end.
   h.store.reset();
@@ -126,7 +126,7 @@ test("a steered completion is delivered only once a checkpoint carries it: a run
   const { client, open } = gatedClient(inner);
   const h = harness({ client });
   const runId = acceptedRunId(await submit(h, "keep going"));
-  await settle();
+  await drainMicrotasks(20);
   const completion = childCompletion({
     completionId: "completion:child-1",
     childId: "child-1",
@@ -164,7 +164,7 @@ test("a steered completion carried by an action's checkpoint is delivered even t
   const { client, open } = gatedClient(inner);
   const h = harness({ client });
   const runId = acceptedRunId(await submit(h, "keep going"));
-  await settle();
+  await drainMicrotasks(20);
   const pending = h.agent.deliverChildCompletion(
     ...childCompletion({
       completionId: "completion:child-2",

--- a/packages/brain/src/children.ts
+++ b/packages/brain/src/children.ts
@@ -172,7 +172,7 @@ export class ChildRuns {
     if (opened.kind === CONTEXT_OPENING.INCOMPATIBLE) {
       return { delivered: false, reason: "the conversation's memory cannot be run" };
     }
-    const text = childCompletionInputText(completion, record, this.#seam.now());
+    const text = childCompletionInputText(completion, record, this.#seam.clock.now());
     const active = this.#options.active();
     if (
       active &&

--- a/packages/brain/src/compaction.test.ts
+++ b/packages/brain/src/compaction.test.ts
@@ -11,7 +11,7 @@ import {
   type ModelResponse,
   TRANSCRIPT_EVENT_KIND,
 } from "@sidecar/runtime/vocabulary";
-import { ACTION_RESULT_STATUS, type WireRecord } from "@sidecar/wire";
+import { ACTION_RESULT_STATUS, toDisposable, type WireRecord } from "@sidecar/wire";
 import { BrainAgent } from "./agent.js";
 import {
   assessCompaction,
@@ -307,13 +307,13 @@ function agentOver(model: ModelAdapter, repository: FakeBrainStateRepository) {
     report: (message) => {
       reports.push(message);
     },
-    now: () => NOW,
-    schedule: (callback) => {
-      const handle = {};
-      setImmediate(callback);
-      return handle;
+    clock: {
+      now: () => NOW,
+      schedule: (_delayMs, run) => {
+        const immediate = setImmediate(run);
+        return toDisposable(() => clearImmediate(immediate));
+      },
     },
-    cancel: () => undefined,
   });
   return { agent, store, reports };
 }

--- a/packages/brain/src/generation-clock.ts
+++ b/packages/brain/src/generation-clock.ts
@@ -1,12 +1,11 @@
-import type { ScheduledTimer } from "@sidecar/runtime/vocabulary";
+import { type Clock, systemClock } from "@sidecar/runtime/vocabulary";
+import type { IDisposable } from "@sidecar/wire";
 import { type BrainPersistedState, brainGenerationExpired } from "./envelope.js";
 import type { BrainStateStore } from "./state-store.js";
 
 export interface BrainGenerationClockOptions {
   store: BrainStateStore;
-  now?: () => number;
-  schedule?: (callback: () => void, delayMs: number) => ScheduledTimer;
-  cancel?: (timer: ScheduledTimer) => void;
+  clock?: Clock;
 }
 
 /**
@@ -18,30 +17,19 @@ export interface BrainGenerationClockOptions {
  * fortnight all leave the file to this. Starting it loads the store, which is
  * also where a file found expired, unreadable, or past its bounds at launch
  * is replaced on disk. Firing asks the store, the one judge of the moment;
- * an agent's own door check asking first costs nothing. On the host's own
- * timers the clock is unreferenced: housekeeping never holds a process open,
- * and the next launch's load covers a generation found dead.
+ * an agent's own door check asking first costs nothing, and the next launch's
+ * load covers a generation found dead.
  */
 export class BrainGenerationClock {
   readonly #store: BrainStateStore;
-  readonly #now: () => number;
-  readonly #schedule: (callback: () => void, delayMs: number) => ScheduledTimer;
-  readonly #cancel: (timer: ScheduledTimer) => void;
-  #timer: ScheduledTimer | undefined;
+  readonly #clock: Clock;
+  #timer: IDisposable | undefined;
   #unsubscribe: (() => void) | undefined;
   #stopped = false;
 
   constructor(options: BrainGenerationClockOptions) {
     this.#store = options.store;
-    this.#now = options.now ?? Date.now;
-    this.#schedule =
-      options.schedule ?? ((callback, delayMs) => globalThis.setTimeout(callback, delayMs).unref());
-    this.#cancel =
-      options.cancel ??
-      ((timer) => {
-        // SAFETY: a timer this clock scheduled itself came from setTimeout above.
-        globalThis.clearTimeout(timer as ReturnType<typeof setTimeout>);
-      });
+    this.#clock = options.clock ?? systemClock;
   }
 
   /** Loads the store, arms the timer for the generation that stands, and follows every replacement. */
@@ -61,19 +49,19 @@ export class BrainGenerationClock {
   #arm(state: BrainPersistedState): void {
     this.#disarm();
     if (this.#stopped || !this.#store.automaticReset) return;
-    if (brainGenerationExpired(state, this.#now())) {
-      this.#store.expireIfDue(this.#now());
+    if (brainGenerationExpired(state, this.#clock.now())) {
+      this.#store.expireIfDue(this.#clock.now());
       return;
     }
-    this.#timer = this.#schedule(() => {
+    this.#timer = this.#clock.schedule(state.expiresAt - this.#clock.now(), () => {
       this.#timer = undefined;
-      this.#store.expireIfDue(this.#now());
-    }, state.expiresAt - this.#now());
+      this.#store.expireIfDue(this.#clock.now());
+    });
   }
 
   #disarm(): void {
     if (this.#timer === undefined) return;
-    this.#cancel(this.#timer);
+    this.#timer.dispose();
     this.#timer = undefined;
   }
 }

--- a/packages/brain/src/guarantees.test.ts
+++ b/packages/brain/src/guarantees.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { RESPONSES_INPUT_ITEM_TYPE } from "@sidecar/hosted";
+import { drainMicrotasks } from "@sidecar/runtime/testing";
 import { RUN_ORIGIN } from "@sidecar/runtime/vocabulary";
 import { OMISSION_MARKER } from "@sidecar/session";
 import {
@@ -43,7 +44,6 @@ import {
   OBSERVATION_ACTIONS,
   seededRequests,
   session,
-  settle,
   submit,
   TRANSCRIPT_SECRET,
   UNKNOWN,
@@ -108,7 +108,7 @@ test("the journal records an action before its effect and its result before the 
   assert.equal(inner.inputs.length, 1, "the model has not been asked again");
 
   held.releases[0]?.();
-  await settle();
+  await drainMicrotasks(20);
   assert.deepEqual(
     journalsAtRequest,
     [[], [{ callId: "act_1", answered: true }]],
@@ -151,9 +151,9 @@ test("an action in a turn the developer did not open is Luke's own", async () =>
   await h.agent.wake([edge(ABC)]);
   await h.clock.advance(NOW + 3_000);
   await h.agent.rosterLook();
-  await settle();
+  await drainMicrotasks(20);
   h.agent.releaseHeld([{ briefing: "held", decidedAt: NOW }]);
-  await settle();
+  await drainMicrotasks(20);
   const observation = h.traces.filter((trace) => trace.trigger !== BRAIN_TURN_TRIGGER.ASK);
   assert.ok(observation.length >= 3);
   assert.ok(observation.every((trace) => trace.origin === RUN_ORIGIN.OBSERVATION));
@@ -240,10 +240,10 @@ test("a repeated unchanged look captures nothing, a hook delivered twice is one 
     roster: () => ({ text: "one", identities: [ABC], sessions: [session(ABC.providerSessionId)] }),
   });
   await h.agent.rosterLook();
-  await settle();
+  await drainMicrotasks(20);
   const captures = h.persisted.length;
   await h.agent.rosterLook();
-  await settle();
+  await drainMicrotasks(20);
   assert.equal(h.persisted.length, captures, "a look over an unchanged session captures nothing");
 
   const twice = edge(ABC, NOW + 100);
@@ -449,7 +449,7 @@ test("a briefing leaves only from a turn that still stands", async () => {
   const turning = other.clock.advance(NOW + 3_000);
   await other.agent.stop();
   await turning;
-  await settle();
+  await drainMicrotasks(20);
   assert.deepEqual(
     other.deliveries,
     [],

--- a/packages/brain/src/harness.ts
+++ b/packages/brain/src/harness.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import { REALTIME_TOOL, type RealtimeFunctionCall } from "@sidecar/actions";
 import { RESPONSES_INPUT_ITEM_TYPE } from "@sidecar/hosted";
 import { RESPONSES_ITEM_FORMAT, TOOL_LOOP_RUNTIME } from "@sidecar/runtime";
-import type { ScheduledTimer } from "@sidecar/runtime/vocabulary";
+import { drainMicrotasks, FakeClock } from "@sidecar/runtime/testing";
 import {
   CHILD_CLEANUP,
   CHILD_CONTEXT_MODE,
@@ -231,40 +231,6 @@ export class FakeClient implements BrainClient {
   }
 }
 
-export class FakeClock {
-  now = NOW;
-  readonly timers = new Map<ScheduledTimer, { callback: () => void; at: number }>();
-
-  schedule = (callback: () => void, delayMs: number): ScheduledTimer => {
-    const handle: ScheduledTimer = {};
-    this.timers.set(handle, { callback, at: this.now + delayMs });
-    return handle;
-  };
-
-  cancel = (timer: ScheduledTimer): void => {
-    this.timers.delete(timer);
-  };
-
-  /** Fires every timer due by `until`, advancing the clock to each in order. */
-  async advance(untilMs: number): Promise<void> {
-    for (;;) {
-      const due = [...this.timers.entries()]
-        .filter(([, timer]) => timer.at <= untilMs)
-        .sort((a, b) => a[1].at - b[1].at)[0];
-      if (!due) break;
-      this.timers.delete(due[0]);
-      this.now = Math.max(this.now, due[1].at);
-      due[1].callback();
-      await settle();
-    }
-    this.now = Math.max(this.now, untilMs);
-  }
-}
-
-export async function settle(): Promise<void> {
-  for (let index = 0; index < 20; index += 1) await new Promise((resolve) => setImmediate(resolve));
-}
-
 export interface Harness {
   agent: BrainAgent;
   runtime: ToolLoopAgentRuntime;
@@ -320,7 +286,7 @@ export function harness(
       },
     },
     createGenerationId: () => `gen-${nextRunId()}`,
-    now: () => clock.now,
+    now: () => clock.instant,
   });
   const performed: RealtimeFunctionCall[] = [];
   const executions: BrainActionExecution[] = [];
@@ -362,9 +328,7 @@ export function harness(
       traces.push(record);
     },
     report: () => {},
-    now: () => clock.now,
-    schedule: clock.schedule,
-    cancel: clock.cancel,
+    clock,
     ...agentOverrides,
   });
   return {
@@ -665,9 +629,7 @@ export function agentOn(runtime: ToolLoopAgentRuntime, h: Harness) {
     store: h.store,
     createRunId: () => `run-${nextRunId()}`,
     report: () => {},
-    now: () => h.clock.now,
-    schedule: h.clock.schedule,
-    cancel: h.clock.cancel,
+    clock: h.clock,
   });
 }
 
@@ -683,14 +645,14 @@ export async function reviewing(...replies: readonly BrainClientAnswer[]) {
   const h = harness({ client: gated.client });
   inner.answers.push(answered([message("nothing spoken")]), ...replies);
   await h.agent.rosterLook();
-  await settle();
+  await drainMicrotasks(20);
   return {
     h,
     inner,
     async release(): Promise<void> {
       gated.open();
-      await settle();
-      while (h.agent.busy()) await settle();
+      await drainMicrotasks(20);
+      while (h.agent.busy()) await drainMicrotasks(20);
     },
   };
 }

--- a/packages/brain/src/journal.test.ts
+++ b/packages/brain/src/journal.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { REALTIME_TOOL } from "@sidecar/actions";
+import { drainMicrotasks } from "@sidecar/runtime/testing";
 import { ACTION_RESULT_STATUS, isWireString } from "@sidecar/wire";
 import { freshBrainState } from "./envelope.js";
 import {
@@ -16,7 +17,6 @@ import {
   messageAction,
   NOW,
   OBSERVATION_ACTIONS,
-  settle,
   submit,
 } from "./harness.js";
 import { UNKNOWN_ACTION_RESULT } from "./journal.js";
@@ -117,7 +117,7 @@ test("an interrupted run's started actions are counted unknown at the next launc
   const h = harness({ actions: held.actions });
   h.client.answers.push(answered([messageAction("call_1")]));
   await submit(h, "send");
-  await settle();
+  await drainMicrotasks(20);
   const relaunched = harness({}, fakeBrainStateRepository(h.repository.state));
   await relaunched.agent.ready();
   const record = relaunched.agent.requests()[0];

--- a/packages/brain/src/ledger.test.ts
+++ b/packages/brain/src/ledger.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { RESPONSES_INPUT_ITEM_TYPE } from "@sidecar/hosted";
+import { drainMicrotasks } from "@sidecar/runtime/testing";
 import { RUN_ORIGIN } from "@sidecar/runtime/vocabulary";
 import { ACTION_RESULT_STATUS, isWireString, type WireRecord } from "@sidecar/wire";
 import { BrainAgent } from "./agent.js";
@@ -35,7 +36,6 @@ import {
   RECORD_CAP,
   runtimeOver,
   seededRequests,
-  settle,
   submissionsIssued,
   submit,
 } from "./harness.js";
@@ -76,10 +76,10 @@ test("a checkpoint that fails before an action refuses it, and acceptance itself
   assert.equal(h.agent.requests().length, 0);
   h.repository.accept();
   const runId = acceptedRunId(await submit(h, "send"));
-  await settle();
+  await drainMicrotasks(20);
   h.repository.refuse();
   gated.open();
-  await settle();
+  await drainMicrotasks(20);
   const record = h.agent.request(runId);
   assert.equal(record?.status, BRAIN_REQUEST_STATUS.FAILED);
   assert.equal(record?.failure, BRAIN_REQUEST_FAILURE.PERSISTENCE);
@@ -130,7 +130,7 @@ test("a restart marks unfinished runs interrupted and pairs a started act as unk
   const h = harness({ actions: held.actions });
   h.client.answers.push(answered([messageAction("call_1")]), answered([message("Sent.")]));
   const runId = acceptedRunId(await submit(h, "send"));
-  await settle();
+  await drainMicrotasks(20);
   // The process dies here: the action has started, its result never recorded.
   const stored = h.repository.state;
   assert.equal(stored?.requests[0]?.status, BRAIN_REQUEST_STATUS.RUNNING);
@@ -172,10 +172,10 @@ test("a retry of a submission whose acceptance is still being written awaits the
   h.client.answers.push(answered([message("once")]));
 
   const first = submit(h, "send", "sub-1");
-  await settle();
+  await drainMicrotasks(20);
   const retry = submit(h, "send", "sub-1");
   const other = submit(h, "send", "sub-1").then(() => h.agent.requests().length);
-  await settle();
+  await drainMicrotasks(20);
   // Nobody has been told anything yet, and no run stands to be found.
   assert.equal(h.agent.requests().length, 0);
   // The write refuses: every caller hears the same refusal, and no run remains.
@@ -192,7 +192,7 @@ test("a retry of a submission whose acceptance is still being written awaits the
   const accepted = await Promise.all([submit(h, "send", "sub-1"), submit(h, "send", "sub-1")]);
   assert.equal(accepted[0]?.outcome, BRAIN_SUBMISSION_OUTCOME.ACCEPTED);
   assert.deepEqual(accepted[0], accepted[1]);
-  await settle();
+  await drainMicrotasks(20);
   assert.equal(h.client.inputs.length, 1);
   assert.equal(h.agent.requests().length, 1);
   // The same id with other words, or another origin, is a conflict, not a retry.
@@ -217,13 +217,13 @@ test("a stop while an acceptance is being written interrupts the run it accepted
   await h.agent.ready();
   const releaseWrite = h.repository.hold();
   const pending = submit(h, "send", "sub-1");
-  await settle();
+  await drainMicrotasks(20);
   const stopping = h.agent.stop();
   releaseWrite?.(true);
   const accepted = await pending;
   await stopping;
   assert.equal(accepted.outcome, BRAIN_SUBMISSION_OUTCOME.ACCEPTED);
-  await settle();
+  await drainMicrotasks(20);
   const record = h.agent.requests()[0];
   assert.equal(record?.status, BRAIN_REQUEST_STATUS.INTERRUPTED);
   assert.equal(h.client.inputs.length, 0);
@@ -248,12 +248,12 @@ test("stop settles only after a held acceptance, which the successor then finds 
   await h.agent.ready();
   const releaseWrite = h.repository.hold();
   const pending = submit(h, "send", "sub-1");
-  await settle();
+  await drainMicrotasks(20);
   let stopped = false;
   const stopping = h.agent.stop().then(() => {
     stopped = true;
   });
-  await settle();
+  await drainMicrotasks(20);
   assert.equal(stopped, false, "stop waits for the acceptance to settle");
   releaseWrite?.(true);
   await stopping;
@@ -276,9 +276,7 @@ test("stop settles only after a held acceptance, which the successor then finds 
     store: h.store,
     createRunId: () => `successor-${nextRunId()}`,
     report: () => {},
-    now: () => h.clock.now,
-    schedule: h.clock.schedule,
-    cancel: h.clock.cancel,
+    clock: h.clock,
   });
   await successor.ready();
   const runId = h.agent.requests()[0]?.runId ?? "";
@@ -307,7 +305,7 @@ test("a copy taken before the second model answer already carries the actions th
   };
   const h = harness({ client });
   await submit(h, "send");
-  await settle();
+  await drainMicrotasks(20);
   assert.ok(release, "the second model call is held");
   const copy = h.repository.state;
   const stored = copy;
@@ -348,7 +346,7 @@ test("a copy taken before the second model answer already carries the actions th
     ]),
   );
   await submit(mixed, "send three");
-  await settle();
+  await drainMicrotasks(20);
   const midway = mixed.repository.state;
   assert.equal(midway?.requests[0]?.unknownActions, 1);
   assert.equal(midway?.journal.length, 3);
@@ -387,7 +385,7 @@ test("a mark is not visible or acknowledged before its write lands, and marking 
   assert.ok(record);
   const releaseWrite = h.repository.hold();
   const first = h.agent.markConversationRecorded(record.runId, NOW + 5);
-  await settle();
+  await drainMicrotasks(20);
   // Nothing reads the mark while the write is out, and a second caller waits
   // on the same write rather than being told yes.
   assert.equal(h.agent.request(record.runId)?.conversationRecordedAt, undefined);
@@ -399,7 +397,7 @@ test("a mark is not visible or acknowledged before its write lands, and marking 
   // The ask marker is another field: it stages its own write and touches
   // nothing of the history marker's.
   const other = h.agent.markAskRecorded(record.runId, NOW);
-  await settle();
+  await drainMicrotasks(20);
   assert.equal(secondAnswered, false);
   releaseWrite(false);
   assert.deepEqual(await Promise.all([first, second]), [false, false]);
@@ -432,7 +430,7 @@ test("a run's success is seen by no reader before the write that keeps it has la
     const record = records.find((entry) => entry.runId === runId);
     if (record) seen.push(record.status);
   });
-  await settle();
+  await drainMicrotasks(20);
   // Hold the write that would carry the success; the turn's own end
   // checkpoint lands first, so the held one is the settle.
   let writes = 0;
@@ -445,14 +443,14 @@ test("a run's success is seen by no reader before the write that keeps it has la
     });
   };
   gated.open();
-  await settle();
+  await drainMicrotasks(20);
   assert.ok(releaseWrite, "the settle write is held");
   // Every public reader still sees the run under way.
   assert.equal(h.agent.request(runId)?.status, BRAIN_REQUEST_STATUS.RUNNING);
   assert.equal(h.agent.requests()[0]?.status, BRAIN_REQUEST_STATUS.RUNNING);
   const waited = h.agent.waitAsk(runId, 1_000);
-  await settle();
-  await h.clock.advance(h.clock.now + 1_000);
+  await drainMicrotasks(20);
+  await h.clock.advance(h.clock.instant + 1_000);
   assert.equal((await waited)?.status, BRAIN_REQUEST_STATUS.RUNNING);
   assert.ok(!seen.includes(BRAIN_REQUEST_STATUS.SUCCEEDED));
   assert.equal(h.repository.state?.requests[0]?.status, BRAIN_REQUEST_STATUS.RUNNING);
@@ -460,7 +458,7 @@ test("a run's success is seen by no reader before the write that keeps it has la
   // kept, and that is the first terminal state anyone sees.
   h.repository.save = landed;
   releaseWrite?.(false);
-  await settle();
+  await drainMicrotasks(20);
   const ended = h.agent.request(runId);
   assert.equal(ended?.status, BRAIN_REQUEST_STATUS.FAILED);
   assert.equal(ended?.failure, BRAIN_REQUEST_FAILURE.PERSISTENCE);
@@ -477,7 +475,7 @@ test("a run's success is seen by no reader before the write that keeps it has la
   await ok.agent.ready();
   const okLanded = ok.repository.save;
   const okRun = acceptedRunId(await submit(ok, "hello"));
-  await settle();
+  await drainMicrotasks(20);
   let okRelease: (() => void) | undefined;
   let okWrites = 0;
   ok.repository.save = (state, transcript) => {
@@ -488,11 +486,11 @@ test("a run's success is seen by no reader before the write that keeps it has la
     });
   };
   okGate.open();
-  await settle();
+  await drainMicrotasks(20);
   assert.equal(ok.agent.request(okRun)?.status, BRAIN_REQUEST_STATUS.RUNNING);
   ok.repository.save = okLanded;
   okRelease?.();
-  await settle();
+  await drainMicrotasks(20);
   assert.equal(ok.agent.request(okRun)?.status, BRAIN_REQUEST_STATUS.SUCCEEDED);
   assert.equal(ok.repository.state?.requests[0]?.status, BRAIN_REQUEST_STATUS.SUCCEEDED);
 
@@ -503,10 +501,10 @@ test("a run's success is seen by no reader before the write that keeps it has la
   const dark = harness({ client: darkGate.client });
   await dark.agent.ready();
   const darkRun = acceptedRunId(await submit(dark, "hello"));
-  await settle();
+  await drainMicrotasks(20);
   dark.repository.refuse();
   darkGate.open();
-  await settle();
+  await drainMicrotasks(20);
   const darkEnd = await dark.agent.waitAsk(darkRun, 1);
   assert.equal(darkEnd?.status, BRAIN_REQUEST_STATUS.FAILED);
   assert.equal(darkEnd?.failure, BRAIN_REQUEST_FAILURE.PERSISTENCE);
@@ -551,15 +549,15 @@ test("an ordinary observation checkpoint composed behind a held mark keeps the m
   const runId = await completedRun(h);
   const releaseWrite = h.repository.hold();
   const marking = h.agent.markConversationRecorded(runId, NOW + 1);
-  await settle();
+  await drainMicrotasks(20);
   // Periodic observation races the publication: its inference and checkpoint
   // queue behind the held mark write.
   h.client.answers.push(answered([message("noted")]));
   h.agent.rosterLook();
-  await settle();
+  await drainMicrotasks(20);
   releaseWrite(true);
   assert.equal(await marking, true);
-  await settle();
+  await drainMicrotasks(20);
   assert.equal(h.client.inputs.length, 2);
   assert.equal(h.agent.request(runId)?.conversationRecordedAt, NOW + 1);
   assert.equal(h.repository.state?.requests[0]?.conversationRecordedAt, NOW + 1);
@@ -572,7 +570,7 @@ test("a terminal end and its marks overlapping a new submission and a checkpoint
   const gated = gatedClient(inner);
   const h = harness({ client: gated.client });
   const first = acceptedRunId(await submit(h, "send"));
-  await settle();
+  await drainMicrotasks(20);
   gated.open();
   // While the first run's end and marks are being saved, a second ask is
   // accepted and an observation wakes: every save composes on the last.
@@ -583,7 +581,7 @@ test("a terminal end and its marks overlapping a new submission and a checkpoint
     h.agent.markAskRecorded(first, NOW),
   ]);
   await h.agent.wake([edge(ABC)]);
-  await h.clock.advance(h.clock.now + 3_000);
+  await h.clock.advance(h.clock.instant + 3_000);
   assert.equal(second.outcome, BRAIN_SUBMISSION_OUTCOME.ACCEPTED);
   assert.equal(end?.status, BRAIN_REQUEST_STATUS.SUCCEEDED);
   assert.deepEqual([marked, askMarked], [true, true]);
@@ -637,11 +635,11 @@ test("a refused acceptance is never saved by an unrelated mark, and never comes 
   const a = await completedRun(h, "s");
   const held = holdNextWrite(h.repository);
   const firstMark = h.agent.markConversationRecorded(a, NOW + 1);
-  await settle();
+  await drainMicrotasks(20);
   const secondMark = h.agent.markAskRecorded(a, NOW);
   // B is provisional while its own acceptance write waits behind the marks.
   const rejectedB = submit(h, "ASK_THAT_WAS_REJECTED", "rejected-b");
-  await settle();
+  await drainMicrotasks(20);
   // Behind the held write: A's second mark lands, B's own write is refused.
   const landed = h.repository.save;
   let later = 0;
@@ -656,7 +654,7 @@ test("a refused acceptance is never saved by an unrelated mark, and never comes 
     outcome: BRAIN_SUBMISSION_OUTCOME.REJECTED,
     reason: BRAIN_SUBMISSION_REJECTION.PERSISTENCE,
   });
-  await settle();
+  await drainMicrotasks(20);
   assert.equal(h.client.inputs.length, 1, "no effect ran for the refused ask");
   assert.deepEqual(
     h.agent.requests().map((r) => r.runId),
@@ -686,7 +684,7 @@ test("a refused acceptance is never saved by an unrelated mark, and never comes 
     origin: BRAIN_REQUEST_ORIGIN.TYPED,
   });
   assert.equal(retried.outcome, BRAIN_SUBMISSION_OUTCOME.ACCEPTED);
-  await settle();
+  await drainMicrotasks(20);
   assert.equal(relaunched.repository.state?.requests.length, 2);
 });
 
@@ -706,7 +704,7 @@ test("two overlapping submissions, one refused, leave no ghost run and execute t
     outcome: BRAIN_SUBMISSION_OUTCOME.REJECTED,
     reason: BRAIN_SUBMISSION_REJECTION.PERSISTENCE,
   });
-  await settle();
+  await drainMicrotasks(20);
   assert.equal(h.client.inputs.length, 1);
   assert.deepEqual(
     h.repository.state?.requests.map((r) => r.submissionId),
@@ -718,7 +716,7 @@ test("two overlapping submissions, one refused, leave no ghost run and execute t
   );
   // The refused one retried is a fresh run, and the accepted one ran once.
   assert.equal((await submit(h, "second", "b")).outcome, BRAIN_SUBMISSION_OUTCOME.ACCEPTED);
-  await settle();
+  await drainMicrotasks(20);
   assert.equal(h.client.inputs.length, 2);
   assert.deepEqual(
     h.repository.state?.requests.map((r) => r.submissionId),
@@ -741,7 +739,7 @@ test("an observation in flight enters no memory through an unrelated mark or acc
   // reads a real delta, moves a cursor, and then waits on the model.
   await observing.agent.wake([edge(ABC)]);
   observing.agent.releaseHeld([{ briefing: "UNCOMMITTED_OBSERVATION", decidedAt: NOW }]);
-  await settle();
+  await drainMicrotasks(20);
   // The delta was captured — an inbox entry and a capture cursor — and read
   // into working memory; the consumed cursor has not moved; the model is held.
   assert.equal(observing.sinceReads.length, 1);
@@ -770,7 +768,7 @@ test("an observation in flight enters no memory through an unrelated mark or acc
   // turn behind it, and that turn is the one that consumes the standing entry.
   inner.answers.unshift(failedAnswer("network"));
   regate.open();
-  await settle();
+  await drainMicrotasks(20);
   const after = observing.repository.state;
   assert.ok(!JSON.stringify(after?.items).includes("UNCOMMITTED_OBSERVATION"));
   assert.equal(after?.inbox.length, 0);
@@ -813,13 +811,13 @@ test("a cancel or stop landing while the start is being written ends the run uno
   cancelling.client.answers.push(answered([messageAction("call_1")]));
   const heldStart = holdWriteMatching(cancelling.repository, CARRIES_A_RUNNING_RUN);
   const runId = acceptedRunId(await submit(cancelling, "send"));
-  await settle();
+  await drainMicrotasks(20);
   assert.equal(heldStart.held(), true);
   const cancelled = cancelling.agent.cancelAsk(runId);
-  await settle();
+  await drainMicrotasks(20);
   heldStart.release(true);
   await cancelled;
-  await settle();
+  await drainMicrotasks(20);
   assert.equal(cancelling.agent.request(runId)?.status, BRAIN_REQUEST_STATUS.CANCELLED);
   assert.equal(cancelling.client.inputs.length, 0);
   assert.deepEqual(cancelling.performed, []);
@@ -831,7 +829,7 @@ test("a cancel or stop landing while the start is being written ends the run uno
   stopping.client.answers.push(answered([messageAction("call_1")]));
   const refusedStart = holdWriteMatching(stopping.repository, CARRIES_A_RUNNING_RUN);
   const stopRun = acceptedRunId(await submit(stopping, "send"));
-  await settle();
+  await drainMicrotasks(20);
   assert.equal(refusedStart.held(), true);
   const stopped = stopping.agent.stop();
   refusedStart.release(false);
@@ -848,11 +846,11 @@ test("a cancel or stop landing while the start is being written ends the run uno
   h.client.answers.push(answered([messageAction("call_1")]));
   const start = holdWriteMatching(h.repository, CARRIES_A_RUNNING_RUN);
   const live = acceptedRunId(await submit(h, "send"));
-  await settle();
+  await drainMicrotasks(20);
   assert.equal(start.held(), true);
   assert.equal(h.client.inputs.length, 0);
   start.release(true);
-  await settle();
+  await drainMicrotasks(20);
   assert.equal(h.client.inputs.length, 1);
   assert.equal(held.performed.length, 1);
   const cancelledLate = await h.agent.cancelAsk(live);
@@ -863,7 +861,7 @@ test("a cancel or stop landing while the start is being written ends the run uno
     if (record && isTerminalBrainRequestStatus(record.status)) seen.push(record);
   });
   held.releases[0]?.();
-  await settle();
+  await drainMicrotasks(20);
   assert.equal(seen.length, 1);
   assert.equal(seen[0]?.status, BRAIN_REQUEST_STATUS.CANCELLED);
   assert.equal(seen[0]?.performedActions, 0);
@@ -889,7 +887,7 @@ test("runs retention lets go of leave the live records and journal too, so the n
     const record = await ask(h, words);
     assert.ok(record);
     runIds.push(record.runId);
-    assert.equal(await h.agent.markConversationRecorded(record.runId, h.clock.now), true);
+    assert.equal(await h.agent.markConversationRecorded(record.runId, h.clock.instant), true);
   }
   // Retention ran inside the marks: the four oldest seeded runs went to make
   // room, in the file, in the live records, and in the journal the agent holds.
@@ -908,7 +906,7 @@ test("runs retention lets go of leave the live records and journal too, so the n
   // journal again, and the pruned runs stay gone.
   h.client.answers.push(answered([message("")]));
   await h.agent.wake([edge(ABC)]);
-  await h.clock.advance(h.clock.now + 3_000);
+  await h.clock.advance(h.clock.instant + 3_000);
   const after = h.repository.state;
   assert.deepEqual(new Set(after?.journal.map((entry) => entry.runId)), new Set(runIds));
   for (const runId of goneIds) assert.ok(!standing(after).has(runId));

--- a/packages/brain/src/observation-inbox.test.ts
+++ b/packages/brain/src/observation-inbox.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { RESPONSES_INPUT_ITEM_TYPE } from "@sidecar/hosted";
+import { drainMicrotasks } from "@sidecar/runtime/testing";
 import {
   normalizeSession,
   type ProviderTranscriptSinceResult,
@@ -26,7 +27,6 @@ import {
   message,
   NOW,
   session,
-  settle,
   submit,
   TRANSCRIPT_SECRET,
 } from "./harness.js";
@@ -159,7 +159,7 @@ test("a roster look carries only the transcripts that grew, never the roster", a
     },
   });
   h.agent.rosterLook();
-  await settle();
+  await drainMicrotasks(20);
 
   assert.equal(h.client.inputs.length, 1);
   const input = h.client.inputs[0] ?? [];
@@ -184,7 +184,7 @@ test("a roster look carries only the transcripts that grew, never the roster", a
 
   // The look can be triggered again by the host.
   h.agent.rosterLook();
-  await settle();
+  await drainMicrotasks(20);
   assert.equal(h.client.inputs.length, 2);
   await h.agent.stop();
 });
@@ -201,7 +201,7 @@ test("a roster look is skipped while the client is quiet or a turn is in flight"
   // Quiet: the look is skipped.
   h.client.quiet = NOW + 30_000;
   h.agent.rosterLook();
-  await settle();
+  await drainMicrotasks(20);
   assert.equal(h.client.inputs.length, 0);
 
   // Quiet over, but a turn is under way: the look yields.
@@ -216,18 +216,18 @@ test("a roster look is skipped while the client is quiet or a turn is in flight"
     return respond(input, options);
   };
   const asked = ask(h, "what's up?");
-  await settle();
+  await drainMicrotasks(20);
   h.agent.rosterLook();
-  await settle();
+  await drainMicrotasks(20);
   assert.equal(h.client.inputs.length, 0);
   release?.();
   await asked;
-  await settle();
+  await drainMicrotasks(20);
   assert.equal(h.client.inputs.length, 1);
 
   // After the turn completes, the look proceeds.
   h.agent.rosterLook();
-  await settle();
+  await drainMicrotasks(20);
   assert.equal(h.client.inputs.length, 2);
   assert.equal(h.traces.at(-1)?.trigger, BRAIN_TURN_TRIGGER.ROSTER);
   await h.agent.stop();
@@ -246,7 +246,7 @@ test("a conversation that observes no session opens no look, however the roster 
     }),
   });
   h.agent.rosterLook();
-  await settle();
+  await drainMicrotasks(20);
   // No transcript is read and no inference opens: this conversation's turns
   // are the developer's asks and its own scheduled review.
   assert.equal(h.client.inputs.length, 0);
@@ -300,8 +300,8 @@ test("captures past a turn's depth are kept whole across a relaunch and read in 
   const relaunched = harness(reading(), quiet.repository);
   relaunched.client.answers.push(answered([message("")]), answered([message("")]));
   await relaunched.agent.ready();
-  await relaunched.clock.advance(relaunched.clock.now + 3_000);
-  await settle();
+  await relaunched.clock.advance(relaunched.clock.instant + 3_000);
+  await drainMicrotasks(20);
   assert.equal(relaunched.sinceReads.length, 0);
   assert.equal(relaunched.client.inputs.length, 1);
   const firstTurn = (relaunched.client.inputs[0] ?? []).map(itemText).join("\n");
@@ -312,8 +312,8 @@ test("captures past a turn's depth are kept whole across a relaunch and read in 
   // The next look finds nothing new in the transcript and still opens the
   // turn the standing captures are owed.
   relaunched.agent.rosterLook();
-  await relaunched.clock.advance(relaunched.clock.now + 3_000);
-  await settle();
+  await relaunched.clock.advance(relaunched.clock.instant + 3_000);
+  await drainMicrotasks(20);
   assert.equal(relaunched.client.inputs.length, 2);
   const secondTurn = (relaunched.client.inputs[1] ?? []).map(itemText).join("\n");
   for (let index = 21; index <= 25; index += 1) assert.ok(secondTurn.includes(`PIECE_${index}`));
@@ -344,7 +344,7 @@ test("a conversation that looks at one session reads only it, and a repeated unc
   });
   h.client.answers.push(answered([message("")]));
   h.agent.rosterLook();
-  await settle();
+  await drainMicrotasks(20);
   assert.equal(h.client.inputs.length, 1);
   assert.deepEqual(notices[0]?.identities, [ABC]);
   assert.ok(!itemText((h.client.inputs[0] ?? [])[0]).includes("for def"));
@@ -353,16 +353,16 @@ test("a conversation that looks at one session reads only it, and a repeated unc
   // Nothing gained and the session unchanged: the look is suppressed, deterministically.
   text = "";
   h.agent.rosterLook();
-  await settle();
+  await drainMicrotasks(20);
   h.agent.rosterLook();
-  await settle();
+  await drainMicrotasks(20);
   assert.equal(h.client.inputs.length, 1);
   assert.equal(notices.length, 1);
   // The transcript growing opens a look again.
   text = "more words";
   h.client.answers.push(answered([message("")]));
   h.agent.rosterLook();
-  await settle();
+  await drainMicrotasks(20);
   assert.equal(h.client.inputs.length, 2);
 });
 
@@ -394,14 +394,14 @@ test("a session the developer is speaking with wakes nothing, and the exchange o
   // exchange being heard first-hand, and nothing is written down to open one
   // later — but the capture cursor moves past what was said.
   h.agent.rosterLook();
-  await settle();
+  await drainMicrotasks(20);
   await h.agent.wake([
     {
       ...edge(ABC),
       session: session("abc", { status: SESSION_STATUS.WORKING, realtimeVoiceLive: true }),
     },
   ]);
-  await settle();
+  await drainMicrotasks(20);
   assert.equal(h.client.inputs.length, 0);
   assert.equal(h.repository.state?.inbox.length ?? 0, 0);
   assert.equal(h.repository.state?.captureCursors["claude-code"]?.abc, String(transcript.length));
@@ -410,14 +410,14 @@ test("a session the developer is speaking with wakes nothing, and the exchange o
   // opens nothing and replays none of what the developer heard themselves.
   live = false;
   h.agent.rosterLook();
-  await settle();
+  await drainMicrotasks(20);
   assert.equal(h.client.inputs.length, 0);
 
   // A fresh turn after it is read from where the exchange left off.
   transcript += "\nassistant: back to typing";
   h.client.answers.push(answered([message("")]));
   h.agent.rosterLook();
-  await settle();
+  await drainMicrotasks(20);
   assert.equal(h.client.inputs.length, 1);
   const opening = itemText((h.client.inputs[0] ?? [])[0]);
   assert.ok(opening.includes("back to typing"));
@@ -443,7 +443,7 @@ test("a wake's session summary carries the hold and the completion cause beside 
     },
   ]);
   await h.clock.advance(NOW + 3_000);
-  await settle();
+  await drainMicrotasks(20);
   const opening = itemText(
     itemsOfType(h.client.inputs[0] ?? [], RESPONSES_INPUT_ITEM_TYPE.MESSAGE)[0],
   );
@@ -464,10 +464,10 @@ test("a relaunch does not run an ask that was only queued, and runs a captured o
   const gated = gatedClient(inner);
   const h = harness({ client: gated.client });
   acceptedRunId(await submit(h, "first?"));
-  await settle();
+  await drainMicrotasks(20);
   const queued = acceptedRunId(await submit(h, "second, queued"));
   await h.agent.wake([edge(DEF)]);
-  await settle();
+  await drainMicrotasks(20);
   assert.equal(h.agent.pendingWakes(), 1);
   // The process dies with the first running, the second steered or queued, and a captured observation waiting.
   const relaunched = harness({}, fakeBrainStateRepository(h.repository.state));

--- a/packages/brain/src/seam.ts
+++ b/packages/brain/src/seam.ts
@@ -1,4 +1,4 @@
-import type { ScheduledTimer } from "@sidecar/runtime/vocabulary";
+import type { Clock } from "@sidecar/runtime/vocabulary";
 import type { Generation } from "./generation.js";
 import type { BrainRequestLedger } from "./ledger.js";
 import type { BrainTurnTrigger, RunControl } from "./turn.js";
@@ -10,9 +10,7 @@ import type { BrainTurnTrigger, RunControl } from "./turn.js";
  * collaborator holds the agent and none of them can own the standing twice.
  */
 export interface AgentSeam {
-  readonly now: () => number;
-  readonly schedule: (callback: () => void, delayMs: number) => ScheduledTimer;
-  readonly cancel: (timer: ScheduledTimer) => void;
+  readonly clock: Clock;
   readonly report: (message: string) => void;
   readonly ledger: BrainRequestLedger;
   /** The generation that stands, or nothing before the first load. */

--- a/packages/brain/src/state-store-retention.test.ts
+++ b/packages/brain/src/state-store-retention.test.ts
@@ -27,14 +27,12 @@ function launch(repository: FakeBrainStateRepository, clock: FakeClock) {
     automaticReset: false,
     repository,
     createGenerationId: () => `gen-${++generations}`,
-    now: () => clock.now,
+    now: () => clock.instant,
     report: (message) => reports.push(message),
   });
   const generationClock = new BrainGenerationClock({
     store,
-    now: () => clock.now,
-    schedule: clock.schedule,
-    cancel: clock.cancel,
+    clock,
   });
   return { store, generationClock, reports };
 }

--- a/packages/brain/src/state-store.test.ts
+++ b/packages/brain/src/state-store.test.ts
@@ -666,10 +666,12 @@ test("default policy keeps an existing checkpoint beyond its legacy deadline and
   let scheduled = false;
   const clock = new BrainGenerationClock({
     store,
-    now: () => now,
-    schedule: () => {
-      scheduled = true;
-      throw new Error("default policy must not schedule expiry");
+    clock: {
+      now: () => now,
+      schedule: () => {
+        scheduled = true;
+        throw new Error("default policy must not schedule expiry");
+      },
     },
   });
   await clock.start();

--- a/packages/brain/src/turn-runner.ts
+++ b/packages/brain/src/turn-runner.ts
@@ -284,7 +284,7 @@ export class TurnRunner {
       // start was being written ends it on its own terms, likewise unopened.
       const started = await this.#seam.ledger.commit(generation, run.runId, {
         status: BRAIN_REQUEST_STATUS.RUNNING,
-        startedAt: this.#seam.now(),
+        startedAt: this.#seam.clock.now(),
       });
       this.#options.notifyRecords();
       if (!started || this.#seam.runRevoked(run)) {
@@ -315,15 +315,15 @@ export class TurnRunner {
         opened.push(rider);
         await this.#seam.ledger.commit(rider.run.generation, rider.run.runId, {
           status: BRAIN_REQUEST_STATUS.RUNNING,
-          startedAt: this.#seam.now(),
+          startedAt: this.#seam.clock.now(),
         });
       }
       if (riders.length > 0) this.#options.notifyRecords();
       const question = askQuestion(opened);
-      run.deadline = this.#seam.schedule(() => {
+      run.deadline = this.#seam.clock.schedule(this.#options.executionDeadlineMs, () => {
         run.timedOut = true;
         run.abort.abort();
-      }, this.#options.executionDeadlineMs);
+      });
       // A child's task runs under its own trigger: the words open as the
       // delegated task rather than the developer's ask, and the final text is
       // the result its requester is handed rather than speech.
@@ -353,7 +353,7 @@ export class TurnRunner {
       } catch {
         result = { outcome: TURN_OUTCOME.FAILED };
       }
-      if (run.deadline !== undefined) this.#seam.cancel(run.deadline);
+      run.deadline?.dispose();
       this.#options.forgetRun(run.runId);
       const { status, end } = runOutcomeOf(run, result, this.#seam.stopped());
       await this.#seam.ledger.settleRun(generation, run.runId, status, end, run);
@@ -408,7 +408,7 @@ export class TurnRunner {
         identities: uniqueIdentities(plan.events),
         briefings: result.outcome === TURN_OUTCOME.DONE ? result.briefings : [],
         performedActions: run.performedActions,
-        at: this.#seam.now(),
+        at: this.#seam.clock.now(),
       });
     }
     return result;
@@ -449,10 +449,10 @@ export class TurnRunner {
     // same deadline: a model that never answers cannot stall every turn
     // behind it.
     if (!plan.run) {
-      run.deadline = this.#seam.schedule(() => {
+      run.deadline = this.#seam.clock.schedule(this.#options.executionDeadlineMs, () => {
         run.timedOut = true;
         run.abort.abort();
-      }, this.#options.executionDeadlineMs);
+      });
     }
     const consumes = plan.events.flatMap((event) => (event.entryId ? [event.entryId] : []));
     const turnContext: TurnContext = {
@@ -474,7 +474,7 @@ export class TurnRunner {
       return { result: await this.#runTurn(plan, turnContext, execution, riders), run };
     } finally {
       ended = true;
-      if (!plan.run && run.deadline !== undefined) this.#seam.cancel(run.deadline);
+      if (!plan.run) run.deadline?.dispose();
       this.#turnInFlight = false;
       // Steered words no checkpoint of the turn carried are owed still.
       plan.deliveries.turnEnded();
@@ -489,7 +489,7 @@ export class TurnRunner {
     riders: RunControl[],
   ): Promise<TurnResult> {
     const { generation, context, run } = turnContext;
-    const startedAt = this.#seam.now();
+    const startedAt = this.#seam.clock.now();
     let contextMark: ContextMark = context.mark();
     let cursorMark = generation.cursors.persisted();
     const gathering: TurnGathering = {
@@ -661,7 +661,7 @@ export class TurnRunner {
         briefingChars: delivery.briefing.length,
       })),
       ...(model ? { model } : undefined),
-      elapsedMs: this.#seam.now() - startedAt,
+      elapsedMs: this.#seam.clock.now() - startedAt,
       iterations: gathering.iterations,
       compacted: gathering.compacted,
       ...(gathering.error ? { error: gathering.error } : undefined),
@@ -693,7 +693,7 @@ export class TurnRunner {
       ),
       generation.abort.signal,
       "the runtime could not reopen its own checkpoint",
-      this.#seam.now,
+      () => this.#seam.clock.now(),
     );
     if (reopened.aborted) return;
     const standing = await generation.opened;
@@ -792,7 +792,7 @@ export class TurnRunner {
           }),
         checkpoint: (checkpointContext) => this.#seam.ledger.checkpoint(checkpointContext),
         runRevoked: (checked) => this.#seam.runRevoked(checked),
-        now: this.#seam.now,
+        now: () => this.#seam.clock.now(),
       },
       {
         policy: turn.policy,
@@ -852,7 +852,7 @@ export class TurnRunner {
         standingContextText(
           this.#options.roster().text,
           this.#options.standingContext(),
-          this.#seam.now(),
+          this.#seam.clock.now(),
         ),
       ],
       maximumOutputTokens: this.#options.maximumOutputTokens,

--- a/packages/brain/src/turn.ts
+++ b/packages/brain/src/turn.ts
@@ -4,8 +4,8 @@ import {
   type ToolDescriptor,
   type ToolPolicyLayers,
 } from "@sidecar/runtime";
-import type { ScheduledTimer } from "@sidecar/runtime/vocabulary";
 import { RUN_ORIGIN, type RunOrigin } from "@sidecar/runtime/vocabulary";
+import type { IDisposable } from "@sidecar/wire";
 import type { Generation } from "./generation.js";
 import type { SteeredDeliveries } from "./steered-deliveries.js";
 import type { RecordingContextEngine } from "./transcript-recorder.js";
@@ -118,7 +118,7 @@ export interface RunControl {
   abort: AbortController;
   cancelled: boolean;
   timedOut: boolean;
-  deadline?: ScheduledTimer;
+  deadline?: IDisposable;
   /** Whether a checkpoint failed inside this run, after which no further action may be dispatched. */
   checkpointFailed: boolean;
   /** Whether the context had to be compacted before the run could be sent and could not be; the context stands as it was. */

--- a/packages/brain/src/wake-queue.ts
+++ b/packages/brain/src/wake-queue.ts
@@ -1,4 +1,5 @@
-import type { ScheduledTimer } from "@sidecar/runtime/vocabulary";
+import type { Clock } from "@sidecar/runtime/vocabulary";
+import type { IDisposable } from "@sidecar/wire";
 import { sameObservation } from "./observation-inbox.js";
 import type { BrainWakeEvent } from "./wake-events.js";
 
@@ -14,9 +15,7 @@ export interface WakeQueueOptions {
   coalesceMs: number;
   /** The most wakes held for one turn. */
   capacity: number;
-  now: () => number;
-  schedule: (callback: () => void, delayMs: number) => ScheduledTimer;
-  cancel: (timer: ScheduledTimer) => void;
+  clock: Clock;
   /** The moment the model may be asked again, or nothing when it may be asked now. */
   quietUntil: () => number | undefined;
   /** Opens a turn over the events taken; the host decides in what and how. */
@@ -26,7 +25,7 @@ export interface WakeQueueOptions {
 export class WakeQueue {
   readonly #options: WakeQueueOptions;
   #pending: BrainWakeEvent[] = [];
-  #timer: ScheduledTimer | undefined;
+  #timer: IDisposable | undefined;
 
   constructor(options: WakeQueueOptions) {
     this.#options = options;
@@ -73,7 +72,7 @@ export class WakeQueue {
 
   /** The wait a quiet earns: until it ends, or the coalescing window at least. */
   quietDelay(until: number): number {
-    return Math.max(until - this.#options.now(), this.#options.coalesceMs);
+    return Math.max(until - this.#options.clock.now(), this.#options.coalesceMs);
   }
 
   /** Drops every pending wake and disarms the window: the memory they described is gone. */
@@ -84,15 +83,15 @@ export class WakeQueue {
 
   #arm(delayMs: number): void {
     if (this.#timer !== undefined) return;
-    this.#timer = this.#options.schedule(() => {
+    this.#timer = this.#options.clock.schedule(delayMs, () => {
       this.#timer = undefined;
       this.#flush();
-    }, delayMs);
+    });
   }
 
   #disarm(): void {
     if (this.#timer === undefined) return;
-    this.#options.cancel(this.#timer);
+    this.#timer.dispose();
     this.#timer = undefined;
   }
 

--- a/packages/brain/src/wakes.ts
+++ b/packages/brain/src/wakes.ts
@@ -95,9 +95,7 @@ export class WakeCapture {
     this.#queue = new WakeQueue({
       coalesceMs: BRAIN_DEFAULTS.WAKE_COALESCE_MS,
       capacity: BRAIN_DEFAULTS.PENDING_WAKE_CAPACITY,
-      now: this.#seam.now,
-      schedule: this.#seam.schedule,
-      cancel: this.#seam.cancel,
+      clock: this.#seam.clock,
       quietUntil: options.quietUntil,
       flush: (events) => this.#flush(events),
     });
@@ -158,7 +156,7 @@ export class WakeCapture {
     const generation = this.#seam.generation();
     if (!generation) return this.#seam.ready().then(() => this.rosterLook());
     const roster = this.#options.roster();
-    const looks = this.#ownLooks(roster, generation.captureCursors, this.#seam.now());
+    const looks = this.#ownLooks(roster, generation.captureCursors, this.#seam.clock.now());
     // The look is captured before anything opens, like a hook: what each
     // session gained stands in the inbox with its cursor, and the turn that
     // follows — now, or the next one if the model is quiet or a turn is in
@@ -229,7 +227,7 @@ export class WakeCapture {
       }>();
       const entries: BrainObservationEntry[] = [];
       let heardFirstHand = false;
-      const now = this.#seam.now();
+      const now = this.#seam.clock.now();
       for (const event of fresh) {
         let read = reads.get(event.identity.providerId, event.identity.providerSessionId);
         if (!read) {

--- a/packages/host/src/brain/conversation-deletion.test.ts
+++ b/packages/host/src/brain/conversation-deletion.test.ts
@@ -24,6 +24,7 @@ import {
   MAIN_CONVERSATION_NAME,
   MAIN_SESSION_KEY,
   type ModelResponse,
+  systemClock,
   type TranscriptEvent,
 } from "@sidecar/runtime/vocabulary";
 import {
@@ -150,7 +151,7 @@ function composed(t: TestContext) {
       store,
       createRunId: () => `run-${++ids}`,
       report: () => undefined,
-      now: () => clock,
+      clock: { ...systemClock, now: () => clock },
     });
     followers.set(
       agent,

--- a/packages/host/src/brain/wiring-children.test.ts
+++ b/packages/host/src/brain/wiring-children.test.ts
@@ -186,7 +186,7 @@ function composed(
   const clock = new FakeClock();
   const workspace = temporaryDirectory(t, "luke-children-");
   const wiring = wireBrain({
-    childTimers: { schedule: clock.schedule, cancel: clock.cancel },
+    childClock: clock,
     repositoryFor: (sessionKey) => {
       let repository = repositories.get(sessionKey);
       if (!repository) {

--- a/packages/host/src/brain/wiring-children.ts
+++ b/packages/host/src/brain/wiring-children.ts
@@ -1,6 +1,6 @@
 import type { BrainAgent, BrainChildAccess } from "@sidecar/brain";
 import { ChildRunService, type ChildStore } from "@sidecar/runtime";
-import type { ModelAdapter, ScheduledTimer } from "@sidecar/runtime/vocabulary";
+import type { Clock, ModelAdapter } from "@sidecar/runtime/vocabulary";
 import {
   CHILD_RUN_STATUS,
   type ChildRunRecord,
@@ -33,11 +33,8 @@ export interface ChildWiringDependencies {
   conversationLines: (sessionKey: SessionKey) => readonly ConversationEntry[];
   /** Where child records and completions stand between launches. */
   childStore: () => ChildStore;
-  /** The clock the child service's delivery retries and archive delays run on; absent means the process's own timers. */
-  childTimers?: {
-    schedule: (callback: () => void, delayMs: number) => ScheduledTimer;
-    cancel: (timer: ScheduledTimer) => void;
-  };
+  /** The clock the child service's delivery retries and archive delays run on; absent means the process's own. */
+  childClock?: Clock;
   createId: () => string;
   report: (message: string) => void;
   /** The model adapter the credential policy built, or nothing when it built none. */
@@ -90,7 +87,7 @@ export function wireChildren(
     store: dependencies.childStore(),
     createId: dependencies.createId,
     report: dependencies.report,
-    ...(dependencies.childTimers ?? undefined),
+    clock: dependencies.childClock,
     executor: {
       start: async (record, fork) => {
         const agent = await openChild(record, fork);

--- a/packages/host/src/device-registration.test.ts
+++ b/packages/host/src/device-registration.test.ts
@@ -61,8 +61,8 @@ function registration(
     client,
     state: deviceStateFile(() => directory),
     mintInstallationId: mint,
-    schedule: clock.schedule,
-    cancel: clock.cancel,
+    schedule: clock.scheduleTimer,
+    cancel: clock.cancelTimer,
   });
 }
 
@@ -157,11 +157,11 @@ test("each beat moves last seen, and a row the service no longer holds is regist
   const subject = registration(directory, client, clock);
   await subject.start();
 
-  await clock.advance(clock.now + DEVICE_HEARTBEAT_INTERVAL_MS);
+  await clock.advance(clock.instant + DEVICE_HEARTBEAT_INTERVAL_MS);
   assert.deepEqual(calls.at(-1), { kind: "heartbeat", body: { deviceId: DEVICE_ID } });
   assert.equal(clock.armed(), 1);
 
-  await clock.advance(clock.now + DEVICE_HEARTBEAT_INTERVAL_MS);
+  await clock.advance(clock.instant + DEVICE_HEARTBEAT_INTERVAL_MS);
   assert.deepEqual(
     calls.map((call) => call.kind),
     ["register", "heartbeat", "heartbeat", "register"],
@@ -182,7 +182,7 @@ test("a registration that did not land is tried again by the next beat, and a la
   assert.deepEqual(storedState(directory), { installationId: INSTALLATION_ID.toLowerCase() });
 
   answer = { deviceId: DEVICE_ID };
-  await clock.advance(clock.now + DEVICE_HEARTBEAT_INTERVAL_MS);
+  await clock.advance(clock.instant + DEVICE_HEARTBEAT_INTERVAL_MS);
   assert.deepEqual(
     calls.map((call) => call.kind),
     ["register", "register"],
@@ -200,7 +200,7 @@ test("a registration that did not land is tried again by the next beat, and a la
   };
   const racing = registration(directory, slow, clock);
   await racing.start();
-  const beat = clock.advance(clock.now + DEVICE_HEARTBEAT_INTERVAL_MS);
+  const beat = clock.advance(clock.instant + DEVICE_HEARTBEAT_INTERVAL_MS);
   await racing.stop({ forget: false });
   release?.();
   await beat;

--- a/packages/host/src/testing/brain-harness.ts
+++ b/packages/host/src/testing/brain-harness.ts
@@ -22,7 +22,7 @@ import {
   fakeBrainStateRepository,
 } from "@sidecar/brain/testing";
 import { drainMicrotasks } from "@sidecar/runtime/testing";
-import type { ModelResponse } from "@sidecar/runtime/vocabulary";
+import { type ModelResponse, systemClock } from "@sidecar/runtime/vocabulary";
 import {
   appendConversationThreadEntry,
   CONVERSATION_ENTRY_KIND,
@@ -191,16 +191,7 @@ export function brainHarness() {
       store,
       createRunId: () => `run-${++ids}`,
       report: () => {},
-      now: () => NOW,
-      // A run left in flight at a test's end must not hold the process open:
-      // its deadline timers are unreferenced, as the test's own would be.
-      schedule: (callback, delayMs) => {
-        const timer = setTimeout(callback, delayMs);
-        timer.unref();
-        return timer;
-      },
-      // SAFETY: the handle is what `schedule` above returned, which is always a `setTimeout` timer.
-      cancel: (timer) => clearTimeout(timer as ReturnType<typeof setTimeout>),
+      clock: { ...systemClock, now: () => NOW },
     });
   };
   return {

--- a/packages/host/src/voice/speech-arbiter.test.ts
+++ b/packages/host/src/voice/speech-arbiter.test.ts
@@ -31,7 +31,7 @@ function harness(now = 1_000): Harness {
   const traces: SpeechTraceRecord[] = [];
   let id = 0;
   const arbiter = new SpeechArbiter({
-    now: () => clock.now,
+    now: () => clock.instant,
     nextId: () => {
       id += 1;
       return `id-${id}`;
@@ -125,7 +125,7 @@ test("quiet beginning holds every pending request; quiet ending releases the bea
   assert.equal(arbiter.next(), undefined);
 
   // The meeting runs long past the news window; a held request does not age.
-  clock.now += SPOKEN_NOTICE_MAX_AGE_MS * 3;
+  clock.instant += SPOKEN_NOTICE_MAX_AGE_MS * 3;
   arbiter.setQuiet(false);
   assert.equal(arbiter.heldBriefingCount, 1, "briefings wait for the brain, not the mouth");
   // The beat is released on a fresh clock: it is offered, not aged out, and
@@ -133,8 +133,8 @@ test("quiet beginning holds every pending request; quiet ending releases the bea
   const offer = arbiter.next();
   assert.ok(offer);
   assert.equal(offer.turn.kind, CALENDAR_ONBOARDING_SPEECH_KIND);
-  assert.equal(offer.turn.decidedAt, clock.now);
-  assert.equal(offer.speakBy, clock.now + SPOKEN_NOTICE_MAX_AGE_MS);
+  assert.equal(offer.turn.decidedAt, clock.instant);
+  assert.equal(offer.speakBy, clock.instant + SPOKEN_NOTICE_MAX_AGE_MS);
 });
 
 test("held briefings are taken in order with briefing and timestamp intact, once", () => {
@@ -187,7 +187,7 @@ test("offers go out FIFO across kinds, each with its deadline from its own decis
   const { arbiter, clock } = harness(5_000);
   requestBriefing(arbiter, "news", 4_000);
   arbiter.request({ kind: ARRIVAL_SPEECH_KIND });
-  clock.now = 6_000;
+  clock.instant = 6_000;
   arbiter.request({ kind: CALENDAR_ONBOARDING_SPEECH_KIND });
 
   const first = arbiter.next();
@@ -220,7 +220,7 @@ test("next ages out unheld requests, spends a stale beat, and never ages a held 
   arbiter.setQuiet(false);
   requestBriefing(arbiter, "old", 5_000);
   arbiter.request({ kind: ARRIVAL_SPEECH_KIND });
-  clock.now = 5_000 + SPOKEN_NOTICE_MAX_AGE_MS + 1;
+  clock.instant = 5_000 + SPOKEN_NOTICE_MAX_AGE_MS + 1;
 
   // Nothing arrives at the mouth stale: the aged briefing is settled here,
   // the beat requested later still stands, and the held briefing waits out
@@ -235,7 +235,7 @@ test("next ages out unheld requests, spends a stale beat, and never ages a held 
   arbiter.settle(offer.id, SPEECH_OUTCOME.HELD);
   arbiter.setQuiet(true);
   arbiter.setQuiet(false);
-  clock.now += SPOKEN_NOTICE_MAX_AGE_MS + 1;
+  clock.instant += SPOKEN_NOTICE_MAX_AGE_MS + 1;
   assert.equal(arbiter.next(), undefined);
   arbiter.request({ kind: ARRIVAL_SPEECH_KIND });
   assert.equal(arbiter.pendingCount, 1, "only the held briefing stands; the beat is spent");
@@ -357,16 +357,16 @@ test("retract removes a pending beat silently and names an offered one for withd
 test("an offer past its deadline with no settle is reclaimed stale and the head re-offered", () => {
   const { arbiter, clock, traces } = harness(1_000);
   requestBriefing(arbiter, "lost", 1_000);
-  clock.now = 1_500;
+  clock.instant = 1_500;
   requestBriefing(arbiter, "next", 1_500);
   const lost = arbiter.next();
   assert.ok(lost);
   // The renderer reloaded: no settle ever comes. Before the deadline, the
   // arbiter waits on it.
-  clock.now = lost.speakBy;
+  clock.instant = lost.speakBy;
   assert.equal(arbiter.next(), undefined);
 
-  clock.now = lost.speakBy + 1;
+  clock.instant = lost.speakBy + 1;
   const reoffered = arbiter.next();
   assert.ok(reoffered && reoffered.turn.kind === BRIEFING_SPEECH_KIND);
   assert.equal(reoffered.turn.briefing, "next");
@@ -389,7 +389,7 @@ test("every trace record carries a kind, a decision, and a count, and never the 
   arbiter.settle(offer.id, SPEECH_OUTCOME.SPOKEN);
   arbiter.setQuiet(true);
   arbiter.setQuiet(false);
-  clock.now += SPOKEN_NOTICE_MAX_AGE_MS + 1;
+  clock.instant += SPOKEN_NOTICE_MAX_AGE_MS + 1;
   arbiter.next();
   arbiter.dropBriefings();
 
@@ -426,7 +426,7 @@ test("withdrawing briefings takes the queued, the held, and the offered alike, a
   // The mouth's late report on the withdrawn offer is nobody's.
   assert.equal(arbiter.settle(offer.id, SPEECH_OUTCOME.SPOKEN), undefined);
   arbiter.setQuiet(false);
-  clock.now += 1;
+  clock.instant += 1;
   assert.equal(offeredWords(arbiter), ARRIVAL_SPEECH_KIND);
   // Nothing to withdraw answers nothing, and a beat is never a briefing.
   assert.equal(arbiter.withdrawBriefings(), undefined);
@@ -462,5 +462,5 @@ test("reclaiming takes the outstanding offer back to the head unspoken, so the n
   arbiter.settle(again?.id ?? "", SPEECH_OUTCOME.SPOKEN);
   arbiter.reclaimOffer();
   assert.equal(arbiter.pendingCount, 1);
-  assert.equal(clock.now, 1_000);
+  assert.equal(clock.instant, 1_000);
 });

--- a/packages/providers/src/shared/spool-watcher.test.ts
+++ b/packages/providers/src/shared/spool-watcher.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test, { type TestContext } from "node:test";
+import { drainMicrotasks, FakeClock } from "@sidecar/runtime/testing";
 import { HOOK_EVENT } from "./hook-merge.js";
 import {
   type ObservedSpoolEvent,
@@ -17,53 +18,11 @@ const EVENTS: readonly SpoolEvent[] = Object.values(HOOK_EVENT);
 const DEBOUNCE_MS = 500;
 const REARM_INTERVAL_MS = 5000;
 
-type Timer = ReturnType<typeof setTimeout>;
+/** The clock's own reading is relative here: every delay the watcher asks for is a fixed interval. */
+const advance = (clock: FakeClock, ms: number): Promise<void> => clock.advance(clock.instant + ms);
 
-interface FakeClock {
-  schedule: (callback: () => void, delayMs: number) => Timer;
-  cancel: (timer: Timer) => void;
-  advance: (ms: number) => Promise<void>;
-  pending: () => number[];
-}
-
-function fakeClock(): FakeClock {
-  let nowMs = 0;
-  let nextId = 1;
-  const timers = new Map<Timer, { dueMs: number; callback: () => void }>();
-  return {
-    schedule: (callback, delayMs) => {
-      // SAFETY: the watcher only hands the timer back to `cancel`, so any
-      // distinct value serves as its handle.
-      const timer = nextId++ as unknown as Timer;
-      timers.set(timer, { dueMs: nowMs + delayMs, callback });
-      return timer;
-    },
-    cancel: (timer) => {
-      timers.delete(timer);
-    },
-    advance: async (ms) => {
-      const untilMs = nowMs + ms;
-      for (;;) {
-        const due = [...timers.entries()]
-          .filter(([, entry]) => entry.dueMs <= untilMs)
-          .sort(([, a], [, b]) => a.dueMs - b.dueMs)[0];
-        if (!due) break;
-        const [timer, entry] = due;
-        timers.delete(timer);
-        nowMs = entry.dueMs;
-        entry.callback();
-        await settle();
-      }
-      nowMs = untilMs;
-    },
-    pending: () => [...timers.values()].map((entry) => entry.dueMs - nowMs),
-  };
-}
-
-/** Gives the reads a fired timer started a chance to finish before asserting. */
-async function settle(): Promise<void> {
-  for (let i = 0; i < 20; i += 1) await new Promise<void>((resolve) => setImmediate(resolve));
-}
+const pending = (clock: FakeClock): number[] =>
+  [...clock.timers.values()].map((timer) => timer.at - clock.instant);
 
 async function waitFor(condition: () => boolean): Promise<void> {
   const deadline = Date.now() + 5000;
@@ -149,8 +108,7 @@ function standWatcher(
       batches.push(events);
     },
     watch: watcher.watch,
-    schedule: clock.schedule,
-    cancel: clock.cancel,
+    clock,
   });
   t.after(() => handle.close());
   return { handle, batches };
@@ -159,7 +117,7 @@ function standWatcher(
 test("one debounce window reports every readable spool file it saw as one batch", async (t) => {
   const spoolDirectory = await temporarySpool(t);
   const watcher = fakeWatcher();
-  const clock = fakeClock();
+  const clock = new FakeClock(0);
   const { batches } = standWatcher(t, spoolDirectory, watcher, clock);
   assert.deepEqual(watcher.directories, [spoolDirectory]);
 
@@ -179,9 +137,9 @@ test("one debounce window reports every readable spool file it saw as one batch"
   watcher.emit("rename", "../escape.json");
   watcher.emit("rename", null);
 
-  await clock.advance(DEBOUNCE_MS - 1);
+  await advance(clock, DEBOUNCE_MS - 1);
   assert.equal(batches.length, 0);
-  await clock.advance(1);
+  await advance(clock, 1);
   await waitFor(() => batches.length === 1);
 
   const batch = batches[0] ?? [];
@@ -199,15 +157,15 @@ test("one debounce window reports every readable spool file it saw as one batch"
 test("the batch window opens at the first event and is not extended by later ones", async (t) => {
   const spoolDirectory = await temporarySpool(t);
   const watcher = fakeWatcher();
-  const clock = fakeClock();
+  const clock = new FakeClock(0);
   const { batches } = standWatcher(t, spoolDirectory, watcher, clock);
 
   await writeSpoolFile(spoolDirectory, "first.json", '{"event":"session-start"}');
   await writeSpoolFile(spoolDirectory, "second.json", '{"event":"stop"}');
   watcher.emit("rename", "first.json");
-  await clock.advance(DEBOUNCE_MS - 100);
+  await advance(clock, DEBOUNCE_MS - 100);
   watcher.emit("rename", "second.json");
-  await clock.advance(100);
+  await advance(clock, 100);
   await waitFor(() => batches.length === 1);
   assert.deepEqual(
     batches.map((batch) => batch.map((event) => event.providerSessionId)),
@@ -215,7 +173,7 @@ test("the batch window opens at the first event and is not extended by later one
   );
 
   watcher.emit("rename", "second.json");
-  await clock.advance(DEBOUNCE_MS);
+  await advance(clock, DEBOUNCE_MS);
   await waitFor(() => batches.length === 2);
   assert.deepEqual(
     batches.map((batch) => batch.map((event) => event.providerSessionId)),
@@ -226,11 +184,11 @@ test("the batch window opens at the first event and is not extended by later one
 test("a batch whose files all fail to read reports nothing", async (t) => {
   const spoolDirectory = await temporarySpool(t);
   const watcher = fakeWatcher();
-  const clock = fakeClock();
+  const clock = new FakeClock(0);
   const { batches } = standWatcher(t, spoolDirectory, watcher, clock);
 
   watcher.emit("rename", "gone.json");
-  await clock.advance(DEBOUNCE_MS);
+  await advance(clock, DEBOUNCE_MS);
   assert.equal(batches.length, 0);
 });
 
@@ -238,23 +196,23 @@ test("a spool directory that does not exist yet is watched once it appears", asy
   const spoolDirectory = path.join(await temporarySpool(t), "events");
   const watcher = fakeWatcher();
   watcher.refuse(missingDirectoryError(), missingDirectoryError());
-  const clock = fakeClock();
+  const clock = new FakeClock(0);
   const { batches } = standWatcher(t, spoolDirectory, watcher, clock);
   assert.deepEqual(watcher.directories, []);
-  assert.deepEqual(clock.pending(), [REARM_INTERVAL_MS]);
+  assert.deepEqual(pending(clock), [REARM_INTERVAL_MS]);
 
-  await clock.advance(REARM_INTERVAL_MS);
+  await advance(clock, REARM_INTERVAL_MS);
   assert.deepEqual(watcher.directories, []);
-  assert.deepEqual(clock.pending(), [REARM_INTERVAL_MS]);
+  assert.deepEqual(pending(clock), [REARM_INTERVAL_MS]);
 
   await fs.mkdir(spoolDirectory);
-  await clock.advance(REARM_INTERVAL_MS);
+  await advance(clock, REARM_INTERVAL_MS);
   assert.deepEqual(watcher.directories, [spoolDirectory]);
-  assert.deepEqual(clock.pending(), []);
+  assert.deepEqual(pending(clock), []);
 
   await writeSpoolFile(spoolDirectory, "late.json", '{"event":"stop"}');
   watcher.emit("rename", "late.json");
-  await clock.advance(DEBOUNCE_MS);
+  await advance(clock, DEBOUNCE_MS);
   await waitFor(() => batches.length === 1);
   assert.deepEqual(
     batches.map((batch) => batch.map((event) => event.providerSessionId)),
@@ -265,22 +223,22 @@ test("a spool directory that does not exist yet is watched once it appears", asy
 test("a watch that fails is closed and stood up again after the rearm interval", async (t) => {
   const spoolDirectory = await temporarySpool(t);
   const watcher = fakeWatcher();
-  const clock = fakeClock();
+  const clock = new FakeClock(0);
   const { batches } = standWatcher(t, spoolDirectory, watcher, clock);
 
   watcher.fail(new Error("watch failed"));
   assert.equal(watcher.closedCount(), 1);
-  assert.deepEqual(clock.pending(), [REARM_INTERVAL_MS]);
+  assert.deepEqual(pending(clock), [REARM_INTERVAL_MS]);
   watcher.fail(new Error("watch failed again"));
   assert.equal(watcher.closedCount(), 1);
-  assert.deepEqual(clock.pending(), [REARM_INTERVAL_MS]);
+  assert.deepEqual(pending(clock), [REARM_INTERVAL_MS]);
 
-  await clock.advance(REARM_INTERVAL_MS);
+  await advance(clock, REARM_INTERVAL_MS);
   assert.deepEqual(watcher.directories, [spoolDirectory, spoolDirectory]);
 
   await writeSpoolFile(spoolDirectory, "after.json", '{"event":"notification"}');
   watcher.emit("rename", "after.json");
-  await clock.advance(DEBOUNCE_MS);
+  await advance(clock, DEBOUNCE_MS);
   await waitFor(() => batches.length === 1);
   assert.deepEqual(
     batches.map((batch) => batch.map((event) => event.event)),
@@ -291,18 +249,18 @@ test("a watch that fails is closed and stood up again after the rearm interval",
 test("closing stops the watch, drops pending ids, and cancels the rearm", async (t) => {
   const spoolDirectory = await temporarySpool(t);
   const watcher = fakeWatcher();
-  const clock = fakeClock();
+  const clock = new FakeClock(0);
   const { handle, batches } = standWatcher(t, spoolDirectory, watcher, clock);
 
   await writeSpoolFile(spoolDirectory, "pending.json", '{"event":"stop"}');
   watcher.emit("rename", "pending.json");
-  assert.deepEqual(clock.pending(), [DEBOUNCE_MS]);
+  assert.deepEqual(pending(clock), [DEBOUNCE_MS]);
   handle.close();
   assert.equal(watcher.closedCount(), 1);
-  assert.deepEqual(clock.pending(), []);
+  assert.deepEqual(pending(clock), []);
 
   watcher.emit("rename", "pending.json");
-  await clock.advance(DEBOUNCE_MS + REARM_INTERVAL_MS);
+  await advance(clock, DEBOUNCE_MS + REARM_INTERVAL_MS);
   assert.equal(batches.length, 0);
   assert.deepEqual(watcher.directories, [spoolDirectory]);
   handle.close();
@@ -313,20 +271,20 @@ test("closing while a directory is still awaited stops the retries", async (t) =
   const spoolDirectory = path.join(await temporarySpool(t), "events");
   const watcher = fakeWatcher();
   watcher.refuse(missingDirectoryError());
-  const clock = fakeClock();
+  const clock = new FakeClock(0);
   const { handle } = standWatcher(t, spoolDirectory, watcher, clock);
-  assert.deepEqual(clock.pending(), [REARM_INTERVAL_MS]);
+  assert.deepEqual(pending(clock), [REARM_INTERVAL_MS]);
   handle.close();
-  assert.deepEqual(clock.pending(), []);
+  assert.deepEqual(pending(clock), []);
   await fs.mkdir(spoolDirectory);
-  await clock.advance(REARM_INTERVAL_MS);
+  await advance(clock, REARM_INTERVAL_MS);
   assert.deepEqual(watcher.directories, []);
 });
 
 test("a batch read after close is not reported", async (t) => {
   const spoolDirectory = await temporarySpool(t);
   const watcher = fakeWatcher();
-  const clock = fakeClock();
+  const clock = new FakeClock(0);
   let closeDuringRead: () => void = () => undefined;
   const batches: (readonly ObservedSpoolEvent<SpoolEvent>[])[] = [];
   const handle = watchObservationSpool({
@@ -336,25 +294,27 @@ test("a batch read after close is not reported", async (t) => {
       batches.push(events);
     },
     watch: watcher.watch,
-    schedule: (callback, delayMs) =>
-      clock.schedule(() => {
-        callback();
-        closeDuringRead();
-      }, delayMs),
-    cancel: clock.cancel,
+    clock: {
+      now: clock.now,
+      schedule: (delayMs, run) =>
+        clock.schedule(delayMs, () => {
+          run();
+          closeDuringRead();
+        }),
+    },
   });
   closeDuringRead = () => handle.close();
 
   await writeSpoolFile(spoolDirectory, "racing.json", '{"event":"stop"}');
   watcher.emit("rename", "racing.json");
-  await clock.advance(DEBOUNCE_MS);
+  await advance(clock, DEBOUNCE_MS);
   assert.equal(batches.length, 0);
 });
 
 test("a listener that throws loses its own batch and the next batch is still delivered", async (t) => {
   const spoolDirectory = await temporarySpool(t);
   const watcher = fakeWatcher();
-  const clock = fakeClock();
+  const clock = new FakeClock(0);
   const batches: (readonly ObservedSpoolEvent<SpoolEvent>[])[] = [];
   let throwOnce = true;
   const handle = watchObservationSpool({
@@ -368,19 +328,18 @@ test("a listener that throws loses its own batch and the next batch is still del
       batches.push(events);
     },
     watch: watcher.watch,
-    schedule: clock.schedule,
-    cancel: clock.cancel,
+    clock,
   });
 
   await writeSpoolFile(spoolDirectory, "first.json", '{"event":"stop"}');
   watcher.emit("rename", "first.json");
-  await clock.advance(DEBOUNCE_MS);
-  await settle();
+  await advance(clock, DEBOUNCE_MS);
+  await drainMicrotasks(20);
   assert.equal(batches.length, 0);
 
   await writeSpoolFile(spoolDirectory, "second.json", '{"event":"prompt"}');
   watcher.emit("rename", "second.json");
-  await clock.advance(DEBOUNCE_MS);
+  await advance(clock, DEBOUNCE_MS);
   await waitFor(() => batches.length === 1);
   assert.deepEqual(
     batches[0]?.map(({ providerSessionId }) => providerSessionId),
@@ -390,7 +349,7 @@ test("a listener that throws loses its own batch and the next batch is still del
   handle.close();
   await writeSpoolFile(spoolDirectory, "third.json", '{"event":"stop"}');
   watcher.emit("rename", "third.json");
-  await clock.advance(DEBOUNCE_MS);
-  await settle();
+  await advance(clock, DEBOUNCE_MS);
+  await drainMicrotasks(20);
   assert.equal(batches.length, 1);
 });

--- a/packages/providers/src/shared/spool-watcher.ts
+++ b/packages/providers/src/shared/spool-watcher.ts
@@ -1,4 +1,6 @@
 import fs from "node:fs";
+import { type Clock, systemClock } from "@sidecar/runtime/vocabulary";
+import type { IDisposable } from "@sidecar/wire";
 import { type ObservedHookEvent, readObservationHookEvent } from "./hook-merge.js";
 
 /**
@@ -33,8 +35,6 @@ const DEFAULT_DEBOUNCE_MS = 500;
  */
 const DEFAULT_REARM_INTERVAL_MS = 5000;
 
-type Timer = ReturnType<typeof setTimeout>;
-
 /** The narrow slice of `fs.watch` the watcher relies on, so a test can stand in. */
 export interface SpoolWatchHandle {
   on(event: "error", listener: (error: Error) => void): void;
@@ -62,8 +62,7 @@ export interface ObservationSpoolWatcherOptions<Event extends string> {
   events: readonly Event[];
   onEvents: (events: readonly ObservedSpoolEvent<Event>[]) => void;
   watch?: SpoolWatch;
-  schedule?: (callback: () => void, delayMs: number) => Timer;
-  cancel?: (timer: Timer) => void;
+  clock?: Clock;
 }
 
 export interface ObservationSpoolWatcher {
@@ -80,12 +79,11 @@ class SpoolWatcher<Event extends string> implements ObservationSpoolWatcher {
   readonly #events: readonly Event[];
   readonly #onEvents: (events: readonly ObservedSpoolEvent<Event>[]) => void;
   readonly #watch: SpoolWatch;
-  readonly #schedule: (callback: () => void, delayMs: number) => Timer;
-  readonly #cancel: (timer: Timer) => void;
+  readonly #clock: Clock;
 
   readonly #pendingIds = new Set<string>();
-  #debounceTimer: Timer | undefined;
-  #rearmTimer: Timer | undefined;
+  #debounceTimer: IDisposable | undefined;
+  #rearmTimer: IDisposable | undefined;
   #handle: SpoolWatchHandle | undefined;
   #reads: Promise<void> = Promise.resolve();
   #closed = false;
@@ -95,16 +93,15 @@ class SpoolWatcher<Event extends string> implements ObservationSpoolWatcher {
     this.#events = options.events;
     this.#onEvents = options.onEvents;
     this.#watch = options.watch ?? fs.watch;
-    this.#schedule = options.schedule ?? setTimeout;
-    this.#cancel = options.cancel ?? clearTimeout;
+    this.#clock = options.clock ?? systemClock;
     this.#arm();
   }
 
   close(): void {
     this.#closed = true;
-    if (this.#debounceTimer !== undefined) this.#cancel(this.#debounceTimer);
+    this.#debounceTimer?.dispose();
     this.#debounceTimer = undefined;
-    if (this.#rearmTimer !== undefined) this.#cancel(this.#rearmTimer);
+    this.#rearmTimer?.dispose();
     this.#rearmTimer = undefined;
     this.#pendingIds.clear();
     this.#dropHandle();
@@ -144,10 +141,10 @@ class SpoolWatcher<Event extends string> implements ObservationSpoolWatcher {
 
   #scheduleRearm(): void {
     if (this.#closed || this.#rearmTimer !== undefined) return;
-    this.#rearmTimer = this.#schedule(() => {
+    this.#rearmTimer = this.#clock.schedule(DEFAULT_REARM_INTERVAL_MS, () => {
       this.#rearmTimer = undefined;
       this.#arm();
-    }, DEFAULT_REARM_INTERVAL_MS);
+    });
   }
 
   /**
@@ -160,12 +157,12 @@ class SpoolWatcher<Event extends string> implements ObservationSpoolWatcher {
     if (providerSessionId === undefined) return;
     this.#pendingIds.add(providerSessionId);
     if (this.#debounceTimer !== undefined) return;
-    this.#debounceTimer = this.#schedule(() => {
+    this.#debounceTimer = this.#clock.schedule(DEFAULT_DEBOUNCE_MS, () => {
       this.#debounceTimer = undefined;
       const ids = [...this.#pendingIds];
       this.#pendingIds.clear();
       this.#reads = this.#reads.then(() => this.#report(ids)).catch(() => undefined);
-    }, DEFAULT_DEBOUNCE_MS);
+    });
   }
 
   /**

--- a/packages/runtime/src/children.test.ts
+++ b/packages/runtime/src/children.test.ts
@@ -25,7 +25,7 @@ import {
   type SessionKey,
   threadSessionKey,
 } from "./identifiers.js";
-import type { ScheduledTimer } from "./timers.js";
+import { drainMicrotasks, FakeClock } from "./testing/index.js";
 
 /**
  * The child service over a synthetic executor and deliverer: the limits, the
@@ -35,46 +35,6 @@ import type { ScheduledTimer } from "./timers.js";
  */
 
 const NOW = 1_800_000_000_000;
-
-class FakeClock {
-  now = NOW;
-  readonly timers = new Map<ScheduledTimer, { callback: () => void; at: number }>();
-  schedule = (callback: () => void, delayMs: number): ScheduledTimer => {
-    const handle: ScheduledTimer = {};
-    this.timers.set(handle, { callback, at: this.now + delayMs });
-    return handle;
-  };
-  cancel = (timer: ScheduledTimer): void => {
-    this.timers.delete(timer);
-  };
-  /** Advances to `at`, firing every timer due on the way, in order. */
-  async advanceTo(at: number): Promise<void> {
-    for (;;) {
-      const due = [...this.timers.entries()]
-        .filter(([, timer]) => timer.at <= at)
-        .sort(([, a], [, b]) => a.at - b.at)[0];
-      if (!due) break;
-      const [handle, timer] = due;
-      this.timers.delete(handle);
-      this.now = Math.max(this.now, timer.at);
-      timer.callback();
-      await settle();
-    }
-    this.now = Math.max(this.now, at);
-  }
-}
-
-function settle(): Promise<void> {
-  return new Promise((resolve) => {
-    let ticks = 0;
-    const tick = () => {
-      ticks += 1;
-      if (ticks > 40) resolve();
-      else setImmediate(tick);
-    };
-    tick();
-  });
-}
 
 class MemoryChildStore implements ChildStore {
   readonly children = new Map<string, ChildRunRecord>();
@@ -185,9 +145,7 @@ function harness(overrides: Partial<ConstructorParameters<typeof ChildRunService
     executor,
     deliverer,
     createId: () => `id-${++ids}`,
-    now: () => clock.now,
-    schedule: clock.schedule,
-    cancel: clock.cancel,
+    clock,
     report: (message) => reports.push(message),
     ...overrides,
   });
@@ -222,10 +180,10 @@ test("a spawn is recorded before its receipt and started after it, and the recei
   assert.ok(stored);
   assert.equal(stored.completionDestination, MAIN_SESSION_KEY);
   assert.equal(stored.timeoutMs, CHILD_DEFAULTS.TIMEOUT_MS);
-  await settle();
+  await drainMicrotasks(40);
   assert.equal(executor.started.length, 1);
   assert.equal(store.children.get("id-1")?.status, CHILD_RUN_STATUS.RUNNING);
-  assert.equal(store.children.get("id-1")?.startedAt, clock.now);
+  assert.equal(store.children.get("id-1")?.startedAt, clock.instant);
 });
 
 test("a spawn the store refuses starts nothing", async () => {
@@ -233,7 +191,7 @@ test("a spawn the store refuses starts nothing", async () => {
   store.refuse = true;
   const outcome = await service.spawn(request());
   assert.deepEqual(outcome, { accepted: false, reason: CHILD_SPAWN_REFUSAL.PERSISTENCE });
-  await settle();
+  await drainMicrotasks(40);
   assert.equal(executor.started.length, 0);
 });
 
@@ -262,7 +220,7 @@ test("children start isolated by default, thread-bound forks inherit, and a fork
   assert.equal(capped.receipt.context, CHILD_CONTEXT_MODE.ISOLATED);
   assert.match(capped.receipt.contextNote ?? "", /fork cap/);
   assert.equal(empty.receipt.context, CHILD_CONTEXT_MODE.ISOLATED);
-  await settle();
+  await drainMicrotasks(40);
   assert.deepEqual(executor.started[1]?.fork, items);
   assert.equal(executor.started[2]?.fork, undefined);
   const other = await service.spawn(
@@ -298,20 +256,23 @@ test("a completion is persisted before delivery, delivered to the requesting con
   const thread = threadSessionKey("private");
   const outcome = await service.spawn(request(thread));
   assert.ok(outcome.accepted);
-  await settle();
+  await drainMicrotasks(40);
   deliverer.accept = false;
   executor.started[0]?.end({ status: CHILD_RUN_STATUS.COMPLETED, resultText: "all green" });
-  await settle();
+  await drainMicrotasks(40);
   const completion = store.completions.get("completion:id-1");
   assert.ok(completion);
   assert.equal(completion.destination, thread);
   assert.equal(completion.resultText, "all green");
   assert.equal(completion.delivery, COMPLETION_DELIVERY_STATUS.PENDING);
   assert.equal(completion.attempts, 1);
-  assert.equal(completion.nextAttemptAt, clock.now + CHILD_DEFAULTS.DELIVERY_INITIAL_BACKOFF_MS);
+  assert.equal(
+    completion.nextAttemptAt,
+    clock.instant + CHILD_DEFAULTS.DELIVERY_INITIAL_BACKOFF_MS,
+  );
   assert.equal(store.children.get("id-1")?.status, CHILD_RUN_STATUS.COMPLETED);
   deliverer.accept = true;
-  await clock.advanceTo(clock.now + CHILD_DEFAULTS.DELIVERY_INITIAL_BACKOFF_MS);
+  await clock.advance(clock.instant + CHILD_DEFAULTS.DELIVERY_INITIAL_BACKOFF_MS);
   assert.equal(
     store.completions.get("completion:id-1")?.delivery,
     COMPLETION_DELIVERY_STATUS.DELIVERED,
@@ -321,7 +282,7 @@ test("a completion is persisted before delivery, delivered to the requesting con
     [thread, thread],
   );
   assert.deepEqual(executor.archived, []);
-  await clock.advanceTo(NOW + CHILD_DEFAULTS.ARCHIVE_AFTER_MS + 1);
+  await clock.advance(NOW + CHILD_DEFAULTS.ARCHIVE_AFTER_MS + 1);
   assert.deepEqual(executor.archived, ["id-1"]);
   assert.ok(store.children.get("id-1")?.archivedAt);
 });
@@ -338,10 +299,10 @@ test("blocked delivery backs off from 15 seconds to five minutes, blocks after 3
   for (let index = 0; index < CHILD_DEFAULTS.BLOCKED_REFUSAL; index += 1) {
     assert.ok((await service.spawn(request())).accepted);
   }
-  await settle();
+  await drainMicrotasks(40);
   for (const started of executor.started) started.end({ status: CHILD_RUN_STATUS.COMPLETED });
-  await settle();
-  await clock.advanceTo(NOW + CHILD_DEFAULTS.DELIVERY_WINDOW_MS + 1);
+  await drainMicrotasks(40);
+  await clock.advance(NOW + CHILD_DEFAULTS.DELIVERY_WINDOW_MS + 1);
   const blocked = [...store.completions.values()].filter(
     (completion) => completion.delivery === COMPLETION_DELIVERY_STATUS.BLOCKED,
   );
@@ -352,7 +313,7 @@ test("blocked delivery backs off from 15 seconds to five minutes, blocks after 3
   if (!refused.accepted) assert.equal(refused.reason, CHILD_SPAWN_REFUSAL.BLOCKED_COMPLETIONS);
   // A blocked result is retained seven days and then let go of at the next load.
   const reloaded = harness({ store });
-  reloaded.clock.now = clock.now + CHILD_DEFAULTS.BLOCKED_RETENTION_MS + 1;
+  reloaded.clock.instant = clock.instant + CHILD_DEFAULTS.BLOCKED_RETENTION_MS + 1;
   await reloaded.service.start();
   assert.equal(reloaded.service.completions().length, 0);
 });
@@ -361,10 +322,10 @@ test("the same completion is delivered once however often the deliverer is asked
   const { service, store, executor, deliverer, clock } = harness();
   deliverer.accept = false;
   assert.ok((await service.spawn(request())).accepted);
-  await settle();
+  await drainMicrotasks(40);
   executor.started[0]?.end({ status: CHILD_RUN_STATUS.COMPLETED, resultText: "x" });
-  await settle();
-  await clock.advanceTo(NOW + CHILD_DEFAULTS.DELIVERY_WINDOW_MS + 1);
+  await drainMicrotasks(40);
+  await clock.advance(NOW + CHILD_DEFAULTS.DELIVERY_WINDOW_MS + 1);
   assert.equal(
     store.completions.get("completion:id-1")?.delivery,
     COMPLETION_DELIVERY_STATUS.BLOCKED,
@@ -372,7 +333,7 @@ test("the same completion is delivered once however often the deliverer is asked
   const attemptsBlocked = deliverer.delivered.length;
   deliverer.accept = true;
   assert.equal(await service.retryDelivery("id-1"), true);
-  await settle();
+  await drainMicrotasks(40);
   assert.equal(
     store.completions.get("completion:id-1")?.delivery,
     COMPLETION_DELIVERY_STATUS.DELIVERED,
@@ -386,19 +347,19 @@ test("a parent's completion never ends its child, but an explicit cancellation c
   const { service, executor, store } = harness();
   const parent = await service.spawn(request());
   assert.ok(parent.accepted);
-  await settle();
+  await drainMicrotasks(40);
   const child = await service.spawn(request(parent.receipt.childSessionKey, { requesterDepth: 1 }));
   assert.ok(child.accepted);
-  await settle();
+  await drainMicrotasks(40);
   const grandchild = await service.spawn(
     request(child.receipt.childSessionKey, { requesterDepth: 2 }),
   );
   assert.ok(grandchild.accepted);
-  await settle();
+  await drainMicrotasks(40);
   assert.equal(grandchild.receipt.depth, 3);
   // The parent ends; its children keep running.
   executor.started[0]?.end({ status: CHILD_RUN_STATUS.COMPLETED });
-  await settle();
+  await drainMicrotasks(40);
   assert.equal(store.children.get(child.receipt.childId)?.status, CHILD_RUN_STATUS.RUNNING);
   assert.equal(store.children.get(grandchild.receipt.childId)?.status, CHILD_RUN_STATUS.RUNNING);
   const cancelled = await service.cancel(child.receipt.childId);
@@ -413,7 +374,7 @@ test("a reset's descendant cancellation reports honestly when a cancel does not 
   const first = await service.spawn(request());
   const second = await service.spawn(request());
   assert.ok(first.accepted && second.accepted);
-  await settle();
+  await drainMicrotasks(40);
   executor.cancelLands = false;
   const outcome = await service.cancelDescendantsOf(MAIN_SESSION_KEY);
   assert.equal(outcome.ok, false);
@@ -433,10 +394,10 @@ test("a cancel racing the child's own end leaves one terminal status and one com
   const { service, executor, store } = harness();
   const spawned = await service.spawn(request());
   assert.ok(spawned.accepted);
-  await settle();
+  await drainMicrotasks(40);
   executor.started[0]?.end({ status: CHILD_RUN_STATUS.COMPLETED, resultText: "finished" });
   const cancelled = service.cancel(spawned.receipt.childId);
-  await settle();
+  await drainMicrotasks(40);
   await cancelled;
   const record = store.children.get(spawned.receipt.childId);
   const terminal: readonly string[] = [CHILD_RUN_STATUS.COMPLETED, CHILD_RUN_STATUS.CANCELLED];
@@ -448,14 +409,14 @@ test("a cancel racing the child's own end leaves one terminal status and one com
 test("a relaunch adopts unfinished children through the executor's recovery and keeps a bounded budget of start failures", async () => {
   const { service, store, executor } = harness();
   for (let index = 0; index < 5; index += 1) assert.ok((await service.spawn(request())).accepted);
-  await settle();
+  await drainMicrotasks(40);
   assert.equal(executor.started.length, 5);
   // Relaunch: the same store, a new service minting ids of its own; the backend refuses every resume.
   let later = 0;
   const relaunch = harness({ store, createId: () => `later-${++later}` });
   relaunch.executor.refuseResume = "no model";
   await relaunch.service.start();
-  await settle();
+  await drainMicrotasks(40);
   assert.equal(relaunch.executor.resumed.length, CHILD_DEFAULTS.RECOVERY_FAILURE_BUDGET);
   assert.equal(relaunch.service.recoveryFailures(), CHILD_DEFAULTS.RECOVERY_FAILURE_BUDGET);
   for (const record of relaunch.service.children()) {
@@ -469,18 +430,18 @@ test("a relaunch adopts unfinished children through the executor's recovery and 
   // A backend that actually starts resets the budget.
   const spawned = await relaunch.service.spawn(request(threadSessionKey("later")));
   assert.ok(spawned.accepted);
-  await settle();
+  await drainMicrotasks(40);
   assert.equal(relaunch.service.recoveryFailures(), 0);
 });
 
 test("a relaunch that recovers a child preserves the unknown outcome the runtime reports rather than replaying it", async () => {
   const { service, store, executor } = harness();
   assert.ok((await service.spawn(request())).accepted);
-  await settle();
+  await drainMicrotasks(40);
   assert.equal(executor.started.length, 1);
   const relaunch = harness({ store });
   await relaunch.service.start();
-  await settle();
+  await drainMicrotasks(40);
   assert.equal(relaunch.executor.resumed.length, 1);
   assert.equal(relaunch.executor.started.length, 0);
   const record = relaunch.service.child("id-1");
@@ -495,9 +456,9 @@ test("a fire-and-forget child records its delivery as not required, and delete c
     request(MAIN_SESSION_KEY, { expectsCompletion: false, cleanup: "delete" }),
   );
   assert.ok(spawned.accepted);
-  await settle();
+  await drainMicrotasks(40);
   executor.started[0]?.end({ status: CHILD_RUN_STATUS.COMPLETED });
-  await settle();
+  await drainMicrotasks(40);
   assert.equal(
     store.completions.get("completion:id-1")?.delivery,
     COMPLETION_DELIVERY_STATUS.NOT_REQUIRED,
@@ -514,7 +475,7 @@ test("a cancel that lands while the child is still starting stops the run that t
   });
   const spawned = await service.spawn(request());
   assert.ok(spawned.accepted);
-  await settle();
+  await drainMicrotasks(40);
   assert.equal(executor.started.length, 0);
   // The cancel finds no run yet; the record settles cancelled on its word.
   const cancelled = await service.cancel(spawned.receipt.childId);
@@ -523,14 +484,14 @@ test("a cancel that lands while the child is still starting stops the run that t
   assert.deepEqual(executor.cancelled, ["id-1"]);
   // The backend then starts the run anyway: it is stopped, and the row stays cancelled, never running.
   release?.();
-  await settle();
+  await drainMicrotasks(40);
   assert.equal(executor.started.length, 1);
   assert.deepEqual(executor.cancelled, ["id-1", "id-1"]);
   const record = store.children.get("id-1");
   assert.equal(record?.status, CHILD_RUN_STATUS.CANCELLED);
   assert.equal(record?.startedAt, undefined);
   executor.started[0]?.end({ status: CHILD_RUN_STATUS.COMPLETED, resultText: "too late" });
-  await settle();
+  await drainMicrotasks(40);
   assert.equal(store.children.get("id-1")?.status, CHILD_RUN_STATUS.CANCELLED);
   assert.equal(store.completions.size, 1);
   assert.equal(store.completions.get("completion:id-1")?.status, CHILD_RUN_STATUS.CANCELLED);

--- a/packages/runtime/src/children.ts
+++ b/packages/runtime/src/children.ts
@@ -1,4 +1,4 @@
-import type { WireRecord } from "@sidecar/wire";
+import type { IDisposable, WireRecord } from "@sidecar/wire";
 import {
   CHILD_CLEANUP,
   CHILD_CONTEXT_MODE,
@@ -15,7 +15,7 @@ import {
   isTerminalChildRunStatus,
 } from "./child-records.js";
 import { type AgentId, childSessionKey, type SessionKey } from "./identifiers.js";
-import type { ScheduledTimer } from "./timers.js";
+import { type Clock, systemClock } from "./timers.js";
 import { CHILD_DEPTH_CAP } from "./tool-policy.js";
 
 /**
@@ -198,9 +198,7 @@ export interface ChildRunServiceOptions {
   executor: ChildExecutor;
   deliverer: CompletionDeliverer;
   createId: () => string;
-  now?: () => number;
-  schedule?: (callback: () => void, delayMs: number) => ScheduledTimer;
-  cancel?: (timer: ScheduledTimer) => void;
+  clock?: Clock;
   report?: (message: string) => void;
   limits?: Partial<{
     maximumActivePerRequester: number;
@@ -238,14 +236,12 @@ export function deliveryBackoffMs(attempts: number): number {
 
 export class ChildRunService {
   readonly #options: ChildRunServiceOptions;
-  readonly #now: () => number;
-  readonly #schedule: (callback: () => void, delayMs: number) => ScheduledTimer;
-  readonly #cancel: (timer: ScheduledTimer) => void;
+  readonly #clock: Clock;
   readonly #report: (message: string) => void;
   readonly #children = new Map<string, ChildRunRecord>();
   readonly #completions = new Map<string, ChildCompletionRecord>();
-  readonly #deliveryTimers = new Map<string, ScheduledTimer>();
-  readonly #archiveTimers = new Map<string, ScheduledTimer>();
+  readonly #deliveryTimers = new Map<string, IDisposable>();
+  readonly #archiveTimers = new Map<string, IDisposable>();
   /** Each child's own write chain, so two updates of one record land in order. */
   readonly #writes = new Map<string, Promise<unknown>>();
   /** Children whose end is being written, claimed synchronously so a cancel and an end racing cannot both settle one child. */
@@ -257,15 +253,7 @@ export class ChildRunService {
 
   constructor(options: ChildRunServiceOptions) {
     this.#options = options;
-    this.#now = options.now ?? Date.now;
-    this.#schedule =
-      options.schedule ?? ((callback, delayMs) => globalThis.setTimeout(callback, delayMs));
-    this.#cancel =
-      options.cancel ??
-      ((timer) => {
-        // SAFETY: a timer this service scheduled itself came from setTimeout above.
-        globalThis.clearTimeout(timer as ReturnType<typeof setTimeout>);
-      });
+    this.#clock = options.clock ?? systemClock;
     this.#report = options.report ?? ((message) => process.stderr.write(`${message}\n`));
   }
 
@@ -386,8 +374,8 @@ export class ChildRunService {
   /** Stops every timer; nothing is delivered or archived after this, and what stands is on disk. */
   stop(): void {
     this.#stopped = true;
-    for (const timer of this.#deliveryTimers.values()) this.#cancel(timer);
-    for (const timer of this.#archiveTimers.values()) this.#cancel(timer);
+    for (const timer of this.#deliveryTimers.values()) timer.dispose();
+    for (const timer of this.#archiveTimers.values()) timer.dispose();
     this.#deliveryTimers.clear();
     this.#archiveTimers.clear();
   }
@@ -468,7 +456,7 @@ export class ChildRunService {
       }
     }
     const childId = this.#options.createId();
-    const now = this.#now();
+    const now = this.#clock.now();
     const record: ChildRunRecord = {
       childId,
       agentId: request.agentId,
@@ -533,7 +521,7 @@ export class ChildRunService {
     await this.#putIfActive(record.childId, (current) => ({
       ...current,
       status: CHILD_RUN_STATUS.RUNNING,
-      startedAt: this.#now(),
+      startedAt: this.#clock.now(),
     }));
     this.#follow(record.childId, start.done);
   }
@@ -628,7 +616,7 @@ export class ChildRunService {
     const record = this.#children.get(childId);
     if (!record || isTerminalChildRunStatus(record.status) || this.#settling.has(childId)) return;
     this.#settling.add(childId);
-    const now = this.#now();
+    const now = this.#clock.now();
     const settled: ChildRunRecord = {
       ...record,
       status: end.status,
@@ -670,14 +658,11 @@ export class ChildRunService {
   #armArchive(record: ChildRunRecord): void {
     if (this.#stopped || this.#archiveTimers.has(record.childId)) return;
     const after = this.#limit("archiveAfterMs", CHILD_DEFAULTS.ARCHIVE_AFTER_MS);
-    const at = (record.settledAt ?? this.#now()) + after;
-    const timer = this.#schedule(
-      () => {
-        this.#archiveTimers.delete(record.childId);
-        void this.#archive(record.childId);
-      },
-      Math.max(0, at - this.#now()),
-    );
+    const at = (record.settledAt ?? this.#clock.now()) + after;
+    const timer = this.#clock.schedule(Math.max(0, at - this.#clock.now()), () => {
+      this.#archiveTimers.delete(record.childId);
+      void this.#archive(record.childId);
+    });
     this.#archiveTimers.set(record.childId, timer);
   }
 
@@ -692,7 +677,7 @@ export class ChildRunService {
       this.#report(`Child ${childId}'s conversation could not be archived`);
       return;
     }
-    await this.#put({ ...record, archivedAt: this.#now() });
+    await this.#put({ ...record, archivedAt: this.#clock.now() });
   }
 
   /** Retries delivery of a completion the host could not take; the operator's manual retry. */
@@ -728,11 +713,11 @@ export class ChildRunService {
 
   #armDelivery(completion: ChildCompletionRecord): void {
     if (this.#stopped || this.#deliveryTimers.has(completion.completionId)) return;
-    const delay = Math.max(0, (completion.nextAttemptAt ?? this.#now()) - this.#now());
-    const timer = this.#schedule(() => {
+    const delay = Math.max(0, (completion.nextAttemptAt ?? this.#clock.now()) - this.#clock.now());
+    const timer = this.#clock.schedule(delay, () => {
       this.#deliveryTimers.delete(completion.completionId);
       void this.#attemptDelivery(completion.completionId);
-    }, delay);
+    });
     this.#deliveryTimers.set(completion.completionId, timer);
   }
 
@@ -741,7 +726,7 @@ export class ChildRunService {
     const record = completion ? this.#children.get(completion.childId) : undefined;
     if (!completion || !record || this.#stopped) return;
     if (completion.delivery !== COMPLETION_DELIVERY_STATUS.PENDING) return;
-    const now = this.#now();
+    const now = this.#clock.now();
     const firstAttemptAt = completion.firstAttemptAt ?? now;
     const outcome = await attempt(
       () => this.#options.deliverer.deliver(completion, record),
@@ -756,14 +741,14 @@ export class ChildRunService {
         delivery: COMPLETION_DELIVERY_STATUS.DELIVERED,
         attempts,
         firstAttemptAt,
-        deliveredAt: this.#now(),
+        deliveredAt: this.#clock.now(),
       });
       return;
     }
     // The window bounds the retries themselves: a next attempt that would
     // fall past it is not scheduled, and the result is retained as blocked now
     // rather than after one more wait nobody would answer.
-    const after = this.#now();
+    const after = this.#clock.now();
     const nextAttemptAt = after + deliveryBackoffMs(attempts);
     if (nextAttemptAt - firstAttemptAt > CHILD_DEFAULTS.DELIVERY_WINDOW_MS) {
       await this.#putCompletion({
@@ -802,7 +787,7 @@ export class ChildRunService {
 
   /** Blocked and dismissed completions older than the retention are let go of, with their children's records. */
   async #pruneRetainedCompletions(): Promise<void> {
-    const now = this.#now();
+    const now = this.#clock.now();
     for (const completion of this.completions()) {
       const retained =
         completion.delivery === COMPLETION_DELIVERY_STATUS.BLOCKED ||

--- a/packages/runtime/src/queue.test.ts
+++ b/packages/runtime/src/queue.test.ts
@@ -14,6 +14,7 @@ import {
   type QueueMode,
   queueSummaryText,
 } from "./queue.js";
+import { FakeClock } from "./testing/index.js";
 
 const input = (id: string, text = `words ${id}`): QueuedInput => ({ id, text, atMs: 1 });
 
@@ -76,25 +77,6 @@ test("the other overflow policies drop the oldest or refuse the newest", () => {
   assert.deepEqual(refused.evicted, [input("d")]);
 });
 
-interface FakeClock {
-  timers: Map<number, () => void>;
-  next: number;
-  fire(): void;
-}
-
-function fakeClock(): FakeClock {
-  const clock: FakeClock = {
-    timers: new Map(),
-    next: 1,
-    fire() {
-      const pending = [...clock.timers.values()];
-      clock.timers.clear();
-      for (const callback of pending) callback();
-    },
-  };
-  return clock;
-}
-
 function queueWith(
   clock: FakeClock,
   steer: (input: QueuedInput) => boolean,
@@ -111,21 +93,13 @@ function queueWith(
     flush: (batches) => {
       for (const batch of batches) flushed.push(batch.inputs.map((entry) => entry.id));
     },
-    schedule: (callback) => {
-      const id = clock.next++;
-      clock.timers.set(id, callback);
-      return id;
-    },
-    cancel: (timer) => {
-      // SAFETY: every timer this test's clock hands out is the number it minted above.
-      clock.timers.delete(timer as number);
-    },
+    clock,
   });
   return { queue, flushed, interrupted: () => interrupted };
 }
 
 test("steer hands input to the run under way and falls back to a follow-up when nothing can take it", () => {
-  const clock = fakeClock();
+  const clock = new FakeClock();
   const steered: string[] = [];
   let active = true;
   const { queue, flushed } = queueWith(clock, (entry) => {
@@ -143,23 +117,23 @@ test("steer hands input to the run under way and falls back to a follow-up when 
   assert.equal(queue.push(input("c")), true);
   assert.deepEqual(steered, ["a"]);
   assert.equal(queue.push(input("c")), false);
-  clock.fire();
+  clock.fireAll();
   assert.deepEqual(flushed, [["b", "c"]]);
   assert.equal(queue.size, 0);
 });
 
 test("follow-up opens one turn per input, collect opens one turn for all, interrupt cancels and opens now", () => {
-  const clock = fakeClock();
+  const clock = new FakeClock();
   const followup = queueWith(clock, () => false, QUEUE_MODE.FOLLOWUP);
   followup.queue.push(input("a"));
   followup.queue.push(input("b"));
-  clock.fire();
+  clock.fireAll();
   assert.deepEqual(followup.flushed, [["a"], ["b"]]);
   const collect = queueWith(clock, () => false, QUEUE_MODE.COLLECT);
   collect.queue.push(input("a"));
   collect.queue.push(input("b"));
   assert.deepEqual(collect.flushed, []);
-  clock.fire();
+  clock.fireAll();
   assert.deepEqual(collect.flushed, [["a", "b"]]);
   const interrupt = queueWith(clock, () => true, QUEUE_MODE.INTERRUPT);
   interrupt.queue.push(input("a"));
@@ -169,18 +143,18 @@ test("follow-up opens one turn per input, collect opens one turn for all, interr
 });
 
 test("clear forgets the queue and its timer", () => {
-  const clock = fakeClock();
+  const clock = new FakeClock();
   const { queue, flushed } = queueWith(clock, () => false);
   queue.push(input("a"));
   assert.equal(clock.timers.size, 1);
   queue.clear();
   assert.equal(clock.timers.size, 0);
-  clock.fire();
+  clock.fireAll();
   assert.deepEqual(flushed, []);
 });
 
 test("withdraw takes one queued input back before the drain, and disarms the timer when nothing is left", () => {
-  const clock = fakeClock();
+  const clock = new FakeClock();
   const { queue, flushed } = queueWith(clock, () => false, QUEUE_MODE.COLLECT);
   queue.push(input("a"));
   queue.push(input("b"));
@@ -188,7 +162,7 @@ test("withdraw takes one queued input back before the drain, and disarms the tim
   assert.equal(queue.withdraw("a"), false);
   assert.equal(queue.withdraw("never-queued"), false);
   assert.equal(clock.timers.size, 1);
-  clock.fire();
+  clock.fireAll();
   assert.deepEqual(flushed, [["b"]]);
   queue.push(input("c"));
   assert.equal(clock.timers.size, 1);
@@ -213,7 +187,7 @@ test("a queue holding only folded asks still drains one turn for them, in follow
 });
 
 test("withdrawing a folded ask by its place in the summary leaves the queue empty and disarmed when nothing else waits", () => {
-  const clock = fakeClock();
+  const clock = new FakeClock();
   const flushed: string[][] = [];
   const full = new PendingInputQueue({
     settings: { mode: QUEUE_MODE.COLLECT, capacity: 1, overflow: QUEUE_OVERFLOW.SUMMARIZE },
@@ -222,13 +196,7 @@ test("withdrawing a folded ask by its place in the summary leaves the queue empt
     flush: (batches) => {
       for (const batch of batches) flushed.push(batch.inputs.map((entry) => entry.id));
     },
-    schedule: (callback) => {
-      const id = clock.next++;
-      clock.timers.set(id, callback);
-      return id;
-    },
-    // SAFETY: every timer this test's clock hands out is the number it minted above.
-    cancel: (timer) => void clock.timers.delete(timer as number),
+    clock,
   });
   full.push(input("a"));
   full.push(input("b"));
@@ -246,6 +214,6 @@ test("withdrawing a folded ask by its place in the summary leaves the queue empt
   assert.equal(full.size, 0);
   assert.equal(clock.timers.size, 0);
   assert.equal(full.withdrawSummarized(0), false);
-  clock.fire();
+  clock.fireAll();
   assert.deepEqual(flushed, []);
 });

--- a/packages/runtime/src/queue.ts
+++ b/packages/runtime/src/queue.ts
@@ -1,4 +1,5 @@
-import type { ScheduledTimer } from "./timers.js";
+import type { IDisposable } from "@sidecar/wire";
+import { type Clock, systemClock } from "./timers.js";
 
 /**
  * How input that arrives while a conversation is busy is queued, ported from
@@ -174,8 +175,7 @@ export interface PendingInputQueueOptions {
   interrupt: () => void;
   /** Opens the drained turns, in order. */
   flush: (batches: readonly QueueBatch[]) => void;
-  schedule?: (callback: () => void, delayMs: number) => ScheduledTimer;
-  cancel?: (timer: ScheduledTimer) => void;
+  clock?: Clock;
 }
 
 /**
@@ -188,22 +188,14 @@ export interface PendingInputQueueOptions {
 export class PendingInputQueue {
   readonly #settings: QueueSettings;
   readonly #options: PendingInputQueueOptions;
-  readonly #schedule: (callback: () => void, delayMs: number) => ScheduledTimer;
-  readonly #cancel: (timer: ScheduledTimer) => void;
+  readonly #clock: Clock;
   #state: PendingQueueState = EMPTY_QUEUE;
-  #timer: ScheduledTimer | undefined;
+  #timer: IDisposable | undefined;
 
   constructor(options: PendingInputQueueOptions) {
     this.#options = options;
     this.#settings = { ...DEFAULT_QUEUE_SETTINGS, ...options.settings };
-    this.#schedule =
-      options.schedule ?? ((callback, delayMs) => globalThis.setTimeout(callback, delayMs));
-    this.#cancel =
-      options.cancel ??
-      ((timer) => {
-        // SAFETY: a timer this queue scheduled itself came from setTimeout above.
-        globalThis.clearTimeout(timer as ReturnType<typeof setTimeout>);
-      });
+    this.#clock = options.clock ?? systemClock;
   }
 
   get settings(): QueueSettings {
@@ -281,15 +273,15 @@ export class PendingInputQueue {
 
   #arm(): void {
     if (this.#timer !== undefined) return;
-    this.#timer = this.#schedule(() => {
+    this.#timer = this.#clock.schedule(this.#settings.debounceMs, () => {
       this.#timer = undefined;
       this.#flushNow();
-    }, this.#settings.debounceMs);
+    });
   }
 
   #disarm(): void {
     if (this.#timer === undefined) return;
-    this.#cancel(this.#timer);
+    this.#timer.dispose();
     this.#timer = undefined;
   }
 

--- a/packages/runtime/src/testing/fake-clock.ts
+++ b/packages/runtime/src/testing/fake-clock.ts
@@ -1,4 +1,5 @@
-import type { ScheduledTimer } from "../vocabulary.js";
+import { type IDisposable, toDisposable } from "@sidecar/wire";
+import type { Clock, ScheduledTimer } from "../vocabulary.js";
 import { drainMicrotasks } from "./drain.js";
 
 interface ArmedTimer {
@@ -12,25 +13,38 @@ interface ArmedTimer {
  * A clock a test drives by hand: nothing is due until the test advances or
  * fires, so a deadline can be crossed without waiting out a real one.
  */
-export class FakeClock {
-  now: number;
+export class FakeClock implements Clock {
+  /** The instant every reading answers with, moved by the test or by a fire. */
+  instant: number;
   /** Every timer still armed, in the order it was scheduled. */
   readonly timers = new Map<ScheduledTimer, ArmedTimer>();
   /** Every delay ever asked for, in order, including timers since cancelled. */
   readonly delays: number[] = [];
 
-  constructor(now = 1_800_000_000_000) {
-    this.now = now;
+  constructor(instant = 1_800_000_000_000) {
+    this.instant = instant;
   }
 
-  schedule = (callback: () => void, delayMs: number): ScheduledTimer => {
+  now = (): number => this.instant;
+
+  schedule = (delayMs: number, run: () => void): IDisposable => {
+    const handle = this.scheduleTimer(run, delayMs);
+    return toDisposable(() => this.cancelTimer(handle));
+  };
+
+  /**
+   * The same schedule for a component still taking a callback and a token
+   * beside a canceller rather than a {@link Clock}. One table stands behind
+   * both, so `advance`, `fireAll`, and `armed` cover whatever armed them.
+   */
+  scheduleTimer = (callback: () => void, delayMs: number): ScheduledTimer => {
     const handle: ScheduledTimer = {};
     this.delays.push(delayMs);
-    this.timers.set(handle, { callback, at: this.now + delayMs, delayMs });
+    this.timers.set(handle, { callback, at: this.instant + delayMs, delayMs });
     return handle;
   };
 
-  cancel = (timer: ScheduledTimer): void => {
+  cancelTimer = (timer: ScheduledTimer): void => {
     this.timers.delete(timer);
   };
 
@@ -42,11 +56,11 @@ export class FakeClock {
         .sort((a, b) => a[1].at - b[1].at)[0];
       if (!due) break;
       this.timers.delete(due[0]);
-      this.now = Math.max(this.now, due[1].at);
+      this.instant = Math.max(this.instant, due[1].at);
       due[1].callback();
       await drainMicrotasks(20);
     }
-    this.now = Math.max(this.now, untilMs);
+    this.instant = Math.max(this.instant, untilMs);
   }
 
   /**

--- a/packages/runtime/src/testing/index.ts
+++ b/packages/runtime/src/testing/index.ts
@@ -4,7 +4,7 @@
  * drives. `drainMicrotasks` and `FakeClock` live behind their own door
  * because they reach `node:fs` and `node:os`, which nothing that ships may
  * have to resolve, and in this package because the clock stands in for the
- * runtime's own `ScheduledTimer` and every test that needs one is above the
+ * runtime's own `Clock` and every test that needs one is above the
  * runtime already. `temporaryDirectory` itself lives in `@sidecar/wire/testing`,
  * which every package here already reaches, and is re-exported so this door
  * still hands it out.

--- a/packages/runtime/src/timers.ts
+++ b/packages/runtime/src/timers.ts
@@ -1,3 +1,5 @@
+import { type IDisposable, toDisposable } from "@sidecar/wire";
+
 /**
  * What a scheduler hands back so the same schedule can be cancelled. A
  * browser answers with a number, Node with a timer object, and a test with
@@ -6,6 +8,31 @@
  * package is cancellable in another.
  */
 export type ScheduledTimer = number | object;
+
+/**
+ * What time it is and how to run something later, as one seam. A component
+ * that takes a clock is drivable by a test without waiting out a real delay,
+ * and cancellation rides on the handle the schedule answers with rather than
+ * on a second function beside it, so no caller has to keep a token and the
+ * matching canceller together.
+ */
+export interface Clock {
+  now(): number;
+  schedule(delayMs: number, run: () => void): IDisposable;
+}
+
+/** The process's own clock: what every owner of a schedule runs on unless a test hands it another. */
+export const systemClock: Clock = {
+  now: () => Date.now(),
+  schedule: (delayMs, run) => {
+    const timer = globalThis.setTimeout(run, delayMs);
+    // A schedule never holds the process open by itself: every owner here is
+    // already kept alive by the work it waits on, and a process with nothing
+    // else left has nothing left for the callback to reach either.
+    timer.unref();
+    return toDisposable(() => globalThis.clearTimeout(timer));
+  },
+};
 
 /** One day in milliseconds, for every age, half-life, and lookback measured in days. */
 export const DAY_MS = 24 * 60 * 60 * 1000;

--- a/packages/runtime/src/vocabulary.ts
+++ b/packages/runtime/src/vocabulary.ts
@@ -1,8 +1,8 @@
 /**
  * The runtime's vocabulary: the identities it keeps apart, the storage
  * contracts a durable owner of conversation state satisfies, the execution
- * seams a host composes over, the records delegation keeps, and the one
- * scheduler handle. A re-export door and nothing else, Node-free by
+ * seams a host composes over, the records delegation keeps, and the clock they
+ * all run on. A re-export door and nothing else, Node-free by
  * construction, because packages below the runtime — realtime, hosted,
  * voice, devtrace, memory — import this door and not the barrel, which
  * reaches `node:fs`.
@@ -134,4 +134,4 @@ export {
   TRANSCRIPT_EVENT_KIND,
   type TranscriptEvent,
 } from "./storage.js";
-export { DAY_MS, type ScheduledTimer } from "./timers.js";
+export { type Clock, DAY_MS, type ScheduledTimer, systemClock } from "./timers.js";

--- a/packages/voice/src/orchestrator/speech-mouth.test.ts
+++ b/packages/voice/src/orchestrator/speech-mouth.test.ts
@@ -105,8 +105,8 @@ function mouth(session: FakeSession, timers: FakeClock, now = () => 1_000) {
     session: () => session,
     settle: (id, outcome) => settled.push({ id, outcome }),
     now,
-    schedule: timers.schedule,
-    cancel: timers.cancel,
+    schedule: timers.scheduleTimer,
+    cancel: timers.cancelTimer,
   });
   return { subject, settled };
 }


### PR DESCRIPTION
## What this does

Four spellings of "what time it is and run this later" become one seam:

```ts
interface Clock {
  now(): number;
  schedule(delayMs: number, run: () => void): IDisposable;
}
```

in `packages/runtime/src/timers.ts`, with a `systemClock` beside it, exposed on
the `@sidecar/runtime/vocabulary` door. Cancellation rides on the handle
`schedule` answers with — PR 1's `IDisposable` — so the `(now, schedule, cancel)`
parameter clump dissolves wherever it appeared.

`clock?: Clock` replaces that clump at the eight owners:

| File | Was |
| --- | --- |
| `brain/src/seam.ts` | `readonly now`, `readonly schedule`, `readonly cancel` on `AgentSeam` |
| `brain/src/agent.ts` | `now?`/`schedule?`/`cancel?` plus three private fields and two inline `setTimeout`/`clearTimeout` defaults |
| `brain/src/generation-clock.ts` | same three, with its own unreffing default |
| `brain/src/wake-queue.ts` | `now`/`schedule`/`cancel` on `WakeQueueOptions` |
| `runtime/src/queue.ts` | `schedule?`/`cancel?` on `PendingInputQueueOptions` |
| `runtime/src/children.ts` | `now?`/`schedule?`/`cancel?`, two `Map<string, ScheduledTimer>` |
| `host/src/brain/wiring-children.ts` | `childTimers?: { schedule, cancel }` → `childClock?: Clock` |
| `providers/src/shared/spool-watcher.ts` | its own `type Timer = ReturnType<typeof setTimeout>` and a `schedule?`/`cancel?` pair |

The ripple through `brain/src/{asks,wakes,turn-runner,turn}.ts` is the same
change: `run.deadline` is an `IDisposable` and a cancel is `run.deadline?.dispose()`.

## What was deleted

- `brain/src/harness.ts`'s own `FakeClock` and its `settle()`. `settle()` was
  `drainMicrotasks(20)` under another name; every caller now says the length of
  the wait it is settling.
- The duplicate `FakeClock` classes in `brain/src/acceptance.test.ts` and
  `runtime/src/children.test.ts`, and the duplicate `fakeClock()` factories in
  `runtime/src/queue.test.ts` and `providers/src/shared/spool-watcher.test.ts`,
  along with `children.test.ts`'s and `spool-watcher.test.ts`'s own hand-rolled
  `settle()` (40 ticks and 20 ticks, for one wait).
- Four copies of the `// SAFETY: a timer this X scheduled itself came from
  setTimeout above.` assertion, one per owner that hand-rolled its own default.

Net −197 lines.

`@sidecar/runtime/testing`'s `FakeClock` now `implements Clock`: its instant is
a settable `instant` field (it can no longer be a field named `now`), and it
keeps a `scheduleTimer`/`cancelTimer` pair over the same timer table for the
schedulers still on the older calling convention (`voice`'s orchestrator,
`gateway/shutdown.ts`, `host/device-registration.ts`), which this PR does not
touch. That pair is the one thing here that a follow-up PR migrating those
files should delete; `ScheduledTimer` itself stays for the same reason.

## One deliberate behaviour change

`systemClock.schedule` unrefs its timer. Before, only two owners did:
`BrainGenerationClock` ("housekeeping never holds a process open", in its own
doc comment) and `host/src/testing/brain-harness.ts`, whose comment read "a run
left in flight at a test's end must not hold the process open". The other three
did not care either way — in Electron main the loop is held by the app, and in
tests they are handed a `FakeClock`. Unreffing is what lets one `systemClock`
serve all of them; the reverse would have left two owners keeping schedulers of
their own, which is the thing this PR removes. Both comments are now carried by
`systemClock` itself, and `generation-clock.ts`'s sentence was trimmed to stop
claiming an unref it no longer performs itself.

## `./scripts/check.sh`

Green, exit 0.

```
72 generated files are up to date
4 generated files are up to date
Design contract checks passed.
Repository contract checks passed.

> luke@0.5.0 lint
> biome check . && pnpm oxlint
Checked 1241 files in 894ms. No fixes applied.
Found 23 warnings.
Found 1 info.
(oxlint: warnings only, all pre-existing; exit 0)

> luke@0.5.0 typecheck
(every package: Done)

> luke@0.5.0 test
packages/wire      ℹ tests 66   ℹ pass 66   ℹ fail 0
packages/runtime   ℹ tests 62   ℹ pass 62   ℹ fail 0
packages/providers ℹ tests 468  ℹ pass 468  ℹ fail 0
packages/brain     ℹ tests 335  ℹ pass 335  ℹ fail 0
packages/host      ℹ tests 285  ℹ pass 285  ℹ fail 0
packages/voice     ℹ tests 71   ℹ pass 71   ℹ fail 0
… 26 suites in all, 3016 tests, 0 failures

> luke@0.5.0 build
(apps/web, apps/desktop: Done)
```

`./scripts/verify.sh` needs a Mac and is not available in this cloud workspace.
This change is portable-only — no macOS, renderer, or UI surface is touched —
so `check.sh` is the applicable invariant.

No `setImmediate` ordering drifted: the two hand-rolled `settle()` copies with
different tick counts (40 in `runtime/src/children.test.ts`, 20 everywhere
else) each became `drainMicrotasks(<its own count>)`, and no wait was papered
over with a sleep.

## Documentation sentence changed

`packages/AGENTS.md`, in "A barrel is an all-or-nothing door":

> …and in this package because the clock stands in for the runtime's own
> ~~`ScheduledTimer`~~ **`Clock`**.

`packages/runtime/src/vocabulary.ts`'s own door comment moved the same way
("the one scheduler handle" → "the clock they all run on"), and
`packages/runtime/src/testing/index.ts`'s. No sentence in `CLAUDE.md`,
`PRIVACY.md`, or any `README.md` names either type.

## Review passes

**Cursor's thermo-nuclear code quality review** ([skill](https://github.com/cursor/plugins/blob/main/cursor-team-kit/skills/thermo-nuclear-code-quality-review/SKILL.md), applied to this diff):

1. *Boundary cleanliness / unjustified optionality* — `wireChildren` passed the
   clock through as `...(dependencies.childClock ? { clock: … } : undefined)`,
   a spread standing in for one property. Fixed: `clock: dependencies.childClock`.
2. *Legibility regression* — folding `#now()` into `#clock.now()` pushed
   `BrainAgent.#expireIfDue`'s guard past the line width, and it read the clock
   twice in one decision. Fixed: one `const now`, one reading, one line.
3. *Silent semantic change* — flagged the `unref` widening; kept it, for the
   reason set out above, and documented rather than buried.
4. *Boundary leak* — `FakeClock` carrying two calling conventions. Judged
   justified: the alternative is an unchecked `as IDisposable` assertion in two
   out-of-scope test files, and one adapter in one place beats two. Named above
   as the thing the follow-up deletes.

**Ponytail review** ([skill](https://github.com/DietrichGebert/ponytail/blob/main/skills/ponytail-review/SKILL.md), over-engineering only):

- `delete` — `ArmedTimer.delayMs` in `fake-clock.ts` looked write-only. **Not
  cut**: `host/src/brain/wiring-children.test.ts` reads it to find the archive
  timer by its hour-long delay. Reverted after typecheck caught it.
- `shrink` — three call sites wrote `{ now: () => X, schedule: systemClock.schedule }`.
  Now `{ ...systemClock, now: () => X }`, which also says what it means.
- `yagni` — no new abstraction survives with a single implementation:
  `Clock` has two (`systemClock`, `FakeClock`) plus three inline literals, and
  nothing speculative was added beside it.
- The rest of the pass is what the PR already is: the whole change is deletion
  of duplicated scheduler plumbing. `net: -197 lines`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/56984281-b90c-4938-8f37-ac4bf57d7253)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34422028530/artifacts/10131314229) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34422028530)

- Commit: `fbed908d44a1494d6ed995ceb61ee120afe9b848`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
