### PR TITLE
feat(desktop): compose an action row from the act's record and the roster as it stands

### DIFF
--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -44,6 +44,7 @@ import {
   type PanelPresentation,
 } from "./panel-state";
 import { PANEL_TAB, type PanelTab } from "./panel-tabs";
+import { displaySessions } from "./session-model";
 import { applySessionReplay } from "./session-replay";
 import { focusSearchField } from "./session-search";
 import type { MicrophoneControl, ShortcutControl, UpdateControl } from "./settings/controls";
@@ -1050,6 +1051,7 @@ export function App(): React.JSX.Element {
             onOpenSessionApplication={sessions.onOpenSessionApplication}
             writes={sessions.writes}
             conversationLines={state.conversation.entries}
+            roster={displaySessions(state)}
             liveConversationEntries={liveConversationEntries}
             onClearConversationConversation={clearConversationLines}
             brainRequests={brainRequests}

--- a/apps/desktop/src/renderer/conversation-action.test.ts
+++ b/apps/desktop/src/renderer/conversation-action.test.ts
@@ -1,0 +1,124 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { ACTION_KIND, CONVERSATION_ENTRY_KIND, SESSION_APPLICATION_SCOPE } from "@sidecar/session";
+import { actionRowParts } from "./conversation-action";
+import type { SessionView } from "./session-model";
+
+const lisbon: SessionView = {
+  id: "a",
+  title: "lisbon-v2",
+  providerId: "codex",
+  provider: "Codex",
+  applications: [
+    { id: "cursor", name: "Cursor", scope: SESSION_APPLICATION_SCOPE.SESSION, openable: true },
+  ],
+  detail: "Working",
+  urgency: "urgency-working",
+  label: "Working",
+  location: "local",
+  lastActivityAt: 0,
+  openable: false,
+  canMessage: true,
+  actions: [],
+  hasChange: false,
+};
+const identity = { providerId: "codex", providerSessionId: "a" };
+const line = (action: NonNullable<Parameters<typeof actionRowParts>[0]["action"]>) => ({
+  kind: CONVERSATION_ENTRY_KIND.ACTION,
+  words: "recorded at the time",
+  identity,
+  action,
+});
+const text = (parts: ReturnType<typeof actionRowParts>) => parts?.map((part) => part.text).join("");
+
+test("a row is composed from the act's record and the session's current name", () => {
+  const sent = actionRowParts(line({ kind: ACTION_KIND.MESSAGE, runId: "r", text: "ship it" }), [
+    lisbon,
+  ]);
+  assert.equal(text(sent), 'Sent a message to lisbon-v2: "ship it"');
+  assert.deepEqual(sent?.[1], { text: "lisbon-v2", name: true });
+  assert.equal(
+    text(actionRowParts(line({ kind: ACTION_KIND.CONTROL, runId: "r", label: "Retry" }), [lisbon])),
+    'Ran "Retry" on lisbon-v2',
+  );
+  assert.equal(
+    text(actionRowParts(line({ kind: ACTION_KIND.OPEN, runId: "r" }), [lisbon])),
+    "Opened lisbon-v2",
+  );
+  assert.equal(
+    text(
+      actionRowParts(line({ kind: ACTION_KIND.OPEN, runId: "r", applicationId: "cursor" }), [
+        lisbon,
+      ]),
+    ),
+    "Opened lisbon-v2 in Cursor",
+  );
+  assert.equal(
+    text(
+      actionRowParts(line({ kind: ACTION_KIND.ADD_AGENT, runId: "r", agent: "claude" }), [lisbon]),
+    ),
+    "Added a claude agent to lisbon-v2",
+  );
+  assert.equal(
+    text(
+      actionRowParts(line({ kind: ACTION_KIND.RENAME_WORKSPACE, runId: "r", name: "release" }), [
+        lisbon,
+      ]),
+    ),
+    'Renamed the workspace of lisbon-v2 to "release"',
+  );
+  // A renamed session is already called by its new name; the row repeats it only while they differ.
+  assert.equal(
+    text(
+      actionRowParts(line({ kind: ACTION_KIND.RENAME_SESSION, runId: "r", name: "lisbon-v3" }), [
+        lisbon,
+      ]),
+    ),
+    'Renamed lisbon-v2 to "lisbon-v3"',
+  );
+  assert.equal(
+    text(
+      actionRowParts(line({ kind: ACTION_KIND.RENAME_SESSION, runId: "r", name: "lisbon-v2" }), [
+        lisbon,
+      ]),
+    ),
+    "Renamed lisbon-v2",
+  );
+  // The session is named as the roster calls it now, not as the line was recorded.
+  assert.equal(
+    text(
+      actionRowParts(line({ kind: ACTION_KIND.MESSAGE, runId: "r", text: "go" }), [
+        { ...lisbon, title: "lisbon-v3" },
+      ]),
+    ),
+    'Sent a message to lisbon-v3: "go"',
+  );
+});
+
+test("a creation names its provider as the roster's rows for that provider do", () => {
+  const created = {
+    kind: CONVERSATION_ENTRY_KIND.ACTION,
+    words: "recorded",
+    action: { kind: ACTION_KIND.CREATE_WORKSPACE, runId: "r", providerId: "codex", name: "Notch" },
+  };
+  assert.equal(text(actionRowParts(created, [lisbon])), 'Created a new workspace "Notch" in Codex');
+  assert.equal(actionRowParts(created, []), undefined);
+});
+
+test("nothing is composed for a record that cannot be read back to a row", () => {
+  // No record at all, from a build before the facts were written down.
+  assert.equal(
+    actionRowParts({ kind: CONVERSATION_ENTRY_KIND.ACTION, words: "opened a session" }, [lisbon]),
+    undefined,
+  );
+  // A session the roster has let go.
+  assert.equal(
+    actionRowParts(line({ kind: ACTION_KIND.MESSAGE, runId: "r", text: "go" }), []),
+    undefined,
+  );
+  // A record missing the fact its kind needs.
+  assert.equal(
+    actionRowParts(line({ kind: ACTION_KIND.MESSAGE, runId: "r" }), [lisbon]),
+    undefined,
+  );
+});

--- a/apps/desktop/src/renderer/conversation-action.ts
+++ b/apps/desktop/src/renderer/conversation-action.ts
@@ -1,0 +1,81 @@
+import { ACTION_KIND, type ConversationEntry } from "@sidecar/session";
+import type { SessionView } from "./session-model";
+
+/** One run of an action row's words; a name is a session's title, set apart from the rest. */
+export interface ActionRowPart {
+  text: string;
+  name?: true;
+}
+
+function named(title: string): ActionRowPart {
+  return { text: title, name: true };
+}
+
+/**
+ * The words an action row draws, composed from the act's own record and the
+ * roster as it stands now, so a session is named as it is called today and
+ * the wording is the build's rather than the sentence recorded at the time.
+ * Nothing here is answered when the record cannot be read back to a row — a
+ * line an earlier build wrote without its facts, a session the roster has let
+ * go, a creation whose provider no row stands for — and the caller draws the
+ * recorded words in its place, which is what the model was read.
+ */
+export function actionRowParts(
+  entry: ConversationEntry,
+  sessions: readonly SessionView[],
+): readonly ActionRowPart[] | undefined {
+  const action = entry.action;
+  if (action === undefined) return undefined;
+  const identity = entry.identity;
+  const session = identity
+    ? sessions.find(
+        (candidate) =>
+          candidate.providerId === identity.providerId &&
+          candidate.id === identity.providerSessionId,
+      )
+    : undefined;
+  switch (action.kind) {
+    case ACTION_KIND.MESSAGE:
+      if (!session || action.text === undefined) return undefined;
+      return [{ text: "Sent a message to " }, named(session.title), { text: `: "${action.text}"` }];
+    case ACTION_KIND.CONTROL:
+      if (!session || action.label === undefined) return undefined;
+      return [{ text: `Ran "${action.label}" on ` }, named(session.title)];
+    case ACTION_KIND.OPEN: {
+      if (!session) return undefined;
+      const application =
+        action.applicationId === undefined
+          ? undefined
+          : (session.applications.find((candidate) => candidate.id === action.applicationId)
+              ?.name ?? action.applicationId);
+      return [
+        { text: "Opened " },
+        named(session.title),
+        ...(application === undefined ? [] : [{ text: ` in ${application}` }]),
+      ];
+    }
+    case ACTION_KIND.CREATE_WORKSPACE: {
+      const provider = sessions.find((candidate) => candidate.providerId === action.providerId);
+      if (!provider) return undefined;
+      const name = action.name === undefined ? "" : ` "${action.name}"`;
+      return [{ text: `Created a new workspace${name} in ${provider.provider}` }];
+    }
+    case ACTION_KIND.ADD_AGENT:
+      if (!session || action.agent === undefined) return undefined;
+      return [{ text: `Added a ${action.agent} agent to ` }, named(session.title)];
+    case ACTION_KIND.RENAME_WORKSPACE:
+      if (!session || action.name === undefined) return undefined;
+      return [
+        { text: "Renamed the workspace of " },
+        named(session.title),
+        { text: ` to "${action.name}"` },
+      ];
+    case ACTION_KIND.RENAME_SESSION:
+      // The roster already calls the session by its new name once the rename
+      // has landed, so the row repeats the name only while the two differ.
+      if (!session || action.name === undefined) return undefined;
+      return session.title === action.name
+        ? [{ text: "Renamed " }, named(session.title)]
+        : [{ text: "Renamed " }, named(session.title), { text: ` to "${action.name}"` }];
+  }
+}

--- a/apps/desktop/src/renderer/conversation-panel.test.ts
+++ b/apps/desktop/src/renderer/conversation-panel.test.ts
@@ -96,6 +96,55 @@ test("an action draws as a row led by the mark of its kind, with no bubble and n
   assert.match(unmarked, /<span class="conversation-action-mark" aria-hidden="true"><\/span>/);
 });
 
+test("an action row is worded from its record and the roster, and from its recorded words when it cannot be", () => {
+  const entry = {
+    kind: CONVERSATION_ENTRY_KIND.ACTION,
+    words: 'sent a message to "checkout-service": "please add tests"',
+    identity: { providerId: "claude-code", providerSessionId: "session-a" },
+    action: { kind: ACTION_KIND.MESSAGE, runId: "run-1", text: "please add tests" },
+  };
+  const render = (sessions: Parameters<typeof ConversationPanel>[0]["sessions"]) =>
+    renderToStaticMarkup(
+      createElement(ConversationPanel, {
+        entries: [entry],
+        sessions,
+        now: NOW,
+        ask: async () => undefined,
+        onAskEngaged: () => undefined,
+      }),
+    );
+  const composed = render([
+    {
+      id: "session-a",
+      title: "checkout",
+      providerId: "claude-code",
+      provider: "Claude Code",
+      applications: [],
+      detail: "Working",
+      urgency: "urgency-working",
+      label: "Working",
+      location: "local",
+      lastActivityAt: 0,
+      openable: false,
+      canMessage: true,
+      actions: [],
+      hasChange: false,
+    },
+  ]);
+  // The session by its current name, set apart, in a sentence the build wrote.
+  assert.match(
+    composed,
+    /<span class="conversation-words"><span>Sent a message to <\/span><span class="conversation-action-name">checkout<\/span><span>: &quot;please add tests&quot;<\/span><\/span>/,
+  );
+  assert.doesNotMatch(composed, /checkout-service|class="markdown/);
+  // Without the session on the roster, the words recorded at the time stand.
+  const recorded = render([]);
+  assert.match(
+    recorded,
+    /<div class="markdown conversation-words"><p>sent a message to &quot;checkout-service&quot;/,
+  );
+});
+
 test("an action row ends on the mark of the provider it reached", () => {
   const render = (entry: Parameters<typeof ConversationPanel>[0]["entries"][number]) =>
     renderToStaticMarkup(

--- a/apps/desktop/src/renderer/conversation-panel.tsx
+++ b/apps/desktop/src/renderer/conversation-panel.tsx
@@ -24,12 +24,14 @@ import { useEffect, useId, useRef, useState } from "react";
 import { ACT_KIND } from "#shared/messages/acts";
 import { tell } from "./act";
 import { type AskHandler, AskLuke } from "./ask-luke";
+import { actionRowParts } from "./conversation-action";
 import {
   createConversationTimeBreakFormatter,
   opensConversationTimeBreak,
 } from "./conversation-time-break";
 import { MarkdownMessage } from "./markdown-message";
 import { PANEL_TAB, panelPanelId, panelTabId } from "./panel-tabs";
+import type { SessionView } from "./session-model";
 
 export const CONVERSATION_ENTRY_SPEAKER = {
   YOU: "you",
@@ -242,18 +244,27 @@ function ConversationMessageRow({
  * from a turn nobody opened leads with Luke's face instead — he signs his own
  * work here as the errand has him do on a control — so whose judgment an
  * action was is read at a glance and never wears a reply's bubble. The words
- * end on the mark of the provider the action reached — the session's own for
- * an action on a session, the one a creation asked for a new workspace — so
- * a row is placed the way a session row is, by its mark. A line an earlier
- * build recorded without its kind draws with the mark's room left empty
- * rather than guessing one. No copy control: the words are a record of an
- * act, not something said.
+ * are composed from the act's record and the roster as it stands, the session
+ * set apart by name; a line whose record cannot be read back to a row draws
+ * the words recorded at the time instead. They end on the mark of the
+ * provider the action reached — the session's own for an action on a
+ * session, the one a creation asked for a new workspace — so a row is placed
+ * the way a session row is, by its mark. A line an earlier build recorded
+ * without its kind draws with the mark's room left empty rather than guessing
+ * one. No copy control: the words are a record of an act, not something said.
  */
-function ConversationActionRow({ entry }: { entry: ConversationEntry }): React.JSX.Element {
+function ConversationActionRow({
+  entry,
+  sessions,
+}: {
+  entry: ConversationEntry;
+  sessions: readonly SessionView[];
+}): React.JSX.Element {
   const presentation = conversationEntryPresentation(entry.kind);
   const own = entry.kind === CONVERSATION_ENTRY_KIND.OWN_ACTION;
   const Glyph = entry.action ? ACTION_GLYPH[entry.action.kind] : undefined;
   const providerId = entry.identity?.providerId ?? entry.action?.providerId;
+  const parts = actionRowParts(entry, sessions);
   return (
     <li
       className="conversation-entry"
@@ -266,7 +277,23 @@ function ConversationActionRow({ entry }: { entry: ConversationEntry }): React.J
           <span className="conversation-action-mark" aria-hidden="true">
             {own ? <WingFace /> : Glyph ? <Glyph /> : null}
           </span>
-          <MarkdownMessage words={entry.words} className="conversation-words" />
+          {parts ? (
+            <span className="conversation-words">
+              {parts.map((part, index) =>
+                part.name ? (
+                  // biome-ignore lint/suspicious/noArrayIndexKey: The parts are a fixed composition of one record, so a position names a part for as long as the row stands.
+                  <span key={index} className="conversation-action-name">
+                    {part.text}
+                  </span>
+                ) : (
+                  // biome-ignore lint/suspicious/noArrayIndexKey: As above.
+                  <span key={index}>{part.text}</span>
+                ),
+              )}
+            </span>
+          ) : (
+            <MarkdownMessage words={entry.words} className="conversation-words" />
+          )}
           {providerId === undefined ? null : (
             <span className="conversation-action-provider" aria-hidden="true">
               <ProviderMark providerId={providerId} />
@@ -279,13 +306,17 @@ function ConversationActionRow({ entry }: { entry: ConversationEntry }): React.J
   );
 }
 
-function ConversationEntryRow(props: {
+function ConversationEntryRow({
+  sessions,
+  ...props
+}: {
   entry: ConversationEntry;
+  sessions: readonly SessionView[];
   streaming?: boolean;
 }): React.JSX.Element {
   return conversationEntryPresentation(props.entry.kind).speaker ===
     CONVERSATION_ENTRY_SPEAKER.EVENT ? (
-    <ConversationActionRow entry={props.entry} />
+    <ConversationActionRow entry={props.entry} sessions={sessions} />
   ) : (
     <ConversationMessageRow {...props} />
   );
@@ -305,9 +336,11 @@ function ConversationEntryRow(props: {
  */
 function ConversationTurn({
   entries,
+  sessions,
   pending,
 }: {
   entries: readonly KeyedConversationEntry[];
+  sessions: readonly SessionView[];
   pending: boolean;
 }): React.JSX.Element {
   const [choice, setChoice] = useState<boolean | undefined>(undefined);
@@ -336,7 +369,7 @@ function ConversationTurn({
       </div>
       <ol id={actionsId} className="conversation-turn-actions" hidden={!open}>
         {entries.map(({ entry, key }) => (
-          <ConversationActionRow key={key} entry={entry} />
+          <ConversationActionRow key={key} entry={entry} sessions={sessions} />
         ))}
       </ol>
     </li>
@@ -472,6 +505,7 @@ export function ConversationPanel({
   entries,
   live = [],
   requests = [],
+  sessions = [],
   now,
   ask,
   onAskEngaged,
@@ -492,6 +526,11 @@ export function ConversationPanel({
    * the stop is the composer's.
    */
   requests?: readonly BrainRequestSnapshot[];
+  /**
+   * The roster as the rows draw it, for an action row to name its session as
+   * it is called now and a creation its provider as the provider names itself.
+   */
+  sessions?: readonly SessionView[];
   /**
    * The lines still being said, drawn under the settled thread as the same
    * bubbles they will settle into — words growing, no timestamp, no copy.
@@ -576,13 +615,18 @@ export function ConversationPanel({
                     <ConversationTurn
                       key={`turn:${lead.key}`}
                       entries={item.items}
+                      sessions={sessions}
                       pending={turnPending(item.turn, index === items.length - 1)}
                     />,
                   );
                 }
                 return dated(
                   item.item,
-                  <ConversationEntryRow key={item.item.key} entry={item.item.entry} />,
+                  <ConversationEntryRow
+                    key={item.item.key}
+                    entry={item.item.entry}
+                    sessions={sessions}
+                  />,
                 );
               })}
               {live.map((entry, index) => (
@@ -590,6 +634,7 @@ export function ConversationPanel({
                   // biome-ignore lint/suspicious/noArrayIndexKey: A line still being said has no durable id, and its words change on every delta — a key made of either would remount the bubble mid-sentence, while its position holds still for exactly as long as the line does.
                   key={`live:${entry.kind}:${index}`}
                   entry={entry}
+                  sessions={sessions}
                   streaming
                 />
               ))}

--- a/apps/desktop/src/renderer/panel-body.tsx
+++ b/apps/desktop/src/renderer/panel-body.tsx
@@ -191,6 +191,8 @@ export interface PanelBodyProps {
   writes: SessionWriteHandlers;
   /** The conversation between the developer and Luke, this launch's and what survived the last. */
   conversationLines: readonly ConversationEntry[];
+  /** Every observed session, unnarrowed, for the thread to name the sessions its actions reached. */
+  roster: readonly SessionView[];
   /** The lines still being said, drawn under that thread while their words grow. */
   liveConversationEntries: readonly ConversationEntry[];
   /** Clears that same thread from the view, Luke's next context, and the stored file. */
@@ -249,6 +251,7 @@ export function PanelBody({
   onOpenSessionApplication,
   writes,
   conversationLines,
+  roster,
   liveConversationEntries,
   onClearConversationConversation,
   brainRequests,
@@ -373,6 +376,7 @@ export function PanelBody({
       ) : tab === PANEL_TAB.CONVERSATION ? (
         <ConversationPanel
           entries={conversationLines}
+          sessions={roster}
           live={liveConversationEntries}
           requests={brainRequests}
           now={now}

--- a/apps/desktop/src/renderer/styles/conversation.css
+++ b/apps/desktop/src/renderer/styles/conversation.css
@@ -442,8 +442,15 @@
   line-height: 1.4;
 }
 
-/* The narration is written in the model's lower case; the row reads as a
-   sentence of its own. */
+/* The session an action reached, set apart by name the way the row for it is:
+   the one thing in the sentence the eye is looking for. */
+.conversation-action-name {
+  color: var(--text-primary);
+  font-weight: 600;
+}
+
+/* A line drawn from its recorded words rather than its record keeps the
+   model's lower case; the row reads as a sentence of its own. */
 .conversation-entry[data-speaker="event"] .conversation-words > p:first-child::first-letter {
   text-transform: uppercase;
 }

--- a/packages/actions/src/action-narration.ts
+++ b/packages/actions/src/action-narration.ts
@@ -18,6 +18,7 @@ import {
   type ActionKind,
   type CarriedAction,
   type CarriedSessionAction,
+  type SessionActionKind,
 } from "./action-kinds.js";
 
 /**
@@ -99,6 +100,43 @@ const ACTION_NARRATION = {
   [K in ActionKind]: (action: CarriedAction<K>, context: ActionNarrationContext) => string;
 };
 
+/**
+ * The act's own facts, for the panel to compose its row from: one table over
+ * the session kinds, so a kind whose facts are not written down does not
+ * compile. Only what the narration names rides along — never a model or an
+ * effort, which the row has no words for.
+ */
+const ACTION_RECORD = {
+  [ACTION_KIND.MESSAGE]: (action) => ({ text: action.text }),
+  [ACTION_KIND.CONTROL]: (action) => ({ label: action.control.label }),
+  [ACTION_KIND.OPEN]: (action) =>
+    action.applicationId !== undefined ? { applicationId: action.applicationId } : {},
+  [ACTION_KIND.CREATE_WORKSPACE]: (action) => ({
+    providerId: action.providerId,
+    ...(action.name !== undefined ? { name: action.name } : undefined),
+  }),
+  [ACTION_KIND.ADD_AGENT]: (action) => ({
+    agent: action.agent,
+    ...(action.name !== undefined ? { name: action.name } : undefined),
+  }),
+  [ACTION_KIND.RENAME_WORKSPACE]: (action) => ({ name: action.name }),
+  [ACTION_KIND.RENAME_SESSION]: (action) => ({ name: action.name }),
+} as const satisfies {
+  [K in SessionActionKind]: (
+    action: CarriedAction<K>,
+  ) => Omit<ConversationEntryAction, "kind" | "runId">;
+};
+
+function carriedActionRecord(action: CarriedSessionAction, runId: string): ConversationEntryAction {
+  const record = ACTION_RECORD[action.kind];
+  // SAFETY: the table is keyed by the same union `action.kind` ranges over, so the
+  // entry selected is the one written for this action's own shape.
+  const details = (
+    record as (action: CarriedSessionAction) => Omit<ConversationEntryAction, "kind" | "runId">
+  )(action);
+  return { kind: action.kind, runId, ...details };
+}
+
 /** The Conversation sentence declared by the same vocabulary that declared the action. */
 export function actionNarration(action: CarriedAction, context: ActionNarrationContext): string {
   const narrate = ACTION_NARRATION[action.kind];
@@ -130,9 +168,7 @@ export function sessionActionConversationEntry(
   runId: string,
 ): ConversationEntry {
   const words = actionNarration(action, context);
-  const carried: ConversationEntryAction = { kind: action.kind, runId };
-  if (action.kind === ACTION_KIND.CREATE_WORKSPACE) carried.providerId = action.providerId;
-  const entry: ConversationEntry = { kind, words, action: carried };
+  const entry: ConversationEntry = { kind, words, action: carriedActionRecord(action, runId) };
   if ("identity" in action) entry.identity = action.identity;
   return entry;
 }

--- a/packages/actions/src/actions.test.ts
+++ b/packages/actions/src/actions.test.ts
@@ -241,19 +241,23 @@ test("an action's line records the ask in words, with the identity it named", ()
   assert.equal(message.kind, CONVERSATION_ENTRY_KIND.ACTION);
   assert.equal(message.words, 'sent a message to "checkout-service": "please add tests"');
   assert.deepEqual(message.identity, identity);
-  // The kind and the run ride beside the words, for the panel to draw and fold by.
-  assert.deepEqual(message.action, { kind: ACTION_KIND.MESSAGE, runId: "run-1" });
+  // The kind, the run, and the act's own facts ride beside the words, for the
+  // panel to compose its row from and fold by.
+  assert.deepEqual(message.action, {
+    kind: ACTION_KIND.MESSAGE,
+    runId: "run-1",
+    text: "please add tests",
+  });
 
   const control: AdvertisedControl = { kind: ACTION_KIND.CONTROL, id: "retry", label: "Retry" };
-  assert.equal(
-    sessionActionConversationEntry(
-      { kind: ACTION_KIND.CONTROL, identity, control },
-      { sessions, projects },
-      CONVERSATION_ENTRY_KIND.ACTION,
-      "run-1",
-    ).words,
-    'ran "Retry" on "checkout-service"',
+  const pressed = sessionActionConversationEntry(
+    { kind: ACTION_KIND.CONTROL, identity, control },
+    { sessions, projects },
+    CONVERSATION_ENTRY_KIND.ACTION,
+    "run-1",
   );
+  assert.equal(pressed.words, 'ran "Retry" on "checkout-service"');
+  assert.deepEqual(pressed.action, { kind: ACTION_KIND.CONTROL, runId: "run-1", label: "Retry" });
 
   // A session the roster no longer shows is still named honestly.
   assert.equal(

--- a/packages/host/src/brain/action-performer.test.ts
+++ b/packages/host/src/brain/action-performer.test.ts
@@ -176,7 +176,11 @@ test("a session action reaches the performer only for a session the roster holds
   // names the run that carried it, so the panel can fold the turn's actions.
   assert.equal(recorded.length, 1);
   assert.equal(recorded[0]?.kind, "action");
-  assert.deepEqual(recorded[0]?.action, { kind: "message", runId: LIVE.runId });
+  assert.deepEqual(recorded[0]?.action, {
+    kind: "message",
+    runId: LIVE.runId,
+    text: "go ahead",
+  });
 
   const stranger = await actions.perform(
     {
@@ -344,7 +348,7 @@ test("an action in a turn Luke opened himself runs under the same validators and
   assert.equal(performed.length, 1);
   assert.equal(recorded.length, 1);
   assert.equal(recorded[0]?.kind, "own-action");
-  assert.deepEqual(recorded[0]?.action, { kind: "message", runId: "wake-1" });
+  assert.deepEqual(recorded[0]?.action, { kind: "message", runId: "wake-1", text: "go ahead" });
 });
 
 test("an action with no turn standing is refused in main before any validator or effect", async () => {

--- a/packages/session/src/conversation/conversation.test.ts
+++ b/packages/session/src/conversation/conversation.test.ts
@@ -448,6 +448,28 @@ test("a stored line reads back, and retention cuts by age and by count", () => {
     storedConversationEntry({ ...created, action: { ...created.action, providerId: 7 } }),
     undefined,
   );
+  // Every detail a kind records rides the same way, and is held to the same read.
+  const detailed = {
+    ...acted,
+    action: {
+      kind: ACTION_KIND.MESSAGE,
+      runId: "run-1",
+      text: "go ahead",
+      label: "Retry",
+      applicationId: "cursor",
+      agent: "claude",
+      name: "release-candidate",
+    },
+  };
+  assert.deepEqual(storedConversationEntry(conversationEntryToWire(detailed)), detailed);
+  assert.equal(
+    storedConversationEntry({ ...detailed, action: { ...detailed.action, text: "" } }),
+    undefined,
+  );
+  assert.equal(
+    storedConversationEntry({ ...detailed, action: { ...detailed.action, name: ["x"] } }),
+    undefined,
+  );
 
   const stale = { ...line, recordedAt: now - storedConversationMaximumAgeMs - 1 };
   assert.deepEqual(retainedConversationEntries([stale, line], now), [line]);

--- a/packages/session/src/conversation/conversation.ts
+++ b/packages/session/src/conversation/conversation.ts
@@ -152,6 +152,13 @@ export interface ConversationEntry {
   action?: ConversationEntryAction;
 }
 
+/**
+ * The act as it was carried, in its own facts rather than in a sentence, so
+ * the panel composes the row it draws from them and the roster as they stand
+ * — a session by its current name, a provider by its display name, a wording
+ * the build may change — while the line's words stay the record the model
+ * was read. Each kind fills the fields its narration names and no other.
+ */
 export interface ConversationEntryAction {
   kind: ActionKind;
   runId: string;
@@ -161,7 +168,26 @@ export interface ConversationEntryAction {
    * from. Every other action's provider is its identity's.
    */
   providerId?: string;
+  /** The message a send carried, the developer's own words. */
+  text?: string;
+  /** The label of the control a press ran, as the provider advertised it. */
+  label?: string;
+  /** The application an open was aimed at, when the developer named one. */
+  applicationId?: string;
+  /** The kind of agent an add started, as the provider's endpoint takes it. */
+  agent?: string;
+  /** The name a creation, an add, or a rename gave. */
+  name?: string;
 }
+
+const CONVERSATION_ENTRY_ACTION_DETAILS = [
+  "providerId",
+  "text",
+  "label",
+  "applicationId",
+  "agent",
+  "name",
+] as const satisfies readonly (keyof ConversationEntryAction)[];
 
 /** The line as the Gateway protocol carries it; the unstrict read below takes it back whole. */
 export function conversationEntryToWire(entry: ConversationEntry): WireRecord {
@@ -581,18 +607,14 @@ function storedConversationEntryAction(
   if (!isRecord(value) || !isConversationEntryActionKind(value.kind)) return undefined;
   if (!isWireString(value.runId)) return undefined;
   if (strict && value.runId.length === 0) return undefined;
-  const providerId = value.providerId;
-  if (
-    providerId !== undefined &&
-    !(isWireString(providerId) && (!strict || providerId.length > 0))
-  ) {
-    return undefined;
+  const action: ConversationEntryAction = { kind: value.kind, runId: value.runId };
+  for (const detail of CONVERSATION_ENTRY_ACTION_DETAILS) {
+    const held = value[detail];
+    if (held === undefined) continue;
+    if (!isWireString(held) || (strict && held.length === 0)) return undefined;
+    action[detail] = held;
   }
-  return {
-    kind: value.kind,
-    runId: value.runId,
-    ...(isWireString(providerId) ? { providerId } : undefined),
-  };
+  return action;
 }
 
 /**


### PR DESCRIPTION
Stacked on #890 → #889 → #882.

An action row drew the sentence recorded when the action was carried, so its wording was frozen at the build that wrote it and a session it named kept the name it had then.

- **The record holds the act's facts.** `ConversationEntryAction` gains the detail each kind's narration names and nothing else: `text` for a message, `label` for a control, `applicationId` for an open aimed at an app, `agent` and `name` for an added agent, `name` for a creation or a rename, beside the existing kind, run, and a creation's provider. They travel on the wire and round-trip through the store under the same strictness as the other optional fields (a blank detail refuses the line on the strict read).
- **The panel composes the row.** A new `actionRowParts` reads the record against the roster the rows draw from: the session by its current name (set apart in the primary ink), an application or a creation's provider by display name, in the build's own wording. A renamed session, already called by its new name, is repeated only while the two differ.
- **The recorded sentence remains** what the model is read and what the row falls back to when the record cannot be read back to a row: a line an earlier build wrote without its facts, a session the roster has let go, a creation whose provider no row stands for. Dropping `words` from action lines altogether would reach the store schema, the search index, and the model context, and is left as a separate decision.
- The panel body now hands the thread the unnarrowed roster view.

Verification: typecheck clean; session 89, actions 60, host 286, and desktop renderer 287 tests pass, with a new `conversation-action.test.ts` covering every kind, the live rename, and each fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/edd416a9-4048-4f0a-ac6d-fdae20bd92f6)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34425283344/artifacts/10132467592) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34425283344)

- Commit: `7aadc36900de8de3e587b5295266788a1f875179`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
