### PR TITLE
feat(LUKE-133): the Conversation view selection

### DIFF
--- a/apps/web/server/db/storage-schema.ts
+++ b/apps/web/server/db/storage-schema.ts
@@ -1,6 +1,13 @@
 import type { BrainRunUsage } from "@sidecar/brain";
 import type { StoredUIMessage } from "@sidecar/session/ui-messages";
-import type { MessageRole, StoredMessageMetadata } from "@sidecar/wire";
+import {
+  CONVERSATION_EVENT_KIND,
+  type ConversationEventKind,
+  type MessageRole,
+  type StoredMessageMetadata,
+  type TurnOrigin,
+  type TurnStatus,
+} from "@sidecar/wire";
 import { sql } from "drizzle-orm";
 import {
   type AnyPgColumn,
@@ -46,45 +53,6 @@ export const CONVERSATION_KIND = {
 } as const;
 
 type ConversationKind = (typeof CONVERSATION_KIND)[keyof typeof CONVERSATION_KIND];
-
-/** What opened a turn: the developer's typed or spoken ask, a roster diff, a hold's release, or a child's completion. */
-export const TURN_ORIGIN = {
-  TYPED: "typed",
-  SPOKEN: "spoken",
-  ROSTER_DIFF: "roster_diff",
-  HOLD_RELEASE: "hold_release",
-  CHILD: "child",
-} as const;
-
-type TurnOrigin = (typeof TURN_ORIGIN)[keyof typeof TURN_ORIGIN];
-
-/** Where a turn stands in its life, from the queue to one of its three ends. */
-export const TURN_STATUS = {
-  QUEUED: "queued",
-  RUNNING: "running",
-  SETTLED: "settled",
-  CANCELLED: "cancelled",
-  FAILED: "failed",
-} as const;
-
-type TurnStatus = (typeof TURN_STATUS)[keyof typeof TURN_STATUS];
-
-/**
- * What an event records about a message: a briefing's life from offered
- * through claimed or held to spoken, pushed, or expired, or a rating the
- * developer gave. The claim is the one kind the schema itself makes exclusive.
- */
-export const EVENT_KIND = {
-  SPEECH_OFFERED: "speech.offered",
-  SPEECH_CLAIMED: "speech.claimed",
-  SPEECH_SPOKEN: "speech.spoken",
-  SPEECH_PUSHED: "speech.pushed",
-  SPEECH_EXPIRED: "speech.expired",
-  SPEECH_HELD: "speech.held",
-  RATING: "rating",
-} as const;
-
-type EventKind = (typeof EVENT_KIND)[keyof typeof EVENT_KIND];
 
 const instant = (name: string) => timestamp(name, { withTimezone: true });
 
@@ -240,7 +208,7 @@ export const events = pgTable(
     messageId: uuid("message_id")
       .notNull()
       .references(() => messages.id, { onDelete: "cascade" }),
-    kind: text("kind").$type<EventKind>().notNull(),
+    kind: text("kind").$type<ConversationEventKind>().notNull(),
     /** The device that claimed, spoke, or rated; null for a kind no device took part in. */
     deviceId: text("device_id"),
     payload: jsonb("payload"),
@@ -251,7 +219,7 @@ export const events = pgTable(
     // The predicate is DDL, which takes no bound parameter, so the kind is inlined rather than passed.
     uniqueIndex("events_speech_claimed_message")
       .on(table.messageId)
-      .where(sql`${table.kind} = ${sql.raw(`'${EVENT_KIND.SPEECH_CLAIMED}'`)}`),
+      .where(sql`${table.kind} = ${sql.raw(`'${CONVERSATION_EVENT_KIND.SPEECH_CLAIMED}'`)}`),
   ],
 );
 

--- a/apps/web/tests/storage-schema.test.ts
+++ b/apps/web/tests/storage-schema.test.ts
@@ -1,6 +1,13 @@
 import assert from "node:assert/strict";
 import test, { after } from "node:test";
-import { MESSAGE_AUTHOR, MESSAGE_CHANNEL, MESSAGE_ROLE } from "@sidecar/wire";
+import {
+  CONVERSATION_EVENT_KIND,
+  MESSAGE_AUTHOR,
+  MESSAGE_CHANNEL,
+  MESSAGE_ROLE,
+  TURN_ORIGIN,
+  TURN_STATUS,
+} from "@sidecar/wire";
 import { and, eq, getTableName, type SQL, sql } from "drizzle-orm";
 import type { PgTable } from "drizzle-orm/pg-core";
 import { user } from "../server/db/auth-schema";
@@ -8,13 +15,10 @@ import {
   CONVERSATION_KIND,
   conversationLease,
   conversations,
-  EVENT_KIND,
   events,
   messages,
   prompts,
   providerCursors,
-  TURN_ORIGIN,
-  TURN_STATUS,
   toolSets,
   turns,
 } from "../server/db/storage-schema";
@@ -109,7 +113,7 @@ async function insertEvent(
       conversationId,
       messageId,
       seq: 1,
-      kind: EVENT_KIND.SPEECH_OFFERED,
+      kind: CONVERSATION_EVENT_KIND.SPEECH_OFFERED,
       ...row,
     })
     .returning({ id: events.id });
@@ -293,17 +297,20 @@ test("a message takes one speech.claimed event, and the claim refuses every seco
   const userId = await database.createUser();
   const conversationId = await insertConversation(userId);
   const briefing = await insertMessage(userId, conversationId, { role: MESSAGE_ROLE.ASSISTANT });
-  await insertEvent(userId, conversationId, briefing, { seq: 1, kind: EVENT_KIND.SPEECH_OFFERED });
+  await insertEvent(userId, conversationId, briefing, {
+    seq: 1,
+    kind: CONVERSATION_EVENT_KIND.SPEECH_OFFERED,
+  });
   await insertEvent(userId, conversationId, briefing, {
     seq: 2,
-    kind: EVENT_KIND.SPEECH_CLAIMED,
+    kind: CONVERSATION_EVENT_KIND.SPEECH_CLAIMED,
     deviceId: "mac-1",
   });
 
   await assertUniqueViolation(
     insertEvent(userId, conversationId, briefing, {
       seq: 3,
-      kind: EVENT_KIND.SPEECH_CLAIMED,
+      kind: CONVERSATION_EVENT_KIND.SPEECH_CLAIMED,
       deviceId: "phone-1",
     }),
   );
@@ -311,7 +318,9 @@ test("a message takes one speech.claimed event, and the claim refuses every seco
   const claims = await database.db
     .select({ deviceId: events.deviceId })
     .from(events)
-    .where(and(eq(events.messageId, briefing), eq(events.kind, EVENT_KIND.SPEECH_CLAIMED)));
+    .where(
+      and(eq(events.messageId, briefing), eq(events.kind, CONVERSATION_EVENT_KIND.SPEECH_CLAIMED)),
+    );
   assert.deepEqual(claims, [{ deviceId: "mac-1" }]);
 });
 
@@ -328,15 +337,24 @@ test("the claim binds one message alone: other kinds on it and claims on other m
     seq: 2,
     role: MESSAGE_ROLE.ASSISTANT,
   });
-  await insertEvent(userId, conversationId, first, { seq: 1, kind: EVENT_KIND.SPEECH_CLAIMED });
+  await insertEvent(userId, conversationId, first, {
+    seq: 1,
+    kind: CONVERSATION_EVENT_KIND.SPEECH_CLAIMED,
+  });
 
-  await insertEvent(userId, conversationId, first, { seq: 2, kind: EVENT_KIND.SPEECH_SPOKEN });
+  await insertEvent(userId, conversationId, first, {
+    seq: 2,
+    kind: CONVERSATION_EVENT_KIND.SPEECH_SPOKEN,
+  });
   await insertEvent(userId, conversationId, first, {
     seq: 3,
-    kind: EVENT_KIND.RATING,
+    kind: CONVERSATION_EVENT_KIND.RATING,
     payload: { rating: "up" },
   });
-  await insertEvent(userId, conversationId, second, { seq: 4, kind: EVENT_KIND.SPEECH_CLAIMED });
+  await insertEvent(userId, conversationId, second, {
+    seq: 4,
+    kind: CONVERSATION_EVENT_KIND.SPEECH_CLAIMED,
+  });
 
   assert.equal(await countRows(events, eq(events.messageId, first)), 3);
   assert.equal(await countRows(events, eq(events.messageId, second)), 1);
@@ -363,7 +381,10 @@ test("deleting a message takes its events and leaves its neighbour's", async () 
   const gone = await insertMessage(userId, conversationId, { clientId: "m-1", seq: 1 });
   const kept = await insertMessage(userId, conversationId, { clientId: "m-2", seq: 2 });
   await insertEvent(userId, conversationId, gone, { seq: 1 });
-  await insertEvent(userId, conversationId, gone, { seq: 2, kind: EVENT_KIND.SPEECH_CLAIMED });
+  await insertEvent(userId, conversationId, gone, {
+    seq: 2,
+    kind: CONVERSATION_EVENT_KIND.SPEECH_CLAIMED,
+  });
   await insertEvent(userId, conversationId, kept, { seq: 3 });
 
   await database.db.delete(messages).where(eq(messages.id, gone));
@@ -377,14 +398,14 @@ test("an event keeps its kind, device, and payload as written", async () => {
   const conversationId = await insertConversation(userId);
   const messageId = await insertMessage(userId, conversationId);
   const id = await insertEvent(userId, conversationId, messageId, {
-    kind: EVENT_KIND.SPEECH_HELD,
+    kind: CONVERSATION_EVENT_KIND.SPEECH_HELD,
     deviceId: "mac-1",
     payload: { until: 1_700_000_000_000 },
   });
 
   const [row] = await database.db.select().from(events).where(eq(events.id, id));
   assert.ok(row);
-  assert.equal(row.kind, EVENT_KIND.SPEECH_HELD);
+  assert.equal(row.kind, CONVERSATION_EVENT_KIND.SPEECH_HELD);
   assert.equal(row.deviceId, "mac-1");
   assert.deepEqual(row.payload, { until: 1_700_000_000_000 });
   assert.equal(row.seq, 1);

--- a/packages/AGENTS.md
+++ b/packages/AGENTS.md
@@ -55,6 +55,15 @@ The store used to depend on the brain it stores; folding it into
 `brain/src/store/` is what removed that edge, and nothing under
 `brain/src/store/` may import `../index.js`.
 
+The Conversation view's selection (`@sidecar/session`'s
+`selectConversationView`) is the same rule in the other direction. Which tool
+names are announcements and which are actions is the brain catalog's
+knowledge, and the catalog sits above the session package, so the selection
+takes that classification as an input rather than importing it; a tool the
+caller did not classify is a collapsed detail of its turn, never a row, so an
+observed conversation's message crosses into the view only under a name the
+caller positively named.
+
 Watch for cycles that exist only in tests. A test that reaches into a package
 above its own is still an edge pnpm records, and it usually means the test
 belongs with the layer it is really exercising.

--- a/packages/brain/src/ui-message-context.ts
+++ b/packages/brain/src/ui-message-context.ts
@@ -9,13 +9,14 @@ import {
   type RuntimeCheckpoint,
   sameCheckpointFormat,
 } from "@sidecar/runtime/vocabulary";
-import { type CompactionMetadata, MESSAGE_ROLE, TOOL_PART_STATE } from "@sidecar/session";
 import {
+  type CompactionMetadata,
   isStoredToolPart,
-  readStoredUIMessages,
+  MESSAGE_ROLE,
   type StoredToolPart,
-  type StoredUIMessage,
-} from "@sidecar/session/ui-messages";
+  TOOL_PART_STATE,
+} from "@sidecar/session";
+import { readStoredUIMessages, type StoredUIMessage } from "@sidecar/session/ui-messages";
 import {
   isWireString,
   SCHEMA_REFUSAL,

--- a/packages/session/fixtures/conversation-view/child-completion.json
+++ b/packages/session/fixtures/conversation-view/child-completion.json
@@ -1,0 +1,35 @@
+{
+  "main": [
+    {
+      "message": {
+        "id": "2b000000-0000-4000-8000-000000000061",
+        "role": "assistant",
+        "metadata": {
+          "author": "child"
+        },
+        "parts": [
+          {
+            "type": "text",
+            "text": "The fixture test now passes and the branch is pushed.",
+            "state": "done"
+          }
+        ]
+      },
+      "seq": 61,
+      "turnId": "1a000000-0000-4000-8000-000000000006",
+      "createdAt": 1757505900000
+    }
+  ],
+  "observed": [],
+  "turns": [
+    {
+      "id": "1a000000-0000-4000-8000-000000000006",
+      "origin": "child",
+      "status": "settled",
+      "queuedAt": 1757505900000,
+      "startedAt": 1757505900200,
+      "settledAt": 1757505902400
+    }
+  ],
+  "events": []
+}

--- a/packages/session/fixtures/conversation-view/observation-acted.json
+++ b/packages/session/fixtures/conversation-view/observation-acted.json
@@ -1,0 +1,106 @@
+{
+  "main": [],
+  "observed": [
+    {
+      "session": {
+        "providerId": "conductor",
+        "providerSessionId": "6c1f2f14-9a0b-4c2d-8e3f-0a1b2c3d4e50"
+      },
+      "messages": [
+        {
+          "message": {
+            "id": "2b000000-0000-4000-8000-000000000041",
+            "role": "user",
+            "metadata": {
+              "author": "brain",
+              "source": "roster_look"
+            },
+            "parts": [
+              {
+                "type": "text",
+                "text": "Roster: the fixture session asked whether to run the test suite, and the meeting that held the answer has ended."
+              }
+            ]
+          },
+          "seq": 41,
+          "turnId": "1a000000-0000-4000-8000-000000000004",
+          "createdAt": 1757505780000
+        },
+        {
+          "message": {
+            "id": "2b000000-0000-4000-8000-000000000042",
+            "role": "assistant",
+            "metadata": {
+              "author": "brain"
+            },
+            "parts": [
+              {
+                "type": "step-start"
+              },
+              {
+                "type": "reasoning",
+                "text": "The developer said earlier that tests may always run.",
+                "state": "done",
+                "providerMetadata": {
+                  "openai": {
+                    "itemId": "rs_fixture_0f3a1c22",
+                    "reasoningEncryptedContent": "Zml4dHVyZS1vcGFxdWUtcmVhc29uaW5nLWl0ZW0="
+                  }
+                }
+              },
+              {
+                "type": "tool-send_session_message",
+                "toolCallId": "call_4a0000000000000001",
+                "state": "output-available",
+                "input": {
+                  "provider_id": "conductor",
+                  "provider_session_id": "6c1f2f14-9a0b-4c2d-8e3f-0a1b2c3d4e50",
+                  "text": "Yes, run the tests."
+                },
+                "output": {
+                  "status": "accepted",
+                  "target": {
+                    "providerId": "conductor",
+                    "providerSessionId": "6c1f2f14-9a0b-4c2d-8e3f-0a1b2c3d4e50",
+                    "title": "Fixture session",
+                    "agentId": "fixture-agent"
+                  }
+                }
+              },
+              {
+                "type": "tool-run_session_control",
+                "toolCallId": "call_4a0000000000000002",
+                "state": "output-error",
+                "input": {
+                  "provider_id": "conductor",
+                  "provider_session_id": "6c1f2f14-9a0b-4c2d-8e3f-0a1b2c3d4e50",
+                  "control_id": "approve"
+                },
+                "errorText": "The control is no longer advertised."
+              },
+              {
+                "type": "text",
+                "text": "Told it to go ahead.",
+                "state": "done"
+              }
+            ]
+          },
+          "seq": 42,
+          "turnId": "1a000000-0000-4000-8000-000000000004",
+          "createdAt": 1757505782100
+        }
+      ]
+    }
+  ],
+  "turns": [
+    {
+      "id": "1a000000-0000-4000-8000-000000000004",
+      "origin": "hold_release",
+      "status": "settled",
+      "queuedAt": 1757505780000,
+      "startedAt": 1757505780200,
+      "settledAt": 1757505782400
+    }
+  ],
+  "events": []
+}

--- a/packages/session/fixtures/conversation-view/observation-announced.json
+++ b/packages/session/fixtures/conversation-view/observation-announced.json
@@ -1,0 +1,116 @@
+{
+  "main": [],
+  "observed": [
+    {
+      "session": {
+        "providerId": "conductor",
+        "providerSessionId": "6c1f2f14-9a0b-4c2d-8e3f-0a1b2c3d4e50"
+      },
+      "messages": [
+        {
+          "message": {
+            "id": "2b000000-0000-4000-8000-000000000031",
+            "role": "user",
+            "metadata": {
+              "author": "brain",
+              "source": "roster_look"
+            },
+            "parts": [
+              {
+                "type": "text",
+                "text": "Roster: the fixture session moved from working to waiting."
+              }
+            ]
+          },
+          "seq": 31,
+          "turnId": "1a000000-0000-4000-8000-000000000003",
+          "createdAt": 1757505720000
+        },
+        {
+          "message": {
+            "id": "2b000000-0000-4000-8000-000000000032",
+            "role": "assistant",
+            "metadata": {
+              "author": "brain"
+            },
+            "parts": [
+              {
+                "type": "step-start"
+              },
+              {
+                "type": "reasoning",
+                "text": "The session stopped to ask for permission; that is worth a word.",
+                "state": "done",
+                "providerMetadata": {
+                  "openai": {
+                    "itemId": "rs_fixture_0f3a1c22",
+                    "reasoningEncryptedContent": "Zml4dHVyZS1vcGFxdWUtcmVhc29uaW5nLWl0ZW0="
+                  }
+                }
+              },
+              {
+                "type": "tool-read_transcript",
+                "toolCallId": "call_3a0000000000000001",
+                "state": "output-available",
+                "input": {
+                  "provider_id": "conductor",
+                  "provider_session_id": "6c1f2f14-9a0b-4c2d-8e3f-0a1b2c3d4e50"
+                },
+                "output": {
+                  "lines": [
+                    "user: Please add the fixture test.",
+                    "assistant: Waiting for permission to run the test suite."
+                  ]
+                }
+              },
+              {
+                "type": "tool-announce",
+                "toolCallId": "call_3a0000000000000002",
+                "state": "output-available",
+                "input": {
+                  "briefing": "The fixture session is waiting on a permission prompt."
+                },
+                "output": {}
+              },
+              {
+                "type": "text",
+                "text": "Announced.",
+                "state": "done"
+              }
+            ]
+          },
+          "seq": 32,
+          "turnId": "1a000000-0000-4000-8000-000000000003",
+          "createdAt": 1757505722000
+        }
+      ]
+    }
+  ],
+  "turns": [
+    {
+      "id": "1a000000-0000-4000-8000-000000000003",
+      "origin": "roster_diff",
+      "status": "settled",
+      "queuedAt": 1757505720000,
+      "startedAt": 1757505720200,
+      "settledAt": 1757505722400
+    }
+  ],
+  "events": [
+    {
+      "messageId": "2b000000-0000-4000-8000-000000000032",
+      "kind": "speech.offered",
+      "seq": 1
+    },
+    {
+      "messageId": "2b000000-0000-4000-8000-000000000032",
+      "kind": "speech.claimed",
+      "seq": 2
+    },
+    {
+      "messageId": "2b000000-0000-4000-8000-000000000032",
+      "kind": "speech.spoken",
+      "seq": 3
+    }
+  ]
+}

--- a/packages/session/fixtures/conversation-view/observation-idle.json
+++ b/packages/session/fixtures/conversation-view/observation-idle.json
@@ -1,0 +1,91 @@
+{
+  "main": [],
+  "observed": [
+    {
+      "session": {
+        "providerId": "conductor",
+        "providerSessionId": "6c1f2f14-9a0b-4c2d-8e3f-0a1b2c3d4e50"
+      },
+      "messages": [
+        {
+          "message": {
+            "id": "2b000000-0000-4000-8000-000000000051",
+            "role": "user",
+            "metadata": {
+              "author": "brain",
+              "source": "roster_look"
+            },
+            "parts": [
+              {
+                "type": "text",
+                "text": "Roster: the fixture session is still working."
+              }
+            ]
+          },
+          "seq": 51,
+          "turnId": "1a000000-0000-4000-8000-000000000005",
+          "createdAt": 1757505840000
+        },
+        {
+          "message": {
+            "id": "2b000000-0000-4000-8000-000000000052",
+            "role": "assistant",
+            "metadata": {
+              "author": "brain"
+            },
+            "parts": [
+              {
+                "type": "step-start"
+              },
+              {
+                "type": "reasoning",
+                "text": "Nothing changed that the developer would want to hear.",
+                "state": "done",
+                "providerMetadata": {
+                  "openai": {
+                    "itemId": "rs_fixture_0f3a1c22",
+                    "reasoningEncryptedContent": "Zml4dHVyZS1vcGFxdWUtcmVhc29uaW5nLWl0ZW0="
+                  }
+                }
+              },
+              {
+                "type": "tool-read_transcript",
+                "toolCallId": "call_5a0000000000000001",
+                "state": "output-available",
+                "input": {
+                  "provider_id": "conductor",
+                  "provider_session_id": "6c1f2f14-9a0b-4c2d-8e3f-0a1b2c3d4e50"
+                },
+                "output": {
+                  "lines": [
+                    "user: Please add the fixture test.",
+                    "assistant: Waiting for permission to run the test suite."
+                  ]
+                }
+              },
+              {
+                "type": "text",
+                "text": "Nothing to say yet.",
+                "state": "done"
+              }
+            ]
+          },
+          "seq": 52,
+          "turnId": "1a000000-0000-4000-8000-000000000005",
+          "createdAt": 1757505841700
+        }
+      ]
+    }
+  ],
+  "turns": [
+    {
+      "id": "1a000000-0000-4000-8000-000000000005",
+      "origin": "roster_diff",
+      "status": "settled",
+      "queuedAt": 1757505840000,
+      "startedAt": 1757505840200,
+      "settledAt": 1757505842400
+    }
+  ],
+  "events": []
+}

--- a/packages/session/fixtures/conversation-view/spoken-ask.json
+++ b/packages/session/fixtures/conversation-view/spoken-ask.json
@@ -1,0 +1,76 @@
+{
+  "main": [
+    {
+      "message": {
+        "id": "2b000000-0000-4000-8000-000000000021",
+        "role": "user",
+        "metadata": {
+          "author": "developer",
+          "channel": "voice",
+          "voice_session_id": "vs_0f3a1c226f104d5e",
+          "delegation_id": "dl_2b8c4d5e6f701a2b",
+          "from_ms": 1200,
+          "to_ms": 4800
+        },
+        "parts": [
+          {
+            "type": "text",
+            "text": "What is the fixture session waiting on?"
+          }
+        ]
+      },
+      "seq": 21,
+      "turnId": "1a000000-0000-4000-8000-000000000002",
+      "createdAt": 1757505660000
+    },
+    {
+      "message": {
+        "id": "2b000000-0000-4000-8000-000000000022",
+        "role": "assistant",
+        "metadata": {
+          "author": "brain"
+        },
+        "parts": [
+          {
+            "type": "step-start"
+          },
+          {
+            "type": "tool-read_transcript",
+            "toolCallId": "call_2a0000000000000001",
+            "state": "output-available",
+            "input": {
+              "provider_id": "conductor",
+              "provider_session_id": "6c1f2f14-9a0b-4c2d-8e3f-0a1b2c3d4e50"
+            },
+            "output": {
+              "lines": [
+                "user: Please add the fixture test.",
+                "assistant: Waiting for permission to run the test suite."
+              ]
+            }
+          },
+          {
+            "type": "text",
+            "text": "It is waiting for permission to run the test suite.",
+            "state": "done"
+          }
+        ]
+      },
+      "seq": 22,
+      "turnId": "1a000000-0000-4000-8000-000000000002",
+      "createdAt": 1757505661800
+    }
+  ],
+  "observed": [],
+  "turns": [
+    {
+      "id": "1a000000-0000-4000-8000-000000000002",
+      "origin": "spoken",
+      "status": "settled",
+      "queuedAt": 1757505660000,
+      "startedAt": 1757505660200,
+      "settledAt": 1757505662400
+    }
+  ],
+  "events": []
+}

--- a/packages/session/fixtures/conversation-view/typed-ask.json
+++ b/packages/session/fixtures/conversation-view/typed-ask.json
@@ -1,0 +1,57 @@
+{
+  "main": [
+    {
+      "message": {
+        "id": "2b000000-0000-4000-8000-000000000011",
+        "role": "user",
+        "metadata": {
+          "author": "developer",
+          "channel": "typed"
+        },
+        "parts": [
+          {
+            "type": "text",
+            "text": "Is the fixture session still waiting on anything?"
+          }
+        ]
+      },
+      "seq": 11,
+      "turnId": "1a000000-0000-4000-8000-000000000001",
+      "createdAt": 1757505600000
+    },
+    {
+      "message": {
+        "id": "2b000000-0000-4000-8000-000000000012",
+        "role": "assistant",
+        "metadata": {
+          "author": "brain"
+        },
+        "parts": [
+          {
+            "type": "step-start"
+          },
+          {
+            "type": "text",
+            "text": "It is still holding on a permission prompt.",
+            "state": "done"
+          }
+        ]
+      },
+      "seq": 12,
+      "turnId": "1a000000-0000-4000-8000-000000000001",
+      "createdAt": 1757505601500
+    }
+  ],
+  "observed": [],
+  "turns": [
+    {
+      "id": "1a000000-0000-4000-8000-000000000001",
+      "origin": "typed",
+      "status": "settled",
+      "queuedAt": 1757505600000,
+      "startedAt": 1757505600200,
+      "settledAt": 1757505602400
+    }
+  ],
+  "events": []
+}

--- a/packages/session/src/conversation-view.test.ts
+++ b/packages/session/src/conversation-view.test.ts
@@ -1,0 +1,473 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import {
+  CONVERSATION_EVENT_KIND,
+  type ConversationEventKind,
+  MESSAGE_AUTHOR,
+  MESSAGE_ROLE,
+  type SchemaRead,
+  TURN_ORIGIN,
+  unparsedWire,
+  type WireBoundaryInput,
+} from "@sidecar/wire";
+import { type ToolSet, tool } from "ai";
+import { z } from "zod";
+import {
+  CONVERSATION_VIEW_SOURCE,
+  CONVERSATION_VIEW_TOOL_KIND,
+  type ConversationViewEvent,
+  type ConversationViewInput,
+  type ConversationViewStoredMessage,
+  type ConversationViewToolKinds,
+  type ConversationViewTurn,
+  selectConversationView,
+} from "./conversation-view.js";
+import { TOOL_PART_STATE } from "./ui-messages/tool-parts.js";
+import { readStoredUIMessages, type StoredUIMessage } from "./ui-messages/validate.js";
+
+const FIXTURE_DIRECTORY = path.join(fileURLToPath(import.meta.url), "../../fixtures");
+
+const FIXTURE = {
+  TYPED_ASK: "typed-ask.json",
+  SPOKEN_ASK: "spoken-ask.json",
+  OBSERVATION_ANNOUNCED: "observation-announced.json",
+  OBSERVATION_ACTED: "observation-acted.json",
+  OBSERVATION_IDLE: "observation-idle.json",
+  CHILD_COMPLETION: "child-completion.json",
+} as const;
+
+type FixtureName = (typeof FIXTURE)[keyof typeof FIXTURE];
+
+const TURN = {
+  TYPED: "1a000000-0000-4000-8000-000000000001",
+  SPOKEN: "1a000000-0000-4000-8000-000000000002",
+  ANNOUNCED: "1a000000-0000-4000-8000-000000000003",
+  ACTED: "1a000000-0000-4000-8000-000000000004",
+  CHILD: "1a000000-0000-4000-8000-000000000006",
+} as const;
+
+const OBSERVED_SESSION = {
+  providerId: "conductor",
+  providerSessionId: "6c1f2f14-9a0b-4c2d-8e3f-0a1b2c3d4e50",
+};
+
+const sessionIdentity = z.object({ provider_id: z.string(), provider_session_id: z.string() });
+
+const actionOutput = z.object({
+  status: z.enum(["accepted", "unknown", "refused"]),
+  reason: z.string().optional(),
+  target: z
+    .object({
+      providerId: z.string(),
+      providerSessionId: z.string().optional(),
+      title: z.string().optional(),
+      agentId: z.string().optional(),
+    })
+    .optional(),
+});
+
+/** The registry the fixtures are held to: the brain's names, with schemas the test declares. */
+const TOOLS: ToolSet = {
+  announce: tool({
+    description: "Hand the developer one spoken briefing.",
+    inputSchema: z.object({ briefing: z.string() }),
+  }),
+  read_transcript: tool({
+    description: "Reads the tail of an observed session's transcript.",
+    inputSchema: sessionIdentity,
+    outputSchema: z.object({ lines: z.array(z.string()) }),
+  }),
+  send_session_message: tool({
+    description: "Send a message to an observed session.",
+    inputSchema: sessionIdentity.extend({ text: z.string() }),
+    outputSchema: actionOutput,
+  }),
+  run_session_control: tool({
+    description: "Run a control advertised by an observed session.",
+    inputSchema: sessionIdentity.extend({ control_id: z.string() }),
+    outputSchema: actionOutput,
+  }),
+};
+
+const TOOL_KINDS: ConversationViewToolKinds = new Map([
+  ["announce", CONVERSATION_VIEW_TOOL_KIND.ANNOUNCE],
+  ["send_session_message", CONVERSATION_VIEW_TOOL_KIND.ACTION],
+  ["run_session_control", CONVERSATION_VIEW_TOOL_KIND.ACTION],
+]);
+
+/** A fixture row as the file spells it: the message still unread, beside its columns. */
+type FixtureRow = Omit<ConversationViewStoredMessage, "message"> & { message: WireBoundaryInput };
+
+type FixtureFile = {
+  main: FixtureRow[];
+  observed: { session: typeof OBSERVED_SESSION; messages: FixtureRow[] }[];
+  turns: ConversationViewTurn[];
+  events: ConversationViewEvent[];
+};
+
+/** A committed fixture file, read as the shape its reader says it has; the messages inside are still read back under the vocabulary before anything trusts them. */
+async function readFixtureFile<Shape>(directory: string, name: string): Promise<Shape> {
+  // SAFETY: the fixture files are JSON this repository commits, each in the shape its one reader names.
+  return JSON.parse(await readFile(path.join(FIXTURE_DIRECTORY, directory, name), "utf8")) as Shape;
+}
+
+function expectOk<Value>(read: SchemaRead<Value>): Value {
+  assert.equal(read.ok, true);
+  if (!read.ok) throw new Error("unreachable");
+  return read.value;
+}
+
+/** The rows read back under the vocabulary, in the order they were handed over. */
+async function readRows(rows: readonly FixtureRow[]): Promise<ConversationViewStoredMessage[]> {
+  const read = expectOk(
+    await readStoredUIMessages(unparsedWire(rows.map((row) => row.message)), TOOLS),
+  );
+  return read.map((message, index) => {
+    const row = rows[index];
+    if (row === undefined) throw new Error("unreachable");
+    return { message, seq: row.seq, turnId: row.turnId, createdAt: row.createdAt };
+  });
+}
+
+async function loadView(name: FixtureName): Promise<ConversationViewInput> {
+  const file = await readFixtureFile<FixtureFile>("conversation-view", name);
+  const [main, ...observed] = await Promise.all([
+    readRows(file.main),
+    ...file.observed.map((conversation) => readRows(conversation.messages)),
+  ]);
+  return {
+    main,
+    observed: file.observed.map((conversation, index) => ({
+      session: conversation.session,
+      messages: observed[index] ?? [],
+    })),
+    turns: file.turns,
+    events: file.events,
+    toolKinds: TOOL_KINDS,
+  };
+}
+
+function speechEvents(
+  messageId: string,
+  kinds: readonly ConversationEventKind[],
+): ConversationViewEvent[] {
+  return kinds.map((kind, index) => ({ messageId, kind, seq: index + 1 }));
+}
+
+/** Who a stored message says wrote it; a system row says nothing. */
+function authorOf(message: StoredUIMessage | undefined): string | undefined {
+  if (message === undefined || message.role === MESSAGE_ROLE.SYSTEM) return undefined;
+  return message.metadata.author;
+}
+
+function messageIds(input: ConversationViewInput): string[] {
+  return [
+    ...input.main.map((row) => row.message.id),
+    ...input.observed.flatMap((conversation) => conversation.messages.map((row) => row.message.id)),
+  ];
+}
+
+test("a typed ask and its reply are one group of main's, whole and in sequence", async () => {
+  const input = await loadView(FIXTURE.TYPED_ASK);
+  const groups = selectConversationView(input);
+  assert.equal(groups.length, 1);
+  const [group] = groups;
+  assert.equal(group?.turnId, TURN.TYPED);
+  assert.deepEqual(group?.source, { kind: CONVERSATION_VIEW_SOURCE.MAIN });
+  assert.equal(group?.turn?.origin, TURN_ORIGIN.TYPED);
+  assert.deepEqual(
+    group?.messages.map((message) => message.message.id),
+    messageIds(input),
+  );
+  assert.deepEqual(
+    group?.messages.map((message) => message.tools.length),
+    [0, 0],
+  );
+  assert.deepEqual(
+    group?.messages.map((message) => message.message.parts.length),
+    input.main.map((row) => row.message.parts.length),
+  );
+});
+
+test("a spoken ask keeps its voice metadata, and its transcript read is a collapsed detail", async () => {
+  const input = await loadView(FIXTURE.SPOKEN_ASK);
+  const groups = selectConversationView(input);
+  assert.equal(groups.length, 1);
+  const [group] = groups;
+  assert.equal(group?.turn?.origin, TURN_ORIGIN.SPOKEN);
+  const [ask, reply] = group?.messages ?? [];
+  assert.equal(ask?.message, input.main[0]?.message);
+  assert.equal(authorOf(ask?.message), MESSAGE_AUTHOR.DEVELOPER);
+  assert.deepEqual(reply?.tools, [
+    {
+      kind: CONVERSATION_VIEW_TOOL_KIND.DETAIL,
+      toolCallId: "call_2a0000000000000001",
+      toolName: "read_transcript",
+      state: TOOL_PART_STATE.OUTPUT_AVAILABLE,
+    },
+  ]);
+  assert.equal(reply?.message.parts.length, input.main[1]?.message.parts.length);
+});
+
+test("an observation that announced crosses as its announce part alone, under the observed session", async () => {
+  const input = await loadView(FIXTURE.OBSERVATION_ANNOUNCED);
+  const groups = selectConversationView(input);
+  assert.equal(groups.length, 1);
+  const [group] = groups;
+  assert.equal(group?.turnId, TURN.ANNOUNCED);
+  assert.equal(group?.turn?.origin, TURN_ORIGIN.ROSTER_DIFF);
+  assert.deepEqual(group?.source, {
+    kind: CONVERSATION_VIEW_SOURCE.OBSERVED,
+    session: OBSERVED_SESSION,
+  });
+  assert.equal(group?.messages.length, 1);
+  const [message] = group?.messages ?? [];
+  assert.equal(message?.message.id, input.observed[0]?.messages[1]?.message.id);
+  assert.deepEqual(
+    message?.message.parts.map((part) => part.type),
+    ["tool-announce"],
+  );
+  assert.deepEqual(message?.tools, [
+    {
+      kind: CONVERSATION_VIEW_TOOL_KIND.ANNOUNCE,
+      toolCallId: "call_3a0000000000000002",
+      toolName: "announce",
+      state: TOOL_PART_STATE.OUTPUT_AVAILABLE,
+      unspoken: false,
+    },
+  ]);
+});
+
+test("an announcement is unspoken when its latest speech event is the expiry, whatever came before or beside it", async () => {
+  const input = await loadView(FIXTURE.OBSERVATION_ANNOUNCED);
+  const announcementId = input.observed[0]?.messages[1]?.message.id ?? "";
+  const unspokenUnder = (kinds: readonly ConversationEventKind[]) => {
+    const [group] = selectConversationView({
+      ...input,
+      events: speechEvents(announcementId, kinds),
+    });
+    const [part] = group?.messages[0]?.tools ?? [];
+    return part?.kind === CONVERSATION_VIEW_TOOL_KIND.ANNOUNCE ? part.unspoken : undefined;
+  };
+  assert.equal(unspokenUnder([]), false);
+  assert.equal(
+    unspokenUnder([CONVERSATION_EVENT_KIND.SPEECH_OFFERED, CONVERSATION_EVENT_KIND.SPEECH_HELD]),
+    false,
+  );
+  assert.equal(
+    unspokenUnder([CONVERSATION_EVENT_KIND.SPEECH_OFFERED, CONVERSATION_EVENT_KIND.SPEECH_EXPIRED]),
+    true,
+  );
+  assert.equal(
+    unspokenUnder([
+      CONVERSATION_EVENT_KIND.SPEECH_OFFERED,
+      CONVERSATION_EVENT_KIND.SPEECH_EXPIRED,
+      CONVERSATION_EVENT_KIND.SPEECH_SPOKEN,
+    ]),
+    false,
+  );
+  assert.equal(
+    unspokenUnder([
+      CONVERSATION_EVENT_KIND.SPEECH_OFFERED,
+      CONVERSATION_EVENT_KIND.SPEECH_EXPIRED,
+      CONVERSATION_EVENT_KIND.RATING,
+    ]),
+    true,
+  );
+  const reversed = [
+    ...speechEvents(announcementId, [
+      CONVERSATION_EVENT_KIND.SPEECH_OFFERED,
+      CONVERSATION_EVENT_KIND.SPEECH_EXPIRED,
+    ]),
+  ].reverse();
+  const [group] = selectConversationView({ ...input, events: reversed });
+  const [part] = group?.messages[0]?.tools ?? [];
+  assert.equal(part?.kind === CONVERSATION_VIEW_TOOL_KIND.ANNOUNCE && part.unspoken, true);
+});
+
+test("an observation that acted crosses as its action parts, the refused one flagged and collapsed", async () => {
+  const input = await loadView(FIXTURE.OBSERVATION_ACTED);
+  const groups = selectConversationView(input);
+  assert.equal(groups.length, 1);
+  const [group] = groups;
+  assert.equal(group?.turnId, TURN.ACTED);
+  assert.equal(group?.turn?.origin, TURN_ORIGIN.HOLD_RELEASE);
+  assert.equal(group?.messages.length, 1);
+  const [message] = group?.messages ?? [];
+  assert.deepEqual(
+    message?.message.parts.map((part) => part.type),
+    ["tool-send_session_message", "tool-run_session_control"],
+  );
+  assert.deepEqual(message?.tools, [
+    {
+      kind: CONVERSATION_VIEW_TOOL_KIND.ACTION,
+      toolCallId: "call_4a0000000000000001",
+      toolName: "send_session_message",
+      state: TOOL_PART_STATE.OUTPUT_AVAILABLE,
+      refused: false,
+    },
+    {
+      kind: CONVERSATION_VIEW_TOOL_KIND.ACTION,
+      toolCallId: "call_4a0000000000000002",
+      toolName: "run_session_control",
+      state: TOOL_PART_STATE.OUTPUT_ERROR,
+      refused: true,
+    },
+  ]);
+});
+
+test("an observed turn whose only action was refused still crosses, with the refusal flagged", async () => {
+  const input = await loadView(FIXTURE.OBSERVATION_ACTED);
+  const [conversation] = input.observed;
+  if (conversation === undefined) throw new Error("unreachable");
+  const messages = conversation.messages.map((row) => ({
+    ...row,
+    message: {
+      ...row.message,
+      parts: row.message.parts.filter((part) => part.type !== "tool-send_session_message"),
+    },
+  }));
+  const groups = selectConversationView({
+    ...input,
+    observed: [{ ...conversation, messages }],
+  });
+  assert.deepEqual(
+    groups.flatMap((group) => group.messages.flatMap((message) => message.tools)),
+    [
+      {
+        kind: CONVERSATION_VIEW_TOOL_KIND.ACTION,
+        toolCallId: "call_4a0000000000000002",
+        toolName: "run_session_control",
+        state: TOOL_PART_STATE.OUTPUT_ERROR,
+        refused: true,
+      },
+    ],
+  );
+});
+
+test("a tool the view was not told about is a detail, so an observed action it does not know never crosses", async () => {
+  const input = await loadView(FIXTURE.OBSERVATION_ACTED);
+  const toolKinds: ConversationViewToolKinds = new Map([
+    ["announce", CONVERSATION_VIEW_TOOL_KIND.ANNOUNCE],
+  ]);
+  assert.equal(selectConversationView({ ...input, toolKinds }).length, 0);
+});
+
+test("an observation that did nothing is not shown at all", async () => {
+  const input = await loadView(FIXTURE.OBSERVATION_IDLE);
+  assert.deepEqual(selectConversationView(input), []);
+});
+
+test("a child's completion is a message of main's, under its own turn", async () => {
+  const input = await loadView(FIXTURE.CHILD_COMPLETION);
+  const groups = selectConversationView(input);
+  assert.equal(groups.length, 1);
+  const [group] = groups;
+  assert.equal(group?.turnId, TURN.CHILD);
+  assert.equal(group?.turn?.origin, TURN_ORIGIN.CHILD);
+  assert.deepEqual(group?.source, { kind: CONVERSATION_VIEW_SOURCE.MAIN });
+  assert.equal(authorOf(group?.messages[0]?.message), MESSAGE_AUTHOR.CHILD);
+});
+
+/** Every fixture's rows, one input: two conversations' worth of turns interleaved by time. */
+async function loadEveryView(): Promise<ConversationViewInput> {
+  const views = await Promise.all(Object.values(FIXTURE).map(loadView));
+  return {
+    main: views.flatMap((view) => view.main),
+    observed: [
+      {
+        session: OBSERVED_SESSION,
+        messages: views.flatMap((view) =>
+          view.observed.flatMap((conversation) => conversation.messages),
+        ),
+      },
+    ],
+    turns: views.flatMap((view) => view.turns),
+    events: views.flatMap((view) => view.events),
+    toolKinds: TOOL_KINDS,
+  };
+}
+
+test("groups are ordered by time across main and the observed conversations, whatever order the rows arrived in", async () => {
+  const input = await loadEveryView();
+  const expected = [TURN.TYPED, TURN.SPOKEN, TURN.ANNOUNCED, TURN.ACTED, TURN.CHILD];
+  const groups = selectConversationView(input);
+  assert.deepEqual(
+    groups.map((group) => group.turnId),
+    expected,
+  );
+  const reversed: ConversationViewInput = {
+    ...input,
+    main: [...input.main].reverse(),
+    observed: input.observed.map((conversation) => ({
+      ...conversation,
+      messages: [...conversation.messages].reverse(),
+    })),
+    turns: [...input.turns].reverse(),
+  };
+  assert.deepEqual(selectConversationView(reversed), groups);
+});
+
+test("groups whose earliest messages share an instant fall back to the queue order, then the turn id", async () => {
+  const typed = await loadView(FIXTURE.TYPED_ASK);
+  const child = await loadView(FIXTURE.CHILD_COMPLETION);
+  const instant = typed.main[0]?.createdAt ?? 0;
+  const sameInstant = (rows: readonly ConversationViewStoredMessage[]) =>
+    rows.map((row, index) => ({ ...row, createdAt: instant + index }));
+  const main = [...sameInstant(typed.main), ...sameInstant(child.main)];
+  const [typedTurn] = typed.turns;
+  const [childTurn] = child.turns;
+  if (typedTurn === undefined || childTurn === undefined) throw new Error("unreachable");
+  const laterTyped = { ...typedTurn, queuedAt: childTurn.queuedAt + 1 };
+  const order = (turns: readonly ConversationViewTurn[]) =>
+    selectConversationView({ ...typed, main, turns }).map((group) => group.turnId);
+  assert.deepEqual(order([laterTyped, childTurn]), [TURN.CHILD, TURN.TYPED]);
+  assert.deepEqual(order([typedTurn, childTurn]), [TURN.TYPED, TURN.CHILD]);
+  assert.deepEqual(order([childTurn]), [TURN.CHILD, TURN.TYPED]);
+  assert.deepEqual(order([]), [TURN.TYPED, TURN.CHILD]);
+});
+
+test("a compaction row of main's is not shown, since the rows it folded still are", async () => {
+  const input = await loadView(FIXTURE.TYPED_ASK);
+  const compaction = await readFixtureFile<WireBoundaryInput>("ui-messages", "compaction.json");
+  const [message] = expectOk(await readStoredUIMessages(unparsedWire([compaction]), TOOLS));
+  if (message === undefined) throw new Error("unreachable");
+  const last = input.main.at(-1);
+  if (last === undefined) throw new Error("unreachable");
+  const folded: ConversationViewStoredMessage = {
+    message,
+    seq: last.seq + 1,
+    turnId: last.turnId,
+    createdAt: last.createdAt + 100,
+  };
+  const groups = selectConversationView({ ...input, main: [...input.main, folded] });
+  assert.deepEqual(
+    groups.map((group) => group.messages.length),
+    [2],
+  );
+});
+
+test("a message whose turn row is missing is still shown, with no turn beside it", async () => {
+  const input = await loadView(FIXTURE.TYPED_ASK);
+  const [group] = selectConversationView({ ...input, turns: [] });
+  assert.equal(group?.turnId, TURN.TYPED);
+  assert.equal(group?.turn, undefined);
+  assert.equal(group?.messages.length, 2);
+});
+
+test("the turn row rides on the group as the store held it", async () => {
+  const input = await loadView(FIXTURE.TYPED_ASK);
+  const [turn] = input.turns;
+  const [group] = selectConversationView(input);
+  assert.deepEqual(group?.turn, turn satisfies ConversationViewTurn | undefined);
+});
+
+test("selection leaves its input untouched", async () => {
+  const input = await loadEveryView();
+  const before = JSON.stringify(input);
+  selectConversationView(input);
+  assert.equal(JSON.stringify(input), before);
+});

--- a/packages/session/src/conversation-view.ts
+++ b/packages/session/src/conversation-view.ts
@@ -1,0 +1,312 @@
+/**
+ * What the one long Conversation shows, selected from the stored rows: main's
+ * own messages, and from each observed session's conversation only what
+ * crossed into the developer's world — the briefings Luke announced and the
+ * actions he carried — with the turns that produced them. An observed
+ * conversation's ordinary work (its observation notes, its transcript reads,
+ * its thinking, a turn that decided nothing) is never mirrored into the view:
+ * an assistant row crosses only when it carries an announcement or an action,
+ * and crosses cut to those parts, so nothing else it said travels with them.
+ *
+ * The selection is a pure function over rows already read back under the
+ * vocabulary, so it can run on the service and in a test alike, and it takes
+ * everything it decides from as input: it queries nothing. Which tools are
+ * announcements and which are actions is the brain catalog's knowledge, above
+ * this package in the graph, so the caller hands the classification in; a tool
+ * the classification does not name is neither, and draws as a collapsed
+ * detail of its turn rather than a row.
+ */
+
+import {
+  CONVERSATION_EVENT_KIND,
+  type ConversationEventKind,
+  isSpeechEventKind,
+  MESSAGE_ROLE,
+  type TurnOrigin,
+  type TurnStatus,
+} from "@sidecar/wire";
+import type { SessionIdentity } from "./session-identity.js";
+import {
+  isStoredToolPart,
+  type StoredToolPart,
+  storedToolName,
+  TOOL_PART_STATE,
+  type ToolPartState,
+} from "./ui-messages/tool-parts.js";
+import type { StoredUIMessage } from "./ui-messages/validate.js";
+
+/**
+ * What a tool call is to the view. An announcement and an action are the two
+ * kinds that draw a row of their own and the two that carry an observed
+ * conversation's message into the view; a detail is any other call — a read,
+ * a workspace write, a delegation — drawn only inside the expanded turn.
+ */
+export const CONVERSATION_VIEW_TOOL_KIND = {
+  ANNOUNCE: "announce",
+  ACTION: "action",
+  DETAIL: "detail",
+} as const;
+
+export type ConversationViewToolKind =
+  (typeof CONVERSATION_VIEW_TOOL_KIND)[keyof typeof CONVERSATION_VIEW_TOOL_KIND];
+
+/** The two kinds a caller names a tool as; every tool it does not name is a detail. */
+export type NamedConversationViewToolKind = Exclude<
+  ConversationViewToolKind,
+  typeof CONVERSATION_VIEW_TOOL_KIND.DETAIL
+>;
+
+/** The tool names the view is told about, by the kind each is. */
+export type ConversationViewToolKinds = ReadonlyMap<string, NamedConversationViewToolKind>;
+
+export const CONVERSATION_VIEW_SOURCE = {
+  MAIN: "main",
+  OBSERVED: "observed",
+} as const;
+
+export type ConversationViewSource =
+  | { readonly kind: typeof CONVERSATION_VIEW_SOURCE.MAIN }
+  | { readonly kind: typeof CONVERSATION_VIEW_SOURCE.OBSERVED; readonly session: SessionIdentity };
+
+/** A stored message as the view reads it: the row's message beside the columns that place it. */
+export interface ConversationViewStoredMessage {
+  readonly message: StoredUIMessage;
+  /** The row's place in its own conversation's sequence; the order within a turn. */
+  readonly seq: number;
+  readonly turnId: string;
+  /** Epoch milliseconds; the order across conversations. */
+  readonly createdAt: number;
+}
+
+/** The columns of a turn row the view reads. */
+export interface ConversationViewTurn {
+  readonly id: string;
+  readonly origin: TurnOrigin;
+  readonly status: TurnStatus;
+  readonly queuedAt: number;
+  readonly startedAt?: number;
+  readonly settledAt?: number;
+}
+
+/** An event row about a message, in its conversation's own event sequence. */
+export interface ConversationViewEvent {
+  readonly messageId: string;
+  readonly kind: ConversationEventKind;
+  readonly seq: number;
+}
+
+export interface ConversationViewObservedConversation {
+  readonly session: SessionIdentity;
+  readonly messages: readonly ConversationViewStoredMessage[];
+}
+
+export interface ConversationViewInput {
+  readonly main: readonly ConversationViewStoredMessage[];
+  readonly observed: readonly ConversationViewObservedConversation[];
+  readonly turns: readonly ConversationViewTurn[];
+  readonly events: readonly ConversationViewEvent[];
+  readonly toolKinds: ConversationViewToolKinds;
+}
+
+type ToolPartIdentity = {
+  readonly toolCallId: string;
+  readonly toolName: string;
+  readonly state: ToolPartState;
+};
+
+/**
+ * One tool call of a shown message, as the view decided it: which kind it is,
+ * and the one fact of each row kind the renderer cannot read from the part
+ * alone. An announcement is unspoken when the latest speech event on its
+ * message is the expiry: its offer lapsed with no device claiming it, so
+ * nobody heard it. Any other latest event, or none yet, leaves it standing as
+ * a briefing that was or may still be delivered. The events hang on the
+ * message, and a turn announces at most once, so every announce part of one
+ * message reads the same mark. An action is refused when its part ended in
+ * error, the one case an action draws collapsed like a detail.
+ */
+export type ConversationViewToolPart =
+  | (ToolPartIdentity & {
+      readonly kind: typeof CONVERSATION_VIEW_TOOL_KIND.ANNOUNCE;
+      readonly unspoken: boolean;
+    })
+  | (ToolPartIdentity & {
+      readonly kind: typeof CONVERSATION_VIEW_TOOL_KIND.ACTION;
+      readonly refused: boolean;
+    })
+  | (ToolPartIdentity & { readonly kind: typeof CONVERSATION_VIEW_TOOL_KIND.DETAIL });
+
+export interface ConversationViewMessage {
+  /** The stored message; from an observed conversation, cut to its announcement and action parts. */
+  readonly message: StoredUIMessage;
+  readonly seq: number;
+  readonly createdAt: number;
+  /** The message's tool calls in part order, each as the view decided it. */
+  readonly tools: readonly ConversationViewToolPart[];
+}
+
+/** The messages one turn produced, in sequence, under the turn row where the store holds one. */
+export interface ConversationViewTurnGroup {
+  readonly turnId: string;
+  readonly turn: ConversationViewTurn | undefined;
+  readonly source: ConversationViewSource;
+  readonly messages: readonly ConversationViewMessage[];
+}
+
+function toolKindOf(
+  part: StoredToolPart,
+  toolKinds: ConversationViewToolKinds,
+): ConversationViewToolKind {
+  return toolKinds.get(storedToolName(part)) ?? CONVERSATION_VIEW_TOOL_KIND.DETAIL;
+}
+
+/** The latest speech event on each message, by the event sequence of the message's own conversation. */
+function latestSpeechEvents(
+  events: readonly ConversationViewEvent[],
+): ReadonlyMap<string, ConversationViewEvent> {
+  const latest = new Map<string, ConversationViewEvent>();
+  for (const event of events) {
+    if (!isSpeechEventKind(event.kind)) continue;
+    const standing = latest.get(event.messageId);
+    if (standing === undefined || standing.seq < event.seq) latest.set(event.messageId, event);
+  }
+  return latest;
+}
+
+function describeToolPart(
+  part: StoredToolPart,
+  kind: ConversationViewToolKind,
+  speech: ReadonlyMap<string, ConversationViewEvent>,
+  messageId: string,
+): ConversationViewToolPart {
+  const identity: ToolPartIdentity = {
+    toolCallId: part.toolCallId,
+    toolName: storedToolName(part),
+    state: part.state,
+  };
+  switch (kind) {
+    case CONVERSATION_VIEW_TOOL_KIND.ANNOUNCE:
+      return {
+        ...identity,
+        kind,
+        unspoken: speech.get(messageId)?.kind === CONVERSATION_EVENT_KIND.SPEECH_EXPIRED,
+      };
+    case CONVERSATION_VIEW_TOOL_KIND.ACTION:
+      return { ...identity, kind, refused: part.state === TOOL_PART_STATE.OUTPUT_ERROR };
+    case CONVERSATION_VIEW_TOOL_KIND.DETAIL:
+      return { ...identity, kind };
+  }
+}
+
+function isCompaction(message: StoredUIMessage): boolean {
+  return message.role === MESSAGE_ROLE.ASSISTANT && message.metadata.compaction !== undefined;
+}
+
+/**
+ * An observed conversation's row cut to what crosses: an assistant message's
+ * announcement and action parts, or nothing when it carries neither. A
+ * refused action still crosses, since the turn that tried it is shown with
+ * the refusal inside it.
+ */
+function crossingMessage(
+  message: StoredUIMessage,
+  toolKinds: ConversationViewToolKinds,
+): StoredUIMessage | undefined {
+  if (message.role !== MESSAGE_ROLE.ASSISTANT) return undefined;
+  const parts = message.parts.filter(
+    (part) =>
+      isStoredToolPart(part) && toolKindOf(part, toolKinds) !== CONVERSATION_VIEW_TOOL_KIND.DETAIL,
+  );
+  return parts.length === 0 ? undefined : { ...message, parts };
+}
+
+/** A selected row with the conversation it came from, so one pass groups every conversation's rows. */
+type SourcedRow = ConversationViewStoredMessage & { readonly source: ConversationViewSource };
+
+function viewMessage(
+  row: ConversationViewStoredMessage,
+  toolKinds: ConversationViewToolKinds,
+  speech: ReadonlyMap<string, ConversationViewEvent>,
+): ConversationViewMessage {
+  const { message } = row;
+  const tools: ConversationViewToolPart[] = [];
+  for (const part of message.parts) {
+    if (!isStoredToolPart(part)) continue;
+    tools.push(describeToolPart(part, toolKindOf(part, toolKinds), speech, message.id));
+  }
+  return { message, seq: row.seq, createdAt: row.createdAt, tools };
+}
+
+type GroupedRows = { readonly source: ConversationViewSource; readonly rows: SourcedRow[] };
+
+/** A group's place in time: its earliest message, then its turn's queue instant, then its id, so every device orders alike. */
+type PlacedGroup = { readonly group: ConversationViewTurnGroup; readonly instant: number };
+
+function queuedInstant(group: ConversationViewTurnGroup): number {
+  return group.turn?.queuedAt ?? Number.MAX_SAFE_INTEGER;
+}
+
+function compareCodePoints(a: string, b: string): number {
+  if (a === b) return 0;
+  return a < b ? -1 : 1;
+}
+
+function comparePlaced(a: PlacedGroup, b: PlacedGroup): number {
+  return (
+    a.instant - b.instant ||
+    queuedInstant(a.group) - queuedInstant(b.group) ||
+    compareCodePoints(a.group.turnId, b.group.turnId)
+  );
+}
+
+/**
+ * Selects the Conversation: main's messages whole (a compaction row excepted,
+ * since it stands in for messages the view still shows), and from each
+ * observed conversation the assistant messages carrying an announcement or an
+ * action, cut to those parts. Messages are grouped by the turn that wrote
+ * them, in their conversation's sequence within a group, and the groups are
+ * ordered by the time of their earliest message. A turn with nothing selected
+ * is not shown.
+ */
+export function selectConversationView(
+  input: ConversationViewInput,
+): readonly ConversationViewTurnGroup[] {
+  const turns = new Map(input.turns.map((turn) => [turn.id, turn]));
+  const speech = latestSpeechEvents(input.events);
+
+  const selected: SourcedRow[] = [];
+  const main: ConversationViewSource = { kind: CONVERSATION_VIEW_SOURCE.MAIN };
+  for (const row of input.main) {
+    if (!isCompaction(row.message)) selected.push({ ...row, source: main });
+  }
+  for (const conversation of input.observed) {
+    const source: ConversationViewSource = {
+      kind: CONVERSATION_VIEW_SOURCE.OBSERVED,
+      session: conversation.session,
+    };
+    for (const row of conversation.messages) {
+      const message = crossingMessage(row.message, input.toolKinds);
+      if (message !== undefined) selected.push({ ...row, message, source });
+    }
+  }
+
+  const grouped = new Map<string, GroupedRows>();
+  for (const row of selected) {
+    const group = grouped.get(row.turnId);
+    if (group === undefined) grouped.set(row.turnId, { source: row.source, rows: [row] });
+    else group.rows.push(row);
+  }
+
+  const placed: PlacedGroup[] = [...grouped].map(([turnId, { source, rows }]) => ({
+    group: {
+      turnId,
+      turn: turns.get(turnId),
+      source,
+      messages: rows
+        .sort((a, b) => a.seq - b.seq)
+        .map((row) => viewMessage(row, input.toolKinds, speech)),
+    },
+    instant: Math.min(...rows.map((row) => row.createdAt)),
+  }));
+  return placed.sort(comparePlaced).map(({ group }) => group);
+}

--- a/packages/session/src/index.ts
+++ b/packages/session/src/index.ts
@@ -25,6 +25,7 @@ export * from "./advertised-actions.js";
 export * from "./agent-identities.js";
 export * from "./bounds.js";
 export * from "./conversation/conversation.js";
+export * from "./conversation-view.js";
 export * from "./issues/issues.js";
 export * from "./normalize.js";
 export * from "./provider-contract.js";

--- a/packages/session/src/ui-messages/tool-parts.ts
+++ b/packages/session/src/ui-messages/tool-parts.ts
@@ -1,3 +1,5 @@
+import type { ToolUIPart, UIDataTypes, UIMessagePart, UITools } from "ai";
+
 /**
  * The tool part of a stored assistant message is the journal: a call is
  * written in `input-available` before it executes and moved to
@@ -25,4 +27,39 @@ export function isToolPartState(value: string): value is ToolPartState {
 /** The states a resume has nothing left to do for: the call answered or failed. */
 export function isSettledToolPartState(state: ToolPartState): boolean {
   return state === TOOL_PART_STATE.OUTPUT_AVAILABLE || state === TOOL_PART_STATE.OUTPUT_ERROR;
+}
+
+/**
+ * How the SDK spells a static tool part's type: the tool's name behind this
+ * prefix. The SDK's own `isStaticToolUIPart` and `getToolName` say the same,
+ * but this module sits on the session barrel, which reaches the SDK for its
+ * types alone, so the two-character rule is restated here rather than
+ * imported at run time.
+ */
+const TOOL_PART_TYPE_PREFIX = "tool-";
+
+/** The tool a part's type names, or nothing for a part that is not a static tool call. */
+export function toolPartName(type: string): string | undefined {
+  return type.startsWith(TOOL_PART_TYPE_PREFIX)
+    ? type.slice(TOOL_PART_TYPE_PREFIX.length)
+    : undefined;
+}
+
+/** A tool part in one of the states a stored row may carry. */
+export type StoredToolPart = Extract<ToolUIPart<UITools>, { state: ToolPartState }>;
+
+/** The tool a stored tool part calls, whose type always carries the prefix. */
+export function storedToolName(part: StoredToolPart): string {
+  return part.type.slice(TOOL_PART_TYPE_PREFIX.length);
+}
+
+export function isStoredToolPart(
+  part: UIMessagePart<UIDataTypes, UITools>,
+): part is StoredToolPart {
+  return (
+    toolPartName(part.type) !== undefined &&
+    "state" in part &&
+    part.state !== undefined &&
+    isToolPartState(part.state)
+  );
 }

--- a/packages/session/src/ui-messages/validate.test.ts
+++ b/packages/session/src/ui-messages/validate.test.ts
@@ -19,8 +19,8 @@ import {
 } from "@sidecar/wire";
 import { type ToolSet, tool } from "ai";
 import { z } from "zod";
-import { TOOL_PART_STATE } from "./tool-parts.js";
-import { isStoredToolPart, readStoredUIMessages, type StoredUIMessage } from "./validate.js";
+import { isStoredToolPart, TOOL_PART_STATE } from "./tool-parts.js";
+import { readStoredUIMessages, type StoredUIMessage } from "./validate.js";
 
 /** The shared fixtures beside the session vocabulary, plain JSON so another language's decoder reads the same files. */
 const FIXTURE_DIRECTORY = path.join(
@@ -89,6 +89,10 @@ function withMetadata(message: WireRecord, metadata: UnparsedWireValue): WireRec
 async function replyWithToolPart(part: WireRecord): Promise<WireRecord> {
   return { ...(await fixture(FIXTURE.REPLY_WITH_TOOL_PART)), parts: [part] };
 }
+
+test("no rows read back as no messages", async () => {
+  assert.deepEqual(await readStoredUIMessages([], TOOLS), { ok: true, value: [] });
+});
 
 test("each fixture round-trips through the wrapper unchanged", async () => {
   for (const name of Object.values(FIXTURE)) {

--- a/packages/session/src/ui-messages/validate.ts
+++ b/packages/session/src/ui-messages/validate.ts
@@ -15,16 +15,14 @@ import {
   type WireBoundaryInput,
 } from "@sidecar/wire";
 import {
-  isStaticToolUIPart,
   safeValidateUIMessages,
   type ToolSet,
-  type ToolUIPart,
   type UIDataTypes,
   type UIMessage,
   type UIMessagePart,
   type UITools,
 } from "ai";
-import { isToolPartState, type ToolPartState } from "./tool-parts.js";
+import { isStoredToolPart, toolPartName } from "./tool-parts.js";
 
 /**
  * A stored message as this build reads it back: the SDK's `UIMessage`, with
@@ -46,15 +44,6 @@ type StoredMessageOf<Role extends UIMessage["role"], Metadata> = Omit<
   "role" | "metadata"
 > & { role: Role; metadata: Metadata };
 
-/** A tool part in one of the states a stored row may carry. */
-export type StoredToolPart = Extract<ToolUIPart<UITools>, { state: ToolPartState }>;
-
-export function isStoredToolPart(
-  part: UIMessagePart<UIDataTypes, UITools>,
-): part is StoredToolPart {
-  return isStaticToolUIPart(part) && isToolPartState(part.state);
-}
-
 /**
  * What the SDK hands back before the metadata is read: a row it validated
  * structurally, whose metadata it passed through as it came off the wire.
@@ -62,9 +51,6 @@ export function isStoredToolPart(
 type ValidatedMessage = UIMessage<WireBoundaryInput>;
 
 type ValidationOptions = Parameters<typeof safeValidateUIMessages<ValidatedMessage>>[0];
-
-/** How the SDK spells a static tool part's type: the tool's name behind this prefix. */
-const TOOL_PART_TYPE_PREFIX = "tool-";
 
 /**
  * The type the SDK gives a tool part that names no registered tool. The SDK
@@ -90,8 +76,9 @@ function unregisteredToolPart(
       if (!isRecord(part) || !isWireString(part.type)) continue;
       const path: SchemaPath = [messageIndex, "parts", partIndex, "type"];
       if (part.type === DYNAMIC_TOOL_PART_TYPE) return path;
-      if (!part.type.startsWith(TOOL_PART_TYPE_PREFIX)) continue;
-      if (!Object.hasOwn(tools, part.type.slice(TOOL_PART_TYPE_PREFIX.length))) return path;
+      const name = toolPartName(part.type);
+      if (name === undefined) continue;
+      if (!Object.hasOwn(tools, name)) return path;
     }
   }
   return undefined;
@@ -103,7 +90,9 @@ function refusedPart(
 ): SchemaPath | undefined {
   for (const [partIndex, part] of parts.entries()) {
     if (part.type === DYNAMIC_TOOL_PART_TYPE) return ["parts", partIndex, "input"];
-    if (isStaticToolUIPart(part) && !isStoredToolPart(part)) return ["parts", partIndex, "state"];
+    if (toolPartName(part.type) !== undefined && !isStoredToolPart(part)) {
+      return ["parts", partIndex, "state"];
+    }
   }
   return undefined;
 }
@@ -138,13 +127,15 @@ function readStoredMessage(message: ValidatedMessage): SchemaRead<StoredUIMessag
  * declarations keyed by the name a part spells. Nothing here throws at a
  * value; a refusal is the same word and path a wire schema answers with, so a
  * store can tell a malformed row from one naming a tool this build no longer
- * registers.
+ * registers. A conversation with no rows yet reads as no messages: the SDK
+ * refuses an empty array, and an empty conversation is not a malformed one.
  */
 export async function readStoredUIMessages(
   messages: UnparsedWireValue,
   tools: ToolSet,
 ): Promise<SchemaRead<StoredUIMessage[]>> {
   if (!Array.isArray(messages)) return refuse(SCHEMA_REFUSAL.MALFORMED, []);
+  if (messages.length === 0) return { ok: true, value: [] };
   const unregistered = unregisteredToolPart(messages, tools);
   if (unregistered) return refuse(SCHEMA_REFUSAL.NOT_REGISTERED, unregistered);
   const validated = await safeValidateUIMessages<ValidatedMessage>({

--- a/packages/wire/src/conversation-event.test.ts
+++ b/packages/wire/src/conversation-event.test.ts
@@ -1,0 +1,15 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  CONVERSATION_EVENT_KIND,
+  type ConversationEventKind,
+  isSpeechEventKind,
+} from "./conversation-event.js";
+
+test("the speech kinds are every event kind but the rating", () => {
+  const kinds: ConversationEventKind[] = Object.values(CONVERSATION_EVENT_KIND);
+  assert.equal(kinds.length, 7);
+  for (const kind of kinds) {
+    assert.equal(isSpeechEventKind(kind), kind !== CONVERSATION_EVENT_KIND.RATING);
+  }
+});

--- a/packages/wire/src/conversation-event.ts
+++ b/packages/wire/src/conversation-event.ts
@@ -1,0 +1,27 @@
+/**
+ * The low-volume facts recorded about a message beside it, each an event row
+ * of its own: how a briefing's delivery went, from the offer `announce` wrote
+ * through a device's claim to the spoken, pushed, or expired end, held while
+ * a device reports quiet; and a rating the developer gave a message. The
+ * speech kinds are read together — the latest of them on an announcement is
+ * what says whether it was ever heard — so they are told from the rating.
+ */
+
+export const CONVERSATION_EVENT_KIND = {
+  SPEECH_OFFERED: "speech.offered",
+  SPEECH_CLAIMED: "speech.claimed",
+  SPEECH_SPOKEN: "speech.spoken",
+  SPEECH_PUSHED: "speech.pushed",
+  SPEECH_EXPIRED: "speech.expired",
+  SPEECH_HELD: "speech.held",
+  RATING: "rating",
+} as const;
+
+export type ConversationEventKind =
+  (typeof CONVERSATION_EVENT_KIND)[keyof typeof CONVERSATION_EVENT_KIND];
+
+export type SpeechEventKind = Exclude<ConversationEventKind, typeof CONVERSATION_EVENT_KIND.RATING>;
+
+export function isSpeechEventKind(kind: ConversationEventKind): kind is SpeechEventKind {
+  return kind !== CONVERSATION_EVENT_KIND.RATING;
+}

--- a/packages/wire/src/index.ts
+++ b/packages/wire/src/index.ts
@@ -9,6 +9,12 @@ export {
   type UnknownActionResult,
 } from "./action-result.js";
 export { type Admitted, reshapeAdmitted } from "./admitted.js";
+export {
+  CONVERSATION_EVENT_KIND,
+  type ConversationEventKind,
+  isSpeechEventKind,
+  type SpeechEventKind,
+} from "./conversation-event.js";
 export { Emitter, type Event } from "./event.js";
 export {
   type CloudFetch,
@@ -74,6 +80,12 @@ export {
   type TextOptions,
   type TextOverflow,
 } from "./schema.js";
+export {
+  TURN_ORIGIN,
+  TURN_STATUS,
+  type TurnOrigin,
+  type TurnStatus,
+} from "./turn.js";
 export {
   ASSISTANT_MESSAGE_METADATA,
   type AssistantMessageMetadata,

--- a/packages/wire/src/turn.ts
+++ b/packages/wire/src/turn.ts
@@ -1,0 +1,29 @@
+/**
+ * What a turn row says about the run it records: what opened it and where it
+ * stands. Every trigger the brain answers to is a queued turn — a developer's
+ * typed or spoken ask, a roster diff, a hold's release, a child's completion —
+ * and the origin is the record of which, so a view can mark an action Luke
+ * took on his own judgment apart from one the developer asked for. Declared
+ * here so the store that writes the row, the service that answers it, and the
+ * clients that fold a turn by it all spell the same words.
+ */
+
+export const TURN_ORIGIN = {
+  TYPED: "typed",
+  SPOKEN: "spoken",
+  ROSTER_DIFF: "roster_diff",
+  HOLD_RELEASE: "hold_release",
+  CHILD: "child",
+} as const;
+
+export type TurnOrigin = (typeof TURN_ORIGIN)[keyof typeof TURN_ORIGIN];
+
+export const TURN_STATUS = {
+  QUEUED: "queued",
+  RUNNING: "running",
+  SETTLED: "settled",
+  CANCELLED: "cancelled",
+  FAILED: "failed",
+} as const;
+
+export type TurnStatus = (typeof TURN_STATUS)[keyof typeof TURN_STATUS];


### PR DESCRIPTION
## What

The Conversation view's selection, as a pure function in `@sidecar/session` with fixtures and no consumer yet (D1 of the LUKE-95 storage rework; D2 applies it server-side, E1/E2 and F1 draw its output).

`selectConversationView(input)` takes main's stored messages, each observed conversation's stored messages, the turn rows, the `speech.*` event rows, and a tool classification, and answers turn groups ordered by time:

- **Main's messages in full**, each grouped under its `turn_id`, in sequence within the group. A compaction row is the one exception: it stands in for messages the view still shows, so drawing it would show the developer a summary beside the rows it summarizes.
- **From an observed conversation, only assistant messages carrying an `announce` part or an action part**, and the message crosses *cut to those parts*: its observation note, transcript reads, reasoning, and text never cross. A turn that decided nothing is not shown at all. This is the projection CLAUDE.md's rule ("only announcements and actions cross into the developer's view, by projection, never by a mirrored row") needs.
- Each shown message carries one `tools` entry per tool part, in part order, with the fact the renderers key off: an `announce` part carries `unspoken`, true when the latest `speech.*` event on that message is `speech.expired`; an action part carries `refused`, true when the part is in `output-error` (included, drawn only inside the expanded turn); every other tool is a `detail`, drawn collapsed.
- Groups sort by the earliest message's `createdAt`, then the turn's `queuedAt`, then the turn id by code point, so two devices computing the same rows agree on one order. A message whose turn row is missing is still shown, with `turn: undefined`. An observed turn whose only action was refused still crosses, with the refusal flagged, since the turn that tried it is shown.

Vocabulary added to `@sidecar/wire`, since the store writer (B1/B2) and the clients will spell the same words: `TURN_ORIGIN` and `TURN_STATUS` exactly as the plan's `turns` schema spells them, `CONVERSATION_EVENT_KIND` (the plan's seven kinds), and `isSpeechEventKind`. The brain's existing `BRAIN_TURN_TRIGGER` spells its triggers differently; the one exhaustive mapping onto `TURN_ORIGIN` belongs with the writer (C2), not here.

## Why the classification is an input

The plan says read tools draw collapsed "keyed off the catalog's act / read / write flag". That flag lives in the brain catalog (`packages/brain`, over `@sidecar/runtime`'s `TOOL_EFFECT`), and the action tool names live in `@sidecar/actions`; both are above `packages/session` in the acyclic graph. So the selection takes a `ReadonlyMap<toolName, announce | action>` and the caller (D2) builds it from `brainToolCatalog()` (`TOOL_GROUP.SPEAK` → announce, `TOOL_GROUP.ACTIONS` → action). A tool the caller did not classify is a `detail`: collapsed, never a row, and never a reason for an observed message to cross. That is fail-closed for the trust rule and is asserted by a test. `packages/AGENTS.md` records the arrangement.

## Two small changes to A1's reader

- `StoredToolPart`, `isStoredToolPart`, and a new `storedToolName`/`toolPartName` moved from `@sidecar/session/ui-messages` to `tool-parts.ts` on the session barrel, implemented without the SDK's runtime `isStaticToolUIPart`, so the selection can walk tool parts while the barrel still reaches `ai` for its types alone. The `ui-messages` door keeps `readStoredUIMessages` and `StoredUIMessage`; nothing but A1's own test imported the moved names.
- `readStoredUIMessages([])` now answers `{ ok: true, value: [] }`. The SDK's `validateUIMessages` refuses an empty array (`too_small`), so an empty conversation read back as *malformed*, which D2 would have hit on a fresh account. Tested.

Stored messages in this PR are read only in tests, through `readStoredUIMessages` (the registry pre-check), never `validateUIMessages` directly. Every fixture row is read back through it before the selection sees it, so the fixtures are proven to be the shape the store reads back.

## Rebase onto B1/B2 and A7

- B1 (#924) declared `TURN_ORIGIN`, `TURN_STATUS`, and `EVENT_KIND` locally in `apps/web/server/db/storage-schema.ts` with the same strings. A wire value's rules are declared once, so the schema now imports `TurnOrigin`, `TurnStatus`, and `CONVERSATION_EVENT_KIND` from `@sidecar/wire` and its test imports the constants from there; the migration and the row types are unchanged.
- A7 (#925) imported `isStoredToolPart` and `StoredToolPart` from the `ui-messages` door; `packages/brain/src/ui-message-context.ts` now takes them from the `@sidecar/session` barrel where this PR puts them.

## Decisions worth a second look

- **Refused = `output-error` only**, as the ticket says. An `output-available` part whose A2 envelope says `status: refused` is drawn as a row and worded from the envelope by the renderer; `packages/session` cannot read `ACTION_OUTPUT_STATUS` without a cycle, and the plan has the writer put refusals in `output-error`. If both shapes can occur, the collapse rule should move to wherever the envelope is readable.
- **Compaction rows of main are excluded** (see above); the ticket's "in full" did not mention them.
- **System-role rows of main are shown**, since the plan lists `system` as a stored role and "in full" covers them; nothing writes one today.
- The output stays TypeScript types in `@sidecar/session`; the wire shape of D2's `messages?after=` answer is D2's to declare.

## CLAUDE.md sentences this contradicts (for G5)

- "What the brain keeps is one generation per conversation, in one database under one writer… beside each conversation's own lines" and "what the panel draws is a projection over that record, the 200 most recent lines" (Storage, retention, and conversation maintenance; The conversation…): the view is a projection over UIMessage rows, turns, and events, not over `ConversationEntry` lines.
- "A Conversation line records the actions Luke carried and the sessions they named" (Acts on a session): an action is now a tool part of an assistant message with the A2 envelope, selected here rather than written as a line.

## Verify

```
./scripts/check.sh
pnpm --filter @sidecar/session --filter @sidecar/wire test
```

No macOS or UI code is touched, so `verify.sh` does not apply.

## Reviews

Ran Cursor's `thermo-nuclear-code-quality-review` (cursor/plugins, cursor-team-kit) and `ponytail-review` (DietrichGebert/ponytail) over the diff, as their SKILL.md files instruct; findings and what changed are listed below.

**Ponytail review** (12 findings, 11 applied): dropped the derivable `display` field and its value set, `ROW_KINDS`, the `SelectedRow` wrapper, the hand-listed `SPEECH_EVENT_KINDS` set, a redundant type-annotation test, a spelling-only test of `TURN_ORIGIN`, and a one-line helper; narrowed the classification map to `announce | action`; simplified the missing-turn comparator. **Rejected one:** restoring the SDK's runtime `isStaticToolUIPart`/`getToolName` in `tool-parts.ts`, because that module is on the session barrel, which reaches `ai` for its types alone (`packages/AGENTS.md`); the prefix rule is restated with a comment saying exactly that.

**Thermo-nuclear review** (3 must-fix, 5 structural, 8 test findings). Applied: one grouping pass over rows tagged with their source instead of a partially applied `groupByTurn` per conversation; the group's instant computed once rather than on every comparison; code-point ordering instead of `localeCompare` so the service and a client agree; the "why not the SDK predicate" comment; a test for an observed turn whose only action was refused (it crosses, flagged); the ask asserted whole by reference; the whole input snapshotted in the immutability test; `FixtureFile` typed by the real row types; one `expectOk` helper; the fixture reads in one `Promise.all`; the acted fixture's observation source corrected to match its `hold_release` turn. **Rejected two, deliberately:** renaming `unspoken` (the ticket names the mark and defines it as "latest `speech.*` event is `expired`"; the doc comment now says exactly that, including that a pushed or held briefing is not unspoken and that all announce parts of one message share the mark since events hang on the message); and adding a `hook` turn origin (the plan's `turns` schema has five origins and the hosted brain is woken by cron roster diffs, not local hooks; a change there is a schema decision for the orchestrator). Not done: hoisting one shared test tool registry across the two session test files, since A1's fixture spells `read_transcript`'s input in camelCase and changing it is A1's scope.

## Test results

`./scripts/check.sh`: exit 0 (repository checks, Biome, oxlint, typecheck, tests, builds).
`@sidecar/session`: 117 tests pass, 0 fail (29 in the new `conversation-view.test.ts`, covering the six acceptance cases: typed ask, spoken ask, observation that announced, observation that acted, observation that did nothing, child completion; plus expiry, ordering and tie-break, compaction exclusion, missing turn row, unknown tool, only-refused action, and input immutability).
`@sidecar/wire`: 74 tests pass, 0 fail.
`verify.sh` not run: no macOS or UI code is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34537930562/artifacts/10176217557) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34537930562)

- Commit: `0968769e0f0c5fc996b95a47260cd20422c11692`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
