### PR TITLE
fix(host): record a carried action's line once its effect has settled

### DIFF
--- a/packages/host/src/brain/action-performer.test.ts
+++ b/packages/host/src/brain/action-performer.test.ts
@@ -21,7 +21,7 @@ import {
   type Session,
   WORKSPACE_TASK_SUPPORT,
 } from "@sidecar/session";
-import { ACTION_RESULT_STATUS } from "@sidecar/wire";
+import { ACTION_RESULT_STATUS, UNKNOWN_ACTION_STATUS } from "@sidecar/wire";
 import {
   type BrainActionPerformerDependencies,
   createBrainActionPerformer,
@@ -172,7 +172,7 @@ test("a session action reaches the performer only for a session the roster holds
   assert.equal(landed.status, ACTION_RESULT_STATUS.ACCEPTED);
   assert.equal(performed.length, 1);
   assert.equal(performed[0]?.kind, "message");
-  // The ask is recorded as the developer's, before the outcome is known, and
+  // The act is recorded as the developer's once the provider accepted it, and
   // names the run that carried it, so the panel can fold the turn's actions.
   assert.equal(recorded.length, 1);
   assert.equal(recorded[0]?.kind, "action");
@@ -193,6 +193,34 @@ test("a session action reaches the performer only for a session the roster holds
     status: ACTION_RESULT_STATUS.REJECTED,
     reason: "No such tool exists.",
   });
+});
+
+test("a session action the provider refused leaves no line, and one whose answer never came back does", async () => {
+  const refusing = performer({
+    sessionActions: {
+      perform: async () => ({ status: ACTION_RESULT_STATUS.REJECTED, reason: "Not now." }),
+      openSession: async () => ({ status: ACTION_RESULT_STATUS.ACCEPTED }),
+      openSessionApplication: async () => ({ status: ACTION_RESULT_STATUS.ACCEPTED }),
+      openSessionChange: async () => ({ status: ACTION_RESULT_STATUS.ACCEPTED }),
+    },
+  });
+  const refused = await refusing.actions.perform(MESSAGE_CALL, LIVE);
+  assert.equal(refused.status, ACTION_RESULT_STATUS.REJECTED);
+  assert.deepEqual(refusing.recorded, []);
+
+  const uncertain = performer({
+    sessionActions: {
+      perform: async () => ({ status: UNKNOWN_ACTION_STATUS, reason: "The connection closed." }),
+      openSession: async () => ({ status: ACTION_RESULT_STATUS.ACCEPTED }),
+      openSessionApplication: async () => ({ status: ACTION_RESULT_STATUS.ACCEPTED }),
+      openSessionChange: async () => ({ status: ACTION_RESULT_STATUS.ACCEPTED }),
+    },
+  });
+  const unknown = await uncertain.actions.perform(MESSAGE_CALL, LIVE);
+  assert.equal(unknown.status, UNKNOWN_ACTION_STATUS);
+  // The act may have landed, so the thread says it was taken; the reply carries the doubt.
+  assert.equal(uncertain.recorded.length, 1);
+  assert.equal(uncertain.recorded[0]?.kind, "action");
 });
 
 test("an issue action is refused outright while no tracker is connected", async () => {

--- a/packages/host/src/brain/action-performer.ts
+++ b/packages/host/src/brain/action-performer.ts
@@ -23,7 +23,12 @@ import {
   type Session,
   workspaceAgentModels,
 } from "@sidecar/session";
-import { ACTION_RESULT_STATUS, isWireString, type WireRecord } from "@sidecar/wire";
+import {
+  ACTION_RESULT_STATUS,
+  isWireString,
+  UNKNOWN_ACTION_STATUS,
+  type WireRecord,
+} from "@sidecar/wire";
 import type { SessionActionPerformer } from "../session-action-performer.js";
 
 /** The developer's saved creation tie-breaks, as the projects context narrates them. */
@@ -138,26 +143,34 @@ export function createBrainActionPerformer(
     };
   };
 
-  const carrySessionAction = (
+  const carrySessionAction = async (
     action: ValidatedAction<SessionActionKind>,
     execution: BrainActionExecution,
   ): Promise<WireRecord> => {
-    // The ask is recorded before the outcome is known: a refusal still leaves
-    // the developer having asked it, and the reply voicing the outcome is
-    // recorded as what Luke said.
-    dependencies.recordConversationEntry(
-      sessionActionConversationEntry(
-        action,
-        { sessions: dependencies.sessions(), projects: dependencies.workspaceProjects() },
-        execution.origin === RUN_ORIGIN.USER
-          ? CONVERSATION_ENTRY_KIND.ACTION
-          : CONVERSATION_ENTRY_KIND.OWN_ACTION,
-        execution.runId,
-      ),
-    );
     // The performer awaits once more of its own before a create or a spawn,
     // so the execution rides along to be asked again there.
-    return dependencies.sessionActions.perform(action, execution);
+    const result = await dependencies.sessionActions.perform(action, execution);
+    // The line records the act, in the past tense, so it is written once the
+    // effect has settled: a provider that accepted it, or one whose answer
+    // never came back, so the act may have landed. A provider that refused it
+    // leaves no line — nothing was done — and the reply voicing the refusal is
+    // recorded as what Luke said.
+    if (
+      result.status === ACTION_RESULT_STATUS.ACCEPTED ||
+      result.status === UNKNOWN_ACTION_STATUS
+    ) {
+      dependencies.recordConversationEntry(
+        sessionActionConversationEntry(
+          action,
+          { sessions: dependencies.sessions(), projects: dependencies.workspaceProjects() },
+          execution.origin === RUN_ORIGIN.USER
+            ? CONVERSATION_ENTRY_KIND.ACTION
+            : CONVERSATION_ENTRY_KIND.OWN_ACTION,
+          execution.runId,
+        ),
+      );
+    }
+    return result;
   };
 
   return {


### PR DESCRIPTION
Stacked on #889, which is stacked on #882.

A carried action's conversation line was written before the provider answered. With the line now worded as the act ("created a new workspace …", "sent a message …"), that meant a creation read as done while it was still being asked, and an action the provider refused still left a line saying it had happened.

The performer now awaits the effect and records the line only for an action the provider accepted, or one whose answer never came back and so may have landed (the unknown outcome, whose doubt the reply already voices). A refused action leaves no line: nothing was done, and the reply voicing the refusal is recorded as what Luke said. This is the same rule for every kind, so a creation lands in the thread when it completes, like a message or an open.

Verification: typecheck clean; host 286 tests pass, with new cases for a refused perform (no line) and an unknown one (a line).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/edd416a9-4048-4f0a-ac6d-fdae20bd92f6)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34425282377/artifacts/10132488826) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34425282377)

- Commit: `421c7a31db78d06b8b5311db8eaa58915f8f8e81`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
