### PR TITLE
feat(LUKE-125): the voice writer

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -17,7 +17,7 @@
     "dev": "vite",
     "preview": "vite preview",
     "test": "tsx --test 'tests/**/*.test.ts'",
-    "test:store": "tsx --test tests/hosted-store.test.ts tests/hosted-payload-envelope.test.ts tests/storage-schema.test.ts tests/voice-schema.test.ts tests/hosted-store-writer.test.ts tests/storage-reads.test.ts",
+    "test:store": "tsx --test tests/hosted-store.test.ts tests/hosted-payload-envelope.test.ts tests/storage-schema.test.ts tests/voice-schema.test.ts tests/hosted-store-writer.test.ts tests/storage-reads.test.ts tests/voice-writer.test.ts",
     "typecheck": "tsc --project tsconfig.json"
   },
   "dependencies": {

--- a/apps/web/server/README.md
+++ b/apps/web/server/README.md
@@ -470,8 +470,29 @@ with a flag saying whether the API confirmed them or a lost connection left
 them estimated. A segment is one span of what was actually said, by whom, in
 milliseconds on the session's clock. Nothing spoken is ever a message: the
 brain's reply is the assistant message, and what the voice said of it lives
-here as segments alone. No audio is ever stored, and nothing reads or writes
-these tables yet.
+here as segments alone. No audio is ever stored.
+
+Two writers share those tables and never a column. The voice service's own
+`server/voice/session-record.ts` owns the session row's whole life: it is
+inserted when the session is created, found again by `(user_id,
+live_session_id)` when a fresh function instance re-attaches to the same
+live session, overwritten with each unconfirmed usage snapshot while open,
+and closed once with the confirmed seconds, the instant, and the reason. The
+voice writer in `server/hosted/store/voice-writer.ts` only reads that row
+for its id and hangs everything else off it: a segment per transcript delta
+at the next position of the session's own sequence, the `speech.spoken`
+event on a briefing's message once the session's voice follows the
+commentary append that carried it (the first output delta beginning at or
+after the append's acknowledged end), and the developer's spoken ask as a
+user message on the voice channel, cut from the stored user segments between
+the previous ask's end and the delegation's offset and named with the
+session, the delegation, and the span. A row whose `closed_at` is still
+null may keep gaining segments, because an instance that dies at its
+duration bound never sends `session.closed` and the re-attach lands on the
+same row; the writer reads nothing from the row's state but its id. It
+keeps one thing in memory, which message a commentary append carried until
+its speech lands, and reads everything else back from the record, so a
+fresh instance continues a session where the last one stopped.
 
 The store tests run the generated migrations on PGlite in process, so
 `check.sh` needs no service; the `postgres` CI job runs the same migrations

--- a/apps/web/server/hosted/store/index.ts
+++ b/apps/web/server/hosted/store/index.ts
@@ -332,6 +332,14 @@ export {
 export { CLEARED_CONVERSATION_RETENTION_MS } from "./soft-delete.js";
 
 export {
+  type CommentaryAppend,
+  VOICE_WRITE_REFUSAL,
+  type VoiceTarget,
+  type VoiceWriteResult,
+  type VoiceWriter,
+  voiceWriter,
+} from "./voice-writer.js";
+export {
   type ConversationTarget,
   STORE_WRITE_EFFECT,
   STORE_WRITE_REFUSAL,

--- a/apps/web/server/hosted/store/voice-writer.ts
+++ b/apps/web/server/hosted/store/voice-writer.ts
@@ -192,7 +192,10 @@ export function voiceWriter({ db, store }: VoiceWriterOptions): VoiceWriter {
    * A briefing is known to have been said when the session's own voice
    * follows the append: the first output delta that begins at or after the
    * appended commentary's end writes `speech.spoken` on the briefing's
-   * message, once, and the append is forgotten.
+   * message, once, and the append is forgotten. Every append the delta has
+   * reached is marked by it, since two briefings appended back to back may
+   * both be answered by one delta and a second would otherwise wait for
+   * speech that never comes.
    */
   async function markSpoken(
     target: VoiceTarget,
@@ -200,6 +203,7 @@ export function voiceWriter({ db, store }: VoiceWriterOptions): VoiceWriter {
     voiceSessionId: string,
   ): Promise<VoiceWriteResult | undefined> {
     const appends = appendsOf(target.liveSessionId);
+    let outcome: VoiceWriteResult | undefined;
     for (const [clientEventId, append] of appends) {
       if (append.spokenFromMs === undefined || delta.start_ms < append.spokenFromMs) continue;
       appends.delete(clientEventId);
@@ -209,12 +213,19 @@ export function voiceWriter({ db, store }: VoiceWriterOptions): VoiceWriter {
         // Which session said it, and when on that session's clock.
         payload: { voice_session_id: voiceSessionId, at_ms: delta.start_ms },
       });
-      if (written.ok) return WRITTEN;
-      return written.refusal === STORE_WRITE_REFUSAL.NO_MESSAGE
-        ? { ok: false, refusal: VOICE_WRITE_REFUSAL.NO_MESSAGE }
-        : { ok: false, refusal: VOICE_WRITE_REFUSAL.NO_CONVERSATION };
+      if (written.ok) {
+        outcome ??= WRITTEN;
+      } else {
+        outcome = {
+          ok: false,
+          refusal:
+            written.refusal === STORE_WRITE_REFUSAL.NO_MESSAGE
+              ? VOICE_WRITE_REFUSAL.NO_MESSAGE
+              : VOICE_WRITE_REFUSAL.NO_CONVERSATION,
+        };
+      }
     }
-    return undefined;
+    return outcome;
   }
 
   function placeAppend(target: VoiceTarget, appended: CommentaryAppended): VoiceWriteResult {

--- a/apps/web/server/hosted/store/voice-writer.ts
+++ b/apps/web/server/hosted/store/voice-writer.ts
@@ -1,0 +1,305 @@
+import { and, eq, gte, lt, sql } from "drizzle-orm";
+import {
+  CONVERSATION_EVENT_KIND,
+  MESSAGE_AUTHOR,
+  MESSAGE_CHANNEL,
+  type SpokenAskMetadata,
+} from "../../core.js";
+import {
+  VOICE_SEGMENT_ROLE,
+  type VoiceSegmentRole,
+  voiceSessions,
+  voiceTranscriptSegments,
+} from "../../db/voice-schema.js";
+import { LIVE_SERVER_EVENT, type LiveServerEvent } from "../../live.js";
+import type { HostedStoreDatabase } from "./database.js";
+import {
+  type ConversationTarget,
+  STORE_WRITE_EFFECT,
+  STORE_WRITE_REFUSAL,
+  type StoreWriter,
+} from "./writer.js";
+
+/**
+ * The voice writer: what a GPT Live session's event stream leaves in the
+ * record. It writes the tables the plan gives the voice and no other — the
+ * timed segments of what was actually said, by whom, in milliseconds on the
+ * session's own clock; the `speech.spoken` event that says a briefing was
+ * heard rather than merely offered; and the one thing a voice session says
+ * that is a message, the developer's own spoken ask, cut from the transcript
+ * where a delegation places it. The `voice_sessions` row itself is another
+ * writer's: the voice service creates it when it creates the session and
+ * closes it on `session.closed`, and this writer only reads it for its id,
+ * so a session whose row it cannot find is refused rather than invented.
+ *
+ * The row's own state decides nothing here. A function instance dies at its
+ * duration bound without a `session.closed`, and the desktop re-attaches to
+ * the same live session on a fresh instance, landing on the same row; so a
+ * row with `closed_at` null may still gain segments, a row that has segments
+ * is not thereby closed, and nothing this writer keeps between events lives
+ * anywhere but the record: the ask a delegation cuts is read back from the
+ * segments already written, from the previous ask's end on, and the only
+ * memory kept in the process is which message a commentary append carried,
+ * which the same connection that sent the append learns the answer to.
+ *
+ * Nothing spoken becomes a message. The brain's reply is the assistant
+ * message the model's context replays; what the voice spoke of it is a
+ * paraphrase, and it lives as segments. Segments may overlap, because timed
+ * deltas do, and no audio is ever stored.
+ */
+
+/** The live session a stream belongs to, and the conversation its asks and briefings belong to. */
+export interface VoiceTarget {
+  readonly userId: string;
+  readonly liveSessionId: string;
+  readonly conversation: ConversationTarget;
+}
+
+/** A commentary append the voice service sent, so the ack and the speech that follows can be tied to the message it carried. */
+export interface CommentaryAppend {
+  /** The client event id the append was sent with, which the `commentary.appended` ack names back. */
+  readonly clientEventId: string;
+  readonly messageId: string;
+}
+
+export const VOICE_WRITE_REFUSAL = {
+  /** No `voice_sessions` row stands for this account and live session. */
+  NO_SESSION: "no_session",
+  NO_CONVERSATION: STORE_WRITE_REFUSAL.NO_CONVERSATION,
+  NO_MESSAGE: STORE_WRITE_REFUSAL.NO_MESSAGE,
+  MESSAGE_REFUSED: STORE_WRITE_REFUSAL.MESSAGE_REFUSED,
+} as const;
+
+type VoiceWriteRefusal = (typeof VOICE_WRITE_REFUSAL)[keyof typeof VOICE_WRITE_REFUSAL];
+
+type VoiceWriteEffect = (typeof STORE_WRITE_EFFECT)[keyof typeof STORE_WRITE_EFFECT];
+
+export type VoiceWriteResult =
+  | { readonly ok: true; readonly effect: VoiceWriteEffect }
+  | { readonly ok: false; readonly refusal: VoiceWriteRefusal };
+
+const IGNORED: VoiceWriteResult = { ok: true, effect: STORE_WRITE_EFFECT.IGNORED };
+const WRITTEN: VoiceWriteResult = { ok: true, effect: STORE_WRITE_EFFECT.WRITTEN };
+const REPEATED: VoiceWriteResult = { ok: true, effect: STORE_WRITE_EFFECT.REPEATED };
+const NO_SESSION: VoiceWriteResult = { ok: false, refusal: VOICE_WRITE_REFUSAL.NO_SESSION };
+
+export interface VoiceWriter {
+  /** Consumes one server event of the live session's stream. */
+  consume(target: VoiceTarget, event: LiveServerEvent): Promise<VoiceWriteResult>;
+  /** Tells the writer which message a commentary append carries, before the stream acknowledges it. */
+  noteAppend(target: VoiceTarget, append: CommentaryAppend): void;
+}
+
+interface VoiceWriterOptions {
+  readonly db: HostedStoreDatabase;
+  /** The messages and events writer, which the spoken ask and the speech event go through. */
+  readonly store: StoreWriter;
+}
+
+/** An append the service sent, from the ack that placed it to the speech that followed it. */
+interface PendingAppend {
+  readonly messageId: string;
+  readonly conversation: ConversationTarget;
+  /** Where the appended commentary ends on the session's clock; unknown until the ack. */
+  spokenFromMs?: number;
+}
+
+type SegmentDelta = Extract<
+  LiveServerEvent,
+  {
+    type:
+      | typeof LIVE_SERVER_EVENT.INPUT_TRANSCRIPT_DELTA
+      | typeof LIVE_SERVER_EVENT.OUTPUT_TRANSCRIPT_DELTA;
+  }
+>;
+
+type DelegationCreated = Extract<
+  LiveServerEvent,
+  { type: typeof LIVE_SERVER_EVENT.DELEGATION_CREATED }
+>;
+
+type CommentaryAppended = Extract<
+  LiveServerEvent,
+  { type: typeof LIVE_SERVER_EVENT.COMMENTARY_APPENDED }
+>;
+
+const SEGMENT_ROLE_OF_DELTA = {
+  [LIVE_SERVER_EVENT.INPUT_TRANSCRIPT_DELTA]: VOICE_SEGMENT_ROLE.USER,
+  [LIVE_SERVER_EVENT.OUTPUT_TRANSCRIPT_DELTA]: VOICE_SEGMENT_ROLE.ASSISTANT,
+} as const satisfies Record<SegmentDelta["type"], VoiceSegmentRole>;
+
+export function voiceWriter({ db, store }: VoiceWriterOptions): VoiceWriter {
+  /** Appends by live session and client event id: the one thing kept in memory, and only until the speech lands. */
+  const pending = new Map<string, Map<string, PendingAppend>>();
+
+  const appendsOf = (liveSessionId: string): Map<string, PendingAppend> => {
+    const standing = pending.get(liveSessionId);
+    if (standing !== undefined) return standing;
+    const created = new Map<string, PendingAppend>();
+    pending.set(liveSessionId, created);
+    return created;
+  };
+
+  /**
+   * The row's id, or nothing when no row stands for this account and live
+   * session, since the writer invents no session. Locked where the caller is
+   * about to take a position in the session's sequence, so two deltas of one
+   * session take theirs in turn.
+   */
+  async function sessionId(
+    tx: HostedStoreDatabase,
+    target: VoiceTarget,
+    lock: boolean,
+  ): Promise<string | undefined> {
+    const query = tx
+      .select({ id: voiceSessions.id })
+      .from(voiceSessions)
+      .where(
+        and(
+          eq(voiceSessions.userId, target.userId),
+          eq(voiceSessions.liveSessionId, target.liveSessionId),
+        ),
+      );
+    const [row] = await (lock ? query.for("update") : query);
+    return row?.id;
+  }
+
+  /** One segment, at the next position of the session's own sequence; the primary key is the backstop. Answers the row's id. */
+  async function appendSegment(
+    target: VoiceTarget,
+    delta: SegmentDelta,
+  ): Promise<string | undefined> {
+    return db.transaction(async (tx) => {
+      const voiceSessionId = await sessionId(tx, target, true);
+      if (voiceSessionId === undefined) return undefined;
+      const [last] = await tx
+        .select({ seq: sql<number>`coalesce(max(${voiceTranscriptSegments.seq}), 0)::int` })
+        .from(voiceTranscriptSegments)
+        .where(eq(voiceTranscriptSegments.voiceSessionId, voiceSessionId));
+      await tx.insert(voiceTranscriptSegments).values({
+        voiceSessionId,
+        seq: (last?.seq ?? 0) + 1,
+        role: SEGMENT_ROLE_OF_DELTA[delta.type],
+        text: delta.delta,
+        startMs: delta.start_ms,
+        endMs: delta.end_ms,
+      });
+      return voiceSessionId;
+    });
+  }
+
+  /**
+   * A briefing is known to have been said when the session's own voice
+   * follows the append: the first output delta that begins at or after the
+   * appended commentary's end writes `speech.spoken` on the briefing's
+   * message, once, and the append is forgotten.
+   */
+  async function markSpoken(
+    target: VoiceTarget,
+    delta: SegmentDelta,
+    voiceSessionId: string,
+  ): Promise<VoiceWriteResult | undefined> {
+    const appends = appendsOf(target.liveSessionId);
+    for (const [clientEventId, append] of appends) {
+      if (append.spokenFromMs === undefined || delta.start_ms < append.spokenFromMs) continue;
+      appends.delete(clientEventId);
+      const written = await store.recordEvent(append.conversation, {
+        messageId: append.messageId,
+        kind: CONVERSATION_EVENT_KIND.SPEECH_SPOKEN,
+        // Which session said it, and when on that session's clock.
+        payload: { voice_session_id: voiceSessionId, at_ms: delta.start_ms },
+      });
+      if (written.ok) return WRITTEN;
+      return written.refusal === STORE_WRITE_REFUSAL.NO_MESSAGE
+        ? { ok: false, refusal: VOICE_WRITE_REFUSAL.NO_MESSAGE }
+        : { ok: false, refusal: VOICE_WRITE_REFUSAL.NO_CONVERSATION };
+    }
+    return undefined;
+  }
+
+  function placeAppend(target: VoiceTarget, appended: CommentaryAppended): VoiceWriteResult {
+    const clientEventId = appended.client_event_id;
+    if (clientEventId === undefined) return IGNORED;
+    const append = appendsOf(target.liveSessionId).get(clientEventId);
+    if (append === undefined) return IGNORED;
+    append.spokenFromMs = appended.end_ms;
+    return WRITTEN;
+  }
+
+  /**
+   * The developer's spoken ask, cut where the delegation places it: every
+   * segment of the developer's own words from the previous ask's end (or the
+   * session's start) up to the delegation's offset, joined exactly as the
+   * deltas came, and written as a user message on the voice channel naming
+   * the session, the delegation, and the span. A delegation with no words
+   * before it writes nothing.
+   */
+  async function recordSpokenAsk(
+    target: VoiceTarget,
+    created: DelegationCreated,
+  ): Promise<VoiceWriteResult> {
+    const voiceSessionId = await sessionId(db, target, false);
+    if (voiceSessionId === undefined) return NO_SESSION;
+    const previous = await store.spokenAskEnd(target.conversation, {
+      voiceSessionId,
+      delegationId: created.delegation.id,
+    });
+    if (!previous.ok) return { ok: false, refusal: previous.refusal };
+    const fromMs = previous.toMs;
+    const spoken = await db
+      .select({ text: voiceTranscriptSegments.text, startMs: voiceTranscriptSegments.startMs })
+      .from(voiceTranscriptSegments)
+      .where(
+        and(
+          eq(voiceTranscriptSegments.voiceSessionId, voiceSessionId),
+          eq(voiceTranscriptSegments.role, VOICE_SEGMENT_ROLE.USER),
+          gte(voiceTranscriptSegments.startMs, fromMs),
+          lt(voiceTranscriptSegments.startMs, created.offset_ms),
+        ),
+      )
+      .orderBy(voiceTranscriptSegments.seq);
+    const text = spoken.map((segment) => segment.text).join("");
+    if (text.length === 0) return IGNORED;
+    const metadata: SpokenAskMetadata = {
+      author: MESSAGE_AUTHOR.DEVELOPER,
+      channel: MESSAGE_CHANNEL.VOICE,
+      voice_session_id: voiceSessionId,
+      delegation_id: created.delegation.id,
+      from_ms: Math.min(...spoken.map((segment) => segment.startMs)),
+      to_ms: created.offset_ms,
+    };
+    const written = await store.recordUserMessage(target.conversation, {
+      clientId: created.delegation.id,
+      text,
+      metadata,
+    });
+    if (written.ok) return written.effect === STORE_WRITE_EFFECT.REPEATED ? REPEATED : WRITTEN;
+    return { ok: false, refusal: written.refusal };
+  }
+
+  return {
+    noteAppend(target, append) {
+      appendsOf(target.liveSessionId).set(append.clientEventId, {
+        messageId: append.messageId,
+        conversation: target.conversation,
+      });
+    },
+    async consume(target, event) {
+      switch (event.type) {
+        case LIVE_SERVER_EVENT.INPUT_TRANSCRIPT_DELTA:
+          return (await appendSegment(target, event)) === undefined ? NO_SESSION : WRITTEN;
+        case LIVE_SERVER_EVENT.OUTPUT_TRANSCRIPT_DELTA: {
+          const voiceSessionId = await appendSegment(target, event);
+          if (voiceSessionId === undefined) return NO_SESSION;
+          return (await markSpoken(target, event, voiceSessionId)) ?? WRITTEN;
+        }
+        case LIVE_SERVER_EVENT.COMMENTARY_APPENDED:
+          return placeAppend(target, event);
+        case LIVE_SERVER_EVENT.DELEGATION_CREATED:
+          return recordSpokenAsk(target, event);
+        default:
+          return IGNORED;
+      }
+    },
+  };
+}

--- a/apps/web/server/hosted/store/writer.ts
+++ b/apps/web/server/hosted/store/writer.ts
@@ -8,7 +8,7 @@ import {
   type UIMessage,
   type UITools,
 } from "ai";
-import { and, eq, isNull, sql } from "drizzle-orm";
+import { and, eq, isNull, ne, sql } from "drizzle-orm";
 import {
   BRAIN_REQUEST_STATUS,
   BRAIN_RUN_EVENT,
@@ -40,6 +40,7 @@ import {
   UI_PART_STATE,
   UI_PART_TYPE,
   type UnparsedWireValue,
+  type UserMessageMetadata,
   unknownActionOutput,
   unparsedWire,
 } from "../../core.js";
@@ -194,6 +195,32 @@ interface CompactionWrite {
   readonly tokensBefore?: number;
 }
 
+/**
+ * A user message written outside the run stream: the developer's own words
+ * as another writer cut them — a spoken ask from a voice session's transcript
+ * — with the metadata that says how they arrived. Idempotent on its client id.
+ */
+interface UserMessageWrite {
+  readonly clientId: string;
+  readonly turnId?: string;
+  readonly text: string;
+  readonly metadata: UserMessageMetadata;
+}
+
+/** Where the developer's earlier spoken asks on one voice session end, for the next to be cut from. */
+interface SpokenAskEnd {
+  readonly voiceSessionId: string;
+  /** The ask being cut, left out so a delegation told twice cuts the same span. */
+  readonly delegationId: string;
+}
+
+type SpokenAskEndResult = { readonly ok: true; readonly toMs: number } | typeof NO_CONVERSATION;
+
+type UserMessageWriteResult =
+  | { readonly ok: true; readonly id: string; readonly effect: StoreWriteEffect }
+  | typeof NO_CONVERSATION
+  | Extract<StoreWriteResult, { ok: false; refusal: typeof STORE_WRITE_REFUSAL.MESSAGE_REFUSED }>;
+
 interface EventWrite {
   readonly messageId: string;
   readonly kind: ConversationEventKind;
@@ -209,7 +236,7 @@ type EventWriteResult =
       | typeof STORE_WRITE_REFUSAL.ALREADY_CLAIMED
     >;
 
-interface StoreWriter {
+export interface StoreWriter {
   /** Consumes one event of the run stream for the conversation it names. */
   consume(target: ConversationTarget, event: BrainRunEvent): Promise<StoreWriteResult>;
   /** Writes a turn as queued, ahead of the stream telling its start; answers the turn's id. */
@@ -221,6 +248,13 @@ interface StoreWriter {
   ): Promise<StoreWriteResult>;
   /** Appends one event about a message, numbered by the conversation's event sequence. */
   recordEvent(target: ConversationTarget, event: EventWrite): Promise<EventWriteResult>;
+  /** Writes the developer's own words as a finished user message, once per client id. */
+  recordUserMessage(
+    target: ConversationTarget,
+    message: UserMessageWrite,
+  ): Promise<UserMessageWriteResult>;
+  /** The latest end, on the session's clock, of the spoken asks already written for one voice session; zero for none. */
+  spokenAskEnd(target: ConversationTarget, end: SpokenAskEnd): Promise<SpokenAskEndResult>;
 }
 
 /**
@@ -802,6 +836,47 @@ async function recordCompaction(
   return { ok: true, effect: STORE_WRITE_EFFECT.WRITTEN };
 }
 
+async function spokenAskEnd(
+  context: WriterContext,
+  end: SpokenAskEnd,
+): Promise<SpokenAskEndResult> {
+  const [row] = await context.tx
+    .select({ toMs: sql<number>`coalesce(max((${messages.metadata} ->> 'to_ms')::int), 0)::int` })
+    .from(messages)
+    .where(
+      and(
+        eq(messages.conversationId, context.target.conversationId),
+        ne(messages.clientId, end.delegationId),
+        sql`${messages.metadata} ->> 'voice_session_id' = ${end.voiceSessionId}`,
+      ),
+    );
+  return { ok: true, toMs: row?.toMs ?? 0 };
+}
+
+async function recordUserMessage(
+  context: WriterContext,
+  write: UserMessageWrite,
+): Promise<UserMessageWriteResult> {
+  const standing = await messageByClientId(context, write.clientId);
+  if (standing !== undefined) {
+    return { ok: true, id: standing.id, effect: STORE_WRITE_EFFECT.REPEATED };
+  }
+  const read = await admitted(context, {
+    id: write.clientId,
+    role: MESSAGE_ROLE.USER,
+    metadata: write.metadata,
+    parts: [{ type: UI_PART_TYPE.TEXT, text: write.text, state: UI_PART_STATE.DONE }],
+  });
+  if (!read.ok) return read;
+  const id = await insertMessage(context, {
+    clientId: write.clientId,
+    turnId: write.turnId,
+    message: read.message,
+    finishedAt: context.now(),
+  });
+  return { ok: true, id, effect: STORE_WRITE_EFFECT.WRITTEN };
+}
+
 /**
  * One event about a message. A claim is the one kind the schema makes
  * exclusive, and under the conversation's lock the check for a standing claim
@@ -890,5 +965,9 @@ export async function storeWriter({
       underConversation(target, (context) => recordCompaction(context, compaction)),
     recordEvent: (target, event) =>
       underConversation(target, (context) => recordEvent(context, event)),
+    recordUserMessage: (target, message) =>
+      underConversation(target, (context) => recordUserMessage(context, message)),
+    spokenAskEnd: (target, end) =>
+      underConversation(target, (context) => spokenAskEnd(context, end)),
   };
 }

--- a/apps/web/tests/voice-writer.test.ts
+++ b/apps/web/tests/voice-writer.test.ts
@@ -1,0 +1,414 @@
+import assert from "node:assert/strict";
+import test, { after } from "node:test";
+import { type ToolSet, tool } from "ai";
+import { asc, eq } from "drizzle-orm";
+import { z } from "zod";
+import {
+  CONVERSATION_EVENT_KIND,
+  MESSAGE_AUTHOR,
+  MESSAGE_CHANNEL,
+  MESSAGE_ROLE,
+  type UserMessageMetadata,
+} from "../server/core";
+import { CONVERSATION_KIND, conversations, events, messages } from "../server/db/storage-schema";
+import {
+  VOICE_SEGMENT_ROLE,
+  voiceSessions,
+  voiceTranscriptSegments,
+} from "../server/db/voice-schema";
+import {
+  type CommentaryAppend,
+  type ConversationTarget,
+  STORE_WRITE_EFFECT,
+  storeWriter,
+  VOICE_WRITE_REFUSAL,
+  type VoiceTarget,
+  type VoiceWriteResult,
+  type VoiceWriter,
+  voiceWriter,
+} from "../server/hosted/store";
+import { LIVE_DELEGATION_TARGET, LIVE_SERVER_EVENT, type LiveServerEvent } from "../server/live";
+import { voiceSessionRecord } from "../server/voice/session-record";
+import { openHostedStoreTestDatabase } from "./support/hosted-store-database";
+
+/**
+ * The voice writer over the real migrations on PGlite, fed a synthetic Live
+ * stream: no real spoken word, title, or session. What these tests hold to is
+ * the record the plan describes — which segments a stream leaves, with which
+ * timings and roles, on which row; when the briefing's message is marked
+ * spoken; which words a delegation cuts into the developer's ask — and never
+ * the words themselves beyond the fixtures' own.
+ */
+
+const NOW = Date.parse("2026-09-10T12:00:00.000Z");
+
+const database = await openHostedStoreTestDatabase();
+after(() => database.close());
+
+const TOOLS: ToolSet = {
+  announce: tool({
+    description: "Says a briefing aloud.",
+    inputSchema: z.object({ briefing: z.string() }),
+    outputSchema: z.object({}),
+  }),
+};
+
+const store = await storeWriter({ db: database.db, tools: TOOLS, now: () => new Date(NOW) });
+const record = voiceSessionRecord(database.db, () => NOW);
+
+let liveSessions = 0;
+let eventIds = 0;
+
+const WRITTEN: VoiceWriteResult = { ok: true, effect: STORE_WRITE_EFFECT.WRITTEN };
+
+function writer(): VoiceWriter {
+  return voiceWriter({ db: database.db, store });
+}
+
+/** A user with a main conversation and a registered live session, the shape every stream lands on. */
+async function target(): Promise<VoiceTarget> {
+  const userId = await database.createUser();
+  const [row] = await database.db
+    .insert(conversations)
+    .values({ userId, kind: CONVERSATION_KIND.MAIN })
+    .returning({ id: conversations.id });
+  assert.ok(row);
+  liveSessions += 1;
+  const liveSessionId = `sess_fixture_${liveSessions}`;
+  await record.register({ userId, sessionId: liveSessionId });
+  return { userId, liveSessionId, conversation: { userId, conversationId: row.id } };
+}
+
+function eventId(): string {
+  eventIds += 1;
+  return `evt_${eventIds}`;
+}
+
+function heard(delta: string, startMs: number, endMs: number): LiveServerEvent {
+  return {
+    type: LIVE_SERVER_EVENT.INPUT_TRANSCRIPT_DELTA,
+    event_id: eventId(),
+    delta,
+    start_ms: startMs,
+    end_ms: endMs,
+  };
+}
+
+function said(delta: string, startMs: number, endMs: number): LiveServerEvent {
+  return {
+    type: LIVE_SERVER_EVENT.OUTPUT_TRANSCRIPT_DELTA,
+    event_id: eventId(),
+    delta,
+    start_ms: startMs,
+    end_ms: endMs,
+  };
+}
+
+function appended(clientEventId: string, startMs: number, endMs: number): LiveServerEvent {
+  return {
+    type: LIVE_SERVER_EVENT.COMMENTARY_APPENDED,
+    event_id: eventId(),
+    client_event_id: clientEventId,
+    start_ms: startMs,
+    end_ms: endMs,
+  };
+}
+
+function delegated(delegationId: string, offsetMs: number): LiveServerEvent {
+  return {
+    type: LIVE_SERVER_EVENT.DELEGATION_CREATED,
+    event_id: eventId(),
+    offset_ms: offsetMs,
+    delegation: { id: delegationId, target: LIVE_DELEGATION_TARGET.CLIENT },
+  };
+}
+
+async function sessionRowId(liveSessionId: string): Promise<string> {
+  const [row] = await database.db
+    .select({ id: voiceSessions.id })
+    .from(voiceSessions)
+    .where(eq(voiceSessions.liveSessionId, liveSessionId));
+  assert.ok(row);
+  return row.id;
+}
+
+async function segments(liveSessionId: string) {
+  return database.db
+    .select({
+      seq: voiceTranscriptSegments.seq,
+      role: voiceTranscriptSegments.role,
+      text: voiceTranscriptSegments.text,
+      startMs: voiceTranscriptSegments.startMs,
+      endMs: voiceTranscriptSegments.endMs,
+    })
+    .from(voiceTranscriptSegments)
+    .where(eq(voiceTranscriptSegments.voiceSessionId, await sessionRowId(liveSessionId)))
+    .orderBy(asc(voiceTranscriptSegments.seq));
+}
+
+/** The briefing message a `speech.spoken` hangs on: an announce written by the store writer's own path. */
+async function briefing(conversation: ConversationTarget): Promise<string> {
+  const enqueued = await store.enqueueTurn(conversation, { origin: "roster_diff" });
+  assert.ok(enqueued.ok);
+  const written = await store.recordCompaction(conversation, {
+    clientId: `briefing-${enqueued.turnId}`,
+    turnId: enqueued.turnId,
+    text: "Earlier briefings folded.",
+    firstKeptMessageId: "00000000-0000-4000-8000-000000000000",
+  });
+  assert.ok(written.ok);
+  const [row] = await database.db
+    .select({ id: messages.id })
+    .from(messages)
+    .where(eq(messages.conversationId, conversation.conversationId));
+  assert.ok(row);
+  return row.id;
+}
+
+async function speechEvents(conversation: ConversationTarget) {
+  return database.db
+    .select({ kind: events.kind, messageId: events.messageId, payload: events.payload })
+    .from(events)
+    .where(eq(events.conversationId, conversation.conversationId))
+    .orderBy(asc(events.seq));
+}
+
+test("transcript deltas become segments with their timings and roles, in the order they arrived, overlap included", async () => {
+  const live = await target();
+  const voice = writer();
+  const results: VoiceWriteResult[] = [
+    await voice.consume(live, heard("what is", 1200, 1800)),
+    await voice.consume(live, heard(" the fixture waiting on", 1700, 3400)),
+    await voice.consume(live, said("It is waiting", 3500, 4300)),
+    await voice.consume(live, said(" on a permission prompt.", 4200, 5600)),
+  ];
+  assert.deepEqual(results, [WRITTEN, WRITTEN, WRITTEN, WRITTEN]);
+  assert.deepEqual(await segments(live.liveSessionId), [
+    { seq: 1, role: VOICE_SEGMENT_ROLE.USER, text: "what is", startMs: 1200, endMs: 1800 },
+    {
+      seq: 2,
+      role: VOICE_SEGMENT_ROLE.USER,
+      text: " the fixture waiting on",
+      startMs: 1700,
+      endMs: 3400,
+    },
+    {
+      seq: 3,
+      role: VOICE_SEGMENT_ROLE.ASSISTANT,
+      text: "It is waiting",
+      startMs: 3500,
+      endMs: 4300,
+    },
+    {
+      seq: 4,
+      role: VOICE_SEGMENT_ROLE.ASSISTANT,
+      text: " on a permission prompt.",
+      startMs: 4200,
+      endMs: 5600,
+    },
+  ]);
+  assert.deepEqual(await speechEvents(live.conversation), []);
+});
+
+test("segments after a gap land on the same open row, from a fresh writer, with closed_at still null", async () => {
+  const live = await target();
+  const first = writer();
+  await first.consume(live, heard("before the gap", 1000, 2000));
+  await record.noteUsage({ sessionId: live.liveSessionId, seconds: 12 });
+
+  const attached = writer();
+  await record.register({ userId: live.userId, sessionId: live.liveSessionId });
+  assert.deepEqual(await attached.consume(live, heard("after the gap", 900_000, 901_000)), WRITTEN);
+
+  const rows = await database.db
+    .select({ closedAt: voiceSessions.closedAt, usage: voiceSessions.usage })
+    .from(voiceSessions)
+    .where(eq(voiceSessions.liveSessionId, live.liveSessionId));
+  assert.deepEqual(rows, [{ closedAt: null, usage: { seconds: 12, confirmed: false } }]);
+  assert.deepEqual(
+    (await segments(live.liveSessionId)).map((segment) => [segment.seq, segment.startMs]),
+    [
+      [1, 1000],
+      [2, 900_000],
+    ],
+  );
+});
+
+test("a session no row stands for is refused, and another account's row is not this account's", async () => {
+  const live = await target();
+  const voice = writer();
+  assert.deepEqual(
+    await voice.consume({ ...live, liveSessionId: "sess_unknown" }, heard("x", 0, 1)),
+    {
+      ok: false,
+      refusal: VOICE_WRITE_REFUSAL.NO_SESSION,
+    },
+  );
+  const other = await database.createUser();
+  assert.deepEqual(await voice.consume({ ...live, userId: other }, heard("x", 0, 1)), {
+    ok: false,
+    refusal: VOICE_WRITE_REFUSAL.NO_SESSION,
+  });
+  assert.deepEqual(await segments(live.liveSessionId), []);
+});
+
+test("events the writer does not keep are ignored, and nothing is written for them", async () => {
+  const live = await target();
+  const voice = writer();
+  const ignored: LiveServerEvent[] = [
+    { type: LIVE_SERVER_EVENT.INPUT_AUDIO_MUTED, event_id: eventId() },
+    { type: LIVE_SERVER_EVENT.USAGE_UPDATED, event_id: eventId(), usage: { seconds: 3 } },
+    { type: LIVE_SERVER_EVENT.INPUT_AUDIO_APPEND },
+    { type: LIVE_SERVER_EVENT.OUTPUT_AUDIO_DELTA },
+    {
+      type: LIVE_SERVER_EVENT.SESSION_STARTED,
+      event_id: eventId(),
+      session: { id: live.liveSessionId },
+    },
+  ];
+  for (const event of ignored) {
+    assert.deepEqual(await voice.consume(live, event), {
+      ok: true,
+      effect: STORE_WRITE_EFFECT.IGNORED,
+    });
+  }
+  assert.deepEqual(await segments(live.liveSessionId), []);
+  assert.deepEqual(await speechEvents(live.conversation), []);
+});
+
+test("speech.spoken is written once, on the first output delta at or after the append's end", async () => {
+  const live = await target();
+  const messageId = await briefing(live.conversation);
+  const voice = writer();
+  const append: CommentaryAppend = { clientEventId: "append-1", messageId };
+  voice.noteAppend(live, append);
+
+  // Before the ack places the append, a delta says nothing about it.
+  await voice.consume(live, said("Earlier words.", 100, 900));
+  assert.deepEqual(await voice.consume(live, appended("append-1", 1000, 4000)), {
+    ok: true,
+    effect: STORE_WRITE_EFFECT.WRITTEN,
+  });
+  // A delta that begins before the appended commentary ends is not its speech.
+  await voice.consume(live, said("The fixture", 3800, 4100));
+  assert.deepEqual(await speechEvents(live.conversation), []);
+  // The first delta beginning at or after the end is.
+  await voice.consume(live, said(" session is waiting", 4000, 5200));
+  await voice.consume(live, said(" on a permission prompt.", 5200, 6400));
+
+  const spoken = await speechEvents(live.conversation);
+  const voiceSessionId = await sessionRowId(live.liveSessionId);
+  assert.deepEqual(spoken, [
+    {
+      kind: CONVERSATION_EVENT_KIND.SPEECH_SPOKEN,
+      messageId,
+      payload: { voice_session_id: voiceSessionId, at_ms: 4000 },
+    },
+  ]);
+  // Every delta was still a segment, whatever it said about the append.
+  assert.equal((await segments(live.liveSessionId)).length, 4);
+  // An ack for an append this writer was never told of is ignored rather than marked.
+  assert.deepEqual(await voice.consume(live, appended("append-unknown", 7000, 8000)), {
+    ok: true,
+    effect: STORE_WRITE_EFFECT.IGNORED,
+  });
+});
+
+test("an append whose message is gone is refused at the speech, not the segment", async () => {
+  const live = await target();
+  const voice = writer();
+  voice.noteAppend(live, {
+    clientEventId: "append-2",
+    messageId: "00000000-0000-4000-8000-000000000404",
+  });
+  await voice.consume(live, appended("append-2", 0, 500));
+  assert.deepEqual(await voice.consume(live, said("Words.", 600, 900)), {
+    ok: false,
+    refusal: VOICE_WRITE_REFUSAL.NO_MESSAGE,
+  });
+  assert.equal((await segments(live.liveSessionId)).length, 1);
+});
+
+async function spokenAsks(conversation: ConversationTarget) {
+  return database.db
+    .select({
+      clientId: messages.clientId,
+      role: messages.role,
+      parts: messages.parts,
+      metadata: messages.metadata,
+      finishedAt: messages.finishedAt,
+    })
+    .from(messages)
+    .where(eq(messages.conversationId, conversation.conversationId))
+    .orderBy(asc(messages.seq));
+}
+
+test("a delegation cuts the developer's words before it into a spoken ask naming its span, and the next cuts from there", async () => {
+  const live = await target();
+  const voice = writer();
+  const voiceSessionId = await sessionRowId(live.liveSessionId);
+  await voice.consume(live, heard("What is the fixture", 1200, 2600));
+  await voice.consume(live, heard(" waiting on?", 2500, 4800));
+  await voice.consume(live, said("It is waiting on a permission prompt.", 5000, 7000));
+  assert.deepEqual(await voice.consume(live, delegated("dl_1", 4900)), {
+    ok: true,
+    effect: STORE_WRITE_EFFECT.WRITTEN,
+  });
+  await voice.consume(live, heard("Tell it to go ahead.", 8000, 9400));
+  assert.deepEqual(await voice.consume(live, delegated("dl_2", 9500)), {
+    ok: true,
+    effect: STORE_WRITE_EFFECT.WRITTEN,
+  });
+
+  const first: UserMessageMetadata = {
+    author: MESSAGE_AUTHOR.DEVELOPER,
+    channel: MESSAGE_CHANNEL.VOICE,
+    voice_session_id: voiceSessionId,
+    delegation_id: "dl_1",
+    from_ms: 1200,
+    to_ms: 4900,
+  };
+  const second: UserMessageMetadata = {
+    ...first,
+    delegation_id: "dl_2",
+    from_ms: 8000,
+    to_ms: 9500,
+  };
+  assert.deepEqual(await spokenAsks(live.conversation), [
+    {
+      clientId: "dl_1",
+      role: MESSAGE_ROLE.USER,
+      parts: [{ type: "text", text: "What is the fixture waiting on?", state: "done" }],
+      metadata: first,
+      finishedAt: new Date(NOW),
+    },
+    {
+      clientId: "dl_2",
+      role: MESSAGE_ROLE.USER,
+      parts: [{ type: "text", text: "Tell it to go ahead.", state: "done" }],
+      metadata: second,
+      finishedAt: new Date(NOW),
+    },
+  ]);
+  // Nothing Luke said became a message; his words are segments alone.
+  assert.equal((await segments(live.liveSessionId)).length, 4);
+});
+
+test("a delegation is one ask however many times it is told, and one with no words before it writes nothing", async () => {
+  const live = await target();
+  const voice = writer();
+  assert.deepEqual(await voice.consume(live, delegated("dl_empty", 500)), {
+    ok: true,
+    effect: STORE_WRITE_EFFECT.IGNORED,
+  });
+  await voice.consume(live, heard("Stop the fixture.", 600, 1800));
+  assert.deepEqual(await voice.consume(live, delegated("dl_3", 2000)), {
+    ok: true,
+    effect: STORE_WRITE_EFFECT.WRITTEN,
+  });
+  assert.deepEqual(await voice.consume(live, delegated("dl_3", 2000)), {
+    ok: true,
+    effect: STORE_WRITE_EFFECT.REPEATED,
+  });
+  assert.equal((await spokenAsks(live.conversation)).length, 1);
+});

--- a/apps/web/tests/voice-writer.test.ts
+++ b/apps/web/tests/voice-writer.test.ts
@@ -314,6 +314,40 @@ test("speech.spoken is written once, on the first output delta at or after the a
   });
 });
 
+test("one delta past the ends of two acknowledged appends marks both briefings", async () => {
+  const live = await target();
+  const first = await briefing(live.conversation);
+  const [row] = await database.db
+    .insert(messages)
+    .values({
+      userId: live.userId,
+      conversationId: live.conversation.conversationId,
+      seq: 99,
+      clientId: "second-briefing",
+      role: MESSAGE_ROLE.ASSISTANT,
+      parts: [{ type: "text", text: "A second briefing.", state: "done" }],
+      metadata: { author: MESSAGE_AUTHOR.BRAIN },
+    })
+    .returning({ id: messages.id });
+  assert.ok(row);
+  const voice = writer();
+  voice.noteAppend(live, { clientEventId: "append-a", messageId: first });
+  voice.noteAppend(live, { clientEventId: "append-b", messageId: row.id });
+  await voice.consume(live, appended("append-a", 0, 1000));
+  await voice.consume(live, appended("append-b", 1000, 2000));
+  assert.deepEqual(await voice.consume(live, said("Both said.", 2000, 3000)), WRITTEN);
+  assert.deepEqual(
+    (await speechEvents(live.conversation)).map((event) => [event.kind, event.messageId]),
+    [
+      [CONVERSATION_EVENT_KIND.SPEECH_SPOKEN, first],
+      [CONVERSATION_EVENT_KIND.SPEECH_SPOKEN, row.id],
+    ],
+  );
+  // Neither is marked a second time.
+  await voice.consume(live, said("And more.", 3000, 4000));
+  assert.equal((await speechEvents(live.conversation)).length, 2);
+});
+
 test("an append whose message is gone is refused at the speech, not the segment", async () => {
   const live = await target();
   const voice = writer();


### PR DESCRIPTION
## What

The voice writer, `apps/web/server/hosted/store/voice-writer.ts`, beside B5's store writer: a library that consumes a GPT Live session's server events (`LiveServerEvent`, read through `server/live.ts`) and writes what the plan gives the voice. No route, no consumer yet; C8 wires it.

`voiceWriter({ db, store }).consume(target, event)` where `target` is `{ userId, liveSessionId, conversation }`:

- **Segments.** Every `session.input_transcript.delta` and `session.output_transcript.delta` becomes one `voice_transcript_segments` row: the delta's words exactly as received, `user` or `assistant`, `start_ms`/`end_ms` on the session's clock, at the next position of the session's own sequence (allocated under the `voice_sessions` row's lock; the primary key on `(voice_session_id, seq)` is the backstop). Overlapping spans are stored as they came.
- **`speech.spoken`.** The service tells the writer which message a commentary append carries (`noteAppend({ clientEventId, messageId })`). The `session.commentary.appended` ack places the append by `client_event_id` and its `end_ms`; the first `output_transcript.delta` whose `start_ms` is at or after that end writes one `speech.spoken` event on the briefing's message through the store writer's `recordEvent`, payload `{ voice_session_id, at_ms }`, and the append is forgotten. Deltas before the end, and acks for appends the writer was never told of, mark nothing.
- **The spoken ask.** On `session.delegation.created`, the developer's `user` segments from the previous ask's end (read back from the stored asks' `to_ms` for this session, or the session's start) up to the delegation's `offset_ms` are joined as received and written as a **user message** on the voice channel: `{ author: developer, channel: voice, voice_session_id, delegation_id, from_ms, to_ms }`, idempotent on the delegation id as `client_id`. A delegation with no words before it writes nothing.
- Everything else on the stream (`session.started`, `usage.updated`, `session.closed`, mute acks, reflected audio) is ignored here: the session row is another writer's, and audio is never stored.

## The `voice_sessions` row, as settled

The rollout's PR 4b (`server/voice/session-record.ts`, merged as `8030562e`) owns that row's whole life. This writer **reads it for its id alone**, by `(user_id, live_session_id)`, and reads nothing of its state: a row with `closed_at` null may still gain segments, because an instance dying at its duration bound sends no `session.closed` and the re-attach lands on the same row. Nothing is kept between events but the pending appends (the same connection that sends an append hears its ack), and the ask boundary is read back from the record, so a fresh instance continues where the last stopped.

## Two seams on B5's writer

`StoreWriter.recordUserMessage(target, { clientId, turnId?, text, metadata })`: the developer's own words as a finished user message, held to the vocabulary through the same `readStoredUIMessages` path every message write takes, idempotent on `client_id`. `StoreWriter.spokenAskEnd(target, { voiceSessionId, delegationId })`: where this session's earlier asks end, the delegation being cut left out so a delegation told twice cuts the same span and lands on its own row. The messages table keeps one writer and one importer.

## Tests (`apps/web/tests/voice-writer.test.ts`, PGlite on the real migrations, in `test:store`)

Segments carry timings and roles in arrival order with overlap; **segments after a gap, from a fresh writer, land on the same row with `closed_at` still null** (the required re-attach case, with a usage snapshot standing unconfirmed); an unknown live session and another account's session are refused `no_session`; ignored kinds write nothing; `speech.spoken` is written exactly once on the first output delta at or after the append's end, not before, with an ack for an unknown append ignored; an append whose message is gone is refused at the speech and the segment still lands; two delegations cut two asks with their spans and the second cuts from the first's end; a delegation told twice is one ask (`repeated`) and a wordless one writes nothing; nothing Luke said became a message. All fixtures are synthetic.

Stored messages are read only through `readStoredUIMessages` (B5's `admitted`); the SDK's validator is never called directly, and no new cast was needed.

## Conventions

Instants are the tables' own `timestamp with time zone`; no instant is introduced. Value sets are imported from `voice-schema.ts` (`VOICE_SEGMENT_ROLE`) and `@sidecar/wire` (`MESSAGE_AUTHOR`, `MESSAGE_CHANNEL`, `CONVERSATION_EVENT_KIND`); nothing is respelled. `LIVE_SERVER_EVENT` and `LIVE_DELEGATION_TARGET` come through `server/live.ts`. Nothing under `server/voice/` or `api/voice/*` is touched.

## Replay and duplication, settled

Segments carry no Live `event_id` on purpose, and the question is closed rather than deferred, with the Live docs as the source (confirmed through the rollout's orchestrator):

1. **Re-attach does not replay.** The sideband reference says attaching "does not create a session or replay earlier events", and the server-controls guide tells the client to retain its own history rather than rely on attachment to reconstruct transcripts. A fresh instance receives only deltas produced after it attached; whatever was emitted between the old instance dying and the new one attaching is gone, a gap PR 4b documents as acceptable. **Transcript deltas carry no event id at all**, so there is nothing to key on even if a writer wanted to.
2. **Overlap is not duplication.** The docs allow deltas whose `start_ms`/`end_ms` ranges overlap and say to append them verbatim. A writer that deduplicated by time range would **drop real text**; that is the actual hazard, and it is why this writer stores every delta as it came and orders by `(voice_session_id, seq)` exactly as B3 laid the table out.

## One writer per table, enforced

B5's boundary test caught the first head of this PR importing the `messages` table for the previous-ask lookup. The lookup moved behind `StoreWriter.spokenAskEnd`, so `messages` keeps one importer; the test was not widened.

## Reviews run

- **Thermonuclear code quality review** (Cursor's `cursor-team-kit` skill, as written): the session lookup is one function used locked or unlocked rather than two; a stray `now` option nothing read and a speaker-to-role table nothing used were removed; the payload interface became the object literal it was.
- **Cursor Bugbot** found one real issue on the first head, fixed in the follow-up commit: a delta past the ends of two acknowledged appends marked only the first briefing, so a second appended back to back could wait forever. Every append the delta has reached is now marked by it, with a test.
- **Ponytail review** (`DietrichGebert/ponytail`, as written): `delete` — the two unused exports above; otherwise lean.

## Verify

`./scripts/check.sh` passes (lint, knip, typecheck, every package's tests including the new PGlite suite, build). No macOS or UI code; `verify.sh` does not apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34546341482/artifacts/10179193540) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34546341482)

- Commit: `3eb9c23c293597fce418862d0360536ead381775`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
