### PR TITLE
feat(settings): live voices, no speed

### DIFF
--- a/apps/desktop/src/main/ipc/settings-side-effects.ts
+++ b/apps/desktop/src/main/ipc/settings-side-effects.ts
@@ -62,7 +62,6 @@ export function clientSettingSideEffects(dependencies: ClientSettingSideEffectDe
   return {
     [SETTING_SIDE_EFFECT.NONE]: noClientSettingSideEffect,
     [SETTING_SIDE_EFFECT.VOICE]: noClientSettingSideEffect,
-    [SETTING_SIDE_EFFECT.VOICE_SPEED]: noClientSettingSideEffect,
     [SETTING_SIDE_EFFECT.ANNOUNCEMENT_HOLD]: noClientSettingSideEffect,
     [SETTING_SIDE_EFFECT.VAULT_SYNC]: noClientSettingSideEffect,
     [SETTING_SIDE_EFFECT.LOGIN_ITEM]: ({ settings }) => applyLoginItem(settings.stored.openAtLogin),

--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -265,7 +265,6 @@ export function App(): React.JSX.Element {
       // another app for a chord nobody is contesting.
       hotkey: {
         ...(held.hotkeys.talk ? { hotkey: voiceHotkeyLabel(held.hotkeys.talk) } : undefined),
-        held: held.hotkeys.talkHeld,
         removed: current.voiceHotkey === VOICE_HOTKEY_NONE,
       },
       ...(held.hotkeys.ask ? { askKey: voiceHotkeyLabel(held.hotkeys.ask) } : undefined),

--- a/apps/desktop/src/renderer/luke-errand.test.ts
+++ b/apps/desktop/src/renderer/luke-errand.test.ts
@@ -35,7 +35,7 @@ const guideInput: LukeGuideInput = {
   },
   voiceAvailable: true,
   microphoneStatus: "granted",
-  hotkey: { hotkey: "⌥Space", held: true },
+  hotkey: { hotkey: "⌥Space" },
   askKey: "⌥L",
 };
 

--- a/apps/desktop/src/renderer/luke-guide.test.ts
+++ b/apps/desktop/src/renderer/luke-guide.test.ts
@@ -50,7 +50,7 @@ function guideInput(overrides: Partial<LukeGuideInput> = {}): LukeGuideInput {
     update: idleUpdate(),
     voiceAvailable: true,
     microphoneStatus: "granted",
-    hotkey: { hotkey: "⌥Space", held: true },
+    hotkey: { hotkey: "⌥Space" },
     askKey: "⌥L",
     stopKey: "⌥S",
     ...overrides,
@@ -393,8 +393,6 @@ test("every adjustable setting is carried to the bridge call its row uses", asyn
     "showOnAllDisplays:true",
     "voice:alloy",
     "voiceCaptions:true",
-    // The first choice offered is "slow", which is the 0.75 multiple.
-    "voiceSpeed:0.75",
     // The first choice offered is "Conductor's default", which clears.
     "workspaceAgentDefaults:default",
   ]);

--- a/apps/desktop/src/renderer/luke-guide.ts
+++ b/apps/desktop/src/renderer/luke-guide.ts
@@ -87,7 +87,7 @@ export interface LukeGuideInput {
    * absence that is the developer's own choice — the shortcut was deleted —
    * and the fact must say so rather than blame another app.
    */
-  hotkey: { hotkey?: string; held: boolean; removed?: boolean };
+  hotkey: { hotkey?: string; removed?: boolean };
   /** The ask key labelled on the same terms, absent when none was registered. */
   askKey?: string;
   /** Whether the ask key's absence is a deleted shortcut, on the talk key's terms. */
@@ -115,12 +115,13 @@ function talkKeyFact(hotkey: LukeGuideInput["hotkey"]): AppGuideFact {
         "None is registered right now — another app may own the shortcut. The Settings tab's Keyboard shortcuts page shows its state.",
     };
   }
-  const use = hotkey.held
-    ? "hold to talk, let go to send; tap instead to keep the turn open"
-    : "press to talk, again to send, again to interrupt";
   return {
     label: "Talk key",
-    detail: `${hotkey.hotkey}, from any app: ${use}. A different chord can be recorded, the default restored, or the shortcut removed, in ${SHORTCUTS_PAGE}.`,
+    detail:
+      `${hotkey.hotkey}, from any app: press to listen, and press the stop key, or this key ` +
+      "again, to mute. Luke keeps the conversation while it lasts, so the next press picks it " +
+      "up rather than starting over; a voice chosen in Settings is heard from the next " +
+      `conversation on. A different chord can be recorded, the default restored, or the shortcut removed, in ${SHORTCUTS_PAGE}.`,
   };
 }
 
@@ -148,8 +149,9 @@ function askKeyFact(askKey: string | undefined, removed: boolean | undefined): A
 
 const MICROPHONE_DETAIL = {
   [MICROPHONE_STATUS.GRANTED]:
-    "Granted. The microphone opens only when the talk key takes a turn, sends nothing after " +
-    "the key comes up, and closes once the exchange settles. Typing to Luke never opens it.",
+    "Granted. The microphone is heard only from a talk key press until the stop key, or a " +
+    "second press, mutes it; muted, it sends nothing, and it closes with the conversation. " +
+    "Typing to Luke never unmutes it.",
   [MICROPHONE_STATUS.DENIED]:
     "Denied, so the talk key cannot capture. Typing to Luke still works: a typed ask opens no " +
     "capture device, and the reply is spoken either way. It can only be granted back in " +
@@ -502,8 +504,8 @@ export function buildLukeGuide(input: LukeGuideInput): AppGuideSnapshot {
                   : "Escape while Luke is speaking cuts the reply off and asks for nothing in " +
                     "its place. No system-wide stop key is registered right now — another app " +
                     "may own the shortcut.") +
-              " The talk key over a reply interrupts too, but takes the turn with the same " +
-              `press. A different stop chord can be recorded, the default restored, or the ` +
+              " The talk key over a reply opens the microphone instead, and Luke stops on his " +
+              `own when spoken over. A different stop chord can be recorded, the default restored, or the ` +
               `shortcut removed, in ${SHORTCUTS_PAGE}.`,
           },
           {
@@ -555,10 +557,11 @@ export function buildLukeGuide(input: LukeGuideInput): AppGuideSnapshot {
           {
             label: "How long a conversation lasts",
             detail:
-              "A call opens on the first press of the talk key or the first typed ask and " +
-              "is put away after a few minutes of silence. The next press picks the " +
-              "conversation back up: the recent exchange is kept in memory alone, never " +
-              "written to disk, so Luke remembers what was just said.",
+              "A conversation opens on the first press of the talk key, or when Luke has " +
+              "something to say, and is put away after a few quiet minutes. The next press " +
+              "picks it back up, seeded from the recent exchange in Luke's own record, so " +
+              "Luke remembers what was just said; a voice chosen in Settings is heard from " +
+              "that next conversation on.",
           },
         ]
       : [

--- a/apps/ios/Luke/VoiceSettingsSheet.swift
+++ b/apps/ios/Luke/VoiceSettingsSheet.swift
@@ -125,7 +125,6 @@ struct VoiceSettingsSheet: View {
             set: { value in
                 guard let step = RealtimeVoiceSpeed(multiplier: value), step != speed else { return }
                 speed = step
-                events.record(.settingUpdate(setting: .voiceSpeed, value: .set))
             }
         )
     }

--- a/apps/ios/LukeKit/Sources/LukeKit/AccountPreferencesClient.swift
+++ b/apps/ios/LukeKit/Sources/LukeKit/AccountPreferencesClient.swift
@@ -178,11 +178,9 @@ extension DeviceSettingsSnapshot {
 
         var voice = RealtimeVoice.default
         if let rawVoice = wire[AccountPreferenceWireField.voice] {
-            guard let name = rawVoice as? String else { return nil }
-            // The desktop chooses from GPT Live's voices, more than this app's
-            // Realtime set names; one it does not know is the default here, not
-            // a refusal of the whole snapshot the workspace defaults ride in.
-            voice = RealtimeVoice(rawValue: name) ?? .default
+            guard let name = rawVoice as? String, let parsed = RealtimeVoice(rawValue: name)
+            else { return nil }
+            voice = parsed
         }
 
         var speed = RealtimeVoiceSpeed.default

--- a/apps/ios/LukeKit/Sources/LukeKit/AccountPreferencesClient.swift
+++ b/apps/ios/LukeKit/Sources/LukeKit/AccountPreferencesClient.swift
@@ -178,9 +178,11 @@ extension DeviceSettingsSnapshot {
 
         var voice = RealtimeVoice.default
         if let rawVoice = wire[AccountPreferenceWireField.voice] {
-            guard let name = rawVoice as? String, let parsed = RealtimeVoice(rawValue: name)
-            else { return nil }
-            voice = parsed
+            guard let name = rawVoice as? String else { return nil }
+            // The desktop chooses from GPT Live's voices, more than this app's
+            // Realtime set names; one it does not know is the default here, not
+            // a refusal of the whole snapshot the workspace defaults ride in.
+            voice = RealtimeVoice(rawValue: name) ?? .default
         }
 
         var speed = RealtimeVoiceSpeed.default

--- a/apps/ios/LukeKit/Sources/LukeKit/ProductEvents.swift
+++ b/apps/ios/LukeKit/Sources/LukeKit/ProductEvents.swift
@@ -50,7 +50,6 @@ public enum ProductSessionAction: String, Sendable {
 /// The subset of the shared vocabulary's `APP_SETTING_ID` this app can change.
 public enum ProductSettingID: String, Sendable {
     case voice
-    case voiceSpeed = "voice_speed"
 }
 
 /// The shape of a setting's change, never its value.

--- a/apps/ios/LukeKit/Tests/LukeKitTests/AccountPreferencesClientTests.swift
+++ b/apps/ios/LukeKit/Tests/LukeKitTests/AccountPreferencesClientTests.swift
@@ -70,10 +70,7 @@ final class AccountPreferencesClientTests: XCTestCase {
 
     func testAccountPreferencesWireRejectsUnknownAndInvalidHostedValues() {
         XCTAssertNil(DeviceSettingsSnapshot(accountPreferencesWire: ["futureSetting": "ignored"]))
-        XCTAssertNil(DeviceSettingsSnapshot(accountPreferencesWire: ["voice": 7]))
-        XCTAssertEqual(
-            DeviceSettingsSnapshot(accountPreferencesWire: ["voice": "gleam"])?.voice, .default
-        )
+        XCTAssertNil(DeviceSettingsSnapshot(accountPreferencesWire: ["voice": "baritone"]))
         XCTAssertNil(DeviceSettingsSnapshot(accountPreferencesWire: ["voiceSpeed": true]))
         XCTAssertNil(
             DeviceSettingsSnapshot(accountPreferencesWire: [

--- a/apps/ios/LukeKit/Tests/LukeKitTests/AccountPreferencesClientTests.swift
+++ b/apps/ios/LukeKit/Tests/LukeKitTests/AccountPreferencesClientTests.swift
@@ -70,7 +70,10 @@ final class AccountPreferencesClientTests: XCTestCase {
 
     func testAccountPreferencesWireRejectsUnknownAndInvalidHostedValues() {
         XCTAssertNil(DeviceSettingsSnapshot(accountPreferencesWire: ["futureSetting": "ignored"]))
-        XCTAssertNil(DeviceSettingsSnapshot(accountPreferencesWire: ["voice": "baritone"]))
+        XCTAssertNil(DeviceSettingsSnapshot(accountPreferencesWire: ["voice": 7]))
+        XCTAssertEqual(
+            DeviceSettingsSnapshot(accountPreferencesWire: ["voice": "gleam"])?.voice, .default
+        )
         XCTAssertNil(DeviceSettingsSnapshot(accountPreferencesWire: ["voiceSpeed": true]))
         XCTAssertNil(
             DeviceSettingsSnapshot(accountPreferencesWire: [

--- a/apps/ios/LukeKit/Tests/LukeKitTests/ProductEventsTests.swift
+++ b/apps/ios/LukeKit/Tests/LukeKitTests/ProductEventsTests.swift
@@ -46,11 +46,11 @@ final class ProductEventsTests: XCTestCase {
             ["provider_id": "conductor", "session_action": "message_send"]
         )
 
-        let update = ProductEvent.settingUpdate(setting: .voiceSpeed, value: .set)
+        let update = ProductEvent.settingUpdate(setting: .voice, value: .set)
         XCTAssertEqual(update.name, "setting:update")
         XCTAssertEqual(
             update.wireProperties(appVersion: "0.1.1") as? [String: String],
-            ["setting_id": "voice_speed", "setting_value": "set"]
+            ["setting_id": "voice", "setting_value": "set"]
         )
         XCTAssertEqual(ProductEvent.settingsReset.name, "settings:reset")
         XCTAssertTrue(ProductEvent.settingsReset.wireProperties(appVersion: "0.1.1").isEmpty)

--- a/apps/ios/LukeWatch/WatchVoiceSettingsView.swift
+++ b/apps/ios/LukeWatch/WatchVoiceSettingsView.swift
@@ -94,7 +94,6 @@ struct WatchVoiceSettingsView: View {
             set: { chosen in
                 guard chosen != speed else { return }
                 speed = chosen
-                events.record(.settingUpdate(setting: .voiceSpeed, value: .set))
             }
         )
     }

--- a/apps/web/api/account/preferences.ts
+++ b/apps/web/api/account/preferences.ts
@@ -14,7 +14,6 @@ import { hostedVaultRoute } from "../../server/hosted/vault-route.js";
 function rowPreferences(
   preference: {
     voice: string | null;
-    voiceSpeed: number | null;
     defaultWorkspaceProvider: string | null;
   },
   workspacePreferences: readonly {
@@ -45,7 +44,6 @@ function rowPreferences(
   return (
     accountPreferencesFromStored({
       ...(preference.voice ? { voice: preference.voice } : undefined),
-      ...(preference.voiceSpeed !== null ? { voiceSpeed: preference.voiceSpeed } : undefined),
       ...(preference.defaultWorkspaceProvider
         ? { defaultWorkspaceProvider: preference.defaultWorkspaceProvider }
         : undefined),
@@ -113,7 +111,6 @@ export default hostedVaultRoute(async ({ request, resolveUserId }) => {
           const [preference] = await transaction
             .select({
               voice: accountPreference.voice,
-              voiceSpeed: accountPreference.voiceSpeed,
               defaultWorkspaceProvider: accountPreference.defaultWorkspaceProvider,
               updatedAt: accountPreference.updatedAt,
             })
@@ -155,7 +152,6 @@ export default hostedVaultRoute(async ({ request, resolveUserId }) => {
           .values({
             userId,
             voice: preferences.voice ?? null,
-            voiceSpeed: preferences.voiceSpeed ?? null,
             defaultWorkspaceProvider: preferences.defaultWorkspaceProvider ?? null,
             updatedAt,
           })
@@ -163,7 +159,6 @@ export default hostedVaultRoute(async ({ request, resolveUserId }) => {
             target: accountPreference.userId,
             set: {
               voice: preferences.voice ?? null,
-              voiceSpeed: preferences.voiceSpeed ?? null,
               defaultWorkspaceProvider: preferences.defaultWorkspaceProvider ?? null,
               updatedAt,
             },

--- a/apps/web/api/account/preferences.ts
+++ b/apps/web/api/account/preferences.ts
@@ -1,4 +1,4 @@
-import type { AccountPreferences } from "@sidecar/settings";
+import { isRealtimeVoiceSpeed } from "@sidecar/realtime";
 import { accountPreferencesFromStored } from "@sidecar/settings";
 import { eq } from "drizzle-orm";
 import { getDatabase } from "../../server/db/index.js";
@@ -6,6 +6,7 @@ import { accountPreference, accountWorkspacePreference } from "../../server/db/s
 import {
   type AccountPreferencesReadOptions,
   type AccountPreferencesWriteOptions,
+  type HostedAccountPreferences,
   handleAccountPreferencesRead,
   handleAccountPreferencesWrite,
 } from "../../server/hosted/account-preferences.js";
@@ -14,6 +15,7 @@ import { hostedVaultRoute } from "../../server/hosted/vault-route.js";
 function rowPreferences(
   preference: {
     voice: string | null;
+    voiceSpeed: number | null;
     defaultWorkspaceProvider: string | null;
   },
   workspacePreferences: readonly {
@@ -23,7 +25,7 @@ function rowPreferences(
     model: string | null;
     effort: string | null;
   }[],
-): AccountPreferences {
+): HostedAccountPreferences {
   const workspaceProjectDefaults: Record<string, string> = {};
   const workspaceAgentDefaults: Record<string, { agent: string; model?: string; effort?: string }> =
     {};
@@ -41,7 +43,7 @@ function rowPreferences(
     }
   }
 
-  return (
+  const shared =
     accountPreferencesFromStored({
       ...(preference.voice ? { voice: preference.voice } : undefined),
       ...(preference.defaultWorkspaceProvider
@@ -51,11 +53,20 @@ function rowPreferences(
         ? { workspaceProjectDefaults }
         : undefined),
       ...(Object.keys(workspaceAgentDefaults).length > 0 ? { workspaceAgentDefaults } : undefined),
-    }) ?? {}
-  );
+    }) ?? {};
+  return {
+    ...shared,
+    ...(isRealtimeVoiceSpeed(preference.voiceSpeed)
+      ? { voiceSpeed: preference.voiceSpeed }
+      : undefined),
+  };
 }
 
-function workspacePreferenceRows(userId: string, preferences: AccountPreferences, updatedAt: Date) {
+function workspacePreferenceRows(
+  userId: string,
+  preferences: HostedAccountPreferences,
+  updatedAt: Date,
+) {
   const projects = preferences.workspaceProjectDefaults ?? {};
   const agents = preferences.workspaceAgentDefaults ?? {};
   const rows = new Map<
@@ -111,6 +122,7 @@ export default hostedVaultRoute(async ({ request, resolveUserId }) => {
           const [preference] = await transaction
             .select({
               voice: accountPreference.voice,
+              voiceSpeed: accountPreference.voiceSpeed,
               defaultWorkspaceProvider: accountPreference.defaultWorkspaceProvider,
               updatedAt: accountPreference.updatedAt,
             })
@@ -152,6 +164,7 @@ export default hostedVaultRoute(async ({ request, resolveUserId }) => {
           .values({
             userId,
             voice: preferences.voice ?? null,
+            voiceSpeed: preferences.voiceSpeed ?? null,
             defaultWorkspaceProvider: preferences.defaultWorkspaceProvider ?? null,
             updatedAt,
           })
@@ -159,6 +172,7 @@ export default hostedVaultRoute(async ({ request, resolveUserId }) => {
             target: accountPreference.userId,
             set: {
               voice: preferences.voice ?? null,
+              voiceSpeed: preferences.voiceSpeed ?? null,
               defaultWorkspaceProvider: preferences.defaultWorkspaceProvider ?? null,
               updatedAt,
             },

--- a/apps/web/server/hosted/account-preferences.ts
+++ b/apps/web/server/hosted/account-preferences.ts
@@ -1,31 +1,34 @@
-import { type AccountPreferences, accountPreferencesFromWire } from "@sidecar/settings";
+import { isRealtimeVoiceSpeed, type RealtimeVoiceSpeed } from "@sidecar/realtime";
+import {
+  type AccountPreferences,
+  accountPreferencesFromWire,
+  RETIRED_ACCOUNT_PREFERENCE_FIELD,
+} from "@sidecar/settings";
 import { isRecord, type UnparsedWireValue } from "@sidecar/wire";
 import { errorResponse, HOSTED_API_ERROR, HOSTED_HTTP_STATUS, jsonResponse } from "./http.js";
 
 /**
- * Fields a client of an earlier contract still writes and this build no
- * longer keeps. The phone syncs its Realtime pace under this key until it
- * moves to Live; the desktop has no pace and the row no longer carries one,
- * so the key is dropped at the door rather than refusing the phone's whole
- * snapshot. Removing an entry here is the phone's follow-up, not a cleanup.
+ * The hosted snapshot: the preferences every device shares, and the phone's
+ * Realtime pace, which the desktop no longer has and its reader drops. The
+ * pace is kept here for the phone alone until it moves to Live, so a phone
+ * that syncs its pace today keeps it across its own devices meanwhile.
  */
-const RETIRED_ACCOUNT_PREFERENCE_FIELD = {
-  VOICE_SPEED: "voiceSpeed",
-} as const;
+export type HostedAccountPreferences = AccountPreferences & {
+  [RETIRED_ACCOUNT_PREFERENCE_FIELD.VOICE_SPEED]?: RealtimeVoiceSpeed;
+};
 
-const RETIRED_ACCOUNT_PREFERENCE_FIELDS: ReadonlySet<string> = new Set(
-  Object.values(RETIRED_ACCOUNT_PREFERENCE_FIELD),
-);
+type PhoneVoiceSpeed = { valid: true; value: RealtimeVoiceSpeed | undefined } | { valid: false };
 
-function withoutRetiredFields(preferences: UnparsedWireValue): UnparsedWireValue {
-  if (!isRecord(preferences)) return preferences;
-  return Object.fromEntries(
-    Object.entries(preferences).filter(([field]) => !RETIRED_ACCOUNT_PREFERENCE_FIELDS.has(field)),
-  );
+/** The phone's pace out of the raw snapshot: absent or null is none, and anything but a pace the Realtime contract offers refuses the write. */
+function phoneVoiceSpeed(preferences: UnparsedWireValue): PhoneVoiceSpeed {
+  if (!isRecord(preferences)) return { valid: true, value: undefined };
+  const raw = preferences[RETIRED_ACCOUNT_PREFERENCE_FIELD.VOICE_SPEED];
+  if (raw === undefined || raw === null) return { valid: true, value: undefined };
+  return isRealtimeVoiceSpeed(raw) ? { valid: true, value: raw } : { valid: false };
 }
 
 export interface AccountPreferencesRow {
-  preferences: AccountPreferences;
+  preferences: HostedAccountPreferences;
   updatedAt: Date;
 }
 
@@ -38,7 +41,7 @@ export interface AccountPreferencesReadOptions {
 export interface AccountPreferencesWriteOptions {
   request: Request;
   resolveUserId: (request: Request) => Promise<string | undefined>;
-  writePreferences: (userId: string, preferences: AccountPreferences) => Promise<Date>;
+  writePreferences: (userId: string, preferences: HostedAccountPreferences) => Promise<Date>;
 }
 
 export async function handleAccountPreferencesRead(
@@ -94,10 +97,17 @@ export async function handleAccountPreferencesWrite(
     return errorResponse(HOSTED_HTTP_STATUS.BAD_REQUEST, HOSTED_API_ERROR.INVALID_REQUEST);
   }
 
-  const incoming = accountPreferencesFromWire(withoutRetiredFields(body.preferences));
-  if (incoming === undefined) {
+  const shared = accountPreferencesFromWire(body.preferences);
+  const pace = phoneVoiceSpeed(body.preferences);
+  if (shared === undefined || !pace.valid) {
     return errorResponse(HOSTED_HTTP_STATUS.BAD_REQUEST, HOSTED_API_ERROR.INVALID_REQUEST);
   }
+  const incoming: HostedAccountPreferences = {
+    ...shared,
+    ...(pace.value !== undefined
+      ? { [RETIRED_ACCOUNT_PREFERENCE_FIELD.VOICE_SPEED]: pace.value }
+      : undefined),
+  };
 
   const updatedAt = await writePreferences(userId, incoming);
 

--- a/apps/web/server/hosted/account-preferences.ts
+++ b/apps/web/server/hosted/account-preferences.ts
@@ -2,6 +2,28 @@ import { type AccountPreferences, accountPreferencesFromWire } from "@sidecar/se
 import { isRecord, type UnparsedWireValue } from "@sidecar/wire";
 import { errorResponse, HOSTED_API_ERROR, HOSTED_HTTP_STATUS, jsonResponse } from "./http.js";
 
+/**
+ * Fields a client of an earlier contract still writes and this build no
+ * longer keeps. The phone syncs its Realtime pace under this key until it
+ * moves to Live; the desktop has no pace and the row no longer carries one,
+ * so the key is dropped at the door rather than refusing the phone's whole
+ * snapshot. Removing an entry here is the phone's follow-up, not a cleanup.
+ */
+const RETIRED_ACCOUNT_PREFERENCE_FIELD = {
+  VOICE_SPEED: "voiceSpeed",
+} as const;
+
+const RETIRED_ACCOUNT_PREFERENCE_FIELDS: ReadonlySet<string> = new Set(
+  Object.values(RETIRED_ACCOUNT_PREFERENCE_FIELD),
+);
+
+function withoutRetiredFields(preferences: UnparsedWireValue): UnparsedWireValue {
+  if (!isRecord(preferences)) return preferences;
+  return Object.fromEntries(
+    Object.entries(preferences).filter(([field]) => !RETIRED_ACCOUNT_PREFERENCE_FIELDS.has(field)),
+  );
+}
+
 export interface AccountPreferencesRow {
   preferences: AccountPreferences;
   updatedAt: Date;
@@ -72,7 +94,7 @@ export async function handleAccountPreferencesWrite(
     return errorResponse(HOSTED_HTTP_STATUS.BAD_REQUEST, HOSTED_API_ERROR.INVALID_REQUEST);
   }
 
-  const incoming = accountPreferencesFromWire(body.preferences);
+  const incoming = accountPreferencesFromWire(withoutRetiredFields(body.preferences));
   if (incoming === undefined) {
     return errorResponse(HOSTED_HTTP_STATUS.BAD_REQUEST, HOSTED_API_ERROR.INVALID_REQUEST);
   }

--- a/apps/web/tests/account-preferences.test.ts
+++ b/apps/web/tests/account-preferences.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { REALTIME_VOICE, REALTIME_VOICE_SPEED } from "@sidecar/realtime";
+import { REALTIME_VOICE } from "@sidecar/realtime";
 import { PROVIDER_ID } from "@sidecar/session";
 import type { AccountPreferences } from "@sidecar/settings";
 import type { WireBoundaryInput } from "@sidecar/wire";
@@ -72,7 +72,7 @@ test("reading account preferences returns the stored snapshot", async () => {
       readPreferences: async () => ({
         preferences: {
           voice: REALTIME_VOICE.CORAL,
-          voiceSpeed: REALTIME_VOICE_SPEED.QUICK,
+          defaultWorkspaceProvider: PROVIDER_ID.CONDUCTOR,
         },
         updatedAt: NOW,
       }),
@@ -81,7 +81,7 @@ test("reading account preferences returns the stored snapshot", async () => {
 
   assert.equal(response.status, 200);
   assert.deepEqual(await response.json(), {
-    preferences: { voice: REALTIME_VOICE.CORAL, voiceSpeed: REALTIME_VOICE_SPEED.QUICK },
+    preferences: { voice: REALTIME_VOICE.CORAL, defaultWorkspaceProvider: PROVIDER_ID.CONDUCTOR },
     updatedAt: NOW.getTime(),
   });
 });
@@ -128,7 +128,6 @@ test("writing account preferences validates and stores a full snapshot", async (
       request: writeRequest({
         preferences: {
           voice: REALTIME_VOICE.MARIN,
-          voiceSpeed: REALTIME_VOICE_SPEED.FAST,
           defaultWorkspaceProvider: PROVIDER_ID.CONDUCTOR,
           workspaceProjectDefaults: { conductor: "project-1" },
           workspaceAgentDefaults: {
@@ -148,7 +147,6 @@ test("writing account preferences validates and stores a full snapshot", async (
     userId: "user-1",
     preferences: {
       voice: REALTIME_VOICE.MARIN,
-      voiceSpeed: REALTIME_VOICE_SPEED.FAST,
       defaultWorkspaceProvider: PROVIDER_ID.CONDUCTOR,
       workspaceProjectDefaults: { conductor: "project-1" },
       workspaceAgentDefaults: {
@@ -207,4 +205,24 @@ test("writes reject unknown or invalid preferences instead of storing arbitrary 
     }),
   );
   assert.equal(trimmedMap.status, 400);
+});
+
+test("a phone's retired pace field is dropped at the door rather than refusing its snapshot", async () => {
+  let stored: { userId: string; preferences: AccountPreferences } | undefined;
+
+  const response = await handleAccountPreferencesWrite(
+    writeOptions({
+      request: writeRequest({
+        preferences: { voice: REALTIME_VOICE.MARIN, voiceSpeed: 1.25 },
+      }),
+      writePreferences: async (userId, preferences) => {
+        stored = { userId, preferences };
+        return NOW;
+      },
+    }),
+  );
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(stored?.preferences, { voice: REALTIME_VOICE.MARIN });
+  assert.deepEqual(Object.keys((await response.json()).preferences), ["voice"]);
 });

--- a/apps/web/tests/account-preferences.test.ts
+++ b/apps/web/tests/account-preferences.test.ts
@@ -1,9 +1,9 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { REALTIME_VOICE } from "@sidecar/realtime";
+import { REALTIME_VOICE, REALTIME_VOICE_SPEED } from "@sidecar/realtime";
 import { PROVIDER_ID } from "@sidecar/session";
-import type { AccountPreferences } from "@sidecar/settings";
 import type { WireBoundaryInput } from "@sidecar/wire";
+import type { HostedAccountPreferences } from "../server/hosted/account-preferences";
 import {
   type AccountPreferencesRow,
   handleAccountPreferencesRead,
@@ -46,7 +46,7 @@ function writeOptions(
   return {
     request: writeRequest({ preferences: { voice: REALTIME_VOICE.SAGE } }),
     resolveUserId: async () => "user-1",
-    writePreferences: async (_userId: string, _preferences: AccountPreferences) => NOW,
+    writePreferences: async (_userId: string, _preferences: HostedAccountPreferences) => NOW,
     ...overrides,
   };
 }
@@ -72,7 +72,7 @@ test("reading account preferences returns the stored snapshot", async () => {
       readPreferences: async () => ({
         preferences: {
           voice: REALTIME_VOICE.CORAL,
-          defaultWorkspaceProvider: PROVIDER_ID.CONDUCTOR,
+          voiceSpeed: REALTIME_VOICE_SPEED.QUICK,
         },
         updatedAt: NOW,
       }),
@@ -81,7 +81,7 @@ test("reading account preferences returns the stored snapshot", async () => {
 
   assert.equal(response.status, 200);
   assert.deepEqual(await response.json(), {
-    preferences: { voice: REALTIME_VOICE.CORAL, defaultWorkspaceProvider: PROVIDER_ID.CONDUCTOR },
+    preferences: { voice: REALTIME_VOICE.CORAL, voiceSpeed: REALTIME_VOICE_SPEED.QUICK },
     updatedAt: NOW.getTime(),
   });
 });
@@ -121,13 +121,14 @@ test("the account preferences write gate order is method, token, then body", asy
 });
 
 test("writing account preferences validates and stores a full snapshot", async () => {
-  let stored: { userId: string; preferences: AccountPreferences } | undefined;
+  let stored: { userId: string; preferences: HostedAccountPreferences } | undefined;
 
   const response = await handleAccountPreferencesWrite(
     writeOptions({
       request: writeRequest({
         preferences: {
           voice: REALTIME_VOICE.MARIN,
+          voiceSpeed: REALTIME_VOICE_SPEED.FAST,
           defaultWorkspaceProvider: PROVIDER_ID.CONDUCTOR,
           workspaceProjectDefaults: { conductor: "project-1" },
           workspaceAgentDefaults: {
@@ -147,6 +148,7 @@ test("writing account preferences validates and stores a full snapshot", async (
     userId: "user-1",
     preferences: {
       voice: REALTIME_VOICE.MARIN,
+      voiceSpeed: REALTIME_VOICE_SPEED.FAST,
       defaultWorkspaceProvider: PROVIDER_ID.CONDUCTOR,
       workspaceProjectDefaults: { conductor: "project-1" },
       workspaceAgentDefaults: {
@@ -161,7 +163,7 @@ test("writing account preferences validates and stores a full snapshot", async (
 });
 
 test("omitted and null account preference fields clear the stored value", async () => {
-  let stored: AccountPreferences | undefined;
+  let stored: HostedAccountPreferences | undefined;
 
   const response = await handleAccountPreferencesWrite(
     writeOptions({
@@ -207,22 +209,30 @@ test("writes reject unknown or invalid preferences instead of storing arbitrary 
   assert.equal(trimmedMap.status, 400);
 });
 
-test("a phone's retired pace field is dropped at the door rather than refusing its snapshot", async () => {
-  let stored: { userId: string; preferences: AccountPreferences } | undefined;
-
-  const response = await handleAccountPreferencesWrite(
+test("the phone's pace is kept beside the shared snapshot and refused outside its contract", async () => {
+  let stored: HostedAccountPreferences | undefined;
+  const writeOptionsFor = (preferences: WireBoundaryInput) =>
     writeOptions({
-      request: writeRequest({
-        preferences: { voice: REALTIME_VOICE.MARIN, voiceSpeed: 1.25 },
-      }),
-      writePreferences: async (userId, preferences) => {
-        stored = { userId, preferences };
+      request: writeRequest({ preferences }),
+      writePreferences: async (_userId: string, preferences: HostedAccountPreferences) => {
+        stored = preferences;
         return NOW;
       },
-    }),
-  );
+    });
 
-  assert.equal(response.status, 200);
-  assert.deepEqual(stored?.preferences, { voice: REALTIME_VOICE.MARIN });
-  assert.deepEqual(Object.keys((await response.json()).preferences), ["voice"]);
+  const desktop = await handleAccountPreferencesWrite(
+    writeOptionsFor({ voice: REALTIME_VOICE.MARIN }),
+  );
+  assert.equal(desktop.status, 200);
+  assert.deepEqual(Object.keys(stored ?? {}), ["voice"]);
+
+  const phone = await handleAccountPreferencesWrite(
+    writeOptionsFor({ voice: REALTIME_VOICE.MARIN, voiceSpeed: REALTIME_VOICE_SPEED.SLOW }),
+  );
+  assert.equal(phone.status, 200);
+  assert.equal(stored?.voiceSpeed, REALTIME_VOICE_SPEED.SLOW);
+
+  const badPace = await handleAccountPreferencesWrite(writeOptionsFor({ voiceSpeed: 9 }));
+  assert.equal(badPace.status, 400);
+  assert.equal((await badPace.json()).error, HOSTED_API_ERROR.INVALID_REQUEST);
 });

--- a/packages/guide/src/app-settings.ts
+++ b/packages/guide/src/app-settings.ts
@@ -7,7 +7,6 @@
  */
 export const APP_SETTING_ID = {
   VOICE: "voice",
-  VOICE_SPEED: "voice_speed",
   VOICE_CAPTIONS: "voice_captions",
   DUCK_OTHER_MEDIA: "duck_other_media",
   PREFER_BUILT_IN_MICROPHONE: "prefer_built_in_microphone",

--- a/packages/host/package.json
+++ b/packages/host/package.json
@@ -26,7 +26,6 @@
     "@sidecar/live": "workspace:*",
     "@sidecar/memory": "workspace:*",
     "@sidecar/providers": "workspace:*",
-    "@sidecar/realtime": "workspace:*",
     "@sidecar/runtime": "workspace:*",
     "@sidecar/session": "workspace:*",
     "@sidecar/settings": "workspace:*",

--- a/packages/host/src/account-preferences-client.test.ts
+++ b/packages/host/src/account-preferences-client.test.ts
@@ -4,7 +4,7 @@ import type { AccountPreferences } from "@sidecar/settings";
 import { AccountPreferencesClient } from "./account-preferences-client.js";
 
 const PREFERENCES_ANSWER = {
-  preferences: { voice: "marin", voiceSpeed: 1.5 },
+  preferences: { voice: "marin", defaultWorkspaceProvider: "conductor" },
   updatedAt: 1_800_000_000_000,
 };
 
@@ -72,7 +72,7 @@ test("writes account preferences as a full snapshot", async () => {
 
   const answer = await client({ fetch: fetchLike }).writePreferences({
     voice: "marin",
-    voiceSpeed: 1.5,
+    defaultWorkspaceProvider: "conductor",
   });
   assert.deepEqual(answer, {
     preferences: PREFERENCES_ANSWER.preferences,
@@ -84,7 +84,7 @@ test("writes account preferences as a full snapshot", async () => {
   assert.equal(request?.init?.method, "PUT");
   assert.equal(new Headers(request?.init?.headers).get("content-type"), "application/json");
   assert.deepEqual(JSON.parse(String(request?.init?.body)), {
-    preferences: { voice: "marin", voiceSpeed: 1.5 },
+    preferences: { voice: "marin", defaultWorkspaceProvider: "conductor" },
   });
 });
 

--- a/packages/host/src/compose-host.ts
+++ b/packages/host/src/compose-host.ts
@@ -92,7 +92,6 @@ export function composeHost(options: HostSeams): Host {
     },
     applyVoiceCredential: account.applyVoiceCredential,
     setVoice: (voice) => account.voiceCapabilities.liveSessions?.setVoice(voice),
-    setVoiceSpeed: (speed) => account.voiceCapabilities.realtimeCredentials?.setSpeed(speed),
     reconcileSpeech: () => {
       void live.service.reconcile();
     },

--- a/packages/host/src/compose-settings.ts
+++ b/packages/host/src/compose-settings.ts
@@ -57,7 +57,6 @@ interface SettingsLinks {
   refreshAccount: () => Promise<void>;
   applyVoiceCredential: () => Promise<void>;
   setVoice: (voice: StoredSettings["voice"]) => void;
-  setVoiceSpeed: (speed: StoredSettings["voiceSpeed"]) => void;
   reconcileSpeech: () => void;
   refreshSupersetWorkspaceHost: () => Promise<void>;
   broadcastWorkspaceProjects: () => Promise<void>;
@@ -303,7 +302,6 @@ export function composeSettings(dependencies: SettingsDependencies): SettingsCom
 
   const sideEffects = hostSettingSideEffects({
     setVoice: (voice) => links.get().setVoice(voice),
-    setVoiceSpeed: (speed) => links.get().setVoiceSpeed(speed),
     applyVoiceCredential: () => links.get().applyVoiceCredential(),
     reconcileSpeech: () => links.get().reconcileSpeech(),
     applyVaultSync: (syncProviderKeys) => void vaultSync.apply(syncProviderKeys, { claim: true }),

--- a/packages/host/src/settings-side-effects.ts
+++ b/packages/host/src/settings-side-effects.ts
@@ -25,7 +25,6 @@ const noHostSettingSideEffect: HostSettingSideEffect = () => {};
 /** What the host's own side effects reach in the concerns around them. */
 export interface HostSettingSideEffectDependencies {
   setVoice: (voice: StoredAppSettings["voice"]) => void;
-  setVoiceSpeed: (speed: StoredAppSettings["voiceSpeed"]) => void;
   applyVoiceCredential: () => Promise<void>;
   reconcileSpeech: () => void;
   applyVaultSync: (syncProviderKeys: boolean) => void;
@@ -49,8 +48,6 @@ export function hostSettingSideEffects(dependencies: HostSettingSideEffectDepend
     [SETTING_SIDE_EFFECT.STOP_HOTKEY]: noHostSettingSideEffect,
     [SETTING_SIDE_EFFECT.MEDIA_DUCK]: noHostSettingSideEffect,
     [SETTING_SIDE_EFFECT.VOICE]: ({ settings }) => dependencies.setVoice(settings.voice),
-    [SETTING_SIDE_EFFECT.VOICE_SPEED]: ({ settings }) =>
-      dependencies.setVoiceSpeed(settings.voiceSpeed),
     [SETTING_SIDE_EFFECT.VOICE_SOURCE]: async () => {
       await dependencies.applyVoiceCredential();
       await dependencies.emitSettings();

--- a/packages/host/src/settings-store.test.ts
+++ b/packages/host/src/settings-store.test.ts
@@ -5,7 +5,7 @@ import test from "node:test";
 import { CREDENTIAL_PROVIDER_ID, type CredentialProviderId } from "@sidecar/credentials";
 import { ACCOUNT_STATUS } from "@sidecar/credentials/snapshot";
 import { CREDENTIAL_SOURCE, SECRET_STORAGE } from "@sidecar/credentials/vocabulary";
-import { REALTIME_DEFAULTS, REALTIME_VOICE, REALTIME_VOICE_SPEED } from "@sidecar/realtime";
+import { LIVE_DEFAULTS, LIVE_VOICE } from "@sidecar/live";
 import { temporaryDirectory } from "@sidecar/runtime/testing";
 import {
   PROVIDER_ID,
@@ -197,8 +197,7 @@ async function readSettingsFile(directory: string): Promise<string> {
 const SAMPLE_VALUE = {
   openAtLogin: false,
   showInDock: true,
-  voice: REALTIME_VOICE.MARIN,
-  voiceSpeed: REALTIME_VOICE_SPEED.QUICK,
+  voice: LIVE_VOICE.MARIN,
   voiceCaptions: true,
   voiceHotkey: "Shift+Command+L",
   askHotkey: "Control+Alt+K",
@@ -226,7 +225,6 @@ const SAMPLE_VALUE = {
  */
 const RESOLVED_FIELDS = new Set<AppSettingField>([
   APP_SETTING_SCHEMA.voice.field,
-  APP_SETTING_SCHEMA.voiceSpeed.field,
   APP_SETTING_SCHEMA.voiceSource.field,
   APP_SETTING_SCHEMA.formFactor.field,
 ]);
@@ -826,20 +824,20 @@ test("decides the Dock icon from the file alone, never the keychain", async (t) 
 test("prefers the chosen voice over the environment, and the environment over the default", async (t) => {
   const directory = temporaryDirectory(t, "luke-settings-");
   const store = storeIn(directory, {
-    environment: { LUKE_REALTIME_VOICE: REALTIME_VOICE.SAGE },
+    environment: { LUKE_LIVE_VOICE: LIVE_VOICE.SAGE },
   });
 
-  assert.equal(appSettingsView(await store.snapshot()).voice, REALTIME_VOICE.SAGE);
+  assert.equal(appSettingsView(await store.snapshot()).voice, LIVE_VOICE.SAGE);
   // The environment names the voice only until the user does, so it is
   // SAFETY: Fixture value matches the narrowed runtime shape this test exercises.
   // reported in the snapshot but never as something the user stored.
   assert.equal(await store.get(APP_SETTING_SCHEMA.voice.field), undefined);
 
-  await store.set(APP_SETTING_SCHEMA.voice.field, REALTIME_VOICE.MARIN);
-  assert.equal(appSettingsView(await store.snapshot()).voice, REALTIME_VOICE.MARIN);
+  await store.set(APP_SETTING_SCHEMA.voice.field, LIVE_VOICE.MARIN);
+  assert.equal(appSettingsView(await store.snapshot()).voice, LIVE_VOICE.MARIN);
 
   await store.set(APP_SETTING_SCHEMA.voice.field, undefined);
-  assert.equal(appSettingsView(await store.snapshot()).voice, REALTIME_VOICE.SAGE);
+  assert.equal(appSettingsView(await store.snapshot()).voice, LIVE_VOICE.SAGE);
 });
 
 test("ignores a stored or environment voice this build does not offer", async (t) => {
@@ -848,55 +846,24 @@ test("ignores a stored or environment voice this build does not offer", async (t
     path.join(directory, SETTINGS_FILE_NAME),
     JSON.stringify({ version: 2, apiKeys: {}, voice: "baritone" }),
   );
-  const store = storeIn(directory, { environment: { LUKE_REALTIME_VOICE: "baritone" } });
+  const store = storeIn(directory, { environment: { LUKE_LIVE_VOICE: "baritone" } });
 
   assert.equal(await store.get(APP_SETTING_SCHEMA.voice.field), undefined);
-  assert.equal(appSettingsView(await store.snapshot()).voice, REALTIME_DEFAULTS.VOICE);
-});
-
-test("prefers the chosen pace over the environment, and the environment over the default", async (t) => {
-  const directory = temporaryDirectory(t, "luke-settings-");
-  const store = storeIn(directory, {
-    environment: { LUKE_REALTIME_SPEED: String(REALTIME_VOICE_SPEED.SLOW) },
-  });
-
-  assert.equal(appSettingsView(await store.snapshot()).voiceSpeed, REALTIME_VOICE_SPEED.SLOW);
-  assert.equal(await store.get(APP_SETTING_SCHEMA.voiceSpeed.field), undefined);
-
-  await store.set(APP_SETTING_SCHEMA.voiceSpeed.field, REALTIME_VOICE_SPEED.FAST);
-  assert.equal(appSettingsView(await store.snapshot()).voiceSpeed, REALTIME_VOICE_SPEED.FAST);
-
-  await store.set(APP_SETTING_SCHEMA.voiceSpeed.field, undefined);
-  assert.equal(appSettingsView(await store.snapshot()).voiceSpeed, REALTIME_VOICE_SPEED.SLOW);
-});
-
-test("ignores a stored or environment pace this build does not offer", async (t) => {
-  const directory = temporaryDirectory(t, "luke-settings-");
-  await fs.writeFile(
-    path.join(directory, SETTINGS_FILE_NAME),
-    JSON.stringify({ version: 2, apiKeys: {}, voiceSpeed: 3 }),
-  );
-  const store = storeIn(directory, { environment: { LUKE_REALTIME_SPEED: "0.1" } });
-
-  assert.equal(await store.get(APP_SETTING_SCHEMA.voiceSpeed.field), undefined);
-  assert.equal(appSettingsView(await store.snapshot()).voiceSpeed, REALTIME_DEFAULTS.SPEED);
+  assert.equal(appSettingsView(await store.snapshot()).voice, LIVE_DEFAULTS.VOICE);
 });
 
 test("account preferences extraction excludes resolved defaults and local-only preferences", async (t) => {
   const directory = temporaryDirectory(t, "luke-settings-");
   const store = storeIn(directory, {
-    environment: {
-      LUKE_REALTIME_VOICE: REALTIME_VOICE.SAGE,
-      LUKE_REALTIME_SPEED: String(REALTIME_VOICE_SPEED.SLOW),
-    },
+    environment: { LUKE_LIVE_VOICE: LIVE_VOICE.SAGE },
   });
 
   await store.set(APP_SETTING_SCHEMA.showInDock.field, true);
   await store.set(APP_SETTING_SCHEMA.voiceHotkey.field, VOICE_HOTKEY_NONE);
-  await store.set(APP_SETTING_SCHEMA.voiceSpeed.field, REALTIME_VOICE_SPEED.FAST);
+  await store.set(APP_SETTING_SCHEMA.voice.field, LIVE_VOICE.CEDAR);
 
   assert.deepEqual(await store.accountPreferences(), {
-    voiceSpeed: REALTIME_VOICE_SPEED.FAST,
+    voice: LIVE_VOICE.CEDAR,
   });
 });
 
@@ -905,26 +872,23 @@ test("applies account preferences to disk and restores them from a new store", a
   const store = storeIn(directory);
   await store.set(APP_SETTING_SCHEMA.showInDock.field, true);
   await store.set(APP_SETTING_SCHEMA.voiceHotkey.field, VOICE_HOTKEY_NONE);
-  await store.set(APP_SETTING_SCHEMA.voice.field, REALTIME_VOICE.SAGE);
-  await store.set(APP_SETTING_SCHEMA.voiceSpeed.field, REALTIME_VOICE_SPEED.FAST);
+  await store.set(APP_SETTING_SCHEMA.voice.field, LIVE_VOICE.SAGE);
   await setWorkspaceProjectDefault(store, PROVIDER_ID.CONDUCTOR, "project-local");
 
   const result = await store.applyAccountPreferences({
-    voice: REALTIME_VOICE.MARIN,
+    voice: LIVE_VOICE.MARIN,
     workspaceAgentDefaults: { conductor: { agent: "codex", model: "gpt-5.6-sol" } },
   });
 
   assert.deepEqual(result.changed, [
     APP_SETTING_SCHEMA.voice.field,
-    APP_SETTING_SCHEMA.voiceSpeed.field,
     APP_SETTING_SCHEMA.workspaceProjectDefaults.field,
     APP_SETTING_SCHEMA.workspaceAgentDefaults.field,
   ]);
   const reopened = storeIn(directory);
   assert.equal(await reopened.get(APP_SETTING_SCHEMA.showInDock.field), true);
   assert.equal(await reopened.get(APP_SETTING_SCHEMA.voiceHotkey.field), VOICE_HOTKEY_NONE);
-  assert.equal(await reopened.get(APP_SETTING_SCHEMA.voice.field), REALTIME_VOICE.MARIN);
-  assert.equal(await reopened.get(APP_SETTING_SCHEMA.voiceSpeed.field), undefined);
+  assert.equal(await reopened.get(APP_SETTING_SCHEMA.voice.field), LIVE_VOICE.MARIN);
   assert.equal(await readWorkspaceProjectDefault(reopened, PROVIDER_ID.CONDUCTOR), undefined);
   assert.deepEqual(await readWorkspaceAgentDefault(reopened, PROVIDER_ID.CONDUCTOR), {
     agent: "codex",
@@ -943,26 +907,29 @@ test("merges hosted account preferences around concurrent local preference edits
     provider: "github" as const,
   };
   await store.setAccount(account);
-  await store.set(APP_SETTING_SCHEMA.voice.field, REALTIME_VOICE.SAGE);
+  await store.set(APP_SETTING_SCHEMA.voice.field, LIVE_VOICE.SAGE);
   const expected = await store.accountPreferences();
 
-  await store.set(APP_SETTING_SCHEMA.voice.field, REALTIME_VOICE.ECHO);
+  await store.set(APP_SETTING_SCHEMA.voice.field, LIVE_VOICE.ECHO);
   await setWorkspaceProjectDefault(store, PROVIDER_ID.CONDUCTOR, "local-project");
   const result = await store.applyAccountPreferences(
     {
-      voice: REALTIME_VOICE.MARIN,
-      voiceSpeed: REALTIME_VOICE_SPEED.FAST,
+      voice: LIVE_VOICE.MARIN,
+      defaultWorkspaceProvider: PROVIDER_ID.CODEX,
       workspaceProjectDefaults: { [PROVIDER_ID.CODEX]: "remote-project" },
     },
     { accountEmail: account.email, preferences: expected },
   );
 
   assert.deepEqual(result.changed, [
-    APP_SETTING_SCHEMA.voiceSpeed.field,
+    APP_SETTING_SCHEMA.defaultWorkspaceProvider.field,
     APP_SETTING_SCHEMA.workspaceProjectDefaults.field,
   ]);
-  assert.equal(await store.get(APP_SETTING_SCHEMA.voice.field), REALTIME_VOICE.ECHO);
-  assert.equal(await store.get(APP_SETTING_SCHEMA.voiceSpeed.field), REALTIME_VOICE_SPEED.FAST);
+  assert.equal(await store.get(APP_SETTING_SCHEMA.voice.field), LIVE_VOICE.ECHO);
+  assert.equal(
+    await store.get(APP_SETTING_SCHEMA.defaultWorkspaceProvider.field),
+    PROVIDER_ID.CODEX,
+  );
   assert.equal(await readWorkspaceProjectDefault(store, PROVIDER_ID.CONDUCTOR), "local-project");
   assert.equal(await readWorkspaceProjectDefault(store, PROVIDER_ID.CODEX), "remote-project");
 });
@@ -978,21 +945,24 @@ test("keeps local account preference edits across a failed hosted write and rest
   };
   const store = storeIn(directory);
   await store.setAccount(account);
-  await store.set(APP_SETTING_SCHEMA.voice.field, REALTIME_VOICE.SAGE);
+  await store.set(APP_SETTING_SCHEMA.voice.field, LIVE_VOICE.SAGE);
   await store.setAccountPreferencesSyncBaseline(account.email, await store.accountPreferences());
 
-  await store.set(APP_SETTING_SCHEMA.voice.field, REALTIME_VOICE.ECHO);
+  await store.set(APP_SETTING_SCHEMA.voice.field, LIVE_VOICE.ECHO);
   const reopened = storeIn(directory);
   const baseline = await reopened.accountPreferencesSyncBaseline(account.email);
-  assert.deepEqual(baseline, { voice: REALTIME_VOICE.SAGE });
+  assert.deepEqual(baseline, { voice: LIVE_VOICE.SAGE });
   const result = await reopened.applyAccountPreferences(
-    { voice: REALTIME_VOICE.SAGE, voiceSpeed: REALTIME_VOICE_SPEED.FAST },
+    { voice: LIVE_VOICE.SAGE, defaultWorkspaceProvider: PROVIDER_ID.CODEX },
     { accountEmail: account.email, preferences: baseline ?? {} },
   );
 
-  assert.deepEqual(result.changed, [APP_SETTING_SCHEMA.voiceSpeed.field]);
-  assert.equal(await reopened.get(APP_SETTING_SCHEMA.voice.field), REALTIME_VOICE.ECHO);
-  assert.equal(await reopened.get(APP_SETTING_SCHEMA.voiceSpeed.field), REALTIME_VOICE_SPEED.FAST);
+  assert.deepEqual(result.changed, [APP_SETTING_SCHEMA.defaultWorkspaceProvider.field]);
+  assert.equal(await reopened.get(APP_SETTING_SCHEMA.voice.field), LIVE_VOICE.ECHO);
+  assert.equal(
+    await reopened.get(APP_SETTING_SCHEMA.defaultWorkspaceProvider.field),
+    PROVIDER_ID.CODEX,
+  );
 });
 
 test("skips a guarded account preference apply after account sign-out", async (t) => {
@@ -1006,20 +976,18 @@ test("skips a guarded account preference apply after account sign-out", async (t
     provider: "github" as const,
   };
   await store.setAccount(account);
-  await store.set(APP_SETTING_SCHEMA.voice.field, REALTIME_VOICE.SAGE);
-  await store.set(APP_SETTING_SCHEMA.voiceSpeed.field, REALTIME_VOICE_SPEED.FAST);
+  await store.set(APP_SETTING_SCHEMA.voice.field, LIVE_VOICE.SAGE);
   await setWorkspaceProjectDefault(store, PROVIDER_ID.CONDUCTOR, "local-project");
   const expected = await store.accountPreferences();
 
   await store.clearAccount();
   const result = await store.applyAccountPreferences(
-    { voice: REALTIME_VOICE.MARIN },
+    { voice: LIVE_VOICE.MARIN },
     { accountEmail: account.email, preferences: expected },
   );
 
   assert.deepEqual(result.changed, []);
   assert.equal(await store.get(APP_SETTING_SCHEMA.voice.field), undefined);
-  assert.equal(await store.get(APP_SETTING_SCHEMA.voiceSpeed.field), undefined);
   assert.equal(await readWorkspaceProjectDefault(store, PROVIDER_ID.CONDUCTOR), undefined);
   assert.equal(await store.accountPreferencesSyncBaseline(account.email), undefined);
 });
@@ -1394,39 +1362,36 @@ test("recovers from a corrupt settings file", async (t) => {
   assert.equal(await store.readApiKey(CONDUCTOR), TEST_API_KEY);
 });
 
-test("a voice reset forgets the voice, pace, captions, and duck in one action", async (t) => {
+test("a voice reset forgets the voice, captions, and duck in one action", async (t) => {
   const directory = temporaryDirectory(t, "luke-settings-");
   const store = storeIn(directory);
-  await store.set(APP_SETTING_SCHEMA.voice.field, REALTIME_VOICE.MARIN);
-  await store.set(APP_SETTING_SCHEMA.voiceSpeed.field, REALTIME_VOICE_SPEED.QUICK);
+  await store.set(APP_SETTING_SCHEMA.voice.field, LIVE_VOICE.CEDAR);
   await store.set(APP_SETTING_SCHEMA.voiceCaptions.field, true);
   await store.set(APP_SETTING_SCHEMA.duckOtherMedia.field, false);
 
   const { settings, reason } = await store.resetSettings(SETTINGS_RESET_SCOPE.VOICE);
 
   assert.equal(reason, undefined);
-  assert.equal(appSettingsView(settings).voice, REALTIME_DEFAULTS.VOICE);
-  assert.equal(appSettingsView(settings).voiceSpeed, REALTIME_DEFAULTS.SPEED);
+  assert.equal(appSettingsView(settings).voice, LIVE_DEFAULTS.VOICE);
   assert.equal(appSettingsView(settings).voiceCaptions, false);
   assert.equal(appSettingsView(settings).duckOtherMedia, true);
   // The choices are forgotten rather than restated, so a default that moves
   // in a later build moves these settings with it.
   assert.equal(await storeIn(directory).get(APP_SETTING_SCHEMA.voice.field), undefined);
-  assert.equal(await storeIn(directory).get(APP_SETTING_SCHEMA.voiceSpeed.field), undefined);
 });
 
 test("a voice reset returns to the environment's voice where one stands behind the choice", async (t) => {
   const directory = temporaryDirectory(t, "luke-settings-");
   const store = storeIn(directory, {
-    environment: { LUKE_REALTIME_VOICE: REALTIME_VOICE.SAGE },
+    environment: { LUKE_LIVE_VOICE: LIVE_VOICE.SAGE },
   });
-  await store.set(APP_SETTING_SCHEMA.voice.field, REALTIME_VOICE.MARIN);
+  await store.set(APP_SETTING_SCHEMA.voice.field, LIVE_VOICE.MARIN);
 
   const { settings } = await store.resetSettings(SETTINGS_RESET_SCOPE.VOICE);
 
   // Forgetting the choice is the reset's whole meaning: what stands afterwards
   // is whatever would have stood had none been made.
-  assert.equal(appSettingsView(settings).voice, REALTIME_VOICE.SAGE);
+  assert.equal(appSettingsView(settings).voice, LIVE_VOICE.SAGE);
   assert.equal(await store.get(APP_SETTING_SCHEMA.voice.field), undefined);
 });
 
@@ -1436,7 +1401,7 @@ test("an appearance reset returns Luke's stances without touching the voice page
   await store.set(APP_SETTING_SCHEMA.showInDock.field, true);
   await store.set(APP_SETTING_SCHEMA.showOnAllDisplays.field, true);
   await store.set(APP_SETTING_SCHEMA.formFactor.field, PANEL_FORM_FACTOR.NOTCH);
-  await store.set(APP_SETTING_SCHEMA.voice.field, REALTIME_VOICE.MARIN);
+  await store.set(APP_SETTING_SCHEMA.voice.field, LIVE_VOICE.MARIN);
 
   const { settings, reason } = await store.resetSettings(SETTINGS_RESET_SCOPE.APPEARANCE);
 
@@ -1446,7 +1411,7 @@ test("an appearance reset returns Luke's stances without touching the voice page
   assert.equal(appSettingsView(settings).formFactor, PANEL_FORM_FACTOR.BUBBLE);
   assert.equal(await storeIn(directory).get(APP_SETTING_SCHEMA.formFactor.field), undefined);
   // One scope's reset is that scope's alone.
-  assert.equal(appSettingsView(settings).voice, REALTIME_VOICE.MARIN);
+  assert.equal(appSettingsView(settings).voice, LIVE_VOICE.MARIN);
 });
 
 test("a shortcuts reset forgets all three chords at once", async (t) => {
@@ -1498,7 +1463,7 @@ test("a reset of settings already at their defaults writes nothing", async (t) =
   const { settings, reason } = await store.resetSettings(SETTINGS_RESET_SCOPE.VOICE);
 
   assert.equal(reason, undefined);
-  assert.equal(appSettingsView(settings).voice, REALTIME_DEFAULTS.VOICE);
+  assert.equal(appSettingsView(settings).voice, LIVE_DEFAULTS.VOICE);
   // Nothing changed, so no file was created — the same silence every setter
   // keeps when asked for the value it already holds.
   await assert.rejects(readSettingsFile(directory));

--- a/packages/host/src/settings-store.ts
+++ b/packages/host/src/settings-store.ts
@@ -23,7 +23,7 @@ import {
   SECRET_STORAGE,
   type SecretStorage,
 } from "@sidecar/credentials/vocabulary";
-import { REALTIME_DEFAULTS } from "@sidecar/realtime";
+import { LIVE_DEFAULTS } from "@sidecar/live";
 import {
   type AppSettings,
   type SettingsResetScope,
@@ -66,11 +66,7 @@ import {
   type StoredAppSettings,
   sameSettingEntry,
 } from "@sidecar/settings";
-import {
-  environmentRealtimeSpeed,
-  environmentRealtimeVoice,
-  resolveVoiceCapability,
-} from "@sidecar/voice";
+import { environmentLiveVoice, resolveVoiceCapability } from "@sidecar/voice";
 
 const SETTINGS_FILE_NAME = "settings.json";
 const SETTINGS_TEMPORARY_FILE_NAME = "settings.json.tmp";
@@ -719,14 +715,9 @@ export class SettingsStore {
     return {
       stored: {
         ...storedSettingsFromPersisted(persisted),
-        // Resolved the way the minter resolves them, so the panel marks what
-        // would actually be heard while the persisted file remains optional.
-        voice:
-          persisted.voice ?? environmentRealtimeVoice(this.#environment) ?? REALTIME_DEFAULTS.VOICE,
-        voiceSpeed:
-          persisted.voiceSpeed ??
-          environmentRealtimeSpeed(this.#environment) ??
-          REALTIME_DEFAULTS.SPEED,
+        // Resolved the way the session source resolves it, so the panel marks
+        // what would actually be heard while the persisted file remains optional.
+        voice: persisted.voice ?? environmentLiveVoice(this.#environment) ?? LIVE_DEFAULTS.VOICE,
         voiceSource: voiceCapability.source,
         formFactor: persisted.formFactor ?? DEFAULT_PANEL_FORM_FACTOR,
       },

--- a/packages/settings/package.json
+++ b/packages/settings/package.json
@@ -24,6 +24,7 @@
     "@sidecar/credentials": "workspace:*",
     "@sidecar/guide": "workspace:*",
     "@sidecar/live": "workspace:*",
+    "@sidecar/realtime": "workspace:*",
     "@sidecar/session": "workspace:*",
     "@sidecar/surface": "workspace:*",
     "@sidecar/wire": "workspace:*"

--- a/packages/settings/package.json
+++ b/packages/settings/package.json
@@ -23,7 +23,7 @@
     "@sidecar/calendar": "workspace:*",
     "@sidecar/credentials": "workspace:*",
     "@sidecar/guide": "workspace:*",
-    "@sidecar/realtime": "workspace:*",
+    "@sidecar/live": "workspace:*",
     "@sidecar/session": "workspace:*",
     "@sidecar/surface": "workspace:*",
     "@sidecar/wire": "workspace:*"

--- a/packages/settings/src/account-preferences.test.ts
+++ b/packages/settings/src/account-preferences.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { REALTIME_VOICE, REALTIME_VOICE_SPEED } from "@sidecar/realtime";
+import { LIVE_VOICE } from "@sidecar/live";
 import { PROVIDER_ID, SUPERSET_WORKSPACE_PROVIDER_ID } from "@sidecar/session";
 import { APP_SETTING_SCHEMA } from "./schema.js";
 import {
@@ -12,7 +12,6 @@ import {
 test("the account preference allowlist contains only cross-device preferences", () => {
   assert.deepEqual(ACCOUNT_PREFERENCE_FIELDS, [
     "voice",
-    "voiceSpeed",
     "defaultWorkspaceProvider",
     "workspaceProjectDefaults",
     "workspaceAgentDefaults",
@@ -28,8 +27,7 @@ test("the account preference allowlist contains only cross-device preferences", 
 test("account preferences validate the shared fields and reject local-only payloads", () => {
   assert.deepEqual(
     accountPreferencesFromWire({
-      voice: REALTIME_VOICE.MARIN,
-      voiceSpeed: REALTIME_VOICE_SPEED.FAST,
+      voice: LIVE_VOICE.MARIN,
       defaultWorkspaceProvider: PROVIDER_ID.CONDUCTOR,
       workspaceProjectDefaults: { conductor: "project-1" },
       workspaceAgentDefaults: {
@@ -38,8 +36,7 @@ test("account preferences validate the shared fields and reject local-only paylo
       },
     }),
     {
-      voice: REALTIME_VOICE.MARIN,
-      voiceSpeed: REALTIME_VOICE_SPEED.FAST,
+      voice: LIVE_VOICE.MARIN,
       defaultWorkspaceProvider: PROVIDER_ID.CONDUCTOR,
       workspaceProjectDefaults: { conductor: "project-1" },
       workspaceAgentDefaults: {
@@ -51,6 +48,7 @@ test("account preferences validate the shared fields and reject local-only paylo
 
   assert.equal(accountPreferencesFromWire({ voiceHotkey: "Command+Space" }), undefined);
   assert.equal(accountPreferencesFromWire({ voice: "baritone" }), undefined);
+  assert.equal(accountPreferencesFromWire({ voiceSpeed: 1.5 }), undefined);
 });
 
 test("null clears an account preference field in write payloads", () => {
@@ -66,11 +64,11 @@ test("null clears an account preference field in write payloads", () => {
 test("account preferences reads ignore newer and corrupt stored fields", () => {
   assert.deepEqual(
     accountPreferencesFromStored({
-      voice: REALTIME_VOICE.SAGE,
+      voice: LIVE_VOICE.SAGE,
       futureSetting: "held by a newer build",
       workspaceAgentDefaults: { conductor: { agent: "codex", model: "no-such-model" } },
     }),
-    { voice: REALTIME_VOICE.SAGE },
+    { voice: LIVE_VOICE.SAGE },
   );
 });
 

--- a/packages/settings/src/account-preferences.test.ts
+++ b/packages/settings/src/account-preferences.test.ts
@@ -48,7 +48,11 @@ test("account preferences validate the shared fields and reject local-only paylo
 
   assert.equal(accountPreferencesFromWire({ voiceHotkey: "Command+Space" }), undefined);
   assert.equal(accountPreferencesFromWire({ voice: "baritone" }), undefined);
-  assert.equal(accountPreferencesFromWire({ voiceSpeed: 1.5 }), undefined);
+  // The phone's Realtime pace still travels in the shared snapshot; here it
+  // is dropped rather than refused, so a phone's write stays readable.
+  assert.deepEqual(accountPreferencesFromWire({ voice: LIVE_VOICE.MARIN, voiceSpeed: 1.5 }), {
+    voice: LIVE_VOICE.MARIN,
+  });
 });
 
 test("null clears an account preference field in write payloads", () => {

--- a/packages/settings/src/index.ts
+++ b/packages/settings/src/index.ts
@@ -35,6 +35,7 @@ export {
   isSettingEntryKey,
   isSettingsResetScope,
   type KeyedAppSettingField,
+  RETIRED_ACCOUNT_PREFERENCE_FIELD,
   SETTING_PAGE,
   type SettingEntryValue,
   type SettingsRowsInput,

--- a/packages/settings/src/schema-access.ts
+++ b/packages/settings/src/schema-access.ts
@@ -64,7 +64,6 @@ export function isAppSettingField(value: UnparsedWireValue): value is AppSetting
  */
 export const ACCOUNT_PREFERENCE_FIELDS = [
   APP_SETTING_SCHEMA.voice.field,
-  APP_SETTING_SCHEMA.voiceSpeed.field,
   APP_SETTING_SCHEMA.defaultWorkspaceProvider.field,
   APP_SETTING_SCHEMA.workspaceProjectDefaults.field,
   APP_SETTING_SCHEMA.workspaceAgentDefaults.field,

--- a/packages/settings/src/schema-access.ts
+++ b/packages/settings/src/schema-access.ts
@@ -70,7 +70,23 @@ export const ACCOUNT_PREFERENCE_FIELDS = [
 ] as const satisfies readonly AppSettingField[];
 
 export type AccountPreferenceField = (typeof ACCOUNT_PREFERENCE_FIELDS)[number];
+
 export type AccountPreferences = Partial<Pick<StoredAppSettings, AccountPreferenceField>>;
+
+/**
+ * Fields a client of an earlier contract still carries on the wire and this
+ * build's settings no longer hold. The phone syncs its Realtime pace under
+ * this key until it moves to Live, and the hosted snapshot keeps the pace
+ * for the phone alone, so a reader here drops the key rather than refusing
+ * the snapshot the two share. Removing an entry is the phone's follow-up.
+ */
+export const RETIRED_ACCOUNT_PREFERENCE_FIELD = {
+  VOICE_SPEED: "voiceSpeed",
+} as const;
+
+const RETIRED_ACCOUNT_PREFERENCE_FIELD_SET: ReadonlySet<string> = new Set(
+  Object.values(RETIRED_ACCOUNT_PREFERENCE_FIELD),
+);
 
 const ACCOUNT_PREFERENCE_FIELD_SET: ReadonlySet<string> = new Set(ACCOUNT_PREFERENCE_FIELDS);
 
@@ -103,7 +119,7 @@ function parseAccountPreferences(
   const preferences: Record<string, UnparsedWireValue> = {};
   for (const [field, rawValue] of Object.entries(value)) {
     if (!isAccountPreferenceField(field)) {
-      if (source === "wire") return undefined;
+      if (source === "wire" && !RETIRED_ACCOUNT_PREFERENCE_FIELD_SET.has(field)) return undefined;
       continue;
     }
     const wireValue = rawValue === null ? undefined : rawValue;

--- a/packages/settings/src/schema-types.ts
+++ b/packages/settings/src/schema-types.ts
@@ -56,7 +56,6 @@ export const SETTING_SIDE_EFFECT = {
   DISPLAYS: "displays",
   FORM_FACTOR: "form-factor",
   VOICE: "voice",
-  VOICE_SPEED: "voice-speed",
   TALK_HOTKEY: "talk-hotkey",
   ASK_HOTKEY: "ask-hotkey",
   STOP_HOTKEY: "stop-hotkey",

--- a/packages/settings/src/schema.test.ts
+++ b/packages/settings/src/schema.test.ts
@@ -8,6 +8,7 @@ import {
   APP_SETTING_KIND,
   isAppSettingId,
 } from "@sidecar/guide";
+import { LIVE_DEFAULTS, LIVE_VOICE, LIVE_VOICE_LIST } from "@sidecar/live";
 import { PROVIDER_ID, SUPERSET_WORKSPACE_PROVIDER_ID } from "@sidecar/session";
 import {
   APP_SETTING_SCHEMA,
@@ -326,14 +327,7 @@ test("a page's section draws its own members, in the order they claim", () => {
   const voice = settingRowsForPage(SETTINGS_PAGE.VOICE, SETTING_SECTION.CONTROLS, view);
   assert.deepEqual(
     voice.map((row) => row.field),
-    [
-      "voice",
-      "voiceSpeed",
-      "voiceCaptions",
-      "duckOtherMedia",
-      "preferBuiltInMicrophone",
-      "announceSessions",
-    ],
+    ["voice", "voiceCaptions", "duckOtherMedia", "preferBuiltInMicrophone", "announceSessions"],
   );
   // The credential picker draws the source itself, so the controls do not.
   assert.ok(!voice.some((row) => row.field === "voiceSource"));
@@ -346,22 +340,30 @@ test("a page's section draws its own members, in the order they claim", () => {
 
 test("a choice row's control offers what its own values say, worded for a control", () => {
   const view = settingsVisibility({ voiceControlsDrawn: true });
-  const [speed] = settingRowsForPage(SETTINGS_PAGE.VOICE, SETTING_SECTION.CONTROLS, view).filter(
-    (row) => row.field === "voiceSpeed",
+  const [voice] = settingRowsForPage(SETTINGS_PAGE.VOICE, SETTING_SECTION.CONTROLS, view).filter(
+    (row) => row.field === "voice",
   );
-  assert.ok(speed?.control);
-  // The guide offers the word and the multiple; the control wears the
-  // multiple alone, and the token it stores is the word either way.
+  assert.ok(voice?.control);
+  // The voices are the Live API's own set, in its order, and the default
+  // carries its status into the menu alone.
   assert.deepEqual(
-    speed.control.options.map((option) => option.value),
-    ["slow", "normal", "quick", "fast"],
+    voice.control.options.map((option) => option.value),
+    LIVE_VOICE_LIST,
   );
   assert.deepEqual(
-    speed.control.options.map((option) => option.label),
-    ["0.75×", "1× (default)", "1.25×", "1.5×"],
+    voice.control.options
+      .filter((option) => option.label.endsWith("(default)"))
+      .map((option) => option.value),
+    [LIVE_DEFAULTS.VOICE],
   );
-  assert.equal(speed.control.value, "normal");
-  assert.equal(speed.changed, false);
+  assert.equal(voice.control.value, LIVE_VOICE.CEDAR);
+  assert.equal(voice.changed, true);
+  const [resting] = settingRowsForPage(
+    SETTINGS_PAGE.VOICE,
+    SETTING_SECTION.CONTROLS,
+    settingsVisibility({ voiceControlsDrawn: true, settings: { voice: LIVE_DEFAULTS.VOICE } }),
+  ).filter((row) => row.field === "voice");
+  assert.equal(resting?.changed, false);
 
   // The default-workspace row offers what the observation reported and one
   // token for no default at all, which no provider id can collide with.

--- a/packages/settings/src/schema.test.ts
+++ b/packages/settings/src/schema.test.ts
@@ -8,7 +8,8 @@ import {
   APP_SETTING_KIND,
   isAppSettingId,
 } from "@sidecar/guide";
-import { LIVE_DEFAULTS, LIVE_VOICE, LIVE_VOICE_LIST } from "@sidecar/live";
+import { isLiveVoice, LIVE_DEFAULTS, LIVE_VOICE } from "@sidecar/live";
+import { isRealtimeVoice } from "@sidecar/realtime";
 import { PROVIDER_ID, SUPERSET_WORKSPACE_PROVIDER_ID } from "@sidecar/session";
 import {
   APP_SETTING_SCHEMA,
@@ -344,12 +345,14 @@ test("a choice row's control offers what its own values say, worded for a contro
     (row) => row.field === "voice",
   );
   assert.ok(voice?.control);
-  // The voices are the Live API's own set, in its order, and the default
+  // Every offered voice is one the Live API speaks and one the phone's
+  // Realtime reader still names, with the default among them; the default
   // carries its status into the menu alone.
-  assert.deepEqual(
-    voice.control.options.map((option) => option.value),
-    LIVE_VOICE_LIST,
-  );
+  const offered = voice.control.options.map((option) => option.value);
+  assert.ok(offered.length > 1);
+  assert.equal(offered.every(isLiveVoice), true);
+  assert.equal(offered.every(isRealtimeVoice), true);
+  assert.equal(offered.includes(LIVE_DEFAULTS.VOICE), true);
   assert.deepEqual(
     voice.control.options
       .filter((option) => option.label.endsWith("(default)"))

--- a/packages/settings/src/schema.ts
+++ b/packages/settings/src/schema.ts
@@ -11,6 +11,7 @@ import {
   isAppSettingId,
 } from "@sidecar/guide";
 import { isLiveVoice, LIVE_DEFAULTS, LIVE_VOICE_LIST, type LiveVoice } from "@sidecar/live";
+import { isRealtimeVoice } from "@sidecar/realtime";
 import {
   CONDUCTOR_LOCAL_WORKSPACE_PROVIDER_ID,
   isProviderId,
@@ -101,6 +102,13 @@ const VOICE_SOURCE_CHOICE = {
   [VOICE_SOURCE.ACCOUNT]: "your Luke account",
   [VOICE_SOURCE.KEY]: "your OpenAI key",
 } as const satisfies Record<VoiceSource, string>;
+
+/* The voice is an account preference every device applies, and the phone
+   still speaks through the Realtime API, whose reader refuses a snapshot
+   naming a voice it does not know. So the row offers the Live voices the
+   Realtime contract also names, until the phone moves to Live; the guard
+   still admits any Live voice, so a stored one stands whatever is offered. */
+const OFFERED_VOICE_LIST: readonly LiveVoice[] = LIVE_VOICE_LIST.filter(isRealtimeVoice);
 
 /* The API names its voices in lowercase; on a control they read as names. The
    default carries its status into the menu, so returning to it never needs the
@@ -262,7 +270,7 @@ export const APP_SETTING_SCHEMA = {
     label: "Voice",
     description:
       "Which voice Luke speaks with. A conversation keeps the voice it opened with, so a change is heard from the next conversation on.",
-    values: LIVE_VOICE_LIST,
+    values: OFFERED_VOICE_LIST,
     say: (voice) => voice,
     optionLabel: voiceOptionLabel,
     guard: (value: UnparsedWireValue) => optional(value, isLiveVoice),

--- a/packages/settings/src/schema.ts
+++ b/packages/settings/src/schema.ts
@@ -10,16 +10,7 @@ import {
   type AppSettingId,
   isAppSettingId,
 } from "@sidecar/guide";
-import {
-  isRealtimeVoice,
-  isRealtimeVoiceSpeed,
-  REALTIME_DEFAULTS,
-  REALTIME_VOICE_LIST,
-  REALTIME_VOICE_SPEED,
-  REALTIME_VOICE_SPEED_LIST,
-  type RealtimeVoice,
-  type RealtimeVoiceSpeed,
-} from "@sidecar/realtime";
+import { isLiveVoice, LIVE_DEFAULTS, LIVE_VOICE_LIST, type LiveVoice } from "@sidecar/live";
 import {
   CONDUCTOR_LOCAL_WORKSPACE_PROVIDER_ID,
   isProviderId,
@@ -111,28 +102,12 @@ const VOICE_SOURCE_CHOICE = {
   [VOICE_SOURCE.KEY]: "your OpenAI key",
 } as const satisfies Record<VoiceSource, string>;
 
-const VOICE_SPEED_WORD = {
-  [REALTIME_VOICE_SPEED.SLOW]: "slow",
-  [REALTIME_VOICE_SPEED.NORMAL]: "normal",
-  [REALTIME_VOICE_SPEED.QUICK]: "quick",
-  [REALTIME_VOICE_SPEED.FAST]: "fast",
-} as const satisfies Record<RealtimeVoiceSpeed, string>;
-
-const voiceSpeedMultiple = (speed: RealtimeVoiceSpeed): string => `${speed}×`;
-
 /* The API names its voices in lowercase; on a control they read as names. The
    default carries its status into the menu, so returning to it never needs the
    README or a memory of what shipped. */
-function voiceOptionLabel(voice: RealtimeVoice): string {
+function voiceOptionLabel(voice: LiveVoice): string {
   const name = voice.charAt(0).toUpperCase() + voice.slice(1);
-  return voice === REALTIME_DEFAULTS.VOICE ? `${name} (default)` : name;
-}
-
-/* A pace reads as a rate multiple, the way every player writes one. The
-   natural rate carries its status into the menu for the same reason the
-   default voice does. */
-function speedOptionLabel(speed: RealtimeVoiceSpeed): string {
-  return speed === REALTIME_DEFAULTS.SPEED ? `${speed}× (default)` : `${speed}×`;
+  return voice === LIVE_DEFAULTS.VOICE ? `${name} (default)` : name;
 }
 
 /* The forms read as names, and the bubble carries its status into the menu the
@@ -286,47 +261,18 @@ export const APP_SETTING_SCHEMA = {
     id: APP_SETTING_ID.VOICE,
     label: "Voice",
     description:
-      "Which voice Luke speaks with; a change is heard right away — a conversation under way starts afresh in the new voice.",
-    values: REALTIME_VOICE_LIST,
+      "Which voice Luke speaks with. A conversation keeps the voice it opened with, so a change is heard from the next conversation on.",
+    values: LIVE_VOICE_LIST,
     say: (voice) => voice,
     optionLabel: voiceOptionLabel,
-    guard: (value: UnparsedWireValue) => optional(value, isRealtimeVoice),
-    default: REALTIME_DEFAULTS.VOICE,
+    guard: (value: UnparsedWireValue) => optional(value, isLiveVoice),
+    default: LIVE_DEFAULTS.VOICE,
     page: SETTINGS_PAGE.VOICE,
     section: SETTING_SECTION.CONTROLS,
     order: 30,
     resetScope: SETTINGS_RESET_SCOPE.VOICE,
     manual: VOICE_PAGE,
     sideEffect: SETTING_SIDE_EFFECT.VOICE,
-    adjustable: true,
-    visible: voiceControlDrawn,
-  }),
-  voiceSpeed: choiceSetting({
-    field: "voiceSpeed",
-    id: APP_SETTING_ID.VOICE_SPEED,
-    label: "Speed",
-    description:
-      "How fast Luke talks: slow 0.75×, normal 1×, quick 1.25×, fast 1.5× the voice's natural rate. An ask may use the word or the multiple. A change is heard from the next reply on.",
-    values: REALTIME_VOICE_SPEED_LIST,
-    say: (speed) => VOICE_SPEED_WORD[speed],
-    optionLabel: speedOptionLabel,
-    // The multiple is a second spelling of the same pace, so an ask may name
-    // either; the guide offers both and the control wears the multiple alone.
-    alias: Object.fromEntries(
-      REALTIME_VOICE_SPEED_LIST.map((speed) => [voiceSpeedMultiple(speed), speed]),
-    ),
-    choices: REALTIME_VOICE_SPEED_LIST.flatMap((speed) => [
-      VOICE_SPEED_WORD[speed],
-      voiceSpeedMultiple(speed),
-    ]),
-    guard: (value: UnparsedWireValue) => optional(value, isRealtimeVoiceSpeed),
-    default: REALTIME_DEFAULTS.SPEED,
-    page: SETTINGS_PAGE.VOICE,
-    section: SETTING_SECTION.CONTROLS,
-    order: 40,
-    resetScope: SETTINGS_RESET_SCOPE.VOICE,
-    manual: VOICE_PAGE,
-    sideEffect: SETTING_SIDE_EFFECT.VOICE_SPEED,
     adjustable: true,
     visible: voiceControlDrawn,
   }),

--- a/packages/settings/src/testing.ts
+++ b/packages/settings/src/testing.ts
@@ -3,7 +3,7 @@ import {
   CREDENTIAL_SOURCE,
   SECRET_STORAGE,
 } from "@sidecar/credentials/vocabulary";
-import { REALTIME_VOICE, REALTIME_VOICE_SPEED } from "@sidecar/realtime";
+import { LIVE_VOICE } from "@sidecar/live";
 import { PANEL_FORM_FACTOR } from "@sidecar/surface";
 import { VOICE_SOURCE } from "./schema.js";
 import { APP_SETTING_DEFAULTS } from "./schema-access.js";
@@ -27,8 +27,7 @@ export function settingsView(overrides: Partial<AppSettingsView> = {}): AppSetti
       },
       secretStorage: SECRET_STORAGE.UNKNOWN,
       showInDock: false,
-      voice: REALTIME_VOICE.CEDAR,
-      voiceSpeed: REALTIME_VOICE_SPEED.NORMAL,
+      voice: LIVE_VOICE.CEDAR,
       voiceCaptions: false,
       duckOtherMedia: true,
       quietDuringMeetings: true,

--- a/packages/settings/src/wire.ts
+++ b/packages/settings/src/wire.ts
@@ -22,7 +22,7 @@ export interface AppSettings {
 }
 
 /** A renderer-local view over the two disjoint halves of the settings wire. */
-type ResolvedSettingField = "voice" | "voiceSpeed" | "voiceSource" | "formFactor";
+type ResolvedSettingField = "voice" | "voiceSource" | "formFactor";
 export type AppSettingsView = Omit<StoredAppSettings, ResolvedSettingField> & {
   [Field in ResolvedSettingField]-?: NonNullable<StoredAppSettings[Field]>;
 } & RuntimeStatus;
@@ -32,7 +32,6 @@ export function appSettingsView(settings: AppSettings): AppSettingsView {
     ...settings.stored,
     ...settings.status,
     voice: settings.stored.voice ?? APP_SETTING_DEFAULTS.voice,
-    voiceSpeed: settings.stored.voiceSpeed ?? APP_SETTING_DEFAULTS.voiceSpeed,
     voiceSource: settings.stored.voiceSource ?? VOICE_SOURCE.ACCOUNT,
     formFactor: settings.stored.formFactor ?? APP_SETTING_DEFAULTS.formFactor,
   };

--- a/packages/voice/src/capability-assembler.ts
+++ b/packages/voice/src/capability-assembler.ts
@@ -232,10 +232,9 @@ export class VoiceCapabilityAssembler {
       readAccountKey: async () => (await this.#options.settings.readAccount())?.email,
       ...(this.#options.fetch ? { fetch: this.#options.fetch } : undefined),
     };
-    const [voice, speed] = await Promise.all([
-      this.#options.settings.get(APP_SETTING_SCHEMA.voice.field).catch(() => undefined),
-      this.#options.settings.get(APP_SETTING_SCHEMA.voiceSpeed.field).catch(() => undefined),
-    ]);
+    const voice = await this.#options.settings
+      .get(APP_SETTING_SCHEMA.voice.field)
+      .catch(() => undefined);
     if (!isCurrent()) return { latest: false, isCurrent };
 
     const builtBrainModel = policy.useKey
@@ -243,10 +242,7 @@ export class VoiceCapabilityAssembler {
       : policy.useHosted
         ? new HostedModelAdapter(seams)
         : undefined;
-    const preferences = {
-      ...(voice ? { voice } : undefined),
-      ...(speed ? { speed } : undefined),
-    };
+    const preferences = voice ? { voice } : {};
     this.#brainModel =
       builtBrainModel && this.#options.wrapBrainModel
         ? this.#options.wrapBrainModel(builtBrainModel)

--- a/packages/voice/src/orchestrator/voice-call.ts
+++ b/packages/voice/src/orchestrator/voice-call.ts
@@ -38,7 +38,6 @@ export interface SpeakOnlyVoiceCall {
   close(): Promise<void>;
   speak(turn: ProactiveSpeechTurn): boolean;
   stopSpeaking(): boolean;
-  applySpeed(speed: number): void;
   reportRemoteAudioLevel(active: boolean): void;
 }
 

--- a/packages/voice/src/orchestrator/voice-orchestrator.test.ts
+++ b/packages/voice/src/orchestrator/voice-orchestrator.test.ts
@@ -45,7 +45,6 @@ class FakeCall {
   stopSpeaking() {
     return true;
   }
-  applySpeed() {}
   reportRemoteAudioLevel() {}
   beginTurn() {
     this.turns += 1;

--- a/packages/voice/src/orchestrator/voice-orchestrator.ts
+++ b/packages/voice/src/orchestrator/voice-orchestrator.ts
@@ -7,7 +7,6 @@ import {
   REALTIME_STATUS,
   type RealtimeStatus,
   type RealtimeVoice,
-  type RealtimeVoiceSpeed,
   voiceExchangeActive,
 } from "@sidecar/realtime";
 import type { SpeechOffer } from "@sidecar/realtime/speech";
@@ -37,7 +36,6 @@ import {
 import {
   activeVoiceStream,
   liveConversationEntries,
-  liveSpeedApplies,
   lukeCaptionsToShow,
   spokenAskPreviewSurvives,
   talkKeyPress,
@@ -62,7 +60,6 @@ export interface VoiceSurroundings {
   /** Undefined until the host has answered; saying "off" before then would draw a dead key. */
   voiceAvailable?: boolean;
   voice?: RealtimeVoice;
-  voiceSpeed?: RealtimeVoiceSpeed;
   captionsEnabled: boolean;
   /** Whether the Mac's output would swallow the speech, which is a reason to read it. */
   outputSilent: boolean;
@@ -224,7 +221,6 @@ export class VoiceOrchestrator<Stream> {
   #adopted: VoiceConversationSlice | undefined;
 
   #heardVoice: RealtimeVoice | undefined;
-  #heardSpeed: RealtimeVoiceSpeed | undefined;
   #restartDue = false;
 
   #state: VoiceState<Stream> = { meterStream: undefined, remoteStream: undefined };
@@ -300,11 +296,6 @@ export class VoiceOrchestrator<Stream> {
     const previous = this.#surroundings;
     this.#surroundings = next;
     if (previous.voiceAvailable !== next.voiceAvailable) this.#voiceAvailabilityChanged();
-    if (next.voiceSpeed !== undefined) {
-      const heard = this.#heardSpeed;
-      this.#heardSpeed = next.voiceSpeed;
-      if (liveSpeedApplies(heard, next.voiceSpeed)) this.#liveCall()?.applySpeed(next.voiceSpeed);
-    }
     if (previous.voice !== next.voice) this.#considerRestart();
     if (previous.announcementsHeld !== next.announcementsHeld) {
       if (next.announcementsHeld) this.#ensureMouth().setHeld(true);

--- a/packages/voice/src/orchestrator/voice-policy.test.ts
+++ b/packages/voice/src/orchestrator/voice-policy.test.ts
@@ -1,12 +1,11 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { REALTIME_STATUS, REALTIME_VOICE, REALTIME_VOICE_SPEED } from "@sidecar/realtime";
+import { REALTIME_STATUS, REALTIME_VOICE } from "@sidecar/realtime";
 import { CONVERSATION_ENTRY_KIND } from "@sidecar/session";
 import { REPLY_KIND } from "./voice-call.js";
 import {
   activeVoiceStream,
   liveConversationEntries,
-  liveSpeedApplies,
   lukeCaptionsToShow,
   spokenAskPreviewSurvives,
   talkKeyPress,
@@ -171,13 +170,6 @@ test("the press-wait meter rides a handshake and a pending takeover, nothing els
   assert.equal(talkOpeningHolds({ status: REALTIME_STATUS.LISTENING, turnPending: false }), false);
   assert.equal(talkOpeningHolds({ status: REALTIME_STATUS.READY, turnPending: false }), false);
   assert.equal(talkOpeningHolds({ status: REALTIME_STATUS.FAILED, turnPending: false }), false);
-});
-
-test("the first stored pace is not a change, and a later one is", () => {
-  assert.equal(liveSpeedApplies(undefined, REALTIME_VOICE_SPEED.QUICK), false);
-  assert.equal(liveSpeedApplies(REALTIME_VOICE_SPEED.NORMAL, REALTIME_VOICE_SPEED.NORMAL), false);
-  assert.equal(liveSpeedApplies(REALTIME_VOICE_SPEED.NORMAL, REALTIME_VOICE_SPEED.QUICK), true);
-  assert.equal(liveSpeedApplies(REALTIME_VOICE_SPEED.QUICK, undefined), false);
 });
 
 test("a changed voice on a live call waits for the turn to end, then restarts", () => {

--- a/packages/voice/src/orchestrator/voice-policy.ts
+++ b/packages/voice/src/orchestrator/voice-policy.ts
@@ -1,4 +1,3 @@
-import type { RealtimeVoiceSpeed } from "@sidecar/realtime";
 import { REALTIME_STATUS, type RealtimeStatus, type RealtimeVoice } from "@sidecar/realtime";
 import {
   CONVERSATION_ENTRY_KIND,
@@ -87,18 +86,6 @@ export function talkKeyPress(input: { latched: boolean; microphoneCall: boolean 
  */
 export function talkOpeningHolds(input: { status: RealtimeStatus; turnPending: boolean }): boolean {
   return input.status === REALTIME_STATUS.CONNECTING || input.turnPending;
-}
-
-/**
- * Whether a changed pace should be carried onto the call now open. The first
- * snapshot is the stored value rather than a change, and with no next value
- * there is nothing to apply — the next call is minted at the stored pace.
- */
-export function liveSpeedApplies(
-  previous: RealtimeVoiceSpeed | undefined,
-  next: RealtimeVoiceSpeed | undefined,
-): boolean {
-  return next !== undefined && previous !== undefined && previous !== next;
 }
 
 /** Whether a changed voice is still owed a restart, and what to do about it now. */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -775,9 +775,9 @@ importers:
       '@sidecar/guide':
         specifier: workspace:*
         version: link:../guide
-      '@sidecar/realtime':
+      '@sidecar/live':
         specifier: workspace:*
-        version: link:../realtime
+        version: link:../live
       '@sidecar/session':
         specifier: workspace:*
         version: link:../session

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -778,6 +778,9 @@ importers:
       '@sidecar/live':
         specifier: workspace:*
         version: link:../live
+      '@sidecar/realtime':
+        specifier: workspace:*
+        version: link:../realtime
       '@sidecar/session':
         specifier: workspace:*
         version: link:../session

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -523,9 +523,6 @@ importers:
       '@sidecar/providers':
         specifier: workspace:*
         version: link:../providers
-      '@sidecar/realtime':
-        specifier: workspace:*
-        version: link:../realtime
       '@sidecar/runtime':
         specifier: workspace:*
         version: link:../runtime


### PR DESCRIPTION
## What

GPT Live fixes a session's voice at creation and has no speed control, so this PR removes the voice speed setting and points the Voice row at the Live voice set.

- `packages/settings`: `voiceSpeed` deleted from the schema, its access list, the account-preference fields, the wire view, and `SETTING_SIDE_EFFECT`; the Voice row's values are Live voices, guarded by `isLiveVoice`, default `marin`, described as applying to the next conversation. The row **offers** only the Live voices the Realtime contract also names (10 of 22) until the phone moves to Live, because the voice is an account preference the phone applies and its reader refuses a snapshot naming a voice it does not know; the guard still admits any Live voice, so a stored one stands. Lifting the subset is a one-line change in the iOS follow-up.
- `packages/guide`: `APP_SETTING_ID.VOICE_SPEED` deleted (the analytics allowlist derives from this set).
- `packages/host`: `setVoiceSpeed` link and side effect removed; the store resolves the shown voice from `LUKE_LIVE_VOICE` and `LIVE_DEFAULTS.VOICE`.
- `packages/voice`: the assembler no longer reads a speed; `liveSpeedApplies`, `applySpeed`, and the orchestrator's speed surroundings go.
- Desktop: the Speed row disappears with its schema entry; the guide's talk-key, microphone, stopping, and conversation-length facts describe the Live session (press to listen, stop or a second press to mute, the conversation kept while it lasts, a voice change heard on the next one); the `held` talk-key input is gone since the key is a press either way now.
- `apps/web`: `voiceSpeed` leaves the shared account-preferences wire. Because the iOS app still syncs its Realtime pace under that key and applies a missing pace as the default, the hosted snapshot keeps it **for the phone alone**: the handler validates `voiceSpeed` against the Realtime contract and stores and returns it beside the shared fields (`HostedAccountPreferences`), while the shared wire parser in `@sidecar/settings` drops the retired key (`RETIRED_ACCOUNT_PREFERENCE_FIELD`) so the desktop reads the same snapshot without refusing it. The `voice_speed` column stays for the phone's follow-up (plan §B).
- iOS: `ProductSettingID.voiceSpeed` removed from the phone's product-event vocabulary (with the two `settingUpdate` records that used it), because the parity test requires every phone setting id to be in the shared `APP_SETTING_ID` set. The phone's preference reader is otherwise unchanged; its pace setting is unchanged.

## How it follows the GPT Live docs

The session config guide documents `audio.output.voice` with no speed field and states voice is immutable once a session starts; the setting's description and the guide facts say a change is heard from the next conversation on, and nothing tries to apply one mid-session.

## Verification

- `./scripts/check.sh` passed (exit 0) on the final branch after rebasing onto `origin/main`.
- `./scripts/verify.sh` is the completion invariant for a UI change and **could not run here**: this workspace is a Linux cloud sandbox with no macOS. The UI change is the removal of one schema-drawn row; no new element is drawn. No physical-notch check was performed.
- Swift changes were not compiled here (no Xcode); they remove one enum case and its three uses, and the parity test passes against the edited source.
- Tests added or changed: the shared wire parser drops `voiceSpeed` and keeps the rest; the web handler stores a valid phone pace, stores none for a desktop snapshot, and refuses a pace outside the contract; voice row options deep-equal `LIVE_VOICE_LIST` with `marin` the sole default label and `changed` false at the default; settings-store, account-preferences-client, and guide tests updated for the removed field.
- CHANGELOG: this repository writes the release's entry with the version bump (`chore(release)`), so no entry is added here.

## Bugbot

Bugbot's findings were real and are fixed: the phone's pace reset on every reconcile (the hosted snapshot now keeps the phone's pace for it alone), and Live-only voices stalling the phone's preference sync. The first fix for the latter, defaulting an unknown voice on the phone, would have written that default back over the desktop's choice (Bugbot's third finding), so the row offers the shared subset instead and the phone's reader is left as it was. The fourth finding, a desktop write clearing the phone's pace, is main's full-snapshot semantics (a desktop at its default pace already omitted the key and cleared it) and cannot be fixed on the web while the phone omits its own default pace; it goes with the phone's follow-up.

## Reviews

Cursor's `thermo-nuclear-review` skill text was applied to the diff: traced persisted `settings.json` files holding the old key (read by known fields only), the desktop's strict wire parsing against the new web answer, old desktops writing `voiceSpeed` (tolerated), the analytics allowlist shrinking (old clients' `voice_speed` setting events are refused with their batch, analytics only), and the introduction's Realtime mint (takes no stored voice). The "ponytail review" skill was not found as a Cursor skill; the closest published text (jwiegley's `ponytail-review.md` prompt) was applied: the diff is net negative and nothing added was cut further.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34546370234/artifacts/10179224387) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34546370234)

- Commit: `bcc528dba790b6ae00dedccd8f279aec6bcaec1a`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
