### PR TITLE
feat(LUKE-112): run events for every turn kind

### DIFF
--- a/packages/brain/package.json
+++ b/packages/brain/package.json
@@ -25,11 +25,13 @@
     "@sidecar/memory": "workspace:*",
     "@sidecar/runtime": "workspace:*",
     "@sidecar/session": "workspace:*",
-    "@sidecar/wire": "workspace:*"
+    "@sidecar/wire": "workspace:*",
+    "ai": "7.0.97"
   },
   "devDependencies": {
     "@types/node": "26.2.0",
     "tsx": "4.23.12",
-    "typescript": "7.0.2"
+    "typescript": "7.0.2",
+    "zod": "4.5.4"
   }
 }

--- a/packages/brain/src/acceptance.test.ts
+++ b/packages/brain/src/acceptance.test.ts
@@ -35,6 +35,7 @@ import {
   type ContextInput,
   type ContextLifecycle,
   type ContextOpening,
+  MAIN_SESSION_KEY,
   MEMORY_SCOPE_KIND,
   type MemoryDefinition,
   type ModelAdapter,
@@ -290,6 +291,7 @@ function host(
     lastActivityAt: NOW,
   });
   const agent = new BrainAgent({
+    conversationId: MAIN_SESSION_KEY,
     runtime: runtimeOver(model),
     observes: { kind: LOOK_SUBJECT.NONE },
     prepareTurn: () => ({ prompt: "instructions", layers: {} }),

--- a/packages/brain/src/agent-flush.test.ts
+++ b/packages/brain/src/agent-flush.test.ts
@@ -8,6 +8,7 @@ import {
 } from "@sidecar/memory";
 import { RESPONSES_ITEM_FORMAT, TOOL_LOOP_RUNTIME } from "@sidecar/runtime";
 import {
+  MAIN_SESSION_KEY,
   MEMORY_CAPTURE_PHASE,
   MEMORY_SCOPE_KIND,
   type MemoryCaptureTurn,
@@ -162,6 +163,7 @@ function agentWith(
     now: () => NOW,
   });
   const agent = new BrainAgent({
+    conversationId: MAIN_SESSION_KEY,
     runtime,
     observes: { kind: LOOK_SUBJECT.NONE },
     prepareTurn: () => ({ prompt: "flush test", layers: {} }),

--- a/packages/brain/src/agent.ts
+++ b/packages/brain/src/agent.ts
@@ -6,6 +6,7 @@ import type {
   MemoryDefinition,
   ReasoningEffort,
   ScheduledTimer,
+  SessionKey,
 } from "@sidecar/runtime/vocabulary";
 import type {
   ProviderTranscriptResult,
@@ -41,7 +42,7 @@ import {
   interruptedUnfinishedRequests,
   isTerminalBrainRequestStatus,
 } from "./requests.js";
-import { BRAIN_RUN_EVENT, type BrainRunEvent } from "./run-events.js";
+import type { BrainRunEvent } from "./run-events.js";
 import type { AgentSeam } from "./seam.js";
 import type { BrainStateStore } from "./state-store.js";
 import { SteeredDeliveries } from "./steered-deliveries.js";
@@ -54,6 +55,7 @@ import {
   type BrainTurnTrigger,
   type RunControl,
 } from "./turn.js";
+import { TurnEvents } from "./turn-events.js";
 import { type BrainOpeningNotes, TurnRunner } from "./turn-runner.js";
 import type { BrainDelivery, BrainTurnReport, BrainWakeEvent } from "./wake-events.js";
 import { type LookSubject, WakeCapture } from "./wakes.js";
@@ -70,6 +72,8 @@ export { LOOK_SUBJECT } from "./wakes.js";
 type BrainLane = <T>(trigger: BrainTurnTrigger, work: () => Promise<T>) => Promise<T>;
 
 export interface BrainAgentOptions {
+  /** The conversation this agent is: the key every run event names, which is the conversation's id in this build. */
+  conversationId: SessionKey;
   /** The execution the host runs turns on; it decides how a model and its tools loop, and it alone reaches the model. */
   runtime: AgentRuntime;
   actions: BrainActionPerformer;
@@ -219,10 +223,14 @@ export class BrainAgent {
   readonly #runEvents = new Emitter<BrainRunEvent>();
 
   /**
-   * What each recorded run tells as it goes — its slow step, its actions
-   * settling, its reply a sentence at a time, its end — for a host relaying
-   * the run into a live conversation. Delivered in that order per run, for
-   * recorded runs alone, and a listener that throws ends no turn.
+   * What every turn tells as it goes, whichever kind opened it. A recorded
+   * run's moments — its slow step, its actions settling, its reply a sentence
+   * at a time, its record's end — come in that order for a host relaying the
+   * run into a live conversation, and only for recorded runs. Around them,
+   * every turn tells its start, each tool call before and after it runs, each
+   * reasoning item, each message it completed, each compaction it folded, and
+   * its end, each event stamped with the conversation, the turn, and its
+   * place in the turn's sequence. A listener that throws ends no turn.
    */
   readonly onRunEvent: Event<BrainRunEvent> = this.#runEvents.event;
 
@@ -245,16 +253,21 @@ export class BrainAgent {
       now: this.#now,
       report: this.#report,
       notify: () => this.#asks.notify(),
-      runEnded: (record) =>
-        this.#fireRunEvent({
-          kind: BRAIN_RUN_EVENT.ENDED,
-          runId: record.runId,
-          status: record.status,
-          ...(record.text !== undefined ? { text: record.text } : undefined),
-          ...(record.failure !== undefined ? { failure: record.failure } : undefined),
-          ...(record.usage !== undefined ? { usage: record.usage } : undefined),
-          ...(record.responseIds !== undefined ? { responseIds: record.responseIds } : undefined),
-        }),
+      // A record's end is numbered in the turn it rode in; one that never
+      // opened a turn — cancelled while queued, refused at the door — is a
+      // turn of its own with this one event.
+      runEnded: (record) => {
+        const events =
+          this.#turns.takeEvents(record.runId) ??
+          new TurnEvents({
+            conversationId: options.conversationId,
+            turnId: record.runId,
+            fire: (event) => this.#fireRunEvent(event),
+            createMessageId: options.createRunId,
+            now: this.#now,
+          });
+        events.recordEnded(record);
+      },
     });
     const seam: AgentSeam = {
       now: this.#now,
@@ -281,6 +294,7 @@ export class BrainAgent {
     });
     this.#turns = new TurnRunner({
       seam,
+      conversationId: options.conversationId,
       runtime: options.runtime,
       actions: options.actions,
       roster: options.roster,

--- a/packages/brain/src/asks.ts
+++ b/packages/brain/src/asks.ts
@@ -19,8 +19,8 @@ import {
 } from "./requests.js";
 import type { AgentSeam } from "./seam.js";
 import type { BrainStateStore } from "./state-store.js";
-import { BRAIN_TURN_TRIGGER, type RunControl } from "./turn.js";
-import { type ActiveExecution, type AskInput, newRunControl } from "./turn-runner.js";
+import { type AskInput, BRAIN_TURN_TRIGGER, newRunControl, type RunControl } from "./turn.js";
+import type { ActiveExecution } from "./turn-runner.js";
 
 export type BrainRequestsListener = (records: readonly BrainRequestRecord[]) => void;
 
@@ -347,6 +347,7 @@ export class AskLedger {
     const text = askInputText(input.text, [], this.#seam.now());
     if (!active.started.steer({ kind: CONTEXT_INPUT_KIND.USER_TEXT, text })) return false;
     active.riders.push(run);
+    active.events.adopt(run.runId);
     // The one place a rider is committed running: its words are in the model's
     // hands, and the run it rides is the run it ends with.
     void this.#seam.ledger

--- a/packages/brain/src/compaction.test.ts
+++ b/packages/brain/src/compaction.test.ts
@@ -5,6 +5,7 @@ import { RESPONSES_ITEM_FORMAT, TOOL_LOOP_RUNTIME } from "@sidecar/runtime";
 import {
   COMPACTION_SOURCE,
   CONTEXT_INPUT_KIND,
+  MAIN_SESSION_KEY,
   MODEL_RESPONSE_OUTCOME,
   type ModelAdapter,
   type ModelCapabilities,
@@ -31,6 +32,7 @@ import {
   BRAIN_SUBMISSION_OUTCOME,
 } from "./requests.js";
 import { responsesModelAnswer, userMessageItem } from "./responses-api.js";
+import { BRAIN_RUN_EVENT, type BrainRunEvent } from "./run-events.js";
 import { ToolLoopAgentRuntime } from "./runtime.js";
 import { BrainStateStore } from "./state-store.js";
 import { type FakeBrainStateRepository, fakeBrainStateRepository } from "./testing.js";
@@ -245,6 +247,7 @@ test("an explicit compaction is asked over the retained items alone, adopted who
     compacted: true,
     source: COMPACTION_SOURCE.LOCAL_SUMMARY,
     dropped: 2,
+    summary: `${LOCAL_SUMMARY_MARKER}\nfolded words`,
   });
   assert.equal(toolsOffered, 0);
   assert.deepEqual(
@@ -294,6 +297,7 @@ function agentOver(model: ModelAdapter, repository: FakeBrainStateRepository) {
   });
   const reports: string[] = [];
   const agent = new BrainAgent({
+    conversationId: MAIN_SESSION_KEY,
     runtime,
     observes: { kind: LOOK_SUBJECT.NONE },
     prepareTurn: () => ({ prompt: "instructions", layers: {} }),
@@ -350,6 +354,8 @@ test("a turn's inputs travel into the transcript with the checkpoint, and option
     },
   });
   const { agent } = agentOver(model, repository);
+  const events: BrainRunEvent[] = [];
+  agent.onRunEvent((event) => events.push(event));
   const accepted = await agent.submitAsk({
     submissionId: "s1",
     question: "hello",
@@ -360,6 +366,16 @@ test("a turn's inputs travel into the transcript with the checkpoint, and option
   const record = agent.requests()[0];
   assert.equal(record?.status, BRAIN_REQUEST_STATUS.SUCCEEDED);
   assert.equal(compacted, 1);
+  // The maintenance fold is told to the turn that queued it, after that
+  // turn's own end and its record's, in the same numbered sequence.
+  const turnEnded = events.findIndex((event) => event.kind === BRAIN_RUN_EVENT.TURN_ENDED);
+  const folded = events.findIndex((event) => event.kind === BRAIN_RUN_EVENT.COMPACTION_COMPLETED);
+  assert.ok(turnEnded >= 0 && folded > turnEnded);
+  const fold = events[folded];
+  assert.ok(fold?.kind === BRAIN_RUN_EVENT.COMPACTION_COMPLETED);
+  assert.equal(fold.turnId, record?.runId);
+  assert.equal(fold.sequence, events.length);
+  assert.deepEqual(fold.compaction, { source: COMPACTION_SOURCE.PROVIDER_EXPLICIT, dropped: 2 });
   const kinds = repository.transcripts.flat().map((event) => event.kind);
   assert.deepEqual(kinds, [
     TRANSCRIPT_EVENT_KIND.CONTEXT_INPUT,

--- a/packages/brain/src/compaction.ts
+++ b/packages/brain/src/compaction.ts
@@ -167,6 +167,7 @@ export async function compactContext(
     return { compacted: false, reason: "this transport offers no compaction" };
   }
   let failure: string | undefined;
+  let summary: string | undefined;
   const summarize = async (older: readonly WireRecord[]): Promise<string | undefined> => {
     const answer = await model.respond(older, {
       prompt: LOCAL_SUMMARY_INSTRUCTIONS,
@@ -185,12 +186,18 @@ export async function compactContext(
       failure = "the summary came back empty";
       return undefined;
     }
-    return `${LOCAL_SUMMARY_MARKER}\n${answer.text.trim()}`;
+    summary = `${LOCAL_SUMMARY_MARKER}\n${answer.text.trim()}`;
+    return summary;
   };
   const dropped = await context.foldBehindSummary(summarize, COMPACTION_POLICY.KEEP_RECENT_TOKENS, {
     signal: request.signal,
   });
   if (request.signal.aborted) return { compacted: false, reason: "compaction cancelled" };
   if (dropped <= 0) return { compacted: false, reason: failure ?? "nothing could be folded" };
-  return { compacted: true, source: COMPACTION_SOURCE.LOCAL_SUMMARY, dropped };
+  return {
+    compacted: true,
+    source: COMPACTION_SOURCE.LOCAL_SUMMARY,
+    dropped,
+    ...(summary !== undefined ? { summary } : undefined),
+  };
 }

--- a/packages/brain/src/harness.ts
+++ b/packages/brain/src/harness.ts
@@ -371,6 +371,7 @@ export function harness(
   // so the two writes reach the performer under test like every other action.
   const scope = { kind: MEMORY_SCOPE_KIND.ACCOUNT, key: DEFAULT_AGENT_ID };
   const agent = new BrainAgent({
+    conversationId: MAIN_SESSION_KEY,
     runtime,
     prepareTurn: PLAIN_PREPARATION,
     observes: { kind: LOOK_SUBJECT.SESSION, identity: ABC },
@@ -691,6 +692,7 @@ export function heldOpenRuntime(model: ModelAdapter, disposeHangs = false) {
 
 export function agentOn(runtime: ToolLoopAgentRuntime, h: Harness) {
   return new BrainAgent({
+    conversationId: MAIN_SESSION_KEY,
     runtime,
     prepareTurn: PLAIN_PREPARATION,
     observes: { kind: LOOK_SUBJECT.NONE },

--- a/packages/brain/src/index.ts
+++ b/packages/brain/src/index.ts
@@ -82,9 +82,16 @@ export {
 } from "./responses-api.js";
 export {
   BRAIN_RUN_EVENT,
+  BRAIN_TURN_ORIGIN,
   type BrainRunEvent,
+  type BrainRunEventBody,
+  type BrainRunEventKind,
+  type BrainTurnOrigin,
   SLOW_STEP_KIND,
   type SlowStepKind,
+  TOOL_CALL_SETTLEMENT,
+  type ToolCallSettlement,
+  type TurnCompaction,
 } from "./run-events.js";
 export {
   CONTEXT_ITEM_KIND,

--- a/packages/brain/src/ledger.test.ts
+++ b/packages/brain/src/ledger.test.ts
@@ -6,7 +6,7 @@ import {
   refusedActionOutput,
 } from "@sidecar/actions";
 import { RESPONSES_INPUT_ITEM_TYPE } from "@sidecar/hosted";
-import { RUN_ORIGIN } from "@sidecar/runtime/vocabulary";
+import { MAIN_SESSION_KEY, RUN_ORIGIN } from "@sidecar/runtime/vocabulary";
 import { ACTION_RESULT_STATUS } from "@sidecar/wire";
 import { BrainAgent, LOOK_SUBJECT } from "./agent.js";
 import { type BrainPersistedState, freshBrainState } from "./envelope.js";
@@ -264,6 +264,7 @@ test("stop settles only after a held acceptance, which the successor then finds 
   // — here, a mark — lands nowhere, while the successor's own writes do.
   const successorModel = adapterOf(new FakeClient());
   const successor = new BrainAgent({
+    conversationId: MAIN_SESSION_KEY,
     runtime: runtimeOver(successorModel),
     observes: { kind: LOOK_SUBJECT.NONE },
     prepareTurn: PLAIN_PREPARATION,

--- a/packages/brain/src/maintenance.ts
+++ b/packages/brain/src/maintenance.ts
@@ -16,6 +16,7 @@ import {
   reserveTokens,
 } from "./compaction.js";
 import { CONTEXT_OPENING } from "./generation.js";
+import { turnCompactionOf } from "./run-events.js";
 import type { AgentSeam } from "./seam.js";
 import { claimedUnlessAborted, type Settled, settledUnlessAborted } from "./settled.js";
 import {
@@ -95,7 +96,7 @@ export class Maintenance {
     countedTokens: number | undefined,
     abort: AbortController,
   ): Promise<void> {
-    const { generation, context } = turnContext;
+    const { generation, context, events } = turnContext;
     if (
       abort.signal.aborted ||
       this.#seam.stopped() ||
@@ -115,7 +116,7 @@ export class Maintenance {
       const prepared = await this.#options.prepareTurn({ kind: BRAIN_TURN_KIND.MAINTENANCE });
       if (signal.aborted || generation !== this.#seam.generation()) return;
       const compacted = await this.compactIfNeeded(
-        { generation, context, signal },
+        { generation, context, signal, events },
         prepared.prompt,
         countedTokens,
       );
@@ -162,6 +163,10 @@ export class Maintenance {
     if (!(await this.#seam.ledger.checkpoint(turnContext))) {
       return { ok: false, reason: "the compacted context could not be checkpointed" };
     }
+    // The fold is told once it is on record, and to the turn whose sequence it
+    // belongs in: the turn about to run, or the settled turn that queued this
+    // maintenance, whose events it follows.
+    turnContext.events.compacted(turnCompactionOf(outcome));
     return { ok: true };
   }
 

--- a/packages/brain/src/responses-api.test.ts
+++ b/packages/brain/src/responses-api.test.ts
@@ -202,9 +202,15 @@ test("the response id, each reasoning item's summary, and the four-way usage are
     cachedInputTokens: 768,
     reasoningTokens: 100,
   });
-  // One summary per item that has words, joined as paragraphs; an item with none is not a summary.
+  // One summary per item that has words, joined as paragraphs, the encrypted
+  // content lifted beside it and the item whole; an item with none is not a summary.
   assert.deepEqual(answer.reasoning, [
-    { itemId: "rs_1", summary: "Checking which session is waiting.\n\nOnly one needs a reply." },
+    {
+      itemId: "rs_1",
+      summary: "Checking which session is waiting.\n\nOnly one needs a reply.",
+      encryptedContent: "opaque",
+      item: summarized,
+    },
   ]);
   // The items themselves are untouched: the opaque content rides with the summary for replay.
   assert.deepEqual(answer.items[0], summarized);

--- a/packages/brain/src/responses-api.ts
+++ b/packages/brain/src/responses-api.ts
@@ -193,8 +193,9 @@ function outputTextFromContent(content: UnparsedWireValue): string {
 
 /**
  * A reasoning item's summary in words, or nothing for an item that is not a
- * reasoning item or carries no words: the parts are joined as paragraphs, and
- * the item's `encrypted_content` is never read.
+ * reasoning item or carries no words: the parts are joined as paragraphs, the
+ * item's `encrypted_content` is lifted beside them for a replay to carry and
+ * read for nothing else, and the item rides along whole.
  */
 function reasoningSummaryFromItem(item: WireRecord): ReasoningSummary | undefined {
   if (item.type !== RESPONSES_INPUT_ITEM_TYPE.REASONING) return undefined;
@@ -203,7 +204,14 @@ function reasoningSummaryFromItem(item: WireRecord): ReasoningSummary | undefine
   const summary = joinReplyMessages(
     partTexts(item.summary, RESPONSES_CONTENT_PART_TYPE.SUMMARY_TEXT),
   );
-  return summary.length > 0 ? { itemId, summary } : undefined;
+  if (summary.length === 0) return undefined;
+  const encryptedContent = text(item.encrypted_content);
+  return {
+    itemId,
+    summary,
+    ...(encryptedContent ? { encryptedContent } : undefined),
+    item,
+  };
 }
 
 function functionCallFromItem(item: WireRecord): BrainFunctionCall | undefined {

--- a/packages/brain/src/run-events.test.ts
+++ b/packages/brain/src/run-events.test.ts
@@ -1,6 +1,20 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { REALTIME_TOOL } from "@sidecar/actions";
+import { ACTION_OUTPUT_STATUS, REALTIME_TOOL, refusedActionOutput } from "@sidecar/actions";
+import { COMPACTION_SOURCE, MAIN_SESSION_KEY } from "@sidecar/runtime/vocabulary";
+import { TOOL_PART_STATE } from "@sidecar/session";
+import { readStoredUIMessages } from "@sidecar/session/ui-messages";
+import {
+  ACTION_RESULT_STATUS,
+  isRecord,
+  MESSAGE_AUTHOR,
+  MESSAGE_CHANNEL,
+  MESSAGE_ROLE,
+  OBSERVATION_SOURCE,
+  type UnparsedWireValue,
+} from "@sidecar/wire";
+import { type ToolSet, tool, type UIMessage } from "ai";
+import { z } from "zod";
 import {
   ABC,
   acceptedRunId,
@@ -9,8 +23,10 @@ import {
   ask,
   type BrainClientAnswer,
   call,
+  compaction,
   edge,
   FakeClient,
+  gatedClient,
   harness,
   message,
   NOW,
@@ -21,18 +37,82 @@ import {
 import { BRAIN_REQUEST_ORIGIN, BRAIN_REQUEST_STATUS } from "./requests.js";
 import {
   BRAIN_RUN_EVENT,
+  BRAIN_TURN_ORIGIN,
   type BrainRunEvent,
+  type BrainRunEventKind,
   replySentences,
   SLOW_STEP_KIND,
   slowStepOf,
+  TOOL_CALL_SETTLEMENT,
+  toolCallInput,
+  toolCallSettlementOf,
+  turnOriginOf,
 } from "./run-events.js";
+import { TOOL_RESULT_STATUS } from "./runtime.js";
 import { BRAIN_TOOL, brainToolCatalog, resolveTurnToolPolicy } from "./tools.js";
 import { BRAIN_TURN_KIND, BRAIN_TURN_TRIGGER, type BrainTurnDescription } from "./turn.js";
+import { TurnEvents } from "./turn-events.js";
+import {
+  AssistantMessageBuilder,
+  REASONING_PROVIDER_KEY,
+  toolPartType,
+  UI_PART_STATE,
+  UI_PART_TYPE,
+  userMetadataOf,
+} from "./ui-messages.js";
 
 function listen(h: ReturnType<typeof harness>): BrainRunEvent[] {
   const events: BrainRunEvent[] = [];
   h.agent.onRunEvent((event) => events.push(event));
   return events;
+}
+
+/** The four moments a live relay reads, and nothing the record's writer reads beside them. */
+const RELAY_KINDS: ReadonlySet<BrainRunEventKind> = new Set([
+  BRAIN_RUN_EVENT.SLOW_STEP,
+  BRAIN_RUN_EVENT.ACTIONS_SETTLED,
+  BRAIN_RUN_EVENT.REPLY_SENTENCE,
+  BRAIN_RUN_EVENT.ENDED,
+]);
+
+/** An event as the relay of #910 reads it: its own fields, without the turn stamp every event now carries. */
+function bare(event: BrainRunEvent | undefined) {
+  if (!event) return undefined;
+  const { conversationId: _conversation, turnId: _turn, sequence: _sequence, ...own } = event;
+  return own;
+}
+
+function relayed(events: readonly BrainRunEvent[]) {
+  return events.filter((event) => RELAY_KINDS.has(event.kind)).map(bare);
+}
+
+function kinds(events: readonly BrainRunEvent[]): BrainRunEventKind[] {
+  return events.map((event) => event.kind);
+}
+
+/** Every event of one turn: stamped with the conversation and that turn, and numbered from one without a gap. */
+function assertOneTurn(events: readonly BrainRunEvent[], turnId: string): void {
+  assert.deepEqual(
+    events.map((event) => event.conversationId),
+    events.map(() => MAIN_SESSION_KEY),
+  );
+  assert.deepEqual(
+    events.map((event) => event.turnId),
+    events.map(() => turnId),
+  );
+  assert.deepEqual(
+    events.map((event) => event.sequence),
+    events.map((_, index) => index + 1),
+  );
+}
+
+function ofKind<Kind extends BrainRunEventKind>(
+  events: readonly BrainRunEvent[],
+  kind: Kind,
+): Extract<BrainRunEvent, { kind: Kind }>[] {
+  return events.filter(
+    (event): event is Extract<BrainRunEvent, { kind: Kind }> => event.kind === kind,
+  );
 }
 
 const readAbc = call("read_1", BRAIN_TOOL.READ_TRANSCRIPT, {
@@ -47,6 +127,36 @@ const messageAbc = (callId: string) =>
     text: "run the tests",
   });
 
+/** The tools the turns below call, as the storage reader is registered with them. */
+const STORED_TOOLS: ToolSet = {
+  [BRAIN_TOOL.READ_TRANSCRIPT]: tool({
+    inputSchema: z.object({ provider_id: z.string(), provider_session_id: z.string() }),
+  }),
+  [REALTIME_TOOL.SEND_SESSION_MESSAGE]: tool({
+    inputSchema: z.object({
+      provider_id: z.string(),
+      provider_session_id: z.string(),
+      text: z.string(),
+    }),
+  }),
+};
+
+/** The messages as a store would hold them: serialized and read back, which is what the reader is handed. */
+function stored(messages: readonly (UIMessage | undefined)[]): UnparsedWireValue {
+  // SAFETY: a JSON round trip of UIMessages answers a wire value; the reader validates its shape.
+  return JSON.parse(JSON.stringify(messages)) as UnparsedWireValue;
+}
+
+const TYPED_ASK = { author: MESSAGE_AUTHOR.DEVELOPER, channel: MESSAGE_CHANNEL.TYPED };
+const BRAIN_AUTHORED = { author: MESSAGE_AUTHOR.BRAIN };
+
+const SUMMARIZED_REASONING = {
+  type: "reasoning",
+  id: "rs_1",
+  summary: [{ type: "summary_text", text: "Only abc is waiting." }],
+  encrypted_content: "opaque",
+};
+
 test("a run that reads a transcript tells its slow step once, then its actions settling, then each sentence, then its end", async () => {
   const h = harness();
   const events = listen(h);
@@ -57,7 +167,7 @@ test("a run that reads a transcript tells its slow step once, then its actions s
   const record = await ask(h, "how is it going?");
   assert.equal(record?.status, BRAIN_REQUEST_STATUS.SUCCEEDED);
   const runId = record?.runId ?? "";
-  assert.deepEqual(events, [
+  assert.deepEqual(relayed(events), [
     { kind: BRAIN_RUN_EVENT.SLOW_STEP, runId, step: SLOW_STEP_KIND.TRANSCRIPT_READ },
     { kind: BRAIN_RUN_EVENT.ACTIONS_SETTLED, runId },
     { kind: BRAIN_RUN_EVENT.REPLY_SENTENCE, runId, sentence: "The tests pass." },
@@ -70,6 +180,108 @@ test("a run that reads a transcript tells its slow step once, then its actions s
       usage: { inputTokens: 200, outputTokens: 0, cachedInputTokens: 0, reasoningTokens: 0 },
     },
   ]);
+  await h.agent.stop();
+});
+
+test("a developer turn tells the documented sequence, every event stamped with the conversation and the turn and numbered without a gap", async () => {
+  const h = harness();
+  const events = listen(h);
+  h.client.answers.push(
+    answeredUnder("resp_1", [readAbc], { input: 900, output: 40, cached: 768, reasoning: 30 }),
+    answeredUnder("resp_2", [message("The tests pass. Nothing needs you!")], {
+      input: 1000,
+      output: 10,
+      cached: 896,
+      reasoning: 0,
+    }),
+  );
+  const record = await ask(h, "how is it going?");
+  assert.equal(record?.status, BRAIN_REQUEST_STATUS.SUCCEEDED);
+  const runId = record?.runId ?? "";
+  assert.deepEqual(kinds(events), [
+    BRAIN_RUN_EVENT.TURN_STARTED,
+    BRAIN_RUN_EVENT.MESSAGE_COMPLETED,
+    BRAIN_RUN_EVENT.TOOL_CALL_STARTED,
+    BRAIN_RUN_EVENT.SLOW_STEP,
+    BRAIN_RUN_EVENT.TOOL_CALL_SETTLED,
+    BRAIN_RUN_EVENT.MESSAGE_COMPLETED,
+    BRAIN_RUN_EVENT.ACTIONS_SETTLED,
+    BRAIN_RUN_EVENT.REPLY_SENTENCE,
+    BRAIN_RUN_EVENT.REPLY_SENTENCE,
+    BRAIN_RUN_EVENT.ENDED,
+    BRAIN_RUN_EVENT.TURN_ENDED,
+  ]);
+  assertOneTurn(events, runId);
+
+  const [started] = ofKind(events, BRAIN_RUN_EVENT.TURN_STARTED);
+  assert.deepEqual(bare(started), {
+    kind: BRAIN_RUN_EVENT.TURN_STARTED,
+    origin: BRAIN_TURN_ORIGIN.TYPED,
+    trigger: BRAIN_TURN_TRIGGER.ASK,
+    at: NOW,
+  });
+
+  // The call is told with its parsed input before it runs, and its output after.
+  const [callStarted] = ofKind(events, BRAIN_RUN_EVENT.TOOL_CALL_STARTED);
+  assert.deepEqual(bare(callStarted), {
+    kind: BRAIN_RUN_EVENT.TOOL_CALL_STARTED,
+    callId: "read_1",
+    name: BRAIN_TOOL.READ_TRANSCRIPT,
+    input: { provider_id: ABC.providerId, provider_session_id: ABC.providerSessionId },
+  });
+  const [callSettled] = ofKind(events, BRAIN_RUN_EVENT.TOOL_CALL_SETTLED);
+  assert.equal(callSettled?.callId, "read_1");
+  assert.equal(callSettled?.name, BRAIN_TOOL.READ_TRANSCRIPT);
+  assert.equal(callSettled?.settlement.state, TOOL_CALL_SETTLEMENT.OUTPUT_AVAILABLE);
+  assert.equal(callSettled?.settlement.status, ACTION_RESULT_STATUS.ACCEPTED);
+  assert.ok(isRecord(callSettled?.settlement.output));
+  assert.equal(callSettled?.settlement.output.status, ACTION_RESULT_STATUS.ACCEPTED);
+
+  // The turn's messages: the developer's words first, the model's answer once
+  // it is on record, each saying what the storage vocabulary lets it say.
+  const [opening, answer] = ofKind(events, BRAIN_RUN_EVENT.MESSAGE_COMPLETED);
+  assert.equal(opening?.message.role, MESSAGE_ROLE.USER);
+  assert.deepEqual(opening?.message.metadata, TYPED_ASK);
+  assert.deepEqual(
+    opening?.message.parts.map((part) => part.type),
+    [UI_PART_TYPE.TEXT],
+  );
+  assert.equal(answer?.message.role, MESSAGE_ROLE.ASSISTANT);
+  assert.deepEqual(answer?.message.metadata, BRAIN_AUTHORED);
+  assert.deepEqual(answer?.message.parts, [
+    {
+      type: toolPartType(BRAIN_TOOL.READ_TRANSCRIPT),
+      toolCallId: "read_1",
+      state: TOOL_PART_STATE.OUTPUT_AVAILABLE,
+      input: { provider_id: ABC.providerId, provider_session_id: ABC.providerSessionId },
+      output: callSettled?.settlement.output,
+    },
+    {
+      type: UI_PART_TYPE.TEXT,
+      text: "The tests pass. Nothing needs you!",
+      state: UI_PART_STATE.DONE,
+    },
+  ]);
+  assert.notEqual(opening?.message.id, answer?.message.id);
+  // Both rows read back under the storage vocabulary exactly as they were told.
+  const messages = [opening?.message, answer?.message];
+  assert.deepEqual(await readStoredUIMessages(stored(messages), STORED_TOOLS), {
+    ok: true,
+    value: messages,
+  });
+
+  // The turn's end carries what the run kept: the same accounting its record ends with.
+  const [turnEnded] = ofKind(events, BRAIN_RUN_EVENT.TURN_ENDED);
+  const [ended] = ofKind(events, BRAIN_RUN_EVENT.ENDED);
+  assert.deepEqual(bare(turnEnded), {
+    kind: BRAIN_RUN_EVENT.TURN_ENDED,
+    status: BRAIN_REQUEST_STATUS.SUCCEEDED,
+    usage: { inputTokens: 1900, outputTokens: 50, cachedInputTokens: 1664, reasoningTokens: 30 },
+    responseIds: ["resp_1", "resp_2"],
+    at: NOW,
+  });
+  assert.deepEqual(ended?.usage, turnEnded?.usage);
+  assert.deepEqual(ended?.responseIds, turnEnded?.responseIds);
   await h.agent.stop();
 });
 
@@ -123,26 +335,36 @@ test("two provider writes are one slow step, and the reply streams only after bo
   const record = await ask(h, "tell them to run the tests, twice");
   assert.equal(record?.status, BRAIN_REQUEST_STATUS.SUCCEEDED);
   assert.equal(h.performed.length, 2);
-  const kinds = events.map((event) => event.kind);
-  assert.deepEqual(kinds, [
+  assert.deepEqual(kinds(events.filter((event) => RELAY_KINDS.has(event.kind))), [
     BRAIN_RUN_EVENT.SLOW_STEP,
     BRAIN_RUN_EVENT.ACTIONS_SETTLED,
     BRAIN_RUN_EVENT.REPLY_SENTENCE,
     BRAIN_RUN_EVENT.REPLY_SENTENCE,
     BRAIN_RUN_EVENT.ENDED,
   ]);
-  const [slow] = events;
-  assert.equal(
-    slow?.kind === BRAIN_RUN_EVENT.SLOW_STEP && slow.step,
-    SLOW_STEP_KIND.PROVIDER_WRITE,
-  );
+  const [slow] = ofKind(events, BRAIN_RUN_EVENT.SLOW_STEP);
+  assert.equal(slow?.step, SLOW_STEP_KIND.PROVIDER_WRITE);
   // Every sentence follows the settle, and the words said before the action
   // are part of the reply as much as the words after.
   assert.deepEqual(
-    events.flatMap((event) =>
-      event.kind === BRAIN_RUN_EVENT.REPLY_SENTENCE ? [event.sentence] : [],
-    ),
+    ofKind(events, BRAIN_RUN_EVENT.REPLY_SENTENCE).map((event) => event.sentence),
     ["Sending.", "Both sent."],
+  );
+  // Both calls are told started before settled, each under its own id, and the
+  // finished message holds both settled.
+  assert.deepEqual(
+    ofKind(events, BRAIN_RUN_EVENT.TOOL_CALL_STARTED).map((event) => event.callId),
+    ["send_1", "send_2"],
+  );
+  assert.deepEqual(
+    ofKind(events, BRAIN_RUN_EVENT.TOOL_CALL_SETTLED).map((event) => event.settlement.state),
+    [TOOL_CALL_SETTLEMENT.OUTPUT_AVAILABLE, TOOL_CALL_SETTLEMENT.OUTPUT_AVAILABLE],
+  );
+  const [, answer] = ofKind(events, BRAIN_RUN_EVENT.MESSAGE_COMPLETED);
+  const sent = toolPartType(REALTIME_TOOL.SEND_SESSION_MESSAGE);
+  assert.deepEqual(
+    answer?.message.parts.map((part) => part.type),
+    [UI_PART_TYPE.TEXT, sent, sent, UI_PART_TYPE.TEXT],
   );
   await h.agent.stop();
 });
@@ -157,17 +379,18 @@ class HangingClient extends FakeClient {
   }
 }
 
-test("a run with no slow step still settles its actions before its sentences, and a cancelled run ends with its end alone", async () => {
+test("a run with no slow step still settles its actions before its sentences, and a cancelled queued run ends with its end alone, as a turn of its own", async () => {
   const client = new HangingClient();
   const h = harness({ client });
   const events = listen(h);
   client.answers.push(answered([message("Hello there.")]));
   const first = await ask(h, "hello");
   assert.equal(first?.status, BRAIN_REQUEST_STATUS.SUCCEEDED);
-  assert.deepEqual(
-    events.map((event) => event.kind),
-    [BRAIN_RUN_EVENT.ACTIONS_SETTLED, BRAIN_RUN_EVENT.REPLY_SENTENCE, BRAIN_RUN_EVENT.ENDED],
-  );
+  assert.deepEqual(kinds(events.filter((event) => RELAY_KINDS.has(event.kind))), [
+    BRAIN_RUN_EVENT.ACTIONS_SETTLED,
+    BRAIN_RUN_EVENT.REPLY_SENTENCE,
+    BRAIN_RUN_EVENT.ENDED,
+  ]);
   events.length = 0;
 
   client.hang = true;
@@ -177,24 +400,311 @@ test("a run with no slow step still settles its actions before its sentences, an
   await h.agent.cancelAsk(runId);
   await settle();
   assert.equal(h.agent.request(runId)?.status, BRAIN_REQUEST_STATUS.CANCELLED);
-  assert.deepEqual(events, [
-    { kind: BRAIN_RUN_EVENT.ENDED, runId, status: BRAIN_REQUEST_STATUS.CANCELLED },
+  // The run opened its turn before hanging, so the turn's start and its
+  // opening words precede the record's end, and the turn's end is the last word.
+  assert.deepEqual(kinds(events), [
+    BRAIN_RUN_EVENT.TURN_STARTED,
+    BRAIN_RUN_EVENT.MESSAGE_COMPLETED,
+    BRAIN_RUN_EVENT.ENDED,
+    BRAIN_RUN_EVENT.TURN_ENDED,
   ]);
+  assertOneTurn(events, runId);
+  assert.deepEqual(bare(events[2]), {
+    kind: BRAIN_RUN_EVENT.ENDED,
+    runId,
+    status: BRAIN_REQUEST_STATUS.CANCELLED,
+  });
+  const [turnEnded] = ofKind(events, BRAIN_RUN_EVENT.TURN_ENDED);
+  assert.equal(turnEnded?.status, BRAIN_REQUEST_STATUS.CANCELLED);
+  assert.equal(turnEnded?.usage, undefined);
+  assert.deepEqual(turnEnded?.responseIds, []);
   await h.agent.stop();
 });
 
-test("an observation turn tells nothing, however many transcripts it reads", async () => {
+test("an ask cancelled while it waits behind another turn ends alone, at sequence one of a turn named by its own id", async () => {
+  const inner = new FakeClient();
+  const gated = gatedClient(inner);
+  const h = harness({ client: gated.client });
+  await h.agent.wake([edge(ABC)]);
+  inner.answers.push(answered([message("")]));
+  await h.clock.advance(NOW + 3_000);
+  const events = listen(h);
+  // An observation turn takes no steered words, so the ask waits in the queue.
+  const waiting = acceptedRunId(await submit(h, "later"));
+  await settle();
+  assert.equal(h.agent.request(waiting)?.status, BRAIN_REQUEST_STATUS.QUEUED);
+  await h.agent.cancelAsk(waiting);
+  assert.deepEqual(events, [
+    {
+      kind: BRAIN_RUN_EVENT.ENDED,
+      runId: waiting,
+      status: BRAIN_REQUEST_STATUS.CANCELLED,
+      conversationId: MAIN_SESSION_KEY,
+      turnId: waiting,
+      sequence: 1,
+    },
+  ]);
+  gated.open();
+  await settle();
+  await h.agent.stop();
+});
+
+test("an observation turn tells its start, its words, its calls, its answer, and its end, and none of the relay's moments", async () => {
   const h = harness();
   const events = listen(h);
   await h.agent.wake([edge(ABC)]);
   h.client.answers.push(answered([readAbc]), answered([message("")]));
   await h.clock.advance(NOW + 3_000);
   assert.equal(h.wholeReads.length, 1);
-  assert.deepEqual(events, []);
+  assert.deepEqual(kinds(events), [
+    BRAIN_RUN_EVENT.TURN_STARTED,
+    BRAIN_RUN_EVENT.MESSAGE_COMPLETED,
+    BRAIN_RUN_EVENT.TOOL_CALL_STARTED,
+    BRAIN_RUN_EVENT.TOOL_CALL_SETTLED,
+    BRAIN_RUN_EVENT.MESSAGE_COMPLETED,
+    BRAIN_RUN_EVENT.TURN_ENDED,
+  ]);
+  assert.deepEqual(relayed(events), []);
+  const turnId = events[0]?.turnId ?? "";
+  assertOneTurn(events, turnId);
+  // The turn is not a recorded run's, so its id is its own and no record ends it.
+  assert.equal(h.agent.requests().length, 0);
+  const [started] = ofKind(events, BRAIN_RUN_EVENT.TURN_STARTED);
+  assert.equal(started?.origin, BRAIN_TURN_ORIGIN.OBSERVATION);
+  assert.equal(started?.trigger, BRAIN_TURN_TRIGGER.WAKE);
+  const [observation, answer] = ofKind(events, BRAIN_RUN_EVENT.MESSAGE_COMPLETED);
+  assert.equal(observation?.message.role, MESSAGE_ROLE.USER);
+  assert.deepEqual(observation?.message.metadata, {
+    author: MESSAGE_AUTHOR.BRAIN,
+    source: OBSERVATION_SOURCE.HOOK,
+  });
+  assert.equal(answer?.message.role, MESSAGE_ROLE.ASSISTANT);
+  // An answer that said nothing adds no text part: the call is the whole message.
+  assert.deepEqual(
+    answer?.message.parts.map((part) => part.type),
+    [toolPartType(BRAIN_TOOL.READ_TRANSCRIPT)],
+  );
+  const messages = [observation?.message, answer?.message];
+  assert.deepEqual(await readStoredUIMessages(stored(messages), STORED_TOOLS), {
+    ok: true,
+    value: messages,
+  });
+  const [turnEnded] = ofKind(events, BRAIN_RUN_EVENT.TURN_ENDED);
+  assert.equal(turnEnded?.status, BRAIN_REQUEST_STATUS.SUCCEEDED);
   await h.agent.stop();
 });
 
-test("a spoken ask's turn is prepared with the spoken origin, and a typed ask's with the typed one", async () => {
+test("a child's task turn is told as a child's, with the task as its words and its record's end in its sequence", async () => {
+  const h = harness();
+  const events = listen(h);
+  h.client.answers.push(answered([message("Looked into it.")]));
+  const run = await h.agent.runChildTask("look into it", "child-run-1");
+  assert.ok(run);
+  await run.done;
+  assert.deepEqual(kinds(events), [
+    BRAIN_RUN_EVENT.TURN_STARTED,
+    BRAIN_RUN_EVENT.MESSAGE_COMPLETED,
+    BRAIN_RUN_EVENT.MESSAGE_COMPLETED,
+    BRAIN_RUN_EVENT.ACTIONS_SETTLED,
+    BRAIN_RUN_EVENT.REPLY_SENTENCE,
+    BRAIN_RUN_EVENT.ENDED,
+    BRAIN_RUN_EVENT.TURN_ENDED,
+  ]);
+  assertOneTurn(events, run.runId);
+  const [started] = ofKind(events, BRAIN_RUN_EVENT.TURN_STARTED);
+  assert.equal(started?.origin, BRAIN_TURN_ORIGIN.CHILD);
+  assert.equal(started?.trigger, BRAIN_TURN_TRIGGER.CHILD_TASK);
+  const [task, answer] = ofKind(events, BRAIN_RUN_EVENT.MESSAGE_COMPLETED);
+  assert.equal(task?.message.role, MESSAGE_ROLE.USER);
+  assert.equal("metadata" in (task?.message ?? {}), false);
+  assert.deepEqual(answer?.message.parts, [
+    { type: UI_PART_TYPE.TEXT, text: "Looked into it.", state: UI_PART_STATE.DONE },
+  ]);
+  const [ended] = ofKind(events, BRAIN_RUN_EVENT.ENDED);
+  assert.equal(ended?.runId, run.runId);
+  assert.equal(ended?.status, BRAIN_REQUEST_STATUS.SUCCEEDED);
+  await h.agent.stop();
+});
+
+test("a hold's release is told under its own origin", async () => {
+  const h = harness();
+  const events = listen(h);
+  h.client.answers.push(answered([message("")]));
+  h.agent.releaseHeld([{ briefing: "held", decidedAt: NOW }]);
+  await settle();
+  while (h.agent.busy()) await settle();
+  const [started] = ofKind(events, BRAIN_RUN_EVENT.TURN_STARTED);
+  assert.equal(started?.origin, BRAIN_TURN_ORIGIN.HOLD_RELEASE);
+  assert.equal(started?.trigger, BRAIN_TURN_TRIGGER.HOLD_RELEASED);
+  assert.deepEqual(kinds(events).at(-1), BRAIN_RUN_EVENT.TURN_ENDED);
+  await h.agent.stop();
+});
+
+test("a reasoning item is told with its summary and the opaque item, and the message keeps the summary beside the provider's replay data", async () => {
+  const h = harness();
+  const events = listen(h);
+  h.client.answers.push(answered([SUMMARIZED_REASONING, message("Only abc.")]));
+  const record = await ask(h, "who is waiting?");
+  assert.equal(record?.status, BRAIN_REQUEST_STATUS.SUCCEEDED);
+  assert.deepEqual(kinds(events), [
+    BRAIN_RUN_EVENT.TURN_STARTED,
+    BRAIN_RUN_EVENT.MESSAGE_COMPLETED,
+    BRAIN_RUN_EVENT.REASONING_COMPLETED,
+    BRAIN_RUN_EVENT.MESSAGE_COMPLETED,
+    BRAIN_RUN_EVENT.ACTIONS_SETTLED,
+    BRAIN_RUN_EVENT.REPLY_SENTENCE,
+    BRAIN_RUN_EVENT.ENDED,
+    BRAIN_RUN_EVENT.TURN_ENDED,
+  ]);
+  const [reasoned] = ofKind(events, BRAIN_RUN_EVENT.REASONING_COMPLETED);
+  assert.deepEqual(bare(reasoned), {
+    kind: BRAIN_RUN_EVENT.REASONING_COMPLETED,
+    summary: "Only abc is waiting.",
+    item: SUMMARIZED_REASONING,
+  });
+  const [, answer] = ofKind(events, BRAIN_RUN_EVENT.MESSAGE_COMPLETED);
+  assert.deepEqual(answer?.message.parts, [
+    {
+      type: UI_PART_TYPE.REASONING,
+      id: "rs_1",
+      text: "Only abc is waiting.",
+      state: UI_PART_STATE.DONE,
+      providerMetadata: {
+        [REASONING_PROVIDER_KEY]: { itemId: "rs_1", reasoningEncryptedContent: "opaque" },
+      },
+    },
+    { type: UI_PART_TYPE.TEXT, text: "Only abc.", state: UI_PART_STATE.DONE },
+  ]);
+  await h.agent.stop();
+});
+
+test("a refused call settles as an error carrying the refusal's own reason, and the message's tool part says so", async () => {
+  const h = harness({ actions: { perform: async () => refusedActionOutput("not now") } });
+  const events = listen(h);
+  h.client.answers.push(answered([messageAbc("send_x")]), answered([message("It refused.")]));
+  const record = await ask(h, "tell abc to run the tests");
+  assert.equal(record?.status, BRAIN_REQUEST_STATUS.SUCCEEDED);
+  const [settled] = ofKind(events, BRAIN_RUN_EVENT.TOOL_CALL_SETTLED);
+  assert.deepEqual(settled?.settlement, {
+    state: TOOL_CALL_SETTLEMENT.OUTPUT_ERROR,
+    output: { status: ACTION_OUTPUT_STATUS.REFUSED, reason: "not now" },
+    errorText: "not now",
+    status: ACTION_OUTPUT_STATUS.REFUSED,
+  });
+  const [, answer] = ofKind(events, BRAIN_RUN_EVENT.MESSAGE_COMPLETED);
+  assert.deepEqual(answer?.message.parts[0], {
+    type: toolPartType(REALTIME_TOOL.SEND_SESSION_MESSAGE),
+    toolCallId: "send_x",
+    state: TOOL_PART_STATE.OUTPUT_ERROR,
+    input: {
+      provider_id: ABC.providerId,
+      provider_session_id: ABC.providerSessionId,
+      text: "run the tests",
+    },
+    errorText: "not now",
+  });
+  await h.agent.stop();
+});
+
+test("a compaction the provider folded inside the run is told between the call and the answer", async () => {
+  const h = harness();
+  const events = listen(h);
+  h.client.answers.push(answered([compaction("c_1"), message("Folded.")]));
+  const record = await ask(h, "hello");
+  assert.equal(record?.status, BRAIN_REQUEST_STATUS.SUCCEEDED);
+  assert.deepEqual(kinds(events), [
+    BRAIN_RUN_EVENT.TURN_STARTED,
+    BRAIN_RUN_EVENT.MESSAGE_COMPLETED,
+    BRAIN_RUN_EVENT.COMPACTION_COMPLETED,
+    BRAIN_RUN_EVENT.MESSAGE_COMPLETED,
+    BRAIN_RUN_EVENT.ACTIONS_SETTLED,
+    BRAIN_RUN_EVENT.REPLY_SENTENCE,
+    BRAIN_RUN_EVENT.ENDED,
+    BRAIN_RUN_EVENT.TURN_ENDED,
+  ]);
+  const [compacted] = ofKind(events, BRAIN_RUN_EVENT.COMPACTION_COMPLETED);
+  assert.equal(compacted?.compaction.source, COMPACTION_SOURCE.PROVIDER_INLINE);
+  assert.ok(Number.isInteger(compacted?.compaction.dropped));
+  assert.equal("summary" in (compacted?.compaction ?? {}), false);
+  await h.agent.stop();
+});
+
+test("an ask steered into a running turn is a message of that turn, and its record's end is numbered in that turn before the turn's own end", async () => {
+  const inner = new FakeClient();
+  const gated = gatedClient(inner);
+  const h = harness({ client: gated.client });
+  const events = listen(h);
+  inner.answers.push(answered([message("First alone.")]), answered([message("Both answered.")]));
+  const first = acceptedRunId(await submit(h, "first?"));
+  await settle();
+  const second = acceptedRunId(await submit(h, "second?"));
+  await settle();
+  assert.equal(h.agent.request(second)?.status, BRAIN_REQUEST_STATUS.RUNNING);
+  gated.open();
+  await settle();
+  assert.equal((await h.agent.waitAsk(second, 1))?.status, BRAIN_REQUEST_STATUS.SUCCEEDED);
+  assertOneTurn(events, first);
+  assert.deepEqual(kinds(events), [
+    BRAIN_RUN_EVENT.TURN_STARTED,
+    BRAIN_RUN_EVENT.MESSAGE_COMPLETED,
+    BRAIN_RUN_EVENT.MESSAGE_COMPLETED,
+    BRAIN_RUN_EVENT.MESSAGE_COMPLETED,
+    BRAIN_RUN_EVENT.ACTIONS_SETTLED,
+    BRAIN_RUN_EVENT.REPLY_SENTENCE,
+    BRAIN_RUN_EVENT.REPLY_SENTENCE,
+    BRAIN_RUN_EVENT.ENDED,
+    BRAIN_RUN_EVENT.ENDED,
+    BRAIN_RUN_EVENT.TURN_ENDED,
+  ]);
+  assert.deepEqual(
+    ofKind(events, BRAIN_RUN_EVENT.MESSAGE_COMPLETED).map((event) => event.message.role),
+    [MESSAGE_ROLE.USER, MESSAGE_ROLE.USER, MESSAGE_ROLE.ASSISTANT],
+  );
+  assert.deepEqual(
+    ofKind(events, BRAIN_RUN_EVENT.ENDED).map((event) => event.runId),
+    [second, first],
+  );
+  await h.agent.stop();
+});
+
+test("a rider withdrawn mid-turn ends where it was withdrawn, numbered in the turn it left, and the turn still ends last", async () => {
+  const inner = new FakeClient();
+  const gated = gatedClient(inner);
+  const h = harness({ client: gated.client });
+  const events = listen(h);
+  inner.answers.push(answered([message("Alone again.")]));
+  const first = acceptedRunId(await submit(h, "first?"));
+  await settle();
+  const second = acceptedRunId(await submit(h, "second?"));
+  await settle();
+  await h.agent.cancelAsk(second);
+  assert.equal(h.agent.request(second)?.status, BRAIN_REQUEST_STATUS.CANCELLED);
+  gated.open();
+  await settle();
+  assert.equal((await h.agent.waitAsk(first, 1))?.status, BRAIN_REQUEST_STATUS.SUCCEEDED);
+  assertOneTurn(events, first);
+  assert.deepEqual(kinds(events), [
+    BRAIN_RUN_EVENT.TURN_STARTED,
+    BRAIN_RUN_EVENT.MESSAGE_COMPLETED,
+    BRAIN_RUN_EVENT.MESSAGE_COMPLETED,
+    BRAIN_RUN_EVENT.ENDED,
+    BRAIN_RUN_EVENT.MESSAGE_COMPLETED,
+    BRAIN_RUN_EVENT.ACTIONS_SETTLED,
+    BRAIN_RUN_EVENT.REPLY_SENTENCE,
+    BRAIN_RUN_EVENT.ENDED,
+    BRAIN_RUN_EVENT.TURN_ENDED,
+  ]);
+  assert.deepEqual(
+    ofKind(events, BRAIN_RUN_EVENT.ENDED).map((event) => [event.runId, event.status]),
+    [
+      [second, BRAIN_REQUEST_STATUS.CANCELLED],
+      [first, BRAIN_REQUEST_STATUS.SUCCEEDED],
+    ],
+  );
+  await h.agent.stop();
+});
+
+test("a spoken ask's turn is prepared with the spoken origin and told under it, and a typed ask's with the typed one", async () => {
   const prepared: BrainTurnDescription[] = [];
   const h = harness({
     prepareTurn: (turn) => {
@@ -202,6 +712,7 @@ test("a spoken ask's turn is prepared with the spoken origin, and a typed ask's 
       return PLAIN_PREPARATION(turn);
     },
   });
+  const events = listen(h);
   h.client.answers.push(answered([message("Yes.")]), answered([message("No.")]));
   const spoken = await h.agent.submitAsk({
     submissionId: "spoken-1",
@@ -222,6 +733,16 @@ test("a spoken ask's turn is prepared with the spoken origin, and a typed ask's 
       askOrigin: BRAIN_REQUEST_ORIGIN.TYPED,
     },
   ]);
+  assert.deepEqual(
+    ofKind(events, BRAIN_RUN_EVENT.TURN_STARTED).map((event) => event.origin),
+    [BRAIN_TURN_ORIGIN.SPOKEN, BRAIN_TURN_ORIGIN.TYPED],
+  );
+  assert.deepEqual(
+    ofKind(events, BRAIN_RUN_EVENT.MESSAGE_COMPLETED)
+      .filter((event) => event.message.role === MESSAGE_ROLE.USER)
+      .map((event) => event.message.metadata),
+    [{ author: MESSAGE_AUTHOR.DEVELOPER, channel: MESSAGE_CHANNEL.VOICE }, TYPED_ASK],
+  );
   await h.agent.stop();
 });
 
@@ -235,6 +756,177 @@ test("a listener that throws ends no run", async () => {
   assert.equal(record?.status, BRAIN_REQUEST_STATUS.SUCCEEDED);
   assert.equal(record?.text, "Fine.");
   await h.agent.stop();
+});
+
+test("every trigger has one origin: an ask's by where the ask came from, the rest by the trigger alone", () => {
+  assert.deepEqual(
+    [
+      turnOriginOf(BRAIN_TURN_TRIGGER.ASK, BRAIN_REQUEST_ORIGIN.TYPED),
+      turnOriginOf(BRAIN_TURN_TRIGGER.ASK, BRAIN_REQUEST_ORIGIN.SPOKEN),
+      turnOriginOf(BRAIN_TURN_TRIGGER.ASK, undefined),
+      turnOriginOf(BRAIN_TURN_TRIGGER.CHILD_TASK, BRAIN_REQUEST_ORIGIN.CHILD),
+      turnOriginOf(BRAIN_TURN_TRIGGER.CHILD_COMPLETION, undefined),
+      turnOriginOf(BRAIN_TURN_TRIGGER.HOLD_RELEASED, undefined),
+      turnOriginOf(BRAIN_TURN_TRIGGER.WAKE, undefined),
+      turnOriginOf(BRAIN_TURN_TRIGGER.ROSTER, undefined),
+    ],
+    [
+      BRAIN_TURN_ORIGIN.TYPED,
+      BRAIN_TURN_ORIGIN.SPOKEN,
+      BRAIN_TURN_ORIGIN.TYPED,
+      BRAIN_TURN_ORIGIN.CHILD,
+      BRAIN_TURN_ORIGIN.CHILD_COMPLETION,
+      BRAIN_TURN_ORIGIN.HOLD_RELEASE,
+      BRAIN_TURN_ORIGIN.OBSERVATION,
+      BRAIN_TURN_ORIGIN.OBSERVATION,
+    ],
+  );
+});
+
+test("a user row's metadata follows the trigger: asks by channel, observations by source, and none where the vocabulary has no shape", () => {
+  assert.deepEqual(
+    [
+      userMetadataOf(BRAIN_TURN_TRIGGER.ASK, BRAIN_REQUEST_ORIGIN.TYPED),
+      userMetadataOf(BRAIN_TURN_TRIGGER.ASK, BRAIN_REQUEST_ORIGIN.SPOKEN),
+      userMetadataOf(BRAIN_TURN_TRIGGER.WAKE, undefined),
+      userMetadataOf(BRAIN_TURN_TRIGGER.ROSTER, undefined),
+      userMetadataOf(BRAIN_TURN_TRIGGER.HOLD_RELEASED, undefined),
+      userMetadataOf(BRAIN_TURN_TRIGGER.CHILD_TASK, BRAIN_REQUEST_ORIGIN.CHILD),
+      userMetadataOf(BRAIN_TURN_TRIGGER.CHILD_COMPLETION, undefined),
+    ],
+    [
+      TYPED_ASK,
+      { author: MESSAGE_AUTHOR.DEVELOPER, channel: MESSAGE_CHANNEL.VOICE },
+      { author: MESSAGE_AUTHOR.BRAIN, source: OBSERVATION_SOURCE.HOOK },
+      { author: MESSAGE_AUTHOR.BRAIN, source: OBSERVATION_SOURCE.ROSTER_LOOK },
+      undefined,
+      undefined,
+      undefined,
+    ],
+  );
+});
+
+test("a tool's result settles as an answer unless its status is a refusal or its silence, and an error carries the output's reason or the text itself", () => {
+  const accepted = JSON.stringify({ status: ACTION_RESULT_STATUS.ACCEPTED, sent: true });
+  assert.deepEqual(toolCallSettlementOf(accepted, ACTION_RESULT_STATUS.ACCEPTED), {
+    state: TOOL_CALL_SETTLEMENT.OUTPUT_AVAILABLE,
+    output: { status: ACTION_RESULT_STATUS.ACCEPTED, sent: true },
+    status: ACTION_RESULT_STATUS.ACCEPTED,
+  });
+  assert.deepEqual(toolCallSettlementOf(JSON.stringify({ sessions: [] }), undefined), {
+    state: TOOL_CALL_SETTLEMENT.OUTPUT_AVAILABLE,
+    output: { sessions: [] },
+  });
+  const rejected = JSON.stringify({ status: ACTION_RESULT_STATUS.REJECTED, reason: "not here" });
+  assert.deepEqual(toolCallSettlementOf(rejected, ACTION_RESULT_STATUS.REJECTED), {
+    state: TOOL_CALL_SETTLEMENT.OUTPUT_ERROR,
+    output: { status: ACTION_RESULT_STATUS.REJECTED, reason: "not here" },
+    errorText: "not here",
+    status: ACTION_RESULT_STATUS.REJECTED,
+  });
+  const silent = JSON.stringify({ status: TOOL_RESULT_STATUS.UNKNOWN });
+  assert.deepEqual(toolCallSettlementOf(silent, TOOL_RESULT_STATUS.UNKNOWN), {
+    state: TOOL_CALL_SETTLEMENT.OUTPUT_ERROR,
+    output: { status: TOOL_RESULT_STATUS.UNKNOWN },
+    errorText: silent,
+    status: TOOL_RESULT_STATUS.UNKNOWN,
+  });
+  const refused = JSON.stringify(refusedActionOutput("not here either"));
+  assert.equal(
+    toolCallSettlementOf(refused, ACTION_OUTPUT_STATUS.REFUSED).state,
+    TOOL_CALL_SETTLEMENT.OUTPUT_ERROR,
+  );
+  assert.deepEqual(toolCallSettlementOf("not json", ACTION_RESULT_STATUS.UNSUPPORTED), {
+    state: TOOL_CALL_SETTLEMENT.OUTPUT_ERROR,
+    output: "not json",
+    errorText: "not json",
+    status: ACTION_RESULT_STATUS.UNSUPPORTED,
+  });
+  assert.deepEqual(toolCallInput('{"text":"hi"}'), { text: "hi" });
+  assert.equal(toolCallInput("{broken"), "{broken");
+});
+
+test("a turn's teller numbers its events from one, knows once its start was told, and registers the runs it adopts", () => {
+  const fired: BrainRunEvent[] = [];
+  const registry = new Map<string, TurnEvents>();
+  let minted = 0;
+  const events = new TurnEvents({
+    conversationId: MAIN_SESSION_KEY,
+    turnId: "turn-1",
+    fire: (event) => fired.push(event),
+    createMessageId: () => `m-${++minted}`,
+    now: () => NOW,
+    registry,
+  });
+  assert.equal(events.opened, false);
+  events.actionsSettled("turn-1");
+  assert.equal(events.opened, false);
+  events.started(BRAIN_TURN_ORIGIN.TYPED, BRAIN_TURN_TRIGGER.ASK);
+  assert.equal(events.opened, true);
+  events.words("hello", TYPED_ASK);
+  events.adopt("rider-1");
+  assert.equal(registry.get("rider-1"), events);
+  assert.deepEqual(
+    fired.map((event) => [event.kind, event.conversationId, event.turnId, event.sequence]),
+    [
+      [BRAIN_RUN_EVENT.ACTIONS_SETTLED, MAIN_SESSION_KEY, "turn-1", 1],
+      [BRAIN_RUN_EVENT.TURN_STARTED, MAIN_SESSION_KEY, "turn-1", 2],
+      [BRAIN_RUN_EVENT.MESSAGE_COMPLETED, MAIN_SESSION_KEY, "turn-1", 3],
+    ],
+  );
+  const [, , words] = fired;
+  assert.ok(words?.kind === BRAIN_RUN_EVENT.MESSAGE_COMPLETED);
+  assert.equal(words.message.id, "m-1");
+  assert.equal(words.message.role, MESSAGE_ROLE.USER);
+  assert.deepEqual(words.message.metadata, TYPED_ASK);
+});
+
+test("the assistant message gathers reasoning, text, and tool parts in order, settling each call in place and adding no part for silence", () => {
+  const builder = new AssistantMessageBuilder();
+  builder.reasoning({ itemId: "rs_1", summary: "Thinking.", item: { type: "reasoning" } });
+  builder.text("");
+  builder.toolCall({ callId: "c_1", name: "list_sessions", argumentsJson: "{}" }, {});
+  builder.toolCall({ callId: "c_2", name: "open_session", argumentsJson: "{}" }, { id: "abc" });
+  builder.toolResult("c_1", {
+    state: TOOL_CALL_SETTLEMENT.OUTPUT_AVAILABLE,
+    output: { sessions: [] },
+  });
+  builder.toolResult("c_2", {
+    state: TOOL_CALL_SETTLEMENT.OUTPUT_ERROR,
+    output: { status: ACTION_RESULT_STATUS.REJECTED },
+    errorText: "no",
+  });
+  builder.toolResult("c_3", { state: TOOL_CALL_SETTLEMENT.OUTPUT_AVAILABLE, output: 1 });
+  builder.text("Done.");
+  assert.deepEqual(builder.finish("m_1"), {
+    id: "m_1",
+    role: MESSAGE_ROLE.ASSISTANT,
+    metadata: BRAIN_AUTHORED,
+    parts: [
+      {
+        type: UI_PART_TYPE.REASONING,
+        id: "rs_1",
+        text: "Thinking.",
+        state: UI_PART_STATE.DONE,
+        providerMetadata: { [REASONING_PROVIDER_KEY]: { itemId: "rs_1" } },
+      },
+      {
+        type: toolPartType("list_sessions"),
+        toolCallId: "c_1",
+        state: TOOL_PART_STATE.OUTPUT_AVAILABLE,
+        input: {},
+        output: { sessions: [] },
+      },
+      {
+        type: toolPartType("open_session"),
+        toolCallId: "c_2",
+        state: TOOL_PART_STATE.OUTPUT_ERROR,
+        input: { id: "abc" },
+        errorText: "no",
+      },
+      { type: UI_PART_TYPE.TEXT, text: "Done.", state: UI_PART_STATE.DONE },
+    ],
+  });
 });
 
 test("the slow steps are the whole-transcript read and the performer's writes, only when the policy offers them", () => {

--- a/packages/brain/src/run-events.ts
+++ b/packages/brain/src/run-events.ts
@@ -1,14 +1,41 @@
+import { ACTION_OUTPUT_STATUS } from "@sidecar/actions";
 import { type EffectiveToolPolicy, TOOL_EFFECT, TOOL_EXECUTION } from "@sidecar/runtime";
-import type { BrainRequestFailure, BrainRequestStatus, BrainRunUsage } from "./requests.js";
+import type { CompactionSource, RuntimeCompaction, SessionKey } from "@sidecar/runtime/vocabulary";
+import {
+  ACTION_RESULT_STATUS,
+  isRecord,
+  isWireString,
+  type UnparsedWireValue,
+  type WireRecord,
+} from "@sidecar/wire";
+import type { UIMessage } from "ai";
+import {
+  BRAIN_REQUEST_ORIGIN,
+  type BrainRequestFailure,
+  type BrainRequestOrigin,
+  type BrainRequestStatus,
+  type BrainRunUsage,
+} from "./requests.js";
+import { TOOL_RESULT_STATUS } from "./runtime.js";
 import { BRAIN_TOOL } from "./tools.js";
+import { BRAIN_TURN_TRIGGER, type BrainTurnTrigger } from "./turn.js";
 
 /**
- * What a recorded run tells whoever is relaying it into a live conversation,
- * as it happens: the one moment it begins a step worth a spoken update, the
- * moment every action it took has its result journaled, the final answer a
- * sentence at a time once that moment has passed, and its end. The events
- * carry the run's id and the record's own vocabulary, never a transcript,
- * and a listener that throws ends no turn.
+ * What a turn tells whoever is listening, as it happens, whichever kind of
+ * turn it is: a developer's ask, an observation, a hold's release, a child's
+ * task, or a child's completion. Two audiences hear one stream. A relay into
+ * a live conversation reads the recorded run's moments: the one step worth a
+ * spoken update, the moment every action it took has its result journaled,
+ * the final answer a sentence at a time once that moment has passed, and the
+ * record's end. A writer keeping the conversation reads the turn whole: its
+ * start and origin, each tool call before it runs and its output or error
+ * after, each reasoning item's summary beside the provider's opaque item, the
+ * messages the turn completed as AI SDK `UIMessage`s, a compaction it folded,
+ * and its end with the status, the usage split four ways, and the response
+ * ids. Every event carries the conversation's key, the turn's id, and its
+ * place in the turn's sequence, numbered from one by the turn's one teller
+ * (`TurnEvents`), which fires them in order, so a consumer can verify it
+ * heard the turn whole. A listener that throws ends no turn.
  */
 
 export const BRAIN_RUN_EVENT = {
@@ -20,7 +47,23 @@ export const BRAIN_RUN_EVENT = {
   REPLY_SENTENCE: "reply_sentence",
   /** The run's record reached a terminal status. */
   ENDED: "ended",
+  /** The turn opened past its door and is about to read its opening words. */
+  TURN_STARTED: "turn_started",
+  /** The model asked for a tool; nothing of the call has run yet. */
+  TOOL_CALL_STARTED: "tool_call_started",
+  /** The tool answered, or was refused, and its output is in the context. */
+  TOOL_CALL_SETTLED: "tool_call_settled",
+  /** One reasoning item of an answer is in the context. */
+  REASONING_COMPLETED: "reasoning_completed",
+  /** A message of the turn is complete: the words the turn opened with, words steered in, or the model's finished answer. */
+  MESSAGE_COMPLETED: "message_completed",
+  /** The context was folded, before the turn's first inference or inside the run. */
+  COMPACTION_COMPLETED: "compaction_completed",
+  /** The turn's execution is over, however it ended. */
+  TURN_ENDED: "turn_ended",
 } as const;
+
+export type BrainRunEventKind = (typeof BRAIN_RUN_EVENT)[keyof typeof BRAIN_RUN_EVENT];
 
 /** The kinds of step that count as slow: a whole transcript read, or a write the provider carries. */
 export const SLOW_STEP_KIND = {
@@ -30,7 +73,93 @@ export const SLOW_STEP_KIND = {
 
 export type SlowStepKind = (typeof SLOW_STEP_KIND)[keyof typeof SLOW_STEP_KIND];
 
-export type BrainRunEvent =
+/** Who or what opened a turn, as the turn's record takes it: attribution, never a permission. */
+export const BRAIN_TURN_ORIGIN = {
+  /** A developer's ask typed into a composer. */
+  TYPED: "typed",
+  /** A developer's ask spoken, relayed by the voice service. */
+  SPOKEN: "spoken",
+  /** A provider's hook or the roster look on the observation pass. */
+  OBSERVATION: "observation",
+  /** A hold's release of briefings decided earlier. */
+  HOLD_RELEASE: "hold_release",
+  /** A child's own delegated task. */
+  CHILD: "child",
+  /** A requester's turn opened by a child's completion. */
+  CHILD_COMPLETION: "child_completion",
+} as const;
+
+export type BrainTurnOrigin = (typeof BRAIN_TURN_ORIGIN)[keyof typeof BRAIN_TURN_ORIGIN];
+
+/** The origin a turn's trigger and, for an ask, its ask's origin amount to. */
+export function turnOriginOf(
+  trigger: BrainTurnTrigger,
+  askOrigin: BrainRequestOrigin | undefined,
+): BrainTurnOrigin {
+  switch (trigger) {
+    case BRAIN_TURN_TRIGGER.ASK:
+      return askOrigin === BRAIN_REQUEST_ORIGIN.SPOKEN
+        ? BRAIN_TURN_ORIGIN.SPOKEN
+        : BRAIN_TURN_ORIGIN.TYPED;
+    case BRAIN_TURN_TRIGGER.CHILD_TASK:
+      return BRAIN_TURN_ORIGIN.CHILD;
+    case BRAIN_TURN_TRIGGER.CHILD_COMPLETION:
+      return BRAIN_TURN_ORIGIN.CHILD_COMPLETION;
+    case BRAIN_TURN_TRIGGER.HOLD_RELEASED:
+      return BRAIN_TURN_ORIGIN.HOLD_RELEASE;
+    case BRAIN_TURN_TRIGGER.WAKE:
+    case BRAIN_TURN_TRIGGER.ROSTER:
+      return BRAIN_TURN_ORIGIN.OBSERVATION;
+  }
+}
+
+/** How a tool call settled, in the AI SDK's own words for a tool part's state. */
+export const TOOL_CALL_SETTLEMENT = {
+  OUTPUT_AVAILABLE: "output-available",
+  OUTPUT_ERROR: "output-error",
+} as const;
+
+/**
+ * A tool call's outcome: its output as the model read it, parsed, and the
+ * status word the output carried. A refusal, an unsupported act, or a tool
+ * that did not answer is an error, its text the output's own reason.
+ */
+export type ToolCallSettlement =
+  | {
+      readonly state: typeof TOOL_CALL_SETTLEMENT.OUTPUT_AVAILABLE;
+      readonly output: UnparsedWireValue;
+      readonly status?: string;
+    }
+  | {
+      readonly state: typeof TOOL_CALL_SETTLEMENT.OUTPUT_ERROR;
+      readonly output: UnparsedWireValue;
+      readonly errorText: string;
+      readonly status?: string;
+    };
+
+/** A compaction as the turn reports it: which way it folded, how much, and the summary where one was written. */
+export interface TurnCompaction {
+  readonly source: CompactionSource;
+  readonly dropped: number;
+  readonly summary?: string;
+}
+
+/** What every event of the stream carries beside its own fields. */
+interface BrainRunEventBase {
+  /** The conversation's key, which is its id in this build. */
+  readonly conversationId: SessionKey;
+  /** The turn the event belongs to: the primary run's id for an ask's turn, the turn's own for the rest. */
+  readonly turnId: string;
+  /**
+   * The event's place in the turn, numbered from one. `TURN_ENDED` is the
+   * last event of a turn, after every record that rode to its end has ended;
+   * a rider withdrawn mid-turn ends where it was withdrawn, numbered in the
+   * turn it left; a record's end that never opened a turn stands alone at one.
+   */
+  readonly sequence: number;
+}
+
+export type BrainRunEventBody =
   | {
       readonly kind: typeof BRAIN_RUN_EVENT.SLOW_STEP;
       readonly runId: string;
@@ -52,7 +181,101 @@ export type BrainRunEvent =
       readonly usage?: BrainRunUsage;
       /** The id of every response OpenAI answered the run with, in order. */
       readonly responseIds?: readonly string[];
+    }
+  | {
+      readonly kind: typeof BRAIN_RUN_EVENT.TURN_STARTED;
+      readonly origin: BrainTurnOrigin;
+      readonly trigger: BrainTurnTrigger;
+      readonly at: number;
+    }
+  | {
+      readonly kind: typeof BRAIN_RUN_EVENT.TOOL_CALL_STARTED;
+      readonly callId: string;
+      readonly name: string;
+      /** The call's arguments parsed, or the raw arguments text when they do not parse. */
+      readonly input: UnparsedWireValue;
+    }
+  | {
+      readonly kind: typeof BRAIN_RUN_EVENT.TOOL_CALL_SETTLED;
+      readonly callId: string;
+      readonly name: string;
+      readonly settlement: ToolCallSettlement;
+    }
+  | {
+      readonly kind: typeof BRAIN_RUN_EVENT.REASONING_COMPLETED;
+      readonly summary: string;
+      /** The provider's item, opaque and whole, as the context ingested it. */
+      readonly item: WireRecord;
+    }
+  | { readonly kind: typeof BRAIN_RUN_EVENT.MESSAGE_COMPLETED; readonly message: UIMessage }
+  | {
+      readonly kind: typeof BRAIN_RUN_EVENT.COMPACTION_COMPLETED;
+      readonly compaction: TurnCompaction;
+    }
+  | {
+      readonly kind: typeof BRAIN_RUN_EVENT.TURN_ENDED;
+      readonly status: BrainRequestStatus;
+      readonly failure?: BrainRequestFailure;
+      /** What the turn's inferences cost, split four ways, as the run kept them; absent when no inference answered. */
+      readonly usage?: BrainRunUsage;
+      /** The id of every response the turn was answered with, in order. */
+      readonly responseIds: readonly string[];
+      readonly at: number;
     };
+
+export type BrainRunEvent = BrainRunEventBody & BrainRunEventBase;
+
+/** A compaction the runtime reported, as the turn's event carries it. */
+export function turnCompactionOf(
+  compaction: RuntimeCompaction & { compacted: true },
+): TurnCompaction {
+  return {
+    source: compaction.source,
+    dropped: compaction.dropped,
+    ...(compaction.summary !== undefined ? { summary: compaction.summary } : undefined),
+  };
+}
+
+/** The statuses whose output is a refusal or a silence rather than an answer: a tool's, a performer's, or the runtime's. */
+const TOOL_ERROR_STATUSES: ReadonlySet<string> = new Set([
+  ACTION_RESULT_STATUS.REJECTED,
+  ACTION_RESULT_STATUS.UNSUPPORTED,
+  ACTION_OUTPUT_STATUS.REFUSED,
+  ACTION_OUTPUT_STATUS.UNKNOWN,
+  TOOL_RESULT_STATUS.UNKNOWN,
+]);
+
+/** JSON the runtime serialized, read back as data; text that is not JSON is kept as the text it is. */
+function parsedJson(json: string): UnparsedWireValue {
+  try {
+    // SAFETY: JSON.parse answers a wire value; the callers keep it as data and read nothing off it but a reason.
+    return JSON.parse(json) as UnparsedWireValue;
+  } catch {
+    return json;
+  }
+}
+
+/** A call's arguments as the tool part keeps them: parsed when they parse, the raw text otherwise. */
+export function toolCallInput(argumentsJson: string): UnparsedWireValue {
+  return parsedJson(argumentsJson);
+}
+
+/** How a tool's result reads as a tool part's settlement: an answer, or an error carrying the output's own reason. */
+export function toolCallSettlementOf(
+  outputJson: string,
+  status: string | undefined,
+): ToolCallSettlement {
+  const output = parsedJson(outputJson);
+  if (status === undefined || !TOOL_ERROR_STATUSES.has(status)) {
+    return {
+      state: TOOL_CALL_SETTLEMENT.OUTPUT_AVAILABLE,
+      output,
+      ...(status !== undefined ? { status } : undefined),
+    };
+  }
+  const reason = isRecord(output) && isWireString(output.reason) ? output.reason : outputJson;
+  return { state: TOOL_CALL_SETTLEMENT.OUTPUT_ERROR, output, errorText: reason, status };
+}
 
 /** Which slow step a tool call the policy offers begins, or nothing for a call that is neither slow nor offered. */
 export function slowStepOf(policy: EffectiveToolPolicy, name: string): SlowStepKind | undefined {

--- a/packages/brain/src/runtime.ts
+++ b/packages/brain/src/runtime.ts
@@ -351,6 +351,9 @@ export class ToolLoopAgentRuntime implements AgentRuntime {
     }
     await ingest({ kind: CONTEXT_INPUT_KIND.MODEL_OUTPUT, items: answer.items });
     if (lifecycle.signal?.aborted) return false;
+    for (const reasoning of answer.reasoning ?? []) {
+      await emit({ kind: RUNTIME_EVENT.REASONING, reasoning });
+    }
     if (answer.compacted) {
       const settled = await settledUnlessAborted(
         Promise.resolve(request.context.compact(lifecycle)),

--- a/packages/brain/src/turn-events.ts
+++ b/packages/brain/src/turn-events.ts
@@ -1,0 +1,208 @@
+import {
+  CONTEXT_INPUT_KIND,
+  RUNTIME_EVENT,
+  type RuntimeEvent,
+  type RuntimeRun,
+  type SessionKey,
+} from "@sidecar/runtime/vocabulary";
+import type { UserMessageMetadata } from "@sidecar/wire";
+import type { BrainRequestFailure, BrainRequestRecord, BrainRequestStatus } from "./requests.js";
+import {
+  BRAIN_RUN_EVENT,
+  type BrainRunEvent,
+  type BrainRunEventBody,
+  type BrainTurnOrigin,
+  type SlowStepKind,
+  type TurnCompaction,
+  toolCallInput,
+  toolCallSettlementOf,
+} from "./run-events.js";
+import type { BrainTurnTrigger, RunControl } from "./turn.js";
+import { AssistantMessageBuilder, userMessage } from "./ui-messages.js";
+
+export interface TurnEventsOptions {
+  readonly conversationId: SessionKey;
+  readonly turnId: string;
+  readonly fire: (event: BrainRunEvent) => void;
+  /** Mints the id of each message the turn completes. */
+  readonly createMessageId: () => string;
+  readonly now: () => number;
+  /** Where the runs a turn carries are looked up by id when their records end, so their ends join the turn's sequence. */
+  readonly registry?: Map<string, TurnEvents>;
+}
+
+/**
+ * The one teller of a turn's events. It stamps the conversation, the turn,
+ * and the next sequence number on each event and fires it at once, so the
+ * order a listener hears is the order the turn told, and it holds the
+ * model's answer as the message the turn completes, gathered from the
+ * runtime's events part by part until the turn's checkpoint puts it on record.
+ */
+export class TurnEvents {
+  readonly conversationId: SessionKey;
+  readonly turnId: string;
+  readonly #options: TurnEventsOptions;
+  readonly #message = new AssistantMessageBuilder();
+  #sequence = 0;
+  #opened = false;
+
+  constructor(options: TurnEventsOptions) {
+    this.conversationId = options.conversationId;
+    this.turnId = options.turnId;
+    this.#options = options;
+  }
+
+  /** Whether the turn's start was told, so its end is told only for a turn that started. */
+  get opened(): boolean {
+    return this.#opened;
+  }
+
+  /** Names a run whose record ends inside this turn, so that end is numbered in the turn's sequence. */
+  adopt(runId: string): void {
+    this.#options.registry?.set(runId, this);
+  }
+
+  started(origin: BrainTurnOrigin, trigger: BrainTurnTrigger): void {
+    this.#opened = true;
+    this.#emit({ kind: BRAIN_RUN_EVENT.TURN_STARTED, origin, trigger, at: this.#options.now() });
+  }
+
+  /**
+   * Words handed to the turn — its opening, or an ask steered in — are a user
+   * message, complete as handed over, saying what the vocabulary lets it say
+   * about itself.
+   */
+  words(text: string, metadata: UserMessageMetadata | undefined): void {
+    this.#emit({
+      kind: BRAIN_RUN_EVENT.MESSAGE_COMPLETED,
+      message: userMessage(this.#options.createMessageId(), text, metadata),
+    });
+  }
+
+  /** The run under way, its steer telling each message the run takes as words of the turn's own kind. */
+  relaying(run: RuntimeRun, metadata: UserMessageMetadata | undefined): RuntimeRun {
+    return {
+      runId: run.runId,
+      done: run.done,
+      cancel: (reason) => run.cancel(reason),
+      steer: (input) => {
+        const taken = run.steer(input);
+        if (taken && input.kind === CONTEXT_INPUT_KIND.USER_TEXT) this.words(input.text, metadata);
+        return taken;
+      },
+    };
+  }
+
+  /** What the runtime reports that the record hears: each reasoning item, each call before and after it runs, and the words. */
+  heard(event: RuntimeEvent): void {
+    switch (event.kind) {
+      case RUNTIME_EVENT.REASONING:
+        this.#message.reasoning(event.reasoning);
+        this.#emit({
+          kind: BRAIN_RUN_EVENT.REASONING_COMPLETED,
+          summary: event.reasoning.summary,
+          item: event.reasoning.item,
+        });
+        return;
+      case RUNTIME_EVENT.TEXT:
+        this.#message.text(event.text);
+        return;
+      case RUNTIME_EVENT.TOOL_CALL: {
+        const input = toolCallInput(event.invocation.argumentsJson);
+        this.#message.toolCall(event.invocation, input);
+        this.#emit({
+          kind: BRAIN_RUN_EVENT.TOOL_CALL_STARTED,
+          callId: event.invocation.callId,
+          name: event.invocation.name,
+          input,
+        });
+        return;
+      }
+      case RUNTIME_EVENT.TOOL_RESULT: {
+        const settlement = toolCallSettlementOf(event.result.outputJson, event.result.status);
+        this.#message.toolResult(event.invocation.callId, settlement);
+        this.#emit({
+          kind: BRAIN_RUN_EVENT.TOOL_CALL_SETTLED,
+          callId: event.invocation.callId,
+          name: event.invocation.name,
+          settlement,
+        });
+        return;
+      }
+      default:
+        return;
+    }
+  }
+
+  /** The final answer's words where the runtime's end carried ones its events had not. */
+  finalText(text: string): void {
+    this.#message.text(text);
+  }
+
+  compacted(compaction: TurnCompaction): void {
+    this.#emit({ kind: BRAIN_RUN_EVENT.COMPACTION_COMPLETED, compaction });
+  }
+
+  /** The model's answer as one message, told once the checkpoint carrying it has landed. */
+  answered(): void {
+    this.#emit({
+      kind: BRAIN_RUN_EVENT.MESSAGE_COMPLETED,
+      message: this.#message.finish(this.#options.createMessageId()),
+    });
+  }
+
+  slowStep(runId: string, step: SlowStepKind): void {
+    this.#emit({ kind: BRAIN_RUN_EVENT.SLOW_STEP, runId, step });
+  }
+
+  actionsSettled(runId: string): void {
+    this.#emit({ kind: BRAIN_RUN_EVENT.ACTIONS_SETTLED, runId });
+  }
+
+  replySentence(runId: string, sentence: string): void {
+    this.#emit({ kind: BRAIN_RUN_EVENT.REPLY_SENTENCE, runId, sentence });
+  }
+
+  /**
+   * The turn's end, the last event of every turn: told once every record that
+   * rode to the end has ended, with the status the primary record settled on
+   * where there is one, and with the run's own accounting.
+   */
+  ended(
+    run: RunControl,
+    status: BrainRequestStatus,
+    failure: BrainRequestFailure | undefined,
+  ): void {
+    this.#emit({
+      kind: BRAIN_RUN_EVENT.TURN_ENDED,
+      status,
+      ...(failure !== undefined ? { failure } : undefined),
+      ...(run.usage !== undefined ? { usage: run.usage } : undefined),
+      responseIds: [...run.responseIds],
+      at: this.#options.now(),
+    });
+  }
+
+  /** A record's end, exactly as the ledger settled it. */
+  recordEnded(record: BrainRequestRecord): void {
+    this.#emit({
+      kind: BRAIN_RUN_EVENT.ENDED,
+      runId: record.runId,
+      status: record.status,
+      ...(record.text !== undefined ? { text: record.text } : undefined),
+      ...(record.failure !== undefined ? { failure: record.failure } : undefined),
+      ...(record.usage !== undefined ? { usage: record.usage } : undefined),
+      ...(record.responseIds !== undefined ? { responseIds: record.responseIds } : undefined),
+    });
+  }
+
+  #emit(body: BrainRunEventBody): void {
+    this.#sequence += 1;
+    this.#options.fire({
+      ...body,
+      conversationId: this.conversationId,
+      turnId: this.turnId,
+      sequence: this.#sequence,
+    });
+  }
+}

--- a/packages/brain/src/turn-runner.ts
+++ b/packages/brain/src/turn-runner.ts
@@ -1,10 +1,7 @@
-import {
-  type ChildPolicyContext,
-  type EffectiveToolPolicy,
-  queueSummaryText,
-} from "@sidecar/runtime";
+import type { ChildPolicyContext, EffectiveToolPolicy } from "@sidecar/runtime";
 import {
   type AgentRuntime,
+  COMPACTION_SOURCE,
   CONTEXT_INPUT_KIND,
   type ContextMark,
   type MemoryDefinition,
@@ -15,6 +12,7 @@ import {
   type RuntimeEvent,
   type RuntimeRun,
   type RuntimeRunEnd,
+  type SessionKey,
 } from "@sidecar/runtime/vocabulary";
 import {
   joinReplyMessages,
@@ -22,14 +20,9 @@ import {
   type ProviderTranscriptSinceResult,
   type SessionIdentity,
 } from "@sidecar/session";
-import type { WireRecord } from "@sidecar/wire";
+import type { UserMessageMetadata, WireRecord } from "@sidecar/wire";
 import { BRAIN_DEFAULTS } from "./defaults.js";
-import {
-  CONTEXT_OPENING,
-  claimOpenedContext,
-  type Generation,
-  retireContext,
-} from "./generation.js";
+import { CONTEXT_OPENING, claimOpenedContext, retireContext } from "./generation.js";
 import {
   activityNoticesInputText,
   askInputText,
@@ -38,7 +31,6 @@ import {
   subagentTaskInputText,
 } from "./input-items.js";
 import { UNKNOWN_ACTION_RESULT } from "./journal.js";
-import type { RunEnd } from "./ledger.js";
 import { inboxEvents } from "./observation-inbox.js";
 import type { BrainActionExecution, BrainActionPerformer, BrainRoster } from "./performer.js";
 import { sameIdentity } from "./records.js";
@@ -47,9 +39,8 @@ import {
   BRAIN_REQUEST_FAILURE,
   BRAIN_REQUEST_ORIGIN,
   BRAIN_REQUEST_STATUS,
-  type BrainRequestRecord,
 } from "./requests.js";
-import { BRAIN_RUN_EVENT, type BrainRunEvent, replySentences, slowStepOf } from "./run-events.js";
+import { type BrainRunEvent, replySentences, slowStepOf, turnOriginOf } from "./run-events.js";
 import { incompleteDetail, TOOL_RESULT_STATUS } from "./runtime.js";
 import type { AgentSeam } from "./seam.js";
 import { settledUnlessAborted } from "./settled.js";
@@ -64,20 +55,26 @@ import { brainToolCatalog, brainToolSchemas, resolveTurnToolPolicy } from "./too
 import type { BrainToolCallTrace, BrainTurnTraceRecord } from "./trace.js";
 import { attachTranscriptDeltas, readWholeTranscript } from "./transcript-reads.js";
 import {
+  type AskInput,
+  askQuestion,
   BRAIN_TURN_KIND,
   BRAIN_TURN_TRIGGER,
   type BrainTurnDescription,
   type BrainTurnPreparation,
   type BrainTurnTrigger,
+  newRunControl,
   REPORTED_OUTCOMES,
   type RunControl,
   runOriginOf,
+  runOutcomeOf,
   TURN_OUTCOME,
   type TurnContext,
   type TurnPlan,
   type TurnResult,
   turnRevoked,
 } from "./turn.js";
+import { TurnEvents } from "./turn-events.js";
+import { userMetadataOf } from "./ui-messages.js";
 import type {
   BrainDelivery,
   BrainTurnNotice,
@@ -85,26 +82,11 @@ import type {
   BrainWakeEvent,
 } from "./wake-events.js";
 
-/**
- * What a run's end is read from: the flags its own execution set and the
- * generation it ran in. A rider's end is the primary's flags with its own
- * record, so nothing has to fabricate a control to reuse the reading.
- */
-type RunEndFlags = Pick<
-  RunControl,
-  "generation" | "cancelled" | "timedOut" | "checkpointFailed" | "compactionFailed"
->;
-
-/** What a turn came to and the run it ran under, read by the settlement that follows every exit. */
+/** What a turn came to, the run it ran under, and its teller when it opened, read by the settlement that follows every exit. */
 interface OpenedTurn {
   result: TurnResult;
   run: RunControl | undefined;
-}
-
-/** How a run ended, as its record takes it: the status and what rides beside it. */
-interface RunOutcome {
-  status: BrainRequestRecord["status"];
-  end: RunEnd;
+  events: TurnEvents | undefined;
 }
 
 /** The execution under way: for an ask to steer into or interrupt, and for a steered delivery to be answered through its plan's deliveries. */
@@ -114,6 +96,8 @@ export interface ActiveExecution {
   plan: TurnPlan;
   /** The asks riding inside the run, settled with its end. */
   riders: RunControl[];
+  /** The turn's teller, which a rider steered in is adopted by so its record's end joins the turn's sequence. */
+  events: TurnEvents;
 }
 
 /** What one turn gathers as it runs, for its trace and its deliveries. */
@@ -133,53 +117,10 @@ interface TurnGathering {
   slowStepTold: boolean;
 }
 
-/**
- * One ask as its turn reads it: the run that records it and the words the
- * model is shown for it, its question or, once the overflow folded it, the
- * one summary line the queue cut it to.
- */
-export interface AskInput {
-  readonly run: RunControl;
-  readonly text: string;
-  readonly folded: boolean;
-}
-
-/** A run's live controls as every run starts: nothing revoked, nothing failed, nothing yet done. */
-export function newRunControl(
-  runId: string,
-  generation: Generation,
-  recorded: boolean,
-): RunControl {
-  return {
-    runId,
-    generation,
-    recorded,
-    abort: new AbortController(),
-    cancelled: false,
-    timedOut: false,
-    checkpointFailed: false,
-    performedActions: 0,
-    unknownActions: 0,
-    responseIds: [],
-  };
-}
-
-/** The question one turn opens with for the asks that opened it: the overflow's summary first, then each ask's words. */
-function askQuestion(opened: readonly AskInput[]): string {
-  const summaryLines = opened.filter((input) => input.folded).map((input) => input.text);
-  const summary = queueSummaryText({
-    entries: [],
-    summaryLines,
-    summarizedCount: summaryLines.length,
-  });
-  return [
-    ...(summary === undefined ? [] : [summary]),
-    ...opened.filter((input) => !input.folded).map((input) => input.text),
-  ].join("\n\n");
-}
-
 export interface TurnRunnerOptions {
   seam: AgentSeam;
+  /** The conversation every event of this runner's turns is stamped with. */
+  conversationId: SessionKey;
   runtime: AgentRuntime;
   actions: BrainActionPerformer;
   roster: () => BrainRoster;
@@ -192,7 +133,7 @@ export interface TurnRunnerOptions {
   readTranscript: (identity: SessionIdentity) => Promise<ProviderTranscriptResult>;
   deliver: (delivery: BrainDelivery) => void | Promise<void>;
   notice?: (report: BrainTurnReport) => void;
-  /** Hears a recorded run's slow step, its actions settling, and its reply's sentences; the ledger tells its end. */
+  /** Hears every event a turn tells, stamped by the turn's own teller; the ledger tells a record's end through the same seam. */
   onRunEvent: (event: BrainRunEvent) => void;
   trace?: (record: BrainTurnTraceRecord) => void;
   openingNotes?: BrainOpeningNotes;
@@ -245,10 +186,19 @@ export class TurnRunner {
   #turnInFlight = false;
   /** The execution under way, for an ask to steer into or interrupt, and the asks riding inside it. */
   #active: ActiveExecution | undefined;
+  /** Which turn's teller each recorded run under way belongs to, so the record's end is numbered in that turn. */
+  readonly #turnOfRun = new Map<string, TurnEvents>();
 
   constructor(options: TurnRunnerOptions) {
     this.#options = options;
     this.#seam = options.seam;
+  }
+
+  /** The teller of the turn a run rode in, taken once at the record's end; nothing for a run that never opened one. */
+  takeEvents(runId: string): TurnEvents | undefined {
+    const events = this.#turnOfRun.get(runId);
+    this.#turnOfRun.delete(runId);
+    return events;
   }
 
   /** Whether a turn or the maintenance holds the context; a look waits for it. */
@@ -336,6 +286,7 @@ export class TurnRunner {
       const askOrigin = generation.requests.get(run.runId)?.origin;
       const childTask = askOrigin === BRAIN_REQUEST_ORIGIN.CHILD;
       let result: TurnResult;
+      let events: TurnEvents | undefined;
       try {
         const opened = {
           generation,
@@ -343,7 +294,7 @@ export class TurnRunner {
           events: inboxEvents(generation.inbox),
           run,
         };
-        result = await this.turn(
+        ({ result, events } = await this.#turn(
           childTask
             ? {
                 ...opened,
@@ -357,7 +308,7 @@ export class TurnRunner {
                 open: (attached, now) => [askInputText(question, attached, now)],
               },
           riders,
-        );
+        ));
       } catch {
         result = { outcome: TURN_OUTCOME.FAILED };
       }
@@ -365,6 +316,13 @@ export class TurnRunner {
       this.#options.forgetRun(run.runId);
       const { status, end } = runOutcomeOf(run, result, this.#seam.stopped());
       await this.#seam.ledger.settleRun(generation, run.runId, status, end, run);
+      this.#turnOfRun.delete(run.runId);
+      // The turn ends after its record does, and says what the record says:
+      // a settle the store refused downgrades the record, and the turn with it.
+      const record = generation.requests.get(run.runId);
+      if (events?.opened) {
+        events.ended(run, record?.status ?? status, record?.failure ?? end.failure);
+      }
       return;
     }
   }
@@ -385,6 +343,7 @@ export class TurnRunner {
       this.#options.forgetRun(rider.runId);
       const { status, end } = runOutcomeOf(primary, result, this.#seam.stopped());
       await this.#seam.ledger.settleRun(primary.generation, rider.runId, status, end);
+      this.#turnOfRun.delete(rider.runId);
     }
   }
 
@@ -393,14 +352,19 @@ export class TurnRunner {
    * hook, or by the model — the asks riding in it end with it, the asks that
    * waited behind it open, and an observation turn leaves its notice.
    */
-  async turn(plan: TurnPlan, riders: RunControl[] = []): Promise<TurnResult> {
+  async turn(plan: TurnPlan): Promise<TurnResult> {
+    return (await this.#turn(plan, [])).result;
+  }
+
+  /** The turn and its teller, for the ask's settlement that tells the turn's end after the record's. */
+  async #turn(plan: TurnPlan, riders: RunControl[]): Promise<Omit<OpenedTurn, "run">> {
     let outcome: OpenedTurn;
     try {
       outcome = await this.#openTurn(plan, riders);
     } catch {
-      outcome = { result: { outcome: TURN_OUTCOME.FAILED }, run: plan.run };
+      outcome = { result: { outcome: TURN_OUTCOME.FAILED }, run: plan.run, events: undefined };
     }
-    const { result, run } = outcome;
+    const { result, run, events } = outcome;
     // Riders ride an ask's turn alone, and an ask always brings its run.
     if (plan.run) await this.#settleRiders(riders, plan.run, result);
     // Asks that arrived while this turn ran open now rather than waiting out
@@ -419,7 +383,12 @@ export class TurnRunner {
         at: this.#seam.now(),
       });
     }
-    return result;
+    // A turn with no record of its own ends here; an ask's ends once its record has.
+    if (run && !plan.run && events?.opened) {
+      const { status, end } = runOutcomeOf(run, result, this.#seam.stopped());
+      events.ended(run, status, end.failure);
+    }
+    return { result, events };
   }
 
   /** The turn itself, answering its result and the run it ran under; the door's refusals answer the plan's own. */
@@ -433,16 +402,16 @@ export class TurnRunner {
     // Work queued in a generation since replaced opens nothing: its briefings
     // and its wakes described a memory that no longer exists.
     if (generation !== this.#seam.generation() || generation.abort.signal.aborted) {
-      return { result: { outcome: TURN_OUTCOME.REVOKED }, run: plan.run };
+      return { result: { outcome: TURN_OUTCOME.REVOKED }, run: plan.run, events: undefined };
     }
     const opened = await generation.opened;
     if (generation !== this.#seam.generation() || generation.abort.signal.aborted) {
-      return { result: { outcome: TURN_OUTCOME.REVOKED }, run: plan.run };
+      return { result: { outcome: TURN_OUTCOME.REVOKED }, run: plan.run, events: undefined };
     }
     if (opened.kind === CONTEXT_OPENING.INCOMPATIBLE) {
       // The memory is kept as it is and nothing is read or written over it.
       this.#seam.reportIncompatible(generation, opened.reason);
-      return { result: { outcome: TURN_OUTCOME.INCOMPATIBLE }, run: plan.run };
+      return { result: { outcome: TURN_OUTCOME.INCOMPATIBLE }, run: plan.run, events: undefined };
     }
     const context = opened.context;
     // An observation turn runs under an unrecorded run of its own, so an action
@@ -462,12 +431,25 @@ export class TurnRunner {
         run.abort.abort();
       }, this.#options.executionDeadlineMs);
     }
+    // The turn's events are numbered by one teller for the turn's whole life,
+    // and the recorded runs riding in it are adopted so their ends join it.
+    const events = new TurnEvents({
+      conversationId: this.#options.conversationId,
+      turnId: run.runId,
+      fire: this.#options.onRunEvent,
+      createMessageId: this.#options.createRunId,
+      now: this.#seam.now,
+      registry: this.#turnOfRun,
+    });
+    if (plan.run) events.adopt(run.runId);
+    for (const rider of riders) events.adopt(rider.runId);
     const consumes = plan.events.flatMap((event) => (event.entryId ? [event.entryId] : []));
     const turnContext: TurnContext = {
       generation,
       context,
       run,
       signal: AbortSignal.any([generation.abort.signal, run.abort.signal]),
+      events,
       ...(consumes.length > 0 ? { consumes } : undefined),
     };
     this.#turnInFlight = true;
@@ -478,8 +460,13 @@ export class TurnRunner {
       isRevoked: () => ended || this.#revoked(turnContext),
       signal: turnContext.signal,
     };
+    // A turn that threw past its teller still answers with it, so a start
+    // that was told is followed by an end.
+    let result: TurnResult;
     try {
-      return { result: await this.#runTurn(plan, turnContext, execution, riders), run };
+      result = await this.#runTurn(plan, turnContext, execution, riders);
+    } catch {
+      result = { outcome: TURN_OUTCOME.FAILED };
     } finally {
       ended = true;
       if (!plan.run && run.deadline !== undefined) this.#seam.cancel(run.deadline);
@@ -488,6 +475,7 @@ export class TurnRunner {
       plan.deliveries.turnEnded();
       this.#active = undefined;
     }
+    return { result, run, events };
   }
 
   async #runTurn(
@@ -496,7 +484,7 @@ export class TurnRunner {
     execution: BrainActionExecution,
     riders: RunControl[],
   ): Promise<TurnResult> {
-    const { generation, context, run } = turnContext;
+    const { generation, context, run, events } = turnContext;
     const startedAt = this.#seam.now();
     let contextMark: ContextMark = context.mark();
     let cursorMark = generation.cursors.persisted();
@@ -517,6 +505,7 @@ export class TurnRunner {
       return { outcome: TURN_OUTCOME.REVOKED };
     };
     if (this.#revoked(turnContext)) return revocation();
+    events.started(turnOriginOf(plan.trigger, plan.askOrigin), plan.trigger);
 
     // The consumed cursor moves to where each entry's capture read, in
     // memory now and on disk with the checkpoint; a turn that fails rolls it
@@ -585,16 +574,24 @@ export class TurnRunner {
           contextMark = context.mark();
           const recalled = await this.#recall(turnContext);
           notes = this.#options.openingNotes?.take() ?? [];
+          const hosted = [
+            ...recalled.opening,
+            ...(notes.length > 0 ? [activityNoticesInputText(notes, startedAt)] : []),
+          ];
+          const words = plan.open(events, startedAt);
+          // The words the turn opens with are its first messages, told before
+          // the model reads them: the host's own notes say nothing of
+          // themselves, and the turn's words say what opened them.
+          const metadata = userMetadataOf(plan.trigger, plan.askOrigin);
+          for (const text of hosted) turnContext.events.words(text, undefined);
+          for (const text of words) turnContext.events.words(text, metadata);
           const end = await this.#execute(turnContext, execution, gathering, {
             prompt: preparation.prompt,
             policy,
             plan,
             riders,
-            opening: [
-              ...recalled.opening,
-              ...(notes.length > 0 ? [activityNoticesInputText(notes, startedAt)] : []),
-              ...plan.open(events, startedAt),
-            ],
+            opening: [...hosted, ...words],
+            steered: metadata,
             recalled: recalled.standing,
             advanceMark,
           });
@@ -627,17 +624,15 @@ export class TurnRunner {
         plan.deliveries.persisted();
         await context.afterTurn({ signal: turnContext.signal });
       }
-      // The reply is relayed only once the checkpoint that carries every
-      // action's result has landed: nothing is said of the run before what it
-      // did is on record, and a revoked turn says nothing.
+      // The answer is a message only once the checkpoint that carries every
+      // action's result has landed, and the reply is relayed only after that:
+      // nothing is said of the run before what it did is on record, and a
+      // revoked turn says nothing.
+      if (written && !this.#revoked(turnContext)) events.answered();
       if (run.recorded && written && !this.#revoked(turnContext)) {
-        this.#options.onRunEvent({ kind: BRAIN_RUN_EVENT.ACTIONS_SETTLED, runId: run.runId });
+        events.actionsSettled(run.runId);
         for (const sentence of replySentences(gathering.outputText)) {
-          this.#options.onRunEvent({
-            kind: BRAIN_RUN_EVENT.REPLY_SENTENCE,
-            runId: run.runId,
-            sentence,
-          });
+          events.replySentence(run.runId, sentence);
         }
       }
       // A briefing leaves only from a turn that still stands: the stop or the
@@ -811,12 +806,14 @@ export class TurnRunner {
       plan: TurnPlan;
       riders: RunControl[];
       opening: readonly string[];
+      /** What an ask steered into this run says about itself: the turn's own kind, since only an ask's turn takes one. */
+      steered: UserMessageMetadata | undefined;
       /** What the memory provider recalled for every inference of the turn, after the standing context. */
       recalled: readonly string[];
       advanceMark: () => Promise<void>;
     },
   ): Promise<RuntimeRunEnd> {
-    const { context, run } = turnContext;
+    const { context, run, events } = turnContext;
     const runId = run.runId;
     const tools = createTurnToolExecutor(
       {
@@ -843,9 +840,14 @@ export class TurnRunner {
       },
     );
     const onEvent = async (event: RuntimeEvent) => {
+      // The record hears every event first; what the run keeps of it follows.
+      events.heard(event);
       switch (event.kind) {
         case RUNTIME_EVENT.ANSWERED:
           if (event.toolCalls > 0) gathering.iterations += 1;
+          return;
+        case RUNTIME_EVENT.RESPONSE:
+          run.responseIds.push(event.responseId);
           return;
         case RUNTIME_EVENT.TEXT:
           gathering.said.push(event.text);
@@ -857,12 +859,10 @@ export class TurnRunner {
           }
           run.usage = addModelUsage(run.usage, event.usage);
           return;
-        case RUNTIME_EVENT.RESPONSE:
-          run.responseIds.push(event.responseId);
-          return;
         case RUNTIME_EVENT.COMPACTED:
           gathering.compacted = true;
           turnContext.generation.compactionCount += 1;
+          events.compacted({ source: COMPACTION_SOURCE.PROVIDER_INLINE, dropped: event.dropped });
           return;
         case RUNTIME_EVENT.STEERED:
           turn.plan.deliveries.ingested();
@@ -872,7 +872,7 @@ export class TurnRunner {
           const step = slowStepOf(turn.policy, event.invocation.name);
           if (step === undefined) return;
           gathering.slowStepTold = true;
-          this.#options.onRunEvent({ kind: BRAIN_RUN_EVENT.SLOW_STEP, runId, step });
+          events.slowStep(runId, step);
           return;
         }
         case RUNTIME_EVENT.TOOL_RESULT:
@@ -919,7 +919,13 @@ export class TurnRunner {
       signal: turnContext.signal,
       onEvent,
     });
-    this.#active = { run, started, plan: turn.plan, riders: turn.riders };
+    this.#active = {
+      run,
+      started: events.relaying(started, turn.steered),
+      plan: turn.plan,
+      riders: turn.riders,
+      events,
+    };
     // Steered words the runtime never ingested are not delivered; words it
     // did ingest wait for the turn's final checkpoint, which decides them.
     return started.done.finally(() => turn.plan.deliveries.runEnded());
@@ -942,7 +948,10 @@ export class TurnRunner {
         // after, and a final answer that said nothing drops none of them. The
         // end's own text is the final answer's, already reported as the last
         // words unless the runtime reported none.
-        if (gathering.said.at(-1) !== end.text) gathering.said.push(end.text);
+        if (gathering.said.at(-1) !== end.text) {
+          gathering.said.push(end.text);
+          turnContext.events.finalText(end.text);
+        }
         gathering.outputText = joinReplyMessages(gathering.said);
         if (end.incomplete) gathering.incomplete = incompleteDetail(end.incomplete);
         return undefined;
@@ -970,39 +979,6 @@ export class TurnRunner {
   #revoked(context: Pick<TurnContext, "signal">): boolean {
     return turnRevoked(this.#seam.stopped(), context);
   }
-}
-
-/** How a run's turn result reads as its record's end. */
-function runOutcomeOf(flags: RunEndFlags, result: TurnResult, stopped: boolean): RunOutcome {
-  const end: RunEnd = {};
-  let status: BrainRequestRecord["status"];
-  if (flags.timedOut) {
-    status = BRAIN_REQUEST_STATUS.TIMED_OUT;
-    end.failure = BRAIN_REQUEST_FAILURE.DEADLINE;
-  } else if (flags.cancelled) {
-    status = BRAIN_REQUEST_STATUS.CANCELLED;
-  } else if (stopped || flags.generation.abort.signal.aborted) {
-    status = BRAIN_REQUEST_STATUS.INTERRUPTED;
-  } else if (flags.checkpointFailed) {
-    // What the run did may be unrecorded; that outranks whatever the model
-    // did afterwards, and the reply, if one formed, still travels.
-    status = BRAIN_REQUEST_STATUS.FAILED;
-    end.failure = BRAIN_REQUEST_FAILURE.PERSISTENCE;
-    if (result.outcome === TURN_OUTCOME.DONE && result.text) end.text = result.text;
-  } else if (flags.compactionFailed) {
-    status = BRAIN_REQUEST_STATUS.FAILED;
-    end.failure = BRAIN_REQUEST_FAILURE.COMPACTION;
-  } else if (result.outcome === TURN_OUTCOME.INCOMPLETE) {
-    status = BRAIN_REQUEST_STATUS.FAILED;
-    end.failure = BRAIN_REQUEST_FAILURE.INCOMPLETE;
-  } else if (result.outcome !== TURN_OUTCOME.DONE) {
-    status = BRAIN_REQUEST_STATUS.FAILED;
-    end.failure = BRAIN_REQUEST_FAILURE.MODEL;
-  } else {
-    status = BRAIN_REQUEST_STATUS.SUCCEEDED;
-    if (result.text) end.text = result.text;
-  }
-  return { status, end };
 }
 
 function uniqueIdentities(events: readonly BrainWakeEvent[]): readonly SessionIdentity[] {

--- a/packages/brain/src/turn.ts
+++ b/packages/brain/src/turn.ts
@@ -1,15 +1,24 @@
 import {
   CHILD_SPAWN_REFUSAL,
   type ChildSpawnRefusal,
+  queueSummaryText,
   type ToolDescriptor,
   type ToolPolicyLayers,
 } from "@sidecar/runtime";
 import type { ScheduledTimer } from "@sidecar/runtime/vocabulary";
 import { RUN_ORIGIN, type RunOrigin } from "@sidecar/runtime/vocabulary";
 import type { Generation } from "./generation.js";
-import type { BrainRequestOrigin, BrainRunUsage } from "./requests.js";
+import type { RunEnd } from "./ledger.js";
+import {
+  BRAIN_REQUEST_FAILURE,
+  BRAIN_REQUEST_STATUS,
+  type BrainRequestOrigin,
+  type BrainRequestRecord,
+  type BrainRunUsage,
+} from "./requests.js";
 import type { SteeredDeliveries } from "./steered-deliveries.js";
 import type { RecordingContextEngine } from "./transcript-recorder.js";
+import type { TurnEvents } from "./turn-events.js";
 import type { BrainWakeEvent } from "./wake-events.js";
 
 export const BRAIN_TURN_TRIGGER = {
@@ -131,6 +140,100 @@ export interface RunControl {
   responseIds: string[];
 }
 
+/** A run's live controls as every run starts: nothing revoked, nothing failed, nothing yet done. */
+export function newRunControl(
+  runId: string,
+  generation: Generation,
+  recorded: boolean,
+): RunControl {
+  return {
+    runId,
+    generation,
+    recorded,
+    abort: new AbortController(),
+    cancelled: false,
+    timedOut: false,
+    checkpointFailed: false,
+    performedActions: 0,
+    unknownActions: 0,
+    responseIds: [],
+  };
+}
+
+/**
+ * What a run's end is read from: the flags its own execution set and the
+ * generation it ran in. A rider's end is the primary's flags with its own
+ * record, so nothing has to fabricate a control to reuse the reading.
+ */
+type RunEndFlags = Pick<
+  RunControl,
+  "generation" | "cancelled" | "timedOut" | "checkpointFailed" | "compactionFailed"
+>;
+
+/** How a run ended, as its record takes it: the status and what rides beside it. */
+interface RunOutcome {
+  status: BrainRequestRecord["status"];
+  end: RunEnd;
+}
+
+/** How a run's turn result reads as its record's end. */
+export function runOutcomeOf(flags: RunEndFlags, result: TurnResult, stopped: boolean): RunOutcome {
+  const end: RunEnd = {};
+  let status: BrainRequestRecord["status"];
+  if (flags.timedOut) {
+    status = BRAIN_REQUEST_STATUS.TIMED_OUT;
+    end.failure = BRAIN_REQUEST_FAILURE.DEADLINE;
+  } else if (flags.cancelled) {
+    status = BRAIN_REQUEST_STATUS.CANCELLED;
+  } else if (stopped || flags.generation.abort.signal.aborted) {
+    status = BRAIN_REQUEST_STATUS.INTERRUPTED;
+  } else if (flags.checkpointFailed) {
+    // What the run did may be unrecorded; that outranks whatever the model
+    // did afterwards, and the reply, if one formed, still travels.
+    status = BRAIN_REQUEST_STATUS.FAILED;
+    end.failure = BRAIN_REQUEST_FAILURE.PERSISTENCE;
+    if (result.outcome === TURN_OUTCOME.DONE && result.text) end.text = result.text;
+  } else if (flags.compactionFailed) {
+    status = BRAIN_REQUEST_STATUS.FAILED;
+    end.failure = BRAIN_REQUEST_FAILURE.COMPACTION;
+  } else if (result.outcome === TURN_OUTCOME.INCOMPLETE) {
+    status = BRAIN_REQUEST_STATUS.FAILED;
+    end.failure = BRAIN_REQUEST_FAILURE.INCOMPLETE;
+  } else if (result.outcome !== TURN_OUTCOME.DONE) {
+    status = BRAIN_REQUEST_STATUS.FAILED;
+    end.failure = BRAIN_REQUEST_FAILURE.MODEL;
+  } else {
+    status = BRAIN_REQUEST_STATUS.SUCCEEDED;
+    if (result.text) end.text = result.text;
+  }
+  return { status, end };
+}
+
+/**
+ * One ask as its turn reads it: the run that records it and the words the
+ * model is shown for it, its question or, once the overflow folded it, the
+ * one summary line the queue cut it to.
+ */
+export interface AskInput {
+  readonly run: RunControl;
+  readonly text: string;
+  readonly folded: boolean;
+}
+
+/** The question one turn opens with for the asks that opened it: the overflow's summary first, then each ask's words. */
+export function askQuestion(opened: readonly AskInput[]): string {
+  const summaryLines = opened.filter((input) => input.folded).map((input) => input.text);
+  const summary = queueSummaryText({
+    entries: [],
+    summaryLines,
+    summarizedCount: summaryLines.length,
+  });
+  return [
+    ...(summary === undefined ? [] : [summary]),
+    ...opened.filter((input) => !input.folded).map((input) => input.text),
+  ].join("\n\n");
+}
+
 interface TurnPlanBase {
   events: readonly BrainWakeEvent[];
   /** The words the turn opens with, each ingested as the developer's or the host's, in order. */
@@ -163,6 +266,8 @@ export interface TurnContext {
   context: RecordingContextEngine;
   run: RunControl;
   signal: AbortSignal;
+  /** The turn's one emitter of run events, so a compaction the maintenance folds after the turn is numbered in the turn's sequence. */
+  events: TurnEvents;
   /** The inbox entries this turn opened with, consumed by its checkpoint and by nothing sooner. */
   consumes?: readonly string[];
 }

--- a/packages/brain/src/ui-messages.ts
+++ b/packages/brain/src/ui-messages.ts
@@ -1,0 +1,175 @@
+import type { ReasoningSummary, ToolInvocation } from "@sidecar/runtime/vocabulary";
+import { TOOL_PART_STATE } from "@sidecar/session";
+import {
+  type AssistantMessageMetadata,
+  MESSAGE_AUTHOR,
+  MESSAGE_CHANNEL,
+  MESSAGE_ROLE,
+  OBSERVATION_SOURCE,
+  type UnparsedWireValue,
+  type UserMessageMetadata,
+} from "@sidecar/wire";
+import type { ReasoningUIPart, TextUIPart, ToolUIPart, UIMessage, UITools } from "ai";
+import { BRAIN_REQUEST_ORIGIN, type BrainRequestOrigin } from "./requests.js";
+import { TOOL_CALL_SETTLEMENT, type ToolCallSettlement } from "./run-events.js";
+import { BRAIN_TURN_TRIGGER, type BrainTurnTrigger } from "./turn.js";
+
+/**
+ * A turn's messages in the AI SDK's `UIMessage` shape, under the storage
+ * vocabulary `@sidecar/wire` and `@sidecar/session` declare for a stored row:
+ * the words the turn was handed as user messages, each carrying the metadata
+ * its role's schema names where this build has a shape for it, and the
+ * model's answer as one assistant message whose parts are its reasoning
+ * summaries, its text, and its tool calls in their settled states, in the
+ * order the run produced them. Nothing here reads inside a provider's item:
+ * the reasoning part keeps the summary and the replay data the adapter
+ * lifted, under the key the AI SDK's own OpenAI provider reads them from.
+ */
+
+export const UI_PART_TYPE = {
+  TEXT: "text",
+  REASONING: "reasoning",
+} as const;
+
+export const UI_PART_STATE = {
+  DONE: "done",
+} as const;
+
+/** The provider key the AI SDK's OpenAI provider reads a reasoning part's replay data from. */
+export const REASONING_PROVIDER_KEY = "openai";
+
+/** How the SDK spells a tool part's type: the tool's name behind this prefix, which its own readers derive the name from. */
+const TOOL_PART_TYPE_PREFIX = "tool-";
+
+type ToolPart = ToolUIPart<UITools>;
+type AssistantPart = TextUIPart | ReasoningUIPart | ToolPart;
+
+/** The SDK's own type discriminator for a tool part, spelled as it spells it. */
+export function toolPartType(name: string): ToolPart["type"] {
+  return `${TOOL_PART_TYPE_PREFIX}${name}`;
+}
+
+/**
+ * What a user row of this turn says about itself, where the vocabulary has a
+ * shape for it: a developer's ask by the channel it arrived on, an
+ * observation by what opened it. A hold's release, a child's task, and the
+ * host's own notes have no shape yet and carry none.
+ */
+export function userMetadataOf(
+  trigger: BrainTurnTrigger,
+  askOrigin: BrainRequestOrigin | undefined,
+): UserMessageMetadata | undefined {
+  switch (trigger) {
+    case BRAIN_TURN_TRIGGER.ASK:
+      return {
+        author: MESSAGE_AUTHOR.DEVELOPER,
+        channel:
+          askOrigin === BRAIN_REQUEST_ORIGIN.SPOKEN ? MESSAGE_CHANNEL.VOICE : MESSAGE_CHANNEL.TYPED,
+      };
+    case BRAIN_TURN_TRIGGER.WAKE:
+      return { author: MESSAGE_AUTHOR.BRAIN, source: OBSERVATION_SOURCE.HOOK };
+    case BRAIN_TURN_TRIGGER.ROSTER:
+      return { author: MESSAGE_AUTHOR.BRAIN, source: OBSERVATION_SOURCE.ROSTER_LOOK };
+    case BRAIN_TURN_TRIGGER.HOLD_RELEASED:
+    case BRAIN_TURN_TRIGGER.CHILD_TASK:
+    case BRAIN_TURN_TRIGGER.CHILD_COMPLETION:
+      return undefined;
+  }
+}
+
+/** The message a text the turn was handed amounts to: the developer's ask, an observation, a steered ask. */
+export function userMessage(
+  id: string,
+  text: string,
+  metadata: UserMessageMetadata | undefined,
+): UIMessage {
+  return {
+    id,
+    role: MESSAGE_ROLE.USER,
+    ...(metadata ? { metadata } : undefined),
+    parts: [{ type: UI_PART_TYPE.TEXT, text, state: UI_PART_STATE.DONE }],
+  };
+}
+
+const ASSISTANT_METADATA: AssistantMessageMetadata = { author: MESSAGE_AUTHOR.BRAIN };
+
+function reasoningPart(reasoning: ReasoningSummary): ReasoningUIPart {
+  return {
+    type: UI_PART_TYPE.REASONING,
+    id: reasoning.itemId,
+    text: reasoning.summary,
+    state: UI_PART_STATE.DONE,
+    providerMetadata: {
+      [REASONING_PROVIDER_KEY]: {
+        itemId: reasoning.itemId,
+        ...(reasoning.encryptedContent !== undefined
+          ? { reasoningEncryptedContent: reasoning.encryptedContent }
+          : undefined),
+      },
+    },
+  };
+}
+
+function settledToolPart(part: ToolPart, settlement: ToolCallSettlement): ToolPart {
+  const call = { type: part.type, toolCallId: part.toolCallId };
+  return settlement.state === TOOL_CALL_SETTLEMENT.OUTPUT_ERROR
+    ? {
+        ...call,
+        state: TOOL_PART_STATE.OUTPUT_ERROR,
+        input: part.input,
+        errorText: settlement.errorText,
+      }
+    : {
+        ...call,
+        state: TOOL_PART_STATE.OUTPUT_AVAILABLE,
+        input: part.input,
+        output: settlement.output,
+      };
+}
+
+/**
+ * The assistant message of one turn, gathered part by part as the run
+ * reports them. A tool call enters with its input before it runs and is
+ * replaced in place by its settled state; `finish` answers the message as it
+ * stands, and a turn that fails before its answer never finishes one.
+ */
+export class AssistantMessageBuilder {
+  readonly #parts: AssistantPart[] = [];
+  readonly #toolParts = new Map<string, number>();
+
+  reasoning(reasoning: ReasoningSummary): void {
+    this.#parts.push(reasoningPart(reasoning));
+  }
+
+  /** The words of one answer; an answer that said nothing adds no part. */
+  text(text: string): void {
+    if (text.length === 0) return;
+    this.#parts.push({ type: UI_PART_TYPE.TEXT, text, state: UI_PART_STATE.DONE });
+  }
+
+  toolCall(invocation: ToolInvocation, input: UnparsedWireValue): void {
+    this.#toolParts.set(invocation.callId, this.#parts.length);
+    this.#parts.push({
+      type: toolPartType(invocation.name),
+      toolCallId: invocation.callId,
+      state: TOOL_PART_STATE.INPUT_AVAILABLE,
+      input,
+    });
+  }
+
+  toolResult(callId: string, settlement: ToolCallSettlement): void {
+    const index = this.#toolParts.get(callId);
+    const part = index === undefined ? undefined : this.#parts[index];
+    if (index === undefined || !part || !("toolCallId" in part)) return;
+    this.#parts[index] = settledToolPart(part, settlement);
+  }
+
+  finish(id: string): UIMessage {
+    return {
+      id,
+      role: MESSAGE_ROLE.ASSISTANT,
+      metadata: ASSISTANT_METADATA,
+      parts: [...this.#parts],
+    };
+  }
+}

--- a/packages/host/src/brain/conversation-deletion.test.ts
+++ b/packages/host/src/brain/conversation-deletion.test.ts
@@ -133,6 +133,7 @@ function composed(t: TestContext) {
   const followers = new Map<BrainAgent, () => Promise<void>>();
   const build = (client: BareResponsesModel) => {
     const agent = new BrainAgent({
+      conversationId: MAIN_SESSION_KEY,
       runtime: toolLoopRuntimeOver(bareModelAdapter(client)),
       observes: { kind: LOOK_SUBJECT.NONE },
       prepareTurn: () => ({ prompt: "instructions", layers: {} }),

--- a/packages/host/src/brain/wiring.ts
+++ b/packages/host/src/brain/wiring.ts
@@ -563,6 +563,7 @@ export function wireBrain(dependencies: BrainWiringDependencies): BrainWiring {
     // host with none leaves the agent to refuse the tools itself.
     const memory = memoryFor(sessionKey);
     return new BrainAgent({
+      conversationId: sessionKey,
       observes: observed
         ? { kind: LOOK_SUBJECT.SESSION, identity: observed }
         : { kind: LOOK_SUBJECT.NONE },

--- a/packages/host/src/testing/brain-harness.ts
+++ b/packages/host/src/testing/brain-harness.ts
@@ -23,7 +23,7 @@ import {
   fakeBrainStateRepository,
 } from "@sidecar/brain/testing";
 import { drainMicrotasks } from "@sidecar/runtime/testing";
-import type { ModelResponse } from "@sidecar/runtime/vocabulary";
+import { MAIN_SESSION_KEY, type ModelResponse } from "@sidecar/runtime/vocabulary";
 import {
   appendConversationThreadEntry,
   CONVERSATION_ENTRY_KIND,
@@ -180,6 +180,7 @@ export function brainHarness() {
   const build = (client: BareResponsesModel, options: Partial<BrainAgentOptions> = {}) => {
     const model = bareModelAdapter(client);
     return new BrainAgent({
+      conversationId: MAIN_SESSION_KEY,
       observes: { kind: LOOK_SUBJECT.NONE },
       ...options,
       runtime: toolLoopRuntimeOver(model),

--- a/packages/host/src/voice-credential-transition.test.ts
+++ b/packages/host/src/voice-credential-transition.test.ts
@@ -18,7 +18,7 @@ import {
   hostedBrainBounds,
 } from "@sidecar/hosted";
 import { drainMicrotasks } from "@sidecar/runtime/testing";
-import { REASONING_EFFORT } from "@sidecar/runtime/vocabulary";
+import { MAIN_SESSION_KEY, REASONING_EFFORT } from "@sidecar/runtime/vocabulary";
 import { APP_SETTING_SCHEMA, VOICE_SOURCE, type VoiceSource } from "@sidecar/settings";
 import { VoiceCapabilityAssembler, type VoiceSettings } from "@sidecar/voice";
 import { BrainHost } from "./brain/host.js";
@@ -137,6 +137,7 @@ function composition() {
       if (!model) return undefined;
       builds.push(model.model ?? "hosted");
       return new BrainAgent({
+        conversationId: MAIN_SESSION_KEY,
         runtime: toolLoopRuntimeOver(model),
         observes: { kind: LOOK_SUBJECT.NONE },
         prepareTurn: () => ({ prompt: "instructions", layers: {} }),

--- a/packages/host/src/voice/live-brain-adapter.test.ts
+++ b/packages/host/src/voice/live-brain-adapter.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { BRAIN_RUN_EVENT, type BrainRunEvent } from "@sidecar/brain";
+import { BRAIN_RUN_EVENT, type BrainRunEvent, type BrainRunEventBody } from "@sidecar/brain";
 import {
   BRAIN_ASK_REFUSAL,
   BRAIN_REQUEST_ORIGIN,
@@ -9,6 +9,7 @@ import {
   BRAIN_SUBMISSION_REJECTION,
   type BrainSubmission,
 } from "@sidecar/brain/requests";
+import { MAIN_SESSION_KEY } from "@sidecar/runtime/vocabulary";
 import { Emitter } from "@sidecar/wire";
 import {
   LIVE_BRAIN_RUN_END,
@@ -18,11 +19,28 @@ import {
 } from "./live-brain.js";
 import { brainAgentLiveBrain, type LiveBrainAgent } from "./live-brain-adapter.js";
 
+/** The stamp every run event carries beside its own fields, as the agent's teller adds it: the conversation, the turn, its place in it. */
+function stamped(emitter: Emitter<BrainRunEvent>) {
+  let sequence = 0;
+  return {
+    fire: (body: BrainRunEventBody) => {
+      sequence += 1;
+      emitter.fire({
+        ...body,
+        conversationId: MAIN_SESSION_KEY,
+        turnId: "runId" in body ? body.runId : body.kind,
+        sequence,
+      });
+    },
+  };
+}
+
 function fakeAgent(options: { reject?: boolean } = {}) {
-  const events = new Emitter<BrainRunEvent>();
+  const emitter = new Emitter<BrainRunEvent>();
+  const events = stamped(emitter);
   const submissions: BrainSubmission[] = [];
   const agent: LiveBrainAgent = {
-    onRunEvent: events.event,
+    onRunEvent: emitter.event,
     submitAsk: async (submission) => {
       submissions.push(submission);
       if (options.reject) {

--- a/packages/runtime/src/execution.ts
+++ b/packages/runtime/src/execution.ts
@@ -178,6 +178,10 @@ export interface ReasoningSummary {
   /** The provider's id for the reasoning item the summary describes. */
   readonly itemId: string;
   readonly summary: string;
+  /** The item's encrypted content, lifted beside it by the adapter where the provider gives one, so a replay elsewhere can carry it. */
+  readonly encryptedContent?: string;
+  /** The item itself, opaque and whole, as the context ingested it; carried for a record and never read inside. */
+  readonly item: WireRecord;
 }
 
 export const MODEL_RESPONSE_OUTCOME = {
@@ -461,6 +465,8 @@ export const RUNTIME_EVENT = {
   USAGE: "usage",
   /** One inference was answered under a provider response id. */
   RESPONSE: "response",
+  /** One reasoning item of an answer, after the answer's items are in the context. */
+  REASONING: "reasoning",
   COMPACTED: "compacted",
   INCOMPLETE: "incomplete",
   THROTTLED: "throttled",
@@ -515,6 +521,7 @@ export type RuntimeEvent =
     }
   | { readonly kind: typeof RUNTIME_EVENT.USAGE; readonly usage: ModelUsage }
   | { readonly kind: typeof RUNTIME_EVENT.RESPONSE; readonly responseId: string }
+  | { readonly kind: typeof RUNTIME_EVENT.REASONING; readonly reasoning: ReasoningSummary }
   | { readonly kind: typeof RUNTIME_EVENT.COMPACTED; readonly dropped: number }
   | { readonly kind: typeof RUNTIME_EVENT.INCOMPLETE; readonly incomplete: ModelIncomplete }
   | { readonly kind: typeof RUNTIME_EVENT.THROTTLED; readonly until: number }
@@ -580,7 +587,13 @@ export interface RuntimeIdentity {
 
 /** That a compaction happened, by which way and folding how much, or why it did not. */
 export type RuntimeCompaction =
-  | { readonly compacted: true; readonly source: CompactionSource; readonly dropped: number }
+  | {
+      readonly compacted: true;
+      readonly source: CompactionSource;
+      readonly dropped: number;
+      /** The summary the older items were folded behind, where the compaction wrote one; a provider's opaque window carries none. */
+      readonly summary?: string;
+    }
   | { readonly compacted: false; readonly reason: string };
 
 /** What a compaction runs under: the prompt the next request will carry, and the signal that ends the wait. */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -177,10 +177,10 @@ importers:
     dependencies:
       '@better-auth/drizzle-adapter':
         specifier: 1.6.29
-        version: 1.6.29(@better-auth/core@1.6.29(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.5.0))(@better-auth/utils@0.4.2)(drizzle-orm@0.45.2(@electric-sql/pglite@0.5.8)(@opentelemetry/api@1.9.1)(@types/pg@8.21.0)(kysely@0.29.5)(pg@8.23.0))
+        version: 1.6.29(@better-auth/core@1.6.29(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.5.4))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.5.0))(@better-auth/utils@0.4.2)(drizzle-orm@0.45.2(@electric-sql/pglite@0.5.8)(@opentelemetry/api@1.9.1)(@types/pg@8.21.0)(kysely@0.29.5)(pg@8.23.0))
       '@better-auth/oauth-provider':
         specifier: 1.6.29
-        version: 1.6.29(@better-auth/core@1.6.29(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.5.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-auth@1.6.29(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.5.8)(@opentelemetry/api@1.9.1)(@types/pg@8.21.0)(kysely@0.29.5)(pg@8.23.0))(next@16.3.1(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@types/node@22.20.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(pg@8.23.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(better-call@1.4.0(zod@4.4.3))
+        version: 1.6.29(@better-auth/core@1.6.29(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.5.4))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.5.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-auth@1.6.29(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.5.8)(@opentelemetry/api@1.9.1)(@types/pg@8.21.0)(kysely@0.29.5)(pg@8.23.0))(next@16.3.1(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@types/node@22.20.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(pg@8.23.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(better-call@1.4.0(zod@4.5.4))
       '@fontsource-variable/bricolage-grotesque':
         specifier: 5.3.0
         version: 5.3.0
@@ -355,6 +355,9 @@ importers:
       '@sidecar/wire':
         specifier: workspace:*
         version: link:../wire
+      ai:
+        specifier: 7.0.97
+        version: 7.0.97(zod@4.5.4)
     devDependencies:
       '@types/node':
         specifier: 26.2.0
@@ -365,6 +368,9 @@ importers:
       typescript:
         specifier: 7.0.2
         version: 7.0.2
+      zod:
+        specifier: 4.5.4
+        version: 4.5.4
 
   packages/calendar:
     dependencies:
@@ -5364,9 +5370,6 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
-  zod@4.4.3:
-    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
-
   zod@4.5.4:
     resolution: {integrity: sha512-sC95tT5iHHH9gtpj6A81kh+NEaRAUFN+qlUPDUbRfOMvNf5QCBqsb3WgvnpVtK5Y+4UfA6KqufotuTvMGiTlsA==}
 
@@ -5509,13 +5512,13 @@ snapshots:
       '@babel/helper-string-parser': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
 
-  '@better-auth/core@1.6.29(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.5.0)':
+  '@better-auth/core@1.6.29(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.5.4))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.5.0)':
     dependencies:
       '@better-auth/utils': 0.4.2
       '@better-fetch/fetch': 1.3.1
       '@opentelemetry/semantic-conventions': 1.43.0
       '@standard-schema/spec': 1.1.0
-      better-call: 1.4.0(zod@4.4.3)
+      better-call: 1.4.0(zod@4.5.4)
       jose: 6.2.9
       kysely: 0.29.5
       nanostores: 1.5.0
@@ -5523,48 +5526,48 @@ snapshots:
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
 
-  '@better-auth/drizzle-adapter@1.6.29(@better-auth/core@1.6.29(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.5.0))(@better-auth/utils@0.4.2)(drizzle-orm@0.45.2(@electric-sql/pglite@0.5.8)(@opentelemetry/api@1.9.1)(@types/pg@8.21.0)(kysely@0.29.5)(pg@8.23.0))':
+  '@better-auth/drizzle-adapter@1.6.29(@better-auth/core@1.6.29(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.5.4))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.5.0))(@better-auth/utils@0.4.2)(drizzle-orm@0.45.2(@electric-sql/pglite@0.5.8)(@opentelemetry/api@1.9.1)(@types/pg@8.21.0)(kysely@0.29.5)(pg@8.23.0))':
     dependencies:
-      '@better-auth/core': 1.6.29(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.5.0)
+      '@better-auth/core': 1.6.29(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.5.4))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.5.0)
       '@better-auth/utils': 0.4.2
     optionalDependencies:
       drizzle-orm: 0.45.2(@electric-sql/pglite@0.5.8)(@opentelemetry/api@1.9.1)(@types/pg@8.21.0)(kysely@0.29.5)(pg@8.23.0)
 
-  '@better-auth/kysely-adapter@1.6.29(@better-auth/core@1.6.29(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.5.0))(@better-auth/utils@0.4.2)(kysely@0.29.5)':
+  '@better-auth/kysely-adapter@1.6.29(@better-auth/core@1.6.29(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.5.4))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.5.0))(@better-auth/utils@0.4.2)(kysely@0.29.5)':
     dependencies:
-      '@better-auth/core': 1.6.29(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.5.0)
+      '@better-auth/core': 1.6.29(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.5.4))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.5.0)
       '@better-auth/utils': 0.4.2
     optionalDependencies:
       kysely: 0.29.5
 
-  '@better-auth/memory-adapter@1.6.29(@better-auth/core@1.6.29(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.5.0))(@better-auth/utils@0.4.2)':
+  '@better-auth/memory-adapter@1.6.29(@better-auth/core@1.6.29(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.5.4))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.5.0))(@better-auth/utils@0.4.2)':
     dependencies:
-      '@better-auth/core': 1.6.29(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.5.0)
+      '@better-auth/core': 1.6.29(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.5.4))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.5.0)
       '@better-auth/utils': 0.4.2
 
-  '@better-auth/mongo-adapter@1.6.29(@better-auth/core@1.6.29(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.5.0))(@better-auth/utils@0.4.2)':
+  '@better-auth/mongo-adapter@1.6.29(@better-auth/core@1.6.29(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.5.4))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.5.0))(@better-auth/utils@0.4.2)':
     dependencies:
-      '@better-auth/core': 1.6.29(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.5.0)
+      '@better-auth/core': 1.6.29(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.5.4))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.5.0)
       '@better-auth/utils': 0.4.2
 
-  '@better-auth/oauth-provider@1.6.29(@better-auth/core@1.6.29(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.5.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-auth@1.6.29(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.5.8)(@opentelemetry/api@1.9.1)(@types/pg@8.21.0)(kysely@0.29.5)(pg@8.23.0))(next@16.3.1(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@types/node@22.20.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(pg@8.23.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(better-call@1.4.0(zod@4.4.3))':
+  '@better-auth/oauth-provider@1.6.29(@better-auth/core@1.6.29(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.5.4))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.5.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-auth@1.6.29(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.5.8)(@opentelemetry/api@1.9.1)(@types/pg@8.21.0)(kysely@0.29.5)(pg@8.23.0))(next@16.3.1(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@types/node@22.20.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(pg@8.23.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(better-call@1.4.0(zod@4.5.4))':
     dependencies:
-      '@better-auth/core': 1.6.29(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.5.0)
+      '@better-auth/core': 1.6.29(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.5.4))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.5.0)
       '@better-auth/utils': 0.4.2
       '@better-fetch/fetch': 1.3.1
       better-auth: 1.6.29(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.5.8)(@opentelemetry/api@1.9.1)(@types/pg@8.21.0)(kysely@0.29.5)(pg@8.23.0))(next@16.3.1(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@types/node@22.20.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(pg@8.23.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      better-call: 1.4.0(zod@4.4.3)
+      better-call: 1.4.0(zod@4.5.4)
       jose: 6.2.9
-      zod: 4.4.3
+      zod: 4.5.4
 
-  '@better-auth/prisma-adapter@1.6.29(@better-auth/core@1.6.29(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.5.0))(@better-auth/utils@0.4.2)':
+  '@better-auth/prisma-adapter@1.6.29(@better-auth/core@1.6.29(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.5.4))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.5.0))(@better-auth/utils@0.4.2)':
     dependencies:
-      '@better-auth/core': 1.6.29(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.5.0)
+      '@better-auth/core': 1.6.29(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.5.4))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.5.0)
       '@better-auth/utils': 0.4.2
 
-  '@better-auth/telemetry@1.6.29(@better-auth/core@1.6.29(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.5.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)':
+  '@better-auth/telemetry@1.6.29(@better-auth/core@1.6.29(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.5.4))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.5.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)':
     dependencies:
-      '@better-auth/core': 1.6.29(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.5.0)
+      '@better-auth/core': 1.6.29(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.5.4))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.5.0)
       '@better-auth/utils': 0.4.2
       '@better-fetch/fetch': 1.3.1
 
@@ -7174,23 +7177,23 @@ snapshots:
 
   better-auth@1.6.29(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.5.8)(@opentelemetry/api@1.9.1)(@types/pg@8.21.0)(kysely@0.29.5)(pg@8.23.0))(next@16.3.1(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@types/node@22.20.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(pg@8.23.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:
-      '@better-auth/core': 1.6.29(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.5.0)
-      '@better-auth/drizzle-adapter': 1.6.29(@better-auth/core@1.6.29(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.5.0))(@better-auth/utils@0.4.2)(drizzle-orm@0.45.2(@electric-sql/pglite@0.5.8)(@opentelemetry/api@1.9.1)(@types/pg@8.21.0)(kysely@0.29.5)(pg@8.23.0))
-      '@better-auth/kysely-adapter': 1.6.29(@better-auth/core@1.6.29(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.5.0))(@better-auth/utils@0.4.2)(kysely@0.29.5)
-      '@better-auth/memory-adapter': 1.6.29(@better-auth/core@1.6.29(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.5.0))(@better-auth/utils@0.4.2)
-      '@better-auth/mongo-adapter': 1.6.29(@better-auth/core@1.6.29(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.5.0))(@better-auth/utils@0.4.2)
-      '@better-auth/prisma-adapter': 1.6.29(@better-auth/core@1.6.29(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.5.0))(@better-auth/utils@0.4.2)
-      '@better-auth/telemetry': 1.6.29(@better-auth/core@1.6.29(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.5.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)
+      '@better-auth/core': 1.6.29(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.5.4))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.5.0)
+      '@better-auth/drizzle-adapter': 1.6.29(@better-auth/core@1.6.29(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.5.4))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.5.0))(@better-auth/utils@0.4.2)(drizzle-orm@0.45.2(@electric-sql/pglite@0.5.8)(@opentelemetry/api@1.9.1)(@types/pg@8.21.0)(kysely@0.29.5)(pg@8.23.0))
+      '@better-auth/kysely-adapter': 1.6.29(@better-auth/core@1.6.29(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.5.4))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.5.0))(@better-auth/utils@0.4.2)(kysely@0.29.5)
+      '@better-auth/memory-adapter': 1.6.29(@better-auth/core@1.6.29(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.5.4))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.5.0))(@better-auth/utils@0.4.2)
+      '@better-auth/mongo-adapter': 1.6.29(@better-auth/core@1.6.29(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.5.4))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.5.0))(@better-auth/utils@0.4.2)
+      '@better-auth/prisma-adapter': 1.6.29(@better-auth/core@1.6.29(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.5.4))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.5.0))(@better-auth/utils@0.4.2)
+      '@better-auth/telemetry': 1.6.29(@better-auth/core@1.6.29(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.5.4))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.5.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)
       '@better-auth/utils': 0.4.2
       '@better-fetch/fetch': 1.3.1
       '@noble/ciphers': 2.3.0
       '@noble/hashes': 2.3.0
-      better-call: 1.4.0(zod@4.4.3)
+      better-call: 1.4.0(zod@4.5.4)
       defu: 6.1.7
       jose: 6.2.9
       kysely: 0.29.5
       nanostores: 1.5.0
-      zod: 4.4.3
+      zod: 4.5.4
     optionalDependencies:
       drizzle-kit: 0.31.10
       drizzle-orm: 0.45.2(@electric-sql/pglite@0.5.8)(@opentelemetry/api@1.9.1)(@types/pg@8.21.0)(kysely@0.29.5)(pg@8.23.0)
@@ -7202,14 +7205,14 @@ snapshots:
       - '@cloudflare/workers-types'
       - '@opentelemetry/api'
 
-  better-call@1.4.0(zod@4.4.3):
+  better-call@1.4.0(zod@4.5.4):
     dependencies:
       '@better-auth/utils': 0.5.0
       '@better-fetch/fetch': 1.3.1
       rou3: 0.9.2
       set-cookie-parser: 3.1.2
     optionalDependencies:
-      zod: 4.4.3
+      zod: 4.5.4
 
   boolean@3.2.0:
     optional: true
@@ -9537,8 +9540,6 @@ snapshots:
       yargs-parser: 21.1.1
 
   yocto-queue@0.1.0: {}
-
-  zod@4.4.3: {}
 
   zod@4.5.4: {}
 


### PR DESCRIPTION
## What

Widens #910's typed run event stream (`BrainAgent.onRunEvent`) so it tells every kind of turn, and tells enough of each for a store writer (B5) to build the turn's `UIMessage`s, `turns` row, and events without reading anything else.

- **Every turn kind now emits.** Developer asks (typed and spoken), observation turns (a provider's hook or the roster look), a hold's release, a child's task, and a child-completion turn. The plan's coordination section recorded that #910's stream emitted nothing for observation turns and that the storage writer needs those too; closing that gap is the heart of this PR.
- **New event kinds**, each an `as const` member of `BRAIN_RUN_EVENT` with a derived union:
  - `TURN_STARTED` — `origin` (`BRAIN_TURN_ORIGIN`: `typed`, `spoken`, `observation`, `hold_release`, `child`, `child_completion`), `trigger`, `at`.
  - `TOOL_CALL_STARTED` — `callId`, `name`, `input` (arguments parsed, or the raw text when they do not parse), told before the tool runs.
  - `TOOL_CALL_SETTLED` — `callId`, `name`, `settlement` in the AI SDK's own state words: `output-available` with the parsed `output`, or `output-error` with `errorText` (the output's own `reason`) for a refusal, an unsupported act, or a tool that did not answer; the status word rides along on both.
  - `REASONING_COMPLETED` — `summary` and the provider's opaque `item`, whole.
  - `MESSAGE_COMPLETED` — a finished AI SDK `UIMessage` under A1's storage vocabulary (#917): one `user` message per text the turn was handed (its opening words, and each ask steered into it as the run takes it), carrying the `metadata` its role's schema names where this build has a shape for it (a developer's ask by channel, an observation by what opened it), and one `assistant` message per turn with `metadata { author: brain }`, told once the checkpoint carrying every action's result has landed, whose parts are the reasoning parts (`text` = summary, `providerMetadata.openai = { itemId, reasoningEncryptedContent }`, the shape the AI SDK's OpenAI provider replays from), the text parts, and static `tool-<name>` parts in A1's `TOOL_PART_STATE` states, in run order. The developer and observation turns' messages round-trip through A1's `readStoredUIMessages` in the tests.
  - `COMPACTION_COMPLETED` — `source`, `dropped`, and `summary` where the fold wrote one (the local summary fold; a provider's opaque window carries none).
  - `TURN_ENDED` — `status` and `failure` as the run's record would read them, `usage` split four ways and `responseIds` taken from where A5 (#918) keeps them on the run, and `at`.
- **Every event carries `conversationId`, `turnId`, and `sequence`.** `conversationId` is the conversation's `SessionKey`, handed to `BrainAgent` as a new required option (`conversationId`); the host wiring passes the conversation's key.

### How total order is guaranteed

One `TurnEvents` teller per turn (`packages/brain/src/turn-events.ts`) fires every event of the turn synchronously, from a single-threaded host, stamping a per-turn `sequence` from 1 with no gaps, so a consumer can verify it heard the turn whole. `TURN_ENDED` is the last event of every turn: for an ask's turn it is told after the primary record has settled and carries the status the record settled on (so a settle the store refused, which the ledger downgrades to `failed` / `persistence`, reads the same on the turn and on `ENDED`); for a turn with no record of its own it is told once the execution and the notice are done. The recorded runs a turn carries (its primary ask, drained riders, asks steered in mid-turn) are adopted by that teller through a registry the turn runner owns, so their `ENDED` events are numbered in the turn's sequence: riders that ride to the end and the primary end just before `TURN_ENDED`, and a rider withdrawn mid-turn ends where it was withdrawn, still numbered in the turn it left. A record that never opened a turn (cancelled while queued, refused at the door) stands alone at `sequence: 1` with `turnId` equal to its own `runId`, which is the plan's queued-then-cancelled turn row. The optional maintenance compaction after a turn is told to the turn that queued it, in that turn's sequence after `TURN_ENDED`, so a writer sees the fold under the turn whose context it folded.

Documented sequences, each asserted in `run-events.test.ts`:

- developer ask with a transcript read: `turn_started, message_completed (user), tool_call_started, slow_step, tool_call_settled, message_completed (assistant), actions_settled, reply_sentence…, ended, turn_ended`
- observation turn: `turn_started, message_completed (user), tool_call_started, tool_call_settled, message_completed (assistant), turn_ended` and none of the four relay kinds
- child task: `turn_started, message_completed (user), message_completed (assistant), actions_settled, reply_sentence, ended, turn_ended`
- an ask steered in mid-turn adds its `message_completed (user)` where the run took it and its `ended` beside the primary's, before `turn_ended`; one withdrawn mid-turn ends where it was withdrawn

### Strictly additive to #910

`SLOW_STEP`, `ACTIONS_SETTLED`, `REPLY_SENTENCE`, and `ENDED` keep their names, their existing fields, and their relative order; `ENDED` is still fired exactly once per run from the ledger's one `settleRun`, and `submitAsk`'s signature and origin values are untouched. The only change to those four is the three stamp fields every event now carries (`conversationId`, `turnId`, `sequence`); `ENDED`'s optional `usage` and `responseIds` are A5's and are carried unchanged.

### Runtime seams (packages/runtime, additive)

- `RUNTIME_EVENT.REASONING` carries each `ReasoningSummary` after the answer's items are in the context; it is emitted in the tool loop's `#absorb` from `ModelAnswer.reasoning`, where A5 put the summaries. A5's `RUNTIME_EVENT.RESPONSE` is used as is, not duplicated.
- `ReasoningSummary` gains `encryptedContent` (lifted by the adapter in `responses-api.ts`, the provider layer that already reads the item's `summary` and `id`) and `item` (the opaque item, whole). The host still reads inside no provider item.
- `RuntimeCompaction` gains an optional `summary`, which the local summary fold fills.

### Decomposition

Adding the telling to `turn-runner.ts` pushed it well past 1,000 lines (main has it at 1,016 after A8). It is now 992: the teller and the message it gathers live in `turn-events.ts`; `UIMessage` composition (`userMessage`, `AssistantMessageBuilder`, `userMetadataOf`) in `ui-messages.ts`; and `newRunControl`, `runOutcomeOf`, `AskInput`, and `askQuestion` moved to `turn.ts`, which already owns `RunControl` and `TurnResult`.

### Dependencies

`ai@7.0.97` is added to `@sidecar/brain` for the `UIMessage` types (type-only imports; nothing of it reaches a bundle), matching the pin A1 put on `@sidecar/session`; `zod` is a dev dependency for the round-trip test's `tool()` registry. The message roles, authors, channels, observation sources, and tool-part states are A1's (`@sidecar/wire`, `@sidecar/session`), not a second set.

## How it follows the plan

- `storage-plan.md`, Execution: "The store writer is a consumer of a runtime event stream (turn started, message completed, tool call started/settled, reasoning completed, compaction completed). Our loop emits it now." This PR is that stream from our loop.
- Storage shape: tool parts in `input-available` before execution and `output-available` / `output-error` after → `TOOL_CALL_STARTED` / `TOOL_CALL_SETTLED` and the settled `dynamic-tool` parts of the finished message; reasoning as a part with the summary and the provider's opaque item for replay → `REASONING_COMPLETED` and the reasoning part's `providerMetadata`; `turns.origin`, `status`, `response_ids`, `usage`, timings, `failure` → `TURN_STARTED` / `TURN_ENDED`.
- One naming difference to note for B5: the plan's `turns.origin` lists `roster_diff`; this build's observation turns are told as `observation`, with `trigger` distinguishing a hook (`wake`) from the roster look (`roster`), and it adds `child_completion`, a turn kind the plan's list does not name.

## Notes for B5 and C1

- User messages are told one per text the turn was handed: recalled notes and sibling activity notices open an ask's turn beside the ask itself, each as its own `user` message. A1's `USER_MESSAGE_METADATA` has a shape for a typed ask, a spoken ask, and a hook or roster-look observation, and those messages carry it; a hold's release, a child's task, the host's own notes, and a child-completion turn's words have no shape in that vocabulary yet and carry no metadata, so A1's reader refuses them until the vocabulary names them (reported to the orchestrator for A1 / B5). An ask steered into a running turn carries the turn's own ask metadata, since only an ask's turn takes one.
- A reasoning item with no summary words is not told (A5's reader keeps only items with words); it stays in the context for replay.
- `TURN_ENDED.usage` is absent when no inference answered; a throttled observation turn reads `failed` / `model` exactly as a record would.
- No store is written and `apps/web` is untouched; no migration was needed.

## CLAUDE.md

No sentence is contradicted. The stream describes what the host already does (journal, checkpoint, cursors) rather than replacing it; G5's rewrite should describe the run event stream as the record's source once B5 consumes it.

## How to verify

```
./scripts/check.sh
cd packages/brain && npx tsx --test src/run-events.test.ts src/responses-api.test.ts src/compaction.test.ts
```

Tests assert kinds and their order, sequence numbers, `as const` members, message roles and part shapes, and counts; never prose.

## Results

- `./scripts/check.sh`: passed (lint, knip, typecheck across 27 workspaces, tests, build); `packages/brain` tests 355 passing.
- No macOS or UI code touched, so `./scripts/verify.sh` does not apply.
- Rebased over A5 (#918, `1a7011c`), A1 (#917), A8 (#920), and the Live rollout's PR 8 (#921). A5's shapes (`BrainRunUsage`, `responseIds`, `ReasoningSummary`, `RUNTIME_EVENT.RESPONSE`) are used, not recomputed. PR 8's `live-brain-adapter.ts` reads the four kinds by name and drops the rest, so it needed no change; its test's fake agent now stamps the fixtures it fires the way the teller does (one helper in `live-brain-adapter.test.ts`, nothing in `packages/live`, `packages/realtime`, or the voice service).

## Reviews

Both skills fetched from their sources and applied to this diff before opening the PR.

- **Thermo-nuclear code quality review** (`cursor/plugins`, `cursor-team-kit/skills/thermo-nuclear-code-quality-review`): flagged `turn-runner.ts` crossing 1,000 lines → decomposed as above; flagged the teller keeping its own usage and response-id counters beside A5's run accounting → deleted, `TURN_ENDED` reads the run; flagged `OpenedTurn` carrying the teller only to hand it to rider settlement → dropped, riders are adopted where they join (at open, or at steer).
- **Ponytail review** (`dietrichgebert/ponytail`, `.openclaw/skills/ponytail-review`): `turn-runner.ts: delete: rider re-adoption in #settleRiders, already adopted at open or steer`; `run-events.ts: delete: BrainRunEventBase and ToolCallSettlementState exports nothing consumed`; `run-events.ts: shrink: REASONING_COMPLETED.item typed UnparsedWireValue where the adapter guarantees a WireRecord`; `run-events.test.ts: delete: weak tail assertions in the refusal test`. All applied. net: -54 lines possible, all taken.
- **Cursor Bugbot** on the first push: a rider cancelled mid-turn emitted `ENDED` before `TURN_ENDED` while the body said records end after the turn → the contract now says `TURN_ENDED` is the last event and a withdrawn rider ends where it is withdrawn, with a test; `TURN_ENDED` was told from `runOutcomeOf` before the record's settle, so a refused write could leave them disagreeing → `TURN_ENDED` is now told after the primary record settles, carrying the record's status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34534777441/artifacts/10175059765) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34534777441)

- Commit: `4d647db6d68baadf25042c8f43de1d8b9db5cbea`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
