### PR TITLE
fix(providers): render transcript messages whole and walk Conductor chats to their end

### DIFF
--- a/packages/brain/src/guarantees.test.ts
+++ b/packages/brain/src/guarantees.test.ts
@@ -289,6 +289,8 @@ test("a whole-transcript read is cut from the front to 60,000 characters", async
   assert.ok(record && isWireString(record.transcript));
   assert.equal(record.truncated, true);
   assert.ok(record.transcript.length <= FULL_TRANSCRIPT_CHARS);
+  // From the front: the newest characters are the ones kept.
+  assert.equal(record.transcript.slice(-3), "END");
 });
 
 /**

--- a/packages/providers/src/claude-code/transcript.test.ts
+++ b/packages/providers/src/claude-code/transcript.test.ts
@@ -146,6 +146,34 @@ test("renders every line uncut when no rendered length is asked for", async (t) 
   assert.equal(rendered.split("\n").length, 400);
 });
 
+// A message is rendered whole, line breaks and all; a tool's answer is the
+// gist, cut to its own bound.
+test("renders a long message whole and keeps a tool answer short", async (t) => {
+  const claudeHome = await temporaryClaudeHome(t);
+  const report = Array.from({ length: 30 }, (_, index) => `- ${index}: ${"x".repeat(100)}`).join(
+    "\n",
+  );
+  await writeTranscript(claudeHome, TEST_SESSION_ID, [
+    {
+      type: "assistant",
+      message: { role: "assistant", content: [{ type: "text", text: report }] },
+    },
+    {
+      type: "user",
+      message: {
+        role: "user",
+        content: [{ type: "tool_result", tool_use_id: "t1", content: "y".repeat(1_000) }],
+      },
+    },
+  ]);
+
+  const lines = await claudeTranscriptLines(claudeHome, TEST_SESSION_ID);
+
+  assert.equal(lines.length, 2);
+  assert.equal(lines[0], `Claude: ${report}`);
+  assert.equal(lines[1]?.length, "← ".length + TRANSCRIPT_BOUNDS.MAXIMUM_TOOL_LENGTH);
+});
+
 test("reads nothing for a session that has no transcript file", async (t) => {
   const claudeHome = await temporaryClaudeHome(t);
   await writeTranscript(claudeHome, TEST_SESSION_ID, [

--- a/packages/providers/src/claude-code/transcript.ts
+++ b/packages/providers/src/claude-code/transcript.ts
@@ -6,6 +6,7 @@ import {
   text,
   type UnparsedWireValue,
   type WireRecord,
+  wholeText,
 } from "@sidecar/wire";
 import { TRANSCRIPT_BOUNDS, transcriptLine } from "../shared/jsonl-transcript.js";
 import { readDirectory, statDirectoryEntry } from "../shared/local-files.js";
@@ -89,12 +90,12 @@ export function linesFromClaudeRecord(record: WireRecord): string[] {
       const answer = oneLine(toolResultText(record), TRANSCRIPT_BOUNDS.MAXIMUM_TOOL_LENGTH);
       return answer ? [transcriptLine.toolResult(answer)] : [];
     }
-    const prompt = oneLine(claudeMessageText(record), TRANSCRIPT_BOUNDS.MAXIMUM_MESSAGE_LENGTH);
+    const prompt = wholeText(claudeMessageText(record));
     return prompt ? [transcriptLine.developer(prompt)] : [];
   }
   if (record.type === CLAUDE_EVENT_TYPE.ASSISTANT) {
     const lines: string[] = [];
-    const words = oneLine(claudeMessageText(record), TRANSCRIPT_BOUNDS.MAXIMUM_MESSAGE_LENGTH);
+    const words = wholeText(claudeMessageText(record));
     if (words) lines.push(transcriptLine.agent("Claude", words));
     for (const block of claudeContentBlocks(record)) {
       if (block.type !== CLAUDE_CONTENT_TYPE.TOOL_USE) continue;
@@ -114,7 +115,7 @@ export function linesFromClaudeRecord(record: WireRecord): string[] {
     return words ? [transcriptLine.error(words)] : [];
   }
   if (record.type === CLAUDE_EVENT_TYPE.RESULT) {
-    const words = oneLine(text(record.result), TRANSCRIPT_BOUNDS.MAXIMUM_MESSAGE_LENGTH);
+    const words = wholeText(text(record.result));
     return words ? [`Result: ${words}`] : [];
   }
   return [];

--- a/packages/providers/src/codex/transcript.ts
+++ b/packages/providers/src/codex/transcript.ts
@@ -6,6 +6,7 @@ import {
   text,
   type UnparsedWireValue,
   type WireRecord,
+  wholeText,
 } from "@sidecar/wire";
 import { TRANSCRIPT_BOUNDS, transcriptLine } from "../shared/jsonl-transcript.js";
 import { argumentPhrase, CODEX_CALL_ARGUMENT_KEY } from "./records.js";
@@ -141,11 +142,11 @@ function linesFromResponseItem(payload: WireRecord): string[] {
     const words = messageWords(payload.content);
     if (!words) return [];
     if (payload.role === CODEX_MESSAGE_ROLE.USER) {
-      const typed = oneLine(developerWords(words), TRANSCRIPT_BOUNDS.MAXIMUM_MESSAGE_LENGTH);
+      const typed = wholeText(developerWords(words));
       return typed ? [transcriptLine.developer(typed)] : [];
     }
     if (payload.role === CODEX_MESSAGE_ROLE.ASSISTANT) {
-      const said = oneLine(words, TRANSCRIPT_BOUNDS.MAXIMUM_MESSAGE_LENGTH);
+      const said = wholeText(words);
       return said ? [transcriptLine.agent(CODEX_SPEAKER_NAME, said)] : [];
     }
     return [];

--- a/packages/providers/src/conductor/conversation.test.ts
+++ b/packages/providers/src/conductor/conversation.test.ts
@@ -317,7 +317,7 @@ function longConversationApi() {
   });
 }
 
-test("an opening read walks to the end of a long transcript in a bounded few requests", async () => {
+test("an opening read walks to the end of a long transcript one page at a time", async () => {
   const api = longConversationApi();
   const plugin = pluginFor(api.fetch);
   await plugin.observe();
@@ -327,9 +327,8 @@ test("an opening read walks to the end of a long transcript in a bounded few req
 
   assert.equal(result.status, "accepted");
   if (result.status !== "accepted") return;
-  // The walk reached the end of the 120 stored messages and answers with the
-  // pages it read: the newest page carries 20 attributed messages, short of
-  // the history target, so the page before it stands with it.
+  // The walk reached the end of the 120 stored messages and answers with
+  // every page it read.
   assert.equal(result.messages.length, LONG_TRANSCRIPT_LENGTH);
   assert.equal(result.messages[0]?.id, longMessageUuid(0));
   assert.equal(result.messages.at(-1)?.id, longMessageUuid(119));
@@ -482,7 +481,9 @@ test("the brain's transcript read renders the attributed words one line each, in
     read.transcript,
     [
       "Developer: Fix the flaky roster test",
-      "Conductor: Looking at the test now. It races the clock.",
+      "Conductor: Looking at the test now.",
+      "",
+      "It races the clock.",
       "Conductor: Fixed: the test now stubs the clock.",
     ].join("\n"),
   );
@@ -492,6 +493,52 @@ test("the brain's transcript read renders the attributed words one line each, in
     assert.equal(request.method, "GET");
     assert.equal(request.pathname, `/v0/sessions/${IDLE_SESSION_UUID}/messages`);
   }
+});
+
+// An agent's final report is a document, not a line: the read hands the brain
+// the whole of it, and only the brain's own tail cut bounds the total.
+test("a transcript read renders a long message whole, with its line breaks", async () => {
+  const report = Array.from(
+    { length: 60 },
+    (_, index) => `- finding ${index}: ${"x".repeat(80)}`,
+  ).join("\n");
+  const api = conversationApi({
+    storedMessages: [
+      storedUserMessage(longMessageUuid(0), "Write the report", TEST_TIME - 2_000),
+      storedAgentEvent(
+        longMessageUuid(1),
+        { type: "assistant", message: { content: [{ type: "text", text: report }] } },
+        TEST_TIME - 1_000,
+      ),
+    ],
+  });
+  const plugin = pluginFor(api.fetch);
+  await plugin.observe();
+
+  const read = await dispatchRead(plugin, "transcript", IDLE_SESSION_UUID);
+
+  assert.equal(read.status, "accepted");
+  if (read.status !== "accepted") return;
+  const lines = read.transcript.split("\n");
+  assert.equal(lines.length, 1 + report.split("\n").length);
+  assert.equal(
+    read.transcript.length,
+    "Developer: Write the report\n".length + "Conductor: ".length + report.length,
+  );
+});
+
+test("a transcript read of a chat longer than one page reaches the stored newest message", async () => {
+  const api = longConversationApi();
+  const plugin = pluginFor(api.fetch);
+  await plugin.observe();
+
+  const read = await dispatchRead(plugin, "transcript", IDLE_SESSION_UUID);
+
+  assert.equal(read.status, "accepted");
+  if (read.status !== "accepted") return;
+  const lines = read.transcript.split("\n");
+  assert.equal(lines.length, LONG_TRANSCRIPT_LENGTH);
+  assert.equal(lines.at(-1), `Developer: message ${LONG_TRANSCRIPT_LENGTH - 1}`);
 });
 
 test("a transcript read refuses a session the latest pass did not report and reaches nothing", async () => {

--- a/packages/providers/src/conductor/conversation.ts
+++ b/packages/providers/src/conductor/conversation.ts
@@ -130,7 +130,7 @@ function newestStoredId(records: readonly WireRecord[]): string | undefined {
 /**
  * One page of older history ending at `endOffset`, read the way a chat screen
  * scrolls: fixed-width windows paged backward by offset arithmetic until
- * enough attributed messages stand or the chat's start is reached, answered
+ * enough attributed messages stand or the window budget is spent, answered
  * with where the page began so the next scroll can continue. It never names a
  * poll cursor, because history must not move a poll backward.
  */
@@ -141,7 +141,13 @@ async function readConversationPage(
 ): Promise<ProviderConversationResult> {
   const messages: ProviderConversationMessage[] = [];
   let chunkEnd = endOffset;
-  while (chunkEnd > 0 && messages.length < CONDUCTOR_CONVERSATION_BOUNDS.HISTORY_TARGET_MESSAGES) {
+  for (
+    let window = 0;
+    window < CONDUCTOR_CONVERSATION_BOUNDS.MAXIMUM_HISTORY_WINDOWS &&
+    chunkEnd > 0 &&
+    messages.length < CONDUCTOR_CONVERSATION_BOUNDS.HISTORY_TARGET_MESSAGES;
+    window += 1
+  ) {
     const chunkStart = Math.max(0, chunkEnd - CONDUCTOR_CONVERSATION_BOUNDS.PAGE_SIZE);
     const body = await messagesPage(pass, providerSessionId, {
       [CONDUCTOR_QUERY.LIMIT]: String(chunkEnd - chunkStart),

--- a/packages/providers/src/conductor/conversation.ts
+++ b/packages/providers/src/conductor/conversation.ts
@@ -7,15 +7,11 @@ import {
   type ProviderConversationResult,
   type ProviderTranscriptResult,
 } from "@sidecar/session";
-import { oneLine, type WireRecord } from "@sidecar/wire";
+import { type WireRecord, wholeText } from "@sidecar/wire";
 import { ADAPTER_FAILURE, AdapterFailure } from "../shared/adapter-failure.js";
 import type { CloudPass } from "../shared/cloud-pass.js";
 import { isDefined, recordsFromPage, textFromRecord } from "../shared/cloud-wire.js";
-import {
-  boundedTranscript,
-  TRANSCRIPT_BOUNDS,
-  transcriptLine,
-} from "../shared/jsonl-transcript.js";
+import { boundedTranscript, transcriptLine } from "../shared/jsonl-transcript.js";
 import { CONDUCTOR_PROVIDER_NAME, UUID_PATTERN } from "./vocabulary.js";
 import {
   CONDUCTOR_CONVERSATION_BOUNDS,
@@ -134,7 +130,7 @@ function newestStoredId(records: readonly WireRecord[]): string | undefined {
 /**
  * One page of older history ending at `endOffset`, read the way a chat screen
  * scrolls: fixed-width windows paged backward by offset arithmetic until
- * enough attributed messages stand or the window budget is spent, answered
+ * enough attributed messages stand or the chat's start is reached, answered
  * with where the page began so the next scroll can continue. It never names a
  * poll cursor, because history must not move a poll backward.
  */
@@ -145,13 +141,7 @@ async function readConversationPage(
 ): Promise<ProviderConversationResult> {
   const messages: ProviderConversationMessage[] = [];
   let chunkEnd = endOffset;
-  for (
-    let window = 0;
-    window < CONDUCTOR_CONVERSATION_BOUNDS.MAXIMUM_HISTORY_WINDOWS &&
-    chunkEnd > 0 &&
-    messages.length < CONDUCTOR_CONVERSATION_BOUNDS.HISTORY_TARGET_MESSAGES;
-    window += 1
-  ) {
+  while (chunkEnd > 0 && messages.length < CONDUCTOR_CONVERSATION_BOUNDS.HISTORY_TARGET_MESSAGES) {
     const chunkStart = Math.max(0, chunkEnd - CONDUCTOR_CONVERSATION_BOUNDS.PAGE_SIZE);
     const body = await messagesPage(pass, providerSessionId, {
       [CONDUCTOR_QUERY.LIMIT]: String(chunkEnd - chunkStart),
@@ -180,12 +170,10 @@ async function readConversationPage(
  * rather than sought: the walk starts one page before the end a previous read
  * of this session already reached — zero the first time — asks for one page
  * there, and stops as soon as a page comes back short or says no more remain.
- * A re-opened chat therefore costs exactly one request, and a first open at
- * most `MAXIMUM_HISTORY_WINDOWS`. The pages the walk read *are* the newest
- * ones, so the tail is assembled from them and no further request is made. A
- * transcript longer than the walk's budget answers with the deepest page it
- * reached; the poll that follows walks forward to the true newest on its own,
- * exactly as it did when the probe seek this replaced fell short.
+ * A re-opened chat therefore costs exactly one request, and a first open as
+ * many as the transcript has pages. Every page the walk read is answered: the
+ * reader that asked bounds what it keeps, and a page withheld here would be
+ * the one the newest words were on.
  *
  * Every request in the walk carries only the fixed page size and an offset
  * this walk composed, so nothing stored can steer one.
@@ -198,11 +186,7 @@ async function readTailPage(
   const walk = async (from: number) => {
     const pages: WalkedPage[] = [];
     let offset = from;
-    for (
-      let window = 0;
-      window < CONDUCTOR_CONVERSATION_BOUNDS.MAXIMUM_HISTORY_WINDOWS;
-      window += 1
-    ) {
+    for (;;) {
       const body = await messagesPage(pass, providerSessionId, {
         [CONDUCTOR_QUERY.LIMIT]: String(CONDUCTOR_CONVERSATION_BOUNDS.PAGE_SIZE),
         [CONDUCTOR_QUERY.OFFSET]: String(offset),
@@ -234,18 +218,7 @@ async function readTailPage(
   }
   rememberEnd(ends, providerSessionId, walked.end);
 
-  // The kept pages are the newest the walk read, enough of them to carry the
-  // history target; the rest is what an older-history scroll will ask for.
-  const kept: WalkedPage[] = [];
-  let attributed = 0;
-  for (let index = walked.pages.length - 1; index >= 0; index -= 1) {
-    const page = walked.pages[index];
-    if (!page) continue;
-    kept.unshift(page);
-    attributed += page.messages.length;
-    if (attributed >= CONDUCTOR_CONVERSATION_BOUNDS.HISTORY_TARGET_MESSAGES) break;
-  }
-  const firstOffset = kept[0]?.offset ?? walked.end;
+  const firstOffset = walked.pages[0]?.offset ?? walked.end;
   // The newest stored message of the whole walk, attributed or not: the poll
   // resumes exactly where this read stopped.
   const lastMessageId = walked.pages
@@ -254,7 +227,7 @@ async function readTailPage(
     .at(-1);
   return {
     status: ACTION_RESULT_STATUS.ACCEPTED,
-    messages: kept.flatMap((page) => page.messages),
+    messages: walked.pages.flatMap((page) => page.messages),
     hasMore: false,
     firstOffset,
     hasOlder: firstOffset > 0,
@@ -328,7 +301,7 @@ export async function readConductorTranscript(
   if (tail.status !== ACTION_RESULT_STATUS.ACCEPTED) return tail;
   const speaker = observation.agent?.displayName ?? CONDUCTOR_SPEAKER_NAME;
   const lines = tail.messages.flatMap((message) => {
-    const words = oneLine(message.text, TRANSCRIPT_BOUNDS.MAXIMUM_MESSAGE_LENGTH);
+    const words = wholeText(message.text);
     if (!words) return [];
     return [
       message.author === CONVERSATION_MESSAGE_AUTHOR.USER

--- a/packages/providers/src/conductor/wire.ts
+++ b/packages/providers/src/conductor/wire.ts
@@ -211,6 +211,14 @@ export const CONDUCTOR_CONVERSATION_BOUNDS = {
   /** How many attributed messages an older-history page aims to carry. */
   HISTORY_TARGET_MESSAGES: 30,
   /**
+   * How many raw windows one older-history read may page backward. The end
+   * offset it pages from is the caller's, so the budget is what keeps a far
+   * offset against a short chat from becoming a long chain of requests; the
+   * tail walk needs none, since its offsets are its own and it ends where
+   * the transcript does.
+   */
+  MAXIMUM_HISTORY_WINDOWS: 6,
+  /**
    * How many sessions' transcript ends one credential's reads remember at
    * once. A re-opened chat starts its walk where the last read of it reached,
    * so the cache is what makes a re-open one request.

--- a/packages/providers/src/conductor/wire.ts
+++ b/packages/providers/src/conductor/wire.ts
@@ -208,10 +208,8 @@ export const CONDUCTOR_CONVERSATION_BOUNDS = {
   MAXIMUM_PAGES: 10,
   /** How many attributed messages one poll answer may carry. */
   MAXIMUM_MESSAGES: 200,
-  /** How many attributed messages a tail or older-history page aims to carry. */
+  /** How many attributed messages an older-history page aims to carry. */
   HISTORY_TARGET_MESSAGES: 30,
-  /** How many raw windows one tail or older-history read may page backward. */
-  MAXIMUM_HISTORY_WINDOWS: 6,
   /**
    * How many sessions' transcript ends one credential's reads remember at
    * once. A re-opened chat starts its walk where the last read of it reached,

--- a/packages/providers/src/omp/transcript.ts
+++ b/packages/providers/src/omp/transcript.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-import { isRecord, oneLine, text, type WireRecord } from "@sidecar/wire";
+import { isRecord, oneLine, text, type WireRecord, wholeText } from "@sidecar/wire";
 import { TRANSCRIPT_BOUNDS, transcriptLine } from "../shared/jsonl-transcript.js";
 import { readDirectory, statDirectoryEntry } from "../shared/local-files.js";
 import {
@@ -44,7 +44,7 @@ export function linesFromOmpRecord(record: WireRecord): string[] {
     // A synthetic user message is OMP's own auto-continue, not the
     // developer's words, so it takes no attributed line.
     if (message.synthetic === true) return [];
-    const prompt = oneLine(ompMessageText(message), TRANSCRIPT_BOUNDS.MAXIMUM_MESSAGE_LENGTH);
+    const prompt = wholeText(ompMessageText(message));
     return prompt ? [transcriptLine.developer(prompt)] : [];
   }
   if (role === OMP_MESSAGE_ROLE.TOOL_RESULT) {
@@ -56,7 +56,7 @@ export function linesFromOmpRecord(record: WireRecord): string[] {
   }
   if (role !== OMP_MESSAGE_ROLE.ASSISTANT) return [];
   const lines: string[] = [];
-  const words = oneLine(ompMessageText(message), TRANSCRIPT_BOUNDS.MAXIMUM_MESSAGE_LENGTH);
+  const words = wholeText(ompMessageText(message));
   if (words) lines.push(transcriptLine.agent(OMP_SPEAKER_NAME, words));
   for (const block of ompContentBlocks(message)) {
     if (block.type !== OMP_CONTENT_TYPE.TOOL_CALL) continue;

--- a/packages/providers/src/shared/jsonl-transcript.ts
+++ b/packages/providers/src/shared/jsonl-transcript.ts
@@ -5,8 +5,10 @@
  * name for its replies, `→` for a tool call, `←` for its answer, `Error:` for
  * a failure the provider recorded — and this module holds every rendering to
  * the same bounds however the records differ: how much of the file one read
- * loads, and how long any one line may run. There is no bound on the total:
- * a reader sees the whole rendering the tail it read produces.
+ * loads, and how long a tool line may run. A message is rendered whole, line
+ * breaks and all, and there is no bound on the total: the reader that asked
+ * cuts the rendering from the front to what it can carry, so a second bound
+ * here could only lose words it would have kept.
  */
 
 import {
@@ -37,8 +39,6 @@ export const transcriptLine = {
 export const TRANSCRIPT_BOUNDS = {
   /** How much of the file's end one read may load. */
   READ_TAIL_BYTES: transcriptReadTailBytes,
-  /** A rendered message line: enough to carry meaning, not a document. */
-  MAXIMUM_MESSAGE_LENGTH: 400,
   /** A rendered tool call or its result: the gist, never the payload. */
   MAXIMUM_TOOL_LENGTH: 200,
 } as const;
@@ -46,7 +46,7 @@ export const TRANSCRIPT_BOUNDS = {
 /**
  * Joins rendered lines into one rendering, or nothing when there are no lines
  * to render. With no maximum the whole rendering stands, bounded only by the
- * tail the read loaded and the per-line cuts already applied. When a caller
+ * tail the read loaded and the tool-line cuts already applied. When a caller
  * asks for one, the newest turns win the space: a question about a session is
  * almost always about where it is now, so the rendering is cut from the
  * front, at a line, and says so.
@@ -209,7 +209,7 @@ export interface JsonlTranscriptReader {
  * Every on-demand read of a JSONL-backed transcript: the bounded tail read,
  * the cursor arithmetic, the path cache an incremental read walks by, and the
  * bounds every rendering is held to — the tail the build fixes, and the
- * per-line cuts, with no bound on the total, so a reader sees the whole
+ * tool-line cuts, with no bound on the total, so a reader sees the whole
  * rendering the tail it read produces. A provider supplies only where its
  * records live and what one of them says; nothing here opens a file for
  * writing, and the rendering is kept nowhere.

--- a/packages/wire/src/index.ts
+++ b/packages/wire/src/index.ts
@@ -37,6 +37,7 @@ export {
   type WireRecord,
   type WireValue,
   wholeNumber,
+  wholeText,
   wireRecord,
   withoutTrailingSlash,
 } from "./json.js";


### PR DESCRIPTION
## Why

Luke reported that his read of a Conductor session "included the start of the agent's final report, but it was shortened before the rest could be seen." The cause was not the 60,000-character tail cut (which cuts from the front and keeps the newest text) but a 400-character per-message cut every provider's transcript rendering applied. Any agent's final report reached the brain as its first 400 characters plus an ellipsis. Conductor is where it showed, since `read_transcript` is Luke's only window onto a Conductor chat.

## What

- `TRANSCRIPT_BOUNDS.MAXIMUM_MESSAGE_LENGTH` deleted. Claude Code, Codex, OMP, and Conductor message lines render through the existing `wholeText`, keeping Markdown line breaks. Tool call and result lines keep their 200-character cut. The brain's 60,000 / 20,000 front cuts remain the only bound on the total.
- Conductor's tail walk no longer stops after six pages or keeps only a screenful of them: it walks until the endpoint says no more remain and answers every page read. `MAXIMUM_HISTORY_WINDOWS` is removed.
- Tests: the Conductor rendering test moves to the whole-text form; new cases assert a long message renders whole with its newlines (Conductor and Claude Code), a tool result is still cut to 200, a 120-message chat's transcript read ends on the stored newest message, and the brain's 60,000 cut keeps the end.

`PRIVACY.md` needs no change: its 20,000 / 60,000 bounds still hold.

## Verification

`./scripts/check.sh` passes. No macOS or UI change; no visual evidence, no physical-notch check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/c128d956-9a84-40d3-b767-77f8e472e441)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34529576649/artifacts/10173052020) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34529576649)

- Commit: `15364126515c9863434fcd50850efdd9ac8c0a61`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
