### PR TITLE
refactor(repo): one word per concept for ending a life

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -612,7 +612,7 @@ Canonical commands:
   by no control and no method, and stands exercised by its tests.
   **Delete conversation** is the
   recoverable deletion, in a fixed order: the relayed thread is fenced and
-  every window told, the conversation's brain retired and its publication
+  every window told, the conversation's brain disposed and its publication
   drained, and then the store removes the conversation's lines, transcript,
   boundaries, and standing lifetime in one transaction with a compressed
   recovery archive of them all — zstd through `node:zlib` where the runtime
@@ -1208,7 +1208,7 @@ Canonical commands:
   them, the words Luke spoke or announced, and the actions he carried at their
   ask), beside the brain's own working memory of its turns — so the one
   conversation survives the calls that transport it: a briefing read out on
-  Luke's own call, or a call retired idle, is still remembered on the next
+  Luke's own call, or a call disposed idle, is still remembered on the next
   ask. A reply that quoted or summarized a transcript read is Conversation like
   any other reply, and enters that context under the same bounds. Each
   Conversation line's session identity is the roster-validated one its action

--- a/apps/desktop/src/main/app-state.test.ts
+++ b/apps/desktop/src/main/app-state.test.ts
@@ -129,7 +129,7 @@ test("listeners are announced in order and an unsubscribed one hears nothing", (
   const first = app.subscribe(() => heard.push("first"));
   app.subscribe(() => heard.push("second"));
   app.update({ announcements: { held: true } });
-  first();
+  first.dispose();
   app.update({ announcements: { held: false } });
   assert.deepEqual(heard, ["first", "second", "second"]);
 });

--- a/apps/desktop/src/main/app-state.ts
+++ b/apps/desktop/src/main/app-state.ts
@@ -2,6 +2,7 @@ import { isDeepStrictEqual } from "node:util";
 import { ACCOUNT_STATUS } from "@sidecar/credentials/snapshot";
 import { EMPTY_APP_GUIDE } from "@sidecar/guide";
 import { fixtureSnapshot } from "@sidecar/session/fixtures";
+import { type IDisposable, toDisposable } from "@sidecar/wire";
 import type { AppState } from "#shared/messages/app-state";
 import { MICROPHONE_STATUS } from "#shared/messages/audio";
 import type { HostBootstrap } from "./gateway/host-operator";
@@ -71,11 +72,11 @@ export class AppStateStore {
     this.#announce();
   }
 
-  subscribe(listener: () => void): () => void {
+  subscribe(listener: () => void): IDisposable {
     this.#listeners.add(listener);
-    return () => {
+    return toDisposable(() => {
       this.#listeners.delete(listener);
-    };
+    });
   }
 
   #announce(): void {

--- a/apps/desktop/src/main/gateway/host-operator.ts
+++ b/apps/desktop/src/main/gateway/host-operator.ts
@@ -38,6 +38,7 @@ import type { AppSettings, SettingsUpdateResult } from "@sidecar/settings/wire";
 import {
   ACTION_RESULT_STATUS,
   type ActionResult,
+  type IDisposable,
   isRecord,
   isWireBoolean,
   isWireNumber,
@@ -165,23 +166,23 @@ export interface HostOperator {
   onboardingState(): Promise<{ calendarOnboardingOwed: boolean } | undefined>;
   skipCalendarOnboarding(): Promise<void>;
   completeCalendarOnboarding(): Promise<void>;
-  onSettingsChanged(listener: (change: HostSettingsChange) => void): () => void;
-  onAccountChanged(listener: (account: AccountSnapshot) => void): () => void;
+  onSettingsChanged(listener: (change: HostSettingsChange) => void): IDisposable;
+  onAccountChanged(listener: (account: AccountSnapshot) => void): IDisposable;
   onSessionsChanged(
     listener: (roster: { sessions: readonly Session[]; settled: boolean }) => void,
-  ): () => void;
+  ): IDisposable;
   onWorkspaceProjectsChanged(
     listener: (projects: readonly ObservedWorkspaceProject[]) => void,
-  ): () => void;
+  ): IDisposable;
   onCalendarsChanged(
     listener: (calendars: readonly ObservedAccountCalendars[]) => void,
-  ): () => void;
-  onAnnouncementsHeldChanged(listener: (held: boolean) => void): () => void;
-  onSupersetSignInChanged(listener: (state: SupersetSignInSnapshot) => void): () => void;
-  onCalendarOnboardingChanged(listener: (owed: boolean) => void): () => void;
-  onSpeechOffered(listener: (offer: SpeechOffer) => void): () => void;
-  onSpeechWithdrawn(listener: (id: string) => void): () => void;
-  onSessionReplayChanged(listener: (replay: HostSessionReplay) => void): () => void;
+  ): IDisposable;
+  onAnnouncementsHeldChanged(listener: (held: boolean) => void): IDisposable;
+  onSupersetSignInChanged(listener: (state: SupersetSignInSnapshot) => void): IDisposable;
+  onCalendarOnboardingChanged(listener: (owed: boolean) => void): IDisposable;
+  onSpeechOffered(listener: (offer: SpeechOffer) => void): IDisposable;
+  onSpeechWithdrawn(listener: (id: string) => void): IDisposable;
+  onSessionReplayChanged(listener: (replay: HostSessionReplay) => void): IDisposable;
 }
 
 export interface HostOperatorOptions {

--- a/apps/desktop/src/main/ipc/voice-runtime.ts
+++ b/apps/desktop/src/main/ipc/voice-runtime.ts
@@ -67,14 +67,14 @@ export function voiceRuntimeActRows(
     // bounded it; here it is checked to come from a panel — the voice window
     // does not command itself — and handed on. A Clear is carried out here
     // first, because the main process is the thread's store and every panel's
-    // relay; the voice window is told to retire its own turns at the fence,
+    // relay; the voice window is told to dispose its own turns at the fence,
     // whatever the disk later answers, and the panel hears whether the
     // erasure completed.
     async [ACT_KIND.VOICE_COMMAND]({ command }, { panel }) {
       if (!panel) return undefined;
       // The Clear's fence is raised in this call's synchronous prefix, and
       // the voice window is told in the same breath — before the disk is
-      // waited on — so its turns, marks, and context retire with main's.
+      // waited on — so its turns, marks, and context are disposed with main's.
       // Its answer, the disk's, comes after and goes to the panel alone.
       const erasing =
         command === VOICE_COMMAND.CLEAR_CONVERSATION ? dependencies.clearConversation() : undefined;

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -120,13 +120,13 @@ async function main(): Promise<void> {
  * The whole quit: every service gives back what it began, in the reverse of
  * the order it began in, and the host's drain is one of those steps — so no
  * runtime work of Luke's continues after an intentional quit. The first ask
- * is held open for the teardown; the quit it makes afterwards is the one that
+ * is held open for the dispose; the quit it makes afterwards is the one that
  * leaves.
  *
- * A quit arriving after the teardown has finished is never held, and the
+ * A quit arriving after the dispose has finished is never held, and the
  * updater's restart depends on it: Squirrel's own quit must reach the
- * installer, and a prevented `before-quit` aborts the update. So the updater
- * runs the same teardown itself and only then hands over, which is why what
+ * installer, and a prevented `before-quit` cancels the update. So the updater
+ * runs the same dispose itself and only then hands over, which is why what
  * is read here is whether one has finished rather than whether one is owed.
  */
 function registerQuit(services: DesktopServices): void {

--- a/apps/desktop/src/main/native/microphone-route.ts
+++ b/apps/desktop/src/main/native/microphone-route.ts
@@ -35,7 +35,7 @@ export interface MicrophoneRouteWatch {
    * the same line every change does.
    */
   probe(): void;
-  /** Stops the helper. Nothing succeeds it during shutdown, so no one waits. */
+  /** Stops the helper. Nothing succeeds it during dispose, so no one waits. */
   stop(): void;
 }
 

--- a/apps/desktop/src/main/native/output-volume.ts
+++ b/apps/desktop/src/main/native/output-volume.ts
@@ -35,7 +35,7 @@ export interface OutputVolumeWatch {
    * is not yet a readable output — that arrives on the helper's first line.
    */
   start(): boolean;
-  /** Stops the helper. Nothing succeeds it during shutdown, so no one waits. */
+  /** Stops the helper. Nothing succeeds it during dispose, so no one waits. */
   stop(): void;
 }
 

--- a/apps/desktop/src/main/native/talk-key.test.ts
+++ b/apps/desktop/src/main/native/talk-key.test.ts
@@ -110,7 +110,7 @@ test("stopping is the app's own doing and is not a key becoming unavailable", ()
   context.die();
 
   assert.equal(context.killed(), true);
-  // Falling back to another key during shutdown would register a global
+  // Falling back to another key during dispose would register a global
   // shortcut on the way out of the app.
   assert.deepEqual(context.edges, ["registered:Alt+Space"]);
 });

--- a/apps/desktop/src/main/services/compose-desktop.ts
+++ b/apps/desktop/src/main/services/compose-desktop.ts
@@ -40,9 +40,9 @@ export interface DesktopServices {
   stop: () => Promise<void>;
   /**
    * Whether a stop has run to its end. The entry reads it to decide whether
-   * to hold a quit back: the first ask is held so the teardown can finish,
+   * to hold a quit back: the first ask is held so the dispose can finish,
    * and every quit after it — including the installer's own — is let
-   * through, because a prevented `before-quit` aborts an update.
+   * through, because a prevented `before-quit` cancels an update.
    */
   stopped: () => boolean;
 }
@@ -62,8 +62,8 @@ export function composeDesktop(config: DesktopConfig): DesktopServices {
    * Whether a Quit has been asked for. It is set the moment `stop` is called
    * rather than when the drain is reached, because the drain is several
    * awaited stops behind that ask: a launch suspended on one of its own waits
-   * would otherwise resume after the teardown and open a window, claim the
-   * keys, and re-attach the listeners the teardown just released.
+   * would otherwise resume after the dispose and open a window, claim the
+   * keys, and re-attach the listeners the dispose just released.
    */
   let quitting = false;
   const keychain = createKeychainService();
@@ -99,7 +99,7 @@ export function composeDesktop(config: DesktopConfig): DesktopServices {
     config,
     recordProductEvent: telemetry.recordProductEvent,
     engine: updateEngine,
-    beforeRestart: () => teardown(),
+    beforeRestart: () => dispose(),
     state,
   });
 
@@ -145,11 +145,11 @@ export function composeDesktop(config: DesktopConfig): DesktopServices {
   let stopping: Promise<void> | undefined;
   let stopped = false;
 
-  // Two paths ask for the teardown — the explicit Quit, a launch that could
+  // Two paths ask for the dispose — the explicit Quit, a launch that could
   // not stand up — and the updater asks for it before the install. All three
   // are handed the one under way rather than a second pass over services
   // already stopped.
-  function teardown(): Promise<void> {
+  function dispose(): Promise<void> {
     quitting = true;
     // An action still waiting on a panel is refused before the host drains: the
     // panels are going, so nothing can answer one, and the drain would
@@ -178,12 +178,12 @@ export function composeDesktop(config: DesktopConfig): DesktopServices {
       await host.start();
       // A Quit that landed during the standup is already tearing this process
       // down; the launch must not go on to spend the update mark or draw
-      // windows over it, which would also abort the quit it interrupted.
+      // windows over it, which would also cancel the quit it interrupted.
       if (quitting) return;
       await updates.start();
       await windows.start();
     },
-    stop: teardown,
+    stop: dispose,
     stopped: () => stopped,
   };
 }

--- a/apps/desktop/src/main/services/lifecycle.ts
+++ b/apps/desktop/src/main/services/lifecycle.ts
@@ -1,18 +1,37 @@
+import { DisposableStore, toDisposable } from "@sidecar/wire";
 import type { DesktopService } from "./service";
 
 /**
  * Every concern gives back what it began, in the reverse of the order it
- * began in. One that cannot must not strand the rest: a window teardown that
+ * began in. One that cannot must not strand the rest: a window dispose that
  * throws would otherwise leave the runtime undrained, which is the one thing
  * a quit may not do.
+ *
+ * `DisposableStore` gives the reverse order and the idempotent one-shot entry
+ * for free; what it does not give is sequencing an async `stop()`, since its
+ * own `dispose()` is synchronous, so each entry only schedules its service's
+ * stop onto a chain rather than awaiting it inline. Disposing the store then
+ * runs every entry synchronously, in reverse, which builds the chain in the
+ * same order a plain reversed loop would have awaited it in — the later
+ * service's stop still finishes before the earlier one's begins.
  */
 export async function stopInReverse(
   services: readonly DesktopService[],
   report: (message: string) => void,
 ): Promise<void> {
-  for (const service of [...services].reverse()) {
-    await service.stop().catch((error: Error) => {
-      report(`the ${service.name} service did not stop cleanly: ${error.message}`);
-    });
+  const store = new DisposableStore();
+  let chain: Promise<void> = Promise.resolve();
+  for (const service of services) {
+    store.add(
+      toDisposable(() => {
+        chain = chain.then(() =>
+          service.stop().catch((error: Error) => {
+            report(`the ${service.name} service did not stop cleanly: ${error.message}`);
+          }),
+        );
+      }),
+    );
   }
+  store.dispose();
+  return chain;
 }

--- a/apps/desktop/src/main/services/operator-client.ts
+++ b/apps/desktop/src/main/services/operator-client.ts
@@ -5,7 +5,7 @@ import { type AppGuideSnapshot, EMPTY_APP_GUIDE } from "@sidecar/guide";
 import { HOST_OPERATOR_CLIENT_ID } from "@sidecar/host";
 import { SUPERSET_SIGN_IN_STAGE } from "@sidecar/providers/superset/sign-in-stage";
 import type { AppSettings } from "@sidecar/settings/wire";
-import { type LateRef, lateRef } from "@sidecar/wire";
+import { DisposableStore, type LateRef, lateRef } from "@sidecar/wire";
 import { channels } from "#shared/bridge";
 import { type AppStateStore, bootstrapPatch } from "../app-state";
 import type { HostBootstrap, HostOperator } from "../gateway/host-operator";
@@ -76,7 +76,7 @@ export function createOperatorClient(dependencies: OperatorClientDependencies): 
    */
   let voiceAvailable = false;
   let attachments = 0;
-  const unsubscribers: (() => void)[] = [];
+  const subscriptions = new DisposableStore();
 
   const gateway = wireGateway({
     transport: new InProcessTransport(dependencies.server, {
@@ -97,16 +97,20 @@ export function createOperatorClient(dependencies: OperatorClientDependencies): 
 
   // The two offers a receiver alone may take are not state and reach the voice
   // window directly; everything else is written to the document.
-  unsubscribers.push(
+  subscriptions.add(
     gateway.host.onSettingsChanged((change) => {
       const stoodVoice = voiceAvailable;
       voiceAvailable = change.settings.status.voiceAvailable;
       state.update({ settings: change.settings });
       if (stoodVoice !== voiceAvailable) links.get().reapplyTalkHotkey();
     }),
+  );
+  subscriptions.add(
     gateway.host.onAccountChanged((account) => {
       state.update({ account });
     }),
+  );
+  subscriptions.add(
     gateway.host.onSessionsChanged((roster) => {
       state.update({
         sessions: {
@@ -116,18 +120,26 @@ export function createOperatorClient(dependencies: OperatorClientDependencies): 
         },
       });
     }),
+  );
+  subscriptions.add(
     gateway.host.onWorkspaceProjectsChanged((workspaceProjects) => {
       state.update({ sessions: { ...state.snapshot().sessions, workspaceProjects } });
     }),
+  );
+  subscriptions.add(
     gateway.host.onCalendarsChanged((calendars) => {
       state.update({ calendars });
     }),
+  );
+  subscriptions.add(
     gateway.host.onAnnouncementsHeldChanged((held) => {
       state.update({ announcements: { held } });
     }),
-    // The stage is also what answers for the connection between two host
-    // reads: the bootstrap probes the CLI's own login configuration, and a
-    // sign-in carried through — or a sign-out — moves this first.
+  );
+  // The stage is also what answers for the connection between two host
+  // reads: the bootstrap probes the CLI's own login configuration, and a
+  // sign-in carried through — or a sign-out — moves this first.
+  subscriptions.add(
     gateway.host.onSupersetSignInChanged((signIn) => {
       state.update({
         superset: {
@@ -137,17 +149,25 @@ export function createOperatorClient(dependencies: OperatorClientDependencies): 
         },
       });
     }),
+  );
+  subscriptions.add(
     gateway.host.onCalendarOnboardingChanged((calendarOwed) => {
       state.update({ onboarding: { calendarOwed } });
     }),
+  );
+  subscriptions.add(
     gateway.host.onSpeechOffered((offer) =>
       links.get().sendToVoice(channels.onSpeechOffered, offer),
     ),
+  );
+  subscriptions.add(
     gateway.host.onSpeechWithdrawn((id) =>
       links.get().sendToVoice(channels.onSpeechWithdrawn, { id }),
     ),
-    // The host's own answer about recording stands the halt down: it is the
-    // account transition the halt was waiting on.
+  );
+  // The host's own answer about recording stands the halt down: it is the
+  // account transition the halt was waiting on.
+  subscriptions.add(
     gateway.host.onSessionReplayChanged((replay) => {
       state.update({ sessionReplay: { ...replay, halted: false } });
     }),
@@ -205,7 +225,7 @@ export function createOperatorClient(dependencies: OperatorClientDependencies): 
       relay.recycleVoiceWindow();
     },
     stop: async () => {
-      while (unsubscribers.length > 0) unsubscribers.pop()?.();
+      subscriptions.dispose();
       gateway.client.close();
     },
   };

--- a/apps/desktop/src/main/services/services.test.ts
+++ b/apps/desktop/src/main/services/services.test.ts
@@ -148,7 +148,7 @@ test("the host service starts and stops leaving no handle, and says what the dra
   await host.stop();
   assert.equal(host.drainOwed(), false);
   assert.ok(
-    reports.some((message) => message.startsWith("shutting down:")),
+    reports.some((message) => message.startsWith("disposing:")),
     `the drain reported nothing: ${reports.join(" | ")}`,
   );
   // A second ask is not a second drain, and nothing is owed once one finished.
@@ -210,7 +210,7 @@ test("the updater's timers are handles the stop takes back, and a restart tears 
     recordProductEvent: () => undefined,
     engine,
     beforeRestart: async () => {
-      order.push("teardown");
+      order.push("dispose");
     },
     state,
   });
@@ -222,7 +222,7 @@ test("the updater's timers are handles the stop takes back, and a restart tears 
   // The restart into a downloaded build swaps this executable, so everything
   // owed is given back before Squirrel is let anywhere near it — and given
   // back first, so the installer's own quit is not the one held open.
-  assert.deepEqual(order, ["teardown", "install"]);
+  assert.deepEqual(order, ["dispose", "install"]);
   assert.ok(snapshots.length > 0, "no update state ever reached the windows");
   await updates.stop();
   await updates.stop();
@@ -231,9 +231,9 @@ test("the updater's timers are handles the stop takes back, and a restart tears 
 test("a launch suspended on one of its waits opens nothing once a quit has been asked for", async (t) => {
   // The invariant, in the shape the composition wires: the signal a start
   // re-checks is set the instant `stop` is asked for, so a start that resumes
-  // after the teardown has run opens nothing. Reading the drain's own state
+  // after the dispose has run opens nothing. Reading the drain's own state
   // instead would flip the signal several awaited stops later, which is how a
-  // resumed start came to re-open what the teardown had just given back.
+  // resumed start came to re-open what the dispose had just given back.
   const stateRoot = await temporaryDirectory(t);
   const host = createHostService({ config: fixtureConfig(stateRoot), cipher: CIPHER });
   host.link({ attach: async () => undefined });
@@ -251,7 +251,7 @@ test("a launch suspended on one of its waits opens nothing once a quit has been 
       if (!quitting) opened.push("window");
     },
     stop: async () => {
-      opened.push("teardown");
+      opened.push("dispose");
     },
   };
   const all = [host, windows];
@@ -264,17 +264,17 @@ test("a launch suspended on one of its waits opens nothing once a quit has been 
   const quit = stop();
   releaseSettings?.();
   await Promise.all([launch, quit]);
-  // The teardown ran and the launch, resuming after it, opened nothing.
-  assert.deepEqual(opened, ["teardown"]);
+  // The dispose ran and the launch, resuming after it, opened nothing.
+  assert.deepEqual(opened, ["dispose"]);
   // And by now the drain has finished, so its own state is back to owing
   // nothing — a signal that says nothing about whether a quit was asked for.
   assert.equal(host.drainOwed(), false);
 });
 
-test("a quit arriving after the teardown finished is not held back, so an install is not aborted", async () => {
-  // The regression this pins: holding every `before-quit` open aborts the
+test("a quit arriving after the dispose finished is not held back, so an install is not cancelled", async () => {
+  // The regression this pins: holding every `before-quit` open cancels the
   // update, because Squirrel's own quit is the one that reaches the
-  // installer. The updater runs the teardown itself and hands over only once
+  // installer. The updater runs the dispose itself and hands over only once
   // it has finished, so what the entry reads is whether one has finished.
   const order: string[] = [];
   let stopped = false;
@@ -288,7 +288,7 @@ test("a quit arriving after the teardown finished is not held back, so an instal
       },
     },
   ];
-  const teardown = (): Promise<void> => {
+  const dispose = (): Promise<void> => {
     if (!stopping) {
       stopping = stopInReverse(all, () => undefined).finally(() => {
         stopping = undefined;
@@ -300,16 +300,16 @@ test("a quit arriving after the teardown finished is not held back, so an instal
   // The entry's own rule, as `registerQuit` applies it.
   const beforeQuit = (): "held" | "through" => {
     if (stopped) return "through";
-    void teardown();
+    void dispose();
     return "held";
   };
 
-  await teardown();
+  await dispose();
   order.push("install");
   assert.equal(beforeQuit(), "through");
   assert.deepEqual(order, ["drain", "install"]);
 
-  // And the explicit Quit, which arrives with nothing torn down yet, is held
+  // And the explicit Quit, which arrives with nothing disposed yet, is held
   // exactly once.
   stopped = false;
   assert.equal(beforeQuit(), "held");
@@ -318,8 +318,8 @@ test("a quit arriving after the teardown finished is not held back, so an instal
 });
 
 test("a wait guarded against the quit schedules nothing new once one is asked for", () => {
-  // Both halves matter. A wait that fires must not act after the teardown,
-  // and a wait that was running must not arm the next one behind a teardown
+  // Both halves matter. A wait that fires must not act after the dispose,
+  // and a wait that was running must not arm the next one behind a dispose
   // that has already cleared them — which is how the takeover's fade came to
   // be scheduled after its own stop.
   let standing = true;

--- a/apps/desktop/src/main/services/update-service-host.ts
+++ b/apps/desktop/src/main/services/update-service-host.ts
@@ -23,11 +23,11 @@ export interface UpdateServiceHostDependencies {
    */
   engine: UpdaterEngine | undefined;
   /**
-   * The whole quit's teardown, awaited before Squirrel is let near this
-   * executable. It is the teardown and not the host's drain alone for two
+   * The whole quit's dispose, awaited before Squirrel is let near this
+   * executable. It is the dispose and not the host's drain alone for two
    * reasons: the restart must not swap the binary over runtime work still
    * going, and the install's own quit must not be the one `before-quit`
-   * holds back — a prevented `before-quit` aborts the install, so everything
+   * holds back — a prevented `before-quit` cancels the install, so everything
    * owed has to be given back, and seen to be given back, before the
    * installer asks to leave.
    */

--- a/apps/desktop/src/main/services/window-service.ts
+++ b/apps/desktop/src/main/services/window-service.ts
@@ -51,7 +51,7 @@ export interface WindowServiceDependencies {
    * Whether the launch this start belongs to still stands. False from the
    * moment a Quit is asked for, which is what every wait below re-checks: a
    * start suspended on one of its own awaits must not resume into opening a
-   * window and re-claiming keys the teardown has already given back.
+   * window and re-claiming keys the dispose has already given back.
    */
   launchStanding: () => boolean;
 }
@@ -240,14 +240,14 @@ export function createWindowService(dependencies: WindowServiceDependencies): Wi
    * Every wait this service schedules — the takeover's handoff and the
    * settling a display change waits out — held so the quit can take them
    * back. Each opens a window or claims the keys when it fires, and the
-   * teardown now runs for seconds with the drain behind it, so one landing
-   * afterwards would re-open what the teardown had just given back.
+   * dispose now runs for seconds with the drain behind it, so one landing
+   * afterwards would re-open what the dispose had just given back.
    */
   const pendingWaits = new Set<ReturnType<typeof setTimeout>>();
   function afterDelay(delayMs: number, run: () => void): void {
     // Nothing new is scheduled once a quit has been asked for, so the last
     // act of a wait that was already running cannot arm the next one behind
-    // the teardown that just cleared them.
+    // the dispose that just cleared them.
     if (!launchStanding()) return;
     const wait = setTimeout(() => {
       pendingWaits.delete(wait);

--- a/apps/desktop/src/main/window/voice-window.ts
+++ b/apps/desktop/src/main/window/voice-window.ts
@@ -98,8 +98,8 @@ export class VoiceWindow {
 
   /**
    * Stands a fresh renderer up in place of one that died, after a short pause
-   * and only within the bound. A window `close()` already retired reports
-   * nothing: its listeners can still fire as it is torn down.
+   * and only within the bound. A window `close()` already disposed reports
+   * nothing: its listeners can still fire as it is disposed.
    */
   #replace(window: BrowserWindow, reason: string): void {
     if (this.#closedForGood || window !== this.#window || this.#reopenTimer) return;

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -29,7 +29,9 @@ for (const [method, definition] of bridgeEntries()) {
       if (definition.result?.(payload) !== false) callback(payload);
     };
     ipcRenderer.on(definition.channel, listener);
-    return () => ipcRenderer.removeListener(definition.channel, listener);
+    return () => {
+      ipcRenderer.removeListener(definition.channel, listener);
+    };
   };
 }
 

--- a/apps/web/server/hosted/action-execute.ts
+++ b/apps/web/server/hosted/action-execute.ts
@@ -118,7 +118,7 @@ interface ObservedActionPass {
   unreachable: boolean;
 }
 
-async function observeForAction(
+async function passForAction(
   providerId: CloudAgentProviderId,
   apiKey: string,
   seams: ActionExecuteSeams,
@@ -249,7 +249,7 @@ export async function executeSessionAction(options: {
   const unsupported = actionUnsupportedReason(kind, providerId);
   if (unsupported) return { result: ACTION_RESULT_STATUS.UNSUPPORTED, reason: unsupported };
 
-  const pass = await observeForAction(providerId, apiKey, options.seams ?? {});
+  const pass = await passForAction(providerId, apiKey, options.seams ?? {});
   const request: ActionRequest<HostedSessionActionKind> = { kind, fields };
   const admitted = await admit(request, admissionOver(pass));
   if (admitted.kind === undefined) return fromRefusal(providerId, pass, admitted);
@@ -325,7 +325,7 @@ export async function executeConversationRead(options: {
     };
   }
 
-  const pass = await observeForAction(providerId, apiKey, options.seams ?? {});
+  const pass = await passForAction(providerId, apiKey, options.seams ?? {});
   const observation = pass.observations.find(
     (candidate) => candidate.providerSessionId === providerSessionId,
   );

--- a/apps/web/server/hosted/cloud-adapters.ts
+++ b/apps/web/server/hosted/cloud-adapters.ts
@@ -4,11 +4,11 @@ import type { CloudAgentProviderId, CloudFetch } from "../core.js";
 import { CLOUD_AGENT_PROVIDER_ID } from "../core.js";
 
 /**
- * What one invocation supplies to a cloud plugin: the caller's own decrypted
- * key behind the same read-at-action-time seam the desktop uses, and the
- * fetch, clock, and sleep seams tests inject. The refresh debounce is always
- * bypassed — every server-side plugin lives for exactly one pass, so a
- * debounced pass could only ever answer with nothing.
+ * What a stateless invocation supplies to a cloud plugin: the caller's own
+ * decrypted key behind the same read-at-action-time seam the desktop uses, and
+ * the fetch/now seams tests inject. The pass debounce is always bypassed —
+ * every server-side plugin lives for exactly one request, so a debounced
+ * pass could only ever answer with nothing.
  */
 export interface CloudAdapterSeams {
   readApiKey: () => Promise<string | undefined>;
@@ -23,7 +23,7 @@ type PluginBuilder = (seams: CloudAdapterSeams) => CloudSessionPlugin;
 function baseOptions(seams: CloudAdapterSeams) {
   return {
     readApiKey: seams.readApiKey,
-    minimumRefreshIntervalMs: 0,
+    minimumPassIntervalMs: 0,
     ...(seams.fetch ? { fetch: seams.fetch } : undefined),
     ...(seams.now ? { now: seams.now } : undefined),
     ...(seams.sleep ? { sleep: seams.sleep } : undefined),

--- a/apps/web/server/hosted/observe.ts
+++ b/apps/web/server/hosted/observe.ts
@@ -38,7 +38,7 @@ export interface ObserveOptions
 
 /**
  * Observe-on-demand: decrypts the caller's vault keys, runs each cloud
- * adapter once (minimumRefreshIntervalMs: 0 bypasses the refresh debounce),
+ * adapter once (minimumPassIntervalMs: 0 bypasses the pass debounce),
  * and returns a bounded roster. Nothing is stored between requests.
  */
 export async function handleObserve(options: ObserveOptions): Promise<Response> {

--- a/apps/web/server/hosted/posthog.ts
+++ b/apps/web/server/hosted/posthog.ts
@@ -115,7 +115,7 @@ export interface PosthogForgetOptions extends PosthogUpstreamOptions {
  * Asks the processor to erase the person behind one distinct id, and the
  * events recorded against them. The documented bulk-delete endpoint takes the
  * distinct ids in its body and `delete_events` in its query, and queues the
- * event deletion rather than performing it — so a resolved promise means the
+ * event deletion rather than performing it — so a settled promise means the
  * erasure was accepted, never that it has already happened.
  */
 export async function forgetPosthogPerson(

--- a/apps/web/server/hosted/remote-voice-mint.ts
+++ b/apps/web/server/hosted/remote-voice-mint.ts
@@ -75,14 +75,14 @@ export async function handleRemoteVoiceMint(options: RemoteVoiceMintOptions): Pr
 
   const now = options.now ?? Date.now;
 
-  // Ephemeral Realtime keys expire in 60 s. Cap the observe leg to 30 s so the
+  // Ephemeral Realtime keys expire in 60 s. Cap the pass leg to 30 s so the
   // key still has plenty of time to connect even if a cloud pass runs long.
-  // observe resolves to [] on timeout rather than failing the whole request.
-  const OBSERVE_TIMEOUT_MS = 30_000;
+  // The pass resolves to [] on timeout rather than failing the whole request.
+  const PASS_TIMEOUT_MS = 30_000;
 
-  // Mint credential and observe sessions concurrently — neither depends on the
-  // other, so there is no reason to serialize them.
-  let observeTimeoutHandle: ReturnType<typeof setTimeout> | undefined;
+  // Mint the credential and run the session pass concurrently — neither
+  // depends on the other, so there is no reason to serialize them.
+  let passTimeoutHandle: ReturnType<typeof setTimeout> | undefined;
   const [minted, sessions] = await Promise.all([
     mintRealtimeConnection({
       apiKey,
@@ -94,11 +94,11 @@ export async function handleRemoteVoiceMint(options: RemoteVoiceMintOptions): Pr
       timeoutMs: options.timeoutMs,
     }),
     Promise.race([
-      observeCloudSessions(userId, options),
+      passCloudSessions(userId, options),
       new Promise<ObservedSession[]>((resolve) => {
-        observeTimeoutHandle = setTimeout(() => resolve([]), OBSERVE_TIMEOUT_MS);
+        passTimeoutHandle = setTimeout(() => resolve([]), PASS_TIMEOUT_MS);
       }),
-    ]).finally(() => clearTimeout(observeTimeoutHandle)),
+    ]).finally(() => clearTimeout(passTimeoutHandle)),
   ]);
 
   if ("failure" in minted) return minted.failure;
@@ -121,7 +121,7 @@ export async function handleRemoteVoiceMint(options: RemoteVoiceMintOptions): Pr
   });
 }
 
-async function observeCloudSessions(
+async function passCloudSessions(
   userId: string,
   options: RemoteVoiceMintOptions,
 ): Promise<ObservedSession[]> {

--- a/apps/web/src/admin/use-admin-read.ts
+++ b/apps/web/src/admin/use-admin-read.ts
@@ -20,7 +20,7 @@ export type AdminRead<T> =
 export type AdminReader<T> = (response: Response) => Promise<T>;
 
 export interface AdminReadOptions<T> {
-  /** False parks the read: no fetch, no abort, the state stands. Default true. */
+  /** False parks the read: no fetch, no cancel, the state stands. Default true. */
   enabled?: boolean;
   /**
    * Delays a path changed after the first read by this many milliseconds. The
@@ -152,7 +152,7 @@ function isFailedRead<State extends { status: string }>(state: State): state is 
  * refusals kept distinct, and the last answer held up while the next is in
  * flight. A screen names its address, how to read a 200, and what to say when
  * the endpoint refuses for no reason of the gate's; everything else — the
- * local sign-in consent, the abort discipline, the refreshing flag, the
+ * local sign-in consent, the cancellation discipline, the refreshing flag, the
  * sign-out withdrawal — is the same on every screen and lives here.
  */
 export function useAdminRead<T>(

--- a/packages/AGENTS.md
+++ b/packages/AGENTS.md
@@ -30,9 +30,49 @@ statements of the same rule that can drift.
 
 `@sidecar/wire` is also the base every layer's lifecycle is written in —
 `IDisposable`, `DisposableStore`, `toDisposable`, `Event`, and `Emitter` — so a
-listener's unsubscribe, a watcher's teardown, and the store that ends both are
+listener's unsubscribe, a watcher's dispose, and the store that ends both are
 one shape wherever they are held, and adopting it adds no edge: every package
 but `packages/panel` already depends on wire.
+
+## One word per concept
+
+The repository names each of these ideas with exactly one word, everywhere,
+so a reader never has to check whether `retire` and `dispose` two lines apart
+mean the same thing or something subtly different. This is the standing word
+list; a new file that reaches for a synonym below is reaching for the wrong
+word, not a stylistic variant.
+
+- **`dispose`** — a resource, subscription, or service reaching the end of
+  its life. `retire`, `teardown`/`tear down`, `destroy`, and `shutdown`/
+  `shut down` are the same concept and are never used for it. `start`/`stop`
+  stay only where `Composer`, `DesktopService`, or CLAUDE.md's `Host.stop()`
+  already name the pair; everywhere else, ending something is `dispose`. A
+  function that returns a bare `() => void` whose only purpose is
+  unsubscribing or undoing a registration returns an `IDisposable` instead,
+  so the caller holds one shape rather than a bag of unlabeled callbacks.
+- **`cancel`** — stopping in-flight work, except where the thing genuinely is
+  a web-standard `AbortSignal` or `AbortController`, which keep their own
+  vocabulary because it is not ours to rename.
+- **`close`** — a socket, stream, or handle.
+- **`release`** — a lock or a hold.
+- **`settle`** — a promise or a queued unit of work reaching its outcome.
+  `resolve` stays for configuration, path, and module resolution, which is an
+  unrelated sense of the word.
+- **`generation`** — a late-answer barrier (a conversation's envelope
+  replaced out from under an in-flight turn). `epoch` stays only for the
+  wire-visible receiver epochs, which are a different, narrower mechanism.
+- **`pass`** — one iteration of an observation loop (reading a coding-agent
+  session's state, a roster of sessions, or similar). `poll`, `refresh`, and
+  `observe` are not used for this; each of those words also has an
+  unrelated, legitimate sense elsewhere (a credential's refresh token, the
+  generic observer/listener pattern) that is not this concept and is not
+  renamed.
+- **`roster`** / **`directory`** — the observed set of sessions, and the
+  conversation registry, respectively.
+
+Fixed value sets are `as const` SCREAMING_SNAKE_CASE objects with unions
+derived from them, never a raw string literal repeated at each call site, and
+never a key built by concatenating identifiers.
 
 ## The graph is acyclic, and stays that way
 

--- a/packages/actions/src/admit.ts
+++ b/packages/actions/src/admit.ts
@@ -239,26 +239,26 @@ export function guardedRead<T>(
     const settle = () => {
       if (decided) return false;
       decided = true;
-      signal.removeEventListener("abort", onAbort);
+      signal.removeEventListener("abort", onCancel);
       return true;
     };
-    function onAbort() {
+    function onCancel() {
       if (settle()) resolve(undefined);
     }
     if (signal.aborted) {
-      onAbort();
+      onCancel();
       // The read still runs; its value and any failure are nobody's once the
-      // abort has answered, so neither is left to surface unhandled.
+      // cancel has answered, so neither is left to surface unhandled.
       void read.catch(() => undefined);
       return;
     }
-    signal.addEventListener("abort", onAbort, { once: true });
+    signal.addEventListener("abort", onCancel, { once: true });
     void (async () => {
       try {
         const value = await read;
         if (settle()) resolve(value);
       } catch (failure) {
-        // A failure after the abort answered belongs to nobody, and is dropped
+        // A failure after the cancel answered belongs to nobody, and is dropped
         // rather than surfacing as an unhandled rejection.
         if (settle()) reject(failure instanceof Error ? failure : new Error(String(failure)));
       }

--- a/packages/brain/src/acceptance.test.ts
+++ b/packages/brain/src/acceptance.test.ts
@@ -726,7 +726,7 @@ function heldIngestRuntime(model: ModelAdapter): AgentRuntime {
   });
 }
 
-test("an ingest held across a cancel that resolves after the successor turn began lands on the retired engine, never in the context the next turn reads or keeps", async () => {
+test("an ingest held across a cancel that resolves after the successor turn began lands on the disposed engine, never in the context the next turn reads or keeps", async () => {
   const repository = fakeBrainStateRepository();
   const upstream = fakeUpstream([
     () => payload([message("LATE_WORDS")]),

--- a/packages/brain/src/agent.test.ts
+++ b/packages/brain/src/agent.test.ts
@@ -533,7 +533,7 @@ test("a queued ask cancelled before its turn never starts, and its record says c
   assert.equal(await h.agent.cancelAsk("no-such-run"), undefined);
 });
 
-test("a cancel while the model is thinking aborts the request and settles the run cancelled", async () => {
+test("a cancel while the model is thinking cancels the request and settles the run cancelled", async () => {
   const signals: (AbortSignal | undefined)[] = [];
   let reject: ((error: Error) => void) | undefined;
   const h = harness({
@@ -542,7 +542,7 @@ test("a cancel while the model is thinking aborts the request and settles the ru
         signals.push(options.signal);
         return new Promise((_resolve, rejectRespond) => {
           reject = rejectRespond;
-          options.signal?.addEventListener("abort", () => rejectRespond(new Error("aborted")));
+          options.signal?.addEventListener("abort", () => rejectRespond(new Error("cancelled")));
         });
       },
       quietUntil: () => undefined,
@@ -730,9 +730,9 @@ test("a spoken submission keeps its origin, and an empty ask is refused without 
   });
   const runId = acceptedRunId(accepted);
   const heard: (readonly BrainRequestRecord[])[] = [];
-  const unsubscribe = h.agent.subscribe((records) => heard.push(records));
+  const subscription = h.agent.subscribe((records) => heard.push(records));
   const record = await h.agent.waitAsk(runId, 60_000);
-  unsubscribe();
+  subscription.dispose();
   assert.equal(record?.origin, BRAIN_REQUEST_ORIGIN.SPOKEN);
   assert.equal(record?.question, "hello there");
   assert.ok(heard.length > 0);
@@ -1258,7 +1258,7 @@ test("the reply is everything the model said across the run: a preface before a 
   assert.equal(h.traces[2]?.incomplete, "incomplete: max_output_tokens");
 });
 
-test("a stop during a held initial bootstrap settles at once; the open finishing afterwards is retired exactly once, and a dispose that never settles holds nothing", async () => {
+test("a stop during a held initial bootstrap settles at once; the open finishing afterwards is disposed exactly once, and a dispose that never settles holds nothing", async () => {
   for (const disposeHangs of [false, true]) {
     const model = adapterOf(new FakeClient());
     const held = heldOpenRuntime(model, disposeHangs);
@@ -1325,7 +1325,7 @@ test("a reopen the runtime refuses re-admits nothing: the generation refuses tur
   await h.agent.stop();
 });
 
-test("a reopen claimed just before a stop installs nothing: the stop's signal is checked after the wait, and the claimed context is retired", async () => {
+test("a reopen claimed just before a stop installs nothing: the stop's signal is checked after the wait, and the claimed context is disposed", async () => {
   const h = harness();
   let disposed = 0;
   let releaseReopen: (() => void) | undefined;

--- a/packages/brain/src/agent.ts
+++ b/packages/brain/src/agent.ts
@@ -12,7 +12,7 @@ import type {
   ProviderTranscriptSinceResult,
   SessionIdentity,
 } from "@sidecar/session";
-import type { WireRecord } from "@sidecar/wire";
+import type { IDisposable, WireRecord } from "@sidecar/wire";
 import { AskLedger, type BrainRequestsListener } from "./asks.js";
 import { type BrainCompletionDelivery, ChildRuns } from "./children.js";
 import { BRAIN_DEFAULTS } from "./defaults.js";
@@ -23,9 +23,9 @@ import {
 } from "./envelope.js";
 import {
   CONTEXT_OPENING,
+  disposeOpenedContext,
   type Generation,
   generationFrom,
-  retireOpenedContext,
 } from "./generation.js";
 import { holdReleasedInputText, wakeInputText } from "./input-items.js";
 import { journalActionCounts, UNKNOWN_ACTION_RESULT } from "./journal.js";
@@ -218,7 +218,7 @@ export class BrainAgent {
   #restored: Promise<void> | undefined;
   #queue: Promise<unknown> = Promise.resolve();
   #stopped = false;
-  #unsubscribeStore: (() => void) | undefined;
+  #storeSubscription: IDisposable | undefined;
   #incompatibleReported: string | undefined;
 
   constructor(options: BrainAgentOptions) {
@@ -328,7 +328,7 @@ export class BrainAgent {
       active: () => this.#turns.active(),
       turn: (plan) => this.#turns.turn(plan),
     });
-    this.#unsubscribeStore = options.store.onReplaced((state) => this.#adoptGeneration(state));
+    this.#storeSubscription = options.store.onReplaced((state) => this.#adoptGeneration(state));
   }
 
   /** The store lease this agent writes under, for a host to check who owns the store. */
@@ -395,7 +395,7 @@ export class BrainAgent {
   }
 
   /** Hears the whole list on every change to any record. */
-  subscribe(listener: BrainRequestsListener): () => void {
+  subscribe(listener: BrainRequestsListener): IDisposable {
     return this.#asks.subscribe(listener);
   }
 
@@ -426,8 +426,8 @@ export class BrainAgent {
 
   /**
    * Cancels a run: a queued one never starts, a running one has its model and
-   * read work aborted and every action not yet dispatched refused. An action whose
-   * effect is already under way is neither retried nor aborted — its result
+   * read work cancelled and every action not yet dispatched refused. An action whose
+   * effect is already under way is neither retried nor cancelled — its result
    * is kept, known or unknown — because cancelling cannot undo a message
    * already sent.
    */
@@ -547,10 +547,10 @@ export class BrainAgent {
     this.#maintenance.cancel();
     this.#wakes.clear();
     const waiting = this.#asks.takeWaiting();
-    this.#unsubscribeStore?.();
-    this.#unsubscribeStore = undefined;
+    this.#storeSubscription?.dispose();
+    this.#storeSubscription = undefined;
     this.#generation?.abort.abort();
-    this.#asks.abortAll();
+    this.#asks.interruptAll();
     // An acceptance whose write is still out settles before the stop does:
     // its caller hears the durable answer, its run is recorded interrupted,
     // and nothing of it is left to land on the agent that comes next.
@@ -570,7 +570,7 @@ export class BrainAgent {
       }
     }
     await this.#queue;
-    if (this.#generation) retireOpenedContext(this.#generation);
+    if (this.#generation) disposeOpenedContext(this.#generation);
   }
 
   /**
@@ -698,7 +698,7 @@ export class BrainAgent {
     void this.#asks.settleWaiting(this.#asks.takeWaiting());
     previous?.abort.abort();
     this.#asks.revokeAll();
-    if (previous) retireOpenedContext(previous);
+    if (previous) disposeOpenedContext(previous);
     // Wakes coalesced against the old memory — including a quiet retry's —
     // are that generation's work, and go with it.
     this.#wakes.clear();

--- a/packages/brain/src/asks.ts
+++ b/packages/brain/src/asks.ts
@@ -6,6 +6,7 @@ import {
 } from "@sidecar/runtime";
 import type { ScheduledTimer } from "@sidecar/runtime/vocabulary";
 import { CONTEXT_INPUT_KIND } from "@sidecar/runtime/vocabulary";
+import { type IDisposable, toDisposable } from "@sidecar/wire";
 import { CONTEXT_OPENING, type Generation } from "./generation.js";
 import { askInputText } from "./input-items.js";
 import {
@@ -97,7 +98,7 @@ export class AskLedger {
     this.#queue.flush();
   }
 
-  /** Aborts and forgets every run this agent holds; the generation being replaced is not a cancel. */
+  /** Revokes and forgets every run this agent holds; the generation being replaced is not a cancel. */
   revokeAll(): void {
     for (const run of this.#runs.values()) {
       run.cancelled = true;
@@ -106,8 +107,8 @@ export class AskLedger {
     this.#runs.clear();
   }
 
-  /** Aborts every run without cancelling it: the agent is stopping, not the developer. */
-  abortAll(): void {
+  /** Interrupts every run without cancelling it: the agent is stopping, not the developer. */
+  interruptAll(): void {
     for (const run of this.#runs.values()) run.abort.abort();
   }
 
@@ -143,11 +144,11 @@ export class AskLedger {
   }
 
   /** Hears the whole list on every change to any record. */
-  subscribe(listener: BrainRequestsListener): () => void {
+  subscribe(listener: BrainRequestsListener): IDisposable {
     this.#listeners.add(listener);
-    return () => {
+    return toDisposable(() => {
       this.#listeners.delete(listener);
-    };
+    });
   }
 
   /**
@@ -437,11 +438,11 @@ export class AskLedger {
     return new Promise((resolve) => {
       let timer: ScheduledTimer | undefined;
       const finish = () => {
-        unsubscribe();
+        subscription.dispose();
         if (timer !== undefined) this.#seam.cancel(timer);
         resolve(this.record(runId));
       };
-      const unsubscribe = this.subscribe(() => {
+      const subscription = this.subscribe(() => {
         const current = this.record(runId);
         if (!current || isTerminalBrainRequestStatus(current.status)) finish();
       });
@@ -451,8 +452,8 @@ export class AskLedger {
 
   /**
    * Cancels a run: a queued one never starts, a running one has its model and
-   * read work aborted and every action not yet dispatched refused. An action whose
-   * effect is already under way is neither retried nor aborted — its result
+   * read work cancelled and every action not yet dispatched refused. An action whose
+   * effect is already under way is neither retried nor cancelled — its result
    * is kept, known or unknown — because cancelling cannot undo a message
    * already sent.
    */

--- a/packages/brain/src/defaults.ts
+++ b/packages/brain/src/defaults.ts
@@ -4,7 +4,7 @@ import { INBOX_CAPACITY } from "./observation-inbox.js";
 /** The bounds and cadences a brain agent runs under when its host names none. */
 export const BRAIN_DEFAULTS = {
   MAXIMUM_OUTPUT_TOKENS: HOSTED_BRAIN_OPTION_BOUNDS.MAXIMUM_OUTPUT_TOKENS,
-  /** Wakes inside this window open one turn together: a hook and the poll's edge for the same stop. */
+  /** Wakes inside this window open one turn together: a hook and the pass's edge for the same stop. */
   WAKE_COALESCE_MS: 3_000,
   /**
    * How long a caller waits on a run before being answered with the run still

--- a/packages/brain/src/generation-clock.ts
+++ b/packages/brain/src/generation-clock.ts
@@ -1,4 +1,5 @@
 import type { ScheduledTimer } from "@sidecar/runtime/vocabulary";
+import type { IDisposable } from "@sidecar/wire";
 import { type BrainPersistedState, brainGenerationExpired } from "./envelope.js";
 import type { BrainStateStore } from "./state-store.js";
 
@@ -28,7 +29,7 @@ export class BrainGenerationClock {
   readonly #schedule: (callback: () => void, delayMs: number) => ScheduledTimer;
   readonly #cancel: (timer: ScheduledTimer) => void;
   #timer: ScheduledTimer | undefined;
-  #unsubscribe: (() => void) | undefined;
+  #subscription: IDisposable | undefined;
   #stopped = false;
 
   constructor(options: BrainGenerationClockOptions) {
@@ -46,7 +47,7 @@ export class BrainGenerationClock {
 
   /** Loads the store, arms the timer for the generation that stands, and follows every replacement. */
   async start(): Promise<void> {
-    this.#unsubscribe ??= this.#store.onReplaced((state) => this.#arm(state));
+    this.#subscription ??= this.#store.onReplaced((state) => this.#arm(state));
     const state = await this.#store.load();
     if (!this.#stopped) this.#arm(this.#store.current() ?? state);
   }
@@ -54,8 +55,8 @@ export class BrainGenerationClock {
   stop(): void {
     this.#stopped = true;
     this.#disarm();
-    this.#unsubscribe?.();
-    this.#unsubscribe = undefined;
+    this.#subscription?.dispose();
+    this.#subscription = undefined;
   }
 
   #arm(state: BrainPersistedState): void {

--- a/packages/brain/src/generation.test.ts
+++ b/packages/brain/src/generation.test.ts
@@ -44,15 +44,15 @@ async function tick(): Promise<void> {
   for (let index = 0; index < 5; index += 1) await new Promise((resolve) => setImmediate(resolve));
 }
 
-test("an abort and the open's resolution in the same turn leave the context discarded exactly once and never installed, in either order", async () => {
-  const abortFirst = heldRuntime();
-  const first = generationFrom(freshBrainState("gen-1", NOW), abortFirst.runtime, "{}");
+test("a cancel and the open's resolution in the same turn leave the context discarded exactly once and never installed, in either order", async () => {
+  const cancelFirst = heldRuntime();
+  const first = generationFrom(freshBrainState("gen-1", NOW), cancelFirst.runtime, "{}");
   first.abort.abort();
-  abortFirst.release();
+  cancelFirst.release();
   const firstOpened = await first.opened;
   await tick();
   assert.equal(firstOpened.kind, CONTEXT_OPENING.INCOMPATIBLE);
-  assert.equal(abortFirst.disposed(), 1);
+  assert.equal(cancelFirst.disposed(), 1);
   assert.match(
     firstOpened.kind === CONTEXT_OPENING.INCOMPATIBLE ? firstOpened.reason : "",
     /replaced while its context was opening/u,

--- a/packages/brain/src/generation.ts
+++ b/packages/brain/src/generation.ts
@@ -11,7 +11,7 @@ import type { BrainPersistedState } from "./envelope.js";
 import { BrainJournal } from "./journal.js";
 import type { BrainObservationEntry } from "./observation-inbox.js";
 import type { BrainRequestRecord } from "./requests.js";
-import { claimedUnlessAborted, type Settled } from "./settled.js";
+import { claimedUnlessCancelled, type Settled } from "./settled.js";
 import { RecordingContextEngine } from "./transcript-recorder.js";
 
 /**
@@ -93,10 +93,10 @@ export function storedCheckpoint(state: BrainPersistedState): RuntimeCheckpoint 
  * against the signal: a runtime whose bootstrap ignores the signal cannot
  * hold the wait open past a stop or a replacement, and a context that
  * finishes opening once the signal has fired — in the same turn or later —
- * is retired by the race itself, exactly once, so a successor never inherits
+ * is disposed by the race itself, exactly once, so a successor never inherits
  * it. The value is claimed while the signal stands, but this continuation
  * runs later, so the signal is read once more before the context is handed
- * back: an abort that landed between the two retires it as well.
+ * back: a cancel that landed between the two disposes it as well.
  */
 export async function claimOpenedContext(
   open: Promise<ContextOpening>,
@@ -104,19 +104,21 @@ export async function claimOpenedContext(
   notLoadedReason: string,
   now: () => number = Date.now,
 ): Promise<Settled<OpenedContext>> {
-  const claimed = await claimedUnlessAborted(open, signal, ({ context }) => retireContext(context));
-  if (claimed.aborted) return claimed;
+  const claimed = await claimedUnlessCancelled(open, signal, ({ context }) =>
+    disposeContext(context),
+  );
+  if (claimed.cancelled) return claimed;
   const { context, bootstrap } = claimed.value;
   if (signal.aborted) {
-    retireContext(context);
-    return { aborted: true };
+    disposeContext(context);
+    return { cancelled: true };
   }
   if (bootstrap.loaded) {
     // The engine is handed back behind the transcript recorder, so every
     // input the runtime ingests and every fold is on record beside the
     // checkpoint that carries it.
     return {
-      aborted: false,
+      cancelled: false,
       value: {
         kind: CONTEXT_OPENING.LOADED,
         context: new RecordingContextEngine(context, now),
@@ -124,8 +126,8 @@ export async function claimOpenedContext(
       },
     };
   }
-  retireContext(context);
-  return { aborted: false, value: incompatibleContext(bootstrap.reason ?? notLoadedReason) };
+  disposeContext(context);
+  return { cancelled: false, value: incompatibleContext(bootstrap.reason ?? notLoadedReason) };
 }
 
 export function generationFrom(
@@ -150,7 +152,7 @@ export function generationFrom(
           now,
         )
           .then((claimed) =>
-            claimed.aborted ? incompatibleContext(REPLACED_WHILE_OPENING) : claimed.value,
+            claimed.cancelled ? incompatibleContext(REPLACED_WHILE_OPENING) : claimed.value,
           )
           .catch((error: Error) =>
             incompatibleContext(`the runtime could not open the context: ${error.message}`),
@@ -171,10 +173,10 @@ export function generationFrom(
   };
 }
 
-/** Retires the generation's context once it is known, when it was loaded; nothing else holds one. */
-export function retireOpenedContext(generation: Generation): void {
+/** Disposes the generation's context once it is known, when it was loaded; nothing else holds one. */
+export function disposeOpenedContext(generation: Generation): void {
   void generation.opened.then((opened) => {
-    if (opened.kind === CONTEXT_OPENING.LOADED) retireContext(opened.context);
+    if (opened.kind === CONTEXT_OPENING.LOADED) disposeContext(opened.context);
   });
 }
 
@@ -183,7 +185,7 @@ export function retireOpenedContext(generation: Generation): void {
  * an engine whose dispose hangs must not hold a stop, a replacement, or a
  * successor's first turn, and a dispose that throws has nothing to tell.
  */
-export function retireContext(context: ContextEngine): void {
+export function disposeContext(context: ContextEngine): void {
   void Promise.resolve()
     .then(() => context.dispose())
     .catch(() => undefined);

--- a/packages/brain/src/harness.ts
+++ b/packages/brain/src/harness.ts
@@ -625,7 +625,7 @@ export const LIFETIME = 14 * 24 * 60 * 60 * 1000;
  * A runtime whose first context open is held until the test releases it, over
  * an engine whose dispose the test can count or hold. What the host does
  * with an open that finishes after a stop is the point: the late context is
- * retired, exactly once, and a dispose that never settles holds nothing.
+ * disposed, exactly once, and a dispose that never settles holds nothing.
  */
 export function heldOpenRuntime(model: ModelAdapter, disposeHangs = false) {
   const inner = runtimeOver(model);

--- a/packages/brain/src/index.ts
+++ b/packages/brain/src/index.ts
@@ -90,7 +90,7 @@ export {
   responsesModelAnswer,
   userMessageItem,
 } from "./responses-api.js";
-export { settledUnlessAborted } from "./settled.js";
+export { settledUnlessCancelled } from "./settled.js";
 export {
   CONTEXT_ITEM_KIND,
   type ContextItemKind,

--- a/packages/brain/src/maintenance.ts
+++ b/packages/brain/src/maintenance.ts
@@ -15,7 +15,7 @@ import {
 } from "./compaction.js";
 import { CONTEXT_OPENING } from "./generation.js";
 import type { AgentSeam } from "./seam.js";
-import { claimedUnlessAborted, type Settled, settledUnlessAborted } from "./settled.js";
+import { claimedUnlessCancelled, type Settled, settledUnlessCancelled } from "./settled.js";
 import {
   BRAIN_TURN_KIND,
   type BrainTurnDescription,
@@ -208,7 +208,7 @@ export class Maintenance {
     });
     if (!due) return;
     const cycle = generation.compactionCount;
-    const settled = await settledUnlessAborted(
+    const settled = await settledUnlessCancelled(
       hook({
         items: [...context.checkpoint().items],
         contextTokens: assessment.contextTokens,
@@ -219,7 +219,7 @@ export class Maintenance {
       }).catch((error: Error) => failedHousekeeping(error.message)),
       signal,
     );
-    if (settled.aborted || this.#revoked(turnContext)) return;
+    if (settled.cancelled || this.#revoked(turnContext)) return;
     if (!housekeepingCompleted(settled.value.outcome)) {
       this.#seam.report(
         `Memory flush did not complete (${settled.value.outcome}${settled.value.reason ? `: ${settled.value.reason}` : ""}); it runs again at the next assessment`,
@@ -227,7 +227,7 @@ export class Maintenance {
       return;
     }
     const marked = await this.#writeFlushMarker(turnContext, cycle);
-    if (marked.aborted || this.#revoked(turnContext)) return;
+    if (marked.cancelled || this.#revoked(turnContext)) return;
     if (!marked.value.ok) {
       this.#seam.report(
         `Memory flush completed but its marker could not be recorded after ${MEMORY_FLUSH_DEFAULTS.MARKER_WRITE_ATTEMPTS} attempt(s) (${marked.value.reason}); the cycle stays unflushed and runs again at the next assessment`,
@@ -252,8 +252,8 @@ export class Maintenance {
       // A write an earlier turn stopped waiting for may still be in flight;
       // the gate is read only once it has landed or failed, so the store is
       // never consulted ahead of a write already issued to it.
-      const settled = await settledUnlessAborted(generation.flush.settling, signal);
-      if (settled.aborted || this.#revoked(turnContext)) return false;
+      const settled = await settledUnlessCancelled(generation.flush.settling, signal);
+      if (settled.cancelled || this.#revoked(turnContext)) return false;
       delete generation.flush.settling;
     }
     if (generation.flush.read) return true;
@@ -262,14 +262,14 @@ export class Maintenance {
       generation.flush.read = true;
       return true;
     }
-    const read = await settledUnlessAborted(
+    const read = await settledUnlessCancelled(
       store.read(generation.id).then(
         (lastCompactionCount) => ({ ok: true as const, lastCompactionCount }),
         (error: Error) => ({ ok: false as const, reason: error.message }),
       ),
       signal,
     );
-    if (read.aborted || this.#revoked(turnContext)) return false;
+    if (read.cancelled || this.#revoked(turnContext)) return false;
     if (!read.value.ok) {
       this.#seam.report(
         `Memory flush marker could not be read (${read.value.reason}); the flush waits for the next assessment`,
@@ -293,7 +293,7 @@ export class Maintenance {
     cycle: number,
   ): Promise<Settled<{ ok: true } | { ok: false; reason: string }>> {
     const store = this.#options.flushMarker;
-    if (!store) return { aborted: false, value: { ok: true } };
+    if (!store) return { cancelled: false, value: { ok: true } };
     const { generation, signal } = turnContext;
     const attempts = async (): Promise<{ ok: true } | { ok: false; reason: string }> => {
       let reason = "";
@@ -309,10 +309,10 @@ export class Maintenance {
       return { ok: false, reason };
     };
     const outcome = attempts();
-    const settled = await claimedUnlessAborted(outcome, signal, (late) => {
+    const settled = await claimedUnlessCancelled(outcome, signal, (late) => {
       if (late.ok) generation.flush.lastCompactionCount = cycle;
     });
-    if (settled.aborted) {
+    if (settled.cancelled) {
       generation.flush.settling = outcome.then(() => undefined);
     }
     return settled;

--- a/packages/brain/src/performer.ts
+++ b/packages/brain/src/performer.ts
@@ -30,7 +30,7 @@ export interface BrainActionExecution {
   isRevoked(): boolean;
   /**
    * Fires the moment the standing is revoked, so a performer can settle a
-   * read it is waiting on — a roster refresh, a settings read — rather than
+   * read it is waiting on — a roster pass, a settings read — rather than
    * finishing it first. It reaches no provider write: an effect already
    * dispatched is awaited for its result whatever the signal says.
    */

--- a/packages/brain/src/runtime.ts
+++ b/packages/brain/src/runtime.ts
@@ -29,7 +29,7 @@ import {
 import { ACTION_RESULT_STATUS } from "@sidecar/wire";
 import { compactContext } from "./compaction.js";
 import { LOOP_GUARD_LEVEL, LoopGuard, type LoopGuardConfig } from "./loop-guard.js";
-import { settledUnlessAborted } from "./settled.js";
+import { settledUnlessCancelled } from "./settled.js";
 import { outputStatus } from "./tool-results.js";
 
 /**
@@ -212,8 +212,8 @@ export class ToolLoopAgentRuntime implements AgentRuntime {
     // on the model: a held hook cannot keep a cancel or a deadline from
     // landing, and its late answer is not read.
     const engine = async <Value>(work: MaybePromise<Value>): Promise<Value | undefined> => {
-      const settled = await settledUnlessAborted(Promise.resolve(work), signal);
-      return settled.aborted ? undefined : settled.value;
+      const settled = await settledUnlessCancelled(Promise.resolve(work), signal);
+      return settled.cancelled ? undefined : settled.value;
     };
     const ingest = (input: ContextInput) => engine(context.ingest(input, lifecycle));
     for (const input of request.input) {
@@ -234,7 +234,7 @@ export class ToolLoopAgentRuntime implements AgentRuntime {
         context.assemble({ ephemeral: request.ephemeral() }, lifecycle),
       );
       if (assembled === undefined || signal.aborted) return cancelled();
-      const answered = await settledUnlessAborted(
+      const answered = await settledUnlessCancelled(
         this.#options.model.respond(assembled, {
           prompt: request.prompt,
           tools: request.toolSchemas,
@@ -247,7 +247,7 @@ export class ToolLoopAgentRuntime implements AgentRuntime {
         }),
         signal,
       );
-      if (answered.aborted || signal.aborted) return cancelled();
+      if (answered.cancelled || signal.aborted) return cancelled();
       const answer = answered.value;
       if (answer.outcome === MODEL_RESPONSE_OUTCOME.THROTTLED) {
         await emit({ kind: RUNTIME_EVENT.THROTTLED, until: answer.until });
@@ -349,11 +349,11 @@ export class ToolLoopAgentRuntime implements AgentRuntime {
     await ingest({ kind: CONTEXT_INPUT_KIND.MODEL_OUTPUT, items: answer.items });
     if (lifecycle.signal?.aborted) return false;
     if (answer.compacted) {
-      const settled = await settledUnlessAborted(
+      const settled = await settledUnlessCancelled(
         Promise.resolve(request.context.compact(lifecycle)),
         lifecycle.signal ?? new AbortController().signal,
       );
-      if (settled.aborted) return false;
+      if (settled.cancelled) return false;
       await emit({ kind: RUNTIME_EVENT.COMPACTED, dropped: settled.value });
     }
     if (answer.usage) await emit({ kind: RUNTIME_EVENT.USAGE, usage: answer.usage });

--- a/packages/brain/src/settled.ts
+++ b/packages/brain/src/settled.ts
@@ -1,42 +1,42 @@
-export type Settled<T> = { aborted: true } | { aborted: false; value: T };
+export type Settled<T> = { cancelled: true } | { cancelled: false; value: T };
 
 /**
  * Waits on a promise only as long as the signal stands. Once it fires the
- * wait settles as aborted at once and the promise's eventual value is
+ * wait settles as cancelled at once and the promise's eventual value is
  * dropped unread — a late model answer or transcript can then reach nothing.
  * The promise's own rejection still propagates.
  */
-export function settledUnlessAborted<T>(
+export function settledUnlessCancelled<T>(
   promise: Promise<T>,
   signal: AbortSignal,
 ): Promise<Settled<T>> {
-  return claimedUnlessAborted(promise, signal, () => undefined);
+  return claimedUnlessCancelled(promise, signal, () => undefined);
 }
 
 /**
  * Waits on a promise whose value is a thing that must be owned by exactly
  * one party: the caller, when the value arrives while the signal stands, or
  * `discard`, when the signal fired first and the value arrives afterwards.
- * The decision is made once, at whichever comes first, so an abort and a
+ * The decision is made once, at whichever comes first, so a cancel and a
  * resolution in the same turn — or in either order across turns — leave the
  * value either claimed or discarded, never both and never neither. A
  * rejection is the caller's when nothing was decided yet, and dropped after
- * the abort answered.
+ * the cancel answered.
  */
-export function claimedUnlessAborted<T>(
+export function claimedUnlessCancelled<T>(
   promise: Promise<T>,
   signal: AbortSignal,
   discard: (value: T) => void,
 ): Promise<Settled<T>> {
   return new Promise<Settled<T>>((resolve, reject) => {
     let decided = false;
-    const abort = () => {
+    const cancel = () => {
       if (decided) return;
       decided = true;
-      resolve({ aborted: true });
+      resolve({ cancelled: true });
     };
-    if (signal.aborted) abort();
-    else signal.addEventListener("abort", abort, { once: true });
+    if (signal.aborted) cancel();
+    else signal.addEventListener("abort", cancel, { once: true });
     promise.then(
       (value) => {
         if (decided) {
@@ -44,13 +44,13 @@ export function claimedUnlessAborted<T>(
           return;
         }
         decided = true;
-        signal.removeEventListener("abort", abort);
-        resolve({ aborted: false, value });
+        signal.removeEventListener("abort", cancel);
+        resolve({ cancelled: false, value });
       },
       (error: Error) => {
         if (decided) return;
         decided = true;
-        signal.removeEventListener("abort", abort);
+        signal.removeEventListener("abort", cancel);
         reject(error);
       },
     );

--- a/packages/brain/src/state-store.ts
+++ b/packages/brain/src/state-store.ts
@@ -1,4 +1,5 @@
 import { checkpointFormatTag, type TranscriptEvent } from "@sidecar/runtime/vocabulary";
+import { type IDisposable, toDisposable } from "@sidecar/wire";
 import {
   BRAIN_STATE_VERSION,
   type BrainPersistedState,
@@ -535,11 +536,11 @@ export class BrainStateStore {
   }
 
   /** Hears every replacement, expiry, or Clear, with the generation that now stands. */
-  onReplaced(listener: (state: BrainPersistedState) => void): () => void {
+  onReplaced(listener: (state: BrainPersistedState) => void): IDisposable {
     this.#replacedListeners.add(listener);
-    return () => {
+    return toDisposable(() => {
       this.#replacedListeners.delete(listener);
-    };
+    });
   }
 
   /** Settles once every write queued so far has landed or been refused. */

--- a/packages/brain/src/store/store-operations.ts
+++ b/packages/brain/src/store/store-operations.ts
@@ -222,7 +222,7 @@ export function isStoreOperationName(value: UnparsedWireValue): value is StoreOp
 }
 
 /**
- * The two messages that are not operations: they create and destroy the
+ * The two messages that are not operations: they create and dispose the
  * `OpenStore` every operation's first parameter is, so the worker owns them
  * and the table holds neither.
  */

--- a/packages/brain/src/transcript-reads.ts
+++ b/packages/brain/src/transcript-reads.ts
@@ -6,7 +6,7 @@ import {
 } from "@sidecar/session";
 import { ACTION_RESULT_STATUS, type WireRecord } from "@sidecar/wire";
 import { rejection, sameIdentity } from "./records.js";
-import { type Settled, settledUnlessAborted } from "./settled.js";
+import { type Settled, settledUnlessCancelled } from "./settled.js";
 import { REFUSAL_REASON } from "./turn.js";
 import type { BrainTranscriptDelta, BrainWakeEvent } from "./wake-events.js";
 
@@ -85,14 +85,14 @@ export async function readTranscriptDelta(
   const { cursors } = options;
   let read: Settled<ProviderTranscriptSinceResult>;
   try {
-    read = await settledUnlessAborted(
+    read = await settledUnlessCancelled(
       options.read(identity, cursors.cursor(identity)),
       options.signal,
     );
   } catch {
     return { text: "", truncated: false, status: ACTION_RESULT_STATUS.REJECTED };
   }
-  if (read.aborted) return undefined;
+  if (read.cancelled) return undefined;
   const result = read.value;
   if (result.status !== ACTION_RESULT_STATUS.ACCEPTED) {
     return { text: "", truncated: false, status: result.status };
@@ -118,11 +118,11 @@ export async function readWholeTranscript(
 ): Promise<WireRecord> {
   let read: Settled<ProviderTranscriptResult>;
   try {
-    read = await settledUnlessAborted(options.read(identity), options.signal);
+    read = await settledUnlessCancelled(options.read(identity), options.signal);
   } catch {
     return rejection(REFUSAL_REASON.READ_FAILED);
   }
-  if (read.aborted) return rejection(REFUSAL_REASON.RUN_REVOKED);
+  if (read.cancelled) return rejection(REFUSAL_REASON.RUN_REVOKED);
   const result = read.value;
   if (result.status !== ACTION_RESULT_STATUS.ACCEPTED) {
     return { status: result.status, reason: result.reason };

--- a/packages/brain/src/turn-runner.ts
+++ b/packages/brain/src/turn-runner.ts
@@ -26,8 +26,8 @@ import { BRAIN_DEFAULTS } from "./defaults.js";
 import {
   CONTEXT_OPENING,
   claimOpenedContext,
+  disposeContext,
   type Generation,
-  retireContext,
 } from "./generation.js";
 import {
   activityNoticesInputText,
@@ -49,7 +49,7 @@ import {
 } from "./requests.js";
 import { incompleteDetail, TOOL_RESULT_STATUS } from "./runtime.js";
 import type { AgentSeam } from "./seam.js";
-import { settledUnlessAborted } from "./settled.js";
+import { settledUnlessCancelled } from "./settled.js";
 import { SteeredDeliveries } from "./steered-deliveries.js";
 import {
   type BrainChildAccess,
@@ -695,18 +695,18 @@ export class TurnRunner {
       "the runtime could not reopen its own checkpoint",
       this.#seam.now,
     );
-    if (reopened.aborted) return;
+    if (reopened.cancelled) return;
     const standing = await generation.opened;
     const stillUsed = standing.kind === CONTEXT_OPENING.LOADED && standing.context === context;
     if (generation !== this.#seam.generation() || !stillUsed) {
-      if (reopened.value.kind === CONTEXT_OPENING.LOADED) retireContext(reopened.value.context);
+      if (reopened.value.kind === CONTEXT_OPENING.LOADED) disposeContext(reopened.value.context);
       return;
     }
     // The engine the turn used is not re-admitted either way: it may hold
     // what a late hook applied. A refused reopen leaves the generation
     // standing without a context, every turn over it refused as incompatible.
     generation.opened = Promise.resolve(reopened.value);
-    retireContext(context);
+    disposeContext(context);
     if (reopened.value.kind === CONTEXT_OPENING.INCOMPATIBLE) {
       this.#seam.reportIncompatible(generation, reopened.value.reason);
     }
@@ -726,7 +726,7 @@ export class TurnRunner {
       // A forked child: the requester's context is the child's opening
       // history, adopted whole and recorded as a fork boundary, and the task
       // then follows it as the first words of the child's own.
-      await settledUnlessAborted(
+      await settledUnlessCancelled(
         Promise.resolve(context.adoptFork(inherited, { signal: turnContext.signal })),
         turnContext.signal,
       );
@@ -734,8 +734,8 @@ export class TurnRunner {
     }
     const primer = this.#options.primeFreshContext;
     if (!primer) return [];
-    const settled = await settledUnlessAborted(primer(), turnContext.signal);
-    if (settled.aborted || !settled.value) return [];
+    const settled = await settledUnlessCancelled(primer(), turnContext.signal);
+    if (settled.cancelled || !settled.value) return [];
     return [primedNotesInputText(settled.value)];
   }
 

--- a/packages/brain/src/turn.ts
+++ b/packages/brain/src/turn.ts
@@ -106,7 +106,7 @@ export type TurnResult =
 
 /**
  * One developer run's live controls: the signal its model and read work are
- * aborted through, and the flags every `isRevoked` reads. A run's execution
+ * cancelled through, and the flags every `isRevoked` reads. A run's execution
  * is revoked by the developer's cancel, by the deadline, by the agent
  * stopping, and by the store's generation being replaced under it.
  */

--- a/packages/brain/src/wake-queue.ts
+++ b/packages/brain/src/wake-queue.ts
@@ -4,7 +4,7 @@ import type { BrainWakeEvent } from "./wake-events.js";
 
 /**
  * The wakes waiting for a turn. Nothing opens at once: wakes inside the
- * coalescing window open one turn together — a hook and the poll's edge for
+ * coalescing window open one turn together — a hook and the pass's edge for
  * the same stop — and wakes during a model's quiet wait for it to end rather
  * than being dropped. The queue owns the events and the timer; the host owns
  * what a flush does with them, and hands events back when the turn they

--- a/packages/calendar/src/reader.test.ts
+++ b/packages/calendar/src/reader.test.ts
@@ -75,14 +75,14 @@ function readerWith(
 test("with no accounts it observes nothing and issues no request", async () => {
   const { reader, requests } = readerWith(routes, []);
 
-  assert.equal(await reader.observe(), undefined);
+  assert.equal(await reader.pass(), undefined);
   assert.deepEqual(requests, []);
 });
 
 test("an account's pass lists its calendars and reads only their busy times", async () => {
   const { reader, requests } = readerWith(routes, [WORK_ACCOUNT]);
 
-  const observed = await reader.observe();
+  const observed = await reader.pass();
 
   assert.deepEqual(observed, [
     {
@@ -115,7 +115,7 @@ test("a selection the list no longer names never enters the read document", asyn
     { ...WORK_ACCOUNT, selectedCalendarIds: ["team-calendar", "a-calendar-long-gone"] },
   ]);
 
-  await reader.observe();
+  await reader.pass();
 
   const read = JSON.parse(requests[2]?.body ?? "{}");
   assert.deepEqual(read.items, [{ id: "team-calendar" }]);
@@ -124,7 +124,7 @@ test("a selection the list no longer names never enters the read document", asyn
 test("nothing selected means no free/busy read at all", async () => {
   const { reader, requests } = readerWith(routes, [{ ...WORK_ACCOUNT, selectedCalendarIds: [] }]);
 
-  const observed = await reader.observe();
+  const observed = await reader.pass();
 
   assert.deepEqual(observed?.[0]?.meetings, []);
   assert.deepEqual(
@@ -158,7 +158,7 @@ test("every connected account is read, and their meetings stand apart", async ()
     [WORK_ACCOUNT, home],
   );
 
-  const observed = await reader.observe();
+  const observed = await reader.pass();
 
   assert.equal(observed?.length, 2);
   assert.equal(observed?.[1]?.accountId, "home@example.com");
@@ -175,8 +175,8 @@ test("every connected account is read, and their meetings stand apart", async ()
 test("the access token is cached across passes under the same grant", async () => {
   const { reader, requests } = readerWith(routes, [WORK_ACCOUNT]);
 
-  await reader.observe();
-  await reader.observe();
+  await reader.pass();
+  await reader.pass();
 
   assert.equal(requests.filter((request) => request.url === TOKEN_URL).length, 1);
 });
@@ -190,7 +190,7 @@ test("a revoked grant is a failure naming the account, not a quieter calendar", 
     [WORK_ACCOUNT],
   );
 
-  const observed = await reader.observe();
+  const observed = await reader.pass();
 
   assert.match(observed?.[0]?.failure ?? "", /work@example\.com.*connect the account again/);
   assert.deepEqual(observed?.[0]?.meetings, []);
@@ -219,10 +219,10 @@ test("one bad account never blinds the others, and keeps what it last showed", a
     [WORK_ACCOUNT, home],
   );
 
-  const first = await reader.observe();
+  const first = await reader.pass();
   assert.equal(first?.[0]?.failure, undefined);
   workBroken = true;
-  const second = await reader.observe();
+  const second = await reader.pass();
 
   assert.equal(second?.length, 2);
   // Work answers with what it last showed, and why it cannot answer now.
@@ -258,10 +258,10 @@ test("a calendar unread inside an OK answer is a failure, not a quieter calendar
     [WORK_ACCOUNT],
   );
 
-  const first = await reader.observe();
+  const first = await reader.pass();
   assert.equal(first?.[0]?.failure, undefined);
   broken = true;
-  const second = await reader.observe();
+  const second = await reader.pass();
 
   assert.match(second?.[0]?.failure ?? "", /team-calendar/);
   assert.deepEqual(second?.[0]?.meetings, first?.[0]?.meetings);
@@ -282,7 +282,7 @@ test("an asked-for calendar missing from the answer fails the pass the same way"
     [WORK_ACCOUNT],
   );
 
-  const observed = await reader.observe();
+  const observed = await reader.pass();
 
   assert.match(observed?.[0]?.failure ?? "", /team-calendar/);
   assert.deepEqual(observed?.[0]?.meetings, []);
@@ -298,13 +298,13 @@ test("forgetting ends an era: a failing pass after it holds nothing up", async (
     [WORK_ACCOUNT],
   );
 
-  const first = await reader.observe();
+  const first = await reader.pass();
   assert.notEqual(first?.[0]?.meetings.length, 0);
   // Sign-out forgets what observation held; a failing pass after signing
   // back in must not resurrect meetings from the era the stop ended.
   reader.forget();
   broken = true;
-  const second = await reader.observe();
+  const second = await reader.pass();
 
   assert.match(second?.[0]?.failure ?? "", /work@example\.com/);
   assert.deepEqual(second?.[0]?.meetings, []);

--- a/packages/calendar/src/reader.ts
+++ b/packages/calendar/src/reader.ts
@@ -125,7 +125,7 @@ export class GoogleCalendarReader {
     this.#accessTokens.clear();
   }
 
-  async observe(): Promise<readonly CalendarAccountObservation[] | undefined> {
+  async pass(): Promise<readonly CalendarAccountObservation[] | undefined> {
     const accounts = await this.#readAccounts();
     // No accounts, no request: the calendar is not connected, which is a
     // different answer from a connected calendar with no meetings.
@@ -141,7 +141,7 @@ export class GoogleCalendarReader {
     const observations: CalendarAccountObservation[] = [];
     for (const account of accounts) {
       try {
-        const observation = await this.#observeAccount(account);
+        const observation = await this.#passAccount(account);
         this.#lastObservations.set(account.id, observation);
         observations.push(observation);
       } catch (error) {
@@ -206,7 +206,7 @@ export class GoogleCalendarReader {
     );
   }
 
-  async #observeAccount(account: CalendarAccountCredential): Promise<CalendarAccountObservation> {
+  async #passAccount(account: CalendarAccountCredential): Promise<CalendarAccountObservation> {
     const now = this.#now();
     const accessToken = await this.#accessTokenFor(account, now);
     const calendars = await this.listCalendars(accessToken);

--- a/packages/gateway/src/attachment.test.ts
+++ b/packages/gateway/src/attachment.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import { toDisposable } from "@sidecar/wire";
 import { retryAttachWhileDetached } from "./attachment.js";
 
 /** A client stand-in: it announces changes in whether a host stands, never the standing state. */
@@ -8,7 +9,9 @@ function client() {
   return {
     onAttachedChanged: (listener: (attached: boolean) => void) => {
       listeners.add(listener);
-      return () => listeners.delete(listener);
+      return toDisposable(() => {
+        listeners.delete(listener);
+      });
     },
     announce: (attached: boolean) => {
       for (const listener of [...listeners]) listener(attached);
@@ -53,7 +56,7 @@ test("a failed attach is tried again after a growing pause until one attaches, a
   scheduled[2]?.work();
   c.announce(false);
   assert.equal(scheduled.at(-1)?.delayMs, 100);
-  release();
+  release.dispose();
   const before = attaches;
   scheduled.at(-1)?.work();
   assert.equal(attaches, before);

--- a/packages/gateway/src/attachment.ts
+++ b/packages/gateway/src/attachment.ts
@@ -1,3 +1,5 @@
+import { type IDisposable, toDisposable } from "@sidecar/wire";
+
 export const ATTACH_RETRY_DEFAULTS = {
   /** The first pause before a failed attach is tried again; each next pause doubles up to the cap. */
   INITIAL_DELAY_MS: 5_000,
@@ -6,7 +8,7 @@ export const ATTACH_RETRY_DEFAULTS = {
 
 export interface AttachRetryPorts {
   /** Hears every change in whether a host stands; a standing state is never announced. */
-  onAttachedChanged: (listener: (attached: boolean) => void) => () => void;
+  onAttachedChanged: (listener: (attached: boolean) => void) => IDisposable;
   /** Whether one stands as the retries begin; a client whose first attach already failed retries at once. */
   attached?: () => boolean;
   /** Tries once to reach a host; whether it did is heard on the attached stream, not answered here. */
@@ -22,12 +24,12 @@ export interface AttachRetryPorts {
  * reachable answers the typed disconnected error until an explicit attach,
  * and a host that was merely slow to answer would otherwise leave the client
  * with none for good. So every detachment is followed by another attach
- * after a growing pause, capped, until one attaches or the returned release
+ * after a growing pause, capped, until one attaches or the returned disposable
  * ends the retries; nothing is drawn for it, and the disconnected posture
  * stands meanwhile. This is the policy a client over a socket needs; the
  * client composed in this process reaches its host without one.
  */
-export function retryAttachWhileDetached(ports: AttachRetryPorts): () => void {
+export function retryAttachWhileDetached(ports: AttachRetryPorts): IDisposable {
   const schedule = ports.setTimeout ?? ((work, delayMs) => setTimeout(work, delayMs));
   const initialDelayMs = ports.initialDelayMs ?? ATTACH_RETRY_DEFAULTS.INITIAL_DELAY_MS;
   const maximumDelayMs = ports.maximumDelayMs ?? ATTACH_RETRY_DEFAULTS.MAXIMUM_DELAY_MS;
@@ -52,8 +54,8 @@ export function retryAttachWhileDetached(ports: AttachRetryPorts): () => void {
   };
   const unsubscribe = ports.onAttachedChanged(consider);
   if (ports.attached?.() === false) consider(false);
-  return () => {
+  return toDisposable(() => {
     released = true;
-    unsubscribe();
-  };
+    unsubscribe.dispose();
+  });
 }

--- a/packages/gateway/src/client.ts
+++ b/packages/gateway/src/client.ts
@@ -1,4 +1,11 @@
-import { isRecord, isWireNumber, type WireRecord, type WireValue } from "@sidecar/wire";
+import {
+  type IDisposable,
+  isRecord,
+  isWireNumber,
+  toDisposable,
+  type WireRecord,
+  type WireValue,
+} from "@sidecar/wire";
 import {
   GATEWAY_ERROR,
   GATEWAY_METHOD,
@@ -70,7 +77,7 @@ export class GatewayClient {
   #generation = 0;
   /** Events that arrived while a reconnection was in flight, taken again once it has settled. */
   #arrivedDuringReconnect: GatewayEvent[] = [];
-  #unsubscribe: (() => void) | undefined;
+  #unsubscribe: IDisposable | undefined;
 
   constructor(options: GatewayClientOptions) {
     this.#options = options;
@@ -83,7 +90,7 @@ export class GatewayClient {
 
   /** Ends the subscription; a client not listening reconnects nothing. */
   close(): void {
-    this.#unsubscribe?.();
+    this.#unsubscribe?.dispose();
     this.#unsubscribe = undefined;
   }
 
@@ -111,20 +118,20 @@ export class GatewayClient {
   }
 
   /** Hears every event of one kind, in sequence, after any gap has been filled. */
-  on(kind: GatewayEventKind, listener: GatewayClientEventListener): () => void {
+  on(kind: GatewayEventKind, listener: GatewayClientEventListener): IDisposable {
     const held = this.#listeners.get(kind) ?? new Set<GatewayClientEventListener>();
     held.add(listener);
     this.#listeners.set(kind, held);
-    return () => {
+    return toDisposable(() => {
       held.delete(listener);
-    };
+    });
   }
 
-  onEvery(listener: GatewayClientEventListener): () => void {
+  onEvery(listener: GatewayClientEventListener): IDisposable {
     this.#everyListener.add(listener);
-    return () => {
+    return toDisposable(() => {
       this.#everyListener.delete(listener);
-    };
+    });
   }
 
   /**

--- a/packages/gateway/src/dispose.ts
+++ b/packages/gateway/src/dispose.ts
@@ -2,46 +2,46 @@
  * How the Gateway leaves at an explicit quit, in a fixed order: the door
  * closes to new work, everything under way is cancelled, and the host waits
  * a bounded time for it to settle. What has not settled by then is persisted
- * as unresolved for the next launch's recovery and reported as such: a
- * shutdown never fabricates a completion for work it cut off, and an effect
+ * as unsettled for the next launch's recovery and reported as such: a
+ * dispose never fabricates a completion for work it cut off, and an effect
  * whose outcome the cut left unknown stays unknown.
  */
 import type { ScheduledTimer } from "@sidecar/runtime/vocabulary";
 
-export const GATEWAY_SHUTDOWN_DEFAULTS = {
+export const GATEWAY_DISPOSE_DEFAULTS = {
   DEADLINE_MS: 10_000,
 } as const;
 
-export interface GatewayShutdownSteps {
+export interface GatewayDisposeSteps {
   closeAdmissions: () => void;
   /** Cancels everything under way; answers the ids of the runs it asked to stop. */
   cancelActive: () => Promise<readonly string[]>;
   /** Settles once no run is under way, or rejects/hangs, in which case the deadline decides. */
   awaitSettled: (signal: AbortSignal) => Promise<void>;
   /** Writes down whatever did not settle; answers how many records were left for recovery. */
-  persistUnresolved: () => Promise<number>;
+  persistUnsettled: () => Promise<number>;
 }
 
-export interface GatewayShutdownOptions {
+export interface GatewayDisposeOptions {
   deadlineMs?: number;
   now?: () => number;
   setTimeout?: (work: () => void, delayMs: number) => ScheduledTimer;
   clearTimeout?: (handle: ScheduledTimer) => void;
 }
 
-export interface GatewayShutdownReport {
+export interface GatewayDisposeReport {
   /** Whether every run under way settled before the deadline. */
   settled: boolean;
   cancelled: readonly string[];
-  /** How many records were persisted unresolved for recovery. */
-  unresolved: number;
+  /** How many records were persisted unsettled for recovery. */
+  unsettled: number;
   elapsedMs: number;
 }
 
-export async function shutdownGateway(
-  steps: GatewayShutdownSteps,
-  options: GatewayShutdownOptions = {},
-): Promise<GatewayShutdownReport> {
+export async function disposeGateway(
+  steps: GatewayDisposeSteps,
+  options: GatewayDisposeOptions = {},
+): Promise<GatewayDisposeReport> {
   const now = options.now ?? Date.now;
   const schedule = options.setTimeout ?? ((work, ms) => setTimeout(work, ms));
   const cancel =
@@ -50,7 +50,7 @@ export async function shutdownGateway(
       // SAFETY: a handle this default cancels is one the default scheduler above made, a Node timeout.
       clearTimeout(handle as NodeJS.Timeout);
     });
-  const deadlineMs = options.deadlineMs ?? GATEWAY_SHUTDOWN_DEFAULTS.DEADLINE_MS;
+  const deadlineMs = options.deadlineMs ?? GATEWAY_DISPOSE_DEFAULTS.DEADLINE_MS;
   const startedAt = now();
   steps.closeAdmissions();
   // One deadline covers the cancellation and the settling both: a cancel
@@ -78,6 +78,6 @@ export async function shutdownGateway(
         deadline,
       ]);
   if (timer !== undefined) cancel(timer);
-  const unresolved = await steps.persistUnresolved();
-  return { settled, cancelled, unresolved, elapsedMs: now() - startedAt };
+  const unsettled = await steps.persistUnsettled();
+  return { settled, cancelled, unsettled, elapsedMs: now() - startedAt };
 }

--- a/packages/gateway/src/index.ts
+++ b/packages/gateway/src/index.ts
@@ -14,10 +14,10 @@
  */
 export * from "./attachment.js";
 export * from "./client.js";
+export * from "./dispose.js";
 export * from "./invocations.js";
 export * from "./nodes.js";
 export * from "./protocol.js";
 export * from "./server.js";
-export * from "./shutdown.js";
 export * from "./transport.js";
 export * from "./wire.js";

--- a/packages/gateway/src/invocations.ts
+++ b/packages/gateway/src/invocations.ts
@@ -48,7 +48,7 @@ export function unknownInvocation(
 export class PendingInvocations {
   readonly #pending = new Map<
     string,
-    { capability: string; resolve: (result: NodeCapabilityResult) => void }
+    { capability: string; settle: (result: NodeCapabilityResult) => void }
   >();
   #closed = false;
 
@@ -63,8 +63,8 @@ export class PendingInvocations {
         unavailableInvocation(invocation, NODE_INVOCATION_REFUSAL.DISCONNECTED),
       );
     }
-    return new Promise((resolve) => {
-      this.#pending.set(invocation.invocationId, { capability: invocation.capability, resolve });
+    return new Promise((settle) => {
+      this.#pending.set(invocation.invocationId, { capability: invocation.capability, settle });
     });
   }
 
@@ -73,7 +73,7 @@ export class PendingInvocations {
     const held = this.#pending.get(answer.invocationId);
     if (!held) return false;
     this.#pending.delete(answer.invocationId);
-    held.resolve(answer.result);
+    held.settle(answer.result);
     return true;
   }
 
@@ -86,7 +86,7 @@ export class PendingInvocations {
     this.#closed = true;
     for (const [id, held] of [...this.#pending]) {
       this.#pending.delete(id);
-      held.resolve(unknownInvocation({ capability: held.capability }));
+      held.settle(unknownInvocation({ capability: held.capability }));
     }
   }
 }

--- a/packages/gateway/src/node-invocations.test.ts
+++ b/packages/gateway/src/node-invocations.test.ts
@@ -1,6 +1,12 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { isRecord, isWireString, type UnparsedWireValue, type WireRecord } from "@sidecar/wire";
+import {
+  isRecord,
+  isWireString,
+  toDisposable,
+  type UnparsedWireValue,
+  type WireRecord,
+} from "@sidecar/wire";
 import { WebSocket } from "ws";
 import { GatewayClient } from "./client.js";
 import { InvocationMemory, NODE_INVOCATION_REFUSAL } from "./invocations.js";
@@ -381,7 +387,9 @@ test("a client that adopts a replaced host follows the new host's numbering from
       request: (request) => current.handle(request, OPERATOR),
       events: (sink) => {
         sinks.add(sink);
-        return () => sinks.delete(sink);
+        return toDisposable(() => {
+          sinks.delete(sink);
+        });
       },
       connected: () => true,
     },
@@ -526,7 +534,9 @@ test("an event of the new host arriving during adoption is held and delivered af
       },
       events: (sink) => {
         sinks.add(sink);
-        return () => sinks.delete(sink);
+        return toDisposable(() => {
+          sinks.delete(sink);
+        });
       },
       connected: () => true,
     },

--- a/packages/gateway/src/nodes.ts
+++ b/packages/gateway/src/nodes.ts
@@ -1,5 +1,5 @@
 import type { MaybePromise } from "@sidecar/runtime/vocabulary";
-import type { WireRecord, WireValue } from "@sidecar/wire";
+import { type IDisposable, toDisposable, type WireRecord, type WireValue } from "@sidecar/wire";
 import { NODE_CAPABILITY_STATUS, type NodeCapabilityResult } from "./protocol.js";
 
 export type NodeCapabilityHandler = (params: WireRecord) => MaybePromise<WireValue | undefined>;
@@ -146,11 +146,11 @@ export class NodeRegistry {
     return provider.perform(capability, params);
   }
 
-  onChange(listener: NodeRegistryListener): () => void {
+  onChange(listener: NodeRegistryListener): IDisposable {
     this.#listeners.add(listener);
-    return () => {
+    return toDisposable(() => {
       this.#listeners.delete(listener);
-    };
+    });
   }
 
   #provider(capability: string): HeldNode | undefined {

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -1,5 +1,11 @@
 import type { MaybePromise } from "@sidecar/runtime/vocabulary";
-import { isWireNumber, type WireRecord, type WireValue } from "@sidecar/wire";
+import {
+  type IDisposable,
+  isWireNumber,
+  toDisposable,
+  type WireRecord,
+  type WireValue,
+} from "@sidecar/wire";
 import {
   GATEWAY_CLIENT_ROLE,
   GATEWAY_ERROR,
@@ -120,7 +126,7 @@ export class GatewayServer {
   }
 
   /**
-   * Closes the door to new work: every mutating method but the shutdown
+   * Closes the door to new work: every mutating method but the dispose
    * itself answers shutting-down from here on, while reads, hellos, and
    * reconnections still answer, so a client can see the host leaving rather
    * than lose it. Nothing under way is touched; that is the coordinator's.
@@ -174,11 +180,11 @@ export class GatewayServer {
     return event;
   }
 
-  subscribe(listener: GatewayEventListener): () => void {
+  subscribe(listener: GatewayEventListener): IDisposable {
     this.#listeners.add(listener);
-    return () => {
+    return toDisposable(() => {
       this.#listeners.delete(listener);
-    };
+    });
   }
 
   /**

--- a/packages/gateway/src/transport.ts
+++ b/packages/gateway/src/transport.ts
@@ -1,3 +1,4 @@
+import { type IDisposable, toDisposable } from "@sidecar/wire";
 import {
   InvocationMemory,
   NODE_INVOCATION_REFUSAL,
@@ -29,10 +30,10 @@ export type GatewayEventSink = (event: GatewayEvent) => void;
  */
 export interface GatewayTransport {
   request(request: GatewayRequest): Promise<GatewayResponse>;
-  events(sink: GatewayEventSink): () => void;
+  events(sink: GatewayEventSink): IDisposable;
   connected(): boolean;
   /** Serves the host's invocations of this client's node capabilities, deduped by id before anything native runs. */
-  serveInvocations?(handler: NodeInvocationHandler): () => void;
+  serveInvocations?(handler: NodeInvocationHandler): IDisposable;
 }
 
 /**
@@ -46,7 +47,7 @@ export interface GatewayTransport {
 export interface GatewayHostConnection {
   connectionId: string;
   invoke(invocation: NodeInvocation): Promise<NodeCapabilityResult>;
-  onClosed(listener: () => void): () => void;
+  onClosed(listener: () => void): IDisposable;
 }
 
 /**
@@ -64,7 +65,7 @@ export abstract class ServerBoundTransport implements GatewayTransport {
   readonly #sinks = new Set<GatewayEventSink>();
   readonly #closedListeners = new Set<() => void>();
   #memory: InvocationMemory | undefined;
-  #unsubscribe: (() => void) | undefined;
+  #unsubscribe: IDisposable | undefined;
   #connected = true;
   static #connections = 0;
 
@@ -77,19 +78,19 @@ export abstract class ServerBoundTransport implements GatewayTransport {
       invoke: (invocation) => this.#invoke(invocation),
       onClosed: (listener) => {
         this.#closedListeners.add(listener);
-        return () => {
+        return toDisposable(() => {
           this.#closedListeners.delete(listener);
-        };
+        });
       },
     };
   }
 
-  serveInvocations(handler: NodeInvocationHandler): () => void {
+  serveInvocations(handler: NodeInvocationHandler): IDisposable {
     const memory = new InvocationMemory(handler);
     this.#memory = memory;
-    return () => {
+    return toDisposable(() => {
       if (this.#memory === memory) this.#memory = undefined;
-    };
+    });
   }
 
   async #invoke(invocation: NodeInvocation): Promise<NodeCapabilityResult> {
@@ -110,12 +111,12 @@ export abstract class ServerBoundTransport implements GatewayTransport {
     return this.carryRequest(request);
   }
 
-  events(sink: GatewayEventSink): () => void {
+  events(sink: GatewayEventSink): IDisposable {
     this.#sinks.add(sink);
     this.#unsubscribe ??= this.server.subscribe((event) => this.carryEvent(event));
-    return () => {
+    return toDisposable(() => {
       this.#sinks.delete(sink);
-    };
+    });
   }
 
   connected(): boolean {
@@ -130,7 +131,7 @@ export abstract class ServerBoundTransport implements GatewayTransport {
   /** Ends the transport for good: no request answers, no event is delivered, and the host hears the connection close. */
   close(): void {
     this.#connected = false;
-    this.#unsubscribe?.();
+    this.#unsubscribe?.dispose();
     this.#unsubscribe = undefined;
     this.#sinks.clear();
     for (const listener of [...this.#closedListeners]) listener();

--- a/packages/gateway/src/websocket.test.ts
+++ b/packages/gateway/src/websocket.test.ts
@@ -34,7 +34,7 @@ interface Hosted {
   host: WebSocketTransport;
   server: GatewayServer;
   port: number;
-  shutdowns: number;
+  disposals: number;
   effects: string[];
   close: () => Promise<void>;
 }
@@ -43,7 +43,7 @@ async function hosted(
   authenticate: GatewayAuthenticate = bearerAuthentication(TOKEN),
 ): Promise<Hosted> {
   const effects: string[] = [];
-  const state = { shutdowns: 0 };
+  const state = { disposals: 0 };
   let ids = 0;
   const server = new GatewayServer({
     methods: {
@@ -54,7 +54,7 @@ async function hosted(
         return gatewayOk({ runId: `run-${effects.length}` });
       },
       [GATEWAY_METHOD.SHUTDOWN]: () => {
-        state.shutdowns += 1;
+        state.disposals += 1;
         return gatewayOk({ accepted: true });
       },
       [GATEWAY_METHOD.MEMORY_STATUS]: () => gatewayError(GATEWAY_ERROR.REFUSED, "no"),
@@ -75,8 +75,8 @@ async function hosted(
     server,
     port,
     effects,
-    get shutdowns() {
-      return state.shutdowns;
+    get disposals() {
+      return state.disposals;
     },
     close: () => host.close(),
   };
@@ -174,7 +174,7 @@ test("a wrong token, a wrong protocol, and a malformed handshake are refused bef
   }
 });
 
-test("closing admissions refuses new connections and new mutations while reads and the shutdown still answer", async () => {
+test("closing admissions refuses new connections and new mutations while reads and the dispose still answer", async () => {
   const h = await hosted();
   try {
     const attached = await connect(h);
@@ -193,7 +193,7 @@ test("closing admissions refuses new connections and new mutations while reads a
     assert.deepEqual(h.effects, []);
     assert.equal((await client.call(GATEWAY_METHOD.RUN_LIST)).ok, true);
     assert.equal((await client.call(GATEWAY_METHOD.SHUTDOWN)).ok, true);
-    assert.equal(h.shutdowns, 1);
+    assert.equal(h.disposals, 1);
     attached.connection.close();
   } finally {
     await h.close();

--- a/packages/gateway/src/websocket.ts
+++ b/packages/gateway/src/websocket.ts
@@ -3,7 +3,13 @@ import http, { type IncomingMessage } from "node:http";
 import type { AddressInfo } from "node:net";
 import type { Duplex } from "node:stream";
 import { isIdentifier } from "@sidecar/runtime/vocabulary";
-import { isRecord, isWireString, type UnparsedWireValue } from "@sidecar/wire";
+import {
+  type IDisposable,
+  isRecord,
+  isWireString,
+  toDisposable,
+  type UnparsedWireValue,
+} from "@sidecar/wire";
 import { WebSocket, WebSocketServer } from "ws";
 import {
   InvocationMemory,
@@ -162,7 +168,7 @@ export class WebSocketTransport {
   /** The raw sockets whose credential is still being checked; `ws` owns none of them yet. */
   readonly #handshaking = new Set<Duplex>();
   readonly #closedListeners = new Set<(client: GatewayClientIdentity) => void>();
-  #unsubscribe: (() => void) | undefined;
+  #unsubscribe: IDisposable | undefined;
   #admitting = true;
   #connections = 0;
 
@@ -212,11 +218,11 @@ export class WebSocketTransport {
   }
 
   /** Hears every admitted socket close, with the identity it was admitted under. */
-  onClientClosed(listener: (client: GatewayClientIdentity) => void): () => void {
+  onClientClosed(listener: (client: GatewayClientIdentity) => void): IDisposable {
     this.#closedListeners.add(listener);
-    return () => {
+    return toDisposable(() => {
       this.#closedListeners.delete(listener);
-    };
+    });
   }
 
   /** Refuses every new connection from here on and closes the server's own door to mutations. */
@@ -227,7 +233,7 @@ export class WebSocketTransport {
 
   async close(): Promise<void> {
     this.#admitting = false;
-    this.#unsubscribe?.();
+    this.#unsubscribe?.dispose();
     this.#unsubscribe = undefined;
     for (const socket of [...this.#clients.keys()]) socket.close(1001, "the host is leaving");
     this.#clients.clear();
@@ -307,9 +313,9 @@ export class WebSocketTransport {
       },
       onClosed: (listener) => {
         client.closedListeners.add(listener);
-        return () => {
+        return toDisposable(() => {
           client.closedListeners.delete(listener);
-        };
+        });
       },
     };
   }
@@ -485,8 +491,8 @@ export class WebSocketGatewayConnection implements GatewayTransport {
     if (!this.#open || this.#socket.readyState !== WebSocket.OPEN) {
       return Promise.resolve(disconnected(request.id));
     }
-    return new Promise((resolve) => {
-      this.#pending.set(request.id, resolve);
+    return new Promise((settle) => {
+      this.#pending.set(request.id, settle);
       this.#socket.send(
         JSON.stringify({
           kind: GATEWAY_FRAME.REQUEST,
@@ -495,17 +501,17 @@ export class WebSocketGatewayConnection implements GatewayTransport {
         (error) => {
           if (!error) return;
           this.#pending.delete(request.id);
-          resolve(disconnected(request.id));
+          settle(disconnected(request.id));
         },
       );
     });
   }
 
-  events(sink: GatewayEventSink): () => void {
+  events(sink: GatewayEventSink): IDisposable {
     this.#sinks.add(sink);
-    return () => {
+    return toDisposable(() => {
       this.#sinks.delete(sink);
-    };
+    });
   }
 
   connected(): boolean {
@@ -518,19 +524,19 @@ export class WebSocketGatewayConnection implements GatewayTransport {
    * invocation arriving while no handler is served is answered unavailable,
    * so the host never waits on a node that is not there.
    */
-  serveInvocations(handler: NodeInvocationHandler): () => void {
+  serveInvocations(handler: NodeInvocationHandler): IDisposable {
     const memory = new InvocationMemory(handler);
     this.#memory = memory;
-    return () => {
+    return toDisposable(() => {
       if (this.#memory === memory) this.#memory = undefined;
-    };
+    });
   }
 
-  onClosed(listener: () => void): () => void {
+  onClosed(listener: () => void): IDisposable {
     this.#closedListeners.add(listener);
-    return () => {
+    return toDisposable(() => {
       this.#closedListeners.delete(listener);
-    };
+    });
   }
 
   close(): void {
@@ -552,10 +558,10 @@ export class WebSocketGatewayConnection implements GatewayTransport {
     if (kind === GATEWAY_FRAME.RESPONSE) {
       const response = gatewayResponseFromWire(envelope);
       if (!response) return;
-      const resolve = this.#pending.get(response.id);
-      if (!resolve) return;
+      const settle = this.#pending.get(response.id);
+      if (!settle) return;
       this.#pending.delete(response.id);
-      resolve(response);
+      settle(response);
       return;
     }
     if (kind === GATEWAY_FRAME.EVENT) {
@@ -591,7 +597,7 @@ export class WebSocketGatewayConnection implements GatewayTransport {
   #closed(): void {
     if (!this.#open) return;
     this.#open = false;
-    for (const [id, resolve] of this.#pending) resolve(disconnected(id));
+    for (const [id, settle] of this.#pending) settle(disconnected(id));
     this.#pending.clear();
     for (const listener of [...this.#closedListeners]) listener();
     this.#closedListeners.clear();

--- a/packages/host/AGENTS.md
+++ b/packages/host/AGENTS.md
@@ -49,9 +49,9 @@ argument, in the order the composers are built.
 
 `Host.stop()` is the whole quit, in the coordinator's fixed order:
 admissions closed, everything under way cancelled, a bounded wait for it to
-settle, whatever did not settle written down as unresolved for the next
+settle, whatever did not settle written down as unsettled for the next
 launch's recovery, and only then the store closed. A caller that ran the
-steps itself would be a second order for the same quit; a shutdown never
+steps itself would be a second order for the same quit; a dispose never
 fabricates a completion for work it cut off.
 
 ## The account preference client is here for the graph's sake

--- a/packages/host/src/apple-calendar.test.ts
+++ b/packages/host/src/apple-calendar.test.ts
@@ -50,7 +50,7 @@ function fullAccessAnswer(): string {
 
 test("with no connection the helper is never run", async () => {
   const { reader, runs } = readerFor({ answer: () => fullAccessAnswer() });
-  assert.equal(await reader.observe(), undefined);
+  assert.equal(await reader.pass(), undefined);
   assert.equal(runs.length, 0);
 });
 
@@ -60,7 +60,7 @@ test("a pass asks for the shared window and the chosen calendars, and answers me
     answer: () => fullAccessAnswer(),
   });
 
-  const observation = await reader.observe();
+  const observation = await reader.pass();
   assert.deepEqual(runs[0]?.helperArguments, [
     "observe",
     new Date(NOW - MAXIMUM_MEETING_LENGTH_MS).toISOString(),
@@ -134,14 +134,14 @@ test("access withdrawn empties the calendar rather than standing what it held", 
     answer: () => answer(),
   });
 
-  const first = await reader.observe();
+  const first = await reader.pass();
   assert.equal(first?.meetings.length, 2);
 
   // The system's own answer takes the calendars and meetings with it:
   // nothing may keep standing — or keep holding announcements — on consent
   // the user just took back in System Settings.
   answer = () => JSON.stringify({ access: APPLE_CALENDAR_ACCESS.DENIED });
-  const withdrawn = await reader.observe();
+  const withdrawn = await reader.pass();
   assert.match(withdrawn?.failure ?? "", /System Settings/);
   assert.deepEqual(withdrawn?.meetings, []);
   assert.deepEqual(withdrawn?.calendars, []);
@@ -151,7 +151,7 @@ test("access withdrawn empties the calendar rather than standing what it held", 
   // withdrawal itself — never resurrecting what it took, nor dressing the
   // row back up as connected.
   answer = () => new Error("helper went away");
-  const failed = await reader.observe();
+  const failed = await reader.pass();
   assert.deepEqual(failed?.meetings, []);
   assert.equal(failed?.revoked, true);
   assert.match(failed?.failure ?? "", /helper went away/);
@@ -163,15 +163,15 @@ test("a helper that fails or answers unreadably stands the last observation", as
     connection: { selectedCalendarIds: ["work"] },
     answer: () => answer(),
   });
-  const first = await reader.observe();
+  const first = await reader.pass();
 
   answer = () => new Error("helper went away");
-  const failed = await reader.observe();
+  const failed = await reader.pass();
   assert.match(failed?.failure ?? "", /helper went away/);
   assert.deepEqual(failed?.meetings, first?.meetings);
 
   answer = () => "not json at all";
-  const unreadable = await reader.observe();
+  const unreadable = await reader.pass();
   assert.match(unreadable?.failure ?? "", /answered unreadably/);
   assert.deepEqual(unreadable?.meetings, first?.meetings);
 });
@@ -182,11 +182,11 @@ test("forget clears what a failing pass would otherwise stand", async () => {
     connection: { selectedCalendarIds: ["work"] },
     answer: () => (healthy ? fullAccessAnswer() : new Error("helper went away")),
   });
-  await reader.observe();
+  await reader.pass();
   reader.forget();
 
   healthy = false;
-  const observation = await reader.observe();
+  const observation = await reader.pass();
   assert.deepEqual(observation?.meetings, []);
   assert.deepEqual(observation?.calendars, []);
   assert.match(observation?.failure ?? "", /helper went away/);

--- a/packages/host/src/apple-calendar.ts
+++ b/packages/host/src/apple-calendar.ts
@@ -208,7 +208,7 @@ export class AppleCalendarReader {
     this.#lastObservation = undefined;
   }
 
-  async observe(): Promise<AppleCalendarObservation | undefined> {
+  async pass(): Promise<AppleCalendarObservation | undefined> {
     const connection = await this.#readConnection();
     // Not connected, no read: the calendar is not connected, which is a
     // different answer from a connected calendar with no meetings.
@@ -217,7 +217,7 @@ export class AppleCalendarReader {
       return undefined;
     }
     try {
-      const observation = await this.#observeConnection(connection);
+      const observation = await this.#passConnection(connection);
       // What the next failing pass stands: a clean read's lists, or a
       // refusal's emptiness with its `revoked` — a transient failure after a
       // withdrawal must not resurrect what the withdrawal already took, nor
@@ -311,7 +311,7 @@ export class AppleCalendarReader {
     return outcome;
   }
 
-  async #observeConnection(connection: AppleCalendarConnection): Promise<AppleCalendarObservation> {
+  async #passConnection(connection: AppleCalendarConnection): Promise<AppleCalendarObservation> {
     const now = this.#now();
     // The same window the Google free/busy read keeps to, so the two sources
     // hold and release announcements on identical terms.

--- a/packages/host/src/brain/action-performer.test.ts
+++ b/packages/host/src/brain/action-performer.test.ts
@@ -118,7 +118,7 @@ function performer(overrides: Partial<BrainActionPerformerDependencies> = {}) {
       openSessionChange: async () => ({ status: ACTION_RESULT_STATUS.ACCEPTED }),
     },
     sessions: (): readonly Session[] => [observed],
-    refreshSessions: async () => {},
+    passSessions: async () => {},
     workspaceProjects: () => [],
     workspaceDefaults: async () => ({}),
     trackedIssues: () => undefined,
@@ -357,7 +357,7 @@ test("an action with no turn standing is refused in main before any validator or
 test("a turn revoked while the roster refreshed is refused before the effect, and nothing is recorded", async () => {
   let revoked = false;
   const { actions, performed, recorded } = performer({
-    refreshSessions: async () => {
+    passSessions: async () => {
       revoked = true;
     },
   });
@@ -404,7 +404,7 @@ test("an action is validated against the roster as refreshed inside the turn, no
   let sessions: readonly Session[] = [observed];
   const { actions, performed } = performer({
     sessions: () => sessions,
-    refreshSessions: async () => {
+    passSessions: async () => {
       // The session is gone by the time the action is validated.
       sessions = [];
     },
@@ -419,7 +419,7 @@ test("a creation is admitted against the projects the same pass reported, and th
   let passes = 0;
   const { actions, performed } = performer({
     workspaceProjects: () => projects,
-    refreshSessions: async () => {
+    passSessions: async () => {
       passes += 1;
       // The project is only offered once an observation pass has run.
       projects = [LISTED_PROJECT];
@@ -437,7 +437,7 @@ test("a creation is admitted against the projects the same pass reported, and th
 test("an issue act observes nothing: no pass runs for an action the roster cannot answer for", async () => {
   let passes = 0;
   const { actions } = performer({
-    refreshSessions: async () => {
+    passSessions: async () => {
       passes += 1;
     },
   });
@@ -449,8 +449,8 @@ test("an issue act observes nothing: no pass runs for an action the roster canno
   assert.equal(passes, 0);
 });
 
-test("a cancel during the roster refresh or the defaults read settles the action, and the late read dispatches nothing", async () => {
-  for (const held of ["refreshSessions", "workspaceDefaults"] as const) {
+test("a cancel during the roster pass or the defaults read settles the action, and the late read dispatches nothing", async () => {
+  for (const held of ["passSessions", "workspaceDefaults"] as const) {
     let release: (() => void) | undefined;
     const gate = new Promise<void>((resolve) => {
       release = resolve;
@@ -472,7 +472,7 @@ test("a cancel during the roster refresh or the defaults read settles the action
     // Only a creation reads the defaults, so each held read is exercised by the
     // act that actually waits on it.
     const pending = h.actions.perform(
-      held === "refreshSessions" ? MESSAGE_CALL : CREATE_CALL,
+      held === "passSessions" ? MESSAGE_CALL : CREATE_CALL,
       execution,
     );
     let settled = false;

--- a/packages/host/src/brain/action-performer.ts
+++ b/packages/host/src/brain/action-performer.ts
@@ -46,7 +46,7 @@ export interface BrainActionPerformerDependencies {
    * Triggers a fresh observation pass so the session registry is current before
    * validation and perform. Called before every session action.
    */
-  refreshSessions: () => Promise<void>;
+  passSessions: () => Promise<void>;
   workspaceProjects: () => readonly ObservedWorkspaceProject[];
   workspaceDefaults: () => Promise<WorkspaceCreationDefaults>;
   trackedIssues: () => readonly TrackedIssue[] | undefined;
@@ -95,7 +95,7 @@ function rejection(reason: string): WireRecord {
  * the run and who opened it. Whether the action may run at all was the tool
  * policy's decision before the call left the brain; here the context is what
  * says the turn still stands, and admission asks it again after every read of
- * its own, so an action whose turn ended while the roster was refreshing is
+ * its own, so an action whose turn ended while the roster pass was under way is
  * refused rather than dispatched. A call with no context or a malformed one is
  * refused before admission runs. The origin decides only how Conversation records
  * the action: at the developer's ask, or as Luke's own judgment in a turn nobody
@@ -111,13 +111,13 @@ export function createBrainActionPerformer(
     // them admission asks for. An action that asks for neither — an issue action, a
     // setting — observes nothing at all.
     let pass: Promise<void> | undefined;
-    const observed = () => (pass ??= dependencies.refreshSessions());
+    const observed = () => (pass ??= dependencies.passSessions());
     return {
       origin: execution.origin,
       guard: execution,
       // The reads before an effect wait only as long as the standing does: a
-      // cancel landing mid-refresh settles the action inside admission, and the
-      // refresh's late answer dispatches nothing.
+      // cancel landing mid-pass settles the action inside admission, and the
+      // pass's late answer dispatches nothing.
       roster: {
         read: async () => {
           await observed();

--- a/packages/host/src/brain/conversation-deletion.ts
+++ b/packages/host/src/brain/conversation-deletion.ts
@@ -67,7 +67,7 @@ export const CONVERSATION_DELETION_INCOMPLETE = {
  * remove what stood at or before the press: the lines and transcript of that
  * instant and earlier, in one transaction with the compressed recovery
  * archive and the raised cutoff, while a line accepted after the press stays
- * and the successor lifetime stands. Nothing is retired or reopened: the same
+ * and the successor lifetime stands. Nothing is disposed or reopened: the same
  * brain works on from the empty successor, and a credential rebuild landing
  * meanwhile builds over the same store, whose standing generation is that
  * successor.

--- a/packages/host/src/brain/host-lifecycle.test.ts
+++ b/packages/host/src/brain/host-lifecycle.test.ts
@@ -107,7 +107,7 @@ test("a successor replacing the agent under outstanding runs inherits a thread w
   const fresh = c.repository.state?.requests.find((r) => r.question === "new ask");
   assert.equal(fresh?.status, BRAIN_REQUEST_STATUS.SUCCEEDED);
   assert.equal(c.thread().at(-1)?.words, "done");
-  // The retired agent takes nothing more and writes nothing more: its store
+  // The disposed agent takes nothing more and writes nothing more: its store
   // lease passed to the successor with the handoff.
   assert.equal(
     (

--- a/packages/host/src/brain/host.test.ts
+++ b/packages/host/src/brain/host.test.ts
@@ -32,7 +32,7 @@ function host(log: string[]) {
   });
 }
 
-test("retiring withdraws the agent at once and begins its stop before any await", () => {
+test("disposing withdraws the agent at once and begins its stop before any await", () => {
   const log: string[] = [];
   const brains = host(log);
   const a = fakeAgent("a", log);
@@ -40,7 +40,7 @@ test("retiring withdraws the agent at once and begins its stop before any await"
   a.release();
   return brains.settled().then(() => {
     assert.equal(brains.current(), a.agent);
-    brains.retire();
+    brains.dispose();
     assert.equal(brains.current(), undefined);
     assert.deepEqual(log, ["follow agent", "stop a"]);
   });
@@ -56,7 +56,7 @@ test("overlapping transitions install only the latest agent, once every earlier 
   assert.equal(brains.current(), a.agent);
   const installed = log.length;
 
-  // Transition B retires A and waits on A's slow stop; transition C arrives
+  // Transition B disposes A and waits on A's slow stop; transition C arrives
   // meanwhile. B must install nothing, and C must not install until A has
   // stopped.
   const second = brains.replace(() => {
@@ -100,7 +100,7 @@ test("a build decided after a newer transition is stopped rather than installed,
   assert.equal(log.filter((entry) => entry === "publish empty").length, 1);
 });
 
-test("a retirement while an earlier replacement waits on a stop leaves that build uninstalled", async () => {
+test("a disposal while an earlier replacement waits on a stop leaves that build uninstalled", async () => {
   const log: string[] = [];
   const brains = host(log);
   const a = fakeAgent("a", log);
@@ -111,7 +111,7 @@ test("a retirement while an earlier replacement waits on a stop leaves that buil
     return b.agent;
   });
   // The source goes away before A has finished stopping: nothing may install.
-  brains.retire();
+  brains.dispose();
   a.release();
   await replacing;
   assert.equal(brains.current(), undefined);
@@ -121,12 +121,12 @@ test("a retirement while an earlier replacement waits on a stop leaves that buil
   assert.equal(log.filter((entry) => entry === "publish empty").length, 1);
 });
 
-test("the follower outlives the stop it relays, and retires once the stop settles", async () => {
+test("the follower outlives the stop it relays, and is disposed once the stop settles", async () => {
   const log: string[] = [];
   const brains = host(log);
   const a = fakeAgent("a", log);
   await brains.replace(() => a.agent);
-  brains.retire();
+  brains.dispose();
   assert.deepEqual(log, ["follow agent", "stop a"]);
   a.release();
   await brains.replace(() => undefined);
@@ -179,7 +179,7 @@ test("a rejected drain fails the transition that waited on it, and the next tran
   await brains.replace(() => a.agent);
   const b = fakeAgent("b", log);
   b.release();
-  // Retiring a queues its rejecting drain; the replacement that waits on it
+  // Disposing a queues its rejecting drain; the replacement that waits on it
   // fails as its caller's transition, and b is never installed.
   await assert.rejects(
     brains.replace(() => b.agent),
@@ -189,7 +189,7 @@ test("a rejected drain fails the transition that waited on it, and the next tran
   assert.equal(log.includes("follow 2"), false);
 
   // The queue is not poisoned: the next transition installs, and the one
-  // after it retires that agent and publishes empty.
+  // after it disposes that agent and publishes empty.
   const c = fakeAgent("c", log);
   c.release();
   await brains.replace(() => c.agent);
@@ -238,7 +238,7 @@ test("a superseded build's rejecting stop fails the older transition, and the ne
   assert.deepEqual(log, ["follow agent", "stop first", "unfollow", "stop stale", "follow agent"]);
 });
 
-test("a retirement queued alone has its rejection handled before any transition waits on it", async () => {
+test("a disposal queued alone has its rejection handled before any transition waits on it", async () => {
   const log: string[] = [];
   let unhandled = 0;
   const onUnhandled = () => {
@@ -257,8 +257,8 @@ test("a retirement queued alone has its rejection handled before any transition 
     const a = fakeAgent("a", log);
     a.release();
     await brains.replace(() => a.agent);
-    brains.retire();
-    // A slow credential apply stands between the retire and the rebuild.
+    brains.dispose();
+    // A slow credential apply stands between the dispose and the rebuild.
     await new Promise((resolve) => setTimeout(resolve, 20));
     assert.equal(unhandled, 0);
     await assert.rejects(

--- a/packages/host/src/brain/host.ts
+++ b/packages/host/src/brain/host.ts
@@ -2,12 +2,12 @@ import type { BrainAgent } from "@sidecar/brain";
 
 /**
  * Who owns the standing brain agent through a transition. A key or account
- * change retires the agent that stands and, once the new capability is known,
+ * change disposes the agent that stands and, once the new capability is known,
  * builds another; two transitions can overlap — an account landing while a
  * key is still being removed — and the older one must never install an agent
- * after the newer has decided. So retirement is synchronous and immediate,
+ * after the newer has decided. So disposal is synchronous and immediate,
  * withdrawing the old agent's execution before the transition's first await,
- * and building is serialized behind every earlier retirement and coalesced to
+ * and building is serialized behind every earlier disposal and coalesced to
  * the latest transition: when the queue reaches a build, only the newest
  * request still owns the outcome, and every older one installs nothing.
  */
@@ -18,9 +18,9 @@ export interface BrainHostDependencies {
   publishEmpty: () => void;
 }
 
-type RetirementOutcome = { ok: true } | { ok: false; error: Error };
+type DisposalOutcome = { ok: true } | { ok: false; error: Error };
 
-function settledOutcome(drain: Promise<unknown>): Promise<RetirementOutcome> {
+function settledOutcome(drain: Promise<unknown>): Promise<DisposalOutcome> {
   return drain.then(
     () => ({ ok: true }),
     (error: Error) => ({ ok: false, error }),
@@ -32,12 +32,12 @@ export class BrainHost {
   #agent: BrainAgent | undefined;
   #unfollow: (() => Promise<void>) | undefined;
   /**
-   * Each retirement's drain, captured as it settles rather than as it runs: a
+   * Each disposal's drain, captured as it settles rather than as it runs: a
    * drain that rejects has a handler from the moment it is queued, since the
    * transition that awaits it may begin only after a slow credential apply,
    * and its failure is kept for that transition to answer with.
    */
-  #retiring: Promise<RetirementOutcome>[] = [];
+  #disposing: Promise<DisposalOutcome>[] = [];
   #transitions = 0;
   #chain: Promise<void> = Promise.resolve();
 
@@ -53,11 +53,11 @@ export class BrainHost {
    * Withdraws the standing agent now: nothing may ask it anything more, and
    * its `stop` — which revokes every run and observation turn synchronously
    * before it awaits — is begun at once. Its follower relays the stop's own
-   * interruptions and retires when the stop settles. The stop's settling is
+   * interruptions and disposes when the stop settles. The stop's settling is
    * awaited by the next build, never by the caller.
    */
-  retire(): void {
-    // Retiring is itself a transition: a build already queued for an earlier
+  dispose(): void {
+    // Disposing is itself a transition: a build already queued for an earlier
     // one must not install after this withdrawal, or a source that has gone
     // away would gain an agent.
     this.#transitions += 1;
@@ -66,14 +66,14 @@ export class BrainHost {
     this.#agent = undefined;
     this.#unfollow = undefined;
     if (!previous) {
-      if (unfollow) this.#retiring.push(settledOutcome(unfollow()));
+      if (unfollow) this.#disposing.push(settledOutcome(unfollow()));
       return;
     }
     // The follower stays through the stop, so the runs the stop interrupts
     // still reach the windows and the thread, and its publication of them
     // drains before anything succeeds this agent: the next build, and the
     // store's lease, wait on it.
-    this.#retiring.push(
+    this.#disposing.push(
       settledOutcome(
         previous
           .stop()
@@ -84,19 +84,19 @@ export class BrainHost {
   }
 
   /**
-   * Retires whatever stands and, once every retirement has settled, installs
+   * Disposes whatever stands and, once every disposal has settled, installs
    * what `build` answers — unless a newer transition has been asked for since,
    * in which case this one installs nothing and the newer one decides. A
    * build answering nothing stands the host down and says so to the windows.
    */
   replace(build: () => BrainAgent | undefined): Promise<void> {
-    this.retire();
+    this.dispose();
     const transition = ++this.#transitions;
     const step = this.#chain.then(async () => {
-      // Every retirement queued so far drains before a successor stands. A
+      // Every disposal queued so far drains before a successor stands. A
       // drain that rejected has still ended, and its failure is this
       // transition's to answer with, as it always was.
-      const outcomes = await Promise.all(this.#retiring.splice(0));
+      const outcomes = await Promise.all(this.#disposing.splice(0));
       const failed = outcomes.find((outcome) => !outcome.ok);
       if (failed && !failed.ok) throw failed.error;
       if (transition !== this.#transitions) return;

--- a/packages/host/src/brain/publication.test.ts
+++ b/packages/host/src/brain/publication.test.ts
@@ -14,6 +14,7 @@ import {
   type ConversationEntry,
   maximumTypedAskLength,
 } from "@sidecar/session";
+import { toDisposable } from "@sidecar/wire";
 import { operatorOverBrain } from "../testing/index.js";
 import { followBrainRequests, publishRuns } from "./publication.js";
 
@@ -200,7 +201,7 @@ test("a run's end reaches the thread once, at the moment it settled, decided aga
   assert.equal(written.recorded.length, 2);
 });
 
-test("a retired follower stops between two records, and the second waits for a live report", async () => {
+test("a disposed follower stops between two records, and the second waits for a live report", async () => {
   const written = thread();
   const marked: string[] = [];
   const live = [record({ runId: "run-1" }), record({ runId: "run-2" })];
@@ -343,9 +344,9 @@ test("following a brain relays every report, writes and marks the ended runs, an
   const agent = {
     subscribe: (next: (records: readonly BrainRequestRecord[]) => void) => {
       listener = next;
-      return () => {
+      return toDisposable(() => {
         listener = undefined;
-      };
+      });
     },
     ready: () => Promise.resolve(),
     requests: () => [ready],
@@ -377,14 +378,14 @@ test("following a brain relays every report, writes and marks the ended runs, an
   assert.equal(listener, undefined);
 });
 
-test("a retired follower relays nothing a late report carries", async () => {
+test("a disposed follower relays nothing a late report carries", async () => {
   let listener: ((records: readonly BrainRequestRecord[]) => void) | undefined;
   let releaseReady: (() => void) | undefined;
   // SAFETY: the follower reads only these four members off the agent.
   const agent = {
     subscribe: (next: (records: readonly BrainRequestRecord[]) => void) => {
       listener = next;
-      return () => undefined;
+      return toDisposable(() => undefined);
     },
     ready: () =>
       new Promise<void>((resolve) => {
@@ -453,7 +454,7 @@ test("an end is published downstream only once its line and its mark have both l
   assert.equal(written.entries().length, 1);
 });
 
-test("a refused thread write publishes nothing downstream, and a retired follower publishes nothing late", async () => {
+test("a refused thread write publishes nothing downstream, and a disposed follower publishes nothing late", async () => {
   const published: string[] = [];
   let refuse = true;
   // SAFETY: publication reads only these members off the agent.
@@ -473,10 +474,10 @@ test("a refused thread write publishes nothing downstream, and a retired followe
   assert.equal(published.length, 0);
   refuse = false;
   let following = true;
-  // The follower retires while the mark is out: the end is written, but not
-  // handed on, because nothing may be offered on a retired follower's behalf.
+  // The follower is disposed while the mark is out: the end is written, but not
+  // handed on, because nothing may be offered on a disposed follower's behalf.
   // SAFETY: publication reads only `request` and the two marks off the agent; the fixture stands in for the rest.
-  const retiringAgent = {
+  const disposingAgent = {
     ...agent,
     markConversationRecorded: async () => {
       following = false;
@@ -484,7 +485,7 @@ test("a refused thread write publishes nothing downstream, and a retired followe
     },
   } as unknown as BrainAgent;
   await publishRuns(
-    retiringAgent,
+    disposingAgent,
     [record()],
     written.record,
     () => following,

--- a/packages/host/src/brain/publication.ts
+++ b/packages/host/src/brain/publication.ts
@@ -125,7 +125,7 @@ async function publishEnd(
  * rebuilt followers, and launches. Each write is decided against the record
  * as it stands at that moment, never against the report that prompted it, so
  * an older report cannot write what a newer one already marked, and a
- * follower retired mid-way writes nothing more. Only a write the thread
+ * follower disposed mid-way writes nothing more. Only a write the thread
  * confirmed marks the run; a write that failed leaves it for the next report.
  * The mark, not the thread's contents, is what says a run was published, so
  * a line the thread has since let go of is never written back.
@@ -152,7 +152,7 @@ export async function publishRuns(
  * as it arrives, its records relayed to every window and its runs written to
  * the thread. The subscription is the completion channel the reply delivery
  * reads; the thread write here is the one Conversation write for a run.
- * Unfollowing retires the subscription, drains the publication of the reports
+ * Unfollowing disposes the subscription, drains the publication of the reports
  * already taken, and then relays nothing more, so a replaced agent's records
  * are all written once and its late ones reach neither the thread nor the
  * windows.
@@ -188,13 +188,13 @@ export function followBrainRequests(
   const unsubscribe = agent.subscribe(listener);
   void agent.ready().then(() => listener(agent.requests()));
   // Unfollowing takes no more reports at once, but lets the ones already
-  // taken finish: the stop that retires an agent reports every run it
+  // taken finish: the stop that disposes an agent reports every run it
   // interrupted, and those ends belong in the thread before the follower
   // goes. Each write answers promptly — the store refuses rather than hangs —
   // so the drain is bounded by the reports already queued.
   return async () => {
     accepting = false;
-    unsubscribe();
+    unsubscribe.dispose();
     await publishing;
     following = false;
   };

--- a/packages/host/src/brain/wiring-children.test.ts
+++ b/packages/host/src/brain/wiring-children.test.ts
@@ -235,7 +235,7 @@ function composed(
         openSessionChange: () => Promise.reject(new Error("not in test")),
       },
       sessions: () => [],
-      refreshSessions: async () => undefined,
+      passSessions: async () => undefined,
       workspaceProjects: () => [],
       workspaceDefaults: async () => ({}),
       trackedIssues: () => undefined,
@@ -362,7 +362,7 @@ test("a spawn from main runs the child in its own conversation at depth one and 
   await drainMicrotasks(180);
   assert.deepEqual(c.archived, [child.childSessionKey]);
   assert.equal(c.wiring.current(child.childSessionKey), undefined);
-  c.wiring.retire();
+  c.wiring.dispose();
   await c.wiring.rebuild();
 });
 
@@ -403,7 +403,7 @@ test("a child spawning a child counts one deeper, and at the depth cap the deleg
   for (const record of c.children.values()) {
     assert.equal(record.status, CHILD_RUN_STATUS.COMPLETED);
   }
-  c.wiring.retire();
+  c.wiring.dispose();
   await c.wiring.rebuild();
 });
 
@@ -450,7 +450,7 @@ test("a fork carries the requester's context into the child and an isolated chil
   const isolatedTurn = childTurns.find((seen) => !seen.texts.includes(MAIN_SECRET));
   assert.ok(forkedTurn, "the forked child read the requester's earlier words");
   assert.ok(isolatedTurn, "the isolated child read none of them");
-  c.wiring.retire();
+  c.wiring.dispose();
   await c.wiring.rebuild();
 });
 
@@ -466,7 +466,7 @@ test("Start fresh cancels a conversation's descendants first, and their cancella
     if (seen.texts.includes(BRAIN_INPUT_MARKER.SUBAGENT_TASK)) {
       // The child's model call never answers until released: the child stays running.
       return new Promise<ScriptedAnswer>((_resolve, reject) => {
-        releaseChild = () => reject(new Error("aborted"));
+        releaseChild = () => reject(new Error("cancelled"));
       });
     }
     return script(seen, calls);
@@ -488,7 +488,7 @@ test("Start fresh cancels a conversation's descendants first, and their cancella
   assert.ok(completion);
   assert.equal(completion.status, CHILD_RUN_STATUS.CANCELLED);
   releaseChild?.();
-  c.wiring.retire();
+  c.wiring.dispose();
   await c.wiring.rebuild();
 });
 
@@ -520,6 +520,6 @@ test("a reset capture that was skipped reports nothing, while one that failed is
       reported,
       outcome,
     );
-    c.wiring.retire();
+    c.wiring.dispose();
   }
 });

--- a/packages/host/src/brain/wiring-children.ts
+++ b/packages/host/src/brain/wiring-children.ts
@@ -54,7 +54,7 @@ export interface ChildWiringHost {
    * inherited fork as its opening history; nothing while no model stands.
    */
   open: (sessionKey: SessionKey, fork?: readonly WireRecord[]) => Promise<BrainAgent | undefined>;
-  /** Retires a conversation's brain and lets its store go. */
+  /** Disposes a conversation's brain and lets its store go. */
   closeConversation: (sessionKey: SessionKey) => Promise<void>;
 }
 

--- a/packages/host/src/brain/wiring-routing.test.ts
+++ b/packages/host/src/brain/wiring-routing.test.ts
@@ -195,7 +195,7 @@ function composed(t: TestContext, gate?: Gate): Composed {
         openSessionChange: () => Promise.reject(new Error("not in test")),
       },
       sessions: () => roster,
-      refreshSessions: async () => undefined,
+      passSessions: async () => undefined,
       workspaceProjects: () => [],
       workspaceDefaults: async () => ({}),
       trackedIssues: () => undefined,
@@ -282,7 +282,7 @@ test("each conversation's standing context is built for its own key", async (t) 
   for (const text of texts) {
     assert.ok(!text.includes(`standing context for ${MAIN_SESSION_KEY}`));
   }
-  c.wiring.retire();
+  c.wiring.dispose();
   await c.wiring.rebuild();
 });
 
@@ -348,7 +348,7 @@ test("a roster look opens one conversation per observed session, each reading on
   await until(() => c.wiring.current(defKey) === undefined);
   assert.equal(c.wiring.current(defKey), undefined);
   assert.ok(c.wiring.current(abcKey));
-  c.wiring.retire();
+  c.wiring.dispose();
   await c.wiring.rebuild();
 });
 
@@ -388,7 +388,7 @@ test("hooks route to the session's own conversation, main is never woken by one,
   assert.ok(releases.some((text) => text.includes("old news") && !text.includes("abc finished")));
   // The wake rode into the source conversation's hold-release turn, and main's carried none.
   assert.equal(observed.pendingWakes(), 0);
-  c.wiring.retire();
+  c.wiring.dispose();
   await c.wiring.rebuild();
 });
 
@@ -417,7 +417,7 @@ test("a held briefing whose source conversation has stood down goes back to that
   assert.ok(releases()[0]?.includes("a session that has stood down"));
   // Main read nothing of it: the one notice is the source's own turn.
   assert.equal(c.wiring.pendingNotices().length, 1);
-  c.wiring.retire();
+  c.wiring.dispose();
   await c.wiring.rebuild();
 });
 
@@ -446,7 +446,7 @@ test("a session that leaves the roster while its analysis is held keeps its conv
   // The next look, with the analysis over and nothing owed, stands it down.
   c.wiring.rosterLook();
   await until(() => c.wiring.current(abcKey) === undefined);
-  c.wiring.retire();
+  c.wiring.dispose();
   await c.wiring.rebuild();
 });
 
@@ -480,7 +480,7 @@ test("a hook for a session whose conversation is standing down waits for the clo
   // first was let go of before the second was opened.
   assert.ok(c.wiring.current(abcKey));
   assert.equal(c.repositories.get(abcKey), 2);
-  c.wiring.retire();
+  c.wiring.dispose();
   await c.wiring.rebuild();
 });
 
@@ -501,7 +501,7 @@ test("a rebuild landing while a conversation stands down leaves the closing host
   await closing;
   assert.equal(c.wiring.current(abcKey), undefined);
   // The rebuild built main's brain and def's, and nothing onto the host the
-  // close was about to discard, where no retire could ever reach it; the
+  // close was about to discard, where no dispose could ever reach it; the
   // first envelope took no write after its conversation stood down.
   await drainMicrotasks(60);
   assert.equal(c.builds() - buildsBefore, 2);
@@ -520,7 +520,7 @@ test("a rebuild landing while a conversation stands down leaves the closing host
   await until(() => c.wiring.pendingNotices().length === 3);
   assert.ok(c.wiring.current(abcKey));
   assert.equal(c.repositories.get(abcKey), 2);
-  c.wiring.retire();
+  c.wiring.dispose();
   await c.wiring.rebuild();
 });
 
@@ -539,7 +539,7 @@ test("a conversation reopened while it stands down waits for the close and stand
   // directory, on the second store, and the first is gone.
   assert.ok(c.wiring.current(threadKey));
   assert.equal(c.repositories.get(threadKey), 2);
-  c.wiring.retire();
+  c.wiring.dispose();
   await c.wiring.rebuild();
 });
 
@@ -570,7 +570,7 @@ test("two opens of one key landing in the same tick, a hook and a held briefing,
   const last = itemTexts(c.inputs[1] ?? []).join("\n");
   assert.ok(last.includes(BRAIN_INPUT_MARKER.OBSERVED_EVENTS));
   assert.ok(last.includes(BRAIN_INPUT_MARKER.HOLD_RELEASED));
-  c.wiring.retire();
+  c.wiring.dispose();
   await c.wiring.rebuild();
 });
 
@@ -606,6 +606,6 @@ test("one observed conversation waiting on its model neither blocks another nor 
   assert.equal(c.wiring.lanes.snapshot("agent").active, 0);
   assert.equal(c.wiring.pendingNotices().length, 1);
   assert.equal(c.wiring.pendingNotices()[0]?.label, "Claude Code: def");
-  c.wiring.retire();
+  c.wiring.dispose();
   await c.wiring.rebuild();
 });

--- a/packages/host/src/brain/wiring.test.ts
+++ b/packages/host/src/brain/wiring.test.ts
@@ -43,7 +43,7 @@ function dependencies(overrides: Partial<BrainWiringDependencies> = {}) {
         openSessionChange: async () => ({ status: "accepted" }),
       },
       sessions: () => [],
-      refreshSessions: async () => undefined,
+      passSessions: async () => undefined,
       workspaceProjects: () => [],
       workspaceDefaults: async () => ({}),
       trackedIssues: () => undefined,
@@ -86,7 +86,7 @@ test("with no model to run on, a rebuild opens no conversation and loads no stor
   assert.deepEqual(loads, [MAIN_SESSION_KEY, threadSessionKey("t-1")]);
   assert.equal(brains.current(threadSessionKey("t-1")), undefined);
   await brains.closeConversation(threadSessionKey("t-1"));
-  brains.retire();
+  brains.dispose();
 });
 
 const NOW = 1_800_000_000_000;
@@ -124,7 +124,7 @@ test("every hook event wakes the brain, carrying the session when the roster hol
     session: held,
     atMs: NOW - 500,
   });
-  // A hook for a session the poll has not seen yet still wakes the brain,
+  // A hook for a session the pass has not seen yet still wakes the brain,
   // dated now when the spool carried no usable time.
   assert.deepEqual(wakes[1], {
     kind: BRAIN_WAKE_KIND.HOOK,

--- a/packages/host/src/brain/wiring.ts
+++ b/packages/host/src/brain/wiring.ts
@@ -90,7 +90,7 @@ import {
   type SessionIdentity,
   type SessionProviderPlugin,
 } from "@sidecar/session";
-import { ACTION_RESULT_STATUS, type WireRecord } from "@sidecar/wire";
+import { ACTION_RESULT_STATUS, type IDisposable, type WireRecord } from "@sidecar/wire";
 import {
   type BrainActionPerformerDependencies,
   createBrainActionPerformer,
@@ -232,11 +232,11 @@ export interface BrainWiring {
    */
   rebuild: () => Promise<void>;
   /** Withdraws every standing brain now; their stops are awaited by the next rebuild. */
-  retire: () => void;
+  dispose: () => void;
   /** Opens a conversation for asks: its store is built and, when a model stands, its brain. */
   openConversation: (sessionKey: SessionKey) => Promise<void>;
   /**
-   * Retires a conversation's brain, drains its publication, and forgets its
+   * Disposes a conversation's brain, drains its publication, and forgets its
    * store, so nothing of the old lifetime can write. An archive closes a
    * thread for good; a deletion closes any conversation, main included, and
    * opens it again over the emptied rows.
@@ -284,7 +284,7 @@ interface OpenConversation {
   host: BrainHost;
   store: BrainStateStore;
   clock: BrainGenerationClock;
-  unsubscribe: () => void;
+  unsubscribe: IDisposable;
 }
 
 /** How many notices main keeps unread before the oldest go; each is one line about one turn. */
@@ -395,7 +395,7 @@ export function wireBrain(dependencies: BrainWiringDependencies): BrainWiring {
     // The generation's clock stands with the store, not with an agent, so a
     // store whose automatic reset is enabled sees the generation die on time
     // through a launch with no key or account, and after its agent was
-    // retired. Under the default policy of no automatic reset it arms nothing.
+    // disposed. Under the default policy of no automatic reset it arms nothing.
     const clock = new BrainGenerationClock({ store });
     void clock.start();
     const opened: OpenConversation = { host, store, clock, unsubscribe };
@@ -693,7 +693,7 @@ export function wireBrain(dependencies: BrainWiringDependencies): BrainWiring {
     // A conversation standing down is left to its close: a rebuild landing
     // while its drain is awaited would be the newer transition, and would
     // install a live agent on a host the close is about to drop from the
-    // directory, where nothing could ever retire it. The reopen that follows
+    // directory, where nothing could ever dispose it. The reopen that follows
     // the close builds on the model then standing.
     await Promise.all(
       [...conversations.entries()]
@@ -706,8 +706,8 @@ export function wireBrain(dependencies: BrainWiringDependencies): BrainWiring {
     if (model) await children.service.start();
   };
 
-  const retire = (): void => {
-    for (const opened of conversations.values()) opened.host.retire();
+  const dispose = (): void => {
+    for (const opened of conversations.values()) opened.host.dispose();
   };
 
   /**
@@ -873,15 +873,15 @@ export function wireBrain(dependencies: BrainWiringDependencies): BrainWiring {
     const opened = conversations.get(sessionKey);
     if (!opened) return Promise.resolve();
     const work = (async () => {
-      // The replacement with nothing awaits every retirement's drain, so the
+      // The replacement with nothing awaits every disposal's drain, so the
       // follower has written its last interruption before the store is let
       // go. The entry stays in the directory until then: an open that lands
       // meanwhile waits on this closing rather than building a second store
       // on the same envelope.
-      opened.host.retire();
+      opened.host.dispose();
       await opened.host.replace(() => undefined);
       opened.clock.stop();
-      opened.unsubscribe();
+      opened.unsubscribe.dispose();
       conversations.delete(sessionKey);
       latestRecords.delete(sessionKey);
       publications.delete(sessionKey);
@@ -932,7 +932,7 @@ export function wireBrain(dependencies: BrainWiringDependencies): BrainWiring {
     allRequests,
     busyConversations: () => [...latestRecords.keys()].filter(busy),
     rebuild,
-    retire,
+    dispose,
     openConversation: async (sessionKey) => {
       // The same wait an observed opening keeps: a conversation still
       // standing down is let go of before it is opened again, so the reopen
@@ -998,7 +998,7 @@ export function wireBrain(dependencies: BrainWiringDependencies): BrainWiring {
  * Turns one provider's batch of spool events into wakes. Every hook event
  * wakes the brain — the brain decides what matters, so nothing is filtered
  * here — and each wake carries the session as the registry holds it at that
- * moment, when it holds it at all: a hook can land for a session the poll has
+ * moment, when it holds it at all: a hook can land for a session the pass has
  * not yet seen, and the brain still hears that it moved.
  */
 export function wakeEventsFromHooks(

--- a/packages/host/src/compose-account.ts
+++ b/packages/host/src/compose-account.ts
@@ -40,7 +40,7 @@ export interface AccountLinks {
   onFirstSignIn: () => void;
   /** The arrival beat's own moment, recorded after the account event. */
   onFirstSignInArrival: () => void;
-  retireBrain: () => void;
+  disposeBrain: () => void;
   rebuildBrain: () => Promise<void>;
   syncMemory: () => void;
   /** The device row let go of on the departing account's own token, before the credential is cleared. */
@@ -159,7 +159,7 @@ export function composeAccount(dependencies: AccountDependencies): AccountCompos
 
   async function applyVoiceCredential(): Promise<void> {
     await transitionVoiceCredential({
-      retire: () => links.get().retireBrain(),
+      dispose: () => links.get().disposeBrain(),
       apply: () => voiceCapabilities.apply(),
       rebuild: async () => {
         await links.get().rebuildBrain();

--- a/packages/host/src/compose-brain.ts
+++ b/packages/host/src/compose-brain.ts
@@ -35,6 +35,7 @@ import {
 import { VOICE_SOURCE } from "@sidecar/settings";
 import {
   ACTION_RESULT_STATUS,
+  type IDisposable,
   isRecord,
   UNKNOWN_ACTION_STATUS,
   type WireRecord,
@@ -103,7 +104,7 @@ export function composeBrain(dependencies: BrainDependencies): BrainComposer {
   });
   const deliveries = new DeliveryLedger<GrantedWords>({ nextDeliveryId: createId });
   let appGuide: AppGuideSnapshot = EMPTY_APP_GUIDE;
-  let stopConversationMaintenance: (() => void) | undefined;
+  let conversationMaintenance: IDisposable | undefined;
 
   const memory: MemoryWiring = runMode.observesProviders
     ? composeNotebookMemory({
@@ -216,7 +217,7 @@ export function composeBrain(dependencies: BrainDependencies): BrainComposer {
     actions: {
       sessionActions: observation.sessionActions,
       sessions: observation.actableSessions,
-      refreshSessions: () => observation.loop.refresh(),
+      passSessions: () => observation.loop.pass(),
       workspaceProjects: observation.workspaceProjects,
       workspaceDefaults: observation.workspaceDefaults,
       trackedIssues: () => issues.issues(),
@@ -309,12 +310,12 @@ export function composeBrain(dependencies: BrainDependencies): BrainComposer {
       });
       await wiring.store().load();
       await store.restore();
-      stopConversationMaintenance = startConversationMaintenance({ store, brain: wiring });
+      conversationMaintenance = startConversationMaintenance({ store, brain: wiring });
     },
     stop: async () => {
-      stopConversationMaintenance?.();
-      stopConversationMaintenance = undefined;
-      wiring.retire();
+      conversationMaintenance?.dispose();
+      conversationMaintenance = undefined;
+      wiring.dispose();
       memory.stop();
       await store.close();
     },

--- a/packages/host/src/compose-calendars.ts
+++ b/packages/host/src/compose-calendars.ts
@@ -38,7 +38,7 @@ import type { OnboardingBeatKind } from "./voice/speech-arbiter.js";
 import { reporterOf } from "./wire-helpers.js";
 
 /** A diary changes at the pace of hands too; five minutes is current. */
-const CALENDAR_REFRESH_INTERVAL_MS = 5 * 60_000;
+const CALENDAR_PASS_INTERVAL_MS = 5 * 60_000;
 /**
  * How often held notices ask whether the meeting holding them has ended. The
  * question is answered from meetings already in memory, so asking often costs
@@ -54,7 +54,7 @@ const HELD_NOTICE_RELEASE_INTERVAL_MS = 30_000;
  * process can be trusted about where the switch stands now. Ten seconds is
  * the longest consent taken back keeps holding anything.
  */
-const APPLE_ACCESS_POLL_INTERVAL_MS = 10_000;
+const APPLE_ACCESS_PASS_INTERVAL_MS = 10_000;
 
 /** What the calendars reach in the speech the meetings hold. */
 export interface CalendarsLinks {
@@ -127,7 +127,7 @@ export function composeCalendars(dependencies: CalendarsDependencies): Calendars
   let quietBoundaryTimer: NodeJS.Timeout | undefined;
   let observedCalendars: readonly ObservedAccountCalendars[] = [];
   let heldNoticeReleaseTimer: NodeJS.Timeout | undefined;
-  let appleAccessPollTimer: NodeJS.Timeout | undefined;
+  let appleAccessPassTimer: NodeJS.Timeout | undefined;
   let appleAccessProbeFailing = false;
   let announcementsHeld = false;
   let appleConnectGeneration = 0;
@@ -210,11 +210,11 @@ export function composeCalendars(dependencies: CalendarsDependencies): Calendars
     quietBoundaryTimer.unref();
   }
 
-  async function refreshCalendarMeetings(generation: number): Promise<void> {
+  async function passCalendarMeetings(generation: number): Promise<void> {
     try {
       const [observations, appleObservation] = await Promise.all([
-        googleCalendar.observe(),
-        appleCalendar.observe(),
+        googleCalendar.pass(),
+        appleCalendar.pass(),
       ]);
       if (!loop.isCurrent(generation)) return;
       const accounts = [...(observations ?? []), ...(appleObservation ? [appleObservation] : [])];
@@ -244,11 +244,11 @@ export function composeCalendars(dependencies: CalendarsDependencies): Calendars
 
   const loop = new ObservationLoop({
     gate: observationGate,
-    intervalMs: CALENDAR_REFRESH_INTERVAL_MS,
-    run: refreshCalendarMeetings,
+    intervalMs: CALENDAR_PASS_INTERVAL_MS,
+    run: passCalendarMeetings,
   });
 
-  async function pollAppleCalendarAccess(): Promise<void> {
+  async function passAppleCalendarAccess(): Promise<void> {
     if (!(await settingsStore.readAppleCalendarConnection())) return;
     let access: string | undefined;
     try {
@@ -267,7 +267,7 @@ export function composeCalendars(dependencies: CalendarsDependencies): Calendars
     const probeRevoked = access !== APPLE_CALENDAR_ACCESS.FULL;
     if (probeRevoked !== drawnRevoked) {
       report(`Calendar access now reads ${access}; running a pass.`);
-      void loop.refresh();
+      void loop.pass();
     }
   }
 
@@ -278,18 +278,18 @@ export function composeCalendars(dependencies: CalendarsDependencies): Calendars
     }, HELD_NOTICE_RELEASE_INTERVAL_MS);
     heldNoticeReleaseTimer.unref();
     if (process.platform === "darwin" && runMode.observesProviders) {
-      appleAccessPollTimer = setInterval(() => {
-        void pollAppleCalendarAccess();
-      }, APPLE_ACCESS_POLL_INTERVAL_MS);
-      appleAccessPollTimer.unref();
+      appleAccessPassTimer = setInterval(() => {
+        void passAppleCalendarAccess();
+      }, APPLE_ACCESS_PASS_INTERVAL_MS);
+      appleAccessPassTimer.unref();
     }
   }
 
   function stopObservation(): void {
     if (heldNoticeReleaseTimer) clearInterval(heldNoticeReleaseTimer);
     heldNoticeReleaseTimer = undefined;
-    if (appleAccessPollTimer) clearInterval(appleAccessPollTimer);
-    appleAccessPollTimer = undefined;
+    if (appleAccessPassTimer) clearInterval(appleAccessPassTimer);
+    appleAccessPassTimer = undefined;
     appleAccessProbeFailing = false;
     if (quietBoundaryTimer) clearTimeout(quietBoundaryTimer);
     quietBoundaryTimer = undefined;
@@ -322,7 +322,7 @@ export function composeCalendars(dependencies: CalendarsDependencies): Calendars
         },
         (saved) => {
           if (saved.reason) return;
-          void loop.refresh();
+          void loop.pass();
           settings.recordProductEvent(PRODUCT_EVENT.CALENDAR_CONNECT, {
             calendar_source: PRODUCT_CALENDAR_SOURCE.GOOGLE,
           });
@@ -347,7 +347,7 @@ export function composeCalendars(dependencies: CalendarsDependencies): Calendars
         () => settingsStore.removeCalendarAccount(accountId),
         (saved) => {
           if (saved.reason) return;
-          void loop.refresh();
+          void loop.pass();
           settings.recordProductEvent(PRODUCT_EVENT.CALENDAR_DISCONNECT, {
             calendar_source: PRODUCT_CALENDAR_SOURCE.GOOGLE,
           });
@@ -388,7 +388,7 @@ export function composeCalendars(dependencies: CalendarsDependencies): Calendars
         },
         (saved) => {
           if (saved.reason) return;
-          void loop.refresh();
+          void loop.pass();
           if (stored) {
             settings.recordProductEvent(PRODUCT_EVENT.CALENDAR_CONNECT, {
               calendar_source: PRODUCT_CALENDAR_SOURCE.APPLE,
@@ -405,7 +405,7 @@ export function composeCalendars(dependencies: CalendarsDependencies): Calendars
         () => settingsStore.disconnectAppleCalendar(),
         (saved) => {
           if (saved.reason) return;
-          void loop.refresh();
+          void loop.pass();
           settings.recordProductEvent(PRODUCT_EVENT.CALENDAR_DISCONNECT, {
             calendar_source: PRODUCT_CALENDAR_SOURCE.APPLE,
           });
@@ -427,7 +427,7 @@ export function composeCalendars(dependencies: CalendarsDependencies): Calendars
       return gatewayOk({});
     },
     [GATEWAY_METHOD.CALENDAR_REFRESH]: async () => {
-      await loop.refresh();
+      await loop.pass();
       return gatewayOk({});
     },
     [GATEWAY_METHOD.CALENDAR_SET_SELECTED]: async (params) => {
@@ -454,7 +454,7 @@ export function composeCalendars(dependencies: CalendarsDependencies): Calendars
         () => settingsStore.setCalendarSelected(accountId, calendarId, selected),
         (saved) => {
           if (saved.reason) return;
-          void loop.refresh();
+          void loop.pass();
           settings.recordProductEvent(PRODUCT_EVENT.SETTING_UPDATE, {
             setting_id: APP_SETTING_ID.CALENDAR_SELECTED,
             setting_value: selected ? PRODUCT_SETTING_VALUE.ON : PRODUCT_SETTING_VALUE.OFF,

--- a/packages/host/src/compose-host.ts
+++ b/packages/host/src/compose-host.ts
@@ -1,13 +1,13 @@
 import { BRAIN_REQUEST_STATUS } from "@sidecar/brain/requests";
 import {
   carried,
+  disposeGateway,
   GATEWAY_METHOD,
+  type GatewayDisposeOptions,
+  type GatewayDisposeSteps,
   type GatewayMethodTable,
   type GatewayServer,
-  type GatewayShutdownOptions,
-  type GatewayShutdownSteps,
   gatewayOk,
-  shutdownGateway,
 } from "@sidecar/gateway";
 import { ARRIVAL_SPEECH_KIND, CALENDAR_ONBOARDING_SPEECH_KIND } from "@sidecar/realtime";
 import { ObservationSupervisor } from "@sidecar/runtime";
@@ -28,7 +28,7 @@ import { composeSettings } from "./compose-settings.js";
 import { composeSpeech } from "./compose-speech.js";
 import { type Composer, mergeMethods } from "./composer.js";
 import { createHostKernel, type HostSeams } from "./host-kernel.js";
-import { shutdownStepsFlushingEvents } from "./lifecycle.js";
+import { disposeStepsFlushingEvents } from "./lifecycle.js";
 import { createGatewayService } from "./service.js";
 
 /**
@@ -47,13 +47,13 @@ export interface Host {
   /**
    * The whole quit, in the coordinator's fixed order: admissions closed,
    * everything under way cancelled, a bounded wait for it to settle,
-   * whatever did not settle written down as unresolved for the next launch's
+   * whatever did not settle written down as unsettled for the next launch's
    * recovery, and only then the store closed. A caller that ran the steps
    * itself would be a second order for the same quit, so there is none to
    * run: what became of it is reported, never answered, because nothing a
    * client could do with the answer is left to do.
    */
-  stop: (options?: GatewayShutdownOptions) => Promise<void>;
+  stop: (options?: GatewayDisposeOptions) => Promise<void>;
 }
 
 export function composeHost(options: HostSeams): Host {
@@ -81,12 +81,12 @@ export function composeHost(options: HostSeams): Host {
     setVoice: (voice) => account.voiceCapabilities.realtimeCredentials?.setVoice(voice),
     setVoiceSpeed: (speed) => account.voiceCapabilities.realtimeCredentials?.setSpeed(speed),
     reconcileSpeech: () => void speech.reconcileSpeech(),
-    refreshSupersetWorkspaceHost: async () => {
+    passSupersetWorkspaceHost: async () => {
       await observation.readSupersetWorkspaceHost();
     },
     broadcastWorkspaceProjects: observation.broadcastWorkspaceProjects,
     refreshCredentialAdapter: observation.refreshCredentialAdapter,
-    refreshIssues: issues.refresh,
+    passIssues: issues.pass,
     workspaceProjectOffered: observation.workspaceProjectOffered,
   });
   account.link({
@@ -94,7 +94,7 @@ export function composeHost(options: HostSeams): Host {
     stopCapabilities: stopAccountCapabilities,
     onFirstSignIn: calendars.recordFirstSignIn,
     onFirstSignInArrival: speech.seedArrivalOnFirstSignIn,
-    retireBrain: () => brain.wiring.retire(),
+    disposeBrain: () => brain.wiring.dispose(),
     rebuildBrain: () => brain.wiring.rebuild(),
     syncMemory: brain.syncMemory,
     releaseDevice: (stored) => devices.release(stored),
@@ -270,7 +270,7 @@ export function composeHost(options: HostSeams): Host {
    * counted rather than finished: the store's load at the next start marks
    * an unsettled run interrupted and replays nothing.
    */
-  const shutdownSteps: GatewayShutdownSteps = shutdownStepsFlushingEvents(
+  const disposeSteps: GatewayDisposeSteps = disposeStepsFlushingEvents(
     {
       closeAdmissions: () => service.server.closeAdmissions(),
       cancelActive: async () => {
@@ -298,27 +298,27 @@ export function composeHost(options: HostSeams): Host {
         if (signal.aborted) return;
         await brain.wiring.publicationSettled();
       },
-      persistUnresolved: async () => {
+      persistUnsettled: async () => {
         // What the next launch will find: the records as the stores last
         // persisted them, read from the envelopes rather than from memory. A
         // cancellation whose write did not land leaves its run queued or
         // running on disk, and that is what the load marks interrupted and
-        // never replays, so it is counted here as unresolved.
+        // never replays, so it is counted here as unsettled.
         const keys = new Set<SessionKey>([
           MAIN_SESSION_KEY,
           ...brain.store.directory().map((entry) => entry.sessionKey),
         ]);
-        let unresolved = 0;
+        let unsettled = 0;
         for (const key of keys) {
           const persisted = brain.wiring.store(key).current();
           if (!persisted) continue;
-          unresolved += persisted.requests.filter(
+          unsettled += persisted.requests.filter(
             (record) =>
               record.status === BRAIN_REQUEST_STATUS.QUEUED ||
               record.status === BRAIN_REQUEST_STATUS.RUNNING,
           ).length;
         }
-        return unresolved;
+        return unsettled;
       },
     },
     () => settings.flushProductEvents(),
@@ -335,14 +335,14 @@ export function composeHost(options: HostSeams): Host {
     }
   };
 
-  const stop = async (shutdown: GatewayShutdownOptions = {}): Promise<void> => {
+  const stop = async (dispose: GatewayDisposeOptions = {}): Promise<void> => {
     // A drain that cannot finish still says so and still closes the store:
     // what it could not settle is what the next launch marks interrupted, and
     // a quit must leave either way rather than on an unhandled failure.
     try {
-      const outcome = await shutdownGateway(shutdownSteps, shutdown);
+      const outcome = await disposeGateway(disposeSteps, dispose);
       report(
-        `shutting down: ${outcome.settled ? "settled" : "unsettled"}, ${outcome.cancelled.length} cancelled, ${outcome.unresolved} unresolved`,
+        `disposing: ${outcome.settled ? "settled" : "not settled"}, ${outcome.cancelled.length} cancelled, ${outcome.unsettled} left for recovery`,
       );
     } catch (error) {
       report(`the drain did not finish: ${error instanceof Error ? error.message : String(error)}`);

--- a/packages/host/src/compose-issues.ts
+++ b/packages/host/src/compose-issues.ts
@@ -13,14 +13,14 @@ import type { Composer, ComposerContext } from "./composer.js";
 import { reporterOf } from "./wire-helpers.js";
 
 /** A board changes at the pace of hands, not of models; a minute is current. */
-const ISSUE_REFRESH_INTERVAL_MS = 60_000;
+const ISSUE_PASS_INTERVAL_MS = 60_000;
 
 export interface IssuesComposer extends Composer {
   /** The loop the merge's supervisor enables; the composer never enables it itself. */
   readonly loop: ObservationLoop;
   readonly trackers: readonly LinearIssueTracker[];
   issues: () => readonly TrackedIssue[] | undefined;
-  refresh: () => void;
+  pass: () => void;
   /** What the account's capability gate takes back: the board a signed-out Luke may not draw. */
   stopObservation: () => void;
 }
@@ -55,7 +55,7 @@ export function composeIssues(dependencies: IssuesDependencies): IssuesComposer 
   const issueTrackers = [linearTracker] as const;
   let trackedIssues: readonly TrackedIssue[] | undefined;
 
-  async function refreshTrackedIssues(generation: number): Promise<void> {
+  async function passTrackedIssues(generation: number): Promise<void> {
     try {
       const collected: TrackedIssue[] = [];
       let connected = false;
@@ -82,8 +82,8 @@ export function composeIssues(dependencies: IssuesDependencies): IssuesComposer 
 
   const loop = new ObservationLoop({
     gate: observationGate,
-    intervalMs: ISSUE_REFRESH_INTERVAL_MS,
-    run: refreshTrackedIssues,
+    intervalMs: ISSUE_PASS_INTERVAL_MS,
+    run: passTrackedIssues,
   });
 
   const methods: GatewayMethodTable = {
@@ -96,7 +96,7 @@ export function composeIssues(dependencies: IssuesDependencies): IssuesComposer 
         },
         (saved) => {
           if (saved.reason) return;
-          void loop.refresh();
+          void loop.pass();
           settings.recordProductEvent(PRODUCT_EVENT.TRACKER_CONNECT, {
             tracker_id: ISSUE_TRACKER_ID.LINEAR,
           });
@@ -125,7 +125,7 @@ export function composeIssues(dependencies: IssuesDependencies): IssuesComposer 
         },
         (saved) => {
           if (saved.reason) return;
-          void loop.refresh();
+          void loop.pass();
           settings.recordProductEvent(PRODUCT_EVENT.TRACKER_DISCONNECT, {
             tracker_id: ISSUE_TRACKER_ID.LINEAR,
           });
@@ -142,7 +142,7 @@ export function composeIssues(dependencies: IssuesDependencies): IssuesComposer 
     loop,
     trackers: issueTrackers,
     issues: () => trackedIssues,
-    refresh: () => void loop.refresh(),
+    pass: () => void loop.pass(),
     stopObservation,
     // The loop is armed by the merge's supervisor, so there is nothing of its own to begin.
     start: async () => undefined,

--- a/packages/host/src/compose-observation.ts
+++ b/packages/host/src/compose-observation.ts
@@ -60,6 +60,7 @@ import {
 import { APP_SETTING_SCHEMA } from "@sidecar/settings";
 import {
   ACTION_RESULT_STATUS,
+  type IDisposable,
   isRecord,
   isWireString,
   lateRef,
@@ -79,7 +80,7 @@ import {
 } from "./session-action-performer.js";
 import { createSessionRowActions } from "./session-row-actions.js";
 
-const SESSION_REFRESH_INTERVAL_MS = 60_000;
+const SESSION_PASS_INTERVAL_MS = 60_000;
 
 const DIAGNOSTIC_COUNTED_AS = {
   [ADAPTER_DIAGNOSTIC_KIND.PASS_FAILURE]: PRODUCT_DIAGNOSTIC_KIND.PASS_FAILURE,
@@ -194,7 +195,7 @@ export function composeObservation(dependencies: ObservationDependencies): Obser
 
   let spoolWatchers: readonly ObservationSpoolWatcher[] = [];
   const createdWorkspaceOpens = new CreatedWorkspaceOpenTracker();
-  let unsubscribeSessions: (() => void) | undefined;
+  let sessionsSubscription: IDisposable | undefined;
   let lastWorkspaceProjects: string | undefined;
   let workspaceProjectsBroadcastGeneration = 0;
   let rosterBroadcast = false;
@@ -206,7 +207,7 @@ export function composeObservation(dependencies: ObservationDependencies): Obser
     onChange: (state) => {
       kernel.emit(GATEWAY_EVENT.SUPERSET_SIGN_IN_CHANGED, carried(state));
       if (state.stage !== SUPERSET_SIGN_IN_STAGE.CONNECTED) return;
-      void loop.refresh();
+      void loop.pass();
       settings.recordProductEvent(PRODUCT_EVENT.SUPERSET_ACTION, {
         superset_action: PRODUCT_SUPERSET_ACTION.SIGN_IN_COMPLETE,
       });
@@ -399,7 +400,7 @@ export function composeObservation(dependencies: ObservationDependencies): Obser
     openCreatedWorkspaces: () => openCreatedWorkspaces(sessionRegistry.list()),
     trackedIssues: () => issues.issues(),
     issueTrackers: issues.trackers,
-    refreshIssues: () => issues.refresh(),
+    passIssues: () => issues.pass(),
     supersetContext: (identity) =>
       superset.actableContext(identity.providerId, identity.providerSessionId),
     supersetCli,
@@ -413,7 +414,7 @@ export function composeObservation(dependencies: ObservationDependencies): Obser
   const rowActions = createSessionRowActions({
     roster: {
       read: async () => {
-        await loop.refresh();
+        await loop.pass();
         return actableSessions();
       },
     },
@@ -447,7 +448,7 @@ export function composeObservation(dependencies: ObservationDependencies): Obser
           events: observationSpool.events,
           onEvents: (events) => {
             void (async () => {
-              await loop.refresh().catch(() => undefined);
+              await loop.pass().catch(() => undefined);
               links.get().wake(wakeEventsFromHooks(providerId, events, sessionRegistry, now()));
             })();
           },
@@ -461,7 +462,7 @@ export function composeObservation(dependencies: ObservationDependencies): Obser
       const agentDefault = (
         await settingsStore.get(APP_SETTING_SCHEMA.workspaceAgentDefaults.field)
       )?.[SUPERSET_WORKSPACE_PROVIDER_ID]?.agent;
-      return await superset.refresh(agentDefault);
+      return await superset.pass(agentDefault);
     } catch (error) {
       report(
         `Superset observation failed: ${error instanceof Error ? error.message : String(error)}`,
@@ -470,9 +471,9 @@ export function composeObservation(dependencies: ObservationDependencies): Obser
     }
   }
 
-  async function refreshProviderSessions(generation: number): Promise<void> {
+  async function passProviderSessions(generation: number): Promise<void> {
     const actionsWereEnabled = superset.activeOrganization() !== undefined;
-    const conductorRepositoriesPromise = conductorLocalWorkspaces.refresh().catch((error) => {
+    const conductorRepositoriesPromise = conductorLocalWorkspaces.pass().catch((error) => {
       report(
         `Conductor repository observation failed: ${error instanceof Error ? error.message : String(error)}`,
       );
@@ -502,7 +503,7 @@ export function composeObservation(dependencies: ObservationDependencies): Obser
     await Promise.all([
       ...orderedRegistrations.map(async ({ plugin }) => {
         try {
-          await sessionRegistry.refresh(plugin, (providerId, observations) =>
+          await sessionRegistry.pass(plugin, (providerId, observations) =>
             hostEnrichments.reduce(
               (enriched, enrichment) => enrichment(providerId, enriched),
               observations,
@@ -516,7 +517,7 @@ export function composeObservation(dependencies: ObservationDependencies): Obser
       }),
       (async () => {
         try {
-          await sessionRegistry.refresh(superset);
+          await sessionRegistry.pass(superset);
         } catch (error) {
           report(
             `Session observation failed (${superset.provider.id}): ${error instanceof Error ? error.message : String(error)}`,
@@ -530,8 +531,8 @@ export function composeObservation(dependencies: ObservationDependencies): Obser
 
   const loop = new ObservationLoop({
     gate: observationGate,
-    intervalMs: SESSION_REFRESH_INTERVAL_MS,
-    run: refreshProviderSessions,
+    intervalMs: SESSION_PASS_INTERVAL_MS,
+    run: passProviderSessions,
     afterRun: () => {
       links.get().rosterLook();
     },
@@ -573,8 +574,8 @@ export function composeObservation(dependencies: ObservationDependencies): Obser
   }
 
   function startObservation(): void {
-    if (!runMode.observesProviders || !account.capabilitiesActive() || unsubscribeSessions) return;
-    unsubscribeSessions = sessionRegistry.subscribe((sessions) => {
+    if (!runMode.observesProviders || !account.capabilitiesActive() || sessionsSubscription) return;
+    sessionsSubscription = sessionRegistry.subscribe((sessions) => {
       broadcastSessions(sessions);
       openCreatedWorkspaces(sessions);
       void broadcastWorkspaceProjects();
@@ -584,8 +585,8 @@ export function composeObservation(dependencies: ObservationDependencies): Obser
 
   function stopObservation(): void {
     workspaceProjectsBroadcastGeneration += 1;
-    unsubscribeSessions?.();
-    unsubscribeSessions = undefined;
+    sessionsSubscription?.dispose();
+    sessionsSubscription = undefined;
     for (const { plugin } of orderedRegistrations) {
       sessionRegistry.replaceProvider(plugin.provider, []);
     }
@@ -690,7 +691,7 @@ export function composeObservation(dependencies: ObservationDependencies): Obser
         });
       }
       supersetSignIn.cancel();
-      void loop.refresh();
+      void loop.pass();
       settings.recordProductEvent(PRODUCT_EVENT.SUPERSET_ACTION, {
         superset_action: PRODUCT_SUPERSET_ACTION.DISCONNECT,
       });
@@ -714,7 +715,7 @@ export function composeObservation(dependencies: ObservationDependencies): Obser
     readSupersetWorkspaceHost,
     refreshCredentialAdapter: (providerId) => {
       const plugin = pluginForCredential(providerId);
-      if (plugin) void sessionRegistry.refresh(plugin);
+      if (plugin) void sessionRegistry.pass(plugin);
     },
     actableSessions,
     roster: () => {
@@ -743,11 +744,11 @@ export function composeObservation(dependencies: ObservationDependencies): Obser
       });
     },
     stop: async () => {
-      unsubscribeSessions?.();
-      unsubscribeSessions = undefined;
+      sessionsSubscription?.dispose();
+      sessionsSubscription = undefined;
       for (const watcher of spoolWatchers) watcher.close();
       spoolWatchers = [];
-      supersetSignIn.shutdown();
+      supersetSignIn.dispose();
     },
   };
 }

--- a/packages/host/src/compose-settings.ts
+++ b/packages/host/src/compose-settings.ts
@@ -59,11 +59,11 @@ export interface SettingsLinks {
   setVoice: (voice: StoredSettings["voice"]) => void;
   setVoiceSpeed: (speed: StoredSettings["voiceSpeed"]) => void;
   reconcileSpeech: () => void;
-  refreshSupersetWorkspaceHost: () => Promise<void>;
+  passSupersetWorkspaceHost: () => Promise<void>;
   broadcastWorkspaceProjects: () => Promise<void>;
   /** One provider's sessions read again after its key changed. */
   refreshCredentialAdapter: (providerId: CredentialProviderId) => void;
-  refreshIssues: () => void;
+  passIssues: () => void;
   workspaceProjectOffered: (providerId: string, providerProjectId: string) => boolean;
 }
 
@@ -328,7 +328,7 @@ export function composeSettings(dependencies: SettingsDependencies): SettingsCom
       APP_SETTING_SCHEMA.workspaceAgentDefaults.field,
     );
     if (workspaceAgentDefaultsChanged) {
-      await links.get().refreshSupersetWorkspaceHost();
+      await links.get().passSupersetWorkspaceHost();
     }
     if (
       workspaceAgentDefaultsChanged ||
@@ -451,7 +451,7 @@ export function composeSettings(dependencies: SettingsDependencies): SettingsCom
         async (saved) => {
           if (saved.reason) return;
           links.get().refreshCredentialAdapter(providerId);
-          if (providerId === CREDENTIAL_PROVIDER_ID.LINEAR) links.get().refreshIssues();
+          if (providerId === CREDENTIAL_PROVIDER_ID.LINEAR) links.get().passIssues();
           if (providerId === VOICE_CREDENTIAL_PROVIDER_ID) {
             await links.get().applyVoiceCredential();
             await emitSettings();

--- a/packages/host/src/compose-speech.ts
+++ b/packages/host/src/compose-speech.ts
@@ -144,7 +144,7 @@ export function composeSpeech(dependencies: SpeechDependencies): SpeechComposer 
       return;
     }
     if (!arrivalBeatOwed(calendars.onboarding())) return;
-    await observation.loop.refresh().catch(() => undefined);
+    await observation.loop.pass().catch(() => undefined);
     if (!account.signedIn() || !arrivalBeatOwed(calendars.onboarding())) return;
     arbiter.request({ kind: ARRIVAL_SPEECH_KIND });
     void reconcileSpeech();

--- a/packages/host/src/conversation-operations.test.ts
+++ b/packages/host/src/conversation-operations.test.ts
@@ -72,7 +72,7 @@ function harness(erasePublished = true, { marks = true, readsCutoff = true } = {
   return { operations: conversationOperations(dependencies), calls };
 }
 
-test("Delete conversation fences the thread and the brain's generation, then erases what stood at or before the press while the successor lifetime stands; nothing is retired or reopened", async () => {
+test("Delete conversation fences the thread and the brain's generation, then erases what stood at or before the press while the successor lifetime stands; nothing is disposed or reopened", async () => {
   const { operations, calls } = harness();
   assert.equal(await operations.deleteConversation(THREAD), CONVERSATION_DELETE_OUTCOME.COMPLETE);
   assert.deepEqual(calls, [
@@ -111,9 +111,9 @@ test("a cutoff the store cannot read refuses the deletion after the marker, with
   assert.ok(calls.some((call) => call.includes("earlier cutoff could not be read")));
 });
 
-test("maintenance runs at the launch, preserving the busy conversations, and stops with its clock", () => {
+test("maintenance runs at the launch, preserving the busy conversations, and ends with its clock", () => {
   const runs: (readonly SessionKey[])[] = [];
-  const stop = startConversationMaintenance({
+  const maintenance = startConversationMaintenance({
     store: {
       runMaintenance: async (preserve) => {
         runs.push(preserve);
@@ -123,5 +123,5 @@ test("maintenance runs at the launch, preserving the busy conversations, and sto
     brain: { busyConversations: () => [THREAD] },
   });
   assert.deepEqual(runs, [[THREAD]]);
-  stop();
+  maintenance.dispose();
 });

--- a/packages/host/src/conversation-operations.ts
+++ b/packages/host/src/conversation-operations.ts
@@ -1,5 +1,6 @@
 import type { ConversationRecord, SessionKey } from "@sidecar/runtime/vocabulary";
 import type { ConversationEntry } from "@sidecar/session";
+import { type IDisposable, toDisposable } from "@sidecar/wire";
 import {
   type ConversationDeleteOutcome,
   deleteConversationFlow,
@@ -69,13 +70,14 @@ export interface ConversationMaintenanceDependencies {
 /**
  * Maintenance runs at every live launch — interrupted archive publications
  * retried first — and then on its own hourly clock, keeping the
- * conversations with a run under way whatever their age. Answers the stop.
+ * conversations with a run under way whatever their age. Answers the hourly
+ * clock's own disposable.
  */
 export function startConversationMaintenance(
   dependencies: ConversationMaintenanceDependencies,
-): () => void {
+): IDisposable {
   const run = () => void dependencies.store.runMaintenance(dependencies.brain.busyConversations());
   run();
   const timer = setInterval(run, CONVERSATION_MAINTENANCE_INTERVAL_MS).unref();
-  return () => clearInterval(timer);
+  return toDisposable(() => clearInterval(timer));
 }

--- a/packages/host/src/lifecycle.test.ts
+++ b/packages/host/src/lifecycle.test.ts
@@ -1,8 +1,8 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { GATEWAY_SHUTDOWN_DEFAULTS, shutdownGateway } from "@sidecar/gateway";
+import { disposeGateway, GATEWAY_DISPOSE_DEFAULTS } from "@sidecar/gateway";
 import { drainMicrotasks } from "@sidecar/runtime/testing";
-import { seedWorkspaceThenStartMemory, shutdownStepsFlushingEvents } from "./lifecycle.js";
+import { disposeStepsFlushingEvents, seedWorkspaceThenStartMemory } from "./lifecycle.js";
 
 test("a workspace seed that fails is reported and the memory index still starts, after the seed and not before", async () => {
   const order: string[] = [];
@@ -51,17 +51,17 @@ function baseSteps(order: string[]) {
     awaitSettled: async () => {
       order.push("settled");
     },
-    persistUnresolved: async () => {
+    persistUnsettled: async () => {
       order.push("persist");
       return 0;
     },
   };
 }
 
-test("the flush begins as admissions close and is waited for before the unresolved count, so the install's count leaves with the drain", async () => {
+test("the flush begins as admissions close and is waited for before the unsettled count, so the install's count leaves with the drain", async () => {
   const order: string[] = [];
   let settleFlush: (() => void) | undefined;
-  const steps = shutdownStepsFlushingEvents(baseSteps(order), () => {
+  const steps = disposeStepsFlushingEvents(baseSteps(order), () => {
     order.push("flush:start");
     return new Promise<void>((resolve) => {
       settleFlush = () => {
@@ -70,7 +70,7 @@ test("the flush begins as admissions close and is waited for before the unresolv
       };
     });
   });
-  const report = shutdownGateway(steps, { deadlineMs: GATEWAY_SHUTDOWN_DEFAULTS.DEADLINE_MS });
+  const report = disposeGateway(steps, { deadlineMs: GATEWAY_DISPOSE_DEFAULTS.DEADLINE_MS });
   await drainMicrotasks(1);
   assert.deepEqual(order, ["close", "flush:start", "cancel", "settled"]);
   settleFlush?.();
@@ -80,26 +80,26 @@ test("the flush begins as admissions close and is waited for before the unresolv
   assert.deepEqual(outcome.cancelled, ["run-1"]);
 });
 
-test("a flush that never answers ends the shutdown at the deadline with the runs' own outcome intact", async () => {
+test("a flush that never answers ends the dispose at the deadline with the runs' own outcome intact", async () => {
   const order: string[] = [];
-  const steps = shutdownStepsFlushingEvents(
+  const steps = disposeStepsFlushingEvents(
     baseSteps(order),
     () => new Promise<void>(() => undefined),
   );
-  const outcome = await shutdownGateway(steps, { deadlineMs: 20 });
+  const outcome = await disposeGateway(steps, { deadlineMs: 20 });
   assert.equal(outcome.settled, false);
   assert.deepEqual(outcome.cancelled, ["run-1"]);
-  assert.equal(outcome.unresolved, 0);
+  assert.equal(outcome.unsettled, 0);
   assert.ok(order.includes("persist"));
 });
 
 test("a flush that rejects is a count nobody has, not a failed quit", async () => {
   const order: string[] = [];
-  const steps = shutdownStepsFlushingEvents(baseSteps(order), () =>
+  const steps = disposeStepsFlushingEvents(baseSteps(order), () =>
     Promise.reject(new Error("offline")),
   );
-  const outcome = await shutdownGateway(steps, {
-    deadlineMs: GATEWAY_SHUTDOWN_DEFAULTS.DEADLINE_MS,
+  const outcome = await disposeGateway(steps, {
+    deadlineMs: GATEWAY_DISPOSE_DEFAULTS.DEADLINE_MS,
   });
   assert.equal(outcome.settled, true);
   assert.deepEqual(order, ["close", "cancel", "settled", "persist"]);
@@ -107,7 +107,7 @@ test("a flush that rejects is a count nobody has, not a failed quit", async () =
 
 test("closing admissions twice flushes once", () => {
   let flushes = 0;
-  const steps = shutdownStepsFlushingEvents(baseSteps([]), async () => {
+  const steps = disposeStepsFlushingEvents(baseSteps([]), async () => {
     flushes += 1;
   });
   steps.closeAdmissions();

--- a/packages/host/src/lifecycle.ts
+++ b/packages/host/src/lifecycle.ts
@@ -1,4 +1,4 @@
-import type { GatewayShutdownSteps } from "@sidecar/gateway";
+import type { GatewayDisposeSteps } from "@sidecar/gateway";
 
 /**
  * Two moments of the runtime host's life where one concern must not decide
@@ -42,10 +42,10 @@ export async function seedWorkspaceThenStartMemory(options: StartupStoreOptions)
  * The sender's own flush never rejects; the guard here is for the shape, not
  * a case it has.
  */
-export function shutdownStepsFlushingEvents(
-  steps: GatewayShutdownSteps,
+export function disposeStepsFlushingEvents(
+  steps: GatewayDisposeSteps,
   flushEvents: () => Promise<void>,
-): GatewayShutdownSteps {
+): GatewayDisposeSteps {
   let flushing: Promise<void> | undefined;
   return {
     closeAdmissions: () => {
@@ -56,6 +56,6 @@ export function shutdownStepsFlushingEvents(
     awaitSettled: async (signal) => {
       await Promise.all([steps.awaitSettled(signal), flushing ?? Promise.resolve()]);
     },
-    persistUnresolved: steps.persistUnresolved,
+    persistUnsettled: steps.persistUnsettled,
   };
 }

--- a/packages/host/src/operator.ts
+++ b/packages/host/src/operator.ts
@@ -12,7 +12,14 @@ import {
 import type { GatewayCallResult, GatewayClient } from "@sidecar/gateway";
 import { GATEWAY_EVENT, GATEWAY_METHOD, gatewayEventReader } from "@sidecar/gateway";
 import { MAIN_SESSION_KEY, type SessionKey } from "@sidecar/runtime/vocabulary";
-import { isRecord, isWireBoolean, isWireNumber, isWireString, type WireValue } from "@sidecar/wire";
+import {
+  type IDisposable,
+  isRecord,
+  isWireBoolean,
+  isWireNumber,
+  isWireString,
+  type WireValue,
+} from "@sidecar/wire";
 import { CONVERSATION_DELETE_OUTCOME } from "./brain/conversation-deletion.js";
 import { REJECTED_SUBMISSION } from "./brain/publication.js";
 
@@ -37,10 +44,10 @@ export interface GatewayOperator {
   acknowledge: (runId: string, deliveryId: string, epoch: number) => Promise<boolean>;
   /** Delete conversation on a conversation: answers whether the erasure completed or was interrupted, false only when refused. */
   deleteConversation: (sessionKey?: SessionKey) => Promise<boolean>;
-  onRunsChanged: (listener: (runs: readonly BrainRequestSnapshot[]) => void) => () => void;
-  onDeliveryOffered: (listener: (offer: BrainReplyOffer) => void) => () => void;
-  onDeliveriesWithdrawn: (listener: (epoch: number) => void) => () => void;
-  onConversationChanged: (listener: (change: GatewayConversationChange) => void) => () => void;
+  onRunsChanged: (listener: (runs: readonly BrainRequestSnapshot[]) => void) => IDisposable;
+  onDeliveryOffered: (listener: (offer: BrainReplyOffer) => void) => IDisposable;
+  onDeliveriesWithdrawn: (listener: (epoch: number) => void) => IDisposable;
+  onConversationChanged: (listener: (change: GatewayConversationChange) => void) => IDisposable;
   /** The underlying client, for the calls the typed surface above does not name. */
   readonly client: GatewayClient;
 }

--- a/packages/host/src/service.test.ts
+++ b/packages/host/src/service.test.ts
@@ -169,7 +169,7 @@ function fixture(transportKind: "in-process" | "loopback" = "in-process") {
     deleted,
     events,
     generation,
-    retireBrain: () => {
+    disposeBrain: () => {
       brainStands = false;
     },
     /** The followers' report of every record, as the wiring's broadcast hands it on. */
@@ -303,9 +303,9 @@ for (const kind of ["in-process", "loopback"] as const) {
     f.receiver.markReady(epoch);
     f.end("run-1");
     assert.equal(deliveryState(f.deliveries, "run-1"), DELIVERY_STATE.OFFERED);
-    // The credential changes: the generation is replaced and the brain retired.
+    // The credential changes: the generation is replaced and the brain disposed.
     f.generation.id = "gen-2";
-    f.retireBrain();
+    f.disposeBrain();
     f.service.generationReplaced(MAIN_SESSION_KEY);
     assert.deepEqual(withdrawn, [epoch]);
     assert.equal(deliveryState(f.deliveries, "run-1"), undefined);

--- a/packages/host/src/session-action-performer.test.ts
+++ b/packages/host/src/session-action-performer.test.ts
@@ -111,7 +111,7 @@ function deeperPerformer(
     openCreatedWorkspaces: () => {},
     trackedIssues: () => undefined,
     issueTrackers: [],
-    refreshIssues: () => {},
+    passIssues: () => {},
     supersetContext: () => undefined,
     supersetCli: {
       sendMessage: unreachable,

--- a/packages/host/src/session-action-performer.ts
+++ b/packages/host/src/session-action-performer.ts
@@ -72,7 +72,7 @@ function unknownOpen(error: ExternalOpenAnswerLostError): SessionOpenResult {
 /**
  * What performing an action needs from the app: the registry the action is
  * validated against once more, the adapters that carry it, and the seams a
- * landed action moves — the refresh, the created-workspace watch, the counts.
+ * landed action moves — the pass, the created-workspace watch, the counts.
  */
 export interface SessionActionPerformerDependencies {
   sessionRegistry: SessionRoster;
@@ -97,7 +97,7 @@ export interface SessionActionPerformerDependencies {
   openCreatedWorkspaces: () => void;
   trackedIssues: () => readonly TrackedIssue[] | undefined;
   issueTrackers: readonly LinearIssueTracker[];
-  refreshIssues: () => void;
+  passIssues: () => void;
   supersetContext: (identity: SessionIdentity) => SupersetSessionContext | undefined;
   supersetCli: Pick<
     SupersetCli,
@@ -172,7 +172,7 @@ export function createSessionActionPerformer(
     openCreatedWorkspaces,
     trackedIssues,
     issueTrackers,
-    refreshIssues,
+    passIssues,
     supersetContext,
     supersetCli,
     recordProductEvent,
@@ -217,13 +217,13 @@ export function createSessionActionPerformer(
       return { status: ACTION_RESULT_STATUS.UNSUPPORTED, reason: REFUSAL.PROVIDER_ABSENT };
     }
     const result = await action(plugin);
-    // A rejection refreshes like an acceptance: a write whose answer never
+    // A rejection runs a pass like an acceptance: a write whose answer never
     // arrived may still have landed, so the roster must catch up with the
     // provider rather than keep advertising what it may have already taken. A
     // rejection that never reached the network is answered from the adapter's
     // cache anyway.
     if (result.status !== ACTION_RESULT_STATUS.UNSUPPORTED) {
-      void sessionRegistry.refresh(plugin);
+      void sessionRegistry.pass(plugin);
     }
     return countSessionAction(plugin.provider.id, counted, result);
   }
@@ -417,7 +417,7 @@ export function createSessionActionPerformer(
     );
     // A workspace that landed is a session the panel should be showing, so
     // the next look must actually ask rather than serve the cache. A
-    // rejection refreshes too: a workspace can stand with its opening task
+    // rejection runs one too: a workspace can stand with its opening task
     // undelivered, and the adapter answers a rejection that never reached
     // the network from its cache anyway.
     if (result.status !== ACTION_RESULT_STATUS.UNSUPPORTED) {
@@ -425,7 +425,7 @@ export function createSessionActionPerformer(
       // taken to, so the session the creation response named — an id the
       // adapter reported, never an address — waits here for observation to
       // report it, and is opened then like a pressed row. Noted before the
-      // refresh, so the very pass that first sees the session resolves it.
+      // pass, so the very pass that first sees the session resolves it.
       if (result.status === ACTION_RESULT_STATUS.ACCEPTED && result.providerSessionId) {
         expectCreatedWorkspace(
           { providerId: plugin.provider.id, providerSessionId: result.providerSessionId },
@@ -438,7 +438,7 @@ export function createSessionActionPerformer(
         // against here, and future commits carry every later arrival.
         openCreatedWorkspaces();
       }
-      void sessionRegistry.refresh(plugin);
+      void sessionRegistry.pass(plugin);
     }
     // The first workspace that actually lands chooses the default provider,
     // so a later ask that names none has somewhere unsurprising to go. Only
@@ -570,7 +570,7 @@ export function createSessionActionPerformer(
     // An action that landed changes the board, so the roster should catch up
     // as soon as Linear will say.
     if (result.status === ACTION_RESULT_STATUS.ACCEPTED) {
-      refreshIssues();
+      passIssues();
       if (isIssueTrackerId(issue.trackerId)) {
         recordProductEvent(PRODUCT_EVENT.ISSUE_ACTION_SEND, {
           tracker_id: issue.trackerId,

--- a/packages/host/src/session-row-actions.test.ts
+++ b/packages/host/src/session-row-actions.test.ts
@@ -94,7 +94,7 @@ function fixture() {
     openCreatedWorkspaces: () => {},
     trackedIssues: () => undefined,
     issueTrackers: [],
-    refreshIssues: () => {},
+    passIssues: () => {},
     supersetContext: () => undefined,
     supersetCli: {
       sendMessage: unreachable,

--- a/packages/host/src/socket-ownership.test.ts
+++ b/packages/host/src/socket-ownership.test.ts
@@ -4,14 +4,14 @@ import type { BrainAgent, BrainRequestRecord, BrainSubmission } from "@sidecar/b
 import { DeliveryLedger } from "@sidecar/brain";
 import { BRAIN_REQUEST_ORIGIN, BRAIN_REQUEST_STATUS } from "@sidecar/brain/requests";
 import {
+  disposeGateway,
   GATEWAY_CLIENT_ROLE,
+  GATEWAY_DISPOSE_DEFAULTS,
   GATEWAY_ERROR,
   GATEWAY_HANDSHAKE_HEADER,
   GATEWAY_METHOD,
-  GATEWAY_SHUTDOWN_DEFAULTS,
   GatewayClient,
   NODE_CAPABILITY_STATUS,
-  shutdownGateway,
 } from "@sidecar/gateway";
 import {
   bearerAuthentication,
@@ -34,7 +34,7 @@ import { VoiceReceiver } from "./voice-receiver.js";
  * socket: the host holds the asks, the Conversation, and the receiver; a client
  * that dies takes none of it with it; the next client finds it all; the
  * host's native asks answer typed unavailable while no client stands; and
- * the explicit shutdown counts what the durable records still hold.
+ * the explicit dispose counts what the durable records still hold.
  */
 const NOW = 1_800_000_000_000;
 const TOKEN = "a-shared-secret";
@@ -231,7 +231,7 @@ test("while no client stands, a native capability the host needs answers unavail
   }
 });
 
-test("the explicit shutdown closes admissions, cancels what runs, and counts unresolved from the persisted records, so a cancellation that never landed stays recoverable", async () => {
+test("the explicit dispose closes admissions, cancels what runs, and counts unsettled from the persisted records, so a cancellation that never landed stays recoverable", async () => {
   for (const persistCancellations of [true, false]) {
     const f = fakeHost({ persistCancellations });
     const { host, port } = await listen(f.service);
@@ -243,7 +243,7 @@ test("the explicit shutdown closes admissions, cancels what runs, and counts unr
         { idempotencyKey: "sub-q" },
       );
       assert.ok(submitted.ok);
-      const report = await shutdownGateway(
+      const report = await disposeGateway(
         {
           closeAdmissions: () => {
             host.closeAdmissions();
@@ -258,21 +258,21 @@ test("the explicit shutdown closes admissions, cancels what runs, and counts unr
             return cancelled;
           },
           awaitSettled: async () => undefined,
-          persistUnresolved: async () =>
+          persistUnsettled: async () =>
             [...f.persisted.values()].filter(
               (held) =>
                 held.status === BRAIN_REQUEST_STATUS.QUEUED ||
                 held.status === BRAIN_REQUEST_STATUS.RUNNING,
             ).length,
         },
-        { deadlineMs: GATEWAY_SHUTDOWN_DEFAULTS.DEADLINE_MS },
+        { deadlineMs: GATEWAY_DISPOSE_DEFAULTS.DEADLINE_MS },
       );
       assert.deepEqual(report.cancelled, ["run-1"]);
       assert.equal(report.settled, true);
-      // A cancellation the store took leaves nothing unresolved; one it did
+      // A cancellation the store took leaves nothing unsettled; one it did
       // not leaves the run running on disk, which the next launch marks
       // interrupted and never replays.
-      assert.equal(report.unresolved, persistCancellations ? 0 : 1);
+      assert.equal(report.unsettled, persistCancellations ? 0 : 1);
       // The door is closed: a new ask is refused as shutting down, a read still answers.
       const refused = await desktop.gateway.call(
         GATEWAY_METHOD.RUN_SUBMIT,
@@ -289,17 +289,17 @@ test("the explicit shutdown closes admissions, cancels what runs, and counts unr
   }
 });
 
-test("a shutdown whose cancellation hangs still ends at the deadline with what did not settle counted", async () => {
-  const report = await shutdownGateway(
+test("a dispose whose cancellation hangs still ends at the deadline with what did not settle counted", async () => {
+  const report = await disposeGateway(
     {
       closeAdmissions: () => undefined,
       cancelActive: () => new Promise(() => undefined),
       awaitSettled: async () => undefined,
-      persistUnresolved: async () => 2,
+      persistUnsettled: async () => 2,
     },
     { deadlineMs: 20 },
   );
   assert.equal(report.settled, false);
   assert.deepEqual(report.cancelled, []);
-  assert.equal(report.unresolved, 2);
+  assert.equal(report.unsettled, 2);
 });

--- a/packages/host/src/store-wiring.ts
+++ b/packages/host/src/store-wiring.ts
@@ -124,11 +124,11 @@ export interface StoreWiring {
     kind: ConversationKind,
     name: string,
   ) => Promise<ConversationRecord>;
-  /** Closes the worker, once opened; the host's last action at a shutdown. */
+  /** Closes the worker, once opened; the host's last action at a dispose. */
   close: () => Promise<void>;
   /** The child service's records and completions; a run with nothing on disk keeps them in memory alone. */
   childStore: () => ChildStore;
-  /** Retires a conversation's row, keeping its history: the brain's own cleanup of an ended child. */
+  /** Disposes a conversation's row, keeping its history: the brain's own cleanup of an ended child. */
   archive: (sessionKey: SessionKey) => Promise<boolean>;
   /**
    * The conversation's durable Clear cutoff as the store holds it now, in
@@ -139,7 +139,7 @@ export interface StoreWiring {
   conversationCutoff: (sessionKey: SessionKey) => Promise<CutoffBefore | undefined>;
   /**
    * The store side of Delete conversation, called once the thread is fenced and
-   * the conversation's brain retired: the rows go behind a committed archive
+   * the conversation's brain disposed: the rows go behind a committed archive
    * and the archive is published. A thread held in memory alone has nothing
    * on disk to archive, so forgetting its lines is the whole erasure and
    * answers as published.

--- a/packages/host/src/voice-credential-transition.test.ts
+++ b/packages/host/src/voice-credential-transition.test.ts
@@ -151,7 +151,7 @@ function composition() {
     });
   const transition = () =>
     transitionVoiceCredential({
-      retire: () => host.retire(),
+      dispose: () => host.dispose(),
       apply: () => assembler.apply(),
       rebuild,
     });

--- a/packages/host/src/voice-credential-transition.ts
+++ b/packages/host/src/voice-credential-transition.ts
@@ -2,20 +2,20 @@ import type { VoiceCapabilityApplication } from "@sidecar/voice";
 
 /**
  * One credential transition, from the seams the host owns: the brain
- * wiring's synchronous retire, the assembler's application, and the rebuild
- * that installs what the applied capability allows. The retire is immediate,
+ * wiring's synchronous dispose, the assembler's application, and the rebuild
+ * that installs what the applied capability allows. The dispose is immediate,
  * so no run keeps the old source's authority past the transition's first
  * await. The rebuild belongs to the current application alone, asked at the
  * moment of use rather than read off the answer: a newer transition can begin
  * between the assembler's publication and this continuation, and it has
- * already retired the wiring, so a rebuild on the older one's behalf would be
- * the newest thing the host was asked for and would install the retired
+ * already disposed the wiring, so a rebuild on the older one's behalf would be
+ * the newest thing the host was asked for and would install the disposed
  * source over the selection still being read. An overtaken transition builds
  * nothing and leaves the host empty for the newer one to fill. Answers
  * whether this transition was the one that installed.
  */
 export interface VoiceCredentialTransitionSeams {
-  retire: () => void;
+  dispose: () => void;
   apply: () => Promise<VoiceCapabilityApplication>;
   rebuild: () => Promise<void>;
 }
@@ -23,7 +23,7 @@ export interface VoiceCredentialTransitionSeams {
 export async function transitionVoiceCredential(
   seams: VoiceCredentialTransitionSeams,
 ): Promise<boolean> {
-  seams.retire();
+  seams.dispose();
   const applied = await seams.apply();
   if (!applied.latest || !applied.isCurrent()) return false;
   await seams.rebuild();

--- a/packages/host/src/voice-receiver.test.ts
+++ b/packages/host/src/voice-receiver.test.ts
@@ -46,9 +46,9 @@ test("every reload, replacement, or close ends the epoch and makes the receiver 
 test("a ready listener removed hears nothing more", () => {
   const receiver = new VoiceReceiver();
   const heard: number[] = [];
-  const stop = receiver.onReady((epoch) => heard.push(epoch));
+  const ready = receiver.onReady((epoch) => heard.push(epoch));
   const epoch = receiver.begin();
-  stop();
+  ready.dispose();
   receiver.markReady(epoch);
   assert.deepEqual(heard, []);
 });

--- a/packages/host/src/voice-receiver.ts
+++ b/packages/host/src/voice-receiver.ts
@@ -10,6 +10,8 @@
  * makes the receiver unready again; whatever was offered to the old epoch is
  * the caller's to reoffer once a new one reports.
  */
+import { type IDisposable, toDisposable } from "@sidecar/wire";
+
 export type VoiceReceiverListener = (epoch: number) => void;
 
 export class VoiceReceiver {
@@ -55,19 +57,19 @@ export class VoiceReceiver {
     return true;
   }
 
-  onReady(listener: VoiceReceiverListener): () => void {
+  onReady(listener: VoiceReceiverListener): IDisposable {
     this.#readyListeners.add(listener);
-    return () => {
+    return toDisposable(() => {
       this.#readyListeners.delete(listener);
-    };
+    });
   }
 
   /** Hears every epoch ending, with the epoch that ended, after a reset or a new beginning. */
-  onReset(listener: VoiceReceiverListener): () => void {
+  onReset(listener: VoiceReceiverListener): IDisposable {
     this.#resetListeners.add(listener);
-    return () => {
+    return toDisposable(() => {
       this.#resetListeners.delete(listener);
-    };
+    });
   }
 
   #end(): void {

--- a/packages/providers/src/codex/observe.test.ts
+++ b/packages/providers/src/codex/observe.test.ts
@@ -846,7 +846,7 @@ test("a thread archived between passes leaves the roster and stays gone", async 
   });
   const registry = new SessionRoster();
 
-  await registry.refresh(plugin);
+  await registry.pass(plugin);
   assert.deepEqual(
     registry.list().map((session) => session.providerSessionId),
     ["codex-live"],
@@ -863,7 +863,7 @@ test("a thread archived between passes leaves the roster and stays gone", async 
     database.close();
   }
 
-  await registry.refresh(plugin);
+  await registry.pass(plugin);
   assert.deepEqual(registry.list(), []);
 });
 

--- a/packages/providers/src/conductor/contract.test.ts
+++ b/packages/providers/src/conductor/contract.test.ts
@@ -14,7 +14,7 @@ describeProviderContract(
       baseUrl: "https://api.conductor.test",
       fetch: input.api.fetch,
       now: input.now,
-      minimumRefreshIntervalMs: input.minimumRefreshIntervalMs,
+      minimumPassIntervalMs: input.minimumPassIntervalMs,
     }),
   {
     providerId: "conductor",

--- a/packages/providers/src/conductor/index.ts
+++ b/packages/providers/src/conductor/index.ts
@@ -20,7 +20,7 @@ export interface ConductorPluginOptions {
   baseUrl?: string;
   fetch?: CloudFetch;
   now?: () => number;
-  minimumRefreshIntervalMs?: number;
+  minimumPassIntervalMs?: number;
   sleep?: (ms: number) => Promise<void>;
   onDiagnostic?: AdapterDiagnosticCallback;
 }

--- a/packages/providers/src/conductor/local-workspaces.test.ts
+++ b/packages/providers/src/conductor/local-workspaces.test.ts
@@ -169,7 +169,7 @@ test("an absent Conductor database reports no repositories", async (t) => {
   assert.deepEqual(await reader.read(), []);
 });
 
-test("refresh offers each repository as an optional-task project", async (t) => {
+test("a pass offers each repository as an optional-task project", async (t) => {
   const databasePath = await temporaryDatabasePath(t);
   const database = createReposDatabase(databasePath);
   writeRepo(database, {
@@ -185,7 +185,7 @@ test("refresh offers each repository as an optional-task project", async (t) => 
     openExternal: async () => {},
   });
   assert.deepEqual(plugin.projects?.() ?? [], []);
-  await plugin.refresh();
+  await plugin.pass();
   assert.deepEqual(plugin.projects?.() ?? [], [
     {
       providerProjectId: "repo-luke",
@@ -210,7 +210,7 @@ test("creating a workspace fires Conductor's create link for the offered reposit
       opened.push(url);
     },
   });
-  await plugin.refresh();
+  await plugin.pass();
   const result = await dispatchAction(
     plugin,
     "createWorkspace",
@@ -233,7 +233,7 @@ test("creating a workspace fires Conductor's create link for the offered reposit
   );
 });
 
-test("a failed refresh empties the offer rather than keeping a stale one", async (t) => {
+test("a failed pass empties the offer rather than keeping a stale one", async (t) => {
   const databasePath = await temporaryDatabasePath(t);
   // The file must exist for the read-only open to be attempted; the mock below
   // stands in for its contents, succeeding once and then failing.
@@ -260,11 +260,11 @@ test("a failed refresh empties the offer rather than keeping a stale one", async
     repositories: conductorRepositories({ databasePath, sqlite }),
     openExternal: async () => {},
   });
-  await plugin.refresh();
+  await plugin.pass();
   assert.equal((plugin.projects?.() ?? []).length, 1);
   // A non-ignorable read failure surfaces, and must leave nothing behind to
   // validate a later create against.
-  await assert.rejects(() => plugin.refresh());
+  await assert.rejects(() => plugin.pass());
   assert.deepEqual(plugin.projects?.() ?? [], []);
 });
 
@@ -278,7 +278,7 @@ test("creating a workspace with no task lands clean, with no send warning", asyn
     repositories: conductorRepositories({ databasePath }),
     openExternal: async () => {},
   });
-  await plugin.refresh();
+  await plugin.pass();
   const result = await dispatchAction(
     plugin,
     "createWorkspace",
@@ -302,7 +302,7 @@ test("creating a workspace uses the offered root path, never the request's", asy
       opened.push(url);
     },
   });
-  await plugin.refresh();
+  await plugin.pass();
   // A request naming a different target than the one offered is not the project
   // this pass reported, so it is refused rather than fired at a path of its own.
   const result = await dispatchAction(
@@ -331,7 +331,7 @@ test("creating a workspace in an unoffered project is unsupported", async (t) =>
       opened.push(url);
     },
   });
-  await plugin.refresh();
+  await plugin.pass();
   const result = await dispatchAction(
     plugin,
     "createWorkspace",
@@ -353,7 +353,7 @@ test("a failed open is reported as a rejection the user can act on", async (t) =
       throw new Error("no handler for conductor://");
     },
   });
-  await plugin.refresh();
+  await plugin.pass();
   const result = await dispatchAction(
     plugin,
     "createWorkspace",
@@ -391,7 +391,7 @@ test("a create whose deep link was handed to the machine and never answered is u
       throw new ExternalOpenAnswerLostError("the desktop went away before answering");
     },
   });
-  await plugin.refresh();
+  await plugin.pass();
   const result = await dispatchAction(
     plugin,
     "createWorkspace",
@@ -409,7 +409,7 @@ test("a create whose deep link was handed to the machine and never answered is u
       throw new Error("no handler for the scheme");
     },
   });
-  await refused.refresh();
+  await refused.pass();
   const rejected = await dispatchAction(
     refused,
     "createWorkspace",

--- a/packages/providers/src/conductor/local-workspaces.ts
+++ b/packages/providers/src/conductor/local-workspaces.ts
@@ -160,7 +160,7 @@ export interface ConductorLocalWorkspaceOptions {
 
 /** A Conductor local-workspace plugin, plus the read that fills its offer. */
 export interface ConductorLocalWorkspacePlugin extends SessionProviderPlugin {
-  refresh(): Promise<void>;
+  pass(): Promise<void>;
 }
 
 /**
@@ -210,7 +210,7 @@ export function conductorLocalWorkspacePlugin(
      * empties the offer, so a create is never validated against repositories
      * a later read could no longer see.
      */
-    async refresh() {
+    async pass() {
       let repositories: readonly ConductorRepository[];
       try {
         repositories = await repositoryIndex.read();

--- a/packages/providers/src/conductor/observe.test.ts
+++ b/packages/providers/src/conductor/observe.test.ts
@@ -769,7 +769,7 @@ test("adopts the provider's timestamp again the moment the chat's work moves", a
 
 // SAFETY: Fixture value matches the narrowed runtime shape this test exercises.
 test("a whole turn between passes reads as unmoved", async () => {
-  // A short turn can start and settle inside one refresh interval, so both
+  // A short turn can start and settle inside one pass interval, so both
   // passes read idle. Status and failure are the only facts compared, and
   // neither moved, so the wake-bumped timestamp is not adopted: the accepted
   // cost of reading no words of the conversation is that such a turn keeps

--- a/packages/providers/src/conductor/wire.ts
+++ b/packages/providers/src/conductor/wire.ts
@@ -28,7 +28,7 @@ import {
 /**
  * Documented public API routes. The reads walk projects, the user's own open
  * workspaces through the workspace listing's documented creator and archive
- * filters, and each workspace's sessions, and poll the status endpoints
+ * filters, and each workspace's sessions, and read the status endpoints
  * workspaces and sessions document. Beside those pass-driven reads stands one
  * a user asks for by opening a conversation screen:
  * `GET …/sessions/{id}/messages`, Conductor's documented read of one

--- a/packages/providers/src/shared/cloud-pass.test.ts
+++ b/packages/providers/src/shared/cloud-pass.test.ts
@@ -91,7 +91,7 @@ interface StubOptions {
   apiKey?: string | undefined;
   readApiKey?: () => Promise<string | undefined>;
   now?: () => number;
-  minimumRefreshIntervalMs?: number;
+  minimumPassIntervalMs?: number;
   onDiagnostic?: AdapterDiagnosticCallback;
   requestHeaders?: Readonly<Record<string, string>>;
   sleep?: (ms: number) => Promise<void>;
@@ -116,7 +116,7 @@ function stubPluginFor(fetch: CloudFetch, overrides: StubOptions = {}): StubClou
     baseUrl: TEST_BASE_URL,
     fetch,
     now: overrides.now ?? (() => TEST_TIME),
-    minimumRefreshIntervalMs: overrides.minimumRefreshIntervalMs ?? 0,
+    minimumPassIntervalMs: overrides.minimumPassIntervalMs ?? 0,
     ...(overrides.onDiagnostic ? { onDiagnostic: overrides.onDiagnostic } : undefined),
     ...(overrides.sleep ? { sleep: overrides.sleep } : undefined),
     forget: () => {
@@ -381,7 +381,7 @@ function deferred() {
 function accountBoundPlugin(options: {
   readApiKey: () => Promise<string | undefined>;
   fetch: CloudFetch;
-  minimumRefreshIntervalMs: number;
+  minimumPassIntervalMs: number;
 }) {
   return cloudPass({
     provider: STUB_PROVIDER,
@@ -440,7 +440,7 @@ test("a pass superseded by a key rotation neither lands nor keeps using the old 
   const plugin = accountBoundPlugin({
     readApiKey: async () => apiKey,
     fetch,
-    minimumRefreshIntervalMs: 0,
+    minimumPassIntervalMs: 0,
   });
 
   const stalePass = plugin.run();
@@ -470,7 +470,7 @@ test("a replaced key rejected mid-flight does not clear the new key's observatio
   const plugin = accountBoundPlugin({
     readApiKey: async () => apiKey,
     fetch,
-    minimumRefreshIntervalMs: 60_000,
+    minimumPassIntervalMs: 60_000,
   });
 
   const stalePass = plugin.run();
@@ -478,7 +478,7 @@ test("a replaced key rejected mid-flight does not clear the new key's observatio
   await plugin.run();
   oldKeyRequest.resolve();
   const staleObservations = await stalePass;
-  // Inside the refresh interval this serves the cache, which is exactly where
+  // Inside the pass interval this serves the cache, which is exactly where
   // SAFETY: Fixture value matches the narrowed runtime shape this test exercises.
   // a wrongly cleared snapshot would surface as vanished rows.
   const cachedObservations = await plugin.run();
@@ -512,7 +512,7 @@ test("a programming error during observation is reported rather than swallowed",
   const stub = stubFetch();
   const plugin = stubPluginFor(stub.fetch, {
     now: () => now,
-    minimumRefreshIntervalMs: 60_000,
+    minimumPassIntervalMs: 60_000,
     onDiagnostic: (kind, error) => diagnostics.push([kind, error]),
   });
   plugin.collected = [observation("session-one")];
@@ -629,7 +629,7 @@ test("reports an unanswered send as indeterminate and makes the next refresh ask
     if (failWrites && request.method === "POST") throw new Error("connection reset");
     return jsonResponse({});
   });
-  const plugin = stubPluginFor(fetch, { minimumRefreshIntervalMs: 60_000 });
+  const plugin = stubPluginFor(fetch, { minimumPassIntervalMs: 60_000 });
   plugin.collected = [observation("session-one", { advertises: [{ kind: ACTION_KIND.MESSAGE }] })];
   await plugin.observe();
 
@@ -654,7 +654,7 @@ test("reports an unanswered send as indeterminate and makes the next refresh ask
 test("a write answered with an unnamed status makes the next refresh ask", async () => {
   let status: number = HTTP_STATUS.OK;
   const stub = stubFetch(() => status);
-  const plugin = stubPluginFor(stub.fetch, { minimumRefreshIntervalMs: 60_000 });
+  const plugin = stubPluginFor(stub.fetch, { minimumPassIntervalMs: 60_000 });
   plugin.collected = [observation("session-one", { advertises: [{ kind: ACTION_KIND.MESSAGE }] })];
   await plugin.observe();
 
@@ -682,7 +682,7 @@ test("a write runs on the deadline its own route asked for", async () => {
       request.init.signal?.addEventListener("abort", () => reject(new Error("deadline")));
     });
   });
-  const plugin = stubPluginFor(fetch, { minimumRefreshIntervalMs: 60_000 });
+  const plugin = stubPluginFor(fetch, { minimumPassIntervalMs: 60_000 });
   plugin.collected = [observation("session-slow", { advertises: [STUB_SLOW_ACTION_CONTROL] })];
   await plugin.observe();
 

--- a/packages/providers/src/shared/cloud-pass.ts
+++ b/packages/providers/src/shared/cloud-pass.ts
@@ -101,7 +101,7 @@ export interface CloudPassInput {
   now?: () => number;
   /** How a 429's wait is spent; injected in tests, a timer otherwise. */
   sleep?: (ms: number) => Promise<void>;
-  minimumRefreshIntervalMs?: number;
+  minimumPassIntervalMs?: number;
   /**
    * The headers every request carries besides the credential, for a provider
    * that asks for its own media type or a version pin. The authorization
@@ -137,7 +137,7 @@ export interface CloudSessionPlugin extends SessionProviderPlugin {
 
 /**
  * The shared half of every cloud provider: credential handling, its own
- * refresh cadence, the failure rules that decide whether a snapshot survives,
+ * pass cadence, the failure rules that decide whether a snapshot survives,
  * bounded read-only requests, and the one authenticated write. An adapter
  * supplies the provider's routes and how its reported state maps onto Luke's,
  * and reaches its provider through nothing but these.
@@ -198,10 +198,10 @@ export function cloudPass(input: CloudPassInput): CloudPass {
   const performFetch = input.fetch ?? defaultFetch;
   const sleep = input.sleep ?? defaultSleep;
   const now = input.now ?? Date.now;
-  const { minimumRefreshIntervalMs } = resolveOptions(
+  const { minimumPassIntervalMs } = resolveOptions(
     input,
-    { minimumRefreshIntervalMs: CLOUD_ADAPTER_DEFAULTS.MINIMUM_REFRESH_INTERVAL_MS },
-    { nonNegative: ["minimumRefreshIntervalMs"] },
+    { minimumPassIntervalMs: CLOUD_ADAPTER_DEFAULTS.MINIMUM_PASS_INTERVAL_MS },
+    { nonNegative: ["minimumPassIntervalMs"] },
   );
   const requestHeaders = input.requestHeaders ?? DEFAULT_REQUEST_HEADERS;
 
@@ -219,7 +219,7 @@ export function cloudPass(input: CloudPassInput): CloudPass {
   let collectPass = 0;
 
   /**
-   * One observer must never abort the shared refresh pass, so a settings read
+   * One observer must never cancel the shared pass, so a settings read
    * that fails is treated the same as having no credential at all — here, and
    * for the action that reads the credential again at its own moment.
    */
@@ -376,19 +376,19 @@ export function cloudPass(input: CloudPassInput): CloudPass {
 
       const attemptedAt = now();
       if (apiKey === credential) {
-        // A network provider refreshes on its own cadence instead of on every
-        // tick of the shared observation timer.
-        if (attemptedAt - lastAttemptAt < minimumRefreshIntervalMs) return observations;
+        // A network provider takes a pass on its own cadence instead of on
+        // every tick of the shared observation timer.
+        if (attemptedAt - lastAttemptAt < minimumPassIntervalMs) return observations;
       } else {
         credential = apiKey;
         forgetObservedState();
       }
       lastAttemptAt = attemptedAt;
 
-      // Observers can overlap: a settings save refreshes this adapter while a
-      // timer-driven pass is still in flight with the key it replaced. Only
-      // the newest pass may write, or sessions read as one credential would be
-      // served as another's until the next refresh.
+      // Observers can overlap: a settings save opens a pass over this adapter
+      // while a timer-driven pass is still in flight with the key it replaced.
+      // Only the newest pass may write, or sessions read as one credential
+      // would be served as another's until the next pass.
       const pass = ++collectPass;
       try {
         const collected = await input.collect(requestForPass(pass, apiKey), attemptedAt);
@@ -463,7 +463,7 @@ export function cloudPass(input: CloudPassInput): CloudPass {
         // connection that never opened sent nothing, but a timeout or a reset
         // while the answer was coming back leaves a request the provider may
         // have already acted on. So the refusal hedges rather than claims, and
-        // the refresh that follows must actually ask, so a write that did land
+        // the pass that follows must actually ask, so a write that did land
         // is reconciled against the provider instead of the cache still
         // advertising it.
         lastAttemptAt = Number.NEGATIVE_INFINITY;
@@ -477,7 +477,7 @@ export function cloudPass(input: CloudPassInput): CloudPass {
 
       if (response.ok) {
         // A write that landed changes what the session is doing, so the
-        // refresh that follows must actually ask: served from the cache inside
+        // pass that follows must actually ask: served from the cache inside
         // the minimum interval, the row would keep offering what the provider
         // has already taken.
         lastAttemptAt = Number.NEGATIVE_INFINITY;
@@ -518,7 +518,7 @@ export function cloudPass(input: CloudPassInput): CloudPass {
       }
       // Any other status is an answer that says nothing certain about the action
       // — a gateway that gave up may stand in front of a write that finished —
-      // so this hedges the way a thrown fetch does, and the refresh that
+      // so this hedges the way a thrown fetch does, and the pass that
       // follows must actually ask rather than keep advertising what the
       // provider may have already taken.
       lastAttemptAt = Number.NEGATIVE_INFINITY;

--- a/packages/providers/src/shared/cloud-wire.ts
+++ b/packages/providers/src/shared/cloud-wire.ts
@@ -15,7 +15,7 @@ const GIT_SUFFIX = ".git";
  * shared with every local provider.
  */
 export const CLOUD_ADAPTER_DEFAULTS = {
-  MINIMUM_REFRESH_INTERVAL_MS: 15 * 1000,
+  MINIMUM_PASS_INTERVAL_MS: 15 * 1000,
   REQUEST_TIMEOUT_MS: 8 * 1000,
   /**
    * For the rare read a provider documents as slow — Cursor's repository list

--- a/packages/providers/src/shared/hook-merge.ts
+++ b/packages/providers/src/shared/hook-merge.ts
@@ -460,7 +460,7 @@ export async function installObservationHooks<Event extends string>(
 /**
  * Takes the whole arrangement back out: the registration entries, the script,
  * and the spool with whatever events it held. The configuration file is the
- * one thing never created here — a teardown that leaves new files behind has
+ * one thing never created here — a dispose that leaves new files behind has
  * the relationship backwards — and a file that cannot be parsed is left as
  * found.
  *

--- a/packages/providers/src/superset/contract.test.ts
+++ b/packages/providers/src/superset/contract.test.ts
@@ -20,10 +20,10 @@ describeProviderContract(
     });
     return {
       ...plugin,
-      // Superset's rows come from the host-state read its `refresh` performs,
+      // Superset's rows come from the host-state read its `pass` performs,
       // so the pass under test is that read and the roster it publishes.
       async observe() {
-        await plugin.refresh(undefined);
+        await plugin.pass(undefined);
         return plugin.observe();
       },
     };

--- a/packages/providers/src/superset/plugin.test.ts
+++ b/packages/providers/src/superset/plugin.test.ts
@@ -35,7 +35,7 @@ test("reports the idle workspaces its own pass read, and nothing before one", as
   // Nothing until a pass has run: the rows are the pass's, never state this
   // reads for itself.
   assert.deepEqual(await plugin.observe(), []);
-  await plugin.refresh(undefined);
+  await plugin.pass(undefined);
   assert.deepEqual(await plugin.observe(), []);
   assert.equal(plugin.provider.id, SUPERSET_WORKSPACE_PROVIDER_ID);
   assert.equal(plugin.activeOrganization(), "org-1");
@@ -55,8 +55,8 @@ test("reuses recently discovered workspace projects", async (t) => {
     },
   });
 
-  await plugin.refresh("codex");
-  await plugin.refresh("codex");
+  await plugin.pass("codex");
+  await plugin.pass("codex");
 
   assert.equal(projectQueries, 1);
   assert.equal(plugin.projects?.()[0]?.defaultAgent, "codex");
@@ -76,8 +76,8 @@ test("retries workspace discovery after an empty result", async (t) => {
     },
   });
 
-  await plugin.refresh("codex");
-  await plugin.refresh("codex");
+  await plugin.pass("codex");
+  await plugin.pass("codex");
 
   assert.equal(projectQueries, 2);
   assert.equal(plugin.projects?.()[0]?.providerProjectId, "project-1");
@@ -91,7 +91,7 @@ test("a signed-out home observes its workspaces and offers no project", async (t
     },
   });
 
-  const enrich = await plugin.refresh("codex");
+  const enrich = await plugin.pass("codex");
 
   // Host state reads without a login, so the rows stand — undecorated with
   // actions — however the connection looks.

--- a/packages/providers/src/superset/plugin.ts
+++ b/packages/providers/src/superset/plugin.ts
@@ -24,7 +24,7 @@ export interface SupersetPlugin extends SessionProviderPlugin {
    * offers for creation. Answers the enrichment that pass produced, which is
    * what annotates the other providers' rows.
    */
-  refresh(defaultAgent: string | undefined): Promise<WorkspaceHostEnrichment>;
+  pass(defaultAgent: string | undefined): Promise<WorkspaceHostEnrichment>;
   /** The organization the CLI's login serves, as the latest pass read it. */
   activeOrganization(): string | undefined;
   /** The context an action resolves against, in that organization and no other. */
@@ -82,15 +82,15 @@ export function supersetPlugin(options: SupersetPluginOptions): SupersetPlugin {
 
     /**
      * The idle workspaces the latest pass reported, exactly as the snapshot
-     * decorated them. `refresh` publishes them rather than this reading state
-     * of its own, so a plain registry refresh after an action commits the same
+     * decorated them. `pass` publishes them rather than this reading state
+     * of its own, so a plain registry pass after an action commits the same
      * shape the observation loop does.
      */
     observe: async () => workspaceRows,
     latest: () => workspaceRows,
     projects: () => projects,
 
-    async refresh(defaultAgent) {
+    async pass(defaultAgent) {
       const [read, activeOrganization] = await Promise.all([
         supersetHostState(options),
         cli.activeOrganization(),

--- a/packages/providers/src/superset/sign-in.test.ts
+++ b/packages/providers/src/superset/sign-in.test.ts
@@ -167,9 +167,9 @@ test("duplicate starts share one attempt and cancellation kills its exact child"
   assert.equal(signIn.current().stage, SUPERSET_SIGN_IN_STAGE.IDLE);
 });
 
-test("process failure, timeout, and shutdown end without exposing CLI output", async (t) => {
+test("process failure, timeout, and dispose end without exposing CLI output", async (t) => {
   const home = await homeWithCli(t);
-  for (const ending of ["error", "timeout", "shutdown"] as const) {
+  for (const ending of ["error", "timeout", "dispose"] as const) {
     const child = new FakeChild();
     const states: string[] = [];
     const signIn = new SupersetSignIn({
@@ -182,7 +182,7 @@ test("process failure, timeout, and shutdown end without exposing CLI output", a
     await signIn.begin();
     child.stderr.write("token=must-not-cross-the-boundary");
     if (ending === "error") child.emit("error", new Error("secret output"));
-    if (ending === "shutdown") signIn.shutdown();
+    if (ending === "dispose") signIn.dispose();
     await new Promise((resolve) => setTimeout(resolve, ending === "timeout" ? 5 : 0));
     assert.equal(
       states.some((state) => state.includes("must-not-cross")),

--- a/packages/providers/src/superset/sign-in.ts
+++ b/packages/providers/src/superset/sign-in.ts
@@ -193,7 +193,7 @@ export class SupersetSignIn {
     this.#set(snapshot(SUPERSET_SIGN_IN_STAGE.IDLE));
   }
 
-  shutdown(): void {
+  dispose(): void {
     this.cancel();
   }
 

--- a/packages/providers/src/superset/snapshot.ts
+++ b/packages/providers/src/superset/snapshot.ts
@@ -284,7 +284,7 @@ export function supersetSnapshot(
     /**
      * The chatless workspaces as rows of the Superset workspace provider,
      * decorated here — beside `enrich`, from the same observed state — rather
-     * than by a registry transform, so an action path's plain refresh commits the
+     * than by a registry transform, so an action path's plain pass commits the
      * same shape the observation loop does. Each row stands (`standing`): it is
      * re-reported for as long as the workspace exists and dropped the pass
      * after it is gone, so retention never ages it out however long the

--- a/packages/providers/src/testing/conductor-api.ts
+++ b/packages/providers/src/testing/conductor-api.ts
@@ -310,7 +310,7 @@ export function pluginFor(
     apiKey?: string | undefined;
     readApiKey?: () => Promise<string | undefined>;
     now?: () => number;
-    minimumRefreshIntervalMs?: number;
+    minimumPassIntervalMs?: number;
   } = {},
 ): SessionProviderPlugin {
   const apiKey = "apiKey" in overrides ? overrides.apiKey : TEST_API_KEY;
@@ -319,7 +319,7 @@ export function pluginFor(
     baseUrl: TEST_BASE_URL,
     fetch,
     now: overrides.now ?? (() => TEST_TIME),
-    minimumRefreshIntervalMs: overrides.minimumRefreshIntervalMs ?? 0,
+    minimumPassIntervalMs: overrides.minimumPassIntervalMs ?? 0,
   });
 }
 export const LUKE_PROJECT: TestProject = {

--- a/packages/providers/src/testing/provider-contract.ts
+++ b/packages/providers/src/testing/provider-contract.ts
@@ -57,7 +57,7 @@ export interface ProviderFixtureInput {
   /** A temporary directory seeded from `home/`; the provider's home for this case. */
   readonly home: string;
   readonly now: () => number;
-  readonly minimumRefreshIntervalMs: number;
+  readonly minimumPassIntervalMs: number;
   /** Answers `undefined` for the no-key cases, and throws for the unreadable one. */
   readonly readApiKey: () => Promise<string | undefined>;
   /**
@@ -187,7 +187,7 @@ function admissionRequest(
 
 const CONTRACT_API_KEY = "contract-initial-key";
 const REPLACEMENT_API_KEY = "contract-replacement-key";
-const REFRESH_INTERVAL_MS = 15_000;
+const PASS_INTERVAL_MS = 15_000;
 /** The one body key a POSTed read document rides under. */
 const READ_DOCUMENT_FIELD = "query";
 const UNSUPPORTED_MESSAGE_TEXT = "This message must never reach a provider.";
@@ -303,7 +303,7 @@ interface ContractCase {
 
 interface CaseOptions {
   readonly readApiKey?: () => Promise<string | undefined>;
-  readonly minimumRefreshIntervalMs?: number;
+  readonly minimumPassIntervalMs?: number;
   readonly hookEventsDirectory?: () => string | undefined;
 }
 
@@ -341,7 +341,7 @@ export function describeProviderContract(
     const plugin = await factory({
       home,
       now: () => now,
-      minimumRefreshIntervalMs: options.minimumRefreshIntervalMs ?? 0,
+      minimumPassIntervalMs: options.minimumPassIntervalMs ?? 0,
       readApiKey: options.readApiKey ?? (async () => apiKey),
       api,
       hookEventsDirectory: options.hookEventsDirectory ?? (() => undefined),
@@ -569,7 +569,7 @@ export function describeProviderContract(
     });
 
     test(named("reads again at once under a credential the user just replaced"), async (t) => {
-      const contract = await contractCase(t, { minimumRefreshIntervalMs: 60_000 });
+      const contract = await contractCase(t, { minimumPassIntervalMs: 60_000 });
 
       await contract.plugin.observe();
       const requestsAfterFirstPass = contract.api.requests().length;
@@ -598,12 +598,12 @@ export function describeProviderContract(
       },
     );
 
-    test(named("asks nothing again inside its own refresh interval"), async (t) => {
-      const contract = await contractCase(t, { minimumRefreshIntervalMs: REFRESH_INTERVAL_MS });
+    test(named("asks nothing again inside its own pass interval"), async (t) => {
+      const contract = await contractCase(t, { minimumPassIntervalMs: PASS_INTERVAL_MS });
 
       const first = await contract.plugin.observe();
       const requestsAfterFirstPass = contract.api.requests().length;
-      contract.setNow(fixtures.now + REFRESH_INTERVAL_MS / 3);
+      contract.setNow(fixtures.now + PASS_INTERVAL_MS / 3);
       const throttled = await contract.plugin.observe();
 
       assert.deepEqual(throttled, first);

--- a/packages/runtime/src/lanes.test.ts
+++ b/packages/runtime/src/lanes.test.ts
@@ -3,11 +3,11 @@ import test from "node:test";
 import { agentLaneWidth, LANE, LaneScheduler, laneConfiguration } from "./lanes.js";
 
 function deferred<T = void>() {
-  let resolve!: (value: T) => void;
+  let settle!: (value: T) => void;
   const promise = new Promise<T>((done) => {
-    resolve = done;
+    settle = done;
   });
-  return { promise, resolve };
+  return { promise, settle };
 }
 
 const tick = () => new Promise<void>((done) => setImmediate(done));
@@ -49,9 +49,9 @@ test("a lane admits its width and queues the rest in order, apart from every oth
   assert.deepEqual(started, [0, 1, 2]);
   assert.equal(await child, "child");
   assert.deepEqual(scheduler.snapshot(LANE.BACKGROUND), { width: 3, active: 3, queued: 1 });
-  gates[0]?.resolve();
+  gates[0]?.settle();
   await tick();
   assert.deepEqual(started, [0, 1, 2, 3]);
-  for (const gate of gates) gate.resolve();
+  for (const gate of gates) gate.settle();
   assert.deepEqual(await Promise.all(runs), [0, 1, 2, 3]);
 });

--- a/packages/runtime/src/observation-loop.test.ts
+++ b/packages/runtime/src/observation-loop.test.ts
@@ -3,14 +3,14 @@ import test from "node:test";
 import { ObservationLoop, ObservationSupervisor } from "./observation-loop.js";
 
 function deferred() {
-  let resolve: () => void = () => undefined;
-  const promise = new Promise<void>((settle) => {
-    resolve = settle;
+  let settle: () => void = () => undefined;
+  const promise = new Promise<void>((resolve) => {
+    settle = resolve;
   });
-  return { promise, resolve };
+  return { promise, settle };
 }
 
-test("coalesces overlapping refreshes into one immediate follow-up", async () => {
+test("coalesces overlapping passes into one immediate follow-up", async () => {
   const first = deferred();
   const generations: number[] = [];
   const loop = new ObservationLoop({
@@ -22,11 +22,11 @@ test("coalesces overlapping refreshes into one immediate follow-up", async () =>
     },
   });
 
-  const running = loop.refresh();
-  await loop.refresh();
-  await loop.refresh();
+  const running = loop.pass();
+  await loop.pass();
+  await loop.pass();
   assert.deepEqual(generations, [0]);
-  first.resolve();
+  first.settle();
   await running;
   await new Promise((resolve) => setImmediate(resolve));
   assert.deepEqual(generations, [0, 0]);
@@ -42,13 +42,13 @@ test("stop invalidates work already in flight and prevents gated work", async ()
   });
 
   const generation = loop.generation;
-  const running = loop.refresh();
+  const running = loop.pass();
   loop.stop();
   enabled = false;
   assert.equal(loop.isCurrent(generation), false);
-  pending.resolve();
+  pending.settle();
   await running;
-  await loop.refresh();
+  await loop.pass();
   assert.equal(loop.generation, generation + 1);
 });
 
@@ -113,14 +113,14 @@ test("a pass that outlives its stop does not run the after-run hook", async () =
     afterRun: () => hooks.push(1),
   });
 
-  const running = loop.refresh();
+  const running = loop.pass();
   loop.stop();
   enabled = false;
-  pending.resolve();
+  pending.settle();
   await running;
   assert.deepEqual(hooks, []);
 
   enabled = true;
-  await loop.refresh();
+  await loop.pass();
   assert.deepEqual(hooks, [1]);
 });

--- a/packages/runtime/src/observation-loop.ts
+++ b/packages/runtime/src/observation-loop.ts
@@ -26,8 +26,8 @@ export class ObservationLoop {
 
   start(): void {
     if (this.#timer || !this.#options.gate()) return;
-    void this.refresh();
-    this.#timer = setInterval(() => void this.refresh(), this.#options.intervalMs);
+    void this.pass();
+    this.#timer = setInterval(() => void this.pass(), this.#options.intervalMs);
     this.#timer.unref();
   }
 
@@ -38,7 +38,7 @@ export class ObservationLoop {
     this.#timer = undefined;
   }
 
-  async refresh(): Promise<void> {
+  async pass(): Promise<void> {
     if (!this.#options.gate()) return;
     if (this.#running) {
       this.#queued = true;
@@ -57,7 +57,7 @@ export class ObservationLoop {
       if (this.isCurrent(generation)) this.#options.afterRun?.();
       if (this.#queued) {
         this.#queued = false;
-        void this.refresh();
+        void this.pass();
       }
     }
   }

--- a/packages/session/src/conversation/conversation.ts
+++ b/packages/session/src/conversation/conversation.ts
@@ -1,8 +1,8 @@
 /**
  * The conversation history: the one continuous conversation, held on this side
  * of the wire. A Realtime call is a transport that comes and goes — the
- * announcer's speak-only call is torn down by the very talk-key press that
- * asks about it, and the developer's call retires when idle — so the thread
+ * announcer's speak-only call is disposed by the very talk-key press that
+ * asks about it, and the developer's call disposes when idle — so the thread
  * itself is kept here, and a bounded recent slice is re-fed to whichever call
  * the developer opens next.
  *

--- a/packages/session/src/session-registry.test.ts
+++ b/packages/session/src/session-registry.test.ts
@@ -262,12 +262,12 @@ test("a session runs on this machine unless its provider observed it elsewhere",
   );
 });
 
-test("refresh replaces one adapter's sessions whole and leaves other providers untouched", async () => {
+test("a pass replaces one adapter's sessions whole and leaves other providers untouched", async () => {
   const roster = new SessionRoster();
   roster.replaceProvider(codex, [observation("stale", 10), observation("active", 20)]);
   roster.replaceProvider(claude, [observation("review", 30, { status: SESSION_STATUS.WAITING })]);
 
-  await roster.refresh({
+  await roster.pass({
     provider: codex,
     observe: async () => [observation("active", 50), observation("new", 60)],
   });
@@ -289,9 +289,9 @@ test("refresh replaces one adapter's sessions whole and leaves other providers u
   assert.equal(roster.get({ providerId: "codex", providerSessionId: "stale" }), undefined);
 });
 
-test("a refresh may reshape the observation before it lands, per provider", async () => {
+test("a pass may reshape the observation before it lands, per provider", async () => {
   const roster = new SessionRoster();
-  await roster.refresh(
+  await roster.pass(
     { provider: codex, observe: async () => [observation("run:1", 10)] },
     (providerId, observations) =>
       observations.map((observed) => ({ ...observed, title: `${providerId}: ${observed.title}` })),
@@ -305,14 +305,14 @@ test("a refresh may reshape the observation before it lands, per provider", asyn
 test("every pass reaches the listeners, moved or not", () => {
   const roster = new SessionRoster();
   const heard: number[] = [];
-  const unsubscribe = roster.subscribe((sessions) => {
+  const subscription = roster.subscribe((sessions) => {
     heard.push(sessions.length);
   });
 
   roster.replaceProvider(codex, [observation("active", 10)]);
   roster.replaceProvider(codex, [observation("active", 10)]);
   roster.replaceProvider(codex, []);
-  unsubscribe();
+  subscription.dispose();
   roster.replaceProvider(codex, [observation("active", 10)]);
 
   // Nothing here decides whether anything moved; the renderer draws identical

--- a/packages/session/src/session-registry.ts
+++ b/packages/session/src/session-registry.ts
@@ -1,3 +1,4 @@
+import { type IDisposable, toDisposable } from "@sidecar/wire";
 import { normalizeSession, normalizeSessionIdentity } from "./normalize.js";
 import type { SessionProviderPlugin } from "./provider-plugin.js";
 import type { SessionIdentity, SessionProvider } from "./session-identity.js";
@@ -19,7 +20,7 @@ function normalizedProviderId(provider: SessionProvider): string {
 }
 
 /**
- * The roster is the latest poll and nothing more: each provider's most recent
+ * The roster is the latest pass and nothing more: each provider's most recent
  * observation, normalized, merged into one list for the panel, the brain, and
  * action validation. Nothing here detects a change — no field comparators, no
  * revision, no retention of sessions a provider stopped reporting. A session
@@ -50,9 +51,11 @@ export class SessionRoster {
       );
   }
 
-  subscribe(listener: SessionRosterListener): () => void {
+  subscribe(listener: SessionRosterListener): IDisposable {
     this.#listeners.add(listener);
-    return () => this.#listeners.delete(listener);
+    return toDisposable(() => {
+      this.#listeners.delete(listener);
+    });
   }
 
   /**
@@ -84,7 +87,7 @@ export class SessionRoster {
   }
 
   /** Reads one provider's pass and takes its newest full observation as that provider's sessions. */
-  async refresh(
+  async pass(
     plugin: Pick<SessionProviderPlugin, "provider" | "observe">,
     transform?: SessionObservationTransform,
   ): Promise<readonly Session[]> {

--- a/packages/session/src/workspace-opens.ts
+++ b/packages/session/src/workspace-opens.ts
@@ -5,7 +5,7 @@ import type { Session } from "./session-shape.js";
  * How long a created workspace stays worth opening. The identity arrives the
  * moment its creation is accepted, but the address only exists once an
  * observation pass reports the new session with a link — usually the very next
- * pass, though a cloud provider's refresh floor and an eventually-consistent
+ * pass, though a cloud provider's pass floor and an eventually-consistent
  * listing can each add one more. Past this window the open would no longer
  * read as the answer to the ask that created it, so the entry lapses and the
  * workspace stays where every other session starts: on its row, unopened.

--- a/packages/voice/src/capability-assembler.ts
+++ b/packages/voice/src/capability-assembler.ts
@@ -15,6 +15,7 @@ import {
   VOICE_SOURCE,
   type VoiceSource,
 } from "@sidecar/settings";
+import { type IDisposable, toDisposable } from "@sidecar/wire";
 import { openAiRealtimeCredentials, unavailableRealtimeDiagnostics } from "./openai-credentials.js";
 import { hostedRealtimeCredentialMinter, type RealtimeCredentialMinter } from "./service-mint.js";
 
@@ -141,13 +142,13 @@ export class VoiceCapabilityAssembler {
   /**
    * Hears every application that published, after its capability set stands,
    * so a reader of the adapters can follow a credential change without
-   * polling. Answers the unsubscribe.
+   * polling. Answers the listener's own disposable.
    */
-  onApplied(listener: () => void): () => void {
+  onApplied(listener: () => void): IDisposable {
     this.#applied.add(listener);
-    return () => {
+    return toDisposable(() => {
       this.#applied.delete(listener);
-    };
+    });
   }
 
   get realtimeCredentials(): RealtimeCredentialMinter | undefined {

--- a/packages/voice/src/orchestrator/conversation-thread.test.ts
+++ b/packages/voice/src/orchestrator/conversation-thread.test.ts
@@ -102,7 +102,7 @@ test("a line refused by the store is sent again on the next publish", async () =
   );
 });
 
-test("a Clear retires the turns, the previews, and the generations that outlived it", () => {
+test("a Clear disposes the turns, the previews, and the generations that outlived it", () => {
   const { subject } = thread();
   subject.seed([]);
   subject.openTurn();
@@ -119,7 +119,7 @@ test("a Clear retires the turns, the previews, and the generations that outlived
   assert.equal(subject.previews.size, 0);
   assert.equal(subject.latestTurn, undefined);
   assert.equal(subject.takeAnnouncementGeneration(), undefined);
-  // A transcript for the retired turn cannot borrow the newer thread's place.
+  // A transcript for the disposed turn cannot borrow the newer thread's place.
   subject.rememberSpokenAsk("how is the checkout agent", "item-1");
   assert.deepEqual(subject.entries, []);
 });

--- a/packages/voice/src/orchestrator/conversation-thread.ts
+++ b/packages/voice/src/orchestrator/conversation-thread.ts
@@ -59,8 +59,8 @@ export interface ConversationThreadOptions {
 /**
  * The spoken conversation this launch leaves behind, held apart from the call
  * that transported any of it: a call is a transport that comes and goes —
- * Luke's own is torn down by the talk key on its way to the developer's, and
- * an idle one retires — while the thread stands for as long as the window
+ * Luke's own is disposed by the talk key on its way to the developer's, and an
+ * idle one disposes itself — while the thread stands for as long as the window
  * does. It owns the lines, the generation a Clear advances, the marks that
  * say where a spoken turn belongs when its transcript comes back on the
  * service's own clock, and the previews drawn while it is still arriving.
@@ -180,7 +180,7 @@ export class ConversationThread {
 
   /**
    * The Clear a panel pressed, already carried out by the main process,
-   * arriving here to retire this window's in-flight turns the way the press
+   * arriving here to dispose this window's in-flight turns the way the press
    * would have.
    */
   clear(): void {
@@ -195,7 +195,7 @@ export class ConversationThread {
     this.#latestMark = undefined;
     this.#activeMark = undefined;
     // The previews go with the marks: a transcription still arriving belongs
-    // to a turn the press just retired.
+    // to a turn the press just disposed.
     this.#previews = NO_SPOKEN_ASK_PREVIEWS;
     this.#replyGeneration = undefined;
     this.#announcementGeneration = undefined;

--- a/packages/voice/src/orchestrator/reply-delivery-player.test.ts
+++ b/packages/voice/src/orchestrator/reply-delivery-player.test.ts
@@ -142,7 +142,7 @@ test("a withdrawn generation while the call is opening leaves the words unspoken
   assert.deepEqual(h.log.at(-1), "claim run-2@1");
 });
 
-test("a newer offer arriving during a claim retires the older attempt without speaking it", async () => {
+test("a newer offer arriving during a claim disposes the older attempt without speaking it", async () => {
   const h = harness();
   h.player.offer(offer("run-1"));
   h.player.offer(offer("run-2"));

--- a/packages/voice/src/orchestrator/voice-orchestrator.test.ts
+++ b/packages/voice/src/orchestrator/voice-orchestrator.test.ts
@@ -187,7 +187,7 @@ test("the meter is pointed at whoever holds the turn, and the element at Luke", 
   assert.deepEqual(seen.at(-1), [undefined, "luke"]);
 });
 
-test("a Clear retires the latch, so the next press opens a turn rather than ending one", async () => {
+test("a Clear disposes the latch, so the next press opens a turn rather than ending one", async () => {
   const { subject, calls } = orchestrator();
   await subject.beginTalk();
   const conversation = calls.conversation;

--- a/packages/voice/src/orchestrator/voice-orchestrator.ts
+++ b/packages/voice/src/orchestrator/voice-orchestrator.ts
@@ -438,9 +438,9 @@ export class VoiceOrchestrator<Stream> {
 
   /**
    * The Clear a panel pressed, already carried out by the main process,
-   * arriving here to retire this window's in-flight turns the way the press
+   * arriving here to dispose this window's in-flight turns the way the press
    * would have. The talk key's latch goes with them: a turn the press just
-   * retired is not one the next press ends.
+   * disposed is not one the next press ends.
    */
   clearConversation(): void {
     this.#thread.clear();
@@ -523,8 +523,8 @@ export class VoiceOrchestrator<Stream> {
   /**
    * The call Luke opens for himself. A stood-down call cannot be recalled
    * mid-handshake: a mint already out lands when it lands, and the abandon
-   * that follows tears the attempt down and reports it. Reported to the
-   * window, that teardown would clear the remote stream the developer's call
+   * that follows disposes the attempt and reports it. Reported to the
+   * window, that disposal would clear the remote stream the developer's call
    * had already put there, and a late failure of Luke's own call would be
    * drawn as theirs. So the speak-only call is heard only while no
    * conversation call has taken over, which is exactly when standing it down

--- a/packages/wire/src/lifecycle.test.ts
+++ b/packages/wire/src/lifecycle.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { DisposableStore, disposeAll, toDisposable } from "./lifecycle.js";
 
-test("a wrapped teardown runs at most once however often it is disposed", () => {
+test("a wrapped dispose runs at most once however often it is disposed", () => {
   let runs = 0;
   const disposable = toDisposable(() => {
     runs += 1;

--- a/packages/wire/src/lifecycle.ts
+++ b/packages/wire/src/lifecycle.ts
@@ -1,6 +1,6 @@
 /**
  * One word for the end of a thing's life. A listener's unsubscribe, a watcher's
- * teardown, a timer's cancellation, and a store of all three are the same
+ * dispose, a timer's cancellation, and a store of all three are the same
  * shape, so a composition can hold what it created without knowing what any of
  * it was.
  */
@@ -9,7 +9,7 @@ export interface IDisposable {
 }
 
 /**
- * Wraps a teardown callback, which runs at most once however many times
+ * Wraps a dispose callback, which runs at most once however many times
  * `dispose()` is called. A callback that ran again on the second call would
  * make every double-dispose a bug the caller has to prevent, and the whole
  * point of handing an unsubscribe to a `DisposableStore` is that the caller
@@ -30,7 +30,7 @@ export function toDisposable(run: () => void): IDisposable {
 
 /**
  * Disposes every entry in iteration order, and lets a thrower stop none of the
- * rest: one owner's failed teardown must not leave its siblings alive. The
+ * rest: one owner's failed dispose must not leave its siblings alive. The
  * failures are reported together once the round is complete, as a single
  * `AggregateError` whatever their number, so a caller catches one shape rather
  * than deciding at run time whether it holds the failure or a bag of them.
@@ -55,7 +55,7 @@ export function disposeAll(disposables: Iterable<IDisposable>): void {
  * Holds what a composition created so one `dispose()` ends all of it, in the
  * reverse of the order it was added: the later entry is the one that may still
  * be reading the earlier, so unwinding a construction backwards is what keeps
- * a teardown from reaching through something already gone.
+ * a dispose from reaching through something already gone.
  */
 export class DisposableStore implements IDisposable {
   #held: IDisposable[] = [];

--- a/packages/wire/src/testing/temporary-directory.ts
+++ b/packages/wire/src/testing/temporary-directory.ts
@@ -8,7 +8,7 @@ import type { TestContext } from "node:test";
  * seeds a provider home needs one, and a test that forgets to remove it leaves
  * a machine's temporary directory holding fixture trees for as long as it
  * stands — so the removal is registered before the path is handed back rather
- * than left to the caller's own teardown. Synchronous, so a fixture assembled
+ * than left to the caller's own dispose. Synchronous, so a fixture assembled
  * outside an async helper can have one.
  */
 export function temporaryDirectory(t: TestContext, prefix = "luke-"): string {


### PR DESCRIPTION
## What this is

PR 2 of the cleanup stack, and **the one pure-rename PR in the stack — no behavior change anywhere.** Builds on PR 1 (#871, `@sidecar/wire`'s `IDisposable`/`DisposableStore`/`Emitter`/`Event`, already on main).

First, wrote the glossary into `packages/AGENTS.md` as a new "One word per concept" section — the repo's standing word list.

Then applied it across `packages/**`, `apps/web`, `tools/`, and desktop **main/shared/preload** — never `apps/desktop/src/renderer/**`, which a later PR does once its own inventory is taken.

## What changed

- **`retire`/`teardown`/`destroy`/`shutdown` → `dispose`** — ~250 lines across ~45 files (identifiers, types, comments, test names), including a file rename: `packages/gateway/src/shutdown.ts` → `dispose.ts` (`shutdownGateway` → `disposeGateway`, `GatewayShutdownSteps/Options/Report` → `GatewayDispose*`). The wire-protocol method name `GATEWAY_METHOD.SHUTDOWN` (`"gateway.shutdown"`) is untouched — that's client-visible wire vocabulary, not ours to rename. `apps/desktop/src/main/services/lifecycle.ts`'s `stopInReverse` now builds a `DisposableStore` (see note below).
- **`abort` → `cancel`** — ~75 lines across ~22 files, except real `AbortSignal`/`AbortController` usage and OMP's own wire vocabulary (`OMP_STOP_REASON.ABORTED`), which keep their vocabulary. `packages/brain/src/asks.ts`'s `abortAll()` became **`interruptAll()`**, not `cancelAll()` — it's a deliberately distinct concept from developer-initiated cancel (agent-stopping-itself vs. developer-stopping-it), already backed by its own `BRAIN_REQUEST_STATUS.INTERRUPTED`; merging the two words would have merged two different concepts.
- **`poll`/`refresh`/`observe` → `pass`** — ~230 lines across ~30 files, narrowly scoped to the one-observation-pass concept (`ObservationLoop.refresh`→`pass`, `SessionRoster.refresh`→`pass`, the calendar/issue/Superset/Conductor observation cadences). Left untouched: OAuth/credential refresh tokens, the generic Observer/listener pattern, wire/protocol method and route names (`CALENDAR_REFRESH`, `/api/observe`), the Conductor conversation-cursor "poll" (a deliberately distinct concept per its own comments), and analytics event names.
- **`resolve` → `settle`** — ~50 lines across ~13 files, narrowly scoped to a promise/queued-work ledger reaching its outcome (`PendingInvocations.resolve`, the websocket/store-client pending-request ledgers, `persistUnresolved`/`unresolved` → `persistUnsettled`/`unsettled`). `resolve` stays for configuration, path, and module resolution, and for transient inline `new Promise((resolve, reject) => ...)` executors that aren't named abstractions.
- **A returned `() => void` unsubscribe → `IDisposable`** — ~35 declarations and their capturing call sites (gateway's whole event/registration surface, `BrainStateStore.onReplaced`, `BrainAgent`/`AskLedger.subscribe`, `SessionRoster.subscribe`, `VoiceReceiver.onReady`/`onReset`, `HostOperator`'s 11 members, `AppStateStore.subscribe`, etc.). `apps/desktop/src/main/services/operator-client.ts`'s 11-entry `unsubscribers: (() => void)[]` array is now a `DisposableStore`.

## Deliberate scope decisions

- **`SessionProviderPlugin.observe()` is left unrenamed**, everywhere (all 6 provider implementations). Renaming it to `pass()` would collide with `SupersetPlugin`'s own `refresh(defaultAgent)` method on the same object, which **is** renamed to `pass(defaultAgent)` — the real "one pass over Superset's own state" per its doc comment. Resolving that collision by redesigning Superset's plugin shape is out of scope for a pure-rename PR.
- **Two renderer-only seams keep their `() => void` shape**: `VoiceOrchestrator.subscribe` (packages/voice) and the preload IPC listener wrapper (`apps/desktop/src/preload/index.ts` / `apps/desktop/src/shared/bridge.ts`'s `DerivedAppBridge`). Both were converted to `IDisposable` initially, but their only consumers live in `apps/desktop/src/renderer/**`, which this PR must not touch — converting them broke the desktop's typecheck across that boundary, so they're reverted to `() => void` here and flagged for the renderer-inventory PR.

## `apps/desktop/src/main/services/lifecycle.ts`'s `stopInReverse`

Now builds a `DisposableStore`: each service's stop is wrapped in `toDisposable`, which schedules it onto a promise chain rather than awaiting inline (since `DisposableStore.dispose()` is synchronous but a service's `stop()` is async). Disposing the store synchronously builds the chain in the same reverse order a plain loop would have awaited it in, so the later service's stop still finishes before the earlier one's begins — sequential completion is load-bearing here (services unwind in the reverse of their start order specifically so one is never stopped while a later one might still be reading it) and is preserved and tested (`services.test.ts`'s ordering assertion, unchanged, still passes).

## Doc sentences fixed

- `packages/AGENTS.md`: added the "One word per concept" glossary section; fixed the wire-lifecycle sentence ("a watcher's teardown" → "dispose").
- `AGENTS.md` (root, `CLAUDE.md` symlink target): "the conversation's brain retired" → "disposed"; "a call retired idle" → "disposed idle".
- `packages/host/AGENTS.md`: "a shutdown never fabricates a completion" → "a dispose never..."; "written down as unresolved" → "as unsettled".

## Verification

`./scripts/check.sh` is green: lint (Biome + oxlint), typecheck, test, and build all pass across all 25 workspace packages/apps/tools, plus the design and repository contract checks. Full output:

```
Design contract checks passed.
Repository contract checks passed.

lint: biome check . && pnpm oxlint — clean
typecheck: all 25 packages/apps/tools — Done, 0 errors
test: all 25 packages/apps/tools — Done, 0 failures
  (apps/desktop: 677/677; packages/host: 285/285; packages/brain: 335/335;
   packages/gateway: 39/39; packages/providers: 468/468; packages/actions:
   60/60; packages/voice: 118/118; apps/web: 349/349; and 17 more, all green)
build: apps/web + apps/desktop — Done
```

`./scripts/verify.sh` needs a Mac and was not run — this change touches no UI, renderer, or platform-specific code, so it should be a no-op there, but the developer should confirm.

## The two required review passes

**Thermonuclear code quality review** (structural simplification, file-size, spaghetti, boundary cleanliness): no findings against the mechanical renames themselves — no branching, casts, or optionality were added, no file crossed the 1000-line threshold because of this PR (checked: files already over 1000 lines pre-date it, net line deltas there are ~0). One honest flag against my own work: `lifecycle.ts`'s `stopInReverse` rewrite (above) is less direct than the four-line reversed-`for`-loop it replaced — the added indirection (a `DisposableStore` plus a manually-chained promise) exists only to satisfy the task's explicit instruction that this function "becomes a `DisposableStore`," not because the simpler loop was wrong. Kept as instructed; behavior is unchanged and covered by the existing ordering test.

**Ponytail review** (over-engineering, delete/stdlib/native/yagni/shrink): same finding as above is the one "shrink" candidate in the diff — same logic, fewer lines available via the original loop. Everything else nets out at effectively zero lines of new logic; the `operator-client.ts` `DisposableStore` conversion trades one `.push(...)` call with 11 arguments for 11 separate `.add(...)` calls, which looks like more lines but is the only shape `DisposableStore.add()`'s single-argument signature allows — not over-engineering, just the primitive's contract. Nothing else to cut.

## Not done here (by design)

Widening this rename into `apps/desktop/src/renderer/**` — that's the next PR's inventory to take.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/681967a8-e378-468c-9f21-abdf7cb39acf)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34420692139/artifacts/10130840687) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34420692139)

- Commit: `acd7fff360ccb91965d4a99765ec33149470b663`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
