### PR TITLE
feat(voice): live session sources

### DIFF
--- a/packages/voice/package.json
+++ b/packages/voice/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "exports": {
     ".": "./src/index.js",
-    "./orchestrator": "./src/orchestrator/index.js"
+    "./orchestrator": "./src/orchestrator/index.js",
+    "./testing": "./src/testing.js"
   },
   "types": "./src/index.ts",
   "scripts": {
@@ -21,6 +22,7 @@
     "@sidecar/brain": "workspace:*",
     "@sidecar/credentials": "workspace:*",
     "@sidecar/hosted": "workspace:*",
+    "@sidecar/live": "workspace:*",
     "@sidecar/realtime": "workspace:*",
     "@sidecar/runtime": "workspace:*",
     "@sidecar/session": "workspace:*",

--- a/packages/voice/src/capability-assembler.test.ts
+++ b/packages/voice/src/capability-assembler.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import { LIVE_SESSION_OUTCOME } from "@sidecar/live";
 import { REALTIME_MINT_OUTCOME } from "@sidecar/realtime";
 import { APP_SETTING_SCHEMA, VOICE_SOURCE } from "@sidecar/settings";
 import {
@@ -7,6 +8,7 @@ import {
   VoiceCapabilityAssembler,
   type VoiceSettings,
 } from "./capability-assembler.js";
+import { scriptedOpenSocket } from "./testing.js";
 
 test("fixture runs never expose or select a credential", () => {
   assert.deepEqual(
@@ -213,4 +215,67 @@ test("the brain follows the voice source: hosted on an account, direct on a key,
   });
   await fixture.apply();
   assert.equal(fixture.brainModel, undefined);
+});
+
+test("live sessions follow the voice source, and stand only where a socket seam was handed", async () => {
+  const { openSocket } = scriptedOpenSocket([]);
+  const seams = {
+    credentialsUsable: () => true,
+    fixtureRun: () => false,
+    accountSignedIn: () => true,
+    hostedServiceBaseUrl: "https://example.test",
+    refreshAccount: async () => undefined,
+    report: () => undefined,
+    fetch: async () => new Response(null, { status: 204 }),
+  };
+
+  const keyed = new VoiceCapabilityAssembler({
+    ...seams,
+    openSocket,
+    settings: settingsFor({ source: VOICE_SOURCE.KEY, key: "test-key" }),
+  });
+  await keyed.apply();
+  assert.equal(keyed.liveSessions?.diagnostics().apiKeyConfigured, true);
+  assert.equal(keyed.liveSessions?.diagnostics().hosted, undefined);
+
+  const hosted = new VoiceCapabilityAssembler({
+    ...seams,
+    openSocket,
+    settings: settingsFor({ source: VOICE_SOURCE.ACCOUNT, key: "stored-but-unchosen" }),
+  });
+  await hosted.apply();
+  assert.equal(hosted.liveSessions?.diagnostics().hosted, true);
+  assert.equal(hosted.liveSessions?.diagnostics().apiKeyConfigured, false);
+
+  const signedOut = new VoiceCapabilityAssembler({
+    ...seams,
+    openSocket,
+    accountSignedIn: () => false,
+    settings: settingsFor({ source: VOICE_SOURCE.ACCOUNT }),
+  });
+  await signedOut.apply();
+  assert.equal(signedOut.liveSessions, undefined);
+  assert.equal(signedOut.unavailableLiveDiagnostics.lastOutcome, LIVE_SESSION_OUTCOME.NO_API_KEY);
+
+  const fixture = new VoiceCapabilityAssembler({
+    ...seams,
+    openSocket,
+    credentialsUsable: () => false,
+    fixtureRun: () => true,
+    settings: settingsFor({ source: VOICE_SOURCE.KEY, key: "must-not-be-used" }),
+  });
+  await fixture.apply();
+  assert.equal(fixture.liveSessions, undefined);
+  assert.equal(
+    fixture.unavailableLiveDiagnostics.lastOutcome,
+    LIVE_SESSION_OUTCOME.DISABLED_BY_FIXTURE,
+  );
+
+  const withoutSeam = new VoiceCapabilityAssembler({
+    ...seams,
+    settings: settingsFor({ source: VOICE_SOURCE.KEY, key: "test-key" }),
+  });
+  await withoutSeam.apply();
+  assert.ok(withoutSeam.realtimeCredentials);
+  assert.equal(withoutSeam.liveSessions, undefined);
 });

--- a/packages/voice/src/capability-assembler.ts
+++ b/packages/voice/src/capability-assembler.ts
@@ -5,7 +5,8 @@ import {
   openAiModelAdapter,
 } from "@sidecar/brain";
 import { VOICE_CREDENTIAL_PROVIDER_ID } from "@sidecar/credentials/vocabulary";
-import { HOSTED_SERVICE_PATH } from "@sidecar/hosted";
+import { HOSTED_SERVICE_PATH, HOSTED_VOICE_SERVICE_ORIGIN } from "@sidecar/hosted";
+import type { LiveDiagnostics } from "@sidecar/live";
 import { type RealtimeDiagnostics, realtimeMintExplanation } from "@sidecar/realtime";
 import type { EmbeddingAdapter, ModelAdapter } from "@sidecar/runtime/vocabulary";
 import {
@@ -15,6 +16,13 @@ import {
   VOICE_SOURCE,
   type VoiceSource,
 } from "@sidecar/settings";
+import {
+  HostedLiveSessionSource,
+  keyedLiveSessions,
+  type LiveSessionSource,
+  unavailableLiveDiagnostics,
+} from "./live-session-source.js";
+import type { OpenSocket } from "./live-socket.js";
 import { openAiRealtimeCredentials, unavailableRealtimeDiagnostics } from "./openai-credentials.js";
 import { hostedRealtimeCredentialMinter, type RealtimeCredentialMinter } from "./service-mint.js";
 
@@ -72,6 +80,17 @@ export interface VoiceCapabilityAssemblerOptions {
   fixtureRun: () => boolean;
   accountSignedIn: () => boolean;
   hostedServiceBaseUrl: string;
+  /**
+   * The voice service origin a hosted live session's socket opens to;
+   * `HOSTED_VOICE_SERVICE_ORIGIN` when absent.
+   */
+  hostedVoiceServiceOrigin?: string;
+  /**
+   * The socket seam live sessions attach their sideband through. A host that
+   * hands none offers no live sessions, since a session with no trusted side
+   * would have nowhere to speak from.
+   */
+  openSocket?: OpenSocket;
   refreshAccount: () => Promise<void>;
   fetch?: typeof fetch;
   report?: (message: string) => void;
@@ -102,7 +121,9 @@ export class VoiceCapabilityAssembler {
   #brainModel: ModelAdapter | undefined;
   #embeddingAdapter: EmbeddingAdapter | undefined;
   #realtimeCredentials: RealtimeCredentialMinter | undefined;
+  #liveSessions: LiveSessionSource | undefined;
   #unavailableDiagnostics: RealtimeDiagnostics;
+  #unavailableLiveDiagnostics: LiveDiagnostics;
   #voiceSource: VoiceSource = VOICE_SOURCE.ACCOUNT;
   #applications = 0;
   readonly #applied = new Set<() => void>();
@@ -110,6 +131,10 @@ export class VoiceCapabilityAssembler {
   constructor(options: VoiceCapabilityAssemblerOptions) {
     this.#options = options;
     this.#unavailableDiagnostics = unavailableRealtimeDiagnostics({
+      fixtureMode: options.fixtureRun(),
+      apiKeyConfigured: false,
+    });
+    this.#unavailableLiveDiagnostics = unavailableLiveDiagnostics({
       fixtureMode: options.fixtureRun(),
       apiKeyConfigured: false,
     });
@@ -156,6 +181,20 @@ export class VoiceCapabilityAssembler {
 
   get unavailableDiagnostics(): RealtimeDiagnostics {
     return this.#unavailableDiagnostics;
+  }
+
+  /**
+   * Where a GPT Live session comes from under the same policy the Realtime
+   * mint follows: the developer's key straight to OpenAI, or the signed-in
+   * account through Luke's voice service. Nothing when neither stands, or
+   * when the host handed no socket seam.
+   */
+  get liveSessions(): LiveSessionSource | undefined {
+    return this.#liveSessions;
+  }
+
+  get unavailableLiveDiagnostics(): LiveDiagnostics {
+    return this.#unavailableLiveDiagnostics;
   }
 
   /** Which credential the last applied policy settled on, for a count to name. */
@@ -227,6 +266,29 @@ export class VoiceCapabilityAssembler {
         ? hostedRealtimeCredentialMinter({ ...seams, ...preferences })
         : undefined;
     this.#unavailableDiagnostics = unavailableRealtimeDiagnostics({
+      fixtureMode: this.#options.fixtureRun(),
+      apiKeyConfigured: apiKey !== undefined,
+    });
+    const openSocket = this.#options.openSocket;
+    this.#liveSessions = !openSocket
+      ? undefined
+      : apiKey
+        ? keyedLiveSessions(apiKey, {
+            openSocket,
+            ...(voice ? { voice } : undefined),
+            ...(this.#options.fetch ? { fetch: this.#options.fetch } : undefined),
+          })
+        : policy.useHosted
+          ? new HostedLiveSessionSource({
+              serviceOrigin: this.#options.hostedVoiceServiceOrigin ?? HOSTED_VOICE_SERVICE_ORIGIN,
+              openSocket,
+              readAccessToken: seams.readAccessToken,
+              refreshAccount: seams.refreshAccount,
+              readAccountKey: seams.readAccountKey,
+              ...(voice ? { voice } : undefined),
+            })
+          : undefined;
+    this.#unavailableLiveDiagnostics = unavailableLiveDiagnostics({
       fixtureMode: this.#options.fixtureRun(),
       apiKeyConfigured: apiKey !== undefined,
     });

--- a/packages/voice/src/index.ts
+++ b/packages/voice/src/index.ts
@@ -8,6 +8,36 @@ export {
   type VoiceSettings,
 } from "./capability-assembler.js";
 export {
+  environmentLiveVoice,
+  type HostedLiveSessionOptions,
+  HostedLiveSessionSource,
+  type IntroductionLiveSessionOpened,
+  type IntroductionLiveSessionOptions,
+  IntroductionLiveSessionSource,
+  type IntroductionSessionSource,
+  type KeyedLiveSessionOptions,
+  KeyedLiveSessionSource,
+  type KeyedLiveSessionSourceOptions,
+  keyedLiveSessions,
+  LIVE_ENVIRONMENT,
+  type LiveSessionCreateInput,
+  type LiveSessionOpened,
+  type LiveSessionSource,
+  unavailableLiveDiagnostics,
+} from "./live-session-source.js";
+export {
+  type LiveSideband,
+  type LiveSocket,
+  type OpenSocket,
+  SOCKET_OPEN_FAULT,
+  type SocketClose,
+  type SocketOpenFailure,
+  type SocketOpenFault,
+  type SocketOpening,
+  sidebandOverSocket,
+  socketOpened,
+} from "./live-socket.js";
+export {
   environmentRealtimeSpeed,
   environmentRealtimeVoice,
   OPENAI_ENVIRONMENT,

--- a/packages/voice/src/live-session-source.test.ts
+++ b/packages/voice/src/live-session-source.test.ts
@@ -302,10 +302,16 @@ test("the hosted source's attach is the socket that answered, and the answer fra
   assert.ok(socket);
   assert.equal(socket.closedByClient, false);
 
+  assert.equal(source.diagnostics().sidebandAttached, true);
+  socket.receive({
+    type: LIVE_SERVER_EVENT.SESSION_STARTED,
+    event_id: "ev_0",
+    session: { id: SESSION_ID },
+  });
+
   const sideband = await opened.attach();
   assert.equal(await opened.attach(), sideband);
   assert.equal(script.opens.length, 1);
-  assert.equal(source.diagnostics().sidebandAttached, true);
 
   const seen: LiveServerEvent[] = [];
   sideband.onEvent((event) => seen.push(event));
@@ -317,7 +323,7 @@ test("the hosted source's attach is the socket that answered, and the answer fra
   });
   assert.deepEqual(
     seen.map((event) => event.type),
-    [LIVE_SERVER_EVENT.INPUT_AUDIO_MUTED],
+    [LIVE_SERVER_EVENT.SESSION_STARTED, LIVE_SERVER_EVENT.INPUT_AUDIO_MUTED],
   );
 
   sideband.send({ type: LIVE_CLIENT_EVENT.CLOSE, event_id: "c_2" });

--- a/packages/voice/src/live-session-source.test.ts
+++ b/packages/voice/src/live-session-source.test.ts
@@ -1,0 +1,517 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { HOSTED_API_ERROR, VOICE_SERVICE_FRAME, VOICE_SERVICE_PATH } from "@sidecar/hosted";
+import {
+  developerSeedItem,
+  LIVE_CLIENT_EVENT,
+  LIVE_DEFAULTS,
+  LIVE_SERVER_EVENT,
+  LIVE_SESSION_OUTCOME,
+  LIVE_SESSIONS_PATH,
+  LIVE_VOICE,
+  type LiveServerEvent,
+  liveAttachPath,
+  RENDERER_CLIENT_EVENTS,
+  RENDERER_SERVER_EVENTS,
+} from "@sidecar/live";
+import type { ParsedJsonObject } from "@sidecar/wire/testing";
+import {
+  type HostedLiveSessionOptions,
+  HostedLiveSessionSource,
+  IntroductionLiveSessionSource,
+  KeyedLiveSessionSource,
+  keyedLiveSessions,
+  unavailableLiveDiagnostics,
+} from "./live-session-source.js";
+import { SOCKET_OPEN_FAULT } from "./live-socket.js";
+import { type ScriptedOpening, type ScriptedSocketSeam, scriptedOpenSocket } from "./testing.js";
+
+const NOW = 1_800_000_000_000;
+const SDP_OFFER =
+  "v=0\r\no=- 1 1 IN IP4 127.0.0.1\r\ns=-\r\nt=0 0\r\nm=audio 9 UDP/TLS/RTP/SAVPF 111\r\n";
+const SDP_ANSWER =
+  "v=0\r\no=- 2 2 IN IP4 127.0.0.1\r\ns=-\r\nt=0 0\r\nm=audio 9 UDP/TLS/RTP/SAVPF 111\r\n";
+const SESSION_ID = "ls_123";
+const SERVICE_ORIGIN = "wss://voice.example.test";
+const INPUT = [developerSeedItem("Roster: one session working.")];
+const QUOTA = { used: 3, limit: 50, resetsAt: NOW + 3_600_000 };
+
+interface RecordedRequest {
+  url: string;
+  init: RequestInit;
+}
+
+function openAi(answers: Array<() => Response>) {
+  const requests: RecordedRequest[] = [];
+  let call = 0;
+  const fetchLike = async (url: string, init: RequestInit): Promise<Response> => {
+    requests.push({ url, init });
+    const answer = answers[Math.min(call, answers.length - 1)];
+    call += 1;
+    if (!answer) throw new Error("no scripted answer");
+    return answer();
+  };
+  return { requests, fetchLike };
+}
+
+function created(body: ParsedJsonObject = {}) {
+  return () =>
+    new Response(
+      JSON.stringify({
+        session: { id: SESSION_ID, model: LIVE_DEFAULTS.MODEL },
+        transport: { type: "webrtc", sdp: SDP_ANSWER },
+        ...body,
+      }),
+      { status: 201 },
+    );
+}
+
+function status(code: number) {
+  return () => new Response(JSON.stringify({ error: "refused" }), { status: code });
+}
+
+function requestBody(request: RecordedRequest | undefined): ParsedJsonObject {
+  // SAFETY: the test scripted the body as JSON; the assertions read its shape.
+  return JSON.parse(String(request?.init.body)) as ParsedJsonObject;
+}
+
+function keyed(fetchLike: (url: string, init: RequestInit) => Promise<Response>) {
+  const script = scriptedOpenSocket([() => undefined]);
+  const source = new KeyedLiveSessionSource({
+    apiKey: "sk-test",
+    fetch: fetchLike,
+    openSocket: script.openSocket,
+    now: () => NOW,
+  });
+  return { source, ...script };
+}
+
+test("the keyed source posts the live session document with the key as its bearer", async () => {
+  const { requests, fetchLike } = openAi([created()]);
+  const { source } = keyed(fetchLike);
+  source.setVoice(LIVE_VOICE.CEDAR);
+
+  const opened = await source.create({ sdpOffer: SDP_OFFER, input: INPUT });
+
+  assert.equal(opened?.sessionId, SESSION_ID);
+  assert.equal(opened?.sdpAnswer, SDP_ANSWER);
+  const [request] = requests;
+  assert.equal(request?.url, `https://api.openai.com/v1${LIVE_SESSIONS_PATH}`);
+  assert.equal(request?.init.method, "POST");
+  assert.equal(new Headers(request?.init.headers).get("authorization"), "Bearer sk-test");
+  const body = requestBody(request);
+  assert.deepEqual(body.transport, { type: "webrtc", sdp: SDP_OFFER });
+  // SAFETY: the request body was composed by liveSessionConfig, whose session is a record.
+  const session = body.session as ParsedJsonObject;
+  assert.equal(session.model, LIVE_DEFAULTS.MODEL);
+  assert.deepEqual(session.audio, { output: { voice: LIVE_VOICE.CEDAR } });
+  assert.deepEqual(session.delegation, { type: "client" });
+  assert.equal(session.store, false);
+  assert.deepEqual(session.input, INPUT);
+  assert.deepEqual(session.client, {
+    data_channel: {
+      allowed_client_events: RENDERER_CLIENT_EVENTS,
+      allowed_server_events: RENDERER_SERVER_EVENTS,
+    },
+  });
+  assert.equal("tools" in session, false);
+  // SAFETY: the same document's audio field is the record asserted two lines above.
+  assert.equal("format" in (session.audio as ParsedJsonObject), false);
+  const report = source.diagnostics();
+  assert.equal(report.lastOutcome, LIVE_SESSION_OUTCOME.SUCCEEDED);
+  assert.equal(report.apiKeyConfigured, true);
+  assert.equal(report.hosted, undefined);
+  assert.equal(report.voice, LIVE_VOICE.CEDAR);
+  assert.equal(report.sidebandAttached, false);
+  assert.equal(report.lastAttemptAt, NOW);
+});
+
+test("the keyed source attaches its sideband at the session's attach path under the same key", async () => {
+  const { fetchLike } = openAi([created()]);
+  const { source, opens, sockets } = keyed(fetchLike);
+  const opened = await source.create({ sdpOffer: SDP_OFFER, input: [] });
+  assert.ok(opened);
+
+  const sideband = await opened.attach();
+  const seen: LiveServerEvent[] = [];
+  sideband.onEvent((event) => seen.push(event));
+
+  const [open] = opens;
+  assert.equal(open?.url, `wss://api.openai.com/v1${liveAttachPath(SESSION_ID)}`);
+  assert.deepEqual(open?.headers, { authorization: "Bearer sk-test" });
+  assert.equal(source.diagnostics().sidebandAttached, true);
+
+  const [socket] = sockets;
+  socket?.receive({
+    type: LIVE_SERVER_EVENT.SESSION_STARTED,
+    event_id: "ev_1",
+    session: { id: SESSION_ID },
+  });
+  socket?.receive({ type: LIVE_SERVER_EVENT.OUTPUT_AUDIO_DELTA, delta: "AAAA" });
+  assert.deepEqual(
+    seen.map((event) => event.type),
+    [LIVE_SERVER_EVENT.SESSION_STARTED],
+  );
+
+  socket?.closeFromServer({ code: 1000 });
+  assert.equal(source.diagnostics().sidebandAttached, false);
+});
+
+test("the keyed source records a sideband that would not open and rejects the attach", async () => {
+  const { fetchLike } = openAi([created()]);
+  const script = scriptedOpenSocket([() => ({ fault: SOCKET_OPEN_FAULT.REFUSED, status: 403 })]);
+  const source = new KeyedLiveSessionSource({
+    apiKey: "sk-test",
+    fetch: fetchLike,
+    openSocket: script.openSocket,
+  });
+  const opened = await source.create({ sdpOffer: SDP_OFFER, input: [] });
+  assert.ok(opened);
+
+  await assert.rejects(opened.attach());
+  assert.equal(source.diagnostics().lastOutcome, LIVE_SESSION_OUTCOME.SIDEBAND_FAILED);
+  assert.equal(source.diagnostics().sidebandAttached, false);
+});
+
+test("the keyed source names each failure class and answers nothing", async () => {
+  const cases: Array<{ answer: () => Response; outcome: string }> = [
+    { answer: status(401), outcome: LIVE_SESSION_OUTCOME.HTTP_ERROR },
+    { answer: status(429), outcome: LIVE_SESSION_OUTCOME.HTTP_ERROR },
+    {
+      answer: () => new Response("<html>", { status: 200 }),
+      outcome: LIVE_SESSION_OUTCOME.MALFORMED_RESPONSE,
+    },
+    {
+      answer: () => new Response(JSON.stringify({ session: { id: SESSION_ID } }), { status: 200 }),
+      outcome: LIVE_SESSION_OUTCOME.MALFORMED_RESPONSE,
+    },
+    {
+      answer: () => {
+        throw new TypeError("fetch failed");
+      },
+      outcome: LIVE_SESSION_OUTCOME.NETWORK_ERROR,
+    },
+  ];
+  for (const { answer, outcome } of cases) {
+    const { fetchLike } = openAi([answer]);
+    const { source } = keyed(fetchLike);
+    assert.equal(await source.create({ sdpOffer: SDP_OFFER, input: [] }), undefined);
+    assert.equal(source.diagnostics().lastOutcome, outcome);
+  }
+});
+
+test("the keyed source falls back to its configured voice when a setting is cleared or unknown", () => {
+  const { fetchLike } = openAi([created()]);
+  const { source } = keyed(fetchLike);
+  assert.equal(source.diagnostics().voice, LIVE_DEFAULTS.VOICE);
+  source.setVoice(LIVE_VOICE.ASH);
+  assert.equal(source.diagnostics().voice, LIVE_VOICE.ASH);
+  source.setVoice("not-a-voice");
+  assert.equal(source.diagnostics().voice, LIVE_DEFAULTS.VOICE);
+  source.setVoice(undefined);
+  assert.equal(source.diagnostics().voice, LIVE_DEFAULTS.VOICE);
+});
+
+test("a keyed source is built only from a key", () => {
+  const { openSocket } = scriptedOpenSocket([]);
+  assert.equal(keyedLiveSessions(undefined, { openSocket }), undefined);
+  assert.equal(keyedLiveSessions("  ", { openSocket }), undefined);
+  assert.equal(keyedLiveSessions("sk-test", { openSocket })?.model, LIVE_DEFAULTS.MODEL);
+  assert.equal(
+    keyedLiveSessions("sk-test", { openSocket, model: "gpt-live-next" })?.model,
+    "gpt-live-next",
+  );
+});
+
+function createdFrame(overrides: ParsedJsonObject = {}) {
+  return {
+    type: VOICE_SERVICE_FRAME.SESSION_CREATED,
+    sessionId: SESSION_ID,
+    sdpAnswer: SDP_ANSWER,
+    quota: QUOTA,
+    ...overrides,
+  };
+}
+
+function answering(frame: ParsedJsonObject): ScriptedOpening {
+  return (socket) => {
+    socket.onSent(() => queueMicrotask(() => socket.receive(frame)));
+    return undefined;
+  };
+}
+
+function answeringText(data: string): ScriptedOpening {
+  return (socket) => {
+    socket.onSent(() => queueMicrotask(() => socket.receiveText(data)));
+    return undefined;
+  };
+}
+
+function closingOnSend(code: number): ScriptedOpening {
+  return (socket) => {
+    socket.onSent(() => queueMicrotask(() => socket.closeFromServer({ code })));
+    return undefined;
+  };
+}
+
+function hosted(script: ScriptedSocketSeam, options: Partial<HostedLiveSessionOptions> = {}) {
+  return new HostedLiveSessionSource({
+    serviceOrigin: SERVICE_ORIGIN,
+    openSocket: script.openSocket,
+    readAccessToken: async () => "token-1",
+    refreshAccount: async () => undefined,
+    readAccountKey: async () => "dev@example.test",
+    now: () => NOW,
+    requestTimeoutMs: 50,
+    ...options,
+  });
+}
+
+test("the hosted source opens one socket with the bearer on its handshake and sends the create frame first", async () => {
+  const script = scriptedOpenSocket([answering(createdFrame())]);
+  const source = hosted(script, { voice: LIVE_VOICE.MARIN });
+
+  const opened = await source.create({ sdpOffer: SDP_OFFER, input: INPUT });
+
+  assert.equal(opened?.sessionId, SESSION_ID);
+  assert.equal(opened?.sdpAnswer, SDP_ANSWER);
+  assert.equal(script.opens.length, 1);
+  assert.equal(script.opens[0]?.url, `${SERVICE_ORIGIN}${VOICE_SERVICE_PATH.SESSIONS}`);
+  assert.deepEqual(script.opens[0]?.headers, { authorization: "Bearer token-1" });
+  const [socket] = script.sockets;
+  assert.equal(socket?.sent.length, 1);
+  assert.deepEqual(JSON.parse(socket?.sent[0] ?? ""), {
+    type: VOICE_SERVICE_FRAME.SESSION_CREATE,
+    sdp: SDP_OFFER,
+    voice: LIVE_VOICE.MARIN,
+    input: INPUT,
+  });
+  const report = source.diagnostics();
+  assert.equal(report.hosted, true);
+  assert.equal(report.apiKeyConfigured, false);
+  assert.equal(report.lastOutcome, LIVE_SESSION_OUTCOME.SUCCEEDED);
+  assert.deepEqual(report.quota, QUOTA);
+});
+
+test("the hosted source's attach is the socket that answered, and the answer frame is not an event", async () => {
+  const script = scriptedOpenSocket([answering(createdFrame())]);
+  const source = hosted(script);
+  const opened = await source.create({ sdpOffer: SDP_OFFER, input: [] });
+  assert.ok(opened);
+  const [socket] = script.sockets;
+  assert.ok(socket);
+  assert.equal(socket.closedByClient, false);
+
+  const sideband = await opened.attach();
+  assert.equal(await opened.attach(), sideband);
+  assert.equal(script.opens.length, 1);
+  assert.equal(source.diagnostics().sidebandAttached, true);
+
+  const seen: LiveServerEvent[] = [];
+  sideband.onEvent((event) => seen.push(event));
+  socket.receive(createdFrame());
+  socket.receive({
+    type: LIVE_SERVER_EVENT.INPUT_AUDIO_MUTED,
+    event_id: "ev_1",
+    client_event_id: "c_1",
+  });
+  assert.deepEqual(
+    seen.map((event) => event.type),
+    [LIVE_SERVER_EVENT.INPUT_AUDIO_MUTED],
+  );
+
+  sideband.send({ type: LIVE_CLIENT_EVENT.CLOSE, event_id: "c_2" });
+  assert.equal(socket.sent.length, 2);
+  socket.closeFromServer({ code: 1000 });
+  assert.equal(source.diagnostics().sidebandAttached, false);
+});
+
+test("the hosted source refuses to open without an access token and opens no socket", async () => {
+  const script = scriptedOpenSocket([answering(createdFrame())]);
+  const source = hosted(script, { readAccessToken: async () => undefined });
+
+  assert.equal(await source.create({ sdpOffer: SDP_OFFER, input: [] }), undefined);
+  assert.equal(script.opens.length, 0);
+  assert.equal(source.diagnostics().lastOutcome, LIVE_SESSION_OUTCOME.NOT_SIGNED_IN);
+});
+
+test("the hosted source names a refused handshake by its status", async () => {
+  const cases: Array<{ status: number; outcome: string }> = [
+    { status: 401, outcome: LIVE_SESSION_OUTCOME.NOT_SIGNED_IN },
+    { status: 429, outcome: LIVE_SESSION_OUTCOME.QUOTA_EXHAUSTED },
+    { status: 503, outcome: LIVE_SESSION_OUTCOME.HOSTED_UNAVAILABLE },
+    { status: 500, outcome: LIVE_SESSION_OUTCOME.HTTP_ERROR },
+  ];
+  for (const { status: code, outcome } of cases) {
+    const script = scriptedOpenSocket([() => ({ fault: SOCKET_OPEN_FAULT.REFUSED, status: code })]);
+    const source = hosted(script);
+    assert.equal(await source.create({ sdpOffer: SDP_OFFER, input: [] }), undefined);
+    assert.equal(source.diagnostics().lastOutcome, outcome);
+  }
+  const script = scriptedOpenSocket([
+    () => ({ fault: SOCKET_OPEN_FAULT.NETWORK, errorName: "ECONNREFUSED" }),
+  ]);
+  const source = hosted(script);
+  assert.equal(await source.create({ sdpOffer: SDP_OFFER, input: [] }), undefined);
+  assert.equal(source.diagnostics().lastOutcome, LIVE_SESSION_OUTCOME.NETWORK_ERROR);
+});
+
+test("the hosted source renews a refused bearer once and retries with the renewed one", async () => {
+  let token = "token-old";
+  const script = scriptedOpenSocket([
+    () => ({ fault: SOCKET_OPEN_FAULT.REFUSED, status: 401 }),
+    answering(createdFrame()),
+  ]);
+  const source = hosted(script, {
+    readAccessToken: async () => token,
+    refreshAccount: async () => {
+      token = "token-new";
+    },
+  });
+
+  const opened = await source.create({ sdpOffer: SDP_OFFER, input: [] });
+
+  assert.equal(opened?.sessionId, SESSION_ID);
+  assert.deepEqual(
+    script.opens.map((open) => open.headers.authorization),
+    ["Bearer token-old", "Bearer token-new"],
+  );
+});
+
+test("the hosted source does not carry a renewed bearer for another account", async () => {
+  let token = "token-old";
+  let holder = "one@example.test";
+  const script = scriptedOpenSocket([
+    () => ({ fault: SOCKET_OPEN_FAULT.REFUSED, status: 401 }),
+    answering(createdFrame()),
+  ]);
+  const source = hosted(script, {
+    readAccessToken: async () => token,
+    readAccountKey: async () => holder,
+    refreshAccount: async () => {
+      token = "token-new";
+      holder = "two@example.test";
+    },
+  });
+
+  assert.equal(await source.create({ sdpOffer: SDP_OFFER, input: [] }), undefined);
+  assert.equal(script.opens.length, 1);
+  assert.equal(source.diagnostics().lastOutcome, LIVE_SESSION_OUTCOME.NOT_SIGNED_IN);
+});
+
+test("the hosted source reads a hosted error frame as the refusal it names and closes the socket", async () => {
+  const cases: Array<{ frame: ParsedJsonObject; outcome: string }> = [
+    {
+      frame: { error: HOSTED_API_ERROR.INVALID_TOKEN },
+      outcome: LIVE_SESSION_OUTCOME.NOT_SIGNED_IN,
+    },
+    {
+      frame: { error: HOSTED_API_ERROR.QUOTA_EXHAUSTED, quota: QUOTA },
+      outcome: LIVE_SESSION_OUTCOME.QUOTA_EXHAUSTED,
+    },
+    {
+      frame: { error: HOSTED_API_ERROR.UNAVAILABLE },
+      outcome: LIVE_SESSION_OUTCOME.HOSTED_UNAVAILABLE,
+    },
+    { frame: { error: HOSTED_API_ERROR.UPSTREAM_ERROR }, outcome: LIVE_SESSION_OUTCOME.HTTP_ERROR },
+  ];
+  for (const { frame, outcome } of cases) {
+    const script = scriptedOpenSocket([answering(frame)]);
+    const source = hosted(script);
+    assert.equal(await source.create({ sdpOffer: SDP_OFFER, input: [] }), undefined);
+    assert.equal(source.diagnostics().lastOutcome, outcome);
+    assert.equal(script.sockets[0]?.closedByClient, true);
+  }
+  const script = scriptedOpenSocket([
+    answering({ error: HOSTED_API_ERROR.QUOTA_EXHAUSTED, quota: QUOTA }),
+  ]);
+  const source = hosted(script);
+  await source.create({ sdpOffer: SDP_OFFER, input: [] });
+  assert.deepEqual(source.diagnostics().quota, QUOTA);
+});
+
+test("the hosted source treats a frame that is neither answer nor error as malformed", async () => {
+  const answers = [
+    answeringText("not json"),
+    answering({ type: "session.started" }),
+    answering(createdFrame({ sdpAnswer: "" })),
+  ];
+  for (const answer of answers) {
+    const script = scriptedOpenSocket([answer]);
+    const source = hosted(script);
+    assert.equal(await source.create({ sdpOffer: SDP_OFFER, input: [] }), undefined);
+    assert.equal(source.diagnostics().lastOutcome, LIVE_SESSION_OUTCOME.MALFORMED_RESPONSE);
+    assert.equal(script.sockets[0]?.closedByClient, true);
+  }
+});
+
+test("the hosted source records a socket closed or silent before it answered as the service unavailable", async () => {
+  const closing = scriptedOpenSocket([closingOnSend(1011)]);
+  const closed = hosted(closing);
+  assert.equal(await closed.create({ sdpOffer: SDP_OFFER, input: [] }), undefined);
+  assert.equal(closed.diagnostics().lastOutcome, LIVE_SESSION_OUTCOME.HOSTED_UNAVAILABLE);
+
+  const silent = scriptedOpenSocket([() => undefined]);
+  const quiet = hosted(silent, { requestTimeoutMs: 10 });
+  assert.equal(await quiet.create({ sdpOffer: SDP_OFFER, input: [] }), undefined);
+  assert.equal(quiet.diagnostics().lastOutcome, LIVE_SESSION_OUTCOME.HOSTED_UNAVAILABLE);
+  assert.equal(silent.sockets[0]?.closedByClient, true);
+  assert.deepEqual(silent.sockets[0]?.listenerCounts, { messages: 0, closes: 0 });
+});
+
+test("the introduction source carries no authorization and opens no sideband", async () => {
+  const { quota: _quota, ...unmetered } = createdFrame();
+  const script = scriptedOpenSocket([answering(unmetered)]);
+  const source = new IntroductionLiveSessionSource({
+    serviceOrigin: SERVICE_ORIGIN,
+    openSocket: script.openSocket,
+    now: () => NOW,
+    requestTimeoutMs: 50,
+  });
+
+  const opened = await source.create({ sdpOffer: SDP_OFFER, input: INPUT });
+
+  assert.deepEqual(opened, { sessionId: SESSION_ID, sdpAnswer: SDP_ANSWER });
+  assert.equal("attach" in (opened ?? {}), false);
+  assert.equal(script.opens[0]?.url, `${SERVICE_ORIGIN}${VOICE_SERVICE_PATH.INTRODUCTION}`);
+  assert.deepEqual(script.opens[0]?.headers, {});
+  // SAFETY: the source sent the frame it composed as JSON; the assertions read its shape.
+  const frame = JSON.parse(script.sockets[0]?.sent[0] ?? "") as ParsedJsonObject;
+  assert.equal(frame.type, VOICE_SERVICE_FRAME.SESSION_CREATE);
+  assert.equal(frame.voice, LIVE_DEFAULTS.VOICE);
+  assert.deepEqual(frame.input, INPUT);
+  assert.equal(script.sockets[0]?.closedByClient, true);
+  const report = source.diagnostics();
+  assert.equal(report.lastOutcome, LIVE_SESSION_OUTCOME.SUCCEEDED);
+  assert.equal(report.sidebandAttached, false);
+  assert.equal(report.quota, undefined);
+});
+
+test("the introduction source never reads a refusal as signed out", async () => {
+  const refused = scriptedOpenSocket([() => ({ fault: SOCKET_OPEN_FAULT.REFUSED, status: 401 })]);
+  const source = new IntroductionLiveSessionSource({
+    serviceOrigin: SERVICE_ORIGIN,
+    openSocket: refused.openSocket,
+  });
+  assert.equal(await source.create({ sdpOffer: SDP_OFFER, input: [] }), undefined);
+  assert.equal(source.diagnostics().lastOutcome, LIVE_SESSION_OUTCOME.HTTP_ERROR);
+
+  const metered = scriptedOpenSocket([() => ({ fault: SOCKET_OPEN_FAULT.REFUSED, status: 429 })]);
+  const capped = new IntroductionLiveSessionSource({
+    serviceOrigin: SERVICE_ORIGIN,
+    openSocket: metered.openSocket,
+  });
+  assert.equal(await capped.create({ sdpOffer: SDP_OFFER, input: [] }), undefined);
+  assert.equal(capped.diagnostics().lastOutcome, LIVE_SESSION_OUTCOME.QUOTA_EXHAUSTED);
+});
+
+test("unavailable diagnostics name the fixture run apart from the missing key", () => {
+  assert.equal(
+    unavailableLiveDiagnostics({ fixtureMode: true, apiKeyConfigured: false }).lastOutcome,
+    LIVE_SESSION_OUTCOME.DISABLED_BY_FIXTURE,
+  );
+  const missing = unavailableLiveDiagnostics({ fixtureMode: false, apiKeyConfigured: false });
+  assert.equal(missing.lastOutcome, LIVE_SESSION_OUTCOME.NO_API_KEY);
+  assert.equal(missing.sidebandAttached, false);
+  assert.equal(missing.voice, LIVE_DEFAULTS.VOICE);
+});

--- a/packages/voice/src/live-session-source.ts
+++ b/packages/voice/src/live-session-source.ts
@@ -1,0 +1,685 @@
+import {
+  type AccountToken,
+  CALL_FAULT,
+  type CallFailure,
+  callAnswered,
+  createAccountCall,
+  fixedBearer,
+  HOSTED_API_ERROR,
+  type HostedApiError,
+  type HostedQuota,
+  hostedErrorSchema,
+  hostedQuotaSchema,
+  isHostedVoiceServiceAddress,
+  type LiveSessionCreated,
+  type SessionCreateFrame,
+  sessionCreatedFrameSchema,
+  VOICE_SERVICE_FRAME,
+  VOICE_SERVICE_PATH,
+} from "@sidecar/hosted";
+import {
+  decodeLivePayload,
+  type InitialItem,
+  isLiveVoice,
+  LIVE_DEFAULTS,
+  LIVE_SCENE,
+  LIVE_SESSION_OUTCOME,
+  LIVE_SESSIONS_PATH,
+  type LiveDiagnostics,
+  type LiveSessionOutcome,
+  type LiveVoice,
+  liveAttachPath,
+  liveCreateAnswerSchema,
+  liveCreateRequest,
+  liveSessionConfig,
+} from "@sidecar/live";
+import {
+  type CloudFetch,
+  HTTP_METHOD,
+  HTTP_STATUS,
+  positiveInteger,
+  text,
+  unparsedWire,
+  type WireRecord,
+  withoutTrailingSlash,
+} from "@sidecar/wire";
+import {
+  type LiveSideband,
+  type LiveSocket,
+  type OpenSocket,
+  SOCKET_OPEN_FAULT,
+  type SocketOpenFailure,
+  type SocketOpening,
+  sidebandOverSocket,
+  socketOpened,
+} from "./live-socket.js";
+
+/**
+ * Where a GPT Live session comes from — the developer's own OpenAI key, the
+ * signed-in account through Luke's voice service, or the accountless
+ * introduction endpoint — and what each answers with: the session's opaque id
+ * and the SDP answer the renderer applies, never a credential. The trusted
+ * side of the session (the sideband) is reached only through what a source
+ * opened, so the renderer's peer connection and the host's sideband are one
+ * session by construction.
+ */
+
+export const LIVE_ENVIRONMENT = {
+  MODEL: "LUKE_LIVE_MODEL",
+  VOICE: "LUKE_LIVE_VOICE",
+} as const;
+
+const OPENAI_LIVE_DEFAULTS = {
+  BASE_URL: "https://api.openai.com/v1",
+  REQUEST_TIMEOUT_MS: 10_000,
+} as const;
+
+const UNAVAILABLE_STATUS = 503;
+
+export interface LiveSessionCreateInput {
+  /** The renderer's SDP offer, as written. */
+  sdpOffer: string;
+  /** The startup history, already bounded by `conversationSeedItems`. */
+  input: readonly InitialItem[];
+}
+
+/** A session that stands: the renderer's half, and the trusted half the host attaches. */
+export interface LiveSessionOpened extends LiveSessionCreated {
+  /**
+   * Opens the trusted sideband on this session. Called once per session; a
+   * failure records `SIDEBAND_FAILED` on the source and rejects, and the
+   * session it leaves standing is the caller's to close.
+   */
+  attach(): Promise<LiveSideband>;
+}
+
+/** The introduction's session has no trusted half on the desktop; the voice service holds that sideband. */
+export type IntroductionLiveSessionOpened = LiveSessionCreated;
+
+export interface LiveSessionSource {
+  create(input: LiveSessionCreateInput): Promise<LiveSessionOpened | undefined>;
+  /** Applies to the next session: a voice is immutable once a session has started. */
+  setVoice(voice: string | undefined): void;
+  diagnostics(): LiveDiagnostics;
+}
+
+/** The introduction's source: the same create, no voice to set, and no sideband on this side. */
+export interface IntroductionSessionSource {
+  create(input: LiveSessionCreateInput): Promise<IntroductionLiveSessionOpened | undefined>;
+  diagnostics(): LiveDiagnostics;
+}
+
+/** The launch environment's voice, honoured only when it is one the API speaks. */
+export function environmentLiveVoice(
+  environment: NodeJS.ProcessEnv = process.env,
+): LiveVoice | undefined {
+  const value = environment[LIVE_ENVIRONMENT.VOICE]?.trim();
+  return isLiveVoice(value) ? value : undefined;
+}
+
+function chosenVoice(voice: string | undefined, fallback: LiveVoice): LiveVoice {
+  return isLiveVoice(voice) ? voice : fallback;
+}
+
+/**
+ * What every source records about its last attempt, and the stderr line a
+ * failed one writes: the outcome and a status or error name, never a request,
+ * a key, or an SDP.
+ */
+class OutcomeRecord {
+  readonly #logLabel: string;
+  readonly #now: () => number;
+  lastOutcome: LiveSessionOutcome = LIVE_SESSION_OUTCOME.NOT_ATTEMPTED;
+  lastDetail: string | undefined;
+  lastAttemptAt: number | undefined;
+
+  constructor(logLabel: string, now: () => number) {
+    this.#logLabel = logLabel;
+    this.#now = now;
+  }
+
+  attempt(): void {
+    this.lastAttemptAt = this.#now();
+  }
+
+  record(outcome: LiveSessionOutcome, detail?: string): void {
+    this.lastOutcome = outcome;
+    this.lastDetail = detail;
+    if (outcome === LIVE_SESSION_OUTCOME.SUCCEEDED) return;
+    process.stderr.write(`${this.#logLabel}: ${outcome}${detail ? ` (${detail})` : ""}\n`);
+  }
+
+  fields(): Pick<LiveDiagnostics, "lastOutcome" | "lastDetail" | "lastAttemptAt"> {
+    return {
+      lastOutcome: this.lastOutcome,
+      ...(this.lastDetail ? { lastDetail: this.lastDetail } : undefined),
+      ...(this.lastAttemptAt === undefined ? undefined : { lastAttemptAt: this.lastAttemptAt }),
+    };
+  }
+}
+
+interface RecordedOutcome {
+  outcome: LiveSessionOutcome;
+  detail: string;
+}
+
+/** A socket that never opened, named by the fault it ended at, for either service-side source. */
+function socketFaultOutcome(opening: SocketOpenFailure): RecordedOutcome {
+  if (opening.fault === SOCKET_OPEN_FAULT.NETWORK) {
+    return {
+      outcome: LIVE_SESSION_OUTCOME.NETWORK_ERROR,
+      detail: opening.errorName ?? "unknown error",
+    };
+  }
+  return { outcome: statusOutcome(opening.status), detail: `status ${opening.status}` };
+}
+
+function statusOutcome(status: number): LiveSessionOutcome {
+  if (status === HTTP_STATUS.TOO_MANY_REQUESTS) return LIVE_SESSION_OUTCOME.QUOTA_EXHAUSTED;
+  if (status === UNAVAILABLE_STATUS) return LIVE_SESSION_OUTCOME.HOSTED_UNAVAILABLE;
+  if (status === HTTP_STATUS.UNAUTHORIZED) return LIVE_SESSION_OUTCOME.NOT_SIGNED_IN;
+  return LIVE_SESSION_OUTCOME.HTTP_ERROR;
+}
+
+/** The hosted refusals that name a distinct way forward; every other reason is a plain HTTP error. */
+const HOSTED_ERROR_OUTCOME: ReadonlyMap<HostedApiError, LiveSessionOutcome> = new Map([
+  [HOSTED_API_ERROR.INVALID_TOKEN, LIVE_SESSION_OUTCOME.NOT_SIGNED_IN],
+  [HOSTED_API_ERROR.QUOTA_EXHAUSTED, LIVE_SESSION_OUTCOME.QUOTA_EXHAUSTED],
+  [HOSTED_API_ERROR.UNAVAILABLE, LIVE_SESSION_OUTCOME.HOSTED_UNAVAILABLE],
+  [HOSTED_API_ERROR.UPSTREAM_THROTTLED, LIVE_SESSION_OUTCOME.HOSTED_UNAVAILABLE],
+]);
+
+export interface KeyedLiveSessionOptions {
+  apiKey: string;
+  openSocket: OpenSocket;
+  model?: string;
+  voice?: string;
+  /** The API's `/v1` base; the attach address is derived from it by scheme alone. */
+  baseUrl?: string;
+  fetch?: CloudFetch;
+  now?: () => number;
+  requestTimeoutMs?: number;
+}
+
+/**
+ * Sessions created with the developer's own OpenAI key. The key never leaves
+ * the main process: the renderer receives the id and the SDP answer, and the
+ * sideband this source attaches carries the same key on its handshake, from
+ * here. A failure resolves to nothing rather than an error, leaving voice
+ * unavailable and the rest of Luke working.
+ */
+export class KeyedLiveSessionSource implements LiveSessionSource {
+  readonly #apiKey: string;
+  readonly #openSocket: OpenSocket;
+  readonly #model: string;
+  /** The voice from construction, which a cleared setting falls back to. */
+  readonly #configuredVoice: LiveVoice;
+  #voice: LiveVoice;
+  readonly #baseUrl: string;
+  readonly #fetch: CloudFetch | undefined;
+  readonly #requestTimeoutMs: number;
+  readonly #outcome: OutcomeRecord;
+  #sidebandAttached = false;
+
+  constructor(options: KeyedLiveSessionOptions) {
+    const apiKey = text(options.apiKey);
+    if (!apiKey) throw new Error("OpenAI API key must not be empty");
+    this.#apiKey = apiKey;
+    this.#openSocket = options.openSocket;
+    this.#model = text(options.model) ?? LIVE_DEFAULTS.MODEL;
+    this.#configuredVoice = chosenVoice(options.voice, LIVE_DEFAULTS.VOICE);
+    this.#voice = this.#configuredVoice;
+    this.#baseUrl = withoutTrailingSlash(text(options.baseUrl) ?? OPENAI_LIVE_DEFAULTS.BASE_URL);
+    this.#fetch = options.fetch;
+    this.#requestTimeoutMs = positiveInteger(
+      options.requestTimeoutMs,
+      OPENAI_LIVE_DEFAULTS.REQUEST_TIMEOUT_MS,
+    );
+    this.#outcome = new OutcomeRecord("OpenAI live session", options.now ?? Date.now);
+  }
+
+  get model(): string {
+    return this.#model;
+  }
+
+  setVoice(voice: string | undefined): void {
+    this.#voice = chosenVoice(voice, this.#configuredVoice);
+  }
+
+  async create(input: LiveSessionCreateInput): Promise<LiveSessionOpened | undefined> {
+    this.#outcome.attempt();
+    this.#sidebandAttached = false;
+    const call = createAccountCall({
+      baseUrl: this.#baseUrl,
+      credential: fixedBearer(this.#apiKey),
+      fetch: this.#fetch,
+      requestTimeoutMs: this.#requestTimeoutMs,
+    });
+    const session = liveSessionConfig({
+      scene: LIVE_SCENE.DESKTOP,
+      model: this.#model,
+      voice: this.#voice,
+      input: input.input,
+    });
+    const answer = await call.send({
+      method: HTTP_METHOD.POST,
+      path: LIVE_SESSIONS_PATH,
+      body: JSON.stringify(liveCreateRequest(session, input.sdpOffer)),
+    });
+    if (!callAnswered(answer)) {
+      this.#refuseCall(answer);
+      return undefined;
+    }
+    const { response } = answer;
+    if (!response.ok) {
+      // Status alone diagnoses credentials or rate limits without writing the
+      // request or the key to the log.
+      this.#outcome.record(LIVE_SESSION_OUTCOME.HTTP_ERROR, `status ${response.status}`);
+      return undefined;
+    }
+    const payload = await response.json().catch(() => undefined);
+    const created =
+      payload === undefined ? undefined : liveCreateAnswerSchema.parse(unparsedWire(payload));
+    if (!created) {
+      this.#outcome.record(LIVE_SESSION_OUTCOME.MALFORMED_RESPONSE, "no session id and SDP answer");
+      return undefined;
+    }
+    this.#outcome.record(LIVE_SESSION_OUTCOME.SUCCEEDED);
+    const sessionId = created.session.id;
+    return {
+      sessionId,
+      sdpAnswer: created.transport.sdp,
+      attach: () => this.#attach(sessionId),
+    };
+  }
+
+  diagnostics(): LiveDiagnostics {
+    return {
+      apiKeyConfigured: true,
+      fixtureMode: false,
+      model: this.#model,
+      voice: this.#voice,
+      sidebandAttached: this.#sidebandAttached,
+      ...this.#outcome.fields(),
+    };
+  }
+
+  /**
+   * The attach address is the sessions path under the API's socket scheme,
+   * with the id kept unchanged, and the handshake carries the same project
+   * key that created the session, as the server-controls guide requires.
+   */
+  async #attach(sessionId: string): Promise<LiveSideband> {
+    const address = new URL(`${this.#baseUrl}${liveAttachPath(sessionId)}`);
+    address.protocol = address.protocol === "http:" ? "ws:" : "wss:";
+    const opening = await this.#openSocket(address.toString(), {
+      authorization: `Bearer ${this.#apiKey}`,
+    });
+    if (!socketOpened(opening)) {
+      const { detail } = socketFaultOutcome(opening);
+      this.#outcome.record(LIVE_SESSION_OUTCOME.SIDEBAND_FAILED, detail);
+      throw new Error(`sideband attach failed (${detail})`);
+    }
+    this.#sidebandAttached = true;
+    opening.socket.onClose(() => {
+      this.#sidebandAttached = false;
+    });
+    return sidebandOverSocket(opening.socket);
+  }
+
+  #refuseCall(failure: CallFailure): void {
+    switch (failure.fault) {
+      case CALL_FAULT.NETWORK:
+        this.#outcome.record(
+          LIVE_SESSION_OUTCOME.NETWORK_ERROR,
+          failure.errorName ?? "unknown error",
+        );
+        return;
+      case CALL_FAULT.NO_CREDENTIAL:
+      case CALL_FAULT.HOLDER_CHANGED:
+        this.#outcome.record(LIVE_SESSION_OUTCOME.NO_API_KEY);
+        return;
+    }
+  }
+}
+
+interface ServiceSessionOptions {
+  /** The voice service origin, `wss://` scheme; a value that is not an origin is refused at construction. */
+  serviceOrigin: string;
+  servicePath: string;
+  openSocket: OpenSocket;
+  logLabel: string;
+  /**
+   * The identity a socket's handshake carries. The introduction's endpoint
+   * takes none, so it omits this, and then neither the header nor the
+   * refresh-and-retry exists.
+   */
+  authorization?: AccountToken;
+  voice?: string;
+  now?: () => number;
+  requestTimeoutMs?: number;
+}
+
+/**
+ * The frames the voice service exchanges before Live events flow, over one
+ * socket per session: the desktop's `session.create` first, the service's
+ * `session.created` back, and from then on the same socket carries the
+ * session's events as themselves. A refusal comes back as the hosted error
+ * document, or as the upgrade's own status.
+ */
+class ServiceLiveSessionSource {
+  readonly #address: string;
+  readonly #openSocket: OpenSocket;
+  readonly #authorization: AccountToken | undefined;
+  readonly #configuredVoice: LiveVoice;
+  #voice: LiveVoice;
+  readonly #requestTimeoutMs: number;
+  readonly #outcome: OutcomeRecord;
+  #quota: HostedQuota | undefined;
+  #sidebandAttached = false;
+
+  constructor(options: ServiceSessionOptions) {
+    const origin = text(options.serviceOrigin) ?? "";
+    const address = `${origin}${options.servicePath}`;
+    if (!isHostedVoiceServiceAddress(address, origin)) {
+      throw new Error("The voice service origin must be an origin");
+    }
+    this.#address = address;
+    this.#openSocket = options.openSocket;
+    this.#authorization = options.authorization;
+    this.#configuredVoice = chosenVoice(options.voice, LIVE_DEFAULTS.VOICE);
+    this.#voice = this.#configuredVoice;
+    this.#requestTimeoutMs = positiveInteger(
+      options.requestTimeoutMs,
+      OPENAI_LIVE_DEFAULTS.REQUEST_TIMEOUT_MS,
+    );
+    this.#outcome = new OutcomeRecord(options.logLabel, options.now ?? Date.now);
+  }
+
+  setVoice(voice: string | undefined): void {
+    this.#voice = chosenVoice(voice, this.#configuredVoice);
+  }
+
+  diagnostics(): LiveDiagnostics {
+    return {
+      apiKeyConfigured: false,
+      hosted: true,
+      fixtureMode: false,
+      model: LIVE_DEFAULTS.MODEL,
+      voice: this.#voice,
+      sidebandAttached: this.#sidebandAttached,
+      ...this.#outcome.fields(),
+      ...(this.#quota ? { quota: this.#quota } : undefined),
+    };
+  }
+
+  /**
+   * One session per socket. The socket is opened with the bearer on its
+   * handshake, the offer and seed go as the first frame, and the answer is
+   * the first frame back; the socket that answered is the sideband, held for
+   * the caller's `attach`. Anything else — a refusal, a frame that is not the
+   * answer, a close, or silence past the deadline — closes the socket and
+   * resolves to nothing.
+   */
+  protected async createSession(
+    input: LiveSessionCreateInput,
+  ): Promise<{ created: LiveSessionCreated; socket: LiveSocket } | undefined> {
+    this.#outcome.attempt();
+    this.#sidebandAttached = false;
+    const bearer = await this.#bearer();
+    if (this.#authorization && bearer === undefined) {
+      this.#outcome.record(LIVE_SESSION_OUTCOME.NOT_SIGNED_IN, "no access token");
+      return undefined;
+    }
+    let opening = await this.#open(bearer);
+    if (
+      !socketOpened(opening) &&
+      opening.fault === SOCKET_OPEN_FAULT.REFUSED &&
+      opening.status === HTTP_STATUS.UNAUTHORIZED &&
+      this.#authorization
+    ) {
+      // Routine expiry of an hour-lived token: renew once and retry once, only
+      // on a bearer that actually changed and still answers for the same account.
+      const holder = await this.#holder();
+      await this.#authorization.refreshAccount().catch(() => undefined);
+      const renewed = await this.#bearer();
+      if (renewed !== undefined && renewed !== bearer) {
+        if ((await this.#holder()) !== holder) {
+          this.#outcome.record(LIVE_SESSION_OUTCOME.NOT_SIGNED_IN, "the account changed");
+          return undefined;
+        }
+        opening = await this.#open(renewed);
+      }
+    }
+    if (!socketOpened(opening)) {
+      const { outcome, detail } = socketFaultOutcome(opening);
+      this.#refuse(outcome, detail);
+      return undefined;
+    }
+    const { socket } = opening;
+    const frame: SessionCreateFrame = {
+      type: VOICE_SERVICE_FRAME.SESSION_CREATE,
+      sdp: input.sdpOffer,
+      voice: this.#voice,
+      input: [...input.input],
+    };
+    const answer = await this.#firstFrame(socket, () => socket.send(JSON.stringify(frame)));
+    const created = answer === undefined ? undefined : this.#readCreated(answer);
+    if (!created) {
+      socket.close();
+      return undefined;
+    }
+    this.#outcome.record(LIVE_SESSION_OUTCOME.SUCCEEDED);
+    return { created, socket };
+  }
+
+  /**
+   * A refusal is only a signed-out answer where an identity was sent at all;
+   * the introduction endpoint takes none, so its 401 is a fault worth chasing.
+   */
+  #refuse(outcome: LiveSessionOutcome, detail: string): void {
+    this.#outcome.record(
+      outcome === LIVE_SESSION_OUTCOME.NOT_SIGNED_IN && !this.#authorization
+        ? LIVE_SESSION_OUTCOME.HTTP_ERROR
+        : outcome,
+      detail,
+    );
+  }
+
+  protected holdSideband(socket: LiveSocket): LiveSideband {
+    this.#sidebandAttached = true;
+    socket.onClose(() => {
+      this.#sidebandAttached = false;
+    });
+    return sidebandOverSocket(socket);
+  }
+
+  async #bearer(): Promise<string | undefined> {
+    if (!this.#authorization) return undefined;
+    const token = await this.#authorization.readAccessToken().catch(() => undefined);
+    return token ? `Bearer ${token}` : undefined;
+  }
+
+  async #holder(): Promise<string | undefined> {
+    return this.#authorization?.readAccountKey?.().catch(() => undefined);
+  }
+
+  #open(bearer: string | undefined): Promise<SocketOpening> {
+    return this.#openSocket(this.#address, bearer === undefined ? {} : { authorization: bearer });
+  }
+
+  /**
+   * Waits for the service's one answer. A frame is decoded but not judged
+   * here; a socket closed before it answered, or one silent past the request
+   * deadline, is recorded as the service unavailable.
+   */
+  #firstFrame(socket: LiveSocket, send: () => void): Promise<WireRecord | undefined> {
+    return new Promise((resolve) => {
+      let settled = false;
+      const settle = (value: WireRecord | undefined) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        stopMessages();
+        stopClose();
+        resolve(value);
+      };
+      const timer = setTimeout(() => {
+        this.#outcome.record(
+          LIVE_SESSION_OUTCOME.HOSTED_UNAVAILABLE,
+          "no answer before the deadline",
+        );
+        settle(undefined);
+      }, this.#requestTimeoutMs);
+      const stopMessages = socket.onMessage((data) => {
+        const payload = decodeLivePayload(data);
+        if (payload === undefined) {
+          this.#outcome.record(
+            LIVE_SESSION_OUTCOME.MALFORMED_RESPONSE,
+            "answer was not a document",
+          );
+        }
+        settle(payload);
+      });
+      const stopClose = socket.onClose((close) => {
+        this.#outcome.record(
+          LIVE_SESSION_OUTCOME.HOSTED_UNAVAILABLE,
+          close.code === undefined ? "closed before answering" : `closed with code ${close.code}`,
+        );
+        settle(undefined);
+      });
+      send();
+    });
+  }
+
+  #readCreated(payload: WireRecord): LiveSessionCreated | undefined {
+    const created = sessionCreatedFrameSchema.parse(payload);
+    if (created) {
+      this.#quota = created.quota ?? this.#quota;
+      return { sessionId: created.sessionId, sdpAnswer: created.sdpAnswer };
+    }
+    const error = hostedErrorSchema.parse(payload);
+    if (error) {
+      if (error === HOSTED_API_ERROR.QUOTA_EXHAUSTED) {
+        this.#quota = hostedQuotaSchema.parse(unparsedWire(payload.quota)) ?? this.#quota;
+      }
+      this.#refuse(HOSTED_ERROR_OUTCOME.get(error) ?? LIVE_SESSION_OUTCOME.HTTP_ERROR, error);
+      return undefined;
+    }
+    this.#outcome.record(LIVE_SESSION_OUTCOME.MALFORMED_RESPONSE, "no session id and SDP answer");
+    return undefined;
+  }
+}
+
+type ServiceSourceOptions = Omit<
+  ServiceSessionOptions,
+  "servicePath" | "logLabel" | "authorization"
+>;
+
+export type HostedLiveSessionOptions = ServiceSourceOptions & AccountToken;
+
+/**
+ * The signed-in account's sessions, through Luke's voice service, for a
+ * developer who has not connected an OpenAI key of their own. The socket the
+ * service answered on is the sideband, so attaching opens nothing further.
+ */
+export class HostedLiveSessionSource extends ServiceLiveSessionSource implements LiveSessionSource {
+  constructor(options: HostedLiveSessionOptions) {
+    const { readAccessToken, refreshAccount, readAccountKey, ...rest } = options;
+    super({
+      ...rest,
+      servicePath: VOICE_SERVICE_PATH.SESSIONS,
+      logLabel: "Hosted live session",
+      authorization: { readAccessToken, refreshAccount, readAccountKey },
+    });
+  }
+
+  async create(input: LiveSessionCreateInput): Promise<LiveSessionOpened | undefined> {
+    const opened = await this.createSession(input);
+    if (!opened) return undefined;
+    let sideband: LiveSideband | undefined;
+    return {
+      ...opened.created,
+      attach: async () => {
+        sideband ??= this.holdSideband(opened.socket);
+        return sideband;
+      },
+    };
+  }
+}
+
+export type IntroductionLiveSessionOptions = Omit<ServiceSourceOptions, "voice">;
+
+/**
+ * The one-time introduction's session, before any account exists. The
+ * handshake deliberately carries no authorization header — the endpoint takes
+ * no identity and this source holds none to send — and the session has no
+ * sideband on this side by type: the voice service holds it and sends the
+ * greeting, so nothing on this machine can append to it.
+ */
+export class IntroductionLiveSessionSource
+  extends ServiceLiveSessionSource
+  implements IntroductionSessionSource
+{
+  constructor(options: IntroductionLiveSessionOptions) {
+    super({
+      ...options,
+      servicePath: VOICE_SERVICE_PATH.INTRODUCTION,
+      logLabel: "Introduction live session",
+    });
+  }
+
+  async create(input: LiveSessionCreateInput): Promise<IntroductionLiveSessionOpened | undefined> {
+    const opened = await this.createSession(input);
+    if (!opened) return undefined;
+    opened.socket.close();
+    return opened.created;
+  }
+}
+
+/**
+ * Explains why no source exists, which is the state the panel shows as voice
+ * unavailable. A missing key and a fixture run look identical from the panel
+ * and have completely different fixes.
+ */
+export function unavailableLiveDiagnostics(input: {
+  fixtureMode: boolean;
+  apiKeyConfigured: boolean;
+}): LiveDiagnostics {
+  return {
+    apiKeyConfigured: input.apiKeyConfigured,
+    fixtureMode: input.fixtureMode,
+    model: text(process.env[LIVE_ENVIRONMENT.MODEL]) ?? LIVE_DEFAULTS.MODEL,
+    voice: environmentLiveVoice() ?? LIVE_DEFAULTS.VOICE,
+    sidebandAttached: false,
+    lastOutcome: input.fixtureMode
+      ? LIVE_SESSION_OUTCOME.DISABLED_BY_FIXTURE
+      : LIVE_SESSION_OUTCOME.NO_API_KEY,
+  };
+}
+
+export type KeyedLiveSessionSourceOptions = Omit<KeyedLiveSessionOptions, "apiKey">;
+
+/**
+ * Builds a keyed source only when there is a key to build one from. The key
+ * is resolved by the settings store; the model and voice fall back to the
+ * launch environment here. `OPENAI_BASE_URL` is deliberately not read: the
+ * renderer's peer connection reaches OpenAI's own media servers whatever base
+ * a redirect names, so a session created elsewhere would answer an SDP the
+ * media path cannot honor.
+ */
+export function keyedLiveSessions(
+  apiKey: string | undefined,
+  options: KeyedLiveSessionSourceOptions,
+): KeyedLiveSessionSource | undefined {
+  const resolved = text(apiKey);
+  if (!resolved) return undefined;
+  const model = text(options.model) ?? text(process.env[LIVE_ENVIRONMENT.MODEL]);
+  const voice = isLiveVoice(options.voice) ? options.voice : environmentLiveVoice();
+  return new KeyedLiveSessionSource({
+    ...options,
+    apiKey: resolved,
+    ...(model ? { model } : undefined),
+    ...(voice ? { voice } : undefined),
+  });
+}

--- a/packages/voice/src/live-session-source.ts
+++ b/packages/voice/src/live-session-source.ts
@@ -597,14 +597,10 @@ export class HostedLiveSessionSource extends ServiceLiveSessionSource implements
   async create(input: LiveSessionCreateInput): Promise<LiveSessionOpened | undefined> {
     const opened = await this.createSession(input);
     if (!opened) return undefined;
-    let sideband: LiveSideband | undefined;
-    return {
-      ...opened.created,
-      attach: async () => {
-        sideband ??= this.holdSideband(opened.socket);
-        return sideband;
-      },
-    };
+    // The socket that answered is already the session's: the sideband is held
+    // now, so nothing the session says before the host attaches is lost.
+    const sideband = this.holdSideband(opened.socket);
+    return { ...opened.created, attach: async () => sideband };
   }
 }
 

--- a/packages/voice/src/live-socket.test.ts
+++ b/packages/voice/src/live-socket.test.ts
@@ -1,0 +1,70 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { closeEvent, LIVE_SERVER_EVENT, type LiveServerEvent, thinkingAppend } from "@sidecar/live";
+import { SOCKET_OPEN_FAULT, sidebandOverSocket, socketOpened } from "./live-socket.js";
+import { FakeLiveSocket } from "./testing.js";
+
+test("a sideband parses the socket's frames and drops reflected audio by type", () => {
+  const socket = new FakeLiveSocket();
+  const sideband = sidebandOverSocket(socket);
+  const seen: LiveServerEvent[] = [];
+  sideband.onEvent((event) => seen.push(event));
+
+  socket.receive({
+    type: LIVE_SERVER_EVENT.SESSION_STARTED,
+    event_id: "ev_1",
+    session: { id: "ls_1" },
+  });
+  socket.receive({ type: LIVE_SERVER_EVENT.INPUT_AUDIO_APPEND, audio: "AAAA" });
+  socket.receive({ type: LIVE_SERVER_EVENT.OUTPUT_AUDIO_DELTA, delta: "AAAA" });
+  socket.receiveText("not json");
+  socket.receive({ type: "session.unknown" });
+  socket.receive({
+    type: LIVE_SERVER_EVENT.INPUT_TRANSCRIPT_DELTA,
+    event_id: "ev_2",
+    delta: " hi",
+    start_ms: 0,
+    end_ms: 400,
+  });
+
+  assert.deepEqual(
+    seen.map((event) => event.type),
+    [LIVE_SERVER_EVENT.SESSION_STARTED, LIVE_SERVER_EVENT.INPUT_TRANSCRIPT_DELTA],
+  );
+});
+
+test("a sideband sends client events as JSON frames and closes the socket it stands on", () => {
+  const socket = new FakeLiveSocket();
+  const sideband = sidebandOverSocket(socket);
+  const append = thinkingAppend({ eventId: "ev_a", delegationId: null, content: "roster" });
+
+  sideband.send(append);
+  sideband.send(closeEvent("ev_b"));
+  sideband.close();
+
+  assert.deepEqual(
+    socket.sent.map((frame) => JSON.parse(frame)),
+    [append, closeEvent("ev_b")],
+  );
+  assert.equal(socket.closedByClient, true);
+});
+
+test("a sideband's close listener follows the socket's and unsubscribes", () => {
+  const socket = new FakeLiveSocket();
+  const sideband = sidebandOverSocket(socket);
+  const closes: Array<{ code?: number }> = [];
+  const stop = sideband.onClose((close) => closes.push(close));
+
+  socket.closeFromServer({ code: 1006 });
+  stop();
+  socket.closeFromServer({ code: 1000 });
+
+  assert.deepEqual(closes, [{ code: 1006 }]);
+  assert.equal(socket.listenerCounts.closes, 0);
+});
+
+test("an opening is a socket or one of the two faults", () => {
+  assert.equal(socketOpened({ socket: new FakeLiveSocket() }), true);
+  assert.equal(socketOpened({ fault: SOCKET_OPEN_FAULT.REFUSED, status: 401 }), false);
+  assert.equal(socketOpened({ fault: SOCKET_OPEN_FAULT.NETWORK }), false);
+});

--- a/packages/voice/src/live-socket.test.ts
+++ b/packages/voice/src/live-socket.test.ts
@@ -60,11 +60,36 @@ test("a sideband's close listener follows the socket's and unsubscribes", () => 
   socket.closeFromServer({ code: 1000 });
 
   assert.deepEqual(closes, [{ code: 1006 }]);
-  assert.equal(socket.listenerCounts.closes, 0);
 });
 
 test("an opening is a socket or one of the two faults", () => {
   assert.equal(socketOpened({ socket: new FakeLiveSocket() }), true);
   assert.equal(socketOpened({ fault: SOCKET_OPEN_FAULT.REFUSED, status: 401 }), false);
   assert.equal(socketOpened({ fault: SOCKET_OPEN_FAULT.NETWORK }), false);
+});
+
+test("a sideband holds what arrived before anyone listened and replays it to the first listener", () => {
+  const socket = new FakeLiveSocket();
+  const sideband = sidebandOverSocket(socket);
+  socket.receive({
+    type: LIVE_SERVER_EVENT.SESSION_STARTED,
+    event_id: "ev_1",
+    session: { id: "ls_1" },
+  });
+  socket.receive({ type: LIVE_SERVER_EVENT.OUTPUT_AUDIO_DELTA, delta: "AAAA" });
+  socket.closeFromServer({ code: 1006 });
+
+  const seen: LiveServerEvent[] = [];
+  const closes: Array<{ code?: number }> = [];
+  sideband.onEvent((event) => seen.push(event));
+  sideband.onClose((close) => closes.push(close));
+  const late: LiveServerEvent[] = [];
+  sideband.onEvent((event) => late.push(event));
+
+  assert.deepEqual(
+    seen.map((event) => event.type),
+    [LIVE_SERVER_EVENT.SESSION_STARTED],
+  );
+  assert.deepEqual(late, []);
+  assert.deepEqual(closes, [{ code: 1006 }]);
 });

--- a/packages/voice/src/live-socket.ts
+++ b/packages/voice/src/live-socket.ts
@@ -79,17 +79,55 @@ const REFLECTED_AUDIO_TYPES: ReadonlySet<string> = new Set([
  * A sideband over an open socket. Frames that are not events this build reads
  * are discarded, and the two reflected audio events are dropped by type
  * before any listener sees them: the developer's voice is heard by the model
- * over the media track and is never kept or read here.
+ * over the media track and is never kept or read here. Events and a close
+ * that arrive before anyone listens are held and replayed to the first
+ * listener, so a session that spoke between its creation and the host's
+ * attach loses nothing, and a socket that died in that gap is seen dead.
  */
 export function sidebandOverSocket(socket: LiveSocket): LiveSideband {
+  const eventListeners = new Set<(event: LiveServerEvent) => void>();
+  const closeListeners = new Set<(close: SocketClose) => void>();
+  let heldEvents: LiveServerEvent[] = [];
+  let heldClose: SocketClose | undefined;
+
+  socket.onMessage((data) => {
+    const event = parseLiveServerEvent(data);
+    if (event === undefined || REFLECTED_AUDIO_TYPES.has(event.type)) return;
+    if (eventListeners.size === 0) {
+      heldEvents.push(event);
+      return;
+    }
+    for (const listener of [...eventListeners]) listener(event);
+  });
+  socket.onClose((close) => {
+    if (closeListeners.size === 0) {
+      heldClose = close;
+      return;
+    }
+    for (const listener of [...closeListeners]) listener(close);
+  });
+
   return {
-    onEvent: (listener) =>
-      socket.onMessage((data) => {
-        const event = parseLiveServerEvent(data);
-        if (event === undefined || REFLECTED_AUDIO_TYPES.has(event.type)) return;
-        listener(event);
-      }),
-    onClose: (listener) => socket.onClose(listener),
+    onEvent: (listener) => {
+      eventListeners.add(listener);
+      const replay = heldEvents;
+      heldEvents = [];
+      for (const event of replay) listener(event);
+      return () => {
+        eventListeners.delete(listener);
+      };
+    },
+    onClose: (listener) => {
+      closeListeners.add(listener);
+      if (heldClose !== undefined) {
+        const close = heldClose;
+        heldClose = undefined;
+        listener(close);
+      }
+      return () => {
+        closeListeners.delete(listener);
+      };
+    },
     send: (event) => socket.send(JSON.stringify(event)),
     close: () => socket.close(),
   };

--- a/packages/voice/src/live-socket.ts
+++ b/packages/voice/src/live-socket.ts
@@ -1,0 +1,96 @@
+import {
+  LIVE_SERVER_EVENT,
+  type LiveClientEvent,
+  type LiveServerEvent,
+  parseLiveServerEvent,
+} from "@sidecar/live";
+
+/**
+ * The socket seam a live session source opens its trusted connections
+ * through: OpenAI's attach endpoint on the keyed tier, Luke's voice service on
+ * the hosted one. The seam is injected so this package never reaches `ws`;
+ * the host implements it over `ws`, and a test hands in a scripted socket.
+ */
+
+/** Why a socket never opened: the server answered the upgrade with a status, or nothing answered. */
+export const SOCKET_OPEN_FAULT = {
+  REFUSED: "refused",
+  NETWORK: "network",
+} as const;
+
+export type SocketOpenFault = (typeof SOCKET_OPEN_FAULT)[keyof typeof SOCKET_OPEN_FAULT];
+
+/** How a socket ended, as the transport reported it; the code is the close frame's where one arrived. */
+export interface SocketClose {
+  code?: number;
+}
+
+/** An open socket: text frames out, text frames in, and the close both sides can see. */
+export interface LiveSocket {
+  send(data: string): void;
+  close(): void;
+  onMessage(listener: (data: string) => void): () => void;
+  onClose(listener: (close: SocketClose) => void): () => void;
+}
+
+export type SocketOpenFailure =
+  | { fault: typeof SOCKET_OPEN_FAULT.REFUSED; status: number }
+  | {
+      fault: typeof SOCKET_OPEN_FAULT.NETWORK;
+      /** The kind of error the attempt ended with, never its words, which could carry a credential. */
+      errorName?: string;
+    };
+
+export type SocketOpening = { socket: LiveSocket } | SocketOpenFailure;
+
+export function socketOpened(opening: SocketOpening): opening is { socket: LiveSocket } {
+  return "socket" in opening;
+}
+
+/**
+ * Opens one WebSocket and settles once the handshake has: with the socket, or
+ * with why the upgrade was refused. The headers are the handshake's alone, and
+ * the one this package ever sets is the bearer the endpoint takes.
+ */
+export type OpenSocket = (
+  url: string,
+  headers: Readonly<Record<string, string>>,
+) => Promise<SocketOpening>;
+
+/**
+ * The trusted side's view of one running session: every event the session
+ * emits, parsed, and the client events the trusted side may send. The host's
+ * live session service is the one consumer; the renderer's data channel is
+ * never a sideband.
+ */
+export interface LiveSideband {
+  onEvent(listener: (event: LiveServerEvent) => void): () => void;
+  onClose(listener: (close: SocketClose) => void): () => void;
+  send(event: LiveClientEvent): void;
+  close(): void;
+}
+
+const REFLECTED_AUDIO_TYPES: ReadonlySet<string> = new Set([
+  LIVE_SERVER_EVENT.INPUT_AUDIO_APPEND,
+  LIVE_SERVER_EVENT.OUTPUT_AUDIO_DELTA,
+]);
+
+/**
+ * A sideband over an open socket. Frames that are not events this build reads
+ * are discarded, and the two reflected audio events are dropped by type
+ * before any listener sees them: the developer's voice is heard by the model
+ * over the media track and is never kept or read here.
+ */
+export function sidebandOverSocket(socket: LiveSocket): LiveSideband {
+  return {
+    onEvent: (listener) =>
+      socket.onMessage((data) => {
+        const event = parseLiveServerEvent(data);
+        if (event === undefined || REFLECTED_AUDIO_TYPES.has(event.type)) return;
+        listener(event);
+      }),
+    onClose: (listener) => socket.onClose(listener),
+    send: (event) => socket.send(JSON.stringify(event)),
+    close: () => socket.close(),
+  };
+}

--- a/packages/voice/src/testing.ts
+++ b/packages/voice/src/testing.ts
@@ -1,0 +1,100 @@
+import type { WireRecord } from "@sidecar/wire";
+import type { LiveSocket, OpenSocket, SocketClose, SocketOpening } from "./live-socket.js";
+
+/**
+ * A scripted socket for the sources' tests: what the source sent is kept,
+ * and the test feeds frames and closes from the far side.
+ */
+export class FakeLiveSocket implements LiveSocket {
+  readonly sent: string[] = [];
+  closedByClient = false;
+  readonly #sentListeners = new Set<(data: string) => void>();
+  readonly #messageListeners = new Set<(data: string) => void>();
+  readonly #closeListeners = new Set<(close: SocketClose) => void>();
+
+  send(data: string): void {
+    this.sent.push(data);
+    for (const listener of [...this.#sentListeners]) listener(data);
+  }
+
+  /** Hears what the source sends, so a script can answer the frame it was sent. */
+  onSent(listener: (data: string) => void): () => void {
+    this.#sentListeners.add(listener);
+    return () => {
+      this.#sentListeners.delete(listener);
+    };
+  }
+
+  close(): void {
+    this.closedByClient = true;
+  }
+
+  onMessage(listener: (data: string) => void): () => void {
+    this.#messageListeners.add(listener);
+    return () => {
+      this.#messageListeners.delete(listener);
+    };
+  }
+
+  onClose(listener: (close: SocketClose) => void): () => void {
+    this.#closeListeners.add(listener);
+    return () => {
+      this.#closeListeners.delete(listener);
+    };
+  }
+
+  /** Delivers one frame from the far side, encoded as the service would send it. */
+  receive(frame: WireRecord): void {
+    this.receiveText(JSON.stringify(frame));
+  }
+
+  /** Delivers raw text from the far side, for a frame that is not JSON at all. */
+  receiveText(data: string): void {
+    for (const listener of [...this.#messageListeners]) listener(data);
+  }
+
+  closeFromServer(close: SocketClose = {}): void {
+    for (const listener of [...this.#closeListeners]) listener(close);
+  }
+
+  get listenerCounts(): ListenerCounts {
+    return { messages: this.#messageListeners.size, closes: this.#closeListeners.size };
+  }
+}
+
+/** How many listeners still stand on a socket, so a test can see a settled wait let go of it. */
+export interface ListenerCounts {
+  messages: number;
+  closes: number;
+}
+
+interface RecordedOpen {
+  url: string;
+  headers: Readonly<Record<string, string>>;
+}
+
+/** What one scripted open does: refuse, or take the fresh socket and answer with it. */
+export type ScriptedOpening = (socket: FakeLiveSocket) => SocketOpening | undefined;
+
+export interface ScriptedSocketSeam {
+  openSocket: OpenSocket;
+  opens: RecordedOpen[];
+  sockets: FakeLiveSocket[];
+}
+
+/** An `openSocket` seam that answers each open from a script and records what it was asked. */
+export function scriptedOpenSocket(answers: ScriptedOpening[]): ScriptedSocketSeam {
+  const opens: RecordedOpen[] = [];
+  const sockets: FakeLiveSocket[] = [];
+  let call = 0;
+  const openSocket: OpenSocket = async (url, headers) => {
+    opens.push({ url, headers });
+    const socket = new FakeLiveSocket();
+    sockets.push(socket);
+    const answer = answers[Math.min(call, answers.length - 1)];
+    call += 1;
+    if (!answer) throw new Error("no scripted opening");
+    return answer(socket) ?? { socket };
+  };
+  return { openSocket, opens, sockets };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -795,6 +795,9 @@ importers:
       '@sidecar/hosted':
         specifier: workspace:*
         version: link:../hosted
+      '@sidecar/live':
+        specifier: workspace:*
+        version: link:../live
       '@sidecar/realtime':
         specifier: workspace:*
         version: link:../realtime


### PR DESCRIPTION
## What

PR 7 of the GPT Live rollout. Adds the three GPT Live session sources to `@sidecar/voice`, beside the Realtime minters (which stay until PRs 13/14 remove them):

- `KeyedLiveSessionSource`: `POST /v1/live/sessions` on `api.openai.com` with the developer's key as the bearer, through the existing `createAccountCall`/`fixedBearer` helpers; `attach()` opens the sideband at `liveAttachPath(id)` under the same key.
- `HostedLiveSessionSource`: one socket to `HOSTED_VOICE_SERVICE_ORIGIN + VOICE_SERVICE_PATH.SESSIONS` with the account bearer on the handshake; `create` sends the `session.create` frame and resolves on `session.created`; `attach()` returns the same socket as the sideband. A 401 on the handshake renews the bearer once and retries once, only for the same account.
- `IntroductionLiveSessionSource`: the voice service's `/introduction`, no credential on the handshake, and no `attach` by type (the service holds that sideband).
- `live-socket.ts`: the `LiveSideband` transport interface (`onEvent`, `onClose`, `send`, `close`), the injected `openSocket(url, headers)` seam so this package never imports `ws`, and `sidebandOverSocket`, which parses frames with `parseLiveServerEvent` and drops the two reflected-audio events by type.
- `capability-assembler.ts`: a `liveSessions` capability beside `realtimeCredentials`, under the same source policy; speed is ignored. The voice service origin is taken as an option defaulting to the build-pinned `HOSTED_VOICE_SERVICE_ORIGIN`, so PR 8 can hand in `hostedVoiceServiceOrigin()`.
- Diagnostics use `LiveDiagnostics` and `LIVE_SESSION_OUTCOME` from `@sidecar/live`; `@sidecar/voice/testing` exports the scripted fake socket for PR 8's host tests.

Nothing consumes the new capability yet.

## How it follows the GPT Live docs

- WebRTC guide: the session is created server-side by `POST /v1/live/sessions { session, transport: { type: "webrtc", sdp } }`, on the trusted side, with the project key; the renderer receives only the session id and the SDP answer.
- Server-controls guide: the sideband attaches at `wss://api.openai.com/v1/live/sessions/{id}/attach` with the id kept unchanged and `Authorization: Bearer` of the key that created the session; the attached socket never receives `session.start`; reflected audio events are dropped before any listener sees them.
- The session document is `@sidecar/live`'s `liveSessionConfig`: client delegation, `store: false`, renderer channel restrictions, no `tools`, `audio.format`, speed, or truncation.

## Verification

- `./scripts/check.sh` passes (lint, knip, typecheck, tests, build). The voice package runs 153 tests; the new ones cover request body structure, answer parsing, outcome on each failure class (HTTP status, malformed body, network fault, sideband refusal), bearer placement on both the POST and the attach handshake, first-frame structure, hosted refusals by status and by error frame, bearer renewal, close-or-silence before the answer, and no credential on the introduction source.
- No macOS or UI code is touched, so `./scripts/verify.sh` does not apply.

## Reviews

Both Cursor skills were looked up and applied to the diff: the thermo-nuclear code quality review (cursor/plugins `cursor-team-kit`) and ponytail-review (dietrichgebert/ponytail). Fixes made: the "not signed in becomes http-error without a bearer" branch was folded into one method; the origin guard moved to construction instead of running per create; the hosted error table shrank to the four reasons with a distinct outcome; the first-frame decoder now reuses `decodeLivePayload` from `@sidecar/live`.

## Note for PR 4 / PR 8

The hosted source reads a refusal two ways: an upgrade refused with a status (401 signed out, 429 quota, 503 unavailable, else http-error) or a first frame matching `hostedErrorSchema` (`{ error, quota? }`). The voice service can refuse either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/61a3ebea-f0ea-4061-a1bf-735c8021be8a)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34526705787/artifacts/10171948836) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34526705787)

- Commit: `72eee15005f3b240513fb39b1d8f04ff961886cd`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
