### PR TITLE
feat(hosted): live session contract and service paths

### DIFF
--- a/apps/web/server/core.ts
+++ b/apps/web/server/core.ts
@@ -28,6 +28,7 @@
  */
 import "../../../packages/credentials/src/credential-providers.js";
 import "../../../packages/guide/src/index.js";
+import "../../../packages/live/src/index.js";
 import "../../../packages/memory/src/index.js";
 import "../../../packages/runtime/src/index.js";
 

--- a/packages/hosted/AGENTS.md
+++ b/packages/hosted/AGENTS.md
@@ -2,10 +2,12 @@
 
 This package is the desktop-to-service wire boundary. It owns the hosted
 service paths (`service-paths.ts`), one wire module per domain — vault,
-device, observe, conversation, projects, mint, act, and the service vocabulary
-they share — each a `Schema` declaration rather than a hand-written reader,
-and the realtime credential contract, and depends only on lower wire/session
-vocabulary. The two clients here are `vault-client.ts`, the desktop's side of
+device, observe, conversation, projects, mint, act, live, and the service
+vocabulary they share — each a `Schema` declaration rather than a hand-written
+reader, and the realtime credential contract, and depends only on lower
+wire/session vocabulary and `@sidecar/live` for the Live voice set and the
+`InitialItem` shape (that package imports nothing of this one, so the edge
+points down). The two clients here are `vault-client.ts`, the desktop's side of
 the three vault routes, and `device-client.ts`, its side of the one devices
 path; each sits in this package because it speaks nothing but hosted
 vocabulary and holds no credential of its own. Behavior that needs
@@ -37,6 +39,38 @@ Every caller in this package now makes that call, `device-client.ts`
 included, and so do the two hosted endpoints that reach a third party on a
 key the deployment fixed: a `fixedBearer` for OpenAI, and `NO_CREDENTIAL` for
 the analytics batch, whose project token travels in the document itself.
+
+## The live contract is a socket's first two frames
+
+`live-contract.ts` is the desktop's contract with the hosted voice service,
+the one process on Luke's side that holds a GPT Live project key. The
+service is not the account service: it is a long-running process on its own
+origin, `HOSTED_VOICE_SERVICE_ORIGIN`, pinned by the build the way
+`HOSTED_CALLS_URL` pins the Realtime host and compared as `URL.origin` —
+scheme, host, and port, never a path or a query — so nothing a service
+answers can send a desktop's socket elsewhere. `hostedVoiceServiceOrigin`
+is where a development build's override enters, reduced to its origin and
+refused past the packaging boundary, the same rule `LUKE_ACCOUNT_BASE_URL`
+follows in the host; the package reads no environment itself and is handed
+the value. The socket's own vocabulary is two frames, `VOICE_SERVICE_FRAME`:
+the desktop's `session.create` (the SDP offer as written, a voice that is a
+member of `LIVE_VOICE`, and a seed of at most 128 `InitialItem`s of one text
+part each, bounded per item so a frame the Live API would refuse is refused
+before a session is spent on it) and the service's `session.created` (the
+opaque session id, the SDP answer, and the quota the session was spent
+against, dropped if mis-answered). After those two, GPT Live events pass
+through the same socket as themselves and are declared in `@sidecar/live`,
+not here. A request frame refuses a key it did not name; an answer ignores
+one a newer service added, the rule every wire module here keeps.
+
+`service-paths.ts` carries the two sides of that service: `VOICE_SERVICE_PATH`
+for the upgrades on the voice service's origin (`/sessions` under an account
+bearer, `/introduction` under none), and under `HOSTED_SERVICE_PATH` the two
+internal routes on the account service that only the voice service calls,
+`VOICE_AUTHORIZE` and `VOICE_USAGE`, authenticated by the shared secret in
+`VOICE_SERVICE_SECRET_HEADER` rather than by any account's bearer. The
+Realtime mint paths and `realtime-contract.ts` stand beside it untouched for
+the installed desktops and the phone that still speak them.
 
 A renamed wire field keeps its old name on the wire for one iOS release. The
 desktop and the service ship together, but an installed phone reads whatever

--- a/packages/hosted/package.json
+++ b/packages/hosted/package.json
@@ -12,6 +12,7 @@
     "typecheck": "tsc --project tsconfig.json"
   },
   "dependencies": {
+    "@sidecar/live": "workspace:*",
     "@sidecar/runtime": "workspace:*",
     "@sidecar/session": "workspace:*",
     "@sidecar/wire": "workspace:*"

--- a/packages/hosted/src/index.ts
+++ b/packages/hosted/src/index.ts
@@ -82,6 +82,19 @@ export {
   type PushEnvironment,
 } from "./device-wire.js";
 export {
+  HOSTED_VOICE_SERVICE_ORIGIN,
+  hostedVoiceServiceOrigin,
+  isHostedVoiceServiceAddress,
+  type LiveSessionCreated,
+  liveSessionCreatedSchema,
+  SESSION_CREATE_BOUNDS,
+  type SessionCreatedFrame,
+  type SessionCreateFrame,
+  sessionCreatedFrameSchema,
+  sessionCreateFrameSchema,
+  VOICE_SERVICE_FRAME,
+} from "./live-contract.js";
+export {
   HOSTED_CALLS_URL,
   HOSTED_WS_BASE_URL,
   type HostedMintAnswer,
@@ -125,7 +138,11 @@ export {
   RESPONSES_MESSAGE_ROLE,
   serializedRequestBytes,
 } from "./responses-input.js";
-export { HOSTED_SERVICE_PATH } from "./service-paths.js";
+export {
+  HOSTED_SERVICE_PATH,
+  VOICE_SERVICE_PATH,
+  VOICE_SERVICE_SECRET_HEADER,
+} from "./service-paths.js";
 export {
   HOSTED_API_ERROR,
   type HostedApiError,

--- a/packages/hosted/src/live-contract.test.ts
+++ b/packages/hosted/src/live-contract.test.ts
@@ -1,0 +1,182 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { LIVE_INPUT_BOUNDS, LIVE_VOICE } from "@sidecar/live";
+import { SCHEMA_REFUSAL, type UnparsedWireValue, type WireValue } from "@sidecar/wire";
+import {
+  HOSTED_VOICE_SERVICE_ORIGIN,
+  hostedVoiceServiceOrigin,
+  isHostedVoiceServiceAddress,
+  liveSessionCreatedSchema,
+  SESSION_CREATE_BOUNDS,
+  sessionCreatedFrameSchema,
+  sessionCreateFrameSchema,
+  VOICE_SERVICE_FRAME,
+} from "./live-contract.js";
+import { VOICE_SERVICE_PATH } from "./service-paths.js";
+
+const SDP =
+  "v=0\r\no=- 1 1 IN IP4 127.0.0.1\r\ns=-\r\nt=0 0\r\nm=audio 9 UDP/TLS/RTP/SAVPF 111\r\n";
+
+const developer = {
+  type: "message",
+  role: "developer",
+  content: [{ type: "input_text", text: "Roster: one session working." }],
+};
+const part = { type: "input_text", text: "What needs me?" };
+const user = { type: "message", role: "user", content: [part] };
+const assistant = {
+  type: "message",
+  role: "assistant",
+  content: [{ type: "output_text", text: "Nothing yet." }],
+};
+
+function createFrame(overrides: { [field: string]: UnparsedWireValue } = {}) {
+  return {
+    type: VOICE_SERVICE_FRAME.SESSION_CREATE,
+    sdp: SDP,
+    voice: LIVE_VOICE.MARIN,
+    input: [developer, user, assistant],
+    ...overrides,
+  };
+}
+
+test("a session.create frame round-trips with its offer and seed as written", () => {
+  const frame = createFrame();
+  assert.deepEqual(sessionCreateFrameSchema.parse(frame), frame);
+});
+
+test("a session.create frame may open with no history at all", () => {
+  const parsed = sessionCreateFrameSchema.parse(createFrame({ input: [] }));
+  assert.deepEqual(parsed?.input, []);
+});
+
+test("a voice outside the Live built-in set is refused at the voice field", () => {
+  const read = sessionCreateFrameSchema.read(createFrame({ voice: "hal" }));
+  assert.equal(read.ok, false);
+  if (!read.ok) {
+    assert.equal(read.refusal, SCHEMA_REFUSAL.MALFORMED);
+    assert.deepEqual(read.path, ["voice"]);
+  }
+});
+
+test("a seed past the Live input bound is too large, one item under it is not", () => {
+  const atBound = Array.from({ length: LIVE_INPUT_BOUNDS.MESSAGES }, () => user);
+  assert.equal(sessionCreateFrameSchema.read(createFrame({ input: atBound })).ok, true);
+  const over = sessionCreateFrameSchema.read(createFrame({ input: [...atBound, user] }));
+  assert.equal(over.ok, false);
+  if (!over.ok) {
+    assert.equal(over.refusal, SCHEMA_REFUSAL.TOO_LARGE);
+    assert.deepEqual(over.path, ["input"]);
+  }
+});
+
+test("an item's text past its character bound refuses the frame at that item", () => {
+  const long = {
+    ...user,
+    content: [{ type: "input_text", text: "x".repeat(SESSION_CREATE_BOUNDS.ITEM_CHARS + 1) }],
+  };
+  const read = sessionCreateFrameSchema.read(createFrame({ input: [developer, long] }));
+  assert.equal(read.ok, false);
+  if (!read.ok) assert.deepEqual(read.path, ["input", 1]);
+  const atBound = {
+    ...long,
+    content: [{ type: "input_text", text: "x".repeat(SESSION_CREATE_BOUNDS.ITEM_CHARS) }],
+  };
+  assert.equal(sessionCreateFrameSchema.read(createFrame({ input: [atBound] })).ok, true);
+});
+
+test("a seed item is a message of one text part of the type its role writes, and nothing else", () => {
+  const cases: [WireValue, boolean][] = [
+    [{ ...user, role: "system" }, false],
+    [{ ...user, content: [{ type: "output_text", text: "wrong part" }] }, false],
+    [{ ...assistant, content: [{ type: "input_text", text: "wrong part" }] }, false],
+    [{ ...assistant, content: [{ type: "text", text: "plain" }] }, false],
+    [{ ...user, content: [] }, false],
+    [{ ...user, content: [part, part] }, false],
+    [{ ...user, id: "msg_1" }, false],
+    [{ ...user, status: "completed" }, false],
+    [{ role: "user", content: [part] }, false],
+    [user, true],
+    [assistant, true],
+  ];
+  for (const [item, admitted] of cases) {
+    assert.equal(sessionCreateFrameSchema.read(createFrame({ input: [item] })).ok, admitted);
+  }
+});
+
+test("a frame of the other type, or with a field beside the four, is not a session.create", () => {
+  assert.equal(
+    sessionCreateFrameSchema.read(createFrame({ type: VOICE_SERVICE_FRAME.SESSION_CREATED })).ok,
+    false,
+  );
+  assert.equal(sessionCreateFrameSchema.read(createFrame({ model: "gpt-live-1" })).ok, false);
+  assert.equal(sessionCreateFrameSchema.read(createFrame({ sdp: "   " })).ok, false);
+});
+
+test("a session.created frame round-trips, with or without a quota, ignoring what a newer service adds", () => {
+  const created = {
+    type: VOICE_SERVICE_FRAME.SESSION_CREATED,
+    sessionId: "live_123",
+    sdpAnswer: SDP,
+  };
+  assert.deepEqual(sessionCreatedFrameSchema.parse({ ...created, later: true }), created);
+  const quota = { used: 2, limit: 30, resetsAt: 1_800_000_000_000 };
+  assert.deepEqual(sessionCreatedFrameSchema.parse({ ...created, quota })?.quota, quota);
+  const misquoted = sessionCreatedFrameSchema.parse({ ...created, quota: { used: -1 } });
+  assert.ok(misquoted);
+  assert.equal("quota" in misquoted, false);
+});
+
+test("the created session read on its own is the id and the answer, both required", () => {
+  assert.deepEqual(
+    liveSessionCreatedSchema.parse({ sessionId: "live_123", sdpAnswer: SDP, quota: {} }),
+    {
+      sessionId: "live_123",
+      sdpAnswer: SDP,
+    },
+  );
+  assert.equal(liveSessionCreatedSchema.parse({ sessionId: "live_123" }), undefined);
+  assert.equal(liveSessionCreatedSchema.parse({ sdpAnswer: SDP }), undefined);
+});
+
+test("the frame types are two distinct members", () => {
+  assert.equal(new Set(Object.values(VOICE_SERVICE_FRAME)).size, 2);
+});
+
+test("an address is the voice service's by origin alone", () => {
+  assert.equal(
+    isHostedVoiceServiceAddress(`${HOSTED_VOICE_SERVICE_ORIGIN}${VOICE_SERVICE_PATH.SESSIONS}`),
+    true,
+  );
+  assert.equal(isHostedVoiceServiceAddress(`${HOSTED_VOICE_SERVICE_ORIGIN}/other?x=1#y`), true);
+  assert.equal(isHostedVoiceServiceAddress("wss://voice.tryluke.dev.evil.example/sessions"), false);
+  assert.equal(isHostedVoiceServiceAddress("ws://voice.tryluke.dev/sessions"), false);
+  assert.equal(isHostedVoiceServiceAddress("wss://voice.tryluke.dev:8443/sessions"), false);
+  assert.equal(isHostedVoiceServiceAddress("not a url"), false);
+  assert.equal(new URL(HOSTED_VOICE_SERVICE_ORIGIN).origin, HOSTED_VOICE_SERVICE_ORIGIN);
+});
+
+test("a development override reduces to its origin; a packaged build never leaves the pinned one", () => {
+  assert.equal(
+    hostedVoiceServiceOrigin({ packaged: false, override: undefined }),
+    HOSTED_VOICE_SERVICE_ORIGIN,
+  );
+  assert.equal(
+    hostedVoiceServiceOrigin({ packaged: false, override: "ws://localhost:8788/sessions" }),
+    "ws://localhost:8788",
+  );
+  assert.equal(
+    hostedVoiceServiceOrigin({ packaged: true, override: "ws://localhost:8788" }),
+    HOSTED_VOICE_SERVICE_ORIGIN,
+  );
+  assert.equal(
+    hostedVoiceServiceOrigin({ packaged: false, override: "localhost:8788" }),
+    HOSTED_VOICE_SERVICE_ORIGIN,
+  );
+  assert.equal(
+    hostedVoiceServiceOrigin({ packaged: false, override: "data:text/plain,x" }),
+    HOSTED_VOICE_SERVICE_ORIGIN,
+  );
+  const local = hostedVoiceServiceOrigin({ packaged: false, override: "ws://localhost:8788" });
+  assert.equal(isHostedVoiceServiceAddress("ws://localhost:8788/sessions", local), true);
+});

--- a/packages/hosted/src/live-contract.ts
+++ b/packages/hosted/src/live-contract.ts
@@ -1,0 +1,183 @@
+import {
+  type InitialItem,
+  LIVE_INPUT_BOUNDS,
+  LIVE_VOICE_LIST,
+  type LiveVoice,
+  SEED_CONTENT_TYPE,
+  SEED_ITEM_TYPE,
+  SEED_ROLE,
+} from "@sidecar/live";
+import { RECORD_EXTRA_KEYS, SCHEMA_REFUSAL, type Schema, s, TEXT_ENDS } from "@sidecar/wire";
+import { type HostedQuota, hostedQuotaSchema } from "./service-wire.js";
+
+/**
+ * The desktop's contract with the hosted voice service, the one process on
+ * Luke's side that may hold a GPT Live project key: it creates the session at
+ * OpenAI (`POST /v1/live/sessions`), attaches the trusted sideband itself, and
+ * then carries Live events between the desktop and OpenAI untouched. The
+ * desktop reaches it over one WebSocket per session, and what travels on that
+ * socket before the Live events do is declared here, once, for both ends.
+ */
+
+/**
+ * The one origin a hosted desktop opens a voice socket to. Pinned by the
+ * build the way `HOSTED_CALLS_URL` pins the Realtime host, and compared as an
+ * origin — scheme, host, and port — so a path or query can never make
+ * another host read as Luke's service. A development build may be pointed
+ * elsewhere through {@link hostedVoiceServiceOrigin}; a packaged one may not.
+ */
+export const HOSTED_VOICE_SERVICE_ORIGIN = "wss://voice.tryluke.dev";
+
+/** Whether an address is on the hosted voice service's origin, by `URL.origin` alone. */
+export function isHostedVoiceServiceAddress(address: string, origin = HOSTED_VOICE_SERVICE_ORIGIN) {
+  try {
+    return new URL(address).origin === origin;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * The origin a build connects to: the pinned one, or — only where the caller
+ * says the build is unpackaged and hands an override it read from its own
+ * environment, the same mechanism the account service's development override
+ * uses — that override reduced to its origin. An override that is not an
+ * absolute URL is ignored rather than reached.
+ */
+export function hostedVoiceServiceOrigin(options: {
+  packaged: boolean;
+  override: string | undefined;
+}): string {
+  if (options.packaged || options.override === undefined) return HOSTED_VOICE_SERVICE_ORIGIN;
+  try {
+    const origin = new URL(options.override).origin;
+    return origin === "null" ? HOSTED_VOICE_SERVICE_ORIGIN : origin;
+  } catch {
+    return HOSTED_VOICE_SERVICE_ORIGIN;
+  }
+}
+
+/** The frames the desktop and the voice service exchange before Live events flow. */
+export const VOICE_SERVICE_FRAME = {
+  /** The desktop's first and only frame of its own: the offer, the voice, and the seed. */
+  SESSION_CREATE: "session.create",
+  /** The service's answer once OpenAI has created the session and the sideband stands. */
+  SESSION_CREATED: "session.created",
+} as const;
+
+/**
+ * The character bounds of a `session.create` frame. The seed's message count
+ * is the API's own, `LIVE_INPUT_BOUNDS.MESSAGES`; the bound per item's text is
+ * the whole of the API's token budget for `input` at four characters a
+ * token, so a frame the API would refuse is refused here before the service
+ * spends a session on it. The offer bound is generous for an SDP, which is a
+ * few kilobytes.
+ */
+export const SESSION_CREATE_BOUNDS = {
+  ITEM_CHARS: LIVE_INPUT_BOUNDS.TOKENS * 4,
+  SDP_CHARS: 65_536,
+} as const;
+
+/** What the service answered with: the session's opaque id and the SDP answer to set as the remote description. */
+export interface LiveSessionCreated {
+  sessionId: string;
+  sdpAnswer: string;
+}
+
+/** The desktop's opening frame. */
+export interface SessionCreateFrame {
+  type: typeof VOICE_SERVICE_FRAME.SESSION_CREATE;
+  sdp: string;
+  voice: LiveVoice;
+  input: InitialItem[];
+}
+
+/** The service's answer, and the allowance the session was spent against. */
+export interface SessionCreatedFrame extends LiveSessionCreated {
+  type: typeof VOICE_SERVICE_FRAME.SESSION_CREATED;
+  quota?: HostedQuota;
+}
+
+/**
+ * An SDP is admitted as written: its lines are its syntax, and a reader that
+ * trimmed or collapsed them would hand the peer something the other end did
+ * not say. A seed item's text is kept the same way, for the reason the seed
+ * wrote it.
+ */
+function verbatimText(max: number): Schema<string> {
+  return s.refine(
+    s.text({ ends: TEXT_ENDS.KEEP, allowEmpty: true, max }),
+    (value) => value.trim().length > 0,
+  );
+}
+
+const itemText = verbatimText(SESSION_CREATE_BOUNDS.ITEM_CHARS);
+
+/**
+ * Exactly one part, answered as the one-element tuple the seed type names
+ * rather than as a list that happens to hold one. The list bound already
+ * refuses any other count; the reader is what lets the type say so.
+ */
+function onlyPart<Part>(part: Schema<Part>): Schema<readonly [Part]> {
+  const list = s.array(part, { minimum: 1, max: 1 });
+  return s.reader({
+    read: (value) => {
+      const read = list.read(value);
+      if (!read.ok) return read;
+      const [only] = read.value;
+      return only === undefined
+        ? { ok: false, refusal: SCHEMA_REFUSAL.MALFORMED, path: [] }
+        : { ok: true, value: [only] };
+    },
+    jsonSchema: list.jsonSchema,
+  });
+}
+
+/**
+ * One history message as `@sidecar/live` seeds it: the `message` type, a
+ * role, and exactly one text part of the type that role writes. The SDK's
+ * `InitialItem` also allows an id, a status, and a plain `text` part; none
+ * is admitted, because the service composes the request to OpenAI from this
+ * frame and takes into it only what the desktop's seed has a reason to send.
+ */
+function seedMessage<
+  Role extends InitialItem["role"],
+  Part extends InitialItem["content"][0]["type"],
+>(role: Role, part: Part) {
+  return s.record({
+    type: s.literal(SEED_ITEM_TYPE),
+    role: s.literal(role),
+    content: onlyPart(s.record({ type: s.literal(part), text: itemText })),
+  });
+}
+
+const liveInitialItemSchema: Schema<InitialItem> = s.union([
+  seedMessage(SEED_ROLE.DEVELOPER, SEED_CONTENT_TYPE.INPUT_TEXT),
+  seedMessage(SEED_ROLE.USER, SEED_CONTENT_TYPE.INPUT_TEXT),
+  seedMessage(SEED_ROLE.ASSISTANT, SEED_CONTENT_TYPE.OUTPUT_TEXT),
+]);
+
+export const sessionCreateFrameSchema: Schema<SessionCreateFrame> = s.record({
+  type: s.literal(VOICE_SERVICE_FRAME.SESSION_CREATE),
+  sdp: verbatimText(SESSION_CREATE_BOUNDS.SDP_CHARS),
+  voice: s.enumOf(LIVE_VOICE_LIST),
+  input: s.array(liveInitialItemSchema, { max: LIVE_INPUT_BOUNDS.MESSAGES }),
+});
+
+const CREATED_FIELDS = {
+  sessionId: s.text(),
+  sdpAnswer: verbatimText(SESSION_CREATE_BOUNDS.SDP_CHARS),
+} as const;
+
+export const liveSessionCreatedSchema: Schema<LiveSessionCreated> = s.record(CREATED_FIELDS, {
+  extraKeys: RECORD_EXTRA_KEYS.IGNORE,
+});
+
+export const sessionCreatedFrameSchema: Schema<SessionCreatedFrame> = s.record(
+  {
+    type: s.literal(VOICE_SERVICE_FRAME.SESSION_CREATED),
+    ...CREATED_FIELDS,
+    quota: s.dropRefused(hostedQuotaSchema),
+  },
+  { extraKeys: RECORD_EXTRA_KEYS.IGNORE },
+);

--- a/packages/hosted/src/service-paths.test.ts
+++ b/packages/hosted/src/service-paths.test.ts
@@ -1,6 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { HOSTED_SERVICE_PATH } from "./service-paths.js";
+import {
+  HOSTED_SERVICE_PATH,
+  VOICE_SERVICE_PATH,
+  VOICE_SERVICE_SECRET_HEADER,
+} from "./service-paths.js";
 
 test("the introduction mint has its own path beside the ordinary one", () => {
   assert.equal(HOSTED_SERVICE_PATH.INTRODUCTION_MINT, "/api/voice/introduction-mint");
@@ -13,4 +17,20 @@ test("account preferences have a stable endpoint path", () => {
 
 test("the device registration has a stable endpoint path", () => {
   assert.equal(HOSTED_SERVICE_PATH.DEVICES, "/api/devices");
+});
+
+test("the voice service's internal routes sit under one internal prefix", () => {
+  assert.equal(HOSTED_SERVICE_PATH.VOICE_AUTHORIZE, "/api/internal/voice/authorize");
+  assert.equal(HOSTED_SERVICE_PATH.VOICE_USAGE, "/api/internal/voice/usage");
+  assert.notEqual(HOSTED_SERVICE_PATH.VOICE_AUTHORIZE, HOSTED_SERVICE_PATH.VOICE_USAGE);
+});
+
+test("the voice service's own paths are two distinct upgrades", () => {
+  assert.deepEqual(Object.values(VOICE_SERVICE_PATH), ["/sessions", "/introduction"]);
+  assert.equal(new Set(Object.values(VOICE_SERVICE_PATH)).size, 2);
+});
+
+test("the service secret travels in a header of its own, lowercase as HTTP/2 carries it", () => {
+  assert.equal(VOICE_SERVICE_SECRET_HEADER, VOICE_SERVICE_SECRET_HEADER.toLowerCase());
+  assert.notEqual(VOICE_SERVICE_SECRET_HEADER, "authorization");
 });

--- a/packages/hosted/src/service-paths.ts
+++ b/packages/hosted/src/service-paths.ts
@@ -96,4 +96,34 @@ export const HOSTED_SERVICE_PATH = {
    * conversation screen asks; no observation pass ever issues this read.
    */
   SESSION_MESSAGES: "/api/sessions/messages",
+  /**
+   * The two routes only the hosted voice service calls, under
+   * {@link VOICE_SERVICE_SECRET_HEADER} rather than an account bearer: before
+   * creating a Live session, authorize the account whose bearer opened the
+   * socket and spend its voice allowance (POST); after `session.closed`,
+   * record the billed seconds once (POST). No desktop calls either.
+   */
+  VOICE_AUTHORIZE: "/api/internal/voice/authorize",
+  VOICE_USAGE: "/api/internal/voice/usage",
 } as const;
+
+/**
+ * Where the hosted voice service answers, rooted at
+ * `HOSTED_VOICE_SERVICE_ORIGIN` rather than the account service's origin,
+ * because the service is its own long-running process. Each path is a
+ * WebSocket upgrade: one session per socket.
+ */
+export const VOICE_SERVICE_PATH = {
+  /** A signed-in desktop's voice session; the account bearer travels on the handshake. */
+  SESSIONS: "/sessions",
+  /** The accountless introduction session, metered by the service itself; no bearer. */
+  INTRODUCTION: "/introduction",
+} as const;
+
+/**
+ * The header the voice service authenticates its internal calls with. The
+ * value is a shared secret both deployments hold, compared on the account
+ * service in constant time, and it is the whole of the identity those two
+ * routes accept: an account bearer on them is refused.
+ */
+export const VOICE_SERVICE_SECRET_HEADER = "x-luke-voice-service-secret";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -533,6 +533,9 @@ importers:
 
   packages/hosted:
     dependencies:
+      '@sidecar/live':
+        specifier: workspace:*
+        version: link:../live
       '@sidecar/runtime':
         specifier: workspace:*
         version: link:../runtime


### PR DESCRIPTION
## What

PR2 of the GPT Live rollout, stacked on #911 (`live/01-live-package`). Additive wire vocabulary in `@sidecar/hosted`, no consumer yet:

- `live-contract.ts`: `VOICE_SERVICE_FRAME` (`session.create`, `session.created`) and one `@sidecar/wire` schema per frame. The desktop's `session.create` carries the SDP offer as written, a voice that must be a member of `LIVE_VOICE`, and a seed of at most `LIVE_INPUT_BOUNDS.MESSAGES` (128) `InitialItem`s, each the `message` type with exactly one text part of the type its role writes, and each item's text bounded so a frame the API would refuse is refused before a session is spent. The service's `session.created` carries the opaque session id, the SDP answer, and the quota (dropped if mis-answered). `LiveSessionCreated` is the same read without the frame type. `HOSTED_VOICE_SERVICE_ORIGIN` is pinned by the build (`wss://voice.tryluke.dev`), compared as `URL.origin` by `isHostedVoiceServiceAddress`, and `hostedVoiceServiceOrigin` reduces a development override to its origin and refuses one past the packaging boundary, the same rule the host applies to `LUKE_ACCOUNT_BASE_URL`. The package reads no environment itself.
- `service-paths.ts`: `VOICE_SERVICE_PATH` (`/sessions`, `/introduction`) on the voice service's origin; `HOSTED_SERVICE_PATH.VOICE_AUTHORIZE` and `VOICE_USAGE` under `/api/internal/voice/…` on the account service; `VOICE_SERVICE_SECRET_HEADER` for the shared secret those two routes take. The Realtime mint paths and `realtime-contract.ts` are untouched.
- `apps/web/server/core.ts`: a side-effect door for `@sidecar/live`, which hosted now reaches (`packages/AGENTS.md`'s door rule; `repository-checks.sh` enforces it).
- `packages/hosted/AGENTS.md` documents the contract and the dependency direction (`@sidecar/live` imports nothing of hosted; the graph stays acyclic).

## How it follows the GPT Live docs

- The WebRTC guide: the trusted server exchanges the browser's SDP offer for an answer through `POST /v1/live/sessions` and the answer is `{ session: { id }, transport: { sdp } }`; the frames carry exactly those two values back to the desktop, the id treated as opaque, and the SDP verbatim because its lines are its syntax.
- `input` is bounded to 128 messages of `developer`/`user`/`assistant` with one text part each, per the session config docs and the SDK's `InitialItem` (`resources/live/live.d.ts`); an id, status, or plain `text` part the SDK also allows is not admitted, since the desktop's seed (`@sidecar/live`'s `seed.ts`) never writes one.
- The voice is admitted only as a member of the SDK's `BuiltInVoice` list, which `LIVE_VOICE` transcribes.
- Server-side controls: create and attach are one process on the service, so no ticket handshake exists; after the two frames, Live events pass through as themselves and are declared in `@sidecar/live`, not here.

## Verify

```
./scripts/check.sh
```

Passes locally (lint, knip, typecheck, tests, build). `packages/hosted`: 94 tests pass, including frame round-trips, refusal of a bad voice (`path: ["voice"]`), an oversize seed (`too-large` at `["input"]`), an oversize item, non-seed item shapes, quota drop, and origin comparison (host suffix, scheme, and port mismatches all refused). No macOS or UI code is touched, so `verify.sh` does not apply.

## Reviews applied

Cursor's thermo-nuclear code quality review (`cursor/plugins` `cursor-team-kit`) and the ponytail review (`DietrichGebert/ponytail`) were read and applied to the diff: an unused exported frame-type alias and an exported item schema nothing outside the frame needs were removed, a chained type assertion was replaced by a small reader that answers the one-element tuple honestly, and the test fixtures were given concrete wire types.

## Note for the orchestrator

The pinned origin `wss://voice.tryluke.dev` is a choice this PR makes; PR4's deployment must answer there, or this constant moves with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/f2397aee-fd66-441b-ad42-544b4f24c048)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34524469912/artifacts/10171072229) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34524469912)

- Commit: `b09d441390eecf4a91fa3909d24e5556dbeb13a3`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
