### PR TITLE
feat(LUKE-136): fold turns, collapse read tools, mark own judgment

### DIFF
--- a/apps/desktop/src/renderer/conversation-panel.tsx
+++ b/apps/desktop/src/renderer/conversation-panel.tsx
@@ -88,7 +88,7 @@ export function thinkingElapsedLabel(since: number, now: number): string | undef
  * which both tabs share. The reader's line is the live region, and the age
  * beside it is not, so a ticking count is never read out second by second.
  */
-function ConversationThinkingRow({
+export function ConversationThinkingRow({
   since,
   now,
 }: {

--- a/apps/desktop/src/renderer/conversation-turns.fixtures.ts
+++ b/apps/desktop/src/renderer/conversation-turns.fixtures.ts
@@ -159,19 +159,38 @@ const reply = (id: string, parts: StoredUIMessage["parts"]): StoredUIMessage => 
   parts,
 });
 
-const TURN = {
+/** The fixture turns by what each stands for; exported so a test can name the turn it reads. */
+export const FIXTURE_TURN = {
+  /** A typed ask answered with one reply and one read: no action at all. */
   ASK: "1a000000-0000-4000-8000-000000000101",
+  /** Every session action kind in one settled turn: folded closed under its count. */
   EVERY_KIND: "1a000000-0000-4000-8000-000000000102",
+  /** A refused, an unknown, a pending, and an errored action. */
   REFUSED: "1a000000-0000-4000-8000-000000000103",
+  /** An observed session's own turn, opened by the roster: Luke's own judgment. */
   ANNOUNCED: "1a000000-0000-4000-8000-000000000104",
+  /** A turn still running two actions in: folded open, with Luke's wait at its foot. */
+  RUNNING: "1a000000-0000-4000-8000-000000000105",
+  /** One action and nothing else: the row itself, no fold. */
+  SINGLE: "1a000000-0000-4000-8000-000000000106",
+  /** A hold's release in main: Luke's own judgment, with words and an action of his own. */
+  OWN: "1a000000-0000-4000-8000-000000000107",
 } as const;
+
+const TURN = FIXTURE_TURN;
 
 const AT = {
   ASK: 1757505600000,
   EVERY_KIND: 1757505700000,
   REFUSED: 1757505800000,
   ANNOUNCED: 1757505900000,
+  RUNNING: 1757506000000,
+  SINGLE: 1757506100000,
+  OWN: 1757506200000,
 } as const;
+
+/** The instant the fixtures are read against: the running turn has been going for a while. */
+export const FIXTURE_NOW = 1757506300000;
 
 /** One conversation covering every row the renderer draws. */
 export const FIXTURE_INPUT: ConversationViewInput = {
@@ -342,6 +361,79 @@ export const FIXTURE_INPUT: ConversationViewInput = {
       turnId: TURN.REFUSED,
       createdAt: AT.REFUSED + 2000,
     },
+    {
+      message: ask("2b000000-0000-4000-8000-000000000207", "Nudge both fixtures along."),
+      seq: 7,
+      turnId: TURN.RUNNING,
+      createdAt: AT.RUNNING,
+    },
+    {
+      message: reply("2b000000-0000-4000-8000-000000000208", [
+        { type: "step-start" },
+        call(
+          "send_session_message",
+          { ...identity(FIXTURE_SESSION.HELD), text: "Carry on." },
+          accepted({ target: target(FIXTURE_SESSION.HELD, FIXTURE_TITLE.HELD) }),
+        ),
+        call(
+          "send_session_message",
+          { ...identity(FIXTURE_SESSION.CREATED), text: "Carry on." },
+          accepted({ target: target(FIXTURE_SESSION.CREATED, FIXTURE_TITLE.CREATED) }),
+        ),
+        pendingCall("send_session_message", {
+          ...identity(FIXTURE_SESSION.UNOPENABLE),
+          text: "You too.",
+        }),
+      ]),
+      seq: 8,
+      turnId: TURN.RUNNING,
+      createdAt: AT.RUNNING + 900,
+    },
+    {
+      message: ask("2b000000-0000-4000-8000-000000000209", "Stop the fixture session."),
+      seq: 9,
+      turnId: TURN.SINGLE,
+      createdAt: AT.SINGLE,
+    },
+    {
+      message: reply("2b000000-0000-4000-8000-000000000210", [
+        { type: "step-start" },
+        call(
+          "run_session_control",
+          { ...identity(FIXTURE_SESSION.HELD), control_id: "stop" },
+          accepted({
+            target: {
+              ...target(FIXTURE_SESSION.HELD, FIXTURE_TITLE.HELD),
+              controlKind: SESSION_CONTROL_KIND.STOP,
+              controlLabel: "Stop",
+            },
+          }),
+        ),
+        { type: "step-start" },
+        { type: "text", text: "Stopped it.", state: "done" },
+      ]),
+      seq: 10,
+      turnId: TURN.SINGLE,
+      createdAt: AT.SINGLE + 800,
+    },
+    {
+      message: reply("2b000000-0000-4000-8000-000000000211", [
+        { type: "step-start" },
+        {
+          type: "text",
+          text: "The meeting ended, so I answered the fixture session's question myself.",
+          state: "done",
+        },
+        call(
+          "send_session_message",
+          { ...identity(FIXTURE_SESSION.HELD), text: "Yes, go ahead." },
+          accepted({ target: target(FIXTURE_SESSION.HELD, FIXTURE_TITLE.HELD) }),
+        ),
+      ]),
+      seq: 11,
+      turnId: TURN.OWN,
+      createdAt: AT.OWN,
+    },
   ],
   observed: [
     {
@@ -388,6 +480,25 @@ export const FIXTURE_INPUT: ConversationViewInput = {
       origin: TURN_ORIGIN.ROSTER_DIFF,
       status: TURN_STATUS.SETTLED,
       queuedAt: AT.ANNOUNCED,
+    },
+    {
+      id: TURN.RUNNING,
+      origin: TURN_ORIGIN.TYPED,
+      status: TURN_STATUS.RUNNING,
+      queuedAt: AT.RUNNING,
+      startedAt: AT.RUNNING + 200,
+    },
+    {
+      id: TURN.SINGLE,
+      origin: TURN_ORIGIN.TYPED,
+      status: TURN_STATUS.SETTLED,
+      queuedAt: AT.SINGLE,
+    },
+    {
+      id: TURN.OWN,
+      origin: TURN_ORIGIN.HOLD_RELEASE,
+      status: TURN_STATUS.SETTLED,
+      queuedAt: AT.OWN,
     },
   ],
   events: [],

--- a/apps/desktop/src/renderer/conversation-turns.test.ts
+++ b/apps/desktop/src/renderer/conversation-turns.test.ts
@@ -8,14 +8,22 @@ import {
   type SessionIdentity,
   selectConversationView,
 } from "@sidecar/session";
-import { CONVERSATION_EVENT_KIND } from "@sidecar/wire";
+import { CONVERSATION_EVENT_KIND, TURN_ORIGIN, TURN_STATUS } from "@sidecar/wire";
 import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { TOOL_ROW_STATUS, toolRow } from "./conversation-tool-row";
-import { announcedWords, ConversationTurns, detailToolLabel } from "./conversation-turns";
+import {
+  announcedWords,
+  ConversationTurns,
+  detailToolLabel,
+  judgmentOf,
+  turnPending,
+} from "./conversation-turns";
 import {
   FIXTURE_INPUT,
+  FIXTURE_NOW,
   FIXTURE_ROSTER,
+  FIXTURE_TURN,
   fixtureConversationTurns,
 } from "./conversation-turns.fixtures";
 
@@ -29,6 +37,7 @@ function render(
     createElement(ConversationTurns, {
       groups,
       roster: FIXTURE_ROSTER,
+      now: FIXTURE_NOW,
       ...(onOpenChat ? { onOpenChat } : undefined),
     }),
   );
@@ -60,7 +69,8 @@ test("the fixture scenarios draw every session action kind as a row", () => {
   assert.ok(count(markup, "data-tool-status", TOOL_ROW_STATUS.ACCEPTED) >= 7);
   assert.equal(count(markup, "data-tool-status", TOOL_ROW_STATUS.REFUSED), 1);
   assert.equal(count(markup, "data-tool-status", TOOL_ROW_STATUS.UNKNOWN), 1);
-  assert.equal(count(markup, "data-tool-status", TOOL_ROW_STATUS.PENDING), 1);
+  // One pending call in the refused turn, and one in the turn still running.
+  assert.equal(count(markup, "data-tool-status", TOOL_ROW_STATUS.PENDING), 2);
 });
 
 test("a chip is a press exactly where the composition says the session opens, and a name everywhere else", () => {
@@ -130,6 +140,87 @@ test("a refused action and the turn's details draw only inside the turn's fold",
   const unfolded = groups.filter((group) => !folded.includes(group));
   assert.ok(unfolded.length > 0);
   assert.equal(count(render(unfolded, OPEN), "data-folded", "true"), 0);
+});
+
+function groupOf(turnId: string): ConversationViewTurnGroup {
+  const group = fixtureConversationTurns().find((candidate) => candidate.turnId === turnId);
+  assert.ok(group);
+  return group;
+}
+
+/** The action rows a rendering draws, top level or inside a fold alike. */
+function actionRows(markup: string): number {
+  return (markup.match(/data-action-kind="/g) ?? []).length;
+}
+
+test("a turn's actions fold under a count once there are two: open while it runs, closed once settled", () => {
+  const running = render([groupOf(FIXTURE_TURN.RUNNING)], OPEN);
+  assert.equal(count(running, "data-actions-fold", "running"), 1);
+  assert.equal(count(running, "data-actions-fold", "settled"), 0);
+  assert.equal((running.match(/<details class="conversation-actions-fold" open/g) ?? []).length, 1);
+  assert.equal(actionRows(running), 3);
+
+  const settled = render([groupOf(FIXTURE_TURN.EVERY_KIND)], OPEN);
+  assert.equal(count(settled, "data-actions-fold", "settled"), 1);
+  assert.equal((settled.match(/<details class="conversation-actions-fold" open/g) ?? []).length, 0);
+  assert.equal((settled.match(/<details class="conversation-actions-fold"/g) ?? []).length, 1);
+  assert.equal(actionRows(settled), 9);
+  // The fold stands where the first action stood: after the ask and before the reply.
+  const [beforeFold, afterFold] = settled.split('<details class="conversation-actions-fold"');
+  assert.ok(beforeFold !== undefined && afterFold !== undefined);
+  assert.equal(count(beforeFold, "data-speaker", "you"), 1);
+  assert.equal(actionRows(beforeFold), 0);
+  assert.equal(count(afterFold, "data-speaker", "luke"), 1);
+});
+
+test("a turn of one action draws the row itself, with no fold and no wait", () => {
+  const markup = render([groupOf(FIXTURE_TURN.SINGLE)], OPEN);
+  assert.equal((markup.match(/data-actions-fold=/g) ?? []).length, 0);
+  assert.equal(actionRows(markup), 1);
+  assert.equal(count(markup, "data-thinking", "true"), 0);
+  assert.equal(count(markup, "data-judgment", "ask"), 1);
+});
+
+test("a running turn ends in Luke's wait, driven by the turn row's status alone", () => {
+  assert.equal(count(render([groupOf(FIXTURE_TURN.RUNNING)], OPEN), "data-thinking", "true"), 1);
+  for (const turnId of [FIXTURE_TURN.SINGLE, FIXTURE_TURN.EVERY_KIND, FIXTURE_TURN.OWN]) {
+    assert.equal(count(render([groupOf(turnId)], OPEN), "data-thinking", "true"), 0);
+  }
+  const turn = groupOf(FIXTURE_TURN.RUNNING).turn;
+  assert.ok(turn);
+  assert.equal(turnPending(turn), true);
+  assert.equal(turnPending({ ...turn, status: TURN_STATUS.QUEUED }), true);
+  for (const status of [TURN_STATUS.SETTLED, TURN_STATUS.CANCELLED, TURN_STATUS.FAILED]) {
+    assert.equal(turnPending({ ...turn, status }), false);
+  }
+  assert.equal(turnPending(undefined), false);
+});
+
+test("a turn nobody opened is Luke's own judgment: his face leads every row, and his words are never a reply bubble", () => {
+  const own = render([groupOf(FIXTURE_TURN.OWN)], OPEN);
+  assert.equal(count(own, "data-judgment", "own"), 2);
+  assert.equal(count(own, "data-judgment", "ask"), 0);
+  assert.equal(count(own, "data-own-words", "true"), 1);
+  assert.equal(count(own, "data-speaker", "luke"), 0);
+  assert.equal((own.match(/class="luke-face"/g) ?? []).length, 2);
+
+  const asked = render([groupOf(FIXTURE_TURN.SINGLE)], OPEN);
+  assert.equal(count(asked, "data-judgment", "own"), 0);
+  assert.equal((asked.match(/class="luke-face"/g) ?? []).length, 0);
+
+  // The observed session's own turn: its announcement stays his bubble, its action his judgment.
+  const announced = render([groupOf(FIXTURE_TURN.ANNOUNCED)], OPEN);
+  assert.equal(count(announced, "data-speaker", "luke"), 1);
+
+  const turn = groupOf(FIXTURE_TURN.OWN).turn;
+  assert.ok(turn);
+  for (const origin of [TURN_ORIGIN.ROSTER_DIFF, TURN_ORIGIN.HOLD_RELEASE, TURN_ORIGIN.CHILD]) {
+    assert.equal(judgmentOf({ ...turn, origin }), "own");
+  }
+  for (const origin of [TURN_ORIGIN.TYPED, TURN_ORIGIN.SPOKEN]) {
+    assert.equal(judgmentOf({ ...turn, origin }), "ask");
+  }
+  assert.equal(judgmentOf(undefined), "ask");
 });
 
 test("a reasoning part folds to a line on Luke's side, and an announcement is his bubble marked when unheard", () => {

--- a/apps/desktop/src/renderer/conversation-turns.test.ts
+++ b/apps/desktop/src/renderer/conversation-turns.test.ts
@@ -161,6 +161,14 @@ test("a turn's actions fold under a count once there are two: open while it runs
   assert.equal((running.match(/<details class="conversation-actions-fold" open/g) ?? []).length, 1);
   assert.equal(actionRows(running), 3);
 
+  // Inside the fold the rows carry no stamp of their own; the fold's line carries the turn's.
+  const [, insideRunning] = running.split('<details class="conversation-actions-fold"');
+  assert.ok(insideRunning !== undefined);
+  const [foldBody] = insideRunning.split("</details>");
+  assert.ok(foldBody !== undefined);
+  assert.equal(count(foldBody, "class", "conversation-time"), 0);
+  assert.equal(count(running, "class", "conversation-time"), 2);
+
   const settled = render([groupOf(FIXTURE_TURN.EVERY_KIND)], OPEN);
   assert.equal(count(settled, "data-actions-fold", "settled"), 1);
   assert.equal((settled.match(/<details class="conversation-actions-fold" open/g) ?? []).length, 0);

--- a/apps/desktop/src/renderer/conversation-turns.test.ts
+++ b/apps/desktop/src/renderer/conversation-turns.test.ts
@@ -16,6 +16,7 @@ import {
   announcedWords,
   ConversationTurns,
   detailToolLabel,
+  foldOpen,
   judgmentOf,
   turnPending,
 } from "./conversation-turns";
@@ -171,6 +172,20 @@ test("a turn's actions fold under a count once there are two: open while it runs
   assert.equal(count(beforeFold, "data-speaker", "you"), 1);
   assert.equal(actionRows(beforeFold), 0);
   assert.equal(count(afterFold, "data-speaker", "luke"), 1);
+});
+
+test("a fold follows the turn's state, and a press holds only until that state next changes", () => {
+  assert.equal(foldOpen(undefined, true), true);
+  assert.equal(foldOpen(undefined, false), false);
+  // Pressed closed while running: held closed while it still runs.
+  assert.equal(foldOpen({ pending: true, open: false }, true), false);
+  // Pressed open once settled: held open while it stays settled.
+  assert.equal(foldOpen({ pending: false, open: true }, false), true);
+  // The turn settled after the press: the turn's own word is the later one, and the fold closes.
+  assert.equal(foldOpen({ pending: true, open: true }, false), false);
+  assert.equal(foldOpen({ pending: true, open: false }, false), false);
+  // And a press made while settled does not reopen a fold for a turn that started running again.
+  assert.equal(foldOpen({ pending: false, open: false }, true), true);
 });
 
 test("a turn of one action draws the row itself, with no fold and no wait", () => {

--- a/apps/desktop/src/renderer/conversation-turns.tsx
+++ b/apps/desktop/src/renderer/conversation-turns.tsx
@@ -486,10 +486,13 @@ function ActionsFold({
   rows,
   pending,
   judgment,
+  at,
 }: {
   rows: readonly React.JSX.Element[];
   pending: boolean;
   judgment: Judgment;
+  /** When the first of the folded actions ran: the line's stamp, since the rows inside carry none. */
+  at: number;
 }): React.JSX.Element {
   const [choice, setChoice] = useState<FoldChoice | undefined>(undefined);
   const open = foldOpen(choice, pending);
@@ -526,6 +529,7 @@ function ActionsFold({
           <ol className="conversation-turn-rows">{rows}</ol>
         </details>
       </div>
+      <RowStamp at={at} />
     </li>
   );
 }
@@ -582,10 +586,19 @@ function userVoice(
  * view's decision, read back by call id; a call the view did not describe is
  * a detail.
  */
-/** One drawn row, and whether it is an action the turn may fold under its count. */
-interface DrawnRow {
-  readonly element: React.JSX.Element;
-  readonly action: boolean;
+/**
+ * One row as a message hands it to its turn: drawn already, or an action the
+ * turn decides the place of — a stamped row of its own, or a row inside the
+ * fold, whose line carries the stamp for all of them.
+ */
+type DrawnRow =
+  | { readonly element: React.JSX.Element; readonly action?: undefined }
+  | { readonly element?: undefined; readonly action: DrawnAction };
+
+interface DrawnAction {
+  readonly key: string;
+  readonly row: ToolRow;
+  readonly at: number;
 }
 
 interface MessageRows {
@@ -597,7 +610,6 @@ function messageRows(
   view: ConversationViewMessage,
   judgment: Judgment,
   roster: readonly SessionView[],
-  onOpenChat: ((identity: SessionIdentity) => void) | undefined,
 ): MessageRows {
   const { message } = view;
   if (message.role === MESSAGE_ROLE.USER) {
@@ -614,7 +626,6 @@ function messageRows(
               copy={voice === VOICE.YOU}
             />
           ),
-          action: false,
         },
       ],
       folded: [],
@@ -626,8 +637,7 @@ function messageRows(
     view.tools.map((tool) => [tool.toolCallId, tool]),
   );
   const rows: DrawnRow[] = [];
-  const draw = (element: React.JSX.Element) => rows.push({ element, action: false });
-  const open = onOpenChat ? { onOpenChat } : undefined;
+  const draw = (element: React.JSX.Element) => rows.push({ element });
   message.parts.forEach((part: StoredPart, index) => {
     const key = `${message.id}:${index}`;
     if (isTextPart(part)) {
@@ -669,12 +679,7 @@ function messageRows(
         } else if (tool.refused) {
           folded.push({ kind: CONVERSATION_VIEW_TOOL_KIND.ACTION, row, part });
         } else {
-          rows.push({
-            element: (
-              <ActionRow key={key} row={row} judgment={judgment} at={view.createdAt} {...open} />
-            ),
-            action: true,
-          });
+          rows.push({ action: { key, row, at: view.createdAt } });
         }
         return;
       }
@@ -689,32 +694,50 @@ function messageRows(
 const FOLD_FROM_ACTIONS = 2;
 
 /**
- * One turn's rows in order, its actions folded under a count where there are
- * enough of them to fold: the fold stands where the first action stood, and
- * the rows between actions keep their places around it.
+ * One turn's rows in order, its actions placed: each a stamped row of its own
+ * while there are too few to fold, or all of them inside one fold standing
+ * where the first stood, unstamped, under the fold's own stamp. The rows
+ * between actions keep their places around it.
  */
 function turnRows(
   drawn: readonly DrawnRow[],
   pending: boolean,
   judgment: Judgment,
   turnId: string,
+  onOpenChat: ((identity: SessionIdentity) => void) | undefined,
 ): readonly React.JSX.Element[] {
-  const actions = drawn.filter((row) => row.action).map((row) => row.element);
-  if (actions.length < FOLD_FROM_ACTIONS) return drawn.map((row) => row.element);
-  const first = drawn.findIndex((row) => row.action);
-  return drawn.flatMap((row, index) => {
-    if (index === first) {
-      return [
-        <ActionsFold
-          key={`${turnId}:actions`}
-          rows={actions}
-          pending={pending}
+  const open = onOpenChat ? { onOpenChat } : undefined;
+  const actions = drawn.flatMap((row) => (row.action ? [row.action] : []));
+  const first = actions[0];
+  if (first === undefined || actions.length < FOLD_FROM_ACTIONS) {
+    return drawn.map((row) =>
+      row.action ? (
+        <ActionRow
+          key={row.action.key}
+          row={row.action.row}
           judgment={judgment}
-        />,
-      ];
-    }
-    return row.action ? [] : [row.element];
-  });
+          at={row.action.at}
+          {...open}
+        />
+      ) : (
+        row.element
+      ),
+    );
+  }
+  const fold = (
+    <ActionsFold
+      key={`${turnId}:actions`}
+      rows={actions.map((action) => (
+        <ActionRow key={action.key} row={action.row} judgment={judgment} {...open} />
+      ))}
+      pending={pending}
+      judgment={judgment}
+      at={first.at}
+    />
+  );
+  return drawn.flatMap((row) =>
+    row.action ? (row.action === first ? [fold] : []) : [row.element],
+  );
 }
 
 /**
@@ -749,14 +772,13 @@ export function ConversationTurns({
       {groups.flatMap((group) => {
         const judgment = judgmentOf(group.turn);
         const pending = turnPending(group.turn);
-        const drawn = group.messages.map((message) =>
-          messageRows(message, judgment, roster, onOpenChat),
-        );
+        const drawn = group.messages.map((message) => messageRows(message, judgment, roster));
         const rows = turnRows(
           drawn.flatMap((message) => message.rows),
           pending,
           judgment,
           group.turnId,
+          onOpenChat,
         );
         const folded = drawn.flatMap((message) => message.folded);
         return [

--- a/apps/desktop/src/renderer/conversation-turns.tsx
+++ b/apps/desktop/src/renderer/conversation-turns.tsx
@@ -454,13 +454,33 @@ function FoldedRows({
   );
 }
 
+/** The reader's press on a fold, remembered with the turn state it was made under. */
+export interface FoldChoice {
+  readonly pending: boolean;
+  readonly open: boolean;
+}
+
+/**
+ * Whether a fold stands open: as the turn's state has it — open while the
+ * turn still runs, closed once settled — unless the reader pressed it under
+ * that same state, in which case their press holds. A press made while the
+ * turn ran does not outlive the turn's settling: the turn's own change is the
+ * later word, and the fold follows it.
+ */
+export function foldOpen(choice: FoldChoice | undefined, pending: boolean): boolean {
+  return choice !== undefined && choice.pending === pending ? choice.open : pending;
+}
+
 /**
  * The actions one turn carried, folded under a line that counts them. The
  * fold follows the turn: open while the turn still runs, so what it is doing
  * is watched as it happens, and closed once it has settled, so a finished
  * turn reads as one line; a press holds whichever the reader chose until the
- * turn's own state next changes. Under Luke's own judgment the line leads
- * with his face, as each row inside it does.
+ * turn's own state next changes. The element's toggle fires for the state the
+ * turn sets as well as for a press, so a toggle is read as the reader's only
+ * when it leaves the element in a state the turn did not ask for; a fold that
+ * mistook the turn's word for the reader's would never close. Under Luke's
+ * own judgment the line leads with his face, as each row inside it does.
  */
 function ActionsFold({
   rows,
@@ -471,8 +491,8 @@ function ActionsFold({
   pending: boolean;
   judgment: Judgment;
 }): React.JSX.Element {
-  const [choice, setChoice] = useState<boolean | undefined>(undefined);
-  const open = choice ?? pending;
+  const [choice, setChoice] = useState<FoldChoice | undefined>(undefined);
+  const open = foldOpen(choice, pending);
   const own = judgment === JUDGMENT.OWN;
   const voice = own ? VOICE.OWN : VOICE.ACTION;
   return (
@@ -487,7 +507,13 @@ function ActionsFold({
         <details
           className="conversation-actions-fold"
           open={open}
-          onToggle={(event) => setChoice(event.currentTarget.open)}
+          onToggle={(event) => {
+            // The browser fires this for the state the turn set as well as for a
+            // press; only a state the prop does not already hold is the reader's.
+            if (event.currentTarget.open !== open) {
+              setChoice({ pending, open: event.currentTarget.open });
+            }
+          }}
         >
           <summary className="conversation-turn-summary">
             {own ? (

--- a/apps/desktop/src/renderer/conversation-turns.tsx
+++ b/apps/desktop/src/renderer/conversation-turns.tsx
@@ -8,11 +8,13 @@ import {
   PlusIcon,
   ProviderMark,
   StopIcon,
+  WingFace,
 } from "@sidecar/panel";
 import {
   CONVERSATION_VIEW_TOOL_KIND,
   type ConversationViewMessage,
   type ConversationViewToolPart,
+  type ConversationViewTurn,
   type ConversationViewTurnGroup,
   isStoredToolPart,
   MESSAGE_AUTHOR,
@@ -25,9 +27,23 @@ import {
   TOOL_PART_STATE,
 } from "@sidecar/session";
 import type { StoredUIMessage } from "@sidecar/session/ui-messages";
-import { isRecord, isWireString, unparsedWire, type WireBoundaryInput } from "@sidecar/wire";
+import {
+  isRecord,
+  isWireString,
+  TURN_ORIGIN,
+  TURN_STATUS,
+  type TurnOrigin,
+  type TurnStatus,
+  unparsedWire,
+  type WireBoundaryInput,
+} from "@sidecar/wire";
+import { useState } from "react";
 import { ConversationCopyButton } from "./conversation-copy";
-import { CONVERSATION_ENTRY_SPEAKER, type ConversationEntrySpeaker } from "./conversation-panel";
+import {
+  CONVERSATION_ENTRY_SPEAKER,
+  type ConversationEntrySpeaker,
+  ConversationThinkingRow,
+} from "./conversation-panel";
 import { TOOL_ROW_STATUS, type ToolRow, type ToolRowChip, toolRow } from "./conversation-tool-row";
 import { MarkdownMessage } from "./markdown-message";
 import type { SessionView } from "./session-model";
@@ -44,7 +60,14 @@ import { ThinkingDots } from "./thinking-dots";
  * classed as a detail — a read, a workspace write, a delegation — and an
  * action whose tool failed outright draw only inside the turn, folded under
  * a count, so the thread reads as what was said and done and the turn's
- * working stays a level down.
+ * working stays a level down. A turn that carried more than one action folds
+ * them under a line that counts them, open while the turn still runs and
+ * closed once it has settled, a press holding whichever the reader chose;
+ * a turn of one action draws the row itself. A turn the developer did not
+ * open — a roster look, a hold's release, a child's end — is Luke's own
+ * judgment, and everything it did leads with his face under that name and
+ * never wears a reply's bubble, so what he decided for himself is never read
+ * as something the developer asked.
  *
  * Everything here is drawn inside the Conversation subtree, which the session
  * recording blocks whole: a session's title on a chip, a briefing's words, a
@@ -63,7 +86,35 @@ const VOICE = {
   /** A note the brain wrote itself into the conversation, never the developer's words. */
   NOTE: { speaker: CONVERSATION_ENTRY_SPEAKER.EVENT, label: "Note" },
   ACTION: { speaker: CONVERSATION_ENTRY_SPEAKER.EVENT, label: "Action" },
+  /** A turn nobody opened: what Luke did and said in it is his own judgment, and the label says so. */
+  OWN: { speaker: CONVERSATION_ENTRY_SPEAKER.EVENT, label: "Luke, on his own judgment" },
 } as const satisfies Record<string, RowVoice>;
+
+/** Whose judgment a turn's rows record, stamped on each so the two never look alike. */
+const JUDGMENT = { ASK: "ask", OWN: "own" } as const;
+
+type Judgment = (typeof JUDGMENT)[keyof typeof JUDGMENT];
+
+/** The origins the developer opened a turn by; every other origin is a wake, and the turn Luke's own. */
+const DEVELOPER_ORIGINS: ReadonlySet<TurnOrigin> = new Set<TurnOrigin>([
+  TURN_ORIGIN.TYPED,
+  TURN_ORIGIN.SPOKEN,
+]);
+
+/** A turn with no row to say who opened it is drawn as an ask rather than claimed as Luke's own. */
+export function judgmentOf(turn: ConversationViewTurn | undefined): Judgment {
+  return turn !== undefined && !DEVELOPER_ORIGINS.has(turn.origin) ? JUDGMENT.OWN : JUDGMENT.ASK;
+}
+
+/** The statuses under which a turn is still going: queued for its run, or running it. */
+const PENDING_STATUSES: ReadonlySet<TurnStatus> = new Set<TurnStatus>([
+  TURN_STATUS.QUEUED,
+  TURN_STATUS.RUNNING,
+]);
+
+export function turnPending(turn: ConversationViewTurn | undefined): boolean {
+  return turn !== undefined && PENDING_STATUSES.has(turn.status);
+}
 
 /**
  * The mark an action row leads with, one per kind of thing that can be done
@@ -161,6 +212,33 @@ function ReasoningRow({ text }: { text: string }): React.JSX.Element {
 }
 
 /**
+ * Words Luke wrote in a turn nobody opened: his own judgment, drawn in the
+ * quiet voice under his face and never as a reply's bubble, because a bubble
+ * would read as an answer to something the developer said.
+ */
+function OwnWordsRow({ words, at }: { words: string; at: number }): React.JSX.Element {
+  return (
+    <li
+      className="conversation-entry"
+      data-speaker={VOICE.OWN.speaker}
+      data-judgment={JUDGMENT.OWN}
+      data-own-words="true"
+    >
+      <small className="visually-hidden">{VOICE.OWN.label}</small>
+      <div className="conversation-message">
+        <span className="conversation-action">
+          <span className="conversation-action-mark" aria-hidden="true">
+            <WingFace />
+          </span>
+          <MarkdownMessage words={words} className="conversation-words" />
+        </span>
+      </div>
+      <RowStamp at={at} />
+    </li>
+  );
+}
+
+/**
  * The chip naming the session an action reached. Where the session has an
  * identity to open by and its row would open, the chip is that row's own press
  * by another hand: it mints the same open act, for the identity the record
@@ -215,10 +293,12 @@ function chipOf(row: ToolRow): ToolRowChip | undefined {
  */
 function ActionRow({
   row,
+  judgment,
   at,
   onOpenChat,
 }: {
   row: ToolRow;
+  judgment: Judgment;
   at?: number;
   onOpenChat?: (identity: SessionIdentity) => void;
 }): React.JSX.Element {
@@ -226,22 +306,25 @@ function ActionRow({
   const chip = chipOf(row);
   const trailingProvider =
     row.providerId !== undefined && chip?.markId !== row.providerId ? row.providerId : undefined;
+  const own = judgment === JUDGMENT.OWN;
+  const voice = own ? VOICE.OWN : VOICE.ACTION;
   return (
     <li
       className="conversation-entry"
-      data-speaker={VOICE.ACTION.speaker}
+      data-speaker={voice.speaker}
+      data-judgment={judgment}
       data-action-kind={row.kind}
       data-tool-status={row.status}
     >
-      <small className="visually-hidden">{VOICE.ACTION.label}</small>
+      <small className="visually-hidden">{voice.label}</small>
       <div className="conversation-message">
         <span className="conversation-action">
           <span
             className="conversation-action-mark"
             aria-hidden="true"
-            data-control={row.controlKind}
+            data-control={own ? undefined : row.controlKind}
           >
-            <Glyph />
+            {own ? <WingFace /> : <Glyph />}
           </span>
           <span className="conversation-action-body">
             <span className="conversation-words">
@@ -335,9 +418,11 @@ function foldedLabel(count: number): string {
  */
 function FoldedRows({
   rows,
+  judgment,
   onOpenChat,
 }: {
   rows: readonly FoldedRow[];
+  judgment: Judgment;
   onOpenChat?: (identity: SessionIdentity) => void;
 }): React.JSX.Element {
   return (
@@ -357,11 +442,62 @@ function FoldedRows({
                 <ActionRow
                   key={folded.part.toolCallId}
                   row={folded.row}
+                  judgment={judgment}
                   {...(onOpenChat ? { onOpenChat } : undefined)}
                 />
               ),
             )}
           </ol>
+        </details>
+      </div>
+    </li>
+  );
+}
+
+/**
+ * The actions one turn carried, folded under a line that counts them. The
+ * fold follows the turn: open while the turn still runs, so what it is doing
+ * is watched as it happens, and closed once it has settled, so a finished
+ * turn reads as one line; a press holds whichever the reader chose until the
+ * turn's own state next changes. Under Luke's own judgment the line leads
+ * with his face, as each row inside it does.
+ */
+function ActionsFold({
+  rows,
+  pending,
+  judgment,
+}: {
+  rows: readonly React.JSX.Element[];
+  pending: boolean;
+  judgment: Judgment;
+}): React.JSX.Element {
+  const [choice, setChoice] = useState<boolean | undefined>(undefined);
+  const open = choice ?? pending;
+  const own = judgment === JUDGMENT.OWN;
+  const voice = own ? VOICE.OWN : VOICE.ACTION;
+  return (
+    <li
+      className="conversation-entry"
+      data-speaker={voice.speaker}
+      data-judgment={judgment}
+      data-actions-fold={pending ? "running" : "settled"}
+    >
+      <small className="visually-hidden">{voice.label}</small>
+      <div className="conversation-message">
+        <details
+          className="conversation-actions-fold"
+          open={open}
+          onToggle={(event) => setChoice(event.currentTarget.open)}
+        >
+          <summary className="conversation-turn-summary">
+            {own ? (
+              <span className="conversation-action-mark" aria-hidden="true">
+                <WingFace />
+              </span>
+            ) : null}
+            {`${rows.length} actions`}
+          </summary>
+          <ol className="conversation-turn-rows">{rows}</ol>
         </details>
       </div>
     </li>
@@ -420,13 +556,20 @@ function userVoice(
  * view's decision, read back by call id; a call the view did not describe is
  * a detail.
  */
+/** One drawn row, and whether it is an action the turn may fold under its count. */
+interface DrawnRow {
+  readonly element: React.JSX.Element;
+  readonly action: boolean;
+}
+
 interface MessageRows {
-  readonly rows: readonly React.JSX.Element[];
+  readonly rows: readonly DrawnRow[];
   readonly folded: readonly FoldedRow[];
 }
 
 function messageRows(
   view: ConversationViewMessage,
+  judgment: Judgment,
   roster: readonly SessionView[],
   onOpenChat: ((identity: SessionIdentity) => void) | undefined,
 ): MessageRows {
@@ -435,13 +578,18 @@ function messageRows(
     const voice = userVoice(message);
     return {
       rows: [
-        <BubbleRow
-          key={message.id}
-          voice={voice}
-          words={userWords(message)}
-          at={view.createdAt}
-          copy={voice === VOICE.YOU}
-        />,
+        {
+          element: (
+            <BubbleRow
+              key={message.id}
+              voice={voice}
+              words={userWords(message)}
+              at={view.createdAt}
+              copy={voice === VOICE.YOU}
+            />
+          ),
+          action: false,
+        },
       ],
       folded: [],
     };
@@ -451,16 +599,23 @@ function messageRows(
   const described = new Map<string, ConversationViewToolPart>(
     view.tools.map((tool) => [tool.toolCallId, tool]),
   );
-  const rows: React.JSX.Element[] = [];
+  const rows: DrawnRow[] = [];
+  const draw = (element: React.JSX.Element) => rows.push({ element, action: false });
   const open = onOpenChat ? { onOpenChat } : undefined;
   message.parts.forEach((part: StoredPart, index) => {
     const key = `${message.id}:${index}`;
     if (isTextPart(part)) {
-      rows.push(<BubbleRow key={key} voice={VOICE.LUKE} words={part.text} at={view.createdAt} />);
+      draw(
+        judgment === JUDGMENT.OWN ? (
+          <OwnWordsRow key={key} words={part.text} at={view.createdAt} />
+        ) : (
+          <BubbleRow key={key} voice={VOICE.LUKE} words={part.text} at={view.createdAt} />
+        ),
+      );
       return;
     }
     if (isReasoningPart(part)) {
-      rows.push(<ReasoningRow key={key} text={part.text} />);
+      draw(<ReasoningRow key={key} text={part.text} />);
       return;
     }
     if (!isStoredToolPart(part)) return;
@@ -469,7 +624,7 @@ function messageRows(
       case CONVERSATION_VIEW_TOOL_KIND.ANNOUNCE: {
         const words = announcedWords(part);
         if (words !== undefined) {
-          rows.push(
+          draw(
             <BubbleRow
               key={key}
               voice={VOICE.LUKE}
@@ -488,7 +643,12 @@ function messageRows(
         } else if (tool.refused) {
           folded.push({ kind: CONVERSATION_VIEW_TOOL_KIND.ACTION, row, part });
         } else {
-          rows.push(<ActionRow key={key} row={row} at={view.createdAt} {...open} />);
+          rows.push({
+            element: (
+              <ActionRow key={key} row={row} judgment={judgment} at={view.createdAt} {...open} />
+            ),
+            action: true,
+          });
         }
         return;
       }
@@ -499,16 +659,51 @@ function messageRows(
   return { rows, folded };
 }
 
+/** How many actions a turn carries before they fold under a count rather than standing as rows. */
+const FOLD_FROM_ACTIONS = 2;
+
 /**
- * The thread as turns. Each group's messages draw in sequence, and the
- * group's working — its details and its failed actions — closes the group
- * under one fold, so a refusal is read inside the turn that tried it and
- * never as a row of its own.
+ * One turn's rows in order, its actions folded under a count where there are
+ * enough of them to fold: the fold stands where the first action stood, and
+ * the rows between actions keep their places around it.
+ */
+function turnRows(
+  drawn: readonly DrawnRow[],
+  pending: boolean,
+  judgment: Judgment,
+  turnId: string,
+): readonly React.JSX.Element[] {
+  const actions = drawn.filter((row) => row.action).map((row) => row.element);
+  if (actions.length < FOLD_FROM_ACTIONS) return drawn.map((row) => row.element);
+  const first = drawn.findIndex((row) => row.action);
+  return drawn.flatMap((row, index) => {
+    if (index === first) {
+      return [
+        <ActionsFold
+          key={`${turnId}:actions`}
+          rows={actions}
+          pending={pending}
+          judgment={judgment}
+        />,
+      ];
+    }
+    return row.action ? [] : [row.element];
+  });
+}
+
+/**
+ * The thread as turns. Each group's messages draw in sequence, its actions
+ * fold under a count once there are two, and the group's working — its
+ * details and its failed actions — closes the group under one fold, so a
+ * refusal is read inside the turn that tried it and never as a row of its
+ * own. A turn still running ends in Luke's wait, driven by the turn row's
+ * own status and nothing else.
  */
 export function ConversationTurns({
   groups,
   roster = [],
   onOpenChat,
+  now,
 }: {
   groups: readonly ConversationViewTurnGroup[];
   /**
@@ -520,23 +715,46 @@ export function ConversationTurns({
   roster?: readonly SessionView[];
   /** The row's own press by identity; absent where nothing can open a session, and every chip is a name. */
   onOpenChat?: (identity: SessionIdentity) => void;
+  /** The instant a running turn's wait is read against; passed down because only the app knows which clock is honest. */
+  now: number;
 }): React.JSX.Element {
   return (
     <ol className="conversation-list">
       {groups.flatMap((group) => {
-        const drawn = group.messages.map((message) => messageRows(message, roster, onOpenChat));
-        const rows = drawn.flatMap((message) => message.rows);
+        const judgment = judgmentOf(group.turn);
+        const pending = turnPending(group.turn);
+        const drawn = group.messages.map((message) =>
+          messageRows(message, judgment, roster, onOpenChat),
+        );
+        const rows = turnRows(
+          drawn.flatMap((message) => message.rows),
+          pending,
+          judgment,
+          group.turnId,
+        );
         const folded = drawn.flatMap((message) => message.folded);
-        return folded.length === 0
-          ? rows
-          : [
-              ...rows,
-              <FoldedRows
-                key={`${group.turnId}:folded`}
-                rows={folded}
-                {...(onOpenChat ? { onOpenChat } : undefined)}
-              />,
-            ];
+        return [
+          ...rows,
+          ...(folded.length === 0
+            ? []
+            : [
+                <FoldedRows
+                  key={`${group.turnId}:folded`}
+                  rows={folded}
+                  judgment={judgment}
+                  {...(onOpenChat ? { onOpenChat } : undefined)}
+                />,
+              ]),
+          ...(pending && group.turn !== undefined
+            ? [
+                <ConversationThinkingRow
+                  key={`${group.turnId}:thinking`}
+                  since={group.turn.startedAt ?? group.turn.queuedAt}
+                  now={now}
+                />,
+              ]
+            : []),
+        ];
       })}
     </ol>
   );

--- a/apps/desktop/src/renderer/styles/conversation.css
+++ b/apps/desktop/src/renderer/styles/conversation.css
@@ -581,3 +581,48 @@ button.conversation-action-chip:focus-visible {
 .conversation-detail-state {
   color: var(--text-tertiary);
 }
+
+/* The actions one turn carried, folded under a line that counts them, at the
+   place the first of them stood. The line reads in the quiet voice, and under
+   Luke's own judgment it leads with his face as each row inside it does. */
+.conversation-actions-fold {
+  min-width: 0;
+  color: var(--text-secondary);
+  font-size: 10.5px;
+  line-height: 1.4;
+}
+
+.conversation-actions-fold > .conversation-turn-summary {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+}
+
+.conversation-entry[data-actions-fold] .conversation-message {
+  justify-content: flex-start;
+  padding: 2px 12px;
+  text-align: left;
+}
+
+/* Luke's face in the mark's room wears the text colour like the strip's does,
+   only smaller: it signs the row as his own judgment rather than decorating it. */
+.conversation-action-mark .luke-face {
+  width: 12px;
+  height: 12px;
+  color: var(--text-secondary);
+}
+
+/* Words Luke wrote on his own judgment are a quiet row under his face, never
+   a reply's bubble: nothing here answers the developer. */
+.conversation-entry[data-own-words] .conversation-message {
+  justify-content: flex-start;
+  padding: 2px 12px;
+  text-align: left;
+}
+
+.conversation-entry[data-own-words] .conversation-words {
+  padding: 0;
+  color: var(--text-secondary);
+  font-size: 10.5px;
+  line-height: 1.4;
+}


### PR DESCRIPTION
## What

E1's renderer (`ConversationTurns`, #936) learns the three things E2 names, renderer only and still unmounted (E4 moves the data source):

- **Turns fold.** A turn's action rows fold under one line that counts them (`N actions`) once there are two, standing where the first action stood so the ask, the reply, and the rows between keep their places. The fold is a native `<details>`: **open while `turns.status` is `running` or `queued`, closed once settled**, and a press holds whichever the reader chose (`choice ?? pending`). A turn of one action draws the row itself.
- **Read tools stay collapsed inside the turn.** The rule is D1's classification applied exactly: `detail` or `refused` collapses (E1 landed this; it is unchanged here, and every read tool — `read_transcript`, `list_sessions`, `memory_search`, workspace reads — is a `detail` under the catalog's classification).
- **The Conversation thinking row is driven by `turns.status`.** A pending turn ends in Luke's wait (`ConversationThinkingRow`, now exported from the existing panel and shared), its age read from `startedAt ?? queuedAt` against the `now` the caller passes.
- **A wake turn is Luke's own judgment.** `judgmentOf(turn)` reads `turns.origin` against `@sidecar/wire`'s `TURN_ORIGIN`: `typed` and `spoken` are the developer's; every other origin (`roster_diff`, `hold_release`, `child`) is a wake. In such a turn every action row leads with Luke's face under the hidden label **"Luke, on his own judgment"**, the actions fold leads with the same face, and words he wrote are a quiet row under his face, **never a reply bubble**. A turn with no turn row is drawn as an ask rather than claimed as his own. This is the one wording in the PR that carries a trust meaning: CLAUDE.md says an action Luke took on his own initiative is narrated as Luke's own judgment, never as something the developer asked, and the mark keeps that true on screen.

## Fixtures instead of the harness

The ticket names harness scenarios; the harness (#650) is not on main and is not part of this graph, so the acceptance is met by E1's synthetic fixtures, extended rather than duplicated: a turn still running (`FIXTURE_TURN.RUNNING`, two accepted actions and one pending, status `running`), a settled turn of every action kind (`EVERY_KIND`, folded closed), a turn of one action (`SINGLE`), and a hold's release in main (`OWN`, with words and an action of Luke's own), beside the observed roster-look turn from E1. Every title, id, and sentence is invented.

## Tests

`conversation-turns.test.ts` gains: the fold is present and open for the running turn and present and closed for the settled one, with the action count inside and the fold standing between the ask and the reply; a single action draws the row with no fold and no wait; the wait appears for the running turn only and `turnPending` answers by status; the own-judgment turn stamps `data-judgment="own"` on every row, draws Luke's face on each, draws no Luke bubble, and `judgmentOf` maps every origin. Assertions count structural markers the renderer stamps, never phrases. 26 renderer tests pass across the three Conversation test files.

## Verify

- `./scripts/check.sh` passes (lint, knip, typecheck, tests, build).
- **`verify.sh` could not be run: this is a Linux cloud sandbox with no macOS.** The renderer is not reachable in the app yet (E4 mounts it inside the `conversation-view ph-no-capture` subtree), so an evidence run on a Mac would show the existing Conversation tab unchanged and demonstrate nothing about this change; the renderer tests over the fixtures are what covers it. **No physical-notch check was performed.** No screenshots are committed.
- Nothing is drawn outside the Conversation subtree; the component's only mount is still its tests.

## Reviews run

- **Thermonuclear code quality review** (Cursor's `cursor-team-kit` skill, applied as written): rows now travel as `{ element, action }` so the fold is one pure pass (`turnRows`) over a turn rather than a flag threaded through the part loop; judgment and pending are decided once per turn from the turn row and handed down.
- **Cursor Bugbot** found one real issue on the first head, fixed in the follow-up commit: the fold recorded the reader's choice on the toggle React's own `open` change fires, so a fold opened by a running turn never closed once the turn settled. The choice is now read only from a toggle that leaves the element in a state the prop does not already hold, and is dropped when the turn's state changes (`foldOpen()`, tested case by case).
- **Ponytail review** (`DietrichGebert/ponytail`, as written): `shrink` — inlined a one-line label helper. Otherwise lean.

## CLAUDE.md

No sentence contradicted; the own-judgment mark implements "narrated as Luke's own judgment, never as something the developer asked" on screen.

E4 (LUKE-102) stacks on this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34543177359/artifacts/10178088412) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34543177359)

- Commit: `04f2ca7c0c61a1a202c6f4e704abbd92be0cedaa`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
