### PR TITLE
feat(LUKE-147): name every brain-authored user message in the metadata vocabulary

### DIFF
--- a/packages/brain/src/run-events.test.ts
+++ b/packages/brain/src/run-events.test.ts
@@ -54,6 +54,7 @@ import { BRAIN_TURN_KIND, BRAIN_TURN_TRIGGER, type BrainTurnDescription } from "
 import { TurnEvents } from "./turn-events.js";
 import {
   AssistantMessageBuilder,
+  HOSTED_WORDS_METADATA,
   REASONING_PROVIDER_KEY,
   toolPartType,
   UI_PART_STATE,
@@ -516,7 +517,11 @@ test("a child's task turn is told as a child's, with the task as its words and i
   assert.equal(started?.trigger, BRAIN_TURN_TRIGGER.CHILD_TASK);
   const [task, answer] = ofKind(events, BRAIN_RUN_EVENT.MESSAGE_COMPLETED);
   assert.equal(task?.message.role, MESSAGE_ROLE.USER);
-  assert.equal("metadata" in (task?.message ?? {}), false);
+  assert.deepEqual(task?.message.metadata, {
+    author: MESSAGE_AUTHOR.BRAIN,
+    source: OBSERVATION_SOURCE.CHILD,
+  });
+  assert.deepEqual(answer?.message.metadata, BRAIN_AUTHORED);
   assert.deepEqual(answer?.message.parts, [
     { type: UI_PART_TYPE.TEXT, text: "Looked into it.", state: UI_PART_STATE.DONE },
   ]);
@@ -536,6 +541,11 @@ test("a hold's release is told under its own origin", async () => {
   const [started] = ofKind(events, BRAIN_RUN_EVENT.TURN_STARTED);
   assert.equal(started?.origin, BRAIN_TURN_ORIGIN.HOLD_RELEASE);
   assert.equal(started?.trigger, BRAIN_TURN_TRIGGER.HOLD_RELEASED);
+  const [released] = ofKind(events, BRAIN_RUN_EVENT.MESSAGE_COMPLETED);
+  assert.deepEqual(released?.message.metadata, {
+    author: MESSAGE_AUTHOR.BRAIN,
+    source: OBSERVATION_SOURCE.HOLD_RELEASE,
+  });
   assert.deepEqual(kinds(events).at(-1), BRAIN_RUN_EVENT.TURN_ENDED);
   await h.agent.stop();
 });
@@ -783,7 +793,7 @@ test("every trigger has one origin: an ask's by where the ask came from, the res
   );
 });
 
-test("a user row's metadata follows the trigger: asks by channel, observations by source, and none where the vocabulary has no shape", () => {
+test("a user row's metadata follows the trigger: asks by channel, everything the brain writes for itself by source", () => {
   assert.deepEqual(
     [
       userMetadataOf(BRAIN_TURN_TRIGGER.ASK, BRAIN_REQUEST_ORIGIN.TYPED),
@@ -799,11 +809,15 @@ test("a user row's metadata follows the trigger: asks by channel, observations b
       { author: MESSAGE_AUTHOR.DEVELOPER, channel: MESSAGE_CHANNEL.VOICE },
       { author: MESSAGE_AUTHOR.BRAIN, source: OBSERVATION_SOURCE.HOOK },
       { author: MESSAGE_AUTHOR.BRAIN, source: OBSERVATION_SOURCE.ROSTER_LOOK },
-      undefined,
-      undefined,
-      undefined,
+      { author: MESSAGE_AUTHOR.BRAIN, source: OBSERVATION_SOURCE.HOLD_RELEASE },
+      { author: MESSAGE_AUTHOR.BRAIN, source: OBSERVATION_SOURCE.CHILD },
+      { author: MESSAGE_AUTHOR.BRAIN, source: OBSERVATION_SOURCE.CHILD_COMPLETION },
     ],
   );
+  assert.deepEqual(Object.values(HOSTED_WORDS_METADATA), [
+    { author: MESSAGE_AUTHOR.BRAIN, source: OBSERVATION_SOURCE.RECALLED_NOTES },
+    { author: MESSAGE_AUTHOR.BRAIN, source: OBSERVATION_SOURCE.ACTIVITY_NOTICES },
+  ]);
 });
 
 test("a tool's result settles as an answer unless its status is a refusal or its silence, and an error carries the output's reason or the text itself", () => {

--- a/packages/brain/src/turn-events.ts
+++ b/packages/brain/src/turn-events.ts
@@ -72,7 +72,7 @@ export class TurnEvents {
    * message, complete as handed over, saying what the vocabulary lets it say
    * about itself.
    */
-  words(text: string, metadata: UserMessageMetadata | undefined): void {
+  words(text: string, metadata: UserMessageMetadata): void {
     this.#emit({
       kind: BRAIN_RUN_EVENT.MESSAGE_COMPLETED,
       message: userMessage(this.#options.createMessageId(), text, metadata),
@@ -80,7 +80,7 @@ export class TurnEvents {
   }
 
   /** The run under way, its steer telling each message the run takes as words of the turn's own kind. */
-  relaying(run: RuntimeRun, metadata: UserMessageMetadata | undefined): RuntimeRun {
+  relaying(run: RuntimeRun, metadata: UserMessageMetadata): RuntimeRun {
     return {
       runId: run.runId,
       done: run.done,

--- a/packages/brain/src/turn-runner.ts
+++ b/packages/brain/src/turn-runner.ts
@@ -74,7 +74,7 @@ import {
   turnRevoked,
 } from "./turn.js";
 import { TurnEvents } from "./turn-events.js";
-import { userMetadataOf } from "./ui-messages.js";
+import { HOSTED_WORDS_METADATA, userMetadataOf } from "./ui-messages.js";
 import type {
   BrainDelivery,
   BrainTurnNotice,
@@ -574,23 +574,25 @@ export class TurnRunner {
           contextMark = context.mark();
           const recalled = await this.#recall(turnContext);
           notes = this.#options.openingNotes?.take() ?? [];
-          const hosted = [
-            ...recalled.opening,
-            ...(notes.length > 0 ? [activityNoticesInputText(notes, startedAt)] : []),
-          ];
+          const notices = notes.length > 0 ? [activityNoticesInputText(notes, startedAt)] : [];
           const words = plan.open(events, startedAt);
           // The words the turn opens with are its first messages, told before
-          // the model reads them: the host's own notes say nothing of
-          // themselves, and the turn's words say what opened them.
+          // the model reads them, each saying what it is: a recalled note, the
+          // siblings' notices, or the turn's own words by what opened them.
           const metadata = userMetadataOf(plan.trigger, plan.askOrigin);
-          for (const text of hosted) turnContext.events.words(text, undefined);
+          for (const text of recalled.opening) {
+            turnContext.events.words(text, HOSTED_WORDS_METADATA.RECALLED_NOTES);
+          }
+          for (const text of notices) {
+            turnContext.events.words(text, HOSTED_WORDS_METADATA.ACTIVITY_NOTICES);
+          }
           for (const text of words) turnContext.events.words(text, metadata);
           const end = await this.#execute(turnContext, execution, gathering, {
             prompt: preparation.prompt,
             policy,
             plan,
             riders,
-            opening: [...hosted, ...words],
+            opening: [...recalled.opening, ...notices, ...words],
             steered: metadata,
             recalled: recalled.standing,
             advanceMark,
@@ -807,7 +809,7 @@ export class TurnRunner {
       riders: RunControl[];
       opening: readonly string[];
       /** What an ask steered into this run says about itself: the turn's own kind, since only an ask's turn takes one. */
-      steered: UserMessageMetadata | undefined;
+      steered: UserMessageMetadata;
       /** What the memory provider recalled for every inference of the turn, after the standing context. */
       recalled: readonly string[];
       advanceMark: () => Promise<void>;

--- a/packages/brain/src/ui-messages.ts
+++ b/packages/brain/src/ui-messages.ts
@@ -50,15 +50,15 @@ export function toolPartType(name: string): ToolPart["type"] {
 }
 
 /**
- * What a user row of this turn says about itself, where the vocabulary has a
- * shape for it: a developer's ask by the channel it arrived on, an
- * observation by what opened it. A hold's release, a child's task, and the
- * host's own notes have no shape yet and carry none.
+ * What a user row of a turn's own words says about itself: a developer's ask
+ * by the channel it arrived on, and everything the brain wrote down for
+ * itself by what opened the turn. The notes the host hands a turn beside its
+ * words name their own sources, below.
  */
 export function userMetadataOf(
   trigger: BrainTurnTrigger,
   askOrigin: BrainRequestOrigin | undefined,
-): UserMessageMetadata | undefined {
+): UserMessageMetadata {
   switch (trigger) {
     case BRAIN_TURN_TRIGGER.ASK:
       return {
@@ -71,22 +71,26 @@ export function userMetadataOf(
     case BRAIN_TURN_TRIGGER.ROSTER:
       return { author: MESSAGE_AUTHOR.BRAIN, source: OBSERVATION_SOURCE.ROSTER_LOOK };
     case BRAIN_TURN_TRIGGER.HOLD_RELEASED:
+      return { author: MESSAGE_AUTHOR.BRAIN, source: OBSERVATION_SOURCE.HOLD_RELEASE };
     case BRAIN_TURN_TRIGGER.CHILD_TASK:
+      return { author: MESSAGE_AUTHOR.BRAIN, source: OBSERVATION_SOURCE.CHILD };
     case BRAIN_TURN_TRIGGER.CHILD_COMPLETION:
-      return undefined;
+      return { author: MESSAGE_AUTHOR.BRAIN, source: OBSERVATION_SOURCE.CHILD_COMPLETION };
   }
 }
 
-/** The message a text the turn was handed amounts to: the developer's ask, an observation, a steered ask. */
-export function userMessage(
-  id: string,
-  text: string,
-  metadata: UserMessageMetadata | undefined,
-): UIMessage {
+/** What the notes the host hands a turn beside its words say about themselves. */
+export const HOSTED_WORDS_METADATA = {
+  RECALLED_NOTES: { author: MESSAGE_AUTHOR.BRAIN, source: OBSERVATION_SOURCE.RECALLED_NOTES },
+  ACTIVITY_NOTICES: { author: MESSAGE_AUTHOR.BRAIN, source: OBSERVATION_SOURCE.ACTIVITY_NOTICES },
+} as const satisfies Record<string, UserMessageMetadata>;
+
+/** The message a text the turn was handed amounts to: the developer's ask, an observation, a steered ask, a note. */
+export function userMessage(id: string, text: string, metadata: UserMessageMetadata): UIMessage {
   return {
     id,
     role: MESSAGE_ROLE.USER,
-    ...(metadata ? { metadata } : undefined),
+    metadata,
     parts: [{ type: UI_PART_TYPE.TEXT, text, state: UI_PART_STATE.DONE }],
   };
 }

--- a/packages/session/fixtures/ui-messages/activity-notices.json
+++ b/packages/session/fixtures/ui-messages/activity-notices.json
@@ -1,0 +1,14 @@
+{
+  "id": "b18ed276-70af-4d91-e4c2-5f60718293a4",
+  "role": "user",
+  "metadata": {
+    "author": "brain",
+    "source": "activity_notices"
+  },
+  "parts": [
+    {
+      "type": "text",
+      "text": "[activity] The checkout conversation announced once and sent one message."
+    }
+  ]
+}

--- a/packages/session/fixtures/ui-messages/child-completion.json
+++ b/packages/session/fixtures/ui-messages/child-completion.json
@@ -1,0 +1,14 @@
+{
+  "id": "9f6cb054-5e8d-4b7f-c2a0-3d4e5f607182",
+  "role": "user",
+  "metadata": {
+    "author": "brain",
+    "source": "child_completion"
+  },
+  "parts": [
+    {
+      "type": "text",
+      "text": "[child completed] The fixture session renamed two files and added a test."
+    }
+  ]
+}

--- a/packages/session/fixtures/ui-messages/child-task.json
+++ b/packages/session/fixtures/ui-messages/child-task.json
@@ -1,0 +1,14 @@
+{
+  "id": "8e5baf43-4d7c-4a6e-b19f-2c3d4e5f6071",
+  "role": "user",
+  "metadata": {
+    "author": "brain",
+    "source": "child"
+  },
+  "parts": [
+    {
+      "type": "text",
+      "text": "[delegated task] Summarize what the fixture session changed since the last review."
+    }
+  ]
+}

--- a/packages/session/fixtures/ui-messages/hold-release.json
+++ b/packages/session/fixtures/ui-messages/hold-release.json
@@ -1,0 +1,14 @@
+{
+  "id": "7d4a9e32-3c6b-4f5d-a08e-1b2c3d4e5f60",
+  "role": "user",
+  "metadata": {
+    "author": "brain",
+    "source": "hold_release"
+  },
+  "parts": [
+    {
+      "type": "text",
+      "text": "[held briefings released] The tests passed on the checkout branch while you were in a meeting."
+    }
+  ]
+}

--- a/packages/session/fixtures/ui-messages/observation-hook.json
+++ b/packages/session/fixtures/ui-messages/observation-hook.json
@@ -1,0 +1,14 @@
+{
+  "id": "5b2e7c10-1a4f-4d3b-8e6c-9f0a1b2c3d4e",
+  "role": "user",
+  "metadata": {
+    "author": "brain",
+    "source": "hook"
+  },
+  "parts": [
+    {
+      "type": "text",
+      "text": "[observation] Claude Code: checkout finished its turn and is waiting."
+    }
+  ]
+}

--- a/packages/session/fixtures/ui-messages/observation-roster-look.json
+++ b/packages/session/fixtures/ui-messages/observation-roster-look.json
@@ -1,0 +1,14 @@
+{
+  "id": "6c3f8d21-2b5a-4e4c-9f7d-0a1b2c3d4e5f",
+  "role": "user",
+  "metadata": {
+    "author": "brain",
+    "source": "roster_look"
+  },
+  "parts": [
+    {
+      "type": "text",
+      "text": "[roster look] Two sessions are working; one is waiting on a permission."
+    }
+  ]
+}

--- a/packages/session/fixtures/ui-messages/recalled-notes.json
+++ b/packages/session/fixtures/ui-messages/recalled-notes.json
@@ -1,0 +1,14 @@
+{
+  "id": "a07dc165-6f9e-4c80-d3b1-4e5f60718293",
+  "role": "user",
+  "metadata": {
+    "author": "brain",
+    "source": "recalled_notes"
+  },
+  "parts": [
+    {
+      "type": "text",
+      "text": "[recalled] The developer prefers tests before a refactor lands."
+    }
+  ]
+}

--- a/packages/session/src/ui-messages/validate.test.ts
+++ b/packages/session/src/ui-messages/validate.test.ts
@@ -6,6 +6,8 @@ import { fileURLToPath } from "node:url";
 import {
   MESSAGE_AUTHOR,
   MESSAGE_ROLE,
+  OBSERVATION_SOURCE,
+  type ObservationSource,
   SCHEMA_REFUSAL,
   type SchemaPath,
   type SchemaRead,
@@ -30,7 +32,25 @@ const FIXTURE = {
   SPOKEN_ASK: "spoken-ask.json",
   REPLY_WITH_TOOL_PART: "reply-with-tool-part.json",
   COMPACTION: "compaction.json",
+  OBSERVATION_HOOK: "observation-hook.json",
+  OBSERVATION_ROSTER_LOOK: "observation-roster-look.json",
+  HOLD_RELEASE: "hold-release.json",
+  CHILD_TASK: "child-task.json",
+  CHILD_COMPLETION: "child-completion.json",
+  RECALLED_NOTES: "recalled-notes.json",
+  ACTIVITY_NOTICES: "activity-notices.json",
 } as const;
+
+/** The fixture that carries each source the brain writes a user row under, one per member of the set. */
+const BRAIN_SOURCE_FIXTURES = {
+  [OBSERVATION_SOURCE.HOOK]: FIXTURE.OBSERVATION_HOOK,
+  [OBSERVATION_SOURCE.ROSTER_LOOK]: FIXTURE.OBSERVATION_ROSTER_LOOK,
+  [OBSERVATION_SOURCE.HOLD_RELEASE]: FIXTURE.HOLD_RELEASE,
+  [OBSERVATION_SOURCE.CHILD]: FIXTURE.CHILD_TASK,
+  [OBSERVATION_SOURCE.CHILD_COMPLETION]: FIXTURE.CHILD_COMPLETION,
+  [OBSERVATION_SOURCE.RECALLED_NOTES]: FIXTURE.RECALLED_NOTES,
+  [OBSERVATION_SOURCE.ACTIVITY_NOTICES]: FIXTURE.ACTIVITY_NOTICES,
+} as const satisfies Record<ObservationSource, (typeof FIXTURE)[keyof typeof FIXTURE]>;
 
 async function fixture(name: (typeof FIXTURE)[keyof typeof FIXTURE]): Promise<WireRecord> {
   // SAFETY: the fixture files are JSON this repository commits; JSON.parse answers the structured-clone shape the wire boundary takes.
@@ -95,6 +115,24 @@ test("a row is typed by its role, and its tool parts are told by their state", a
     reply.parts.map((part) => (isStoredToolPart(part) ? part.state : undefined)),
     [undefined, undefined, TOOL_PART_STATE.OUTPUT_AVAILABLE, undefined],
   );
+});
+
+test("a brain-authored user row reads back under each source the vocabulary names, and a source it does not name is refused", async () => {
+  for (const [source, name] of Object.entries(BRAIN_SOURCE_FIXTURES)) {
+    const message = await fixture(name);
+    const read = await readStoredUIMessages([message], TOOLS);
+    assert.ok(read.ok);
+    const [stored] = read.value;
+    assert.equal(stored?.role, MESSAGE_ROLE.USER);
+    assert.deepEqual(stored?.metadata, { author: MESSAGE_AUTHOR.BRAIN, source });
+  }
+  const unnamed = withMetadata(await fixture(FIXTURE.HOLD_RELEASE), {
+    author: MESSAGE_AUTHOR.BRAIN,
+    source: "bulletin",
+  });
+  const read = await readStoredUIMessages([unnamed], TOOLS);
+  assert.equal(refusalOf(read), SCHEMA_REFUSAL.MALFORMED);
+  assert.deepEqual(pathOf(read), [0, "metadata"]);
 });
 
 test("a message with metadata the vocabulary does not name is refused at the metadata", async () => {

--- a/packages/wire/src/ui-message-metadata.test.ts
+++ b/packages/wire/src/ui-message-metadata.test.ts
@@ -62,6 +62,37 @@ test("a user row is a typed ask, a spoken ask, or an observation, each admitted 
   );
 });
 
+test("every way the brain writes a user row for itself is a source, and a source the vocabulary does not name is refused", () => {
+  const sources = Object.values(OBSERVATION_SOURCE);
+  assert.deepEqual(
+    sources.map((source) => USER_MESSAGE_METADATA.parse({ author: MESSAGE_AUTHOR.BRAIN, source })),
+    sources.map((source) => ({ author: MESSAGE_AUTHOR.BRAIN, source })),
+  );
+  assert.deepEqual(
+    new Set(sources),
+    new Set([
+      OBSERVATION_SOURCE.HOOK,
+      OBSERVATION_SOURCE.ROSTER_LOOK,
+      OBSERVATION_SOURCE.HOLD_RELEASE,
+      OBSERVATION_SOURCE.CHILD,
+      OBSERVATION_SOURCE.CHILD_COMPLETION,
+      OBSERVATION_SOURCE.RECALLED_NOTES,
+      OBSERVATION_SOURCE.ACTIVITY_NOTICES,
+    ]),
+  );
+  const refused: UnparsedWireValue[] = [
+    { author: MESSAGE_AUTHOR.BRAIN, source: "bulletin" },
+    { author: MESSAGE_AUTHOR.BRAIN, source: MESSAGE_CHANNEL.TYPED },
+    { author: MESSAGE_AUTHOR.BRAIN, source: "" },
+    { author: MESSAGE_AUTHOR.BRAIN },
+    { author: MESSAGE_AUTHOR.CHILD, source: OBSERVATION_SOURCE.CHILD },
+    { author: MESSAGE_AUTHOR.DEVELOPER, source: OBSERVATION_SOURCE.HOLD_RELEASE },
+  ];
+  for (const value of refused) {
+    assert.equal(refusalOf(USER_MESSAGE_METADATA, value), SCHEMA_REFUSAL.MALFORMED);
+  }
+});
+
 test("the authors are bound to their shapes: a child never speaks as user, the brain never on a channel, the developer never as an observation", () => {
   const refused: UnparsedWireValue[] = [
     { author: MESSAGE_AUTHOR.CHILD, channel: MESSAGE_CHANNEL.TYPED },

--- a/packages/wire/src/ui-message-metadata.ts
+++ b/packages/wire/src/ui-message-metadata.ts
@@ -41,10 +41,27 @@ export const MESSAGE_CHANNEL = {
 
 export type MessageChannel = (typeof MESSAGE_CHANNEL)[keyof typeof MESSAGE_CHANNEL];
 
-/** What opened an observation the brain wrote down as a user row. */
+/**
+ * What the brain wrote a user row down for itself about: the words a turn
+ * opened with that no developer typed or spoke. The turn's origin names the
+ * first three the way the turns table does; the rest are the notes the host
+ * hands a turn beside its own words.
+ */
 export const OBSERVATION_SOURCE = {
+  /** A provider's hook reported a session's turn ending or a tool holding. */
   HOOK: "hook",
+  /** The roster look on the observation pass. */
   ROSTER_LOOK: "roster_look",
+  /** Briefings held through a meeting or a pause, handed back for one re-decision. */
+  HOLD_RELEASE: "hold_release",
+  /** A child's own turn: the task its requester delegated, as the child reads it. */
+  CHILD: "child",
+  /** A requester's turn opened by a child's completion, with the child's result as its words. */
+  CHILD_COMPLETION: "child_completion",
+  /** Notes the memory provider recalled for the turn. */
+  RECALLED_NOTES: "recalled_notes",
+  /** The compact notices of what sibling conversations did since main's last turn. */
+  ACTIVITY_NOTICES: "activity_notices",
 } as const;
 
 export type ObservationSource = (typeof OBSERVATION_SOURCE)[keyof typeof OBSERVATION_SOURCE];
@@ -92,7 +109,7 @@ function coherentSpan(metadata: SpokenAskMetadata): boolean {
   return metadata.from_ms <= metadata.to_ms;
 }
 
-/** An observation arrives on no channel: the brain's own note of what a hook or a roster look reported. */
+/** An observation arrives on no channel: the brain's own note of what opened the turn or what the host handed it. */
 const OBSERVATION_METADATA_FIELDS = {
   author: s.literal(MESSAGE_AUTHOR.BRAIN),
   source: s.enumOf(Object.values(OBSERVATION_SOURCE)),


### PR DESCRIPTION
## What

A1's `USER_MESSAGE_METADATA` named shapes for a typed ask, a spoken ask, and an observation opened by a `hook` or a `roster_look`. The brain also opens turns from a hold's release, a child's task, and a child's completion, and hands every turn recalled notes and sibling activity notices beside its words; each of those is written as a user-role message, and A3's stream told them with no metadata, so `readStoredUIMessages` refused them. This PR names every one of them.

- `OBSERVATION_SOURCE` in `@sidecar/wire` gains `hold_release`, `child`, `child_completion`, `recalled_notes`, and `activity_notices` beside `hook` and `roster_look`. The first three are the values `turns.origin` already uses (and the brain's own `BRAIN_TURN_ORIGIN`); the last two name the notes the host hands a turn. The set stays `as const` with its derived union, declared once in `@sidecar/wire` and re-exported by `@sidecar/session`; the record shape (`author: brain`, `source`) and A1's refinements are unchanged, so an observation-shaped row still names a source where a developer's ask names a channel, and a row naming a source outside the set is still refused.
- The brain now emits every user row it writes for itself under its source: `userMetadataOf` answers a shape for every trigger rather than `undefined` for three of them, recalled notes and activity notices carry their own, and `userMessage` / `TurnEvents.words` take metadata as required rather than optional, so a nameless user row has no way to be composed.
- Fixtures: one JSON row per source under `packages/session/fixtures/ui-messages/` (`observation-hook`, `observation-roster-look`, `hold-release`, `child-task`, `child-completion`, `recalled-notes`, `activity-notices`), beside A1's three, synthetic throughout.

## How it follows the plan

`storage-plan.md`'s `turns.origin` names `hold_release` and `child`, so the plan already required those turns; this makes the message vocabulary consistent with that requirement rather than extending it (the orchestrator's decision on LUKE-147: widen the vocabulary, never make metadata optional). B5 writes these rows from A3's `MESSAGE_COMPLETED` events and reads them back through A1's reader; with this, every row the brain emits reads back clean, and an unnamed one still does not.

No sixth way was found: the runtime's loop-guard warning is ingested into the model's context as user text but is never told as a message, and the folded ask queue's summary line rides inside the typed ask it opens. The local compaction summary is a context item today and becomes an assistant message under A6, so it is not a user row either.

## Stored reads

The tests go through `readStoredUIMessages`, never the SDK's `validateUIMessages` directly, so the registry pre-check stands; no new cast is needed since the reader owns A1's `SAFETY`-commented one.

## CLAUDE.md

No sentence contradicted.

## How to verify

```
./scripts/check.sh
cd packages/wire && npx tsx --test src/ui-message-metadata.test.ts
cd packages/session && npx tsx --test src/ui-messages/validate.test.ts
cd packages/brain && npx tsx --test src/run-events.test.ts
```

Tests assert set membership (the source set equals the seven members), values (each source parses back to itself; each fixture reads back under its source), refusals (a `bulletin` source, a channel word as a source, an empty source, a missing source, and a child or developer author on a source-shaped row all refuse `MALFORMED` at `metadata`), and the brain's mapping from every trigger to a shape; never prose.

## Results

- `./scripts/check.sh`: passed (lint, knip, typecheck across 27 workspaces, tests, build); wire 74, session 102, brain 368 tests passing.
- No macOS or UI code touched, so `./scripts/verify.sh` does not apply.

## Reviews

- **Thermo-nuclear code quality review** (`cursor/plugins`, `cursor-team-kit/skills/thermo-nuclear-code-quality-review`): the one structural finding was in the code this widens: three `UserMessageMetadata | undefined` signatures and the `...(metadata ? { metadata } : undefined)` branch existed only because the vocabulary had holes; with the holes closed they are gone, so the composer cannot build a nameless row. No file grows past its bounds.
- **Ponytail review** (`dietrichgebert/ponytail`, `.openclaw/skills/ponytail-review`): `ui-messages.ts: delete: optional metadata on userMessage and words; the vocabulary names every row, so nothing composes without one.` Applied. Otherwise `Lean already. Ship.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/fe0cef85-abbc-4ce1-8573-4ade08036d9d)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34536140858/artifacts/10175564614) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34536140858)

- Commit: `9cf601c95849bc992604a81779e8df4ea39a2d62`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
