### PR TITLE
fix(voice): the microphone follows the talk key

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1075,14 +1075,20 @@ Canonical commands:
   which device the renderer asks the browser to open when a voice session
   opens, so a Bluetooth headset is not pulled onto its call codec while the
   Mac's own microphone can listen, and is listened to itself when a shut lid
-  would muffle the Mac's. The capture device is bound to the session: its
-  track rides the session's offer disabled, under the microphone permission
-  onboarding already granted, is enabled only on the session's own
-  acknowledgment of the talk key's unmute and disabled again on the stop
-  key's or a second press's mute, and is stopped when the session ends; a
-  session Luke opened for his own speech acquires it muted and hears nothing
-  until the talk key, and typed asks open none. An unreadable
-  route means the browser's default device, never a refusal to listen.
+  would muffle the Mac's. The capture device is bound to the talk key, not
+  the session: the key is held to talk, the press opens the device and puts
+  its track on the session's sending line disabled, the track is enabled
+  only on the session's own acknowledgment of that press's unmute, and the
+  release (or the stop key) sends the mute and then, whatever the session
+  answered, takes the track off the line and stops the device, so the
+  system's microphone indicator is lit exactly while the key is down. A
+  session Luke opens for his own speech carries no capture device at all,
+  only a sending line with no track that the next press fills, and typed asks
+  open none. The one place a press stands in for a release is the Electron
+  fallback, where the native talk-key helper could not start and the system
+  reports presses alone: there one press starts the hold and the next ends
+  it, and the shortcuts row says so. An unreadable route means the browser's
+  default device, never a refusal to listen.
 
 ### Updating
 
@@ -1263,10 +1269,11 @@ Canonical commands:
   signed-in launch rather than improvising a substitute; only the append
   settled spoken by the session's own output transcript settles it. When no
   session stands, a briefing or a beat asks the voice window for one, and the
-  window opens it muted: the microphone track rides the offer disabled under
-  the permission onboarding already granted, so nothing is heard until the
-  talk key, and the same session is the one the developer joins by pressing
-  it. There is no speak-only call and no second kind of session. What the
+  window opens it with no microphone: the offer carries a sending audio line
+  with no track and no capture device is opened, so nothing can be heard
+  until the talk key is held, and the same session is the one the developer
+  joins by holding it. There is no speak-only call and no second kind of
+  session. What the
   session is seeded with at creation is bounded: Luke's own Conversation
   record (the 20 most recent lines, in their roles, each cut to its length
   bound) and the same redacted roster view the brain's standing context

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -356,9 +356,10 @@ and email you signed it with, and any screenshots you attached.
 ## Who we send it to
 
 - OpenAI, for voice and for Luke's own judgment. On the Mac, a voice session
-  is one continuous conversation: while the microphone is unmuted everything
-  it hears streams to OpenAI, and while it is muted nothing does; Luke can
-  still speak into a muted session. A typed turn sends your words, each voice
+  is one continuous conversation: while you hold the talk key everything the
+  microphone hears streams to OpenAI, and the moment you let go the
+  microphone is closed and nothing does; Luke can still speak into a session
+  whose microphone is closed. A typed turn sends your words, each voice
   session carries the recent Conversation lines and the session summary
   described above as it opens, and both kinds of turn send the session fields
   listed above — on the Mac app, read locally from your machine; on iOS and
@@ -488,9 +489,13 @@ service, usage counts and recordings by PostHog, and crash reports by Sentry.
 - What you type or say to Luke goes to his main conversation; the
   conversation an ask is for is fixed at the moment you send it and never
   moved afterwards.
-- Luke does not listen through your microphone until you press the talk
-  key: a voice session Luke opens to speak to you keeps the microphone muted,
-  and the stop key or a second press of the talk key mutes it again.
+- Luke does not listen through your microphone except while you hold the
+  talk key. The press opens the microphone and letting go closes it, so
+  macOS's microphone indicator is lit exactly while the key is down; the stop
+  key closes it too. A voice session Luke opens to speak to you opens no
+  microphone at all. If Luke's key helper cannot start, the key reports
+  presses alone, so one press opens the microphone and the next closes it,
+  and the Keyboard shortcuts page says so.
 - Delete your account from the Account section in Settings. This erases your
   account, your sign-in records, your usage counts, and any provider API keys
   you synced to the hosted service, and asks PostHog to erase your usage data

--- a/apps/desktop/src/main/window/hotkey-registrar.test.ts
+++ b/apps/desktop/src/main/window/hotkey-registrar.test.ts
@@ -1,6 +1,8 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { VOICE_HOTKEY_NONE } from "@sidecar/settings";
+import type { BrowserWindow } from "electron";
+import { channels } from "#shared/bridge";
 import type { TalkKeyEdges } from "../native/talk-key";
 import {
   HOTKEY_RANK,
@@ -23,6 +25,11 @@ function harness(options: { credentials?: boolean; registers?: boolean } = {}) {
   const talkStops: number[] = [];
   let talkEdges: TalkKeyEdges | undefined;
   let talkStart = true;
+  const voiceHostSent: string[] = [];
+  // SAFETY: the registrar reaches only `webContents.send` on the voice host.
+  const voiceHost = {
+    webContents: { send: (channel: string) => voiceHostSent.push(channel) },
+  } as unknown as BrowserWindow;
 
   const shortcut: ShortcutSurface = {
     register(accelerator, callback) {
@@ -54,7 +61,7 @@ function harness(options: { credentials?: boolean; registers?: boolean } = {}) {
     },
     recordProductEvent: () => undefined,
     host: {
-      voiceHost: () => undefined,
+      voiceHost: () => voiceHost,
       primaryPanel: () => undefined,
       displayIdFor: () => undefined,
       modeFor: () => "compact",
@@ -70,12 +77,24 @@ function harness(options: { credentials?: boolean; registers?: boolean } = {}) {
     unregisterAllCount: () => unregisterAllCount,
     announced: () => announced,
     talkStops: () => talkStops,
+    voiceHostSent: () => voiceHostSent,
+    pressTalk() {
+      const talk = registered.find((entry) => entry.accelerator === registrar.talk);
+      assert.ok(talk, "the talk key is registered with Electron");
+      talk.callback();
+    },
+    pressStop() {
+      const stop = registered.find((entry) => entry.accelerator === registrar.stop);
+      assert.ok(stop, "the stop key is registered with Electron");
+      stop.callback();
+    },
     failTalkStart() {
       talkStart = false;
     },
     announceTalk(accelerator: string) {
       talkEdges?.onRegistered(accelerator);
     },
+    talkEdges: () => talkEdges,
   };
 }
 
@@ -191,10 +210,47 @@ test("no credential takes no system key", async () => {
   assert.deepEqual(context.registered(), []);
 });
 
-test("a helper that cannot start falls back to a toggle", async () => {
+test("a helper that cannot start falls back to Electron, whose talk key reports no hold", async () => {
   const context = harness();
   context.failTalkStart();
   await context.registrar.reapply(HOTKEY_RANK.TALK);
   assert.equal(context.registrar.talk, "Alt+Space");
   assert.equal(context.registrar.held, false);
+});
+
+test("the Electron fallback alternates press and release across presses, and a stop ends the pair", async () => {
+  const context = harness();
+  context.failTalkStart();
+  await context.registrar.reapply(HOTKEY_RANK.TALK);
+  context.pressTalk();
+  context.pressTalk();
+  context.pressTalk();
+  assert.deepEqual(context.voiceHostSent(), [
+    channels.onVoiceHotkeyPress,
+    channels.onVoiceHotkeyRelease,
+    channels.onVoiceHotkeyPress,
+  ]);
+  context.pressStop();
+  context.pressTalk();
+  assert.deepEqual(context.voiceHostSent().slice(3), [
+    channels.onStopHotkeyPress,
+    channels.onVoiceHotkeyPress,
+  ]);
+  // A press held back by a chord being recorded moves the pair nowhere.
+  context.registrar.setShortcutCapturing(true);
+  context.pressTalk();
+  context.registrar.setShortcutCapturing(false);
+  context.pressTalk();
+  assert.deepEqual(context.voiceHostSent().slice(5), [channels.onVoiceHotkeyRelease]);
+});
+
+test("the native watcher's edges reach the voice host as they are", async () => {
+  const context = harness();
+  await context.registrar.reapply(HOTKEY_RANK.TALK);
+  context.talkEdges()?.onPress();
+  context.talkEdges()?.onRelease();
+  assert.deepEqual(context.voiceHostSent(), [
+    channels.onVoiceHotkeyPress,
+    channels.onVoiceHotkeyRelease,
+  ]);
 });

--- a/apps/desktop/src/main/window/hotkey-registrar.ts
+++ b/apps/desktop/src/main/window/hotkey-registrar.ts
@@ -128,11 +128,18 @@ export class HotkeyRegistrar {
   #talkKeyWatcher: TalkKeyHandle | undefined;
   /**
    * Whether the key reports being let go of. The helper does and the Electron
-   * fallback cannot, and that is the difference between holding a turn and
-   * toggling one — so the panel is told which key it actually has rather than
-   * describing the one it hoped for.
+   * fallback cannot, and that is the difference between holding the
+   * microphone open and pressing to start and again to stop — so the panel is
+   * told which key it actually has rather than describing the one it hoped
+   * for.
    */
   #held = true;
+  /**
+   * Under the Electron fallback, whether the last press started a hold that
+   * has not been ended: Electron reports presses alone, so a press stands in
+   * for the release the key cannot report, and the two alternate.
+   */
+  #fallbackTalking = false;
 
   /**
    * True while a settings row is recording a chord. Both Luke keys stay
@@ -156,13 +163,7 @@ export class HotkeyRegistrar {
         HOTKEY_RANK.TALK,
         {
           candidates: voiceHotkeyCandidates,
-          onPress: () => {
-            this.#sendPress(channels.onVoiceHotkeyPress);
-            // A toggle has only the one edge, so it reports a release immediately
-            // and one short enough to read as a tap. Every press then latches or
-            // ends a turn.
-            this.#sendTo(this.#voiceHostContents(), channels.onVoiceHotkeyRelease);
-          },
+          onPress: () => this.#toggleFallbackTalk(),
           chosen: undefined,
           accelerator: undefined,
         },
@@ -180,7 +181,12 @@ export class HotkeyRegistrar {
         HOTKEY_RANK.STOP,
         {
           candidates: stopHotkeyCandidates,
-          onPress: () => this.#sendPress(channels.onStopHotkeyPress),
+          onPress: () => {
+            // The stop ends whatever hold the fallback had begun, so the next
+            // talk press starts one rather than ending one already over.
+            this.#fallbackTalking = false;
+            this.#sendPress(channels.onStopHotkeyPress);
+          },
           chosen: undefined,
           accelerator: undefined,
         },
@@ -323,6 +329,22 @@ export class HotkeyRegistrar {
   }
 
   /**
+   * The Electron fallback's talk key. The system gives it no release edge, so
+   * one press starts the hold and the next ends it: the one place a press
+   * stands in for letting go, and only because nothing else can. A press
+   * held back by a recording moves nothing, so the pair stays in step with
+   * what the voice host was actually told.
+   */
+  #toggleFallbackTalk(): void {
+    const voiceHost = this.#voiceHostContents();
+    if (this.#shortcutCapturing || !voiceHost) return;
+    this.#fallbackTalking = !this.#fallbackTalking;
+    voiceHost.send(
+      this.#fallbackTalking ? channels.onVoiceHotkeyPress : channels.onVoiceHotkeyRelease,
+    );
+  }
+
+  /**
    * The panel stands up focused, then the renderer is asked to put the caret in
    * the field — or, when the caret is already there, it reads the same press as
    * the dismissal, so one key summons and puts away like every launcher does.
@@ -366,17 +388,20 @@ export class HotkeyRegistrar {
   }
 
   /**
-   * The candidate loop against Electron. For the talk key it is a toggle rather
-   * than a hold, because Electron reports only the press: a lesser thing than
-   * the helper rather than a broken one, and what lets one key interrupt a
-   * reply already playing.
+   * The candidate loop against Electron. For the talk key it is press to
+   * start and press again to stop rather than a hold, because Electron
+   * reports only the press: a lesser thing than the helper rather than a
+   * broken one.
    */
   #registerWithElectron(rank: HotkeyRank): void {
     const state = this.#key(rank);
     for (const accelerator of state.candidates(state.chosen, this.#taken(rank))) {
       if (!this.#shortcut.register(accelerator, state.onPress)) continue;
       state.accelerator = accelerator;
-      if (rank === HOTKEY_RANK.TALK) this.#held = false;
+      if (rank === HOTKEY_RANK.TALK) {
+        this.#held = false;
+        this.#fallbackTalking = false;
+      }
       return;
     }
   }

--- a/apps/desktop/src/renderer/AGENTS.md
+++ b/apps/desktop/src/renderer/AGENTS.md
@@ -56,25 +56,40 @@ state that arrives in its `app:state` snapshot and forwards its presses back as
 acts; it constructs no call of its own.
 
 The policy behind that hook is not the renderer's at all. Whether a session
-stands, what the talk key and the stop key do to its microphone, how the
-host's `voiceLiveSession.changed` is obeyed — wanted opens a session muted,
-closing hangs up, a session lost with the microphone live listens again on
-the next — and what view the panels draw are `LiveVoiceOrchestrator` in
-`@sidecar/voice`, which touches no DOM: what the hook supplies is the call
-it drives, and what it takes back is one view to report and the two streams
-only a browser can play or meter.
+stands, what the talk key and the stop key do to its microphone — the key is
+held to talk: `beginTalk` on the press opens a session if none stands and
+unmutes, `endTalk` on the release mutes, `stopSpeaking` mutes the same way,
+and a release or stop during the press's opening leaves the session muted —
+how the host's `voiceLiveSession.changed` is obeyed — wanted opens a session
+with no microphone, closing hangs up, a session lost while the key is still
+held listens again on the next — and what view the panels draw are
+`LiveVoiceOrchestrator` in `@sidecar/voice`, which touches no DOM: what the
+hook supplies is the call it drives, and what it takes back is one view to
+report and the two streams only a browser can play or meter. The hook
+subscribes both talk-key edges, `onVoiceHotkeyPress` and
+`onVoiceHotkeyRelease`, from main's native watcher; under the Electron
+fallback main alternates the two across presses, since that key reports no
+release.
 
 The voice window is a GPT Live peer and nothing more. `voice/live-peer.ts`
-builds the `RTCPeerConnection` in the WebRTC guide's order — the preferred
-microphone track added with `enabled` false, the `oai-events` data channel
-created before the offer, ICE gathered under a bound, the offer handed to
-the host through `ACT_KIND.VOICE_CREATE_LIVE_SESSION`, the host's SDP answer
-set — and never sends `session.start`, because the host's request is what
-started the session. `voice/live-call.ts` is a table of handlers keyed by
+builds the `RTCPeerConnection` in the WebRTC guide's order — the audio line
+first (for a session a press opened, the preferred microphone track added
+with `enabled` false; for one opened for Luke's own speech, a `sendrecv`
+transceiver with no track, so no capture device stands behind a session
+nobody pressed for), the `oai-events` data channel created before the offer,
+ICE gathered under a bound, the offer handed to the host through
+`ACT_KIND.VOICE_CREATE_LIVE_SESSION`, the host's SDP answer set — and never
+sends `session.start`, because the host's request is what started the
+session. `voice/live-call.ts` is a table of handlers keyed by
 `LIVE_SERVER_EVENT` over `parseLiveServerEvent`: it waits for
 `session.started`, sends only the mute, the unmute, and the close the data
-channel permissions allow it, flips the track only on the `muted` or
-`unmuted` acknowledgment, hangs up the way the conversations guide says
+channel permissions allow it, opens the capture device for an unmute when
+none stands and puts it on the line before the switch goes, flips the track
+only on the `muted` or `unmuted` acknowledgment, and after every mute —
+acknowledged, refused, or timed out, in that the key being up is the
+developer's decision — takes the track off the line with `replaceTrack(null)`
+and stops the device, so the microphone is open exactly while the talk key
+is held; it hangs up the way the conversations guide says
 (`session.closed` registered, `session.close` sent, everything held open
 under the bound), reports its transport and its one idle decision to the
 host, and reads Luke as speaking from the remote track's level, never from

--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -266,6 +266,7 @@ export function App(): React.JSX.Element {
       hotkey: {
         ...(held.hotkeys.talk ? { hotkey: voiceHotkeyLabel(held.hotkeys.talk) } : undefined),
         removed: current.voiceHotkey === VOICE_HOTKEY_NONE,
+        held: held.hotkeys.talkHeld,
       },
       ...(held.hotkeys.ask ? { askKey: voiceHotkeyLabel(held.hotkeys.ask) } : undefined),
       askKeyRemoved: current.askHotkey === VOICE_HOTKEY_NONE,

--- a/apps/desktop/src/renderer/introduction/introduction-takeover.tsx
+++ b/apps/desktop/src/renderer/introduction/introduction-takeover.tsx
@@ -714,12 +714,14 @@ function IntroductionFlight({
       case INTRODUCTION_BEAT.CONNECT: {
         // Landed, the session opens: the offer with the titles goes to the
         // main process, the answer comes back, and `open` resolves on
-        // `session.started`. The microphone is unmuted at once — the guide's
-        // greeting pattern wants the input running from the start — and the
-        // greeting itself is the voice service's, sent on the same event.
+        // `session.started`. The device rides the offer as a press's would,
+        // since the developer's press on the microphone ask is what opened
+        // this, and is unmuted at once — the guide's greeting pattern wants
+        // the input running from the start — while the greeting itself is
+        // the voice service's, sent on the same event.
         let gone = false;
         const call = ensureCall();
-        void call.open().then(async (opened) => {
+        void call.open({ byPress: true }).then(async (opened) => {
           if (gone) return;
           if (!opened) {
             dispatch(INTRODUCTION_EVENT.VOICE_FAILED);

--- a/apps/desktop/src/renderer/luke-guide.ts
+++ b/apps/desktop/src/renderer/luke-guide.ts
@@ -85,9 +85,11 @@ export interface LukeGuideInput {
    * registered. Labelled rather than drawn as keys: the guide is spoken and
    * read, and a chord said aloud is one thing to press. `removed` is the one
    * absence that is the developer's own choice — the shortcut was deleted —
-   * and the fact must say so rather than blame another app.
+   * and the fact must say so rather than blame another app. `held` is
+   * whether the key reports being let go of: the native helper does, and
+   * Electron's fallback presses to start and again to stop instead.
    */
-  hotkey: { hotkey?: string; removed?: boolean };
+  hotkey: { hotkey?: string; removed?: boolean; held?: boolean };
   /** The ask key labelled on the same terms, absent when none was registered. */
   askKey?: string;
   /** Whether the ask key's absence is a deleted shortcut, on the talk key's terms. */
@@ -115,13 +117,19 @@ function talkKeyFact(hotkey: LukeGuideInput["hotkey"]): AppGuideFact {
         "None is registered right now — another app may own the shortcut. The Settings tab's Keyboard shortcuts page shows its state.",
     };
   }
+  const hold =
+    hotkey.held === false
+      ? "press to start talking and press again, or press the stop key, to stop; the key " +
+        "cannot tell when it is let go of, so it works in pairs"
+      : "hold it to talk and let go to stop, and the microphone is open only while it is " +
+        "held; the stop key also closes it";
   return {
     label: "Talk key",
     detail:
-      `${hotkey.hotkey}, from any app: press to listen, and press the stop key, or this key ` +
-      "again, to mute. Luke keeps the conversation while it lasts, so the next press picks it " +
-      "up rather than starting over; a voice chosen in Settings is heard from the next " +
-      `conversation on. A different chord can be recorded, the default restored, or the shortcut removed, in ${SHORTCUTS_PAGE}.`,
+      `${hotkey.hotkey}, from any app: ${hold}. Luke keeps the conversation while it lasts, ` +
+      "so the next press picks it up rather than starting over; a voice chosen in Settings " +
+      "is heard from the next conversation on. A different chord can be recorded, the " +
+      `default restored, or the shortcut removed, in ${SHORTCUTS_PAGE}.`,
   };
 }
 
@@ -149,9 +157,9 @@ function askKeyFact(askKey: string | undefined, removed: boolean | undefined): A
 
 const MICROPHONE_DETAIL = {
   [MICROPHONE_STATUS.GRANTED]:
-    "Granted. The microphone is heard only from a talk key press until the stop key, or a " +
-    "second press, mutes it; muted, it sends nothing, and it closes with the conversation. " +
-    "Typing to Luke never unmutes it.",
+    "Granted. The microphone is open only while the talk key is held: the press opens it and " +
+    "letting go closes it, so nothing is captured between holds, and a conversation Luke " +
+    "opens to speak carries no microphone at all. Typing to Luke never opens it.",
   [MICROPHONE_STATUS.DENIED]:
     "Denied, so the talk key cannot capture. Typing to Luke still works: a typed ask opens no " +
     "capture device, and the reply is spoken either way. It can only be granted back in " +

--- a/apps/desktop/src/renderer/settings/shortcuts-page.tsx
+++ b/apps/desktop/src/renderer/settings/shortcuts-page.tsx
@@ -269,12 +269,12 @@ export function ShortcutSection({
         title="Talk to Luke"
         anchor={SETTINGS_SEARCH_ROW.TALK_KEY}
         // What the key actually does, which depends on whether it can report
-        // being let go of. Describing a hold to someone whose key can only
-        // toggle would leave them holding it and wondering.
+        // being let go of. Describing a hold to someone whose key reports
+        // presses alone would leave them holding it and wondering.
         detail={
           shortcuts.voiceHotkeyHeld
-            ? "Hold to talk, let go to send."
-            : "Press to talk, again to send."
+            ? "Hold to talk; the microphone is open only while the key is down."
+            : "Press to start talking, again to stop. Luke's key helper could not start, so the key cannot tell when it is let go of."
         }
         {...(shownTalk ? { shown: shownTalk } : undefined)}
         chosen={shortcuts.voiceChosen}

--- a/apps/desktop/src/renderer/voice/live-call.test.ts
+++ b/apps/desktop/src/renderer/voice/live-call.test.ts
@@ -495,6 +495,59 @@ test("a release while the press's device is being attached takes it back off the
   assert.equal(f.local.length, 1);
 });
 
+test("a press landing while the release's mute is still in flight waits for it, then opens a fresh device", async () => {
+  const f = fixture();
+  const opening = f.call.open({ byPress: true });
+  await drainMicrotasks();
+  f.peer.gathered();
+  await drainMicrotasks();
+  f.started();
+  await opening;
+  const first = f.call.unmute();
+  await drainMicrotasks();
+  f.acknowledge(LIVE_SERVER_EVENT.INPUT_AUDIO_UNMUTED);
+  await first;
+  const muting = f.call.mute();
+  await drainMicrotasks();
+  const second = f.call.unmute();
+  await drainMicrotasks();
+  // Nothing of the press goes until the release has let the device go.
+  assert.deepEqual(f.sentTypes(), [
+    LIVE_CLIENT_EVENT.INPUT_AUDIO_UNMUTE,
+    LIVE_CLIENT_EVENT.INPUT_AUDIO_MUTE,
+  ]);
+  assert.equal(f.microphoneOpens(), 1);
+  f.acknowledge(LIVE_SERVER_EVENT.INPUT_AUDIO_MUTED);
+  assert.equal(await muting, true);
+  await drainMicrotasks();
+  assert.equal(f.track.stopped, true);
+  assert.equal(f.microphoneOpens(), 2);
+  const fresh = f.tracks[1];
+  assert.ok(fresh);
+  assert.deepEqual(f.peer.replaced, [null, fresh]);
+  assert.deepEqual(f.sentTypes().at(-1), LIVE_CLIENT_EVENT.INPUT_AUDIO_UNMUTE);
+  f.acknowledge(LIVE_SERVER_EVENT.INPUT_AUDIO_UNMUTED);
+  assert.equal(await second, true);
+  assert.equal(f.call.listening, true);
+  assert.equal(fresh.enabled, true);
+});
+
+test("a press's device released before the session stood is let go of by the mute the release owes it", async () => {
+  const f = fixture();
+  const opening = f.call.open({ byPress: true });
+  await drainMicrotasks();
+  f.peer.gathered();
+  await drainMicrotasks();
+  f.started();
+  await opening;
+  assert.equal(f.track.stopped, false);
+  assert.equal(await f.call.mute(), true);
+  assert.deepEqual(f.sentTypes(), []);
+  assert.deepEqual(f.peer.replaced, [null]);
+  assert.equal(f.track.stopped, true);
+  assert.equal(f.local.at(-1), undefined);
+});
+
 test("a session opened for Luke's own speech carries no device: a trackless line and no microphone open", async () => {
   const f = fixture();
   const opening = f.call.open({ byPress: false });

--- a/apps/desktop/src/renderer/voice/live-call.test.ts
+++ b/apps/desktop/src/renderer/voice/live-call.test.ts
@@ -154,8 +154,11 @@ function fixture(options: { microphone?: boolean; sessionCreated?: boolean } = {
   let microphoneGranted = options.microphone !== false;
   const clock = new FakeClock();
   const peer = new FakePeerConnection();
-  const track = new FakeTrack();
-  const stream = new FakeStream([track]);
+  /** One device per open, so a release's stop and a later press's fresh device can each be told apart. */
+  const tracks: FakeTrack[] = [new FakeTrack()];
+  let microphoneOpens = 0;
+  let devicesOpened = 0;
+  let holdMicrophone: (() => void) | undefined;
   const statuses: LiveStatus[] = [];
   const captions: (readonly LiveCaptionRow[])[] = [];
   const errors: (string | undefined)[] = [];
@@ -187,9 +190,15 @@ function fixture(options: { microphone?: boolean; sessionCreated?: boolean } = {
     },
     createPeerConnection: () => peer,
     openMicrophone: async () => {
+      microphoneOpens += 1;
+      if (holdMicrophone) await new Promise<void>((resolve) => (holdMicrophone = resolve));
       if (!microphoneGranted) throw new Error("refused");
+      const track = devicesOpened === 0 ? tracks[0] : new FakeTrack();
+      assert.ok(track);
+      if (devicesOpened > 0) tracks.push(track);
+      devicesOpened += 1;
       // SAFETY: the call reads only the audio tracks and their `enabled` and `stop` off the stream.
-      return stream as unknown as MediaStream;
+      return new FakeStream([track]) as unknown as MediaStream;
     },
     onRemoteStream: (value) => remote.push(value),
     onLocalStream: (value) => local.push(value),
@@ -223,7 +232,22 @@ function fixture(options: { microphone?: boolean; sessionCreated?: boolean } = {
   return {
     clock,
     peer,
-    track,
+    get track(): FakeTrack {
+      const first = tracks[0];
+      assert.ok(first);
+      return first;
+    },
+    tracks,
+    microphoneOpens: () => microphoneOpens,
+    /** The next device open waits until `releaseMicrophone` lets it finish. */
+    holdNextMicrophone: () => {
+      holdMicrophone = () => undefined;
+    },
+    releaseMicrophone: () => {
+      const release = holdMicrophone;
+      holdMicrophone = undefined;
+      release?.();
+    },
     call,
     statuses,
     captions,
@@ -247,7 +271,7 @@ function fixture(options: { microphone?: boolean; sessionCreated?: boolean } = {
 
 test("the peer is built in the guide's order: track, channel before the offer, ICE under its bound, the host's answer set, and started awaited", async () => {
   const f = fixture();
-  const opening = f.call.open();
+  const opening = f.call.open({ byPress: true });
   await drainMicrotasks();
   assert.deepEqual(f.peer.steps, ["add-track", "create-channel", "create-offer", "set-local"]);
   assert.equal(f.track.enabled, false);
@@ -269,7 +293,7 @@ test("the peer is built in the guide's order: track, channel before the offer, I
 
 test("ICE gathering that never completes sends the offer at the bound", async () => {
   const f = fixture();
-  void f.call.open();
+  void f.call.open({ byPress: true });
   await drainMicrotasks();
   await f.clock.advance(f.clock.now + 5_000);
   assert.equal(f.offers.length, 1);
@@ -277,7 +301,7 @@ test("ICE gathering that never completes sends the offer at the bound", async ()
 
 test("a host that creates no session leaves the peer closed and the call failed", async () => {
   const f = fixture({ sessionCreated: false });
-  const opening = f.call.open();
+  const opening = f.call.open({ byPress: true });
   await drainMicrotasks();
   f.peer.gathered();
   assert.equal(await opening, false);
@@ -290,7 +314,7 @@ test("a host that creates no session leaves the peer closed and the call failed"
 
 test("a session that never announces itself started is given up at the bound", async () => {
   const f = fixture();
-  const opening = f.call.open();
+  const opening = f.call.open({ byPress: true });
   await drainMicrotasks();
   f.peer.gathered();
   await drainMicrotasks();
@@ -302,7 +326,7 @@ test("a session that never announces itself started is given up at the bound", a
 
 test("unmute and mute send the switch and flip the track only on the acknowledgment; an error naming the switch refuses it", async () => {
   const f = fixture();
-  const opening = f.call.open();
+  const opening = f.call.open({ byPress: true });
   await drainMicrotasks();
   f.peer.gathered();
   await drainMicrotasks();
@@ -330,18 +354,185 @@ test("unmute and mute send the switch and flip the track only on the acknowledgm
     error: { type: "invalid_request_error", message: "no" },
   });
   assert.equal(await muting, false);
-  assert.equal(f.track.enabled, true);
-  assert.equal(f.call.listening, true);
-  // An acknowledgment that never comes gives the switch up at the bound.
-  const again = f.call.mute();
+  // Refused or not, the key is up: the device leaves the line and stops.
+  assert.deepEqual(f.peer.replaced, [null]);
+  assert.equal(f.track.stopped, true);
+  assert.equal(f.call.listening, false);
+  assert.equal(f.local.at(-1), undefined);
+  assert.equal(f.statuses.at(-1), LIVE_STATUS.MUTED);
+});
+
+test("the release after the acknowledgment takes the track off the line and stops the device exactly once", async () => {
+  const f = fixture();
+  const opening = f.call.open({ byPress: true });
+  await drainMicrotasks();
+  f.peer.gathered();
+  await drainMicrotasks();
+  f.started();
+  await opening;
+  const unmuting = f.call.unmute();
+  await drainMicrotasks();
+  f.acknowledge(LIVE_SERVER_EVENT.INPUT_AUDIO_UNMUTED);
+  assert.equal(await unmuting, true);
+  const muting = f.call.mute();
+  await drainMicrotasks();
+  // The switch first, the device after: nothing is taken off the line while the mute is in flight.
+  assert.deepEqual(f.peer.replaced, []);
+  assert.equal(f.track.stopped, false);
+  f.acknowledge(LIVE_SERVER_EVENT.INPUT_AUDIO_MUTED);
+  assert.equal(await muting, true);
+  assert.deepEqual(f.peer.replaced, [null]);
+  assert.equal(f.track.stopped, true);
+  assert.equal(f.local.at(-1), undefined);
+  assert.equal(f.call.listening, false);
+  // A second release finds no device and sends nothing.
+  assert.equal(await f.call.mute(), true);
+  assert.deepEqual(f.peer.replaced, [null]);
+  assert.equal(f.sentTypes().length, 2);
+});
+
+test("a mute the server never acknowledges still releases the device at the bound", async () => {
+  const f = fixture();
+  const opening = f.call.open({ byPress: true });
+  await drainMicrotasks();
+  f.peer.gathered();
+  await drainMicrotasks();
+  f.started();
+  await opening;
+  const unmuting = f.call.unmute();
+  await drainMicrotasks();
+  f.acknowledge(LIVE_SERVER_EVENT.INPUT_AUDIO_UNMUTED);
+  await unmuting;
+  const muting = f.call.mute();
   await drainMicrotasks();
   await f.clock.advance(f.clock.now + MICROPHONE_ACK_TIMEOUT_MS);
-  assert.equal(await again, false);
+  assert.equal(await muting, false);
+  assert.deepEqual(f.peer.replaced, [null]);
+  assert.equal(f.track.stopped, true);
+  assert.equal(f.local.at(-1), undefined);
+});
+
+test("the next press after a release opens a fresh device and puts it on the line before the switch", async () => {
+  const f = fixture();
+  const opening = f.call.open({ byPress: true });
+  await drainMicrotasks();
+  f.peer.gathered();
+  await drainMicrotasks();
+  f.started();
+  await opening;
+  assert.equal(f.microphoneOpens(), 1);
+  const first = f.call.unmute();
+  await drainMicrotasks();
+  f.acknowledge(LIVE_SERVER_EVENT.INPUT_AUDIO_UNMUTED);
+  await first;
+  const muting = f.call.mute();
+  await drainMicrotasks();
+  f.acknowledge(LIVE_SERVER_EVENT.INPUT_AUDIO_MUTED);
+  await muting;
+  const second = f.call.unmute();
+  await drainMicrotasks();
+  assert.equal(f.microphoneOpens(), 2);
+  assert.equal(f.tracks.length, 2);
+  const fresh = f.tracks[1];
+  assert.ok(fresh);
+  assert.deepEqual(f.peer.replaced, [null, fresh]);
+  assert.equal(fresh.enabled, false);
+  assert.deepEqual(f.sentTypes().at(-1), LIVE_CLIENT_EVENT.INPUT_AUDIO_UNMUTE);
+  f.acknowledge(LIVE_SERVER_EVENT.INPUT_AUDIO_UNMUTED);
+  assert.equal(await second, true);
+  assert.equal(fresh.enabled, true);
+  assert.equal(f.local.at(-1) !== undefined, true);
+});
+
+test("a release while the press's device is still opening stops that device instead of attaching it", async () => {
+  const f = fixture();
+  const opening = f.call.open({ byPress: false });
+  await drainMicrotasks();
+  f.peer.gathered();
+  await drainMicrotasks();
+  f.started();
+  await opening;
+  f.holdNextMicrophone();
+  const unmuting = f.call.unmute();
+  await drainMicrotasks();
+  assert.equal(f.microphoneOpens(), 1);
+  const muting = f.call.mute();
+  assert.equal(await muting, true);
+  f.releaseMicrophone();
+  assert.equal(await unmuting, false);
+  assert.equal(f.track.stopped, true);
+  assert.deepEqual(f.peer.replaced, []);
+  assert.deepEqual(f.sentTypes(), []);
+  assert.equal(f.call.listening, false);
+});
+
+test("a release while the press's device is being attached takes it back off the line and stops it", async () => {
+  const f = fixture();
+  const opening = f.call.open({ byPress: false });
+  await drainMicrotasks();
+  f.peer.gathered();
+  await drainMicrotasks();
+  f.started();
+  await opening;
+  let attach: (() => void) | undefined;
+  f.peer.sender.replaceTrack = (track) => {
+    f.peer.replaced.push(track);
+    return track === null
+      ? Promise.resolve()
+      : new Promise<void>((resolve) => {
+          attach = resolve;
+        });
+  };
+  const unmuting = f.call.unmute();
+  await drainMicrotasks();
+  assert.deepEqual(f.peer.replaced, [f.track]);
+  assert.equal(await f.call.mute(), true);
+  attach?.();
+  assert.equal(await unmuting, false);
+  assert.deepEqual(f.peer.replaced, [f.track, null]);
+  assert.equal(f.track.stopped, true);
+  assert.deepEqual(f.sentTypes(), []);
+  assert.equal(f.local.length, 1);
+});
+
+test("a session opened for Luke's own speech carries no device: a trackless line and no microphone open", async () => {
+  const f = fixture();
+  const opening = f.call.open({ byPress: false });
+  await drainMicrotasks();
+  assert.deepEqual(f.peer.steps.slice(0, 2), ["add-transceiver", "create-channel"]);
+  assert.equal(f.microphoneOpens(), 0);
+  f.peer.gathered();
+  await drainMicrotasks();
+  f.started();
+  assert.equal(await opening, true);
+  assert.equal(f.local.at(-1), undefined);
+  assert.equal(f.track.stopped, false);
+  // The press against it opens the device then, and only then.
+  const unmuting = f.call.unmute();
+  await drainMicrotasks();
+  assert.equal(f.microphoneOpens(), 1);
+  assert.deepEqual(f.peer.replaced, [f.track]);
+  f.acknowledge(LIVE_SERVER_EVENT.INPUT_AUDIO_UNMUTED);
+  assert.equal(await unmuting, true);
+});
+
+test("a muted session with no device still reports idle once the window passes", async () => {
+  const f = fixture();
+  const opening = f.call.open({ byPress: false });
+  await drainMicrotasks();
+  f.peer.gathered();
+  await drainMicrotasks();
+  f.started();
+  await opening;
+  await f.clock.advance(f.clock.now + LIVE_IDLE_WINDOW_MS - 1);
+  assert.deepEqual(f.activity, []);
+  await f.clock.advance(f.clock.now + 1);
+  assert.deepEqual(f.activity, [true]);
 });
 
 test("a stop during an unmute still awaiting its acknowledgment gives the unmute up and mutes anyway", async () => {
   const f = fixture();
-  const opening = f.call.open();
+  const opening = f.call.open({ byPress: true });
   await drainMicrotasks();
   f.peer.gathered();
   await drainMicrotasks();
@@ -364,7 +555,7 @@ test("a stop during an unmute still awaiting its acknowledgment gives the unmute
 
 test("a microphone the system refused rides as a trackless line and is filled by the first unmute", async () => {
   const f = fixture({ microphone: false });
-  const opening = f.call.open();
+  const opening = f.call.open({ byPress: true });
   await drainMicrotasks();
   assert.deepEqual(f.peer.steps.slice(0, 2), ["add-transceiver", "create-channel"]);
   f.peer.gathered();
@@ -380,7 +571,7 @@ test("a microphone the system refused rides as a trackless line and is filled by
 
 test("granted after the session opened, the first unmute fills the trackless line before the switch goes", async () => {
   const f = fixture({ microphone: false });
-  const opening = f.call.open();
+  const opening = f.call.open({ byPress: true });
   await drainMicrotasks();
   f.peer.gathered();
   await drainMicrotasks();
@@ -399,7 +590,7 @@ test("granted after the session opened, the first unmute fills the trackless lin
 
 test("the speaking status comes from the remote track's level and never from transcript events; captions draw both speakers", async () => {
   const f = fixture();
-  const opening = f.call.open();
+  const opening = f.call.open({ byPress: true });
   await drainMicrotasks();
   f.peer.gathered();
   await drainMicrotasks();
@@ -449,7 +640,7 @@ test("the speaking status comes from the remote track's level and never from tra
 
 test("the transport is reported as the peer connection moves, and a failed one ends the call", async () => {
   const f = fixture();
-  const opening = f.call.open();
+  const opening = f.call.open({ byPress: true });
   await drainMicrotasks();
   f.peer.gathered();
   await drainMicrotasks();
@@ -474,7 +665,7 @@ test("the transport is reported as the peer connection moves, and a failed one e
 
 test("idle is reported once after the window with no microphone activity, and cleared once on the next", async () => {
   const f = fixture();
-  const opening = f.call.open();
+  const opening = f.call.open({ byPress: true });
   await drainMicrotasks();
   f.peer.gathered();
   await drainMicrotasks();
@@ -495,7 +686,7 @@ test("idle is reported once after the window with no microphone activity, and cl
 
 test("the hang-up registers closed, sends close, holds everything open until closed arrives, and gives up at the bound", async () => {
   const f = fixture();
-  const opening = f.call.open();
+  const opening = f.call.open({ byPress: true });
   await drainMicrotasks();
   f.peer.gathered();
   await drainMicrotasks();
@@ -519,7 +710,7 @@ test("the hang-up registers closed, sends close, holds everything open until clo
   assert.deepEqual(f.remote.at(-1), undefined);
   // A second call with no closed event gives up at the bound.
   const g = fixture();
-  const opened = g.call.open();
+  const opened = g.call.open({ byPress: true });
   await drainMicrotasks();
   g.peer.gathered();
   await drainMicrotasks();
@@ -539,7 +730,7 @@ test("the hang-up registers closed, sends close, holds everything open until clo
 
 test("a channel that closes under the call ends it, and a hang-up over a channel that cannot carry it is left to the host", async () => {
   const f = fixture();
-  const opening = f.call.open();
+  const opening = f.call.open({ byPress: true });
   await drainMicrotasks();
   f.peer.gathered();
   await drainMicrotasks();
@@ -550,7 +741,7 @@ test("a channel that closes under the call ends it, and a hang-up over a channel
   assert.equal(f.statuses.at(-1), LIVE_STATUS.IDLE);
   assert.equal(f.transports.at(-1), LIVE_TRANSPORT_STATE.CLOSED);
   const g = fixture();
-  const opened = g.call.open();
+  const opened = g.call.open({ byPress: true });
   await drainMicrotasks();
   g.peer.gathered();
   await drainMicrotasks();

--- a/apps/desktop/src/renderer/voice/live-call.ts
+++ b/apps/desktop/src/renderer/voice/live-call.ts
@@ -23,6 +23,7 @@ import type {
   LiveCaptionRow,
   LiveVoiceCall,
   LiveVoiceCallEvents,
+  LiveVoiceCallOpening,
 } from "@sidecar/voice/orchestrator";
 import type { UnparsedWireValue, WireRecord } from "@sidecar/wire";
 import { LiveCaptions } from "./live-captions";
@@ -31,6 +32,7 @@ import {
   type LivePeer,
   type LivePeerConnection,
   openLivePeer,
+  stopDevice,
   teardown,
 } from "./live-peer";
 
@@ -93,11 +95,13 @@ type ServerEventHandlers = { [Type in LiveServerEvent["type"]]?: ServerEventHand
 /**
  * The voice window's one session as a GPT Live peer. The renderer owns the
  * microphone switch and the hang-up and nothing else: it sends the mute,
- * unmute, and close events the data channel permissions allow it, flips the
- * track only on the acknowledgment, draws both speakers' captions from the
- * transcript deltas, reports its transport and its idle to the host, and
- * reads Luke as speaking from the remote track's playback level rather than
- * from transcript events. Every append is the host's, over its sideband.
+ * unmute, and close events the data channel permissions allow it, opens the
+ * capture device for the unmute and releases it after the mute so the device
+ * is open exactly while the talk key is held, flips the track only on the
+ * acknowledgment, draws both speakers' captions from the transcript deltas,
+ * reports its transport and its idle to the host, and reads Luke as speaking
+ * from the remote track's playback level rather than from transcript events.
+ * Every append is the host's, over its sideband.
  */
 export class LiveCall implements LiveVoiceCall {
   readonly #options: LiveCallOptions;
@@ -116,6 +120,8 @@ export class LiveCall implements LiveVoiceCall {
   #idleReported = false;
   #speakingHangover: ScheduledTimer | undefined;
   #captionTick: ScheduledTimer | undefined;
+  /** Counts the mutes, so an unmute still opening its device learns the key came up while it waited. */
+  #muteEpoch = 0;
   #ids = 0;
 
   constructor(options: LiveCallOptions) {
@@ -142,23 +148,23 @@ export class LiveCall implements LiveVoiceCall {
     return this.standing && this.#micLive;
   }
 
-  async open(): Promise<boolean> {
+  async open(opening: LiveVoiceCallOpening): Promise<boolean> {
     if (this.#peer) return this.standing;
     this.#setStatus(LIVE_STATUS.CONNECTING);
-    const opening = await openLivePeer({
+    const opened = await openLivePeer({
       createPeerConnection: this.#options.createPeerConnection,
-      openMicrophone: this.#options.openMicrophone,
+      ...(opening.byPress ? { openMicrophone: this.#options.openMicrophone } : undefined),
       createSession: this.#options.acts.createSession,
       onRemoteStream: (stream) => this.#options.onRemoteStream(stream),
       schedule: this.#options.schedule,
       cancel: this.#options.cancel,
     });
-    if (opening.outcome !== LIVE_PEER_OUTCOME.OPENED) {
-      this.#options.events.onError(opening.message);
+    if (opened.outcome !== LIVE_PEER_OUTCOME.OPENED) {
+      this.#options.events.onError(opened.message);
       this.#setStatus(LIVE_STATUS.FAILED);
       return false;
     }
-    const peer = opening.peer;
+    const peer = opened.peer;
     this.#peer = peer;
     this.#options.onLocalStream(peer.microphoneStream);
     peer.connection.onconnectionstatechange = () => this.#onTransport(peer);
@@ -175,22 +181,43 @@ export class LiveCall implements LiveVoiceCall {
     return true;
   }
 
+  /**
+   * The talk key's press: the device is opened here, at the press, when none
+   * stands, and put on the sending line before the switch goes. A key that
+   * came up while the device was still opening or attaching leaves it
+   * stopped and off the line, since the mute that release sent found nothing
+   * to release.
+   */
   async unmute(): Promise<boolean> {
     const peer = this.#peer;
     if (!peer || !this.#started || this.#ended) return false;
-    if (!peer.microphone) {
+    if (!peer.microphoneStream) {
+      const epoch = this.#muteEpoch;
+      let stream: MediaStream;
       try {
-        const stream = await this.#options.openMicrophone();
-        const track = stream.getAudioTracks()[0];
-        if (!track) return false;
-        track.enabled = false;
-        await peer.sender.replaceTrack(track);
-        peer.microphone = track;
-        peer.microphoneStream = stream;
-        this.#options.onLocalStream(stream);
+        stream = await this.#options.openMicrophone();
       } catch {
         return false;
       }
+      const track = stream.getAudioTracks()[0];
+      if (!track || epoch !== this.#muteEpoch || this.#ended) {
+        stopDevice(stream);
+        return false;
+      }
+      track.enabled = false;
+      try {
+        await peer.sender.replaceTrack(track);
+      } catch {
+        stopDevice(stream);
+        return false;
+      }
+      if (epoch !== this.#muteEpoch || this.#ended) {
+        await this.#takeOffLine(peer, stream);
+        return false;
+      }
+      peer.microphone = track;
+      peer.microphoneStream = stream;
+      this.#options.onLocalStream(stream);
     }
     if (this.#micLive) return true;
     const acknowledged = await this.#switchMicrophone(unmuteEvent);
@@ -203,22 +230,26 @@ export class LiveCall implements LiveVoiceCall {
   }
 
   /**
-   * The stop: an unmute still waiting on its acknowledgment is given up
-   * first, and the mute goes whatever the track shows, since the server may
-   * still be about to honour the unmute it was asked for.
+   * The talk key's release, and the stop: an unmute still waiting on its
+   * acknowledgment is given up first, and the mute goes whatever the track
+   * shows, since the server may still be about to honour the unmute it was
+   * asked for. The device is released only once the mute is answered,
+   * acknowledged or not, so the model is not fed a vanishing track while the
+   * switch is still in flight; released it is, whatever the answer, because
+   * the key being up is the developer's decision and the device is theirs.
+   * The answer stays the session's own word on the switch.
    */
   async mute(): Promise<boolean> {
     const peer = this.#peer;
     if (!peer || !this.#started || this.#ended) return false;
+    this.#muteEpoch += 1;
     const unmuting = this.#pendingSwitch !== undefined;
-    if (!this.#micLive && !unmuting) return true;
-    const acknowledged = await this.#switchMicrophone(muteEvent);
-    if (!acknowledged) return false;
-    if (peer.microphone) peer.microphone.enabled = false;
+    const acknowledged = this.#micLive || unmuting ? await this.#switchMicrophone(muteEvent) : true;
+    await this.#releaseDevice(peer);
     this.#micLive = false;
     this.#armIdle();
     this.#refreshStatus();
-    return true;
+    return acknowledged;
   }
 
   /**
@@ -465,6 +496,25 @@ export class LiveCall implements LiveVoiceCall {
     this.#options.onLocalStream(undefined);
     this.#options.onRemoteStream(undefined);
     this.#setStatus(status);
+  }
+
+  /** Takes the device off the sending line and stops it, so the system's indicator goes out with the key. */
+  async #releaseDevice(peer: LivePeer): Promise<void> {
+    const stream = peer.microphoneStream;
+    if (!stream) return;
+    peer.microphone = undefined;
+    peer.microphoneStream = undefined;
+    await this.#takeOffLine(peer, stream);
+    this.#options.onLocalStream(undefined);
+  }
+
+  async #takeOffLine(peer: LivePeer, stream: MediaStream): Promise<void> {
+    try {
+      await peer.sender.replaceTrack(null);
+    } catch {
+      // A line already closed has nothing to take the track off; the device is stopped either way.
+    }
+    stopDevice(stream);
   }
 
   #nextId(): string {

--- a/apps/desktop/src/renderer/voice/live-call.ts
+++ b/apps/desktop/src/renderer/voice/live-call.ts
@@ -122,6 +122,8 @@ export class LiveCall implements LiveVoiceCall {
   #captionTick: ScheduledTimer | undefined;
   /** Counts the mutes, so an unmute still opening its device learns the key came up while it waited. */
   #muteEpoch = 0;
+  /** The mute under way, so a press landing before its release has settled waits for the device to be let go of first. */
+  #muting: Promise<boolean> | undefined;
   #ids = 0;
 
   constructor(options: LiveCallOptions) {
@@ -189,6 +191,7 @@ export class LiveCall implements LiveVoiceCall {
    * to release.
    */
   async unmute(): Promise<boolean> {
+    while (this.#muting) await this.#muting;
     const peer = this.#peer;
     if (!peer || !this.#started || this.#ended) return false;
     if (!peer.microphoneStream) {
@@ -239,10 +242,18 @@ export class LiveCall implements LiveVoiceCall {
    * the key being up is the developer's decision and the device is theirs.
    * The answer stays the session's own word on the switch.
    */
-  async mute(): Promise<boolean> {
+  mute(): Promise<boolean> {
+    if (this.#muting) return this.#muting;
     const peer = this.#peer;
-    if (!peer || !this.#started || this.#ended) return false;
+    if (!peer || !this.#started || this.#ended) return Promise.resolve(false);
     this.#muteEpoch += 1;
+    this.#muting = this.#muteAndRelease(peer).finally(() => {
+      this.#muting = undefined;
+    });
+    return this.#muting;
+  }
+
+  async #muteAndRelease(peer: LivePeer): Promise<boolean> {
     const unmuting = this.#pendingSwitch !== undefined;
     const acknowledged = this.#micLive || unmuting ? await this.#switchMicrophone(muteEvent) : true;
     await this.#releaseDevice(peer);

--- a/apps/desktop/src/renderer/voice/live-peer.ts
+++ b/apps/desktop/src/renderer/voice/live-peer.ts
@@ -2,12 +2,14 @@ import type { ScheduledTimer } from "@sidecar/runtime/vocabulary";
 
 /**
  * The WebRTC peer the voice window is, as the WebRTC guide builds one: the
- * microphone track added first, the `oai-events` data channel created before
- * the offer, ICE gathered under a bound, the offer handed to the host that
- * holds the key, and the host's answer applied. The HTTP request the host
- * makes is what starts the session, so nothing here sends `session.start`.
- * The peer is written over the narrowest slice of the browser's objects the
- * peer touches, so a test can stand a fake in for each without a browser.
+ * audio line first (the microphone's track where a press opened the session,
+ * a sending line with no track otherwise), the `oai-events` data channel
+ * created before the offer, ICE gathered under a bound, the offer handed to
+ * the host that holds the key, and the host's answer applied. The HTTP
+ * request the host makes is what starts the session, so nothing here sends
+ * `session.start`. The peer is written over the narrowest slice of the
+ * browser's objects the peer touches, so a test can stand a fake in for each
+ * without a browser.
  */
 
 /** How long ICE gathering may run before the offer goes with what it has. */
@@ -36,7 +38,7 @@ export interface LivePeerConnection {
   readonly localDescription: { readonly sdp: string } | null;
   createDataChannel(label: string): LiveDataChannel;
   addTrack(track: MediaStreamTrack, stream: MediaStream): LiveTrackSender;
-  /** A sending audio line with no track yet, for a session opened before the microphone is granted. */
+  /** A sending audio line with no track, filled by the first unmute a press asks for. */
   addTransceiver(kind: "audio", init: { direction: "sendrecv" }): { sender: LiveTrackSender };
   createOffer(): Promise<RTCSessionDescriptionInit>;
   setLocalDescription(description: RTCSessionDescriptionInit): Promise<void>;
@@ -49,8 +51,14 @@ export interface LivePeerConnection {
 
 export interface LivePeerSeams {
   createPeerConnection: () => LivePeerConnection;
-  /** The preferred capture device; a refusal opens the session with no track until the first unmute. */
-  openMicrophone: () => Promise<MediaStream>;
+  /**
+   * The preferred capture device, handed over only for a session a press
+   * opened, since the press is the user action the WebRTC guide asks the
+   * microphone be requested from; absent, the session opens with no device
+   * and its first unmute opens one. A refusal opens the session the same
+   * way, with no track until the first unmute.
+   */
+  openMicrophone?: () => Promise<MediaStream>;
   /** The host: the peer's offer becomes the one session, answered with the SDP the peer sets. */
   createSession: (sdp: string) => Promise<{ sessionId: string; sdpAnswer: string } | undefined>;
   onRemoteStream: (stream: MediaStream) => void;
@@ -63,7 +71,7 @@ export interface LivePeer {
   sessionId: string;
   connection: LivePeerConnection;
   channel: LiveDataChannel;
-  /** The developer's track, disabled until the session is unmuted; absent when the microphone was refused. */
+  /** The developer's track while the talk key holds the device open, disabled until the session is unmuted; absent otherwise. */
   microphone: MediaStreamTrack | undefined;
   microphoneStream: MediaStream | undefined;
   sender: LiveTrackSender;
@@ -98,10 +106,11 @@ async function gatherIce(connection: LivePeerConnection, seams: LivePeerSeams): 
 }
 
 /**
- * Opens the peer in the guide's order. The microphone rides the offer with
- * its track disabled, so a session opened for Luke's own speech hears nothing
- * until the talk key; a microphone the system refuses leaves a sending line
- * with no track, which the first unmute fills.
+ * Opens the peer in the guide's order. A press's microphone rides the offer
+ * with its track disabled until the session acknowledges the unmute; a
+ * session opened for Luke's own speech, or one whose microphone the system
+ * refuses, carries a sending line with no track, which the first unmute
+ * fills, so no capture device is open behind a session nobody pressed for.
  */
 export async function openLivePeer(seams: LivePeerSeams): Promise<LivePeerOpening> {
   let connection: LivePeerConnection | undefined;
@@ -113,11 +122,13 @@ export async function openLivePeer(seams: LivePeerSeams): Promise<LivePeerOpenin
       seams.onRemoteStream(stream);
     };
     let microphone: MediaStreamTrack | undefined;
-    try {
-      microphoneStream = await seams.openMicrophone();
-      microphone = microphoneStream.getAudioTracks()[0];
-    } catch {
-      microphoneStream = undefined;
+    if (seams.openMicrophone) {
+      try {
+        microphoneStream = await seams.openMicrophone();
+        microphone = microphoneStream.getAudioTracks()[0];
+      } catch {
+        microphoneStream = undefined;
+      }
     }
     let sender: LiveTrackSender;
     if (microphone && microphoneStream) {
@@ -158,11 +169,16 @@ export async function openLivePeer(seams: LivePeerSeams): Promise<LivePeerOpenin
   }
 }
 
-/** Closes the peer and stops the capture device it opened. */
+/** Stops every track of a capture device, so the system's indicator goes with it. */
+export function stopDevice(stream: MediaStream | undefined): void {
+  for (const track of stream?.getTracks() ?? []) track.stop();
+}
+
+/** Closes the peer and stops the capture device standing on it. */
 export function teardown(
   connection: LivePeerConnection,
   microphoneStream: MediaStream | undefined,
 ): void {
-  for (const track of microphoneStream?.getTracks() ?? []) track.stop();
+  stopDevice(microphoneStream);
   connection.close();
 }

--- a/apps/desktop/src/renderer/voice/use-voice-session.ts
+++ b/apps/desktop/src/renderer/voice/use-voice-session.ts
@@ -210,12 +210,18 @@ export function useVoiceSession(remoteAudio: RefObject<HTMLAudioElement | null>)
   );
 
   // The talk key is registered by the main process so it answers from any app,
-  // which is the whole point: no window to find, nothing to focus first. Only
-  // the press decides anything: the microphone is a switch on the session, so
-  // a release ends nothing. A press during a chord being recorded is held
-  // back in the main process, where the recording is known.
+  // which is the whole point: no window to find, nothing to focus first. It
+  // is held to talk: the press opens the microphone and the release closes
+  // it, so the device is open exactly while the key is down. A press during
+  // a chord being recorded is held back in the main process, where the
+  // recording is known; a release always lands, so a hold begun before the
+  // recording still ends.
   useEffect(
     () => window.sidecar.onVoiceHotkeyPress(() => void orchestrator.beginTalk()),
+    [orchestrator],
+  );
+  useEffect(
+    () => window.sidecar.onVoiceHotkeyRelease(() => void orchestrator.endTalk()),
     [orchestrator],
   );
   // The stop key asks for quiet from any app, exactly as Escape asks for it

--- a/packages/voice/src/orchestrator/index.ts
+++ b/packages/voice/src/orchestrator/index.ts
@@ -2,6 +2,7 @@ export type {
   LiveCaptionRow,
   LiveVoiceCall,
   LiveVoiceCallEvents,
+  LiveVoiceCallOpening,
 } from "./live-voice-call.js";
 export {
   type LiveVoiceBridge,

--- a/packages/voice/src/orchestrator/live-voice-call.ts
+++ b/packages/voice/src/orchestrator/live-voice-call.ts
@@ -10,6 +10,15 @@ import type { ConversationEntry } from "@sidecar/session";
  * playback. Nothing here appends to the model: every append is the host's,
  * over its trusted sideband, so the call can carry no authority to speak.
  */
+/**
+ * Who opened the session, which decides whether a capture device rides its
+ * offer: a press is the user action the WebRTC guide asks the microphone be
+ * requested from, and a session opened for Luke's own speech carries none.
+ */
+export interface LiveVoiceCallOpening {
+  byPress: boolean;
+}
+
 export interface LiveVoiceCall {
   readonly status: LiveStatus;
   /** The session the host created for this call, once its offer was answered; what the host's word about a session is matched against. */
@@ -20,13 +29,19 @@ export interface LiveVoiceCall {
   readonly listening: boolean;
   /**
    * Builds the peer, hands the offer to the host, and waits for the session
-   * to start; the microphone track rides the offer disabled. Answers whether
-   * a session stands at the end of it.
+   * to start; a press's microphone track rides the offer disabled, and any
+   * other opening carries no device. Answers whether a session stands at the
+   * end of it.
    */
-  open(): Promise<boolean>;
-  /** Asks the session to hear the microphone; the track enables on the acknowledgment. */
+  open(opening: LiveVoiceCallOpening): Promise<boolean>;
+  /** Opens the capture device if none stands and asks the session to hear it; the track enables on the acknowledgment. */
   unmute(): Promise<boolean>;
-  /** Asks the session to stop hearing the microphone; the track disables on the acknowledgment. */
+  /**
+   * Asks the session to stop hearing the microphone, then releases the
+   * capture device whatever the session answered: the key coming up is the
+   * developer's decision and the device is theirs. The answer stays the
+   * session's own word on the switch.
+   */
   mute(): Promise<boolean>;
   /** The graceful hang-up: `session.closed` registered, `session.close` sent, waited for under the guide's bound. */
   close(): Promise<void>;

--- a/packages/voice/src/orchestrator/live-voice-orchestrator.test.ts
+++ b/packages/voice/src/orchestrator/live-voice-orchestrator.test.ts
@@ -4,7 +4,12 @@ import { LIVE_SESSION_PHASE } from "@sidecar/gateway";
 import { LIVE_CLOSE_REASON, LIVE_STATUS, type LiveStatus } from "@sidecar/live";
 import { drainMicrotasks } from "@sidecar/runtime/testing";
 import { CONVERSATION_ENTRY_KIND, type ConversationEntryKind } from "@sidecar/session";
-import type { LiveCaptionRow, LiveVoiceCall, LiveVoiceCallEvents } from "./live-voice-call.js";
+import type {
+  LiveCaptionRow,
+  LiveVoiceCall,
+  LiveVoiceCallEvents,
+  LiveVoiceCallOpening,
+} from "./live-voice-call.js";
 import {
   type LiveVoiceExchangeOpening,
   LiveVoiceOrchestrator,
@@ -19,6 +24,8 @@ class FakeCall implements LiveVoiceCall {
   status: LiveStatus = LIVE_STATUS.IDLE;
   sessionId: string | undefined;
   opens = 0;
+  /** Who the call was told opened it, so a briefing's session can be seen to carry no device. */
+  openings: LiveVoiceCallOpening[] = [];
   unmutes = 0;
   mutes = 0;
   closes = 0;
@@ -40,8 +47,9 @@ class FakeCall implements LiveVoiceCall {
     return this.status === LIVE_STATUS.LISTENING;
   }
 
-  open(): Promise<boolean> {
+  open(opening: LiveVoiceCallOpening): Promise<boolean> {
     this.opens += 1;
+    this.openings.push(opening);
     this.settle(LIVE_STATUS.CONNECTING);
     return new Promise<boolean>((resolve) => {
       this.#release = () => {
@@ -95,6 +103,7 @@ function fixture(surroundings: Partial<LiveVoiceSurroundings> = {}) {
   const openings: (LiveVoiceExchangeOpening | undefined)[] = [];
   let microphoneGranted = true;
   let microphoneAsks = 0;
+  let microphoneAsk: (() => Promise<boolean>) | undefined;
   const orchestrator = new LiveVoiceOrchestrator({
     bridge: {
       reportView: (view, exchange) => {
@@ -103,7 +112,7 @@ function fixture(surroundings: Partial<LiveVoiceSurroundings> = {}) {
       },
       requestMicrophone: async () => {
         microphoneAsks += 1;
-        return microphoneGranted;
+        return microphoneAsk ? microphoneAsk() : microphoneGranted;
       },
       hostedUnavailableNote: async () => undefined,
     },
@@ -122,6 +131,10 @@ function fixture(surroundings: Partial<LiveVoiceSurroundings> = {}) {
     setMicrophone: (granted: boolean) => {
       microphoneGranted = granted;
     },
+    /** The system's dialog standing: the ask answers when the test says so. */
+    setMicrophoneAsk: (ask: () => Promise<boolean>) => {
+      microphoneAsk = ask;
+    },
     microphoneAsks: () => microphoneAsks,
     latest: () => calls[calls.length - 1],
   };
@@ -136,34 +149,87 @@ function row(
   return { rowId, entry: { kind, words }, settled };
 }
 
-test("the talk key opens a session when none stands and unmutes it once started; a second press mutes", async () => {
+test("the talk key's press opens a session by press when none stands and unmutes it once started; its release mutes once", async () => {
   const f = fixture();
   const pressed = f.orchestrator.beginTalk();
   const call = f.latest();
   assert.ok(call);
   assert.equal(call.opens, 1);
+  assert.deepEqual(call.openings, [{ byPress: true }]);
   assert.equal(call.unmutes, 0);
   call.started();
   await pressed;
   assert.equal(call.unmutes, 1);
+  assert.equal(call.mutes, 0);
   assert.equal(call.status, LIVE_STATUS.LISTENING);
-  await f.orchestrator.beginTalk();
+  await f.orchestrator.endTalk();
   assert.equal(call.mutes, 1);
   assert.equal(call.opens, 1);
   assert.equal(f.calls.length, 1);
-  // Pressed again against the muted session: no second session, one more unmute.
+  // A release with no press behind it does nothing.
+  await f.orchestrator.endTalk();
+  assert.equal(call.mutes, 1);
+  // The next hold against the standing session: no second session, one more unmute, one more mute.
   await f.orchestrator.beginTalk();
   assert.equal(f.calls.length, 1);
   assert.equal(call.unmutes, 2);
+  assert.equal(call.mutes, 1);
+  await f.orchestrator.endTalk();
+  assert.equal(call.mutes, 2);
 });
 
-test("the stop key mutes a standing session and does nothing against none", async () => {
+test("a second press while the developer is heard never mutes", async () => {
+  const f = fixture();
+  const pressed = f.orchestrator.beginTalk();
+  f.latest()?.started();
+  await pressed;
+  await f.orchestrator.beginTalk();
+  await f.orchestrator.beginTalk();
+  const call = f.latest();
+  assert.ok(call);
+  assert.equal(call.mutes, 0);
+  assert.equal(call.status, LIVE_STATUS.LISTENING);
+});
+
+test("a release while the press's session is still opening leaves it to open muted", async () => {
+  const f = fixture();
+  const pressed = f.orchestrator.beginTalk();
+  const call = f.latest();
+  assert.ok(call);
+  assert.equal(call.standing, false);
+  await f.orchestrator.endTalk();
+  call.started();
+  await pressed;
+  assert.equal(call.unmutes, 0);
+  assert.equal(call.mutes, 0);
+  assert.equal(call.status, LIVE_STATUS.MUTED);
+});
+
+test("a press during a session opened for Luke's speech unmutes it once started, and a release during the opening does not", async () => {
+  const f = fixture();
+  f.orchestrator.obeySessionChange({ phase: LIVE_SESSION_PHASE.WANTED });
+  const call = f.latest();
+  assert.ok(call);
+  assert.deepEqual(call.openings, [{ byPress: false }]);
+  const pressed = f.orchestrator.beginTalk();
+  await drainMicrotasks();
+  assert.equal(f.calls.length, 1);
+  call.started();
+  await pressed;
+  assert.equal(call.unmutes, 1);
+  await f.orchestrator.endTalk();
+  assert.equal(call.mutes, 1);
+});
+
+test("the stop key mutes a standing session once, does nothing against none, and ends the hold so the release mutes nothing more", async () => {
   const f = fixture();
   assert.equal(await f.orchestrator.stopSpeaking(), false);
   const pressed = f.orchestrator.beginTalk();
   f.latest()?.started();
   await pressed;
   assert.equal(await f.orchestrator.stopSpeaking(), true);
+  assert.equal(f.latest()?.mutes, 1);
+  await f.orchestrator.endTalk();
   assert.equal(f.latest()?.mutes, 1);
 });
 
@@ -184,13 +250,25 @@ test("a press without the microphone asks for it, and a refusal opens nothing", 
   assert.equal(f.latest()?.unmutes, 1);
 });
 
+test("a key let go of while the microphone dialog stands opens the session muted", async () => {
+  const f = fixture({ microphoneGranted: false });
+  let grant: ((granted: boolean) => void) | undefined;
+  f.setMicrophoneAsk(() => new Promise<boolean>((resolve) => (grant = resolve)));
+  const pressed = f.orchestrator.beginTalk();
+  await drainMicrotasks();
+  await f.orchestrator.endTalk();
+  grant?.(true);
+  await pressed;
+  assert.equal(f.calls.length, 0);
+});
+
 test("a press while voice is off opens nothing", async () => {
   const f = fixture({ voiceAvailable: false });
   await f.orchestrator.beginTalk();
   assert.equal(f.calls.length, 0);
 });
 
-test("wanted opens a session muted, closing hangs it up, and a lost session with the microphone live listens again on the next", async () => {
+test("wanted opens a session with no device, closing hangs it up, and a session lost mid-hold listens again on the next", async () => {
   const f = fixture();
   f.orchestrator.obeySessionChange({ phase: LIVE_SESSION_PHASE.WANTED });
   const first = f.latest();
@@ -205,9 +283,12 @@ test("wanted opens a session muted, closing hangs it up, and a lost session with
     sessionId: first.sessionId,
   });
   assert.equal(f.calls.length, 1);
-  // The developer joins, then the connection is lost under them: the peer's
-  // own end may land before the host's word, and the wanted right after it.
-  await first.unmute();
+  assert.deepEqual(first.openings, [{ byPress: false }]);
+  // The developer holds the key, then the connection is lost under them: the
+  // peer's own end may land before the host's word, and the wanted right
+  // after it.
+  await f.orchestrator.beginTalk();
+  assert.equal(first.unmutes, 1);
   const lost = first.sessionId;
   first.settle(LIVE_STATUS.IDLE);
   f.orchestrator.obeySessionChange({
@@ -219,6 +300,7 @@ test("wanted opens a session muted, closing hangs it up, and a lost session with
   const second = f.latest();
   assert.ok(second);
   assert.notEqual(second, first);
+  assert.deepEqual(second.openings, [{ byPress: false }]);
   second.started();
   await drainMicrotasks();
   assert.equal(second.unmutes, 1);
@@ -232,6 +314,34 @@ test("wanted opens a session muted, closing hangs it up, and a lost session with
   });
   await drainMicrotasks();
   assert.equal(second.closes, 1);
+});
+
+test("a session lost after the key was let go of does not listen again on the next", async () => {
+  const f = fixture();
+  const pressed = f.orchestrator.beginTalk();
+  const first = f.latest();
+  assert.ok(first);
+  first.started();
+  await pressed;
+  await f.orchestrator.endTalk();
+  assert.equal(first.mutes, 1);
+  // Lost before the mute's status landed: the last status the call reported was listening.
+  first.status = LIVE_STATUS.LISTENING;
+  first.events.onStatus(LIVE_STATUS.LISTENING);
+  const lost = first.sessionId;
+  first.settle(LIVE_STATUS.IDLE);
+  f.orchestrator.obeySessionChange({
+    phase: LIVE_SESSION_PHASE.CLOSED,
+    sessionId: lost,
+    reason: LIVE_CLOSE_REASON.CONNECTION_LOST,
+  });
+  f.orchestrator.obeySessionChange({ phase: LIVE_SESSION_PHASE.WANTED });
+  const second = f.latest();
+  assert.ok(second);
+  assert.notEqual(second, first);
+  second.started();
+  await drainMicrotasks();
+  assert.equal(second.unmutes, 0);
 });
 
 test("a session closed by the host's own decision does not listen again on the next", async () => {

--- a/packages/voice/src/orchestrator/live-voice-orchestrator.test.ts
+++ b/packages/voice/src/orchestrator/live-voice-orchestrator.test.ts
@@ -200,8 +200,9 @@ test("a release while the press's session is still opening leaves it to open mut
   await f.orchestrator.endTalk();
   call.started();
   await pressed;
+  // The release's mute still goes once the session stands: the press's device rode the offer.
   assert.equal(call.unmutes, 0);
-  assert.equal(call.mutes, 0);
+  assert.equal(call.mutes, 1);
   assert.equal(call.status, LIVE_STATUS.MUTED);
 });
 
@@ -503,7 +504,7 @@ test("a stop while a press's session is still opening leaves it muted", async ()
   call.started();
   await pressed;
   assert.equal(call.unmutes, 0);
-  assert.equal(call.mutes, 0);
+  assert.equal(call.mutes, 1);
   assert.equal(call.status, LIVE_STATUS.MUTED);
 });
 

--- a/packages/voice/src/orchestrator/live-voice-orchestrator.ts
+++ b/packages/voice/src/orchestrator/live-voice-orchestrator.ts
@@ -74,14 +74,16 @@ function sameView(left: LiveVoiceView, right: LiveVoiceView): boolean {
 /**
  * The one voice session as the desktop drives it, following the live guide's
  * one-owner rule: the renderer owns the microphone switch and the hang-up,
- * the host owns every append and the close decision. The talk key opens the
- * session if none stands and unmutes it; pressed again while the developer is
- * heard, it mutes, as the stop key does. The host's `voiceLiveSession.changed`
- * is obeyed rather than reasoned about: wanted opens a session muted for
- * whatever Luke has to say, closing hangs up, and a session lost with the
- * microphone live is listened to again on the session that replaces it. No
- * turn is committed, no reply is claimed, and no words are written here: both
- * speakers' lines are the host's, from the transcript its sideband receives.
+ * the host owns every append and the close decision. The talk key is held to
+ * talk: its press opens the session if none stands and unmutes it, its
+ * release mutes, and the microphone is open exactly between the two; the
+ * stop key mutes the same way. The host's `voiceLiveSession.changed` is
+ * obeyed rather than reasoned about: wanted opens a session with no
+ * microphone for whatever Luke has to say, closing hangs up, and a session
+ * lost while the key is still held is listened to again on the session that
+ * replaces it. No turn is committed, no reply is claimed, and no words are
+ * written here: both speakers' lines are the host's, from the transcript its
+ * sideband receives.
  */
 export class LiveVoiceOrchestrator {
   readonly #bridge: LiveVoiceBridge;
@@ -106,8 +108,13 @@ export class LiveVoiceOrchestrator {
   /** Whether the session standing was opened by a press rather than for Luke's own speech. */
   #openedByPress = false;
   #opening: Promise<boolean> | undefined;
-  /** A stop pressed while a press's session was still opening: the press ends muted rather than unmuting a session nobody wants heard. */
-  #pressStopped = false;
+  /**
+   * Whether the talk key is down. A press's unmute follows the session it
+   * opened only while this still stands, so a key let go of, or a stop
+   * pressed, during the opening leaves the session muted rather than
+   * unmuting one nobody wants heard.
+   */
+  #pressHeld = false;
   #reported: LiveVoiceView | undefined;
   /** The call whose exchange has been counted, so a session pausing between Luke's sentences is not a second exchange. */
   #countedCall: LiveVoiceCall | undefined;
@@ -131,9 +138,11 @@ export class LiveVoiceOrchestrator {
   }
 
   /**
-   * The talk key. Against no session it opens one and unmutes it; against a
-   * muted session it unmutes; against a listening one it mutes, so the key
-   * alone can end what it began.
+   * The talk key going down. Against no session it opens one and unmutes it;
+   * against a standing session it unmutes. It never mutes: the key coming up
+   * does that, so a hold is heard for exactly as long as it lasts, and a
+   * hold that ended while the system's microphone dialog stood, or while the
+   * session was opening, unmutes nothing.
    */
   async beginTalk(): Promise<void> {
     if (this.#surroundings.voiceAvailable === false) {
@@ -141,21 +150,17 @@ export class LiveVoiceOrchestrator {
       if (unavailable) this.#strip.showNotice(unavailable);
       return;
     }
-    const standing = this.#call;
-    if (standing?.listening) {
-      await standing.mute();
-      return;
-    }
+    this.#pressHeld = true;
     if (!this.#surroundings.microphoneGranted) {
       const granted = await this.#bridge.requestMicrophone();
       if (!granted) {
         this.#strip.showError(MICROPHONE_REFUSED_NOTE);
         return;
       }
+      if (!this.#pressHeld) return;
     }
-    this.#pressStopped = false;
     const call = await this.#ensureSession({ byPress: true });
-    if (call && !this.#pressStopped) await call.unmute();
+    if (call && this.#pressHeld) await call.unmute();
     // The press is answered once the session hears the developer; between the
     // offer and the unmute the session passes through muted, which is not the
     // exchange ending.
@@ -164,17 +169,28 @@ export class LiveVoiceOrchestrator {
   }
 
   /**
+   * The talk key coming up: the microphone closes. A release while the
+   * press's session is still opening leaves it to open muted, and one with
+   * no press behind it does nothing.
+   */
+  async endTalk(): Promise<void> {
+    if (!this.#pressHeld) return;
+    this.#pressHeld = false;
+    if (this.#opening) return;
+    const call = this.#call;
+    if (call?.standing) await call.mute();
+  }
+
+  /**
    * The stop key, and the panel's Escape: the microphone closes and the host
    * tells the model to stop. Pressed while a press's session is still
    * opening, it cancels that press's unmute, so the session opens muted.
    */
   async stopSpeaking(): Promise<boolean> {
-    // A session still being opened has no peer to mute yet; the stop is
-    // remembered for the press, which then leaves the session muted.
-    if (this.#opening) {
-      this.#pressStopped = true;
-      return true;
-    }
+    this.#pressHeld = false;
+    // A session still being opened has no peer to mute yet; the press
+    // remembers the key is no longer held and leaves the session muted.
+    if (this.#opening) return true;
     const call = this.#call;
     if (!call?.standing) return false;
     await call.mute();
@@ -198,19 +214,19 @@ export class LiveVoiceOrchestrator {
 
   /**
    * The host's word on the one session. Wanted is Luke with something to say
-   * and no session to say it into, so one opens muted; closing is the host's
-   * decision to end it, so the peer hangs up; a close that lost the developer
-   * mid-conversation is remembered so the next session listens again.
+   * and no session to say it into, so one opens with no microphone; closing
+   * is the host's decision to end it, so the peer hangs up; a close that lost
+   * the developer mid-hold is remembered so the next session listens again,
+   * for as long as the key is still down.
    */
   obeySessionChange(change: VoiceLiveSessionChanged): void {
     switch (change.phase) {
       case LIVE_SESSION_PHASE.WANTED:
         if (this.#surroundings.voiceAvailable === false) return;
         void this.#ensureSession({ byPress: false }).then(async (call) => {
-          if (call && this.#resumeListening) {
-            this.#resumeListening = false;
-            await call.unmute();
-          }
+          const resume = this.#resumeListening;
+          this.#resumeListening = false;
+          if (call && resume && this.#pressHeld) await call.unmute();
         });
         return;
       case LIVE_SESSION_PHASE.CLOSING:
@@ -288,7 +304,7 @@ export class LiveVoiceOrchestrator {
     this.#call = call;
     this.#talkOpening = input.byPress;
     this.#touch();
-    this.#opening = call.open();
+    this.#opening = call.open({ byPress: input.byPress });
     const opened = await this.#opening;
     this.#opening = undefined;
     if (!opened) {

--- a/packages/voice/src/orchestrator/live-voice-orchestrator.ts
+++ b/packages/voice/src/orchestrator/live-voice-orchestrator.ts
@@ -160,7 +160,10 @@ export class LiveVoiceOrchestrator {
       if (!this.#pressHeld) return;
     }
     const call = await this.#ensureSession({ byPress: true });
-    if (call && this.#pressHeld) await call.unmute();
+    // A key let go of during the opening leaves the session muted, and the
+    // mute is still sent: the press's device rode the offer, and only the
+    // release takes it back.
+    if (call) await (this.#pressHeld ? call.unmute() : call.mute());
     // The press is answered once the session hears the developer; between the
     // offer and the unmute the session passes through muted, which is not the
     // exchange ending.


### PR DESCRIPTION
## What

Hold-to-talk only, per the product decision of 2026-09-11. The capture device is open exactly while the talk key is held; a briefing never opens the microphone; the key is no longer a toggle.

- `live-peer.ts`: `openMicrophone` is optional. A session a press opened adds the device's track disabled; any other opening (a briefing, a beat, a late reply) adds a `sendrecv` audio transceiver with no track, so no capture device stands behind a session nobody pressed for.
- `live-call.ts`: `open({ byPress })` decides which. `unmute()` opens the device when none stands and puts it on the line before the switch goes; if the key came up while the device was opening or attaching, the device is stopped and taken back off the line. `mute()` sends the switch, then, whatever the session answered (acknowledged, refused, or timed out), `replaceTrack(null)` and stops every track, clears the local stream. The returned boolean stays the session's word on the switch. Idle still arms from the mute, so a muted session with no device still reports idle on the existing clock.
- `LiveVoiceOrchestrator`: `beginTalk()` never mutes; it opens by press if none stands and unmutes only while the key is still held. New `endTalk()` mutes; a release during the opening, or while the system's microphone dialog stands, leaves the session muted. `stopSpeaking()` ends the hold and mutes. A session lost mid-hold listens again on its replacement only while the key is still down.
- `use-voice-session.ts` subscribes `onVoiceHotkeyRelease` (already sent by main's native watcher) to `endTalk()`.
- Electron fallback (`hotkey-registrar.ts`, native helper unavailable): the key reports presses alone, so one press starts and the next ends; the stop key resets the pair; a press held back by a chord recording moves nothing. Disclosed on the shortcuts row detail and the guide's talk-key fact (`hotkey.held` now reaches the guide).
- The introduction takeover opens `{ byPress: true }`, since the developer's press on the microphone ask is the user action; its mic timing is otherwise untouched (PR10).
- Docs moved in the same PR: `CLAUDE.md` (device-helper input paragraph; "what leaves the machine" briefing session), `PRIVACY.md` (OpenAI bullet; "Luke does not listen" bullet), `apps/desktop/src/renderer/AGENTS.md` (orchestrator and live-peer paragraphs), guide copy. `CHANGELOG.md` untouched per its release-time rule.

## How this follows the GPT Live docs

- WebRTC guide: "request microphone access from a user action and add its tracks to a peer connection" — the press is that action; a briefing has none, so it gets a trackless line.
- Conversations guide: `session.input_audio.mute` / `unmute` control input without ending the session — hold sends unmute, release sends mute, one session throughout. "Control microphone capture and audio playback separately in your application" — stopping the device at release is that separate control.
- Migration guide: audio streams continuously, no commits or turn triggers — none added.
- The mute goes first and the device leaves the line only after the answer, so the model is never fed a vanishing track mid-switch.

**Note on interruption:** hold-to-talk narrows GPT Live's full-duplex interruption model to the held window. The developer can interrupt Luke only while holding the key; the backchannel and interruption policy lines in the instructions still apply within that window.

## Briefing sessions: unverified on hardware

Briefing sessions (a session the host wants for Luke's own speech) ride a track-less negotiated `sendrecv` audio line: no capture device is opened, so the macOS microphone indicator stays off. **Whether the model speaks over a track-less line is unverified on hardware**: this PR was built and checked in a Linux sandbox, and the developer decided to merge without a Mac check first. If Luke stays silent on a briefing session on a real Mac, the documented next step is the fallback: attach the device disabled for briefing sessions only, and state it in `CLAUDE.md` and `PRIVACY.md` as the one exception to "the microphone is open only while the talk key is held". `PRIVACY.md` currently states the indicator behaviour as implemented: lit exactly while the key is held.

## Verification

- `./scripts/check.sh`: passes (exit 0) on the committed tree.
- `./scripts/verify.sh`: not run — this environment is a Linux sandbox with no macOS; CI's macOS job is the check.
- New tests (values and structure): press opens the device and attaches the track; release after the ack calls `replaceTrack(null)` once and `stop()` once, clears the local stream; the same on ack timeout and on a refused mute; the next press opens a fresh device and attaches it before the switch; a release while the device is opening, or while it is attaching, stops it and leaves the line empty; a non-press open adds a transceiver and calls `openMicrophone` zero times; a muted session with no device still reports idle; orchestrator press → unmute and never mute, release → one mute, release with no press → nothing, release during opening → session opens muted, second press never mutes, stop key → one mute and ends the hold, release during the microphone dialog → nothing opens, a lost session resumes only while held; registrar fallback alternates press/release, stop resets, a capture-held press moves nothing; native edges pass through as they are.
- Manual on a Mac (not automatable here): hold → dot on; release → dot off within a second; briefing → dot stays off and Luke speaks over the trackless line; press during a briefing → dot on, Luke hears you; trace shows mute/unmute pairs per hold and no appends from the window.

## Self-review

Ran the diff under the two Cursor skills the brief names, from their published texts (cursor/plugins `thermo-nuclear-code-quality-review`, dietrichgebert/ponytail `ponytail-review`). Findings fixed before pushing: a release landing while the press's device was attaching left the microphone live (now re-checked after `replaceTrack`); a release during the system microphone dialog unmuted afterwards (`#pressHeld` now set before the ask and re-read after); `#releaseDevice`'s redundant double guard and the fallback toggle's duplicated branches collapsed; the fallback no longer flips state when no voice window stands to hear it.

Cursor Bugbot's two findings on the first push (a release during the open left the press's device captured; a re-press during the mute's ack wait returned on the stale live flag while the mute stopped the device) are fixed in the second commit with tests for each.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/b25d5574-2fe1-4157-aacd-ecb09dee60de)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34549839907/artifacts/10180437407) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34549839907)

- Commit: `b0df2d61b2be66bc7eb0ee5b48672139326c6914`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

