### PR TITLE
feat(desktop): name the session an action reached as a chip under its mark

### DIFF
--- a/apps/desktop/src/renderer/conversation-action.test.ts
+++ b/apps/desktop/src/renderer/conversation-action.test.ts
@@ -41,9 +41,9 @@ test("a row is composed from the act's record and the session's current name", (
     lisbon,
   ]);
   assert.equal(text(sent), 'Sent a message to lisbon-v2: "ship it"');
-  // The name is a chip; it wears a mark only for a hosted agent, since the
-  // row's own marks already say the provider.
-  assert.deepEqual(sent?.[1], { text: "lisbon-v2", name: {} });
+  // The name is a chip wearing the mark its roster row wears: the provider's,
+  // or the agent's where the provider hosts agents.
+  assert.deepEqual(sent?.[1], { text: "lisbon-v2", name: { markId: "codex" } });
   const hosted = actionRowParts(line({ kind: ACTION_KIND.MESSAGE, runId: "r", text: "go" }), [
     { ...lisbon, agentId: "cursor", agent: "Cursor" },
   ]);
@@ -162,7 +162,13 @@ test("a chat the roster has let go is still named, by the title the record kept"
     [],
   );
   assert.equal(text(archived), "Archived lisbon-v2");
-  assert.deepEqual(archived?.[1], { text: "lisbon-v2", name: {} });
+  assert.deepEqual(archived?.[1], { text: "lisbon-v2", name: { markId: "codex" } });
+  // A hosted chat the roster let go keeps its agent's mark from the record.
+  const hostedGone = actionRowParts(
+    line({ kind: ACTION_KIND.MESSAGE, runId: "r", text: "go", title: "cloud", agentId: "cursor" }),
+    [],
+  );
+  assert.deepEqual(hostedGone?.[1], { text: "cloud", name: { markId: "cursor" } });
   // The roster's name wins while the roster holds the chat.
   assert.equal(
     text(

--- a/apps/desktop/src/renderer/conversation-action.test.ts
+++ b/apps/desktop/src/renderer/conversation-action.test.ts
@@ -41,7 +41,12 @@ test("a row is composed from the act's record and the session's current name", (
     lisbon,
   ]);
   assert.equal(text(sent), 'Sent a message to lisbon-v2: "ship it"');
-  assert.deepEqual(sent?.[1], { text: "lisbon-v2", name: true });
+  // The name is a chip under the mark the session's own row wears.
+  assert.deepEqual(sent?.[1], { text: "lisbon-v2", name: { markId: "codex" } });
+  const hosted = actionRowParts(line({ kind: ACTION_KIND.MESSAGE, runId: "r", text: "go" }), [
+    { ...lisbon, agentId: "cursor", agent: "Cursor" },
+  ]);
+  assert.deepEqual(hosted?.[1]?.name, { markId: "cursor" });
   assert.equal(
     text(actionRowParts(line({ kind: ACTION_KIND.CONTROL, runId: "r", label: "Retry" }), [lisbon])),
     'Ran "Retry" on lisbon-v2',
@@ -135,7 +140,9 @@ test("a creation names its provider as the roster's rows for that provider do", 
     words: "recorded",
     action: { kind: ACTION_KIND.CREATE_WORKSPACE, runId: "r", providerId: "codex", name: "Notch" },
   };
-  assert.equal(text(actionRowParts(created, [lisbon])), 'Created a new workspace "Notch" in Codex');
+  const parts = actionRowParts(created, [lisbon]);
+  assert.equal(text(parts), 'Created a new workspace "Notch" in Codex');
+  assert.deepEqual(parts?.[1], { text: "Codex", name: { markId: "codex" } });
   assert.equal(actionRowParts(created, []), undefined);
 });
 

--- a/apps/desktop/src/renderer/conversation-action.test.ts
+++ b/apps/desktop/src/renderer/conversation-action.test.ts
@@ -41,8 +41,9 @@ test("a row is composed from the act's record and the session's current name", (
     lisbon,
   ]);
   assert.equal(text(sent), 'Sent a message to lisbon-v2: "ship it"');
-  // The name is a chip under the mark the session's own row wears.
-  assert.deepEqual(sent?.[1], { text: "lisbon-v2", name: { markId: "codex" } });
+  // The name is a chip; it wears a mark only for a hosted agent, since the
+  // row's own marks already say the provider.
+  assert.deepEqual(sent?.[1], { text: "lisbon-v2", name: {} });
   const hosted = actionRowParts(line({ kind: ACTION_KIND.MESSAGE, runId: "r", text: "go" }), [
     { ...lisbon, agentId: "cursor", agent: "Cursor" },
   ]);
@@ -134,16 +135,44 @@ test("a row is composed from the act's record and the session's current name", (
   );
 });
 
-test("a creation names its provider as the roster's rows for that provider do", () => {
+test("a creation names the workspace it made as a chip, with no roster to consult", () => {
   const created = {
     kind: CONVERSATION_ENTRY_KIND.ACTION,
     words: "recorded",
     action: { kind: ACTION_KIND.CREATE_WORKSPACE, runId: "r", providerId: "codex", name: "Notch" },
   };
-  const parts = actionRowParts(created, [lisbon]);
-  assert.equal(text(parts), 'Created a new workspace "Notch" in Codex');
-  assert.deepEqual(parts?.[1], { text: "Codex", name: { markId: "codex" } });
-  assert.equal(actionRowParts(created, []), undefined);
+  const parts = actionRowParts(created, []);
+  assert.equal(text(parts), "Created a new workspace Notch");
+  assert.deepEqual(parts?.[1], { text: "Notch", name: {} });
+  assert.equal(
+    text(actionRowParts({ ...created, action: { ...created.action, name: undefined } }, [])),
+    "Created a new workspace",
+  );
+});
+
+test("a chat the roster has let go is still named, by the title the record kept", () => {
+  const archived = actionRowParts(
+    line({
+      kind: ACTION_KIND.CONTROL,
+      runId: "r",
+      label: "Archive",
+      controlKind: SESSION_CONTROL_KIND.ARCHIVE,
+      title: "lisbon-v2",
+    }),
+    [],
+  );
+  assert.equal(text(archived), "Archived lisbon-v2");
+  assert.deepEqual(archived?.[1], { text: "lisbon-v2", name: {} });
+  // The roster's name wins while the roster holds the chat.
+  assert.equal(
+    text(
+      actionRowParts(
+        line({ kind: ACTION_KIND.MESSAGE, runId: "r", text: "go", title: "old-name" }),
+        [lisbon],
+      ),
+    ),
+    'Sent a message to lisbon-v2: "go"',
+  );
 });
 
 test("nothing is composed for a record that cannot be read back to a row", () => {
@@ -152,7 +181,7 @@ test("nothing is composed for a record that cannot be read back to a row", () =>
     actionRowParts({ kind: CONVERSATION_ENTRY_KIND.ACTION, words: "opened a session" }, [lisbon]),
     undefined,
   );
-  // A session the roster has let go.
+  // A session the roster has let go, whose line kept no name for it.
   assert.equal(
     actionRowParts(line({ kind: ACTION_KIND.MESSAGE, runId: "r", text: "go" }), []),
     undefined,

--- a/apps/desktop/src/renderer/conversation-action.ts
+++ b/apps/desktop/src/renderer/conversation-action.ts
@@ -1,14 +1,19 @@
 import { ACTION_KIND, type ConversationEntry, SESSION_CONTROL_KIND } from "@sidecar/session";
 import type { SessionView } from "./session-model";
 
-/** One run of an action row's words; a name is a session's title, set apart from the rest. */
+/**
+ * One run of an action row's words. A name is the session the action reached,
+ * or the provider a creation asked, drawn as a chip under the mark its own
+ * row wears — the agent's where the provider hosts agents, else the
+ * provider's — so the thread names things the way the roster does.
+ */
 export interface ActionRowPart {
   text: string;
-  name?: true;
+  name?: { markId: string };
 }
 
-function named(title: string): ActionRowPart {
-  return { text: title, name: true };
+function named(session: SessionView): ActionRowPart {
+  return { text: session.title, name: { markId: session.agentId ?? session.providerId } };
 }
 
 /**
@@ -37,16 +42,16 @@ export function actionRowParts(
   switch (action.kind) {
     case ACTION_KIND.MESSAGE:
       if (!session || action.text === undefined) return undefined;
-      return [{ text: "Sent a message to " }, named(session.title), { text: `: "${action.text}"` }];
+      return [{ text: "Sent a message to " }, named(session), { text: `: "${action.text}"` }];
     case ACTION_KIND.CONTROL:
       if (!session || action.label === undefined) return undefined;
       switch (action.controlKind) {
         case SESSION_CONTROL_KIND.ARCHIVE:
-          return [{ text: "Archived " }, named(session.title)];
+          return [{ text: "Archived " }, named(session)];
         case SESSION_CONTROL_KIND.STOP:
-          return [{ text: "Stopped " }, named(session.title)];
+          return [{ text: "Stopped " }, named(session)];
         default:
-          return [{ text: `Ran "${action.label}" on ` }, named(session.title)];
+          return [{ text: `Ran "${action.label}" on ` }, named(session)];
       }
     case ACTION_KIND.OPEN: {
       if (!session) return undefined;
@@ -57,7 +62,7 @@ export function actionRowParts(
               ?.name ?? action.applicationId);
       return [
         { text: "Opened " },
-        named(session.title),
+        named(session),
         ...(application === undefined ? [] : [{ text: ` in ${application}` }]),
       ];
     }
@@ -65,16 +70,19 @@ export function actionRowParts(
       const provider = sessions.find((candidate) => candidate.providerId === action.providerId);
       if (!provider) return undefined;
       const name = action.name === undefined ? "" : ` "${action.name}"`;
-      return [{ text: `Created a new workspace${name} in ${provider.provider}` }];
+      return [
+        { text: `Created a new workspace${name} in ` },
+        { text: provider.provider, name: { markId: provider.providerId } },
+      ];
     }
     case ACTION_KIND.ADD_AGENT:
       if (!session || action.agent === undefined) return undefined;
-      return [{ text: `Added a ${action.agent} agent to ` }, named(session.title)];
+      return [{ text: `Added a ${action.agent} agent to ` }, named(session)];
     case ACTION_KIND.RENAME_WORKSPACE:
       if (!session || action.name === undefined) return undefined;
       return [
         { text: "Renamed the workspace of " },
-        named(session.title),
+        named(session),
         { text: ` to "${action.name}"` },
       ];
     case ACTION_KIND.RENAME_SESSION:
@@ -82,7 +90,7 @@ export function actionRowParts(
       // has landed, so the row repeats the name only while the two differ.
       if (!session || action.name === undefined) return undefined;
       return session.title === action.name
-        ? [{ text: "Renamed " }, named(session.title)]
-        : [{ text: "Renamed " }, named(session.title), { text: ` to "${action.name}"` }];
+        ? [{ text: "Renamed " }, named(session)]
+        : [{ text: "Renamed " }, named(session), { text: ` to "${action.name}"` }];
   }
 }

--- a/apps/desktop/src/renderer/conversation-action.ts
+++ b/apps/desktop/src/renderer/conversation-action.ts
@@ -1,19 +1,38 @@
-import { ACTION_KIND, type ConversationEntry, SESSION_CONTROL_KIND } from "@sidecar/session";
+import {
+  ACTION_KIND,
+  type ConversationEntry,
+  type ConversationEntryAction,
+  SESSION_CONTROL_KIND,
+} from "@sidecar/session";
 import type { SessionView } from "./session-model";
 
 /**
- * One run of an action row's words. A name is the session the action reached,
- * or the provider a creation asked, drawn as a chip under the mark its own
- * row wears — the agent's where the provider hosts agents, else the
- * provider's — so the thread names things the way the roster does.
+ * One run of an action row's words. A name is the chat the action reached,
+ * or the workspace a creation made, drawn as a chip. The chip wears a mark
+ * only where the roster row for the chat does and the row's own provider
+ * mark would not say it: the agent's, where a provider hosts agents.
  */
 export interface ActionRowPart {
   text: string;
-  name?: { markId: string };
+  name?: { markId?: string };
 }
 
-function named(session: SessionView): ActionRowPart {
-  return { text: session.title, name: { markId: session.agentId ?? session.providerId } };
+/**
+ * The chat by its current name while the roster holds it, and by the name
+ * the record kept once the roster has let it go — archived, or gone with its
+ * provider — so an act on a chat that no longer stands still says which one.
+ */
+function named(
+  session: SessionView | undefined,
+  action: ConversationEntryAction,
+): ActionRowPart | undefined {
+  if (session) {
+    return {
+      text: session.title,
+      name: session.agentId === undefined ? {} : { markId: session.agentId },
+    };
+  }
+  return action.title === undefined ? undefined : { text: action.title, name: {} };
 }
 
 /**
@@ -21,8 +40,8 @@ function named(session: SessionView): ActionRowPart {
  * roster as it stands now, so a session is named as it is called today and
  * the wording is the build's rather than the sentence recorded at the time.
  * Nothing here is answered when the record cannot be read back to a row — a
- * line an earlier build wrote without its facts, a session the roster has let
- * go, a creation whose provider no row stands for — and the caller draws the
+ * line an earlier build wrote without its facts, or one that names a chat
+ * the roster has let go and never kept a name for — and the caller draws the
  * recorded words in its place, which is what the model was read.
  */
 export function actionRowParts(
@@ -39,58 +58,53 @@ export function actionRowParts(
           candidate.id === identity.providerSessionId,
       )
     : undefined;
+  const chat = named(session, action);
   switch (action.kind) {
     case ACTION_KIND.MESSAGE:
-      if (!session || action.text === undefined) return undefined;
-      return [{ text: "Sent a message to " }, named(session), { text: `: "${action.text}"` }];
+      if (!chat || action.text === undefined) return undefined;
+      return [{ text: "Sent a message to " }, chat, { text: `: "${action.text}"` }];
     case ACTION_KIND.CONTROL:
-      if (!session || action.label === undefined) return undefined;
+      if (!chat || action.label === undefined) return undefined;
       switch (action.controlKind) {
         case SESSION_CONTROL_KIND.ARCHIVE:
-          return [{ text: "Archived " }, named(session)];
+          return [{ text: "Archived " }, chat];
         case SESSION_CONTROL_KIND.STOP:
-          return [{ text: "Stopped " }, named(session)];
+          return [{ text: "Stopped " }, chat];
         default:
-          return [{ text: `Ran "${action.label}" on ` }, named(session)];
+          return [{ text: `Ran "${action.label}" on ` }, chat];
       }
     case ACTION_KIND.OPEN: {
-      if (!session) return undefined;
+      if (!chat) return undefined;
       const application =
         action.applicationId === undefined
           ? undefined
-          : (session.applications.find((candidate) => candidate.id === action.applicationId)
+          : (session?.applications.find((candidate) => candidate.id === action.applicationId)
               ?.name ?? action.applicationId);
       return [
         { text: "Opened " },
-        named(session),
+        chat,
         ...(application === undefined ? [] : [{ text: ` in ${application}` }]),
       ];
     }
-    case ACTION_KIND.CREATE_WORKSPACE: {
-      const provider = sessions.find((candidate) => candidate.providerId === action.providerId);
-      if (!provider) return undefined;
-      const name = action.name === undefined ? "" : ` "${action.name}"`;
-      return [
-        { text: `Created a new workspace${name} in ` },
-        { text: provider.provider, name: { markId: provider.providerId } },
-      ];
-    }
+    case ACTION_KIND.CREATE_WORKSPACE:
+      // The provider it landed in is the row's mark; the workspace is named
+      // as the developer named it, since the roster row it became is not tied
+      // back to this line.
+      return action.name === undefined
+        ? [{ text: "Created a new workspace" }]
+        : [{ text: "Created a new workspace " }, { text: action.name, name: {} }];
     case ACTION_KIND.ADD_AGENT:
-      if (!session || action.agent === undefined) return undefined;
-      return [{ text: `Added a ${action.agent} agent to ` }, named(session)];
+      if (!chat || action.agent === undefined) return undefined;
+      return [{ text: `Added a ${action.agent} agent to ` }, chat];
     case ACTION_KIND.RENAME_WORKSPACE:
-      if (!session || action.name === undefined) return undefined;
-      return [
-        { text: "Renamed the workspace of " },
-        named(session),
-        { text: ` to "${action.name}"` },
-      ];
+      if (!chat || action.name === undefined) return undefined;
+      return [{ text: "Renamed the workspace of " }, chat, { text: ` to "${action.name}"` }];
     case ACTION_KIND.RENAME_SESSION:
       // The roster already calls the session by its new name once the rename
       // has landed, so the row repeats the name only while the two differ.
-      if (!session || action.name === undefined) return undefined;
-      return session.title === action.name
-        ? [{ text: "Renamed " }, named(session)]
-        : [{ text: "Renamed " }, named(session), { text: ` to "${action.name}"` }];
+      if (!chat || action.name === undefined) return undefined;
+      return chat.text === action.name
+        ? [{ text: "Renamed " }, chat]
+        : [{ text: "Renamed " }, chat, { text: ` to "${action.name}"` }];
   }
 }

--- a/apps/desktop/src/renderer/conversation-action.ts
+++ b/apps/desktop/src/renderer/conversation-action.ts
@@ -8,9 +8,10 @@ import type { SessionView } from "./session-model";
 
 /**
  * One run of an action row's words. A name is the chat the action reached,
- * or the workspace a creation made, drawn as a chip. The chip wears a mark
- * only where the roster row for the chat does and the row's own provider
- * mark would not say it: the agent's, where a provider hosts agents.
+ * or the workspace a creation made, drawn as a chip. The chat's chip wears
+ * the mark its roster row wears — the agent having it where the provider
+ * hosts agents, else the provider's — so the thread names chats the way the
+ * roster does; a workspace's chip has no row yet and wears none.
  */
 export interface ActionRowPart {
   text: string;
@@ -18,21 +19,21 @@ export interface ActionRowPart {
 }
 
 /**
- * The chat by its current name while the roster holds it, and by the name
- * the record kept once the roster has let it go — archived, or gone with its
- * provider — so an act on a chat that no longer stands still says which one.
+ * The chat by its current name and mark while the roster holds it, and by
+ * those the record kept once the roster has let it go — archived, or gone
+ * with its provider — so an act on a chat that no longer stands still says
+ * which one.
  */
 function named(
   session: SessionView | undefined,
+  identity: { providerId: string } | undefined,
   action: ConversationEntryAction,
 ): ActionRowPart | undefined {
   if (session) {
-    return {
-      text: session.title,
-      name: session.agentId === undefined ? {} : { markId: session.agentId },
-    };
+    return { text: session.title, name: { markId: session.agentId ?? session.providerId } };
   }
-  return action.title === undefined ? undefined : { text: action.title, name: {} };
+  if (action.title === undefined || identity === undefined) return undefined;
+  return { text: action.title, name: { markId: action.agentId ?? identity.providerId } };
 }
 
 /**
@@ -58,7 +59,7 @@ export function actionRowParts(
           candidate.id === identity.providerSessionId,
       )
     : undefined;
-  const chat = named(session, action);
+  const chat = named(session, identity, action);
   switch (action.kind) {
     case ACTION_KIND.MESSAGE:
       if (!chat || action.text === undefined) return undefined;

--- a/apps/desktop/src/renderer/conversation-panel.test.ts
+++ b/apps/desktop/src/renderer/conversation-panel.test.ts
@@ -78,12 +78,12 @@ test("an action draws as a row led by the mark of its kind, with no bubble and n
   // The mark leads the words inside the row, and the stamp stands outside it.
   assert.match(
     markup,
-    /<span class="conversation-action"><span class="conversation-action-mark" aria-hidden="true"><svg class="icon-button-glyph"/,
+    /<span class="conversation-action"><span class="conversation-action-marks" aria-hidden="true"><span class="conversation-action-mark"><svg class="icon-button-glyph"/,
   );
   assert.match(markup, /<\/div><time class="conversation-time"/);
   assert.doesNotMatch(markup, /conversation-bubble|conversation-copy|conversation-turn/);
-  // No identity and no provider on the action: the words end with no mark.
-  assert.doesNotMatch(markup, /conversation-action-provider/);
+  // No identity and no provider on the action: the kind's mark stands alone.
+  assert.equal(markup.match(/class="conversation-action-mark"/g)?.length, 1);
   // A line an earlier build recorded without its kind keeps the mark's room and fills it with nothing.
   const unmarked = renderToStaticMarkup(
     createElement(ConversationPanel, {
@@ -93,7 +93,7 @@ test("an action draws as a row led by the mark of its kind, with no bubble and n
       onAskEngaged: () => undefined,
     }),
   );
-  assert.match(unmarked, /<span class="conversation-action-mark" aria-hidden="true"><\/span>/);
+  assert.match(unmarked, /<span class="conversation-action-mark"><\/span>/);
 });
 
 test("an action row is worded from its record and the roster, and from its recorded words when it cannot be", () => {
@@ -131,13 +131,17 @@ test("an action row is worded from its record and the roster, and from its recor
       hasChange: false,
     },
   ]);
-  // The session by its current name, as a chip under its row's mark, in a
-  // sentence the build wrote; the chip is the mark, so the row ends on none.
+  // The kind's mark then the provider's lead the row; the session by its
+  // current name is a chip, bare, since the provider is already said.
   assert.match(
     composed,
-    /<span class="conversation-words"><span>Sent a message to <\/span><span class="conversation-action-chip"><svg class="provider-mark conversation-chip-mark" data-mark="claude-code"[^>]*>.*?<\/svg>checkout<\/span><span>: &quot;please add tests&quot;<\/span><\/span>/,
+    /<span class="conversation-action-marks" aria-hidden="true"><span class="conversation-action-mark"><svg class="icon-button-glyph".*?<\/svg><\/span><span class="conversation-action-mark"><svg class="provider-mark" data-mark="claude-code"/,
   );
-  assert.doesNotMatch(composed, /checkout-service|class="markdown|conversation-action-provider/);
+  assert.match(
+    composed,
+    /<span class="conversation-words"><span>Sent a message to <\/span><span class="conversation-action-chip">checkout<\/span><span>: &quot;please add tests&quot;<\/span><\/span>/,
+  );
+  assert.doesNotMatch(composed, /checkout-service|class="markdown|conversation-chip-mark/);
   // Without the session on the roster, the words recorded at the time stand.
   const recorded = render([]);
   assert.match(
@@ -146,7 +150,7 @@ test("an action row is worded from its record and the roster, and from its recor
   );
 });
 
-test("a row drawn from its recorded words ends on the mark of the provider it reached", () => {
+test("every row leads with its kind then the provider it reached, a creation with the one it asked", () => {
   const render = (entry: Parameters<typeof ConversationPanel>[0]["entries"][number]) =>
     renderToStaticMarkup(
       createElement(ConversationPanel, {
@@ -156,24 +160,33 @@ test("a row drawn from its recorded words ends on the mark of the provider it re
         onAskEngaged: () => undefined,
       }),
     );
-  // An action on a session wears the session's own provider.
-  const onSession = render({
+  // A row drawn from its recorded words still leads with the provider its identity names.
+  const recorded = render({
     kind: CONVERSATION_ENTRY_KIND.ACTION,
     words: 'sent a message to "checkout-service": "please add tests"',
     identity: { providerId: "claude-code", providerSessionId: "session-a" },
-    action: { kind: ACTION_KIND.MESSAGE, runId: "run-1" },
   });
   assert.match(
-    onSession,
-    /<\/div><span class="conversation-action-provider" aria-hidden="true"><svg class="provider-mark" data-mark="claude-code"/,
+    recorded,
+    /class="conversation-action-mark"><svg class="provider-mark" data-mark="claude-code"/,
   );
   // A creation has no session, so its line names the provider it asked.
   const creation = render({
     kind: CONVERSATION_ENTRY_KIND.ACTION,
-    words: 'asked conductor to create a workspace named "Notch panel clipping"',
-    action: { kind: ACTION_KIND.CREATE_WORKSPACE, runId: "run-2", providerId: "conductor" },
+    words: 'created a new workspace "Notch panel clipping" in Conductor',
+    action: {
+      kind: ACTION_KIND.CREATE_WORKSPACE,
+      runId: "run-2",
+      providerId: "conductor",
+      name: "Notch panel clipping",
+    },
   });
   assert.match(creation, /class="provider-mark" data-mark="conductor"/);
+  assert.match(
+    creation,
+    /<span>Created a new workspace <\/span><span class="conversation-action-chip">Notch panel clipping<\/span>/,
+  );
+  assert.doesNotMatch(creation, /in Conductor/);
 });
 
 test("a control's mark follows what its adapter said it does", () => {
@@ -199,12 +212,12 @@ test("a control's mark follows what its adapter said it does", () => {
     );
   assert.match(
     render("archive"),
-    /class="conversation-action-mark" aria-hidden="true" data-control="archive"><svg class="icon-button-glyph"/,
+    /class="conversation-action-mark" data-control="archive"><svg class="icon-button-glyph"/,
   );
   assert.match(render("stop"), /data-control="stop"><svg class="control-icon"/);
   assert.match(
     render(undefined),
-    /class="conversation-action-mark" aria-hidden="true"><svg class="icon-button-glyph"/,
+    /class="conversation-action-mark"><svg class="icon-button-glyph"/,
   );
 });
 
@@ -225,10 +238,7 @@ test("an action Luke took on his own is signed with his face and never wears a r
   );
   assert.match(markup, /data-speaker="event" data-origin="own"/);
   assert.match(markup, /<small class="visually-hidden">Luke, on his own judgment<\/small>/);
-  assert.match(
-    markup,
-    /class="conversation-action-mark" aria-hidden="true"><svg class="luke-face"/,
-  );
+  assert.match(markup, /class="conversation-action-mark"><svg class="luke-face"/);
   assert.doesNotMatch(markup, /data-speaker="luke"|conversation-copy/);
 });
 

--- a/apps/desktop/src/renderer/conversation-panel.test.ts
+++ b/apps/desktop/src/renderer/conversation-panel.test.ts
@@ -131,12 +131,13 @@ test("an action row is worded from its record and the roster, and from its recor
       hasChange: false,
     },
   ]);
-  // The session by its current name, set apart, in a sentence the build wrote.
+  // The session by its current name, as a chip under its row's mark, in a
+  // sentence the build wrote; the chip is the mark, so the row ends on none.
   assert.match(
     composed,
-    /<span class="conversation-words"><span>Sent a message to <\/span><span class="conversation-action-name">checkout<\/span><span>: &quot;please add tests&quot;<\/span><\/span>/,
+    /<span class="conversation-words"><span>Sent a message to <\/span><span class="conversation-action-chip"><svg class="provider-mark conversation-chip-mark" data-mark="claude-code"[^>]*>.*?<\/svg>checkout<\/span><span>: &quot;please add tests&quot;<\/span><\/span>/,
   );
-  assert.doesNotMatch(composed, /checkout-service|class="markdown/);
+  assert.doesNotMatch(composed, /checkout-service|class="markdown|conversation-action-provider/);
   // Without the session on the roster, the words recorded at the time stand.
   const recorded = render([]);
   assert.match(
@@ -145,7 +146,7 @@ test("an action row is worded from its record and the roster, and from its recor
   );
 });
 
-test("an action row ends on the mark of the provider it reached", () => {
+test("a row drawn from its recorded words ends on the mark of the provider it reached", () => {
   const render = (entry: Parameters<typeof ConversationPanel>[0]["entries"][number]) =>
     renderToStaticMarkup(
       createElement(ConversationPanel, {

--- a/apps/desktop/src/renderer/conversation-panel.test.ts
+++ b/apps/desktop/src/renderer/conversation-panel.test.ts
@@ -131,17 +131,17 @@ test("an action row is worded from its record and the roster, and from its recor
       hasChange: false,
     },
   ]);
-  // The kind's mark then the provider's lead the row; the session by its
-  // current name is a chip, bare, since the provider is already said.
+  // The kind's mark leads the row; the session by its current name is a chip
+  // wearing its row's mark, which says the provider, so the row does not.
   assert.match(
     composed,
-    /<span class="conversation-action-marks" aria-hidden="true"><span class="conversation-action-mark"><svg class="icon-button-glyph".*?<\/svg><\/span><span class="conversation-action-mark"><svg class="provider-mark" data-mark="claude-code"/,
+    /<span class="conversation-action-marks" aria-hidden="true"><span class="conversation-action-mark"><svg class="icon-button-glyph".*?<\/svg><\/span><\/span>/,
   );
   assert.match(
     composed,
-    /<span class="conversation-words"><span>Sent a message to <\/span><span class="conversation-action-chip">checkout<\/span><span>: &quot;please add tests&quot;<\/span><\/span>/,
+    /<span class="conversation-words"><span>Sent a message to <\/span><span class="conversation-action-chip"><svg class="provider-mark conversation-chip-mark" data-mark="claude-code".*?<\/svg>checkout<\/span><span>: &quot;please add tests&quot;<\/span><\/span>/,
   );
-  assert.doesNotMatch(composed, /checkout-service|class="markdown|conversation-chip-mark/);
+  assert.doesNotMatch(composed, /checkout-service|class="markdown/);
   // Without the session on the roster, the words recorded at the time stand.
   const recorded = render([]);
   assert.match(
@@ -181,12 +181,36 @@ test("every row leads with its kind then the provider it reached, a creation wit
       name: "Notch panel clipping",
     },
   });
-  assert.match(creation, /class="provider-mark" data-mark="conductor"/);
+  assert.match(
+    creation,
+    /class="conversation-action-mark"><svg class="provider-mark" data-mark="conductor"/,
+  );
   assert.match(
     creation,
     /<span>Created a new workspace <\/span><span class="conversation-action-chip">Notch panel clipping<\/span>/,
   );
   assert.doesNotMatch(creation, /in Conductor/);
+  // A hosted chat's chip wears the agent's mark, so the row's provider mark still earns its place.
+  const hosted = render({
+    kind: CONVERSATION_ENTRY_KIND.ACTION,
+    words: 'sent a message to "cloud": "go"',
+    identity: { providerId: "conductor", providerSessionId: "c" },
+    action: {
+      kind: ACTION_KIND.MESSAGE,
+      runId: "run-3",
+      text: "go",
+      title: "cloud",
+      agentId: "cursor",
+    },
+  });
+  assert.match(
+    hosted,
+    /class="conversation-action-mark"><svg class="provider-mark" data-mark="conductor"/,
+  );
+  assert.match(
+    hosted,
+    /class="conversation-action-chip"><svg class="provider-mark conversation-chip-mark" data-mark="cursor"/,
+  );
 });
 
 test("a control's mark follows what its adapter said it does", () => {

--- a/apps/desktop/src/renderer/conversation-panel.tsx
+++ b/apps/desktop/src/renderer/conversation-panel.tsx
@@ -267,8 +267,10 @@ function ConversationMessageRow({
  * work here as the errand has him do on a control — so whose judgment an
  * action was is read at a glance and never wears a reply's bubble. The words
  * are composed from the act's record and the roster as it stands, the session
- * the chat it reached a chip; the kind's mark is followed by the mark of the
- * provider the action reached, so a row is placed the way a session row is.
+ * the chat it reached a chip wearing the mark its own row wears; the kind's
+ * mark is followed by the provider's where the chip does not already say it —
+ * a hosted agent's chat, or a creation, which has no chip that could — so a
+ * row is placed the way a session row is and no mark is drawn twice.
  * A line whose record cannot be read back to a row draws the words recorded
  * at the time instead. A line an earlier build recorded without its kind
  * draws with the mark's room left empty rather than guessing one. No copy
@@ -286,8 +288,10 @@ function ConversationActionRow({
   const presentation = conversationEntryPresentation(entry.kind);
   const own = entry.kind === CONVERSATION_ENTRY_KIND.OWN_ACTION;
   const Glyph = entry.action ? actionGlyph(entry.action) : undefined;
-  const providerId = entry.identity?.providerId ?? entry.action?.providerId;
   const parts = actionRowParts(entry, sessions);
+  const chipMark = parts?.find((part) => part.name)?.name?.markId;
+  const provider = entry.identity?.providerId ?? entry.action?.providerId;
+  const providerId = provider === chipMark ? undefined : provider;
   return (
     <li
       className="conversation-entry"

--- a/apps/desktop/src/renderer/conversation-panel.tsx
+++ b/apps/desktop/src/renderer/conversation-panel.tsx
@@ -267,13 +267,14 @@ function ConversationMessageRow({
  * work here as the errand has him do on a control — so whose judgment an
  * action was is read at a glance and never wears a reply's bubble. The words
  * are composed from the act's record and the roster as it stands, the session
- * set apart by name; a line whose record cannot be read back to a row draws
- * the words recorded at the time instead. They end on the mark of the
- * provider the action reached — the session's own for an action on a
- * session, the one a creation asked for a new workspace — so a row is placed
- * the way a session row is, by its mark. A line an earlier build recorded
- * without its kind draws with the mark's room left empty rather than guessing
- * one. No copy control: the words are a record of an act, not something said.
+ * the session a chip under the mark its own row wears, so a row is placed the
+ * way a session row is; a line whose record cannot be read back to a row
+ * draws the words recorded at the time instead, ending on the mark of the
+ * provider its identity names, since those words carry no chip. A line an
+ * earlier build recorded without its kind draws with the mark's room left
+ * empty rather than guessing one. No copy control: the words are a record of
+ * an act, not something said. A chip is a name, not a press: a session's
+ * address is reached by its row or by a validated ask, never from here.
  */
 function ConversationActionRow({
   entry,
@@ -308,7 +309,11 @@ function ConversationActionRow({
               {parts.map((part, index) =>
                 part.name ? (
                   // biome-ignore lint/suspicious/noArrayIndexKey: The parts are a fixed composition of one record, so a position names a part for as long as the row stands.
-                  <span key={index} className="conversation-action-name">
+                  <span key={index} className="conversation-action-chip">
+                    <ProviderMark
+                      providerId={part.name.markId}
+                      className="conversation-chip-mark"
+                    />
                     {part.text}
                   </span>
                 ) : (
@@ -318,12 +323,14 @@ function ConversationActionRow({
               )}
             </span>
           ) : (
-            <MarkdownMessage words={entry.words} className="conversation-words" />
-          )}
-          {providerId === undefined ? null : (
-            <span className="conversation-action-provider" aria-hidden="true">
-              <ProviderMark providerId={providerId} />
-            </span>
+            <>
+              <MarkdownMessage words={entry.words} className="conversation-words" />
+              {providerId === undefined ? null : (
+                <span className="conversation-action-provider" aria-hidden="true">
+                  <ProviderMark providerId={providerId} />
+                </span>
+              )}
+            </>
           )}
         </span>
       </div>

--- a/apps/desktop/src/renderer/conversation-panel.tsx
+++ b/apps/desktop/src/renderer/conversation-panel.tsx
@@ -267,14 +267,14 @@ function ConversationMessageRow({
  * work here as the errand has him do on a control — so whose judgment an
  * action was is read at a glance and never wears a reply's bubble. The words
  * are composed from the act's record and the roster as it stands, the session
- * the session a chip under the mark its own row wears, so a row is placed the
- * way a session row is; a line whose record cannot be read back to a row
- * draws the words recorded at the time instead, ending on the mark of the
- * provider its identity names, since those words carry no chip. A line an
- * earlier build recorded without its kind draws with the mark's room left
- * empty rather than guessing one. No copy control: the words are a record of
- * an act, not something said. A chip is a name, not a press: a session's
- * address is reached by its row or by a validated ask, never from here.
+ * the chat it reached a chip; the kind's mark is followed by the mark of the
+ * provider the action reached, so a row is placed the way a session row is.
+ * A line whose record cannot be read back to a row draws the words recorded
+ * at the time instead. A line an earlier build recorded without its kind
+ * draws with the mark's room left empty rather than guessing one. No copy
+ * control: the words are a record of an act, not something said. A chip is a
+ * name, not a press: a session's address is reached by its row or by a
+ * validated ask, never from here.
  */
 function ConversationActionRow({
   entry,
@@ -297,12 +297,15 @@ function ConversationActionRow({
       <small className="visually-hidden">{presentation.label}</small>
       <div className="conversation-message">
         <span className="conversation-action">
-          <span
-            className="conversation-action-mark"
-            aria-hidden="true"
-            data-control={entry.action?.controlKind}
-          >
-            {own ? <WingFace /> : Glyph ? <Glyph /> : null}
+          <span className="conversation-action-marks" aria-hidden="true">
+            <span className="conversation-action-mark" data-control={entry.action?.controlKind}>
+              {own ? <WingFace /> : Glyph ? <Glyph /> : null}
+            </span>
+            {providerId === undefined ? null : (
+              <span className="conversation-action-mark">
+                <ProviderMark providerId={providerId} />
+              </span>
+            )}
           </span>
           {parts ? (
             <span className="conversation-words">
@@ -310,10 +313,12 @@ function ConversationActionRow({
                 part.name ? (
                   // biome-ignore lint/suspicious/noArrayIndexKey: The parts are a fixed composition of one record, so a position names a part for as long as the row stands.
                   <span key={index} className="conversation-action-chip">
-                    <ProviderMark
-                      providerId={part.name.markId}
-                      className="conversation-chip-mark"
-                    />
+                    {part.name.markId === undefined ? null : (
+                      <ProviderMark
+                        providerId={part.name.markId}
+                        className="conversation-chip-mark"
+                      />
+                    )}
                     {part.text}
                   </span>
                 ) : (
@@ -323,14 +328,7 @@ function ConversationActionRow({
               )}
             </span>
           ) : (
-            <>
-              <MarkdownMessage words={entry.words} className="conversation-words" />
-              {providerId === undefined ? null : (
-                <span className="conversation-action-provider" aria-hidden="true">
-                  <ProviderMark providerId={providerId} />
-                </span>
-              )}
-            </>
+            <MarkdownMessage words={entry.words} className="conversation-words" />
           )}
         </span>
       </div>

--- a/apps/desktop/src/renderer/styles/conversation.css
+++ b/apps/desktop/src/renderer/styles/conversation.css
@@ -442,11 +442,31 @@
   line-height: 1.4;
 }
 
-/* The session an action reached, set apart by name the way the row for it is:
-   the one thing in the sentence the eye is looking for. */
-.conversation-action-name {
+/* The session an action reached, or the provider a creation asked, as a chip
+   under the mark its own row wears: the one thing in the sentence the eye is
+   looking for, named the way the roster names it. It is a name and not a
+   press, so it takes no hover and no ground change. */
+.conversation-action-chip {
+  display: inline-flex;
+  height: 18px;
+  align-items: center;
+  gap: 4px;
+  padding: 0 6px 0 4px;
+  border-radius: 6px;
+  background: var(--raised-strong);
   color: var(--text-primary);
   font-weight: 600;
+  vertical-align: -4px;
+  white-space: nowrap;
+}
+
+.conversation-action-chip .provider-mark {
+  width: 11px;
+  height: 11px;
+}
+
+.conversation-action-chip .provider-mark[data-mark="superset"] {
+  width: 19px;
 }
 
 /* A line drawn from its recorded words rather than its record keeps the

--- a/apps/desktop/src/renderer/styles/conversation.css
+++ b/apps/desktop/src/renderer/styles/conversation.css
@@ -394,27 +394,19 @@
   padding: 3px 0;
 }
 
-/* The provider's mark, at the size the row's own marks take, trailing the
-   words the way a session row's application marks trail its title. */
-.conversation-action-provider {
+/* The marks a row leads with: the kind of thing done, then the provider it
+   reached, the way a session row leads with its provider's mark. The kind's
+   room is reserved whether or not a mark fills it, so rows with and without
+   one keep their words on one line. Luke's face in it wears the text colour
+   like the strip's does, only smaller. */
+.conversation-action-marks {
   display: inline-flex;
-  height: 16px;
   flex: 0 0 auto;
   align-items: center;
+  gap: 6px;
+  margin-top: 2px;
 }
 
-.conversation-action-provider .provider-mark {
-  width: 12px;
-  height: 12px;
-}
-
-.conversation-action-provider .provider-mark[data-mark="superset"] {
-  width: 21px;
-}
-
-/* The mark's room is reserved whether or not a mark fills it, so rows with
-   and without one keep their words on one line. Luke's face in it wears the
-   text colour like the strip's does, only smaller. */
 .conversation-action-mark {
   display: inline-flex;
   width: 12px;
@@ -422,13 +414,16 @@
   flex: 0 0 auto;
   align-items: center;
   justify-content: center;
-  margin-top: 2px;
   color: var(--text-tertiary);
 }
 
 .conversation-action-mark svg {
   width: 12px;
   height: 12px;
+}
+
+.conversation-action-mark .provider-mark[data-mark="superset"] {
+  width: 21px;
 }
 
 .conversation-action-mark .luke-face {
@@ -442,31 +437,38 @@
   line-height: 1.4;
 }
 
-/* The session an action reached, or the provider a creation asked, as a chip
-   under the mark its own row wears: the one thing in the sentence the eye is
-   looking for, named the way the roster names it. It is a name and not a
-   press, so it takes no hover and no ground change. */
+/* The chat an action reached, or the workspace a creation made, as a chip:
+   the one thing in the sentence the eye is looking for, named the way the
+   roster names it. It sits on the line's middle rather than its baseline, so
+   it reads as part of the sentence and not as a tag hung under it, and it is
+   drawn a hair shorter than the line so it never pushes the lines apart. It
+   wears a mark only for a hosted agent, since the row's own marks already
+   say the provider. It is a name and not a press, so it takes no hover. */
 .conversation-action-chip {
   display: inline-flex;
-  height: 18px;
+  height: 16px;
   align-items: center;
   gap: 4px;
-  padding: 0 6px 0 4px;
-  border-radius: 6px;
+  padding: 0 6px;
+  border-radius: 5px;
   background: var(--raised-strong);
   color: var(--text-primary);
   font-weight: 600;
-  vertical-align: -4px;
+  vertical-align: middle;
   white-space: nowrap;
 }
 
+.conversation-action-chip:has(.provider-mark) {
+  padding-left: 4px;
+}
+
 .conversation-action-chip .provider-mark {
-  width: 11px;
-  height: 11px;
+  width: 10px;
+  height: 10px;
 }
 
 .conversation-action-chip .provider-mark[data-mark="superset"] {
-  width: 19px;
+  width: 18px;
 }
 
 /* A line drawn from its recorded words rather than its record keeps the

--- a/apps/desktop/src/renderer/styles/conversation.css
+++ b/apps/desktop/src/renderer/styles/conversation.css
@@ -439,22 +439,23 @@
 
 /* The chat an action reached, or the workspace a creation made, as a chip:
    the one thing in the sentence the eye is looking for, named the way the
-   roster names it. It sits on the line's middle rather than its baseline, so
-   it reads as part of the sentence and not as a tag hung under it, and it is
-   drawn a hair shorter than the line so it never pushes the lines apart. It
-   wears a mark only for a hosted agent, since the row's own marks already
-   say the provider. It is a name and not a press, so it takes no hover. */
+   roster names it. Its text shares the sentence's baseline — an inline flex
+   box takes its first item's baseline, and the text is that item — so the
+   name reads as a word of the sentence with a ground under it, and the box
+   is one pixel over and under the line so it never pushes the lines apart.
+   It wears the mark its roster row wears. It is a name and not a press, so
+   it takes no hover. */
 .conversation-action-chip {
   display: inline-flex;
-  height: 16px;
   align-items: center;
   gap: 4px;
-  padding: 0 6px;
+  padding: 1px 6px;
   border-radius: 5px;
   background: var(--raised-strong);
   color: var(--text-primary);
   font-weight: 600;
-  vertical-align: middle;
+  line-height: 14px;
+  vertical-align: baseline;
   white-space: nowrap;
 }
 

--- a/packages/actions/src/action-narration.ts
+++ b/packages/actions/src/action-narration.ts
@@ -118,39 +118,72 @@ const ACTION_NARRATION = {
  * compile. Only what the narration names rides along — never a model or an
  * effort, which the row has no words for.
  */
+type ActionRecordDetails = Omit<ConversationEntryAction, "kind" | "runId">;
+
+/** The title the roster held for the session at the time, for the row to fall back to once it is gone. */
+function observedTitle(
+  identity: SessionIdentity,
+  sessions: readonly Session[],
+): ActionRecordDetails {
+  const session = sessions.find(
+    (candidate) =>
+      candidate.providerId === identity.providerId &&
+      candidate.providerSessionId === identity.providerSessionId,
+  );
+  return session ? { title: session.title } : {};
+}
+
 const ACTION_RECORD = {
-  [ACTION_KIND.MESSAGE]: (action) => ({ text: action.text }),
-  [ACTION_KIND.CONTROL]: (action) => ({
+  [ACTION_KIND.MESSAGE]: (action, sessions) => ({
+    text: action.text,
+    ...observedTitle(action.identity, sessions),
+  }),
+  [ACTION_KIND.CONTROL]: (action, sessions) => ({
     label: action.control.label,
     ...(action.control.controlKind !== undefined
       ? { controlKind: action.control.controlKind }
       : undefined),
+    ...observedTitle(action.identity, sessions),
   }),
-  [ACTION_KIND.OPEN]: (action) =>
-    action.applicationId !== undefined ? { applicationId: action.applicationId } : {},
+  [ACTION_KIND.OPEN]: (action, sessions) => ({
+    ...(action.applicationId !== undefined ? { applicationId: action.applicationId } : undefined),
+    ...observedTitle(action.identity, sessions),
+  }),
   [ACTION_KIND.CREATE_WORKSPACE]: (action) => ({
     providerId: action.providerId,
     ...(action.name !== undefined ? { name: action.name } : undefined),
   }),
-  [ACTION_KIND.ADD_AGENT]: (action) => ({
+  [ACTION_KIND.ADD_AGENT]: (action, sessions) => ({
     agent: action.agent,
     ...(action.name !== undefined ? { name: action.name } : undefined),
+    ...observedTitle(action.identity, sessions),
   }),
-  [ACTION_KIND.RENAME_WORKSPACE]: (action) => ({ name: action.name }),
-  [ACTION_KIND.RENAME_SESSION]: (action) => ({ name: action.name }),
+  [ACTION_KIND.RENAME_WORKSPACE]: (action, sessions) => ({
+    name: action.name,
+    ...observedTitle(action.identity, sessions),
+  }),
+  [ACTION_KIND.RENAME_SESSION]: (action, sessions) => ({
+    name: action.name,
+    ...observedTitle(action.identity, sessions),
+  }),
 } as const satisfies {
   [K in SessionActionKind]: (
     action: CarriedAction<K>,
-  ) => Omit<ConversationEntryAction, "kind" | "runId">;
+    sessions: readonly Session[],
+  ) => ActionRecordDetails;
 };
 
-function carriedActionRecord(action: CarriedSessionAction, runId: string): ConversationEntryAction {
+function carriedActionRecord(
+  action: CarriedSessionAction,
+  sessions: readonly Session[],
+  runId: string,
+): ConversationEntryAction {
   const record = ACTION_RECORD[action.kind];
   // SAFETY: the table is keyed by the same union `action.kind` ranges over, so the
   // entry selected is the one written for this action's own shape.
   const details = (
-    record as (action: CarriedSessionAction) => Omit<ConversationEntryAction, "kind" | "runId">
-  )(action);
+    record as (action: CarriedSessionAction, sessions: readonly Session[]) => ActionRecordDetails
+  )(action, sessions);
   return { kind: action.kind, runId, ...details };
 }
 
@@ -185,7 +218,11 @@ export function sessionActionConversationEntry(
   runId: string,
 ): ConversationEntry {
   const words = actionNarration(action, context);
-  const entry: ConversationEntry = { kind, words, action: carriedActionRecord(action, runId) };
+  const entry: ConversationEntry = {
+    kind,
+    words,
+    action: carriedActionRecord(action, context.sessions, runId),
+  };
   if ("identity" in action) entry.identity = action.identity;
   return entry;
 }

--- a/packages/actions/src/action-narration.ts
+++ b/packages/actions/src/action-narration.ts
@@ -120,7 +120,11 @@ const ACTION_NARRATION = {
  */
 type ActionRecordDetails = Omit<ConversationEntryAction, "kind" | "runId">;
 
-/** The title the roster held for the session at the time, for the row to fall back to once it is gone. */
+/**
+ * How the roster named and marked the chat at the time — its title, and the
+ * agent having it where the provider hosts agents — for the row to fall back
+ * to once the roster has let the chat go.
+ */
 function observedTitle(
   identity: SessionIdentity,
   sessions: readonly Session[],
@@ -130,7 +134,8 @@ function observedTitle(
       candidate.providerId === identity.providerId &&
       candidate.providerSessionId === identity.providerSessionId,
   );
-  return session ? { title: session.title } : {};
+  if (!session) return {};
+  return { title: session.title, ...(session.agent ? { agentId: session.agent.id } : undefined) };
 }
 
 const ACTION_RECORD = {

--- a/packages/actions/src/actions.test.ts
+++ b/packages/actions/src/actions.test.ts
@@ -248,6 +248,7 @@ test("an action's line records the ask in words, with the identity it named", ()
     kind: ACTION_KIND.MESSAGE,
     runId: "run-1",
     text: "please add tests",
+    title: "checkout-service",
   });
 
   const control: AdvertisedControl = { kind: ACTION_KIND.CONTROL, id: "retry", label: "Retry" };
@@ -258,7 +259,12 @@ test("an action's line records the ask in words, with the identity it named", ()
     "run-1",
   );
   assert.equal(pressed.words, 'ran "Retry" on "checkout-service"');
-  assert.deepEqual(pressed.action, { kind: ACTION_KIND.CONTROL, runId: "run-1", label: "Retry" });
+  assert.deepEqual(pressed.action, {
+    kind: ACTION_KIND.CONTROL,
+    runId: "run-1",
+    label: "Retry",
+    title: "checkout-service",
+  });
   // A control whose adapter said what it does is narrated as that act, and records it.
   const archive: AdvertisedControl = {
     kind: ACTION_KIND.CONTROL,
@@ -278,6 +284,7 @@ test("an action's line records the ask in words, with the identity it named", ()
     runId: "run-1",
     label: "Archive",
     controlKind: SESSION_CONTROL_KIND.ARCHIVE,
+    title: "checkout-service",
   });
   const stop: AdvertisedControl = {
     kind: ACTION_KIND.CONTROL,

--- a/packages/host/src/brain/action-performer.test.ts
+++ b/packages/host/src/brain/action-performer.test.ts
@@ -180,6 +180,7 @@ test("a session action reaches the performer only for a session the roster holds
     kind: "message",
     runId: LIVE.runId,
     text: "go ahead",
+    title: "Fix the flaky test",
   });
 
   const stranger = await actions.perform(
@@ -348,7 +349,12 @@ test("an action in a turn Luke opened himself runs under the same validators and
   assert.equal(performed.length, 1);
   assert.equal(recorded.length, 1);
   assert.equal(recorded[0]?.kind, "own-action");
-  assert.deepEqual(recorded[0]?.action, { kind: "message", runId: "wake-1", text: "go ahead" });
+  assert.deepEqual(recorded[0]?.action, {
+    kind: "message",
+    runId: "wake-1",
+    text: "go ahead",
+    title: "Fix the flaky test",
+  });
 });
 
 test("an action with no turn standing is refused in main before any validator or effect", async () => {

--- a/packages/session/src/conversation/conversation.test.ts
+++ b/packages/session/src/conversation/conversation.test.ts
@@ -459,6 +459,7 @@ test("a stored line reads back, and retention cuts by age and by count", () => {
       applicationId: "cursor",
       agent: "claude",
       name: "release-candidate",
+      title: "checkout-service",
     },
   };
   assert.deepEqual(storedConversationEntry(conversationEntryToWire(detailed)), detailed);

--- a/packages/session/src/conversation/conversation.ts
+++ b/packages/session/src/conversation/conversation.ts
@@ -192,6 +192,13 @@ export interface ConversationEntryAction {
   agent?: string;
   /** The name a creation, an add, or a rename gave. */
   name?: string;
+  /**
+   * The title the session the action reached had at the time. The panel names
+   * a session from the roster while the roster holds it; this is the name it
+   * falls back to once the session is archived or otherwise gone, so the row
+   * can still say which chat the act reached.
+   */
+  title?: string;
 }
 
 const CONVERSATION_ENTRY_ACTION_DETAILS = [
@@ -201,6 +208,7 @@ const CONVERSATION_ENTRY_ACTION_DETAILS = [
   "applicationId",
   "agent",
   "name",
+  "title",
 ] as const satisfies readonly (keyof ConversationEntryAction)[];
 
 /** The line as the Gateway protocol carries it; the unstrict read below takes it back whole. */

--- a/packages/session/src/conversation/conversation.ts
+++ b/packages/session/src/conversation/conversation.ts
@@ -199,6 +199,12 @@ export interface ConversationEntryAction {
    * can still say which chat the act reached.
    */
   title?: string;
+  /**
+   * The agent having that chat, where its provider hosts agents rather than
+   * being one, so the chip for a chat the roster has let go still wears the
+   * mark its row wore.
+   */
+  agentId?: string;
 }
 
 const CONVERSATION_ENTRY_ACTION_DETAILS = [
@@ -209,6 +215,7 @@ const CONVERSATION_ENTRY_ACTION_DETAILS = [
   "agent",
   "name",
   "title",
+  "agentId",
 ] as const satisfies readonly (keyof ConversationEntryAction)[];
 
 /** The line as the Gateway protocol carries it; the unstrict read below takes it back whole. */


### PR DESCRIPTION
Stacked on #893 → #892 → #890 → #889 → #882.

The session an action reached stood in the row as emphasized text, with the provider's mark trailing the sentence. Now:

- **Every row leads with two marks:** the kind of thing done, then the provider it reached, the way a session row leads with its provider's mark. The trailing mark is gone.
- **The chat is a chip**, named and marked as its roster row is: the agent's mark where the provider hosts agents (Claude inside a Conductor chat), else the provider's. The row's own provider mark steps aside where the chip already says it, so no mark is drawn twice. The chip's text shares the sentence's baseline.
- **A creation reads "Created a new workspace" followed by the workspace's name as a chip**, with the provider's mark after the plus; it no longer ends on a provider chip.
- **The record keeps the chat's title and agent at the time**, so an act on a chat the roster has since archived or lost still names and marks it instead of falling back to the recorded sentence.

In this PR a chip is a name and not a press; the next PR in the stack makes it one.

Verification: typecheck clean; desktop renderer 288 tests pass, with the composer test asserting the chip's mark follows the agent when one is hosted, and the panel test asserting the chip markup and the absence of the trailing mark. The panel was rendered against the real stylesheets and inspected: chips for Superset, Conductor, and a Claude Code fallback row all draw as intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34426351440/artifacts/10132862328) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34426351440)

- Commit: `30e5c096afdb8da08ce5bec6b857db9c6667bda0`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/edd416a9-4048-4f0a-ac6d-fdae20bd92f6)


