### PR TITLE
test(wire): run wire's tests on vitest

### DIFF
--- a/packages/AGENTS.md
+++ b/packages/AGENTS.md
@@ -6,7 +6,8 @@ and the Vite site. `packages/panel` is the one shared React package: it owns the
 panel's React anatomy so the desktop and marketing mock compose the same
 components. Each app owns the styling that presents those components. Other
 modules belong in an app when they import `electron`, `react`, or a DOM API.
-Everything else is logic and can be tested with `node --test` and no harness.
+Everything else is logic and can be tested with vitest and no harness; a
+package's own `vitest.config.ts` registers it in the root's project list.
 A developer command-line tool lives under `tools/` instead, where what it
 reaches cannot become a package's: `tools/trace-export` reads a recorded trace
 against `@sidecar/brain`'s hosted tool catalog, which `@sidecar/devtrace` would

--- a/packages/wire/package.json
+++ b/packages/wire/package.json
@@ -9,12 +9,12 @@
   },
   "types": "./src/index.ts",
   "scripts": {
-    "test": "tsx --test 'src/**/*.test.ts'",
+    "test": "vitest run",
     "typecheck": "tsc --project tsconfig.json"
   },
   "devDependencies": {
     "@types/node": "catalog:",
-    "tsx": "catalog:",
-    "typescript": "catalog:"
+    "typescript": "catalog:",
+    "vitest": "catalog:"
   }
 }

--- a/packages/wire/src/action-result.test.ts
+++ b/packages/wire/src/action-result.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import { test } from "vitest";
 import { isActionResult } from "./action-result.js";
 
 test("the action result guard accepts exactly the canonical status shapes", () => {

--- a/packages/wire/src/conversation-event.test.ts
+++ b/packages/wire/src/conversation-event.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import { test } from "vitest";
 import {
   CONVERSATION_EVENT_KIND,
   type ConversationEventKind,

--- a/packages/wire/src/event.test.ts
+++ b/packages/wire/src/event.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import { test } from "vitest";
 import { Emitter } from "./event.js";
 import { DisposableStore, type IDisposable } from "./lifecycle.js";
 

--- a/packages/wire/src/json.test.ts
+++ b/packages/wire/src/json.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import { test } from "vitest";
 import {
   isOptionalWireString,
   isRecord,

--- a/packages/wire/src/lifecycle.test.ts
+++ b/packages/wire/src/lifecycle.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import { test } from "vitest";
 import { DisposableStore, disposeAll, toDisposable } from "./lifecycle.js";
 
 test("a wrapped teardown runs at most once however often it is disposed", () => {

--- a/packages/wire/src/schema.test.ts
+++ b/packages/wire/src/schema.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import { test } from "vitest";
 import { type UnparsedWireValue, unparsedWire } from "./json.js";
 import {
   RECORD_EXTRA_KEYS,

--- a/packages/wire/src/testing/cloud-fake.test.ts
+++ b/packages/wire/src/testing/cloud-fake.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import { test } from "vitest";
 import { fakeCloudApi, recordedRoutes } from "./cloud-fake.js";
 import { HTTP_STATUS } from "./http-fake.js";
 

--- a/packages/wire/src/ui-message-metadata.test.ts
+++ b/packages/wire/src/ui-message-metadata.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import { test } from "vitest";
 import { type UnparsedWireValue, unparsedWire } from "./json.js";
 import { SCHEMA_REFUSAL, type Schema, type SchemaPath } from "./schema.js";
 import {

--- a/packages/wire/vitest.config.ts
+++ b/packages/wire/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    name: "wire",
+    include: ["src/**/*.test.ts"],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -902,12 +902,12 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 26.2.0
-      tsx:
-        specifier: 'catalog:'
-        version: 4.23.12
       typescript:
         specifier: 'catalog:'
         version: 7.0.2
+      vitest:
+        specifier: 'catalog:'
+        version: 3.2.7(@types/debug@4.1.13)(@types/node@26.2.0)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.12)(yaml@2.9.0)
 
   tools/ios-parity:
     dependencies:

--- a/scripts/node-test-to-vitest.mjs
+++ b/scripts/node-test-to-vitest.mjs
@@ -1,0 +1,54 @@
+import { glob, readFile, writeFile } from "node:fs/promises";
+import { pathToFileURL } from "node:url";
+
+const NODE_TEST_IMPORT =
+  /^import\s+(?:(\w+)\s*(?:,\s*\{([^}]+)\})?|\{([^}]+)\})\s+from\s+["']node:test["'];?$/m;
+
+export function transformNodeTestImport(source) {
+  const match = NODE_TEST_IMPORT.exec(source);
+  if (!match) {
+    return source;
+  }
+
+  const [full, defaultImport, namedAlongsideDefault, namedOnly] = match;
+  const names = [];
+  if (defaultImport) {
+    names.push(defaultImport);
+  }
+  for (const named of (namedAlongsideDefault ?? namedOnly ?? "").split(",")) {
+    const trimmed = named.trim();
+    if (trimmed && !names.includes(trimmed)) {
+      names.push(trimmed);
+    }
+  }
+
+  const replacement = `import { ${names.join(", ")} } from "vitest";`;
+  return source.slice(0, match.index) + replacement + source.slice(match.index + full.length);
+}
+
+export function needsTransform(source) {
+  return NODE_TEST_IMPORT.test(source);
+}
+
+async function main() {
+  const pattern = process.argv[2];
+  if (!pattern) {
+    throw new Error("usage: node scripts/node-test-to-vitest.mjs <glob>");
+  }
+
+  let changed = 0;
+  for await (const path of glob(pattern)) {
+    const source = await readFile(path, "utf8");
+    if (!needsTransform(source)) {
+      continue;
+    }
+    await writeFile(path, transformNodeTestImport(source));
+    changed += 1;
+    process.stdout.write(`rewrote ${path}\n`);
+  }
+  process.stdout.write(`${changed} file(s) rewritten\n`);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  await main();
+}

--- a/scripts/node-test-to-vitest.test.mjs
+++ b/scripts/node-test-to-vitest.test.mjs
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { needsTransform, transformNodeTestImport } from "./node-test-to-vitest.mjs";
+
+test("rewrites a default-only node:test import to a named vitest import", () => {
+  const result = transformNodeTestImport('import test from "node:test";\n\ntest("x", () => {});\n');
+
+  assert.equal(result, 'import { test } from "vitest";\n\ntest("x", () => {});\n');
+});
+
+test("rewrites a named node:test import, deduplicating identifiers", () => {
+  const result = transformNodeTestImport('import { test, describe } from "node:test";\n');
+
+  assert.equal(result, 'import { test, describe } from "vitest";\n');
+});
+
+test("rewrites a default import with named imports alongside it", () => {
+  const result = transformNodeTestImport('import test, { describe } from "node:test";\n');
+
+  assert.equal(result, 'import { test, describe } from "vitest";\n');
+});
+
+test("leaves node:assert imports untouched", () => {
+  const source = 'import assert from "node:assert/strict";\nimport test from "node:test";\n';
+
+  const result = transformNodeTestImport(source);
+
+  assert.match(result, /import assert from "node:assert\/strict";/);
+});
+
+test("leaves a source with no node:test import unchanged", () => {
+  const source = 'import { describe } from "vitest";\n';
+
+  assert.equal(transformNodeTestImport(source), source);
+  assert.equal(needsTransform(source), false);
+});
+
+test("reports whether a source still imports from node:test", () => {
+  assert.equal(needsTransform('import test from "node:test";\n'), true);
+  assert.equal(needsTransform('import { test } from "vitest";\n'), false);
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,6 +5,6 @@ import { defineConfig } from "vitest/config";
 // per-package `node --test` scripts until each is swapped.
 export default defineConfig({
   test: {
-    projects: [],
+    projects: ["packages/wire"],
   },
 });


### PR DESCRIPTION
P0-04 — run wire tests on vitest (Effect migration plan)

Pilot runner swap for the wire package: this is the template the remaining
runner-swap PRs (P0-05..P0-13) copy. Adds a reusable
`scripts/node-test-to-vitest.mjs` codemod (with its own test) that rewrites
`import test from "node:test"` / `import { test, describe } from "node:test"`
into a named `vitest` import, leaving `node:assert` imports untouched. Applied
it to every `*.test.ts` file under `packages/wire`.

- `packages/wire/vitest.config.ts` added; registered as `"packages/wire"` in
  the root `vitest.config.ts` projects list.
- `packages/wire/package.json`: `"test"` is now `"vitest run"`; `vitest` added
  to devDependencies (via `catalog:`); `tsx` removed (knip flagged it unused
  once vitest replaced it as the package's only tsx consumer).
- `packages/CLAUDE.md` / `packages/AGENTS.md` (a symlink pair, so one edit
  keeps them identical): the "tested with `node --test`" sentence now says
  vitest and mentions the per-package `vitest.config.ts` registration.

Test count: 75 tests before (`node --test`) and 75 after
(`vitest run --reporter=json`), unchanged.

## Invariants checklist

- [x] `./scripts/check.sh` green; renderer/UI PRs also `./scripts/verify.sh` with evidence inspected. (N/A — not a renderer/UI PR)
- [x] JSON Schema goldens unchanged (no goldens exist yet before P0-16; N/A)
- [x] Gateway envelope goldens unchanged. (N/A — no gateway changes)
- [x] No new `as` type assertion outside the allowlisted files.
- [x] No `effect` import in an OpenClaw-ported file. (N/A — no `effect` import added)
- [x] No `Effect.runPromise`/`runSync`/`runFork` outside the runtime edges. (N/A)
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` in a package already migrated. (N/A)
- [x] Test count equals the pre-PR count or the delta is listed: 75 → 75.
- [x] Each hand-rolled file the PR replaces is deleted or marked `@deprecated` with its deletion PR named. (N/A — no hand-rolled file replaced)
- [x] Every `CLAUDE.md`/`AGENTS.md` sentence naming a changed part is edited; root pair stays byte-identical. (`packages/CLAUDE.md`/`AGENTS.md` symlink pair updated)
- [x] `PRIVACY.md` unchanged.
- [x] Package `package.json` deps match what the sources import by bare specifier; `effect` via `catalog:`. (`vitest` via `catalog:`; `tsx` removed as unused)
- [x] Barrel/door rule: no Node-reaching Effect module behind a barrel the renderer or a web function opens. (N/A — no Effect module added)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/540f482f-2c6a-4665-b8d3-a6fad15df24b)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34549484425/artifacts/10180322465) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34549484425)

- Commit: `97e46f4196bd65dd756c8cdc162ce3c1944fe848`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
