### PR TITLE
feat(LUKE-135): render UIMessage tool parts and the action envelope

### DIFF
--- a/apps/desktop/src/renderer/conversation-copy.tsx
+++ b/apps/desktop/src/renderer/conversation-copy.tsx
@@ -1,0 +1,39 @@
+import { CheckIcon, CopyIcon } from "@sidecar/panel";
+import { useEffect, useState } from "react";
+import { ACT_KIND } from "#shared/messages/acts";
+import { tell } from "./act";
+
+const COPY_CONFIRMATION_MS = 1500;
+
+/**
+ * The copy control a settled bubble carries in its free margin. It copies the
+ * words as written, Markdown marks included, so a paste carries the structure
+ * the bubble drew — and never the structured model context behind them. The
+ * glyph alone speaks: the accessible name captions it, and the confirmation is
+ * the same green check a finished session wears, standing for a moment before
+ * the control returns to its resting glyph.
+ */
+export function ConversationCopyButton({ words }: { words: string }): React.JSX.Element {
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    if (!copied) return;
+    const timer = setTimeout(() => setCopied(false), COPY_CONFIRMATION_MS);
+    return () => clearTimeout(timer);
+  }, [copied]);
+
+  return (
+    <button
+      type="button"
+      className="conversation-copy"
+      data-copied={copied ? "true" : undefined}
+      aria-label={copied ? "Copied" : "Copy message"}
+      onClick={() => {
+        tell(ACT_KIND.WINDOW_COPY_TEXT, { words });
+        setCopied(true);
+      }}
+    >
+      {copied ? <CheckIcon /> : <CopyIcon />}
+    </button>
+  );
+}

--- a/apps/desktop/src/renderer/conversation-panel.tsx
+++ b/apps/desktop/src/renderer/conversation-panel.tsx
@@ -1,5 +1,5 @@
 import { type BrainRequestSnapshot, brainRequestPending } from "@sidecar/brain/requests-wire";
-import { CheckIcon, CopyIcon, WingFace } from "@sidecar/panel";
+import { WingFace } from "@sidecar/panel";
 import {
   CONVERSATION_ENTRY_KIND,
   type ConversationEntry,
@@ -8,9 +8,8 @@ import {
 } from "@sidecar/session";
 import { FACE_MOTION } from "@sidecar/surface";
 import { useEffect, useRef, useState } from "react";
-import { ACT_KIND } from "#shared/messages/acts";
-import { tell } from "./act";
 import { type AskHandler, AskLuke } from "./ask-luke";
+import { ConversationCopyButton } from "./conversation-copy";
 import {
   createConversationTimeBreakFormatter,
   opensConversationTimeBreak,
@@ -25,7 +24,7 @@ export const CONVERSATION_ENTRY_SPEAKER = {
   EVENT: "event",
 } as const;
 
-type ConversationEntrySpeaker =
+export type ConversationEntrySpeaker =
   (typeof CONVERSATION_ENTRY_SPEAKER)[keyof typeof CONVERSATION_ENTRY_SPEAKER];
 
 export interface ConversationEntryPresentation {
@@ -51,8 +50,6 @@ export function conversationEntryPresentation(
       return { speaker: CONVERSATION_ENTRY_SPEAKER.EVENT, label: "At your request" };
   }
 }
-
-const COPY_CONFIRMATION_MS = 1500;
 
 const ENTRY_TIME = new Intl.DateTimeFormat(undefined, { hour: "numeric", minute: "2-digit" });
 
@@ -171,14 +168,6 @@ function ConversationEntryRow({
 }): React.JSX.Element {
   const presentation = conversationEntryPresentation(entry.kind);
   const words = entry.words;
-  const [copied, setCopied] = useState(false);
-
-  useEffect(() => {
-    if (!copied) return;
-    const timer = setTimeout(() => setCopied(false), COPY_CONFIRMATION_MS);
-    return () => clearTimeout(timer);
-  }, [copied]);
-
   const recordedAt = entry.recordedAt === undefined ? undefined : new Date(entry.recordedAt);
 
   return (
@@ -194,21 +183,7 @@ function ConversationEntryRow({
           {/* Copying words still arriving would copy half a sentence; the control
             appears with the settled line the same words become. */}
           {presentation.speaker === CONVERSATION_ENTRY_SPEAKER.EVENT || streaming ? null : (
-            <button
-              type="button"
-              className="conversation-copy"
-              data-copied={copied ? "true" : undefined}
-              aria-label={copied ? "Copied" : "Copy message"}
-              onClick={() => {
-                // The line's own words as written, Markdown marks included, so
-                // a paste carries the structure the bubble drew — and never the
-                // structured model context behind an announcement.
-                tell(ACT_KIND.WINDOW_COPY_TEXT, { words });
-                setCopied(true);
-              }}
-            >
-              {copied ? <CheckIcon /> : <CopyIcon />}
-            </button>
+            <ConversationCopyButton words={words} />
           )}
         </span>
       </div>

--- a/apps/desktop/src/renderer/conversation-tool-row.test.ts
+++ b/apps/desktop/src/renderer/conversation-tool-row.test.ts
@@ -1,0 +1,338 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { ACTION_KIND, ACTION_OUTPUT_STATUS, type SessionActionKind } from "@sidecar/actions";
+import {
+  isStoredToolPart,
+  MESSAGE_ROLE,
+  SESSION_CONTROL_KIND,
+  type StoredToolPart,
+  TOOL_PART_STATE,
+} from "@sidecar/session";
+import {
+  TOOL_ROW_STATUS,
+  type ToolRow,
+  type ToolRowChip,
+  toolRow,
+  UNNAMED_SESSION,
+} from "./conversation-tool-row";
+import {
+  FIXTURE_INPUT,
+  FIXTURE_ROSTER,
+  FIXTURE_SESSION,
+  FIXTURE_TITLE,
+} from "./conversation-turns.fixtures";
+
+const PROVIDER = "conductor";
+const AGENT = "claude-code";
+
+type ToolCallInput = StoredToolPart["input"];
+type ToolCallOutput = Extract<
+  StoredToolPart,
+  { state: typeof TOOL_PART_STATE.OUTPUT_AVAILABLE }
+>["output"];
+
+function part(
+  toolName: string,
+  input: ToolCallInput,
+  answer:
+    | { state: typeof TOOL_PART_STATE.OUTPUT_AVAILABLE; output: ToolCallOutput }
+    | { state: typeof TOOL_PART_STATE.OUTPUT_ERROR; errorText: string }
+    | { state: typeof TOOL_PART_STATE.INPUT_AVAILABLE },
+): StoredToolPart {
+  return { type: `tool-${toolName}`, toolCallId: "call_1", input, ...answer };
+}
+
+const answered = (output: ToolCallOutput) =>
+  ({ state: TOOL_PART_STATE.OUTPUT_AVAILABLE, output }) as const;
+
+const HELD = { provider_id: PROVIDER, provider_session_id: FIXTURE_SESSION.HELD };
+const DEPARTED_TARGET = {
+  providerId: PROVIDER,
+  providerSessionId: FIXTURE_SESSION.DEPARTED,
+  title: FIXTURE_TITLE.DEPARTED,
+  agentId: AGENT,
+};
+
+function chipOf(row: ToolRow | undefined): ToolRowChip | undefined {
+  for (const run of row?.runs ?? []) if ("chip" in run) return run.chip;
+  return undefined;
+}
+
+/** Every action part the fixture conversation holds, in order. */
+function fixtureActionParts(): StoredToolPart[] {
+  return FIXTURE_INPUT.main.flatMap((row) =>
+    row.message.role === MESSAGE_ROLE.ASSISTANT ? row.message.parts.filter(isStoredToolPart) : [],
+  );
+}
+
+test("every session action kind composes a row, and a tool that is not one composes none", () => {
+  const kinds = new Set<SessionActionKind>();
+  for (const candidate of fixtureActionParts()) {
+    const row = toolRow(candidate, FIXTURE_ROSTER);
+    if (row !== undefined) kinds.add(row.kind);
+  }
+  assert.deepEqual(
+    [...kinds].sort(),
+    [
+      ACTION_KIND.ADD_AGENT,
+      ACTION_KIND.CONTROL,
+      ACTION_KIND.CREATE_WORKSPACE,
+      ACTION_KIND.MESSAGE,
+      ACTION_KIND.OPEN,
+      ACTION_KIND.RENAME_SESSION,
+      ACTION_KIND.RENAME_WORKSPACE,
+    ].sort(),
+  );
+  assert.equal(
+    toolRow(part("read_transcript", HELD, answered({ lines: [] })), FIXTURE_ROSTER),
+    undefined,
+  );
+  assert.equal(
+    toolRow(part("announce", { briefing: "hi" }, answered({})), FIXTURE_ROSTER),
+    undefined,
+  );
+});
+
+test("a chip names a held session by the roster and opens exactly when its row would", () => {
+  const row = toolRow(
+    part(
+      "send_session_message",
+      { ...HELD, text: "go" },
+      answered({
+        status: ACTION_OUTPUT_STATUS.ACCEPTED,
+        target: {
+          providerId: PROVIDER,
+          providerSessionId: FIXTURE_SESSION.HELD,
+          title: FIXTURE_TITLE.HELD_THEN,
+        },
+      }),
+    ),
+    FIXTURE_ROSTER,
+  );
+  assert.deepEqual(chipOf(row), {
+    text: FIXTURE_TITLE.HELD,
+    markId: AGENT,
+    identity: { providerId: PROVIDER, providerSessionId: FIXTURE_SESSION.HELD },
+    openable: true,
+  });
+  assert.equal(row?.status, TOOL_ROW_STATUS.ACCEPTED);
+  assert.equal(row?.providerId, PROVIDER);
+
+  const quiet = toolRow(
+    part(
+      "send_session_message",
+      { provider_id: PROVIDER, provider_session_id: FIXTURE_SESSION.UNOPENABLE, text: "go" },
+      answered({ status: ACTION_OUTPUT_STATUS.ACCEPTED }),
+    ),
+    FIXTURE_ROSTER,
+  );
+  assert.equal(chipOf(quiet)?.openable, false);
+  assert.equal(chipOf(quiet)?.text, FIXTURE_TITLE.UNOPENABLE);
+});
+
+test("a departed session is named from the envelope's snapshot and opened by identity", () => {
+  const row = toolRow(
+    part(
+      "run_session_control",
+      {
+        provider_id: PROVIDER,
+        provider_session_id: FIXTURE_SESSION.DEPARTED,
+        control_id: "archive",
+      },
+      answered({
+        status: ACTION_OUTPUT_STATUS.ACCEPTED,
+        target: {
+          ...DEPARTED_TARGET,
+          controlKind: SESSION_CONTROL_KIND.ARCHIVE,
+          controlLabel: "Archive",
+        },
+      }),
+    ),
+    FIXTURE_ROSTER,
+  );
+  assert.deepEqual(chipOf(row), {
+    text: FIXTURE_TITLE.DEPARTED,
+    markId: AGENT,
+    identity: { providerId: PROVIDER, providerSessionId: FIXTURE_SESSION.DEPARTED },
+    openable: true,
+  });
+  assert.equal(row?.controlKind, SESSION_CONTROL_KIND.ARCHIVE);
+
+  const nameless = toolRow(
+    part(
+      "send_session_message",
+      { provider_id: PROVIDER, provider_session_id: "gone", text: "go" },
+      answered({ status: ACTION_OUTPUT_STATUS.ACCEPTED }),
+    ),
+    FIXTURE_ROSTER,
+  );
+  assert.deepEqual(chipOf(nameless), {
+    text: UNNAMED_SESSION,
+    markId: PROVIDER,
+    identity: { providerId: PROVIDER, providerSessionId: "gone" },
+    openable: true,
+  });
+});
+
+test("a control's kind and label come from the envelope, never from the call", () => {
+  const withKind = (controlKind: string | undefined) =>
+    toolRow(
+      part(
+        "run_session_control",
+        { ...HELD, control_id: "x" },
+        answered({
+          status: ACTION_OUTPUT_STATUS.ACCEPTED,
+          target: {
+            providerId: PROVIDER,
+            providerSessionId: FIXTURE_SESSION.HELD,
+            ...(controlKind !== undefined ? { controlKind } : undefined),
+            controlLabel: "Retry",
+          },
+        }),
+      ),
+      FIXTURE_ROSTER,
+    );
+  assert.equal(withKind(SESSION_CONTROL_KIND.STOP)?.controlKind, SESSION_CONTROL_KIND.STOP);
+  assert.equal(withKind(SESSION_CONTROL_KIND.ACTION)?.controlKind, SESSION_CONTROL_KIND.ACTION);
+  assert.equal(withKind(undefined)?.controlKind, undefined);
+  // The words lead, the chip follows: two runs, the chip second, whatever the kind.
+  for (const kind of [SESSION_CONTROL_KIND.STOP, SESSION_CONTROL_KIND.ARCHIVE, undefined]) {
+    const runs = withKind(kind)?.runs ?? [];
+    assert.equal(runs.length, 2);
+    assert.ok(runs[0] !== undefined && "text" in runs[0]);
+    assert.ok(runs[1] !== undefined && "chip" in runs[1]);
+  }
+});
+
+test("a creation's chip is the session its answer named, by the roster once it holds it", () => {
+  const input = { provider_id: PROVIDER, name: FIXTURE_TITLE.CREATED, agent: AGENT };
+  const landed = toolRow(
+    part(
+      "create_workspace",
+      input,
+      answered({
+        status: ACTION_OUTPUT_STATUS.ACCEPTED,
+        target: { providerId: PROVIDER },
+        createdSession: { providerId: PROVIDER, providerSessionId: FIXTURE_SESSION.CREATED },
+      }),
+    ),
+    FIXTURE_ROSTER,
+  );
+  assert.deepEqual(chipOf(landed)?.identity, {
+    providerId: PROVIDER,
+    providerSessionId: FIXTURE_SESSION.CREATED,
+  });
+  assert.equal(chipOf(landed)?.openable, true);
+  assert.equal(chipOf(landed)?.text, FIXTURE_TITLE.CREATED);
+
+  const unlanded = toolRow(
+    part(
+      "create_workspace",
+      input,
+      answered({ status: ACTION_OUTPUT_STATUS.ACCEPTED, target: { providerId: PROVIDER } }),
+    ),
+    FIXTURE_ROSTER,
+  );
+  assert.deepEqual(chipOf(unlanded), {
+    text: FIXTURE_TITLE.CREATED,
+    markId: AGENT,
+    openable: false,
+  });
+
+  const unnamed = toolRow(
+    part(
+      "create_workspace",
+      { provider_id: PROVIDER },
+      answered({ status: ACTION_OUTPUT_STATUS.ACCEPTED }),
+    ),
+    FIXTURE_ROSTER,
+  );
+  assert.equal(chipOf(unnamed), undefined);
+  assert.equal(unnamed?.runs.length, 1);
+  assert.equal(unnamed?.providerId, PROVIDER);
+});
+
+test("part state and envelope status are different questions, and each has its own word", () => {
+  const message = { ...HELD, text: "go" };
+  assert.equal(
+    toolRow(
+      part("send_session_message", message, { state: TOOL_PART_STATE.INPUT_AVAILABLE }),
+      FIXTURE_ROSTER,
+    )?.status,
+    TOOL_ROW_STATUS.PENDING,
+  );
+  const failed = toolRow(
+    part("send_session_message", message, {
+      state: TOOL_PART_STATE.OUTPUT_ERROR,
+      errorText: "tool threw",
+    }),
+    FIXTURE_ROSTER,
+  );
+  assert.equal(failed?.status, TOOL_ROW_STATUS.FAILED);
+  assert.equal(failed?.reason, "tool threw");
+  const refused = toolRow(
+    part(
+      "send_session_message",
+      message,
+      answered({ status: ACTION_OUTPUT_STATUS.REFUSED, reason: "not advertised" }),
+    ),
+    FIXTURE_ROSTER,
+  );
+  assert.equal(refused?.status, TOOL_ROW_STATUS.REFUSED);
+  assert.equal(refused?.reason, "not advertised");
+  const unknown = toolRow(
+    part(
+      "send_session_message",
+      message,
+      answered({ status: ACTION_OUTPUT_STATUS.UNKNOWN, reason: "lost" }),
+    ),
+    FIXTURE_ROSTER,
+  );
+  assert.equal(unknown?.status, TOOL_ROW_STATUS.UNKNOWN);
+  assert.equal(unknown?.reason, "lost");
+  const unreadable = toolRow(
+    part("send_session_message", message, answered({ status: "done" })),
+    FIXTURE_ROSTER,
+  );
+  assert.equal(unreadable?.status, TOOL_ROW_STATUS.UNKNOWN);
+  assert.notEqual(unreadable?.reason, undefined);
+  const noted = toolRow(
+    part(
+      "open_session",
+      { ...HELD, application: "claude" },
+      answered({
+        status: ACTION_OUTPUT_STATUS.ACCEPTED,
+        note: "Opened in Claude.",
+        warning: "Slowly.",
+      }),
+    ),
+    FIXTURE_ROSTER,
+  );
+  assert.equal(noted?.note, "Opened in Claude.");
+  assert.equal(noted?.warning, "Slowly.");
+  assert.equal(noted?.reason, undefined);
+});
+
+test("a call whose arguments cannot be read still draws its kind and whatever the envelope names", () => {
+  const row = toolRow(
+    part(
+      "send_session_message",
+      { nonsense: true },
+      answered({
+        status: ACTION_OUTPUT_STATUS.ACCEPTED,
+        target: {
+          providerId: PROVIDER,
+          providerSessionId: FIXTURE_SESSION.DEPARTED,
+          title: FIXTURE_TITLE.DEPARTED,
+        },
+      }),
+    ),
+    FIXTURE_ROSTER,
+  );
+  assert.equal(row?.kind, ACTION_KIND.MESSAGE);
+  assert.equal(row?.runs.length, 2);
+  assert.deepEqual(chipOf(row)?.identity, {
+    providerId: PROVIDER,
+    providerSessionId: FIXTURE_SESSION.DEPARTED,
+  });
+});

--- a/apps/desktop/src/renderer/conversation-tool-row.test.ts
+++ b/apps/desktop/src/renderer/conversation-tool-row.test.ts
@@ -239,6 +239,27 @@ test("a creation's chip is the session its answer named, by the roster once it h
     openable: false,
   });
 
+  // The answer named a session the roster does not hold, and the call named nothing: the chip
+  // is still the session, opened by identity, under the agent the call asked for.
+  const departed = toolRow(
+    part(
+      "create_workspace",
+      { provider_id: PROVIDER, agent: AGENT },
+      answered({
+        status: ACTION_OUTPUT_STATUS.ACCEPTED,
+        target: { providerId: PROVIDER },
+        createdSession: { providerId: PROVIDER, providerSessionId: "created-then-archived" },
+      }),
+    ),
+    FIXTURE_ROSTER,
+  );
+  assert.deepEqual(chipOf(departed), {
+    text: UNNAMED_SESSION,
+    markId: AGENT,
+    identity: { providerId: PROVIDER, providerSessionId: "created-then-archived" },
+    openable: true,
+  });
+
   const unnamed = toolRow(
     part(
       "create_workspace",

--- a/apps/desktop/src/renderer/conversation-tool-row.ts
+++ b/apps/desktop/src/renderer/conversation-tool-row.ts
@@ -1,0 +1,372 @@
+import {
+  ACTION_KIND,
+  ACTION_OUTPUT,
+  ACTION_OUTPUT_STATUS,
+  ACTIONS,
+  type ActionOutputEnvelope,
+  type ActionTargetSnapshot,
+  realtimeToolKind,
+  type SessionActionKind,
+} from "@sidecar/actions";
+import {
+  SESSION_CONTROL_KIND,
+  type SessionControlKind,
+  type SessionIdentity,
+  type StoredToolPart,
+  storedToolName,
+  TOOL_PART_STATE,
+} from "@sidecar/session";
+import { type UnparsedWireValue, unparsedWire, type WireBoundaryInput } from "@sidecar/wire";
+import type { SessionView } from "./session-model";
+
+/**
+ * How an action's tool part becomes a row: from the call's own arguments and
+ * the envelope its output carries, and nothing else. The arguments say what
+ * was asked — which session, what text, which control — and the envelope says
+ * what became of it and what the target was when it ran: its title, its agent,
+ * the control's label and kind, the session a creation made. The roster as it
+ * stands now supplies the current name of a session it still holds; once it
+ * has let the session go, the envelope's snapshot names it, which is what keeps
+ * a departed chat nameable. No sentence is stored anywhere for a row to draw:
+ * the words here are the desktop's, and the phone words the same parts itself.
+ */
+
+/** The action kinds a tool row is drawn for: the session family, whose tools answer in the envelope. */
+const SESSION_ACTION_KINDS: ReadonlySet<string> = new Set<SessionActionKind>([
+  ACTION_KIND.MESSAGE,
+  ACTION_KIND.CONTROL,
+  ACTION_KIND.OPEN,
+  ACTION_KIND.CREATE_WORKSPACE,
+  ACTION_KIND.ADD_AGENT,
+  ACTION_KIND.RENAME_WORKSPACE,
+  ACTION_KIND.RENAME_SESSION,
+]);
+
+function isSessionActionKind(kind: string): kind is SessionActionKind {
+  return SESSION_ACTION_KINDS.has(kind);
+}
+
+/**
+ * What became of the action, as the row marks it: the envelope's three words,
+ * and beside them the two the part's own state says before an envelope
+ * exists — a call still under way, and one whose tool failed outright and
+ * answered with an error rather than an envelope. Part state and envelope
+ * status are different questions: an answered part whose envelope says
+ * refused is a row that says so, while an errored part is a refusal drawn only
+ * inside its turn.
+ */
+export const TOOL_ROW_STATUS = {
+  ACCEPTED: ACTION_OUTPUT_STATUS.ACCEPTED,
+  UNKNOWN: ACTION_OUTPUT_STATUS.UNKNOWN,
+  REFUSED: ACTION_OUTPUT_STATUS.REFUSED,
+  PENDING: "pending",
+  FAILED: "failed",
+} as const;
+
+type ToolRowStatus = (typeof TOOL_ROW_STATUS)[keyof typeof TOOL_ROW_STATUS];
+
+/**
+ * The session a row names, drawn as a chip: its current title while the roster
+ * holds it, the title the envelope kept once it does not, under the mark of the
+ * agent behind it or its provider. The chip is the row's own press by another
+ * hand where the session has an identity to open by; a session the roster
+ * holds but reported no address for, and a creation whose answer named no
+ * session, are names alone.
+ */
+export interface ToolRowChip {
+  readonly text: string;
+  readonly markId?: string;
+  readonly identity?: SessionIdentity;
+  readonly openable: boolean;
+}
+
+/** One run of the row's words: plain text, or the chip. */
+type ToolRowRun = { readonly text: string } | { readonly chip: ToolRowChip };
+
+export interface ToolRow {
+  readonly kind: SessionActionKind;
+  /** What a control does, when its adapter said; the row's mark follows it. */
+  readonly controlKind?: SessionControlKind;
+  readonly status: ToolRowStatus;
+  /** The provider the action reached, for the row's trailing mark. */
+  readonly providerId?: string;
+  readonly runs: readonly ToolRowRun[];
+  /** Why a refused or unknown action ended as it did, or what an errored tool answered. */
+  readonly reason?: string;
+  /** The carrier's own sentence about an accepted action, where it wrote one. */
+  readonly note?: string;
+  readonly warning?: string;
+}
+
+/** What a chip says of a session neither the roster nor the envelope can name. */
+export const UNNAMED_SESSION = "an unnamed chat";
+
+/** What a row says when the record of the action's answer cannot be read. */
+const UNREADABLE_ENVELOPE = "The record of this action's answer could not be read.";
+
+function envelopeOf(part: StoredToolPart): ActionOutputEnvelope | undefined {
+  if (part.state !== TOOL_PART_STATE.OUTPUT_AVAILABLE) return undefined;
+  // SAFETY: a stored part's output is JSON the store holds as jsonb; the wire boundary is where it is read.
+  const read = ACTION_OUTPUT.read(unparsedWire(part.output as WireBoundaryInput));
+  return read.ok ? read.value : undefined;
+}
+
+/** What became of the action and, where it did not simply land, why. */
+interface RowOutcome {
+  readonly status: ToolRowStatus;
+  readonly reason?: string;
+}
+
+function rowStatus(part: StoredToolPart, envelope: ActionOutputEnvelope | undefined): RowOutcome {
+  switch (part.state) {
+    case TOOL_PART_STATE.INPUT_STREAMING:
+    case TOOL_PART_STATE.INPUT_AVAILABLE:
+      return { status: TOOL_ROW_STATUS.PENDING };
+    case TOOL_PART_STATE.OUTPUT_ERROR:
+      return { status: TOOL_ROW_STATUS.FAILED, reason: part.errorText };
+    case TOOL_PART_STATE.OUTPUT_AVAILABLE:
+      if (envelope === undefined) {
+        return { status: TOOL_ROW_STATUS.UNKNOWN, reason: UNREADABLE_ENVELOPE };
+      }
+      return envelope.status === ACTION_OUTPUT_STATUS.ACCEPTED
+        ? { status: envelope.status }
+        : { status: envelope.status, reason: envelope.reason };
+  }
+}
+
+function inputOf(part: StoredToolPart): UnparsedWireValue {
+  // SAFETY: a stored part's input is the call's JSON arguments; the wire boundary is where they are read.
+  return unparsedWire(part.input as WireBoundaryInput);
+}
+
+function rosterSession(
+  identity: SessionIdentity | undefined,
+  roster: readonly SessionView[],
+): SessionView | undefined {
+  if (identity === undefined) return undefined;
+  return roster.find(
+    (session) =>
+      session.providerId === identity.providerId && session.id === identity.providerSessionId,
+  );
+}
+
+/**
+ * The chip for the session an action named: by the roster while it holds the
+ * session, by the envelope's snapshot once it does not. A session the roster
+ * holds is pressable exactly when its own row is; one the roster has let go is
+ * pressable by identity, and the host answers with the address it last
+ * reported or refuses.
+ */
+function sessionChip(
+  identity: SessionIdentity | undefined,
+  target: ActionTargetSnapshot | undefined,
+  roster: readonly SessionView[],
+  fallbackName?: string,
+): ToolRowChip {
+  const session = rosterSession(identity, roster);
+  if (session !== undefined) {
+    return {
+      text: session.title,
+      markId: session.agentId ?? session.providerId,
+      identity: { providerId: session.providerId, providerSessionId: session.id },
+      openable: session.openable,
+    };
+  }
+  const markId = target?.agentId ?? target?.providerId ?? identity?.providerId;
+  return {
+    text: target?.title ?? fallbackName ?? UNNAMED_SESSION,
+    ...(markId !== undefined ? { markId } : undefined),
+    ...(identity !== undefined ? { identity } : undefined),
+    openable: identity !== undefined,
+  };
+}
+
+function identityFrom(
+  input: { provider_id: string; provider_session_id: string } | undefined,
+  target: ActionTargetSnapshot | undefined,
+): SessionIdentity | undefined {
+  if (input !== undefined) {
+    return { providerId: input.provider_id, providerSessionId: input.provider_session_id };
+  }
+  return target?.providerSessionId !== undefined
+    ? { providerId: target.providerId, providerSessionId: target.providerSessionId }
+    : undefined;
+}
+
+/** The name an application id draws: the roster's own for the session, or the id where the roster no longer says. */
+function applicationName(applicationId: string, session: SessionView | undefined): string {
+  return (
+    session?.applications.find((application) => application.id === applicationId)?.name ??
+    applicationId
+  );
+}
+
+interface Composition {
+  readonly runs: readonly ToolRowRun[];
+  readonly providerId?: string;
+  readonly controlKind?: SessionControlKind;
+}
+
+/** The session an action's arguments name, as a chip and the provider mark beside it. */
+interface NamedSession {
+  readonly identity: SessionIdentity | undefined;
+  readonly chip: ToolRowChip;
+  readonly providerId?: string;
+}
+
+function namedSession(
+  input: { provider_id: string; provider_session_id: string } | undefined,
+  target: ActionTargetSnapshot | undefined,
+  roster: readonly SessionView[],
+): NamedSession {
+  const identity = identityFrom(input, target);
+  const providerId = target?.providerId ?? identity?.providerId;
+  return {
+    identity,
+    chip: sessionChip(identity, target, roster),
+    ...(providerId !== undefined ? { providerId } : undefined),
+  };
+}
+
+function composeRuns(
+  kind: SessionActionKind,
+  part: StoredToolPart,
+  target: ActionTargetSnapshot | undefined,
+  envelope: ActionOutputEnvelope | undefined,
+  roster: readonly SessionView[],
+): Composition {
+  const input = inputOf(part);
+  switch (kind) {
+    case ACTION_KIND.MESSAGE: {
+      const read = ACTIONS.SEND_SESSION_MESSAGE.request.read(input);
+      const { chip, providerId } = namedSession(read.ok ? read.value : undefined, target, roster);
+      return {
+        runs: [
+          { text: "Sent a message to " },
+          { chip },
+          ...(read.ok ? [{ text: `: "${read.value.text}"` }] : []),
+        ],
+        ...(providerId !== undefined ? { providerId } : undefined),
+      };
+    }
+    case ACTION_KIND.CONTROL: {
+      const read = ACTIONS.RUN_SESSION_CONTROL.request.read(input);
+      const { chip, providerId } = namedSession(read.ok ? read.value : undefined, target, roster);
+      const controlKind = target?.controlKind;
+      const label = target?.controlLabel;
+      const lead =
+        controlKind === SESSION_CONTROL_KIND.ARCHIVE
+          ? "Archived "
+          : controlKind === SESSION_CONTROL_KIND.STOP
+            ? "Stopped "
+            : label === undefined
+              ? "Ran a control on "
+              : `Ran "${label}" on `;
+      return {
+        runs: [{ text: lead }, { chip }],
+        ...(providerId !== undefined ? { providerId } : undefined),
+        ...(controlKind !== undefined ? { controlKind } : undefined),
+      };
+    }
+    case ACTION_KIND.OPEN: {
+      const read = ACTIONS.OPEN_SESSION.request.read(input);
+      const { identity, chip, providerId } = namedSession(
+        read.ok ? read.value : undefined,
+        target,
+        roster,
+      );
+      const applicationId = target?.applicationId ?? (read.ok ? read.value.application : undefined);
+      return {
+        runs: [
+          { text: "Opened " },
+          { chip },
+          ...(applicationId === undefined
+            ? []
+            : [{ text: ` in ${applicationName(applicationId, rosterSession(identity, roster))}` }]),
+        ],
+        ...(providerId !== undefined ? { providerId } : undefined),
+      };
+    }
+    case ACTION_KIND.CREATE_WORKSPACE: {
+      const read = ACTIONS.CREATE_WORKSPACE.request.read(input);
+      const created =
+        envelope?.status === ACTION_OUTPUT_STATUS.ACCEPTED ? envelope.createdSession : undefined;
+      const providerId = target?.providerId ?? (read.ok ? read.value.provider_id : undefined);
+      const name = read.ok ? read.value.name : undefined;
+      const agent = read.ok ? read.value.agent : undefined;
+      const session = rosterSession(created, roster);
+      const chip: ToolRowChip | undefined =
+        session !== undefined
+          ? sessionChip(created, target, roster)
+          : name !== undefined
+            ? {
+                text: name,
+                ...((agent ?? providerId) ? { markId: agent ?? providerId } : undefined),
+                ...(created !== undefined ? { identity: created } : undefined),
+                openable: created !== undefined,
+              }
+            : undefined;
+      return {
+        runs:
+          chip === undefined
+            ? [{ text: "Created a new workspace" }]
+            : [{ text: "Created a new workspace " }, { chip }],
+        ...(providerId !== undefined ? { providerId } : undefined),
+      };
+    }
+    case ACTION_KIND.ADD_AGENT: {
+      const read = ACTIONS.ADD_WORKSPACE_AGENT.request.read(input);
+      const { chip, providerId } = namedSession(read.ok ? read.value : undefined, target, roster);
+      return {
+        runs: [
+          { text: read.ok ? `Added a ${read.value.agent} agent to ` : "Added an agent to " },
+          { chip },
+        ],
+        ...(providerId !== undefined ? { providerId } : undefined),
+      };
+    }
+    case ACTION_KIND.RENAME_WORKSPACE:
+    case ACTION_KIND.RENAME_SESSION: {
+      const read = (
+        kind === ACTION_KIND.RENAME_WORKSPACE ? ACTIONS.RENAME_WORKSPACE : ACTIONS.RENAME_SESSION
+      ).request.read(input);
+      const { chip, providerId } = namedSession(read.ok ? read.value : undefined, target, roster);
+      return {
+        runs: [
+          { text: kind === ACTION_KIND.RENAME_WORKSPACE ? "Renamed workspace " : "Renamed " },
+          { chip },
+          ...(read.ok ? [{ text: ` to "${read.value.name}"` }] : []),
+        ],
+        ...(providerId !== undefined ? { providerId } : undefined),
+      };
+    }
+  }
+}
+
+/**
+ * The row an action's tool part draws, or nothing for a tool that is not a
+ * session action. Composed from the part's arguments and its envelope alone,
+ * with the roster as it stands supplying only the current name and address of
+ * a session it still holds.
+ */
+export function toolRow(part: StoredToolPart, roster: readonly SessionView[]): ToolRow | undefined {
+  const kind = realtimeToolKind(storedToolName(part));
+  if (kind === undefined || !isSessionActionKind(kind)) return undefined;
+  const envelope = envelopeOf(part);
+  const target = envelope?.target;
+  const { status, reason } = rowStatus(part, envelope);
+  const composition = composeRuns(kind, part, target, envelope, roster);
+  const accepted = envelope?.status === ACTION_OUTPUT_STATUS.ACCEPTED ? envelope : undefined;
+  return {
+    kind,
+    ...(composition.controlKind !== undefined
+      ? { controlKind: composition.controlKind }
+      : undefined),
+    status,
+    ...(composition.providerId !== undefined ? { providerId: composition.providerId } : undefined),
+    runs: composition.runs,
+    ...(reason !== undefined ? { reason } : undefined),
+    ...(accepted?.note !== undefined ? { note: accepted.note } : undefined),
+    ...(accepted?.warning !== undefined ? { warning: accepted.warning } : undefined),
+  };
+}

--- a/apps/desktop/src/renderer/conversation-tool-row.ts
+++ b/apps/desktop/src/renderer/conversation-tool-row.ts
@@ -150,18 +150,24 @@ function rosterSession(
   );
 }
 
+/** What a chip falls back on when neither the roster nor the envelope names the session: the call's own words. */
+interface ChipFallback {
+  readonly name?: string;
+  readonly markId?: string;
+}
+
 /**
  * The chip for the session an action named: by the roster while it holds the
- * session, by the envelope's snapshot once it does not. A session the roster
- * holds is pressable exactly when its own row is; one the roster has let go is
- * pressable by identity, and the host answers with the address it last
- * reported or refuses.
+ * session, by the envelope's snapshot once it does not, and by the call's own
+ * words where neither says. A session the roster holds is pressable exactly
+ * when its own row is; one the roster has let go is pressable by identity,
+ * and the host answers with the address it last reported or refuses.
  */
 function sessionChip(
   identity: SessionIdentity | undefined,
   target: ActionTargetSnapshot | undefined,
   roster: readonly SessionView[],
-  fallbackName?: string,
+  fallback: ChipFallback = {},
 ): ToolRowChip {
   const session = rosterSession(identity, roster);
   if (session !== undefined) {
@@ -172,9 +178,9 @@ function sessionChip(
       openable: session.openable,
     };
   }
-  const markId = target?.agentId ?? target?.providerId ?? identity?.providerId;
+  const markId = target?.agentId ?? fallback.markId ?? target?.providerId ?? identity?.providerId;
   return {
-    text: target?.title ?? fallbackName ?? UNNAMED_SESSION,
+    text: target?.title ?? fallback.name ?? UNNAMED_SESSION,
     ...(markId !== undefined ? { markId } : undefined),
     ...(identity !== undefined ? { identity } : undefined),
     openable: identity !== undefined,
@@ -293,18 +299,18 @@ function composeRuns(
         envelope?.status === ACTION_OUTPUT_STATUS.ACCEPTED ? envelope.createdSession : undefined;
       const providerId = target?.providerId ?? (read.ok ? read.value.provider_id : undefined);
       const name = read.ok ? read.value.name : undefined;
-      const agent = read.ok ? read.value.agent : undefined;
-      const session = rosterSession(created, roster);
+      const markId = (read.ok ? read.value.agent : undefined) ?? providerId;
+      const fallback: ChipFallback = {
+        ...(name !== undefined ? { name } : undefined),
+        ...(markId !== undefined ? { markId } : undefined),
+      };
+      // The session the answer named is the chip, wherever the roster stands;
+      // a creation whose answer named none is a name alone, or no chip at all.
       const chip: ToolRowChip | undefined =
-        session !== undefined
-          ? sessionChip(created, target, roster)
+        created !== undefined
+          ? sessionChip(created, target, roster, fallback)
           : name !== undefined
-            ? {
-                text: name,
-                ...((agent ?? providerId) ? { markId: agent ?? providerId } : undefined),
-                ...(created !== undefined ? { identity: created } : undefined),
-                openable: created !== undefined,
-              }
+            ? { text: name, ...(markId !== undefined ? { markId } : undefined), openable: false }
             : undefined;
       return {
         runs:

--- a/apps/desktop/src/renderer/conversation-turns.fixtures.ts
+++ b/apps/desktop/src/renderer/conversation-turns.fixtures.ts
@@ -1,0 +1,400 @@
+import { ACTION_OUTPUT_STATUS, type ActionOutputEnvelope } from "@sidecar/actions";
+import {
+  CONVERSATION_VIEW_TOOL_KIND,
+  type ConversationViewInput,
+  type ConversationViewToolKinds,
+  type ConversationViewTurnGroup,
+  MESSAGE_AUTHOR,
+  MESSAGE_CHANNEL,
+  MESSAGE_ROLE,
+  SESSION_CONTROL_KIND,
+  SESSION_LOCATION,
+  SESSION_URGENCY,
+  type StoredToolPart,
+  selectConversationView,
+  TOOL_PART_STATE,
+} from "@sidecar/session";
+import type { StoredUIMessage } from "@sidecar/session/ui-messages";
+import { TURN_ORIGIN, TURN_STATUS } from "@sidecar/wire";
+import type { SessionView } from "./session-model";
+
+/**
+ * Synthetic scenarios the renderer is driven by before its data arrives: the
+ * rows a store would hold, run through the view selection exactly as a
+ * service would run them, over a roster that still holds some of the sessions
+ * they name and has let one go. Nothing here is copied from a real session.
+ */
+
+const PROVIDER = "conductor";
+const AGENT = "claude-code";
+
+export const FIXTURE_SESSION = {
+  /** Held by the roster: its chip names it by the roster's current title and opens like its row. */
+  HELD: "6c1f2f14-9a0b-4c2d-8e3f-0a1b2c3d4e50",
+  /** Held by the roster, but its provider reported no address: a name, not a press. */
+  UNOPENABLE: "7d2a3b25-0b1c-4d3e-9f40-1b2c3d4e5f61",
+  /** Gone from the roster since the action ran: named by the envelope's snapshot, opened by identity. */
+  DEPARTED: "8e3b4c36-1c2d-4e4f-a051-2c3d4e5f6a72",
+  /** The workspace a creation made, which the roster came to hold. */
+  CREATED: "9f4c5d47-2d3e-4f50-b162-3d4e5f6a7b83",
+} as const;
+
+export const FIXTURE_TITLE = {
+  HELD: "Fixture session",
+  HELD_THEN: "Fixture session (before rename)",
+  UNOPENABLE: "Quiet fixture",
+  DEPARTED: "Archived fixture",
+  CREATED: "Notch panel clipping",
+} as const;
+
+function rosterSession(id: string, title: string, openable: boolean): SessionView {
+  return {
+    id,
+    title,
+    providerId: PROVIDER,
+    provider: "Conductor",
+    agentId: AGENT,
+    agent: "Claude Code",
+    applications: [],
+    detail: "Working",
+    urgency: SESSION_URGENCY.WORKING,
+    label: "Working",
+    location: SESSION_LOCATION.CLOUD,
+    lastActivityAt: 1757505600000,
+    openable,
+    canMessage: true,
+    actions: [],
+    hasChange: false,
+  };
+}
+
+/** The roster as it stands when the scenarios are drawn. */
+export const FIXTURE_ROSTER: readonly SessionView[] = [
+  rosterSession(FIXTURE_SESSION.HELD, FIXTURE_TITLE.HELD, true),
+  rosterSession(FIXTURE_SESSION.UNOPENABLE, FIXTURE_TITLE.UNOPENABLE, false),
+  rosterSession(FIXTURE_SESSION.CREATED, FIXTURE_TITLE.CREATED, true),
+];
+
+const FIXTURE_TOOL_KINDS: ConversationViewToolKinds = new Map([
+  ["announce", CONVERSATION_VIEW_TOOL_KIND.ANNOUNCE],
+  ["send_session_message", CONVERSATION_VIEW_TOOL_KIND.ACTION],
+  ["run_session_control", CONVERSATION_VIEW_TOOL_KIND.ACTION],
+  ["open_session", CONVERSATION_VIEW_TOOL_KIND.ACTION],
+  ["create_workspace", CONVERSATION_VIEW_TOOL_KIND.ACTION],
+  ["add_workspace_agent", CONVERSATION_VIEW_TOOL_KIND.ACTION],
+  ["rename_workspace", CONVERSATION_VIEW_TOOL_KIND.ACTION],
+  ["rename_session", CONVERSATION_VIEW_TOOL_KIND.ACTION],
+]);
+
+const identity = (providerSessionId: string) => ({
+  provider_id: PROVIDER,
+  provider_session_id: providerSessionId,
+});
+
+const target = (providerSessionId: string, title: string) => ({
+  providerId: PROVIDER,
+  providerSessionId,
+  title,
+  agentId: AGENT,
+});
+
+const accepted = (
+  envelope: Omit<Extract<ActionOutputEnvelope, { status: "accepted" }>, "status">,
+) => ({
+  status: ACTION_OUTPUT_STATUS.ACCEPTED,
+  ...envelope,
+});
+
+type ToolCallInput = StoredToolPart["input"];
+type ToolCallOutput = Extract<
+  StoredToolPart,
+  { state: typeof TOOL_PART_STATE.OUTPUT_AVAILABLE }
+>["output"];
+
+let calls = 0;
+
+function call(toolName: string, input: ToolCallInput, output: ToolCallOutput): StoredToolPart {
+  calls += 1;
+  return {
+    type: `tool-${toolName}`,
+    toolCallId: `call_fixture_${String(calls).padStart(2, "0")}`,
+    state: TOOL_PART_STATE.OUTPUT_AVAILABLE,
+    input,
+    output,
+  };
+}
+
+function erroredCall(toolName: string, input: ToolCallInput, errorText: string): StoredToolPart {
+  calls += 1;
+  return {
+    type: `tool-${toolName}`,
+    toolCallId: `call_fixture_${String(calls).padStart(2, "0")}`,
+    state: TOOL_PART_STATE.OUTPUT_ERROR,
+    input,
+    errorText,
+  };
+}
+
+function pendingCall(toolName: string, input: ToolCallInput): StoredToolPart {
+  calls += 1;
+  return {
+    type: `tool-${toolName}`,
+    toolCallId: `call_fixture_${String(calls).padStart(2, "0")}`,
+    state: TOOL_PART_STATE.INPUT_AVAILABLE,
+    input,
+  };
+}
+
+const ask = (id: string, text: string): StoredUIMessage => ({
+  id,
+  role: MESSAGE_ROLE.USER,
+  metadata: { author: MESSAGE_AUTHOR.DEVELOPER, channel: MESSAGE_CHANNEL.TYPED },
+  parts: [{ type: "text", text }],
+});
+
+const reply = (id: string, parts: StoredUIMessage["parts"]): StoredUIMessage => ({
+  id,
+  role: MESSAGE_ROLE.ASSISTANT,
+  metadata: { author: MESSAGE_AUTHOR.BRAIN },
+  parts,
+});
+
+const TURN = {
+  ASK: "1a000000-0000-4000-8000-000000000101",
+  EVERY_KIND: "1a000000-0000-4000-8000-000000000102",
+  REFUSED: "1a000000-0000-4000-8000-000000000103",
+  ANNOUNCED: "1a000000-0000-4000-8000-000000000104",
+} as const;
+
+const AT = {
+  ASK: 1757505600000,
+  EVERY_KIND: 1757505700000,
+  REFUSED: 1757505800000,
+  ANNOUNCED: 1757505900000,
+} as const;
+
+/** One conversation covering every row the renderer draws. */
+export const FIXTURE_INPUT: ConversationViewInput = {
+  main: [
+    {
+      message: ask("2b000000-0000-4000-8000-000000000201", "Is the fixture session still waiting?"),
+      seq: 1,
+      turnId: TURN.ASK,
+      createdAt: AT.ASK,
+    },
+    {
+      message: reply("2b000000-0000-4000-8000-000000000202", [
+        { type: "step-start" },
+        {
+          type: "reasoning",
+          text: "The developer asked about the fixture session, so read its tail before answering.",
+          state: "done",
+        },
+        call("read_transcript", identity(FIXTURE_SESSION.HELD), {
+          lines: ["assistant: Waiting for permission to run the test suite."],
+        }),
+        { type: "step-start" },
+        { type: "text", text: "It is holding on a permission prompt.", state: "done" },
+      ]),
+      seq: 2,
+      turnId: TURN.ASK,
+      createdAt: AT.ASK + 1500,
+    },
+    {
+      message: ask(
+        "2b000000-0000-4000-8000-000000000203",
+        "Tell it to go ahead, archive the old one, and set up a workspace for the notch clipping.",
+      ),
+      seq: 3,
+      turnId: TURN.EVERY_KIND,
+      createdAt: AT.EVERY_KIND,
+    },
+    {
+      message: reply("2b000000-0000-4000-8000-000000000204", [
+        { type: "step-start" },
+        call(
+          "send_session_message",
+          { ...identity(FIXTURE_SESSION.HELD), text: "Yes, run the tests." },
+          accepted({ target: target(FIXTURE_SESSION.HELD, FIXTURE_TITLE.HELD_THEN) }),
+        ),
+        call(
+          "run_session_control",
+          { ...identity(FIXTURE_SESSION.DEPARTED), control_id: "archive" },
+          accepted({
+            target: {
+              ...target(FIXTURE_SESSION.DEPARTED, FIXTURE_TITLE.DEPARTED),
+              controlKind: SESSION_CONTROL_KIND.ARCHIVE,
+              controlLabel: "Archive",
+            },
+          }),
+        ),
+        call(
+          "run_session_control",
+          { ...identity(FIXTURE_SESSION.HELD), control_id: "stop" },
+          accepted({
+            target: {
+              ...target(FIXTURE_SESSION.HELD, FIXTURE_TITLE.HELD_THEN),
+              controlKind: SESSION_CONTROL_KIND.STOP,
+              controlLabel: "Stop",
+            },
+          }),
+        ),
+        call(
+          "run_session_control",
+          { ...identity(FIXTURE_SESSION.UNOPENABLE), control_id: "retry" },
+          accepted({
+            target: {
+              ...target(FIXTURE_SESSION.UNOPENABLE, FIXTURE_TITLE.UNOPENABLE),
+              controlKind: SESSION_CONTROL_KIND.ACTION,
+              controlLabel: "Retry",
+            },
+          }),
+        ),
+        call(
+          "open_session",
+          { ...identity(FIXTURE_SESSION.HELD), application: "claude" },
+          accepted({
+            target: {
+              ...target(FIXTURE_SESSION.HELD, FIXTURE_TITLE.HELD_THEN),
+              applicationId: "claude",
+            },
+            note: "Opened in Claude.",
+          }),
+        ),
+        call(
+          "create_workspace",
+          { provider_id: PROVIDER, name: FIXTURE_TITLE.CREATED, agent: AGENT },
+          accepted({
+            target: { providerId: PROVIDER },
+            createdSession: { providerId: PROVIDER, providerSessionId: FIXTURE_SESSION.CREATED },
+          }),
+        ),
+        call(
+          "add_workspace_agent",
+          { ...identity(FIXTURE_SESSION.CREATED), agent: "codex" },
+          accepted({ target: target(FIXTURE_SESSION.CREATED, FIXTURE_TITLE.CREATED) }),
+        ),
+        call(
+          "rename_workspace",
+          { ...identity(FIXTURE_SESSION.CREATED), name: FIXTURE_TITLE.CREATED },
+          accepted({ target: target(FIXTURE_SESSION.CREATED, "Untitled workspace") }),
+        ),
+        call(
+          "rename_session",
+          { ...identity(FIXTURE_SESSION.HELD), name: FIXTURE_TITLE.HELD },
+          accepted({ target: target(FIXTURE_SESSION.HELD, FIXTURE_TITLE.HELD_THEN) }),
+        ),
+        { type: "step-start" },
+        {
+          type: "text",
+          text: "Done: told it to go ahead, archived the old one, and set up the workspace.",
+          state: "done",
+        },
+      ]),
+      seq: 4,
+      turnId: TURN.EVERY_KIND,
+      createdAt: AT.EVERY_KIND + 4000,
+    },
+    {
+      message: ask("2b000000-0000-4000-8000-000000000205", "Approve it and delete the other one."),
+      seq: 5,
+      turnId: TURN.REFUSED,
+      createdAt: AT.REFUSED,
+    },
+    {
+      message: reply("2b000000-0000-4000-8000-000000000206", [
+        { type: "step-start" },
+        erroredCall(
+          "run_session_control",
+          { ...identity(FIXTURE_SESSION.HELD), control_id: "approve" },
+          "The control is no longer advertised.",
+        ),
+        call(
+          "send_session_message",
+          { ...identity(FIXTURE_SESSION.DEPARTED), text: "Please delete it." },
+          {
+            status: ACTION_OUTPUT_STATUS.REFUSED,
+            reason: "That session is no longer observed.",
+            target: target(FIXTURE_SESSION.DEPARTED, FIXTURE_TITLE.DEPARTED),
+          },
+        ),
+        call(
+          "send_session_message",
+          { ...identity(FIXTURE_SESSION.HELD), text: "Carry on." },
+          {
+            status: ACTION_OUTPUT_STATUS.UNKNOWN,
+            reason: "The connection closed before the provider answered.",
+            target: target(FIXTURE_SESSION.HELD, FIXTURE_TITLE.HELD),
+          },
+        ),
+        pendingCall("send_session_message", {
+          ...identity(FIXTURE_SESSION.HELD),
+          text: "Still there?",
+        }),
+        { type: "step-start" },
+        {
+          type: "text",
+          text: "The approve control is gone, and the other session is no longer observed.",
+          state: "done",
+        },
+      ]),
+      seq: 6,
+      turnId: TURN.REFUSED,
+      createdAt: AT.REFUSED + 2000,
+    },
+  ],
+  observed: [
+    {
+      session: { providerId: PROVIDER, providerSessionId: FIXTURE_SESSION.HELD },
+      messages: [
+        {
+          message: reply("2b000000-0000-4000-8000-000000000301", [
+            { type: "step-start" },
+            {
+              type: "reasoning",
+              text: "The session stopped to ask for permission; that is worth a word.",
+              state: "done",
+            },
+            call(
+              "announce",
+              { briefing: "The fixture session is waiting on a permission prompt." },
+              {},
+            ),
+            { type: "text", text: "Announced.", state: "done" },
+          ]),
+          seq: 1,
+          turnId: TURN.ANNOUNCED,
+          createdAt: AT.ANNOUNCED,
+        },
+      ],
+    },
+  ],
+  turns: [
+    { id: TURN.ASK, origin: TURN_ORIGIN.TYPED, status: TURN_STATUS.SETTLED, queuedAt: AT.ASK },
+    {
+      id: TURN.EVERY_KIND,
+      origin: TURN_ORIGIN.TYPED,
+      status: TURN_STATUS.SETTLED,
+      queuedAt: AT.EVERY_KIND,
+    },
+    {
+      id: TURN.REFUSED,
+      origin: TURN_ORIGIN.TYPED,
+      status: TURN_STATUS.SETTLED,
+      queuedAt: AT.REFUSED,
+    },
+    {
+      id: TURN.ANNOUNCED,
+      origin: TURN_ORIGIN.ROSTER_DIFF,
+      status: TURN_STATUS.SETTLED,
+      queuedAt: AT.ANNOUNCED,
+    },
+  ],
+  events: [],
+  toolKinds: FIXTURE_TOOL_KINDS,
+};
+
+/** The scenarios as the renderer takes them: the view selection over the rows above. */
+export function fixtureConversationTurns(): readonly ConversationViewTurnGroup[] {
+  return selectConversationView(FIXTURE_INPUT);
+}

--- a/apps/desktop/src/renderer/conversation-turns.test.ts
+++ b/apps/desktop/src/renderer/conversation-turns.test.ts
@@ -1,0 +1,196 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  CONVERSATION_VIEW_TOOL_KIND,
+  type ConversationViewTurnGroup,
+  isStoredToolPart,
+  MESSAGE_ROLE,
+  type SessionIdentity,
+  selectConversationView,
+} from "@sidecar/session";
+import { CONVERSATION_EVENT_KIND } from "@sidecar/wire";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { TOOL_ROW_STATUS, toolRow } from "./conversation-tool-row";
+import { announcedWords, ConversationTurns, detailToolLabel } from "./conversation-turns";
+import {
+  FIXTURE_INPUT,
+  FIXTURE_ROSTER,
+  fixtureConversationTurns,
+} from "./conversation-turns.fixtures";
+
+const OPEN = (identity: SessionIdentity) => void identity;
+
+function render(
+  groups: readonly ConversationViewTurnGroup[],
+  onOpenChat?: (identity: SessionIdentity) => void,
+) {
+  return renderToStaticMarkup(
+    createElement(ConversationTurns, {
+      groups,
+      roster: FIXTURE_ROSTER,
+      ...(onOpenChat ? { onOpenChat } : undefined),
+    }),
+  );
+}
+
+/** How many times one fixed attribute the renderer stamps appears; a structural count, never a phrase. */
+function count(markup: string, attribute: string, value: string): number {
+  return markup.split(`${attribute}="${value}"`).length - 1;
+}
+
+const FOLD_OPENING = '<details class="conversation-turn-details"';
+
+test("the fixture scenarios draw every session action kind as a row", () => {
+  const markup = render(fixtureConversationTurns(), OPEN);
+  const kinds = new Set<string>();
+  for (const match of markup.matchAll(/data-action-kind="([^"]+)"/g)) {
+    if (match[1] !== undefined) kinds.add(match[1]);
+  }
+  assert.deepEqual([...kinds].sort(), [
+    "add-agent",
+    "control",
+    "create-workspace",
+    "message",
+    "open",
+    "rename-session",
+    "rename-workspace",
+  ]);
+  // Both the accepted actions and the three other outcomes stand in the thread.
+  assert.ok(count(markup, "data-tool-status", TOOL_ROW_STATUS.ACCEPTED) >= 7);
+  assert.equal(count(markup, "data-tool-status", TOOL_ROW_STATUS.REFUSED), 1);
+  assert.equal(count(markup, "data-tool-status", TOOL_ROW_STATUS.UNKNOWN), 1);
+  assert.equal(count(markup, "data-tool-status", TOOL_ROW_STATUS.PENDING), 1);
+});
+
+test("a chip is a press exactly where the composition says the session opens, and a name everywhere else", () => {
+  const groups = fixtureConversationTurns();
+  const chips = groups
+    .flatMap((group) => group.messages)
+    .flatMap((view) =>
+      view.message.role === MESSAGE_ROLE.ASSISTANT
+        ? view.message.parts.filter(isStoredToolPart).flatMap((part) => {
+            const row = toolRow(part, FIXTURE_ROSTER);
+            return row ? row.runs.flatMap((run) => ("chip" in run ? [run.chip] : [])) : [];
+          })
+        : [],
+    );
+  const pressable = chips.filter((chip) => chip.identity !== undefined && chip.openable).length;
+  assert.ok(pressable > 0 && pressable < chips.length);
+
+  const withPress = render(groups, OPEN);
+  assert.equal(
+    count(withPress, "class", "conversation-action-chip") -
+      withPress.split('<button type="button" class="conversation-action-chip"').length +
+      1,
+    chips.length - pressable,
+  );
+  assert.equal(
+    withPress.split('<button type="button" class="conversation-action-chip"').length - 1,
+    pressable,
+  );
+
+  // With nothing to hand a press to, every chip is a name.
+  const withoutPress = render(groups);
+  assert.equal(
+    withoutPress.split('<button type="button" class="conversation-action-chip"').length - 1,
+    0,
+  );
+  assert.equal(count(withoutPress, "class", "conversation-action-chip"), chips.length);
+});
+
+test("a refused action and the turn's details draw only inside the turn's fold", () => {
+  const groups = fixtureConversationTurns();
+  const folded = groups.filter((group) =>
+    group.messages.some((view) =>
+      view.tools.some(
+        (tool) =>
+          tool.kind === CONVERSATION_VIEW_TOOL_KIND.DETAIL ||
+          (tool.kind === CONVERSATION_VIEW_TOOL_KIND.ACTION && tool.refused),
+      ),
+    ),
+  );
+  assert.equal(folded.length, 2);
+  for (const group of folded) {
+    const markup = render([group], OPEN);
+    assert.equal(count(markup, "data-folded", "true"), 1);
+    const [aboveFold, insideFold] = markup.split(FOLD_OPENING);
+    assert.ok(aboveFold !== undefined && insideFold !== undefined);
+    assert.equal(count(aboveFold, "data-tool-status", TOOL_ROW_STATUS.FAILED), 0);
+    assert.equal(count(aboveFold, "class", "conversation-detail"), 0);
+    const failedActions = group.messages
+      .flatMap((view) => view.tools)
+      .filter((tool) => tool.kind === CONVERSATION_VIEW_TOOL_KIND.ACTION && tool.refused).length;
+    const details = group.messages
+      .flatMap((view) => view.tools)
+      .filter((tool) => tool.kind === CONVERSATION_VIEW_TOOL_KIND.DETAIL).length;
+    assert.equal(count(insideFold, "data-tool-status", TOOL_ROW_STATUS.FAILED), failedActions);
+    assert.equal(count(insideFold, "class", "conversation-detail"), details);
+  }
+  const unfolded = groups.filter((group) => !folded.includes(group));
+  assert.ok(unfolded.length > 0);
+  assert.equal(count(render(unfolded, OPEN), "data-folded", "true"), 0);
+});
+
+test("a reasoning part folds to a line on Luke's side, and an announcement is his bubble marked when unheard", () => {
+  const groups = fixtureConversationTurns();
+  const markup = render(groups, OPEN);
+  // Main's turn carries its thought; the observed turn's crosses cut to its announcement.
+  assert.equal(count(markup, "data-reasoning", "true"), 1);
+  assert.equal(count(markup, "data-unspoken", "true"), 0);
+
+  const announced = FIXTURE_INPUT.observed[0]?.messages[0];
+  assert.ok(announced);
+  const expired = selectConversationView({
+    ...FIXTURE_INPUT,
+    main: [],
+    events: [
+      { messageId: announced.message.id, kind: CONVERSATION_EVENT_KIND.SPEECH_OFFERED, seq: 1 },
+      { messageId: announced.message.id, kind: CONVERSATION_EVENT_KIND.SPEECH_EXPIRED, seq: 2 },
+    ],
+  });
+  const unheard = render(expired, OPEN);
+  assert.equal(count(unheard, "data-unspoken", "true"), 1);
+  assert.equal(count(unheard, "data-speaker", "luke"), 1);
+  assert.equal(count(unheard, "data-reasoning", "true"), 0);
+});
+
+test("the words an announce call carries are its briefing, and a detail's label is its tool's name", () => {
+  const announced = FIXTURE_INPUT.observed[0]?.messages[0]?.message;
+  assert.ok(announced && announced.role === MESSAGE_ROLE.ASSISTANT);
+  const announce = announced.parts
+    .filter(isStoredToolPart)
+    .find((part) => part.type === "tool-announce");
+  assert.ok(announce);
+  assert.equal(announcedWords(announce), "The fixture session is waiting on a permission prompt.");
+  assert.equal(announcedWords({ ...announce, input: { text: "not a briefing" } }), undefined);
+  assert.equal(detailToolLabel("read_transcript"), "read transcript");
+});
+
+test("a developer's row is a sent bubble with a copy control, and a note the brain wrote is a quiet row", () => {
+  const groups = fixtureConversationTurns();
+  const markup = render(groups, OPEN);
+  const asks = FIXTURE_INPUT.main.filter((row) => row.message.role === MESSAGE_ROLE.USER).length;
+  assert.equal(count(markup, "data-speaker", "you"), asks);
+  const noted = selectConversationView({
+    ...FIXTURE_INPUT,
+    observed: [],
+    main: [
+      {
+        message: {
+          id: "2b000000-0000-4000-8000-000000000901",
+          role: MESSAGE_ROLE.USER,
+          metadata: { author: "brain", source: "roster_look" },
+          parts: [{ type: "text", text: "Roster: a session finished." }],
+        },
+        seq: 1,
+        turnId: "1a000000-0000-4000-8000-000000000901",
+        createdAt: 1757505600000,
+      },
+    ],
+  });
+  const note = render(noted);
+  assert.equal(count(note, "data-speaker", "you"), 0);
+  assert.equal(count(note, "data-speaker", "event"), 1);
+  assert.equal(count(note, "class", "conversation-copy"), 0);
+});

--- a/apps/desktop/src/renderer/conversation-turns.tsx
+++ b/apps/desktop/src/renderer/conversation-turns.tsx
@@ -1,0 +1,543 @@
+import { ACTION_KIND, type SessionActionKind } from "@sidecar/actions";
+import {
+  ArchiveIcon,
+  ControlIcon,
+  ExternalIcon,
+  MessageIcon,
+  PencilIcon,
+  PlusIcon,
+  ProviderMark,
+  StopIcon,
+} from "@sidecar/panel";
+import {
+  CONVERSATION_VIEW_TOOL_KIND,
+  type ConversationViewMessage,
+  type ConversationViewToolPart,
+  type ConversationViewTurnGroup,
+  isStoredToolPart,
+  MESSAGE_AUTHOR,
+  MESSAGE_ROLE,
+  SESSION_CONTROL_KIND,
+  type SessionControlKind,
+  type SessionIdentity,
+  type StoredToolPart,
+  storedToolName,
+  TOOL_PART_STATE,
+} from "@sidecar/session";
+import type { StoredUIMessage } from "@sidecar/session/ui-messages";
+import { isRecord, isWireString, unparsedWire, type WireBoundaryInput } from "@sidecar/wire";
+import { ConversationCopyButton } from "./conversation-copy";
+import { CONVERSATION_ENTRY_SPEAKER, type ConversationEntrySpeaker } from "./conversation-panel";
+import { TOOL_ROW_STATUS, type ToolRow, type ToolRowChip, toolRow } from "./conversation-tool-row";
+import { MarkdownMessage } from "./markdown-message";
+import type { SessionView } from "./session-model";
+import { ThinkingDots } from "./thinking-dots";
+
+/**
+ * The Conversation drawn from its stored shape: the turn groups the view
+ * selection answers, each a run of `UIMessage` rows. A text part is a bubble
+ * on its author's side; a reasoning part is Luke's thought, folded to a line
+ * that opens on its summary; an announcement is Luke's briefing in his own
+ * bubble, marked when nobody heard it; and an action is a row composed from
+ * the call's arguments and the envelope it answered with, the session it
+ * reached a chip that is the row's own press by another hand. What the view
+ * classed as a detail — a read, a workspace write, a delegation — and an
+ * action whose tool failed outright draw only inside the turn, folded under
+ * a count, so the thread reads as what was said and done and the turn's
+ * working stays a level down.
+ *
+ * Everything here is drawn inside the Conversation subtree, which the session
+ * recording blocks whole: a session's title on a chip, a briefing's words, a
+ * refusal's reason all stay on this machine.
+ */
+
+/** What each kind of row is to a reader: who it speaks for, and the name read before it. */
+interface RowVoice {
+  readonly speaker: ConversationEntrySpeaker;
+  readonly label: string;
+}
+
+const VOICE = {
+  YOU: { speaker: CONVERSATION_ENTRY_SPEAKER.YOU, label: "You" },
+  LUKE: { speaker: CONVERSATION_ENTRY_SPEAKER.LUKE, label: "Luke" },
+  /** A note the brain wrote itself into the conversation, never the developer's words. */
+  NOTE: { speaker: CONVERSATION_ENTRY_SPEAKER.EVENT, label: "Note" },
+  ACTION: { speaker: CONVERSATION_ENTRY_SPEAKER.EVENT, label: "Action" },
+} as const satisfies Record<string, RowVoice>;
+
+/**
+ * The mark an action row leads with, one per kind of thing that can be done
+ * to a session, total over the kinds so a new kind does not compile until it
+ * has one. Two renames share the pencil and two creations the plus: the mark
+ * says what sort of thing happened, and the words say to what.
+ */
+const ACTION_GLYPH = {
+  [ACTION_KIND.MESSAGE]: MessageIcon,
+  [ACTION_KIND.CONTROL]: ControlIcon,
+  [ACTION_KIND.OPEN]: ExternalIcon,
+  [ACTION_KIND.CREATE_WORKSPACE]: PlusIcon,
+  [ACTION_KIND.ADD_AGENT]: PlusIcon,
+  [ACTION_KIND.RENAME_WORKSPACE]: PencilIcon,
+  [ACTION_KIND.RENAME_SESSION]: PencilIcon,
+} as const satisfies Record<SessionActionKind, () => React.JSX.Element>;
+
+/** A control's mark follows what its adapter said it does; a plain action keeps the bolt. */
+const CONTROL_GLYPH = {
+  [SESSION_CONTROL_KIND.ACTION]: ControlIcon,
+  [SESSION_CONTROL_KIND.ARCHIVE]: ArchiveIcon,
+  [SESSION_CONTROL_KIND.STOP]: StopIcon,
+} as const satisfies Record<SessionControlKind, () => React.JSX.Element>;
+
+function actionGlyph(row: ToolRow): () => React.JSX.Element {
+  return row.controlKind !== undefined ? CONTROL_GLYPH[row.controlKind] : ACTION_GLYPH[row.kind];
+}
+
+/** What a reader is told of an announcement no device claimed before its offer lapsed. */
+const UNSPOKEN_LABEL = "Not spoken";
+
+/** What a reader is told of an action still under way. */
+const PENDING_LABEL = "Under way";
+
+const ROW_TIME = new Intl.DateTimeFormat(undefined, { hour: "numeric", minute: "2-digit" });
+
+function RowStamp({ at }: { at: number }): React.JSX.Element {
+  const instant = new Date(at);
+  return (
+    <time className="conversation-time" dateTime={instant.toISOString()}>
+      {ROW_TIME.format(instant)}
+    </time>
+  );
+}
+
+function BubbleRow({
+  voice,
+  words,
+  at,
+  copy = true,
+  unspoken = false,
+}: {
+  voice: RowVoice;
+  words: string;
+  at: number;
+  copy?: boolean;
+  unspoken?: boolean;
+}): React.JSX.Element {
+  return (
+    <li
+      className="conversation-entry"
+      data-speaker={voice.speaker}
+      data-unspoken={unspoken ? "true" : undefined}
+    >
+      <small className="visually-hidden">{voice.label}</small>
+      <div className="conversation-message">
+        <span className="conversation-bubble">
+          <MarkdownMessage words={words} className="conversation-words" />
+          {unspoken ? <span className="conversation-unspoken">{UNSPOKEN_LABEL}</span> : null}
+          {copy ? <ConversationCopyButton words={words} /> : null}
+        </span>
+      </div>
+      <RowStamp at={at} />
+    </li>
+  );
+}
+
+/** Luke's thought before what followed it, folded to a line that opens on its words; never a control of anything. */
+function ReasoningRow({ text }: { text: string }): React.JSX.Element {
+  return (
+    <li
+      className="conversation-entry"
+      data-speaker={CONVERSATION_ENTRY_SPEAKER.LUKE}
+      data-reasoning="true"
+    >
+      <small className="visually-hidden">{VOICE.LUKE.label}</small>
+      <div className="conversation-message">
+        <details className="conversation-reasoning">
+          <summary className="conversation-reasoning-summary">Thought</summary>
+          <span className="conversation-reasoning-words">{text}</span>
+        </details>
+      </div>
+    </li>
+  );
+}
+
+/**
+ * The chip naming the session an action reached. Where the session has an
+ * identity to open by and its row would open, the chip is that row's own press
+ * by another hand: it mints the same open act, for the identity the record
+ * names, and the host answers with the address the provider reported — or
+ * refuses, for a session that reported none. Every other chip is a name.
+ */
+function SessionChip({
+  chip,
+  onOpenChat,
+}: {
+  chip: ToolRowChip;
+  onOpenChat?: (identity: SessionIdentity) => void;
+}): React.JSX.Element {
+  const face = (
+    <>
+      {chip.markId === undefined ? null : (
+        <ProviderMark providerId={chip.markId} className="conversation-chip-mark" />
+      )}
+      {chip.text}
+    </>
+  );
+  const identity = chip.identity;
+  return identity !== undefined && chip.openable && onOpenChat !== undefined ? (
+    <button
+      type="button"
+      className="conversation-action-chip"
+      aria-label={`Open ${chip.text}`}
+      onClick={() => onOpenChat(identity)}
+    >
+      {face}
+    </button>
+  ) : (
+    <span className="conversation-action-chip">{face}</span>
+  );
+}
+
+/** A row's runs are one chip at most and text runs that never repeat, so each names itself. */
+const RUN_KEY = { CHIP: "chip" } as const;
+
+function chipOf(row: ToolRow): ToolRowChip | undefined {
+  for (const run of row.runs) if ("chip" in run) return run.chip;
+  return undefined;
+}
+
+/**
+ * An action Luke carried is a row rather than a bubble: what was done, in the
+ * quiet voice the dates use, led by a mark for the kind of thing it was and
+ * ended on the mark of the provider it reached — unless the chip already wears
+ * that provider's mark, in which case the row's trailing mark stands down
+ * rather than repeat it. A refused or unknown outcome says why under the
+ * words; an accepted one shows the carrier's own note where it wrote one.
+ */
+function ActionRow({
+  row,
+  at,
+  onOpenChat,
+}: {
+  row: ToolRow;
+  at?: number;
+  onOpenChat?: (identity: SessionIdentity) => void;
+}): React.JSX.Element {
+  const Glyph = actionGlyph(row);
+  const chip = chipOf(row);
+  const trailingProvider =
+    row.providerId !== undefined && chip?.markId !== row.providerId ? row.providerId : undefined;
+  return (
+    <li
+      className="conversation-entry"
+      data-speaker={VOICE.ACTION.speaker}
+      data-action-kind={row.kind}
+      data-tool-status={row.status}
+    >
+      <small className="visually-hidden">{VOICE.ACTION.label}</small>
+      <div className="conversation-message">
+        <span className="conversation-action">
+          <span
+            className="conversation-action-mark"
+            aria-hidden="true"
+            data-control={row.controlKind}
+          >
+            <Glyph />
+          </span>
+          <span className="conversation-action-body">
+            <span className="conversation-words">
+              {row.runs.map((run) =>
+                "chip" in run ? (
+                  <SessionChip
+                    key={RUN_KEY.CHIP}
+                    chip={run.chip}
+                    {...(onOpenChat ? { onOpenChat } : undefined)}
+                  />
+                ) : (
+                  <span key={run.text}>{run.text}</span>
+                ),
+              )}
+              {row.status === TOOL_ROW_STATUS.PENDING ? (
+                <span className="conversation-action-pending">
+                  <ThinkingDots />
+                  <span className="visually-hidden">{PENDING_LABEL}</span>
+                </span>
+              ) : null}
+            </span>
+            {row.reason !== undefined ? (
+              <span className="conversation-action-reason">{row.reason}</span>
+            ) : null}
+            {row.note !== undefined ? (
+              <span className="conversation-action-note">{row.note}</span>
+            ) : null}
+            {row.warning !== undefined ? (
+              <span className="conversation-action-reason">{row.warning}</span>
+            ) : null}
+          </span>
+          {trailingProvider === undefined ? null : (
+            <span className="conversation-action-provider" aria-hidden="true">
+              <ProviderMark providerId={trailingProvider} />
+            </span>
+          )}
+        </span>
+      </div>
+      {at === undefined ? null : <RowStamp at={at} />}
+    </li>
+  );
+}
+
+/** What a detail's state says of it, in one word the row draws beside the tool's name. */
+const DETAIL_STATE_LABEL = {
+  [TOOL_PART_STATE.INPUT_STREAMING]: PENDING_LABEL,
+  [TOOL_PART_STATE.INPUT_AVAILABLE]: PENDING_LABEL,
+  [TOOL_PART_STATE.OUTPUT_AVAILABLE]: "Done",
+  [TOOL_PART_STATE.OUTPUT_ERROR]: "Failed",
+} as const satisfies Record<StoredToolPart["state"], string>;
+
+/** A tool's name as a reader sees it: the underscores the model spells it with become spaces. */
+export function detailToolLabel(toolName: string): string {
+  return toolName.replaceAll("_", " ");
+}
+
+/**
+ * A call the view classed as a detail — a read, a workspace write, a
+ * delegation: the turn's working, named by its tool and its state and nothing
+ * of what it read or wrote, drawn only inside the turn.
+ */
+function DetailRow({ part }: { part: StoredToolPart }): React.JSX.Element {
+  return (
+    <li className="conversation-detail" data-tool-state={part.state}>
+      <span className="conversation-detail-name">{detailToolLabel(storedToolName(part))}</span>
+      <span className="conversation-detail-state">{DETAIL_STATE_LABEL[part.state]}</span>
+      {part.state === TOOL_PART_STATE.OUTPUT_ERROR ? (
+        <span className="conversation-action-reason">{part.errorText}</span>
+      ) : null}
+    </li>
+  );
+}
+
+/** What the turn folds a level down: its details, and the actions whose tools failed outright. */
+type FoldedRow =
+  | { readonly kind: typeof CONVERSATION_VIEW_TOOL_KIND.DETAIL; readonly part: StoredToolPart }
+  | {
+      readonly kind: typeof CONVERSATION_VIEW_TOOL_KIND.ACTION;
+      readonly row: ToolRow;
+      readonly part: StoredToolPart;
+    };
+
+function foldedLabel(count: number): string {
+  return count === 1 ? "1 detail" : `${count} details`;
+}
+
+/**
+ * The turn's working, folded under a count: closed by default, opened on the
+ * summary's press, and a native disclosure rather than a control of Luke's
+ * own, so a reader opens and closes it with nothing else moving.
+ */
+function FoldedRows({
+  rows,
+  onOpenChat,
+}: {
+  rows: readonly FoldedRow[];
+  onOpenChat?: (identity: SessionIdentity) => void;
+}): React.JSX.Element {
+  return (
+    <li
+      className="conversation-entry"
+      data-speaker={CONVERSATION_ENTRY_SPEAKER.EVENT}
+      data-folded="true"
+    >
+      <div className="conversation-message">
+        <details className="conversation-turn-details">
+          <summary className="conversation-turn-summary">{foldedLabel(rows.length)}</summary>
+          <ol className="conversation-turn-rows">
+            {rows.map((folded) =>
+              folded.kind === CONVERSATION_VIEW_TOOL_KIND.DETAIL ? (
+                <DetailRow key={folded.part.toolCallId} part={folded.part} />
+              ) : (
+                <ActionRow
+                  key={folded.part.toolCallId}
+                  row={folded.row}
+                  {...(onOpenChat ? { onOpenChat } : undefined)}
+                />
+              ),
+            )}
+          </ol>
+        </details>
+      </div>
+    </li>
+  );
+}
+
+type StoredPart = StoredUIMessage["parts"][number];
+
+/**
+ * The two part types drawn as words, as the SDK spells them. Restated here
+ * against the SDK's own type rather than imported at run time, because the
+ * session barrel reaches the SDK for its types alone and this bundle keeps it
+ * that way.
+ */
+const UI_PART_TYPE = {
+  TEXT: "text",
+  REASONING: "reasoning",
+} as const satisfies Record<string, StoredPart["type"]>;
+
+type TextPart = Extract<StoredPart, { type: typeof UI_PART_TYPE.TEXT }>;
+type ReasoningPart = Extract<StoredPart, { type: typeof UI_PART_TYPE.REASONING }>;
+
+function isTextPart(part: StoredPart): part is TextPart {
+  return part.type === UI_PART_TYPE.TEXT;
+}
+
+function isReasoningPart(part: StoredPart): part is ReasoningPart {
+  return part.type === UI_PART_TYPE.REASONING;
+}
+
+/** The words an announce call carries: its one `briefing` argument, or nothing for a call spelled otherwise. */
+export function announcedWords(part: StoredToolPart): string | undefined {
+  // SAFETY: a stored part's input is the call's JSON arguments; the wire boundary is where they are read.
+  const input = unparsedWire(part.input as WireBoundaryInput);
+  return isRecord(input) && isWireString(input.briefing) ? input.briefing : undefined;
+}
+
+/** The text a user row says, every text part joined as paragraphs. */
+function userWords(message: StoredUIMessage): string {
+  return message.parts
+    .filter(isTextPart)
+    .map((part) => part.text)
+    .join("\n\n");
+}
+
+function userVoice(
+  message: Extract<StoredUIMessage, { role: typeof MESSAGE_ROLE.USER }>,
+): RowVoice {
+  return message.metadata.author === MESSAGE_AUTHOR.DEVELOPER ? VOICE.YOU : VOICE.NOTE;
+}
+
+/**
+ * One message's rows: a user row is one bubble; an assistant row is its parts
+ * in order, each drawn as what it is, with the turn's working set aside for
+ * the fold. Which tool calls are announcements, actions, or details is the
+ * view's decision, read back by call id; a call the view did not describe is
+ * a detail.
+ */
+interface MessageRows {
+  readonly rows: readonly React.JSX.Element[];
+  readonly folded: readonly FoldedRow[];
+}
+
+function messageRows(
+  view: ConversationViewMessage,
+  roster: readonly SessionView[],
+  onOpenChat: ((identity: SessionIdentity) => void) | undefined,
+): MessageRows {
+  const { message } = view;
+  if (message.role === MESSAGE_ROLE.USER) {
+    const voice = userVoice(message);
+    return {
+      rows: [
+        <BubbleRow
+          key={message.id}
+          voice={voice}
+          words={userWords(message)}
+          at={view.createdAt}
+          copy={voice === VOICE.YOU}
+        />,
+      ],
+      folded: [],
+    };
+  }
+  if (message.role === MESSAGE_ROLE.SYSTEM) return { rows: [], folded: [] };
+  const folded: FoldedRow[] = [];
+  const described = new Map<string, ConversationViewToolPart>(
+    view.tools.map((tool) => [tool.toolCallId, tool]),
+  );
+  const rows: React.JSX.Element[] = [];
+  const open = onOpenChat ? { onOpenChat } : undefined;
+  message.parts.forEach((part: StoredPart, index) => {
+    const key = `${message.id}:${index}`;
+    if (isTextPart(part)) {
+      rows.push(<BubbleRow key={key} voice={VOICE.LUKE} words={part.text} at={view.createdAt} />);
+      return;
+    }
+    if (isReasoningPart(part)) {
+      rows.push(<ReasoningRow key={key} text={part.text} />);
+      return;
+    }
+    if (!isStoredToolPart(part)) return;
+    const tool = described.get(part.toolCallId);
+    switch (tool?.kind) {
+      case CONVERSATION_VIEW_TOOL_KIND.ANNOUNCE: {
+        const words = announcedWords(part);
+        if (words !== undefined) {
+          rows.push(
+            <BubbleRow
+              key={key}
+              voice={VOICE.LUKE}
+              words={words}
+              at={view.createdAt}
+              unspoken={tool.unspoken}
+            />,
+          );
+        }
+        return;
+      }
+      case CONVERSATION_VIEW_TOOL_KIND.ACTION: {
+        const row = toolRow(part, roster);
+        if (row === undefined) {
+          folded.push({ kind: CONVERSATION_VIEW_TOOL_KIND.DETAIL, part });
+        } else if (tool.refused) {
+          folded.push({ kind: CONVERSATION_VIEW_TOOL_KIND.ACTION, row, part });
+        } else {
+          rows.push(<ActionRow key={key} row={row} at={view.createdAt} {...open} />);
+        }
+        return;
+      }
+      default:
+        folded.push({ kind: CONVERSATION_VIEW_TOOL_KIND.DETAIL, part });
+    }
+  });
+  return { rows, folded };
+}
+
+/**
+ * The thread as turns. Each group's messages draw in sequence, and the
+ * group's working — its details and its failed actions — closes the group
+ * under one fold, so a refusal is read inside the turn that tried it and
+ * never as a row of its own.
+ */
+export function ConversationTurns({
+  groups,
+  roster = [],
+  onOpenChat,
+}: {
+  groups: readonly ConversationViewTurnGroup[];
+  /**
+   * The sessions as the roster holds them now, so a chip names a session by
+   * its current title while the roster still holds it and offers its press
+   * exactly when its own row would; a session the roster has let go is named
+   * from the envelope's snapshot instead.
+   */
+  roster?: readonly SessionView[];
+  /** The row's own press by identity; absent where nothing can open a session, and every chip is a name. */
+  onOpenChat?: (identity: SessionIdentity) => void;
+}): React.JSX.Element {
+  return (
+    <ol className="conversation-list">
+      {groups.flatMap((group) => {
+        const drawn = group.messages.map((message) => messageRows(message, roster, onOpenChat));
+        const rows = drawn.flatMap((message) => message.rows);
+        const folded = drawn.flatMap((message) => message.folded);
+        return folded.length === 0
+          ? rows
+          : [
+              ...rows,
+              <FoldedRows
+                key={`${group.turnId}:folded`}
+                rows={folded}
+                {...(onOpenChat ? { onOpenChat } : undefined)}
+              />,
+            ];
+      })}
+    </ol>
+  );
+}

--- a/apps/desktop/src/renderer/styles/conversation.css
+++ b/apps/desktop/src/renderer/styles/conversation.css
@@ -428,7 +428,13 @@
   height: 12px;
 }
 
-.conversation-entry[data-speaker="event"] .conversation-action .conversation-words {
+/* An action row and the turn's fold speak in the quiet voice the requested
+   actions use, but they are Luke's doing, so they read from his edge rather
+   than centered between the two sides the way a dated line is. */
+.conversation-entry[data-action-kind] .conversation-message,
+.conversation-entry[data-folded] .conversation-message {
+  justify-content: flex-start;
+  padding: 2px 12px;
   text-align: left;
 }
 

--- a/apps/desktop/src/renderer/styles/conversation.css
+++ b/apps/desktop/src/renderer/styles/conversation.css
@@ -375,3 +375,203 @@
   color: var(--text-primary);
   font-size: 12px;
 }
+
+/* An action Luke carried is a row, not a bubble: what was done, in the quiet
+   voice the dates use, led by a mark for the kind of thing it was and ended
+   on the mark of the provider it reached. It reads from Luke's side of the
+   thread, because it is his doing — its leading mark sits on the edge his
+   bubbles start from — and it stands still under the pull as his words do. */
+.conversation-action {
+  display: flex;
+  min-width: 0;
+  max-width: min(88%, 64ch);
+  align-items: flex-start;
+  gap: 7px;
+  padding: 3px 0;
+}
+
+.conversation-action-body {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 2px;
+}
+
+/* The mark's room is reserved whether or not a mark fills it, so rows with
+   and without one keep their words on one line. */
+.conversation-action-mark {
+  display: inline-flex;
+  width: 12px;
+  height: 12px;
+  flex: 0 0 auto;
+  justify-content: center;
+  margin-top: 2px;
+  color: var(--text-tertiary);
+}
+
+.conversation-action-mark svg {
+  width: 12px;
+  height: 12px;
+}
+
+/* The provider's mark, at the size the row's own marks take, trailing the
+   words the way a session row's application marks trail its title. */
+.conversation-action-provider {
+  display: inline-flex;
+  height: 16px;
+  flex: 0 0 auto;
+  align-items: center;
+}
+
+.conversation-action-provider .provider-mark {
+  width: 12px;
+  height: 12px;
+}
+
+.conversation-entry[data-speaker="event"] .conversation-action .conversation-words {
+  text-align: left;
+}
+
+/* The session an action reached, named inline as a chip: a rounded box with
+   the mark its roster row wears, sized to sit in the sentence as one of its
+   words. Where the session has an identity to open by the chip is the row's
+   own press by another hand and lifts under the pointer; a name alone takes
+   no hover. */
+.conversation-action-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  margin: -1px 0;
+  padding: 0 5px;
+  border-radius: 6px;
+  background: var(--raised);
+  color: var(--text-primary);
+  font-size: 10.5px;
+  font-weight: 620;
+  line-height: 14px;
+  vertical-align: baseline;
+  white-space: nowrap;
+  transition: background-color var(--duration-hover) ease;
+}
+
+button.conversation-action-chip:hover,
+button.conversation-action-chip:focus-visible {
+  background: var(--selected);
+}
+
+.conversation-chip-mark {
+  width: 10px;
+  height: 10px;
+}
+
+/* Why an action ended as it did, or what its carrier said of it, under the
+   words in the same quiet voice; a refusal reads in the danger colour so a
+   thing that did not happen is never mistaken for one that did. */
+.conversation-action-reason,
+.conversation-action-note {
+  color: var(--text-secondary);
+  font-size: 10.5px;
+  line-height: 1.4;
+}
+
+.conversation-entry[data-tool-status="refused"] .conversation-action-reason,
+.conversation-entry[data-tool-status="failed"] .conversation-action-reason,
+.conversation-detail[data-tool-state="output-error"] .conversation-action-reason {
+  color: var(--danger);
+}
+
+/* An action still under way: the same dots the wait draws, beside the words. */
+.conversation-action-pending {
+  display: inline-flex;
+  align-items: center;
+  margin-left: 6px;
+  vertical-align: middle;
+}
+
+/* An announcement nobody heard says so beside its words, so a briefing that
+   lapsed unclaimed is never read as one that was spoken. */
+.conversation-unspoken {
+  align-self: flex-start;
+  padding: 0 10px 6px;
+  color: var(--text-tertiary);
+  font-size: 10px;
+  font-weight: 620;
+}
+
+/* Luke's thought, folded to one line on his side of the thread that opens on
+   its words. A native disclosure rather than a control of Luke's own, and no
+   bubble: a thought is not something he said. */
+.conversation-reasoning {
+  min-width: 0;
+  max-width: min(82%, 58ch);
+  padding: 2px 10px;
+  color: var(--text-secondary);
+  font-size: 11px;
+  line-height: 1.4;
+}
+
+.conversation-reasoning-summary {
+  cursor: default;
+  color: var(--text-tertiary);
+  font-size: 10.5px;
+  font-weight: 620;
+}
+
+.conversation-reasoning-words {
+  display: block;
+  padding-top: 3px;
+  overflow-wrap: anywhere;
+}
+
+/* The turn's working, folded under a count at the turn's foot in the quiet
+   voice: the details it read and wrote, and the actions whose tools failed.
+   Closed by default; opening it moves nothing else. */
+.conversation-turn-details {
+  min-width: 0;
+  padding: 2px 12px;
+  color: var(--text-secondary);
+  font-size: 10.5px;
+  line-height: 1.4;
+}
+
+.conversation-turn-summary {
+  cursor: default;
+  color: var(--text-tertiary);
+  font-weight: 620;
+}
+
+.conversation-turn-rows {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin: 4px 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.conversation-turn-rows .conversation-entry {
+  width: auto;
+}
+
+.conversation-turn-rows .conversation-message {
+  position: static;
+  width: 100%;
+}
+
+/* One call the turn made and nothing of what it read or wrote: its tool's
+   name and its state, in a line. */
+.conversation-detail {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 6px;
+}
+
+.conversation-detail-name {
+  color: var(--text-primary);
+  font-weight: 620;
+}
+
+.conversation-detail-state {
+  color: var(--text-tertiary);
+}

--- a/packages/actions/src/actions.ts
+++ b/packages/actions/src/actions.ts
@@ -251,6 +251,11 @@ export function realtimeToolFamily(name: string): ActionFamily | undefined {
   return ACTS_BY_NAME.get(name)?.family;
 }
 
+/** The kind of action a named tool carries, or nothing when no such tool exists. */
+export function realtimeToolKind(name: string): ActionKind | undefined {
+  return ACTS_BY_NAME.get(name)?.kind;
+}
+
 /** One function tool as a Responses or Realtime request carries it. */
 export interface ActionToolDefinition {
   type: "function";

--- a/packages/panel/src/glyphs.tsx
+++ b/packages/panel/src/glyphs.tsx
@@ -407,6 +407,45 @@ export function SendIcon(): React.JSX.Element {
   );
 }
 
+/** A speech bubble: words sent to a session. */
+export function MessageIcon(): React.JSX.Element {
+  return (
+    <Glyph className="icon-button-glyph">
+      <path d="M20.4 6.2a1.8 1.8 0 0 0-1.8-1.8H5.4a1.8 1.8 0 0 0-1.8 1.8v7.4a1.8 1.8 0 0 0 1.8 1.8h3.4v3.8l4.4-3.8h5.4a1.8 1.8 0 0 0 1.8-1.8z" />
+    </Glyph>
+  );
+}
+
+/** A bolt: a control a session advertised, pressed. */
+export function ControlIcon(): React.JSX.Element {
+  return (
+    <Glyph className="icon-button-glyph">
+      <path d="M13.2 2.8 5.6 13.6h5.6l-1 7.6 7.6-10.8h-5.6z" />
+    </Glyph>
+  );
+}
+
+/** A box with its lid on: the settled thing filed away. */
+export function ArchiveIcon(): React.JSX.Element {
+  return (
+    <Glyph className="icon-button-glyph">
+      <path d="M4 4.6h16v4H4z" />
+      <path d="M5.4 8.6v9.2a1.6 1.6 0 0 0 1.6 1.6h10a1.6 1.6 0 0 0 1.6-1.6V8.6" />
+      <path d="M10 12.4h4" />
+    </Glyph>
+  );
+}
+
+/** A plus: a workspace or an agent that did not exist before the action. */
+export function PlusIcon(): React.JSX.Element {
+  return (
+    <Glyph className="icon-button-glyph">
+      <path d="M12 5.4v13.2" />
+      <path d="M5.4 12h13.2" />
+    </Glyph>
+  );
+}
+
 /** Stops the reply under way, drawn the way every chat surface draws it: a square. */
 export function StopIcon(): React.JSX.Element {
   return (


### PR DESCRIPTION
## What

The Conversation panel learns the storage rework's shape before its data arrives: a renderer over the turn groups `selectConversationView` answers (D1, LUKE-133), in which a text part is a bubble on its author's side, a reasoning part is Luke's thought folded to a line that opens on its summary, an announcement is his bubble marked when nobody heard it, and an action is a row composed from the tool call's own `input` plus A2's envelope (LUKE-111) and nothing else. Renderer only; nothing is wired to app state, and no data source moves (that is E4).

- `apps/desktop/src/renderer/conversation-tool-row.ts`: the pure composition. `toolRow(part, roster)` reads the call's arguments through the action's own request schema from `@sidecar/actions` (declared once; no second parser), reads the envelope through `ACTION_OUTPUT`, and answers the row's kind, control kind, status, provider mark, word runs with one chip, and any reason, note, or warning.
- `apps/desktop/src/renderer/conversation-turns.tsx`: `ConversationTurns({ groups, roster, onOpenChat })`. Rows reuse the existing bubble grammar and classes; the action row, chip, and glyph tables are lifted from the closed #882–#904 stack where they fit, with the record they composed from replaced by `input` plus the envelope.
- `conversation-copy.tsx`: the copy control extracted from `ConversationPanel` so both renderers share one.
- `packages/panel`: `MessageIcon`, `ControlIcon`, `ArchiveIcon`, `PlusIcon` (from the stack). `packages/actions`: `realtimeToolKind(name)` beside `realtimeToolFamily`.
- `styles/conversation.css`: action rows, chips, reasoning fold, the turn's fold, detail lines.

## The chip

Named from the **roster** while it holds the session (current title, agent or provider mark, pressable exactly when the session's own row is, so a session that reported no address is a name), and from the envelope's **target snapshot** once the roster has let it go (the title it wore then, opened by identity, the host answering with the address it last reported or refusing). The press mints the same `onOpenChat(identity)` a row's press does, as #904 had it. A creation's chip is the session `createdSession` named (an identifier, never an address), by the roster once it holds it; a creation whose answer named none is a name alone. `controlLabel` and `controlKind` come from the envelope's target, since `run_session_control`'s input carries only `control_id`; `note` is shown under an accepted row.

## Collapse rule, as D1 finalised it

Detail or refused collapses. A tool the classification names as `detail`, and an action whose part is `output-error` (`refused: true` in the view), draw only inside the turn's fold (`<details>`, closed by default, at the turn's foot). An `output-available` part whose envelope says `status: refused` is still a row and says why; part state and envelope status are different questions, and the row model keeps five words for them (`accepted`, `unknown`, `refused`, `pending`, `failed`). Compaction rows never arrive (D1 excludes them). An observed conversation's message crosses cut to its announce and action parts, so its reasoning never draws; main's does.

## Fixtures instead of the harness, and why

The ticket names the dev harness (#650) as the instrument. #650 is not on main and not part of the LUKE-95 graph: it is an open PR from another workstream, and adopting it as a dependency would put a PR outside this rework's control on the critical path to E5. The acceptance is met by better means: committed synthetic fixtures (`conversation-turns.fixtures.ts`) build the store rows and run them through `selectConversationView` exactly as a service would, and the renderer tests render the result. They are repeatable, run in CI, and are what lane F's iOS parity check will decode later. The scenarios cover every session action kind (message, control as archive, stop, and plain, open with an application, create workspace, add agent, rename workspace, rename session), an envelope-refused row, an unknown outcome, a pending call, an errored action folded inside its turn, a reasoning part, an announcement (spoken, and unspoken via a `speech.expired` event in a test), and a chip for a departed session. Every title, id, and sentence in them is invented; none is copied from a real session.

## Tests

- `conversation-tool-row.test.ts`: every session action kind composes and non-actions compose nothing; roster naming and openability; departed-session naming by snapshot and by identity; control kind from the envelope; a creation's chip landed, unlanded, and unnamed; the five status words each from their own source; unreadable arguments still draw kind and target.
- `conversation-turns.test.ts`: every kind drawn as a row; chips are buttons exactly where the composition says the session opens (counted against the model, not hard-coded) and names without a press handler; a refused action and details appear only inside the fold, per group; reasoning and unspoken marks; developer rows as sent bubbles with copy and a brain-written note as a quiet row. Assertions count structural markers (data attributes and classes the renderer stamps), never phrases.

## Replay boundary

Everything drawn here sits inside `.conversation-view.ph-no-capture`; nothing about a session is drawn outside the Conversation subtree.

## Verify

- `./scripts/check.sh` passes (lint, knip, typecheck, all package tests including the 22 renderer tests, build).
- **`verify.sh` could not be run: this is a Linux cloud sandbox with no macOS.** Beyond that, the new renderer is not reachable in the app yet (E4 mounts it over the service's messages), so an evidence run on a Mac would show the existing Conversation tab unchanged and demonstrate nothing about this change; the renderer tests over the fixtures are what covers it. **No physical-notch check was performed.** No screenshots are committed anywhere.

## Reviews run

- **Thermonuclear code quality review** (Cursor's `cursor/plugins` → `cursor-team-kit/skills/thermo-nuclear-code-quality-review/SKILL.md`, applied as written): replaced a mutated out-parameter in `messageRows` with a returned `{ rows, folded }`; folded five repeated chip compositions into one `namedSession`; reused the panel's `CONVERSATION_ENTRY_SPEAKER` rather than a second speaker set; made an `at={undefined}` prop optional; named the anonymous `rowStatus` return as `RowOutcome`; keyed word runs by content rather than index.
- **Cursor Bugbot** found two real issues on the first head, both fixed in the follow-up commit: action rows inherited the dated line's centering, and a creation whose answer named a session the roster did not hold, with no `name` in the call, drew no chip.
- **Ponytail review** (`DietrichGebert/ponytail`, `ponytail-review` skill as written): `yagni` — unexported the fixture tool-kind map and two row types nothing outside the module reads; otherwise lean.

## CLAUDE.md

No sentence contradicted. The chip follows "Opening a session … is not a write and needs no endpoint" and "a session that reported no address is offered nowhere to open"; the fold follows "A refused action is a tool part in output-error, drawn only inside the expanded turn."

E2 (LUKE-136) stacks on this: folding turns under a count, collapsing read tools further, and marking own judgment by `turns.origin`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34540538696/artifacts/10177152787) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34540538696)

- Commit: `f0e638b387cfc03cd29563b066af8d4101683887`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
