### PR TITLE
fix(host): register the live exchange before awaiting the record write

### DIFF
--- a/packages/host/src/voice/live-session-service.test.ts
+++ b/packages/host/src/voice/live-session-service.test.ts
@@ -41,6 +41,7 @@ import {
 } from "./live-brain.js";
 import type { DeveloperUtteranceRecord, LiveRecord, LukeUtteranceRecord } from "./live-record.js";
 import {
+  ASK_UNRECORDED_NOTE,
   LiveSessionService,
   RUN_END_NOTE,
   STOP_SPEAKING_INSTRUCTION,
@@ -192,10 +193,31 @@ class FakeBrain implements LiveBrain {
 class FakeRecord implements LiveRecord {
   readonly developer: DeveloperUtteranceRecord[] = [];
   readonly luke: LukeUtteranceRecord[] = [];
+  /** While set, developer writes wait here for the test to answer them. */
+  #held: ((written: boolean) => void)[] | undefined;
+
+  /** The next developer writes are held until `release` answers them. */
+  hold(): void {
+    this.#held = [];
+  }
+
+  /** Answers the oldest held developer write; a write answered true is on the record. */
+  release(written: boolean): void {
+    const held = this.#held?.shift();
+    assert.ok(held, "a developer write is held");
+    held(written);
+  }
 
   async writeDeveloperUtterance(record: DeveloperUtteranceRecord): Promise<boolean> {
-    this.developer.push(record);
-    return true;
+    if (this.#held === undefined) {
+      this.developer.push(record);
+      return true;
+    }
+    const written = await new Promise<boolean>((resolve) => {
+      this.#held?.push(resolve);
+    });
+    if (written) this.developer.push(record);
+    return written;
   }
 
   async writeLukeUtterance(record: LukeUtteranceRecord): Promise<boolean> {
@@ -1054,4 +1076,93 @@ test("an append pending when the session dies is dropped with it and never re-se
   });
   await f.clock.advance(f.clock.now + 1000);
   assert.equal(appends(second, LIVE_CLIENT_EVENT.COMMENTARY_APPEND).length, 0);
+});
+
+test("run events landing while the ask's record write is out are deferred, then spoken in order once the record holds the ask", async () => {
+  const f = fixture();
+  const sideband = await f.open();
+  f.record.hold();
+  sideband.input("Ship it.", 0, 800);
+  sideband.delegation("item_1", 900);
+  await drainMicrotasks();
+  assert.equal(f.brain.asks.length, 1);
+  f.brain.fire({ kind: LIVE_BRAIN_RUN_EVENT.ACTIONS_SETTLED, runId: "run-1" });
+  f.brain.fire({ kind: LIVE_BRAIN_RUN_EVENT.REPLY_SENTENCE, runId: "run-1", sentence: "Shipped." });
+  f.brain.fire({ kind: LIVE_BRAIN_RUN_EVENT.REPLY_SENTENCE, runId: "run-1", sentence: "Green." });
+  await drainMicrotasks();
+  assert.equal(f.record.developer.length, 0);
+  assert.equal(appends(sideband, LIVE_CLIENT_EVENT.COMMENTARY_APPEND).length, 0);
+  f.record.release(true);
+  await drainMicrotasks();
+  assert.equal(f.record.developer.length, 1);
+  const commentary = appends(sideband, LIVE_CLIENT_EVENT.COMMENTARY_APPEND);
+  assert.deepEqual(
+    commentary.map((event) => ("content" in event ? event.content : undefined)),
+    ["Shipped."],
+  );
+  assert.equal(
+    commentary[0] && "delegation_id" in commentary[0] && commentary[0].delegation_id,
+    "item_1",
+  );
+  sideband.acknowledge(0, 1000, 1100);
+  await drainMicrotasks();
+  assert.equal(appends(sideband, LIVE_CLIENT_EVENT.COMMENTARY_APPEND).length, 2);
+});
+
+test("a run that ends during the ask's record write is finalized once the write lands, its end spoken as the standing note", async () => {
+  const f = fixture();
+  const sideband = await f.open();
+  f.record.hold();
+  sideband.input("Do the thing.", 0, 800);
+  sideband.delegation("item_1", 900);
+  await drainMicrotasks();
+  f.brain.fire({
+    kind: LIVE_BRAIN_RUN_EVENT.ENDED,
+    runId: "run-1",
+    end: LIVE_BRAIN_RUN_END.FAILED,
+  });
+  await f.clock.advance(f.clock.now + 1000);
+  assert.equal(appends(sideband, LIVE_CLIENT_EVENT.COMMENTARY_APPEND).length, 0);
+  f.record.release(true);
+  await drainMicrotasks();
+  await f.clock.advance(f.clock.now + 1000);
+  const commentary = appends(sideband, LIVE_CLIENT_EVENT.COMMENTARY_APPEND);
+  assert.equal(commentary.length, 1);
+  assert.equal(
+    commentary[0] && "content" in commentary[0] && commentary[0].content,
+    RUN_END_NOTE[LIVE_BRAIN_RUN_END.FAILED],
+  );
+});
+
+test("an ask whose record write fails is answered with the unrecorded note once, and its run's later events reach nothing", async () => {
+  const f = fixture();
+  const sideband = await f.open();
+  f.record.hold();
+  sideband.input("Send it.", 0, 800);
+  sideband.delegation("item_1", 900);
+  await drainMicrotasks();
+  f.brain.fire({ kind: LIVE_BRAIN_RUN_EVENT.ACTIONS_SETTLED, runId: "run-1" });
+  f.brain.fire({ kind: LIVE_BRAIN_RUN_EVENT.REPLY_SENTENCE, runId: "run-1", sentence: "Sent." });
+  f.record.release(false);
+  await drainMicrotasks();
+  const commentary = appends(sideband, LIVE_CLIENT_EVENT.COMMENTARY_APPEND);
+  assert.equal(commentary.length, 1);
+  assert.equal(
+    commentary[0] && "content" in commentary[0] && commentary[0].content,
+    ASK_UNRECORDED_NOTE,
+  );
+  assert.equal(
+    commentary[0] && "delegation_id" in commentary[0] && commentary[0].delegation_id,
+    "item_1",
+  );
+  sideband.acknowledge(0, 1000, 1100);
+  f.brain.fire({ kind: LIVE_BRAIN_RUN_EVENT.REPLY_SENTENCE, runId: "run-1", sentence: "Late." });
+  f.brain.fire({
+    kind: LIVE_BRAIN_RUN_EVENT.ENDED,
+    runId: "run-1",
+    end: LIVE_BRAIN_RUN_END.FAILED,
+  });
+  await f.clock.advance(f.clock.now + 1000);
+  assert.equal(appends(sideband, LIVE_CLIENT_EVENT.COMMENTARY_APPEND).length, 1);
+  assert.equal(f.record.developer.length, 0);
 });

--- a/packages/host/src/voice/live-session-service.test.ts
+++ b/packages/host/src/voice/live-session-service.test.ts
@@ -1166,3 +1166,42 @@ test("an ask whose record write fails is answered with the unrecorded note once,
   assert.equal(appends(sideband, LIVE_CLIENT_EVENT.COMMENTARY_APPEND).length, 1);
   assert.equal(f.record.developer.length, 0);
 });
+
+test("a steered ask whose sibling's record write fails is settled once every write is in: one unrecorded note, nothing spoken", async () => {
+  const f = fixture();
+  const sideband = await f.open();
+  f.record.hold();
+  sideband.input("What failed?", 0, 800);
+  sideband.delegation("item_1", 900);
+  await drainMicrotasks();
+  sideband.input("In the API repo.", 5000, 5800);
+  sideband.delegation("item_2", 5900);
+  await drainMicrotasks();
+  assert.equal(f.brain.asks.length, 2);
+  f.brain.fire({ kind: LIVE_BRAIN_RUN_EVENT.ACTIONS_SETTLED, runId: "run-1" });
+  f.brain.fire({
+    kind: LIVE_BRAIN_RUN_EVENT.REPLY_SENTENCE,
+    runId: "run-2",
+    sentence: "Two tests.",
+  });
+  f.record.release(false);
+  await drainMicrotasks();
+  assert.equal(appends(sideband, LIVE_CLIENT_EVENT.COMMENTARY_APPEND).length, 0);
+  f.record.release(true);
+  await drainMicrotasks();
+  const commentary = appends(sideband, LIVE_CLIENT_EVENT.COMMENTARY_APPEND);
+  assert.equal(commentary.length, 1);
+  assert.equal(
+    commentary[0] && "content" in commentary[0] && commentary[0].content,
+    ASK_UNRECORDED_NOTE,
+  );
+  assert.equal(
+    commentary[0] && "delegation_id" in commentary[0] && commentary[0].delegation_id,
+    "item_1",
+  );
+  sideband.acknowledge(0, 6000, 6100);
+  f.brain.fire({ kind: LIVE_BRAIN_RUN_EVENT.REPLY_SENTENCE, runId: "run-2", sentence: "Late." });
+  await drainMicrotasks();
+  assert.equal(appends(sideband, LIVE_CLIENT_EVENT.COMMENTARY_APPEND).length, 1);
+  assert.equal(f.record.developer.length, 1);
+});

--- a/packages/host/src/voice/live-session-service.ts
+++ b/packages/host/src/voice/live-session-service.ts
@@ -197,6 +197,8 @@ interface Exchange {
   pendingRecords: number;
   /** Run events held while a record write is out, replayed in order once it lands. */
   deferred: LiveBrainRunEvent[];
+  /** The delegation whose ask the record refused, if any: once every write is in, the exchange is dropped and told so once. */
+  unrecorded: string | undefined;
   /** The session the delegations belong to; a closed session's ids die with it and later sentences go session-wide. */
   sessionId: string | undefined;
   settled: boolean;
@@ -227,6 +229,7 @@ function newExchange(
     delegationIds,
     pendingRecords: 0,
     deferred: [],
+    unrecorded: undefined,
     sessionId,
     settled: false,
     buffered: [],
@@ -747,14 +750,17 @@ export class LiveSessionService<Delivery extends BriefingDelivery = BriefingDeli
       runId: submission.runId,
     });
     exchange.pendingRecords -= 1;
-    if (!recorded) {
+    if (!recorded) exchange.unrecorded ??= delegationId;
+    // A sibling ask steered into this exchange may still have its own write
+    // out; the exchange is settled once, when the last of them is in.
+    if (exchange.pendingRecords > 0) return;
+    if (exchange.unrecorded !== undefined) {
+      const refusedDelegation = exchange.unrecorded;
       this.#dropExchange(exchange);
-      this.#speakInto(session, delegationId, ASK_UNRECORDED_NOTE);
+      this.#speakInto(session, refusedDelegation, ASK_UNRECORDED_NOTE);
       return;
     }
-    if (exchange.pendingRecords === 0) {
-      for (const event of exchange.deferred.splice(0)) this.#onRunEvent(event);
-    }
+    for (const event of exchange.deferred.splice(0)) this.#onRunEvent(event);
   }
 
   /** The run joins the exchange open on its session, or opens one; either way its events are read from now on. */

--- a/packages/host/src/voice/live-session-service.ts
+++ b/packages/host/src/voice/live-session-service.ts
@@ -93,6 +93,10 @@ const SLOW_STEP_GENERAL_NOTE = "Luke is still working on it; this takes a moment
 
 const TYPED_ASK_MIRROR_NOTE = "The developer typed this ask into Luke's composer:";
 
+/** Said once, under the delegation, when the developer's ask could not be put on record: an ask off the record is answered nowhere. */
+export const ASK_UNRECORDED_NOTE =
+  "I couldn't write that ask down, so I'm not going to answer it here.";
+
 /**
  * What the stop key says to the model. Muting the microphone never stops the
  * output, as the live guide notes, so a microphone muted while Luke is
@@ -189,6 +193,10 @@ interface StandingSession {
 interface Exchange {
   readonly runIds: Set<string>;
   delegationIds: string[];
+  /** Asks of this exchange whose record write is still out; while any is, run events are deferred rather than spoken. */
+  pendingRecords: number;
+  /** Run events held while a record write is out, replayed in order once it lands. */
+  deferred: LiveBrainRunEvent[];
   /** The session the delegations belong to; a closed session's ids die with it and later sentences go session-wide. */
   sessionId: string | undefined;
   settled: boolean;
@@ -217,6 +225,8 @@ function newExchange(
   return {
     runIds: new Set([runId]),
     delegationIds,
+    pendingRecords: 0,
+    deferred: [],
     sessionId,
     settled: false,
     buffered: [],
@@ -640,7 +650,7 @@ export class LiveSessionService<Delivery extends BriefingDelivery = BriefingDeli
     }
   }
 
-  async #write(write: UtteranceWrite): Promise<void> {
+  async #write(write: UtteranceWrite): Promise<boolean> {
     const { session, utterance } = write;
     const recordedAt = session.rowBeganAt.get(utterance.rowId) ?? this.#options.now();
     const written =
@@ -664,6 +674,7 @@ export class LiveSessionService<Delivery extends BriefingDelivery = BriefingDeli
             recordedAt,
           });
     if (!written) this.#options.report("A live utterance could not be written to the record");
+    return written;
   }
 
   /**
@@ -707,40 +718,81 @@ export class LiveSessionService<Delivery extends BriefingDelivery = BriefingDeli
       submissionId: this.#options.createId(),
       question,
     });
-    const runId =
-      submission.outcome === LIVE_BRAIN_SUBMISSION.ACCEPTED ? submission.runId : undefined;
-    if (!session.writtenRows.has(ask.rowId)) {
-      session.writtenRows.add(ask.rowId);
-      await this.#write({
-        session,
-        utterance: ask,
-        delegationId,
-        askContext: { sinceMs, untilMs: offsetMs },
-        ...(runId !== undefined ? { runId } : undefined),
-      });
-    }
     if (submission.outcome === LIVE_BRAIN_SUBMISSION.REFUSED) {
+      if (!session.writtenRows.has(ask.rowId)) {
+        session.writtenRows.add(ask.rowId);
+        await this.#write({
+          session,
+          utterance: ask,
+          delegationId,
+          askContext: { sinceMs, untilMs: offsetMs },
+        });
+      }
       this.#speakInto(session, delegationId, submission.refusal);
       return;
     }
+    // The exchange stands before the ask's record write is awaited, so a run
+    // that ends at once or speaks its first sentence during the write is
+    // deferred into it rather than dropped; the record still precedes the
+    // speech, because nothing deferred is spoken until the write lands.
+    const exchange = this.#registerExchange(session, submission.runId, delegationId);
+    if (session.writtenRows.has(ask.rowId)) return;
+    session.writtenRows.add(ask.rowId);
+    exchange.pendingRecords += 1;
+    const recorded = await this.#write({
+      session,
+      utterance: ask,
+      delegationId,
+      askContext: { sinceMs, untilMs: offsetMs },
+      runId: submission.runId,
+    });
+    exchange.pendingRecords -= 1;
+    if (!recorded) {
+      this.#dropExchange(exchange);
+      this.#speakInto(session, delegationId, ASK_UNRECORDED_NOTE);
+      return;
+    }
+    if (exchange.pendingRecords === 0) {
+      for (const event of exchange.deferred.splice(0)) this.#onRunEvent(event);
+    }
+  }
+
+  /** The run joins the exchange open on its session, or opens one; either way its events are read from now on. */
+  #registerExchange(session: StandingSession, runId: string, delegationId: string): Exchange {
     const open = [...this.#exchanges.values()].find(
       (exchange) => exchange.sessionId === session.sessionId && exchange.end === undefined,
     );
     if (open) {
       open.delegationIds.push(delegationId);
-      open.runIds.add(submission.runId);
-      this.#exchanges.set(submission.runId, open);
-      return;
+      open.runIds.add(runId);
+      this.#exchanges.set(runId, open);
+      return open;
     }
-    this.#exchanges.set(
-      submission.runId,
-      newExchange(submission.runId, [delegationId], session.sessionId),
-    );
+    const exchange = newExchange(runId, [delegationId], session.sessionId);
+    this.#exchanges.set(runId, exchange);
+    return exchange;
+  }
+
+  /** An exchange whose ask never reached the record answers nothing: its runs are forgotten and what they said is dropped. */
+  #dropExchange(exchange: Exchange): void {
+    if (exchange.finalize !== undefined) this.#options.cancel(exchange.finalize);
+    exchange.finalize = undefined;
+    exchange.deferred = [];
+    exchange.buffered = [];
+    exchange.late = [];
+    this.#lateExchanges.delete(exchange);
+    for (const [runId, held] of [...this.#exchanges]) {
+      if (held === exchange) this.#exchanges.delete(runId);
+    }
   }
 
   #onRunEvent(event: LiveBrainRunEvent): void {
     const exchange = this.#exchanges.get(event.runId);
     if (!exchange) return;
+    if (exchange.pendingRecords > 0) {
+      exchange.deferred.push(event);
+      return;
+    }
     switch (event.kind) {
       case LIVE_BRAIN_RUN_EVENT.SLOW_STEP: {
         if (exchange.slowStepTold) return;


### PR DESCRIPTION
## What

Follow-up to #942 (PR12b). `LiveSessionService.#compose` registered a delegation's exchange only after the developer's ask had been written to Conversation, so a run event landing during that write found no exchange and was dropped: an `ENDED` from an instant failure lost its spoken note, and a first `REPLY_SENTENCE` lost a sentence.

- The exchange is registered the moment the brain accepts the ask (`#registerExchange`), before the record write is awaited.
- While an ask's write is out (`pendingRecords > 0`), the exchange's run events are deferred in order and replayed once the record holds the ask, so the record still precedes the speech. A second delegation steering into the same exchange counts its own write the same way.
- A write that fails drops the exchange (`#dropExchange`), appends one commentary under the delegation with the fixed `ASK_UNRECORDED_NOTE`, and answers nothing more for that run.
- `#write` now answers whether the write landed.

## GPT Live docs

No new event type or field. The deferred events become the same `session.commentary.append` / `session.thinking.append` sends as before, each still awaiting its acknowledgment or error.

## Tests

Three new cases in `voice/live-session-service.test.ts`, over a `FakeRecord` whose developer writes the test holds and releases:
- `ACTIONS_SETTLED` and two `REPLY_SENTENCE`s fired while the write is out append nothing until the write lands, then exactly one commentary per sentence, in order, under the delegation id;
- an `ENDED` (failed) fired during the write is finalized once the write lands and spoken as the standing note once;
- a write answered false drops the exchange: exactly one `ASK_UNRECORDED_NOTE` commentary, and later `REPLY_SENTENCE` / `ENDED` for that run append nothing.

## Verification

`./scripts/check.sh` passes on this branch rebased over `a6e42a13`. `@sidecar/host`: 295 tests, 0 failures. `./scripts/verify.sh` not run: Linux sandbox, no UI touched.

## Reviews

Ponytail review applied: the drop path's clears of `buffered`/`late`/`finalize` only matter for a steered exchange whose second ask fails to record; kept because that is the case where the drop must be complete. The "thermonuclear code review" skill text could not be found online; an adversarial pass was run instead over the steering case (two asks sharing an exchange, `pendingRecords` as a count) and the already-written row case (a settle timer that wrote the ask first skips the write and defers nothing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/0183696a-d3c3-4d09-a66a-9b2072e49d11)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34546381996/artifacts/10179216045) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34546381996)

- Commit: `24a1ddb08a6268fa562f1b49433b3fb941ac10b8`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
