### PR TITLE
feat(LUKE-100): run Luke's brain in the service over the Postgres store

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -527,7 +527,20 @@ Canonical commands:
   capabilities first and fails with a compatibility error when the service
   lacks them; there is no older contract to fall back to. The service
   therefore deploys before such a desktop ships, and widening the contract
-  is a product decision, not an implementation detail.
+  is a product decision, not an implementation detail. Beside that contract
+  the service now also runs the brain itself, over its own Postgres store
+  (`apps/web/server/hosted/brain-host/`): the same `BrainAgent`, composed
+  request-scoped under a per-conversation lease with a heartbeat, resuming a
+  run a function left unfinished from its journal rather than performing a
+  journaled action again, its prompt built from the account's workspace rows,
+  its roster the stored snapshot, its tools the facts table, the workspace
+  rows, the briefing table, and the cloud action execution, and nothing on
+  any machine; a tool the catalog has but the service cannot perform is not
+  offered. Its turns read a working or waiting Conductor chat's new messages
+  through the plugin's documented read on a wake, every inference spends the
+  same daily allowance, and `PRIVACY.md` says each in as many words. The
+  desktop still runs its own local brain over SQLite until the change that
+  moves it.
 
 ### Storage, retention, and conversation maintenance
 

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -311,17 +311,53 @@ Conductor key and have signed in within the last 7 days, our service reads
 your Conductor sessions on its own schedule, about once a minute, the same
 read-only pass the iOS app used to ask for on demand: your open workspaces,
 their chats, each chat's status, the agent kind running it, and the error
-line it stopped on. It never reads a chat's messages. We keep the latest
-roster it read, encrypted at rest with the same server-only secret as your
-keys, and beside it what changed since the pass before — a session that
-appeared or vanished, a status that moved, an error line that changed — so
-Luke can later be woken by a change rather than by a clock, and so the phone
-and watch can later be shown your sessions without asking Conductor again;
-today they still ask Conductor directly. The roster and its changes are
-replaced on every pass; nothing older is kept.
+line it stopped on. The pass itself never reads a chat's messages. We keep
+the latest roster it read, encrypted at rest with the same server-only
+secret as your keys, and beside it what changed since the pass before — a
+session that appeared or vanished, a status that moved, an error line that
+changed — so Luke is woken by a change rather than by a clock, and so the
+phone and watch can later be shown your sessions without asking Conductor
+again; today they still ask Conductor directly. The roster and its changes
+are replaced on every pass; nothing older is kept.
 Observation stops, and the stored roster and changes are deleted, when you
 delete the synced key, when you have not signed in for 7 days, and alongside
 your account if you delete that.
+
+**Luke's hosted brain.** Luke's judgment now runs in our own service as well
+as on your Mac: one conversation per account, shared by every device you sign
+into. What you ask him there — typed or spoken, handed to the service as
+text — his replies, the actions he carried at your ask, and the briefings he
+decided to give live in our own database, encrypted at rest with the same
+server-only secret as your keys, beside his working memory of the
+conversation (the model's own context, including the encrypted compaction
+items the model provider hands back), the facts he remembers about you, and
+his identity workspace — the same `AGENTS.md`, `SOUL.md`, `USER.md`,
+`MEMORY.md`, and dated notes the Mac keeps under his application data —
+seeded once per account and edited only by his own tools. Each turn he runs
+there sends the same things a turn on your Mac sends, to the same model
+provider on our key, asked not to store them: the prompt built from those
+workspace files, his memory of the conversation, the stored roster, and the
+words that opened the turn. When the stored roster changes, our service wakes
+him about once a minute over what changed, and in that turn he reads what
+each working or waiting Conductor chat the change named has said since he
+last looked — your own messages and the agent's replies, through Conductor's
+documented messages endpoint under your synced key, never a tool call, tool
+output, or unattributed record — bounded to 20,000 characters per chat per
+turn, and where he last read to is kept so the next wake reads only what is
+newer. He may also read one chat's recent transcript whole, up to 60,000
+characters, when you ask him about it or he judges he needs it. What he reads
+enters his working memory like everything else in a turn and is kept only as
+that memory keeps it. Each turn he runs also writes down its own shape beside
+the run: what woke it, how it ended, its token counts, how many transcript
+characters it read, and which tools it used, as numbers and fixed names,
+never the words. Every inference spends your account's one daily allowance.
+When you rate one of his lines with a thumb, we store the thumb, the note you
+added if any (encrypted), which device you pressed it on, and when, beside
+that line. Clearing the conversation from any device deletes the
+conversation, his working memory of it, the lines, and their ratings
+outright, with no recovery copy on our side; his workspace files and the
+facts he remembers stay until you edit or forget them. All of it is deleted
+alongside your account if you delete that.
 
 **Devices.** When you sign in on the Mac app, the iOS app, or the Apple Watch
 app, that installation registers itself with our service as one device row.
@@ -432,13 +468,15 @@ your network address, as it does for the app's recordings.
 
 ## Storage
 
-Your settings, your conversation with Luke, his working memory, his workspace
-files, the things he remembers about you, local provider API keys, and
-calendar access stay on your Mac.
+Your settings, the Mac app's own conversation with Luke, his working memory
+of it, his workspace files, the things he remembers about you, local provider
+API keys, and calendar access stay on your Mac.
 Local keys and calendar access are encrypted in the macOS Keychain. Provider
-API keys you sync to the hosted service, and the latest roster of your
-Conductor sessions with what changed since the pass before, are stored
-encrypted in our own database, as described above. Your account information is held by our own
+API keys you sync to the hosted service, the latest roster of your Conductor
+sessions with what changed since the pass before, and the hosted brain's
+conversation, working memory, remembered facts, identity workspace, briefings,
+and line ratings are stored encrypted in our own database, as described
+above. Your account information is held by our own
 service, usage counts and recordings by PostHog, and crash reports by Sentry.
 
 ## Your choices
@@ -449,7 +487,9 @@ service, usage counts and recordings by PostHog, and crash reports by Sentry.
   are also deleted when you delete your account.
 - Clear the Conversation tab to remove the stored conversation and Luke's working
   memory of it behind a recovery archive on your Mac. Nothing discards them
-  on a schedule: a conversation stands until you clear it.
+  on a schedule: a conversation stands until you clear it. Clearing the
+  hosted conversation deletes it, his working memory of it, and its ratings
+  from our database outright, with no recovery copy.
 - Ask Luke what he remembers, correct a memory, or tell him to forget one.
 - Edit or delete any of Luke's workspace files yourself; Luke never overwrites
   your edit, and clearing the Conversation tab does not touch them.
@@ -462,8 +502,10 @@ service, usage counts and recordings by PostHog, and crash reports by Sentry.
   moved afterwards.
 - Luke does not use your microphone until you start a turn.
 - Delete your account from the Account section in Settings. This erases your
-  account, your sign-in records, your usage counts, and any provider API keys
-  you synced to the hosted service, and asks PostHog to erase your usage data
+  account, your sign-in records, your usage counts, any provider API keys
+  you synced to the hosted service, and everything the hosted brain kept for
+  you — its conversation, working memory, remembered facts, identity
+  workspace, briefings, and ratings — and asks PostHog to erase your usage data
   and recordings, including the iOS and Apple Watch apps'. It does not reach a recording that was
   never attached to your account, as described above. Luke stops recording for
   the rest of the session, and starts again the next time you open it or sign

--- a/apps/ios/LukeKit/Sources/LukeKit/VaultClient.swift
+++ b/apps/ios/LukeKit/Sources/LukeKit/VaultClient.swift
@@ -96,6 +96,10 @@ public enum HostedAPIError: String, Sendable {
     case promptTooLarge = "prompt-too-large"
     case unknownTool = "unknown-tool"
     case methodNotAllowed = "method-not-allowed"
+    /// The run, line, or record the path names is not one this account holds.
+    case notFound = "not-found"
+    /// Another request holds the conversation; nothing changed, ask again shortly.
+    case conversationBusy = "conversation-busy"
 }
 
 public enum VaultClientError: Error, Equatable {

--- a/apps/web/api/brain/ask.ts
+++ b/apps/web/api/brain/ask.ts
@@ -1,0 +1,5 @@
+import { handleBrainAsk } from "../../server/hosted/brain-host/ask.js";
+import { hostedBrainHostRoute } from "../../server/hosted/brain-host/production.js";
+
+/** Asks Luke's hosted brain: one ask becomes a run of the account's conversation, answered by its id. */
+export default hostedBrainHostRoute(handleBrainAsk);

--- a/apps/web/api/brain/ask/[runId].ts
+++ b/apps/web/api/brain/ask/[runId].ts
@@ -1,0 +1,5 @@
+import { handleBrainAskWait } from "../../../server/hosted/brain-host/ask.js";
+import { hostedBrainHostRoute } from "../../../server/hosted/brain-host/production.js";
+
+/** Waits on one run of the hosted brain, answering it when it ends or as it stands after a bounded hold. */
+export default hostedBrainHostRoute(handleBrainAskWait);

--- a/apps/web/api/brain/ask/[runId]/cancel.ts
+++ b/apps/web/api/brain/ask/[runId]/cancel.ts
@@ -1,0 +1,5 @@
+import { handleBrainAskCancel } from "../../../../server/hosted/brain-host/ask.js";
+import { hostedBrainHostRoute } from "../../../../server/hosted/brain-host/production.js";
+
+/** Cancels one run of the hosted brain. */
+export default hostedBrainHostRoute(handleBrainAskCancel);

--- a/apps/web/api/brain/wake.ts
+++ b/apps/web/api/brain/wake.ts
@@ -1,0 +1,8 @@
+import { brainWakeRoute } from "../../server/hosted/brain-host/production.js";
+
+/**
+ * The scheduled wake of the hosted brain, called by Vercel's cron on the
+ * cadence `vercel.json` fixes: an observation turn for every account whose
+ * roster changed, and the resumption of every run a function left unfinished.
+ */
+export default brainWakeRoute;

--- a/apps/web/api/conversation.ts
+++ b/apps/web/api/conversation.ts
@@ -1,0 +1,22 @@
+import {
+  handleConversationClear,
+  handleConversationLines,
+} from "../server/hosted/brain-host/conversation.js";
+import { hostedBrainHostRoute } from "../server/hosted/brain-host/production.js";
+import { errorResponse, HOSTED_API_ERROR, HOSTED_HTTP_STATUS } from "../server/hosted/http.js";
+
+const HTTP_METHOD = { GET: "GET", DELETE: "DELETE" } as const;
+
+/** The account's one Conversation: its lines (GET) and its Clear (DELETE). */
+export default hostedBrainHostRoute((route) => {
+  switch (route.request.method) {
+    case HTTP_METHOD.GET:
+      return handleConversationLines(route);
+    case HTTP_METHOD.DELETE:
+      return handleConversationClear(route);
+    default:
+      return Promise.resolve(
+        errorResponse(HOSTED_HTTP_STATUS.METHOD_NOT_ALLOWED, HOSTED_API_ERROR.METHOD_NOT_ALLOWED),
+      );
+  }
+});

--- a/apps/web/api/conversation/lines/[lineId]/rating.ts
+++ b/apps/web/api/conversation/lines/[lineId]/rating.ts
@@ -1,0 +1,5 @@
+import { handleLineRating } from "../../../../server/hosted/brain-host/conversation.js";
+import { hostedBrainHostRoute } from "../../../../server/hosted/brain-host/production.js";
+
+/** The developer's rating of one line Luke wrote (PUT). */
+export default hostedBrainHostRoute(handleLineRating);

--- a/apps/web/api/facts.ts
+++ b/apps/web/api/facts.ts
@@ -1,0 +1,5 @@
+import { handleFacts } from "../server/hosted/brain-host/facts.js";
+import { hostedBrainHostRoute } from "../server/hosted/brain-host/production.js";
+
+/** The facts Luke remembers about the signed-in developer (GET). */
+export default hostedBrainHostRoute(handleFacts);

--- a/apps/web/drizzle/0013_numerous_sentinels.sql
+++ b/apps/web/drizzle/0013_numerous_sentinels.sql
@@ -1,0 +1,26 @@
+CREATE TABLE "conversation_lease" (
+	"user_id" text NOT NULL,
+	"session_key" text NOT NULL,
+	"owner_id" text NOT NULL,
+	"acquired_at" bigint NOT NULL,
+	"heartbeat_at" bigint NOT NULL,
+	"expires_at" bigint NOT NULL,
+	CONSTRAINT "conversation_lease_user_id_session_key_pk" PRIMARY KEY("user_id","session_key")
+);
+--> statement-breakpoint
+CREATE TABLE "conversation_line_rating" (
+	"user_id" text NOT NULL,
+	"session_key" text NOT NULL,
+	"event_key" text NOT NULL,
+	"rating" text NOT NULL,
+	"sealed_note" text,
+	"device_id" text NOT NULL,
+	"rated_at" bigint NOT NULL,
+	CONSTRAINT "conversation_line_rating_user_id_session_key_event_key_pk" PRIMARY KEY("user_id","session_key","event_key")
+);
+--> statement-breakpoint
+ALTER TABLE "conversation_run" ADD COLUMN "cancel_requested_at" bigint;--> statement-breakpoint
+ALTER TABLE "conversation_lease" ADD CONSTRAINT "conversation_lease_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "conversation_line_rating" ADD CONSTRAINT "conversation_line_rating_conversation_fk" FOREIGN KEY ("user_id","session_key") REFERENCES "public"."conversation"("user_id","session_key") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "conversation_line_rating" ADD CONSTRAINT "conversation_line_rating_line_fk" FOREIGN KEY ("user_id","session_key","event_key") REFERENCES "public"."conversation_line"("user_id","session_key","event_key") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "conversation_line_rating_by_rating" ON "conversation_line_rating" USING btree ("user_id","rating","rated_at");

--- a/apps/web/drizzle/meta/0013_snapshot.json
+++ b/apps/web/drizzle/meta/0013_snapshot.json
@@ -1,0 +1,3199 @@
+{
+  "id": "81679cfd-31bb-4dbd-bebf-5a000796ec75",
+  "prevId": "0bf2f341-43ea-4eee-a469-67c628f5bb8d",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.jwks": {
+      "name": "jwks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_key": {
+          "name": "private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_access_token": {
+      "name": "oauth_access_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_id": {
+          "name": "refresh_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "oauthAccessToken_clientId_idx": {
+          "name": "oauthAccessToken_clientId_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthAccessToken_sessionId_idx": {
+          "name": "oauthAccessToken_sessionId_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthAccessToken_userId_idx": {
+          "name": "oauthAccessToken_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthAccessToken_refreshId_idx": {
+          "name": "oauthAccessToken_refreshId_idx",
+          "columns": [
+            {
+              "expression": "refresh_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_access_token_client_id_oauth_client_client_id_fk": {
+          "name": "oauth_access_token_client_id_oauth_client_client_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "oauth_client",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["client_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_session_id_session_id_fk": {
+          "name": "oauth_access_token_session_id_session_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "session",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_user_id_user_id_fk": {
+          "name": "oauth_access_token_user_id_user_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_refresh_id_oauth_refresh_token_id_fk": {
+          "name": "oauth_access_token_refresh_id_oauth_refresh_token_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "oauth_refresh_token",
+          "columnsFrom": ["refresh_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_access_token_token_unique": {
+          "name": "oauth_access_token_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_client": {
+      "name": "oauth_client",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "skip_consent": {
+          "name": "skip_consent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enable_end_session": {
+          "name": "enable_end_session",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject_type": {
+          "name": "subject_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contacts": {
+          "name": "contacts",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tos": {
+          "name": "tos",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "policy": {
+          "name": "policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_id": {
+          "name": "software_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_version": {
+          "name": "software_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_statement": {
+          "name": "software_statement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_logout_redirect_uris": {
+          "name": "post_logout_redirect_uris",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_endpoint_auth_method": {
+          "name": "token_endpoint_auth_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grant_types": {
+          "name": "grant_types",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_types": {
+          "name": "response_types",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public": {
+          "name": "public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "require_pkce": {
+          "name": "require_pkce",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "oauthClient_userId_idx": {
+          "name": "oauthClient_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_client_user_id_user_id_fk": {
+          "name": "oauth_client_user_id_user_id_fk",
+          "tableFrom": "oauth_client",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_client_client_id_unique": {
+          "name": "oauth_client_client_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["client_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_consent": {
+      "name": "oauth_consent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "oauthConsent_clientId_idx": {
+          "name": "oauthConsent_clientId_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthConsent_userId_idx": {
+          "name": "oauthConsent_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_consent_client_id_oauth_client_client_id_fk": {
+          "name": "oauth_consent_client_id_oauth_client_client_id_fk",
+          "tableFrom": "oauth_consent",
+          "tableTo": "oauth_client",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["client_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_consent_user_id_user_id_fk": {
+          "name": "oauth_consent_user_id_user_id_fk",
+          "tableFrom": "oauth_consent",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_refresh_token": {
+      "name": "oauth_refresh_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked": {
+          "name": "revoked",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_time": {
+          "name": "auth_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "oauthRefreshToken_clientId_idx": {
+          "name": "oauthRefreshToken_clientId_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthRefreshToken_sessionId_idx": {
+          "name": "oauthRefreshToken_sessionId_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthRefreshToken_userId_idx": {
+          "name": "oauthRefreshToken_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_refresh_token_client_id_oauth_client_client_id_fk": {
+          "name": "oauth_refresh_token_client_id_oauth_client_client_id_fk",
+          "tableFrom": "oauth_refresh_token",
+          "tableTo": "oauth_client",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["client_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_refresh_token_session_id_session_id_fk": {
+          "name": "oauth_refresh_token_session_id_session_id_fk",
+          "tableFrom": "oauth_refresh_token",
+          "tableTo": "session",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "oauth_refresh_token_user_id_user_id_fk": {
+          "name": "oauth_refresh_token_user_id_user_id_fk",
+          "tableFrom": "oauth_refresh_token",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_refresh_token_token_unique": {
+          "name": "oauth_refresh_token_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_login_method": {
+          "name": "last_login_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'user'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation_lease": {
+      "name": "conversation_lease",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_key": {
+          "name": "session_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "acquired_at": {
+          "name": "acquired_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "heartbeat_at": {
+          "name": "heartbeat_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "conversation_lease_user_id_user_id_fk": {
+          "name": "conversation_lease_user_id_user_id_fk",
+          "tableFrom": "conversation_lease",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "conversation_lease_user_id_session_key_pk": {
+          "name": "conversation_lease_user_id_session_key_pk",
+          "columns": ["user_id", "session_key"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation_line_rating": {
+      "name": "conversation_line_rating",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_key": {
+          "name": "session_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_key": {
+          "name": "event_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rating": {
+          "name": "rating",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sealed_note": {
+          "name": "sealed_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rated_at": {
+          "name": "rated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "conversation_line_rating_by_rating": {
+          "name": "conversation_line_rating_by_rating",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "rating",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "rated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_line_rating_conversation_fk": {
+          "name": "conversation_line_rating_conversation_fk",
+          "tableFrom": "conversation_line_rating",
+          "tableTo": "conversation",
+          "columnsFrom": ["user_id", "session_key"],
+          "columnsTo": ["user_id", "session_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "conversation_line_rating_line_fk": {
+          "name": "conversation_line_rating_line_fk",
+          "tableFrom": "conversation_line_rating",
+          "tableTo": "conversation_line",
+          "columnsFrom": ["user_id", "session_key", "event_key"],
+          "columnsTo": ["user_id", "session_key", "event_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "conversation_line_rating_user_id_session_key_event_key_pk": {
+          "name": "conversation_line_rating_user_id_session_key_event_key_pk",
+          "columns": ["user_id", "session_key", "event_key"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.briefing": {
+      "name": "briefing",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_key": {
+          "name": "session_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sealed_words": {
+          "name": "sealed_words",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claimed_by_device_id": {
+          "name": "claimed_by_device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settled_at": {
+          "name": "settled_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "briefing_by_user_state": {
+          "name": "briefing_by_user_state",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "decided_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "briefing_user_id_user_id_fk": {
+          "name": "briefing_user_id_user_id_fk",
+          "tableFrom": "briefing",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "briefing_user_id_id_pk": {
+          "name": "briefing_user_id_id_pk",
+          "columns": ["user_id", "id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.action_receipt": {
+      "name": "action_receipt",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "call_id": {
+          "name": "call_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ordinal": {
+          "name": "ordinal",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sealed_arguments": {
+          "name": "sealed_arguments",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sealed_output": {
+          "name": "sealed_output",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settled_at": {
+          "name": "settled_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "action_receipt_by_session": {
+          "name": "action_receipt_by_session",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ordinal",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "action_receipt_session_fk": {
+          "name": "action_receipt_session_fk",
+          "tableFrom": "action_receipt",
+          "tableTo": "conversation_session",
+          "columnsFrom": ["user_id", "session_id"],
+          "columnsTo": ["user_id", "session_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "action_receipt_user_id_run_id_call_id_pk": {
+          "name": "action_receipt_user_id_run_id_call_id_pk",
+          "columns": ["user_id", "run_id", "call_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.compaction_boundary": {
+      "name": "compaction_boundary",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_key": {
+          "name": "session_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transcript_sequence": {
+          "name": "transcript_sequence",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dropped": {
+          "name": "dropped",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "checkpoint_format": {
+          "name": "checkpoint_format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "compaction_boundary_conversation_fk": {
+          "name": "compaction_boundary_conversation_fk",
+          "tableFrom": "compaction_boundary",
+          "tableTo": "conversation",
+          "columnsFrom": ["user_id", "session_key"],
+          "columnsTo": ["user_id", "session_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "compaction_boundary_user_id_session_key_transcript_sequence_pk": {
+          "name": "compaction_boundary_user_id_session_key_transcript_sequence_pk",
+          "columns": ["user_id", "session_key", "transcript_sequence"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation": {
+      "name": "conversation",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_key": {
+          "name": "session_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "next_line_sequence": {
+          "name": "next_line_sequence",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "next_transcript_sequence": {
+          "name": "next_transcript_sequence",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "cleared_at": {
+          "name": "cleared_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "conversation_user_id_user_id_fk": {
+          "name": "conversation_user_id_user_id_fk",
+          "tableFrom": "conversation",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "conversation_user_id_session_key_pk": {
+          "name": "conversation_user_id_session_key_pk",
+          "columns": ["user_id", "session_key"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation_line": {
+      "name": "conversation_line",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_key": {
+          "name": "session_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_key": {
+          "name": "event_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recorded_at": {
+          "name": "recorded_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_session_id": {
+          "name": "provider_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sealed_payload": {
+          "name": "sealed_payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "conversation_line_by_key": {
+          "name": "conversation_line_by_key",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_line_by_time": {
+          "name": "conversation_line_by_time",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recorded_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sequence",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_line_once_published": {
+          "name": "conversation_line_once_published",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"conversation_line\".\"request_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_line_conversation_fk": {
+          "name": "conversation_line_conversation_fk",
+          "tableFrom": "conversation_line",
+          "tableTo": "conversation",
+          "columnsFrom": ["user_id", "session_key"],
+          "columnsTo": ["user_id", "session_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "conversation_line_user_id_session_key_sequence_pk": {
+          "name": "conversation_line_user_id_session_key_sequence_pk",
+          "columns": ["user_id", "session_key", "sequence"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation_run": {
+      "name": "conversation_run",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ordinal": {
+          "name": "ordinal",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submission_id": {
+          "name": "submission_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "origin": {
+          "name": "origin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sealed_question": {
+          "name": "sealed_question",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revision": {
+          "name": "revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settled_at": {
+          "name": "settled_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sealed_text": {
+          "name": "sealed_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure": {
+          "name": "failure",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "performed_actions": {
+          "name": "performed_actions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unknown_actions": {
+          "name": "unknown_actions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ask_recorded_at": {
+          "name": "ask_recorded_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conversation_recorded_at": {
+          "name": "conversation_recorded_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancel_requested_at": {
+          "name": "cancel_requested_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_origin": {
+          "name": "run_origin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ending": {
+          "name": "ending",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_item_kinds": {
+          "name": "input_item_kinds",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transcript_bytes": {
+          "name": "transcript_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "elapsed_ms": {
+          "name": "elapsed_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_names": {
+          "name": "tool_names",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "compacted": {
+          "name": "compacted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "conversation_run_by_session": {
+          "name": "conversation_run_by_session",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ordinal",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_run_session_fk": {
+          "name": "conversation_run_session_fk",
+          "tableFrom": "conversation_run",
+          "tableTo": "conversation_session",
+          "columnsFrom": ["user_id", "session_id"],
+          "columnsTo": ["user_id", "session_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "conversation_run_user_id_run_id_pk": {
+          "name": "conversation_run_user_id_run_id_pk",
+          "columns": ["user_id", "run_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation_session": {
+      "name": "conversation_session",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_key": {
+          "name": "session_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reset_cleared_at": {
+          "name": "reset_cleared_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reset_generation_id": {
+          "name": "reset_generation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checkpoint_format": {
+          "name": "checkpoint_format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "compaction_count": {
+          "name": "compaction_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "conversation_session_one_standing": {
+          "name": "conversation_session_one_standing",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_session_conversation_fk": {
+          "name": "conversation_session_conversation_fk",
+          "tableFrom": "conversation_session",
+          "tableTo": "conversation",
+          "columnsFrom": ["user_id", "session_key"],
+          "columnsTo": ["user_id", "session_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "conversation_session_user_id_session_id_pk": {
+          "name": "conversation_session_user_id_session_id_pk",
+          "columns": ["user_id", "session_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.observation_capture_cursor": {
+      "name": "observation_capture_cursor",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_session_id": {
+          "name": "provider_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cursor": {
+          "name": "cursor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "observation_capture_cursor_session_fk": {
+          "name": "observation_capture_cursor_session_fk",
+          "tableFrom": "observation_capture_cursor",
+          "tableTo": "conversation_session",
+          "columnsFrom": ["user_id", "session_id"],
+          "columnsTo": ["user_id", "session_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "observation_capture_cursor_user_id_session_id_provider_id_provider_session_id_pk": {
+          "name": "observation_capture_cursor_user_id_session_id_provider_id_provider_session_id_pk",
+          "columns": ["user_id", "session_id", "provider_id", "provider_session_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.observation_cursor": {
+      "name": "observation_cursor",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_session_id": {
+          "name": "provider_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cursor": {
+          "name": "cursor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "observation_cursor_session_fk": {
+          "name": "observation_cursor_session_fk",
+          "tableFrom": "observation_cursor",
+          "tableTo": "conversation_session",
+          "columnsFrom": ["user_id", "session_id"],
+          "columnsTo": ["user_id", "session_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "observation_cursor_user_id_session_id_provider_id_provider_session_id_pk": {
+          "name": "observation_cursor_user_id_session_id_provider_id_provider_session_id_pk",
+          "columns": ["user_id", "session_id", "provider_id", "provider_session_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.observation_inbox_entry": {
+      "name": "observation_inbox_entry",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ordinal": {
+          "name": "ordinal",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entry_id": {
+          "name": "entry_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sealed_payload": {
+          "name": "sealed_payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "observation_inbox_entry_session_fk": {
+          "name": "observation_inbox_entry_session_fk",
+          "tableFrom": "observation_inbox_entry",
+          "tableTo": "conversation_session",
+          "columnsFrom": ["user_id", "session_id"],
+          "columnsTo": ["user_id", "session_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "observation_inbox_entry_user_id_session_id_ordinal_pk": {
+          "name": "observation_inbox_entry_user_id_session_id_ordinal_pk",
+          "columns": ["user_id", "session_id", "ordinal"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.runtime_checkpoint": {
+      "name": "runtime_checkpoint",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sealed_item": {
+          "name": "sealed_item",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "runtime_checkpoint_session_fk": {
+          "name": "runtime_checkpoint_session_fk",
+          "tableFrom": "runtime_checkpoint",
+          "tableTo": "conversation_session",
+          "columnsFrom": ["user_id", "session_id"],
+          "columnsTo": ["user_id", "session_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "runtime_checkpoint_user_id_session_id_sequence_pk": {
+          "name": "runtime_checkpoint_user_id_session_id_sequence_pk",
+          "columns": ["user_id", "session_id", "sequence"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transcript_event": {
+      "name": "transcript_event",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_key": {
+          "name": "session_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recorded_at": {
+          "name": "recorded_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sealed_payload": {
+          "name": "sealed_payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "transcript_event_conversation_fk": {
+          "name": "transcript_event_conversation_fk",
+          "tableFrom": "transcript_event",
+          "tableTo": "conversation",
+          "columnsFrom": ["user_id", "session_key"],
+          "columnsTo": ["user_id", "session_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "transcript_event_user_id_session_key_sequence_pk": {
+          "name": "transcript_event_user_id_session_key_sequence_pk",
+          "columns": ["user_id", "session_key", "sequence"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.devices": {
+      "name": "devices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "active_until": {
+          "name": "active_until",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "push_token": {
+          "name": "push_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "push_environment": {
+          "name": "push_environment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "devices_user_id_user_id_fk": {
+          "name": "devices_user_id_user_id_fk",
+          "tableFrom": "devices",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "devices_installation_id_unique": {
+          "name": "devices_installation_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["installation_id"]
+        },
+        "devices_push_token_unique": {
+          "name": "devices_push_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["push_token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.admin_favorite": {
+      "name": "admin_favorite",
+      "schema": "",
+      "columns": {
+        "admin_id": {
+          "name": "admin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "admin_favorite_admin_id_user_id_fk": {
+          "name": "admin_favorite_admin_id_user_id_fk",
+          "tableFrom": "admin_favorite",
+          "tableTo": "user",
+          "columnsFrom": ["admin_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "admin_favorite_user_id_user_id_fk": {
+          "name": "admin_favorite_user_id_user_id_fk",
+          "tableFrom": "admin_favorite",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "admin_favorite_admin_id_user_id_pk": {
+          "name": "admin_favorite_admin_id_user_id_pk",
+          "columns": ["admin_id", "user_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.account_preference": {
+      "name": "account_preference",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "voice": {
+          "name": "voice",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "voice_speed": {
+          "name": "voice_speed",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_workspace_provider": {
+          "name": "default_workspace_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_preference_user_id_user_id_fk": {
+          "name": "account_preference_user_id_user_id_fk",
+          "tableFrom": "account_preference",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.account_workspace_preference": {
+      "name": "account_workspace_preference",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_project_id": {
+          "name": "default_project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent": {
+          "name": "agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "effort": {
+          "name": "effort",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_workspace_preference_user_id_user_id_fk": {
+          "name": "account_workspace_preference_user_id_user_id_fk",
+          "tableFrom": "account_workspace_preference",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "account_workspace_preference_user_id_provider_id_pk": {
+          "name": "account_workspace_preference_user_id_provider_id_pk",
+          "columns": ["user_id", "provider_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.observation_pass": {
+      "name": "observation_pass",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "attempted_at": {
+          "name": "attempted_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure": {
+          "name": "failure",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "observation_pass_user_id_user_id_fk": {
+          "name": "observation_pass_user_id_user_id_fk",
+          "tableFrom": "observation_pass",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.roster_diff": {
+      "name": "roster_diff",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previous_observed_at": {
+          "name": "previous_observed_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sealed_payload": {
+          "name": "sealed_payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "roster_diff_by_user_pending": {
+          "name": "roster_diff_by_user_pending",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "consumed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "observed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "roster_diff_user_id_user_id_fk": {
+          "name": "roster_diff_user_id_user_id_fk",
+          "tableFrom": "roster_diff",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "roster_diff_user_id_id_pk": {
+          "name": "roster_diff_user_id_id_pk",
+          "columns": ["user_id", "id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.roster_snapshot": {
+      "name": "roster_snapshot",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "sealed_body": {
+          "name": "sealed_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "roster_snapshot_user_id_user_id_fk": {
+          "name": "roster_snapshot_user_id_user_id_fk",
+          "tableFrom": "roster_snapshot",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.hosted_usage": {
+      "name": "hosted_usage",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "day": {
+          "name": "day",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "calls": {
+          "name": "calls",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "hosted_usage_user_id_user_id_fk": {
+          "name": "hosted_usage_user_id_user_id_fk",
+          "tableFrom": "hosted_usage",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "hosted_usage_user_id_day_pk": {
+          "name": "hosted_usage_user_id_day_pk",
+          "columns": ["user_id", "day"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.introduction_usage": {
+      "name": "introduction_usage",
+      "schema": "",
+      "columns": {
+        "caller": {
+          "name": "caller",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "day": {
+          "name": "day",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mints": {
+          "name": "mints",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "introduction_usage_caller_day_pk": {
+          "name": "introduction_usage_caller_day_pk",
+          "columns": ["caller", "day"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provider_key": {
+      "name": "provider_key",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ciphertext": {
+          "name": "ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "provider_key_user_id_user_id_fk": {
+          "name": "provider_key_user_id_user_id_fk",
+          "tableFrom": "provider_key",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "provider_key_user_id_provider_id_pk": {
+          "name": "provider_key_user_id_provider_id_pk",
+          "columns": ["user_id", "provider_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.personal_fact": {
+      "name": "personal_fact",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ordinal": {
+          "name": "ordinal",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sealed_words": {
+          "name": "sealed_words",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "personal_fact_user_id_user_id_fk": {
+          "name": "personal_fact_user_id_user_id_fk",
+          "tableFrom": "personal_fact",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "personal_fact_user_id_id_pk": {
+          "name": "personal_fact_user_id_id_pk",
+          "columns": ["user_id", "id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspace_file": {
+      "name": "workspace_file",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sealed_content": {
+          "name": "sealed_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workspace_file_user_id_user_id_fk": {
+          "name": "workspace_file_user_id_user_id_fk",
+          "tableFrom": "workspace_file",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "workspace_file_user_id_path_pk": {
+          "name": "workspace_file_user_id_path_pk",
+          "columns": ["user_id", "path"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/web/drizzle/meta/_journal.json
+++ b/apps/web/drizzle/meta/_journal.json
@@ -92,6 +92,13 @@
       "when": 1788985706850,
       "tag": "0012_pale_molly_hayes",
       "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "7",
+      "when": 1788999566084,
+      "tag": "0013_numerous_sentinels",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -36,6 +36,7 @@
     "@sidecar/surface": "workspace:*",
     "@sidecar/wire": "workspace:*",
     "@tailwindcss/vite": "4.3.3",
+    "@vercel/functions": "3.4.2",
     "better-auth": "1.6.29",
     "drizzle-orm": "0.45.2",
     "marked": "18.0.9",

--- a/apps/web/server/README.md
+++ b/apps/web/server/README.md
@@ -226,6 +226,70 @@ nothing in a request can name one. Without `OPENAI_API_KEY` the routes answer
 503 like the rest of the hosted tier. The existing mint and device routes are
 untouched by these routes and keep their contracts for released clients.
 
+## Hosted brain host
+
+The routes under `api/brain/ask*`, `api/conversation*`, and `api/facts.ts`
+run Luke's brain itself in the service — the same `BrainAgent` the desktop
+runs, composed in `server/hosted/brain-host/` over the Postgres store below
+rather than over a SQLite file — for one conversation per account, shared by
+every device that signs in. The tool loop runs over the Responses context
+engine on the OpenAI adapter called directly with `OPENAI_API_KEY`
+(`LUKE_BRAIN_MODEL` overrides the model, as it does for the inference
+routes), and every inference spends the same `hosted_usage` meter; a spend
+the meter refuses ends the run as the desktop's own meter refusal does.
+
+The host is request-scoped. A run is executed by whichever function holds the
+conversation's lease (`conversation_lease`): the ask acquires it, or waits up
+to 20 seconds for a holder to finish and answers `409 conversation-busy`
+otherwise; the holder heartbeats the lease every 10 seconds while it works,
+applying any cancel the developer noted meanwhile, and releases it when the
+run has settled and its lines are written. A lease whose heartbeat stopped
+expires after 30 seconds, and the next request or wake that finds it expired
+with a run still queued or running takes it over and resumes the run from
+its journal: the checkpoint already holds the ask's words and every answered
+tool result, a call that started and never answered is paired as an unknown
+result, and nothing journaled is performed again. Runs execute under a
+240-second deadline inside the 300-second function duration `vercel.json`
+gives these routes, and a function answers its request first and finishes
+the run afterwards through Vercel's `waitUntil`.
+
+| Route | What it does |
+| --- | --- |
+| `POST /api/brain/ask` | Accepts one typed or spoken ask into a run and answers the run's id; the run finishes after the answer. |
+| `GET /api/brain/ask/{runId}?wait=ms` | Answers the run when it ends or as it stands after a hold of at most 25 seconds; a run whose holder died is resumed by this request. |
+| `POST /api/brain/ask/{runId}/cancel` | Notes the cancel for the holder, or performs it when no holder stands. |
+| `GET /api/conversation?after=ms` | The Conversation's lines as the panel draws them, with each line's rating and a cursor for what is newer. |
+| `DELETE /api/conversation` | Clear: a hard delete of the conversation and everything under it, taken under the lease. |
+| `PUT /api/conversation/lines/{lineId}/rating` | A thumb up or down, an optional note, and the device, on a line Luke authored in the caller's own conversation. |
+| `GET /api/facts` | The facts Luke remembers about the developer. |
+
+`api/brain/wake.ts` is the second cron: `vercel.json` schedules it every
+minute with a 300-second duration, under the same `CRON_SECRET` bearer as the
+observation tick. It lists every account with a `roster_diff` still pending
+and every conversation with a run left unfinished, longest waiting first,
+and runs four at a time, starting a batch only while a whole run deadline
+still fits inside the function and answering `exhausted: true` when
+accounts remained. For each it takes the lease (an account another holder is
+running is left for the next minute), resumes anything unfinished, opens one
+observation turn over the pending diffs — the brain's own look at what
+changed, in which each working or waiting Conductor chat the diffs named has
+its new messages read through the plugin's `transcriptSince` behind the
+`after` cursor, 20,000 characters per chat per turn, the cursor written to
+`observation_cursor` with the checkpoint — and consumes the diffs. The tick
+stays as it was and runs no brain turn inside its 60-second function.
+
+The brain's tools on the service are the catalog's, less what the service
+cannot perform: the cloud actions through `action-execute.ts`, admitted
+against the snapshot; `list_sessions` and `read_transcript` over the
+snapshot and the Conductor plugin; `remember_fact` and `forget_fact` on the
+facts table; the workspace read and write on the workspace rows, seeded once
+from the brain's own seeds; and `announce`, which inserts an offered
+`briefing` row expiring after five minutes and the announcement's line, and
+delivers nothing yet. Opening a session, the app actions, the issue actions,
+delegation, the notebook index, and skills are not offered. Every turn
+writes its about-fields onto its run row. The runtime's development trace
+is the desktop's and records nothing here.
+
 ## Provider key vault
 
 `api/vault/key.ts` and `api/vault/keys.ts` store, list, and delete the provider
@@ -254,13 +318,15 @@ conversation per account: the conversation directory, the standing generation
 with its checkpoint items, cursors, inbox, runs, and action receipts, the
 conversation lines, the retained transcript and its compaction boundaries, the
 identity workspace and daily notes, the remembered facts, the latest roster
-snapshot with its diffs and pass record, and the briefings. Every row is
-keyed by `user_id` and cascades with the user row, so `api/account/delete.ts`
-erases them with the account. The roster tables are read and written by the
-scheduled observation below and the routes that serve it; nothing reads the
-conversation tables yet. `server/hosted/store/` is the store the brain host
-will compose against, implementing the storage contracts the desktop's SQLite
-store implements under `packages/brain/src/store`.
+snapshot with its diffs and pass record, the briefings, and, under
+`brain-host-schema.ts`, the conversation leases and the ratings of Luke's
+lines. Every row is keyed by `user_id` and cascades with the user row, so
+`api/account/delete.ts` erases them with the account. The roster tables are
+read and written by the scheduled observation below and the routes that
+serve it; the conversation tables by the brain host above.
+`server/hosted/store/` is the store the brain host composes against,
+implementing the storage contracts the desktop's SQLite store implements
+under `packages/brain/src/store`.
 
 Every user-derived column is a `sealed_*` column: the payload envelope in
 `server/hosted/encryption.ts`, AES-256-GCM under the vault's
@@ -342,7 +408,8 @@ reads a chat's messages; the brain host's own reads will write them.
 own live pass per request for now; serving the stored snapshot and admitting
 actions against it lands in a follow-up once the schedule has run in
 production. `api/sessions/messages.ts` keeps its own fresh pass before the
-read either way.
+read either way. The hosted brain host above is what consumes the diffs the
+tick leaves; the tick itself still decides nothing.
 
 ## Devices
 

--- a/apps/web/server/core.ts
+++ b/apps/web/server/core.ts
@@ -29,7 +29,6 @@
 import "../../../packages/credentials/src/credential-providers.js";
 import "../../../packages/guide/src/index.js";
 import "../../../packages/memory/src/index.js";
-import "../../../packages/runtime/src/index.js";
 
 export * from "../../../packages/actions/src/index.js";
 // The action table and the session package both name the action vocabulary: the
@@ -42,6 +41,10 @@ export * from "../../../packages/brain/src/index.js";
 export * from "../../../packages/brain/src/store/shapes.js";
 export * from "../../../packages/hosted/src/index.js";
 export * from "../../../packages/realtime/src/index.js";
+// The runtime's barrel and its vocabulary door carry no name in common, so
+// both stand here: the brain host composes prompts and tool policies from
+// the barrel, and every function on this server reaches `node:fs` anyway.
+export * from "../../../packages/runtime/src/index.js";
 export * from "../../../packages/runtime/src/vocabulary.js";
 export * from "../../../packages/session/src/index.js";
 export * from "../../../packages/wire/src/index.js";

--- a/apps/web/server/db/brain-host-schema.ts
+++ b/apps/web/server/db/brain-host-schema.ts
@@ -1,0 +1,73 @@
+import { bigint, foreignKey, index, pgTable, primaryKey, text } from "drizzle-orm/pg-core";
+import { user } from "./auth-schema.js";
+import { conversation, conversationLine } from "./conversation-schema.js";
+
+/**
+ * What the hosted brain host keeps beside the conversation tables to run
+ * request-scoped: who holds a conversation right now, and what the developer
+ * thought of a line Luke wrote.
+ *
+ * A lease is the one thing standing between two functions that would both
+ * run a turn over one conversation: whichever acquires it runs, heartbeats
+ * while it does, and releases at the end, and a lease whose heartbeat stopped
+ * — a function cut off by its own duration — expires so the next request or
+ * tick can pick the run up from its journal. It hangs from the user rather
+ * than the conversation row, because a Clear deletes the conversation under
+ * the lease that guards the Clear itself. Nothing here is sealed: an owner
+ * id is the function's own random token and the rest are instants.
+ */
+export const conversationLease = pgTable(
+  "conversation_lease",
+  {
+    userId: text("user_id")
+      .notNull()
+      .references(() => user.id, { onDelete: "cascade" }),
+    sessionKey: text("session_key").notNull(),
+    ownerId: text("owner_id").notNull(),
+    acquiredAt: bigint("acquired_at", { mode: "number" }).notNull(),
+    heartbeatAt: bigint("heartbeat_at", { mode: "number" }).notNull(),
+    expiresAt: bigint("expires_at", { mode: "number" }).notNull(),
+  },
+  (table) => [primaryKey({ columns: [table.userId, table.sessionKey] })],
+);
+
+/**
+ * The developer's rating of one line Luke authored, a reply or an
+ * announcement: a thumb, and the words they added if any. It hangs from the
+ * line by the key the line is idempotent on, so it goes with the line at a
+ * Clear and with the user at deletion, and it names the device it was pressed
+ * on and the instant. The rating itself is a fixed word and stands clear, so
+ * "why was this rated down" can join it to the run's about-fields; the note
+ * is the developer's own words and is sealed.
+ */
+export const conversationLineRating = pgTable(
+  "conversation_line_rating",
+  {
+    userId: text("user_id").notNull(),
+    sessionKey: text("session_key").notNull(),
+    eventKey: text("event_key").notNull(),
+    rating: text("rating").notNull(),
+    /** The developer's words about the rating, when they added any. Sealed. */
+    sealedNote: text("sealed_note"),
+    deviceId: text("device_id").notNull(),
+    ratedAt: bigint("rated_at", { mode: "number" }).notNull(),
+  },
+  (table) => [
+    primaryKey({ columns: [table.userId, table.sessionKey, table.eventKey] }),
+    foreignKey({
+      columns: [table.userId, table.sessionKey],
+      foreignColumns: [conversation.userId, conversation.sessionKey],
+      name: "conversation_line_rating_conversation_fk",
+    }).onDelete("cascade"),
+    foreignKey({
+      columns: [table.userId, table.sessionKey, table.eventKey],
+      foreignColumns: [
+        conversationLine.userId,
+        conversationLine.sessionKey,
+        conversationLine.eventKey,
+      ],
+      name: "conversation_line_rating_line_fk",
+    }).onDelete("cascade"),
+    index("conversation_line_rating_by_rating").on(table.userId, table.rating, table.ratedAt),
+  ],
+);

--- a/apps/web/server/db/conversation-schema.ts
+++ b/apps/web/server/db/conversation-schema.ts
@@ -203,6 +203,12 @@ export const conversationRun = pgTable(
     unknownActions: integer("unknown_actions").notNull(),
     askRecordedAt: bigint("ask_recorded_at", { mode: "number" }),
     conversationRecordedAt: bigint("conversation_recorded_at", { mode: "number" }),
+    /**
+     * When the developer asked for the run to be cancelled through the
+     * service, for the function running it — or the one that resumes it — to
+     * read at its next heartbeat; the record's own end is still the brain's.
+     */
+    cancelRequestedAt: bigint("cancel_requested_at", { mode: "number" }),
     trigger: text("trigger"),
     runOrigin: text("run_origin"),
     ending: text("ending"),

--- a/apps/web/server/db/schema.ts
+++ b/apps/web/server/db/schema.ts
@@ -1,6 +1,7 @@
 // Better Auth owns its generated schema; Luke-owned tables can join this
 // aggregate from their own schema modules without being overwritten by it.
 export * from "./auth-schema.js";
+export * from "./brain-host-schema.js";
 export * from "./briefing-schema.js";
 export * from "./conversation-schema.js";
 export * from "./devices-schema.js";

--- a/apps/web/server/hosted/brain-host/ask.ts
+++ b/apps/web/server/hosted/brain-host/ask.ts
@@ -113,7 +113,7 @@ export async function handleBrainAsk(route: HostedBrainRoute): Promise<Response>
   if (!lease) return busyResponse();
   const session = await openBrainSession(route, admission, openAiKey, lease);
   const { agent } = session.brain;
-  await agent.ready();
+  await session.ready();
   const result = await agent.submitAsk({
     submissionId: ask.submissionId ?? randomUUID(),
     question: ask.question,
@@ -182,7 +182,7 @@ export async function handleBrainAskWait(route: HostedBrainRoute): Promise<Respo
       const lease = await leaseNow(route, admission.store, admission.userId);
       if (lease) {
         const session = await openBrainSession(route, admission, openAiKey, lease);
-        await session.brain.agent.ready();
+        await session.ready();
         const waited = await session.brain.agent.waitAsk(runId, Math.max(0, deadline - now()));
         // A run that ended inside the hold reaches the Conversation before
         // its reply is answered, so a device never hears a reply the thread
@@ -230,7 +230,7 @@ export async function handleBrainAskCancel(route: HostedBrainRoute): Promise<Res
       : await leaseNow(route, admission.store, admission.userId);
   if (lease && !(openAiKey instanceof Response)) {
     const session = await openBrainSession(route, admission, openAiKey, lease);
-    await session.brain.agent.ready();
+    await session.ready();
     const cancelled = await session.brain.agent.cancelAsk(runId);
     if (cancelled) await session.brain.publish();
     route.continueAfterResponse(session.finish());

--- a/apps/web/server/hosted/brain-host/ask.ts
+++ b/apps/web/server/hosted/brain-host/ask.ts
@@ -29,10 +29,10 @@ import {
   leaseNow,
   leaseWithin,
   openAiKeyOrUnavailable,
-  openBrainSession,
   pathSegmentAfter,
   readRunRecord,
   runToWire,
+  underLease,
 } from "./route.js";
 
 /**
@@ -111,23 +111,23 @@ export async function handleBrainAsk(route: HostedBrainRoute): Promise<Response>
 
   const lease = await leaseWithin(route, admission.store, admission.userId);
   if (!lease) return busyResponse();
-  const session = await openBrainSession(route, admission, openAiKey, lease);
-  const { agent } = session.brain;
-  await session.ready();
-  const result = await agent.submitAsk({
-    submissionId: ask.submissionId ?? randomUUID(),
-    question: ask.question,
-    origin: ask.origin,
+  return underLease(route, admission, openAiKey, lease, async (session) => {
+    await session.ready();
+    const result = await session.brain.agent.submitAsk({
+      submissionId: ask.submissionId ?? randomUUID(),
+      question: ask.question,
+      origin: ask.origin,
+    });
+    // The ask's own line stands in the Conversation before the caller hears
+    // of the run, so a device reading the thread finds the ask beside the run.
+    await session.brain.publish();
+    route.continueAfterResponse(session.finish());
+    const answer: HostedBrainAskAnswer =
+      result.outcome === BRAIN_SUBMISSION_OUTCOME.ACCEPTED
+        ? { outcome: result.outcome, runId: result.runId, acceptedAt: result.acceptedAt }
+        : { outcome: result.outcome, reason: result.reason };
+    return jsonResponse(HOSTED_HTTP_STATUS.OK, answer);
   });
-  // The ask's own line stands in the Conversation before the caller hears
-  // of the run, so a device reading the thread finds the ask beside the run.
-  await session.brain.publish();
-  route.continueAfterResponse(session.finish());
-  const answer: HostedBrainAskAnswer =
-    result.outcome === BRAIN_SUBMISSION_OUTCOME.ACCEPTED
-      ? { outcome: result.outcome, runId: result.runId, acceptedAt: result.acceptedAt }
-      : { outcome: result.outcome, reason: result.reason };
-  return jsonResponse(HOSTED_HTTP_STATUS.OK, answer);
 }
 
 function waitMsOf(request: Request): number {
@@ -181,16 +181,19 @@ export async function handleBrainAskWait(route: HostedBrainRoute): Promise<Respo
       if (openAiKey instanceof Response) return openAiKey;
       const lease = await leaseNow(route, admission.store, admission.userId);
       if (lease) {
-        const session = await openBrainSession(route, admission, openAiKey, lease);
-        await session.ready();
-        const waited = await session.brain.agent.waitAsk(runId, Math.max(0, deadline - now()));
-        // A run that ended inside the hold reaches the Conversation before
-        // its reply is answered, so a device never hears a reply the thread
-        // has yet to take.
-        if (waited && isTerminalBrainRequestStatus(waited.status)) await session.brain.publish();
-        route.continueAfterResponse(session.finish());
-        const current = waited ?? (await readRunRecord(admission.store, admission.userId, runId));
-        return current ? runAnswer(HOSTED_HTTP_STATUS.OK, current) : notFound();
+        return underLease(route, admission, openAiKey, lease, async (session) => {
+          await session.ready();
+          const waited = await session.brain.agent.waitAsk(runId, Math.max(0, deadline - now()));
+          // A run that ended inside the hold reaches the Conversation before
+          // its reply is answered, so a device never hears a reply the thread
+          // has yet to take.
+          if (waited && isTerminalBrainRequestStatus(waited.status)) {
+            await session.brain.publish();
+          }
+          route.continueAfterResponse(session.finish());
+          const current = waited ?? (await readRunRecord(admission.store, admission.userId, runId));
+          return current ? runAnswer(HOSTED_HTTP_STATUS.OK, current) : notFound();
+        });
       }
     }
     const current = await readRunRecord(admission.store, admission.userId, runId);
@@ -228,14 +231,16 @@ export async function handleBrainAskCancel(route: HostedBrainRoute): Promise<Res
     openAiKey instanceof Response
       ? undefined
       : await leaseNow(route, admission.store, admission.userId);
-  if (lease && !(openAiKey instanceof Response)) {
-    const session = await openBrainSession(route, admission, openAiKey, lease);
+  const noted202 = async () => {
+    const record = await readRunRecord(admission.store, admission.userId, runId);
+    return record ? runAnswer(HOSTED_HTTP_STATUS.ACCEPTED, record) : notFound();
+  };
+  if (!lease || openAiKey instanceof Response) return noted202();
+  return underLease(route, admission, openAiKey, lease, async (session) => {
     await session.ready();
     const cancelled = await session.brain.agent.cancelAsk(runId);
     if (cancelled) await session.brain.publish();
     route.continueAfterResponse(session.finish());
-    if (cancelled) return runAnswer(HOSTED_HTTP_STATUS.OK, cancelled);
-  }
-  const record = await readRunRecord(admission.store, admission.userId, runId);
-  return record ? runAnswer(HOSTED_HTTP_STATUS.ACCEPTED, record) : notFound();
+    return cancelled ? runAnswer(HOSTED_HTTP_STATUS.OK, cancelled) : noted202();
+  });
 }

--- a/apps/web/server/hosted/brain-host/ask.ts
+++ b/apps/web/server/hosted/brain-host/ask.ts
@@ -1,0 +1,241 @@
+import { randomUUID } from "node:crypto";
+import {
+  BRAIN_SUBMISSION_OUTCOME,
+  HOSTED_BRAIN_WAIT,
+  HOSTED_SERVICE_PATH,
+  type HostedBrainAskAnswer,
+  type HostedBrainRunAnswer,
+  hostedBrainAskRequestSchema,
+  isTerminalBrainRequestStatus,
+  type UnparsedWireValue,
+} from "../../core.js";
+import {
+  BODY_READ,
+  errorResponse,
+  HOSTED_API_ERROR,
+  HOSTED_HTTP_STATUS,
+  jsonResponse,
+  readBoundedBody,
+} from "../http.js";
+import { createRateBrake } from "../rate-brake.js";
+import { BRAIN_HOST } from "./bounds.js";
+import {
+  admitBrainRoute,
+  type BrainRouteAdmission,
+  busyResponse,
+  clock,
+  HOSTED_CONVERSATION_KEY,
+  type HostedBrainRoute,
+  leaseNow,
+  leaseWithin,
+  openAiKeyOrUnavailable,
+  openBrainSession,
+  pathSegmentAfter,
+  readRunRecord,
+  runToWire,
+} from "./route.js";
+
+/**
+ * The developer's ask of the hosted brain, in three routes. The submit takes
+ * the conversation's lease, opens the brain, accepts the ask into a run —
+ * resuming first whatever the last holder left unfinished — answers the run's
+ * id, and finishes the run after the answer. The wait answers the run when
+ * it ends or as it stands after a bounded hold, and a wait that finds the
+ * run orphaned — its lease expired with the run unfinished — is the request
+ * that resumes it. The cancel notes the developer's cancel on the run for
+ * its holder, or performs it itself when no holder stands.
+ */
+
+const ASK_RATE_LIMIT = {
+  WINDOW_MS: 60_000,
+  MAX_REQUESTS_PER_WINDOW: 30,
+  MAX_TRACKED_USERS: 10_000,
+} as const;
+
+const askRateLimited = createRateBrake({
+  windowMs: ASK_RATE_LIMIT.WINDOW_MS,
+  maxRequestsPerWindow: ASK_RATE_LIMIT.MAX_REQUESTS_PER_WINDOW,
+  maxTrackedUsers: ASK_RATE_LIMIT.MAX_TRACKED_USERS,
+});
+
+/** An ask is words and two short ids; anything heavier is not an ask. */
+const MAXIMUM_ASK_BODY_BYTES = 64 * 1024;
+
+const HTTP_METHOD = {
+  GET: "GET",
+  POST: "POST",
+} as const;
+
+function invalidRequest(): Response {
+  return errorResponse(HOSTED_HTTP_STATUS.BAD_REQUEST, HOSTED_API_ERROR.INVALID_REQUEST);
+}
+
+function notFound(): Response {
+  return errorResponse(HOSTED_HTTP_STATUS.NOT_FOUND, HOSTED_API_ERROR.NOT_FOUND);
+}
+
+function runAnswer(status: number, record: Parameters<typeof runToWire>[0]): Response {
+  const answer: HostedBrainRunAnswer = { run: runToWire(record) };
+  return jsonResponse(status, answer);
+}
+
+async function readAsk(request: Request) {
+  const body = await readBoundedBody(request, MAXIMUM_ASK_BODY_BYTES);
+  if (body.outcome === BODY_READ.TOO_LARGE) {
+    return errorResponse(HOSTED_HTTP_STATUS.PAYLOAD_TOO_LARGE, HOSTED_API_ERROR.REQUEST_TOO_LARGE);
+  }
+  if (body.outcome !== BODY_READ.READ) return invalidRequest();
+  let payload: UnparsedWireValue;
+  try {
+    // SAFETY: JSON.parse returns unknown; the schema below is the validation.
+    payload = JSON.parse(body.text) as UnparsedWireValue;
+  } catch {
+    return invalidRequest();
+  }
+  const ask = hostedBrainAskRequestSchema.parse(payload);
+  return ask ?? invalidRequest();
+}
+
+/** POST: accepts one ask into a run of the account's conversation and answers the run's id. */
+export async function handleBrainAsk(route: HostedBrainRoute): Promise<Response> {
+  const admission = await admitBrainRoute(route, HTTP_METHOD.POST);
+  if (admission instanceof Response) return admission;
+  const openAiKey = openAiKeyOrUnavailable(route);
+  if (openAiKey instanceof Response) return openAiKey;
+  const now = clock(route);
+  if (askRateLimited(admission.userId, now())) {
+    return errorResponse(HOSTED_HTTP_STATUS.TOO_MANY_REQUESTS, HOSTED_API_ERROR.QUOTA_EXHAUSTED);
+  }
+  const ask = await readAsk(route.request);
+  if (ask instanceof Response) return ask;
+
+  const lease = await leaseWithin(route, admission.store, admission.userId);
+  if (!lease) return busyResponse();
+  const session = await openBrainSession(route, admission, openAiKey, lease);
+  const { agent } = session.brain;
+  await agent.ready();
+  const result = await agent.submitAsk({
+    submissionId: ask.submissionId ?? randomUUID(),
+    question: ask.question,
+    origin: ask.origin,
+  });
+  // The ask's own line stands in the Conversation before the caller hears
+  // of the run, so a device reading the thread finds the ask beside the run.
+  await session.brain.publish();
+  route.continueAfterResponse(session.finish());
+  const answer: HostedBrainAskAnswer =
+    result.outcome === BRAIN_SUBMISSION_OUTCOME.ACCEPTED
+      ? { outcome: result.outcome, runId: result.runId, acceptedAt: result.acceptedAt }
+      : { outcome: result.outcome, reason: result.reason };
+  return jsonResponse(HOSTED_HTTP_STATUS.OK, answer);
+}
+
+function waitMsOf(request: Request): number {
+  const asked = new URL(request.url).searchParams.get(HOSTED_BRAIN_WAIT.QUERY);
+  const parsed = asked === null ? Number.NaN : Number(asked);
+  if (!Number.isFinite(parsed) || parsed < 0) return HOSTED_BRAIN_WAIT.MAXIMUM_MS;
+  return Math.min(Math.floor(parsed), HOSTED_BRAIN_WAIT.MAXIMUM_MS);
+}
+
+function sleepFor(route: Pick<HostedBrainRoute, "sleep">, ms: number): Promise<void> {
+  return (
+    route.sleep?.(ms) ??
+    new Promise((resolve) => {
+      setTimeout(resolve, ms);
+    })
+  );
+}
+
+/**
+ * Whether the conversation's lease is free to take: none stands, or the one
+ * standing has expired. A lease held by a live function is the run's own
+ * holder, and this request only watches the record.
+ */
+async function leaseIsFree(admission: BrainRouteAdmission, now: number): Promise<boolean> {
+  const lease = await admission.store.leases.read(admission.userId, HOSTED_CONVERSATION_KEY);
+  return lease === undefined || lease.expiresAt <= now;
+}
+
+/**
+ * GET: the run as it stands, answered when it ends or when the hold runs
+ * out. A run whose holder died is resumed by this request under the lease it
+ * takes, and the hold then waits on the resumed run itself.
+ */
+export async function handleBrainAskWait(route: HostedBrainRoute): Promise<Response> {
+  const admission = await admitBrainRoute(route, HTTP_METHOD.GET);
+  if (admission instanceof Response) return admission;
+  const runId = pathSegmentAfter(route.request, HOSTED_SERVICE_PATH.BRAIN_ASK);
+  if (!runId) return invalidRequest();
+  const now = clock(route);
+  const deadline = now() + waitMsOf(route.request);
+
+  const record = await readRunRecord(admission.store, admission.userId, runId);
+  if (!record) return notFound();
+  if (isTerminalBrainRequestStatus(record.status)) {
+    return runAnswer(HOSTED_HTTP_STATUS.OK, record);
+  }
+
+  for (;;) {
+    if (await leaseIsFree(admission, now())) {
+      const openAiKey = openAiKeyOrUnavailable(route);
+      if (openAiKey instanceof Response) return openAiKey;
+      const lease = await leaseNow(route, admission.store, admission.userId);
+      if (lease) {
+        const session = await openBrainSession(route, admission, openAiKey, lease);
+        await session.brain.agent.ready();
+        const waited = await session.brain.agent.waitAsk(runId, Math.max(0, deadline - now()));
+        // A run that ended inside the hold reaches the Conversation before
+        // its reply is answered, so a device never hears a reply the thread
+        // has yet to take.
+        if (waited && isTerminalBrainRequestStatus(waited.status)) await session.brain.publish();
+        route.continueAfterResponse(session.finish());
+        const current = waited ?? (await readRunRecord(admission.store, admission.userId, runId));
+        return current ? runAnswer(HOSTED_HTTP_STATUS.OK, current) : notFound();
+      }
+    }
+    const current = await readRunRecord(admission.store, admission.userId, runId);
+    if (!current) return notFound();
+    if (
+      isTerminalBrainRequestStatus(current.status) ||
+      now() + BRAIN_HOST.WAIT_POLL_MS > deadline
+    ) {
+      return runAnswer(HOSTED_HTTP_STATUS.OK, current);
+    }
+    await sleepFor(route, BRAIN_HOST.WAIT_POLL_MS);
+  }
+}
+
+/**
+ * POST: cancels a run. The cancel is noted on the run row first, so the
+ * function holding the run reads it at its next heartbeat; when no holder
+ * stands, this request takes the lease and cancels the run itself, which
+ * settles it as cancelled through the brain's own path.
+ */
+export async function handleBrainAskCancel(route: HostedBrainRoute): Promise<Response> {
+  const admission = await admitBrainRoute(route, HTTP_METHOD.POST);
+  if (admission instanceof Response) return admission;
+  const runId = pathSegmentAfter(route.request, HOSTED_SERVICE_PATH.BRAIN_ASK);
+  if (!runId) return invalidRequest();
+  const now = clock(route);
+
+  const noted = await admission.store.runs.requestCancel(admission.userId, runId, now());
+  if (!noted) {
+    const record = await readRunRecord(admission.store, admission.userId, runId);
+    return record ? runAnswer(HOSTED_HTTP_STATUS.OK, record) : notFound();
+  }
+  const openAiKey = openAiKeyOrUnavailable(route);
+  const lease =
+    openAiKey instanceof Response
+      ? undefined
+      : await leaseNow(route, admission.store, admission.userId);
+  if (lease && !(openAiKey instanceof Response)) {
+    const session = await openBrainSession(route, admission, openAiKey, lease);
+    await session.brain.agent.ready();
+    const cancelled = await session.brain.agent.cancelAsk(runId);
+    if (cancelled) await session.brain.publish();
+    route.continueAfterResponse(session.finish());
+    if (cancelled) return runAnswer(HOSTED_HTTP_STATUS.OK, cancelled);
+  }
+  const record = await readRunRecord(admission.store, admission.userId, runId);
+  return record ? runAnswer(HOSTED_HTTP_STATUS.ACCEPTED, record) : notFound();
+}

--- a/apps/web/server/hosted/brain-host/bounds.ts
+++ b/apps/web/server/hosted/brain-host/bounds.ts
@@ -1,0 +1,39 @@
+/**
+ * The bounds the hosted brain host runs under. Every one is a product knob
+ * as much as an implementation detail: how long a run may execute inside the
+ * function window Vercel gives the routes, how a lease is kept and when it is
+ * taken over, and how long a briefing nobody claimed stands.
+ */
+export const BRAIN_HOST = {
+  /** The function duration `vercel.json` gives the ask, the wait, the cancel, and the wake. */
+  MAX_DURATION_SECONDS: 300,
+  /** How long one run may execute before its deadline revokes it, inside that window with room to settle. */
+  RUN_DEADLINE_MS: 240_000,
+  /**
+   * How long a lease stands past its last heartbeat. A holder moves it along
+   * every `HEARTBEAT_MS`, so a function cut off mid-run leaves a lease the
+   * next request or tick can take over inside half a minute.
+   */
+  LEASE_TTL_MS: 30_000,
+  HEARTBEAT_MS: 10_000,
+  /** How long a request waits for a held lease before answering that the conversation is busy. */
+  LEASE_WAIT_MS: 20_000,
+  LEASE_POLL_MS: 500,
+  /** How long an offered briefing stands before it expires unspoken; delivery is the next change's. */
+  BRIEFING_EXPIRY_MS: 5 * 60_000,
+  /** How often a wait on a run reads the record back while it holds. */
+  WAIT_POLL_MS: 1_000,
+  /** The wake's own budget: users are started only while a whole run deadline still fits inside the function. */
+  WAKE_BUDGET_MS: 300_000 - 240_000 - 10_000,
+  /** Users the wake opens turns for at once, each a run of its own. */
+  WAKE_CONCURRENCY: 4,
+  /** The most users one wake lists, longest waiting first, so nobody starves. */
+  WAKE_MAX_USERS: 200,
+  /** The name the prompt's workspace section gives the row-backed workspace; a label, never a path anything reads. */
+  WORKSPACE_NAME: "workspace",
+} as const;
+
+/** The environment the routes read; the OpenAI key and model are the names every hosted route already honours. */
+export const BRAIN_HOST_ENVIRONMENT = {
+  CRON_SECRET: "CRON_SECRET",
+} as const;

--- a/apps/web/server/hosted/brain-host/context.ts
+++ b/apps/web/server/hosted/brain-host/context.ts
@@ -1,0 +1,45 @@
+import {
+  type ConversationEntry,
+  conversationLinesText,
+  type RememberedFact,
+  recentConversationEntries,
+  rememberedFactsText,
+  type Session,
+  workspaceProjectContextText,
+} from "../../core.js";
+import type { HostedRoster } from "./roster.js";
+
+/** The developer's saved creation tie-breaks, as the projects context narrates them. */
+export interface HostedWorkspaceDefaults {
+  readonly defaultProviderId?: string;
+  readonly defaultProjectIds?: Readonly<Partial<Record<string, string>>>;
+}
+
+export interface StandingContextInput {
+  readonly roster: HostedRoster;
+  readonly defaults: HostedWorkspaceDefaults;
+  readonly facts: readonly RememberedFact[];
+  readonly lines: readonly ConversationEntry[];
+}
+
+/**
+ * What the hosted brain is handed beside the roster, in the shape the
+ * desktop composes for the conversation the developer holds: the projects a
+ * workspace could be created in, the facts Luke remembers, and the recent
+ * exchange. The app guide the desktop adds is the panel's own, and the
+ * service draws no panel, so it is absent here rather than invented.
+ */
+export function hostedStandingContext(input: StandingContextInput): string {
+  const sessions: readonly Session[] = input.roster.sessions;
+  return [
+    workspaceProjectContextText(
+      input.roster.projects,
+      input.defaults.defaultProviderId,
+      input.defaults.defaultProjectIds,
+    ),
+    rememberedFactsText(input.facts),
+    conversationLinesText(recentConversationEntries(input.lines), sessions),
+  ]
+    .filter((part): part is string => part !== undefined && part.trim().length > 0)
+    .join("\n\n");
+}

--- a/apps/web/server/hosted/brain-host/conversation.ts
+++ b/apps/web/server/hosted/brain-host/conversation.ts
@@ -1,0 +1,162 @@
+import {
+  type ConversationEntry,
+  HOSTED_CONVERSATION_QUERY,
+  HOSTED_SERVICE_PATH,
+  type HostedConversationClearAnswer,
+  type HostedConversationLine,
+  type HostedConversationLinesAnswer,
+  type HostedLineRatingAnswer,
+  hostedLineRatingRequestSchema,
+  type LineRating,
+  type UnparsedWireValue,
+} from "../../core.js";
+import {
+  BODY_READ,
+  errorResponse,
+  HOSTED_API_ERROR,
+  HOSTED_HTTP_STATUS,
+  jsonResponse,
+  readBoundedBody,
+} from "../http.js";
+import { ratingOf } from "../store/index.js";
+import {
+  admitBrainRoute,
+  busyResponse,
+  clock,
+  HOSTED_CONVERSATION_KEY,
+  type HostedBrainRoute,
+  leaseWithin,
+  pathSegmentAfter,
+} from "./route.js";
+
+/**
+ * The account's one Conversation as the service serves it: the lines the
+ * panel draws, the projection the store already keeps — the most recent
+ * lines inside their retention — with a cursor for what is newer than the
+ * last read and the rating each of Luke's lines carries; its Clear, the
+ * hard delete of the conversation and everything under it, taken under the
+ * conversation's lease so no turn is cut mid-thought; and the developer's
+ * rating of one line Luke wrote.
+ */
+
+const HTTP_METHOD = {
+  GET: "GET",
+  DELETE: "DELETE",
+  PUT: "PUT",
+} as const;
+
+/** A rating is a word, a short note, and a device id; anything heavier is not one. */
+const MAXIMUM_RATING_BODY_BYTES = 16 * 1024;
+
+const CONVERSATION_LINES_PREFIX = `${HOSTED_SERVICE_PATH.CONVERSATION}/lines`;
+
+function invalidRequest(): Response {
+  return errorResponse(HOSTED_HTTP_STATUS.BAD_REQUEST, HOSTED_API_ERROR.INVALID_REQUEST);
+}
+
+/** One stored line as the wire carries it; a line without an instant never left the store and is not drawn. */
+export function lineToWire(
+  entry: ConversationEntry,
+  rating: LineRating | undefined,
+): HostedConversationLine | undefined {
+  if (entry.recordedAt === undefined) return undefined;
+  return {
+    kind: entry.kind,
+    ...(entry.eventId !== undefined ? { eventId: entry.eventId } : undefined),
+    words: entry.words,
+    ...(entry.identity ? { identity: { ...entry.identity } } : undefined),
+    recordedAt: entry.recordedAt,
+    ...(entry.requestId !== undefined ? { requestId: entry.requestId } : undefined),
+    ...(rating !== undefined ? { rating } : undefined),
+  };
+}
+
+function afterOf(request: Request): number | undefined {
+  const asked = new URL(request.url).searchParams.get(HOSTED_CONVERSATION_QUERY.AFTER);
+  if (asked === null) return undefined;
+  const parsed = Number(asked);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : undefined;
+}
+
+/** GET: the lines the panel draws, newest last, those newer than `after` when the caller names one. */
+export async function handleConversationLines(route: HostedBrainRoute): Promise<Response> {
+  const admission = await admitBrainRoute(route, HTTP_METHOD.GET);
+  if (admission instanceof Response) return admission;
+  const { store, userId } = admission;
+  const after = afterOf(route.request);
+  const [entries, ratings] = await Promise.all([
+    store.lines.list(userId, HOSTED_CONVERSATION_KEY, clock(route)()),
+    store.ratings.list(userId, HOSTED_CONVERSATION_KEY),
+  ]);
+  const lines: HostedConversationLine[] = [];
+  let cursor: number | undefined;
+  for (const entry of entries) {
+    const line = lineToWire(entry, ratingOf(ratings, entry));
+    if (!line) continue;
+    cursor = cursor === undefined ? line.recordedAt : Math.max(cursor, line.recordedAt);
+    if (after !== undefined && line.recordedAt <= after) continue;
+    lines.push(line);
+  }
+  const answer: HostedConversationLinesAnswer = {
+    lines,
+    ...(cursor !== undefined ? { cursor } : undefined),
+  };
+  return jsonResponse(HOSTED_HTTP_STATUS.OK, answer);
+}
+
+/**
+ * DELETE: the Clear. The conversation's lease is taken first, so a turn
+ * under way in another function finishes before its conversation goes rather
+ * than writing into a deleted one; then the conversation and every row under
+ * it are removed with no archive, and the next ask or wake makes a fresh one.
+ */
+export async function handleConversationClear(route: HostedBrainRoute): Promise<Response> {
+  const admission = await admitBrainRoute(route, HTTP_METHOD.DELETE);
+  if (admission instanceof Response) return admission;
+  const { store, userId } = admission;
+  const lease = await leaseWithin(route, store, userId);
+  if (!lease) return busyResponse();
+  try {
+    const cleared = await store.conversations.delete(userId, HOSTED_CONVERSATION_KEY);
+    const answer: HostedConversationClearAnswer = { cleared };
+    return jsonResponse(HOSTED_HTTP_STATUS.OK, answer);
+  } finally {
+    await lease.release();
+  }
+}
+
+/**
+ * PUT: the developer's rating of one line Luke wrote, named in the path by
+ * the id its writer minted. Only a line the caller's own conversation holds
+ * and Luke authored takes one; anything else is not found.
+ */
+export async function handleLineRating(route: HostedBrainRoute): Promise<Response> {
+  const admission = await admitBrainRoute(route, HTTP_METHOD.PUT);
+  if (admission instanceof Response) return admission;
+  const lineId = pathSegmentAfter(route.request, CONVERSATION_LINES_PREFIX);
+  if (!lineId) return invalidRequest();
+  const body = await readBoundedBody(route.request, MAXIMUM_RATING_BODY_BYTES);
+  if (body.outcome === BODY_READ.TOO_LARGE) {
+    return errorResponse(HOSTED_HTTP_STATUS.PAYLOAD_TOO_LARGE, HOSTED_API_ERROR.REQUEST_TOO_LARGE);
+  }
+  if (body.outcome !== BODY_READ.READ) return invalidRequest();
+  let payload: UnparsedWireValue;
+  try {
+    // SAFETY: JSON.parse returns unknown; the schema below is the validation.
+    payload = JSON.parse(body.text) as UnparsedWireValue;
+  } catch {
+    return invalidRequest();
+  }
+  const rating = hostedLineRatingRequestSchema.parse(payload);
+  if (!rating) return invalidRequest();
+  const rated = await admission.store.ratings.rate(admission.userId, HOSTED_CONVERSATION_KEY, {
+    eventId: lineId,
+    rating: rating.rating,
+    ...(rating.note ? { note: rating.note } : undefined),
+    deviceId: rating.deviceId,
+    ratedAt: clock(route)(),
+  });
+  if (!rated) return errorResponse(HOSTED_HTTP_STATUS.NOT_FOUND, HOSTED_API_ERROR.NOT_FOUND);
+  const answer: HostedLineRatingAnswer = { rated: true };
+  return jsonResponse(HOSTED_HTTP_STATUS.OK, answer);
+}

--- a/apps/web/server/hosted/brain-host/defaults.ts
+++ b/apps/web/server/hosted/brain-host/defaults.ts
@@ -1,0 +1,37 @@
+import { eq } from "drizzle-orm";
+import { accountPreference, accountWorkspacePreference } from "../../db/schema.js";
+import type { HostedStoreDatabase } from "../store/database.js";
+import type { HostedWorkspaceDefaults } from "./context.js";
+
+/**
+ * The developer's saved creation tie-breaks as the account keeps them: the
+ * provider a nameless creation goes to, and each provider's default project.
+ * They steer the projects context the brain reads and the admission of a
+ * creation that names no project, exactly as the desktop's settings do.
+ */
+export async function readWorkspaceDefaults(
+  db: HostedStoreDatabase,
+  userId: string,
+): Promise<HostedWorkspaceDefaults> {
+  const [preference] = await db
+    .select({ defaultWorkspaceProvider: accountPreference.defaultWorkspaceProvider })
+    .from(accountPreference)
+    .where(eq(accountPreference.userId, userId));
+  const projects = await db
+    .select({
+      providerId: accountWorkspacePreference.providerId,
+      defaultProjectId: accountWorkspacePreference.defaultProjectId,
+    })
+    .from(accountWorkspacePreference)
+    .where(eq(accountWorkspacePreference.userId, userId));
+  const defaultProjectIds: Partial<Record<string, string>> = {};
+  for (const row of projects) {
+    if (row.defaultProjectId) defaultProjectIds[row.providerId] = row.defaultProjectId;
+  }
+  return {
+    ...(preference?.defaultWorkspaceProvider
+      ? { defaultProviderId: preference.defaultWorkspaceProvider }
+      : undefined),
+    ...(Object.keys(defaultProjectIds).length > 0 ? { defaultProjectIds } : undefined),
+  };
+}

--- a/apps/web/server/hosted/brain-host/facts.ts
+++ b/apps/web/server/hosted/brain-host/facts.ts
@@ -1,0 +1,16 @@
+import type { HostedFactsAnswer } from "../../core.js";
+import { HOSTED_HTTP_STATUS, jsonResponse } from "../http.js";
+import { admitBrainRoute, type HostedBrainRoute } from "./route.js";
+
+const HTTP_METHOD = { GET: "GET" } as const;
+
+/** GET: the facts Luke remembers about the developer, oldest first, as the brain's standing context lists them. */
+export async function handleFacts(route: HostedBrainRoute): Promise<Response> {
+  const admission = await admitBrainRoute(route, HTTP_METHOD.GET);
+  if (admission instanceof Response) return admission;
+  const facts = await admission.store.facts.list(admission.userId);
+  const answer: HostedFactsAnswer = {
+    facts: facts.map((fact) => ({ id: fact.id, words: fact.words, createdAt: fact.createdAt })),
+  };
+  return jsonResponse(HOSTED_HTTP_STATUS.OK, answer);
+}

--- a/apps/web/server/hosted/brain-host/host.ts
+++ b/apps/web/server/hosted/brain-host/host.ts
@@ -1,0 +1,349 @@
+import { createHash } from "node:crypto";
+import {
+  ACTION_RESULT_STATUS,
+  announcementConversationEntry,
+  BRAIN_RECOVERY,
+  BRAIN_TURN_KIND,
+  BrainAgent,
+  type BrainRoster,
+  BrainStateStore,
+  type BrainTurnTraceRecord,
+  brainToolCatalog,
+  type CloudAgentProviderId,
+  type ConversationEntry,
+  type ConversationLineRecorder,
+  dispatchRead,
+  GROUP_PREFIX,
+  isCloudAgentProviderId,
+  LOOK_SUBJECT,
+  MAIN_CONVERSATION_NAME,
+  type ModelAdapter,
+  maximumRememberedFacts,
+  type ProviderTranscriptResult,
+  type ProviderTranscriptSinceResult,
+  publishRuns,
+  REALTIME_TOOL,
+  type RememberedFact,
+  rememberedFactText,
+  resolveTurnToolPolicy,
+  type SessionIdentity,
+  type SessionKey,
+  type SessionProviderPlugin,
+  TOOL_GROUP,
+  type ToolPolicyLayers,
+  toolLoopRuntimeOver,
+} from "../../core.js";
+import { type CloudAdapterSeams, cloudSessionPluginFor } from "../cloud-adapters.js";
+import type { HostedStore } from "../store/index.js";
+import { BRAIN_HOST } from "./bounds.js";
+import { type HostedWorkspaceDefaults, hostedStandingContext } from "./context.js";
+import { type CloudActionExecutor, hostedActionPerformer } from "./performer.js";
+import { brainRosterOf, type HostedRoster, readHostedRoster, sessionIsLive } from "./roster.js";
+import {
+  hostedPrompt,
+  hostedWorkspaceAccess,
+  recentHostedDailyNotes,
+  seedHostedWorkspace,
+} from "./workspace.js";
+
+/**
+ * The hosted brain: the same `BrainAgent` the desktop runs, composed for one
+ * request over the account's rows in the Postgres store. Nothing about the
+ * agent knows it runs in a function: the store it writes is the account's,
+ * the roster it is shown is the stored snapshot, the prompt is built from
+ * the workspace rows, and its tools reach the facts table, the workspace
+ * rows, the briefing table, and the cloud action execution — and nothing on
+ * any machine. It is opened for the work one request or one wake brings,
+ * drained, and stopped; whatever it left unfinished the next one resumes.
+ */
+
+/**
+ * What the service cannot perform is not offered: the tools that reach a
+ * machine — an open, an app setting, the panel, the feedback composer, the
+ * updater — and the issue tracker no grant is held for, and the groups
+ * behind seams the service does not wire: delegation, the notebook index,
+ * skills. Everything else in the catalog stands, and the turn's own layer
+ * still withholds `announce` from an ask.
+ */
+export const HOSTED_TOOL_POLICY: ToolPolicyLayers = {
+  agent: {
+    deny: [
+      `${GROUP_PREFIX}${TOOL_GROUP.SESSIONS}`,
+      `${GROUP_PREFIX}${TOOL_GROUP.MEMORY}`,
+      `${GROUP_PREFIX}${TOOL_GROUP.SKILLS}`,
+      REALTIME_TOOL.OPEN_SESSION,
+      REALTIME_TOOL.CHANGE_APP_SETTING,
+      REALTIME_TOOL.SHOW_PANEL,
+      REALTIME_TOOL.OPEN_FEEDBACK_COMPOSER,
+      REALTIME_TOOL.RUN_UPDATE_ACTION,
+      REALTIME_TOOL.UPDATE_ISSUE_STATE,
+      REALTIME_TOOL.COMMENT_ON_ISSUE,
+    ],
+  },
+};
+
+export interface HostedBrainSeams {
+  readonly store: HostedStore;
+  readonly userId: string;
+  readonly sessionKey: SessionKey;
+  /** The model the runtime reaches, the meter already in front of it. */
+  readonly model: ModelAdapter;
+  readonly now: () => number;
+  readonly createId: () => string;
+  readonly report: (message: string) => void;
+  /** The account's stored key for a cloud provider, decrypted; nothing where none is stored. */
+  readonly apiKey: (providerId: CloudAgentProviderId) => Promise<string | undefined>;
+  readonly executeAction: CloudActionExecutor;
+  readonly workspaceDefaults: () => Promise<HostedWorkspaceDefaults>;
+  /** The plugin a transcript read goes through; production builds the provider's own over the account's key. */
+  readonly cloudPlugin?: (
+    providerId: CloudAgentProviderId,
+    seams: CloudAdapterSeams,
+  ) => SessionProviderPlugin;
+  readonly trace?: (record: BrainTurnTraceRecord) => void;
+  /**
+   * Whether this host may still write the conversation: true while it holds
+   * the lease. A save asked for after the lease passed to another holder is
+   * refused rather than landed over the successor's run.
+   */
+  readonly writable?: () => boolean;
+}
+
+export interface HostedBrain {
+  readonly agent: BrainAgent;
+  /** The roster as the brain currently holds it. */
+  roster(): HostedRoster;
+  /** Reads the snapshot again, for a turn opened after a pass may have moved it. */
+  refreshRoster(): Promise<HostedRoster>;
+  /** Writes into the Conversation the asks and ends of every run it has not yet taken. */
+  publish(): Promise<void>;
+  /** Cancels the runs the developer asked the service to cancel since the brain last looked. */
+  applyCancels(): Promise<void>;
+  /** Stands the agent down once its work is done; a run still going is left for the next holder. */
+  stop(): Promise<void>;
+}
+
+/** The prefix cache the account's turns share: a digest of who and which conversation, never the ids. */
+function promptCacheKeyFor(userId: string, sessionKey: SessionKey): string {
+  return createHash("sha256").update(`${userId}\n${sessionKey}`).digest("hex");
+}
+
+const NOT_OBSERVED: ProviderTranscriptSinceResult & ProviderTranscriptResult = {
+  status: ACTION_RESULT_STATUS.REJECTED,
+  reason: "No observed session matches that identity.",
+};
+
+const NOT_CLOUD: ProviderTranscriptSinceResult & ProviderTranscriptResult = {
+  status: ACTION_RESULT_STATUS.UNSUPPORTED,
+  reason: "That session's provider is not one the service reads.",
+};
+
+const NOT_LIVE: ProviderTranscriptSinceResult = {
+  status: ACTION_RESULT_STATUS.UNSUPPORTED,
+  reason: "not read: the session is neither working nor waiting",
+};
+
+export async function openHostedBrain(seams: HostedBrainSeams): Promise<HostedBrain> {
+  const { store, userId, sessionKey, now, createId, report } = seams;
+  await store.conversations.create(userId, {
+    sessionKey,
+    name: MAIN_CONVERSATION_NAME,
+    now: now(),
+  });
+  await seedHostedWorkspace(store, userId, now());
+
+  let roster = await readHostedRoster(store, userId);
+  let facts: readonly RememberedFact[] = await store.facts.list(userId);
+  let lines: readonly ConversationEntry[] = await store.lines.list(userId, sessionKey, now());
+  const defaults = await seams.workspaceDefaults();
+
+  const refreshRoster = async () => {
+    roster = await readHostedRoster(store, userId);
+    return roster;
+  };
+  const refreshLines = async () => {
+    lines = await store.lines.list(userId, sessionKey, now());
+  };
+
+  /** Appends one line the brain's own work produced, minted here, and answers whether the thread took it. */
+  const recordLine: ConversationLineRecorder = async (entry, recordedAt) => {
+    const appended = await store.lines.append(
+      userId,
+      sessionKey,
+      [{ ...entry, recordedAt }],
+      Math.max(now(), recordedAt),
+    );
+    lines = appended.entries;
+    return (
+      appended.changed ||
+      (entry.requestId !== undefined &&
+        appended.entries.some(
+          (held) => held.requestId === entry.requestId && held.kind === entry.kind,
+        ))
+    );
+  };
+
+  const plugins = new Map<CloudAgentProviderId, SessionProviderPlugin>();
+  const pluginFor = (providerId: CloudAgentProviderId): SessionProviderPlugin => {
+    const held = plugins.get(providerId);
+    if (held) return held;
+    const build = seams.cloudPlugin ?? cloudSessionPluginFor;
+    const plugin = build(providerId, {
+      readApiKey: () => seams.apiKey(providerId),
+      reported: () => roster.observations.get(providerId) ?? [],
+    });
+    plugins.set(providerId, plugin);
+    return plugin;
+  };
+  const observed = (identity: SessionIdentity) =>
+    roster.sessions.find(
+      (session) =>
+        session.providerId === identity.providerId &&
+        session.providerSessionId === identity.providerSessionId,
+    );
+
+  const repository = store.brainStateRepository(userId, sessionKey);
+  const writable = seams.writable ?? (() => true);
+  const stateStore = new BrainStateStore({
+    repository: {
+      load: () => repository.load(),
+      save: (state, transcript) => (writable() ? repository.save(state, transcript) : false),
+    },
+    createGenerationId: createId,
+    report,
+  });
+
+  const performer = hostedActionPerformer({
+    roster: refreshRoster,
+    defaults: async () => defaults,
+    facts: {
+      list: async () => facts,
+      remember: async (ask) => {
+        const words = rememberedFactText(ask.words);
+        if (!words) return false;
+        const kept = facts.filter((fact) => fact.id !== ask.replaces);
+        if (kept.some((fact) => fact.words === words)) return true;
+        if (kept.length >= maximumRememberedFacts) return false;
+        facts = await store.facts.replace(userId, [...kept, { id: ask.id, words }], now());
+        return true;
+      },
+      forget: async (id) => {
+        if (!facts.some((fact) => fact.id === id)) return false;
+        facts = await store.facts.replace(
+          userId,
+          facts.filter((fact) => fact.id !== id),
+          now(),
+        );
+        return true;
+      },
+    },
+    apiKey: seams.apiKey,
+    execute: seams.executeAction,
+    recordLine: async (entry) => {
+      await recordLine({ ...entry, eventId: createId() }, now(), sessionKey);
+    },
+  });
+
+  const agent = new BrainAgent({
+    runtime: toolLoopRuntimeOver(seams.model),
+    actions: performer,
+    roster: (): BrainRoster => brainRosterOf(roster, now()),
+    standingContext: () => hostedStandingContext({ roster, defaults, facts, lines }),
+    prepareTurn: async (turn) => {
+      const catalog = brainToolCatalog();
+      const policy = resolveTurnToolPolicy(
+        catalog,
+        HOSTED_TOOL_POLICY,
+        turn.kind === BRAIN_TURN_KIND.TURN ? turn.trigger : undefined,
+      );
+      const built = await hostedPrompt(store, userId, {
+        policy,
+        ...(seams.model.model ? { model: seams.model.model } : undefined),
+      });
+      return { prompt: built.text, layers: HOSTED_TOOL_POLICY, catalog };
+    },
+    workspace: hostedWorkspaceAccess(store, userId, now),
+    primeFreshContext: () => recentHostedDailyNotes(store, userId, now()),
+    observes: { kind: LOOK_SUBJECT.NONE },
+    readTranscriptSince: async (identity, cursor) => {
+      const session = observed(identity);
+      if (!session) return NOT_OBSERVED;
+      if (!isCloudAgentProviderId(identity.providerId)) return NOT_CLOUD;
+      if (!sessionIsLive(session)) return NOT_LIVE;
+      return dispatchRead(
+        pluginFor(identity.providerId),
+        "transcriptSince",
+        identity.providerSessionId,
+        cursor,
+      );
+    },
+    readTranscript: async (identity) => {
+      if (!observed(identity)) return NOT_OBSERVED;
+      if (!isCloudAgentProviderId(identity.providerId)) return NOT_CLOUD;
+      return dispatchRead(pluginFor(identity.providerId), "transcript", identity.providerSessionId);
+    },
+    deliver: async (delivery) => {
+      const id = createId();
+      await store.briefings.insert(userId, {
+        id,
+        sessionKey,
+        words: delivery.briefing,
+        decidedAt: delivery.decidedAt,
+        expiresAt: delivery.decidedAt + BRAIN_HOST.BRIEFING_EXPIRY_MS,
+      });
+      await recordLine(
+        { ...announcementConversationEntry(delivery.briefing), eventId: id },
+        delivery.decidedAt,
+        sessionKey,
+      );
+    },
+    store: stateStore,
+    createRunId: createId,
+    trace: (record) => {
+      seams.trace?.(record);
+      void store.runs
+        .recordAbout(userId, record.runId, {
+          trigger: record.trigger,
+          origin: record.origin,
+          ...(record.ending !== undefined ? { ending: record.ending } : undefined),
+          ...(record.inputTokens !== undefined ? { inputTokens: record.inputTokens } : undefined),
+          ...(record.outputTokens !== undefined
+            ? { outputTokens: record.outputTokens }
+            : undefined),
+          transcriptBytes: record.transcriptBytes,
+          elapsedMs: record.elapsedMs,
+          toolNames: record.tools,
+          compacted: record.compacted,
+        })
+        .catch((error: Error) => report(`Run about-fields could not be written: ${error.name}`));
+    },
+    report,
+    now,
+    executionDeadlineMs: BRAIN_HOST.RUN_DEADLINE_MS,
+    promptCacheKey: promptCacheKeyFor(userId, sessionKey),
+    recovery: BRAIN_RECOVERY.RESUME,
+  });
+
+  return {
+    agent,
+    roster: () => roster,
+    refreshRoster,
+    publish: async () => {
+      await publishRuns(
+        agent,
+        agent.requests().map((record) => ({ runId: record.runId })),
+        recordLine,
+        () => true,
+        undefined,
+        sessionKey,
+      );
+      await refreshLines();
+    },
+    applyCancels: async () => {
+      for (const runId of await store.runs.cancelRequested(userId, sessionKey)) {
+        await agent.cancelAsk(runId);
+      }
+    },
+    stop: () => agent.stop(),
+  };
+}

--- a/apps/web/server/hosted/brain-host/host.ts
+++ b/apps/web/server/hosted/brain-host/host.ts
@@ -102,9 +102,11 @@ export interface HostedBrainSeams {
   ) => SessionProviderPlugin;
   readonly trace?: (record: BrainTurnTraceRecord) => void;
   /**
-   * Whether this host may still write the conversation: true while it holds
-   * the lease. A save asked for after the lease passed to another holder is
-   * refused rather than landed over the successor's run.
+   * Whether this host may still write for the account: true while it holds
+   * the lease. Every write asked for after the lease passed to another holder
+   * — the envelope, a line, a briefing, a fact, a workspace file, an action
+   * carried to a provider — is refused rather than landed over the
+   * successor's, and the refusal is what the model reads.
    */
   readonly writable?: () => boolean;
 }
@@ -138,6 +140,9 @@ const NOT_CLOUD: ProviderTranscriptSinceResult & ProviderTranscriptResult = {
   reason: "That session's provider is not one the service reads.",
 };
 
+/** What every write answers once the lease has passed to another holder. */
+const LEASE_LOST = "not run: this conversation is now run by another request";
+
 const NOT_LIVE: ProviderTranscriptSinceResult = {
   status: ACTION_RESULT_STATUS.UNSUPPORTED,
   reason: "not read: the session is neither working nor waiting",
@@ -157,6 +162,7 @@ export async function openHostedBrain(seams: HostedBrainSeams): Promise<HostedBr
   let lines: readonly ConversationEntry[] = await store.lines.list(userId, sessionKey, now());
   const defaults = await seams.workspaceDefaults();
 
+  const writable = seams.writable ?? (() => true);
   const refreshRoster = async () => {
     roster = await readHostedRoster(store, userId);
     return roster;
@@ -167,6 +173,7 @@ export async function openHostedBrain(seams: HostedBrainSeams): Promise<HostedBr
 
   /** Appends one line the brain's own work produced, minted here, and answers whether the thread took it. */
   const recordLine: ConversationLineRecorder = async (entry, recordedAt) => {
+    if (!writable()) return false;
     const appended = await store.lines.append(
       userId,
       sessionKey,
@@ -203,7 +210,6 @@ export async function openHostedBrain(seams: HostedBrainSeams): Promise<HostedBr
     );
 
   const repository = store.brainStateRepository(userId, sessionKey);
-  const writable = seams.writable ?? (() => true);
   const stateStore = new BrainStateStore({
     repository: {
       load: () => repository.load(),
@@ -220,7 +226,7 @@ export async function openHostedBrain(seams: HostedBrainSeams): Promise<HostedBr
       list: async () => facts,
       remember: async (ask) => {
         const words = rememberedFactText(ask.words);
-        if (!words) return false;
+        if (!words || !writable()) return false;
         const kept = facts.filter((fact) => fact.id !== ask.replaces);
         if (kept.some((fact) => fact.words === words)) return true;
         if (kept.length >= maximumRememberedFacts) return false;
@@ -228,7 +234,7 @@ export async function openHostedBrain(seams: HostedBrainSeams): Promise<HostedBr
         return true;
       },
       forget: async (id) => {
-        if (!facts.some((fact) => fact.id === id)) return false;
+        if (!writable() || !facts.some((fact) => fact.id === id)) return false;
         facts = await store.facts.replace(
           userId,
           facts.filter((fact) => fact.id !== id),
@@ -238,7 +244,10 @@ export async function openHostedBrain(seams: HostedBrainSeams): Promise<HostedBr
       },
     },
     apiKey: seams.apiKey,
-    execute: seams.executeAction,
+    execute: (input) =>
+      writable()
+        ? seams.executeAction(input)
+        : Promise.resolve({ result: ACTION_RESULT_STATUS.REJECTED, reason: LEASE_LOST }),
     recordLine: async (entry) => {
       await recordLine({ ...entry, eventId: createId() }, now(), sessionKey);
     },
@@ -262,7 +271,7 @@ export async function openHostedBrain(seams: HostedBrainSeams): Promise<HostedBr
       });
       return { prompt: built.text, layers: HOSTED_TOOL_POLICY, catalog };
     },
-    workspace: hostedWorkspaceAccess(store, userId, now),
+    workspace: hostedWorkspaceAccess(store, userId, now, writable),
     primeFreshContext: () => recentHostedDailyNotes(store, userId, now()),
     observes: { kind: LOOK_SUBJECT.NONE },
     readTranscriptSince: async (identity, cursor) => {
@@ -283,6 +292,7 @@ export async function openHostedBrain(seams: HostedBrainSeams): Promise<HostedBr
       return dispatchRead(pluginFor(identity.providerId), "transcript", identity.providerSessionId);
     },
     deliver: async (delivery) => {
+      if (!writable()) throw new Error(LEASE_LOST);
       const id = createId();
       await store.briefings.insert(userId, {
         id,

--- a/apps/web/server/hosted/brain-host/lease-run.ts
+++ b/apps/web/server/hosted/brain-host/lease-run.ts
@@ -1,0 +1,114 @@
+import type { SessionKey } from "../../core.js";
+import type { HostedStore } from "../store/index.js";
+import { BRAIN_HOST } from "./bounds.js";
+
+/**
+ * One request's or one wake's hold on a conversation. The lease is acquired
+ * before the brain is opened and kept warm while it runs; a holder that
+ * loses it — its heartbeat stalled past the lease's life — is told so, and a
+ * holder that is done lets it go. A holder cut off by its function neither
+ * releases nor heartbeats, so the row expires and the next holder takes it.
+ */
+export interface LeaseSeams {
+  readonly store: Pick<HostedStore, "leases">;
+  readonly userId: string;
+  readonly sessionKey: SessionKey;
+  readonly ownerId: string;
+  readonly now: () => number;
+  readonly ttlMs?: number;
+  readonly heartbeatMs?: number;
+  /** How the wait between attempts is spent; a timer unless a test says otherwise. */
+  readonly sleep?: (ms: number) => Promise<void>;
+}
+
+export interface HeldLease {
+  readonly ownerId: string;
+  /**
+   * Starts the heartbeat: every interval the lease is moved along and `tick`
+   * runs under it, and a lease this owner no longer holds ends the heartbeat
+   * and tells `lost`. Answers the stop.
+   */
+  heartbeat(tick: () => Promise<void>, lost: () => void): () => void;
+  /** Lets the lease go; a lease that has passed to another is left alone. */
+  release(): Promise<void>;
+}
+
+function realSleep(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+function held(seams: LeaseSeams): HeldLease {
+  const { store, userId, sessionKey, ownerId, now } = seams;
+  const ttlMs = seams.ttlMs ?? BRAIN_HOST.LEASE_TTL_MS;
+  return {
+    ownerId,
+    heartbeat(tick, lost) {
+      let stopped = false;
+      let beating = false;
+      const timer = setInterval(() => {
+        if (stopped || beating) return;
+        beating = true;
+        void (async () => {
+          try {
+            if (!(await store.leases.heartbeat(userId, sessionKey, ownerId, now(), ttlMs))) {
+              stopped = true;
+              clearInterval(timer);
+              lost();
+              return;
+            }
+            await tick();
+          } catch {
+            // A heartbeat that could not reach the store says nothing about
+            // the lease; the next one asks again, and the row's own expiry
+            // is the one judge of a holder that never reaches it.
+          } finally {
+            beating = false;
+          }
+        })();
+      }, seams.heartbeatMs ?? BRAIN_HOST.HEARTBEAT_MS);
+      timer.unref();
+      return () => {
+        stopped = true;
+        clearInterval(timer);
+      };
+    },
+    release: async () => {
+      await store.leases.release(userId, sessionKey, ownerId);
+    },
+  };
+}
+
+/** Takes the lease now, or answers nothing while another holder's stands. */
+export async function acquireLeaseNow(seams: LeaseSeams): Promise<HeldLease | undefined> {
+  const taken = await seams.store.leases.acquire(
+    seams.userId,
+    seams.sessionKey,
+    seams.ownerId,
+    seams.now(),
+    seams.ttlMs ?? BRAIN_HOST.LEASE_TTL_MS,
+  );
+  return taken ? held(seams) : undefined;
+}
+
+/**
+ * Takes the lease, waiting a bounded while for a holder under way to finish:
+ * an ask that arrives while a wake runs the conversation waits for it rather
+ * than being refused, and one that would wait longer than the bound is told
+ * the conversation is busy.
+ */
+export async function acquireLeaseWithin(
+  seams: LeaseSeams,
+  waitMs: number,
+  pollMs: number = BRAIN_HOST.LEASE_POLL_MS,
+): Promise<HeldLease | undefined> {
+  const sleep = seams.sleep ?? realSleep;
+  const deadline = seams.now() + waitMs;
+  for (;;) {
+    const lease = await acquireLeaseNow(seams);
+    if (lease) return lease;
+    if (seams.now() + pollMs > deadline) return undefined;
+    await sleep(pollMs);
+  }
+}

--- a/apps/web/server/hosted/brain-host/metered-model.ts
+++ b/apps/web/server/hosted/brain-host/metered-model.ts
@@ -1,0 +1,37 @@
+import { MODEL_RESPONSE_OUTCOME, type ModelAdapter } from "../../core.js";
+import type { HostedSpend } from "../quota.js";
+
+/**
+ * The model adapter with the daily meter in front of it. Every inference —
+ * an answer, or the explicit compaction that is one — spends one unit of the
+ * account's single daily allowance before the upstream is asked, and a spend
+ * the meter refuses ends the inference as a throttle until the day's counter
+ * resets, which the runtime carries as the run's quiet end exactly as the
+ * desktop's hosted adapter does when the service answers it the same. A
+ * token count spends nothing: it asks the model for no words.
+ */
+export function meteredModelAdapter(
+  inner: ModelAdapter,
+  spend: () => Promise<HostedSpend>,
+): ModelAdapter {
+  const admitted = async () => {
+    const spent = await spend();
+    return spent.allowed ? undefined : spent.quota.resetsAt;
+  };
+  return {
+    ...(inner.model !== undefined ? { model: inner.model } : undefined),
+    capabilities: () => inner.capabilities(),
+    respond: async (items, options) => {
+      const until = await admitted();
+      if (until !== undefined) return { outcome: MODEL_RESPONSE_OUTCOME.THROTTLED, until };
+      return inner.respond(items, options);
+    },
+    countInputTokens: (items, options) => inner.countInputTokens(items, options),
+    compact: async (items, options) => {
+      const until = await admitted();
+      if (until !== undefined) return { outcome: MODEL_RESPONSE_OUTCOME.THROTTLED, until };
+      return inner.compact(items, options);
+    },
+    quietUntil: () => inner.quietUntil(),
+  };
+}

--- a/apps/web/server/hosted/brain-host/performer.ts
+++ b/apps/web/server/hosted/brain-host/performer.ts
@@ -1,0 +1,212 @@
+import { randomUUID } from "node:crypto";
+import {
+  ACTION_KIND,
+  ACTION_REFUSAL,
+  ACTION_RESULT_STATUS,
+  type AdmitContext,
+  type BrainActionExecution,
+  type BrainActionPerformer,
+  type CloudAgentProviderId,
+  CONVERSATION_ENTRY_KIND,
+  type ConversationEntry,
+  dispatchByKind,
+  isCloudAgentProviderId,
+  isRecord,
+  isRunOrigin,
+  isWireString,
+  type RealtimeFunctionCall,
+  type RememberedFact,
+  RUN_ORIGIN,
+  type SessionActionKind,
+  sessionActionConversationEntry,
+  toolAction,
+  type UnparsedWireValue,
+  type ValidatedAction,
+  type WireRecord,
+  workspaceAgentModels,
+} from "../../core.js";
+import type { ActionExecutionAnswer, HostedSessionActionKind } from "../action-execute.js";
+import type { HostedWorkspaceDefaults } from "./context.js";
+import type { HostedRoster } from "./roster.js";
+
+/**
+ * The gauntlet every action the hosted brain asks for runs, in the service:
+ * the call is admitted by `admit`, against the stored roster snapshot it
+ * reads for itself, the projects that snapshot listed, and the facts Luke
+ * remembers, and only the validated action it mints reaches what carries it
+ * — the facts table for a memory, the cloud action execution for a session
+ * or a workspace, which admits it once more against the same snapshot before
+ * the provider's documented endpoint sees it. Nothing here reaches a
+ * machine: an open, an app action, and an issue action have no performer on
+ * the service and the tool policy offers none of them, so a call that still
+ * names one is refused before admission runs.
+ */
+
+/** The facts as an action reaches them: remember answers whether the words now stand, forget whether the entry is gone. */
+export interface HostedFactsWriter {
+  list(): Promise<readonly RememberedFact[]>;
+  remember(ask: { id: string; words: string; replaces?: string }): Promise<boolean>;
+  forget(id: string): Promise<boolean>;
+}
+
+/** One session action carried to its provider through the service's own execution, admitted there again. */
+export type CloudActionExecutor = (input: {
+  kind: HostedSessionActionKind;
+  providerId: CloudAgentProviderId;
+  fields: WireRecord;
+  apiKey: string;
+}) => Promise<ActionExecutionAnswer>;
+
+export interface HostedPerformerDependencies {
+  /** The roster as the snapshot holds it now, read again for every action. */
+  roster: () => Promise<HostedRoster>;
+  defaults: () => Promise<HostedWorkspaceDefaults>;
+  facts: HostedFactsWriter;
+  /** The account's stored key for a provider, decrypted; nothing where none is stored. */
+  apiKey: (providerId: CloudAgentProviderId) => Promise<string | undefined>;
+  execute: CloudActionExecutor;
+  /** Records the ask a carried session action was, so the Conversation holds it. */
+  recordLine: (entry: ConversationEntry) => Promise<void>;
+}
+
+const REFUSAL = {
+  NO_EXECUTION: "Not run: an action needs the standing of a turn.",
+  TURN_OVER: ACTION_REFUSAL.TURN_OVER,
+  MEMORY_NOT_SAVED: "That memory could not be saved.",
+  MEMORY_NOT_REMOVED: "That memory could not be removed.",
+  NOT_HERE: "Not run: this action reaches a machine, and the service has none.",
+  NO_KEY: "No provider key is stored for that session's provider.",
+  NOT_CLOUD: "Not run: that session's provider is not one the service reaches.",
+  UNREADABLE_CALL: "Not run: the call's arguments are not a record.",
+} as const;
+
+function rejection(reason: string): WireRecord {
+  return { status: ACTION_RESULT_STATUS.REJECTED, reason };
+}
+
+function isExecution(
+  execution: BrainActionExecution | undefined,
+): execution is BrainActionExecution {
+  return (
+    execution !== undefined &&
+    execution !== null &&
+    isWireString(execution.runId) &&
+    execution.runId.length > 0 &&
+    isRunOrigin(execution.origin) &&
+    execution.isRevoked instanceof Function &&
+    execution.signal instanceof AbortSignal
+  );
+}
+
+function parsedArguments(call: RealtimeFunctionCall): WireRecord | undefined {
+  try {
+    // SAFETY: JSON.parse returns unknown; isRecord below validates the shape.
+    const parsed = JSON.parse(call.argumentsJson) as UnparsedWireValue;
+    return isRecord(parsed) ? parsed : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function fromExecution(executed: ActionExecutionAnswer): WireRecord {
+  return {
+    status: executed.result,
+    ...(executed.reason ? { reason: executed.reason } : undefined),
+    ...(executed.providerSessionId
+      ? { provider_session_id: executed.providerSessionId }
+      : undefined),
+  };
+}
+
+export function hostedActionPerformer(
+  dependencies: HostedPerformerDependencies,
+): BrainActionPerformer {
+  const admissionContext = async (execution: BrainActionExecution): Promise<AdmitContext> => {
+    // The roster and the projects an action is admitted against are two
+    // readings of one snapshot, read once per action so a session that left
+    // between the turn's opening and the call is refused rather than written to.
+    let read: Promise<HostedRoster> | undefined;
+    const roster = () => (read ??= dependencies.roster());
+    return {
+      origin: execution.origin,
+      guard: execution,
+      roster: { read: async () => (await roster()).sessions },
+      projects: {
+        read: async () => (await roster()).projects,
+        defaults: () => dependencies.defaults(),
+        agentModels: workspaceAgentModels,
+      },
+      rememberedFacts: await dependencies.facts.list(),
+    };
+  };
+
+  const carrySessionAction = async (
+    action: ValidatedAction<SessionActionKind>,
+    kind: HostedSessionActionKind,
+    fields: WireRecord,
+    execution: BrainActionExecution,
+  ): Promise<WireRecord> => {
+    const providerId = "identity" in action ? action.identity.providerId : action.providerId;
+    if (!isCloudAgentProviderId(providerId)) return rejection(REFUSAL.NOT_CLOUD);
+    const apiKey = await dependencies.apiKey(providerId);
+    if (execution.isRevoked()) return rejection(REFUSAL.TURN_OVER);
+    if (!apiKey) return rejection(REFUSAL.NO_KEY);
+    // The ask is recorded before the outcome is known: a refusal still leaves
+    // the developer having asked it, or Luke having judged it worth doing.
+    await dependencies.recordLine(
+      sessionActionConversationEntry(
+        action,
+        (await dependencies.roster()).sessions,
+        execution.origin === RUN_ORIGIN.USER
+          ? CONVERSATION_ENTRY_KIND.ACTION
+          : CONVERSATION_ENTRY_KIND.OWN_ACTION,
+      ),
+    );
+    return fromExecution(await dependencies.execute({ kind, providerId, fields, apiKey }));
+  };
+
+  return {
+    async perform(call, execution) {
+      if (!isExecution(execution)) return rejection(REFUSAL.NO_EXECUTION);
+      if (execution.isRevoked()) return rejection(REFUSAL.TURN_OVER);
+      const fields = parsedArguments(call);
+      if (!fields) return rejection(REFUSAL.UNREADABLE_CALL);
+      const admitted = await toolAction(call, await admissionContext(execution));
+      if (admitted.kind === undefined) return rejection(admitted.reason);
+      if (execution.isRevoked()) return rejection(REFUSAL.TURN_OVER);
+      return dispatchByKind(admitted, {
+        [ACTION_KIND.REMEMBER]: async (action) =>
+          (await dependencies.facts.remember({
+            id: randomUUID(),
+            words: action.words,
+            ...(action.replaces !== undefined ? { replaces: action.replaces } : undefined),
+          }))
+            ? { status: ACTION_RESULT_STATUS.ACCEPTED }
+            : rejection(REFUSAL.MEMORY_NOT_SAVED),
+        [ACTION_KIND.FORGET]: async (action) =>
+          (await dependencies.facts.forget(action.id))
+            ? { status: ACTION_RESULT_STATUS.ACCEPTED }
+            : rejection(REFUSAL.MEMORY_NOT_REMOVED),
+        [ACTION_KIND.MESSAGE]: (action) =>
+          carrySessionAction(action, ACTION_KIND.MESSAGE, fields, execution),
+        [ACTION_KIND.CONTROL]: (action) =>
+          carrySessionAction(action, ACTION_KIND.CONTROL, fields, execution),
+        [ACTION_KIND.CREATE_WORKSPACE]: (action) =>
+          carrySessionAction(action, ACTION_KIND.CREATE_WORKSPACE, fields, execution),
+        [ACTION_KIND.ADD_AGENT]: (action) =>
+          carrySessionAction(action, ACTION_KIND.ADD_AGENT, fields, execution),
+        [ACTION_KIND.RENAME_WORKSPACE]: (action) =>
+          carrySessionAction(action, ACTION_KIND.RENAME_WORKSPACE, fields, execution),
+        [ACTION_KIND.RENAME_SESSION]: (action) =>
+          carrySessionAction(action, ACTION_KIND.RENAME_SESSION, fields, execution),
+        [ACTION_KIND.OPEN]: async () => rejection(REFUSAL.NOT_HERE),
+        [ACTION_KIND.SETTING]: async () => rejection(REFUSAL.NOT_HERE),
+        [ACTION_KIND.PANEL]: async () => rejection(REFUSAL.NOT_HERE),
+        [ACTION_KIND.FEEDBACK]: async () => rejection(REFUSAL.NOT_HERE),
+        [ACTION_KIND.UPDATE]: async () => rejection(REFUSAL.NOT_HERE),
+        [ACTION_KIND.ISSUE_STATE]: async () => rejection(REFUSAL.NOT_HERE),
+        [ACTION_KIND.ISSUE_COMMENT]: async () => rejection(REFUSAL.NOT_HERE),
+      });
+    },
+  };
+}

--- a/apps/web/server/hosted/brain-host/production.ts
+++ b/apps/web/server/hosted/brain-host/production.ts
@@ -1,0 +1,77 @@
+import { waitUntil } from "@vercel/functions";
+import { eq } from "drizzle-orm";
+import { auth } from "../../auth.js";
+import { getDatabase } from "../../db/index.js";
+import { providerKey } from "../../db/schema.js";
+import type { Route } from "../../route.js";
+import { hostedUserId, oauthUserInfoFromAuthAnswer } from "../bearer.js";
+import { payloadKeyRing, VAULT_ENCRYPTION_ENVIRONMENT } from "../encryption.js";
+import { HOSTED_OPENAI_ENVIRONMENT } from "../openai.js";
+import { spendHostedMeter } from "../quota.js";
+import { type HostedStore, hostedStore } from "../store/index.js";
+import { BRAIN_HOST_ENVIRONMENT } from "./bounds.js";
+import { readWorkspaceDefaults } from "./defaults.js";
+import type { HostedBrainRoute } from "./route.js";
+import { type BrainWakeOptions, handleBrainWake } from "./wake.js";
+
+/**
+ * The deployment's real seams behind the brain-host routes, built once: the
+ * bearer's account through the auth service's own userinfo, the stored keys
+ * out of the vault table, the store under the payload key ring, Luke's own
+ * OpenAI key and model, the daily meter, the account's saved creation
+ * defaults, and Vercel's `waitUntil` for the run that finishes after the
+ * answer. A route file hands its handler here and nothing else.
+ */
+
+let storeUnderSecret: { secret: string; store: HostedStore } | undefined;
+
+/** One store per process, rebuilt only if the secret it was built under changes. */
+function storeFor(secret: string): HostedStore {
+  if (storeUnderSecret?.secret !== secret) {
+    storeUnderSecret = {
+      secret,
+      store: hostedStore({ db: getDatabase(), keys: payloadKeyRing(secret) }),
+    };
+  }
+  return storeUnderSecret.store;
+}
+
+const seams = {
+  resolveUserId: (request: Request) =>
+    hostedUserId(request, async (input) =>
+      oauthUserInfoFromAuthAnswer(await auth.api.oauth2UserInfo(input)),
+    ),
+  encryptionSecret: process.env[VAULT_ENCRYPTION_ENVIRONMENT.SECRET],
+  openAiKey: process.env[HOSTED_OPENAI_ENVIRONMENT.API_KEY],
+  model: process.env[HOSTED_OPENAI_ENVIRONMENT.BRAIN_MODEL],
+  readVaultKeys: (userId: string) =>
+    getDatabase()
+      .select({ providerId: providerKey.providerId, ciphertext: providerKey.ciphertext })
+      .from(providerKey)
+      .where(eq(providerKey.userId, userId)),
+  store: storeFor,
+  spend: (userId: string) => spendHostedMeter(getDatabase(), { userId, now: Date.now() }),
+  workspaceDefaults: (userId: string) => readWorkspaceDefaults(getDatabase(), userId),
+  continueAfterResponse: (work: Promise<void>) => {
+    waitUntil(work);
+  },
+} satisfies Omit<HostedBrainRoute, "request">;
+
+/** One brain-host route over the deployment's seams. */
+export function hostedBrainHostRoute(
+  handler: (route: HostedBrainRoute) => Promise<Response>,
+): Route {
+  return { fetch: (request) => handler({ ...seams, request }) };
+}
+
+/** The scheduled wake over the same seams, under the cron's own bearer. */
+export const brainWakeRoute: Route = {
+  fetch: (request) => {
+    const options: BrainWakeOptions = {
+      ...seams,
+      request,
+      cronSecret: process.env[BRAIN_HOST_ENVIRONMENT.CRON_SECRET],
+    };
+    return handleBrainWake(options);
+  },
+};

--- a/apps/web/server/hosted/brain-host/roster.ts
+++ b/apps/web/server/hosted/brain-host/roster.ts
@@ -1,0 +1,90 @@
+import {
+  type BrainRoster,
+  normalizeSession,
+  type ObservedWorkspaceProject,
+  PROVIDER_IDENTITY_BY_ID,
+  type ProviderSessionObservation,
+  SESSION_STATUS,
+  type Session,
+  type SessionIdentity,
+  sessionContextText,
+} from "../../core.js";
+import type { ObservationStore } from "../observation-pass.js";
+import { storedRoster } from "../observation-pass.js";
+import type { ObservedRoster } from "../observed-roster.js";
+
+/**
+ * The roster the hosted brain is shown: the account's stored snapshot, the
+ * same one the observe route serves and an action is admitted against, read
+ * into the sessions and projects the desktop's standing context is composed
+ * from. It is read from the store and never from a provider — the brain's
+ * turns observe nothing; the scheduled pass does — so every inference of a
+ * request reads the roster as the last pass left it.
+ */
+export interface HostedRoster {
+  readonly sessions: readonly Session[];
+  readonly projects: readonly ObservedWorkspaceProject[];
+  readonly observations: ReadonlyMap<string, readonly ProviderSessionObservation[]>;
+  readonly observedAt: number | undefined;
+}
+
+export const EMPTY_HOSTED_ROSTER: HostedRoster = {
+  sessions: [],
+  projects: [],
+  observations: new Map(),
+  observedAt: undefined,
+};
+
+export function hostedRosterFrom(
+  roster: ObservedRoster | undefined,
+  observedAt: number | undefined,
+): HostedRoster {
+  if (!roster) return { ...EMPTY_HOSTED_ROSTER, observedAt };
+  const sessions: Session[] = [];
+  const projects: ObservedWorkspaceProject[] = [];
+  const observations = new Map<string, readonly ProviderSessionObservation[]>();
+  for (const provider of roster.providers) {
+    const identity = PROVIDER_IDENTITY_BY_ID[provider.providerId];
+    const sessionProvider = { id: identity.id, displayName: identity.displayName };
+    observations.set(provider.providerId, provider.observations);
+    for (const observation of provider.observations) {
+      sessions.push(normalizeSession(sessionProvider, observation));
+    }
+    for (const project of provider.projects) {
+      projects.push({
+        ...project,
+        providerId: provider.providerId,
+        providerName: identity.displayName,
+      });
+    }
+  }
+  return { sessions, projects, observations, observedAt };
+}
+
+/** The stored snapshot as the brain reads it; nothing where no pass has written one. */
+export async function readHostedRoster(
+  store: ObservationStore,
+  userId: string,
+): Promise<HostedRoster> {
+  const stored = await storedRoster(store, userId);
+  return hostedRosterFrom(stored?.roster, stored?.observedAt);
+}
+
+/** The roster as the brain's turns take it: rendered, with the identities every tool argument is validated against. */
+export function brainRosterOf(roster: HostedRoster, now: number): BrainRoster {
+  return {
+    text: sessionContextText(roster.sessions, now),
+    identities: roster.sessions.map(
+      (session): SessionIdentity => ({
+        providerId: session.providerId,
+        providerSessionId: session.providerSessionId,
+      }),
+    ),
+    sessions: roster.sessions,
+  };
+}
+
+/** Whether a session's transcript is one an observation turn reads: it is working or waiting for the developer. */
+export function sessionIsLive(session: Pick<Session, "status">): boolean {
+  return session.status === SESSION_STATUS.WORKING || session.status === SESSION_STATUS.WAITING;
+}

--- a/apps/web/server/hosted/brain-host/route.ts
+++ b/apps/web/server/hosted/brain-host/route.ts
@@ -311,13 +311,14 @@ export async function openBrainSession(
   // A lease that passed to another holder means that holder now runs the
   // conversation: this brain writes nothing more and stands down, its runs
   // ending in memory alone while the successor resumes them from the store.
+  const standDown = (why: string) => {
+    lost = true;
+    report(why);
+    void brain.stop();
+  };
   const stopHeartbeat = lease.heartbeat(
     () => brain.applyCancels(),
-    () => {
-      lost = true;
-      report("The conversation's lease passed to another holder; this brain stands down.");
-      void brain.stop();
-    },
+    () => standDown("The conversation's lease passed to another holder; this brain stands down."),
   );
   const sleep = sleeper(route);
   const drainMs = route.drainMs ?? BRAIN_HOST.RUN_DEADLINE_MS + 20_000;
@@ -336,8 +337,11 @@ export async function openBrainSession(
         ]);
         if (lost) return;
         if (!idle) {
-          report("A brain run outlasted its function's drain and is left for the next holder.");
+          // The run is the next holder's from here: this one stops writing
+          // now, so the lease can expire under a run nobody else is touching,
+          // and the successor resumes it from the last checkpoint that landed.
           stopHeartbeat();
+          standDown("A brain run outlasted its function's drain and is left for the next holder.");
           return;
         }
         await brain.publish();
@@ -346,10 +350,38 @@ export async function openBrainSession(
         await lease.release();
       } catch (error) {
         stopHeartbeat();
-        report(
+        standDown(
           `The brain session did not finish cleanly: ${error instanceof Error ? error.name : "unknown error"}`,
         );
       }
     },
   };
+}
+
+/**
+ * Runs a route's work over a session opened under a lease already taken, and
+ * makes sure the lease is let go however the work ends: a session that opened
+ * finishes after the answer, and a lease whose session never opened is
+ * released at once, so a throw cannot leave the conversation busy until the
+ * lease expires.
+ */
+export async function underLease(
+  route: BrainSessionSeams & Pick<HostedBrainRoute, "continueAfterResponse">,
+  admission: BrainRouteAdmission,
+  openAiKey: string,
+  lease: HeldLease,
+  work: (session: BrainSession) => Promise<Response>,
+): Promise<Response> {
+  let session: BrainSession | undefined;
+  try {
+    session = await openBrainSession(route, admission, openAiKey, lease);
+    return await work(session);
+  } catch (error) {
+    reporter(route)(
+      `A brain route failed: ${error instanceof Error ? error.message : "unknown error"}`,
+    );
+    if (session) route.continueAfterResponse(session.finish());
+    else await lease.release().catch(() => undefined);
+    return errorResponse(HOSTED_HTTP_STATUS.SERVICE_UNAVAILABLE, HOSTED_API_ERROR.UNAVAILABLE);
+  }
 }

--- a/apps/web/server/hosted/brain-host/route.ts
+++ b/apps/web/server/hosted/brain-host/route.ts
@@ -227,6 +227,13 @@ export function busyResponse(): Response {
 export interface BrainSession {
   readonly brain: HostedBrain;
   readonly lease: HeldLease;
+  /**
+   * The agent restored — a run the last holder left is resuming — with the
+   * cancels the developer noted meanwhile already applied, so a resumed run
+   * the developer cancelled is revoked before it acts rather than at the
+   * first heartbeat.
+   */
+  ready(): Promise<void>;
   finish(): Promise<void>;
 }
 
@@ -317,6 +324,10 @@ export async function openBrainSession(
   return {
     brain,
     lease,
+    ready: async () => {
+      await brain.agent.ready();
+      await brain.applyCancels();
+    },
     finish: async () => {
       try {
         const idle = await Promise.race([

--- a/apps/web/server/hosted/brain-host/route.ts
+++ b/apps/web/server/hosted/brain-host/route.ts
@@ -1,0 +1,344 @@
+import { randomUUID } from "node:crypto";
+import {
+  type BrainRequestRecord,
+  type CloudAgentProviderId,
+  type HostedBrainRun,
+  isCloudAgentProviderId,
+  MAIN_SESSION_KEY,
+  type ModelAdapter,
+  openAiModelAdapter,
+  type SessionKey,
+} from "../../core.js";
+import { executeSessionAction } from "../action-execute.js";
+import { decryptProviderKey } from "../encryption.js";
+import { errorResponse, HOSTED_API_ERROR, HOSTED_HTTP_STATUS } from "../http.js";
+import type { HostedSpend } from "../quota.js";
+import type { HostedStore } from "../store/index.js";
+import type { VaultKeyRow } from "../vault-route.js";
+import { BRAIN_HOST } from "./bounds.js";
+import type { HostedWorkspaceDefaults } from "./context.js";
+import { type HostedBrain, type HostedBrainSeams, openHostedBrain } from "./host.js";
+import {
+  acquireLeaseNow,
+  acquireLeaseWithin,
+  type HeldLease,
+  type LeaseSeams,
+} from "./lease-run.js";
+import { meteredModelAdapter } from "./metered-model.js";
+import type { CloudActionExecutor } from "./performer.js";
+
+/**
+ * The deployment's seams behind every brain-host route, handed to a handler
+ * once: the bearer's account, the vault's secret and the account's stored
+ * keys, the store under the payload key ring, Luke's own OpenAI key and
+ * model, the meter every inference spends, and the one thing a function on
+ * Vercel needs to finish a run after it has answered. A handler takes only
+ * what its route needs, and a test hands in a scripted model and a clock.
+ */
+export interface HostedBrainRoute {
+  request: Request;
+  resolveUserId: (request: Request) => Promise<string | undefined>;
+  /** The value of PROVIDER_KEY_ENCRYPTION_SECRET; undefined means the env var is absent. */
+  encryptionSecret: string | undefined;
+  /** Luke's own OpenAI key, from the deployment environment; absent means the brain is off. */
+  openAiKey: string | undefined;
+  /** A deployment-configured model override; the shared default otherwise. */
+  model: string | undefined;
+  readVaultKeys: (userId: string) => Promise<VaultKeyRow[]>;
+  store: (secret: string) => HostedStore;
+  spend: (userId: string) => Promise<HostedSpend>;
+  workspaceDefaults: (userId: string) => Promise<HostedWorkspaceDefaults>;
+  /**
+   * Keeps the function alive past its response until the work settles:
+   * Vercel's `waitUntil` in production. A test collects the work and awaits
+   * it itself.
+   */
+  continueAfterResponse: (work: Promise<void>) => void;
+  /** The cloud action execution the brain's session actions go out through. */
+  executeAction?: CloudActionExecutor;
+  /** The model the runtime reaches; production builds the OpenAI adapter on the key. */
+  modelAdapter?: (apiKey: string, model: string | undefined) => ModelAdapter;
+  cloudPlugin?: HostedBrainSeams["cloudPlugin"];
+  now?: () => number;
+  createId?: () => string;
+  report?: (message: string) => void;
+  sleep?: (ms: number) => Promise<void>;
+  leaseWaitMs?: number;
+  /** How long the drain after a response waits for the run before leaving it to the next holder. */
+  drainMs?: number;
+}
+
+/** The main conversation is the one every route reaches; private threads keep their code and no route. */
+export const HOSTED_CONVERSATION_KEY: SessionKey = MAIN_SESSION_KEY;
+
+export function reporter(route: Pick<HostedBrainRoute, "report">): (message: string) => void {
+  return route.report ?? ((message) => process.stderr.write(`${message}\n`));
+}
+
+export function clock(route: Pick<HostedBrainRoute, "now">): () => number {
+  return route.now ?? Date.now;
+}
+
+function sleeper(route: Pick<HostedBrainRoute, "sleep">): (ms: number) => Promise<void> {
+  return (
+    route.sleep ??
+    ((ms) =>
+      new Promise((resolve) => {
+        setTimeout(resolve, ms);
+      }))
+  );
+}
+
+/** What every brain-host route resolves before it looks at its own ask, or the answer the caller gets instead. */
+export interface BrainRouteAdmission {
+  userId: string;
+  secret: string;
+  store: HostedStore;
+}
+
+export async function admitBrainRoute(
+  route: Pick<HostedBrainRoute, "request" | "resolveUserId" | "encryptionSecret" | "store">,
+  method: string,
+): Promise<BrainRouteAdmission | Response> {
+  if (route.request.method !== method) {
+    return errorResponse(
+      HOSTED_HTTP_STATUS.METHOD_NOT_ALLOWED,
+      HOSTED_API_ERROR.METHOD_NOT_ALLOWED,
+    );
+  }
+  const secret = route.encryptionSecret?.trim();
+  if (!secret) {
+    return errorResponse(HOSTED_HTTP_STATUS.SERVICE_UNAVAILABLE, HOSTED_API_ERROR.UNAVAILABLE);
+  }
+  const userId = await route.resolveUserId(route.request);
+  if (!userId) {
+    return errorResponse(HOSTED_HTTP_STATUS.UNAUTHORIZED, HOSTED_API_ERROR.INVALID_TOKEN);
+  }
+  return { userId, secret, store: route.store(secret) };
+}
+
+/** The key the brain infers on, or the 503 the whole hosted tier answers without one. */
+export function openAiKeyOrUnavailable(
+  route: Pick<HostedBrainRoute, "openAiKey">,
+): string | Response {
+  const key = route.openAiKey?.trim();
+  return key
+    ? key
+    : errorResponse(HOSTED_HTTP_STATUS.SERVICE_UNAVAILABLE, HOSTED_API_ERROR.UNAVAILABLE);
+}
+
+/** A run as the wire carries it: the record's own fields and no other. */
+export function runToWire(record: BrainRequestRecord): HostedBrainRun {
+  return {
+    runId: record.runId,
+    submissionId: record.submissionId,
+    origin: record.origin,
+    question: record.question,
+    status: record.status,
+    revision: record.revision,
+    acceptedAt: record.acceptedAt,
+    ...(record.startedAt !== undefined ? { startedAt: record.startedAt } : undefined),
+    ...(record.settledAt !== undefined ? { settledAt: record.settledAt } : undefined),
+    ...(record.text !== undefined ? { text: record.text } : undefined),
+    ...(record.failure !== undefined ? { failure: record.failure } : undefined),
+    performedActions: record.performedActions,
+    unknownActions: record.unknownActions,
+    ...(record.askRecordedAt !== undefined ? { askRecordedAt: record.askRecordedAt } : undefined),
+    ...(record.conversationRecordedAt !== undefined
+      ? { conversationRecordedAt: record.conversationRecordedAt }
+      : undefined),
+  };
+}
+
+/** One run's record as the store holds it, read without opening a brain; nothing for a run the conversation does not hold. */
+export async function readRunRecord(
+  store: HostedStore,
+  userId: string,
+  runId: string,
+): Promise<BrainRequestRecord | undefined> {
+  const loaded = await store.brainStateRepository(userId, HOSTED_CONVERSATION_KEY).load();
+  return loaded.state?.requests.find((record) => record.runId === runId);
+}
+
+/** The path segment after a fixed prefix, decoded, or nothing for a path that is not one of the route's. */
+export function pathSegmentAfter(request: Request, prefix: string): string | undefined {
+  const { pathname } = new URL(request.url);
+  if (!pathname.startsWith(`${prefix}/`)) return undefined;
+  const rest = pathname.slice(prefix.length + 1);
+  const [segment] = rest.split("/");
+  if (!segment) return undefined;
+  try {
+    return decodeURIComponent(segment);
+  } catch {
+    return undefined;
+  }
+}
+
+/** The lease seams for one request over the account's conversation. */
+export function leaseSeamsFor(
+  route: Pick<HostedBrainRoute, "now" | "sleep">,
+  store: HostedStore,
+  userId: string,
+): LeaseSeams {
+  return {
+    store,
+    userId,
+    sessionKey: HOSTED_CONVERSATION_KEY,
+    ownerId: randomUUID(),
+    now: clock(route),
+    sleep: sleeper(route),
+  };
+}
+
+/** A lease taken now, or nothing while another holder's stands. */
+export function leaseNow(
+  route: Pick<HostedBrainRoute, "now" | "sleep">,
+  store: HostedStore,
+  userId: string,
+): Promise<HeldLease | undefined> {
+  return acquireLeaseNow(leaseSeamsFor(route, store, userId));
+}
+
+/** A lease taken within the route's wait, or nothing when the conversation stayed busy. */
+export function leaseWithin(
+  route: Pick<HostedBrainRoute, "now" | "sleep" | "leaseWaitMs">,
+  store: HostedStore,
+  userId: string,
+): Promise<HeldLease | undefined> {
+  return acquireLeaseWithin(
+    leaseSeamsFor(route, store, userId),
+    route.leaseWaitMs ?? BRAIN_HOST.LEASE_WAIT_MS,
+  );
+}
+
+export function busyResponse(): Response {
+  return errorResponse(HOSTED_HTTP_STATUS.CONFLICT, HOSTED_API_ERROR.CONVERSATION_BUSY);
+}
+
+/**
+ * One holder's use of the brain: opened under a lease already taken, its
+ * heartbeat running and the developer's cancels applied at every beat, and
+ * finished by draining the agent, publishing what its runs left for the
+ * Conversation, stopping it, and releasing the lease. A run the drain could
+ * not wait out is left running for the lease to expire under: the next
+ * request or wake resumes it from its journal, and stopping it here would
+ * write an interruption over a run this function only ran out of time for.
+ */
+export interface BrainSession {
+  readonly brain: HostedBrain;
+  readonly lease: HeldLease;
+  finish(): Promise<void>;
+}
+
+/** The seams a brain session needs of a route: everything but the request's own admission, so the wake can open one too. */
+export type BrainSessionSeams = Pick<
+  HostedBrainRoute,
+  | "model"
+  | "readVaultKeys"
+  | "spend"
+  | "workspaceDefaults"
+  | "executeAction"
+  | "modelAdapter"
+  | "cloudPlugin"
+  | "now"
+  | "createId"
+  | "report"
+  | "sleep"
+  | "drainMs"
+>;
+
+export async function openBrainSession(
+  route: BrainSessionSeams,
+  admission: BrainRouteAdmission,
+  openAiKey: string,
+  lease: HeldLease,
+): Promise<BrainSession> {
+  const { userId, secret, store } = admission;
+  const now = clock(route);
+  const report = reporter(route);
+  const buildModel =
+    route.modelAdapter ??
+    ((apiKey: string, model: string | undefined): ModelAdapter => {
+      const adapter = openAiModelAdapter(apiKey, { ...(model ? { model } : undefined), now });
+      if (!adapter) throw new Error("the OpenAI adapter needs a key");
+      return adapter;
+    });
+  const model = meteredModelAdapter(buildModel(openAiKey, route.model?.trim() || undefined), () =>
+    route.spend(userId),
+  );
+  const rows = await route.readVaultKeys(userId);
+  const apiKey = async (providerId: CloudAgentProviderId) => {
+    const row = rows.find((candidate) => candidate.providerId === providerId);
+    if (!row) return undefined;
+    try {
+      return decryptProviderKey(row.ciphertext, secret);
+    } catch {
+      return undefined;
+    }
+  };
+  const execute: CloudActionExecutor =
+    route.executeAction ??
+    ((input) =>
+      executeSessionAction({
+        kind: input.kind,
+        providerId: input.providerId,
+        fields: input.fields,
+        apiKey: input.apiKey,
+      }));
+  let lost = false;
+  const brain = await openHostedBrain({
+    store,
+    userId,
+    sessionKey: HOSTED_CONVERSATION_KEY,
+    model,
+    now,
+    createId: route.createId ?? randomUUID,
+    report,
+    apiKey: (providerId) =>
+      isCloudAgentProviderId(providerId) ? apiKey(providerId) : Promise.resolve(undefined),
+    executeAction: execute,
+    workspaceDefaults: () => route.workspaceDefaults(userId),
+    ...(route.cloudPlugin ? { cloudPlugin: route.cloudPlugin } : undefined),
+    writable: () => !lost,
+  });
+  // A lease that passed to another holder means that holder now runs the
+  // conversation: this brain writes nothing more and stands down, its runs
+  // ending in memory alone while the successor resumes them from the store.
+  const stopHeartbeat = lease.heartbeat(
+    () => brain.applyCancels(),
+    () => {
+      lost = true;
+      report("The conversation's lease passed to another holder; this brain stands down.");
+      void brain.stop();
+    },
+  );
+  const sleep = sleeper(route);
+  const drainMs = route.drainMs ?? BRAIN_HOST.RUN_DEADLINE_MS + 20_000;
+  return {
+    brain,
+    lease,
+    finish: async () => {
+      try {
+        const idle = await Promise.race([
+          brain.agent.idle().then(() => true),
+          sleep(drainMs).then(() => false),
+        ]);
+        if (lost) return;
+        if (!idle) {
+          report("A brain run outlasted its function's drain and is left for the next holder.");
+          stopHeartbeat();
+          return;
+        }
+        await brain.publish();
+        stopHeartbeat();
+        await brain.stop();
+        await lease.release();
+      } catch (error) {
+        stopHeartbeat();
+        report(
+          `The brain session did not finish cleanly: ${error instanceof Error ? error.name : "unknown error"}`,
+        );
+      }
+    },
+  };
+}

--- a/apps/web/server/hosted/brain-host/wake-events.ts
+++ b/apps/web/server/hosted/brain-host/wake-events.ts
@@ -1,0 +1,120 @@
+import {
+  BRAIN_WAKE_KIND,
+  type BrainWakeEvent,
+  type Session,
+  type SessionIdentity,
+  type WireRecord,
+} from "../../core.js";
+import type { RosterDiff, RosterDiffSession } from "../roster-diff.js";
+import type { HostedRoster } from "./roster.js";
+
+/**
+ * The wakes a stored roster diff becomes: one event per session the diff
+ * named, at the instant of the snapshot that showed the change, carrying the
+ * session as the snapshot now holds it and the changes the diff recorded in
+ * words the turn's opening renders as data. A session the snapshot no longer
+ * holds is named with what the diff last knew of it and nothing is read for
+ * it. The transcript each live session gained is read at capture, from its
+ * cursor, by the brain itself.
+ */
+
+const SESSION_CHANGE = {
+  APPEARED: "appeared",
+  VANISHED: "vanished",
+} as const;
+
+interface NamedChanges {
+  readonly identity: SessionIdentity;
+  readonly last: RosterDiffSession;
+  readonly changes: string[];
+}
+
+function identityKey(identity: SessionIdentity): string {
+  return JSON.stringify([identity.providerId, identity.providerSessionId]);
+}
+
+function sessionSummary(session: Session): WireRecord {
+  return {
+    provider_name: session.provider.displayName,
+    title: session.title,
+    status: session.status,
+    ...(session.holdingForDeveloper === true ? { holding_for_developer: true } : undefined),
+    ...(session.completionCause ? { completion_cause: session.completionCause } : undefined),
+    ...(session.workspace?.name ? { workspace: session.workspace.name } : undefined),
+    ...(session.detail.error ? { error: session.detail.error } : undefined),
+    ...(session.detail.activity ? { activity: session.detail.activity } : undefined),
+    ...(session.detail.branch ? { branch: session.detail.branch } : undefined),
+    updated_at: new Date(session.lastActivityAt).toISOString(),
+  };
+}
+
+function vanishedSummary(last: RosterDiffSession): WireRecord {
+  return {
+    title: last.title,
+    status: last.status,
+    ...(last.workspaceName ? { workspace: last.workspaceName } : undefined),
+  };
+}
+
+function lineChange(field: string, from: string | undefined, to: string | undefined): string {
+  return `${field}: ${from ?? "none"} → ${to ?? "none"}`;
+}
+
+/** One stored diff with the instant of the snapshot it led to, which is the instant its wakes carry. */
+export interface DatedRosterDiff {
+  readonly diff: RosterDiff;
+  readonly observedAt: number;
+}
+
+export function wakeEventsFromDiff(
+  { diff, observedAt }: DatedRosterDiff,
+  roster: HostedRoster,
+): BrainWakeEvent[] {
+  const named = new Map<string, NamedChanges>();
+  const note = (session: RosterDiffSession, change: string) => {
+    const identity: SessionIdentity = {
+      providerId: session.providerId,
+      providerSessionId: session.providerSessionId,
+    };
+    const key = identityKey(identity);
+    const held = named.get(key) ?? { identity, last: session, changes: [] };
+    held.changes.push(change);
+    named.set(key, held);
+  };
+  for (const session of diff.appeared) note(session, SESSION_CHANGE.APPEARED);
+  for (const transition of diff.statusChanged) {
+    note(transition.session, lineChange("status", transition.from, transition.to));
+  }
+  for (const change of diff.errorChanged) {
+    note(change.session, lineChange("error", change.from, change.to));
+  }
+  for (const change of diff.activityChanged) {
+    note(change.session, lineChange("activity", change.from, change.to));
+  }
+  for (const session of diff.vanished) note(session, SESSION_CHANGE.VANISHED);
+
+  return [...named.values()].map(({ identity, last, changes }) => {
+    const session = roster.sessions.find(
+      (candidate) =>
+        candidate.providerId === identity.providerId &&
+        candidate.providerSessionId === identity.providerSessionId,
+    );
+    return {
+      kind: BRAIN_WAKE_KIND.ROSTER,
+      identity,
+      atMs: observedAt,
+      sessionSummary: {
+        ...(session ? sessionSummary(session) : vanishedSummary(last)),
+        changes,
+      },
+    };
+  });
+}
+
+/** Every pending diff's wakes together, oldest diff first. */
+export function wakeEventsFromDiffs(
+  diffs: readonly DatedRosterDiff[],
+  roster: HostedRoster,
+): BrainWakeEvent[] {
+  return diffs.flatMap((dated) => wakeEventsFromDiff(dated, roster));
+}

--- a/apps/web/server/hosted/brain-host/wake.ts
+++ b/apps/web/server/hosted/brain-host/wake.ts
@@ -1,0 +1,161 @@
+import { timingSafeEqual } from "node:crypto";
+import { errorResponse, HOSTED_API_ERROR, HOSTED_HTTP_STATUS, jsonResponse } from "../http.js";
+import { decodeRosterDiff } from "../roster-diff.js";
+import type { HostedStore } from "../store/index.js";
+import { BRAIN_HOST } from "./bounds.js";
+import { acquireLeaseNow } from "./lease-run.js";
+import {
+  type BrainSessionSeams,
+  HOSTED_CONVERSATION_KEY,
+  leaseSeamsFor,
+  openBrainSession,
+  reporter,
+} from "./route.js";
+import { wakeEventsFromDiffs } from "./wake-events.js";
+
+/**
+ * The scheduled wake of the hosted brain: once a minute, for every account
+ * whose stored roster changed since the brain last looked, one observation
+ * turn over the pending diffs — the brain's own look at what changed, its
+ * `announce` the one thing that can leave a briefing — and for every
+ * conversation a function left a run unfinished in, its resumption. The
+ * observation tick stays what it is: it writes the roster down and decides
+ * nothing, and the brain runs here, in a function with the room a turn needs.
+ */
+
+export interface BrainWakeOptions extends BrainSessionSeams {
+  request: Request;
+  /** The value of CRON_SECRET; undefined means the env var is absent and the schedule is off. */
+  cronSecret: string | undefined;
+  encryptionSecret: string | undefined;
+  openAiKey: string | undefined;
+  store: (secret: string) => HostedStore;
+  budgetMs?: number;
+  concurrency?: number;
+}
+
+export interface BrainWakeAnswer {
+  /** Conversations the wake reached. */
+  users: number;
+  /** Conversations that opened an observation turn over pending diffs. */
+  woke: number;
+  /** Conversations opened only to resume what a function left unfinished. */
+  resumed: number;
+  /** Conversations another holder still ran, left for the next wake. */
+  busy: number;
+  failed: number;
+  /** Whether the wake stopped on its budget with conversations still listed. */
+  exhausted: boolean;
+}
+
+const WAKE_OUTCOME = {
+  WOKE: "woke",
+  RESUMED: "resumed",
+  BUSY: "busy",
+  FAILED: "failed",
+} as const;
+
+type WakeOutcome = (typeof WAKE_OUTCOME)[keyof typeof WAKE_OUTCOME];
+
+function bearerMatches(request: Request, secret: string): boolean {
+  const authorization = request.headers.get("authorization")?.trim() ?? "";
+  const offered = Buffer.from(authorization);
+  const wanted = Buffer.from(`Bearer ${secret}`);
+  return offered.length === wanted.length && timingSafeEqual(offered, wanted);
+}
+
+async function wakeConversation(
+  options: BrainWakeOptions,
+  store: HostedStore,
+  secret: string,
+  openAiKey: string,
+  userId: string,
+): Promise<WakeOutcome> {
+  const lease = await acquireLeaseNow(leaseSeamsFor(options, store, userId));
+  if (!lease) return WAKE_OUTCOME.BUSY;
+  const session = await openBrainSession(options, { userId, secret, store }, openAiKey, lease);
+  const now = options.now ?? Date.now;
+  try {
+    await session.brain.agent.ready();
+    const pending = await store.roster.pendingDiffs(userId);
+    const diffs = pending.flatMap((record) => {
+      const diff = decodeRosterDiff(record.payload);
+      return diff ? [{ diff, observedAt: record.observedAt }] : [];
+    });
+    const roster = await session.brain.refreshRoster();
+    // The events open one turn together; the inbox's earlier entries, if a
+    // turn left any standing, open with them. A diff this build cannot read
+    // is consumed with the rest: the snapshot it led to is the truth, and
+    // the next diff is taken against that.
+    await session.brain.agent.observe(wakeEventsFromDiffs(diffs, roster));
+    for (const record of pending) await store.roster.consumeDiff(userId, record.id, now());
+    return pending.length > 0 ? WAKE_OUTCOME.WOKE : WAKE_OUTCOME.RESUMED;
+  } catch (error) {
+    reporter(options)(
+      `The brain's wake for one account failed: ${error instanceof Error ? error.name : "unknown error"}`,
+    );
+    return WAKE_OUTCOME.FAILED;
+  } finally {
+    await session.finish();
+  }
+}
+
+export async function handleBrainWake(options: BrainWakeOptions): Promise<Response> {
+  const { request } = options;
+  if (request.method !== "GET") {
+    return errorResponse(
+      HOSTED_HTTP_STATUS.METHOD_NOT_ALLOWED,
+      HOSTED_API_ERROR.METHOD_NOT_ALLOWED,
+    );
+  }
+  const cronSecret = options.cronSecret?.trim();
+  const encryptionSecret = options.encryptionSecret?.trim();
+  const openAiKey = options.openAiKey?.trim();
+  if (!cronSecret || !encryptionSecret || !openAiKey) {
+    return errorResponse(HOSTED_HTTP_STATUS.SERVICE_UNAVAILABLE, HOSTED_API_ERROR.UNAVAILABLE);
+  }
+  if (!bearerMatches(request, cronSecret)) {
+    return errorResponse(HOSTED_HTTP_STATUS.UNAUTHORIZED, HOSTED_API_ERROR.INVALID_TOKEN);
+  }
+
+  const now = options.now ?? Date.now;
+  const startedAt = now();
+  const budgetMs = options.budgetMs ?? BRAIN_HOST.WAKE_BUDGET_MS;
+  const concurrency = options.concurrency ?? BRAIN_HOST.WAKE_CONCURRENCY;
+  const store = options.store(encryptionSecret);
+
+  // A user with a diff waiting and a user with a run left unfinished are one
+  // list: the same session runs both, resuming first, then observing.
+  const listed = new Set<string>();
+  for (const userId of await store.roster.usersWithPendingDiffs(BRAIN_HOST.WAKE_MAX_USERS)) {
+    listed.add(userId);
+  }
+  for (const unfinished of await store.runs.unfinished(BRAIN_HOST.WAKE_MAX_USERS)) {
+    if (unfinished.sessionKey === HOSTED_CONVERSATION_KEY) listed.add(unfinished.userId);
+  }
+  const users = [...listed];
+
+  const answer: BrainWakeAnswer = {
+    users: 0,
+    woke: 0,
+    resumed: 0,
+    busy: 0,
+    failed: 0,
+    exhausted: false,
+  };
+  for (let index = 0; index < users.length; index += concurrency) {
+    if (now() - startedAt > budgetMs) {
+      answer.exhausted = true;
+      break;
+    }
+    const batch = users.slice(index, index + concurrency);
+    const outcomes = await Promise.all(
+      batch.map((userId) => wakeConversation(options, store, encryptionSecret, openAiKey, userId)),
+    );
+    for (const outcome of outcomes) {
+      answer.users += 1;
+      answer[outcome] += 1;
+    }
+  }
+  return jsonResponse(HOSTED_HTTP_STATUS.OK, answer);
+}

--- a/apps/web/server/hosted/brain-host/wake.ts
+++ b/apps/web/server/hosted/brain-host/wake.ts
@@ -76,7 +76,7 @@ async function wakeConversation(
   const session = await openBrainSession(options, { userId, secret, store }, openAiKey, lease);
   const now = options.now ?? Date.now;
   try {
-    await session.brain.agent.ready();
+    await session.ready();
     const pending = await store.roster.pendingDiffs(userId);
     const diffs = pending.flatMap((record) => {
       const diff = decodeRosterDiff(record.payload);

--- a/apps/web/server/hosted/brain-host/wake.ts
+++ b/apps/web/server/hosted/brain-host/wake.ts
@@ -5,6 +5,7 @@ import type { HostedStore } from "../store/index.js";
 import { BRAIN_HOST } from "./bounds.js";
 import { acquireLeaseNow } from "./lease-run.js";
 import {
+  type BrainSession,
   type BrainSessionSeams,
   HOSTED_CONVERSATION_KEY,
   leaseSeamsFor,
@@ -73,8 +74,19 @@ async function wakeConversation(
 ): Promise<WakeOutcome> {
   const lease = await acquireLeaseNow(leaseSeamsFor(options, store, userId));
   if (!lease) return WAKE_OUTCOME.BUSY;
-  const session = await openBrainSession(options, { userId, secret, store }, openAiKey, lease);
   const now = options.now ?? Date.now;
+  let session: BrainSession;
+  try {
+    session = await openBrainSession(options, { userId, secret, store }, openAiKey, lease);
+  } catch (error) {
+    // A brain that could not open holds nothing: the lease goes back at
+    // once rather than standing until it expires.
+    await lease.release().catch(() => undefined);
+    reporter(options)(
+      `The brain could not be opened for one account: ${error instanceof Error ? error.name : "unknown error"}`,
+    );
+    return WAKE_OUTCOME.FAILED;
+  }
   try {
     await session.ready();
     const pending = await store.roster.pendingDiffs(userId);
@@ -98,6 +110,26 @@ async function wakeConversation(
   } finally {
     await session.finish();
   }
+}
+
+/**
+ * Whom one wake reaches, in order: the conversations a function left a run
+ * unfinished in come first, longest waiting first, because a developer is
+ * waiting on each of those and a wake that only ever starts one batch must
+ * not let pending diffs starve them; the accounts with a diff waiting follow.
+ * The same session runs both for an account on both lists, resuming first.
+ */
+export async function wakeCandidates(
+  store: Pick<HostedStore, "roster" | "runs">,
+): Promise<readonly string[]> {
+  const listed = new Set<string>();
+  for (const unfinished of await store.runs.unfinished(BRAIN_HOST.WAKE_MAX_USERS)) {
+    if (unfinished.sessionKey === HOSTED_CONVERSATION_KEY) listed.add(unfinished.userId);
+  }
+  for (const userId of await store.roster.usersWithPendingDiffs(BRAIN_HOST.WAKE_MAX_USERS)) {
+    listed.add(userId);
+  }
+  return [...listed];
 }
 
 export async function handleBrainWake(options: BrainWakeOptions): Promise<Response> {
@@ -124,16 +156,7 @@ export async function handleBrainWake(options: BrainWakeOptions): Promise<Respon
   const concurrency = options.concurrency ?? BRAIN_HOST.WAKE_CONCURRENCY;
   const store = options.store(encryptionSecret);
 
-  // A user with a diff waiting and a user with a run left unfinished are one
-  // list: the same session runs both, resuming first, then observing.
-  const listed = new Set<string>();
-  for (const userId of await store.roster.usersWithPendingDiffs(BRAIN_HOST.WAKE_MAX_USERS)) {
-    listed.add(userId);
-  }
-  for (const unfinished of await store.runs.unfinished(BRAIN_HOST.WAKE_MAX_USERS)) {
-    if (unfinished.sessionKey === HOSTED_CONVERSATION_KEY) listed.add(unfinished.userId);
-  }
-  const users = [...listed];
+  const users = await wakeCandidates(store);
 
   const answer: BrainWakeAnswer = {
     users: 0,

--- a/apps/web/server/hosted/brain-host/workspace.ts
+++ b/apps/web/server/hosted/brain-host/workspace.ts
@@ -1,0 +1,171 @@
+import {
+  BOOTSTRAP_BOUNDS,
+  BOOTSTRAP_FILE_ORDER,
+  BRAIN_IDENTITY_LINE,
+  BRAIN_INPUT_MARKER,
+  BRAIN_WORKSPACE_SEEDS,
+  type BrainWorkspaceAccess,
+  type BuiltPrompt,
+  boundBootstrapFiles,
+  brainToolNotes,
+  buildSystemPrompt,
+  DAILY_NOTES_DIRECTORY,
+  DEFAULT_AGENT_ID,
+  type EffectiveToolPolicy,
+  isWorkspaceFile,
+  PROMPT_PROFILE,
+  parseDailyNoteName,
+  TOOL_LOOP_RUNTIME,
+  WORKSPACE_FILE,
+  WORKSPACE_FILE_REFUSAL,
+  type WorkspaceFile,
+} from "../../core.js";
+import type { HostedStore } from "../store/index.js";
+import { BRAIN_HOST } from "./bounds.js";
+
+/**
+ * The hosted brain's identity workspace: the same files the desktop keeps
+ * under `agents/main/workspace`, one row per user per file, seeded once from
+ * the brain's own seeds and edited only by the brain's workspace tools. The
+ * prompt is composed from the rows exactly as the desktop composes it from
+ * the directory — the bootstrap order, the per-file and total bounds, the
+ * pure builder — and the tools can name nothing but the six bootstrap files
+ * and a dated note under `memory/`.
+ */
+
+/** The slice of the store the workspace reaches. */
+export type WorkspaceStore = Pick<HostedStore, "workspace">;
+
+const DAILY_NOTES_PREFIX = `${DAILY_NOTES_DIRECTORY}/`;
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/** A name the agent gave as a workspace row's path, or nothing for one outside the workspace. */
+export function hostedWorkspacePath(name: string): string | undefined {
+  if (isWorkspaceFile(name)) return name;
+  if (!name.startsWith(DAILY_NOTES_PREFIX)) return undefined;
+  return parseDailyNoteName(name.slice(DAILY_NOTES_PREFIX.length)) ? name : undefined;
+}
+
+/** Writes every missing bootstrap file for the user; an existing row, edited or not, is left as it is. */
+export async function seedHostedWorkspace(
+  store: WorkspaceStore,
+  userId: string,
+  now: number,
+): Promise<readonly WorkspaceFile[]> {
+  const seeded: WorkspaceFile[] = [];
+  for (const name of Object.values(WORKSPACE_FILE)) {
+    if (await store.workspace.seed(userId, name, BRAIN_WORKSPACE_SEEDS[name], now)) {
+      seeded.push(name);
+    }
+  }
+  return seeded;
+}
+
+/** The workspace tools' reach: the rows, bounded like the files, with no skills to load. */
+export function hostedWorkspaceAccess(
+  store: WorkspaceStore,
+  userId: string,
+  now: () => number,
+): BrainWorkspaceAccess {
+  return {
+    read: async (name) => {
+      const path = hostedWorkspacePath(name);
+      if (!path) return { ok: false, reason: WORKSPACE_FILE_REFUSAL.OUTSIDE_WORKSPACE };
+      const row = await store.workspace.read(userId, path);
+      if (!row) return { ok: false, reason: WORKSPACE_FILE_REFUSAL.NOT_FOUND };
+      return { ok: true, content: row.content.slice(0, BOOTSTRAP_BOUNDS.MAXIMUM_CHARS_PER_FILE) };
+    },
+    write: async (name, content) => {
+      const path = hostedWorkspacePath(name);
+      if (!path) return { ok: false, reason: WORKSPACE_FILE_REFUSAL.OUTSIDE_WORKSPACE };
+      if (content.length > BOOTSTRAP_BOUNDS.MAXIMUM_CHARS_PER_FILE) {
+        return { ok: false, reason: WORKSPACE_FILE_REFUSAL.TOO_LARGE };
+      }
+      await store.workspace.write(userId, path, content, now());
+      return { ok: true, chars: content.length };
+    },
+    loadSkill: async () => ({ ok: false, reason: "not loaded: this agent lists no skills" }),
+  };
+}
+
+/**
+ * Today's and yesterday's notes, for priming a conversation that just
+ * started fresh, read from the rows the way the desktop reads them from the
+ * directory: slugged variants included, oldest name first, bounded like the
+ * bootstrap files.
+ */
+export async function recentHostedDailyNotes(
+  store: WorkspaceStore,
+  userId: string,
+  now: number,
+): Promise<string | undefined> {
+  const days = new Set([dayStamp(now), dayStamp(now - DAY_MS)]);
+  const listed = await store.workspace.list(userId);
+  const names = listed
+    .map((file) => file.path)
+    .filter((path) => {
+      if (!path.startsWith(DAILY_NOTES_PREFIX)) return false;
+      const note = parseDailyNoteName(path.slice(DAILY_NOTES_PREFIX.length));
+      return note !== undefined && days.has(note.day);
+    })
+    .sort();
+  const notes: string[] = [];
+  let remaining = BOOTSTRAP_BOUNDS.MAXIMUM_TOTAL_CHARS;
+  for (const path of names) {
+    const row = await store.workspace.read(userId, path);
+    if (!row) continue;
+    const cut = row.content.slice(
+      0,
+      Math.min(BOOTSTRAP_BOUNDS.MAXIMUM_CHARS_PER_FILE, Math.max(0, remaining)),
+    );
+    remaining -= cut.length;
+    notes.push(`## ${path.slice(DAILY_NOTES_PREFIX.length)}\n\n${cut}`);
+  }
+  return notes.length > 0 ? notes.join("\n\n") : undefined;
+}
+
+function dayStamp(atMs: number): string {
+  return new Date(atMs).toISOString().slice(0, 10);
+}
+
+export interface HostedPromptInput {
+  readonly policy: EffectiveToolPolicy;
+  readonly model?: string;
+}
+
+/**
+ * The prompt one turn runs under, built by the same pure builder the desktop
+ * uses over the bootstrap files read from the rows: the identity line, the
+ * tools the effective policy offers, the brain's own tool notes, the marker
+ * the standing context arrives behind, and the workspace files in order and
+ * within their bounds. The service lists no skills and runs in no directory,
+ * so those sections are absent rather than invented.
+ */
+export async function hostedPrompt(
+  store: WorkspaceStore,
+  userId: string,
+  input: HostedPromptInput,
+): Promise<BuiltPrompt> {
+  const files = await Promise.all(
+    BOOTSTRAP_FILE_ORDER.map(async (name) => ({
+      name,
+      path: `${BRAIN_HOST.WORKSPACE_NAME}/${name}`,
+      content: (await store.workspace.read(userId, name))?.content,
+    })),
+  );
+  return buildSystemPrompt({
+    profile: PROMPT_PROFILE.FULL,
+    identity: BRAIN_IDENTITY_LINE,
+    tools: input.policy.allowed.map((tool) => ({ name: tool.schema.name, groups: tool.groups })),
+    toolNotes: brainToolNotes(),
+    runtimeContextMarker: BRAIN_INPUT_MARKER.STANDING_CONTEXT,
+    skills: [],
+    workspaceDirectory: BRAIN_HOST.WORKSPACE_NAME,
+    bootstrapFiles: boundBootstrapFiles(files),
+    runtime: {
+      agentId: DEFAULT_AGENT_ID,
+      runtimeId: TOOL_LOOP_RUNTIME.ID,
+      ...(input.model ? { model: input.model } : undefined),
+    },
+  });
+}

--- a/apps/web/server/hosted/brain-host/workspace.ts
+++ b/apps/web/server/hosted/brain-host/workspace.ts
@@ -61,11 +61,14 @@ export async function seedHostedWorkspace(
   return seeded;
 }
 
-/** The workspace tools' reach: the rows, bounded like the files, with no skills to load. */
+const WRITE_REFUSED = "not written: this conversation is now run by another request";
+
+/** The workspace tools' reach: the rows, bounded like the files, with no skills to load; a write needs the lease still held. */
 export function hostedWorkspaceAccess(
   store: WorkspaceStore,
   userId: string,
   now: () => number,
+  writable: () => boolean = () => true,
 ): BrainWorkspaceAccess {
   return {
     read: async (name) => {
@@ -81,6 +84,7 @@ export function hostedWorkspaceAccess(
       if (content.length > BOOTSTRAP_BOUNDS.MAXIMUM_CHARS_PER_FILE) {
         return { ok: false, reason: WORKSPACE_FILE_REFUSAL.TOO_LARGE };
       }
+      if (!writable()) return { ok: false, reason: WRITE_REFUSED };
       await store.workspace.write(userId, path, content, now());
       return { ok: true, chars: content.length };
     },

--- a/apps/web/server/hosted/cloud-adapters.ts
+++ b/apps/web/server/hosted/cloud-adapters.ts
@@ -1,6 +1,6 @@
 import { conductorPlugin } from "../../../../packages/providers/src/conductor/index.js";
 import type { CloudSessionPlugin } from "../../../../packages/providers/src/shared/cloud-pass.js";
-import type { CloudAgentProviderId, CloudFetch } from "../core.js";
+import type { CloudAgentProviderId, CloudFetch, ProviderSessionObservation } from "../core.js";
 import { CLOUD_AGENT_PROVIDER_ID } from "../core.js";
 
 /**
@@ -16,6 +16,8 @@ export interface CloudAdapterSeams {
   now?: () => number;
   /** How a 429's backoff wait is spent; injected in tests so a forced 429 costs no wall clock. */
   sleep?: (ms: number) => Promise<void>;
+  /** The roster the brain's transcript reads answer for, when the caller holds the stored snapshot rather than running a pass. */
+  reported?: () => readonly ProviderSessionObservation[];
 }
 
 type PluginBuilder = (seams: CloudAdapterSeams) => CloudSessionPlugin;
@@ -27,6 +29,7 @@ function baseOptions(seams: CloudAdapterSeams) {
     ...(seams.fetch ? { fetch: seams.fetch } : undefined),
     ...(seams.now ? { now: seams.now } : undefined),
     ...(seams.sleep ? { sleep: seams.sleep } : undefined),
+    ...(seams.reported ? { reported: seams.reported } : undefined),
   };
 }
 

--- a/apps/web/server/hosted/store/conversation-lines.ts
+++ b/apps/web/server/hosted/store/conversation-lines.ts
@@ -236,7 +236,7 @@ const VALUE_EVENT_KEY_PREFIX = "value:";
  * a value-keyed line's identity is its words and the key column is indexed
  * in the clear.
  */
-function conversationEventKey(entry: ConversationEntry): string {
+export function conversationEventKey(entry: ConversationEntry): string {
   const identity = conversationEntryIdentity(entry);
   const prefixed =
     entry.eventId !== undefined

--- a/apps/web/server/hosted/store/index.ts
+++ b/apps/web/server/hosted/store/index.ts
@@ -6,6 +6,7 @@ import {
   type ConversationEntry,
   type ConversationRecord,
   EnvelopeTracker,
+  type LineRating,
   type SessionKey,
   type StoredTranscriptEvent,
   type TranscriptEvent,
@@ -36,6 +37,18 @@ import {
 import { type HostedStoreContext, userSeal } from "./database.js";
 import { type FactWrite, listFacts, replaceFacts, type StoredFact } from "./facts.js";
 import {
+  acquireLease,
+  heartbeatLease,
+  type LeaseRecord,
+  readLease,
+  releaseLease,
+} from "./lease.js";
+import {
+  type LineRatingWrite,
+  listConversationLineRatings,
+  rateConversationLine,
+} from "./ratings.js";
+import {
   advanceRosterSnapshot,
   consumeRosterDiff,
   forgetObservationIneligible,
@@ -49,9 +62,18 @@ import {
   readRosterSnapshot,
   recordObservationPass,
   rosterSnapshotObservedAt,
+  usersWithPendingRosterDiffs,
   writeRosterSnapshot,
 } from "./roster-snapshot.js";
-import { type RunAboutFields, recordRunAbout, runAbout } from "./run-about.js";
+import {
+  cancelRequestedRuns,
+  type RunAboutFields,
+  recordRunAbout,
+  requestRunCancel,
+  runAbout,
+  type UnfinishedConversation,
+  unfinishedConversations,
+} from "./run-about.js";
 import {
   listCompactionBoundaries,
   listTranscript,
@@ -122,6 +144,36 @@ export interface HostedStore {
   runs: {
     recordAbout(userId: string, runId: string, about: RunAboutFields): Promise<boolean>;
     about(userId: string, runId: string): Promise<RunAboutFields | undefined>;
+    /** Notes the developer's cancel on an unfinished run for its holder to read; false once the run has ended. */
+    requestCancel(userId: string, runId: string, now: number): Promise<boolean>;
+    /** The unfinished runs of one conversation the developer asked to cancel. */
+    cancelRequested(userId: string, sessionKey: SessionKey): Promise<readonly string[]>;
+    /** The conversations holding a run a function left unfinished, longest waiting first. */
+    unfinished(limit: number): Promise<readonly UnfinishedConversation[]>;
+  };
+  leases: {
+    acquire(
+      userId: string,
+      sessionKey: SessionKey,
+      ownerId: string,
+      now: number,
+      ttlMs: number,
+    ): Promise<boolean>;
+    heartbeat(
+      userId: string,
+      sessionKey: SessionKey,
+      ownerId: string,
+      now: number,
+      ttlMs: number,
+    ): Promise<boolean>;
+    release(userId: string, sessionKey: SessionKey, ownerId: string): Promise<boolean>;
+    read(userId: string, sessionKey: SessionKey): Promise<LeaseRecord | undefined>;
+  };
+  ratings: {
+    /** Writes the developer's rating of one line Luke authored; false for any other line. */
+    rate(userId: string, sessionKey: SessionKey, write: LineRatingWrite): Promise<boolean>;
+    /** Every rating in the conversation, by the key each line is idempotent on. */
+    list(userId: string, sessionKey: SessionKey): Promise<ReadonlyMap<string, LineRating>>;
   };
   facts: {
     list(userId: string): Promise<readonly StoredFact[]>;
@@ -155,6 +207,8 @@ export interface HostedStore {
       previousObservedAt: number | undefined,
     ): Promise<boolean>;
     pendingDiffs(userId: string): Promise<readonly RosterDiffRecord[]>;
+    /** The users with a diff still waiting, longest waiting first, for the wake to open a turn for. */
+    usersWithPendingDiffs(limit: number): Promise<readonly string[]>;
     consumeDiff(userId: string, id: string, now: number): Promise<boolean>;
     pass(userId: string): Promise<ObservationPassRecord | undefined>;
     recordPass(userId: string, attempt: { attemptedAt: number; failure?: string }): Promise<void>;
@@ -216,6 +270,22 @@ export function hostedStore({ db, keys }: HostedStoreContext): HostedStore {
     runs: {
       recordAbout: (userId, runId, about) => recordRunAbout(db, userId, runId, about),
       about: (userId, runId) => runAbout(db, userId, runId),
+      requestCancel: (userId, runId, now) => requestRunCancel(db, userId, runId, now),
+      cancelRequested: (userId, sessionKey) => cancelRequestedRuns(db, userId, sessionKey),
+      unfinished: (limit) => unfinishedConversations(db, limit),
+    },
+    leases: {
+      acquire: (userId, sessionKey, ownerId, now, ttlMs) =>
+        acquireLease(db, userId, sessionKey, ownerId, now, ttlMs),
+      heartbeat: (userId, sessionKey, ownerId, now, ttlMs) =>
+        heartbeatLease(db, userId, sessionKey, ownerId, now, ttlMs),
+      release: (userId, sessionKey, ownerId) => releaseLease(db, userId, sessionKey, ownerId),
+      read: (userId, sessionKey) => readLease(db, userId, sessionKey),
+    },
+    ratings: {
+      rate: (userId, sessionKey, write) =>
+        rateConversationLine(db, sealFor(userId), userId, sessionKey, write),
+      list: (userId, sessionKey) => listConversationLineRatings(db, userId, sessionKey),
     },
     facts: {
       list: (userId) => listFacts(db, sealFor(userId), userId),
@@ -237,6 +307,7 @@ export function hostedStore({ db, keys }: HostedStoreContext): HostedStore {
       advance: (userId, snapshot, diff, previousObservedAt) =>
         advanceRosterSnapshot(db, sealFor(userId), userId, snapshot, diff, previousObservedAt),
       pendingDiffs: (userId) => listPendingRosterDiffs(db, sealFor(userId), userId),
+      usersWithPendingDiffs: (limit) => usersWithPendingRosterDiffs(db, limit),
       consumeDiff: (userId, id, now) => consumeRosterDiff(db, userId, id, now),
       pass: (userId) => readObservationPass(db, userId),
       recordPass: (userId, attempt) => recordObservationPass(db, userId, attempt),
@@ -262,6 +333,8 @@ export {
 export type { ConversationCreation } from "./conversations.js";
 export type { HostedStoreContext, HostedStoreDatabase } from "./database.js";
 export type { FactWrite, StoredFact } from "./facts.js";
+export type { LeaseRecord } from "./lease.js";
+export { type LineRatingWrite, ratingOf } from "./ratings.js";
 export {
   MAXIMUM_PENDING_ROSTER_DIFFS,
   type ObservationEligibility,
@@ -270,7 +343,7 @@ export {
   type RosterDiffRecord,
   type RosterSnapshotRecord,
 } from "./roster-snapshot.js";
-export type { RunAboutFields } from "./run-about.js";
+export type { RunAboutFields, UnfinishedConversation } from "./run-about.js";
 export type { StoredCompactionBoundary, TranscriptListOptions } from "./transcript.js";
 export {
   isWorkspacePath,

--- a/apps/web/server/hosted/store/lease.ts
+++ b/apps/web/server/hosted/store/lease.ts
@@ -1,0 +1,113 @@
+import { and, eq, lte, sql } from "drizzle-orm";
+import type { SessionKey } from "../../core.js";
+import { conversationLease } from "../../db/schema.js";
+import type { HostedStoreDatabase } from "./database.js";
+
+/**
+ * Who runs a conversation right now. A turn is run by whichever function
+ * holds the conversation's lease: acquired in one statement that either
+ * inserts the row or takes over one whose heartbeat stopped, moved along by
+ * the holder while it works, and released when it is done. A holder that
+ * dies leaves the row to expire, and the next request or tick that finds it
+ * expired with a run unfinished takes it over and resumes the run from its
+ * journal. Every transition names the owner, so a holder that lost the lease
+ * learns so at its next heartbeat and a late release cannot take a successor's.
+ */
+export interface LeaseRecord {
+  readonly ownerId: string;
+  readonly acquiredAt: number;
+  readonly heartbeatAt: number;
+  readonly expiresAt: number;
+}
+
+/** Takes the lease if none stands or the standing one has expired; answers whether this owner now holds it. */
+export async function acquireLease(
+  db: HostedStoreDatabase,
+  userId: string,
+  sessionKey: SessionKey,
+  ownerId: string,
+  now: number,
+  ttlMs: number,
+): Promise<boolean> {
+  const taken = await db
+    .insert(conversationLease)
+    .values({
+      userId,
+      sessionKey,
+      ownerId,
+      acquiredAt: now,
+      heartbeatAt: now,
+      expiresAt: now + ttlMs,
+    })
+    .onConflictDoUpdate({
+      target: [conversationLease.userId, conversationLease.sessionKey],
+      set: { ownerId, acquiredAt: now, heartbeatAt: now, expiresAt: now + ttlMs },
+      setWhere: lte(conversationLease.expiresAt, now),
+    })
+    .returning({ ownerId: conversationLease.ownerId });
+  return taken.some((row) => row.ownerId === ownerId);
+}
+
+/** Moves the holder's lease along; answers false for a holder that no longer holds it. */
+export async function heartbeatLease(
+  db: HostedStoreDatabase,
+  userId: string,
+  sessionKey: SessionKey,
+  ownerId: string,
+  now: number,
+  ttlMs: number,
+): Promise<boolean> {
+  const moved = await db
+    .update(conversationLease)
+    .set({
+      heartbeatAt: now,
+      expiresAt: sql`greatest(${conversationLease.expiresAt}, ${now + ttlMs})`,
+    })
+    .where(
+      and(
+        eq(conversationLease.userId, userId),
+        eq(conversationLease.sessionKey, sessionKey),
+        eq(conversationLease.ownerId, ownerId),
+      ),
+    )
+    .returning({ ownerId: conversationLease.ownerId });
+  return moved.length > 0;
+}
+
+/** Lets the lease go, only while this owner still holds it. */
+export async function releaseLease(
+  db: HostedStoreDatabase,
+  userId: string,
+  sessionKey: SessionKey,
+  ownerId: string,
+): Promise<boolean> {
+  const released = await db
+    .delete(conversationLease)
+    .where(
+      and(
+        eq(conversationLease.userId, userId),
+        eq(conversationLease.sessionKey, sessionKey),
+        eq(conversationLease.ownerId, ownerId),
+      ),
+    )
+    .returning({ ownerId: conversationLease.ownerId });
+  return released.length > 0;
+}
+
+export async function readLease(
+  db: HostedStoreDatabase,
+  userId: string,
+  sessionKey: SessionKey,
+): Promise<LeaseRecord | undefined> {
+  const [row] = await db
+    .select()
+    .from(conversationLease)
+    .where(and(eq(conversationLease.userId, userId), eq(conversationLease.sessionKey, sessionKey)));
+  if (!row) return undefined;
+  return {
+    ownerId: row.ownerId,
+    acquiredAt: row.acquiredAt,
+    heartbeatAt: row.heartbeatAt,
+    expiresAt: row.expiresAt,
+  };
+}

--- a/apps/web/server/hosted/store/ratings.ts
+++ b/apps/web/server/hosted/store/ratings.ts
@@ -1,0 +1,112 @@
+import { and, eq, inArray } from "drizzle-orm";
+import {
+  CONVERSATION_ENTRY_KIND,
+  type ConversationEntry,
+  LINE_RATING,
+  type LineRating,
+  type SessionKey,
+} from "../../core.js";
+import { conversationLine, conversationLineRating } from "../../db/schema.js";
+import { conversationEventKey } from "./conversation-lines.js";
+import type { HostedStoreDatabase, UserSeal } from "./database.js";
+
+/**
+ * The developer's ratings of Luke's lines. A rating attaches to a line the
+ * caller's own conversation holds and Luke authored — a reply or an
+ * announcement — by the id its writer minted; a line of any other kind, or
+ * one the conversation does not hold, takes none. One rating stands per
+ * line, the latest press replacing the one before, with the words the
+ * developer added sealed beside it.
+ */
+
+/** The kinds a rating may attach to: the lines Luke himself wrote. */
+const RATEABLE_KINDS: readonly string[] = [
+  CONVERSATION_ENTRY_KIND.REPLY,
+  CONVERSATION_ENTRY_KIND.ANNOUNCEMENT,
+];
+
+const LINE_RATING_LIST: readonly LineRating[] = Object.values(LINE_RATING);
+
+export interface LineRatingWrite {
+  readonly eventId: string;
+  readonly rating: LineRating;
+  readonly note?: string;
+  readonly deviceId: string;
+  readonly ratedAt: number;
+}
+
+/** Writes the rating, answering false for a line the conversation does not hold or Luke did not author. */
+export async function rateConversationLine(
+  db: HostedStoreDatabase,
+  seal: UserSeal,
+  userId: string,
+  sessionKey: SessionKey,
+  write: LineRatingWrite,
+): Promise<boolean> {
+  const eventKey = conversationEventKey({
+    kind: CONVERSATION_ENTRY_KIND.REPLY,
+    words: "",
+    eventId: write.eventId,
+  });
+  const [line] = await db
+    .select({ kind: conversationLine.kind })
+    .from(conversationLine)
+    .where(
+      and(
+        eq(conversationLine.userId, userId),
+        eq(conversationLine.sessionKey, sessionKey),
+        eq(conversationLine.eventKey, eventKey),
+        inArray(conversationLine.kind, [...RATEABLE_KINDS]),
+      ),
+    );
+  if (!line) return false;
+  const columns = {
+    rating: write.rating,
+    sealedNote: write.note === undefined ? null : seal.seal(write.note),
+    deviceId: write.deviceId,
+    ratedAt: write.ratedAt,
+  };
+  await db
+    .insert(conversationLineRating)
+    .values({ userId, sessionKey, eventKey, ...columns })
+    .onConflictDoUpdate({
+      target: [
+        conversationLineRating.userId,
+        conversationLineRating.sessionKey,
+        conversationLineRating.eventKey,
+      ],
+      set: columns,
+    });
+  return true;
+}
+
+/** The rating each rated line carries, by the key the line is idempotent on; a row naming a rating this build does not know is left out. */
+export async function listConversationLineRatings(
+  db: HostedStoreDatabase,
+  userId: string,
+  sessionKey: SessionKey,
+): Promise<ReadonlyMap<string, LineRating>> {
+  const rows = await db
+    .select({ eventKey: conversationLineRating.eventKey, rating: conversationLineRating.rating })
+    .from(conversationLineRating)
+    .where(
+      and(
+        eq(conversationLineRating.userId, userId),
+        eq(conversationLineRating.sessionKey, sessionKey),
+      ),
+    );
+  const ratings = new Map<string, LineRating>();
+  for (const row of rows) {
+    const rating = LINE_RATING_LIST.find((candidate) => candidate === row.rating);
+    if (rating !== undefined) ratings.set(row.eventKey, rating);
+  }
+  return ratings;
+}
+
+/** The rating a line carries, looked up by the line itself. */
+export function ratingOf(
+  ratings: ReadonlyMap<string, LineRating>,
+  entry: ConversationEntry,
+): LineRating | undefined {
+  return ratings.get(conversationEventKey(entry));
+}

--- a/apps/web/server/hosted/store/roster-snapshot.ts
+++ b/apps/web/server/hosted/store/roster-snapshot.ts
@@ -8,6 +8,7 @@ import {
   isNotNull,
   isNull,
   lte,
+  min,
   notInArray,
   or,
 } from "drizzle-orm";
@@ -214,6 +215,21 @@ export async function listPendingRosterDiffs(
       },
     ];
   });
+}
+
+/** The users with a diff still waiting, the one waiting longest first, for the wake to open a turn for. */
+export async function usersWithPendingRosterDiffs(
+  db: HostedStoreDatabase,
+  limit: number,
+): Promise<readonly string[]> {
+  const rows = await db
+    .select({ userId: rosterDiff.userId, waitingSince: min(rosterDiff.observedAt) })
+    .from(rosterDiff)
+    .where(isNull(rosterDiff.consumedAt))
+    .groupBy(rosterDiff.userId)
+    .orderBy(asc(min(rosterDiff.observedAt)))
+    .limit(limit);
+  return rows.map((row) => row.userId);
 }
 
 /** Marks one diff read; only a diff still pending can be, and only once. */

--- a/apps/web/server/hosted/store/run-about.ts
+++ b/apps/web/server/hosted/store/run-about.ts
@@ -1,5 +1,6 @@
-import { and, eq } from "drizzle-orm";
+import { and, asc, eq, inArray, isNotNull, min } from "drizzle-orm";
 import {
+  BRAIN_REQUEST_STATUS,
   BRAIN_TURN_TRIGGER,
   type BrainTurnTrigger,
   isRunOrigin,
@@ -7,9 +8,10 @@ import {
   RUN_END_REASON,
   type RunEndReason,
   type RunOrigin,
+  type SessionKey,
   type UnparsedWireValue,
 } from "../../core.js";
-import { conversationRun } from "../../db/schema.js";
+import { conversationRun, conversationSession } from "../../db/schema.js";
 import type { HostedStoreDatabase } from "./database.js";
 
 /**
@@ -112,4 +114,96 @@ export async function runAbout(
     ...(row.toolNames !== null ? { toolNames: row.toolNames } : undefined),
     ...(row.compacted !== null ? { compacted: row.compacted } : undefined),
   };
+}
+
+/** The statuses a run still has ahead of it, which a cancel may still reach and a resume still picks up. */
+const UNFINISHED_STATUSES = [BRAIN_REQUEST_STATUS.QUEUED, BRAIN_REQUEST_STATUS.RUNNING];
+
+/**
+ * Notes the developer's cancel on the run row, for whichever function holds
+ * the run to read at its next heartbeat; answers false for a run the tables
+ * do not hold or that has already ended, whose record the cancel cannot move.
+ */
+export async function requestRunCancel(
+  db: HostedStoreDatabase,
+  userId: string,
+  runId: string,
+  now: number,
+): Promise<boolean> {
+  const noted = await db
+    .update(conversationRun)
+    .set({ cancelRequestedAt: now })
+    .where(
+      and(
+        eq(conversationRun.userId, userId),
+        eq(conversationRun.runId, runId),
+        inArray(conversationRun.status, UNFINISHED_STATUSES),
+      ),
+    )
+    .returning({ runId: conversationRun.runId });
+  return noted.length > 0;
+}
+
+/** The unfinished runs of one conversation the developer asked to cancel, for the holder to act on. */
+export async function cancelRequestedRuns(
+  db: HostedStoreDatabase,
+  userId: string,
+  sessionKey: SessionKey,
+): Promise<readonly string[]> {
+  const rows = await db
+    .select({ runId: conversationRun.runId })
+    .from(conversationRun)
+    .innerJoin(
+      conversationSession,
+      and(
+        eq(conversationSession.userId, conversationRun.userId),
+        eq(conversationSession.sessionId, conversationRun.sessionId),
+      ),
+    )
+    .where(
+      and(
+        eq(conversationRun.userId, userId),
+        eq(conversationSession.sessionKey, sessionKey),
+        inArray(conversationRun.status, UNFINISHED_STATUSES),
+        isNotNull(conversationRun.cancelRequestedAt),
+      ),
+    )
+    .orderBy(asc(conversationRun.ordinal));
+  return rows.map((row) => row.runId);
+}
+
+export interface UnfinishedConversation {
+  readonly userId: string;
+  readonly sessionKey: SessionKey;
+}
+
+/**
+ * The conversations holding a run a function left unfinished, the one whose
+ * earliest run has waited longest first, for the wake to resume under the
+ * lease. Whether the holder is still alive is the lease's to say.
+ */
+export async function unfinishedConversations(
+  db: HostedStoreDatabase,
+  limit: number,
+): Promise<readonly UnfinishedConversation[]> {
+  const rows = await db
+    .select({
+      userId: conversationRun.userId,
+      sessionKey: conversationSession.sessionKey,
+      waitingSince: min(conversationRun.acceptedAt),
+    })
+    .from(conversationRun)
+    .innerJoin(
+      conversationSession,
+      and(
+        eq(conversationSession.userId, conversationRun.userId),
+        eq(conversationSession.sessionId, conversationRun.sessionId),
+      ),
+    )
+    .where(inArray(conversationRun.status, UNFINISHED_STATUSES))
+    .groupBy(conversationRun.userId, conversationSession.sessionKey)
+    .orderBy(asc(min(conversationRun.acceptedAt)))
+    .limit(limit);
+  // SAFETY: the column holds the key the constructor admitted when the row was written.
+  return rows.map((row) => ({ userId: row.userId, sessionKey: row.sessionKey as SessionKey }));
 }

--- a/apps/web/tests/hosted-brain-host.test.ts
+++ b/apps/web/tests/hosted-brain-host.test.ts
@@ -759,3 +759,53 @@ test("a holder whose lease passed to another writes nothing more: no fact, no fi
     .where(eq(conversationRun.userId, userId));
   assert.equal(row?.status, BRAIN_REQUEST_STATUS.RUNNING);
 });
+
+test("a route whose brain cannot open lets the lease go at once, and a holder whose drain ran out stops writing", async () => {
+  const { database, userId, harness } = await developer();
+
+  const broken = await handleBrainAsk(
+    harness.route(jsonRequest(ASK_URL, "POST", { question: "hello", origin: "typed" }), {
+      modelAdapter: () => {
+        throw new Error("no adapter today");
+      },
+    }),
+  );
+  assert.equal(broken.status, 503);
+  assert.equal(await database.store.leases.read(userId, MAIN_SESSION_KEY), undefined);
+
+  // A model that never answers: the drain runs out, the holder fences its
+  // writes and stands down, and the run stays running for the next holder.
+  const model = new ScriptedModel();
+  let release: (() => void) | undefined;
+  model.respond = () =>
+    new Promise((resolve) => {
+      release = () => resolve(answered([message("too late")]));
+    });
+  const slow = brainRouteHarness(database, userId, {
+    modelAdapter: () => bareModelAdapter(model),
+    drainMs: 50,
+  });
+  const accepted = await ask(slow, "take your time");
+  assert.equal(accepted.outcome, BRAIN_SUBMISSION_OUTCOME.ACCEPTED);
+  if (accepted.outcome !== BRAIN_SUBMISSION_OUTCOME.ACCEPTED) return;
+  await slow.drain();
+  const [row] = await database.db
+    .select({ status: conversationRun.status })
+    .from(conversationRun)
+    .where(and(eq(conversationRun.userId, userId), eq(conversationRun.runId, accepted.runId)));
+  assert.equal(row?.status, BRAIN_REQUEST_STATUS.RUNNING);
+  // The lease is left to expire rather than released under a run still going.
+  assert.notEqual(await database.store.leases.read(userId, MAIN_SESSION_KEY), undefined);
+  release?.();
+  await new Promise((resolve) => setTimeout(resolve, 50));
+  const [after] = await database.db
+    .select({ status: conversationRun.status })
+    .from(conversationRun)
+    .where(and(eq(conversationRun.userId, userId), eq(conversationRun.runId, accepted.runId)));
+  assert.equal(after?.status, BRAIN_REQUEST_STATUS.RUNNING);
+  const thread = await lines(harness);
+  assert.deepEqual(
+    thread.lines.map((line) => line.kind),
+    [CONVERSATION_ENTRY_KIND.TYPED_ASK],
+  );
+});

--- a/apps/web/tests/hosted-brain-host.test.ts
+++ b/apps/web/tests/hosted-brain-host.test.ts
@@ -1,0 +1,639 @@
+import assert from "node:assert/strict";
+import test, { after } from "node:test";
+import { BRAIN_REQUEST_STATUS, BRAIN_SUBMISSION_OUTCOME, freshBrainState } from "@sidecar/brain";
+import {
+  BRAIN_REQUEST_ORIGIN,
+  brainAskCancelPath,
+  brainAskRunPath,
+  conversationLineRatingPath,
+  HOSTED_SERVICE_PATH,
+  hostedBrainAskAnswerSchema,
+  hostedBrainRunAnswerSchema,
+  hostedConversationLinesAnswerSchema,
+  hostedFactsAnswerSchema,
+  LINE_RATING,
+  RESPONSES_INPUT_ITEM_TYPE,
+} from "@sidecar/hosted";
+import { CONVERSATION_ENTRY_KIND } from "@sidecar/session";
+import type { WireRecord } from "@sidecar/wire";
+import { and, eq } from "drizzle-orm";
+import {
+  BRAIN_TURN_TRIGGER,
+  checkpointFormatTag,
+  MAIN_SESSION_KEY,
+  REALTIME_TOOL,
+  RESPONSES_ITEM_FORMAT,
+  RUN_END_REASON,
+  RUN_ORIGIN,
+  TOOL_LOOP_RUNTIME,
+  UNKNOWN_ACTION_STATUS,
+} from "../server/core";
+import {
+  actionReceipt,
+  conversation,
+  conversationLease,
+  conversationLine,
+  conversationLineRating,
+  conversationRun,
+  personalFact,
+  runtimeCheckpoint,
+  user,
+} from "../server/db/schema";
+import {
+  handleBrainAsk,
+  handleBrainAskCancel,
+  handleBrainAskWait,
+} from "../server/hosted/brain-host/ask";
+import {
+  handleConversationClear,
+  handleConversationLines,
+  handleLineRating,
+} from "../server/hosted/brain-host/conversation";
+import { handleFacts } from "../server/hosted/brain-host/facts";
+import {
+  answered,
+  type BrainRouteHarness,
+  brainRouteHarness,
+  functionCall,
+  jsonRequest,
+  message,
+  REMEMBER_CALL,
+} from "./support/brain-route";
+import {
+  type HostedStoreTestDatabase,
+  openHostedStoreTestDatabase,
+} from "./support/hosted-store-database";
+
+/** Synthetic fixtures: no real title, branch, or transcript anywhere. */
+
+const ORIGIN = "https://luke.test";
+const ASK_URL = `${ORIGIN}${HOSTED_SERVICE_PATH.BRAIN_ASK}`;
+
+const opening = openHostedStoreTestDatabase();
+after(async () => {
+  await (await opening).close();
+});
+
+async function developer(): Promise<{
+  database: HostedStoreTestDatabase;
+  userId: string;
+  harness: BrainRouteHarness;
+}> {
+  const database = await opening;
+  const userId = await database.createUser();
+  return { database, userId, harness: brainRouteHarness(database, userId) };
+}
+
+async function ask(harness: BrainRouteHarness, question: string, submissionId?: string) {
+  const response = await handleBrainAsk(
+    harness.route(
+      jsonRequest(ASK_URL, "POST", {
+        question,
+        origin: BRAIN_REQUEST_ORIGIN.TYPED,
+        ...(submissionId ? { submissionId } : undefined),
+      }),
+    ),
+  );
+  assert.equal(response.status, 200);
+  const answer = hostedBrainAskAnswerSchema.parse(await response.json());
+  assert.ok(answer);
+  return answer;
+}
+
+async function waitFor(harness: BrainRouteHarness, runId: string, waitMs = 5_000) {
+  const response = await handleBrainAskWait(
+    harness.route(jsonRequest(`${ORIGIN}${brainAskRunPath(runId)}?wait=${waitMs}`, "GET")),
+  );
+  assert.equal(response.status, 200);
+  const answer = hostedBrainRunAnswerSchema.parse(await response.json());
+  assert.ok(answer);
+  return answer.run;
+}
+
+async function lines(harness: BrainRouteHarness, after?: number) {
+  const url = `${ORIGIN}${HOSTED_SERVICE_PATH.CONVERSATION}${after === undefined ? "" : `?after=${after}`}`;
+  const response = await handleConversationLines(harness.route(jsonRequest(url, "GET")));
+  assert.equal(response.status, 200);
+  const answer = hostedConversationLinesAnswerSchema.parse(await response.json());
+  assert.ok(answer);
+  return answer;
+}
+
+test("an ask runs a turn in the service: the fact is remembered, the receipt journaled, the about-fields written, and the lines stand", async () => {
+  const { database, userId, harness } = await developer();
+  harness.model.answers.push(
+    answered([REMEMBER_CALL("call-remember", "The developer prefers short replies")]),
+    answered([message("Noted: short replies from now on.")]),
+  );
+
+  const accepted = await ask(harness, "remember that I prefer short replies");
+  assert.equal(accepted.outcome, BRAIN_SUBMISSION_OUTCOME.ACCEPTED);
+  if (accepted.outcome !== BRAIN_SUBMISSION_OUTCOME.ACCEPTED) return;
+  await harness.drain();
+
+  const run = await waitFor(harness, accepted.runId);
+  assert.equal(run.status, BRAIN_REQUEST_STATUS.SUCCEEDED);
+  assert.equal(run.text, "Noted: short replies from now on.");
+  assert.equal(run.performedActions, 1);
+  // Every inference spent the one daily meter, and nothing else did.
+  assert.equal(harness.spends.length, 2);
+  // The action tool was offered; the tools the service cannot perform were not.
+  const offered = harness.model.toolsOffered[0] ?? [];
+  assert.ok(offered.includes(REALTIME_TOOL.REMEMBER_FACT));
+  assert.ok(offered.includes(REALTIME_TOOL.SEND_SESSION_MESSAGE));
+  assert.ok(!offered.includes(REALTIME_TOOL.OPEN_SESSION));
+  assert.ok(!offered.includes(REALTIME_TOOL.CHANGE_APP_SETTING));
+  assert.ok(!offered.includes("sessions_spawn"));
+  assert.ok(!offered.includes("memory_search"));
+  assert.ok(!offered.includes("announce"));
+
+  const facts = await database.db
+    .select()
+    .from(personalFact)
+    .where(eq(personalFact.userId, userId));
+  assert.equal(facts.length, 1);
+  const factsAnswer = hostedFactsAnswerSchema.parse(
+    await (
+      await handleFacts(harness.route(jsonRequest(`${ORIGIN}${HOSTED_SERVICE_PATH.FACTS}`, "GET")))
+    ).json(),
+  );
+  assert.deepEqual(
+    factsAnswer?.facts.map((fact) => fact.words),
+    ["The developer prefers short replies"],
+  );
+
+  const receipts = await database.db
+    .select()
+    .from(actionReceipt)
+    .where(and(eq(actionReceipt.userId, userId), eq(actionReceipt.runId, accepted.runId)));
+  assert.equal(receipts.length, 1);
+  assert.equal(receipts[0]?.name, REALTIME_TOOL.REMEMBER_FACT);
+  assert.notEqual(receipts[0]?.sealedOutput, null);
+
+  const about = await database.store.runs.about(userId, accepted.runId);
+  assert.equal(about?.trigger, BRAIN_TURN_TRIGGER.ASK);
+  assert.equal(about?.origin, RUN_ORIGIN.USER);
+  assert.equal(about?.ending, RUN_END_REASON.COMPLETED);
+  assert.equal(about?.inputTokens, 100);
+  assert.equal(about?.outputTokens, 40);
+  assert.ok(about?.toolNames?.includes(REALTIME_TOOL.REMEMBER_FACT));
+  assert.equal(about?.compacted, false);
+
+  const thread = await lines(harness);
+  assert.deepEqual(
+    thread.lines.map((line) => [line.kind, line.words]),
+    [
+      [CONVERSATION_ENTRY_KIND.TYPED_ASK, "remember that I prefer short replies"],
+      [CONVERSATION_ENTRY_KIND.REPLY, "Noted: short replies from now on."],
+    ],
+  );
+  assert.equal(thread.lines[1]?.requestId, accepted.runId);
+  assert.ok(thread.cursor !== undefined);
+  const newer = await lines(harness, thread.cursor);
+  assert.deepEqual(newer.lines, []);
+  // The lease was released with the run, and the run's cancel column is untouched.
+  const leases = await database.db
+    .select()
+    .from(conversationLease)
+    .where(eq(conversationLease.userId, userId));
+  assert.deepEqual(leases, []);
+  // A retried submission finds the same run rather than opening a second.
+  const again = await ask(harness, "remember that I prefer short replies", accepted.runId);
+  assert.equal(again.outcome, BRAIN_SUBMISSION_OUTCOME.ACCEPTED);
+  await harness.drain();
+});
+
+test("a refused meter ends the run the way the desktop's refusal does, and the reply says so", async () => {
+  const { harness } = await developer();
+  harness.refuse = true;
+  harness.model.answers.push(answered([message("never reached")]));
+
+  const accepted = await ask(harness, "what is going on?");
+  assert.equal(accepted.outcome, BRAIN_SUBMISSION_OUTCOME.ACCEPTED);
+  if (accepted.outcome !== BRAIN_SUBMISSION_OUTCOME.ACCEPTED) return;
+  await harness.drain();
+
+  const run = await waitFor(harness, accepted.runId);
+  assert.equal(run.status, BRAIN_REQUEST_STATUS.FAILED);
+  assert.equal(run.failure, "model");
+  assert.equal(harness.model.inputs.length, 0);
+  assert.equal(harness.spends.length, 1);
+  const thread = await lines(harness);
+  assert.equal(thread.lines.at(-1)?.kind, CONVERSATION_ENTRY_KIND.REPLY);
+  assert.match(thread.lines.at(-1)?.words ?? "", /Ask me again/u);
+});
+
+test("a run a function left mid-action is resumed by the next wait from its journal, and the journaled action is not performed again", async () => {
+  const { database, userId, harness } = await developer();
+  await database.store.conversations.create(userId, {
+    sessionKey: MAIN_SESSION_KEY,
+    name: "main",
+    now: Date.now(),
+  });
+  const runId = "run-orphaned";
+  const call = functionCall("call-orphaned", REALTIME_TOOL.REMEMBER_FACT, {
+    words: "The developer works from Lisbon",
+  });
+  const left = {
+    ...freshBrainState("gen-orphaned", Date.now() - 60_000),
+    checkpointFormat: checkpointFormatTag({
+      runtime: TOOL_LOOP_RUNTIME.ID,
+      runtimeVersion: TOOL_LOOP_RUNTIME.VERSION,
+      format: RESPONSES_ITEM_FORMAT.format,
+      formatVersion: RESPONSES_ITEM_FORMAT.version,
+    }),
+    items: [
+      {
+        type: RESPONSES_INPUT_ITEM_TYPE.MESSAGE,
+        role: "user",
+        content: [{ type: "input_text", text: "[developer ask] remember where I work" }],
+      },
+      call,
+    ],
+    requests: [
+      {
+        runId,
+        submissionId: "submission-orphaned",
+        origin: BRAIN_REQUEST_ORIGIN.TYPED,
+        question: "remember where I work",
+        status: BRAIN_REQUEST_STATUS.RUNNING,
+        revision: 1,
+        acceptedAt: Date.now() - 50_000,
+        startedAt: Date.now() - 49_000,
+        performedActions: 0,
+        unknownActions: 0,
+      },
+    ],
+    journal: [
+      {
+        runId,
+        callId: "call-orphaned",
+        name: REALTIME_TOOL.REMEMBER_FACT,
+        argumentsJson: String(call.arguments),
+        startedAt: Date.now() - 48_000,
+      },
+    ],
+  };
+  assert.ok(await database.store.brainStateRepository(userId, MAIN_SESSION_KEY).save(left));
+  // The holder that died left its lease behind, expired.
+  assert.ok(
+    await database.store.leases.acquire(
+      userId,
+      MAIN_SESSION_KEY,
+      "dead-function",
+      Date.now() - 120_000,
+      30_000,
+    ),
+  );
+  harness.model.answers.push(
+    answered([message("I have that noted, though the earlier save is unconfirmed.")]),
+  );
+
+  const run = await waitFor(harness, runId);
+  await harness.drain();
+
+  assert.equal(run.status, BRAIN_REQUEST_STATUS.SUCCEEDED);
+  assert.equal(run.unknownActions, 1);
+  assert.equal(run.performedActions, 0);
+  // The model read the journaled call paired with its lost result and was asked with no new words.
+  const input = harness.model.inputs[0] ?? [];
+  const output = input.find((item) => item.type === RESPONSES_INPUT_ITEM_TYPE.FUNCTION_CALL_OUTPUT);
+  assert.ok(output);
+  assert.ok(String(output.output).includes(UNKNOWN_ACTION_STATUS));
+  // Nothing was remembered twice: the facts table holds no row for the lost call.
+  const facts = await database.db
+    .select()
+    .from(personalFact)
+    .where(eq(personalFact.userId, userId));
+  assert.deepEqual(facts, []);
+  // The reply carries the run's honest account of the action nobody confirmed.
+  const thread = await lines(harness);
+  assert.equal(
+    thread.lines.at(-1)?.words,
+    "I have that noted, though the earlier save is unconfirmed. one action may have gone through without confirming, so I won't repeat it on my own.",
+  );
+});
+
+test("a cancel is performed by the request when no holder stands, and noted for the holder when one does", async () => {
+  const { database, userId, harness } = await developer();
+  await database.store.conversations.create(userId, {
+    sessionKey: MAIN_SESSION_KEY,
+    name: "main",
+    now: Date.now(),
+  });
+  const queued = {
+    ...freshBrainState("gen-queued", Date.now() - 60_000),
+    requests: [
+      {
+        runId: "run-queued",
+        submissionId: "submission-queued",
+        origin: BRAIN_REQUEST_ORIGIN.TYPED,
+        question: "a question nobody ran",
+        status: BRAIN_REQUEST_STATUS.QUEUED,
+        revision: 0,
+        acceptedAt: Date.now() - 50_000,
+        performedActions: 0,
+        unknownActions: 0,
+      },
+    ],
+  };
+  assert.ok(await database.store.brainStateRepository(userId, MAIN_SESSION_KEY).save(queued));
+
+  const cancelled = await handleBrainAskCancel(
+    harness.route(jsonRequest(`${ORIGIN}${brainAskCancelPath("run-queued")}`, "POST")),
+  );
+  assert.equal(cancelled.status, 200);
+  const answer = hostedBrainRunAnswerSchema.parse(await cancelled.json());
+  assert.equal(answer?.run.status, BRAIN_REQUEST_STATUS.CANCELLED);
+  await harness.drain();
+  assert.equal(harness.model.inputs.length, 0);
+
+  const unknown = await handleBrainAskCancel(
+    harness.route(jsonRequest(`${ORIGIN}${brainAskCancelPath("run-missing")}`, "POST")),
+  );
+  assert.equal(unknown.status, 404);
+
+  // A holder alive elsewhere: the cancel is noted on the row and answered as accepted.
+  const held = await database.createUser();
+  const heldHarness = brainRouteHarness(database, held);
+  await database.store.conversations.create(held, {
+    sessionKey: MAIN_SESSION_KEY,
+    name: "main",
+    now: Date.now(),
+  });
+  assert.ok(
+    await database.store
+      .brainStateRepository(held, MAIN_SESSION_KEY)
+      .save({ ...queued, generationId: "gen-held" }),
+  );
+  assert.ok(
+    await database.store.leases.acquire(
+      held,
+      MAIN_SESSION_KEY,
+      "live-function",
+      Date.now(),
+      30_000,
+    ),
+  );
+  const noted = await handleBrainAskCancel(
+    heldHarness.route(jsonRequest(`${ORIGIN}${brainAskCancelPath("run-queued")}`, "POST")),
+  );
+  assert.equal(noted.status, 202);
+  const [row] = await database.db
+    .select({ cancelRequestedAt: conversationRun.cancelRequestedAt })
+    .from(conversationRun)
+    .where(and(eq(conversationRun.userId, held), eq(conversationRun.runId, "run-queued")));
+  assert.notEqual(row?.cancelRequestedAt, null);
+  assert.deepEqual(await database.store.runs.cancelRequested(held, MAIN_SESSION_KEY), [
+    "run-queued",
+  ]);
+});
+
+test("a rating attaches only to a line Luke authored in the caller's own conversation, and travels back with the lines", async () => {
+  const { database, userId, harness } = await developer();
+  harness.model.answers.push(answered([message("Here is my reply.")]));
+  const accepted = await ask(harness, "say something");
+  assert.equal(accepted.outcome, BRAIN_SUBMISSION_OUTCOME.ACCEPTED);
+  await harness.drain();
+
+  const thread = await lines(harness);
+  const askLine = thread.lines.find((line) => line.kind === CONVERSATION_ENTRY_KIND.TYPED_ASK);
+  const replyLine = thread.lines.find((line) => line.kind === CONVERSATION_ENTRY_KIND.REPLY);
+  assert.ok(askLine?.eventId === undefined || askLine.eventId);
+  assert.ok(replyLine);
+  // A reply published by the brain carries no writer-minted id, so the store's
+  // key is its value; the rating names the line by the id the store hands
+  // back, which for such a line is absent, and the route names it by value.
+  const replyId = replyLine.eventId;
+  const rate = (lineId: string, body: WireRecord) =>
+    handleLineRating(
+      harness.route(jsonRequest(`${ORIGIN}${conversationLineRatingPath(lineId)}`, "PUT", body)),
+    );
+
+  const unknown = await rate("not-a-line", { rating: LINE_RATING.DOWN, deviceId: "device-1" });
+  assert.equal(unknown.status, 404);
+  const malformed = await rate("not-a-line", { rating: "sideways", deviceId: "device-1" });
+  assert.equal(malformed.status, 400);
+
+  // A line the brain announced carries its briefing's id and takes a rating.
+  const announcementId = "briefing-1";
+  await database.store.lines.append(
+    userId,
+    MAIN_SESSION_KEY,
+    [
+      {
+        kind: CONVERSATION_ENTRY_KIND.ANNOUNCEMENT,
+        words: "The checkout agent finished.",
+        eventId: announcementId,
+        recordedAt: Date.now(),
+      },
+    ],
+    Date.now(),
+  );
+  const rated = await rate(announcementId, {
+    rating: LINE_RATING.UP,
+    note: "exactly right",
+    deviceId: "device-1",
+  });
+  assert.equal(rated.status, 200);
+  const rows = await database.db
+    .select()
+    .from(conversationLineRating)
+    .where(eq(conversationLineRating.userId, userId));
+  assert.equal(rows.length, 1);
+  assert.equal(rows[0]?.rating, LINE_RATING.UP);
+  assert.equal(rows[0]?.deviceId, "device-1");
+  assert.notEqual(rows[0]?.sealedNote, null);
+  assert.ok(!String(rows[0]?.sealedNote).includes("exactly right"));
+
+  // The developer's own line, by id, is not Luke's to be rated.
+  await database.store.lines.append(
+    userId,
+    MAIN_SESSION_KEY,
+    [
+      {
+        kind: CONVERSATION_ENTRY_KIND.TYPED_ASK,
+        words: "my own words",
+        eventId: "ask-line-1",
+        recordedAt: Date.now(),
+      },
+    ],
+    Date.now(),
+  );
+  const own = await rate("ask-line-1", { rating: LINE_RATING.DOWN, deviceId: "device-1" });
+  assert.equal(own.status, 404);
+
+  // Another account's line is not this caller's, whatever its id.
+  const other = await database.createUser();
+  const otherHarness = brainRouteHarness(database, other);
+  const foreign = await handleLineRating(
+    otherHarness.route(
+      jsonRequest(`${ORIGIN}${conversationLineRatingPath(announcementId)}`, "PUT", {
+        rating: LINE_RATING.DOWN,
+        deviceId: "device-2",
+      }),
+    ),
+  );
+  assert.equal(foreign.status, 404);
+
+  const withRatings = await lines(harness);
+  const announced = withRatings.lines.find((line) => line.eventId === announcementId);
+  assert.equal(announced?.rating, LINE_RATING.UP);
+  assert.equal(replyId === undefined || replyId.length > 0, true);
+});
+
+test("Clear hard-deletes the conversation under its lease, and deleting the account cascades through every brain-host row", async () => {
+  const { database, userId, harness } = await developer();
+  harness.model.answers.push(answered([message("A reply to clear.")]));
+  const accepted = await ask(harness, "something to clear");
+  assert.equal(accepted.outcome, BRAIN_SUBMISSION_OUTCOME.ACCEPTED);
+  await harness.drain();
+  await database.store.lines.append(
+    userId,
+    MAIN_SESSION_KEY,
+    [
+      {
+        kind: CONVERSATION_ENTRY_KIND.ANNOUNCEMENT,
+        words: "An announcement to clear.",
+        eventId: "briefing-clear",
+        recordedAt: Date.now(),
+      },
+    ],
+    Date.now(),
+  );
+  await handleLineRating(
+    harness.route(
+      jsonRequest(`${ORIGIN}${conversationLineRatingPath("briefing-clear")}`, "PUT", {
+        rating: LINE_RATING.DOWN,
+        deviceId: "device-1",
+      }),
+    ),
+  );
+
+  // A conversation another function holds is not cleared under it.
+  assert.ok(
+    await database.store.leases.acquire(
+      userId,
+      MAIN_SESSION_KEY,
+      "live-function",
+      Date.now(),
+      30_000,
+    ),
+  );
+  const busy = await handleConversationClear(
+    harness.route(jsonRequest(`${ORIGIN}${HOSTED_SERVICE_PATH.CONVERSATION}`, "DELETE")),
+  );
+  assert.equal(busy.status, 409);
+  assert.ok(await database.store.leases.release(userId, MAIN_SESSION_KEY, "live-function"));
+
+  const cleared = await handleConversationClear(
+    harness.route(jsonRequest(`${ORIGIN}${HOSTED_SERVICE_PATH.CONVERSATION}`, "DELETE")),
+  );
+  assert.equal(cleared.status, 200);
+  assert.deepEqual(await cleared.json(), { cleared: true });
+  const rowsOf = async () => ({
+    conversations: (
+      await database.db.select().from(conversation).where(eq(conversation.userId, userId))
+    ).length,
+    lines: (
+      await database.db.select().from(conversationLine).where(eq(conversationLine.userId, userId))
+    ).length,
+    ratings: (
+      await database.db
+        .select()
+        .from(conversationLineRating)
+        .where(eq(conversationLineRating.userId, userId))
+    ).length,
+    runs: (
+      await database.db.select().from(conversationRun).where(eq(conversationRun.userId, userId))
+    ).length,
+    checkpoints: (
+      await database.db.select().from(runtimeCheckpoint).where(eq(runtimeCheckpoint.userId, userId))
+    ).length,
+    leases: (
+      await database.db.select().from(conversationLease).where(eq(conversationLease.userId, userId))
+    ).length,
+    facts: (await database.db.select().from(personalFact).where(eq(personalFact.userId, userId)))
+      .length,
+  });
+  assert.deepEqual(await rowsOf(), {
+    conversations: 0,
+    lines: 0,
+    ratings: 0,
+    runs: 0,
+    checkpoints: 0,
+    leases: 0,
+    facts: 0,
+  });
+  // The thread reads empty rather than failing, and the next ask makes a fresh conversation.
+  const empty = await lines(harness);
+  assert.deepEqual(empty.lines, []);
+  harness.model.answers.push(answered([message("Fresh start.")]));
+  const fresh = await ask(harness, "hello again");
+  assert.equal(fresh.outcome, BRAIN_SUBMISSION_OUTCOME.ACCEPTED);
+  await harness.drain();
+  await database.store.facts.replace(userId, [{ id: "fact-1", words: "A fact." }], Date.now());
+  assert.ok(
+    await database.store.leases.acquire(
+      userId,
+      MAIN_SESSION_KEY,
+      "another-function",
+      Date.now(),
+      30_000,
+    ),
+  );
+
+  await database.db.delete(user).where(eq(user.id, userId));
+  assert.deepEqual(await rowsOf(), {
+    conversations: 0,
+    lines: 0,
+    ratings: 0,
+    runs: 0,
+    checkpoints: 0,
+    leases: 0,
+    facts: 0,
+  });
+});
+
+test("the ask routes refuse a missing bearer, a missing key, a malformed ask, and a conversation another holder runs", async () => {
+  const { database, userId, harness } = await developer();
+  const unauthorized = await handleBrainAsk(
+    harness.route(
+      new Request(ASK_URL, {
+        method: "POST",
+        body: JSON.stringify({ question: "x", origin: "typed" }),
+      }),
+    ),
+  );
+  assert.equal(unauthorized.status, 401);
+  const noKey = await handleBrainAsk(
+    harness.route(jsonRequest(ASK_URL, "POST", { question: "x", origin: "typed" }), {
+      openAiKey: undefined,
+    }),
+  );
+  assert.equal(noKey.status, 503);
+  const malformed = await handleBrainAsk(
+    harness.route(jsonRequest(ASK_URL, "POST", { question: "x", origin: "child" })),
+  );
+  assert.equal(malformed.status, 400);
+  const method = await handleBrainAsk(harness.route(jsonRequest(ASK_URL, "GET")));
+  assert.equal(method.status, 405);
+  assert.ok(
+    await database.store.leases.acquire(
+      userId,
+      MAIN_SESSION_KEY,
+      "live-function",
+      Date.now(),
+      30_000,
+    ),
+  );
+  const busy = await handleBrainAsk(
+    harness.route(jsonRequest(ASK_URL, "POST", { question: "x", origin: "typed" })),
+  );
+  assert.equal(busy.status, 409);
+  assert.equal(harness.model.inputs.length, 0);
+  const missing = await handleBrainAskWait(
+    harness.route(jsonRequest(`${ORIGIN}${brainAskRunPath("nope")}`, "GET")),
+  );
+  assert.equal(missing.status, 404);
+});

--- a/apps/web/tests/hosted-brain-host.test.ts
+++ b/apps/web/tests/hosted-brain-host.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test, { after } from "node:test";
 import { BRAIN_REQUEST_STATUS, BRAIN_SUBMISSION_OUTCOME, freshBrainState } from "@sidecar/brain";
+import { bareModelAdapter } from "@sidecar/brain/testing";
 import {
   BRAIN_REQUEST_ORIGIN,
   brainAskCancelPath,
@@ -18,6 +19,8 @@ import { CONVERSATION_ENTRY_KIND } from "@sidecar/session";
 import type { WireRecord } from "@sidecar/wire";
 import { and, eq } from "drizzle-orm";
 import {
+  ACTION_RESULT_STATUS,
+  BRAIN_TOOL,
   BRAIN_TURN_TRIGGER,
   checkpointFormatTag,
   MAIN_SESSION_KEY,
@@ -50,6 +53,7 @@ import {
   handleLineRating,
 } from "../server/hosted/brain-host/conversation";
 import { handleFacts } from "../server/hosted/brain-host/facts";
+import { openHostedBrain } from "../server/hosted/brain-host/host";
 import {
   answered,
   type BrainRouteHarness,
@@ -58,6 +62,7 @@ import {
   jsonRequest,
   message,
   REMEMBER_CALL,
+  ScriptedModel,
 } from "./support/brain-route";
 import {
   type HostedStoreTestDatabase,
@@ -636,4 +641,121 @@ test("the ask routes refuse a missing bearer, a missing key, a malformed ask, an
     harness.route(jsonRequest(`${ORIGIN}${brainAskRunPath("nope")}`, "GET")),
   );
   assert.equal(missing.status, 404);
+});
+
+test("a cancel noted while a run was orphaned revokes the run the moment the next holder resumes it", async () => {
+  const { database, userId, harness } = await developer();
+  await database.store.conversations.create(userId, {
+    sessionKey: MAIN_SESSION_KEY,
+    name: "main",
+    now: Date.now(),
+  });
+  const running = {
+    ...freshBrainState("gen-cancel-orphan", Date.now() - 60_000),
+    requests: [
+      {
+        runId: "run-orphan-cancelled",
+        submissionId: "submission-orphan-cancelled",
+        origin: BRAIN_REQUEST_ORIGIN.TYPED,
+        question: "remember something I no longer want remembered",
+        status: BRAIN_REQUEST_STATUS.RUNNING,
+        revision: 1,
+        acceptedAt: Date.now() - 50_000,
+        startedAt: Date.now() - 49_000,
+        performedActions: 0,
+        unknownActions: 0,
+      },
+    ],
+  };
+  assert.ok(await database.store.brainStateRepository(userId, MAIN_SESSION_KEY).save(running));
+  assert.ok(await database.store.runs.requestCancel(userId, "run-orphan-cancelled", Date.now()));
+  harness.model.answers.push(
+    answered([REMEMBER_CALL("call-late", "A fact the developer cancelled")]),
+    answered([message("Remembered.")]),
+  );
+
+  const run = await waitFor(harness, "run-orphan-cancelled");
+  await harness.drain();
+
+  assert.equal(run.status, BRAIN_REQUEST_STATUS.CANCELLED);
+  assert.equal(run.performedActions, 0);
+  const facts = await database.db
+    .select()
+    .from(personalFact)
+    .where(eq(personalFact.userId, userId));
+  assert.deepEqual(facts, []);
+});
+
+test("a holder whose lease passed to another writes nothing more: no fact, no file, no line, no briefing, no action", async () => {
+  const { database, userId } = await developer();
+  const model = new ScriptedModel();
+  let writable = true;
+  const executed: string[] = [];
+  const brain = await openHostedBrain({
+    store: database.store,
+    userId,
+    sessionKey: MAIN_SESSION_KEY,
+    model: bareModelAdapter(model),
+    now: Date.now,
+    createId: () => `id-${executed.length}-${Math.random().toString(36).slice(2)}`,
+    report: () => {},
+    apiKey: async () => "conductor-key",
+    executeAction: async (input) => {
+      executed.push(input.kind);
+      return { result: ACTION_RESULT_STATUS.ACCEPTED };
+    },
+    workspaceDefaults: async () => ({}),
+    writable: () => writable,
+  });
+  const before = await database.store.workspace.read(userId, "MEMORY.md");
+  // The lease passes to another holder while the model is thinking: every
+  // call the answer then makes is refused, and the run's own end lands nowhere.
+  model.answers.push(
+    answered([
+      REMEMBER_CALL("call-fact", "A fact from a holder that lost its lease"),
+      functionCall("call-file", BRAIN_TOOL.WRITE_WORKSPACE_FILE, {
+        name: "MEMORY.md",
+        content: "# MEMORY.md\n\nwritten late",
+      }),
+    ]),
+    answered([message("Done, supposedly.")]),
+  );
+  const original = model.respond.bind(model);
+  model.respond = (items, options) => {
+    writable = false;
+    return original(items, options);
+  };
+  await brain.agent.ready();
+  const accepted = await brain.agent.submitAsk({
+    submissionId: "submission-late",
+    question: "remember this and write it down",
+    origin: BRAIN_REQUEST_ORIGIN.TYPED,
+  });
+  assert.equal(accepted.outcome, BRAIN_SUBMISSION_OUTCOME.ACCEPTED);
+  await brain.agent.idle();
+  await brain.publish();
+  await brain.stop();
+
+  const facts = await database.db
+    .select()
+    .from(personalFact)
+    .where(eq(personalFact.userId, userId));
+  assert.deepEqual(facts, []);
+  assert.equal(
+    (await database.store.workspace.read(userId, "MEMORY.md"))?.content,
+    before?.content,
+  );
+  const lines = await database.db
+    .select()
+    .from(conversationLine)
+    .where(eq(conversationLine.userId, userId));
+  // Not even the ask's own line: the route writes it while it holds the
+  // lease, and this holder's publication came after the lease had passed.
+  assert.deepEqual(lines, []);
+  assert.deepEqual(executed, []);
+  const [row] = await database.db
+    .select({ status: conversationRun.status })
+    .from(conversationRun)
+    .where(eq(conversationRun.userId, userId));
+  assert.equal(row?.status, BRAIN_REQUEST_STATUS.RUNNING);
 });

--- a/apps/web/tests/hosted-brain-lease.test.ts
+++ b/apps/web/tests/hosted-brain-lease.test.ts
@@ -1,0 +1,94 @@
+import assert from "node:assert/strict";
+import test, { after } from "node:test";
+import { MAIN_SESSION_KEY } from "../server/core";
+import { acquireLeaseWithin } from "../server/hosted/brain-host/lease-run";
+import { openHostedStoreTestDatabase } from "./support/hosted-store-database";
+
+/** Synthetic fixtures: owner ids and instants alone. */
+
+const NOW = 1_800_000_000_000;
+const TTL = 30_000;
+
+const opening = openHostedStoreTestDatabase();
+after(async () => {
+  await (await opening).close();
+});
+
+test("a lease is taken once, kept by its holder's heartbeat, refused to another while it stands, and taken over once it expires", async () => {
+  const database = await opening;
+  const userId = await database.createUser();
+  const { leases } = database.store;
+
+  assert.equal(await leases.acquire(userId, MAIN_SESSION_KEY, "first", NOW, TTL), true);
+  assert.equal(await leases.acquire(userId, MAIN_SESSION_KEY, "second", NOW + 1_000, TTL), false);
+  assert.deepEqual(await leases.read(userId, MAIN_SESSION_KEY), {
+    ownerId: "first",
+    acquiredAt: NOW,
+    heartbeatAt: NOW,
+    expiresAt: NOW + TTL,
+  });
+
+  // The heartbeat moves the expiry along, and only the holder's does.
+  assert.equal(await leases.heartbeat(userId, MAIN_SESSION_KEY, "first", NOW + 10_000, TTL), true);
+  assert.equal(
+    await leases.heartbeat(userId, MAIN_SESSION_KEY, "second", NOW + 10_000, TTL),
+    false,
+  );
+  assert.equal((await leases.read(userId, MAIN_SESSION_KEY))?.expiresAt, NOW + 10_000 + TTL);
+  assert.equal(await leases.acquire(userId, MAIN_SESSION_KEY, "second", NOW + 35_000, TTL), false);
+
+  // Past the last heartbeat's life the lease is another's to take, and the
+  // old holder's heartbeat and release then reach nothing.
+  assert.equal(await leases.acquire(userId, MAIN_SESSION_KEY, "second", NOW + 40_000, TTL), true);
+  assert.equal((await leases.read(userId, MAIN_SESSION_KEY))?.ownerId, "second");
+  assert.equal(await leases.heartbeat(userId, MAIN_SESSION_KEY, "first", NOW + 41_000, TTL), false);
+  assert.equal(await leases.release(userId, MAIN_SESSION_KEY, "first"), false);
+  assert.equal((await leases.read(userId, MAIN_SESSION_KEY))?.ownerId, "second");
+
+  assert.equal(await leases.release(userId, MAIN_SESSION_KEY, "second"), true);
+  assert.equal(await leases.read(userId, MAIN_SESSION_KEY), undefined);
+  // Two conversations of one account lease independently.
+  assert.equal(await leases.acquire(userId, MAIN_SESSION_KEY, "third", NOW + 50_000, TTL), true);
+});
+
+test("a bounded wait for the lease takes it when the holder lets go, and answers nothing when the holder keeps it", async () => {
+  const database = await opening;
+  const userId = await database.createUser();
+  const { leases } = database.store;
+  let now = NOW;
+  const seams = {
+    store: database.store,
+    userId,
+    sessionKey: MAIN_SESSION_KEY,
+    ownerId: "waiter",
+    now: () => now,
+    sleep: async (ms: number) => {
+      now += ms;
+    },
+  };
+
+  assert.equal(await leases.acquire(userId, MAIN_SESSION_KEY, "holder", NOW, TTL), true);
+  const refused = await acquireLeaseWithin(seams, 5_000, 1_000);
+  assert.equal(refused, undefined);
+  assert.equal((await leases.read(userId, MAIN_SESSION_KEY))?.ownerId, "holder");
+
+  // The holder releases two polls in: the waiter takes the lease then.
+  let polls = 0;
+  const taken = await acquireLeaseWithin(
+    {
+      ...seams,
+      sleep: async (ms) => {
+        now += ms;
+        polls += 1;
+        if (polls === 2) await leases.release(userId, MAIN_SESSION_KEY, "holder");
+      },
+    },
+    10_000,
+    1_000,
+  );
+  assert.ok(taken);
+  assert.equal(taken.ownerId, "waiter");
+  assert.equal((await leases.read(userId, MAIN_SESSION_KEY))?.ownerId, "waiter");
+  await taken.release();
+  assert.equal(await leases.read(userId, MAIN_SESSION_KEY), undefined);
+});

--- a/apps/web/tests/hosted-brain-wake.test.ts
+++ b/apps/web/tests/hosted-brain-wake.test.ts
@@ -1,0 +1,345 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test, { after } from "node:test";
+import { BRAIN_TOOL } from "@sidecar/brain";
+import { HOSTED_SERVICE_PATH } from "@sidecar/hosted";
+import { CONVERSATION_ENTRY_KIND, SESSION_STATUS } from "@sidecar/session";
+import { and, eq } from "drizzle-orm";
+import {
+  fakeConductorApi,
+  IDLE_SESSION_UUID,
+  isoTimestamp,
+  LUKE_PROJECT,
+  ownedWorkspace,
+  TEST_CONDUCTOR_STATUS,
+  TEST_SESSION_NAME,
+  TEST_TIME,
+  TEST_USER_ID,
+} from "../../../packages/providers/src/testing/conductor-api";
+import { CLOUD_AGENT_PROVIDER_ID, MAIN_SESSION_KEY } from "../server/core";
+import { briefing, observationCursor, rosterDiff } from "../server/db/schema";
+import { BRAIN_HOST } from "../server/hosted/brain-host/bounds";
+import { type BrainWakeOptions, handleBrainWake } from "../server/hosted/brain-host/wake";
+import { cloudSessionPluginFor } from "../server/hosted/cloud-adapters";
+import { encryptProviderKey } from "../server/hosted/encryption";
+import { encodeObservedRoster, type ObservedRoster } from "../server/hosted/observed-roster";
+import { encodeRosterDiff, type RosterDiff } from "../server/hosted/roster-diff";
+import { BRIEFING_STATE } from "../server/hosted/store";
+import { answered, brainRouteHarness, functionCall, message } from "./support/brain-route";
+import { openHostedStoreTestDatabase, TEST_PAYLOAD_SECRET } from "./support/hosted-store-database";
+
+/** Synthetic fixtures: no real title, branch, or transcript anywhere. */
+
+const CRON_SECRET = "cron-secret-1";
+const CONDUCTOR_KEY = "conductor-test-key";
+const WORKSPACE_ID = "workspace-wake";
+const MESSAGE_IDS = [
+  "bbbbbbbb-0000-4000-8000-000000000001",
+  "bbbbbbbb-0000-4000-8000-000000000002",
+  "bbbbbbbb-0000-4000-8000-000000000003",
+] as const;
+
+const opening = openHostedStoreTestDatabase();
+after(async () => {
+  await (await opening).close();
+});
+
+function storedUserMessage(id: string, text: string, at: number) {
+  return {
+    id,
+    sessionId: IDLE_SESSION_UUID,
+    sessionIndex: 1,
+    type: "userMessage",
+    content: { type: "userMessage", message: text },
+    receivedAt: isoTimestamp(at),
+  };
+}
+
+function storedAgentMessage(id: string, text: string, at: number) {
+  return {
+    id,
+    sessionId: IDLE_SESSION_UUID,
+    sessionIndex: 2,
+    type: "agent",
+    content: {
+      type: "agent",
+      rawPayload: { type: "assistant", message: { content: [{ type: "text", text }] } },
+    },
+    receivedAt: isoTimestamp(at),
+  };
+}
+
+/** The snapshot the tick left: one working chat, as the pass reports it. */
+function snapshot(status: (typeof SESSION_STATUS)[keyof typeof SESSION_STATUS]): ObservedRoster {
+  return {
+    version: 1,
+    providers: [
+      {
+        providerId: CLOUD_AGENT_PROVIDER_ID.CONDUCTOR,
+        observations: [
+          {
+            providerSessionId: IDLE_SESSION_UUID,
+            title: TEST_SESSION_NAME,
+            status,
+            lastActivityAt: TEST_TIME,
+            workspace: { providerWorkspaceId: WORKSPACE_ID, name: "wake-workspace" },
+            advertises: [{ kind: "message" }],
+          },
+        ],
+        projects: [],
+      },
+    ],
+  };
+}
+
+function statusDiff(): RosterDiff {
+  const session = {
+    providerId: CLOUD_AGENT_PROVIDER_ID.CONDUCTOR,
+    providerSessionId: IDLE_SESSION_UUID,
+    title: TEST_SESSION_NAME,
+    status: SESSION_STATUS.WORKING,
+    workspaceId: WORKSPACE_ID,
+    workspaceName: "wake-workspace",
+  };
+  return {
+    appeared: [],
+    vanished: [],
+    statusChanged: [{ session, from: SESSION_STATUS.WAITING, to: SESSION_STATUS.WORKING }],
+    errorChanged: [],
+    activityChanged: [],
+    workspacesAppeared: [],
+    workspacesVanished: [],
+  };
+}
+
+function wakeRequest(authorization: string | null = `Bearer ${CRON_SECRET}`): Request {
+  return new Request(`https://luke.test${HOSTED_SERVICE_PATH.BRAIN_WAKE}`, {
+    method: "GET",
+    ...(authorization ? { headers: { authorization } } : undefined),
+  });
+}
+
+test("a wake consumes the pending diff into one observation turn that reads the working chat's new words and announces", async () => {
+  const database = await opening;
+  const userId = await database.createUser();
+  const api = fakeConductorApi({
+    userId: TEST_USER_ID,
+    projects: [LUKE_PROJECT],
+    workspaces: [ownedWorkspace(WORKSPACE_ID, TEST_TIME - 30_000)],
+    sessions: [
+      {
+        id: IDLE_SESSION_UUID,
+        workspaceId: WORKSPACE_ID,
+        name: TEST_SESSION_NAME,
+        status: TEST_CONDUCTOR_STATUS.WORKING,
+        statusUpdatedAt: TEST_TIME - 5_000,
+        storedMessages: [
+          storedUserMessage(MESSAGE_IDS[0], "Fix the flaky roster test", TEST_TIME - 9_000),
+          storedAgentMessage(MESSAGE_IDS[1], "Looking at the test now.", TEST_TIME - 7_000),
+        ],
+      },
+    ],
+  });
+  const now = TEST_TIME + 60_000;
+  await database.store.roster.advance(
+    userId,
+    { body: encodeObservedRoster(snapshot(SESSION_STATUS.WORKING)), observedAt: now },
+    {
+      id: "diff-1",
+      observedAt: now,
+      previousObservedAt: now - 60_000,
+      payload: encodeRosterDiff(statusDiff()),
+    },
+    undefined,
+  );
+  const harness = brainRouteHarness(database, userId, {
+    readVaultKeys: async () => [
+      {
+        providerId: CLOUD_AGENT_PROVIDER_ID.CONDUCTOR,
+        ciphertext: encryptProviderKey(CONDUCTOR_KEY, TEST_PAYLOAD_SECRET),
+      },
+    ],
+    cloudPlugin: (providerId, seams) =>
+      cloudSessionPluginFor(providerId, { ...seams, fetch: api.fetch }),
+  });
+  harness.model.answers.push(
+    answered([
+      functionCall("announce-1", BRAIN_TOOL.ANNOUNCE, {
+        briefing: "The roster test agent has started working.",
+      }),
+    ]),
+    answered([message("")]),
+  );
+  const route = harness.route(wakeRequest());
+  const options: BrainWakeOptions = {
+    ...route,
+    cronSecret: CRON_SECRET,
+    store: () => database.store,
+  };
+
+  const response = await handleBrainWake(options);
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(await response.json(), {
+    users: 1,
+    woke: 1,
+    resumed: 0,
+    busy: 0,
+    failed: 0,
+    exhausted: false,
+  });
+  // The turn opened with the change and the chat's new words, read once through the documented endpoint.
+  assert.equal(harness.model.inputs.length, 2);
+  const opened = JSON.stringify(harness.model.inputs[0]);
+  assert.ok(opened.includes("[observed events]"));
+  assert.ok(opened.includes("status: waiting → working"));
+  assert.ok(opened.includes("Developer: Fix the flaky roster test"));
+  assert.ok(opened.includes("Conductor: Looking at the test now."));
+  assert.ok(harness.model.toolsOffered[0]?.includes(BRAIN_TOOL.ANNOUNCE));
+  const reads = api.requests.filter((request) => request.pathname.endsWith("/messages"));
+  assert.ok(reads.length >= 1);
+  assert.ok(reads.every((request) => request.method === "GET"));
+  // The cursor the read reached stands in the store, so the next wake reads only what is newer.
+  const cursors = await database.db
+    .select()
+    .from(observationCursor)
+    .where(eq(observationCursor.userId, userId));
+  assert.equal(cursors.length, 1);
+  assert.equal(cursors[0]?.providerSessionId, IDLE_SESSION_UUID);
+  assert.equal(cursors[0]?.cursor, MESSAGE_IDS[1]);
+  // The briefing is offered and the announcement stands as a line; nothing delivers it yet.
+  const briefings = await database.db.select().from(briefing).where(eq(briefing.userId, userId));
+  assert.equal(briefings.length, 1);
+  assert.equal(briefings[0]?.state, BRIEFING_STATE.OFFERED);
+  assert.equal(briefings[0]?.expiresAt, briefings[0]!.decidedAt + 5 * 60_000);
+  const lines = await database.store.lines.list(userId, MAIN_SESSION_KEY, Date.now());
+  assert.deepEqual(
+    lines.map((line) => [line.kind, line.words, line.eventId]),
+    [
+      [
+        CONVERSATION_ENTRY_KIND.ANNOUNCEMENT,
+        "The roster test agent has started working.",
+        briefings[0]?.id,
+      ],
+    ],
+  );
+  // The diff is consumed, and a second wake finds nothing to open.
+  const [consumed] = await database.db
+    .select({ consumedAt: rosterDiff.consumedAt })
+    .from(rosterDiff)
+    .where(and(eq(rosterDiff.userId, userId), eq(rosterDiff.id, "diff-1")));
+  assert.notEqual(consumed?.consumedAt, null);
+  const quiet = await handleBrainWake({ ...options, request: wakeRequest() });
+  assert.deepEqual(await quiet.json(), {
+    users: 0,
+    woke: 0,
+    resumed: 0,
+    busy: 0,
+    failed: 0,
+    exhausted: false,
+  });
+  assert.equal(harness.model.inputs.length, 2);
+
+  // A later wake over a newer diff reads only past the cursor.
+  api.requests.length = 0;
+  await database.store.roster.advance(
+    userId,
+    { body: encodeObservedRoster(snapshot(SESSION_STATUS.WORKING)), observedAt: now + 60_000 },
+    {
+      id: "diff-2",
+      observedAt: now + 60_000,
+      previousObservedAt: now,
+      payload: encodeRosterDiff(statusDiff()),
+    },
+    now,
+  );
+  harness.model.answers.push(answered([message("")]));
+  const second = await handleBrainWake({ ...options, request: wakeRequest() });
+  assert.equal((await second.json()).woke, 1);
+  const poll = api.requests.find((request) => request.pathname.endsWith("/messages"));
+  assert.equal(poll?.searchParams.get("after"), MESSAGE_IDS[1]);
+});
+
+test("the wake refuses without its secrets, refuses a wrong bearer, and leaves a conversation another holder runs", async () => {
+  const database = await opening;
+  const userId = await database.createUser();
+  const now = TEST_TIME + 60_000;
+  await database.store.roster.advance(
+    userId,
+    { body: encodeObservedRoster(snapshot(SESSION_STATUS.WORKING)), observedAt: now },
+    {
+      id: "diff-busy",
+      observedAt: now,
+      previousObservedAt: now - 60_000,
+      payload: encodeRosterDiff(statusDiff()),
+    },
+    undefined,
+  );
+  const harness = brainRouteHarness(database, userId);
+  const options: BrainWakeOptions = {
+    ...harness.route(wakeRequest()),
+    cronSecret: CRON_SECRET,
+    store: () => database.store,
+  };
+
+  assert.equal((await handleBrainWake({ ...options, cronSecret: undefined })).status, 503);
+  assert.equal((await handleBrainWake({ ...options, openAiKey: undefined })).status, 503);
+  assert.equal(
+    (await handleBrainWake({ ...options, request: wakeRequest("Bearer wrong") })).status,
+    401,
+  );
+  assert.equal((await handleBrainWake({ ...options, request: wakeRequest(null) })).status, 401);
+  assert.equal(
+    (
+      await handleBrainWake({
+        ...options,
+        request: new Request("https://luke.test/api/brain/wake", { method: "POST" }),
+      })
+    ).status,
+    405,
+  );
+
+  assert.ok(
+    await database.store.leases.acquire(
+      userId,
+      MAIN_SESSION_KEY,
+      "live-function",
+      Date.now(),
+      30_000,
+    ),
+  );
+  const busy = await handleBrainWake({ ...options, request: wakeRequest() });
+  assert.deepEqual(await busy.json(), {
+    users: 1,
+    woke: 0,
+    resumed: 0,
+    busy: 1,
+    failed: 0,
+    exhausted: false,
+  });
+  assert.equal(harness.model.inputs.length, 0);
+  assert.equal((await database.store.roster.pendingDiffs(userId)).length, 1);
+});
+
+test("the wake and the ask routes get the function duration the run deadline needs, and the cron names the wake", () => {
+  // SAFETY: the file is this repository's own vercel.json; the fields read are the ones asserted.
+  const vercel = JSON.parse(readFileSync(new URL("../vercel.json", import.meta.url), "utf8")) as {
+    functions: Record<string, { maxDuration: number }>;
+    crons: Array<{ path: string; schedule: string }>;
+  };
+  assert.deepEqual(
+    vercel.crons.filter((cron) => cron.path === HOSTED_SERVICE_PATH.BRAIN_WAKE),
+    [{ path: HOSTED_SERVICE_PATH.BRAIN_WAKE, schedule: "* * * * *" }],
+  );
+  for (const route of [
+    "api/brain/ask.ts",
+    "api/brain/ask/[runId].ts",
+    "api/brain/ask/[runId]/cancel.ts",
+    "api/brain/wake.ts",
+  ]) {
+    assert.equal(vercel.functions[route]?.maxDuration, BRAIN_HOST.MAX_DURATION_SECONDS);
+  }
+  assert.ok(
+    BRAIN_HOST.RUN_DEADLINE_MS + BRAIN_HOST.WAKE_BUDGET_MS < BRAIN_HOST.MAX_DURATION_SECONDS * 1000,
+  );
+});

--- a/apps/web/tests/hosted-brain-wake.test.ts
+++ b/apps/web/tests/hosted-brain-wake.test.ts
@@ -1,8 +1,8 @@
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import test, { after } from "node:test";
-import { BRAIN_TOOL } from "@sidecar/brain";
-import { HOSTED_SERVICE_PATH } from "@sidecar/hosted";
+import { BRAIN_TOOL, freshBrainState } from "@sidecar/brain";
+import { BRAIN_REQUEST_ORIGIN, BRAIN_REQUEST_STATUS, HOSTED_SERVICE_PATH } from "@sidecar/hosted";
 import { CONVERSATION_ENTRY_KIND, SESSION_STATUS } from "@sidecar/session";
 import { and, eq } from "drizzle-orm";
 import {
@@ -19,7 +19,11 @@ import {
 import { CLOUD_AGENT_PROVIDER_ID, MAIN_SESSION_KEY } from "../server/core";
 import { briefing, observationCursor, rosterDiff } from "../server/db/schema";
 import { BRAIN_HOST } from "../server/hosted/brain-host/bounds";
-import { type BrainWakeOptions, handleBrainWake } from "../server/hosted/brain-host/wake";
+import {
+  type BrainWakeOptions,
+  handleBrainWake,
+  wakeCandidates,
+} from "../server/hosted/brain-host/wake";
 import { cloudSessionPluginFor } from "../server/hosted/cloud-adapters";
 import { encryptProviderKey } from "../server/hosted/encryption";
 import { encodeObservedRoster, type ObservedRoster } from "../server/hosted/observed-roster";
@@ -342,4 +346,58 @@ test("the wake and the ask routes get the function duration the run deadline nee
   assert.ok(
     BRAIN_HOST.RUN_DEADLINE_MS + BRAIN_HOST.WAKE_BUDGET_MS < BRAIN_HOST.MAX_DURATION_SECONDS * 1000,
   );
+});
+
+test("a wake lists the conversations with unfinished runs before the accounts with pending diffs", async () => {
+  const database = await opening;
+  const now = TEST_TIME + 60_000;
+  const diffOnly = await database.createUser();
+  const runOnly = await database.createUser();
+  const both = await database.createUser();
+  const pendingDiff = async (userId: string, at: number) => {
+    await database.store.roster.advance(
+      userId,
+      { body: encodeObservedRoster(snapshot(SESSION_STATUS.WORKING)), observedAt: at },
+      {
+        id: `diff-${userId}`,
+        observedAt: at,
+        previousObservedAt: at - 60_000,
+        payload: encodeRosterDiff(statusDiff()),
+      },
+      undefined,
+    );
+  };
+  const unfinishedRun = async (userId: string, at: number) => {
+    await database.store.conversations.create(userId, {
+      sessionKey: MAIN_SESSION_KEY,
+      name: "main",
+      now: at,
+    });
+    await database.store.brainStateRepository(userId, MAIN_SESSION_KEY).save({
+      ...freshBrainState(`gen-${userId}`, at),
+      requests: [
+        {
+          runId: `run-${userId}`,
+          submissionId: `submission-${userId}`,
+          origin: BRAIN_REQUEST_ORIGIN.TYPED,
+          question: "left running",
+          status: BRAIN_REQUEST_STATUS.RUNNING,
+          revision: 1,
+          acceptedAt: at,
+          startedAt: at,
+          performedActions: 0,
+          unknownActions: 0,
+        },
+      ],
+    });
+  };
+  await pendingDiff(diffOnly, now - 5_000);
+  await pendingDiff(both, now - 4_000);
+  await unfinishedRun(both, now - 2_000);
+  await unfinishedRun(runOnly, now - 1_000);
+
+  const candidates = await wakeCandidates(database.store);
+
+  const ours = candidates.filter((userId) => [diffOnly, runOnly, both].includes(userId));
+  assert.deepEqual(ours, [both, runOnly, diffOnly]);
 });

--- a/apps/web/tests/hosted-observation-tick.test.ts
+++ b/apps/web/tests/hosted-observation-tick.test.ts
@@ -183,7 +183,10 @@ test("the budget leaves headroom under the function cap, and the cron entry name
     functions: Record<string, { maxDuration: number }>;
     crons: Array<{ path: string; schedule: string }>;
   };
-  assert.deepEqual(vercel.crons, [{ path: OBSERVATION_TICK_PATH, schedule: "* * * * *" }]);
+  assert.deepEqual(
+    vercel.crons.filter((cron) => cron.path === OBSERVATION_TICK_PATH),
+    [{ path: OBSERVATION_TICK_PATH, schedule: "* * * * *" }],
+  );
   assert.equal(
     vercel.functions[`${OBSERVATION_TICK_PATH.slice(1)}.ts`]?.maxDuration,
     OBSERVATION_TICK.MAX_DURATION_SECONDS,

--- a/apps/web/tests/support/brain-route.ts
+++ b/apps/web/tests/support/brain-route.ts
@@ -1,0 +1,143 @@
+import { randomUUID } from "node:crypto";
+import { type BrainTurnTraceRecord, responsesModelAnswer } from "@sidecar/brain";
+import { bareModelAdapter } from "@sidecar/brain/testing";
+import { RESPONSES_INPUT_ITEM_TYPE } from "@sidecar/hosted";
+import type { WireRecord } from "@sidecar/wire";
+import { type ModelRequestOptions, type ModelResponse, REALTIME_TOOL } from "../../server/core";
+import type { HostedBrainRoute } from "../../server/hosted/brain-host/route";
+import type { HostedSpend } from "../../server/hosted/quota";
+import type { HostedStoreTestDatabase } from "./hosted-store-database";
+import { TEST_PAYLOAD_SECRET } from "./hosted-store-database";
+
+/**
+ * The brain-host routes over a scripted model: the store is the PGlite one
+ * the store tests run on, the bearer resolves to the test's user, the meter
+ * counts and refuses when told, and the work a route continues after its
+ * answer is collected so a test awaits it rather than a function's lifetime.
+ */
+
+export const OPENAI_TEST_KEY = "sk-test-key";
+
+/** A model whose every answer is scripted, remembering what it was asked. */
+export class ScriptedModel {
+  readonly model = "scripted-model";
+  readonly inputs: WireRecord[][] = [];
+  readonly toolsOffered: string[][] = [];
+  readonly answers: ModelResponse[] = [];
+  fallback: ModelResponse = answered([message("")]);
+
+  respond(items: readonly WireRecord[], options: ModelRequestOptions): Promise<ModelResponse> {
+    this.inputs.push([...items]);
+    this.toolsOffered.push(options.tools.map((tool) => tool.name));
+    return Promise.resolve(this.answers.shift() ?? this.fallback);
+  }
+
+  quietUntil(): number | undefined {
+    return undefined;
+  }
+}
+
+export function answered(output: readonly WireRecord[], inputTokens = 100): ModelResponse {
+  const answer = responsesModelAnswer({
+    output,
+    usage: { input_tokens: inputTokens, output_tokens: 20 },
+  });
+  if (!answer) throw new Error("the scripted answer is not a Responses payload");
+  return answer;
+}
+
+export function message(text: string): WireRecord {
+  return {
+    type: RESPONSES_INPUT_ITEM_TYPE.MESSAGE,
+    role: "assistant",
+    content: [{ type: "output_text", text }],
+  };
+}
+
+export function functionCall(callId: string, name: string, args: WireRecord): WireRecord {
+  return {
+    type: RESPONSES_INPUT_ITEM_TYPE.FUNCTION_CALL,
+    call_id: callId,
+    name,
+    arguments: JSON.stringify(args),
+  };
+}
+
+export const REMEMBER_CALL = (callId: string, words: string) =>
+  functionCall(callId, REALTIME_TOOL.REMEMBER_FACT, { words });
+
+/** A request as a signed-in device sends it, its body the JSON record given. */
+export function jsonRequest(url: string, method: string, body?: WireRecord): Request {
+  return new Request(url, {
+    method,
+    headers: { authorization: "Bearer developer-token", "content-type": "application/json" },
+    ...(body !== undefined ? { body: JSON.stringify(body) } : undefined),
+  });
+}
+
+export interface BrainRouteHarness {
+  readonly model: ScriptedModel;
+  /** Every spend the meter took, in order. */
+  readonly spends: string[];
+  /** Whether the next spends are refused. */
+  refuse: boolean;
+  /** The work routes continued after answering; awaited by `drain`. */
+  readonly continued: Promise<void>[];
+  readonly traces: BrainTurnTraceRecord[];
+  route(request: Request, overrides?: Partial<HostedBrainRoute>): HostedBrainRoute;
+  drain(): Promise<void>;
+}
+
+export function brainRouteHarness(
+  database: HostedStoreTestDatabase,
+  userId: string,
+  overrides: Partial<HostedBrainRoute> = {},
+): BrainRouteHarness {
+  const model = new ScriptedModel();
+  const spends: string[] = [];
+  const continued: Promise<void>[] = [];
+  const traces: BrainTurnTraceRecord[] = [];
+  const harness: BrainRouteHarness = {
+    model,
+    spends,
+    refuse: false,
+    continued,
+    traces,
+    route: (request, requestOverrides = {}) => ({
+      request,
+      resolveUserId: async (incoming) =>
+        incoming.headers.get("authorization") === "Bearer developer-token" ? userId : undefined,
+      encryptionSecret: TEST_PAYLOAD_SECRET,
+      openAiKey: OPENAI_TEST_KEY,
+      model: undefined,
+      readVaultKeys: async () => [],
+      store: () => database.store,
+      spend: async (spentBy): Promise<HostedSpend> => {
+        spends.push(spentBy);
+        return {
+          allowed: !harness.refuse,
+          quota: { used: spends.length, limit: 5, resetsAt: Date.now() + 60_000 },
+        };
+      },
+      workspaceDefaults: async () => ({}),
+      continueAfterResponse: (work) => {
+        continued.push(work);
+      },
+      modelAdapter: () => bareModelAdapter(model),
+      createId: () => randomUUID(),
+      report: () => {},
+      sleep: (ms) =>
+        new Promise((resolve) => {
+          setTimeout(resolve, ms).unref();
+        }),
+      leaseWaitMs: 200,
+      drainMs: 10_000,
+      ...overrides,
+      ...requestOverrides,
+    }),
+    drain: async () => {
+      while (continued.length > 0) await continued.shift();
+    },
+  };
+  return harness;
+}

--- a/apps/web/tests/support/observation-store.ts
+++ b/apps/web/tests/support/observation-store.ts
@@ -55,6 +55,11 @@ export function memoryObservationStore(): MemoryObservationStore {
       },
       pendingDiffs: async (userId) =>
         (diffs.get(userId) ?? []).filter((one) => one.consumedAt === undefined),
+      usersWithPendingDiffs: async (limit) =>
+        [...diffs.entries()]
+          .filter(([, held]) => held.some((one) => one.consumedAt === undefined))
+          .map(([userId]) => userId)
+          .slice(0, limit),
       consumeDiff: async (userId, id, now) => {
         const held = diffs.get(userId) ?? [];
         const index = held.findIndex((one) => one.id === id && one.consumedAt === undefined);

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -2,18 +2,64 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "buildCommand": "pnpm db:migrate && pnpm auth:seed && pnpm build",
   "functions": {
-    "api/brain/v2/respond.ts": { "maxDuration": 120 },
-    "api/brain/v2/compact.ts": { "maxDuration": 120 },
-    "api/brain/v2/count-tokens.ts": { "maxDuration": 120 },
-    "api/brain/v2/embed.ts": { "maxDuration": 60 },
-    "api/observation/tick.ts": { "maxDuration": 60 }
+    "api/brain/v2/respond.ts": {
+      "maxDuration": 120
+    },
+    "api/brain/v2/compact.ts": {
+      "maxDuration": 120
+    },
+    "api/brain/v2/count-tokens.ts": {
+      "maxDuration": 120
+    },
+    "api/brain/v2/embed.ts": {
+      "maxDuration": 60
+    },
+    "api/observation/tick.ts": {
+      "maxDuration": 60
+    },
+    "api/brain/ask.ts": {
+      "maxDuration": 300
+    },
+    "api/brain/ask/[runId].ts": {
+      "maxDuration": 300
+    },
+    "api/brain/ask/[runId]/cancel.ts": {
+      "maxDuration": 300
+    },
+    "api/brain/wake.ts": {
+      "maxDuration": 300
+    }
   },
-  "crons": [{ "path": "/api/observation/tick", "schedule": "* * * * *" }],
+  "crons": [
+    {
+      "path": "/api/observation/tick",
+      "schedule": "* * * * *"
+    },
+    {
+      "path": "/api/brain/wake",
+      "schedule": "* * * * *"
+    }
+  ],
   "routes": [
-    { "src": "/api/auth/(.*)", "dest": "/api/auth/[...all].ts" },
-    { "src": "/about", "dest": "/about.html" },
-    { "src": "/privacy", "dest": "/privacy.html" },
-    { "src": "/changelog", "dest": "/changelog.html" },
-    { "src": "/admin", "dest": "/admin.html" }
+    {
+      "src": "/api/auth/(.*)",
+      "dest": "/api/auth/[...all].ts"
+    },
+    {
+      "src": "/about",
+      "dest": "/about.html"
+    },
+    {
+      "src": "/privacy",
+      "dest": "/privacy.html"
+    },
+    {
+      "src": "/changelog",
+      "dest": "/changelog.html"
+    },
+    {
+      "src": "/admin",
+      "dest": "/admin.html"
+    }
   ]
 }

--- a/packages/brain/src/agent.ts
+++ b/packages/brain/src/agent.ts
@@ -53,7 +53,7 @@ import {
   type BrainTurnTrigger,
   type RunControl,
 } from "./turn.js";
-import { type BrainOpeningNotes, TurnRunner } from "./turn-runner.js";
+import { type BrainOpeningNotes, newRunControl, TurnRunner } from "./turn-runner.js";
 import type { BrainDelivery, BrainTurnReport, BrainWakeEvent } from "./wake-events.js";
 import { LOOK_SUBJECT, type LookSubject, WakeCapture } from "./wakes.js";
 
@@ -64,6 +64,27 @@ export type { BrainFlushInput, BrainFlushMarkerStore } from "./maintenance.js";
 export type { BrainWorkspaceAccess } from "./tool-executor.js";
 export type { BrainOpeningNotes } from "./turn-runner.js";
 export { LOOK_SUBJECT, type LookSubject, type LookSubjectKind } from "./wakes.js";
+
+/**
+ * What a launch does with the runs the last one left unfinished. Interrupting
+ * is the desktop's: a process that died mid-action cannot know the action's
+ * effect, so every unfinished record ends as interrupted and nothing is run
+ * again. Resuming is a request-scoped host's, where a function cut off by its
+ * own duration is the ordinary end of a run and the next request picks it
+ * up: a queued ask opens as it would have, and a running one is asked again
+ * over the checkpoint it left — its opening words and every answered effect
+ * already on record, a call it started and never answered paired as unknown
+ * at load — so nothing journaled is performed twice.
+ */
+export const BRAIN_RECOVERY = {
+  INTERRUPT: "interrupt",
+  RESUME: "resume",
+} as const;
+
+export type BrainRecovery = (typeof BRAIN_RECOVERY)[keyof typeof BRAIN_RECOVERY];
+
+/** How long the idle wait sleeps between looks at the conversation's standing. */
+const IDLE_POLL_MS = 25;
 
 /** Runs a turn's work under the host's lane for its trigger, so conversations share the lanes' budgets and nothing wider. */
 export type BrainLane = <T>(trigger: BrainTurnTrigger, work: () => Promise<T>) => Promise<T>;
@@ -158,6 +179,8 @@ export interface BrainAgentOptions {
    */
   promptCacheKey?: string;
   executionDeadlineMs?: number;
+  /** What a load does with unfinished runs; interrupting them unless the host says to resume. */
+  recovery?: BrainRecovery;
 }
 
 /**
@@ -290,6 +313,7 @@ export class BrainAgent {
         ? { promptCacheKey: options.promptCacheKey }
         : undefined),
       executionDeadlineMs: options.executionDeadlineMs ?? BRAIN_DEFAULTS.EXECUTION_DEADLINE_MS,
+      checkpointOpening: options.recovery === BRAIN_RECOVERY.RESUME,
       compactIfNeeded: (turnContext, prompt, countedTokens) =>
         this.#maintenance.compactIfNeeded(turnContext, prompt, countedTokens),
       scheduleMaintenance: (turnContext, countedTokens) =>
@@ -304,6 +328,8 @@ export class BrainAgent {
       store: options.store,
       createRunId: options.createRunId,
       runAsk: (inputs) => this.#queueTurn(BRAIN_TURN_TRIGGER.ASK, () => this.#turns.runAsk(inputs)),
+      resumeAsk: (runs) =>
+        this.#queueTurn(BRAIN_TURN_TRIGGER.ASK, () => this.#turns.resumeAsk(runs)),
       active: () => this.#turns.active(),
       disarmWakes: () => this.#wakes.take(),
       cancelMaintenance: () => this.#maintenance.cancel(),
@@ -472,6 +498,46 @@ export class BrainAgent {
   }
 
   /**
+   * Captures wake events and opens their turn at once, settling when the
+   * turn has ended: for a host whose wakes arrive already batched, with no
+   * window in which to coalesce them. Entries a failed or throttled turn
+   * left standing open with them; nothing captured and nothing waiting opens
+   * no turn.
+   */
+  observe(events: readonly BrainWakeEvent[]): Promise<void> {
+    return this.#wakes.observe(events);
+  }
+
+  /**
+   * Settles once nothing is under way or owed a turn: no turn running or
+   * queued, no capture landing, no ask waiting, no wake armed. A host that
+   * runs one request's work over this agent awaits it before stopping the
+   * agent, so a run is never cut by the request that opened it. Entries
+   * standing in the inbox do not hold it: they wait for the next turn to open
+   * with them, whichever request opens it.
+   */
+  async idle(): Promise<void> {
+    for (;;) {
+      await this.#queue;
+      if (!this.#working()) return;
+      await new Promise<void>((resolve) => {
+        this.#schedule(resolve, IDLE_POLL_MS);
+      });
+    }
+  }
+
+  #working(): boolean {
+    return (
+      this.#turns.inFlight() ||
+      this.#turnsQueued > 0 ||
+      this.#wakes.capturesInFlight() > 0 ||
+      this.#turns.active() !== undefined ||
+      this.#asks.size() > 0 ||
+      this.#wakes.size() > 0
+    );
+  }
+
+  /**
    * Hands back briefings the host held while a meeting or a pause stood, for
    * one re-decision against the roster as it now stands. Pending wakes open
    * in the same turn, ahead of the held briefings, so the decision is made
@@ -632,11 +698,17 @@ export class BrainAgent {
     this.#generation = generation;
     const opened = await generation.opened;
     if (generation !== this.#generation) return;
-    this.#wakes.armInbox(generation);
+    const resume = this.#options.recovery === BRAIN_RECOVERY.RESUME;
+    // A resuming host opens the inbox's entries with the turn it came to run,
+    // ask or observation; arming the window here would only hold that
+    // request for a turn the same entries are about to open anyway.
+    if (!resume) this.#wakes.armInbox(generation);
     if (opened.kind === CONTEXT_OPENING.INCOMPATIBLE) {
       this.#reportIncompatible(generation, opened.reason);
     }
-    const interrupted = interruptedUnfinishedRequests(state.requests, this.#now());
+    const interrupted = resume
+      ? state.requests
+      : interruptedUnfinishedRequests(state.requests, this.#now());
     // An action found started with no result may have happened: the runtime's
     // context paired it as unknown at load, and the interrupted run says so
     // in its count; neither is ever a call to make again.
@@ -650,7 +722,6 @@ export class BrainAgent {
     if (orphaned.length > 0) {
       generation.journal.dropRuns(new Set(orphaned.map((entry) => entry.runId)));
     }
-    if (interrupted === state.requests && repaired === 0 && orphaned.length === 0) return;
     const unfinished = new Set(
       state.requests
         .filter((record) => !isTerminalBrainRequestStatus(record.status))
@@ -660,19 +731,51 @@ export class BrainAgent {
     // whose result was accepted went through, actions whose result says unknown
     // or never arrived may have. Counted from the journal alone, so a copy
     // taken mid-run and a copy taken after it both say the same.
-    generation.requests = new Map(
-      interrupted.map((record) => [
-        record.runId,
-        unfinished.has(record.runId)
-          ? { ...record, ...journalActionCounts(state.journal, record.runId) }
-          : record,
-      ]),
-    );
-    await this.#ledger.restored(
-      generation,
-      opened.kind === CONTEXT_OPENING.LOADED ? opened.context : undefined,
-    );
-    this.#asks.notify();
+    if (interrupted !== state.requests || repaired > 0 || orphaned.length > 0) {
+      generation.requests = new Map(
+        interrupted.map((record) => [
+          record.runId,
+          unfinished.has(record.runId)
+            ? { ...record, ...journalActionCounts(state.journal, record.runId) }
+            : record,
+        ]),
+      );
+      await this.#ledger.restored(
+        generation,
+        opened.kind === CONTEXT_OPENING.LOADED ? opened.context : undefined,
+      );
+      this.#asks.notify();
+    }
+    if (resume && opened.kind === CONTEXT_OPENING.LOADED && unfinished.size > 0) {
+      this.#resumeUnfinished(generation, state.journal);
+    }
+  }
+
+  /**
+   * Picks the unfinished runs up where the last host left them. The running
+   * ones open one turn together, the earliest started standing as the turn's
+   * own and the rest riding inside it as their steered words already did,
+   * each carrying the accounting its journal established so a resumed run
+   * reports every action the run before the cut performed. The queued ones
+   * are admitted as their acceptance would have admitted them, behind it.
+   */
+  #resumeUnfinished(generation: Generation, journal: BrainPersistedState["journal"]): void {
+    const records = [...generation.requests.values()];
+    const running = records
+      .filter((record) => record.status === BRAIN_REQUEST_STATUS.RUNNING)
+      .sort(
+        (left, right) =>
+          (left.startedAt ?? left.acceptedAt) - (right.startedAt ?? right.acceptedAt) ||
+          left.acceptedAt - right.acceptedAt,
+      )
+      .map((record) => ({
+        ...newRunControl(record.runId, generation, true),
+        ...journalActionCounts(journal, record.runId),
+      }));
+    if (running.length > 0) this.#asks.resume(running);
+    for (const record of records) {
+      if (record.status === BRAIN_REQUEST_STATUS.QUEUED) this.#asks.readmit(record);
+    }
   }
 
   #reportIncompatible(generation: Generation, reason: string): void {

--- a/packages/brain/src/asks.ts
+++ b/packages/brain/src/asks.ts
@@ -37,6 +37,8 @@ export interface AskLedgerOptions {
   createRunId: () => string;
   /** Opens one turn for the asks a drain handed over; the runner's own. */
   runAsk: (inputs: readonly AskInput[]) => Promise<void>;
+  /** Continues the runs a load found running, in one turn; the runner's own. */
+  resumeAsk: (runs: readonly RunControl[]) => Promise<void>;
   /** The execution under way, for steering and interrupt. */
   active: () => ActiveExecution | undefined;
   /** Disarms the wake window before an ask's turn opens with the inbox as it stands. */
@@ -288,6 +290,33 @@ export class AskLedger {
     this.#runs.set(run.runId, run);
     this.#admit(run, submission.question);
     return accepted;
+  }
+
+  /**
+   * The runs a load found running, under a host that resumes rather than
+   * interrupts: each is held as a live run again, its accounting the
+   * journal's, and the turn that continues them is queued at once. The
+   * wake window is disarmed as for any ask's turn, since the turn opens with
+   * the inbox as it stands.
+   */
+  resume(runs: readonly RunControl[]): void {
+    if (runs.length === 0) return;
+    for (const run of runs) this.#runs.set(run.runId, run);
+    this.#options.disarmWakes();
+    void this.#options.resumeAsk(runs);
+  }
+
+  /**
+   * An ask a load found still queued, under a host that resumes: admitted
+   * exactly as its acceptance admitted it, its record already durable, so it
+   * opens a turn of its own or waits behind the one under way.
+   */
+  readmit(record: BrainRequestRecord): void {
+    const generation = this.#seam.generation();
+    if (!generation || this.#runs.has(record.runId)) return;
+    const run = newRunControl(record.runId, generation, true);
+    this.#runs.set(run.runId, run);
+    this.#admit(run, record.question);
   }
 
   /**

--- a/packages/brain/src/index.ts
+++ b/packages/brain/src/index.ts
@@ -1,9 +1,11 @@
 export {
   BRAIN_DEFAULTS,
+  BRAIN_RECOVERY,
   BrainAgent,
   type BrainAgentOptions,
   type BrainFlushInput,
   type BrainFlushMarkerStore,
+  type BrainRecovery,
   type BrainWorkspaceAccess,
   LOOK_SUBJECT,
   type LookSubjectKind,
@@ -65,11 +67,20 @@ export {
 } from "./openai-model-adapter.js";
 export type { BrainActionExecution, BrainActionPerformer, BrainRoster } from "./performer.js";
 export {
+  type BrainPublicationAgent,
+  type BrainRunReference,
+  type ConversationLineRecorder,
+  publishAsk,
+  publishEnd,
+  publishRuns,
+} from "./publication.js";
+export {
   BRAIN_REQUEST_ORIGIN,
   BRAIN_REQUEST_STATUS,
   BRAIN_SUBMISSION_OUTCOME,
   type BrainRequestRecord,
   type BrainSubmission,
+  isTerminalBrainRequestStatus,
 } from "./requests.js";
 export {
   BRAIN_RESPONSES_COMPACT_PATH,
@@ -105,6 +116,7 @@ export {
   brainToolCatalog,
   hostedBrainToolCatalog,
   resolveTurnToolPolicy,
+  TOOL_GROUP,
 } from "./tools.js";
 export type { BrainTurnTraceRecord } from "./trace.js";
 export {

--- a/packages/brain/src/publication.ts
+++ b/packages/brain/src/publication.ts
@@ -1,0 +1,134 @@
+import { MAIN_SESSION_KEY, type SessionKey } from "@sidecar/runtime/vocabulary";
+import {
+  type ConversationEntry,
+  replyConversationEntry,
+  stoppedAskConversationEntry,
+  typedAskConversationEntry,
+} from "@sidecar/session";
+import type { BrainAgent } from "./agent.js";
+import {
+  BRAIN_REQUEST_ORIGIN,
+  type BrainRequestRecord,
+  brainReplyWords,
+  isTerminalBrainRequestStatus,
+  stoppedAskNarration,
+} from "./requests.js";
+
+/**
+ * How a run reaches the Conversation: its typed ask written once at its
+ * acceptance, its end written once when it settled, each marked on the
+ * record once the thread took it. The marks are what say a run was
+ * published, not the thread's contents, so a line the thread has since let
+ * go of is never written back, and a write the thread refused leaves the
+ * run for the next report. The desktop's follower and the hosted host both
+ * publish through here, so the two cannot word an end differently.
+ */
+
+/**
+ * Records one line in one conversation's thread at the moment given, answering
+ * whether the thread took it. A line the thread already holds for that run
+ * answers true, because holding it is the whole of what was asked.
+ */
+export type ConversationLineRecorder = (
+  entry: ConversationEntry,
+  recordedAt: number,
+  sessionKey: SessionKey,
+) => boolean | Promise<boolean>;
+
+/** The part of the agent publication reads and marks: the live record, and the two marks. */
+export type BrainPublicationAgent = Pick<
+  BrainAgent,
+  "request" | "markConversationRecorded" | "markAskRecorded"
+>;
+
+/** The record's identity as a report carries it. */
+export interface BrainRunReference {
+  readonly runId: string;
+}
+
+/** Writes a typed ask's own line once, at its acceptance, and marks the run when the thread took it. */
+export async function publishAsk(
+  agent: BrainPublicationAgent,
+  runId: string,
+  record: ConversationLineRecorder,
+  sessionKey: SessionKey,
+): Promise<void> {
+  const current = agent.request(runId);
+  if (!current || current.origin !== BRAIN_REQUEST_ORIGIN.TYPED) return;
+  if (current.askRecordedAt !== undefined) return;
+  if (
+    !(await record(
+      typedAskConversationEntry(current.question, current.runId),
+      current.acceptedAt,
+      sessionKey,
+    ))
+  ) {
+    return;
+  }
+  await agent.markAskRecorded(runId, current.acceptedAt);
+}
+
+/**
+ * Writes a run's end once, at the moment it settled, and marks the run when
+ * the thread took it. Answers the live record once its end stands written and
+ * marked — now, or from an earlier report — and nothing while it does not: a
+ * write the thread refused, or a mark the store refused, leaves the end
+ * unpublished for the next report, and nothing downstream may treat it as
+ * said.
+ */
+export async function publishEnd(
+  agent: BrainPublicationAgent,
+  runId: string,
+  record: ConversationLineRecorder,
+  sessionKey: SessionKey,
+): Promise<BrainRequestRecord | undefined> {
+  const current = agent.request(runId);
+  if (!current || !isTerminalBrainRequestStatus(current.status)) return undefined;
+  if (current.conversationRecordedAt !== undefined) return current;
+  // An end with words is Luke's reply; a plain stop has none and leaves the
+  // quiet line instead, so every ended run reaches the thread and is marked.
+  const words = brainReplyWords(current);
+  const narration = words === undefined ? stoppedAskNarration(current) : undefined;
+  const entry =
+    words !== undefined
+      ? replyConversationEntry(words, current.runId)
+      : narration !== undefined
+        ? stoppedAskConversationEntry(narration, current.runId)
+        : undefined;
+  if (!entry) return undefined;
+  const at = current.settledAt ?? current.acceptedAt;
+  if (!(await record(entry, at, sessionKey))) return undefined;
+  if (!(await agent.markConversationRecorded(runId, at))) return undefined;
+  // Re-read rather than patched: the mark landed on the live record, and a
+  // Clear or a replacement in the meantime has taken the record with it.
+  const marked = agent.request(runId);
+  return marked?.conversationRecordedAt !== undefined ? marked : undefined;
+}
+
+/**
+ * The one place a run reaches the thread. Every record reported is read for
+ * what the thread has not yet taken — its typed ask, its end — and the record
+ * itself says which, in marks the brain keeps across reports, rebuilt
+ * followers, and launches. Each write is decided against the record as it
+ * stands at that moment, never against the report that prompted it, so an
+ * older report cannot write what a newer one already marked, and a follower
+ * retired mid-way writes nothing more.
+ */
+export async function publishRuns(
+  agent: BrainPublicationAgent,
+  runs: readonly BrainRunReference[],
+  record: ConversationLineRecorder,
+  stillFollowing: () => boolean = () => true,
+  onEndPublished:
+    | ((record: BrainRequestRecord, sessionKey: SessionKey) => void)
+    | undefined = undefined,
+  sessionKey: SessionKey = MAIN_SESSION_KEY,
+): Promise<void> {
+  for (const run of runs) {
+    if (!stillFollowing()) return;
+    await publishAsk(agent, run.runId, record, sessionKey);
+    if (!stillFollowing()) return;
+    const published = await publishEnd(agent, run.runId, record, sessionKey);
+    if (published && stillFollowing()) onEndPublished?.(published, sessionKey);
+  }
+}

--- a/packages/brain/src/recovery.test.ts
+++ b/packages/brain/src/recovery.test.ts
@@ -1,0 +1,184 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { REALTIME_TOOL } from "@sidecar/actions";
+import { RESPONSES_INPUT_ITEM_TYPE } from "@sidecar/hosted";
+import { checkpointFormatTag } from "@sidecar/runtime/vocabulary";
+import { UNKNOWN_ACTION_STATUS } from "@sidecar/wire";
+import { BRAIN_RECOVERY } from "./agent.js";
+import { type BrainPersistedState, freshBrainState } from "./envelope.js";
+import {
+  ABC,
+  answered,
+  CHECKPOINT,
+  call,
+  edge,
+  functionOutputs,
+  gatedClient,
+  harness,
+  itemsOfType,
+  itemText,
+  message,
+  NOW,
+  settle,
+  submit,
+} from "./harness.js";
+import { BRAIN_INPUT_MARKER } from "./input-items.js";
+import { BRAIN_REQUEST_ORIGIN, BRAIN_REQUEST_STATUS, type BrainRequestRecord } from "./requests.js";
+import type { ResponsesInputItem } from "./responses-api.js";
+import { fakeBrainStateRepository } from "./testing.js";
+
+/**
+ * The recovery a request-scoped host asks for: a run the last host left
+ * unfinished is picked up rather than interrupted, over the checkpoint it
+ * left, and nothing journaled is performed twice.
+ */
+
+function userMessage(text: string) {
+  return {
+    type: RESPONSES_INPUT_ITEM_TYPE.MESSAGE,
+    role: "user",
+    content: [{ type: "input_text", text }],
+  };
+}
+
+function record(overrides: Partial<BrainRequestRecord>): BrainRequestRecord {
+  return {
+    runId: "run-left",
+    submissionId: "submission-left",
+    origin: BRAIN_REQUEST_ORIGIN.TYPED,
+    question: "send the checkout agent a nudge",
+    status: BRAIN_REQUEST_STATUS.RUNNING,
+    revision: 1,
+    acceptedAt: NOW - 5_000,
+    startedAt: NOW - 4_000,
+    performedActions: 0,
+    unknownActions: 0,
+    ...overrides,
+  };
+}
+
+/** The developer's words in a request: the user messages that are not the standing context rebuilt for every inference. */
+function developerWords(items: readonly ResponsesInputItem[]): string[] {
+  return itemsOfType(items, RESPONSES_INPUT_ITEM_TYPE.MESSAGE)
+    .filter((item) => item.role === "user")
+    .map(itemText)
+    .filter((text) => !text.startsWith(BRAIN_INPUT_MARKER.STANDING_CONTEXT));
+}
+
+async function drained(h: ReturnType<typeof harness>): Promise<void> {
+  await h.agent.ready();
+  for (let round = 0; round < 50 && h.agent.busy(); round += 1) await settle();
+}
+
+const MESSAGE_CALL = call("call-left", REALTIME_TOOL.SEND_SESSION_MESSAGE, {
+  provider_id: ABC.providerId,
+  provider_session_id: ABC.providerSessionId,
+  text: "run the tests",
+});
+
+/** A generation a host died in mid-action: the ask and the call on record, the call's result never written. */
+function leftRunning(): BrainPersistedState {
+  return {
+    ...freshBrainState("gen-left", NOW - 10_000),
+    checkpointFormat: checkpointFormatTag(CHECKPOINT),
+    items: [userMessage("[developer ask] send the checkout agent a nudge"), MESSAGE_CALL],
+    requests: [record({})],
+    journal: [
+      {
+        runId: "run-left",
+        callId: "call-left",
+        name: REALTIME_TOOL.SEND_SESSION_MESSAGE,
+        argumentsJson: String(MESSAGE_CALL.arguments),
+        startedAt: NOW - 3_000,
+      },
+    ],
+  };
+}
+
+test("a resuming host continues a running run over its checkpoint and performs no journaled action again", async () => {
+  const h = harness({ recovery: BRAIN_RECOVERY.RESUME }, fakeBrainStateRepository(leftRunning()));
+  h.client.answers.push(answered([message("Nudged. The result of the earlier send was lost.")]));
+
+  await drained(h);
+
+  const settled = h.agent.request("run-left");
+  assert.equal(settled?.status, BRAIN_REQUEST_STATUS.SUCCEEDED);
+  assert.equal(settled?.text, "Nudged. The result of the earlier send was lost.");
+  // The journaled call's result was lost with the last host, so it counts as
+  // unknown, is paired as such in what the model reads, and is never re-run.
+  assert.equal(settled?.unknownActions, 1);
+  assert.deepEqual(h.performed, []);
+  assert.equal(h.client.inputs.length, 1);
+  const outputs = functionOutputs(h.client.inputs[0] ?? []);
+  assert.equal(outputs.length, 1);
+  assert.equal(outputs[0]?.callId, "call-left");
+  assert.ok(outputs[0]?.output.includes(UNKNOWN_ACTION_STATUS));
+  // The model was asked again with no new words: the ask already stands in the context.
+  assert.deepEqual(developerWords(h.client.inputs[0] ?? []), [
+    "[developer ask] send the checkout agent a nudge",
+  ]);
+});
+
+test("a resuming host re-admits a queued ask, and the default host still interrupts both", async () => {
+  const queued = {
+    ...freshBrainState("gen-queued", NOW - 10_000),
+    requests: [
+      record({ runId: "run-queued", status: BRAIN_REQUEST_STATUS.QUEUED, startedAt: undefined }),
+    ],
+  };
+  const resuming = harness({ recovery: BRAIN_RECOVERY.RESUME }, fakeBrainStateRepository(queued));
+  resuming.client.answers.push(answered([message("Here is the answer.")]));
+  await drained(resuming);
+  assert.equal(resuming.agent.request("run-queued")?.status, BRAIN_REQUEST_STATUS.SUCCEEDED);
+  assert.equal(resuming.agent.request("run-queued")?.text, "Here is the answer.");
+  assert.equal(resuming.client.inputs.length, 1);
+
+  const interrupting = harness({}, fakeBrainStateRepository(leftRunning()));
+  await drained(interrupting);
+  assert.equal(interrupting.agent.request("run-left")?.status, BRAIN_REQUEST_STATUS.INTERRUPTED);
+  assert.equal(interrupting.client.inputs.length, 0);
+});
+
+test("a resuming host checkpoints an ask's opening words before the model reads them", async () => {
+  const inner = harness().client;
+  const gate = gatedClient(inner);
+  const h = harness({ recovery: BRAIN_RECOVERY.RESUME, client: gate.client });
+  inner.answers.push(answered([message("Done.")]));
+
+  await submit(h, "what is the checkout agent doing?");
+  await settle();
+
+  // The model has not answered, and the checkpoint already carries the ask.
+  assert.equal(inner.inputs.length, 0);
+  const latest = h.persisted.at(-1);
+  assert.ok(latest);
+  const words = developerWords(latest.items);
+  assert.equal(words.length, 1);
+  assert.ok(words[0]?.includes("what is the checkout agent doing?"));
+  assert.equal(latest.requests[0]?.status, BRAIN_REQUEST_STATUS.RUNNING);
+
+  gate.open();
+  for (let round = 0; round < 50 && h.agent.busy(); round += 1) await settle();
+  assert.equal(h.agent.requests()[0]?.status, BRAIN_REQUEST_STATUS.SUCCEEDED);
+  // The runtime opened with no words of its own: the checkpointed ask is what it read.
+  assert.equal(inner.inputs.length, 1);
+  assert.equal(developerWords(inner.inputs[0] ?? []).length, 1);
+});
+
+test("observe captures the events and opens their turn at once, with no window to wait out", async () => {
+  const h = harness({ recovery: BRAIN_RECOVERY.RESUME });
+  h.client.answers.push(
+    answered([call("announce-1", "announce", { briefing: "abc finished its work." })]),
+    answered([message("")]),
+  );
+
+  await h.agent.observe([edge(ABC)]);
+
+  assert.equal(h.client.inputs.length, 2);
+  assert.deepEqual(
+    h.deliveries.map((delivery) => delivery.briefing),
+    ["abc finished its work."],
+  );
+  assert.equal(h.agent.pendingWakes(), 0);
+  assert.deepEqual(h.clock.timers.size, 0);
+});

--- a/packages/brain/src/requests.ts
+++ b/packages/brain/src/requests.ts
@@ -1,4 +1,16 @@
 import {
+  BRAIN_REQUEST_FAILURE,
+  BRAIN_REQUEST_ORIGIN,
+  BRAIN_REQUEST_STATUS,
+  BRAIN_SUBMISSION_OUTCOME,
+  BRAIN_SUBMISSION_REJECTION,
+  type BrainRequestFailure,
+  type BrainRequestOrigin,
+  type BrainRequestStatus,
+  type BrainSubmissionRejection,
+  isBrainRequestOrigin,
+} from "@sidecar/hosted";
+import {
   isRecord,
   isWireNumber,
   isWireString,
@@ -15,17 +27,18 @@ import {
  * than resuming an action it cannot know the state of.
  */
 
-export const BRAIN_REQUEST_STATUS = {
-  QUEUED: "queued",
-  RUNNING: "running",
-  SUCCEEDED: "succeeded",
-  FAILED: "failed",
-  CANCELLED: "cancelled",
-  TIMED_OUT: "timed_out",
-  INTERRUPTED: "interrupted",
-} as const;
-
-export type BrainRequestStatus = (typeof BRAIN_REQUEST_STATUS)[keyof typeof BRAIN_REQUEST_STATUS];
+export {
+  BRAIN_REQUEST_FAILURE,
+  BRAIN_REQUEST_ORIGIN,
+  BRAIN_REQUEST_STATUS,
+  BRAIN_SUBMISSION_OUTCOME,
+  BRAIN_SUBMISSION_REJECTION,
+  type BrainRequestFailure,
+  type BrainRequestOrigin,
+  type BrainRequestStatus,
+  type BrainSubmissionRejection,
+  isBrainRequestOrigin,
+};
 
 const BRAIN_REQUEST_STATUS_LIST: readonly BrainRequestStatus[] =
   Object.values(BRAIN_REQUEST_STATUS);
@@ -49,51 +62,6 @@ export function isBrainRequestStatus(value: UnparsedWireValue): value is BrainRe
 export function isTerminalBrainRequestStatus(status: BrainRequestStatus): boolean {
   return BRAIN_REQUEST_TERMINAL_STATUS.has(status);
 }
-
-/** Where the ask came from, which decides who records its words in the thread. */
-export const BRAIN_REQUEST_ORIGIN = {
-  /** Typed into a composer; the words travel with the submission and the host records them. */
-  TYPED: "typed",
-  /** Spoken; the voice service's own transcript is the record, and the question here is the mouth's relay. */
-  SPOKEN: "spoken",
-  /** A child's delegated task, handed to the child's own conversation by its requester's spawn. */
-  CHILD: "child",
-} as const;
-
-export type BrainRequestOrigin = (typeof BRAIN_REQUEST_ORIGIN)[keyof typeof BRAIN_REQUEST_ORIGIN];
-
-const BRAIN_REQUEST_ORIGIN_LIST: readonly BrainRequestOrigin[] =
-  Object.values(BRAIN_REQUEST_ORIGIN);
-
-export function isBrainRequestOrigin(value: UnparsedWireValue): value is BrainRequestOrigin {
-  // SAFETY: value is a string; list membership is the vocabulary check.
-  return isWireString(value) && BRAIN_REQUEST_ORIGIN_LIST.includes(value as BrainRequestOrigin);
-}
-
-/**
- * Why a run ended without a reply, as a fixed word rather than a provider's
- * sentence: the host words each one for the thread, so no raw model or
- * network output reaches the developer's record.
- */
-export const BRAIN_REQUEST_FAILURE = {
-  /** The model did not answer, or answered nothing readable. */
-  MODEL: "model",
-  /** A checkpoint could not be written, so the run stopped before or after an action. */
-  PERSISTENCE: "persistence",
-  /** The run reached its execution deadline. */
-  DEADLINE: "deadline",
-  /** The model stopped before a reply formed: an incomplete output, or the tool budget spent. */
-  INCOMPLETE: "incomplete",
-  /**
-   * The context had to be compacted before the run could be sent and the
-   * compaction did not succeed. The conversation stands exactly as it was;
-   * the ask can be made again once the model or the network is back.
-   */
-  COMPACTION: "compaction",
-} as const;
-
-export type BrainRequestFailure =
-  (typeof BRAIN_REQUEST_FAILURE)[keyof typeof BRAIN_REQUEST_FAILURE];
 
 const BRAIN_REQUEST_FAILURE_LIST: readonly BrainRequestFailure[] =
   Object.values(BRAIN_REQUEST_FAILURE);
@@ -236,30 +204,6 @@ export function interruptedUnfinishedRequests(
  * retry of the same submission — and rejected says why in a word the host
  * words for the developer.
  */
-export const BRAIN_SUBMISSION_REJECTION = {
-  EMPTY: "empty",
-  ABSENT: "absent",
-  PERSISTENCE: "persistence",
-  /** The submission id is already taken by an ask with other words or another origin. */
-  CONFLICT: "conflict",
-  /** The generation holds as many records as it may, and none is yet eligible to be let go. */
-  FULL: "full",
-  /**
-   * The generation's checkpoint was written by a runtime this build does not
-   * run; it is kept whole, and nothing may open a turn over it until a
-   * compatible runtime loads it or the developer starts fresh.
-   */
-  INCOMPATIBLE: "incompatible",
-} as const;
-
-export type BrainSubmissionRejection =
-  (typeof BRAIN_SUBMISSION_REJECTION)[keyof typeof BRAIN_SUBMISSION_REJECTION];
-
-export const BRAIN_SUBMISSION_OUTCOME = {
-  ACCEPTED: "accepted",
-  REJECTED: "rejected",
-} as const;
-
 export type BrainSubmissionResult =
   | { outcome: typeof BRAIN_SUBMISSION_OUTCOME.ACCEPTED; runId: string; acceptedAt: number }
   | { outcome: typeof BRAIN_SUBMISSION_OUTCOME.REJECTED; reason: BrainSubmissionRejection };

--- a/packages/brain/src/trace.ts
+++ b/packages/brain/src/trace.ts
@@ -1,4 +1,4 @@
-import type { RunOrigin } from "@sidecar/runtime/vocabulary";
+import type { RunEndReason, RunOrigin } from "@sidecar/runtime/vocabulary";
 import type { BrainTurnTrigger } from "./turn.js";
 
 export interface BrainToolCallTrace {
@@ -16,6 +16,8 @@ export interface BrainToolCallTrace {
  * prompt's.
  */
 export interface BrainTurnTraceRecord {
+  /** The run the turn ran under: a recorded ask's own id, or the id an observation turn minted for itself. */
+  runId: string;
   trigger: BrainTurnTrigger;
   origin: RunOrigin;
   /** Which agent runtime ran the turn, by its id. */
@@ -24,6 +26,9 @@ export interface BrainTurnTraceRecord {
   tools: readonly string[];
   promptChars: number;
   inputTokens?: number;
+  outputTokens?: number;
+  /** How the runtime ended the run, when the run reached the runtime at all. */
+  ending?: RunEndReason;
   transcriptBytes: number;
   toolCalls: readonly BrainToolCallTrace[];
   outputText?: string;

--- a/packages/brain/src/turn-runner.ts
+++ b/packages/brain/src/turn-runner.ts
@@ -6,11 +6,13 @@ import {
 import {
   type AgentRuntime,
   CONTEXT_INPUT_KIND,
+  type ContextInput,
   type ContextMark,
   type ReasoningEffort,
   RUN_END_REASON,
   RUN_ORIGIN,
   RUNTIME_EVENT,
+  type RunEndReason,
   type RuntimeEvent,
   type RuntimeRun,
   type RuntimeRunEnd,
@@ -122,6 +124,8 @@ interface TurnGathering {
   iterations: number;
   compacted: boolean;
   inputTokens?: number;
+  outputTokens?: number;
+  ending?: RunEndReason;
   /** Each answer's words in order, the empty ones included, so the reply is composed from all of them. */
   said: string[];
   outputText: string;
@@ -201,6 +205,13 @@ export interface TurnRunnerOptions {
   reasoningEffort?: ReasoningEffort;
   promptCacheKey?: string;
   executionDeadlineMs: number;
+  /**
+   * Whether a recorded run's opening words are checkpointed before the model
+   * reads them. A host that resumes unfinished runs needs them on record: a
+   * function cut off mid-inference then resumes over the words that opened
+   * the run rather than over a context that never heard them.
+   */
+  checkpointOpening?: boolean;
   /** The one compaction path, owned by the maintenance that also holds the flush counters. */
   compactIfNeeded: (
     turnContext: Omit<TurnContext, "run"> & { run?: RunControl },
@@ -359,6 +370,46 @@ export class TurnRunner {
       await this.#seam.ledger.settleRun(generation, run.runId, status, end, run);
       return;
     }
+  }
+
+  /**
+   * Continues the runs a load found running, as one turn: the checkpoint
+   * already holds their opening words and every answered effect, each call
+   * left unanswered paired as unknown at load, so the model is asked again
+   * over that context with no new words. A call it repeats under a journaled
+   * id is answered from the journal rather than performed again. The first
+   * run stands as the turn's own and the rest ride inside it, as they did
+   * when their words were steered in, and every one ends with the turn.
+   */
+  async resumeAsk(runs: readonly RunControl[]): Promise<void> {
+    const [primary, ...riders] = runs;
+    if (!primary) return;
+    const generation = primary.generation;
+    primary.deadline = this.#seam.schedule(() => {
+      primary.timedOut = true;
+      primary.abort.abort();
+    }, this.#options.executionDeadlineMs);
+    const childTask = generation.requests.get(primary.runId)?.origin === BRAIN_REQUEST_ORIGIN.CHILD;
+    let result: TurnResult;
+    try {
+      result = await this.turn(
+        {
+          generation,
+          deliveries: new SteeredDeliveries(),
+          events: inboxEvents(generation.inbox),
+          run: primary,
+          trigger: childTask ? BRAIN_TURN_TRIGGER.CHILD_TASK : BRAIN_TURN_TRIGGER.ASK,
+          open: () => [],
+        },
+        riders,
+      );
+    } catch {
+      result = { outcome: TURN_OUTCOME.FAILED };
+    }
+    if (primary.deadline !== undefined) this.#seam.cancel(primary.deadline);
+    this.#options.forgetRun(primary.runId);
+    const { status, end } = runOutcomeOf(primary, result, this.#seam.stopped());
+    await this.#seam.ledger.settleRun(generation, primary.runId, status, end, primary);
   }
 
   /**
@@ -647,12 +698,17 @@ export class TurnRunner {
 
     const { id: runtime, model } = this.#options.runtime.descriptor;
     this.#options.trace?.({
+      runId: run.runId,
       trigger: plan.trigger,
       origin: runOriginOf(plan.trigger),
       runtime,
       tools: policy?.allowed.map((tool) => tool.schema.name) ?? [],
       promptChars: preparation?.prompt.length ?? 0,
       ...(gathering.inputTokens !== undefined ? { inputTokens: gathering.inputTokens } : undefined),
+      ...(gathering.outputTokens !== undefined
+        ? { outputTokens: gathering.outputTokens }
+        : undefined),
+      ...(gathering.ending !== undefined ? { ending: gathering.ending } : undefined),
       transcriptBytes,
       toolCalls: gathering.toolCalls,
       ...(gathering.outputText ? { outputText: gathering.outputText } : undefined),
@@ -762,7 +818,7 @@ export class TurnRunner {
    * inference, and a listener that keeps what the run gathers and
    * checkpoints each answered effect before the runtime asks the model again.
    */
-  #execute(
+  async #execute(
     turnContext: TurnContext,
     execution: BrainActionExecution,
     gathering: TurnGathering,
@@ -777,6 +833,25 @@ export class TurnRunner {
   ): Promise<RuntimeRunEnd> {
     const { context, run } = turnContext;
     const runId = run.runId;
+    const opening: ContextInput[] = turn.opening.map((text) => ({
+      kind: CONTEXT_INPUT_KIND.USER_TEXT,
+      text,
+    }));
+    // Under a resuming host a recorded run's opening words stand on disk
+    // before the model reads them: ingested here and checkpointed, so the
+    // runtime opens with nothing new and a resume opens over the same words.
+    const checkpointedOpening =
+      this.#options.checkpointOpening === true && run.recorded && opening.length > 0;
+    if (checkpointedOpening) {
+      for (const input of opening) {
+        const ingested = await settledUnlessAborted(
+          Promise.resolve(context.ingest(input, { signal: turnContext.signal })),
+          turnContext.signal,
+        );
+        if (ingested.aborted) break;
+      }
+      if (!turnContext.signal.aborted) await turn.advanceMark();
+    }
     const tools = createTurnToolExecutor(
       {
         roster: this.#options.roster,
@@ -814,6 +889,9 @@ export class TurnRunner {
           if (event.usage.inputTokens !== undefined) {
             gathering.inputTokens = event.usage.inputTokens;
           }
+          if (event.usage.outputTokens !== undefined) {
+            gathering.outputTokens = (gathering.outputTokens ?? 0) + event.usage.outputTokens;
+          }
           return;
         case RUNTIME_EVENT.COMPACTED:
           gathering.compacted = true;
@@ -847,7 +925,7 @@ export class TurnRunner {
       tools,
       toolSchemas: brainToolSchemas(turn.policy),
       prompt: turn.prompt,
-      input: turn.opening.map((text) => ({ kind: CONTEXT_INPUT_KIND.USER_TEXT, text })),
+      input: checkpointedOpening ? [] : opening,
       ephemeral: () => [
         standingContextText(
           this.#options.roster().text,
@@ -877,6 +955,7 @@ export class TurnRunner {
     turnContext: TurnContext,
     gathering: TurnGathering,
   ): TurnResult | undefined {
+    gathering.ending = end.reason;
     if (this.#revoked(turnContext)) {
       gathering.error = turnContext.run.timedOut ? "execution deadline passed" : "turn revoked";
       return { outcome: TURN_OUTCOME.REVOKED };

--- a/packages/brain/src/wakes.ts
+++ b/packages/brain/src/wakes.ts
@@ -191,6 +191,34 @@ export class WakeCapture {
   }
 
   /**
+   * Captures the events as a wake does and opens their turn at once, settling
+   * when it has ended: for a host whose wakes arrive already batched, with no
+   * window in which to coalesce them. Entries a failed or throttled turn left
+   * standing open with them; nothing captured and nothing waiting opens no
+   * turn, and a throttled turn leaves its entries for the next.
+   */
+  observe(events: readonly BrainWakeEvent[]): Promise<void> {
+    if (this.#seam.stopped()) return Promise.resolve();
+    return this.#capture(events).then(async (captured) => {
+      if (this.#seam.stopped()) return;
+      const generation = this.#seam.generation();
+      if (!generation || (captured === 0 && generation.inbox.length === 0)) return;
+      this.#queue.take();
+      await this.#seam.queueTurn(BRAIN_TURN_TRIGGER.WAKE, async () => {
+        const inbox = inboxEvents(generation.inbox);
+        if (inbox.length === 0) return;
+        await this.#options.turn({
+          generation,
+          trigger: BRAIN_TURN_TRIGGER.WAKE,
+          deliveries: new SteeredDeliveries(),
+          events: inbox,
+          open: (attached, now) => [wakeInputText(attached, now)],
+        });
+      });
+    });
+  }
+
+  /**
    * Observations captured before the last launch ended, or left standing by a
    * turn that failed, open a turn once the state is read: they were written
    * down to be read, and a relaunch reads them without touching a transcript.

--- a/packages/devtrace/src/trace-writer.test.ts
+++ b/packages/devtrace/src/trace-writer.test.ts
@@ -35,6 +35,7 @@ test("lines land in the named file, stamped, in the order they were recorded", a
     outputTokens: 60,
   });
   writer.recordBrainTurn({
+    runId: "wake:run-1",
     trigger: BRAIN_TURN_TRIGGER.WAKE,
     origin: RUN_ORIGIN.OBSERVATION,
     runtime: TOOL_LOOP_RUNTIME.ID,

--- a/packages/host/src/brain/publication.ts
+++ b/packages/host/src/brain/publication.ts
@@ -1,20 +1,8 @@
-import type { BrainAgent, BrainRequestRecord } from "@sidecar/brain";
-import {
-  BRAIN_REQUEST_ORIGIN,
-  BRAIN_SUBMISSION_OUTCOME,
-  BRAIN_SUBMISSION_REJECTION,
-  brainReplyWords,
-  isTerminalBrainRequestStatus,
-  stoppedAskNarration,
-} from "@sidecar/brain/requests";
+import { type BrainAgent, type BrainRequestRecord, publishRuns } from "@sidecar/brain";
+import { BRAIN_SUBMISSION_OUTCOME, BRAIN_SUBMISSION_REJECTION } from "@sidecar/brain/requests";
 import type { BrainAskSubmissionResult, BrainRequestSnapshot } from "@sidecar/brain/requests-wire";
 import { MAIN_SESSION_KEY, type SessionKey } from "@sidecar/runtime/vocabulary";
-import {
-  type ConversationEntry,
-  replyConversationEntry,
-  stoppedAskConversationEntry,
-  typedAskConversationEntry,
-} from "@sidecar/session";
+import type { ConversationEntry } from "@sidecar/session";
 
 /** What the publication owner reaches: the thread, every window, and the delivery owner. */
 export interface BrainPublicationDependencies {
@@ -53,99 +41,7 @@ export const REJECTED_SUBMISSION: BrainAskSubmissionResult = {
   reason: BRAIN_SUBMISSION_REJECTION.ABSENT,
 };
 
-/** The part of the agent publication reads and marks: the live record, and the two marks. */
-export type BrainPublicationAgent = Pick<
-  BrainAgent,
-  "request" | "markConversationRecorded" | "markAskRecorded"
->;
-
-/** Writes a typed ask's own line once, at its acceptance, and marks the run when the thread took it. */
-export async function publishAsk(
-  agent: BrainPublicationAgent,
-  runId: string,
-  record: BrainPublicationDependencies["recordConversationEntry"],
-  sessionKey: SessionKey,
-): Promise<void> {
-  const current = agent.request(runId);
-  if (!current || current.origin !== BRAIN_REQUEST_ORIGIN.TYPED) return;
-  if (current.askRecordedAt !== undefined) return;
-  if (
-    !(await record(
-      typedAskConversationEntry(current.question, current.runId),
-      current.acceptedAt,
-      sessionKey,
-    ))
-  ) {
-    return;
-  }
-  await agent.markAskRecorded(runId, current.acceptedAt);
-}
-
-/**
- * Writes a run's end once, at the moment it settled, and marks the run when
- * the thread took it. Answers the live record once its end stands written and
- * marked — now, or from an earlier report — and nothing while it does not: a
- * write the thread refused, or a mark the store refused, leaves the end
- * unpublished for the next report, and nothing downstream may treat it as
- * said.
- */
-async function publishEnd(
-  agent: BrainPublicationAgent,
-  runId: string,
-  record: BrainPublicationDependencies["recordConversationEntry"],
-  sessionKey: SessionKey,
-): Promise<BrainRequestRecord | undefined> {
-  const current = agent.request(runId);
-  if (!current || !isTerminalBrainRequestStatus(current.status)) return undefined;
-  if (current.conversationRecordedAt !== undefined) return current;
-  // An end with words is Luke's reply; a plain stop has none and leaves the
-  // quiet line instead, so every ended run reaches the thread and is marked.
-  const words = brainReplyWords(current);
-  const narration = words === undefined ? stoppedAskNarration(current) : undefined;
-  const entry =
-    words !== undefined
-      ? replyConversationEntry(words, current.runId)
-      : narration !== undefined
-        ? stoppedAskConversationEntry(narration, current.runId)
-        : undefined;
-  if (!entry) return undefined;
-  const at = current.settledAt ?? current.acceptedAt;
-  if (!(await record(entry, at, sessionKey))) return undefined;
-  if (!(await agent.markConversationRecorded(runId, at))) return undefined;
-  // Re-read rather than patched: the mark landed on the live record, and a
-  // Clear or a replacement in the meantime has taken the record with it.
-  const marked = agent.request(runId);
-  return marked?.conversationRecordedAt !== undefined ? marked : undefined;
-}
-
-/**
- * The one place a run reaches the thread. Every record the brain reports is
- * read for what the thread has not yet taken — its typed ask, its end — and
- * the record itself says which, in marks the brain keeps across reports,
- * rebuilt followers, and launches. Each write is decided against the record
- * as it stands at that moment, never against the report that prompted it, so
- * an older report cannot write what a newer one already marked, and a
- * follower retired mid-way writes nothing more. Only a write the thread
- * confirmed marks the run; a write that failed leaves it for the next report.
- * The mark, not the thread's contents, is what says a run was published, so
- * a line the thread has since let go of is never written back.
- */
-export async function publishRuns(
-  agent: BrainPublicationAgent,
-  snapshots: readonly BrainRequestSnapshot[],
-  record: BrainPublicationDependencies["recordConversationEntry"],
-  stillFollowing: () => boolean = () => true,
-  onEndPublished: BrainPublicationDependencies["onEndPublished"] = undefined,
-  sessionKey: SessionKey = MAIN_SESSION_KEY,
-): Promise<void> {
-  for (const snapshot of snapshots) {
-    if (!stillFollowing()) return;
-    await publishAsk(agent, snapshot.runId, record, sessionKey);
-    if (!stillFollowing()) return;
-    const published = await publishEnd(agent, snapshot.runId, record, sessionKey);
-    if (published && stillFollowing()) onEndPublished?.(published, sessionKey);
-  }
-}
+export { type BrainPublicationAgent, publishAsk, publishRuns } from "@sidecar/brain";
 
 /**
  * Follows the brain that currently stands: each rebuilt agent is subscribed

--- a/packages/hosted/src/brain-ask-wire.ts
+++ b/packages/hosted/src/brain-ask-wire.ts
@@ -1,0 +1,219 @@
+import { maximumTypedAskLength } from "@sidecar/session";
+import {
+  isWireString,
+  RECORD_EXTRA_KEYS,
+  type Schema,
+  s,
+  TEXT_ENDS,
+  type UnparsedWireValue,
+} from "@sidecar/wire";
+import { countedNumber, writtenText } from "./service-wire.js";
+
+/**
+ * A developer's ask of the hosted brain and the run it becomes, as the ask
+ * routes take and answer them. The run record's vocabulary — its statuses,
+ * origins, and failures, and the outcome of a submission — is declared here
+ * because it is the wire's: the brain package, which owns the record's
+ * behavior, imports these words rather than restating them, so the record a
+ * client reads back is the record the brain wrote and the two cannot drift.
+ */
+
+export const BRAIN_REQUEST_STATUS = {
+  QUEUED: "queued",
+  RUNNING: "running",
+  SUCCEEDED: "succeeded",
+  FAILED: "failed",
+  CANCELLED: "cancelled",
+  TIMED_OUT: "timed_out",
+  INTERRUPTED: "interrupted",
+} as const;
+
+export type BrainRequestStatus = (typeof BRAIN_REQUEST_STATUS)[keyof typeof BRAIN_REQUEST_STATUS];
+
+/** Where the ask came from, which decides who records its words in the thread. */
+export const BRAIN_REQUEST_ORIGIN = {
+  /** Typed into a composer; the words travel with the submission and the host records them. */
+  TYPED: "typed",
+  /** Spoken; the voice service's own transcript is the record, and the question here is the mouth's relay. */
+  SPOKEN: "spoken",
+  /** A child's delegated task, handed to the child's own conversation by its requester's spawn. */
+  CHILD: "child",
+} as const;
+
+export type BrainRequestOrigin = (typeof BRAIN_REQUEST_ORIGIN)[keyof typeof BRAIN_REQUEST_ORIGIN];
+
+/**
+ * Why a run ended without a reply, as a fixed word rather than a provider's
+ * sentence: the host words each one for the thread, so no raw model or
+ * network output reaches the developer's record.
+ */
+export const BRAIN_REQUEST_FAILURE = {
+  /** The model did not answer, or answered nothing readable. */
+  MODEL: "model",
+  /** A checkpoint could not be written, so the run stopped before or after an action. */
+  PERSISTENCE: "persistence",
+  /** The run reached its execution deadline. */
+  DEADLINE: "deadline",
+  /** The model stopped before a reply formed: an incomplete output, or the tool budget spent. */
+  INCOMPLETE: "incomplete",
+  /**
+   * The context had to be compacted before the run could be sent and the
+   * compaction did not succeed. The conversation stands exactly as it was;
+   * the ask can be made again once the model or the network is back.
+   */
+  COMPACTION: "compaction",
+} as const;
+
+export type BrainRequestFailure =
+  (typeof BRAIN_REQUEST_FAILURE)[keyof typeof BRAIN_REQUEST_FAILURE];
+
+export const BRAIN_SUBMISSION_OUTCOME = {
+  ACCEPTED: "accepted",
+  REJECTED: "rejected",
+} as const;
+
+export type BrainSubmissionOutcome =
+  (typeof BRAIN_SUBMISSION_OUTCOME)[keyof typeof BRAIN_SUBMISSION_OUTCOME];
+
+/**
+ * Why a submission was refused, in a word the host words for the developer.
+ */
+export const BRAIN_SUBMISSION_REJECTION = {
+  EMPTY: "empty",
+  ABSENT: "absent",
+  PERSISTENCE: "persistence",
+  /** The submission id is already taken by an ask with other words or another origin. */
+  CONFLICT: "conflict",
+  /** The generation holds as many records as it may, and none is yet eligible to be let go. */
+  FULL: "full",
+  /**
+   * The generation's checkpoint was written by a runtime this build does not
+   * run; it is kept whole, and nothing may open a turn over it until a
+   * compatible runtime loads it or the developer starts fresh.
+   */
+  INCOMPATIBLE: "incompatible",
+} as const;
+
+export type BrainSubmissionRejection =
+  (typeof BRAIN_SUBMISSION_REJECTION)[keyof typeof BRAIN_SUBMISSION_REJECTION];
+
+const ORIGIN_LIST = Object.values(BRAIN_REQUEST_ORIGIN);
+const STATUS_LIST = Object.values(BRAIN_REQUEST_STATUS);
+const FAILURE_LIST = Object.values(BRAIN_REQUEST_FAILURE);
+const REJECTION_LIST = Object.values(BRAIN_SUBMISSION_REJECTION);
+const ORIGIN_SET: ReadonlySet<string> = new Set(ORIGIN_LIST);
+
+export function isBrainRequestOrigin(value: UnparsedWireValue): value is BrainRequestOrigin {
+  return isWireString(value) && ORIGIN_SET.has(value);
+}
+
+/** The origins a developer's ask may arrive under over the wire; a child's task never crosses it. */
+const ASK_ORIGIN_LIST = [BRAIN_REQUEST_ORIGIN.TYPED, BRAIN_REQUEST_ORIGIN.SPOKEN] as const;
+
+/** How long a submission id may run: the client's own uuid, or any id of that size. */
+export const BRAIN_SUBMISSION_ID_BOUNDS = { MAXIMUM_CHARS: 64 } as const;
+
+/**
+ * One deliberate ask (POST). The submission id is the client's, minted once
+ * per ask, so a retried request finds the run the first one made rather than
+ * opening a second; a request naming none is one deliberate ask and the
+ * service mints one for it.
+ */
+export interface HostedBrainAskRequest {
+  question: string;
+  origin: (typeof ASK_ORIGIN_LIST)[number];
+  submissionId?: string;
+}
+
+export const hostedBrainAskRequestSchema: Schema<HostedBrainAskRequest> = s.record(
+  {
+    question: s.text({ max: maximumTypedAskLength, ends: TEXT_ENDS.TRIM }),
+    origin: s.enumOf(ASK_ORIGIN_LIST, { ends: TEXT_ENDS.TRIM }),
+    submissionId: s.text({ max: BRAIN_SUBMISSION_ID_BOUNDS.MAXIMUM_CHARS }).optional(),
+  },
+  { extraKeys: RECORD_EXTRA_KEYS.REFUSE },
+);
+
+/** A run as the ask routes answer it: the brain's own record, unchanged. */
+export interface HostedBrainRun {
+  runId: string;
+  submissionId: string;
+  origin: BrainRequestOrigin;
+  question: string;
+  status: BrainRequestStatus;
+  revision: number;
+  acceptedAt: number;
+  startedAt?: number;
+  settledAt?: number;
+  /** The reply, when the run reached one. */
+  text?: string;
+  failure?: BrainRequestFailure;
+  performedActions: number;
+  unknownActions: number;
+  askRecordedAt?: number;
+  conversationRecordedAt?: number;
+}
+
+export const hostedBrainRunSchema: Schema<HostedBrainRun> = s.record(
+  {
+    runId: writtenText,
+    submissionId: writtenText,
+    origin: s.enumOf(ORIGIN_LIST, { ends: TEXT_ENDS.TRIM }),
+    question: s.text({ ends: TEXT_ENDS.KEEP, allowEmpty: true }),
+    status: s.enumOf(STATUS_LIST, { ends: TEXT_ENDS.TRIM }),
+    revision: countedNumber,
+    acceptedAt: countedNumber,
+    startedAt: countedNumber.optional(),
+    settledAt: countedNumber.optional(),
+    text: s.text({ ends: TEXT_ENDS.KEEP, allowEmpty: true }).optional(),
+    failure: s.enumOf(FAILURE_LIST, { ends: TEXT_ENDS.TRIM }).optional(),
+    performedActions: countedNumber,
+    unknownActions: countedNumber,
+    askRecordedAt: countedNumber.optional(),
+    conversationRecordedAt: countedNumber.optional(),
+  },
+  { extraKeys: RECORD_EXTRA_KEYS.IGNORE },
+);
+
+/** What a submission came to: the run it opened, or why it was refused. */
+export type HostedBrainAskAnswer =
+  | { outcome: typeof BRAIN_SUBMISSION_OUTCOME.ACCEPTED; runId: string; acceptedAt: number }
+  | { outcome: typeof BRAIN_SUBMISSION_OUTCOME.REJECTED; reason: BrainSubmissionRejection };
+
+export const hostedBrainAskAnswerSchema: Schema<HostedBrainAskAnswer> = s.union([
+  s.record(
+    {
+      outcome: s.literal(BRAIN_SUBMISSION_OUTCOME.ACCEPTED),
+      runId: writtenText,
+      acceptedAt: countedNumber,
+    },
+    { extraKeys: RECORD_EXTRA_KEYS.IGNORE },
+  ),
+  s.record(
+    {
+      outcome: s.literal(BRAIN_SUBMISSION_OUTCOME.REJECTED),
+      reason: s.enumOf(REJECTION_LIST, { ends: TEXT_ENDS.TRIM }),
+    },
+    { extraKeys: RECORD_EXTRA_KEYS.IGNORE },
+  ),
+]);
+
+/** What the wait and the cancel answer: the run as it now stands. */
+export interface HostedBrainRunAnswer {
+  run: HostedBrainRun;
+}
+
+export const hostedBrainRunAnswerSchema: Schema<HostedBrainRunAnswer> = s.record(
+  { run: hostedBrainRunSchema },
+  { extraKeys: RECORD_EXTRA_KEYS.IGNORE },
+);
+
+/**
+ * How long a wait on a run may hold before answering the run as it stands,
+ * and the query the client names a shorter hold with. The run is not
+ * abandoned at the edge: it keeps going, and the next wait answers it.
+ */
+export const HOSTED_BRAIN_WAIT = {
+  QUERY: "wait",
+  MAXIMUM_MS: 25_000,
+} as const;

--- a/packages/hosted/src/conversation-lines-wire.ts
+++ b/packages/hosted/src/conversation-lines-wire.ts
@@ -1,0 +1,118 @@
+import { CONVERSATION_ENTRY_KIND } from "@sidecar/session";
+import { RECORD_EXTRA_KEYS, type Schema, s, TEXT_ENDS } from "@sidecar/wire";
+import { countedNumber, writtenText } from "./service-wire.js";
+
+/**
+ * The Conversation as the service answers it (GET): the lines the panel
+ * draws, in the line shape the session package keeps, each carrying the
+ * rating the developer gave it when they gave one, and a cursor for the
+ * lines newer than the last answer. The service projects what the panel
+ * projects — the most recent lines inside their retention — and the cursor
+ * is the newest line's instant, so a client asks for what it has not seen by
+ * naming when it last looked.
+ */
+
+export const LINE_RATING = {
+  UP: "up",
+  DOWN: "down",
+} as const;
+
+export type LineRating = (typeof LINE_RATING)[keyof typeof LINE_RATING];
+
+const LINE_RATING_LIST = Object.values(LINE_RATING);
+
+export const lineRatingSchema: Schema<LineRating> = s.enumOf(LINE_RATING_LIST, {
+  ends: TEXT_ENDS.TRIM,
+});
+
+export interface HostedConversationLine {
+  kind: (typeof CONVERSATION_ENTRY_KIND)[keyof typeof CONVERSATION_ENTRY_KIND];
+  /** The line's id as its writer minted it; what a rating names. */
+  eventId?: string;
+  words: string;
+  identity?: { providerId: string; providerSessionId: string };
+  recordedAt: number;
+  requestId?: string;
+  rating?: LineRating;
+}
+
+export interface HostedConversationLinesAnswer {
+  lines: HostedConversationLine[];
+  /** The newest line's instant, for the next read's `after`; absent when no line stands. */
+  cursor?: number;
+}
+
+const conversationLineSchema: Schema<HostedConversationLine> = s.record(
+  {
+    kind: s.enumOf(Object.values(CONVERSATION_ENTRY_KIND), { ends: TEXT_ENDS.TRIM }),
+    eventId: s.dropRefused(writtenText),
+    words: s.text({ ends: TEXT_ENDS.KEEP, allowEmpty: true }),
+    identity: s.dropRefused(
+      s.record(
+        { providerId: writtenText, providerSessionId: writtenText },
+        { extraKeys: RECORD_EXTRA_KEYS.IGNORE },
+      ),
+    ),
+    recordedAt: countedNumber,
+    requestId: s.dropRefused(writtenText),
+    rating: s.dropRefused(lineRatingSchema),
+  },
+  { extraKeys: RECORD_EXTRA_KEYS.IGNORE },
+);
+
+/** A malformed line is skipped, not fatal. */
+export const hostedConversationLinesAnswerSchema: Schema<HostedConversationLinesAnswer> = s.record(
+  {
+    lines: s.array(conversationLineSchema, { skipRefused: true }),
+    cursor: s.dropRefused(countedNumber),
+  },
+  { extraKeys: RECORD_EXTRA_KEYS.IGNORE },
+);
+
+/** The query a read names the lines newer than a cursor with. */
+export const HOSTED_CONVERSATION_QUERY = {
+  AFTER: "after",
+} as const;
+
+/** What the Clear answers. */
+export interface HostedConversationClearAnswer {
+  cleared: boolean;
+}
+
+export const hostedConversationClearAnswerSchema: Schema<HostedConversationClearAnswer> = s.record(
+  { cleared: s.boolean() },
+  { extraKeys: RECORD_EXTRA_KEYS.IGNORE },
+);
+
+/** How long the developer's words about a rating may run. */
+export const LINE_RATING_NOTE_BOUNDS = { MAXIMUM_CHARS: 2_000 } as const;
+
+/**
+ * One rating of one line Luke authored (PUT): the thumb, the developer's
+ * optional words, and the device it was pressed on. The line is named in the
+ * path by the id its writer minted; only a line the caller's own conversation
+ * holds and Luke authored takes one.
+ */
+export interface HostedLineRatingRequest {
+  rating: LineRating;
+  note?: string;
+  deviceId: string;
+}
+
+export const hostedLineRatingRequestSchema: Schema<HostedLineRatingRequest> = s.record(
+  {
+    rating: lineRatingSchema,
+    note: s.text({ max: LINE_RATING_NOTE_BOUNDS.MAXIMUM_CHARS, ends: TEXT_ENDS.TRIM }).optional(),
+    deviceId: s.text({ max: 64 }),
+  },
+  { extraKeys: RECORD_EXTRA_KEYS.REFUSE },
+);
+
+export interface HostedLineRatingAnswer {
+  rated: boolean;
+}
+
+export const hostedLineRatingAnswerSchema: Schema<HostedLineRatingAnswer> = s.record(
+  { rated: s.boolean() },
+  { extraKeys: RECORD_EXTRA_KEYS.IGNORE },
+);

--- a/packages/hosted/src/facts-wire.ts
+++ b/packages/hosted/src/facts-wire.ts
@@ -1,0 +1,31 @@
+import { RECORD_EXTRA_KEYS, type Schema, s, TEXT_ENDS } from "@sidecar/wire";
+import { countedNumber, writtenText } from "./service-wire.js";
+
+/**
+ * The facts Luke remembers about the developer, as the service answers them
+ * (GET): each the words as Luke kept them, the id a request to forget names,
+ * and when it was first remembered, oldest first.
+ */
+export interface HostedFact {
+  id: string;
+  words: string;
+  createdAt: number;
+}
+
+export interface HostedFactsAnswer {
+  facts: HostedFact[];
+}
+
+const factSchema: Schema<HostedFact> = s.record(
+  {
+    id: writtenText,
+    words: s.text({ ends: TEXT_ENDS.KEEP, allowEmpty: true }),
+    createdAt: countedNumber,
+  },
+  { extraKeys: RECORD_EXTRA_KEYS.IGNORE },
+);
+
+export const hostedFactsAnswerSchema: Schema<HostedFactsAnswer> = s.record(
+  { facts: s.array(factSchema, { skipRefused: true }) },
+  { extraKeys: RECORD_EXTRA_KEYS.IGNORE },
+);

--- a/packages/hosted/src/index.ts
+++ b/packages/hosted/src/index.ts
@@ -17,6 +17,29 @@ export {
   hostedActionWorkspaceAnswerSchema,
 } from "./action-wire.js";
 export {
+  BRAIN_REQUEST_FAILURE,
+  BRAIN_REQUEST_ORIGIN,
+  BRAIN_REQUEST_STATUS,
+  BRAIN_SUBMISSION_ID_BOUNDS,
+  BRAIN_SUBMISSION_OUTCOME,
+  BRAIN_SUBMISSION_REJECTION,
+  type BrainRequestFailure,
+  type BrainRequestOrigin,
+  type BrainRequestStatus,
+  type BrainSubmissionOutcome,
+  type BrainSubmissionRejection,
+  HOSTED_BRAIN_WAIT,
+  type HostedBrainAskAnswer,
+  type HostedBrainAskRequest,
+  type HostedBrainRun,
+  type HostedBrainRunAnswer,
+  hostedBrainAskAnswerSchema,
+  hostedBrainAskRequestSchema,
+  hostedBrainRunAnswerSchema,
+  hostedBrainRunSchema,
+  isBrainRequestOrigin,
+} from "./brain-ask-wire.js";
+export {
   HOSTED_BRAIN_CONTRACT_VERSION,
   HOSTED_BRAIN_EMBED_BOUNDS,
   HOSTED_BRAIN_OPERATION,
@@ -45,6 +68,22 @@ export {
   hostedBrainEmbedRequestFromWire,
   hostedBrainRespondRequestFromWire,
 } from "./brain-contract.js";
+export {
+  HOSTED_CONVERSATION_QUERY,
+  type HostedConversationClearAnswer,
+  type HostedConversationLine,
+  type HostedConversationLinesAnswer,
+  type HostedLineRatingAnswer,
+  type HostedLineRatingRequest,
+  hostedConversationClearAnswerSchema,
+  hostedConversationLinesAnswerSchema,
+  hostedLineRatingAnswerSchema,
+  hostedLineRatingRequestSchema,
+  LINE_RATING,
+  LINE_RATING_NOTE_BOUNDS,
+  type LineRating,
+  lineRatingSchema,
+} from "./conversation-lines-wire.js";
 export {
   type HostedConversationAnswer,
   type HostedConversationMessage,
@@ -81,6 +120,7 @@ export {
   PUSH_ENVIRONMENT,
   type PushEnvironment,
 } from "./device-wire.js";
+export { type HostedFact, type HostedFactsAnswer, hostedFactsAnswerSchema } from "./facts-wire.js";
 export {
   HOSTED_CALLS_URL,
   HOSTED_WS_BASE_URL,
@@ -125,7 +165,12 @@ export {
   RESPONSES_MESSAGE_ROLE,
   serializedRequestBytes,
 } from "./responses-input.js";
-export { HOSTED_SERVICE_PATH } from "./service-paths.js";
+export {
+  brainAskCancelPath,
+  brainAskRunPath,
+  conversationLineRatingPath,
+  HOSTED_SERVICE_PATH,
+} from "./service-paths.js";
 export {
   HOSTED_API_ERROR,
   type HostedApiError,

--- a/packages/hosted/src/service-paths.ts
+++ b/packages/hosted/src/service-paths.ts
@@ -62,6 +62,29 @@ export const HOSTED_SERVICE_PATH = {
   BRAIN_COMPACT: "/api/brain/v2/compact",
   /** Embeddings for the notebook index on Luke's key (POST), the fourth operation of the second contract. */
   BRAIN_EMBED: "/api/brain/v2/embed",
+  /**
+   * Ask Luke's hosted brain (POST): the developer's typed or spoken words
+   * become a run of the account's one conversation, answered by its id. The
+   * run is waited on at `brainAskRunPath` and cancelled at
+   * `brainAskCancelPath`; the service runs the turn itself, over its own
+   * store, and the routes are how every device reaches the same brain.
+   */
+  BRAIN_ASK: "/api/brain/ask",
+  /**
+   * The scheduled wake of the hosted brain: for every account whose stored
+   * roster changed since the brain last looked, one observation turn over the
+   * pending diffs, and for a run a function left unfinished, its resumption.
+   * Called by Vercel's cron under `CRON_SECRET`, never by a client.
+   */
+  BRAIN_WAKE: "/api/brain/wake",
+  /**
+   * The account's one Conversation (GET), the lines the panel draws with a
+   * cursor for what is newer, and its Clear (DELETE), a hard delete of the
+   * conversation with no archive behind it.
+   */
+  CONVERSATION: "/api/conversation",
+  /** The facts Luke remembers about the developer (GET), as the brain's standing context lists them. */
+  FACTS: "/api/facts",
   ACCOUNT_DELETE: "/api/account/delete",
   USAGE: "/api/usage",
   EVENTS: "/api/events",
@@ -97,3 +120,23 @@ export const HOSTED_SERVICE_PATH = {
    */
   SESSION_MESSAGES: "/api/sessions/messages",
 } as const;
+
+/**
+ * Where one run of the hosted brain is waited on (GET) and, under `/cancel`,
+ * cancelled (POST). The run id is the brain's own, answered by the ask.
+ */
+export function brainAskRunPath(runId: string): string {
+  return `${HOSTED_SERVICE_PATH.BRAIN_ASK}/${encodeURIComponent(runId)}`;
+}
+
+export function brainAskCancelPath(runId: string): string {
+  return `${brainAskRunPath(runId)}/cancel`;
+}
+
+/**
+ * Where one Conversation line's rating is written (PUT): the line by the id
+ * its writer minted, the rating in the body.
+ */
+export function conversationLineRatingPath(lineId: string): string {
+  return `${HOSTED_SERVICE_PATH.CONVERSATION}/lines/${encodeURIComponent(lineId)}/rating`;
+}

--- a/packages/hosted/src/service-wire.ts
+++ b/packages/hosted/src/service-wire.ts
@@ -39,6 +39,14 @@ export const HOSTED_API_ERROR = {
   /** A tool name the service's catalog does not register; no schema was selected. */
   UNKNOWN_TOOL: "unknown-tool",
   METHOD_NOT_ALLOWED: "method-not-allowed",
+  /** The run, line, or record the path names is not one this account holds. */
+  NOT_FOUND: "not-found",
+  /**
+   * Another request holds the conversation — a turn is under way in a
+   * function that is still alive — and this one would not wait any longer
+   * for it. Nothing was changed; the caller asks again shortly.
+   */
+  CONVERSATION_BUSY: "conversation-busy",
 } as const;
 
 export type HostedApiError = (typeof HOSTED_API_ERROR)[keyof typeof HOSTED_API_ERROR];

--- a/packages/providers/src/conductor/conversation.test.ts
+++ b/packages/providers/src/conductor/conversation.test.ts
@@ -239,22 +239,74 @@ test("a poll walks the store's pages to the fixed bounds and answers hasMore hon
   assert.equal(reads[2]?.searchParams.get("after"), STORED_MESSAGE_UUIDS[6]);
 });
 
-test("an incremental transcript read keeps the inherited unsupported answer and reads nothing", async () => {
+test("an incremental transcript read opens on the newest page and then reads only what is newer", async () => {
   const api = conversationApi();
   const plugin = pluginFor(api.fetch);
   await plugin.observe();
-  const requestsBefore = api.requests.length;
 
   const opening = await dispatchRead(plugin, "transcriptSince", IDLE_SESSION_UUID);
-  const poll = await dispatchRead(
+
+  assert.equal(opening.status, "accepted");
+  if (opening.status !== "accepted") return;
+  assert.equal(
+    opening.text,
+    [
+      "Developer: Fix the flaky roster test",
+      "Conductor: Looking at the test now. It races the clock.",
+      "Conductor: Fixed: the test now stubs the clock.",
+    ].join("\n"),
+  );
+  // The cursor is the newest stored message the page consumed, kept or
+  // dropped, so the next read resumes past the lifecycle noise as well.
+  assert.equal(opening.cursor, STORED_MESSAGE_UUIDS[7]);
+  assert.equal(opening.truncated, false);
+
+  const requestsBefore = api.requests.length;
+  const quiet = await dispatchRead(plugin, "transcriptSince", IDLE_SESSION_UUID, opening.cursor);
+
+  assert.deepEqual(quiet, {
+    status: "accepted",
+    text: "",
+    cursor: STORED_MESSAGE_UUIDS[7],
+    truncated: false,
+  });
+  const poll = api.requests.slice(requestsBefore);
+  assert.equal(poll.length, 1);
+  assert.equal(poll[0]?.method, "GET");
+  assert.equal(poll[0]?.pathname, `/v0/sessions/${IDLE_SESSION_UUID}/messages`);
+  assert.equal(poll[0]?.searchParams.get("after"), STORED_MESSAGE_UUIDS[7]);
+  assert.equal(poll[0]?.searchParams.get("offset"), null);
+
+  const since = await dispatchRead(
     plugin,
     "transcriptSince",
     IDLE_SESSION_UUID,
     STORED_MESSAGE_UUIDS[2],
   );
 
-  assert.equal(opening.status, "unsupported");
-  assert.equal(poll.status, "unsupported");
+  assert.deepEqual(since, {
+    status: "accepted",
+    text: "Conductor: Fixed: the test now stubs the clock.",
+    cursor: STORED_MESSAGE_UUIDS[7],
+    truncated: false,
+  });
+});
+
+test("an incremental transcript read refuses a cursor Conductor never handed back and reaches nothing", async () => {
+  const api = conversationApi();
+  const plugin = pluginFor(api.fetch);
+  await plugin.observe();
+  const requestsBefore = api.requests.length;
+
+  const read = await dispatchRead(plugin, "transcriptSince", IDLE_SESSION_UUID, "../not-a-cursor");
+  const unknown = await dispatchRead(
+    plugin,
+    "transcriptSince",
+    "99999999-9999-4999-8999-999999999999",
+  );
+
+  assert.equal(read.status, "rejected");
+  assert.equal(unknown.status, "unsupported");
   assert.equal(api.requests.length, requestsBefore);
 });
 

--- a/packages/providers/src/conductor/conversation.ts
+++ b/packages/providers/src/conductor/conversation.ts
@@ -5,7 +5,9 @@ import {
   OMISSION_MARKER,
   type ProviderConversationMessage,
   type ProviderConversationResult,
+  type ProviderSessionObservation,
   type ProviderTranscriptResult,
+  type ProviderTranscriptSinceResult,
 } from "@sidecar/session";
 import { oneLine, type WireRecord } from "@sidecar/wire";
 import { ADAPTER_FAILURE, AdapterFailure } from "../shared/adapter-failure.js";
@@ -28,18 +30,19 @@ import {
 
 /**
  * One observed chat's stored conversation, through the documented transcript
- * read `GET …/sessions/{id}/messages`, never from an observation pass. Two
+ * read `GET …/sessions/{id}/messages`, never from an observation pass. Three
  * callers ask for it. A conversation screen reads the way a chat screen does:
  * opened plain it answers the newest page, walking to the transcript's end
  * because the endpoint pages ascending; handed `beforeOffset` it answers the
  * older history just before what the screen holds; handed `afterMessageId`
  * it answers only what is newer, behind the endpoint's own polling cursor.
- * The brain's transcript read takes the same newest page, rendered in the
- * line vocabulary every local transcript reader speaks, so one shape
- * describes an agent wherever it runs. Every mode keeps only the messages the
- * store itself attributes, and everything else is dropped unread. The page is
- * answered to the caller and nothing is kept here: the conversation stays the
- * provider's.
+ * The brain's whole transcript read takes the same newest page, and its
+ * incremental read takes what is newer than the cursor its last read handed
+ * back — the same `after` the screen polls with — each rendered in the line
+ * vocabulary every local transcript reader speaks, so one shape describes an
+ * agent wherever it runs. Every mode keeps only the messages the store itself
+ * attributes, and everything else is dropped unread. The page is answered to
+ * the caller and nothing is kept here: the conversation stays the provider's.
  */
 
 /**
@@ -295,6 +298,40 @@ function readRefusal(failure: AdapterFailure, subject: string) {
   };
 }
 
+const NOT_REPORTED = {
+  status: ACTION_RESULT_STATUS.UNSUPPORTED,
+  reason: "That session is not one the latest observation pass reported.",
+} as const;
+
+/** The roster a brain read answers for: what the latest pass reported, or what a host holding the roster itself hands in. */
+export type ReportedSessions = () => readonly ProviderSessionObservation[];
+
+/** The session behind a brain read, or nothing: a read reaches the provider, so only a reported UUID may. */
+function reportedSession(
+  reported: ReportedSessions,
+  providerSessionId: string,
+): ProviderSessionObservation | undefined {
+  if (!UUID_PATTERN.test(providerSessionId)) return undefined;
+  return reported().find((candidate) => candidate.providerSessionId === providerSessionId);
+}
+
+/** Attributed messages as transcript lines: the developer's in the shared lead, the agent's under its own name. */
+function transcriptLines(
+  observation: ProviderSessionObservation,
+  messages: readonly ProviderConversationMessage[],
+): string[] {
+  const speaker = observation.agent?.displayName ?? CONDUCTOR_SPEAKER_NAME;
+  return messages.flatMap((message) => {
+    const words = oneLine(message.text, TRANSCRIPT_BOUNDS.MAXIMUM_MESSAGE_LENGTH);
+    if (!words) return [];
+    return [
+      message.author === CONVERSATION_MESSAGE_AUTHOR.USER
+        ? transcriptLine.developer(words)
+        : transcriptLine.agent(speaker, words),
+    ];
+  });
+}
+
 /**
  * The brain's whole-transcript read of one cloud chat: the newest page of its
  * stored conversation, rendered one attributed message per line. It reaches
@@ -307,17 +344,11 @@ function readRefusal(failure: AdapterFailure, subject: string) {
 export async function readConductorTranscript(
   pass: CloudPass,
   ends: ConductorConversationEnds,
+  reported: ReportedSessions,
   providerSessionId: string,
 ): Promise<ProviderTranscriptResult> {
-  const observation = pass
-    .latest()
-    .find((candidate) => candidate.providerSessionId === providerSessionId);
-  if (!observation || !UUID_PATTERN.test(providerSessionId)) {
-    return {
-      status: ACTION_RESULT_STATUS.UNSUPPORTED,
-      reason: "That session is not one the latest observation pass reported.",
-    };
-  }
+  const observation = reportedSession(reported, providerSessionId);
+  if (!observation) return NOT_REPORTED;
   let tail: ProviderConversationResult;
   try {
     tail = await readTailPage(pass, ends, providerSessionId);
@@ -326,17 +357,7 @@ export async function readConductorTranscript(
     throw error;
   }
   if (tail.status !== ACTION_RESULT_STATUS.ACCEPTED) return tail;
-  const speaker = observation.agent?.displayName ?? CONDUCTOR_SPEAKER_NAME;
-  const lines = tail.messages.flatMap((message) => {
-    const words = oneLine(message.text, TRANSCRIPT_BOUNDS.MAXIMUM_MESSAGE_LENGTH);
-    if (!words) return [];
-    return [
-      message.author === CONVERSATION_MESSAGE_AUTHOR.USER
-        ? transcriptLine.developer(words)
-        : transcriptLine.agent(speaker, words),
-    ];
-  });
-  const rendered = boundedTranscript(lines);
+  const rendered = boundedTranscript(transcriptLines(observation, tail.messages));
   if (rendered === undefined) {
     return {
       status: ACTION_RESULT_STATUS.REJECTED,
@@ -346,6 +367,55 @@ export async function readConductorTranscript(
   return {
     status: ACTION_RESULT_STATUS.ACCEPTED,
     transcript: tail.hasOlder ? `${OMISSION_MARKER}\n${rendered}` : rendered,
+  };
+}
+
+/**
+ * The brain's incremental read of one cloud chat, for an observation turn:
+ * what the store gained since the cursor the last read handed back, walked
+ * forward behind the endpoint's own `after` exactly as the screen's poll is,
+ * and rendered in the same lines the whole read speaks. With no cursor yet it
+ * answers the newest page and says the front was cut, the way a local reader
+ * falls back to its tail, so the first look at a chat reads its recent words
+ * rather than its whole history. The cursor answered is the newest stored
+ * message the read consumed, attributed or not, so the next read resumes past
+ * the lifecycle noise too; a chat that gained nothing answers no words and
+ * the same cursor. It reaches the provider, so it answers only for a session
+ * the latest pass reported, and only behind a cursor Conductor itself handed
+ * back.
+ */
+export async function readConductorTranscriptSince(
+  pass: CloudPass,
+  ends: ConductorConversationEnds,
+  reported: ReportedSessions,
+  providerSessionId: string,
+  cursor: string | undefined,
+): Promise<ProviderTranscriptSinceResult> {
+  const observation = reportedSession(reported, providerSessionId);
+  if (!observation) return NOT_REPORTED;
+  if (cursor !== undefined && !UUID_PATTERN.test(cursor)) {
+    return {
+      status: ACTION_RESULT_STATUS.REJECTED,
+      reason: "That transcript cursor is not one Conductor handed back.",
+    };
+  }
+  let page: ProviderConversationResult;
+  try {
+    page =
+      cursor === undefined
+        ? await readTailPage(pass, ends, providerSessionId)
+        : await readNewerMessages(pass, providerSessionId, cursor);
+  } catch (error) {
+    if (error instanceof AdapterFailure) return readRefusal(error, "transcript");
+    throw error;
+  }
+  if (page.status !== ACTION_RESULT_STATUS.ACCEPTED) return page;
+  const next = page.lastMessageId ?? cursor;
+  return {
+    status: ACTION_RESULT_STATUS.ACCEPTED,
+    text: transcriptLines(observation, page.messages).join("\n"),
+    ...(next !== undefined ? { cursor: next } : undefined),
+    truncated: cursor === undefined ? page.hasOlder === true : page.hasMore,
   };
 }
 

--- a/packages/providers/src/conductor/index.ts
+++ b/packages/providers/src/conductor/index.ts
@@ -1,4 +1,4 @@
-import { WORKSPACE_TASK_SUPPORT } from "@sidecar/session";
+import { type ProviderSessionObservation, WORKSPACE_TASK_SUPPORT } from "@sidecar/session";
 import type { CloudFetch } from "@sidecar/wire";
 import type { AdapterDiagnosticCallback } from "../shared/adapter-diagnostics.js";
 import { type CloudSessionPlugin, cloudPass } from "../shared/cloud-pass.js";
@@ -7,6 +7,7 @@ import {
   conductorConversationEnds,
   readConductorConversation,
   readConductorTranscript,
+  readConductorTranscriptSince,
 } from "./conversation.js";
 import { type ConductorPassCache, conductorObservations } from "./observe.js";
 import {
@@ -23,6 +24,12 @@ export interface ConductorPluginOptions {
   minimumRefreshIntervalMs?: number;
   sleep?: (ms: number) => Promise<void>;
   onDiagnostic?: AdapterDiagnosticCallback;
+  /**
+   * The roster the brain's transcript reads answer for, when a host holds
+   * one the plugin did not read itself: the hosted brain reads against the
+   * stored snapshot its turns were shown. Absent, the latest pass's own.
+   */
+  reported?: () => readonly ProviderSessionObservation[];
 }
 
 /**
@@ -36,13 +43,15 @@ export interface ConductorPluginOptions {
  * thing a press opens and a write reaches, and a workspace holding two chats
  * in two states is two facts, not one.
  *
- * No observation pass reads a word of a conversation. Its two reads are the
- * `conversation` handler, reached at a developer's own press on a chat's
- * screen, and the `transcript` handler, reached by the brain's own read tool
- * in a turn, and between them they keep nothing but where in each transcript
- * the last read got to. Neither takes a cursor from a pass: the incremental
- * `transcriptSince` read stays unanswered, so an observation pass judges a
- * cloud chat from what Conductor reports about it.
+ * No observation pass reads a word of a conversation. Its three reads are
+ * the `conversation` handler, reached at a developer's own press on a chat's
+ * screen, the `transcript` handler, reached by the brain's own read tool in a
+ * turn, and the `transcriptSince` handler, reached by the brain's observation
+ * turn for a chat the roster diff named, each behind the cursor Conductor's
+ * own last answer handed back; between them they keep nothing but where in
+ * each transcript the last read got to. None takes anything from a pass: the
+ * pass still judges a cloud chat from what Conductor reports about it, and
+ * the brain's own reads are what open its messages.
  */
 export function conductorPlugin(options: ConductorPluginOptions): CloudSessionPlugin {
   /**
@@ -68,6 +77,8 @@ export function conductorPlugin(options: ConductorPluginOptions): CloudSessionPl
     collect: (request, now) => conductorObservations(request, now, cache),
   });
 
+  const reported = options.reported ?? (() => pass.latest());
+
   return {
     provider: CONDUCTOR_PROVIDER,
     observe: () => pass.run(),
@@ -90,7 +101,10 @@ export function conductorPlugin(options: ConductorPluginOptions): CloudSessionPl
     actions: conductorActions(pass),
 
     reads: {
-      transcript: (providerSessionId) => readConductorTranscript(pass, ends, providerSessionId),
+      transcript: (providerSessionId) =>
+        readConductorTranscript(pass, ends, reported, providerSessionId),
+      transcriptSince: (providerSessionId, cursor) =>
+        readConductorTranscriptSince(pass, ends, reported, providerSessionId, cursor),
       conversation: ({ request, observation }) =>
         readConductorConversation(pass, ends, observation.providerSessionId, request),
     },

--- a/packages/providers/src/conductor/observe.test.ts
+++ b/packages/providers/src/conductor/observe.test.ts
@@ -42,10 +42,15 @@ test("names every action Conductor documents, and none it does not", () => {
     "renameWorkspace",
     "spawnAgent",
   ]);
-  // A cloud session's conversation lives with its provider, and both reads of
-  // it go there: the developer's own conversation read and the brain's
-  // transcript read, with no incremental read for an observation pass.
-  assert.deepEqual(Object.keys(plugin.reads ?? {}).sort(), ["conversation", "transcript"]);
+  // A cloud session's conversation lives with its provider, and every read of
+  // it goes there: the developer's own conversation read, the brain's whole
+  // transcript read, and the brain's incremental read behind the cursor its
+  // last read handed back; an observation pass issues none of them.
+  assert.deepEqual(Object.keys(plugin.reads ?? {}).sort(), [
+    "conversation",
+    "transcript",
+    "transcriptSince",
+  ]);
 });
 test("observes cloud sessions the signed-in user created, under their own names", async () => {
   const api = fakeConductorApi({

--- a/packages/providers/src/conductor/wire.ts
+++ b/packages/providers/src/conductor/wire.ts
@@ -33,8 +33,9 @@ import {
  * a user asks for by opening a conversation screen:
  * `GET …/sessions/{id}/messages`, Conductor's documented read of one
  * session's stored transcript, paged with the `after` cursor its own answers
- * hand back; the brain's own transcript read takes its newest page too, and
- * it is never issued by an observation pass. The writers
+ * hand back; the brain's own transcript reads take its newest page and what
+ * is newer than a cursor too, and it is never issued by an observation pass.
+ * The writers
  * are `POST …/sessions/{id}/messages`, which is
  * Conductor's documented way to hand a prompt to an existing session — queued
  * while it is idle, steered into the running turn while it works —

--- a/packages/providers/src/shared/cloud-pass.ts
+++ b/packages/providers/src/shared/cloud-pass.ts
@@ -531,6 +531,10 @@ export function cloudPass(input: CloudPassInput): CloudPass {
     },
 
     async credentialBoundRead(segments, query, options, apply) {
+      // A read on a pass that has not run — the hosted brain reads a chat
+      // against the roster its stored snapshot holds — takes the credential
+      // the way a pass would, so the read is bound to it from here on.
+      if (credential === undefined) credential = await readApiKey();
       const epoch = credentialEpoch;
       const apiKey = credential;
       if (!apiKey) {

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -139,6 +139,7 @@ export {
   DAILY_NOTES_DIRECTORY,
   type DailyNote,
   dailyNoteName,
+  isWorkspaceFile,
   parseDailyNoteName,
   readBootstrapFiles,
   readWorkspaceFile,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -192,6 +192,9 @@ importers:
       '@tailwindcss/vite':
         specifier: 4.3.3
         version: 4.3.3(vite@7.3.1(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.12)(yaml@2.9.0))
+      '@vercel/functions':
+        specifier: 3.4.2
+        version: 3.4.2
       better-auth:
         specifier: 1.6.29
         version: 1.6.29(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.5.8)(@opentelemetry/api@1.9.1)(@types/pg@8.21.0)(kysely@0.29.5)(pg@8.23.0))(next@16.3.1(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@types/node@22.20.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(pg@8.23.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -2880,6 +2883,19 @@ packages:
 
   '@ungap/structured-clone@1.4.0':
     resolution: {integrity: sha512-1mEZtMKPM09vDmQt5y7YvmN2+DFTP7Tg0EWXdic8/C6VRnpb33e4ghisCIE3WZjsE2N8mf+QV1Zqh7ZFYLWInQ==}
+
+  '@vercel/functions@3.4.2':
+    resolution: {integrity: sha512-WDsNNuGOOUhRYxfcSgk8nlXaYW/6u1Lw2eaKm0y4+gDPGK/hwmYIeP2hESfccuCiPXd5ZGO8Jz/V5Ud3ZByoUQ==}
+    engines: {node: '>= 20'}
+    peerDependencies:
+      '@aws-sdk/credential-provider-web-identity': '*'
+    peerDependenciesMeta:
+      '@aws-sdk/credential-provider-web-identity':
+        optional: true
+
+  '@vercel/oidc@3.2.0':
+    resolution: {integrity: sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==}
+    engines: {node: '>= 20'}
 
   '@vitejs/plugin-react@5.1.2':
     resolution: {integrity: sha512-EcA07pHJouywpzsoTUqNh5NwGayl2PPVEJKUSinGGSxFGYn+shYbqMGBg6FXDqgXum9Ou/ecb+411ssw8HImJQ==}
@@ -6485,6 +6501,12 @@ snapshots:
     optional: true
 
   '@ungap/structured-clone@1.4.0': {}
+
+  '@vercel/functions@3.4.2':
+    dependencies:
+      '@vercel/oidc': 3.2.0
+
+  '@vercel/oidc@3.2.0': {}
 
   '@vitejs/plugin-react@5.1.2(vite@7.3.1(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.12)(yaml@2.9.0))':
     dependencies:


### PR DESCRIPTION
Fifth of twelve under LUKE-95. After this change Luke's judgment runs in the service: the same `BrainAgent` the desktop runs, composed request-scoped in Vercel Functions over the Postgres store from PR 2, for one conversation per account. Briefings are recorded and not yet delivered (PR 6); the desktop keeps its local brain and the hosted inference routes until PR 7.

Linear: LUKE-100 (this PR), LUKE-108 (the rating write, step 2), LUKE-95 (the parent and every settled decision).

## Host composition

`apps/web/server/hosted/brain-host/` composes `BrainAgent` with the tool-loop runtime over the Responses context engine on the OpenAI adapter, called directly on `OPENAI_API_KEY` with `LUKE_BRAIN_MODEL` as the model override, over `hostedStore().brainStateRepository(userId, MAIN)`. The prompt is built by the runtime's own pure builder from the account's workspace rows (seeded once from the brain's seeds, bounded as the desktop bounds its files). The roster is the stored snapshot, rendered by `sessionContextText` exactly as the desktop renders it; the standing context is the desktop's shape less the app guide the service has no panel for: projects, remembered facts, the recent lines. Every seam the agent needs of a machine is either the store or absent.

Additive changes to `packages/brain` make that possible without a second host:

- `BRAIN_RECOVERY.RESUME`: a load re-admits a queued run and continues a running one over its checkpoint (the runtime's `openContext`, which `resume` wraps, pairs each unanswered call with the unknown result), with the run's accounting taken from the journal. The desktop's default stays `INTERRUPT`.
- Under a resuming host a recorded run's opening words are checkpointed before the model reads them, so a function cut off mid-inference resumes over the words that opened the run.
- `BrainAgent.observe(events)` captures and opens a wake turn at once, with no coalescing window; `BrainAgent.idle()` is what a request drains on.
- `publishRuns`/`publishAsk` move into `@sidecar/brain` so the desktop's follower and the hosted host word a run's end from one place; the trace record gains the run id, the ending, and the output tokens so the about-fields can be written faithfully.
- The run record's vocabulary (`BRAIN_REQUEST_STATUS`, `BRAIN_REQUEST_ORIGIN`, `BRAIN_REQUEST_FAILURE`, the submission outcome and rejection) moves down into `@sidecar/hosted`, where the wire contracts are declared; the brain re-exports it, so every existing import stands.

## Lease and resume

`conversation_lease` (user, session key, owner, acquired, heartbeat, expires). A turn is run by whichever function holds the lease: the ask acquires it or waits up to 20 s for a holder to finish (`409 conversation-busy` past that), heartbeats every 10 s while it runs and applies any cancel noted meanwhile, and releases when the run has settled and its lines are written. A lease whose heartbeat stopped expires after 30 s. The next request or wake that finds it expired with a run still queued or running takes it over and resumes the run from its journal; nothing journaled is performed again. Runs execute under a 240 s deadline inside the 300 s `maxDuration` the four brain routes get, and a function answers first and finishes the run through Vercel's `waitUntil`. A holder that learns its lease passed to another stops writing.

Everything a run does lands in the store the way the SQLite store lands it: checkpoint items, transcript, cursors, lines, receipts, and the run's about-fields (trigger, origin, ending, token counts, transcript bytes, timing, tool names) on the run row.

## Routes and crons

| Route | |
| --- | --- |
| `POST /api/brain/ask` | question, origin typed or spoken, optional submission id → run id |
| `GET /api/brain/ask/{runId}?wait=ms` | the run when it ends or after a hold of at most 25 s; resumes an orphaned run |
| `POST /api/brain/ask/{runId}/cancel` | noted for the holder, or performed when no holder stands |
| `GET /api/conversation?after=ms` | the 200-line fortnight projection with each line's rating and a cursor |
| `DELETE /api/conversation` | Clear: hard delete under the lease, no archive |
| `PUT /api/conversation/lines/{lineId}/rating` | up or down, optional bounded note, device id; only a line the caller owns and Luke authored |
| `GET /api/facts` | the remembered facts |
| `GET /api/brain/wake` | cron, every minute, `CRON_SECRET`, `maxDuration` 300 |

The wake lists accounts with pending `roster_diff` rows and conversations with unfinished runs, longest waiting first, runs four at a time while a whole run deadline still fits, and reports `exhausted`. Each opens one observation turn over its diffs (resuming first), then consumes them. The observation tick from #863 is unchanged and runs no brain turn.

Wire contracts for all of it are `Schema` declarations in `@sidecar/hosted` (`brain-ask-wire.ts`, `conversation-lines-wire.ts`, `facts-wire.ts`, the new paths), so PR 7 and PR 10 mirror one source. Same 401/400/503 shapes and per-user rate brake as the other hosted routes; two error slugs are added (`not-found`, `conversation-busy`).

## Tools offered and refused

Offered, through the same policy layers and the same `ToolExecutor` gate the desktop uses: the cloud actions (message, control, create workspace, add agent, rename session, rename workspace) admitted by `admit()` against the stored snapshot and carried through the existing `executeSessionAction`; `list_sessions` and `read_transcript` over the snapshot and the Conductor plugin's documented read (whole tail, 60,000 chars); `remember_fact` and `forget_fact` on the facts table; the workspace read and write on the rows; `announce`, which inserts an offered `briefing` row (expiry five minutes) and the announcement line. Not offered, as an agent-layer deny so the model never sees them: `open_session`, the four app actions, the two issue actions, delegation, the notebook index, and skills.

The Conductor plugin gains `transcriptSince` over the `after` cursor, in the line vocabulary the whole read speaks, dropping tool activity and unattributed records as #865 does; observation turns read it for each working or waiting session a diff named (20,000 chars per session per turn) and the cursor lands in `observation_cursor` with the checkpoint. The plugin also takes a `reported` seam so the brain's reads answer for the stored snapshot rather than a live pass, and a credential-bound read on a pass that never ran takes the credential the way a pass would.

## Meter

Every inference (an answer, an explicit compaction) spends the single daily counter in `quota.ts` before the upstream is asked. A refused spend ends the run as the desktop's meter refusal does: the runtime's throttle, the run failed with the model failure, the reply saying to ask again.

## Docs

`PRIVACY.md` says the conversation, working memory, remembered facts, and identity workspace now live on our servers encrypted at rest, that the brain reads a working or waiting Conductor chat's new messages on observation wakes, what a rating stores, and that account deletion cascades through all of it. `apps/web/server/README.md` documents the two crons, the lease, the routes, and the environment. `CLAUDE.md`'s hosted-tier paragraph gains the minimal statement that the service now also runs the brain over its own store; the full rewrite is PR 12.

## What the next PRs add

PR 6 delivers the offered briefings (claim, speak, push, expire) and wakes the brain on a hold's release. PR 7 points the desktop at these routes and retires its use of the v2 inference routes.

## Dependencies

`@vercel/functions` (3.4.2) is added to `@luke/web` for `waitUntil`, the one documented way a Vercel Function keeps running past its response; outside Vercel it is a no-op, and tests collect the continued work themselves.

## Migration

`0013_numerous_sentinels.sql`: `conversation_lease`, `conversation_line_rating`, and `conversation_run.cancel_requested_at`. If a migration lands on main ahead of this one, this migration is regenerated on top, and the Vercel preview deploy will fail once because its Neon branch keeps the old one.

## Checks

`./scripts/check.sh` exit 0 on this branch: repository checks, Biome, oxlint, every workspace typecheck, every test suite, and the build. Test counts by package: harness 66, wire 66, feedback 14, runtime 62, session 89, surface 17, actions 60, hosted 79, gateway 39, memory 20, realtime 52, credentials 76, analytics 30, calendar 21, providers 476, brain 341, devtrace 14, panel 12, ios-parity 29, settings 42, trace-export 6, voice 117, web 381 (PGlite store, host, lease, wake, and route tests included), host 284, desktop 677; 0 failures. No macOS or UI change, so `verify.sh` was not run and no physical-notch check applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/fb00beaa-2274-4f09-aba7-9f4a1105e9ae)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34426441492/artifacts/10132879854) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34426441492)

- Commit: `bdd7718c25407dd832d05159f4cc44e86b61f4e7`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
