### PR TITLE
refactor(LUKE-113): action tools as modules

### DIFF
--- a/packages/AGENTS.md
+++ b/packages/AGENTS.md
@@ -34,6 +34,24 @@ listener's unsubscribe, a watcher's teardown, and the store that ends both are
 one shape wherever they are held, and adopting it adds no edge: every package
 but `packages/panel` already depends on wire.
 
+The brain's tools are modules under `packages/brain/src/tools/`, each
+declaring its `description`, its `inputSchema` (the wire `Schema` its fields
+are declared in once, which parses a call and emits what the model is shown;
+the AI SDK's `tool()` takes it through `jsonSchema()`), and one
+`execute(input, ctx)`, where `ctx` carries the conversation, the turn, the
+run, who opened it, and the abort signal — the shape eve's `defineTool` and
+the AI SDK's `tool()` both take. An action tool's `execute` is the whole
+gauntlet: `admit()` first, over the readers the host hands it in `ctx`
+(admission reads the roster for itself through them and is never handed a
+copy), then `ctx.carry`, which takes only the `ValidatedAction` admission
+minted, so nothing reaches a carrier without admission having run. A module
+imports the packages below the brain and its own directory and nothing else
+of the brain; `repository-checks.sh` refuses a relative import that leaves
+the directory, so a tool stays readable, testable, and movable without the
+agent that runs it. The catalog and the effective tool policy are unchanged
+by this: the policy still fixes both the schemas a turn is offered and the
+gate every emitted call meets at dispatch.
+
 ## The graph is acyclic, and stays that way
 
 Every package declares exactly the packages its own sources reach by bare

--- a/packages/brain/src/acceptance.test.ts
+++ b/packages/brain/src/acceptance.test.ts
@@ -3,7 +3,12 @@ import { promises as fs } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
-import { type ActionOutputEnvelope, acceptedActionOutput, REALTIME_TOOL } from "@sidecar/actions";
+import {
+  ACTION_KIND,
+  type ActionOutputEnvelope,
+  acceptedActionOutput,
+  REALTIME_TOOL,
+} from "@sidecar/actions";
 import {
   HOSTED_BRAIN_CONTRACT_VERSION,
   HOSTED_BRAIN_OPERATION,
@@ -73,7 +78,11 @@ import {
 } from "./requests.js";
 import { ToolLoopAgentRuntime } from "./runtime.js";
 import { BrainStateStore } from "./state-store.js";
-import { type FakeBrainStateRepository, fakeBrainStateRepository } from "./testing.js";
+import {
+  type FakeBrainStateRepository,
+  fakeActionPerformer,
+  fakeBrainStateRepository,
+} from "./testing.js";
 import { brainToolCatalog, hostedBrainToolCatalog, resolveTurnToolPolicy } from "./tools.js";
 import { BRAIN_TURN_KIND, runOriginOf } from "./turn.js";
 import { BRAIN_WAKE_KIND } from "./wake-events.js";
@@ -289,18 +298,20 @@ function host(
     title: "Claude Code: abc",
     status: SESSION_STATUS.WAITING,
     lastActivityAt: NOW,
+    advertises: [{ kind: ACTION_KIND.MESSAGE }],
   });
   const agent = new BrainAgent({
     conversationId: MAIN_SESSION_KEY,
     runtime: runtimeOver(model),
     observes: { kind: LOOK_SUBJECT.NONE },
     prepareTurn: () => ({ prompt: "instructions", layers: {} }),
-    actions: {
-      perform: async (call) => {
-        performed.push(call.name);
+    actions: fakeActionPerformer({
+      sessions: [session],
+      carry: async (action) => {
+        performed.push(action.kind);
         return performer();
       },
-    },
+    }).actions,
     roster: () => ({ text: "- abc", identities: [ABC], sessions: session ? [session] : [] }),
     standingContext: () => "Durable facts: none.",
     readTranscriptSince: async () => ({
@@ -354,10 +365,7 @@ for (const transport of [KEYED, HOSTED]) {
     assert.equal(record?.status, BRAIN_REQUEST_STATUS.SUCCEEDED);
     assert.equal(record?.text, "Sent twice.");
     assert.equal(record?.performedActions, 2);
-    assert.deepEqual(h.performed, [
-      REALTIME_TOOL.SEND_SESSION_MESSAGE,
-      REALTIME_TOOL.SEND_SESSION_MESSAGE,
-    ]);
+    assert.deepEqual(h.performed, [ACTION_KIND.MESSAGE, ACTION_KIND.MESSAGE]);
     // The third inference replayed every encrypted reasoning item and every
     // call with its output, in order.
     const third = upstream.calls[2]?.body.input;
@@ -623,7 +631,7 @@ test("a runtime that is not Responses drives the same host: actions journaled th
   assert.equal(record?.status, BRAIN_REQUEST_STATUS.SUCCEEDED);
   assert.equal(record?.text, "scripted reply after 3 tools");
   assert.equal(record?.performedActions, 1);
-  assert.deepEqual(h.performed, [REALTIME_TOOL.SEND_SESSION_MESSAGE]);
+  assert.deepEqual(h.performed, [ACTION_KIND.MESSAGE]);
   const stored = repository.state;
   assert.equal(stored?.checkpointFormat, "scripted@3:scripted-turns/1");
   assert.ok(stored?.items.every((item) => "scripted" in item));
@@ -647,7 +655,7 @@ test("a runtime that is not Responses drives the same host: actions journaled th
   o.clock.now += 3_000;
   for (const timer of [...o.clock.timers.values()]) timer.callback();
   await settle();
-  assert.deepEqual(o.performed, [REALTIME_TOOL.SEND_SESSION_MESSAGE]);
+  assert.deepEqual(o.performed, [ACTION_KIND.MESSAGE]);
   assert.equal(repository.state?.cursors[claude.id]?.abc, "c1");
   assert.equal(repository.state?.journal.length, 1, "the ask's journal alone stays");
   await o.agent.stop();

--- a/packages/brain/src/agent-flush.test.ts
+++ b/packages/brain/src/agent-flush.test.ts
@@ -30,7 +30,11 @@ import {
 import { type ResponsesInputItem, responsesModelAnswer } from "./responses-api.js";
 import { ToolLoopAgentRuntime } from "./runtime.js";
 import { BrainStateStore } from "./state-store.js";
-import { type FakeBrainStateRepository, fakeBrainStateRepository } from "./testing.js";
+import {
+  type FakeBrainStateRepository,
+  fakeActionPerformer,
+  fakeBrainStateRepository,
+} from "./testing.js";
 
 /**
  * The flush before compaction, at the host: a small window makes the soft
@@ -156,7 +160,7 @@ function agentWith(
     runtime,
     observes: { kind: LOOK_SUBJECT.NONE },
     prepareTurn: () => ({ prompt: "flush test", layers: {} }),
-    actions: { perform: async () => ({ status: ACTION_RESULT_STATUS.ACCEPTED }) },
+    actions: fakeActionPerformer().actions,
     roster: () => ({ text: "", identities: [] }),
     standingContext: () => "",
     readTranscriptSince: async () => ({ status: ACTION_RESULT_STATUS.REJECTED, reason: "no" }),

--- a/packages/brain/src/agent.test.ts
+++ b/packages/brain/src/agent.test.ts
@@ -1,11 +1,12 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import {
+  ACTION_KIND,
   type ActionOutputEnvelope,
   acceptedActionOutput,
   REALTIME_TOOL,
-  type RealtimeFunctionCall,
   refusedActionOutput,
+  type ValidatedAction,
 } from "@sidecar/actions";
 import { RESPONSES_INPUT_ITEM_TYPE } from "@sidecar/hosted";
 import { TOOL_LOOP_RUNTIME } from "@sidecar/runtime";
@@ -51,6 +52,7 @@ import {
   NOW,
   OBSERVATION_ACTIONS,
   OLD_SECRET,
+  performerWith,
   quietAnswer,
   reasoning,
   reviewing,
@@ -58,7 +60,7 @@ import {
   settle,
   submit,
 } from "./harness.js";
-import type { BrainActionExecution, BrainActionPerformer } from "./performer.js";
+import type { BrainActionExecution } from "./performer.js";
 import {
   BRAIN_REQUEST_FAILURE,
   BRAIN_REQUEST_ORIGIN,
@@ -134,14 +136,7 @@ test("an ask returns the final text, carries pending wakes, and refuses announce
   assert.equal(answer?.performedActions, 1);
   assert.deepEqual(h.deliveries, []);
   assert.deepEqual(h.performed, [
-    {
-      name: "send_session_message",
-      argumentsJson: JSON.stringify({
-        provider_id: ABC.providerId,
-        provider_session_id: ABC.providerSessionId,
-        text: "run the tests",
-      }),
-    },
+    { kind: ACTION_KIND.MESSAGE, identity: ABC, text: "run the tests", origin: RUN_ORIGIN.USER },
   ]);
   assert.equal(h.agent.pendingWakes(), 0);
   assert.equal(h.clock.timers.size, 0);
@@ -426,15 +421,13 @@ test("a developer ask carries every action with a live execution, revoked once t
     release = resolve;
   });
   const h = harness({
-    actions: {
-      perform: async (functionCall, execution): Promise<ActionOutputEnvelope> => {
-        performedLate.push({ call: functionCall, execution });
-        await held;
-        return execution.isRevoked() ? refusedActionOutput("turn over") : acceptedActionOutput();
-      },
-    },
+    actions: performerWith(async (action, execution): Promise<ActionOutputEnvelope> => {
+      performedLate.push({ action, execution });
+      await held;
+      return execution.isRevoked() ? refusedActionOutput("turn over") : acceptedActionOutput();
+    }).actions,
   });
-  const performedLate: { call: RealtimeFunctionCall; execution: BrainActionExecution }[] = [];
+  const performedLate: { action: ValidatedAction; execution: BrainActionExecution }[] = [];
   const [messageAction] = OBSERVATION_ACTIONS;
   assert.ok(messageAction);
   h.client.answers.push(answered([messageAction]), answered([message("Done.")]));
@@ -581,7 +574,7 @@ test("a repeated call id answers the recorded result once; the same id with othe
   const record = await ask(h, "send");
   assert.equal(record?.status, BRAIN_REQUEST_STATUS.SUCCEEDED);
   assert.deepEqual(
-    h.performed.map((functionCall) => JSON.parse(functionCall.argumentsJson).text),
+    h.performed.map((action) => (action.kind === ACTION_KIND.MESSAGE ? action.text : action.kind)),
     ["one", "two"],
   );
   const outputs = functionOutputs(h.client.inputs[2] ?? []);
@@ -594,14 +587,13 @@ test("actions run one at a time in the order the model emitted them", async () =
   const held = heldPerformer();
   const order: string[] = [];
   const h = harness({
-    actions: {
-      perform: async (functionCall, execution) => {
-        order.push(`start ${JSON.parse(functionCall.argumentsJson).text}`);
-        const output = await held.actions.perform(functionCall, execution);
-        order.push(`end ${JSON.parse(functionCall.argumentsJson).text}`);
-        return output;
-      },
-    },
+    actions: performerWith(async (action, execution) => {
+      const words = action.kind === ACTION_KIND.MESSAGE ? action.text : action.kind;
+      order.push(`start ${words}`);
+      const output = await held.actions.carry(action, execution);
+      order.push(`end ${words}`);
+      return output;
+    }).actions,
   });
   h.client.answers.push(
     answered([messageAction("c1", "a"), messageAction("c2", "b"), messageAction("c3", "c")]),
@@ -1048,16 +1040,14 @@ test("a Clear or expiry asked for while a write is out on disk revokes a held ac
   for (const ending of ["clear", "expiry"] as const) {
     let releasePreparation: (() => void) | undefined;
     let effects = 0;
-    const actions: BrainActionPerformer = {
-      perform: async (_call, execution): Promise<ActionOutputEnvelope> => {
-        await new Promise<void>((resolve) => {
-          releasePreparation = resolve;
-        });
-        if (execution.isRevoked()) return refusedActionOutput("revoked before the effect");
-        effects += 1;
-        return acceptedActionOutput();
-      },
-    };
+    const { actions } = performerWith(async (_action, execution): Promise<ActionOutputEnvelope> => {
+      await new Promise<void>((resolve) => {
+        releasePreparation = resolve;
+      });
+      if (execution.isRevoked()) return refusedActionOutput("revoked before the effect");
+      effects += 1;
+      return acceptedActionOutput();
+    });
     const h = harness({ actions });
     const generationClock = new BrainGenerationClock({
       store: h.store,

--- a/packages/brain/src/compaction.test.ts
+++ b/packages/brain/src/compaction.test.ts
@@ -41,7 +41,11 @@ import {
 import { BRAIN_RUN_EVENT, type BrainRunEvent } from "./run-events.js";
 import { ToolLoopAgentRuntime } from "./runtime.js";
 import { BrainStateStore } from "./state-store.js";
-import { type FakeBrainStateRepository, fakeBrainStateRepository } from "./testing.js";
+import {
+  type FakeBrainStateRepository,
+  fakeActionPerformer,
+  fakeBrainStateRepository,
+} from "./testing.js";
 import { RecordingContextEngine } from "./transcript-recorder.js";
 
 /**
@@ -333,7 +337,7 @@ function agentOver(model: ModelAdapter, repository: FakeBrainStateRepository) {
     runtime,
     observes: { kind: LOOK_SUBJECT.NONE },
     prepareTurn: () => ({ prompt: "instructions", layers: {} }),
-    actions: { perform: async () => ({ status: ACTION_RESULT_STATUS.ACCEPTED }) },
+    actions: fakeActionPerformer().actions,
     roster: () => ({ text: "none", identities: [] }),
     standingContext: () => "",
     readTranscriptSince: async () => ({ status: ACTION_RESULT_STATUS.UNSUPPORTED, reason: "n" }),

--- a/packages/brain/src/harness.ts
+++ b/packages/brain/src/harness.ts
@@ -1,13 +1,13 @@
 import assert from "node:assert/strict";
 import {
+  ACTION_KIND,
   ACTION_OUTPUT,
   ACTION_OUTPUT_STATUS,
-  type ActionOutputEnvelope,
   acceptedActionOutput,
   REALTIME_TOOL,
-  type RealtimeFunctionCall,
   realtimeToolFamily,
   refusedActionOutput,
+  type ValidatedAction,
 } from "@sidecar/actions";
 import { RESPONSES_INPUT_ITEM_TYPE } from "@sidecar/hosted";
 import { notebookMemoryProvider } from "@sidecar/memory";
@@ -57,7 +57,14 @@ import {
 import { type ResponsesInputItem, responsesModelAnswer } from "./responses-api.js";
 import { ToolLoopAgentRuntime } from "./runtime.js";
 import { BrainStateStore } from "./state-store.js";
-import { type FakeBrainStateRepository, fakeBrainStateRepository } from "./testing.js";
+import {
+  CAPTIONS_GUIDE,
+  type FakeActionPerformerOptions,
+  type FakeBrainStateRepository,
+  fakeActionPerformer,
+  fakeBrainStateRepository,
+  performCall,
+} from "./testing.js";
 import { BRAIN_TOOL, TOOL_GROUP } from "./tools.js";
 import type { BrainTurnTraceRecord } from "./trace.js";
 import { REFUSAL_REASON } from "./turn.js";
@@ -100,8 +107,21 @@ export function session(id: string, overrides: Partial<ProviderSessionObservatio
     title: `Claude Code: ${id}`,
     status: SESSION_STATUS.WAITING,
     lastActivityAt: NOW,
+    advertises: [{ kind: ACTION_KIND.MESSAGE }],
+    detail: { link: `https://sessions.example.test/${id}` },
     ...overrides,
   });
+}
+
+/** The two sessions the harness roster holds, as admission reads them. */
+const HARNESS_SESSIONS: readonly Session[] = [
+  session(ABC.providerSessionId),
+  session(DEF.providerSessionId),
+];
+
+/** A performer over the harness roster and guide whose carrier the test chooses. */
+export function performerWith(carry: FakeActionPerformerOptions["carry"]) {
+  return fakeActionPerformer({ sessions: HARNESS_SESSIONS, guide: CAPTIONS_GUIDE, carry });
 }
 
 export function edge(identity: SessionIdentity, atMs = NOW): BrainWakeEvent {
@@ -297,7 +317,7 @@ export interface Harness {
   store: BrainStateStore;
   deliveries: BrainDelivery[];
   persisted: BrainPersistedState[];
-  performed: RealtimeFunctionCall[];
+  performed: ValidatedAction[];
   executions: BrainActionExecution[];
   traces: BrainTurnTraceRecord[];
   sinceReads: { identity: SessionIdentity; cursor: string | undefined }[];
@@ -345,18 +365,12 @@ export function harness(
     createGenerationId: () => `gen-${nextRunId()}`,
     now: () => clock.now,
   });
-  const performed: RealtimeFunctionCall[] = [];
-  const executions: BrainActionExecution[] = [];
   const traces: BrainTurnTraceRecord[] = [];
   const sinceReads: Harness["sinceReads"] = [];
   const wholeReads: SessionIdentity[] = [];
-  const actions: BrainActionPerformer = agentOverrides.actions ?? {
-    perform: async (functionCall, execution) => {
-      performed.push(functionCall);
-      executions.push(execution);
-      return { status: ACTION_RESULT_STATUS.ACCEPTED };
-    },
-  };
+  const fake = performerWith(undefined);
+  const { performed, executions } = fake;
+  const actions: BrainActionPerformer = agentOverrides.actions ?? fake.actions;
   // The notebook as the host wires it, over no index and an empty notebook,
   // so the two writes reach the performer under test like every other action.
   const scope = { kind: MEMORY_SCOPE_KIND.ACCOUNT, key: DEFAULT_AGENT_ID };
@@ -373,7 +387,12 @@ export function harness(
         access: undefined,
         facts: () => [],
         recentNotes: async () => [],
-        perform: (functionCall, execution) => actions.perform(functionCall, execution),
+        perform: (call, context) =>
+          performCall(actions, call, {
+            ...context,
+            conversationId: MAIN_SESSION_KEY,
+            turnId: context.runId,
+          }),
       }),
     },
     roster: () => ({ text: "Currently observed sessions:\n- abc\n- def", identities: [ABC, DEF] }),
@@ -576,18 +595,12 @@ export function messageAction(callId: string, words = "run the tests"): WireReco
 /** A performer whose actions hold until the test releases each one, in order. */
 export function heldPerformer() {
   const releases: (() => void)[] = [];
-  const performed: RealtimeFunctionCall[] = [];
-  const executions: BrainActionExecution[] = [];
-  const actions: BrainActionPerformer = {
-    perform: async (functionCall, execution): Promise<ActionOutputEnvelope> => {
-      performed.push(functionCall);
-      executions.push(execution);
-      await new Promise<void>((resolve) => {
-        releases.push(resolve);
-      });
-      return execution.isRevoked() ? refusedActionOutput("turn over") : acceptedActionOutput();
-    },
-  };
+  const { actions, performed, executions } = performerWith(async (_action, execution) => {
+    await new Promise<void>((resolve) => {
+      releases.push(resolve);
+    });
+    return execution.isRevoked() ? refusedActionOutput("turn over") : acceptedActionOutput();
+  });
   return { actions, releases, performed, executions };
 }
 
@@ -686,7 +699,7 @@ export function agentOn(runtime: ToolLoopAgentRuntime, h: Harness) {
     runtime,
     prepareTurn: PLAIN_PREPARATION,
     observes: { kind: LOOK_SUBJECT.NONE },
-    actions: { perform: async () => ({ status: ACTION_RESULT_STATUS.ACCEPTED }) },
+    actions: fakeActionPerformer().actions,
     roster: () => ({ text: "", identities: [] }),
     standingContext: () => "",
     readTranscriptSince: async () => ({ status: ACTION_RESULT_STATUS.REJECTED, reason: "no" }),

--- a/packages/brain/src/index.ts
+++ b/packages/brain/src/index.ts
@@ -98,6 +98,14 @@ export {
 export { BrainStateStore } from "./state-store.js";
 export type { BrainChildAccess } from "./tool-executor.js";
 export {
+  ACTION_TOOLS,
+  type ActionAdmissionReads,
+  type ActionToolContext,
+  type ActionToolModule,
+  actionToolNamed,
+} from "./tools/action-tools.js";
+export { type ToolContext, type ToolModule, toolArguments } from "./tools/tool-module.js";
+export {
   BRAIN_TOOL,
   brainToolCatalog,
   hostedBrainToolCatalog,

--- a/packages/brain/src/journal.test.ts
+++ b/packages/brain/src/journal.test.ts
@@ -15,6 +15,7 @@ import {
   messageAction,
   NOW,
   OBSERVATION_ACTIONS,
+  performerWith,
   settle,
   submit,
 } from "./harness.js";
@@ -71,9 +72,7 @@ test("an observation turn's run id never repeats across a rebuild, and a journal
 
 test("a performer that throws after dispatch leaves an unknown action, kept through a later model failure and a restart", async () => {
   const h = harness({
-    actions: {
-      perform: () => Promise.reject(new Error("socket closed after send")),
-    },
+    actions: performerWith(() => Promise.reject(new Error("socket closed after send"))).actions,
   });
   h.client.answers.push(answered([messageAction("call_1")]), failedAnswer("network"));
   const record = await ask(h, "send it");
@@ -88,9 +87,7 @@ test("a performer that throws after dispatch leaves an unknown action, kept thro
 
   // A confirmed refusal, by contrast, is a refusal: nothing unknown about it.
   const refusing = harness({
-    actions: {
-      perform: async () => refusedActionOutput("not observed"),
-    },
+    actions: performerWith(async () => refusedActionOutput("not observed")).actions,
   });
   refusing.client.answers.push(
     answered([messageAction("call_1")]),

--- a/packages/brain/src/ledger.test.ts
+++ b/packages/brain/src/ledger.test.ts
@@ -37,6 +37,7 @@ import {
   NOW,
   nextRunId,
   PLAIN_PREPARATION,
+  performerWith,
   RECORD_CAP,
   runtimeOver,
   seededRequests,
@@ -55,7 +56,11 @@ import {
   isTerminalBrainRequestStatus,
 } from "./requests.js";
 import { BrainStateStore } from "./state-store.js";
-import { type FakeBrainStateRepository, fakeBrainStateRepository } from "./testing.js";
+import {
+  type FakeBrainStateRepository,
+  fakeActionPerformer,
+  fakeBrainStateRepository,
+} from "./testing.js";
 
 /**
  * The ledger's own guarantees: an acceptance nobody hears of until its record
@@ -98,14 +103,12 @@ test("a checkpoint that fails after an action keeps its result in memory, blocks
   let acted = 0;
   let repository: FakeBrainStateRepository | undefined;
   const h = harness({
-    actions: {
-      perform: async (): Promise<ActionOutputEnvelope> => {
-        acted += 1;
-        // The disk goes away from the moment the first effect has happened.
-        repository?.refuse();
-        return acceptedActionOutput();
-      },
-    },
+    actions: performerWith(async (): Promise<ActionOutputEnvelope> => {
+      acted += 1;
+      // The disk goes away from the moment the first effect has happened.
+      repository?.refuse();
+      return acceptedActionOutput();
+    }).actions,
   });
   repository = h.repository;
   h.client.answers.push(
@@ -268,7 +271,7 @@ test("stop settles only after a held acceptance, which the successor then finds 
     runtime: runtimeOver(successorModel),
     observes: { kind: LOOK_SUBJECT.NONE },
     prepareTurn: PLAIN_PREPARATION,
-    actions: { perform: async () => ({ status: ACTION_RESULT_STATUS.ACCEPTED }) },
+    actions: fakeActionPerformer().actions,
     roster: () => ({ text: "", identities: [] }),
     standingContext: () => "",
     readTranscriptSince: async () => ({ status: ACTION_RESULT_STATUS.REJECTED, reason: "no" }),
@@ -330,16 +333,14 @@ test("a copy taken before the second model answer already carries the actions th
   const held = heldPerformer();
   let dispatched = 0;
   const mixed = harness({
-    actions: {
-      perform: (functionCall, execution) => {
-        dispatched += 1;
-        if (dispatched === 1) return Promise.reject(new Error("socket closed after send"));
-        if (dispatched === 2) {
-          return Promise.resolve(refusedActionOutput("not observed"));
-        }
-        return held.actions.perform(functionCall, execution);
-      },
-    },
+    actions: performerWith((action, execution) => {
+      dispatched += 1;
+      if (dispatched === 1) return Promise.reject(new Error("socket closed after send"));
+      if (dispatched === 2) {
+        return Promise.resolve(refusedActionOutput("not observed"));
+      }
+      return held.actions.carry(action, execution);
+    }).actions,
   });
   mixed.client.answers.push(
     answered([
@@ -782,7 +783,7 @@ test("an observation in flight enters no memory through an unrelated mark or acc
 
 test("a run whose start the store refuses opens no work and ends as a persistence failure", async () => {
   const h = harness({
-    actions: { perform: async () => ({ status: ACTION_RESULT_STATUS.ACCEPTED }) },
+    actions: fakeActionPerformer().actions,
   });
   await h.agent.ready();
   h.client.answers.push(answered([messageAction("call_1")]), answered([message("Sent.")]));

--- a/packages/brain/src/performer.ts
+++ b/packages/brain/src/performer.ts
@@ -1,6 +1,7 @@
-import type { ActionOutputEnvelope, RealtimeFunctionCall } from "@sidecar/actions";
-import type { RunOrigin } from "@sidecar/runtime/vocabulary";
+import type { ActionOutputEnvelope, ValidatedAction } from "@sidecar/actions";
 import type { Session, SessionIdentity } from "@sidecar/session";
+import type { ActionAdmissionReads } from "./tools/action-tools.js";
+import type { ToolContext } from "./tools/tool-module.js";
 
 /**
  * The roster as the host renders it, with the identities every tool argument
@@ -14,36 +15,29 @@ export interface BrainRoster {
 }
 
 /**
- * The standing a turn hands the performer with each action: which run it
- * belongs to and who opened it — attribution, so Conversation can say whether the
- * developer asked for the action or Luke took it on his own judgment — and
- * whether the turn still stands. The performer asks `isRevoked()` after each
- * step it awaited and once more just before the effect, so an action prepared
- * inside a turn that has since ended is refused rather than dispatched.
- * Whether the action may run at all was decided by the tool policy before the
- * call reached the performer; the performer validates what it is aimed at.
+ * The standing a turn hands an action with each call: which conversation,
+ * turn, and run it belongs to and who opened it — attribution, so
+ * Conversation can say whether the developer asked for the action or Luke
+ * took it on his own judgment — and whether the turn still stands. Admission
+ * and the performer each ask `isRevoked()` after every step they awaited and
+ * once more just before the effect, so an action prepared inside a turn that
+ * has since ended is refused rather than dispatched; the signal fires the
+ * moment the standing is revoked, so a read awaited before the effect
+ * settles at once, while an effect already dispatched is awaited for its
+ * result whatever the signal says. Whether the action may run at all was
+ * decided by the tool policy before the call reached its module.
  */
-export interface BrainActionExecution {
-  readonly runId: string;
-  readonly origin: RunOrigin;
-  isRevoked(): boolean;
-  /**
-   * Fires the moment the standing is revoked, so a performer can settle a
-   * read it is waiting on — a roster refresh, a settings read — rather than
-   * finishing it first. It reaches no provider write: an effect already
-   * dispatched is awaited for its result whatever the signal says.
-   */
-  readonly signal: AbortSignal;
-}
+export type BrainActionExecution = ToolContext;
 
 /**
- * Carries one action for the host to validate and perform, and answers what
- * happened in the one envelope every action tool shares: the status, the
- * target as the roster held it at execution, and the session a creation named.
+ * The host's two halves of carrying an action, which the action tool's own
+ * `execute` joins with `admit()` between them: the readers admission
+ * consults for an execution, and the carrier, which takes only what
+ * admission minted and answers in the one envelope every action tool shares —
+ * the status, the target as the roster held it at execution, and the session
+ * a creation named. The host never sees a call before admission has read it.
  */
 export interface BrainActionPerformer {
-  perform(
-    call: RealtimeFunctionCall,
-    execution: BrainActionExecution,
-  ): Promise<ActionOutputEnvelope>;
+  admission(execution: BrainActionExecution): ActionAdmissionReads;
+  carry(action: ValidatedAction, execution: BrainActionExecution): Promise<ActionOutputEnvelope>;
 }

--- a/packages/brain/src/run-events.test.ts
+++ b/packages/brain/src/run-events.test.ts
@@ -30,6 +30,7 @@ import {
   message,
   NOW,
   PLAIN_PREPARATION,
+  performerWith,
   settle,
   submit,
 } from "./harness.js";
@@ -588,7 +589,7 @@ test("a reasoning item is told with its summary and the opaque item, and the mes
 });
 
 test("a refused call settles as an error carrying the refusal's own reason, and the message's tool part says so", async () => {
-  const h = harness({ actions: { perform: async () => refusedActionOutput("not now") } });
+  const h = harness({ actions: performerWith(async () => refusedActionOutput("not now")).actions });
   const events = listen(h);
   h.client.answers.push(answered([messageAbc("send_x")]), answered([message("It refused.")]));
   const record = await ask(h, "tell abc to run the tests");

--- a/packages/brain/src/testing.ts
+++ b/packages/brain/src/testing.ts
@@ -1,3 +1,12 @@
+import {
+  type ActionOutputEnvelope,
+  acceptedActionOutput,
+  type RealtimeFunctionCall,
+  refusedActionOutput,
+  toolAction,
+  type ValidatedAction,
+} from "@sidecar/actions";
+import { APP_SETTING_KIND, type AppGuideSnapshot, EMPTY_APP_GUIDE } from "@sidecar/guide";
 import { RESPONSES_ITEM_FORMAT, TOOL_LOOP_RUNTIME } from "@sidecar/runtime";
 import {
   MODEL_FAILURE,
@@ -7,9 +16,12 @@ import {
   type ModelResponse,
   type TranscriptEvent,
 } from "@sidecar/runtime/vocabulary";
+import type { Session } from "@sidecar/session";
 import type { WireRecord } from "@sidecar/wire";
 import type { BrainPersistedState, BrainStateLoad, BrainStateRepository } from "./envelope.js";
 import { BRAIN_MAXIMUM_OUTPUT_TOKENS, failed } from "./model-adapter-shared.js";
+import type { BrainActionExecution, BrainActionPerformer } from "./performer.js";
+import { actionToolNamed } from "./tools/action-tools.js";
 
 /** The two things a bare transport answers: an inference, and when it is quiet. */
 export interface BareResponsesModel {
@@ -165,4 +177,94 @@ export function fakeBrainStateRepository(
       });
     },
   };
+}
+
+/** A guide with one adjustable toggle, so a test's setting change has something to be admitted against. */
+export const CAPTIONS_GUIDE: AppGuideSnapshot = {
+  ...EMPTY_APP_GUIDE,
+  settings: [
+    {
+      id: "voice_captions",
+      label: "Captions",
+      description: "Luke's words on screen.",
+      kind: APP_SETTING_KIND.TOGGLE,
+      value: "off",
+      defaultValue: "off",
+      adjustable: true,
+      manual: "the Voice page",
+    },
+  ],
+};
+
+export interface FakeActionPerformerOptions {
+  /** The roster admission reads, as the latest pass would report it; empty admits no session action. */
+  readonly sessions?: readonly Session[];
+  readonly guide?: AppGuideSnapshot;
+  /** What carrying an admitted action answers; accepted by default. */
+  readonly carry?: (
+    action: ValidatedAction,
+    execution: BrainActionExecution,
+  ) => Promise<ActionOutputEnvelope>;
+}
+
+export interface FakeActionPerformer {
+  readonly actions: BrainActionPerformer;
+  /** Every action carried, admitted, in order. */
+  readonly performed: ValidatedAction[];
+  readonly executions: BrainActionExecution[];
+}
+
+/**
+ * The host's two halves as a test stands them in: readers over the sessions
+ * and guide the test chose, and a carrier that records what admission minted
+ * and answers what the test chose. Admission itself is the real one, run by
+ * the tool's own `execute`, so a test's action is admitted exactly as a
+ * developer's would be.
+ */
+export function fakeActionPerformer(options: FakeActionPerformerOptions = {}): FakeActionPerformer {
+  const performed: ValidatedAction[] = [];
+  const executions: BrainActionExecution[] = [];
+  const actions: BrainActionPerformer = {
+    admission: () => ({
+      roster: { read: async () => options.sessions ?? [] },
+      guide: options.guide ?? EMPTY_APP_GUIDE,
+      rememberedFacts: [],
+    }),
+    carry: async (action, execution) => {
+      performed.push(action);
+      executions.push(execution);
+      return options.carry ? options.carry(action, execution) : acceptedActionOutput();
+    },
+  };
+  return { actions, performed, executions };
+}
+
+/**
+ * A raw call run through the performer the way the host's notebook path still
+ * runs one: an action tool's module where the name is an action's, admission
+ * in the host's own hands for the notebook's two writes.
+ */
+export async function performCall(
+  actions: BrainActionPerformer,
+  call: RealtimeFunctionCall,
+  execution: BrainActionExecution,
+): Promise<ActionOutputEnvelope> {
+  const admission = actions.admission(execution);
+  const tool = actionToolNamed(call.name);
+  if (tool) {
+    // SAFETY: JSON.parse answers a wire value; the tool reads it as the record it is or refuses.
+    const input = JSON.parse(call.argumentsJson) as WireRecord;
+    return tool.execute(input, {
+      ...execution,
+      admission,
+      carry: (action) => actions.carry(action, execution),
+    });
+  }
+  const admitted = await toolAction(call, {
+    ...admission,
+    origin: execution.origin,
+    guard: execution,
+  });
+  if (admitted.kind === undefined) return refusedActionOutput(admitted.reason);
+  return actions.carry(admitted, execution);
 }

--- a/packages/brain/src/tool-executor.test.ts
+++ b/packages/brain/src/tool-executor.test.ts
@@ -22,6 +22,7 @@ import {
 } from "@sidecar/runtime/vocabulary";
 import { ACTION_RESULT_STATUS, isRecord, type UnparsedWireValue } from "@sidecar/wire";
 import { BrainJournal } from "./journal.js";
+import { fakeActionPerformer } from "./testing.js";
 import {
   type BrainChildAccess,
   createTurnToolExecutor,
@@ -88,7 +89,7 @@ function executor(
   } as unknown as TurnContext;
   const dependencies: ToolExecutorDependencies = {
     roster: () => ({ text: "roster", identities: [] }),
-    actions: { perform: async () => ({ status: ACTION_RESULT_STATUS.ACCEPTED }) },
+    actions: fakeActionPerformer().actions,
     children,
     memory,
     workspace: {
@@ -111,6 +112,8 @@ function executor(
     policy,
     context,
     execution: {
+      conversationId: MAIN_SESSION_KEY,
+      turnId: run.runId,
       runId: run.runId,
       origin: RUN_ORIGIN.OBSERVATION,
       isRevoked: () => false,

--- a/packages/brain/src/tool-executor.ts
+++ b/packages/brain/src/tool-executor.ts
@@ -1,5 +1,6 @@
 import {
   ACTION_OUTPUT,
+  ACTION_REFUSAL,
   realtimeToolFamily,
   refusedActionOutput,
   unknownActionOutput,
@@ -54,6 +55,8 @@ import { UNCONFIRMED_ACTION_RESULT, UNKNOWN_ACTION_RESULT } from "./journal.js";
 import type { BrainActionExecution, BrainActionPerformer, BrainRoster } from "./performer.js";
 import { identityFromRecord, parsedRecord, rejection, sameIdentity } from "./records.js";
 import { answer } from "./tool-results.js";
+import { actionToolNamed } from "./tools/action-tools.js";
+import { toolArguments } from "./tools/tool-module.js";
 import {
   BRAIN_TOOL,
   isBrainOnlyTool,
@@ -67,8 +70,8 @@ import type { BrainDelivery } from "./wake-events.js";
 /**
  * The tool executor one turn hands its runtime. Every call the model emits
  * lands here, is refused when the effective policy does not offer it, and is
- * otherwise dispatched by what the catalog says the tool is: an action carried
- * through the journal to the performer, a workspace file's read or write, a
+ * otherwise dispatched by what the catalog says the tool is: an action tool's
+ * module run through the journal, a workspace file's read or write, a
  * memory provider's read or write — the write through the same journal — or
  * one of the brain's own — the roster in full, a whole transcript, the
  * briefing it decided to give. The policy is enforced again at this door,
@@ -447,28 +450,29 @@ export function createTurnToolExecutor(
       const roster = dependencies.roster();
       const args = parsedRecord(call.argumentsJson);
       const execution: BrainActionExecution = {
-        runId: turn.execution.runId,
-        origin: turn.execution.origin,
+        ...turn.execution,
         isRevoked: () => turn.execution.isRevoked() || runtimeContext.isRevoked(),
-        signal: turn.execution.signal,
       };
       const tool = descriptors.get(call.name);
       if (tool?.execution === TOOL_EXECUTION.PERFORMER) {
-        // The performer's answer is validated before the journal keeps it. One
-        // this build cannot read is answered unknown: the action was dispatched,
+        const actionTool = actionToolNamed(call.name);
+        if (!actionTool) return answer(refusedActionOutput(REFUSAL_REASON.NOT_OFFERED));
+        // The module runs inside the journal: admission, then the carrier,
+        // whose answer is validated before the journal keeps it. One this
+        // build cannot read is answered unknown: the action was dispatched,
         // and what became of it is exactly what could not be read.
         return answer(
-          await performJournaled(
-            call,
-            execution,
-            async () =>
-              ACTION_OUTPUT.parse(
-                await dependencies.actions.perform(
-                  { name: call.name, argumentsJson: call.argumentsJson },
-                  execution,
-                ),
-              ) ?? unknownActionOutput(REFUSAL_REASON.UNREADABLE_ANSWER),
-          ),
+          await performJournaled(call, execution, async () => {
+            const input = toolArguments(call.argumentsJson);
+            if (input === undefined) return refusedActionOutput(ACTION_REFUSAL.UNREADABLE);
+            return actionTool.execute(input, {
+              ...execution,
+              admission: dependencies.actions.admission(execution),
+              carry: async (action) =>
+                ACTION_OUTPUT.parse(await dependencies.actions.carry(action, execution)) ??
+                unknownActionOutput(REFUSAL_REASON.UNREADABLE_ANSWER),
+            });
+          }),
         );
       }
       if (tool?.execution === TOOL_EXECUTION.WORKSPACE) {

--- a/packages/brain/src/tools.ts
+++ b/packages/brain/src/tools.ts
@@ -1,13 +1,5 @@
-import {
-  type ActionToolDefinition,
-  realtimeToolDefinitions,
-  realtimeToolFamily,
-} from "@sidecar/actions";
-import {
-  NOTEBOOK_MEMORY_TOOL,
-  type NotebookMemoryToolShape,
-  notebookMemoryToolShapes,
-} from "@sidecar/memory";
+import { type ActionToolDefinition, realtimeToolFamily } from "@sidecar/actions";
+import { type NotebookMemoryToolShape, notebookMemoryToolShapes } from "@sidecar/memory";
 import {
   type ChildPolicyContext,
   type EffectiveToolPolicy,
@@ -25,14 +17,16 @@ import {
   responsesToolDefinition,
   toolSchemaFromDefinition,
 } from "./responses-api.js";
+import { ACTION_TOOLS, type ActionToolModule } from "./tools/action-tools.js";
 import { BRAIN_TURN_TRIGGER, type BrainTurnTrigger } from "./turn.js";
 
 /**
  * The brain's tool catalog: every tool a turn could be offered, as the
- * registry describes it. The action rows come from the same table the Realtime
- * session was configured from, so the brain can ask for nothing the actions
- * package does not validate; the brain's own tools — the roster in full, a
- * whole transcript, the briefing, the workspace files, a skill's
+ * registry describes it. The action rows are the action tool modules, each
+ * declared from the same table the Realtime session was configured from, so
+ * the brain can ask for nothing the actions package does not validate; the
+ * brain's own tools — the roster in full, a whole transcript, the briefing,
+ * the workspace files, a skill's
  * instructions — are dispatched inside the agent and reach no action path;
  * the memory tools are the configured memory provider's own, the notebook's
  * search and read and its two writes, and the provider's shapes are what the
@@ -339,14 +333,17 @@ const BRAIN_ONLY_DESCRIPTORS = {
   },
 } as const satisfies Record<BrainToolName, ToolPlacement & { groups: readonly string[] }>;
 
-function actionDescriptor(definition: ActionToolDefinition): ToolDescriptor {
-  const family = realtimeToolFamily(definition.name);
-  if (family === undefined) throw new TypeError(`${definition.name} is not an action`);
+function actionDescriptor(tool: ActionToolModule): ToolDescriptor {
   return {
-    schema: toolSchemaFromDefinition(definition),
+    schema: toolSchemaFromDefinition({
+      type: BRAIN_TOOL_TYPE,
+      name: tool.name,
+      description: tool.description,
+      parameters: tool.inputSchema.jsonSchema(),
+    }),
     execution: TOOL_EXECUTION.PERFORMER,
     effect: TOOL_EFFECT.WRITE,
-    groups: [TOOL_GROUP.ACTIONS, family],
+    groups: [TOOL_GROUP.ACTIONS, tool.family],
   };
 }
 
@@ -358,8 +355,6 @@ function brainOnlyDescriptor(definition: ActionToolDefinition): ToolDescriptor {
     ...BRAIN_ONLY_DESCRIPTORS[name],
   };
 }
-
-const MEMORY_TOOL_NAMES: ReadonlySet<string> = new Set(Object.values(NOTEBOOK_MEMORY_TOOL));
 
 /**
  * The memory provider's tools as the catalog places them: a read is a read
@@ -384,9 +379,7 @@ function memoryDescriptor(shape: NotebookMemoryToolShape): ToolDescriptor {
 /** The whole catalog as descriptors: every action, then the brain's own tools, then the memory provider's, in a fixed order. */
 export function brainToolCatalog(): readonly ToolDescriptor[] {
   return [
-    ...realtimeToolDefinitions()
-      .filter((definition) => !MEMORY_TOOL_NAMES.has(definition.name))
-      .map(actionDescriptor),
+    ...ACTION_TOOLS.map(actionDescriptor),
     ...BRAIN_ONLY_TOOLS.map(brainOnlyDescriptor),
     ...notebookMemoryToolShapes().map(memoryDescriptor),
   ];

--- a/packages/brain/src/tools/action-tools.test.ts
+++ b/packages/brain/src/tools/action-tools.test.ts
@@ -1,0 +1,134 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  ACTION_KIND,
+  ACTION_OUTPUT_STATUS,
+  ACTION_REFUSAL,
+  ACTIONS,
+  acceptedActionOutput,
+  type ValidatedAction,
+} from "@sidecar/actions";
+import { MAIN_SESSION_KEY, RUN_ORIGIN } from "@sidecar/runtime/vocabulary";
+import { normalizeSession, SESSION_STATUS } from "@sidecar/session";
+import { ACTION_TOOLS, type ActionToolContext, actionToolNamed } from "./action-tools.js";
+
+const NOW = 1_800_000_000_000;
+
+const observed = normalizeSession(
+  { id: "claude-code", displayName: "Claude Code" },
+  {
+    providerSessionId: "abc",
+    title: "Claude Code: abc",
+    status: SESSION_STATUS.WAITING,
+    lastActivityAt: NOW,
+    advertises: [{ kind: ACTION_KIND.MESSAGE }],
+  },
+);
+
+const MESSAGE_INPUT = { provider_id: "claude-code", provider_session_id: "abc", text: "go" };
+
+/** A turn's standing over a roster of one session, whose carrier records what it was handed. */
+function context(revoked: () => boolean = () => false) {
+  const carried: ValidatedAction[] = [];
+  const rosterReads: number[] = [];
+  const ctx: ActionToolContext = {
+    conversationId: MAIN_SESSION_KEY,
+    turnId: "run-1",
+    runId: "run-1",
+    origin: RUN_ORIGIN.USER,
+    isRevoked: revoked,
+    signal: new AbortController().signal,
+    admission: {
+      roster: {
+        read: async () => {
+          rosterReads.push(rosterReads.length + 1);
+          return [observed];
+        },
+      },
+    },
+    carry: async (action) => {
+      carried.push(action);
+      return acceptedActionOutput();
+    },
+  };
+  return { ctx, carried, rosterReads };
+}
+
+test("every performer-carried row of the actions table is a module, in the table's order, and the notebook's two writes are not", () => {
+  const rows = Object.values(ACTIONS).filter(
+    (spec) => spec.kind !== ACTION_KIND.REMEMBER && spec.kind !== ACTION_KIND.FORGET,
+  );
+  assert.deepEqual(
+    ACTION_TOOLS.map((tool) => [tool.name, tool.kind, tool.family]),
+    rows.map((spec) => [spec.name, spec.kind, spec.family]),
+  );
+  for (const [index, tool] of ACTION_TOOLS.entries()) {
+    assert.equal(tool.inputSchema, rows[index]?.request);
+    assert.equal(actionToolNamed(tool.name), tool);
+  }
+  assert.equal(actionToolNamed("remember_fact"), undefined);
+  assert.equal(actionToolNamed("delete_everything"), undefined);
+});
+
+test("execute admits over the roster admission reads for itself, then carries what admission minted", async () => {
+  const tool = actionToolNamed("send_session_message");
+  assert.ok(tool);
+  const { ctx, carried, rosterReads } = context();
+  const output = await tool.execute(MESSAGE_INPUT, ctx);
+  assert.equal(output.status, ACTION_OUTPUT_STATUS.ACCEPTED);
+  assert.deepEqual(rosterReads, [1]);
+  assert.deepEqual(carried, [
+    {
+      kind: ACTION_KIND.MESSAGE,
+      identity: { providerId: "claude-code", providerSessionId: "abc" },
+      text: "go",
+      origin: RUN_ORIGIN.USER,
+    },
+  ]);
+});
+
+test("a call admission refuses carries nothing, and a standing already revoked reads no roster at all", async () => {
+  const tool = actionToolNamed("send_session_message");
+  assert.ok(tool);
+  const stranger = context();
+  const refused = await tool.execute(
+    { ...MESSAGE_INPUT, provider_session_id: "ghost" },
+    stranger.ctx,
+  );
+  assert.equal(refused.status, ACTION_OUTPUT_STATUS.REFUSED);
+  assert.deepEqual(stranger.carried, []);
+  assert.deepEqual(stranger.rosterReads, [1]);
+
+  const over = context(() => true);
+  const late = await tool.execute(MESSAGE_INPUT, over.ctx);
+  assert.deepEqual(late, {
+    status: ACTION_OUTPUT_STATUS.REFUSED,
+    reason: ACTION_REFUSAL.TURN_OVER,
+  });
+  assert.deepEqual(over.carried, []);
+  assert.deepEqual(over.rosterReads, []);
+});
+
+test("a standing revoked while admission read the roster refuses before the carrier, with the same word", async () => {
+  const tool = actionToolNamed("send_session_message");
+  assert.ok(tool);
+  let revoked = false;
+  const { ctx, carried } = context(() => revoked);
+  const reading = {
+    ...ctx,
+    admission: {
+      roster: {
+        read: async () => {
+          revoked = true;
+          return [observed];
+        },
+      },
+    },
+  };
+  const late = await tool.execute(MESSAGE_INPUT, reading);
+  assert.deepEqual(late, {
+    status: ACTION_OUTPUT_STATUS.REFUSED,
+    reason: ACTION_REFUSAL.TURN_OVER,
+  });
+  assert.deepEqual(carried, []);
+});

--- a/packages/brain/src/tools/action-tools.ts
+++ b/packages/brain/src/tools/action-tools.ts
@@ -1,0 +1,86 @@
+import {
+  ACTION_KIND,
+  ACTION_REFUSAL,
+  ACTIONS,
+  type ActionFamily,
+  type ActionKind,
+  type ActionOutputEnvelope,
+  type AdmitContext,
+  admit,
+  refusedActionOutput,
+  type ToolSpec,
+  type ValidatedAction,
+} from "@sidecar/actions";
+import type { WireRecord } from "@sidecar/wire";
+import type { ToolContext, ToolModule } from "./tool-module.js";
+
+/**
+ * The action tools as modules: one per row of the actions table that a
+ * performer carries. Each one's `execute` is the whole gauntlet an action
+ * runs — `admit()` first, against the roster admission reads for itself
+ * through the readers the host supplies, then the carrier, which takes only
+ * what admission minted. Nothing in a module knows the agent: the standing it
+ * runs under, the readers, and the carrier all arrive in its context, so a
+ * module cannot be handed a roster, and a caller cannot reach a carrier
+ * without an admitted action to hand it.
+ */
+
+/**
+ * The readers admission consults, as the host supplies them for one
+ * execution: the roster and the projects as the latest pass reports them,
+ * the guide, the issues, the facts. The readers answer what stands when
+ * admission asks, never a copy a caller took earlier; who opened the turn
+ * and whether it still stands come from the context, not from here.
+ */
+export type ActionAdmissionReads = Omit<AdmitContext, "origin" | "guard">;
+
+export interface ActionToolContext extends ToolContext {
+  readonly admission: ActionAdmissionReads;
+  /** Carries an action admission minted, and nothing else has the type to be carried. */
+  carry(action: ValidatedAction): Promise<ActionOutputEnvelope>;
+}
+
+export interface ActionToolModule extends ToolModule<ActionOutputEnvelope, ActionToolContext> {
+  readonly kind: ActionKind;
+  readonly family: ActionFamily;
+}
+
+function defineActionTool(spec: ToolSpec<ActionFamily, ActionKind>): ActionToolModule {
+  return {
+    name: spec.name,
+    description: spec.description,
+    inputSchema: spec.request,
+    kind: spec.kind,
+    family: spec.family,
+    async execute(input: WireRecord, context: ActionToolContext): Promise<ActionOutputEnvelope> {
+      if (context.isRevoked()) return refusedActionOutput(ACTION_REFUSAL.TURN_OVER);
+      const admitted = await admit(
+        { kind: spec.kind, fields: input },
+        { ...context.admission, origin: context.origin, guard: context },
+      );
+      if (admitted.kind === undefined) return refusedActionOutput(admitted.reason);
+      // Asked once more after admission's own reads, so an action whose turn
+      // ended while the roster was refreshing is refused rather than carried.
+      if (context.isRevoked()) return refusedActionOutput(ACTION_REFUSAL.TURN_OVER);
+      return context.carry(admitted);
+    },
+  };
+}
+
+/** The notebook's two writes are the memory provider's tools, carried through its own path, and are no action tool here. */
+const MEMORY_ACTION_KINDS: ReadonlySet<ActionKind> = new Set([
+  ACTION_KIND.REMEMBER,
+  ACTION_KIND.FORGET,
+]);
+
+/** Every action tool, in the actions table's own order, which is the order the catalog lists them. */
+export const ACTION_TOOLS: readonly ActionToolModule[] = Object.values(ACTIONS)
+  .filter((spec) => !MEMORY_ACTION_KINDS.has(spec.kind))
+  .map(defineActionTool);
+
+const ACTION_TOOLS_BY_NAME = new Map(ACTION_TOOLS.map((tool) => [tool.name, tool]));
+
+/** The action tool a call names, or nothing for a name that is not an action tool's. */
+export function actionToolNamed(name: string): ActionToolModule | undefined {
+  return ACTION_TOOLS_BY_NAME.get(name);
+}

--- a/packages/brain/src/tools/tool-module.ts
+++ b/packages/brain/src/tools/tool-module.ts
@@ -1,0 +1,51 @@
+import type { RunOrigin, SessionKey, ToolExecutionContext } from "@sidecar/runtime/vocabulary";
+import { isRecord, type Schema, type UnparsedWireValue, type WireRecord } from "@sidecar/wire";
+
+/**
+ * The shape every tool of the brain is declared in: what it is called, what
+ * it does in the model's words, the schema of what it takes, and the one
+ * function that carries a call out. It is the shape eve's `defineTool` and
+ * the AI SDK's `tool()` both take, so the catalog, the executor, and a later
+ * runtime read the same module. The schema is the wire `Schema` the tool's
+ * fields are declared in once — it parses a call and emits what the model is
+ * shown, and the AI SDK's `tool()` takes it through `jsonSchema()` — rather
+ * than a second statement of the same rule in another schema language.
+ *
+ * A module under this directory reaches the brain's own internals through
+ * its context and nothing else: the repository check refuses an import from
+ * outside the directory, so a tool can be read, tested, and moved without
+ * the agent that runs it.
+ */
+
+/**
+ * The standing a tool's call runs under: which conversation and turn it
+ * belongs to, which run, who opened it, and whether it still stands. The
+ * origin is attribution, never a permission; `isRevoked()` is asked again
+ * after every await and once more before an effect.
+ */
+export interface ToolContext extends ToolExecutionContext {
+  readonly conversationId: SessionKey;
+  /** The turn the call was emitted in: the primary run's id for an ask's turn, the turn's own for the rest. */
+  readonly turnId: string;
+  readonly origin: RunOrigin;
+}
+
+/** A call's arguments as a module takes them: the record they parse to, or nothing when they are not one. */
+export function toolArguments(argumentsJson: string): WireRecord | undefined {
+  try {
+    // SAFETY: JSON.parse answers a wire value; the record check is the validation.
+    const parsed = JSON.parse(argumentsJson) as UnparsedWireValue;
+    return isRecord(parsed) ? parsed : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export interface ToolModule<Output extends WireRecord, Context extends ToolContext> {
+  readonly name: string;
+  readonly description: string;
+  /** The tool's fields as the model is offered them and as a call is read; declared once, in `@sidecar/wire`'s schema. */
+  readonly inputSchema: Schema<unknown>;
+  /** Carries one call whose arguments parsed as a record; everything the call may do runs inside. */
+  execute(input: WireRecord, context: Context): Promise<Output>;
+}

--- a/packages/brain/src/turn-runner.ts
+++ b/packages/brain/src/turn-runner.ts
@@ -453,6 +453,8 @@ export class TurnRunner {
     this.#turnInFlight = true;
     let ended = false;
     const execution: BrainActionExecution = {
+      conversationId: this.#options.conversationId,
+      turnId: run.runId,
       runId: run.runId,
       origin: runOriginOf(plan.trigger),
       isRevoked: () => ended || this.#revoked(turnContext),

--- a/packages/host/src/brain/action-performer.test.ts
+++ b/packages/host/src/brain/action-performer.test.ts
@@ -12,9 +12,10 @@ import {
 } from "@sidecar/actions";
 import type { BrainActionExecution } from "@sidecar/brain";
 import type { BrainAppActionRequest } from "@sidecar/brain/requests-wire";
+import { CAPTIONS_GUIDE } from "@sidecar/brain/testing";
 import { APP_SETTING_KIND, EMPTY_APP_GUIDE } from "@sidecar/guide";
 import { drainMicrotasks } from "@sidecar/runtime/testing";
-import { RUN_ORIGIN } from "@sidecar/runtime/vocabulary";
+import { MAIN_SESSION_KEY, RUN_ORIGIN } from "@sidecar/runtime/vocabulary";
 import type { ConversationEntry } from "@sidecar/session";
 import {
   ACTION_KIND,
@@ -36,6 +37,8 @@ const NOW = 1_800_000_000_000;
 /** A developer-opened turn still standing, or one revoked from the moment `revoked()` first says so. */
 function developerTurn(revoked: () => boolean = () => false): BrainActionExecution {
   return {
+    conversationId: MAIN_SESSION_KEY,
+    turnId: "run-1",
     runId: "run-1",
     origin: RUN_ORIGIN.USER,
     isRevoked: revoked,
@@ -46,6 +49,8 @@ function developerTurn(revoked: () => boolean = () => false): BrainActionExecuti
 /** An observation turn's standing: the same shape, attributed to Luke's own judgment. */
 function observationTurn(): BrainActionExecution {
   return {
+    conversationId: MAIN_SESSION_KEY,
+    turnId: "wake-1",
     runId: "wake-1",
     origin: RUN_ORIGIN.OBSERVATION,
     isRevoked: () => false,
@@ -62,21 +67,6 @@ const MESSAGE_CALL = {
 const REMEMBER_CALL = {
   name: REALTIME_TOOL.REMEMBER_FACT,
   argumentsJson: '{"words":"prefers concise answers"}',
-};
-const CAPTIONS_GUIDE = {
-  facts: [],
-  settings: [
-    {
-      id: "voice_captions",
-      label: "Captions",
-      description: "Luke's words on screen.",
-      kind: APP_SETTING_KIND.TOGGLE,
-      value: "off",
-      defaultValue: "off",
-      adjustable: true,
-      manual: "the Voice page",
-    },
-  ],
 };
 const SETTING_CALL = {
   name: REALTIME_TOOL.CHANGE_APP_SETTING,
@@ -593,6 +583,8 @@ test("a cancel during the roster refresh or the defaults read settles the action
     });
     const controller = new AbortController();
     const execution: BrainActionExecution = {
+      conversationId: MAIN_SESSION_KEY,
+      turnId: "run-1",
       runId: "run-1",
       origin: RUN_ORIGIN.USER,
       isRevoked: () => controller.signal.aborted,

--- a/packages/host/src/brain/action-performer.ts
+++ b/packages/host/src/brain/action-performer.ts
@@ -3,7 +3,6 @@ import {
   ACTION_KIND,
   ACTION_REFUSAL,
   type ActionOutputEnvelope,
-  type AdmitContext,
   acceptedActionOutput,
   actionOutputFromResult,
   actionTargetSnapshot,
@@ -17,7 +16,13 @@ import {
   toolAction,
   type ValidatedAction,
 } from "@sidecar/actions";
-import type { BrainActionExecution, BrainActionPerformer } from "@sidecar/brain";
+import {
+  type ActionAdmissionReads,
+  actionToolNamed,
+  type BrainActionExecution,
+  type BrainActionPerformer,
+  toolArguments,
+} from "@sidecar/brain";
 import type { BrainAppActionRequest } from "@sidecar/brain/requests-wire";
 import type { AppGuideSnapshot } from "@sidecar/guide";
 import { isRunOrigin, RUN_ORIGIN } from "@sidecar/runtime/vocabulary";
@@ -49,6 +54,19 @@ export interface WorkspaceCreationDefaults {
 interface BrainNotebookWriter {
   remember(ask: { id: string; words: string; replaces?: string }): Promise<boolean>;
   forget(id: string): Promise<boolean>;
+}
+
+/**
+ * The host's performer: the brain's two halves — the readers admission
+ * consults and the carrier of what it minted — and one whole run of a raw
+ * call for the notebook's two writes, which the memory provider still hands
+ * over as calls until they are modules of their own.
+ */
+export interface HostActionPerformer extends BrainActionPerformer {
+  perform(
+    call: RealtimeFunctionCall,
+    execution: BrainActionExecution,
+  ): Promise<ActionOutputEnvelope>;
 }
 
 export interface BrainActionPerformerDependencies {
@@ -122,29 +140,31 @@ function panelResult(answered: WireRecord): CarriedActionResult | undefined {
 }
 
 /**
- * The gauntlet every action the brain asks for runs, in the main process: the
- * call is admitted by `admit`, against the roster it reads for itself, the
- * issue board, the offered projects, the guide, or the remembered facts, and
- * only the validated action it mints reaches the performer that carries it. The
- * brain is another way to ask, never a wider one: a call that names a session
- * Luke was not shown, a project no adapter offers, or a setting the guide does
- * not list is refused with a reason the brain can read.
+ * The host's side of the gauntlet every action the brain asks for runs. The
+ * action tool's own `execute` admits the call by `admit`, against the roster
+ * it reads for itself through the readers handed out here — the issue board,
+ * the offered projects, the guide, and the remembered facts beside it — and
+ * only the validated action it mints reaches the carrier below. The brain is
+ * another way to ask, never a wider one: a call that names a session Luke was
+ * not shown, a project no adapter offers, or a setting the guide does not list
+ * is refused with a reason the brain can read.
  *
- * Before any of that, the action has to arrive with a turn's standing: an
- * execution context the brain built for the turn that emitted the call, naming
- * the run and who opened it. Whether the action may run at all was the tool
+ * Every half is handed a turn's standing: an execution context the brain built
+ * for the turn that emitted the call, naming the conversation, the turn, the
+ * run, and who opened it. Whether the action may run at all was the tool
  * policy's decision before the call left the brain; here the context is what
  * says the turn still stands, and admission asks it again after every read of
  * its own, so an action whose turn ended while the roster was refreshing is
- * refused rather than dispatched. A call with no context or a malformed one is
- * refused before admission runs. The origin decides only how Conversation records
- * the action: at the developer's ask, or as Luke's own judgment in a turn nobody
- * asked him anything in.
+ * refused rather than dispatched. The carrier is the last gate before an
+ * effect and reads its context as untrusted: a missing or malformed one
+ * refuses. The origin decides only how Conversation records the action: at the
+ * developer's ask, or as Luke's own judgment in a turn nobody asked him
+ * anything in.
  */
 export function createBrainActionPerformer(
   dependencies: BrainActionPerformerDependencies,
-): BrainActionPerformer {
-  const admissionContext = (execution: BrainActionExecution): AdmitContext => {
+): HostActionPerformer {
+  const admission = (): ActionAdmissionReads => {
     const issues = dependencies.trackedIssues();
     // The roster and the projects an action is admitted against are two readings
     // of one observation pass, so the pass runs once per action however many of
@@ -153,8 +173,6 @@ export function createBrainActionPerformer(
     let pass: Promise<void> | undefined;
     const observed = () => (pass ??= dependencies.refreshSessions());
     return {
-      origin: execution.origin,
-      guard: execution,
       // The reads before an effect wait only as long as the standing does: a
       // cancel landing mid-refresh settles the action inside admission, and the
       // refresh's late answer dispatches nothing.
@@ -217,46 +235,74 @@ export function createBrainActionPerformer(
       : actionOutputFromResult(result);
   };
 
+  const carry = async (
+    action: ValidatedAction,
+    execution: BrainActionExecution,
+  ): Promise<ActionOutputEnvelope> => {
+    if (!isExecution(execution)) return refusedActionOutput(REFUSAL.NO_EXECUTION);
+    if (execution.isRevoked()) return refusedActionOutput(REFUSAL.TURN_OVER);
+    // Where each admitted action goes, named kind by kind: the two notebook
+    // writes are carried here, an app action is the renderer's to perform, an
+    // issue action reaches its tracker without a Conversation line, and a session
+    // action is recorded as it is carried. Every answer is the one envelope.
+    return dispatchByKind(action, {
+      [ACTION_KIND.REMEMBER]: async (action) =>
+        (await dependencies.notebook.remember({
+          id: randomUUID(),
+          words: action.words,
+          ...(action.replaces !== undefined ? { replaces: action.replaces } : undefined),
+        }))
+          ? acceptedActionOutput()
+          : refusedActionOutput(REFUSAL.MEMORY_NOT_SAVED),
+      [ACTION_KIND.FORGET]: async (action) =>
+        (await dependencies.notebook.forget(action.id))
+          ? acceptedActionOutput()
+          : refusedActionOutput(REFUSAL.MEMORY_NOT_REMOVED),
+      [ACTION_KIND.SETTING]: carryAppAction,
+      [ACTION_KIND.PANEL]: carryAppAction,
+      [ACTION_KIND.FEEDBACK]: carryAppAction,
+      [ACTION_KIND.UPDATE]: carryAppAction,
+      [ACTION_KIND.ISSUE_STATE]: async (action) =>
+        actionOutputFromResult(await dependencies.sessionActions.perform(action, execution)),
+      [ACTION_KIND.ISSUE_COMMENT]: async (action) =>
+        actionOutputFromResult(await dependencies.sessionActions.perform(action, execution)),
+      [ACTION_KIND.MESSAGE]: (action) => carrySessionAction(action, execution),
+      [ACTION_KIND.CONTROL]: (action) => carrySessionAction(action, execution),
+      [ACTION_KIND.OPEN]: (action) => carrySessionAction(action, execution),
+      [ACTION_KIND.CREATE_WORKSPACE]: (action) => carrySessionAction(action, execution),
+      [ACTION_KIND.ADD_AGENT]: (action) => carrySessionAction(action, execution),
+      [ACTION_KIND.RENAME_WORKSPACE]: (action) => carrySessionAction(action, execution),
+      [ACTION_KIND.RENAME_SESSION]: (action) => carrySessionAction(action, execution),
+    });
+  };
+
   return {
+    admission,
+    carry,
     async perform(call: RealtimeFunctionCall, execution: BrainActionExecution) {
       if (!isExecution(execution)) return refusedActionOutput(REFUSAL.NO_EXECUTION);
       if (execution.isRevoked()) return refusedActionOutput(REFUSAL.TURN_OVER);
-      const admitted = await toolAction(call, admissionContext(execution));
-      if (admitted.kind === undefined) return refusedActionOutput(admitted.reason);
-      if (execution.isRevoked()) return refusedActionOutput(REFUSAL.TURN_OVER);
-      // Where each admitted action goes, named kind by kind: the two notebook
-      // writes are carried here, an app action is the renderer's to perform, an
-      // issue action reaches its tracker without a Conversation line, and a session
-      // action is recorded as it is carried. Every answer is the one envelope.
-      return dispatchByKind(admitted, {
-        [ACTION_KIND.REMEMBER]: async (action) =>
-          (await dependencies.notebook.remember({
-            id: randomUUID(),
-            words: action.words,
-            ...(action.replaces !== undefined ? { replaces: action.replaces } : undefined),
-          }))
-            ? acceptedActionOutput()
-            : refusedActionOutput(REFUSAL.MEMORY_NOT_SAVED),
-        [ACTION_KIND.FORGET]: async (action) =>
-          (await dependencies.notebook.forget(action.id))
-            ? acceptedActionOutput()
-            : refusedActionOutput(REFUSAL.MEMORY_NOT_REMOVED),
-        [ACTION_KIND.SETTING]: carryAppAction,
-        [ACTION_KIND.PANEL]: carryAppAction,
-        [ACTION_KIND.FEEDBACK]: carryAppAction,
-        [ACTION_KIND.UPDATE]: carryAppAction,
-        [ACTION_KIND.ISSUE_STATE]: async (action) =>
-          actionOutputFromResult(await dependencies.sessionActions.perform(action, execution)),
-        [ACTION_KIND.ISSUE_COMMENT]: async (action) =>
-          actionOutputFromResult(await dependencies.sessionActions.perform(action, execution)),
-        [ACTION_KIND.MESSAGE]: (action) => carrySessionAction(action, execution),
-        [ACTION_KIND.CONTROL]: (action) => carrySessionAction(action, execution),
-        [ACTION_KIND.OPEN]: (action) => carrySessionAction(action, execution),
-        [ACTION_KIND.CREATE_WORKSPACE]: (action) => carrySessionAction(action, execution),
-        [ACTION_KIND.ADD_AGENT]: (action) => carrySessionAction(action, execution),
-        [ACTION_KIND.RENAME_WORKSPACE]: (action) => carrySessionAction(action, execution),
-        [ACTION_KIND.RENAME_SESSION]: (action) => carrySessionAction(action, execution),
+      const reads = admission();
+      // An action tool's call runs its own module, admission inside; the
+      // notebook's two writes are admitted here, the same way, until they are
+      // modules of their own.
+      const tool = actionToolNamed(call.name);
+      if (tool) {
+        const input = toolArguments(call.argumentsJson);
+        if (input === undefined) return refusedActionOutput(ACTION_REFUSAL.UNREADABLE);
+        return tool.execute(input, {
+          ...execution,
+          admission: reads,
+          carry: (action) => carry(action, execution),
+        });
+      }
+      const admitted = await toolAction(call, {
+        ...reads,
+        origin: execution.origin,
+        guard: execution,
       });
+      if (admitted.kind === undefined) return refusedActionOutput(admitted.reason);
+      return carry(admitted, execution);
     },
   };
 }
@@ -272,6 +318,10 @@ function isExecution(
   return (
     execution !== undefined &&
     execution !== null &&
+    isWireString(execution.conversationId) &&
+    execution.conversationId.length > 0 &&
+    isWireString(execution.turnId) &&
+    execution.turnId.length > 0 &&
     isWireString(execution.runId) &&
     execution.runId.length > 0 &&
     isRunOrigin(execution.origin) &&

--- a/packages/host/src/brain/conversation-deletion.test.ts
+++ b/packages/host/src/brain/conversation-deletion.test.ts
@@ -15,7 +15,11 @@ import {
   toolLoopRuntimeOver,
 } from "@sidecar/brain";
 import { type StoreClient, type StorePort, serveStore, storeClient } from "@sidecar/brain/store";
-import { type BareResponsesModel, bareModelAdapter } from "@sidecar/brain/testing";
+import {
+  type BareResponsesModel,
+  bareModelAdapter,
+  fakeActionPerformer,
+} from "@sidecar/brain/testing";
 import { drainMicrotasks, temporaryDirectory } from "@sidecar/runtime/testing";
 import {
   DEFAULT_AGENT_ID,
@@ -137,7 +141,7 @@ function composed(t: TestContext) {
       runtime: toolLoopRuntimeOver(bareModelAdapter(client)),
       observes: { kind: LOOK_SUBJECT.NONE },
       prepareTurn: () => ({ prompt: "instructions", layers: {} }),
-      actions: { perform: async () => ({ status: ACTION_RESULT_STATUS.ACCEPTED }) },
+      actions: fakeActionPerformer().actions,
       roster: () => ({ text: "- abc", identities: [] }),
       // The standing context as the main process renders it: the recent
       // thread, so a line the Clear left anywhere would reach the model.

--- a/packages/host/src/brain/wiring.ts
+++ b/packages/host/src/brain/wiring.ts
@@ -6,7 +6,6 @@ import {
   BRAIN_TURN_TRIGGER,
   BRAIN_WAKE_KIND,
   BRAIN_WORKSPACE_SEEDS,
-  type BrainActionPerformer,
   BrainAgent,
   type BrainDelivery,
   type BrainFlushMarkerStore,
@@ -90,6 +89,7 @@ import { ACTION_RESULT_STATUS, type WireRecord } from "@sidecar/wire";
 import {
   type BrainActionPerformerDependencies,
   createBrainActionPerformer,
+  type HostActionPerformer,
 } from "./action-performer.js";
 import { BrainHost } from "./host.js";
 import { type BrainPublicationDependencies, followBrainRequests } from "./publication.js";
@@ -147,7 +147,7 @@ export interface BrainWiringDependencies extends ChildWiringDependencies {
    * writes run the same gauntlet as every other action. Absent, nothing is
    * recalled and the memory tools refuse.
    */
-  memory?: (sessionKey: SessionKey, actions: BrainActionPerformer) => MemoryDefinition | undefined;
+  memory?: (sessionKey: SessionKey, actions: HostActionPerformer) => MemoryDefinition | undefined;
   /** Where one conversation's flush marker outlives the process; nothing for one that never flushes. */
   flushMarker?: (sessionKey: SessionKey) => BrainFlushMarkerStore | undefined;
 }

--- a/packages/host/src/memory-definition.ts
+++ b/packages/host/src/memory-definition.ts
@@ -1,8 +1,8 @@
 import type { RememberedFact } from "@sidecar/actions";
-import type { BrainActionPerformer } from "@sidecar/brain";
 import { notebookMemoryProvider } from "@sidecar/memory";
 import { recentDailyNotes } from "@sidecar/runtime";
 import type { MemoryDefinition, MemoryScope, SessionKey } from "@sidecar/runtime/vocabulary";
+import type { HostActionPerformer } from "./brain/action-performer.js";
 import type { MemoryMaintenance } from "./memory-maintenance.js";
 import type { MemoryWiring } from "./notebook-memory.js";
 
@@ -28,7 +28,7 @@ export interface MemoryDefinitionDependencies {
  * says keep their memory.
  */
 export function wireMemoryDefinitions(dependencies: MemoryDefinitionDependencies) {
-  return (sessionKey: SessionKey, actions: BrainActionPerformer): MemoryDefinition => {
+  return (sessionKey: SessionKey, actions: HostActionPerformer): MemoryDefinition => {
     const capture = dependencies.maintenance.captureFor(sessionKey);
     return {
       scope: dependencies.scope,
@@ -37,7 +37,9 @@ export function wireMemoryDefinitions(dependencies: MemoryDefinitionDependencies
         access: dependencies.index.accessFor(sessionKey),
         facts: dependencies.facts,
         recentNotes: () => recentDailyNotes(dependencies.workspaceDirectory(), dependencies.now()),
-        perform: (call, context) => actions.perform(call, context),
+        // A notebook write's turn is the run it was called in, in the conversation whose memory this is.
+        perform: (call, context) =>
+          actions.perform(call, { ...context, conversationId: sessionKey, turnId: context.runId }),
         ...(capture ? { capture } : undefined),
       }),
     };

--- a/packages/host/src/testing/brain-harness.ts
+++ b/packages/host/src/testing/brain-harness.ts
@@ -20,6 +20,7 @@ import type {
 import {
   type BareResponsesModel,
   bareModelAdapter,
+  fakeActionPerformer,
   fakeBrainStateRepository,
 } from "@sidecar/brain/testing";
 import { drainMicrotasks } from "@sidecar/runtime/testing";
@@ -185,7 +186,7 @@ export function brainHarness() {
       ...options,
       runtime: toolLoopRuntimeOver(model),
       prepareTurn: () => ({ prompt: "instructions", layers: {} }),
-      actions: { perform: async () => ({ status: ACTION_RESULT_STATUS.ACCEPTED }) },
+      actions: fakeActionPerformer().actions,
       roster: () => ({ text: "", identities: [] }),
       standingContext: () => "",
       readTranscriptSince: async () => ({ status: ACTION_RESULT_STATUS.REJECTED, reason: "no" }),

--- a/packages/host/src/voice-credential-transition.test.ts
+++ b/packages/host/src/voice-credential-transition.test.ts
@@ -10,7 +10,7 @@ import {
   LOOK_SUBJECT,
   toolLoopRuntimeOver,
 } from "@sidecar/brain";
-import { fakeBrainStateRepository } from "@sidecar/brain/testing";
+import { fakeActionPerformer, fakeBrainStateRepository } from "@sidecar/brain/testing";
 import {
   HOSTED_BRAIN_CONTRACT_VERSION,
   HOSTED_BRAIN_OPERATION,
@@ -141,7 +141,7 @@ function composition() {
         runtime: toolLoopRuntimeOver(model),
         observes: { kind: LOOK_SUBJECT.NONE },
         prepareTurn: () => ({ prompt: "instructions", layers: {} }),
-        actions: { perform: async () => ({ status: "accepted" }) },
+        actions: fakeActionPerformer().actions,
         roster: () => ({ text: "none", identities: [] }),
         standingContext: () => "",
         readTranscriptSince: async () => ({ status: "unsupported", reason: "no" }),

--- a/scripts/repository-checks.sh
+++ b/scripts/repository-checks.sh
@@ -142,6 +142,34 @@ node --input-type=module -e '
   }
 ' "$SIDECAR_REPO_ROOT"
 
+# A tool module under `packages/brain/src/tools/` reaches the brain only
+# through the context its `execute` is handed: it imports the packages below
+# the brain and its own directory, never the agent, the turn runner, the
+# ledger, or anything else of the brain by relative path. That is what lets a
+# tool be read, tested, and moved to another runtime without the agent that
+# runs it, and what keeps `admit()` inside `execute` rather than beside it.
+node --input-type=module -e '
+  import { readdir, readFile } from "node:fs/promises";
+  import path from "node:path";
+  const directory = path.join(process.argv[1], "packages/brain/src/tools");
+  const reaching = [];
+  for (const file of (await readdir(directory)).filter((name) => name.endsWith(".ts")).sort()) {
+    const text = await readFile(path.join(directory, file), "utf8");
+    for (const match of text.matchAll(/from\s+"([^"]+)"/g)) {
+      const specifier = match[1];
+      if (specifier.startsWith("../") || specifier.startsWith("@sidecar/brain")) {
+        reaching.push(`${file}: ${specifier}`);
+      }
+    }
+  }
+  if (reaching.length > 0) {
+    process.stderr.write(
+      `error: a tool module reaches into the brain outside its directory: ${reaching.join(", ")}\n`,
+    );
+    process.exit(1);
+  }
+' "$SIDECAR_REPO_ROOT"
+
 # The brand artwork has one source and three sets of committed outputs cut from
 # it: the SVGs, the face the renderer draws, and the motions it plays. If the
 # copies no longer match the source, one of them is telling a story the artwork


### PR DESCRIPTION
## What

A behaviour-neutral refactor: every action tool the brain offers is now a module, and `admit()` runs inside the module's own `execute`.

- **The module shape** (`packages/brain/src/tools/tool-module.ts`): `name`, `description`, `inputSchema`, and `execute(input, ctx)`, where `ctx` (`ToolContext`) carries the conversation (`conversationId`), the turn (`turnId`), the run, who opened it (`origin`), the abort signal, and `isRevoked()`. It is the shape eve's `defineTool` and the AI SDK's `tool()` both take, so A4b's tools, the catalog, and a later runtime read one thing.
- **The action tools** (`packages/brain/src/tools/action-tools.ts`): one module per performer-carried row of the actions table, declared from that table so nothing is stated twice: message, control, open, create workspace, add agent, rename workspace, rename session, the two issue actions, and the four app actions. The notebook's two writes are the memory provider's tools (A4b) and are not action tools. `ACTION_TOOLS` lists them in the table's order; `actionToolNamed` looks one up.
- **`admit()` inside `execute`.** An action module's `execute` is the whole gauntlet: refuse if the standing is already revoked, `admit({ kind, fields: input }, { ...ctx.admission, origin: ctx.origin, guard: ctx })`, refuse again if the standing lapsed while admission read, then `ctx.carry(admitted)`.
- **The host seam** (`BrainActionPerformer`, `packages/brain/src/performer.ts`) is now two halves: `admission(execution)` answers the readers admission consults (roster, projects, guide, issues, facts), and `carry(action, execution)` carries a `ValidatedAction` and answers A2's envelope. The old `perform(call, execution)` is gone from the brain's seam. The host's `createBrainActionPerformer` answers both halves and keeps a `perform` of its own (`HostActionPerformer`) for the memory provider's notebook writes, which still arrive as raw calls until A4b makes them modules; for an action tool's name that `perform` runs the module, so there is one admission path per kind.
- **The executor** (`tool-executor.ts`) dispatches a `PERFORMER` descriptor to its module inside the same journal as before, parsing the arguments to a record first (a non-record refuses `UNREADABLE`, as `toolAction` did) and validating the carrier's answer before the journal keeps it, exactly as it validated the performer's.
- **The catalog** (`tools.ts`) builds the action descriptors from the modules (`inputSchema.jsonSchema()`), in the same order, with the same `PERFORMER` placement, `WRITE` effect, and groups, so the effective tool policy is unchanged: it still fixes the schemas a turn is offered and the gate every emitted call meets at dispatch, separately.
- **The repository check** (`scripts/repository-checks.sh`): a file under `packages/brain/src/tools/` may import the packages below the brain and its own directory, and nothing of the brain by relative path or through `@sidecar/brain`; the check fails on a `../` import and I verified it does.
- **`BrainActionExecution`** is now the `ToolContext`: it gained `conversationId` and `turnId` beside `runId`, `origin`, `isRevoked`, and `signal`. The turn runner sets both; the host's memory wiring sets them for a notebook write (the conversation whose memory it is, the run's id as the turn's); the host's last-gate `isExecution` check reads them as untrusted like the rest.

## How admission stays impossible to skip or to hand a roster to

- `admit()` is called in exactly one place in a module, its `execute`, and `execute` is the only thing the executor calls for an action tool; there is no other entry to a module.
- A module is never handed a roster. `ctx.admission` is `ActionAdmissionReads`, which is `AdmitContext` without `origin` and `guard`: its `roster` is a reader (`read(): Promise<Session[]>`) the host builds over its own observation pass, so admission reads the roster for itself when it asks, never a copy a caller took. The origin and the guard come from the turn's own standing (`ctx`), not from the host.
- The carrier takes only a `ValidatedAction`. `carry(action)` is typed on the branded type `admit()` alone mints, so nothing can reach the host's carrier, or a provider behind it, without admission having minted what it carries; the type is the proof, exactly as CLAUDE.md describes for a provider's write signature.
- The brain no longer holds a `perform(call)` seam at all, so no brain path can hand the host a raw call to admit and carry in one breath.

## How it follows the plan

`storage-plan.md`, Execution: "Tools are eve-shaped modules: description, Zod input schema, output type, `execute(input, ctx)`; `admit()` runs inside `execute`. The catalog decides which tools a turn is offered." One deviation, made for CLAUDE.md's sake and endorsed by the orchestrator so that A4b follows it and G5 carries it: the ticket's "Zod `inputSchema`" wording is superseded, and `inputSchema` is the wire `Schema` each action's fields are already declared in (`@sidecar/actions`' request schemas), not a second Zod statement of the same rule. CLAUDE.md asks that a wire value's rules be declared once, in `@sidecar/wire`'s `Schema`, which both parses and emits the JSON Schema a model is shown; the AI SDK's `tool()` takes that schema through `jsonSchema()`, so B5's registry and A1's reader can still be built from these modules. Writing each request twice, in Zod, would be two statements of one rule that can drift.

## Behaviour

Nothing a tool does changes. What changed in the tests is only the shape they call: the brain's fakes answer `admission` and `carry` rather than `perform`, and because admission now runs for real inside the brain, the harness roster's sessions advertise the message act and carry an address, and the harness guide lists the captions toggle, so the actions the tests always emitted are admitted exactly as a developer's would be. `performed` records the admitted actions rather than the raw calls. A shared fake (`fakeActionPerformer`, `performCall`, `CAPTIONS_GUIDE`) lives behind `@sidecar/brain/testing`; the host's performer tests use the same fixture rather than a second copy.

New tests in `packages/brain/src/tools/action-tools.test.ts`: the modules are the table's performer rows in its order with the table's schemas; `execute` reads the roster once through the readers and carries what admission minted; a refusal carries nothing; an already-revoked standing reads no roster; a standing revoked during admission's read refuses with `TURN_OVER` before the carrier. Tests assert values, structure, and set membership; never prose.

## CLAUDE.md

No sentence contradicted. `packages/AGENTS.md` gains a paragraph on the module shape and the repository check.

## How to verify

```
./scripts/check.sh
cd packages/brain && npx tsx --test src/tools/action-tools.test.ts src/tool-executor.test.ts src/agent.test.ts
cd packages/host && npx tsx --test src/brain/action-performer.test.ts
```

## Results

- `./scripts/check.sh`: passed (lint, knip, typecheck across 27 workspaces, tests, build); brain 372 and host 331 tests passing.
- No macOS or UI code touched, so `./scripts/verify.sh` does not apply.

## Reviews

- **Thermo-nuclear code quality review** (`cursor/plugins`, `cursor-team-kit/skills/thermo-nuclear-code-quality-review`): the seam split is the structural change it asked for — the brain's `perform(call)` (admit and carry in one host call) became two typed halves with `admit()` between them in the module, which removed the host's `AdmitContext` assembly from the brain's view and let `BrainActionExecution` become the one `ToolContext` rather than a second standing shape. No file grew past its bounds; `tool-executor.ts` shrank.
- **Ponytail review** (`dietrichgebert/ponytail`, `.openclaw/skills/ponytail-review`): `tool-executor.ts / action-performer.ts: stdlib-ish: the same JSON-to-record parser written twice. One toolArguments in tool-module.ts, exported.` `action-performer.test.ts: delete: a second CAPTIONS_GUIDE. Import the brain's testing one.` `testing.ts: delete: NOTEBOOK_ACTION_KINDS, nothing reads it.` `harness.ts: delete: export on HARNESS_SESSIONS, used in its own file.` All taken. net: -34 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34540175681/artifacts/10177041921) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34540175681)

- Commit: `93d50139fe6df824d3d744de5983591d095024a4`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
