### PR TITLE
feat(desktop): fold the actions one turn carried under a count

### DIFF
--- a/apps/desktop/src/renderer/conversation-panel.test.ts
+++ b/apps/desktop/src/renderer/conversation-panel.test.ts
@@ -4,6 +4,7 @@ import {
   ACTION_KIND,
   appendConversationThreadEntry,
   CONVERSATION_ENTRY_KIND,
+  type ConversationEntry,
 } from "@sidecar/session";
 import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
@@ -64,7 +65,7 @@ test("an action draws as a row led by the mark of its kind, with no bubble and n
           kind: CONVERSATION_ENTRY_KIND.ACTION,
           words: 'sent a message to "checkout-service": "please add tests"',
           recordedAt: NOW,
-          action: { kind: ACTION_KIND.MESSAGE },
+          action: { kind: ACTION_KIND.MESSAGE, runId: "run-1" },
         },
       ],
       now: NOW,
@@ -110,7 +111,7 @@ test("an action row ends on the mark of the provider it reached", () => {
     kind: CONVERSATION_ENTRY_KIND.ACTION,
     words: 'sent a message to "checkout-service": "please add tests"',
     identity: { providerId: "claude-code", providerSessionId: "session-a" },
-    action: { kind: ACTION_KIND.MESSAGE },
+    action: { kind: ACTION_KIND.MESSAGE, runId: "run-1" },
   });
   assert.match(
     onSession,
@@ -120,7 +121,7 @@ test("an action row ends on the mark of the provider it reached", () => {
   const creation = render({
     kind: CONVERSATION_ENTRY_KIND.ACTION,
     words: 'asked conductor to create a workspace named "Notch panel clipping"',
-    action: { kind: ACTION_KIND.CREATE_WORKSPACE, providerId: "conductor" },
+    action: { kind: ACTION_KIND.CREATE_WORKSPACE, runId: "run-2", providerId: "conductor" },
   });
   assert.match(creation, /class="provider-mark" data-mark="conductor"/);
 });
@@ -132,7 +133,7 @@ test("an action Luke took on his own is signed with his face and never wears a r
         {
           kind: CONVERSATION_ENTRY_KIND.OWN_ACTION,
           words: 'ran "Retry" on "checkout-service"',
-          action: { kind: ACTION_KIND.CONTROL },
+          action: { kind: ACTION_KIND.CONTROL, runId: "wake-1" },
         },
       ],
       now: NOW,
@@ -147,6 +148,128 @@ test("an action Luke took on his own is signed with his face and never wears a r
     /class="conversation-action-mark" aria-hidden="true"><svg class="luke-face"/,
   );
   assert.doesNotMatch(markup, /data-speaker="luke"|conversation-copy/);
+});
+
+test("the actions one run carried fold under a count once the run ends, and stand open while it runs", () => {
+  const run = {
+    runId: "run-1",
+    submissionId: "sub-1",
+    origin: "typed",
+    question: "ship it and open it",
+    revision: 1,
+    acceptedAt: 1,
+    performedActions: 0,
+    unknownActions: 0,
+  } as const;
+  const render = (status: "running" | "succeeded") =>
+    renderToStaticMarkup(
+      createElement(ConversationPanel, {
+        entries: [
+          {
+            kind: CONVERSATION_ENTRY_KIND.TYPED_ASK,
+            words: "ship it and open it",
+            requestId: "run-1",
+          },
+          {
+            kind: CONVERSATION_ENTRY_KIND.ACTION,
+            words: 'sent a message to "checkout-service": "ship it"',
+            action: { kind: ACTION_KIND.MESSAGE, runId: "run-1" },
+          },
+          {
+            kind: CONVERSATION_ENTRY_KIND.ACTION,
+            words: 'opened "checkout-service"',
+            action: { kind: ACTION_KIND.OPEN, runId: "run-1" },
+          },
+          { kind: CONVERSATION_ENTRY_KIND.REPLY, words: "Done.", requestId: "run-1" },
+        ],
+        requests: [{ ...run, status }],
+        now: NOW,
+        ask: async () => undefined,
+        onAskEngaged: () => undefined,
+      }),
+    );
+  const working = render("running");
+  assert.match(working, /<li class="conversation-turn" data-open="true">/);
+  assert.match(
+    working,
+    /class="conversation-turn-toggle" aria-expanded="true" aria-controls="([^"]+)"/,
+  );
+  assert.match(working, /<span>2 actions<\/span>/);
+  assert.equal(working.match(/class="conversation-action"/g)?.length, 2);
+  assert.doesNotMatch(working, /hidden=""/);
+
+  const settled = render("succeeded");
+  assert.match(settled, /<li class="conversation-turn">/);
+  assert.match(settled, /aria-expanded="false"/);
+  assert.match(settled, /<ol id="[^"]+" class="conversation-turn-actions" hidden="">/);
+  // The ask before the turn and the reply after it stay lines of their own.
+  assert.match(settled, /data-speaker="you"/);
+  assert.match(settled, /data-speaker="luke"/);
+  // The toggle names the list it folds.
+  const controls = settled.match(/aria-controls="([^"]+)"/)?.[1];
+  assert.ok(controls);
+  assert.match(settled, new RegExp(`<ol id="${controls.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}"`));
+});
+
+test("a turn Luke opened himself stands open while it is the newest line, and folds once anything follows", () => {
+  const retried = {
+    kind: CONVERSATION_ENTRY_KIND.OWN_ACTION,
+    words: 'ran "Retry" on "amber-shoal"',
+    action: { kind: ACTION_KIND.CONTROL, runId: "wake-1" },
+  };
+  const opened = {
+    kind: CONVERSATION_ENTRY_KIND.OWN_ACTION,
+    words: 'opened "amber-shoal"',
+    action: { kind: ACTION_KIND.OPEN, runId: "wake-1" },
+  };
+  const render = (entries: readonly ConversationEntry[], live: readonly ConversationEntry[] = []) =>
+    renderToStaticMarkup(
+      createElement(ConversationPanel, {
+        entries,
+        live,
+        now: NOW,
+        ask: async () => undefined,
+        onAskEngaged: () => undefined,
+      }),
+    );
+  // No request record stands for a wake, so the tail is the only sign the turn is still going.
+  assert.match(render([retried, opened]), /<li class="conversation-turn" data-open="true">/);
+  const announced = render([
+    retried,
+    opened,
+    { kind: CONVERSATION_ENTRY_KIND.ANNOUNCEMENT, words: "I retried amber-shoal." },
+  ]);
+  assert.match(announced, /<li class="conversation-turn">/);
+  // The announcement still being said counts as something after it.
+  const speaking = render(
+    [retried, opened],
+    [{ kind: CONVERSATION_ENTRY_KIND.ANNOUNCEMENT, words: "I retried" }],
+  );
+  assert.match(speaking, /<li class="conversation-turn">/);
+});
+
+test("a turn of one action is the row it is, and two runs' actions never fold together", () => {
+  const markup = renderToStaticMarkup(
+    createElement(ConversationPanel, {
+      entries: [
+        {
+          kind: CONVERSATION_ENTRY_KIND.ACTION,
+          words: 'opened "checkout-service"',
+          action: { kind: ACTION_KIND.OPEN, runId: "run-1" },
+        },
+        {
+          kind: CONVERSATION_ENTRY_KIND.ACTION,
+          words: 'opened "lisbon-v2"',
+          action: { kind: ACTION_KIND.OPEN, runId: "run-2" },
+        },
+      ],
+      now: NOW,
+      ask: async () => undefined,
+      onAskEngaged: () => undefined,
+    }),
+  );
+  assert.doesNotMatch(markup, /conversation-turn/);
+  assert.equal(markup.match(/class="conversation-action"/g)?.length, 2);
 });
 
 test("an announcement shows its spoken transcript", () => {

--- a/apps/desktop/src/renderer/conversation-panel.tsx
+++ b/apps/desktop/src/renderer/conversation-panel.tsx
@@ -1,6 +1,7 @@
 import { type BrainRequestSnapshot, brainRequestPending } from "@sidecar/brain/requests-wire";
 import {
   CheckIcon,
+  ChevronIcon,
   ControlIcon,
   CopyIcon,
   ExternalIcon,
@@ -19,7 +20,7 @@ import {
   conversationEntryKey,
 } from "@sidecar/session";
 import { FACE_MOTION } from "@sidecar/surface";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useId, useRef, useState } from "react";
 import { ACT_KIND } from "#shared/messages/acts";
 import { tell } from "./act";
 import { type AskHandler, AskLuke } from "./ask-luke";
@@ -291,6 +292,58 @@ function ConversationEntryRow(props: {
 }
 
 /**
+ * The actions one turn carried, folded under a single line that counts them.
+ * The fold follows the run: open while the run is still going, so the
+ * developer watches the actions land as Luke takes them, and closed once it
+ * has ended, so a settled turn takes one row of the thread however much it
+ * did. Whether the run is going is read from its request record where one
+ * stands; a turn Luke opened himself is a wake, not an ask, and has none, so
+ * it stands open while it is the thread's newest line and folds once anything
+ * lands after it. A press on the toggle is the developer's own choice and
+ * holds from then on, whatever the run does next. A turn of one action never
+ * gets here: there is nothing to fold.
+ */
+function ConversationTurn({
+  entries,
+  pending,
+}: {
+  entries: readonly KeyedConversationEntry[];
+  pending: boolean;
+}): React.JSX.Element {
+  const [choice, setChoice] = useState<boolean | undefined>(undefined);
+  const open = choice ?? pending;
+  const actionsId = useId();
+  const own = entries.some(({ entry }) => entry.kind === CONVERSATION_ENTRY_KIND.OWN_ACTION);
+  return (
+    <li className="conversation-turn" data-open={open ? "true" : undefined}>
+      <div className="conversation-message conversation-turn-head">
+        <button
+          type="button"
+          className="conversation-turn-toggle"
+          aria-expanded={open}
+          aria-controls={actionsId}
+          onClick={() => setChoice(!open)}
+        >
+          <ChevronIcon />
+          {own ? (
+            <span className="conversation-action-mark" aria-hidden="true">
+              <WingFace />
+            </span>
+          ) : null}
+          <span>{entries.length} actions</span>
+          {own ? <small className="visually-hidden">on his own judgment</small> : null}
+        </button>
+      </div>
+      <ol id={actionsId} className="conversation-turn-actions" hidden={!open}>
+        {entries.map(({ entry, key }) => (
+          <ConversationActionRow key={key} entry={entry} />
+        ))}
+      </ol>
+    </li>
+  );
+}
+
+/**
  * The moment a line was said, set over it the way iMessage dates a message
  * that followed a long silence. It is the thread's line, not a message: it
  * reads in the quiet voice the requested actions use, and it stands still under
@@ -328,6 +381,36 @@ function keyedConversationEntries(
     const opensBreak = opensConversationTimeBreak(previousRecordedAt, entry.recordedAt);
     if (entry.recordedAt !== undefined) previousRecordedAt = entry.recordedAt;
     return { entry, key: `${base}:${occurrence}`, opensBreak };
+  });
+}
+
+type ConversationThreadItem =
+  | { turn?: undefined; item: KeyedConversationEntry }
+  | { turn: string; items: readonly KeyedConversationEntry[] };
+
+/**
+ * The thread as it is drawn: every line its own row, except that consecutive
+ * actions one run carried stand together as that run's turn. Only actions
+ * group — the run's ask before them and its reply after are lines of their
+ * own — and a run that carried one action is drawn as the row it is.
+ */
+export function conversationThreadItems(
+  entries: readonly ConversationEntry[],
+): readonly ConversationThreadItem[] {
+  const items: ConversationThreadItem[] = [];
+  for (const keyed of keyedConversationEntries(entries)) {
+    const runId = keyed.entry.action?.runId;
+    const last = items.at(-1);
+    if (runId !== undefined && last?.turn === runId) {
+      items[items.length - 1] = { turn: runId, items: [...last.items, keyed] };
+      continue;
+    }
+    items.push(runId === undefined ? { item: keyed } : { turn: runId, items: [keyed] });
+  }
+  return items.map((item) => {
+    if (item.turn === undefined) return item;
+    const [only, ...rest] = item.items;
+    return only !== undefined && rest.length === 0 ? { item: only } : item;
   });
 }
 
@@ -404,8 +487,9 @@ export function ConversationPanel({
   now: number;
   /**
    * The brain's runs, so a run still going draws Luke's turn at the thread's
-   * tail. Read here from the records alone; the reply's own line arrives when
-   * the run ends, and the stop is the composer's.
+   * tail and a turn still carrying actions stands unfolded. Read here from
+   * the records alone; the reply's own line arrives when the run ends, and
+   * the stop is the composer's.
    */
   requests?: readonly BrainRequestSnapshot[];
   /**
@@ -427,6 +511,10 @@ export function ConversationPanel({
   // way, and two waits for one turn would say otherwise. Its age is the
   // oldest run's.
   const pending = requests.filter(brainRequestPending);
+  const pendingRuns = new Set(pending.map((snapshot) => snapshot.runId));
+  const recordedRuns = new Set(requests.map((snapshot) => snapshot.runId));
+  const turnPending = (runId: string, tail: boolean) =>
+    recordedRuns.has(runId) ? pendingRuns.has(runId) : tail && live.length === 0;
   const thinkingSince =
     pending.length > 0 ? Math.min(...pending.map((snapshot) => snapshot.acceptedAt)) : undefined;
 
@@ -479,9 +567,24 @@ export function ConversationPanel({
               moment the fingers lift, which only the browser can see. */}
           <div className="conversation-pull">
             <ol className="conversation-list">
-              {keyedConversationEntries(entries).flatMap((keyed) =>
-                dated(keyed, <ConversationEntryRow key={keyed.key} entry={keyed.entry} />),
-              )}
+              {conversationThreadItems(entries).flatMap((item, index, items) => {
+                if (item.turn !== undefined) {
+                  const [lead] = item.items;
+                  if (lead === undefined) return [];
+                  return dated(
+                    lead,
+                    <ConversationTurn
+                      key={`turn:${lead.key}`}
+                      entries={item.items}
+                      pending={turnPending(item.turn, index === items.length - 1)}
+                    />,
+                  );
+                }
+                return dated(
+                  item.item,
+                  <ConversationEntryRow key={item.item.key} entry={item.item.entry} />,
+                );
+              })}
               {live.map((entry, index) => (
                 <ConversationEntryRow
                   // biome-ignore lint/suspicious/noArrayIndexKey: A line still being said has no durable id, and its words change on every delta — a key made of either would remount the bubble mid-sentence, while its position holds still for exactly as long as the line does.

--- a/apps/desktop/src/renderer/styles/conversation.css
+++ b/apps/desktop/src/renderer/styles/conversation.css
@@ -89,6 +89,10 @@
   /* Room for the widest stamp a twelve-hour clock draws, with its own inset
      from the thread's edge. */
   --conversation-time-column: 56px;
+  /* The room a folded turn's toggle overhangs the thread's left edge by, so
+     its hover ground rounds on that side too: the pull is a scroll box and
+     clips whatever crosses its edge, so the room has to be inside it. */
+  --conversation-toggle-overhang: 6px;
 
   position: relative;
   display: flex;
@@ -96,7 +100,7 @@
   flex-direction: column;
   gap: 4px;
   margin: 0;
-  padding: 0;
+  padding: 0 0 0 var(--conversation-toggle-overhang);
   list-style: none;
 }
 
@@ -467,8 +471,8 @@
   min-height: 24px;
   align-items: center;
   gap: 7px;
-  margin-left: -6px;
-  padding: 0 6px;
+  margin-left: calc(-1 * var(--conversation-toggle-overhang));
+  padding: 0 var(--conversation-toggle-overhang);
   border-radius: 8px;
   background: transparent;
   color: var(--text-secondary);

--- a/apps/desktop/src/renderer/styles/conversation.css
+++ b/apps/desktop/src/renderer/styles/conversation.css
@@ -444,6 +444,68 @@
   text-transform: uppercase;
 }
 
+/* The actions one turn carried, under a line that counts them. The toggle is
+   the count, led by the disclosure chevron the settings rows use, and the
+   rows it folds are indented no further: the chevron sits on the same edge
+   the rows' marks do, so folded and unfolded read as one column. The hover
+   ground reaches past that edge rather than pushing the chevron off it. */
+.conversation-turn {
+  display: flex;
+  width: 100%;
+  flex: 0 0 auto;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.conversation-turn-head {
+  position: sticky;
+  left: 0;
+}
+
+.conversation-turn-toggle {
+  display: inline-flex;
+  min-height: 24px;
+  align-items: center;
+  gap: 7px;
+  margin-left: -6px;
+  padding: 0 6px;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 11.5px;
+  transition:
+    background-color var(--duration-hover) ease,
+    color var(--duration-hover) ease;
+}
+
+.conversation-turn-toggle:hover {
+  background: var(--raised);
+  color: var(--text-primary);
+}
+
+.conversation-turn-toggle .settings-chevron {
+  width: 12px;
+  height: 12px;
+  transition: transform var(--duration-quick) var(--motion-exit);
+}
+
+.conversation-turn[data-open="true"] .conversation-turn-toggle .settings-chevron {
+  transform: rotate(90deg);
+}
+
+.conversation-turn-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.conversation-turn-actions[hidden] {
+  display: none;
+}
+
 /* The date over a line that followed a long silence, in the quiet voice the
    requested actions use, with the day set apart from the time the way iMessage
    sets it. It stands still under the pull as Luke's rows do, in the room the

--- a/packages/actions/src/action-narration.ts
+++ b/packages/actions/src/action-narration.ts
@@ -93,8 +93,9 @@ export function actionNarration(action: CarriedAction, sessions: readonly Sessio
 /**
  * The history line one carried action leaves behind: the ask, in the words of
  * what was asked — never the outcome, which the reply voicing it records as
- * its own line — beside the kind it was, which is what the panel draws the
- * line by. A transcript reading is deliberately only the fact that one was read: the
+ * its own line — beside the kind it was and the run that carried it, which is
+ * what the panel draws the line by and folds a turn's actions together on. A
+ * transcript reading is deliberately only the fact that one was read: the
  * rendering travels in the turn that asked for it and nowhere else, so the
  * record keeps the action and not a word of what it rendered.
  *
@@ -106,9 +107,10 @@ export function sessionActionConversationEntry(
   action: CarriedSessionAction,
   sessions: readonly Session[],
   kind: typeof CONVERSATION_ENTRY_KIND.ACTION | typeof CONVERSATION_ENTRY_KIND.OWN_ACTION,
+  runId: string,
 ): ConversationEntry {
   const words = actionNarration(action, sessions);
-  const carried: ConversationEntryAction = { kind: action.kind };
+  const carried: ConversationEntryAction = { kind: action.kind, runId };
   if (action.kind === ACTION_KIND.CREATE_WORKSPACE) carried.providerId = action.providerId;
   const entry: ConversationEntry = { kind, words, action: carried };
   if ("identity" in action) entry.identity = action.identity;

--- a/packages/actions/src/actions.test.ts
+++ b/packages/actions/src/actions.test.ts
@@ -226,12 +226,13 @@ test("an action's line records the ask in words, with the identity it named", ()
     { kind: ACTION_KIND.MESSAGE, identity, text: "please add tests" },
     sessions,
     CONVERSATION_ENTRY_KIND.ACTION,
+    "run-1",
   );
   assert.equal(message.kind, CONVERSATION_ENTRY_KIND.ACTION);
   assert.equal(message.words, 'sent a message to "checkout-service": "please add tests"');
   assert.deepEqual(message.identity, identity);
-  // The kind rides beside the words, for the panel to draw the row by.
-  assert.deepEqual(message.action, { kind: ACTION_KIND.MESSAGE });
+  // The kind and the run ride beside the words, for the panel to draw and fold by.
+  assert.deepEqual(message.action, { kind: ACTION_KIND.MESSAGE, runId: "run-1" });
 
   const control: AdvertisedControl = { kind: ACTION_KIND.CONTROL, id: "retry", label: "Retry" };
   assert.equal(
@@ -239,6 +240,7 @@ test("an action's line records the ask in words, with the identity it named", ()
       { kind: ACTION_KIND.CONTROL, identity, control },
       sessions,
       CONVERSATION_ENTRY_KIND.ACTION,
+      "run-1",
     ).words,
     'ran "Retry" on "checkout-service"',
   );
@@ -249,6 +251,7 @@ test("an action's line records the ask in words, with the identity it named", ()
       { kind: ACTION_KIND.OPEN, identity },
       [],
       CONVERSATION_ENTRY_KIND.ACTION,
+      "run-1",
     ).words,
     "opened a session",
   );
@@ -278,11 +281,16 @@ test("an action's line records the ask in words, with the identity it named", ()
     applicationId: SESSION_APPLICATION_ID.SUPERSET,
   } as const;
   assert.equal(
-    sessionActionConversationEntry(openedInApp, [heldByApp], CONVERSATION_ENTRY_KIND.ACTION).words,
+    sessionActionConversationEntry(
+      openedInApp,
+      [heldByApp],
+      CONVERSATION_ENTRY_KIND.ACTION,
+      "run-1",
+    ).words,
     'opened "checkout-service" in Superset',
   );
   assert.equal(
-    sessionActionConversationEntry(openedInApp, [], CONVERSATION_ENTRY_KIND.ACTION).words,
+    sessionActionConversationEntry(openedInApp, [], CONVERSATION_ENTRY_KIND.ACTION, "run-1").words,
     "opened a session in superset",
   );
 
@@ -291,12 +299,14 @@ test("an action's line records the ask in words, with the identity it named", ()
     { kind: ACTION_KIND.CREATE_WORKSPACE, providerId: "conductor", providerProjectId: "p1" },
     sessions,
     CONVERSATION_ENTRY_KIND.ACTION,
+    "run-1",
   );
   assert.equal(created.words, "asked conductor to create a workspace");
   assert.equal(created.identity, undefined);
   // With no identity to name it, the creation's line names the provider it asked.
   assert.deepEqual(created.action, {
     kind: ACTION_KIND.CREATE_WORKSPACE,
+    runId: "run-1",
     providerId: "conductor",
   });
   const createdNamed = sessionActionConversationEntry(
@@ -308,6 +318,7 @@ test("an action's line records the ask in words, with the identity it named", ()
     },
     sessions,
     CONVERSATION_ENTRY_KIND.ACTION,
+    "run-1",
   );
   assert.equal(
     createdNamed.words,

--- a/packages/host/src/brain/action-performer.test.ts
+++ b/packages/host/src/brain/action-performer.test.ts
@@ -172,11 +172,11 @@ test("a session action reaches the performer only for a session the roster holds
   assert.equal(landed.status, ACTION_RESULT_STATUS.ACCEPTED);
   assert.equal(performed.length, 1);
   assert.equal(performed[0]?.kind, "message");
-  // The ask is recorded as the developer's, before the outcome is known, with
-  // the kind of thing it was, so the panel can draw the row by it.
+  // The ask is recorded as the developer's, before the outcome is known, and
+  // names the run that carried it, so the panel can fold the turn's actions.
   assert.equal(recorded.length, 1);
   assert.equal(recorded[0]?.kind, "action");
-  assert.deepEqual(recorded[0]?.action, { kind: "message" });
+  assert.deepEqual(recorded[0]?.action, { kind: "message", runId: LIVE.runId });
 
   const stranger = await actions.perform(
     {
@@ -316,7 +316,7 @@ test("an action in a turn Luke opened himself runs under the same validators and
   assert.equal(performed.length, 1);
   assert.equal(recorded.length, 1);
   assert.equal(recorded[0]?.kind, "own-action");
-  assert.deepEqual(recorded[0]?.action, { kind: "message" });
+  assert.deepEqual(recorded[0]?.action, { kind: "message", runId: "wake-1" });
 });
 
 test("an action with no turn standing is refused in main before any validator or effect", async () => {

--- a/packages/host/src/brain/action-performer.ts
+++ b/packages/host/src/brain/action-performer.ts
@@ -152,6 +152,7 @@ export function createBrainActionPerformer(
         execution.origin === RUN_ORIGIN.USER
           ? CONVERSATION_ENTRY_KIND.ACTION
           : CONVERSATION_ENTRY_KIND.OWN_ACTION,
+        execution.runId,
       ),
     );
     // The performer awaits once more of its own before a create or a spawn,

--- a/packages/session/src/conversation/conversation.test.ts
+++ b/packages/session/src/conversation/conversation.test.ts
@@ -408,26 +408,36 @@ test("a stored line reads back, and retention cuts by age and by count", () => {
     line,
   );
 
-  // An action line keeps the kind it was, over the wire and back from disk; a
-  // kind this build does not know refuses the line the way a malformed
-  // identity does.
+  // An action line keeps the kind it was and the run that carried it, over
+  // the wire and back from disk; a kind this build does not know, or a run
+  // left blank, refuses the line the way a malformed identity does.
   const acted = {
     kind: CONVERSATION_ENTRY_KIND.ACTION,
     words: 'sent a message to "checkout-service": "go ahead"',
     recordedAt: now,
     identity: { providerId: "claude-code", providerSessionId: "a" },
-    action: { kind: ACTION_KIND.MESSAGE },
+    action: { kind: ACTION_KIND.MESSAGE, runId: "run-1" },
   };
   assert.deepEqual(storedConversationEntry(conversationEntryToWire(acted)), acted);
   assert.deepEqual(storedConversationEntry(JSON.parse(JSON.stringify(acted))), acted);
-  assert.equal(storedConversationEntry({ ...acted, action: { kind: "invented" } }), undefined);
-  assert.equal(storedConversationEntry({ ...acted, action: {} }), undefined);
+  assert.equal(
+    storedConversationEntry({ ...acted, action: { kind: "invented", runId: "run-1" } }),
+    undefined,
+  );
+  assert.equal(
+    storedConversationEntry({ ...acted, action: { kind: ACTION_KIND.MESSAGE, runId: "" } }),
+    undefined,
+  );
+  assert.equal(
+    storedConversationEntry({ ...acted, action: { kind: ACTION_KIND.MESSAGE } }),
+    undefined,
+  );
   // A creation names the provider it asked on the action itself, having no identity to name it.
   const created = {
     kind: CONVERSATION_ENTRY_KIND.ACTION,
     words: 'asked conductor to create a workspace named "Notch panel clipping"',
     recordedAt: now,
-    action: { kind: ACTION_KIND.CREATE_WORKSPACE, providerId: "conductor" },
+    action: { kind: ACTION_KIND.CREATE_WORKSPACE, runId: "run-2", providerId: "conductor" },
   };
   assert.deepEqual(storedConversationEntry(conversationEntryToWire(created)), created);
   assert.equal(
@@ -469,15 +479,9 @@ test("the unstrict read takes what the strict one refuses, and nothing wider", (
   const blankIdentity = { ...unclocked, identity: { providerId: "", providerSessionId: "" } };
   assert.deepEqual(storedConversationEntry(blankIdentity, { strict: false }), blankIdentity);
 
-  const blankProvider = {
-    ...unclocked,
-    action: { kind: ACTION_KIND.CREATE_WORKSPACE, providerId: "" },
-  };
-  assert.deepEqual(storedConversationEntry(blankProvider, { strict: false }), blankProvider);
-  assert.equal(
-    storedConversationEntry({ ...blankProvider, recordedAt: line.recordedAt }),
-    undefined,
-  );
+  const blankRun = { ...unclocked, action: { kind: ACTION_KIND.MESSAGE, runId: "" } };
+  assert.deepEqual(storedConversationEntry(blankRun, { strict: false }), blankRun);
+  assert.equal(storedConversationEntry({ ...blankRun, recordedAt: line.recordedAt }), undefined);
   assert.equal(
     storedConversationEntry({ ...blankIdentity, recordedAt: line.recordedAt }),
     undefined,

--- a/packages/session/src/conversation/conversation.ts
+++ b/packages/session/src/conversation/conversation.ts
@@ -142,15 +142,19 @@ export interface ConversationEntry {
   requestId?: string;
   /**
    * The action an action line records, for the panel to draw the line by:
-   * which kind of thing was done. Never rendered into model context, whose
-   * lead already says whose judgment the action was and whose words say what
-   * it did.
+   * which kind of thing was done, and the run that carried it. The run is
+   * named here rather than in `requestId` because that field says a line is a
+   * run's ask or its end, published once per run, while one run may carry
+   * several actions; it is what lets Conversation fold a turn's actions
+   * together. Never rendered into model context, whose lead already says
+   * whose judgment the action was and whose words say what it did.
    */
   action?: ConversationEntryAction;
 }
 
 export interface ConversationEntryAction {
   kind: ActionKind;
+  runId: string;
   /**
    * The provider a workspace creation asked, the one action aimed at no
    * session and so the one whose line carries no identity to read a provider
@@ -568,13 +572,15 @@ export function storedConversationEntry(
 /**
  * The action field as one line carries it, held to the same strictness as
  * the line's other optional fields: a kind this build does not know refuses
- * the line either way, and only the strict read refuses a provider left blank.
+ * the line either way, and only the strict read refuses a run left blank.
  */
 function storedConversationEntryAction(
   value: UnparsedWireValue,
   strict: boolean,
 ): ConversationEntryAction | undefined {
   if (!isRecord(value) || !isConversationEntryActionKind(value.kind)) return undefined;
+  if (!isWireString(value.runId)) return undefined;
+  if (strict && value.runId.length === 0) return undefined;
   const providerId = value.providerId;
   if (
     providerId !== undefined &&
@@ -584,6 +590,7 @@ function storedConversationEntryAction(
   }
   return {
     kind: value.kind,
+    runId: value.runId,
     ...(isWireString(providerId) ? { providerId } : undefined),
   };
 }


### PR DESCRIPTION
Stacked on #882; #889 and the rest of the stack sit on this.

Three actions from one ask stood as three unrelated rows. Consecutive actions one run carried now fold under a single line that counts them:

- **Open while the run is going**, so the developer watches the actions land as Luke takes them; **closed once it has ended**, so a settled turn takes one row however much it did. A press on the toggle is the developer's own choice and holds.
- A turn Luke opened himself is a wake with no request record (requests carry only typed, spoken, and child origins), so it stands open while it is the thread's newest line and folds once anything lands after it, including an announcement still being spoken.
- A turn of one action is drawn as the row it is; two runs' actions never fold together.

The action line records the run that carried it in its own field rather than `requestId`, because that field names a run's ask or its end and the store publishes it once per run per kind (`conversation_events` has a unique index on `session_key, request_id, kind`) while one run may carry several actions.

Verification: typecheck clean; tests pass in session, actions, host, and the desktop renderer, with cases for the fold open-while-running and closed-when-settled, the own-turn tail rule, and the single-action row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34425281691/artifacts/10132463970) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34425281691)

- Commit: `ebed2ba616218832b4d56da58bc88b9201c0f202`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
