### PR TITLE
feat(LUKE-115): reasoning summaries, response ids, and usage on the run

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -366,10 +366,11 @@ and email you signed it with, and any screenshots you attached.
   most recent lines of your conversation, and the things he remembers about
   you — directly to OpenAI on your own key if you entered one, or through our
   own service on our key when you use Luke through your account. Either way
-  the request asks OpenAI not to store it, and our service performs one model
-  call per request and stores and logs none of the request, the reply, or the
-  encrypted compaction that travels in it; the compaction OpenAI hands back is
-  kept only on your Mac, under the lifetime above. Each call counts against
+  OpenAI stores the request and its reply under its own retention policy, and
+  our service performs one model call per request and stores and logs none of
+  the request, the reply, or the encrypted compaction that travels in it; the
+  compaction OpenAI hands back is kept only on your Mac, under the lifetime
+  above. Each call counts against
   your daily review allowance. When Luke runs through your account, the Mac
   app also sends our service the standing instructions it prepared for the
   call — composed on your Mac from Luke's workspace files described above —

--- a/apps/web/drizzle/0014_a5_run_usage_response_ids.sql
+++ b/apps/web/drizzle/0014_a5_run_usage_response_ids.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "conversation_run" ADD COLUMN "usage" jsonb;--> statement-breakpoint
+ALTER TABLE "conversation_run" ADD COLUMN "response_ids" text[];

--- a/apps/web/drizzle/meta/0014_snapshot.json
+++ b/apps/web/drizzle/meta/0014_snapshot.json
@@ -1,0 +1,3088 @@
+{
+  "id": "bcf8e00f-d8e4-47ca-9e5a-16482b5f0939",
+  "prevId": "e05145f3-64d3-464e-a668-725cc35234b3",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.jwks": {
+      "name": "jwks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_key": {
+          "name": "private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_access_token": {
+      "name": "oauth_access_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_id": {
+          "name": "refresh_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "oauthAccessToken_clientId_idx": {
+          "name": "oauthAccessToken_clientId_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthAccessToken_sessionId_idx": {
+          "name": "oauthAccessToken_sessionId_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthAccessToken_userId_idx": {
+          "name": "oauthAccessToken_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthAccessToken_refreshId_idx": {
+          "name": "oauthAccessToken_refreshId_idx",
+          "columns": [
+            {
+              "expression": "refresh_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_access_token_client_id_oauth_client_client_id_fk": {
+          "name": "oauth_access_token_client_id_oauth_client_client_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "oauth_client",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["client_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_session_id_session_id_fk": {
+          "name": "oauth_access_token_session_id_session_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "session",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_user_id_user_id_fk": {
+          "name": "oauth_access_token_user_id_user_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_refresh_id_oauth_refresh_token_id_fk": {
+          "name": "oauth_access_token_refresh_id_oauth_refresh_token_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "oauth_refresh_token",
+          "columnsFrom": ["refresh_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_access_token_token_unique": {
+          "name": "oauth_access_token_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_client": {
+      "name": "oauth_client",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "skip_consent": {
+          "name": "skip_consent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enable_end_session": {
+          "name": "enable_end_session",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject_type": {
+          "name": "subject_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contacts": {
+          "name": "contacts",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tos": {
+          "name": "tos",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "policy": {
+          "name": "policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_id": {
+          "name": "software_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_version": {
+          "name": "software_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_statement": {
+          "name": "software_statement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_logout_redirect_uris": {
+          "name": "post_logout_redirect_uris",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_endpoint_auth_method": {
+          "name": "token_endpoint_auth_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grant_types": {
+          "name": "grant_types",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_types": {
+          "name": "response_types",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public": {
+          "name": "public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "require_pkce": {
+          "name": "require_pkce",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "oauthClient_userId_idx": {
+          "name": "oauthClient_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_client_user_id_user_id_fk": {
+          "name": "oauth_client_user_id_user_id_fk",
+          "tableFrom": "oauth_client",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_client_client_id_unique": {
+          "name": "oauth_client_client_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["client_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_consent": {
+      "name": "oauth_consent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "oauthConsent_clientId_idx": {
+          "name": "oauthConsent_clientId_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthConsent_userId_idx": {
+          "name": "oauthConsent_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_consent_client_id_oauth_client_client_id_fk": {
+          "name": "oauth_consent_client_id_oauth_client_client_id_fk",
+          "tableFrom": "oauth_consent",
+          "tableTo": "oauth_client",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["client_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_consent_user_id_user_id_fk": {
+          "name": "oauth_consent_user_id_user_id_fk",
+          "tableFrom": "oauth_consent",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_refresh_token": {
+      "name": "oauth_refresh_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked": {
+          "name": "revoked",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_time": {
+          "name": "auth_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "oauthRefreshToken_clientId_idx": {
+          "name": "oauthRefreshToken_clientId_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthRefreshToken_sessionId_idx": {
+          "name": "oauthRefreshToken_sessionId_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthRefreshToken_userId_idx": {
+          "name": "oauthRefreshToken_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_refresh_token_client_id_oauth_client_client_id_fk": {
+          "name": "oauth_refresh_token_client_id_oauth_client_client_id_fk",
+          "tableFrom": "oauth_refresh_token",
+          "tableTo": "oauth_client",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["client_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_refresh_token_session_id_session_id_fk": {
+          "name": "oauth_refresh_token_session_id_session_id_fk",
+          "tableFrom": "oauth_refresh_token",
+          "tableTo": "session",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "oauth_refresh_token_user_id_user_id_fk": {
+          "name": "oauth_refresh_token_user_id_user_id_fk",
+          "tableFrom": "oauth_refresh_token",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_refresh_token_token_unique": {
+          "name": "oauth_refresh_token_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_login_method": {
+          "name": "last_login_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'user'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.briefing": {
+      "name": "briefing",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_key": {
+          "name": "session_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sealed_words": {
+          "name": "sealed_words",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claimed_by_device_id": {
+          "name": "claimed_by_device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settled_at": {
+          "name": "settled_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "briefing_by_user_state": {
+          "name": "briefing_by_user_state",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "decided_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "briefing_user_id_user_id_fk": {
+          "name": "briefing_user_id_user_id_fk",
+          "tableFrom": "briefing",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "briefing_user_id_id_pk": {
+          "name": "briefing_user_id_id_pk",
+          "columns": ["user_id", "id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.action_receipt": {
+      "name": "action_receipt",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "call_id": {
+          "name": "call_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ordinal": {
+          "name": "ordinal",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sealed_arguments": {
+          "name": "sealed_arguments",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sealed_output": {
+          "name": "sealed_output",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settled_at": {
+          "name": "settled_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "action_receipt_by_session": {
+          "name": "action_receipt_by_session",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ordinal",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "action_receipt_session_fk": {
+          "name": "action_receipt_session_fk",
+          "tableFrom": "action_receipt",
+          "tableTo": "conversation_session",
+          "columnsFrom": ["user_id", "session_id"],
+          "columnsTo": ["user_id", "session_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "action_receipt_user_id_run_id_call_id_pk": {
+          "name": "action_receipt_user_id_run_id_call_id_pk",
+          "columns": ["user_id", "run_id", "call_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.compaction_boundary": {
+      "name": "compaction_boundary",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_key": {
+          "name": "session_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transcript_sequence": {
+          "name": "transcript_sequence",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dropped": {
+          "name": "dropped",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "checkpoint_format": {
+          "name": "checkpoint_format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "compaction_boundary_conversation_fk": {
+          "name": "compaction_boundary_conversation_fk",
+          "tableFrom": "compaction_boundary",
+          "tableTo": "conversation",
+          "columnsFrom": ["user_id", "session_key"],
+          "columnsTo": ["user_id", "session_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "compaction_boundary_user_id_session_key_transcript_sequence_pk": {
+          "name": "compaction_boundary_user_id_session_key_transcript_sequence_pk",
+          "columns": ["user_id", "session_key", "transcript_sequence"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation": {
+      "name": "conversation",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_key": {
+          "name": "session_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "next_line_sequence": {
+          "name": "next_line_sequence",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "next_transcript_sequence": {
+          "name": "next_transcript_sequence",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "cleared_at": {
+          "name": "cleared_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "conversation_user_id_user_id_fk": {
+          "name": "conversation_user_id_user_id_fk",
+          "tableFrom": "conversation",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "conversation_user_id_session_key_pk": {
+          "name": "conversation_user_id_session_key_pk",
+          "columns": ["user_id", "session_key"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation_line": {
+      "name": "conversation_line",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_key": {
+          "name": "session_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_key": {
+          "name": "event_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recorded_at": {
+          "name": "recorded_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_session_id": {
+          "name": "provider_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sealed_payload": {
+          "name": "sealed_payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "conversation_line_by_key": {
+          "name": "conversation_line_by_key",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_line_by_time": {
+          "name": "conversation_line_by_time",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recorded_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sequence",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_line_once_published": {
+          "name": "conversation_line_once_published",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"conversation_line\".\"request_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_line_conversation_fk": {
+          "name": "conversation_line_conversation_fk",
+          "tableFrom": "conversation_line",
+          "tableTo": "conversation",
+          "columnsFrom": ["user_id", "session_key"],
+          "columnsTo": ["user_id", "session_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "conversation_line_user_id_session_key_sequence_pk": {
+          "name": "conversation_line_user_id_session_key_sequence_pk",
+          "columns": ["user_id", "session_key", "sequence"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation_run": {
+      "name": "conversation_run",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ordinal": {
+          "name": "ordinal",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submission_id": {
+          "name": "submission_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "origin": {
+          "name": "origin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sealed_question": {
+          "name": "sealed_question",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revision": {
+          "name": "revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settled_at": {
+          "name": "settled_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sealed_text": {
+          "name": "sealed_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure": {
+          "name": "failure",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "performed_actions": {
+          "name": "performed_actions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unknown_actions": {
+          "name": "unknown_actions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ask_recorded_at": {
+          "name": "ask_recorded_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conversation_recorded_at": {
+          "name": "conversation_recorded_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage": {
+          "name": "usage",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_ids": {
+          "name": "response_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_origin": {
+          "name": "run_origin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ending": {
+          "name": "ending",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_item_kinds": {
+          "name": "input_item_kinds",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transcript_bytes": {
+          "name": "transcript_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "elapsed_ms": {
+          "name": "elapsed_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_names": {
+          "name": "tool_names",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "compacted": {
+          "name": "compacted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "conversation_run_by_session": {
+          "name": "conversation_run_by_session",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ordinal",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_run_session_fk": {
+          "name": "conversation_run_session_fk",
+          "tableFrom": "conversation_run",
+          "tableTo": "conversation_session",
+          "columnsFrom": ["user_id", "session_id"],
+          "columnsTo": ["user_id", "session_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "conversation_run_user_id_run_id_pk": {
+          "name": "conversation_run_user_id_run_id_pk",
+          "columns": ["user_id", "run_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation_session": {
+      "name": "conversation_session",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_key": {
+          "name": "session_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reset_cleared_at": {
+          "name": "reset_cleared_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reset_generation_id": {
+          "name": "reset_generation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checkpoint_format": {
+          "name": "checkpoint_format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "compaction_count": {
+          "name": "compaction_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "conversation_session_one_standing": {
+          "name": "conversation_session_one_standing",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_session_conversation_fk": {
+          "name": "conversation_session_conversation_fk",
+          "tableFrom": "conversation_session",
+          "tableTo": "conversation",
+          "columnsFrom": ["user_id", "session_key"],
+          "columnsTo": ["user_id", "session_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "conversation_session_user_id_session_id_pk": {
+          "name": "conversation_session_user_id_session_id_pk",
+          "columns": ["user_id", "session_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.observation_capture_cursor": {
+      "name": "observation_capture_cursor",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_session_id": {
+          "name": "provider_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cursor": {
+          "name": "cursor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "observation_capture_cursor_session_fk": {
+          "name": "observation_capture_cursor_session_fk",
+          "tableFrom": "observation_capture_cursor",
+          "tableTo": "conversation_session",
+          "columnsFrom": ["user_id", "session_id"],
+          "columnsTo": ["user_id", "session_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "observation_capture_cursor_user_id_session_id_provider_id_provider_session_id_pk": {
+          "name": "observation_capture_cursor_user_id_session_id_provider_id_provider_session_id_pk",
+          "columns": ["user_id", "session_id", "provider_id", "provider_session_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.observation_cursor": {
+      "name": "observation_cursor",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_session_id": {
+          "name": "provider_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cursor": {
+          "name": "cursor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "observation_cursor_session_fk": {
+          "name": "observation_cursor_session_fk",
+          "tableFrom": "observation_cursor",
+          "tableTo": "conversation_session",
+          "columnsFrom": ["user_id", "session_id"],
+          "columnsTo": ["user_id", "session_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "observation_cursor_user_id_session_id_provider_id_provider_session_id_pk": {
+          "name": "observation_cursor_user_id_session_id_provider_id_provider_session_id_pk",
+          "columns": ["user_id", "session_id", "provider_id", "provider_session_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.observation_inbox_entry": {
+      "name": "observation_inbox_entry",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ordinal": {
+          "name": "ordinal",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entry_id": {
+          "name": "entry_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sealed_payload": {
+          "name": "sealed_payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "observation_inbox_entry_session_fk": {
+          "name": "observation_inbox_entry_session_fk",
+          "tableFrom": "observation_inbox_entry",
+          "tableTo": "conversation_session",
+          "columnsFrom": ["user_id", "session_id"],
+          "columnsTo": ["user_id", "session_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "observation_inbox_entry_user_id_session_id_ordinal_pk": {
+          "name": "observation_inbox_entry_user_id_session_id_ordinal_pk",
+          "columns": ["user_id", "session_id", "ordinal"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.runtime_checkpoint": {
+      "name": "runtime_checkpoint",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sealed_item": {
+          "name": "sealed_item",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "runtime_checkpoint_session_fk": {
+          "name": "runtime_checkpoint_session_fk",
+          "tableFrom": "runtime_checkpoint",
+          "tableTo": "conversation_session",
+          "columnsFrom": ["user_id", "session_id"],
+          "columnsTo": ["user_id", "session_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "runtime_checkpoint_user_id_session_id_sequence_pk": {
+          "name": "runtime_checkpoint_user_id_session_id_sequence_pk",
+          "columns": ["user_id", "session_id", "sequence"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transcript_event": {
+      "name": "transcript_event",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_key": {
+          "name": "session_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recorded_at": {
+          "name": "recorded_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sealed_payload": {
+          "name": "sealed_payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "transcript_event_conversation_fk": {
+          "name": "transcript_event_conversation_fk",
+          "tableFrom": "transcript_event",
+          "tableTo": "conversation",
+          "columnsFrom": ["user_id", "session_key"],
+          "columnsTo": ["user_id", "session_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "transcript_event_user_id_session_key_sequence_pk": {
+          "name": "transcript_event_user_id_session_key_sequence_pk",
+          "columns": ["user_id", "session_key", "sequence"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.devices": {
+      "name": "devices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "active_until": {
+          "name": "active_until",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "push_token": {
+          "name": "push_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "push_environment": {
+          "name": "push_environment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "devices_user_id_user_id_fk": {
+          "name": "devices_user_id_user_id_fk",
+          "tableFrom": "devices",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "devices_installation_id_unique": {
+          "name": "devices_installation_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["installation_id"]
+        },
+        "devices_push_token_unique": {
+          "name": "devices_push_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["push_token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.admin_favorite": {
+      "name": "admin_favorite",
+      "schema": "",
+      "columns": {
+        "admin_id": {
+          "name": "admin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "admin_favorite_admin_id_user_id_fk": {
+          "name": "admin_favorite_admin_id_user_id_fk",
+          "tableFrom": "admin_favorite",
+          "tableTo": "user",
+          "columnsFrom": ["admin_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "admin_favorite_user_id_user_id_fk": {
+          "name": "admin_favorite_user_id_user_id_fk",
+          "tableFrom": "admin_favorite",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "admin_favorite_admin_id_user_id_pk": {
+          "name": "admin_favorite_admin_id_user_id_pk",
+          "columns": ["admin_id", "user_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.account_preference": {
+      "name": "account_preference",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "voice": {
+          "name": "voice",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "voice_speed": {
+          "name": "voice_speed",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_workspace_provider": {
+          "name": "default_workspace_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_preference_user_id_user_id_fk": {
+          "name": "account_preference_user_id_user_id_fk",
+          "tableFrom": "account_preference",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.account_workspace_preference": {
+      "name": "account_workspace_preference",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_project_id": {
+          "name": "default_project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent": {
+          "name": "agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "effort": {
+          "name": "effort",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_workspace_preference_user_id_user_id_fk": {
+          "name": "account_workspace_preference_user_id_user_id_fk",
+          "tableFrom": "account_workspace_preference",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "account_workspace_preference_user_id_provider_id_pk": {
+          "name": "account_workspace_preference_user_id_provider_id_pk",
+          "columns": ["user_id", "provider_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.observation_pass": {
+      "name": "observation_pass",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "attempted_at": {
+          "name": "attempted_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure": {
+          "name": "failure",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "observation_pass_user_id_user_id_fk": {
+          "name": "observation_pass_user_id_user_id_fk",
+          "tableFrom": "observation_pass",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.roster_diff": {
+      "name": "roster_diff",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previous_observed_at": {
+          "name": "previous_observed_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sealed_payload": {
+          "name": "sealed_payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "roster_diff_by_user_pending": {
+          "name": "roster_diff_by_user_pending",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "consumed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "observed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "roster_diff_user_id_user_id_fk": {
+          "name": "roster_diff_user_id_user_id_fk",
+          "tableFrom": "roster_diff",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "roster_diff_user_id_id_pk": {
+          "name": "roster_diff_user_id_id_pk",
+          "columns": ["user_id", "id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.roster_snapshot": {
+      "name": "roster_snapshot",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "sealed_body": {
+          "name": "sealed_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "roster_snapshot_user_id_user_id_fk": {
+          "name": "roster_snapshot_user_id_user_id_fk",
+          "tableFrom": "roster_snapshot",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.hosted_usage": {
+      "name": "hosted_usage",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "day": {
+          "name": "day",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "calls": {
+          "name": "calls",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "voice_seconds": {
+          "name": "voice_seconds",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "hosted_usage_user_id_user_id_fk": {
+          "name": "hosted_usage_user_id_user_id_fk",
+          "tableFrom": "hosted_usage",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "hosted_usage_user_id_day_pk": {
+          "name": "hosted_usage_user_id_day_pk",
+          "columns": ["user_id", "day"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.introduction_usage": {
+      "name": "introduction_usage",
+      "schema": "",
+      "columns": {
+        "caller": {
+          "name": "caller",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "day": {
+          "name": "day",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mints": {
+          "name": "mints",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "introduction_usage_caller_day_pk": {
+          "name": "introduction_usage_caller_day_pk",
+          "columns": ["caller", "day"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.voice_session_usage": {
+      "name": "voice_session_usage",
+      "schema": "",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seconds": {
+          "name": "seconds",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recorded_at": {
+          "name": "recorded_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "voice_session_usage_user_id_user_id_fk": {
+          "name": "voice_session_usage_user_id_user_id_fk",
+          "tableFrom": "voice_session_usage",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provider_key": {
+      "name": "provider_key",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ciphertext": {
+          "name": "ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "provider_key_user_id_user_id_fk": {
+          "name": "provider_key_user_id_user_id_fk",
+          "tableFrom": "provider_key",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "provider_key_user_id_provider_id_pk": {
+          "name": "provider_key_user_id_provider_id_pk",
+          "columns": ["user_id", "provider_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.personal_fact": {
+      "name": "personal_fact",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ordinal": {
+          "name": "ordinal",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sealed_words": {
+          "name": "sealed_words",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "personal_fact_user_id_user_id_fk": {
+          "name": "personal_fact_user_id_user_id_fk",
+          "tableFrom": "personal_fact",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "personal_fact_user_id_id_pk": {
+          "name": "personal_fact_user_id_id_pk",
+          "columns": ["user_id", "id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspace_file": {
+      "name": "workspace_file",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sealed_content": {
+          "name": "sealed_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workspace_file_user_id_user_id_fk": {
+          "name": "workspace_file_user_id_user_id_fk",
+          "tableFrom": "workspace_file",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "workspace_file_user_id_path_pk": {
+          "name": "workspace_file_user_id_path_pk",
+          "columns": ["user_id", "path"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/web/drizzle/meta/_journal.json
+++ b/apps/web/drizzle/meta/_journal.json
@@ -99,6 +99,13 @@
       "when": 1789070771878,
       "tag": "0013_amusing_shape",
       "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "7",
+      "when": 1789073559193,
+      "tag": "0014_a5_run_usage_response_ids",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/web/server/README.md
+++ b/apps/web/server/README.md
@@ -244,7 +244,9 @@ cut, the input array is capped at 2,000 items each of which must take one of
 the forms the brain replays, and every tool name must be one this service
 registers a schema for, so a caller can never upload a schema. The service
 then fixes the model, the upstream, its credential, the output budget's
-ceiling, and `store: false` from its own build and posts once. An inference's
+ceiling, and the reasoning summary from its own build and posts once, leaving
+OpenAI's `store` at its default so the response stands with OpenAI under its
+own retention, named back by the id the desktop keeps on the run. An inference's
 answer is handed down as it came, once it is known to be a Responses payload
 every item of which the same admission would replay next turn; an answer this
 route could not replay is a 502, because the client would keep it verbatim and

--- a/apps/web/server/db/conversation-schema.ts
+++ b/apps/web/server/db/conversation-schema.ts
@@ -5,6 +5,7 @@ import {
   foreignKey,
   index,
   integer,
+  jsonb,
   pgTable,
   primaryKey,
   text,
@@ -203,6 +204,10 @@ export const conversationRun = pgTable(
     unknownActions: integer("unknown_actions").notNull(),
     askRecordedAt: bigint("ask_recorded_at", { mode: "number" }),
     conversationRecordedAt: bigint("conversation_recorded_at", { mode: "number" }),
+    /** The run's inference cost so far, split four ways as the record keeps it. */
+    usage: jsonb("usage"),
+    /** The id of every response OpenAI answered the run with, in order. */
+    responseIds: text("response_ids").array(),
     trigger: text("trigger"),
     runOrigin: text("run_origin"),
     ending: text("ending"),

--- a/apps/web/server/hosted/brain-v2.ts
+++ b/apps/web/server/hosted/brain-v2.ts
@@ -55,7 +55,7 @@ import type { HostedSpend } from "./quota.js";
  * envelope, and names the tools it means to offer, each a name this service
  * registers a schema for — a caller can never upload a schema, and a name the
  * catalog does not hold refuses the request. The service fixes the model, the
- * upstream, its credential, the refusal to store, and the bounds, answers its
+ * upstream, its credential, the reasoning summary, and the bounds, answers its
  * capabilities so a desktop can decide before sending anything, and posts each
  * operation once: an inference, a token count, or an explicit compaction whose
  * answered window the desktop adopts whole. It runs no tool, keeps no

--- a/apps/web/server/hosted/store/brain-envelope.ts
+++ b/apps/web/server/hosted/store/brain-envelope.ts
@@ -10,6 +10,7 @@ import {
   brainPersistedStateFromWire,
   SAVE_KIND,
   type SessionKey,
+  type UnparsedWireValue,
   type WireRecord,
   type WireValue,
 } from "../../core.js";
@@ -464,6 +465,8 @@ async function upsertRequest(
     unknownActions: record.unknownActions,
     askRecordedAt: nullable(record.askRecordedAt),
     conversationRecordedAt: nullable(record.conversationRecordedAt),
+    usage: nullable(record.usage),
+    responseIds: record.responseIds === undefined ? null : [...record.responseIds],
   };
   await db
     .insert(conversationRun)
@@ -514,6 +517,9 @@ function requestWire(seal: UserSeal, row: typeof conversationRun.$inferSelect): 
     ...optionalField("failure", row.failure),
     ...optionalField("askRecordedAt", row.askRecordedAt),
     ...optionalField("conversationRecordedAt", row.conversationRecordedAt),
+    // SAFETY: jsonb answers the JSON it stored; the envelope reader validates the usage's shape.
+    ...optionalField("usage", row.usage === null ? null : (row.usage as UnparsedWireValue)),
+    ...optionalField("responseIds", row.responseIds),
   };
 }
 

--- a/apps/web/tests/hosted-brain-v2.test.ts
+++ b/apps/web/tests/hosted-brain-v2.test.ts
@@ -4,6 +4,7 @@ import {
   BRAIN_OPENAI_DEFAULTS,
   BRAIN_RATE_LIMIT_COOLDOWN_MS,
   BRAIN_RATE_LIMIT_RETRY_AFTER_BOUND_MS,
+  BRAIN_REASONING_SUMMARY,
   BRAIN_TOOL,
   HOSTED_BRAIN_CONTRACT_VERSION,
   HOSTED_BRAIN_OPERATION,
@@ -179,9 +180,9 @@ test("a respond request runs the prepared prompt over the schemas its names sele
   assert.equal(calls[0]?.url, `${BRAIN_OPENAI_DEFAULTS.BASE_URL}/responses`);
   assert.equal(sent.model, HOSTED_BRAIN_DEFAULTS.MODEL);
   assert.equal(sent.instructions, "You are Luke.");
-  assert.equal(sent.store, false);
+  assert.equal("store" in sent, false);
   assert.equal(sent.max_output_tokens, 900);
-  assert.deepEqual(sent.reasoning, { effort: "low" });
+  assert.deepEqual(sent.reasoning, { effort: "low", summary: BRAIN_REASONING_SUMMARY });
   assert.ok(Array.isArray(sent.tools));
   assert.deepEqual(
     sent.tools.map((tool) => (isRecord(tool) ? tool.name : undefined)),
@@ -211,7 +212,7 @@ test("a request's prompt cache key is forwarded upstream and kept nowhere", asyn
   );
   assert.equal(response.status, 200);
   assert.equal(calls[0]?.body?.prompt_cache_key, "9f86d0818");
-  assert.equal(calls[0]?.body?.store, false);
+  assert.equal(calls[0]?.body !== undefined && "store" in calls[0].body, false);
 });
 
 test("each refusal answers its own error before anything is spent: prompt envelope, unknown tool, bounds, shape, size", async () => {

--- a/apps/web/tests/hosted-store.test.ts
+++ b/apps/web/tests/hosted-store.test.ts
@@ -544,17 +544,27 @@ test("a run's about-fields land on its row, survive a record upsert, and answer 
   assert.deepEqual(await database.store.runs.about(userId, "run-1"), about);
   assert.equal(await database.store.runs.recordAbout(userId, "run-missing", about), false);
 
+  const usage = {
+    inputTokens: 1900,
+    outputTokens: 50,
+    cachedInputTokens: 1664,
+    reasoningTokens: 30,
+  };
   await repository.save({
     ...state,
     requests: state.requests.map((record) =>
-      record.runId === "run-1" ? { ...record, revision: 2, text: "amended" } : record,
+      record.runId === "run-1"
+        ? { ...record, revision: 2, text: "amended", usage, responseIds: ["resp_1", "resp_2"] }
+        : record,
     ),
   });
   assert.deepEqual(await database.store.runs.about(userId, "run-1"), about);
-  assert.equal(
-    (await repository.load()).state?.requests.find((record) => record.runId === "run-1")?.text,
-    "amended",
+  const amended = (await repository.load()).state?.requests.find(
+    (record) => record.runId === "run-1",
   );
+  assert.equal(amended?.text, "amended");
+  assert.deepEqual(amended?.usage, usage);
+  assert.deepEqual(amended?.responseIds, ["resp_1", "resp_2"]);
 });
 
 test("facts are listed in order and replaced whole, a kept id keeping its first instant, and sealed at rest", async () => {

--- a/packages/brain/src/agent.ts
+++ b/packages/brain/src/agent.ts
@@ -256,6 +256,8 @@ export class BrainAgent {
           status: record.status,
           ...(record.text !== undefined ? { text: record.text } : undefined),
           ...(record.failure !== undefined ? { failure: record.failure } : undefined),
+          ...(record.usage !== undefined ? { usage: record.usage } : undefined),
+          ...(record.responseIds !== undefined ? { responseIds: record.responseIds } : undefined),
         }),
     });
     const seam: AgentSeam = {

--- a/packages/brain/src/harness.ts
+++ b/packages/brain/src/harness.ts
@@ -154,6 +154,26 @@ export function answered(output: readonly WireRecord[], inputTokens = 100): Brai
   return answer;
 }
 
+/** An answer as OpenAI stores it: under a response id, with every count the provider reports. */
+export function answeredUnder(
+  responseId: string,
+  output: readonly WireRecord[],
+  usage: { input: number; output: number; cached: number; reasoning: number },
+): BrainClientAnswer {
+  const answer = responsesModelAnswer({
+    id: responseId,
+    output,
+    usage: {
+      input_tokens: usage.input,
+      output_tokens: usage.output,
+      input_tokens_details: { cached_tokens: usage.cached },
+      output_tokens_details: { reasoning_tokens: usage.reasoning },
+    },
+  });
+  assert.ok(answer);
+  return answer;
+}
+
 export function quietAnswer(until: number): BrainClientAnswer {
   return { outcome: MODEL_RESPONSE_OUTCOME.THROTTLED, until };
 }

--- a/packages/brain/src/index.ts
+++ b/packages/brain/src/index.ts
@@ -59,9 +59,11 @@ export {
   BRAIN_REQUEST_STATUS,
   BRAIN_SUBMISSION_OUTCOME,
   type BrainRequestRecord,
+  type BrainRunUsage,
   type BrainSubmission,
 } from "./requests.js";
 export {
+  BRAIN_REASONING_SUMMARY,
   BRAIN_RESPONSES_COMPACT_PATH,
   BRAIN_RESPONSES_INPUT_TOKENS_PATH,
   BRAIN_RESPONSES_PATH,

--- a/packages/brain/src/ledger.ts
+++ b/packages/brain/src/ledger.ts
@@ -25,6 +25,14 @@ import type { RunControl, TurnContext } from "./turn.js";
  * work is deciding which save a caller means and what its answer says.
  */
 
+/** What a run's inferences have cost and been answered under so far, as its record keeps them; nothing before the first answer. */
+function runAccounting(run: RunControl): Pick<RecordChanges, "usage" | "responseIds"> {
+  return {
+    ...(run.usage !== undefined ? { usage: run.usage } : undefined),
+    ...(run.responseIds.length > 0 ? { responseIds: [...run.responseIds] } : undefined),
+  };
+}
+
 /** The two markers the host's thread writes onto a run, each once. */
 export const PENDING_MARK_FIELD = {
   ASK_RECORDED_AT: "askRecordedAt",
@@ -145,6 +153,7 @@ export class BrainRequestLedger {
                 changes: {
                   performedActions: run.performedActions,
                   unknownActions: run.unknownActions,
+                  ...runAccounting(run),
                 },
               },
             }
@@ -212,7 +221,11 @@ export class BrainRequestLedger {
       ...(end.text !== undefined ? { text: end.text } : undefined),
       ...(end.failure !== undefined ? { failure: end.failure } : undefined),
       ...(run
-        ? { performedActions: run.performedActions, unknownActions: run.unknownActions }
+        ? {
+            performedActions: run.performedActions,
+            unknownActions: run.unknownActions,
+            ...runAccounting(run),
+          }
         : undefined),
     };
     if (await this.commit(generation, runId, settled)) {

--- a/packages/brain/src/openai-model-adapter.test.ts
+++ b/packages/brain/src/openai-model-adapter.test.ts
@@ -4,7 +4,7 @@ import { MODEL_FAILURE, MODEL_RESPONSE_OUTCOME } from "@sidecar/runtime/vocabula
 import { isRecord, type UnparsedWireValue } from "@sidecar/wire";
 import { BRAIN_RATE_LIMIT_COOLDOWN_MS } from "./model-adapter-shared.js";
 import { OpenAiModelAdapter, openAiModelAdapter } from "./openai-model-adapter.js";
-import { userMessageItem } from "./responses-api.js";
+import { BRAIN_REASONING_SUMMARY, userMessageItem } from "./responses-api.js";
 import { brainToolCatalog, brainToolSchemas, resolveTurnToolPolicy } from "./tools.js";
 import { BRAIN_TURN_TRIGGER } from "./turn.js";
 
@@ -70,8 +70,8 @@ test("respond posts the fixed request on the developer's key and normalizes the 
   assert.equal(new Headers(call.init.headers).get("authorization"), "Bearer sk-test");
   assert.equal(call.body.model, "gpt-test");
   assert.equal(call.body.instructions, "instructions");
-  assert.equal(call.body.store, false);
-  assert.deepEqual(call.body.reasoning, { effort: "medium" });
+  assert.equal("store" in call.body, false);
+  assert.deepEqual(call.body.reasoning, { effort: "medium", summary: BRAIN_REASONING_SUMMARY });
   assert.equal(call.body.max_output_tokens, 500);
   assert.equal("context_management" in call.body, false);
   assert.equal("prompt_cache_key" in call.body, false);

--- a/packages/brain/src/requests.test.ts
+++ b/packages/brain/src/requests.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import {
+  addModelUsage,
   BRAIN_REQUEST_FAILURE,
   BRAIN_REQUEST_ORIGIN,
   BRAIN_REQUEST_STATUS,
@@ -29,6 +30,8 @@ test("a request record survives the wire whole, with every optional field presen
     failure: BRAIN_REQUEST_FAILURE.MODEL,
     performedActions: 1,
     unknownActions: 0,
+    usage: { inputTokens: 1200, outputTokens: 80, cachedInputTokens: 1024, reasoningTokens: 40 },
+    responseIds: ["resp_1", "resp_2"],
     askRecordedAt: NOW,
     conversationRecordedAt: NOW + 2,
   };
@@ -48,6 +51,37 @@ test("a request record survives the wire whole, with every optional field presen
     assert.deepEqual(brainRequestRecordFromWire(wire), record);
     assert.deepEqual(Object.keys(wire).sort(), Object.keys(record).sort());
   }
+  // A usage missing one of its four counts, or a response id that is not a
+  // non-empty string, is a record this build cannot vouch for, not a partial one.
+  const wire = brainRequestRecordToWire(full);
+  assert.equal(
+    brainRequestRecordFromWire({
+      ...wire,
+      usage: { inputTokens: 1, outputTokens: 1, cachedInputTokens: 1 },
+    }),
+    undefined,
+  );
+  assert.equal(brainRequestRecordFromWire({ ...wire, responseIds: ["resp_1", ""] }), undefined);
+  assert.equal(brainRequestRecordFromWire({ ...wire, responseIds: "resp_1" }), undefined);
+});
+
+test("a run's usage sums each answer's counts four ways, a count the provider left out adding nothing", () => {
+  const first = addModelUsage(undefined, { inputTokens: 500, outputTokens: 20 });
+  assert.deepEqual(first, {
+    inputTokens: 500,
+    outputTokens: 20,
+    cachedInputTokens: 0,
+    reasoningTokens: 0,
+  });
+  assert.deepEqual(
+    addModelUsage(first, {
+      inputTokens: 700,
+      outputTokens: 30,
+      cachedInputTokens: 512,
+      reasoningTokens: 25,
+    }),
+    { inputTokens: 1200, outputTokens: 50, cachedInputTokens: 512, reasoningTokens: 25 },
+  );
 });
 
 test("a plain stop has no reply words and leaves the quiet line; one that had acted keeps its account", () => {

--- a/packages/brain/src/requests.ts
+++ b/packages/brain/src/requests.ts
@@ -1,3 +1,4 @@
+import type { ModelUsage } from "@sidecar/runtime/vocabulary";
 import {
   isRecord,
   isWireNumber,
@@ -103,6 +104,63 @@ function isBrainRequestFailure(value: UnparsedWireValue): value is BrainRequestF
   return isWireString(value) && BRAIN_REQUEST_FAILURE_LIST.includes(value as BrainRequestFailure);
 }
 
+/**
+ * What a run's inferences cost, summed over every answer the run was given
+ * and split the four ways the provider counts: the input the model read, the
+ * output it wrote, how much of the input its prefix cache answered, and how
+ * much of the output was reasoning before the words. A count the provider
+ * did not say adds nothing, so every field is a number from the first answer.
+ */
+export interface BrainRunUsage {
+  inputTokens: number;
+  outputTokens: number;
+  cachedInputTokens: number;
+  reasoningTokens: number;
+}
+
+/** One answer's counts added onto a run's so far (nothing, before its first answer), each missing count counting as nothing. */
+export function addModelUsage(total: BrainRunUsage | undefined, usage: ModelUsage): BrainRunUsage {
+  return {
+    inputTokens: (total?.inputTokens ?? 0) + (usage.inputTokens ?? 0),
+    outputTokens: (total?.outputTokens ?? 0) + (usage.outputTokens ?? 0),
+    cachedInputTokens: (total?.cachedInputTokens ?? 0) + (usage.cachedInputTokens ?? 0),
+    reasoningTokens: (total?.reasoningTokens ?? 0) + (usage.reasoningTokens ?? 0),
+  };
+}
+
+function brainRunUsageFromWire(value: UnparsedWireValue): BrainRunUsage | undefined {
+  if (!isRecord(value)) return undefined;
+  const { inputTokens, outputTokens, cachedInputTokens, reasoningTokens } = value;
+  if (
+    !finiteNumber(inputTokens) ||
+    !finiteNumber(outputTokens) ||
+    !finiteNumber(cachedInputTokens) ||
+    !finiteNumber(reasoningTokens)
+  ) {
+    return undefined;
+  }
+  return { inputTokens, outputTokens, cachedInputTokens, reasoningTokens };
+}
+
+function brainRunUsageToWire(usage: BrainRunUsage): WireRecord {
+  return {
+    inputTokens: usage.inputTokens,
+    outputTokens: usage.outputTokens,
+    cachedInputTokens: usage.cachedInputTokens,
+    reasoningTokens: usage.reasoningTokens,
+  };
+}
+
+function responseIdsFromWire(value: UnparsedWireValue): readonly string[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const ids: string[] = [];
+  for (const id of value) {
+    if (!isWireString(id) || id.length === 0) return undefined;
+    ids.push(id);
+  }
+  return ids;
+}
+
 export interface BrainRequestRecord {
   /** The run's own id, minted by the brain at acceptance. */
   runId: string;
@@ -129,6 +187,10 @@ export interface BrainRequestRecord {
    * happened, so none is retried and the developer is told as much.
    */
   unknownActions: number;
+  /** What the run's inferences cost so far, summed; absent until its first answer. */
+  usage?: BrainRunUsage;
+  /** The id of every response OpenAI answered the run with, in order, as OpenAI stores them. */
+  responseIds?: readonly string[];
   /** When the host recorded the ask itself in the thread, for an origin whose words the host records. */
   askRecordedAt?: number;
   /** When the host recorded the run's end in the thread, so it is recorded exactly once. */
@@ -159,6 +221,11 @@ export function brainRequestRecordFromWire(
   if (value.settledAt !== undefined && !finiteNumber(value.settledAt)) return undefined;
   if (value.text !== undefined && !isWireString(value.text)) return undefined;
   if (value.failure !== undefined && !isBrainRequestFailure(value.failure)) return undefined;
+  const usage = value.usage === undefined ? undefined : brainRunUsageFromWire(value.usage);
+  if (value.usage !== undefined && !usage) return undefined;
+  const responseIds =
+    value.responseIds === undefined ? undefined : responseIdsFromWire(value.responseIds);
+  if (value.responseIds !== undefined && !responseIds) return undefined;
   const record: BrainRequestRecord = {
     runId,
     submissionId,
@@ -177,6 +244,8 @@ export function brainRequestRecordFromWire(
   if (value.settledAt !== undefined) record.settledAt = value.settledAt;
   if (value.text !== undefined) record.text = value.text;
   if (value.failure !== undefined) record.failure = value.failure;
+  if (usage !== undefined) record.usage = usage;
+  if (responseIds !== undefined) record.responseIds = responseIds;
   return record;
 }
 
@@ -196,6 +265,8 @@ export function brainRequestRecordToWire(record: BrainRequestRecord): WireRecord
     ...(record.failure !== undefined ? { failure: record.failure } : undefined),
     performedActions: record.performedActions,
     unknownActions: record.unknownActions,
+    ...(record.usage !== undefined ? { usage: brainRunUsageToWire(record.usage) } : undefined),
+    ...(record.responseIds !== undefined ? { responseIds: [...record.responseIds] } : undefined),
     ...(record.askRecordedAt !== undefined ? { askRecordedAt: record.askRecordedAt } : undefined),
     ...(record.conversationRecordedAt !== undefined
       ? { conversationRecordedAt: record.conversationRecordedAt }

--- a/packages/brain/src/responses-api.test.ts
+++ b/packages/brain/src/responses-api.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 import { MODEL_FAILURE, MODEL_RESPONSE_OUTCOME } from "@sidecar/runtime/vocabulary";
 import {
   BRAIN_REASONING_EFFORT,
+  BRAIN_REASONING_SUMMARY,
   brainResponsesOutput,
   brainResponsesRequest,
   functionCallOutputItem,
@@ -12,7 +13,7 @@ import {
 } from "./responses-api.js";
 import { BRAIN_TOOL, hostedBrainToolCatalog } from "./tools.js";
 
-test("the request asks the API for no compaction of its own, stores nothing, and replays reasoning", () => {
+test("the request asks the API for no compaction of its own, leaves storage at the API's default, and asks for reasoning it can replay and summarize", () => {
   const request = brainResponsesRequest([userMessageItem("hello")], {
     model: "gpt-test",
     instructions: "be Luke",
@@ -22,13 +23,14 @@ test("the request asks the API for no compaction of its own, stores nothing, and
   });
   assert.equal(request.model, "gpt-test");
   assert.equal(request.instructions, "be Luke");
-  assert.equal(request.store, false);
+  // Storage is the API's default: the response stands with OpenAI under its retention, named by its id.
+  assert.equal("store" in request, false);
   // The host schedules compaction itself; a provider policy beside it would compete over one window.
   assert.equal("context_management" in request, false);
   // No key asked for, none sent: an absent field is not an empty one.
   assert.equal("prompt_cache_key" in request, false);
   assert.deepEqual(request.include, ["reasoning.encrypted_content"]);
-  assert.deepEqual(request.reasoning, { effort: "medium" });
+  assert.deepEqual(request.reasoning, { effort: "medium", summary: BRAIN_REASONING_SUMMARY });
   assert.equal(request.tool_choice, "auto");
   assert.equal(request.parallel_tool_calls, true);
   assert.equal(request.max_output_tokens, 1234);
@@ -162,8 +164,60 @@ test("a prompt cache key rides on the request as the routing hint it is", () => 
     promptCacheKey: "9f86d0818",
   });
   assert.equal(request.prompt_cache_key, "9f86d0818");
-  // The key routes a prefix cache; it does not ask the API to keep anything.
-  assert.equal(request.store, false);
+  // The key routes a prefix cache; it decides nothing about storage, which stays the API's default.
+  assert.equal("store" in request, false);
+});
+
+test("the response id, each reasoning item's summary, and the four-way usage are read beside the items, which stay verbatim", () => {
+  const summarized = {
+    type: "reasoning",
+    id: "rs_1",
+    summary: [
+      { type: "summary_text", text: "Checking which session is waiting." },
+      { type: "summary_text", text: "Only one needs a reply." },
+    ],
+    encrypted_content: "opaque",
+  };
+  const wordless = { type: "reasoning", id: "rs_2", summary: [], encrypted_content: "opaque" };
+  const answer = responsesModelAnswer({
+    id: "resp_1",
+    status: "completed",
+    output: [
+      summarized,
+      wordless,
+      { type: "message", role: "assistant", content: [{ type: "output_text", text: "ok" }] },
+    ],
+    usage: {
+      input_tokens: 900,
+      output_tokens: 120,
+      input_tokens_details: { cached_tokens: 768 },
+      output_tokens_details: { reasoning_tokens: 100 },
+    },
+  });
+  assert.ok(answer?.outcome === MODEL_RESPONSE_OUTCOME.ANSWERED);
+  assert.equal(answer.responseId, "resp_1");
+  assert.deepEqual(answer.usage, {
+    inputTokens: 900,
+    outputTokens: 120,
+    cachedInputTokens: 768,
+    reasoningTokens: 100,
+  });
+  // One summary per item that has words, joined as paragraphs; an item with none is not a summary.
+  assert.deepEqual(answer.reasoning, [
+    { itemId: "rs_1", summary: "Checking which session is waiting.\n\nOnly one needs a reply." },
+  ]);
+  // The items themselves are untouched: the opaque content rides with the summary for replay.
+  assert.deepEqual(answer.items[0], summarized);
+  assert.deepEqual(answer.items[1], wordless);
+  // An answer that names no id and carries no summary says neither, rather than an empty one.
+  const bare = responsesModelAnswer({
+    status: "completed",
+    output: [{ type: "message", role: "assistant", content: [] }],
+    usage: { input_tokens: 1, output_tokens: 0 },
+  });
+  assert.ok(bare?.outcome === MODEL_RESPONSE_OUTCOME.ANSWERED);
+  assert.equal("responseId" in bare, false);
+  assert.equal("reasoning" in bare, false);
 });
 
 test("the cached input tokens the API reports are read for the trace", () => {

--- a/packages/brain/src/responses-api.ts
+++ b/packages/brain/src/responses-api.ts
@@ -9,6 +9,7 @@ import {
   MODEL_RESPONSE_OUTCOME,
   type ModelResponse,
   type ModelUsage,
+  type ReasoningSummary,
   type ToolSchema,
 } from "@sidecar/runtime/vocabulary";
 import { joinReplyMessages } from "@sidecar/session";
@@ -25,15 +26,20 @@ import {
 /**
  * The one OpenAI Responses request a brain turn may be, and the one reading of
  * its answer. Built here once so the keyed client and the hosted service send
- * the same shape: instructions, tools, the refusal to store, and server-side
- * compaction are fixed by the build, and only the input array varies.
+ * the same shape: instructions, tools, the reasoning summary, and server-side
+ * compaction are fixed by the build, and only the input array varies. The
+ * request leaves OpenAI's `store` at its default, so each response stands
+ * with OpenAI under its own retention and is named back by its id, which the
+ * run keeps; the brain still replays its context itself and never reads a
+ * stored response back.
  *
  * Item shapes follow the Responses API reference as it stands today. A
  * `function_call` output carries `call_id`, `name`, and `arguments` (a JSON
  * string); its answer is a `function_call_output` carrying the same `call_id`
- * and a string `output`. A `reasoning` item carries `encrypted_content` when
- * `store` is false, and a `compaction` item carries `type: "compaction"` and
- * its own `encrypted_content`. Every output item is appended to the input
+ * and a string `output`. A `reasoning` item carries `encrypted_content`
+ * because the request asks for it, and a `summary` in words because the
+ * request asks for that too; a `compaction` item carries `type: "compaction"`
+ * and its own `encrypted_content`. Every output item is appended to the input
  * array verbatim, because a reasoning model run statelessly must see its own
  * reasoning items replayed beside the function calls they preceded.
  */
@@ -50,6 +56,9 @@ export type ResponsesInputItem = WireRecord;
 
 const RESPONSES_TOOL_CHOICE_AUTO = "auto";
 const RESPONSES_INCLUDE_ENCRYPTED_REASONING = "reasoning.encrypted_content";
+
+/** How much of its reasoning the model is asked to put into words beside each opaque reasoning item. */
+export const BRAIN_REASONING_SUMMARY = "detailed";
 
 export const BRAIN_REASONING_EFFORT = {
   LOW: "low",
@@ -78,8 +87,9 @@ export interface BrainResponsesOptions {
   reasoningEffort: BrainReasoningEffort;
   /**
    * Which prefix cache the turn's own request should land against: a routing
-   * hint, independent of `store: false`, and never an identifier of anything
-   * — the host hashes what it names before it travels.
+   * hint, separate from the response id OpenAI stores the answer under, and
+   * never an identifier of anything — the host hashes what it names before it
+   * travels.
    */
   promptCacheKey?: string;
 }
@@ -89,7 +99,8 @@ export interface BrainResponsesOptions {
  * compaction is asked of the API: the host schedules compaction itself, so
  * two policies never compete over one window, and an explicit compaction is
  * a request of its own. Reasoning items come back encrypted so the memory
- * can carry them without the API storing anything.
+ * can replay them itself, and summarized so the record can say in words what
+ * the model was reasoning about.
  */
 export function brainResponsesRequest(
   input: readonly ResponsesInputItem[],
@@ -102,9 +113,8 @@ export function brainResponsesRequest(
     tools: options.tools,
     tool_choice: RESPONSES_TOOL_CHOICE_AUTO,
     parallel_tool_calls: true,
-    store: false,
     include: [RESPONSES_INCLUDE_ENCRYPTED_REASONING],
-    reasoning: { effort: options.reasoningEffort },
+    reasoning: { effort: options.reasoningEffort, summary: BRAIN_REASONING_SUMMARY },
     max_output_tokens: options.maximumOutputTokens,
     ...(options.promptCacheKey !== undefined
       ? { prompt_cache_key: options.promptCacheKey }
@@ -153,30 +163,47 @@ interface BrainFunctionCall {
 /**
  * One Responses answer read down to what a turn acts on: every output item
  * verbatim for the memory, the function calls to dispatch, the text the model
- * wrote, whether a compaction item arrived, and the input size the API
- * counted, which is the one honest measure of how large the memory really is.
+ * wrote, the reasoning summaries in words, whether a compaction item arrived,
+ * the input size the API counted, which is the one honest measure of how
+ * large the memory really is, and the id OpenAI stored the response under.
  */
 export interface BrainResponsesOutput {
   items: readonly ResponsesInputItem[];
   functionCalls: readonly BrainFunctionCall[];
   outputText: string;
+  reasoning: readonly ReasoningSummary[];
   compacted: boolean;
   inputTokens?: number;
+  responseId?: string;
   status?: string;
   incompleteReason?: string;
 }
 
+/** The text of each part of one fixed type, in order, a part of any other shape reading as empty. */
+function partTexts(parts: UnparsedWireValue, type: string): string[] {
+  if (!Array.isArray(parts)) return [];
+  return parts.map((part) =>
+    isRecord(part) && part.type === type && isWireString(part.text) ? part.text : "",
+  );
+}
+
 function outputTextFromContent(content: UnparsedWireValue): string {
-  if (!Array.isArray(content)) return "";
-  return content
-    .map((entry) =>
-      isRecord(entry) &&
-      entry.type === RESPONSES_CONTENT_PART_TYPE.OUTPUT_TEXT &&
-      isWireString(entry.text)
-        ? entry.text
-        : "",
-    )
-    .join("");
+  return partTexts(content, RESPONSES_CONTENT_PART_TYPE.OUTPUT_TEXT).join("");
+}
+
+/**
+ * A reasoning item's summary in words, or nothing for an item that is not a
+ * reasoning item or carries no words: the parts are joined as paragraphs, and
+ * the item's `encrypted_content` is never read.
+ */
+function reasoningSummaryFromItem(item: WireRecord): ReasoningSummary | undefined {
+  if (item.type !== RESPONSES_INPUT_ITEM_TYPE.REASONING) return undefined;
+  const itemId = text(item.id);
+  if (!itemId) return undefined;
+  const summary = joinReplyMessages(
+    partTexts(item.summary, RESPONSES_CONTENT_PART_TYPE.SUMMARY_TEXT),
+  );
+  return summary.length > 0 ? { itemId, summary } : undefined;
 }
 
 function functionCallFromItem(item: WireRecord): BrainFunctionCall | undefined {
@@ -196,6 +223,7 @@ export function brainResponsesOutput(payload: UnparsedWireValue): BrainResponses
   if (!isRecord(payload) || !Array.isArray(payload.output)) return undefined;
   const items: ResponsesInputItem[] = [];
   const functionCalls: BrainFunctionCall[] = [];
+  const reasoning: ReasoningSummary[] = [];
   const texts: string[] = [];
   let compacted = false;
   for (const item of payload.output) {
@@ -204,6 +232,8 @@ export function brainResponsesOutput(payload: UnparsedWireValue): BrainResponses
     if (isCompactionItem(item)) compacted = true;
     const call = functionCallFromItem(item);
     if (call) functionCalls.push(call);
+    const summary = reasoningSummaryFromItem(item);
+    if (summary) reasoning.push(summary);
     if (
       item.type === RESPONSES_INPUT_ITEM_TYPE.MESSAGE &&
       item.role === RESPONSES_MESSAGE_ROLE.ASSISTANT
@@ -215,13 +245,16 @@ export function brainResponsesOutput(payload: UnparsedWireValue): BrainResponses
   const inputTokens = usage ? wholeNumber(usage.input_tokens) : undefined;
   const details = isRecord(payload.incomplete_details) ? payload.incomplete_details : undefined;
   const status = text(payload.status);
+  const responseId = text(payload.id);
   const incompleteReason = details ? text(details.reason) : undefined;
   return {
     items,
     functionCalls,
     outputText: joinReplyMessages(texts),
+    reasoning,
     compacted,
     ...(inputTokens !== undefined ? { inputTokens } : undefined),
+    ...(responseId ? { responseId } : undefined),
     ...(status ? { status } : undefined),
     ...(incompleteReason ? { incompleteReason } : undefined),
   };
@@ -313,10 +346,14 @@ export function responsesModelAnswer(payload: UnparsedWireValue): ModelResponse 
   const inputDetails =
     usage && isRecord(usage.input_tokens_details) ? usage.input_tokens_details : undefined;
   const cachedInputTokens = inputDetails ? wholeNumber(inputDetails.cached_tokens) : undefined;
+  const outputDetails =
+    usage && isRecord(usage.output_tokens_details) ? usage.output_tokens_details : undefined;
+  const reasoningTokens = outputDetails ? wholeNumber(outputDetails.reasoning_tokens) : undefined;
   const modelUsage: ModelUsage = {
     ...(output.inputTokens !== undefined ? { inputTokens: output.inputTokens } : undefined),
     ...(outputTokens !== undefined ? { outputTokens } : undefined),
     ...(cachedInputTokens !== undefined ? { cachedInputTokens } : undefined),
+    ...(reasoningTokens !== undefined ? { reasoningTokens } : undefined),
   };
   return {
     outcome: MODEL_RESPONSE_OUTCOME.ANSWERED,
@@ -324,6 +361,8 @@ export function responsesModelAnswer(payload: UnparsedWireValue): ModelResponse 
     text: output.outputText,
     toolCalls: output.functionCalls,
     ...(usage ? { usage: modelUsage } : undefined),
+    ...(output.responseId !== undefined ? { responseId: output.responseId } : undefined),
+    ...(output.reasoning.length > 0 ? { reasoning: output.reasoning } : undefined),
     compacted: output.compacted,
     ...(output.incompleteReason
       ? {

--- a/packages/brain/src/run-events.test.ts
+++ b/packages/brain/src/run-events.test.ts
@@ -5,6 +5,7 @@ import {
   ABC,
   acceptedRunId,
   answered,
+  answeredUnder,
   ask,
   type BrainClientAnswer,
   call,
@@ -66,8 +67,48 @@ test("a run that reads a transcript tells its slow step once, then its actions s
       runId,
       status: BRAIN_REQUEST_STATUS.SUCCEEDED,
       text: "The tests pass. Nothing needs you!",
+      usage: { inputTokens: 200, outputTokens: 0, cachedInputTokens: 0, reasoningTokens: 0 },
     },
   ]);
+  await h.agent.stop();
+});
+
+test("a run keeps every response id and the four counts summed over its answers, on its record and on its end", async () => {
+  const h = harness();
+  const events = listen(h);
+  h.client.answers.push(
+    answeredUnder("resp_1", [messageAbc("send_1")], {
+      input: 900,
+      output: 40,
+      cached: 768,
+      reasoning: 30,
+    }),
+    answeredUnder("resp_2", [message("Sent.")], {
+      input: 1000,
+      output: 10,
+      cached: 896,
+      reasoning: 0,
+    }),
+  );
+  const record = await ask(h, "tell abc to run the tests");
+  assert.equal(record?.status, BRAIN_REQUEST_STATUS.SUCCEEDED);
+  const usage = {
+    inputTokens: 1900,
+    outputTokens: 50,
+    cachedInputTokens: 1664,
+    reasoningTokens: 30,
+  };
+  assert.deepEqual(record?.responseIds, ["resp_1", "resp_2"]);
+  assert.deepEqual(record?.usage, usage);
+  // The record on disk says the same, so a relaunch reads what the run cost.
+  const stored = h.repository.state?.requests.find((entry) => entry.runId === record?.runId);
+  assert.deepEqual(stored?.responseIds, ["resp_1", "resp_2"]);
+  assert.deepEqual(stored?.usage, usage);
+  const ended = events.find((event) => event.kind === BRAIN_RUN_EVENT.ENDED);
+  assert.ok(ended?.kind === BRAIN_RUN_EVENT.ENDED);
+  assert.deepEqual(ended.responseIds, ["resp_1", "resp_2"]);
+  assert.deepEqual(ended.usage, usage);
+  assert.equal(events.filter((event) => event.kind === BRAIN_RUN_EVENT.ENDED).length, 1);
   await h.agent.stop();
 });
 

--- a/packages/brain/src/run-events.ts
+++ b/packages/brain/src/run-events.ts
@@ -1,5 +1,5 @@
 import { type EffectiveToolPolicy, TOOL_EXECUTION } from "@sidecar/runtime";
-import type { BrainRequestFailure, BrainRequestStatus } from "./requests.js";
+import type { BrainRequestFailure, BrainRequestStatus, BrainRunUsage } from "./requests.js";
 import { BRAIN_TOOL } from "./tools.js";
 
 /**
@@ -48,6 +48,10 @@ export type BrainRunEvent =
       readonly status: BrainRequestStatus;
       readonly text?: string;
       readonly failure?: BrainRequestFailure;
+      /** What the run's inferences cost, split four ways, when it was answered at all. */
+      readonly usage?: BrainRunUsage;
+      /** The id of every response OpenAI answered the run with, in order. */
+      readonly responseIds?: readonly string[];
     };
 
 /** Which slow step a tool call the policy offers begins, or nothing for a call that is neither slow nor offered. */

--- a/packages/brain/src/runtime.ts
+++ b/packages/brain/src/runtime.ts
@@ -346,6 +346,9 @@ export class ToolLoopAgentRuntime implements AgentRuntime {
     lifecycle: ContextLifecycle,
   ): Promise<boolean> {
     await emit({ kind: RUNTIME_EVENT.ANSWERED, toolCalls: answer.toolCalls.length });
+    if (answer.responseId !== undefined) {
+      await emit({ kind: RUNTIME_EVENT.RESPONSE, responseId: answer.responseId });
+    }
     await ingest({ kind: CONTEXT_INPUT_KIND.MODEL_OUTPUT, items: answer.items });
     if (lifecycle.signal?.aborted) return false;
     if (answer.compacted) {

--- a/packages/brain/src/store/brain-envelope.ts
+++ b/packages/brain/src/store/brain-envelope.ts
@@ -358,8 +358,8 @@ function upsertRequest(
       `INSERT OR REPLACE INTO requests
          (run_id, session_id, ordinal, submission_id, origin, question, status, revision,
           accepted_at, started_at, settled_at, text, failure, performed_actions, unknown_actions,
-          ask_recorded_at, conversation_recorded_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+          ask_recorded_at, conversation_recorded_at, usage_json, response_ids_json)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
     )
     .run(
       record.runId,
@@ -379,6 +379,8 @@ function upsertRequest(
       record.unknownActions,
       nullable(record.askRecordedAt),
       nullable(record.conversationRecordedAt),
+      record.usage === undefined ? null : JSON.stringify(record.usage),
+      record.responseIds === undefined ? null : JSON.stringify(record.responseIds),
     );
 }
 
@@ -424,6 +426,8 @@ function requestWire(row: Record<string, SQLInputValue>): WireRecord {
     ...optionalField("failure", column(row.failure, isWireString)),
     ...optionalField("askRecordedAt", column(row.ask_recorded_at, isWireNumber)),
     ...optionalField("conversationRecordedAt", column(row.conversation_recorded_at, isWireNumber)),
+    ...optionalField("usage", jsonColumn(row.usage_json)),
+    ...optionalField("responseIds", jsonColumn(row.response_ids_json)),
   };
 }
 
@@ -442,4 +446,20 @@ function journalWire(row: Record<string, SQLInputValue>): WireRecord {
 /** A nullable column as the envelope reader expects it: present with its value, or absent. */
 function optionalField(name: string, value: WireValue): WireRecord {
   return value === null ? {} : { [name]: value };
+}
+
+/**
+ * A TEXT column holding JSON, read back as the wire value it serialized, or
+ * absent when the column is null or does not parse; the envelope reader, not
+ * this table module, decides whether the value's shape is admitted.
+ */
+function jsonColumn(value: SQLInputValue | undefined): WireValue {
+  const json = column(value, isWireString);
+  if (json === null) return null;
+  try {
+    // SAFETY: JSON.parse answers a wire value; the envelope reader validates its shape.
+    return JSON.parse(json) as WireValue;
+  } catch {
+    return null;
+  }
 }

--- a/packages/brain/src/store/database.test.ts
+++ b/packages/brain/src/store/database.test.ts
@@ -874,3 +874,74 @@ test("the observation inbox and capture cursors round-trip, amend whole, and cas
     .run("gen-inbox", 0, "bad", JSON.stringify({ id: "bad" }));
   assert.equal(loadBrainEnvelope(database, MAIN_SESSION_KEY).unreadable, true);
 });
+
+test("a database from before the run accounting opens with the two columns added, and a record's usage and response ids round-trip through them", () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "luke-runtime-store-"));
+  const location = path.join(directory, "agent.sqlite");
+  const seeded = StoreDatabase.open(location);
+  createConversation(seeded, {
+    agentId: DEFAULT_AGENT_ID,
+    sessionKey: MAIN_SESSION_KEY,
+    name: "main",
+    now: NOW,
+  });
+  saveBrainEnvelope(seeded, MAIN_SESSION_KEY, {
+    kind: SAVE_KIND.REPLACE,
+    state: populatedState("gen-kept"),
+  });
+  seeded.close();
+  const older = new DatabaseSync(location);
+  older.exec("ALTER TABLE requests DROP COLUMN usage_json");
+  older.exec("ALTER TABLE requests DROP COLUMN response_ids_json");
+  older.exec("UPDATE schema_version SET version = 11");
+  older.close();
+
+  const database = StoreDatabase.open(location);
+  // SAFETY: the schema_version table has one integer column.
+  const version = database.prepare("SELECT version FROM schema_version").get() as {
+    version: number;
+  };
+  assert.equal(version.version, STORE_SCHEMA_VERSION);
+  // SAFETY: PRAGMA table_info answers one text column named name per column of the table.
+  const columns = new Set(
+    (database.prepare("PRAGMA table_info(requests)").all() as { name: string }[]).map(
+      (column) => column.name,
+    ),
+  );
+  assert.equal(columns.has("usage_json"), true);
+  assert.equal(columns.has("response_ids_json"), true);
+  // A record from before the columns reads with neither field, not with empty ones.
+  const kept = loadBrainEnvelope(database, MAIN_SESSION_KEY).state;
+  assert.equal(kept?.generationId, "gen-kept");
+  assert.equal(kept?.requests[0] !== undefined && "usage" in kept.requests[0], false);
+  assert.equal(kept?.requests[0] !== undefined && "responseIds" in kept.requests[0], false);
+
+  const usage = {
+    inputTokens: 1900,
+    outputTokens: 50,
+    cachedInputTokens: 1664,
+    reasoningTokens: 30,
+  };
+  assert.equal(
+    saveBrainEnvelope(database, MAIN_SESSION_KEY, {
+      kind: SAVE_KIND.REPLACE,
+      expectGeneration: "gen-kept",
+      state: {
+        ...populatedState("gen-next"),
+        requests: [
+          request("run-1", {
+            status: BRAIN_REQUEST_STATUS.SUCCEEDED,
+            usage,
+            responseIds: ["resp_1", "resp_2"],
+          }),
+        ],
+      },
+    }),
+    true,
+  );
+  const reloaded = loadBrainEnvelope(database, MAIN_SESSION_KEY).state?.requests[0];
+  assert.deepEqual(reloaded?.usage, usage);
+  assert.deepEqual(reloaded?.responseIds, ["resp_1", "resp_2"]);
+  database.close();
+  fs.rmSync(directory, { recursive: true, force: true });
+});

--- a/packages/brain/src/store/database.ts
+++ b/packages/brain/src/store/database.ts
@@ -107,6 +107,7 @@ export class StoreDatabase {
           const steps = STORE_SCHEMA_MIGRATIONS.get(version) ?? [];
           for (const step of steps) {
             if (step.onlyIf && !this.#stands(step.onlyIf)) continue;
+            if (step.unless && this.#stands(step.unless)) continue;
             this.#db.prepare(step.sql).run(...step.params);
           }
         }

--- a/packages/brain/src/store/schema.ts
+++ b/packages/brain/src/store/schema.ts
@@ -100,7 +100,7 @@ const MEMORY_FLUSH_STATE_TABLE = `CREATE TABLE IF NOT EXISTS memory_flush_state 
     flushed_at INTEGER NOT NULL
   )`;
 
-export const STORE_SCHEMA_VERSION = 11;
+export const STORE_SCHEMA_VERSION = 12;
 
 /**
  * The earliest version this build opens. Every version since the first has a
@@ -127,6 +127,12 @@ export interface SchemaMigrationStep {
    * table under the new one — and SQLite's DDL carries no condition of its own.
    */
   onlyIf?: { table: string; column?: string };
+  /**
+   * Skips the step where the named column already stands: an added column
+   * must not be added twice on a database whose table the current statements
+   * created with it, and SQLite's ADD COLUMN carries no IF NOT EXISTS.
+   */
+  unless?: { table: string; column: string };
 }
 
 const CONVERSATION_EVENTS_INDEXES: readonly string[] = [
@@ -276,6 +282,21 @@ export const STORE_SCHEMA_MIGRATIONS: ReadonlyMap<number, readonly SchemaMigrati
       ],
     ],
     [11, RENAME_TO_CONVERSATION_STEPS],
+    [
+      12,
+      [
+        {
+          sql: "ALTER TABLE requests ADD COLUMN usage_json TEXT",
+          params: [],
+          unless: { table: "requests", column: "usage_json" },
+        },
+        {
+          sql: "ALTER TABLE requests ADD COLUMN response_ids_json TEXT",
+          params: [],
+          unless: { table: "requests", column: "response_ids_json" },
+        },
+      ],
+    ],
   ],
 );
 
@@ -357,7 +378,9 @@ export const STORE_SCHEMA_STATEMENTS: readonly string[] = [
     performed_actions INTEGER NOT NULL,
     unknown_actions INTEGER NOT NULL,
     ask_recorded_at INTEGER,
-    conversation_recorded_at INTEGER
+    conversation_recorded_at INTEGER,
+    usage_json TEXT,
+    response_ids_json TEXT
   )`,
   `CREATE INDEX IF NOT EXISTS requests_by_session ON requests(session_id, ordinal)`,
   `CREATE TABLE IF NOT EXISTS action_receipts (

--- a/packages/brain/src/turn-runner.ts
+++ b/packages/brain/src/turn-runner.ts
@@ -42,6 +42,7 @@ import { inboxEvents } from "./observation-inbox.js";
 import type { BrainActionExecution, BrainActionPerformer, BrainRoster } from "./performer.js";
 import { sameIdentity } from "./records.js";
 import {
+  addModelUsage,
   BRAIN_REQUEST_FAILURE,
   BRAIN_REQUEST_ORIGIN,
   BRAIN_REQUEST_STATUS,
@@ -159,6 +160,7 @@ export function newRunControl(
     checkpointFailed: false,
     performedActions: 0,
     unknownActions: 0,
+    responseIds: [],
   };
 }
 
@@ -830,6 +832,10 @@ export class TurnRunner {
           if (event.usage.inputTokens !== undefined) {
             gathering.inputTokens = event.usage.inputTokens;
           }
+          run.usage = addModelUsage(run.usage, event.usage);
+          return;
+        case RUNTIME_EVENT.RESPONSE:
+          run.responseIds.push(event.responseId);
           return;
         case RUNTIME_EVENT.COMPACTED:
           gathering.compacted = true;

--- a/packages/brain/src/turn.ts
+++ b/packages/brain/src/turn.ts
@@ -7,7 +7,7 @@ import {
 import type { ScheduledTimer } from "@sidecar/runtime/vocabulary";
 import { RUN_ORIGIN, type RunOrigin } from "@sidecar/runtime/vocabulary";
 import type { Generation } from "./generation.js";
-import type { BrainRequestOrigin } from "./requests.js";
+import type { BrainRequestOrigin, BrainRunUsage } from "./requests.js";
 import type { SteeredDeliveries } from "./steered-deliveries.js";
 import type { RecordingContextEngine } from "./transcript-recorder.js";
 import type { BrainWakeEvent } from "./wake-events.js";
@@ -126,6 +126,10 @@ export interface RunControl {
   compactionFailed?: boolean;
   performedActions: number;
   unknownActions: number;
+  /** What the run's inferences have cost so far, summed over every answer; nothing before the first. */
+  usage?: BrainRunUsage;
+  /** The id of every response the run was answered with, in order. */
+  responseIds: string[];
 }
 
 interface TurnPlanBase {

--- a/packages/hosted/src/brain-contract.ts
+++ b/packages/hosted/src/brain-contract.ts
@@ -21,7 +21,7 @@ import {
  * The hosted brain contract. The desktop prepares the prompt and names the
  * tools, because the prompt is composed on the desktop and the toolset is
  * chosen by a policy there. What the service fixes is everything a caller
- * could abuse: the model, the upstream, the credential, the refusal to store,
+ * could abuse: the model, the upstream, the credential, the reasoning summary,
  * the catalog of tool schemas a name may select, and every bound below. A
  * tool travels as its registered name and nothing more, so a caller can never
  * upload a schema; the prompt travels as bounded text with an explicit

--- a/packages/runtime/src/execution.ts
+++ b/packages/runtime/src/execution.ts
@@ -163,6 +163,21 @@ export interface ModelUsage {
   readonly outputTokens?: number;
   /** How much of the input the provider answered from its prefix cache, when it says; the trace reads it. */
   readonly cachedInputTokens?: number;
+  /** How much of the output the provider spent reasoning before it wrote, when it says. */
+  readonly reasoningTokens?: number;
+}
+
+/**
+ * What one reasoning item says about itself in words: the provider's summary
+ * of the reasoning behind the calls and words that followed it, read beside
+ * the opaque item it belongs to. The item itself stays in the context for
+ * replay and is never read inside; the summary is what a record keeps and a
+ * client is shown.
+ */
+export interface ReasoningSummary {
+  /** The provider's id for the reasoning item the summary describes. */
+  readonly itemId: string;
+  readonly summary: string;
 }
 
 export const MODEL_RESPONSE_OUTCOME = {
@@ -212,6 +227,10 @@ export interface ModelAnswer {
   readonly usage?: ModelUsage;
   readonly compacted: boolean;
   readonly incomplete?: ModelIncomplete;
+  /** The provider's id for this response, when it named one; a run keeps every one it was answered with. */
+  readonly responseId?: string;
+  /** The summaries of the reasoning items this answer carried, in the order the items stand. */
+  readonly reasoning?: readonly ReasoningSummary[];
 }
 
 export type ModelResponse =
@@ -440,6 +459,8 @@ export const RUNTIME_EVENT = {
   TOOL_CALL: "tool_call",
   TOOL_RESULT: "tool_result",
   USAGE: "usage",
+  /** One inference was answered under a provider response id. */
+  RESPONSE: "response",
   COMPACTED: "compacted",
   INCOMPLETE: "incomplete",
   THROTTLED: "throttled",
@@ -493,6 +514,7 @@ export type RuntimeEvent =
       readonly result: ToolResult;
     }
   | { readonly kind: typeof RUNTIME_EVENT.USAGE; readonly usage: ModelUsage }
+  | { readonly kind: typeof RUNTIME_EVENT.RESPONSE; readonly responseId: string }
   | { readonly kind: typeof RUNTIME_EVENT.COMPACTED; readonly dropped: number }
   | { readonly kind: typeof RUNTIME_EVENT.INCOMPLETE; readonly incomplete: ModelIncomplete }
   | { readonly kind: typeof RUNTIME_EVENT.THROTTLED; readonly until: number }

--- a/packages/runtime/src/vocabulary.ts
+++ b/packages/runtime/src/vocabulary.ts
@@ -60,6 +60,7 @@ export {
   type ModelUsage,
   REASONING_EFFORT,
   type ReasoningEffort,
+  type ReasoningSummary,
   RUN_END_REASON,
   RUNTIME_EVENT,
   type RunEndReason,


### PR DESCRIPTION
## What

Lane A, PR A5 of the LUKE-95 storage rework (Linear LUKE-115).

- The brain's Responses request leaves OpenAI's `store` at its default (no `store: false`) and asks for `reasoning: { effort, summary: "detailed" }` beside the `reasoning.encrypted_content` it already includes. Every reasoning item therefore carries its summary in words next to the opaque item, and the opaque item is still what replay uses.
- The answer reading (`responsesModelAnswer`) now reads the response id, one `ReasoningSummary` per reasoning item that has words (item id plus the summary parts joined as paragraphs), and usage split four ways: input, output, cached input, reasoning. `ModelUsage` gains `reasoningTokens`; `ModelAnswer` gains `responseId` and `reasoning`.
- The run record (`BrainRequestRecord`) carries `usage` (the four counts summed over every answer the run was given) and `responseIds` (every id, in order). They accumulate on the run control from the runtime's `usage` event and a new `response` runtime event, land with each checkpoint and the settle through the ledger, persist in both stores, and ride as **new optional fields** on the existing `ENDED` run event.
- SQLite store: schema version 12 adds `usage_json` and `response_ids_json` to `requests`, each behind a new `unless` guard so a database whose table the current statements created with the columns is not altered twice.
- Postgres store: generated Drizzle migration `0014_a5_run_usage_response_ids` adds `usage` jsonb and `response_ids` text[] to `conversation_run`, the same shapes the plan's `turns` table names.
- PRIVACY.md: one sentence, in the existing "Who we send it to" bullet, saying OpenAI stores the request and its reply under its own retention policy. Nothing else about storage was restated.

## Why / how it follows the plan

`plan/storage-plan.md` decides: OpenAI `store` stays on, response ids are recorded on the turn, reasoning summaries are requested and stored beside the opaque item, usage is split input/output/cached/reasoning, and clients receive the summary rather than the opaque item. This PR puts those on the run record that exists today; PR B1's `turns` table takes the same `usage jsonb` and `response_ids text[]` shapes.

## Additive to #910's run event stream

This change is strictly additive. `BRAIN_RUN_EVENT.SLOW_STEP`, `ACTIONS_SETTLED`, `REPLY_SENTENCE`, and `ENDED` are untouched in name and shape; `ENDED` is still emitted exactly once per run (asserted by test) and only gains the optional `usage` and `responseIds` fields. `submitAsk` and its origin values are unchanged.

## For A3 (LUKE-112)

The turn-ended event does not exist in this tree, so the four counts and the response ids are on the run record and on `ENDED`; A3 carries them onto its turn-ended event from the same record. A3's reasoning-completed event has its source in `ModelAnswer.reasoning` (read in the runtime's `#absorb`); no runtime event for it is emitted here since nothing listens yet.

## CLAUDE.md sentences this contradicts (for G5)

- "asks OpenAI not to store it, and keeps and logs none of the request body" (the brain and transcript reads section) — the request no longer asks that; the service half still holds.
- "The service fixes the model, the upstream, its credential, the refusal to store, the output budget's ceiling…" (hosted tier section) — there is no refusal to store any more.

## How to verify

```
./scripts/check.sh
cd packages/brain && pnpm test
cd apps/web && pnpm exec drizzle-kit check
```

`./scripts/verify.sh` was not run: the change touches no macOS or UI code, and this environment is a Linux sandbox where it cannot run.

## Test results

- `./scripts/check.sh`: green (repository checks, typecheck, lint, tests, build).
- `packages/brain`: 340 pass, 0 fail. New assertions: the request shape (no `store` key, `reasoning` with summary), the response id and per-item summaries and four-way usage read as values, the record's wire round trip and refusals, a run's record and `ENDED` carrying summed usage and both response ids with `ENDED` emitted once, SQLite v11 → v12 migration with round trip through the new columns.
- `apps/web`: the hosted respond route asserts the same request shape; the hosted store round-trips `usage` and `responseIds` through the Postgres row.

## Reviews

Ran Cursor's thermo-nuclear code quality review (`cursor/plugins` → `thermos/skills/thermo-nuclear-code-quality-review/SKILL.md`) and ponytail review (`DietrichGebert/ponytail` → `skills/ponytail-review/SKILL.md`) over the diff and applied the findings: the reasoning-summary reader and the output-text reader now share one part walker; a listener-less `reasoning` runtime event was deleted; a double cast in the SQLite JSON column reader became one; the hosted upsert reuses `nullable`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/51a39984-b649-4822-a009-257b5549aef3)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34530397052/artifacts/10173346935) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34530397052)

- Commit: `de1c63f9f73f83098ffcd1321b3cdfd5647ace9f`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
