### PR TITLE
feat(LUKE-124): message reads and soft delete

### DIFF
--- a/apps/web/api/observation/tick.ts
+++ b/apps/web/api/observation/tick.ts
@@ -54,6 +54,7 @@ const route: Route = {
       forgetIneligible: async (seenAfter) => {
         await store?.roster.forgetIneligible({ providerIds: CLOUD_PROVIDER_IDS, seenAfter });
       },
+      purgeCleared: async (now) => (store ? store.retention.purgeCleared(new Date(now)) : 0),
       observe: async (userId) => {
         if (!store || !encryptionSecret) return { complete: false, changed: false };
         const rows = await database

--- a/apps/web/drizzle/0018_b6_standing_main_purge_and_turn_indexes.sql
+++ b/apps/web/drizzle/0018_b6_standing_main_purge_and_turn_indexes.sql
@@ -1,0 +1,3 @@
+CREATE UNIQUE INDEX "conversations_standing_main" ON "conversations" USING btree ("user_id") WHERE "conversations"."kind" = 'main' and "conversations"."deleted_at" is null;--> statement-breakpoint
+CREATE INDEX "conversations_deleted_at" ON "conversations" USING btree ("deleted_at") WHERE "conversations"."deleted_at" is not null;--> statement-breakpoint
+CREATE INDEX "turns_by_user" ON "turns" USING btree ("user_id");

--- a/apps/web/drizzle/meta/0018_snapshot.json
+++ b/apps/web/drizzle/meta/0018_snapshot.json
@@ -1,0 +1,4011 @@
+{
+  "id": "84a4b50a-03c7-4db4-97ae-92bb3456aa61",
+  "prevId": "ddb09c2c-4397-4908-b499-086e661ded59",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.jwks": {
+      "name": "jwks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_key": {
+          "name": "private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_access_token": {
+      "name": "oauth_access_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_id": {
+          "name": "refresh_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "oauthAccessToken_clientId_idx": {
+          "name": "oauthAccessToken_clientId_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthAccessToken_sessionId_idx": {
+          "name": "oauthAccessToken_sessionId_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthAccessToken_userId_idx": {
+          "name": "oauthAccessToken_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthAccessToken_refreshId_idx": {
+          "name": "oauthAccessToken_refreshId_idx",
+          "columns": [
+            {
+              "expression": "refresh_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_access_token_client_id_oauth_client_client_id_fk": {
+          "name": "oauth_access_token_client_id_oauth_client_client_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "oauth_client",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["client_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_session_id_session_id_fk": {
+          "name": "oauth_access_token_session_id_session_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "session",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_user_id_user_id_fk": {
+          "name": "oauth_access_token_user_id_user_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_refresh_id_oauth_refresh_token_id_fk": {
+          "name": "oauth_access_token_refresh_id_oauth_refresh_token_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "oauth_refresh_token",
+          "columnsFrom": ["refresh_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_access_token_token_unique": {
+          "name": "oauth_access_token_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_client": {
+      "name": "oauth_client",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "skip_consent": {
+          "name": "skip_consent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enable_end_session": {
+          "name": "enable_end_session",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject_type": {
+          "name": "subject_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contacts": {
+          "name": "contacts",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tos": {
+          "name": "tos",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "policy": {
+          "name": "policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_id": {
+          "name": "software_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_version": {
+          "name": "software_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_statement": {
+          "name": "software_statement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_logout_redirect_uris": {
+          "name": "post_logout_redirect_uris",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_endpoint_auth_method": {
+          "name": "token_endpoint_auth_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grant_types": {
+          "name": "grant_types",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_types": {
+          "name": "response_types",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public": {
+          "name": "public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "require_pkce": {
+          "name": "require_pkce",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "oauthClient_userId_idx": {
+          "name": "oauthClient_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_client_user_id_user_id_fk": {
+          "name": "oauth_client_user_id_user_id_fk",
+          "tableFrom": "oauth_client",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_client_client_id_unique": {
+          "name": "oauth_client_client_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["client_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_consent": {
+      "name": "oauth_consent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "oauthConsent_clientId_idx": {
+          "name": "oauthConsent_clientId_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthConsent_userId_idx": {
+          "name": "oauthConsent_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_consent_client_id_oauth_client_client_id_fk": {
+          "name": "oauth_consent_client_id_oauth_client_client_id_fk",
+          "tableFrom": "oauth_consent",
+          "tableTo": "oauth_client",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["client_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_consent_user_id_user_id_fk": {
+          "name": "oauth_consent_user_id_user_id_fk",
+          "tableFrom": "oauth_consent",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_refresh_token": {
+      "name": "oauth_refresh_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked": {
+          "name": "revoked",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_time": {
+          "name": "auth_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "oauthRefreshToken_clientId_idx": {
+          "name": "oauthRefreshToken_clientId_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthRefreshToken_sessionId_idx": {
+          "name": "oauthRefreshToken_sessionId_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthRefreshToken_userId_idx": {
+          "name": "oauthRefreshToken_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_refresh_token_client_id_oauth_client_client_id_fk": {
+          "name": "oauth_refresh_token_client_id_oauth_client_client_id_fk",
+          "tableFrom": "oauth_refresh_token",
+          "tableTo": "oauth_client",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["client_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_refresh_token_session_id_session_id_fk": {
+          "name": "oauth_refresh_token_session_id_session_id_fk",
+          "tableFrom": "oauth_refresh_token",
+          "tableTo": "session",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "oauth_refresh_token_user_id_user_id_fk": {
+          "name": "oauth_refresh_token_user_id_user_id_fk",
+          "tableFrom": "oauth_refresh_token",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_refresh_token_token_unique": {
+          "name": "oauth_refresh_token_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_login_method": {
+          "name": "last_login_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'user'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.briefing": {
+      "name": "briefing",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_key": {
+          "name": "session_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sealed_words": {
+          "name": "sealed_words",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claimed_by_device_id": {
+          "name": "claimed_by_device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settled_at": {
+          "name": "settled_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "briefing_by_user_state": {
+          "name": "briefing_by_user_state",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "decided_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "briefing_user_id_user_id_fk": {
+          "name": "briefing_user_id_user_id_fk",
+          "tableFrom": "briefing",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "briefing_user_id_id_pk": {
+          "name": "briefing_user_id_id_pk",
+          "columns": ["user_id", "id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.action_receipt": {
+      "name": "action_receipt",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "call_id": {
+          "name": "call_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ordinal": {
+          "name": "ordinal",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sealed_arguments": {
+          "name": "sealed_arguments",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sealed_output": {
+          "name": "sealed_output",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settled_at": {
+          "name": "settled_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "action_receipt_by_session": {
+          "name": "action_receipt_by_session",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ordinal",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "action_receipt_session_fk": {
+          "name": "action_receipt_session_fk",
+          "tableFrom": "action_receipt",
+          "tableTo": "conversation_session",
+          "columnsFrom": ["user_id", "session_id"],
+          "columnsTo": ["user_id", "session_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "action_receipt_user_id_run_id_call_id_pk": {
+          "name": "action_receipt_user_id_run_id_call_id_pk",
+          "columns": ["user_id", "run_id", "call_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.compaction_boundary": {
+      "name": "compaction_boundary",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_key": {
+          "name": "session_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transcript_sequence": {
+          "name": "transcript_sequence",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dropped": {
+          "name": "dropped",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "checkpoint_format": {
+          "name": "checkpoint_format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "compaction_boundary_conversation_fk": {
+          "name": "compaction_boundary_conversation_fk",
+          "tableFrom": "compaction_boundary",
+          "tableTo": "conversation",
+          "columnsFrom": ["user_id", "session_key"],
+          "columnsTo": ["user_id", "session_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "compaction_boundary_user_id_session_key_transcript_sequence_pk": {
+          "name": "compaction_boundary_user_id_session_key_transcript_sequence_pk",
+          "columns": ["user_id", "session_key", "transcript_sequence"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation": {
+      "name": "conversation",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_key": {
+          "name": "session_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "next_line_sequence": {
+          "name": "next_line_sequence",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "next_transcript_sequence": {
+          "name": "next_transcript_sequence",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "cleared_at": {
+          "name": "cleared_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "conversation_user_id_user_id_fk": {
+          "name": "conversation_user_id_user_id_fk",
+          "tableFrom": "conversation",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "conversation_user_id_session_key_pk": {
+          "name": "conversation_user_id_session_key_pk",
+          "columns": ["user_id", "session_key"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation_line": {
+      "name": "conversation_line",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_key": {
+          "name": "session_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_key": {
+          "name": "event_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recorded_at": {
+          "name": "recorded_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_session_id": {
+          "name": "provider_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sealed_payload": {
+          "name": "sealed_payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "conversation_line_by_key": {
+          "name": "conversation_line_by_key",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_line_by_time": {
+          "name": "conversation_line_by_time",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recorded_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sequence",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_line_once_published": {
+          "name": "conversation_line_once_published",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"conversation_line\".\"request_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_line_conversation_fk": {
+          "name": "conversation_line_conversation_fk",
+          "tableFrom": "conversation_line",
+          "tableTo": "conversation",
+          "columnsFrom": ["user_id", "session_key"],
+          "columnsTo": ["user_id", "session_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "conversation_line_user_id_session_key_sequence_pk": {
+          "name": "conversation_line_user_id_session_key_sequence_pk",
+          "columns": ["user_id", "session_key", "sequence"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation_run": {
+      "name": "conversation_run",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ordinal": {
+          "name": "ordinal",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submission_id": {
+          "name": "submission_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "origin": {
+          "name": "origin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sealed_question": {
+          "name": "sealed_question",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revision": {
+          "name": "revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settled_at": {
+          "name": "settled_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sealed_text": {
+          "name": "sealed_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure": {
+          "name": "failure",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "performed_actions": {
+          "name": "performed_actions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unknown_actions": {
+          "name": "unknown_actions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ask_recorded_at": {
+          "name": "ask_recorded_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conversation_recorded_at": {
+          "name": "conversation_recorded_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage": {
+          "name": "usage",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_ids": {
+          "name": "response_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_origin": {
+          "name": "run_origin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ending": {
+          "name": "ending",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_item_kinds": {
+          "name": "input_item_kinds",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transcript_bytes": {
+          "name": "transcript_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "elapsed_ms": {
+          "name": "elapsed_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_names": {
+          "name": "tool_names",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "compacted": {
+          "name": "compacted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "conversation_run_by_session": {
+          "name": "conversation_run_by_session",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ordinal",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_run_session_fk": {
+          "name": "conversation_run_session_fk",
+          "tableFrom": "conversation_run",
+          "tableTo": "conversation_session",
+          "columnsFrom": ["user_id", "session_id"],
+          "columnsTo": ["user_id", "session_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "conversation_run_user_id_run_id_pk": {
+          "name": "conversation_run_user_id_run_id_pk",
+          "columns": ["user_id", "run_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation_session": {
+      "name": "conversation_session",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_key": {
+          "name": "session_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reset_cleared_at": {
+          "name": "reset_cleared_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reset_generation_id": {
+          "name": "reset_generation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checkpoint_format": {
+          "name": "checkpoint_format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "compaction_count": {
+          "name": "compaction_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "conversation_session_one_standing": {
+          "name": "conversation_session_one_standing",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_session_conversation_fk": {
+          "name": "conversation_session_conversation_fk",
+          "tableFrom": "conversation_session",
+          "tableTo": "conversation",
+          "columnsFrom": ["user_id", "session_key"],
+          "columnsTo": ["user_id", "session_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "conversation_session_user_id_session_id_pk": {
+          "name": "conversation_session_user_id_session_id_pk",
+          "columns": ["user_id", "session_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.observation_capture_cursor": {
+      "name": "observation_capture_cursor",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_session_id": {
+          "name": "provider_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cursor": {
+          "name": "cursor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "observation_capture_cursor_session_fk": {
+          "name": "observation_capture_cursor_session_fk",
+          "tableFrom": "observation_capture_cursor",
+          "tableTo": "conversation_session",
+          "columnsFrom": ["user_id", "session_id"],
+          "columnsTo": ["user_id", "session_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "observation_capture_cursor_user_id_session_id_provider_id_provider_session_id_pk": {
+          "name": "observation_capture_cursor_user_id_session_id_provider_id_provider_session_id_pk",
+          "columns": ["user_id", "session_id", "provider_id", "provider_session_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.observation_cursor": {
+      "name": "observation_cursor",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_session_id": {
+          "name": "provider_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cursor": {
+          "name": "cursor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "observation_cursor_session_fk": {
+          "name": "observation_cursor_session_fk",
+          "tableFrom": "observation_cursor",
+          "tableTo": "conversation_session",
+          "columnsFrom": ["user_id", "session_id"],
+          "columnsTo": ["user_id", "session_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "observation_cursor_user_id_session_id_provider_id_provider_session_id_pk": {
+          "name": "observation_cursor_user_id_session_id_provider_id_provider_session_id_pk",
+          "columns": ["user_id", "session_id", "provider_id", "provider_session_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.observation_inbox_entry": {
+      "name": "observation_inbox_entry",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ordinal": {
+          "name": "ordinal",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entry_id": {
+          "name": "entry_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sealed_payload": {
+          "name": "sealed_payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "observation_inbox_entry_session_fk": {
+          "name": "observation_inbox_entry_session_fk",
+          "tableFrom": "observation_inbox_entry",
+          "tableTo": "conversation_session",
+          "columnsFrom": ["user_id", "session_id"],
+          "columnsTo": ["user_id", "session_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "observation_inbox_entry_user_id_session_id_ordinal_pk": {
+          "name": "observation_inbox_entry_user_id_session_id_ordinal_pk",
+          "columns": ["user_id", "session_id", "ordinal"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.runtime_checkpoint": {
+      "name": "runtime_checkpoint",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sealed_item": {
+          "name": "sealed_item",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "runtime_checkpoint_session_fk": {
+          "name": "runtime_checkpoint_session_fk",
+          "tableFrom": "runtime_checkpoint",
+          "tableTo": "conversation_session",
+          "columnsFrom": ["user_id", "session_id"],
+          "columnsTo": ["user_id", "session_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "runtime_checkpoint_user_id_session_id_sequence_pk": {
+          "name": "runtime_checkpoint_user_id_session_id_sequence_pk",
+          "columns": ["user_id", "session_id", "sequence"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transcript_event": {
+      "name": "transcript_event",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_key": {
+          "name": "session_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recorded_at": {
+          "name": "recorded_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sealed_payload": {
+          "name": "sealed_payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "transcript_event_conversation_fk": {
+          "name": "transcript_event_conversation_fk",
+          "tableFrom": "transcript_event",
+          "tableTo": "conversation",
+          "columnsFrom": ["user_id", "session_key"],
+          "columnsTo": ["user_id", "session_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "transcript_event_user_id_session_key_sequence_pk": {
+          "name": "transcript_event_user_id_session_key_sequence_pk",
+          "columns": ["user_id", "session_key", "sequence"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.devices": {
+      "name": "devices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "active_until": {
+          "name": "active_until",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "push_token": {
+          "name": "push_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "push_environment": {
+          "name": "push_environment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "devices_user_id_user_id_fk": {
+          "name": "devices_user_id_user_id_fk",
+          "tableFrom": "devices",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "devices_installation_id_unique": {
+          "name": "devices_installation_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["installation_id"]
+        },
+        "devices_push_token_unique": {
+          "name": "devices_push_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["push_token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.admin_favorite": {
+      "name": "admin_favorite",
+      "schema": "",
+      "columns": {
+        "admin_id": {
+          "name": "admin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "admin_favorite_admin_id_user_id_fk": {
+          "name": "admin_favorite_admin_id_user_id_fk",
+          "tableFrom": "admin_favorite",
+          "tableTo": "user",
+          "columnsFrom": ["admin_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "admin_favorite_user_id_user_id_fk": {
+          "name": "admin_favorite_user_id_user_id_fk",
+          "tableFrom": "admin_favorite",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "admin_favorite_admin_id_user_id_pk": {
+          "name": "admin_favorite_admin_id_user_id_pk",
+          "columns": ["admin_id", "user_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.account_preference": {
+      "name": "account_preference",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "voice": {
+          "name": "voice",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "voice_speed": {
+          "name": "voice_speed",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_workspace_provider": {
+          "name": "default_workspace_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_preference_user_id_user_id_fk": {
+          "name": "account_preference_user_id_user_id_fk",
+          "tableFrom": "account_preference",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.account_workspace_preference": {
+      "name": "account_workspace_preference",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_project_id": {
+          "name": "default_project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent": {
+          "name": "agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "effort": {
+          "name": "effort",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_workspace_preference_user_id_user_id_fk": {
+          "name": "account_workspace_preference_user_id_user_id_fk",
+          "tableFrom": "account_workspace_preference",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "account_workspace_preference_user_id_provider_id_pk": {
+          "name": "account_workspace_preference_user_id_provider_id_pk",
+          "columns": ["user_id", "provider_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.observation_pass": {
+      "name": "observation_pass",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "attempted_at": {
+          "name": "attempted_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure": {
+          "name": "failure",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "observation_pass_user_id_user_id_fk": {
+          "name": "observation_pass_user_id_user_id_fk",
+          "tableFrom": "observation_pass",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.roster_diff": {
+      "name": "roster_diff",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previous_observed_at": {
+          "name": "previous_observed_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sealed_payload": {
+          "name": "sealed_payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "roster_diff_by_user_pending": {
+          "name": "roster_diff_by_user_pending",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "consumed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "observed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "roster_diff_user_id_user_id_fk": {
+          "name": "roster_diff_user_id_user_id_fk",
+          "tableFrom": "roster_diff",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "roster_diff_user_id_id_pk": {
+          "name": "roster_diff_user_id_id_pk",
+          "columns": ["user_id", "id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.roster_snapshot": {
+      "name": "roster_snapshot",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "sealed_body": {
+          "name": "sealed_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "roster_snapshot_user_id_user_id_fk": {
+          "name": "roster_snapshot_user_id_user_id_fk",
+          "tableFrom": "roster_snapshot",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation_lease": {
+      "name": "conversation_lease",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "acquired_at": {
+          "name": "acquired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "heartbeat_at": {
+          "name": "heartbeat_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "conversation_lease_user_id_user_id_fk": {
+          "name": "conversation_lease_user_id_user_id_fk",
+          "tableFrom": "conversation_lease",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversations": {
+      "name": "conversations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_session_id": {
+          "name": "provider_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_conversation_id": {
+          "name": "parent_conversation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spawned_by_message_id": {
+          "name": "spawned_by_message_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fork_of_seq": {
+          "name": "fork_of_seq",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_session_id": {
+          "name": "runtime_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_message_seq": {
+          "name": "next_message_seq",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "next_event_seq": {
+          "name": "next_event_seq",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "conversations_observed_session": {
+          "name": "conversations_observed_session",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_standing_main": {
+          "name": "conversations_standing_main",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"conversations\".\"kind\" = 'main' and \"conversations\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_deleted_at": {
+          "name": "conversations_deleted_at",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"conversations\".\"deleted_at\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversations_user_id_user_id_fk": {
+          "name": "conversations_user_id_user_id_fk",
+          "tableFrom": "conversations",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "conversations_parent_conversation_id_conversations_id_fk": {
+          "name": "conversations_parent_conversation_id_conversations_id_fk",
+          "tableFrom": "conversations",
+          "tableTo": "conversations",
+          "columnsFrom": ["parent_conversation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "conversations_spawned_by_message_id_messages_id_fk": {
+          "name": "conversations_spawned_by_message_id_messages_id_fk",
+          "tableFrom": "conversations",
+          "tableTo": "messages",
+          "columnsFrom": ["spawned_by_message_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.events": {
+      "name": "events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq": {
+          "name": "seq",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "events_speech_claimed_message": {
+          "name": "events_speech_claimed_message",
+          "columns": [
+            {
+              "expression": "message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"events\".\"kind\" = 'speech.claimed'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "events_user_id_user_id_fk": {
+          "name": "events_user_id_user_id_fk",
+          "tableFrom": "events",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "events_conversation_id_conversations_id_fk": {
+          "name": "events_conversation_id_conversations_id_fk",
+          "tableFrom": "events",
+          "tableTo": "conversations",
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "events_message_id_messages_id_fk": {
+          "name": "events_message_id_messages_id_fk",
+          "tableFrom": "events",
+          "tableTo": "messages",
+          "columnsFrom": ["message_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "events_conversation_seq": {
+          "name": "events_conversation_seq",
+          "nullsNotDistinct": false,
+          "columns": ["conversation_id", "seq"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq": {
+          "name": "seq",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "turn_id": {
+          "name": "turn_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parts": {
+          "name": "parts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "messages_user_id_user_id_fk": {
+          "name": "messages_user_id_user_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messages_conversation_id_conversations_id_fk": {
+          "name": "messages_conversation_id_conversations_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "conversations",
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messages_turn_id_turns_id_fk": {
+          "name": "messages_turn_id_turns_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "turns",
+          "columnsFrom": ["turn_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "messages_conversation_client": {
+          "name": "messages_conversation_client",
+          "nullsNotDistinct": false,
+          "columns": ["conversation_id", "client_id"]
+        },
+        "messages_conversation_seq": {
+          "name": "messages_conversation_seq",
+          "nullsNotDistinct": false,
+          "columns": ["conversation_id", "seq"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.prompts": {
+      "name": "prompts",
+      "schema": "",
+      "columns": {
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provider_cursors": {
+      "name": "provider_cursors",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_session_id": {
+          "name": "provider_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cursor": {
+          "name": "cursor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "provider_cursors_user_id_user_id_fk": {
+          "name": "provider_cursors_user_id_user_id_fk",
+          "tableFrom": "provider_cursors",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "provider_cursors_user_id_provider_id_provider_session_id_pk": {
+          "name": "provider_cursors_user_id_provider_id_provider_session_id_pk",
+          "columns": ["user_id", "provider_id", "provider_session_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tool_sets": {
+      "name": "tool_sets",
+      "schema": "",
+      "columns": {
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "schemas": {
+          "name": "schemas",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.turns": {
+      "name": "turns",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "origin": {
+          "name": "origin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reasoning_effort": {
+          "name": "reasoning_effort",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompt_hash": {
+          "name": "prompt_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_set_hash": {
+          "name": "tool_set_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_ids": {
+          "name": "response_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage": {
+          "name": "usage",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "queued_at": {
+          "name": "queued_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settled_at": {
+          "name": "settled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure": {
+          "name": "failure",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancel_requested_at": {
+          "name": "cancel_requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "turns_by_user": {
+          "name": "turns_by_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "turns_user_id_user_id_fk": {
+          "name": "turns_user_id_user_id_fk",
+          "tableFrom": "turns",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "turns_conversation_id_conversations_id_fk": {
+          "name": "turns_conversation_id_conversations_id_fk",
+          "tableFrom": "turns",
+          "tableTo": "conversations",
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.hosted_usage": {
+      "name": "hosted_usage",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "day": {
+          "name": "day",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "calls": {
+          "name": "calls",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "voice_seconds": {
+          "name": "voice_seconds",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "hosted_usage_user_id_user_id_fk": {
+          "name": "hosted_usage_user_id_user_id_fk",
+          "tableFrom": "hosted_usage",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "hosted_usage_user_id_day_pk": {
+          "name": "hosted_usage_user_id_day_pk",
+          "columns": ["user_id", "day"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.introduction_usage": {
+      "name": "introduction_usage",
+      "schema": "",
+      "columns": {
+        "caller": {
+          "name": "caller",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "day": {
+          "name": "day",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mints": {
+          "name": "mints",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "introduction_usage_caller_day_pk": {
+          "name": "introduction_usage_caller_day_pk",
+          "columns": ["caller", "day"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.voice_session_usage": {
+      "name": "voice_session_usage",
+      "schema": "",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seconds": {
+          "name": "seconds",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recorded_at": {
+          "name": "recorded_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "voice_session_usage_user_id_user_id_fk": {
+          "name": "voice_session_usage_user_id_user_id_fk",
+          "tableFrom": "voice_session_usage",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provider_key": {
+      "name": "provider_key",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ciphertext": {
+          "name": "ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "provider_key_user_id_user_id_fk": {
+          "name": "provider_key_user_id_user_id_fk",
+          "tableFrom": "provider_key",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "provider_key_user_id_provider_id_pk": {
+          "name": "provider_key_user_id_provider_id_pk",
+          "columns": ["user_id", "provider_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.voice_sessions": {
+      "name": "voice_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "live_session_id": {
+          "name": "live_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delegation_mode": {
+          "name": "delegation_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "close_reason": {
+          "name": "close_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage": {
+          "name": "usage",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "voice_sessions_by_owner": {
+          "name": "voice_sessions_by_owner",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "live_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "voice_sessions_user_id_user_id_fk": {
+          "name": "voice_sessions_user_id_user_id_fk",
+          "tableFrom": "voice_sessions",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "voice_sessions_live_session_id_unique": {
+          "name": "voice_sessions_live_session_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["live_session_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.voice_transcript_segments": {
+      "name": "voice_transcript_segments",
+      "schema": "",
+      "columns": {
+        "voice_session_id": {
+          "name": "voice_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_ms": {
+          "name": "start_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_ms": {
+          "name": "end_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "voice_transcript_segments_voice_session_id_voice_sessions_id_fk": {
+          "name": "voice_transcript_segments_voice_session_id_voice_sessions_id_fk",
+          "tableFrom": "voice_transcript_segments",
+          "tableTo": "voice_sessions",
+          "columnsFrom": ["voice_session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "voice_transcript_segments_voice_session_id_seq_pk": {
+          "name": "voice_transcript_segments_voice_session_id_seq_pk",
+          "columns": ["voice_session_id", "seq"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.personal_fact": {
+      "name": "personal_fact",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ordinal": {
+          "name": "ordinal",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sealed_words": {
+          "name": "sealed_words",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "personal_fact_user_id_user_id_fk": {
+          "name": "personal_fact_user_id_user_id_fk",
+          "tableFrom": "personal_fact",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "personal_fact_user_id_id_pk": {
+          "name": "personal_fact_user_id_id_pk",
+          "columns": ["user_id", "id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspace_file": {
+      "name": "workspace_file",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sealed_content": {
+          "name": "sealed_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workspace_file_user_id_user_id_fk": {
+          "name": "workspace_file_user_id_user_id_fk",
+          "tableFrom": "workspace_file",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "workspace_file_user_id_path_pk": {
+          "name": "workspace_file_user_id_path_pk",
+          "columns": ["user_id", "path"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/web/drizzle/meta/_journal.json
+++ b/apps/web/drizzle/meta/_journal.json
@@ -127,6 +127,13 @@
       "when": 1789079396109,
       "tag": "0017_b3_voice_sessions_segments",
       "breakpoints": true
+    },
+    {
+      "idx": 18,
+      "version": "7",
+      "when": 1789082654593,
+      "tag": "0018_b6_standing_main_purge_and_turn_indexes",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -17,7 +17,7 @@
     "dev": "vite",
     "preview": "vite preview",
     "test": "tsx --test 'tests/**/*.test.ts'",
-    "test:store": "tsx --test tests/hosted-store.test.ts tests/hosted-payload-envelope.test.ts tests/storage-schema.test.ts tests/voice-schema.test.ts tests/hosted-store-writer.test.ts",
+    "test:store": "tsx --test tests/hosted-store.test.ts tests/hosted-payload-envelope.test.ts tests/storage-schema.test.ts tests/voice-schema.test.ts tests/hosted-store-writer.test.ts tests/storage-reads.test.ts",
     "typecheck": "tsc --project tsconfig.json"
   },
   "dependencies": {

--- a/apps/web/server/db/storage-schema.ts
+++ b/apps/web/server/db/storage-schema.ts
@@ -12,6 +12,7 @@ import { sql } from "drizzle-orm";
 import {
   type AnyPgColumn,
   bigint,
+  index,
   jsonb,
   pgTable,
   primaryKey,
@@ -94,6 +95,19 @@ export const conversations = pgTable(
       table.providerId,
       table.providerSessionId,
     ),
+    // One main stands per account at a time: Clear stamps the old one and opens the next in one
+    // transaction, and a first-use creation lands one; this index is what refuses a second standing
+    // main whatever path raced to it, so reads never silently pick one of two. The predicate is
+    // DDL, which takes no bound parameter, so the kind is inlined rather than passed.
+    uniqueIndex("conversations_standing_main")
+      .on(table.userId)
+      .where(
+        sql`${table.kind} = ${sql.raw(`'${CONVERSATION_KIND.MAIN}'`)} and ${table.deletedAt} is null`,
+      ),
+    // The purge runs every minute over the stamped rows alone.
+    index("conversations_deleted_at")
+      .on(table.deletedAt)
+      .where(sql`${table.deletedAt} is not null`),
   ],
 );
 
@@ -141,30 +155,34 @@ export const messages = pgTable(
  * the v1 run row and the desktop's trace keep, spelled the same way, and
  * `response_ids` every response OpenAI answered the turn with, in order.
  */
-export const turns = pgTable("turns", {
-  id: uuid("id").primaryKey().defaultRandom(),
-  userId: text("user_id")
-    .notNull()
-    .references(() => user.id, { onDelete: "cascade" }),
-  conversationId: uuid("conversation_id")
-    .notNull()
-    .references(() => conversations.id, { onDelete: "cascade" }),
-  origin: text("origin").$type<TurnOrigin>().notNull(),
-  status: text("status").$type<TurnStatus>().notNull(),
-  model: text("model"),
-  reasoningEffort: text("reasoning_effort"),
-  /** The content address of the prompt the turn ran under. */
-  promptHash: text("prompt_hash"),
-  /** The content address of the tool set the turn was offered. */
-  toolSetHash: text("tool_set_hash"),
-  responseIds: text("response_ids").array(),
-  usage: jsonb("usage").$type<BrainRunUsage>(),
-  queuedAt: instant("queued_at").notNull().defaultNow(),
-  startedAt: instant("started_at"),
-  settledAt: instant("settled_at"),
-  failure: text("failure"),
-  cancelRequestedAt: instant("cancel_requested_at"),
-});
+export const turns = pgTable(
+  "turns",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    userId: text("user_id")
+      .notNull()
+      .references(() => user.id, { onDelete: "cascade" }),
+    conversationId: uuid("conversation_id")
+      .notNull()
+      .references(() => conversations.id, { onDelete: "cascade" }),
+    origin: text("origin").$type<TurnOrigin>().notNull(),
+    status: text("status").$type<TurnStatus>().notNull(),
+    model: text("model"),
+    reasoningEffort: text("reasoning_effort"),
+    /** The content address of the prompt the turn ran under. */
+    promptHash: text("prompt_hash"),
+    /** The content address of the tool set the turn was offered. */
+    toolSetHash: text("tool_set_hash"),
+    responseIds: text("response_ids").array(),
+    usage: jsonb("usage").$type<BrainRunUsage>(),
+    queuedAt: instant("queued_at").notNull().defaultNow(),
+    startedAt: instant("started_at"),
+    settledAt: instant("settled_at"),
+    failure: text("failure"),
+    cancelRequestedAt: instant("cancel_requested_at"),
+  },
+  (table) => [index("turns_by_user").on(table.userId)],
+);
 
 /**
  * The one lease per account under which turns are drained and sequences

--- a/apps/web/server/hosted/observation-tick.ts
+++ b/apps/web/server/hosted/observation-tick.ts
@@ -69,6 +69,13 @@ export interface ObservationTickOptions {
   listAccounts: (limit: number, seenAfter: number) => Promise<ObservedAccount[]>;
   /** Drops the snapshot, diffs, and pass record of every account without a cloud key or not seen since `seenAfter`. */
   forgetIneligible: (seenAfter: number) => Promise<void>;
+  /**
+   * Removes every conversation a Clear stamped past its retention window,
+   * answering how many went. Retention rides on the observation tick because
+   * it is the one schedule the service runs; the purge is not an observation
+   * and reads nothing of any account.
+   */
+  purgeCleared: (now: number) => Promise<number>;
   /** One read-only pass over the account's cloud providers, written down as the pass module does. */
   observe: (userId: string) => Promise<AccountPassOutcome>;
   now?: () => number;
@@ -87,6 +94,8 @@ interface ObservationTickAnswer {
   changed: number;
   /** Whether the tick stopped on its budget with accounts still listed. */
   exhausted: boolean;
+  /** Cleared conversations the tick purged past their retention window. */
+  purged: number;
 }
 
 const FAILED_PASS: AccountPassOutcome = { complete: false, changed: false };
@@ -136,6 +145,7 @@ export async function handleObservationTick(options: ObservationTickOptions): Pr
   const seenAfter = startedAt - OBSERVATION_TICK.ACCOUNT_SEEN_WITHIN_MS;
 
   await options.forgetIneligible(seenAfter);
+  const purged = await options.purgeCleared(startedAt);
   const accounts = await options.listAccounts(OBSERVATION_TICK.MAX_ACCOUNTS, seenAfter);
 
   const answer: ObservationTickAnswer = {
@@ -144,6 +154,7 @@ export async function handleObservationTick(options: ObservationTickOptions): Pr
     failed: 0,
     changed: 0,
     exhausted: false,
+    purged,
   };
   for (let index = 0; index < accounts.length; index += OBSERVATION_TICK.CONCURRENCY) {
     if (now() - startedAt + passDeadlineMs > budgetMs) {

--- a/apps/web/server/hosted/store/index.ts
+++ b/apps/web/server/hosted/store/index.ts
@@ -1,3 +1,4 @@
+import type { ToolSet } from "ai";
 import {
   type BrainPersistedState,
   type BrainStateLoad,
@@ -36,6 +37,16 @@ import {
 import { type HostedStoreContext, userSeal } from "./database.js";
 import { type FactWrite, listFacts, replaceFacts, type StoredFact } from "./facts.js";
 import {
+  listEvents,
+  listMessages,
+  listTurns,
+  type MessageListRead,
+  type SequenceCursor,
+  type StoredEventRecord,
+  type StoredTurnRecord,
+  type TurnCursor,
+} from "./message-reads.js";
+import {
   advanceRosterSnapshot,
   consumeRosterDiff,
   forgetObservationIneligible,
@@ -52,6 +63,11 @@ import {
   writeRosterSnapshot,
 } from "./roster-snapshot.js";
 import { type RunAboutFields, recordRunAbout, runAbout } from "./run-about.js";
+import {
+  type ClearOutcome,
+  clearMainConversation,
+  purgeClearedConversations,
+} from "./soft-delete.js";
 import {
   listCompactionBoundaries,
   listTranscript,
@@ -93,6 +109,40 @@ export interface HostedStore {
     create(userId: string, creation: ConversationCreation): Promise<ConversationRecord>;
     /** The hard delete: the conversation and every row under it, with no archive behind them. */
     delete(userId: string, sessionKey: SessionKey): Promise<boolean>;
+  };
+  /**
+   * The v2 rows: cursor reads a device polls, over the `messages`, `events`,
+   * and `turns` tables, and the Clear that stamps the main conversation
+   * rather than erasing it. Every read skips a conversation the Clear
+   * stamped, so a cleared main is gone from the call after it.
+   */
+  messages: {
+    /** Messages after `after` in sequence order, read back under the registry; a page with an unreadable row is refused whole. */
+    list(
+      userId: string,
+      conversationId: string,
+      tools: ToolSet,
+      cursor?: SequenceCursor,
+    ): Promise<MessageListRead>;
+  };
+  events: {
+    list(
+      userId: string,
+      conversationId: string,
+      cursor?: SequenceCursor,
+    ): Promise<readonly StoredEventRecord[]>;
+  };
+  turns: {
+    /** The account's turns in the order they last changed, so a settlement is answered again. */
+    list(userId: string, cursor?: TurnCursor): Promise<readonly StoredTurnRecord[]>;
+  };
+  main: {
+    /** Clear: stamps the standing main and its descendants and opens a new main, in one transaction. */
+    clear(userId: string, now: Date): Promise<ClearOutcome>;
+  };
+  retention: {
+    /** The cron's purge of every conversation, of any account, stamped past the retention window. */
+    purgeCleared(now: Date): Promise<number>;
   };
   lines: {
     append(
@@ -201,6 +251,22 @@ export function hostedStore({ db, keys }: HostedStoreContext): HostedStore {
       create: (userId, creation) => createConversation(db, userId, creation),
       delete: (userId, sessionKey) => deleteConversation(db, userId, sessionKey),
     },
+    messages: {
+      list: (userId, conversationId, tools, cursor) =>
+        listMessages(db, userId, conversationId, tools, cursor),
+    },
+    events: {
+      list: (userId, conversationId, cursor) => listEvents(db, userId, conversationId, cursor),
+    },
+    turns: {
+      list: (userId, cursor) => listTurns(db, userId, cursor),
+    },
+    main: {
+      clear: (userId, now) => clearMainConversation(db, userId, now),
+    },
+    retention: {
+      purgeCleared: (now) => purgeClearedConversations(db, now),
+    },
     lines: {
       append: (userId, sessionKey, entries, now) =>
         appendConversationLines(db, sealFor(userId), userId, sessionKey, entries, now),
@@ -254,15 +320,16 @@ export function hostedStore({ db, keys }: HostedStoreContext): HostedStore {
 }
 
 export { BRIEFING_STATE } from "./briefings.js";
-
 export type { HostedStoreContext, HostedStoreDatabase } from "./database.js";
-
+export type { StoredMessageRecord } from "./message-reads.js";
 export {
   MAXIMUM_PENDING_ROSTER_DIFFS,
   type ObservationPassRecord,
   type RosterDiffRecord,
   type RosterSnapshotRecord,
 } from "./roster-snapshot.js";
+
+export { CLEARED_CONVERSATION_RETENTION_MS } from "./soft-delete.js";
 
 export {
   type ConversationTarget,

--- a/apps/web/server/hosted/store/message-reads.ts
+++ b/apps/web/server/hosted/store/message-reads.ts
@@ -1,0 +1,266 @@
+import type { ToolSet } from "ai";
+import { and, asc, eq, gt, isNull, or, sql } from "drizzle-orm";
+import type { AnyPgColumn } from "drizzle-orm/pg-core";
+import {
+  readStoredUIMessages,
+  type SchemaPath,
+  type SchemaRead,
+  type SchemaRefusal,
+  type StoredUIMessage,
+  unparsedWire,
+  type WireBoundaryInput,
+} from "../../core.js";
+import { conversations, events, messages, turns } from "../../db/schema.js";
+import { type HostedStoreDatabase, optionalField } from "./database.js";
+
+/**
+ * The per-resource reads a device polls with a cursor of its own: a
+ * conversation's messages after a sequence, its events after a sequence, and
+ * the account's turns after the instant one last changed. There is no feed;
+ * every device keeps its own cursors, and the unique `(conversation_id, seq)`
+ * pairs are what make every device converge on the same rows in the same
+ * order. A conversation Clear soft-deleted is read by nothing here: each
+ * read joins the conversation row and skips one stamped `deleted_at`, so a
+ * cleared conversation is gone from every read from the call after the Clear.
+ *
+ * Messages are read back through `readStoredUIMessages`, never the SDK's
+ * validator alone, because the SDK turns a terminal tool part naming a tool
+ * the registry does not hold into a dynamic-tool part rather than refusing
+ * it; a page holding a row this build cannot read is refused whole, naming
+ * the row's sequence, rather than answered with the row silently reshaped.
+ */
+
+/** The most rows one read answers; a device with more to take asks again from the last sequence it took. */
+const MAXIMUM_READ_PAGE = 200;
+
+export interface SequenceCursor {
+  /** Rows after this sequence; absent or zero for the conversation's beginning. */
+  readonly after?: number;
+  readonly limit?: number;
+}
+
+export interface StoredMessageRecord {
+  readonly id: string;
+  readonly conversationId: string;
+  readonly seq: number;
+  readonly turnId?: string;
+  readonly clientId: string;
+  readonly createdAt: Date;
+  /** Absent while the message is still in flight and mutable. */
+  readonly finishedAt?: Date;
+  readonly message: StoredUIMessage;
+}
+
+/**
+ * A refused page names the sequence of the first row this build could not
+ * read and the path inside that row. The registry pre-check names the row
+ * itself; the SDK's structural refusal names none, so the rows are then read
+ * one at a time, in order, to find it, a cost paid only on the failure path.
+ */
+export type MessageListRead =
+  | { readonly ok: true; readonly value: readonly StoredMessageRecord[] }
+  | {
+      readonly ok: false;
+      readonly refusal: SchemaRefusal;
+      readonly seq: number;
+      readonly path: SchemaPath;
+    };
+
+type MessageRow = {
+  readonly id: string;
+  readonly seq: number;
+  readonly turnId: string | null;
+  readonly clientId: string;
+  readonly createdAt: Date;
+  readonly finishedAt: Date | null;
+  /** The row's message as it was written, held to the vocabulary by the read and by nothing before it. */
+  readonly stored: WireBoundaryInput;
+};
+
+type RefusedPage = Exclude<MessageListRead, { ok: true }>;
+
+async function refusedRow(
+  rows: readonly MessageRow[],
+  read: Exclude<SchemaRead<unknown>, { ok: true }>,
+  tools: ToolSet,
+): Promise<RefusedPage> {
+  const [index, ...path] = read.path;
+  const named = rows.find((_, position) => position === index);
+  if (named !== undefined) return { ok: false, refusal: read.refusal, seq: named.seq, path };
+  for (const row of rows) {
+    const single = await readStoredUIMessages(unparsedWire([row.stored]), tools);
+    if (!single.ok) {
+      const [, ...inner] = single.path;
+      return { ok: false, refusal: single.refusal, seq: row.seq, path: inner };
+    }
+  }
+  throw new Error("a page was refused whole and every row of it read alone");
+}
+
+function pageLimit(cursor: { readonly limit?: number }): number {
+  return Math.min(Math.max(cursor.limit ?? MAXIMUM_READ_PAGE, 1), MAXIMUM_READ_PAGE);
+}
+
+/** The one statement of "a stamped conversation is read by nothing": the join every read makes to its conversation row. */
+function standingConversation(table: { conversationId: AnyPgColumn }) {
+  return and(eq(conversations.id, table.conversationId), isNull(conversations.deletedAt));
+}
+
+export async function listMessages(
+  db: HostedStoreDatabase,
+  userId: string,
+  conversationId: string,
+  tools: ToolSet,
+  cursor: SequenceCursor = {},
+): Promise<MessageListRead> {
+  const selected = await db
+    .select({
+      id: messages.id,
+      seq: messages.seq,
+      turnId: messages.turnId,
+      clientId: messages.clientId,
+      role: messages.role,
+      // The jsonb columns are selected as the unparsed boundary values they hold, since the read below is what holds them to the vocabulary; the driver hands jsonb back parsed either way.
+      parts: sql<WireBoundaryInput>`${messages.parts}`,
+      metadata: sql<WireBoundaryInput>`${messages.metadata}`,
+      createdAt: messages.createdAt,
+      finishedAt: messages.finishedAt,
+    })
+    .from(messages)
+    .innerJoin(conversations, standingConversation(messages))
+    .where(
+      and(
+        eq(messages.conversationId, conversationId),
+        eq(messages.userId, userId),
+        gt(messages.seq, cursor.after ?? 0),
+      ),
+    )
+    .orderBy(asc(messages.seq))
+    .limit(pageLimit(cursor));
+  const rows: MessageRow[] = selected.map(({ role, parts, metadata, ...row }) => ({
+    ...row,
+    stored: { id: row.id, role, parts, ...optionalField("metadata", metadata) },
+  }));
+  const read = await readStoredUIMessages(unparsedWire(rows.map((row) => row.stored)), tools);
+  if (!read.ok) return refusedRow(rows, read, tools);
+  return {
+    ok: true,
+    value: read.value.map((message, index) => {
+      const row = rows[index];
+      if (row === undefined) throw new Error("a read answered more messages than rows");
+      return {
+        id: row.id,
+        conversationId,
+        seq: row.seq,
+        ...optionalField("turnId", row.turnId),
+        clientId: row.clientId,
+        createdAt: row.createdAt,
+        ...optionalField("finishedAt", row.finishedAt),
+        message,
+      };
+    }),
+  };
+}
+
+export interface StoredEventRecord {
+  readonly id: string;
+  readonly conversationId: string;
+  readonly seq: number;
+  readonly messageId: string;
+  readonly kind: (typeof events.$inferSelect)["kind"];
+  readonly deviceId?: string;
+  readonly payload?: unknown;
+  readonly createdAt: Date;
+}
+
+export async function listEvents(
+  db: HostedStoreDatabase,
+  userId: string,
+  conversationId: string,
+  cursor: SequenceCursor = {},
+): Promise<readonly StoredEventRecord[]> {
+  const rows = await db
+    .select({
+      id: events.id,
+      seq: events.seq,
+      messageId: events.messageId,
+      kind: events.kind,
+      deviceId: events.deviceId,
+      payload: events.payload,
+      createdAt: events.createdAt,
+    })
+    .from(events)
+    .innerJoin(conversations, standingConversation(events))
+    .where(
+      and(
+        eq(events.conversationId, conversationId),
+        eq(events.userId, userId),
+        gt(events.seq, cursor.after ?? 0),
+      ),
+    )
+    .orderBy(asc(events.seq))
+    .limit(pageLimit(cursor));
+  return rows.map((row) => ({
+    id: row.id,
+    conversationId,
+    seq: row.seq,
+    messageId: row.messageId,
+    kind: row.kind,
+    ...optionalField("deviceId", row.deviceId),
+    ...optionalField("payload", row.payload),
+    createdAt: row.createdAt,
+  }));
+}
+
+/**
+ * Where a turn stands in the order of change: the latest instant any of its
+ * stamps was set, as Postgres renders it to the microsecond, and its id to
+ * break a tie. It is the instant's own text rather than a `Date` because a
+ * JavaScript instant keeps milliseconds and a stamp set in the same
+ * millisecond as the one a device already took would otherwise never read as
+ * later; the text round-trips through `::timestamptz` exactly.
+ */
+interface TurnCursorPosition {
+  readonly changedAt: string;
+  readonly id: string;
+}
+
+export interface TurnCursor {
+  /** Turns past this position, the last row a device took; absent for every turn the account holds. */
+  readonly after?: TurnCursorPosition;
+  readonly limit?: number;
+}
+
+export type StoredTurnRecord = typeof turns.$inferSelect & {
+  /** The row's place in the order of change, handed back as the next read's `after`. */
+  readonly cursor: TurnCursorPosition;
+};
+
+/** A turn row is mutable, so its order is the latest instant any of its stamps was set. */
+const turnChangedAt = sql`greatest(${turns.queuedAt}, coalesce(${turns.startedAt}, ${turns.queuedAt}), coalesce(${turns.settledAt}, ${turns.queuedAt}), coalesce(${turns.cancelRequestedAt}, ${turns.queuedAt}))`;
+
+/** The rows past the position: changed later, or changed at the same instant with a greater id. */
+function changedAfter(after: TurnCursorPosition) {
+  const instant = sql`${after.changedAt}::timestamptz`;
+  return or(gt(turnChangedAt, instant), and(eq(turnChangedAt, instant), gt(turns.id, after.id)));
+}
+
+/** The account's turns in the order they last changed, so a turn that settled since a device's last read is answered again with its new status; a page edge drops nothing, since the id breaks a tie. */
+export async function listTurns(
+  db: HostedStoreDatabase,
+  userId: string,
+  cursor: TurnCursor = {},
+): Promise<readonly StoredTurnRecord[]> {
+  const { after } = cursor;
+  const rows = await db
+    .select({ turn: turns, changedAt: sql<string>`(${turnChangedAt})::text` })
+    .from(turns)
+    .innerJoin(conversations, standingConversation(turns))
+    .where(and(eq(turns.userId, userId), after === undefined ? undefined : changedAfter(after)))
+    .orderBy(asc(turnChangedAt), asc(turns.id))
+    .limit(pageLimit(cursor));
+  return rows.map((row) => ({
+    ...row.turn,
+    cursor: { changedAt: row.changedAt, id: row.turn.id },
+  }));
+}

--- a/apps/web/server/hosted/store/soft-delete.ts
+++ b/apps/web/server/hosted/store/soft-delete.ts
@@ -1,0 +1,104 @@
+import { and, eq, inArray, isNull, lte } from "drizzle-orm";
+import { CONVERSATION_KIND, conversations, user } from "../../db/schema.js";
+import type { HostedStoreDatabase } from "./database.js";
+
+/**
+ * Clear as a soft delete, and the purge that follows it. Nothing is erased
+ * at the Clear: the main conversation standing for the account is stamped
+ * `deleted_at`, every descendant of it with it, and a new main row is
+ * opened in the same transaction, so the reads — which skip a stamped row —
+ * show an empty main from the call after the Clear while the rows stand
+ * until the purge. The Clear takes the account's user row lock first, so two
+ * Clears run one after the other and a child spawned mid-Clear is stamped
+ * with its parent; the partial unique index over the standing main is what
+ * refuses a second one however the lock is held. There is no archive, no registry, and no cutoff: the
+ * stamp is the whole record of the Clear, and the cron's purge removes the
+ * stamped conversations thirty days on, their messages, turns, events, and
+ * children going with them by the schema's own cascade. A Clear reaches
+ * neither the notebook nor any provider's file; deleting the account
+ * cascades everything at once, stamped or not.
+ */
+
+/** How long a cleared conversation's rows stand before the purge takes them. */
+export const CLEARED_CONVERSATION_RETENTION_MS = 30 * 24 * 60 * 60 * 1000;
+
+export interface ClearOutcome {
+  /** The main conversation the Clear stamped, and every descendant stamped with it; empty when none stood. */
+  readonly cleared: readonly string[];
+  /** The main conversation opened in its place. */
+  readonly opened: string;
+}
+
+/** Stamps every not-yet-stamped child of the given rows, level by level, and answers every id stamped. */
+async function stampDescendants(
+  db: HostedStoreDatabase,
+  parents: readonly string[],
+  deletedAt: Date,
+): Promise<string[]> {
+  const stamped: string[] = [];
+  let frontier = parents;
+  while (frontier.length > 0) {
+    const children = await db
+      .update(conversations)
+      .set({ deletedAt })
+      .where(
+        and(inArray(conversations.parentConversationId, frontier), isNull(conversations.deletedAt)),
+      )
+      .returning({ id: conversations.id });
+    frontier = children.map((child) => child.id);
+    stamped.push(...frontier);
+  }
+  return stamped;
+}
+
+export function clearMainConversation(
+  db: HostedStoreDatabase,
+  userId: string,
+  now: Date,
+): Promise<ClearOutcome> {
+  return db.transaction(async (tx) => {
+    await tx.select({ id: user.id }).from(user).where(eq(user.id, userId)).for("update");
+    const stamped = await tx
+      .update(conversations)
+      .set({ deletedAt: now })
+      .where(
+        and(
+          eq(conversations.userId, userId),
+          eq(conversations.kind, CONVERSATION_KIND.MAIN),
+          isNull(conversations.deletedAt),
+        ),
+      )
+      .returning({ id: conversations.id });
+    const mainIds = stamped.map((row) => row.id);
+    const descendants = await stampDescendants(tx, mainIds, now);
+    const [opened] = await tx
+      .insert(conversations)
+      .values({
+        userId,
+        kind: CONVERSATION_KIND.MAIN,
+        createdAt: now,
+        lastActivityAt: now,
+      })
+      .returning({ id: conversations.id });
+    if (opened === undefined) throw new Error("the Clear opened no main conversation");
+    return { cleared: [...mainIds, ...descendants], opened: opened.id };
+  });
+}
+
+/**
+ * Removes every conversation stamped at or before the retention window's
+ * edge, across every account; the schema cascades the rows beneath each.
+ * Answers how many conversations went, descendants counted where they were
+ * stamped themselves and not where the cascade alone took them.
+ */
+export async function purgeClearedConversations(
+  db: HostedStoreDatabase,
+  now: Date,
+): Promise<number> {
+  const edge = new Date(now.getTime() - CLEARED_CONVERSATION_RETENTION_MS);
+  const removed = await db
+    .delete(conversations)
+    .where(lte(conversations.deletedAt, edge))
+    .returning({ id: conversations.id });
+  return removed.length;
+}

--- a/apps/web/tests/hosted-observation-tick.test.ts
+++ b/apps/web/tests/hosted-observation-tick.test.ts
@@ -26,6 +26,7 @@ function tickRequest(authorization: string | null = `Bearer ${CRON_SECRET}`): Re
 /** What one tick was asked to do, recorded for the test to read back. */
 interface Recorded {
   forgot: number[];
+  purged: number[];
   listed: Array<{ limit: number; seenAfter: number }>;
   observed: string[];
 }
@@ -38,7 +39,7 @@ function tickOptions(
     changed: false,
   }),
 ) {
-  const recorded: Recorded = { forgot: [], listed: [], observed: [] };
+  const recorded: Recorded = { forgot: [], purged: [], listed: [], observed: [] };
   const options: ObservationTickOptions = {
     request: tickRequest(),
     cronSecret: CRON_SECRET,
@@ -49,6 +50,10 @@ function tickOptions(
     },
     forgetIneligible: async (seenAfter) => {
       recorded.forgot.push(seenAfter);
+    },
+    purgeCleared: async (now) => {
+      recorded.purged.push(now);
+      return 2;
     },
     observe: async (userId) => {
       recorded.observed.push(userId);
@@ -111,9 +116,11 @@ test("a tick forgets the ineligible, lists accounts seen within the week, and ob
     failed: 1,
     changed: 1,
     exhausted: false,
+    purged: 2,
   });
   const seenAfter = TICK_TIME - OBSERVATION_TICK.ACCOUNT_SEEN_WITHIN_MS;
   assert.deepEqual(recorded.forgot, [seenAfter]);
+  assert.deepEqual(recorded.purged, [TICK_TIME]);
   assert.deepEqual(recorded.listed, [{ limit: OBSERVATION_TICK.MAX_ACCOUNTS, seenAfter }]);
   assert.deepEqual(recorded.observed, ["user-a", "user-b", "user-c"]);
 });
@@ -132,6 +139,7 @@ test("a pass that throws is counted as failed and does not end the tick", async 
     failed: 1,
     changed: 0,
     exhausted: false,
+    purged: 2,
   });
 });
 
@@ -151,6 +159,7 @@ test("a tick starts a batch only while a whole pass deadline still fits its budg
 
   const body = await response.json();
   assert.equal(body.exhausted, true);
+  assert.equal(body.purged, 2);
   assert.equal(body.accounts, OBSERVATION_TICK.CONCURRENCY);
   assert.equal(recorded.observed.length, OBSERVATION_TICK.CONCURRENCY);
 });
@@ -170,6 +179,7 @@ test("a pass that outruns its deadline is counted failed and the tick moves on",
     failed: 1,
     changed: 1,
     exhausted: false,
+    purged: 2,
   });
 });
 

--- a/apps/web/tests/storage-reads.test.ts
+++ b/apps/web/tests/storage-reads.test.ts
@@ -1,0 +1,515 @@
+import assert from "node:assert/strict";
+import test, { after } from "node:test";
+import {
+  CONVERSATION_EVENT_KIND,
+  MESSAGE_AUTHOR,
+  MESSAGE_CHANNEL,
+  MESSAGE_ROLE,
+  SCHEMA_REFUSAL,
+  TURN_ORIGIN,
+  TURN_STATUS,
+} from "@sidecar/wire";
+import { type ToolSet, tool } from "ai";
+import { and, eq, isNull, sql } from "drizzle-orm";
+import { z } from "zod";
+import {
+  CONVERSATION_KIND,
+  conversations,
+  events,
+  messages,
+  turns,
+  user,
+} from "../server/db/schema";
+import {
+  CLEARED_CONVERSATION_RETENTION_MS,
+  type StoredMessageRecord,
+} from "../server/hosted/store";
+import { openHostedStoreTestDatabase } from "./support/hosted-store-database";
+
+/**
+ * The v2 reads and the Clear, against the real migrations: a device's cursor
+ * reads answer the rows in sequence and skip a conversation the Clear
+ * stamped from the very next call, the purge takes the stamped rows once the
+ * window has passed and nothing sooner, and a row this build cannot read
+ * back — a tool part naming a tool the registry does not hold, or parts
+ * that are not a message's — refuses the page rather than riding out in it.
+ */
+
+const database = await openHostedStoreTestDatabase();
+after(() => database.close());
+
+const NOW = new Date("2026-09-10T12:00:00.000Z");
+const UNIQUE_VIOLATION = "23505";
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+const TOOLS: ToolSet = {
+  read_transcript: tool({
+    description: "Reads the tail of an observed session's transcript.",
+    inputSchema: z.object({ provider_id: z.string(), provider_session_id: z.string() }),
+    outputSchema: z.object({ lines: z.array(z.string()) }),
+  }),
+};
+
+const TYPED_ASK = { author: MESSAGE_AUTHOR.DEVELOPER, channel: MESSAGE_CHANNEL.TYPED } as const;
+
+async function insertConversation(
+  userId: string,
+  row: Partial<typeof conversations.$inferInsert> = {},
+): Promise<string> {
+  const [inserted] = await database.db
+    .insert(conversations)
+    .values({ userId, kind: CONVERSATION_KIND.MAIN, ...row })
+    .returning({ id: conversations.id });
+  assert.ok(inserted);
+  return inserted.id;
+}
+
+async function insertTurn(
+  userId: string,
+  conversationId: string,
+  row: Partial<typeof turns.$inferInsert> = {},
+): Promise<string> {
+  const [inserted] = await database.db
+    .insert(turns)
+    .values({
+      userId,
+      conversationId,
+      origin: TURN_ORIGIN.TYPED,
+      status: TURN_STATUS.SETTLED,
+      queuedAt: NOW,
+      ...row,
+    })
+    .returning({ id: turns.id });
+  assert.ok(inserted);
+  return inserted.id;
+}
+
+async function insertMessage(
+  userId: string,
+  conversationId: string,
+  seq: number,
+  row: Partial<typeof messages.$inferInsert> = {},
+): Promise<string> {
+  const [inserted] = await database.db
+    .insert(messages)
+    .values({
+      userId,
+      conversationId,
+      seq,
+      clientId: `client-${seq}`,
+      role: MESSAGE_ROLE.USER,
+      parts: [{ type: "text", text: `ask ${seq}` }],
+      metadata: TYPED_ASK,
+      ...row,
+    })
+    .returning({ id: messages.id });
+  assert.ok(inserted);
+  return inserted.id;
+}
+
+async function insertEvent(
+  userId: string,
+  conversationId: string,
+  messageId: string,
+  seq: number,
+  row: Partial<typeof events.$inferInsert> = {},
+): Promise<string> {
+  const [inserted] = await database.db
+    .insert(events)
+    .values({
+      userId,
+      conversationId,
+      messageId,
+      seq,
+      kind: CONVERSATION_EVENT_KIND.SPEECH_OFFERED,
+      ...row,
+    })
+    .returning({ id: events.id });
+  assert.ok(inserted);
+  return inserted.id;
+}
+
+async function countConversations(id: string): Promise<number> {
+  const rows = await database.db.select().from(conversations).where(eq(conversations.id, id));
+  return rows.length;
+}
+
+function readRecords(
+  read: Awaited<ReturnType<typeof database.store.messages.list>>,
+): readonly StoredMessageRecord[] {
+  assert.equal(read.ok, true);
+  return read.ok ? read.value : [];
+}
+
+/** A main conversation with three messages, an event on each, and the turn that wrote them. */
+async function populateMain(
+  userId: string,
+): Promise<{ main: string; turn: string; ids: string[] }> {
+  const main = await insertConversation(userId);
+  const turn = await insertTurn(userId, main);
+  const ids: string[] = [];
+  for (const seq of [1, 2, 3]) {
+    const id = await insertMessage(userId, main, seq, { turnId: turn });
+    await insertEvent(userId, main, id, seq);
+    ids.push(id);
+  }
+  return { main, turn, ids };
+}
+
+test("messages read back in sequence after the cursor, typed by role, with the row's columns beside them", async () => {
+  const userId = await database.createUser();
+  const { main, turn, ids } = await populateMain(userId);
+  await insertMessage(userId, main, 4, {
+    role: MESSAGE_ROLE.SYSTEM,
+    metadata: null,
+    parts: [{ type: "text", text: "standing instructions" }],
+    finishedAt: NOW,
+  });
+
+  const all = readRecords(await database.store.messages.list(userId, main, TOOLS));
+  assert.deepEqual(
+    all.map((record) => record.seq),
+    [1, 2, 3, 4],
+  );
+  assert.deepEqual(
+    all.slice(0, 3).map((record) => record.id),
+    ids,
+  );
+  assert.deepEqual(
+    all.map((record) => record.message.role),
+    [MESSAGE_ROLE.USER, MESSAGE_ROLE.USER, MESSAGE_ROLE.USER, MESSAGE_ROLE.SYSTEM],
+  );
+  assert.equal(all[0]?.turnId, turn);
+  assert.equal(all[0]?.finishedAt, undefined);
+  assert.deepEqual(all[3]?.finishedAt, NOW);
+  assert.equal(
+    all[0]?.message.role === MESSAGE_ROLE.USER && all[0].message.metadata.author,
+    MESSAGE_AUTHOR.DEVELOPER,
+  );
+
+  const afterTwo = readRecords(
+    await database.store.messages.list(userId, main, TOOLS, { after: 2 }),
+  );
+  assert.deepEqual(
+    afterTwo.map((record) => record.seq),
+    [3, 4],
+  );
+  const page = readRecords(await database.store.messages.list(userId, main, TOOLS, { limit: 2 }));
+  assert.deepEqual(
+    page.map((record) => record.seq),
+    [1, 2],
+  );
+  const clamped = readRecords(
+    await database.store.messages.list(userId, main, TOOLS, { limit: 0 }),
+  );
+  assert.deepEqual(
+    clamped.map((record) => record.seq),
+    [1],
+  );
+});
+
+test("events read back in sequence after the cursor, and turns in the order they last changed", async () => {
+  const userId = await database.createUser();
+  const { main, turn, ids } = await populateMain(userId);
+
+  const all = await database.store.events.list(userId, main);
+  assert.deepEqual(
+    all.map((event) => [event.seq, event.messageId]),
+    [
+      [1, ids[0]],
+      [2, ids[1]],
+      [3, ids[2]],
+    ],
+  );
+  assert.deepEqual(
+    (await database.store.events.list(userId, main, { after: 1 })).map((event) => event.seq),
+    [2, 3],
+  );
+
+  const laterTurn = await insertTurn(userId, main, {
+    status: TURN_STATUS.QUEUED,
+    queuedAt: new Date(NOW.getTime() + 1000),
+  });
+  const first = await database.store.turns.list(userId);
+  assert.deepEqual(
+    first.map((row) => row.id),
+    [turn, laterTurn],
+  );
+  const [earlier, later] = first;
+  assert.ok(earlier && later);
+  assert.deepEqual(
+    (await database.store.turns.list(userId, { after: earlier.cursor })).map((row) => row.id),
+    [laterTurn],
+  );
+
+  const settledAt = new Date(NOW.getTime() + 5000);
+  await database.db
+    .update(turns)
+    .set({ status: TURN_STATUS.SETTLED, settledAt })
+    .where(eq(turns.id, turn));
+  const changed = await database.store.turns.list(userId, { after: later.cursor });
+  assert.deepEqual(
+    changed.map((row) => [row.id, row.status, row.settledAt]),
+    [[turn, TURN_STATUS.SETTLED, settledAt]],
+  );
+  assert.equal(changed[0]?.cursor.id, turn);
+  assert.notEqual(changed[0]?.cursor.changedAt, earlier.cursor.changedAt);
+});
+
+test("the turn cursor is exact to the microsecond: a stamp in the same millisecond is answered again, and a tie at a page's edge is answered on the next page", async () => {
+  const userId = await database.createUser();
+  const main = await insertConversation(userId);
+  const [precise] = await database.db
+    .insert(turns)
+    .values({
+      userId,
+      conversationId: main,
+      origin: TURN_ORIGIN.ROSTER_DIFF,
+      status: TURN_STATUS.QUEUED,
+      queuedAt: sql`'2026-09-10 12:00:00.000500+00'::timestamptz`,
+    })
+    .returning({ id: turns.id });
+  assert.ok(precise);
+  const [answered] = await database.store.turns.list(userId);
+  assert.equal(answered?.id, precise.id);
+  assert.equal(answered?.cursor.changedAt, "2026-09-10 12:00:00.0005+00");
+  assert.deepEqual(await database.store.turns.list(userId, { after: answered.cursor }), []);
+
+  await database.db
+    .update(turns)
+    .set({
+      status: TURN_STATUS.RUNNING,
+      startedAt: sql`'2026-09-10 12:00:00.000900+00'::timestamptz`,
+    })
+    .where(eq(turns.id, precise.id));
+  const started = await database.store.turns.list(userId, { after: answered.cursor });
+  assert.deepEqual(
+    started.map((row) => [row.id, row.status]),
+    [[precise.id, TURN_STATUS.RUNNING]],
+  );
+
+  const tied = new Date(NOW.getTime() + 60_000);
+  const ids = await Promise.all([1, 2, 3].map(() => insertTurn(userId, main, { queuedAt: tied })));
+  const pageOne = await database.store.turns.list(userId, { after: started[0]?.cursor, limit: 2 });
+  const pageTwo = await database.store.turns.list(userId, {
+    after: pageOne.at(-1)?.cursor,
+    limit: 2,
+  });
+  assert.deepEqual(
+    [...pageOne, ...pageTwo].map((row) => row.id),
+    [...ids].sort(),
+  );
+});
+
+test("one account's rows are never read under another's id", async () => {
+  const userId = await database.createUser();
+  const other = await database.createUser();
+  const { main } = await populateMain(userId);
+  await populateMain(other);
+
+  assert.deepEqual(readRecords(await database.store.messages.list(other, main, TOOLS)), []);
+  assert.deepEqual(await database.store.events.list(other, main), []);
+  assert.equal((await database.store.turns.list(other)).length, 1);
+});
+
+test("a cleared conversation disappears from every read on the next call, and a new main stands in its place", async () => {
+  const userId = await database.createUser();
+  const { main, turn } = await populateMain(userId);
+  const child = await insertConversation(userId, {
+    kind: CONVERSATION_KIND.CHILD,
+    parentConversationId: main,
+  });
+  const grandchild = await insertConversation(userId, {
+    kind: CONVERSATION_KIND.CHILD,
+    parentConversationId: child,
+  });
+  await insertMessage(userId, child, 1, { turnId: await insertTurn(userId, child) });
+  const observed = await insertConversation(userId, {
+    kind: CONVERSATION_KIND.OBSERVED,
+    providerId: "conductor",
+    providerSessionId: "6c1f2f14-9a0b-4c2d-8e3f-0a1b2c3d4e50",
+  });
+  await insertMessage(userId, observed, 1, { turnId: await insertTurn(userId, observed) });
+
+  const outcome = await database.store.main.clear(userId, NOW);
+  assert.deepEqual([...outcome.cleared].sort(), [main, child, grandchild].sort());
+  assert.notEqual(outcome.opened, main);
+
+  assert.deepEqual(readRecords(await database.store.messages.list(userId, main, TOOLS)), []);
+  assert.deepEqual(readRecords(await database.store.messages.list(userId, child, TOOLS)), []);
+  assert.deepEqual(await database.store.events.list(userId, main), []);
+  const remaining = await database.store.turns.list(userId);
+  assert.equal(
+    remaining.some((row) => row.id === turn),
+    false,
+  );
+  assert.deepEqual(
+    remaining.map((row) => row.conversationId),
+    [observed],
+  );
+  assert.equal((await database.store.messages.list(userId, observed, TOOLS)).ok, true);
+
+  const [opened] = await database.db
+    .select()
+    .from(conversations)
+    .where(eq(conversations.id, outcome.opened));
+  assert.equal(opened?.kind, CONVERSATION_KIND.MAIN);
+  assert.equal(opened?.deletedAt, null);
+  assert.deepEqual(opened?.createdAt, NOW);
+  const [stamped] = await database.db
+    .select()
+    .from(conversations)
+    .where(eq(conversations.id, main));
+  assert.deepEqual(stamped?.deletedAt, NOW);
+  assert.equal(await countConversations(main), 1);
+  assert.equal(
+    (await database.db.select().from(messages).where(eq(messages.conversationId, main))).length,
+    3,
+  );
+});
+
+test("one main stands per account: two Clears leave exactly one, and a second standing main is refused", async () => {
+  const userId = await database.createUser();
+  await populateMain(userId);
+  const first = await database.store.main.clear(userId, NOW);
+  const second = await database.store.main.clear(userId, new Date(NOW.getTime() + 1));
+  assert.deepEqual(second.cleared, [first.opened]);
+  const standing = await database.db
+    .select({ id: conversations.id })
+    .from(conversations)
+    .where(
+      and(
+        eq(conversations.userId, userId),
+        eq(conversations.kind, CONVERSATION_KIND.MAIN),
+        isNull(conversations.deletedAt),
+      ),
+    );
+  assert.deepEqual(
+    standing.map((row) => row.id),
+    [second.opened],
+  );
+  await assert.rejects(insertConversation(userId), (error) => {
+    assert.ok(error instanceof Error);
+    const { cause } = error;
+    assert.ok(cause instanceof Error && "code" in cause);
+    assert.equal(cause.code, UNIQUE_VIOLATION);
+    return true;
+  });
+});
+
+test("a Clear on an account with no main opens one and stamps nothing", async () => {
+  const userId = await database.createUser();
+  const outcome = await database.store.main.clear(userId, NOW);
+  assert.deepEqual(outcome.cleared, []);
+  assert.equal(await countConversations(outcome.opened), 1);
+});
+
+test("the purge takes a cleared conversation and everything under it once the window has passed, and nothing sooner", async () => {
+  // The purge runs across every account, so this test's stamps stand in a year of their own, clear of the other tests' Clears.
+  const base = new Date("2020-01-01T00:00:00.000Z");
+  const userId = await database.createUser();
+  const other = await database.createUser();
+  const { main } = await populateMain(userId);
+  const child = await insertConversation(userId, {
+    kind: CONVERSATION_KIND.CHILD,
+    parentConversationId: main,
+  });
+  const cleared = await database.store.main.clear(userId, base);
+  const { main: recent } = await populateMain(other);
+  const { opened: standing } = await database.store.main.clear(
+    other,
+    new Date(base.getTime() + DAY_MS),
+  );
+
+  const beforeWindow = new Date(base.getTime() + CLEARED_CONVERSATION_RETENTION_MS - 1);
+  assert.equal(await database.store.retention.purgeCleared(beforeWindow), 0);
+  assert.equal(await countConversations(main), 1);
+
+  const atWindow = new Date(base.getTime() + CLEARED_CONVERSATION_RETENTION_MS);
+  assert.equal(await database.store.retention.purgeCleared(atWindow), 2);
+  assert.equal(await countConversations(main), 0);
+  assert.equal(await countConversations(child), 0);
+  assert.equal(
+    (await database.db.select().from(messages).where(eq(messages.conversationId, main))).length,
+    0,
+  );
+  assert.equal(
+    (await database.db.select().from(turns).where(eq(turns.conversationId, main))).length,
+    0,
+  );
+  assert.equal(
+    (await database.db.select().from(events).where(eq(events.conversationId, main))).length,
+    0,
+  );
+  assert.equal(await countConversations(cleared.opened), 1);
+  assert.equal(await countConversations(recent), 1);
+  assert.equal(await countConversations(standing), 1);
+
+  assert.equal(
+    await database.store.retention.purgeCleared(new Date(atWindow.getTime() + DAY_MS)),
+    1,
+  );
+  assert.equal(await countConversations(recent), 0);
+  assert.equal(await countConversations(standing), 1);
+});
+
+test("deleting the account takes cleared and standing conversations alike", async () => {
+  const userId = await database.createUser();
+  const { main } = await populateMain(userId);
+  const { opened } = await database.store.main.clear(userId, NOW);
+  await database.db.delete(user).where(eq(user.id, userId));
+  assert.equal(await countConversations(main), 0);
+  assert.equal(await countConversations(opened), 0);
+});
+
+test("a row naming a tool the registry does not hold refuses the page, naming the row", async () => {
+  const userId = await database.createUser();
+  const { main } = await populateMain(userId);
+  await insertMessage(userId, main, 4, {
+    role: MESSAGE_ROLE.ASSISTANT,
+    metadata: { author: MESSAGE_AUTHOR.BRAIN },
+    parts: [
+      {
+        type: "tool-nobody_registered",
+        toolCallId: "call_4a0000000000000001",
+        state: "output-available",
+        input: {},
+        output: {},
+      },
+    ],
+  });
+
+  const read = await database.store.messages.list(userId, main, TOOLS);
+  assert.equal(read.ok, false);
+  if (read.ok) return;
+  assert.equal(read.refusal, SCHEMA_REFUSAL.NOT_REGISTERED);
+  assert.equal(read.seq, 4);
+  assert.deepEqual(read.path, ["parts", 0, "type"]);
+
+  const before = readRecords(await database.store.messages.list(userId, main, TOOLS, { limit: 3 }));
+  assert.deepEqual(
+    before.map((record) => record.seq),
+    [1, 2, 3],
+  );
+});
+
+test("a row whose parts are not a message's refuses the page as malformed", async () => {
+  const userId = await database.createUser();
+  const { main } = await populateMain(userId);
+  await database.db.insert(messages).values({
+    userId,
+    conversationId: main,
+    seq: 4,
+    clientId: "client-4",
+    role: MESSAGE_ROLE.USER,
+    // SAFETY: the column is typed as a message's parts; the test writes what a corrupt row would hold.
+    parts: [{ type: "text" }] as unknown as (typeof messages.$inferInsert)["parts"],
+    metadata: TYPED_ASK,
+  });
+  const read = await database.store.messages.list(userId, main, TOOLS, { after: 3 });
+  assert.equal(read.ok, false);
+  if (read.ok) return;
+  assert.equal(read.refusal, SCHEMA_REFUSAL.MALFORMED);
+  assert.equal(read.seq, 4);
+  assert.deepEqual(read.path, []);
+});

--- a/apps/web/tests/storage-schema.test.ts
+++ b/apps/web/tests/storage-schema.test.ts
@@ -251,8 +251,8 @@ test("an observed session has one conversation per account, and unobserved kinds
   await assertUniqueViolation(insertConversation(userId, observed));
   await insertConversation(other, observed);
   await insertConversation(userId, { ...observed, providerSessionId: "session-2" });
-  await insertConversation(userId);
-  await insertConversation(userId);
+  await insertConversation(userId, { kind: CONVERSATION_KIND.THREAD });
+  await insertConversation(userId, { kind: CONVERSATION_KIND.THREAD });
 
   assert.equal(await countRows(conversations, eq(conversations.userId, userId)), 4);
   assert.equal(await countRows(conversations, eq(conversations.userId, other)), 1);

--- a/apps/web/tests/store-writer-boundary.test.ts
+++ b/apps/web/tests/store-writer-boundary.test.ts
@@ -9,9 +9,12 @@ import { fileURLToPath } from "node:url";
  * the invariant the writer establishes, stated over the server's import graph.
  * A module that could write one of the three tables has to import it from the
  * schema by name, so the set of server modules that do is the set that could
- * write, and that set is the writer alone. The aggregate schema module
- * re-exports them for the query builder and imports nothing, and a reader
- * that lands later joins this list by name, in the open.
+ * write, and that set is the writer and the one reader that selects from
+ * the same three tables. The import graph cannot tell a select from an
+ * insert, so the reader stands in the list by name, in the open, beside the
+ * statement that it writes none of them. The aggregate schema module
+ * re-exports them for the query builder and imports nothing, and another
+ * reader that lands later joins this list the same way.
  */
 
 const SERVER_ROOTS = ["server", "api"].map((root) =>
@@ -20,7 +23,14 @@ const SERVER_ROOTS = ["server", "api"].map((root) =>
 
 const WRITTEN_TABLES: ReadonlySet<string> = new Set(["messages", "turns", "events"]);
 
-const WRITERS: ReadonlySet<string> = new Set(["server/hosted/store/writer.ts"]);
+const WRITER = "server/hosted/store/writer.ts";
+
+/** The read module: `listMessages`, `listEvents`, and `listTurns` select from the three tables and insert into none. */
+const READER = "server/hosted/store/message-reads.ts";
+
+const TABLE_IMPORTERS: ReadonlySet<string> = new Set([WRITER, READER]);
+
+const WRITE_STATEMENT = /\.(insert|update|delete)\(\s*(messages|turns|events)\s*\)/;
 
 /**
  * The modules that import the whole schema as a namespace, which reaches
@@ -72,7 +82,7 @@ function importedTables(source: string): readonly string[] {
   return tables;
 }
 
-test("the writer is the one server module that imports the messages, turns, or events table, and the schema is imported whole by the two that build queries over it", async () => {
+test("the writer and the reader are the two server modules that import the messages, turns, or events table, only the writer writes them, and the schema is imported whole by the two that build queries over it", async () => {
   const repositoryRoot = fileURLToPath(new URL("../", import.meta.url));
   const importers = new Map<string, readonly string[]>();
   const namespaceImporters = new Set<string>();
@@ -85,7 +95,10 @@ test("the writer is the one server module that imports the messages, turns, or e
       if (importsSchemaNamespace(source)) namespaceImporters.add(relative);
     }
   }
-  assert.deepEqual(new Set(importers.keys()), WRITERS);
-  assert.deepEqual(new Set(importers.get("server/hosted/store/writer.ts")), WRITTEN_TABLES);
+  assert.deepEqual(new Set(importers.keys()), TABLE_IMPORTERS);
+  assert.deepEqual(new Set(importers.get(WRITER)), WRITTEN_TABLES);
+  assert.deepEqual(new Set(importers.get(READER)), WRITTEN_TABLES);
+  const reader = await readFile(path.join(repositoryRoot, READER), "utf8");
+  assert.equal(WRITE_STATEMENT.test(reader), false);
   assert.deepEqual(namespaceImporters, SCHEMA_NAMESPACE_IMPORTERS);
 });


### PR DESCRIPTION
## What

The v2 store's read side and its Clear, in `apps/web/server/hosted/store`, exposed on `HostedStore` as `messages.list`, `events.list`, `turns.list`, `main.clear`, and `main.purgeCleared` (B6 of the LUKE-95 storage rework; D2 and C6 consume them).

- **`listMessages(userId, conversationId, tools, { after, limit })`** answers a conversation's rows after a sequence, in sequence order, each read back into a `StoredUIMessage` beside its columns (`seq`, `turnId`, `clientId`, `createdAt`, `finishedAt`). Pages are bounded at 200 rows.
- **`listEvents(userId, conversationId, { after, limit })`** is the same cursor read over the `events` table.
- **`listTurns(userId, { after, limit })`** answers the account's turns ordered by the latest instant any of their stamps was set (`greatest` of queued, started, settled, cancel-requested), so a turn that settled since a device last read is answered again with its new status. A turn row is mutable, which is why its cursor is not a sequence: each row carries a `cursor` position, the instant **as Postgres renders it to the microsecond** plus the row's id, and a device passes the last row's position back as `after`. The instant is text rather than a `Date` because a JavaScript instant keeps milliseconds, and a stamp set in the same millisecond as the position a device already took would otherwise never read as later (Bugbot's finding on the first push); the id breaks ties so a page edge drops nothing.
- **Every read joins the conversation row and skips one stamped `deleted_at`**, and every read is scoped by `user_id` on the row and on the conversation, so a cleared conversation is gone from every read on the call after the Clear, and no account reads another's rows.
- **Clear is a soft delete.** `clearMainConversation` runs one transaction: it takes the account's user-row lock (the same `for update` the facts writer takes, so two Clears run one after the other and a child spawned mid-Clear is stamped with its parent), stamps `deleted_at` on the standing main and on every descendant level by level (a child of a cleared main would otherwise still read as live), and opens a new main row. Nothing is erased. An account with no main gets one opened.
- **The purge** deletes every conversation stamped 30 days or more ago, across accounts; the schema's cascades take the messages, turns, events, and children with it. It runs from the one cron, `/api/observation/tick`, as a new `purgeCleared` seam beside `forgetIneligible`, and the tick's answer reports the count. Account deletion cascades everything, stamped or not, which the test asserts.

## How the read holds rows to the vocabulary

Messages are read through `readStoredUIMessages` (A1's wrapper), **never the SDK's `validateUIMessages` directly**, because the SDK turns a terminal tool part naming an unregistered tool into a dynamic-tool part rather than refusing it. The registry (`ToolSet`) is a parameter of the read; the caller (D2) supplies the catalog's registry. A page holding a row this build cannot read is **refused whole**, answering the refusal word, the row's `seq`, and the path inside the row. The registry pre-check names the row itself; the SDK's structural refusal names none, so on that path the rows are read one at a time to find the culprit, a cost paid only when a page is already refused. Both cases are tested (`not_registered` on a tool part naming an unknown tool; `malformed` on parts that are not a message's).

The read reaches the wrapper through a new door in `server/core.ts` (`export *` of `packages/session/src/ui-messages/validate.js`), since the session barrel keeps the SDK off it and nothing in the server's compile closure reached that file before.

`ai@7.0.97` and `zod@4.5.4` are added as **devDependencies** of `apps/web` (the versions `packages/session` pins) so the PGlite tests can build a `ToolSet` with `tool()`; the server code imports only the `ToolSet` type.

## CLAUDE.md sentences this contradicts (for G5)

All under "Storage, retention, and conversation maintenance", replaced by the plan's soft delete:

- "**Delete conversation** is the recoverable deletion, in a fixed order: … the store removes the conversation's lines, transcript, boundaries, and standing lifetime in one transaction with a compressed recovery archive of them all — zstd through `node:zlib` where the runtime has it, plain JSONL otherwise — committed into the archive registry and the conversation's cutoff raised to the deletion's instant; only then is the archive published under `archives/` … a payload not yet published stays in the registry and every launch retries it." None of that exists here: no archive, no registry, no publication retry.
- "The cutoff on the conversation's row outlives any generation and is only ever raised by a deletion, so a late line from before it is refused whatever the disk did." There is no cutoff column; the stamp is the whole record, and a new main row is what a later write lands in.
- "Nothing reads an archive back: it stands on the developer's own disk for the developer alone." There is no archive; the stamped rows stand in Postgres for 30 days and are purged by the cron.
- "Conversation maintenance is OpenClaw's, ported from `store-maintenance.ts` … a 10 GiB physical budget cleaned to 8 GiB …" is not ported; the only maintenance here is the 30-day purge.

The rule that a deletion "reaches neither the facts Luke separately remembers nor any provider's file" survives unchanged: the Clear touches the `conversations` table alone.

## Migration 0018

No columns; three indexes:

- **A partial unique index over the standing main**, `conversations (user_id) where kind = 'main' and deleted_at is null`. The plan says one long Conversation per account, and Clear's whole design (stamp `deleted_at`, open a new main) assumes exactly one standing main; the index says so structurally, so a concurrent first-use creation in C1/C2 or a plain bug there cannot leave two rows both claiming to be the account's main with reads silently picking one. B1's schema test used two mains as its instrument for proving that the observed-session uniqueness index does not collapse non-observed rows; that test now uses two `thread` rows, which prove the same thing and are a kind an account genuinely may hold several of. Decided with the orchestrator.
- A partial index on `conversations (deleted_at) where deleted_at is not null`, for the purge that runs every minute.
- `turns (user_id)`, for the per-account turn read.

## Decisions worth a second look

- **Descendants are stamped with the main**, not left standing. The plan says a parent's deletion cascades to descendants; at the soft-delete stage that means the children must stop reading too, or a cleared main's child conversations would still be served.
- **The purge counts conversations it deleted directly** (stamped rows), not the rows the cascade took; the test pins that.
- **Instants cross the store boundary as `Date`**, as Drizzle answers `timestamp with time zone`; the wire shape of D2's answers is D2's to declare.
- **`listTurns` is per account, not per conversation**, since D2's route is `turns?after=` with no conversation; it skips turns of deleted conversations.
- Rebased onto B5 (#937) after it merged. The reads run over the B1/B2 tables and the tests insert rows directly, as B1's own tests do. B5's import-graph boundary test (only the writer imports the three tables) now names `message-reads.ts` beside the writer as the one reader, in the open, with an assertion that the reader issues no insert, update, or delete on them; B5's `ui-messages/index.js` door already carries the validator, so this PR's own door line was dropped in the rebase.

## Verify

```
./scripts/check.sh
pnpm --filter @luke/web test:store
```

No macOS or UI code is touched, so `verify.sh` does not apply.

## Reviews

Ran Cursor's `thermo-nuclear-code-quality-review` (cursor/plugins, cursor-team-kit) and `ponytail-review` (DietrichGebert/ponytail) over the diff, as their SKILL.md files instruct.

**Thermo-nuclear** (3 must-fix, 2 should-fix, 5 optional). Applied: the turns cursor was lossy on real Postgres (a microsecond `queued_at` came back cut to the millisecond and re-answered forever) and dropped ties at a page edge; first fixed with a millisecond cut, then, after Bugbot showed a same-millisecond stamp would be missed, made microsecond-exact by carrying the instant as Postgres's own text with the id breaking ties. Tested with a microsecond instant, a start stamped in the same millisecond, and a three-way tie split across pages. Two concurrent Clears could leave two standing mains; now the Clear takes the user-row lock first, tested with two Clears. Purge and turn-read indexes added (migration 0018). One `standingConversation(table)` join helper replaces three spellings. The refusal path carries the row instead of reconciling two parallel arrays. `purgeCleared` moved off `main` to a `retention` namespace since it runs across accounts. The tick seam's doc says why retention rides on the observation schedule. A `limit: 0` clamp test added. **Not taken:** selecting `parts`/`metadata` as their column types (the SDK part type is not assignable to the boundary type, so the `sql<WireBoundaryInput>` selection stays, with a comment); reshaping `StoredTurnRecord` away from `$inferSelect` (D2 declares the wire shape); bounding the purge statement (no evidence yet that a backlog is a problem); bounding the purge statement stays out; the standing-main unique index was first left out and then added at the orchestrator's decision (see Migration 0018).

**Ponytail** (5 findings, all applied): `update … returning` replaces select-for-update plus update plus a length guard; `optionalField` for the metadata omission; `and(…, undefined)` instead of a mutable predicate list; a constant-against-itself assertion deleted; `MAXIMUM_READ_PAGE` made module-private (knip agreed).

**Cursor Bugbot** (first push): one medium finding, the same-millisecond stamp above. Fixed as described; the thread has the reply.

## Test results

`./scripts/check.sh`: exit 0 (repository checks, Biome, oxlint, knip, typecheck, tests, builds).
`apps/web` store tests on PGlite: 31 pass, 0 fail across `storage-reads.test.ts` (11: sequence reads and clamp, event and turn cursors, microsecond-exact turn cursor with a same-millisecond start and a page-edge tie, account scoping, Clear within one call, Clear with no main, two Clears and a refused second main, purge window, account cascade, unregistered tool refused, malformed parts refused), `storage-schema.test.ts`, and `hosted-observation-tick.test.ts` (purge seam called once per tick with the tick's instant and counted in the answer).
`verify.sh` not run: no macOS or UI code is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34544384186/artifacts/10178537951) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34544384186)

- Commit: `c02bccec5562fe0533c736461c153b6925d0c327`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
