### PR TITLE
feat(LUKE-110): UIMessage storage vocabulary

### DIFF
--- a/packages/AGENTS.md
+++ b/packages/AGENTS.md
@@ -112,11 +112,16 @@ A subpath is also how a package keeps something out of a bundle that has no
 use for it. `@sidecar/session/fixtures` is the synthetic snapshot the fixture
 runs and the marketing mock draw, and it stays off the barrel because three
 hundred lines of test data must not ride into a production bundle behind a
-session type. `@sidecar/runtime/testing` is the scaffolding every test in this
-repository shares — a self-cleaning temporary directory, a stated microtask
-drain, and a clock the test drives — behind its own door because it reaches
-`node:fs` and `node:os`, and in this package because the clock stands in for
-the runtime's own `ScheduledTimer`.
+session type. `@sidecar/session/ui-messages` is the reader that holds stored
+`UIMessage` rows to the vocabulary, behind its own door because it calls the
+AI SDK's `validateUIMessages` at run time, where the vocabulary itself — the
+message metadata schemas in `@sidecar/wire` and the tool-part states on the
+session barrel — reaches the SDK for its types alone, so a renderer that only
+names a state pulls none of it. `@sidecar/runtime/testing` is the scaffolding
+every test in this repository shares — a self-cleaning temporary directory, a
+stated microtask drain, and a clock the test drives — behind its own door
+because it reaches `node:fs` and `node:os`, and in this package because the
+clock stands in for the runtime's own `ScheduledTimer`.
 
 `@sidecar/brain` is the reason the rule exists twice in one package: the barrel
 is a door the web functions and the renderer open, and the store beneath it

--- a/packages/session/fixtures/ui-messages/compaction.json
+++ b/packages/session/fixtures/ui-messages/compaction.json
@@ -1,0 +1,18 @@
+{
+  "id": "7c3e9d4f-1a5b-4c2d-9e34-5f6a7b8c9d92",
+  "role": "assistant",
+  "metadata": {
+    "author": "brain",
+    "compaction": {
+      "first_kept_message_id": "5a2d7b3c-8e4f-4a9b-8c12-3d4e5f6a7b81",
+      "tokens_before": 48210
+    }
+  },
+  "parts": [
+    {
+      "type": "text",
+      "text": "Earlier in this conversation the developer asked about the fixture session twice; it was working on a fixture test and then held on a permission prompt. Nothing was sent to it.",
+      "state": "done"
+    }
+  ]
+}

--- a/packages/session/fixtures/ui-messages/reply-with-tool-part.json
+++ b/packages/session/fixtures/ui-messages/reply-with-tool-part.json
@@ -1,0 +1,43 @@
+{
+  "id": "5a2d7b3c-8e4f-4a9b-8c12-3d4e5f6a7b81",
+  "role": "assistant",
+  "metadata": {
+    "author": "brain"
+  },
+  "parts": [
+    {
+      "type": "step-start"
+    },
+    {
+      "type": "reasoning",
+      "text": "The developer asked about the fixture session, so read its tail before answering.",
+      "state": "done",
+      "providerMetadata": {
+        "openai": {
+          "itemId": "rs_fixture_0f3a1c22",
+          "reasoningEncryptedContent": "Zml4dHVyZS1vcGFxdWUtcmVhc29uaW5nLWl0ZW0="
+        }
+      }
+    },
+    {
+      "type": "tool-read_transcript",
+      "toolCallId": "call_6f10d4e59a712b8c",
+      "state": "output-available",
+      "input": {
+        "providerId": "conductor",
+        "providerSessionId": "6c1f2f14-9a0b-4c2d-8e3f-0a1b2c3d4e50"
+      },
+      "output": {
+        "lines": [
+          "user: Please add the fixture test.",
+          "assistant: Waiting for permission to run the test suite."
+        ]
+      }
+    },
+    {
+      "type": "text",
+      "text": "It is holding on a permission prompt before it runs the tests.",
+      "state": "done"
+    }
+  ]
+}

--- a/packages/session/fixtures/ui-messages/spoken-ask.json
+++ b/packages/session/fixtures/ui-messages/spoken-ask.json
@@ -1,0 +1,18 @@
+{
+  "id": "3f1c9a2e-7b4d-4e8f-9a01-2b3c4d5e6f70",
+  "role": "user",
+  "metadata": {
+    "author": "developer",
+    "channel": "voice",
+    "voice_session_id": "vs_0f3a1c226f104d5e",
+    "delegation_id": "dl_2b8c4d5e6f701a2b",
+    "from_ms": 1200,
+    "to_ms": 4800
+  },
+  "parts": [
+    {
+      "type": "text",
+      "text": "What is the fixture session waiting on?"
+    }
+  ]
+}

--- a/packages/session/package.json
+++ b/packages/session/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "exports": {
     ".": "./src/index.js",
-    "./fixtures": "./src/fixtures.js"
+    "./fixtures": "./src/fixtures.js",
+    "./ui-messages": "./src/ui-messages/validate.js"
   },
   "types": "./src/index.ts",
   "scripts": {
@@ -13,11 +14,13 @@
     "typecheck": "tsc --project tsconfig.json"
   },
   "dependencies": {
-    "@sidecar/wire": "workspace:*"
+    "@sidecar/wire": "workspace:*",
+    "ai": "7.0.97"
   },
   "devDependencies": {
     "@types/node": "26.2.0",
     "tsx": "4.23.12",
-    "typescript": "7.0.2"
+    "typescript": "7.0.2",
+    "zod": "4.5.4"
   }
 }

--- a/packages/session/src/index.ts
+++ b/packages/session/src/index.ts
@@ -1,4 +1,25 @@
-export { ACTION_RESULT_STATUS, UNSUPPORTED_BY_OBSERVATION } from "@sidecar/wire";
+export {
+  ACTION_RESULT_STATUS,
+  ASSISTANT_MESSAGE_METADATA,
+  type AssistantMessageMetadata,
+  COMPACTION_METADATA,
+  type CompactionMetadata,
+  MESSAGE_AUTHOR,
+  MESSAGE_CHANNEL,
+  MESSAGE_ROLE,
+  type MessageAuthor,
+  type MessageChannel,
+  type MessageRole,
+  OBSERVATION_SOURCE,
+  type ObservationMetadata,
+  type ObservationSource,
+  type SpokenAskMetadata,
+  type StoredMessageMetadata,
+  type TypedAskMetadata,
+  UNSUPPORTED_BY_OBSERVATION,
+  USER_MESSAGE_METADATA,
+  type UserMessageMetadata,
+} from "@sidecar/wire";
 export * from "./action-results.js";
 export * from "./advertised-actions.js";
 export * from "./agent-identities.js";
@@ -15,6 +36,7 @@ export * from "./session-identity.js";
 export * from "./session-registry.js";
 export * from "./session-shape.js";
 export * from "./session-status.js";
+export * from "./ui-messages/tool-parts.js";
 export * from "./urgency.js";
 export * from "./workspace-agents.js";
 export * from "./workspace-opens.js";

--- a/packages/session/src/ui-messages/tool-parts.test.ts
+++ b/packages/session/src/ui-messages/tool-parts.test.ts
@@ -1,0 +1,23 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { isSettledToolPartState, isToolPartState, TOOL_PART_STATE } from "./tool-parts.js";
+
+test("the stored tool states are the SDK's four, and the approval states are outside the set", () => {
+  assert.deepEqual(Object.values(TOOL_PART_STATE), [
+    "input-streaming",
+    "input-available",
+    "output-available",
+    "output-error",
+  ]);
+  for (const state of Object.values(TOOL_PART_STATE)) assert.equal(isToolPartState(state), true);
+  assert.equal(isToolPartState("approval-requested"), false);
+  assert.equal(isToolPartState("approval-responded"), false);
+  assert.equal(isToolPartState("output-denied"), false);
+});
+
+test("a call is settled once it answered or failed, and pending before", () => {
+  assert.equal(isSettledToolPartState(TOOL_PART_STATE.OUTPUT_AVAILABLE), true);
+  assert.equal(isSettledToolPartState(TOOL_PART_STATE.OUTPUT_ERROR), true);
+  assert.equal(isSettledToolPartState(TOOL_PART_STATE.INPUT_AVAILABLE), false);
+  assert.equal(isSettledToolPartState(TOOL_PART_STATE.INPUT_STREAMING), false);
+});

--- a/packages/session/src/ui-messages/tool-parts.ts
+++ b/packages/session/src/ui-messages/tool-parts.ts
@@ -1,0 +1,28 @@
+/**
+ * The tool part of a stored assistant message is the journal: a call is
+ * written in `input-available` before it executes and moved to
+ * `output-available` or `output-error` after, so a row a writer died inside
+ * still says which call was under way. The SDK names more states than these —
+ * the approval exchange among them — and a stored row carries none of those,
+ * so a part outside this set is refused at the door rather than read as one
+ * of them.
+ */
+export const TOOL_PART_STATE = {
+  INPUT_STREAMING: "input-streaming",
+  INPUT_AVAILABLE: "input-available",
+  OUTPUT_AVAILABLE: "output-available",
+  OUTPUT_ERROR: "output-error",
+} as const;
+
+export type ToolPartState = (typeof TOOL_PART_STATE)[keyof typeof TOOL_PART_STATE];
+
+const TOOL_PART_STATE_LIST: readonly string[] = Object.values(TOOL_PART_STATE);
+
+export function isToolPartState(value: string): value is ToolPartState {
+  return TOOL_PART_STATE_LIST.includes(value);
+}
+
+/** The states a resume has nothing left to do for: the call answered or failed. */
+export function isSettledToolPartState(state: ToolPartState): boolean {
+  return state === TOOL_PART_STATE.OUTPUT_AVAILABLE || state === TOOL_PART_STATE.OUTPUT_ERROR;
+}

--- a/packages/session/src/ui-messages/validate.test.ts
+++ b/packages/session/src/ui-messages/validate.test.ts
@@ -1,0 +1,272 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import {
+  MESSAGE_AUTHOR,
+  MESSAGE_ROLE,
+  SCHEMA_REFUSAL,
+  type SchemaPath,
+  type SchemaRead,
+  type UnparsedWireValue,
+  unparsedWire,
+  type WireBoundaryInput,
+  type WireRecord,
+  wireRecord,
+} from "@sidecar/wire";
+import { type ToolSet, tool } from "ai";
+import { z } from "zod";
+import { TOOL_PART_STATE } from "./tool-parts.js";
+import { isStoredToolPart, readStoredUIMessages, type StoredUIMessage } from "./validate.js";
+
+/** The shared fixtures beside the session vocabulary, plain JSON so another language's decoder reads the same files. */
+const FIXTURE_DIRECTORY = path.join(
+  fileURLToPath(import.meta.url),
+  "../../../fixtures/ui-messages",
+);
+
+const FIXTURE = {
+  SPOKEN_ASK: "spoken-ask.json",
+  REPLY_WITH_TOOL_PART: "reply-with-tool-part.json",
+  COMPACTION: "compaction.json",
+} as const;
+
+async function fixture(name: (typeof FIXTURE)[keyof typeof FIXTURE]): Promise<WireRecord> {
+  // SAFETY: the fixture files are JSON this repository commits; JSON.parse answers the structured-clone shape the wire boundary takes.
+  const parsed = JSON.parse(
+    await readFile(path.join(FIXTURE_DIRECTORY, name), "utf8"),
+  ) as WireBoundaryInput;
+  const record = wireRecord(unparsedWire(parsed));
+  if (record === undefined) throw new Error("fixture is not a record");
+  return record;
+}
+
+const TOOLS: ToolSet = {
+  read_transcript: tool({
+    description: "Reads the tail of an observed session's transcript.",
+    inputSchema: z.object({ providerId: z.string(), providerSessionId: z.string() }),
+    outputSchema: z.object({ lines: z.array(z.string()) }),
+  }),
+};
+
+const TOOL_INPUT = { providerId: "conductor", providerSessionId: "s" };
+
+function refusalOf(read: SchemaRead<StoredUIMessage[]>): string {
+  return read.ok ? "admitted" : read.refusal;
+}
+
+function pathOf(read: SchemaRead<StoredUIMessage[]>): SchemaPath {
+  return read.ok ? [] : read.path;
+}
+
+function withMetadata(message: WireRecord, metadata: UnparsedWireValue): WireRecord {
+  const { metadata: _replaced, ...rest } = message;
+  return metadata === undefined ? rest : { ...rest, metadata };
+}
+
+/** The reply fixture carrying one tool part in place of its own. */
+async function replyWithToolPart(part: WireRecord): Promise<WireRecord> {
+  return { ...(await fixture(FIXTURE.REPLY_WITH_TOOL_PART)), parts: [part] };
+}
+
+test("each fixture round-trips through the wrapper unchanged", async () => {
+  for (const name of Object.values(FIXTURE)) {
+    const message = await fixture(name);
+    assert.deepEqual(await readStoredUIMessages([message], TOOLS), { ok: true, value: [message] });
+  }
+});
+
+test("a row is typed by its role, and its tool parts are told by their state", async () => {
+  const read = await readStoredUIMessages(
+    [await fixture(FIXTURE.SPOKEN_ASK), await fixture(FIXTURE.REPLY_WITH_TOOL_PART)],
+    TOOLS,
+  );
+  assert.equal(read.ok, true);
+  if (!read.ok) return;
+  const [ask, reply] = read.value;
+  assert.equal(ask?.role, MESSAGE_ROLE.USER);
+  if (ask?.role !== MESSAGE_ROLE.USER) return;
+  assert.equal(ask.metadata.author, MESSAGE_AUTHOR.DEVELOPER);
+  assert.equal(reply?.role, MESSAGE_ROLE.ASSISTANT);
+  if (reply?.role !== MESSAGE_ROLE.ASSISTANT) return;
+  assert.equal(reply.metadata.author, MESSAGE_AUTHOR.BRAIN);
+  assert.deepEqual(
+    reply.parts.map((part) => (isStoredToolPart(part) ? part.state : undefined)),
+    [undefined, undefined, TOOL_PART_STATE.OUTPUT_AVAILABLE, undefined],
+  );
+});
+
+test("a message with metadata the vocabulary does not name is refused at the metadata", async () => {
+  const spokenAsk = await fixture(FIXTURE.SPOKEN_ASK);
+  const extra = withMetadata(spokenAsk, { ...wireRecord(spokenAsk.metadata), mood: "cheerful" });
+  const read = await readStoredUIMessages([extra], TOOLS);
+  assert.equal(refusalOf(read), SCHEMA_REFUSAL.MALFORMED);
+  assert.deepEqual(pathOf(read), [0, "metadata"]);
+  const compaction = await fixture(FIXTURE.COMPACTION);
+  const decorated = withMetadata(compaction, { author: MESSAGE_AUTHOR.BRAIN, mood: "cheerful" });
+  assert.deepEqual(pathOf(await readStoredUIMessages([decorated], TOOLS)), [0, "metadata", "mood"]);
+});
+
+test("a role's metadata is held to that role's schema", async () => {
+  const spokenAsk = await fixture(FIXTURE.SPOKEN_ASK);
+  const compaction = await fixture(FIXTURE.COMPACTION);
+  const childAsUser = withMetadata(spokenAsk, { author: MESSAGE_AUTHOR.CHILD, channel: "typed" });
+  assert.deepEqual(pathOf(await readStoredUIMessages([childAsUser], TOOLS)), [0, "metadata"]);
+  const developerAsAssistant = withMetadata(compaction, { author: MESSAGE_AUTHOR.DEVELOPER });
+  assert.deepEqual(pathOf(await readStoredUIMessages([spokenAsk, developerAsAssistant], TOOLS)), [
+    1,
+    "metadata",
+    "author",
+  ]);
+  const unwritten = withMetadata(compaction, undefined);
+  assert.deepEqual(pathOf(await readStoredUIMessages([unwritten], TOOLS)), [0, "metadata"]);
+});
+
+test("a system message carries no metadata", async () => {
+  const bare: WireRecord = {
+    id: "sys_1",
+    role: MESSAGE_ROLE.SYSTEM,
+    parts: [{ type: "text", text: "Be brief." }],
+  };
+  assert.deepEqual(await readStoredUIMessages([bare], TOOLS), { ok: true, value: [bare] });
+  const decorated = withMetadata(bare, { author: MESSAGE_AUTHOR.BRAIN });
+  assert.deepEqual(pathOf(await readStoredUIMessages([decorated], TOOLS)), [0, "metadata"]);
+});
+
+test("a tool part naming a tool the registry does not hold is refused, whatever its state", async () => {
+  const reply = await fixture(FIXTURE.REPLY_WITH_TOOL_PART);
+  const readAnswered = await readStoredUIMessages([reply], {});
+  assert.equal(refusalOf(readAnswered), SCHEMA_REFUSAL.NOT_REGISTERED);
+  assert.deepEqual(pathOf(readAnswered), [0, "parts", 2, "type"]);
+  const pending = await replyWithToolPart({
+    type: "tool-list_sessions",
+    toolCallId: "call_2",
+    state: TOOL_PART_STATE.INPUT_AVAILABLE,
+    input: {},
+  });
+  const readPending = await readStoredUIMessages([pending], TOOLS);
+  assert.equal(refusalOf(readPending), SCHEMA_REFUSAL.NOT_REGISTERED);
+  assert.deepEqual(pathOf(readPending), [0, "parts", 0, "type"]);
+});
+
+test("a dynamic tool part is refused: a stored row names a registered tool or none", async () => {
+  const dynamic = await replyWithToolPart({
+    type: "dynamic-tool",
+    toolName: "read_transcript",
+    toolCallId: "call_3",
+    state: TOOL_PART_STATE.OUTPUT_AVAILABLE,
+    input: {},
+    output: {},
+  });
+  const read = await readStoredUIMessages([dynamic], TOOLS);
+  assert.equal(refusalOf(read), SCHEMA_REFUSAL.NOT_REGISTERED);
+  assert.deepEqual(pathOf(read), [0, "parts", 0, "type"]);
+});
+
+test("a registered tool's input is held to its schema in every state, including the ones the SDK would convert", async () => {
+  const wrongInput = await replyWithToolPart({
+    type: "tool-read_transcript",
+    toolCallId: "call_4",
+    state: TOOL_PART_STATE.OUTPUT_AVAILABLE,
+    input: { providerId: 7 },
+    output: { lines: [] },
+  });
+  assert.equal(
+    refusalOf(await readStoredUIMessages([wrongInput], TOOLS)),
+    SCHEMA_REFUSAL.MALFORMED,
+  );
+  const emptyInput = await replyWithToolPart({
+    type: "tool-read_transcript",
+    toolCallId: "call_5",
+    state: TOOL_PART_STATE.OUTPUT_AVAILABLE,
+    input: {},
+    output: { lines: [] },
+  });
+  const readEmpty = await readStoredUIMessages([emptyInput], TOOLS);
+  assert.equal(refusalOf(readEmpty), SCHEMA_REFUSAL.MALFORMED);
+  assert.deepEqual(pathOf(readEmpty), [0, "parts", 0, "input"]);
+  const failedWithRefusedInput = await replyWithToolPart({
+    type: "tool-read_transcript",
+    toolCallId: "call_6",
+    state: TOOL_PART_STATE.OUTPUT_ERROR,
+    input: { providerId: 7 },
+    errorText: "refused",
+  });
+  const readFailed = await readStoredUIMessages([failedWithRefusedInput], TOOLS);
+  assert.equal(refusalOf(readFailed), SCHEMA_REFUSAL.MALFORMED);
+  assert.deepEqual(pathOf(readFailed), [0, "parts", 0, "input"]);
+});
+
+test("a tool part in an SDK state the store never writes is refused at its state", async () => {
+  const awaitingApproval = await replyWithToolPart({
+    type: "tool-read_transcript",
+    toolCallId: "call_7",
+    state: "approval-requested",
+    input: TOOL_INPUT,
+    approval: { id: "approval_1" },
+  });
+  const readAwaiting = await readStoredUIMessages([awaitingApproval], TOOLS);
+  assert.equal(refusalOf(readAwaiting), SCHEMA_REFUSAL.MALFORMED);
+  assert.deepEqual(pathOf(readAwaiting), [0, "parts", 0, "state"]);
+  const denied = await replyWithToolPart({
+    type: "tool-read_transcript",
+    toolCallId: "call_8",
+    state: "output-denied",
+    input: TOOL_INPUT,
+    approval: { id: "approval_2", approved: false },
+  });
+  const readDenied = await readStoredUIMessages([denied], TOOLS);
+  assert.equal(refusalOf(readDenied), SCHEMA_REFUSAL.MALFORMED);
+  assert.deepEqual(pathOf(readDenied), [0, "parts", 0, "state"]);
+});
+
+test("the pending and failed journal states are admitted", async () => {
+  const pending = await replyWithToolPart({
+    type: "tool-read_transcript",
+    toolCallId: "call_9",
+    state: TOOL_PART_STATE.INPUT_AVAILABLE,
+    input: TOOL_INPUT,
+  });
+  const failed = {
+    ...(await replyWithToolPart({
+      type: "tool-read_transcript",
+      toolCallId: "call_10",
+      state: TOOL_PART_STATE.OUTPUT_ERROR,
+      input: TOOL_INPUT,
+      errorText: "refused: the session is not in the roster",
+    })),
+    id: "failed_1",
+  };
+  const read = await readStoredUIMessages([pending, failed], TOOLS);
+  assert.equal(read.ok, true);
+  if (!read.ok) return;
+  assert.deepEqual(
+    read.value.map((message) =>
+      message.parts.map((part) => (isStoredToolPart(part) ? part.state : undefined)),
+    ),
+    [[TOOL_PART_STATE.INPUT_AVAILABLE], [TOOL_PART_STATE.OUTPUT_ERROR]],
+  );
+});
+
+test("what is not a list of rows, or not a row, is malformed", async () => {
+  assert.equal(refusalOf(await readStoredUIMessages({ id: "x" }, TOOLS)), SCHEMA_REFUSAL.MALFORMED);
+  assert.equal(refusalOf(await readStoredUIMessages(undefined, TOOLS)), SCHEMA_REFUSAL.MALFORMED);
+  assert.equal(
+    refusalOf(await readStoredUIMessages(["not a row"], TOOLS)),
+    SCHEMA_REFUSAL.MALFORMED,
+  );
+  assert.equal(
+    refusalOf(await readStoredUIMessages([{ id: "x", role: "tool", parts: [] }], TOOLS)),
+    SCHEMA_REFUSAL.MALFORMED,
+  );
+  assert.equal(
+    refusalOf(
+      await readStoredUIMessages(
+        [{ id: "x", role: MESSAGE_ROLE.USER, parts: [{ type: "text" }] }],
+        TOOLS,
+      ),
+    ),
+    SCHEMA_REFUSAL.MALFORMED,
+  );
+});

--- a/packages/session/src/ui-messages/validate.ts
+++ b/packages/session/src/ui-messages/validate.ts
@@ -1,0 +1,165 @@
+import {
+  ASSISTANT_MESSAGE_METADATA,
+  type AssistantMessageMetadata,
+  isRecord,
+  isWireString,
+  MESSAGE_ROLE,
+  SCHEMA_REFUSAL,
+  type SchemaPath,
+  type SchemaRead,
+  type SchemaRefusal,
+  type UnparsedWireValue,
+  USER_MESSAGE_METADATA,
+  type UserMessageMetadata,
+  unparsedWire,
+  type WireBoundaryInput,
+} from "@sidecar/wire";
+import {
+  isStaticToolUIPart,
+  safeValidateUIMessages,
+  type ToolSet,
+  type ToolUIPart,
+  type UIDataTypes,
+  type UIMessage,
+  type UIMessagePart,
+  type UITools,
+} from "ai";
+import { isToolPartState, type ToolPartState } from "./tool-parts.js";
+
+/**
+ * A stored message as this build reads it back: the SDK's `UIMessage`, with
+ * the row's role deciding which metadata it carries. Reading rows back is
+ * where a stored shape is held to the vocabulary, and it goes through the
+ * SDK's own `validateUIMessages` so the structure a row must have is the
+ * SDK's own statement of it, not a second one kept here. What this wrapper
+ * adds is what the SDK leaves to its caller: the metadata schema for each
+ * role, the refusal of a tool name the catalog did not register, and the
+ * refusal of a tool state a stored row never carries.
+ */
+export type StoredUIMessage =
+  | StoredMessageOf<typeof MESSAGE_ROLE.USER, UserMessageMetadata>
+  | StoredMessageOf<typeof MESSAGE_ROLE.ASSISTANT, AssistantMessageMetadata>
+  | (Omit<UIMessage<never>, "role" | "metadata"> & { role: typeof MESSAGE_ROLE.SYSTEM });
+
+type StoredMessageOf<Role extends UIMessage["role"], Metadata> = Omit<
+  UIMessage<Metadata>,
+  "role" | "metadata"
+> & { role: Role; metadata: Metadata };
+
+/** A tool part in one of the states a stored row may carry. */
+export type StoredToolPart = Extract<ToolUIPart<UITools>, { state: ToolPartState }>;
+
+export function isStoredToolPart(
+  part: UIMessagePart<UIDataTypes, UITools>,
+): part is StoredToolPart {
+  return isStaticToolUIPart(part) && isToolPartState(part.state);
+}
+
+/**
+ * What the SDK hands back before the metadata is read: a row it validated
+ * structurally, whose metadata it passed through as it came off the wire.
+ */
+type ValidatedMessage = UIMessage<WireBoundaryInput>;
+
+type ValidationOptions = Parameters<typeof safeValidateUIMessages<ValidatedMessage>>[0];
+
+/** How the SDK spells a static tool part's type: the tool's name behind this prefix. */
+const TOOL_PART_TYPE_PREFIX = "tool-";
+
+/**
+ * The type the SDK gives a tool part that names no registered tool. The SDK
+ * converts an unregistered part that already answered into one of these
+ * rather than refusing it, so a stored row is held to the registry before
+ * the SDK sees it; one found afterwards is a registered tool whose input the
+ * registered schema refused.
+ */
+const DYNAMIC_TOOL_PART_TYPE = "dynamic-tool";
+
+function refuse(refusal: SchemaRefusal, path: SchemaPath): SchemaRead<never> {
+  return { ok: false, refusal, path };
+}
+
+/** The first tool part, as the rows arrived, whose name the registry does not hold. */
+function unregisteredToolPart(
+  messages: readonly UnparsedWireValue[],
+  tools: ToolSet,
+): SchemaPath | undefined {
+  for (const [messageIndex, message] of messages.entries()) {
+    if (!isRecord(message) || !Array.isArray(message.parts)) continue;
+    for (const [partIndex, part] of message.parts.entries()) {
+      if (!isRecord(part) || !isWireString(part.type)) continue;
+      const path: SchemaPath = [messageIndex, "parts", partIndex, "type"];
+      if (part.type === DYNAMIC_TOOL_PART_TYPE) return path;
+      if (!part.type.startsWith(TOOL_PART_TYPE_PREFIX)) continue;
+      if (!Object.hasOwn(tools, part.type.slice(TOOL_PART_TYPE_PREFIX.length))) return path;
+    }
+  }
+  return undefined;
+}
+
+/** The first part a stored row may not carry: a converted dynamic part, or a tool state outside the set. */
+function refusedPart(
+  parts: readonly UIMessagePart<UIDataTypes, UITools>[],
+): SchemaPath | undefined {
+  for (const [partIndex, part] of parts.entries()) {
+    if (part.type === DYNAMIC_TOOL_PART_TYPE) return ["parts", partIndex, "input"];
+    if (isStaticToolUIPart(part) && !isStoredToolPart(part)) return ["parts", partIndex, "state"];
+  }
+  return undefined;
+}
+
+/** A validated row typed by its role, its metadata read under that role's schema. */
+function readStoredMessage(message: ValidatedMessage): SchemaRead<StoredUIMessage> {
+  const part = refusedPart(message.parts);
+  if (part) return refuse(SCHEMA_REFUSAL.MALFORMED, part);
+  const { id, parts } = message;
+  const metadata = unparsedWire(message.metadata);
+  switch (message.role) {
+    case MESSAGE_ROLE.USER: {
+      const read = USER_MESSAGE_METADATA.read(metadata);
+      if (!read.ok) return refuse(read.refusal, ["metadata", ...read.path]);
+      return { ok: true, value: { id, role: message.role, parts, metadata: read.value } };
+    }
+    case MESSAGE_ROLE.ASSISTANT: {
+      const read = ASSISTANT_MESSAGE_METADATA.read(metadata);
+      if (!read.ok) return refuse(read.refusal, ["metadata", ...read.path]);
+      return { ok: true, value: { id, role: message.role, parts, metadata: read.value } };
+    }
+    case MESSAGE_ROLE.SYSTEM:
+      if (metadata !== undefined) return refuse(SCHEMA_REFUSAL.MALFORMED, ["metadata"]);
+      return { ok: true, value: { id, role: message.role, parts } };
+  }
+}
+
+/**
+ * Reads stored rows back under the vocabulary: the SDK's own structural
+ * validation and the registered tools' schemas, then this build's metadata by
+ * role and its tool-state set. The registry is the catalog's `tool()`
+ * declarations keyed by the name a part spells. Nothing here throws at a
+ * value; a refusal is the same word and path a wire schema answers with, so a
+ * store can tell a malformed row from one naming a tool this build no longer
+ * registers.
+ */
+export async function readStoredUIMessages(
+  messages: UnparsedWireValue,
+  tools: ToolSet,
+): Promise<SchemaRead<StoredUIMessage[]>> {
+  if (!Array.isArray(messages)) return refuse(SCHEMA_REFUSAL.MALFORMED, []);
+  const unregistered = unregisteredToolPart(messages, tools);
+  if (unregistered) return refuse(SCHEMA_REFUSAL.NOT_REGISTERED, unregistered);
+  const validated = await safeValidateUIMessages<ValidatedMessage>({
+    messages,
+    // SAFETY: the SDK types this option for a message whose tool set is known statically, and a
+    // concrete `tool()` is not assignable to its `Tool<unknown, unknown>` (vercel/ai#9147); the
+    // validation itself reads each registered tool's schemas by name, which is what a `ToolSet` is.
+    tools: tools as ValidationOptions["tools"],
+  });
+  if (!validated.success) return refuse(SCHEMA_REFUSAL.MALFORMED, []);
+  const stored: StoredUIMessage[] = [];
+  for (const [messageIndex, message] of validated.data.entries()) {
+    const read = readStoredMessage(message);
+    if (!read.ok) return refuse(read.refusal, [messageIndex, ...read.path]);
+    stored.push(read.value);
+  }
+  return { ok: true, value: stored };
+}

--- a/packages/wire/src/index.ts
+++ b/packages/wire/src/index.ts
@@ -74,3 +74,23 @@ export {
   type TextOptions,
   type TextOverflow,
 } from "./schema.js";
+export {
+  ASSISTANT_MESSAGE_METADATA,
+  type AssistantMessageMetadata,
+  COMPACTION_METADATA,
+  type CompactionMetadata,
+  MESSAGE_AUTHOR,
+  MESSAGE_CHANNEL,
+  MESSAGE_ROLE,
+  type MessageAuthor,
+  type MessageChannel,
+  type MessageRole,
+  OBSERVATION_SOURCE,
+  type ObservationMetadata,
+  type ObservationSource,
+  type SpokenAskMetadata,
+  type StoredMessageMetadata,
+  type TypedAskMetadata,
+  USER_MESSAGE_METADATA,
+  type UserMessageMetadata,
+} from "./ui-message-metadata.js";

--- a/packages/wire/src/ui-message-metadata.test.ts
+++ b/packages/wire/src/ui-message-metadata.test.ts
@@ -1,0 +1,197 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { type UnparsedWireValue, unparsedWire } from "./json.js";
+import { SCHEMA_REFUSAL, type Schema, type SchemaPath } from "./schema.js";
+import {
+  ASSISTANT_MESSAGE_METADATA,
+  COMPACTION_METADATA,
+  MESSAGE_AUTHOR,
+  MESSAGE_CHANNEL,
+  OBSERVATION_SOURCE,
+  USER_MESSAGE_METADATA,
+} from "./ui-message-metadata.js";
+
+function refusalOf(schema: Schema<unknown>, value: UnparsedWireValue): string {
+  const read = schema.read(value);
+  return read.ok ? "admitted" : read.refusal;
+}
+
+function pathOf(schema: Schema<unknown>, value: UnparsedWireValue): SchemaPath {
+  const read = schema.read(value);
+  return read.ok ? [] : read.path;
+}
+
+const spokenAsk = unparsedWire({
+  author: MESSAGE_AUTHOR.DEVELOPER,
+  channel: MESSAGE_CHANNEL.VOICE,
+  voice_session_id: "vs_0f3a1c22",
+  delegation_id: "dl_2b8c4d5e",
+  from_ms: 1200,
+  to_ms: 4800,
+});
+
+test("a user row is a typed ask, a spoken ask, or an observation, each admitted whole", () => {
+  assert.deepEqual(
+    USER_MESSAGE_METADATA.parse({
+      author: MESSAGE_AUTHOR.DEVELOPER,
+      channel: MESSAGE_CHANNEL.TYPED,
+    }),
+    { author: MESSAGE_AUTHOR.DEVELOPER, channel: MESSAGE_CHANNEL.TYPED },
+  );
+  assert.deepEqual(USER_MESSAGE_METADATA.parse(spokenAsk), {
+    author: MESSAGE_AUTHOR.DEVELOPER,
+    channel: MESSAGE_CHANNEL.VOICE,
+    voice_session_id: "vs_0f3a1c22",
+    delegation_id: "dl_2b8c4d5e",
+    from_ms: 1200,
+    to_ms: 4800,
+  });
+  assert.deepEqual(
+    USER_MESSAGE_METADATA.parse({
+      author: MESSAGE_AUTHOR.VOICE_MODEL,
+      channel: MESSAGE_CHANNEL.VOICE,
+    }),
+    { author: MESSAGE_AUTHOR.VOICE_MODEL, channel: MESSAGE_CHANNEL.VOICE },
+  );
+  assert.deepEqual(
+    USER_MESSAGE_METADATA.parse({
+      author: MESSAGE_AUTHOR.BRAIN,
+      source: OBSERVATION_SOURCE.ROSTER_LOOK,
+    }),
+    { author: MESSAGE_AUTHOR.BRAIN, source: OBSERVATION_SOURCE.ROSTER_LOOK },
+  );
+});
+
+test("the authors are bound to their shapes: a child never speaks as user, the brain never on a channel, the developer never as an observation", () => {
+  const refused: UnparsedWireValue[] = [
+    { author: MESSAGE_AUTHOR.CHILD, channel: MESSAGE_CHANNEL.TYPED },
+    { author: MESSAGE_AUTHOR.BRAIN, channel: MESSAGE_CHANNEL.TYPED },
+    { author: MESSAGE_AUTHOR.BRAIN, channel: MESSAGE_CHANNEL.VOICE },
+    { author: MESSAGE_AUTHOR.DEVELOPER, source: OBSERVATION_SOURCE.HOOK },
+    { author: MESSAGE_AUTHOR.VOICE_MODEL, source: OBSERVATION_SOURCE.ROSTER_LOOK },
+    { author: MESSAGE_AUTHOR.VOICE_MODEL, channel: MESSAGE_CHANNEL.TYPED },
+    {
+      author: MESSAGE_AUTHOR.BRAIN,
+      source: OBSERVATION_SOURCE.HOOK,
+      channel: MESSAGE_CHANNEL.TYPED,
+    },
+    { author: MESSAGE_AUTHOR.DEVELOPER },
+    { channel: MESSAGE_CHANNEL.TYPED },
+    {},
+    undefined,
+  ];
+  for (const value of refused) {
+    assert.equal(refusalOf(USER_MESSAGE_METADATA, value), SCHEMA_REFUSAL.MALFORMED);
+  }
+});
+
+test("the spoken fields belong to the voice channel and the span runs forward with both ends", () => {
+  const refused: UnparsedWireValue[] = [
+    { author: MESSAGE_AUTHOR.DEVELOPER, channel: MESSAGE_CHANNEL.TYPED, voice_session_id: "vs_1" },
+    { author: MESSAGE_AUTHOR.DEVELOPER, channel: MESSAGE_CHANNEL.TYPED, from_ms: 10, to_ms: 20 },
+    {
+      author: MESSAGE_AUTHOR.DEVELOPER,
+      channel: MESSAGE_CHANNEL.VOICE,
+      from_ms: 4800,
+      to_ms: 1200,
+    },
+    { author: MESSAGE_AUTHOR.DEVELOPER, channel: MESSAGE_CHANNEL.VOICE, from_ms: 1200 },
+    { author: MESSAGE_AUTHOR.DEVELOPER, channel: MESSAGE_CHANNEL.VOICE, to_ms: 1200 },
+    { author: MESSAGE_AUTHOR.DEVELOPER, channel: MESSAGE_CHANNEL.VOICE, from_ms: -1, to_ms: 5 },
+    { author: MESSAGE_AUTHOR.DEVELOPER, channel: MESSAGE_CHANNEL.VOICE, from_ms: 1.5, to_ms: 5 },
+  ];
+  for (const value of refused) {
+    assert.equal(refusalOf(USER_MESSAGE_METADATA, value), SCHEMA_REFUSAL.MALFORMED);
+  }
+  assert.deepEqual(
+    USER_MESSAGE_METADATA.parse({
+      author: MESSAGE_AUTHOR.DEVELOPER,
+      channel: MESSAGE_CHANNEL.VOICE,
+      from_ms: 1200,
+      to_ms: 1200,
+    }),
+    {
+      author: MESSAGE_AUTHOR.DEVELOPER,
+      channel: MESSAGE_CHANNEL.VOICE,
+      from_ms: 1200,
+      to_ms: 1200,
+    },
+  );
+});
+
+test("a key the vocabulary does not name is refused", () => {
+  assert.equal(
+    refusalOf(USER_MESSAGE_METADATA, {
+      author: MESSAGE_AUTHOR.DEVELOPER,
+      channel: MESSAGE_CHANNEL.TYPED,
+      mood: "cheerful",
+    }),
+    SCHEMA_REFUSAL.MALFORMED,
+  );
+  assert.deepEqual(
+    pathOf(ASSISTANT_MESSAGE_METADATA, { author: MESSAGE_AUTHOR.BRAIN, mood: "cheerful" }),
+    ["mood"],
+  );
+});
+
+test("an assistant row's author is the brain, the voice model, or a child, and never the developer", () => {
+  for (const author of [MESSAGE_AUTHOR.BRAIN, MESSAGE_AUTHOR.VOICE_MODEL, MESSAGE_AUTHOR.CHILD]) {
+    assert.deepEqual(ASSISTANT_MESSAGE_METADATA.parse({ author }), { author });
+  }
+  assert.deepEqual(pathOf(ASSISTANT_MESSAGE_METADATA, { author: MESSAGE_AUTHOR.DEVELOPER }), [
+    "author",
+  ]);
+  assert.deepEqual(pathOf(ASSISTANT_MESSAGE_METADATA, {}), ["author"]);
+  assert.equal(refusalOf(ASSISTANT_MESSAGE_METADATA, undefined), SCHEMA_REFUSAL.MALFORMED);
+});
+
+test("a compaction row names the first kept message and the tokens it folded", () => {
+  const compaction = {
+    first_kept_message_id: "8a1d2e3f-4b5c-4d6e-8f90-1a2b3c4d5e6f",
+    tokens_before: 48210,
+  };
+  assert.deepEqual(ASSISTANT_MESSAGE_METADATA.parse({ author: MESSAGE_AUTHOR.BRAIN, compaction }), {
+    author: MESSAGE_AUTHOR.BRAIN,
+    compaction,
+  });
+  assert.deepEqual(pathOf(COMPACTION_METADATA, { first_kept_message_id: "m", tokens_before: -1 }), [
+    "tokens_before",
+  ]);
+  assert.deepEqual(
+    pathOf(COMPACTION_METADATA, { first_kept_message_id: "m", tokens_before: 1.5 }),
+    ["tokens_before"],
+  );
+  assert.deepEqual(pathOf(COMPACTION_METADATA, { tokens_before: 3 }), ["first_kept_message_id"]);
+  assert.deepEqual(
+    pathOf(ASSISTANT_MESSAGE_METADATA, {
+      author: MESSAGE_AUTHOR.CHILD,
+      compaction: { tokens_before: 3 },
+    }),
+    ["compaction", "first_kept_message_id"],
+  );
+});
+
+test("the emitted schema offers the three user shapes and names only the fields each parser reads", () => {
+  const user = USER_MESSAGE_METADATA.jsonSchema();
+  assert.equal("anyOf" in user, true);
+  if (!("anyOf" in user)) return;
+  const shapes = user.anyOf.map((member) =>
+    "type" in member && member.type === "object"
+      ? { keys: Object.keys(member.properties).sort(), required: [...member.required].sort() }
+      : undefined,
+  );
+  assert.deepEqual(shapes, [
+    { keys: ["author", "channel"], required: ["author", "channel"] },
+    {
+      keys: ["author", "channel", "delegation_id", "from_ms", "to_ms", "voice_session_id"],
+      required: ["author", "channel"],
+    },
+    { keys: ["author", "source"], required: ["author", "source"] },
+  ]);
+  const assistant = ASSISTANT_MESSAGE_METADATA.jsonSchema();
+  assert.equal("type" in assistant && assistant.type, "object");
+  if (!("type" in assistant) || assistant.type !== "object") return;
+  assert.deepEqual(Object.keys(assistant.properties).sort(), ["author", "compaction"]);
+  assert.deepEqual([...assistant.required], ["author"]);
+  assert.equal(assistant.additionalProperties, false);
+});

--- a/packages/wire/src/ui-message-metadata.ts
+++ b/packages/wire/src/ui-message-metadata.ts
@@ -1,0 +1,138 @@
+import { type RecordOf, type Schema, type SchemaFields, s } from "./schema.js";
+
+/**
+ * What a stored message says about itself beside its parts. The message
+ * itself is the AI SDK's `UIMessage`, one row per message with its parts as
+ * JSON; this is the `metadata` field on that row, and the one place the
+ * storage says who wrote a message and how it arrived. Each role has its own
+ * shape, because a user row and an assistant row answer different questions:
+ * a user row says whose words these are and which channel carried them, an
+ * assistant row says which of Luke's parts spoke and whether the row is a
+ * compaction standing in for the rows before it. A system row carries no
+ * metadata at all. Declared here so the desktop, the service, and the phone
+ * decode one shape, and so a key the schema does not name is refused rather
+ * than stored.
+ */
+
+/** The roles a stored message may carry, as the SDK names them. */
+export const MESSAGE_ROLE = {
+  USER: "user",
+  ASSISTANT: "assistant",
+  SYSTEM: "system",
+} as const;
+
+export type MessageRole = (typeof MESSAGE_ROLE)[keyof typeof MESSAGE_ROLE];
+
+/** Who wrote a message: the developer, Luke's own judgment, the voice model, or a child run. */
+export const MESSAGE_AUTHOR = {
+  DEVELOPER: "developer",
+  BRAIN: "brain",
+  VOICE_MODEL: "voice_model",
+  CHILD: "child",
+} as const;
+
+export type MessageAuthor = (typeof MESSAGE_AUTHOR)[keyof typeof MESSAGE_AUTHOR];
+
+/** How a developer's ask arrived. */
+export const MESSAGE_CHANNEL = {
+  TYPED: "typed",
+  VOICE: "voice",
+} as const;
+
+export type MessageChannel = (typeof MESSAGE_CHANNEL)[keyof typeof MESSAGE_CHANNEL];
+
+/** What opened an observation the brain wrote down as a user row. */
+export const OBSERVATION_SOURCE = {
+  HOOK: "hook",
+  ROSTER_LOOK: "roster_look",
+} as const;
+
+export type ObservationSource = (typeof OBSERVATION_SOURCE)[keyof typeof OBSERVATION_SOURCE];
+
+/** An identifier another table minted: a voice session's, a delegation's, a message's. */
+const identifier = s.text({ max: 128 });
+
+/** A millisecond offset into a voice session's own clock, never a wall-clock instant. */
+const spanInstant = s.wholeNumber({ minimum: 0 });
+
+/**
+ * A user row is one of three things, and the shape says which: the
+ * developer's typed ask, a spoken ask cut from a voice session, or an
+ * observation the brain wrote down for itself. Three records rather than one
+ * with every field optional, so an observation carrying a channel or a typed
+ * ask carrying a voice session has no shape to arrive in.
+ */
+const TYPED_ASK_METADATA_FIELDS = {
+  author: s.literal(MESSAGE_AUTHOR.DEVELOPER),
+  channel: s.literal(MESSAGE_CHANNEL.TYPED),
+} satisfies SchemaFields;
+
+export type TypedAskMetadata = RecordOf<typeof TYPED_ASK_METADATA_FIELDS>;
+
+/**
+ * A spoken ask is the developer's own words, or the voice model's delegation
+ * of them, cut from the session and delegation it names over a span of that
+ * session's clock whose two ends come together or not at all and run forward.
+ */
+const SPOKEN_ASK_METADATA_FIELDS = {
+  author: s.enumOf([MESSAGE_AUTHOR.DEVELOPER, MESSAGE_AUTHOR.VOICE_MODEL]),
+  channel: s.literal(MESSAGE_CHANNEL.VOICE),
+  voice_session_id: identifier.optional(),
+  delegation_id: identifier.optional(),
+  from_ms: spanInstant.optional(),
+  to_ms: spanInstant.optional(),
+} satisfies SchemaFields;
+
+export type SpokenAskMetadata = RecordOf<typeof SPOKEN_ASK_METADATA_FIELDS>;
+
+function coherentSpan(metadata: SpokenAskMetadata): boolean {
+  if (metadata.from_ms === undefined || metadata.to_ms === undefined) {
+    return metadata.from_ms === metadata.to_ms;
+  }
+  return metadata.from_ms <= metadata.to_ms;
+}
+
+/** An observation arrives on no channel: the brain's own note of what a hook or a roster look reported. */
+const OBSERVATION_METADATA_FIELDS = {
+  author: s.literal(MESSAGE_AUTHOR.BRAIN),
+  source: s.enumOf(Object.values(OBSERVATION_SOURCE)),
+} satisfies SchemaFields;
+
+export type ObservationMetadata = RecordOf<typeof OBSERVATION_METADATA_FIELDS>;
+
+export type UserMessageMetadata = TypedAskMetadata | SpokenAskMetadata | ObservationMetadata;
+
+/** What a user row says about itself. */
+export const USER_MESSAGE_METADATA: Schema<UserMessageMetadata> = s.union([
+  s.record(TYPED_ASK_METADATA_FIELDS),
+  s.refine(s.record(SPOKEN_ASK_METADATA_FIELDS), coherentSpan),
+  s.record(OBSERVATION_METADATA_FIELDS),
+]);
+
+/**
+ * A compaction row's account of what it folded: the first message the model
+ * still reads after it, and how many tokens the folded messages had cost.
+ */
+const COMPACTION_METADATA_FIELDS = {
+  first_kept_message_id: identifier,
+  tokens_before: s.wholeNumber({ minimum: 0 }),
+} satisfies SchemaFields;
+
+export type CompactionMetadata = RecordOf<typeof COMPACTION_METADATA_FIELDS>;
+
+export const COMPACTION_METADATA: Schema<CompactionMetadata> = s.record(COMPACTION_METADATA_FIELDS);
+
+const ASSISTANT_MESSAGE_METADATA_FIELDS = {
+  author: s.enumOf([MESSAGE_AUTHOR.BRAIN, MESSAGE_AUTHOR.VOICE_MODEL, MESSAGE_AUTHOR.CHILD]),
+  compaction: COMPACTION_METADATA.optional(),
+} satisfies SchemaFields;
+
+export type AssistantMessageMetadata = RecordOf<typeof ASSISTANT_MESSAGE_METADATA_FIELDS>;
+
+/** What an assistant row says about itself. */
+export const ASSISTANT_MESSAGE_METADATA: Schema<AssistantMessageMetadata> = s.record(
+  ASSISTANT_MESSAGE_METADATA_FIELDS,
+);
+
+/** The metadata a stored message of either speaking role carries. */
+export type StoredMessageMetadata = UserMessageMetadata | AssistantMessageMetadata;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -742,6 +742,9 @@ importers:
       '@sidecar/wire':
         specifier: workspace:*
         version: link:../wire
+      ai:
+        specifier: 7.0.97
+        version: 7.0.97(zod@4.5.4)
     devDependencies:
       '@types/node':
         specifier: 26.2.0
@@ -752,6 +755,9 @@ importers:
       typescript:
         specifier: 7.0.2
         version: 7.0.2
+      zod:
+        specifier: 4.5.4
+        version: 4.5.4
 
   packages/settings:
     dependencies:
@@ -927,6 +933,22 @@ packages:
 
   7zip-bin@5.2.0:
     resolution: {integrity: sha512-ukTPVhqG4jNzMro2qA9HSCSSVJN3aN7tlb+hfqYCt3ER0yWroeA2VR38MNrOHLQ/cVj+DaIMad0kFCtWWowh/A==}
+
+  '@ai-sdk/gateway@4.0.78':
+    resolution: {integrity: sha512-fcamzmFlcy+c/tIc7QcATLe/kArgSVGQ1QxaddMjhOSX8zypc2hmD5sHB2bp1DSFcSxDD32d6usF9a7xLCTULg==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider-utils@5.0.39':
+    resolution: {integrity: sha512-VIFp4Qv3j+V941crFB1y2VG5yeGbeLOFRxiPaZJETkkpo1H5WviLx6H5yRkFkrXIGxnTGygKsPgCAJG0X61Auw==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider@4.0.13':
+    resolution: {integrity: sha512-sJvnbFIFLzmKFXIjfwS8XCOAj6puHCawItwvA9PBZgk2f/l/TiC4OSfK3ueDbUVXfRCOn5eJN97EIF10toIOmQ==}
+    engines: {node: '>=22'}
 
   '@babel/code-frame@7.29.7':
     resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
@@ -3181,11 +3203,18 @@ packages:
   '@ungap/structured-clone@1.4.0':
     resolution: {integrity: sha512-1mEZtMKPM09vDmQt5y7YvmN2+DFTP7Tg0EWXdic8/C6VRnpb33e4ghisCIE3WZjsE2N8mf+QV1Zqh7ZFYLWInQ==}
 
+  '@vercel/oidc@3.2.0':
+    resolution: {integrity: sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==}
+    engines: {node: '>= 20'}
+
   '@vitejs/plugin-react@5.1.2':
     resolution: {integrity: sha512-EcA07pHJouywpzsoTUqNh5NwGayl2PPVEJKUSinGGSxFGYn+shYbqMGBg6FXDqgXum9Ou/ecb+411ssw8HImJQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
+
+  '@workflow/serde@4.1.0':
+    resolution: {integrity: sha512-pav4F2BoirECWR7Nf1TKt+2eETcBj7jj4cBefQ8VXQCA6NPkaKeLfj/zMgi+3zYV5ZIBT4GuUiphsj0/b9hPQQ==}
 
   '@xmldom/xmldom@0.8.14':
     resolution: {integrity: sha512-T4EDRUBVZYRldYApjEJiU0e1stYWaRAX7CuSnKzrpwdZKo53zGV8/pqfzV6FfwNl9YThD2OumQYvqtvjvgG7aQ==}
@@ -3208,6 +3237,12 @@ packages:
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
+
+  ai@7.0.97:
+    resolution: {integrity: sha512-tQGZ234p/bk5X/LNQdB43a5/z1Bve7wK0EOR1AwN6xrosZih4MIC/3pXhcnytcpBJHMbhLISW6J1dFTd/tnwPA==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
 
   ajv-keywords@3.5.2:
     resolution: {integrity: sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==}
@@ -4142,6 +4177,9 @@ packages:
 
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+
+  json-schema@0.4.0:
+    resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
 
   json-stringify-safe@5.0.1:
     resolution: {integrity: sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==}
@@ -5330,6 +5368,26 @@ snapshots:
 
   7zip-bin@5.2.0: {}
 
+  '@ai-sdk/gateway@4.0.78(zod@4.5.4)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.13
+      '@ai-sdk/provider-utils': 5.0.39(zod@4.5.4)
+      '@vercel/oidc': 3.2.0
+      zod: 4.5.4
+
+  '@ai-sdk/provider-utils@5.0.39(zod@4.5.4)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.13
+      '@standard-schema/spec': 1.1.0
+      '@workflow/serde': 4.1.0
+      eventsource-parser: 3.1.1
+      undici: 7.29.0
+      zod: 4.5.4
+
+  '@ai-sdk/provider@4.0.13':
+    dependencies:
+      json-schema: 0.4.0
+
   '@babel/code-frame@7.29.7':
     dependencies:
       '@babel/helper-validator-identifier': 7.29.7
@@ -5452,7 +5510,7 @@ snapshots:
       jose: 6.2.9
       kysely: 0.29.5
       nanostores: 1.5.0
-      zod: 4.4.3
+      zod: 4.5.4
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
 
@@ -6980,6 +7038,8 @@ snapshots:
 
   '@ungap/structured-clone@1.4.0': {}
 
+  '@vercel/oidc@3.2.0': {}
+
   '@vitejs/plugin-react@5.1.2(vite@7.3.1(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.12)(yaml@2.9.0))':
     dependencies:
       '@babel/core': 7.29.7
@@ -6991,6 +7051,8 @@ snapshots:
       vite: 7.3.1(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.12)(yaml@2.9.0)
     transitivePeerDependencies:
       - supports-color
+
+  '@workflow/serde@4.1.0': {}
 
   '@xmldom/xmldom@0.8.14': {}
 
@@ -7005,6 +7067,13 @@ snapshots:
       - supports-color
 
   agent-base@7.1.4: {}
+
+  ai@7.0.97(zod@4.5.4):
+    dependencies:
+      '@ai-sdk/gateway': 4.0.78(zod@4.5.4)
+      '@ai-sdk/provider': 4.0.13
+      '@ai-sdk/provider-utils': 5.0.39(zod@4.5.4)
+      zod: 4.5.4
 
   ajv-keywords@3.5.2(ajv@6.15.0):
     dependencies:
@@ -7694,8 +7763,7 @@ snapshots:
 
   eventemitter3@5.0.4: {}
 
-  eventsource-parser@3.1.1:
-    optional: true
+  eventsource-parser@3.1.1: {}
 
   eventsource@3.0.7:
     dependencies:
@@ -8027,6 +8095,8 @@ snapshots:
   json-buffer@3.0.1: {}
 
   json-schema-traverse@0.4.1: {}
+
+  json-schema@0.4.0: {}
 
   json-stringify-safe@5.0.1:
     optional: true
@@ -9291,8 +9361,7 @@ snapshots:
 
   undici@6.28.0: {}
 
-  undici@7.29.0:
-    optional: true
+  undici@7.29.0: {}
 
   unified@11.0.5:
     dependencies:


### PR DESCRIPTION
## Summary

- Adopts the AI SDK's `UIMessage` (`ai@7.0.97`, pinned) as the stored message vocabulary, per the LUKE-95 storage plan (`orchestration/storage-plan`, `plan/storage-plan.md` "Storage shape"). Lane A, PR A1: shared vocabulary only, no consumer, no service change. Nothing in `packages/brain`'s storage or the desktop is touched.
- **Metadata schema, declared once in `@sidecar/wire`** (`packages/wire/src/ui-message-metadata.ts`): a user row is one of three shapes, `s.union` of three records, so an incoherent combination has no shape to arrive in: a typed ask (`author developer`, `channel typed`), a spoken ask (`author developer|voice_model`, `channel voice`, optional `voice_session_id`, `delegation_id`, `from_ms`, `to_ms`, the span's ends together and running forward), or an observation (`author brain`, `source hook|roster_look`). An assistant row carries `author brain|voice_model|child` and optional `compaction { first_kept_message_id, tokens_before }`; a system row carries none. Value sets are `as const` objects with derived unions (`MESSAGE_ROLE`, `MESSAGE_AUTHOR`, `MESSAGE_CHANNEL`, `OBSERVATION_SOURCE`). `@sidecar/session` re-exports the vocabulary from its barrel, as the ticket asks.
- **Tool-part state helpers**: `TOOL_PART_STATE` over the SDK's `input-streaming | input-available | output-available | output-error`, `isToolPartState`, and `isSettledToolPartState` on the session barrel (`packages/session/src/ui-messages/tool-parts.ts`, no SDK runtime); `StoredToolPart` and `isStoredToolPart` behind the door beside the reader, over the SDK's own `isStaticToolUIPart`. The SDK's approval states are outside the stored set and are refused rather than read.
- **`validateUIMessages` wrapper** (`readStoredUIMessages`, behind its own door `@sidecar/session/ui-messages` because it reaches the SDK at run time; the barrel reaches no SDK runtime, and the desktop bundles were checked to carry none of it): the SDK's structural validation and the registered tools' input/output schemas, then this build's metadata schema by role and its tool-state set. It answers `StoredUIMessage`, a row typed by its role with the metadata that role requires. Refusals are the wire vocabulary's own `SchemaRead` word and path (`malformed` / `not-registered`), never a throw.
- **Fixtures** (`packages/session/fixtures/ui-messages/`): a spoken ask, a reply with a reasoning part and an `output-available` tool part, and a compaction message. Plain JSON, synthetic ids and words, no real title, branch, or path; a Swift test in lane F can read them from the same path.

### Discovered while implementing (affects later PRs)

- With a `tools` registry supplied, the SDK's `validateUIMessages` does **not** refuse an unregistered tool name in a terminal state (`output-available` / `output-error`); it silently converts the part into a `dynamic-tool` part. It refuses only a non-terminal unregistered part. The wrapper therefore checks tool names against the registry itself before the SDK sees the rows, and refuses any `dynamic-tool` part it finds afterwards (a registered tool whose input the schema refused with an empty object is converted the same way). Any later reader that calls the SDK directly (B1's store read, D1) should go through this wrapper or repeat that check.
- The SDK types the `tools` option of `validateUIMessages` for a message whose tool set is known statically; a concrete `tool()` is not assignable to its `Tool<unknown, unknown>` (vercel/ai#9147). The wrapper takes a `ToolSet` and carries one SAFETY-commented assertion at the SDK call.
- The SDK's structural schema strips keys it does not name from parts rather than refusing them (Zod object default). Metadata is not affected: it is read under the wire record schema, which refuses an unknown key at its path.

### CLAUDE.md sentences this contradicts (for G5 to rewrite)

The plan wins per the worker rules; the following in `CLAUDE.md` describe storage this vocabulary replaces:

- "Storage, retention, and conversation maintenance": *"What the brain keeps is one generation per conversation, in one database under one writer, and the generation's shape is the retention rule for the model's context alone."* and *"with a table for each kind of thing the envelope holds — the model's checkpoint items, the transcript cursors, the requests, the action receipts — beside each conversation's own lines"* and *"The envelope holds the Responses input from the latest compaction onward — the API's encrypted compaction item included, which is user-derived data however opaque — the transcript cursors, the record of every developer ask and how it ended, and the action journal that pairs each action with its outcome."* The plan stores one `UIMessage` row per message with parts as JSON, no checkpoint table, the journal as tool-part state on the in-flight message, and compaction as an assistant message with `compaction` metadata.
- "The judgment's parts and its prompt": *"by asking the provider for an explicit compaction and adopting the answered window whole"* and the checkpoint stamp *"(`tool-loop@1:openai-responses-input/1` today)"*: the plan has no provider-side compaction item and no checkpoint.
- "The brain and transcript reads": *"the observation entry and the advanced capture cursor land in one save into the conversation's durable inbox"*: the plan writes an observation as a user message with `source` metadata and advances `provider_cursors` in the same transaction.

Nothing here changes behaviour yet, so `PRIVACY.md` is unchanged. `packages/AGENTS.md` gains the new door in its subpath list.

## Evidence

- Platform-independent checks: `./scripts/check.sh` passed (exit 0) on the final diff: Biome, oxlint anti-slop, knip, every package's typecheck (acyclic graph), all tests (`@sidecar/wire` 7 new, `@sidecar/session` 13 new: fixtures round-trip unchanged; rows typed by role; unknown metadata key refused; wrong role's author refused; system row with metadata refused; unregistered tool refused as `not-registered` at the part's `type` whether answered or pending; `dynamic-tool` refused; registered input held to the Zod schema in `output-available` and `output-error`, including the empty-object and refused-input cases the SDK would otherwise convert; `approval-requested` and `output-denied` refused at `state`; pending and failed journal states admitted), and the web and desktop builds.
- macOS Electron verification (`./scripts/verify.sh`): `not run` — no macOS or UI code changed, and this is a Linux cloud workspace. Inspected instead: the built desktop bundles (`renderer.js`, `voice.js`, `main.js`) contain none of the AI SDK's runtime.

### Physical-device evidence

- Screenshot or screen recording: `not attached` (no UI change)
- Physical-notch check: `not performed` (no UI change)
- Device/display configuration: `not recorded`

## Notes

- Reviews (worker rule 7), both run against this diff as their published SKILL.md files describe them and fixed before merge:
  - **Thermo-nuclear code quality review** (`cursor/plugins`, `cursor-team-kit/skills/thermo-nuclear-code-quality-review`): requested changes on four points, all applied: `StoredUIMessage` is now typed per role with `metadata` required where the schema requires it, replacing a loose union reassembled by a computed spread; the role-to-schema rule is stated once (the `MESSAGE_METADATA_BY_ROLE` table is gone); a comment naming a Swift consumer that does not exist yet is gone; the two SDK conversions the design comment relies on (`output-error` with refused input, `output-denied`) are tested. Of its "consider" items: the user metadata is now the union of the three real shapes it proposed; the two-pass shape (registry pre-check, then SDK, then state check) it verified as the simplest correct one is kept; the reader stays in `@sidecar/session` because the ticket places it there.
  - **Ponytail review** (`DietrichGebert/ponytail`, `skills/ponytail-review`): 14 findings, net -125 lines proposed; applied: inlined the one-use bound and the one-use helper, deleted `toolPartName` and the hand-rolled `isToolPart` in favour of the SDK's `isStaticToolUIPart`, deleted the narrating per-member comments and the single-use key constants, collapsed redundant test assertions and a test that re-read fixture fields, dropped the test of the SDK's own output validation. Not applied, with reasons: the session barrel re-export is what the ticket specifies; `isSettledToolPartState` is the state helper the plan's journal (`finished_at`, resume) names.
- Blockers or follow-up verification: None. Five later PRs block on this one (A6, A7, B1, D1, E1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34531137044/artifacts/10173653144) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34531137044)

- Commit: `6800136d6af04cb6c8e490ab1712bf228265869e`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
