### PR TITLE
feat(gateway): live session methods and event

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -445,9 +445,16 @@ Canonical commands:
   methods, and the change events beside them; `voice.recordTrace` carries
   the renderer's tapped realtime events to the development trace writer the
   host owns, under the same gate, so an untraced run drops them at the
-  host). No credential or account secret travels in any answer or event, and
-  the one secret that reaches the voice client is the ephemeral realtime
-  credential the host minted. Widening the method vocabulary, the event set,
+  host; and the live voice session's `voice.createLiveSession`,
+  `voice.endLiveSession`, `voice.reportLiveTransport`, and
+  `voice.reportLiveActivity`, with the `voiceLiveSession.changed` event
+  beside them, each mutating and idempotency-keyed so a retried SDP offer
+  cannot create and bill a second session, their shapes declared once as
+  `@sidecar/wire` schemas in `protocol.ts`, and answered by no host handler
+  yet, so the server's typed `unknown_method` is what they meet until the
+  host's live session service lands). No credential or account secret
+  travels in any answer or event, and the one secret that reaches the voice
+  client is the ephemeral realtime credential the host minted. Widening the method vocabulary, the event set,
   or what a node may be asked is a product decision, not an implementation
   detail.
 - The host is what composes and owns the runtime, and it draws nothing. It is

--- a/apps/desktop/src/main/gateway/host-operator.ts
+++ b/apps/desktop/src/main/gateway/host-operator.ts
@@ -10,7 +10,12 @@ import {
   GATEWAY_EVENT,
   GATEWAY_METHOD,
   gatewayEventReader,
+  type LiveTransportState,
   RECEIVER_REPORT_KIND,
+  type VoiceCreateLiveSessionResult,
+  type VoiceLiveSessionChanged,
+  voiceCreateLiveSessionResultSchema,
+  voiceLiveSessionChangedSchema,
 } from "@sidecar/gateway";
 import type { AppGuideSnapshot } from "@sidecar/guide";
 import type { RealtimeConnection } from "@sidecar/hosted";
@@ -154,6 +159,12 @@ export interface HostOperator {
   resetReceiver(): Promise<void>;
   mintRealtimeCredential(): Promise<RealtimeConnection | undefined>;
   realtimeDiagnostics(): Promise<RealtimeDiagnostics | undefined>;
+  /** The peer's SDP offer, answered with the session the host created; a host that creates none answers nothing. */
+  createLiveSession(sdp: string): Promise<VoiceCreateLiveSessionResult | undefined>;
+  endLiveSession(): Promise<void>;
+  reportLiveTransport(state: LiveTransportState): Promise<void>;
+  /** The peer's own idle decision, from its local signals alone; the host decides the close. */
+  reportLiveActivity(idle: boolean): Promise<void>;
   /** One tapped wire event for the host's development trace; the host drops it where no writer stands. */
   recordAgentTrace(trace: AgentWireTrace): void;
   reportGuide(guide: AppGuideSnapshot): Promise<void>;
@@ -181,6 +192,7 @@ export interface HostOperator {
   onCalendarOnboardingChanged(listener: (owed: boolean) => void): () => void;
   onSpeechOffered(listener: (offer: SpeechOffer) => void): () => void;
   onSpeechWithdrawn(listener: (id: string) => void): () => void;
+  onVoiceLiveSessionChanged(listener: (change: VoiceLiveSessionChanged) => void): () => void;
   onSessionReplayChanged(listener: (replay: HostSessionReplay) => void): () => void;
 }
 
@@ -420,6 +432,15 @@ export function createHostOperator(options: HostOperatorOptions): HostOperator {
       answered<RealtimeDiagnostics>(
         record(await client.call(GATEWAY_METHOD.VOICE_DIAGNOSTICS))?.diagnostics,
       ),
+    createLiveSession: async (sdp) => {
+      const answer = await client.call(GATEWAY_METHOD.VOICE_CREATE_LIVE_SESSION, { sdp });
+      return answer.ok ? voiceCreateLiveSessionResultSchema.parse(answer.result) : undefined;
+    },
+    endLiveSession: () => fire(client.call(GATEWAY_METHOD.VOICE_END_LIVE_SESSION)),
+    reportLiveTransport: (state) =>
+      fire(client.call(GATEWAY_METHOD.VOICE_REPORT_LIVE_TRANSPORT, { state })),
+    reportLiveActivity: (idle) =>
+      fire(client.call(GATEWAY_METHOD.VOICE_REPORT_LIVE_ACTIVITY, { idle })),
     recordAgentTrace: (trace) => {
       void client.call(GATEWAY_METHOD.VOICE_RECORD_TRACE, { trace: carried(trace) });
     },
@@ -523,6 +544,12 @@ export function createHostOperator(options: HostOperatorOptions): HostOperator {
       on(
         GATEWAY_EVENT.SPEECH_WITHDRAWN,
         (payload) => (isRecord(payload) && isWireString(payload.id) ? payload.id : undefined),
+        listener,
+      ),
+    onVoiceLiveSessionChanged: (listener) =>
+      on(
+        GATEWAY_EVENT.VOICE_LIVE_SESSION_CHANGED,
+        (payload) => voiceLiveSessionChangedSchema.parse(payload),
         listener,
       ),
     onSessionReplayChanged: (listener) =>

--- a/packages/gateway/AGENTS.md
+++ b/packages/gateway/AGENTS.md
@@ -13,6 +13,17 @@ detail. What a method's own parameters may say belongs here too, beside the
 entry that names it: `RECEIVER_REPORT_KIND` is the vocabulary of
 `receiver.report`, so the host that answers it and the client that sends it
 read the same three words from the contract rather than from each other.
+The live voice session's vocabulary is declared the same way, as `@sidecar/wire`
+schemas beside the four methods and the one event that speak it:
+`voice.createLiveSession` takes the peer's SDP offer verbatim (SDP is
+line-oriented, so nothing trims, collapses, or cuts it) and answers the
+session id and the SDP answer; `voice.reportLiveTransport` names one of
+`LIVE_TRANSPORT_STATE`; `voice.reportLiveActivity` carries the peer's one idle
+boolean; `voice.endLiveSession` carries nothing; and `voiceLiveSession.changed`
+names a `LIVE_SESSION_PHASE`, the session id once a provider has named one,
+and the reason of a close. Every one of the four mutates, so a retried offer
+finds the first session rather than creating and billing a second, and no
+credential has a field to travel in.
 
 ## Three doors, because one of them reaches `ws`
 

--- a/packages/gateway/src/live-session.test.ts
+++ b/packages/gateway/src/live-session.test.ts
@@ -1,0 +1,102 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  GATEWAY_EVENT,
+  GATEWAY_METHOD,
+  isGatewayEventKind,
+  isGatewayMethod,
+  isMutatingGatewayMethod,
+  LIVE_SDP_MAX_CHARACTERS,
+  LIVE_SESSION_PHASE,
+  LIVE_TRANSPORT_STATE,
+  voiceCreateLiveSessionParamsSchema,
+  voiceCreateLiveSessionResultSchema,
+  voiceLiveSessionChangedSchema,
+  voiceReportLiveActivityParamsSchema,
+  voiceReportLiveTransportParamsSchema,
+} from "./protocol.js";
+
+const LIVE_METHODS = [
+  GATEWAY_METHOD.VOICE_CREATE_LIVE_SESSION,
+  GATEWAY_METHOD.VOICE_END_LIVE_SESSION,
+  GATEWAY_METHOD.VOICE_REPORT_LIVE_TRANSPORT,
+  GATEWAY_METHOD.VOICE_REPORT_LIVE_ACTIVITY,
+] as const;
+
+test("the four live session methods are in the vocabulary, and every one of them mutates", () => {
+  for (const method of LIVE_METHODS) {
+    assert.equal(isGatewayMethod(method), true);
+    assert.equal(isMutatingGatewayMethod(method), true);
+  }
+  assert.equal(isGatewayEventKind(GATEWAY_EVENT.VOICE_LIVE_SESSION_CHANGED), true);
+});
+
+test("the realtime vocabulary the live methods will replace still stands beside them", () => {
+  for (const method of [
+    GATEWAY_METHOD.VOICE_MINT_REALTIME_CREDENTIAL,
+    GATEWAY_METHOD.SPEECH_SETTLE,
+    GATEWAY_METHOD.RECEIVER_REPORT,
+    GATEWAY_METHOD.DELIVERY_CLAIM,
+  ]) {
+    assert.equal(isGatewayMethod(method), true);
+  }
+  assert.equal(isGatewayEventKind(GATEWAY_EVENT.SPEECH_OFFERED), true);
+  assert.equal(isGatewayEventKind(GATEWAY_EVENT.SPEECH_WITHDRAWN), true);
+});
+
+test("a create request carries the offer and nothing else", () => {
+  const offer = "v=0\r\no=- 1 1 IN IP4 127.0.0.1\r\n";
+  assert.deepEqual(voiceCreateLiveSessionParamsSchema.parse({ sdp: offer }), { sdp: offer });
+  assert.equal(voiceCreateLiveSessionParamsSchema.parse({}), undefined);
+  assert.equal(voiceCreateLiveSessionParamsSchema.parse({ sdp: "" }), undefined);
+  assert.equal(voiceCreateLiveSessionParamsSchema.parse({ sdp: offer, voice: "marin" }), undefined);
+  assert.equal(
+    voiceCreateLiveSessionParamsSchema.parse({ sdp: "a".repeat(LIVE_SDP_MAX_CHARACTERS + 1) }),
+    undefined,
+  );
+});
+
+test("a create answer names the session and the SDP answer, tolerating what a newer host adds", () => {
+  const answer = { sessionId: "sess_1", sdpAnswer: "v=0\r\n", quota: { remaining: 1 } };
+  assert.deepEqual(voiceCreateLiveSessionResultSchema.parse(answer), {
+    sessionId: "sess_1",
+    sdpAnswer: "v=0\r\n",
+  });
+  assert.equal(voiceCreateLiveSessionResultSchema.parse({ sessionId: "sess_1" }), undefined);
+  assert.equal(voiceCreateLiveSessionResultSchema.parse({ sdpAnswer: "v=0\r\n" }), undefined);
+});
+
+test("a transport report names one of the declared states", () => {
+  for (const state of Object.values(LIVE_TRANSPORT_STATE)) {
+    assert.deepEqual(voiceReportLiveTransportParamsSchema.parse({ state }), { state });
+  }
+  assert.equal(voiceReportLiveTransportParamsSchema.parse({ state: "new" }), undefined);
+  assert.equal(voiceReportLiveTransportParamsSchema.parse({}), undefined);
+});
+
+test("an activity report is one boolean", () => {
+  assert.deepEqual(voiceReportLiveActivityParamsSchema.parse({ idle: true }), { idle: true });
+  assert.deepEqual(voiceReportLiveActivityParamsSchema.parse({ idle: false }), { idle: false });
+  assert.equal(voiceReportLiveActivityParamsSchema.parse({ idle: "yes" }), undefined);
+  assert.equal(voiceReportLiveActivityParamsSchema.parse({ idle: true, sinceMs: 1 }), undefined);
+});
+
+test("a session change carries a phase, and a session id and reason only when the host has one", () => {
+  for (const phase of Object.values(LIVE_SESSION_PHASE)) {
+    assert.deepEqual(voiceLiveSessionChangedSchema.parse({ phase }), { phase });
+  }
+  assert.deepEqual(
+    voiceLiveSessionChangedSchema.parse({
+      sessionId: "sess_1",
+      phase: LIVE_SESSION_PHASE.CLOSED,
+      reason: "expired",
+    }),
+    { sessionId: "sess_1", phase: LIVE_SESSION_PHASE.CLOSED, reason: "expired" },
+  );
+  assert.equal(voiceLiveSessionChangedSchema.parse({ phase: "speaking" }), undefined);
+  assert.equal(voiceLiveSessionChangedSchema.parse({ sessionId: "sess_1" }), undefined);
+  assert.equal(
+    voiceLiveSessionChangedSchema.parse({ phase: LIVE_SESSION_PHASE.STARTED, sessionId: 7 }),
+    undefined,
+  );
+});

--- a/packages/gateway/src/protocol.ts
+++ b/packages/gateway/src/protocol.ts
@@ -4,6 +4,10 @@ import {
   isWireBoolean,
   isWireNumber,
   isWireString,
+  RECORD_EXTRA_KEYS,
+  type RecordOf,
+  s,
+  TEXT_ENDS,
   type UnparsedWireValue,
   type WireRecord,
   type WireValue,
@@ -94,6 +98,10 @@ const GATEWAY_METHODS = {
   RECEIVER_REPORT: { name: "receiver.report", mutates: true },
   VOICE_MINT_REALTIME_CREDENTIAL: { name: "voice.mintRealtimeCredential", mutates: true },
   VOICE_DIAGNOSTICS: { name: "voice.diagnostics", mutates: false },
+  VOICE_CREATE_LIVE_SESSION: { name: "voice.createLiveSession", mutates: true },
+  VOICE_END_LIVE_SESSION: { name: "voice.endLiveSession", mutates: true },
+  VOICE_REPORT_LIVE_TRANSPORT: { name: "voice.reportLiveTransport", mutates: true },
+  VOICE_REPORT_LIVE_ACTIVITY: { name: "voice.reportLiveActivity", mutates: true },
   /** One tapped realtime event for the host's development trace; a no-op where no writer stands. */
   VOICE_RECORD_TRACE: { name: "voice.recordTrace", mutates: true },
   GUIDE_REPORT: { name: "guide.report", mutates: true },
@@ -120,6 +128,88 @@ export const RECEIVER_REPORT_KIND = {
 } as const;
 
 export type ReceiverReportKind = (typeof RECEIVER_REPORT_KIND)[keyof typeof RECEIVER_REPORT_KIND];
+
+/**
+ * The live voice session's vocabulary, declared beside the four methods and
+ * the one event that speak it, so the host that answers them and the client
+ * that sends them read one shape. The session itself belongs to the host; the
+ * renderer is a WebRTC peer that hands over an SDP offer, reports what its
+ * transport and microphone are doing, and asks for the end, and no credential
+ * of any kind travels in these shapes.
+ */
+
+/** Where the one live session stands, as `voiceLiveSession.changed` reports it. */
+export const LIVE_SESSION_PHASE = {
+  /** The host wants a session and no peer has offered one yet. */
+  WANTED: "wanted",
+  /** The provider created the session; its answer is on its way to the peer. */
+  CREATED: "created",
+  /** The provider announced the session live. */
+  STARTED: "started",
+  /** The host asked for a graceful close and is waiting for it to be confirmed. */
+  CLOSING: "closing",
+  CLOSED: "closed",
+} as const;
+
+export type LiveSessionPhase = (typeof LIVE_SESSION_PHASE)[keyof typeof LIVE_SESSION_PHASE];
+
+const LIVE_SESSION_PHASES: readonly LiveSessionPhase[] = Object.values(LIVE_SESSION_PHASE);
+
+/** What a peer's transport reports of itself, after the peer connection's own states. */
+export const LIVE_TRANSPORT_STATE = {
+  CONNECTING: "connecting",
+  CONNECTED: "connected",
+  DISCONNECTED: "disconnected",
+  FAILED: "failed",
+  CLOSED: "closed",
+} as const;
+
+export type LiveTransportState = (typeof LIVE_TRANSPORT_STATE)[keyof typeof LIVE_TRANSPORT_STATE];
+
+const LIVE_TRANSPORT_STATES: readonly LiveTransportState[] = Object.values(LIVE_TRANSPORT_STATE);
+
+/**
+ * The most characters an SDP document may carry. A WebRTC offer for one audio
+ * track and one data channel is a few kilobytes; the bound refuses an offer
+ * no peer of this build composes rather than carrying it to a provider.
+ */
+export const LIVE_SDP_MAX_CHARACTERS = 65_536;
+
+/** SDP is line-oriented and ends its lines with CRLF, so it travels verbatim: nothing is trimmed, collapsed, or cut. */
+const sdpSchema = s.text({ max: LIVE_SDP_MAX_CHARACTERS, ends: TEXT_ENDS.KEEP });
+
+/** `voice.createLiveSession`: the peer's SDP offer, and nothing else. */
+export const voiceCreateLiveSessionParamsSchema = s.record({ sdp: sdpSchema });
+
+const VOICE_CREATE_LIVE_SESSION_RESULT = { sessionId: s.text(), sdpAnswer: sdpSchema } as const;
+
+/** What `voice.createLiveSession` answers: the session the provider named, and the SDP answer the peer sets. */
+export const voiceCreateLiveSessionResultSchema = s.record(VOICE_CREATE_LIVE_SESSION_RESULT, {
+  extraKeys: RECORD_EXTRA_KEYS.IGNORE,
+});
+
+export type VoiceCreateLiveSessionResult = RecordOf<typeof VOICE_CREATE_LIVE_SESSION_RESULT>;
+
+/** `voice.reportLiveTransport`: the peer connection's state as the peer saw it change. */
+export const voiceReportLiveTransportParamsSchema = s.record({
+  state: s.enumOf(LIVE_TRANSPORT_STATES),
+});
+
+/** `voice.reportLiveActivity`: whether the peer has decided, from its own local signals, that the exchange is idle. */
+export const voiceReportLiveActivityParamsSchema = s.record({ idle: s.boolean() });
+
+const VOICE_LIVE_SESSION_CHANGED = {
+  sessionId: s.text().optional(),
+  phase: s.enumOf(LIVE_SESSION_PHASES),
+  reason: s.text().optional(),
+} as const;
+
+/** `voiceLiveSession.changed`: the phase the host's one session moved to, the id once the provider named one, and the reason of a close. */
+export const voiceLiveSessionChangedSchema = s.record(VOICE_LIVE_SESSION_CHANGED, {
+  extraKeys: RECORD_EXTRA_KEYS.IGNORE,
+});
+
+export type VoiceLiveSessionChanged = RecordOf<typeof VOICE_LIVE_SESSION_CHANGED>;
 
 const GATEWAY_METHODS_BY_NAME: ReadonlyMap<string, GatewayMethodEntry> = new Map(
   Object.values(GATEWAY_METHODS).map((entry) => [entry.name, entry]),
@@ -212,6 +302,7 @@ export const GATEWAY_EVENT = {
   CALENDAR_ONBOARDING_CHANGED: "calendarOnboarding.changed",
   SPEECH_OFFERED: "speech.offered",
   SPEECH_WITHDRAWN: "speech.withdrawn",
+  VOICE_LIVE_SESSION_CHANGED: "voiceLiveSession.changed",
   SESSION_REPLAY_CHANGED: "sessionReplay.changed",
 } as const;
 


### PR DESCRIPTION
## What

PR5 of the GPT Live rollout: the additive Gateway vocabulary for the live voice session, with no consumer on the host yet.

- `packages/gateway/src/protocol.ts`: methods `voice.createLiveSession { sdp }`, `voice.endLiveSession`, `voice.reportLiveTransport { state }`, `voice.reportLiveActivity { idle }`, all flagged `mutates: true`, and the event `voiceLiveSession.changed { sessionId?, phase, reason? }`. `LIVE_SESSION_PHASE` (`wanted | created | started | closing | closed`) and `LIVE_TRANSPORT_STATE` (`connecting | connected | disconnected | failed | closed`, after `RTCPeerConnectionState`) are `as const` sets. Params, result, and payload are `@sidecar/wire` schemas declared once: requests refuse extra keys, the result and the event ignore them.
- `apps/desktop/src/main/gateway/host-operator.ts`: the typed `HostOperator` gains `createLiveSession`, `endLiveSession`, `reportLiveTransport`, `reportLiveActivity`, and `onVoiceLiveSessionChanged`, each reading its answer or payload through the protocol's schema.
- `packages/gateway/AGENTS.md` and `CLAUDE.md` name the new methods and event.
- Nothing is removed: `voice.mintRealtimeCredential`, `speech.*`, `receiver.*`, and `delivery.claim` stand until PR 15.

## Why

The host's live session service (PR 8) and the desktop cutover (PR 9) both speak this vocabulary; landing it first keeps each of those PRs to its own behaviour. Every one of the four methods mutates because the client then keys each call: a retried SDP offer finds the first session's answer through the idempotency ledger rather than creating and billing a second session at the provider.

## How it follows the GPT Live docs

The session is created server-side from the peer's SDP offer (`POST /v1/live/sessions` with `transport: { type: "webrtc", sdp }`), so the only thing the peer hands over is the offer and the only thing it gets back is the session id and the SDP answer; no client secret has a field to travel in. SDP is line-oriented with CRLF endings, so its schema keeps the text verbatim and only bounds and refuses. Idle is a local decision the peer reports once (`reportLiveActivity`), never inferred from transcript silence, per the docs' caution; the close decision stays the host's.

## Host handlers

No host handler is registered. `GatewayServer` already answers the typed `unknown_method` error for a method no handler stands for, so the four methods meet a typed refusal until PR 8 registers them, and no throwaway stub has to be deleted then.

## Verify

```
./scripts/check.sh
```

`./scripts/verify.sh` was not run: this PR touches no macOS or UI code, and the environment is a Linux sandbox.

## Test results

`./scripts/check.sh` passes locally (lint, knip, typecheck, tests, build). `packages/gateway`: 46 tests pass, including the new `live-session.test.ts` (vocabulary membership, mutates flags, schema round-trips, extra-key and enum refusals, SDP bound, realtime vocabulary still present).

## Reviews

Applied the Cursor `thermo-nuclear-review` and `thermo-nuclear-code-quality-review` skill texts (from `cursor/plugins`) and the `ponytail-review` skill text (from `DietrichGebert/ponytail`) to the diff. Thermonuclear: no correctness, breakage, or leak findings; the change is additive and the one `HostOperator` test fake casts through `unknown`. Ponytail: three exported params types and five redundant `Schema<...>` annotations had no consumer and were deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34521903739/artifacts/10170095379) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34521903739)

- Commit: `eea7a8bcaef4442f6223988b57bf4b8b4ee8d8f0`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
