### PR TITLE
feat(voice-service): hosted voice service

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,22 @@
+# The one Dockerfile in this repository builds apps/voice-service from the
+# repository root. Every workspace manifest stays in the context so pnpm can
+# read the lockfile against the whole workspace; only the packages' sources and
+# the service itself are copied beyond that.
+*
+!package.json
+!pnpm-lock.yaml
+!pnpm-workspace.yaml
+!apps
+apps/*/**
+!apps/*/package.json
+!apps/voice-service/**
+!packages
+packages/*/**
+!packages/*/package.json
+!packages/*/src/**
+!packages/*/tsconfig.json
+!tools
+tools/*/**
+!tools/*/package.json
+**/node_modules
+**/*.test.ts

--- a/apps/voice-service/Dockerfile
+++ b/apps/voice-service/Dockerfile
@@ -1,0 +1,21 @@
+# Built from the repository root, because the service is a pnpm workspace
+# member and resolves @sidecar packages by workspace link:
+#
+#   docker build -f apps/voice-service/Dockerfile -t luke-voice-service .
+#
+# The root .dockerignore keeps the context to the manifests, the lockfile,
+# the packages' sources, and this app; nothing of the desktop, the site, or
+# the iOS tree enters the image.
+FROM node:24-alpine
+
+ENV NODE_ENV=production
+RUN corepack enable && corepack prepare pnpm@10.34.5 --activate
+
+WORKDIR /luke
+COPY . .
+RUN pnpm install --frozen-lockfile --ignore-scripts --filter @luke/voice-service...
+
+USER node
+WORKDIR /luke/apps/voice-service
+EXPOSE 8080
+CMD ["./node_modules/.bin/tsx", "src/main.ts"]

--- a/apps/voice-service/README.md
+++ b/apps/voice-service/README.md
@@ -20,7 +20,7 @@ Both are WebSocket upgrades; one session per socket.
 | Path | Who | Authorization |
 | --- | --- | --- |
 | `/sessions` | A signed-in desktop | `Authorization: Bearer <account token>` on the handshake, forwarded whole to the account service's `VOICE_AUTHORIZE` route, which resolves the account and spends its allowance before any session exists |
-| `/introduction` | A fresh install with no account | None; the service's own meter, per hashed caller address and shared, both per UTC day |
+| `/introduction` | A fresh install with no account | None; the service's own meter, per hashed caller address and shared, both per UTC day. The caller is the last `X-Forwarded-For` hop, the one the platform's proxy appended, so a client cannot name itself; the counts live in this process, so run one machine or accept a per-replica ceiling |
 | `GET /healthz` | The platform's health probe | None |
 
 The socket's first frame is the desktop's `session.create` (the SDP offer, a
@@ -74,8 +74,11 @@ same way and the process waits for each session to finalize before exiting.
 Two shapes, and the desktop reads both:
 
 - Before any socket stands, an HTTP status on the upgrade: `401` for
-  `/sessions` without a bearer, `429` for an introduction past the meter,
-  `503` while the service is stopping, `404` for any other path.
+  `/sessions` without a bearer, `403` for a handshake carrying a browser
+  `Origin` header (the desktop connects from its main process and never sends
+  one, so a page in a browser is not a caller this service has), `429` for an
+  introduction past the meter, `503` while the service is stopping, `404` for
+  any other path.
 - Once a socket stands, one frame `{ "error": <reason> }` in
   `@sidecar/hosted`'s `hostedErrorSchema` vocabulary, then a close with code
   1008 and the same reason: `invalid-request` for a first frame that is not a

--- a/apps/voice-service/README.md
+++ b/apps/voice-service/README.md
@@ -1,0 +1,155 @@
+# Luke's hosted voice service
+
+The one process on Luke's side that holds a GPT Live project key. A desktop
+with no OpenAI key of its own opens one WebSocket here per voice session; the
+service creates the session at OpenAI from the desktop's WebRTC offer,
+attaches the trusted sideband itself, answers the SDP, and from then on is a
+pipe between the desktop and OpenAI. It keeps no conversation, reads no frame
+past its `type`, and writes down status codes and counts. The desktop's side
+of this contract is `live-contract.ts` in `@sidecar/hosted`; the Live grammar
+both ends speak is `@sidecar/live`.
+
+It is its own long-running container rather than a Vercel function because
+whoever holds the project key must hold the sideband for the whole session,
+and a function can hold neither a socket nor a call.
+
+## Routes
+
+Both are WebSocket upgrades; one session per socket.
+
+| Path | Who | Authorization |
+| --- | --- | --- |
+| `/sessions` | A signed-in desktop | `Authorization: Bearer <account token>` on the handshake, forwarded whole to the account service's `VOICE_AUTHORIZE` route, which resolves the account and spends its allowance before any session exists |
+| `/introduction` | A fresh install with no account | None; the service's own meter, per hashed caller address and shared, both per UTC day |
+| `GET /healthz` | The platform's health probe | None |
+
+The socket's first frame is the desktop's `session.create` (the SDP offer, a
+voice from `LIVE_VOICE`, and the seed as `input` items). The service answers
+`session.created` with the opaque session id, the SDP answer, and, on
+`/sessions`, the quota the session was spent against. After that, GPT Live
+events cross as themselves.
+
+### What crosses, and what does not
+
+- Desktop to OpenAI on `/sessions`: every frame, untouched. The desktop's host
+  is the session's trusted side at one remove; its appends and close are its
+  own.
+- OpenAI to desktop on `/sessions`: every frame, untouched, except
+  `session.input_audio.append` and `session.output_audio.delta`, which are
+  dropped by type so the developer's voice and Luke's never transit this
+  service. Audio stays on the WebRTC media tracks between the desktop and
+  OpenAI.
+- On `/introduction` the sideband is the service's alone: the caller may send
+  only what a renderer's data channel may (`session.input_audio.mute`,
+  `session.input_audio.unmute`, `session.close`) and is shown only what a
+  renderer's data channel is shown (the lifecycle, both captions, the
+  microphone acknowledgments, usage, error, info). On `session.started` the
+  service sends `greetingInstruction()` as one `session.instructions.append`
+  with `delegation_id: null`, once, the docs' "greet before the caller
+  speaks" pattern from the trusted side. The seed is bounded to one developer
+  message of at most 1,024 characters, since it is client text entering a
+  prompt on Luke's key with no account behind it.
+
+Every session is created with `liveSessionConfig` from `@sidecar/live`: the
+scene's instructions, client delegation, `store: false`, and the renderer's
+`client.data_channel` permissions (`RENDERER_CLIENT_EVENTS`,
+`RENDERER_SERVER_EVENTS`), and nothing the API does not document for WebRTC.
+
+### How a session ends
+
+`session.closed` is finalization. When it arrives the service forwards it,
+reports `usage.seconds` once to the account service's `VOICE_USAGE` route
+(the route's own ledger answers `repeated` to a second report of the same
+session, so a retry cannot bill twice), and closes both ends. A desktop that
+hangs up first has `session.close` sent on its behalf and the sideband held
+for `session.closed` for 15 seconds, the docs' close sequence, after which
+finalization is logged as unconfirmed and the sideband released. A sideband
+that ends first closes the desktop socket with code 1001 and reason
+`upstream-closed`, and reports nothing, since without the final event the
+usage is unconfirmed. On stop (`SIGTERM`), every desktop socket is closed the
+same way and the process waits for each session to finalize before exiting.
+
+### How a refusal looks
+
+Two shapes, and the desktop reads both:
+
+- Before any socket stands, an HTTP status on the upgrade: `401` for
+  `/sessions` without a bearer, `429` for an introduction past the meter,
+  `503` while the service is stopping, `404` for any other path.
+- Once a socket stands, one frame `{ "error": <reason> }` in
+  `@sidecar/hosted`'s `hostedErrorSchema` vocabulary, then a close with code
+  1008 and the same reason: `invalid-request` for a first frame that is not a
+  valid `session.create`; `invalid-token` and `quota-exhausted` as the account
+  service answered them; `unavailable` when the account service did not
+  answer; `upstream-error` when OpenAI refused the creation or the sideband
+  could not attach; `upstream-throttled` when OpenAI answered 429.
+
+## Configuration
+
+| Variable | Meaning |
+| --- | --- |
+| `OPENAI_API_KEY` | The GPT Live project key. Required. |
+| `LUKE_LIVE_MODEL` | A pinned model; `gpt-live-1` otherwise. |
+| `WEB_ORIGIN` | The account service's origin, e.g. `https://tryluke.dev`. Required. |
+| `VOICE_SERVICE_SECRET` | The shared secret the account service's two internal routes accept in `x-luke-voice-service-secret`; the same value is set on the Vercel deployment. Required. |
+| `PORT`, `HOST` | Where to listen; `8080` on every interface by default. |
+
+A blank value reads as absent. A launch missing a required value names every
+one it lacks on stderr and exits.
+
+## Running locally
+
+```sh
+OPENAI_API_KEY=sk-… WEB_ORIGIN=http://localhost:3000 VOICE_SERVICE_SECRET=dev \
+  pnpm --filter @luke/voice-service start
+```
+
+Tests run against a fake OpenAI and a fake account service on loopback:
+
+```sh
+pnpm --filter @luke/voice-service test
+```
+
+## Deploying
+
+The desktop's build pins the service's origin as
+`HOSTED_VOICE_SERVICE_ORIGIN` (`wss://voice.tryluke.dev`) in
+`@sidecar/hosted`, so the deployment must answer on that host, or the
+constant moves with it. The service and the account service's internal routes
+deploy before the desktop that connects to them ships.
+
+Build the image from the repository root:
+
+```sh
+docker build -f apps/voice-service/Dockerfile -t luke-voice-service .
+```
+
+Fly.io:
+
+```sh
+fly launch --no-deploy --name luke-voice --dockerfile apps/voice-service/Dockerfile
+fly secrets set OPENAI_API_KEY=… VOICE_SERVICE_SECRET=… WEB_ORIGIN=https://tryluke.dev
+fly deploy --dockerfile apps/voice-service/Dockerfile
+fly certs add voice.tryluke.dev
+```
+
+Set the `internal_port` to 8080 and the health check to `GET /healthz`; keep
+one machine always running, since a session holds a socket for its whole
+life. Point `voice.tryluke.dev` at the app and set the same
+`VOICE_SERVICE_SECRET` on the Vercel deployment so the internal routes switch
+on.
+
+Railway: create a service from this repository with the root directory `/`
+and the Dockerfile path `apps/voice-service/Dockerfile`, set the four
+variables, attach the custom domain `voice.tryluke.dev`, and set the health
+check path to `/healthz`. Railway supplies `PORT` itself.
+
+## What it logs
+
+One JSON line per event on standard output: the listening address, an upgrade
+refused and its status, a session refused and its reason, a session created,
+a greeting sent, usage reported with its seconds and the account service's
+status, and a session ended with its finalization and the frame and byte
+counts in each direction, including how many frames were dropped as reflected
+audio or as unpermitted on the introduction. No line carries a session id, a
+bearer, an SDP, a transcript fragment, or any frame's content.

--- a/apps/voice-service/package.json
+++ b/apps/voice-service/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@luke/voice-service",
+  "version": "0.5.0",
+  "private": true,
+  "type": "module",
+  "description": "The hosted voice service: owns each hosted GPT Live session on Luke's project key and pipes its events to the desktop",
+  "engines": {
+    "node": ">=24.0.0"
+  },
+  "scripts": {
+    "start": "tsx src/main.ts",
+    "test": "tsx --test 'src/**/*.test.ts'",
+    "typecheck": "tsc --project tsconfig.json"
+  },
+  "dependencies": {
+    "@sidecar/hosted": "workspace:*",
+    "@sidecar/live": "workspace:*",
+    "@sidecar/wire": "workspace:*",
+    "tsx": "4.23.12",
+    "ws": "8.21.3"
+  },
+  "devDependencies": {
+    "@types/node": "26.2.0",
+    "@types/ws": "8.18.1",
+    "typescript": "7.0.2"
+  }
+}

--- a/apps/voice-service/src/account-service.test.ts
+++ b/apps/voice-service/src/account-service.test.ts
@@ -1,0 +1,143 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  HOSTED_API_ERROR,
+  HOSTED_SERVICE_PATH,
+  VOICE_SERVICE_SECRET_HEADER,
+  VOICE_USAGE_RECORD,
+} from "@sidecar/hosted";
+import type { CloudFetch } from "@sidecar/wire";
+import {
+  AUTHORIZE_OUTCOME,
+  createAccountService,
+  USAGE_REPORT_OUTCOME,
+} from "./account-service.js";
+
+const SECRET = "shared";
+const QUOTA = { used: 1, limit: 5000, resetsAt: 1_800_000_000_000 };
+
+interface Seen {
+  url: string;
+  headers: Headers;
+  body: string | undefined;
+}
+
+interface Upstream {
+  fetch: CloudFetch;
+  seen: Seen[];
+}
+
+function answering(status: number, body: string): Upstream {
+  const seen: Seen[] = [];
+  return {
+    seen,
+    fetch: async (url, init) => {
+      seen.push({
+        url,
+        headers: new Headers(init.headers),
+        body: init.body === undefined || init.body === null ? undefined : init.body.toString(),
+      });
+      return new Response(body, { status, headers: { "content-type": "application/json" } });
+    },
+  };
+}
+
+const service = (fetch: CloudFetch) =>
+  createAccountService({ webOrigin: "https://luke.test/", serviceSecret: SECRET, fetch });
+
+test("authorize posts the bearer under the service secret and reads the account back", async () => {
+  const upstream = answering(200, JSON.stringify({ userId: "user-1", quota: QUOTA }));
+  const result = await service(upstream.fetch).authorize("Bearer token");
+  assert.deepEqual(result, {
+    outcome: AUTHORIZE_OUTCOME.AUTHORIZED,
+    userId: "user-1",
+    quota: QUOTA,
+  });
+  assert.equal(upstream.seen.length, 1);
+  const call = upstream.seen[0];
+  assert.ok(call);
+  assert.equal(call.url, `https://luke.test${HOSTED_SERVICE_PATH.VOICE_AUTHORIZE}`);
+  assert.equal(call.headers.get(VOICE_SERVICE_SECRET_HEADER), SECRET);
+  assert.equal(call.headers.get("authorization"), null);
+  assert.deepEqual(JSON.parse(call.body ?? ""), { bearer: "Bearer token" });
+});
+
+test("a 401 and a 429 are refusals carrying the reason the account service named", async () => {
+  const unknown = await service(
+    answering(401, JSON.stringify({ error: HOSTED_API_ERROR.INVALID_TOKEN })).fetch,
+  ).authorize("Bearer stale");
+  assert.deepEqual(unknown, {
+    outcome: AUTHORIZE_OUTCOME.REFUSED,
+    reason: HOSTED_API_ERROR.INVALID_TOKEN,
+    status: 401,
+  });
+  const spent = await service(
+    answering(429, JSON.stringify({ error: HOSTED_API_ERROR.QUOTA_EXHAUSTED, quota: QUOTA })).fetch,
+  ).authorize("Bearer token");
+  assert.deepEqual(spent, {
+    outcome: AUTHORIZE_OUTCOME.REFUSED,
+    reason: HOSTED_API_ERROR.QUOTA_EXHAUSTED,
+    status: 429,
+  });
+});
+
+test("a refusal without a readable body still refuses by its status", async () => {
+  const result = await service(answering(429, "").fetch).authorize("Bearer token");
+  assert.deepEqual(result, {
+    outcome: AUTHORIZE_OUTCOME.REFUSED,
+    reason: HOSTED_API_ERROR.QUOTA_EXHAUSTED,
+    status: 429,
+  });
+});
+
+test("a 5xx, an unreadable success, and a network fault are each unavailable", async () => {
+  assert.deepEqual(await service(answering(503, "{}").fetch).authorize("Bearer t"), {
+    outcome: AUTHORIZE_OUTCOME.UNAVAILABLE,
+    status: 503,
+  });
+  assert.deepEqual(
+    await service(answering(200, JSON.stringify({ userId: 4 })).fetch).authorize("Bearer t"),
+    {
+      outcome: AUTHORIZE_OUTCOME.UNAVAILABLE,
+      status: 200,
+    },
+  );
+  const failing: CloudFetch = () => Promise.reject(new TypeError("fetch failed"));
+  assert.deepEqual(await service(failing).authorize("Bearer t"), {
+    outcome: AUTHORIZE_OUTCOME.UNAVAILABLE,
+    status: undefined,
+  });
+});
+
+test("a usage report is posted whole and answered as recorded or repeated", async () => {
+  const upstream = answering(200, JSON.stringify({ record: VOICE_USAGE_RECORD.RECORDED }));
+  const report = { userId: "user-1", sessionId: "live_1", seconds: 42 };
+  assert.deepEqual(await service(upstream.fetch).recordUsage(report), {
+    outcome: USAGE_REPORT_OUTCOME.RECORDED,
+    status: 200,
+  });
+  const call = upstream.seen[0];
+  assert.ok(call);
+  assert.equal(call.url, `https://luke.test${HOSTED_SERVICE_PATH.VOICE_USAGE}`);
+  assert.equal(call.headers.get(VOICE_SERVICE_SECRET_HEADER), SECRET);
+  assert.deepEqual(JSON.parse(call.body ?? ""), report);
+
+  const repeated = answering(200, JSON.stringify({ record: VOICE_USAGE_RECORD.REPEATED }));
+  assert.deepEqual(await service(repeated.fetch).recordUsage(report), {
+    outcome: USAGE_REPORT_OUTCOME.REPEATED,
+    status: 200,
+  });
+});
+
+test("a usage report the account service refuses or cannot take is failed, never recorded", async () => {
+  const report = { userId: "user-1", sessionId: "live_1", seconds: 42 };
+  assert.deepEqual(await service(answering(400, "{}").fetch).recordUsage(report), {
+    outcome: USAGE_REPORT_OUTCOME.FAILED,
+    status: 400,
+  });
+  const failing: CloudFetch = () => Promise.reject(new TypeError("fetch failed"));
+  assert.deepEqual(await service(failing).recordUsage(report), {
+    outcome: USAGE_REPORT_OUTCOME.FAILED,
+    status: undefined,
+  });
+});

--- a/apps/voice-service/src/account-service.ts
+++ b/apps/voice-service/src/account-service.ts
@@ -1,0 +1,133 @@
+import {
+  callAnswered,
+  createAccountCall,
+  HOSTED_API_ERROR,
+  HOSTED_SERVICE_PATH,
+  type HostedApiError,
+  type HostedQuota,
+  hostedErrorSchema,
+  NO_CREDENTIAL,
+  VOICE_SERVICE_SECRET_HEADER,
+  VOICE_USAGE_RECORD,
+  type VoiceAuthorizeRequest,
+  type VoiceUsageRequest,
+  voiceAuthorizeAnswerSchema,
+  voiceUsageAnswerSchema,
+} from "@sidecar/hosted";
+import { type CloudFetch, HTTP_METHOD, HTTP_STATUS } from "@sidecar/wire";
+
+/**
+ * The two calls this service makes to the account service, under the shared
+ * secret and never under an account of its own. Before a session is spent,
+ * authorize says whose socket this is and whether their allowance covers one
+ * more; after `session.closed`, usage records the seconds OpenAI billed. The
+ * desktop's bearer travels in the authorize body as the thing being asked
+ * about, exactly as the route reads it, and is held here no longer than the
+ * call.
+ */
+
+export const AUTHORIZE_OUTCOME = {
+  AUTHORIZED: "authorized",
+  /** The account service answered a refusal: no account behind the bearer, or a spent allowance. */
+  REFUSED: "refused",
+  /** No usable answer: a network fault, a 5xx, or a body the wire schema could not read. */
+  UNAVAILABLE: "unavailable",
+} as const;
+
+type AuthorizeResult =
+  | { outcome: typeof AUTHORIZE_OUTCOME.AUTHORIZED; userId: string; quota: HostedQuota }
+  | { outcome: typeof AUTHORIZE_OUTCOME.REFUSED; reason: HostedApiError; status: number }
+  | { outcome: typeof AUTHORIZE_OUTCOME.UNAVAILABLE; status: number | undefined };
+
+/** The wire's two records, and the one more this side adds: a report the account service did not take. */
+export const USAGE_REPORT_OUTCOME = {
+  ...VOICE_USAGE_RECORD,
+  /** The seconds stand only in this service's log. */
+  FAILED: "failed",
+} as const;
+
+type UsageReportOutcome = (typeof USAGE_REPORT_OUTCOME)[keyof typeof USAGE_REPORT_OUTCOME];
+
+interface UsageReportResult {
+  outcome: UsageReportOutcome;
+  /** The account service's status, or nothing when the call never reached it. */
+  status: number | undefined;
+}
+
+export interface AccountServiceOptions {
+  webOrigin: string;
+  serviceSecret: string;
+  fetch?: CloudFetch;
+  requestTimeoutMs?: number;
+}
+
+export interface AccountService {
+  authorize(bearer: string): Promise<AuthorizeResult>;
+  recordUsage(report: VoiceUsageRequest): Promise<UsageReportResult>;
+}
+
+const REFUSAL_BY_STATUS = {
+  [HTTP_STATUS.UNAUTHORIZED]: HOSTED_API_ERROR.INVALID_TOKEN,
+  [HTTP_STATUS.TOO_MANY_REQUESTS]: HOSTED_API_ERROR.QUOTA_EXHAUSTED,
+} as const;
+
+function isRefusalStatus(status: number): status is keyof typeof REFUSAL_BY_STATUS {
+  return status === HTTP_STATUS.UNAUTHORIZED || status === HTTP_STATUS.TOO_MANY_REQUESTS;
+}
+
+export function createAccountService(options: AccountServiceOptions): AccountService {
+  const call = createAccountCall({
+    baseUrl: options.webOrigin,
+    credential: NO_CREDENTIAL,
+    fetch: options.fetch,
+    requestTimeoutMs: options.requestTimeoutMs,
+  });
+  const headers = { [VOICE_SERVICE_SECRET_HEADER]: options.serviceSecret };
+
+  return {
+    async authorize(bearer) {
+      const body: VoiceAuthorizeRequest = { bearer };
+      const answer = await call.send({
+        method: HTTP_METHOD.POST,
+        path: HOSTED_SERVICE_PATH.VOICE_AUTHORIZE,
+        body: JSON.stringify(body),
+        headers,
+      });
+      if (!callAnswered(answer)) {
+        return { outcome: AUTHORIZE_OUTCOME.UNAVAILABLE, status: undefined };
+      }
+      const { status } = answer.response;
+      const payload = await answer.response.json().catch(() => undefined);
+      if (answer.response.ok) {
+        const authorized = voiceAuthorizeAnswerSchema.parse(payload);
+        return authorized
+          ? { outcome: AUTHORIZE_OUTCOME.AUTHORIZED, ...authorized }
+          : { outcome: AUTHORIZE_OUTCOME.UNAVAILABLE, status };
+      }
+      if (isRefusalStatus(status)) {
+        return {
+          outcome: AUTHORIZE_OUTCOME.REFUSED,
+          reason: hostedErrorSchema.parse(payload) ?? REFUSAL_BY_STATUS[status],
+          status,
+        };
+      }
+      return { outcome: AUTHORIZE_OUTCOME.UNAVAILABLE, status };
+    },
+
+    async recordUsage(report) {
+      const answer = await call.send({
+        method: HTTP_METHOD.POST,
+        path: HOSTED_SERVICE_PATH.VOICE_USAGE,
+        body: JSON.stringify(report),
+        headers,
+      });
+      if (!callAnswered(answer)) return { outcome: USAGE_REPORT_OUTCOME.FAILED, status: undefined };
+      const { status } = answer.response;
+      if (!answer.response.ok) return { outcome: USAGE_REPORT_OUTCOME.FAILED, status };
+      const recorded = voiceUsageAnswerSchema.parse(
+        await answer.response.json().catch(() => undefined),
+      );
+      return { outcome: recorded?.record ?? USAGE_REPORT_OUTCOME.FAILED, status };
+    },
+  };
+}

--- a/apps/voice-service/src/environment.test.ts
+++ b/apps/voice-service/src/environment.test.ts
@@ -1,0 +1,52 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { LISTEN_DEFAULTS, readConfiguration, VOICE_SERVICE_ENVIRONMENT } from "./environment.js";
+
+const COMPLETE = {
+  [VOICE_SERVICE_ENVIRONMENT.OPENAI_API_KEY]: "sk-test",
+  [VOICE_SERVICE_ENVIRONMENT.WEB_ORIGIN]: "https://tryluke.dev",
+  [VOICE_SERVICE_ENVIRONMENT.SERVICE_SECRET]: "secret",
+};
+
+test("a complete environment reads to a configuration with the listen defaults", () => {
+  const read = readConfiguration(COMPLETE);
+  assert.ok(read.ok);
+  assert.deepEqual(read.configuration, {
+    apiKey: "sk-test",
+    model: undefined,
+    webOrigin: "https://tryluke.dev",
+    serviceSecret: "secret",
+    port: LISTEN_DEFAULTS.PORT,
+    host: LISTEN_DEFAULTS.HOST,
+  });
+});
+
+test("the model, port, and host are taken when set", () => {
+  const read = readConfiguration({
+    ...COMPLETE,
+    [VOICE_SERVICE_ENVIRONMENT.LIVE_MODEL]: "gpt-live-1",
+    [VOICE_SERVICE_ENVIRONMENT.PORT]: "9000",
+    [VOICE_SERVICE_ENVIRONMENT.HOST]: "127.0.0.1",
+  });
+  assert.ok(read.ok);
+  assert.equal(read.configuration.model, "gpt-live-1");
+  assert.equal(read.configuration.port, 9000);
+  assert.equal(read.configuration.host, "127.0.0.1");
+});
+
+test("a missing or blank required value names every variable the launch lacks", () => {
+  const read = readConfiguration({
+    [VOICE_SERVICE_ENVIRONMENT.OPENAI_API_KEY]: "  ",
+    [VOICE_SERVICE_ENVIRONMENT.WEB_ORIGIN]: "https://tryluke.dev",
+  });
+  assert.deepEqual(read, {
+    ok: false,
+    missing: [VOICE_SERVICE_ENVIRONMENT.OPENAI_API_KEY, VOICE_SERVICE_ENVIRONMENT.SERVICE_SECRET],
+  });
+});
+
+test("a port that is not a positive integer falls back to the default", () => {
+  const read = readConfiguration({ ...COMPLETE, [VOICE_SERVICE_ENVIRONMENT.PORT]: "eighty" });
+  assert.ok(read.ok);
+  assert.equal(read.configuration.port, LISTEN_DEFAULTS.PORT);
+});

--- a/apps/voice-service/src/environment.ts
+++ b/apps/voice-service/src/environment.ts
@@ -1,0 +1,74 @@
+import { text } from "@sidecar/wire";
+
+/**
+ * Everything the service is told by its deployment, and nothing it reads for
+ * itself. Four values make the service what it is: the GPT Live project key
+ * it creates and attaches sessions with, the model a deployment may pin, the
+ * account service's origin, and the secret the two internal routes there
+ * accept. A blank value is absent, the same reading every hosted secret
+ * gets, so a deployment that sets a key to nothing has switched the service
+ * off rather than handed it an empty credential.
+ */
+export const VOICE_SERVICE_ENVIRONMENT = {
+  OPENAI_API_KEY: "OPENAI_API_KEY",
+  /** A deployment-pinned model; `LIVE_DEFAULTS.MODEL` otherwise. */
+  LIVE_MODEL: "LUKE_LIVE_MODEL",
+  /** The account service's origin, where `VOICE_AUTHORIZE` and `VOICE_USAGE` answer. */
+  WEB_ORIGIN: "WEB_ORIGIN",
+  /** The shared secret both deployments hold, sent in `VOICE_SERVICE_SECRET_HEADER`. */
+  SERVICE_SECRET: "VOICE_SERVICE_SECRET",
+  PORT: "PORT",
+  HOST: "HOST",
+} as const;
+
+type VoiceServiceVariable =
+  (typeof VOICE_SERVICE_ENVIRONMENT)[keyof typeof VOICE_SERVICE_ENVIRONMENT];
+
+export const LISTEN_DEFAULTS = {
+  PORT: 8080,
+  /** Every interface: the service runs in a container behind the platform's own proxy. */
+  HOST: "0.0.0.0",
+} as const;
+
+interface VoiceServiceConfiguration {
+  apiKey: string;
+  model: string | undefined;
+  webOrigin: string;
+  serviceSecret: string;
+  port: number;
+  host: string;
+}
+
+export type ConfigurationRead =
+  | { ok: true; configuration: VoiceServiceConfiguration }
+  | { ok: false; missing: readonly VoiceServiceVariable[] };
+
+const REQUIRED: readonly VoiceServiceVariable[] = [
+  VOICE_SERVICE_ENVIRONMENT.OPENAI_API_KEY,
+  VOICE_SERVICE_ENVIRONMENT.WEB_ORIGIN,
+  VOICE_SERVICE_ENVIRONMENT.SERVICE_SECRET,
+];
+
+/** Reads the environment once at launch; a launch missing a required value names every one it lacks. */
+export function readConfiguration(environment: NodeJS.ProcessEnv): ConfigurationRead {
+  const read = (name: VoiceServiceVariable) => text(environment[name]);
+  const missing = REQUIRED.filter((name) => read(name) === undefined);
+  const apiKey = read(VOICE_SERVICE_ENVIRONMENT.OPENAI_API_KEY);
+  const webOrigin = read(VOICE_SERVICE_ENVIRONMENT.WEB_ORIGIN);
+  const serviceSecret = read(VOICE_SERVICE_ENVIRONMENT.SERVICE_SECRET);
+  if (apiKey === undefined || webOrigin === undefined || serviceSecret === undefined) {
+    return { ok: false, missing };
+  }
+  const port = Number(read(VOICE_SERVICE_ENVIRONMENT.PORT));
+  return {
+    ok: true,
+    configuration: {
+      apiKey,
+      model: read(VOICE_SERVICE_ENVIRONMENT.LIVE_MODEL),
+      webOrigin,
+      serviceSecret,
+      port: Number.isInteger(port) && port > 0 ? port : LISTEN_DEFAULTS.PORT,
+      host: read(VOICE_SERVICE_ENVIRONMENT.HOST) ?? LISTEN_DEFAULTS.HOST,
+    },
+  };
+}

--- a/apps/voice-service/src/frames.test.ts
+++ b/apps/voice-service/src/frames.test.ts
@@ -1,0 +1,100 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { VOICE_SERVICE_PATH } from "@sidecar/hosted";
+import {
+  LIVE_CLIENT_EVENT,
+  LIVE_SERVER_EVENT,
+  RENDERER_CLIENT_EVENTS,
+  RENDERER_SERVER_EVENTS,
+} from "@sidecar/live";
+import {
+  desktopFrameDecision,
+  FRAME_DECISION,
+  frameText,
+  frameType,
+  routeForPath,
+  upstreamFrameDecision,
+  VOICE_ROUTE,
+} from "./frames.js";
+
+test("the two upgrade paths map to the two routes and nothing else does", () => {
+  assert.equal(routeForPath(VOICE_SERVICE_PATH.SESSIONS), VOICE_ROUTE.SESSIONS);
+  assert.equal(routeForPath(VOICE_SERVICE_PATH.INTRODUCTION), VOICE_ROUTE.INTRODUCTION);
+  assert.equal(routeForPath(`${VOICE_SERVICE_PATH.SESSIONS}/`), undefined);
+  assert.equal(routeForPath("/"), undefined);
+});
+
+test("a frame's type is read from its JSON record alone", () => {
+  assert.equal(frameType(JSON.stringify({ type: LIVE_SERVER_EVENT.INFO })), LIVE_SERVER_EVENT.INFO);
+  assert.equal(frameType(JSON.stringify({ type: 4 })), undefined);
+  assert.equal(frameType(JSON.stringify([1, 2])), undefined);
+  assert.equal(frameType("not json"), undefined);
+  assert.equal(frameType(undefined), undefined);
+});
+
+test("a binary frame reads as nothing and a text frame as its text", () => {
+  assert.equal(frameText(Buffer.from("{}"), true), undefined);
+  assert.equal(frameText(Buffer.from("{}"), false), "{}");
+  assert.equal(frameText([Buffer.from("{"), Buffer.from("}")], false), "{}");
+  assert.equal(frameText(new Uint8Array([123, 125]).buffer, false), "{}");
+});
+
+test("reflected audio is dropped by type toward the desktop on both routes", () => {
+  for (const route of Object.values(VOICE_ROUTE)) {
+    assert.equal(
+      upstreamFrameDecision(LIVE_SERVER_EVENT.INPUT_AUDIO_APPEND, route),
+      FRAME_DECISION.DROP_AUDIO,
+    );
+    assert.equal(
+      upstreamFrameDecision(LIVE_SERVER_EVENT.OUTPUT_AUDIO_DELTA, route),
+      FRAME_DECISION.DROP_AUDIO,
+    );
+  }
+});
+
+test("a signed-in session forwards every other frame in both directions, unread ones included", () => {
+  assert.equal(
+    upstreamFrameDecision(LIVE_SERVER_EVENT.DELEGATION_CREATED, VOICE_ROUTE.SESSIONS),
+    FRAME_DECISION.FORWARD,
+  );
+  assert.equal(upstreamFrameDecision(undefined, VOICE_ROUTE.SESSIONS), FRAME_DECISION.FORWARD);
+  assert.equal(
+    desktopFrameDecision(LIVE_CLIENT_EVENT.COMMENTARY_APPEND, VOICE_ROUTE.SESSIONS),
+    FRAME_DECISION.FORWARD,
+  );
+  assert.equal(desktopFrameDecision(undefined, VOICE_ROUTE.SESSIONS), FRAME_DECISION.FORWARD);
+});
+
+test("the introduction is shown exactly the renderer's server events and may send exactly its client events", () => {
+  for (const selector of RENDERER_SERVER_EVENTS) {
+    assert.equal(
+      upstreamFrameDecision(selector.type, VOICE_ROUTE.INTRODUCTION),
+      FRAME_DECISION.FORWARD,
+    );
+  }
+  for (const type of [
+    LIVE_SERVER_EVENT.DELEGATION_CREATED,
+    LIVE_SERVER_EVENT.COMMENTARY_APPENDED,
+    LIVE_SERVER_EVENT.INSTRUCTIONS_APPENDED,
+    undefined,
+  ]) {
+    assert.equal(
+      upstreamFrameDecision(type, VOICE_ROUTE.INTRODUCTION),
+      FRAME_DECISION.DROP_UNPERMITTED,
+    );
+  }
+  for (const type of RENDERER_CLIENT_EVENTS) {
+    assert.equal(desktopFrameDecision(type, VOICE_ROUTE.INTRODUCTION), FRAME_DECISION.FORWARD);
+  }
+  for (const type of [
+    LIVE_CLIENT_EVENT.COMMENTARY_APPEND,
+    LIVE_CLIENT_EVENT.INSTRUCTIONS_APPEND,
+    LIVE_CLIENT_EVENT.THINKING_APPEND,
+    undefined,
+  ]) {
+    assert.equal(
+      desktopFrameDecision(type, VOICE_ROUTE.INTRODUCTION),
+      FRAME_DECISION.DROP_UNPERMITTED,
+    );
+  }
+});

--- a/apps/voice-service/src/frames.ts
+++ b/apps/voice-service/src/frames.ts
@@ -1,0 +1,97 @@
+import { VOICE_SERVICE_PATH } from "@sidecar/hosted";
+import {
+  decodeLivePayload,
+  LIVE_SERVER_EVENT,
+  RENDERER_CLIENT_EVENTS,
+  RENDERER_SERVER_EVENTS,
+} from "@sidecar/live";
+import { isWireString, type UnparsedWireValue } from "@sidecar/wire";
+import type { RawData } from "ws";
+
+/**
+ * Which frames cross the service in which direction. The service is a pipe,
+ * and the whole of its judgment about a frame is its `type`: it reads that
+ * one field to decide, and forwards the bytes it received rather than a
+ * re-serialization of them, so nothing here can reword what either side said.
+ */
+
+/** The two upgrades the service answers, by the path each stands on. */
+export const VOICE_ROUTE = {
+  /** A signed-in desktop's session: the host's sideband at one remove, everything forwarded. */
+  SESSIONS: "sessions",
+  /** The accountless introduction: the service keeps the sideband, the caller sees captions. */
+  INTRODUCTION: "introduction",
+} as const;
+
+export type VoiceRoute = (typeof VOICE_ROUTE)[keyof typeof VOICE_ROUTE];
+
+export function routeForPath(path: string): VoiceRoute | undefined {
+  if (path === VOICE_SERVICE_PATH.SESSIONS) return VOICE_ROUTE.SESSIONS;
+  if (path === VOICE_SERVICE_PATH.INTRODUCTION) return VOICE_ROUTE.INTRODUCTION;
+  return undefined;
+}
+
+export const FRAME_DECISION = {
+  FORWARD: "forward",
+  /** Reflected audio: the developer's voice and Luke's never transit the service. */
+  DROP_AUDIO: "drop-audio",
+  /** A frame the route does not admit in this direction. */
+  DROP_UNPERMITTED: "drop-unpermitted",
+} as const;
+
+export type FrameDecision = (typeof FRAME_DECISION)[keyof typeof FRAME_DECISION];
+
+const REFLECTED_AUDIO: readonly string[] = [
+  LIVE_SERVER_EVENT.INPUT_AUDIO_APPEND,
+  LIVE_SERVER_EVENT.OUTPUT_AUDIO_DELTA,
+];
+
+const INTRODUCTION_SERVER_EVENTS: readonly string[] = RENDERER_SERVER_EVENTS.map(
+  (selector) => selector.type,
+);
+
+const INTRODUCTION_CLIENT_EVENTS: readonly string[] = RENDERER_CLIENT_EVENTS;
+
+/** The text of one socket frame; a binary frame is not a Live event and reads as nothing. */
+export function frameText(data: RawData, isBinary: boolean): string | undefined {
+  if (isBinary) return undefined;
+  if (Buffer.isBuffer(data)) return data.toString("utf8");
+  if (Array.isArray(data)) return Buffer.concat(data).toString("utf8");
+  return Buffer.from(data).toString("utf8");
+}
+
+/** The `type` of one frame, or nothing when the frame is not a JSON record naming one. */
+export function frameType(text: UnparsedWireValue): string | undefined {
+  const payload = decodeLivePayload(text);
+  if (payload === undefined) return undefined;
+  const type = payload.type;
+  return isWireString(type) ? type : undefined;
+}
+
+/**
+ * What to do with a frame OpenAI sent toward the desktop. Reflected audio
+ * is dropped on every route. The introduction's caller is shown only what
+ * a renderer's own data channel would be shown, since it holds no account
+ * and the sideband is the service's, not its own.
+ */
+export function upstreamFrameDecision(type: string | undefined, route: VoiceRoute): FrameDecision {
+  if (type !== undefined && REFLECTED_AUDIO.includes(type)) return FRAME_DECISION.DROP_AUDIO;
+  if (route === VOICE_ROUTE.SESSIONS) return FRAME_DECISION.FORWARD;
+  return type !== undefined && INTRODUCTION_SERVER_EVENTS.includes(type)
+    ? FRAME_DECISION.FORWARD
+    : FRAME_DECISION.DROP_UNPERMITTED;
+}
+
+/**
+ * What to do with a frame the desktop sent toward OpenAI. A signed-in
+ * desktop's frames are the host's own sideband commands and pass untouched;
+ * an introduction caller may send only what a renderer's data channel may,
+ * the microphone switch and the hang-up, so nothing it says can append to a
+ * session running on Luke's key.
+ */
+export function desktopFrameDecision(type: string | undefined, route: VoiceRoute): FrameDecision {
+  if (route === VOICE_ROUTE.SESSIONS) return FRAME_DECISION.FORWARD;
+  return type !== undefined && INTRODUCTION_CLIENT_EVENTS.includes(type)
+    ? FRAME_DECISION.FORWARD
+    : FRAME_DECISION.DROP_UNPERMITTED;
+}

--- a/apps/voice-service/src/introduction-meter.test.ts
+++ b/apps/voice-service/src/introduction-meter.test.ts
@@ -1,0 +1,33 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { INTRODUCTION_METER_LIMITS, IntroductionMeter } from "./introduction-meter.js";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+test("a caller is admitted up to the per-caller limit and refused past it", () => {
+  const meter = new IntroductionMeter({ now: () => 0 });
+  for (let attempt = 0; attempt < INTRODUCTION_METER_LIMITS.PER_CALLER; attempt += 1) {
+    assert.equal(meter.spend("198.51.100.1").allowed, true);
+  }
+  assert.equal(meter.spend("198.51.100.1").allowed, false);
+  assert.equal(meter.spend("198.51.100.2").allowed, true);
+});
+
+test("the day's counts reset at the UTC day boundary", () => {
+  let now = Date.parse("2026-09-10T23:59:59.000Z");
+  const meter = new IntroductionMeter({ now: () => now });
+  for (let attempt = 0; attempt <= INTRODUCTION_METER_LIMITS.PER_CALLER; attempt += 1) {
+    meter.spend("198.51.100.1");
+  }
+  assert.equal(meter.spend("198.51.100.1").allowed, false);
+  now += 2_000;
+  assert.equal(meter.spend("198.51.100.1").allowed, true);
+});
+
+test("the shared ceiling refuses everyone once the day is spent", () => {
+  const meter = new IntroductionMeter({ now: () => DAY_MS });
+  for (let attempt = 0; attempt < INTRODUCTION_METER_LIMITS.GLOBAL; attempt += 1) {
+    meter.spend(`caller-${attempt}`);
+  }
+  assert.equal(meter.spend("fresh-caller").allowed, false);
+});

--- a/apps/voice-service/src/introduction-meter.ts
+++ b/apps/voice-service/src/introduction-meter.ts
@@ -1,0 +1,62 @@
+import { createHash, randomBytes } from "node:crypto";
+
+/**
+ * The introduction's own ceiling, kept by the service because no account
+ * stands behind an introduction to meter it on. Two counts a day: one per
+ * caller and one shared, the same two the introduction mint kept. The caller
+ * is known only as a hash of its network address under a salt minted at
+ * launch, so the meter can tell a repeat caller from a new one for one day
+ * and nothing on this machine can name either; a restart forgets everything.
+ */
+export const INTRODUCTION_METER_LIMITS = {
+  /** Introductions one address may open in a UTC day; a fresh install needs one. */
+  PER_CALLER: 8,
+  /** Introductions every caller together may open in a UTC day. */
+  GLOBAL: 500,
+} as const;
+
+export interface IntroductionSpend {
+  allowed: boolean;
+}
+
+interface DayCounts {
+  day: string;
+  global: number;
+  callers: Map<string, number>;
+}
+
+function utcDayKey(now: number): string {
+  return new Date(now).toISOString().slice(0, 10);
+}
+
+export class IntroductionMeter {
+  readonly #salt = randomBytes(16).toString("hex");
+  readonly #now: () => number;
+  #counts: DayCounts | undefined;
+
+  constructor(options: { now?: () => number } = {}) {
+    this.#now = options.now ?? Date.now;
+  }
+
+  /** Spends one introduction for the address; a refused attempt still counts, as the mint's did. */
+  spend(address: string): IntroductionSpend {
+    const counts = this.#today();
+    const caller = createHash("sha256").update(this.#salt).update(address).digest("hex");
+    const used = (counts.callers.get(caller) ?? 0) + 1;
+    counts.callers.set(caller, used);
+    counts.global += 1;
+    return {
+      allowed:
+        used <= INTRODUCTION_METER_LIMITS.PER_CALLER &&
+        counts.global <= INTRODUCTION_METER_LIMITS.GLOBAL,
+    };
+  }
+
+  #today(): DayCounts {
+    const day = utcDayKey(this.#now());
+    if (this.#counts?.day !== day) {
+      this.#counts = { day, global: 0, callers: new Map() };
+    }
+    return this.#counts;
+  }
+}

--- a/apps/voice-service/src/log.ts
+++ b/apps/voice-service/src/log.ts
@@ -1,0 +1,66 @@
+import type { HostedApiError } from "@sidecar/hosted";
+import type { VoiceRoute } from "./frames.js";
+
+/**
+ * What the service writes down about itself: status codes, close codes,
+ * outcome names, and counts. No line carries a session id, a bearer, an SDP,
+ * a transcript fragment, or any frame's content, so a log this service kept
+ * for a year would still say nothing about anyone's conversation.
+ */
+export const LOG_EVENT = {
+  LISTENING: "listening",
+  /** A handshake refused before any socket stood: the HTTP status says why. */
+  UPGRADE_REFUSED: "upgrade-refused",
+  /** A socket refused after standing: the reason frame the desktop was sent says why. */
+  SESSION_REFUSED: "session-refused",
+  SESSION_CREATED: "session-created",
+  GREETING_SENT: "greeting-sent",
+  USAGE_REPORTED: "usage-reported",
+  SESSION_ENDED: "session-ended",
+} as const;
+
+/** Whether `session.closed` was seen before the transports went, as the docs define finalization. */
+export const FINALIZATION = {
+  CONFIRMED: "confirmed",
+  UNCONFIRMED: "unconfirmed",
+} as const;
+
+export type Finalization = (typeof FINALIZATION)[keyof typeof FINALIZATION];
+
+export interface RelayCounts {
+  framesToUpstream: number;
+  bytesToUpstream: number;
+  framesToDesktop: number;
+  bytesToDesktop: number;
+  /** Reflected audio frames dropped by type, never forwarded. */
+  droppedAudio: number;
+  /** Frames a route does not permit in that direction, dropped by type. */
+  droppedUnpermitted: number;
+}
+
+export type LogEntry =
+  | { event: typeof LOG_EVENT.LISTENING; host: string; port: number }
+  | { event: typeof LOG_EVENT.UPGRADE_REFUSED; route: string; status: number }
+  | { event: typeof LOG_EVENT.SESSION_REFUSED; route: VoiceRoute; reason: HostedApiError }
+  | { event: typeof LOG_EVENT.SESSION_CREATED; route: VoiceRoute }
+  | { event: typeof LOG_EVENT.GREETING_SENT; route: VoiceRoute }
+  | {
+      event: typeof LOG_EVENT.USAGE_REPORTED;
+      route: VoiceRoute;
+      seconds: number;
+      /** The account service's status, or nothing when the report never reached it. */
+      status: number | undefined;
+    }
+  | ({
+      event: typeof LOG_EVENT.SESSION_ENDED;
+      route: VoiceRoute;
+      finalization: Finalization;
+      seconds: number | undefined;
+    } & RelayCounts);
+
+export type Log = (entry: LogEntry) => void;
+
+/** One JSON line per entry on standard output, which is what a container platform collects. */
+export const standardOutputLog: Log = (entry) => {
+  process.stdout.write(`${JSON.stringify(entry)}\n`);
+};

--- a/apps/voice-service/src/main.ts
+++ b/apps/voice-service/src/main.ts
@@ -1,0 +1,31 @@
+import { readConfiguration } from "./environment.js";
+import { VoiceService } from "./service.js";
+
+/**
+ * The container's entry: read the deployment's environment, listen, and
+ * leave gracefully on the platform's stop signal so every session under way
+ * gets its `session.close` and its seconds recorded before the process ends.
+ */
+
+const read = readConfiguration(process.env);
+if (!read.ok) {
+  process.stderr.write(`voice-service: missing ${read.missing.join(", ")}\n`);
+  process.exit(1);
+}
+
+const { configuration } = read;
+const service = new VoiceService({
+  apiKey: configuration.apiKey,
+  model: configuration.model,
+  webOrigin: configuration.webOrigin,
+  serviceSecret: configuration.serviceSecret,
+});
+
+await service.listen(configuration.port, configuration.host);
+
+const STOP_SIGNALS: readonly NodeJS.Signals[] = ["SIGTERM", "SIGINT"];
+for (const signal of STOP_SIGNALS) {
+  process.once(signal, () => {
+    void service.close().then(() => process.exit(0));
+  });
+}

--- a/apps/voice-service/src/openai.ts
+++ b/apps/voice-service/src/openai.ts
@@ -1,0 +1,117 @@
+import { callAnswered, createAccountCall, fixedBearer } from "@sidecar/hosted";
+import {
+  LIVE_SESSION_OUTCOME,
+  LIVE_SESSIONS_PATH,
+  type LiveCreateAnswer,
+  type LiveSessionConfig,
+  liveAttachPath,
+  liveCreateAnswerSchema,
+  liveCreateRequest,
+} from "@sidecar/live";
+import { type CloudFetch, HTTP_METHOD, withoutTrailingSlash } from "@sidecar/wire";
+import { WebSocket } from "ws";
+
+/**
+ * How the service reaches OpenAI on Luke's project key: the one POST that
+ * creates a WebRTC session from the desktop's offer, and the one socket that
+ * attaches this service's sideband to it. The key travels as the bearer on
+ * both and nowhere else; a failure is answered as an outcome name and a
+ * status, never as an error whose words could carry the key.
+ */
+
+const OPENAI_DEFAULTS = {
+  BASE_URL: "https://api.openai.com/v1",
+  CREATE_TIMEOUT_MS: 15_000,
+  ATTACH_TIMEOUT_MS: 15_000,
+} as const;
+
+type LiveCreateResult =
+  | { outcome: typeof LIVE_SESSION_OUTCOME.SUCCEEDED; answer: LiveCreateAnswer }
+  | { outcome: typeof LIVE_SESSION_OUTCOME.HTTP_ERROR; status: number }
+  | { outcome: typeof LIVE_SESSION_OUTCOME.NETWORK_ERROR; errorName: string | undefined }
+  | { outcome: typeof LIVE_SESSION_OUTCOME.MALFORMED_RESPONSE };
+
+export interface LiveUpstreamOptions {
+  apiKey: string;
+  /** The API's `/v1` base; a test points it at a fake. The attach socket derives from the same base. */
+  baseUrl?: string;
+  fetch?: CloudFetch;
+  createTimeoutMs?: number;
+  attachTimeoutMs?: number;
+}
+
+export interface LiveUpstream {
+  create(config: LiveSessionConfig, sdpOffer: string): Promise<LiveCreateResult>;
+  /** Resolves once the sideband is open, or rejects when it could not attach within the timeout. */
+  attach(sessionId: string): Promise<WebSocket>;
+}
+
+const WS_PROTOCOL = { SECURE: "wss:", PLAIN: "ws:", PLAIN_HTTP: "http:" } as const;
+
+/** The `wss` address of a session's attach path under the same base the session was created at. */
+function attachAddress(baseUrl: string, sessionId: string): string {
+  const url = new URL(`${withoutTrailingSlash(baseUrl)}${liveAttachPath(sessionId)}`);
+  url.protocol = url.protocol === WS_PROTOCOL.PLAIN_HTTP ? WS_PROTOCOL.PLAIN : WS_PROTOCOL.SECURE;
+  return url.toString();
+}
+
+export function createLiveUpstream(options: LiveUpstreamOptions): LiveUpstream {
+  const baseUrl = options.baseUrl ?? OPENAI_DEFAULTS.BASE_URL;
+  const credential = fixedBearer(options.apiKey);
+  const call = createAccountCall({
+    baseUrl,
+    credential,
+    fetch: options.fetch,
+    requestTimeoutMs: options.createTimeoutMs ?? OPENAI_DEFAULTS.CREATE_TIMEOUT_MS,
+  });
+  const attachTimeoutMs = options.attachTimeoutMs ?? OPENAI_DEFAULTS.ATTACH_TIMEOUT_MS;
+
+  return {
+    async create(config, sdpOffer) {
+      const answer = await call.send({
+        method: HTTP_METHOD.POST,
+        path: LIVE_SESSIONS_PATH,
+        body: JSON.stringify(liveCreateRequest(config, sdpOffer)),
+      });
+      if (!callAnswered(answer)) {
+        return { outcome: LIVE_SESSION_OUTCOME.NETWORK_ERROR, errorName: answer.errorName };
+      }
+      if (!answer.response.ok) {
+        return { outcome: LIVE_SESSION_OUTCOME.HTTP_ERROR, status: answer.response.status };
+      }
+      const created = liveCreateAnswerSchema.parse(
+        await answer.response.json().catch(() => undefined),
+      );
+      return created
+        ? { outcome: LIVE_SESSION_OUTCOME.SUCCEEDED, answer: created }
+        : { outcome: LIVE_SESSION_OUTCOME.MALFORMED_RESPONSE };
+    },
+
+    async attach(sessionId) {
+      const authorization = await credential.authorization?.();
+      const socket = new WebSocket(attachAddress(baseUrl, sessionId), {
+        headers: authorization === undefined ? {} : { authorization },
+        followRedirects: false,
+      });
+      return new Promise<WebSocket>((resolve, reject) => {
+        const timer = setTimeout(() => {
+          socket.terminate();
+          reject(new Error("The sideband did not attach within its timeout"));
+        }, attachTimeoutMs);
+        socket.once("open", () => {
+          clearTimeout(timer);
+          resolve(socket);
+        });
+        socket.once("error", (error) => {
+          clearTimeout(timer);
+          reject(error);
+        });
+        socket.once("unexpected-response", (_request, response) => {
+          clearTimeout(timer);
+          socket.terminate();
+          reject(new Error(`The attach handshake was refused with status ${response.statusCode}`));
+        });
+      });
+    },
+  };
+}

--- a/apps/voice-service/src/relay.ts
+++ b/apps/voice-service/src/relay.ts
@@ -1,0 +1,186 @@
+import { randomUUID } from "node:crypto";
+import {
+  closeEvent,
+  LIVE_SERVER_EVENT,
+  type LiveClientEvent,
+  parseLiveServerEvent,
+} from "@sidecar/live";
+import type { RawData, WebSocket } from "ws";
+import {
+  desktopFrameDecision,
+  FRAME_DECISION,
+  frameText,
+  frameType,
+  upstreamFrameDecision,
+  type VoiceRoute,
+} from "./frames.js";
+import { FINALIZATION, type Finalization, type RelayCounts } from "./log.js";
+
+/**
+ * The pipe between one desktop socket and one OpenAI sideband, once both
+ * stand. Frames cross as the bytes they arrived as; the service reads each
+ * frame's `type` and nothing else of it, drops reflected audio by that type
+ * on every route, and on the introduction route admits only what a
+ * renderer's own data channel would carry. It ends the way the docs say a
+ * session ends: `session.closed` is the finalization, reported once with the
+ * seconds it named; a desktop that goes first has `session.close` sent on
+ * its behalf and the sideband held open for the final event under a
+ * timeout; a sideband that goes first leaves the usage unconfirmed and takes
+ * the desktop socket with it.
+ */
+
+export const RELAY_DEFAULTS = {
+  /** How long the sideband is held for `session.closed` after `session.close` was sent, the docs' 15 seconds. */
+  CLOSE_TIMEOUT_MS: 15_000,
+} as const;
+
+/** The WebSocket close codes this service sends, by what each one says. */
+export const SOCKET_CLOSE_CODE = {
+  NORMAL: 1000,
+  /** The service itself is leaving, or the upstream left first. */
+  GOING_AWAY: 1001,
+  /** The peer sent something this route does not admit, or was refused. */
+  POLICY_VIOLATION: 1008,
+} as const;
+
+/** The reason a desktop socket is closed with when OpenAI's side ended before `session.closed`. */
+export const UPSTREAM_CLOSED_REASON = "upstream-closed";
+
+export interface RelayOptions {
+  route: VoiceRoute;
+  desktop: WebSocket;
+  upstream: WebSocket;
+  /** Runs once, on the first `session.closed`, with the seconds it named; the relay waits for it before settling. */
+  onSessionClosed?: (seconds: number) => Promise<void>;
+  /** Asked once, on the first `session.started`, for an event to send upstream from the service's own side. */
+  onSessionStarted?: () => LiveClientEvent | undefined;
+  closeTimeoutMs?: number;
+}
+
+export interface RelaySummary extends RelayCounts {
+  finalization: Finalization;
+  /** The seconds `session.closed` named, once it was seen. */
+  seconds: number | undefined;
+}
+
+function frameBytes(data: RawData): number {
+  if (Buffer.isBuffer(data)) return data.byteLength;
+  if (Array.isArray(data)) return data.reduce((total, part) => total + part.byteLength, 0);
+  return data.byteLength;
+}
+
+function isOpen(socket: WebSocket): boolean {
+  return socket.readyState === socket.OPEN;
+}
+
+/** Runs the pipe until the session is finalized or both transports are gone, and answers what it carried. */
+export function relaySession(options: RelayOptions): Promise<RelaySummary> {
+  const { route, desktop, upstream } = options;
+  const closeTimeoutMs = options.closeTimeoutMs ?? RELAY_DEFAULTS.CLOSE_TIMEOUT_MS;
+  const counts: RelayCounts = {
+    framesToUpstream: 0,
+    bytesToUpstream: 0,
+    framesToDesktop: 0,
+    bytesToDesktop: 0,
+    droppedAudio: 0,
+    droppedUnpermitted: 0,
+  };
+  let closedSeen = false;
+  let startedSeen = false;
+  let seconds: number | undefined;
+  let closeTimer: ReturnType<typeof setTimeout> | undefined;
+
+  return new Promise<RelaySummary>((resolve) => {
+    let settled = false;
+    const settle = (finalization: Finalization): void => {
+      if (settled) return;
+      settled = true;
+      if (closeTimer !== undefined) clearTimeout(closeTimer);
+      if (isOpen(desktop)) {
+        desktop.close(
+          finalization === FINALIZATION.CONFIRMED
+            ? SOCKET_CLOSE_CODE.NORMAL
+            : SOCKET_CLOSE_CODE.GOING_AWAY,
+          finalization === FINALIZATION.CONFIRMED ? undefined : UPSTREAM_CLOSED_REASON,
+        );
+      }
+      if (isOpen(upstream)) upstream.close(SOCKET_CLOSE_CODE.NORMAL);
+      resolve({ ...counts, finalization, seconds });
+    };
+
+    const finalize = async (): Promise<void> => {
+      if (seconds !== undefined && options.onSessionClosed) {
+        await options.onSessionClosed(seconds).catch(() => undefined);
+      }
+      settle(FINALIZATION.CONFIRMED);
+    };
+
+    const onUpstreamMessage = (data: RawData, isBinary: boolean): void => {
+      const text = frameText(data, isBinary);
+      const type = frameType(text);
+      const decision = upstreamFrameDecision(type, route);
+      if (decision === FRAME_DECISION.DROP_AUDIO) {
+        counts.droppedAudio += 1;
+      } else if (decision === FRAME_DECISION.DROP_UNPERMITTED) {
+        counts.droppedUnpermitted += 1;
+      } else if (isOpen(desktop)) {
+        desktop.send(data, { binary: isBinary });
+        counts.framesToDesktop += 1;
+        counts.bytesToDesktop += frameBytes(data);
+      }
+      if (type === LIVE_SERVER_EVENT.SESSION_STARTED && !startedSeen) {
+        startedSeen = true;
+        const opening = options.onSessionStarted?.();
+        if (opening !== undefined && isOpen(upstream)) upstream.send(JSON.stringify(opening));
+      }
+      if (type === LIVE_SERVER_EVENT.SESSION_CLOSED && !closedSeen) {
+        closedSeen = true;
+        const closed = parseLiveServerEvent(text);
+        if (closed?.type === LIVE_SERVER_EVENT.SESSION_CLOSED) seconds = closed.usage.seconds;
+        void finalize();
+      }
+    };
+
+    const onUpstreamGone = (): void => {
+      if (!closedSeen) settle(FINALIZATION.UNCONFIRMED);
+    };
+
+    const onDesktopMessage = (data: RawData, isBinary: boolean): void => {
+      const decision = desktopFrameDecision(frameType(frameText(data, isBinary)), route);
+      if (decision !== FRAME_DECISION.FORWARD) {
+        counts.droppedUnpermitted += 1;
+        return;
+      }
+      if (!isOpen(upstream)) return;
+      upstream.send(data, { binary: isBinary });
+      counts.framesToUpstream += 1;
+      counts.bytesToUpstream += frameBytes(data);
+    };
+
+    /**
+     * The desktop went first. The docs' graceful close on its behalf: the
+     * `session.closed` listener already stands, `session.close` goes up, and
+     * the sideband is held for the final event so the seconds are recorded,
+     * under the timeout after which finalization is reported incomplete.
+     */
+    const onDesktopGone = (): void => {
+      if (closedSeen || settled) return;
+      if (!isOpen(upstream)) {
+        settle(FINALIZATION.UNCONFIRMED);
+        return;
+      }
+      upstream.send(JSON.stringify(closeEvent(randomUUID())));
+      closeTimer = setTimeout(() => {
+        if (!closedSeen) settle(FINALIZATION.UNCONFIRMED);
+      }, closeTimeoutMs);
+    };
+
+    upstream.on("message", onUpstreamMessage);
+    upstream.on("close", onUpstreamGone);
+    upstream.on("error", onUpstreamGone);
+    desktop.on("message", onDesktopMessage);
+    desktop.on("close", onDesktopGone);
+    desktop.on("error", onDesktopGone);
+    if (!isOpen(desktop)) onDesktopGone();
+  });
+}

--- a/apps/voice-service/src/service.test.ts
+++ b/apps/voice-service/src/service.test.ts
@@ -537,7 +537,7 @@ test("an introduction seed beyond one bounded developer message is refused befor
 test("the introduction meter refuses a caller's ninth upgrade of the day with 429 and admits another caller", async (t) => {
   const context = await stand();
   t.after(() => context.stop());
-  const caller = { "x-forwarded-for": "203.0.113.7, 10.0.0.1" };
+  const caller = { "x-forwarded-for": "10.0.0.1, 203.0.113.7" };
 
   for (let attempt = 0; attempt < INTRODUCTION_METER_LIMITS.PER_CALLER; attempt += 1) {
     const opened = await connect(context.url(VOICE_SERVICE_PATH.INTRODUCTION), caller);
@@ -553,6 +553,44 @@ test("the introduction meter refuses a caller's ninth upgrade of the day with 42
   });
   assert.ok("reader" in other);
   other.reader.socket.close();
+});
+
+test("a caller cannot become another by writing an earlier X-Forwarded-For hop", async (t) => {
+  const context = await stand();
+  t.after(() => context.stop());
+
+  for (let attempt = 0; attempt < INTRODUCTION_METER_LIMITS.PER_CALLER; attempt += 1) {
+    const opened = await connect(context.url(VOICE_SERVICE_PATH.INTRODUCTION), {
+      "x-forwarded-for": `198.51.100.${attempt}, 203.0.113.7`,
+    });
+    assert.ok("reader" in opened);
+    opened.reader.socket.close();
+    await opened.reader.closed;
+  }
+  assert.deepEqual(
+    await connect(context.url(VOICE_SERVICE_PATH.INTRODUCTION), {
+      "x-forwarded-for": "198.51.100.99, 203.0.113.7",
+    }),
+    { status: UPGRADE_STATUS.TOO_MANY_REQUESTS },
+  );
+});
+
+test("an upgrade carrying a browser Origin is refused with 403 on both routes", async (t) => {
+  const context = await stand();
+  t.after(() => context.stop());
+
+  assert.deepEqual(
+    await connect(context.url(VOICE_SERVICE_PATH.INTRODUCTION), { origin: "https://evil.test" }),
+    { status: UPGRADE_STATUS.FORBIDDEN },
+  );
+  assert.deepEqual(
+    await connect(context.url(VOICE_SERVICE_PATH.SESSIONS), {
+      authorization: BEARER,
+      origin: "https://evil.test",
+    }),
+    { status: UPGRADE_STATUS.FORBIDDEN },
+  );
+  assert.equal(context.accounts.authorizeCalls.length, 0);
 });
 
 test("closing the service closes every desktop socket and refuses new upgrades with 503", async (t) => {

--- a/apps/voice-service/src/service.test.ts
+++ b/apps/voice-service/src/service.test.ts
@@ -1,0 +1,570 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  HOSTED_API_ERROR,
+  hostedErrorSchema,
+  sessionCreatedFrameSchema,
+  VOICE_SERVICE_FRAME,
+  VOICE_SERVICE_PATH,
+} from "@sidecar/hosted";
+import {
+  greetingInstruction,
+  LIVE_CLIENT_EVENT,
+  LIVE_CLOSE_REASON,
+  LIVE_DELEGATION_TARGET,
+  LIVE_SCENE,
+  LIVE_SERVER_EVENT,
+  LIVE_TRANSPORT_TYPE,
+  LIVE_VOICE,
+  RENDERER_CLIENT_EVENTS,
+  RENDERER_SERVER_EVENTS,
+  SEED_CONTENT_TYPE,
+  SEED_ITEM_TYPE,
+  SEED_ROLE,
+  sessionInstructions,
+} from "@sidecar/live";
+import { isRecord, isWireString, unparsedWire, type WireRecord } from "@sidecar/wire";
+import { INTRODUCTION_METER_LIMITS } from "./introduction-meter.js";
+import type { LogEntry } from "./log.js";
+import { SOCKET_CLOSE_CODE, UPSTREAM_CLOSED_REASON } from "./relay.js";
+import { INTRODUCTION_INPUT_BOUNDS, UPGRADE_STATUS, VoiceService } from "./service.js";
+import {
+  connect,
+  FAKE_QUOTA,
+  FAKE_SDP_ANSWER,
+  FAKE_USER_ID,
+  type FakeAccountService,
+  type FakeOpenAi,
+  readSocket,
+  send,
+  sendText,
+  startFakeAccountService,
+  startFakeOpenAi,
+} from "./testing/fakes.js";
+
+const API_KEY = "sk-test-project-key";
+const SERVICE_SECRET = "shared-service-secret";
+const BEARER = "Bearer account-token-1";
+const SDP_OFFER =
+  "v=0\r\no=- 1 1 IN IP4 127.0.0.1\r\ns=-\r\nt=0 0\r\nm=audio 9 UDP/TLS/RTP/SAVPF 111\r\n";
+const CLOSE_TIMEOUT_MS = 300;
+
+const developerMessage = (text: string) => ({
+  type: SEED_ITEM_TYPE,
+  role: SEED_ROLE.DEVELOPER,
+  content: [{ type: SEED_CONTENT_TYPE.INPUT_TEXT, text }],
+});
+
+const SEED = [
+  developerMessage("Roster: one session working."),
+  {
+    type: SEED_ITEM_TYPE,
+    role: SEED_ROLE.USER,
+    content: [{ type: SEED_CONTENT_TYPE.INPUT_TEXT, text: "What needs me?" }],
+  },
+  {
+    type: SEED_ITEM_TYPE,
+    role: SEED_ROLE.ASSISTANT,
+    content: [{ type: SEED_CONTENT_TYPE.OUTPUT_TEXT, text: "Nothing yet." }],
+  },
+];
+
+function createFrame(input: WireRecord[] = SEED): WireRecord {
+  return {
+    type: VOICE_SERVICE_FRAME.SESSION_CREATE,
+    sdp: SDP_OFFER,
+    voice: LIVE_VOICE.MARIN,
+    input,
+  };
+}
+
+function record(text: string): WireRecord {
+  const value = unparsedWire(JSON.parse(text));
+  assert.ok(isRecord(value));
+  return value;
+}
+
+interface Stand {
+  openAi: FakeOpenAi;
+  accounts: FakeAccountService;
+  service: VoiceService;
+  log: LogEntry[];
+  url(path: string): string;
+  stop(): Promise<void>;
+}
+
+async function stand(): Promise<Stand> {
+  const openAi = await startFakeOpenAi();
+  const accounts = await startFakeAccountService();
+  const log: LogEntry[] = [];
+  const service = new VoiceService({
+    apiKey: API_KEY,
+    webOrigin: accounts.origin,
+    serviceSecret: SERVICE_SECRET,
+    openAiBaseUrl: openAi.baseUrl,
+    log: (entry) => {
+      log.push(entry);
+    },
+    closeTimeoutMs: CLOSE_TIMEOUT_MS,
+    firstFrameTimeoutMs: 1_000,
+    attachTimeoutMs: 2_000,
+  });
+  const port = await service.listen(0, "127.0.0.1");
+  return {
+    openAi,
+    accounts,
+    service,
+    log,
+    url: (path) => `ws://127.0.0.1:${port}${path}`,
+    stop: async () => {
+      await service.close();
+      await openAi.close();
+      await accounts.close();
+    },
+  };
+}
+
+/** A signed-in desktop through to a standing session: the created frame read, and OpenAI's end of the sideband. */
+async function openSession(context: Stand) {
+  const opened = await connect(context.url(VOICE_SERVICE_PATH.SESSIONS), { authorization: BEARER });
+  assert.ok("reader" in opened);
+  const desktop = opened.reader;
+  await send(desktop.socket, createFrame());
+  const attach = await context.openAi.nextAttach();
+  const created = sessionCreatedFrameSchema.parse(record(await desktop.next()));
+  assert.ok(created);
+  return { desktop, upstream: readSocket(attach.socket), attach, created };
+}
+
+test("a /sessions upgrade without a bearer is refused with 401 before any socket stands", async (t) => {
+  const context = await stand();
+  t.after(() => context.stop());
+
+  const refused = await connect(context.url(VOICE_SERVICE_PATH.SESSIONS));
+  assert.deepEqual(refused, { status: UPGRADE_STATUS.UNAUTHORIZED });
+  const blank = await connect(context.url(VOICE_SERVICE_PATH.SESSIONS), {
+    authorization: "Bearer  ",
+  });
+  assert.deepEqual(blank, { status: UPGRADE_STATUS.UNAUTHORIZED });
+  assert.equal(context.accounts.authorizeCalls.length, 0);
+});
+
+test("an unknown path is refused with 404", async (t) => {
+  const context = await stand();
+  t.after(() => context.stop());
+  assert.deepEqual(await connect(context.url("/elsewhere")), { status: UPGRADE_STATUS.NOT_FOUND });
+});
+
+test("an authorize refusal closes the socket behind one hosted error frame and spends no session", async (t) => {
+  const context = await stand();
+  t.after(() => context.stop());
+  context.accounts.authorizeAnswer = {
+    status: 429,
+    body: { error: HOSTED_API_ERROR.QUOTA_EXHAUSTED, quota: FAKE_QUOTA },
+  };
+
+  const opened = await connect(context.url(VOICE_SERVICE_PATH.SESSIONS), { authorization: BEARER });
+  assert.ok("reader" in opened);
+  await send(opened.reader.socket, createFrame());
+
+  assert.equal(
+    hostedErrorSchema.parse(record(await opened.reader.next())),
+    HOSTED_API_ERROR.QUOTA_EXHAUSTED,
+  );
+  const end = await opened.reader.closed;
+  assert.equal(end.code, SOCKET_CLOSE_CODE.POLICY_VIOLATION);
+  assert.equal(end.reason, HOSTED_API_ERROR.QUOTA_EXHAUSTED);
+  assert.equal(context.openAi.creates.length, 0);
+  assert.equal(context.accounts.authorizeCalls.length, 1);
+});
+
+test("an account service that does not answer refuses as unavailable", async (t) => {
+  const context = await stand();
+  t.after(() => context.stop());
+  context.accounts.authorizeAnswer = { status: 500, body: {} };
+
+  const opened = await connect(context.url(VOICE_SERVICE_PATH.SESSIONS), { authorization: BEARER });
+  assert.ok("reader" in opened);
+  await send(opened.reader.socket, createFrame());
+  assert.equal(
+    hostedErrorSchema.parse(record(await opened.reader.next())),
+    HOSTED_API_ERROR.UNAVAILABLE,
+  );
+  assert.equal(context.openAi.creates.length, 0);
+});
+
+test("a first frame that is not session.create is refused as an invalid request", async (t) => {
+  const context = await stand();
+  t.after(() => context.stop());
+
+  const opened = await connect(context.url(VOICE_SERVICE_PATH.SESSIONS), { authorization: BEARER });
+  assert.ok("reader" in opened);
+  await send(opened.reader.socket, { type: LIVE_CLIENT_EVENT.INPUT_AUDIO_MUTE, event_id: "m1" });
+  assert.equal(
+    hostedErrorSchema.parse(record(await opened.reader.next())),
+    HOSTED_API_ERROR.INVALID_REQUEST,
+  );
+  assert.equal((await opened.reader.closed).code, SOCKET_CLOSE_CODE.POLICY_VIOLATION);
+  assert.equal(context.accounts.authorizeCalls.length, 0);
+});
+
+test("a session is authorized, created, attached, and answered in that order with the documented shapes", async (t) => {
+  const context = await stand();
+  t.after(() => context.stop());
+
+  const { attach, created } = await openSession(context);
+
+  assert.deepEqual(context.accounts.authorizeCalls, [
+    { secret: SERVICE_SECRET, body: { bearer: BEARER } },
+  ]);
+
+  assert.equal(context.openAi.creates.length, 1);
+  const create = context.openAi.creates[0];
+  assert.ok(create);
+  assert.equal(create.authorization, `Bearer ${API_KEY}`);
+  const session = create.body.session;
+  assert.ok(isRecord(session));
+  assert.deepEqual(create.body.transport, { type: LIVE_TRANSPORT_TYPE, sdp: SDP_OFFER });
+  assert.equal(session.instructions, sessionInstructions(LIVE_SCENE.DESKTOP));
+  assert.deepEqual(session.delegation, { type: LIVE_DELEGATION_TARGET.CLIENT });
+  assert.equal(session.store, false);
+  assert.deepEqual(session.audio, { output: { voice: LIVE_VOICE.MARIN } });
+  assert.deepEqual(session.input, SEED);
+  assert.deepEqual(session.client, {
+    data_channel: {
+      allowed_client_events: RENDERER_CLIENT_EVENTS,
+      allowed_server_events: RENDERER_SERVER_EVENTS,
+    },
+  });
+  assert.deepEqual(Object.keys(session).sort(), [
+    "audio",
+    "client",
+    "delegation",
+    "input",
+    "instructions",
+    "model",
+    "store",
+  ]);
+
+  assert.equal(attach.sessionId, created.sessionId);
+  assert.equal(attach.authorization, `Bearer ${API_KEY}`);
+  assert.equal(created.sdpAnswer, FAKE_SDP_ANSWER);
+  assert.deepEqual(created.quota, FAKE_QUOTA);
+  assert.equal(context.service.sessions(), 1);
+});
+
+test("frames pass through untouched in both directions, except reflected audio, which is dropped by type", async (t) => {
+  const context = await stand();
+  t.after(() => context.stop());
+  const { desktop, upstream } = await openSession(context);
+
+  const toUpstream = [
+    JSON.stringify({ type: LIVE_CLIENT_EVENT.INPUT_AUDIO_UNMUTE, event_id: "u1" }),
+    JSON.stringify({
+      type: LIVE_CLIENT_EVENT.COMMENTARY_APPEND,
+      event_id: "c1",
+      delegation_id: null,
+      content: "Two sessions are working.",
+    }),
+    JSON.stringify({ type: LIVE_CLIENT_EVENT.INPUT_AUDIO_MUTE, event_id: "m1" }),
+  ];
+  for (const frame of toUpstream) await sendText(desktop.socket, frame);
+  const received: string[] = [];
+  for (let index = 0; index < toUpstream.length; index += 1) received.push(await upstream.next());
+  assert.deepEqual(received, toUpstream);
+
+  const shown = [
+    JSON.stringify({
+      type: LIVE_SERVER_EVENT.SESSION_STARTED,
+      event_id: "e1",
+      session: { id: "live_test_1" },
+    }),
+    JSON.stringify({
+      type: LIVE_SERVER_EVENT.INPUT_TRANSCRIPT_DELTA,
+      event_id: "e2",
+      delta: " ",
+      start_ms: 0,
+      end_ms: 10,
+    }),
+    JSON.stringify({
+      type: LIVE_SERVER_EVENT.DELEGATION_CREATED,
+      event_id: "e3",
+      offset_ms: 10,
+      delegation: { id: "dlg_1", target: LIVE_DELEGATION_TARGET.CLIENT },
+    }),
+    JSON.stringify({
+      type: LIVE_SERVER_EVENT.USAGE_UPDATED,
+      event_id: "e4",
+      usage: { seconds: 12 },
+    }),
+  ];
+  const dropped = [
+    JSON.stringify({ type: LIVE_SERVER_EVENT.INPUT_AUDIO_APPEND, audio: "AAAA" }),
+    JSON.stringify({
+      type: LIVE_SERVER_EVENT.OUTPUT_AUDIO_DELTA,
+      delta: "AAAA",
+      start_ms: 0,
+      end_ms: 20,
+    }),
+  ];
+  await sendText(upstream.socket, dropped[0] ?? "");
+  for (const frame of shown) await sendText(upstream.socket, frame);
+  await sendText(upstream.socket, dropped[1] ?? "");
+  const seen: string[] = [];
+  for (let index = 0; index < shown.length; index += 1) seen.push(await desktop.next());
+  assert.deepEqual(seen, shown);
+  assert.equal(await desktop.arrives(), false);
+});
+
+test("session.closed is forwarded, its seconds reported exactly once, and both ends closed", async (t) => {
+  const context = await stand();
+  t.after(() => context.stop());
+  const { desktop, upstream, created } = await openSession(context);
+
+  const closedEvent = JSON.stringify({
+    type: LIVE_SERVER_EVENT.SESSION_CLOSED,
+    event_id: "e9",
+    reason: LIVE_CLOSE_REASON.CLOSE_REQUESTED,
+    usage: { seconds: 61.5 },
+  });
+  await sendText(upstream.socket, closedEvent);
+  await sendText(upstream.socket, closedEvent);
+
+  assert.equal(await desktop.next(), closedEvent);
+  const desktopEnd = await desktop.closed;
+  assert.equal(desktopEnd.code, SOCKET_CLOSE_CODE.NORMAL);
+  await upstream.closed;
+
+  assert.deepEqual(context.accounts.usageCalls, [
+    {
+      secret: SERVICE_SECRET,
+      body: { userId: FAKE_USER_ID, sessionId: created.sessionId, seconds: 61.5 },
+    },
+  ]);
+  assert.equal(context.service.sessions(), 0);
+});
+
+test("a desktop that hangs up first has session.close sent for it and its seconds still recorded", async (t) => {
+  const context = await stand();
+  t.after(() => context.stop());
+  const { desktop, upstream, created } = await openSession(context);
+
+  desktop.socket.close(SOCKET_CLOSE_CODE.NORMAL);
+  const close = record(await upstream.next());
+  assert.equal(close.type, LIVE_CLIENT_EVENT.CLOSE);
+  assert.equal(Object.keys(close).length, 2);
+
+  await sendText(
+    upstream.socket,
+    JSON.stringify({
+      type: LIVE_SERVER_EVENT.SESSION_CLOSED,
+      event_id: "e9",
+      reason: LIVE_CLOSE_REASON.REMOTE_HANGUP,
+      usage: { seconds: 30 },
+    }),
+  );
+  assert.equal((await upstream.closed).code, SOCKET_CLOSE_CODE.NORMAL);
+  assert.deepEqual(
+    context.accounts.usageCalls.map((call) => call.body),
+    [{ userId: FAKE_USER_ID, sessionId: created.sessionId, seconds: 30 }],
+  );
+});
+
+test("a sideband that never answers session.close is released at the timeout with usage unconfirmed", async (t) => {
+  const context = await stand();
+  t.after(() => context.stop());
+  const { desktop, upstream } = await openSession(context);
+
+  desktop.socket.close(SOCKET_CLOSE_CODE.NORMAL);
+  await upstream.next();
+  const end = await upstream.closed;
+  assert.equal(end.code, SOCKET_CLOSE_CODE.NORMAL);
+  assert.equal(context.accounts.usageCalls.length, 0);
+  const ended = context.log.find((entry) => entry.event === "session-ended");
+  assert.ok(ended && ended.event === "session-ended");
+  assert.equal(ended.finalization, "unconfirmed");
+});
+
+test("a sideband that closes first takes the desktop socket with it and reports nothing", async (t) => {
+  const context = await stand();
+  t.after(() => context.stop());
+  const { desktop, upstream } = await openSession(context);
+
+  upstream.socket.close(SOCKET_CLOSE_CODE.GOING_AWAY);
+  const end = await desktop.closed;
+  assert.equal(end.code, SOCKET_CLOSE_CODE.GOING_AWAY);
+  assert.equal(end.reason, UPSTREAM_CLOSED_REASON);
+  assert.equal(context.accounts.usageCalls.length, 0);
+});
+
+test("a creation OpenAI refuses is answered as an upstream error and nothing is attached", async (t) => {
+  const context = await stand();
+  t.after(() => context.stop());
+  context.openAi.createStatus = 500;
+
+  const opened = await connect(context.url(VOICE_SERVICE_PATH.SESSIONS), { authorization: BEARER });
+  assert.ok("reader" in opened);
+  await send(opened.reader.socket, createFrame());
+  assert.equal(
+    hostedErrorSchema.parse(record(await opened.reader.next())),
+    HOSTED_API_ERROR.UPSTREAM_ERROR,
+  );
+  await opened.reader.closed;
+  assert.equal(context.openAi.attaches.length, 0);
+});
+
+test("the introduction is created without an account, greeted exactly once after session.started, and shown captions only", async (t) => {
+  const context = await stand();
+  t.after(() => context.stop());
+
+  const opened = await connect(context.url(VOICE_SERVICE_PATH.INTRODUCTION));
+  assert.ok("reader" in opened);
+  const desktop = opened.reader;
+  await send(
+    desktop.socket,
+    createFrame([developerMessage("Running: api on main; web on feature/login.")]),
+  );
+  const attach = await context.openAi.nextAttach();
+  const upstream = readSocket(attach.socket);
+  const created = sessionCreatedFrameSchema.parse(record(await desktop.next()));
+  assert.ok(created);
+  assert.equal(created.quota, undefined);
+  assert.equal(context.accounts.authorizeCalls.length, 0);
+
+  const create = context.openAi.creates[0];
+  assert.ok(create && isRecord(create.body.session));
+  assert.equal(create.body.session.instructions, sessionInstructions(LIVE_SCENE.INTRODUCTION));
+  assert.deepEqual(create.body.session.client, {
+    data_channel: {
+      allowed_client_events: RENDERER_CLIENT_EVENTS,
+      allowed_server_events: RENDERER_SERVER_EVENTS,
+    },
+  });
+
+  const started = JSON.stringify({
+    type: LIVE_SERVER_EVENT.SESSION_STARTED,
+    event_id: "e1",
+    session: { id: created.sessionId },
+  });
+  await sendText(upstream.socket, started);
+  const greeting = record(await upstream.next());
+  assert.equal(greeting.type, LIVE_CLIENT_EVENT.INSTRUCTIONS_APPEND);
+  assert.equal(greeting.delegation_id, null);
+  assert.equal(greeting.content, greetingInstruction());
+  assert.equal(isWireString(greeting.event_id), true);
+  assert.equal(await desktop.next(), started);
+
+  await sendText(upstream.socket, started);
+  assert.equal(await desktop.next(), started);
+  assert.equal(await upstream.arrives(), false);
+
+  const delegation = JSON.stringify({
+    type: LIVE_SERVER_EVENT.DELEGATION_CREATED,
+    event_id: "e3",
+    offset_ms: 10,
+    delegation: { id: "dlg_1", target: LIVE_DELEGATION_TARGET.CLIENT },
+  });
+  const caption = JSON.stringify({
+    type: LIVE_SERVER_EVENT.OUTPUT_TRANSCRIPT_DELTA,
+    event_id: "e4",
+    delta: "Hi",
+    start_ms: 0,
+    end_ms: 300,
+  });
+  await sendText(upstream.socket, delegation);
+  await sendText(upstream.socket, caption);
+  assert.equal(await desktop.next(), caption);
+  assert.equal(await desktop.arrives(), false);
+
+  await send(desktop.socket, {
+    type: LIVE_CLIENT_EVENT.COMMENTARY_APPEND,
+    event_id: "c1",
+    delegation_id: null,
+    content: "Say something else.",
+  });
+  const mute = JSON.stringify({ type: LIVE_CLIENT_EVENT.INPUT_AUDIO_MUTE, event_id: "m1" });
+  await sendText(desktop.socket, mute);
+  assert.equal(await upstream.next(), mute);
+  assert.equal(await upstream.arrives(), false);
+
+  await sendText(
+    upstream.socket,
+    JSON.stringify({
+      type: LIVE_SERVER_EVENT.SESSION_CLOSED,
+      event_id: "e9",
+      reason: LIVE_CLOSE_REASON.CLOSE_REQUESTED,
+      usage: { seconds: 20 },
+    }),
+  );
+  await desktop.closed;
+  assert.equal(context.accounts.usageCalls.length, 0);
+});
+
+test("an introduction seed beyond one bounded developer message is refused before any session is spent", async (t) => {
+  const context = await stand();
+  t.after(() => context.stop());
+
+  const tooMany = await connect(context.url(VOICE_SERVICE_PATH.INTRODUCTION));
+  assert.ok("reader" in tooMany);
+  await send(tooMany.reader.socket, createFrame([developerMessage("a"), developerMessage("b")]));
+  assert.equal(
+    hostedErrorSchema.parse(record(await tooMany.reader.next())),
+    HOSTED_API_ERROR.INVALID_REQUEST,
+  );
+
+  const tooLong = await connect(context.url(VOICE_SERVICE_PATH.INTRODUCTION));
+  assert.ok("reader" in tooLong);
+  await send(
+    tooLong.reader.socket,
+    createFrame([developerMessage("x".repeat(INTRODUCTION_INPUT_BOUNDS.CHARS + 1))]),
+  );
+  assert.equal(
+    hostedErrorSchema.parse(record(await tooLong.reader.next())),
+    HOSTED_API_ERROR.INVALID_REQUEST,
+  );
+
+  const wrongRole = await connect(context.url(VOICE_SERVICE_PATH.INTRODUCTION));
+  assert.ok("reader" in wrongRole);
+  await send(wrongRole.reader.socket, createFrame([SEED[1] ?? {}]));
+  assert.equal(
+    hostedErrorSchema.parse(record(await wrongRole.reader.next())),
+    HOSTED_API_ERROR.INVALID_REQUEST,
+  );
+
+  assert.equal(context.openAi.creates.length, 0);
+});
+
+test("the introduction meter refuses a caller's ninth upgrade of the day with 429 and admits another caller", async (t) => {
+  const context = await stand();
+  t.after(() => context.stop());
+  const caller = { "x-forwarded-for": "203.0.113.7, 10.0.0.1" };
+
+  for (let attempt = 0; attempt < INTRODUCTION_METER_LIMITS.PER_CALLER; attempt += 1) {
+    const opened = await connect(context.url(VOICE_SERVICE_PATH.INTRODUCTION), caller);
+    assert.ok("reader" in opened);
+    opened.reader.socket.close();
+    await opened.reader.closed;
+  }
+  assert.deepEqual(await connect(context.url(VOICE_SERVICE_PATH.INTRODUCTION), caller), {
+    status: UPGRADE_STATUS.TOO_MANY_REQUESTS,
+  });
+  const other = await connect(context.url(VOICE_SERVICE_PATH.INTRODUCTION), {
+    "x-forwarded-for": "198.51.100.2",
+  });
+  assert.ok("reader" in other);
+  other.reader.socket.close();
+});
+
+test("closing the service closes every desktop socket and refuses new upgrades with 503", async (t) => {
+  const context = await stand();
+  const { desktop, upstream } = await openSession(context);
+  t.after(async () => {
+    await context.openAi.close();
+    await context.accounts.close();
+  });
+
+  const closing = context.service.close();
+  assert.equal(await desktop.closed.then((end) => end.code), SOCKET_CLOSE_CODE.GOING_AWAY);
+  assert.equal(record(await upstream.next()).type, LIVE_CLIENT_EVENT.CLOSE);
+  await closing;
+});

--- a/apps/voice-service/src/service.ts
+++ b/apps/voice-service/src/service.ts
@@ -62,6 +62,8 @@ const SERVICE_DEFAULTS = {
 /** The statuses an upgrade is refused with, before any socket stands. */
 export const UPGRADE_STATUS = {
   UNAUTHORIZED: HTTP_STATUS.UNAUTHORIZED,
+  /** The handshake carried a browser `Origin`; the desktop connects from its main process and never does. */
+  FORBIDDEN: HTTP_STATUS.FORBIDDEN,
   NOT_FOUND: HTTP_STATUS.NOT_FOUND,
   TOO_MANY_REQUESTS: HTTP_STATUS.TOO_MANY_REQUESTS,
   SERVICE_UNAVAILABLE: 503,
@@ -120,9 +122,15 @@ function presentedBearer(request: IncomingMessage): string | undefined {
   return authorization.slice(BEARER_SCHEME.length).trim().length > 0 ? authorization : undefined;
 }
 
-/** The caller as the platform's proxy names it, or as the socket does when nothing stands in front. */
+/**
+ * The caller as the platform's proxy names it: the last `X-Forwarded-For`
+ * hop, which is the one the proxy in front of this process appended and the
+ * only one a client cannot write for itself, or the socket's own peer when
+ * nothing stands in front.
+ */
 function callerAddress(request: IncomingMessage): string {
-  const forwarded = headerValue(request.headers[FORWARDED_FOR_HEADER])?.split(",")[0]?.trim();
+  const hops = headerValue(request.headers[FORWARDED_FOR_HEADER])?.split(",") ?? [];
+  const forwarded = hops[hops.length - 1]?.trim();
   return forwarded || (request.socket.remoteAddress ?? "");
 }
 
@@ -221,8 +229,7 @@ export class VoiceService {
     const decision = this.#admit(request, routeForPath(path));
     if ("status" in decision) {
       this.#log({ event: LOG_EVENT.UPGRADE_REFUSED, route: path, status: decision.status });
-      socket.write(`HTTP/1.1 ${decision.status} Refused\r\nConnection: close\r\n\r\n`);
-      socket.destroy();
+      socket.end(`HTTP/1.1 ${decision.status} Refused\r\nConnection: close\r\n\r\n`);
       return;
     }
     this.#sockets.handleUpgrade(request, socket, head, (webSocket) => {
@@ -237,6 +244,7 @@ export class VoiceService {
   #admit(request: IncomingMessage, route: VoiceRoute | undefined): UpgradeDecision {
     if (!this.#admitting) return { status: UPGRADE_STATUS.SERVICE_UNAVAILABLE };
     if (route === undefined) return { status: UPGRADE_STATUS.NOT_FOUND };
+    if (request.headers.origin !== undefined) return { status: UPGRADE_STATUS.FORBIDDEN };
     if (route === VOICE_ROUTE.SESSIONS) {
       const bearer = presentedBearer(request);
       return bearer === undefined ? { status: UPGRADE_STATUS.UNAUTHORIZED } : { route, bearer };

--- a/apps/voice-service/src/service.ts
+++ b/apps/voice-service/src/service.ts
@@ -1,0 +1,379 @@
+import { randomUUID } from "node:crypto";
+import http, { type IncomingMessage } from "node:http";
+import type { AddressInfo } from "node:net";
+import type { Duplex } from "node:stream";
+import {
+  HOSTED_API_ERROR,
+  type HostedApiError,
+  type SessionCreatedFrame,
+  type SessionCreateFrame,
+  sessionCreateFrameSchema,
+  VOICE_SERVICE_FRAME,
+  type VoiceAuthorizeAnswer,
+} from "@sidecar/hosted";
+import {
+  decodeLivePayload,
+  greetingInstruction,
+  instructionsAppend,
+  LIVE_SCENE,
+  LIVE_SESSION_OUTCOME,
+  liveSessionConfig,
+  RENDERER_CLIENT_EVENTS,
+  RENDERER_SERVER_EVENTS,
+  SEED_ROLE,
+} from "@sidecar/live";
+import { type CloudFetch, HTTP_STATUS } from "@sidecar/wire";
+import { type RawData, type WebSocket, WebSocketServer } from "ws";
+import { type AccountService, AUTHORIZE_OUTCOME, createAccountService } from "./account-service.js";
+import { frameText, routeForPath, VOICE_ROUTE, type VoiceRoute } from "./frames.js";
+import { IntroductionMeter } from "./introduction-meter.js";
+import { LOG_EVENT, type Log, standardOutputLog } from "./log.js";
+import { createLiveUpstream, type LiveUpstream } from "./openai.js";
+import { RELAY_DEFAULTS, relaySession, SOCKET_CLOSE_CODE } from "./relay.js";
+
+/**
+ * The hosted voice service: the one process on Luke's side that holds a GPT
+ * Live project key, so it is the one that creates each hosted session,
+ * attaches the trusted sideband, and carries events between the desktop and
+ * OpenAI. It keeps no conversation and executes nothing: a session's
+ * transcript crosses it as bytes it never reads past the `type` field, and
+ * what it writes down is status codes and counts.
+ *
+ * Two upgrades stand. `/sessions` takes a signed-in desktop under its account
+ * bearer, which the service never verifies itself: it forwards the bearer to
+ * the account service's authorize route, which resolves the account and
+ * spends its allowance before any session exists. `/introduction` takes a
+ * fresh install with no account under the service's own meter, and on that
+ * route the sideband is the service's alone: it sends the greeting once the
+ * session starts and shows the caller only captions and status.
+ *
+ * A refusal has one of two shapes the desktop reads: an HTTP status on the
+ * upgrade (401, 429, 503) before any socket stands, or, once one does, a
+ * first frame carrying `{ error }` in the hosted vocabulary before the close.
+ */
+
+const SERVICE_DEFAULTS = {
+  /** How long a fresh socket has to send `session.create` before it is refused. */
+  FIRST_FRAME_TIMEOUT_MS: 10_000,
+  /** The largest frame either side may send; `ws` closes the connection on a larger one. */
+  MAXIMUM_FRAME_BYTES: 2 * 1024 * 1024,
+} as const;
+
+/** The statuses an upgrade is refused with, before any socket stands. */
+export const UPGRADE_STATUS = {
+  UNAUTHORIZED: HTTP_STATUS.UNAUTHORIZED,
+  NOT_FOUND: HTTP_STATUS.NOT_FOUND,
+  TOO_MANY_REQUESTS: HTTP_STATUS.TOO_MANY_REQUESTS,
+  SERVICE_UNAVAILABLE: 503,
+} as const;
+
+const HTTP_OK = 200;
+
+/** Answers the platform's health probe; nothing else is served over plain HTTP. */
+const HEALTH_PATH = "/healthz";
+
+/**
+ * What an accountless introduction may put into a session running on Luke's
+ * key: one developer message naming the detected sessions, bounded well
+ * under what the takeover composes (at most eight titles of eighty
+ * characters), because this is client text entering a prompt with no account
+ * to answer for it.
+ */
+export const INTRODUCTION_INPUT_BOUNDS = {
+  MESSAGES: 1,
+  CHARS: 1_024,
+} as const;
+
+const BEARER_SCHEME = "Bearer ";
+const FORWARDED_FOR_HEADER = "x-forwarded-for";
+
+export interface VoiceServiceOptions {
+  apiKey: string;
+  model?: string;
+  webOrigin: string;
+  serviceSecret: string;
+  /** The OpenAI `/v1` base; a test points it at a fake. */
+  openAiBaseUrl?: string;
+  fetch?: CloudFetch;
+  log?: Log;
+  closeTimeoutMs?: number;
+  attachTimeoutMs?: number;
+  createTimeoutMs?: number;
+  firstFrameTimeoutMs?: number;
+  now?: () => number;
+}
+
+/** Who an upgrade admitted: a desktop with the `Authorization` value it presented, forwarded whole to authorize, or an introduction with nothing. */
+type Admission =
+  | { route: typeof VOICE_ROUTE.SESSIONS; bearer: string }
+  | { route: typeof VOICE_ROUTE.INTRODUCTION };
+
+type UpgradeDecision = Admission | { status: number };
+
+function headerValue(value: string | string[] | undefined): string | undefined {
+  return Array.isArray(value) ? value[0] : value;
+}
+
+function presentedBearer(request: IncomingMessage): string | undefined {
+  const authorization = headerValue(request.headers.authorization);
+  if (authorization === undefined || !authorization.startsWith(BEARER_SCHEME)) return undefined;
+  return authorization.slice(BEARER_SCHEME.length).trim().length > 0 ? authorization : undefined;
+}
+
+/** The caller as the platform's proxy names it, or as the socket does when nothing stands in front. */
+function callerAddress(request: IncomingMessage): string {
+  const forwarded = headerValue(request.headers[FORWARDED_FOR_HEADER])?.split(",")[0]?.trim();
+  return forwarded || (request.socket.remoteAddress ?? "");
+}
+
+function introductionInputAdmitted(frame: SessionCreateFrame): boolean {
+  return (
+    frame.input.length <= INTRODUCTION_INPUT_BOUNDS.MESSAGES &&
+    frame.input.every(
+      (item) =>
+        item.role === SEED_ROLE.DEVELOPER &&
+        item.content.every((part) => part.text.length <= INTRODUCTION_INPUT_BOUNDS.CHARS),
+    )
+  );
+}
+
+export class VoiceService {
+  readonly #options: VoiceServiceOptions;
+  readonly #log: Log;
+  readonly #accounts: AccountService;
+  readonly #upstream: LiveUpstream;
+  readonly #meter: IntroductionMeter;
+  readonly #sockets: WebSocketServer;
+  readonly #http = http.createServer((request, response) => {
+    if (request.url === HEALTH_PATH) {
+      response.writeHead(HTTP_OK).end();
+      return;
+    }
+    response.writeHead(UPGRADE_STATUS.NOT_FOUND).end();
+  });
+  /** Every session under way, so a close can wait for each to finalize. */
+  readonly #active = new Set<Promise<void>>();
+  #admitting = true;
+
+  constructor(options: VoiceServiceOptions) {
+    this.#options = options;
+    this.#log = options.log ?? standardOutputLog;
+    this.#accounts = createAccountService({
+      webOrigin: options.webOrigin,
+      serviceSecret: options.serviceSecret,
+      fetch: options.fetch,
+    });
+    this.#upstream = createLiveUpstream({
+      apiKey: options.apiKey,
+      baseUrl: options.openAiBaseUrl,
+      fetch: options.fetch,
+      createTimeoutMs: options.createTimeoutMs,
+      attachTimeoutMs: options.attachTimeoutMs,
+    });
+    this.#meter = new IntroductionMeter({ now: options.now });
+    this.#sockets = new WebSocketServer({
+      noServer: true,
+      maxPayload: SERVICE_DEFAULTS.MAXIMUM_FRAME_BYTES,
+    });
+    this.#http.on("upgrade", (request, socket, head) => {
+      this.#upgrade(request, socket, head);
+    });
+  }
+
+  listen(port: number, host: string): Promise<number> {
+    return new Promise((resolve, reject) => {
+      this.#http.once("error", reject);
+      this.#http.listen(port, host, () => {
+        this.#http.off("error", reject);
+        // SAFETY: a TCP server that is listening answers an AddressInfo, never a pipe path.
+        const address = this.#http.address() as AddressInfo;
+        this.#log({ event: LOG_EVENT.LISTENING, host, port: address.port });
+        resolve(address.port);
+      });
+    });
+  }
+
+  sessions(): number {
+    return this.#active.size;
+  }
+
+  /**
+   * Refuses new upgrades, closes every desktop socket so each relay runs
+   * its graceful close upstream, waits for those to finalize under their
+   * own timeouts, and then releases the listener.
+   */
+  async close(): Promise<void> {
+    this.#admitting = false;
+    for (const socket of this.#sockets.clients) {
+      socket.close(SOCKET_CLOSE_CODE.GOING_AWAY);
+    }
+    await Promise.all(this.#active);
+    await new Promise<void>((resolve) => {
+      this.#sockets.close(() => {
+        this.#http.close(() => resolve());
+      });
+    });
+  }
+
+  #upgrade(request: IncomingMessage, socket: Duplex, head: Buffer): void {
+    socket.on("error", () => socket.destroy());
+    const path = new URL(request.url ?? "/", "http://voice-service").pathname;
+    const decision = this.#admit(request, routeForPath(path));
+    if ("status" in decision) {
+      this.#log({ event: LOG_EVENT.UPGRADE_REFUSED, route: path, status: decision.status });
+      socket.write(`HTTP/1.1 ${decision.status} Refused\r\nConnection: close\r\n\r\n`);
+      socket.destroy();
+      return;
+    }
+    this.#sockets.handleUpgrade(request, socket, head, (webSocket) => {
+      const session = this.#serve(webSocket, decision).finally(() => {
+        this.#active.delete(session);
+      });
+      this.#active.add(session);
+    });
+  }
+
+  /** Who an upgrade admits before any socket stands, or the status it is refused with. */
+  #admit(request: IncomingMessage, route: VoiceRoute | undefined): UpgradeDecision {
+    if (!this.#admitting) return { status: UPGRADE_STATUS.SERVICE_UNAVAILABLE };
+    if (route === undefined) return { status: UPGRADE_STATUS.NOT_FOUND };
+    if (route === VOICE_ROUTE.SESSIONS) {
+      const bearer = presentedBearer(request);
+      return bearer === undefined ? { status: UPGRADE_STATUS.UNAUTHORIZED } : { route, bearer };
+    }
+    return this.#meter.spend(callerAddress(request)).allowed
+      ? { route }
+      : { status: UPGRADE_STATUS.TOO_MANY_REQUESTS };
+  }
+
+  /** One socket, one session: the create frame, the authorization, the creation, the attach, the pipe. */
+  async #serve(desktop: WebSocket, admission: Admission): Promise<void> {
+    const { route } = admission;
+    const refuse = (reason: HostedApiError): void => {
+      this.#log({ event: LOG_EVENT.SESSION_REFUSED, route, reason });
+      if (desktop.readyState !== desktop.OPEN) return;
+      desktop.send(JSON.stringify({ error: reason }));
+      desktop.close(SOCKET_CLOSE_CODE.POLICY_VIOLATION, reason);
+    };
+
+    const frame = await this.#firstFrame(desktop);
+    if (desktop.readyState !== desktop.OPEN) return;
+    if (frame === undefined) {
+      refuse(HOSTED_API_ERROR.INVALID_REQUEST);
+      return;
+    }
+    if (route === VOICE_ROUTE.INTRODUCTION && !introductionInputAdmitted(frame)) {
+      refuse(HOSTED_API_ERROR.INVALID_REQUEST);
+      return;
+    }
+
+    let account: VoiceAuthorizeAnswer | undefined;
+    if (admission.route === VOICE_ROUTE.SESSIONS) {
+      const authorized = await this.#accounts.authorize(admission.bearer);
+      if (authorized.outcome !== AUTHORIZE_OUTCOME.AUTHORIZED) {
+        refuse(
+          authorized.outcome === AUTHORIZE_OUTCOME.REFUSED
+            ? authorized.reason
+            : HOSTED_API_ERROR.UNAVAILABLE,
+        );
+        return;
+      }
+      account = { userId: authorized.userId, quota: authorized.quota };
+    }
+    if (desktop.readyState !== desktop.OPEN) return;
+
+    const config = liveSessionConfig({
+      scene: route === VOICE_ROUTE.SESSIONS ? LIVE_SCENE.DESKTOP : LIVE_SCENE.INTRODUCTION,
+      model: this.#options.model,
+      voice: frame.voice,
+      input: frame.input,
+      clientEvents: RENDERER_CLIENT_EVENTS,
+      serverEvents: RENDERER_SERVER_EVENTS,
+    });
+    const created = await this.#upstream.create(config, frame.sdp);
+    if (created.outcome !== LIVE_SESSION_OUTCOME.SUCCEEDED) {
+      refuse(
+        created.outcome === LIVE_SESSION_OUTCOME.HTTP_ERROR &&
+          created.status === HTTP_STATUS.TOO_MANY_REQUESTS
+          ? HOSTED_API_ERROR.UPSTREAM_THROTTLED
+          : HOSTED_API_ERROR.UPSTREAM_ERROR,
+      );
+      return;
+    }
+    const sessionId = created.answer.session.id;
+
+    let upstream: WebSocket;
+    try {
+      upstream = await this.#upstream.attach(sessionId);
+    } catch {
+      refuse(HOSTED_API_ERROR.UPSTREAM_ERROR);
+      return;
+    }
+
+    if (desktop.readyState === desktop.OPEN) {
+      const answer: SessionCreatedFrame = {
+        type: VOICE_SERVICE_FRAME.SESSION_CREATED,
+        sessionId,
+        sdpAnswer: created.answer.transport.sdp,
+      };
+      if (account !== undefined) answer.quota = account.quota;
+      desktop.send(JSON.stringify(answer));
+      this.#log({ event: LOG_EVENT.SESSION_CREATED, route });
+    }
+
+    const accountId = account?.userId;
+    const summary = await relaySession({
+      route,
+      desktop,
+      upstream,
+      closeTimeoutMs: this.#options.closeTimeoutMs ?? RELAY_DEFAULTS.CLOSE_TIMEOUT_MS,
+      onSessionStarted:
+        route === VOICE_ROUTE.INTRODUCTION
+          ? () => {
+              this.#log({ event: LOG_EVENT.GREETING_SENT, route });
+              return instructionsAppend({
+                eventId: randomUUID(),
+                delegationId: null,
+                content: greetingInstruction(),
+              });
+            }
+          : undefined,
+      onSessionClosed:
+        accountId === undefined
+          ? undefined
+          : (seconds) => this.#reportUsage(accountId, sessionId, seconds),
+    });
+    this.#log({ event: LOG_EVENT.SESSION_ENDED, route, ...summary });
+  }
+
+  async #reportUsage(userId: string, sessionId: string, seconds: number): Promise<void> {
+    const reported = await this.#accounts.recordUsage({ userId, sessionId, seconds });
+    this.#log({
+      event: LOG_EVENT.USAGE_REPORTED,
+      route: VOICE_ROUTE.SESSIONS,
+      seconds,
+      status: reported.status,
+    });
+  }
+
+  /** The socket's first frame as a `session.create`, or nothing when it was late, closed, or not one. */
+  #firstFrame(desktop: WebSocket): Promise<SessionCreateFrame | undefined> {
+    const timeoutMs = this.#options.firstFrameTimeoutMs ?? SERVICE_DEFAULTS.FIRST_FRAME_TIMEOUT_MS;
+    return new Promise((resolve) => {
+      const done = (frame: SessionCreateFrame | undefined): void => {
+        clearTimeout(timer);
+        desktop.off("message", onMessage);
+        desktop.off("close", onClose);
+        resolve(frame);
+      };
+      const timer = setTimeout(() => done(undefined), timeoutMs);
+      const onMessage = (data: RawData, isBinary: boolean): void => {
+        const payload = decodeLivePayload(frameText(data, isBinary));
+        done(payload === undefined ? undefined : sessionCreateFrameSchema.parse(payload));
+      };
+      const onClose = (): void => done(undefined);
+      desktop.once("message", onMessage);
+      desktop.once("close", onClose);
+    });
+  }
+}

--- a/apps/voice-service/src/testing/fakes.ts
+++ b/apps/voice-service/src/testing/fakes.ts
@@ -1,0 +1,284 @@
+import http, { type IncomingMessage } from "node:http";
+import type { AddressInfo } from "node:net";
+import {
+  HOSTED_SERVICE_PATH,
+  VOICE_SERVICE_SECRET_HEADER,
+  VOICE_USAGE_RECORD,
+} from "@sidecar/hosted";
+import { LIVE_SESSIONS_PATH, LIVE_TRANSPORT_TYPE } from "@sidecar/live";
+import { isRecord, type UnparsedWireValue, unparsedWire, type WireRecord } from "@sidecar/wire";
+import { type RawData, WebSocket, WebSocketServer } from "ws";
+
+/**
+ * The two services this one talks to, stood up on this machine for a test:
+ * an OpenAI that creates sessions and takes attaches, and an account service
+ * that authorizes and records usage. Each remembers what it was asked and
+ * answers what the test told it to, and hands the test the far end of every
+ * socket so the test can play OpenAI's part.
+ */
+
+const LOOPBACK = "127.0.0.1";
+const HTTP_CREATED = 201;
+const HTTP_OK = 200;
+
+export const FAKE_SDP_ANSWER =
+  "v=0\r\no=- 2 2 IN IP4 127.0.0.1\r\ns=-\r\nt=0 0\r\nm=audio 9 UDP/TLS/RTP/SAVPF 111\r\n";
+
+function readBody(request: IncomingMessage): Promise<string> {
+  return new Promise((resolve) => {
+    const parts: Buffer[] = [];
+    request.on("data", (part: Buffer) => parts.push(part));
+    request.on("end", () => resolve(Buffer.concat(parts).toString("utf8")));
+  });
+}
+
+function jsonRecord(text: string): WireRecord {
+  const parsed = unparsedWire(JSON.parse(text));
+  if (!isRecord(parsed)) throw new Error("A fake was sent a body that is not a record");
+  return parsed;
+}
+
+function listen(server: http.Server): Promise<number> {
+  return new Promise((resolve) => {
+    server.listen(0, LOOPBACK, () => {
+      // SAFETY: a listening TCP server answers an AddressInfo, never a pipe path.
+      resolve((server.address() as AddressInfo).port);
+    });
+  });
+}
+
+function closeServer(server: http.Server): Promise<void> {
+  return new Promise((resolve) => {
+    server.closeAllConnections();
+    server.close(() => resolve());
+  });
+}
+
+interface RecordedCreate {
+  authorization: string | undefined;
+  body: WireRecord;
+}
+
+interface RecordedAttach {
+  sessionId: string;
+  authorization: string | undefined;
+  /** OpenAI's end of the sideband: what the test sends here, the service receives. */
+  socket: WebSocket;
+}
+
+export interface FakeOpenAi {
+  baseUrl: string;
+  creates: RecordedCreate[];
+  attaches: RecordedAttach[];
+  /** The status the next create answers with; 201 unless a test says otherwise. */
+  createStatus: number;
+  /** Resolves with the next attach the service opens, or the one already waiting. */
+  nextAttach(): Promise<RecordedAttach>;
+  close(): Promise<void>;
+}
+
+const ATTACH_PATH = new RegExp(`^/v1${LIVE_SESSIONS_PATH}/([^/]+)/attach$`);
+
+export async function startFakeOpenAi(): Promise<FakeOpenAi> {
+  const creates: RecordedCreate[] = [];
+  const attaches: RecordedAttach[] = [];
+  const unclaimed: RecordedAttach[] = [];
+  const waiting: Array<(attach: RecordedAttach) => void> = [];
+  let sessions = 0;
+  const fake: FakeOpenAi = {
+    baseUrl: "",
+    creates,
+    attaches,
+    createStatus: HTTP_CREATED,
+    nextAttach: () =>
+      new Promise((resolve) => {
+        const ready = unclaimed.shift();
+        if (ready) resolve(ready);
+        else waiting.push(resolve);
+      }),
+    close: async () => {
+      for (const attach of attaches) attach.socket.terminate();
+      sockets.close();
+      await closeServer(server);
+    },
+  };
+  const sockets = new WebSocketServer({ noServer: true });
+  const server = http.createServer(async (request, response) => {
+    if (request.method === "POST" && request.url === `/v1${LIVE_SESSIONS_PATH}`) {
+      const body = jsonRecord(await readBody(request));
+      creates.push({ authorization: request.headers.authorization, body });
+      sessions += 1;
+      if (fake.createStatus !== HTTP_CREATED) {
+        response.writeHead(fake.createStatus).end(JSON.stringify({ error: "refused" }));
+        return;
+      }
+      response.writeHead(HTTP_CREATED, { "content-type": "application/json" }).end(
+        JSON.stringify({
+          session: { id: `live_test_${sessions}` },
+          transport: { type: LIVE_TRANSPORT_TYPE, sdp: FAKE_SDP_ANSWER },
+        }),
+      );
+      return;
+    }
+    response.writeHead(404).end();
+  });
+  server.on("upgrade", (request, socket, head) => {
+    const match = ATTACH_PATH.exec(request.url ?? "");
+    if (!match?.[1]) {
+      socket.destroy();
+      return;
+    }
+    const sessionId = decodeURIComponent(match[1]);
+    sockets.handleUpgrade(request, socket, head, (webSocket) => {
+      const attach: RecordedAttach = {
+        sessionId,
+        authorization: request.headers.authorization,
+        socket: webSocket,
+      };
+      attaches.push(attach);
+      const waiter = waiting.shift();
+      if (waiter) waiter(attach);
+      else unclaimed.push(attach);
+    });
+  });
+  const port = await listen(server);
+  fake.baseUrl = `http://${LOOPBACK}:${port}/v1`;
+  return fake;
+}
+
+interface RecordedInternalCall {
+  secret: string | undefined;
+  body: WireRecord;
+}
+
+interface FakeAnswer {
+  status: number;
+  body: UnparsedWireValue;
+}
+
+export interface FakeAccountService {
+  origin: string;
+  authorizeCalls: RecordedInternalCall[];
+  usageCalls: RecordedInternalCall[];
+  authorizeAnswer: FakeAnswer;
+  usageAnswer: FakeAnswer;
+  close(): Promise<void>;
+}
+
+export const FAKE_QUOTA = { used: 3, limit: 5000, resetsAt: 1_800_000_000_000 };
+export const FAKE_USER_ID = "user-1";
+
+export async function startFakeAccountService(): Promise<FakeAccountService> {
+  const authorizeCalls: RecordedInternalCall[] = [];
+  const usageCalls: RecordedInternalCall[] = [];
+  const fake: FakeAccountService = {
+    origin: "",
+    authorizeCalls,
+    usageCalls,
+    authorizeAnswer: { status: HTTP_OK, body: { userId: FAKE_USER_ID, quota: FAKE_QUOTA } },
+    usageAnswer: { status: HTTP_OK, body: { record: VOICE_USAGE_RECORD.RECORDED } },
+    close: () => closeServer(server),
+  };
+  const server = http.createServer(async (request, response) => {
+    const call: RecordedInternalCall = {
+      secret: request.headers[VOICE_SERVICE_SECRET_HEADER]?.toString(),
+      body: jsonRecord(await readBody(request)),
+    };
+    let answer: FakeAnswer | undefined;
+    if (request.url === HOSTED_SERVICE_PATH.VOICE_AUTHORIZE) {
+      authorizeCalls.push(call);
+      answer = fake.authorizeAnswer;
+    } else if (request.url === HOSTED_SERVICE_PATH.VOICE_USAGE) {
+      usageCalls.push(call);
+      answer = fake.usageAnswer;
+    }
+    if (answer === undefined) {
+      response.writeHead(404).end();
+      return;
+    }
+    response
+      .writeHead(answer.status, { "content-type": "application/json" })
+      .end(JSON.stringify(answer.body));
+  });
+  const port = await listen(server);
+  fake.origin = `http://${LOOPBACK}:${port}`;
+  return fake;
+}
+
+/** A socket's inbound frames as text, taken one at a time, and its close as a promise. */
+export interface SocketReader {
+  socket: WebSocket;
+  next(timeoutMs?: number): Promise<string>;
+  /** Whether a frame arrives within the wait; false is the assertion that none did. */
+  arrives(timeoutMs?: number): Promise<boolean>;
+  closed: Promise<{ code: number; reason: string }>;
+}
+
+const READ_TIMEOUT_MS = 2_000;
+const QUIET_MS = 150;
+
+export function readSocket(socket: WebSocket): SocketReader {
+  const frames: string[] = [];
+  const waiting: Array<(frame: string) => void> = [];
+  socket.on("message", (data: RawData) => {
+    const text = data.toString();
+    const waiter = waiting.shift();
+    if (waiter) waiter(text);
+    else frames.push(text);
+  });
+  const closed = new Promise<{ code: number; reason: string }>((resolve) => {
+    socket.once("close", (code, reason) => resolve({ code, reason: reason.toString() }));
+  });
+  const next = (timeoutMs = READ_TIMEOUT_MS): Promise<string> => {
+    const queued = frames.shift();
+    if (queued !== undefined) return Promise.resolve(queued);
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        waiting.splice(waiting.indexOf(resolve), 1);
+        reject(new Error("No frame arrived within the wait"));
+      }, timeoutMs);
+      waiting.push((frame) => {
+        clearTimeout(timer);
+        resolve(frame);
+      });
+    });
+  };
+  return {
+    socket,
+    next,
+    arrives: (timeoutMs = QUIET_MS) =>
+      next(timeoutMs).then(
+        () => true,
+        () => false,
+      ),
+    closed,
+  };
+}
+
+/** Opens a socket to the service and resolves once the handshake completed, or with the refused status. */
+export function connect(
+  url: string,
+  headers: Record<string, string> = {},
+): Promise<{ reader: SocketReader } | { status: number }> {
+  return new Promise((resolve, reject) => {
+    const socket = new WebSocket(url, { headers });
+    const reader = readSocket(socket);
+    socket.once("open", () => resolve({ reader }));
+    socket.once("unexpected-response", (_request, response) => {
+      socket.terminate();
+      resolve({ status: response.statusCode ?? 0 });
+    });
+    socket.once("error", reject);
+  });
+}
+
+/** Sends one JSON frame and waits for the write to leave. */
+export function send(socket: WebSocket, frame: WireRecord): Promise<void> {
+  return sendText(socket, JSON.stringify(frame));
+}
+
+export function sendText(socket: WebSocket, text: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    socket.send(text, (error) => (error ? reject(error) : resolve()));
+  });
+}

--- a/apps/voice-service/tsconfig.json
+++ b/apps/voice-service/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/apps/web/server/README.md
+++ b/apps/web/server/README.md
@@ -216,9 +216,10 @@ and only a report that created its row adds to the day's `voice_seconds` on
 count rather than replacing it: a session still spends one call when it
 opens, and the mint routes and their meter stay as they are for installed
 desktops until the seconds are what the allowance is measured in. Both
-tables cascade with the user row. Nothing else calls these routes yet, and the
-desktop never does; the voice service's own origin is pinned by the desktop's
-build in `@sidecar/hosted` rather than answered by this deployment.
+tables cascade with the user row. The caller is `apps/voice-service`, and the
+desktop never calls either route; the voice service's own origin is pinned by
+the desktop's build in `@sidecar/hosted` rather than answered by this
+deployment.
 
 ## Hosted brain inference
 

--- a/knip.json
+++ b/knip.json
@@ -39,6 +39,10 @@
       ],
       "project": ["src/**", "scripts/**"]
     },
+    "apps/voice-service": {
+      "entry": ["src/main.ts", "src/**/*.test.ts"],
+      "project": ["src/**"]
+    },
     "apps/web": {
       "entry": [
         "api/**/*.ts",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -145,6 +145,34 @@ importers:
         specifier: 7.0.2
         version: 7.0.2
 
+  apps/voice-service:
+    dependencies:
+      '@sidecar/hosted':
+        specifier: workspace:*
+        version: link:../../packages/hosted
+      '@sidecar/live':
+        specifier: workspace:*
+        version: link:../../packages/live
+      '@sidecar/wire':
+        specifier: workspace:*
+        version: link:../../packages/wire
+      tsx:
+        specifier: 4.23.12
+        version: 4.23.12
+      ws:
+        specifier: 8.21.3
+        version: 8.21.3
+    devDependencies:
+      '@types/node':
+        specifier: 26.2.0
+        version: 26.2.0
+      '@types/ws':
+        specifier: 8.18.1
+        version: 8.18.1
+      typescript:
+        specifier: 7.0.2
+        version: 7.0.2
+
   apps/web:
     dependencies:
       '@better-auth/drizzle-adapter':


### PR DESCRIPTION
## What

A new workspace, `apps/voice-service`: the hosted voice service, the one process on Luke's side that holds a GPT Live project key. A desktop with no OpenAI key of its own opens one WebSocket here per voice session; the service authorizes the account through the Vercel app's internal route, creates the session at OpenAI from the desktop's WebRTC offer, attaches the trusted sideband itself before answering, returns the SDP answer, and from then on is a pipe. Nothing calls it yet: PR7's hosted `LiveSessionSource` is the desktop's side, and PR9 ships it.

- `src/service.ts`: the two upgrades. `/sessions` requires an account bearer on the handshake and forwards it to `VOICE_AUTHORIZE` under the shared secret before any session exists; `/introduction` takes no bearer and is metered by the service itself, per hashed caller address and shared, per UTC day. Refusals take exactly the two shapes the desktop reads: an upgrade status (401 no bearer, 429 introduction meter, 503 while stopping, 404 other paths) or, once a socket stands, one `{ error }` frame in `hostedErrorSchema`'s vocabulary and a 1008 close (`invalid-request`, `invalid-token`, `quota-exhausted`, `unavailable`, `upstream-error`, `upstream-throttled`).
- `src/relay.ts`: the pipe. Desktop to OpenAI untouched on `/sessions`; OpenAI to desktop untouched except `session.input_audio.append` and `session.output_audio.delta`, dropped by type so the developer's voice and Luke's never transit the service. On `/introduction` the caller may send only `RENDERER_CLIENT_EVENTS` and is shown only `RENDERER_SERVER_EVENTS`; on `session.started` the service sends `greetingInstruction()` as one `session.instructions.append` with `delegation_id: null`, once. `session.closed` is forwarded, its `usage.seconds` reported once to `VOICE_USAGE`, and both ends closed. A desktop that hangs up first has `session.close` sent for it and the sideband held 15 s for `session.closed`; a sideband that ends first closes the desktop with 1001 `upstream-closed` and reports nothing.
- `src/openai.ts`: `POST /v1/live/sessions` with `liveCreateRequest(liveSessionConfig(...), sdp)` under the project key, read back through `liveCreateAnswerSchema`; the sideband attach at `liveAttachPath(id)` on the same base with the same bearer.
- `src/account-service.ts`: the two internal calls on `createAccountCall` with `NO_CREDENTIAL` and the `x-luke-voice-service-secret` header, bodies typed by `@sidecar/hosted`'s `voiceAuthorizeRequestSchema` / `voiceUsageRequestSchema` shapes, answers read through their answer schemas.
- `src/frames.ts`, `src/introduction-meter.ts`, `src/environment.ts`, `src/log.ts`: the per-route frame decisions, the in-memory two-count meter under a launch-minted salt, the environment reader (`OPENAI_API_KEY`, `LUKE_LIVE_MODEL`, `WEB_ORIGIN`, `VOICE_SERVICE_SECRET`, `PORT`, `HOST`), and structured JSON log lines that carry statuses and counts and never an id, a bearer, an SDP, or content.
- `Dockerfile` + root `.dockerignore`, `README.md` with the contract and the deployment steps, a `knip.json` workspace entry, and the web server README sentence that said nothing called the internal routes yet.

## How it follows the GPT Live docs

- WebRTC guide: the session is created server-side with the project key from `{ session, transport: { type: "webrtc", sdp } }`; the id and SDP answer are read from the JSON response and the id is kept opaque; no `session.start` is ever sent on the data channel or the sideband; `audio.format` is omitted (via `liveSessionConfig`).
- Server-side controls: the sideband attaches at `wss://api.openai.com/v1/live/sessions/{id}/attach` with `Authorization: Bearer $OPENAI_API_KEY`, before the answer reaches the desktop ("attach early"); reflected audio is recognised by type; one owner per action (the desktop's host owns appends and hang-up, the service owns the introduction greeting and the close on a departed desktop).
- Managing sessions: `session.closed` is finalization and `usage.seconds` is read from it; the `session.closed` listener stands before `session.close` is sent and the sideband is held 15 s for the final event; a close without it is logged as unconfirmed rather than success. The greeting follows "Greet before the caller speaks": one fresh `instructions.append` with `delegation_id: null` after `session.started`.
- Cost guide: `session.usage.updated` is passed through as a snapshot and never summed; the billed figure recorded is the one `session.closed` names.

## How to verify

```sh
pnpm --filter @luke/voice-service test
./scripts/check.sh
docker build -f apps/voice-service/Dockerfile -t luke-voice-service .
```

## Test results

- `pnpm --filter @luke/voice-service test`: 35 tests, 35 pass. The integration suite runs the service against a fake OpenAI (HTTP create + attach upgrade) and a fake account service on loopback: bearer refusal (401), unknown path (404), authorize refusal as one hosted error frame with no session spent, unavailable account service, invalid first frame, create body structure (`delegation.type === "client"`, `store === false`, instructions per scene, `input` as sent, permission arrays deep-equal to `RENDERER_CLIENT_EVENTS` / `RENDERER_SERVER_EVENTS`, the exact key set), bearer on create and attach, `session.created` shape and quota, pass-through in both directions with audio dropped by type, seconds reported exactly once across a repeated `session.closed`, desktop-first close with `session.close` sent and seconds still recorded, close timeout with usage unconfirmed, sideband-first close propagation, upstream creation failure, introduction created without authorize and greeted exactly once with `delegation_id` null, introduction shown captions only and allowed only renderer client events, introduction seed bounds, introduction meter (429 on the ninth upgrade, another caller admitted), and service close (sockets closed, `session.close` sent, 503 after).
- `./scripts/check.sh`: passes (repository checks, biome, oxlint, knip, typecheck, test, build).
- Docker: the image builds from the repository root; a container without the required variables exits 1 naming them, and one with them answers `GET /healthz` 200 and refuses an unauthenticated `/sessions` upgrade with 401.
- `./scripts/verify.sh` was not run: this PR touches no macOS or UI code.

## Reviews

Both named skills were located and applied to the diff before this PR was opened: Cursor's `thermo-nuclear-code-quality-review` (cursor/plugins, cursor-team-kit) and `ponytail-review` (DietrichGebert/ponytail). Findings acted on: the bearer was read twice on the upgrade path (folded into one `#admit` decision), the admission carried needless optionality (now a discriminated union per route), two usage-report helpers collapsed into one, `USAGE_REPORT_OUTCOME` restated `VOICE_USAGE_RECORD` (now spreads it), and two test helpers duplicated each other.

## Deployment (after merge, before PR9 ships)

The desktop pins `HOSTED_VOICE_SERVICE_ORIGIN = wss://voice.tryluke.dev` in `@sidecar/hosted`, so the service must answer on that host, or the constant moves with it.

1. Build from the repository root: `docker build -f apps/voice-service/Dockerfile -t luke-voice-service .`
2. Fly.io: `fly launch --no-deploy --name luke-voice --dockerfile apps/voice-service/Dockerfile`, set `internal_port = 8080` and an HTTP health check on `GET /healthz`, keep at least one machine always running (a session holds a socket for its whole life), then `fly secrets set OPENAI_API_KEY=… VOICE_SERVICE_SECRET=… WEB_ORIGIN=https://tryluke.dev` (optionally `LUKE_LIVE_MODEL`), `fly deploy --dockerfile apps/voice-service/Dockerfile`, `fly certs add voice.tryluke.dev`, and point `voice.tryluke.dev` at the app. Railway equivalent: root directory `/`, Dockerfile path `apps/voice-service/Dockerfile`, the same variables (Railway supplies `PORT`), health check `/healthz`, custom domain `voice.tryluke.dev`.
3. Set the same `VOICE_SERVICE_SECRET` on the Vercel deployment so `api/internal/voice/authorize` and `api/internal/voice/usage` switch on; they answer 503 until it is set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34528653188/artifacts/10172701848) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34528653188)

- Commit: `f104f8a0f1f4cf122cfb843a46c75dd0b431fb7b`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
