### PR TITLE
feat(LUKE-111): one output envelope for every action tool

### DIFF
--- a/packages/actions/src/action-narration.ts
+++ b/packages/actions/src/action-narration.ts
@@ -4,12 +4,13 @@
  * written and no action can be recorded as "an action" with nothing said about it.
  */
 
-import type {
-  CONVERSATION_ENTRY_KIND,
-  ConversationEntry,
-  Session,
-  SessionApplicationId,
-  SessionIdentity,
+import {
+  type CONVERSATION_ENTRY_KIND,
+  type ConversationEntry,
+  type Session,
+  type SessionApplicationId,
+  type SessionIdentity,
+  sessionWithIdentity,
 } from "@sidecar/session";
 import {
   ACTION_KIND,
@@ -19,11 +20,7 @@ import {
 } from "./action-kinds.js";
 
 function observedSessionName(identity: SessionIdentity, sessions: readonly Session[]): string {
-  const session = sessions.find(
-    (candidate) =>
-      candidate.providerId === identity.providerId &&
-      candidate.providerSessionId === identity.providerSessionId,
-  );
+  const session = sessionWithIdentity(identity, sessions);
   return session ? `"${session.title}"` : "a session";
 }
 
@@ -32,11 +29,7 @@ function observedApplicationName(
   applicationId: SessionApplicationId,
   sessions: readonly Session[],
 ): string {
-  const session = sessions.find(
-    (candidate) =>
-      candidate.providerId === identity.providerId &&
-      candidate.providerSessionId === identity.providerSessionId,
-  );
+  const session = sessionWithIdentity(identity, sessions);
   return (
     session?.applications.find((application) => application.id === applicationId)?.displayName ??
     applicationId

--- a/packages/actions/src/action-output.test.ts
+++ b/packages/actions/src/action-output.test.ts
@@ -1,0 +1,191 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  ACTION_KIND as ADVERTISED_ACTION_KIND,
+  normalizeSession,
+  SESSION_APPLICATION_ID,
+  SESSION_CONTROL_KIND,
+  SESSION_STATUS,
+  type Session,
+} from "@sidecar/session";
+import { ACTION_RESULT_STATUS, UNKNOWN_ACTION_STATUS, type WireRecord } from "@sidecar/wire";
+import { ACTION_KIND, type CarriedAction, type SessionActionKind } from "./action-kinds.js";
+import {
+  ACTION_OUTPUT,
+  ACTION_OUTPUT_STATUS,
+  acceptedActionOutput,
+  actionOutputFromResult,
+  actionTargetSnapshot,
+  maximumActionOutputSentenceLength,
+  refusedActionOutput,
+  unknownActionOutput,
+} from "./action-output.js";
+
+const NOW = 1_800_000_000_000;
+const IDENTITY = { providerId: "conductor", providerSessionId: "chat-1" } as const;
+const STOP = {
+  kind: ADVERTISED_ACTION_KIND.CONTROL,
+  id: "stop",
+  label: "Stop",
+  controlKind: SESSION_CONTROL_KIND.STOP,
+} as const;
+const PLAIN = { kind: ADVERTISED_ACTION_KIND.CONTROL, id: "retry", label: "Retry" } as const;
+const STOP_ACTION: CarriedAction<typeof ACTION_KIND.CONTROL> = {
+  kind: ACTION_KIND.CONTROL,
+  identity: IDENTITY,
+  control: STOP,
+};
+
+const observed: Session = normalizeSession(
+  { id: IDENTITY.providerId, displayName: "Conductor" },
+  {
+    providerSessionId: IDENTITY.providerSessionId,
+    title: "Fix the flaky test",
+    status: SESSION_STATUS.WORKING,
+    lastActivityAt: NOW,
+    agent: { id: "cursor", displayName: "Cursor" },
+    advertises: [{ kind: ADVERTISED_ACTION_KIND.MESSAGE }, STOP, PLAIN],
+  },
+);
+
+/** One admitted action of every session kind, aimed at the observed session or its provider. */
+const SESSION_ACTIONS: readonly CarriedAction<SessionActionKind>[] = [
+  { kind: ACTION_KIND.MESSAGE, identity: IDENTITY, text: "go ahead" },
+  STOP_ACTION,
+  { kind: ACTION_KIND.OPEN, identity: IDENTITY, applicationId: SESSION_APPLICATION_ID.CONDUCTOR },
+  { kind: ACTION_KIND.ADD_AGENT, identity: IDENTITY, agent: "claude" },
+  { kind: ACTION_KIND.RENAME_WORKSPACE, identity: IDENTITY, name: "Flaky test" },
+  { kind: ACTION_KIND.RENAME_SESSION, identity: IDENTITY, name: "Flaky test chat" },
+  { kind: ACTION_KIND.CREATE_WORKSPACE, providerId: "conductor", providerProjectId: "luke" },
+];
+
+test("the target snapshot is the roster's picture at execution: identity, title, and agent for a session action, the provider alone for a creation", () => {
+  const session = {
+    providerId: "conductor",
+    providerSessionId: "chat-1",
+    title: "Fix the flaky test",
+    agentId: "cursor",
+  };
+  const snapshots = SESSION_ACTIONS.map((action) => actionTargetSnapshot(action, [observed]));
+  assert.deepEqual(snapshots, [
+    session,
+    { ...session, controlKind: SESSION_CONTROL_KIND.STOP, controlLabel: "Stop" },
+    { ...session, applicationId: SESSION_APPLICATION_ID.CONDUCTOR },
+    session,
+    session,
+    session,
+    { providerId: "conductor" },
+  ]);
+});
+
+test("a control with no declared kind names its label alone, and a session the roster let go keeps its identity with no title", () => {
+  const plain = actionTargetSnapshot(
+    { kind: ACTION_KIND.CONTROL, identity: IDENTITY, control: PLAIN },
+    [observed],
+  );
+  assert.deepEqual(plain, {
+    providerId: "conductor",
+    providerSessionId: "chat-1",
+    title: "Fix the flaky test",
+    agentId: "cursor",
+    controlLabel: "Retry",
+  });
+  const departed = actionTargetSnapshot(
+    { kind: ACTION_KIND.MESSAGE, identity: IDENTITY, text: "still there?" },
+    [],
+  );
+  assert.deepEqual(departed, { providerId: "conductor", providerSessionId: "chat-1" });
+});
+
+test("every envelope the builders make validates, and validation reads it back unchanged", () => {
+  const target = actionTargetSnapshot(STOP_ACTION, [observed]);
+  const envelopes = [
+    acceptedActionOutput(),
+    acceptedActionOutput({ target }),
+    acceptedActionOutput({
+      target: { providerId: "conductor" },
+      createdSession: { providerId: "conductor", providerSessionId: "chat-9" },
+      warning: "the opening task was not delivered",
+    }),
+    refusedActionOutput("No observed session matches that identity."),
+    refusedActionOutput("That session advertises no such control.", target),
+    unknownActionOutput("the node went away", target),
+  ];
+  for (const envelope of envelopes) {
+    assert.deepEqual(ACTION_OUTPUT.read(envelope), { ok: true, value: envelope });
+  }
+});
+
+test("a refusal or an unknown without a reason, a status outside the set, and a target without a provider are not envelopes, while a key a later build added is", () => {
+  const malformed: readonly WireRecord[] = [
+    { status: ACTION_OUTPUT_STATUS.REFUSED },
+    { status: ACTION_OUTPUT_STATUS.REFUSED, reason: "   " },
+    { status: ACTION_OUTPUT_STATUS.UNKNOWN },
+    { status: ACTION_RESULT_STATUS.REJECTED, reason: "an adapter's word, not the envelope's" },
+    { status: ACTION_OUTPUT_STATUS.ACCEPTED, target: { providerSessionId: "chat-1" } },
+    { status: ACTION_OUTPUT_STATUS.ACCEPTED, createdSession: { providerId: "conductor" } },
+  ];
+  for (const record of malformed) {
+    assert.equal(ACTION_OUTPUT.read(record).ok, false);
+  }
+  assert.deepEqual(ACTION_OUTPUT.parse({ status: ACTION_OUTPUT_STATUS.ACCEPTED, later: true }), {
+    status: ACTION_OUTPUT_STATUS.ACCEPTED,
+  });
+});
+
+test("a row's fields are dropped when malformed rather than refusing the envelope, and a sentence past its bound is cut", () => {
+  const read = ACTION_OUTPUT.parse({
+    status: ACTION_OUTPUT_STATUS.ACCEPTED,
+    target: {
+      providerId: "conductor",
+      providerSessionId: "chat-1",
+      title: "",
+      agentId: 7,
+      controlKind: "detonate",
+      applicationId: "notepad",
+    },
+  });
+  assert.deepEqual(read, {
+    status: ACTION_OUTPUT_STATUS.ACCEPTED,
+    target: { providerId: "conductor", providerSessionId: "chat-1" },
+  });
+  const long = ACTION_OUTPUT.parse(
+    refusedActionOutput("x".repeat(maximumActionOutputSentenceLength + 10)),
+  );
+  assert.equal(long?.status, ACTION_OUTPUT_STATUS.REFUSED);
+  assert.equal(long?.reason.length, maximumActionOutputSentenceLength);
+});
+
+test("a carried result folds into the envelope: accepted keeps the target and the created session, rejected and unsupported are both refused, unknown stays unknown", () => {
+  const target = { providerId: "conductor" };
+  const createdSession = { providerId: "conductor", providerSessionId: "chat-9" };
+  assert.deepEqual(
+    actionOutputFromResult(
+      { status: ACTION_RESULT_STATUS.ACCEPTED, createdSession, warning: "late" },
+      target,
+    ),
+    { status: ACTION_OUTPUT_STATUS.ACCEPTED, target, createdSession, warning: "late" },
+  );
+  assert.deepEqual(actionOutputFromResult({ status: ACTION_RESULT_STATUS.ACCEPTED }), {
+    status: ACTION_OUTPUT_STATUS.ACCEPTED,
+  });
+  assert.deepEqual(
+    actionOutputFromResult({ status: ACTION_RESULT_STATUS.REJECTED, reason: "no" }, target),
+    { status: ACTION_OUTPUT_STATUS.REFUSED, reason: "no", target },
+  );
+  assert.deepEqual(
+    actionOutputFromResult({ status: ACTION_RESULT_STATUS.UNSUPPORTED, reason: "no" }),
+    {
+      status: ACTION_OUTPUT_STATUS.REFUSED,
+      reason: "no",
+    },
+  );
+  assert.deepEqual(
+    actionOutputFromResult({ status: UNKNOWN_ACTION_STATUS, reason: "lost" }, target),
+    {
+      status: ACTION_OUTPUT_STATUS.UNKNOWN,
+      reason: "lost",
+      target,
+    },
+  );
+});

--- a/packages/actions/src/action-output.ts
+++ b/packages/actions/src/action-output.ts
@@ -1,0 +1,266 @@
+/**
+ * The one shape every action tool answers in, whoever refused or carried the
+ * action: what became of it, the target as the roster held it when the
+ * action ran, and the one identifier a creation named. A Conversation row is
+ * composed from the tool call's own arguments and this envelope and nothing
+ * else, so anything a row needs that the arguments do not carry — the
+ * provider a defaulted creation resolved to, a control's label and kind, the
+ * title a session wore before it was renamed or archived — is written here at
+ * execution rather than looked up later from a roster that has moved on.
+ *
+ * The status words are the ones the journal and the loop already count:
+ * accepted and unknown are `@sidecar/wire`'s own, and refused folds an
+ * adapter's rejected and unsupported into one word, because to the reader of
+ * a row they are one thing — an action that did not happen, with the reason
+ * it was answered. Unknown stays its own word: the action was dispatched and
+ * its answer lost, so it may have happened and is never retried.
+ */
+
+import {
+  maximumSessionTitleLength,
+  SESSION_APPLICATION_ID,
+  SESSION_CONTROL_KIND,
+  type Session,
+  type SessionControlKind,
+  type SessionIdentity,
+  sessionWithIdentity,
+} from "@sidecar/session";
+import {
+  ACTION_RESULT_STATUS,
+  type ActionResult,
+  RECORD_EXTRA_KEYS,
+  type Schema,
+  s,
+  TEXT_OVERFLOW,
+  UNKNOWN_ACTION_STATUS,
+  type UnknownActionResult,
+} from "@sidecar/wire";
+import { ACTION_KIND, type CarriedAction, type SessionActionKind } from "./action-kinds.js";
+import { maximumIdentifierLength } from "./action-schemas.js";
+
+export const ACTION_OUTPUT_STATUS = {
+  ACCEPTED: ACTION_RESULT_STATUS.ACCEPTED,
+  UNKNOWN: UNKNOWN_ACTION_STATUS,
+  REFUSED: "refused",
+} as const;
+
+export type ActionOutputStatus = (typeof ACTION_OUTPUT_STATUS)[keyof typeof ACTION_OUTPUT_STATUS];
+
+/**
+ * The target as it stood when the action ran. A session action names its
+ * session and, where the roster still held it, the title and agent it wore
+ * then; a creation names only the provider it resolved to, since it aims at
+ * a project rather than a session. The control and application fields ride
+ * only on the kinds that resolved one.
+ */
+export type ActionTargetSnapshot = {
+  readonly providerId: string;
+  readonly providerSessionId?: string;
+  readonly title?: string;
+  readonly agentId?: string;
+  readonly controlKind?: SessionControlKind;
+  readonly controlLabel?: string;
+  readonly applicationId?: string;
+};
+
+export type AcceptedActionOutput = {
+  readonly status: typeof ACTION_OUTPUT_STATUS.ACCEPTED;
+  readonly target?: ActionTargetSnapshot;
+  /** The session a creation's answer named: an identifier, never an address. */
+  readonly createdSession?: Readonly<SessionIdentity>;
+  /** The action landed, and a non-essential follow-up did not. */
+  readonly warning?: string;
+};
+
+export type UnknownActionOutput = {
+  readonly status: typeof ACTION_OUTPUT_STATUS.UNKNOWN;
+  readonly reason: string;
+  readonly target?: ActionTargetSnapshot;
+};
+
+export type RefusedActionOutput = {
+  readonly status: typeof ACTION_OUTPUT_STATUS.REFUSED;
+  readonly reason: string;
+  readonly target?: ActionTargetSnapshot;
+};
+
+export type ActionOutputEnvelope = AcceptedActionOutput | UnknownActionOutput | RefusedActionOutput;
+
+/** A sentence a person reads; past the bound it is cut with an ellipsis rather than lost whole. */
+export const maximumActionOutputSentenceLength = 2_000;
+
+const identifier = s.text({ max: maximumIdentifierLength });
+const sentence = s.text({
+  max: maximumActionOutputSentenceLength,
+  oneLine: true,
+  overflow: TEXT_OVERFLOW.ELLIPSIS,
+});
+
+/**
+ * An envelope is an answer, so a key a later build added is ignored rather
+ * than refused, and the fields a row would draw are dropped when malformed
+ * rather than refusing the envelope: a title the roster reported is worth
+ * having when it is well formed and worth nothing when it is not, and
+ * refusing the whole answer over one of them would cost the reader what
+ * became of the action. The identifiers stay required and exact, because an
+ * effect hangs on them.
+ */
+const answer = <Fields extends Parameters<typeof s.record>[0]>(fields: Fields) =>
+  s.record(fields, { extraKeys: RECORD_EXTRA_KEYS.IGNORE });
+
+const TARGET_SNAPSHOT: Schema<ActionTargetSnapshot> = answer({
+  providerId: identifier,
+  providerSessionId: identifier.optional(),
+  title: s.dropRefused(s.text({ max: maximumSessionTitleLength })),
+  agentId: s.dropRefused(identifier),
+  controlKind: s.dropRefused(s.enumOf(Object.values(SESSION_CONTROL_KIND))),
+  controlLabel: s.dropRefused(s.text({ max: maximumSessionTitleLength })),
+  applicationId: s.dropRefused(s.enumOf(Object.values(SESSION_APPLICATION_ID))),
+});
+
+const CREATED_SESSION: Schema<SessionIdentity> = answer({
+  providerId: identifier,
+  providerSessionId: identifier,
+});
+
+/**
+ * The envelope as it is validated on write and read back: every action tool's
+ * output has to read under this schema, and a record that does not is not an
+ * action's output at all.
+ */
+export const ACTION_OUTPUT: Schema<ActionOutputEnvelope> = s.union([
+  answer({
+    status: s.literal(ACTION_OUTPUT_STATUS.ACCEPTED),
+    target: TARGET_SNAPSHOT.optional(),
+    createdSession: CREATED_SESSION.optional(),
+    warning: s.dropRefused(sentence),
+  }),
+  answer({
+    status: s.literal(ACTION_OUTPUT_STATUS.UNKNOWN),
+    reason: sentence,
+    target: TARGET_SNAPSHOT.optional(),
+  }),
+  answer({
+    status: s.literal(ACTION_OUTPUT_STATUS.REFUSED),
+    reason: sentence,
+    target: TARGET_SNAPSHOT.optional(),
+  }),
+]);
+
+export function refusedActionOutput(
+  reason: string,
+  target?: ActionTargetSnapshot,
+): RefusedActionOutput {
+  return {
+    status: ACTION_OUTPUT_STATUS.REFUSED,
+    reason,
+    ...(target !== undefined ? { target } : undefined),
+  };
+}
+
+export function unknownActionOutput(
+  reason: string,
+  target?: ActionTargetSnapshot,
+): UnknownActionOutput {
+  return {
+    status: ACTION_OUTPUT_STATUS.UNKNOWN,
+    reason,
+    ...(target !== undefined ? { target } : undefined),
+  };
+}
+
+export function acceptedActionOutput(
+  details: Omit<AcceptedActionOutput, "status"> = {},
+): AcceptedActionOutput {
+  return { status: ACTION_OUTPUT_STATUS.ACCEPTED, ...details };
+}
+
+/**
+ * What carrying an action answered, before it is folded into the envelope:
+ * the three words every adapter and tracker answers in, the lost answer, and
+ * on an acceptance the two things a creation's answer may add. The created
+ * session is already an identity here, composed by the performer that knows
+ * which provider it asked.
+ */
+export type CarriedActionResult =
+  | {
+      readonly status: typeof ACTION_RESULT_STATUS.ACCEPTED;
+      readonly createdSession?: Readonly<SessionIdentity>;
+      readonly warning?: string;
+    }
+  | Exclude<ActionResult, { status: typeof ACTION_RESULT_STATUS.ACCEPTED }>
+  | UnknownActionResult;
+
+/** Folds a carried result into the envelope under the target the performer resolved. */
+export function actionOutputFromResult(
+  result: CarriedActionResult,
+  target?: ActionTargetSnapshot,
+): ActionOutputEnvelope {
+  switch (result.status) {
+    case ACTION_RESULT_STATUS.ACCEPTED:
+      return acceptedActionOutput({
+        ...(target !== undefined ? { target } : undefined),
+        ...(result.createdSession !== undefined
+          ? { createdSession: result.createdSession }
+          : undefined),
+        ...(result.warning !== undefined ? { warning: result.warning } : undefined),
+      });
+    case UNKNOWN_ACTION_STATUS:
+      return unknownActionOutput(result.reason, target);
+    case ACTION_RESULT_STATUS.REJECTED:
+    case ACTION_RESULT_STATUS.UNSUPPORTED:
+      return refusedActionOutput(result.reason, target);
+  }
+}
+
+function sessionSnapshot(
+  identity: SessionIdentity,
+  sessions: readonly Session[],
+): ActionTargetSnapshot {
+  const session = sessionWithIdentity(identity, sessions);
+  const agentId = session?.agent?.id;
+  return {
+    providerId: identity.providerId,
+    providerSessionId: identity.providerSessionId,
+    ...(session !== undefined ? { title: session.title } : undefined),
+    ...(agentId !== undefined ? { agentId } : undefined),
+  };
+}
+
+/**
+ * The target of one admitted session action, as the roster held it when the
+ * action ran. Every field is read back out of the admitted action or the
+ * roster the performer holds — the control the advertisement itself supplied,
+ * the application admission resolved, the provider a creation landed on —
+ * never out of a caller's copy. A session the roster no longer holds still
+ * names its identity, with no title to give.
+ */
+export function actionTargetSnapshot(
+  action: CarriedAction<SessionActionKind>,
+  sessions: readonly Session[],
+): ActionTargetSnapshot {
+  switch (action.kind) {
+    case ACTION_KIND.CONTROL: {
+      const { controlKind, label } = action.control;
+      return {
+        ...sessionSnapshot(action.identity, sessions),
+        ...(controlKind !== undefined ? { controlKind } : undefined),
+        controlLabel: label,
+      };
+    }
+    case ACTION_KIND.OPEN:
+      return {
+        ...sessionSnapshot(action.identity, sessions),
+        ...(action.applicationId !== undefined
+          ? { applicationId: action.applicationId }
+          : undefined),
+      };
+    case ACTION_KIND.CREATE_WORKSPACE:
+      return { providerId: action.providerId };
+    case ACTION_KIND.MESSAGE:
+    case ACTION_KIND.ADD_AGENT:
+    case ACTION_KIND.RENAME_WORKSPACE:
+    case ACTION_KIND.RENAME_SESSION:
+      return sessionSnapshot(action.identity, sessions);
+  }
+}

--- a/packages/actions/src/action-output.ts
+++ b/packages/actions/src/action-output.ts
@@ -68,6 +68,8 @@ export type AcceptedActionOutput = {
   readonly target?: ActionTargetSnapshot;
   /** The session a creation's answer named: an identifier, never an address. */
   readonly createdSession?: Readonly<SessionIdentity>;
+  /** The carrier's own sentence about how the action landed, where it had one. */
+  readonly note?: string;
   /** The action landed, and a non-essential follow-up did not. */
   readonly warning?: string;
 };
@@ -133,6 +135,7 @@ export const ACTION_OUTPUT: Schema<ActionOutputEnvelope> = s.union([
     status: s.literal(ACTION_OUTPUT_STATUS.ACCEPTED),
     target: TARGET_SNAPSHOT.optional(),
     createdSession: CREATED_SESSION.optional(),
+    note: s.dropRefused(sentence),
     warning: s.dropRefused(sentence),
   }),
   answer({
@@ -186,6 +189,7 @@ export type CarriedActionResult =
   | {
       readonly status: typeof ACTION_RESULT_STATUS.ACCEPTED;
       readonly createdSession?: Readonly<SessionIdentity>;
+      readonly note?: string;
       readonly warning?: string;
     }
   | Exclude<ActionResult, { status: typeof ACTION_RESULT_STATUS.ACCEPTED }>
@@ -203,6 +207,7 @@ export function actionOutputFromResult(
         ...(result.createdSession !== undefined
           ? { createdSession: result.createdSession }
           : undefined),
+        ...(result.note !== undefined ? { note: result.note } : undefined),
         ...(result.warning !== undefined ? { warning: result.warning } : undefined),
       });
     case UNKNOWN_ACTION_STATUS:

--- a/packages/actions/src/action-schemas.ts
+++ b/packages/actions/src/action-schemas.ts
@@ -34,7 +34,7 @@ import {
 import { SESSION_LIST_ALL, SESSION_LIST_VOICE } from "./action-kinds.js";
 
 /** An identifier travels in a URL segment or a request field, never as prose. */
-const maximumIdentifierLength = 200;
+export const maximumIdentifierLength = 200;
 
 /**
  * Every value a spoken narrowing may name, fixed by the build: the whole-list

--- a/packages/actions/src/index.ts
+++ b/packages/actions/src/index.ts
@@ -1,5 +1,6 @@
 export * from "./action-kinds.js";
 export * from "./action-narration.js";
+export * from "./action-output.js";
 export * from "./actions.js";
 export * from "./adapter-requests.js";
 export * from "./admit.js";

--- a/packages/brain/src/acceptance.test.ts
+++ b/packages/brain/src/acceptance.test.ts
@@ -3,7 +3,7 @@ import { promises as fs } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
-import { REALTIME_TOOL } from "@sidecar/actions";
+import { type ActionOutputEnvelope, acceptedActionOutput, REALTIME_TOOL } from "@sidecar/actions";
 import {
   HOSTED_BRAIN_CONTRACT_VERSION,
   HOSTED_BRAIN_OPERATION,
@@ -273,7 +273,7 @@ function host(
   runtimeOver: (model: ModelAdapter) => AgentRuntime,
   model: ModelAdapter,
   repository = fakeBrainStateRepository(),
-  performer: () => Promise<WireRecord> = async () => ({ status: ACTION_RESULT_STATUS.ACCEPTED }),
+  performer: () => Promise<ActionOutputEnvelope> = async () => acceptedActionOutput(),
   overrides: Partial<BrainAgentOptions> = {},
 ): Host {
   const clock = new FakeClock();

--- a/packages/brain/src/agent.test.ts
+++ b/packages/brain/src/agent.test.ts
@@ -1,6 +1,12 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { REALTIME_TOOL, type RealtimeFunctionCall } from "@sidecar/actions";
+import {
+  type ActionOutputEnvelope,
+  acceptedActionOutput,
+  REALTIME_TOOL,
+  type RealtimeFunctionCall,
+  refusedActionOutput,
+} from "@sidecar/actions";
 import { RESPONSES_INPUT_ITEM_TYPE } from "@sidecar/hosted";
 import { TOOL_LOOP_RUNTIME } from "@sidecar/runtime";
 import { checkpointFormatTag, RUN_ORIGIN } from "@sidecar/runtime/vocabulary";
@@ -9,7 +15,7 @@ import {
   type ProviderTranscriptSinceResult,
   SESSION_STATUS,
 } from "@sidecar/session";
-import { ACTION_RESULT_STATUS, type WireRecord } from "@sidecar/wire";
+import { ACTION_RESULT_STATUS } from "@sidecar/wire";
 import { type BrainPersistedState, freshBrainState } from "./envelope.js";
 import { BrainGenerationClock } from "./generation-clock.js";
 import {
@@ -441,12 +447,10 @@ test("a developer ask carries every action with a live execution, revoked once t
   });
   const h = harness({
     actions: {
-      perform: async (functionCall, execution): Promise<WireRecord> => {
+      perform: async (functionCall, execution): Promise<ActionOutputEnvelope> => {
         performedLate.push({ call: functionCall, execution });
         await held;
-        return execution.isRevoked()
-          ? { status: ACTION_RESULT_STATUS.REJECTED, reason: "turn over" }
-          : { status: ACTION_RESULT_STATUS.ACCEPTED };
+        return execution.isRevoked() ? refusedActionOutput("turn over") : acceptedActionOutput();
       },
     },
   });
@@ -1066,15 +1070,13 @@ test("a Clear or expiry asked for while a write is out on disk revokes a held ac
     let releasePreparation: (() => void) | undefined;
     let effects = 0;
     const actions: BrainActionPerformer = {
-      perform: async (_call, execution): Promise<WireRecord> => {
+      perform: async (_call, execution): Promise<ActionOutputEnvelope> => {
         await new Promise<void>((resolve) => {
           releasePreparation = resolve;
         });
-        if (execution.isRevoked()) {
-          return { status: ACTION_RESULT_STATUS.REJECTED, reason: "revoked before the effect" };
-        }
+        if (execution.isRevoked()) return refusedActionOutput("revoked before the effect");
         effects += 1;
-        return { status: ACTION_RESULT_STATUS.ACCEPTED };
+        return acceptedActionOutput();
       },
     };
     const h = harness({ actions });

--- a/packages/brain/src/harness.ts
+++ b/packages/brain/src/harness.ts
@@ -1,5 +1,14 @@
 import assert from "node:assert/strict";
-import { REALTIME_TOOL, type RealtimeFunctionCall, realtimeToolFamily } from "@sidecar/actions";
+import {
+  ACTION_OUTPUT,
+  ACTION_OUTPUT_STATUS,
+  type ActionOutputEnvelope,
+  acceptedActionOutput,
+  REALTIME_TOOL,
+  type RealtimeFunctionCall,
+  realtimeToolFamily,
+  refusedActionOutput,
+} from "@sidecar/actions";
 import { RESPONSES_INPUT_ITEM_TYPE } from "@sidecar/hosted";
 import { notebookMemoryProvider } from "@sidecar/memory";
 import { RESPONSES_ITEM_FORMAT, TOOL_LOOP_RUNTIME } from "@sidecar/runtime";
@@ -37,6 +46,7 @@ import { BRAIN_DEFAULTS, BrainAgent, type BrainAgentOptions, LOOK_SUBJECT } from
 import { ResponsesContextEngine } from "./context-engine.js";
 import { type BrainPersistedState, MAXIMUM_TERMINAL_REQUESTS } from "./envelope.js";
 import type { BrainActionExecution, BrainActionPerformer } from "./performer.js";
+import { parsedRecord } from "./records.js";
 import {
   BRAIN_REQUEST_ORIGIN,
   BRAIN_REQUEST_STATUS,
@@ -50,6 +60,7 @@ import { BrainStateStore } from "./state-store.js";
 import { type FakeBrainStateRepository, fakeBrainStateRepository } from "./testing.js";
 import { BRAIN_TOOL, TOOL_GROUP } from "./tools.js";
 import type { BrainTurnTraceRecord } from "./trace.js";
+import { REFUSAL_REASON } from "./turn.js";
 import { BRAIN_WAKE_KIND, type BrainDelivery, type BrainWakeEvent } from "./wake-events.js";
 
 const TOOL_LOOP_IDENTITY = { id: TOOL_LOOP_RUNTIME.ID, version: TOOL_LOOP_RUNTIME.VERSION };
@@ -549,8 +560,9 @@ export function assertNoActionReached(h: Harness): void {
   for (const forbidden of OBSERVATION_ACTIONS) {
     const output = outputs.find((entry) => entry.callId === forbidden.call_id);
     assert.ok(output, `${String(forbidden.call_id)} was answered`);
-    assert.ok(output.output.includes("not run"), output.output);
-    assert.ok(output.output.includes(ACTION_RESULT_STATUS.REJECTED));
+    const envelope = ACTION_OUTPUT.parse(parsedRecord(output.output));
+    assert.equal(envelope?.status, ACTION_OUTPUT_STATUS.REFUSED);
+    assert.equal(envelope?.reason, REFUSAL_REASON.NOT_ALLOWED);
   }
   assert.ok(h.traces.every((trace) => trace.origin === RUN_ORIGIN.OBSERVATION));
   // Denied at the schemas as well as at dispatch: the model was never shown an action.
@@ -576,15 +588,13 @@ export function heldPerformer() {
   const performed: RealtimeFunctionCall[] = [];
   const executions: BrainActionExecution[] = [];
   const actions: BrainActionPerformer = {
-    perform: async (functionCall, execution): Promise<WireRecord> => {
+    perform: async (functionCall, execution): Promise<ActionOutputEnvelope> => {
       performed.push(functionCall);
       executions.push(execution);
       await new Promise<void>((resolve) => {
         releases.push(resolve);
       });
-      return execution.isRevoked()
-        ? { status: ACTION_RESULT_STATUS.REJECTED, reason: "turn over" }
-        : { status: ACTION_RESULT_STATUS.ACCEPTED };
+      return execution.isRevoked() ? refusedActionOutput("turn over") : acceptedActionOutput();
     },
   };
   return { actions, releases, performed, executions };

--- a/packages/brain/src/journal.test.ts
+++ b/packages/brain/src/journal.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { REALTIME_TOOL } from "@sidecar/actions";
+import { REALTIME_TOOL, refusedActionOutput } from "@sidecar/actions";
 import { ACTION_RESULT_STATUS, isWireString } from "@sidecar/wire";
 import { freshBrainState } from "./envelope.js";
 import {
@@ -89,7 +89,7 @@ test("a performer that throws after dispatch leaves an unknown action, kept thro
   // A confirmed refusal, by contrast, is a refusal: nothing unknown about it.
   const refusing = harness({
     actions: {
-      perform: async () => ({ status: ACTION_RESULT_STATUS.REJECTED, reason: "not observed" }),
+      perform: async () => refusedActionOutput("not observed"),
     },
   });
   refusing.client.answers.push(

--- a/packages/brain/src/ledger.test.ts
+++ b/packages/brain/src/ledger.test.ts
@@ -1,8 +1,13 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import {
+  type ActionOutputEnvelope,
+  acceptedActionOutput,
+  refusedActionOutput,
+} from "@sidecar/actions";
 import { RESPONSES_INPUT_ITEM_TYPE } from "@sidecar/hosted";
 import { RUN_ORIGIN } from "@sidecar/runtime/vocabulary";
-import { ACTION_RESULT_STATUS, type WireRecord } from "@sidecar/wire";
+import { ACTION_RESULT_STATUS } from "@sidecar/wire";
 import { BrainAgent, LOOK_SUBJECT } from "./agent.js";
 import { type BrainPersistedState, freshBrainState } from "./envelope.js";
 import {
@@ -94,11 +99,11 @@ test("a checkpoint that fails after an action keeps its result in memory, blocks
   let repository: FakeBrainStateRepository | undefined;
   const h = harness({
     actions: {
-      perform: async (): Promise<WireRecord> => {
+      perform: async (): Promise<ActionOutputEnvelope> => {
         acted += 1;
         // The disk goes away from the moment the first effect has happened.
         repository?.refuse();
-        return { status: ACTION_RESULT_STATUS.ACCEPTED };
+        return acceptedActionOutput();
       },
     },
   });
@@ -329,7 +334,7 @@ test("a copy taken before the second model answer already carries the actions th
         dispatched += 1;
         if (dispatched === 1) return Promise.reject(new Error("socket closed after send"));
         if (dispatched === 2) {
-          return Promise.resolve({ status: ACTION_RESULT_STATUS.REJECTED, reason: "not observed" });
+          return Promise.resolve(refusedActionOutput("not observed"));
         }
         return held.actions.perform(functionCall, execution);
       },

--- a/packages/brain/src/performer.ts
+++ b/packages/brain/src/performer.ts
@@ -1,7 +1,6 @@
-import type { RealtimeFunctionCall } from "@sidecar/actions";
+import type { ActionOutputEnvelope, RealtimeFunctionCall } from "@sidecar/actions";
 import type { RunOrigin } from "@sidecar/runtime/vocabulary";
 import type { Session, SessionIdentity } from "@sidecar/session";
-import type { WireRecord } from "@sidecar/wire";
 
 /**
  * The roster as the host renders it, with the identities every tool argument
@@ -37,7 +36,14 @@ export interface BrainActionExecution {
   readonly signal: AbortSignal;
 }
 
-/** Carries one action for the host to validate and perform; answers what happened as a record. */
+/**
+ * Carries one action for the host to validate and perform, and answers what
+ * happened in the one envelope every action tool shares: the status, the
+ * target as the roster held it at execution, and the session a creation named.
+ */
 export interface BrainActionPerformer {
-  perform(call: RealtimeFunctionCall, execution: BrainActionExecution): Promise<WireRecord>;
+  perform(
+    call: RealtimeFunctionCall,
+    execution: BrainActionExecution,
+  ): Promise<ActionOutputEnvelope>;
 }

--- a/packages/brain/src/tool-executor.ts
+++ b/packages/brain/src/tool-executor.ts
@@ -1,4 +1,10 @@
 import {
+  ACTION_OUTPUT,
+  realtimeToolFamily,
+  refusedActionOutput,
+  unknownActionOutput,
+} from "@sidecar/actions";
+import {
   type ChildCancellation,
   type ChildSpawnOutcome,
   type EffectiveToolPolicy,
@@ -35,6 +41,7 @@ import {
   isWireNumber,
   isWireString,
   text,
+  UNKNOWN_ACTION_STATUS,
   type WireRecord,
 } from "@sidecar/wire";
 import {
@@ -172,6 +179,31 @@ export function journaledEffect(policy: EffectiveToolPolicy, name: string): bool
 }
 
 /**
+ * How a kind of tool spells the two answers the executor itself gives: a
+ * refusal at the door, and a result it cannot vouch for. An action tool
+ * answers in the envelope every action tool shares, whoever wrote the answer;
+ * every other tool answers the bare record it always has.
+ */
+interface ExecutorOutcomes {
+  readonly refuse: (reason: string) => WireRecord;
+  readonly unknown: (reason: string) => WireRecord;
+}
+
+const RECORD_OUTCOMES: ExecutorOutcomes = {
+  refuse: rejection,
+  unknown: (reason) => ({ status: UNKNOWN_ACTION_STATUS, reason }),
+};
+
+const ACTION_OUTCOMES: ExecutorOutcomes = {
+  refuse: refusedActionOutput,
+  unknown: unknownActionOutput,
+};
+
+function outcomesFor(name: string): ExecutorOutcomes {
+  return realtimeToolFamily(name) !== undefined ? ACTION_OUTCOMES : RECORD_OUTCOMES;
+}
+
+/**
  * Why the policy refuses a call, from the policy's own answer: a name the
  * catalog never held, the briefing channel withheld by the turn's own layer
  * because the reply is the speech, or a tool a configured layer removed.
@@ -181,12 +213,13 @@ export function refusalForPolicy(
   name: string,
 ): WireRecord | undefined {
   if (policy.allows(name)) return undefined;
+  const { refuse } = outcomesFor(name);
   const layer = policy.deniedBy(name);
-  if (layer === undefined) return rejection(REFUSAL_REASON.NOT_OFFERED);
+  if (layer === undefined) return refuse(REFUSAL_REASON.NOT_OFFERED);
   if (layer === TOOL_POLICY_LAYER.TURN && name === BRAIN_TOOL.ANNOUNCE) {
-    return rejection(REFUSAL_REASON.ANNOUNCE_IN_ASK);
+    return refuse(REFUSAL_REASON.ANNOUNCE_IN_ASK);
   }
-  return rejection(REFUSAL_REASON.NOT_ALLOWED);
+  return refuse(REFUSAL_REASON.NOT_ALLOWED);
 }
 
 export function createTurnToolExecutor(
@@ -216,19 +249,20 @@ export function createTurnToolExecutor(
     effect: () => Promise<WireRecord>,
   ): Promise<WireRecord> => {
     const { run, generation } = context;
+    const outcomes = outcomesFor(call.name);
     if (dependencies.runRevoked(run) || execution.isRevoked()) {
-      return rejection(REFUSAL_REASON.RUN_REVOKED);
+      return outcomes.refuse(REFUSAL_REASON.RUN_REVOKED);
     }
     const recorded = generation.journal.get(run.runId, call.callId);
     if (recorded) {
       if (recorded.argumentsJson !== call.argumentsJson) {
-        return rejection(REFUSAL_REASON.CALL_ID_REUSED);
+        return outcomes.refuse(REFUSAL_REASON.CALL_ID_REUSED);
       }
       return recorded.outputJson === undefined
-        ? { ...UNKNOWN_ACTION_RESULT }
+        ? outcomes.unknown(UNKNOWN_ACTION_RESULT.reason)
         : parsedRecord(recorded.outputJson);
     }
-    if (run.checkpointFailed) return rejection(REFUSAL_REASON.NOT_CHECKPOINTED);
+    if (run.checkpointFailed) return outcomes.refuse(REFUSAL_REASON.NOT_CHECKPOINTED);
     generation.journal.start({
       runId: run.runId,
       callId: call.callId,
@@ -239,16 +273,16 @@ export function createTurnToolExecutor(
     if (!(await dependencies.checkpoint(context))) {
       generation.journal.forget(run.runId, call.callId);
       run.checkpointFailed = true;
-      return rejection(REFUSAL_REASON.NOT_CHECKPOINTED);
+      return outcomes.refuse(REFUSAL_REASON.NOT_CHECKPOINTED);
     }
     let output: WireRecord;
     try {
       output = await effect();
     } catch {
-      output = { ...UNCONFIRMED_ACTION_RESULT };
+      output = outcomes.unknown(UNCONFIRMED_ACTION_RESULT.reason);
     }
     if (output.status === ACTION_RESULT_STATUS.ACCEPTED) run.performedActions += 1;
-    if (output.status === UNCONFIRMED_ACTION_RESULT.status) run.unknownActions += 1;
+    if (output.status === UNKNOWN_ACTION_STATUS) run.unknownActions += 1;
     generation.journal.settle(run.runId, call.callId, JSON.stringify(output), dependencies.now());
     return output;
   };
@@ -420,12 +454,20 @@ export function createTurnToolExecutor(
       };
       const tool = descriptors.get(call.name);
       if (tool?.execution === TOOL_EXECUTION.PERFORMER) {
+        // The performer's answer is validated before the journal keeps it. One
+        // this build cannot read is answered unknown: the action was dispatched,
+        // and what became of it is exactly what could not be read.
         return answer(
-          await performJournaled(call, execution, () =>
-            dependencies.actions.perform(
-              { name: call.name, argumentsJson: call.argumentsJson },
-              execution,
-            ),
+          await performJournaled(
+            call,
+            execution,
+            async () =>
+              ACTION_OUTPUT.parse(
+                await dependencies.actions.perform(
+                  { name: call.name, argumentsJson: call.argumentsJson },
+                  execution,
+                ),
+              ) ?? unknownActionOutput(REFUSAL_REASON.UNREADABLE_ANSWER),
           ),
         );
       }

--- a/packages/brain/src/turn.ts
+++ b/packages/brain/src/turn.ts
@@ -46,6 +46,7 @@ export const REFUSAL_REASON = {
   NOT_OFFERED: "not run: no such tool in this turn",
   EMPTY_BRIEFING: "a briefing needs words",
   ACTION_FAILED: "the action did not complete",
+  UNREADABLE_ANSWER: "the action answered in a shape this build cannot read",
   READ_FAILED: "the transcript could not be read",
   RUN_REVOKED: "not run: this ask was cancelled or its run ended",
   NOT_CHECKPOINTED: "not run: the action could not be recorded before running, so it was not run",

--- a/packages/host/src/brain/action-performer.test.ts
+++ b/packages/host/src/brain/action-performer.test.ts
@@ -294,20 +294,33 @@ test("a carried action's refusal and lost answer keep their words apart: refused
   });
 });
 
-test("a panel's answer is read as untrusted: a bare result folds into the envelope and an unreadable shape is a refusal", async () => {
+test("a panel's answer is read in its own dialect: an acceptance keeps its note and drops the rest, a lost answer stays unknown, and an unreadable shape is a refusal", async () => {
   const answers: WireRecord[] = [
+    { status: ACTION_RESULT_STATUS.ACCEPTED, tab: "settings", kind: "setting" },
+    { status: ACTION_RESULT_STATUS.ACCEPTED, note: "The ask is drafted in the composer." },
+    { status: ACTION_RESULT_STATUS.ACCEPTED, outcome: "Up to date." },
     { status: UNKNOWN_ACTION_STATUS, reason: "the panel went away" },
+    { status: ACTION_RESULT_STATUS.REJECTED },
     { outcome: "fine" },
   ];
   const { actions } = performer({
     appGuide: () => CAPTIONS_GUIDE,
     performAppAction: async () => answers.shift() ?? {},
   });
-  assert.deepEqual(await actions.perform(SETTING_CALL, LIVE), {
-    status: ACTION_OUTPUT_STATUS.UNKNOWN,
-    reason: "the panel went away",
-  });
-  assert.equal((await actions.perform(SETTING_CALL, LIVE)).status, ACTION_OUTPUT_STATUS.REFUSED);
+  const outcomes = [];
+  while (answers.length > 0) outcomes.push(await actions.perform(SETTING_CALL, LIVE));
+  const unreadable = {
+    status: ACTION_OUTPUT_STATUS.REFUSED,
+    reason: "The panel answered in a shape this build cannot read.",
+  };
+  assert.deepEqual(outcomes, [
+    { status: ACTION_OUTPUT_STATUS.ACCEPTED },
+    { status: ACTION_OUTPUT_STATUS.ACCEPTED, note: "The ask is drafted in the composer." },
+    { status: ACTION_OUTPUT_STATUS.ACCEPTED, note: "Up to date." },
+    { status: ACTION_OUTPUT_STATUS.UNKNOWN, reason: "the panel went away" },
+    unreadable,
+    unreadable,
+  ]);
 });
 
 test("an issue action is refused outright while no tracker is connected", async () => {

--- a/packages/host/src/brain/action-performer.test.ts
+++ b/packages/host/src/brain/action-performer.test.ts
@@ -1,7 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import {
+  ACTION_OUTPUT,
+  ACTION_OUTPUT_STATUS,
   ACTION_REFUSAL,
+  type CarriedActionResult,
   type CarriedIssueAction,
   type CarriedSessionAction,
   REALTIME_TOOL,
@@ -17,11 +20,12 @@ import {
   ACTION_KIND,
   normalizeSession,
   type ObservedWorkspaceProject,
+  SESSION_CONTROL_KIND,
   SESSION_STATUS,
   type Session,
   WORKSPACE_TASK_SUPPORT,
 } from "@sidecar/session";
-import { ACTION_RESULT_STATUS } from "@sidecar/wire";
+import { ACTION_RESULT_STATUS, UNKNOWN_ACTION_STATUS, type WireRecord } from "@sidecar/wire";
 import {
   type BrainActionPerformerDependencies,
   createBrainActionPerformer,
@@ -91,6 +95,12 @@ const LISTED_PROJECT: ObservedWorkspaceProject = {
   taskSupport: WORKSPACE_TASK_SUPPORT.OPTIONAL,
 };
 
+const STOP_CONTROL = {
+  kind: ACTION_KIND.CONTROL,
+  id: "stop",
+  label: "Stop",
+  controlKind: SESSION_CONTROL_KIND.STOP,
+} as const;
 const observed = normalizeSession(
   { id: "claude-code", displayName: "Claude Code" },
   {
@@ -98,11 +108,22 @@ const observed = normalizeSession(
     title: "Fix the flaky test",
     status: SESSION_STATUS.WAITING,
     lastActivityAt: NOW,
-    advertises: [{ kind: ACTION_KIND.MESSAGE }],
+    agent: { id: "cursor", displayName: "Cursor" },
+    advertises: [{ kind: ACTION_KIND.MESSAGE }, STOP_CONTROL],
   },
 );
+const CONTROL_CALL = {
+  name: REALTIME_TOOL.RUN_SESSION_CONTROL,
+  argumentsJson: `{${IDENTITY},"control_id":"stop"}`,
+};
 
-function performer(overrides: Partial<BrainActionPerformerDependencies> = {}) {
+/** The one performer fake, answering every carried action with the result the test chose. */
+function performer(
+  overrides: Partial<BrainActionPerformerDependencies> = {},
+  answer: (action: CarriedSessionAction | CarriedIssueAction) => CarriedActionResult = () => ({
+    status: ACTION_RESULT_STATUS.ACCEPTED,
+  }),
+) {
   const performed: (CarriedSessionAction | CarriedIssueAction)[] = [];
   const recorded: ConversationEntry[] = [];
   const appActions: BrainAppActionRequest["action"][] = [];
@@ -111,7 +132,7 @@ function performer(overrides: Partial<BrainActionPerformerDependencies> = {}) {
     sessionActions: {
       perform: async (action) => {
         performed.push(action);
-        return { status: ACTION_RESULT_STATUS.ACCEPTED };
+        return answer(action);
       },
       openSession: async () => ({ status: ACTION_RESULT_STATUS.ACCEPTED }),
       openSessionApplication: async () => ({ status: ACTION_RESULT_STATUS.ACCEPTED }),
@@ -183,14 +204,110 @@ test("a session action reaches the performer only for a session the roster holds
     },
     LIVE,
   );
-  assert.equal(stranger.status, ACTION_RESULT_STATUS.REJECTED);
+  assert.equal(stranger.status, ACTION_OUTPUT_STATUS.REFUSED);
   assert.equal(performed.length, 1);
 
   const unknown = await actions.perform({ name: "delete_everything", argumentsJson: "{}" }, LIVE);
   assert.deepEqual(unknown, {
-    status: ACTION_RESULT_STATUS.REJECTED,
-    reason: "No such tool exists.",
+    status: ACTION_OUTPUT_STATUS.REFUSED,
+    reason: ACTION_REFUSAL.NO_TOOL,
   });
+});
+
+test("every answer is the envelope: a session action's target as the roster held it, and the created session a creation named", async () => {
+  const { actions } = performer({ workspaceProjects: () => [LISTED_PROJECT] }, (action) =>
+    action.kind === ACTION_KIND.CREATE_WORKSPACE
+      ? {
+          status: ACTION_RESULT_STATUS.ACCEPTED,
+          createdSession: { providerId: "conductor", providerSessionId: "workspace-9" },
+        }
+      : { status: ACTION_RESULT_STATUS.ACCEPTED },
+  );
+
+  const sent = await actions.perform(MESSAGE_CALL, LIVE);
+  assert.deepEqual(sent, {
+    status: ACTION_OUTPUT_STATUS.ACCEPTED,
+    target: {
+      providerId: "claude-code",
+      providerSessionId: "session-a",
+      title: "Fix the flaky test",
+      agentId: "cursor",
+    },
+  });
+
+  const stopped = await actions.perform(CONTROL_CALL, LIVE);
+  assert.deepEqual(stopped, {
+    status: ACTION_OUTPUT_STATUS.ACCEPTED,
+    target: {
+      providerId: "claude-code",
+      providerSessionId: "session-a",
+      title: "Fix the flaky test",
+      agentId: "cursor",
+      controlKind: SESSION_CONTROL_KIND.STOP,
+      controlLabel: "Stop",
+    },
+  });
+
+  const created = await actions.perform(CREATE_CALL, LIVE);
+  assert.deepEqual(created, {
+    status: ACTION_OUTPUT_STATUS.ACCEPTED,
+    target: { providerId: "conductor" },
+    createdSession: { providerId: "conductor", providerSessionId: "workspace-9" },
+  });
+
+  for (const envelope of [sent, stopped, created]) {
+    assert.deepEqual(ACTION_OUTPUT.parse(envelope), envelope);
+  }
+});
+
+test("a carried action's refusal and lost answer keep their words apart: refused folds the adapter's two words, unknown stays unknown", async () => {
+  const outcomes: CarriedActionResult[] = [
+    { status: ACTION_RESULT_STATUS.REJECTED, reason: "the provider said no" },
+    { status: ACTION_RESULT_STATUS.UNSUPPORTED, reason: "no documented way in" },
+    { status: UNKNOWN_ACTION_STATUS, reason: "the node went away" },
+  ];
+  const { actions } = performer({}, () => {
+    const next = outcomes.shift();
+    assert.ok(next);
+    return next;
+  });
+  const target = {
+    providerId: "claude-code",
+    providerSessionId: "session-a",
+    title: "Fix the flaky test",
+    agentId: "cursor",
+  };
+  assert.deepEqual(await actions.perform(MESSAGE_CALL, LIVE), {
+    status: ACTION_OUTPUT_STATUS.REFUSED,
+    reason: "the provider said no",
+    target,
+  });
+  assert.deepEqual(await actions.perform(MESSAGE_CALL, LIVE), {
+    status: ACTION_OUTPUT_STATUS.REFUSED,
+    reason: "no documented way in",
+    target,
+  });
+  assert.deepEqual(await actions.perform(MESSAGE_CALL, LIVE), {
+    status: ACTION_OUTPUT_STATUS.UNKNOWN,
+    reason: "the node went away",
+    target,
+  });
+});
+
+test("a panel's answer is read as untrusted: a bare result folds into the envelope and an unreadable shape is a refusal", async () => {
+  const answers: WireRecord[] = [
+    { status: UNKNOWN_ACTION_STATUS, reason: "the panel went away" },
+    { outcome: "fine" },
+  ];
+  const { actions } = performer({
+    appGuide: () => CAPTIONS_GUIDE,
+    performAppAction: async () => answers.shift() ?? {},
+  });
+  assert.deepEqual(await actions.perform(SETTING_CALL, LIVE), {
+    status: ACTION_OUTPUT_STATUS.UNKNOWN,
+    reason: "the panel went away",
+  });
+  assert.equal((await actions.perform(SETTING_CALL, LIVE)).status, ACTION_OUTPUT_STATUS.REFUSED);
 });
 
 test("an issue action is refused outright while no tracker is connected", async () => {
@@ -202,7 +319,7 @@ test("an issue action is refused outright while no tracker is connected", async 
     },
     LIVE,
   );
-  assert.equal(refused.status, ACTION_RESULT_STATUS.REJECTED);
+  assert.equal(refused.status, ACTION_OUTPUT_STATUS.REFUSED);
   assert.equal(performed.length, 0);
 });
 
@@ -303,7 +420,7 @@ test("an app action is validated against the reported guide before a renderer ca
     },
     LIVE,
   );
-  assert.equal(unlisted.status, ACTION_RESULT_STATUS.REJECTED);
+  assert.equal(unlisted.status, ACTION_OUTPUT_STATUS.REFUSED);
   assert.equal(appActions.length, 1);
 });
 
@@ -344,7 +461,7 @@ test("an action with no turn standing is refused in main before any validator or
   for (const execution of malformed) {
     for (const call of [MESSAGE_CALL, REMEMBER_CALL, SETTING_CALL]) {
       const refused = await actions.perform(call, execution);
-      assert.equal(refused.status, ACTION_RESULT_STATUS.REJECTED);
+      assert.equal(refused.status, ACTION_OUTPUT_STATUS.REFUSED);
     }
   }
   assert.deepEqual(performed, []);
@@ -364,7 +481,7 @@ test("a turn revoked while the roster refreshed is refused before the effect, an
     MESSAGE_CALL,
     developerTurn(() => revoked),
   );
-  assert.equal(refused.status, ACTION_RESULT_STATUS.REJECTED);
+  assert.equal(refused.status, ACTION_OUTPUT_STATUS.REFUSED);
   assert.equal(refused.reason, ACTION_REFUSAL.TURN_OVER);
   assert.deepEqual(performed, []);
   assert.deepEqual(recorded, []);
@@ -383,7 +500,7 @@ test("a turn revoked while the creation defaults were read is refused before the
     CREATE_CALL,
     developerTurn(() => revoked),
   );
-  assert.equal(refused.status, ACTION_RESULT_STATUS.REJECTED);
+  assert.equal(refused.status, ACTION_OUTPUT_STATUS.REFUSED);
   assert.deepEqual(performed, []);
   assert.deepEqual(recorded, []);
 });
@@ -392,10 +509,10 @@ test("a revoked turn reaches no memory write and no renderer action", async () =
   const { actions, facts, appActions } = performer({ appGuide: () => CAPTIONS_GUIDE });
   const over = developerTurn(() => true);
   const notSaved = await actions.perform(REMEMBER_CALL, over);
-  assert.equal(notSaved.status, ACTION_RESULT_STATUS.REJECTED);
+  assert.equal(notSaved.status, ACTION_OUTPUT_STATUS.REFUSED);
   assert.deepEqual(facts(), []);
   const notChanged = await actions.perform(SETTING_CALL, over);
-  assert.equal(notChanged.status, ACTION_RESULT_STATUS.REJECTED);
+  assert.equal(notChanged.status, ACTION_OUTPUT_STATUS.REFUSED);
   assert.deepEqual(appActions, []);
 });
 
@@ -409,7 +526,7 @@ test("an action is validated against the roster as refreshed inside the turn, no
     },
   });
   const refused = await actions.perform(MESSAGE_CALL, LIVE);
-  assert.equal(refused.status, ACTION_RESULT_STATUS.REJECTED);
+  assert.equal(refused.status, ACTION_OUTPUT_STATUS.REFUSED);
   assert.deepEqual(performed, []);
 });
 
@@ -444,7 +561,7 @@ test("an issue act observes nothing: no pass runs for an action the roster canno
     { name: REALTIME_TOOL.COMMENT_ON_ISSUE, argumentsJson: "{}" },
     LIVE,
   );
-  assert.equal(refused.status, ACTION_RESULT_STATUS.REJECTED);
+  assert.equal(refused.status, ACTION_OUTPUT_STATUS.REFUSED);
   assert.equal(passes, 0);
 });
 
@@ -482,7 +599,7 @@ test("a cancel during the roster refresh or the defaults read settles the action
     assert.equal(settled, false);
     controller.abort();
     const outcome = await pending;
-    assert.equal(outcome.status, ACTION_RESULT_STATUS.REJECTED);
+    assert.equal(outcome.status, ACTION_OUTPUT_STATUS.REFUSED);
     assert.deepEqual(h.performed, []);
     release?.();
     await drainMicrotasks(1);

--- a/packages/host/src/brain/action-performer.ts
+++ b/packages/host/src/brain/action-performer.ts
@@ -7,6 +7,7 @@ import {
   acceptedActionOutput,
   actionOutputFromResult,
   actionTargetSnapshot,
+  type CarriedActionResult,
   dispatchByKind,
   type RealtimeFunctionCall,
   type RememberedFact,
@@ -24,12 +25,18 @@ import type { TrackedIssue } from "@sidecar/session";
 import {
   CONVERSATION_ENTRY_KIND,
   type ConversationEntry,
-  isSessionWriteResult,
   type ObservedWorkspaceProject,
   type Session,
   workspaceAgentModels,
 } from "@sidecar/session";
-import { isWireString, type WireRecord } from "@sidecar/wire";
+import {
+  ACTION_RESULT_STATUS,
+  isWireString,
+  RECORD_EXTRA_KEYS,
+  s,
+  UNKNOWN_ACTION_STATUS,
+  type WireRecord,
+} from "@sidecar/wire";
 import type { SessionActionPerformer } from "../session-action-performer.js";
 
 /** The developer's saved creation tie-breaks, as the projects context narrates them. */
@@ -83,6 +90,36 @@ const REFUSAL = {
   MEMORY_NOT_REMOVED: "That memory could not be removed.",
   UNREADABLE_PANEL_ANSWER: "The panel answered in a shape this build cannot read.",
 } as const;
+
+/**
+ * The panel's answer to an app action, read as untrusted: the status and the
+ * sentence beside it, in the panel's own dialect — a refusal's reason, or the
+ * note or outcome an acceptance sometimes carries — and nothing else it says.
+ */
+const PANEL_ANSWER = s.record(
+  {
+    status: s.enumOf<CarriedActionResult["status"]>([
+      ACTION_RESULT_STATUS.ACCEPTED,
+      ACTION_RESULT_STATUS.REJECTED,
+      ACTION_RESULT_STATUS.UNSUPPORTED,
+      UNKNOWN_ACTION_STATUS,
+    ]),
+    reason: s.dropRefused(s.text()),
+    note: s.dropRefused(s.text()),
+    outcome: s.dropRefused(s.text()),
+  },
+  { extraKeys: RECORD_EXTRA_KEYS.IGNORE },
+);
+
+function panelResult(answered: WireRecord): CarriedActionResult | undefined {
+  const read = PANEL_ANSWER.parse(answered);
+  if (read === undefined) return undefined;
+  if (read.status === ACTION_RESULT_STATUS.ACCEPTED) {
+    const note = read.note ?? read.outcome;
+    return { status: read.status, ...(note !== undefined ? { note } : undefined) };
+  }
+  return read.reason === undefined ? undefined : { status: read.status, reason: read.reason };
+}
 
 /**
  * The gauntlet every action the brain asks for runs, in the main process: the
@@ -170,14 +207,14 @@ export function createBrainActionPerformer(
     );
   };
 
-  /** The panel's answer, read as untrusted: a shape this build cannot read is a refusal, never an acceptance. */
+  /** A panel answer this build cannot read is a refusal, never an acceptance. */
   const carryAppAction = async (
     action: BrainAppActionRequest["action"],
   ): Promise<ActionOutputEnvelope> => {
-    const answered = await dependencies.performAppAction(action);
-    return isSessionWriteResult(answered)
-      ? actionOutputFromResult(answered)
-      : refusedActionOutput(REFUSAL.UNREADABLE_PANEL_ANSWER);
+    const result = panelResult(await dependencies.performAppAction(action));
+    return result === undefined
+      ? refusedActionOutput(REFUSAL.UNREADABLE_PANEL_ANSWER)
+      : actionOutputFromResult(result);
   };
 
   return {

--- a/packages/host/src/brain/action-performer.ts
+++ b/packages/host/src/brain/action-performer.ts
@@ -2,10 +2,15 @@ import { randomUUID } from "node:crypto";
 import {
   ACTION_KIND,
   ACTION_REFUSAL,
+  type ActionOutputEnvelope,
   type AdmitContext,
+  acceptedActionOutput,
+  actionOutputFromResult,
+  actionTargetSnapshot,
   dispatchByKind,
   type RealtimeFunctionCall,
   type RememberedFact,
+  refusedActionOutput,
   type SessionActionKind,
   sessionActionConversationEntry,
   toolAction,
@@ -19,11 +24,12 @@ import type { TrackedIssue } from "@sidecar/session";
 import {
   CONVERSATION_ENTRY_KIND,
   type ConversationEntry,
+  isSessionWriteResult,
   type ObservedWorkspaceProject,
   type Session,
   workspaceAgentModels,
 } from "@sidecar/session";
-import { ACTION_RESULT_STATUS, isWireString, type WireRecord } from "@sidecar/wire";
+import { isWireString, type WireRecord } from "@sidecar/wire";
 import type { SessionActionPerformer } from "../session-action-performer.js";
 
 /** The developer's saved creation tie-breaks, as the projects context narrates them. */
@@ -75,11 +81,8 @@ const REFUSAL = {
   TURN_OVER: ACTION_REFUSAL.TURN_OVER,
   MEMORY_NOT_SAVED: "That memory could not be saved.",
   MEMORY_NOT_REMOVED: "That memory could not be removed.",
+  UNREADABLE_PANEL_ANSWER: "The panel answered in a shape this build cannot read.",
 } as const;
-
-function rejection(reason: string): WireRecord {
-  return { status: ACTION_RESULT_STATUS.REJECTED, reason };
-}
 
 /**
  * The gauntlet every action the brain asks for runs, in the main process: the
@@ -138,17 +141,22 @@ export function createBrainActionPerformer(
     };
   };
 
-  const carrySessionAction = (
+  const carrySessionAction = async (
     action: ValidatedAction<SessionActionKind>,
     execution: BrainActionExecution,
-  ): Promise<WireRecord> => {
+  ): Promise<ActionOutputEnvelope> => {
+    // The roster as admission just refreshed it is the snapshot the envelope
+    // carries: the title and agent the target wore when the action ran, read
+    // now rather than at render, when the session may be renamed or gone.
+    const sessions = dependencies.sessions();
+    const target = actionTargetSnapshot(action, sessions);
     // The ask is recorded before the outcome is known: a refusal still leaves
     // the developer having asked it, and the reply voicing the outcome is
     // recorded as what Luke said.
     dependencies.recordConversationEntry(
       sessionActionConversationEntry(
         action,
-        dependencies.sessions(),
+        sessions,
         execution.origin === RUN_ORIGIN.USER
           ? CONVERSATION_ENTRY_KIND.ACTION
           : CONVERSATION_ENTRY_KIND.OWN_ACTION,
@@ -156,20 +164,33 @@ export function createBrainActionPerformer(
     );
     // The performer awaits once more of its own before a create or a spawn,
     // so the execution rides along to be asked again there.
-    return dependencies.sessionActions.perform(action, execution);
+    return actionOutputFromResult(
+      await dependencies.sessionActions.perform(action, execution),
+      target,
+    );
+  };
+
+  /** The panel's answer, read as untrusted: a shape this build cannot read is a refusal, never an acceptance. */
+  const carryAppAction = async (
+    action: BrainAppActionRequest["action"],
+  ): Promise<ActionOutputEnvelope> => {
+    const answered = await dependencies.performAppAction(action);
+    return isSessionWriteResult(answered)
+      ? actionOutputFromResult(answered)
+      : refusedActionOutput(REFUSAL.UNREADABLE_PANEL_ANSWER);
   };
 
   return {
     async perform(call: RealtimeFunctionCall, execution: BrainActionExecution) {
-      if (!isExecution(execution)) return rejection(REFUSAL.NO_EXECUTION);
-      if (execution.isRevoked()) return rejection(REFUSAL.TURN_OVER);
+      if (!isExecution(execution)) return refusedActionOutput(REFUSAL.NO_EXECUTION);
+      if (execution.isRevoked()) return refusedActionOutput(REFUSAL.TURN_OVER);
       const admitted = await toolAction(call, admissionContext(execution));
-      if (admitted.kind === undefined) return rejection(admitted.reason);
-      if (execution.isRevoked()) return rejection(REFUSAL.TURN_OVER);
+      if (admitted.kind === undefined) return refusedActionOutput(admitted.reason);
+      if (execution.isRevoked()) return refusedActionOutput(REFUSAL.TURN_OVER);
       // Where each admitted action goes, named kind by kind: the two notebook
       // writes are carried here, an app action is the renderer's to perform, an
       // issue action reaches its tracker without a Conversation line, and a session
-      // action is recorded as it is carried.
+      // action is recorded as it is carried. Every answer is the one envelope.
       return dispatchByKind(admitted, {
         [ACTION_KIND.REMEMBER]: async (action) =>
           (await dependencies.notebook.remember({
@@ -177,20 +198,20 @@ export function createBrainActionPerformer(
             words: action.words,
             ...(action.replaces !== undefined ? { replaces: action.replaces } : undefined),
           }))
-            ? { status: ACTION_RESULT_STATUS.ACCEPTED }
-            : rejection(REFUSAL.MEMORY_NOT_SAVED),
+            ? acceptedActionOutput()
+            : refusedActionOutput(REFUSAL.MEMORY_NOT_SAVED),
         [ACTION_KIND.FORGET]: async (action) =>
           (await dependencies.notebook.forget(action.id))
-            ? { status: ACTION_RESULT_STATUS.ACCEPTED }
-            : rejection(REFUSAL.MEMORY_NOT_REMOVED),
-        [ACTION_KIND.SETTING]: (action) => dependencies.performAppAction(action),
-        [ACTION_KIND.PANEL]: (action) => dependencies.performAppAction(action),
-        [ACTION_KIND.FEEDBACK]: (action) => dependencies.performAppAction(action),
-        [ACTION_KIND.UPDATE]: (action) => dependencies.performAppAction(action),
-        [ACTION_KIND.ISSUE_STATE]: (action) =>
-          dependencies.sessionActions.perform(action, execution),
-        [ACTION_KIND.ISSUE_COMMENT]: (action) =>
-          dependencies.sessionActions.perform(action, execution),
+            ? acceptedActionOutput()
+            : refusedActionOutput(REFUSAL.MEMORY_NOT_REMOVED),
+        [ACTION_KIND.SETTING]: carryAppAction,
+        [ACTION_KIND.PANEL]: carryAppAction,
+        [ACTION_KIND.FEEDBACK]: carryAppAction,
+        [ACTION_KIND.UPDATE]: carryAppAction,
+        [ACTION_KIND.ISSUE_STATE]: async (action) =>
+          actionOutputFromResult(await dependencies.sessionActions.perform(action, execution)),
+        [ACTION_KIND.ISSUE_COMMENT]: async (action) =>
+          actionOutputFromResult(await dependencies.sessionActions.perform(action, execution)),
         [ACTION_KIND.MESSAGE]: (action) => carrySessionAction(action, execution),
         [ACTION_KIND.CONTROL]: (action) => carrySessionAction(action, execution),
         [ACTION_KIND.OPEN]: (action) => carrySessionAction(action, execution),

--- a/packages/host/src/session-action-performer.ts
+++ b/packages/host/src/session-action-performer.ts
@@ -3,6 +3,7 @@ import {
   ACTION_KIND,
   ACTION_REFUSAL,
   type ActionGuard,
+  type CarriedActionResult,
   dispatchByKind,
   guardedRead,
   type IssueActionKind,
@@ -51,7 +52,6 @@ import {
   ACTION_RESULT_STATUS,
   UNKNOWN_ACTION_STATUS,
   type UnknownActionResult,
-  type WireRecord,
 } from "@sidecar/wire";
 import { HOST_NODE_OPEN_KIND, type HostNodeOpenKind } from "./node-capabilities.js";
 import type { SettingsStore } from "./settings-store.js";
@@ -126,7 +126,7 @@ export interface SessionActionPerformer {
   perform(
     action: ValidatedAction<SessionActionKind | IssueActionKind>,
     guard?: ActionGuard,
-  ): Promise<WireRecord>;
+  ): Promise<CarriedActionResult>;
   openSession(identity: SessionIdentity): Promise<SessionOpenResult>;
   openSessionApplication(
     identity: SessionIdentity,
@@ -327,7 +327,7 @@ export function createSessionActionPerformer(
   // or, for a Superset-managed row, through the CLI that owns its terminal.
   const sendMessage = async (
     action: ValidatedAction<typeof ACTION_KIND.MESSAGE>,
-  ): Promise<WireRecord> => {
+  ): Promise<CarriedActionResult> => {
     const { identity } = action;
     const managed = supersetContext(identity);
     if (managed) {
@@ -346,7 +346,7 @@ export function createSessionActionPerformer(
   // the effect is built from on either path.
   const executeControl = async (
     action: ValidatedAction<typeof ACTION_KIND.CONTROL>,
-  ): Promise<WireRecord> => {
+  ): Promise<CarriedActionResult> => {
     const { identity, control } = action;
     const managed = supersetContext(identity);
     if (managed && isSupersetControlId(control.id)) {
@@ -455,12 +455,21 @@ export function createSessionActionPerformer(
         action.agent,
       );
       countSessionAction(plugin.provider.id, PRODUCT_SESSION_ACTION.WORKSPACE_CREATE, result);
-      // The named session was consumed above; the answer stays what became
-      // of the ask, so nothing rides out that the roster will not report on
-      // its own.
-      return result.warning
-        ? { status: ACTION_RESULT_STATUS.ACCEPTED, warning: result.warning }
-        : { status: ACTION_RESULT_STATUS.ACCEPTED };
+      // The session the creation named rides out as an identity under the
+      // provider that was asked — an identifier, never an address — for the
+      // envelope to record as the created session.
+      return {
+        status: ACTION_RESULT_STATUS.ACCEPTED,
+        ...(result.providerSessionId !== undefined
+          ? {
+              createdSession: {
+                providerId: plugin.provider.id,
+                providerSessionId: result.providerSessionId,
+              },
+            }
+          : undefined),
+        ...(result.warning !== undefined ? { warning: result.warning } : undefined),
+      };
     }
     return result;
   };
@@ -471,7 +480,7 @@ export function createSessionActionPerformer(
   const addWorkspaceAgent = async (
     action: ValidatedAction<typeof ACTION_KIND.ADD_AGENT>,
     guard: ActionGuard | undefined,
-  ): Promise<WireRecord> => {
+  ): Promise<CarriedActionResult> => {
     const { identity } = action;
     const managed = supersetContext(identity);
     if (managed) {
@@ -501,7 +510,7 @@ export function createSessionActionPerformer(
   // last pass, never from the action, which carries the session and the name.
   const renameWorkspace = async (
     action: ValidatedAction<typeof ACTION_KIND.RENAME_WORKSPACE>,
-  ): Promise<WireRecord> => {
+  ): Promise<CarriedActionResult> => {
     const { identity } = action;
     const managed = supersetContext(identity);
     if (managed) {
@@ -518,7 +527,7 @@ export function createSessionActionPerformer(
 
   const renameSession = async (
     action: ValidatedAction<typeof ACTION_KIND.RENAME_SESSION>,
-  ): Promise<WireRecord> =>
+  ): Promise<CarriedActionResult> =>
     performOnSession(action.identity, PRODUCT_SESSION_ACTION.SESSION_RENAME, (plugin) =>
       dispatchAction(plugin, "renameSession", providerSessionRenameRequest(action)),
     );
@@ -590,13 +599,13 @@ export function createSessionActionPerformer(
   const performSessionAction = (
     action: ValidatedAction<SessionActionKind>,
     guard: ActionGuard | undefined,
-  ): Promise<WireRecord> =>
+  ): Promise<CarriedActionResult> =>
     dispatchByKind(action, {
       [ACTION_KIND.MESSAGE]: sendMessage,
       [ACTION_KIND.CONTROL]: executeControl,
       // An open the brain carries was asked of Luke, never pressed on a row,
       // so the node is told a panel still stands over the chat coming forward.
-      [ACTION_KIND.OPEN]: async (open): Promise<WireRecord> =>
+      [ACTION_KIND.OPEN]: async (open): Promise<CarriedActionResult> =>
         open.applicationId
           ? openSessionApplication(
               open.identity,
@@ -604,7 +613,7 @@ export function createSessionActionPerformer(
               HOST_NODE_OPEN_KIND.ASKED_SESSION,
             )
           : openSession(open.identity, HOST_NODE_OPEN_KIND.ASKED_SESSION),
-      [ACTION_KIND.CREATE_WORKSPACE]: async (creation): Promise<WireRecord> =>
+      [ACTION_KIND.CREATE_WORKSPACE]: async (creation): Promise<CarriedActionResult> =>
         createWorkspace(creation, guard),
       [ACTION_KIND.ADD_AGENT]: (spawn) => addWorkspaceAgent(spawn, guard),
       [ACTION_KIND.RENAME_WORKSPACE]: renameWorkspace,

--- a/packages/session/src/session-shape.ts
+++ b/packages/session/src/session-shape.ts
@@ -180,6 +180,18 @@ export interface ProviderSessionObservation extends SessionFields {
   directory?: string;
 }
 
+/** The observed session standing under one identity, or nothing once the roster has let it go. */
+export function sessionWithIdentity(
+  identity: SessionIdentity,
+  sessions: readonly Session[],
+): Session | undefined {
+  return sessions.find(
+    (candidate) =>
+      candidate.providerId === identity.providerId &&
+      candidate.providerSessionId === identity.providerSessionId,
+  );
+}
+
 export type Session = SessionIdentity &
   Omit<SessionFields, NormalizedSessionField> &
   Required<Pick<SessionFields, NormalizedSessionField>> & { provider: SessionProvider };


### PR DESCRIPTION
## What

One output envelope, declared in `@sidecar/actions` (`action-output.ts`), is now the result of every action tool — the seven session actions (message, control, open, add agent, create workspace, rename workspace, rename session), the two issue actions, the four app actions, and the two notebook writes:

- `status`: an `as const` set of `accepted | unknown | refused`. Accepted and unknown are `@sidecar/wire`'s own words, so the journal's and the loop's counts (`performedActions`, `unknownActions`) read exactly what they read before. Refused folds an adapter's `rejected` and `unsupported` into one word and carries the reason as written.
- `target`: the resolved target as the roster held it **at execution** — `providerId`, `providerSessionId`, `title`, `agentId`, plus `controlKind` and `controlLabel` on a control and `applicationId` on an open. A creation names only the provider it resolved to.
- `createdSession`: the `{ providerId, providerSessionId }` a provider's creation answer named, when there is one.
- `note` on an acceptance for the carrier's own sentence about how it landed (the panel's note or outcome), and `warning` where a non-essential follow-up did not land.

The envelope is a `Schema` (`ACTION_OUTPUT`), validated on write: the brain's executor validates the performer's answer before the journal keeps it, and folds its own refusals (policy, revoked run, reused call id, no checkpoint) and the journal's replay of a lost result into the same shape, so a reader of a tool part meets one shape whoever refused or carried the action. Row fields (title, agent, control kind, application) are dropped when malformed rather than refusing the envelope; a refusal or unknown without a reason, a status outside the set, or a target without a provider is not an envelope.

The host's `createBrainActionPerformer` fills it: `actionTargetSnapshot(admittedAction, sessions)` reads the roster admission just refreshed and the admitted action (the advertised control, the resolved application, the resolved provider), then `actionOutputFromResult` folds the provider's or tracker's answer. The session performer's creation now returns the provider's answer whole (its `providerSessionId` was previously cut before the model read it) so the envelope can record the created session. A panel's answer to an app action is read as untrusted in the panel's own dialect (status, reason, note, outcome; every other field ignored) and refused when unreadable — Cursor Bugbot caught the first cut of this using an exact-shape guard that refused acceptances carrying `tab` or `kind`.

## Why

Lane A of the LUKE-95 storage plan (`orchestration/storage-plan`, `plan/storage-plan.md`, "The #882–#904 stack"). D1 and E1 compose a Conversation row from the tool part's `input` plus this envelope and nothing else, so anything a row needs that `input` lacks must be here: the provider a defaulted creation resolved to, a control's label and kind (the tool's `input` carries only `control_id`), the title and agent a session wore before it was renamed or archived, the created session for a chip. The roster snapshot supplies *current* names at render; the envelope carries the picture as it was. The recorded narration sentence is untouched here and is dropped in G2.

Trust rules are unchanged: `admit()` still mints the only validated action, the envelope is filled after admission from the admitted action and the roster, and nothing widens what an action may do — only the shape of what it reports. `unknown` stays distinct from `refused` throughout (an unreadable answer whose status said unknown is answered unknown, never refused).

## CLAUDE.md sentences this contradicts (for G5)

- "Acts on a session": *"the session id the provider's creation response named (the one thing read out of that response that outlives the write, an identifier and never an address) is held briefly, and the first observation pass to report that session with an address hands the address to the operating system exactly once"* — the id is still held for the open, but it now also rides out in the tool output as `createdSession` (an identifier, never an address), so the model and the journal record it too.
- "The judgment's parts and its prompt" / storage sections describe the action journal pairing "each action with its outcome" as a bare status record; the outcome is now the envelope. No sentence names the `rejected`/`unsupported` words, but the model now reads `refused` for both.

## Verify

```
./scripts/check.sh
```

Passes (typecheck, lint, tests, build). No macOS or UI code is touched, so `verify.sh` does not apply.

Reviews run on the diff: Cursor's `thermo-nuclear-code-quality-review` (from `cursor/plugins`, rubric applied as written) and `ponytail-review` (from `DietrichGebert/ponytail`, applied as written). Findings and what changed are listed below.

### Thermo-nuclear code quality review (findings and what changed)

- **Blocker 1a — a third status word forced a translation layer** (`isActionTool` branch, a doubled fold around `performJournaled`, a schema-union fallback that re-spelled `rejected` as `refused`, a dead unknown/refused fork). The review's remedy was to keep wire's `rejected`; the ticket fixes the set at `accepted | unknown | refused`, so `refused` stays. The machinery went instead: the executor now names its two own answers once per tool kind (`ExecutorOutcomes`: refuse and unknown, the envelope for action tools and the bare record for the rest) and the performer's answer is validated by `ACTION_OUTPUT.parse` alone, an unreadable one answered unknown. `actionOutputFromRecord`, the `CARRIED_RESULT` schema, and the double fold are deleted.
- **Blocker 1b — duplicated canonical types and helpers.** `CreatedSession` is now `Readonly<SessionIdentity>`; the identity-find loop is one helper, `sessionWithIdentity` in `@sidecar/session`, used by the envelope and by `action-narration.ts` (two copies gone). `CarriedActionResult` is kept rather than aliased to `ProviderWorkspaceResult`, because after 2a the accepted arm carries a composed `createdSession` identity, not the provider's bare `providerSessionId`.
- **Should-fix 2a — the created session was re-composed a layer above.** The session performer's `createWorkspace` now returns the identity it already composes for `expectCreatedWorkspace`; the `target !== undefined` guard, the silent drop, and its test are gone.
- **Should-fix 4a — answer schemas used the request extra-key policy.** Every envelope record now ignores unknown keys, per wire's own rule, so a later build's key cannot make a replay lose its target.
- **Nit 4b** — moot, the `dropRefused` identifier went with `CARRIED_RESULT`. **Nit 4c** — the `as never` cast in the host test is gone. **Nit 2b** — `acceptedActionOutput` is a single spread.

### Ponytail review (findings and what changed)

- `yagni` `CreatedSession` ≡ `SessionIdentity` — applied. `shrink` three-spread `acceptedActionOutput` — applied. `yagni`/`shrink` `CARRIED_RESULT` arms — deleted whole. `shrink` fourth identity-find copy — applied via `sessionWithIdentity`. `shrink` `refusalForPolicy` split into three functions — applied, one function again.
- `delete` `ActionOutputStatus` has no reader yet — kept: the repo derives the union beside every `as const` set, and D1/E1 are its readers.
- `yagni` `CarriedActionResult` ≡ `ProviderWorkspaceResult` — not applied, see 1b above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34533485662/artifacts/10174552281) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34533485662)

- Commit: `e100935d2091d2c79a4837c80f28ae88ef3a03f5`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
