### PR TITLE
refactor(runtime): Emitter, SingleFlight, BoundedMap replace the hand-rolled copies

### DIFF
--- a/apps/desktop/src/main/app-state.test.ts
+++ b/apps/desktop/src/main/app-state.test.ts
@@ -129,7 +129,7 @@ test("listeners are announced in order and an unsubscribed one hears nothing", (
   const first = app.subscribe(() => heard.push("first"));
   app.subscribe(() => heard.push("second"));
   app.update({ announcements: { held: true } });
-  first();
+  first.dispose();
   app.update({ announcements: { held: false } });
   assert.deepEqual(heard, ["first", "second", "second"]);
 });

--- a/apps/desktop/src/main/app-state.ts
+++ b/apps/desktop/src/main/app-state.ts
@@ -2,6 +2,7 @@ import { isDeepStrictEqual } from "node:util";
 import { ACCOUNT_STATUS } from "@sidecar/credentials/snapshot";
 import { EMPTY_APP_GUIDE } from "@sidecar/guide";
 import { fixtureSnapshot } from "@sidecar/session/fixtures";
+import { Emitter, type Event } from "@sidecar/wire";
 import type { AppState } from "#shared/messages/app-state";
 import { MICROPHONE_STATUS } from "#shared/messages/audio";
 import type { HostBootstrap } from "./gateway/host-operator";
@@ -36,7 +37,9 @@ function patchEntries(patch: AppStatePatch): [AppStateSlice, AppState[AppStateSl
  */
 export class AppStateStore {
   #state: AppState;
-  readonly #listeners = new Set<() => void>();
+  readonly #announced = new Emitter<void>();
+  /** Hears every applied patch and every touch, with the document to be read back by snapshot. */
+  readonly subscribe: Event<void> = this.#announced.event;
 
   constructor(initial: Omit<AppState, "version">) {
     this.#state = { ...initial, version: 0 };
@@ -71,18 +74,11 @@ export class AppStateStore {
     this.#announce();
   }
 
-  subscribe(listener: () => void): () => void {
-    this.#listeners.add(listener);
-    return () => {
-      this.#listeners.delete(listener);
-    };
-  }
-
   #announce(): void {
     // A listener that patches in turn is applied and announced inside this
-    // call, so nothing it wrote is lost; the copy is what lets it subscribe
-    // or unsubscribe while the round is running.
-    for (const listener of Array.from(this.#listeners)) listener();
+    // call, so nothing it wrote is lost; the emitter's own copy is what lets
+    // it subscribe or unsubscribe while the round is running.
+    this.#announced.fire();
   }
 }
 

--- a/apps/desktop/src/main/gateway/host-operator.ts
+++ b/apps/desktop/src/main/gateway/host-operator.ts
@@ -38,6 +38,7 @@ import type { AppSettings, SettingsUpdateResult } from "@sidecar/settings/wire";
 import {
   ACTION_RESULT_STATUS,
   type ActionResult,
+  type Event,
   isRecord,
   isWireBoolean,
   isWireNumber,
@@ -165,23 +166,17 @@ export interface HostOperator {
   onboardingState(): Promise<{ calendarOnboardingOwed: boolean } | undefined>;
   skipCalendarOnboarding(): Promise<void>;
   completeCalendarOnboarding(): Promise<void>;
-  onSettingsChanged(listener: (change: HostSettingsChange) => void): () => void;
-  onAccountChanged(listener: (account: AccountSnapshot) => void): () => void;
-  onSessionsChanged(
-    listener: (roster: { sessions: readonly Session[]; settled: boolean }) => void,
-  ): () => void;
-  onWorkspaceProjectsChanged(
-    listener: (projects: readonly ObservedWorkspaceProject[]) => void,
-  ): () => void;
-  onCalendarsChanged(
-    listener: (calendars: readonly ObservedAccountCalendars[]) => void,
-  ): () => void;
-  onAnnouncementsHeldChanged(listener: (held: boolean) => void): () => void;
-  onSupersetSignInChanged(listener: (state: SupersetSignInSnapshot) => void): () => void;
-  onCalendarOnboardingChanged(listener: (owed: boolean) => void): () => void;
-  onSpeechOffered(listener: (offer: SpeechOffer) => void): () => void;
-  onSpeechWithdrawn(listener: (id: string) => void): () => void;
-  onSessionReplayChanged(listener: (replay: HostSessionReplay) => void): () => void;
+  onSettingsChanged: Event<HostSettingsChange>;
+  onAccountChanged: Event<AccountSnapshot>;
+  onSessionsChanged: Event<{ sessions: readonly Session[]; settled: boolean }>;
+  onWorkspaceProjectsChanged: Event<readonly ObservedWorkspaceProject[]>;
+  onCalendarsChanged: Event<readonly ObservedAccountCalendars[]>;
+  onAnnouncementsHeldChanged: Event<boolean>;
+  onSupersetSignInChanged: Event<SupersetSignInSnapshot>;
+  onCalendarOnboardingChanged: Event<boolean>;
+  onSpeechOffered: Event<SpeechOffer>;
+  onSpeechWithdrawn: Event<string>;
+  onSessionReplayChanged: Event<HostSessionReplay>;
 }
 
 export interface HostOperatorOptions {

--- a/apps/desktop/src/main/native/native-helper.ts
+++ b/apps/desktop/src/main/native/native-helper.ts
@@ -1,5 +1,6 @@
 import { type StdioOptions, spawn } from "node:child_process";
 import path from "node:path";
+import { Emitter, type Event } from "@sidecar/wire";
 import { app } from "electron";
 
 export interface NativeHelperProcess {
@@ -47,22 +48,18 @@ export function nativeHelperPath(binary: string): string {
  */
 export class NativeHelper {
   readonly #options: NativeHelperOptions;
-  readonly #lineListeners = new Set<(line: string) => void>();
-  readonly #exitListeners = new Set<() => void>();
+  readonly #lines = new Emitter<string>();
+  readonly #exits = new Emitter<void>();
+  /** Hears each complete line the helper wrote, trimmed of its newline. */
+  readonly onLine: Event<string> = this.#lines.event;
+  /** Hears the one ending: an exit, a spawn failure, or a broken pipe, whichever came first. */
+  readonly onExit: Event<void> = this.#exits.event;
   #child: NativeHelperProcess | undefined;
   #buffer = "";
   #ended = false;
 
   constructor(options: NativeHelperOptions) {
     this.#options = options;
-  }
-
-  onLine(listener: (line: string) => void): void {
-    this.#lineListeners.add(listener);
-  }
-
-  onExit(listener: () => void): void {
-    this.#exitListeners.add(listener);
   }
 
   start(): boolean {
@@ -146,8 +143,7 @@ export class NativeHelper {
     const lines = this.#buffer.split("\n");
     this.#buffer = lines.pop() ?? "";
     for (const line of lines) {
-      const trimmed = line.trim();
-      for (const listener of this.#lineListeners) listener(trimmed);
+      this.#lines.fire(line.trim());
     }
   }
 
@@ -159,7 +155,7 @@ export class NativeHelper {
     this.#buffer = "";
     this.#ended = true;
     this.#child = undefined;
-    for (const listener of this.#exitListeners) listener();
+    this.#exits.fire();
   }
 
   #detach(): NativeHelperProcess | undefined {

--- a/apps/desktop/src/main/services/operator-client.ts
+++ b/apps/desktop/src/main/services/operator-client.ts
@@ -5,7 +5,7 @@ import { type AppGuideSnapshot, EMPTY_APP_GUIDE } from "@sidecar/guide";
 import { HOST_OPERATOR_CLIENT_ID } from "@sidecar/host";
 import { SUPERSET_SIGN_IN_STAGE } from "@sidecar/providers/superset/sign-in-stage";
 import type { AppSettings } from "@sidecar/settings/wire";
-import { type LateRef, lateRef } from "@sidecar/wire";
+import { DisposableStore, type LateRef, lateRef } from "@sidecar/wire";
 import { channels } from "#shared/bridge";
 import { type AppStateStore, bootstrapPatch } from "../app-state";
 import type { HostBootstrap, HostOperator } from "../gateway/host-operator";
@@ -76,7 +76,7 @@ export function createOperatorClient(dependencies: OperatorClientDependencies): 
    */
   let voiceAvailable = false;
   let attachments = 0;
-  const unsubscribers: (() => void)[] = [];
+  const subscriptions = new DisposableStore();
 
   const gateway = wireGateway({
     transport: new InProcessTransport(dependencies.server, {
@@ -97,7 +97,7 @@ export function createOperatorClient(dependencies: OperatorClientDependencies): 
 
   // The two offers a receiver alone may take are not state and reach the voice
   // window directly; everything else is written to the document.
-  unsubscribers.push(
+  for (const subscription of [
     gateway.host.onSettingsChanged((change) => {
       const stoodVoice = voiceAvailable;
       voiceAvailable = change.settings.status.voiceAvailable;
@@ -151,7 +151,9 @@ export function createOperatorClient(dependencies: OperatorClientDependencies): 
     gateway.host.onSessionReplayChanged((replay) => {
       state.update({ sessionReplay: { ...replay, halted: false } });
     }),
-  );
+  ]) {
+    subscriptions.add(subscription);
+  }
 
   function setSessionReplayHalted(halted: boolean): void {
     state.update({ sessionReplay: { ...state.snapshot().sessionReplay, halted } });
@@ -205,7 +207,7 @@ export function createOperatorClient(dependencies: OperatorClientDependencies): 
       relay.recycleVoiceWindow();
     },
     stop: async () => {
-      while (unsubscribers.length > 0) unsubscribers.pop()?.();
+      subscriptions.dispose();
       gateway.client.close();
     },
   };

--- a/apps/desktop/src/renderer/voice/use-voice-session.ts
+++ b/apps/desktop/src/renderer/voice/use-voice-session.ts
@@ -153,7 +153,13 @@ export function useVoiceSession(remoteAudio: RefObject<HTMLAudioElement | null>)
   const audioContext = useRef<AudioContext | undefined>(undefined);
 
   const { meterStream, remoteStream } = useSyncExternalStore(
-    useMemo(() => orchestrator.subscribe.bind(orchestrator), [orchestrator]),
+    useMemo(
+      () => (onStoreChange: () => void) => {
+        const subscription = orchestrator.subscribe(onStoreChange);
+        return () => subscription.dispose();
+      },
+      [orchestrator],
+    ),
     useMemo(() => orchestrator.snapshot.bind(orchestrator), [orchestrator]),
   );
 

--- a/packages/AGENTS.md
+++ b/packages/AGENTS.md
@@ -132,9 +132,12 @@ hosted tier's Postgres store under `apps/web/server/hosted/store/` writes and
 reads the same rows the SQLite store does without resolving `node:sqlite`.
 
 `@sidecar/runtime/vocabulary` is the same rule at the bottom of the graph: the
-identities, the storage contracts, and the execution seams are Node-free, and
-the packages below the runtime import that door so the barrel's `node:fs`
-never reaches a renderer or a web function. Nothing is behind both
+identities, the storage contracts, the execution seams, and the two
+collections a layer keeps its bookkeeping in — `BoundedMap` for a cache that
+must not grow for as long as a process runs, `SingleFlight` for concurrent
+asks that are one run — are Node-free, and the packages below the runtime
+import that door so the barrel's `node:fs` never reaches a renderer or a web
+function. Nothing is behind both
 doors: the barrel re-exports no vocabulary name, so every symbol has exactly
 one way in.
 

--- a/packages/brain/src/agent.test.ts
+++ b/packages/brain/src/agent.test.ts
@@ -730,9 +730,9 @@ test("a spoken submission keeps its origin, and an empty ask is refused without 
   });
   const runId = acceptedRunId(accepted);
   const heard: (readonly BrainRequestRecord[])[] = [];
-  const unsubscribe = h.agent.subscribe((records) => heard.push(records));
+  const subscription = h.agent.subscribe((records) => heard.push(records));
   const record = await h.agent.waitAsk(runId, 60_000);
-  unsubscribe();
+  subscription.dispose();
   assert.equal(record?.origin, BRAIN_REQUEST_ORIGIN.SPOKEN);
   assert.equal(record?.question, "hello there");
   assert.ok(heard.length > 0);

--- a/packages/brain/src/agent.ts
+++ b/packages/brain/src/agent.ts
@@ -12,8 +12,8 @@ import type {
   ProviderTranscriptSinceResult,
   SessionIdentity,
 } from "@sidecar/session";
-import type { WireRecord } from "@sidecar/wire";
-import { AskLedger, type BrainRequestsListener } from "./asks.js";
+import type { IDisposable, WireRecord } from "@sidecar/wire";
+import { AskLedger } from "./asks.js";
 import { type BrainCompletionDelivery, ChildRuns } from "./children.js";
 import { BRAIN_DEFAULTS } from "./defaults.js";
 import {
@@ -57,7 +57,6 @@ import { type BrainOpeningNotes, TurnRunner } from "./turn-runner.js";
 import type { BrainDelivery, BrainTurnReport, BrainWakeEvent } from "./wake-events.js";
 import { type LookSubject, WakeCapture } from "./wakes.js";
 
-export type { BrainRequestsListener } from "./asks.js";
 export type { BrainCompletionDelivery } from "./children.js";
 export { BRAIN_DEFAULTS } from "./defaults.js";
 export type { BrainFlushInput, BrainFlushMarkerStore } from "./maintenance.js";
@@ -217,7 +216,7 @@ export class BrainAgent {
   #restored: Promise<void> | undefined;
   #queue: Promise<unknown> = Promise.resolve();
   #stopped = false;
-  #unsubscribeStore: (() => void) | undefined;
+  #storeReplacements: IDisposable | undefined;
   #incompatibleReported: string | undefined;
 
   constructor(options: BrainAgentOptions) {
@@ -327,7 +326,7 @@ export class BrainAgent {
       active: () => this.#turns.active(),
       turn: (plan) => this.#turns.turn(plan),
     });
-    this.#unsubscribeStore = options.store.onReplaced((state) => this.#adoptGeneration(state));
+    this.#storeReplacements = options.store.onReplaced((state) => this.#adoptGeneration(state));
   }
 
   /** The store lease this agent writes under, for a host to check who owns the store. */
@@ -394,7 +393,7 @@ export class BrainAgent {
   }
 
   /** Hears the whole list on every change to any record. */
-  subscribe(listener: BrainRequestsListener): () => void {
+  subscribe(listener: (records: readonly BrainRequestRecord[]) => void): IDisposable {
     return this.#asks.subscribe(listener);
   }
 
@@ -546,8 +545,8 @@ export class BrainAgent {
     this.#maintenance.cancel();
     this.#wakes.clear();
     const waiting = this.#asks.takeWaiting();
-    this.#unsubscribeStore?.();
-    this.#unsubscribeStore = undefined;
+    this.#storeReplacements?.dispose();
+    this.#storeReplacements = undefined;
     this.#generation?.abort.abort();
     this.#asks.abortAll();
     // An acceptance whose write is still out settles before the stop does:

--- a/packages/brain/src/asks.ts
+++ b/packages/brain/src/asks.ts
@@ -6,6 +6,7 @@ import {
 } from "@sidecar/runtime";
 import type { ScheduledTimer } from "@sidecar/runtime/vocabulary";
 import { CONTEXT_INPUT_KIND } from "@sidecar/runtime/vocabulary";
+import { Emitter, type Event } from "@sidecar/wire";
 import { CONTEXT_OPENING, type Generation } from "./generation.js";
 import { askInputText } from "./input-items.js";
 import {
@@ -21,8 +22,6 @@ import type { AgentSeam } from "./seam.js";
 import type { BrainStateStore } from "./state-store.js";
 import { BRAIN_TURN_TRIGGER, type RunControl } from "./turn.js";
 import { type ActiveExecution, type AskInput, newRunControl } from "./turn-runner.js";
-
-export type BrainRequestsListener = (records: readonly BrainRequestRecord[]) => void;
 
 /** A pending submission, held so a retry of the same id awaits the same durable answer. */
 interface PendingSubmission {
@@ -58,7 +57,9 @@ export class AskLedger {
   readonly #seam: AgentSeam;
   readonly #runs = new Map<string, RunControl>();
   readonly #pendingSubmissions = new Map<string, PendingSubmission>();
-  readonly #listeners = new Set<BrainRequestsListener>();
+  readonly #changes = new Emitter<readonly BrainRequestRecord[]>();
+  /** Hears the whole list on every change to any record. */
+  readonly subscribe: Event<readonly BrainRequestRecord[]> = this.#changes.event;
   /** Where an ask that arrives while this conversation is busy waits, under the queue's own mode and bounds. */
   readonly #queue: PendingInputQueue;
   /**
@@ -120,10 +121,9 @@ export class AskLedger {
     );
   }
 
-  /** Hears the whole list on every change to any record. */
+  /** Hands the whole list to every listener, on every change to any record. */
   notify(): void {
-    const records = this.records();
-    for (const listener of [...this.#listeners]) listener(records);
+    this.#changes.fire(this.records());
   }
 
   /** Every acknowledged run this generation holds, oldest acceptance first. */
@@ -140,14 +140,6 @@ export class AskLedger {
     if (!generation || generation.provisional.has(runId)) return undefined;
     const record = generation.requests.get(runId);
     return record ? { ...record } : undefined;
-  }
-
-  /** Hears the whole list on every change to any record. */
-  subscribe(listener: BrainRequestsListener): () => void {
-    this.#listeners.add(listener);
-    return () => {
-      this.#listeners.delete(listener);
-    };
   }
 
   /**
@@ -437,11 +429,11 @@ export class AskLedger {
     return new Promise((resolve) => {
       let timer: ScheduledTimer | undefined;
       const finish = () => {
-        unsubscribe();
+        subscription.dispose();
         if (timer !== undefined) this.#seam.cancel(timer);
         resolve(this.record(runId));
       };
-      const unsubscribe = this.subscribe(() => {
+      const subscription = this.subscribe(() => {
         const current = this.record(runId);
         if (!current || isTerminalBrainRequestStatus(current.status)) finish();
       });

--- a/packages/brain/src/children.ts
+++ b/packages/brain/src/children.ts
@@ -3,6 +3,7 @@ import {
   type ChildCompletionRecord,
   type ChildRunRecord,
   CONTEXT_INPUT_KIND,
+  SingleFlight,
 } from "@sidecar/runtime/vocabulary";
 import { childRunEnd, RUN_FORGOTTEN } from "./child-records.js";
 import { BRAIN_DEFAULTS } from "./defaults.js";
@@ -53,7 +54,7 @@ export class ChildRuns {
   /** Completions this conversation has taken, by their stable id, so a retried delivery is one item. */
   readonly #delivered = new Set<string>();
   /** Deliveries still being decided, by completion id, so a retry that arrives meanwhile joins rather than repeats. */
-  readonly #pending = new Map<string, Promise<BrainCompletionDelivery>>();
+  readonly #deciding = new SingleFlight<string, BrainCompletionDelivery>();
 
   constructor(options: ChildRunsOptions) {
     this.#options = options;
@@ -146,13 +147,9 @@ export class ChildRuns {
     completion: ChildCompletionRecord,
     record: ChildRunRecord,
   ): Promise<BrainCompletionDelivery> {
-    const pending = this.#pending.get(completion.completionId);
-    if (pending) return pending;
-    const deciding = this.#deliverCompletion(completion, record).finally(() => {
-      this.#pending.delete(completion.completionId);
-    });
-    this.#pending.set(completion.completionId, deciding);
-    return deciding;
+    return this.#deciding.run(completion.completionId, () =>
+      this.#deliverCompletion(completion, record),
+    );
   }
 
   async #deliverCompletion(

--- a/packages/brain/src/generation-clock.ts
+++ b/packages/brain/src/generation-clock.ts
@@ -1,4 +1,5 @@
 import type { ScheduledTimer } from "@sidecar/runtime/vocabulary";
+import type { IDisposable } from "@sidecar/wire";
 import { type BrainPersistedState, brainGenerationExpired } from "./envelope.js";
 import type { BrainStateStore } from "./state-store.js";
 
@@ -28,7 +29,7 @@ export class BrainGenerationClock {
   readonly #schedule: (callback: () => void, delayMs: number) => ScheduledTimer;
   readonly #cancel: (timer: ScheduledTimer) => void;
   #timer: ScheduledTimer | undefined;
-  #unsubscribe: (() => void) | undefined;
+  #replacements: IDisposable | undefined;
   #stopped = false;
 
   constructor(options: BrainGenerationClockOptions) {
@@ -46,7 +47,7 @@ export class BrainGenerationClock {
 
   /** Loads the store, arms the timer for the generation that stands, and follows every replacement. */
   async start(): Promise<void> {
-    this.#unsubscribe ??= this.#store.onReplaced((state) => this.#arm(state));
+    this.#replacements ??= this.#store.onReplaced((state) => this.#arm(state));
     const state = await this.#store.load();
     if (!this.#stopped) this.#arm(this.#store.current() ?? state);
   }
@@ -54,8 +55,8 @@ export class BrainGenerationClock {
   stop(): void {
     this.#stopped = true;
     this.#disarm();
-    this.#unsubscribe?.();
-    this.#unsubscribe = undefined;
+    this.#replacements?.dispose();
+    this.#replacements = undefined;
   }
 
   #arm(state: BrainPersistedState): void {

--- a/packages/brain/src/ledger.ts
+++ b/packages/brain/src/ledger.ts
@@ -1,3 +1,4 @@
+import { SingleFlight } from "@sidecar/runtime/vocabulary";
 import type { BrainStoreLease } from "./envelope.js";
 import type { Generation } from "./generation.js";
 import type { BrainObservationEntry } from "./observation-inbox.js";
@@ -54,7 +55,14 @@ export class BrainRequestLedger {
   readonly #now: () => number;
   readonly #report: (message: string) => void;
   readonly #notify: () => void;
-  readonly #pendingMarks = new Map<string, Map<PendingMarkField, Promise<boolean>>>();
+  /**
+   * The marks still being written, nested by field and then by run: two
+   * identifiers name a flight together, and joining them into one key would
+   * let a run id be spelled into a field's place. The field is the outer key
+   * because there are two of them and no end of run ids, so this map is
+   * bounded by the vocabulary and each flight forgets its run as it settles.
+   */
+  readonly #pendingMarks = new Map<PendingMarkField, SingleFlight<string, boolean>>();
 
   constructor(options: BrainRequestLedgerOptions) {
     this.#store = options.store;
@@ -73,29 +81,20 @@ export class BrainRequestLedger {
    * run while a write is out share that write's answer, the way retried
    * submissions share one acceptance.
    */
-  async mark(
+  mark(
     generation: Generation,
     runId: string,
     field: PendingMarkField,
     recordedAt: number,
   ): Promise<boolean> {
-    const pending = this.#pendingMarks.get(runId)?.get(field);
-    if (pending) return pending;
-    const marking = (async () => {
+    const marks = this.#pendingMarks.get(field) ?? new SingleFlight<string, boolean>();
+    this.#pendingMarks.set(field, marks);
+    return marks.run(runId, async () => {
       const record = generation.requests.get(runId);
       if (!record) return false;
       if (record[field] !== undefined) return true;
       return this.commit(generation, runId, { [field]: recordedAt });
-    })();
-    const marks = this.#pendingMarks.get(runId) ?? new Map<PendingMarkField, Promise<boolean>>();
-    marks.set(field, marking);
-    this.#pendingMarks.set(runId, marks);
-    try {
-      return await marking;
-    } finally {
-      marks.delete(field);
-      if (marks.size === 0) this.#pendingMarks.delete(runId);
-    }
+    });
   }
 
   /**

--- a/packages/brain/src/state-store.ts
+++ b/packages/brain/src/state-store.ts
@@ -1,4 +1,5 @@
 import { checkpointFormatTag, type TranscriptEvent } from "@sidecar/runtime/vocabulary";
+import { Emitter, type Event } from "@sidecar/wire";
 import {
   BRAIN_STATE_VERSION,
   type BrainPersistedState,
@@ -58,7 +59,9 @@ export class BrainStateStore {
   #state: BrainPersistedState | undefined;
   #lease: BrainStoreLease | undefined;
   #queue: Promise<unknown> = Promise.resolve();
-  readonly #replacedListeners = new Set<(state: BrainPersistedState) => void>();
+  readonly #replaced = new Emitter<BrainPersistedState>();
+  /** Hears every replacement, expiry, or Clear, with the generation that now stands. */
+  readonly onReplaced: Event<BrainPersistedState> = this.#replaced.event;
 
   constructor(options: BrainStateStoreOptions) {
     this.automaticReset = options.automaticReset ?? false;
@@ -534,14 +537,6 @@ export class BrainStateStore {
     });
   }
 
-  /** Hears every replacement, expiry, or Clear, with the generation that now stands. */
-  onReplaced(listener: (state: BrainPersistedState) => void): () => void {
-    this.#replacedListeners.add(listener);
-    return () => {
-      this.#replacedListeners.delete(listener);
-    };
-  }
-
   /** Settles once every write queued so far has landed or been refused. */
   async flush(): Promise<void> {
     await this.#queue;
@@ -571,7 +566,7 @@ export class BrainStateStore {
   }
 
   #announceReplaced(state: BrainPersistedState): void {
-    for (const listener of [...this.#replacedListeners]) listener(state);
+    this.#replaced.fire(state);
   }
 
   async #persist(

--- a/packages/gateway/src/client.ts
+++ b/packages/gateway/src/client.ts
@@ -1,4 +1,12 @@
-import { isRecord, isWireNumber, type WireRecord, type WireValue } from "@sidecar/wire";
+import {
+  Emitter,
+  type Event,
+  type IDisposable,
+  isRecord,
+  isWireNumber,
+  type WireRecord,
+  type WireValue,
+} from "@sidecar/wire";
 import {
   GATEWAY_ERROR,
   GATEWAY_METHOD,
@@ -36,8 +44,6 @@ export type GatewayCallResult =
   | { ok: true; result: WireValue | undefined }
   | { ok: false; error: GatewayError };
 
-export type GatewayClientEventListener = (event: GatewayEvent) => void;
-
 /**
  * The client side of the protocol. It mints request ids, stamps the version,
  * supplies an idempotency key to every mutation the caller did not key
@@ -49,8 +55,10 @@ export type GatewayClientEventListener = (event: GatewayEvent) => void;
  */
 export class GatewayClient {
   readonly #options: GatewayClientOptions;
-  readonly #listeners = new Map<GatewayEventKind, Set<GatewayClientEventListener>>();
-  readonly #everyListener = new Set<GatewayClientEventListener>();
+  readonly #byKind = new Map<GatewayEventKind, Emitter<GatewayEvent>>();
+  readonly #every = new Emitter<GatewayEvent>();
+  /** Hears every event of every kind, in sequence, after any gap has been filled. */
+  readonly onEvery: Event<GatewayEvent> = this.#every.event;
   #lastSequence = 0;
   /**
    * Whether this client has a baseline in the host's numbering: adopted from
@@ -70,11 +78,11 @@ export class GatewayClient {
   #generation = 0;
   /** Events that arrived while a reconnection was in flight, taken again once it has settled. */
   #arrivedDuringReconnect: GatewayEvent[] = [];
-  #unsubscribe: (() => void) | undefined;
+  #transportEvents: IDisposable | undefined;
 
   constructor(options: GatewayClientOptions) {
     this.#options = options;
-    this.#unsubscribe = options.transport.events((event) => this.#take(event));
+    this.#transportEvents = options.transport.events((event) => this.#take(event));
   }
 
   lastSequence(): number {
@@ -83,8 +91,8 @@ export class GatewayClient {
 
   /** Ends the subscription; a client not listening reconnects nothing. */
   close(): void {
-    this.#unsubscribe?.();
-    this.#unsubscribe = undefined;
+    this.#transportEvents?.dispose();
+    this.#transportEvents = undefined;
   }
 
   async call(
@@ -111,20 +119,10 @@ export class GatewayClient {
   }
 
   /** Hears every event of one kind, in sequence, after any gap has been filled. */
-  on(kind: GatewayEventKind, listener: GatewayClientEventListener): () => void {
-    const held = this.#listeners.get(kind) ?? new Set<GatewayClientEventListener>();
-    held.add(listener);
-    this.#listeners.set(kind, held);
-    return () => {
-      held.delete(listener);
-    };
-  }
-
-  onEvery(listener: GatewayClientEventListener): () => void {
-    this.#everyListener.add(listener);
-    return () => {
-      this.#everyListener.delete(listener);
-    };
+  on(kind: GatewayEventKind, listener: (event: GatewayEvent) => void): IDisposable {
+    const held = this.#byKind.get(kind) ?? new Emitter<GatewayEvent>();
+    this.#byKind.set(kind, held);
+    return held.event(listener);
   }
 
   /**
@@ -256,8 +254,8 @@ export class GatewayClient {
 
   #deliver(event: GatewayEvent): void {
     this.#lastSequence = event.sequence;
-    for (const listener of [...(this.#listeners.get(event.kind) ?? [])]) listener(event);
-    for (const listener of [...this.#everyListener]) listener(event);
+    this.#byKind.get(event.kind)?.fire(event);
+    this.#every.fire(event);
   }
 }
 

--- a/packages/gateway/src/invocations.ts
+++ b/packages/gateway/src/invocations.ts
@@ -1,3 +1,4 @@
+import { BoundedMap, SingleFlight } from "@sidecar/runtime/vocabulary";
 import {
   NODE_CAPABILITY_STATUS,
   type NodeCapabilityResult,
@@ -108,28 +109,22 @@ export const INVOCATION_MEMORY_DEFAULTS = {
  */
 export class InvocationMemory {
   readonly #handler: NodeInvocationHandler;
-  readonly #inFlight = new Map<string, Promise<NodeCapabilityResult>>();
-  readonly #settled = new Map<string, NodeCapabilityResult>();
-  readonly #capacity: number;
+  readonly #performing = new SingleFlight<string, NodeCapabilityResult>();
+  readonly #settled: BoundedMap<string, NodeCapabilityResult>;
 
   constructor(
     handler: NodeInvocationHandler,
     capacity = INVOCATION_MEMORY_DEFAULTS.SETTLED_CAPACITY,
   ) {
     this.#handler = handler;
-    this.#capacity = capacity;
+    this.#settled = new BoundedMap(capacity);
   }
 
   async take(invocation: NodeInvocation): Promise<NodeInvocationAnswer> {
     const { invocationId } = invocation;
     const settled = this.#settled.get(invocationId);
     if (settled) return { invocationId, result: settled };
-    let performance = this.#inFlight.get(invocationId);
-    if (!performance) {
-      performance = this.#perform(invocation);
-      this.#inFlight.set(invocationId, performance);
-    }
-    const result = await performance;
+    const result = await this.#performing.run(invocationId, () => this.#perform(invocation));
     return { invocationId, result };
   }
 
@@ -144,12 +139,7 @@ export class InvocationMemory {
         reason: error instanceof Error ? error.message : String(error),
       };
     }
-    this.#inFlight.delete(invocation.invocationId);
     this.#settled.set(invocation.invocationId, result);
-    if (this.#settled.size > this.#capacity) {
-      const oldest = this.#settled.keys().next().value;
-      if (oldest !== undefined) this.#settled.delete(oldest);
-    }
     return result;
   }
 }

--- a/packages/gateway/src/node-invocations.test.ts
+++ b/packages/gateway/src/node-invocations.test.ts
@@ -1,6 +1,12 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { isRecord, isWireString, type UnparsedWireValue, type WireRecord } from "@sidecar/wire";
+import {
+  Emitter,
+  isRecord,
+  isWireString,
+  type UnparsedWireValue,
+  type WireRecord,
+} from "@sidecar/wire";
 import { WebSocket } from "ws";
 import { GatewayClient } from "./client.js";
 import { InvocationMemory, NODE_INVOCATION_REFUSAL } from "./invocations.js";
@@ -13,6 +19,7 @@ import {
   GATEWAY_METHOD,
   GATEWAY_PROTOCOL_VERSION,
   type GatewayClientIdentity,
+  type GatewayEvent,
   NODE_CAPABILITY_STATUS,
   type NodeInvocation,
   nodeInvocationAnswerToWire,
@@ -369,20 +376,17 @@ test("a client that adopts a replaced host follows the new host's numbering from
   const oldServer = makeServer("old");
   const newServer = makeServer("new");
   let current = oldServer;
-  const sinks = new Set<(event: import("./protocol.js").GatewayEvent) => void>();
+  const events = new Emitter<GatewayEvent>();
   for (const server of [oldServer, newServer]) {
     server.subscribe((event) => {
       if (current !== server) return;
-      for (const sink of [...sinks]) sink(event);
+      events.fire(event);
     });
   }
   const client = new GatewayClient({
     transport: {
       request: (request) => current.handle(request, OPERATOR),
-      events: (sink) => {
-        sinks.add(sink);
-        return () => sinks.delete(sink);
-      },
+      events: events.event,
       connected: () => true,
     },
     createId: () => `r-${++ids}`,
@@ -506,11 +510,11 @@ test("an event of the new host arriving during adoption is held and delivered af
   const newServer = makeServer();
   let current = oldServer;
   let wireUp = true;
-  const sinks = new Set<(event: import("./protocol.js").GatewayEvent) => void>();
+  const events = new Emitter<GatewayEvent>();
   for (const server of [oldServer, newServer]) {
     server.subscribe((event) => {
       if (current !== server || !wireUp) return;
-      for (const sink of [...sinks]) sink(event);
+      events.fire(event);
     });
   }
   // Every request is handled at once but its answer travels back only when
@@ -524,10 +528,7 @@ test("an event of the new host arriving during adoption is held and delivered af
         await new Promise<void>((resolve) => pendingAnswers.push(resolve));
         return answered;
       },
-      events: (sink) => {
-        sinks.add(sink);
-        return () => sinks.delete(sink);
-      },
+      events: events.event,
       connected: () => true,
     },
     createId: () => `r-${++ids}`,

--- a/packages/gateway/src/nodes.ts
+++ b/packages/gateway/src/nodes.ts
@@ -1,5 +1,5 @@
 import type { MaybePromise } from "@sidecar/runtime/vocabulary";
-import type { WireRecord, WireValue } from "@sidecar/wire";
+import { Emitter, type Event, type WireRecord, type WireValue } from "@sidecar/wire";
 import { NODE_CAPABILITY_STATUS, type NodeCapabilityResult } from "./protocol.js";
 
 export type NodeCapabilityHandler = (params: WireRecord) => MaybePromise<WireValue | undefined>;
@@ -35,8 +35,6 @@ export interface NodeSnapshot {
   connected: boolean;
 }
 
-export type NodeRegistryListener = (nodes: readonly NodeSnapshot[]) => void;
-
 /**
  * The nodes connected to the host and what each can do. A native capability
  * — opening an address on this machine, carrying an action to a panel — is the
@@ -49,7 +47,9 @@ export type NodeRegistryListener = (nodes: readonly NodeSnapshot[]) => void;
  */
 export class NodeRegistry {
   readonly #nodes = new Map<string, HeldNode>();
-  readonly #listeners = new Set<NodeRegistryListener>();
+  readonly #changes = new Emitter<readonly NodeSnapshot[]>();
+  /** Hears the whole registry whenever a node registers, disconnects, or comes back. */
+  readonly onChange: Event<readonly NodeSnapshot[]> = this.#changes.event;
 
   register(registration: NodeRegistration): void {
     this.#nodes.set(registration.nodeId, {
@@ -146,13 +146,6 @@ export class NodeRegistry {
     return provider.perform(capability, params);
   }
 
-  onChange(listener: NodeRegistryListener): () => void {
-    this.#listeners.add(listener);
-    return () => {
-      this.#listeners.delete(listener);
-    };
-  }
-
   #provider(capability: string): HeldNode | undefined {
     for (const node of this.#nodes.values()) {
       if (node.connected && node.capabilities.includes(capability)) return node;
@@ -169,8 +162,7 @@ export class NodeRegistry {
   }
 
   #changed(): void {
-    const nodes = this.list();
-    for (const listener of [...this.#listeners]) listener(nodes);
+    this.#changes.fire(this.list());
   }
 }
 

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -1,5 +1,5 @@
-import type { MaybePromise } from "@sidecar/runtime/vocabulary";
-import { isWireNumber, type WireRecord, type WireValue } from "@sidecar/wire";
+import { BoundedMap, type MaybePromise } from "@sidecar/runtime/vocabulary";
+import { Emitter, type Event, isWireNumber, type WireRecord, type WireValue } from "@sidecar/wire";
 import {
   GATEWAY_CLIENT_ROLE,
   GATEWAY_ERROR,
@@ -75,8 +75,6 @@ interface IdempotentAnswer {
   answer: Promise<GatewayMethodOutcome>;
 }
 
-export type GatewayEventListener = (event: GatewayEvent) => void;
-
 /** The methods a node may call: to offer itself and to be told what it owes; everything else is the operator's. */
 const NODE_METHODS: ReadonlySet<GatewayMethod> = new Set<GatewayMethod>([
   GATEWAY_METHOD.HELLO,
@@ -100,9 +98,11 @@ export class GatewayServer {
   readonly #options: GatewayServerOptions;
   /** The host's handlers, with the two the protocol itself answers: hello and reconnect are the server's own. */
   readonly #methods: GatewayMethodTable;
-  readonly #idempotent = new Map<GatewayMethod, Map<string, IdempotentAnswer>>();
+  readonly #idempotent = new Map<GatewayMethod, BoundedMap<string, IdempotentAnswer>>();
   readonly #events: GatewayEvent[] = [];
-  readonly #listeners = new Set<GatewayEventListener>();
+  readonly #published = new Emitter<GatewayEvent>();
+  /** Hears every event the server emits, in the sequence it numbered them. */
+  readonly subscribe: Event<GatewayEvent> = this.#published.event;
   #sequence = 0;
   #admitting = true;
 
@@ -170,15 +170,8 @@ export class GatewayServer {
     this.#events.push(event);
     const window = this.#options.replayWindow ?? GATEWAY_SERVER_DEFAULTS.REPLAY_WINDOW;
     if (this.#events.length > window) this.#events.splice(0, this.#events.length - window);
-    for (const listener of [...this.#listeners]) listener(event);
+    this.#published.fire(event);
     return event;
-  }
-
-  subscribe(listener: GatewayEventListener): () => void {
-    this.#listeners.add(listener);
-    return () => {
-      this.#listeners.delete(listener);
-    };
   }
 
   /**
@@ -300,7 +293,11 @@ export class GatewayServer {
         .catch((error: Error) => gatewayError(GATEWAY_ERROR.INTERNAL, error.message));
     const key = request.idempotencyKey;
     if (key === undefined || !isMutatingGatewayMethod(request.method)) return run();
-    const ledger = this.#idempotent.get(request.method) ?? new Map<string, IdempotentAnswer>();
+    const ledger =
+      this.#idempotent.get(request.method) ??
+      new BoundedMap<string, IdempotentAnswer>(
+        this.#options.idempotencyCapacity ?? GATEWAY_SERVER_DEFAULTS.IDEMPOTENCY_CAPACITY,
+      );
     this.#idempotent.set(request.method, ledger);
     const paramsText = JSON.stringify(request.params);
     const held = ledger.get(key);
@@ -317,12 +314,6 @@ export class GatewayServer {
     }
     const answer = run();
     ledger.set(key, { paramsText, answer });
-    const capacity =
-      this.#options.idempotencyCapacity ?? GATEWAY_SERVER_DEFAULTS.IDEMPOTENCY_CAPACITY;
-    if (ledger.size > capacity) {
-      const oldest = ledger.keys().next().value;
-      if (oldest !== undefined) ledger.delete(oldest);
-    }
     return answer;
   }
 

--- a/packages/gateway/src/transport.ts
+++ b/packages/gateway/src/transport.ts
@@ -1,3 +1,4 @@
+import { Emitter, type Event, type IDisposable, toDisposable } from "@sidecar/wire";
 import {
   InvocationMemory,
   NODE_INVOCATION_REFUSAL,
@@ -29,10 +30,10 @@ export type GatewayEventSink = (event: GatewayEvent) => void;
  */
 export interface GatewayTransport {
   request(request: GatewayRequest): Promise<GatewayResponse>;
-  events(sink: GatewayEventSink): () => void;
+  events(sink: GatewayEventSink): IDisposable;
   connected(): boolean;
   /** Serves the host's invocations of this client's node capabilities, deduped by id before anything native runs. */
-  serveInvocations?(handler: NodeInvocationHandler): () => void;
+  serveInvocations?(handler: NodeInvocationHandler): IDisposable;
 }
 
 /**
@@ -46,7 +47,7 @@ export interface GatewayTransport {
 export interface GatewayHostConnection {
   connectionId: string;
   invoke(invocation: NodeInvocation): Promise<NodeCapabilityResult>;
-  onClosed(listener: () => void): () => void;
+  onClosed: Event<void>;
 }
 
 /**
@@ -61,10 +62,10 @@ export abstract class ServerBoundTransport implements GatewayTransport {
   protected readonly identity: GatewayClientIdentity;
   /** This transport as the host sees it: the connection its requests arrive on and its node is asked through. */
   protected readonly hostConnection: GatewayHostConnection;
-  readonly #sinks = new Set<GatewayEventSink>();
-  readonly #closedListeners = new Set<() => void>();
+  readonly #sinks = new Emitter<GatewayEvent>();
+  readonly #closed = new Emitter<void>();
   #memory: InvocationMemory | undefined;
-  #unsubscribe: (() => void) | undefined;
+  #serverEvents: IDisposable | undefined;
   #connected = true;
   static #connections = 0;
 
@@ -75,21 +76,16 @@ export abstract class ServerBoundTransport implements GatewayTransport {
     this.hostConnection = {
       connectionId: `in-process-${ServerBoundTransport.#connections}`,
       invoke: (invocation) => this.#invoke(invocation),
-      onClosed: (listener) => {
-        this.#closedListeners.add(listener);
-        return () => {
-          this.#closedListeners.delete(listener);
-        };
-      },
+      onClosed: this.#closed.event,
     };
   }
 
-  serveInvocations(handler: NodeInvocationHandler): () => void {
+  serveInvocations(handler: NodeInvocationHandler): IDisposable {
     const memory = new InvocationMemory(handler);
     this.#memory = memory;
-    return () => {
+    return toDisposable(() => {
       if (this.#memory === memory) this.#memory = undefined;
-    };
+    });
   }
 
   async #invoke(invocation: NodeInvocation): Promise<NodeCapabilityResult> {
@@ -110,12 +106,10 @@ export abstract class ServerBoundTransport implements GatewayTransport {
     return this.carryRequest(request);
   }
 
-  events(sink: GatewayEventSink): () => void {
-    this.#sinks.add(sink);
-    this.#unsubscribe ??= this.server.subscribe((event) => this.carryEvent(event));
-    return () => {
-      this.#sinks.delete(sink);
-    };
+  events(sink: GatewayEventSink): IDisposable {
+    const subscription = this.#sinks.event(sink);
+    this.#serverEvents ??= this.server.subscribe((event) => this.carryEvent(event));
+    return subscription;
   }
 
   connected(): boolean {
@@ -130,16 +124,16 @@ export abstract class ServerBoundTransport implements GatewayTransport {
   /** Ends the transport for good: no request answers, no event is delivered, and the host hears the connection close. */
   close(): void {
     this.#connected = false;
-    this.#unsubscribe?.();
-    this.#unsubscribe = undefined;
-    this.#sinks.clear();
-    for (const listener of [...this.#closedListeners]) listener();
-    this.#closedListeners.clear();
+    this.#serverEvents?.dispose();
+    this.#serverEvents = undefined;
+    this.#sinks.dispose();
+    this.#closed.fire();
+    this.#closed.dispose();
   }
 
   /** Hands one event, already carried across, to every sink. */
   protected deliver(event: GatewayEvent): void {
-    for (const held of [...this.#sinks]) held(event);
+    this.#sinks.fire(event);
   }
 
   /** Carries a request the connected transport admitted to the server and answers what came back. */

--- a/packages/gateway/src/websocket.ts
+++ b/packages/gateway/src/websocket.ts
@@ -3,7 +3,15 @@ import http, { type IncomingMessage } from "node:http";
 import type { AddressInfo } from "node:net";
 import type { Duplex } from "node:stream";
 import { isIdentifier } from "@sidecar/runtime/vocabulary";
-import { isRecord, isWireString, type UnparsedWireValue } from "@sidecar/wire";
+import {
+  Emitter,
+  type Event,
+  type IDisposable,
+  isRecord,
+  isWireString,
+  toDisposable,
+  type UnparsedWireValue,
+} from "@sidecar/wire";
 import { WebSocket, WebSocketServer } from "ws";
 import {
   InvocationMemory,
@@ -105,7 +113,8 @@ interface AdmittedClient {
   /** The asks out on this socket; closed with it, so every unanswered ask reads unavailable and uncertain. */
   pending: PendingInvocations;
   connection: GatewayHostConnection;
-  closedListeners: Set<() => void>;
+  /** Fired once when this client's socket closes, so every node registered on it is marked disconnected. */
+  closed: Emitter<void>;
 }
 
 type HandshakeDecision =
@@ -161,8 +170,10 @@ export class WebSocketTransport {
   readonly #clients = new Map<WebSocket, AdmittedClient>();
   /** The raw sockets whose credential is still being checked; `ws` owns none of them yet. */
   readonly #handshaking = new Set<Duplex>();
-  readonly #closedListeners = new Set<(client: GatewayClientIdentity) => void>();
-  #unsubscribe: (() => void) | undefined;
+  readonly #clientClosed = new Emitter<GatewayClientIdentity>();
+  /** Hears every admitted socket close, with the identity it was admitted under. */
+  readonly onClientClosed: Event<GatewayClientIdentity> = this.#clientClosed.event;
+  #serverEvents: IDisposable | undefined;
   #admitting = true;
   #connections = 0;
 
@@ -193,7 +204,7 @@ export class WebSocketTransport {
         this.#http.off("error", reject);
         // SAFETY: a TCP server that is listening answers an AddressInfo, never a pipe path.
         const address = this.#http.address() as AddressInfo;
-        this.#unsubscribe = this.#options.server.subscribe((event) => {
+        this.#serverEvents = this.#options.server.subscribe((event) => {
           const frame = JSON.stringify({
             kind: GATEWAY_FRAME.EVENT,
             envelope: eventToWire(event),
@@ -211,14 +222,6 @@ export class WebSocketTransport {
     return this.#clients.size;
   }
 
-  /** Hears every admitted socket close, with the identity it was admitted under. */
-  onClientClosed(listener: (client: GatewayClientIdentity) => void): () => void {
-    this.#closedListeners.add(listener);
-    return () => {
-      this.#closedListeners.delete(listener);
-    };
-  }
-
   /** Refuses every new connection from here on and closes the server's own door to mutations. */
   closeAdmissions(): void {
     this.#admitting = false;
@@ -227,8 +230,8 @@ export class WebSocketTransport {
 
   async close(): Promise<void> {
     this.#admitting = false;
-    this.#unsubscribe?.();
-    this.#unsubscribe = undefined;
+    this.#serverEvents?.dispose();
+    this.#serverEvents = undefined;
     for (const socket of [...this.#clients.keys()]) socket.close(1001, "the host is leaving");
     this.#clients.clear();
     // A socket whose credential is still being checked belongs to nobody
@@ -305,12 +308,7 @@ export class WebSocketTransport {
         );
         return answered;
       },
-      onClosed: (listener) => {
-        client.closedListeners.add(listener);
-        return () => {
-          client.closedListeners.delete(listener);
-        };
-      },
+      onClosed: client.closed.event,
     };
   }
 
@@ -333,7 +331,7 @@ export class WebSocketTransport {
       admitted: {
         identity: authenticated.admitted,
         pending: new PendingInvocations(),
-        closedListeners: new Set(),
+        closed: new Emitter(),
       },
     };
   }
@@ -372,9 +370,9 @@ export class WebSocketTransport {
       // reads unavailable before it hears the connection is gone and marks
       // the node disconnected.
       client.pending.close();
-      for (const listener of [...client.closedListeners]) listener();
-      client.closedListeners.clear();
-      for (const listener of [...this.#closedListeners]) listener(client.identity);
+      client.closed.fire();
+      client.closed.dispose();
+      this.#clientClosed.fire(client.identity);
     });
     socket.on("error", (error) => {
       this.#options.report?.(`a Gateway client socket failed: ${error.message}`);
@@ -466,8 +464,10 @@ function disconnected(id: string): GatewayResponse {
 export class WebSocketGatewayConnection implements GatewayTransport {
   readonly #socket: WebSocket;
   readonly #pending = new Map<string, (response: GatewayResponse) => void>();
-  readonly #sinks = new Set<GatewayEventSink>();
-  readonly #closedListeners = new Set<() => void>();
+  readonly #sinks = new Emitter<GatewayEvent>();
+  readonly #closed = new Emitter<void>();
+  /** Hears this connection's socket close, however it closed. */
+  readonly onClosed: Event<void> = this.#closed.event;
   #memory: InvocationMemory | undefined;
   #open = true;
 
@@ -477,8 +477,8 @@ export class WebSocketGatewayConnection implements GatewayTransport {
       if (isBinary) return;
       this.#take(data.toString());
     });
-    socket.on("close", () => this.#closed());
-    socket.on("error", () => this.#closed());
+    socket.on("close", () => this.#settleClosed());
+    socket.on("error", () => this.#settleClosed());
   }
 
   request(request: GatewayRequest): Promise<GatewayResponse> {
@@ -501,11 +501,8 @@ export class WebSocketGatewayConnection implements GatewayTransport {
     });
   }
 
-  events(sink: GatewayEventSink): () => void {
-    this.#sinks.add(sink);
-    return () => {
-      this.#sinks.delete(sink);
-    };
+  events(sink: GatewayEventSink): IDisposable {
+    return this.#sinks.event(sink);
   }
 
   connected(): boolean {
@@ -518,25 +515,18 @@ export class WebSocketGatewayConnection implements GatewayTransport {
    * invocation arriving while no handler is served is answered unavailable,
    * so the host never waits on a node that is not there.
    */
-  serveInvocations(handler: NodeInvocationHandler): () => void {
+  serveInvocations(handler: NodeInvocationHandler): IDisposable {
     const memory = new InvocationMemory(handler);
     this.#memory = memory;
-    return () => {
+    return toDisposable(() => {
       if (this.#memory === memory) this.#memory = undefined;
-    };
-  }
-
-  onClosed(listener: () => void): () => void {
-    this.#closedListeners.add(listener);
-    return () => {
-      this.#closedListeners.delete(listener);
-    };
+    });
   }
 
   close(): void {
     if (!this.#open) return;
     this.#socket.close(1000, "the client is leaving");
-    this.#closed();
+    this.#settleClosed();
   }
 
   #take(text: string): void {
@@ -561,7 +551,7 @@ export class WebSocketGatewayConnection implements GatewayTransport {
     if (kind === GATEWAY_FRAME.EVENT) {
       const event: GatewayEvent | undefined = gatewayEventFromWire(envelope);
       if (!event) return;
-      for (const sink of [...this.#sinks]) sink(event);
+      this.#sinks.fire(event);
       return;
     }
     if (kind === GATEWAY_FRAME.INVOCATION) {
@@ -588,14 +578,15 @@ export class WebSocketGatewayConnection implements GatewayTransport {
     );
   }
 
-  #closed(): void {
+  /** Settles every ask still out, tells whoever is holding this connection, and delivers nothing further. */
+  #settleClosed(): void {
     if (!this.#open) return;
     this.#open = false;
     for (const [id, resolve] of this.#pending) resolve(disconnected(id));
     this.#pending.clear();
-    for (const listener of [...this.#closedListeners]) listener();
-    this.#closedListeners.clear();
-    this.#sinks.clear();
+    this.#closed.fire();
+    this.#closed.dispose();
+    this.#sinks.dispose();
   }
 }
 

--- a/packages/host/src/brain/action-performer.test.ts
+++ b/packages/host/src/brain/action-performer.test.ts
@@ -107,7 +107,9 @@ function performer(overrides: Partial<BrainActionPerformerDependencies> = {}) {
   const recorded: ConversationEntry[] = [];
   const appActions: BrainAppActionRequest["action"][] = [];
   let facts: readonly RememberedFact[] = [];
+  let ids = 0;
   const dependencies: BrainActionPerformerDependencies = {
+    createId: () => `fact-${++ids}`,
     sessionActions: {
       perform: async (action) => {
         performed.push(action);

--- a/packages/host/src/brain/action-performer.ts
+++ b/packages/host/src/brain/action-performer.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from "node:crypto";
 import {
   ACTION_KIND,
   ACTION_REFUSAL,
@@ -14,7 +13,7 @@ import {
 import type { BrainActionExecution, BrainActionPerformer } from "@sidecar/brain";
 import type { BrainAppActionRequest } from "@sidecar/brain/requests-wire";
 import type { AppGuideSnapshot } from "@sidecar/guide";
-import { isRunOrigin, RUN_ORIGIN } from "@sidecar/runtime/vocabulary";
+import { type CreateId, isRunOrigin, RUN_ORIGIN } from "@sidecar/runtime/vocabulary";
 import type { TrackedIssue } from "@sidecar/session";
 import {
   CONVERSATION_ENTRY_KIND,
@@ -40,6 +39,7 @@ export interface BrainNotebookWriter {
 
 export interface BrainActionPerformerDependencies {
   sessionActions: SessionActionPerformer;
+  createId: CreateId;
   /** The roster as the brain was shown it: every observed session still worth a row. */
   sessions: () => readonly Session[];
   /**
@@ -173,7 +173,7 @@ export function createBrainActionPerformer(
       return dispatchByKind(admitted, {
         [ACTION_KIND.REMEMBER]: async (action) =>
           (await dependencies.notebook.remember({
-            id: randomUUID(),
+            id: dependencies.createId(),
             words: action.words,
             ...(action.replaces !== undefined ? { replaces: action.replaces } : undefined),
           }))

--- a/packages/host/src/brain/publication.test.ts
+++ b/packages/host/src/brain/publication.test.ts
@@ -14,6 +14,7 @@ import {
   type ConversationEntry,
   maximumTypedAskLength,
 } from "@sidecar/session";
+import { toDisposable } from "@sidecar/wire";
 import { operatorOverBrain } from "../testing/index.js";
 import { followBrainRequests, publishRuns } from "./publication.js";
 
@@ -343,9 +344,9 @@ test("following a brain relays every report, writes and marks the ended runs, an
   const agent = {
     subscribe: (next: (records: readonly BrainRequestRecord[]) => void) => {
       listener = next;
-      return () => {
+      return toDisposable(() => {
         listener = undefined;
-      };
+      });
     },
     ready: () => Promise.resolve(),
     requests: () => [ready],
@@ -384,7 +385,7 @@ test("a retired follower relays nothing a late report carries", async () => {
   const agent = {
     subscribe: (next: (records: readonly BrainRequestRecord[]) => void) => {
       listener = next;
-      return () => undefined;
+      return toDisposable(() => undefined);
     },
     ready: () =>
       new Promise<void>((resolve) => {

--- a/packages/host/src/brain/publication.ts
+++ b/packages/host/src/brain/publication.ts
@@ -185,7 +185,7 @@ export function followBrainRequests(
       ),
     );
   };
-  const unsubscribe = agent.subscribe(listener);
+  const subscription = agent.subscribe(listener);
   void agent.ready().then(() => listener(agent.requests()));
   // Unfollowing takes no more reports at once, but lets the ones already
   // taken finish: the stop that retires an agent reports every run it
@@ -194,7 +194,7 @@ export function followBrainRequests(
   // so the drain is bounded by the reports already queued.
   return async () => {
     accepting = false;
-    unsubscribe();
+    subscription.dispose();
     await publishing;
     following = false;
   };

--- a/packages/host/src/brain/wiring-children.test.ts
+++ b/packages/host/src/brain/wiring-children.test.ts
@@ -228,6 +228,7 @@ function composed(
     broadcastRequests: () => undefined,
     onGenerationReplaced: () => undefined,
     actions: {
+      createId: () => "id",
       sessionActions: {
         perform: async () => ({ status: ACTION_RESULT_STATUS.REJECTED, reason: "not in test" }),
         openSession: () => Promise.reject(new Error("not in test")),

--- a/packages/host/src/brain/wiring-routing.test.ts
+++ b/packages/host/src/brain/wiring-routing.test.ts
@@ -201,6 +201,7 @@ function composed(t: TestContext, gate?: Gate): Composed {
     broadcastRequests: () => undefined,
     onGenerationReplaced: () => undefined,
     actions: {
+      createId: () => "id",
       sessionActions: {
         perform: async () => ({ status: ACTION_RESULT_STATUS.REJECTED, reason: "not in test" }),
         openSession: () => Promise.reject(new Error("not in test")),

--- a/packages/host/src/brain/wiring.test.ts
+++ b/packages/host/src/brain/wiring.test.ts
@@ -36,6 +36,7 @@ function dependencies(overrides: Partial<BrainWiringDependencies> = {}) {
     broadcastRequests: () => undefined,
     onGenerationReplaced: () => undefined,
     actions: {
+      createId: () => "id",
       sessionActions: {
         perform: async () => ({ status: "accepted" }),
         openSession: async () => ({ status: "accepted" }),

--- a/packages/host/src/brain/wiring.ts
+++ b/packages/host/src/brain/wiring.ts
@@ -90,7 +90,7 @@ import {
   type SessionIdentity,
   type SessionProviderPlugin,
 } from "@sidecar/session";
-import { ACTION_RESULT_STATUS, type WireRecord } from "@sidecar/wire";
+import { ACTION_RESULT_STATUS, type IDisposable, type WireRecord } from "@sidecar/wire";
 import {
   type BrainActionPerformerDependencies,
   createBrainActionPerformer,
@@ -284,7 +284,7 @@ interface OpenConversation {
   host: BrainHost;
   store: BrainStateStore;
   clock: BrainGenerationClock;
-  unsubscribe: () => void;
+  generationReplacements: IDisposable;
 }
 
 /** How many notices main keeps unread before the oldest go; each is one line about one turn. */
@@ -391,14 +391,16 @@ export function wireBrain(dependencies: BrainWiringDependencies): BrainWiring {
     // included: they are that generation's words, and an offer is not proof
     // they were said. The agent hears the same announcement and stands its
     // runs down itself.
-    const unsubscribe = store.onReplaced(() => dependencies.onGenerationReplaced(sessionKey));
+    const generationReplacements = store.onReplaced(() =>
+      dependencies.onGenerationReplaced(sessionKey),
+    );
     // The generation's clock stands with the store, not with an agent, so a
     // store whose automatic reset is enabled sees the generation die on time
     // through a launch with no key or account, and after its agent was
     // retired. Under the default policy of no automatic reset it arms nothing.
     const clock = new BrainGenerationClock({ store });
     void clock.start();
-    const opened: OpenConversation = { host, store, clock, unsubscribe };
+    const opened: OpenConversation = { host, store, clock, generationReplacements };
     conversations.set(sessionKey, opened);
     return opened;
   };
@@ -882,7 +884,7 @@ export function wireBrain(dependencies: BrainWiringDependencies): BrainWiring {
       opened.host.retire();
       await opened.host.replace(() => undefined);
       opened.clock.stop();
-      opened.unsubscribe();
+      opened.generationReplacements.dispose();
       conversations.delete(sessionKey);
       latestRecords.delete(sessionKey);
       publications.delete(sessionKey);

--- a/packages/host/src/compose-brain.ts
+++ b/packages/host/src/compose-brain.ts
@@ -215,6 +215,7 @@ export function composeBrain(dependencies: BrainDependencies): BrainComposer {
     },
     actions: {
       sessionActions: observation.sessionActions,
+      createId,
       sessions: observation.actableSessions,
       refreshSessions: () => observation.loop.refresh(),
       workspaceProjects: observation.workspaceProjects,

--- a/packages/host/src/compose-observation.ts
+++ b/packages/host/src/compose-observation.ts
@@ -60,6 +60,7 @@ import {
 import { APP_SETTING_SCHEMA } from "@sidecar/settings";
 import {
   ACTION_RESULT_STATUS,
+  type IDisposable,
   isRecord,
   isWireString,
   lateRef,
@@ -194,7 +195,7 @@ export function composeObservation(dependencies: ObservationDependencies): Obser
 
   let spoolWatchers: readonly ObservationSpoolWatcher[] = [];
   const createdWorkspaceOpens = new CreatedWorkspaceOpenTracker();
-  let unsubscribeSessions: (() => void) | undefined;
+  let observedPasses: IDisposable | undefined;
   let lastWorkspaceProjects: string | undefined;
   let workspaceProjectsBroadcastGeneration = 0;
   let rosterBroadcast = false;
@@ -390,6 +391,7 @@ export function composeObservation(dependencies: ObservationDependencies): Obser
 
   const sessionActions = createSessionActionPerformer({
     sessionRegistry,
+    createId: kernel.createId,
     openExternal: (url, kind) => kernel.openExternalThroughNode(url, kind),
     pluginFor,
     sendsNetwork: runMode.sendsNetwork,
@@ -573,8 +575,8 @@ export function composeObservation(dependencies: ObservationDependencies): Obser
   }
 
   function startObservation(): void {
-    if (!runMode.observesProviders || !account.capabilitiesActive() || unsubscribeSessions) return;
-    unsubscribeSessions = sessionRegistry.subscribe((sessions) => {
+    if (!runMode.observesProviders || !account.capabilitiesActive() || observedPasses) return;
+    observedPasses = sessionRegistry.subscribe((sessions) => {
       broadcastSessions(sessions);
       openCreatedWorkspaces(sessions);
       void broadcastWorkspaceProjects();
@@ -584,8 +586,8 @@ export function composeObservation(dependencies: ObservationDependencies): Obser
 
   function stopObservation(): void {
     workspaceProjectsBroadcastGeneration += 1;
-    unsubscribeSessions?.();
-    unsubscribeSessions = undefined;
+    observedPasses?.dispose();
+    observedPasses = undefined;
     for (const { plugin } of orderedRegistrations) {
       sessionRegistry.replaceProvider(plugin.provider, []);
     }
@@ -743,8 +745,8 @@ export function composeObservation(dependencies: ObservationDependencies): Obser
       });
     },
     stop: async () => {
-      unsubscribeSessions?.();
-      unsubscribeSessions = undefined;
+      observedPasses?.dispose();
+      observedPasses = undefined;
       for (const watcher of spoolWatchers) watcher.close();
       spoolWatchers = [];
       supersetSignIn.shutdown();

--- a/packages/host/src/operator.ts
+++ b/packages/host/src/operator.ts
@@ -12,7 +12,14 @@ import {
 import type { GatewayCallResult, GatewayClient } from "@sidecar/gateway";
 import { GATEWAY_EVENT, GATEWAY_METHOD, gatewayEventReader } from "@sidecar/gateway";
 import { MAIN_SESSION_KEY, type SessionKey } from "@sidecar/runtime/vocabulary";
-import { isRecord, isWireBoolean, isWireNumber, isWireString, type WireValue } from "@sidecar/wire";
+import {
+  type Event,
+  isRecord,
+  isWireBoolean,
+  isWireNumber,
+  isWireString,
+  type WireValue,
+} from "@sidecar/wire";
 import { CONVERSATION_DELETE_OUTCOME } from "./brain/conversation-deletion.js";
 import { REJECTED_SUBMISSION } from "./brain/publication.js";
 
@@ -37,10 +44,10 @@ export interface GatewayOperator {
   acknowledge: (runId: string, deliveryId: string, epoch: number) => Promise<boolean>;
   /** Delete conversation on a conversation: answers whether the erasure completed or was interrupted, false only when refused. */
   deleteConversation: (sessionKey?: SessionKey) => Promise<boolean>;
-  onRunsChanged: (listener: (runs: readonly BrainRequestSnapshot[]) => void) => () => void;
-  onDeliveryOffered: (listener: (offer: BrainReplyOffer) => void) => () => void;
-  onDeliveriesWithdrawn: (listener: (epoch: number) => void) => () => void;
-  onConversationChanged: (listener: (change: GatewayConversationChange) => void) => () => void;
+  onRunsChanged: Event<readonly BrainRequestSnapshot[]>;
+  onDeliveryOffered: Event<BrainReplyOffer>;
+  onDeliveriesWithdrawn: Event<number>;
+  onConversationChanged: Event<GatewayConversationChange>;
   /** The underlying client, for the calls the typed surface above does not name. */
   readonly client: GatewayClient;
 }

--- a/packages/host/src/session-action-performer.test.ts
+++ b/packages/host/src/session-action-performer.test.ts
@@ -102,6 +102,7 @@ function deeperPerformer(
   };
   return createSessionActionPerformer({
     sessionRegistry: registry,
+    createId: () => "press-nonce",
     openExternal,
     pluginFor: (providerId) => (providerId === plugin.provider.id ? plugin : undefined),
     sendsNetwork: true,

--- a/packages/host/src/session-action-performer.ts
+++ b/packages/host/src/session-action-performer.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from "node:crypto";
 import {
   ACTION_KIND,
   ACTION_REFUSAL,
@@ -29,6 +28,7 @@ import {
   type SupersetSessionContext,
   supersetPressedLink,
 } from "@sidecar/providers";
+import type { CreateId } from "@sidecar/runtime/vocabulary";
 import {
   dispatchAction,
   ExternalOpenAnswerLostError,
@@ -76,6 +76,7 @@ function unknownOpen(error: ExternalOpenAnswerLostError): SessionOpenResult {
  */
 export interface SessionActionPerformerDependencies {
   sessionRegistry: SessionRoster;
+  createId: CreateId;
   /**
    * Hands an address to the operating system through the native node, told
    * what the address is: a row's press has already stood its panel down, and
@@ -163,6 +164,7 @@ export function createSessionActionPerformer(
 ): SessionActionPerformer {
   const {
     sessionRegistry,
+    createId,
     openExternal,
     pluginFor,
     sendsNetwork,
@@ -233,7 +235,7 @@ export function createSessionActionPerformer(
   // focus once per request id, so a nonce composed at observation time would
   // be spent by the first press and dead for every later one.
   const pressedLink = (link: string | undefined): string | undefined =>
-    link === undefined ? undefined : supersetPressedLink(link, randomUUID());
+    link === undefined ? undefined : supersetPressedLink(link, createId());
 
   const countOpen = (identity: SessionIdentity) => {
     if (isProviderId(identity.providerId)) {

--- a/packages/host/src/session-row-actions.test.ts
+++ b/packages/host/src/session-row-actions.test.ts
@@ -84,6 +84,7 @@ function fixture() {
   };
   const performer = createSessionActionPerformer({
     sessionRegistry: registry,
+    createId: () => "press-nonce",
     openExternal: async () => {},
     pluginFor: (providerId) => (providerId === PROVIDER.id ? plugin : undefined),
     sendsNetwork: true,

--- a/packages/host/src/voice-receiver.test.ts
+++ b/packages/host/src/voice-receiver.test.ts
@@ -46,9 +46,9 @@ test("every reload, replacement, or close ends the epoch and makes the receiver 
 test("a ready listener removed hears nothing more", () => {
   const receiver = new VoiceReceiver();
   const heard: number[] = [];
-  const stop = receiver.onReady((epoch) => heard.push(epoch));
+  const subscription = receiver.onReady((epoch) => heard.push(epoch));
   const epoch = receiver.begin();
-  stop();
+  subscription.dispose();
   receiver.markReady(epoch);
   assert.deepEqual(heard, []);
 });

--- a/packages/host/src/voice-receiver.ts
+++ b/packages/host/src/voice-receiver.ts
@@ -1,3 +1,5 @@
+import { Emitter, type Event } from "@sidecar/wire";
+
 /**
  * Whether the hidden voice renderer can receive anything right now, as the
  * main process alone decides it. A BrowserWindow standing is not a receiver:
@@ -10,15 +12,17 @@
  * makes the receiver unready again; whatever was offered to the old epoch is
  * the caller's to reoffer once a new one reports.
  */
-export type VoiceReceiverListener = (epoch: number) => void;
-
 export class VoiceReceiver {
   #epoch = 0;
   /** Whether a renderer has been begun and not since ended; no report counts otherwise. */
   #open = false;
   #ready = false;
-  readonly #readyListeners = new Set<VoiceReceiverListener>();
-  readonly #resetListeners = new Set<VoiceReceiverListener>();
+  readonly #readied = new Emitter<number>();
+  readonly #reset = new Emitter<number>();
+  /** Hears the epoch that just became ready to receive. */
+  readonly onReady: Event<number> = this.#readied.event;
+  /** Hears every epoch ending, with the epoch that ended, after a reset or a new beginning. */
+  readonly onReset: Event<number> = this.#reset.event;
 
   /** Begins a new epoch for a renderer about to load, unready, and answers it. */
   begin(): number {
@@ -51,29 +55,14 @@ export class VoiceReceiver {
   markReady(epoch: number): boolean {
     if (!this.#open || epoch !== this.#epoch || this.#ready) return false;
     this.#ready = true;
-    for (const listener of [...this.#readyListeners]) listener(epoch);
+    this.#readied.fire(epoch);
     return true;
-  }
-
-  onReady(listener: VoiceReceiverListener): () => void {
-    this.#readyListeners.add(listener);
-    return () => {
-      this.#readyListeners.delete(listener);
-    };
-  }
-
-  /** Hears every epoch ending, with the epoch that ended, after a reset or a new beginning. */
-  onReset(listener: VoiceReceiverListener): () => void {
-    this.#resetListeners.add(listener);
-    return () => {
-      this.#resetListeners.delete(listener);
-    };
   }
 
   #end(): void {
     const ended = this.#epoch;
     this.#open = false;
     this.#ready = false;
-    for (const listener of [...this.#resetListeners]) listener(ended);
+    this.#reset.fire(ended);
   }
 }

--- a/packages/providers/src/conductor/conversation.ts
+++ b/packages/providers/src/conductor/conversation.ts
@@ -1,3 +1,4 @@
+import { BoundedMap } from "@sidecar/runtime/vocabulary";
 import {
   ACTION_RESULT_STATUS,
   CONVERSATION_MESSAGE_AUTHOR,
@@ -45,14 +46,15 @@ import {
 /**
  * The newest offset a read of each session already reached, per credential.
  * It is the whole reason a re-opened chat costs one request: the walk starts
- * where the last read stopped instead of seeking the end again.
+ * where the last read stopped instead of seeking the end again. It is bounded
+ * and least-recently-reached first, so it stays a cache and not a ledger.
  */
 export interface ConductorConversationEnds {
-  reached: Map<string, number>;
+  reached: BoundedMap<string, number>;
 }
 
 export function conductorConversationEnds(): ConductorConversationEnds {
-  return { reached: new Map() };
+  return { reached: new BoundedMap(CONDUCTOR_CONVERSATION_BOUNDS.END_CACHE_ENTRIES) };
 }
 
 /** One documented stored-messages read, with the query the mode composed. */
@@ -232,7 +234,7 @@ async function readTailPage(
     ends.reached.delete(providerSessionId);
     walked = await walk(0);
   }
-  rememberEnd(ends, providerSessionId, walked.end);
+  ends.reached.set(providerSessionId, walked.end);
 
   // The kept pages are the newest the walk read, enough of them to carry the
   // history target; the rest is what an older-history scroll will ask for.
@@ -260,21 +262,6 @@ async function readTailPage(
     hasOlder: firstOffset > 0,
     ...(lastMessageId ? { lastMessageId } : undefined),
   };
-}
-
-/** Least-recently-reached first, so the cache stays a cache and not a ledger. */
-function rememberEnd(
-  ends: ConductorConversationEnds,
-  providerSessionId: string,
-  end: number,
-): void {
-  ends.reached.delete(providerSessionId);
-  ends.reached.set(providerSessionId, end);
-  while (ends.reached.size > CONDUCTOR_CONVERSATION_BOUNDS.END_CACHE_ENTRIES) {
-    const oldest = ends.reached.keys().next();
-    if (oldest.done) break;
-    ends.reached.delete(oldest.value);
-  }
 }
 
 /**

--- a/packages/providers/src/shared/jsonl-transcript.ts
+++ b/packages/providers/src/shared/jsonl-transcript.ts
@@ -9,6 +9,7 @@
  * a reader sees the whole rendering the tail it read produces.
  */
 
+import { BoundedMap } from "@sidecar/runtime/vocabulary";
 import {
   ACTION_RESULT_STATUS,
   OMISSION_MARKER,
@@ -153,7 +154,7 @@ export async function readRecordsSince(
 export class TranscriptPathCache {
   static readonly MAXIMUM_ENTRIES = 64;
 
-  readonly #paths = new Map<string, string>();
+  readonly #paths = new BoundedMap<string, string>(TranscriptPathCache.MAXIMUM_ENTRIES);
 
   async resolve(
     providerSessionId: string,
@@ -165,10 +166,6 @@ export class TranscriptPathCache {
     const located = await locate();
     if (located === undefined) return undefined;
     this.#paths.set(providerSessionId, located);
-    const oldest = this.#paths.keys().next();
-    if (this.#paths.size > TranscriptPathCache.MAXIMUM_ENTRIES && !oldest.done) {
-      this.#paths.delete(oldest.value);
-    }
     return located;
   }
 }

--- a/packages/providers/src/superset/cli.test.ts
+++ b/packages/providers/src/superset/cli.test.ts
@@ -282,7 +282,7 @@ test("discovers host-scoped projects and creates a workspace with a generated br
   const mutableCommands = commands as string[][];
   const cli = new SupersetCli({
     ...testCliOptions(home),
-    uniqueId: () => "deadbeef-0000-0000-0000-000000000000",
+    createId: () => "deadbeef-0000-0000-0000-000000000000",
     query: async (_executable, arguments_) => {
       if (arguments_[0] === "hosts") return "[]";
       if (arguments_[0] === "projects") {

--- a/packages/providers/src/superset/cli.ts
+++ b/packages/providers/src/superset/cli.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
+import type { CreateId } from "@sidecar/runtime/vocabulary";
 import {
   ACTION_RESULT_STATUS,
   type ProviderControlResult,
@@ -84,7 +85,7 @@ export interface SupersetCliOptions {
   homeDirectory: string;
   run?: SupersetCommandRunner;
   query?: SupersetQueryRunner;
-  uniqueId?: () => string;
+  createId?: CreateId;
   /** Overridable for tests through the file it reads, never through a process. */
   activeOrganizationId?: () => Promise<string | undefined>;
 }
@@ -93,13 +94,13 @@ export class SupersetCli {
   readonly #homeDirectory: string;
   readonly #run: SupersetCommandRunner;
   readonly #query: SupersetQueryRunner;
-  readonly #uniqueId: () => string;
+  readonly #createId: CreateId;
   readonly #activeOrganizationId: () => Promise<string | undefined>;
 
   constructor(options: SupersetCliOptions) {
     this.#homeDirectory = options.homeDirectory;
     this.#run = options.run ?? defaultCommandRunner;
-    this.#uniqueId = options.uniqueId ?? randomUUID;
+    this.#createId = options.createId ?? randomUUID;
     this.#activeOrganizationId =
       options.activeOrganizationId ?? (() => activeOrganizationId(this.#homeDirectory));
     this.#query =
@@ -508,6 +509,6 @@ export class SupersetCli {
       .replace(/^-+|-+$/gu, "")
       .slice(0, 40)
       .replace(/-+$/gu, "");
-    return `luke-${slug || "session"}-${this.#uniqueId().slice(0, 8)}`;
+    return `luke-${slug || "session"}-${this.#createId().slice(0, 8)}`;
   }
 }

--- a/packages/runtime/src/bounded-map.test.ts
+++ b/packages/runtime/src/bounded-map.test.ts
@@ -1,0 +1,62 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { BoundedMap } from "./bounded-map.js";
+
+test("entries stand until the capacity is reached", () => {
+  const held = new BoundedMap<string, number>(3);
+  held.set("a", 1).set("b", 2).set("c", 3);
+  assert.equal(held.size, 3);
+  assert.deepEqual([...held.keys()], ["a", "b", "c"]);
+  assert.equal(held.get("a"), 1);
+});
+
+test("the oldest entry is the one evicted", () => {
+  const held = new BoundedMap<string, number>(2);
+  held.set("a", 1).set("b", 2).set("c", 3);
+  assert.equal(held.size, 2);
+  assert.deepEqual([...held.keys()], ["b", "c"]);
+  assert.equal(held.get("a"), undefined);
+});
+
+test("reading does not refresh an entry, so who looked cannot change what is evicted", () => {
+  const held = new BoundedMap<string, number>(2);
+  held.set("a", 1).set("b", 2);
+  assert.equal(held.get("a"), 1);
+  held.set("c", 3);
+  assert.deepEqual([...held.keys()], ["b", "c"]);
+});
+
+test("a key written again becomes the newest", () => {
+  const held = new BoundedMap<string, number>(2);
+  held.set("a", 1).set("b", 2).set("a", 3);
+  assert.equal(held.size, 2);
+  assert.deepEqual([...held.keys()], ["b", "a"]);
+  held.set("c", 4);
+  assert.deepEqual([...held.keys()], ["a", "c"]);
+  assert.equal(held.get("a"), 3);
+});
+
+test("deleting and clearing leave room again", () => {
+  const held = new BoundedMap<string, number>(2);
+  held.set("a", 1).set("b", 2);
+  assert.ok(held.delete("a"));
+  assert.ok(!held.delete("a"));
+  assert.equal(held.size, 1);
+  held.clear();
+  assert.equal(held.size, 0);
+  assert.deepEqual([...held.keys()], []);
+});
+
+test("a capacity of one keeps only the newest", () => {
+  const held = new BoundedMap<string, number>(1);
+  held.set("a", 1).set("b", 2);
+  assert.deepEqual([...held.keys()], ["b"]);
+});
+
+test("a capacity that is not a positive integer is refused", () => {
+  assert.throws(() => new BoundedMap<string, number>(0), {
+    name: "RangeError",
+    message: "a bounded map's capacity must be a positive integer",
+  });
+  assert.throws(() => new BoundedMap<string, number>(1.5), { name: "RangeError" });
+});

--- a/packages/runtime/src/bounded-map.ts
+++ b/packages/runtime/src/bounded-map.ts
@@ -1,0 +1,54 @@
+/**
+ * A map that never grows past its capacity: once it is full, the next entry
+ * evicts the oldest one. What a bounded map is for is a cache or a ledger of
+ * recent answers, where forgetting the oldest costs a repeated read and
+ * keeping everything costs a process that grows for as long as it runs.
+ *
+ * A key written again becomes the newest rather than keeping its first
+ * position, so a map written on every reach ages by last write. Reading
+ * refreshes nothing: a read that moved an entry would make the eviction order
+ * depend on who looked, which is not what any caller here means by oldest.
+ */
+export class BoundedMap<Key, Value> {
+  readonly #entries = new Map<Key, Value>();
+  readonly #capacity: number;
+
+  constructor(capacity: number) {
+    if (!Number.isInteger(capacity) || capacity < 1) {
+      throw new RangeError("a bounded map's capacity must be a positive integer");
+    }
+    this.#capacity = capacity;
+  }
+
+  get size(): number {
+    return this.#entries.size;
+  }
+
+  get(key: Key): Value | undefined {
+    return this.#entries.get(key);
+  }
+
+  set(key: Key, value: Value): this {
+    this.#entries.delete(key);
+    this.#entries.set(key, value);
+    while (this.#entries.size > this.#capacity) {
+      const oldest = this.#entries.keys().next();
+      if (oldest.done) break;
+      this.#entries.delete(oldest.value);
+    }
+    return this;
+  }
+
+  delete(key: Key): boolean {
+    return this.#entries.delete(key);
+  }
+
+  clear(): void {
+    this.#entries.clear();
+  }
+
+  /** Oldest first, the order eviction follows. */
+  keys(): IterableIterator<Key> {
+    return this.#entries.keys();
+  }
+}

--- a/packages/runtime/src/identifiers.ts
+++ b/packages/runtime/src/identifiers.ts
@@ -32,6 +32,13 @@ function identifier<Brand extends string>(kind: Brand, value: string): Identifie
 export const agentId = (value: string): AgentId => identifier("agent", value);
 export const sessionKey = (value: string): SessionKey => identifier("session-key", value);
 
+/**
+ * Where a fresh identifier comes from. Everything that mints one takes this
+ * seam rather than reaching `node:crypto` itself, so a test names the ids it
+ * expects and one composition root decides what a real id is.
+ */
+export type CreateId = () => string;
+
 /** The provider and provider-session pair that identifies an observed coding session. */
 export interface SourceSessionRef {
   providerId: string;

--- a/packages/runtime/src/single-flight.test.ts
+++ b/packages/runtime/src/single-flight.test.ts
@@ -1,0 +1,77 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { SingleFlight } from "./single-flight.js";
+
+function deferred<Value>() {
+  let settle: (value: Value) => void = () => {};
+  let fail: (reason: Error) => void = () => {};
+  const promise = new Promise<Value>((resolve, reject) => {
+    settle = resolve;
+    fail = reject;
+  });
+  return { promise, settle, fail };
+}
+
+test("concurrent asks under one key share the run, and the work happens once", async () => {
+  const flights = new SingleFlight<string, number>();
+  const held = deferred<number>();
+  let runs = 0;
+  const start = () => {
+    runs += 1;
+    return held.promise;
+  };
+
+  const first = flights.run("a", start);
+  const second = flights.run("a", start);
+  assert.equal(runs, 1);
+
+  held.settle(7);
+  assert.deepEqual(await Promise.all([first, second]), [7, 7]);
+  assert.equal(runs, 1);
+});
+
+test("different keys are different flights", async () => {
+  const flights = new SingleFlight<string, string>();
+  const answers = await Promise.all([
+    flights.run("a", async () => "first"),
+    flights.run("b", async () => "second"),
+  ]);
+  assert.deepEqual(answers, ["first", "second"]);
+});
+
+test("a settled flight is forgotten, so the next ask runs the work again", async () => {
+  const flights = new SingleFlight<string, number>();
+  let runs = 0;
+  const start = async () => {
+    runs += 1;
+    return runs;
+  };
+
+  assert.equal(await flights.run("a", start), 1);
+  assert.equal(await flights.run("a", start), 2);
+  assert.equal(runs, 2);
+});
+
+test("a rejected flight is forgotten too, so a failure is not the answer every later ask gets", async () => {
+  const flights = new SingleFlight<string, number>();
+  let runs = 0;
+  const start = async () => {
+    runs += 1;
+    if (runs === 1) throw new Error("the first run failed");
+    return runs;
+  };
+
+  await assert.rejects(flights.run("a", start), { message: "the first run failed" });
+  assert.equal(await flights.run("a", start), 2);
+});
+
+test("every caller of a rejected flight hears the same failure", async () => {
+  const flights = new SingleFlight<string, number>();
+  const held = deferred<number>();
+  const first = flights.run("a", () => held.promise);
+  const second = flights.run("a", () => held.promise);
+
+  held.fail(new Error("the run failed"));
+  await assert.rejects(first, { message: "the run failed" });
+  await assert.rejects(second, { message: "the run failed" });
+});

--- a/packages/runtime/src/single-flight.ts
+++ b/packages/runtime/src/single-flight.ts
@@ -1,0 +1,30 @@
+/**
+ * Collapses concurrent asks under one key into one run, so the work happens
+ * once and every caller awaits the same outcome. The flight is forgotten the
+ * moment its promise settles, a rejection included: a key left occupied by a
+ * failed run would answer every later ask with that same failure, and the
+ * work would be undoable for as long as the map stands.
+ *
+ * A key is one identifier. Where two identifiers name a flight together, the
+ * caller nests a `SingleFlight` inside a map of the other one rather than
+ * joining them into a string, so neither identifier can be spelled into the
+ * other's.
+ */
+export class SingleFlight<Key, Value> {
+  readonly #flights = new Map<Key, Promise<Value>>();
+
+  /**
+   * The run standing for the key, started here when none does. `start` is
+   * called only for a flight this call opened, so a joiner never runs the
+   * work a second time.
+   */
+  run(key: Key, start: () => Promise<Value>): Promise<Value> {
+    const held = this.#flights.get(key);
+    if (held) return held;
+    const flight = start().finally(() => {
+      this.#flights.delete(key);
+    });
+    this.#flights.set(key, flight);
+    return flight;
+  }
+}

--- a/packages/runtime/src/vocabulary.ts
+++ b/packages/runtime/src/vocabulary.ts
@@ -1,13 +1,15 @@
 /**
  * The runtime's vocabulary: the identities it keeps apart, the storage
  * contracts a durable owner of conversation state satisfies, the execution
- * seams a host composes over, the records delegation keeps, and the one
- * scheduler handle. A re-export door and nothing else, Node-free by
+ * seams a host composes over, the records delegation keeps, the scheduler
+ * handle, and the two collections a runtime's bookkeeping is kept in. A
+ * re-export door and nothing else, Node-free by
  * construction, because packages below the runtime — realtime, hosted,
  * voice, devtrace, memory — import this door and not the barrel, which
  * reaches `node:fs`.
  */
 
+export { BoundedMap } from "./bounded-map.js";
 export {
   CHILD_CLEANUP,
   CHILD_CONTEXT_MODE,
@@ -92,6 +94,7 @@ export {
   agentIdOf,
   CONVERSATION_KIND,
   type ConversationKind,
+  type CreateId,
   childAgentOf,
   childIdOf,
   childSessionKey,
@@ -113,6 +116,7 @@ export {
   sessionKey,
   threadSessionKey,
 } from "./identifiers.js";
+export { SingleFlight } from "./single-flight.js";
 export {
   ARCHIVE_ENCODING,
   ARCHIVE_REASON,

--- a/packages/session/src/session-registry.test.ts
+++ b/packages/session/src/session-registry.test.ts
@@ -305,14 +305,14 @@ test("a refresh may reshape the observation before it lands, per provider", asyn
 test("every pass reaches the listeners, moved or not", () => {
   const roster = new SessionRoster();
   const heard: number[] = [];
-  const unsubscribe = roster.subscribe((sessions) => {
+  const subscription = roster.subscribe((sessions) => {
     heard.push(sessions.length);
   });
 
   roster.replaceProvider(codex, [observation("active", 10)]);
   roster.replaceProvider(codex, [observation("active", 10)]);
   roster.replaceProvider(codex, []);
-  unsubscribe();
+  subscription.dispose();
   roster.replaceProvider(codex, [observation("active", 10)]);
 
   // Nothing here decides whether anything moved; the renderer draws identical

--- a/packages/session/src/session-registry.ts
+++ b/packages/session/src/session-registry.ts
@@ -1,9 +1,8 @@
+import { Emitter, type Event } from "@sidecar/wire";
 import { normalizeSession, normalizeSessionIdentity } from "./normalize.js";
 import type { SessionProviderPlugin } from "./provider-plugin.js";
 import type { SessionIdentity, SessionProvider } from "./session-identity.js";
 import type { ProviderSessionObservation, Session } from "./session-shape.js";
-
-export type SessionRosterListener = (sessions: readonly Session[]) => void;
 
 type SessionObservationTransform = (
   providerId: string,
@@ -29,7 +28,9 @@ function normalizedProviderId(provider: SessionProvider): string {
  */
 export class SessionRoster {
   #sessions = new Map<string, ProviderSessions>();
-  #listeners = new Set<SessionRosterListener>();
+  readonly #passes = new Emitter<readonly Session[]>();
+  /** Hears every pass, whether or not anything moved; what is new is the reader's own to notice. */
+  readonly subscribe: Event<readonly Session[]> = this.#passes.event;
 
   get(identity: SessionIdentity): Session | undefined {
     const normalizedIdentity = normalizeSessionIdentity(identity);
@@ -48,11 +49,6 @@ export class SessionRoster {
           first.providerId.localeCompare(second.providerId) ||
           first.providerSessionId.localeCompare(second.providerSessionId),
       );
-  }
-
-  subscribe(listener: SessionRosterListener): () => void {
-    this.#listeners.add(listener);
-    return () => this.#listeners.delete(listener);
   }
 
   /**
@@ -79,7 +75,7 @@ export class SessionRoster {
     if (replacement.size === 0) this.#sessions.delete(providerId);
     else this.#sessions.set(providerId, replacement);
     const sessions = this.list();
-    for (const listener of this.#listeners) listener(sessions);
+    this.#passes.fire(sessions);
     return sessions;
   }
 

--- a/packages/voice/src/capability-assembler.ts
+++ b/packages/voice/src/capability-assembler.ts
@@ -15,6 +15,7 @@ import {
   VOICE_SOURCE,
   type VoiceSource,
 } from "@sidecar/settings";
+import { Emitter, type Event } from "@sidecar/wire";
 import { openAiRealtimeCredentials, unavailableRealtimeDiagnostics } from "./openai-credentials.js";
 import { hostedRealtimeCredentialMinter, type RealtimeCredentialMinter } from "./service-mint.js";
 
@@ -105,7 +106,13 @@ export class VoiceCapabilityAssembler {
   #unavailableDiagnostics: RealtimeDiagnostics;
   #voiceSource: VoiceSource = VOICE_SOURCE.ACCOUNT;
   #applications = 0;
-  readonly #applied = new Set<() => void>();
+  readonly #applied = new Emitter<void>();
+  /**
+   * Hears every application that published, after its capability set stands,
+   * so a reader of the adapters can follow a credential change without
+   * polling.
+   */
+  readonly onApplied: Event<void> = this.#applied.event;
 
   constructor(options: VoiceCapabilityAssemblerOptions) {
     this.#options = options;
@@ -136,18 +143,6 @@ export class VoiceCapabilityAssembler {
    */
   get embeddingAdapter(): EmbeddingAdapter | undefined {
     return this.#embeddingAdapter;
-  }
-
-  /**
-   * Hears every application that published, after its capability set stands,
-   * so a reader of the adapters can follow a credential change without
-   * polling. Answers the unsubscribe.
-   */
-  onApplied(listener: () => void): () => void {
-    this.#applied.add(listener);
-    return () => {
-      this.#applied.delete(listener);
-    };
   }
 
   get realtimeCredentials(): RealtimeCredentialMinter | undefined {
@@ -233,7 +228,7 @@ export class VoiceCapabilityAssembler {
     this.#voiceSource = policy.source;
     if (policy.useHosted) this.#warmHostedVoice();
     this.#report(apiKey !== undefined);
-    for (const listener of this.#applied) listener();
+    this.#applied.fire();
     return { latest: true, isCurrent };
   }
 

--- a/packages/voice/src/orchestrator/conversation-thread.test.ts
+++ b/packages/voice/src/orchestrator/conversation-thread.test.ts
@@ -23,7 +23,7 @@ function thread(
       return overrides.append?.(entries) ?? Promise.resolve(true);
     },
     onChanged: () => changes.push(1),
-    newEventId: () => {
+    createEventId: () => {
       ids += 1;
       return `event-${ids}`;
     },

--- a/packages/voice/src/orchestrator/conversation-thread.ts
+++ b/packages/voice/src/orchestrator/conversation-thread.ts
@@ -1,4 +1,4 @@
-import type { ScheduledTimer } from "@sidecar/runtime/vocabulary";
+import type { CreateId, ScheduledTimer } from "@sidecar/runtime/vocabulary";
 import {
   adoptConversationThread,
   appendConversationThreadEntry,
@@ -53,7 +53,7 @@ export interface ConversationThreadOptions {
   now?: () => number;
   schedule?: (callback: () => void, delayMs: number) => ScheduledTimer;
   cancel?: (timer: ScheduledTimer) => void;
-  newEventId?: () => string;
+  createEventId?: CreateId;
 }
 
 /**
@@ -225,7 +225,7 @@ export class ConversationThread {
     if (!entry || !conversationEntryBelongsToConversation(generation, this.#generation)) return;
     this.#entries = appendConversationThreadEntry(this.#entries, {
       ...entry,
-      eventId: entry.eventId ?? this.#newEventId(),
+      eventId: entry.eventId ?? this.#createEventId(),
     });
     this.#publish();
   }
@@ -339,7 +339,7 @@ export class ConversationThread {
       mark.after,
       mark.recordedAt,
       mark.runId,
-      this.#newEventId(),
+      this.#createEventId(),
     );
     // A transcription that came back empty ended its turn — the preview and
     // the mark are already spent — but placed no line, and a thread that did
@@ -458,8 +458,8 @@ export class ConversationThread {
     this.#clearRetention();
   }
 
-  #newEventId(): string {
-    return (this.#options.newEventId ?? crypto.randomUUID.bind(crypto))();
+  #createEventId(): string {
+    return (this.#options.createEventId ?? crypto.randomUUID.bind(crypto))();
   }
 
   #now(): number {

--- a/packages/voice/src/orchestrator/voice-orchestrator.ts
+++ b/packages/voice/src/orchestrator/voice-orchestrator.ts
@@ -11,7 +11,7 @@ import {
   voiceExchangeActive,
 } from "@sidecar/realtime";
 import type { SpeechOffer } from "@sidecar/realtime/speech";
-import type { ScheduledTimer } from "@sidecar/runtime/vocabulary";
+import type { CreateId, ScheduledTimer } from "@sidecar/runtime/vocabulary";
 import {
   announcementConversationEntry,
   type ConversationEntry,
@@ -21,7 +21,7 @@ import {
   type Session,
 } from "@sidecar/session";
 import { TALK_KEY_RELEASE, talkKeyRelease, voiceHotkeyLabel } from "@sidecar/settings";
-import type { WireRecord } from "@sidecar/wire";
+import { Emitter, type Event, type WireRecord } from "@sidecar/wire";
 import { askBrain } from "./brain-ask.js";
 import { ConversationThread } from "./conversation-thread.js";
 import { NoticeStrip } from "./notice-strip.js";
@@ -155,7 +155,7 @@ export interface VoiceOrchestratorDeps<Stream> {
   elapsed?: () => number;
   schedule?: (callback: () => void, delayMs: number) => ScheduledTimer;
   cancel?: (timer: ScheduledTimer) => void;
-  newEventId?: () => string;
+  createEventId?: CreateId;
 }
 
 /**
@@ -177,7 +177,9 @@ export class VoiceOrchestrator<Stream> {
   readonly #strip: NoticeStrip;
   /** What leaves for every panel to draw, and the rules about when. */
   readonly #reporter: VoiceViewReporter;
-  readonly #listeners = new Set<(state: VoiceState<Stream>) => void>();
+  readonly #states = new Emitter<VoiceState<Stream>>();
+  /** Hears the streams the surface draws, whenever either changes. */
+  readonly subscribe: Event<VoiceState<Stream>> = this.#states.event;
 
   #surroundings: VoiceSurroundings = NO_SURROUNDINGS;
   /**
@@ -251,18 +253,11 @@ export class VoiceOrchestrator<Stream> {
       now: deps.now,
       schedule: deps.schedule,
       cancel: deps.cancel,
-      newEventId: deps.newEventId,
+      createEventId: deps.createEventId,
     });
   }
 
   // — what the surface reads —
-
-  subscribe(listener: (state: VoiceState<Stream>) => void): () => void {
-    this.#listeners.add(listener);
-    return () => {
-      this.#listeners.delete(listener);
-    };
-  }
 
   snapshot(): VoiceState<Stream> {
     return this.#state;
@@ -890,7 +885,7 @@ export class VoiceOrchestrator<Stream> {
       return;
     }
     this.#state = { meterStream, remoteStream: this.#remoteStream };
-    for (const listener of [...this.#listeners]) listener(this.#state);
+    this.#states.fire(this.#state);
   }
 
   #view(): VoiceViewReport {


### PR DESCRIPTION
Thirteen files kept twenty of their own listener `Set`s, their own copy-on-fire loop, and their own unsubscribe closure; four kept their own oldest-first eviction; three kept their own in-flight map. Each of those is now one implementation. Net **+154 lines** across 53 files (+558 / −404), of which the two new primitives and their tests are +228.

## What was deleted

**Hand-rolled listener sets → `@sidecar/wire`'s `Emitter`/`Event` (PR 1's).** Twenty sets across thirteen files, and with them twenty copies of `add`/`delete`/`for (const l of [...set]) l(v)`:

| Package | File | What went |
| --- | --- | --- |
| gateway | `transport.ts` | `#sinks`, `#closedListeners`; `GatewayHostConnection.onClosed` is now `Event<void>` |
| gateway | `server.ts` | `#listeners`, `GatewayEventListener`; `subscribe` is now `Event<GatewayEvent>` |
| gateway | `nodes.ts` | `#listeners`, `NodeRegistryListener`; `onChange` is now `Event<readonly NodeSnapshot[]>` |
| gateway | `client.ts` | `#listeners` map + `#everyListener`, `GatewayClientEventListener` |
| gateway | `websocket.ts` | three sets: `AdmittedClient.closedListeners`, `WebSocketTransport.#closedListeners`, `WebSocketGatewayConnection.#sinks`/`#closedListeners` |
| brain | `state-store.ts` | `#replacedListeners`; `onReplaced` is now `Event<BrainPersistedState>` |
| brain | `asks.ts` | `#listeners`, `BrainRequestsListener` |
| brain | `agent.ts` | the delegating `subscribe`, the re-exported `BrainRequestsListener` |
| voice | `orchestrator/voice-orchestrator.ts` | `#listeners` |
| voice | `capability-assembler.ts` | `#applied` |
| host | `voice-receiver.ts` | `#readyListeners`, `#resetListeners`, `VoiceReceiverListener` |
| desktop main | `app-state.ts` | `#listeners` |
| desktop main | `native/native-helper.ts` | `#lineListeners`, `#exitListeners` |
| session | `session-registry.ts` | `#listeners`, `SessionRosterListener` (its fire loop had no copy-on-fire; the emitter's does) |

Two more sets in `node-invocations.test.ts`'s transport double go the same way, since its `events()` has to answer an `IDisposable` now.

A returned unsubscribe is an `IDisposable` everywhere one is returned, so `GatewayOperator`'s four `onX` and `HostOperator`'s eleven are `Event<T>` declarations rather than `(listener) => () => void`, and `apps/desktop/src/main/services/operator-client.ts`'s `unsubscribers: (() => void)[]` / `while (…) pop()?.()` is a `DisposableStore`.

**New: `packages/runtime/src/single-flight.ts` and `bounded-map.ts`,** each with tests, exported through the Node-free `@sidecar/runtime/vocabulary` door (the barrel reaches `node:fs`, and gateway, providers, and the renderer bundle all import the vocabulary door only).

- `SingleFlight<Key, Value>.run(key, start)` — the flight is forgotten the moment its promise settles, **a rejection included**, so a failed run is never the answer every later ask gets. Tested: joining, work-happens-once, forgotten-on-resolve, forgotten-on-reject, and every joiner hearing the same failure.
- `BoundedMap<Key, Value>` — **eviction is oldest-first**; a key written again becomes the newest, and reading refreshes nothing. Tested: the bound, the order, write-refreshes, read-does-not, capacity 1, and a refused capacity.

Adopted at:

- `packages/brain/src/children.ts` — `#pending` (deliveries being decided by completion id).
- `packages/brain/src/ledger.ts` — `#pendingMarks`, **nested, never a single joined key** (see the ponytail pass below for which way the nesting ended up).
- `packages/gateway/src/server.ts` — the per-method idempotency ledger; the local `size > capacity` / `keys().next()` eviction is gone.
- `packages/gateway/src/invocations.ts` — `InvocationMemory`'s `#settled` is a `BoundedMap` and its `#inFlight` is a `SingleFlight`. The in-flight map was the third hand-rolled copy of the same shape, in a file this PR was already editing for the bounded one; leaving it would have been a half-adoption.
- `packages/providers/src/shared/jsonl-transcript.ts` — `TranscriptPathCache.#paths`.
- `packages/providers/src/conductor/conversation.ts` — `ends.reached`; the whole `rememberEnd` helper goes, because `BoundedMap.set` already means least-recently-reached-first.

**`type CreateId`** (in `packages/runtime/src/identifiers.ts`, exported from the vocabulary door) names the id seam, and is applied at exactly the places this PR is changing for another reason:

- The two odd names out are renamed onto it: `SupersetCliOptions.uniqueId` → `createId`, and `ConversationThreadOptions.newEventId` → `createEventId` with its pass-through in `VoiceOrchestratorDeps`.
- `packages/host/src/brain/action-performer.ts` and `packages/host/src/session-action-performer.ts` stop importing `node:crypto` and take a `CreateId` the composers hand them from `kernel.createId` — which is `packages/host/CLAUDE.md`'s rule that everything of the machine arrives as a seam, and those two direct `randomUUID()` calls were the exception.

Thirteen other option fields still spell `() => string` (`host-kernel.ts`, `service.ts`, `store-wiring.ts`, `turn-runner.ts`, `wakes.ts`, and the rest). **That is deliberate:** retyping seams in files this PR has no other business in is churn, and a sweep is a better second PR than a scattering here. An earlier revision of this branch had retyped four of them (`state-store.ts`, `asks.ts`, and the two Gateway ones) purely because those files were open; that has been pulled back, so `CreateId` now appears only where it is injected or where a field was renamed.

The direct `randomUUID` at composition roots (`operator-client.ts`, `host-service.ts`, `native-node.ts`, `window-service.ts`, `SupersetCli`'s default) stays.

## Deliberately left alone

- **`packages/credentials/src/single-flight.ts`** — a different shape: no key at all, a `() => Promise<void>` closure over one rotating refresh, wrapped once at construction. Keying it would add a parameter nobody passes.
- **`packages/runtime/src/children.ts`'s `#writes`** — a serialization chain (each write awaits the last), not a join; concurrent callers get *different* promises in order, which is the opposite of a single flight.
- **`packages/brain/src/wake-queue.ts`** — a queue, not a flight or a cache.
- **`packages/providers/src/shared/spool-watcher.ts`** — an earlier revision of this PR turned its `close()` into `dispose()` and deleted the `ObservationSpoolWatcher` interface. Reverted: the watcher held no hand-rolled listener set, single flight, or bounded map, so it is a lifecycle-vocabulary change rather than this PR's concern. `CLAUDE.md` does call a watcher's teardown an `IDisposable`, so it is worth doing — in a PR about that.
- **`packages/gateway/src/attachment.ts`'s `onAttachedChanged`** — a consumed contract with no production implementer (only its own test), so converting it would churn a type nothing supplies.

## One file the PR was told not to touch, and why it moved anyway

`packages/host/src/brain/wiring.ts` is PR 9's. `BrainStateStore.onReplaced` returning an `IDisposable` is a type-level break, so three lines there had to move with it: `OpenConversation.unsubscribe: () => void` → `generationReplacements: IDisposable`, its assignment, and `opened.unsubscribe()` → `opened.generationReplacements.dispose()`. Nothing else in that file changed. A rebase resolves it; **PR 9 should rebase on `origin/main` after this lands.**

## Documentation

One sentence became incomplete and is fixed in `packages/AGENTS.md` (line 131), which listed exactly what lives behind the Node-free vocabulary door:

> `@sidecar/runtime/vocabulary` is the same rule at the bottom of the graph: the identities, the storage contracts, ~~and~~ the execution seams, **and the two collections a layer keeps its bookkeeping in — `BoundedMap` for a cache that must not grow for as long as a process runs, `SingleFlight` for concurrent asks that are one run —** are Node-free…

Nothing in `CLAUDE.md`, `PRIVACY.md`, or any `README.md` became false: no observed data, no network path, no retention, and no trust boundary moves here. `packages/AGENTS.md`'s wire paragraph ("a listener's unsubscribe, a watcher's teardown, and the store that ends both are one shape") was written by PR 1 as the rule this PR carries out, and is now true of sixteen more files.

## Rebased on `origin/main`

Rebased past 14 commits (through `0b864b14`). One conflict, in `packages/voice/src/orchestrator/voice-orchestrator.ts`, and it was mechanical: `main` added `import type { WireRecord } from "@sidecar/wire"` while this branch added `import { Emitter, type Event }` from the same module. Resolved by keeping both on one line — neither side's change was dropped, and the file's `#states` emitter, `subscribe` field, and `createEventId` rename all survive alongside `main`'s new `conversationSeed()`.

Re-checked afterwards for what a clean auto-merge can still hide: no commit that landed meanwhile introduced a new hand-rolled listener set (`conversation-thread.ts`'s `#contextWaiters` is a one-shot promise latch — fired once, cleared, never unsubscribed — not a subscription), and the `ComposerContext` refactor left `kernel.createId` where the two performers now read it from.

## `./scripts/check.sh`

```
$ ./scripts/check.sh
…
> pnpm lint && pnpm typecheck && pnpm test && pnpm build

biome check .          Checked 1241 files in 903ms. No fixes applied.  (0 errors)
oxlint                 Found 0 warnings and 0 errors.   [25 pre-existing style warnings, unchanged from main]
typecheck              25 of 26 workspace projects — all Done
test                   ℹ tests 3107   ℹ pass 3107   ℹ fail 0
build                  apps/web Done, apps/desktop Done

exit=0
```

Per-package, before the repository run:

```
@sidecar/runtime    typecheck ✓   tests  74 / pass  74 / fail 0
@sidecar/gateway    typecheck ✓   tests  39 / pass  39 / fail 0
@sidecar/brain      typecheck ✓   tests 335 / pass 335 / fail 0
@sidecar/session    typecheck ✓   tests  89 / pass  89 / fail 0
@sidecar/providers  typecheck ✓   tests 468 / pass 468 / fail 0
@sidecar/voice      typecheck ✓   tests 118 / pass 118 / fail 0
@sidecar/host       typecheck ✓   tests 285 / pass 285 / fail 0
@luke/desktop       typecheck ✓   tests 677 / pass 677 / fail 0
```

`./scripts/verify.sh` needs a Mac and is not available in this cloud workspace. **This change is not macOS- or UI-bearing:** no renderer component, style, layout, or drawn surface moves. The one renderer file touched, `apps/desktop/src/renderer/voice/use-voice-session.ts`, adapts `useSyncExternalStore` to the new `Event` shape and renders exactly what it rendered.

## Review passes

Neither skill is installed here, so both were looked up and applied to this diff as published.

### Thermonuclear code quality review

Applied [Cursor's `thermo-nuclear-code-quality-review` skill](https://github.com/cursor/plugins/blob/main/cursor-team-kit/skills/thermo-nuclear-code-quality-review/SKILL.md) — ambitious structural simplification, spaghetti prevention, boundary clarity, no file crossing 1000 lines.

**Found and fixed — the code-judo move on `ledger.ts`.** The first cut nested `Map<runId, SingleFlight<PendingMarkField, boolean>>`, which needs a `try`/`finally` to prune the outer map, because there is no end of run ids. But `PENDING_MARK_FIELD` has exactly two members. Inverting the nesting to `Map<PendingMarkField, SingleFlight<string, boolean>>` makes the outer map bounded by the vocabulary by construction — no pruning, no `try`/`finally`, no leak to reason about, and `mark()` stops being `async` because it no longer awaits anything. Still nested, still no joined key; the field is simply the bounded half. `mark()` went from 20 lines to 8.

**Checked, no finding:** no file grew (every touched file shrank); no new conditional was threaded through an unrelated flow; no `any`, cast, or new optionality; `BoundedMap`/`SingleFlight` are not thin wrappers — each replaces three or four copy-pasted implementations; the `#byKind` map of emitters in `client.ts` is bounded by the fixed `GATEWAY_EVENT` vocabulary; the per-method idempotency map in `server.ts` is bounded by the fixed method table.

**Noted and since audited:** `Emitter.fire` throws a single `AggregateError` when a listener throws, where these sites previously let the first throw stop the round. All 20 fire sites were walked against their callers:

- Nothing in the repository reads `.errors` or tests `instanceof AggregateError` on any of these paths.
- `AggregateError extends Error`, so every `instanceof Error` / `error.message` catch above a fire still matches. The one catch that inspects an error type on an emit-adjacent path, `service.ts`'s `error instanceof ParamRefusal`, is unreachable from a listener — `ParamRefusal` is thrown by the param readers inside a handler, never by a subscriber.
- The one observable difference is diagnostic: a handler that calls `kernel.emit` whose listener throws is still answered `GATEWAY_ERROR.INTERNAL` by `server.ts`'s `#answer` catch, but with the message `"1 of 2 listeners failed"` rather than the listener's own text. Status and control flow are unchanged.
- The real semantic change is that later listeners now run where an earlier throw skipped them. Every registered listener across these sites is a transport send, a state publish, or a test collector; none has a side effect that must be skipped when a sibling fails. `AppStateStore` has exactly one subscriber, so it is unaffected either way.

That is PR 1's decided semantics, it is covered by `packages/wire/src/event.test.ts` rather than re-tested per site, and no site depended on the old behavior. The sites that fire inside another emitter's round — `ServerBoundTransport.deliver` inside `GatewayServer`'s — nest correctly.

### Ponytail review

Applied [the `ponytail-review` skill](https://github.com/DietrichGebert/ponytail/blob/main/skills/ponytail-review/SKILL.md) — over-engineering only: `delete`, `stdlib`, `native`, `yagni`, `shrink`.

- `bounded-map.ts`: **yagni** — a `capacity` getter with no caller anywhere. Deleted.
- `bounded-map.ts`: **yagni** — a `has()` with no caller anywhere (every site reads `get`). Deleted; the test that used it reads `get(…) === undefined`.
- `single-flight.ts`: **yagni** — `has()` and a `size` getter. `size` had exactly one caller, the outer-map pruning that the thermonuclear finding above deleted. Both gone; `run()` is the whole class, and the tests prove forgetting by running again rather than by peeking at a counter.
- `ledger.ts`: **shrink** — the same finding as above from the other side: −12 lines.
- `conductor/conversation.ts`: **delete** — the `rememberEnd` helper is now `BoundedMap.set`. −16 lines.
- `bounded-map.ts`: **kept** — `clear()` looked like yagni until `packages/providers/src/conductor/index.ts`'s `forget()` turned out to call it. Deleting it broke `pnpm --filter @sidecar/providers typecheck`, which is how it was caught; restored with a test.
- **Not cut, per the skill's own exclusion:** the capacity validation in `BoundedMap`'s constructor, and the `oldest.done` guard in its eviction loop.

`net: −44 lines` from the two passes, on top of the −194 the adoption itself removes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34434938260/artifacts/10135861019) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34434938260)

- Commit: `b571fb6c697213cc63f97b1d873b7fa58da3bd0e`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/156ba9ab-29be-480d-a09d-6dcc49a16ace)



