### PR TITLE
fix(LUKE-149): an unknown action reads as unknown to the model on resume

### DIFF
--- a/packages/brain/src/ui-message-context.test.ts
+++ b/packages/brain/src/ui-message-context.test.ts
@@ -22,6 +22,7 @@ import {
   isRecord,
   isWireString,
   SCHEMA_REFUSAL,
+  UNKNOWN_ACTION_STATUS,
   type UnparsedWireValue,
   type WireRecord,
 } from "@sidecar/wire";
@@ -51,7 +52,10 @@ import {
 } from "./ui-message-context.js";
 
 const RUNTIME = { id: "tool-loop", version: 1 };
-const LOST = JSON.stringify({ status: "unknown", reason: "the result was lost" });
+const LOST_RESULT = { status: UNKNOWN_ACTION_STATUS, reason: "the result was lost" } as const;
+const LOST = JSON.stringify(LOST_RESULT);
+/** How the SDK marks a tool result's output to the model when it is an answer rather than an error. */
+const MODEL_RESULT_OUTPUT = { JSON: "json" } as const;
 const MODEL = "gpt-5.4-mini";
 const PROVIDER = "openai";
 const REPLAY: ReplayTarget = { provider: PROVIDER, model: MODEL };
@@ -212,6 +216,9 @@ function replyParts(
     { type: "text", text: TURN.REPLY, state: "done" },
   ];
 }
+
+/** How many of a reply's parts stand before the crash the interrupted fixtures model: the step's start, its reasoning, and the call. */
+const PARTS_THROUGH_CALL = 3;
 
 const ASK_ROW = userRow("3f1c9a2e-7b4d-4e8f-9a01-2b3c4d5e6f70", TURN.ASK);
 const REPLY_ROW = assistantRow("5a2d7b3c-8e4f-4a9b-8c12-3d4e5f6a7b81", replyParts(), MODEL);
@@ -633,6 +640,34 @@ test("compact drops the rows the derivation no longer reads, keeps the rest in w
   assert.equal(context.compact(), 0);
 });
 
+test("a call left unanswered is shown to the model as an answer whose envelope says unknown, the same from both engines", async () => {
+  const responses = new ResponsesContextEngine(RUNTIME);
+  responses.bootstrap(undefined, LOST);
+  responses.ingest({ kind: CONTEXT_INPUT_KIND.USER_TEXT, text: TURN.ASK });
+  responses.ingest({
+    kind: CONTEXT_INPUT_KIND.MODEL_OUTPUT,
+    items: [reasoningItem(TURN.REASONING_BEFORE_CALL), functionCallItem()],
+  });
+  const resumed = new ResponsesContextEngine(RUNTIME);
+  resumed.bootstrap(responses.checkpoint(), LOST);
+  const interrupted = assistantRow(
+    "m2",
+    replyParts(TOOL_PART_STATE.INPUT_AVAILABLE).slice(0, PARTS_THROUGH_CALL),
+    MODEL,
+  );
+  const { context, bootstrap } = await bootstrapped([ASK_ROW, interrupted]);
+  assert.deepEqual(bootstrap, { loaded: true, repaired: 1 });
+
+  const fromCheckpoint = shownByResponses(resumed.assemble({ ephemeral: [] }));
+  const fromRows = shownByModelMessages(await context.assemble({ ephemeral: [] }));
+  assert.deepEqual(fromRows, fromCheckpoint);
+  assert.deepEqual(
+    fromRows.map((item) => item.kind),
+    [SHOWN.USER, SHOWN.REASONING, SHOWN.CALL, SHOWN.RESULT],
+  );
+  assert.deepEqual(fromRows[3], { kind: SHOWN.RESULT, callId: TURN.CALL_ID, output: LOST_RESULT });
+});
+
 test("a call the record left unanswered is answered with the lost result, and the record is not rewritten", async () => {
   for (const [state, extra] of [
     [TOOL_PART_STATE.INPUT_AVAILABLE, {}],
@@ -648,7 +683,7 @@ test("a call the record left unanswered is answered with the lost result, and th
     ]);
     const answered = messages.find(isTool);
     assert.deepEqual(answered ? resultParts(answered).map((part) => part.output) : [], [
-      { type: "error-text", value: LOST },
+      { type: MODEL_RESULT_OUTPUT.JSON, value: LOST_RESULT },
     ]);
     const kept = context.checkpoint().items[1];
     const parts = kept && isRecord(kept.message) ? kept.message.parts : undefined;

--- a/packages/brain/src/ui-message-context.ts
+++ b/packages/brain/src/ui-message-context.ts
@@ -19,6 +19,7 @@ import {
 import { readStoredUIMessages, type StoredUIMessage } from "@sidecar/session/ui-messages";
 import {
   isWireString,
+  recordFromJsonLine,
   SCHEMA_REFUSAL,
   type SchemaPath,
   type SchemaRead,
@@ -189,8 +190,16 @@ function preparedToolPart(
       ? { callProviderMetadata: part.callProviderMetadata }
       : undefined),
   };
+  // A call a crash left unanswered is answered with the host's lost result, the
+  // envelope saying its effect is unknown: an answer, not an error, because an
+  // error reads to the model as a failure it may repeat, and an action whose
+  // effect is unknown is never retried on Luke's own initiative.
   if (!isSettled(part)) {
-    return { ...call, state: TOOL_PART_STATE.OUTPUT_ERROR, errorText: options.lostResultJson };
+    return {
+      ...call,
+      state: TOOL_PART_STATE.OUTPUT_AVAILABLE,
+      output: recordFromJsonLine(options.lostResultJson) ?? options.lostResultJson,
+    };
   }
   const result =
     replayed && part.resultProviderMetadata !== undefined


### PR DESCRIPTION
## What

A7's UIMessage context engine presented a stored `input-available` tool part, at a resume, as an `output-error` whose text was the host's lost-result JSON. The text said unknown; the shape said failed. It now presents it as an **`output-available` part whose output is the lost-result envelope** (`{ status: "unknown", reason }`), the same thing B5b's writer stores for a call a turn ended without answering, and the same thing the Responses checkpoint engine has always paired a dangling call with. The stored row is not rewritten; only what the model is shown changes.

## What the model receives

- **Before:** through `convertToModelMessages`, a tool result of kind `error-text` whose value was the JSON string — an error shape a model may reasonably read as a failure to retry.
- **After:** a tool result of kind `json` whose value is the envelope, `status: unknown` with its reason. It reads as unknown, not as success (the envelope's status word is what says so) and not as an error.
- The Responses engine already showed the model a `function_call_output` carrying that same JSON, so the two engines now agree on this path too; the new equivalence case asserts it directly.

## Tests

- New: a turn interrupted after its tool call, resumed in both engines, shows the model the identical sequence `user, reasoning, call, result`, and the result is `{ status: "unknown", reason }` from both (`shownByResponses` vs `shownByModelMessages`).
- Updated: the existing unanswered-call test asserts the model input's tool result is `{ type: "json", value: LOST_RESULT }` for `input-available`, `input-streaming`, and a preliminary `output-available` part, and that the stored part keeps its state (the record is not rewritten). Set membership and structure only; no wording asserted.
- A7's existing equivalence test for a settled turn is unchanged and still holds.

No stored messages are read here beyond what A7's engine already read through `readStoredUIMessages`.

## CLAUDE.md

Nothing contradicted; this closes the last place the record's unknown-versus-refused distinction disagreed with what the model is shown ("an unknown action is never retried on Luke's own initiative").

## Verify

```sh
./scripts/check.sh
pnpm --filter @sidecar/brain exec tsx --test src/ui-message-context.test.ts
```

No macOS or UI code touched; `verify.sh` does not apply.

## Reviews run

Neither Cursor skill is installed here; both were located online and applied as written.

- **Cursor `thermo-nuclear-code-quality-review`**: on the first commit, REQUEST CHANGES for one blocker — the new `lostResultOf` was a third private clone of a JSON-or-text parser in the brain package; replaced by `@sidecar/wire`'s `recordFromJsonLine`, which also removes the type assertion. Verified independently that the SDK renders the new part as a `json` result (never `error-text`), that the Responses engine, the store writer, the live tool executor, and the view all already carry unknown as an answer, and that the equivalence test catches exactly the regression it targets. APPROVE on the working tree. Follow-up it names, not taken here: the `bootstrap(checkpoint, lostResultJson: string)` seam types a build-fixed envelope as text; carrying `UnknownActionResult` on the seam would remove the parse entirely, but it is a runtime-vocabulary change for its own PR, and the two remaining `parsedJson` twins in `run-events.ts` and `loop-guard.ts` could retire with it.
- **`ponytail-review`** (DietrichGebert): `net: -27 lines possible`, all taken — the wire helper in place of the local parser, the interrupted fixture built from `replyParts(...).slice(0, PARTS_THROUGH_CALL)` instead of a hand copy, and the misplaced constant moved beside `LOST`.
- **Cursor Bugbot** and **Security Reviewer**: both success on the first commit, no comments.

## Test results

`./scripts/check.sh` exit 0. Brain suite 384 passing; `ui-message-context` 14 passing, including the new cross-engine case for an interrupted turn and the unanswered-call case asserting a `json` result whose value is the unknown envelope for all three unsettled states.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34546406243/artifacts/10179229214) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34546406243)

- Commit: `2e17e47de1f3624072f92a3a334aab78f9726e68`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
