### PR TITLE
feat(voice): hold a spoken turn's place in the thread until its first words

### DIFF
--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -573,7 +573,8 @@ export function App(): React.JSX.Element {
     requestMicrophoneAccess,
     clearConversationLines,
   } = useVoiceView();
-  const { voiceError, voiceNotice, talkOpening, liveConversationEntries } = voiceView;
+  const { voiceError, voiceNotice, talkOpening, liveConversationEntries, spokenAskPending } =
+    voiceView;
   // Whether a run of Luke's is still going, from the same records Conversation
   // draws its wait from: the strip's face, the stage's growth for the dots
   // beside it, and the thread's wait all read one answer.
@@ -1059,6 +1060,7 @@ export function App(): React.JSX.Element {
             writes={sessions.writes}
             conversationLines={state.conversation.entries}
             liveConversationEntries={liveConversationEntries}
+            spokenAskPending={spokenAskPending}
             onClearConversationConversation={clearConversationLines}
             brainRequests={brainRequests}
             onStopThinking={stopThinking}

--- a/apps/desktop/src/renderer/conversation-panel.test.ts
+++ b/apps/desktop/src/renderer/conversation-panel.test.ts
@@ -5,6 +5,7 @@ import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import {
   CONVERSATION_ENTRY_SPEAKER,
+  CONVERSATION_LISTENING_LABEL,
   CONVERSATION_THINKING_LABEL,
   ConversationClearButton,
   ConversationPanel,
@@ -70,6 +71,36 @@ test("an announcement shows its spoken transcript", () => {
   assert.match(markup, /data-speaker="luke"/);
   assert.match(markup, />Checkout is ready\.<\/p>/);
   assert.doesNotMatch(markup, /provider:|running:/);
+});
+
+test("a spoken turn still owed its words holds a sent bubble in the thread", () => {
+  const markup = renderToStaticMarkup(
+    createElement(ConversationPanel, {
+      entries: [],
+      spokenAskPending: true,
+      now: NOW,
+      ask: async () => undefined,
+      onAskEngaged: () => undefined,
+    }),
+  );
+
+  // The wait alone is a thread: a press into an empty conversation must be
+  // answered on screen, not by the empty state.
+  assert.match(markup, /data-speaker="you"/);
+  assert.match(markup, /conversation-listening/);
+  assert.match(markup, new RegExp(CONVERSATION_LISTENING_LABEL));
+  assert.doesNotMatch(markup, /No messages yet/);
+
+  const idle = renderToStaticMarkup(
+    createElement(ConversationPanel, {
+      entries: [],
+      spokenAskPending: false,
+      now: NOW,
+      ask: async () => undefined,
+      onAskEngaged: () => undefined,
+    }),
+  );
+  assert.doesNotMatch(idle, /conversation-listening/);
 });
 
 test("a reply keeps its lines through the thread and draws as the Markdown it was written in", () => {

--- a/apps/desktop/src/renderer/conversation-panel.tsx
+++ b/apps/desktop/src/renderer/conversation-panel.tsx
@@ -61,6 +61,9 @@ const timeBreakLabel = createConversationTimeBreakFormatter();
 /** What a reader is told of a run still going; the sighted read the face and the dots. */
 export const CONVERSATION_THINKING_LABEL = "Luke is thinking";
 
+/** What a reader is told while a spoken turn is still owed its first words. */
+export const CONVERSATION_LISTENING_LABEL = "Luke is listening";
+
 /** How long a run goes before the wait says how long it has been. */
 const THINKING_ELAPSED_AFTER_MS = 10_000;
 
@@ -120,6 +123,37 @@ function ConversationThinkingRow({
             {elapsed ? <span className="conversation-thinking-elapsed">{elapsed}</span> : null}
             <span className="visually-hidden" role="status">
               {CONVERSATION_THINKING_LABEL}
+            </span>
+          </span>
+        </span>
+      </div>
+    </li>
+  );
+}
+
+/**
+ * The developer's turn before its words arrive, in the sent bubble the
+ * transcript will fill: the press is heard the moment it lands, not seconds
+ * later when the transcription's first words come back. Three dots and no
+ * face — the face is Luke's own mark, and this turn is the developer's. It is
+ * presentation alone, drawn from the reported voice view and never entering
+ * the thread; the words that settle it arrive as a live line and then a
+ * recorded one, exactly as they always did.
+ */
+function ConversationListeningRow(): React.JSX.Element {
+  return (
+    <li
+      className="conversation-entry"
+      data-speaker={CONVERSATION_ENTRY_SPEAKER.YOU}
+      data-thinking="true"
+    >
+      <small className="visually-hidden">You</small>
+      <div className="conversation-message">
+        <span className="conversation-bubble">
+          <span className="conversation-listening">
+            <ThinkingDots />
+            <span className="visually-hidden" role="status">
+              {CONVERSATION_LISTENING_LABEL}
             </span>
           </span>
         </span>
@@ -281,6 +315,7 @@ export function ConversationPanel({
   entries,
   live = [],
   requests = [],
+  spokenAskPending = false,
   now,
   ask,
   onAskEngaged,
@@ -305,6 +340,12 @@ export function ConversationPanel({
    * bubbles they will settle into — words growing, no timestamp, no copy.
    */
   live?: readonly ConversationEntry[];
+  /**
+   * Whether a spoken turn is still owed its first words — being listened to,
+   * or committed with its transcription not yet streaming — so the thread
+   * holds the developer's place before anything is written.
+   */
+  spokenAskPending?: boolean;
   /** The same ask the sessions tab's composer carries: one conversation, reached from either tab. */
   ask: AskHandler;
   onAskEngaged: (engaged: boolean) => void;
@@ -323,12 +364,12 @@ export function ConversationPanel({
     pending.length > 0 ? Math.min(...pending.map((snapshot) => snapshot.acceptedAt)) : undefined;
 
   useEffect(() => {
-    // Reading the count binds the scroll to an append, a clear, or the wait
+    // Reading the count binds the scroll to an append, a clear, or a wait
     // arriving, not to an unrelated render of the same conversation.
-    if (entryCount === 0 && thinkingSince === undefined) return;
+    if (entryCount === 0 && thinkingSince === undefined && !spokenAskPending) return;
     const element = list.current;
     if (element) element.scrollTop = element.scrollHeight;
-  }, [entryCount, thinkingSince]);
+  }, [entryCount, thinkingSince, spokenAskPending]);
 
   useEffect(() => {
     // A streaming line only carries the reader along; unlike an append, it
@@ -340,7 +381,8 @@ export function ConversationPanel({
     if (fromTail <= STREAM_FOLLOW_SLACK_PX) element.scrollTop = element.scrollHeight;
   }, [liveLength]);
 
-  const thread = entries.length > 0 || live.length > 0 || thinkingSince !== undefined;
+  const thread =
+    entries.length > 0 || live.length > 0 || thinkingSince !== undefined || spokenAskPending;
 
   return (
     <section
@@ -380,8 +422,12 @@ export function ConversationPanel({
                   streaming
                 />
               ))}
-              {/* After the lines still being said: a spoken ask's own words
-                  stream in above the wait for their answer. */}
+              {/* After the lines still being said: the newest spoken turn's
+                  place, held while its first words are still on the service's
+                  clock. */}
+              {spokenAskPending ? <ConversationListeningRow /> : null}
+              {/* And then the wait for the answer: a spoken ask's own words
+                  stream in above it. */}
               {thinkingSince !== undefined ? (
                 <ConversationThinkingRow since={thinkingSince} now={now} />
               ) : null}

--- a/apps/desktop/src/renderer/panel-body.tsx
+++ b/apps/desktop/src/renderer/panel-body.tsx
@@ -193,6 +193,8 @@ export interface PanelBodyProps {
   conversationLines: readonly ConversationEntry[];
   /** The lines still being said, drawn under that thread while their words grow. */
   liveConversationEntries: readonly ConversationEntry[];
+  /** Whether a spoken turn is still owed its first words, so the thread holds its place. */
+  spokenAskPending: boolean;
   /** Clears that same thread from the view, Luke's next context, and the stored file. */
   onClearConversationConversation: () => void;
   /** The brain's runs, so Conversation draws Luke's turn while one is going and the composer offers its stop. */
@@ -250,6 +252,7 @@ export function PanelBody({
   writes,
   conversationLines,
   liveConversationEntries,
+  spokenAskPending,
   onClearConversationConversation,
   brainRequests,
   onStopThinking,
@@ -374,6 +377,7 @@ export function PanelBody({
         <ConversationPanel
           entries={conversationLines}
           live={liveConversationEntries}
+          spokenAskPending={spokenAskPending}
           requests={brainRequests}
           now={now}
           ask={ask}

--- a/apps/desktop/src/renderer/styles/conversation.css
+++ b/apps/desktop/src/renderer/styles/conversation.css
@@ -225,6 +225,23 @@
   height: 16px;
 }
 
+/* The developer's turn before its words arrive: a sent bubble in every
+   measure but its words, so the transcript streams in exactly where the wait
+   stood. Dots alone — the face is Luke's own mark — brightened to read
+   against the sent blue the way the words themselves do. */
+.conversation-listening {
+  display: inline-flex;
+  min-height: 32px;
+  align-items: center;
+  padding: 6px 12px;
+  border-radius: 15px 15px 5px 15px;
+  background: var(--message-sent);
+}
+
+.conversation-listening .thinking-dots i {
+  background: rgba(255, 255, 255, 0.98);
+}
+
 /* How long the run has been going, said only once it is worth saying. Plain
    text beside the reader's status line rather than inside it, so a count that
    moves every second is never read out every second. */

--- a/apps/desktop/src/shared/bridge.test.ts
+++ b/apps/desktop/src/shared/bridge.test.ts
@@ -222,13 +222,18 @@ const VOICE_VIEW = {
   talkOpening: false,
   lukeCaptions: ["Claude Code finished checkout."],
   liveConversationEntries: [{ kind: "reply", words: "Checkout is green.", recordedAt: 12 }],
+  spokenAskPending: false,
 };
 
-test("a voice view carries its six fields and nothing malformed", () => {
+test("a voice view carries its seven fields and nothing malformed", () => {
   assert.equal(BRIDGE.reportVoiceView.args([VOICE_VIEW, undefined]), true);
   assert.equal(BRIDGE.reportVoiceView.args([VOICE_VIEW]), false);
   assert.equal(BRIDGE.reportVoiceView.args([VOICE_VIEW, VOICE_VIEW]), false);
   assert.equal(BRIDGE.reportVoiceView.args([{ ...VOICE_VIEW, voiceStatus: 1 }, undefined]), false);
+  assert.equal(
+    BRIDGE.reportVoiceView.args([{ ...VOICE_VIEW, spokenAskPending: "yes" }, undefined]),
+    false,
+  );
 });
 
 test("an exchange kind rides a voice view only on an edge that opened one", () => {

--- a/apps/desktop/src/shared/messages/voice-view.ts
+++ b/apps/desktop/src/shared/messages/voice-view.ts
@@ -30,6 +30,12 @@ export interface VoiceView {
    * exactly the edges that carry a caption.
    */
   liveConversationEntries: readonly ConversationEntry[];
+  /**
+   * Whether a spoken turn is still owed its first words — being listened to,
+   * or committed with its transcription not yet streaming — so Conversation
+   * can hold the developer's place in the thread before anything is written.
+   */
+  spokenAskPending: boolean;
 }
 
 /**
@@ -79,6 +85,7 @@ export const IDLE_VOICE_VIEW: VoiceView = {
   talkOpening: false,
   lukeCaptions: undefined,
   liveConversationEntries: [],
+  spokenAskPending: false,
 };
 
 const REALTIME_STATUSES: ReadonlySet<string> = new Set(Object.values(REALTIME_STATUS));
@@ -99,6 +106,7 @@ export function isVoiceView(value: UnparsedWireValue): value is VoiceView & Wire
   if (!isOptionalWireString(value.voiceError) || !isOptionalWireString(value.voiceNotice))
     return false;
   if (!isWireBoolean(value.talkOpening)) return false;
+  if (!isWireBoolean(value.spokenAskPending)) return false;
   const captions = value.lukeCaptions;
   if (captions !== undefined && !(Array.isArray(captions) && captions.every(isWireString))) {
     return false;

--- a/packages/voice/src/orchestrator/conversation-thread.test.ts
+++ b/packages/voice/src/orchestrator/conversation-thread.test.ts
@@ -299,6 +299,32 @@ test("a discarded turn and a failed transcription each end their wait", () => {
   assert.equal(subject.awaitingSpokenWords, false);
 });
 
+test("a call gone retires the turns it can never settle", () => {
+  const { subject } = thread();
+  subject.seed([]);
+  // Two turns the dead call still owed: one committed and awaiting words, one
+  // released with its commit in flight.
+  subject.openTurn();
+  subject.closeTurn();
+  subject.commitTurn("item-1");
+  subject.openTurn();
+  subject.closeTurn();
+  assert.equal(subject.awaitingSpokenWords, true);
+
+  subject.callGone();
+
+  // Nothing is owed by a channel nothing more arrives over — so a later
+  // call going live cannot hold the wait up again on these leftovers.
+  assert.equal(subject.awaitingSpokenWords, false);
+  assert.equal(subject.previews.size, 0);
+  // Its stragglers preview nothing, and its stale pending turn does not hand
+  // its place to the next call's first commit.
+  subject.previewSpokenAsk("item-1", "how is");
+  assert.equal(subject.previews.size, 0);
+  subject.commitTurn("item-2");
+  assert.equal(subject.latestTurn, undefined);
+});
+
 test("a failed transcription takes its live words with it", () => {
   const { subject } = thread();
   subject.seed([]);

--- a/packages/voice/src/orchestrator/conversation-thread.test.ts
+++ b/packages/voice/src/orchestrator/conversation-thread.test.ts
@@ -240,6 +240,65 @@ test("a discarded turn's stragglers cannot outlive the turns in flight", () => {
   assert.deepEqual([...subject.previews.values()], ["second ask"]);
 });
 
+test("a spoken turn is awaited from the press until its first words", () => {
+  const { subject } = thread();
+  subject.seed([]);
+  assert.equal(subject.awaitingSpokenWords, false);
+  subject.openTurn();
+  assert.equal(subject.awaitingSpokenWords, true);
+  // The first words settle the wait; the bubble now speaks for the turn.
+  subject.previewSpokenAsk("item-1", "how is");
+  assert.equal(subject.awaitingSpokenWords, false);
+  subject.closeTurn();
+  subject.commitTurn("item-1");
+  assert.equal(subject.awaitingSpokenWords, false);
+  subject.rememberSpokenAsk("how is the checkout agent", "item-1");
+  assert.equal(subject.awaitingSpokenWords, false);
+});
+
+test("a silent turn is awaited through its commit and settles with its transcript", () => {
+  const { subject } = thread();
+  subject.seed([]);
+  subject.openTurn();
+  subject.closeTurn();
+  subject.commitTurn("item-1");
+  // No delta has arrived: the turn is committed and still owed its words.
+  assert.equal(subject.awaitingSpokenWords, true);
+  // Even an empty transcript ends the wait: nothing more is coming.
+  subject.rememberSpokenAsk("  ", "item-1");
+  assert.equal(subject.awaitingSpokenWords, false);
+});
+
+test("one turn streaming words does not hide a newer silent one", () => {
+  const { subject } = thread();
+  subject.seed([]);
+  subject.openTurn();
+  subject.closeTurn();
+  subject.commitTurn("item-1");
+  subject.previewSpokenAsk("item-1", "first ask");
+  assert.equal(subject.awaitingSpokenWords, false);
+  subject.openTurn();
+  assert.equal(subject.awaitingSpokenWords, true);
+});
+
+test("a discarded turn and a failed transcription each end their wait", () => {
+  const { subject } = thread();
+  subject.seed([]);
+  subject.openTurn();
+  assert.equal(subject.awaitingSpokenWords, true);
+  subject.discardTurn();
+  assert.equal(subject.awaitingSpokenWords, false);
+
+  subject.openTurn();
+  subject.closeTurn();
+  subject.commitTurn("item-1");
+  assert.equal(subject.awaitingSpokenWords, true);
+  // The service gave up: no words and no transcript are coming, so the mark
+  // retires with the preview rather than standing as a turn still owed.
+  subject.failTurn("item-1");
+  assert.equal(subject.awaitingSpokenWords, false);
+});
+
 test("a failed transcription takes its live words with it", () => {
   const { subject } = thread();
   subject.seed([]);

--- a/packages/voice/src/orchestrator/conversation-thread.ts
+++ b/packages/voice/src/orchestrator/conversation-thread.ts
@@ -390,15 +390,25 @@ export class ConversationThread {
   }
 
   /**
-   * The call gone takes its half-transcribed turns with it: no completed
-   * transcript can arrive to settle a preview, so none may keep streaming —
-   * and no commit can arrive either, so nothing is left waiting for one.
+   * The call gone takes its half-transcribed turns with it. Nothing more
+   * arrives over a dead channel — no delta, no commit, no completed
+   * transcript — so no preview may keep streaming, and no turn may keep
+   * standing as one still owed its words: a mark left behind would hold the
+   * wait up again the moment a later call went live, and a pending one would
+   * hand its old place in the thread to the next call's first turn.
    */
-  clearPreviews(): void {
+  callGone(): void {
+    const stood =
+      this.#previews !== NO_SPOKEN_ASK_PREVIEWS ||
+      this.#marks.size > 0 ||
+      this.#pendingMarks.length > 0 ||
+      this.#activeMark !== undefined;
     this.#uncommitted.clear();
-    if (this.#previews === NO_SPOKEN_ASK_PREVIEWS) return;
     this.#previews = NO_SPOKEN_ASK_PREVIEWS;
-    this.#options.onChanged();
+    this.#marks.clear();
+    this.#pendingMarks = [];
+    this.#activeMark = undefined;
+    if (stood) this.#options.onChanged();
   }
 
   /**

--- a/packages/voice/src/orchestrator/conversation-thread.ts
+++ b/packages/voice/src/orchestrator/conversation-thread.ts
@@ -230,6 +230,18 @@ export class ConversationThread {
     this.#publish();
   }
 
+  /**
+   * Whether a spoken turn is still owed its first words: more turns are in
+   * flight — held, commit out, or committed and awaiting transcription — than
+   * previews have words to show for them. It is a count rather than a flag so
+   * one turn streaming words does not hide that a newer, still-silent one is
+   * being listened to.
+   */
+  get awaitingSpokenWords(): boolean {
+    const turns = (this.#activeMark ? 1 : 0) + this.#pendingMarks.length + this.#marks.size;
+    return turns > this.#previews.size;
+  }
+
   /** The press opened a turn: where it belongs is where the thread stands now. */
   openTurn(): void {
     this.#activeMark = {
@@ -238,6 +250,7 @@ export class ConversationThread {
       recordedAt: this.#now(),
     };
     this.#replyGeneration = this.#activeMark.generation;
+    this.#options.onChanged();
   }
 
   /** The turn closed locally, before the server has named the item that carries it. */
@@ -277,13 +290,27 @@ export class ConversationThread {
   discardTurn(): void {
     this.#activeMark = undefined;
     const held = [...this.#uncommitted].filter(([, entry]) => !entry.closed).map(([id]) => id);
-    if (held.length === 0) return;
-    const next = new Map(this.#previews);
-    for (const itemId of held) {
-      this.#uncommitted.delete(itemId);
-      next.delete(itemId);
+    if (held.length > 0) {
+      const next = new Map(this.#previews);
+      for (const itemId of held) {
+        this.#uncommitted.delete(itemId);
+        next.delete(itemId);
+      }
+      this.#previews = next;
     }
-    this.#previews = next;
+    // Told even when nothing drew: the discarded turn was being listened to,
+    // and whoever draws that must hear it ended.
+    this.#options.onChanged();
+  }
+
+  /**
+   * The service gave up on the turn's transcription: no words and no completed
+   * transcript are coming, so the preview leaves and the turn's mark retires
+   * with it rather than standing as a turn still owed its words.
+   */
+  failTurn(itemId: string): void {
+    this.#marks.delete(itemId);
+    this.dropPreview(itemId);
     this.#options.onChanged();
   }
 
@@ -301,6 +328,10 @@ export class ConversationThread {
     this.dropPreview(itemId);
     const mark = this.#marks.get(itemId);
     this.#marks.delete(itemId);
+    // The retired mark ends a turn that may have been the last one awaiting
+    // its words, which is a change whoever draws the wait has to hear even
+    // when no line lands below.
+    if (mark) this.#options.onChanged();
     if (!mark || !conversationEntryBelongsToConversation(mark.generation, this.#generation)) return;
     const placed = insertSpokenAskThreadEntry(
       this.#entries,

--- a/packages/voice/src/orchestrator/voice-orchestrator.ts
+++ b/packages/voice/src/orchestrator/voice-orchestrator.ts
@@ -514,7 +514,7 @@ export class VoiceOrchestrator<Stream> {
         ),
       onSpokenAsk: (transcript, itemId) => this.#thread.rememberSpokenAsk(transcript, itemId),
       onSpokenAskDelta: (itemId, delta) => this.#thread.previewSpokenAsk(itemId, delta),
-      onSpokenAskFailed: (itemId) => this.#thread.dropPreview(itemId),
+      onSpokenAskFailed: (itemId) => this.#thread.failTurn(itemId),
       onSpokenAskClosed: () => this.#thread.closeTurn(),
       onSpokenAskCommitted: (itemId) => this.#thread.commitTurn(itemId),
       onSpokenAskDiscarded: () => this.#thread.discardTurn(),
@@ -890,6 +890,9 @@ export class VoiceOrchestrator<Stream> {
         captions: this.#caption.texts,
       }),
       liveConversationEntries: this.#liveEntries(),
+      // Gated by the same survival rule as the previews: a call gone can
+      // deliver no words, so nothing is awaited from it.
+      spokenAskPending: spokenAskPreviewSurvives(this.#status) && this.#thread.awaitingSpokenWords,
     };
   }
 

--- a/packages/voice/src/orchestrator/voice-orchestrator.ts
+++ b/packages/voice/src/orchestrator/voice-orchestrator.ts
@@ -753,8 +753,9 @@ export class VoiceOrchestrator<Stream> {
     this.#replyPlayer?.onStatus(status);
     this.#considerRestart();
     // The call gone takes its half-transcribed turns with it: no completed
-    // transcript can arrive to settle a preview, so none may keep streaming.
-    if (!spokenAskPreviewSurvives(status)) this.#thread.clearPreviews();
+    // transcript can arrive to settle a preview or end a wait, so none may
+    // keep streaming and none may keep standing as owed.
+    if (!spokenAskPreviewSurvives(status)) this.#thread.callGone();
     // Any settled status ends the wait the press started, however it ended,
     // unless the press is still owed a turn — a takeover passes through
     // Luke's own call settling on its way to the developer's.

--- a/packages/voice/src/orchestrator/voice-view-reporter.ts
+++ b/packages/voice/src/orchestrator/voice-view-reporter.ts
@@ -14,6 +14,12 @@ export interface VoiceViewReport {
   talkOpening: boolean;
   lukeCaptions: readonly string[] | undefined;
   liveConversationEntries: readonly ConversationEntry[];
+  /**
+   * Whether a spoken turn is still owed its first words — being listened to,
+   * or committed with its transcription not yet streaming — so Conversation
+   * can hold the developer's place in the thread before anything is written.
+   */
+  spokenAskPending: boolean;
 }
 
 /**
@@ -42,7 +48,8 @@ function sameVoiceView(left: VoiceViewReport, right: VoiceViewReport): boolean {
     left.voiceNotice === right.voiceNotice &&
     left.talkOpening === right.talkOpening &&
     left.lukeCaptions === right.lukeCaptions &&
-    left.liveConversationEntries === right.liveConversationEntries
+    left.liveConversationEntries === right.liveConversationEntries &&
+    left.spokenAskPending === right.spokenAskPending
   );
 }
 


### PR DESCRIPTION
## Summary

- Follow-up to #899. A press now answers on screen immediately: while a spoken turn is still owed its first words — being listened to, or committed with its transcription not yet streaming — Conversation draws a sent-side bubble with the thinking row's three rising dots where the transcript will fill, so live transcription's first-word latency no longer reads as a press that did nothing. A "Luke is listening" status line speaks for readers.
- The wait is a count, not a flag: `ConversationThread.awaitingSpokenWords` compares turns in flight (held, commit out, committed awaiting words) against previews with words, so one turn streaming cannot hide a newer, still-silent one. It settles with the turn's first delta, its transcript, a discard, a failure, or the call going.
- A failed transcription now retires its mark along with its preview (`failTurn`), rather than standing forever as a turn still owed its words.
- The flag rides the voice view report as `spokenAskPending`, gated by the same call-survival rule as the previews, with the wire guard extended.

## Evidence

- Platform-independent checks: `./scripts/check.sh` passed (exit 0; voice 128/128, desktop 688/688, typechecks and builds clean)
- macOS Electron verification (`./scripts/verify.sh`): `not run` — authored in a Linux cloud workspace with no macOS host

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34425979206/artifacts/10132716271) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34425979206)

- Commit: `b573ecdb56a192256c2f4eb1605c56c31ca399f0`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

### Physical-device evidence

- Screenshot or screen recording: `not attached` — the indicator needs a live spoken exchange; one press shows the dots from the press until the first words replace them in place
- Physical-notch check: `not performed`
- Device/display configuration: `not recorded`

## Notes

- Blockers or follow-up verification: worth one spoken sentence on a physical Mac to see the dots appear at the press and dissolve into the streaming transcript.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/ae007168-85b3-41be-81ea-ecc5a40644c4)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)