### PR TITLE
refactor(hosted): three callers stop copying the account call

### DIFF
--- a/apps/web/server/hosted/openai.ts
+++ b/apps/web/server/hosted/openai.ts
@@ -5,7 +5,7 @@
  * off, the same kill switch the feedback endpoint uses.
  */
 
-import type { CloudFetch } from "@sidecar/wire";
+import { type CloudFetch, HTTP_METHOD } from "@sidecar/wire";
 import type {
   BrainCompactRequest,
   BrainEmbeddingsRequest,
@@ -14,6 +14,7 @@ import type {
   realtimeClientSecretRequest,
   remoteRealtimeClientSecretRequest,
 } from "../core.js";
+import { callAnswered, createAccountCall, fixedBearer } from "../core.js";
 // Type-only, so the value-level import the introduction handler takes from
 // this module never becomes a runtime cycle.
 import type { introductionClientSecretRequest } from "./introduction-mint.js";
@@ -48,11 +49,6 @@ export interface OpenAiUpstreamOptions {
   signal?: AbortSignal;
 }
 
-function upstreamSignal(timeoutMs: number, cancellation: AbortSignal | undefined): AbortSignal {
-  const timeout = AbortSignal.timeout(timeoutMs);
-  return cancellation ? AbortSignal.any([timeout, cancellation]) : timeout;
-}
-
 /**
  * Posts one build-fixed document to OpenAI, resolving to nothing on a network
  * fault so a caller answers 502 without ever holding an error that could name
@@ -63,21 +59,17 @@ export async function postOpenAi(
   body: OpenAiPostBody,
   options: OpenAiUpstreamOptions,
 ): Promise<Response | undefined> {
-  const send = options.fetch ?? ((input: string, init: RequestInit) => fetch(input, init));
-  try {
-    return await send(`${HOSTED_OPENAI_DEFAULTS.BASE_URL}${path}`, {
-      method: "POST",
-      headers: {
-        authorization: `Bearer ${options.apiKey}`,
-        "content-type": "application/json",
-      },
-      body: JSON.stringify(body),
-      signal: upstreamSignal(
-        options.timeoutMs ?? HOSTED_OPENAI_DEFAULTS.REQUEST_TIMEOUT_MS,
-        options.signal,
-      ),
-    });
-  } catch {
-    return undefined;
-  }
+  const call = createAccountCall({
+    baseUrl: HOSTED_OPENAI_DEFAULTS.BASE_URL,
+    credential: fixedBearer(options.apiKey),
+    fetch: options.fetch,
+    requestTimeoutMs: options.timeoutMs ?? HOSTED_OPENAI_DEFAULTS.REQUEST_TIMEOUT_MS,
+  });
+  const answer = await call.send({
+    method: HTTP_METHOD.POST,
+    path,
+    body: JSON.stringify(body),
+    signal: options.signal,
+  });
+  return callAnswered(answer) ? answer.response : undefined;
 }

--- a/apps/web/server/hosted/posthog.ts
+++ b/apps/web/server/hosted/posthog.ts
@@ -13,7 +13,8 @@
  * retry, which this pipeline does not want — the desktop never retries either.
  */
 
-import { type CloudFetch, withoutTrailingSlash } from "@sidecar/wire";
+import { type CloudFetch, HTTP_METHOD, withoutTrailingSlash } from "@sidecar/wire";
+import { callAnswered, createAccountCall, NO_CREDENTIAL } from "../core.js";
 
 export const POSTHOG_ENVIRONMENT = {
   PROJECT_API_KEY: "POSTHOG_PROJECT_API_KEY",
@@ -92,18 +93,20 @@ export async function postPosthogBatch(
   body: PosthogBatch,
   options: PosthogUpstreamOptions = {},
 ): Promise<Response | undefined> {
-  const send = options.fetch ?? ((input: string, init: RequestInit) => fetch(input, init));
-  const host = withoutTrailingSlash(options.host?.trim() || POSTHOG_DEFAULTS.HOST);
-  try {
-    return await send(`${host}${POSTHOG_DEFAULTS.BATCH_PATH}`, {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify(body),
-      signal: AbortSignal.timeout(options.timeoutMs ?? POSTHOG_DEFAULTS.REQUEST_TIMEOUT_MS),
-    });
-  } catch {
-    return undefined;
-  }
+  // The project token travels in the batch document itself, so ingestion takes
+  // no identity of its own.
+  const call = createAccountCall({
+    baseUrl: options.host?.trim() || POSTHOG_DEFAULTS.HOST,
+    credential: NO_CREDENTIAL,
+    fetch: options.fetch,
+    requestTimeoutMs: options.timeoutMs ?? POSTHOG_DEFAULTS.REQUEST_TIMEOUT_MS,
+  });
+  const answer = await call.send({
+    method: HTTP_METHOD.POST,
+    path: POSTHOG_DEFAULTS.BATCH_PATH,
+    body: JSON.stringify(body),
+  });
+  return callAnswered(answer) ? answer.response : undefined;
 }
 
 export interface PosthogForgetOptions extends PosthogUpstreamOptions {

--- a/packages/hosted/AGENTS.md
+++ b/packages/hosted/AGENTS.md
@@ -33,7 +33,10 @@ identity at all), so who may renew a credential and who may say which account
 it answers for stay their owners' to know. What a caller keeps is its own
 vocabulary and its own reading of a status: `ask` for a caller that wants a
 validated body or nothing, `send` for one that reads the status itself.
-`device-client.ts` still carries its own copy of that dance.
+Every caller in this package now makes that call, `device-client.ts`
+included, and so do the two hosted endpoints that reach a third party on a
+key the deployment fixed: a `fixedBearer` for OpenAI, and `NO_CREDENTIAL` for
+the analytics batch, whose project token travels in the document itself.
 
 A renamed wire field keeps its old name on the wire for one iOS release. The
 desktop and the service ship together, but an installed phone reads whatever

--- a/packages/hosted/src/device-client.ts
+++ b/packages/hosted/src/device-client.ts
@@ -1,12 +1,11 @@
+import type { CloudFetch, UnparsedWireValue, WireRecord } from "@sidecar/wire";
 import {
-  type CloudFetch,
-  positiveInteger,
-  text,
-  type UnparsedWireValue,
-  unparsedWire,
-  type WireRecord,
-  withoutTrailingSlash,
-} from "@sidecar/wire";
+  type AccountCall,
+  accountBearer,
+  type CallCredential,
+  createAccountCall,
+  fixedBearer,
+} from "./account-call.js";
 import type { AccountToken } from "./account-token.js";
 import {
   type DeviceForgetAnswer,
@@ -23,12 +22,6 @@ import {
   deviceRegisterRequestSchema,
 } from "./device-wire.js";
 import { HOSTED_SERVICE_PATH } from "./service-paths.js";
-
-const DEVICE_DEFAULTS = {
-  REQUEST_TIMEOUT_MS: 10_000,
-} as const;
-
-const UNAUTHORIZED_STATUS = 401;
 
 export interface HostedDeviceClientOptions extends AccountToken {
   /** The hosted service origin, without a trailing slash. */
@@ -91,31 +84,20 @@ function forgetRecord(request: DeviceForgetRequest): WireRecord {
 /**
  * The desktop's side of the device record: register this installation at
  * sign-in, move its last-seen instant on a timer, and forget it at sign-out.
- * The shape follows the hosted vault client — token read fresh per ask, a 401
- * refreshed and retried once, every answer validated by the shared wire
+ * Every ask is the shared account call — the token read fresh per attempt, a
+ * 401 refreshed and retried once, every answer validated by the shared wire
  * contract — and a failure resolves to nothing, because no row press waits on
  * it: a registration that did not land is tried again by the next heartbeat.
  * A request the service would refuse by shape is refused here without
  * traveling at all.
  */
 export class HostedDeviceClient {
-  readonly #baseUrl: string;
-  readonly #readAccessToken: () => Promise<string | undefined>;
-  readonly #refreshAccount: () => Promise<void>;
-  readonly #fetch: CloudFetch;
-  readonly #requestTimeoutMs: number;
+  readonly #options: HostedDeviceClientOptions;
+  readonly #call: AccountCall;
 
   constructor(options: HostedDeviceClientOptions) {
-    const baseUrl = text(options.serviceBaseUrl);
-    if (!baseUrl) throw new Error("Hosted service base URL must not be empty");
-    this.#baseUrl = withoutTrailingSlash(baseUrl);
-    this.#readAccessToken = options.readAccessToken;
-    this.#refreshAccount = options.refreshAccount;
-    this.#fetch = options.fetch ?? ((input, init) => fetch(input, init));
-    this.#requestTimeoutMs = positiveInteger(
-      options.requestTimeoutMs,
-      DEVICE_DEFAULTS.REQUEST_TIMEOUT_MS,
-    );
+    this.#options = options;
+    this.#call = this.#callOn(accountBearer(options));
   }
 
   register(request: DeviceRegisterRequest): Promise<DeviceRegisterAnswer | undefined> {
@@ -154,41 +136,28 @@ export class HostedDeviceClient {
     );
   }
 
-  async #ask<Answer>(
+  #ask<Answer>(
     request: DeviceRequest,
     read: (payload: UnparsedWireValue) => Answer | undefined,
     departing?: DepartingCredential,
   ): Promise<Answer | undefined> {
-    const token = departing?.accessToken ?? (await this.#readAccessToken());
-    if (!token) return undefined;
-
-    let response = await this.#request(request, token);
-    if (response?.status === UNAUTHORIZED_STATUS && departing === undefined) {
-      await this.#refreshAccount().catch(() => undefined);
-      const refreshed = await this.#readAccessToken();
-      if (refreshed && refreshed !== token) {
-        response = await this.#request(request, refreshed);
-      }
-    }
-    if (!response?.ok) return undefined;
-
-    const payload = await response.json().catch(() => undefined);
-    return payload === undefined ? undefined : read(unparsedWire(payload));
+    const call = departing ? this.#callOn(fixedBearer(departing.accessToken)) : this.#call;
+    return call.ask(
+      {
+        method: request.method,
+        path: HOSTED_SERVICE_PATH.DEVICES,
+        body: JSON.stringify(request.body),
+      },
+      read,
+    );
   }
 
-  async #request(request: DeviceRequest, token: string): Promise<Response | undefined> {
-    try {
-      return await this.#fetch(`${this.#baseUrl}${HOSTED_SERVICE_PATH.DEVICES}`, {
-        method: request.method,
-        headers: {
-          authorization: `Bearer ${token}`,
-          "content-type": "application/json",
-        },
-        body: JSON.stringify(request.body),
-        signal: AbortSignal.timeout(this.#requestTimeoutMs),
-      });
-    } catch {
-      return undefined;
-    }
+  #callOn(credential: CallCredential): AccountCall {
+    return createAccountCall({
+      baseUrl: this.#options.serviceBaseUrl,
+      credential,
+      fetch: this.#options.fetch,
+      requestTimeoutMs: this.#options.requestTimeoutMs,
+    });
   }
 }


### PR DESCRIPTION
## What this deletes

`AccountCall` (#874) already owned the base address trimmed once, the bearer header written once, the deadline joined with the caller's own cancellation, a fetch that threw read as a fault by the error's kind alone, and the one reading of a 401 — renew, retry once, only on a credential that changed, only while it answers for the same holder. Three callers still kept their own copy of it. **4 files, +74 / −105.**

### `device-client.ts` — the whole dance, by hand

The caller PR 5's author named as the obvious next one. Its `#ask`/`#request` pair read the token, refreshed on a 401, retried once only if the token actually changed, and resolved to nothing otherwise — `accountBearer` exactly, duplicated beside the canonical version in the same package. Duplicated credential-retry logic is the kind that drifts silently and reports the drift in production.

The sign-out path is the interesting half. `forget(request, departing)` carries the token of an account on its way out, with nothing left to refresh, which is `fixedBearer` exactly. Expressing it as a credential deleted the `departing === undefined` guard that was threaded through the retry path.

### `postOpenAi` and `postPosthogBatch` — the smaller half

A try/catch around `fetch`, hand-written `authorization` and `content-type` headers, and in OpenAI's case its own `upstreamSignal` helper doing the `AbortSignal.any` join the shared call already does. Both reach a third party on a key the deployment fixed, so both take a build-fixed credential: `fixedBearer` for OpenAI, `NO_CREDENTIAL` for the analytics batch, whose project token travels in the batch document itself rather than in a header.

### What I deliberately did not do

An earlier draft of this PR also introduced a shared `CallEnvironment { fetch?, now?, requestTimeoutMs? }` and threaded it through twelve option types across `packages/brain`, `packages/analytics`, and seven files under `apps/web/server/hosted/`. **I cut it.** It deduplicated a *field list* rather than behaviour: three optional fields, no invariant enforced, nothing prevented, about 36 lines of declarations saved in exchange for an import and an indirection at every site. The tell was that `now` would have been unread by five of its twelve consumers — the type wasn't carving at a joint. What is left here is the part that actually removes risk.

`forgetPosthogPerson` also keeps its own `fetch`, for a real reason: it throws its fault through to `handleAccountDelete`, which logs `error.message`, whereas `AccountCall` answers rather than throws and drops an error's words on purpose. Converting it would have been a behaviour-and-test change outside this PR's concern.

## `check.sh`

`./scripts/check.sh` — exit 0.

```
72 generated files are up to date
4 generated files are up to date
Design contract checks passed.
Repository contract checks passed.

> luke@0.5.0 check
> pnpm lint && pnpm typecheck && pnpm test && pnpm build

... 25 packages typecheck: Done
... 25 packages test: Done
ℹ tests 3053
ℹ pass  3053
ℹ fail  0
apps/web build: Done
apps/desktop build: Done
```

`./scripts/verify.sh` needs a Mac and was not available in this cloud workspace. Nothing here is macOS- or UI-bearing — no renderer, panel, or Electron file is touched — so there is no visual evidence to inspect and no physical-notch check to perform.

## Documentation made false, and fixed

`packages/hosted/AGENTS.md`, last line of **One call stands behind all of them**:

> `device-client.ts` still carries its own copy of that dance.

False the moment this lands. Replaced with a sentence saying every caller in the package now makes that call, `device-client.ts` included, and that the two hosted endpoints reaching a third party on a deployment-fixed key do too — naming which credential each takes and why the analytics batch needs none. No sentence in the root `CLAUDE.md`, `PRIVACY.md`, or any `README.md` describes these call paths, so none of them moved.

## Review passes

### Thermonuclear code quality review ([cursor/plugins](https://github.com/cursor/plugins/blob/main/cursor-team-kit/skills/thermo-nuclear-code-quality-review/SKILL.md))

1. **Boundary cleanliness — `openai.ts` had two separate imports of `../core.js`**, one `import type` and one value import. **Fixed**: one statement with inline `type` modifiers.
2. **"Does this abstraction earn its keep, or merely wrap?"** — applied to `CallEnvironment` itself, and it did not. **Fixed by deletion**: the type and all twelve of its sites are out of this PR. This is the finding that reshaped the change.
3. **Structural regressions:** none. `device-client.ts` 190 → 158, `openai.ts` 82 → 73. No file near 1000 lines.
4. **Missed judo:** checked whether `device-client.ts`'s two credentials could collapse into one — they cannot; the departing token isn't known until `forget` is called, and folding it into a single `CallCredential` would mean the class holding sign-out state. `#callOn` has two callers, so it is not a thin one-off wrapper.
5. **Anti-spaghetti:** the change removes branching rather than adding it, and every deleted dance moved to the canonical owner rather than to a new bespoke helper.

### Ponytail review ([DietrichGebert/ponytail](https://github.com/DietrichGebert/ponytail/blob/main/skills/ponytail-review/SKILL.md))

- `openai.ts:9` `shrink:` two imports of one module. Merged.
- `account-call.ts` `yagni:` `CallEnvironment` — abstraction whose consumers mostly don't use all of it. **Cut entirely** (same finding as thermonuclear #2).
- `openai.ts` `stdlib:` `upstreamSignal` re-implements the `AbortSignal.any` join `createAccountCall` already performs. Deleted.
- `posthog.ts` / `device-client.ts` `stdlib:` hand-rolled try/catch and `AbortSignal.timeout`. Deleted, moved to the shared call.
- `device-client.ts` `shrink:` holding `#options` whole rather than three fields — rejected; naming the three fields again is *more* lines.

`net: -31 lines` (`74 insertions(+), 105 deletions(-)`).

## Behaviour notes

- `HostedDeviceClient` with an empty `serviceBaseUrl` now throws `"A call's base URL must not be empty"` rather than `"Hosted service base URL must not be empty"`. The shared call owns that check; nothing asserts the message.
- A 401 at `postOpenAi` / `postPosthogBatch` does **not** gain a retry: `fixedBearer` has no `renew` and re-reads the same authorization, `NO_CREDENTIAL` re-reads `undefined`, so `createAccountCall` returns the refusal on the first attempt exactly as before.
- `postOpenAi` still joins the caller's `signal` with the deadline, and both calls still set `content-type: application/json` — the shared call does it from the presence of a body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34433134152/artifacts/10135261557) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34433134152)

- Commit: `78d2a4573156bef36a222641ded76e7626aa8814`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
