### PR TITLE
fix(actions): a creation's line says what was created, in the provider's own name

### DIFF
--- a/packages/actions/src/action-narration.ts
+++ b/packages/actions/src/action-narration.ts
@@ -8,6 +8,7 @@ import type {
   CONVERSATION_ENTRY_KIND,
   ConversationEntry,
   ConversationEntryAction,
+  ObservedWorkspaceProject,
   Session,
   SessionApplicationId,
   SessionIdentity,
@@ -18,6 +19,23 @@ import {
   type CarriedAction,
   type CarriedSessionAction,
 } from "./action-kinds.js";
+
+/**
+ * What the narration names things by: the roster the action was admitted
+ * against, and the projects a provider listed on the same pass, which is
+ * where a creation's provider has a display name at all.
+ */
+export interface ActionNarrationContext {
+  sessions: readonly Session[];
+  projects: readonly ObservedWorkspaceProject[];
+}
+
+function observedProviderName(
+  providerId: string,
+  projects: readonly ObservedWorkspaceProject[],
+): string {
+  return projects.find((project) => project.providerId === providerId)?.providerName ?? providerId;
+}
 
 function observedSessionName(identity: SessionIdentity, sessions: readonly Session[]): string {
   const session = sessions.find(
@@ -45,23 +63,25 @@ function observedApplicationName(
 }
 
 const ACTION_NARRATION = {
-  [ACTION_KIND.MESSAGE]: (action, sessions) =>
+  [ACTION_KIND.MESSAGE]: (action, { sessions }) =>
     `sent a message to ${observedSessionName(action.identity, sessions)}: "${action.text}"`,
-  [ACTION_KIND.CONTROL]: (action, sessions) =>
+  [ACTION_KIND.CONTROL]: (action, { sessions }) =>
     `ran "${action.control.label}" on ${observedSessionName(action.identity, sessions)}`,
-  [ACTION_KIND.OPEN]: (action, sessions) => {
+  [ACTION_KIND.OPEN]: (action, { sessions }) => {
     const name = observedSessionName(action.identity, sessions);
     return action.applicationId
       ? `opened ${name} in ${observedApplicationName(action.identity, action.applicationId, sessions)}`
       : `opened ${name}`;
   },
-  [ACTION_KIND.CREATE_WORKSPACE]: (action) =>
-    `asked ${action.providerId} to create a workspace${action.name ? ` named "${action.name}"` : ""}`,
-  [ACTION_KIND.ADD_AGENT]: (action, sessions) =>
+  // The past tense every other kind uses: the line records the act, and the
+  // reply voicing the outcome is its own line.
+  [ACTION_KIND.CREATE_WORKSPACE]: (action, { projects }) =>
+    `created a new workspace${action.name ? ` "${action.name}"` : ""} in ${observedProviderName(action.providerId, projects)}`,
+  [ACTION_KIND.ADD_AGENT]: (action, { sessions }) =>
     `added a ${action.agent} agent to ${observedSessionName(action.identity, sessions)}`,
-  [ACTION_KIND.RENAME_WORKSPACE]: (action, sessions) =>
+  [ACTION_KIND.RENAME_WORKSPACE]: (action, { sessions }) =>
     `renamed the workspace of ${observedSessionName(action.identity, sessions)} to "${action.name}"`,
-  [ACTION_KIND.RENAME_SESSION]: (action, sessions) =>
+  [ACTION_KIND.RENAME_SESSION]: (action, { sessions }) =>
     `renamed ${observedSessionName(action.identity, sessions)} to "${action.name}"`,
   [ACTION_KIND.ISSUE_STATE]: (action) =>
     `moved issue ${action.identity.identifier} to "${action.transition.name}"`,
@@ -76,17 +96,17 @@ const ACTION_NARRATION = {
       : `remembered "${action.words}"`,
   [ACTION_KIND.FORGET]: () => "forgot something remembered before",
 } as const satisfies {
-  [K in ActionKind]: (action: CarriedAction<K>, sessions: readonly Session[]) => string;
+  [K in ActionKind]: (action: CarriedAction<K>, context: ActionNarrationContext) => string;
 };
 
 /** The Conversation sentence declared by the same vocabulary that declared the action. */
-export function actionNarration(action: CarriedAction, sessions: readonly Session[]): string {
+export function actionNarration(action: CarriedAction, context: ActionNarrationContext): string {
   const narrate = ACTION_NARRATION[action.kind];
   // SAFETY: the record is keyed by the same union `action.kind` ranges over, so the
   // entry selected is the one written for this action's own shape.
-  return (narrate as (action: CarriedAction, sessions: readonly Session[]) => string)(
+  return (narrate as (action: CarriedAction, context: ActionNarrationContext) => string)(
     action,
-    sessions,
+    context,
   );
 }
 
@@ -105,11 +125,11 @@ export function actionNarration(action: CarriedAction, sessions: readonly Sessio
  */
 export function sessionActionConversationEntry(
   action: CarriedSessionAction,
-  sessions: readonly Session[],
+  context: ActionNarrationContext,
   kind: typeof CONVERSATION_ENTRY_KIND.ACTION | typeof CONVERSATION_ENTRY_KIND.OWN_ACTION,
   runId: string,
 ): ConversationEntry {
-  const words = actionNarration(action, sessions);
+  const words = actionNarration(action, context);
   const carried: ConversationEntryAction = { kind: action.kind, runId };
   if (action.kind === ACTION_KIND.CREATE_WORKSPACE) carried.providerId = action.providerId;
   const entry: ConversationEntry = { kind, words, action: carried };

--- a/packages/actions/src/actions.test.ts
+++ b/packages/actions/src/actions.test.ts
@@ -9,6 +9,7 @@ import {
   SESSION_APPLICATION_ID,
   SESSION_APPLICATION_SCOPE,
   SESSION_STATUS,
+  WORKSPACE_TASK_SUPPORT,
 } from "@sidecar/session";
 import { ACTION_RESULT_STATUS } from "@sidecar/wire";
 import { ACTION_KIND } from "./action-kinds.js";
@@ -54,7 +55,7 @@ test("a setting action narrates the setting label and accepted value", async () 
         },
         value: "on",
       },
-      [],
+      { sessions: [], projects: [] },
     ),
     "changed Captions to on",
   );
@@ -220,11 +221,20 @@ function rosterSession(providerSessionId: string, title: string) {
 
 test("an action's line records the ask in words, with the identity it named", () => {
   const sessions = [rosterSession("session-a", "checkout-service")];
+  const projects = [
+    {
+      providerId: "conductor",
+      providerName: "Conductor",
+      providerProjectId: "p1",
+      repository: "luke",
+      taskSupport: WORKSPACE_TASK_SUPPORT.OPTIONAL,
+    },
+  ];
   const identity = { providerId: "claude-code", providerSessionId: "session-a" };
 
   const message = sessionActionConversationEntry(
     { kind: ACTION_KIND.MESSAGE, identity, text: "please add tests" },
-    sessions,
+    { sessions, projects },
     CONVERSATION_ENTRY_KIND.ACTION,
     "run-1",
   );
@@ -238,7 +248,7 @@ test("an action's line records the ask in words, with the identity it named", ()
   assert.equal(
     sessionActionConversationEntry(
       { kind: ACTION_KIND.CONTROL, identity, control },
-      sessions,
+      { sessions, projects },
       CONVERSATION_ENTRY_KIND.ACTION,
       "run-1",
     ).words,
@@ -249,7 +259,7 @@ test("an action's line records the ask in words, with the identity it named", ()
   assert.equal(
     sessionActionConversationEntry(
       { kind: ACTION_KIND.OPEN, identity },
-      [],
+      { sessions: [], projects },
       CONVERSATION_ENTRY_KIND.ACTION,
       "run-1",
     ).words,
@@ -283,25 +293,30 @@ test("an action's line records the ask in words, with the identity it named", ()
   assert.equal(
     sessionActionConversationEntry(
       openedInApp,
-      [heldByApp],
+      { sessions: [heldByApp], projects },
       CONVERSATION_ENTRY_KIND.ACTION,
       "run-1",
     ).words,
     'opened "checkout-service" in Superset',
   );
   assert.equal(
-    sessionActionConversationEntry(openedInApp, [], CONVERSATION_ENTRY_KIND.ACTION, "run-1").words,
+    sessionActionConversationEntry(
+      openedInApp,
+      { sessions: [], projects },
+      CONVERSATION_ENTRY_KIND.ACTION,
+      "run-1",
+    ).words,
     "opened a session in superset",
   );
 
   // A workspace creation aims at no session, so its line carries no identity.
   const created = sessionActionConversationEntry(
     { kind: ACTION_KIND.CREATE_WORKSPACE, providerId: "conductor", providerProjectId: "p1" },
-    sessions,
+    { sessions, projects },
     CONVERSATION_ENTRY_KIND.ACTION,
     "run-1",
   );
-  assert.equal(created.words, "asked conductor to create a workspace");
+  assert.equal(created.words, "created a new workspace in Conductor");
   assert.equal(created.identity, undefined);
   // With no identity to name it, the creation's line names the provider it asked.
   assert.deepEqual(created.action, {
@@ -316,12 +331,9 @@ test("an action's line records the ask in words, with the identity it named", ()
       providerProjectId: "p1",
       name: "Notch panel clipping",
     },
-    sessions,
+    { sessions, projects },
     CONVERSATION_ENTRY_KIND.ACTION,
     "run-1",
   );
-  assert.equal(
-    createdNamed.words,
-    'asked conductor to create a workspace named "Notch panel clipping"',
-  );
+  assert.equal(createdNamed.words, 'created a new workspace "Notch panel clipping" in Conductor');
 });

--- a/packages/host/src/brain/action-performer.ts
+++ b/packages/host/src/brain/action-performer.ts
@@ -148,7 +148,7 @@ export function createBrainActionPerformer(
     dependencies.recordConversationEntry(
       sessionActionConversationEntry(
         action,
-        dependencies.sessions(),
+        { sessions: dependencies.sessions(), projects: dependencies.workspaceProjects() },
         execution.origin === RUN_ORIGIN.USER
           ? CONVERSATION_ENTRY_KIND.ACTION
           : CONVERSATION_ENTRY_KIND.OWN_ACTION,


### PR DESCRIPTION
Stacked on #882.

A workspace creation's conversation line read `asked conductor to create a workspace named "XYZ"`: the one kind narrated as an ask rather than an act, and the one naming its provider by raw id while an open names an application by its roster display name ("in Conductor").

It now reads `created a new workspace "XYZ" in Conductor`. The past tense is the one every other kind already uses ("sent", "ran", "opened"): the line records the act, and the reply voicing the outcome is its own line. The provider's display name comes from the projects the same observation pass listed, which the narration now takes beside the roster as one context; a provider with no listed project falls back to its id.

Verification: typecheck clean; actions 60 and host 285 tests pass, with the two wording assertions moved to the new sentence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/edd416a9-4048-4f0a-ac6d-fdae20bd92f6)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34425282511/artifacts/10132478467) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34425282511)

- Commit: `33a85d0c1e943d5bb3f3499eb056571934a11819`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
