### PR TITLE
feat(LUKE-117): context derived from UIMessages

### DIFF
--- a/packages/AGENTS.md
+++ b/packages/AGENTS.md
@@ -135,6 +135,11 @@ in the other direction: the stored shapes and their readings (the envelope
 delta a save carries, the transcript payload a row keeps), Node-free, so the
 hosted tier's Postgres store under `apps/web/server/hosted/store/` writes and
 reads the same rows the SQLite store does without resolving `node:sqlite`.
+`@sidecar/brain/ui-message-context` is the fifth, for the same reason
+`@sidecar/session/ui-messages` has a door: the context engine over stored
+`UIMessage` rows calls the AI SDK's `convertToModelMessages` at run time, and
+a bundle that only names the engine's id from the runtime's `BUILTINS` table
+must not resolve the SDK behind it.
 
 `@sidecar/runtime/vocabulary` is the same rule at the bottom of the graph: the
 identities, the storage contracts, the execution seams, and the memory

--- a/packages/brain/package.json
+++ b/packages/brain/package.json
@@ -11,7 +11,8 @@
     "./store": "./src/store/index.js",
     "./store-shapes": "./src/store/shapes.js",
     "./store-worker": "./src/store/worker-entry.js",
-    "./testing": "./src/testing.js"
+    "./testing": "./src/testing.js",
+    "./ui-message-context": "./src/ui-message-context.js"
   },
   "types": "./src/index.ts",
   "scripts": {
@@ -25,11 +26,13 @@
     "@sidecar/memory": "workspace:*",
     "@sidecar/runtime": "workspace:*",
     "@sidecar/session": "workspace:*",
-    "@sidecar/wire": "workspace:*"
+    "@sidecar/wire": "workspace:*",
+    "ai": "7.0.97"
   },
   "devDependencies": {
     "@types/node": "26.2.0",
     "tsx": "4.23.12",
-    "typescript": "7.0.2"
+    "typescript": "7.0.2",
+    "zod": "4.5.4"
   }
 }

--- a/packages/brain/src/builtins.ts
+++ b/packages/brain/src/builtins.ts
@@ -9,7 +9,10 @@ import { ToolLoopAgentRuntime } from "./runtime.js";
  * built here rather than beside the table because the runtime package must
  * not reach the brain to build one. The model adapters have no counterpart
  * here on purpose: the credential policy builds those from the credential a
- * configuration's reference names.
+ * configuration's reference names. The table's other context engine, the
+ * derivation over stored UIMessages, is constructed behind
+ * `@sidecar/brain/ui-message-context` rather than here, because it reaches
+ * the AI SDK at run time and the barrel must not.
  */
 export function toolLoopRuntimeOver(model: ModelAdapter): AgentRuntime {
   return new ToolLoopAgentRuntime({

--- a/packages/brain/src/ui-message-context.test.ts
+++ b/packages/brain/src/ui-message-context.test.ts
@@ -1,0 +1,737 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  RESPONSES_CONTENT_PART_TYPE,
+  RESPONSES_INPUT_ITEM_TYPE,
+  RESPONSES_MESSAGE_ROLE,
+} from "@sidecar/hosted";
+import {
+  CONTEXT_INPUT_KIND,
+  type ContextEngine,
+  checkpointFormatTag,
+} from "@sidecar/runtime/vocabulary";
+import {
+  MESSAGE_AUTHOR,
+  MESSAGE_CHANNEL,
+  MESSAGE_ROLE,
+  TOOL_PART_STATE,
+  type ToolPartState,
+} from "@sidecar/session";
+import type { StoredUIMessage } from "@sidecar/session/ui-messages";
+import {
+  isRecord,
+  isWireString,
+  SCHEMA_REFUSAL,
+  type UnparsedWireValue,
+  type WireRecord,
+} from "@sidecar/wire";
+import {
+  type AssistantModelMessage,
+  type ModelMessage,
+  type ProviderMetadata,
+  type ToolModelMessage,
+  type ToolSet,
+  tool,
+  type UIDataTypes,
+  type UIMessagePart,
+  type UITools,
+} from "ai";
+import { z } from "zod";
+import { ResponsesContextEngine } from "./context-engine.js";
+import {
+  type ContextRow,
+  type ModelInputOptions,
+  modelInputFrom,
+  type ReplayTarget,
+  readContextRows,
+  rowsSinceCompaction,
+  UI_MESSAGE_ENGINE_REFUSAL,
+  UIMessageContextEngine,
+} from "./ui-message-context.js";
+
+const RUNTIME = { id: "tool-loop", version: 1 };
+const LOST = JSON.stringify({ status: "unknown", reason: "the result was lost" });
+const MODEL = "gpt-5.4-mini";
+const PROVIDER = "openai";
+const REPLAY: ReplayTarget = { provider: PROVIDER, model: MODEL };
+
+const TOOL_NAME = "read_transcript";
+const TOOLS: ToolSet = {
+  [TOOL_NAME]: tool({
+    description: "Reads the tail of an observed session's transcript.",
+    inputSchema: z.object({ providerId: z.string(), providerSessionId: z.string() }),
+    outputSchema: z.object({ lines: z.array(z.string()) }),
+  }),
+};
+
+const OPTIONS: ModelInputOptions = { tools: TOOLS, replay: REPLAY, lostResultJson: LOST };
+
+/** One turn: an ask, a reasoning item before a transcript read, the read's answer, a reasoning item before the reply. */
+const TURN = {
+  ASK: '[developer ask] 2026-09-10T00:00:00.000Z\n{"question":"What is the fixture session waiting on?"}',
+  CALL_ID: "call_6f10d4e59a712b8c",
+  INPUT: { providerId: "conductor", providerSessionId: "6c1f2f14-9a0b-4c2d-8e3f-0a1b2c3d4e50" },
+  OUTPUT: { lines: ["user: Please add the fixture test.", "assistant: Waiting for permission."] },
+  REASONING_BEFORE_CALL: {
+    itemId: "rs_0f3a1c22",
+    encrypted: "Zml4dHVyZS1vcGFxdWUtb25l",
+    summary: "The developer asked about the fixture session, so read its tail before answering.",
+  },
+  REASONING_BEFORE_REPLY: {
+    itemId: "rs_1b4d2e33",
+    encrypted: "Zml4dHVyZS1vcGFxdWUtdHdv",
+    summary: "The tail shows a permission hold; say so.",
+  },
+  REPLY: "It is holding on a permission prompt before it runs the tests.",
+  EPHEMERAL: "[standing context] 2026-09-10T00:00:01.000Z\nroster",
+} as const;
+
+interface Reasoning {
+  readonly itemId: string;
+  readonly encrypted: string;
+  readonly summary: string;
+}
+
+function reasoningItem(reasoning: Reasoning): WireRecord {
+  return {
+    type: RESPONSES_INPUT_ITEM_TYPE.REASONING,
+    id: reasoning.itemId,
+    encrypted_content: reasoning.encrypted,
+    summary: [{ type: RESPONSES_CONTENT_PART_TYPE.SUMMARY_TEXT, text: reasoning.summary }],
+  };
+}
+
+function functionCallItem(): WireRecord {
+  return {
+    type: RESPONSES_INPUT_ITEM_TYPE.FUNCTION_CALL,
+    call_id: TURN.CALL_ID,
+    name: TOOL_NAME,
+    arguments: JSON.stringify(TURN.INPUT),
+  };
+}
+
+function assistantMessageItem(text: string): WireRecord {
+  return {
+    type: RESPONSES_INPUT_ITEM_TYPE.MESSAGE,
+    role: RESPONSES_MESSAGE_ROLE.ASSISTANT,
+    content: [{ type: RESPONSES_CONTENT_PART_TYPE.OUTPUT_TEXT, text }],
+  };
+}
+
+function openAiReplay(reasoning: Reasoning): ProviderMetadata {
+  return {
+    [PROVIDER]: {
+      itemId: reasoning.itemId,
+      reasoningEncryptedContent: reasoning.encrypted,
+    },
+  };
+}
+
+type StoredPart = UIMessagePart<UIDataTypes, UITools>;
+type ModelPart =
+  | Exclude<AssistantModelMessage["content"], string>[number]
+  | ToolModelMessage["content"][number];
+
+/** What a test hangs on a tool part beyond its state: a still-streaming answer, or metadata the call carries for replay. */
+interface ToolPartExtra {
+  readonly preliminary?: boolean;
+  readonly callProviderMetadata?: ProviderMetadata;
+}
+
+function userRow(id: string, text: string): ContextRow {
+  return {
+    message: {
+      id,
+      role: MESSAGE_ROLE.USER,
+      metadata: { author: MESSAGE_AUTHOR.DEVELOPER, channel: MESSAGE_CHANNEL.TYPED },
+      parts: [{ type: "text", text }],
+    },
+  };
+}
+
+function assistantRow(id: string, parts: readonly StoredPart[], model?: string): ContextRow {
+  const message: StoredUIMessage = {
+    id,
+    role: MESSAGE_ROLE.ASSISTANT,
+    metadata: { author: MESSAGE_AUTHOR.BRAIN },
+    parts: [...parts],
+  };
+  return model === undefined ? { message } : { message, model };
+}
+
+function compactionRow(id: string, summary: string, firstKeptMessageId: string): ContextRow {
+  return {
+    model: MODEL,
+    message: {
+      id,
+      role: MESSAGE_ROLE.ASSISTANT,
+      metadata: {
+        author: MESSAGE_AUTHOR.BRAIN,
+        compaction: { first_kept_message_id: firstKeptMessageId, tokens_before: 48_210 },
+      },
+      parts: [{ type: "text", text: summary, state: "done" }],
+    },
+  };
+}
+
+function toolPart(state: ToolPartState, extra: ToolPartExtra = {}): StoredPart {
+  const call = { type: `tool-${TOOL_NAME}` as const, toolCallId: TURN.CALL_ID, input: TURN.INPUT };
+  switch (state) {
+    case TOOL_PART_STATE.OUTPUT_AVAILABLE:
+      return { ...call, state, output: TURN.OUTPUT, ...extra };
+    case TOOL_PART_STATE.OUTPUT_ERROR:
+      return { ...call, state, errorText: "refused", ...extra };
+    case TOOL_PART_STATE.INPUT_AVAILABLE:
+    case TOOL_PART_STATE.INPUT_STREAMING:
+      return { ...call, state, ...extra };
+  }
+}
+
+/** The turn's assistant row as the SDK's own writer shapes it: a step boundary before each inference's parts. */
+function replyParts(
+  toolState: ToolPartState = TOOL_PART_STATE.OUTPUT_AVAILABLE,
+  toolExtra: ToolPartExtra = {},
+): StoredPart[] {
+  return [
+    { type: "step-start" },
+    {
+      type: "reasoning",
+      text: TURN.REASONING_BEFORE_CALL.summary,
+      state: "done",
+      providerMetadata: openAiReplay(TURN.REASONING_BEFORE_CALL),
+    },
+    toolPart(toolState, toolExtra),
+    { type: "step-start" },
+    {
+      type: "reasoning",
+      text: TURN.REASONING_BEFORE_REPLY.summary,
+      state: "done",
+      providerMetadata: openAiReplay(TURN.REASONING_BEFORE_REPLY),
+    },
+    { type: "text", text: TURN.REPLY, state: "done" },
+  ];
+}
+
+const ASK_ROW = userRow("3f1c9a2e-7b4d-4e8f-9a01-2b3c4d5e6f70", TURN.ASK);
+const REPLY_ROW = assistantRow("5a2d7b3c-8e4f-4a9b-8c12-3d4e5f6a7b81", replyParts(), MODEL);
+
+function engine(): UIMessageContextEngine {
+  return new UIMessageContextEngine({ runtime: RUNTIME, tools: TOOLS, replay: REPLAY });
+}
+
+function toWire(value: StoredUIMessage): WireRecord {
+  // SAFETY: a row and a model message are JSON; the round trip is their wire shape, as the engine itself takes it.
+  return JSON.parse(JSON.stringify(value)) as WireRecord;
+}
+
+function itemsOf(rows: readonly ContextRow[]): WireRecord[] {
+  return rows.map((row) => ({
+    message: toWire(row.message),
+    ...(row.model !== undefined ? { model: row.model } : undefined),
+  }));
+}
+
+function checkpointOf(context: UIMessageContextEngine, rows: readonly ContextRow[]) {
+  return { format: context.checkpointFormat, items: itemsOf(rows) };
+}
+
+async function bootstrapped(rows: readonly ContextRow[]) {
+  const context = engine();
+  const bootstrap = await context.bootstrap(checkpointOf(context, rows), LOST);
+  return { context, bootstrap };
+}
+
+/**
+ * The turn as either engine shows it to a model, in one vocabulary: what each
+ * item is and what it carries, provider shapes stripped away. Equivalence is
+ * this sequence being the same from both.
+ */
+const SHOWN = {
+  USER: "user",
+  ASSISTANT: "assistant",
+  REASONING: "reasoning",
+  CALL: "call",
+  RESULT: "result",
+} as const;
+
+type Shown =
+  | { kind: typeof SHOWN.USER; text: string }
+  | { kind: typeof SHOWN.ASSISTANT; text: string }
+  | { kind: typeof SHOWN.REASONING; itemId: unknown; encrypted: unknown; summary: string }
+  | { kind: typeof SHOWN.CALL; callId: unknown; name: unknown; input: unknown }
+  | { kind: typeof SHOWN.RESULT; callId: unknown; output: unknown };
+
+function texts(content: UnparsedWireValue, type: string): string {
+  if (!Array.isArray(content)) return "";
+  return content
+    .map((part) =>
+      isRecord(part) && part.type === type && isWireString(part.text) ? part.text : "",
+    )
+    .join("");
+}
+
+function shownByResponses(items: readonly WireRecord[]): Shown[] {
+  const shown: Shown[] = [];
+  for (const item of items) {
+    switch (item.type) {
+      case RESPONSES_INPUT_ITEM_TYPE.MESSAGE:
+        shown.push(
+          item.role === RESPONSES_MESSAGE_ROLE.USER
+            ? {
+                kind: SHOWN.USER,
+                text: texts(item.content, RESPONSES_CONTENT_PART_TYPE.INPUT_TEXT),
+              }
+            : {
+                kind: SHOWN.ASSISTANT,
+                text: texts(item.content, RESPONSES_CONTENT_PART_TYPE.OUTPUT_TEXT),
+              },
+        );
+        break;
+      case RESPONSES_INPUT_ITEM_TYPE.REASONING:
+        shown.push({
+          kind: SHOWN.REASONING,
+          itemId: item.id,
+          encrypted: item.encrypted_content,
+          summary: texts(item.summary, RESPONSES_CONTENT_PART_TYPE.SUMMARY_TEXT),
+        });
+        break;
+      case RESPONSES_INPUT_ITEM_TYPE.FUNCTION_CALL:
+        shown.push({
+          kind: SHOWN.CALL,
+          callId: item.call_id,
+          name: item.name,
+          input: isWireString(item.arguments) ? JSON.parse(item.arguments) : undefined,
+        });
+        break;
+      case RESPONSES_INPUT_ITEM_TYPE.FUNCTION_CALL_OUTPUT:
+        shown.push({
+          kind: SHOWN.RESULT,
+          callId: item.call_id,
+          output: isWireString(item.output) ? JSON.parse(item.output) : undefined,
+        });
+        break;
+      default:
+        throw new Error(`unexpected item ${String(item.type)}`);
+    }
+  }
+  return shown;
+}
+
+const MODEL_MESSAGE_ROLE = { USER: "user", ASSISTANT: "assistant", TOOL: "tool" } as const;
+const MODEL_PART = {
+  TEXT: "text",
+  REASONING: "reasoning",
+  TOOL_CALL: "tool-call",
+  TOOL_RESULT: "tool-result",
+} as const;
+
+function shownByModelMessages(messages: readonly WireRecord[]): Shown[] {
+  const shown: Shown[] = [];
+  for (const message of messages) {
+    if (message.role === MODEL_MESSAGE_ROLE.USER) {
+      const text = isWireString(message.content)
+        ? message.content
+        : texts(message.content, MODEL_PART.TEXT);
+      shown.push({ kind: SHOWN.USER, text });
+      continue;
+    }
+    if (!Array.isArray(message.content)) throw new Error("content is an array");
+    for (const part of message.content) {
+      if (!isRecord(part)) throw new Error("a part is a record");
+      switch (part.type) {
+        case MODEL_PART.TEXT:
+          shown.push({ kind: SHOWN.ASSISTANT, text: isWireString(part.text) ? part.text : "" });
+          break;
+        case MODEL_PART.REASONING: {
+          const options = isRecord(part.providerOptions) ? part.providerOptions : undefined;
+          const openai = options && isRecord(options[PROVIDER]) ? options[PROVIDER] : undefined;
+          shown.push({
+            kind: SHOWN.REASONING,
+            itemId: openai?.itemId,
+            encrypted: openai?.reasoningEncryptedContent,
+            summary: isWireString(part.text) ? part.text : "",
+          });
+          break;
+        }
+        case MODEL_PART.TOOL_CALL:
+          shown.push({
+            kind: SHOWN.CALL,
+            callId: part.toolCallId,
+            name: part.toolName,
+            input: part.input,
+          });
+          break;
+        case MODEL_PART.TOOL_RESULT: {
+          const output = isRecord(part.output) ? part.output : undefined;
+          shown.push({ kind: SHOWN.RESULT, callId: part.toolCallId, output: output?.value });
+          break;
+        }
+        default:
+          throw new Error(`unexpected part ${String(part.type)}`);
+      }
+    }
+  }
+  return shown;
+}
+
+test("the same turn produces equivalent model input from both engines", async () => {
+  const responses = new ResponsesContextEngine(RUNTIME);
+  responses.bootstrap(undefined, LOST);
+  responses.ingest({ kind: CONTEXT_INPUT_KIND.USER_TEXT, text: TURN.ASK });
+  responses.ingest({
+    kind: CONTEXT_INPUT_KIND.MODEL_OUTPUT,
+    items: [reasoningItem(TURN.REASONING_BEFORE_CALL), functionCallItem()],
+  });
+  responses.ingest({
+    kind: CONTEXT_INPUT_KIND.TOOL_RESULT,
+    callId: TURN.CALL_ID,
+    outputJson: JSON.stringify(TURN.OUTPUT),
+  });
+  responses.ingest({
+    kind: CONTEXT_INPUT_KIND.MODEL_OUTPUT,
+    items: [reasoningItem(TURN.REASONING_BEFORE_REPLY), assistantMessageItem(TURN.REPLY)],
+  });
+  const { context, bootstrap } = await bootstrapped([ASK_ROW, REPLY_ROW]);
+  assert.deepEqual(bootstrap, { loaded: true, repaired: 0 });
+
+  const ephemeral = [TURN.EPHEMERAL];
+  const fromCheckpoint = shownByResponses(responses.assemble({ ephemeral }));
+  const fromRows = shownByModelMessages(await context.assemble({ ephemeral }));
+
+  assert.deepEqual(fromRows, fromCheckpoint);
+  assert.deepEqual(
+    fromRows.map((item) => item.kind),
+    [
+      SHOWN.USER,
+      SHOWN.REASONING,
+      SHOWN.CALL,
+      SHOWN.RESULT,
+      SHOWN.REASONING,
+      SHOWN.ASSISTANT,
+      SHOWN.USER,
+    ],
+  );
+  assert.deepEqual(fromRows[1], {
+    kind: SHOWN.REASONING,
+    itemId: TURN.REASONING_BEFORE_CALL.itemId,
+    encrypted: TURN.REASONING_BEFORE_CALL.encrypted,
+    summary: TURN.REASONING_BEFORE_CALL.summary,
+  });
+  assert.deepEqual(fromRows[3], { kind: SHOWN.RESULT, callId: TURN.CALL_ID, output: TURN.OUTPUT });
+  // The ephemeral text rides last and is kept by neither engine.
+  assert.equal(context.checkpoint().items.length, 2);
+  assert.equal(responses.checkpoint().items.length, 6);
+});
+
+function isAssistant(message: ModelMessage): message is AssistantModelMessage {
+  return message.role === MODEL_MESSAGE_ROLE.ASSISTANT;
+}
+
+function isTool(message: ModelMessage): message is ToolModelMessage {
+  return message.role === MODEL_MESSAGE_ROLE.TOOL;
+}
+
+function assistantParts(message: AssistantModelMessage) {
+  return Array.isArray(message.content)
+    ? message.content
+    : [{ type: MODEL_PART.TEXT, text: message.content }];
+}
+
+function resultParts(message: ToolModelMessage) {
+  return message.content.flatMap((part) => (part.type === MODEL_PART.TOOL_RESULT ? [part] : []));
+}
+
+/** The provider options a model part carries, on the parts that can carry any. */
+function optionsOf(part: ModelPart) {
+  return "providerOptions" in part ? part.providerOptions : undefined;
+}
+
+/** For every assistant message with calls, the call ids it makes and the result ids the next message answers. */
+function callsAndAnswers(messages: readonly ModelMessage[]) {
+  const pairs: { calls: string[]; answers: string[] | undefined }[] = [];
+  for (const [index, message] of messages.entries()) {
+    if (!isAssistant(message)) continue;
+    const calls = assistantParts(message).flatMap((part) =>
+      part.type === MODEL_PART.TOOL_CALL ? [part.toolCallId] : [],
+    );
+    if (calls.length === 0) continue;
+    const next = messages[index + 1];
+    pairs.push({
+      calls,
+      answers: next && isTool(next) ? resultParts(next).map((part) => part.toolCallId) : undefined,
+    });
+  }
+  return pairs;
+}
+
+/** What follows each reasoning part inside its own assistant message: the part type, or nothing at the end. */
+function followersOfReasoning(messages: readonly ModelMessage[]) {
+  const followers: (string | undefined)[] = [];
+  for (const message of messages) {
+    if (!isAssistant(message)) continue;
+    const parts = assistantParts(message);
+    for (const [index, part] of parts.entries()) {
+      if (part.type === MODEL_PART.REASONING) followers.push(parts[index + 1]?.type);
+    }
+  }
+  return followers;
+}
+
+function reasoningReplay(messages: readonly ModelMessage[]) {
+  return messages.flatMap((message) =>
+    isAssistant(message)
+      ? assistantParts(message).flatMap((part) =>
+          part.type === MODEL_PART.REASONING ? [part.providerOptions] : [],
+        )
+      : [],
+  );
+}
+
+test("a reasoning part is never split from its call, and a call is never parted from its result", async () => {
+  const messages = await modelInputFrom([ASK_ROW, REPLY_ROW], OPTIONS);
+  assert.deepEqual(callsAndAnswers(messages), [{ calls: [TURN.CALL_ID], answers: [TURN.CALL_ID] }]);
+  assert.deepEqual(followersOfReasoning(messages), [MODEL_PART.TOOL_CALL, MODEL_PART.TEXT]);
+  assert.deepEqual(reasoningReplay(messages), [
+    openAiReplay(TURN.REASONING_BEFORE_CALL),
+    openAiReplay(TURN.REASONING_BEFORE_REPLY),
+  ]);
+});
+
+test("a provider or model change drops every replay item whole and keeps the words, the call, and its result", async () => {
+  for (const replay of [
+    { provider: PROVIDER, model: "gpt-5.5" },
+    { provider: "anthropic", model: MODEL },
+  ]) {
+    const messages = await modelInputFrom([ASK_ROW, REPLY_ROW], { ...OPTIONS, replay });
+    assert.deepEqual(reasoningReplay(messages), [undefined, undefined]);
+    assert.deepEqual(followersOfReasoning(messages), [MODEL_PART.TOOL_CALL, MODEL_PART.TEXT]);
+    assert.deepEqual(callsAndAnswers(messages), [
+      { calls: [TURN.CALL_ID], answers: [TURN.CALL_ID] },
+    ]);
+    const summaries = messages.flatMap((message) =>
+      isAssistant(message)
+        ? assistantParts(message).flatMap((part) =>
+            part.type === MODEL_PART.REASONING ? [part.text] : [],
+          )
+        : [],
+    );
+    assert.deepEqual(summaries, [
+      TURN.REASONING_BEFORE_CALL.summary,
+      TURN.REASONING_BEFORE_REPLY.summary,
+    ]);
+  }
+});
+
+test("a row whose turn recorded no model proves nothing current, and replays nothing", async () => {
+  const unattributed = assistantRow(REPLY_ROW.message.id, replyParts());
+  const messages = await modelInputFrom([ASK_ROW, unattributed], OPTIONS);
+  assert.deepEqual(reasoningReplay(messages), [undefined, undefined]);
+});
+
+test("replay metadata travels whole when it may travel at all, on reasoning, text, and the call alike", async () => {
+  const twoProviders: ProviderMetadata = {
+    ...openAiReplay(TURN.REASONING_BEFORE_CALL),
+    other: { trace: "kept beside it" },
+  };
+  const callReplay: ProviderMetadata = { [PROVIDER]: { itemId: "fc_9a0b4c2d" } };
+  const textReplay: ProviderMetadata = { [PROVIDER]: { itemId: "msg_8e3f0a1b" } };
+  const parts: StoredPart[] = [
+    { type: "step-start" },
+    {
+      type: "reasoning",
+      text: TURN.REASONING_BEFORE_CALL.summary,
+      state: "done",
+      providerMetadata: twoProviders,
+    },
+    toolPart(TOOL_PART_STATE.OUTPUT_AVAILABLE, { callProviderMetadata: callReplay }),
+    { type: "step-start" },
+    { type: "text", text: TURN.REPLY, state: "done", providerMetadata: textReplay },
+  ];
+  const row = assistantRow("m2", parts, MODEL);
+  const replayed = await modelInputFrom([ASK_ROW, row], OPTIONS);
+  const partOptions = (messages: readonly ModelMessage[]) =>
+    messages.flatMap((message) =>
+      isAssistant(message)
+        ? assistantParts(message).map((part) => [part.type, optionsOf(part)])
+        : isTool(message)
+          ? resultParts(message).map((part) => [part.type, optionsOf(part)])
+          : [],
+    );
+  assert.deepEqual(partOptions(replayed), [
+    [MODEL_PART.REASONING, twoProviders],
+    [MODEL_PART.TOOL_CALL, callReplay],
+    [MODEL_PART.TOOL_RESULT, callReplay],
+    [MODEL_PART.TEXT, textReplay],
+  ]);
+  const dropped = await modelInputFrom([ASK_ROW, row], {
+    ...OPTIONS,
+    replay: { provider: PROVIDER, model: "gpt-5.5" },
+  });
+  assert.deepEqual(partOptions(dropped), [
+    [MODEL_PART.REASONING, undefined],
+    [MODEL_PART.TOOL_CALL, undefined],
+    [MODEL_PART.TOOL_RESULT, undefined],
+    [MODEL_PART.TEXT, undefined],
+  ]);
+});
+
+const SUMMARY =
+  "Earlier the developer asked about the fixture session twice; nothing was sent to it.";
+
+/** Nine rows: three exchanges, a compaction keeping the second's reply on, then one more exchange. */
+function compactedRows(firstKept = "m4"): ContextRow[] {
+  return [
+    userRow("m1", "one"),
+    assistantRow("m2", [{ type: "text", text: "first reply" }], MODEL),
+    userRow("m3", "two"),
+    assistantRow("m4", [{ type: "text", text: "second reply" }], MODEL),
+    userRow("m5", "three"),
+    assistantRow("m6", [{ type: "text", text: "third reply" }], MODEL),
+    compactionRow("m7", SUMMARY, firstKept),
+    userRow("m8", "four"),
+    assistantRow("m9", [{ type: "text", text: "fourth reply" }], MODEL),
+  ];
+}
+
+const ids = (rows: readonly ContextRow[]) => rows.map((row) => row.message.id);
+
+test("the derivation is the latest compaction first, then every row from the one it named as first kept", async () => {
+  assert.deepEqual(ids(rowsSinceCompaction(compactedRows())), ["m7", "m4", "m5", "m6", "m8", "m9"]);
+  assert.deepEqual(ids(rowsSinceCompaction(compactedRows("m8"))), ["m7", "m8", "m9"]);
+  assert.deepEqual(ids(rowsSinceCompaction(compactedRows("not-held"))), ["m7", "m8", "m9"]);
+  const uncompacted = compactedRows().filter((row) => row.message.id !== "m7");
+  assert.deepEqual(ids(rowsSinceCompaction(uncompacted)), ids(uncompacted));
+  const twice = [...compactedRows(), compactionRow("m10", SUMMARY, "m9"), userRow("m11", "five")];
+  assert.deepEqual(ids(rowsSinceCompaction(twice)), ["m10", "m9", "m11"]);
+
+  const messages = await modelInputFrom(compactedRows(), OPTIONS);
+  assert.equal(messages.length, 6);
+  const first = messages[0];
+  assert.ok(first && isAssistant(first));
+  assert.deepEqual(assistantParts(first), [{ type: MODEL_PART.TEXT, text: SUMMARY }]);
+});
+
+test("compact drops the rows the derivation no longer reads, and the record it keeps stays in that order", async () => {
+  const { context } = await bootstrapped(compactedRows());
+  assert.equal(context.compact(), 3);
+  assert.deepEqual(
+    context
+      .checkpoint()
+      .items.map((item) => (isRecord(item.message) ? item.message.id : undefined)),
+    ["m7", "m4", "m5", "m6", "m8", "m9"],
+  );
+  assert.equal(context.compact(), 0);
+});
+
+test("a call the record left unanswered is answered with the lost result, and the record is not rewritten", async () => {
+  for (const [state, extra] of [
+    [TOOL_PART_STATE.INPUT_AVAILABLE, {}],
+    [TOOL_PART_STATE.INPUT_STREAMING, {}],
+    [TOOL_PART_STATE.OUTPUT_AVAILABLE, { preliminary: true }],
+  ] as const) {
+    const row = assistantRow("m2", replyParts(state, extra), MODEL);
+    const { context, bootstrap } = await bootstrapped([ASK_ROW, row]);
+    assert.deepEqual(bootstrap, { loaded: true, repaired: 1 });
+    const messages = await modelInputFrom([ASK_ROW, row], OPTIONS);
+    assert.deepEqual(callsAndAnswers(messages), [
+      { calls: [TURN.CALL_ID], answers: [TURN.CALL_ID] },
+    ]);
+    const answered = messages.find(isTool);
+    assert.deepEqual(answered ? resultParts(answered).map((part) => part.output) : [], [
+      { type: "error-text", value: LOST },
+    ]);
+    const kept = context.checkpoint().items[1];
+    const parts = kept && isRecord(kept.message) ? kept.message.parts : undefined;
+    assert.ok(Array.isArray(parts));
+    const storedPart = parts[2];
+    assert.ok(isRecord(storedPart));
+    assert.equal(storedPart.state, state);
+  }
+});
+
+test("the stamp joins the runtime and the row format, and an empty checkpoint loads as nothing", async () => {
+  const context = engine();
+  assert.equal(checkpointFormatTag(context.checkpointFormat), "tool-loop@1:ai-ui-message/1");
+  assert.deepEqual(await context.bootstrap(undefined, LOST), { loaded: true, repaired: 0 });
+  assert.deepEqual(await context.assemble({ ephemeral: [] }), []);
+  assert.deepEqual(context.checkpoint().items, []);
+});
+
+test("a checkpoint of another stamp, or rows the vocabulary refuses, loads nothing and says why", async () => {
+  const context = engine();
+  const items = itemsOf([ASK_ROW, REPLY_ROW]);
+  for (const format of [
+    { ...context.checkpointFormat, runtime: "other-runtime" },
+    { ...context.checkpointFormat, formatVersion: 2 },
+  ]) {
+    const result = await context.bootstrap({ format, items }, LOST);
+    assert.equal(result.loaded, false);
+    assert.equal(result.repaired, 0);
+    assert.deepEqual(context.checkpoint().items, []);
+  }
+  const unregistered = assistantRow(
+    "m2",
+    [
+      {
+        type: "tool-someone_elses_tool",
+        toolCallId: "c",
+        state: "output-available",
+        input: {},
+        output: {},
+      },
+    ],
+    MODEL,
+  );
+  const refused = await context.bootstrap(checkpointOf(context, [ASK_ROW, unregistered]), LOST);
+  assert.equal(refused.loaded, false);
+  assert.deepEqual(context.checkpoint().items, []);
+});
+
+test("rows are read back field by field, and a refusal names the item and the field", async () => {
+  const read = await readContextRows(itemsOf([ASK_ROW, REPLY_ROW]), TOOLS);
+  assert.deepEqual(read, { ok: true, value: [ASK_ROW, REPLY_ROW] });
+  const refusals = await Promise.all([
+    readContextRows([{ model: MODEL }], TOOLS),
+    readContextRows([{ message: toWire(ASK_ROW.message), model: 3 }], TOOLS),
+    readContextRows([{ message: toWire(ASK_ROW.message), model: "" }], TOOLS),
+    readContextRows(
+      [
+        { message: toWire(ASK_ROW.message) },
+        { message: { ...toWire(REPLY_ROW.message), metadata: {} } },
+      ],
+      TOOLS,
+    ),
+  ]);
+  assert.deepEqual(refusals, [
+    { ok: false, refusal: SCHEMA_REFUSAL.MALFORMED, path: [0, "message"] },
+    { ok: false, refusal: SCHEMA_REFUSAL.MALFORMED, path: [0, "model"] },
+    { ok: false, refusal: SCHEMA_REFUSAL.MALFORMED, path: [0, "model"] },
+    { ok: false, refusal: SCHEMA_REFUSAL.MALFORMED, path: [1, "message", "metadata", "author"] },
+  ]);
+});
+
+test("the engine writes no row: the loop's inputs and a provider's window are refused, not dropped", async () => {
+  const { context } = await bootstrapped([ASK_ROW]);
+  const seam: ContextEngine = context;
+  assert.throws(() => seam.ingest({ kind: CONTEXT_INPUT_KIND.USER_TEXT, text: "late words" }), {
+    message: UI_MESSAGE_ENGINE_REFUSAL.INGEST,
+  });
+  assert.throws(() => seam.adoptCompaction([]), {
+    message: UI_MESSAGE_ENGINE_REFUSAL.ADOPT_COMPACTION,
+  });
+  assert.equal(seam.foldBehindSummary, undefined);
+  assert.equal(context.checkpoint().items.length, 1);
+});
+
+test("a mark rolls the rows back, a foreign mark is refused, and dispose empties them", async () => {
+  const { context } = await bootstrapped(compactedRows());
+  const mark = context.mark();
+  assert.equal(context.compact(), 3);
+  context.rollback(mark);
+  assert.equal(context.checkpoint().items.length, 9);
+  assert.throws(() => context.rollback({ items: [...mark.items] }), {
+    message: UI_MESSAGE_ENGINE_REFUSAL.FOREIGN_MARK,
+  });
+  context.dispose();
+  assert.deepEqual(context.checkpoint().items, []);
+});

--- a/packages/brain/src/ui-message-context.ts
+++ b/packages/brain/src/ui-message-context.ts
@@ -1,0 +1,416 @@
+import { UI_MESSAGE_ITEM_FORMAT } from "@sidecar/runtime";
+import {
+  type CheckpointFormat,
+  type ContextAssembly,
+  type ContextBootstrap,
+  type ContextEngine,
+  type ContextMark,
+  checkpointFormatTag,
+  type RuntimeCheckpoint,
+  sameCheckpointFormat,
+} from "@sidecar/runtime/vocabulary";
+import { type CompactionMetadata, MESSAGE_ROLE, TOOL_PART_STATE } from "@sidecar/session";
+import {
+  isStoredToolPart,
+  readStoredUIMessages,
+  type StoredToolPart,
+  type StoredUIMessage,
+} from "@sidecar/session/ui-messages";
+import {
+  isWireString,
+  SCHEMA_REFUSAL,
+  type SchemaPath,
+  type SchemaRead,
+  type SchemaRefusal,
+  type UnparsedWireValue,
+  type WireRecord,
+  wireRecord,
+} from "@sidecar/wire";
+import {
+  convertToModelMessages,
+  isReasoningUIPart,
+  isTextUIPart,
+  type ModelMessage,
+  type ProviderMetadata,
+  type ToolSet,
+  type UIDataTypes,
+  type UIMessagePart,
+  type UITools,
+} from "ai";
+
+/**
+ * The model's input derived from the conversation's stored rows. Under the
+ * storage plan a conversation is its `UIMessage` rows and nothing else: there
+ * is no checkpoint beside them, a compaction is an assistant message whose
+ * metadata names the first row it kept, and the input one inference is shown
+ * is the AI SDK's `convertToModelMessages` over the rows from the latest
+ * compaction on. The same derivation seeds a fresh runtime session from the
+ * record and decides what is shown and counted, so it is a pure function
+ * here and the engine below is one caller of it.
+ *
+ * Two rules stand between the rows and the model. Provider metadata a part
+ * carries for replay — a reasoning part's opaque item above all, and the item
+ * ids on a text or a tool call — is replayed whole when it names the
+ * provider this inference runs on and the row's turn ran on its model, and
+ * dropped whole otherwise, the summary and the call staying as the record's
+ * words; a provider or model change therefore drops every opaque item cleanly
+ * rather than handing the model half of one. And a call the record left
+ * unanswered — a writer that died between the call and its result — is
+ * answered with the lost-result record before conversion, so the model is
+ * never handed a dangling call and never replays the action. The SDK keeps
+ * reasoning beside the calls it preceded and each call beside its result by
+ * construction: an assistant row's parts convert in order, split at each
+ * `step-start` into one assistant message followed by the tool message that
+ * answers its calls.
+ */
+
+/**
+ * One row as the derivation reads it: the stored message, and the model its
+ * turn ran on when the turn recorded one (`turns.model`, joined by the row's
+ * turn). Without the model, no replay metadata on the row can be proven
+ * current, and none is replayed.
+ */
+export interface ContextRow {
+  readonly message: StoredUIMessage;
+  readonly model?: string;
+}
+
+/** The inference the derived input is bound for: whose provider metadata may replay, on which model. */
+export interface ReplayTarget {
+  readonly provider: string;
+  readonly model: string;
+}
+
+export interface ModelInputOptions {
+  /** The registered tools, by the name a part spells; the SDK renders each result under its tool's declaration. */
+  readonly tools: ToolSet;
+  readonly replay: ReplayTarget;
+  /** What a call the record left unanswered is answered with. */
+  readonly lostResultJson: string;
+}
+
+function compactionOf(row: ContextRow): CompactionMetadata | undefined {
+  return row.message.role === MESSAGE_ROLE.ASSISTANT ? row.message.metadata.compaction : undefined;
+}
+
+/**
+ * The rows the model still reads. The latest compaction message stands in
+ * for every row before the one it named as first kept, so the derivation is
+ * that message first, then every row from the first kept one on, in the
+ * order they were written. A marker naming a row the set does not hold keeps
+ * what follows the compaction; no compaction keeps everything.
+ */
+export function rowsSinceCompaction(rows: readonly ContextRow[]): readonly ContextRow[] {
+  const at = rows.findLastIndex((row) => compactionOf(row) !== undefined);
+  const compaction = rows[at];
+  if (at < 0 || compaction === undefined) return rows;
+  const firstKeptId = compactionOf(compaction)?.first_kept_message_id;
+  const firstKept = rows.findIndex((row) => row.message.id === firstKeptId);
+  const kept =
+    firstKept < 0 ? rows.slice(at + 1) : rows.slice(firstKept).filter((row) => row !== compaction);
+  return [compaction, ...kept];
+}
+
+/** Whether metadata a part carries for replay may travel: it names this inference's provider, and the row's turn ran on its model. */
+function replayable(
+  metadata: ProviderMetadata | undefined,
+  row: ContextRow,
+  replay: ReplayTarget,
+): boolean {
+  return (
+    metadata !== undefined && Object.hasOwn(metadata, replay.provider) && row.model === replay.model
+  );
+}
+
+type StoredPart = UIMessagePart<UIDataTypes, UITools>;
+
+type SettledToolPart = Extract<
+  StoredToolPart,
+  { state: typeof TOOL_PART_STATE.OUTPUT_AVAILABLE | typeof TOOL_PART_STATE.OUTPUT_ERROR }
+>;
+
+/** Whether the record holds the call's answer: an unanswered call, or an answer still preliminary, is one the writer never finished. */
+function isSettled(part: StoredToolPart): part is SettledToolPart {
+  switch (part.state) {
+    case TOOL_PART_STATE.OUTPUT_ERROR:
+      return true;
+    case TOOL_PART_STATE.OUTPUT_AVAILABLE:
+      return part.preliminary !== true;
+    case TOOL_PART_STATE.INPUT_STREAMING:
+    case TOOL_PART_STATE.INPUT_AVAILABLE:
+      return false;
+  }
+}
+
+/** The tool part as the model reads it: settled, and carrying its replay metadata whole or not at all. */
+function preparedToolPart(
+  part: StoredToolPart,
+  row: ContextRow,
+  options: ModelInputOptions,
+): SettledToolPart {
+  const replayed = replayable(part.callProviderMetadata, row, options.replay);
+  const call = {
+    type: part.type,
+    toolCallId: part.toolCallId,
+    input: part.input,
+    ...(part.providerExecuted !== undefined
+      ? { providerExecuted: part.providerExecuted }
+      : undefined),
+    ...(replayed && part.callProviderMetadata !== undefined
+      ? { callProviderMetadata: part.callProviderMetadata }
+      : undefined),
+  };
+  if (!isSettled(part)) {
+    return { ...call, state: TOOL_PART_STATE.OUTPUT_ERROR, errorText: options.lostResultJson };
+  }
+  const result =
+    replayed && part.resultProviderMetadata !== undefined
+      ? { resultProviderMetadata: part.resultProviderMetadata }
+      : undefined;
+  return part.state === TOOL_PART_STATE.OUTPUT_ERROR
+    ? { ...call, state: part.state, errorText: part.errorText, ...result }
+    : { ...call, state: part.state, output: part.output, ...result };
+}
+
+function preparedPart(part: StoredPart, row: ContextRow, options: ModelInputOptions): StoredPart {
+  if (isReasoningUIPart(part) || isTextUIPart(part)) {
+    if (
+      part.providerMetadata === undefined ||
+      replayable(part.providerMetadata, row, options.replay)
+    ) {
+      return part;
+    }
+    const { providerMetadata: _dropped, ...words } = part;
+    return words;
+  }
+  return isStoredToolPart(part) ? preparedToolPart(part, row, options) : part;
+}
+
+function preparedMessage(row: ContextRow, options: ModelInputOptions): StoredUIMessage {
+  if (row.message.role !== MESSAGE_ROLE.ASSISTANT) return row.message;
+  return {
+    ...row.message,
+    parts: row.message.parts.map((part) => preparedPart(part, row, options)),
+  };
+}
+
+/** How many calls the rows leave unanswered, each of which the derivation answers with the lost result. */
+function unansweredCalls(rows: readonly ContextRow[]): number {
+  let count = 0;
+  for (const row of rows) {
+    for (const part of row.message.parts) {
+      if (isStoredToolPart(part) && !isSettled(part)) count += 1;
+    }
+  }
+  return count;
+}
+
+/**
+ * The input one inference is shown, derived from the rows: the SDK's model
+ * messages over the rows since the latest compaction, each prepared under
+ * the two rules above.
+ */
+export function modelInputFrom(
+  rows: readonly ContextRow[],
+  options: ModelInputOptions,
+): Promise<ModelMessage[]> {
+  const messages = rowsSinceCompaction(rows).map((row) => preparedMessage(row, options));
+  return convertToModelMessages(messages, { tools: options.tools });
+}
+
+/** The two fields a row travels under between the store and the engine. */
+const ROW_FIELD = { MESSAGE: "message", MODEL: "model" } as const;
+
+function refuse(refusal: SchemaRefusal, path: SchemaPath): SchemaRead<never> {
+  return { ok: false, refusal, path };
+}
+
+/**
+ * Reads rows back from their wire form: each item's message through the
+ * session package's reader, which holds it to the vocabulary and to the
+ * registered tools, and its model as a non-empty string when it carries one.
+ * The refusal names the item and the field, so a store can tell a malformed
+ * row from one naming a tool this build no longer registers.
+ */
+export async function readContextRows(
+  items: readonly WireRecord[],
+  tools: ToolSet,
+): Promise<SchemaRead<ContextRow[]>> {
+  const messages: WireRecord[] = [];
+  const models: (string | undefined)[] = [];
+  for (const [index, item] of items.entries()) {
+    const message = wireRecord(item[ROW_FIELD.MESSAGE]);
+    if (message === undefined) return refuse(SCHEMA_REFUSAL.MALFORMED, [index, ROW_FIELD.MESSAGE]);
+    const model = item[ROW_FIELD.MODEL];
+    if (model !== undefined && !(isWireString(model) && model.length > 0)) {
+      return refuse(SCHEMA_REFUSAL.MALFORMED, [index, ROW_FIELD.MODEL]);
+    }
+    messages.push(message);
+    models.push(model);
+  }
+  const read = await readStoredUIMessages(messages, tools);
+  if (!read.ok) {
+    const [index, ...rest] = read.path;
+    return refuse(read.refusal, index === undefined ? [] : [index, ROW_FIELD.MESSAGE, ...rest]);
+  }
+  return {
+    ok: true,
+    value: read.value.map((message, index) => {
+      const model = models[index];
+      return model === undefined ? { message } : { message, model };
+    }),
+  };
+}
+
+function toWireRecord(value: StoredUIMessage | ModelMessage): WireRecord {
+  // SAFETY: a stored message is what the store holds as JSON and a model message is what a provider
+  // carries as JSON, so a JSON round trip answers the wire shape of either.
+  const record = wireRecord(JSON.parse(JSON.stringify(value)) as UnparsedWireValue);
+  if (record === undefined) throw new Error("a message serializes as a record");
+  return record;
+}
+
+function rowToWire(row: ContextRow): WireRecord {
+  return {
+    [ROW_FIELD.MESSAGE]: toWireRecord(row.message),
+    ...(row.model !== undefined ? { [ROW_FIELD.MODEL]: row.model } : undefined),
+  };
+}
+
+/** What the engine refuses, because it reads rows and writes none. */
+export const UI_MESSAGE_ENGINE_REFUSAL = {
+  INGEST:
+    "the UIMessage engine reads stored rows and writes none: a turn's inputs reach it as rows through bootstrap, never through ingest",
+  ADOPT_COMPACTION:
+    "the UIMessage engine takes no provider compaction window: a compaction is a message the store writes, and the derivation reads it",
+  FOREIGN_MARK: "the UIMessage engine rolls back only to a mark it took itself",
+} as const;
+
+export interface UIMessageContextEngineOptions {
+  /** The runtime the engine's stamp names, as the Responses engine is stamped. */
+  readonly runtime: { readonly id: string; readonly version: number };
+  readonly tools: ToolSet;
+  readonly replay: ReplayTarget;
+}
+
+/**
+ * The context engine over stored UIMessages: `@sidecar/runtime`'s
+ * `BUILTIN_CONTEXT_ENGINE.UI_MESSAGES`. Its retained items are the
+ * conversation's rows, each the message and the model its turn ran on, and
+ * its assembly is `modelInputFrom` over them. It writes no row: the rows a
+ * turn produces are the store writer's, from the run's event stream, so the
+ * loop's `ingest` and a provider's compaction window are refused rather than
+ * silently dropped, and rows enter at bootstrap alone. Its checkpoint is the
+ * rows themselves, handed back as they came, because on this path there is
+ * nothing else to persist; a host over this engine keeps rows, not a
+ * checkpoint. It is behind `@sidecar/brain/ui-message-context` rather than
+ * the barrel because it reaches the AI SDK at run time, which a bundle that
+ * only names the engine's id must not resolve.
+ */
+export class UIMessageContextEngine implements ContextEngine {
+  readonly checkpointFormat: CheckpointFormat;
+  readonly #options: UIMessageContextEngineOptions;
+  #rows: readonly ContextRow[] = [];
+  #lostResultJson: string | undefined;
+  readonly #marks = new WeakMap<readonly WireRecord[], readonly ContextRow[]>();
+
+  constructor(options: UIMessageContextEngineOptions) {
+    this.#options = options;
+    this.checkpointFormat = {
+      runtime: options.runtime.id,
+      runtimeVersion: options.runtime.version,
+      format: UI_MESSAGE_ITEM_FORMAT.format,
+      formatVersion: UI_MESSAGE_ITEM_FORMAT.version,
+    };
+  }
+
+  /**
+   * An empty checkpoint loads as nothing. A compatible one loads its rows
+   * through the vocabulary's reader and counts the calls the derivation will
+   * answer with the lost result; the rows themselves are kept as they came,
+   * because the record is not repaired by being read. A checkpoint of
+   * another stamp, or rows the reader refuses, loads nothing and says why.
+   */
+  async bootstrap(
+    checkpoint: RuntimeCheckpoint | undefined,
+    lostResultJson: string,
+  ): Promise<ContextBootstrap> {
+    this.#lostResultJson = lostResultJson;
+    this.#rows = [];
+    if (!checkpoint) return { loaded: true, repaired: 0 };
+    if (!sameCheckpointFormat(checkpoint.format, this.checkpointFormat)) {
+      return {
+        loaded: false,
+        reason: `checkpoint ${checkpointFormatTag(checkpoint.format)} is not readable by ${checkpointFormatTag(this.checkpointFormat)}`,
+        repaired: 0,
+      };
+    }
+    const read = await readContextRows(checkpoint.items, this.#options.tools);
+    if (!read.ok) {
+      return {
+        loaded: false,
+        reason: `rows refused: ${read.refusal} at ${read.path.join(".")}`,
+        repaired: 0,
+      };
+    }
+    this.#rows = read.value;
+    return { loaded: true, repaired: unansweredCalls(read.value) };
+  }
+
+  ingest(): void {
+    throw new Error(UI_MESSAGE_ENGINE_REFUSAL.INGEST);
+  }
+
+  /** The derived input, then the ephemeral text as user messages, so the derived prefix stays cacheable. */
+  async assemble(assembly: ContextAssembly): Promise<readonly WireRecord[]> {
+    const lostResultJson = this.#lostResultJson;
+    // Rows arrive only at bootstrap, where the lost result does too; before it there is nothing to derive.
+    const derived: readonly ModelMessage[] =
+      lostResultJson === undefined
+        ? []
+        : await modelInputFrom(this.#rows, {
+            tools: this.#options.tools,
+            replay: this.#options.replay,
+            lostResultJson,
+          });
+    const ephemeral: readonly ModelMessage[] = assembly.ephemeral.map((content) => ({
+      role: MESSAGE_ROLE.USER,
+      content,
+    }));
+    return [...derived, ...ephemeral].map(toWireRecord);
+  }
+
+  /** Drops the rows the derivation no longer reads; answers how many went. */
+  compact(): number {
+    const kept = rowsSinceCompaction(this.#rows);
+    const dropped = this.#rows.length - kept.length;
+    this.#rows = kept;
+    return dropped;
+  }
+
+  adoptCompaction(): void {
+    throw new Error(UI_MESSAGE_ENGINE_REFUSAL.ADOPT_COMPACTION);
+  }
+
+  afterTurn(): void {}
+
+  mark(): ContextMark {
+    const items = this.#rows.map(rowToWire);
+    this.#marks.set(items, this.#rows);
+    return { items };
+  }
+
+  rollback(mark: ContextMark): void {
+    const rows = this.#marks.get(mark.items);
+    if (rows === undefined) throw new Error(UI_MESSAGE_ENGINE_REFUSAL.FOREIGN_MARK);
+    this.#rows = rows;
+  }
+
+  checkpoint(): RuntimeCheckpoint {
+    return { format: this.checkpointFormat, items: this.#rows.map(rowToWire) };
+  }
+
+  dispose(): void {
+    this.#rows = [];
+  }
+}

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -108,6 +108,7 @@ export {
   type ToolEffect,
   type ToolExecution,
   type ToolPlacement,
+  UI_MESSAGE_ITEM_FORMAT,
 } from "./registry.js";
 export {
   discoverSkills,

--- a/packages/runtime/src/registry.test.ts
+++ b/packages/runtime/src/registry.test.ts
@@ -15,8 +15,10 @@ import {
   defaultAgentConfiguration,
   MEMORY_CAPABILITY,
   notebookMemoryProviderFor,
+  RESPONSES_ITEM_FORMAT,
   resolveConfiguration,
   TOOL_LOOP_RUNTIME,
+  UI_MESSAGE_ITEM_FORMAT,
 } from "./registry.js";
 
 function configuration(overrides: Partial<Parameters<typeof defaultAgentConfiguration>[0]> = {}) {
@@ -55,6 +57,23 @@ test("the notebook index stands as a memory provider per embedding adapter, one 
     notebookMemoryProviderFor(CREDENTIAL_REFERENCE_KIND.HOSTED_ACCOUNT),
     BUILTIN_MEMORY_PROVIDER.HOSTED,
   );
+});
+
+test("both context engines stand in the table, each under its own item format, and either resolves", () => {
+  assert.deepEqual(
+    Object.entries(BUILTINS.contextEngines).map(([id, engine]) => [id, engine.itemFormat]),
+    [
+      [BUILTIN_CONTEXT_ENGINE.RESPONSES, RESPONSES_ITEM_FORMAT],
+      [BUILTIN_CONTEXT_ENGINE.UI_MESSAGES, UI_MESSAGE_ITEM_FORMAT],
+    ],
+  );
+  assert.notDeepEqual(RESPONSES_ITEM_FORMAT, UI_MESSAGE_ITEM_FORMAT);
+  for (const contextEngineId of Object.values(BUILTIN_CONTEXT_ENGINE)) {
+    assert.equal(
+      resolveConfiguration(configuration({ contextEngineId })).outcome,
+      CONFIGURATION_OUTCOME.RESOLVED,
+    );
+  }
 });
 
 /** The refusal an outcome carries, or nothing when it resolved. */

--- a/packages/runtime/src/registry.ts
+++ b/packages/runtime/src/registry.ts
@@ -23,17 +23,37 @@ export interface ItemFormatIdentity {
   readonly version: number;
 }
 
-/** The item format every built-in of this build speaks: the Responses input array, first shape. */
+/** The item format the tool loop's adapters speak: the Responses input array, first shape. */
 export const RESPONSES_ITEM_FORMAT = {
   format: "openai-responses-input",
+  version: 1,
+} as const satisfies ItemFormatIdentity;
+
+/**
+ * The item format the UIMessage engine persists: the conversation's stored
+ * rows, each the AI SDK `UIMessage` a store holds and the model its turn ran
+ * on. There is no checkpoint on this path — the rows are the record, and the
+ * model's input is derived from them each turn — so the format names what
+ * the engine reads, not a second copy it keeps.
+ */
+export const UI_MESSAGE_ITEM_FORMAT = {
+  format: "ai-ui-message",
   version: 1,
 } as const satisfies ItemFormatIdentity;
 
 /** The tool-loop runtime's identity, as a checkpoint is stamped with it. */
 export const TOOL_LOOP_RUNTIME = { ID: "tool-loop", VERSION: 1 } as const;
 
-/** The one context engine this build compiles in: the Responses input array. */
-export const BUILTIN_CONTEXT_ENGINE = { RESPONSES: "openai-responses" } as const;
+/**
+ * The two context engines this build compiles in: the Responses input array
+ * the tool loop's checkpoint is written in, and the derivation over stored
+ * UIMessages that replaces it once the host is swapped. Both stand so a
+ * configuration can name either while the swap is under way.
+ */
+export const BUILTIN_CONTEXT_ENGINE = {
+  RESPONSES: "openai-responses",
+  UI_MESSAGES: "ai-ui-messages",
+} as const;
 
 /** The two model adapters: the developer's own OpenAI key, and Luke's hosted service. */
 export const BUILTIN_MODEL_ADAPTER = {
@@ -151,9 +171,14 @@ interface BuiltinMemoryProvider {
   readonly embeddingAdapterId: string;
 }
 
+interface BuiltinContextEngine {
+  /** The item format the engine reads and, where it keeps one, checkpoints in. */
+  readonly itemFormat: ItemFormatIdentity;
+}
+
 interface Builtins {
   readonly agentRuntimeIds: readonly string[];
-  readonly contextEngineIds: readonly string[];
+  readonly contextEngines: Readonly<Record<string, BuiltinContextEngine>>;
   readonly modelAdapters: Readonly<Record<string, BuiltinModelAdapter>>;
   readonly memoryProviders: Readonly<Record<string, BuiltinMemoryProvider>>;
 }
@@ -177,7 +202,10 @@ const NOTEBOOK_MEMORY_CAPABILITIES = [
  */
 export const BUILTINS = {
   agentRuntimeIds: [TOOL_LOOP_RUNTIME.ID],
-  contextEngineIds: [BUILTIN_CONTEXT_ENGINE.RESPONSES],
+  contextEngines: {
+    [BUILTIN_CONTEXT_ENGINE.RESPONSES]: { itemFormat: RESPONSES_ITEM_FORMAT },
+    [BUILTIN_CONTEXT_ENGINE.UI_MESSAGES]: { itemFormat: UI_MESSAGE_ITEM_FORMAT },
+  },
   modelAdapters: {
     [BUILTIN_MODEL_ADAPTER.OPENAI]: {
       credentialKind: CREDENTIAL_REFERENCE_KIND.PROVIDER_KEY,
@@ -199,7 +227,7 @@ export const BUILTINS = {
 } as const satisfies Builtins;
 
 export type BuiltinAgentRuntimeId = (typeof BUILTINS.agentRuntimeIds)[number];
-export type BuiltinContextEngineId = (typeof BUILTINS.contextEngineIds)[number];
+export type BuiltinContextEngineId = keyof typeof BUILTINS.contextEngines;
 export type BuiltinModelAdapterId = keyof typeof BUILTINS.modelAdapters;
 export type BuiltinMemoryProviderId = keyof typeof BUILTINS.memoryProviders;
 
@@ -283,7 +311,7 @@ export function resolveConfiguration(names: AgentConfiguration): ConfigurationOu
   const adapter = table.modelAdapters[names.modelAdapterId];
   if (
     !table.agentRuntimeIds.includes(names.agentRuntimeId) ||
-    !table.contextEngineIds.includes(names.contextEngineId) ||
+    !table.contextEngines[names.contextEngineId] ||
     !adapter ||
     (names.memoryProviderId !== undefined && !table.memoryProviders[names.memoryProviderId])
   ) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -355,6 +355,9 @@ importers:
       '@sidecar/wire':
         specifier: workspace:*
         version: link:../wire
+      ai:
+        specifier: 7.0.97
+        version: 7.0.97(zod@4.5.4)
     devDependencies:
       '@types/node':
         specifier: 26.2.0
@@ -365,6 +368,9 @@ importers:
       typescript:
         specifier: 7.0.2
         version: 7.0.2
+      zod:
+        specifier: 4.5.4
+        version: 4.5.4
 
   packages/calendar:
     dependencies:


### PR DESCRIPTION
## What

The context engine the storage plan replaces the checkpoint engine with: a derivation over the conversation's stored `UIMessage` rows, built with the AI SDK's `convertToModelMessages` (used as it ships, `ai@7.0.97`) over the rows since the latest compaction message. No checkpoint table is read on this path; the rows are the record.

- `packages/brain/src/ui-message-context.ts`, behind a new `@sidecar/brain/ui-message-context` door (it reaches the AI SDK at run time, for the same reason A1 gave `@sidecar/session/ui-messages` its own door):
  - `rowsSinceCompaction(rows)`: the latest compaction message (found by A1's `metadata.compaction`) first, then every row from its `first_kept_message_id` on, in written order. A marker the set does not hold keeps what follows the compaction; no compaction keeps everything.
  - `modelInputFrom(rows, { tools, replay, lostResultJson })`: the SDK's model messages over those rows. This one function is the rotation seed C1 builds an eve `session.started` instruction from and the derivation the view and the count read.
  - `UIMessageContextEngine implements ContextEngine`, stamped `tool-loop@1:ai-ui-message/1`. Rows enter at `bootstrap` (read through `readStoredUIMessages`), `assemble` derives, `compact` drops the rows the derivation no longer reads, `checkpoint` hands the rows back as they came. It writes no row: `ingest` and `adoptCompaction` are refused with a named reason rather than silently dropped, because the rows a turn produces are the store writer's and a live turn's context under eve is eve's. `foldBehindSummary` is left undefined.
- `packages/runtime/src/registry.ts`: `BUILTINS.contextEngines` now names both engines, each under its own item format (`RESPONSES_ITEM_FORMAT`, new `UI_MESSAGE_ITEM_FORMAT`), and `resolveConfiguration` accepts either id. The Responses engine and `toolLoopRuntimeOver` are untouched; the configuration's `contextEngineId` is the flag, and the host still names `RESPONSES` until C1 swaps it. Both paths run at this commit.

## Reasoning replay

Provider metadata a part carries for replay — a reasoning part's opaque item above all, and the item ids on a text or a tool call — travels **whole** when it names the inference's provider and the row's turn ran on its model, and is **dropped whole** otherwise; the summary text and the call stay as the record's words. A provider or model change therefore drops every opaque item cleanly, never half of one. The SDK keeps a reasoning part beside the call it preceded and each call beside its result by construction (an assistant row's parts convert in order, split at each `step-start` into one assistant message and the tool message answering its calls), and the tests assert that structurally. A call the record left unanswered (`input-available`, `input-streaming`, or a `preliminary` output) is answered with the lost-result record before conversion, so the model is never handed a dangling call; the stored row is not rewritten.

The row's model comes from `turns.model` joined by the row's `turn_id`, so the engine's row shape is `{ message, model? }` (`ContextRow`); a row with no model proves nothing current and replays nothing.

## Acceptance

`ui-message-context.test.ts` drives one turn (ask, reasoning, `read_transcript` call, result, reasoning, reply, plus ephemeral standing context) through the Responses checkpoint engine as `ContextInput`s and through the new engine as rows, normalizes both outputs into one item vocabulary, and asserts `deepEqual`. Further tests cover: reasoning never split from its call and a call never parted from its result; model change, provider change, and a model-less row dropping replay metadata whole on reasoning, text, and tool-call parts alike while keeping words and calls; the compaction cut, including two compactions and an unheld marker; the lost-result answer for each unsettled state; stamp refusal; refused rows naming the item and field; the refused `ingest`/`adoptCompaction`; mark/rollback/dispose.

## CLAUDE.md sentences this contradicts (for G5)

- "What persists is the array from the latest compaction onward, stamped with the runtime that wrote it and this item format, and an engine loads only a checkpoint stamped exactly the same" and "A checkpoint is stamped with the runtime that wrote it, its version, and the provider item format (`tool-loop@1:openai-responses-input/1` today) … a runtime loads only its own stamp": on the new path there is no checkpoint; the rows are the record and the stamp names a row format.
- "Compaction has exactly one owner, the host's `compaction.ts`": on the new path a compaction is a message the store writes (A6) and the derivation reads.
- "It is the one place the brain reads a provider item's type" (of the Responses engine) still holds: the new engine reads no provider item.

## A1's two traps

1. Rows are read only through `readStoredUIMessages` (the registry pre-check included); the SDK's `validateUIMessages` is never called directly.
2. No new cast: `convertToModelMessages`'s `tools` option is typed `ToolSet`, so the `vercel/ai#9147` cast stays where A1 put it. Pins unchanged (`ai@7.0.97`; `zod@4.5.4` as a brain devDependency for the test's `tool()` declaration).

## Reviews run

- **Thermonuclear code quality review** (Cursor's `cursor/plugins` → `cursor-team-kit/skills/thermo-nuclear-code-quality-review/SKILL.md`, applied as written): renamed `ReasoningReplay` → `ReplayTarget`, since the rule governs the replay metadata on text and tool-call parts too and the old name claimed less than the code did; replaced `object` / `Record<string, unknown>` parameters and a `typeof` narrowing with named types (also caught by the repo's `anti-slop` oxlint rules); kept `mark`/`rollback` over a `WeakMap` deliberately, because the seam's rollback is synchronous by contract and re-reading rows is async.
- **Ponytail review** (`DietrichGebert/ponytail`, `ponytail-review` skill as written): `yagni` — `unansweredCalls` exported with one caller, now module-private and covered through `bootstrap().repaired`. Otherwise lean.

## Discovered for later PRs

- **B5 (writer):** the SDK splits an assistant row at `step-start`. A writer that omits the boundary between steps puts a call's result after the text of the following step in the model input. Write a `step-start` before each step's parts (as `toUIMessageStream` does).
- **C1:** the engine is fed rows through `bootstrap` (as `{ message, model }` items) and refuses `ingest`; the tool loop cannot run over it, which is the intended shape under eve. The replay target is `{ provider: "openai", model }` from the turn's model.

## Verify

`./scripts/check.sh` passes end to end (lint, knip, typecheck, every package's tests, build; exit 0). One earlier run tripped on `apps/desktop`'s `media-duck.test.ts`, a timing flake in a file this PR does not touch, which passes alone and in the rerun. No macOS or UI code is touched, so `./scripts/verify.sh` does not apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34534526523/artifacts/10174954007) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34534526523)

- Commit: `f1a808cf19906c20a90421adf325e13a0d40408e`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
