### PR TITLE
fix(desktop): drop a quit report to a closed stderr instead of crashing

### DIFF
--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -6,6 +6,7 @@ import { registerDesktopIpc } from "./ipc/register-desktop-ipc";
 import { composeDesktop, type DesktopServices } from "./services/compose-desktop";
 import type { DesktopConfig } from "./services/desktop-config";
 import { initializeCrashReporting } from "./services/telemetry-service";
+import { reportToStderr, tolerateClosedStderr } from "./stderr-report";
 
 /**
  * The desktop client's entry: the process that draws. It owns the windows,
@@ -49,6 +50,7 @@ const fixtureName = argumentValue("--fixture");
 const captureMode = captureOutput !== undefined;
 const runMode = runModeFor({ capture: captureMode, fixture: fixtureName !== undefined });
 initializeCrashReporting(runMode);
+tolerateClosedStderr();
 
 // The introduction's mint lives on the same origin as the account service;
 // the one development override redirects both, and stops at packaging.
@@ -75,7 +77,7 @@ const config: DesktopConfig = {
     captureMode,
     fixtureMode: captureMode || fixtureName !== undefined,
   },
-  report: (message) => process.stderr.write(`${message}\n`),
+  report: reportToStderr,
   openExternal: (url) => shell.openExternal(url),
   quit: () => app.quit(),
 };
@@ -86,8 +88,8 @@ const config: DesktopConfig = {
 if (app.requestSingleInstanceLock()) {
   void main();
 } else {
-  process.stderr.write(
-    "Luke is already running; the existing panel was refreshed instead of starting a second copy.\n",
+  reportToStderr(
+    "Luke is already running; the existing panel was refreshed instead of starting a second copy.",
   );
   app.quit();
 }

--- a/apps/desktop/src/main/stderr-report.test.ts
+++ b/apps/desktop/src/main/stderr-report.test.ts
@@ -1,0 +1,18 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { reportToStderr } from "./stderr-report";
+
+test("a report to a stderr that throws on write is dropped, not raised", () => {
+  const original = process.stderr.write;
+  const closed = Object.assign(new Error("write EIO"), { code: "EIO" });
+  // SAFETY: the reporter only ever calls write with one string, and a closed
+  // pipe's write throws before it would read any other argument.
+  process.stderr.write = (() => {
+    throw closed;
+  }) as typeof process.stderr.write;
+  try {
+    assert.doesNotThrow(() => reportToStderr("the service did not stop cleanly"));
+  } finally {
+    process.stderr.write = original;
+  }
+});

--- a/apps/desktop/src/main/stderr-report.ts
+++ b/apps/desktop/src/main/stderr-report.ts
@@ -1,0 +1,23 @@
+/**
+ * Writes one line to stderr, and loses it rather than throwing when stderr is
+ * gone. A development launch's stderr is a pipe to the terminal that started
+ * it, and stopping the app from that terminal closes the pipe before the quit
+ * finishes tearing down; a report written then fails with EIO or EPIPE, and an
+ * uncaught one would end the quit in Electron's error dialog. A line that has
+ * nobody left to read it is the one thing this reporter may drop.
+ */
+export function reportToStderr(message: string): void {
+  try {
+    process.stderr.write(`${message}\n`);
+  } catch {
+    // Nothing reads a closed pipe; the quit goes on.
+  }
+}
+
+/**
+ * A pipe can also fail after the write was accepted, and Node raises that on
+ * the stream as an `error` event, which is uncaught unless something listens.
+ */
+export function tolerateClosedStderr(): void {
+  process.stderr.on("error", () => undefined);
+}

--- a/apps/desktop/src/main/update-service.ts
+++ b/apps/desktop/src/main/update-service.ts
@@ -4,6 +4,7 @@ import {
   type UpdateSnapshot,
   type UpdateStatus,
 } from "#shared/messages/update";
+import { reportToStderr } from "./stderr-report";
 
 /**
  * The addresses updating ever touches, fixed here rather than passed in,
@@ -195,7 +196,7 @@ export class UpdateService {
       options.justUpdatedFirstCheckDelayMs ??
       UPDATE_CHECK_DEFAULTS.JUST_UPDATED_FIRST_CHECK_DELAY_MS;
     this.#publishingRetryDelaysMs = options.publishingRetryDelaysMs ?? PUBLISHING_RETRY_DELAYS_MS;
-    this.#report = options.report ?? ((line) => process.stderr.write(`${line}\n`));
+    this.#report = options.report ?? reportToStderr;
     this.#snapshot = this.#idle(false);
     this.#engine?.wire({
       onChecking: () => this.#move({ ...this.#base(UPDATE_STATUS.CHECKING) }),


### PR DESCRIPTION
## Summary
- Every development quit showed Electron's "A JavaScript error occurred in the main process" dialog with `write EIO` from `report` inside `stopInReverse`.
- Cause: `config.report` wrote to `process.stderr`, a pipe to the `pnpm start` parent under `run.sh`. Stopping the app from the terminal closes that pipe before the `before-quit` teardown finishes, so a service's "did not stop cleanly" report threw synchronously and nothing caught it. Packaged builds never hit this.
- `reportToStderr` drops a line whose pipe is gone rather than throwing, and `tolerateClosedStderr` attaches an `error` listener so an async pipe failure cannot surface uncaught. Used by `config.report`, the single-instance message, and the updater's default reporter.

## Not in this PR
The underlying "did not stop cleanly" service is still unidentified; its message was lost to the crash. With this fix it prints to stderr when quitting from the panel with the terminal open.

## Test plan
- [x] `./scripts/check.sh` passes, including a new unit test for a throwing stderr
- [ ] `./scripts/verify.sh` on a Mac
- [ ] `./scripts/run.sh`, then Ctrl-C: no dialog
- [ ] `./scripts/run.sh` twice: the second launch's kill of the first shows no dialog

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/ac9e9856-88c0-44b4-be42-3f273f5289de)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34510142899/artifacts/10165567105) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34510142899)

- Commit: `d83f8c9a2a57c40e91d6505bfcefa817edbf60a0`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
