### PR TITLE
fix(LUKE-117): keep retained rows in written order across a compaction cut

### DIFF
--- a/packages/brain/src/ui-message-context.test.ts
+++ b/packages/brain/src/ui-message-context.test.ts
@@ -44,6 +44,7 @@ import {
   modelInputFrom,
   type ReplayTarget,
   readContextRows,
+  retainedRows,
   rowsSinceCompaction,
   UI_MESSAGE_ENGINE_REFUSAL,
   UIMessageContextEngine,
@@ -603,6 +604,14 @@ test("the derivation is the latest compaction first, then every row from the one
   assert.deepEqual(ids(rowsSinceCompaction(uncompacted)), ids(uncompacted));
   const twice = [...compactedRows(), compactionRow("m10", SUMMARY, "m9"), userRow("m11", "five")];
   assert.deepEqual(ids(rowsSinceCompaction(twice)), ["m10", "m9", "m11"]);
+  // A later compaction may keep an earlier one in its tail; the later one still cuts.
+  const nested = [...compactedRows(), compactionRow("m10", SUMMARY, "m6"), userRow("m11", "five")];
+  assert.deepEqual(ids(rowsSinceCompaction(nested)), ["m10", "m6", "m7", "m8", "m9", "m11"]);
+  assert.deepEqual(ids(retainedRows(nested)), ["m6", "m7", "m8", "m9", "m10", "m11"]);
+  assert.deepEqual(
+    ids(rowsSinceCompaction(retainedRows(nested))),
+    ids(rowsSinceCompaction(nested)),
+  );
 
   const messages = await modelInputFrom(compactedRows(), OPTIONS);
   assert.equal(messages.length, 6);
@@ -611,15 +620,16 @@ test("the derivation is the latest compaction first, then every row from the one
   assert.deepEqual(assistantParts(first), [{ type: MODEL_PART.TEXT, text: SUMMARY }]);
 });
 
-test("compact drops the rows the derivation no longer reads, and the record it keeps stays in that order", async () => {
-  const { context } = await bootstrapped(compactedRows());
-  assert.equal(context.compact(), 3);
-  assert.deepEqual(
-    context
-      .checkpoint()
-      .items.map((item) => (isRecord(item.message) ? item.message.id : undefined)),
-    ["m7", "m4", "m5", "m6", "m8", "m9"],
-  );
+test("compact drops the rows the derivation no longer reads, keeps the rest in written order, and cuts the same way again", async () => {
+  const rows = [...compactedRows(), compactionRow("m10", SUMMARY, "m6"), userRow("m11", "five")];
+  const { context } = await bootstrapped(rows);
+  const before = shownByModelMessages(await context.assemble({ ephemeral: [] }));
+  assert.equal(context.compact(), 5);
+  const retained = context
+    .checkpoint()
+    .items.map((item) => (isRecord(item.message) ? item.message.id : undefined));
+  assert.deepEqual(retained, ["m6", "m7", "m8", "m9", "m10", "m11"]);
+  assert.deepEqual(shownByModelMessages(await context.assemble({ ephemeral: [] })), before);
   assert.equal(context.compact(), 0);
 });
 

--- a/packages/brain/src/ui-message-context.ts
+++ b/packages/brain/src/ui-message-context.ts
@@ -93,22 +93,50 @@ function compactionOf(row: ContextRow): CompactionMetadata | undefined {
   return row.message.role === MESSAGE_ROLE.ASSISTANT ? row.message.metadata.compaction : undefined;
 }
 
-/**
- * The rows the model still reads. The latest compaction message stands in
- * for every row before the one it named as first kept, so the derivation is
- * that message first, then every row from the first kept one on, in the
- * order they were written. A marker naming a row the set does not hold keeps
- * what follows the compaction; no compaction keeps everything.
- */
-export function rowsSinceCompaction(rows: readonly ContextRow[]): readonly ContextRow[] {
+interface CompactionCut {
+  readonly compaction: ContextRow;
+  /** The compaction row's index. */
+  readonly at: number;
+  /** Where the kept tail begins: the row the compaction named as first kept, or the row after the compaction when the set does not hold it. */
+  readonly from: number;
+}
+
+/** Where the latest compaction, by written order, cuts the rows; nothing when no row is one. */
+function compactionCut(rows: readonly ContextRow[]): CompactionCut | undefined {
   const at = rows.findLastIndex((row) => compactionOf(row) !== undefined);
   const compaction = rows[at];
-  if (at < 0 || compaction === undefined) return rows;
+  if (at < 0 || compaction === undefined) return undefined;
   const firstKeptId = compactionOf(compaction)?.first_kept_message_id;
   const firstKept = rows.findIndex((row) => row.message.id === firstKeptId);
-  const kept =
-    firstKept < 0 ? rows.slice(at + 1) : rows.slice(firstKept).filter((row) => row !== compaction);
-  return [compaction, ...kept];
+  return { compaction, at, from: firstKept < 0 ? at + 1 : firstKept };
+}
+
+/**
+ * The rows still worth holding, in the order they were written: the latest
+ * compaction message and every row from the one it named as first kept.
+ * Written order is kept on purpose, because the latest compaction is the
+ * last one written, and a kept tail may hold an earlier compaction of its
+ * own; reordering here would let that earlier one read as the latest on the
+ * next cut.
+ */
+export function retainedRows(rows: readonly ContextRow[]): readonly ContextRow[] {
+  const cut = compactionCut(rows);
+  if (!cut) return rows;
+  return rows.filter((_row, index) => index === cut.at || index >= cut.from);
+}
+
+/**
+ * The rows the model reads, in the order it reads them. The latest
+ * compaction message stands in for every row before the one it named as
+ * first kept, so it comes first, then every row from the first kept one on
+ * in written order. A marker naming a row the set does not hold keeps what
+ * follows the compaction; no compaction keeps everything. The same rows in,
+ * retained or not, give the same derivation out.
+ */
+export function rowsSinceCompaction(rows: readonly ContextRow[]): readonly ContextRow[] {
+  const cut = compactionCut(rows);
+  if (!cut) return rows;
+  return [cut.compaction, ...rows.slice(cut.from).filter((row) => row !== cut.compaction)];
 }
 
 /** Whether metadata a part carries for replay may travel: it names this inference's provider, and the row's turn ran on its model. */
@@ -380,9 +408,9 @@ export class UIMessageContextEngine implements ContextEngine {
     return [...derived, ...ephemeral].map(toWireRecord);
   }
 
-  /** Drops the rows the derivation no longer reads; answers how many went. */
+  /** Drops the rows the derivation no longer reads, keeping the rest in written order; answers how many went. */
   compact(): number {
-    const kept = rowsSinceCompaction(this.#rows);
+    const kept = retainedRows(this.#rows);
     const dropped = this.#rows.length - kept.length;
     this.#rows = kept;
     return dropped;


### PR DESCRIPTION
## What

Follow-up to #925 (A7, merged as `b7d87b25`), fixing the one issue Cursor Bugbot found after the PR was already in the merge queue.

`UIMessageContextEngine.compact()` stored the derivation's order — the compaction message moved to the front of the kept tail. `rowsSinceCompaction` finds the latest compaction as the last compaction row in the array, so once a kept tail itself held an earlier compaction, the next cut over the stored rows read that earlier one as the latest and derived the wrong context. The cut was not idempotent.

## Fix

Two orders, one function each:

- `retainedRows(rows)` (new): what the engine keeps, in written order — the latest compaction message and every row from the one it named as first kept. `compact()` now stores this.
- `rowsSinceCompaction(rows)`: what the model reads, summary first, unchanged in shape and result.

Cutting the retained rows again derives the same input, and a later compaction that keeps an earlier one in its tail still cuts. `modelInputFrom`, `bootstrap`, and the row shape are unchanged, so nothing C1 was told about the engine moves.

## Tests

The compaction test adds the nested case (a later compaction whose first-kept row precedes an earlier compaction) and asserts `retainedRows` order, that the derivation over retained rows equals the derivation over the full set, and that `compact()` on the engine leaves `assemble()` identical to before the cut and answers zero on the second call.

## Verify

`./scripts/check.sh` passes (lint, knip, typecheck, tests, build). No macOS or UI code; `verify.sh` does not apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/54693391-88ad-4083-9b09-861badcd1d7d)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34535338177/artifacts/10175261779) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34535338177)

- Commit: `1df49f27621b9835c8048484907669b7d305f4cd`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
