### PR TITLE
fix(voice): draw the developer's speech live in Conversation

### DIFF
--- a/apps/desktop/src/renderer/voice/conversation-call-interruption.test.ts
+++ b/apps/desktop/src/renderer/voice/conversation-call-interruption.test.ts
@@ -64,6 +64,9 @@ test("a developer turn is identified before its transcript returns", async () =>
   });
 
   assert.deepEqual(context.spokenAskItems, ["item-1"]);
+  // A committed turn's words are on their way to a transcript; nothing about
+  // this path is a discard.
+  assert.equal(context.spokenAskDiscards(), 0);
 });
 
 test("the developer's spoken words preview as they are transcribed", async () => {

--- a/apps/desktop/src/renderer/voice/conversation-call.test.ts
+++ b/apps/desktop/src/renderer/voice/conversation-call.test.ts
@@ -467,6 +467,10 @@ test("an abandoned captured turn clears the buffer and settles the seam", async 
     2,
   );
   assert.equal(types.includes(REALTIME_CLIENT_EVENT.INPUT_AUDIO_BUFFER_COMMIT), false);
+  // The abandon is the one discard: the clear that opened the turn cleared an
+  // empty buffer, and words already mid-flight to a commit are not this
+  // press's to take down.
+  assert.equal(context.spokenAskDiscards(), 1);
 
   // A chunk from the capture the session already let go of goes nowhere.
   const sentBefore = context.sent.length;

--- a/apps/desktop/src/renderer/voice/conversation-call.ts
+++ b/apps/desktop/src/renderer/voice/conversation-call.ts
@@ -107,6 +107,12 @@ export interface ConversationCallOptions extends SpeakOnlyCallOptions {
   onSpokenAskClosed?(): void;
   /** The server item that fixes which current-launch history a spoken turn belongs to. */
   onSpokenAskCommitted?(itemId: string): void;
+  /**
+   * The held turn's audio was abandoned before any commit: no item will ever
+   * be named for it, so the words its live transcription already previewed
+   * belong to nothing and must leave.
+   */
+  onSpokenAskDiscarded?(): void;
 }
 
 /** The developer's words as the voice handed them to the brain, or nothing worth asking. */
@@ -333,6 +339,7 @@ export class ConversationCall extends SpeakOnlyCall<ConversationCallOptions> {
       this.#microphone.enabled = false;
       if (!commit) {
         this.send(clearInputAudioEvents());
+        this.options.onSpokenAskDiscarded?.();
         this.setStatus(REALTIME_STATUS.READY);
         return;
       }
@@ -344,6 +351,7 @@ export class ConversationCall extends SpeakOnlyCall<ConversationCallOptions> {
     this.#microphone.enabled = false;
     if (!commit) {
       this.send(clearInputAudioEvents());
+      this.options.onSpokenAskDiscarded?.();
       // Settling to READY is what releases the device: nothing is coming
       // that its closing could talk over.
       this.setStatus(REALTIME_STATUS.READY);

--- a/apps/desktop/src/testing/conversation-call-harness.ts
+++ b/apps/desktop/src/testing/conversation-call-harness.ts
@@ -81,6 +81,8 @@ export interface Harness {
   spokenAskItems: string[];
   /** Number of local audio turns closed before the server acknowledged them. */
   spokenAskClosures: () => number;
+  /** Number of held turns abandoned before any commit could name their item. */
+  spokenAskDiscards: () => number;
   microphoneEnabled: () => boolean;
   microphoneStopped: () => boolean;
   emit: (event: JsonValue) => void;
@@ -166,6 +168,7 @@ export function harness(
   const spokenAskFailures: string[] = [];
   const spokenAskItems: string[] = [];
   let spokenAskClosures = 0;
+  let spokenAskDiscards = 0;
   const requests: { apiKey: string; model: string; url: string }[] = [];
   const calls: string[] = [];
   let enabled = false;
@@ -372,6 +375,9 @@ export function harness(
       spokenAskClosures += 1;
     },
     onSpokenAskCommitted: (itemId) => spokenAskItems.push(itemId),
+    onSpokenAskDiscarded: () => {
+      spokenAskDiscards += 1;
+    },
   };
   if (options.connectTimeoutMs !== undefined) {
     sessionOptions.connectTimeoutMs = options.connectTimeoutMs;
@@ -406,6 +412,7 @@ export function harness(
     spokenAskFailures,
     spokenAskItems,
     spokenAskClosures: () => spokenAskClosures,
+    spokenAskDiscards: () => spokenAskDiscards,
     microphoneEnabled: () => enabled,
     microphoneStopped: () => stopped,
     lukeAudible: () => remoteTrack.enabled,

--- a/packages/voice/src/orchestrator/conversation-thread.test.ts
+++ b/packages/voice/src/orchestrator/conversation-thread.test.ts
@@ -199,6 +199,47 @@ test("a discarded turn takes its live words with it, sparing a turn already comm
   );
 });
 
+test("words whose first delta lands after the release survive the next press's discard", () => {
+  const { subject } = thread();
+  subject.seed([]);
+  // Turn one is released before its transcription says a word: the first
+  // delta arrives with only the commit in flight, so it can only be that
+  // commit's — never the next held turn's to discard.
+  subject.openTurn();
+  subject.closeTurn();
+  subject.previewSpokenAsk("item-1", "first ask");
+  subject.openTurn();
+
+  subject.discardTurn();
+
+  assert.deepEqual([...subject.previews.values()], ["first ask"]);
+  subject.commitTurn("item-1");
+  subject.rememberSpokenAsk("first ask", "item-1");
+  assert.deepEqual(
+    subject.entries.map((entry) => entry.words),
+    ["first ask"],
+  );
+});
+
+test("a discarded turn's stragglers cannot outlive the turns in flight", () => {
+  const { subject } = thread();
+  subject.seed([]);
+  // A discarded turn's cleared audio can still flush a delta while the next
+  // turn's commit is out. No commit will ever name its item, so once every
+  // turn in flight has settled, the words it drew must leave rather than
+  // stream forever.
+  subject.openTurn();
+  subject.discardTurn();
+  subject.openTurn();
+  subject.closeTurn();
+  subject.previewSpokenAsk("item-stray", "never mind");
+  subject.previewSpokenAsk("item-2", "second ask");
+
+  subject.commitTurn("item-2");
+
+  assert.deepEqual([...subject.previews.values()], ["second ask"]);
+});
+
 test("a failed transcription takes its live words with it", () => {
   const { subject } = thread();
   subject.seed([]);

--- a/packages/voice/src/orchestrator/conversation-thread.test.ts
+++ b/packages/voice/src/orchestrator/conversation-thread.test.ts
@@ -140,6 +140,76 @@ test("a spoken ask lands where its turn happened, not where its transcript did",
   );
 });
 
+test("the developer's words draw live from the sentence's front, hold through the commit", () => {
+  const { subject } = thread();
+  subject.seed([]);
+  subject.openTurn();
+  // The live transcription model streams the sentence's front while the talk
+  // key is still held — before the commit has named the turn's item. Refusing
+  // those deltas would stream every spoken bubble from its back.
+  subject.previewSpokenAsk("item-1", "how is");
+  assert.deepEqual([...subject.previews.values()], ["how is"]);
+  subject.closeTurn();
+  subject.previewSpokenAsk("item-1", " the checkout");
+  subject.commitTurn("item-1");
+  subject.previewSpokenAsk("item-1", " agent doing?");
+
+  assert.deepEqual([...subject.previews.values()], ["how is the checkout agent doing?"]);
+});
+
+test("words no turn could own draw nothing", () => {
+  const { subject } = thread();
+  subject.seed([]);
+  // No press opened a turn, so these words are a straggler's — an item from
+  // before a Clear, or another session's leak — and preview nothing.
+  subject.previewSpokenAsk("item-1", "how is");
+  assert.equal(subject.previews.size, 0);
+
+  subject.openTurn();
+  subject.previewSpokenAsk("item-2", "how is");
+  subject.clear();
+  // The Clear retired the held turn: its item's commit finds no mark and its
+  // preview is already gone.
+  assert.equal(subject.previews.size, 0);
+  subject.commitTurn("item-2");
+  assert.equal(subject.previews.size, 0);
+});
+
+test("a discarded turn takes its live words with it, sparing a turn already committed", () => {
+  const { subject } = thread();
+  subject.seed([]);
+  // Turn one: spoken, released, commit sent; its transcription still streams.
+  subject.openTurn();
+  subject.previewSpokenAsk("item-1", "first ask");
+  subject.closeTurn();
+  // Turn two: spoken into and abandoned before any commit.
+  subject.openTurn();
+  subject.previewSpokenAsk("item-2", "never mind");
+
+  subject.discardTurn();
+
+  // Turn one's words are mid-flight to their `committed`; only the held
+  // turn's words had no item coming.
+  assert.deepEqual([...subject.previews.values()], ["first ask"]);
+  subject.commitTurn("item-1");
+  subject.rememberSpokenAsk("first ask", "item-1");
+  assert.deepEqual(
+    subject.entries.map((entry) => entry.words),
+    ["first ask"],
+  );
+});
+
+test("a failed transcription takes its live words with it", () => {
+  const { subject } = thread();
+  subject.seed([]);
+  subject.openTurn();
+  subject.previewSpokenAsk("item-1", "how is");
+  subject.closeTurn();
+  subject.dropPreview("item-1");
+
+  assert.equal(subject.previews.size, 0);
+});
+
 test("a run accepted after the transcript is still tied to the words actually said", () => {
   const { subject } = thread();
   subject.seed([]);

--- a/packages/voice/src/orchestrator/conversation-thread.ts
+++ b/packages/voice/src/orchestrator/conversation-thread.ts
@@ -99,6 +99,20 @@ export class ConversationThread {
    * recorded, or by leaving alone when nothing ever will.
    */
   #previews: ReadonlyMap<string, string> = NO_SPOKEN_ASK_PREVIEWS;
+  /**
+   * The previewed items no commit has named yet. The live transcription model
+   * streams the developer's words while they are still speaking — before the
+   * commit names the item the turn travels as, so before any mark can key
+   * them — and those words draw live like any others: refusing them would
+   * stream every spoken bubble from its tail. What an unnamed item cannot do
+   * is settle — no completed transcript ever comes for a discarded turn — so
+   * each is tracked here until its commit arrives, and a discard takes the
+   * held turn's entries out of the previews instead of leaving them streaming
+   * forever. `closed` says the turn's commit has been sent, which is what
+   * spares an item mid-flight to its `committed` from a discard that can only
+   * mean the turn still being held.
+   */
+  readonly #uncommitted = new Map<string, { closed: boolean }>();
   /** The generation of the developer-opened turn whose reply is still in flight. */
   #replyGeneration: number | undefined;
   /** The Conversation generation in which the current announcement began speaking. */
@@ -197,6 +211,7 @@ export class ConversationThread {
     // The previews go with the marks: a transcription still arriving belongs
     // to a turn the press just retired.
     this.#previews = NO_SPOKEN_ASK_PREVIEWS;
+    this.#uncommitted.clear();
     this.#replyGeneration = undefined;
     this.#announcementGeneration = undefined;
     this.#changed();
@@ -230,13 +245,40 @@ export class ConversationThread {
     const mark = this.#activeMark;
     this.#activeMark = undefined;
     if (mark) this.#pendingMarks.push(mark);
+    // Every item streaming now was spoken into a turn whose commit is out:
+    // a later discard is about a newer turn, not these.
+    for (const entry of this.#uncommitted.values()) entry.closed = true;
   }
 
   /** The server named the item one closed turn travels as. */
   commitTurn(itemId: string): void {
+    this.#uncommitted.delete(itemId);
     const mark = this.#pendingMarks.shift();
     if (mark) this.#marks.set(itemId, mark);
     this.#latestMark = mark;
+    // A commit with no turn left to claim it — one from before a Clear — has
+    // no mark to settle its preview through, so the preview leaves now rather
+    // than streaming for a transcript the recording path would refuse.
+    if (!mark) this.dropPreview(itemId);
+  }
+
+  /**
+   * The held turn was discarded — its audio abandoned before any commit — so
+   * the words already transcribed from it belong to no item a commit will
+   * ever name, and the previews they drew leave now. An item whose turn's
+   * commit is out keeps streaming: its `committed` is on its way.
+   */
+  discardTurn(): void {
+    this.#activeMark = undefined;
+    const held = [...this.#uncommitted].filter(([, entry]) => !entry.closed).map(([id]) => id);
+    if (held.length === 0) return;
+    const next = new Map(this.#previews);
+    for (const itemId of held) {
+      this.#uncommitted.delete(itemId);
+      next.delete(itemId);
+    }
+    this.#previews = next;
+    this.#options.onChanged();
   }
 
   /**
@@ -274,14 +316,24 @@ export class ConversationThread {
   }
 
   /**
-   * The same words while they are still arriving, previewed on the completed
-   * transcript's own terms: only a turn whose committed item holds a mark in
-   * the history generation still showing may draw, so a straggler after Clear
-   * previews nothing it could never record.
+   * The same words while they are still arriving, drawn live: the model
+   * transcribes the developer's speech as it is spoken, so the preview starts
+   * with the sentence's front while the talk key is still held. Words no turn
+   * could own — a straggler after Clear, with the marks and the held turn
+   * retired — preview nothing they could never record; words that merely
+   * outran their turn's commit draw now and are tracked until the commit
+   * names their item.
    */
   previewSpokenAsk(itemId: string, delta: string): void {
     const mark = this.#marks.get(itemId);
-    if (!mark || !conversationEntryBelongsToConversation(mark.generation, this.#generation)) return;
+    if (mark) {
+      if (!conversationEntryBelongsToConversation(mark.generation, this.#generation)) return;
+    } else if (this.#activeMark || this.#pendingMarks.length > 0) {
+      const entry = this.#uncommitted.get(itemId);
+      if (entry === undefined) this.#uncommitted.set(itemId, { closed: false });
+    } else {
+      return;
+    }
     const next = new Map(this.#previews);
     next.set(itemId, (next.get(itemId) ?? "") + delta);
     this.#previews = next;
@@ -289,6 +341,7 @@ export class ConversationThread {
   }
 
   dropPreview(itemId: string): void {
+    this.#uncommitted.delete(itemId);
     if (!this.#previews.has(itemId)) return;
     const next = new Map(this.#previews);
     next.delete(itemId);
@@ -298,9 +351,11 @@ export class ConversationThread {
 
   /**
    * The call gone takes its half-transcribed turns with it: no completed
-   * transcript can arrive to settle a preview, so none may keep streaming.
+   * transcript can arrive to settle a preview, so none may keep streaming —
+   * and no commit can arrive either, so nothing is left waiting for one.
    */
   clearPreviews(): void {
+    this.#uncommitted.clear();
     if (this.#previews === NO_SPOKEN_ASK_PREVIEWS) return;
     this.#previews = NO_SPOKEN_ASK_PREVIEWS;
     this.#options.onChanged();

--- a/packages/voice/src/orchestrator/conversation-thread.ts
+++ b/packages/voice/src/orchestrator/conversation-thread.ts
@@ -260,6 +260,12 @@ export class ConversationThread {
     // no mark to settle its preview through, so the preview leaves now rather
     // than streaming for a transcript the recording path would refuse.
     if (!mark) this.dropPreview(itemId);
+    // With no turn held and no commit in flight, an item still unnamed can
+    // never be named: a discarded turn's stragglers, misread as a turn that
+    // has now settled. Their previews leave rather than streaming forever.
+    if (!this.#activeMark && this.#pendingMarks.length === 0) {
+      for (const orphan of [...this.#uncommitted.keys()]) this.dropPreview(orphan);
+    }
   }
 
   /**
@@ -328,11 +334,14 @@ export class ConversationThread {
     const mark = this.#marks.get(itemId);
     if (mark) {
       if (!conversationEntryBelongsToConversation(mark.generation, this.#generation)) return;
-    } else if (this.#activeMark || this.#pendingMarks.length > 0) {
-      const entry = this.#uncommitted.get(itemId);
-      if (entry === undefined) this.#uncommitted.set(itemId, { closed: false });
-    } else {
-      return;
+    } else if (!this.#uncommitted.has(itemId)) {
+      // Whose turn a first unnamed delta belongs to is read off the lifecycle
+      // at its arrival: words while a turn is held are that turn's, and words
+      // with only a commit in flight can only be that commit's — born closed,
+      // so a discard of the next held turn cannot take them down.
+      if (this.#activeMark) this.#uncommitted.set(itemId, { closed: false });
+      else if (this.#pendingMarks.length > 0) this.#uncommitted.set(itemId, { closed: true });
+      else return;
     }
     const next = new Map(this.#previews);
     next.set(itemId, (next.get(itemId) ?? "") + delta);

--- a/packages/voice/src/orchestrator/voice-orchestrator.ts
+++ b/packages/voice/src/orchestrator/voice-orchestrator.ts
@@ -118,6 +118,7 @@ export interface ConversationCallHooks<Stream> extends SpeakOnlyCallHooks<Stream
   onSpokenAskFailed(itemId: string): void;
   onSpokenAskClosed(): void;
   onSpokenAskCommitted(itemId: string): void;
+  onSpokenAskDiscarded(): void;
 }
 
 /**
@@ -516,6 +517,7 @@ export class VoiceOrchestrator<Stream> {
       onSpokenAskFailed: (itemId) => this.#thread.dropPreview(itemId),
       onSpokenAskClosed: () => this.#thread.closeTurn(),
       onSpokenAskCommitted: (itemId) => this.#thread.commitTurn(itemId),
+      onSpokenAskDiscarded: () => this.#thread.discardTurn(),
     });
     return this.#conversationCall;
   }


### PR DESCRIPTION
## Summary

- Spoken bubbles streamed back to front: the live transcription model (`gpt-live-transcribe`, since #630) hands words over while the developer is still speaking, before the commit names the turn's item, and `previewSpokenAsk` refused every delta with no mark — so the sentence's front never drew and only the tail streamed in after release, with the completed transcript restoring the front last. Visible since #859 first let live preview lines reach the panels.
- Words now draw live from the sentence's front, from the moment they are transcribed, tracked as uncommitted until the server's `committed` names their item.
- The lifecycle the old refusal guarded against is solved instead of avoided: the call reports `onSpokenAskDiscarded` where a spoken-into turn is abandoned (`stopListening` without a commit), and the thread removes exactly the held turn's live words — sparing an item mid-flight to its `committed`, which a fresh press's buffer clear can no longer take down. A straggler after Clear still draws nothing, and a commit from before a Clear drops its preview rather than streaming for a transcript the recording path would refuse.

## Evidence

- Platform-independent checks: `./scripts/check.sh` passed (exit 0; voice 121/121, desktop 677/677, typechecks and builds clean)
- macOS Electron verification (`./scripts/verify.sh`): `not run` — authored in a Linux cloud workspace with no macOS host

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34424720384/artifacts/10132245100) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34424720384)

- Commit: `ab7d3dbad629a04e67acc3c707e042b05afd30c5`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

### Physical-device evidence

- Screenshot or screen recording: `not attached` — a spoken exchange needs a live microphone and key; one press-to-talk sentence shows the bubble streaming front-to-back from mid-hold
- Physical-notch check: `not performed`
- Device/display configuration: `not recorded`

## Notes

- Blockers or follow-up verification: worth one spoken sentence on a physical Mac (`./scripts/run.sh`) to see the live captioning end to end; the development trace will show delta timing relative to `input_audio_buffer.committed` if anything still looks off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/ae007168-85b3-41be-81ea-ecc5a40644c4)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)