### PR TITLE
feat(web): internal voice authorize and usage routes

### DIFF
--- a/apps/web/api/internal/voice/authorize.ts
+++ b/apps/web/api/internal/voice/authorize.ts
@@ -1,0 +1,29 @@
+import { auth } from "../../../server/auth.js";
+import { getDatabase } from "../../../server/db/index.js";
+import {
+  oauthUserInfoFromAuthAnswer,
+  userIdForAuthorization,
+} from "../../../server/hosted/bearer.js";
+import { spendHostedMeter } from "../../../server/hosted/quota.js";
+import { handleVoiceAuthorize } from "../../../server/hosted/voice-authorize.js";
+import { VOICE_SERVICE_ENVIRONMENT } from "../../../server/hosted/voice-service-secret.js";
+
+/**
+ * Tells the hosted voice service whose session it is about to create and
+ * spends that account's allowance, under the shared service secret. The logic
+ * lives in `server/hosted/voice-authorize.ts`; this file only hands it the
+ * deployment's real seams.
+ */
+export default {
+  fetch(request: Request): Promise<Response> {
+    return handleVoiceAuthorize({
+      request,
+      serviceSecret: process.env[VOICE_SERVICE_ENVIRONMENT.SECRET],
+      resolveUserId: (authorization) =>
+        userIdForAuthorization(authorization, async (input) =>
+          oauthUserInfoFromAuthAnswer(await auth.api.oauth2UserInfo(input)),
+        ),
+      spend: (userId) => spendHostedMeter(getDatabase(), { userId, now: Date.now() }),
+    });
+  },
+};

--- a/apps/web/api/internal/voice/usage.ts
+++ b/apps/web/api/internal/voice/usage.ts
@@ -1,0 +1,20 @@
+import { getDatabase } from "../../../server/db/index.js";
+import { recordVoiceSeconds } from "../../../server/hosted/quota.js";
+import { VOICE_SERVICE_ENVIRONMENT } from "../../../server/hosted/voice-service-secret.js";
+import { handleVoiceUsage } from "../../../server/hosted/voice-usage.js";
+
+/**
+ * Records the seconds one closed GPT Live session was billed, once per session
+ * id, under the shared service secret. The logic lives in
+ * `server/hosted/voice-usage.ts`; this file only hands it the deployment's
+ * real seams.
+ */
+export default {
+  fetch(request: Request): Promise<Response> {
+    return handleVoiceUsage({
+      request,
+      serviceSecret: process.env[VOICE_SERVICE_ENVIRONMENT.SECRET],
+      record: (report) => recordVoiceSeconds(getDatabase(), { ...report, now: Date.now() }),
+    });
+  },
+};

--- a/apps/web/drizzle/0013_amusing_shape.sql
+++ b/apps/web/drizzle/0013_amusing_shape.sql
@@ -1,0 +1,9 @@
+CREATE TABLE "voice_session_usage" (
+	"session_id" text PRIMARY KEY NOT NULL,
+	"user_id" text NOT NULL,
+	"seconds" double precision NOT NULL,
+	"recorded_at" bigint NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "hosted_usage" ADD COLUMN "voice_seconds" double precision DEFAULT 0 NOT NULL;--> statement-breakpoint
+ALTER TABLE "voice_session_usage" ADD CONSTRAINT "voice_session_usage_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;

--- a/apps/web/drizzle/meta/0013_snapshot.json
+++ b/apps/web/drizzle/meta/0013_snapshot.json
@@ -1,0 +1,3076 @@
+{
+  "id": "e05145f3-64d3-464e-a668-725cc35234b3",
+  "prevId": "0bf2f341-43ea-4eee-a469-67c628f5bb8d",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.jwks": {
+      "name": "jwks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_key": {
+          "name": "private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_access_token": {
+      "name": "oauth_access_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_id": {
+          "name": "refresh_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "oauthAccessToken_clientId_idx": {
+          "name": "oauthAccessToken_clientId_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthAccessToken_sessionId_idx": {
+          "name": "oauthAccessToken_sessionId_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthAccessToken_userId_idx": {
+          "name": "oauthAccessToken_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthAccessToken_refreshId_idx": {
+          "name": "oauthAccessToken_refreshId_idx",
+          "columns": [
+            {
+              "expression": "refresh_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_access_token_client_id_oauth_client_client_id_fk": {
+          "name": "oauth_access_token_client_id_oauth_client_client_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "oauth_client",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["client_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_session_id_session_id_fk": {
+          "name": "oauth_access_token_session_id_session_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "session",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_user_id_user_id_fk": {
+          "name": "oauth_access_token_user_id_user_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_refresh_id_oauth_refresh_token_id_fk": {
+          "name": "oauth_access_token_refresh_id_oauth_refresh_token_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "oauth_refresh_token",
+          "columnsFrom": ["refresh_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_access_token_token_unique": {
+          "name": "oauth_access_token_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_client": {
+      "name": "oauth_client",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "skip_consent": {
+          "name": "skip_consent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enable_end_session": {
+          "name": "enable_end_session",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject_type": {
+          "name": "subject_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contacts": {
+          "name": "contacts",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tos": {
+          "name": "tos",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "policy": {
+          "name": "policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_id": {
+          "name": "software_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_version": {
+          "name": "software_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_statement": {
+          "name": "software_statement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_logout_redirect_uris": {
+          "name": "post_logout_redirect_uris",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_endpoint_auth_method": {
+          "name": "token_endpoint_auth_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grant_types": {
+          "name": "grant_types",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_types": {
+          "name": "response_types",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public": {
+          "name": "public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "require_pkce": {
+          "name": "require_pkce",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "oauthClient_userId_idx": {
+          "name": "oauthClient_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_client_user_id_user_id_fk": {
+          "name": "oauth_client_user_id_user_id_fk",
+          "tableFrom": "oauth_client",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_client_client_id_unique": {
+          "name": "oauth_client_client_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["client_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_consent": {
+      "name": "oauth_consent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "oauthConsent_clientId_idx": {
+          "name": "oauthConsent_clientId_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthConsent_userId_idx": {
+          "name": "oauthConsent_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_consent_client_id_oauth_client_client_id_fk": {
+          "name": "oauth_consent_client_id_oauth_client_client_id_fk",
+          "tableFrom": "oauth_consent",
+          "tableTo": "oauth_client",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["client_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_consent_user_id_user_id_fk": {
+          "name": "oauth_consent_user_id_user_id_fk",
+          "tableFrom": "oauth_consent",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_refresh_token": {
+      "name": "oauth_refresh_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked": {
+          "name": "revoked",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_time": {
+          "name": "auth_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "oauthRefreshToken_clientId_idx": {
+          "name": "oauthRefreshToken_clientId_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthRefreshToken_sessionId_idx": {
+          "name": "oauthRefreshToken_sessionId_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthRefreshToken_userId_idx": {
+          "name": "oauthRefreshToken_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_refresh_token_client_id_oauth_client_client_id_fk": {
+          "name": "oauth_refresh_token_client_id_oauth_client_client_id_fk",
+          "tableFrom": "oauth_refresh_token",
+          "tableTo": "oauth_client",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["client_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_refresh_token_session_id_session_id_fk": {
+          "name": "oauth_refresh_token_session_id_session_id_fk",
+          "tableFrom": "oauth_refresh_token",
+          "tableTo": "session",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "oauth_refresh_token_user_id_user_id_fk": {
+          "name": "oauth_refresh_token_user_id_user_id_fk",
+          "tableFrom": "oauth_refresh_token",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_refresh_token_token_unique": {
+          "name": "oauth_refresh_token_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_login_method": {
+          "name": "last_login_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'user'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.briefing": {
+      "name": "briefing",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_key": {
+          "name": "session_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sealed_words": {
+          "name": "sealed_words",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claimed_by_device_id": {
+          "name": "claimed_by_device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settled_at": {
+          "name": "settled_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "briefing_by_user_state": {
+          "name": "briefing_by_user_state",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "decided_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "briefing_user_id_user_id_fk": {
+          "name": "briefing_user_id_user_id_fk",
+          "tableFrom": "briefing",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "briefing_user_id_id_pk": {
+          "name": "briefing_user_id_id_pk",
+          "columns": ["user_id", "id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.action_receipt": {
+      "name": "action_receipt",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "call_id": {
+          "name": "call_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ordinal": {
+          "name": "ordinal",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sealed_arguments": {
+          "name": "sealed_arguments",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sealed_output": {
+          "name": "sealed_output",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settled_at": {
+          "name": "settled_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "action_receipt_by_session": {
+          "name": "action_receipt_by_session",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ordinal",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "action_receipt_session_fk": {
+          "name": "action_receipt_session_fk",
+          "tableFrom": "action_receipt",
+          "tableTo": "conversation_session",
+          "columnsFrom": ["user_id", "session_id"],
+          "columnsTo": ["user_id", "session_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "action_receipt_user_id_run_id_call_id_pk": {
+          "name": "action_receipt_user_id_run_id_call_id_pk",
+          "columns": ["user_id", "run_id", "call_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.compaction_boundary": {
+      "name": "compaction_boundary",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_key": {
+          "name": "session_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transcript_sequence": {
+          "name": "transcript_sequence",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dropped": {
+          "name": "dropped",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "checkpoint_format": {
+          "name": "checkpoint_format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "compaction_boundary_conversation_fk": {
+          "name": "compaction_boundary_conversation_fk",
+          "tableFrom": "compaction_boundary",
+          "tableTo": "conversation",
+          "columnsFrom": ["user_id", "session_key"],
+          "columnsTo": ["user_id", "session_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "compaction_boundary_user_id_session_key_transcript_sequence_pk": {
+          "name": "compaction_boundary_user_id_session_key_transcript_sequence_pk",
+          "columns": ["user_id", "session_key", "transcript_sequence"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation": {
+      "name": "conversation",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_key": {
+          "name": "session_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "next_line_sequence": {
+          "name": "next_line_sequence",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "next_transcript_sequence": {
+          "name": "next_transcript_sequence",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "cleared_at": {
+          "name": "cleared_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "conversation_user_id_user_id_fk": {
+          "name": "conversation_user_id_user_id_fk",
+          "tableFrom": "conversation",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "conversation_user_id_session_key_pk": {
+          "name": "conversation_user_id_session_key_pk",
+          "columns": ["user_id", "session_key"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation_line": {
+      "name": "conversation_line",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_key": {
+          "name": "session_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_key": {
+          "name": "event_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recorded_at": {
+          "name": "recorded_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_session_id": {
+          "name": "provider_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sealed_payload": {
+          "name": "sealed_payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "conversation_line_by_key": {
+          "name": "conversation_line_by_key",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_line_by_time": {
+          "name": "conversation_line_by_time",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recorded_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sequence",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_line_once_published": {
+          "name": "conversation_line_once_published",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"conversation_line\".\"request_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_line_conversation_fk": {
+          "name": "conversation_line_conversation_fk",
+          "tableFrom": "conversation_line",
+          "tableTo": "conversation",
+          "columnsFrom": ["user_id", "session_key"],
+          "columnsTo": ["user_id", "session_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "conversation_line_user_id_session_key_sequence_pk": {
+          "name": "conversation_line_user_id_session_key_sequence_pk",
+          "columns": ["user_id", "session_key", "sequence"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation_run": {
+      "name": "conversation_run",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ordinal": {
+          "name": "ordinal",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submission_id": {
+          "name": "submission_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "origin": {
+          "name": "origin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sealed_question": {
+          "name": "sealed_question",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revision": {
+          "name": "revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settled_at": {
+          "name": "settled_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sealed_text": {
+          "name": "sealed_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure": {
+          "name": "failure",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "performed_actions": {
+          "name": "performed_actions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unknown_actions": {
+          "name": "unknown_actions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ask_recorded_at": {
+          "name": "ask_recorded_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conversation_recorded_at": {
+          "name": "conversation_recorded_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_origin": {
+          "name": "run_origin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ending": {
+          "name": "ending",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_item_kinds": {
+          "name": "input_item_kinds",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transcript_bytes": {
+          "name": "transcript_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "elapsed_ms": {
+          "name": "elapsed_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_names": {
+          "name": "tool_names",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "compacted": {
+          "name": "compacted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "conversation_run_by_session": {
+          "name": "conversation_run_by_session",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ordinal",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_run_session_fk": {
+          "name": "conversation_run_session_fk",
+          "tableFrom": "conversation_run",
+          "tableTo": "conversation_session",
+          "columnsFrom": ["user_id", "session_id"],
+          "columnsTo": ["user_id", "session_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "conversation_run_user_id_run_id_pk": {
+          "name": "conversation_run_user_id_run_id_pk",
+          "columns": ["user_id", "run_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation_session": {
+      "name": "conversation_session",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_key": {
+          "name": "session_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reset_cleared_at": {
+          "name": "reset_cleared_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reset_generation_id": {
+          "name": "reset_generation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checkpoint_format": {
+          "name": "checkpoint_format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "compaction_count": {
+          "name": "compaction_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "conversation_session_one_standing": {
+          "name": "conversation_session_one_standing",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_session_conversation_fk": {
+          "name": "conversation_session_conversation_fk",
+          "tableFrom": "conversation_session",
+          "tableTo": "conversation",
+          "columnsFrom": ["user_id", "session_key"],
+          "columnsTo": ["user_id", "session_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "conversation_session_user_id_session_id_pk": {
+          "name": "conversation_session_user_id_session_id_pk",
+          "columns": ["user_id", "session_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.observation_capture_cursor": {
+      "name": "observation_capture_cursor",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_session_id": {
+          "name": "provider_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cursor": {
+          "name": "cursor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "observation_capture_cursor_session_fk": {
+          "name": "observation_capture_cursor_session_fk",
+          "tableFrom": "observation_capture_cursor",
+          "tableTo": "conversation_session",
+          "columnsFrom": ["user_id", "session_id"],
+          "columnsTo": ["user_id", "session_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "observation_capture_cursor_user_id_session_id_provider_id_provider_session_id_pk": {
+          "name": "observation_capture_cursor_user_id_session_id_provider_id_provider_session_id_pk",
+          "columns": ["user_id", "session_id", "provider_id", "provider_session_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.observation_cursor": {
+      "name": "observation_cursor",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_session_id": {
+          "name": "provider_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cursor": {
+          "name": "cursor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "observation_cursor_session_fk": {
+          "name": "observation_cursor_session_fk",
+          "tableFrom": "observation_cursor",
+          "tableTo": "conversation_session",
+          "columnsFrom": ["user_id", "session_id"],
+          "columnsTo": ["user_id", "session_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "observation_cursor_user_id_session_id_provider_id_provider_session_id_pk": {
+          "name": "observation_cursor_user_id_session_id_provider_id_provider_session_id_pk",
+          "columns": ["user_id", "session_id", "provider_id", "provider_session_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.observation_inbox_entry": {
+      "name": "observation_inbox_entry",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ordinal": {
+          "name": "ordinal",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entry_id": {
+          "name": "entry_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sealed_payload": {
+          "name": "sealed_payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "observation_inbox_entry_session_fk": {
+          "name": "observation_inbox_entry_session_fk",
+          "tableFrom": "observation_inbox_entry",
+          "tableTo": "conversation_session",
+          "columnsFrom": ["user_id", "session_id"],
+          "columnsTo": ["user_id", "session_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "observation_inbox_entry_user_id_session_id_ordinal_pk": {
+          "name": "observation_inbox_entry_user_id_session_id_ordinal_pk",
+          "columns": ["user_id", "session_id", "ordinal"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.runtime_checkpoint": {
+      "name": "runtime_checkpoint",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sealed_item": {
+          "name": "sealed_item",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "runtime_checkpoint_session_fk": {
+          "name": "runtime_checkpoint_session_fk",
+          "tableFrom": "runtime_checkpoint",
+          "tableTo": "conversation_session",
+          "columnsFrom": ["user_id", "session_id"],
+          "columnsTo": ["user_id", "session_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "runtime_checkpoint_user_id_session_id_sequence_pk": {
+          "name": "runtime_checkpoint_user_id_session_id_sequence_pk",
+          "columns": ["user_id", "session_id", "sequence"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transcript_event": {
+      "name": "transcript_event",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_key": {
+          "name": "session_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recorded_at": {
+          "name": "recorded_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sealed_payload": {
+          "name": "sealed_payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "transcript_event_conversation_fk": {
+          "name": "transcript_event_conversation_fk",
+          "tableFrom": "transcript_event",
+          "tableTo": "conversation",
+          "columnsFrom": ["user_id", "session_key"],
+          "columnsTo": ["user_id", "session_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "transcript_event_user_id_session_key_sequence_pk": {
+          "name": "transcript_event_user_id_session_key_sequence_pk",
+          "columns": ["user_id", "session_key", "sequence"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.devices": {
+      "name": "devices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "active_until": {
+          "name": "active_until",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "push_token": {
+          "name": "push_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "push_environment": {
+          "name": "push_environment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "devices_user_id_user_id_fk": {
+          "name": "devices_user_id_user_id_fk",
+          "tableFrom": "devices",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "devices_installation_id_unique": {
+          "name": "devices_installation_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["installation_id"]
+        },
+        "devices_push_token_unique": {
+          "name": "devices_push_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["push_token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.admin_favorite": {
+      "name": "admin_favorite",
+      "schema": "",
+      "columns": {
+        "admin_id": {
+          "name": "admin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "admin_favorite_admin_id_user_id_fk": {
+          "name": "admin_favorite_admin_id_user_id_fk",
+          "tableFrom": "admin_favorite",
+          "tableTo": "user",
+          "columnsFrom": ["admin_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "admin_favorite_user_id_user_id_fk": {
+          "name": "admin_favorite_user_id_user_id_fk",
+          "tableFrom": "admin_favorite",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "admin_favorite_admin_id_user_id_pk": {
+          "name": "admin_favorite_admin_id_user_id_pk",
+          "columns": ["admin_id", "user_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.account_preference": {
+      "name": "account_preference",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "voice": {
+          "name": "voice",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "voice_speed": {
+          "name": "voice_speed",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_workspace_provider": {
+          "name": "default_workspace_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_preference_user_id_user_id_fk": {
+          "name": "account_preference_user_id_user_id_fk",
+          "tableFrom": "account_preference",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.account_workspace_preference": {
+      "name": "account_workspace_preference",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_project_id": {
+          "name": "default_project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent": {
+          "name": "agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "effort": {
+          "name": "effort",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_workspace_preference_user_id_user_id_fk": {
+          "name": "account_workspace_preference_user_id_user_id_fk",
+          "tableFrom": "account_workspace_preference",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "account_workspace_preference_user_id_provider_id_pk": {
+          "name": "account_workspace_preference_user_id_provider_id_pk",
+          "columns": ["user_id", "provider_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.observation_pass": {
+      "name": "observation_pass",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "attempted_at": {
+          "name": "attempted_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure": {
+          "name": "failure",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "observation_pass_user_id_user_id_fk": {
+          "name": "observation_pass_user_id_user_id_fk",
+          "tableFrom": "observation_pass",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.roster_diff": {
+      "name": "roster_diff",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previous_observed_at": {
+          "name": "previous_observed_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sealed_payload": {
+          "name": "sealed_payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "roster_diff_by_user_pending": {
+          "name": "roster_diff_by_user_pending",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "consumed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "observed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "roster_diff_user_id_user_id_fk": {
+          "name": "roster_diff_user_id_user_id_fk",
+          "tableFrom": "roster_diff",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "roster_diff_user_id_id_pk": {
+          "name": "roster_diff_user_id_id_pk",
+          "columns": ["user_id", "id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.roster_snapshot": {
+      "name": "roster_snapshot",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "sealed_body": {
+          "name": "sealed_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "roster_snapshot_user_id_user_id_fk": {
+          "name": "roster_snapshot_user_id_user_id_fk",
+          "tableFrom": "roster_snapshot",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.hosted_usage": {
+      "name": "hosted_usage",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "day": {
+          "name": "day",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "calls": {
+          "name": "calls",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "voice_seconds": {
+          "name": "voice_seconds",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "hosted_usage_user_id_user_id_fk": {
+          "name": "hosted_usage_user_id_user_id_fk",
+          "tableFrom": "hosted_usage",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "hosted_usage_user_id_day_pk": {
+          "name": "hosted_usage_user_id_day_pk",
+          "columns": ["user_id", "day"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.introduction_usage": {
+      "name": "introduction_usage",
+      "schema": "",
+      "columns": {
+        "caller": {
+          "name": "caller",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "day": {
+          "name": "day",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mints": {
+          "name": "mints",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "introduction_usage_caller_day_pk": {
+          "name": "introduction_usage_caller_day_pk",
+          "columns": ["caller", "day"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.voice_session_usage": {
+      "name": "voice_session_usage",
+      "schema": "",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seconds": {
+          "name": "seconds",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recorded_at": {
+          "name": "recorded_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "voice_session_usage_user_id_user_id_fk": {
+          "name": "voice_session_usage_user_id_user_id_fk",
+          "tableFrom": "voice_session_usage",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provider_key": {
+      "name": "provider_key",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ciphertext": {
+          "name": "ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "provider_key_user_id_user_id_fk": {
+          "name": "provider_key_user_id_user_id_fk",
+          "tableFrom": "provider_key",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "provider_key_user_id_provider_id_pk": {
+          "name": "provider_key_user_id_provider_id_pk",
+          "columns": ["user_id", "provider_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.personal_fact": {
+      "name": "personal_fact",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ordinal": {
+          "name": "ordinal",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sealed_words": {
+          "name": "sealed_words",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "personal_fact_user_id_user_id_fk": {
+          "name": "personal_fact_user_id_user_id_fk",
+          "tableFrom": "personal_fact",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "personal_fact_user_id_id_pk": {
+          "name": "personal_fact_user_id_id_pk",
+          "columns": ["user_id", "id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspace_file": {
+      "name": "workspace_file",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sealed_content": {
+          "name": "sealed_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workspace_file_user_id_user_id_fk": {
+          "name": "workspace_file_user_id_user_id_fk",
+          "tableFrom": "workspace_file",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "workspace_file_user_id_path_pk": {
+          "name": "workspace_file_user_id_path_pk",
+          "columns": ["user_id", "path"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/web/drizzle/meta/_journal.json
+++ b/apps/web/drizzle/meta/_journal.json
@@ -92,6 +92,13 @@
       "when": 1788985706850,
       "tag": "0012_pale_molly_hayes",
       "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "7",
+      "when": 1789070771878,
+      "tag": "0013_amusing_shape",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/web/server/README.md
+++ b/apps/web/server/README.md
@@ -185,6 +185,41 @@ one atomic upsert before each upstream call, checked against the ceilings in
 long they run; a spend limit on the OpenAI project behind the key is the
 backstop and should be configured with it.
 
+## Hosted voice service routes
+
+`api/internal/voice/authorize.ts` and `api/internal/voice/usage.ts` are the
+two routes only the hosted voice service calls, the long-running process on
+its own origin that holds the GPT Live project key and owns each hosted voice
+session (`live-contract.ts` in `@sidecar/hosted` is the desktop's contract
+with it). Neither route takes an account bearer as its identity: both accept
+one header, `x-luke-voice-service-secret`, compared in constant time against
+`VOICE_SERVICE_SECRET`, and answer 503 while that variable is absent or
+blank, the same kill switch as every other hosted secret. Their paths are
+`HOSTED_SERVICE_PATH.VOICE_AUTHORIZE` and `VOICE_USAGE`, exact-path files
+under `api/internal/`, so Vercel's zero-config detection routes them without
+a `routes` entry.
+
+Authorize is asked before the service spends a session: the body carries the
+`Authorization` value the desktop opened its socket with, resolved to a user
+through the same in-process `/oauth2/userinfo` seam the mint uses, and the
+account's daily allowance is spent by the same `hosted_usage` meter every
+hosted operation shares, before any session exists, so a refused account costs
+no session. The answer is the user id and the quota; a bearer that resolves to
+nobody is a 401, a spent allowance a 429 carrying the quota.
+
+Usage is reported after `session.closed`: the user id authorize answered, the
+session id OpenAI minted, and the seconds it billed. `voice_session_usage`
+keeps one row per session id and is the idempotency ledger; a report the
+service repeats after a lost answer is answered `repeated` and moves nothing,
+and only a report that created its row adds to the day's `voice_seconds` on
+`hosted_usage`, in one transaction. The seconds column stands beside the call
+count rather than replacing it: a session still spends one call when it
+opens, and the mint routes and their meter stay as they are for installed
+desktops until the seconds are what the allowance is measured in. Both
+tables cascade with the user row. Nothing else calls these routes yet, and the
+desktop never does; the voice service's own origin is pinned by the desktop's
+build in `@sidecar/hosted` rather than answered by this deployment.
+
 ## Hosted brain inference
 
 `api/brain/capabilities.ts` and the four routes under `api/brain/v2/` run

--- a/apps/web/server/db/usage-schema.ts
+++ b/apps/web/server/db/usage-schema.ts
@@ -1,4 +1,4 @@
-import { integer, pgTable, primaryKey, text } from "drizzle-orm/pg-core";
+import { bigint, doublePrecision, integer, pgTable, primaryKey, text } from "drizzle-orm/pg-core";
 import { user } from "./auth-schema.js";
 
 /**
@@ -16,8 +16,15 @@ export const hostedUsage = pgTable(
       .references(() => user.id, { onDelete: "cascade" }),
     /** The UTC day the counter covers, as YYYY-MM-DD. */
     day: text("day").notNull(),
-    /** Hosted operations spent: a Realtime mint and a brain turn count alike. */
+    /** Hosted operations spent: a Realtime mint, a Live session opened, and a brain turn count alike. */
     calls: integer("calls").default(0).notNull(),
+    /**
+     * GPT Live seconds OpenAI billed for the day's closed sessions, as the
+     * voice service reported them. Recorded beside the count rather than in
+     * its place: a session still spends one call when it opens, and this is
+     * what the meter will move to once sessions, not opens, are what is bounded.
+     */
+    voiceSeconds: doublePrecision("voice_seconds").default(0).notNull(),
   },
   (table) => [primaryKey({ columns: [table.userId, table.day] })],
 );
@@ -39,3 +46,19 @@ export const introductionUsage = pgTable(
   },
   (table) => [primaryKey({ columns: [table.caller, table.day] })],
 );
+
+/**
+ * One closed GPT Live session's billed seconds, keyed by the session id OpenAI
+ * minted, so the voice service's report is taken once however many times it
+ * is sent: the row is the idempotency ledger, and the day's `voice_seconds`
+ * moves only when the row is new. Nothing of the conversation is here, only
+ * the id, the account, the seconds, and when the report landed.
+ */
+export const voiceSessionUsage = pgTable("voice_session_usage", {
+  sessionId: text("session_id").primaryKey(),
+  userId: text("user_id")
+    .notNull()
+    .references(() => user.id, { onDelete: "cascade" }),
+  seconds: doublePrecision("seconds").notNull(),
+  recordedAt: bigint("recorded_at", { mode: "number" }).notNull(),
+});

--- a/apps/web/server/hosted/bearer.ts
+++ b/apps/web/server/hosted/bearer.ts
@@ -26,11 +26,23 @@ export function oauthUserInfoFromAuthAnswer(value: UnparsedWireValue): OAuthUser
  * purpose: every failure is one 401, and the desktop's existing refresh
  * machinery is what answers it.
  */
-export async function hostedUserId(
+export function hostedUserId(
   request: Request,
   userInfo: UserInfoEndpoint,
 ): Promise<string | undefined> {
-  const authorization = request.headers.get("authorization")?.trim();
+  return userIdForAuthorization(request.headers.get("authorization"), userInfo);
+}
+
+/**
+ * The same resolution for an `Authorization` value that arrived somewhere
+ * other than on its own request: the voice service forwards the header the
+ * desktop opened its socket with, and it is read as if it had been sent here.
+ */
+export async function userIdForAuthorization(
+  value: string | null | undefined,
+  userInfo: UserInfoEndpoint,
+): Promise<string | undefined> {
+  const authorization = value?.trim();
   if (!authorization) return undefined;
   try {
     const identity = await userInfo({ headers: new Headers({ authorization }) });

--- a/apps/web/server/hosted/quota.ts
+++ b/apps/web/server/hosted/quota.ts
@@ -1,7 +1,9 @@
-import { sql } from "drizzle-orm";
-import type { HostedQuota } from "../core.js";
+import { eq, sql } from "drizzle-orm";
+import { type HostedQuota, VOICE_USAGE_RECORD } from "../core.js";
+import { user } from "../db/auth-schema.js";
 import type { createDatabase } from "../db/index.js";
-import { hostedUsage, introductionUsage } from "../db/usage-schema.js";
+import { hostedUsage, introductionUsage, voiceSessionUsage } from "../db/usage-schema.js";
+import type { HostedStoreDatabase } from "./store/database.js";
 
 /**
  * The free tier's daily ceiling, spent by every hosted operation alike — a
@@ -99,4 +101,64 @@ export async function spendIntroductionMeter(
   const day = utcDayKey(input.now);
   const used = await incrementIntroductionUsage(database, day);
   return { allowed: used <= HOSTED_DAILY_LIMIT };
+}
+
+/** Whichever driver stands behind the hosted schema, as the store's tables already take it. */
+type VoiceUsageDatabase = Pick<HostedStoreDatabase, "transaction">;
+
+/**
+ * What recording a session's seconds came to: the wire's two records, and the
+ * one the route turns into a refusal rather than an answer, an account the
+ * report names that the database no longer holds.
+ */
+export const VOICE_SECONDS_OUTCOME = {
+  ...VOICE_USAGE_RECORD,
+  UNKNOWN_USER: "unknown-user",
+} as const;
+
+export type VoiceSecondsOutcome =
+  (typeof VOICE_SECONDS_OUTCOME)[keyof typeof VOICE_SECONDS_OUTCOME];
+
+/**
+ * Records the seconds OpenAI billed for one closed GPT Live session, once. The
+ * session row is the ledger: its insert is the idempotent step, and only a
+ * report that created the row moves the day's `voice_seconds`, so a report
+ * the service repeats after a lost answer adds nothing. Both writes share one
+ * transaction so a crash between them cannot leave a session recorded and a
+ * day uncounted. The day is the report's, not the session's start: the
+ * service reports at `session.closed`, and that is the instant it knows.
+ */
+export async function recordVoiceSeconds(
+  database: VoiceUsageDatabase,
+  input: { userId: string; sessionId: string; seconds: number; now: number },
+): Promise<VoiceSecondsOutcome> {
+  return database.transaction(async (transaction) => {
+    const [account] = await transaction
+      .select({ id: user.id })
+      .from(user)
+      .where(eq(user.id, input.userId))
+      .limit(1);
+    if (!account) return VOICE_SECONDS_OUTCOME.UNKNOWN_USER;
+
+    const inserted = await transaction
+      .insert(voiceSessionUsage)
+      .values({
+        sessionId: input.sessionId,
+        userId: input.userId,
+        seconds: input.seconds,
+        recordedAt: input.now,
+      })
+      .onConflictDoNothing({ target: voiceSessionUsage.sessionId })
+      .returning({ sessionId: voiceSessionUsage.sessionId });
+    if (inserted.length === 0) return VOICE_SECONDS_OUTCOME.REPEATED;
+
+    await transaction
+      .insert(hostedUsage)
+      .values({ userId: input.userId, day: utcDayKey(input.now), voiceSeconds: input.seconds })
+      .onConflictDoUpdate({
+        target: [hostedUsage.userId, hostedUsage.day],
+        set: { voiceSeconds: sql`${hostedUsage.voiceSeconds} + ${input.seconds}` },
+      });
+    return VOICE_SECONDS_OUTCOME.RECORDED;
+  });
 }

--- a/apps/web/server/hosted/voice-authorize.ts
+++ b/apps/web/server/hosted/voice-authorize.ts
@@ -1,0 +1,73 @@
+import {
+  type UnparsedWireValue,
+  type VoiceAuthorizeAnswer,
+  voiceAuthorizeRequestSchema,
+} from "../core.js";
+import {
+  BODY_READ,
+  errorResponse,
+  HOSTED_API_ERROR,
+  HOSTED_HTTP_STATUS,
+  jsonResponse,
+  readBoundedBody,
+} from "./http.js";
+import type { HostedSpend } from "./quota.js";
+import { refuseUnlessVoiceService, VOICE_INTERNAL_BODY_BYTES } from "./voice-service-secret.js";
+
+/**
+ * Answers the hosted voice service's question before it creates a GPT Live
+ * session: whose socket is this, and does their allowance cover one more. The
+ * bearer it forwards is resolved exactly as the mint resolves the one on its
+ * own request, and the spend is the same daily meter every hosted operation
+ * shares, taken here rather than at the session's end so a refused account
+ * costs no session at all.
+ */
+
+export interface VoiceAuthorizeOptions {
+  request: Request;
+  /** The value of VOICE_SERVICE_SECRET; undefined means the env var is absent and the route is off. */
+  serviceSecret: string | undefined;
+  /** Resolves the forwarded `Authorization` value to a user, or nothing. */
+  resolveUserId: (authorization: string) => Promise<string | undefined>;
+  spend: (userId: string) => Promise<HostedSpend>;
+}
+
+export async function handleVoiceAuthorize(options: VoiceAuthorizeOptions): Promise<Response> {
+  const { request } = options;
+  const refused = refuseUnlessVoiceService(request, options.serviceSecret);
+  if (refused) return refused;
+
+  const body = await readBoundedBody(request, VOICE_INTERNAL_BODY_BYTES);
+  if (body.outcome === BODY_READ.TOO_LARGE) {
+    return errorResponse(HOSTED_HTTP_STATUS.PAYLOAD_TOO_LARGE, HOSTED_API_ERROR.REQUEST_TOO_LARGE);
+  }
+  if (body.outcome !== BODY_READ.READ) {
+    return errorResponse(HOSTED_HTTP_STATUS.BAD_REQUEST, HOSTED_API_ERROR.INVALID_REQUEST);
+  }
+  let payload: unknown;
+  try {
+    payload = JSON.parse(body.text);
+  } catch {
+    return errorResponse(HOSTED_HTTP_STATUS.BAD_REQUEST, HOSTED_API_ERROR.INVALID_REQUEST);
+  }
+  // SAFETY: JSON.parse returns a runtime value; the wire schema validates it.
+  const ask = voiceAuthorizeRequestSchema.parse(payload as UnparsedWireValue);
+  if (!ask) {
+    return errorResponse(HOSTED_HTTP_STATUS.BAD_REQUEST, HOSTED_API_ERROR.INVALID_REQUEST);
+  }
+
+  const userId = await options.resolveUserId(ask.bearer);
+  if (!userId) {
+    return errorResponse(HOSTED_HTTP_STATUS.UNAUTHORIZED, HOSTED_API_ERROR.INVALID_TOKEN);
+  }
+
+  const spend = await options.spend(userId);
+  if (!spend.allowed) {
+    return errorResponse(HOSTED_HTTP_STATUS.TOO_MANY_REQUESTS, HOSTED_API_ERROR.QUOTA_EXHAUSTED, {
+      quota: spend.quota,
+    });
+  }
+
+  const answer: VoiceAuthorizeAnswer = { userId, quota: spend.quota };
+  return jsonResponse(HOSTED_HTTP_STATUS.OK, answer);
+}

--- a/apps/web/server/hosted/voice-authorize.ts
+++ b/apps/web/server/hosted/voice-authorize.ts
@@ -1,18 +1,7 @@
-import {
-  type UnparsedWireValue,
-  type VoiceAuthorizeAnswer,
-  voiceAuthorizeRequestSchema,
-} from "../core.js";
-import {
-  BODY_READ,
-  errorResponse,
-  HOSTED_API_ERROR,
-  HOSTED_HTTP_STATUS,
-  jsonResponse,
-  readBoundedBody,
-} from "./http.js";
+import { type VoiceAuthorizeAnswer, voiceAuthorizeRequestSchema } from "../core.js";
+import { errorResponse, HOSTED_API_ERROR, HOSTED_HTTP_STATUS, jsonResponse } from "./http.js";
 import type { HostedSpend } from "./quota.js";
-import { refuseUnlessVoiceService, VOICE_INTERNAL_BODY_BYTES } from "./voice-service-secret.js";
+import { admitVoiceServiceRequest } from "./voice-service-secret.js";
 
 /**
  * Answers the hosted voice service's question before it creates a GPT Live
@@ -33,28 +22,12 @@ export interface VoiceAuthorizeOptions {
 }
 
 export async function handleVoiceAuthorize(options: VoiceAuthorizeOptions): Promise<Response> {
-  const { request } = options;
-  const refused = refuseUnlessVoiceService(request, options.serviceSecret);
-  if (refused) return refused;
-
-  const body = await readBoundedBody(request, VOICE_INTERNAL_BODY_BYTES);
-  if (body.outcome === BODY_READ.TOO_LARGE) {
-    return errorResponse(HOSTED_HTTP_STATUS.PAYLOAD_TOO_LARGE, HOSTED_API_ERROR.REQUEST_TOO_LARGE);
-  }
-  if (body.outcome !== BODY_READ.READ) {
-    return errorResponse(HOSTED_HTTP_STATUS.BAD_REQUEST, HOSTED_API_ERROR.INVALID_REQUEST);
-  }
-  let payload: unknown;
-  try {
-    payload = JSON.parse(body.text);
-  } catch {
-    return errorResponse(HOSTED_HTTP_STATUS.BAD_REQUEST, HOSTED_API_ERROR.INVALID_REQUEST);
-  }
-  // SAFETY: JSON.parse returns a runtime value; the wire schema validates it.
-  const ask = voiceAuthorizeRequestSchema.parse(payload as UnparsedWireValue);
-  if (!ask) {
-    return errorResponse(HOSTED_HTTP_STATUS.BAD_REQUEST, HOSTED_API_ERROR.INVALID_REQUEST);
-  }
+  const ask = await admitVoiceServiceRequest(
+    options.request,
+    options.serviceSecret,
+    voiceAuthorizeRequestSchema,
+  );
+  if (ask instanceof Response) return ask;
 
   const userId = await options.resolveUserId(ask.bearer);
   if (!userId) {

--- a/apps/web/server/hosted/voice-service-secret.ts
+++ b/apps/web/server/hosted/voice-service-secret.ts
@@ -1,6 +1,12 @@
 import { timingSafeEqual } from "node:crypto";
-import { VOICE_SERVICE_SECRET_HEADER } from "../core.js";
-import { errorResponse, HOSTED_API_ERROR, HOSTED_HTTP_STATUS } from "./http.js";
+import { type Schema, type UnparsedWireValue, VOICE_SERVICE_SECRET_HEADER } from "../core.js";
+import {
+  BODY_READ,
+  errorResponse,
+  HOSTED_API_ERROR,
+  HOSTED_HTTP_STATUS,
+  readBoundedBody,
+} from "./http.js";
 
 /**
  * The one identity the two internal voice routes accept: the shared secret
@@ -15,8 +21,8 @@ export const VOICE_SERVICE_ENVIRONMENT = {
   SECRET: "VOICE_SERVICE_SECRET",
 } as const;
 
-/** The smallest body either internal route reads; a bearer and two ids never approach it. */
-export const VOICE_INTERNAL_BODY_BYTES = 16_384;
+/** The most either internal route reads of a body; a bearer and two ids never approach it. */
+const VOICE_INTERNAL_BODY_BYTES = 16_384;
 
 function secretMatches(request: Request, secret: string): boolean {
   const offered = Buffer.from(request.headers.get(VOICE_SERVICE_SECRET_HEADER)?.trim() ?? "");
@@ -25,15 +31,17 @@ function secretMatches(request: Request, secret: string): boolean {
 }
 
 /**
- * The gate every internal voice route opens with: POST only, a configured
- * secret, and a header that matches it. Answers the refusal to send, or
- * nothing when the request may proceed. A blank configured secret is the kill
- * switch, not a secret, so it reads as absent.
+ * The door every internal voice route opens with, answering the admitted
+ * request or the refusal to send: POST only; a configured secret, a blank one
+ * being the kill switch rather than a secret; a header that matches it; and a
+ * bounded JSON body the route's own wire schema admits. Nothing of the body is
+ * read before the secret has matched.
  */
-export function refuseUnlessVoiceService(
+export async function admitVoiceServiceRequest<Admitted>(
   request: Request,
   configuredSecret: string | undefined,
-): Response | undefined {
+  schema: Schema<Admitted>,
+): Promise<Admitted | Response> {
   if (request.method !== "POST") {
     return errorResponse(
       HOSTED_HTTP_STATUS.METHOD_NOT_ALLOWED,
@@ -47,5 +55,23 @@ export function refuseUnlessVoiceService(
   if (!secretMatches(request, secret)) {
     return errorResponse(HOSTED_HTTP_STATUS.UNAUTHORIZED, HOSTED_API_ERROR.INVALID_TOKEN);
   }
-  return undefined;
+
+  const body = await readBoundedBody(request, VOICE_INTERNAL_BODY_BYTES);
+  if (body.outcome === BODY_READ.TOO_LARGE) {
+    return errorResponse(HOSTED_HTTP_STATUS.PAYLOAD_TOO_LARGE, HOSTED_API_ERROR.REQUEST_TOO_LARGE);
+  }
+  if (body.outcome !== BODY_READ.READ) {
+    return errorResponse(HOSTED_HTTP_STATUS.BAD_REQUEST, HOSTED_API_ERROR.INVALID_REQUEST);
+  }
+  let payload: unknown;
+  try {
+    payload = JSON.parse(body.text);
+  } catch {
+    return errorResponse(HOSTED_HTTP_STATUS.BAD_REQUEST, HOSTED_API_ERROR.INVALID_REQUEST);
+  }
+  // SAFETY: JSON.parse returns a runtime value; the route's wire schema validates it.
+  const admitted = schema.parse(payload as UnparsedWireValue);
+  return (
+    admitted ?? errorResponse(HOSTED_HTTP_STATUS.BAD_REQUEST, HOSTED_API_ERROR.INVALID_REQUEST)
+  );
 }

--- a/apps/web/server/hosted/voice-service-secret.ts
+++ b/apps/web/server/hosted/voice-service-secret.ts
@@ -1,0 +1,51 @@
+import { timingSafeEqual } from "node:crypto";
+import { VOICE_SERVICE_SECRET_HEADER } from "../core.js";
+import { errorResponse, HOSTED_API_ERROR, HOSTED_HTTP_STATUS } from "./http.js";
+
+/**
+ * The one identity the two internal voice routes accept: the shared secret
+ * the hosted voice service holds, carried in its own header and compared in
+ * constant time. An account bearer is not read on these routes at all — the
+ * bearer the service forwards travels in the body, as the thing being asked
+ * about rather than as who is asking.
+ */
+
+export const VOICE_SERVICE_ENVIRONMENT = {
+  /** Held by this deployment and the voice service alike; absent, the two routes are off. */
+  SECRET: "VOICE_SERVICE_SECRET",
+} as const;
+
+/** The smallest body either internal route reads; a bearer and two ids never approach it. */
+export const VOICE_INTERNAL_BODY_BYTES = 16_384;
+
+function secretMatches(request: Request, secret: string): boolean {
+  const offered = Buffer.from(request.headers.get(VOICE_SERVICE_SECRET_HEADER)?.trim() ?? "");
+  const wanted = Buffer.from(secret);
+  return offered.length === wanted.length && timingSafeEqual(offered, wanted);
+}
+
+/**
+ * The gate every internal voice route opens with: POST only, a configured
+ * secret, and a header that matches it. Answers the refusal to send, or
+ * nothing when the request may proceed. A blank configured secret is the kill
+ * switch, not a secret, so it reads as absent.
+ */
+export function refuseUnlessVoiceService(
+  request: Request,
+  configuredSecret: string | undefined,
+): Response | undefined {
+  if (request.method !== "POST") {
+    return errorResponse(
+      HOSTED_HTTP_STATUS.METHOD_NOT_ALLOWED,
+      HOSTED_API_ERROR.METHOD_NOT_ALLOWED,
+    );
+  }
+  const secret = configuredSecret?.trim();
+  if (!secret) {
+    return errorResponse(HOSTED_HTTP_STATUS.SERVICE_UNAVAILABLE, HOSTED_API_ERROR.UNAVAILABLE);
+  }
+  if (!secretMatches(request, secret)) {
+    return errorResponse(HOSTED_HTTP_STATUS.UNAUTHORIZED, HOSTED_API_ERROR.INVALID_TOKEN);
+  }
+  return undefined;
+}

--- a/apps/web/server/hosted/voice-usage.ts
+++ b/apps/web/server/hosted/voice-usage.ts
@@ -1,0 +1,75 @@
+import {
+  type UnparsedWireValue,
+  VOICE_USAGE_RECORD,
+  type VoiceUsageAnswer,
+  type VoiceUsageRecord,
+  voiceUsageRequestSchema,
+} from "../core.js";
+import {
+  BODY_READ,
+  errorResponse,
+  HOSTED_API_ERROR,
+  HOSTED_HTTP_STATUS,
+  jsonResponse,
+  readBoundedBody,
+} from "./http.js";
+import { VOICE_SECONDS_OUTCOME, type VoiceSecondsOutcome } from "./quota.js";
+import { refuseUnlessVoiceService, VOICE_INTERNAL_BODY_BYTES } from "./voice-service-secret.js";
+
+/**
+ * Takes the hosted voice service's report of what one closed GPT Live session
+ * cost, in the seconds `session.closed` named, and records it once per
+ * session id. The service may report the same session again after a lost
+ * answer; the second report is answered as repeated and moves nothing.
+ */
+
+export interface VoiceUsageOptions {
+  request: Request;
+  /** The value of VOICE_SERVICE_SECRET; undefined means the env var is absent and the route is off. */
+  serviceSecret: string | undefined;
+  record: (input: {
+    userId: string;
+    sessionId: string;
+    seconds: number;
+  }) => Promise<VoiceSecondsOutcome>;
+}
+
+const ANSWERED_RECORD = {
+  [VOICE_SECONDS_OUTCOME.RECORDED]: VOICE_USAGE_RECORD.RECORDED,
+  [VOICE_SECONDS_OUTCOME.REPEATED]: VOICE_USAGE_RECORD.REPEATED,
+} as const satisfies Record<
+  Exclude<VoiceSecondsOutcome, typeof VOICE_SECONDS_OUTCOME.UNKNOWN_USER>,
+  VoiceUsageRecord
+>;
+
+export async function handleVoiceUsage(options: VoiceUsageOptions): Promise<Response> {
+  const { request } = options;
+  const refused = refuseUnlessVoiceService(request, options.serviceSecret);
+  if (refused) return refused;
+
+  const body = await readBoundedBody(request, VOICE_INTERNAL_BODY_BYTES);
+  if (body.outcome === BODY_READ.TOO_LARGE) {
+    return errorResponse(HOSTED_HTTP_STATUS.PAYLOAD_TOO_LARGE, HOSTED_API_ERROR.REQUEST_TOO_LARGE);
+  }
+  if (body.outcome !== BODY_READ.READ) {
+    return errorResponse(HOSTED_HTTP_STATUS.BAD_REQUEST, HOSTED_API_ERROR.INVALID_REQUEST);
+  }
+  let payload: unknown;
+  try {
+    payload = JSON.parse(body.text);
+  } catch {
+    return errorResponse(HOSTED_HTTP_STATUS.BAD_REQUEST, HOSTED_API_ERROR.INVALID_REQUEST);
+  }
+  // SAFETY: JSON.parse returns a runtime value; the wire schema validates it.
+  const report = voiceUsageRequestSchema.parse(payload as UnparsedWireValue);
+  if (!report) {
+    return errorResponse(HOSTED_HTTP_STATUS.BAD_REQUEST, HOSTED_API_ERROR.INVALID_REQUEST);
+  }
+
+  const outcome = await options.record(report);
+  if (outcome === VOICE_SECONDS_OUTCOME.UNKNOWN_USER) {
+    return errorResponse(HOSTED_HTTP_STATUS.BAD_REQUEST, HOSTED_API_ERROR.INVALID_REQUEST);
+  }
+  const answer: VoiceUsageAnswer = { record: ANSWERED_RECORD[outcome] };
+  return jsonResponse(HOSTED_HTTP_STATUS.OK, answer);
+}

--- a/apps/web/server/hosted/voice-usage.ts
+++ b/apps/web/server/hosted/voice-usage.ts
@@ -1,20 +1,7 @@
-import {
-  type UnparsedWireValue,
-  VOICE_USAGE_RECORD,
-  type VoiceUsageAnswer,
-  type VoiceUsageRecord,
-  voiceUsageRequestSchema,
-} from "../core.js";
-import {
-  BODY_READ,
-  errorResponse,
-  HOSTED_API_ERROR,
-  HOSTED_HTTP_STATUS,
-  jsonResponse,
-  readBoundedBody,
-} from "./http.js";
+import { type VoiceUsageAnswer, type VoiceUsageRequest, voiceUsageRequestSchema } from "../core.js";
+import { errorResponse, HOSTED_API_ERROR, HOSTED_HTTP_STATUS, jsonResponse } from "./http.js";
 import { VOICE_SECONDS_OUTCOME, type VoiceSecondsOutcome } from "./quota.js";
-import { refuseUnlessVoiceService, VOICE_INTERNAL_BODY_BYTES } from "./voice-service-secret.js";
+import { admitVoiceServiceRequest } from "./voice-service-secret.js";
 
 /**
  * Takes the hosted voice service's report of what one closed GPT Live session
@@ -27,49 +14,21 @@ export interface VoiceUsageOptions {
   request: Request;
   /** The value of VOICE_SERVICE_SECRET; undefined means the env var is absent and the route is off. */
   serviceSecret: string | undefined;
-  record: (input: {
-    userId: string;
-    sessionId: string;
-    seconds: number;
-  }) => Promise<VoiceSecondsOutcome>;
+  record: (report: VoiceUsageRequest) => Promise<VoiceSecondsOutcome>;
 }
 
-const ANSWERED_RECORD = {
-  [VOICE_SECONDS_OUTCOME.RECORDED]: VOICE_USAGE_RECORD.RECORDED,
-  [VOICE_SECONDS_OUTCOME.REPEATED]: VOICE_USAGE_RECORD.REPEATED,
-} as const satisfies Record<
-  Exclude<VoiceSecondsOutcome, typeof VOICE_SECONDS_OUTCOME.UNKNOWN_USER>,
-  VoiceUsageRecord
->;
-
 export async function handleVoiceUsage(options: VoiceUsageOptions): Promise<Response> {
-  const { request } = options;
-  const refused = refuseUnlessVoiceService(request, options.serviceSecret);
-  if (refused) return refused;
-
-  const body = await readBoundedBody(request, VOICE_INTERNAL_BODY_BYTES);
-  if (body.outcome === BODY_READ.TOO_LARGE) {
-    return errorResponse(HOSTED_HTTP_STATUS.PAYLOAD_TOO_LARGE, HOSTED_API_ERROR.REQUEST_TOO_LARGE);
-  }
-  if (body.outcome !== BODY_READ.READ) {
-    return errorResponse(HOSTED_HTTP_STATUS.BAD_REQUEST, HOSTED_API_ERROR.INVALID_REQUEST);
-  }
-  let payload: unknown;
-  try {
-    payload = JSON.parse(body.text);
-  } catch {
-    return errorResponse(HOSTED_HTTP_STATUS.BAD_REQUEST, HOSTED_API_ERROR.INVALID_REQUEST);
-  }
-  // SAFETY: JSON.parse returns a runtime value; the wire schema validates it.
-  const report = voiceUsageRequestSchema.parse(payload as UnparsedWireValue);
-  if (!report) {
-    return errorResponse(HOSTED_HTTP_STATUS.BAD_REQUEST, HOSTED_API_ERROR.INVALID_REQUEST);
-  }
+  const report = await admitVoiceServiceRequest(
+    options.request,
+    options.serviceSecret,
+    voiceUsageRequestSchema,
+  );
+  if (report instanceof Response) return report;
 
   const outcome = await options.record(report);
   if (outcome === VOICE_SECONDS_OUTCOME.UNKNOWN_USER) {
     return errorResponse(HOSTED_HTTP_STATUS.BAD_REQUEST, HOSTED_API_ERROR.INVALID_REQUEST);
   }
-  const answer: VoiceUsageAnswer = { record: ANSWERED_RECORD[outcome] };
+  const answer: VoiceUsageAnswer = { record: outcome };
   return jsonResponse(HOSTED_HTTP_STATUS.OK, answer);
 }

--- a/apps/web/tests/hosted-voice-authorize.test.ts
+++ b/apps/web/tests/hosted-voice-authorize.test.ts
@@ -1,0 +1,152 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { VOICE_SERVICE_SECRET_HEADER, voiceAuthorizeAnswerSchema } from "@sidecar/hosted";
+import { HOSTED_API_ERROR } from "../server/hosted/http";
+import type { HostedSpend } from "../server/hosted/quota";
+import { handleVoiceAuthorize } from "../server/hosted/voice-authorize";
+
+const NOW = Date.parse("2026-09-10T12:00:00.000Z");
+const SECRET = "voice-service-secret";
+
+const OPEN_SPEND: HostedSpend = {
+  allowed: true,
+  quota: { used: 1, limit: 5_000, resetsAt: NOW + 43_200_000 },
+};
+
+const SPENT: HostedSpend = {
+  allowed: false,
+  quota: { used: 5_001, limit: 5_000, resetsAt: NOW + 43_200_000 },
+};
+
+const NO_BODY = null;
+
+function authorizeRequest(
+  body: string | typeof NO_BODY = JSON.stringify({ bearer: "Bearer account-token" }),
+  headers: Record<string, string> = { [VOICE_SERVICE_SECRET_HEADER]: SECRET },
+  method = "POST",
+): Request {
+  const init: RequestInit = { method, headers };
+  if (body !== NO_BODY) init.body = body;
+  return new Request("https://luke.test/api/internal/voice/authorize", init);
+}
+
+function options(overrides: Partial<Parameters<typeof handleVoiceAuthorize>[0]> = {}) {
+  return {
+    request: authorizeRequest(),
+    serviceSecret: SECRET,
+    resolveUserId: async (authorization: string) =>
+      authorization === "Bearer account-token" ? "user-1" : undefined,
+    spend: async () => OPEN_SPEND,
+    ...overrides,
+  };
+}
+
+test("an authorized account answers its id and the quota the session was spent against", async () => {
+  const spent: string[] = [];
+  const response = await handleVoiceAuthorize(
+    options({
+      spend: async (userId) => {
+        spent.push(userId);
+        return OPEN_SPEND;
+      },
+    }),
+  );
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(voiceAuthorizeAnswerSchema.parse(await response.json()), {
+    userId: "user-1",
+    quota: OPEN_SPEND.quota,
+  });
+  assert.deepEqual(spent, ["user-1"]);
+});
+
+test("a missing or wrong service secret is refused before the bearer is read", async () => {
+  const resolved: string[] = [];
+  const resolveUserId = async (authorization: string) => {
+    resolved.push(authorization);
+    return "user-1";
+  };
+  const missing = await handleVoiceAuthorize(
+    options({ request: authorizeRequest(NO_BODY, {}), resolveUserId }),
+  );
+  const wrong = await handleVoiceAuthorize(
+    options({
+      request: authorizeRequest(JSON.stringify({ bearer: "Bearer account-token" }), {
+        [VOICE_SERVICE_SECRET_HEADER]: `${SECRET}x`,
+      }),
+      resolveUserId,
+    }),
+  );
+  const bearerInstead = await handleVoiceAuthorize(
+    options({
+      request: authorizeRequest(JSON.stringify({ bearer: "Bearer account-token" }), {
+        authorization: `Bearer ${SECRET}`,
+      }),
+      resolveUserId,
+    }),
+  );
+
+  for (const response of [missing, wrong, bearerInstead]) {
+    assert.equal(response.status, 401);
+    assert.equal((await response.json()).error, HOSTED_API_ERROR.INVALID_TOKEN);
+  }
+  assert.deepEqual(resolved, []);
+});
+
+test("without a configured secret the route is off, whatever the header says", async () => {
+  for (const serviceSecret of [undefined, "", "   "]) {
+    const response = await handleVoiceAuthorize(options({ serviceSecret }));
+    assert.equal(response.status, 503);
+    assert.equal((await response.json()).error, HOSTED_API_ERROR.UNAVAILABLE);
+  }
+});
+
+test("only POST is answered", async () => {
+  const response = await handleVoiceAuthorize(
+    options({
+      request: authorizeRequest(NO_BODY, { [VOICE_SERVICE_SECRET_HEADER]: SECRET }, "GET"),
+    }),
+  );
+  assert.equal(response.status, 405);
+  assert.equal((await response.json()).error, HOSTED_API_ERROR.METHOD_NOT_ALLOWED);
+});
+
+test("a body that is not the one forwarded bearer is refused", async () => {
+  for (const body of [
+    NO_BODY,
+    "not json",
+    JSON.stringify({}),
+    JSON.stringify({ bearer: "" }),
+    JSON.stringify({ bearer: "Bearer t", userId: "u" }),
+  ]) {
+    const response = await handleVoiceAuthorize(options({ request: authorizeRequest(body) }));
+    assert.equal(response.status, 400);
+    assert.equal((await response.json()).error, HOSTED_API_ERROR.INVALID_REQUEST);
+  }
+});
+
+test("a bearer that resolves to no account is refused and spends nothing", async () => {
+  let spends = 0;
+  const response = await handleVoiceAuthorize(
+    options({
+      request: authorizeRequest(JSON.stringify({ bearer: "Bearer revoked" })),
+      spend: async () => {
+        spends += 1;
+        return OPEN_SPEND;
+      },
+    }),
+  );
+
+  assert.equal(response.status, 401);
+  assert.equal((await response.json()).error, HOSTED_API_ERROR.INVALID_TOKEN);
+  assert.equal(spends, 0);
+});
+
+test("a spent allowance refuses the session and reports the quota", async () => {
+  const response = await handleVoiceAuthorize(options({ spend: async () => SPENT }));
+
+  assert.equal(response.status, 429);
+  const body = await response.json();
+  assert.equal(body.error, HOSTED_API_ERROR.QUOTA_EXHAUSTED);
+  assert.deepEqual(body.quota, SPENT.quota);
+});

--- a/apps/web/tests/hosted-voice-usage.test.ts
+++ b/apps/web/tests/hosted-voice-usage.test.ts
@@ -1,0 +1,211 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  VOICE_SERVICE_SECRET_HEADER,
+  VOICE_USAGE_RECORD,
+  voiceUsageAnswerSchema,
+} from "@sidecar/hosted";
+import { eq } from "drizzle-orm";
+import { hostedUsage, voiceSessionUsage } from "../server/db/usage-schema";
+import { HOSTED_API_ERROR } from "../server/hosted/http";
+import { recordVoiceSeconds, utcDayKey, VOICE_SECONDS_OUTCOME } from "../server/hosted/quota";
+import { handleVoiceUsage } from "../server/hosted/voice-usage";
+import { openHostedStoreTestDatabase } from "./support/hosted-store-database";
+
+const NOW = Date.parse("2026-09-10T12:00:00.000Z");
+const SECRET = "voice-service-secret";
+const REPORT = { userId: "user-1", sessionId: "sess_1", seconds: 90.5 };
+
+const NO_BODY = null;
+
+function usageRequest(
+  body: string | typeof NO_BODY = JSON.stringify(REPORT),
+  headers: Record<string, string> = { [VOICE_SERVICE_SECRET_HEADER]: SECRET },
+  method = "POST",
+): Request {
+  const init: RequestInit = { method, headers };
+  if (body !== NO_BODY) init.body = body;
+  return new Request("https://luke.test/api/internal/voice/usage", init);
+}
+
+function options(overrides: Partial<Parameters<typeof handleVoiceUsage>[0]> = {}) {
+  return {
+    request: usageRequest(),
+    serviceSecret: SECRET,
+    record: async () => VOICE_SECONDS_OUTCOME.RECORDED,
+    ...overrides,
+  };
+}
+
+test("a report is recorded under the account and session it names", async () => {
+  const recorded: unknown[] = [];
+  const response = await handleVoiceUsage(
+    options({
+      record: async (report) => {
+        recorded.push(report);
+        return VOICE_SECONDS_OUTCOME.RECORDED;
+      },
+    }),
+  );
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(voiceUsageAnswerSchema.parse(await response.json()), {
+    record: VOICE_USAGE_RECORD.RECORDED,
+  });
+  assert.deepEqual(recorded, [REPORT]);
+});
+
+test("a repeated report is answered as repeated, not as an error", async () => {
+  const response = await handleVoiceUsage(
+    options({ record: async () => VOICE_SECONDS_OUTCOME.REPEATED }),
+  );
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(voiceUsageAnswerSchema.parse(await response.json()), {
+    record: VOICE_USAGE_RECORD.REPEATED,
+  });
+});
+
+test("a report naming an account the database no longer holds is refused", async () => {
+  const response = await handleVoiceUsage(
+    options({ record: async () => VOICE_SECONDS_OUTCOME.UNKNOWN_USER }),
+  );
+
+  assert.equal(response.status, 400);
+  assert.equal((await response.json()).error, HOSTED_API_ERROR.INVALID_REQUEST);
+});
+
+test("a missing or wrong service secret is refused before anything is recorded", async () => {
+  let records = 0;
+  const record = async () => {
+    records += 1;
+    return VOICE_SECONDS_OUTCOME.RECORDED;
+  };
+  const missing = await handleVoiceUsage(
+    options({ request: usageRequest(JSON.stringify(REPORT), {}), record }),
+  );
+  const wrong = await handleVoiceUsage(
+    options({
+      request: usageRequest(JSON.stringify(REPORT), {
+        [VOICE_SERVICE_SECRET_HEADER]: `${SECRET}x`,
+      }),
+      record,
+    }),
+  );
+  for (const response of [missing, wrong]) {
+    assert.equal(response.status, 401);
+    assert.equal((await response.json()).error, HOSTED_API_ERROR.INVALID_TOKEN);
+  }
+
+  const off = await handleVoiceUsage(options({ serviceSecret: undefined, record }));
+  assert.equal(off.status, 503);
+  assert.equal((await off.json()).error, HOSTED_API_ERROR.UNAVAILABLE);
+
+  const method = await handleVoiceUsage(
+    options({
+      request: usageRequest(NO_BODY, { [VOICE_SERVICE_SECRET_HEADER]: SECRET }, "GET"),
+      record,
+    }),
+  );
+  assert.equal(method.status, 405);
+  assert.equal(records, 0);
+});
+
+test("a report that is not one session's bounded seconds is refused", async () => {
+  for (const body of [
+    NO_BODY,
+    "not json",
+    JSON.stringify({}),
+    JSON.stringify({ ...REPORT, seconds: -1 }),
+    JSON.stringify({ ...REPORT, seconds: 86_401 }),
+    JSON.stringify({ ...REPORT, sessionId: "" }),
+    JSON.stringify({ ...REPORT, extra: true }),
+  ]) {
+    const response = await handleVoiceUsage(options({ request: usageRequest(body) }));
+    assert.equal(response.status, 400);
+    assert.equal((await response.json()).error, HOSTED_API_ERROR.INVALID_REQUEST);
+  }
+});
+
+test("recording takes a session's seconds once and moves the day's counter only the first time", async () => {
+  const opened = await openHostedStoreTestDatabase();
+  try {
+    const userId = await opened.createUser();
+    const first = await recordVoiceSeconds(opened.db, {
+      userId,
+      sessionId: "sess_a",
+      seconds: 61,
+      now: NOW,
+    });
+    const again = await recordVoiceSeconds(opened.db, {
+      userId,
+      sessionId: "sess_a",
+      seconds: 61,
+      now: NOW + 1_000,
+    });
+    const second = await recordVoiceSeconds(opened.db, {
+      userId,
+      sessionId: "sess_b",
+      seconds: 30.5,
+      now: NOW + 2_000,
+    });
+
+    assert.equal(first, VOICE_SECONDS_OUTCOME.RECORDED);
+    assert.equal(again, VOICE_SECONDS_OUTCOME.REPEATED);
+    assert.equal(second, VOICE_SECONDS_OUTCOME.RECORDED);
+
+    const sessions = await opened.db
+      .select({
+        sessionId: voiceSessionUsage.sessionId,
+        seconds: voiceSessionUsage.seconds,
+        recordedAt: voiceSessionUsage.recordedAt,
+      })
+      .from(voiceSessionUsage)
+      .where(eq(voiceSessionUsage.userId, userId))
+      .orderBy(voiceSessionUsage.sessionId);
+    assert.deepEqual(sessions, [
+      { sessionId: "sess_a", seconds: 61, recordedAt: NOW },
+      { sessionId: "sess_b", seconds: 30.5, recordedAt: NOW + 2_000 },
+    ]);
+
+    const [day] = await opened.db
+      .select({ calls: hostedUsage.calls, voiceSeconds: hostedUsage.voiceSeconds })
+      .from(hostedUsage)
+      .where(eq(hostedUsage.userId, userId));
+    assert.deepEqual(day, { calls: 0, voiceSeconds: 91.5 });
+    assert.equal(utcDayKey(NOW), "2026-09-10");
+  } finally {
+    await opened.close();
+  }
+});
+
+test("recording for an account the database does not hold writes nothing", async () => {
+  const opened = await openHostedStoreTestDatabase();
+  try {
+    const outcome = await recordVoiceSeconds(opened.db, {
+      userId: "user-gone",
+      sessionId: "sess_x",
+      seconds: 5,
+      now: NOW,
+    });
+    assert.equal(outcome, VOICE_SECONDS_OUTCOME.UNKNOWN_USER);
+    const rows = await opened.db.select().from(voiceSessionUsage);
+    assert.deepEqual(rows, []);
+  } finally {
+    await opened.close();
+  }
+});
+
+test("deleting the account takes its session usage rows with it", async () => {
+  const opened = await openHostedStoreTestDatabase();
+  try {
+    const userId = await opened.createUser();
+    await recordVoiceSeconds(opened.db, { userId, sessionId: "sess_c", seconds: 5, now: NOW });
+    const { user } = await import("../server/db/auth-schema");
+    await opened.db.delete(user).where(eq(user.id, userId));
+    const rows = await opened.db.select().from(voiceSessionUsage);
+    assert.deepEqual(rows, []);
+  } finally {
+    await opened.close();
+  }
+});

--- a/packages/hosted/AGENTS.md
+++ b/packages/hosted/AGENTS.md
@@ -72,6 +72,14 @@ internal routes on the account service that only the voice service calls,
 Realtime mint paths and `realtime-contract.ts` stand beside it untouched for
 the installed desktops and the phone that still speak them.
 
+`voice-internal-wire.ts` is what travels on those two internal routes:
+authorize takes the forwarded `Authorization` value and answers the user id
+and quota; usage takes one session's id, account, and billed seconds and
+answers one of `VOICE_USAGE_RECORD`'s two members, `recorded` or `repeated`,
+so a report sent twice is one record and the service can tell the two apart.
+The seconds are bounded under a day and the ids under a short length, because
+a value past either is a document standing in for an id, not a long call.
+
 A renamed wire field keeps its old name on the wire for one iOS release. The
 desktop and the service ship together, but an installed phone reads whatever
 the service sends until its owner updates it, so the service writes both names

--- a/packages/hosted/src/index.ts
+++ b/packages/hosted/src/index.ts
@@ -162,3 +162,16 @@ export {
   vaultKeyStoreAnswerSchema,
   vaultKeysListAnswerSchema,
 } from "./vault-wire.js";
+export {
+  VOICE_INTERNAL_BOUNDS,
+  VOICE_USAGE_RECORD,
+  type VoiceAuthorizeAnswer,
+  type VoiceAuthorizeRequest,
+  type VoiceUsageAnswer,
+  type VoiceUsageRecord,
+  type VoiceUsageRequest,
+  voiceAuthorizeAnswerSchema,
+  voiceAuthorizeRequestSchema,
+  voiceUsageAnswerSchema,
+  voiceUsageRequestSchema,
+} from "./voice-internal-wire.js";

--- a/packages/hosted/src/voice-internal-wire.test.ts
+++ b/packages/hosted/src/voice-internal-wire.test.ts
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { SCHEMA_REFUSAL } from "@sidecar/wire";
+import {
+  VOICE_INTERNAL_BOUNDS,
+  VOICE_USAGE_RECORD,
+  voiceAuthorizeAnswerSchema,
+  voiceAuthorizeRequestSchema,
+  voiceUsageAnswerSchema,
+  voiceUsageRequestSchema,
+} from "./voice-internal-wire.js";
+
+test("an authorize request is the forwarded bearer and nothing beside it", () => {
+  assert.deepEqual(voiceAuthorizeRequestSchema.parse({ bearer: " Bearer tok " }), {
+    bearer: "Bearer tok",
+  });
+  assert.equal(voiceAuthorizeRequestSchema.parse({ bearer: "" }), undefined);
+  assert.equal(voiceAuthorizeRequestSchema.parse({ bearer: "Bearer tok", userId: "u" }), undefined);
+  const read = voiceAuthorizeRequestSchema.read({
+    bearer: "x".repeat(VOICE_INTERNAL_BOUNDS.BEARER_CHARS + 1),
+  });
+  assert.equal(read.ok, false);
+  if (!read.ok) assert.equal(read.refusal, SCHEMA_REFUSAL.TOO_LARGE);
+});
+
+test("an authorize answer carries the user and the quota and ignores a newer field", () => {
+  const quota = { used: 2, limit: 5_000, resetsAt: 1_800_000_000_000 };
+  assert.deepEqual(voiceAuthorizeAnswerSchema.parse({ userId: "user-1", quota, later: true }), {
+    userId: "user-1",
+    quota,
+  });
+  assert.equal(voiceAuthorizeAnswerSchema.parse({ userId: "user-1" }), undefined);
+});
+
+test("a usage report is one session's non-negative seconds under the day bound", () => {
+  const report = { userId: "user-1", sessionId: "sess_1", seconds: 61.5 };
+  assert.deepEqual(voiceUsageRequestSchema.parse(report), report);
+  assert.equal(voiceUsageRequestSchema.parse({ ...report, seconds: -1 }), undefined);
+  assert.equal(
+    voiceUsageRequestSchema.parse({
+      ...report,
+      seconds: VOICE_INTERNAL_BOUNDS.SESSION_SECONDS + 1,
+    }),
+    undefined,
+  );
+  assert.equal(voiceUsageRequestSchema.parse({ ...report, sessionId: "" }), undefined);
+  assert.equal(voiceUsageRequestSchema.parse({ ...report, extra: 1 }), undefined);
+});
+
+test("a usage answer names one of the two records", () => {
+  for (const record of Object.values(VOICE_USAGE_RECORD)) {
+    assert.deepEqual(voiceUsageAnswerSchema.parse({ record }), { record });
+  }
+  assert.equal(voiceUsageAnswerSchema.parse({ record: "billed" }), undefined);
+  assert.equal(new Set(Object.values(VOICE_USAGE_RECORD)).size, 2);
+});

--- a/packages/hosted/src/voice-internal-wire.ts
+++ b/packages/hosted/src/voice-internal-wire.ts
@@ -1,0 +1,81 @@
+import { RECORD_EXTRA_KEYS, type Schema, s, TEXT_ENDS } from "@sidecar/wire";
+import { type HostedQuota, hostedQuotaSchema } from "./service-wire.js";
+
+/**
+ * The two internal calls the hosted voice service makes to the account
+ * service, under `VOICE_SERVICE_SECRET_HEADER` and never an account bearer of
+ * its own. Before it spends a GPT Live session it asks who opened the socket
+ * and whether their allowance covers one more; after `session.closed` it
+ * reports the seconds OpenAI billed for that session, once. Declared here so
+ * the service that sends and the route that reads cannot drift.
+ */
+
+export const VOICE_INTERNAL_BOUNDS = {
+  /** The account bearer as the desktop handed it on the socket's handshake; a token is far shorter. */
+  BEARER_CHARS: 4_096,
+  /** A GPT Live session id is opaque and short; the bound only refuses a document standing in for one. */
+  SESSION_ID_CHARS: 256,
+  /**
+   * The most seconds one session may report. GPT Live sessions have a duration
+   * limit of their own well under a day, so a larger figure is a miscount,
+   * not a long call.
+   */
+  SESSION_SECONDS: 86_400,
+} as const;
+
+/** What the voice service forwards to learn whose session it is about to create. */
+export interface VoiceAuthorizeRequest {
+  /** The `Authorization` header value the desktop opened the socket with, scheme included. */
+  bearer: string;
+}
+
+/** The account the bearer resolved to and the allowance the session was just spent against. */
+export interface VoiceAuthorizeAnswer {
+  userId: string;
+  quota: HostedQuota;
+}
+
+/** One session's billed seconds, as `session.closed` reported them. */
+export interface VoiceUsageRequest {
+  userId: string;
+  sessionId: string;
+  seconds: number;
+}
+
+/**
+ * How the account service took a usage report. The same session id reported
+ * again is answered `REPEATED` and moves no counter, so a service that
+ * retries a report after a lost answer cannot bill a session twice.
+ */
+export const VOICE_USAGE_RECORD = {
+  RECORDED: "recorded",
+  REPEATED: "repeated",
+} as const;
+
+export type VoiceUsageRecord = (typeof VOICE_USAGE_RECORD)[keyof typeof VOICE_USAGE_RECORD];
+
+export interface VoiceUsageAnswer {
+  record: VoiceUsageRecord;
+}
+
+const opaqueId = s.text({ ends: TEXT_ENDS.TRIM, max: VOICE_INTERNAL_BOUNDS.SESSION_ID_CHARS });
+
+export const voiceAuthorizeRequestSchema: Schema<VoiceAuthorizeRequest> = s.record({
+  bearer: s.text({ ends: TEXT_ENDS.TRIM, max: VOICE_INTERNAL_BOUNDS.BEARER_CHARS }),
+});
+
+export const voiceAuthorizeAnswerSchema: Schema<VoiceAuthorizeAnswer> = s.record(
+  { userId: opaqueId, quota: hostedQuotaSchema },
+  { extraKeys: RECORD_EXTRA_KEYS.IGNORE },
+);
+
+export const voiceUsageRequestSchema: Schema<VoiceUsageRequest> = s.record({
+  userId: opaqueId,
+  sessionId: opaqueId,
+  seconds: s.number({ minimum: 0, maximum: VOICE_INTERNAL_BOUNDS.SESSION_SECONDS }),
+});
+
+export const voiceUsageAnswerSchema: Schema<VoiceUsageAnswer> = s.record(
+  { record: s.enumOf(Object.values(VOICE_USAGE_RECORD)) },
+  { extraKeys: RECORD_EXTRA_KEYS.IGNORE },
+);


### PR DESCRIPTION
PR 3 of the GPT Live rollout. Was stacked on #912 (`live/02-hosted-contract`), now rebased onto `main` after that merged.

## What

- `api/internal/voice/authorize.ts` and `api/internal/voice/usage.ts`, the two routes at the `VOICE_AUTHORIZE` / `VOICE_USAGE` paths PR 2 declared, with the logic in `server/hosted/voice-authorize.ts` and `voice-usage.ts` behind injected seams like every other hosted route.
- Both refuse without the shared secret header (`VOICE_SERVICE_SECRET`, compared with `timingSafeEqual` like the cron secret), answer 503 while the variable is unset or blank, and take POST only. An account bearer is not read as identity on either route.
- **Authorize** takes `{ bearer }`, the `Authorization` value the desktop opened its socket with, resolves it through the same in-process `/oauth2/userinfo` seam `voice-mint.ts` uses, spends the same `hosted_usage` daily meter, and answers `{ userId, quota }`, or `invalid-token` (401) / `quota-exhausted` with the quota (429).
- **Usage** takes `{ userId, sessionId, seconds }` and records the seconds once per session id: a new `voice_session_usage` table is the idempotency ledger, and only a report that created its row adds to a new `voice_seconds` column on `hosted_usage`, in one transaction. A repeat answers `{ record: "repeated" }` and moves nothing; an account the database no longer holds is a 400.
- The wire shapes (`voice-internal-wire.ts`) and the `VOICE_USAGE_RECORD` vocabulary are declared once in `@sidecar/hosted`; no `RealtimeMintOutcome`-style vocabulary existed in the hosted contract to reuse. Both routes admit a request through one door, `admitVoiceServiceRequest` (method, secret, bounded body, wire schema).

## Self-review

Ran the two requested reviews against the diff using their published texts (Cursor's `thermo-nuclear-code-quality-review` SKILL.md from `cursor/plugins`; Ponytail's ruleset and `ponytail-review` command from `DietrichGebert/ponytail`). Findings acted on in the second commit: the two handlers repeated the gate-plus-body-parse sequence (folded into one helper), an identity map between the recorder outcome and the wire record (deleted), and a comment that said "smallest" for a maximum bound. Nothing else to cut.
- Migration `0013_amusing_shape.sql` generated with `drizzle-kit`. No `vercel.json` change: exact-path files under `api/internal/` are routed by zero-config detection, like `api/brain/v2/`.
- `apps/web/server/README.md` gains a "Hosted voice service routes" section; `packages/hosted/AGENTS.md` names the new wire module. The mint routes and their meter are untouched (PR 17 retires them).

## How it follows the GPT Live docs

The cost guide bills a session per second of session time from `session.closed`'s `usage.seconds`, so the meter records seconds per session id, keyed on the id OpenAI minted, and the spend is taken before creation so a refused account costs no session (the 15 s creation charge the cost guide names). The seconds bound (86,400) sits above the API's own session duration limit, so anything past it is a miscount rather than a long call.

## Deviation from the brief, flagged

The brief asked for `VOICE_SERVICE_ORIGIN` "answered in the client bootstrap payload". `apps/web` has no bootstrap payload: the desktop's `client.bootstrap` is a Gateway method the host answers, and PR 2 already fixed the voice service origin as the build-pinned `HOSTED_VOICE_SERVICE_ORIGIN` with an unpackaged-only override (`hostedVoiceServiceOrigin`). Adding the origin to the brain capabilities answer would widen that contract for a value nothing would read, so this PR adds no such field and no `VOICE_SERVICE_ORIGIN` env on the web. Reported to the orchestrator.

## Verify

```sh
./scripts/check.sh
pnpm --filter @luke/web exec tsx --test tests/hosted-voice-authorize.test.ts tests/hosted-voice-usage.test.ts
pnpm --filter @sidecar/hosted test
```

## Tests

- `./scripts/check.sh`: passes (lint, knip, typecheck, tests, build).
- Authorize: secret missing / wrong / bearer-in-place-of-secret refused before the bearer is read; unset secret 503; non-POST 405; malformed bodies 400; unresolvable bearer 401 with no spend; spent allowance 429 with quota; success answers `{ userId, quota }` parsed by the wire schema.
- Usage: recorded / repeated / unknown-user mapping; secret and method refusals record nothing; bounded-body refusals; and against the real migrations on PGlite: first report recorded, same session id repeated with no counter movement, second session adds to the day's `voice_seconds` with `calls` untouched, unknown user writes nothing, deleting the user cascades the ledger.
- Wire: request strictness and bounds, answer extra-key tolerance, record enum membership.

`./scripts/verify.sh` not run: this PR touches no macOS or UI code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/3114dd43-82da-4b9a-b83c-831ded4e2f23)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34525512122/artifacts/10171548884) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34525512122)

- Commit: `969172ba8962e551ed49abf860d5ad0e281bce91`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
