### PR TITLE
chore: collapse generated files in GitHub diffs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,10 @@
+# Collapse generated files in GitHub PR diffs (linguist-generated).
+# SQL migrations stay unmarked so they remain the reviewable change.
+
+apps/web/drizzle/meta/** linguist-generated
+
+packages/surface/src/generated/** linguist-generated
+packages/surface/src/generated/*.test.ts -linguist-generated
+
+apps/desktop/src/renderer/styles/generated/** linguist-generated
+apps/desktop/src/renderer/styles/generated/*.test.ts -linguist-generated


### PR DESCRIPTION
## Summary

- Mark Drizzle schema snapshots and committed surface/desktop codegen as `linguist-generated` so GitHub collapses those files in PR diffs by default.
- Leave SQL migrations and tests next to generated files unmarked so they stay reviewable.

This does not change the PR header +/− count; GitHub has no setting for that.

## Evidence

- Platform-independent checks: `CI`
- macOS Electron verification (`./scripts/verify.sh`): `not run` (no app or UI change)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34536939685/artifacts/10175838859) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34536939685)

- Commit: `aabbeafc175c76d0e26fde7721014bf3e30b3047`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

### Physical-device evidence

- Screenshot or screen recording: `not attached`
- Physical-notch check: `not performed`
- Device/display configuration: `not recorded`

## Notes

- No runtime or product behavior change.


Made with [Cursor](https://cursor.com)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/264ff843-ade9-4505-9367-e711055ace03)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)