### PR TITLE
feat(LUKE-123): the store writer

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -17,7 +17,7 @@
     "dev": "vite",
     "preview": "vite preview",
     "test": "tsx --test 'tests/**/*.test.ts'",
-    "test:store": "tsx --test tests/hosted-store.test.ts tests/hosted-payload-envelope.test.ts tests/storage-schema.test.ts tests/voice-schema.test.ts",
+    "test:store": "tsx --test tests/hosted-store.test.ts tests/hosted-payload-envelope.test.ts tests/storage-schema.test.ts tests/voice-schema.test.ts tests/hosted-store-writer.test.ts",
     "typecheck": "tsc --project tsconfig.json"
   },
   "dependencies": {
@@ -53,9 +53,11 @@
     "@types/react": "19.2.18",
     "@types/react-dom": "19.2.4",
     "@vitejs/plugin-react": "5.1.2",
+    "ai": "7.0.97",
     "drizzle-kit": "0.31.10",
     "tsx": "4.23.12",
     "typescript": "6.0.3",
-    "vite": "7.3.1"
+    "vite": "7.3.1",
+    "zod": "4.5.4"
   }
 }

--- a/apps/web/server/README.md
+++ b/apps/web/server/README.md
@@ -344,9 +344,47 @@ prompt written by every turn is one row a turn's hash names without a foreign
 key. A provider cursor is where the observation of one provider session last
 reached, one row per session per account, advanced in the same transaction as
 the observation message it produced and referenced by no message. Nothing in
-these tables is sealed, and nothing reads or writes them yet: the store writer
-lands on them in its own change, and the v1 tables are dropped only after
-every reader has moved.
+these tables is sealed, and nothing reads them yet: the v1 tables are dropped
+only after every reader has moved.
+
+The store writer, `server/hosted/store/writer.ts`, is the one path by which a
+`messages`, `turns`, or `events` row is written, and
+`tests/store-writer-boundary.test.ts` holds the server's import graph to that:
+the writer is the one server module that imports any of the three tables. It
+consumes the brain's run event stream (`BrainRunEvent`, every kind of turn)
+for a conversation the caller names by its row id and account. A turn row
+goes from queued (written ahead of the stream by `enqueueTurn`, or at the
+turn's start where nothing queued it) through running to settled, cancelled,
+or failed, carrying the origin it was queued under, its usage split four ways,
+its response ids where the runtime has them, and its failure word. Each user
+message the turn opened with lands as its own row by the message's id. The
+turn's answer is one assistant message keyed by the turn's id, and while the
+turn runs that row is its journal: a tool call is written in `input-available`
+before it executes and moved to `output-available` or `output-error` as its
+result lands, a reasoning summary is written as it completes, and the turn's
+completed message replaces the journal's parts whole and sets `finished_at`
+once, after which the row is immutable and a late event for it is refused. A
+turn that ends with a call still unanswered settles the call as an error,
+since nothing will answer it now, and closes the row; a writer that dies
+between the call and its result leaves the part in `input-available`, which
+is what a resume reads. A compaction is written by its owner through
+`recordCompaction`, because the stream's compaction event names neither the
+first kept message nor, under eve, the summary's text; an event about a
+message goes through `recordEvent`, numbered by the conversation's event
+sequence, and a second `speech.claimed` on one message is answered as already
+claimed rather than left to the partial unique index. Every write is
+idempotent — a message by `(conversation_id, client_id)`, a turn by its id, a
+tool part by its call id, a reasoning part by its item's id — so an event
+delivered twice writes one row and a replayed stream changes nothing, and
+every message is held to the vocabulary before it lands, through the same
+`readStoredUIMessages` a read goes through, so no row can carry a tool the
+catalog does not register, an input its schema refuses, or metadata outside
+the set; a message the reader would refuse is refused whole and reported,
+never cut down to the parts that would pass. Every write runs under a lock on
+the conversation row, which no write reaches once Clear has stamped it; the
+sequences come from the row's counters, each allocation landing on the first
+position no row holds, so the unique `(conversation_id, seq)` constraint is
+the backstop for a writer outside the lock and nothing the writer retries.
 
 Voice is stored beside them the way a call platform stores a call, under
 `server/db/voice-schema.ts`: `voice_sessions` and `voice_transcript_segments`.

--- a/apps/web/server/core.ts
+++ b/apps/web/server/core.ts
@@ -46,4 +46,5 @@ export * from "../../../packages/hosted/src/index.js";
 export * from "../../../packages/realtime/src/index.js";
 export * from "../../../packages/runtime/src/vocabulary.js";
 export * from "../../../packages/session/src/index.js";
+export * from "../../../packages/session/src/ui-messages/index.js";
 export * from "../../../packages/wire/src/index.js";

--- a/apps/web/server/hosted/store/index.ts
+++ b/apps/web/server/hosted/store/index.ts
@@ -263,3 +263,11 @@ export {
   type RosterDiffRecord,
   type RosterSnapshotRecord,
 } from "./roster-snapshot.js";
+
+export {
+  type ConversationTarget,
+  STORE_WRITE_EFFECT,
+  STORE_WRITE_REFUSAL,
+  type StoreWriteResult,
+  storeWriter,
+} from "./writer.js";

--- a/apps/web/server/hosted/store/writer.ts
+++ b/apps/web/server/hosted/store/writer.ts
@@ -1,0 +1,848 @@
+import { randomUUID } from "node:crypto";
+import { isDeepStrictEqual } from "node:util";
+import type { ReasoningUIPart, ToolSet, ToolUIPart, UIMessage, UITools } from "ai";
+import { and, eq, isNull, sql } from "drizzle-orm";
+import {
+  BRAIN_REQUEST_STATUS,
+  BRAIN_RUN_EVENT,
+  BRAIN_TURN_ORIGIN,
+  type BrainRunEvent,
+  type BrainTurnOrigin,
+  CONVERSATION_EVENT_KIND,
+  type ConversationEventKind,
+  compactionSummaryMessage,
+  isSettledToolPartState,
+  isStoredToolPart,
+  isWireString,
+  MESSAGE_AUTHOR,
+  MESSAGE_ROLE,
+  readStoredUIMessages,
+  SCHEMA_REFUSAL,
+  type SchemaPath,
+  type SchemaRefusal,
+  type StoredMessageMetadata,
+  type StoredToolPart,
+  type StoredUIMessage,
+  settledToolPart,
+  TOOL_PART_STATE,
+  TURN_ORIGIN,
+  TURN_STATUS,
+  type TurnOrigin,
+  type TurnStatus,
+  toolPartType,
+  UI_PART_STATE,
+  UI_PART_TYPE,
+  type UnparsedWireValue,
+  unparsedWire,
+} from "../../core.js";
+import { conversations, events, messages, turns } from "../../db/storage-schema.js";
+import { type HostedStoreDatabase, nullable } from "./database.js";
+
+/**
+ * The store writer: the one path by which a `messages`, `turns`, or `events`
+ * row is written. It consumes the brain's run event stream (`BrainRunEvent`,
+ * every kind of turn) and keeps the record the plan describes: a turn row
+ * from queued through running to its end, one assistant message per turn
+ * that is the turn's journal while it runs — each tool call written in
+ * `input-available` before it executes and moved to `output-available` or
+ * `output-error` as its result lands, `finished_at` set once and the row
+ * immutable after — the user messages the turn opened with, and a compaction
+ * message where the compaction's owner hands one over. Every write is
+ * idempotent: a message by its `(conversation_id, client_id)`, a turn by its
+ * id, a tool part by its call id, so an event delivered twice writes one row
+ * and a stream replayed from its start changes nothing.
+ *
+ * Every write runs under a lock on the conversation row, which serializes
+ * the conversation's writers, so a check made before an insert holds when
+ * the insert runs. Sequences are allocated from the row's own counters,
+ * each allocation landing on the first position no row of the conversation
+ * holds, so a position taken outside the counter costs nothing but a skip.
+ * The unique constraint on `(conversation_id, seq)` stays the backstop: a
+ * writer that still lands on a taken position is one that wrote outside
+ * this lock, and its violation surfaces rather than being retried into
+ * place. Nothing here reads a row back for the model: what is written is
+ * held to the vocabulary before it lands, through the same reader the
+ * store's reads go through, so no row can carry a tool the catalog does not
+ * register, an input its schema refuses, or metadata outside the set. A
+ * message refused there is refused whole and reported, never cut down to
+ * the parts that would pass: a cut message says something its author did not.
+ */
+
+export interface ConversationTarget {
+  readonly userId: string;
+  readonly conversationId: string;
+}
+
+interface StoreWriterOptions {
+  readonly db: HostedStoreDatabase;
+  /** The catalog's `tool()` declarations by name: what a stored tool part may name, and what its input is held to. */
+  readonly tools: ToolSet;
+  readonly now?: () => Date;
+}
+
+/** What one write did: landed, found its row already standing, or had nothing to do for this kind. */
+export const STORE_WRITE_EFFECT = {
+  WRITTEN: "written",
+  REPEATED: "repeated",
+  IGNORED: "ignored",
+} as const;
+
+type StoreWriteEffect = (typeof STORE_WRITE_EFFECT)[keyof typeof STORE_WRITE_EFFECT];
+
+/**
+ * Why a write was refused: the row it needs is not there, the row or call it
+ * would change is closed, the claim it makes is already another's, or what it
+ * carries is outside the vocabulary.
+ */
+export const STORE_WRITE_REFUSAL = {
+  NO_CONVERSATION: "no_conversation",
+  NO_TURN: "no_turn",
+  NO_CALL: "no_call",
+  NO_MESSAGE: "no_message",
+  FINISHED: "finished",
+  ALREADY_CLAIMED: "already_claimed",
+  MESSAGE_REFUSED: "message_refused",
+} as const;
+
+type StoreWriteRefusal = (typeof STORE_WRITE_REFUSAL)[keyof typeof STORE_WRITE_REFUSAL];
+
+type Refused<Refusal extends StoreWriteRefusal> = { readonly ok: false; readonly refusal: Refusal };
+
+const NO_CONVERSATION: Refused<typeof STORE_WRITE_REFUSAL.NO_CONVERSATION> = {
+  ok: false,
+  refusal: STORE_WRITE_REFUSAL.NO_CONVERSATION,
+};
+
+export type StoreWriteResult =
+  | { readonly ok: true; readonly effect: StoreWriteEffect }
+  | Refused<
+      | typeof STORE_WRITE_REFUSAL.NO_CONVERSATION
+      | typeof STORE_WRITE_REFUSAL.NO_TURN
+      | typeof STORE_WRITE_REFUSAL.NO_CALL
+      | typeof STORE_WRITE_REFUSAL.FINISHED
+    >
+  | {
+      readonly ok: false;
+      readonly refusal: typeof STORE_WRITE_REFUSAL.MESSAGE_REFUSED;
+      readonly reason: SchemaRefusal;
+      readonly path: SchemaPath;
+    };
+
+type BrainRequestStatus = (typeof BRAIN_REQUEST_STATUS)[keyof typeof BRAIN_REQUEST_STATUS];
+
+/** A turn queued ahead of its start: what opened it and, where the caller knows them, what it will run under. */
+interface TurnEnqueue {
+  /** The turn's id where the runtime minted one already; minted here otherwise. */
+  readonly turnId?: string;
+  readonly origin: TurnOrigin;
+  readonly model?: string;
+  readonly reasoningEffort?: string;
+  readonly promptHash?: string;
+  readonly toolSetHash?: string;
+}
+
+type TurnEnqueueResult =
+  | { readonly ok: true; readonly turnId: string; readonly effect: StoreWriteEffect }
+  | typeof NO_CONVERSATION;
+
+/**
+ * What one completed compaction folded, as its owner reports it: the summary
+ * the model wrote, the first stored message the model still reads after it,
+ * and the input tokens the folded messages had cost where the owner counted
+ * them; absent otherwise, never zero.
+ */
+interface CompactionWrite {
+  /** The owner's own id for the fold, the row's idempotency key. */
+  readonly clientId: string;
+  readonly turnId?: string;
+  readonly text: string;
+  readonly firstKeptMessageId: string;
+  readonly tokensBefore?: number;
+}
+
+interface EventWrite {
+  readonly messageId: string;
+  readonly kind: ConversationEventKind;
+  readonly deviceId?: string;
+  readonly payload?: UnparsedWireValue;
+}
+
+type EventWriteResult =
+  | { readonly ok: true; readonly id: string; readonly seq: number }
+  | Refused<
+      | typeof STORE_WRITE_REFUSAL.NO_CONVERSATION
+      | typeof STORE_WRITE_REFUSAL.NO_MESSAGE
+      | typeof STORE_WRITE_REFUSAL.ALREADY_CLAIMED
+    >;
+
+interface StoreWriter {
+  /** Consumes one event of the run stream for the conversation it names. */
+  consume(target: ConversationTarget, event: BrainRunEvent): Promise<StoreWriteResult>;
+  /** Writes a turn as queued, ahead of the stream telling its start; answers the turn's id. */
+  enqueueTurn(target: ConversationTarget, enqueue: TurnEnqueue): Promise<TurnEnqueueResult>;
+  /** Writes the assistant message a compaction stands as; the stream's own compaction event carries too little to write it. */
+  recordCompaction(
+    target: ConversationTarget,
+    compaction: CompactionWrite,
+  ): Promise<StoreWriteResult>;
+  /** Appends one event about a message, numbered by the conversation's event sequence. */
+  recordEvent(target: ConversationTarget, event: EventWrite): Promise<EventWriteResult>;
+}
+
+/**
+ * The plan's turn origin for each origin the brain's stream names. The
+ * hosted tier opens observation turns from roster diffs alone, and a child's
+ * completion opens a turn of the parent's just as a child's task opens the
+ * child's own: the conversation's kind tells the two `child` turns apart.
+ */
+const TURN_ORIGIN_OF_BRAIN_ORIGIN = {
+  [BRAIN_TURN_ORIGIN.TYPED]: TURN_ORIGIN.TYPED,
+  [BRAIN_TURN_ORIGIN.SPOKEN]: TURN_ORIGIN.SPOKEN,
+  [BRAIN_TURN_ORIGIN.OBSERVATION]: TURN_ORIGIN.ROSTER_DIFF,
+  [BRAIN_TURN_ORIGIN.HOLD_RELEASE]: TURN_ORIGIN.HOLD_RELEASE,
+  [BRAIN_TURN_ORIGIN.CHILD]: TURN_ORIGIN.CHILD,
+  [BRAIN_TURN_ORIGIN.CHILD_COMPLETION]: TURN_ORIGIN.CHILD,
+} as const satisfies Record<BrainTurnOrigin, TurnOrigin>;
+
+function turnStatusOf(status: BrainRequestStatus): TurnStatus {
+  switch (status) {
+    case BRAIN_REQUEST_STATUS.SUCCEEDED:
+      return TURN_STATUS.SETTLED;
+    case BRAIN_REQUEST_STATUS.CANCELLED:
+      return TURN_STATUS.CANCELLED;
+    case BRAIN_REQUEST_STATUS.FAILED:
+    case BRAIN_REQUEST_STATUS.TIMED_OUT:
+    case BRAIN_REQUEST_STATUS.INTERRUPTED:
+    case BRAIN_REQUEST_STATUS.QUEUED:
+    case BRAIN_REQUEST_STATUS.RUNNING:
+      return TURN_STATUS.FAILED;
+  }
+}
+
+const TERMINAL_TURN_STATUSES: ReadonlySet<TurnStatus> = new Set([
+  TURN_STATUS.SETTLED,
+  TURN_STATUS.CANCELLED,
+  TURN_STATUS.FAILED,
+]);
+
+type ToolPart = ToolUIPart<UITools>;
+
+type Parts = StoredUIMessage["parts"];
+
+interface MessageRow {
+  readonly id: string;
+  readonly parts: Parts;
+  readonly metadata: StoredMessageMetadata | null;
+  readonly finishedAt: Date | null;
+}
+
+const BRAIN_AUTHORED = { author: MESSAGE_AUTHOR.BRAIN } as const;
+
+function pendingToolPart(name: string, callId: string, input: UnparsedWireValue): ToolPart {
+  return {
+    type: toolPartType(name),
+    toolCallId: callId,
+    state: TOOL_PART_STATE.INPUT_AVAILABLE,
+    input,
+  };
+}
+
+/** A call the turn left unanswered, settled as the error it is once the turn is over: it will never answer now. */
+function unansweredToolPart(part: StoredToolPart, status: BrainRequestStatus): ToolPart {
+  return {
+    type: part.type,
+    toolCallId: part.toolCallId,
+    state: TOOL_PART_STATE.OUTPUT_ERROR,
+    input: part.input,
+    errorText:
+      status === BRAIN_REQUEST_STATUS.CANCELLED
+        ? "The turn was cancelled before the call answered."
+        : "The turn ended before the call answered.",
+  };
+}
+
+/**
+ * The reasoning part the stream's summary amounts to while the turn runs: the
+ * summary's words under the provider item's own id, read for identity alone
+ * so a summary told twice is one part. The completed message's projection
+ * carries the item's replay data in the provider's own slot and replaces this
+ * part when the turn answers.
+ */
+function reasoningPart(summary: string, id: string): ReasoningUIPart {
+  return { type: UI_PART_TYPE.REASONING, id, text: summary, state: UI_PART_STATE.DONE };
+}
+
+function toolPartOf(
+  parts: Parts,
+  callId: string,
+): { index: number; part: StoredToolPart } | undefined {
+  const index = parts.findIndex((part) => isStoredToolPart(part) && part.toolCallId === callId);
+  const part = parts[index];
+  return part !== undefined && isStoredToolPart(part) ? { index, part } : undefined;
+}
+
+interface WriterContext {
+  readonly tx: HostedStoreDatabase;
+  readonly tools: ToolSet;
+  readonly now: () => Date;
+  readonly target: ConversationTarget;
+}
+
+type Admitted =
+  | { readonly ok: true; readonly message: StoredUIMessage }
+  | Extract<StoreWriteResult, { ok: false; refusal: typeof STORE_WRITE_REFUSAL.MESSAGE_REFUSED }>;
+
+/**
+ * Holds one message to the vocabulary before it lands, exactly as a read
+ * holds a stored row: the SDK's structure, the registered tools and their
+ * input schemas, this build's metadata by role and its tool-state set. The
+ * row lands as JSON, so the JSON shape is what is held: a field the
+ * serialization drops was never going to be stored.
+ */
+async function admitted(
+  context: WriterContext,
+  message: UIMessage | StoredUIMessage,
+): Promise<Admitted> {
+  const read = await readStoredUIMessages(
+    unparsedWire([JSON.parse(JSON.stringify(message))]),
+    context.tools,
+  );
+  if (!read.ok) {
+    return {
+      ok: false,
+      refusal: STORE_WRITE_REFUSAL.MESSAGE_REFUSED,
+      reason: read.refusal,
+      path: read.path,
+    };
+  }
+  const [stored] = read.value;
+  if (stored === undefined) throw new Error("the reader answered no row for one message");
+  return { ok: true, message: stored };
+}
+
+/**
+ * The next position of the conversation's message sequence: the counter's
+ * own, or one past the highest position a row already holds where the
+ * counter fell behind it, and the counter moved past whichever was handed
+ * out. The read of `max(seq)` is served by the unique index over the pair.
+ */
+async function allocateMessageSeq(context: WriterContext): Promise<number> {
+  const { conversationId } = context.target;
+  const [row] = await context.tx
+    .update(conversations)
+    .set({
+      nextMessageSeq: sql`greatest(${conversations.nextMessageSeq}, (select coalesce(max(${messages.seq}), 0) + 1 from ${messages} where ${messages.conversationId} = ${conversationId})) + 1`,
+      lastActivityAt: context.now(),
+    })
+    .where(eq(conversations.id, conversationId))
+    .returning({ next: conversations.nextMessageSeq });
+  if (row === undefined) throw new Error("the conversation vanished under its own lock");
+  return row.next - 1;
+}
+
+async function allocateEventSeq(context: WriterContext): Promise<number> {
+  const { conversationId } = context.target;
+  const [row] = await context.tx
+    .update(conversations)
+    .set({
+      nextEventSeq: sql`greatest(${conversations.nextEventSeq}, (select coalesce(max(${events.seq}), 0) + 1 from ${events} where ${events.conversationId} = ${conversationId})) + 1`,
+    })
+    .where(eq(conversations.id, conversationId))
+    .returning({ next: conversations.nextEventSeq });
+  if (row === undefined) throw new Error("the conversation vanished under its own lock");
+  return row.next - 1;
+}
+
+async function turnRow(
+  context: WriterContext,
+  turnId: string,
+): Promise<{ status: TurnStatus } | undefined> {
+  const [row] = await context.tx
+    .select({ status: turns.status })
+    .from(turns)
+    .where(and(eq(turns.id, turnId), eq(turns.conversationId, context.target.conversationId)));
+  return row;
+}
+
+async function messageByClientId(
+  context: WriterContext,
+  clientId: string,
+): Promise<MessageRow | undefined> {
+  const [row] = await context.tx
+    .select({
+      id: messages.id,
+      parts: messages.parts,
+      metadata: messages.metadata,
+      finishedAt: messages.finishedAt,
+    })
+    .from(messages)
+    .where(
+      and(
+        eq(messages.conversationId, context.target.conversationId),
+        eq(messages.clientId, clientId),
+      ),
+    );
+  return row;
+}
+
+async function insertMessage(
+  context: WriterContext,
+  row: {
+    clientId: string;
+    turnId: string | undefined;
+    message: StoredUIMessage;
+    finishedAt: Date | undefined;
+  },
+): Promise<string> {
+  const seq = await allocateMessageSeq(context);
+  const metadata: StoredMessageMetadata | undefined =
+    row.message.role === MESSAGE_ROLE.SYSTEM ? undefined : row.message.metadata;
+  const [inserted] = await context.tx
+    .insert(messages)
+    .values({
+      userId: context.target.userId,
+      conversationId: context.target.conversationId,
+      seq,
+      turnId: nullable(row.turnId),
+      clientId: row.clientId,
+      role: row.message.role,
+      parts: row.message.parts,
+      metadata: nullable(metadata),
+      createdAt: context.now(),
+      finishedAt: nullable(row.finishedAt),
+    })
+    .returning({ id: messages.id });
+  if (inserted === undefined) throw new Error("the message insert answered no row");
+  return inserted.id;
+}
+
+type Journal =
+  | { readonly ok: true; readonly row: MessageRow }
+  | Refused<typeof STORE_WRITE_REFUSAL.NO_TURN | typeof STORE_WRITE_REFUSAL.FINISHED>;
+
+/** Whether a turn may still take a new message or part: it stands, and it has not ended. */
+async function openTurn(
+  context: WriterContext,
+  turnId: string,
+): Promise<
+  Refused<typeof STORE_WRITE_REFUSAL.NO_TURN | typeof STORE_WRITE_REFUSAL.FINISHED> | undefined
+> {
+  const turn = await turnRow(context, turnId);
+  if (turn === undefined) return { ok: false, refusal: STORE_WRITE_REFUSAL.NO_TURN };
+  if (TERMINAL_TURN_STATUSES.has(turn.status)) {
+    return { ok: false, refusal: STORE_WRITE_REFUSAL.FINISHED };
+  }
+  return undefined;
+}
+
+/**
+ * The turn's one assistant message, the journal of the turn under way: keyed
+ * by the turn's id as its client id, opened by the first part the turn
+ * reports while the turn still runs, and closed by the turn's answer or its
+ * end. A turn that has ended opens no journal after the fact.
+ */
+async function journal(context: WriterContext, turnId: string): Promise<Journal> {
+  const standing = await messageByClientId(context, turnId);
+  if (standing !== undefined) return { ok: true, row: standing };
+  const closed = await openTurn(context, turnId);
+  if (closed !== undefined) return closed;
+  const id = await insertMessage(context, {
+    clientId: turnId,
+    turnId,
+    message: { id: turnId, role: MESSAGE_ROLE.ASSISTANT, metadata: BRAIN_AUTHORED, parts: [] },
+    finishedAt: undefined,
+  });
+  return { ok: true, row: { id, parts: [], metadata: BRAIN_AUTHORED, finishedAt: null } };
+}
+
+/** Writes the journal's parts as they now stand, held to the vocabulary first. */
+async function amendJournal(
+  context: WriterContext,
+  row: MessageRow,
+  parts: Parts,
+): Promise<StoreWriteResult> {
+  const read = await admitted(context, {
+    id: row.id,
+    role: MESSAGE_ROLE.ASSISTANT,
+    metadata: BRAIN_AUTHORED,
+    parts,
+  });
+  if (!read.ok) return read;
+  await context.tx
+    .update(messages)
+    .set({ parts: read.message.parts })
+    .where(eq(messages.id, row.id));
+  return { ok: true, effect: STORE_WRITE_EFFECT.WRITTEN };
+}
+
+async function turnStarted(
+  context: WriterContext,
+  event: Extract<BrainRunEvent, { kind: typeof BRAIN_RUN_EVENT.TURN_STARTED }>,
+): Promise<StoreWriteResult> {
+  const standing = await turnRow(context, event.turnId);
+  const startedAt = new Date(event.at);
+  if (standing === undefined) {
+    await context.tx.insert(turns).values({
+      id: event.turnId,
+      userId: context.target.userId,
+      conversationId: context.target.conversationId,
+      origin: TURN_ORIGIN_OF_BRAIN_ORIGIN[event.origin],
+      status: TURN_STATUS.RUNNING,
+      queuedAt: startedAt,
+      startedAt,
+    });
+    return { ok: true, effect: STORE_WRITE_EFFECT.WRITTEN };
+  }
+  if (standing.status !== TURN_STATUS.QUEUED) {
+    return { ok: true, effect: STORE_WRITE_EFFECT.REPEATED };
+  }
+  await context.tx
+    .update(turns)
+    .set({ status: TURN_STATUS.RUNNING, startedAt })
+    .where(eq(turns.id, event.turnId));
+  return { ok: true, effect: STORE_WRITE_EFFECT.WRITTEN };
+}
+
+async function turnEnded(
+  context: WriterContext,
+  event: Extract<BrainRunEvent, { kind: typeof BRAIN_RUN_EVENT.TURN_ENDED }>,
+): Promise<StoreWriteResult> {
+  const standing = await turnRow(context, event.turnId);
+  if (standing === undefined) return { ok: false, refusal: STORE_WRITE_REFUSAL.NO_TURN };
+  if (TERMINAL_TURN_STATUSES.has(standing.status)) {
+    return { ok: true, effect: STORE_WRITE_EFFECT.REPEATED };
+  }
+  const settledAt = new Date(event.at);
+  const status = turnStatusOf(event.status);
+  // A failed turn names its failure word where the run had one, and the status
+  // it ended in otherwise, so a timed-out or interrupted turn still says which.
+  const failure = event.failure ?? (status === TURN_STATUS.FAILED ? event.status : undefined);
+  await context.tx
+    .update(turns)
+    .set({
+      status,
+      settledAt,
+      failure: nullable(failure),
+      usage: nullable(event.usage),
+      responseIds: [...event.responseIds],
+    })
+    .where(eq(turns.id, event.turnId));
+  const open = await messageByClientId(context, event.turnId);
+  if (open !== undefined && open.finishedAt === null) {
+    const parts = open.parts.map((part) =>
+      isStoredToolPart(part) && !isSettledToolPartState(part.state)
+        ? unansweredToolPart(part, event.status)
+        : part,
+    );
+    await context.tx
+      .update(messages)
+      .set({ parts, finishedAt: settledAt })
+      .where(eq(messages.id, open.id));
+  }
+  return { ok: true, effect: STORE_WRITE_EFFECT.WRITTEN };
+}
+
+async function toolCallStarted(
+  context: WriterContext,
+  event: Extract<BrainRunEvent, { kind: typeof BRAIN_RUN_EVENT.TOOL_CALL_STARTED }>,
+): Promise<StoreWriteResult> {
+  const opened = await journal(context, event.turnId);
+  if (!opened.ok) return opened;
+  const { row } = opened;
+  if (toolPartOf(row.parts, event.callId) !== undefined) {
+    return { ok: true, effect: STORE_WRITE_EFFECT.REPEATED };
+  }
+  if (row.finishedAt !== null) return { ok: false, refusal: STORE_WRITE_REFUSAL.FINISHED };
+  return amendJournal(context, row, [
+    ...row.parts,
+    pendingToolPart(event.name, event.callId, event.input),
+  ]);
+}
+
+async function toolCallSettled(
+  context: WriterContext,
+  event: Extract<BrainRunEvent, { kind: typeof BRAIN_RUN_EVENT.TOOL_CALL_SETTLED }>,
+): Promise<StoreWriteResult> {
+  const row = await messageByClientId(context, event.turnId);
+  if (row === undefined) {
+    return {
+      ok: false,
+      refusal:
+        (await turnRow(context, event.turnId)) === undefined
+          ? STORE_WRITE_REFUSAL.NO_TURN
+          : STORE_WRITE_REFUSAL.NO_CALL,
+    };
+  }
+  const found = toolPartOf(row.parts, event.callId);
+  if (found === undefined) return { ok: false, refusal: STORE_WRITE_REFUSAL.NO_CALL };
+  // A call settles once. The same settlement told again is a repeat; a
+  // different one, after the turn's end already settled the call as
+  // unanswered, finds the call closed and is refused rather than rewritten.
+  if (isSettledToolPartState(found.part.state)) {
+    return found.part.state === event.settlement.state
+      ? { ok: true, effect: STORE_WRITE_EFFECT.REPEATED }
+      : { ok: false, refusal: STORE_WRITE_REFUSAL.FINISHED };
+  }
+  if (row.finishedAt !== null) return { ok: false, refusal: STORE_WRITE_REFUSAL.FINISHED };
+  const parts = [...row.parts];
+  parts[found.index] = settledToolPart(found.part, event.settlement);
+  return amendJournal(context, row, parts);
+}
+
+/**
+ * A reasoning summary joins the journal under its item's id. An item that
+ * names no id is not journaled: nothing could tell its second delivery from
+ * a second item, and the turn's completed projection carries every summary
+ * under the id the adapter lifted for it.
+ */
+async function reasoningCompleted(
+  context: WriterContext,
+  event: Extract<BrainRunEvent, { kind: typeof BRAIN_RUN_EVENT.REASONING_COMPLETED }>,
+): Promise<StoreWriteResult> {
+  const { id } = event.item;
+  if (!isWireString(id)) return { ok: true, effect: STORE_WRITE_EFFECT.IGNORED };
+  const opened = await journal(context, event.turnId);
+  if (!opened.ok) return opened;
+  const { row } = opened;
+  if (row.parts.some((part) => part.type === UI_PART_TYPE.REASONING && part.id === id)) {
+    return { ok: true, effect: STORE_WRITE_EFFECT.REPEATED };
+  }
+  if (row.finishedAt !== null) return { ok: false, refusal: STORE_WRITE_REFUSAL.FINISHED };
+  return amendJournal(context, row, [...row.parts, reasoningPart(event.summary, id)]);
+}
+
+/**
+ * A completed message: a user message lands as its own row by its id; the
+ * turn's answer closes the turn's journal, its parts replaced whole by the
+ * projection the turn told, since the projection is the message as the
+ * runtime's own record has it and the journal was the record of it in flight.
+ * A closed journal takes the same projection again as a repeat and a
+ * different one as the late write it is.
+ */
+async function messageCompleted(
+  context: WriterContext,
+  event: Extract<BrainRunEvent, { kind: typeof BRAIN_RUN_EVENT.MESSAGE_COMPLETED }>,
+): Promise<StoreWriteResult> {
+  const read = await admitted(context, event.message);
+  if (!read.ok) return read;
+  const { message } = read;
+  if (message.role !== MESSAGE_ROLE.ASSISTANT) {
+    if ((await messageByClientId(context, message.id)) !== undefined) {
+      return { ok: true, effect: STORE_WRITE_EFFECT.REPEATED };
+    }
+    const closed = await openTurn(context, event.turnId);
+    if (closed !== undefined) return closed;
+    await insertMessage(context, {
+      clientId: message.id,
+      turnId: event.turnId,
+      message,
+      finishedAt: context.now(),
+    });
+    return { ok: true, effect: STORE_WRITE_EFFECT.WRITTEN };
+  }
+  const opened = await journal(context, event.turnId);
+  if (!opened.ok) return opened;
+  const { row } = opened;
+  if (row.finishedAt !== null) {
+    return isDeepStrictEqual(row.parts, message.parts)
+      ? { ok: true, effect: STORE_WRITE_EFFECT.REPEATED }
+      : { ok: false, refusal: STORE_WRITE_REFUSAL.FINISHED };
+  }
+  await context.tx
+    .update(messages)
+    .set({ parts: message.parts, metadata: message.metadata, finishedAt: context.now() })
+    .where(eq(messages.id, row.id));
+  return { ok: true, effect: STORE_WRITE_EFFECT.WRITTEN };
+}
+
+function consume(context: WriterContext, event: BrainRunEvent): Promise<StoreWriteResult> {
+  switch (event.kind) {
+    case BRAIN_RUN_EVENT.TURN_STARTED:
+      return turnStarted(context, event);
+    case BRAIN_RUN_EVENT.TURN_ENDED:
+      return turnEnded(context, event);
+    case BRAIN_RUN_EVENT.TOOL_CALL_STARTED:
+      return toolCallStarted(context, event);
+    case BRAIN_RUN_EVENT.TOOL_CALL_SETTLED:
+      return toolCallSettled(context, event);
+    case BRAIN_RUN_EVENT.REASONING_COMPLETED:
+      return reasoningCompleted(context, event);
+    case BRAIN_RUN_EVENT.MESSAGE_COMPLETED:
+      return messageCompleted(context, event);
+    // The stream's compaction event names neither the summary's first kept
+    // message nor, under eve, the summary's text: the compaction's owner
+    // writes the row through `recordCompaction`. The rest of the stream is
+    // the relay's, about a run's moments rather than the record.
+    case BRAIN_RUN_EVENT.COMPACTION_COMPLETED:
+    case BRAIN_RUN_EVENT.SLOW_STEP:
+    case BRAIN_RUN_EVENT.ACTIONS_SETTLED:
+    case BRAIN_RUN_EVENT.REPLY_SENTENCE:
+    case BRAIN_RUN_EVENT.ENDED:
+      return Promise.resolve({ ok: true, effect: STORE_WRITE_EFFECT.IGNORED });
+  }
+}
+
+async function enqueueTurn(
+  context: WriterContext,
+  enqueue: TurnEnqueue,
+): Promise<TurnEnqueueResult> {
+  const turnId = enqueue.turnId ?? randomUUID();
+  if ((await turnRow(context, turnId)) !== undefined) {
+    return { ok: true, turnId, effect: STORE_WRITE_EFFECT.REPEATED };
+  }
+  await context.tx.insert(turns).values({
+    id: turnId,
+    userId: context.target.userId,
+    conversationId: context.target.conversationId,
+    origin: enqueue.origin,
+    status: TURN_STATUS.QUEUED,
+    model: nullable(enqueue.model),
+    reasoningEffort: nullable(enqueue.reasoningEffort),
+    promptHash: nullable(enqueue.promptHash),
+    toolSetHash: nullable(enqueue.toolSetHash),
+    queuedAt: context.now(),
+  });
+  return { ok: true, turnId, effect: STORE_WRITE_EFFECT.WRITTEN };
+}
+
+/** Whether a stored row is a compaction: an assistant row whose metadata names what it folded. */
+function isCompactionRow(row: MessageRow): boolean {
+  return (
+    row.metadata !== null && "compaction" in row.metadata && row.metadata.compaction !== undefined
+  );
+}
+
+/**
+ * The compaction row for one completed fold, built by the session package's
+ * own builder so the row is the shape every reader of a compaction expects,
+ * and held to the vocabulary like every other message before it lands. An
+ * owner's id names one of its own folds: a row of another kind under it is
+ * the owner's mistake, not a repeat.
+ */
+async function recordCompaction(
+  context: WriterContext,
+  compaction: CompactionWrite,
+): Promise<StoreWriteResult> {
+  const standing = await messageByClientId(context, compaction.clientId);
+  if (standing !== undefined) {
+    if (!isCompactionRow(standing)) {
+      throw new Error("a compaction's client id names a message that is not a compaction");
+    }
+    return { ok: true, effect: STORE_WRITE_EFFECT.REPEATED };
+  }
+  if (
+    compaction.turnId !== undefined &&
+    (await turnRow(context, compaction.turnId)) === undefined
+  ) {
+    return { ok: false, refusal: STORE_WRITE_REFUSAL.NO_TURN };
+  }
+  const built = compactionSummaryMessage(compaction.clientId, {
+    text: compaction.text,
+    firstKeptMessageId: compaction.firstKeptMessageId,
+    ...(compaction.tokensBefore !== undefined
+      ? { tokensBefore: compaction.tokensBefore }
+      : undefined),
+  });
+  if (built === undefined) {
+    return {
+      ok: false,
+      refusal: STORE_WRITE_REFUSAL.MESSAGE_REFUSED,
+      reason: SCHEMA_REFUSAL.MALFORMED,
+      path: [],
+    };
+  }
+  const read = await admitted(context, built);
+  if (!read.ok) return read;
+  await insertMessage(context, {
+    clientId: compaction.clientId,
+    turnId: compaction.turnId,
+    message: read.message,
+    finishedAt: context.now(),
+  });
+  return { ok: true, effect: STORE_WRITE_EFFECT.WRITTEN };
+}
+
+/**
+ * One event about a message. A claim is the one kind the schema makes
+ * exclusive, and under the conversation's lock the check for a standing claim
+ * holds when the insert runs, so the second claimant is answered by name and
+ * the partial unique index stays the backstop it is.
+ */
+async function recordEvent(context: WriterContext, event: EventWrite): Promise<EventWriteResult> {
+  const { conversationId, userId } = context.target;
+  const [message] = await context.tx
+    .select({ id: messages.id })
+    .from(messages)
+    .where(and(eq(messages.id, event.messageId), eq(messages.conversationId, conversationId)));
+  if (message === undefined) return { ok: false, refusal: STORE_WRITE_REFUSAL.NO_MESSAGE };
+  if (event.kind === CONVERSATION_EVENT_KIND.SPEECH_CLAIMED) {
+    const [claimed] = await context.tx
+      .select({ id: events.id })
+      .from(events)
+      .where(
+        and(
+          eq(events.messageId, event.messageId),
+          eq(events.kind, CONVERSATION_EVENT_KIND.SPEECH_CLAIMED),
+        ),
+      );
+    if (claimed !== undefined) return { ok: false, refusal: STORE_WRITE_REFUSAL.ALREADY_CLAIMED };
+  }
+  const seq = await allocateEventSeq(context);
+  const [inserted] = await context.tx
+    .insert(events)
+    .values({
+      userId,
+      conversationId,
+      seq,
+      messageId: event.messageId,
+      kind: event.kind,
+      deviceId: nullable(event.deviceId),
+      payload: nullable(event.payload),
+      createdAt: context.now(),
+    })
+    .returning({ id: events.id });
+  if (inserted === undefined) throw new Error("the event insert answered no row");
+  return { ok: true, id: inserted.id, seq };
+}
+
+export function storeWriter({
+  db,
+  tools,
+  now = () => new Date(),
+}: StoreWriterOptions): StoreWriter {
+  /**
+   * Runs one write under the conversation's row lock, or answers that no such
+   * conversation stands for this account: none by that id, or one Clear
+   * already stamped, which is read by nothing and so written by nothing.
+   */
+  function underConversation<Result>(
+    target: ConversationTarget,
+    write: (context: WriterContext) => Promise<Result>,
+  ): Promise<Result | typeof NO_CONVERSATION> {
+    return db.transaction(async (tx) => {
+      const locked = await tx
+        .select({ id: conversations.id })
+        .from(conversations)
+        .where(
+          and(
+            eq(conversations.id, target.conversationId),
+            eq(conversations.userId, target.userId),
+            isNull(conversations.deletedAt),
+          ),
+        )
+        .for("update");
+      if (locked.length === 0) return NO_CONVERSATION;
+      return write({ tx, tools, now, target });
+    });
+  }
+
+  return {
+    consume: (target, event) => underConversation(target, (context) => consume(context, event)),
+    enqueueTurn: (target, enqueue) =>
+      underConversation(target, (context) => enqueueTurn(context, enqueue)),
+    recordCompaction: (target, compaction) =>
+      underConversation(target, (context) => recordCompaction(context, compaction)),
+    recordEvent: (target, event) =>
+      underConversation(target, (context) => recordEvent(context, event)),
+  };
+}

--- a/apps/web/tests/hosted-store-writer.test.ts
+++ b/apps/web/tests/hosted-store-writer.test.ts
@@ -1,0 +1,999 @@
+import assert from "node:assert/strict";
+import { randomUUID } from "node:crypto";
+import test, { after } from "node:test";
+import { type ToolSet, tool, type UIMessage } from "ai";
+import { and, asc, eq } from "drizzle-orm";
+import { z } from "zod";
+import {
+  BRAIN_REQUEST_STATUS,
+  BRAIN_RUN_EVENT,
+  BRAIN_TURN_ORIGIN,
+  BRAIN_TURN_TRIGGER,
+  type BrainRequestRecord,
+  type BrainRunEvent,
+  type BrainRunEventBody,
+  type BrainTurnOrigin,
+  type BrainTurnTrigger,
+  COMPACTION_SOURCE,
+  CONVERSATION_EVENT_KIND,
+  MAIN_SESSION_KEY,
+  MESSAGE_AUTHOR,
+  MESSAGE_CHANNEL,
+  MESSAGE_ROLE,
+  OBSERVATION_SOURCE,
+  readStoredUIMessages,
+  SCHEMA_REFUSAL,
+  SLOW_STEP_KIND,
+  TOOL_CALL_SETTLEMENT,
+  TOOL_PART_STATE,
+  TURN_ORIGIN,
+  TURN_STATUS,
+  toolPartType,
+  UI_PART_STATE,
+  UI_PART_TYPE,
+  type UnparsedWireValue,
+  type UserMessageMetadata,
+  unparsedWire,
+} from "../server/core";
+import {
+  CONVERSATION_KIND,
+  conversations,
+  events,
+  messages,
+  turns,
+} from "../server/db/storage-schema";
+import {
+  type ConversationTarget,
+  STORE_WRITE_EFFECT,
+  STORE_WRITE_REFUSAL,
+  type StoreWriteResult,
+  storeWriter,
+} from "../server/hosted/store";
+import { openHostedStoreTestDatabase } from "./support/hosted-store-database";
+
+/**
+ * The store writer over the real migrations on PGlite. Synthetic fixtures
+ * throughout: no real title, branch, transcript, or spoken word. What these
+ * tests hold to is the record the plan describes — which rows a turn of each
+ * kind leaves, in which states, in which order — and never the words in them.
+ */
+
+const NOW = 1_800_000_000_000;
+
+type TurnFailure = NonNullable<BrainRequestRecord["failure"]>;
+
+/** The one failure word the fixtures need, typed against the run's own set so a misspelling fails to compile. */
+const MODEL_FAILURE: TurnFailure = "model";
+
+const database = await openHostedStoreTestDatabase();
+after(() => database.close());
+
+const TOOLS: ToolSet = {
+  read_transcript: tool({
+    description: "Reads the tail of an observed session's transcript.",
+    inputSchema: z.object({ providerId: z.string(), providerSessionId: z.string() }),
+    outputSchema: z.object({ lines: z.array(z.string()) }),
+  }),
+  announce: tool({
+    description: "Says a briefing aloud.",
+    inputSchema: z.object({ text: z.string() }),
+    outputSchema: z.object({ status: z.string() }),
+  }),
+};
+
+const TRANSCRIPT_INPUT = { providerId: "conductor", providerSessionId: "s-1" };
+const TRANSCRIPT_OUTPUT = { lines: ["user: fixture ask", "assistant: fixture reply"] };
+const ANNOUNCE_INPUT = { text: "The fixture session finished its turn." };
+
+const TYPED_ASK: UserMessageMetadata = {
+  author: MESSAGE_AUTHOR.DEVELOPER,
+  channel: MESSAGE_CHANNEL.TYPED,
+};
+
+const writer = storeWriter({ db: database.db, tools: TOOLS, now: () => new Date(NOW) });
+
+/** Messages as they cross into the reader: their JSON shape, which is what a row holds. */
+function asWire(stored: readonly UIMessage[]): UnparsedWireValue {
+  return unparsedWire(JSON.parse(JSON.stringify(stored)));
+}
+
+async function conversation(
+  kind: (typeof CONVERSATION_KIND)[keyof typeof CONVERSATION_KIND] = CONVERSATION_KIND.MAIN,
+): Promise<ConversationTarget> {
+  const userId = await database.createUser();
+  const [row] = await database.db
+    .insert(conversations)
+    .values({ userId, kind })
+    .returning({ id: conversations.id });
+  assert.ok(row);
+  return { userId, conversationId: row.id };
+}
+
+/** One turn's stream, numbered as the turn's teller numbers it. */
+class Stream {
+  readonly turnId = randomUUID();
+  #sequence = 0;
+
+  event(body: BrainRunEventBody): BrainRunEvent {
+    this.#sequence += 1;
+    return {
+      ...body,
+      conversationId: MAIN_SESSION_KEY,
+      turnId: this.turnId,
+      sequence: this.#sequence,
+    };
+  }
+
+  started(origin: BrainTurnOrigin, trigger: BrainTurnTrigger, at = NOW): BrainRunEvent {
+    return this.event({ kind: BRAIN_RUN_EVENT.TURN_STARTED, origin, trigger, at });
+  }
+
+  words(id: string, text: string, metadata: UserMessageMetadata): BrainRunEvent {
+    return this.event({
+      kind: BRAIN_RUN_EVENT.MESSAGE_COMPLETED,
+      message: {
+        id,
+        role: MESSAGE_ROLE.USER,
+        metadata,
+        parts: [{ type: UI_PART_TYPE.TEXT, text, state: UI_PART_STATE.DONE }],
+      },
+    });
+  }
+
+  toolCall(callId: string, name: string, input: UnparsedWireValue): BrainRunEvent {
+    return this.event({ kind: BRAIN_RUN_EVENT.TOOL_CALL_STARTED, callId, name, input });
+  }
+
+  toolAnswered(callId: string, name: string, output: UnparsedWireValue): BrainRunEvent {
+    return this.event({
+      kind: BRAIN_RUN_EVENT.TOOL_CALL_SETTLED,
+      callId,
+      name,
+      settlement: { state: TOOL_CALL_SETTLEMENT.OUTPUT_AVAILABLE, output },
+    });
+  }
+
+  toolFailed(callId: string, name: string, errorText: string, status: string): BrainRunEvent {
+    return this.event({
+      kind: BRAIN_RUN_EVENT.TOOL_CALL_SETTLED,
+      callId,
+      name,
+      settlement: {
+        state: TOOL_CALL_SETTLEMENT.OUTPUT_ERROR,
+        output: { status, reason: errorText },
+        errorText,
+        status,
+      },
+    });
+  }
+
+  reasoning(itemId: string, summary: string): BrainRunEvent {
+    return this.event({
+      kind: BRAIN_RUN_EVENT.REASONING_COMPLETED,
+      summary,
+      item: { type: "reasoning", id: itemId, encrypted_content: "b3BhcXVl" },
+    });
+  }
+
+  answered(id: string, parts: UIMessage["parts"]): BrainRunEvent {
+    return this.event({
+      kind: BRAIN_RUN_EVENT.MESSAGE_COMPLETED,
+      message: {
+        id,
+        role: MESSAGE_ROLE.ASSISTANT,
+        metadata: { author: MESSAGE_AUTHOR.BRAIN },
+        parts,
+      },
+    });
+  }
+
+  ended(
+    status: (typeof BRAIN_REQUEST_STATUS)[keyof typeof BRAIN_REQUEST_STATUS],
+    options: {
+      failure?: TurnFailure;
+      responseIds?: readonly string[];
+      at?: number;
+    } = {},
+  ): BrainRunEvent {
+    return this.event({
+      kind: BRAIN_RUN_EVENT.TURN_ENDED,
+      status,
+      ...(options.failure !== undefined ? { failure: options.failure } : undefined),
+      usage: { inputTokens: 120, outputTokens: 30, cachedInputTokens: 40, reasoningTokens: 10 },
+      responseIds: options.responseIds ?? [],
+      at: options.at ?? NOW + 1_000,
+    });
+  }
+}
+
+async function feed(
+  target: ConversationTarget,
+  stream: readonly BrainRunEvent[],
+): Promise<readonly StoreWriteResult[]> {
+  const results: StoreWriteResult[] = [];
+  for (const event of stream) results.push(await writer.consume(target, event));
+  return results;
+}
+
+function effects(results: readonly StoreWriteResult[]): readonly string[] {
+  return results.map((result) => (result.ok ? result.effect : result.refusal));
+}
+
+async function storedMessages(target: ConversationTarget) {
+  return database.db
+    .select({
+      seq: messages.seq,
+      role: messages.role,
+      clientId: messages.clientId,
+      turnId: messages.turnId,
+      parts: messages.parts,
+      metadata: messages.metadata,
+      finishedAt: messages.finishedAt,
+    })
+    .from(messages)
+    .where(eq(messages.conversationId, target.conversationId))
+    .orderBy(asc(messages.seq));
+}
+
+async function storedTurn(turnId: string) {
+  const [row] = await database.db
+    .select({
+      origin: turns.origin,
+      status: turns.status,
+      queuedAt: turns.queuedAt,
+      startedAt: turns.startedAt,
+      settledAt: turns.settledAt,
+      failure: turns.failure,
+      usage: turns.usage,
+      responseIds: turns.responseIds,
+    })
+    .from(turns)
+    .where(eq(turns.id, turnId));
+  return row;
+}
+
+async function counters(target: ConversationTarget) {
+  const [row] = await database.db
+    .select({ message: conversations.nextMessageSeq, event: conversations.nextEventSeq })
+    .from(conversations)
+    .where(eq(conversations.id, target.conversationId));
+  return row;
+}
+
+type Part = UIMessage["parts"][number];
+
+const pendingCall = (callId: string): Part => ({
+  type: toolPartType("read_transcript"),
+  toolCallId: callId,
+  state: TOOL_PART_STATE.INPUT_AVAILABLE,
+  input: TRANSCRIPT_INPUT,
+});
+
+const answeredCall = (callId: string): Part => ({
+  type: toolPartType("read_transcript"),
+  toolCallId: callId,
+  state: TOOL_PART_STATE.OUTPUT_AVAILABLE,
+  input: TRANSCRIPT_INPUT,
+  output: TRANSCRIPT_OUTPUT,
+});
+
+const REPLY_PARTS: UIMessage["parts"] = [
+  {
+    type: UI_PART_TYPE.REASONING,
+    id: "rs_1",
+    text: "Read the tail first.",
+    state: UI_PART_STATE.DONE,
+    providerMetadata: { openai: { itemId: "rs_1", reasoningEncryptedContent: "b3BhcXVl" } },
+  },
+  answeredCall("call_1"),
+  { type: UI_PART_TYPE.TEXT, text: "It is waiting on a permission.", state: UI_PART_STATE.DONE },
+];
+
+/** A developer's typed ask that reads one transcript and answers, told from start to end. */
+function developerTurn(stream: Stream, askId: string, replyId: string): readonly BrainRunEvent[] {
+  return [
+    stream.started(BRAIN_TURN_ORIGIN.TYPED, BRAIN_TURN_TRIGGER.ASK),
+    stream.words(askId, "What is the fixture session doing?", TYPED_ASK),
+    stream.toolCall("call_1", "read_transcript", TRANSCRIPT_INPUT),
+    stream.toolAnswered("call_1", "read_transcript", TRANSCRIPT_OUTPUT),
+    stream.reasoning("rs_1", "Read the tail first."),
+    stream.answered(replyId, REPLY_PARTS),
+    stream.ended(BRAIN_REQUEST_STATUS.SUCCEEDED, { responseIds: ["resp_1", "resp_2"] }),
+  ];
+}
+
+test("a developer turn leaves its ask, its journal closed as the answer told, and a settled turn", async () => {
+  const target = await conversation();
+  const stream = new Stream();
+  const askId = randomUUID();
+  const results = await feed(target, developerTurn(stream, askId, randomUUID()));
+  assert.deepEqual(
+    effects(results),
+    results.map(() => STORE_WRITE_EFFECT.WRITTEN),
+  );
+
+  const rows = await storedMessages(target);
+  assert.deepEqual(
+    rows.map((row) => ({
+      seq: row.seq,
+      role: row.role,
+      clientId: row.clientId,
+      turnId: row.turnId,
+      finished: row.finishedAt !== null,
+    })),
+    [
+      { seq: 1, role: MESSAGE_ROLE.USER, clientId: askId, turnId: stream.turnId, finished: true },
+      {
+        seq: 2,
+        role: MESSAGE_ROLE.ASSISTANT,
+        clientId: stream.turnId,
+        turnId: stream.turnId,
+        finished: true,
+      },
+    ],
+  );
+  assert.deepEqual(rows[0]?.metadata, TYPED_ASK);
+  assert.deepEqual(rows[1]?.metadata, { author: MESSAGE_AUTHOR.BRAIN });
+  assert.deepEqual(rows[1]?.parts, REPLY_PARTS);
+  assert.deepEqual(await counters(target), { message: 3, event: 1 });
+
+  const turn = await storedTurn(stream.turnId);
+  assert.deepEqual(
+    {
+      origin: turn?.origin,
+      status: turn?.status,
+      queuedAt: turn?.queuedAt?.getTime(),
+      startedAt: turn?.startedAt?.getTime(),
+      settledAt: turn?.settledAt?.getTime(),
+      failure: turn?.failure,
+      usage: turn?.usage,
+      responseIds: turn?.responseIds,
+    },
+    {
+      origin: TURN_ORIGIN.TYPED,
+      status: TURN_STATUS.SETTLED,
+      queuedAt: NOW,
+      startedAt: NOW,
+      settledAt: NOW + 1_000,
+      failure: null,
+      usage: { inputTokens: 120, outputTokens: 30, cachedInputTokens: 40, reasoningTokens: 10 },
+      responseIds: ["resp_1", "resp_2"],
+    },
+  );
+
+  const read = await readStoredUIMessages(
+    asWire(
+      rows.map((row) => ({
+        id: row.clientId,
+        role: row.role,
+        metadata: row.metadata,
+        parts: row.parts,
+      })),
+    ),
+    TOOLS,
+  );
+  assert.equal(read.ok, true);
+});
+
+test("an observation turn on an observed conversation is a roster-diff turn whose words the brain wrote for itself", async () => {
+  const target = await conversation(CONVERSATION_KIND.OBSERVED);
+  const stream = new Stream();
+  const lookId = randomUUID();
+  const announceParts: UIMessage["parts"] = [
+    {
+      type: toolPartType("announce"),
+      toolCallId: "call_a",
+      state: TOOL_PART_STATE.OUTPUT_AVAILABLE,
+      input: ANNOUNCE_INPUT,
+      output: { status: "accepted" },
+    },
+  ];
+  const results = await feed(target, [
+    stream.started(BRAIN_TURN_ORIGIN.OBSERVATION, BRAIN_TURN_TRIGGER.ROSTER),
+    stream.words(lookId, "[roster look] One session finished.", {
+      author: MESSAGE_AUTHOR.BRAIN,
+      source: OBSERVATION_SOURCE.ROSTER_LOOK,
+    }),
+    stream.toolCall("call_a", "announce", ANNOUNCE_INPUT),
+    stream.toolAnswered("call_a", "announce", { status: "accepted" }),
+    stream.answered(randomUUID(), announceParts),
+    stream.ended(BRAIN_REQUEST_STATUS.SUCCEEDED),
+  ]);
+  assert.equal(
+    results.every((result) => result.ok),
+    true,
+  );
+
+  const rows = await storedMessages(target);
+  assert.deepEqual(
+    rows.map((row) => [row.seq, row.role, row.metadata]),
+    [
+      [
+        1,
+        MESSAGE_ROLE.USER,
+        { author: MESSAGE_AUTHOR.BRAIN, source: OBSERVATION_SOURCE.ROSTER_LOOK },
+      ],
+      [2, MESSAGE_ROLE.ASSISTANT, { author: MESSAGE_AUTHOR.BRAIN }],
+    ],
+  );
+  assert.deepEqual(rows[1]?.parts, announceParts);
+  const turn = await storedTurn(stream.turnId);
+  assert.deepEqual(
+    [turn?.origin, turn?.status, turn?.responseIds],
+    [TURN_ORIGIN.ROSTER_DIFF, TURN_STATUS.SETTLED, []],
+  );
+});
+
+test("a child turn on a child conversation is a child-origin turn opened by the delegated task", async () => {
+  const target = await conversation(CONVERSATION_KIND.CHILD);
+  const stream = new Stream();
+  const replyParts: UIMessage["parts"] = [
+    { type: UI_PART_TYPE.TEXT, text: "Two files changed.", state: UI_PART_STATE.DONE },
+  ];
+  const results = await feed(target, [
+    stream.started(BRAIN_TURN_ORIGIN.CHILD, BRAIN_TURN_TRIGGER.CHILD_TASK),
+    stream.words(randomUUID(), "[delegated task] Summarize the change.", {
+      author: MESSAGE_AUTHOR.BRAIN,
+      source: OBSERVATION_SOURCE.CHILD,
+    }),
+    stream.answered(randomUUID(), replyParts),
+    stream.ended(BRAIN_REQUEST_STATUS.SUCCEEDED, { responseIds: ["resp_c"] }),
+  ]);
+  assert.equal(
+    results.every((result) => result.ok),
+    true,
+  );
+  const rows = await storedMessages(target);
+  assert.deepEqual(
+    rows.map((row) => [row.seq, row.role, row.turnId, row.finishedAt !== null]),
+    [
+      [1, MESSAGE_ROLE.USER, stream.turnId, true],
+      [2, MESSAGE_ROLE.ASSISTANT, stream.turnId, true],
+    ],
+  );
+  assert.deepEqual(rows[1]?.parts, replyParts);
+  const turn = await storedTurn(stream.turnId);
+  assert.deepEqual([turn?.origin, turn?.status], [TURN_ORIGIN.CHILD, TURN_STATUS.SETTLED]);
+});
+
+test("a writer killed after the calls were told leaves a resumable journal: one call answered, one still pending, the row open", async () => {
+  const target = await conversation();
+  const stream = new Stream();
+  const results = await feed(target, [
+    stream.started(BRAIN_TURN_ORIGIN.TYPED, BRAIN_TURN_TRIGGER.ASK),
+    stream.words(randomUUID(), "Read both.", TYPED_ASK),
+    stream.toolCall("call_1", "read_transcript", TRANSCRIPT_INPUT),
+    stream.toolCall("call_2", "read_transcript", TRANSCRIPT_INPUT),
+    stream.toolAnswered("call_1", "read_transcript", TRANSCRIPT_OUTPUT),
+  ]);
+  assert.equal(
+    results.every((result) => result.ok),
+    true,
+  );
+
+  const rows = await storedMessages(target);
+  const journal = rows[1];
+  assert.ok(journal);
+  assert.equal(journal.finishedAt, null);
+  assert.deepEqual(journal.parts, [answeredCall("call_1"), pendingCall("call_2")]);
+  const turn = await storedTurn(stream.turnId);
+  assert.equal(turn?.status, TURN_STATUS.RUNNING);
+
+  const read = await readStoredUIMessages(
+    asWire([
+      {
+        id: journal.clientId,
+        role: journal.role,
+        metadata: journal.metadata,
+        parts: journal.parts,
+      },
+    ]),
+    TOOLS,
+  );
+  assert.equal(read.ok, true);
+});
+
+test("every event delivered twice, and the whole stream replayed, writes one row each and moves no sequence", async () => {
+  const target = await conversation();
+  const stream = new Stream();
+  const turn = developerTurn(stream, randomUUID(), randomUUID());
+  const first: StoreWriteResult[] = [];
+  const second: StoreWriteResult[] = [];
+  for (const event of turn) {
+    first.push(await writer.consume(target, event));
+    second.push(await writer.consume(target, event));
+  }
+  assert.equal(
+    first.every((result) => result.ok && result.effect === STORE_WRITE_EFFECT.WRITTEN),
+    true,
+  );
+  assert.deepEqual(
+    effects(second),
+    turn.map(() => STORE_WRITE_EFFECT.REPEATED),
+  );
+  const replayed = await feed(target, turn);
+  assert.deepEqual(
+    effects(replayed),
+    turn.map(() => STORE_WRITE_EFFECT.REPEATED),
+  );
+  const rows = await storedMessages(target);
+  assert.deepEqual(
+    rows.map((row) => row.seq),
+    [1, 2],
+  );
+  assert.deepEqual(await counters(target), { message: 3, event: 1 });
+});
+
+test("a refused call settles as an error part carrying the refusal's own reason and no output, in the shape the turn's projection keeps", async () => {
+  const target = await conversation();
+  const stream = new Stream();
+  const results = await feed(target, [
+    stream.started(BRAIN_TURN_ORIGIN.TYPED, BRAIN_TURN_TRIGGER.ASK),
+    stream.toolCall("call_r", "read_transcript", TRANSCRIPT_INPUT),
+    stream.toolFailed("call_r", "read_transcript", "The session is not in the roster.", "refused"),
+  ]);
+  assert.equal(
+    results.every((result) => result.ok),
+    true,
+  );
+  const [journal] = await storedMessages(target);
+  assert.deepEqual(journal?.parts, [
+    {
+      type: toolPartType("read_transcript"),
+      toolCallId: "call_r",
+      state: TOOL_PART_STATE.OUTPUT_ERROR,
+      input: TRANSCRIPT_INPUT,
+      errorText: "The session is not in the roster.",
+    },
+  ]);
+  const again = await writer.consume(
+    target,
+    stream.toolFailed("call_r", "read_transcript", "The session is not in the roster.", "refused"),
+  );
+  assert.deepEqual(again, { ok: true, effect: STORE_WRITE_EFFECT.REPEATED });
+});
+
+test("a turn that ends with a call unanswered settles the call as an error and closes the journal; a cancelled turn says so", async () => {
+  const target = await conversation();
+  const stream = new Stream();
+  await feed(target, [
+    stream.started(BRAIN_TURN_ORIGIN.TYPED, BRAIN_TURN_TRIGGER.ASK),
+    stream.toolCall("call_1", "read_transcript", TRANSCRIPT_INPUT),
+    stream.ended(BRAIN_REQUEST_STATUS.CANCELLED),
+  ]);
+  const [journal] = await storedMessages(target);
+  assert.ok(journal);
+  assert.equal(journal.finishedAt?.getTime(), NOW + 1_000);
+  assert.deepEqual(
+    journal.parts.map((part) => ("state" in part ? part.state : undefined)),
+    [TOOL_PART_STATE.OUTPUT_ERROR],
+  );
+  const turn = await storedTurn(stream.turnId);
+  assert.deepEqual([turn?.status, turn?.failure], [TURN_STATUS.CANCELLED, null]);
+
+  const late = await writer.consume(
+    target,
+    stream.toolAnswered("call_1", "read_transcript", TRANSCRIPT_OUTPUT),
+  );
+  assert.deepEqual(late, { ok: false, refusal: STORE_WRITE_REFUSAL.FINISHED });
+  const again = await writer.consume(target, stream.ended(BRAIN_REQUEST_STATUS.SUCCEEDED));
+  assert.deepEqual(again, { ok: true, effect: STORE_WRITE_EFFECT.REPEATED });
+});
+
+test("a turn that failed records its failure word, and one that timed out without a word records the status it ended in", async () => {
+  const target = await conversation();
+  const failed = new Stream();
+  await feed(target, [
+    failed.started(BRAIN_TURN_ORIGIN.SPOKEN, BRAIN_TURN_TRIGGER.ASK),
+    failed.ended(BRAIN_REQUEST_STATUS.FAILED, { failure: MODEL_FAILURE }),
+  ]);
+  const timedOut = new Stream();
+  await feed(target, [
+    timedOut.started(BRAIN_TURN_ORIGIN.HOLD_RELEASE, BRAIN_TURN_TRIGGER.HOLD_RELEASED),
+    timedOut.ended(BRAIN_REQUEST_STATUS.TIMED_OUT),
+  ]);
+  const failedTurn = await storedTurn(failed.turnId);
+  const timedOutTurn = await storedTurn(timedOut.turnId);
+  assert.deepEqual(
+    [failedTurn?.origin, failedTurn?.status, failedTurn?.failure],
+    [TURN_ORIGIN.SPOKEN, TURN_STATUS.FAILED, MODEL_FAILURE],
+  );
+  assert.deepEqual(
+    [timedOutTurn?.origin, timedOutTurn?.status, timedOutTurn?.failure],
+    [TURN_ORIGIN.HOLD_RELEASE, TURN_STATUS.FAILED, BRAIN_REQUEST_STATUS.TIMED_OUT],
+  );
+});
+
+test("a queued turn keeps the origin it was queued under through running to settled, and is queued once", async () => {
+  const target = await conversation();
+  const stream = new Stream();
+  const queued = await writer.enqueueTurn(target, {
+    turnId: stream.turnId,
+    origin: TURN_ORIGIN.SPOKEN,
+    model: "gpt-fixture",
+  });
+  assert.deepEqual(queued, { ok: true, turnId: stream.turnId, effect: STORE_WRITE_EFFECT.WRITTEN });
+  const twice = await writer.enqueueTurn(target, {
+    turnId: stream.turnId,
+    origin: TURN_ORIGIN.TYPED,
+  });
+  assert.deepEqual(twice, { ok: true, turnId: stream.turnId, effect: STORE_WRITE_EFFECT.REPEATED });
+  assert.equal((await storedTurn(stream.turnId))?.status, TURN_STATUS.QUEUED);
+
+  const started = await writer.consume(
+    target,
+    stream.started(BRAIN_TURN_ORIGIN.TYPED, BRAIN_TURN_TRIGGER.ASK, NOW + 500),
+  );
+  assert.deepEqual(started, { ok: true, effect: STORE_WRITE_EFFECT.WRITTEN });
+  const running = await storedTurn(stream.turnId);
+  assert.deepEqual(
+    [running?.origin, running?.status, running?.queuedAt?.getTime(), running?.startedAt?.getTime()],
+    [TURN_ORIGIN.SPOKEN, TURN_STATUS.RUNNING, NOW, NOW + 500],
+  );
+  await writer.consume(target, stream.ended(BRAIN_REQUEST_STATUS.SUCCEEDED));
+  assert.equal((await storedTurn(stream.turnId))?.status, TURN_STATUS.SETTLED);
+
+  const minted = await writer.enqueueTurn(target, { origin: TURN_ORIGIN.ROSTER_DIFF });
+  assert.equal(minted.ok, true);
+  if (!minted.ok) return;
+  assert.equal((await storedTurn(minted.turnId))?.origin, TURN_ORIGIN.ROSTER_DIFF);
+});
+
+test("a sequence already taken under the counter is the retry signal: the write lands on the next free position and the counter is re-aligned", async () => {
+  const target = await conversation();
+  const stream = new Stream();
+  await writer.consume(target, stream.started(BRAIN_TURN_ORIGIN.TYPED, BRAIN_TURN_TRIGGER.ASK));
+  const before = await counters(target);
+  assert.ok(before);
+  await database.db.insert(messages).values({
+    userId: target.userId,
+    conversationId: target.conversationId,
+    seq: before.message,
+    clientId: "taken-outside-the-counter",
+    role: MESSAGE_ROLE.SYSTEM,
+    parts: [{ type: "text", text: "taken" }],
+  });
+  const askId = randomUUID();
+  const result = await writer.consume(target, stream.words(askId, "hello", TYPED_ASK));
+  assert.deepEqual(result, { ok: true, effect: STORE_WRITE_EFFECT.WRITTEN });
+  const rows = await storedMessages(target);
+  assert.deepEqual(
+    rows.map((row) => [row.seq, row.clientId]),
+    [
+      [before.message, "taken-outside-the-counter"],
+      [before.message + 1, askId],
+    ],
+  );
+  assert.deepEqual(await counters(target), { message: before.message + 2, event: 1 });
+});
+
+test("a message the reader would refuse is refused at the write, with the reader's own word and path, and leaves no row", async () => {
+  const target = await conversation();
+  const stream = new Stream();
+  await writer.consume(target, stream.started(BRAIN_TURN_ORIGIN.TYPED, BRAIN_TURN_TRIGGER.ASK));
+
+  const unregistered = await writer.consume(target, stream.toolCall("call_x", "list_sessions", {}));
+  assert.deepEqual(unregistered, {
+    ok: false,
+    refusal: STORE_WRITE_REFUSAL.MESSAGE_REFUSED,
+    reason: SCHEMA_REFUSAL.NOT_REGISTERED,
+    path: [0, "parts", 0, "type"],
+  });
+
+  const wrongInput = await writer.consume(
+    target,
+    stream.toolCall("call_y", "read_transcript", { providerId: 7 }),
+  );
+  assert.equal(wrongInput.ok, false);
+  if (wrongInput.ok) return;
+  assert.equal(wrongInput.refusal, STORE_WRITE_REFUSAL.MESSAGE_REFUSED);
+  assert.equal("reason" in wrongInput && wrongInput.reason, SCHEMA_REFUSAL.MALFORMED);
+
+  const decorated = await writer.consume(
+    target,
+    stream.event({
+      kind: BRAIN_RUN_EVENT.MESSAGE_COMPLETED,
+      message: {
+        id: randomUUID(),
+        role: MESSAGE_ROLE.USER,
+        metadata: { ...TYPED_ASK, mood: "cheerful" },
+        parts: [{ type: "text", text: "hello" }],
+      },
+    }),
+  );
+  assert.equal(decorated.ok, false);
+  if (decorated.ok) return;
+  assert.equal(decorated.refusal, STORE_WRITE_REFUSAL.MESSAGE_REFUSED);
+
+  const rows = await storedMessages(target);
+  assert.deepEqual(
+    rows.map((row) => row.role),
+    [MESSAGE_ROLE.ASSISTANT],
+  );
+  assert.deepEqual(rows[0]?.parts, []);
+});
+
+test("a write for a conversation, turn, or call that is not there is refused by name", async () => {
+  const target = await conversation();
+  const elsewhere = { userId: target.userId, conversationId: randomUUID() };
+  const stream = new Stream();
+  const noConversation = await writer.consume(
+    elsewhere,
+    stream.started(BRAIN_TURN_ORIGIN.TYPED, BRAIN_TURN_TRIGGER.ASK),
+  );
+  assert.deepEqual(noConversation, { ok: false, refusal: STORE_WRITE_REFUSAL.NO_CONVERSATION });
+
+  const other = await conversation();
+  const otherUser = { userId: other.userId, conversationId: target.conversationId };
+  const wrongUser = await writer.consume(
+    otherUser,
+    stream.started(BRAIN_TURN_ORIGIN.TYPED, BRAIN_TURN_TRIGGER.ASK),
+  );
+  assert.deepEqual(wrongUser, { ok: false, refusal: STORE_WRITE_REFUSAL.NO_CONVERSATION });
+
+  const noTurn = await writer.consume(
+    target,
+    stream.toolCall("call_1", "read_transcript", TRANSCRIPT_INPUT),
+  );
+  assert.deepEqual(noTurn, { ok: false, refusal: STORE_WRITE_REFUSAL.NO_TURN });
+  const noTurnAnswer = await writer.consume(
+    target,
+    stream.toolAnswered("call_1", "read_transcript", TRANSCRIPT_OUTPUT),
+  );
+  assert.deepEqual(noTurnAnswer, { ok: false, refusal: STORE_WRITE_REFUSAL.NO_TURN });
+  const noTurnWords = await writer.consume(target, stream.words(randomUUID(), "hi", TYPED_ASK));
+  assert.deepEqual(noTurnWords, { ok: false, refusal: STORE_WRITE_REFUSAL.NO_TURN });
+  const noTurnEnd = await writer.consume(target, stream.ended(BRAIN_REQUEST_STATUS.SUCCEEDED));
+  assert.deepEqual(noTurnEnd, { ok: false, refusal: STORE_WRITE_REFUSAL.NO_TURN });
+
+  await writer.consume(target, stream.started(BRAIN_TURN_ORIGIN.TYPED, BRAIN_TURN_TRIGGER.ASK));
+  const noCall = await writer.consume(
+    target,
+    stream.toolAnswered("call_never_told", "read_transcript", TRANSCRIPT_OUTPUT),
+  );
+  assert.deepEqual(noCall, { ok: false, refusal: STORE_WRITE_REFUSAL.NO_CALL });
+  assert.deepEqual(await storedMessages(target), []);
+});
+
+test("a cleared conversation is written by nothing, like one that never was", async () => {
+  const target = await conversation();
+  await database.db
+    .update(conversations)
+    .set({ deletedAt: new Date(NOW) })
+    .where(eq(conversations.id, target.conversationId));
+  const stream = new Stream();
+  const started = await writer.consume(
+    target,
+    stream.started(BRAIN_TURN_ORIGIN.TYPED, BRAIN_TURN_TRIGGER.ASK),
+  );
+  assert.deepEqual(started, { ok: false, refusal: STORE_WRITE_REFUSAL.NO_CONVERSATION });
+  const queued = await writer.enqueueTurn(target, { origin: TURN_ORIGIN.TYPED });
+  assert.deepEqual(queued, { ok: false, refusal: STORE_WRITE_REFUSAL.NO_CONVERSATION });
+});
+
+test("a turn that ended without a journal opens none after the fact: a late part, answer, or word is refused as finished", async () => {
+  const target = await conversation();
+  const stream = new Stream();
+  await feed(target, [
+    stream.started(BRAIN_TURN_ORIGIN.TYPED, BRAIN_TURN_TRIGGER.ASK),
+    stream.ended(BRAIN_REQUEST_STATUS.FAILED, { failure: MODEL_FAILURE }),
+  ]);
+  const late = await feed(target, [
+    stream.toolCall("call_late", "read_transcript", TRANSCRIPT_INPUT),
+    stream.reasoning("rs_late", "Too late."),
+    stream.answered(randomUUID(), REPLY_PARTS),
+    stream.words(randomUUID(), "Late words.", TYPED_ASK),
+  ]);
+  assert.deepEqual(
+    effects(late),
+    late.map(() => STORE_WRITE_REFUSAL.FINISHED),
+  );
+  assert.deepEqual(await storedMessages(target), []);
+});
+
+test("a closed journal takes its own projection again as a repeat and a different one as the late write it is", async () => {
+  const target = await conversation();
+  const stream = new Stream();
+  const replyId = randomUUID();
+  await feed(target, developerTurn(stream, randomUUID(), replyId));
+  const same = await writer.consume(target, stream.answered(randomUUID(), REPLY_PARTS));
+  assert.deepEqual(same, { ok: true, effect: STORE_WRITE_EFFECT.REPEATED });
+  const different = await writer.consume(
+    target,
+    stream.answered(randomUUID(), [
+      { type: UI_PART_TYPE.TEXT, text: "Second thoughts.", state: UI_PART_STATE.DONE },
+    ]),
+  );
+  assert.deepEqual(different, { ok: false, refusal: STORE_WRITE_REFUSAL.FINISHED });
+  const [, reply] = await storedMessages(target);
+  assert.deepEqual(reply?.parts, REPLY_PARTS);
+});
+
+test("a reasoning item naming no id is not journaled, since nothing could tell its repeat from a second item", async () => {
+  const target = await conversation();
+  const stream = new Stream();
+  await writer.consume(target, stream.started(BRAIN_TURN_ORIGIN.TYPED, BRAIN_TURN_TRIGGER.ASK));
+  const unnamed = await writer.consume(
+    target,
+    stream.event({
+      kind: BRAIN_RUN_EVENT.REASONING_COMPLETED,
+      summary: "Thinking.",
+      item: { type: "reasoning" },
+    }),
+  );
+  assert.deepEqual(unnamed, { ok: true, effect: STORE_WRITE_EFFECT.IGNORED });
+  const named = await writer.consume(target, stream.reasoning("rs_9", "Thinking."));
+  assert.deepEqual(named, { ok: true, effect: STORE_WRITE_EFFECT.WRITTEN });
+  const again = await writer.consume(target, stream.reasoning("rs_9", "Thinking."));
+  assert.deepEqual(again, { ok: true, effect: STORE_WRITE_EFFECT.REPEATED });
+  const [journal] = await storedMessages(target);
+  assert.deepEqual(journal?.parts, [
+    { type: UI_PART_TYPE.REASONING, id: "rs_9", text: "Thinking.", state: UI_PART_STATE.DONE },
+  ]);
+});
+
+test("the relay's own events and the stream's compaction event write nothing", async () => {
+  const target = await conversation();
+  const stream = new Stream();
+  await writer.consume(target, stream.started(BRAIN_TURN_ORIGIN.TYPED, BRAIN_TURN_TRIGGER.ASK));
+  const results = await feed(target, [
+    stream.event({
+      kind: BRAIN_RUN_EVENT.SLOW_STEP,
+      runId: stream.turnId,
+      step: SLOW_STEP_KIND.TRANSCRIPT_READ,
+    }),
+    stream.event({ kind: BRAIN_RUN_EVENT.ACTIONS_SETTLED, runId: stream.turnId }),
+    stream.event({ kind: BRAIN_RUN_EVENT.REPLY_SENTENCE, runId: stream.turnId, sentence: "Done." }),
+    stream.event({
+      kind: BRAIN_RUN_EVENT.COMPACTION_COMPLETED,
+      compaction: {
+        source: COMPACTION_SOURCE.LOCAL_SUMMARY,
+        dropped: 3,
+        summary: "Earlier: fixtures.",
+      },
+    }),
+    stream.event({
+      kind: BRAIN_RUN_EVENT.ENDED,
+      runId: stream.turnId,
+      status: BRAIN_REQUEST_STATUS.SUCCEEDED,
+    }),
+  ]);
+  assert.deepEqual(
+    effects(results),
+    results.map(() => STORE_WRITE_EFFECT.IGNORED),
+  );
+  assert.deepEqual(await storedMessages(target), []);
+});
+
+test("a compaction is written once by its owner as an assistant row naming what it folded", async () => {
+  const target = await conversation();
+  const stream = new Stream();
+  const askId = randomUUID();
+  await feed(target, developerTurn(stream, askId, randomUUID()));
+  const [ask] = await storedMessages(target);
+  assert.ok(ask);
+  const compaction = {
+    clientId: "compaction-1",
+    turnId: stream.turnId,
+    text: "Earlier the developer asked after the fixture session.",
+    firstKeptMessageId: ask.clientId,
+    tokensBefore: 4_200,
+  };
+  assert.deepEqual(await writer.recordCompaction(target, compaction), {
+    ok: true,
+    effect: STORE_WRITE_EFFECT.WRITTEN,
+  });
+  assert.deepEqual(await writer.recordCompaction(target, compaction), {
+    ok: true,
+    effect: STORE_WRITE_EFFECT.REPEATED,
+  });
+  const rows = await storedMessages(target);
+  assert.deepEqual(
+    rows.map((row) => [row.seq, row.role, row.clientId, row.finishedAt !== null]),
+    [
+      [1, MESSAGE_ROLE.USER, askId, true],
+      [2, MESSAGE_ROLE.ASSISTANT, stream.turnId, true],
+      [3, MESSAGE_ROLE.ASSISTANT, "compaction-1", true],
+    ],
+  );
+  assert.deepEqual(rows[2]?.metadata, {
+    author: MESSAGE_AUTHOR.BRAIN,
+    compaction: { first_kept_message_id: ask.clientId, tokens_before: 4_200 },
+  });
+  assert.deepEqual(rows[2]?.parts, [
+    { type: UI_PART_TYPE.TEXT, text: compaction.text, state: UI_PART_STATE.DONE },
+  ]);
+
+  const unknownTurn = await writer.recordCompaction(target, {
+    ...compaction,
+    clientId: "compaction-2",
+    turnId: randomUUID(),
+  });
+  assert.deepEqual(unknownTurn, { ok: false, refusal: STORE_WRITE_REFUSAL.NO_TURN });
+
+  const uncounted = await writer.recordCompaction(target, {
+    clientId: "compaction-3",
+    text: "Earlier still.",
+    firstKeptMessageId: ask.clientId,
+  });
+  assert.deepEqual(uncounted, { ok: true, effect: STORE_WRITE_EFFECT.WRITTEN });
+  const [, , , uncountedRow] = await storedMessages(target);
+  assert.deepEqual(uncountedRow?.metadata, {
+    author: MESSAGE_AUTHOR.BRAIN,
+    compaction: { first_kept_message_id: ask.clientId },
+  });
+
+  const wordless = await writer.recordCompaction(target, {
+    clientId: "compaction-4",
+    text: "   ",
+    firstKeptMessageId: ask.clientId,
+  });
+  assert.equal(wordless.ok, false);
+  if (wordless.ok) return;
+  assert.equal(wordless.refusal, STORE_WRITE_REFUSAL.MESSAGE_REFUSED);
+});
+
+test("events about a message are numbered by the conversation's own event sequence, and one about no message is refused", async () => {
+  const target = await conversation();
+  const stream = new Stream();
+  await feed(target, developerTurn(stream, randomUUID(), randomUUID()));
+  const [, reply] = await database.db
+    .select({ id: messages.id })
+    .from(messages)
+    .where(eq(messages.conversationId, target.conversationId))
+    .orderBy(asc(messages.seq));
+  assert.ok(reply);
+  const offered = await writer.recordEvent(target, {
+    messageId: reply.id,
+    kind: CONVERSATION_EVENT_KIND.SPEECH_OFFERED,
+  });
+  const claimed = await writer.recordEvent(target, {
+    messageId: reply.id,
+    kind: CONVERSATION_EVENT_KIND.SPEECH_CLAIMED,
+    deviceId: "device-1",
+    payload: { at: NOW },
+  });
+  assert.equal(offered.ok && offered.seq, 1);
+  assert.equal(claimed.ok && claimed.seq, 2);
+  const stored = await database.db
+    .select({
+      seq: events.seq,
+      kind: events.kind,
+      deviceId: events.deviceId,
+      payload: events.payload,
+    })
+    .from(events)
+    .where(and(eq(events.conversationId, target.conversationId), eq(events.messageId, reply.id)))
+    .orderBy(asc(events.seq));
+  assert.deepEqual(stored, [
+    { seq: 1, kind: CONVERSATION_EVENT_KIND.SPEECH_OFFERED, deviceId: null, payload: null },
+    {
+      seq: 2,
+      kind: CONVERSATION_EVENT_KIND.SPEECH_CLAIMED,
+      deviceId: "device-1",
+      payload: { at: NOW },
+    },
+  ]);
+  assert.deepEqual(await counters(target), { message: 3, event: 3 });
+
+  const noMessage = await writer.recordEvent(target, {
+    messageId: randomUUID(),
+    kind: CONVERSATION_EVENT_KIND.SPEECH_OFFERED,
+  });
+  assert.deepEqual(noMessage, { ok: false, refusal: STORE_WRITE_REFUSAL.NO_MESSAGE });
+
+  const other = await conversation();
+  const elsewhere = await writer.recordEvent(other, {
+    messageId: reply.id,
+    kind: CONVERSATION_EVENT_KIND.SPEECH_OFFERED,
+  });
+  assert.deepEqual(elsewhere, { ok: false, refusal: STORE_WRITE_REFUSAL.NO_MESSAGE });
+
+  const secondClaim = await writer.recordEvent(target, {
+    messageId: reply.id,
+    kind: CONVERSATION_EVENT_KIND.SPEECH_CLAIMED,
+    deviceId: "device-2",
+  });
+  assert.deepEqual(secondClaim, { ok: false, refusal: STORE_WRITE_REFUSAL.ALREADY_CLAIMED });
+  assert.deepEqual(await counters(target), { message: 3, event: 3 });
+});

--- a/apps/web/tests/store-writer-boundary.test.ts
+++ b/apps/web/tests/store-writer-boundary.test.ts
@@ -1,0 +1,91 @@
+import assert from "node:assert/strict";
+import { readdir, readFile } from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+/**
+ * No code path writes a message, a turn, or an event except the store writer:
+ * the invariant the writer establishes, stated over the server's import graph.
+ * A module that could write one of the three tables has to import it from the
+ * schema by name, so the set of server modules that do is the set that could
+ * write, and that set is the writer alone. The aggregate schema module
+ * re-exports them for the query builder and imports nothing, and a reader
+ * that lands later joins this list by name, in the open.
+ */
+
+const SERVER_ROOTS = ["server", "api"].map((root) =>
+  fileURLToPath(new URL(`../${root}/`, import.meta.url)),
+);
+
+const WRITTEN_TABLES: ReadonlySet<string> = new Set(["messages", "turns", "events"]);
+
+const WRITERS: ReadonlySet<string> = new Set(["server/hosted/store/writer.ts"]);
+
+/**
+ * The modules that import the whole schema as a namespace, which reaches
+ * every table at once: the two that hand it to the query builder. A third
+ * joins this list by name or fails here.
+ */
+const SCHEMA_NAMESPACE_IMPORTERS: ReadonlySet<string> = new Set([
+  "server/auth.ts",
+  "server/db/index.ts",
+]);
+
+const SCHEMA_MODULE = /(?:^|\/)(?:storage-)?schema\.js$/;
+
+const IMPORT_STATEMENT = /import\s+(type\s+)?\{([^}]*)\}\s*from\s*"([^"]+)"/g;
+
+const NAMESPACE_IMPORT_STATEMENT = /import\s+(type\s+)?\*\s+as\s+\w+\s+from\s*"([^"]+)"/g;
+
+async function sourceFiles(directory: string): Promise<readonly string[]> {
+  const entries = await readdir(directory, { recursive: true });
+  return entries
+    .filter((entry) => entry.endsWith(".ts") && !entry.endsWith(".test.ts"))
+    .map((entry) => path.join(directory, entry));
+}
+
+/** Whether a module imports a schema module whole, as a namespace, type imports aside. */
+function importsSchemaNamespace(source: string): boolean {
+  for (const match of source.matchAll(NAMESPACE_IMPORT_STATEMENT)) {
+    const [, typeOnly, specifier] = match;
+    if (typeOnly === undefined && specifier !== undefined && SCHEMA_MODULE.test(specifier)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/** The written tables a module imports from the schema by name, type imports aside. */
+function importedTables(source: string): readonly string[] {
+  const tables: string[] = [];
+  for (const match of source.matchAll(IMPORT_STATEMENT)) {
+    const [, typeOnly, names, specifier] = match;
+    if (typeOnly !== undefined || specifier === undefined || !SCHEMA_MODULE.test(specifier))
+      continue;
+    for (const name of (names ?? "").split(",")) {
+      const imported = name.trim().replace(/\s+as\s+\w+$/, "");
+      if (imported.startsWith("type ")) continue;
+      if (WRITTEN_TABLES.has(imported)) tables.push(imported);
+    }
+  }
+  return tables;
+}
+
+test("the writer is the one server module that imports the messages, turns, or events table, and the schema is imported whole by the two that build queries over it", async () => {
+  const repositoryRoot = fileURLToPath(new URL("../", import.meta.url));
+  const importers = new Map<string, readonly string[]>();
+  const namespaceImporters = new Set<string>();
+  for (const root of SERVER_ROOTS) {
+    for (const file of await sourceFiles(root)) {
+      const source = await readFile(file, "utf8");
+      const relative = path.relative(repositoryRoot, file);
+      const tables = importedTables(source);
+      if (tables.length > 0) importers.set(relative, tables);
+      if (importsSchemaNamespace(source)) namespaceImporters.add(relative);
+    }
+  }
+  assert.deepEqual(new Set(importers.keys()), WRITERS);
+  assert.deepEqual(new Set(importers.get("server/hosted/store/writer.ts")), WRITTEN_TABLES);
+  assert.deepEqual(namespaceImporters, SCHEMA_NAMESPACE_IMPORTERS);
+});

--- a/packages/brain/src/index.ts
+++ b/packages/brain/src/index.ts
@@ -120,6 +120,7 @@ export {
   type BrainTurnTrigger,
   runOriginOf,
 } from "./turn.js";
+export { settledToolPart, toolPartType, UI_PART_STATE, UI_PART_TYPE } from "./ui-messages.js";
 export {
   BRAIN_WAKE_KIND,
   type BrainDelivery,

--- a/packages/brain/src/ui-messages.ts
+++ b/packages/brain/src/ui-messages.ts
@@ -114,7 +114,8 @@ function reasoningPart(reasoning: ReasoningSummary): ReasoningUIPart {
   };
 }
 
-function settledToolPart(part: ToolPart, settlement: ToolCallSettlement): ToolPart {
+/** A tool part in the state its call settled in: the answer's output, or the error's own text. */
+export function settledToolPart(part: ToolPart, settlement: ToolCallSettlement): ToolPart {
   const call = { type: part.type, toolCallId: part.toolCallId };
   return settlement.state === TOOL_CALL_SETTLEMENT.OUTPUT_ERROR
     ? {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -266,6 +266,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: 5.1.2
         version: 5.1.2(vite@7.3.1(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.12)(yaml@2.9.0))
+      ai:
+        specifier: 7.0.97
+        version: 7.0.97(zod@4.5.4)
       drizzle-kit:
         specifier: 0.31.10
         version: 0.31.10
@@ -278,6 +281,9 @@ importers:
       vite:
         specifier: 7.3.1
         version: 7.3.1(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.12)(yaml@2.9.0)
+      zod:
+        specifier: 4.5.4
+        version: 4.5.4
 
   packages/actions:
     dependencies:


### PR DESCRIPTION
## What

The store writer, `apps/web/server/hosted/store/writer.ts`: the one path by which a `messages`, `turns`, or `events` row is written. It consumes the A3 run event stream (`BrainRunEvent`, every turn kind) for a conversation the caller names by row id and account, and keeps the record `plan/storage-plan.md` describes:

- **turns**: queued (`enqueueTurn`, written ahead of the stream, or at `TURN_STARTED` where nothing queued it) → running → settled / cancelled / failed, with the origin it was queued under, usage split four ways, `response_ids` where the runtime has them (empty otherwise), and the failure word.
- **messages**: each user message the turn opened with lands as its own row by the message's id. The turn's answer is one assistant row keyed by the turn id as `client_id`; while the turn runs that row is its journal — a tool call is written in `input-available` **before** execution and moved to `output-available` / `output-error` as the result lands, a reasoning summary is written as it completes — and the turn's completed message replaces the journal's parts whole and sets `finished_at` once. After that the row is immutable: a late, never-seen event for it is refused as `finished`; a redelivered known one reads as `repeated`.
- A turn that ends with a call still unanswered settles the call as `output-error` (nothing will answer it now; an unknown action is never retried) and closes the row. A writer that dies between the call and its result leaves the part in `input-available`, which is what a resume reads.
- **compaction**: `recordCompaction` writes the assistant row through A6's `compactionSummaryMessage`, naming `first_kept_message_id` and, only where the owner counted them, `tokens_before` (absent otherwise, never zero — A6's finding). The stream's `COMPACTION_COMPLETED` carries neither the first kept message nor, under eve, the summary text, so it is consumed as `ignored` and the compaction's owner hands the row over.
- **events**: `recordEvent` is the one path to the `events` table, numbered by the conversation's event sequence. C5 wires `announce → speech.offered` through it; this PR wires no kind.

## How the invariant holds

"No code path writes messages except this writer" is stated over the import graph, not intended: `tests/store-writer-boundary.test.ts` walks `apps/web/server` and `apps/web/api` and asserts that the set of modules importing `messages`, `turns`, or `events` from the schema by name is exactly `{ server/hosted/store/writer.ts }`. A reader that lands later joins that list by name.

## Idempotency and sequences

- A message by `(conversation_id, client_id)`, a turn by its id, a tool part by its call id, a reasoning part by its item id. The same event delivered twice writes one row; a whole turn replayed changes nothing (`repeated` on every event, counters unmoved) — tested.
- Every write runs under a `FOR UPDATE` lock on the conversation row, which serializes the conversation's writers, so a check made before an insert holds when the insert runs (this is what makes select-then-insert idempotency race-free). Sequences come from the row's counters, and each allocation lands on the first position no row holds (`greatest(counter, max(seq)+1)`), so a position taken outside the counter costs a skip and nothing else. The unique `(conversation_id, seq)` constraint stays the backstop: under the lock and this allocation the B1-convention "retry signal" cannot fire, so there is no retry loop — a violation that still occurs is a writer outside the lock and surfaces loudly. Tested by taking the counter's next position out from under it. A second `speech.claimed` on one message is answered `already_claimed` under the same lock rather than thrown as a driver error.
- A conversation Clear has stamped (`deleted_at`) is written by nothing: `no_conversation`, like one that never was.

## Validation on write

Every message is held to the vocabulary before it lands through `readStoredUIMessages` — the same reader with the registry pre-check A1 built, never the SDK's `validateUIMessages` directly — over the row's JSON shape, so no row can carry a tool the catalog does not register, an input its schema refuses, or metadata outside `@sidecar/wire`'s set. A refusal comes back as the reader's own word and path (`message_refused` + `not-registered` / `malformed`). The `ai` pin stays `7.0.97` and `zod` `4.5.4`, matching A1; the writer needs neither cast because it goes through A1's wrapper.

## eve conditions (S0 Q3)

The consumer is shaped so eve's adapter can feed it: the completed message is the authoritative ordered projection that replaces in-flight parts (order by `stepIndex` is the adapter's, not arrival order in the row); a null `message.completed` simply never completes the journal and `TURN_ENDED` closes it; cancelled parts are settled at `TURN_ENDED`; a retried step's stale in-flight parts are replaced by the projection; `turns.response_ids` is written where present and left `[]` otherwise.

## Findings for the orchestrator (also sent by message)

1. **`turns.origin` vocabulary gap.** A3's `BrainTurnOrigin` names `observation` and `child_completion`; the plan's `TURN_ORIGIN` (B1, D1) names neither. The writer maps `observation → roster_diff` (true in the hosted tier, which opens observation turns from roster diffs alone) and `child_completion → child` (the schema comment already reads `child` as "a child's completion"; the conversation's kind tells a child's own task turn from the parent's completion turn). A queued row's origin (C2's decision) always wins over the mapping.
2. **Refused vs unknown is not on the row.** The SDK's `output-error` part has `output?: never`, and A3's completed projection carries `errorText` alone for an error part, so the action envelope's `status` (`refused` vs `unknown`) does not survive on an `output-error` part. D1 currently draws every `output-error` as refused. The writer matches A3's shape exactly (it must, for the projection to replace the journal without churn). If the distinction must be stored, the slot is `resultProviderMetadata` on the part, in both A3's builder and here — a contract decision, not made in this PR.
3. **Compaction rows are built by A6's `compactionSummaryMessage`** (A6 merged as edc5bad1), so an uncounted compaction is written with `tokens_before` absent — never zero, never refused — and a summary with no words is refused as the builder says.

## CLAUDE.md sentences this contradicts (for G5)

- "the journal that records an action before its effect and its result before the next inference" and "the action journal that pairs each action with its outcome" — the journal is now the in-flight assistant message's tool-part state, no separate journal.
- "What the brain keeps is one generation per conversation, in one database under one writer … one SQLite file per agent" and the generation / checkpoint / cursor / envelope description — replaced by `messages` / `turns` rows in Postgres.
- "The envelope holds the Responses input from the latest compaction onward — the API's encrypted compaction item included" — compaction is a summary message.

## Verify

```sh
./scripts/check.sh
pnpm --filter @luke/web test:store
pnpm --filter @luke/web exec tsx --test tests/store-writer-boundary.test.ts
```

No macOS or UI code is touched; `verify.sh` does not apply.

## Reviews run

Neither skill is installed here; both were located online and applied as written.

- **Cursor `thermo-nuclear-code-quality-review`** (cursor/plugins, `cursor-team-kit/skills/…/SKILL.md`; "thermonuclear code review" resolves to this and to its security sibling, so both were run). Quality pass: REQUEST CHANGES with four blockers, all taken — (1) the ~90-line unique-violation retry apparatus (driver-error schema, constraint-name coupling, retry loop, two realign statements) deleted in favour of the self-healing allocation above; (2) the `speech.claimed` race made a typed `already_claimed` refusal instead of a thrown driver error; (3) the duplicated SDK part builders replaced by exporting `toolPartType`, `settledToolPart`, `UI_PART_TYPE`, `UI_PART_STATE` from `@sidecar/brain` (the only change outside `apps/web`); (4) the boundary test now also accounts for `import * as schema` namespace imports, with an explicit allowlist of the two query-builder modules. Also taken: helpers hoisted to module scope over a `WriterContext` like the sibling store modules, `nullable()` reused, the `{ ok }` result shape everywhere, `messageCompleted` on a closed journal distinguishing a repeated projection from a late different one (deep-equal), `toolCallSettled` answering `no_turn` when the turn itself is missing. Declined: importing `BrainRequestStatus` from the brain barrel (it is not exported there; the derivation stands).
- **Cursor `thermo-nuclear-review`** (security/correctness sibling): no security or cross-tenant issue found; idempotency, lock, transaction rollback, `turnEnded`, validation-on-write, and the star-export door all traced clean. One Medium accepted explicitly rather than fixed: a completed answer naming a tool the catalog does not register (or an input its schema refuses) is refused **whole** and reported as `message_refused`, never cut down to the parts that would pass — a cut message says something its author did not; the turn row still ends. Lows taken: `already_claimed`; an id-less reasoning item is `ignored` rather than journaled (its repeat would be indistinguishable from a second item; the projection carries it anyway); a compaction client id landing on a non-compaction row throws as the caller's bug rather than reading as a repeat; cleared conversations refused. Lows declined with reason: checking `event.conversationId` against `runtime_session_id` (a check that only sometimes runs is worse than none; routing is the caller's, stated in the doc comment), and mapping a cross-conversation `turns_pkey` collision on caller-supplied UUIDs to a refusal.
- **`ponytail-review`** (DietrichGebert/ponytail — not Cursor-authored, but it is what "ponytail review" names; applied as written): 10 findings, `net: -89 lines possible`. Nine taken (the duplicate builders, inlined wrappers, the impossible-state branch, hoisted `missing` literals, `readdir({ recursive: true })`, the seven-literal assertion, and the unused `toolFailed` fixture turned into a real test of a refused call). One declined: the three-member terminal-status set stays as a named concept rather than a double negative.

## Test results

`./scripts/check.sh` exit 0 on the final commit (lint, knip, typecheck, every workspace test, build). `tests/hosted-store-writer.test.ts`: 19 passing on PGlite (developer, observation, and child turns; the killed-writer journal; every event twice plus a whole-turn replay; cancelled/failed/timed-out ends; queued → running → settled; the taken-sequence skip; the reader's refusals with word and path; a refused call's part shape; the closed-journal rules; cleared conversation; id-less reasoning; a turn that ended without a journal opens none after the fact (Bugbot's finding on the first push, fixed); compaction, counted and uncounted; events and the claim). `tests/store-writer-boundary.test.ts`: 1 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34542265497/artifacts/10177794767) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34542265497)

- Commit: `002d6142a8258c1cf3cd0c448a31761b8cf78d7e`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
