### PR TITLE
feat(desktop): word and mark a control by what its adapter said it does

### DIFF
--- a/apps/desktop/src/renderer/conversation-action.test.ts
+++ b/apps/desktop/src/renderer/conversation-action.test.ts
@@ -1,6 +1,11 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { ACTION_KIND, CONVERSATION_ENTRY_KIND, SESSION_APPLICATION_SCOPE } from "@sidecar/session";
+import {
+  ACTION_KIND,
+  CONVERSATION_ENTRY_KIND,
+  SESSION_APPLICATION_SCOPE,
+  SESSION_CONTROL_KIND,
+} from "@sidecar/session";
 import { actionRowParts } from "./conversation-action";
 import type { SessionView } from "./session-model";
 
@@ -40,6 +45,35 @@ test("a row is composed from the act's record and the session's current name", (
   assert.equal(
     text(actionRowParts(line({ kind: ACTION_KIND.CONTROL, runId: "r", label: "Retry" }), [lisbon])),
     'Ran "Retry" on lisbon-v2',
+  );
+  // A control whose adapter said what it does is worded as that act.
+  assert.equal(
+    text(
+      actionRowParts(
+        line({
+          kind: ACTION_KIND.CONTROL,
+          runId: "r",
+          label: "Archive",
+          controlKind: SESSION_CONTROL_KIND.ARCHIVE,
+        }),
+        [lisbon],
+      ),
+    ),
+    "Archived lisbon-v2",
+  );
+  assert.equal(
+    text(
+      actionRowParts(
+        line({
+          kind: ACTION_KIND.CONTROL,
+          runId: "r",
+          label: "Stop",
+          controlKind: SESSION_CONTROL_KIND.STOP,
+        }),
+        [lisbon],
+      ),
+    ),
+    "Stopped lisbon-v2",
   );
   assert.equal(
     text(actionRowParts(line({ kind: ACTION_KIND.OPEN, runId: "r" }), [lisbon])),

--- a/apps/desktop/src/renderer/conversation-action.ts
+++ b/apps/desktop/src/renderer/conversation-action.ts
@@ -1,4 +1,4 @@
-import { ACTION_KIND, type ConversationEntry } from "@sidecar/session";
+import { ACTION_KIND, type ConversationEntry, SESSION_CONTROL_KIND } from "@sidecar/session";
 import type { SessionView } from "./session-model";
 
 /** One run of an action row's words; a name is a session's title, set apart from the rest. */
@@ -40,7 +40,14 @@ export function actionRowParts(
       return [{ text: "Sent a message to " }, named(session.title), { text: `: "${action.text}"` }];
     case ACTION_KIND.CONTROL:
       if (!session || action.label === undefined) return undefined;
-      return [{ text: `Ran "${action.label}" on ` }, named(session.title)];
+      switch (action.controlKind) {
+        case SESSION_CONTROL_KIND.ARCHIVE:
+          return [{ text: "Archived " }, named(session.title)];
+        case SESSION_CONTROL_KIND.STOP:
+          return [{ text: "Stopped " }, named(session.title)];
+        default:
+          return [{ text: `Ran "${action.label}" on ` }, named(session.title)];
+      }
     case ACTION_KIND.OPEN: {
       if (!session) return undefined;
       const application =

--- a/apps/desktop/src/renderer/conversation-panel.test.ts
+++ b/apps/desktop/src/renderer/conversation-panel.test.ts
@@ -175,6 +175,38 @@ test("an action row ends on the mark of the provider it reached", () => {
   assert.match(creation, /class="provider-mark" data-mark="conductor"/);
 });
 
+test("a control's mark follows what its adapter said it does", () => {
+  const render = (controlKind: "archive" | "stop" | undefined) =>
+    renderToStaticMarkup(
+      createElement(ConversationPanel, {
+        entries: [
+          {
+            kind: CONVERSATION_ENTRY_KIND.ACTION,
+            words: 'archived "checkout-service"',
+            action: {
+              kind: ACTION_KIND.CONTROL,
+              runId: "run-1",
+              label: "Archive",
+              ...(controlKind ? { controlKind } : undefined),
+            },
+          },
+        ],
+        now: NOW,
+        ask: async () => undefined,
+        onAskEngaged: () => undefined,
+      }),
+    );
+  assert.match(
+    render("archive"),
+    /class="conversation-action-mark" aria-hidden="true" data-control="archive"><svg class="icon-button-glyph"/,
+  );
+  assert.match(render("stop"), /data-control="stop"><svg class="control-icon"/);
+  assert.match(
+    render(undefined),
+    /class="conversation-action-mark" aria-hidden="true"><svg class="icon-button-glyph"/,
+  );
+});
+
 test("an action Luke took on his own is signed with his face and never wears a reply's bubble", () => {
   const markup = renderToStaticMarkup(
     createElement(ConversationPanel, {

--- a/apps/desktop/src/renderer/conversation-panel.tsx
+++ b/apps/desktop/src/renderer/conversation-panel.tsx
@@ -1,5 +1,6 @@
 import { type BrainRequestSnapshot, brainRequestPending } from "@sidecar/brain/requests-wire";
 import {
+  ArchiveIcon,
   CheckIcon,
   ChevronIcon,
   ControlIcon,
@@ -9,6 +10,7 @@ import {
   PencilIcon,
   PlusIcon,
   ProviderMark,
+  StopIcon,
   WingFace,
 } from "@sidecar/panel";
 import {
@@ -16,8 +18,11 @@ import {
   type ActionKind,
   CONVERSATION_ENTRY_KIND,
   type ConversationEntry,
+  type ConversationEntryAction,
   type ConversationEntryKind,
   conversationEntryKey,
+  SESSION_CONTROL_KIND,
+  type SessionControlKind,
 } from "@sidecar/session";
 import { FACE_MOTION } from "@sidecar/surface";
 import { useEffect, useId, useRef, useState } from "react";
@@ -89,6 +94,23 @@ const ACTION_GLYPH = {
   [ACTION_KIND.RENAME_WORKSPACE]: PencilIcon,
   [ACTION_KIND.RENAME_SESSION]: PencilIcon,
 } as const satisfies Record<ActionKind, () => React.JSX.Element>;
+
+/**
+ * A control's mark follows what its adapter said it does: an archive files
+ * away, a stop is the square every chat surface stops with, and a plain
+ * action keeps the bolt.
+ */
+const CONTROL_GLYPH = {
+  [SESSION_CONTROL_KIND.ACTION]: ControlIcon,
+  [SESSION_CONTROL_KIND.ARCHIVE]: ArchiveIcon,
+  [SESSION_CONTROL_KIND.STOP]: StopIcon,
+} as const satisfies Record<SessionControlKind, () => React.JSX.Element>;
+
+function actionGlyph(action: ConversationEntryAction): () => React.JSX.Element {
+  return action.kind === ACTION_KIND.CONTROL && action.controlKind !== undefined
+    ? CONTROL_GLYPH[action.controlKind]
+    : ACTION_GLYPH[action.kind];
+}
 
 const COPY_CONFIRMATION_MS = 1500;
 
@@ -262,7 +284,7 @@ function ConversationActionRow({
 }): React.JSX.Element {
   const presentation = conversationEntryPresentation(entry.kind);
   const own = entry.kind === CONVERSATION_ENTRY_KIND.OWN_ACTION;
-  const Glyph = entry.action ? ACTION_GLYPH[entry.action.kind] : undefined;
+  const Glyph = entry.action ? actionGlyph(entry.action) : undefined;
   const providerId = entry.identity?.providerId ?? entry.action?.providerId;
   const parts = actionRowParts(entry, sessions);
   return (
@@ -274,7 +296,11 @@ function ConversationActionRow({
       <small className="visually-hidden">{presentation.label}</small>
       <div className="conversation-message">
         <span className="conversation-action">
-          <span className="conversation-action-mark" aria-hidden="true">
+          <span
+            className="conversation-action-mark"
+            aria-hidden="true"
+            data-control={entry.action?.controlKind}
+          >
             {own ? <WingFace /> : Glyph ? <Glyph /> : null}
           </span>
           {parts ? (

--- a/packages/actions/src/action-narration.ts
+++ b/packages/actions/src/action-narration.ts
@@ -4,14 +4,15 @@
  * written and no action can be recorded as "an action" with nothing said about it.
  */
 
-import type {
-  CONVERSATION_ENTRY_KIND,
-  ConversationEntry,
-  ConversationEntryAction,
-  ObservedWorkspaceProject,
-  Session,
-  SessionApplicationId,
-  SessionIdentity,
+import {
+  type CONVERSATION_ENTRY_KIND,
+  type ConversationEntry,
+  type ConversationEntryAction,
+  type ObservedWorkspaceProject,
+  SESSION_CONTROL_KIND,
+  type Session,
+  type SessionApplicationId,
+  type SessionIdentity,
 } from "@sidecar/session";
 import {
   ACTION_KIND,
@@ -66,8 +67,19 @@ function observedApplicationName(
 const ACTION_NARRATION = {
   [ACTION_KIND.MESSAGE]: (action, { sessions }) =>
     `sent a message to ${observedSessionName(action.identity, sessions)}: "${action.text}"`,
-  [ACTION_KIND.CONTROL]: (action, { sessions }) =>
-    `ran "${action.control.label}" on ${observedSessionName(action.identity, sessions)}`,
+  // A control whose adapter said what it does is narrated as that act; one it
+  // did not is narrated by its label, the provider's own word for it.
+  [ACTION_KIND.CONTROL]: (action, { sessions }) => {
+    const name = observedSessionName(action.identity, sessions);
+    switch (action.control.controlKind) {
+      case SESSION_CONTROL_KIND.ARCHIVE:
+        return `archived ${name}`;
+      case SESSION_CONTROL_KIND.STOP:
+        return `stopped ${name}`;
+      default:
+        return `ran "${action.control.label}" on ${name}`;
+    }
+  },
   [ACTION_KIND.OPEN]: (action, { sessions }) => {
     const name = observedSessionName(action.identity, sessions);
     return action.applicationId
@@ -108,7 +120,12 @@ const ACTION_NARRATION = {
  */
 const ACTION_RECORD = {
   [ACTION_KIND.MESSAGE]: (action) => ({ text: action.text }),
-  [ACTION_KIND.CONTROL]: (action) => ({ label: action.control.label }),
+  [ACTION_KIND.CONTROL]: (action) => ({
+    label: action.control.label,
+    ...(action.control.controlKind !== undefined
+      ? { controlKind: action.control.controlKind }
+      : undefined),
+  }),
   [ACTION_KIND.OPEN]: (action) =>
     action.applicationId !== undefined ? { applicationId: action.applicationId } : {},
   [ACTION_KIND.CREATE_WORKSPACE]: (action) => ({

--- a/packages/actions/src/actions.test.ts
+++ b/packages/actions/src/actions.test.ts
@@ -8,6 +8,7 @@ import {
   normalizeSession,
   SESSION_APPLICATION_ID,
   SESSION_APPLICATION_SCOPE,
+  SESSION_CONTROL_KIND,
   SESSION_STATUS,
   WORKSPACE_TASK_SUPPORT,
 } from "@sidecar/session";
@@ -258,6 +259,41 @@ test("an action's line records the ask in words, with the identity it named", ()
   );
   assert.equal(pressed.words, 'ran "Retry" on "checkout-service"');
   assert.deepEqual(pressed.action, { kind: ACTION_KIND.CONTROL, runId: "run-1", label: "Retry" });
+  // A control whose adapter said what it does is narrated as that act, and records it.
+  const archive: AdvertisedControl = {
+    kind: ACTION_KIND.CONTROL,
+    id: "archive",
+    label: "Archive",
+    controlKind: SESSION_CONTROL_KIND.ARCHIVE,
+  };
+  const archived = sessionActionConversationEntry(
+    { kind: ACTION_KIND.CONTROL, identity, control: archive },
+    { sessions, projects },
+    CONVERSATION_ENTRY_KIND.ACTION,
+    "run-1",
+  );
+  assert.equal(archived.words, 'archived "checkout-service"');
+  assert.deepEqual(archived.action, {
+    kind: ACTION_KIND.CONTROL,
+    runId: "run-1",
+    label: "Archive",
+    controlKind: SESSION_CONTROL_KIND.ARCHIVE,
+  });
+  const stop: AdvertisedControl = {
+    kind: ACTION_KIND.CONTROL,
+    id: "stop",
+    label: "Stop",
+    controlKind: SESSION_CONTROL_KIND.STOP,
+  };
+  assert.equal(
+    sessionActionConversationEntry(
+      { kind: ACTION_KIND.CONTROL, identity, control: stop },
+      { sessions, projects },
+      CONVERSATION_ENTRY_KIND.ACTION,
+      "run-1",
+    ).words,
+    'stopped "checkout-service"',
+  );
 
   // A session the roster no longer shows is still named honestly.
   assert.equal(

--- a/packages/panel/src/glyphs.tsx
+++ b/packages/panel/src/glyphs.tsx
@@ -76,6 +76,17 @@ export function MessageIcon(): React.JSX.Element {
   );
 }
 
+/** A box with its lid on: the settled thing filed away. */
+export function ArchiveIcon(): React.JSX.Element {
+  return (
+    <Glyph className="icon-button-glyph">
+      <path d="M4 4.6h16v4H4z" />
+      <path d="M5.4 8.6v9.2a1.6 1.6 0 0 0 1.6 1.6h10a1.6 1.6 0 0 0 1.6-1.6V8.6" />
+      <path d="M10 12.4h4" />
+    </Glyph>
+  );
+}
+
 /** A bolt: a control a session advertised, pressed. */
 export function ControlIcon(): React.JSX.Element {
   return (

--- a/packages/session/src/conversation/conversation.test.ts
+++ b/packages/session/src/conversation/conversation.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { ACTION_KIND } from "../advertised-actions.js";
+import { ACTION_KIND, SESSION_CONTROL_KIND } from "../advertised-actions.js";
 import { normalizeSession } from "../normalize.js";
 import { SESSION_STATUS } from "../session-status.js";
 import {
@@ -468,6 +468,24 @@ test("a stored line reads back, and retention cuts by age and by count", () => {
   );
   assert.equal(
     storedConversationEntry({ ...detailed, action: { ...detailed.action, name: ["x"] } }),
+    undefined,
+  );
+  // What a control does is one of the kinds an adapter may say, or the line is refused.
+  const archived = {
+    ...acted,
+    action: {
+      kind: ACTION_KIND.CONTROL,
+      runId: "run-1",
+      label: "Archive",
+      controlKind: SESSION_CONTROL_KIND.ARCHIVE,
+    },
+  };
+  assert.deepEqual(storedConversationEntry(conversationEntryToWire(archived)), archived);
+  assert.equal(
+    storedConversationEntry({
+      ...archived,
+      action: { ...archived.action, controlKind: "delete" },
+    }),
     undefined,
   );
 

--- a/packages/session/src/conversation/conversation.ts
+++ b/packages/session/src/conversation/conversation.ts
@@ -22,7 +22,12 @@ import {
   type UnparsedWireValue,
   type WireRecord,
 } from "@sidecar/wire";
-import { ACTION_KIND, type ActionKind } from "../advertised-actions.js";
+import {
+  ACTION_KIND,
+  type ActionKind,
+  SESSION_CONTROL_KIND,
+  type SessionControlKind,
+} from "../advertised-actions.js";
 import type { SessionIdentity } from "../session-identity.js";
 import type { Session } from "../session-shape.js";
 
@@ -57,6 +62,13 @@ export type ConversationEntryKind =
 
 const CONVERSATION_ENTRY_KIND_LIST = Object.values(CONVERSATION_ENTRY_KIND);
 const ACTION_KIND_LIST = Object.values(ACTION_KIND);
+const SESSION_CONTROL_KIND_LIST = Object.values(SESSION_CONTROL_KIND);
+
+function isConversationEntryControlKind(value: UnparsedWireValue): value is SessionControlKind {
+  if (!isWireString(value)) return false;
+  // SAFETY: value is a string; list membership is the control vocabulary contract check.
+  return SESSION_CONTROL_KIND_LIST.includes(value as SessionControlKind);
+}
 
 function isConversationEntryActionKind(value: UnparsedWireValue): value is ActionKind {
   if (!isWireString(value)) return false;
@@ -172,6 +184,8 @@ export interface ConversationEntryAction {
   text?: string;
   /** The label of the control a press ran, as the provider advertised it. */
   label?: string;
+  /** What that control does, when its adapter said: an archive or a stop rather than a plain action. */
+  controlKind?: SessionControlKind;
   /** The application an open was aimed at, when the developer named one. */
   applicationId?: string;
   /** The kind of agent an add started, as the provider's endpoint takes it. */
@@ -613,6 +627,10 @@ function storedConversationEntryAction(
     if (held === undefined) continue;
     if (!isWireString(held) || (strict && held.length === 0)) return undefined;
     action[detail] = held;
+  }
+  if (value.controlKind !== undefined) {
+    if (!isConversationEntryControlKind(value.controlKind)) return undefined;
+    action.controlKind = value.controlKind;
   }
   return action;
 }


### PR DESCRIPTION
Stacked on #892 → #890 → #889 → #882.

A control's row read `ran "Archive" on …` under the bolt every control wore, because the row knew only the control's label. Adapters already say what a control does (`controlKind`: action, archive, or stop), and the line now records it:

- An archive reads **Archived …** under a box with its lid on (a new `ArchiveIcon` in `@sidecar/panel`).
- A stop reads **Stopped …** under the square every chat surface stops with (the existing `StopIcon`).
- A plain action keeps its label ("Ran "Retry" on …") and the bolt.

The model-facing narration says the same act (`archived "checkout-service"`, `stopped …`). The record's `controlKind` is validated against the control vocabulary on read; an unknown kind refuses the line like an unknown action kind does. The mark carries `data-control` so the tests, and any styling, can tell them apart.

Verification: typecheck clean; session 89, actions 60, host 286, desktop renderer 288 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/edd416a9-4048-4f0a-ac6d-fdae20bd92f6)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34425282119/artifacts/10132466229) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34425282119)

- Commit: `085923bc8c9ae5f2f987940241c665b04a680b08`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
