### PR TITLE
fix(brain): wake the brain for cloud sessions too

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -232,7 +232,13 @@ Canonical commands:
   scheduled: the observation entry and the advanced capture cursor land in
   one save into the conversation's durable inbox, and the turn that follows
   consumes the entries it opened with at its checkpoint, moving the consumed
-  cursor there and only there. The two cursors are two on purpose: a
+  cursor there and only there. Which sessions are looked at is the host's
+  decision, local or cloud alike: every session working or waiting now, and
+  every one whose conversation already stands. A session whose provider
+  answers no incremental read (a Conductor chat today) is looked at from its
+  roster fields alone — the look itself reads no message of it — and the
+  turn it opens may read that chat's tail only through the same
+  `read_transcript` tool a developer's ask is offered, under the rule above. The two cursors are two on purpose: a
   throttled or failed inference leaves every entry standing for the next
   turn, a crash between capture and run loses nothing and reads nothing
   twice, and a relaunch runs what was captured without touching a

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -41,9 +41,10 @@ session, which keeps no transcript on your Mac, the same "read the recent
 tail" ask reads the newest page of that chat's conversation from Conductor
 instead — your own messages and the agent's replies, not its tool activity —
 using the Conductor key you gave the Mac app, only for a session Luke was just
-shown, and never on his periodic look; what he reads is held in that turn's
-working memory and stored nowhere else. Nothing else reads message history, file
-contents, or command output. If you run
+shown, and only inside a turn: one you opened, or one a status change on that
+chat woke; the periodic look itself reads no message of any chat. What he
+reads is held in that turn's working memory and stored nowhere else. Nothing
+else reads message history, file contents, or command output. If you run
 agents inside the Herdr terminal manager, Luke also asks Herdr's own
 command-line tool which of those sessions it holds, so their rows can say so;
 that read never starts Herdr, reads no terminal output, and sends nothing
@@ -311,11 +312,15 @@ Conductor key and have signed in within the last 7 days, our service reads
 your Conductor sessions on its own schedule, about once a minute, the same
 read-only pass the iOS app used to ask for on demand: your open workspaces,
 their chats, each chat's status, the agent kind running it, and the error
-line it stopped on. It never reads a chat's messages. We keep the latest
-roster it read, encrypted at rest with the same server-only secret as your
-keys, and beside it what changed since the pass before — a session that
-appeared or vanished, a status that moved, an error line that changed — so
-Luke can later be woken by a change rather than by a clock, and so the phone
+line it stopped on. It never reads a chat's messages. On your Mac, a status
+change on a Conductor chat wakes Luke's judgment for that chat the way a
+change on a local session does; that turn may read the chat's recent messages
+under the "read the recent tail" terms above, and the pass itself still reads
+none. We keep the latest roster it read, encrypted at rest with the same
+server-only secret as your keys, and beside it what changed since the pass
+before — a session that appeared or vanished, a status that moved, an error
+line that changed — so Luke can later be woken by a change rather than by a
+clock, and so the phone
 and watch can later be shown your sessions without asking Conductor again;
 today they still ask Conductor directly. The roster and its changes are
 replaced on every pass; nothing older is kept.

--- a/packages/brain/src/acceptance.test.ts
+++ b/packages/brain/src/acceptance.test.ts
@@ -52,7 +52,7 @@ import {
   type UnparsedWireValue,
   type WireRecord,
 } from "@sidecar/wire";
-import { BrainAgent, type BrainAgentOptions } from "./agent.js";
+import { BrainAgent, type BrainAgentOptions, LOOK_SUBJECT } from "./agent.js";
 import { toolLoopRuntimeOver } from "./builtins.js";
 import { ResponsesContextEngine } from "./context-engine.js";
 import { HostedModelAdapter } from "./hosted-model-adapter.js";
@@ -278,6 +278,7 @@ function host(
   });
   const agent = new BrainAgent({
     runtime: runtimeOver(model),
+    observes: { kind: LOOK_SUBJECT.NONE },
     prepareTurn: () => ({ prompt: "instructions", layers: {} }),
     actions: {
       perform: async (call) => {

--- a/packages/brain/src/agent-flush.test.ts
+++ b/packages/brain/src/agent-flush.test.ts
@@ -15,7 +15,12 @@ import {
   type ModelResponse,
 } from "@sidecar/runtime/vocabulary";
 import { ACTION_RESULT_STATUS, type WireRecord } from "@sidecar/wire";
-import { BrainAgent, type BrainFlushInput, type BrainFlushMarkerStore } from "./agent.js";
+import {
+  BrainAgent,
+  type BrainFlushInput,
+  type BrainFlushMarkerStore,
+  LOOK_SUBJECT,
+} from "./agent.js";
 import { ResponsesContextEngine } from "./context-engine.js";
 import {
   BRAIN_REQUEST_ORIGIN,
@@ -153,6 +158,7 @@ function agentWith(
   });
   const agent = new BrainAgent({
     runtime,
+    observes: { kind: LOOK_SUBJECT.NONE },
     prepareTurn: () => ({ prompt: "flush test", layers: {} }),
     actions: { perform: async () => ({ status: ACTION_RESULT_STATUS.ACCEPTED }) },
     roster: () => ({ text: "", identities: [] }),

--- a/packages/brain/src/agent.ts
+++ b/packages/brain/src/agent.ts
@@ -55,7 +55,7 @@ import {
 } from "./turn.js";
 import { type BrainOpeningNotes, TurnRunner } from "./turn-runner.js";
 import type { BrainDelivery, BrainTurnReport, BrainWakeEvent } from "./wake-events.js";
-import { LOOK_SUBJECT, type LookSubject, WakeCapture } from "./wakes.js";
+import { type LookSubject, WakeCapture } from "./wakes.js";
 
 export type { BrainRequestsListener } from "./asks.js";
 export type { BrainCompletionDelivery } from "./children.js";
@@ -119,11 +119,10 @@ export interface BrainAgentOptions {
   lane?: BrainLane;
   openingNotes?: BrainOpeningNotes;
   /**
-   * Which sessions this conversation's roster look reads, so two
-   * conversations never read each other's transcript. Absent, the look reads
-   * every local session that is working, waiting, or read before.
+   * Which session this conversation's roster look reads, so two conversations
+   * never read each other's transcript: its one observed session, or none.
    */
-  observes?: LookSubject;
+  observes: LookSubject;
   /**
    * Set when this conversation is a child's: how deep it is. Every turn is
    * then prepared as a child's — the minimal profile, the child restriction
@@ -310,7 +309,7 @@ export class BrainAgent {
     });
     this.#wakes = new WakeCapture({
       seam,
-      subject: options.observes ?? { kind: LOOK_SUBJECT.ROSTER },
+      subject: options.observes,
       roster: options.roster,
       readTranscriptSince: options.readTranscriptSince,
       createRunId: options.createRunId,

--- a/packages/brain/src/compaction.test.ts
+++ b/packages/brain/src/compaction.test.ts
@@ -12,7 +12,7 @@ import {
   TRANSCRIPT_EVENT_KIND,
 } from "@sidecar/runtime/vocabulary";
 import { ACTION_RESULT_STATUS, type WireRecord } from "@sidecar/wire";
-import { BrainAgent } from "./agent.js";
+import { BrainAgent, LOOK_SUBJECT } from "./agent.js";
 import {
   assessCompaction,
   COMPACTION_NEED,
@@ -295,6 +295,7 @@ function agentOver(model: ModelAdapter, repository: FakeBrainStateRepository) {
   const reports: string[] = [];
   const agent = new BrainAgent({
     runtime,
+    observes: { kind: LOOK_SUBJECT.NONE },
     prepareTurn: () => ({ prompt: "instructions", layers: {} }),
     actions: { perform: async () => ({ status: ACTION_RESULT_STATUS.ACCEPTED }) },
     roster: () => ({ text: "none", identities: [] }),

--- a/packages/brain/src/guarantees.test.ts
+++ b/packages/brain/src/guarantees.test.ts
@@ -147,7 +147,9 @@ test("the effective tool policy fixes the schemas and the gate, and nothing the 
  * `turn.ts`'s `runOriginOf`, read at every turn's opening.
  */
 test("an action in a turn the developer did not open is Luke's own", async () => {
-  const h = harness();
+  const h = harness({
+    roster: () => ({ text: "one", identities: [ABC], sessions: [session(ABC.providerSessionId)] }),
+  });
   await h.agent.wake([edge(ABC)]);
   await h.clock.advance(NOW + 3_000);
   await h.agent.rosterLook();

--- a/packages/brain/src/harness.ts
+++ b/packages/brain/src/harness.ts
@@ -31,7 +31,7 @@ import {
   type SessionProvider,
 } from "@sidecar/session";
 import { ACTION_RESULT_STATUS, isRecord, isWireString, type WireRecord } from "@sidecar/wire";
-import { BRAIN_DEFAULTS, BrainAgent, type BrainAgentOptions } from "./agent.js";
+import { BRAIN_DEFAULTS, BrainAgent, type BrainAgentOptions, LOOK_SUBJECT } from "./agent.js";
 import { ResponsesContextEngine } from "./context-engine.js";
 import { type BrainPersistedState, MAXIMUM_TERMINAL_REQUESTS } from "./envelope.js";
 import type { BrainActionExecution, BrainActionPerformer } from "./performer.js";
@@ -330,6 +330,7 @@ export function harness(
   const agent = new BrainAgent({
     runtime,
     prepareTurn: PLAIN_PREPARATION,
+    observes: { kind: LOOK_SUBJECT.SESSION, identity: ABC },
     actions: {
       perform: async (functionCall, execution) => {
         performed.push(functionCall);
@@ -656,6 +657,7 @@ export function agentOn(runtime: ToolLoopAgentRuntime, h: Harness) {
   return new BrainAgent({
     runtime,
     prepareTurn: PLAIN_PREPARATION,
+    observes: { kind: LOOK_SUBJECT.NONE },
     actions: { perform: async () => ({ status: ACTION_RESULT_STATUS.ACCEPTED }) },
     roster: () => ({ text: "", identities: [] }),
     standingContext: () => "",
@@ -672,17 +674,19 @@ export function agentOn(runtime: ToolLoopAgentRuntime, h: Harness) {
 }
 
 /**
- * A conversation held busy by a roster look. A look's turn takes no steered
- * words, so asks made while it stands wait in the queue for a turn of their
- * own; releasing ends the look, which drains what waited into one turn.
- * `inner.inputs[0]` is the look; the drained turn is the one after it.
+ * A conversation held busy by an observation turn: a hold's release, which
+ * opens a turn over no inbox entry, so nothing is left owed when the turn is
+ * cut short. An observation turn takes no steered words, so asks made while
+ * it stands wait in the queue for a turn of their own; releasing ends the
+ * turn, which drains what waited into one turn. `inner.inputs[0]` is the
+ * observation turn; the drained turn is the one after it.
  */
 export async function reviewing(...replies: readonly BrainClientAnswer[]) {
   const inner = new FakeClient();
   const gated = gatedClient(inner);
   const h = harness({ client: gated.client });
   inner.answers.push(answered([message("nothing spoken")]), ...replies);
-  await h.agent.rosterLook();
+  h.agent.releaseHeld([{ briefing: "held", decidedAt: NOW }]);
   await settle();
   return {
     h,

--- a/packages/brain/src/ledger.test.ts
+++ b/packages/brain/src/ledger.test.ts
@@ -3,7 +3,7 @@ import test from "node:test";
 import { RESPONSES_INPUT_ITEM_TYPE } from "@sidecar/hosted";
 import { RUN_ORIGIN } from "@sidecar/runtime/vocabulary";
 import { ACTION_RESULT_STATUS, isWireString, type WireRecord } from "@sidecar/wire";
-import { BrainAgent } from "./agent.js";
+import { BrainAgent, LOOK_SUBJECT } from "./agent.js";
 import { type BrainPersistedState, freshBrainState } from "./envelope.js";
 import {
   ABC,
@@ -35,6 +35,7 @@ import {
   RECORD_CAP,
   runtimeOver,
   seededRequests,
+  session,
   settle,
   submissionsIssued,
   submit,
@@ -266,6 +267,7 @@ test("stop settles only after a held acceptance, which the successor then finds 
   const successorModel = adapterOf(new FakeClient());
   const successor = new BrainAgent({
     runtime: runtimeOver(successorModel),
+    observes: { kind: LOOK_SUBJECT.NONE },
     prepareTurn: PLAIN_PREPARATION,
     actions: { perform: async () => ({ status: ACTION_RESULT_STATUS.ACCEPTED }) },
     roster: () => ({ text: "", identities: [] }),
@@ -547,7 +549,9 @@ test("two different markers saved concurrently both survive, in either order, on
 });
 
 test("an ordinary observation checkpoint composed behind a held mark keeps the mark", async () => {
-  const h = harness();
+  const h = harness({
+    roster: () => ({ text: "one", identities: [ABC], sessions: [session(ABC.providerSessionId)] }),
+  });
   const runId = await completedRun(h);
   const releaseWrite = h.repository.hold();
   const marking = h.agent.markConversationRecorded(runId, NOW + 1);

--- a/packages/brain/src/observation-inbox.test.ts
+++ b/packages/brain/src/observation-inbox.test.ts
@@ -3,10 +3,13 @@ import test from "node:test";
 import { RESPONSES_INPUT_ITEM_TYPE } from "@sidecar/hosted";
 import {
   normalizeSession,
+  type ProviderSessionObservation,
   type ProviderTranscriptSinceResult,
   SESSION_COMPLETION_CAUSE,
+  SESSION_LOCATION,
   SESSION_STATUS,
   type SessionIdentity,
+  type SessionStatus,
 } from "@sidecar/session";
 import { ACTION_RESULT_STATUS, unparsedWire, wireRecord } from "@sidecar/wire";
 import { type BrainAgentOptions, LOOK_SUBJECT } from "./agent.js";
@@ -128,31 +131,40 @@ test("stop opens nothing more, and a captured observation stays for the next age
   });
 });
 
-test("a roster look carries only the transcripts that grew, never the roster", async () => {
-  const working = session("abc", { status: SESSION_STATUS.WORKING });
-  const settled = session("def", { status: SESSION_STATUS.COMPLETE, lastActivityAt: NOW - 60_000 });
-  const cloud = normalizeSession(
-    { id: "conductor", displayName: "Conductor" },
-    {
-      providerSessionId: "cloud-1",
-      title: "Conductor: cloud",
-      status: SESSION_STATUS.WORKING,
-      lastActivityAt: NOW,
-      location: "cloud",
-    },
-  );
+const CONDUCTOR = { id: "conductor", displayName: "Conductor" };
+const CLOUD: SessionIdentity = { providerId: CONDUCTOR.id, providerSessionId: "cloud-1" };
+
+function cloudSession(overrides: Partial<ProviderSessionObservation> = {}) {
+  return normalizeSession(CONDUCTOR, {
+    providerSessionId: CLOUD.providerSessionId,
+    title: "Conductor: cloud",
+    status: SESSION_STATUS.WORKING,
+    lastActivityAt: NOW,
+    location: SESSION_LOCATION.CLOUD,
+    ...overrides,
+  });
+}
+
+const NO_TRANSCRIPT: ProviderTranscriptSinceResult = {
+  status: ACTION_RESULT_STATUS.UNSUPPORTED,
+  reason: "This provider keeps no transcript this build can read.",
+};
+
+test("a look at a cloud session reads its roster fields alone, carrying an unsupported, empty delta", async () => {
   const read: string[] = [];
   const h = harness({
+    observes: { kind: LOOK_SUBJECT.SESSION, identity: CLOUD },
     roster: () => ({
-      text: "Currently observed sessions:\n- abc\n- def\n- cloud-1",
-      identities: [ABC, DEF, { providerId: "conductor", providerSessionId: "cloud-1" }],
-      sessions: [working, settled, cloud],
+      text: "Currently observed sessions:\n- abc\n- cloud-1",
+      identities: [ABC, CLOUD],
+      sessions: [session("abc", { status: SESSION_STATUS.WORKING }), cloudSession()],
     }),
     readTranscriptSince: async (identity): Promise<ProviderTranscriptSinceResult> => {
       read.push(identity.providerSessionId);
+      if (identity.providerId === CONDUCTOR.id) return NO_TRANSCRIPT;
       return {
         status: ACTION_RESULT_STATUS.ACCEPTED,
-        text: identity.providerSessionId === "abc" ? "assistant: still going" : "",
+        text: "assistant: still going",
         cursor: `${identity.providerSessionId}-cursor`,
         truncated: false,
       };
@@ -161,40 +173,91 @@ test("a roster look carries only the transcripts that grew, never the roster", a
   h.agent.rosterLook();
   await settle();
 
+  // The cloud session is the only one read, through the same seam a local
+  // one is, and the provider's refusal is a defined delta rather than a
+  // reason to capture nothing.
+  assert.deepEqual(read, ["cloud-1"]);
   assert.equal(h.client.inputs.length, 1);
-  const input = h.client.inputs[0] ?? [];
-  const opening = itemText(itemsOfType(input, RESPONSES_INPUT_ITEM_TYPE.MESSAGE)[0]);
+  const entry = h.persisted[0]?.inbox[0];
+  assert.equal(entry?.providerSessionId, "cloud-1");
+  assert.deepEqual(entry?.delta, {
+    text: "",
+    truncated: false,
+    status: ACTION_RESULT_STATUS.UNSUPPORTED,
+  });
+  assert.equal(entry?.cursor, undefined);
+  const opening = itemText((h.client.inputs[0] ?? [])[0]);
   assert.ok(opening.startsWith(`${BRAIN_INPUT_MARKER.OBSERVED_EVENTS} `));
   const body = wireRecord(unparsedWire(JSON.parse(opening.slice(opening.indexOf("\n") + 1))));
-  assert.ok(body);
-  // The roster rides in the standing context of the same request, so the
-  // opening item repeats neither it nor a flag naming the look.
-  assert.equal(body.scheduled_roster_look, undefined);
-  assert.equal(body.roster, undefined);
-  // Only the working local session's transcript is carried: the settled one
-  // had no cursor and nothing live, the cloud one is not read on a look, and
-  // a delta that came back empty is left out rather than reported as news.
-  assert.ok(Array.isArray(body.events));
+  assert.ok(body && Array.isArray(body.events));
   assert.equal(body.events.length, 1);
   const only = wireRecord(unparsedWire(body.events[0]));
   assert.equal(only?.kind, BRAIN_WAKE_KIND.ROSTER);
-  assert.equal(only?.provider_session_id, "abc");
-  assert.deepEqual(read, ["abc"]);
+  assert.equal(only?.provider_id, CONDUCTOR.id);
+  assert.equal(only?.provider_session_id, "cloud-1");
+  assert.equal(wireRecord(unparsedWire(only?.transcript_delta))?.status, "unsupported");
+  assert.equal(wireRecord(unparsedWire(only?.session))?.status, SESSION_STATUS.WORKING);
+  assert.ok(!opening.includes("still going"));
   assert.equal(h.traces[0]?.trigger, BRAIN_TURN_TRIGGER.ROSTER);
+  await h.agent.stop();
+});
 
-  // The look can be triggered again by the host.
+test("a cloud session seen working and then reported failed opens a look for the edge", async () => {
+  let current = cloudSession();
+  const h = harness({
+    observes: { kind: LOOK_SUBJECT.SESSION, identity: CLOUD },
+    roster: () => ({ text: "roster", identities: [CLOUD], sessions: [current] }),
+    readTranscriptSince: async () => NO_TRANSCRIPT,
+  });
+  h.client.answers.push(answered([message("")]), answered([message("")]));
+  h.agent.rosterLook();
+  await settle();
+  assert.equal(h.client.inputs.length, 1);
+
+  current = cloudSession({
+    status: SESSION_STATUS.ERROR,
+    detail: { error: "The agent stopped on an error." },
+  });
   h.agent.rosterLook();
   await settle();
   assert.equal(h.client.inputs.length, 2);
+  const entry = h.persisted
+    .flatMap((state) => state.inbox)
+    .find((captured) => captured.session?.status === SESSION_STATUS.ERROR);
+  assert.ok(entry);
+  assert.equal(entry.session?.error, "The agent stopped on an error.");
+  const second = (h.client.inputs[1] ?? []).map(itemText).join("\n");
+  assert.ok(second.includes(`"status":"${SESSION_STATUS.ERROR}"`));
+  assert.ok(second.includes("The agent stopped on an error."));
+  await h.agent.stop();
+});
+
+test("two identical cloud looks capture once", async () => {
+  const h = harness({
+    observes: { kind: LOOK_SUBJECT.SESSION, identity: CLOUD },
+    roster: () => ({ text: "roster", identities: [CLOUD], sessions: [cloudSession()] }),
+    readTranscriptSince: async () => NO_TRANSCRIPT,
+  });
+  h.client.answers.push(answered([message("")]));
+  h.agent.rosterLook();
+  await settle();
+  assert.equal(h.client.inputs.length, 1);
+  const captures = h.persisted.length;
+  h.agent.rosterLook();
+  await settle();
+  assert.equal(h.persisted.length, captures);
+  assert.equal(h.client.inputs.length, 1);
+  assert.equal(h.agent.pendingWakes(), 0);
   await h.agent.stop();
 });
 
 test("a roster look is skipped while the client is quiet or a turn is in flight", async () => {
+  let status: SessionStatus = SESSION_STATUS.WORKING;
   const h = harness({
     roster: () => ({
       text: "roster",
       identities: [ABC],
-      sessions: [session("abc", { status: SESSION_STATUS.WORKING })],
+      sessions: [session("abc", { status })],
     }),
   });
 
@@ -225,7 +288,8 @@ test("a roster look is skipped while the client is quiet or a turn is in flight"
   await settle();
   assert.equal(h.client.inputs.length, 1);
 
-  // After the turn completes, the look proceeds.
+  // After the turn completes, a look that finds the session moved proceeds.
+  status = SESSION_STATUS.WAITING;
   h.agent.rosterLook();
   await settle();
   assert.equal(h.client.inputs.length, 2);

--- a/packages/brain/src/turn-runner.ts
+++ b/packages/brain/src/turn-runner.ts
@@ -76,12 +76,11 @@ import {
   type TurnResult,
   turnRevoked,
 } from "./turn.js";
-import {
-  BRAIN_WAKE_KIND,
-  type BrainDelivery,
-  type BrainTurnNotice,
-  type BrainTurnReport,
-  type BrainWakeEvent,
+import type {
+  BrainDelivery,
+  BrainTurnNotice,
+  BrainTurnReport,
+  BrainWakeEvent,
 } from "./wake-events.js";
 
 /**
@@ -534,16 +533,11 @@ export class TurnRunner {
       // host has already withdrawn; the cursors go back with the context.
       failure = revocation();
     } else {
-      // A scheduled look carries the whole roster in its own words, so a
-      // session whose transcript gained nothing is left out of the events
-      // rather than repeated as an empty delta.
-      const events =
-        plan.trigger === BRAIN_TURN_TRIGGER.ROSTER
-          ? attachedDeltas.events.filter(
-              (event) =>
-                event.kind !== BRAIN_WAKE_KIND.ROSTER || Boolean(event.transcriptDelta?.text),
-            )
-          : attachedDeltas.events;
+      // A look's event is news by the time it is here — the capture already
+      // dropped a look over a session that gained nothing and stood unchanged
+      // — so an empty delta is kept beside the session fields that moved,
+      // which for a provider answering no incremental read is all a look has.
+      const events = attachedDeltas.events;
       // Every turn advances its rollback point: each answered effect is
       // checkpointed and the mark moves past it, so a later failure returns
       // the context to the last paired state and never to before an action that

--- a/packages/brain/src/wakes.ts
+++ b/packages/brain/src/wakes.ts
@@ -1,12 +1,5 @@
-import {
-  type ProviderTranscriptSinceResult,
-  SESSION_LOCATION,
-  SESSION_STATUS,
-  type Session,
-  type SessionIdentity,
-} from "@sidecar/session";
+import type { ProviderTranscriptSinceResult, Session, SessionIdentity } from "@sidecar/session";
 import { ACTION_RESULT_STATUS } from "@sidecar/wire";
-import type { TranscriptCursors } from "./cursors.js";
 import { BRAIN_DEFAULTS } from "./defaults.js";
 import type { Generation } from "./generation.js";
 import { wakeInputText } from "./input-items.js";
@@ -28,14 +21,13 @@ import { BRAIN_WAKE_KIND, type BrainTranscriptDelta, type BrainWakeEvent } from 
 import { WakeQueue } from "./wake-queue.js";
 
 /**
- * Which sessions a conversation's own roster look reads. It is a fact of the
+ * Which session a conversation's own roster look reads. It is a fact of the
  * conversation, fixed when its agent is built: an observed conversation names
- * its one session and can read no other's transcript, main's ordinary
- * conversation reads none on a look at all, and the whole local roster is
- * what a conversation with no host to narrow it reads.
+ * its one session and can read no other's transcript, and main's ordinary
+ * conversation reads none on a look at all. Which sessions are looked at is
+ * the host's decision, made before it calls `rosterLook()` on a conversation.
  */
 export const LOOK_SUBJECT = {
-  ROSTER: "roster",
   NONE: "none",
   SESSION: "session",
 } as const;
@@ -43,7 +35,6 @@ export const LOOK_SUBJECT = {
 export type LookSubjectKind = (typeof LOOK_SUBJECT)[keyof typeof LOOK_SUBJECT];
 
 export type LookSubject =
-  | { readonly kind: typeof LOOK_SUBJECT.ROSTER }
   | { readonly kind: typeof LOOK_SUBJECT.NONE }
   | { readonly kind: typeof LOOK_SUBJECT.SESSION; readonly identity: SessionIdentity };
 
@@ -145,20 +136,20 @@ export class WakeCapture {
   }
 
   /**
-   * One look at the whole roster, driven by the host's observation pass rather
-   * than an internal timer. Carries the roster as `list_sessions` renders it
-   * and, for every local session the brain has read before or that is working
-   * or waiting now, what its transcript gained since — sessions with nothing
-   * new are left out. Skipped while a turn is in flight or the model is
-   * quiet, because the next look reads the same deltas; pending hook wakes
-   * ride along rather than waiting for their own.
+   * One look at this conversation's session, driven by the host's observation
+   * pass rather than an internal timer. The host decides which sessions are
+   * looked at — local or cloud, working, waiting, or already followed — and
+   * the brain reads its one: what the session's transcript gained since the
+   * last look where the provider answers an incremental read, and its roster
+   * fields alone where it does not. Skipped while a turn is in flight or the
+   * model is quiet, because the next look reads the same deltas; pending hook
+   * wakes ride along rather than waiting for their own.
    */
   rosterLook(): Promise<void> {
     if (this.#seam.stopped()) return Promise.resolve();
     const generation = this.#seam.generation();
     if (!generation) return this.#seam.ready().then(() => this.rosterLook());
-    const roster = this.#options.roster();
-    const looks = this.#ownLooks(roster, generation.captureCursors, this.#seam.now());
+    const looks = this.#ownLooks(this.#options.roster(), this.#seam.now());
     // The look is captured before anything opens, like a hook: what each
     // session gained stands in the inbox with its cursor, and the turn that
     // follows — now, or the next one if the model is quiet or a turn is in
@@ -167,16 +158,7 @@ export class WakeCapture {
       if (this.#seam.stopped() || this.#options.turnInFlight()) return;
       if (generation !== this.#seam.generation()) return;
       if (this.#options.quietUntil() !== undefined) return;
-      // A conversation looking at everything still opens its look with no
-      // events, as the whole-roster look it is; one looking at its own
-      // session opens nothing when nothing was captured and nothing waits.
-      if (
-        this.#subject.kind !== LOOK_SUBJECT.ROSTER &&
-        captured === 0 &&
-        generation.inbox.length === 0
-      ) {
-        return;
-      }
+      if (captured === 0 && generation.inbox.length === 0) return;
       this.#queue.take();
       void this.#seam.queueTurn(BRAIN_TURN_TRIGGER.ROSTER, () =>
         this.#options.turn({
@@ -304,16 +286,15 @@ export class WakeCapture {
   }
 
   /**
-   * The sessions this conversation's own look reads, by its subject: its one
-   * observed session, every local session it has read before or that is live
-   * now, or nothing at all. A session another conversation observes is never
-   * among them, whatever the roster holds.
+   * The one event this conversation's look reads: its observed session as the
+   * roster holds it now, or nothing when the conversation observes none or
+   * the roster no longer holds its session. Whether the session is worth a
+   * look at all — live, or one already followed — was the host's test before
+   * it asked; repeating a narrower one here would only lose edges, such as a
+   * cloud chat's move from waiting to error. A session another conversation
+   * observes is never read, whatever the roster holds.
    */
-  #ownLooks(
-    roster: BrainRoster,
-    cursors: TranscriptCursors,
-    now: number,
-  ): readonly BrainWakeEvent[] {
+  #ownLooks(roster: BrainRoster, now: number): readonly BrainWakeEvent[] {
     const subject = this.#subject;
     if (subject.kind === LOOK_SUBJECT.NONE) return [];
     return (roster.sessions ?? []).flatMap((session) => {
@@ -321,13 +302,7 @@ export class WakeCapture {
         providerId: session.providerId,
         providerSessionId: session.providerSessionId,
       };
-      if (subject.kind === LOOK_SUBJECT.SESSION && !sameIdentity(subject.identity, identity)) {
-        return [];
-      }
-      const readBefore = cursors.cursor(identity) !== undefined;
-      const live =
-        session.status === SESSION_STATUS.WORKING || session.status === SESSION_STATUS.WAITING;
-      if (session.location !== SESSION_LOCATION.LOCAL || !(readBefore || live)) return [];
+      if (!sameIdentity(subject.identity, identity)) return [];
       return [{ kind: BRAIN_WAKE_KIND.ROSTER, identity, session, atMs: now }];
     });
   }

--- a/packages/host/src/brain/conversation-deletion.test.ts
+++ b/packages/host/src/brain/conversation-deletion.test.ts
@@ -12,6 +12,7 @@ import {
   type BrainPersistedState,
   type BrainStateRepository,
   BrainStateStore,
+  LOOK_SUBJECT,
   responsesModelAnswer,
   toolLoopRuntimeOver,
 } from "@sidecar/brain";
@@ -137,6 +138,7 @@ function composed(t: TestContext) {
   const build = (client: BareResponsesModel) => {
     const agent = new BrainAgent({
       runtime: toolLoopRuntimeOver(bareModelAdapter(client)),
+      observes: { kind: LOOK_SUBJECT.NONE },
       prepareTurn: () => ({ prompt: "instructions", layers: {} }),
       actions: { perform: async () => ({ status: ACTION_RESULT_STATUS.ACCEPTED }) },
       roster: () => ({ text: "- abc", identities: [] }),

--- a/packages/host/src/brain/wiring-routing.test.ts
+++ b/packages/host/src/brain/wiring-routing.test.ts
@@ -30,6 +30,7 @@ import {
 } from "@sidecar/runtime/vocabulary";
 import {
   normalizeSession,
+  SESSION_LOCATION,
   SESSION_STATUS,
   type Session,
   type SessionIdentity,
@@ -46,8 +47,10 @@ import { type BrainWiring, wireBrain } from "./wiring.js";
  */
 
 const claude: SessionProvider = { id: "claude-code", displayName: "Claude Code" };
+const conductor: SessionProvider = { id: "conductor", displayName: "Conductor" };
 const ABC: SessionIdentity = { providerId: claude.id, providerSessionId: "abc" };
 const DEF: SessionIdentity = { providerId: claude.id, providerSessionId: "def" };
+const CLOUD: SessionIdentity = { providerId: conductor.id, providerSessionId: "cloud-1" };
 const SECRET = (id: string) => `TRANSCRIPT_OF_${id}`;
 
 function session(id: string): Session {
@@ -56,6 +59,16 @@ function session(id: string): Session {
     title: `Claude Code: ${id}`,
     status: SESSION_STATUS.WORKING,
     lastActivityAt: 1_800_000_000_000,
+  });
+}
+
+function cloudSession(): Session {
+  return normalizeSession(conductor, {
+    providerSessionId: CLOUD.providerSessionId,
+    title: "Conductor: cloud",
+    status: SESSION_STATUS.WORKING,
+    lastActivityAt: 1_800_000_000_000,
+    location: SESSION_LOCATION.CLOUD,
   });
 }
 
@@ -218,13 +231,20 @@ function composed(t: TestContext, gate?: Gate): Composed {
     // The host decides what belongs in one conversation's standing context by
     // its key; this harness reports the key it was asked about.
     standingContext: (sessionKey) => `standing context for ${sessionKey}`,
-    pluginFor: () => ({
-      provider: claude,
+    pluginFor: (providerId) => ({
+      provider: providerId === conductor.id ? conductor : claude,
       observe: async () => [],
       latest: () => [],
       reads: {
         transcriptSince: async (providerSessionId: string, cursor?: string) => {
-          reads.push({ providerId: claude.id, providerSessionId });
+          reads.push({ providerId, providerSessionId });
+          // A cloud provider answers no incremental read; the look still opens.
+          if (providerId === conductor.id) {
+            return {
+              status: ACTION_RESULT_STATUS.UNSUPPORTED,
+              reason: "This provider keeps no transcript this build can read.",
+            };
+          }
           // The transcript grows once; every later read from the cursor finds
           // nothing new.
           return {
@@ -348,6 +368,48 @@ test("a roster look opens one conversation per observed session, each reading on
   await until(() => c.wiring.current(defKey) === undefined);
   assert.equal(c.wiring.current(defKey), undefined);
   assert.ok(c.wiring.current(abcKey));
+  c.wiring.retire();
+  await c.wiring.rebuild();
+});
+
+test("a roster look opens a cloud session's conversation like a local one, reads no message, and stands it down when the session leaves", async (t) => {
+  const c = composed(t);
+  c.roster.push(cloudSession());
+  await c.wiring.rebuild();
+  c.wiring.rosterLook();
+  await until(() => c.inputs.length >= 3 && c.wiring.pendingNotices().length === 3);
+  const cloudKey = observedSessionKey(CLOUD);
+  assert.ok(c.ensured.some((entry) => entry.sessionKey === cloudKey));
+  assert.ok(c.wiring.current(cloudKey));
+  // The cloud session's read went through its own provider and answered no
+  // transcript; its turn opened on the roster fields alone, and no other
+  // session's transcript reached its conversation.
+  assert.deepEqual(
+    c.reads.filter((identity) => identity.providerId === conductor.id),
+    [CLOUD],
+  );
+  const cloudInput = c.inputs.find((input) => itemTexts(input).join("\n").includes("cloud-1"));
+  assert.ok(cloudInput);
+  const cloudTexts = itemTexts(cloudInput).join("\n");
+  assert.ok(!cloudTexts.includes("TRANSCRIPT_OF"));
+  assert.ok(cloudTexts.includes(`standing context for ${cloudKey}`));
+  const cloudNotice = c.wiring
+    .pendingNotices()
+    .find((notice) => notice.label === "Conductor: cloud");
+  assert.ok(cloudNotice);
+  assert.equal(cloudNotice.trigger, BRAIN_TURN_TRIGGER.ROSTER);
+  // A second look at the unchanged cloud session opens no inference.
+  await c.wiring.rosterLook();
+  await pause(200);
+  assert.equal(c.inputs.length, 3);
+  // Gone from the roster, its idle conversation stands down like a local one's.
+  c.roster.splice(
+    c.roster.findIndex((held) => held.providerId === conductor.id),
+    1,
+  );
+  c.wiring.rosterLook();
+  await until(() => c.wiring.current(cloudKey) === undefined);
+  assert.ok(c.wiring.current(observedSessionKey(ABC)));
   c.wiring.retire();
   await c.wiring.rebuild();
 });

--- a/packages/host/src/brain/wiring.ts
+++ b/packages/host/src/brain/wiring.ts
@@ -84,7 +84,6 @@ import {
 import type { ConversationEntry } from "@sidecar/session";
 import {
   dispatchRead,
-  SESSION_LOCATION,
   SESSION_STATUS,
   type Session,
   type SessionIdentity,
@@ -824,7 +823,7 @@ export function wireBrain(dependencies: BrainWiringDependencies): BrainWiring {
       const live =
         session.status === SESSION_STATUS.WORKING || session.status === SESSION_STATUS.WAITING;
       const open = conversations.has(sessionKey);
-      if (session.location !== SESSION_LOCATION.LOCAL || !(live || open)) continue;
+      if (!(live || open)) continue;
       void openObserved(identity).then((agent) => agent?.rosterLook());
     }
     // A session the roster no longer holds has nothing left to observe: its

--- a/packages/host/src/testing/brain-harness.ts
+++ b/packages/host/src/testing/brain-harness.ts
@@ -7,6 +7,7 @@ import {
   DELIVERY_STATE,
   DeliveryLedger,
   type DeliveryRecord,
+  LOOK_SUBJECT,
   responsesModelAnswer,
   toolLoopRuntimeOver,
 } from "@sidecar/brain";
@@ -179,6 +180,7 @@ export function brainHarness() {
   const build = (client: BareResponsesModel, options: Partial<BrainAgentOptions> = {}) => {
     const model = bareModelAdapter(client);
     return new BrainAgent({
+      observes: { kind: LOOK_SUBJECT.NONE },
       ...options,
       runtime: toolLoopRuntimeOver(model),
       prepareTurn: () => ({ prompt: "instructions", layers: {} }),

--- a/packages/host/src/voice-credential-transition.test.ts
+++ b/packages/host/src/voice-credential-transition.test.ts
@@ -7,6 +7,7 @@ import {
   BrainAgent,
   BrainStateStore,
   hostedBrainToolCatalog,
+  LOOK_SUBJECT,
   toolLoopRuntimeOver,
 } from "@sidecar/brain";
 import { fakeBrainStateRepository } from "@sidecar/brain/testing";
@@ -137,6 +138,7 @@ function composition() {
       builds.push(model.model ?? "hosted");
       return new BrainAgent({
         runtime: toolLoopRuntimeOver(model),
+        observes: { kind: LOOK_SUBJECT.NONE },
         prepareTurn: () => ({ prompt: "instructions", layers: {} }),
         actions: { perform: async () => ({ status: "accepted" }) },
         roster: () => ({ text: "none", identities: [] }),


### PR DESCRIPTION
## Why

Luke observes Conductor every minute and the rows update, but he never announces a Conductor agent that needs attention. Two local-only gates kept the brain from ever being woken for a cloud session: the host's roster look opened an observed conversation only for a `location: local` session, and the brain's own look read only a local session it had read before or that was live. Every Conductor observation is stamped `cloud`, so no observation entry was ever captured and no turn ever opened.

## What changes

- **Host gate** (`packages/host/src/brain/wiring.ts`, `rosterLook`): the location clause is gone. `live || open` stays, so a cloud session opens its observed conversation while working or waiting and stands it down when it leaves the roster, exactly like a local one.
- **Brain gate** (`packages/brain/src/wakes.ts`): `#ownLooks` now finds the conversation's one session in the roster and emits one event for it. No location clause and no `readBefore || live`, since the host already applied its test before calling `rosterLook()`, and repeating a narrower one here only lost edges such as a cloud chat's `waiting → error` (a cloud session never gains a capture cursor because Conductor answers no `transcriptSince`).
- **Dead whole-roster mode removed**: `LOOK_SUBJECT.ROSTER` was used by no production conversation and survived only as the default when `observes` was omitted. `LOOK_SUBJECT` is now `{ NONE, SESSION }`, `observes` is required on `BrainAgentOptions`, and the "a conversation looking at everything still opens its look with no events" special case is gone.
- **One gap the plan's pipeline check missed** (`packages/brain/src/turn-runner.ts`): a roster-triggered turn filtered out any roster event whose delta had no text, on the grounds that the whole-roster look "carries the roster in its own words". With a single-session subject that filter would have opened every cloud look with an empty event list, so the status word never reached the observed-events item. The filter is removed; the capture's fingerprint already drops a look over a session that gained nothing and stood unchanged, so an event that reaches the turn is news.
- **Docs**: CLAUDE.md's "The brain and transcript reads" says the host decides which sessions are looked at, local or cloud alike, that a provider answering no incremental read is looked at from roster fields alone with the look itself reading no message, and that the turn may read the chat's tail only through `read_transcript`. PRIVACY.md's Conductor paragraphs say the same and no longer claim the tail is "never" read on the periodic look. AGENTS.md is the mirrored copy.

No prompt change in this PR.

## Why this causes no per-poll churn

`lookFingerprint` gates the turn on roster-field movement alone (status, hold, completion cause, `lastActivityAt`, activity, error). Conductor's `lastActivityAt` is the provider's own `updatedAt`/workspace timestamp and is not bumped per poll (`packages/providers/src/conductor/observe.ts`, covered by `observe.test.ts`), so a Conductor agent working steadily produces at most one roster turn per status edge, not one per minute. The fingerprint was not narrowed.

## Tests

- `packages/host/src/brain/wiring-routing.test.ts`: new case adds a cloud Conductor session to the roster and asserts its observed conversation opens, reads through its own provider (which answers unsupported), carries no other session's transcript, opens no inference on an unchanged second look, and stands down when the session leaves the roster.
- `packages/brain/src/observation-inbox.test.ts`: the old "cloud one is not read on a look" test is rewritten as a cloud-subject conversation whose look reads through `readTranscriptSince`, gets an unsupported answer, and captures an entry with an empty delta and status `unsupported`. New cases: a cloud session seen `working` then reported `error` with `detail.error` produces a look, an entry, and a turn carrying the error; two identical cloud looks capture once.
- Tests that relied on the removed roster default now name a subject (the brain harness defaults to `SESSION` on `abc`; the host harness to `NONE`). The `reviewing()` helper now holds a conversation busy with a hold-release turn instead of a roster look, because a look now captures an inbox entry that a stopped or store-refused turn never consumes.
- `guarantees.test.ts` invariants named in the plan pass unchanged.

## Verification

`./scripts/check.sh` on this branch: exit 0. Repository checks, Biome, typecheck, and build all clean. Test counts: brain 340 pass / 0 fail, host 285 / 0, providers 475 / 0; every other package 0 failures.

Not performed here (no Mac, no live Conductor key in this sandbox), and worth doing before merge:
- `./scripts/run.sh`, let a Conductor agent finish a turn on a question, confirm the development trace records a `roster`-triggered turn for `observed:conductor:<id>` with a `read_transcript` tool name and that an announcement is spoken; then a plain hand-off, and confirm the turn ran with no announcement.
- With a Conductor agent working steadily, confirm the trace shows at most one roster turn for it per status edge.

## Follow-ups (PR 2, in a separate session)

- Rewrite the stale rationale in `packages/providers/src/conductor/vocabulary.ts` that an idle Conductor chat is "not itself an ask" and "no notice speaks it": the brain can now be woken for it and read the tail through `read_transcript`.
- Prompt guidance so the brain reads one Conductor chat's tail when its look reports `waiting`, and decides whether the turn ended on a question or a plain hand-off before announcing.
- Reconcile the panel: the row's "Needs you" and the face's nudge are provider-blind (`apps/desktop/src/renderer/session-model.ts`), and should agree with what Luke now says.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/c3e08ed6-0f74-47a0-ac14-0d4b97be5849)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34425446393/artifacts/10132508056) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34425446393)

- Commit: `aee2d2f185c8a76113a3d7d3d3ef873e4e29d046`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
