### PR TITLE
chore(deps): pin effect 3.22.2 in the catalog and spike it in wire

### DIFF
--- a/docs/adr/0001-effect.md
+++ b/docs/adr/0001-effect.md
@@ -1,0 +1,69 @@
+# ADR 0001: Effect as the infrastructure library
+
+Status: proposed. This stub records the two decisions the compatibility spike
+settled and the one measurement it took; the full record (the shim list and
+its deletion schedule, the idioms the migration writes to) lands with the
+migration's documentation PR.
+
+## Version line
+
+`effect` is pinned at `3.22.2`, the newest 3.x release, through the pnpm
+catalog in `pnpm-workspace.yaml` and nowhere else. Every workspace that reaches
+it declares `"effect": "catalog:"`, so one version resolves across the
+repository, which is what keeps a `Context.Tag` minted in one package the same
+service in another; `repository-checks.sh` refuses a literal version. Today
+that is `@sidecar/wire`'s development dependency alone, for the spike test at
+`packages/wire/src/effect-spike.test.ts`, which exercises `Schema.Struct`
+decoding, `Effect.gen`, `Layer`, and `Context.Tag` under the repository's own
+test runner.
+
+The spike compiled under both TypeScript lines the repository carries:
+`typescript@7.0.2` with `@types/node@26.2.0` (every package) and
+`typescript@6.0.3` with `@types/node@22.20.1` (`apps/web`). The latter was
+checked with a throwaway tsconfig extending `tsconfig.base.json` under
+`apps/web`, naming the spike file alone, so `apps/web`'s own compiler and its
+own `@types/node` resolved it.
+
+## Effect 4
+
+Effect 4 is not adopted. Its release line was a release candidate when this was
+written, and the companion packages the migration depends on (`@effect/platform`,
+`@effect/sql`, `@effect/rpc`) each ship a stable line against 3.x only. The
+decision is re-evaluated when Effect 4 has a stable release and all three ship
+4-compatible stable lines; until then every package pins the 3.x catalog entry.
+
+## `exactOptionalPropertyTypes`
+
+The flag was trialled in `tsconfig.base.json` against the whole workspace, with
+each error counted once by the file it lives in, since every project compiles
+its dependencies' sources and would otherwise report the same error from
+several packages. It is not enabled here; whether to enable it and fix the
+errors, or to have every Effect Schema spell `Schema.optionalWith(..., { exact:
+true })` instead, is decided by the migration's follow-up PR on this count.
+
+| Workspace | Errors |
+| --- | --- |
+| packages/providers | 41 |
+| apps/web | 35 |
+| apps/desktop | 30 |
+| packages/host | 26 |
+| packages/brain | 15 |
+| packages/voice | 15 |
+| packages/credentials | 7 |
+| packages/session | 5 |
+| packages/hosted | 4 |
+| packages/settings | 4 |
+| packages/wire | 2 |
+| packages/actions | 1 |
+| packages/analytics | 1 |
+| packages/calendar | 1 |
+| packages/panel | 1 |
+| **Total** | **188** |
+
+The other 18 workspaces reported none of their own. By diagnostic: 104 are
+`TS2379` (an argument carrying `undefined` into an optional property), 37 are
+`TS2412` (an assignment of `undefined` to an optional property), 35 are
+`TS2375` (an object literal carrying `undefined` into one), and the remaining
+12 are `TS2345`, `TS2322`, `TS2420`, and `TS2769`. Two of the errors sit in
+`packages/wire/src/schema.ts` and are re-reported by every package that
+compiles it.

--- a/packages/wire/package.json
+++ b/packages/wire/package.json
@@ -14,6 +14,7 @@
   },
   "devDependencies": {
     "@types/node": "catalog:",
+    "effect": "catalog:",
     "typescript": "catalog:",
     "vitest": "catalog:"
   }

--- a/packages/wire/src/effect-spike.test.ts
+++ b/packages/wire/src/effect-spike.test.ts
@@ -1,0 +1,106 @@
+import assert from "node:assert/strict";
+import { Context, Effect, Either, Layer, Schema } from "effect";
+import { test } from "vitest";
+
+const SESSION_STATE = {
+  WORKING: "working",
+  WAITING: "waiting",
+} as const;
+
+const SessionRow = Schema.Struct({
+  id: Schema.String,
+  state: Schema.Literal(SESSION_STATE.WORKING, SESSION_STATE.WAITING),
+  turns: Schema.Int,
+  branch: Schema.optionalWith(Schema.String, { exact: true }),
+});
+
+const readSessionRow = Schema.decodeUnknownEither(SessionRow);
+
+test("Schema.Struct decodes a well-formed record to the declared shape", () => {
+  const decoded = readSessionRow({ id: "session-1", state: "working", turns: 3 });
+
+  assert.deepEqual(Either.getOrThrow(decoded), {
+    id: "session-1",
+    state: SESSION_STATE.WORKING,
+    turns: 3,
+  });
+});
+
+test("Schema.Struct refuses a record whose field misses its refinement", () => {
+  const refused = readSessionRow({ id: "session-1", state: "working", turns: 2.5 });
+
+  assert.equal(Either.isLeft(refused), true);
+});
+
+test("Schema.Struct refuses a literal outside the declared set", () => {
+  const refused = readSessionRow({ id: "session-1", state: "settled", turns: 1 });
+
+  assert.equal(Either.isLeft(refused), true);
+});
+
+class Clock extends Context.Tag("@sidecar/wire/effect-spike/Clock")<
+  Clock,
+  { readonly now: () => number }
+>() {}
+
+class Roster extends Context.Tag("@sidecar/wire/effect-spike/Roster")<
+  Roster,
+  { readonly stamp: (id: string) => Effect.Effect<{ readonly id: string; readonly at: number }> }
+>() {}
+
+const FIXED_INSTANT = 1_700_000_000_000;
+
+const clockLayer = Layer.succeed(Clock, { now: () => FIXED_INSTANT });
+
+const rosterLayer = Layer.effect(
+  Roster,
+  Effect.gen(function* () {
+    const clock = yield* Clock;
+    return {
+      stamp: (id: string) => Effect.succeed({ id, at: clock.now() }),
+    };
+  }),
+);
+
+const stampBoth = Effect.gen(function* () {
+  const roster = yield* Roster;
+  const first = yield* roster.stamp("session-1");
+  const second = yield* roster.stamp("session-2");
+  return [first, second];
+});
+
+test("Layer resolves a Context.Tag through the layer it depends on", () => {
+  const stamped = Effect.runSync(Effect.provide(stampBoth, Layer.provide(rosterLayer, clockLayer)));
+
+  assert.deepEqual(stamped, [
+    { id: "session-1", at: FIXED_INSTANT },
+    { id: "session-2", at: FIXED_INSTANT },
+  ]);
+});
+
+test("Effect.gen carries a typed failure to the caller as an Either", async () => {
+  class Refused extends Schema.TaggedError<Refused>()("Refused", {
+    id: Schema.String,
+  }) {}
+
+  const refuse = (id: string) =>
+    Effect.gen(function* () {
+      if (id.length === 0) {
+        return yield* new Refused({ id });
+      }
+      return id;
+    });
+
+  const [accepted, refused] = await Effect.runPromise(
+    Effect.all([Effect.either(refuse("session-1")), Effect.either(refuse(""))]),
+  );
+
+  assert.deepEqual(accepted, Either.right("session-1"));
+  assert.equal(Either.isLeft(refused), true);
+  assert.equal(Either.isLeft(refused) ? refused.left._tag : null, "Refused");
+});
+
+test("two tags with different identifiers are different services", () => {
+  assert.notEqual(Clock.key, Roster.key);
+  assert.equal(Clock.key, "@sidecar/wire/effect-spike/Clock");
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,9 @@ catalogs:
     ai:
       specifier: 7.0.97
       version: 7.0.97
+    effect:
+      specifier: 3.22.2
+      version: 3.22.2
     react:
       specifier: 19.2.8
       version: 19.2.8
@@ -868,6 +871,9 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 26.2.0
+      effect:
+        specifier: 'catalog:'
+        version: 3.22.2
       typescript:
         specifier: 'catalog:'
         version: 7.0.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,6 +5,7 @@ packages:
 
 catalog:
   typescript: 7.0.2
+  effect: 3.22.2
   "@types/node": 26.2.0
   tsx: 4.23.12
   react: 19.2.8


### PR DESCRIPTION
P0-02 of the Effect migration. Built on #944 (P0-01, merged) and rebased over P0-03 (vitest root) and P0-04 (wire's runner swap), which landed on main meanwhile.

## Summary

- `effect` enters the pnpm catalog at `3.22.2`, the newest 3.x release, and `@sidecar/wire` declares it as a `catalog:` devDependency, the only workspace that reaches it. `pnpm why -r effect` finds one version, resolved by `@sidecar/wire` alone, and `node_modules/.pnpm` holds one `effect@3.22.2`.
- `packages/wire/src/effect-spike.test.ts` exercises `Schema.Struct` decoding (accept, refuse a refinement miss, refuse an out-of-set literal), `Effect.gen` with a `Schema.TaggedError` failure surfaced as `Either`, a `Layer` resolving one `Context.Tag` through another, and tag identity. Six tests under vitest (`import { test } from "vitest"`, `node:assert` kept, as P0-04's codemod has it); wire's count goes from 77 to 83.
- The spike compiles under both TypeScript lines: `typescript@7.0.2` with `@types/node@26.2.0` (wire's own `typecheck`) and `typescript@6.0.3` with `@types/node@22.20.1` (a throwaway tsconfig under `apps/web` extending `tsconfig.base.json` and naming the spike file alone, run with `apps/web`'s `tsc`; exit 0, config not committed).
- `docs/adr/0001-effect.md` is the ADR stub P0-18 finishes: the version line, the Effect 4 decision (3.x adopted; re-evaluate when Effect 4 has a stable release and `@effect/platform`, `@effect/sql`, `@effect/rpc` all ship 4-compatible stable lines; today Effect 4 is at `4.0.0-rc.113` and all three peer on `^3.22.x`), and the `exactOptionalPropertyTypes` trial.

## `exactOptionalPropertyTypes` trial (not enabled)

Flag set in `tsconfig.base.json`, `pnpm -r --no-bail run typecheck` run over every workspace, then reverted. Raw output is 464 error lines, but every project compiles its dependencies' sources, so the same error is re-reported from several packages; deduplicated by file, line, and column and attributed to the owning workspace:

| Workspace | Errors |
| --- | --- |
| packages/providers | 41 |
| apps/web | 35 |
| apps/desktop | 30 |
| packages/host | 26 |
| packages/brain | 15 |
| packages/voice | 15 |
| packages/credentials | 7 |
| packages/session | 5 |
| packages/hosted | 4 |
| packages/settings | 4 |
| packages/wire | 2 |
| packages/actions | 1 |
| packages/analytics | 1 |
| packages/calendar | 1 |
| packages/panel | 1 |
| **Total (15 of 33 workspaces)** | **188** |

By code: TS2379 ×104, TS2412 ×37, TS2375 ×35, TS2345 ×7, TS2322 ×3, TS2420 ×1, TS2769 ×1. This is above the ~150 mark the plan names for slicing P0-19 into per-package PRs; the decision is P0-19's.

## Evidence

- Platform-independent checks: `./scripts/check.sh` exit 0 (repository checks, biome, oxlint, knip, typecheck, tests, build).
- macOS Electron verification (`./scripts/verify.sh`): `not run` (no renderer or UI change; Linux sandbox).

### Physical-device evidence

- Screenshot or screen recording: `not attached`
- Physical-notch check: `not performed`
- Device/display configuration: `not recorded`

## Invariants checklist

- [x] `./scripts/check.sh` green; no renderer/UI change so `./scripts/verify.sh` not required.
- [x] JSON Schema goldens unchanged (`LUKE_UPDATE_FIXTURES` not run; no schema touched).
- [x] Gateway envelope goldens unchanged (gateway untouched).
- [x] No new `as` type assertion outside the allowlisted files; `as Admitted` untouched.
- [x] No `effect` import in an OpenClaw-ported file (the only `effect` import is the spike test).
- [ ] No `Effect.runPromise`/`runSync`/`runFork` outside the runtime edges: **the spike test itself calls `Effect.runSync` once and `Effect.runPromise` once** to run its effects under vitest's plain `test`. `@effect/vitest` sits in the catalog from P0-03 but is not taken as a wire dependency here, since this row's scope is `effect` alone. No product code does. The test-side idiom (`it.effect`) arrives with `@effect/vitest` in P0-03/P0-04, and P12-09's lint rule should exempt or rewrite this file then.
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` anywhere.
- [x] Test count: wire 77 → 83 (+6, the spike, `vitest run`). No other package changed.
- [x] No hand-rolled file replaced; nothing to delete or deprecate.
- [x] No `CLAUDE.md`/`AGENTS.md` sentence names a part this PR changes; the one-copy sentence P0-01 added to `packages/AGENTS.md` is what the spike proves. Root pair and package pairs untouched.
- [x] `PRIVACY.md` unchanged.
- [x] `packages/wire/package.json` declares exactly what its sources import by bare specifier; `effect` via `catalog:` (repository-checks grep passes).
- [x] Barrel/door rule: no Node-reaching Effect module added; `effect` is reached only from a test file, never a barrel.

## Notes

- Blockers or follow-up verification: None. The one open checklist row is stated above rather than ticked.

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34550918820/artifacts/10180833671) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34550918820)

- Commit: `cfc631c3fd95dac397b92681ec619abb1bd0a041`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
