### PR TITLE
feat(desktop): a chip naming a chat is the row's own press, and opens a chat the roster let go

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -170,9 +170,15 @@ Canonical commands:
   operating system, and nothing reaches the provider; an open asked of Luke
   still runs only under the effective tool policy, and a session that reported
   no address is offered nowhere to open. A Conversation line records the actions Luke
-  carried and the sessions they named, but draws no press of its own: a
-  session's address is reached by its row's press or by a validated ask in a
-  developer-opened turn, and by nothing else. A workspace Luke just
+  carried and the sessions they named, and the one press it draws is the
+  chip naming that session, which is the row's press by another hand: it
+  mints the same `session.open` act a row does, for the identity the line
+  recorded, and the host answers it from the roster as it stands or, for a
+  session the roster has since let go, from the address that session last
+  reported, which the host keeps in memory for the run and nowhere else. A
+  line that names no session — a workspace creation — draws no press. Beyond
+  that, a session's address is reached by its row's press or by a validated
+  ask in a developer-opened turn, and by nothing else. A workspace Luke just
   created opens itself the same way: the creation ask, already a
   developer-opened turn, is also the ask to be taken there, so the session id
   the provider's creation response named (the one thing read out of that
@@ -1231,7 +1237,8 @@ Canonical commands:
   no notice names a session, no chip previews an issue, and no press under
   the housing opens anything, so the words are the whole of what an
   announcement puts on screen, and a session's address is still reached only
-  by its row's press or a validated ask in a developer-opened turn.
+  by its row's press, the chip on one of its Conversation action lines, or a
+  validated ask in a developer-opened turn.
 
 Before handoff, run `./scripts/check.sh` for portable-only changes. For any
 macOS or UI change, `./scripts/verify.sh` is the completion invariant. Report

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -176,7 +176,9 @@ Canonical commands:
   recorded, and the host answers it from the roster as it stands or, for a
   session the roster has since let go, from the address that session last
   reported, which the host keeps in memory for the run and nowhere else. A
-  line that names no session — a workspace creation — draws no press. Beyond
+  workspace creation's line names the session the provider's creation answer
+  identified — an id and never an address — so its chip is that same press,
+  and a line that names no session draws none. Beyond
   that, a session's address is reached by its row's press or by a validated
   ask in a developer-opened turn, and by nothing else. A workspace Luke just
   created opens itself the same way: the creation ask, already a

--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -1052,6 +1052,7 @@ export function App(): React.JSX.Element {
             writes={sessions.writes}
             conversationLines={state.conversation.entries}
             roster={displaySessions(state)}
+            onOpenSessionIdentity={sessions.onOpenSessionIdentity}
             liveConversationEntries={liveConversationEntries}
             onClearConversationConversation={clearConversationLines}
             brainRequests={brainRequests}

--- a/apps/desktop/src/renderer/conversation-action.test.ts
+++ b/apps/desktop/src/renderer/conversation-action.test.ts
@@ -143,7 +143,19 @@ test("a creation names the workspace it made as a chip, with no roster to consul
   };
   const parts = actionRowParts(created, []);
   assert.equal(text(parts), "Created a new workspace Notch");
-  assert.deepEqual(parts?.[1], { text: "Notch", name: {} });
+  // Unobserved yet: named as the developer named it, under the agent's mark
+  // where the creation asked for one, else the provider's.
+  assert.deepEqual(parts?.[1], { text: "Notch", name: { markId: "codex" } });
+  assert.deepEqual(
+    actionRowParts({ ...created, action: { ...created.action, agentId: "claude" } }, [])?.[1],
+    { text: "Notch", name: { markId: "claude" } },
+  );
+  // Once the roster reports the workspace the line names, its chip is the row's.
+  const observed = actionRowParts(
+    { ...created, identity: { providerId: "codex", providerSessionId: "a" } },
+    [{ ...lisbon, title: "Notch panel clipping" }],
+  );
+  assert.deepEqual(observed?.[1], { text: "Notch panel clipping", name: { markId: "codex" } });
   assert.equal(
     text(actionRowParts({ ...created, action: { ...created.action, name: undefined } }, [])),
     "Created a new workspace",

--- a/apps/desktop/src/renderer/conversation-action.ts
+++ b/apps/desktop/src/renderer/conversation-action.ts
@@ -87,13 +87,19 @@ export function actionRowParts(
         ...(application === undefined ? [] : [{ text: ` in ${application}` }]),
       ];
     }
-    case ACTION_KIND.CREATE_WORKSPACE:
-      // The provider it landed in is the row's mark; the workspace is named
-      // as the developer named it, since the roster row it became is not tied
-      // back to this line.
-      return action.name === undefined
-        ? [{ text: "Created a new workspace" }]
-        : [{ text: "Created a new workspace " }, { text: action.name, name: {} }];
+    case ACTION_KIND.CREATE_WORKSPACE: {
+      // The workspace by the roster's name once observed, else as the
+      // developer named it, under the mark of the agent the creation asked
+      // for — or the provider's, where the choice was left to the provider.
+      const workspace = session
+        ? { text: session.title, name: { markId: session.agentId ?? session.providerId } }
+        : action.name === undefined
+          ? undefined
+          : { text: action.name, name: { markId: action.agentId ?? action.providerId } };
+      return workspace
+        ? [{ text: "Created a new workspace " }, workspace]
+        : [{ text: "Created a new workspace" }];
+    }
     case ACTION_KIND.ADD_AGENT:
       if (!chat || action.agent === undefined) return undefined;
       return [{ text: `Added a ${action.agent} agent to ` }, chat];

--- a/apps/desktop/src/renderer/conversation-panel.test.ts
+++ b/apps/desktop/src/renderer/conversation-panel.test.ts
@@ -150,6 +150,72 @@ test("an action row is worded from its record and the roster, and from its recor
   );
 });
 
+test("a chip naming a chat is the row's own press by identity, and a creation's chip is a name alone", () => {
+  const opened: { providerId: string; providerSessionId: string }[] = [];
+  const render = (entry: Parameters<typeof ConversationPanel>[0]["entries"][number]) =>
+    renderToStaticMarkup(
+      createElement(ConversationPanel, {
+        entries: [entry],
+        onOpenChat: (identity) => opened.push(identity),
+        now: NOW,
+        ask: async () => undefined,
+        onAskEngaged: () => undefined,
+      }),
+    );
+  // Named by the title the record kept: the roster has let this chat go, and
+  // the press still names it by identity for the host to answer.
+  const archived = render({
+    kind: CONVERSATION_ENTRY_KIND.ACTION,
+    words: 'archived "checkout-service"',
+    identity: { providerId: "claude-code", providerSessionId: "session-a" },
+    action: {
+      kind: ACTION_KIND.CONTROL,
+      runId: "run-1",
+      label: "Archive",
+      controlKind: "archive",
+      title: "checkout-service",
+    },
+  });
+  assert.match(
+    archived,
+    /<button type="button" class="conversation-action-chip" aria-label="Open checkout-service"><svg class="provider-mark conversation-chip-mark" data-mark="claude-code".*?<\/svg>checkout-service<\/button>/,
+  );
+  const creation = render({
+    kind: CONVERSATION_ENTRY_KIND.ACTION,
+    words: 'created a new workspace "Notch" in Conductor',
+    action: {
+      kind: ACTION_KIND.CREATE_WORKSPACE,
+      runId: "run-2",
+      providerId: "conductor",
+      name: "Notch",
+    },
+  });
+  assert.match(creation, /<span class="conversation-action-chip">Notch<\/span>/);
+  assert.doesNotMatch(creation, /<button type="button" class="conversation-action-chip"/);
+  // With no press to hand the chat to, every chip is a name.
+  const unpressable = renderToStaticMarkup(
+    createElement(ConversationPanel, {
+      entries: [
+        {
+          kind: CONVERSATION_ENTRY_KIND.ACTION,
+          words: 'archived "checkout-service"',
+          identity: { providerId: "claude-code", providerSessionId: "session-a" },
+          action: {
+            kind: ACTION_KIND.CONTROL,
+            runId: "run-1",
+            label: "Archive",
+            title: "checkout-service",
+          },
+        },
+      ],
+      now: NOW,
+      ask: async () => undefined,
+      onAskEngaged: () => undefined,
+    }),
+  );
+  assert.doesNotMatch(unpressable, /<button type="button" class="conversation-action-chip"/);
+});
+
 test("every row leads with its kind then the provider it reached, a creation with the one it asked", () => {
   const render = (entry: Parameters<typeof ConversationPanel>[0]["entries"][number]) =>
     renderToStaticMarkup(

--- a/apps/desktop/src/renderer/conversation-panel.test.ts
+++ b/apps/desktop/src/renderer/conversation-panel.test.ts
@@ -190,8 +190,24 @@ test("a chip naming a chat is the row's own press by identity, and a creation's 
       name: "Notch",
     },
   });
-  assert.match(creation, /<span class="conversation-action-chip">Notch<\/span>/);
+  assert.match(creation, /<span class="conversation-action-chip">.*?Notch<\/span>/);
   assert.doesNotMatch(creation, /<button type="button" class="conversation-action-chip"/);
+  // A creation whose line took the identity the provider named is pressable like any chat.
+  const landed = render({
+    kind: CONVERSATION_ENTRY_KIND.ACTION,
+    words: 'created a new workspace "Notch" in Conductor',
+    identity: { providerId: "conductor", providerSessionId: "created-1" },
+    action: {
+      kind: ACTION_KIND.CREATE_WORKSPACE,
+      runId: "run-2",
+      providerId: "conductor",
+      name: "Notch",
+    },
+  });
+  assert.match(
+    landed,
+    /<button type="button" class="conversation-action-chip" aria-label="Open Notch">/,
+  );
   // With no press to hand the chat to, every chip is a name.
   const unpressable = renderToStaticMarkup(
     createElement(ConversationPanel, {
@@ -236,7 +252,8 @@ test("every row leads with its kind then the provider it reached, a creation wit
     recorded,
     /class="conversation-action-mark"><svg class="provider-mark" data-mark="claude-code"/,
   );
-  // A creation has no session, so its line names the provider it asked.
+  // A creation that left the agent to the provider names the provider it asked
+  // on its chip, and the row's own mark stands down rather than repeat it.
   const creation = render({
     kind: CONVERSATION_ENTRY_KIND.ACTION,
     words: 'created a new workspace "Notch panel clipping" in Conductor',
@@ -247,15 +264,33 @@ test("every row leads with its kind then the provider it reached, a creation wit
       name: "Notch panel clipping",
     },
   });
+  assert.doesNotMatch(creation, /class="conversation-action-mark"><svg class="provider-mark"/);
   assert.match(
     creation,
+    /<span>Created a new workspace <\/span><span class="conversation-action-chip"><svg class="provider-mark conversation-chip-mark" data-mark="conductor".*?<\/svg>Notch panel clipping<\/span>/,
+  );
+  assert.doesNotMatch(creation, /in Conductor/);
+  // A creation that chose its agent wears that agent on the chip, so the
+  // provider it asked leads the row.
+  const agented = render({
+    kind: CONVERSATION_ENTRY_KIND.ACTION,
+    words: 'created a new workspace "Notch panel clipping" in Conductor',
+    action: {
+      kind: ACTION_KIND.CREATE_WORKSPACE,
+      runId: "run-2",
+      providerId: "conductor",
+      name: "Notch panel clipping",
+      agentId: "claude-code",
+    },
+  });
+  assert.match(
+    agented,
     /class="conversation-action-mark"><svg class="provider-mark" data-mark="conductor"/,
   );
   assert.match(
-    creation,
-    /<span>Created a new workspace <\/span><span class="conversation-action-chip">Notch panel clipping<\/span>/,
+    agented,
+    /class="conversation-action-chip"><svg class="provider-mark conversation-chip-mark" data-mark="claude-code"/,
   );
-  assert.doesNotMatch(creation, /in Conductor/);
   // A hosted chat's chip wears the agent's mark, so the row's provider mark still earns its place.
   const hosted = render({
     kind: CONVERSATION_ENTRY_KIND.ACTION,

--- a/apps/desktop/src/renderer/conversation-panel.tsx
+++ b/apps/desktop/src/renderer/conversation-panel.tsx
@@ -23,6 +23,7 @@ import {
   conversationEntryKey,
   SESSION_CONTROL_KIND,
   type SessionControlKind,
+  type SessionIdentity,
 } from "@sidecar/session";
 import { FACE_MOTION } from "@sidecar/surface";
 import { useEffect, useId, useRef, useState } from "react";
@@ -274,16 +275,20 @@ function ConversationMessageRow({
  * A line whose record cannot be read back to a row draws the words recorded
  * at the time instead. A line an earlier build recorded without its kind
  * draws with the mark's room left empty rather than guessing one. No copy
- * control: the words are a record of an act, not something said. A chip is a
- * name, not a press: a session's address is reached by its row or by a
- * validated ask, never from here.
+ * control: the words are a record of an act, not something said. The chip
+ * naming the chat is the row's own press by another hand: it mints the same
+ * open act a session row does, for the chat the line's identity names, so it
+ * opens the chat even once the roster has let it go. A creation's chip names
+ * a workspace the line never held an identity for, and is a name alone.
  */
 function ConversationActionRow({
   entry,
   sessions,
+  onOpenChat,
 }: {
   entry: ConversationEntry;
   sessions: readonly SessionView[];
+  onOpenChat?: (identity: SessionIdentity) => void;
 }): React.JSX.Element {
   const presentation = conversationEntryPresentation(entry.kind);
   const own = entry.kind === CONVERSATION_ENTRY_KIND.OWN_ACTION;
@@ -313,10 +318,13 @@ function ConversationActionRow({
           </span>
           {parts ? (
             <span className="conversation-words">
-              {parts.map((part, index) =>
-                part.name ? (
+              {parts.map((part, index) => {
+                if (!part.name) {
                   // biome-ignore lint/suspicious/noArrayIndexKey: The parts are a fixed composition of one record, so a position names a part for as long as the row stands.
-                  <span key={index} className="conversation-action-chip">
+                  return <span key={index}>{part.text}</span>;
+                }
+                const chip = (
+                  <>
                     {part.name.markId === undefined ? null : (
                       <ProviderMark
                         providerId={part.name.markId}
@@ -324,12 +332,27 @@ function ConversationActionRow({
                       />
                     )}
                     {part.text}
-                  </span>
+                  </>
+                );
+                const identity = entry.identity;
+                return identity && onOpenChat ? (
+                  <button
+                    // biome-ignore lint/suspicious/noArrayIndexKey: As above.
+                    key={index}
+                    type="button"
+                    className="conversation-action-chip"
+                    aria-label={`Open ${part.text}`}
+                    onClick={() => onOpenChat(identity)}
+                  >
+                    {chip}
+                  </button>
                 ) : (
                   // biome-ignore lint/suspicious/noArrayIndexKey: As above.
-                  <span key={index}>{part.text}</span>
-                ),
-              )}
+                  <span key={index} className="conversation-action-chip">
+                    {chip}
+                  </span>
+                );
+              })}
             </span>
           ) : (
             <MarkdownMessage words={entry.words} className="conversation-words" />
@@ -343,15 +366,21 @@ function ConversationActionRow({
 
 function ConversationEntryRow({
   sessions,
+  onOpenChat,
   ...props
 }: {
   entry: ConversationEntry;
   sessions: readonly SessionView[];
+  onOpenChat?: (identity: SessionIdentity) => void;
   streaming?: boolean;
 }): React.JSX.Element {
   return conversationEntryPresentation(props.entry.kind).speaker ===
     CONVERSATION_ENTRY_SPEAKER.EVENT ? (
-    <ConversationActionRow entry={props.entry} sessions={sessions} />
+    <ConversationActionRow
+      entry={props.entry}
+      sessions={sessions}
+      {...(onOpenChat ? { onOpenChat } : undefined)}
+    />
   ) : (
     <ConversationMessageRow {...props} />
   );
@@ -372,10 +401,12 @@ function ConversationEntryRow({
 function ConversationTurn({
   entries,
   sessions,
+  onOpenChat,
   pending,
 }: {
   entries: readonly KeyedConversationEntry[];
   sessions: readonly SessionView[];
+  onOpenChat?: (identity: SessionIdentity) => void;
   pending: boolean;
 }): React.JSX.Element {
   const [choice, setChoice] = useState<boolean | undefined>(undefined);
@@ -404,7 +435,12 @@ function ConversationTurn({
       </div>
       <ol id={actionsId} className="conversation-turn-actions" hidden={!open}>
         {entries.map(({ entry, key }) => (
-          <ConversationActionRow key={key} entry={entry} sessions={sessions} />
+          <ConversationActionRow
+            key={key}
+            entry={entry}
+            sessions={sessions}
+            {...(onOpenChat ? { onOpenChat } : undefined)}
+          />
         ))}
       </ol>
     </li>
@@ -541,6 +577,7 @@ export function ConversationPanel({
   live = [],
   requests = [],
   sessions = [],
+  onOpenChat,
   now,
   ask,
   onAskEngaged,
@@ -566,6 +603,11 @@ export function ConversationPanel({
    * it is called now and a creation its provider as the provider names itself.
    */
   sessions?: readonly SessionView[];
+  /**
+   * The row's own press by identity, for the chat an action line names. Absent
+   * where nothing can open one, and the chips are names alone.
+   */
+  onOpenChat?: (identity: SessionIdentity) => void;
   /**
    * The lines still being said, drawn under the settled thread as the same
    * bubbles they will settle into — words growing, no timestamp, no copy.
@@ -651,6 +693,7 @@ export function ConversationPanel({
                       key={`turn:${lead.key}`}
                       entries={item.items}
                       sessions={sessions}
+                      {...(onOpenChat ? { onOpenChat } : undefined)}
                       pending={turnPending(item.turn, index === items.length - 1)}
                     />,
                   );
@@ -661,6 +704,7 @@ export function ConversationPanel({
                     key={item.item.key}
                     entry={item.item.entry}
                     sessions={sessions}
+                    {...(onOpenChat ? { onOpenChat } : undefined)}
                   />,
                 );
               })}

--- a/apps/desktop/src/renderer/panel-body.tsx
+++ b/apps/desktop/src/renderer/panel-body.tsx
@@ -5,7 +5,7 @@ import {
   type AccountSnapshot,
 } from "@sidecar/credentials/snapshot";
 import { ProviderMark } from "@sidecar/panel";
-import type { ConversationEntry, SessionApplicationId } from "@sidecar/session";
+import type { ConversationEntry, SessionApplicationId, SessionIdentity } from "@sidecar/session";
 import { cssCustomProperties } from "@sidecar/surface/react-css";
 import { type AskHandler, AskLuke } from "./ask-luke";
 import { CalendarGate, type CalendarGateControl } from "./calendar-gate";
@@ -193,6 +193,8 @@ export interface PanelBodyProps {
   conversationLines: readonly ConversationEntry[];
   /** Every observed session, unnarrowed, for the thread to name the sessions its actions reached. */
   roster: readonly SessionView[];
+  /** The row's own press, by identity, for the chat a Conversation action line names. */
+  onOpenSessionIdentity: (identity: SessionIdentity) => void;
   /** The lines still being said, drawn under that thread while their words grow. */
   liveConversationEntries: readonly ConversationEntry[];
   /** Clears that same thread from the view, Luke's next context, and the stored file. */
@@ -252,6 +254,7 @@ export function PanelBody({
   writes,
   conversationLines,
   roster,
+  onOpenSessionIdentity,
   liveConversationEntries,
   onClearConversationConversation,
   brainRequests,
@@ -377,6 +380,7 @@ export function PanelBody({
         <ConversationPanel
           entries={conversationLines}
           sessions={roster}
+          onOpenChat={onOpenSessionIdentity}
           live={liveConversationEntries}
           requests={brainRequests}
           now={now}

--- a/apps/desktop/src/renderer/styles/conversation.css
+++ b/apps/desktop/src/renderer/styles/conversation.css
@@ -443,8 +443,10 @@
    box takes its first item's baseline, and the text is that item — so the
    name reads as a word of the sentence with a ground under it, and the box
    is one pixel over and under the line so it never pushes the lines apart.
-   It wears the mark its roster row wears. It is a name and not a press, so
-   it takes no hover. */
+   It wears the mark its roster row wears. Where the line holds the chat's
+   identity the chip is the row's own press by another hand and lifts under
+   the pointer; a creation's chip, naming a workspace the line has no identity
+   for, is a name alone. */
 .conversation-action-chip {
   display: inline-flex;
   align-items: center;
@@ -457,6 +459,12 @@
   line-height: 14px;
   vertical-align: baseline;
   white-space: nowrap;
+  transition: background-color var(--duration-hover) ease;
+}
+
+button.conversation-action-chip:hover,
+button.conversation-action-chip:focus-visible {
+  background: var(--selected);
 }
 
 .conversation-action-chip:has(.provider-mark) {

--- a/apps/desktop/src/renderer/use-session-list.ts
+++ b/apps/desktop/src/renderer/use-session-list.ts
@@ -3,6 +3,7 @@ import { CREDENTIAL_PROVIDERS, isCredentialProviderId } from "@sidecar/credentia
 import {
   type ObservedWorkspaceProject,
   type SessionApplicationId,
+  type SessionIdentity,
   workspaceProjectSelectionId,
 } from "@sidecar/session";
 import { APP_SETTING_SCHEMA } from "@sidecar/settings";
@@ -68,6 +69,12 @@ export interface SessionList {
   onViewChange: (next: SessionArrangement) => void;
   onFiltersChange: (filters: readonly SessionFilter[]) => void;
   onOpenSession: (session: SessionView) => void;
+  /**
+   * The same press by identity alone, for a chat named on one of Conversation's
+   * action lines: the roster may have let it go since, and the host still
+   * answers with the address it last reported.
+   */
+  onOpenSessionIdentity: (identity: SessionIdentity) => void;
   onOpenSessionApplication: (session: SessionView, applicationId: SessionApplicationId) => void;
   toggleOptions: () => void;
   closeOptions: () => void;
@@ -316,17 +323,17 @@ export function useSessionList(options: UseSessionListOptions): SessionList {
    * a shape that is no longer drawn, so the close is asked for here rather than
    * waited for.
    */
-  const onOpenSession = useCallback(
-    (session: SessionView) => {
-      tell(ACT_KIND.SESSION_OPEN, {
-        identity: {
-          providerId: session.providerId,
-          providerSessionId: session.id,
-        },
-      });
+  const onOpenSessionIdentity = useCallback(
+    (identity: SessionIdentity) => {
+      tell(ACT_KIND.SESSION_OPEN, { identity });
       dismissPanel();
     },
     [dismissPanel],
+  );
+  const onOpenSession = useCallback(
+    (session: SessionView) =>
+      onOpenSessionIdentity({ providerId: session.providerId, providerSessionId: session.id }),
+    [onOpenSessionIdentity],
   );
 
   /**
@@ -440,6 +447,7 @@ export function useSessionList(options: UseSessionListOptions): SessionList {
     onViewChange,
     onFiltersChange,
     onOpenSession,
+    onOpenSessionIdentity,
     onOpenSessionApplication,
     toggleOptions,
     closeOptions,

--- a/packages/actions/src/action-narration.ts
+++ b/packages/actions/src/action-narration.ts
@@ -154,10 +154,14 @@ const ACTION_RECORD = {
     ...(action.applicationId !== undefined ? { applicationId: action.applicationId } : undefined),
     ...observedTitle(action.identity, sessions),
   }),
-  [ACTION_KIND.CREATE_WORKSPACE]: (action) => ({
-    providerId: action.providerId,
-    ...(action.name !== undefined ? { name: action.name } : undefined),
-  }),
+  [ACTION_KIND.CREATE_WORKSPACE]: (action) => {
+    const agent = action.agent ?? action.agentSelection?.agent;
+    return {
+      providerId: action.providerId,
+      ...(action.name !== undefined ? { name: action.name } : undefined),
+      ...(agent !== undefined ? { agentId: agent } : undefined),
+    };
+  },
   [ACTION_KIND.ADD_AGENT]: (action, sessions) => ({
     agent: action.agent,
     ...(action.name !== undefined ? { name: action.name } : undefined),

--- a/packages/host/src/brain/action-performer.test.ts
+++ b/packages/host/src/brain/action-performer.test.ts
@@ -200,6 +200,33 @@ test("a session action reaches the performer only for a session the roster holds
   });
 });
 
+test("a creation's line names the session the provider made, and the model's answer does not", async () => {
+  const { actions, recorded } = performer({
+    workspaceProjects: () => [LISTED_PROJECT],
+    sessionActions: {
+      perform: async () => ({
+        status: ACTION_RESULT_STATUS.ACCEPTED,
+        createdSession: {
+          providerId: "conductor",
+          providerSessionId: "created-1",
+          agentId: "claude",
+        },
+      }),
+      openSession: async () => ({ status: ACTION_RESULT_STATUS.ACCEPTED }),
+      openSessionApplication: async () => ({ status: ACTION_RESULT_STATUS.ACCEPTED }),
+      openSessionChange: async () => ({ status: ACTION_RESULT_STATUS.ACCEPTED }),
+    },
+  });
+  const answer = await actions.perform(CREATE_CALL, LIVE);
+  assert.deepEqual(answer, { status: ACTION_RESULT_STATUS.ACCEPTED });
+  assert.equal(recorded.length, 1);
+  assert.deepEqual(recorded[0]?.identity, {
+    providerId: "conductor",
+    providerSessionId: "created-1",
+  });
+  assert.equal(recorded[0]?.action?.agentId, "claude");
+});
+
 test("a session action the provider refused leaves no line, and one whose answer never came back does", async () => {
   const refusing = performer({
     sessionActions: {

--- a/packages/host/src/brain/action-performer.ts
+++ b/packages/host/src/brain/action-performer.ts
@@ -25,11 +25,12 @@ import {
 } from "@sidecar/session";
 import {
   ACTION_RESULT_STATUS,
+  isRecord,
   isWireString,
   UNKNOWN_ACTION_STATUS,
   type WireRecord,
 } from "@sidecar/wire";
-import type { SessionActionPerformer } from "../session-action-performer.js";
+import { CREATED_SESSION_FIELD, type SessionActionPerformer } from "../session-action-performer.js";
 
 /** The developer's saved creation tie-breaks, as the projects context narrates them. */
 export interface WorkspaceCreationDefaults {
@@ -84,6 +85,24 @@ const REFUSAL = {
 
 function rejection(reason: string): WireRecord {
   return { status: ACTION_RESULT_STATUS.REJECTED, reason };
+}
+
+/** The session a creation's answer named, read back under the shape the host writes it in. */
+function createdSession(
+  value: WireRecord[string] | undefined,
+): { providerId: string; providerSessionId: string; agentId?: string } | undefined {
+  if (
+    !isRecord(value) ||
+    !isWireString(value.providerId) ||
+    !isWireString(value.providerSessionId)
+  ) {
+    return undefined;
+  }
+  return {
+    providerId: value.providerId,
+    providerSessionId: value.providerSessionId,
+    ...(isWireString(value.agentId) ? { agentId: value.agentId } : undefined),
+  };
 }
 
 /**
@@ -149,28 +168,39 @@ export function createBrainActionPerformer(
   ): Promise<WireRecord> => {
     // The performer awaits once more of its own before a create or a spawn,
     // so the execution rides along to be asked again there.
-    const result = await dependencies.sessionActions.perform(action, execution);
+    const { [CREATED_SESSION_FIELD]: created, ...answer } =
+      await dependencies.sessionActions.perform(action, execution);
     // The line records the act, in the past tense, so it is written once the
     // effect has settled: a provider that accepted it, or one whose answer
     // never came back, so the act may have landed. A provider that refused it
     // leaves no line — nothing was done — and the reply voicing the refusal is
     // recorded as what Luke said.
     if (
-      result.status === ACTION_RESULT_STATUS.ACCEPTED ||
-      result.status === UNKNOWN_ACTION_STATUS
+      answer.status === ACTION_RESULT_STATUS.ACCEPTED ||
+      answer.status === UNKNOWN_ACTION_STATUS
     ) {
-      dependencies.recordConversationEntry(
-        sessionActionConversationEntry(
-          action,
-          { sessions: dependencies.sessions(), projects: dependencies.workspaceProjects() },
-          execution.origin === RUN_ORIGIN.USER
-            ? CONVERSATION_ENTRY_KIND.ACTION
-            : CONVERSATION_ENTRY_KIND.OWN_ACTION,
-          execution.runId,
-        ),
+      const entry = sessionActionConversationEntry(
+        action,
+        { sessions: dependencies.sessions(), projects: dependencies.workspaceProjects() },
+        execution.origin === RUN_ORIGIN.USER
+          ? CONVERSATION_ENTRY_KIND.ACTION
+          : CONVERSATION_ENTRY_KIND.OWN_ACTION,
+        execution.runId,
       );
+      // A creation aims at no session, so its line takes the identity the
+      // provider's answer named — for the panel to name and open the workspace
+      // — and the model's answer keeps only what became of the ask.
+      const session = createdSession(created);
+      if (session) {
+        entry.identity = {
+          providerId: session.providerId,
+          providerSessionId: session.providerSessionId,
+        };
+        if (session.agentId !== undefined && entry.action) entry.action.agentId = session.agentId;
+      }
+      dependencies.recordConversationEntry(entry);
     }
-    return result;
+    return answer;
   };
 
   return {

--- a/packages/host/src/session-action-performer.test.ts
+++ b/packages/host/src/session-action-performer.test.ts
@@ -94,8 +94,8 @@ function deeperPerformer(
   plugin: FakePlugin,
   settingsStore: Pick<SettingsStore, "get">,
   openExternal: (url: string, kind: HostNodeOpenKind) => Promise<void> = async () => {},
+  registry: SessionRoster = new SessionRoster(),
 ) {
-  const registry = new SessionRoster();
   registry.replaceProvider(plugin.provider, [WORKSPACE_OBSERVATION]);
   const unreachable = async () => {
     throw new Error("the CLI is not reached in these tests");
@@ -273,6 +273,28 @@ test("an open the brain carries tells the node it was asked of Luke, and a row p
     [HOST_NODE_OPEN_KIND.ASKED_SESSION, HOST_NODE_OPEN_KIND.ADDRESS],
   );
   assert.ok(node.opens.every((open) => open.url === WORKSPACE_LINK));
+});
+
+test("a session the roster has let go still opens at the address it last reported, and one never seen does not", async () => {
+  const node = recordingOpens();
+  const plugin = fakePlugin();
+  const registry = new SessionRoster();
+  const performer = deeperPerformer(plugin, heldSettings().store, node.openExternal, registry);
+  // Archived on its own surface: the next observation no longer lists it.
+  registry.replaceProvider(plugin.provider, []);
+  assert.equal(registry.get(WORKSPACE_IDENTITY), undefined);
+  assert.equal(
+    (await performer.openSession(WORKSPACE_IDENTITY)).status,
+    ACTION_RESULT_STATUS.ACCEPTED,
+  );
+  assert.deepEqual(node.opens, [{ url: WORKSPACE_LINK, kind: HOST_NODE_OPEN_KIND.ADDRESS }]);
+  // A session this run never observed has no address to remember.
+  const stranger = await performer.openSession({
+    providerId: WORKSPACE_IDENTITY.providerId,
+    providerSessionId: "never-observed",
+  });
+  assert.equal(stranger.status, ACTION_RESULT_STATUS.UNSUPPORTED);
+  assert.equal(node.opens.length, 1);
 });
 
 test("an open refused before the node, or lost at it, is answered without the node opening anything of its own", async () => {

--- a/packages/host/src/session-action-performer.test.ts
+++ b/packages/host/src/session-action-performer.test.ts
@@ -162,6 +162,14 @@ const CREATE: ValidatedAction<SessionActionKind> = admittedForTest({
   task: "add tests",
   origin: RUN_ORIGIN.USER,
 });
+const CREATE_WITH_AGENT: ValidatedAction<SessionActionKind> = admittedForTest({
+  kind: ACTION_KIND.CREATE_WORKSPACE,
+  providerId: PROVIDER_ID.CONDUCTOR,
+  providerProjectId: "project-1",
+  task: "add tests",
+  agent: "claude",
+  origin: RUN_ORIGIN.USER,
+});
 const SPAWN: ValidatedAction<SessionActionKind> = admittedForTest({
   kind: ACTION_KIND.ADD_AGENT,
   identity: { providerId: PROVIDER_ID.CONDUCTOR, providerSessionId: "workspace-1" },
@@ -273,6 +281,32 @@ test("an open the brain carries tells the node it was asked of Luke, and a row p
     [HOST_NODE_OPEN_KIND.ASKED_SESSION, HOST_NODE_OPEN_KIND.ADDRESS],
   );
   assert.ok(node.opens.every((open) => open.url === WORKSPACE_LINK));
+});
+
+test("a creation's answer names the session it made and the agent it asked for, beside what became of the ask", async () => {
+  const plugin = fakePlugin();
+  const naming = {
+    ...plugin,
+    actions: {
+      ...plugin.actions,
+      async createWorkspace(input: Parameters<ActionHandlers["createWorkspace"]>[0]) {
+        plugin.creates.push(input);
+        return { status: ACTION_RESULT_STATUS.ACCEPTED, providerSessionId: "created-1" };
+      },
+    },
+  };
+  const settings = heldSettings();
+  const performer = deeperPerformer(naming, settings.store);
+  const creating = performer.perform(CREATE_WITH_AGENT, { isRevoked: () => false });
+  await drainMicrotasks(10);
+  settings.release();
+  const answer = await creating;
+  assert.equal(answer.status, ACTION_RESULT_STATUS.ACCEPTED);
+  assert.deepEqual(answer.createdSession, {
+    providerId: plugin.provider.id,
+    providerSessionId: "created-1",
+    agentId: "claude",
+  });
 });
 
 test("a session the roster has let go still opens at the address it last reported, and one never seen does not", async () => {

--- a/packages/host/src/session-action-performer.ts
+++ b/packages/host/src/session-action-performer.ts
@@ -37,6 +37,7 @@ import {
   isProviderId,
   type ProviderActionResult,
   type ProviderWorkspaceResult,
+  type Session,
   type SessionApplicationId,
   type SessionIdentity,
   type SessionOpenResult,
@@ -158,6 +159,9 @@ const REFUSAL = {
   OPEN_CHANGE_FAILED: OPEN_REFUSAL.CHANGE,
 } as const;
 
+/** How many departed sessions' addresses one provider keeps for the run; a roster is never near it. */
+const REMEMBERED_ADDRESSES_PER_PROVIDER = 200;
+
 export function createSessionActionPerformer(
   dependencies: SessionActionPerformerDependencies,
 ): SessionActionPerformer {
@@ -244,6 +248,37 @@ export function createSessionActionPerformer(
     }
   };
 
+  /**
+   * The address each observed session last reported, kept for this run only,
+   * so a press on the name of a chat the roster has since let go — archived
+   * on its provider's own surface, most often — still opens the address its
+   * provider gave it, which Conductor honours for an archived chat. Only the
+   * plain open reads it: an app association or a change is opened from the
+   * roster as it stands. Bounded per provider, oldest observation out first,
+   * and never written anywhere.
+   */
+  const lastAddresses = new Map<string, Map<string, string>>();
+  const rememberAddresses = (sessions: readonly Session[]): void => {
+    for (const session of sessions) {
+      const link = session.detail.link;
+      if (link === undefined) continue;
+      const known = lastAddresses.get(session.providerId) ?? new Map<string, string>();
+      known.delete(session.providerSessionId);
+      known.set(session.providerSessionId, link);
+      while (known.size > REMEMBERED_ADDRESSES_PER_PROVIDER) {
+        const oldest = known.keys().next().value;
+        if (oldest === undefined) break;
+        known.delete(oldest);
+      }
+      lastAddresses.set(session.providerId, known);
+    }
+  };
+  // The roster as it stands when the performer is built counts as observed too.
+  rememberAddresses(sessionRegistry.list());
+  sessionRegistry.subscribe(rememberAddresses);
+  const rememberedAddress = (identity: SessionIdentity): string | undefined =>
+    lastAddresses.get(identity.providerId)?.get(identity.providerSessionId);
+
   const openAddress = async (
     identity: SessionIdentity,
     address: (identity: SessionIdentity) => string | undefined,
@@ -252,9 +287,12 @@ export function createSessionActionPerformer(
     absentAddressReason: string,
     failureReason: string,
     kind: HostNodeOpenKind,
+    // The address the session last reported, for an open of a session the
+    // roster no longer holds; absent for the opens that read the roster alone.
+    remembered?: (identity: SessionIdentity) => string | undefined,
   ): Promise<SessionOpenResult> => {
     const observed = sessionRegistry.get(identity) !== undefined;
-    const url = observed ? address(identity) : undefined;
+    const url = observed ? address(identity) : remembered?.(identity);
     if (!url) {
       return {
         status: ACTION_RESULT_STATUS.UNSUPPORTED,
@@ -278,6 +316,7 @@ export function createSessionActionPerformer(
       REFUSAL.NO_ADDRESS,
       REFUSAL.OPEN_FAILED,
       kind,
+      (target) => pressedLink(rememberedAddress(target)),
     );
 
   const openSessionApplication = async (

--- a/packages/host/src/session-action-performer.ts
+++ b/packages/host/src/session-action-performer.ts
@@ -159,6 +159,13 @@ const REFUSAL = {
   OPEN_CHANGE_FAILED: OPEN_REFUSAL.CHANGE,
 } as const;
 
+/**
+ * The field a creation's answer carries the created session under, for the
+ * brain's performer alone: it records the identity on the act's line and cuts
+ * the field before the model reads the answer.
+ */
+export const CREATED_SESSION_FIELD = "createdSession";
+
 /** How many departed sessions' addresses one provider keeps for the run; a roster is never near it. */
 const REMEMBERED_ADDRESSES_PER_PROVIDER = 200;
 
@@ -449,11 +456,8 @@ export function createSessionActionPerformer(
       : undefined;
     if (guard?.isRevoked())
       return { status: ACTION_RESULT_STATUS.REJECTED, reason: REFUSAL.TURN_OVER };
-    const result = await dispatchAction(
-      plugin,
-      "createWorkspace",
-      providerWorkspaceRequest(action, stored),
-    );
+    const request = providerWorkspaceRequest(action, stored);
+    const result = await dispatchAction(plugin, "createWorkspace", request);
     // A workspace that landed is a session the panel should be showing, so
     // the next look must actually ask rather than serve the cache. A
     // rejection refreshes too: a workspace can stand with its opening task
@@ -494,12 +498,25 @@ export function createSessionActionPerformer(
         action.agent,
       );
       countSessionAction(plugin.provider.id, PRODUCT_SESSION_ACTION.WORKSPACE_CREATE, result);
-      // The named session was consumed above; the answer stays what became
-      // of the ask, so nothing rides out that the roster will not report on
-      // its own.
-      return result.warning
-        ? { status: ACTION_RESULT_STATUS.ACCEPTED, warning: result.warning }
-        : { status: ACTION_RESULT_STATUS.ACCEPTED };
+      // The session the creation named rides out once more, as the identity
+      // the brain's performer writes on the act's own line and cuts from the
+      // answer before the model reads it — an id the roster is about to report
+      // on its own, and never an address. The agent is the one the request
+      // asked for; a creation that left the choice to the provider names none.
+      const agent = request.agent ?? request.agentSelection?.agent;
+      return {
+        status: ACTION_RESULT_STATUS.ACCEPTED,
+        ...(result.warning ? { warning: result.warning } : undefined),
+        ...(result.providerSessionId
+          ? {
+              [CREATED_SESSION_FIELD]: {
+                providerId: plugin.provider.id,
+                providerSessionId: result.providerSessionId,
+                ...(agent === undefined ? undefined : { agentId: agent }),
+              },
+            }
+          : undefined),
+      };
     }
     return result;
   };


### PR DESCRIPTION
Stacked on #894 → #893 → #892 → #890 → #889 → #897 → #882. Top of the stack.

The chip on an action row named the chat and did nothing. It is now a press:

- **The row's own press by another hand.** A chip whose line recorded a session identity is a `<button>` that mints the same `session.open` act a session row does, through the session-list hook's new `onOpenSessionIdentity`, and stands the panel down the way a row press does.
- **A created workspace is a chat like any other.** The host's accepted creation answer now carries the session the provider named and the agent the ask chose, behind one field (`createdSession`) that the brain's performer writes onto the act's own line as its identity and cuts before the model reads the answer. The renderer names the workspace from the roster once it has arrived, and from the line's own record before it has, so the creation chip opens and wears its agent's mark either way. The id stays an identifier and never an address, as the guide already has it; the model still sees only what became of the ask.
- **A chat the roster has let go still opens.** The host now keeps, in memory for the run, the address each observed session last reported (bounded to 200 per provider, oldest out first, written nowhere). A plain open for an identity the roster no longer holds falls back to it, so a chip for an archived chat opens Conductor's deep link, which Conductor honours for archived chats. An identity this run never observed still refuses. App-association and change opens keep reading the roster alone.
- **Trust constraint, amended.** `CLAUDE.md` said a Conversation line "draws no press of its own". It now names the chip beside the row's press and the validated ask as the ways a session's address is reached, says a creation's line names the session the provider's answer identified so its chip is that same press, and says exactly what the host remembers and for how long. This widens a stated constraint; it is the product decision behind this PR and is called out here so a reviewer weighs it as one.

Verification: typecheck clean; host 289 tests pass with new cases for a departed session opening at its last address and a never-observed one refusing, and for the creation answer naming its session and agent beside the status; actions 60 pass; desktop 690 pass with new cases for the chip as a button, a created workspace's chip as a button once its line holds the identity, and the creation row leading with Conductor only when the chip wears an agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/edd416a9-4048-4f0a-ac6d-fdae20bd92f6)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34429757567/artifacts/10134071393) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34429757567)

- Commit: `eeed2c4ba7610d55dfe5c9064c7b7c42e70b2fd6`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

