### PR TITLE
fix(actions): ignore a volunteered effort on a setting that takes none

### DIFF
--- a/packages/actions/src/action-schemas.ts
+++ b/packages/actions/src/action-schemas.ts
@@ -247,7 +247,10 @@ export const ISSUE_COMMENT_REQUEST = record({ ...ISSUE_IDENTITY_FIELDS, body: CO
 export const SETTING_REQUEST = record({
   setting_id: s.text({ description: "The setting ID." }),
   value: s.text({ description: "The new value." }),
-  effort: OPTIONAL_EFFORT,
+  effort: OPTIONAL_EFFORT.describe(
+    "An effort level, only when the developer named one and the setting's guide line lists " +
+      "efforts for the value; omit it everywhere else.",
+  ),
 });
 
 /** The narrowing as it arrives on each surface; absent is no narrowing at all. */

--- a/packages/actions/src/admit.ts
+++ b/packages/actions/src/admit.ts
@@ -840,16 +840,16 @@ const admitSetting: Admitter<typeof ACTION_KIND.SETTING> = (fields, context) => 
   // An effort may ride only a value the guide lists levels for, so both halves
   // of one stored pairing can be asked for in one change — matched like the
   // value: case retold rather than copied, answered in the guide's own casing.
+  // A setting with no levels anywhere has no effort to pair: one volunteered
+  // beside it is a field admission does not read, dropped like an unknown key
+  // rather than allowed to block the change it rode in on. Only an
+  // effort-aware setting refuses, because there half the ask would be lost.
   const effortWord = textArgument(fields, "effort");
-  if (effortWord === undefined) return { kind: ACTION_KIND.SETTING, setting, value };
-  const levels = setting.efforts?.[value] ?? [];
-  if (levels.length === 0) {
-    return refuse(
-      setting.efforts === undefined
-        ? `${setting.label} takes no effort level.`
-        : `${value} takes no effort level.`,
-    );
+  if (effortWord === undefined || setting.efforts === undefined) {
+    return { kind: ACTION_KIND.SETTING, setting, value };
   }
+  const levels = setting.efforts[value] ?? [];
+  if (levels.length === 0) return refuse(`${value} takes no effort level.`);
   const normalizedEffort = effortWord.trim().toLowerCase();
   const effort = levels.find((candidate) => candidate.toLowerCase() === normalizedEffort);
   if (effort === undefined) return refuse(`${value}'s effort is one of ${levels.join(", ")}.`);

--- a/packages/actions/src/guide.test.ts
+++ b/packages/actions/src/guide.test.ts
@@ -238,12 +238,18 @@ test("a value and its effort named in one change are validated as the pair they 
     assert.match(levelless.reason, /Cursor Auto takes no effort level/);
   }
 
-  // And a setting with no levels anywhere refuses by its own name.
-  const toggled = await change('{"setting_id":"voice_captions","value":"on","effort":"high"}');
-  assert.equal(toggled.status, ACTION_RESULT_STATUS.REJECTED);
-  if (toggled.status === ACTION_RESULT_STATUS.REJECTED) {
-    assert.match(toggled.reason, /Captions takes no effort level/);
-  }
+  // A setting with no levels anywhere has no effort to pair: a volunteered
+  // one is dropped like an unknown key, and the change it rode in on lands.
+  assert.deepEqual(await change('{"setting_id":"voice_captions","value":"on","effort":"high"}'), {
+    kind: "setting",
+    setting: GUIDE.settings[0],
+    value: "on",
+  });
+  assert.deepEqual(await change('{"setting_id":"voice","value":"Marin","effort":"low"}'), {
+    kind: "setting",
+    setting: GUIDE.settings[1],
+    value: "marin",
+  });
 });
 
 test("a by-hand-only setting is refused with the path to it, so the refusal is the guidance", async () => {

--- a/packages/guide/src/guide.ts
+++ b/packages/guide/src/guide.ts
@@ -66,7 +66,9 @@ export interface AppGuideSetting {
    * the choice exactly as `choices` lists it. A choice absent here takes no
    * level. This is what lets one spoken change name both halves of a stored
    * pairing at once: `change_app_setting` accepts an effort only for a value
-   * this field lists levels for, and refuses it everywhere else.
+   * this field lists levels for, refuses one on any other choice here, and on
+   * a setting with no levels at all ignores it, so a volunteered effort never
+   * blocks a change it could not have meant anything to.
    */
   efforts?: Readonly<Partial<Record<string, readonly string[]>>>;
   /** Whether a spoken ask may change it; false means describe, never act. */


### PR DESCRIPTION
## Summary

A request to turn Captions on failed whenever the model volunteered `change_app_setting`'s optional `effort` field: `admitSetting` refused any effort on a setting whose guide entry declares no `efforts` map, so the whole change died with "Captions takes no effort level." Nothing required the field — the emitted JSON schema correctly leaves `effort` out of `required` on both the brain's Responses path and the realtime voice path — but models routinely fill plausible optional fields, and the validator turned that surplus into a refusal of a change it meant nothing to.

- `packages/actions/src/admit.ts`: a setting with no efforts anywhere now drops a volunteered effort the way the request schema already drops an unknown key, and the change lands. An effort-aware setting keeps its exact behavior: a valid pair is carried in the guide's own casing, an unknown level refuses with the level list, and a value the setting lists no levels for still refuses, because there half the ask would be silently lost.
- `packages/actions/src/action-schemas.ts`: the `effort` field's description now says to supply it only when the developer named one and the setting's guide line lists efforts for the value, steering models away from volunteering it.
- `packages/guide/src/guide.ts`: the `AppGuideSetting.efforts` docstring describes the new contract.
- `packages/actions/src/guide.test.ts`: the captions case now asserts the change succeeds with the effort dropped, plus a new case for a choice setting with no efforts; the effort-aware cases are unchanged.

## Testing

- `./scripts/check.sh` passes end to end (repository checks, typecheck, every package's tests, builds), `fail 0` across all packages.
- Verified the emitted `SETTING_REQUEST` JSON schema still lists only `setting_id` and `value` as required.
- Portable-only change with no UI surface, so no macOS `verify.sh` run or visual evidence applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/f0a5c241-9163-499c-995d-6c3dc6bad92b)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34420358677/artifacts/10130733161) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34420358677)

- Commit: `692d2a63b241cafa98a0c5bec64cb0ff76ba2f6c`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
