### PR TITLE
fix(brain): keep every message a run said, and draw its reply once

### DIFF
--- a/apps/desktop/src/renderer/voice/captions.test.ts
+++ b/apps/desktop/src/renderer/voice/captions.test.ts
@@ -1,11 +1,12 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { REPLY_KIND, type ReplyKind } from "@sidecar/voice/orchestrator";
-import { CAPTION_SEGMENT_LIMIT, CaptionStrip } from "./captions";
+import { CaptionStrip } from "./captions";
 
 interface Drawn {
   texts: readonly string[] | undefined;
   kind: ReplyKind | undefined;
+  runId: string | undefined;
 }
 
 interface Ended {
@@ -25,7 +26,7 @@ function harness(): Harness {
   const ended: Ended[] = [];
   return {
     strip: new CaptionStrip({
-      onCaption: (texts, kind) => drawn.push({ texts, kind }),
+      onCaption: (texts, kind, runId) => drawn.push({ texts, kind, runId }),
       onReplyEnded: (texts, kind, runId) => ended.push({ texts, kind, runId }),
     }),
     drawn,
@@ -76,12 +77,29 @@ test("an item's transcript lands on its own segment after the turn has moved pas
   assert.deepEqual(latest(context.drawn)?.texts, ["Looking now.", "Two agents are waiting."]);
 });
 
-test("only the newest segments stay up", () => {
+test("every segment stays until the reply ends, and the whole reply is handed over", () => {
   const context = harness();
+  context.strip.mark(REPLY_KIND.BRIEFING);
   for (const index of [1, 2, 3, 4]) context.strip.append(`item-${index}`, `Sentence ${index}.`);
 
-  assert.equal(latest(context.drawn)?.texts?.length, CAPTION_SEGMENT_LIMIT);
-  assert.deepEqual(latest(context.drawn)?.texts, ["Sentence 3.", "Sentence 4."]);
+  // How many the housing draws is the surface's own limit; the record is
+  // owed every message the reply said.
+  assert.deepEqual(latest(context.drawn)?.texts, [
+    "Sentence 1.",
+    "Sentence 2.",
+    "Sentence 3.",
+    "Sentence 4.",
+  ]);
+
+  context.strip.end();
+
+  assert.deepEqual(context.ended, [
+    {
+      texts: ["Sentence 1.", "Sentence 2.", "Sentence 3.", "Sentence 4."],
+      kind: REPLY_KIND.BRIEFING,
+      runId: undefined,
+    },
+  ]);
 });
 
 test("a transcript whose item holds no segment writes nothing", () => {
@@ -117,19 +135,34 @@ test("ending hands the words over once, then empties", () => {
   assert.deepEqual(context.ended, [
     { texts: ["Two agents are waiting."], kind: REPLY_KIND.BRIEFING, runId: undefined },
   ]);
-  assert.deepEqual(latest(context.drawn), { texts: undefined, kind: undefined });
+  assert.deepEqual(latest(context.drawn), { texts: undefined, kind: undefined, runId: undefined });
 });
 
 test("the kind and the run are the reply's, and leave with it", () => {
   const context = harness();
   context.strip.mark(REPLY_KIND.REPLY, "run-7");
   assert.equal(context.strip.kinded, true);
-  assert.deepEqual(latest(context.drawn), { texts: undefined, kind: REPLY_KIND.REPLY });
+  assert.deepEqual(latest(context.drawn), {
+    texts: undefined,
+    kind: REPLY_KIND.REPLY,
+    runId: "run-7",
+  });
+
+  // The words draw under the run they voice, so a live line can tell a reply
+  // the thread already holds from one it is still owed.
+  context.strip.append("item-1", "Checkout is nearly done.");
+  assert.deepEqual(latest(context.drawn), {
+    texts: ["Checkout is nearly done."],
+    kind: REPLY_KIND.REPLY,
+    runId: "run-7",
+  });
 
   context.strip.end();
 
   assert.equal(context.strip.kinded, false);
-  assert.deepEqual(context.ended, [{ texts: [], kind: REPLY_KIND.REPLY, runId: "run-7" }]);
+  assert.deepEqual(context.ended, [
+    { texts: ["Checkout is nearly done."], kind: REPLY_KIND.REPLY, runId: "run-7" },
+  ]);
 });
 
 test("a reply that said nothing and named no run hands nothing over", () => {
@@ -148,6 +181,6 @@ test("discarding empties without admitting anything to Conversation", () => {
   context.strip.discard();
 
   assert.deepEqual(context.ended, []);
-  assert.deepEqual(latest(context.drawn), { texts: undefined, kind: undefined });
+  assert.deepEqual(latest(context.drawn), { texts: undefined, kind: undefined, runId: undefined });
   assert.equal(context.strip.kinded, false);
 });

--- a/apps/desktop/src/renderer/voice/captions.ts
+++ b/apps/desktop/src/renderer/voice/captions.ts
@@ -1,20 +1,18 @@
 import type { ReplyKind } from "@sidecar/voice/orchestrator";
 
-/**
- * How many back-to-back responses the caption keeps on screen at once. Two is
- * the shape the surface stacks — the words just settled and the words now
- * arriving — and a third response starting simply retires the oldest, the way
- * a long reply's oldest lines already roll up under the shape.
- */
-export const CAPTION_SEGMENT_LIMIT = 2;
-
 export interface CaptionStripOptions {
   /**
    * The words Luke is currently speaking, growing as they are generated, or
    * undefined once there is nothing being spoken. Each entry is one response's
-   * words.
+   * words. `runId` names the brain run whose end the words are voicing, when
+   * they are one, so a caller drawing the words can tell a reply the thread
+   * already holds from one it is still owed.
    */
-  onCaption(texts: readonly string[] | undefined, kind: ReplyKind | undefined): void;
+  onCaption(
+    texts: readonly string[] | undefined,
+    kind: ReplyKind | undefined,
+    runId?: string,
+  ): void;
   /**
    * The words a reply leaves behind at the moment it ends — finished, talked
    * over, or the call closing under it, whichever came.
@@ -38,7 +36,10 @@ export class CaptionStrip {
    * spoke it. A turn that speaks twice back-to-back — a second message item,
    * or the follow-up after a tool call — starts a new segment rather than
    * running its words onto the last one's, and an item's own final transcript
-   * can still land on its own segment after the turn has moved on.
+   * can still land on its own segment after the turn has moved on. Every
+   * segment stays until the reply ends, because the handover to Conversation
+   * is owed the whole reply; how many the housing draws is the surface's own
+   * limit, applied where the caption is drawn.
    */
   #segments: { itemId: string | undefined; text: string }[] = [];
   /**
@@ -74,8 +75,7 @@ export class CaptionStrip {
    * Grows the caption with the words just generated. The current item's words
    * grow its own segment; an item taking over from another — the reply's
    * second message, or the follow-up after a tool call — starts a segment of
-   * its own, so two responses stack instead of running together. Only the
-   * newest {@link CAPTION_SEGMENT_LIMIT} stay up.
+   * its own, so two responses stack instead of running together.
    */
   append(itemId: string | undefined, delta: string): void {
     const last = this.#segments.at(-1);
@@ -83,7 +83,6 @@ export class CaptionStrip {
       last.text += delta;
     } else {
       this.#segments.push({ itemId, text: delta });
-      this.#segments = this.#segments.slice(-CAPTION_SEGMENT_LIMIT);
     }
     this.#emit();
   }
@@ -138,6 +137,6 @@ export class CaptionStrip {
   }
 
   #emit(): void {
-    this.#options.onCaption(this.#texts(), this.#kind);
+    this.#options.onCaption(this.#texts(), this.#kind, this.#runId);
   }
 }

--- a/apps/desktop/src/renderer/voice/conversation-call-captions.test.ts
+++ b/apps/desktop/src/renderer/voice/conversation-call-captions.test.ts
@@ -93,7 +93,8 @@ test("back-to-back responses stack as two captions instead of running together",
     "Second response, finished.",
   ]);
 
-  // A third response retires the oldest: only two ever stack.
+  // A third response is kept with the rest: the call reports the whole reply,
+  // and how many of its segments the housing draws is the surface's own limit.
   context.emit({
     type: REALTIME_SERVER_EVENT.RESPONSE_OUTPUT_ITEM_ADDED,
     item: { id: "item-three" },
@@ -103,7 +104,11 @@ test("back-to-back responses stack as two captions instead of running together",
     item_id: "item-three",
     delta: "Third.",
   });
-  assert.deepEqual(context.captions.at(-1), ["Second response, finished.", "Third."]);
+  assert.deepEqual(context.captions.at(-1), [
+    "First response, corrected.",
+    "Second response, finished.",
+    "Third.",
+  ]);
 });
 
 test("a brain follow-up keeps the words said before the ask and stacks the answer", async () => {

--- a/apps/desktop/src/renderer/voice/speak-only-call.ts
+++ b/apps/desktop/src/renderer/voice/speak-only-call.ts
@@ -108,8 +108,14 @@ export interface SpeakOnlyCallOptions extends RealtimeCallOptions {
    * so the caller only ever draws what it is handed. `kind` says whether the
    * words are a briefing or a reply to the brain's answer, living exactly as
    * long as that reply; a reply the brain was not asked for carries none.
+   * `runId` names the brain run whose end the words are voicing, when they
+   * are one, for exactly as long as the words are up.
    */
-  onCaption(texts: readonly string[] | undefined, kind: ReplyKind | undefined): void;
+  onCaption(
+    texts: readonly string[] | undefined,
+    kind: ReplyKind | undefined,
+    runId?: string,
+  ): void;
   /**
    * The words a reply leaves behind at the moment it ends — finished, talked
    * over, or the call closing under it, whichever came. `kind` says whether
@@ -235,7 +241,7 @@ export class SpeakOnlyCall<
   #audibleSince: number | undefined;
   /** The words of the reply under way, and whose they are. */
   #captions = new CaptionStrip({
-    onCaption: (texts, kind) => this.options.onCaption(texts, kind),
+    onCaption: (texts, kind, runId) => this.options.onCaption(texts, kind, runId),
     onReplyEnded: (texts, kind, runId) => this.options.onReplyEnded?.(texts, kind, runId),
   });
   /**

--- a/packages/brain/src/agent.test.ts
+++ b/packages/brain/src/agent.test.ts
@@ -1225,7 +1225,7 @@ test("an ask during a client quiet ends as an honest failure with no effects, an
   assert.equal(h.performed.length, 0);
 });
 
-test("the final answer's text is the reply: a preface before a tool call does not survive an empty final answer, and a shortfall with words is kept beside them", async () => {
+test("the reply is everything the model said across the run: a preface before a tool call survives an empty final answer, joins a spoken one as its own paragraph, and a shortfall with words is kept beside them", async () => {
   const h = harness();
   h.client.answers.push(
     answered([message("Let me look."), call("c1", BRAIN_TOOL.LIST_SESSIONS, {})]),
@@ -1233,8 +1233,16 @@ test("the final answer's text is the reply: a preface before a tool call does no
   );
   const silent = await ask(h, "look");
   assert.equal(silent?.status, BRAIN_REQUEST_STATUS.SUCCEEDED);
-  assert.equal(silent?.text, undefined);
-  assert.equal(h.traces[0]?.outputText, undefined);
+  assert.equal(silent?.text, "Let me look.");
+  assert.equal(h.traces[0]?.outputText, "Let me look.");
+
+  h.client.answers.push(
+    answered([message("Looking now."), call("c2", BRAIN_TOOL.LIST_SESSIONS, {})]),
+    answered([message("Two agents are waiting.")]),
+  );
+  const spoken = await ask(h, "look again");
+  assert.equal(spoken?.status, BRAIN_REQUEST_STATUS.SUCCEEDED);
+  assert.equal(spoken?.text, "Looking now.\n\nTwo agents are waiting.");
 
   const partial = responsesModelAnswer({
     output: [message("Half of")],
@@ -1246,8 +1254,8 @@ test("the final answer's text is the reply: a preface before a tool call does no
   const short = await ask(h, "explain at length");
   assert.equal(short?.status, BRAIN_REQUEST_STATUS.SUCCEEDED);
   assert.equal(short?.text, "Half of");
-  assert.equal(h.traces[1]?.outputText, "Half of");
-  assert.equal(h.traces[1]?.incomplete, "incomplete: max_output_tokens");
+  assert.equal(h.traces[2]?.outputText, "Half of");
+  assert.equal(h.traces[2]?.incomplete, "incomplete: max_output_tokens");
 });
 
 test("a stop during a held initial bootstrap settles at once; the open finishing afterwards is retired exactly once, and a dispose that never settles holds nothing", async () => {
@@ -1369,10 +1377,11 @@ test("an ask arriving while the model is thinking is steered into that run and a
   gated.open();
   await settle();
   // Words steered in after the model had already answered are not lost: the
-  // run asks once more with them, and that reply is the run's.
-  assert.equal((await h.agent.waitAsk(first, 1))?.text, "Both answered.");
+  // run asks once more with them, and the run's reply is everything it said,
+  // the answer it had already given and the one that took both in.
+  assert.equal((await h.agent.waitAsk(first, 1))?.text, "First alone.\n\nBoth answered.");
   assert.equal((await h.agent.waitAsk(second, 1))?.status, BRAIN_REQUEST_STATUS.SUCCEEDED);
-  assert.equal(h.agent.request(second)?.text, "Both answered.");
+  assert.equal(h.agent.request(second)?.text, "First alone.\n\nBoth answered.");
   assert.equal(inner.inputs.length, 2);
   const asks = (inner.inputs[1] ?? []).filter(
     (item) =>
@@ -1426,7 +1435,7 @@ test("a steered ask cancelled before the run ends is settled cancelled and takes
   assert.equal((await h.agent.cancelAsk(second))?.status, BRAIN_REQUEST_STATUS.CANCELLED);
   gated.open();
   await settle();
-  assert.equal((await h.agent.waitAsk(first, 1))?.text, "Reply.");
+  assert.equal((await h.agent.waitAsk(first, 1))?.text, "First.\n\nReply.");
   assert.equal(h.agent.request(second)?.status, BRAIN_REQUEST_STATUS.CANCELLED);
   assert.equal(h.agent.request(second)?.text, undefined);
 });
@@ -1546,8 +1555,8 @@ test("a steered companion shares the run's persistence failure: a final write th
   assert.equal(companion?.status, BRAIN_REQUEST_STATUS.FAILED);
   assert.equal(companion?.failure, BRAIN_REQUEST_FAILURE.PERSISTENCE);
   // The reply that formed still travels on both, as the record's own words.
-  assert.equal(primary?.text, "Reply for both.");
-  assert.equal(companion?.text, "Reply for both.");
+  assert.equal(primary?.text, "First alone.\n\nReply for both.");
+  assert.equal(companion?.text, "First alone.\n\nReply for both.");
 });
 
 test("a rider settles when the shared turn dies to a thrown hook after its checkpoint, and none is left running", async () => {

--- a/packages/brain/src/responses-api.test.ts
+++ b/packages/brain/src/responses-api.test.ts
@@ -77,6 +77,25 @@ test("the output reading keeps every item verbatim and picks out calls, text, co
   assert.ok(!isCompactionItem(reasoning));
 });
 
+test("two message items in one answer are two paragraphs of its text, and an empty one adds none", () => {
+  const first = {
+    type: "message",
+    role: "assistant",
+    status: "completed",
+    content: [{ type: "output_text", text: "Looking now." }],
+  };
+  const silent = { type: "message", role: "assistant", status: "completed", content: [] };
+  const second = {
+    type: "message",
+    role: "assistant",
+    status: "completed",
+    content: [{ type: "output_text", text: "Two agents are waiting." }],
+  };
+  const output = brainResponsesOutput({ output: [first, silent, second], status: "completed" });
+  assert.ok(output);
+  assert.equal(output.outputText, "Looking now.\n\nTwo agents are waiting.");
+});
+
 test("a payload with no output array reads as nothing, and an incomplete one names why", () => {
   assert.equal(brainResponsesOutput({ error: "nope" }), undefined);
   assert.equal(brainResponsesOutput(undefined), undefined);

--- a/packages/brain/src/responses-api.ts
+++ b/packages/brain/src/responses-api.ts
@@ -11,6 +11,7 @@ import {
   type ModelUsage,
   type ToolSchema,
 } from "@sidecar/runtime/vocabulary";
+import { joinReplyMessages } from "@sidecar/session";
 import {
   isRecord,
   isWireString,
@@ -219,7 +220,7 @@ export function brainResponsesOutput(payload: UnparsedWireValue): BrainResponses
   return {
     items,
     functionCalls,
-    outputText: texts.join("").trim(),
+    outputText: joinReplyMessages(texts),
     compacted,
     ...(inputTokens !== undefined ? { inputTokens } : undefined),
     ...(status ? { status } : undefined),

--- a/packages/brain/src/turn-runner.ts
+++ b/packages/brain/src/turn-runner.ts
@@ -15,10 +15,11 @@ import {
   type RuntimeRun,
   type RuntimeRunEnd,
 } from "@sidecar/runtime/vocabulary";
-import type {
-  ProviderTranscriptResult,
-  ProviderTranscriptSinceResult,
-  SessionIdentity,
+import {
+  joinReplyMessages,
+  type ProviderTranscriptResult,
+  type ProviderTranscriptSinceResult,
+  type SessionIdentity,
 } from "@sidecar/session";
 import type { WireRecord } from "@sidecar/wire";
 import { BRAIN_DEFAULTS } from "./defaults.js";
@@ -121,6 +122,8 @@ interface TurnGathering {
   iterations: number;
   compacted: boolean;
   inputTokens?: number;
+  /** Each answer's words in order, the empty ones included, so the reply is composed from all of them. */
+  said: string[];
   outputText: string;
   /** The final answer's shortfall, when it stopped short with words still delivered. */
   incomplete?: string;
@@ -494,6 +497,7 @@ export class TurnRunner {
       deliveries: [],
       iterations: 0,
       compacted: false,
+      said: [],
       outputText: "",
     };
     let preparation: BrainTurnPreparation | undefined;
@@ -803,7 +807,8 @@ export class TurnRunner {
           if (event.toolCalls > 0) gathering.iterations += 1;
           return;
         case RUNTIME_EVENT.TEXT:
-          gathering.outputText = event.text;
+          gathering.said.push(event.text);
+          gathering.outputText = joinReplyMessages(gathering.said);
           return;
         case RUNTIME_EVENT.USAGE:
           if (event.usage.inputTokens !== undefined) {
@@ -878,9 +883,13 @@ export class TurnRunner {
     }
     switch (end.reason) {
       case RUN_END_REASON.COMPLETED:
-        // The end's text is the reply: an earlier answer's words that preceded
-        // a tool call are not the answer when the final answer said nothing.
-        gathering.outputText = end.text;
+        // The reply is everything the model said across the run, in order:
+        // the words before a tool call are as much its answer as the words
+        // after, and a final answer that said nothing drops none of them. The
+        // end's own text is the final answer's, already reported as the last
+        // words unless the runtime reported none.
+        if (gathering.said.at(-1) !== end.text) gathering.said.push(end.text);
+        gathering.outputText = joinReplyMessages(gathering.said);
         if (end.incomplete) gathering.incomplete = incompleteDetail(end.incomplete);
         return undefined;
       case RUN_END_REASON.THROTTLED:

--- a/packages/session/src/conversation/conversation.ts
+++ b/packages/session/src/conversation/conversation.ts
@@ -301,6 +301,21 @@ function normalizedEntryWords(words: string): string {
 }
 
 /**
+ * The words of one reply said as several messages — a model answer carrying
+ * more than one message item, its words before a tool call and after it, or
+ * a call's back-to-back output items — kept whole and in order, each apart
+ * from the next as its own paragraph. A message that said nothing adds no
+ * paragraph, so a reply whose last message was empty still carries everything
+ * said before it, and nothing said is ever dropped or run onto its neighbor.
+ */
+export function joinReplyMessages(messages: readonly string[]): string {
+  return messages
+    .map((message) => message.trim())
+    .filter((message) => message.length > 0)
+    .join("\n\n");
+}
+
+/**
  * One line still being said, for the panel to draw under the settled thread
  * while its words grow. It is normalized exactly as its settled form will be,
  * so the streaming bubble and the recorded line can never disagree, and it

--- a/packages/voice/src/orchestrator/index.ts
+++ b/packages/voice/src/orchestrator/index.ts
@@ -23,6 +23,6 @@ export {
   type VoiceState,
   type VoiceSurroundings,
 } from "./voice-orchestrator.js";
-export { activeVoiceStream } from "./voice-policy.js";
+export { activeVoiceStream, CAPTION_SEGMENT_LIMIT } from "./voice-policy.js";
 export { VOICE_READINESS_PART, type VoiceReadinessPart } from "./voice-readiness.js";
 export type { VoiceExchangeOpening, VoiceViewReport } from "./voice-view-reporter.js";

--- a/packages/voice/src/orchestrator/voice-orchestrator.ts
+++ b/packages/voice/src/orchestrator/voice-orchestrator.ts
@@ -14,6 +14,7 @@ import type { ScheduledTimer } from "@sidecar/runtime/vocabulary";
 import {
   announcementConversationEntry,
   type ConversationEntry,
+  joinReplyMessages,
   replyConversationEntry,
   SESSION_STATUS,
   type Session,
@@ -100,7 +101,11 @@ export interface SpeakOnlyCallHooks<Stream> {
   onStatus(status: RealtimeStatus): void;
   onRemoteStream(stream: Stream | undefined): void;
   onError(message: string | undefined): void;
-  onCaption(texts: readonly string[] | undefined, kind: ReplyKind | undefined): void;
+  onCaption(
+    texts: readonly string[] | undefined,
+    kind: ReplyKind | undefined,
+    runId?: string,
+  ): void;
   onReplyEnded(texts: readonly string[], kind: ReplyKind | undefined, runId?: string): void;
 }
 
@@ -118,10 +123,13 @@ export interface ConversationCallHooks<Stream> extends SpeakOnlyCallHooks<Stream
 /**
  * The words of the reply under way and whose they are, held as one value so
  * a live Conversation line can never file a caption under a different reply.
+ * The run named is the brain run whose end the words voice, when they are
+ * one — the reply the main process has already written into the thread.
  */
 interface VoiceCaption {
   texts: readonly string[] | undefined;
   kind: ReplyKind | undefined;
+  runId: string | undefined;
 }
 
 export interface VoiceOrchestratorDeps<Stream> {
@@ -185,7 +193,7 @@ export class VoiceOrchestrator<Stream> {
   #talkOpening = false;
   #localStream: Stream | undefined;
   #remoteStream: Stream | undefined;
-  #caption: VoiceCaption = { texts: undefined, kind: undefined };
+  #caption: VoiceCaption = { texts: undefined, kind: undefined, runId: undefined };
 
   /** When the talk key went down, which is what tells a hold from a tap. */
   #talkPressedAt: number | undefined;
@@ -490,7 +498,7 @@ export class VoiceOrchestrator<Stream> {
       onRemoteStream: (stream) => this.#setRemoteStream(stream),
       onLocalStream: (stream) => this.#setLocalStream(stream),
       onError: (message) => this.#strip.showError(message),
-      onCaption: (texts, kind) => this.#setCaption(texts, kind),
+      onCaption: (texts, kind, runId) => this.#setCaption(texts, kind, runId),
       onReplyEnded: (texts, kind, runId) => this.#replyEnded(texts, kind, runId),
       askBrain: (question, submissionId) =>
         askBrain(
@@ -535,7 +543,7 @@ export class VoiceOrchestrator<Stream> {
       onError: (message) => {
         if (heard()) this.#strip.showError(message);
       },
-      onCaption: (texts, kind) => this.#setCaption(texts, kind),
+      onCaption: (texts, kind, runId) => this.#setCaption(texts, kind, runId),
       onReplyEnded: (texts, kind, runId) => this.#replyEnded(texts, kind, runId),
     });
     return this.#speakOnlyCall;
@@ -717,7 +725,7 @@ export class VoiceOrchestrator<Stream> {
   ): void {
     if (kind === REPLY_KIND.BRIEFING) {
       const generation = this.#thread.takeAnnouncementGeneration();
-      this.#thread.remember(announcementConversationEntry(texts.join(" ")), generation);
+      this.#thread.remember(announcementConversationEntry(joinReplyMessages(texts)), generation);
       return;
     }
     const generation = this.#thread.takeReplyGeneration();
@@ -730,7 +738,7 @@ export class VoiceOrchestrator<Stream> {
       this.#replyPlayer?.onReplyEnded(runId);
       return;
     }
-    this.#thread.remember(replyConversationEntry(texts.join(" ")), generation);
+    this.#thread.remember(replyConversationEntry(joinReplyMessages(texts)), generation);
   }
 
   // — the edges —
@@ -810,8 +818,12 @@ export class VoiceOrchestrator<Stream> {
     })();
   }
 
-  #setCaption(texts: readonly string[] | undefined, kind: ReplyKind | undefined): void {
-    this.#caption = { texts, kind };
+  #setCaption(
+    texts: readonly string[] | undefined,
+    kind: ReplyKind | undefined,
+    runId: string | undefined,
+  ): void {
+    this.#caption = { texts, kind, runId };
     this.#report();
   }
 
@@ -902,6 +914,7 @@ export class VoiceOrchestrator<Stream> {
         spokenAskPreviews: previews,
         captions: this.#caption.texts,
         kind: this.#caption.kind,
+        runId: this.#caption.runId,
       });
       this.#liveFrom = { previews, caption: this.#caption };
     }

--- a/packages/voice/src/orchestrator/voice-policy.test.ts
+++ b/packages/voice/src/orchestrator/voice-policy.test.ts
@@ -21,18 +21,19 @@ test("the live lines mirror exactly what their recording paths will keep", () =>
       ["item-1", "how is the checkout agent"],
       ["item-2", "and the deploy?"],
     ]),
-    captions: ["Checkout is", "nearly done."],
+    captions: ["Looking now.", "Checkout is nearly done."],
     kind: undefined,
+    runId: undefined,
   });
 
-  // The asks precede the answer, and the reply's segments join into the one
-  // line onReplyEnded will record.
+  // The asks precede the answer, and the reply's messages join into the one
+  // line onReplyEnded will record, each kept whole as its own paragraph.
   assert.deepEqual(
     lines.map((line) => ({ kind: line.kind, words: line.words })),
     [
       { kind: CONVERSATION_ENTRY_KIND.SPOKEN_ASK, words: "how is the checkout agent" },
       { kind: CONVERSATION_ENTRY_KIND.SPOKEN_ASK, words: "and the deploy?" },
-      { kind: CONVERSATION_ENTRY_KIND.REPLY, words: "Checkout is nearly done." },
+      { kind: CONVERSATION_ENTRY_KIND.REPLY, words: "Looking now.\n\nCheckout is nearly done." },
     ],
   );
   // A line still growing has not happened yet, so none is stamped.
@@ -45,6 +46,7 @@ test("a briefing's live line settles as an announcement", () => {
       spokenAskPreviews: new Map(),
       captions: ["Claude Code finished checkout-service."],
       kind: REPLY_KIND.BRIEFING,
+      runId: undefined,
     }),
     [
       {
@@ -52,6 +54,21 @@ test("a briefing's live line settles as an announcement", () => {
         words: "Claude Code finished checkout-service.",
       },
     ],
+  );
+});
+
+test("a reply voicing a run's end draws no live line, because its settled line already stands", () => {
+  // The main process wrote the reply from the record when the run ended, so a
+  // live line under it would print the same words twice. The spoken asks
+  // still stream, since nothing has recorded them yet.
+  assert.deepEqual(
+    liveConversationEntries({
+      spokenAskPreviews: new Map([["item-1", "how is the checkout agent"]]),
+      captions: ["Looking now.", "Checkout is nearly done."],
+      kind: REPLY_KIND.REPLY,
+      runId: "run-1",
+    }).map((line) => ({ kind: line.kind, words: line.words })),
+    [{ kind: CONVERSATION_ENTRY_KIND.SPOKEN_ASK, words: "how is the checkout agent" }],
   );
 });
 
@@ -111,6 +128,15 @@ test("Luke's captions are offered only on his turn, and only with a reason to re
     undefined,
     "a caption that raced a status change must not be drawn on the developer's turn",
   );
+  assert.deepEqual(
+    lukeCaptionsToShow({
+      ...shown,
+      captions: ["Sentence 1.", "Sentence 2.", "Sentence 3.", "Sentence 4."],
+    }),
+    ["Sentence 3.", "Sentence 4."],
+    "the housing draws only the newest segments; the reply itself keeps them all",
+  );
+  assert.equal(lukeCaptionsToShow({ ...shown, captions: [] })?.length, 0);
   assert.equal(
     lukeCaptionsToShow({ ...shown, captionsEnabled: false }),
     undefined,

--- a/packages/voice/src/orchestrator/voice-policy.ts
+++ b/packages/voice/src/orchestrator/voice-policy.ts
@@ -3,6 +3,7 @@ import { REALTIME_STATUS, type RealtimeStatus, type RealtimeVoice } from "@sidec
 import {
   CONVERSATION_ENTRY_KIND,
   type ConversationEntry,
+  joinReplyMessages,
   streamingConversationEntry,
 } from "@sidecar/session";
 import { REPLY_KIND, type ReplyKind } from "./voice-call.js";
@@ -71,10 +72,20 @@ export function lukeCaptionsToShow(input: {
     (input.captionsEnabled || input.outputSilent) &&
     input.status === REALTIME_STATUS.RESPONDING
   ) {
-    return input.captions;
+    return input.captions?.slice(-CAPTION_SEGMENT_LIMIT);
   }
   return undefined;
 }
+
+/**
+ * How many back-to-back responses the housing's caption keeps on screen at
+ * once. Two is the shape the surface stacks — the words just settled and the
+ * words now arriving — and a third response starting simply retires the
+ * oldest from view, the way a long reply's oldest lines already roll up under
+ * the shape. A limit on the drawing alone: the call keeps every segment of
+ * the reply, so what Conversation records and streams is the whole of it.
+ */
+export const CAPTION_SEGMENT_LIMIT = 2;
 
 /**
  * Whether a talk-key press has a call to open before the session is asked. A
@@ -159,13 +170,19 @@ export function spokenAskPreviewSurvives(status: RealtimeStatus): boolean {
  * the developer's spoken turns as the service transcribes them, then the
  * reply or announcement as its words are generated — the ask precedes its
  * answer. Presentation only, so each line mirrors exactly what its own
- * recording path will keep: a briefing settles as an announcement, and any
- * other caption settles as a reply.
+ * recording path will keep: a briefing settles as an announcement, any
+ * other caption settles as a reply, and a reply of several messages keeps
+ * each as a paragraph of the one line. A reply voicing a brain run's end draws
+ * no line: the main process wrote that reply into the thread from the record
+ * when the run ended, before the words were granted to any voice, so its
+ * settled line already stands and a live one under it would say the same
+ * words twice. The caption under the housing still carries the speech.
  */
 export function liveConversationEntries(input: {
   spokenAskPreviews: ReadonlyMap<string, string>;
   captions: readonly string[] | undefined;
   kind: ReplyKind | undefined;
+  runId: string | undefined;
 }): readonly ConversationEntry[] {
   const lines: ConversationEntry[] = [];
   for (const words of input.spokenAskPreviews.values()) {
@@ -173,10 +190,10 @@ export function liveConversationEntries(input: {
     if (ask) lines.push(ask);
   }
   const briefing = input.kind === REPLY_KIND.BRIEFING;
-  if (input.captions) {
+  if (input.captions && input.runId === undefined) {
     const speech = streamingConversationEntry(
       briefing ? CONVERSATION_ENTRY_KIND.ANNOUNCEMENT : CONVERSATION_ENTRY_KIND.REPLY,
-      input.captions.join(" "),
+      joinReplyMessages(input.captions),
     );
     if (speech) lines.push(speech);
   }


### PR DESCRIPTION
## Summary

**Duplicate reply in the Conversation tab.** The host writes a run's settled reply line from the record when the run ends, before the words are granted to the voice. The voice window then streamed the same words as a live line under it. The caption now carries the run id it is voicing (`onCaption` on the caption tracker, both call hook types, and the orchestrator), and `liveConversationEntries` draws no live line for a caption that names a run. The housing caption still streams the speech.

**Dropped and merged messages.** A reply of several messages lost words in three places:

- Message items inside one model answer were joined with no separator (`responses-api.ts`).
- Each later answer in the tool loop replaced the earlier one's text, so a preface before a tool call was dropped, and a final answer that said nothing reported "I had nothing to add" (`turn-runner.ts`).
- The voice's caption tracker kept only its two newest output items and joined them with a space at handover (`captions.ts`).

A shared `joinReplyMessages` in the session package keeps every message whole and in order, each as its own paragraph, and skips empty ones. The turn runner composes the reply from everything the model said across the run. The caption tracker keeps every segment; the two-item cap now lives in `lukeCaptionsToShow` and limits only what the housing draws. Steered asks follow the same rule: both asks share the run's whole words rather than only the final answer.

A follow-up will move to one Conversation line per message, which also fixes the ordering where words said before an action appear below the action's line. The flexible-caption workspace (no count cap) overlaps this PR in `captions.ts` and `voice-policy.ts`; whichever lands second resolves so the tracker keeps every segment and no count constant remains.

## Test plan

- [x] `./scripts/check.sh` passes on the branch rebased onto main after #869 and #870
- [x] New and updated tests: the skipped live line for a run's reply; the run id on every caption draw; paragraph joins in the Responses reader and turn runner; the surviving preface; every caption segment kept and handed over; steered-ask replies carry every answer
- [ ] Physical-notch check not performed (portable change; the housing's caption behavior is unchanged apart from which segments it is handed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/230376e4-df68-4244-87a7-619bfda7b5a8)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34419293731/artifacts/10130340042) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34419293731)

- Commit: `e35a43127c2812b16418e0df4593d2aadbfa06d9`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
